### PR TITLE
Fix DeletionPolicy for GitHub OIDC and IAM roles in CloudFormation

### DIFF
--- a/cloudformation/bootstrap-oidc.yaml
+++ b/cloudformation/bootstrap-oidc.yaml
@@ -29,7 +29,7 @@ Resources:
   # Tells AWS to trust tokens issued by GitHub Actions
   GitHubOIDCProvider:
     Type: AWS::IAM::OIDCProvider
-    DeletionPolicy: Retain
+    DeletionPolicy: Delete
     UpdateReplacePolicy: Retain
     Properties:
       Url: https://token.actions.githubusercontent.com
@@ -54,7 +54,7 @@ Resources:
   # =============================================================================
   GitHubActionsRole:
     Type: AWS::IAM::Role
-    DeletionPolicy: Retain
+    DeletionPolicy: Delete
     UpdateReplacePolicy: Retain
     Properties:
       RoleName: !Sub ${ServiceTag}GitHubActionsRole
@@ -382,7 +382,7 @@ Resources:
   # =============================================================================
   GitHubActionsFrontendRole:
     Type: AWS::IAM::Role
-    DeletionPolicy: Retain
+    DeletionPolicy: Delete
     UpdateReplacePolicy: Retain
     Properties:
       RoleName: !Sub ${ServiceTag}GitHubActionsFrontendRole


### PR DESCRIPTION
## Summary
Updated the CloudFormation bootstrap template to change the DeletionPolicy for GitHub OIDC and IAM roles from `Retain` to `Delete`. This ensures proper cleanup of these resources when the CloudFormation stack is deleted.

## Key Changes
- Modified DeletionPolicy for GitHub OIDC provider resource from Retain to Delete
- Updated DeletionPolicy for associated IAM roles from Retain to Delete
- Ensures complete resource cleanup during stack deletion operations

## Infrastructure Considerations
- **Resource Cleanup**: When CloudFormation stacks are deleted, OIDC providers and IAM roles will now be automatically removed instead of being retained
- **Stack Management**: This change improves infrastructure hygiene by preventing orphaned AWS resources
- **Cost Impact**: Eliminates potential costs from retained resources that are no longer needed

## Breaking Changes
⚠️ **IMPORTANT**: This change affects stack deletion behavior. Existing stacks with retained OIDC/IAM resources will not be impacted, but future stack deletions will permanently remove these resources.

## Testing Notes
- Verify stack creation and deletion processes work as expected
- Confirm OIDC authentication continues to function properly
- Test that IAM roles are properly removed during stack cleanup
- Validate no orphaned resources remain after stack deletion

---
🤖 Generated with [Claude Code](https://claude.ai/code)

**Branch Info:**
- Source: `bugfix/gh-oidc-delete-roles`
- Target: `main`
- Type: bugfix

Co-Authored-By: Claude <noreply@anthropic.com>