### PR TITLE
Fix permissions in secrets rotation workflow

### DIFF
--- a/.github/workflows/secrets-rotation.yml
+++ b/.github/workflows/secrets-rotation.yml
@@ -400,6 +400,9 @@ jobs:
       (needs.rotate-postgres.outputs.status == 'success' ||
        needs.rotate-valkey.outputs.status == 'success' ||
        needs.rotate-graph-api.outputs.status == 'success')
+    permissions:
+      id-token: write
+      contents: read
     uses: ./.github/workflows/service-refresh.yml
     with:
       environment: ${{ needs.config.outputs.environment }}


### PR DESCRIPTION
## Summary
This PR addresses a permissions issue in the secrets rotation GitHub Actions workflow by adding the necessary permission configurations to ensure the workflow can execute properly.

## Key Accomplishments
- ✅ Added missing permissions to the secrets rotation workflow
- ✅ Resolved workflow execution failures related to insufficient permissions
- ✅ Ensured secure and proper access control for automated secrets management

## Breaking Changes
None - this is a configuration fix that maintains backward compatibility.

## Testing Notes
- Verify that the secrets rotation workflow can now execute without permission errors
- Confirm that the workflow maintains appropriate security boundaries
- Test that automated secrets rotation completes successfully in the CI/CD pipeline

## Infrastructure Considerations
This change affects the GitHub Actions workflow permissions model and ensures that the secrets rotation automation has the minimal required permissions to function correctly. The update follows security best practices by explicitly defining workflow permissions rather than relying on default settings.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

**Branch Info:**
- Source: `bugfix/fix-secrets-rotation`
- Target: `main`
- Type: bugfix

Co-Authored-By: Claude <noreply@anthropic.com>