### PR TITLE
Remove hardcoded resource identifiers from CloudFormation templates

### DIFF
--- a/cloudformation/postgres.yaml
+++ b/cloudformation/postgres.yaml
@@ -323,7 +323,7 @@ Resources:
       SecretId: !Ref DBPasswordSecret
       RotationLambdaARN: !GetAtt PostgresSecretRotationLambda.Arn
       RotationRules:
-        AutomaticallyAfterDays: 1000  # Fallback only - GHA triggers monthly
+        AutomaticallyAfterDays: 1000 # Fallback only - GHA triggers monthly
       RotateImmediatelyOnUpdate: false
 
   # CloudWatch Alarms for Rotation Monitoring
@@ -417,7 +417,8 @@ Resources:
     UpdateReplacePolicy: Retain
     Properties:
       Description: !Sub Parameter group for ${DBInstanceName}-${Environment} database
-      Family: !FindInMap [PostgresVersionToFamily, !Ref PostgresEngineVersion, RDS]
+      Family:
+        !FindInMap [PostgresVersionToFamily, !Ref PostgresEngineVersion, RDS]
       Parameters:
         rds.force_ssl: "1"
       Tags:
@@ -440,7 +441,8 @@ Resources:
     UpdateReplacePolicy: Retain
     Properties:
       Description: !Sub Parameter group for ${DBInstanceName}-${Environment} Aurora database
-      Family: !FindInMap [PostgresVersionToFamily, !Ref PostgresEngineVersion, Aurora]
+      Family:
+        !FindInMap [PostgresVersionToFamily, !Ref PostgresEngineVersion, Aurora]
       Parameters:
         rds.force_ssl: "1"
       Tags:
@@ -463,7 +465,8 @@ Resources:
     UpdateReplacePolicy: Retain
     Properties:
       Description: !Sub Cluster parameter group for ${DBInstanceName}-${Environment} Aurora cluster
-      Family: !FindInMap [PostgresVersionToFamily, !Ref PostgresEngineVersion, Aurora]
+      Family:
+        !FindInMap [PostgresVersionToFamily, !Ref PostgresEngineVersion, Aurora]
       Parameters:
         rds.force_ssl: "1"
       Tags:
@@ -611,7 +614,6 @@ Resources:
       AllowMajorVersionUpgrade: true
       StorageEncrypted: true
       CopyTagsToSnapshot: true
-      DBInstanceIdentifier: !Sub ${DBInstanceName}-${Environment}
       DBParameterGroupName: !Ref RDSDBParameterGroup
       Tags:
         - Key: Name

--- a/cloudformation/valkey.yaml
+++ b/cloudformation/valkey.yaml
@@ -410,7 +410,7 @@ Resources:
       SecretId: !Ref ValkeyAuthSecret
       RotationLambdaARN: !GetAtt ValkeySecretRotationLambda.Arn
       RotationRules:
-        AutomaticallyAfterDays: 1000  # Fallback only - GHA triggers monthly
+        AutomaticallyAfterDays: 1000 # Fallback only - GHA triggers monthly
       RotateImmediatelyOnUpdate: false
 
   # CloudWatch Alarms for Rotation Monitoring
@@ -452,7 +452,8 @@ Resources:
     DeletionPolicy: Delete
     UpdateReplacePolicy: Retain
     Properties:
-      CacheParameterGroupFamily: !FindInMap [ValkeyVersionToFamily, !Ref ValkeyEngineVersion, Family]
+      CacheParameterGroupFamily:
+        !FindInMap [ValkeyVersionToFamily, !Ref ValkeyEngineVersion, Family]
       Description: Parameter group for RoboSystems Valkey ElastiCache
       Properties:
         # Memory management for application caches
@@ -484,7 +485,6 @@ Resources:
     DeletionPolicy: !If [IsProduction, Snapshot, Delete]
     UpdateReplacePolicy: !If [IsProduction, Snapshot, Delete]
     Properties:
-      ReplicationGroupId: !Sub "robosystems-${Environment}-valkey"
       ReplicationGroupDescription: !Sub "RoboSystems Valkey ElastiCache - ${Environment}"
       # Node Configuration
       CacheNodeType: !Ref NodeType


### PR DESCRIPTION
## Summary
This refactoring removes hardcoded `DBInstanceIdentifier` and `ReplicationGroupId` properties from PostgreSQL and ElastiCache (Valkey) CloudFormation templates, allowing AWS to auto-generate resource identifiers and improving template flexibility.

## Key Accomplishments
- **Streamlined Configuration**: Eliminated manual identifier management for database and cache resources
- **Enhanced Flexibility**: Templates now support multiple deployments without identifier conflicts
- **Improved Maintainability**: Reduced configuration overhead by leveraging AWS auto-naming conventions
- **Simplified Resource Management**: Removed potential naming conflicts across different environments

## Breaking Changes
⚠️ **IMPORTANT**: This change will cause resource replacement during deployment
- Existing PostgreSQL RDS instances will be recreated with new auto-generated identifiers
- Existing ElastiCache replication groups will be recreated with new auto-generated identifiers
- **Data Loss Risk**: Ensure proper backup procedures are in place before deploying
- Applications referencing hardcoded resource names will need to be updated to use CloudFormation outputs or parameter store values

## Infrastructure Considerations
- Plan for maintenance windows during deployment due to resource recreation
- Update any external references to use CloudFormation stack outputs instead of hardcoded names
- Consider implementing blue-green deployment strategy for critical environments
- Verify monitoring and alerting configurations will adapt to new resource identifiers

## Testing Notes
- Validate that auto-generated identifiers follow expected AWS naming conventions
- Confirm all dependent services can resolve new resource identifiers
- Test connectivity and functionality after resource recreation
- Verify backup and restore procedures work with new identifiers

---
🤖 Generated with [Claude Code](https://claude.ai/code)

**Branch Info:**
- Source: `refactor/replace-db-name`
- Target: `main`
- Type: refactor

Co-Authored-By: Claude <noreply@anthropic.com>