### PR TITLE
Refactor docstrings, taxonomy block helpers, and handler signatures

### DIFF
--- a/examples/close_demo/_reset.py
+++ b/examples/close_demo/_reset.py
@@ -89,14 +89,15 @@ def reset_demo_state(graph_id: str) -> None:
     # delete them before structures to avoid constraint violations.
     session.execute(text("DELETE FROM verification_results"))
     session.execute(
-      text("DELETE FROM rules WHERE target_structure_id IN "
-           "(SELECT id FROM structures WHERE created_by != :seeder)"),
+      text(
+        "DELETE FROM rules WHERE target_structure_id IN "
+        "(SELECT id FROM structures WHERE created_by != :seeder)"
+      ),
       {"seeder": _LIBRARY_SEEDER},
     )
     # 6c.ii. Tenant-authored rules attached to taxonomies directly (via
-    # ``taxonomy_id`` host or ``target_taxonomy_id`` target). Phase 2.3
-    # lets tenants attach rules at the taxonomy scope; reset must clear
-    # them before dropping the tenant taxonomies in step 9.
+    # ``taxonomy_id`` host or ``target_taxonomy_id`` target). Reset must
+    # clear them before dropping the tenant taxonomies in step 9.
     session.execute(
       text(
         "DELETE FROM rules WHERE "
@@ -107,8 +108,10 @@ def reset_demo_state(graph_id: str) -> None:
       {"seeder": _LIBRARY_SEEDER},
     )
     session.execute(
-      text("DELETE FROM fact_sets WHERE structure_id IN "
-           "(SELECT id FROM structures WHERE created_by != :seeder)"),
+      text(
+        "DELETE FROM fact_sets WHERE structure_id IN "
+        "(SELECT id FROM structures WHERE created_by != :seeder)"
+      ),
       {"seeder": _LIBRARY_SEEDER},
     )
 

--- a/examples/close_demo/main.py
+++ b/examples/close_demo/main.py
@@ -362,9 +362,9 @@ def create_journal_entries(
 def create_mappings(graph_id: str, element_lookup: dict[str, str]) -> int:
   """Create mapping associations between CoA elements and FAC reporting concepts.
 
-  Per Phase 3b, CoA → FAC (Fundamental Accounting Concepts) is the
-  primary mapping target. FAC → rs-gaap expansion is handled by
-  equivalence arcs on the FAC side.
+  CoA → FAC (Fundamental Accounting Concepts) is the primary mapping
+  target. FAC → rs-gaap expansion is handled by equivalence arcs on
+  the FAC side.
 
   Uses `LedgerClient.create_associations()` — the bulk HTTP API — to
   exercise the same path the frontend UI and MCP tools use.
@@ -388,10 +388,9 @@ def create_mappings(graph_id: str, element_lookup: dict[str, str]) -> int:
     if e.get("qname")
   }
 
-  # Walk MAPPINGS and post each association one-by-one. The bulk
-  # create-associations op was retired in Phase 1; mappings now go
-  # through create-mapping-association which takes a single pair. The
-  # demo's mapping set is ~20 rows so per-call latency is fine.
+  # Walk MAPPINGS and post each association one-by-one through
+  # create-mapping-association which takes a single pair. The demo's
+  # mapping set is ~20 rows so per-call latency is fine.
   created = 0
   for coa_code, fac_qname in MAPPINGS:
     coa_id = element_lookup.get(coa_code)

--- a/examples/close_demo/mappings.py
+++ b/examples/close_demo/mappings.py
@@ -1,9 +1,9 @@
 """CoA to FAC mapping definitions for Cascade Advisory Group LLC.
 
-Per Phase 3b, CoA elements map to FAC (Fundamental Accounting Concepts)
-as the primary reporting target. FAC is a small, stable set of
-high-level statement concepts. Deterministic expansion to rs-gaap /
-us-gaap happens via equivalence arcs on the FAC side.
+CoA elements map to FAC (Fundamental Accounting Concepts) as the
+primary reporting target. FAC is a small, stable set of high-level
+statement concepts. Deterministic expansion to rs-gaap / us-gaap
+happens via equivalence arcs on the FAC side.
 
 The demo resolves FAC qnames → element IDs at runtime against the
 library in the entity graph.

--- a/examples/close_demo/validate.py
+++ b/examples/close_demo/validate.py
@@ -171,7 +171,11 @@ class _Validator:
     self._check("factSet non-null", b.get("factSet") is not None)
     rules = b.get("rules", [])
     self._check("rules present", len(rules) > 0, f"{len(rules)} rules")
-    se = [r for r in rules if r.get("rulePattern") == "SumEquals" and r.get("ruleOrigin") == "native"]
+    se = [
+      r
+      for r in rules
+      if r.get("rulePattern") == "SumEquals" and r.get("ruleOrigin") == "native"
+    ]
     self._check("native SumEquals rule in envelope", len(se) == 1, f"{len(se)} found")
 
   # ── Dispose smoke test ───────────────────────────────────────────────────
@@ -358,7 +362,11 @@ class _Validator:
         f"{fs['periodStart']} → {fs['periodEnd']}",
       )
 
-    se = [r for r in b.get("rules", []) if r.get("rulePattern") == "SumEquals" and r.get("ruleOrigin") == "native"]
+    se = [
+      r
+      for r in b.get("rules", [])
+      if r.get("rulePattern") == "SumEquals" and r.get("ruleOrigin") == "native"
+    ]
     self._check("SumEquals rule present", len(se) == 1, f"{len(se)} found")
 
     duration = [f for f in b.get("facts", []) if f.get("periodType") == "duration"]
@@ -373,7 +381,9 @@ class _Validator:
       payload = client.evaluate_rules(self.graph_id, structure_id=sid)
       summary = payload.get("summary")
       if summary is None:
-        self._check("evaluate-rules all-pass", False, "summary=null (no rules evaluated)")
+        self._check(
+          "evaluate-rules all-pass", False, "summary=null (no rules evaluated)"
+        )
       else:
         fails = summary.get("fail", 0) + summary.get("error", 0)
         self._check("evaluate-rules all-pass", fails == 0, f"summary={summary}")

--- a/robosystems/arelle/__init__.py
+++ b/robosystems/arelle/__init__.py
@@ -6,8 +6,8 @@ seed pipeline (Charlie Hoffman's FAC + SFAC 6 artifacts) and — in the
 future — the SEC filing processor.
 
 The underlying Arelle client still lives at
-`robosystems.adapters.sec.client.arelle` during the POC phase; full
-promotion of the client to this module is Phase 1 work.
+`robosystems.adapters.sec.client.arelle`; promotion of that client into
+this module is not yet complete.
 
 Entry points:
 

--- a/robosystems/arelle/extractor.py
+++ b/robosystems/arelle/extractor.py
@@ -14,7 +14,7 @@ persistence.
 Namespace / formula concept filtering: XBRL Formula / Variable /
 Validation linkbase concepts are skipped at extraction time to keep
 seed artifacts focused on reporting taxonomy. Full formula ingest is
-Phase 1 work (validation rules engine).
+deferred to the validation rules engine.
 """
 
 from __future__ import annotations
@@ -142,9 +142,9 @@ def _concept_iri(concept: Any) -> URIRef | None:
 def _classify_concept(concept: Any) -> str:
   """Derive the classification (asset/liability/equity/revenue/expense).
 
-  Heuristic for POC: use balance + periodType as signals, fall back to
-  name-based inference. Real classification logic should come from the
-  type-subtype linkbase — Phase 1 work.
+  Heuristic: use balance + periodType as signals, fall back to
+  name-based inference. Authoritative classification will eventually
+  come from the type-subtype linkbase.
   """
   balance = getattr(concept, "balance", None)
   period_type = getattr(concept, "periodType", None)

--- a/robosystems/config/env.py
+++ b/robosystems/config/env.py
@@ -662,25 +662,25 @@ class EnvConfig:
     get_parameter_value("EXTENSIONS_GRAPHQL_ENABLED", "true").lower() == "true",
   )
 
-  # Period-boundary obligation promoter (Stream 2.B). When True, the
-  # Dagster sensor not only flips matured `pending` schedule_entry_due
-  # events to `classified` but also dispatches the registered handler so
-  # the closing-entry draft lands in the GL on the same tick. Defaults
-  # to False (co-pilot mode): status flips, drafts wait for an explicit
-  # operator action. Stream 2.E will move this to a per-graph column on
-  # the Graph row so different tenants can run different cadences.
-  EXTENSIONS_PROMOTION_AUTO_DISPATCH = get_bool_env(
-    "EXTENSIONS_PROMOTION_AUTO_DISPATCH",
-    get_parameter_value("EXTENSIONS_PROMOTION_AUTO_DISPATCH", "false").lower()
-    == "true",
-  )
-
   # --- Derived: EXTENSIONS_ENABLED ---
   # Whether the extensions PostgreSQL database should open at all.
   # Computed at class-body evaluation time from the per-domain flags
   # above (Python evaluates class bodies sequentially, so the names are
   # in scope here). Replaces the standalone `EXTENSIONS_ENABLED` env var.
   EXTENSIONS_ENABLED = ROBOLEDGER_ENABLED or ROBOINVESTOR_ENABLED
+
+  # Period-boundary obligation promoter. When True, the Dagster sensor
+  # not only flips matured `pending` schedule_entry_due events to
+  # `classified` but also dispatches the registered handler so the
+  # closing-entry draft lands in the GL on the same tick. Defaults to
+  # False (co-pilot mode): status flips, drafts wait for an explicit
+  # operator action. The per-graph autopilot column on the Graph row
+  # overrides this default when set.
+  EXTENSIONS_PROMOTION_AUTO_DISPATCH = get_bool_env(
+    "EXTENSIONS_PROMOTION_AUTO_DISPATCH",
+    get_parameter_value("EXTENSIONS_PROMOTION_AUTO_DISPATCH", "false").lower()
+    == "true",
+  )
 
   # --- Adapter Pipelines (Dagster) ---
   # Controls whether adapter-specific Dagster assets, jobs, sensors, and schedules

--- a/robosystems/dagster/definitions.py
+++ b/robosystems/dagster/definitions.py
@@ -258,7 +258,7 @@ all_sensors = [
   graph_usage_monitor_sensor,
   # Platform: Worker reliability
   worker_inflight_reaper_sensor,
-  # Extensions: period-boundary obligation promoter (Stream 2.B)
+  # Extensions: period-boundary obligation promoter
   *_extensions_sensors,
   # Adapter: SEC pipeline
   *sec["sensors"],

--- a/robosystems/dagster/jobs/extensions.py
+++ b/robosystems/dagster/jobs/extensions.py
@@ -143,7 +143,7 @@ def extensions_materialize_job():
 
 
 # ─────────────────────────────────────────────────────────────────────────
-# Stream 2.B — Period-boundary obligation promotion
+# Period-boundary obligation promotion
 # ─────────────────────────────────────────────────────────────────────────
 
 

--- a/robosystems/dagster/sensors/scheduled_obligation_promoter.py
+++ b/robosystems/dagster/sensors/scheduled_obligation_promoter.py
@@ -1,4 +1,4 @@
-"""Dagster sensor for the period-boundary obligation promoter (Stream 2.B).
+"""Dagster sensor for the period-boundary obligation promoter.
 
 Walks every active entity graph; for any graph that has matured `pending`
 `schedule_entry_due` events, fires a RunRequest against
@@ -124,10 +124,9 @@ def scheduled_obligation_promotion_sensor(context: SensorEvaluationContext):
       .all()
     )
 
-    # Per-graph autopilot flag added in Stream 2.E. The env var stays
-    # as the fallback default for legacy rows where the column is NULL,
-    # so a deployment-wide override still works during the rollout
-    # window.
+    # Per-graph autopilot flag on Graph.auto_dispatch_obligations. The env
+    # var supplies the deployment-wide default for rows where the column
+    # is NULL.
     env_default_auto_dispatch = bool(env.EXTENSIONS_PROMOTION_AUTO_DISPATCH)
     as_of_iso = now.isoformat()
 

--- a/robosystems/db/extensions.py
+++ b/robosystems/db/extensions.py
@@ -230,7 +230,7 @@ def _widen_library_checks(conn, schema: str) -> None:
   widened_taxonomy_type = (
     "taxonomy_type IN ("
     # 'reporting' retained transitionally for any rows copied from an
-    # un-backfilled public schema; Phase 2 tenant writes use
+    # un-backfilled public schema; tenant writes use
     # 'reporting_standard' / 'reporting_extension' / 'custom_ontology'.
     "'chart_of_accounts', 'reporting', 'mapping', 'schedule', "
     "'classification-vocabulary', 'classification-assignment', 'rules', "

--- a/robosystems/graphql/README.md
+++ b/robosystems/graphql/README.md
@@ -96,7 +96,7 @@ The `Query` root is built at class-construction time from whichever domain mixin
 - Does **not** have `InvestorQuery` in the schema
 - Introspection reports only ledger + information-block fields — there's no way for a client to discover or call `portfolios` on a deployment where investor is off
 
-This is strictly better than the alternative ("expose everything, throw `INVESTOR_NOT_INITIALIZED` at runtime") because clients can branch on the actual schema shape rather than trial-and-error against runtime errors. The tradeoff is that introspection tooling sees a different schema per deployment — fine for now since we don't publish a single SDL.
+This is strictly better than the alternative ("expose everything, throw `INVESTOR_NOT_INITIALIZED` at runtime") because clients can branch on the actual schema shape rather than trial-and-error against runtime errors. The tradeoff is that introspection tooling sees a different schema per deployment. We don't publish a single SDL; the schema is composed dynamically per tenant feature-flag combination.
 
 Per-domain gating also short-circuits the router: if both flags are off, the FastAPI router that mounts `/extensions/{graph_id}/graphql` never mounts at all (see `main.py` line ~369).
 

--- a/robosystems/graphql/types/information_block.py
+++ b/robosystems/graphql/types/information_block.py
@@ -8,9 +8,11 @@ top-level :class:`InformationBlock` is hand-written because its
 Strawberry's pydantic decorator can't unwrap union types cleanly; the
 ``from_pydantic`` classmethod does the construction explicitly.
 
-Phase a ships ``ScheduleMechanicsType`` as the only mechanics variant.
-New block types add their ``*MechanicsType`` wrapper and extend the
-union in :class:`InformationBlock.artifact_mechanics`'s return type.
+The ``mechanics`` field is exposed as ``scalars.JSON`` with a ``kind``
+discriminator embedded in the payload. Promoting it to a typed
+``strawberry.union(...)`` is deferred until each mechanics arm grows
+typed fields worth exposing as a union; until then, clients branch on
+the embedded ``kind`` tag.
 """
 
 from __future__ import annotations
@@ -64,8 +66,7 @@ class InformationBlockElement:
 
 @strawberry.experimental.pydantic.type(model=PydanticClassification, all_fields=True)
 class InformationBlockClassification:
-  """An association-level classification bundled inside the envelope
-  (Phase epsilon)."""
+  """An association-level classification bundled inside the envelope."""
 
 
 @strawberry.experimental.pydantic.type(model=PydanticConnection, all_fields=True)
@@ -84,7 +85,7 @@ class InformationBlockFact:
 
 @strawberry.experimental.pydantic.type(model=PydanticFactSet, all_fields=True)
 class InformationBlockFactSet:
-  """Period-specific instantiation of the Structure (Phase ζ)."""
+  """Period-specific instantiation of the Structure."""
 
 
 @strawberry.experimental.pydantic.type(model=PydanticInformationModel, all_fields=True)
@@ -104,24 +105,19 @@ class InformationBlockRuleVariable:
 
 @strawberry.experimental.pydantic.type(model=PydanticRule, all_fields=True)
 class InformationBlockRule:
-  """A verification rule bundled inside the envelope (Phase δ.2)."""
+  """A verification rule bundled inside the envelope."""
 
 
 @strawberry.experimental.pydantic.type(
   model=PydanticVerificationResult, all_fields=True
 )
 class InformationBlockVerificationResult:
-  """Persisted outcome of a rule evaluation (Phase iota data model)."""
+  """Persisted outcome of a rule evaluation."""
 
 
-# The `mechanics` field is exposed as ``scalars.JSON`` with a `kind`
-# discriminator in the payload. Phases a + b ship ScheduleMechanics +
-# StatementMechanics as Pydantic union arms (shape-validated on the
-# server side); promoting this to a typed ``strawberry.union(...)``
-# on the GraphQL side is deferred until Phase d, when
-# ``artifact_mechanics`` becomes a real column and both arms gain typed
-# fields worth exposing as a union. Until then, clients branch on the
-# embedded ``kind`` tag.
+# Mechanics + template are exposed as ``scalars.JSON`` with a ``kind``
+# discriminator embedded in the payload — see the module docstring for
+# why this is preferred over a typed Strawberry union.
 MechanicsPayload = strawberry.scalars.JSON
 
 
@@ -178,8 +174,9 @@ class InformationBlock:
   facts: list[InformationBlockFact]
   rules: list[InformationBlockRule]
 
-  # Dimensions still typed as JSON until Phase ζ's content side lands.
-  # fact_set + verification_results are typed as of Phase ζ + iota.
+  # Dimensions stay typed as JSON until the dimension catalog exposes
+  # typed fields worth promoting; fact_set + verification_results are
+  # typed leaves driven by their Pydantic models above.
   dimensions: list[MechanicsPayload]
   fact_set: InformationBlockFactSet | None
   verification_results: list[InformationBlockVerificationResult]
@@ -202,8 +199,9 @@ class InformationBlock:
       ],
       facts=[InformationBlockFact.from_pydantic(f) for f in envelope.facts],
       rules=[InformationBlockRule.from_pydantic(r) for r in envelope.rules],
-      # dimensions / verification_results still pass through as JSON
-      # until their phases land; fact_set is typed as of Phase ζ.
+      # dimensions still passes through as JSON; fact_set and
+      # verification_results are typed leaves driven by their Pydantic
+      # arms.
       dimensions=list(envelope.dimensions),
       fact_set=(
         InformationBlockFactSet.from_pydantic(envelope.fact_set)

--- a/robosystems/graphql/types/taxonomy_block.py
+++ b/robosystems/graphql/types/taxonomy_block.py
@@ -7,8 +7,8 @@ can't derive, so the leaves use explicit ``@strawberry.type`` + a
 hand-written because ``verification_results`` is an opaque JSON list.
 ``from_pydantic`` on the envelope constructs the full tree explicitly.
 
-Verification results will gain a typed shape in Phase 2.3 alongside the
-auto-rules engine; until then clients consume the raw JSON.
+Verification results carry an opaque JSON shape; clients consume the
+raw payload as the rule-evaluation surface stabilizes.
 """
 
 from __future__ import annotations
@@ -117,7 +117,7 @@ class TaxonomyBlockAssociation:
 
 @strawberry.type
 class TaxonomyBlockRule:
-  """A verification rule bundled inside a Taxonomy Block envelope (Phase 2.3)."""
+  """A verification rule bundled inside a Taxonomy Block envelope."""
 
   id: str
   name: str
@@ -177,8 +177,8 @@ class TaxonomyBlock:
   associations: list[TaxonomyBlockAssociation]
   rules: list[TaxonomyBlockRule]
 
-  # Phase 2.3 gives verification_results a typed shape; until then the
-  # list carries opaque JSON objects.
+  # ``verification_results`` is an opaque JSON list; clients receive the
+  # raw payload until the rule-evaluation surface stabilizes.
   verification_results: list[VerificationResultPayload]
 
   element_count: int

--- a/robosystems/middleware/mcp/tools/information_block_tools.py
+++ b/robosystems/middleware/mcp/tools/information_block_tools.py
@@ -9,8 +9,8 @@ envelope for any registered block type. Two tools:
 
 These are the eventual unified replacement for the block-type-specific
 read tools in ``schedule_tools.py`` (``list-schedule-structures``,
-``get-schedule-facts``). Both surfaces ship in parallel until agents
-migrate; no breaking change in Phase a.
+``get-schedule-facts``). Both surfaces ship in parallel during the
+migration so callers can switch over without a breaking change.
 
 The ``create-information-block`` **write** tool is NOT in this module —
 it's auto-generated from the OperationSpec via
@@ -60,7 +60,8 @@ A typed envelope with:
 - information_model (concept + member arrangement)
 - artifact (topic, mechanics — typed per block_type)
 - elements, connections, facts (bundled atoms)
-- rules, dimensions, fact_set, verification_results (populated in later phases)
+- rules, dimensions, fact_set, verification_results (populated as
+  the rule engine + FactSet expand work progresses)
 
 **RELATED TOOLS:**
 - list-information-blocks — browse available blocks

--- a/robosystems/middleware/mcp/tools/taxonomy_tools.py
+++ b/robosystems/middleware/mcp/tools/taxonomy_tools.py
@@ -103,7 +103,7 @@ class SuggestMappingTool:
 - Narrows by classification (asset→Assets subtree, revenue→Revenues subtree, etc.)
 
 **HOW IT WORKS:**
-- Reads the shared US GAAP reporting taxonomy (SFAC 6 → us-gaap hierarchy)
+- Reads the shared US GAAP reporting taxonomy (FAC → us-gaap hierarchy)
 - Filters by the same classification as the source element
 - Returns candidate concepts with qname, name, and hierarchy depth
 

--- a/robosystems/models/api/event_block.py
+++ b/robosystems/models/api/event_block.py
@@ -111,9 +111,10 @@ class CreateEventBlockRequest(BaseModel):
   )
   dimension_ids: list[str] = Field(default_factory=list)
 
-  # REA duality chain (forward-materialization + settlement links).
-  # Both are application-validated self-references; same nullable-FK pattern
-  # as the correction chain.
+  # REA duality links — economic relationships expressing obligation origin
+  # (`obligated_by_event_id`) and obligation discharge (`discharges_event_id`).
+  # Forward-materialization + settlement links. Both are application-validated
+  # self-references; same nullable-FK pattern as the correction chain.
   obligated_by_event_id: str | None = Field(
     None,
     description=(

--- a/robosystems/models/api/event_handler.py
+++ b/robosystems/models/api/event_handler.py
@@ -1,11 +1,15 @@
 """API models for Event Handler — the dynamic event → transaction rule registry.
 
-Phase 3 of the event-driven ledger. EventHandlers are the rules that fire
-GL transactions when create-event-block is called with apply_handlers=True.
+EventHandlers map ``event_type`` plus optional match expressions onto a
+transaction template. When ``create-event-block`` runs with
+``apply_handlers=True``, the registry resolves the matching handler and the
+engine evaluates its template to produce GL rows.
 
-TransactionTemplate is the DSL shape. Phase 3 ships immediate postings only
-(debit/credit legs + {{ expr }} interpolation). Recurring/schedule blocks
-come in Phase 4 alongside revenue recognition.
+``TransactionTemplate`` is the DSL shape: immediate postings only
+(debit/credit legs + ``{{ expr }}`` interpolation). Recurring / schedule-block
+templates are not yet implemented — periodic side effects are produced today
+via the obligation register (``schedule_entry_due`` events), not via DSL
+template recurrence.
 """
 
 from __future__ import annotations

--- a/robosystems/models/api/extensions/schedules.py
+++ b/robosystems/models/api/extensions/schedules.py
@@ -202,9 +202,9 @@ class ScheduleCreatedResponse(BaseModel):
   total_periods: int
   total_facts: int
   rule_summary: dict[str, int] | None = None
-  # Stream 2.A — every schedule is now backed by an event chain. Callers
-  # can use `schedule_created_event_id` as the obligation-register handle
-  # and `pending_event_count` as a quick sanity check that materialization
+  # Every schedule is backed by an event chain. Callers can use
+  # `schedule_created_event_id` as the obligation-register handle and
+  # `pending_event_count` as a quick sanity check that materialization
   # produced one event per period.
   schedule_created_event_id: str | None = None
   pending_event_count: int = 0
@@ -246,7 +246,7 @@ class DeleteScheduleRequest(BaseModel):
   structure_id: str
 
 
-# DisposeScheduleRequest / DisposeScheduleResponse retired in Phase 4b.
-# Asset disposal is now an event block: `create-event-block(event_type='asset_disposed')`.
-# See operations/event_block/python_handlers/asset_disposed.py
-# for the metadata schema (AssetDisposedMetadata).
+# Asset disposal is an event block:
+# `create-event-block(event_type='asset_disposed')`. See
+# operations/event_block/python_handlers/asset_disposed.py for the
+# metadata schema (AssetDisposedMetadata).

--- a/robosystems/models/api/information_block.py
+++ b/robosystems/models/api/information_block.py
@@ -5,10 +5,9 @@ Wire-facing types for the cross-domain Information Block construct
 ``create-information-block`` operation, the GraphQL ``informationBlock``/
 ``informationBlocks`` fields, and the MCP read tools.
 
-Phase a ships only the ``schedule`` block type; new block types register
-their own ``*Mechanics`` model and add it to the ``ArtifactMechanics``
-discriminated union here. The envelope shape itself stays invariant —
-adding a block type is a union-arm edit, not an envelope redesign.
+Adding a block type: register its ``*Mechanics`` model and add it to
+the ``ArtifactMechanics`` discriminated union here. The envelope shape
+stays invariant — a union-arm edit, not an envelope redesign.
 """
 
 from __future__ import annotations
@@ -107,8 +106,7 @@ class ConnectionLite(BaseModel):
   """Connection (= Association) projection.
 
   Renamed at the API boundary to match Charlie's ontology vocabulary.
-  The underlying storage is still ``associations``; Phase g keeps that
-  table name stable.
+  The underlying storage table is still ``associations``.
   """
 
   model_config = ConfigDict(from_attributes=True)
@@ -129,10 +127,10 @@ class ConnectionLite(BaseModel):
   classifications: list[ClassificationLite] = Field(
     default_factory=list,
     description=(
-      "Association-level classifications (Phase epsilon) — "
-      "concept_arrangement, member_arrangement, named_disclosure rows "
-      "from the junction. Empty for library-seeded associations that "
-      "haven't been classified yet."
+      "Association-level classifications — concept_arrangement, "
+      "member_arrangement, named_disclosure rows from the junction. "
+      "Empty for library-seeded associations that haven't been "
+      "classified yet."
     ),
   )
 
@@ -156,11 +154,10 @@ class FactLite(BaseModel):
 class FactSetLite(BaseModel):
   """FactSet projection — period-specific instantiation of the Structure.
 
-  Phase ζ data-model landing. The envelope carries one ``FactSetLite``
-  per block when a FactSet row exists for the requested period; older
-  writes (pre-Phase-ζ ``create_report`` / ``create_schedule`` paths) may
-  still leave ``fact_set`` null until the expand pass stamps FactSet
-  rows on every write.
+  The envelope carries one ``FactSetLite`` per block when a FactSet row
+  exists for the requested period; legacy writes that pre-date FactSet
+  stamping leave ``fact_set`` null until the expand pass starts
+  populating those rows.
   """
 
   model_config = ConfigDict(from_attributes=True)
@@ -222,10 +219,10 @@ class RuleVariableLite(BaseModel):
 
 
 class VerificationResultLite(BaseModel):
-  """Persisted outcome of one Rule evaluation (Phase iota data model).
+  """Persisted outcome of one Rule evaluation.
 
-  One row per ``public.verification_results`` entry the engine (Phase
-  δ.3) writes. The envelope surfaces them so the block viewer's
+  One row per ``public.verification_results`` entry the rule engine
+  writes. The envelope surfaces them so the block viewer's
   "Verification Results" tab and MCP ``list-verification-failures``
   tool can render + aggregate without a second round-trip.
   """
@@ -252,10 +249,11 @@ class VerificationResultLite(BaseModel):
 class RuleLite(BaseModel):
   """Rule projection for the Information Block envelope.
 
-  One row per ``public.rules`` entry scoped to this block. The engine
-  (Phase δ.3) consumes ``rule_expression`` + ``rule_variables`` to
-  evaluate against the in-scope fact set; until then the envelope just
-  surfaces the rules so the UI can render them as a checklist.
+  One row per ``public.rules`` entry scoped to this block. The rule
+  engine consumes ``rule_expression`` + ``rule_variables`` to evaluate
+  against the in-scope fact set; the envelope surfaces the rules so
+  the UI can render them as a checklist alongside any persisted
+  verification results.
   """
 
   model_config = ConfigDict(from_attributes=True)
@@ -308,12 +306,12 @@ class RuleLite(BaseModel):
 class ScheduleMechanics(BaseModel):
   """Closing-entry generator mechanics for ``block_type='schedule'``.
 
-  Phase δ: reads directly from the typed ``structures.artifact_mechanics``
-  JSONB column. ``entry_template`` and ``schedule_metadata`` are typed
+  Reads directly from the typed ``structures.artifact_mechanics`` JSONB
+  column. ``entry_template`` and ``schedule_metadata`` are typed
   sub-models (reusing the wire-level request shapes so OpenAPI emits one
   canonical type per concept); the envelope builder falls back to
-  ``structures.metadata_`` for pre-δ Schedule rows that the tenant
-  backfill hasn't yet migrated.
+  ``structures.metadata_`` for legacy Schedule rows that the tenant
+  backfill hasn't yet migrated to the typed column.
   """
 
   kind: Literal["closing_entry_generator"] = "closing_entry_generator"
@@ -336,26 +334,27 @@ class ScheduleMechanics(BaseModel):
     default=0,
     description=(
       "Number of in-scope periods that have at least one closing entry "
-      "posted. Runtime state — Phase ζ migrates this to the typed FactSet "
-      "envelope where it becomes derivable from fact_sets."
+      "posted. Runtime state derived at envelope-build time from the "
+      "Entry table."
     ),
   )
 
 
 class MetricMechanics(BaseModel):
-  """Derivative mechanics for ``block_type='metric'`` (Phase η data model).
+  """Derivative mechanics for ``block_type='metric'``.
 
   A metric block composes its facts from one or more source blocks at
-  read time — covenant tests, ratios, KPI trend computations. Phase η
-  ships the typed arm so the discriminated union covers all three
+  read time — covenant tests, ratios, KPI trend computations. The typed
+  arm ships today so the discriminated union covers all three
   construction modes (declarative / compositional / derivative); the
-  actual derivation evaluator ships in a follow-up.
+  derivation evaluator that actually computes facts from source-block
+  FactSets is not yet implemented.
 
   ``source_block_ids`` is the ordered list of Structure ids this metric
   derives from; ``derivation_type`` names the kind of computation
   (``ratio``, ``trailing_twelve_month``, ``covenant_test``, …), and
-  ``expression`` carries the agent-authored derivation string evaluated
-  at envelope build time.
+  ``expression`` carries the agent-authored derivation string that the
+  evaluator will consume at envelope build time.
   """
 
   kind: Literal["metric"] = "metric"
@@ -363,9 +362,9 @@ class MetricMechanics(BaseModel):
     default_factory=list,
     description=(
       "Ordered list of Structure ids this metric sources from. Must be "
-      "non-empty at evaluation time; the blitz landing allows empty "
-      "lists so library scaffolding can register metric templates "
-      "before source linkage is wired."
+      "non-empty at evaluation time; empty lists are accepted so library "
+      "scaffolding can register metric templates before source linkage "
+      "is wired."
     ),
   )
   derivation_type: str | None = Field(
@@ -373,8 +372,8 @@ class MetricMechanics(BaseModel):
     description=(
       "Free-form label for the derivation kind — 'ratio', "
       "'trailing_twelve_month', 'covenant_test', etc. The evaluator "
-      "dispatches on this tag; future phases may lock the set with a "
-      "CHECK constraint once the derivation catalog stabilizes."
+      "dispatches on this tag; the set may be locked with a CHECK "
+      "constraint once the derivation catalog stabilizes."
     ),
   )
   expression: str | None = Field(
@@ -382,8 +381,7 @@ class MetricMechanics(BaseModel):
     description=(
       "Derivation expression in the metric DSL — evaluated at envelope "
       "read time to produce the derivative fact value. Opaque string "
-      "during the blitz; the rule-engine work (Phase δ.3) lands the "
-      "parser / evaluator in a follow-up."
+      "today; the metric-side parser / evaluator is not yet implemented."
     ),
   )
   unit: str = Field(
@@ -399,12 +397,11 @@ class StatementMechanics(BaseModel):
   """Renderer mechanics for the statement family of block types.
 
   Covers ``balance_sheet``, ``income_statement``, ``cash_flow_statement``,
-  and ``equity_statement``. Phase δ adds typed mechanics fields alongside
-  the existing Phase β tagged body; the fields are all optional so
-  library-seeded rows that haven't been enriched yet still validate.
-  The existing ``statement(...)`` GraphQL field continues to serve
-  rendered output; this mechanics model is the source of truth for
-  future renderer configuration.
+  and ``equity_statement``. All fields are optional so library-seeded
+  rows that haven't been enriched yet still validate against an empty
+  tagged body. The existing ``statement(...)`` GraphQL field continues
+  to serve rendered output; this mechanics model is the source of truth
+  for future renderer configuration.
   """
 
   kind: Literal["statement_renderer"] = "statement_renderer"
@@ -412,9 +409,9 @@ class StatementMechanics(BaseModel):
     None,
     description=(
       "Pinned template id — when set, the renderer uses that template's "
-      "layout instead of the block's default. The templates table lands "
-      "in a later phase; the column lands now so tenant writes can stamp "
-      "it without another migration round-trip."
+      "layout instead of the block's default. The templates table is "
+      "not yet implemented; the column is reserved so tenant writes can "
+      "stamp it without another migration round-trip when it lands."
     ),
   )
   rollup_root_element_ids: list[str] = Field(
@@ -472,13 +469,14 @@ class ArtifactResponse(BaseModel):
     None, description="Structure.description — the block's human-readable topic."
   )
   parenthetical_note: str | None = Field(
-    None, description="e.g. 'in thousands', 'except per share'. Phase d."
+    None, description="e.g. 'in thousands', 'except per share'."
   )
   template: dict[str, Any] | None = Field(
     None,
     description=(
       "Reusable layout (ordering, subtotals, styling) when attached. "
-      "Phase i delivers first-class templates; null in Phase a."
+      "First-class templates are not yet implemented; this field is "
+      "always null on currently-shipped block types."
     ),
   )
   mechanics: ArtifactMechanics
@@ -493,8 +491,9 @@ class InformationBlockEnvelope(BaseModel):
   One envelope per block instance. Carries the block's identity + type,
   Information-Model attributes, the Artifact branch (mechanics +
   topic/template), and bundled atoms (elements, connections, facts).
-  Rules / dimensions / FactSet / verificationResults are present-but-
-  empty until the corresponding phases land.
+  Rules / dimensions / FactSet / verification_results are present-but-
+  empty for blocks where the upstream content (rule engine, FactSet
+  expand, dimension catalog) has not yet been implemented.
   """
 
   id: str
@@ -533,11 +532,11 @@ class InformationBlockEnvelope(BaseModel):
   fact_set: FactSetLite | None = Field(
     None,
     description=(
-      "The period-specific FactSet this envelope instantiates (Phase ζ). "
-      "Null when the underlying block has no FactSet row yet — typically "
+      "The period-specific FactSet this envelope instantiates. Null "
+      "when the underlying block has no FactSet row yet — typically "
       "library-seeded statement Structures with no tenant-generated "
-      "facts, or Schedule rows written before the create-side stamping "
-      "(expand pass) lands."
+      "facts, or Schedule rows written before the create-side FactSet "
+      "stamping was added."
     ),
   )
   verification_results: list[VerificationResultLite] = Field(default_factory=list)
@@ -634,7 +633,7 @@ class DeleteInformationBlockResponse(BaseModel):
 
 
 class EvaluateRulesRequest(BaseModel):
-  """Request body for the ``evaluate-rules`` operation (Phase delta.3).
+  """Request body for the ``evaluate-rules`` operation.
 
   Runs every rule scoped to ``structure_id`` (plus element/association-
   scoped rules for the structure's atoms), binds ``$Variable`` references
@@ -651,8 +650,8 @@ class EvaluateRulesRequest(BaseModel):
     None,
     description=(
       "Optional FactSet id to stamp on each VerificationResult row. "
-      "Allows results to be scoped to a specific period run when the "
-      "FactSet table is populated (Phase zeta expand pass)."
+      "Allows results to be scoped to a specific period run once write "
+      "paths populate the FactSet table on every run."
     ),
   )
   period_start: date | None = Field(

--- a/robosystems/models/api/taxonomy_block.py
+++ b/robosystems/models/api/taxonomy_block.py
@@ -11,9 +11,6 @@ Four block types:
   * ``reporting_extension`` — tenant, extends a library ``reporting_standard``
   * ``chart_of_accounts`` — tenant, CoA curation
   * ``custom_ontology`` — tenant, declarative
-
-Phase 2.1 lands only the request/response shapes. Handlers, registry
-entries, and the validator/auto-rules engine arrive in later sub-phases.
 """
 
 from __future__ import annotations
@@ -348,8 +345,8 @@ class UpdateTaxonomyBlockRequest(BaseModel):
 
   Top-level fields (name / description / version) apply to the taxonomy
   row itself. The delta lists mutate atoms incrementally — the validator
-  (Phase 2.3) re-runs the seven-phase check across the projected post-
-  update state before anything commits.
+  re-runs every create-time check across the projected post-update
+  state before anything commits.
   """
 
   taxonomy_id: str

--- a/robosystems/models/core/graph/graph.py
+++ b/robosystems/models/core/graph/graph.py
@@ -177,15 +177,14 @@ class Graph(Model):
   # schema at provision time. See robosystems/taxonomy/pins.py.
   taxonomy_pin = Column(JSONB, nullable=True)
 
-  # Stream 2.E: per-graph autopilot for the period-boundary obligation
-  # promoter. When False (default — co-pilot), the sensor flips matured
-  # `pending` schedule_entry_due events to `classified` but stops there;
-  # an operator/agent drives draft creation. When True (autopilot), the
+  # Per-graph autopilot for the period-boundary obligation promoter.
+  # When False (default — co-pilot), the sensor flips matured `pending`
+  # schedule_entry_due events to `classified` but stops there; an
+  # operator/agent drives draft creation. When True (autopilot), the
   # sensor also dispatches the registered handler so the closing-entry
-  # draft lands in the GL on the same tick. Replaces the
-  # process-wide EXTENSIONS_PROMOTION_AUTO_DISPATCH env var introduced
-  # in Stream 2.B; the env var stays as the default when this column is
-  # NULL on legacy rows during the rollout window.
+  # draft lands in the GL on the same tick. Overrides the process-wide
+  # EXTENSIONS_PROMOTION_AUTO_DISPATCH env var; the env var supplies the
+  # default when this column is NULL.
   auto_dispatch_obligations = Column(Boolean, nullable=True)
 
   # Lifecycle status

--- a/robosystems/models/extensions/association_classification.py
+++ b/robosystems/models/extensions/association_classification.py
@@ -10,10 +10,10 @@ Mirrors the shape of :class:`ElementClassification`: composite PK on
 ``(association_id, classification_id)``, ``is_primary`` picks the
 canonical row per category, ``confidence`` + ``source`` track AI/adapter
 provenance. Structures carry an aggregate ``concept_arrangement`` column
-(Phase δ.1) for the common case where every association in the structure
-shares the same pattern; the junction enables the disaggregated view
-when they differ (e.g. a statement with a RollUp trunk and RollForward
-branches).
+as an optimized junction for the common case where every association in
+the structure shares the same classifications; the per-row junction
+enables the disaggregated view when they differ (e.g. a statement with a
+RollUp trunk and RollForward branches).
 """
 
 from datetime import UTC, datetime

--- a/robosystems/models/extensions/element.py
+++ b/robosystems/models/extensions/element.py
@@ -128,13 +128,13 @@ class Element(ExtensionsBase):
   external_id = Column(String, nullable=True)
   external_source = Column(String, nullable=True)
 
-  # Canonical concept linkage (Phase θ) — elements pointing at the same
-  # cross-tenant canonical concept share ``agent_id``. ``aliases`` carries
-  # alternate spellings and qname variants (e.g. us-gaap-2024 vs
+  # Cross-tenant canonical concept linkage via ``agent_id``: elements
+  # pointing at the same canonical concept share the value. ``aliases``
+  # carries alternate spellings and qname variants (e.g. us-gaap-2024 vs
   # us-gaap-2020) that agents should treat as the same concept.
   # ``embedding`` holds a 1024-dimensional sentence embedding the
-  # MappingAgent + classifier use for similarity lookups; nullable while
-  # the seed content lands incrementally.
+  # MappingAgent + classifier use for similarity lookups; nullable
+  # because the seed content lands incrementally.
   agent_id = Column(String, nullable=True)
   aliases = Column(ARRAY(String), nullable=False, default=list)
   embedding = Column(ARRAY(Float), nullable=True)

--- a/robosystems/models/extensions/roboledger/agent.py
+++ b/robosystems/models/extensions/roboledger/agent.py
@@ -2,10 +2,7 @@
 
 REA-aligned: Agent is the counterparty in a business event. Distinct from
 Entity (the reporting entity / graph owner). Agents are the external actors
-events are exchanged with.
-
-Phase 2 of the event-driven ledger. agent_id on events gains a real FK to
-this table once this migration runs.
+events are exchanged with. ``events.agent_id`` carries a FK to this table.
 """
 
 from datetime import UTC, datetime

--- a/robosystems/models/extensions/roboledger/event.py
+++ b/robosystems/models/extensions/roboledger/event.py
@@ -5,13 +5,15 @@ with voided and superseded as terminal off-ramps. The triggered_by_event_id
 column on transactions and entries links GL rows back to the originating
 event for the audit chain.
 
-Two REA-aligned link columns let events express duality at the event
-layer rather than only at the GL: ``obligated_by_event_id`` points at the
-event that scheduled this one (forward materialization — e.g. a depreciation
-schedule entry pointing back at the asset_acquired event); ``discharges_event_id``
-points at the obligation this event settles (e.g. cash_received pointing at
-the originating sale_invoiced). Both are nullable, application-validated
-self-references, matching the existing pattern for ``replaced_by_event_id``.
+Two REA duality links — economic relationships expressing obligation origin
+(``obligated_by_event_id``) and obligation discharge (``discharges_event_id``)
+— let events express duality at the event layer rather than only at the GL:
+``obligated_by_event_id`` points at the event that scheduled this one
+(forward materialization — e.g. a depreciation schedule entry pointing back
+at the asset_acquired event); ``discharges_event_id`` points at the
+obligation this event settles (e.g. cash_received pointing at the originating
+sale_invoiced). Both are nullable, application-validated self-references,
+matching the existing pattern for ``replaced_by_event_id``.
 
 ``event_class`` (``'economic' | 'support'``) is orthogonal to ``event_category``.
 Economic events change resources; support events (control, approval,

--- a/robosystems/models/extensions/roboledger/event_handler.py
+++ b/robosystems/models/extensions/roboledger/event_handler.py
@@ -1,11 +1,9 @@
 """EventHandler model — dynamic rule registry for event → transaction transformation.
 
 Each row declares which events it handles (via match criteria) and how to
-produce GL transactions (via transaction_template DSL).
-
-Phase 3 of the event-driven ledger. The handler engine (registry.py +
-engine.py) evaluates these rows when create-event-block fires with
-apply_handlers=True.
+produce GL transactions (via the ``transaction_template`` DSL). The handler
+engine (``operations/event_block/registry.py`` + ``engine.py``) evaluates
+these rows when ``create-event-block`` fires with ``apply_handlers=True``.
 """
 
 from datetime import UTC, datetime

--- a/robosystems/models/extensions/roboledger/fact_set.py
+++ b/robosystems/models/extensions/roboledger/fact_set.py
@@ -1,22 +1,15 @@
 """FactSet model — period-specific instantiation of a Structure.
 
-Phase ζ data-model landing. From the spec §5.3:
+A Structure accumulates many FactSets over time — one per period run.
+Structure = Information Model + Mechanics declaration (persistent);
+FactSet = a period-specific instantiation of that Structure;
+Information Block envelope = Structure + FactSet for a given period.
 
-    A Structure accumulates many FactSets over time — one per period run.
-    Structure = Information Model + Mechanics declaration (persistent).
-    FactSet    = a period-specific instantiation of that Structure.
-    Information Block envelope = Structure + FactSet for a given period.
-
-The table exists so statements and schedules share one period-scoped
-grouping concept instead of the split today (statements use ``report_id``,
-schedules use ``fact_set_id`` as a free-floating string). Over the expand
-pass, ``create_report`` creates a FactSet row first and stamps all facts
-with ``fact_set_id``; ``report_id`` retires once every reader resolves
-through FactSet.
-
-The blitz ships the table + FKs + writer support. Backfill of existing
-rows, ``report_id`` column retirement, and the dimension seeder are
-expand-pass work.
+The table provides one period-scoped grouping concept that statements
+and schedules share. ``create_report`` creates a FactSet row first and
+stamps all facts with ``fact_set_id``; the legacy ``report_id`` column
+remains as a back-pointer for readers that have not yet been migrated
+to resolve through FactSet.
 """
 
 from datetime import UTC, datetime
@@ -64,7 +57,7 @@ class FactSet(ExtensionsBase):
 
   # Kind of FactSet — 'report' for statement renderers, 'schedule' for
   # closing-entry generators, 'custom' for agent-authored derivative
-  # blocks (Phase η). Enum closure enforced by CHECK above.
+  # blocks. Enum closure enforced by the CHECK constraint above.
   factset_type = Column(String, nullable=False, default="report")
 
   # Multi-tenant + cross-link fields. ``entity_id`` matches

--- a/robosystems/models/extensions/rule.py
+++ b/robosystems/models/extensions/rule.py
@@ -1,4 +1,6 @@
-"""Rule model — verification rules sourced from the Seattle Method (Phase d.2).
+"""Verification rules: pattern- and expression-based validations evaluated against fact sets.
+
+The initial rule corpus is sourced from the Seattle Method linkbases.
 
 Tenant-scoped table. Each row is one rule in the canonical Seattle
 Method taxonomy: ``rule_category`` names the governance axis

--- a/robosystems/models/extensions/structure.py
+++ b/robosystems/models/extensions/structure.py
@@ -2,6 +2,11 @@
 
 Tenant-scoped table. The OLTP representation of Structure nodes in the graph.
 Each structure belongs to a taxonomy and contains element associations.
+
+During the metadata_ → artifact_mechanics transition, both columns are
+populated on write and the read paths prefer ``artifact_mechanics``.
+``metadata_`` remains for backward compatibility with rows written before
+the typed mechanics column landed.
 """
 
 from datetime import UTC, datetime
@@ -55,30 +60,28 @@ class Structure(ExtensionsBase):
   # State
   is_active = Column(Boolean, nullable=False, default=True)
 
-  # Information Model axis columns (Phase δ)
+  # Information Model axis columns.
   # concept_arrangement: roll_up | roll_forward | variance | adjustment |
   # set | arithmetic | textblock. Nullable until every block type
-  # declares a default; CHECK constraint deferred to a later phase so
+  # declares a default; the CHECK constraint is intentionally absent so
   # the vocabulary can expand without a migration round-trip.
   concept_arrangement = Column(String, nullable=True)
   # member_arrangement: aggregation | nonaggregation. Null for
   # non-hypercube block types.
   member_arrangement = Column(String, nullable=True)
 
-  # Typed Artifact Mechanics (Phase δ). Pydantic discriminated union
-  # (see models/api/information_block.py::ArtifactMechanics) persisted
-  # as JSONB. Read-path validates shape on envelope build; Schedule
-  # writes stamp this column alongside metadata_ during the migration
-  # window, then metadata_'s entry_template + schedule_metadata keys
-  # are retired in a later phase.
+  # Typed Artifact Mechanics. Pydantic discriminated union (see
+  # ``models/api/information_block.py::ArtifactMechanics``) persisted as
+  # JSONB. Read paths validate shape on envelope build; writes stamp this
+  # column alongside ``metadata_``.
   artifact_mechanics = Column(JSONB, nullable=True)
 
-  # Renderer caveat, e.g. "(in thousands, except per share)". Phase δ.
+  # Renderer caveat, e.g. "(in thousands, except per share)".
   parenthetical_note = Column(String, nullable=True)
 
-  # Nullable FK to structure_templates. The templates table lands in a
-  # later phase; this column is added now so Phase δ writes that pin a
-  # template don't require another round-trip. No FK constraint yet.
+  # Nullable FK to ``structure_templates``. No FK constraint yet so
+  # writes that pin a template don't require coordinated lifecycle with
+  # the templates table.
   template_id = Column(String, nullable=True)
 
   # Metadata

--- a/robosystems/models/extensions/structure_template.py
+++ b/robosystems/models/extensions/structure_template.py
@@ -1,14 +1,11 @@
 """StructureTemplate model — reusable layout/configuration for a Structure.
 
-Phase iota data-model landing. Each row describes a template a Structure
-can pin via ``structures.template_id`` to override default rendering /
-slot ordering / subtotal labels. Library-seeded templates (the four
-statement types + common Schedule variants) share the vocabulary with
-tenant-authored templates so the same column powers both cases.
-
-The blitz ships the table + FK target. Library content (the four
-statement templates + common Schedule variants) lands in the expand
-pass once template shapes are finalized.
+Reusable templates for Structure rows. A template defines the canonical
+shape (axes, mechanics, slot ordering, subtotal labels) that one or more
+Structures instantiate via ``structures.template_id``. Library-seeded
+templates (the four statement types + common Schedule variants) share
+the vocabulary with tenant-authored templates so the same column powers
+both cases.
 """
 
 from datetime import UTC, datetime

--- a/robosystems/models/extensions/verification_result.py
+++ b/robosystems/models/extensions/verification_result.py
@@ -1,7 +1,6 @@
 """VerificationResult model — persisted outcome of a Rule evaluation.
 
-Phase iota data-model landing. Each row records one evaluation of a Rule
-against a particular FactSet / Structure context:
+Each row records a single rule's outcome against a fact set:
 
 - ``rule_id`` FKs the rule being evaluated.
 - ``structure_id`` (nullable) FKs the block the rule was evaluated
@@ -13,8 +12,9 @@ against a particular FactSet / Structure context:
 - ``status`` IN ('pass','fail','error','skipped') captures the
   outcome; ``message`` carries the human-readable explanation.
 
-The engine (Phase δ.3) is the producer; this model exists so engine
-output has a durable home that MCP tools + the block viewer can read.
+Rows are written by the rule evaluation engine; this model exists so
+engine output has a durable home that MCP tools + the block viewer can
+read.
 """
 
 from datetime import UTC, datetime

--- a/robosystems/operations/README.md
+++ b/robosystems/operations/README.md
@@ -58,7 +58,7 @@ operations/
 │   ├── schedule.py            # Schedule block type handler (declarative construction)
 │   ├── statement.py           # Statement block type handlers (compositional, stub)
 │   ├── metric.py              # Metric block type handler (derivative, stub)
-│   ├── classify.py            # Association classifier scaffold (Phase δ.3)
+│   ├── classify.py            # Association classifier scaffold (not yet implemented)
 │   └── rules/                 # Rule evaluation engine
 │       ├── engine.py          # evaluate_rules_for_structure — entry point
 │       ├── evaluators.py      # Per-pattern dispatch (EqualTo, RollUp, Exists, CoExists, …)
@@ -140,11 +140,11 @@ The registry (`registry.py`) maps `block_type` strings to `BlockTypeRegistryEntr
 | `equity_statement` | compositional | `statement.py` | Yes |
 | `metric` | derivative | `metric.py` | No |
 
-Statement and metric dispatch handlers currently raise `NotImplementedError` (→ HTTP 501) — their data models are wired, but the construction logic ships in later phases.
+Statement and metric dispatch handlers currently raise `NotImplementedError` (→ HTTP 501) — their data models are wired, but the construction logic is not yet implemented.
 
 ## Rule Evaluation Engine
 
-`information_block/rules/` implements the Phase δ.3 rule evaluation engine:
+`information_block/rules/` implements the rule evaluation engine:
 
 - **`engine.py`** — entry point: loads rules scoped to a structure (via `envelope.load_rules_for_structure`), binds `$Variable` references to in-scope facts via qname lookup, dispatches per-pattern, writes `VerificationResult` rows, calls `session.flush()` before returning
 - **`evaluators.py`** — pattern dispatchers: `EqualTo`/`RollUp`/`RollForward` (arithmetic equality with configurable tolerance), `Exists` (fact presence), `CoExists` (all-or-nothing binding); other patterns return `skipped`

--- a/robosystems/operations/agents/implementations/mapping/prompt.py
+++ b/robosystems/operations/agents/implementations/mapping/prompt.py
@@ -35,7 +35,7 @@ FASB elementsOfFinancialStatements axis. Primary values for CoA mapping:
 - **loss** — non-operating debit flows (income-statement duration, debit balance)
 
 Candidates have already been filtered to match the CoA element's classification \
-(typically to a specific SFAC 6 anchor subtree), so you don't need to re-filter — focus \
+(typically to a specific FAC anchor subtree), so you don't need to re-filter — focus \
 on choosing the best semantic match within the candidates.
 
 ## Matching Rules
@@ -161,7 +161,7 @@ def build_mapping_prompt(
   Args:
       elements: CoA elements to map (from get-unmapped-elements).
       candidates: FAC concepts to match against (from suggest-mapping; anchor-narrowed
-          via the element's SFAC 6 tagging when available, classification-only
+          via the element's FAC tagging when available, classification-only
           fallback otherwise).
 
   Returns:

--- a/robosystems/operations/event_block/__init__.py
+++ b/robosystems/operations/event_block/__init__.py
@@ -1,7 +1,7 @@
-"""Event Block commands — Phase 1 + Phase 3 write surface.
+"""Event Block commands — create, update, and preview operations.
 
-Re-exports the same names that lived in the old event_block.py so all
-existing imports continue to work unchanged.
+Re-exports the public command surface so callers import a stable module
+path regardless of internal layout.
 """
 
 from .commands import (

--- a/robosystems/operations/event_block/commands.py
+++ b/robosystems/operations/event_block/commands.py
@@ -1,10 +1,16 @@
-"""Event Block commands — Phase 1 + Phase 3 write surface.
+"""Event Block commands — create, update, and preview operations.
 
-Phase 1: create (apply_handlers=False) + update (status transitions + corrections).
-Phase 3: apply_handlers=True fires the handler engine; preview_event_block is a
-dry-run that returns the plan without persisting rows.
+Functions are pure: ``(Session, RequestModel, created_by) → ResponseModel``.
 
-All functions are pure: (Session, RequestModel, created_by) → ResponseModel.
+- ``create_event_block``: persists an event row. With ``apply_handlers=False``
+  the row lands in ``status='captured'`` and nothing else is written. With
+  ``apply_handlers=True`` the event is resolved against the Python registry
+  first, falling back to the DSL registry; the matched handler fires and
+  produces GL rows atomically with the event row.
+- ``update_event_block``: applies status transitions and field corrections to
+  an existing event.
+- ``preview_event_block``: dry-runs handler resolution + template evaluation
+  and returns the plan without persisting anything.
 """
 
 from __future__ import annotations
@@ -12,7 +18,6 @@ from __future__ import annotations
 from datetime import UTC, datetime
 
 from pydantic import ValidationError
-from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from robosystems.models.api.event_block import (
@@ -29,6 +34,10 @@ from robosystems.models.extensions.roboledger.dimension_junctions import (
   event_dimensions,
 )
 from robosystems.models.extensions.roboledger.event import Event
+from robosystems.operations.roboledger.reads.event_block import (
+  _load_dimension_ids,
+  _to_envelope,
+)
 
 from .engine import EngineValidationError, apply_handler
 from .python_handlers import get_python_handler
@@ -68,48 +77,6 @@ _VALID_TRANSITIONS: dict[str, frozenset[str]] = {
   "voided": frozenset(),
   "superseded": frozenset(),
 }
-
-
-def _load_dimension_ids(session: Session, event_id: str) -> list[str]:
-  rows = (
-    session.execute(
-      select(event_dimensions.c.dimension_id).where(
-        event_dimensions.c.event_id == event_id
-      )
-    )
-    .scalars()
-    .all()
-  )
-  return list(rows)
-
-
-def _to_envelope(event: Event, dimension_ids: list[str]) -> EventBlockEnvelope:
-  return EventBlockEnvelope(
-    id=event.id,
-    event_type=event.event_type,
-    event_category=event.event_category,
-    event_class=event.event_class,
-    status=event.status,
-    occurred_at=event.occurred_at,
-    effective_at=event.effective_at,
-    source=event.source,
-    external_id=event.external_id,
-    external_url=event.external_url,
-    amount=event.amount,
-    currency=event.currency,
-    description=event.description,
-    metadata=dict(event.metadata_ or {}),
-    dimension_ids=dimension_ids,
-    agent_id=event.agent_id,
-    resource_type=event.resource_type,
-    resource_element_id=event.resource_element_id,
-    replaced_by_event_id=event.replaced_by_event_id,
-    replaces_event_id=event.replaces_event_id,
-    obligated_by_event_id=event.obligated_by_event_id,
-    discharges_event_id=event.discharges_event_id,
-    created_at=event.created_at,
-    created_by=event.created_by,
-  )
 
 
 def _resolve_agent_type(session: Session, agent_id: str | None) -> str | None:
@@ -158,10 +125,12 @@ def create_event_block(
 ) -> EventBlockEnvelope:
   """Persist an event block, optionally firing the handler engine.
 
-  apply_handlers=False: capture-only (Phase 1 behaviour, status='captured').
-  apply_handlers=True: resolves handler and fires it atomically.
+  ``apply_handlers=False``: capture-only — persists the event row in
+  ``status='captured'`` and writes no GL rows.
+  ``apply_handlers=True``: resolves the event_type to a handler and fires
+  it atomically alongside the event row.
 
-  Handler resolution:
+  Handler resolution order:
     1. Python registry (hub-defined complex workflows, e.g., asset_disposed)
     2. DSL registry (event_handlers table, tenant-configurable simple templates)
 
@@ -196,7 +165,7 @@ def create_event_block(
       session.commit()
       return _to_envelope(event, body.dimension_ids)
 
-    # 2. Fall through to the DSL registry (Phase 3 path)
+    # 2. Fall through to the DSL registry
     agent_type = _resolve_agent_type(session, body.agent_id)
     handler = resolve_handler(
       session,

--- a/robosystems/operations/event_block/engine.py
+++ b/robosystems/operations/event_block/engine.py
@@ -1,9 +1,9 @@
 """Handler engine — evaluate a transaction_template and produce GL rows.
 
-Phase 3: immediate postings only. One template entry → one Transaction +
-one Entry + two LineItems (debit + credit). All rows are flushed but not
-committed; the caller (create_event_block) commits the whole unit of work
-atomically so failures roll back cleanly.
+Immediate postings only: one template entry → one Transaction + one Entry +
+two LineItems (debit + credit). All rows are flushed but not committed; the
+caller (``create_event_block``) commits the whole unit of work atomically so
+failures roll back cleanly.
 """
 
 from __future__ import annotations

--- a/robosystems/operations/event_block/promotion.py
+++ b/robosystems/operations/event_block/promotion.py
@@ -1,9 +1,10 @@
-"""Pending-obligation promotion — Stream 2.B's reusable core.
+"""Pending-obligation promotion — reusable core sweep.
 
-Materialized `pending` `schedule_entry_due` events sit dormant until their
-period boundary passes. At that point a sweep flips them to `classified`
-(committing to the obligation), then optionally dispatches the
-`schedule_entry_due` Python handler to draft the closing entry on the GL.
+Materialized ``pending`` ``schedule_entry_due`` events sit dormant until
+their period boundary passes. At that point a sweep flips them to
+``classified`` (committing to the obligation), then optionally dispatches
+the ``schedule_entry_due`` Python handler to draft the closing entry on the
+GL.
 
 Two surfaces call this:
 
@@ -24,18 +25,18 @@ The ``dispatch_handlers`` flag distinguishes the two operating modes:
 
 - ``False`` (co-pilot, default): flip status only. The operator (or
   another job) is responsible for actually drafting the entry. Useful
-  during early rollout when handler dispatch should be observable
-  before it's automatic.
+  when handler dispatch should be observable before it's automatic.
 - ``True`` (autopilot): also call the registered Python handler so the
   draft entry lands in the GL immediately on the same tick.
 
-Stream 2.E will promote this from a process-wide env var to a
-per-graph column on ``Graph``.
+Mode is selected per graph via ``Graph.auto_dispatch_obligations``, with the
+``EXTENSIONS_PROMOTION_AUTO_DISPATCH`` env var as the deployment-wide default
+when the column is NULL.
 
 Idempotence
 -----------
 
-The flip is `UPDATE … WHERE status='pending' AND occurred_at <= :as_of`
+The flip is ``UPDATE … WHERE status='pending' AND occurred_at <= :as_of``
 so re-running the function is safe — already-classified rows are
 skipped. Handler dispatch is idempotent at the schedule-entry level
 (``ScheduleService.create_closing_entry`` reconciles to the existing

--- a/robosystems/operations/event_block/python_handlers/asset_disposed.py
+++ b/robosystems/operations/event_block/python_handlers/asset_disposed.py
@@ -21,10 +21,10 @@ Event status after success: 'fulfilled' (disposal is terminal — no further wor
 All writes happen in one session. If any step raises, the outer transaction
 rolls back — nothing persists, no half-disposed state.
 
-Stream 2.C migration note: prior versions called `ScheduleService.truncate_schedule`
-to hard-delete forward facts. That path is gone — the obligation register is
-now the single source of truth for "what's still due", and voiding events is
-how a disposal terminates a schedule's remaining lifespan.
+The obligation register is the single source of truth for what is still due.
+Disposal terminates a schedule's remaining lifespan by voiding the schedule's
+pending ``schedule_entry_due`` events; forward facts are left in place as a
+historical record.
 """
 
 from __future__ import annotations
@@ -73,9 +73,8 @@ class AssetDisposedMetadata(BaseModel):
   reason: str = Field(
     "asset_disposed_event",
     description=(
-      "Free-text disposal reason. Stored on the event row's narrative; "
-      "purely informational since Stream 2.C — no longer drives schedule "
-      "truncation."
+      "Free-text disposal reason. Stored on the event row's narrative as "
+      "informational context; does not drive any side effect on the schedule."
     ),
   )
 
@@ -95,8 +94,8 @@ def _void_pending_obligations_for_schedule(
   — the GL's disposal entry is the authoritative end-state.
 
   Returns 0 (no-op) when the structure is missing or has no
-  ``schedule_created_event_id`` — covers schedules created before
-  Stream 2.A and any test fixtures that build Structure rows directly.
+  ``schedule_created_event_id`` — covers schedules without an originating
+  event row (e.g. test fixtures that build Structure rows directly).
   """
   structure = session.get(Structure, structure_id)
   if structure is None:

--- a/robosystems/operations/event_block/python_handlers/schedule_created.py
+++ b/robosystems/operations/event_block/python_handlers/schedule_created.py
@@ -15,17 +15,11 @@ materialized `schedule_entry_due` events point at via
         ▼
     Entry (draft → posted at close-period)
 
-When Stream 4 introduces domain-specific originators
-(``asset_acquired`` / ``prepaid_recorded`` / ``contract_signed``),
-``schedule_created`` events themselves get an
-``obligated_by_event_id`` pointing at the upstream domain event so
-the disposal cascade and AR/AP queries traverse uniformly.
-
 ScheduleService.create_schedule emits this event directly inside its
 own unit of work — it is NOT created via create-event-block by
 external callers. Registering it here is what gives the row a known
-event_type, a metadata schema for validation, and a place for future
-agents to dry-run via preview.
+event_type, a metadata schema for validation, and a place for agents
+to dry-run via preview.
 """
 
 from __future__ import annotations

--- a/robosystems/operations/event_block/registry.py
+++ b/robosystems/operations/event_block/registry.py
@@ -49,15 +49,18 @@ def _matches_metadata_expression(
 ) -> bool:
   """Simple dot-path equality match against event.metadata.
 
-  Accepts both root-relative paths ("category") and the historically
-  documented metadata-prefixed form ("metadata.category").
+  Three supported path forms:
+  - ``"foo"`` — root-relative key inside event.metadata (``metadata["foo"]``).
+  - ``"metadata.foo"`` — same target as ``"foo"``; the ``metadata.`` prefix
+    is stripped before traversal so DSL authors can write either form.
+  - ``"metadata"`` — bare literal that compares the entire metadata dict to
+    the expected value.
   """
   if not expression:
     return True
   for path, expected in expression.items():
-    # Support nested paths like "category" or "sub.key". Keep backward
-    # compatibility with the documented "metadata.foo" form.
     if path == "metadata":
+      # Bare ``metadata`` literal: compare the whole metadata dict.
       node = event_metadata
       if node != expected:
         return False

--- a/robosystems/operations/event_block/template.py
+++ b/robosystems/operations/event_block/template.py
@@ -1,6 +1,6 @@
 """Transaction template DSL — {{ expr }} interpolation.
 
-Phase 3 ships immediate postings only. Supported expressions:
+Supported expressions:
   {{ event.amount }}               — event.amount (int, cents)
   {{ event.metadata.foo }}         — nested metadata field
   {{ event.metadata.foo }} / 2     — integer division
@@ -9,7 +9,6 @@ Phase 3 ships immediate postings only. Supported expressions:
 Rules:
 - All {{ ... }} tokens are resolved before arithmetic.
 - Arithmetic: only  `/ N`  trailing suffix is supported (integer division).
-  Future: `* N`, `+ N`, `- N` can be added here without touching callers.
 - Resolution errors raise TemplateInterpolationError with a descriptive message.
 - int results are returned as int; string results as str.
 """

--- a/robosystems/operations/extensions/materialize.py
+++ b/robosystems/operations/extensions/materialize.py
@@ -185,7 +185,7 @@ def _filter_tables_for_extensions(
 #       postgres_scanner.
 #   (2) Declared in schemas/extensions/roboinvestor.py for schema
 #       completeness but not yet backed by OLTP tables or materialization
-#       SQL — deferred Phase 2 work.
+#       SQL — not yet implemented.
 _UNMATERIALIZED_TABLES: frozenset[str] = frozenset(
   {
     # Category 1: SEC XBRL-only (not written from extensions OLTP)
@@ -203,7 +203,7 @@ _UNMATERIALIZED_TABLES: frozenset[str] = frozenset(
     "FACT_HAS_DIMENSION",
     "ENTITY_EVOLVED_FROM",
     "ENTITY_OWNS_ENTITY",
-    # Category 2: roboinvestor Phase 2 — schema-declared, OLTP not yet wired
+    # Category 2: roboinvestor schema-declared, OLTP not yet wired
     "Trade",
     "Benchmark",
     "MarketData",

--- a/robosystems/operations/information_block/README.md
+++ b/robosystems/operations/information_block/README.md
@@ -2,7 +2,7 @@
 
 The Information Block subsystem provides a registry-driven, type-safe system for constructing and reading structured financial data blocks — schedules, statements, rollforwards, reconciliations, metrics, and policies.
 
-**Architectural context**: `local/docs/specs/information-block.md` has the full spec with phase breakdown. This README is the code-level orientation.
+**Architectural context**: `local/docs/specs/information-block.md` has the full spec. This README is the code-level orientation.
 
 ## What is an Information Block?
 
@@ -23,7 +23,7 @@ information_block/
 ├── schedule.py        # block_type='schedule' handler (declarative construction)
 ├── statement.py       # block_type='balance_sheet|income_statement|...' handlers (stub)
 ├── metric.py          # block_type='metric' handler (stub)
-├── classify.py        # Scaffold for the Phase δ.3 association classifier (see below)
+├── classify.py        # Scaffold for the association classifier (not yet implemented)
 └── rules/
     ├── engine.py      # evaluate_rules_for_structure — entry point
     ├── evaluators.py  # Per-pattern dispatch (EqualTo, RollUp, Exists, CoExists, …)
@@ -41,7 +41,7 @@ Each registered block type declares one of three construction modes:
 | `compositional` | Atoms exist from report ingest; block is a view assembled at read time | `balance_sheet`, `income_statement`, `cash_flow_statement`, `equity_statement` |
 | `derivative` | Facts are computed from other blocks at read time | `metric` |
 
-Phase a only ships full `declarative` support. Compositional and derivative handlers raise `NotImplementedError` (→ HTTP 501) until their phases land.
+The compositional family (statements) and the derivative family (metrics) raise `NotImplementedError` (→ HTTP 501) on the create / update / delete paths today — statements are produced via `create-report`, and the metric derivation evaluator is not yet implemented. Their `build_envelope` paths are fully wired and surface read envelopes normally.
 
 ## Adding a New Block Type
 
@@ -91,12 +91,15 @@ results = evaluate_rules_for_structure(
 
 The engine loads rules via `envelope.load_rules_for_structure` (so element- and association-scoped rules are included), binds `$Variable` names to fact values via qname lookup, dispatches to the per-pattern evaluator, writes one `VerificationResult` row per rule, and returns the written rows. `session.flush()` is called before returning; the caller owns `commit`.
 
-**Binding semantics**: schedule facts are structure-scoped (`Fact.structure_id`). Statement facts are currently report-scoped (`Fact.report_id`, `structure_id=NULL`) — the engine falls back to the most recent matching report for non-schedule blocks until the FactSet expand pass stamps `structure_id` on every fact.
+**Binding semantics**: schedule facts are structure-scoped (`Fact.structure_id`). Statement facts are currently report-scoped (`Fact.report_id`, `structure_id=NULL`) — the engine falls back to the most recent matching report for non-schedule blocks until report-write paths stamp `structure_id` on every fact.
 
 **Expression safety**: `expressions.py` rewrites `$Variable` → `_var_Name`, normalizes bare `=` → `==`, parses with `ast.parse(mode='eval')`, then walks the AST through a whitelist. `eval()` is never called — the AST is evaluated recursively by `_eval_arith`.
 
-## classify.py — Scaffold, Not Yet Implemented
+## Status of Pending Components
 
-`classify.py` is a deliberate empty scaffold that reserves the import path for the Phase δ.3 OLTP association classifier. The current classification implementation lives in the SEC adapter at `adapters/sec/processors/classify.py` (Cypher/parquet-based). The Phase δ.3 extraction will move a Postgres-backed version here so it can run directly over OLTP `associations` + `elements` rows and produce `association_classifications` rows for any tenant — not just SEC-ingested graphs.
+- **Rule evaluation engine**: pattern dispatchers and the safe expression parser are implemented and wired through `evaluate-rules`. Handles `EqualTo` / `RollUp` / `RollForward` / `Exists` / `CoExists` / `SumEquals`; other patterns return `skipped`.
+- **Association classifier (`classify.py`)**: not yet implemented. The current SEC-side classifier lives in `adapters/sec/processors/classify.py` and writes graph-side Classification nodes; a Postgres-backed version that runs over OLTP `associations` + `elements` and produces `association_classifications` rows for any tenant has not been ported. The `classify.py` module reserves the import path so handlers have a stable hook.
+- **FactSet expansion**: not yet implemented. Write paths do not yet stamp every fact with a `fact_set_id`, so `FactSetLite` on the envelope is `None` for blocks whose creation pre-dates FactSet stamping.
+- **Metric derivation evaluator**: not yet implemented. `MetricMechanics` is registered as a typed union arm; the create / update / delete paths raise `NotImplementedError` and `build_envelope` returns the typed mechanics with `facts=[]`.
 
-If the classifier grows into multiple files, promote `classify.py` → `classify/` then. Don't do it preemptively.
+If `classify.py` grows into multiple files, promote it to `classify/` then — don't do it preemptively.

--- a/robosystems/operations/information_block/__init__.py
+++ b/robosystems/operations/information_block/__init__.py
@@ -10,8 +10,8 @@ Public surface:
   the reads.
 
 See ``local/docs/specs/information-block.md`` for the architectural
-context and ``docs/specs/financial-viewer.md`` for the companion View
-layer.
+context and ``local/docs/specs/financial-viewer.md`` for the companion
+View layer.
 """
 
 from __future__ import annotations

--- a/robosystems/operations/information_block/classify.py
+++ b/robosystems/operations/information_block/classify.py
@@ -1,24 +1,5 @@
-"""Association classifier — cross-domain home for pattern detection.
-
-Phase epsilon lands the data model (``association_classifications``
-junction + :class:`ClassificationLite` on the envelope + tenant copy).
-The runtime classifier logic that populates the junction — Cypher
-pattern-matching for RollUp / RollForward / Hypercube / LineItems /
-MemberList / Dimension, plus disclosure-mechanics semantic
-classification — still lives inside the SEC adapter at
-``robosystems/adapters/sec/processors/classify.py``.
-
-The extraction happens in Phase δ.3's expand pass: a Postgres-backed
-classifier that runs over OLTP ``associations`` + ``elements`` directly,
-producing ``association_classifications`` rows. Until then, the SEC
-adapter keeps its LadybugDB/parquet-based implementation and writes
-results to the graph's Classification nodes; tenant OLTP
-``association_classifications`` rows arrive via library seed writers
-when seed content carries them (none today).
-
-Scaffold reserved so future ``classify(session, structure_id, …)``
-calls have a stable import path that handlers can hook into.
-"""
+"""Association classifier — not yet implemented. Reserves the import
+path for future expansion."""
 
 from __future__ import annotations
 

--- a/robosystems/operations/information_block/envelope.py
+++ b/robosystems/operations/information_block/envelope.py
@@ -1,13 +1,15 @@
 """Cross-type assembly helpers for building Information Block envelopes.
 
-Block-type handlers (``schedule.py`` today, more in future phases) each
-own the logic that's specific to their shape. The helpers here are the
-generic atom → Lite conversions shared by every handler — one place to
-maintain the ORM → wire-shape mapping so Phase b's Statement handler
-doesn't diverge from Phase a's Schedule handler.
+Block-type handlers (``schedule.py``, ``statement.py``, ``metric.py``)
+each own the logic that's specific to their shape. The helpers here are
+the generic atom -> Lite conversions shared by every handler — one
+place to maintain the ORM -> wire-shape mapping so handlers don't
+diverge.
 """
 
 from __future__ import annotations
+
+from dataclasses import dataclass
 
 from sqlalchemy import or_, select
 from sqlalchemy.orm import Session
@@ -29,6 +31,7 @@ from robosystems.models.extensions import (
   Classification,
   Element,
   Rule,
+  Structure,
   VerificationResult,
 )
 from robosystems.models.extensions.roboledger import Fact, FactSet
@@ -168,7 +171,7 @@ def load_verification_results_for_structure(
 
   Returns the full history ordered by ``evaluated_at`` descending so
   the envelope exposes the most recent run first. Empty list when no
-  rows — the common case while the engine (Phase δ.3) ships.
+  rows — the common case until the rule engine writes results.
   """
   rows = (
     session.execute(
@@ -190,9 +193,8 @@ def load_latest_fact_set_for_structure(
   Ordered by ``period_end`` descending then ``created_at`` descending so
   a Structure with multiple FactSets (e.g. a Schedule accumulating
   period runs) surfaces the latest slice. Returns ``None`` when no
-  FactSet row exists — Phase ζ sitting in the data-model-only blitz
-  means library-seeded Structures won't have one until creation paths
-  start stamping them (expand pass).
+  FactSet row exists — typically library-seeded Structures whose
+  tenant has not yet generated facts.
   """
   row = session.execute(
     select(FactSet)
@@ -285,11 +287,102 @@ def load_rules_for_structure(
   return [rule_to_lite(r) for r in rules]
 
 
+@dataclass(frozen=True)
+class BaseEnvelopeAtoms:
+  """Shared atoms loaded by every block-type ``build_envelope``.
+
+  The block-specific handlers add mechanics + the per-block fact filter
+  on top; everything else (Structure, taxonomy_name, associations,
+  elements, rules, classifications, fact_set, verification_results) is
+  identical across the registered block types.
+  """
+
+  structure: Structure
+  taxonomy_name: str | None
+  associations: list[Association]
+  elements: list[Element]
+  element_ids: list[str]
+  rules: list[RuleLite]
+  classifications_by_assoc: dict[str, list[ClassificationLite]]
+  fact_set: FactSetLite | None
+  verification_results: list[VerificationResultLite]
+
+
+def load_base_envelope_atoms(
+  session: Session, structure_id: str, *, expected_block_type: str
+) -> BaseEnvelopeAtoms | None:
+  """Load every atom shared by Information Block envelope builders.
+
+  Returns ``None`` when the Structure doesn't exist or its
+  ``structure_type`` doesn't match ``expected_block_type`` — handlers
+  surface that as a clean miss to :func:`get_information_block`. Loading
+  order: Structure -> taxonomy name -> associations -> elements -> rules
+  -> classifications -> fact_set -> verification_results, matching the
+  order each individual handler used to inline.
+  """
+  from robosystems.models.extensions import Taxonomy
+
+  structure = session.get(Structure, structure_id)
+  if structure is None or structure.structure_type != expected_block_type:
+    return None
+
+  taxonomy_name = session.execute(
+    select(Taxonomy.name).where(Taxonomy.id == structure.taxonomy_id)
+  ).scalar()
+
+  associations = list(
+    session.execute(select(Association).where(Association.structure_id == structure_id))
+    .scalars()
+    .all()
+  )
+
+  element_id_set = {a.from_element_id for a in associations} | {
+    a.to_element_id for a in associations
+  }
+  element_ids = [e for e in element_id_set if e is not None]
+  if element_ids:
+    elements = list(
+      session.execute(select(Element).where(Element.id.in_(element_ids)))
+      .scalars()
+      .all()
+    )
+  else:
+    elements = []
+
+  rules = load_rules_for_structure(
+    session,
+    structure_id,
+    element_ids=element_ids,
+    association_ids=[a.id for a in associations],
+  )
+
+  classifications_by_assoc = load_classifications_for_associations(
+    session, [a.id for a in associations]
+  )
+
+  fact_set = load_latest_fact_set_for_structure(session, structure_id)
+  verification_results = load_verification_results_for_structure(session, structure_id)
+
+  return BaseEnvelopeAtoms(
+    structure=structure,
+    taxonomy_name=taxonomy_name,
+    associations=associations,
+    elements=elements,
+    element_ids=element_ids,
+    rules=rules,
+    classifications_by_assoc=classifications_by_assoc,
+    fact_set=fact_set,
+    verification_results=verification_results,
+  )
+
+
 __all__ = [
+  "BaseEnvelopeAtoms",
   "association_to_connection",
   "element_to_lite",
   "fact_set_to_lite",
   "fact_to_lite",
+  "load_base_envelope_atoms",
   "load_classifications_for_associations",
   "load_latest_fact_set_for_structure",
   "load_rules_for_structure",

--- a/robosystems/operations/information_block/metric.py
+++ b/robosystems/operations/information_block/metric.py
@@ -1,16 +1,18 @@
 """Handlers for ``block_type='metric'`` — the derivative construction mode.
 
-Phase η data-model landing: ``MetricMechanics`` now exists as a typed
-arm of the ``ArtifactMechanics`` discriminated union, and ``metric`` is
-registered as a known block type. The derivation evaluator that
-actually computes metric values from source-block FactSets ships in a
-follow-up — the create/update/delete handlers raise ``NotImplementedError``
-in the meantime, mirroring the statement-family handler pattern.
+Typed :class:`MetricMechanics` ships as one arm of the
+``ArtifactMechanics`` discriminated union, and ``metric`` is registered
+as a known block type. The envelope builder reads mechanics from the
+typed ``artifact_mechanics`` column and surfaces the block as a
+placeholder with ``facts=[]``; the derivation evaluator that computes
+metric values from source-block FactSets is not yet implemented. The
+create/update/delete handlers raise :class:`NotImplementedError` via
+the registry's ``make_not_implemented_handler`` factory.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from robosystems.models.api.information_block import (
   ArtifactResponse,
@@ -27,43 +29,26 @@ from robosystems.operations.information_block.envelope import (
 if TYPE_CHECKING:
   from sqlalchemy.orm import Session
 
-METRIC_BLOCK_TYPE = "metric"
-METRIC_DISPLAY_NAME = "Metric"
-METRIC_CATEGORY = "Reporting"
-
-
-def _create_not_implemented(session: Session, body: Any, created_by: str) -> str:
-  """Create raises until Phase η's expand pass lands the evaluator."""
-  raise NotImplementedError(
-    "create-metric-block is not implemented yet. Phase η ships the "
-    "typed MetricMechanics arm; the derivation evaluator + create path "
-    "land in a follow-up once the Rule engine (Phase δ.3) stabilizes."
-  )
-
-
-def _update_not_implemented(session: Session, body: Any, created_by: str) -> str:
-  raise NotImplementedError(
-    "update-metric-block is not implemented yet (Phase η follow-up)."
-  )
-
-
-def _delete_not_implemented(session: Session, body: Any, created_by: str) -> str:
-  raise NotImplementedError(
-    "delete-metric-block is not implemented yet (Phase η follow-up)."
-  )
-
 
 def build_envelope(
   session: Session, structure_id: str
 ) -> InformationBlockEnvelope | None:
   """Reload a metric Structure and pack it into the Information Block envelope.
 
-  Pre-evaluator behaviour: mechanics are read off the typed
-  ``artifact_mechanics`` column; ``facts`` stays empty until the
-  derivation evaluator lands. The envelope shape is stable so callers
-  and UI can already render a metric block as a placeholder.
+  Mechanics are read off the typed ``artifact_mechanics`` column;
+  ``facts`` stays empty until the derivation evaluator is implemented.
+  The envelope shape is stable so callers and UI can already render a
+  metric block as a placeholder.
   """
   from sqlalchemy import select
+
+  # Imported here so the module-level constants can stay in registry.py
+  # without dragging the registry into metric.py's import chain.
+  from robosystems.operations.information_block.registry import (
+    METRIC_BLOCK_TYPE,
+    METRIC_CATEGORY,
+    METRIC_DISPLAY_NAME,
+  )
 
   structure = session.get(Structure, structure_id)
   if structure is None or structure.structure_type != METRIC_BLOCK_TYPE:
@@ -105,8 +90,5 @@ def build_envelope(
 
 
 __all__ = [
-  "METRIC_BLOCK_TYPE",
-  "METRIC_CATEGORY",
-  "METRIC_DISPLAY_NAME",
   "build_envelope",
 ]

--- a/robosystems/operations/information_block/metric.py
+++ b/robosystems/operations/information_block/metric.py
@@ -29,6 +29,10 @@ from robosystems.operations.information_block.envelope import (
 if TYPE_CHECKING:
   from sqlalchemy.orm import Session
 
+METRIC_BLOCK_TYPE = "metric"
+METRIC_DISPLAY_NAME = "Metric"
+METRIC_CATEGORY = "Reporting"
+
 
 def build_envelope(
   session: Session, structure_id: str
@@ -41,14 +45,6 @@ def build_envelope(
   metric block as a placeholder.
   """
   from sqlalchemy import select
-
-  # Imported here so the module-level constants can stay in registry.py
-  # without dragging the registry into metric.py's import chain.
-  from robosystems.operations.information_block.registry import (
-    METRIC_BLOCK_TYPE,
-    METRIC_CATEGORY,
-    METRIC_DISPLAY_NAME,
-  )
 
   structure = session.get(Structure, structure_id)
   if structure is None or structure.structure_type != METRIC_BLOCK_TYPE:
@@ -90,5 +86,8 @@ def build_envelope(
 
 
 __all__ = [
+  "METRIC_BLOCK_TYPE",
+  "METRIC_CATEGORY",
+  "METRIC_DISPLAY_NAME",
   "build_envelope",
 ]

--- a/robosystems/operations/information_block/reads.py
+++ b/robosystems/operations/information_block/reads.py
@@ -6,9 +6,9 @@ tools (``get-information-block`` / ``list-information-blocks``). Shape
 is defined once; agents, SDK callers, and the UI all see the same
 envelope.
 
-Phase a only knows about ``block_type='schedule'``; unknown block_type
-filters raise :class:`ValueError`. Future phases add more entries to
-the registry — no changes needed here.
+Unknown ``block_type`` filters raise :class:`ValueError`; new block
+types register themselves in the registry and surface here without
+changes to this module.
 """
 
 from __future__ import annotations
@@ -35,9 +35,9 @@ def get_information_block(
   try:
     entry = registry_module.get(structure.structure_type)
   except KeyError:
-    # Existing rows with a structure_type that isn't yet modeled as a
-    # block type (e.g. 'balance_sheet' before Phase b) surface as
-    # None rather than raising — the envelope just can't be built.
+    # Existing rows whose structure_type isn't a registered block type
+    # surface as ``None`` rather than raising — the envelope just can't
+    # be built.
     return None
   return entry.dispatch_build_envelope(session, structure_id)
 

--- a/robosystems/operations/information_block/registry.py
+++ b/robosystems/operations/information_block/registry.py
@@ -12,6 +12,9 @@ per block type — ``schedule.py``, ``statement.py``, ...).
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from typing import Any
+
 from pydantic import BaseModel, ConfigDict
 
 from robosystems.models.api.extensions.schedules import (
@@ -32,6 +35,34 @@ from robosystems.operations.information_block.statement import (
   make_statement_handlers,
 )
 from robosystems.operations.information_block.types import BlockTypeRegistryEntry
+
+# Metric block display identity. Kept here (next to the registration) so
+# the handler module doesn't need to re-export wire-shape constants that
+# are only consumed at registry-build time.
+METRIC_BLOCK_TYPE = "metric"
+METRIC_DISPLAY_NAME = "Metric"
+METRIC_CATEGORY = "Reporting"
+
+
+def make_not_implemented_handler(operation: str, message: str) -> Callable[..., Any]:
+  """Build a dispatch handler that raises :class:`NotImplementedError`.
+
+  Used by block types whose ``dispatch_{create,update,delete}`` handler
+  is intentionally a stub — either because the construction path lives
+  elsewhere (statement family flows through ``create-report``) or because
+  the evaluator has not been implemented yet (metric blocks).
+
+  The returned callable accepts and ignores the standard handler
+  arguments ``(session, payload, actor)`` so it can be plugged into
+  :class:`BlockTypeRegistryEntry` without signature gymnastics.
+  """
+
+  def _handler(*_args: Any, **_kwargs: Any) -> str:
+    raise NotImplementedError(message)
+
+  _handler.__name__ = f"_not_implemented_{operation}"
+  _handler.__qualname__ = _handler.__name__
+  return _handler
 
 
 class _EmptyPayload(BaseModel):
@@ -89,7 +120,7 @@ def _make_statement_entry(block_type: str, icon: str) -> BlockTypeRegistryEntry:
   strings. This helper factors the common shape.
   """
   display_name, display_plural = STATEMENT_DISPLAY[block_type]
-  handlers = make_statement_handlers(block_type)
+  build_envelope = make_statement_handlers(block_type)
   return BlockTypeRegistryEntry(
     id=block_type,
     display_name=display_name,
@@ -108,10 +139,25 @@ def _make_statement_entry(block_type: str, icon: str) -> BlockTypeRegistryEntry:
     update_request_model=_EmptyPayload,
     delete_request_model=_EmptyPayload,
     construction_mode="compositional",
-    dispatch_create=handlers["create"],
-    dispatch_update=handlers["update"],
-    dispatch_delete=handlers["delete"],
-    dispatch_build_envelope=handlers["build_envelope"],
+    dispatch_create=make_not_implemented_handler(
+      f"create-{block_type}-block",
+      "Statements are generated via create-report, not "
+      "create-information-block. Create a report with the relevant "
+      "taxonomy; the statement envelope becomes queryable via "
+      "informationBlocks(blockType=...) after the report is published.",
+    ),
+    dispatch_update=make_not_implemented_handler(
+      f"update-{block_type}-block",
+      "Statement blocks are library-seeded and immutable. Use "
+      "create-report to produce new facts; the envelope surfaces the "
+      "most recent report's facts automatically.",
+    ),
+    dispatch_delete=make_not_implemented_handler(
+      f"delete-{block_type}-block",
+      "Statement blocks are library-seeded and cannot be deleted per "
+      "tenant. Archive the underlying Report via the report APIs instead.",
+    ),
+    dispatch_build_envelope=build_envelope,
     # Statement Structures live in public.structures (library-immutable)
     # and should surface on the library sentinel, with facts=[] because
     # reports live in tenant schemas.
@@ -128,16 +174,16 @@ EQUITY_STATEMENT_BLOCK = _make_statement_entry("equity_statement", "pie-chart")
 # ── Metric (derivative) ────────────────────────────────────────────────────
 
 METRIC_BLOCK = BlockTypeRegistryEntry(
-  id=metric_handlers.METRIC_BLOCK_TYPE,
-  display_name=metric_handlers.METRIC_DISPLAY_NAME,
+  id=METRIC_BLOCK_TYPE,
+  display_name=METRIC_DISPLAY_NAME,
   display_plural="Metrics",
-  category=metric_handlers.METRIC_CATEGORY,
+  category=METRIC_CATEGORY,
   icon="gauge",
   description=(
     "Derivative block — computes its facts from one or more source "
     "blocks at read time. Covenant tests, ratios, KPI trend views. "
-    "Phase η ships the typed mechanics arm; the derivation evaluator "
-    "lands in a follow-up."
+    "Typed mechanics ship today; the derivation evaluator that "
+    "computes facts from source-block FactSets is not yet implemented."
   ),
   concept_arrangement_default="arithmetic",
   member_arrangement_default=None,
@@ -146,9 +192,20 @@ METRIC_BLOCK = BlockTypeRegistryEntry(
   update_request_model=_EmptyPayload,
   delete_request_model=_EmptyPayload,
   construction_mode="derivative",
-  dispatch_create=metric_handlers._create_not_implemented,
-  dispatch_update=metric_handlers._update_not_implemented,
-  dispatch_delete=metric_handlers._delete_not_implemented,
+  dispatch_create=make_not_implemented_handler(
+    "create-metric-block",
+    "create-metric-block is not implemented yet. The typed "
+    "MetricMechanics arm ships today; the derivation evaluator + create "
+    "path land once the rule engine stabilizes.",
+  ),
+  dispatch_update=make_not_implemented_handler(
+    "update-metric-block",
+    "update-metric-block is not implemented yet.",
+  ),
+  dispatch_delete=make_not_implemented_handler(
+    "delete-metric-block",
+    "delete-metric-block is not implemented yet.",
+  ),
   dispatch_build_envelope=metric_handlers.build_envelope,
   surfaces_in_library=False,
 )

--- a/robosystems/operations/information_block/registry.py
+++ b/robosystems/operations/information_block/registry.py
@@ -36,12 +36,9 @@ from robosystems.operations.information_block.statement import (
 )
 from robosystems.operations.information_block.types import BlockTypeRegistryEntry
 
-# Metric block display identity. Kept here (next to the registration) so
-# the handler module doesn't need to re-export wire-shape constants that
-# are only consumed at registry-build time.
-METRIC_BLOCK_TYPE = "metric"
-METRIC_DISPLAY_NAME = "Metric"
-METRIC_CATEGORY = "Reporting"
+METRIC_BLOCK_TYPE = metric_handlers.METRIC_BLOCK_TYPE
+METRIC_DISPLAY_NAME = metric_handlers.METRIC_DISPLAY_NAME
+METRIC_CATEGORY = metric_handlers.METRIC_CATEGORY
 
 
 def make_not_implemented_handler(operation: str, message: str) -> Callable[..., Any]:

--- a/robosystems/operations/information_block/rules/engine.py
+++ b/robosystems/operations/information_block/rules/engine.py
@@ -27,10 +27,10 @@ For each ``{variable_name, variable_qname}`` entry in
    table (``fact_scope = 'in_scope'``, most recent ``period_end`` first).
    Structure-scoped facts win. If no structure fact exists, facts from
    the latest matching statement/report are accepted via one pinned
-   ``report_id`` because report creation still writes structure-agnostic
-   facts until the FactSet expand pass stamps ``structure_id``/
-   ``fact_set_id``. Schedules do not use that fallback; their own
-   generated facts are the source of truth. None on miss.
+   ``report_id`` because report-write paths currently write
+   structure-agnostic facts (``structure_id`` / ``fact_set_id`` are not
+   yet stamped on every fact). Schedules do not use that fallback;
+   their own generated facts are the source of truth. None on miss.
 
 One query per variable (N+1 is fine for 3-5 variables per rule).
 """

--- a/robosystems/operations/information_block/schedule.py
+++ b/robosystems/operations/information_block/schedule.py
@@ -1,4 +1,5 @@
-"""Handlers for ``block_type='schedule'`` — the first Information Block type.
+"""Handlers for ``block_type='schedule'`` — the declarative construction
+mode reference.
 
 Two public handlers bind the generic construction machinery to the
 existing Schedule POC:
@@ -9,10 +10,10 @@ existing Schedule POC:
   packs them into the typed :class:`InformationBlockEnvelope`.
 
 Schedule is the reference implementation of the **declarative**
-construction mode (user declares the mechanics + seed params; the
-system generates atoms). Phase b's Statement block type will be the
-reference **compositional** mode; Phase η's Metric block type will be
-the reference **derivative** mode.
+construction mode — the user declares the mechanics + seed params and
+the system generates atoms. The statement family covers the
+**compositional** mode and the metric block covers the **derivative**
+mode.
 """
 
 from __future__ import annotations
@@ -33,16 +34,13 @@ from robosystems.models.api.information_block import (
   InformationModelResponse,
   ScheduleMechanics,
 )
-from robosystems.models.extensions import Association, Element, Structure, Taxonomy
+from robosystems.models.extensions import Structure
 from robosystems.models.extensions.roboledger import Entry, Fact
 from robosystems.operations.information_block.envelope import (
   association_to_connection,
   element_to_lite,
   fact_to_lite,
-  load_classifications_for_associations,
-  load_latest_fact_set_for_structure,
-  load_rules_for_structure,
-  load_verification_results_for_structure,
+  load_base_envelope_atoms,
 )
 from robosystems.operations.roboledger.commands.schedules import (
   create_schedule as cmd_create_schedule,
@@ -114,10 +112,10 @@ def _load_schedule_mechanics(
 ) -> ScheduleMechanics:
   """Build the typed Schedule mechanics from a Structure row.
 
-  Prefers the Phase δ typed column (``artifact_mechanics``). Falls back
-  to the legacy ``metadata_`` JSONB shape for Schedule rows that
-  pre-date the Phase δ backfill — both paths produce the same
-  :class:`ScheduleMechanics` envelope arm.
+  Reads from the typed ``artifact_mechanics`` column when populated and
+  falls back to the legacy ``metadata_`` JSONB shape for Schedule rows
+  that pre-date the typed-column backfill — both paths produce the
+  same :class:`ScheduleMechanics` envelope arm.
   """
   mechanics_blob = structure.artifact_mechanics
   if mechanics_blob:
@@ -131,8 +129,9 @@ def _load_schedule_mechanics(
   if not raw_entry_template:
     raise ValueError(
       f"Schedule structure {structure.id!r} has no entry_template in metadata_ "
-      "and no artifact_mechanics — the row may be corrupted or from an unsupported "
-      "pre-δ path. Check the Schedule creation path and the Phase δ backfill."
+      "and no artifact_mechanics — the row may be corrupted or written by an "
+      "unsupported legacy path. Check the Schedule creation path and the "
+      "artifact_mechanics backfill."
     )
   return ScheduleMechanics(
     kind="closing_entry_generator",
@@ -153,18 +152,20 @@ def build_envelope(
 
   Returns ``None`` when the structure doesn't exist or isn't a schedule,
   so the generic reader can cleanly distinguish misses from errors.
-
-  Phase δ reads mechanics from the typed ``artifact_mechanics`` column,
-  falling back to legacy ``metadata_`` JSONB for rows that pre-date the
-  backfill.
+  Mechanics are read from the typed ``artifact_mechanics`` column with
+  fallback to legacy ``metadata_`` JSONB.
   """
-  structure = session.get(Structure, structure_id)
-  if structure is None or structure.structure_type != SCHEDULE_BLOCK_TYPE:
+  atoms = load_base_envelope_atoms(
+    session, structure_id, expected_block_type=SCHEDULE_BLOCK_TYPE
+  )
+  if atoms is None:
     return None
 
+  structure = atoms.structure
+
   # Runtime state: how many closing entries (draft OR posted) trace back
-  # to this schedule. Phase ζ makes this derivable from typed FactSets
-  # and this counter gets removed.
+  # to this schedule. Kept on the mechanics arm until typed FactSets
+  # make this derivable.
   periods_with_entries = (
     session.execute(
       select(func.count(Entry.id)).where(
@@ -176,28 +177,6 @@ def build_envelope(
   )
 
   mechanics = _load_schedule_mechanics(structure, periods_with_entries)
-
-  taxonomy_name = session.execute(
-    select(Taxonomy.name).where(Taxonomy.id == structure.taxonomy_id)
-  ).scalar()
-
-  associations = (
-    session.execute(select(Association).where(Association.structure_id == structure_id))
-    .scalars()
-    .all()
-  )
-
-  element_ids = {a.to_element_id for a in associations} | {
-    a.from_element_id for a in associations
-  }
-  if element_ids:
-    elements = (
-      session.execute(select(Element).where(Element.id.in_(element_ids)))
-      .scalars()
-      .all()
-    )
-  else:
-    elements = []
 
   # Schedules publish only in-scope facts — historical facts were
   # already reflected in opening balances and shouldn't surface as
@@ -213,20 +192,6 @@ def build_envelope(
     .all()
   )
 
-  rules = load_rules_for_structure(
-    session,
-    structure_id,
-    element_ids=list(element_ids),
-    association_ids=[a.id for a in associations],
-  )
-
-  classifications_by_assoc = load_classifications_for_associations(
-    session, [a.id for a in associations]
-  )
-
-  fact_set = load_latest_fact_set_for_structure(session, structure_id)
-  verification_results = load_verification_results_for_structure(session, structure_id)
-
   return InformationBlockEnvelope(
     id=structure.id,
     block_type=SCHEDULE_BLOCK_TYPE,
@@ -234,7 +199,7 @@ def build_envelope(
     display_name=SCHEDULE_DISPLAY_NAME,
     category=SCHEDULE_CATEGORY,
     taxonomy_id=structure.taxonomy_id,
-    taxonomy_name=taxonomy_name,
+    taxonomy_name=atoms.taxonomy_name,
     information_model=InformationModelResponse(
       concept_arrangement=structure.concept_arrangement or "roll_forward",
       member_arrangement=structure.member_arrangement,
@@ -245,15 +210,15 @@ def build_envelope(
       template=None,
       mechanics=mechanics,
     ),
-    elements=[element_to_lite(e) for e in elements],
+    elements=[element_to_lite(e) for e in atoms.elements],
     connections=[
-      association_to_connection(a, classifications_by_assoc.get(a.id, []))
-      for a in associations
+      association_to_connection(a, atoms.classifications_by_assoc.get(a.id, []))
+      for a in atoms.associations
     ],
     facts=[fact_to_lite(f) for f in facts],
-    rules=rules,
-    fact_set=fact_set,
-    verification_results=verification_results,
+    rules=atoms.rules,
+    fact_set=atoms.fact_set,
+    verification_results=atoms.verification_results,
   )
 
 

--- a/robosystems/operations/information_block/statement.py
+++ b/robosystems/operations/information_block/statement.py
@@ -1,8 +1,8 @@
 """Handlers for the statement family of Information Block types.
 
 Four block types — ``balance_sheet``, ``income_statement``,
-``cash_flow_statement``, ``equity_statement`` — share one handler body
-parameterised on the block_type string. Each corresponds to a
+``cash_flow_statement``, ``equity_statement`` — share one envelope
+builder parameterised on the block_type string. Each corresponds to a
 library-seeded Structure in ``public.structures``; seeds live in
 :mod:`robosystems.taxonomy.seed` (``seed_reporting_taxonomy``).
 
@@ -11,19 +11,18 @@ Structure exists before any tenant action; per-tenant facts come from
 ``create-report`` calls; the envelope materialises on GET by pulling
 the library atoms together with the tenant's most-recent report facts.
 
-Because statements aren't created via ``create-information-block``,
-``dispatch_create`` for every statement block type raises
-:class:`NotImplementedError`, which the registrar's error map
-translates to an HTTP 501 with a pointer to ``create-report``.
+Statements aren't created via ``create-information-block``; the
+``dispatch_create``/``update``/``delete`` handlers in the registry
+entry are the not-implemented stubs built by
+``make_not_implemented_handler``.
 """
 
 from __future__ import annotations
 
 from collections.abc import Callable
 from functools import partial
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
-from pydantic import BaseModel
 from sqlalchemy import select
 
 from robosystems.models.api.information_block import (
@@ -32,16 +31,12 @@ from robosystems.models.api.information_block import (
   InformationModelResponse,
   StatementMechanics,
 )
-from robosystems.models.extensions import Association, Element, Structure, Taxonomy
 from robosystems.models.extensions.roboledger import Fact, Report
 from robosystems.operations.information_block.envelope import (
   association_to_connection,
   element_to_lite,
   fact_to_lite,
-  load_classifications_for_associations,
-  load_latest_fact_set_for_structure,
-  load_rules_for_structure,
-  load_verification_results_for_structure,
+  load_base_envelope_atoms,
 )
 
 if TYPE_CHECKING:
@@ -60,56 +55,6 @@ STATEMENT_DISPLAY: dict[str, tuple[str, str]] = {
 STATEMENT_CATEGORY = "Reporting"
 
 
-def _create_not_implemented(
-  session: Session, payload: BaseModel, created_by: str
-) -> str:
-  """``dispatch_create`` for every statement block type.
-
-  Statements are generated through ``create-report``, not through
-  ``create-information-block``. Raising here propagates to the router's
-  error map and becomes HTTP 501.
-  """
-  raise NotImplementedError(
-    "Statements are generated via create-report, not "
-    "create-information-block. Create a report with the relevant "
-    "taxonomy; the statement envelope becomes queryable via "
-    "informationBlocks(blockType=...) after the report is published."
-  )
-
-
-def _update_not_implemented(
-  session: Session, payload: BaseModel, updated_by: str
-) -> str:
-  """``dispatch_update`` for every statement block type.
-
-  Statement Structures are library-seeded and immutable from a tenant
-  perspective. There is nothing to update — the envelope reflects the
-  library shape plus the tenant's report facts. Changes to what
-  surfaces come from creating a new Report, not from mutating the
-  block.
-  """
-  raise NotImplementedError(
-    "Statement blocks are library-seeded and immutable. Use "
-    "create-report to produce new facts; the envelope surfaces the "
-    "most recent report's facts automatically."
-  )
-
-
-def _delete_not_implemented(
-  session: Session, payload: BaseModel, deleted_by: str
-) -> str:
-  """``dispatch_delete`` for every statement block type.
-
-  Statement Structures are library-seeded and shared across tenants —
-  they cannot be deleted per-tenant. To stop receiving facts on a
-  statement block, archive the underlying Reports instead.
-  """
-  raise NotImplementedError(
-    "Statement blocks are library-seeded and cannot be deleted per "
-    "tenant. Archive the underlying Report via the report APIs instead."
-  )
-
-
 def _build_statement_envelope(
   session: Session,
   structure_id: str,
@@ -122,38 +67,25 @@ def _build_statement_envelope(
   expected block_type — lets :func:`get_information_block` cleanly
   return nothing to the caller.
 
-  Phase b surfaces facts from the **most recent** Report that has at
-  least one fact for this structure's elements. Scoping by element
-  membership — rather than taking the latest Report of any type —
-  avoids an empty envelope when a tenant's most recent report is for a
-  different statement (e.g. asking for the BS envelope when the newest
-  report is an IS). On the library sentinel the search_path is
-  ``public`` and the Report table is empty, so ``facts`` comes back
-  empty, which is the correct behaviour for the sentinel. Phase z
-  replaces this heuristic with explicit ``fact_set_id`` selection.
+  Surfaces facts from the **most recent** Report that has at least one
+  fact for this structure's elements. Scoping by element membership —
+  rather than taking the latest Report of any type — avoids an empty
+  envelope when a tenant's most recent report is for a different
+  statement (e.g. asking for the BS envelope when the newest report is
+  an IS). On the library sentinel the search_path is ``public`` and the
+  Report table is empty, so ``facts`` comes back empty, which is the
+  correct behaviour for the sentinel. A future revision of this
+  behaviour will replace the heuristic with explicit ``fact_set_id``
+  selection once write paths stamp FactSet rows on every report.
   """
-  structure = session.get(Structure, structure_id)
-  if structure is None or structure.structure_type != block_type:
+  atoms = load_base_envelope_atoms(
+    session, structure_id, expected_block_type=block_type
+  )
+  if atoms is None:
     return None
 
-  taxonomy_name = session.execute(
-    select(Taxonomy.name).where(Taxonomy.id == structure.taxonomy_id)
-  ).scalar()
-
-  associations = (
-    session.execute(select(Association).where(Association.structure_id == structure_id))
-    .scalars()
-    .all()
-  )
-
-  element_ids = {a.from_element_id for a in associations} | {
-    a.to_element_id for a in associations
-  }
-  elements = (
-    session.execute(select(Element).where(Element.id.in_(element_ids))).scalars().all()
-    if element_ids
-    else []
-  )
+  structure = atoms.structure
+  element_ids = atoms.element_ids
 
   facts: list[Fact] = []
   if element_ids:
@@ -177,26 +109,13 @@ def _build_statement_envelope(
         .all()
       )
 
-  # Prefer the typed Phase δ column; fall back to the Phase β empty
-  # tagged body for library-seeded rows that pre-date the backfill.
+  # Mechanics are read from the typed ``artifact_mechanics`` column when
+  # populated; library-seeded rows that haven't been enriched fall back
+  # to an empty tagged body so the discriminated union still validates.
   if structure.artifact_mechanics:
     mechanics = StatementMechanics.model_validate(structure.artifact_mechanics)
   else:
     mechanics = StatementMechanics(kind="statement_renderer")
-
-  rules = load_rules_for_structure(
-    session,
-    structure_id,
-    element_ids=list(element_ids),
-    association_ids=[a.id for a in associations],
-  )
-
-  classifications_by_assoc = load_classifications_for_associations(
-    session, [a.id for a in associations]
-  )
-
-  fact_set = load_latest_fact_set_for_structure(session, structure_id)
-  verification_results = load_verification_results_for_structure(session, structure_id)
 
   display_name, _display_plural = STATEMENT_DISPLAY[block_type]
   return InformationBlockEnvelope(
@@ -206,7 +125,7 @@ def _build_statement_envelope(
     display_name=display_name,
     category=STATEMENT_CATEGORY,
     taxonomy_id=structure.taxonomy_id,
-    taxonomy_name=taxonomy_name,
+    taxonomy_name=atoms.taxonomy_name,
     information_model=InformationModelResponse(
       concept_arrangement=structure.concept_arrangement or "roll_up",
       member_arrangement=structure.member_arrangement or "aggregation",
@@ -217,36 +136,33 @@ def _build_statement_envelope(
       template=None,
       mechanics=mechanics,
     ),
-    elements=[element_to_lite(e) for e in elements],
+    elements=[element_to_lite(e) for e in atoms.elements],
     connections=[
-      association_to_connection(a, classifications_by_assoc.get(a.id, []))
-      for a in associations
+      association_to_connection(a, atoms.classifications_by_assoc.get(a.id, []))
+      for a in atoms.associations
     ],
     facts=[fact_to_lite(f) for f in facts],
-    rules=rules,
-    fact_set=fact_set,
-    verification_results=verification_results,
+    rules=atoms.rules,
+    fact_set=atoms.fact_set,
+    verification_results=atoms.verification_results,
   )
 
 
-def make_statement_handlers(block_type: str) -> dict[str, Callable[..., Any]]:
-  """Build the dispatch handlers for one statement type.
+def make_statement_handlers(
+  block_type: str,
+) -> Callable[[Session, str], InformationBlockEnvelope | None]:
+  """Build the envelope handler for one statement type.
 
-  ``functools.partial`` binds the ``block_type`` keyword on the
-  envelope builder so the registry entry holds a two-argument callable
-  matching :class:`BlockTypeRegistryEntry.dispatch_build_envelope`'s
-  signature ``(session, structure_id) -> envelope | None``.
+  ``functools.partial`` binds the ``block_type`` keyword on the envelope
+  builder so the registry entry holds a two-argument callable matching
+  :class:`BlockTypeRegistryEntry.dispatch_build_envelope`'s signature
+  ``(session, structure_id) -> envelope | None``.
 
-  Create / update / delete all raise :class:`NotImplementedError` for
-  the statement family — statement Structures are library-seeded and
-  their per-tenant content comes from Reports, not block mutations.
+  The create / update / delete handlers for statement block types are
+  not built here — the registry installs not-implemented stubs via
+  ``make_not_implemented_handler`` for those slots.
   """
-  return {
-    "create": _create_not_implemented,
-    "update": _update_not_implemented,
-    "delete": _delete_not_implemented,
-    "build_envelope": partial(_build_statement_envelope, block_type=block_type),
-  }
+  return partial(_build_statement_envelope, block_type=block_type)
 
 
 __all__ = [

--- a/robosystems/operations/information_block/types.py
+++ b/robosystems/operations/information_block/types.py
@@ -40,8 +40,7 @@ class BlockTypeRegistryEntry:
 
   id: str
   """Stable discriminator — e.g. 'schedule'. Matches the block_type
-  string on the wire and the structure_type value in the DB (Phase γ
-  renames the column)."""
+  string on the wire and the ``structure_type`` value in the DB."""
 
   display_name: str
   """Human-readable singular name, e.g. 'Schedule'."""
@@ -71,8 +70,9 @@ class BlockTypeRegistryEntry:
   mechanics_schema: type[BaseModel]
   """Pydantic model for the block's Artifact Mechanics (e.g.
   :class:`ScheduleMechanics`). Used by the envelope builder to
-  shape-validate what lives in the metadata_ JSONB (Phase a) or in
-  the typed ``artifact_mechanics`` column (Phase d)."""
+  shape-validate the typed ``artifact_mechanics`` JSONB column (with
+  legacy fallback to ``metadata_`` for rows that pre-date the
+  backfill)."""
 
   create_request_model: type[BaseModel]
   """Pydantic model that the ``create-information-block`` dispatcher
@@ -94,7 +94,7 @@ class BlockTypeRegistryEntry:
   """Declarative (user declares shape + seed params; atoms generated) /
   compositional (atoms exist from ingest; block is a view materialized
   on read) / derivative (atoms come from other blocks via rules).
-  Shapes what the dispatcher does — Phase a only ships declarative."""
+  Shapes what the dispatcher does."""
 
   dispatch_create: Callable[[Session, BaseModel, str], str]
   """Handler that creates the block. Signature:

--- a/robosystems/operations/library/__init__.py
+++ b/robosystems/operations/library/__init__.py
@@ -1,7 +1,7 @@
 """Operations for the taxonomy library.
 
 The taxonomy library is the public schema's shared reference material
-(SFAC 6 + FAC + us-gaap + future rs-gaap). Tenants pull copies during
+(FAC + us-gaap + rs-gaap). Tenants pull copies during
 provisioning but never modify library rows.
 
 This module exposes reads (no writes — library mutation goes through

--- a/robosystems/operations/roboledger/commands/elements.py
+++ b/robosystems/operations/roboledger/commands/elements.py
@@ -212,8 +212,9 @@ def create_element(
 ) -> ElementResponse:
   """Create a new element within a taxonomy.
 
-  Internal only — retired from the public surface in Phase 1 of the
-  Taxonomy Block refactor. Tenant writes use ``create-taxonomy-block``.
+  Internal helper. Tenant writes go through the taxonomy block surface
+  (``create-taxonomy-block`` / ``update-taxonomy-block``); this is
+  invoked indirectly by those operations.
 
   Raises `TaxonomyNotFoundError` if `body.taxonomy_id` does not exist,
   or `ElementNotFoundError` if `body.parent_id` is set but the parent
@@ -307,8 +308,9 @@ def _assign_efs_classification(
 def update_element(session: Session, body: UpdateElementRequest) -> ElementResponse:
   """Update mutable fields on an element.
 
-  Internal only — retired from the public surface in Phase 1 of the
-  Taxonomy Block refactor. Tenant writes use ``update-taxonomy-block``.
+  Internal helper. Tenant writes go through the taxonomy block surface
+  (``create-taxonomy-block`` / ``update-taxonomy-block``); this is
+  invoked indirectly by those operations.
 
   Uses `model_dump(exclude_unset=True)` semantics: omitted fields are
   left unchanged, explicit nulls are applied. For `parent_id`: omit to
@@ -451,8 +453,9 @@ def _reassign_efs_classification(
 def delete_element(session: Session, body: DeleteElementRequest) -> ElementResponse:
   """Soft delete — sets `is_active=false`.
 
-  Internal only — retired from the public surface in Phase 1 of the
-  Taxonomy Block refactor. Tenant writes use ``delete-taxonomy-block``.
+  Internal helper. Tenant writes go through the taxonomy block surface
+  (``delete-taxonomy-block``); this is invoked indirectly by that
+  operation.
 
   Historical line items referencing the element remain valid. New line
   items cannot use an inactive element (enforced by caller / validation

--- a/robosystems/operations/roboledger/commands/schedules.py
+++ b/robosystems/operations/roboledger/commands/schedules.py
@@ -325,9 +325,9 @@ def update_schedule(
     }
 
   structure.metadata_ = metadata
-  # Phase δ: keep artifact_mechanics in sync with metadata_ while both
-  # live on the row. Envelope reads prefer artifact_mechanics; writes
-  # stamp both during the transition window.
+  # Dual-column write: envelope reads prefer artifact_mechanics; writes
+  # stamp both columns so older rows that pre-date artifact_mechanics
+  # remain readable through metadata_.
   # periods_with_entries is transient (queried from facts at read time) —
   # intentionally excluded rather than using ScheduleMechanics.model_dump().
   structure.artifact_mechanics = {
@@ -336,10 +336,10 @@ def update_schedule(
     "schedule_metadata": metadata.get("schedule_metadata"),
   }
 
-  # Stream 2.E: void + re-materialize the pending obligation chain when
-  # the entry template changed. Same transaction as the metadata update
-  # so a partial state is impossible — either the new template + new
-  # pending events both land, or neither does.
+  # When the entry template changed, void and re-materialize the pending
+  # obligation chain in the same transaction so partial state is
+  # impossible: either the new template + new pending events both land,
+  # or neither does.
   if template_changed:
     ScheduleService().supersede_pending_obligations(
       session,
@@ -371,18 +371,11 @@ def update_schedule(
   )
 
 
-# Asset disposal was retired as a standalone operation in Phase 4b of the
-# event-driven ledger. The atomic truncate + SumEquals cleanup + balanced
-# disposal entry logic now lives in the Python handler registry at
-# operations/event_block/python_handlers/asset_disposed.py
-# and is invoked via create-event-block(event_type='asset_disposed').
-
-
 def delete_schedule(session: Session, body: DeleteScheduleRequest) -> dict:
   """Delete a schedule — cascades through facts and associations.
 
   Deletion order respects FK constraints:
-  1. Pending obligation events (Stream 2.E: void before parent disappears)
+  1. Pending obligation events (voided before the parent disappears)
   2. Verification results (referencing rules / structure_id)
   3. Facts and FactSets (referencing structure_id)
   4. Rules and association classifications (referencing associations)

--- a/robosystems/operations/roboledger/commands/taxonomies.py
+++ b/robosystems/operations/roboledger/commands/taxonomies.py
@@ -140,8 +140,9 @@ def create_taxonomy(
 ) -> TaxonomyResponse:
   """Insert a new taxonomy row and return its response representation.
 
-  Internal only — retired from the public surface in Phase 1 of the
-  Taxonomy Block refactor. Tenant writes use ``create-taxonomy-block``.
+  Internal helper. Tenant writes go through the taxonomy block surface
+  (``create-taxonomy-block`` / ``update-taxonomy-block``); this is
+  invoked indirectly by those operations.
   """
   taxonomy = Taxonomy(
     id=generate_prefixed_ulid("tax"),
@@ -163,8 +164,9 @@ def create_structure(
 ) -> StructureResponse:
   """Insert a new structure row and return its response representation.
 
-  Internal only — retired from the public surface in Phase 1 of the
-  Taxonomy Block refactor. Tenant writes use ``create-taxonomy-block``.
+  Internal helper. Tenant writes go through the taxonomy block surface
+  (``create-taxonomy-block`` / ``update-taxonomy-block``); this is
+  invoked indirectly by those operations.
   """
   # Tenants can only add structures to tenant-origin taxonomies.
   assert_tenant_taxonomy(session, body.taxonomy_id)
@@ -311,8 +313,9 @@ def _delete_association_dependents(
 def update_taxonomy(session: Session, body: UpdateTaxonomyRequest) -> TaxonomyResponse:
   """Update mutable fields on a taxonomy.
 
-  Internal only — retired from the public surface in Phase 1 of the
-  Taxonomy Block refactor. Tenant writes use ``update-taxonomy-block``.
+  Internal helper. Tenant writes go through the taxonomy block surface
+  (``create-taxonomy-block`` / ``update-taxonomy-block``); this is
+  invoked indirectly by those operations.
 
   Uses `model_dump(exclude_unset=True)` — omitted fields are left
   unchanged, explicit nulls are applied. `taxonomy_type` is immutable
@@ -338,8 +341,9 @@ def update_taxonomy(session: Session, body: UpdateTaxonomyRequest) -> TaxonomyRe
 def delete_taxonomy(session: Session, body: DeleteTaxonomyRequest) -> TaxonomyResponse:
   """Soft delete — sets `is_active=false`.
 
-  Internal only — retired from the public surface in Phase 1 of the
-  Taxonomy Block refactor. Tenant writes use ``delete-taxonomy-block``.
+  Internal helper. Tenant writes go through the taxonomy block surface
+  (``delete-taxonomy-block``); this is invoked indirectly by that
+  operation.
 
   Historical references (structures, elements, associations) remain
   valid. The taxonomy is simply no longer offered for new writes.
@@ -365,8 +369,9 @@ def update_structure(
 ) -> StructureResponse:
   """Update mutable fields on a structure.
 
-  Internal only — retired from the public surface in Phase 1 of the
-  Taxonomy Block refactor. Tenant writes use ``update-taxonomy-block``.
+  Internal helper. Tenant writes go through the taxonomy block surface
+  (``create-taxonomy-block`` / ``update-taxonomy-block``); this is
+  invoked indirectly by those operations.
 
   `structure_type` and `taxonomy_id` are immutable.
   Raises `StructureNotFoundError` if the structure does not exist.
@@ -391,8 +396,9 @@ def delete_structure(
 ) -> StructureResponse:
   """Soft delete — sets `is_active=false`.
 
-  Internal only — retired from the public surface in Phase 1 of the
-  Taxonomy Block refactor. Tenant writes use ``delete-taxonomy-block``.
+  Internal helper. Tenant writes go through the taxonomy block surface
+  (``delete-taxonomy-block``); this is invoked indirectly by that
+  operation.
 
   Raises `StructureNotFoundError` if the structure does not exist.
   """

--- a/robosystems/operations/roboledger/fiscal_calendar/service.py
+++ b/robosystems/operations/roboledger/fiscal_calendar/service.py
@@ -1,7 +1,10 @@
-"""FiscalCalendarService — rolling close state management.
+"""Rolling close state for the fiscal calendar.
 
-This is the Phase 1 foundation. It does NOT yet drive close workflows
-(that's Phase 4 / CloseAgent). What it DOES do:
+Tracks closed_through and close_target pointers and validates closeable
+preconditions; close workflow orchestration lives in the close-period
+operation.
+
+Responsibilities:
 
 - Lazily creates a `FiscalCalendar` row per graph (idempotent)
 - Maintains the `closed_through_period` ← `close_target_period` pointers
@@ -648,14 +651,14 @@ class FiscalCalendarService:
         if last_sync_date < period_end:
           blockers.append(CloseableGateResult.SYNC_STALE)
 
-    # Gate 4: pending obligations. Stream 2.D — schedules materialize one
-    # `pending` `schedule_entry_due` event per period. The period cannot be
-    # closed while any of those obligations remain pending, because the
-    # corresponding draft entries either haven't been created yet (Stream
-    # 2.B sensor flips them to `classified` and dispatches the handler) or
-    # the operator has not yet voided them. The user-facing remedy is to
-    # promote each obligation (manually via `update-event-block`, or
-    # automatically once Stream 2.B's sensor lands) or to void them.
+    # Gate 4: pending obligations. Schedules materialize one `pending`
+    # `schedule_entry_due` event per period. The period cannot be closed
+    # while any of those obligations remain pending: the corresponding
+    # draft entries have either not yet been classified by the obligation
+    # sensor or the operator has not yet voided them. The user-facing
+    # remedy is to promote each obligation (manually via
+    # `update-event-block`, or automatically via the obligation sensor)
+    # or to void them.
     period_end_dt = datetime.combine(period_end, time(23, 59, 59), tzinfo=UTC)
     pending_count = (
       session.query(Event)

--- a/robosystems/operations/roboledger/reads/event_block.py
+++ b/robosystems/operations/roboledger/reads/event_block.py
@@ -1,4 +1,12 @@
-"""Event Block reads — get and list event envelopes."""
+"""Event Block reads — get and list event envelopes.
+
+Owns the canonical ``_load_dimension_ids`` and ``_to_envelope`` helpers used
+by both the read path here and the write path in
+``operations/event_block/commands.py``. ``_to_envelope`` populates every
+field declared on ``EventBlockEnvelope``, including ``event_class`` and the
+REA duality links (``obligated_by_event_id``, ``discharges_event_id``), so
+agents reading events via MCP see the same shape that creators wrote.
+"""
 
 from __future__ import annotations
 
@@ -24,11 +32,12 @@ def _load_dimension_ids(session: Session, event_id: str) -> list[str]:
   )
 
 
-def _to_envelope(session: Session, event: Event) -> EventBlockEnvelope:
+def _to_envelope(event: Event, dimension_ids: list[str]) -> EventBlockEnvelope:
   return EventBlockEnvelope(
     id=event.id,
     event_type=event.event_type,
     event_category=event.event_category,
+    event_class=event.event_class,
     status=event.status,
     occurred_at=event.occurred_at,
     effective_at=event.effective_at,
@@ -39,12 +48,14 @@ def _to_envelope(session: Session, event: Event) -> EventBlockEnvelope:
     currency=event.currency,
     description=event.description,
     metadata=dict(event.metadata_ or {}),
-    dimension_ids=_load_dimension_ids(session, event.id),
+    dimension_ids=dimension_ids,
     agent_id=event.agent_id,
     resource_type=event.resource_type,
     resource_element_id=event.resource_element_id,
     replaced_by_event_id=event.replaced_by_event_id,
     replaces_event_id=event.replaces_event_id,
+    obligated_by_event_id=event.obligated_by_event_id,
+    discharges_event_id=event.discharges_event_id,
     created_at=event.created_at,
     created_by=event.created_by,
   )
@@ -54,7 +65,7 @@ def get_event_block(session: Session, event_id: str) -> EventBlockEnvelope | Non
   event = session.get(Event, event_id)
   if event is None:
     return None
-  return _to_envelope(session, event)
+  return _to_envelope(event, _load_dimension_ids(session, event.id))
 
 
 def list_event_blocks(
@@ -82,4 +93,4 @@ def list_event_blocks(
 
   stmt = stmt.order_by(Event.occurred_at.desc()).limit(limit).offset(offset)
   events = session.execute(stmt).scalars().all()
-  return [_to_envelope(session, e) for e in events]
+  return [_to_envelope(e, _load_dimension_ids(session, e.id)) for e in events]

--- a/robosystems/operations/roboledger/reports/fact_grid.py
+++ b/robosystems/operations/roboledger/reports/fact_grid.py
@@ -84,7 +84,7 @@ class FactGrid:
   unmapped_count: int = 0
 
 
-# ── Phase 1: Generate facts (structure-agnostic) ─────────────────────────
+# ── Stage 1: Generate facts (structure-agnostic) ─────────────────────────
 
 
 def generate_report_facts(
@@ -152,7 +152,7 @@ def generate_report_facts(
   )
 
 
-# ── Phase 2: Render structure view ───────────────────────────────────────
+# ── Stage 2: Render structure view ───────────────────────────────────────
 
 
 def render_structure_view(

--- a/robosystems/operations/roboledger/schedules/service.py
+++ b/robosystems/operations/roboledger/schedules/service.py
@@ -196,11 +196,11 @@ class ScheduleService:
         "periodic_amounts": schedule_metadata.periodic_amounts,
       }
 
-    # Phase δ: stamp the typed artifact_mechanics column alongside the
-    # legacy metadata_ blob so the envelope builder's typed-column read
-    # path works from creation. metadata_ is kept populated during the
-    # transition window — it's retired in a later phase once the spec
-    # follow-ups remove the fallback path on the read side.
+    # Stamp the typed artifact_mechanics column alongside the legacy
+    # metadata_ blob so the envelope builder's typed-column read path
+    # works from creation. metadata_ stays populated during the
+    # transition window for backward compatibility with rows written
+    # before artifact_mechanics landed.
     # periods_with_entries is a transient read-time value (queried from facts),
     # not a stored property — intentionally excluded here rather than using
     # ScheduleMechanics.model_dump(); it is injected by the envelope builder.
@@ -393,13 +393,11 @@ class ScheduleService:
           )
         )
 
-    # Stream 2.A: materialize the obligation register.
-    # One `schedule_created` event (originator) + one `pending`
-    # `schedule_entry_due` event per period, linked via
-    # `obligated_by_event_id`. The sensor (Stream 2.B) will later flip
-    # the pending events to `classified` at each period boundary and
-    # dispatch the existing handler. Until then, the legacy close path
-    # still works because nothing reads these new rows.
+    # Materialize the obligation register: one `schedule_created` event
+    # (originator) + one `pending` `schedule_entry_due` event per period,
+    # linked via `obligated_by_event_id`. The obligation sensor flips the
+    # pending events to `classified` at each period boundary and dispatches
+    # the existing handler.
     schedule_created_event_id, pending_event_count = (
       self._materialize_pending_obligations(
         session,
@@ -414,9 +412,9 @@ class ScheduleService:
       )
     )
 
-    # Stash the originator event id on the structure so disposal /
-    # supersession (Streams 2.C and 2.E) can find the obligation chain
-    # without an extra query.
+    # Stash the originator event id on the structure so disposal and
+    # supersession paths can find the obligation chain without an extra
+    # query.
     metadata["schedule_created_event_id"] = schedule_created_event_id
     metadata["pending_event_count"] = pending_event_count
     structure.metadata_ = metadata
@@ -551,8 +549,8 @@ class ScheduleService:
       tripping the close-period gate after their parent disappears.
 
     Returns the number of voided rows. Returns 0 (no-op) when the
-    schedule has no ``schedule_created_event_id`` stamped (legacy
-    schedules created before Stream 2.A) or when no pending
+    schedule has no ``schedule_created_event_id`` stamped (rows from
+    before the obligation register existed) or when no pending
     obligations exist.
 
     Also decrements the originator's ``metadata.pending_event_count``
@@ -625,8 +623,8 @@ class ScheduleService:
     replacement events created.
 
     Returns 0 when the schedule has no ``schedule_created_event_id``
-    stamped (legacy schedules created before Stream 2.A) or when no
-    pending events exist.
+    stamped (rows from before the obligation register existed) or when
+    no pending events exist.
     """
     metadata = structure.metadata_ or {}
     schedule_created_event_id = metadata.get("schedule_created_event_id")

--- a/robosystems/operations/taxonomy_block/__init__.py
+++ b/robosystems/operations/taxonomy_block/__init__.py
@@ -3,9 +3,4 @@
 Curates ontology atomically — elements + structures + associations +
 rules — in one transactional envelope. Mirrors the Information Block
 pattern that curates business-logic artifacts.
-
-Phase 2.1 ships only the registry types scaffold. Later sub-phases add
-the registry instances (2.2), command dispatchers (2.2), block-type
-handlers (2.2 / 2.4), validator + auto-rules engine (2.3), envelope
-builder (2.5), router registration (2.6), and library writer change (2.7).
 """

--- a/robosystems/operations/taxonomy_block/_helpers.py
+++ b/robosystems/operations/taxonomy_block/_helpers.py
@@ -1,0 +1,28 @@
+"""Shared helpers for taxonomy block handlers.
+
+Small utilities shared across the CoA / custom_ontology /
+reporting_extension handlers. Factored here so the per-block-type
+modules don't drift on the common derivations.
+"""
+
+from __future__ import annotations
+
+
+def qname_for(
+  standard: str | None,
+  default_namespace: str,
+  code: str | None,
+  name: str,
+) -> str:
+  """Derive the envelope-local qname when the tenant didn't supply one.
+
+  Falls back to ``<standard or default_namespace>:<code or name-without-spaces>``
+  so qname is always set; the DB column is nullable but the envelope
+  treats qname as the canonical identifier.
+  """
+  ns = standard or default_namespace
+  token = code or name.replace(" ", "")
+  return f"{ns}:{token}"
+
+
+__all__ = ["qname_for"]

--- a/robosystems/operations/taxonomy_block/auto_rules.py
+++ b/robosystems/operations/taxonomy_block/auto_rules.py
@@ -1,8 +1,8 @@
-"""Structural auto-rule emission for Taxonomy Block envelopes (Phase 2.3.1).
+"""Structural auto-rule emission for Taxonomy Block envelopes.
 
 At create time, each taxonomy block gets a set of ``rule_origin='auto'``
 Rule rows that encode its structural invariants — the same invariants the
-Phase 2.3 validator checks pre-write, now persisted so ``evaluate-rules``
+create-envelope validator checks pre-write, persisted so ``evaluate-rules``
 can re-check them post-write on demand.
 
 Auto-rules are tied to the taxonomy via ``taxonomy_id`` (ownership) and

--- a/robosystems/operations/taxonomy_block/chart_of_accounts.py
+++ b/robosystems/operations/taxonomy_block/chart_of_accounts.py
@@ -1,8 +1,5 @@
 """Handlers for ``taxonomy_type='chart_of_accounts'`` — tenant CoA curation.
 
-Phase 2.2 minimum viable handler: ``create`` + ``build_envelope``.
-Update and delete surface ``NotImplementedError`` until later sub-phases.
-
 The CoA block is the reference implementation of the **declarative**
 construction mode for taxonomy blocks — tenant declares the full
 envelope (taxonomy + structures + elements + associations) and the
@@ -33,6 +30,7 @@ from robosystems.models.extensions import (
   Structure,
   Taxonomy,
 )
+from robosystems.operations.taxonomy_block._helpers import qname_for
 from robosystems.operations.taxonomy_block.auto_rules import emit_auto_rules
 from robosystems.operations.taxonomy_block.cascade import (
   cascade_delete_taxonomy,
@@ -56,7 +54,6 @@ from robosystems.operations.taxonomy_block.update_apply import (
   apply_top_level_fields,
 )
 from robosystems.operations.taxonomy_block.update_validator import (
-  reject_unsupported_deltas,
   validate_update_envelope,
 )
 from robosystems.operations.taxonomy_block.validators import (
@@ -125,18 +122,6 @@ def _update_efs_classification(
     )
   )
   _assign_efs_classification(session, element_id, identifier)
-
-
-def _qname_for_coa(standard: str | None, code: str | None, name: str) -> str:
-  """Derive the envelope-local qname for a CoA element.
-
-  Prefers the tenant-supplied ``qname`` on the request; falls back to
-  ``<standard>:<code>`` or ``<standard>:<name>`` so qname is always set
-  (the DB column is nullable, but the envelope design treats qname as
-  the canonical identifier)."""
-  ns = standard or "coa"
-  token = code or name.replace(" ", "")
-  return f"{ns}:{token}"
 
 
 def _auto_link_entity(session: Session, taxonomy_id: str) -> None:
@@ -234,7 +219,7 @@ def create(
 
   classifications_to_assign: list[tuple[str, str]] = []
   for req in payload.elements:
-    qname = req.qname or _qname_for_coa(payload.standard, req.code, req.name)
+    qname = req.qname or qname_for(payload.standard, "coa", req.code, req.name)
     element = Element(
       code=req.code,
       name=req.name,
@@ -344,7 +329,7 @@ def create(
 
 
 def _element_factory(req, taxonomy: Taxonomy, updated_by: str) -> tuple[Element, str]:
-  qname = req.qname or _qname_for_coa(taxonomy.standard, req.code, req.name)
+  qname = req.qname or qname_for(taxonomy.standard, "coa", req.code, req.name)
   element = Element(
     code=req.code,
     name=req.name,
@@ -374,8 +359,6 @@ def update(
       f"taxonomy {payload.taxonomy_id!r} is not a chart_of_accounts taxonomy."
     )
 
-  reject_unsupported_deltas(payload)
-
   issues = validate_update_envelope(session, taxonomy, payload)
   if issues:
     raise TaxonomyBlockValidationError(issues)
@@ -401,7 +384,7 @@ def update(
   )
   for req in payload.elements_to_add:
     if req.classification:
-      qname = req.qname or _qname_for_coa(taxonomy.standard, req.code, req.name)
+      qname = req.qname or qname_for(taxonomy.standard, "coa", req.code, req.name)
       element = new_elements.get(qname)
       if element is not None:
         _assign_efs_classification(session, str(element.id), req.classification)

--- a/robosystems/operations/taxonomy_block/custom_ontology.py
+++ b/robosystems/operations/taxonomy_block/custom_ontology.py
@@ -10,8 +10,8 @@ forcing.
 
 Validation below the Pydantic layer is minimal — ``ValueError`` for
 unresolved ``parent_ref`` / ``structure_ref`` / ``from_ref`` /
-``to_ref`` only. The structural rule layer (cycles, orphans, unique
-qnames) lands in Phase 2.3.
+``to_ref`` only. Structural rules (cycles, orphans, unique qnames) are
+enforced by the shared create-envelope validator.
 """
 
 from __future__ import annotations
@@ -34,6 +34,7 @@ from robosystems.models.extensions import (
   Structure,
   Taxonomy,
 )
+from robosystems.operations.taxonomy_block._helpers import qname_for
 from robosystems.operations.taxonomy_block.auto_rules import emit_auto_rules
 from robosystems.operations.taxonomy_block.cascade import (
   cascade_delete_taxonomy,
@@ -57,7 +58,6 @@ from robosystems.operations.taxonomy_block.update_apply import (
   apply_top_level_fields,
 )
 from robosystems.operations.taxonomy_block.update_validator import (
-  reject_unsupported_deltas,
   validate_update_envelope,
 )
 from robosystems.operations.taxonomy_block.validators import (
@@ -69,13 +69,6 @@ CUSTOM_ONTOLOGY_BLOCK_TYPE = "custom_ontology"
 DISPLAY_NAME = "Custom Ontology"
 DISPLAY_PLURAL = "Custom Ontologies"
 CATEGORY = "Custom"
-
-
-def _qname_for_custom(standard: str | None, code: str | None, name: str) -> str:
-  """Derive the envelope-local qname when the tenant didn't supply one."""
-  ns = standard or "custom"
-  token = code or name.replace(" ", "")
-  return f"{ns}:{token}"
 
 
 def create(
@@ -119,7 +112,7 @@ def create(
   parent_refs: dict[str, str | None] = {}
 
   for req in payload.elements:
-    qname = req.qname or _qname_for_custom(payload.standard, req.code, req.name)
+    qname = req.qname or qname_for(payload.standard, "custom", req.code, req.name)
     element = Element(
       code=req.code,
       name=req.name,
@@ -222,7 +215,7 @@ def create(
 
 
 def _element_factory(req, taxonomy: Taxonomy, updated_by: str) -> tuple[Element, str]:
-  qname = req.qname or _qname_for_custom(taxonomy.standard, req.code, req.name)
+  qname = req.qname or qname_for(taxonomy.standard, "custom", req.code, req.name)
   element = Element(
     code=req.code,
     name=req.name,
@@ -251,8 +244,6 @@ def update(
     raise ValueError(
       f"taxonomy {payload.taxonomy_id!r} is not a custom_ontology taxonomy."
     )
-
-  reject_unsupported_deltas(payload)
 
   issues = validate_update_envelope(session, taxonomy, payload)
   if issues:

--- a/robosystems/operations/taxonomy_block/library_creator.py
+++ b/robosystems/operations/taxonomy_block/library_creator.py
@@ -1,22 +1,23 @@
 """TaxonomyPackage → ORM-session inserts for library-origin taxonomies.
 
-Admin-only. Three-phase flow so cross-package arcs resolve via DB lookup
+Admin-only. Three-pass flow so cross-package arcs resolve via DB lookup
 regardless of seed load order:
 
-  Phase 1 — create_library_taxonomy_elements: Taxonomy + Elements + Labels +
-             References + Structures + Classifications per package.
-  Phase 2 — create_library_arcs: Associations + ClassificationAssignments per
-             package (needs every package's elements in the DB first).
-  Phase 3 — create_library_rules: Rules with polymorphic target resolution
-             (needs structures + elements from all packages).
+  ``create_library_taxonomy_elements`` — Taxonomy + Elements + Labels +
+    References + Structures + Classifications per package.
+  ``create_library_arcs`` — Associations + ClassificationAssignments per
+    package (needs every package's elements in the DB first).
+  ``create_library_rules`` — Rules with polymorphic target resolution
+    (needs structures + elements from all packages).
 
 Used by migration 0002 and any future migration that adds or updates library
 seeds. Not routed through the public envelope or registry — takes TaxonomyPackage
 directly because the envelope model (TaxonomyBlockElementRequest) is missing
 library-specific fields (source, labels, references, classifications).
 
-Deterministic UUID5 IDs match library_writer.py's keying exactly so re-runs
-are idempotent and existing seeded DBs are not disturbed.
+Key derivation must remain stable across re-seeds: same input → same UUID5,
+so re-runs hit ON CONFLICT rather than inserting duplicates and existing
+seeded DBs are not disturbed.
 """
 
 from __future__ import annotations
@@ -62,8 +63,8 @@ _ALLOWED_SOURCES = frozenset(
 
 
 # ── Deterministic ID helpers ──────────────────────────────────────────────────
-# Keying matches library_writer.py exactly — same input → same UUID5 →
-# re-runs hit ON CONFLICT rather than inserting duplicates.
+# Key derivation must remain stable across re-seeds: same input → same UUID5
+# → re-runs hit ON CONFLICT rather than inserting duplicates.
 
 
 def _taxonomy_id(standard: str, version: str) -> str:
@@ -114,7 +115,7 @@ def _default_role_uri(package: TaxonomyPackage) -> str:
   return f"{package.namespace_uri}default"
 
 
-# ── Phase 1 ───────────────────────────────────────────────────────────────────
+# ── Taxonomy & elements ───────────────────────────────────────────────────────
 
 
 def create_library_taxonomy_elements(
@@ -122,11 +123,11 @@ def create_library_taxonomy_elements(
   package: TaxonomyPackage,
   created_by: str = "library-seeder",
 ) -> tuple[str, dict[str, int]]:
-  """Phase 1: Taxonomy + Elements + Labels + References + Structures +
-  Classifications + default catch-all structure.
+  """Insert Taxonomy + Elements + Labels + References + Structures +
+  Classifications + default catch-all structure for one package.
 
   Must be called for every package before ``create_library_arcs`` runs for
-  any of them — phase 2 resolves cross-package qname/classification
+  any of them — the arcs pass resolves cross-package qname/classification
   references via DB lookups, which requires the full element + vocabulary
   universe to already be persisted.
 
@@ -316,7 +317,7 @@ def create_library_taxonomy_elements(
   return taxonomy_id, counts
 
 
-# ── Phase 2 ───────────────────────────────────────────────────────────────────
+# ── Cross-package arcs ────────────────────────────────────────────────────────
 
 
 def _resolve_element_id(session: Session, qname: str) -> str | None:
@@ -352,7 +353,7 @@ def create_library_arcs(
   package: TaxonomyPackage,
   created_by: str = "library-seeder",
 ) -> dict[str, int]:
-  """Phase 2: Associations + ClassificationAssignments.
+  """Insert Associations + ClassificationAssignments for one package.
 
   Resolves qnames + classifications via DB lookup so cross-package arcs work
   regardless of which seed defined the target element.
@@ -460,7 +461,7 @@ def create_library_arcs(
   return counts
 
 
-# ── Phase 3 ───────────────────────────────────────────────────────────────────
+# ── Rules ─────────────────────────────────────────────────────────────────────
 
 
 def _resolve_structure_id_by_role(session: Session, role_uri: str) -> str | None:
@@ -476,10 +477,11 @@ def create_library_rules(
   package: TaxonomyPackage,
   created_by: str = "library-seeder",
 ) -> dict[str, int]:
-  """Phase 3: Rules with polymorphic target resolution.
+  """Insert Rules with polymorphic target resolution for one package.
 
-  Must run after phase 2 globally so structure + element targets resolve.
-  Association-targeted rules are not yet supported (logs + skips).
+  Must run after the cross-package arcs pass globally so structure +
+  element targets resolve. Association-targeted rules are not yet
+  supported (logs + skips).
   """
   counts: dict[str, int] = {"rules": 0, "rules_skipped": 0}
   taxonomy_id = _taxonomy_id(package.standard, package.version)

--- a/robosystems/operations/taxonomy_block/registry.py
+++ b/robosystems/operations/taxonomy_block/registry.py
@@ -1,12 +1,12 @@
 """Taxonomy Block type registry.
 
 Single source of truth for every taxonomy-block type the system knows
-about. Populated at module import; frozen thereafter.
-
-Phase 2.2 registers the ``chart_of_accounts`` block only. Later sub-
-phases add ``reporting_standard`` (library, read-only),
-``reporting_extension`` (extends a library reporting taxonomy), and
-``custom_ontology`` (declarative tenant ontology).
+about. Populated at module import; frozen thereafter. Registered types:
+``chart_of_accounts`` (declarative tenant CoA), ``schedule`` (thin
+container for Schedule info blocks), ``reporting_standard`` (library,
+read-only), ``reporting_extension`` (tenant extension of a library
+reporting taxonomy), and ``custom_ontology`` (declarative tenant
+ontology).
 """
 
 from __future__ import annotations

--- a/robosystems/operations/taxonomy_block/reporting_extension.py
+++ b/robosystems/operations/taxonomy_block/reporting_extension.py
@@ -42,6 +42,7 @@ from robosystems.models.extensions import (
   Structure,
   Taxonomy,
 )
+from robosystems.operations.taxonomy_block._helpers import qname_for
 from robosystems.operations.taxonomy_block.auto_rules import emit_auto_rules
 from robosystems.operations.taxonomy_block.cascade import (
   cascade_delete_taxonomy,
@@ -65,7 +66,6 @@ from robosystems.operations.taxonomy_block.update_apply import (
   apply_top_level_fields,
 )
 from robosystems.operations.taxonomy_block.update_validator import (
-  reject_unsupported_deltas,
   validate_update_envelope,
 )
 from robosystems.operations.taxonomy_block.validators import (
@@ -77,13 +77,6 @@ REPORTING_EXTENSION_BLOCK_TYPE = "reporting_extension"
 DISPLAY_NAME = "Reporting Extension"
 DISPLAY_PLURAL = "Reporting Extensions"
 CATEGORY = "Reporting"
-
-
-def _qname_for_extension(standard: str | None, code: str | None, name: str) -> str:
-  """Derive an envelope-local qname when the tenant didn't supply one."""
-  ns = standard or "ext"
-  token = code or name.replace(" ", "")
-  return f"{ns}:{token}"
 
 
 def _library_qname_lookup(
@@ -159,7 +152,7 @@ def create(
   parent_refs: dict[str, str | None] = {}
 
   for req in payload.elements:
-    qname = req.qname or _qname_for_extension(payload.standard, req.code, req.name)
+    qname = req.qname or qname_for(payload.standard, "ext", req.code, req.name)
     element = Element(
       code=req.code,
       name=req.name,
@@ -285,7 +278,7 @@ def create(
 
 
 def _element_factory(req, taxonomy: Taxonomy, updated_by: str) -> tuple[Element, str]:
-  qname = req.qname or _qname_for_extension(taxonomy.standard, req.code, req.name)
+  qname = req.qname or qname_for(taxonomy.standard, "ext", req.code, req.name)
   element = Element(
     code=req.code,
     name=req.name,
@@ -314,8 +307,6 @@ def update(
     raise ValueError(
       f"taxonomy {payload.taxonomy_id!r} is not a reporting_extension taxonomy."
     )
-
-  reject_unsupported_deltas(payload)
 
   issues = validate_update_envelope(session, taxonomy, payload)
   if issues:

--- a/robosystems/operations/taxonomy_block/reporting_standard.py
+++ b/robosystems/operations/taxonomy_block/reporting_standard.py
@@ -56,6 +56,7 @@ def create(
   payload: CreateTaxonomyBlockRequest,
   created_by: str,
 ) -> str:
+  """Intentionally not exposed; admin-only via library_creator."""
   raise NotImplementedError(_ADMIN_ONLY_MESSAGE)
 
 
@@ -64,6 +65,7 @@ def update(
   payload: UpdateTaxonomyBlockRequest,
   updated_by: str,
 ) -> str:
+  """Intentionally not exposed; admin-only via library_creator."""
   raise NotImplementedError(_ADMIN_ONLY_MESSAGE)
 
 
@@ -72,6 +74,7 @@ def delete(
   payload: DeleteTaxonomyBlockRequest,
   deleted_by: str,
 ) -> str:
+  """Intentionally not exposed; admin-only via library_creator."""
   raise NotImplementedError(_ADMIN_ONLY_MESSAGE)
 
 

--- a/robosystems/operations/taxonomy_block/schedule_container.py
+++ b/robosystems/operations/taxonomy_block/schedule_container.py
@@ -57,14 +57,21 @@ def create(
   return taxonomy.id
 
 
+_ADMIN_ONLY_MESSAGE = (
+  "schedule-container update/delete are intentionally not exposed on the "
+  "public envelope; admin-only via library_creator. The schedule artifacts "
+  "themselves live as Schedule Information Blocks and are mutated through "
+  "that surface."
+)
+
+
 def update(
   session: Session,
   payload: UpdateTaxonomyBlockRequest,
   updated_by: str,
 ) -> str:
-  raise NotImplementedError(
-    "schedule-container update-taxonomy-block is not implemented yet."
-  )
+  """Intentionally not exposed; admin-only via library_creator."""
+  raise NotImplementedError(_ADMIN_ONLY_MESSAGE)
 
 
 def delete(
@@ -72,9 +79,8 @@ def delete(
   payload: DeleteTaxonomyBlockRequest,
   deleted_by: str,
 ) -> str:
-  raise NotImplementedError(
-    "schedule-container delete-taxonomy-block is not implemented yet."
-  )
+  """Intentionally not exposed; admin-only via library_creator."""
+  raise NotImplementedError(_ADMIN_ONLY_MESSAGE)
 
 
 def build_envelope(session: Session, taxonomy_id: str) -> TaxonomyBlockEnvelope | None:

--- a/robosystems/operations/taxonomy_block/types.py
+++ b/robosystems/operations/taxonomy_block/types.py
@@ -6,10 +6,9 @@ the block type's display metadata, request/response schemas, and the
 four dispatch handlers (create, update, delete, build_envelope) that
 make the generic construction and read machinery work.
 
-The registry itself is added in Phase 2.2 as a
-``dict[str, TaxonomyBlockRegistryEntry]`` populated at module import.
-Adding a block type is a code change — a new registry literal plus the
-module that holds its handlers.
+The registry is a ``dict[str, TaxonomyBlockRegistryEntry]`` populated
+at module import. Adding a block type is a code change — a new
+registry literal plus the module that holds its handlers.
 """
 
 from __future__ import annotations

--- a/robosystems/operations/taxonomy_block/update_validator.py
+++ b/robosystems/operations/taxonomy_block/update_validator.py
@@ -1,12 +1,12 @@
 """Update-path validator — projects the post-delta state and reuses create phases.
 
-Phase 2.4.1 update scope covers all deltas: ``_to_add``, ``_to_update``,
-and ``_to_remove`` for every atom type, plus ``rules_to_add`` /
+Update scope covers all deltas: ``_to_add``, ``_to_update``, and
+``_to_remove`` for every atom type, plus ``rules_to_add`` /
 ``rules_to_remove`` and top-level field updates. This validator
 synthesizes a virtual :class:`CreateTaxonomyBlockRequest` representing
 the post-delta state of the taxonomy (DB rows minus removals, with
-mutations applied, plus additions), then runs the six create-time
-phases against that projection. Delta-specific guards (library origin
+mutations applied, plus additions), then runs the create-time phases
+against that projection. Delta-specific guards (library origin
 immutability, live fact/line-item dependencies, cross-taxonomy
 mappings, orphan children) run after the projection check.
 """
@@ -597,16 +597,6 @@ def _validate_associations_to_remove(
   return issues
 
 
-def reject_unsupported_deltas(payload: UpdateTaxonomyBlockRequest) -> None:
-  """No-op since Phase 2.4.1 ships all delta kinds.
-
-  Kept as a stable export for callers pinned to the pre-2.4.1 import,
-  until a follow-up cleanup removes the call sites.
-  """
-  return None
-
-
 __all__ = [
-  "reject_unsupported_deltas",
   "validate_update_envelope",
 ]

--- a/robosystems/operations/taxonomy_block/validators.py
+++ b/robosystems/operations/taxonomy_block/validators.py
@@ -1,25 +1,26 @@
-"""Seven-phase validator pipeline for Taxonomy Block create payloads.
+"""Validator pipeline for Taxonomy Block create payloads.
 
-Runs before any handler writes. Collects every issue across all phases
-and surfaces them as a single :class:`TaxonomyBlockValidationError` —
-tenants see every problem in one response, not the first-fail shape
-the inline handler checks produced.
+Runs before any handler writes. Collects every issue across all
+checks and surfaces them as a single
+:class:`TaxonomyBlockValidationError` — tenants see every problem in
+one response, not the first-fail shape the inline handler checks
+produced.
 
-Phases (see ``local/docs/specs/taxonomy-block.md`` §3.1):
+Checks (see ``local/docs/specs/taxonomy-block.md`` §3.1):
 
-1. Reference resolution — parent_ref / structure_ref / from_ref /
-   to_ref / rule targets all resolve locally or (for
-   ``reporting_extension``) in the parent library.
-2. Uniqueness — element qnames and structure names unique within the
-   envelope.
-3. Structural integrity — no cycles in parent_child or summation_item
-   arcs.
-4. Type-specific — CoA classification discipline; extension namespace
-   prefix.
-5. Library-origin respect — tenants can't smuggle library-origin rows
-   in ``elements[]``.
-6. Rule expression parse — safe-AST parse of every tenant rule
-   expression; every ``variable_qname`` resolves.
+* Reference resolution — parent_ref / structure_ref / from_ref /
+  to_ref / rule targets all resolve locally or (for
+  ``reporting_extension``) in the parent library.
+* Uniqueness — element qnames and structure names unique within the
+  envelope.
+* Structural integrity — no cycles in parent_child or summation_item
+  arcs.
+* Type-specific — CoA classification discipline; extension namespace
+  prefix.
+* Library-origin respect — tenants can't smuggle library-origin rows
+  in ``elements[]``.
+* Rule expression parse — safe-AST parse of every tenant rule
+  expression; every ``variable_qname`` resolves.
 
 Returned issues don't distinguish fatal / warning — every issue
 aborts the envelope. The `severity` field on tenant-authored rules is
@@ -51,7 +52,7 @@ from robosystems.operations.information_block.rules.expressions import (
 class ValidationIssue:
   """One problem discovered by the validator.
 
-  ``phase`` names which phase caught it (for diagnosis); ``code`` is a
+  ``phase`` names which check caught it (for diagnosis); ``code`` is a
   stable machine-readable tag (for API consumers); ``message`` is
   human-readable; ``context`` carries the offending atoms (qnames,
   structure names, etc.) for reconstruction.
@@ -64,7 +65,7 @@ class ValidationIssue:
 
 
 class TaxonomyBlockValidationError(ValueError):
-  """Aggregate exception raised when any validator phase produces issues."""
+  """Aggregate exception raised when any validator check produces issues."""
 
   def __init__(self, issues: list[ValidationIssue]):
     self.issues = issues
@@ -77,7 +78,7 @@ def validate_create_envelope(
   payload: CreateTaxonomyBlockRequest,
   session: Session,
 ) -> list[ValidationIssue]:
-  """Run all phases; return the full list of issues (empty when valid)."""
+  """Run all checks; return the full list of issues (empty when valid)."""
   issues: list[ValidationIssue] = []
   issues.extend(_phase_reference_resolution(payload, session))
   issues.extend(_phase_uniqueness(payload))

--- a/robosystems/routers/extensions/roboledger/operations.py
+++ b/robosystems/routers/extensions/roboledger/operations.py
@@ -51,8 +51,8 @@ Every route follows the pattern:
   `remove-publish-list-member`
 
 Raw ontology CRUD (taxonomies, structures, elements, non-mapping
-associations) was retired in Phase 1 — the Taxonomy Block envelope is
-now the only tenant-facing construction path. Mapping associations stay
+associations) is not exposed publicly — the Taxonomy Block envelope is
+the only tenant-facing construction path. Mapping associations stay
 direct (craft, not curation).
 
 `build-fact-grid` is registered separately in the sibling `views.py`
@@ -594,7 +594,7 @@ async def update_entity_op(
 #
 # Taxonomy Block is the only tenant-facing path for ontology curation.
 # Raw CRUD (create-taxonomy, create-structure, create/update/delete-element,
-# create-associations) was retired from the public surface in Phase 1.
+# create-associations) is not exposed on the public surface.
 # ═══════════════════════════════════════════════════════════════════════════
 
 create_taxonomy_block_op = _registrar.register(
@@ -928,8 +928,8 @@ evaluate_rules_op = _registrar.register(
 # ═══════════════════════════════════════════════════════════════════════════
 # Agents
 #
-# Counterparty records (customers, vendors, employees, etc.) — Phase 2 of
-# the event-driven ledger. events.agent_id references this table.
+# Counterparty records (customers, vendors, employees, etc.).
+# events.agent_id references this table.
 # ═══════════════════════════════════════════════════════════════════════════
 
 create_agent_op = _registrar.register(
@@ -966,9 +966,10 @@ update_agent_op = _registrar.register(
 # ═══════════════════════════════════════════════════════════════════════════
 # Event Blocks
 #
-# Real-world business event layer (event-driven-ledger.md). Phase 1 ships
-# the envelope in capture-only mode (apply_handlers=False). The handler
-# engine (apply_handlers=True, event_handlers table) ships in Phase 3.
+# Real-world business event layer (event-driven-ledger.md). Two write
+# modes: apply_handlers=False captures the event without firing GL
+# postings; apply_handlers=True resolves an event_handler and fires its
+# transaction template atomically with the event row.
 # ═══════════════════════════════════════════════════════════════════════════
 
 create_event_block_op = _registrar.register(
@@ -1022,8 +1023,7 @@ update_event_block_op = _registrar.register(
 # ═══════════════════════════════════════════════════════════════════════════
 # Event Handlers
 #
-# Dynamic rule registry for event → transaction transformation (Phase 3).
-# The dynamic rule layer that drives event → GL transformation.
+# Dynamic rule registry that drives event → GL transformation.
 # ═══════════════════════════════════════════════════════════════════════════
 
 create_event_handler_op = _registrar.register(

--- a/robosystems/scripts/build_fac_presentation_seed.py
+++ b/robosystems/scripts/build_fac_presentation_seed.py
@@ -5,7 +5,9 @@ form the presentation linkbase — the scaffold that organizes how a
 statement is rendered. This seed emits those relationships as reified
 ``link:presentationArc`` equivalents — one arc node per (parent, child,
 structure, order) triple, matching the XBRL 2.1 presentation linkbase
-shape (Charlie Hoffmann's sfac6-pre.xml is the canonical reference).
+shape (Charlie Hoffmann's FAC presentation linkbase is the canonical
+reference; the upstream filename retains the historical sfac6-pre.xml
+convention).
 
 Structure:
 

--- a/robosystems/taxonomy/__init__.py
+++ b/robosystems/taxonomy/__init__.py
@@ -16,6 +16,6 @@ supporting runtime:
   git and edited in place (see `seeds/README.md`). Upstream XBRL is not
   tracked; `scripts/import_upstream_seeds.py` is kept as an archaeological
   one-shot for re-bootstrapping a seed from source.
-- `seed.py` — legacy Python-dict seed (retained for the initial migration
-  downgrade path; retired when Phase 1 lands).
+- `seed.py` — legacy Python-dict seed (retained for compatibility during
+  the JSON-LD migration).
 """

--- a/robosystems/taxonomy/loaders/jsonld_loader.py
+++ b/robosystems/taxonomy/loaders/jsonld_loader.py
@@ -38,8 +38,9 @@ RS_NS = RS_VOCAB  # alias for readability
 
 # Enum closures for rule axes. Kept here so both the loader (for
 # cheap sanity-checking during parse) and the migration CHECK
-# constraints can import one canonical source. Expand when Phase δ.3's
-# parser produces rules under the not-yet-seeded categories or patterns.
+# constraints can import one canonical source. Update RULE_CATEGORY_VALUES
+# and RULE_PATTERN_VALUES when new categories or patterns are added to the
+# seed.
 RULE_CATEGORY_VALUES: frozenset[str] = frozenset(
   {
     "AutomatedAccountingAndReportingChecks",

--- a/robosystems/taxonomy/model.py
+++ b/robosystems/taxonomy/model.py
@@ -194,8 +194,8 @@ class RuleTargetSpec(BaseModel):
 class RuleVariableSpec(BaseModel):
   """Binding from a `$Variable` in the rule expression to a concept qname.
 
-  The engine (Phase δ.3) evaluates `rule_expression` by looking each
-  variable up in the Structure's in-scope fact set and substituting the
+  The rule engine evaluates `rule_expression` by looking up each
+  variable in the Structure's in-scope fact set and substituting the
   value. This spec is the compile-time binding table.
   """
 
@@ -247,7 +247,7 @@ class RuleSpec(BaseModel):
     description=(
       "XPath-flavored predicate (verbatim from Charlie's XBRL Formula "
       "linkbases) or natural-language condition for structural rules. "
-      "Evaluation DSL selection is the engine's job (Phase δ.3)."
+      "Evaluation DSL selection is the engine's job."
     ),
   )
   rule_target: RuleTargetSpec | None = Field(

--- a/robosystems/taxonomy/writers/tenant_writer.py
+++ b/robosystems/taxonomy/writers/tenant_writer.py
@@ -265,7 +265,7 @@ def copy_library_into_tenant(
     pin_params,
   )
 
-  # Association classifications (Phase epsilon) — junction rows linking
+  # Association classifications — junction rows linking
   # associations copied above to the classification catalog.
   ac_result = connection.execute(
     text(f"""

--- a/tests/operations/information_block/test_schedule_handlers.py
+++ b/tests/operations/information_block/test_schedule_handlers.py
@@ -117,7 +117,7 @@ class TestBuildEnvelope:
     assert schedule_handlers.build_envelope(session, "struct_other") is None
 
   def test_packs_mechanics_from_typed_artifact_mechanics_column(self) -> None:
-    """Phase δ reads mechanics from structures.artifact_mechanics column.
+    """Mechanics are read from the typed artifact_mechanics column.
 
     This is the post-backfill path every Schedule row takes: the typed
     JSONB column is the authoritative source; metadata_ carries the
@@ -153,13 +153,13 @@ class TestBuildEnvelope:
     structure.metadata_ = {"should_be_ignored": True}
     session.get.return_value = structure
     session.execute.side_effect = [
-      _exec_result(scalar=5),  # periods_with_entries count
       _exec_result(scalar="US GAAP"),  # taxonomy name
       _exec_result(scalars_all=[]),  # associations
-      _exec_result(scalars_all=[]),  # facts
       _exec_result(scalars_all=[]),  # rules
       _exec_result(scalar=None),  # latest fact set → None
       _exec_result(scalars_all=[]),  # verification results
+      _exec_result(scalar=5),  # periods_with_entries count
+      _exec_result(scalars_all=[]),  # facts
     ]
 
     envelope = schedule_handlers.build_envelope(session, "struct_abc")
@@ -209,6 +209,11 @@ class TestBuildEnvelope:
     structure.metadata_ = {}  # no entry_template key
     session.get.return_value = structure
     session.execute.side_effect = [
+      _exec_result(scalar="US GAAP"),  # taxonomy name
+      _exec_result(scalars_all=[]),  # associations
+      _exec_result(scalars_all=[]),  # rules
+      _exec_result(scalar=None),  # latest fact set → None
+      _exec_result(scalars_all=[]),  # verification results
       _exec_result(scalar=0),  # periods_with_entries
     ]
 
@@ -216,7 +221,7 @@ class TestBuildEnvelope:
       schedule_handlers.build_envelope(session, "struct_corrupted")
 
   def test_falls_back_to_metadata_jsonb_when_artifact_mechanics_null(self) -> None:
-    """Pre-δ Schedule rows lacking artifact_mechanics still surface.
+    """Schedule rows lacking artifact_mechanics still surface via metadata_.
 
     The migration backfills every existing Schedule row, so this path is
     only exercised by rows inserted between DDL and backfill — or rows
@@ -242,13 +247,13 @@ class TestBuildEnvelope:
     }
     session.get.return_value = structure
     session.execute.side_effect = [
-      _exec_result(scalar=0),  # periods_with_entries
       _exec_result(scalar="US GAAP"),  # taxonomy name
       _exec_result(scalars_all=[]),  # associations
-      _exec_result(scalars_all=[]),  # facts
       _exec_result(scalars_all=[]),  # rules
       _exec_result(scalar=None),  # latest fact set → None
       _exec_result(scalars_all=[]),  # verification results
+      _exec_result(scalar=0),  # periods_with_entries
+      _exec_result(scalars_all=[]),  # facts
     ]
 
     envelope = schedule_handlers.build_envelope(session, "struct_legacy")

--- a/tests/operations/information_block/test_statement_handlers.py
+++ b/tests/operations/information_block/test_statement_handlers.py
@@ -15,6 +15,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from robosystems.operations.information_block import statement as statement_handlers
+from robosystems.operations.information_block.registry import REGISTRY
 
 
 def _exec_result(
@@ -25,9 +26,8 @@ def _exec_result(
 ) -> MagicMock:
   """Build a MagicMock shaped like a SQLAlchemy Result object.
 
-  ``all_rows`` covers the ``.all()`` path (used by the Phase epsilon
-  association-classifications loader which queries tuples rather than
-  scalars).
+  ``all_rows`` covers the ``.all()`` path used by the association-
+  classifications loader, which queries tuples rather than scalars.
   """
   result = MagicMock()
   if scalars_all is not None:
@@ -37,7 +37,6 @@ def _exec_result(
   if scalar is not None:
     result.scalar.return_value = scalar
   else:
-    # Default: execute().scalar() returns None (no latest report).
     result.scalar.return_value = None
   return result
 
@@ -53,12 +52,10 @@ def _make_statement_structure(
   concept_arrangement: str | None = "roll_up",
   member_arrangement: str | None = "aggregation",
 ) -> MagicMock:
-  """Shape a MagicMock like a Phase δ Structure row for a statement block.
+  """Shape a MagicMock like a Structure row for a statement block.
 
-  The envelope builder now reads typed columns (artifact_mechanics,
-  concept/member_arrangement, parenthetical_note) off the row, so
-  MagicMock's auto-attribute behaviour would otherwise inject unwanted
-  truthy values — this helper pins every field the builder touches.
+  Pins every field the envelope builder touches so MagicMock's
+  auto-attribute behaviour doesn't inject unwanted truthy values.
   """
   structure = MagicMock()
   structure.id = structure_id
@@ -79,66 +76,67 @@ def _make_statement_structure(
 
 class TestCreate:
   def test_create_raises_not_implemented_with_create_report_pointer(self) -> None:
-    session = MagicMock()
+    entry = REGISTRY["balance_sheet"]
     with pytest.raises(NotImplementedError) as exc:
-      statement_handlers._create_not_implemented(session, MagicMock(), "usr_test")
+      entry.dispatch_create(MagicMock(), MagicMock(), "usr_test")
     assert "create-report" in str(exc.value)
 
   @pytest.mark.parametrize(
     "block_type",
     ["balance_sheet", "income_statement", "cash_flow_statement", "equity_statement"],
   )
-  def test_every_statement_handler_binds_the_not_implemented_create(
+  def test_every_statement_type_raises_not_implemented_on_create(
     self, block_type: str
   ) -> None:
-    """Every handler pair wires the same 501-producing ``create``."""
-    handlers = statement_handlers.make_statement_handlers(block_type)
-    assert handlers["create"] is statement_handlers._create_not_implemented
+    """All four statement block types share the same 501-producing create handler."""
+    entry = REGISTRY[block_type]
+    with pytest.raises(NotImplementedError, match="create-report"):
+      entry.dispatch_create(MagicMock(), MagicMock(), "usr_test")
 
 
 class TestUpdate:
   def test_update_raises_not_implemented(self) -> None:
-    session = MagicMock()
+    entry = REGISTRY["balance_sheet"]
     with pytest.raises(NotImplementedError) as exc:
-      statement_handlers._update_not_implemented(session, MagicMock(), "usr_test")
+      entry.dispatch_update(MagicMock(), MagicMock(), "usr_test")
     assert "library-seeded" in str(exc.value)
 
   @pytest.mark.parametrize(
     "block_type",
     ["balance_sheet", "income_statement", "cash_flow_statement", "equity_statement"],
   )
-  def test_every_statement_handler_binds_not_implemented_update(
+  def test_every_statement_type_raises_not_implemented_on_update(
     self, block_type: str
   ) -> None:
-    handlers = statement_handlers.make_statement_handlers(block_type)
-    assert handlers["update"] is statement_handlers._update_not_implemented
+    entry = REGISTRY[block_type]
+    with pytest.raises(NotImplementedError):
+      entry.dispatch_update(MagicMock(), MagicMock(), "usr_test")
 
 
 class TestDelete:
   def test_delete_raises_not_implemented(self) -> None:
-    session = MagicMock()
+    entry = REGISTRY["balance_sheet"]
     with pytest.raises(NotImplementedError) as exc:
-      statement_handlers._delete_not_implemented(session, MagicMock(), "usr_test")
+      entry.dispatch_delete(MagicMock(), MagicMock(), "usr_test")
     assert "library-seeded" in str(exc.value)
 
   @pytest.mark.parametrize(
     "block_type",
     ["balance_sheet", "income_statement", "cash_flow_statement", "equity_statement"],
   )
-  def test_every_statement_handler_binds_not_implemented_delete(
+  def test_every_statement_type_raises_not_implemented_on_delete(
     self, block_type: str
   ) -> None:
-    handlers = statement_handlers.make_statement_handlers(block_type)
-    assert handlers["delete"] is statement_handlers._delete_not_implemented
+    entry = REGISTRY[block_type]
+    with pytest.raises(NotImplementedError):
+      entry.dispatch_delete(MagicMock(), MagicMock(), "usr_test")
 
 
 class TestBuildEnvelope:
   def test_returns_none_when_structure_missing(self) -> None:
     session = MagicMock()
     session.get.return_value = None
-    build = statement_handlers.make_statement_handlers("balance_sheet")[
-      "build_envelope"
-    ]
+    build = statement_handlers.make_statement_handlers("balance_sheet")
     assert build(session, "struct_missing") is None
 
   def test_returns_none_when_structure_is_wrong_block_type(self) -> None:
@@ -147,9 +145,7 @@ class TestBuildEnvelope:
     structure = MagicMock()
     structure.structure_type = "schedule"
     session.get.return_value = structure
-    build = statement_handlers.make_statement_handlers("balance_sheet")[
-      "build_envelope"
-    ]
+    build = statement_handlers.make_statement_handlers("balance_sheet")
     assert build(session, "struct_other") is None
 
   def test_returns_envelope_with_empty_facts_when_no_reports_exist(self) -> None:
@@ -162,9 +158,8 @@ class TestBuildEnvelope:
       description="Assets + Liabilities + Equity",
     )
     session.get.return_value = structure
-    # Query order: taxonomy name, associations, rules, fact_set.
-    # Element/report queries skip when element_ids is empty; the
-    # association-classifications query skips when associations is empty.
+    # Query order (no associations → no elements or classifications queries):
+    # taxonomy name → associations → rules → fact_set → verification_results
     session.execute.side_effect = [
       _exec_result(scalar="US GAAP"),  # taxonomy name
       _exec_result(scalars_all=[]),  # associations
@@ -173,9 +168,7 @@ class TestBuildEnvelope:
       _exec_result(scalars_all=[]),  # verification results
     ]
 
-    build = statement_handlers.make_statement_handlers("balance_sheet")[
-      "build_envelope"
-    ]
+    build = statement_handlers.make_statement_handlers("balance_sheet")
     envelope = build(session, "struct_balance_sheet")
 
     assert envelope is not None
@@ -193,7 +186,6 @@ class TestBuildEnvelope:
     assert envelope.elements == []
     assert envelope.connections == []
     assert envelope.facts == []
-    # Reserved-for-later-phase fields default-empty.
     assert envelope.rules == []
     assert envelope.dimensions == []
     assert envelope.fact_set is None
@@ -239,20 +231,21 @@ class TestBuildEnvelope:
     element_sales.balance_type = "credit"
     element_sales.period_type = "duration"
 
+    # Query order (1 association → elements + classifications queries run):
+    # taxonomy → associations → elements → rules → classifications →
+    # fact_set → verification_results → latest_report_id
     session.execute.side_effect = [
       _exec_result(scalar="US GAAP"),  # taxonomy name
       _exec_result(scalars_all=[association]),  # associations
       _exec_result(scalars_all=[element_revenue, element_sales]),  # elements
-      _exec_result(scalar=None),  # no reports → facts=[]
       _exec_result(scalars_all=[]),  # rules
       _exec_result(all_rows=[]),  # association classifications
       _exec_result(scalar=None),  # latest fact set → None
       _exec_result(scalars_all=[]),  # verification results
+      _exec_result(scalar=None),  # latest report id → None (no reports)
     ]
 
-    build = statement_handlers.make_statement_handlers("income_statement")[
-      "build_envelope"
-    ]
+    build = statement_handlers.make_statement_handlers("income_statement")
     envelope = build(session, "struct_income_statement")
 
     assert envelope is not None
@@ -303,21 +296,22 @@ class TestBuildEnvelope:
     fact.fact_scope = "in_scope"
     fact.fact_set_id = None
 
+    # Query order (1 association, report found):
+    # taxonomy → associations → elements → rules → classifications →
+    # fact_set → verification_results → latest_report_id → facts
     session.execute.side_effect = [
       _exec_result(scalar="US GAAP"),  # taxonomy name
       _exec_result(scalars_all=[assoc]),  # associations
       _exec_result(scalars_all=[element]),  # elements
-      _exec_result(scalar="rep_latest"),  # latest_report_id
-      _exec_result(scalars_all=[fact]),  # facts
       _exec_result(scalars_all=[]),  # rules
       _exec_result(all_rows=[]),  # association classifications
       _exec_result(scalar=None),  # latest fact set → None
       _exec_result(scalars_all=[]),  # verification results
+      _exec_result(scalar="rep_latest"),  # latest_report_id
+      _exec_result(scalars_all=[fact]),  # facts
     ]
 
-    build = statement_handlers.make_statement_handlers("balance_sheet")[
-      "build_envelope"
-    ]
+    build = statement_handlers.make_statement_handlers("balance_sheet")
     envelope = build(session, "struct_balance_sheet")
 
     assert envelope is not None
@@ -339,18 +333,16 @@ class TestBuildEnvelope:
       name=statement_handlers.STATEMENT_DISPLAY[block_type][0],
     )
     session.get.return_value = structure
-    # Query order: taxonomy name, associations, rules, fact_set.
-    # Elements/report queries skip when there are no associations; the
-    # association-classifications query skips too.
+    # No associations → no elements or classifications queries.
     session.execute.side_effect = [
       _exec_result(scalar="US GAAP"),
-      _exec_result(scalars_all=[]),
+      _exec_result(scalars_all=[]),  # associations
       _exec_result(scalars_all=[]),  # rules
       _exec_result(scalar=None),  # latest fact set → None
       _exec_result(scalars_all=[]),  # verification results
     ]
 
-    build = statement_handlers.make_statement_handlers(block_type)["build_envelope"]
+    build = statement_handlers.make_statement_handlers(block_type)
     envelope = build(session, f"struct_{block_type}")
 
     assert envelope is not None

--- a/tests/operations/taxonomy_block/test_update.py
+++ b/tests/operations/taxonomy_block/test_update.py
@@ -1,4 +1,4 @@
-"""Tests for Taxonomy Block update handlers (Phase 2.4 / Phase 2.4.1)."""
+"""Tests for Taxonomy Block update handlers."""
 
 from __future__ import annotations
 
@@ -9,13 +9,9 @@ import pytest
 from robosystems.models.api.taxonomy_block import (
   ElementUpdatePatch,
   StructureUpdatePatch,
-  TaxonomyBlockElementRequest,
   UpdateTaxonomyBlockRequest,
 )
 from robosystems.operations.taxonomy_block import custom_ontology
-from robosystems.operations.taxonomy_block.update_validator import (
-  reject_unsupported_deltas,
-)
 
 
 def _fake_taxonomy(taxonomy_type: str, *, is_locked: bool = False) -> MagicMock:
@@ -30,53 +26,6 @@ def _fake_taxonomy(taxonomy_type: str, *, is_locked: bool = False) -> MagicMock:
   taxonomy.parent_taxonomy_id = None
   taxonomy.namespace_uri = None
   return taxonomy
-
-
-class TestRejectUnsupportedDeltasIsNoop:
-  """Phase 2.4.1 ships every delta kind; the function is now a no-op."""
-
-  def test_elements_to_update_accepted(self) -> None:
-    payload = UpdateTaxonomyBlockRequest(
-      taxonomy_id="tax_1",
-      elements_to_update=[ElementUpdatePatch(qname="x:A", name="A")],
-    )
-    reject_unsupported_deltas(payload)  # no raise
-
-  def test_elements_to_remove_accepted(self) -> None:
-    payload = UpdateTaxonomyBlockRequest(
-      taxonomy_id="tax_1", elements_to_remove=["x:A"]
-    )
-    reject_unsupported_deltas(payload)  # no raise
-
-  def test_structures_to_update_accepted(self) -> None:
-    payload = UpdateTaxonomyBlockRequest(
-      taxonomy_id="tax_1",
-      structures_to_update=[StructureUpdatePatch(structure_id="s1", name="new")],
-    )
-    reject_unsupported_deltas(payload)  # no raise
-
-  def test_structures_to_remove_accepted(self) -> None:
-    payload = UpdateTaxonomyBlockRequest(
-      taxonomy_id="tax_1", structures_to_remove=["s1"]
-    )
-    reject_unsupported_deltas(payload)  # no raise
-
-  def test_associations_to_remove_accepted(self) -> None:
-    payload = UpdateTaxonomyBlockRequest(
-      taxonomy_id="tax_1", associations_to_remove=["assoc_1"]
-    )
-    reject_unsupported_deltas(payload)  # no raise
-
-  def test_empty_payload_accepted(self) -> None:
-    payload = UpdateTaxonomyBlockRequest(taxonomy_id="tax_1")
-    reject_unsupported_deltas(payload)  # no raise
-
-  def test_additive_deltas_accepted(self) -> None:
-    payload = UpdateTaxonomyBlockRequest(
-      taxonomy_id="tax_1",
-      elements_to_add=[TaxonomyBlockElementRequest(qname="x:A", name="A")],
-    )
-    reject_unsupported_deltas(payload)  # no raise
 
 
 class TestCustomOntologyUpdate:
@@ -120,7 +69,7 @@ class TestCustomOntologyUpdate:
     assert tax.version == "v2"
 
 
-# ── Phase 2.4.1 — delta validator unit tests ───────────────────────────────
+# ── Delta validator unit tests ─────────────────────────────────────────────
 
 
 def _mock_execute_result(value: list) -> MagicMock:


### PR DESCRIPTION
## Summary

A broad refactoring pass across 84 files that aligns docstrings to a consistent style, restructures taxonomy block operations by extracting shared helpers, and simplifies handler/command signatures throughout the codebase. This is a code-quality and maintainability improvement with no intended behavioral changes.

## Key Accomplishments

### Docstring & Documentation Alignment
- Standardized docstring format across models, operations, GraphQL types, middleware tools, and extension modules to follow a consistent convention.
- Updated inline README files (`operations/README.md`, `information_block/README.md`, `graphql/README.md`) to reflect current architecture and terminology.

### Taxonomy Block Operations Refactor
- Extracted common taxonomy block logic into a new shared `_helpers.py` module (`robosystems/operations/taxonomy_block/_helpers.py`), reducing duplication across `chart_of_accounts`, `custom_ontology`, `reporting_standard`, `reporting_extension`, `schedule_container`, and `library_creator` modules.
- Simplified the taxonomy block registry, update validator, auto-rules, and type definitions to use the consolidated helpers.

### Handler & Command Signature Simplification
- Streamlined event block command functions and promotion logic by reducing parameter counts and clarifying responsibilities.
- Refined information block operations — `envelope.py` and `registry.py` saw significant expansion/refactoring to improve clarity and support new operational patterns.
- Simplified python event handler implementations (`asset_disposed`, `schedule_created`) and the event block engine/template interfaces.

### Model & API Layer Cleanup
- Tightened model definitions across `api/`, `extensions/`, and `core/graph/` packages with clearer field documentation and minor signature adjustments.
- Adjusted GraphQL type resolvers for `information_block` and `taxonomy_block` to match updated model interfaces.
- Updated environment config (`config/env.py`) with streamlined variable handling.

### Examples & Scripts
- Refreshed `close_demo` example scripts to align with refactored API surfaces.
- Updated the FAC presentation seed build script for consistency.

## Breaking Changes

- **Taxonomy block operations**: Internal helper functions have been relocated to `_helpers.py`. Any code importing directly from individual taxonomy block modules (e.g., `chart_of_accounts`, `reporting_standard`) may need import path updates if it relied on previously-public helper functions.
- **Event block command signatures**: Functions in `event_block/commands.py` and `event_block/promotion.py` have simplified signatures — callers passing positional arguments may need adjustment.
- **Information block registry & envelope**: Expanded interfaces in `registry.py` and `envelope.py` may affect downstream consumers that subclass or directly invoke these operations.

## Testing Notes

- Existing tests in `tests/operations/information_block/` (schedule handlers, statement handlers) and `tests/operations/taxonomy_block/` (update tests) have been updated to match the refactored interfaces.
- All modified modules should be exercised through the existing test suite; particular attention should be given to end-to-end flows involving taxonomy block creation/update and event block promotion pipelines.
- The `close_demo` example can serve as a manual integration smoke test.

## Infrastructure Considerations

- No new dependencies or environment variables introduced.
- No database migration required — changes are limited to application code and documentation.
- The new `_helpers.py` module in taxonomy block operations should be included in any packaging or deployment configurations that use explicit file lists rather than package discovery.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

**Branch Info:**
- Source: `refactor/docstring-alignment`
- Target: `main`
- Type: refactor

Co-Authored-By: Claude <noreply@anthropic.com>