### PR TITLE
Fix DLM deployment by adding required EBS snapshot permissions

### DIFF
--- a/cloudformation/bootstrap-oidc.yaml
+++ b/cloudformation/bootstrap-oidc.yaml
@@ -332,6 +332,13 @@ Resources:
                   - events:*
                 Resource: "*"
 
+              # Data Lifecycle Manager (EBS snapshots)
+              - Sid: DLM
+                Effect: Allow
+                Action:
+                  - dlm:*
+                Resource: "*"
+
               # Service Discovery (Cloud Map) - for ECS service discovery
               - Sid: ServiceDiscovery
                 Effect: Allow

--- a/cloudformation/graph-volumes.yaml
+++ b/cloudformation/graph-volumes.yaml
@@ -94,7 +94,7 @@ Resources:
   EBSSnapshotLifecyclePolicy:
     Type: AWS::DLM::LifecyclePolicy
     Properties:
-      Description: !Sub "EBS snapshot lifecycle for LadybugDB volumes (${Environment})"
+      Description: !Sub "EBS snapshot lifecycle for LadybugDB volumes - ${Environment}"
       State: ENABLED
       ExecutionRoleArn: !GetAtt DLMLifecycleRole.Arn
       PolicyDetails:


### PR DESCRIPTION
## Summary
This PR resolves deployment issues with the Data Lifecycle Manager (DLM) by adding the necessary IAM permissions for EBS snapshot operations and updating the volume configuration.

## Changes Made
- **IAM Permissions**: Added required Data Lifecycle Manager permissions to the OIDC bootstrap configuration to enable proper EBS snapshot lifecycle management
- **Volume Configuration**: Updated graph volumes CloudFormation template to support DLM integration

## Key Accomplishments
- ✅ Resolves DLM deployment failures caused by insufficient permissions
- ✅ Enables automated EBS snapshot lifecycle management
- ✅ Maintains backwards compatibility with existing infrastructure

## Breaking Changes
None - this is a purely additive change that enhances existing functionality.

## Testing Notes
- Verify DLM service can successfully create and manage EBS snapshots
- Confirm OIDC authentication works correctly with the new permissions
- Validate that existing volume operations remain unaffected
- Test snapshot retention policies are properly enforced

## Infrastructure Considerations
- The permission changes only affect the DLM service scope and do not impact other AWS services
- Changes are isolated to IAM policy definitions and volume configuration
- No resource recreations or downtime expected during deployment
- Existing snapshots and volumes will not be affected

---
🤖 Generated with [Claude Code](https://claude.ai/code)

**Branch Info:**
- Source: `bugfix/dlm-deploy`
- Target: `main`
- Type: bugfix

Co-Authored-By: Claude <noreply@anthropic.com>