### PR TITLE
Remove Process node from MCP client and roboledger schema

### DIFF
--- a/robosystems/middleware/mcp/client.py
+++ b/robosystems/middleware/mcp/client.py
@@ -527,7 +527,6 @@ class GraphMCPClient:
       # RoboLedger extension nodes - Transaction section (entity graphs only)
       "Transaction": "Financial transactions from accounting systems",
       "LineItem": "Individual accounting entries with debits/credits",
-      "Process": "Business processes and workflows",
     }
     return descriptions.get(node_name, f"{node_name} entities in the graph")
 

--- a/robosystems/schemas/README.md
+++ b/robosystems/schemas/README.md
@@ -99,9 +99,9 @@ The base schema (`base.py`) provides foundational nodes and relationships that a
 
 #### Transaction Section (General Ledger)
 
-- **Nodes**: Transaction, LineItem, Process
+- **Nodes**: Transaction, LineItem
 - **Use Cases**: Entity accounting, journal entries, trial balances
-- **Key Features**: Transaction tracking, line item details, process workflows
+- **Key Features**: Transaction tracking, line item details
 - **Note**: Chart of accounts is represented via Structure/Association/Element pattern (from Reporting Section)
 
 #### Context-Aware Loading

--- a/robosystems/schemas/extensions/roboledger.py
+++ b/robosystems/schemas/extensions/roboledger.py
@@ -6,7 +6,6 @@ Complete accounting system with both transaction and reporting capabilities.
 This unified schema includes:
 - 📊 Financial Reporting (XBRL, SEC filings, financial statements)
 - 📒 General Ledger (transactions, journal entries, accounts)
-- 💼 Business Processes (workflows, disclosures, compliance)
 
 CONTEXT-AWARE USAGE:
 -------------------
@@ -298,18 +297,6 @@ TRANSACTION_NODES = [
       Property(name="description", type="STRING"),
       Property(name="debit_amount", type="DOUBLE"),
       Property(name="credit_amount", type="DOUBLE"),
-      Property(name="updated_at", type="STRING"),
-    ],
-  ),
-  Node(
-    name="Process",
-    description="Business processes and workflows",
-    properties=[
-      Property(name="identifier", type="STRING", is_primary_key=True),
-      Property(name="name", type="STRING"),
-      Property(name="process_type", type="STRING"),
-      Property(name="description", type="STRING"),
-      Property(name="status", type="STRING"),
       Property(name="updated_at", type="STRING"),
     ],
   ),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -665,17 +665,6 @@ def lbug_repository_with_schema(temp_lbug_db):
     )
     """,
     """
-    CREATE NODE TABLE Process(
-        identifier STRING,
-        name STRING,
-        type STRING,
-        status STRING,
-        created_at TIMESTAMP,
-        updated_at TIMESTAMP,
-        PRIMARY KEY (identifier)
-    )
-    """,
-    """
     CREATE NODE TABLE Security(
         identifier STRING,
         ticker STRING,
@@ -727,7 +716,6 @@ def lbug_repository_with_schema(temp_lbug_db):
     "CREATE REL TABLE HAS_USER(FROM Entity TO User)",
     "CREATE REL TABLE HAS_CONNECTION(FROM Entity TO Connection)",
     "CREATE REL TABLE HAS_TRANSACTION(FROM Entity TO Transaction)",
-    "CREATE REL TABLE HAS_PROCESS(FROM Entity TO Process)",
     "CREATE REL TABLE HAS_SECURITY(FROM Entity TO Security)",
     "CREATE REL TABLE HAS_ELEMENT(FROM Fact TO Element)",
     "CREATE REL TABLE HAS_UNIT(FROM Fact TO Unit)",


### PR DESCRIPTION
## Summary
This PR removes the "Process" node concept from the MCP client and roboledger schema implementation, simplifying the transaction processing model to focus exclusively on "Transaction" and "LineItem" entities.

## Key Changes
- **MCP Client**: Removed Process node references and related functionality
- **Schema Documentation**: Updated README to reflect the simplified transaction model without Process nodes
- **Roboledger Extension**: Eliminated Process node definitions and related code (13 lines removed)
- **Test Configuration**: Cleaned up Process node test fixtures and setup code

## Accomplishments
- Streamlined transaction processing architecture by removing an unnecessary abstraction layer
- Reduced code complexity with a net removal of 26 lines across the codebase
- Simplified the conceptual model for better maintainability and clarity
- Aligned schema documentation with the actual implementation

## Breaking Changes
⚠️ **This is a breaking change** - Any code or integrations that depend on the Process node concept will need to be updated to work directly with Transaction and LineItem entities.

## Testing Notes
- Existing transaction and line item functionality remains unchanged
- Test fixtures have been updated to remove Process node dependencies
- Verify that all transaction processing workflows continue to function correctly without the Process abstraction

## Infrastructure Considerations
This refactoring simplifies the data model and should improve performance by reducing the object hierarchy depth. Monitor transaction processing performance and ensure downstream systems are updated to handle the simplified schema.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

**Branch Info:**
- Source: `refactor/remove-process-node-roboledger`
- Target: `main`
- Type: refactor

Co-Authored-By: Claude <noreply@anthropic.com>