### PR TITLE
Fix GitHub Actions workflows by adding security-events permission

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -4,6 +4,7 @@ permissions:
   contents: read
   deployments: write
   id-token: write
+  security-events: write  # Required for Trivy SARIF upload in test workflow
 
 concurrency:
   group: robosystems-deploy

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -4,6 +4,7 @@ permissions:
   contents: read
   deployments: write
   id-token: write
+  security-events: write  # Required for Trivy SARIF upload in test workflow
 
 concurrency:
   group: robosystems-deploy


### PR DESCRIPTION
## Summary
This PR resolves workflow permission issues by adding the required `security-events` permission to both production and staging GitHub Actions workflows.

## Key Changes
- Updated production workflow to include `security-events: write` permission
- Updated staging workflow to include `security-events: write` permission
- Ensures workflows can properly interact with GitHub's security features

## Key Accomplishments
- ✅ Fixed workflow permission errors that were preventing proper execution
- ✅ Aligned both production and staging environments with consistent permissions
- ✅ Enabled security event reporting and processing capabilities

## Breaking Changes
None - This is a configuration fix that enhances existing functionality without breaking compatibility.

## Testing Notes
- Workflows should now execute without permission-related errors
- Security event processing and reporting should function correctly
- No changes to application logic or user-facing features

## Infrastructure Considerations
- This change affects CI/CD pipeline permissions and security event handling
- Both production and staging environments receive identical permission updates
- Changes take effect immediately upon merge for subsequent workflow runs

---
🤖 Generated with [Claude Code](https://claude.ai/code)

**Branch Info:**
- Source: `bugfix/invalid-workflow-fix`
- Target: `main`
- Type: bugfix

Co-Authored-By: Claude <noreply@anthropic.com>