### PR TITLE
Add webhook access rule to API Gateway configuration

### DIFF
--- a/cloudformation/api.yaml
+++ b/cloudformation/api.yaml
@@ -945,7 +945,27 @@ Resources:
       Certificates:
         - CertificateArn: !Ref ApiCertificate
 
-  # Admin API Block Rule - Deny ALL public access to admin endpoints
+  # Webhooks Allow Rule - Allow external webhook providers (Stripe, etc.) to reach webhook endpoints
+  # These endpoints are secured via signature verification, not network-level blocking
+  # Must have higher priority (lower number) than AdminApiDenyRule
+  WebhooksAllowRule:
+    Type: AWS::ElasticLoadBalancingV2::ListenerRule
+    Condition: IsPublicWithDomain
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Retain
+    Properties:
+      ListenerArn: !Ref ApiHttpsListener
+      Priority: 1
+      Conditions:
+        - Field: path-pattern
+          PathPatternConfig:
+            Values:
+              - "/admin/v1/webhooks/*"
+      Actions:
+        - Type: forward
+          TargetGroupArn: !Ref ApiTargetGroup
+
+  # Admin API Block Rule - Deny ALL other public access to admin endpoints
   # Admin access is only available via SSM tunnel to Service Discovery endpoint
   # Usage: ./bin/tools/tunnels.sh <env> api-internal
   AdminApiDenyRule:


### PR DESCRIPTION
## Summary
This PR adds a new allow rule to the API Gateway CloudFormation configuration to enable webhook access. The change expands the API's security policy to accommodate webhook endpoints while maintaining existing access controls.

## Key Accomplishments
- ✅ Added webhook allow rule to API Gateway configuration
- ✅ Updated CloudFormation template with proper security controls
- ✅ Maintained backward compatibility with existing API endpoints
- ✅ Enhanced API accessibility for webhook integrations

## Breaking Changes
None - This is an additive change that expands access without modifying existing functionality.

## Testing Notes
- Verify that webhook endpoints are accessible after deployment
- Confirm existing API endpoints continue to function as expected
- Test that the new allow rule doesn't interfere with existing security policies
- Validate CloudFormation template syntax and deployment

## Infrastructure Considerations
- This change requires a CloudFormation stack update to take effect
- The API Gateway will need to be redeployed with the new configuration
- Monitor API Gateway logs after deployment to ensure proper rule application
- Consider reviewing associated IAM policies if webhook authentication is required
- Ensure load balancer and security group configurations align with the new webhook access pattern

---
🤖 Generated with [Claude Code](https://claude.ai/code)

**Branch Info:**
- Source: `chore/add-webhook-access`
- Target: `main`
- Type: chore

Co-Authored-By: Claude <noreply@anthropic.com>