### PR TITLE
Fix SEC download rate limiting by reducing concurrency to 1 partition

### DIFF
--- a/robosystems/dagster/assets/sec.py
+++ b/robosystems/dagster/assets/sec.py
@@ -339,8 +339,8 @@ class SECMaterializeConfig(Config):
     "stage": "extraction",
   },
   # Limit concurrent SEC downloads to avoid rate limiting
-  # Max 4 partitions (quarters) download at a time
-  op_tags={"dagster/concurrency_key": "sec_download", "dagster/max_concurrent": "4"},
+  # Sequential execution (1 partition at a time) to prevent SEC rate limiting during backfills
+  op_tags={"dagster/concurrency_key": "sec_download", "dagster/max_concurrent": "1"},
 )
 def sec_raw_filings(
   context: AssetExecutionContext,
@@ -355,7 +355,7 @@ def sec_raw_filings(
   EFTS has a 10k result limit per query. Quarterly partitions typically return
   5-7k filings, safely under the limit.
 
-  Concurrency limited to 4 via dagster/concurrency_key to avoid SEC rate limiting.
+  Concurrency limited to 1 via dagster/concurrency_key to avoid SEC rate limiting.
 
   Returns:
       MaterializeResult with download statistics


### PR DESCRIPTION
## Summary
Updates the SEC data download process to use sequential processing (1 partition at a time) instead of concurrent processing to prevent rate limiting issues during large backfill operations.

## Key Changes
- Modified SEC download concurrency settings to process one partition at a time
- This change specifically addresses rate limiting encountered during backfill operations
- Ensures compliance with SEC API rate limits while maintaining data integrity

## Problem Solved
- Resolves rate limiting errors that were occurring when multiple partitions were processed concurrently
- Prevents download failures during large historical data backfills
- Improves reliability of SEC data ingestion pipeline

## Impact
- **Performance**: Slower download speeds due to sequential processing, but more reliable completion
- **Reliability**: Eliminates rate limiting failures and ensures successful backfill operations
- **Compliance**: Better adherence to SEC API usage guidelines

## Testing Notes
- Verify that SEC downloads complete successfully without rate limiting errors
- Test backfill operations to ensure they run to completion
- Monitor download performance to confirm acceptable processing times

## Breaking Changes
None - this is an internal configuration change that doesn't affect external APIs or data schemas.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

**Branch Info:**
- Source: `bugfix/limit-sec-download-concurrency`
- Target: `main`
- Type: bugfix

Co-Authored-By: Claude <noreply@anthropic.com>