### PR TITLE
Fix S3 public data access permissions for Dagster CloudFormation

### DIFF
--- a/cloudformation/dagster.yaml
+++ b/cloudformation/dagster.yaml
@@ -329,6 +329,8 @@ Resources:
                   - !Sub "arn:${AWS::Partition}:s3:::robosystems-${Environment}-deployment/*"
                   - !Sub "arn:${AWS::Partition}:s3:::robosystems-user-${Environment}"
                   - !Sub "arn:${AWS::Partition}:s3:::robosystems-user-${Environment}/*"
+                  - !Sub "arn:${AWS::Partition}:s3:::robosystems-public-data-${Environment}"
+                  - !Sub "arn:${AWS::Partition}:s3:::robosystems-public-data-${Environment}/*"
               # DynamoDB for graph registries (needed for shared master discovery)
               - Effect: Allow
                 Action:


### PR DESCRIPTION
## Summary
This PR resolves an issue with S3 bucket access permissions in the Dagster CloudFormation template, enabling proper access to public data buckets that were previously inaccessible due to insufficient IAM permissions.

## Key Accomplishments
- ✅ Added missing S3 permissions to the Dagster CloudFormation IAM policy
- ✅ Resolved access denied errors when Dagster attempts to read from public S3 buckets
- ✅ Maintained principle of least privilege by adding only necessary permissions

## Changes Made
- Updated `cloudformation/dagster.yaml` to include additional S3 permissions for public data access
- Modified IAM policy configuration to grant appropriate bucket access rights

## Breaking Changes
None. This is a purely additive change that expands existing permissions without modifying current functionality.

## Testing Notes
- Verify Dagster can successfully access public S3 buckets after CloudFormation stack update
- Confirm existing S3 operations continue to function normally
- Test that no unauthorized access has been inadvertently granted

## Infrastructure Considerations
- This change requires a CloudFormation stack update to take effect
- The update should be non-disruptive as it only adds IAM permissions
- Monitor CloudFormation deployment for any unexpected issues during the update process
- Validate that the expanded permissions align with organizational security policies

---
🤖 Generated with [Claude Code](https://claude.ai/code)

**Branch Info:**
- Source: `bugfix/s3-bucket-public-data-dagster-access`
- Target: `main`
- Type: bugfix

Co-Authored-By: Claude <noreply@anthropic.com>