### PR TITLE
Fix orphaned WAL file cleanup in LadybugBackend and DatabaseManager

### DIFF
--- a/robosystems/graph_api/backends/lbug.py
+++ b/robosystems/graph_api/backends/lbug.py
@@ -70,6 +70,14 @@ class LadybugBackend(GraphBackend):
     return await self.execute_query(graph_id, cypher, parameters, database)
 
   async def create_database(self, database_name: str) -> bool:
+    # Clean up any orphaned WAL file before creating
+    # Only if the main database doesn't exist (WAL without database = orphaned)
+    db_path = self.data_path / f"{database_name}.lbug"
+    wal_path = self.data_path / f"{database_name}.lbug.wal"
+    if not db_path.exists() and wal_path.exists():
+      wal_path.unlink()
+      logger.info(f"Cleaned up orphaned WAL file for {database_name}")
+
     # Simply getting a connection will create the database if it doesn't exist
     with self.connection_pool.get_connection(database_name, read_only=False) as conn:
       # Test connection

--- a/robosystems/graph_api/core/ladybug/manager.py
+++ b/robosystems/graph_api/core/ladybug/manager.py
@@ -155,6 +155,13 @@ class LadybugDatabaseManager:
         detail=f"Database {request.graph_id} already exists",
       )
 
+    # Clean up any orphaned WAL file before creating
+    # This can happen if a previous deletion didn't clean up properly
+    wal_path = self.base_path / f"{request.graph_id}.lbug.wal"
+    if wal_path.exists():
+      wal_path.unlink()
+      logger.info(f"Cleaned up orphaned WAL file for {request.graph_id}")
+
     try:
       logger.info(f"Creating database: {request.graph_id}")
 


### PR DESCRIPTION
## Summary
This bugfix addresses issues during database creation by implementing proper cleanup of orphaned Write-Ahead Logging (WAL) files in both the LadybugBackend and LadybugDatabaseManager components.

## Key Changes
- **LadybugBackend**: Added WAL file cleanup logic to prevent interference with new database creation operations
- **LadybugDatabaseManager**: Implemented orphaned WAL file removal to ensure clean database initialization
- Enhanced database lifecycle management by removing leftover artifacts from previous operations

## Problem Solved
Previously, orphaned WAL files from incomplete or interrupted database operations could remain in the system and cause conflicts when creating new databases. This cleanup ensures a clean slate for each database creation operation.

## Breaking Changes
None. This is a backward-compatible bugfix that only adds cleanup functionality.

## Testing Notes
- Verify that database creation operations complete successfully without WAL file conflicts
- Test scenarios involving interrupted database operations to ensure proper cleanup
- Confirm that existing database operations remain unaffected by the cleanup logic

## Infrastructure Considerations
- The cleanup process runs automatically during database creation and should not impact performance
- Monitor for any file system permission issues during WAL file cleanup operations
- Consider log monitoring to track successful cleanup operations

---
🤖 Generated with [Claude Code](https://claude.ai/code)

**Branch Info:**
- Source: `bugfix/wal-fix`
- Target: `main`
- Type: bugfix

Co-Authored-By: Claude <noreply@anthropic.com>