### PR TITLE
Fix DuckDB staging path to use environment variable configuration

### DIFF
--- a/robosystems/graph_api/app.py
+++ b/robosystems/graph_api/app.py
@@ -58,7 +58,7 @@ def create_app() -> FastAPI:
     # Initialize DuckDB connection pool for staging tables
     from robosystems.graph_api.core.duckdb_pool import initialize_duckdb_pool
 
-    duckdb_base_path = Path(env.DATA_DIR) / "duckdb-staging"
+    duckdb_base_path = Path(env.DUCKDB_STAGING_PATH)
     duckdb_pool = initialize_duckdb_pool(
       base_path=str(duckdb_base_path),
       max_connections_per_db=3,


### PR DESCRIPTION
## Summary
Updated the DuckDB staging path configuration in the graph API application to use an environment variable instead of a hardcoded path value.

## Key Changes
- Modified `robosystems/graph_api/app.py` to retrieve the DuckDB staging path from environment configuration
- Replaced static path reference with dynamic environment variable lookup
- Improves configuration flexibility and deployment portability

## Key Accomplishments
- ✅ Enhanced configuration management by externalizing DuckDB staging path
- ✅ Improved application portability across different environments
- ✅ Follows configuration best practices by avoiding hardcoded paths

## Breaking Changes
None. This is a backward-compatible configuration improvement.

## Testing Notes
- Verify that the appropriate environment variable is set in all deployment environments
- Confirm DuckDB operations continue to function correctly with the new path resolution
- Test application startup to ensure the environment variable is properly loaded

## Infrastructure Considerations
- Ensure the DuckDB staging path environment variable is configured in all deployment environments (development, staging, production)
- Verify that the specified path exists and has appropriate read/write permissions
- Update deployment documentation to include the new environment variable requirement

---
🤖 Generated with [Claude Code](https://claude.ai/code)

**Branch Info:**
- Source: `bugfix/duckdb-staging-path`
- Target: `main`
- Type: bugfix

Co-Authored-By: Claude <noreply@anthropic.com>