### PR TITLE
Remove deprecated S3 deployment bucket configuration

### DIFF
--- a/cloudformation/s3.yaml
+++ b/cloudformation/s3.yaml
@@ -359,7 +359,7 @@ Resources:
         HostedZoneId: Z2FDTNDATAQYW2 # CloudFront's hosted zone ID
         EvaluateTargetHealth: false
 
-  # NEW Deployment Bucket with consistent naming (robosystems-deployment-{env})
+  # Deployment Bucket (Lambda packages, scripts, etc.)
   S3BucketDeploymentNew:
     Type: AWS::S3::Bucket
     DeletionPolicy: Retain
@@ -404,55 +404,6 @@ Resources:
           Value: !Ref ServiceTag
         - Key: Component
           Value: Deployment
-        - Key: CreatedBy
-          Value: CloudFormation
-
-  # DEPRECATED: Old deployment bucket with non-standard naming (robosystems-{env}-deployment)
-  # Will be removed after contents are migrated to S3BucketDeploymentNew
-  S3BucketDeployment:
-    Type: AWS::S3::Bucket
-    DeletionPolicy: Retain
-    UpdateReplacePolicy: Retain
-    Properties:
-      PublicAccessBlockConfiguration:
-        RestrictPublicBuckets: true
-        IgnorePublicAcls: true
-        BlockPublicPolicy: true
-        BlockPublicAcls: true
-      BucketName: !Sub robosystems-${Environment}-deployment
-      OwnershipControls:
-        Rules:
-          - ObjectOwnership: BucketOwnerEnforced
-      BucketEncryption:
-        ServerSideEncryptionConfiguration:
-          - BucketKeyEnabled: false
-            ServerSideEncryptionByDefault:
-              SSEAlgorithm: AES256
-      VersioningConfiguration:
-        Status: Enabled
-      LifecycleConfiguration:
-        Rules:
-          - Id: DeleteOldLambdaVersions
-            Status: Enabled
-            NoncurrentVersionExpirationInDays: 30
-          - Id: CleanupIncompleteMultipartUploads
-            Status: Enabled
-            AbortIncompleteMultipartUpload:
-              DaysAfterInitiation: 1
-          - Id: TransitionToIA
-            Status: Enabled
-            Transitions:
-              - TransitionInDays: 30
-                StorageClass: STANDARD_IA
-      Tags:
-        - Key: Name
-          Value: !Sub ${AWS::StackName}-${Environment}-deployment-bucket-legacy
-        - Key: Environment
-          Value: !Ref Environment
-        - Key: Service
-          Value: !Ref ServiceTag
-        - Key: Component
-          Value: DeploymentLegacy
         - Key: CreatedBy
           Value: CloudFormation
 
@@ -568,7 +519,7 @@ Outputs:
     Export:
       Name: !Sub ${AWS::StackName}-${Environment}-GraphWriterS3PolicyArn
 
-  # Deployment Bucket Outputs (points to new bucket with consistent naming)
+  # Deployment Bucket Outputs
   DeploymentBucketName:
     Description: Name of the deployment bucket
     Value: !Ref S3BucketDeploymentNew


### PR DESCRIPTION
## Summary
This PR cleans up the S3 CloudFormation template by removing deprecated deployment bucket configuration while retaining the current deployment bucket setup.

## Key Changes
- Removed 51 lines of deprecated S3 bucket configuration from `cloudformation/s3.yaml`
- Updated comments for improved clarity and documentation
- Adjusted CloudFormation outputs to reflect the simplified bucket structure
- Maintained existing deployment bucket functionality

## Key Accomplishments
- Simplified infrastructure configuration by removing unused resources
- Improved template readability and maintainability
- Reduced potential confusion from legacy configuration remnants
- Enhanced documentation through clearer comments

## Breaking Changes
None. This change only removes deprecated configuration that was no longer in use. Active deployment processes continue to use the retained bucket configuration.

## Testing Notes
- Verify that existing deployment processes continue to function normally
- Confirm CloudFormation stack updates complete successfully
- Validate that all expected S3 bucket outputs are still available for dependent resources

## Infrastructure Considerations
This change simplifies the S3 infrastructure template without impacting current deployment workflows. The removal of deprecated configuration reduces maintenance overhead and eliminates potential confusion for future infrastructure modifications. Ensure that no external references depend on the removed bucket configuration before deployment.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

**Branch Info:**
- Source: `chore/remove-old-deployment-bucket`
- Target: `main`
- Type: chore

Co-Authored-By: Claude <noreply@anthropic.com>