### PR TITLE
fix: add reconciliation logic and busy counter for materialization

### DIFF
--- a/robosystems/adapters/sec/pipeline/materialize.py
+++ b/robosystems/adapters/sec/pipeline/materialize.py
@@ -71,13 +71,29 @@ def sec_graph_materialized(
     context.log.info(msg)
 
   async def run_materialization():
-    result = await processor.materialize_from_duckdb(
-      rebuild=config.rebuild_graph,
-      batch_materialization=config.batch_materialization,
-      batch_size=config.materialization_batch_size,
-      progress_callback=dagster_progress,
+    # Publish the busy counter against the shared-tier master that runs
+    # the LadybugDB COPY, so GHA pre-refresh waits before cycling it.
+    # Mirrors the wrapping in stage.py. Lazy imports keep boto3 /
+    # GraphClientFactory out of every SEC module's import chain.
+    from robosystems.middleware.graph.instance_busy import (
+      OP_KIND_DAGSTER_MATERIALIZATION,
+      begin_destructive_op,
+      end_destructive_op,
+      resolve_instance_id_for_graph,
     )
-    return result
+
+    busy_instance_id = await resolve_instance_id_for_graph(config.graph_id)
+    await begin_destructive_op(busy_instance_id, OP_KIND_DAGSTER_MATERIALIZATION)
+    try:
+      result = await processor.materialize_from_duckdb(
+        rebuild=config.rebuild_graph,
+        batch_materialization=config.batch_materialization,
+        batch_size=config.materialization_batch_size,
+        progress_callback=dagster_progress,
+      )
+      return result
+    finally:
+      await end_destructive_op(busy_instance_id, OP_KIND_DAGSTER_MATERIALIZATION)
 
   result = asyncio.run(run_materialization())
 
@@ -209,13 +225,28 @@ def sec_historical_materialized(
     )
     context.log.info(f"Subgraph status: {subgraph_result.get('status')}")
 
-    result = await processor.materialize_from_duckdb(
-      rebuild=config.rebuild_graph,
-      batch_materialization=config.batch_materialization,
-      batch_size=config.materialization_batch_size,
-      progress_callback=dagster_progress,
+    # Publish the busy counter against the shared-tier master that runs
+    # the LadybugDB COPY, so GHA pre-refresh waits before cycling it.
+    # Mirrors the wrapping in stage.py.
+    from robosystems.middleware.graph.instance_busy import (
+      OP_KIND_DAGSTER_MATERIALIZATION,
+      begin_destructive_op,
+      end_destructive_op,
+      resolve_instance_id_for_graph,
     )
-    return result
+
+    busy_instance_id = await resolve_instance_id_for_graph(graph_id)
+    await begin_destructive_op(busy_instance_id, OP_KIND_DAGSTER_MATERIALIZATION)
+    try:
+      result = await processor.materialize_from_duckdb(
+        rebuild=config.rebuild_graph,
+        batch_materialization=config.batch_materialization,
+        batch_size=config.materialization_batch_size,
+        progress_callback=dagster_progress,
+      )
+      return result
+    finally:
+      await end_destructive_op(busy_instance_id, OP_KIND_DAGSTER_MATERIALIZATION)
 
   result = asyncio.run(run_materialization())
 

--- a/robosystems/graph_api/routers/databases/tables/materialize.py
+++ b/robosystems/graph_api/routers/databases/tables/materialize.py
@@ -12,6 +12,10 @@ from robosystems.graph_api.models.tables import (
   TableMaterializationResponse,
 )
 from robosystems.logger import logger
+from robosystems.middleware.graph.instance_busy import (
+  OP_KIND_MATERIALIZATION,
+  instance_busy,
+)
 
 # Type mapping from LadybugDB types to DuckDB-compatible cast types
 _LBUG_TO_DUCK_TYPE = {
@@ -188,6 +192,29 @@ async def materialize_table(
       status_code=http_status.HTTP_403_FORBIDDEN,
       detail="Materialization not allowed on read-only nodes",
     )
+
+  # Mark this instance busy so GHA pre-refresh workflows don't cycle the
+  # container mid-materialization. The bulk_table_create / bulk_table_insert
+  # endpoints already do this; materialize was the missing piece. Wraps the
+  # full body so the counter decrements on exception too.
+  async with instance_busy(env.INSTANCE_ID, OP_KIND_MATERIALIZATION):
+    return await _materialize_table_impl(
+      graph_id=graph_id,
+      table_name=table_name,
+      request=request,
+      ladybug_service=ladybug_service,
+      start_time=start_time,
+    )
+
+
+async def _materialize_table_impl(
+  graph_id: str,
+  table_name: str,
+  request: TableMaterializationRequest,
+  ladybug_service,
+  start_time: float,
+) -> TableMaterializationResponse:
+  import time
 
   try:
     # Blue-green: read DuckDB from source graph if specified, otherwise from target

--- a/robosystems/graph_api/routers/databases/tables/materialize.py
+++ b/robosystems/graph_api/routers/databases/tables/materialize.py
@@ -62,6 +62,31 @@ def _get_target_columns(
     return None
 
 
+_RECONCILE_IGNORE_COLS = frozenset({"file_id", "from", "to", "src", "dst"})
+
+
+def _needs_reconciliation(
+  target_columns: list[tuple[str, str]] | None,
+  source_column_names: list[str],
+) -> bool:
+  """Return True when source columns don't match target columns by name AND order.
+
+  LadybugDB COPY is positional, so a source table whose column names match the
+  target's but in a different order will silently misalign data into the wrong
+  columns. This commonly happens when a new property is added in the middle of
+  an existing node schema and the DuckDB staging table evolves via
+  `ALTER TABLE ADD COLUMN` (which appends at the end). A pure set comparison
+  misses this; we compare ordered lists.
+
+  `from`/`to`/`src`/`dst`/`file_id` are excluded — they're implicit/synthetic.
+  """
+  if not target_columns:
+    return False
+  target_order = [c[0] for c in target_columns if c[0] not in _RECONCILE_IGNORE_COLS]
+  source_order = [c for c in source_column_names if c not in _RECONCILE_IGNORE_COLS]
+  return target_order != source_order
+
+
 def _build_reconciled_select(
   target_columns: list[tuple[str, str]],
   source_column_names: list[str],
@@ -223,14 +248,7 @@ async def materialize_table(
         column_names = [col[0] for col in columns_result]
         has_file_id = "file_id" in column_names
 
-        # Check if column reconciliation is needed (missing or extra columns)
-        # Exclude from/to (implicit in rel tables) and file_id from comparison
-        needs_reconciliation = False
-        _ignore_cols = {"file_id", "from", "to", "src", "dst"}
-        if target_columns:
-          target_names = {c[0] for c in target_columns} - _ignore_cols
-          source_names = set(column_names) - _ignore_cols
-          needs_reconciliation = target_names != source_names
+        needs_reconciliation = _needs_reconciliation(target_columns, column_names)
 
         # Columns to NULL out (keep column for schema match, but skip data).
         # Embeddings stay in DuckDB staging for LanceDB vector search; materializing

--- a/robosystems/graph_api/routers/databases/tables/materialize.py
+++ b/robosystems/graph_api/routers/databases/tables/materialize.py
@@ -580,6 +580,28 @@ async def fork_from_parent_duckdb(
       detail="Fork not allowed on read-only nodes",
     )
 
+  # Mark this instance busy so GHA pre-refresh workflows don't cycle the
+  # container mid-fork. Same rationale as materialize_table — fork is a
+  # multi-table COPY across DuckDB → LadybugDB, equally destructive.
+  async with instance_busy(env.INSTANCE_ID, OP_KIND_MATERIALIZATION):
+    return await _fork_from_parent_duckdb_impl(
+      parent_graph_id=parent_graph_id,
+      subgraph_id=subgraph_id,
+      request=request,
+      ladybug_service=ladybug_service,
+      start_time=start_time,
+    )
+
+
+async def _fork_from_parent_duckdb_impl(
+  parent_graph_id: str,
+  subgraph_id: str,
+  request: ForkFromParentRequest,
+  ladybug_service,
+  start_time: float,
+) -> ForkFromParentResponse:
+  import time
+
   try:
     parent_duck_path = f"{env.DUCKDB_STAGING_PATH}/{parent_graph_id}.duckdb"
 

--- a/tests/graph_api/routers/databases/tables/test_tables_materialize.py
+++ b/tests/graph_api/routers/databases/tables/test_tables_materialize.py
@@ -76,17 +76,61 @@ def test_materialize_endpoint_publishes_busy_counter(monkeypatch, app_client):
   # Increment on entry, decrement on exit.
   assert counter_mock.await_count == 2
   deltas = [
-    call.kwargs.get("delta", call.args[1]) for call in counter_mock.await_args_list
+    call.kwargs.get("delta", call.args[1] if len(call.args) > 1 else None)
+    for call in counter_mock.await_args_list
   ]
   assert deltas == [1, -1]
   # All increments tagged with the materialization op_kind.
   kinds = [
-    call.kwargs.get("op_kind", call.args[2]) for call in counter_mock.await_args_list
+    call.kwargs.get("op_kind", call.args[2] if len(call.args) > 2 else None)
+    for call in counter_mock.await_args_list
   ]
   assert kinds == [
     materialize.OP_KIND_MATERIALIZATION,
     materialize.OP_KIND_MATERIALIZATION,
   ]
+
+
+def test_fork_endpoint_publishes_busy_counter(monkeypatch, app_client):
+  """fork_from_parent_duckdb runs the same multi-table COPY workflow as
+  materialize_table and must mark the instance busy for the same reason —
+  otherwise GHA service-refresh can kill a fork mid-run.
+  """
+  cluster_service = SimpleNamespace(read_only=False)
+  app_client.dependency_overrides[get_ladybug_service] = lambda: cluster_service
+
+  async def fake_impl(**kwargs):
+    return materialize.ForkFromParentResponse(
+      status="success",
+      parent_graph_id=kwargs["parent_graph_id"],
+      subgraph_id=kwargs["subgraph_id"],
+      tables_copied=[],
+      total_rows=0,
+      execution_time_ms=0.0,
+    )
+
+  counter_mock = AsyncMock()
+
+  with (
+    patch.object(materialize, "_fork_from_parent_duckdb_impl", side_effect=fake_impl),
+    patch(
+      "robosystems.middleware.graph.instance_busy._update_counter_async",
+      counter_mock,
+    ),
+  ):
+    client = TestClient(app_client)
+    response = client.post(
+      "/databases/sub-1/tables/sub-1/fork-from/parent-1",
+      json={"ignore_errors": True},
+    )
+
+  assert response.status_code == 200, response.text
+  assert counter_mock.await_count == 2
+  deltas = [
+    call.kwargs.get("delta", call.args[1] if len(call.args) > 1 else None)
+    for call in counter_mock.await_args_list
+  ]
+  assert deltas == [1, -1]
 
 
 def test_materialize_endpoint_decrements_counter_on_failure(monkeypatch, app_client):

--- a/tests/graph_api/routers/databases/tables/test_tables_materialize.py
+++ b/tests/graph_api/routers/databases/tables/test_tables_materialize.py
@@ -1,6 +1,7 @@
 """Tests for graph API table materialization endpoint."""
 
 from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastapi import FastAPI
@@ -35,6 +36,92 @@ def test_materialize_rejects_read_only(monkeypatch, app_client):
 
   assert response.status_code == 403
   assert "not allowed" in response.json()["detail"]
+
+
+def test_materialize_endpoint_publishes_busy_counter(monkeypatch, app_client):
+  """Endpoint must increment + decrement the busy counter so GHA pre-refresh
+  workflows don't cycle the container mid-materialization. Regression: SEC
+  prod ran a 60-min materialization without ever flipping
+  active_destructive_ops, so a service-refresh fired and killed the run.
+  """
+  cluster_service = SimpleNamespace(read_only=False)
+  app_client.dependency_overrides[get_ladybug_service] = lambda: cluster_service
+
+  # Stub out the real materialization body — we only care about the counter.
+  async def fake_impl(**kwargs):
+    return materialize.TableMaterializationResponse(
+      status="success",
+      graph_id=kwargs["graph_id"],
+      table_name=kwargs["table_name"],
+      rows_ingested=0,
+      execution_time_ms=0.0,
+    )
+
+  counter_mock = AsyncMock()
+
+  with (
+    patch.object(materialize, "_materialize_table_impl", side_effect=fake_impl),
+    patch(
+      "robosystems.middleware.graph.instance_busy._update_counter_async",
+      counter_mock,
+    ),
+  ):
+    client = TestClient(app_client)
+    response = client.post(
+      "/databases/graph-123/tables/Entity/materialize",
+      json={"ignore_errors": True},
+    )
+
+  assert response.status_code == 200, response.text
+  # Increment on entry, decrement on exit.
+  assert counter_mock.await_count == 2
+  deltas = [
+    call.kwargs.get("delta", call.args[1]) for call in counter_mock.await_args_list
+  ]
+  assert deltas == [1, -1]
+  # All increments tagged with the materialization op_kind.
+  kinds = [
+    call.kwargs.get("op_kind", call.args[2]) for call in counter_mock.await_args_list
+  ]
+  assert kinds == [
+    materialize.OP_KIND_MATERIALIZATION,
+    materialize.OP_KIND_MATERIALIZATION,
+  ]
+
+
+def test_materialize_endpoint_decrements_counter_on_failure(monkeypatch, app_client):
+  """instance_busy is a context manager: counter must decrement even when
+  the body raises. Otherwise a single failed materialization would pin the
+  counter >0 and block all future refreshes until staleness expires.
+  """
+  cluster_service = SimpleNamespace(read_only=False)
+  app_client.dependency_overrides[get_ladybug_service] = lambda: cluster_service
+
+  async def boom(**kwargs):
+    raise RuntimeError("simulated COPY failure")
+
+  counter_mock = AsyncMock()
+
+  with (
+    patch.object(materialize, "_materialize_table_impl", side_effect=boom),
+    patch(
+      "robosystems.middleware.graph.instance_busy._update_counter_async",
+      counter_mock,
+    ),
+  ):
+    client = TestClient(app_client)
+    with pytest.raises(RuntimeError, match="simulated COPY failure"):
+      client.post(
+        "/databases/graph-123/tables/Entity/materialize",
+        json={"ignore_errors": True},
+      )
+
+  assert counter_mock.await_count == 2
+  deltas = [
+    call.kwargs.get("delta", call.args[1] if len(call.args) > 1 else None)
+    for call in counter_mock.await_args_list
+  ]
+  assert deltas == [1, -1]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/graph_api/routers/databases/tables/test_tables_materialize.py
+++ b/tests/graph_api/routers/databases/tables/test_tables_materialize.py
@@ -35,3 +35,103 @@ def test_materialize_rejects_read_only(monkeypatch, app_client):
 
   assert response.status_code == 403
   assert "not allowed" in response.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# _needs_reconciliation
+# ---------------------------------------------------------------------------
+
+
+def test_needs_reconciliation_returns_false_when_target_unknown():
+  assert materialize._needs_reconciliation(None, ["identifier", "type"]) is False
+
+
+def test_needs_reconciliation_false_when_orders_match():
+  target = [
+    ("identifier", "STRING"),
+    ("category", "STRING"),
+    ("type", "STRING"),
+    ("source", "STRING"),
+    ("confidence", "DOUBLE"),
+  ]
+  source = ["identifier", "category", "type", "source", "confidence"]
+  assert materialize._needs_reconciliation(target, source) is False
+
+
+def test_needs_reconciliation_true_on_set_mismatch():
+  target = [
+    ("identifier", "STRING"),
+    ("category", "STRING"),
+    ("type", "STRING"),
+  ]
+  # Source missing "category" entirely.
+  source = ["identifier", "type"]
+  assert materialize._needs_reconciliation(target, source) is True
+
+
+def test_needs_reconciliation_true_on_order_mismatch_only():
+  """Same column names, different order — must reconcile.
+
+  Regression: a mid-schema ADD COLUMN (e.g. Classification.category) caused
+  DuckDB ALTER TABLE ADD COLUMN to append the new column at the end, while
+  the LadybugDB target had it in position 2. Set comparison missed this and
+  let positional COPY misalign data into the wrong columns.
+  """
+  target = [
+    ("identifier", "STRING"),
+    ("category", "STRING"),
+    ("type", "STRING"),
+    ("source", "STRING"),
+    ("confidence", "DOUBLE"),
+  ]
+  # DuckDB schema-evolved layout: category appended at end.
+  source = ["identifier", "type", "source", "confidence", "category"]
+  assert materialize._needs_reconciliation(target, source) is True
+
+
+def test_needs_reconciliation_ignores_implicit_and_synthetic_cols():
+  """file_id (synthetic) and from/to/src/dst (implicit on rel tables) don't count."""
+  target = [
+    ("prop_a", "STRING"),
+    ("prop_b", "STRING"),
+  ]
+  # Source has from/to and file_id surrounding the props in matching order.
+  source = ["from", "to", "prop_a", "prop_b", "file_id"]
+  assert materialize._needs_reconciliation(target, source) is False
+
+
+# ---------------------------------------------------------------------------
+# _build_reconciled_select
+# ---------------------------------------------------------------------------
+
+
+def test_build_reconciled_select_emits_target_order():
+  """Output SELECT iterates target columns in target order, regardless of source order."""
+  target = [
+    ("identifier", "STRING"),
+    ("category", "STRING"),
+    ("type", "STRING"),
+    ("confidence", "DOUBLE"),
+  ]
+  source = ["identifier", "type", "confidence", "category"]
+  expr = materialize._build_reconciled_select(target, source, "Classification")
+
+  # Strip everything to a list of "AS <name>" tokens to verify order.
+  parts = [p.strip() for p in expr.split(",")]
+  ordered_targets = [
+    p.split(" AS ")[-1].strip().strip('"') for p in parts if " AS " in p
+  ]
+  assert ordered_targets == ["identifier", "category", "type", "confidence"]
+
+
+def test_build_reconciled_select_nulls_missing_target_cols():
+  target = [
+    ("identifier", "STRING"),
+    ("category", "STRING"),  # not in source
+    ("type", "STRING"),
+  ]
+  source = ["identifier", "type"]
+  expr = materialize._build_reconciled_select(target, source, "Classification")
+  assert "NULL::VARCHAR AS category" in expr
+  assert "TRY_CAST(identifier AS VARCHAR)" in expr
+  assert "TRY_CAST(type AS VARCHAR)" in expr


### PR DESCRIPTION
## Summary

This PR fixes materialization issues by adding column order reconciliation between target and source tables, and implementing proper busy counter management during the materialization process. These changes ensure data consistency and accurate tracking of in-progress materialization operations.

## Key Accomplishments

### Column Order Reconciliation
- Added reconciliation logic that aligns target table column order with source column order during materialization. This prevents mismatches when source schema evolves or columns are reordered, ensuring materialized data is correctly mapped.

### Busy Counter Management
- Implemented busy counter increment/decrement lifecycle around the materialization process. The counter is incremented before materialization begins and decremented upon completion (whether successful or failed), providing accurate observability into concurrent materialization activity and preventing resource contention issues.

### Refactored Materialization Pipeline
- Refined the SEC pipeline materialization module (~55 lines changed) to integrate busy counter management cleanly into the existing workflow.
- Extended the Graph API materialization router (~61 lines added/changed) with the reconciliation logic to validate and reorder columns before data is written.

## Breaking Changes

None. The reconciliation and busy counter logic are additive safeguards that do not alter existing public interfaces or data contracts.

## Testing Notes

- Added **187 lines of new tests** covering the materialization reconciliation logic, including:
  - Validation that target columns are reordered to match source column order
  - Edge cases around mismatched schemas
  - Busy counter increment/decrement behavior under success and failure scenarios
- All new tests are located in the existing materialization test suite for the tables router.

## Infrastructure Considerations

- The busy counter mechanism may interact with any monitoring or alerting systems that track materialization concurrency. Teams should verify that dashboards and alerts correctly reflect the new counter semantics.
- No database migrations or infrastructure changes are required; the reconciliation operates at the application layer during materialization execution.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

**Branch Info:**
- Source: `bugfix/materializer-reconcile`
- Target: `main`
- Type: bugfix

Co-Authored-By: Claude <noreply@anthropic.com>