### PR TITLE
Add ecs:TagResource permission to Dagster IAM role

### DIFF
--- a/.claude/commands/dev.md
+++ b/.claude/commands/dev.md
@@ -1,0 +1,36 @@
+Start the development environment. This runs the full Docker stack with all services.
+
+## Steps
+
+1. Start Docker services with `just start`
+2. Wait for services to be healthy
+3. Show the API and Dagster logs
+
+## Commands
+
+```bash
+just start
+```
+
+Wait 10 seconds for services to initialize, then tail the logs:
+
+```bash
+sleep 10 && just logs api &
+```
+
+## Services Started
+
+- **API** (port 8000): Main RoboSystems API
+- **Worker**: Background task processing
+- **Graph API** (port 8001): LadybugDB graph database API
+- **Dagster** (port 3001): Orchestration UI
+- **PostgreSQL** (port 5432): Primary database
+- **Valkey** (port 6379): Cache and queues
+
+## Health Check
+
+After starting, verify with:
+```bash
+curl http://localhost:8000/health
+curl http://localhost:8001/status
+```

--- a/cloudformation/dagster.yaml
+++ b/cloudformation/dagster.yaml
@@ -366,6 +366,7 @@ Resources:
                   - ecs:RegisterTaskDefinition
                   - ecs:DeregisterTaskDefinition
                   - ecs:DescribeServices
+                  - ecs:TagResource
                 Resource: "*"
               # IAM pass role for task execution
               - Effect: Allow


### PR DESCRIPTION
## Summary
This PR adds the missing `ecs:TagResource` permission to the Dagster IAM role in CloudFormation to resolve permission issues when Dagster attempts to tag ECS resources during pipeline execution.

## Key Changes
- **CloudFormation Update**: Added `ecs:TagResource` permission to the Dagster IAM role policy
- **Documentation**: Added development commands reference for improved developer workflow

## Problem Solved
Dagster was encountering permission errors when trying to tag ECS resources (tasks, services, etc.) during pipeline runs. This missing permission was causing job failures and preventing proper resource management and cost tracking through tagging.

## Impact
- ✅ Resolves ECS tagging permission errors in Dagster pipelines
- ✅ Enables proper resource tagging for cost allocation and management
- ✅ Improves developer documentation and workflow efficiency
- ✅ No breaking changes - purely additive permission enhancement

## Testing Notes
- Verify that Dagster can successfully tag ECS resources after deployment
- Confirm existing pipeline functionality remains unaffected
- Test that the new IAM permissions are properly applied during CloudFormation stack update

## Infrastructure Considerations
- This change requires a CloudFormation stack update to apply the new IAM permissions
- The permission addition follows the principle of least privilege while enabling required functionality
- No service downtime expected during the IAM role update

---
🤖 Generated with [Claude Code](https://claude.ai/code)

**Branch Info:**
- Source: `bugfix/dagster-fix`
- Target: `main`
- Type: bugfix

Co-Authored-By: Claude <noreply@anthropic.com>