### PR TITLE
Add Docker Hub image configuration option to Docker Compose setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,18 @@
 ## =============================================================================
 
 ## =============================================================================
+## DOCKER IMAGE CONFIGURATION
+## =============================================================================
+## Controls whether to pull pre-built images from Docker Hub or build locally.
+## - New users: Keep these settings to pull pre-built images (~10s download)
+## - Developers: Comment out to build locally from Dockerfile (~3 min build)
+##
+## pull_policy options: if_not_present (pull if missing), always, never
+
+ROBOSYSTEMS_IMAGE=robofinsystems/robosystems:latest
+ROBOSYSTEMS_PULL_POLICY=if_not_present
+
+## =============================================================================
 ## CORE APPLICATION CONFIGURATION
 ## =============================================================================
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -2,10 +2,11 @@ services:
   # Robosystems API
   api:
     container_name: robosystems-api
+    image: ${ROBOSYSTEMS_IMAGE:-robosystems-local}
+    pull_policy: ${ROBOSYSTEMS_PULL_POLICY:-never}
     build:
       context: .
       dockerfile: Dockerfile
-    # image: robofinsystems/robosystems:latest  # Alternative: use pre-built image
     command: /app/bin/entrypoint.sh
     environment:
       - DOCKER_PROFILE=api
@@ -35,10 +36,11 @@ services:
   # Graph API - Default LadybugDB Backend
   graph-api:
     container_name: robosystems-graph-api
+    image: ${ROBOSYSTEMS_IMAGE:-robosystems-local}
+    pull_policy: ${ROBOSYSTEMS_PULL_POLICY:-never}
     build:
       context: .
       dockerfile: Dockerfile
-    # image: robofinsystems/robosystems:latest  # Alternative: use pre-built image
     command: /app/bin/entrypoint.sh
     environment:
       - DOCKER_PROFILE=ladybug-writer
@@ -76,10 +78,11 @@ services:
   # Dagster Webserver - Orchestration UI
   dagster-webserver:
     container_name: robosystems-dagster-webserver
+    image: ${ROBOSYSTEMS_IMAGE:-robosystems-local}
+    pull_policy: ${ROBOSYSTEMS_PULL_POLICY:-never}
     build:
       context: .
       dockerfile: Dockerfile
-    # image: robofinsystems/robosystems:latest  # Alternative: use pre-built image
     command: /app/bin/entrypoint.sh
     environment:
       - DOCKER_PROFILE=dagster
@@ -107,10 +110,11 @@ services:
   # Dagster Daemon - Schedules, Sensors, and Run Coordination
   dagster-daemon:
     container_name: robosystems-dagster-daemon
+    image: ${ROBOSYSTEMS_IMAGE:-robosystems-local}
+    pull_policy: ${ROBOSYSTEMS_PULL_POLICY:-never}
     build:
       context: .
       dockerfile: Dockerfile
-    # image: robofinsystems/robosystems:latest  # Alternative: use pre-built image
     command: /app/bin/entrypoint.sh
     environment:
       - DOCKER_PROFILE=dagster-daemon
@@ -237,10 +241,11 @@ services:
   # Graph API (Neo4j) - Alternative Neo4j Backend (Optional)
   graph-api-neo4j:
     container_name: robosystems-graph-api-neo4j
+    image: ${ROBOSYSTEMS_IMAGE:-robosystems-local}
+    pull_policy: ${ROBOSYSTEMS_PULL_POLICY:-never}
     build:
       context: .
       dockerfile: Dockerfile
-    # image: robofinsystems/robosystems:latest  # Alternative: use pre-built image
     command: /app/bin/entrypoint.sh
     environment:
       - DOCKER_PROFILE=neo4j-writer


### PR DESCRIPTION
## Summary
This PR introduces the ability to use pre-built Docker images from Docker Hub as an alternative to building images locally in the Docker Compose configuration.

## Key Changes
- **Enhanced Docker Compose flexibility**: Added support for using either locally built images or pre-built images from Docker Hub
- **Environment variable configuration**: Extended `.env.example` with new Docker image-related configuration options
- **Updated compose.yaml**: Modified the Docker Compose configuration to support the new image sourcing options

## Key Accomplishments
- Provides developers with the option to use official Docker Hub images for faster setup
- Maintains backward compatibility with existing local build workflows
- Improves development environment setup time by eliminating the need to build images locally when using pre-built alternatives
- Adds clear documentation through environment variable examples

## Breaking Changes
None. This change is fully backward compatible with existing setups.

## Testing Notes
- Verify that Docker Compose works with both local build and Docker Hub image configurations
- Test environment variable substitution in the compose file
- Confirm that existing local development workflows remain unaffected
- Validate that the new Docker Hub image option functions correctly across different environments

## Infrastructure Considerations
- This change provides more deployment flexibility for containerized environments
- Reduces build time and resource requirements when using pre-built images
- Consider image versioning strategy when using Docker Hub images in production environments
- Ensure appropriate image tags are specified to maintain consistency across deployments

---
🤖 Generated with [Claude Code](https://claude.ai/code)

**Branch Info:**
- Source: `feature/docker-hub-compose-option`
- Target: `main`
- Type: feature

Co-Authored-By: Claude <noreply@anthropic.com>