### PR TITLE
hotfix: Revert version from v1.3.89 to v1.3.88

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "robosystems"
-version = "1.3.89"
+version = "1.3.88"
 description = "RoboSystems"
 requires-python = ">=3.13"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -2702,7 +2702,7 @@ wheels = [
 
 [[package]]
 name = "robosystems"
-version = "1.3.89"
+version = "1.3.88"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
This hotfix reverts the application version from v1.3.89 back to v1.3.88 in both the project configuration and dependency lock files.

## Key Changes
- **Version Rollback**: Updated `pyproject.toml` to specify version v1.3.88
- **Dependency Sync**: Updated `uv.lock` to maintain consistency with the reverted version

## Key Accomplishments
- ✅ Successfully reverted version across all relevant configuration files
- ✅ Maintained dependency lock file consistency
- ✅ Prepared codebase for stable v1.3.88 state

## Breaking Changes
None - this is a version revert that should not introduce breaking changes.

## Testing Notes
- Verify that the application reports version v1.3.88 after deployment
- Confirm that all dependencies resolve correctly with the reverted lock file
- Test core functionality to ensure the version rollback doesn't impact application behavior

## Infrastructure Considerations
- This change affects version reporting and package metadata
- Deployment systems should recognize and handle the version downgrade appropriately
- Monitor for any dependency resolution issues during the deployment process
- Consider clearing any cached version information in downstream systems

---
🤖 Generated with [Claude Code](https://claude.ai/code)

**Branch Info:**
- Source: `hotfix/revert-v1.3.89-release-update`
- Target: `main`
- Type: hotfix

Co-Authored-By: Claude <noreply@anthropic.com>