### PR TITLE
Fix discussion URL in issue template to use organization-level page

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Discussion
-    url: https://github.com/RoboFinSystems/robosystems/discussions
+    url: https://github.com/orgs/RoboFinSystems/discussions
     about: For questions or general discussion, start a GitHub Discussion instead


### PR DESCRIPTION
## Summary
Updates the discussion URL in the GitHub issue template configuration to point to the organization-level discussions page instead of the repository-specific one, improving accessibility and discoverability for users seeking community support.

## Key Changes
- Modified `.github/ISSUE_TEMPLATE/config.yml` to redirect users to the organization's centralized discussion forum
- Ensures consistent user experience across all repositories in the organization
- Improves community engagement by directing users to a more active discussion space

## Breaking Changes
None. This change only affects the destination URL when users click the discussion link in the issue template.

## Testing Notes
- Verify that the discussion link in the issue creation flow redirects to the correct organization-level discussions page
- Confirm that the link is accessible and the discussions page loads properly
- Test the complete issue creation workflow to ensure no regressions

## Infrastructure Considerations
This change affects the GitHub issue template configuration and will be automatically applied to the issue creation interface once merged. No additional deployment steps are required.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

**Branch Info:**
- Source: `bugfix/update-discussions-link`
- Target: `main`
- Type: bugfix

Co-Authored-By: Claude <noreply@anthropic.com>