### PR TITLE
Fix MCP tools query results to include units and improve dimensions

### DIFF
--- a/robosystems/middleware/mcp/tools/elements_tool.py
+++ b/robosystems/middleware/mcp/tools/elements_tool.py
@@ -162,8 +162,9 @@ Use the discovered qnames in your Fact queries to get actual values.""",
         if include_samples:
           sample_query = f"""
                     MATCH (e:Element)<-[:FACT_HAS_ELEMENT]-(f:Fact)
+                    OPTIONAL MATCH (f)-[:FACT_HAS_UNIT]->(u:Unit)
                     WHERE e.qname = '{elem["qname"]}' AND f.numeric_value IS NOT NULL
-                    RETURN f.numeric_value as value, f.currency_code as currency
+                    RETURN f.numeric_value as value, u.value as currency
                     LIMIT 3
                     """
           samples = await self.client.execute_query(sample_query)


### PR DESCRIPTION

## Summary
This PR addresses issues in the MCP tools query functionality by enhancing the data structure and field naming conventions used in query results. The changes focus on improving data completeness and clarity in the elements and facts tools.

## Key Changes
- **Enhanced data completeness**: Modified query results to include unit values alongside dimensional data, ensuring consumers have access to complete measurement information
- **Improved field naming**: Updated dimension field names to follow more consistent and descriptive naming conventions
- **Better data accuracy**: Refined the query result structure to provide more accurate and comprehensive information to downstream consumers

## Files Modified
- `elements_tool.py`: Updated query result structure to include unit information
- `facts_tool.py`: Refactored dimension field naming and enhanced query result completeness

## Breaking Changes
⚠️ **Potential breaking changes**: The dimension field name updates may impact existing integrations that rely on the previous field naming structure. Consumers of these tools should verify their field mappings are still valid.

## Testing Notes
- Verify that query results now include unit values where expected
- Confirm that dimension fields use the updated naming conventions
- Test downstream consumers to ensure compatibility with the new field structure
- Validate that the enhanced query results maintain backward compatibility where possible

## Infrastructure Considerations
- Monitor MCP tool consumers for any issues related to the field name changes
- Consider updating any documentation that references the old dimension field names
- Review logging and monitoring to ensure the enhanced query results are captured appropriately

---
🤖 Generated with [Claude Code](https://claude.ai/code)

**Branch Info:**
- Source: `bugfix/mcp-tools-query-fix`
- Target: `main`
- Type: bugfix

Co-Authored-By: Claude <noreply@anthropic.com>