### PR TITLE
Fix bastion UserData to use IMDSv2 for instance ID retrieval

### DIFF
--- a/cloudformation/bastion.yaml
+++ b/cloudformation/bastion.yaml
@@ -295,9 +295,10 @@ Resources:
           echo "Executing UserData script..."
           /tmp/bastion-userdata.sh
 
-          # Tag the root volume
+          # Tag the root volume (using IMDSv2 token-based metadata)
           echo "Tagging EBS volumes..."
-          INSTANCE_ID=$(ec2-metadata --instance-id | cut -d' ' -f2)
+          TOKEN=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+          INSTANCE_ID=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/instance-id)
           ROOT_VOLUME=$(aws ec2 describe-instances \
             --instance-ids $INSTANCE_ID \
             --query "Reservations[0].Instances[0].BlockDeviceMappings[?DeviceName=='/dev/xvda'].Ebs.VolumeId" \
@@ -327,8 +328,7 @@ Resources:
           echo "Auto-stopping bastion instance in 60 seconds..."
           sleep 60
 
-          # Stop this instance (instance can stop itself without additional IAM permissions)
-          INSTANCE_ID=$(ec2-metadata --instance-id | cut -d' ' -f2)
+          # Stop this instance (INSTANCE_ID already set above via IMDSv2)
           aws ec2 stop-instances --instance-ids "$INSTANCE_ID" --region $AWS_REGION
 
           echo "Bastion instance will stop shortly"


### PR DESCRIPTION
## Summary
This PR updates the bastion host configuration to use Instance Metadata Service version 2 (IMDSv2) for retrieving the EC2 instance ID, replacing the deprecated IMDSv1 approach. Additionally, improves code documentation with clearer comments.

## Key Accomplishments
- **Security Enhancement**: Migrated from IMDSv1 to IMDSv2 for instance metadata retrieval, following AWS security best practices
- **Improved Documentation**: Enhanced inline comments for better code maintainability and clarity
- **AWS Compliance**: Aligns with AWS recommendations to phase out IMDSv1 usage

## Breaking Changes
None. This change is backward compatible and maintains existing functionality while improving security posture.

## Testing Notes
- Verify bastion host launches successfully with the updated UserData script
- Confirm instance ID is correctly retrieved and utilized in the initialization process
- Validate that all existing bastion functionality remains intact
- Test in environments where IMDSv1 may be disabled or restricted

## Infrastructure Considerations
- This change affects bastion host initialization and follows AWS security best practices for metadata service usage
- No impact on existing running instances; only affects new bastion deployments
- Ensures compatibility with security policies that may restrict or disable IMDSv1

---
🤖 Generated with [Claude Code](https://claude.ai/code)

**Branch Info:**
- Source: `bugfix/bastion-instance-id`
- Target: `main`
- Type: bugfix

Co-Authored-By: Claude <noreply@anthropic.com>