### PR TITLE
Fix PostgreSQL major version upgrade restriction in CloudFormation

### DIFF
--- a/cloudformation/postgres.yaml
+++ b/cloudformation/postgres.yaml
@@ -605,6 +605,7 @@ Resources:
       PreferredBackupWindow: 03:00-04:00
       PreferredMaintenanceWindow: sun:04:30-sun:05:30
       AutoMinorVersionUpgrade: false
+      AllowMajorVersionUpgrade: true
       CopyTagsToSnapshot: true
       DBInstanceIdentifier: !Sub ${DBInstanceName}-${Environment}
       DBParameterGroupName: !Ref RDSDBParameterGroup


### PR DESCRIPTION
## Summary
This PR resolves a configuration issue in the PostgreSQL CloudFormation template that was preventing major version upgrades of RDS instances.

## Key Changes
- Added the `AllowMajorVersionUpgrade` parameter to the PostgreSQL RDS configuration
- Enables controlled major version upgrades for PostgreSQL databases when needed

## Accomplishments
- ✅ Removes upgrade restriction that could block critical security updates
- ✅ Provides flexibility for planned database version migrations
- ✅ Maintains backward compatibility with existing deployments

## Breaking Changes
None. This change only adds capability and does not modify existing behavior for current deployments.

## Testing Notes
- Verify that existing PostgreSQL instances remain unaffected
- Test that major version upgrades can now be performed when the parameter is explicitly set
- Confirm that the default behavior (no automatic upgrades) is preserved

## Infrastructure Considerations
- This change affects RDS PostgreSQL instances managed by CloudFormation
- Major version upgrades should still be planned and tested in non-production environments first
- Consider database compatibility requirements before initiating major version upgrades
- Monitor applications for any compatibility issues after version upgrades

---
🤖 Generated with [Claude Code](https://claude.ai/code)

**Branch Info:**
- Source: `bugfix/rds-pg-update-major-flag`
- Target: `main`
- Type: bugfix

Co-Authored-By: Claude <noreply@anthropic.com>