### PR TITLE
Fix missing DATABASE_URL environment variable in Dagster CloudFormation

### DIFF
--- a/cloudformation/dagster.yaml
+++ b/cloudformation/dagster.yaml
@@ -596,6 +596,9 @@ Resources:
               Value: dagster-daemon
             - Name: DAGSTER_HOME
               Value: /app/dagster_home
+            # Database Configuration (constructed from direct params + secret)
+            - Name: DATABASE_URL
+              Value: !Sub "postgresql://postgres:{{resolve:secretsmanager:robosystems/${Environment}/postgres:SecretString:POSTGRES_PASSWORD}}@${DatabaseEndpoint}:${DatabasePort}/robosystems?sslmode=require"
             - Name: DAGSTER_POSTGRES_HOST
               Value: !Ref DatabaseEndpoint
             - Name: DAGSTER_POSTGRES_PORT
@@ -688,6 +691,9 @@ Resources:
               Value: /app/dagster_home
             - Name: DAGSTER_PORT
               Value: "3000"
+            # Database Configuration (constructed from direct params + secret)
+            - Name: DATABASE_URL
+              Value: !Sub "postgresql://postgres:{{resolve:secretsmanager:robosystems/${Environment}/postgres:SecretString:POSTGRES_PASSWORD}}@${DatabaseEndpoint}:${DatabasePort}/robosystems?sslmode=require"
             - Name: DAGSTER_POSTGRES_HOST
               Value: !Ref DatabaseEndpoint
             - Name: DAGSTER_POSTGRES_PORT
@@ -786,6 +792,9 @@ Resources:
           Environment:
             - Name: ENVIRONMENT
               Value: !Ref Environment
+            # Database Configuration (constructed from direct params + secret)
+            - Name: DATABASE_URL
+              Value: !Sub "postgresql://postgres:{{resolve:secretsmanager:robosystems/${Environment}/postgres:SecretString:POSTGRES_PASSWORD}}@${DatabaseEndpoint}:${DatabasePort}/robosystems?sslmode=require"
             - Name: DAGSTER_HOME
               Value: /app/dagster_home
             - Name: DAGSTER_POSTGRES_HOST


### PR DESCRIPTION
## Summary
Resolves a critical configuration issue where the Dagster daemon was missing the required DATABASE_URL environment variable in the CloudFormation template. This fix ensures proper database connectivity for the Dagster service.

## Key Accomplishments
- Added DATABASE_URL environment variable configuration to the CloudFormation template
- Ensures Dagster daemon can properly connect to the database
- Maintains consistency with other Dagster service configurations

## Breaking Changes
None. This is a backward-compatible configuration addition.

## Testing Notes
- Verify that Dagster daemon starts successfully after deployment
- Confirm database connectivity is established without errors
- Check that all Dagster services maintain proper communication with the database
- Monitor daemon logs to ensure no connection-related errors occur

## Infrastructure Considerations
- This change requires a CloudFormation stack update to take effect
- The DATABASE_URL should be properly configured in the environment before deployment
- No service downtime is expected during the configuration update
- Ensure database credentials and connection parameters are correctly set in the deployment environment

---
🤖 Generated with [Claude Code](https://claude.ai/code)

**Branch Info:**
- Source: `bugfix/daemon-missing-db`
- Target: `main`
- Type: bugfix

Co-Authored-By: Claude <noreply@anthropic.com>