### PR TITLE
Fix Load Balancer and Target Group naming in replicas CloudFormation

### DIFF
--- a/cloudformation/graph-ladybug-replicas.yaml
+++ b/cloudformation/graph-ladybug-replicas.yaml
@@ -519,7 +519,7 @@ Resources:
   ReplicaALB:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties:
-      Name: !Sub robosystems-shared-replicas-${Environment}-alb
+      Name: !Sub robosystems-shr-rep-${Environment}-alb
       Type: application
       Scheme: internal
       Subnets: !Ref SubnetIds
@@ -534,7 +534,7 @@ Resources:
   ReplicaTargetGroup:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
-      Name: !Sub robosystems-shared-replicas-${Environment}-tg
+      Name: !Sub robosystems-shr-rep-${Environment}-tg
       VpcId: !Ref VpcId
       Port: 8001
       Protocol: HTTP


### PR DESCRIPTION
## Summary
Updated the CloudFormation template for graph-ladybug-replicas to standardize Load Balancer and Target Group resource names, improving consistency and reducing verbosity in the infrastructure naming convention.

## Key Changes
- Modified Load Balancer resource name for better consistency across the stack
- Updated corresponding Target Group name to align with the Load Balancer changes
- Maintained functional equivalence while improving resource naming standards

## Breaking Changes
⚠️ **Potential Infrastructure Impact**: This change modifies AWS resource names in the CloudFormation stack. Depending on the deployment strategy, this could result in:
- Recreation of Load Balancer and Target Group resources during stack update
- Temporary service interruption during resource replacement
- Changes to DNS endpoints if the Load Balancer is recreated

## Testing Notes
- Verify that the CloudFormation template validates successfully
- Confirm that stack updates complete without errors in non-production environments
- Test application connectivity after deployment to ensure Load Balancer functionality is preserved
- Validate that any dependent services or DNS configurations are updated accordingly

## Infrastructure Considerations
- Review deployment timing to minimize impact on active traffic
- Consider blue-green deployment strategy if zero-downtime is critical
- Update any monitoring, alerting, or automation that references the old resource names
- Ensure backup and rollback procedures are in place before applying changes

---
🤖 Generated with [Claude Code](https://claude.ai/code)

**Branch Info:**
- Source: `bugfix/shared-replicas-name`
- Target: `main`
- Type: bugfix

Co-Authored-By: Claude <noreply@anthropic.com>