### PR TITLE
Remove capacity provider strategy from ECS task configuration

### DIFF
--- a/dagster_home/dagster_prod.yaml
+++ b/dagster_home/dagster_prod.yaml
@@ -59,8 +59,11 @@ schedule_storage:
 # ECS cluster configuration. The EcsRunLauncher will use the same network
 # settings as the daemon/webserver services.
 #
-# Default: Spot Fargate for cost savings (~70% cheaper)
-# Falls back to On-Demand automatically if Spot capacity unavailable
+# Capacity provider strategy is NOT set here - controlled by job tags instead.
+# Jobs specify ecs/run_task_kwargs with their preferred strategy:
+# - Long-running jobs (SEC staging): On-demand only to avoid Spot interruptions
+# - Short jobs: Spot-preferred for cost savings
+# If no job tag is specified, ECS uses the cluster's default capacity provider.
 run_launcher:
   module: dagster_aws.ecs
   class: EcsRunLauncher
@@ -70,18 +73,9 @@ run_launcher:
       env: DAGSTER_ECS_RUN_TASK_DEFINITION
     # Container name in the task definition
     container_name: dagster-run
-    # Spot-first capacity strategy with On-Demand fallback
-    # Weight 4:1 means prefer Spot, but use On-Demand if unavailable
     run_task_kwargs:
       cluster:
         env: DAGSTER_ECS_CLUSTER
-      capacityProviderStrategy:
-        - capacityProvider: FARGATE_SPOT
-          weight: 4
-          base: 0
-        - capacityProvider: FARGATE
-          weight: 1
-          base: 0
       # Propagate tags from task definition to tasks for cost allocation
       propagateTags: TASK_DEFINITION
     # Resource overrides removed - uses task definition defaults from CloudFormation


### PR DESCRIPTION
## Summary
This PR updates the ECS run task configuration in the Dagster production environment by removing the capacity provider strategy settings and simplifying the task execution parameters.

## Key Changes
- Removed capacity provider strategy configuration from `dagster_prod.yaml`
- Simplified ECS task execution settings by eliminating 11 lines of capacity provider-related configuration
- Streamlined the overall ECS run task setup while maintaining core functionality

## Key Accomplishments
- Reduced configuration complexity in the Dagster production environment
- Eliminated potentially unnecessary capacity provider strategy overhead
- Simplified ECS task management for better maintainability

## Breaking Changes
⚠️ **Potential Infrastructure Impact**: This change modifies how ECS tasks are scheduled and may affect task placement and resource allocation. Teams should verify that:
- Existing Dagster jobs continue to execute as expected
- ECS task placement still meets performance requirements
- No downstream dependencies rely on the removed capacity provider settings

## Testing Notes
- Verify Dagster pipeline execution in the production environment
- Monitor ECS task startup times and resource allocation
- Confirm that task scheduling behavior remains consistent with expectations
- Validate that compute resources are properly utilized without the capacity provider strategy

## Infrastructure Considerations
This change affects the ECS task execution strategy and may impact how containers are scheduled across the cluster. Teams should monitor cluster performance and task distribution patterns after deployment to ensure optimal resource utilization.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

**Branch Info:**
- Source: `bugfix/remove-dagster-capacity-prov`
- Target: `main`
- Type: bugfix

Co-Authored-By: Claude <noreply@anthropic.com>