### PR TITLE
Fix worker StopTimeout to comply with Fargate limits

### DIFF
--- a/cloudformation/worker.yaml
+++ b/cloudformation/worker.yaml
@@ -397,7 +397,7 @@ Resources:
         - Name: worker
           Image: !Sub ${ECRRepositoryUrl}:${ECRImageTag}
           Essential: true
-          StopTimeout: 300
+          StopTimeout: 119 # Fargate max is <120s
           Command: ["/app/bin/entrypoint.sh"]
           LogConfiguration:
             LogDriver: awslogs


### PR DESCRIPTION
## Summary

Updates the `StopTimeout` configuration in the worker CloudFormation template to comply with AWS Fargate's supported limits.

## Key Accomplishments

- **Fixed Fargate compatibility issue**: The previous `StopTimeout` value in `worker.yaml` exceeded the maximum allowed by AWS Fargate, which could cause deployment failures or unexpected behavior during container shutdown. This change sets the value to one that is within Fargate's accepted range.
- **Ensures graceful worker shutdown**: By aligning the stop timeout with Fargate constraints, worker containers will now properly respect the platform's shutdown lifecycle, preventing forced termination scenarios or deployment errors.

## Breaking Changes

None. This is a configuration correction that brings the infrastructure definition in line with AWS Fargate requirements. Existing deployments should benefit from this fix without any additional migration steps.

## Testing Notes

- Verify that the CloudFormation stack updates successfully without errors related to the `StopTimeout` parameter.
- Confirm that worker containers shut down gracefully within the configured timeout period.
- Validate that in-flight tasks are handled appropriately during container stop events (e.g., scaling events, deployments, or rolling updates).
- Monitor ECS task state transitions to ensure no forced kills occur unexpectedly.

## Infrastructure Considerations

- **AWS Fargate StopTimeout limits**: Fargate enforces a maximum `StopTimeout` value (120 seconds). Any value exceeding this limit may be silently capped or cause deployment failures depending on the CloudFormation/ECS API behavior.
- **Impact on long-running tasks**: If the worker processes long-running jobs, ensure that the new timeout value still provides sufficient time for graceful shutdown and task completion or checkpointing.
- **Rolling deployment behavior**: This change should be safe to deploy via a standard CloudFormation stack update with no expected downtime, as it only affects container stop behavior.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

**Branch Info:**
- Source: `bugfix/stop-timeout-worker`
- Target: `main`
- Type: bugfix

Co-Authored-By: Claude <noreply@anthropic.com>