### PR TITLE
fix: Revoke repository access on subscription cancellation

### DIFF
--- a/robosystems/routers/graphs/subscriptions.py
+++ b/robosystems/routers/graphs/subscriptions.py
@@ -22,7 +22,7 @@ from ...models.api.billing.subscription import (
   UpgradeSubscriptionRequest,
 )
 from ...models.api.common import RESOURCE_ERROR_RESPONSES
-from ...models.core import User
+from ...models.core import User, UserRepository
 from ...models.core.billing import BillingAuditLog, BillingCustomer, BillingSubscription
 from ...models.core.billing.audit_log import BillingEventType
 
@@ -663,6 +663,20 @@ async def cancel_repository_subscription(
       )
 
   subscription.cancel(db, immediate=body.immediate)
+
+  user_repo = UserRepository.get_by_user_and_repository(
+    user_id=current_user.id,
+    repository_name=parent_repo_id,
+    session=db,
+  )
+  if user_repo:
+    if body.immediate:
+      user_repo.revoke_access(db)
+    else:
+      user_repo.expires_at = subscription.ends_at
+      user_repo.next_billing_at = None
+      user_repo.updated_at = subscription.updated_at
+      db.commit()
 
   BillingAuditLog.log_event(
     session=db,


### PR DESCRIPTION
## Summary

Fixes a bug where user repository access was not being revoked when a subscription was cancelled. Previously, cancelling a subscription would update the subscription status but fail to remove the user's access to associated repositories, leaving orphaned permissions in place.

## Key Accomplishments

- **Added repository access revocation logic** to the subscription cancellation flow in the subscriptions graph router
- Ensures that when a subscription is cancelled, the user's access to any linked repositories is properly cleaned up
- Closes a security gap where users could retain repository access after their subscription ended

## Changes

- **`robosystems/routers/graphs/subscriptions.py`**: Extended the subscription cancellation handler with ~15 lines of logic to revoke user repository access as part of the cancellation process. This ensures the access lifecycle is properly tied to the subscription lifecycle.

## Breaking Changes

None. This is a purely additive fix that adds missing behavior to an existing cancellation flow.

## Testing Notes

- Verify that cancelling a subscription correctly removes the user's access to all repositories associated with that subscription
- Confirm that active subscriptions are unaffected and repository access remains intact for non-cancelled subscriptions
- Test edge cases:
  - User with multiple subscriptions (only repos tied to the cancelled subscription should lose access)
  - User whose subscription is already cancelled (idempotency)
  - Cancellation of a subscription with no associated repositories (should not error)
- Validate that any downstream services or webhooks that depend on repository access state reflect the updated permissions

## Infrastructure Considerations

- Review whether any caching layers store repository access permissions that may need invalidation upon cancellation
- Consider whether this change needs to be paired with a backfill/migration to revoke access for users whose subscriptions were previously cancelled without this fix in place
- Monitor for any increase in API calls to the repository access management layer after deployment

---
🤖 Generated with [Claude Code](https://claude.ai/code)

**Branch Info:**
- Source: `bugfix/repo-access-on-cancel-fix`
- Target: `main`
- Type: bugfix

Co-Authored-By: Claude <noreply@anthropic.com>