### PR TITLE
Fix Docker Hub publishing for releases regardless of ECR status

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,8 +122,12 @@ jobs:
           fi
 
           # Check if image already exists in ECR
+          # Always build for Docker Hub releases (need multi-arch + attestations)
           ECR_URL="${ECR_REGISTRY}/${ECR_REPOSITORY}"
-          if aws ecr describe-images --repository-name "$ECR_REPOSITORY" --image-ids imageTag="$IMAGE_TAG" &>/dev/null; then
+          if [[ "${{ inputs.publish_to_dockerhub }}" == "true" ]] && [[ "$IS_RELEASE" == "true" ]]; then
+            echo "🚀 Docker Hub release - will build regardless of ECR state"
+            echo "needs_build=true" >> $GITHUB_OUTPUT
+          elif aws ecr describe-images --repository-name "$ECR_REPOSITORY" --image-ids imageTag="$IMAGE_TAG" &>/dev/null; then
             echo "✅ Image exists: ${IMAGE_TAG} - will skip build"
             echo "needs_build=false" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION

## Summary
This PR fixes a critical issue in the build workflow where Docker Hub releases were not being published when ECR images already existed. The workflow now properly handles release scenarios by ensuring Docker Hub publishing occurs for all releases, independent of ECR image availability.

## Key Changes
- **Enhanced release detection logic**: Modified the build workflow to properly identify release events and adjust build requirements accordingly
- **Decoupled Docker Hub from ECR publishing**: Docker Hub releases now build independently of existing ECR image status
- **Improved workflow reliability**: Ensures consistent Docker Hub publishing for all tagged releases

## Problem Solved
Previously, the workflow would skip Docker Hub publishing if an ECR image already existed, leading to incomplete release artifacts. This change ensures that Docker Hub always receives the latest release images, providing better availability and distribution for end users.

## Testing Notes
- Verify that Docker Hub publishing occurs for new releases even when ECR images exist
- Confirm that non-release builds continue to respect existing ECR image optimization
- Test both scenarios: releases with and without existing ECR images

## Infrastructure Impact
- **No breaking changes**: Existing functionality remains intact for non-release builds
- **Improved reliability**: Release publishing is now more robust and predictable
- **Enhanced distribution**: Docker Hub will consistently receive all release versions

This fix ensures proper multi-registry publishing strategy and improves the overall reliability of the container image distribution pipeline.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

**Branch Info:**
- Source: `bugfix/dockerhub-publish`
- Target: `main`
- Type: bugfix

Co-Authored-By: Claude <noreply@anthropic.com>