### PR TITLE
Fix GitHub Actions workflow permissions for graph maintenance

### DIFF
--- a/.github/workflows/graph-maintenance.yml
+++ b/.github/workflows/graph-maintenance.yml
@@ -40,6 +40,8 @@ permissions:
   id-token: write
   contents: read
   actions: write
+  deployments: write
+  security-events: write
 
 concurrency:
   # Use environment for manual runs, cron schedule for scheduled runs (distinguishes staging vs prod)


### PR DESCRIPTION
## Summary
This PR updates the GitHub Actions workflow permissions for the graph maintenance workflow to include necessary deployment and security event permissions.

## Key Changes
- Added `deployments: write` permission to enable deployment-related operations
- Added `security-events: write` permission to allow writing security events and alerts

## Accomplishments
- Resolves permission issues that were preventing the graph maintenance workflow from executing deployment operations
- Ensures the workflow can properly handle security event reporting and management
- Maintains principle of least privilege by only adding the specific permissions required

## Breaking Changes
None. This change only expands the permissions available to the workflow without modifying existing functionality.

## Testing Notes
- Verify that the graph maintenance workflow can now successfully complete deployment operations
- Confirm that security events are properly recorded during workflow execution
- Ensure no regression in existing workflow functionality

## Infrastructure Considerations
This change affects the CI/CD pipeline by expanding the permissions scope for automated graph maintenance operations. The additional permissions enable better integration with GitHub's deployment and security features while maintaining workflow reliability.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

**Branch Info:**
- Source: `bugfix/graph-maintenance-fix`
- Target: `main`
- Type: bugfix

Co-Authored-By: Claude <noreply@anthropic.com>