### PR TITLE
Fix GHARunnerLogGroup retention policy to allow deletion

### DIFF
--- a/cloudformation/gha-runner.yaml
+++ b/cloudformation/gha-runner.yaml
@@ -191,7 +191,7 @@ Resources:
   GHARunnerLogGroup:
     Type: AWS::Logs::LogGroup
     DeletionPolicy: Delete
-    UpdateReplacePolicy: Retain
+    UpdateReplacePolicy: Delete
     Properties:
       LogGroupName: /robosystems/ci/gha-runner
       RetentionInDays: 14


### PR DESCRIPTION
## Summary
Updates the CloudFormation configuration for the GitHub Actions runner log group to change the UpdateReplacePolicy from `Retain` to `Delete`, enabling proper cleanup of log resources when the stack is updated or deleted.

## Key Changes
- Modified `GHARunnerLogGroup` resource in CloudFormation template to use `Delete` policy instead of `Retain`
- Ensures log groups are automatically removed during stack operations rather than persisting indefinitely

## Breaking Changes
⚠️ **Potential Impact**: Existing log groups may be deleted during the next stack update. Ensure any important logs are backed up before deployment if needed.

## Infrastructure Considerations
- This change affects log retention behavior for GitHub Actions runner infrastructure
- Log groups will now be cleaned up automatically when stacks are updated or deleted
- Reduces accumulation of orphaned CloudWatch log groups
- May impact log availability for debugging purposes after stack operations

## Testing Notes
- Verify that new deployments create log groups as expected
- Confirm that log groups are properly deleted during stack updates
- Test that logging functionality remains intact after the policy change

---
🤖 Generated with [Claude Code](https://claude.ai/code)

**Branch Info:**
- Source: `bugfix/gha-runner-delete-log-group`
- Target: `main`
- Type: bugfix

Co-Authored-By: Claude <noreply@anthropic.com>