### PR TITLE
Remove unused rebuild parameter from XBRL ingestion method

### DIFF
--- a/robosystems/adapters/sec/processors/ingestion.py
+++ b/robosystems/adapters/sec/processors/ingestion.py
@@ -879,7 +879,7 @@ class XBRLDuckDBGraphProcessor:
       # Step 4: Trigger ingestion for each table
       log_progress(f"Step 4: Materializing {len(table_names)} tables to LadybugDB...")
       ingestion_results = await self._trigger_ingestion(
-        table_names, client, rebuild=False, progress_callback=log_progress
+        table_names, client, progress_callback=log_progress
       )
 
       duration = time.time() - start_time
@@ -1736,7 +1736,6 @@ class XBRLDuckDBGraphProcessor:
     self,
     table_names: list[str],
     graph_client,
-    _rebuild: bool = False,  # Unused, kept for API compatibility
     progress_callback: ProgressCallback | None = None,
   ) -> dict[str, Any]:
     """
@@ -1747,7 +1746,6 @@ class XBRLDuckDBGraphProcessor:
     Args:
         table_names: List of table names to ingest
         graph_client: Graph API client instance
-        _rebuild: Unused - rebuild is now handled in process_files before table creation
         progress_callback: Optional callback for progress logging (e.g., Dagster context.log.info)
 
     Returns:


### PR DESCRIPTION
## Summary
This PR removes an unused `rebuild` parameter from the ingestion method in the `XBRLDuckDBGraphProcessor` class, improving code clarity and reducing method signature complexity.

## Key Accomplishments
- **Code Cleanup**: Eliminated dead parameter that was not being utilized in the method implementation
- **Method Signature Simplification**: Reduced parameter count in the ingestion method, making it more focused and easier to understand
- **Improved Maintainability**: Removed potential confusion for developers working with the XBRL processing pipeline

## Breaking Changes
⚠️ **BREAKING CHANGE**: The method signature for the ingestion method in `XBRLDuckDBGraphProcessor` has changed. Any direct calls to this method will need to be updated to remove the `rebuild` parameter.

## Testing Notes
- Verify that all existing ingestion workflows continue to function correctly
- Ensure no regression in XBRL data processing capabilities
- Confirm that downstream consumers of this method are not affected by the signature change

## Infrastructure Considerations
- Review any automated processes that may invoke this method directly
- Update relevant documentation or API references that mention the removed parameter
- Consider checking for other unused parameters across similar processor classes

---
🤖 Generated with [Claude Code](https://claude.ai/code)

**Branch Info:**
- Source: `bugfix/fix-unused-param`
- Target: `main`
- Type: bugfix

Co-Authored-By: Claude <noreply@anthropic.com>