### PR TITLE
Fix ECS service refresh configuration in deployment workflows

### DIFF
--- a/.github/workflows/deploy-dagster.yml
+++ b/.github/workflows/deploy-dagster.yml
@@ -121,7 +121,7 @@ on:
         description: "Refresh ECS services after deployment"
         required: false
         type: string
-        default: "false"
+        default: "true"
 
     secrets:
       ACTIONS_TOKEN:

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -543,7 +543,7 @@ jobs:
       # Other Configuration
       prometheus_stack_name: ${{ needs.deploy-prometheus.outputs.prometheus_stack_name || '' }}
       aws_sns_alert_email: ${{ vars.AWS_SNS_ALERT_EMAIL }}
-      refresh_ecs_service: ${{ vars.API_ASG_REFRESH_PROD || 'false' }}
+      refresh_ecs_service: ${{ vars.API_ASG_REFRESH_PROD || 'true' }}
     secrets:
       ACTIONS_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -599,7 +599,7 @@ jobs:
       # Bastion Access (for internal UI access)
       bastion_sg_id: ${{ needs.deploy-bastion.outputs.bastion_sg_id }}
       # Other Configuration
-      refresh_ecs_service: ${{ vars.DAGSTER_REFRESH_ECS_PROD || 'false' }}
+      refresh_ecs_service: ${{ vars.DAGSTER_REFRESH_ECS_PROD || 'true' }}
     secrets:
       ACTIONS_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/bin/setup/gha.sh
+++ b/bin/setup/gha.sh
@@ -231,7 +231,7 @@ function setup_minimum_config() {
     gh variable set DAGSTER_RUN_WORKER_MAX_INSTANCES_STAGING --body "2"
 
     # Dagster Deployment Options
-    gh variable set DAGSTER_REFRESH_ECS_PROD --body "false"
+    gh variable set DAGSTER_REFRESH_ECS_PROD --body "true"
     gh variable set DAGSTER_REFRESH_ECS_STAGING --body "true"
     gh variable set RUN_MIGRATIONS_PROD --body "true"
     gh variable set RUN_MIGRATIONS_STAGING --body "true"
@@ -491,7 +491,7 @@ function setup_full_config() {
     gh variable set DAGSTER_RUN_WORKER_MAX_INSTANCES_STAGING --body "2"
 
     # Dagster Deployment Options
-    gh variable set DAGSTER_REFRESH_ECS_PROD --body "false"
+    gh variable set DAGSTER_REFRESH_ECS_PROD --body "true"
     gh variable set DAGSTER_REFRESH_ECS_STAGING --body "true"
     gh variable set RUN_MIGRATIONS_PROD --body "true"
     gh variable set RUN_MIGRATIONS_STAGING --body "true"


### PR DESCRIPTION
## Summary
This bugfix updates the ECS service refresh configuration from `false` to `true` across deployment workflows and setup scripts to ensure proper service updates during deployments.

## Key Changes
- Updated ECS refresh settings in Dagster deployment workflow
- Modified production deployment workflow ECS configuration  
- Corrected setup script ECS service refresh defaults

## Key Accomplishments
- Ensures ECS services properly refresh and pick up new task definitions during deployments
- Aligns configuration consistency across all deployment workflows
- Fixes potential issues where services might not update with latest container images or configuration changes

## Breaking Changes
None. This is a configuration correction that improves deployment reliability.

## Testing Notes
- Verify ECS services refresh properly during next deployment
- Monitor deployment workflows to ensure services update as expected
- Confirm task definitions are properly applied to running services

## Infrastructure Considerations
- ECS services will now force refresh during deployments, which may cause brief service interruptions
- This change ensures deployment consistency and prevents stale service configurations
- May slightly increase deployment time due to service refresh operations

---
🤖 Generated with [Claude Code](https://claude.ai/code)

**Branch Info:**
- Source: `bugfix/dagster-ecs-refresh-default`
- Target: `main`
- Type: bugfix

Co-Authored-By: Claude <noreply@anthropic.com>