### PR TITLE
Implement Reporting Style composition and change-reporting-style operation

### DIFF
--- a/examples/roboledger_demo/README.md
+++ b/examples/roboledger_demo/README.md
@@ -13,14 +13,16 @@ The demo also initializes a **fiscal calendar** with `closed_through = month_bef
 just start
 
 # Run the demo setup (creates graph, loads data, creates schedules, uploads policies)
-uv run python -m examples.roboledger_demo.main
+just demo-roboledger
 
 # Or load into an existing graph
-uv run python -m examples.roboledger_demo.main <graph_id>
+just demo-roboledger <graph_id>
 
 # Dry run (validate data only)
-uv run python -m examples.roboledger_demo.main --dry-run
+just demo-roboledger --dry-run
 ```
+
+The `just demo-roboledger` recipe sets `ROBOLEDGER_ENABLED=true` and `UV_ENV_FILE` for you. Running `uv run python -m examples.roboledger_demo.main` directly raises `RuntimeError: Extensions database access attempted but no extension domain is enabled` — the extensions DB session is gated behind the per-domain flag.
 
 ## What Gets Created
 

--- a/examples/roboledger_demo/mappings.py
+++ b/examples/roboledger_demo/mappings.py
@@ -1,9 +1,24 @@
 """CoA to FAC mapping definitions for Cascade Advisory Group LLC.
 
-CoA elements map to FAC (Fundamental Accounting Concepts) as the
-primary reporting target. FAC is a small, stable set of high-level
-statement concepts. Deterministic expansion to rs-gaap / us-gaap
-happens via equivalence arcs on the FAC side.
+CoA elements map to FAC (Fundamental Accounting Concepts) — the small,
+stable spine of high-level statement concepts that every rs-gaap
+presentation Network anchors to. The renderer follows the calc DAG
+from each FAC leaf into the rs-gaap detail when one of the Network's
+calculations cites it.
+
+The demo's Reporting Style is the Default Style (§3.2 Phase 1), so the
+target Networks are rs-gaap Classified BS / Multi-step IS / Indirect
+CF / Equity Roll Forward. Each line below maps to a concept that
+appears in those Networks — otherwise the renderer drops the row as
+"out of structure". In particular:
+
+- Operating expenses target ``fac:OperatingExpenses`` (the Multi-step
+  IS concept), not the Single-step's ``fac:CostsAndExpenses``. Without
+  this, the IS would render empty above the bottom line and the
+  NetIncome synthesis would have nothing to bridge.
+- PP&E rolls into ``fac:NoncurrentAssets`` — BS-classified's parent
+  for long-lived assets. The Classified BS Network has no ``FixedAssets``
+  slot (that's a fac-presentation concept, not rs-gaap).
 
 The demo resolves FAC qnames → element IDs at runtime against the
 library in the entity graph.
@@ -17,9 +32,9 @@ MAPPINGS: list[tuple[str, str]] = [
   ("1200", "fac:CurrentAssets"),  # Prepaid Expenses
   ("1210", "fac:CurrentAssets"),
   ("1220", "fac:CurrentAssets"),
-  ("1300", "fac:FixedAssets"),  # PP&E
-  ("1310", "fac:FixedAssets"),
-  ("1350", "fac:FixedAssets"),  # Accumulated Depreciation (contra)
+  ("1300", "fac:NoncurrentAssets"),  # PP&E — Classified BS parent
+  ("1310", "fac:NoncurrentAssets"),
+  ("1350", "fac:NoncurrentAssets"),  # Accumulated Depreciation (contra)
   # Liabilities
   ("2000", "fac:CurrentLiabilities"),  # Accounts Payable
   ("2100", "fac:CurrentLiabilities"),  # Accrued Liabilities
@@ -31,16 +46,20 @@ MAPPINGS: list[tuple[str, str]] = [
   ("4000", "fac:Revenues"),
   ("4100", "fac:Revenues"),
   ("4200", "fac:Revenues"),
-  # Expenses (SG&A rolls into CostsAndExpenses at the FAC level)
-  ("5000", "fac:CostsAndExpenses"),
-  ("5100", "fac:CostsAndExpenses"),
-  ("5200", "fac:CostsAndExpenses"),
-  ("6000", "fac:CostsAndExpenses"),
-  ("6100", "fac:CostsAndExpenses"),
-  ("6200", "fac:CostsAndExpenses"),
-  ("6300", "fac:CostsAndExpenses"),
-  ("6400", "fac:CostsAndExpenses"),
-  ("6500", "fac:CostsAndExpenses"),
-  ("6600", "fac:CostsAndExpenses"),
-  ("7000", "fac:CostsAndExpenses"),  # Depreciation & Amortization
+  # Operating expenses — rs-gaap Multi-step IS anchors on
+  # fac:OperatingExpenses (the SG&A bucket); the calc DAG expands into
+  # rs-gaap leaves via the calc-linkbase bridges. Cascade is a services
+  # company, so nothing here is COGS-natured — everything sits under
+  # OperatingExpenses.
+  ("5000", "fac:OperatingExpenses"),
+  ("5100", "fac:OperatingExpenses"),
+  ("5200", "fac:OperatingExpenses"),
+  ("6000", "fac:OperatingExpenses"),
+  ("6100", "fac:OperatingExpenses"),
+  ("6200", "fac:OperatingExpenses"),
+  ("6300", "fac:OperatingExpenses"),
+  ("6400", "fac:OperatingExpenses"),
+  ("6500", "fac:OperatingExpenses"),
+  ("6600", "fac:OperatingExpenses"),
+  ("7000", "fac:OperatingExpenses"),  # Depreciation & Amortization
 ]

--- a/migrations/extensions/versions/0008_reporting_style.py
+++ b/migrations/extensions/versions/0008_reporting_style.py
@@ -1,0 +1,312 @@
+"""Reporting Style — pick-one-at-provision composition layer.
+
+Phase 1 of roadmap §3.2: every entity graph picks a Reporting Style
+(Charlie Hoffman's term) at provision; the picker reads it deterministically
+to resolve which Network renders each statement type.
+
+This migration is additive:
+
+1. Widen ``structures.check_structure_type`` to admit ``'reporting_style'``
+   (public + every existing tenant schema). Replaces the 0007 widen.
+2. Create ``public.reporting_style_networks`` — the typed composition
+   table ``(reporting_style_id, statement_type) → network_id``. Mirrors
+   into every tenant schema so ``provision_tenant_schema`` (which uses
+   ``CREATE SCHEMA IF NOT EXISTS`` + ``metadata.create_all``) lands the
+   table for fresh tenants and existing tenants get it via the loop.
+3. Promote the three placeholder Style Structures from
+   ``structure_type='custom'`` → ``'reporting_style'`` in **public only**.
+   Existing tenant rows keep their legacy ``'custom'`` type — the picker
+   doesn't filter on the Style's structure_type, and the immutability
+   trigger blocks tenant-scope UPDATE on library-seeded rows. Newly
+   re-provisioned tenants pick up the corrected type from public.
+4. Seed the Default Style's composition (Balance Sheet / Multi-step IS /
+   Indirect CF / Equity Roll Forward) into ``public.reporting_style_networks``.
+
+No prod backfill (Reporting Style hasn't shipped): the platform-side
+``graphs.reporting_style_id`` lands in a sibling migration; local dev
+demos re-provision to pick up the composition in tenant schemas.
+
+Revision ID: 0008
+Revises: 0007
+Create Date: 2026-05-13
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import text
+
+from robosystems.utils.uuid import generate_deterministic_uuid
+
+# revision identifiers, used by Alembic.
+revision = "0008"
+down_revision = "0007"
+branch_labels = None
+depends_on = None
+
+
+# ── Reporting Style + Network role URIs (deterministic, library-seeded) ──
+
+_DEFAULT_STYLE_ROLE = "https://robosystems.ai/seattle/cm-roles/roles/styles/Default"
+_SMALL_PRIVATE_STYLE_ROLE = (
+  "https://robosystems.ai/seattle/cm-roles/roles/styles/SmallPrivateCompany"
+)
+_BANKING_STYLE_ROLE = "https://robosystems.ai/seattle/cm-roles/roles/styles/Banking"
+
+_BS_NETWORK_ROLE = (
+  "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified"
+)
+_IS_NETWORK_ROLE = (
+  "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep"
+)
+_CF_NETWORK_ROLE = (
+  "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect"
+)
+_SE_NETWORK_ROLE = "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward"
+
+
+def _structure_id(role_uri: str) -> str:
+  return generate_deterministic_uuid(role_uri, namespace="structure")
+
+
+# ── structure_type CHECK widen (admit 'reporting_style') ──────────────────
+
+
+_WIDENED_STRUCTURE_TYPE_CHECK = (
+  "structure_type IN ("
+  "'income_statement', 'balance_sheet', "
+  "'cash_flow_statement', 'equity_statement', "
+  "'comprehensive_income', "
+  "'schedule', 'rollforward', 'reconciliation', 'policy', 'metric', "
+  "'chart_of_accounts', 'coa_mapping', "
+  "'validation_rules', 'disclosure', 'taxonomy_mapping', "
+  "'reporting_style', "
+  "'custom'"
+  ")"
+)
+# Same set as 0007's widen — restored on downgrade.
+_PRIOR_STRUCTURE_TYPE_CHECK = (
+  "structure_type IN ("
+  "'income_statement', 'balance_sheet', "
+  "'cash_flow_statement', 'equity_statement', "
+  "'comprehensive_income', "
+  "'schedule', 'rollforward', 'reconciliation', 'policy', 'metric', "
+  "'chart_of_accounts', 'coa_mapping', "
+  "'validation_rules', 'disclosure', 'taxonomy_mapping', "
+  "'custom'"
+  ")"
+)
+
+
+def _widen_structure_type_check(conn, schema: str) -> None:
+  table = "public.structures" if schema == "public" else f'"{schema}".structures'
+  conn.execute(
+    text(f"ALTER TABLE {table} DROP CONSTRAINT IF EXISTS check_structure_type")
+  )
+  conn.execute(
+    text(
+      f"ALTER TABLE {table} ADD CONSTRAINT check_structure_type "
+      f"CHECK ({_WIDENED_STRUCTURE_TYPE_CHECK})"
+    )
+  )
+
+
+def _restore_structure_type_check(conn, schema: str) -> None:
+  table = "public.structures" if schema == "public" else f'"{schema}".structures'
+  conn.execute(
+    text(f"ALTER TABLE {table} DROP CONSTRAINT IF EXISTS check_structure_type")
+  )
+  conn.execute(
+    text(
+      f"ALTER TABLE {table} ADD CONSTRAINT check_structure_type "
+      f"CHECK ({_PRIOR_STRUCTURE_TYPE_CHECK})"
+    )
+  )
+
+
+# ── reporting_style_networks table — tenant-side CREATE ───────────────────
+
+
+_RSN_DDL = """
+  CREATE TABLE IF NOT EXISTS {table} (
+    reporting_style_id VARCHAR NOT NULL,
+    statement_type     VARCHAR NOT NULL,
+    network_id         VARCHAR NOT NULL,
+    created_at         TIMESTAMP NOT NULL DEFAULT now(),
+    created_by         VARCHAR NOT NULL DEFAULT 'library-seeder',
+    CONSTRAINT pk_reporting_style_networks
+      PRIMARY KEY (reporting_style_id, statement_type),
+    CONSTRAINT check_statement_type CHECK (
+      statement_type IN (
+        'balance_sheet', 'income_statement',
+        'cash_flow_statement', 'equity_statement',
+        'comprehensive_income'
+      )
+    )
+  )
+"""
+
+
+def _create_rsn_in_tenant(conn, schema: str) -> None:
+  conn.execute(text(_RSN_DDL.format(table=f'"{schema}".reporting_style_networks')))
+
+
+def _drop_rsn_in_tenant(conn, schema: str) -> None:
+  conn.execute(text(f'DROP TABLE IF EXISTS "{schema}".reporting_style_networks'))
+
+
+# ── Default Style composition rows (seeded in public only) ────────────────
+
+
+_DEFAULT_STYLE_COMPOSITION = [
+  # (statement_type, network_role_uri)
+  ("balance_sheet", _BS_NETWORK_ROLE),
+  ("income_statement", _IS_NETWORK_ROLE),
+  ("cash_flow_statement", _CF_NETWORK_ROLE),
+  ("equity_statement", _SE_NETWORK_ROLE),
+]
+
+
+def _seed_default_style_composition(conn, schema: str) -> None:
+  """Seed the Default Style's 4 composition rows into ``{schema}.reporting_style_networks``.
+
+  Used for both ``public`` (the library template) and every existing
+  tenant schema. Reporting Style hasn't shipped, so this backfill is
+  safe across all tenants — there's no live composition to overwrite.
+  ``ON CONFLICT DO NOTHING`` keeps it idempotent.
+  """
+  default_style_id = _structure_id(_DEFAULT_STYLE_ROLE)
+  table = (
+    "public.reporting_style_networks"
+    if schema == "public"
+    else f'"{schema}".reporting_style_networks'
+  )
+  for statement_type, role in _DEFAULT_STYLE_COMPOSITION:
+    conn.execute(
+      text(
+        f"""
+        INSERT INTO {table} (
+          reporting_style_id, statement_type, network_id, created_by
+        ) VALUES (:style, :stmt, :network, 'library-seeder')
+        ON CONFLICT (reporting_style_id, statement_type) DO NOTHING
+        """
+      ),
+      {
+        "style": default_style_id,
+        "stmt": statement_type,
+        "network": _structure_id(role),
+      },
+    )
+
+
+def _promote_style_structures(conn) -> None:
+  """Flip the 3 placeholder Style Structures in PUBLIC from 'custom' →
+  'reporting_style'. Tenant rows are left untouched: the library
+  immutability trigger blocks tenant-scope UPDATE, and the picker
+  doesn't care about the Style's structure_type. Fresh tenants pick
+  up the corrected type when ``copy_library_into_tenant`` re-mirrors
+  rows from public after this migration runs.
+  """
+  ids = [
+    _structure_id(_DEFAULT_STYLE_ROLE),
+    _structure_id(_SMALL_PRIVATE_STYLE_ROLE),
+    _structure_id(_BANKING_STYLE_ROLE),
+  ]
+  conn.execute(
+    text(
+      """
+      UPDATE public.structures
+      SET structure_type = 'reporting_style'
+      WHERE id = ANY(:ids) AND structure_type = 'custom'
+      """
+    ),
+    {"ids": ids},
+  )
+
+
+def _restore_style_structures(conn) -> None:
+  ids = [
+    _structure_id(_DEFAULT_STYLE_ROLE),
+    _structure_id(_SMALL_PRIVATE_STYLE_ROLE),
+    _structure_id(_BANKING_STYLE_ROLE),
+  ]
+  conn.execute(
+    text(
+      """
+      UPDATE public.structures
+      SET structure_type = 'custom'
+      WHERE id = ANY(:ids) AND structure_type = 'reporting_style'
+      """
+    ),
+    {"ids": ids},
+  )
+
+
+def upgrade() -> None:
+  conn = op.get_bind()
+  from migrations.extensions.helpers import for_each_tenant_schema
+
+  # 1. Widen structure_type CHECK in public + every tenant schema.
+  _widen_structure_type_check(conn, "public")
+  for_each_tenant_schema(conn, _widen_structure_type_check)
+
+  # 2. Create reporting_style_networks table in public (Alembic op).
+  op.create_table(
+    "reporting_style_networks",
+    sa.Column("reporting_style_id", sa.String(), nullable=False),
+    sa.Column("statement_type", sa.String(), nullable=False),
+    sa.Column("network_id", sa.String(), nullable=False),
+    sa.Column(
+      "created_at", sa.DateTime(), nullable=False, server_default=sa.text("now()")
+    ),
+    sa.Column(
+      "created_by",
+      sa.String(),
+      nullable=False,
+      server_default="library-seeder",
+    ),
+    sa.CheckConstraint(
+      "statement_type IN ("
+      "'balance_sheet', 'income_statement', "
+      "'cash_flow_statement', 'equity_statement', "
+      "'comprehensive_income'"
+      ")",
+      name="check_statement_type",
+    ),
+    sa.PrimaryKeyConstraint(
+      "reporting_style_id", "statement_type", name="pk_reporting_style_networks"
+    ),
+  )
+
+  # 3. Create reporting_style_networks in every existing tenant schema.
+  for_each_tenant_schema(conn, _create_rsn_in_tenant)
+
+  # 4. Promote 3 Style Structures in public from 'custom' →
+  # 'reporting_style'. Tenant rows are left alone (immutability trigger).
+  _promote_style_structures(conn)
+
+  # 5. Seed Default Style's composition (BS / IS / CF / SE) into public
+  # AND every existing tenant. Backfilling tenants is safe here because
+  # Reporting Style hasn't shipped — there's no live composition to
+  # overwrite. Production tenants don't exist yet; local dev tenants
+  # need the rows for the picker to resolve a Network.
+  _seed_default_style_composition(conn, "public")
+  for_each_tenant_schema(conn, _seed_default_style_composition)
+
+
+def downgrade() -> None:
+  conn = op.get_bind()
+  from migrations.extensions.helpers import for_each_tenant_schema
+
+  # Reverse step 4 + 5: restore Style structure_types + drop composition rows.
+  conn.execute(text("TRUNCATE TABLE public.reporting_style_networks"))
+  _restore_style_structures(conn)
+
+  # Drop the table in every tenant schema, then in public.
+  for_each_tenant_schema(conn, _drop_rsn_in_tenant)
+  op.drop_table("reporting_style_networks")
+
+  # Reverse the CHECK widen.
+  _restore_structure_type_check(conn, "public")
+  for_each_tenant_schema(conn, _restore_structure_type_check)

--- a/migrations/extensions/versions/0009_facts_fact_set_id_fk.py
+++ b/migrations/extensions/versions/0009_facts_fact_set_id_fk.py
@@ -1,0 +1,89 @@
+"""facts.fact_set_id → fact_sets.id FK (§3.5 Phase 1 of §6.5).
+
+Promotes ``facts.fact_set_id`` from an unconstrained string to a real
+FK against ``fact_sets.id``. Pairs with the create_report /
+create_schedule reorder that now creates the FactSet row before
+stamping facts.
+
+Steps per schema (public + every tenant):
+
+1. NULL out any orphan ``fact_set_id`` values on ``facts`` that don't
+   resolve to an existing FactSet. The pre-§3.5 code path could stamp
+   a ULID on a fact even when ``_create_report_fact_sets``
+   subsequently skipped the row (e.g., facts whose ``period_end`` was
+   NULL). Reporting Style hasn't shipped to prod so the local-dev
+   blast radius is small; we set orphans to NULL rather than try to
+   reconstruct historical FactSets.
+2. Add the FK with ``ON DELETE SET NULL`` so a cascading FactSet
+   delete leaves facts intact (matching the existing pattern where
+   ``report_id`` is also a soft pointer).
+
+Revision ID: 0009
+Revises: 0008
+Create Date: 2026-05-13
+"""
+
+from __future__ import annotations
+
+from alembic import op
+from sqlalchemy import text
+
+# revision identifiers, used by Alembic.
+revision = "0009"
+down_revision = "0008"
+branch_labels = None
+depends_on = None
+
+_FK_NAME = "fk_facts_fact_set_id"
+
+
+def _clean_orphans(conn, schema: str) -> None:
+  table = "public.facts" if schema == "public" else f'"{schema}".facts'
+  fact_sets = "public.fact_sets" if schema == "public" else f'"{schema}".fact_sets'
+  conn.execute(
+    text(
+      f"""
+      UPDATE {table}
+      SET fact_set_id = NULL
+      WHERE fact_set_id IS NOT NULL
+        AND fact_set_id NOT IN (SELECT id FROM {fact_sets})
+      """
+    )
+  )
+
+
+def _add_fk(conn, schema: str) -> None:
+  table = "public.facts" if schema == "public" else f'"{schema}".facts'
+  fact_sets = "public.fact_sets" if schema == "public" else f'"{schema}".fact_sets'
+  conn.execute(text(f"ALTER TABLE {table} DROP CONSTRAINT IF EXISTS {_FK_NAME}"))
+  conn.execute(
+    text(
+      f"ALTER TABLE {table} ADD CONSTRAINT {_FK_NAME} "
+      f"FOREIGN KEY (fact_set_id) REFERENCES {fact_sets} (id) "
+      f"ON DELETE SET NULL"
+    )
+  )
+
+
+def _drop_fk(conn, schema: str) -> None:
+  table = "public.facts" if schema == "public" else f'"{schema}".facts'
+  conn.execute(text(f"ALTER TABLE {table} DROP CONSTRAINT IF EXISTS {_FK_NAME}"))
+
+
+def upgrade() -> None:
+  conn = op.get_bind()
+  from migrations.extensions.helpers import for_each_tenant_schema
+
+  _clean_orphans(conn, "public")
+  for_each_tenant_schema(conn, _clean_orphans)
+
+  _add_fk(conn, "public")
+  for_each_tenant_schema(conn, _add_fk)
+
+
+def downgrade() -> None:
+  conn = op.get_bind()
+  from migrations.extensions.helpers import for_each_tenant_schema
+
+  _drop_fk(conn, "public")
+  for_each_tenant_schema(conn, _drop_fk)

--- a/migrations/platform/versions/17c5e1e50d67_add_reporting_style_id_to_graphs.py
+++ b/migrations/platform/versions/17c5e1e50d67_add_reporting_style_id_to_graphs.py
@@ -39,7 +39,16 @@ def upgrade() -> None:
       server_default=ReportingStyleConstants.DEFAULT_STYLE_ID,
     ),
   )
+  # Supports future "which graphs use style X" queries
+  # (style-deprecation workflows, per-style usage analytics).
+  # Without this index those queries seq-scan the graphs table.
+  op.create_index(
+    "idx_graphs_reporting_style",
+    "graphs",
+    ["reporting_style_id"],
+  )
 
 
 def downgrade() -> None:
+  op.drop_index("idx_graphs_reporting_style", table_name="graphs")
   op.drop_column("graphs", "reporting_style_id")

--- a/migrations/platform/versions/17c5e1e50d67_add_reporting_style_id_to_graphs.py
+++ b/migrations/platform/versions/17c5e1e50d67_add_reporting_style_id_to_graphs.py
@@ -1,0 +1,45 @@
+"""add reporting_style_id to graphs
+
+Phase 1 of roadmap §3.2: every entity graph picks a Reporting Style
+at provision. The value is a Structure id in the per-tenant extensions
+schema (the same deterministic library UUID lives in every tenant's
+``structures`` table); the renderer picker reads this column to resolve
+which Network fills each statement-type slot.
+
+NOT NULL with a server default so the column applies cleanly to any
+existing rows (Postgres uses the default to fill them before enforcing
+NOT NULL). Reporting Style has not shipped to prod, so no separate
+backfill step is required.
+
+Revision ID: 17c5e1e50d67
+Revises: ac32cd15e221
+Create Date: 2026-05-13 00:28:29.528066
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+from robosystems.config.constants import ReportingStyleConstants
+
+# revision identifiers, used by Alembic.
+revision = "17c5e1e50d67"
+down_revision = "ac32cd15e221"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+  op.add_column(
+    "graphs",
+    sa.Column(
+      "reporting_style_id",
+      sa.String(),
+      nullable=False,
+      server_default=ReportingStyleConstants.DEFAULT_STYLE_ID,
+    ),
+  )
+
+
+def downgrade() -> None:
+  op.drop_column("graphs", "reporting_style_id")

--- a/robosystems/config/constants.py
+++ b/robosystems/config/constants.py
@@ -196,6 +196,22 @@ class URIConstants:
   ISO_4217_URI = "http://www.xbrl.org/2003/iso4217"
 
 
+class ReportingStyleConstants:
+  """Reporting Style identifiers (Charlie Hoffman's term).
+
+  Library-seeded Structure UUIDs for the 3 placeholder Reporting Styles
+  declared in ``rs-gaap-reporting-styles/v1``. Each id is derived
+  deterministically from its style's role URI via
+  ``generate_deterministic_uuid(role, namespace='structure')``; pinned
+  here so the platform-side ``graphs.reporting_style_id`` default and
+  the renderer's picker share a single source of truth.
+  """
+
+  DEFAULT_STYLE_ID = "025f5d48-12ce-5d65-b9eb-4f137a10ef06"
+  SMALL_PRIVATE_COMPANY_STYLE_ID = "921f5214-afd8-565c-8189-50bcc94c0234"
+  BANKING_STYLE_ID = "511aeedc-fa99-5fe5-b7f1-67673b7bdb19"
+
+
 class PrefixConstants:
   """Prefix constants for namespacing."""
 

--- a/robosystems/db/extensions.py
+++ b/robosystems/db/extensions.py
@@ -168,6 +168,10 @@ _LIBRARY_IMMUTABLE_TABLES = (
   "classifications",
   "association_classifications",
   "rules",
+  # Reporting Style composition (Phase 1 of §3.2). Library-seeded rows
+  # pin Networks per statement_type for each Style; tenant writes are
+  # blocked so customer-authored Styles use their own non-seeded rows.
+  "reporting_style_networks",
 )
 
 
@@ -265,6 +269,9 @@ def _widen_library_checks(conn, schema: str) -> None:
     # from presentation): formal calculation rules, named SEC/regulatory
     # disclosures, crosswalks between taxonomies.
     "'validation_rules', 'disclosure', 'taxonomy_mapping', "
+    # Reporting Style — the bundle a company picks (Phase 1 of §3.2);
+    # composes Networks per statement_type via reporting_style_networks.
+    "'reporting_style', "
     # Escape hatch
     "'custom'"
     ")"

--- a/robosystems/graphql/context.py
+++ b/robosystems/graphql/context.py
@@ -103,6 +103,11 @@ class GraphQLContext(TypedDict):
   graph_id: str
   schema_extensions: tuple[str, ...]
   graph_type: str
+  # The graph's active Reporting Style (Phase 1 of §3.2). Populated from
+  # the platform DB during context build so resolvers don't reopen a
+  # platform session per render. Empty string for unauthenticated
+  # introspection traffic and the library sentinel.
+  reporting_style_id: str
 
 
 async def get_context(
@@ -147,6 +152,7 @@ async def get_context(
 
   schema_extensions: tuple[str, ...] = ()
   graph_type: str = ""
+  reporting_style_id: str = ""
   if user is not None:
     check_graph_access(user, graph_id)
     # Library sentinel — no graph row to load, no per-graph metadata.
@@ -161,6 +167,7 @@ async def get_context(
       meta = load_graph_metadata(graph_id, db)
       schema_extensions = meta.schema_extensions
       graph_type = meta.graph_type
+      reporting_style_id = meta.reporting_style_id
 
   return {
     "request": request,
@@ -168,6 +175,7 @@ async def get_context(
     "graph_id": graph_id,
     "schema_extensions": schema_extensions,
     "graph_type": graph_type,
+    "reporting_style_id": reporting_style_id,
   }
 
 

--- a/robosystems/graphql/resolvers/ledger.py
+++ b/robosystems/graphql/resolvers/ledger.py
@@ -744,9 +744,12 @@ class LedgerQuery:
     structure_type: str,
   ) -> Statement | None:
     """Rendered financial statement for a report + structure_type."""
+    graph_id = require_graph_id(info)
     try:
       with _open_session(info, "roboledger") as session:
-        response = reads_reports.get_statement(session, report_id, structure_type)
+        response = reads_reports.get_statement(
+          session, graph_id, report_id, structure_type
+        )
     except reads_reports.StatementStructureNotFoundError:
       return None
     except (ValueError, ProgrammingError):

--- a/robosystems/graphql/resolvers/ledger.py
+++ b/robosystems/graphql/resolvers/ledger.py
@@ -745,10 +745,18 @@ class LedgerQuery:
   ) -> Statement | None:
     """Rendered financial statement for a report + structure_type."""
     graph_id = require_graph_id(info)
+    # Reporting Style is pre-loaded onto the context at request build
+    # time (graphql/context.py) so this resolver doesn't reopen a
+    # platform session per render.
+    reporting_style_id = info.context["reporting_style_id"]
     try:
       with _open_session(info, "roboledger") as session:
         response = reads_reports.get_statement(
-          session, graph_id, report_id, structure_type
+          session,
+          graph_id,
+          report_id,
+          structure_type,
+          reporting_style_id=reporting_style_id,
         )
     except reads_reports.StatementStructureNotFoundError:
       return None

--- a/robosystems/middleware/extensions.py
+++ b/robosystems/middleware/extensions.py
@@ -172,11 +172,16 @@ class GraphExtensionContext:
 
   Returned by `require_graph_extension(...)` so callers that already need
   the graph type or extension list don't reload the row.
+
+  ``reporting_style_id`` is included so the §3.2 picker doesn't need to
+  reopen a platform session per render — the statement read path can
+  thread it through from the route / GraphQL context instead.
   """
 
   graph_type: str
   schema_extensions: tuple[str, ...]
   is_repository: bool
+  reporting_style_id: str
 
 
 def load_graph_metadata(graph_id: str, session: Session) -> GraphExtensionContext:
@@ -196,6 +201,7 @@ def load_graph_metadata(graph_id: str, session: Session) -> GraphExtensionContex
     graph_type=graph.graph_type or "",
     schema_extensions=tuple(graph.schema_extensions or []),
     is_repository=bool(graph.is_repository),
+    reporting_style_id=str(graph.reporting_style_id),
   )
 
 

--- a/robosystems/middleware/mcp/tools/taxonomy_tools.py
+++ b/robosystems/middleware/mcp/tools/taxonomy_tools.py
@@ -160,22 +160,29 @@ class SuggestMappingTool:
   def get_tool_definition(self) -> dict[str, Any]:
     return {
       "name": "suggest-mapping",
-      "description": """Find matching US GAAP reporting concepts for a CoA element.
+      "description": """Find matching rs-gaap reporting concepts for a CoA element.
 
 **WHEN TO USE:**
 - When deciding which reporting concept a CoA account should map to
 - Narrows by classification (asset→Assets subtree, revenue→Revenues subtree, etc.)
 
 **HOW IT WORKS:**
-- Reads the shared US GAAP reporting taxonomy (FAC → us-gaap hierarchy)
-- Filters by the same classification as the source element
-- Returns candidate concepts with qname, name, and hierarchy depth
+- Queries rs-gaap elements filtered by the EFS trait (FASB
+  elementsOfFinancialStatements) matching the source element's
+  classification.
+- Restricts to concepts that appear in at least one rs-gaap-presentation
+  Network — any picked target is guaranteed to render on the standard
+  BS / IS / CF / SE reports under the active Reporting Style.
+- Excludes statement-level subtotals whose value comes from rendering
+  (e.g., rs-gaap:Assets, rs-gaap:LiabilitiesCurrent) — those are
+  computed by the calc DAG, not by a leaf fact.
 
 **TIPS:**
-- The classification filter (asset/liability/equity/revenue/expense) narrows candidates by ~80%
-- Depth 1 = high-level line items (Revenue, Cost of Revenue, Operating Expenses)
-- Depth 2 = detail items (R&D, SGA, Depreciation)
-- Abstract elements are grouping nodes — map to non-abstract concepts""",
+- The classification filter (asset / liability / equity / revenue /
+  expense / gain / loss) narrows candidates by ~80%.
+- Depth 1 = high-level line items; depth 2+ = detail items.
+- rs-gaap is the canonical render target (per §3.2 Reporting Style);
+  no longer a target_taxonomy parameter — only one taxonomy renders.""",
       "inputSchema": {
         "type": "object",
         "properties": {

--- a/robosystems/models/api/graphs/operations.py
+++ b/robosystems/models/api/graphs/operations.py
@@ -86,6 +86,31 @@ class DeleteGraphOp(BaseModel):
   )
 
 
+class ChangeReportingStyleOp(BaseModel):
+  """Body for the change-reporting-style operation (Phase 2 of §3.2).
+
+  Switches the graph to a different Reporting Style. The target Style
+  must be a library- or customer-authored Structure with
+  ``structure_type='reporting_style'`` and a complete composition
+  (one Network per required statement type — BS / IS / CF / SE). Filed
+  Reports are unaffected because each ``Report`` already pins its own
+  ``structure_id`` per FactSet at create-time; new reports use the new
+  Style. Idempotent on the same target id.
+  """
+
+  reporting_style_id: str = Field(
+    ...,
+    min_length=1,
+    description=(
+      "Structure id of the target Reporting Style (e.g., "
+      "`025f5d48-12ce-5d65-b9eb-4f137a10ef06` for the library-seeded "
+      "Default Style). Must resolve to a Structure with "
+      "structure_type='reporting_style' that has a complete composition "
+      "in the graph's tenant schema."
+    ),
+  )
+
+
 class MaterializeOp(BaseModel):
   """Body for the materialize operation."""
 

--- a/robosystems/models/core/graph/graph.py
+++ b/robosystems/models/core/graph/graph.py
@@ -35,6 +35,7 @@ from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session, relationship
 
+from robosystems.config.constants import ReportingStyleConstants
 from robosystems.config.graph_tier import GraphTier
 from robosystems.database import Model
 
@@ -176,6 +177,21 @@ class Graph(Model):
   # listed (standard, version) pair is copied from public.* into the tenant
   # schema at provision time. See robosystems/taxonomy/pins.py.
   taxonomy_pin = Column(JSONB, nullable=True)
+
+  # Reporting Style — Charlie Hoffman's term for the bundle a company
+  # picks (e.g. Default / Small Private Company / Banking). The value is
+  # a Structure id in the per-tenant extensions schema; the renderer
+  # picker uses it to resolve which Network fills each statement-type
+  # slot via ``reporting_style_networks``. NOT NULL because every entity
+  # graph must have a Reporting Style the way it has a fiscal year start
+  # month — see ``local/docs/specs/roadmap.md`` §3.2. No DB-level FK
+  # because ``structures`` lives in a separate database (extensions);
+  # validated at application layer.
+  reporting_style_id = Column(
+    String,
+    nullable=False,
+    default=ReportingStyleConstants.DEFAULT_STYLE_ID,
+  )
 
   # Per-graph autopilot for the period-boundary obligation promoter.
   # When False (default — co-pilot), the sensor flips matured `pending`

--- a/robosystems/models/core/graph/graph.py
+++ b/robosystems/models/core/graph/graph.py
@@ -65,6 +65,7 @@ class Graph(Model):
     Index("idx_graphs_stale", "graph_stale"),
     Index("idx_graphs_status", "status"),
     Index("idx_graphs_status_tier_created", "status", "graph_tier", "created_at"),
+    Index("idx_graphs_reporting_style", "reporting_style_id"),
     CheckConstraint(
       "graph_type IN ('generic', 'entity', 'repository')", name="check_graph_type"
     ),

--- a/robosystems/models/extensions/__init__.py
+++ b/robosystems/models/extensions/__init__.py
@@ -28,6 +28,7 @@ from .entity_taxonomy import EntityTaxonomy
 from .framework import Framework
 from .framework_bridge import FrameworkBridge
 from .framework_package import FrameworkPackage
+from .reporting_style_network import ReportingStyleNetwork
 
 # RoboInvestor extension
 from .roboinvestor import (
@@ -95,6 +96,7 @@ __all__ = [
   "PublishListMember",
   "Report",
   "ReportShare",
+  "ReportingStyleNetwork",
   "Rule",
   "Security",
   "Structure",

--- a/robosystems/models/extensions/reporting_style_network.py
+++ b/robosystems/models/extensions/reporting_style_network.py
@@ -1,0 +1,54 @@
+"""ReportingStyleNetwork — Reporting Style → Network composition.
+
+Tenant-scoped junction table. One row per (reporting_style, statement_type)
+pair, pointing at the Network Structure the renderer should use for that
+statement type when this Reporting Style is in effect.
+
+Library-seeded: the Default Style ships with 4 rows (BS / IS / CF / SE)
+pinned to canonical rs-gaap Networks; Small Private Company Style and
+Banking Style ship empty, to be filled in by future library work or
+customer-authored Taxonomy Blocks (Phase 3 of §3.2).
+
+No DB foreign key on ``network_id`` / ``reporting_style_id``: both are
+``Structure.id`` values, validated at the application layer. Library
+immutability triggers (see ``robosystems/db/extensions.py``) block tenant
+writes to library-seeded rows.
+"""
+
+from datetime import UTC, datetime
+
+from sqlalchemy import (
+  CheckConstraint,
+  Column,
+  DateTime,
+  String,
+)
+
+from robosystems.db.extensions import ExtensionsBase
+
+
+class ReportingStyleNetwork(ExtensionsBase):
+  __tablename__ = "reporting_style_networks"
+  __table_args__ = (
+    CheckConstraint(
+      "statement_type IN ("
+      "'balance_sheet', 'income_statement', "
+      "'cash_flow_statement', 'equity_statement', "
+      "'comprehensive_income'"
+      ")",
+      name="check_statement_type",
+    ),
+  )
+
+  reporting_style_id = Column(String, primary_key=True)
+  statement_type = Column(String, primary_key=True)
+  network_id = Column(String, nullable=False)
+
+  created_at = Column(DateTime, nullable=False, default=lambda: datetime.now(UTC))
+  created_by = Column(String, nullable=False, default="library-seeder")
+
+  def __repr__(self) -> str:
+    return (
+      f"<ReportingStyleNetwork {self.reporting_style_id}"
+      f"[{self.statement_type}] → {self.network_id}>"
+    )

--- a/robosystems/models/extensions/roboledger/fact.py
+++ b/robosystems/models/extensions/roboledger/fact.py
@@ -19,6 +19,7 @@ from sqlalchemy import (
   Date,
   DateTime,
   Float,
+  ForeignKey,
   Index,
   String,
   text,
@@ -64,7 +65,14 @@ class Fact(ExtensionsBase):
   unit = Column(String, nullable=False, default="USD")
   entity_id = Column(String, nullable=False)
   structure_id = Column(String, nullable=True)  # structure this fact belongs to
-  fact_set_id = Column(String, nullable=True)  # fact set grouping within structure
+  # FK → fact_sets.id with ON DELETE SET NULL. Soft pointer, like
+  # report_id; the FactSet is created before the fact is stamped
+  # (§3.5/§6.5), so this should never be a dangling reference for new
+  # writes. Historical rows whose ULID didn't resolve were nulled out
+  # by migration 0009 ahead of the FK install.
+  fact_set_id = Column(
+    String, ForeignKey("fact_sets.id", ondelete="SET NULL"), nullable=True
+  )
   # fact_scope distinguishes "historical" (already reflected in opening balances,
   # ignored by close workflow) from "in_scope" (close workflow drafts entries from
   # these). Defaults to 'in_scope' so existing facts and non-schedule facts are

--- a/robosystems/models/extensions/structure.py
+++ b/robosystems/models/extensions/structure.py
@@ -44,6 +44,7 @@ class Structure(ExtensionsBase):
       # Renderable financial-statement presentations (the user-facing forms)
       "'income_statement', 'balance_sheet', "
       "'cash_flow_statement', 'equity_statement', "
+      "'comprehensive_income', "
       # Domain-specific working-paper / schedule patterns
       "'schedule', 'rollforward', 'reconciliation', 'policy', 'metric', "
       # Chart-of-accounts and CoA→GAAP mapping
@@ -57,6 +58,11 @@ class Structure(ExtensionsBase):
       # consumption paths (rule engine, disclosure registry, mapping
       # resolver).
       "'validation_rules', 'disclosure', 'taxonomy_mapping', "
+      # Reporting Style — the bundle a company picks (Charlie Hoffman's
+      # term). One per entity graph, set at provision via
+      # graphs.reporting_style_id; composes Networks per statement_type
+      # via the reporting_style_networks table.
+      "'reporting_style', "
       # Escape hatch for everything that doesn't fit the above
       "'custom'"
       ")",

--- a/robosystems/operations/graph/commands/reporting_style.py
+++ b/robosystems/operations/graph/commands/reporting_style.py
@@ -1,0 +1,160 @@
+"""Change-reporting-style command (Phase 2 of roadmap §3.2).
+
+Synchronous platform-DB update. Validates the target Style is a
+library- or customer-authored Structure with
+``structure_type='reporting_style'`` and has a complete composition
+(one Network per required statement_type) in the graph's tenant
+schema. Then flips ``graphs.reporting_style_id``.
+
+Filed Reports are unaffected — each ``Report``'s FactSet rows already
+pin their ``structure_id`` at create-time, so historical packages
+keep rendering against the Networks they were authored with. New
+reports use the new Style.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import HTTPException
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from robosystems.models.core import User
+from robosystems.models.core.graph import Graph
+
+# The picker iterates over these four statement types at render time;
+# every Reporting Style must compose a Network for each of them.
+# ``comprehensive_income`` stays optional (only used by Styles that
+# split OCI from the regular IS).
+_REQUIRED_STATEMENT_TYPES: tuple[str, ...] = (
+  "balance_sheet",
+  "income_statement",
+  "cash_flow_statement",
+  "equity_statement",
+)
+
+
+async def change_reporting_style_cmd(
+  graph_id: str,
+  new_reporting_style_id: str,
+  current_user: User,
+  db: Session,
+) -> dict[str, Any]:
+  """Switch the graph's Reporting Style.
+
+  Args:
+      graph_id: Target graph (path parameter).
+      new_reporting_style_id: Structure id of the target Style — must
+          exist in the graph's tenant extensions schema with
+          ``structure_type='reporting_style'`` and have a complete
+          composition.
+      current_user: Authenticated caller (graph access already
+          validated upstream by ``get_current_user_with_graph``).
+      db: Platform-DB session.
+
+  Returns:
+      Summary dict with ``graph_id``, ``previous_reporting_style_id``,
+      ``reporting_style_id``, and ``changed`` (False when same target).
+
+  Raises:
+      HTTPException 404: graph not found.
+      HTTPException 422: target Style not found in tenant, has wrong
+          structure_type, or has an incomplete composition.
+  """
+  from robosystems.db.extensions import extensions_session
+
+  graph = Graph.get_by_id(graph_id, db)
+  if not graph:
+    raise HTTPException(status_code=404, detail=f"Graph {graph_id!r} not found")
+
+  previous_style_id = str(graph.reporting_style_id)
+
+  # Same-target is an idempotent no-op so a retry on transient network
+  # error doesn't churn the platform row or surface a spurious change
+  # event downstream.
+  if previous_style_id == new_reporting_style_id:
+    return {
+      "graph_id": graph_id,
+      "previous_reporting_style_id": previous_style_id,
+      "reporting_style_id": new_reporting_style_id,
+      "changed": False,
+    }
+
+  # Validate the target Style in the tenant's extensions schema.
+  # Structure id is library-deterministic for the 3 seeded Styles and
+  # customer-deterministic for taxonomy-block-authored ones, so the
+  # tenant lookup is the only place that can confirm the row exists
+  # and is renderable here.
+  with extensions_session(graph_id) as ext:
+    row = ext.execute(
+      text(
+        """
+        SELECT id, name, structure_type, is_active
+        FROM structures
+        WHERE id = :sid
+        """
+      ),
+      {"sid": new_reporting_style_id},
+    ).fetchone()
+    if row is None:
+      raise HTTPException(
+        status_code=422,
+        detail=(
+          f"Reporting Style {new_reporting_style_id!r} not found in tenant "
+          f"schema for graph {graph_id!r}."
+        ),
+      )
+    # Accept legacy 'custom' rows so existing tenants whose Style rows
+    # weren't promoted by migration 0008 (immutability trigger leaves
+    # tenant copies alone) can still be selected. The picker doesn't
+    # filter on structure_type either.
+    if row.structure_type not in ("reporting_style", "custom"):
+      raise HTTPException(
+        status_code=422,
+        detail=(
+          f"Structure {new_reporting_style_id!r} has structure_type="
+          f"{row.structure_type!r}; expected 'reporting_style'."
+        ),
+      )
+    if not row.is_active:
+      raise HTTPException(
+        status_code=422,
+        detail=f"Reporting Style {new_reporting_style_id!r} is inactive.",
+      )
+
+    composed = {
+      r.statement_type
+      for r in ext.execute(
+        text(
+          """
+          SELECT statement_type FROM reporting_style_networks
+          WHERE reporting_style_id = :sid
+          """
+        ),
+        {"sid": new_reporting_style_id},
+      ).fetchall()
+    }
+    missing = [st for st in _REQUIRED_STATEMENT_TYPES if st not in composed]
+    if missing:
+      raise HTTPException(
+        status_code=422,
+        detail=(
+          f"Reporting Style {new_reporting_style_id!r} has an incomplete "
+          f"composition — missing Network(s) for: {', '.join(missing)}. "
+          f"Author the missing reporting_style_networks rows before "
+          f"switching."
+        ),
+      )
+
+  # All validation passed — flip the platform-DB column.
+  graph.reporting_style_id = new_reporting_style_id
+  db.commit()
+  db.refresh(graph)
+
+  return {
+    "graph_id": graph_id,
+    "previous_reporting_style_id": previous_style_id,
+    "reporting_style_id": new_reporting_style_id,
+    "changed": True,
+  }

--- a/robosystems/operations/graph/commands/reporting_style.py
+++ b/robosystems/operations/graph/commands/reporting_style.py
@@ -49,8 +49,10 @@ async def change_reporting_style_cmd(
           exist in the graph's tenant extensions schema with
           ``structure_type='reporting_style'`` and have a complete
           composition.
-      current_user: Authenticated caller (graph access already
-          validated upstream by ``get_current_user_with_graph``).
+      current_user: Authenticated caller. Must be an organization
+          owner — the Reporting Style governs every render the org
+          produces going forward, so this matches the authorization
+          bar on ``change-tier`` (the other graph-wide settings op).
       db: Platform-DB session.
 
   Returns:
@@ -58,11 +60,27 @@ async def change_reporting_style_cmd(
       ``reporting_style_id``, and ``changed`` (False when same target).
 
   Raises:
+      HTTPException 403: caller is not an org member, or not an owner.
       HTTPException 404: graph not found.
       HTTPException 422: target Style not found in tenant, has wrong
           structure_type, or has an incomplete composition.
   """
   from robosystems.db.extensions import extensions_session
+  from robosystems.models.core import OrgRole, OrgUser
+
+  # Authorization: org owners only. Reporting Style is a graph-wide
+  # setting that affects every render the org sees; matches the
+  # change-tier auth bar (operations/graph/commands/tier.py).
+  user_orgs = OrgUser.get_user_orgs(current_user.id, db)
+  if not user_orgs:
+    raise HTTPException(
+      status_code=403, detail="You are not a member of any organization"
+    )
+  if user_orgs[0].role != OrgRole.OWNER:
+    raise HTTPException(
+      status_code=403,
+      detail="Only organization owners can change the Reporting Style",
+    )
 
   graph = Graph.get_by_id(graph_id, db)
   if not graph:
@@ -114,7 +132,9 @@ async def change_reporting_style_cmd(
         status_code=422,
         detail=(
           f"Structure {new_reporting_style_id!r} has structure_type="
-          f"{row.structure_type!r}; expected 'reporting_style'."
+          f"{row.structure_type!r}; expected 'reporting_style' "
+          f"(or 'custom' for legacy tenants whose Style rows weren't "
+          f"promoted by migration 0008)."
         ),
       )
     if not row.is_active:

--- a/robosystems/operations/roboledger/commands/reports.py
+++ b/robosystems/operations/roboledger/commands/reports.py
@@ -162,6 +162,12 @@ def _build_structure_mapping(
     except NoNetworkForStatementTypeError:
       # Style doesn't compose this statement type — skip silently so a
       # Style that ships without (say) an equity Network still renders.
+      # Safety net: ``change_reporting_style_cmd`` (Phase 2 of §3.2)
+      # validates that every required statement_type has a composition
+      # row before flipping ``graphs.reporting_style_id``, so by the time
+      # this loop runs the only `NoNetworkForStatementTypeError` we
+      # should see is for genuinely optional types (e.g. a Style that
+      # deliberately omits ``comprehensive_income``).
       continue
     picked_structure_ids.append(network.structure_id)
 

--- a/robosystems/operations/roboledger/commands/reports.py
+++ b/robosystems/operations/roboledger/commands/reports.py
@@ -45,6 +45,11 @@ from robosystems.operations.roboledger.reads.reports import (
   resolve_entity_name,
 )
 from robosystems.operations.roboledger.reports.fact_grid import generate_report_facts
+from robosystems.operations.roboledger.reports.network_picker import (
+  NoNetworkForStatementTypeError,
+  get_render_network,
+  load_graph_reporting_style,
+)
 from robosystems.utils.ulid import generate_prefixed_ulid
 
 
@@ -120,137 +125,67 @@ def _evaluate_report_structures(
   return _rule_summary(all_results)
 
 
+_RENDER_TARGET_STATEMENT_TYPES: tuple[str, ...] = (
+  "balance_sheet",
+  "income_statement",
+  "cash_flow_statement",
+  "equity_statement",
+)
+
+
 def _build_structure_mapping(
   session: Session,
-  taxonomy_id: str,
-  mapping_id: str | None = None,
-  arc_type: str = "mapping",
+  reporting_style_id: str,
 ) -> tuple[dict[str, str], dict[str, str]]:
-  """Return (element_id→structure_id, structure_id→fact_set_id) for a taxonomy.
+  """Return (element_id→structure_id, structure_id→fact_set_id) for the
+  Reporting Style composed for this graph.
 
-  Queries associations to find which elements belong to which
-  **render-target** structure (statements + metric), then
-  pre-generates one fact_set_id ULID per structure.
+  Walks ``reporting_style_networks`` to pick one Network per statement
+  type (per §3.2 Phase 1), then enumerates each Network's association
+  rows to map elements → structure id. Pre-generates a fact_set_id
+  ULID per picked structure.
 
-  When ``mapping_id`` is provided, picks **one canonical structure per
-  block_type** by scoring each candidate against the CoA mapping's
-  target elements (the elements the user's Chart of Accounts is mapped
-  to). The structure whose elements have the highest overlap with the
-  mapping wins — that's the variant that best fits the user's data.
-  Without scoring, multiple variants of the same block_type (FAC ships
-  7 IS variants alone) all received elements via dict-overwrite-wins,
-  splitting a coherent statement across multiple incoherent FactSets.
-
-  Excluded by design (block_type filter):
-
-  - **Schedule / rollforward / reconciliation / policy / CoA**: facts
-    for those come from ScheduleService, not reports.
-  - **validation_rules / disclosure / taxonomy_mapping**: XBRL networks
-    with non-rendering roles (formal calculation rules, SEC schedule
-    disclosures, taxonomy crosswalks). Surfaced through their own
-    consumption paths (rule engine, disclosure registry, mapping
-    resolver) — never report-package render targets.
-  - **custom**: too generic to be safe as a default render target.
+  Networks for statement types the Style doesn't compose are skipped
+  silently — a Style is free to omit, say, the comprehensive_income
+  Network. Statement types the renderer asks for that the Style
+  *does* try to render but lacks a composition row for surface as
+  ``NoNetworkForStatementTypeError`` at picker time (the caller wraps
+  the loop and decides whether to fail closed).
   """
+  element_to_structure: dict[str, str] = {}
+  structure_to_factset: dict[str, str] = {}
+  picked_structure_ids: list[str] = []
+
+  for statement_type in _RENDER_TARGET_STATEMENT_TYPES:
+    try:
+      network = get_render_network(session, reporting_style_id, statement_type)
+    except NoNetworkForStatementTypeError:
+      # Style doesn't compose this statement type — skip silently so a
+      # Style that ships without (say) an equity Network still renders.
+      continue
+    picked_structure_ids.append(network.structure_id)
+
+  if not picked_structure_ids:
+    return {}, {}
+
   rows = session.execute(
     text(
       """
       SELECT DISTINCT
-        s.id AS structure_id,
-        s.structure_type,
+        a.structure_id AS structure_id,
         a.to_element_id AS element_id
-      FROM structures s
-      JOIN associations a ON a.structure_id = s.id
-      WHERE s.taxonomy_id = :tid
-        AND s.structure_type IN (
-          'income_statement', 'balance_sheet',
-          'cash_flow_statement', 'equity_statement',
-          'metric'
-        )
-        AND s.is_active = true
+      FROM associations a
+      WHERE a.structure_id = ANY(:struct_ids)
       """
     ),
-    {"tid": taxonomy_id},
+    {"struct_ids": picked_structure_ids},
   ).fetchall()
 
-  if not rows:
-    return {}, {}
-
-  canonical_by_type = _select_canonical_render_targets(
-    session, rows, mapping_id=mapping_id, arc_type=arc_type
-  )
-  canonical_ids = set(canonical_by_type.values())
-
-  element_to_structure: dict[str, str] = {
-    row.element_id: row.structure_id
-    for row in rows
-    if row.structure_id in canonical_ids
-  }
-  structure_to_factset: dict[str, str] = {
-    structure_id: generate_prefixed_ulid("fs") for structure_id in canonical_ids
+  element_to_structure = {row.element_id: row.structure_id for row in rows}
+  structure_to_factset = {
+    sid: generate_prefixed_ulid("fs") for sid in picked_structure_ids
   }
   return element_to_structure, structure_to_factset
-
-
-def _select_canonical_render_targets(
-  session: Session,
-  rows,
-  *,
-  mapping_id: str | None,
-  arc_type: str = "mapping",
-) -> dict[str, str]:
-  """Pick one canonical structure per block_type from the candidate rows.
-
-  When ``mapping_id`` is provided, scores each candidate by counting
-  elements that overlap with the CoA mapping's target element set
-  (associations of the given ``arc_type``: ``'mapping'`` for FAC, or
-  ``'equivalence'`` for rs-gaap). The candidate with the highest
-  overlap wins per block_type — picks the structure whose elements
-  best match what the user's CoA is mapped to.
-
-  When ``mapping_id`` is null or returns no targets, falls back to the
-  candidate with the most elements per block_type (a reasonable proxy
-  for "richest variant"). Final tie-break is the lexicographically
-  smallest structure_id for determinism across runs.
-
-  Returns ``{block_type: structure_id}`` for every block_type that has
-  at least one candidate.
-  """
-  # Group element sets per (structure_type, structure_id)
-  per_struct_elems: dict[tuple[str, str], set[str]] = {}
-  for r in rows:
-    per_struct_elems.setdefault((r.structure_type, r.structure_id), set()).add(
-      r.element_id
-    )
-
-  mapping_targets: set[str] = set()
-  if mapping_id:
-    target_rows = session.execute(
-      text(
-        """
-        SELECT DISTINCT to_element_id AS element_id
-        FROM associations
-        WHERE structure_id = :mid AND association_type = :arc_type
-        """
-      ),
-      {"mid": mapping_id, "arc_type": arc_type},
-    ).fetchall()
-    mapping_targets = {r.element_id for r in target_rows}
-
-  # Per block_type, pick the structure with the highest score.
-  candidates_by_type: dict[str, list[tuple[int, int, str]]] = {}
-  for (block_type, structure_id), elems in per_struct_elems.items():
-    coverage = len(elems & mapping_targets) if mapping_targets else 0
-    size = len(elems)
-    # Sort key: highest coverage, then largest size, then earliest id.
-    candidates_by_type.setdefault(block_type, []).append((coverage, size, structure_id))
-
-  canonical: dict[str, str] = {}
-  for block_type, scored in candidates_by_type.items():
-    # Highest coverage first; ties broken by largest size, then by id (asc).
-    scored.sort(key=lambda t: (-t[0], -t[1], t[2]))
-    canonical[block_type] = scored[0][2]
-  return canonical
 
 
 def _persist_report_facts(
@@ -357,14 +292,6 @@ def create_report(
   if tax_row is None:
     raise TaxonomyNotFoundError(body.taxonomy_id)
 
-  # rs-gaap-presentation reports walk CoA→rs-gaap equivalence arcs;
-  # everything else (fac-presentation, legacy us-gaap) walks CoA→FAC
-  # mapping arcs. The auto-mapper writes both per CoA, so callers don't
-  # need to remap.
-  arc_type = (
-    "equivalence" if (tax_row.standard or "").startswith("rs-gaap") else "mapping"
-  )
-
   periods = build_periods(
     body.period_start, body.period_end, body.comparative, body.periods
   )
@@ -392,8 +319,9 @@ def create_report(
   )
 
   entity_id = _get_entity_id(session, graph_id)
+  reporting_style_id = load_graph_reporting_style(graph_id)
   element_to_structure, structure_to_factset = _build_structure_mapping(
-    session, body.taxonomy_id, mapping_id=body.mapping_id, arc_type=arc_type
+    session, reporting_style_id
   )
   _persist_report_facts(
     session,
@@ -483,18 +411,6 @@ def regenerate_report(
   report_def.generation_status = "generating"
   session.flush()
 
-  # Match create_report's arc-type selection so a regenerate honors the
-  # same FAC-vs-rs-gaap target as the original report.
-  tax_row = session.execute(
-    text("SELECT standard FROM taxonomies WHERE id = :tid LIMIT 1"),
-    {"tid": report_def.taxonomy_id},
-  ).fetchone()
-  arc_type = (
-    "equivalence"
-    if (tax_row and (tax_row.standard or "").startswith("rs-gaap"))
-    else "mapping"
-  )
-
   facts = generate_report_facts(
     session=session,
     taxonomy_id=report_def.taxonomy_id,
@@ -503,11 +419,9 @@ def regenerate_report(
   )
 
   entity_id = _get_entity_id(session, graph_id)
+  reporting_style_id = load_graph_reporting_style(graph_id)
   element_to_structure, structure_to_factset = _build_structure_mapping(
-    session,
-    report_def.taxonomy_id,
-    mapping_id=report_def.mapping_id,
-    arc_type=arc_type,
+    session, reporting_style_id
   )
   # Stale FactSet rows from the prior generation must be cleared before
   # new rows are inserted with freshly-minted ULIDs.

--- a/robosystems/operations/roboledger/commands/reports.py
+++ b/robosystems/operations/roboledger/commands/reports.py
@@ -227,49 +227,54 @@ def _persist_report_facts(
     session.add(rf)
 
 
-def _create_report_fact_sets(
+def _pre_create_report_fact_sets(
   session: Session,
   report_id: str,
   entity_id: str,
   created_by: str,
-  facts,
-  element_to_structure: dict[str, str],
+  periods,
   structure_to_factset: dict[str, str],
 ) -> None:
-  """Insert one FactSet row per statement structure that received facts.
+  """Insert one FactSet row per picked Network — before facts are stamped.
 
-  Period envelope: for comparative reports with multi-period fact sets,
-  the FactSet row spans the outer range (min period_start, max period_end)
-  of the facts actually linked to this structure. This matches the
-  "Block = fragment" model — the IS block is ONE block regardless of how
-  many periods are compared, and the envelope read
-  (`ORDER BY period_end DESC LIMIT 1`) picks the latest FactSet per
-  structure cleanly.
+  Per §3.5/§6.5 of information-block.md: ``create_report`` creates the
+  ``fact_sets`` row first, then stamps facts referencing its id. The
+  period envelope comes from the report's ``periods`` (min start, max
+  end) rather than being derived post-hoc from filtered facts. That
+  pattern keeps the dataflow forward and lets us add a real FK from
+  ``facts.fact_set_id`` → ``fact_sets.id`` without orphan risk.
+
+  Every picked Network gets a FactSet row, even one whose Network the
+  CoA hasn't reached yet (e.g., the demo's CF Network with no
+  cash-flow CoA mappings). The envelope read
+  (``ORDER BY period_end DESC LIMIT 1``) still resolves cleanly per
+  structure; consumers can detect "no facts in this period" by the
+  zero fact_count on the resulting envelope.
   """
-  per_structure: dict[str, list] = {}
-  for f in facts.facts:
-    sid = element_to_structure.get(f.element_id)
-    if sid is not None:
-      per_structure.setdefault(sid, []).append(f)
+  if not periods:
+    return
 
-  for structure_id, struct_facts in per_structure.items():
-    starts = [f.period_start for f in struct_facts if f.period_start is not None]
-    ends = [f.period_end for f in struct_facts if f.period_end is not None]
-    if not ends:
-      # period_end is NOT NULL on fact_sets — skip structures with no dated facts
-      continue
+  starts = [p.start for p in periods if getattr(p, "start", None) is not None]
+  envelope_start = min(starts) if starts else None
+  envelope_end = max(p.end for p in periods)
+
+  for structure_id, fact_set_id in structure_to_factset.items():
     session.add(
       FactSet(
-        id=structure_to_factset[structure_id],
+        id=fact_set_id,
         structure_id=structure_id,
-        period_start=min(starts) if starts else None,
-        period_end=max(ends),
+        period_start=envelope_start,
+        period_end=envelope_end,
         factset_type="report",
         entity_id=entity_id,
         report_id=report_id,
         created_by=created_by,
       )
     )
+  # Explicit flush so the new fact_sets rows hit the DB before the fact
+  # INSERTs that reference them. SQLAlchemy's session-flush ordering is
+  # by INSERT statement type, not by FK dependency.
+  session.flush()
 
 
 def create_report(
@@ -323,20 +328,22 @@ def create_report(
   element_to_structure, structure_to_factset = _build_structure_mapping(
     session, reporting_style_id
   )
+  # §6.5: create fact_sets rows first so the facts we stamp reference
+  # a row that already exists. Lets us enforce facts.fact_set_id →
+  # fact_sets.id at the DB layer (post-§3.5).
+  _pre_create_report_fact_sets(
+    session,
+    report_def.id,
+    entity_id,
+    created_by,
+    periods,
+    structure_to_factset,
+  )
   _persist_report_facts(
     session,
     report_def.id,
     facts,
     entity_id,
-    element_to_structure,
-    structure_to_factset,
-  )
-  _create_report_fact_sets(
-    session,
-    report_def.id,
-    entity_id,
-    created_by,
-    facts,
     element_to_structure,
     structure_to_factset,
   )
@@ -423,26 +430,33 @@ def regenerate_report(
   element_to_structure, structure_to_factset = _build_structure_mapping(
     session, reporting_style_id
   )
-  # Stale FactSet rows from the prior generation must be cleared before
-  # new rows are inserted with freshly-minted ULIDs.
+  # Stale rows from the prior generation must clear before fresh ULIDs
+  # land. Order matters once the facts → fact_sets FK exists (§6.5):
+  # facts go first (they reference fact_sets), then fact_sets. The
+  # ``_persist_report_facts`` call below also DELETEs by report_id —
+  # idempotent here, but doing the explicit fact delete first keeps
+  # the FK ordering correct even before SQLAlchemy autoflushes.
+  session.execute(
+    text("DELETE FROM facts WHERE report_id = :report_id"),
+    {"report_id": report_def.id},
+  )
   session.execute(
     text("DELETE FROM fact_sets WHERE report_id = :report_id"),
     {"report_id": report_def.id},
+  )
+  _pre_create_report_fact_sets(
+    session,
+    report_def.id,
+    entity_id,
+    acting_user_id,
+    periods,
+    structure_to_factset,
   )
   _persist_report_facts(
     session,
     report_def.id,
     facts,
     entity_id,
-    element_to_structure,
-    structure_to_factset,
-  )
-  _create_report_fact_sets(
-    session,
-    report_def.id,
-    entity_id,
-    acting_user_id,
-    facts,
     element_to_structure,
     structure_to_factset,
   )

--- a/robosystems/operations/roboledger/reads/reports.py
+++ b/robosystems/operations/roboledger/reads/reports.py
@@ -93,7 +93,7 @@ def generate_adhoc_private_statement(
   *,
   statement_type: str,
   periods: list[FactPeriodSpec],
-  taxonomy_id: str | None = None,
+  reporting_style_id: str,
 ):
   """Generate an ad-hoc private-company statement directly from OLTP data.
 
@@ -102,10 +102,16 @@ def generate_adhoc_private_statement(
   active CoA→GAAP mapping. Used by the `live-financial-statement`
   operation (both REST and MCP) — no saved Report needed.
 
-  When ``taxonomy_id`` is None, resolves to the rs-gaap-presentation
-  taxonomy (default tenant pin) — gives the renderer a stable target
-  with full Disclosure structures. Callers that want fac-presentation
-  or another taxonomy can pass the id explicitly.
+  The Network is resolved via the graph's Reporting Style composition
+  (§3.2 Phase 1) — the renderer doesn't pick among same-typed structures
+  by recency anymore. Pass ``Graph.reporting_style_id`` from the platform
+  DB.
+
+  ``generate_report_facts`` still wants a ``taxonomy_id`` to scope its
+  CoA→GAAP arc walk; rs-gaap-presentation remains the canonical target
+  taxonomy (every Default Style Network lives in it). Other Styles that
+  cite Networks in a different taxonomy will need this resolved per
+  picked Network in a future commit.
 
   Returns the rendered structure grid plus an `unmapped_count` counter.
   Raises `CoaMappingNotFoundError` if the tenant hasn't completed the
@@ -119,20 +125,17 @@ def generate_adhoc_private_statement(
       "No CoA→GAAP mapping found. Run the mapping workflow first."
     )
 
-  resolved_taxonomy_id = taxonomy_id
-  if resolved_taxonomy_id is None:
-    row = session.execute(
-      text(
-        "SELECT id FROM taxonomies WHERE standard = 'rs-gaap-presentation' "
-        "ORDER BY version DESC LIMIT 1"
-      )
-    ).fetchone()
-    if row is not None:
-      resolved_taxonomy_id = row.id
+  taxonomy_row = session.execute(
+    text(
+      "SELECT id FROM taxonomies WHERE standard = 'rs-gaap-presentation' "
+      "ORDER BY version DESC LIMIT 1"
+    )
+  ).fetchone()
+  resolved_taxonomy_id = taxonomy_row.id if taxonomy_row else ""
 
   facts = generate_report_facts(
     session=session,
-    taxonomy_id=resolved_taxonomy_id or "",
+    taxonomy_id=resolved_taxonomy_id,
     mapping_id=mapping.id,
     periods=periods,
   )
@@ -142,7 +145,7 @@ def generate_adhoc_private_statement(
     facts=facts.facts,
     structure_type=statement_type,
     periods=periods,
-    taxonomy_id=resolved_taxonomy_id,
+    reporting_style_id=reporting_style_id,
   )
 
   return grid, facts.unmapped_count
@@ -395,13 +398,23 @@ def get_report_package(
 
 
 def get_statement(
-  session: Session, report_id: str, structure_type: str
+  session: Session,
+  graph_id: str,
+  report_id: str,
+  structure_type: str,
 ) -> StatementResponse | None:
   """Render a financial statement for a report + structure_type.
 
   Returns `None` when the report itself doesn't exist. Raises
   `StatementStructureNotFoundError` when the structure_type isn't in
   the report's taxonomy. The caller translates both into HTTP 404s.
+
+  ``graph_id`` is required to resolve the graph's Reporting Style (§3.2
+  Phase 1); the picker reads ``Graph.reporting_style_id`` from the
+  platform DB and the renderer uses it to pick the Network for this
+  statement type. Saved Reports don't need to re-pick because Phase 1
+  defers ``change-reporting-style`` to Phase 2 — until then, re-rendering
+  is stable across calls.
   """
   if structure_type not in VALID_STRUCTURE_TYPES:
     raise ValueError(
@@ -478,12 +491,17 @@ def get_statement(
       periods=[PeriodSpec(start=p.start, end=p.end, label=p.label) for p in periods],
     )
 
+  from robosystems.operations.roboledger.reports.network_picker import (
+    load_graph_reporting_style,
+  )
+
+  reporting_style_id = load_graph_reporting_style(graph_id)
   grid = render_structure_view(
     session=session,
     facts=facts,
     structure_type=structure_type,
     periods=periods,
-    taxonomy_id=report_def.taxonomy_id,
+    reporting_style_id=reporting_style_id,
   )
 
   if not grid.structure_id:
@@ -618,11 +636,17 @@ def get_live_financial_statement(
   Raises ``CoaMappingNotFoundError`` when no CoA→GAAP mapping exists;
   the caller translates to a user-facing tip (400/422).
   """
+  from robosystems.operations.roboledger.reports.network_picker import (
+    load_graph_reporting_style,
+  )
+
+  reporting_style_id = load_graph_reporting_style(graph_id)
   periods = build_current_and_prior_periods(period_start, period_end)
   grid, unmapped_count = generate_adhoc_private_statement(
     session,
     statement_type=statement_type,
     periods=periods,
+    reporting_style_id=reporting_style_id,
   )
 
   facts: list[LiveStatementFactRow] = []

--- a/robosystems/operations/roboledger/reads/reports.py
+++ b/robosystems/operations/roboledger/reads/reports.py
@@ -402,6 +402,7 @@ def get_statement(
   graph_id: str,
   report_id: str,
   structure_type: str,
+  reporting_style_id: str | None = None,
 ) -> StatementResponse | None:
   """Render a financial statement for a report + structure_type.
 
@@ -409,12 +410,12 @@ def get_statement(
   `StatementStructureNotFoundError` when the structure_type isn't in
   the report's taxonomy. The caller translates both into HTTP 404s.
 
-  ``graph_id`` is required to resolve the graph's Reporting Style (§3.2
-  Phase 1); the picker reads ``Graph.reporting_style_id`` from the
-  platform DB and the renderer uses it to pick the Network for this
-  statement type. Saved Reports don't need to re-pick because Phase 1
-  defers ``change-reporting-style`` to Phase 2 — until then, re-rendering
-  is stable across calls.
+  ``reporting_style_id`` resolves the graph's active Style (§3.2 Phase 1).
+  Callers with the value already in scope (REST routes via
+  ``GraphExtensionContext``, GraphQL resolvers via ``info.context``)
+  should pass it explicitly to avoid the per-render platform-DB
+  round-trip; if omitted, falls back to ``load_graph_reporting_style``
+  which opens its own platform session.
   """
   if structure_type not in VALID_STRUCTURE_TYPES:
     raise ValueError(
@@ -491,11 +492,12 @@ def get_statement(
       periods=[PeriodSpec(start=p.start, end=p.end, label=p.label) for p in periods],
     )
 
-  from robosystems.operations.roboledger.reports.network_picker import (
-    load_graph_reporting_style,
-  )
+  if reporting_style_id is None:
+    from robosystems.operations.roboledger.reports.network_picker import (
+      load_graph_reporting_style,
+    )
 
-  reporting_style_id = load_graph_reporting_style(graph_id)
+    reporting_style_id = load_graph_reporting_style(graph_id)
   grid = render_structure_view(
     session=session,
     facts=facts,
@@ -625,6 +627,7 @@ def get_live_financial_statement(
   period_start: date,
   period_end: date,
   limit: int = 50,
+  reporting_style_id: str | None = None,
 ) -> LiveFinancialStatementResponse:
   """Generate an OLTP-backed ad-hoc statement and format the response.
 
@@ -633,14 +636,20 @@ def get_live_financial_statement(
   - filters subtotal rows and all-zero rows
   - caps at ``limit`` rows (marking ``truncated=True`` when capped)
 
+  ``reporting_style_id`` resolves the graph's active Style (§3.2 Phase 1).
+  Routes already loading ``GraphExtensionContext`` (which carries it)
+  should pass the value explicitly to skip the platform-DB lookup;
+  callers without it in scope fall back to ``load_graph_reporting_style``.
+
   Raises ``CoaMappingNotFoundError`` when no CoA→GAAP mapping exists;
   the caller translates to a user-facing tip (400/422).
   """
-  from robosystems.operations.roboledger.reports.network_picker import (
-    load_graph_reporting_style,
-  )
+  if reporting_style_id is None:
+    from robosystems.operations.roboledger.reports.network_picker import (
+      load_graph_reporting_style,
+    )
 
-  reporting_style_id = load_graph_reporting_style(graph_id)
+    reporting_style_id = load_graph_reporting_style(graph_id)
   periods = build_current_and_prior_periods(period_start, period_end)
   grid, unmapped_count = generate_adhoc_private_statement(
     session,

--- a/robosystems/operations/roboledger/reads/taxonomies.py
+++ b/robosystems/operations/roboledger/reads/taxonomies.py
@@ -211,10 +211,22 @@ def suggest_mapping_candidates(
   trait: str | None = None,
   element_id: str | None = None,
 ) -> list[ElementResponse]:
-  """Return FAC candidates for a CoA element, narrowed by EFS trait.
+  """Return rs-gaap candidates for a CoA element, narrowed by EFS trait.
 
-  Filters active ``fac`` elements by the FASB
-  elementsOfFinancialStatements trait (via element_traits).
+  Filters active ``rs-gaap`` elements by the FASB
+  elementsOfFinancialStatements trait (via element_traits), restricted
+  to concepts that appear in at least one rs-gaap-presentation Network
+  (so any picked target is guaranteed to render on the standard BS / IS
+  / CF / SE reports under the §3.2 Reporting Style picker). Subtotal
+  rollups whose value comes from rendering, not from a leaf fact, are
+  excluded via ``RS_GAAP_SUBTOTAL_DENYLIST``.
+
+  Per §3.1.5 #3 (closed 2026-05-13): the prior behaviour returned FAC
+  candidates, which made the MappingAgent surface inconsistent with
+  the renderer (rs-gaap is the only render target). Flipping the
+  suggester to rs-gaap-only aligns the typed-API and the renderer; no
+  ``target_taxonomy`` parameter needed.
+
   ``element_id`` is reserved for future per-element overrides but is
   currently unused — trait alone drives the filter.
   """
@@ -222,18 +234,22 @@ def suggest_mapping_candidates(
   if trait is None:
     return []
 
+  # Lazy import to avoid pulling agent constants into every read path.
+  from robosystems.operations.agents.implementations.mapping.constants import (
+    RS_GAAP_SUBTOTAL_DENYLIST,
+  )
+
+  presentation_set = _load_rs_gaap_presentation_set(session)
+
   rows = (
     session.execute(
       select(Element)
       .where(
-        Element.source == "fac",
+        Element.source == "rs-gaap",
         Element.is_active.is_(True),
         Element.id.in_(
           select(ElementTrait.element_id)
-          .join(
-            Trait,
-            Trait.id == ElementTrait.trait_id,
-          )
+          .join(Trait, Trait.id == ElementTrait.trait_id)
           .where(
             Trait.category == "elementsOfFinancialStatements",
             Trait.identifier == trait,
@@ -245,8 +261,16 @@ def suggest_mapping_candidates(
     .scalars()
     .all()
   )
-  efs_map = _efs_by_element(session, [r.id for r in rows])
-  return [element_to_response(r, efs_map.get(r.id)) for r in rows]
+
+  filtered = [
+    r
+    for r in rows
+    if r.qname not in RS_GAAP_SUBTOTAL_DENYLIST
+    and (not presentation_set or r.id in presentation_set)
+  ]
+
+  efs_map = _efs_by_element(session, [r.id for r in filtered])
+  return [element_to_response(r, efs_map.get(r.id)) for r in filtered]
 
 
 def list_unmapped_elements(

--- a/robosystems/operations/roboledger/reads/taxonomies.py
+++ b/robosystems/operations/roboledger/reads/taxonomies.py
@@ -313,16 +313,34 @@ def list_unmapped_elements(
   ]
 
 
+_RS_GAAP_PRESENTATION_SET_ATTR = "_rs_gaap_presentation_set_cache"
+
+
 def _load_rs_gaap_presentation_set(session: Session) -> set[str]:
   """Return the set of element_ids that appear in any
   ``rs-gaap-presentation`` structure (as either parent or child).
 
-  Used by ``expand_to_rs_gaap_candidates`` to restrict auto-mapper
-  targets to concepts that will render on the standard BS/IS/CF
-  reports. Returns an empty set if the presentation taxonomy isn't
-  seeded — caller treats empty as "no filter" so partial deployments
-  still function.
+  Used by ``expand_to_rs_gaap_candidates`` and ``suggest_mapping_candidates``
+  to restrict mapping targets to concepts that will render on the
+  standard BS / IS / CF reports. Returns an empty set if the
+  presentation taxonomy isn't seeded — caller treats empty as "no
+  filter" so partial deployments still function.
+
+  **Cached on the session** under a private attribute. The UNION query
+  walks `associations → structures → taxonomies` twice and is invariant
+  for the lifetime of a tenant session (rs-gaap-presentation is
+  library-seeded and immutable per-tenant). Mapping workflows that
+  invoke ``suggest-mapping`` repeatedly within one HTTP request would
+  otherwise re-execute the same query on each call.
   """
+  # ``isinstance(..., set)`` guards against MagicMock sessions: a vanilla
+  # ``getattr(mock, attr, None)`` returns a fresh MagicMock (not None),
+  # so the sentinel fallback wouldn't fire. The type check returns False
+  # for MagicMock and treats the test session as uncached.
+  cached = getattr(session, _RS_GAAP_PRESENTATION_SET_ATTR, None)
+  if isinstance(cached, set):
+    return cached
+
   rows = session.execute(
     text("""
       SELECT DISTINCT a.from_element_id AS element_id
@@ -338,7 +356,14 @@ def _load_rs_gaap_presentation_set(session: Session) -> set[str]:
       WHERE t.standard = 'rs-gaap-presentation'
     """),
   ).fetchall()
-  return {r.element_id for r in rows}
+  result = {r.element_id for r in rows}
+  try:
+    setattr(session, _RS_GAAP_PRESENTATION_SET_ATTR, result)
+  except (AttributeError, TypeError):
+    # MagicMock sessions in unit tests sometimes reject arbitrary
+    # attribute writes; fall through without caching in that case.
+    pass
+  return result
 
 
 def expand_to_rs_gaap_candidates(

--- a/robosystems/operations/roboledger/reports/fact_grid.py
+++ b/robosystems/operations/roboledger/reports/fact_grid.py
@@ -192,7 +192,7 @@ def render_structure_view(
   facts: list[ReportFact],
   structure_type: str,
   periods: list[PeriodSpec],
-  taxonomy_id: str | None = None,
+  reporting_style_id: str,
 ) -> FactGrid:
   """Apply a structure's hierarchy to raw facts to produce a rendered view.
 
@@ -210,22 +210,20 @@ def render_structure_view(
       facts: Pre-generated ReportFact objects (from generate_report_facts).
       structure_type: Structure type to render (income_statement, balance_sheet, etc.).
       periods: Ordered list of period specifications for columns.
-      taxonomy_id: When set, restricts structure selection to this taxonomy.
-          Multiple taxonomies (FAC, rs-gaap-presentation, etc.) declare the
-          same structure_type; without this filter ``_load_reporting_structure``
-          picks ambiguously. Saved Reports always pass their taxonomy_id;
-          live-statement readers may omit it (legacy behaviour).
+      reporting_style_id: The graph's Reporting Style id
+          (``Graph.reporting_style_id``). Resolves which Network this
+          statement type renders against via the §3.2 picker.
 
   Returns:
       FactGrid with rows ordered per the structure's hierarchy.
   """
-  # Load Disclosure structure + Concept Arrangement Pattern
+  # Load the Network the Style composes for this statement type
   (
     structure_id,
     structure_name,
     concept_arrangement,
     hierarchy,
-  ) = _load_reporting_structure(session, structure_type, taxonomy_id=taxonomy_id)
+  ) = _load_reporting_structure(session, structure_type, reporting_style_id)
 
   if not hierarchy:
     return FactGrid(
@@ -948,59 +946,41 @@ def _infer_period_type(classification: str) -> str:
 def _load_reporting_structure(
   session: Session,
   report_type: str,
-  taxonomy_id: str | None = None,
+  reporting_style_id: str,
 ) -> tuple[str, str, str | None, list[_HierarchyNode]]:
   """Load the reporting structure hierarchy for the given report type.
 
-  When ``taxonomy_id`` is provided, restricts structure selection to
-  that taxonomy — necessary when multiple taxonomies (FAC vs
-  rs-gaap-presentation) declare the same ``structure_type``. Without
-  the filter the query returns whichever row the planner happens to
-  pick first.
+  Resolves the Network deterministically via the Reporting Style
+  composition layer (§3.2 Phase 1) — the renderer never picks among
+  same-typed Structures by recency / heuristics anymore. The Style's
+  ``reporting_style_networks`` row pins exactly one Network per
+  statement_type.
 
   Returns (structure_id, structure_name, concept_arrangement, root_nodes).
   ``concept_arrangement`` is Charlie's CAP declared on the Disclosure
   (``arithmetic`` / ``roll_up`` / ``roll_forward`` / ``hierarchy``);
   the renderer uses it to pick a compilation strategy.
+
+  When the Reporting Style doesn't compose a Network for this statement
+  type, returns the empty tuple — callers treat that as "no statement
+  to render". This matches the prior behaviour of "no matching structure
+  row" so upstream code paths don't need to grow new error branches.
   """
-  # Filter is_active so deactivated/legacy structures are skipped.
-  # Order by created_at DESC so when multiple active structures match
-  # (e.g., during the rs-gaap-presentation Disclosure rebuild's
-  # transition window), the newer one wins — newly authored Disclosures
-  # supersede legacy entries automatically.
-  if taxonomy_id is not None:
-    struct_result = session.execute(
-      text("""
-        SELECT id, name, concept_arrangement FROM structures
-        WHERE structure_type = :report_type
-          AND taxonomy_id = :taxonomy_id
-          AND is_active = true
-        ORDER BY created_at DESC
-        LIMIT 1
-      """),
-      {"report_type": report_type, "taxonomy_id": taxonomy_id},
-    )
-  else:
-    # Legacy callers (live-financial-statement) without an explicit
-    # taxonomy. Picks any matching structure — caller assumes there's
-    # only one or doesn't care which.
-    struct_result = session.execute(
-      text("""
-        SELECT id, name, concept_arrangement FROM structures
-        WHERE structure_type = :report_type
-          AND is_active = true
-        ORDER BY created_at DESC
-        LIMIT 1
-      """),
-      {"report_type": report_type},
-    )
-  struct_row = struct_result.fetchone()
-  if not struct_row:
+  # Lazy import to avoid the picker's `from .. import` chain pulling
+  # commands code into the reads layer at module-import time.
+  from robosystems.operations.roboledger.reports.network_picker import (
+    NoNetworkForStatementTypeError,
+    get_render_network,
+  )
+
+  try:
+    network = get_render_network(session, reporting_style_id, report_type)
+  except NoNetworkForStatementTypeError:
     return "", "", None, []
 
-  structure_id = struct_row.id
-  structure_name = struct_row.name
-  concept_arrangement = struct_row.concept_arrangement
+  structure_id = network.structure_id
+  structure_name = network.name
+  concept_arrangement = network.concept_arrangement
 
   # Load all elements and associations for this structure.
   # Classification is resolved via element_traits → classifications

--- a/robosystems/operations/roboledger/reports/network_picker.py
+++ b/robosystems/operations/roboledger/reports/network_picker.py
@@ -1,0 +1,119 @@
+"""Reporting Style → Network picker (§3.2 Phase 1).
+
+The render-target resolver: given the graph's Reporting Style and a
+statement type, return the Network Structure the renderer should walk.
+Single source of truth for both the saved-report path
+(``commands/reports.py``) and the live-statement path
+(``reports/fact_grid.py``); replaces the prior "latest active by
+structure_type" + CoA-coverage scoring fallbacks.
+
+Composition lives in ``reporting_style_networks`` (one row per
+``(reporting_style_id, statement_type)``); the Default Style ships
+seeded with rs-gaap Classified BS / Multi-step IS / Indirect CF /
+Equity Roll Forward. Other Styles are placeholders until library or
+customer authoring fills them in.
+
+The picker runs strict: a missing composition row raises
+``NoNetworkForStatementTypeError``. Reporting Style hasn't shipped to
+prod, so there's no legacy tenant the picker needs to be lenient with;
+local dev tenants pick up the composition by re-provisioning.
+"""
+
+from dataclasses import dataclass
+
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+
+class NoNetworkForStatementTypeError(LookupError):
+  """Raised when a Reporting Style has no Network composed for this statement."""
+
+  def __init__(self, reporting_style_id: str, statement_type: str) -> None:
+    super().__init__(
+      f"Reporting Style {reporting_style_id} has no Network composed "
+      f"for statement_type={statement_type!r}. Seed the composition in "
+      f"reporting_style_networks (Phase 1 of §3.2)."
+    )
+    self.reporting_style_id = reporting_style_id
+    self.statement_type = statement_type
+
+
+@dataclass(frozen=True)
+class RenderNetwork:
+  """The Network resolved for one (Reporting Style, statement_type) pair."""
+
+  structure_id: str
+  name: str
+  concept_arrangement: str | None
+
+
+def get_render_network(
+  session: Session,
+  reporting_style_id: str,
+  statement_type: str,
+) -> RenderNetwork:
+  """Resolve which Network this Reporting Style composes for the given
+  statement type.
+
+  Single join against ``reporting_style_networks ⋈ structures``. Filters
+  on ``structures.is_active`` so a deactivated Network composition row
+  reads as missing (forces the caller to author a replacement rather
+  than silently rendering against a stale Network).
+
+  Args:
+      session: Extensions database session (tenant schema active via
+          ``SET search_path``). The same session that holds the rest of
+          the renderer's reads — no fan-out to platform DB.
+      reporting_style_id: The graph's ``Graph.reporting_style_id``. The
+          column is NOT NULL with the Default Style as server default,
+          so callers can pass it verbatim.
+      statement_type: One of ``balance_sheet`` / ``income_statement`` /
+          ``cash_flow_statement`` / ``equity_statement`` /
+          ``comprehensive_income``.
+
+  Raises:
+      NoNetworkForStatementTypeError: when the composition row is
+          missing or the target Network is inactive.
+  """
+  row = session.execute(
+    text(
+      """
+      SELECT s.id, s.name, s.concept_arrangement
+      FROM reporting_style_networks rsn
+      JOIN structures s ON s.id = rsn.network_id
+      WHERE rsn.reporting_style_id = :style_id
+        AND rsn.statement_type = :stmt_type
+        AND s.is_active = true
+      """
+    ),
+    {"style_id": reporting_style_id, "stmt_type": statement_type},
+  ).fetchone()
+
+  if row is None:
+    raise NoNetworkForStatementTypeError(reporting_style_id, statement_type)
+
+  return RenderNetwork(
+    structure_id=row.id,
+    name=row.name,
+    concept_arrangement=row.concept_arrangement,
+  )
+
+
+def load_graph_reporting_style(graph_id: str) -> str:
+  """Fetch ``graphs.reporting_style_id`` from the platform DB.
+
+  Helper for callers that have a graph_id but not a platform session.
+  Opens a short-lived session and returns the Style id; the actual
+  picker query runs against the caller's extensions session.
+
+  Raises:
+      LookupError: when the graph doesn't exist or has been deprovisioned.
+  """
+  from robosystems.database import platform_session
+  from robosystems.models.core.graph.graph import Graph
+
+  with platform_session() as pdb:
+    graph = pdb.query(Graph).filter(Graph.graph_id == graph_id).first()
+    if graph is None:
+      raise LookupError(f"Graph {graph_id!r} not found in platform DB.")
+    return str(graph.reporting_style_id)

--- a/robosystems/operations/roboledger/schedules/service.py
+++ b/robosystems/operations/roboledger/schedules/service.py
@@ -242,6 +242,26 @@ class ScheduleService:
     fact_set_id = generate_prefixed_ulid("fs")
     entity_id = self._get_entity_id(session)
 
+    # Block = Fact Set. Per §6.5: create the fact_sets row first so the
+    # facts we stamp below reference an existing parent; lets us enforce
+    # facts.fact_set_id → fact_sets.id as a real FK without orphan risk.
+    # Explicit flush so the FactSet row hits the DB before the bulk
+    # fact INSERTs — SQLAlchemy's session-flush ordering is by INSERT
+    # statement type, not by FK dependency, and would otherwise emit
+    # facts INSERTs ahead of the FactSet row in the same flush.
+    session.add(
+      FactSet(
+        id=fact_set_id,
+        structure_id=structure.id,
+        period_start=period_start,
+        period_end=period_end,
+        factset_type="schedule",
+        entity_id=entity_id,
+        created_by=created_by,
+      )
+    )
+    session.flush()
+
     periods = _generate_monthly_periods(period_start, period_end)
     amount_dollars = round(monthly_amount / 100.0, 2)
     original_dollars = (
@@ -352,20 +372,6 @@ class ScheduleService:
             fact_scope=fact_scope,
           )
         )
-
-    # Block = Fact Set. One fact_sets row per Information Block creation
-    # event; reuses the ULID already stamped on every fact above.
-    session.add(
-      FactSet(
-        id=fact_set_id,
-        structure_id=structure.id,
-        period_start=period_start,
-        period_end=period_end,
-        factset_type="schedule",
-        entity_id=entity_id,
-        created_by=created_by,
-      )
-    )
 
     # Auto-generate a SumEquals rule so the engine can verify that
     # the sum of period debit facts equals original_amount.

--- a/robosystems/routers/extensions/roboledger/reads.py
+++ b/robosystems/routers/extensions/roboledger/reads.py
@@ -119,6 +119,9 @@ async def live_financial_statement_op(
             period_start=start,
             period_end=end,
             limit=body.limit,
+            # Skip the per-render platform-DB lookup — the value is
+            # already on _ext from the require_roboledger dep.
+            reporting_style_id=_ext.reporting_style_id,
           )
         except CoaMappingNotFoundError as exc:
           raise HTTPException(status_code=422, detail=str(exc))

--- a/robosystems/routers/graphs/operations.py
+++ b/robosystems/routers/graphs/operations.py
@@ -36,6 +36,7 @@ from robosystems.middleware.rate_limits import subscription_aware_rate_limit_dep
 from robosystems.models.api.common import OPERATION_ERROR_RESPONSES
 from robosystems.models.api.graphs.backups import BackupCreateRequest
 from robosystems.models.api.graphs.operations import (
+  ChangeReportingStyleOp,
   ChangeTierOp,
   DeleteGraphOp,
   DeleteSubgraphOp,
@@ -834,6 +835,59 @@ async def change_tier_op(
     event=_AUDIT_EVENT,
   )
   return envelope
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# change-reporting-style
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@router.post(
+  "/change-reporting-style",
+  response_model=OperationEnvelope,
+  operation_id="opChangeReportingStyle",
+  summary="Change Reporting Style",
+  description=(
+    "Switches the graph's Reporting Style (Phase 2 of §3.2). Synchronous: "
+    "validates the target Style has a complete composition in the tenant "
+    "schema, then updates `graphs.reporting_style_id`. Filed Reports are "
+    "unaffected; new reports use the new Style. Idempotent on the same id."
+  ),
+  tags=[_OP_TAG],
+  dependencies=[_RATE_LIMIT],
+  responses={**OPERATION_ERROR_RESPONSES},
+)
+@endpoint_metrics_decorator(
+  f"{_GRAPH_OPS_PATH}/change-reporting-style",
+  method="POST",
+  business_event_type="graph_change_reporting_style",
+)
+async def change_reporting_style_op(
+  body: ChangeReportingStyleOp,
+  graph_id: str = Path(..., pattern=GRAPH_OR_SUBGRAPH_ID_PATTERN),
+  user: User = Depends(get_current_user_with_graph),
+  idempotency_key: str | None = Header(None, alias="Idempotency-Key"),
+  cache: IdempotencyCache = Depends(get_idempotency_cache),
+  db: Session = Depends(get_async_db_session),
+) -> OperationEnvelope:
+  from robosystems.operations.graph.commands.reporting_style import (
+    change_reporting_style_cmd,
+  )
+
+  op_name = "change-reporting-style"
+  user_id = str(user.id)
+  ctx = _ctx(
+    graph_id=graph_id,
+    user_id=user_id,
+    op=op_name,
+    idempotency_key=idempotency_key,
+    body=body,
+  )
+
+  async def _runner():
+    return await change_reporting_style_cmd(graph_id, body.reporting_style_id, user, db)
+
+  return await _dispatch(ctx, _runner, cache)
 
 
 # ═══════════════════════════════════════════════════════════════════════════

--- a/robosystems/taxonomy/packages/rs-gaap-reporting-styles/v1/taxonomy.jsonld
+++ b/robosystems/taxonomy/packages/rs-gaap-reporting-styles/v1/taxonomy.jsonld
@@ -68,21 +68,21 @@
       "@id": "_:style-default-structure",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/styles/Default",
       "structureName": "Default Style — Composition",
-      "structureType": "reporting_style",
+      "structureType": "custom",
       "conceptArrangementPattern": "set"
     },
     {
       "@id": "_:style-smallprivate-structure",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/styles/SmallPrivateCompany",
       "structureName": "Small Private Company Style — Composition",
-      "structureType": "reporting_style",
+      "structureType": "custom",
       "conceptArrangementPattern": "set"
     },
     {
       "@id": "_:style-banking-structure",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/styles/Banking",
       "structureName": "Banking Style — Composition (placeholder)",
-      "structureType": "reporting_style",
+      "structureType": "custom",
       "conceptArrangementPattern": "set"
     },
 

--- a/robosystems/taxonomy/packages/rs-gaap-reporting-styles/v1/taxonomy.jsonld
+++ b/robosystems/taxonomy/packages/rs-gaap-reporting-styles/v1/taxonomy.jsonld
@@ -68,21 +68,21 @@
       "@id": "_:style-default-structure",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/styles/Default",
       "structureName": "Default Style — Composition",
-      "structureType": "custom",
+      "structureType": "reporting_style",
       "conceptArrangementPattern": "set"
     },
     {
       "@id": "_:style-smallprivate-structure",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/styles/SmallPrivateCompany",
       "structureName": "Small Private Company Style — Composition",
-      "structureType": "custom",
+      "structureType": "reporting_style",
       "conceptArrangementPattern": "set"
     },
     {
       "@id": "_:style-banking-structure",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/styles/Banking",
       "structureName": "Banking Style — Composition (placeholder)",
-      "structureType": "custom",
+      "structureType": "reporting_style",
       "conceptArrangementPattern": "set"
     },
 

--- a/robosystems/taxonomy/writers/tenant_writer.py
+++ b/robosystems/taxonomy/writers/tenant_writer.py
@@ -81,6 +81,10 @@ _RULE_COLS = (
   "target_taxonomy_id, rule_variables, metadata, created_at, updated_at, created_by"
 )
 
+_REPORTING_STYLE_NETWORK_COLS = (
+  "reporting_style_id, statement_type, network_id, created_at, created_by"
+)
+
 
 @dataclass(frozen=True)
 class CopyStats:
@@ -97,6 +101,7 @@ class CopyStats:
   classifications: int
   association_classifications: int
   rules: int
+  reporting_style_networks: int
 
   @property
   def total(self) -> int:
@@ -112,6 +117,7 @@ class CopyStats:
       + self.classifications
       + self.association_classifications
       + self.rules
+      + self.reporting_style_networks
     )
 
 
@@ -141,7 +147,7 @@ def copy_library_into_tenant(
   """
   resolved_pin = pin if pin is not None else DEFAULT_TAXONOMY_PIN
   if not resolved_pin:
-    return CopyStats(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    return CopyStats(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
 
   # Flatten the pin into a parameterized IN clause via VALUES.
   # E.g., ("fac", "v1"), ("rs-gaap", "v1"), …
@@ -319,6 +325,20 @@ def copy_library_into_tenant(
     pin_params,
   )
 
+  # Reporting Style composition (Phase 1 of §3.2). Each row points at a
+  # Style Structure + a Network Structure that have both been copied into
+  # this tenant — gate on both structure_ids existing locally so an
+  # unpinned package doesn't leave dangling composition references.
+  rsn_result = connection.execute(
+    text(f"""
+      INSERT INTO {schema}.reporting_style_networks ({_REPORTING_STYLE_NETWORK_COLS})
+      SELECT {_REPORTING_STYLE_NETWORK_COLS} FROM public.reporting_style_networks rsn
+      WHERE EXISTS (SELECT 1 FROM {schema}.structures s WHERE s.id = rsn.reporting_style_id)
+        AND EXISTS (SELECT 1 FROM {schema}.structures s WHERE s.id = rsn.network_id)
+      ON CONFLICT (reporting_style_id, statement_type) DO NOTHING
+    """),
+  )
+
   return CopyStats(
     taxonomies=tax_result.rowcount or 0,
     elements=elem_result.rowcount or 0,
@@ -331,4 +351,5 @@ def copy_library_into_tenant(
     classifications=cls_result.rowcount or 0,
     association_classifications=ac_result.rowcount or 0,
     rules=rule_result.rowcount or 0,
+    reporting_style_networks=rsn_result.rowcount or 0,
   )

--- a/tests/config/test_reporting_style_constants.py
+++ b/tests/config/test_reporting_style_constants.py
@@ -1,0 +1,46 @@
+"""Pin ``ReportingStyleConstants`` UUIDs to their deterministic derivation.
+
+The library-seeded Reporting Style ids in ``config/constants.py`` are
+hardcoded for use as the platform-DB default on ``graphs.reporting_style_id``.
+They MUST equal ``generate_deterministic_uuid(role_uri, namespace="structure")``
+or migration 0008's INSERT will write a different id than the platform
+default points at, breaking provisioning silently.
+
+This test pins each constant to its derivation so a typo in either side
+fails CI instead of producing wrong ids that pass validation but never
+resolve to a real row.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from robosystems.config.constants import ReportingStyleConstants
+from robosystems.utils.uuid import generate_deterministic_uuid
+
+_DEFAULT_STYLE_ROLE = "https://robosystems.ai/seattle/cm-roles/roles/styles/Default"
+_SMALL_PRIVATE_STYLE_ROLE = (
+  "https://robosystems.ai/seattle/cm-roles/roles/styles/SmallPrivateCompany"
+)
+_BANKING_STYLE_ROLE = "https://robosystems.ai/seattle/cm-roles/roles/styles/Banking"
+
+
+@pytest.mark.unit
+class TestReportingStyleConstants:
+  def test_default_style_id_matches_derivation(self) -> None:
+    assert (
+      generate_deterministic_uuid(_DEFAULT_STYLE_ROLE, namespace="structure")
+      == ReportingStyleConstants.DEFAULT_STYLE_ID
+    )
+
+  def test_small_private_company_style_id_matches_derivation(self) -> None:
+    assert (
+      generate_deterministic_uuid(_SMALL_PRIVATE_STYLE_ROLE, namespace="structure")
+      == ReportingStyleConstants.SMALL_PRIVATE_COMPANY_STYLE_ID
+    )
+
+  def test_banking_style_id_matches_derivation(self) -> None:
+    assert (
+      generate_deterministic_uuid(_BANKING_STYLE_ROLE, namespace="structure")
+      == ReportingStyleConstants.BANKING_STYLE_ID
+    )

--- a/tests/graphql/extensions/test_context.py
+++ b/tests/graphql/extensions/test_context.py
@@ -39,6 +39,7 @@ def _entity_meta(
     graph_type="entity",
     schema_extensions=extensions,
     is_repository=False,
+    reporting_style_id="025f5d48-12ce-5d65-b9eb-4f137a10ef06",
   )
 
 

--- a/tests/middleware/mcp/test_gate.py
+++ b/tests/middleware/mcp/test_gate.py
@@ -24,6 +24,8 @@ from robosystems.middleware.mcp.tools._gate import (
   require_not_repository_mcp,
 )
 
+_FAKE_STYLE_ID = "025f5d48-12ce-5d65-b9eb-4f137a10ef06"
+
 
 def _entity_meta(
   extensions=("roboledger",), graph_type="entity"
@@ -32,6 +34,7 @@ def _entity_meta(
     graph_type=graph_type,
     schema_extensions=tuple(extensions),
     is_repository=False,
+    reporting_style_id=_FAKE_STYLE_ID,
   )
 
 
@@ -40,6 +43,7 @@ def _repo_meta() -> GraphExtensionContext:
     graph_type="repository",
     schema_extensions=("roboledger",),
     is_repository=True,
+    reporting_style_id=_FAKE_STYLE_ID,
   )
 
 
@@ -85,6 +89,7 @@ class TestRequireGraphExtensionMCP:
       graph_type="repository",
       schema_extensions=(),  # no extensions
       is_repository=True,
+      reporting_style_id=_FAKE_STYLE_ID,
     )
     with pytest.raises(MCPExtensionGateError) as exc:
       require_graph_extension_mcp(

--- a/tests/middleware/mcp/tools/test_taxonomy_tools.py
+++ b/tests/middleware/mcp/tools/test_taxonomy_tools.py
@@ -161,22 +161,24 @@ class TestSuggestMappingTool:
     source = _element(
       id="elem_1", name="Product Revenue", trait="revenue", source="quickbooks"
     )
+    # Post-§3.1.5 #3: suggest-mapping returns rs-gaap candidates only
+    # (the §3.2 Reporting Style picker targets rs-gaap Networks).
     candidates = [
       _element(
         id="gaap_1",
-        qname="fac:Revenues",
-        name="Revenues",
-        source="fac",
+        qname="rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax",
+        name="Revenue From Contract With Customer (Excluding Assessed Tax)",
+        source="rs-gaap",
         trait="revenue",
-        is_abstract=True,
+        depth=2,
       ),
       _element(
         id="gaap_2",
-        qname="us-gaap:Revenues",
-        name="Revenue",
-        source="us-gaap",
+        qname="rs-gaap:SalesRevenueNet",
+        name="Sales Revenue, Net",
+        source="rs-gaap",
         trait="revenue",
-        depth=1,
+        depth=2,
       ),
     ]
 
@@ -189,7 +191,8 @@ class TestSuggestMappingTool:
 
     assert result["source_element"]["name"] == "Product Revenue"
     assert len(result["candidates"]) == 2
-    assert result["candidates"][0]["qname"] == "fac:Revenues"
+    assert result["candidates"][0]["qname"].startswith("rs-gaap:")
+    assert all(c["source"] == "rs-gaap" for c in result["candidates"])
 
   @pytest.mark.asyncio
   async def test_returns_error_for_missing_element(self, mock_graph_client):

--- a/tests/operations/graph/test_reporting_style_command.py
+++ b/tests/operations/graph/test_reporting_style_command.py
@@ -1,0 +1,220 @@
+# pyright: reportGeneralTypeIssues=false, reportArgumentType=false
+"""Tests for ``change_reporting_style_cmd`` (Phase 2 of §3.2)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from robosystems.operations.graph.commands.reporting_style import (
+  _REQUIRED_STATEMENT_TYPES,
+  change_reporting_style_cmd,
+)
+
+_GRAPH = "robosystems.models.core.graph.Graph"
+_EXT_SESSION = "robosystems.db.extensions.extensions_session"
+
+GRAPH_ID = "kg19e1f9744ea2a8ab4ef7"
+DEFAULT_STYLE_ID = "025f5d48-12ce-5d65-b9eb-4f137a10ef06"
+SMALL_PRIVATE_STYLE_ID = "921f5214-afd8-565c-8189-50bcc94c0234"
+
+
+def _make_graph(reporting_style_id: str = DEFAULT_STYLE_ID):
+  g = MagicMock()
+  g.graph_id = GRAPH_ID
+  g.reporting_style_id = reporting_style_id
+  return g
+
+
+def _make_user():
+  user = MagicMock()
+  user.id = "user_abc"
+  return user
+
+
+def _make_ext_session(
+  *,
+  style_row: MagicMock | None,
+  composed_types: list[str] | None,
+):
+  """Build a context-manager mock that yields a session whose execute
+  returns the configured style row + composition rows."""
+  session = MagicMock()
+
+  def execute_side(stmt, params=None):
+    sql = str(stmt)
+    result = MagicMock()
+    if "FROM structures" in sql:
+      result.fetchone.return_value = style_row
+    elif "FROM reporting_style_networks" in sql:
+      if composed_types is None:
+        result.fetchall.return_value = []
+      else:
+        result.fetchall.return_value = [
+          MagicMock(statement_type=st) for st in composed_types
+        ]
+    else:
+      result.fetchone.return_value = None
+      result.fetchall.return_value = []
+    return result
+
+  session.execute.side_effect = execute_side
+  cm = MagicMock()
+  cm.__enter__.return_value = session
+  cm.__exit__.return_value = False
+  return cm
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+class TestChangeReportingStyleCmd:
+  async def test_same_target_is_idempotent_noop(self):
+    db = MagicMock()
+    user = _make_user()
+    with patch(f"{_GRAPH}.get_by_id", return_value=_make_graph(DEFAULT_STYLE_ID)):
+      result = await change_reporting_style_cmd(GRAPH_ID, DEFAULT_STYLE_ID, user, db)
+
+    assert result["changed"] is False
+    assert result["previous_reporting_style_id"] == DEFAULT_STYLE_ID
+    assert result["reporting_style_id"] == DEFAULT_STYLE_ID
+    # Never touches the platform-DB row when the target is the same.
+    db.commit.assert_not_called()
+
+  async def test_unknown_graph_404(self):
+    db = MagicMock()
+    user = _make_user()
+    with patch(f"{_GRAPH}.get_by_id", return_value=None):
+      with pytest.raises(HTTPException) as ctx:
+        await change_reporting_style_cmd(GRAPH_ID, SMALL_PRIVATE_STYLE_ID, user, db)
+    assert ctx.value.status_code == 404
+
+  async def test_unknown_target_style_422(self):
+    db = MagicMock()
+    user = _make_user()
+    ext_cm = _make_ext_session(style_row=None, composed_types=None)
+    with (
+      patch(f"{_GRAPH}.get_by_id", return_value=_make_graph(DEFAULT_STYLE_ID)),
+      patch(_EXT_SESSION, return_value=ext_cm),
+    ):
+      with pytest.raises(HTTPException) as ctx:
+        await change_reporting_style_cmd(GRAPH_ID, "nonexistent-style-id", user, db)
+    assert ctx.value.status_code == 422
+    assert "not found" in ctx.value.detail.lower()
+    db.commit.assert_not_called()
+
+  async def test_wrong_structure_type_422(self):
+    db = MagicMock()
+    user = _make_user()
+    row = MagicMock()
+    row.id = "wrong-type-id"
+    row.name = "Some Random Structure"
+    row.structure_type = "balance_sheet"  # not a Reporting Style
+    row.is_active = True
+    ext_cm = _make_ext_session(style_row=row, composed_types=None)
+    with (
+      patch(f"{_GRAPH}.get_by_id", return_value=_make_graph(DEFAULT_STYLE_ID)),
+      patch(_EXT_SESSION, return_value=ext_cm),
+    ):
+      with pytest.raises(HTTPException) as ctx:
+        await change_reporting_style_cmd(GRAPH_ID, "wrong-type-id", user, db)
+    assert ctx.value.status_code == 422
+    assert "structure_type" in ctx.value.detail
+
+  async def test_inactive_target_422(self):
+    db = MagicMock()
+    user = _make_user()
+    row = MagicMock()
+    row.id = SMALL_PRIVATE_STYLE_ID
+    row.name = "Small Private Company Style"
+    row.structure_type = "reporting_style"
+    row.is_active = False
+    ext_cm = _make_ext_session(style_row=row, composed_types=None)
+    with (
+      patch(f"{_GRAPH}.get_by_id", return_value=_make_graph(DEFAULT_STYLE_ID)),
+      patch(_EXT_SESSION, return_value=ext_cm),
+    ):
+      with pytest.raises(HTTPException) as ctx:
+        await change_reporting_style_cmd(GRAPH_ID, SMALL_PRIVATE_STYLE_ID, user, db)
+    assert ctx.value.status_code == 422
+    assert "inactive" in ctx.value.detail.lower()
+
+  async def test_incomplete_composition_422(self):
+    """Missing one of BS / IS / CF / SE rejects the switch with the
+    list of missing statement types in the detail."""
+    db = MagicMock()
+    user = _make_user()
+    row = MagicMock()
+    row.id = SMALL_PRIVATE_STYLE_ID
+    row.name = "Small Private Company Style"
+    row.structure_type = "reporting_style"
+    row.is_active = True
+    # Only BS + IS composed; CF + SE missing.
+    ext_cm = _make_ext_session(
+      style_row=row, composed_types=["balance_sheet", "income_statement"]
+    )
+    with (
+      patch(f"{_GRAPH}.get_by_id", return_value=_make_graph(DEFAULT_STYLE_ID)),
+      patch(_EXT_SESSION, return_value=ext_cm),
+    ):
+      with pytest.raises(HTTPException) as ctx:
+        await change_reporting_style_cmd(GRAPH_ID, SMALL_PRIVATE_STYLE_ID, user, db)
+    assert ctx.value.status_code == 422
+    assert "cash_flow_statement" in ctx.value.detail
+    assert "equity_statement" in ctx.value.detail
+    db.commit.assert_not_called()
+
+  async def test_happy_path_flips_column(self):
+    db = MagicMock()
+    user = _make_user()
+    graph = _make_graph(DEFAULT_STYLE_ID)
+    row = MagicMock()
+    row.id = SMALL_PRIVATE_STYLE_ID
+    row.name = "Small Private Company Style"
+    row.structure_type = "reporting_style"
+    row.is_active = True
+    ext_cm = _make_ext_session(
+      style_row=row, composed_types=list(_REQUIRED_STATEMENT_TYPES)
+    )
+    with (
+      patch(f"{_GRAPH}.get_by_id", return_value=graph),
+      patch(_EXT_SESSION, return_value=ext_cm),
+    ):
+      result = await change_reporting_style_cmd(
+        GRAPH_ID, SMALL_PRIVATE_STYLE_ID, user, db
+      )
+
+    assert result["changed"] is True
+    assert result["previous_reporting_style_id"] == DEFAULT_STYLE_ID
+    assert result["reporting_style_id"] == SMALL_PRIVATE_STYLE_ID
+    # The platform-DB row got flipped.
+    assert graph.reporting_style_id == SMALL_PRIVATE_STYLE_ID
+    db.commit.assert_called_once()
+    db.refresh.assert_called_once_with(graph)
+
+  async def test_legacy_custom_structure_type_accepted(self):
+    """Existing tenants whose 3 Style rows weren't promoted by 0008
+    (immutability trigger leaves tenant copies as 'custom') can still
+    be selected — the picker doesn't filter on structure_type either."""
+    db = MagicMock()
+    user = _make_user()
+    graph = _make_graph(DEFAULT_STYLE_ID)
+    row = MagicMock()
+    row.id = SMALL_PRIVATE_STYLE_ID
+    row.name = "Small Private Company Style — Composition"
+    row.structure_type = "custom"  # legacy tenant row
+    row.is_active = True
+    ext_cm = _make_ext_session(
+      style_row=row, composed_types=list(_REQUIRED_STATEMENT_TYPES)
+    )
+    with (
+      patch(f"{_GRAPH}.get_by_id", return_value=graph),
+      patch(_EXT_SESSION, return_value=ext_cm),
+    ):
+      result = await change_reporting_style_cmd(
+        GRAPH_ID, SMALL_PRIVATE_STYLE_ID, user, db
+      )
+
+    assert result["changed"] is True
+    assert graph.reporting_style_id == SMALL_PRIVATE_STYLE_ID

--- a/tests/operations/graph/test_reporting_style_command.py
+++ b/tests/operations/graph/test_reporting_style_command.py
@@ -15,6 +15,7 @@ from robosystems.operations.graph.commands.reporting_style import (
 
 _GRAPH = "robosystems.models.core.graph.Graph"
 _EXT_SESSION = "robosystems.db.extensions.extensions_session"
+_ORG_USER = "robosystems.models.core.OrgUser"
 
 GRAPH_ID = "kg19e1f9744ea2a8ab4ef7"
 DEFAULT_STYLE_ID = "025f5d48-12ce-5d65-b9eb-4f137a10ef06"
@@ -32,6 +33,21 @@ def _make_user():
   user = MagicMock()
   user.id = "user_abc"
   return user
+
+
+def _patch_owner_membership():
+  """Patch ``OrgUser.get_user_orgs`` to return a single OWNER membership.
+
+  Every command path runs the auth check first; tests that exercise
+  downstream behavior (404, 422, happy path) must set this up so the
+  call doesn't 403 before reaching the validation under test.
+  """
+  from robosystems.models.core import OrgRole
+
+  membership = MagicMock()
+  membership.role = OrgRole.OWNER
+  membership.org_id = "org_123"
+  return patch(f"{_ORG_USER}.get_user_orgs", return_value=[membership])
 
 
 def _make_ext_session(
@@ -70,10 +86,40 @@ def _make_ext_session(
 @pytest.mark.asyncio
 @pytest.mark.unit
 class TestChangeReportingStyleCmd:
+  async def test_non_member_rejected_403(self):
+    """User with no organization memberships is rejected before any
+    graph lookup runs — the auth check fires first."""
+    db = MagicMock()
+    user = _make_user()
+    with patch(f"{_ORG_USER}.get_user_orgs", return_value=[]):
+      with pytest.raises(HTTPException) as ctx:
+        await change_reporting_style_cmd(GRAPH_ID, DEFAULT_STYLE_ID, user, db)
+    assert ctx.value.status_code == 403
+    assert "member" in ctx.value.detail.lower()
+
+  async def test_non_owner_rejected_403(self):
+    """Org members who are not owners cannot change the Reporting
+    Style — matches the change-tier authorization bar."""
+    from robosystems.models.core import OrgRole
+
+    db = MagicMock()
+    user = _make_user()
+    membership = MagicMock()
+    membership.role = OrgRole.ADMIN
+    membership.org_id = "org_123"
+    with patch(f"{_ORG_USER}.get_user_orgs", return_value=[membership]):
+      with pytest.raises(HTTPException) as ctx:
+        await change_reporting_style_cmd(GRAPH_ID, DEFAULT_STYLE_ID, user, db)
+    assert ctx.value.status_code == 403
+    assert "owner" in ctx.value.detail.lower()
+
   async def test_same_target_is_idempotent_noop(self):
     db = MagicMock()
     user = _make_user()
-    with patch(f"{_GRAPH}.get_by_id", return_value=_make_graph(DEFAULT_STYLE_ID)):
+    with (
+      _patch_owner_membership(),
+      patch(f"{_GRAPH}.get_by_id", return_value=_make_graph(DEFAULT_STYLE_ID)),
+    ):
       result = await change_reporting_style_cmd(GRAPH_ID, DEFAULT_STYLE_ID, user, db)
 
     assert result["changed"] is False
@@ -85,7 +131,7 @@ class TestChangeReportingStyleCmd:
   async def test_unknown_graph_404(self):
     db = MagicMock()
     user = _make_user()
-    with patch(f"{_GRAPH}.get_by_id", return_value=None):
+    with _patch_owner_membership(), patch(f"{_GRAPH}.get_by_id", return_value=None):
       with pytest.raises(HTTPException) as ctx:
         await change_reporting_style_cmd(GRAPH_ID, SMALL_PRIVATE_STYLE_ID, user, db)
     assert ctx.value.status_code == 404
@@ -95,6 +141,7 @@ class TestChangeReportingStyleCmd:
     user = _make_user()
     ext_cm = _make_ext_session(style_row=None, composed_types=None)
     with (
+      _patch_owner_membership(),
       patch(f"{_GRAPH}.get_by_id", return_value=_make_graph(DEFAULT_STYLE_ID)),
       patch(_EXT_SESSION, return_value=ext_cm),
     ):
@@ -114,6 +161,7 @@ class TestChangeReportingStyleCmd:
     row.is_active = True
     ext_cm = _make_ext_session(style_row=row, composed_types=None)
     with (
+      _patch_owner_membership(),
       patch(f"{_GRAPH}.get_by_id", return_value=_make_graph(DEFAULT_STYLE_ID)),
       patch(_EXT_SESSION, return_value=ext_cm),
     ):
@@ -121,6 +169,10 @@ class TestChangeReportingStyleCmd:
         await change_reporting_style_cmd(GRAPH_ID, "wrong-type-id", user, db)
     assert ctx.value.status_code == 422
     assert "structure_type" in ctx.value.detail
+    # Legacy hint mentioned so tenants whose Style rows weren't
+    # promoted by migration 0008 know 'custom' is also accepted.
+    assert "custom" in ctx.value.detail
+    assert "legacy" in ctx.value.detail
 
   async def test_inactive_target_422(self):
     db = MagicMock()
@@ -132,6 +184,7 @@ class TestChangeReportingStyleCmd:
     row.is_active = False
     ext_cm = _make_ext_session(style_row=row, composed_types=None)
     with (
+      _patch_owner_membership(),
       patch(f"{_GRAPH}.get_by_id", return_value=_make_graph(DEFAULT_STYLE_ID)),
       patch(_EXT_SESSION, return_value=ext_cm),
     ):
@@ -155,6 +208,7 @@ class TestChangeReportingStyleCmd:
       style_row=row, composed_types=["balance_sheet", "income_statement"]
     )
     with (
+      _patch_owner_membership(),
       patch(f"{_GRAPH}.get_by_id", return_value=_make_graph(DEFAULT_STYLE_ID)),
       patch(_EXT_SESSION, return_value=ext_cm),
     ):
@@ -178,6 +232,7 @@ class TestChangeReportingStyleCmd:
       style_row=row, composed_types=list(_REQUIRED_STATEMENT_TYPES)
     )
     with (
+      _patch_owner_membership(),
       patch(f"{_GRAPH}.get_by_id", return_value=graph),
       patch(_EXT_SESSION, return_value=ext_cm),
     ):
@@ -209,6 +264,7 @@ class TestChangeReportingStyleCmd:
       style_row=row, composed_types=list(_REQUIRED_STATEMENT_TYPES)
     )
     with (
+      _patch_owner_membership(),
       patch(f"{_GRAPH}.get_by_id", return_value=graph),
       patch(_EXT_SESSION, return_value=ext_cm),
     ):

--- a/tests/operations/roboledger/commands/test_reports.py
+++ b/tests/operations/roboledger/commands/test_reports.py
@@ -3,13 +3,16 @@
 from __future__ import annotations
 
 from datetime import date
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from robosystems.operations.roboledger.commands.reports import (
   _build_structure_mapping,
   _create_report_fact_sets,
   _persist_report_facts,
-  _select_canonical_render_targets,
+)
+from robosystems.operations.roboledger.reports.network_picker import (
+  NoNetworkForStatementTypeError,
+  RenderNetwork,
 )
 
 
@@ -36,241 +39,96 @@ class _FakeFacts:
     self.facts = facts
 
 
-def test_build_structure_mapping_filters_report_eligible_types() -> None:
-  """The SQL query must restrict to statement/metric types and route
-  facts to one canonical structure per block_type."""
-  session = MagicMock()
-  rows = [
-    MagicMock(
-      structure_id="struct_is",
-      structure_type="income_statement",
-      element_id="elem_rev",
-    ),
-    MagicMock(
-      structure_id="struct_is",
-      structure_type="income_statement",
-      element_id="elem_cogs",
-    ),
-    MagicMock(
-      structure_id="struct_bs",
-      structure_type="balance_sheet",
-      element_id="elem_cash",
-    ),
-  ]
-  session.execute.return_value.fetchall.return_value = rows
+_PICKER_PATH = "robosystems.operations.roboledger.commands.reports.get_render_network"
 
-  elem_map, fs_map = _build_structure_mapping(session, "tax_01")
+
+def test_build_structure_mapping_resolves_each_statement_type_via_picker() -> None:
+  """The picker returns one Network per statement_type; element rows for
+  each picked Network land in the element→structure dict, and one ULID
+  is minted per picked structure_id."""
+  session = MagicMock()
+
+  picked = {
+    "balance_sheet": RenderNetwork("struct_bs", "BS", "roll_up"),
+    "income_statement": RenderNetwork("struct_is", "IS", "arithmetic"),
+    "cash_flow_statement": RenderNetwork("struct_cf", "CF", "arithmetic"),
+    "equity_statement": RenderNetwork("struct_se", "SE", "roll_forward"),
+  }
+
+  def fake_picker(_session, _style_id, stmt_type):
+    return picked[stmt_type]
+
+  # Associations query: 1 row per (structure_id, element_id) — one
+  # element per picked Network keeps the test legible.
+  element_rows = [
+    MagicMock(structure_id="struct_bs", element_id="elem_cash"),
+    MagicMock(structure_id="struct_is", element_id="elem_rev"),
+    MagicMock(structure_id="struct_cf", element_id="elem_op_cash"),
+    MagicMock(structure_id="struct_se", element_id="elem_re"),
+  ]
+  session.execute.return_value.fetchall.return_value = element_rows
+
+  with patch(_PICKER_PATH, side_effect=fake_picker):
+    elem_map, fs_map = _build_structure_mapping(session, "025f5d48-style")
 
   assert elem_map == {
-    "elem_rev": "struct_is",
-    "elem_cogs": "struct_is",
     "elem_cash": "struct_bs",
+    "elem_rev": "struct_is",
+    "elem_op_cash": "struct_cf",
+    "elem_re": "struct_se",
   }
-  # One ULID per canonical structure
-  assert set(fs_map.keys()) == {"struct_is", "struct_bs"}
+  assert set(fs_map.keys()) == {"struct_bs", "struct_is", "struct_cf", "struct_se"}
   assert all(v.startswith("fs_") for v in fs_map.values())
-  assert fs_map["struct_is"] != fs_map["struct_bs"]
-
-  # Verify the query restricts to the expected types
-  call_sql = str(session.execute.call_args[0][0])
-  assert "income_statement" in call_sql
-  assert "balance_sheet" in call_sql
-  assert "cash_flow_statement" in call_sql
-  assert "equity_statement" in call_sql
-  assert "metric" in call_sql
-  assert "schedule" not in call_sql
+  # Every picked structure gets a distinct fact_set_id.
+  assert len(set(fs_map.values())) == 4
 
 
-def test_select_canonical_render_targets_picks_richest_when_no_mapping() -> None:
-  """Without a CoA mapping, falls back to the richest structure per type
-  (most elements). Deterministic id sort breaks remaining ties."""
-  rows = [
-    # IS Single-step — 2 elements
-    MagicMock(
-      structure_id="struct_is_single",
-      structure_type="income_statement",
-      element_id="elem_rev",
-    ),
-    MagicMock(
-      structure_id="struct_is_single",
-      structure_type="income_statement",
-      element_id="elem_costs",
-    ),
-    # IS Multi-step — 5 elements (richer)
-    MagicMock(
-      structure_id="struct_is_multi",
-      structure_type="income_statement",
-      element_id="elem_rev",
-    ),
-    MagicMock(
-      structure_id="struct_is_multi",
-      structure_type="income_statement",
-      element_id="elem_cogs",
-    ),
-    MagicMock(
-      structure_id="struct_is_multi",
-      structure_type="income_statement",
-      element_id="elem_gp",
-    ),
-    MagicMock(
-      structure_id="struct_is_multi",
-      structure_type="income_statement",
-      element_id="elem_opex",
-    ),
-    MagicMock(
-      structure_id="struct_is_multi",
-      structure_type="income_statement",
-      element_id="elem_oi",
-    ),
-  ]
+def test_build_structure_mapping_skips_uncomposed_statement_types() -> None:
+  """A Reporting Style that doesn't compose every statement type (e.g.,
+  Banking with no equity Network) skips the missing types silently —
+  the picker raises ``NoNetworkForStatementTypeError`` which the caller
+  catches."""
   session = MagicMock()
-  canonical = _select_canonical_render_targets(session, rows, mapping_id=None)
-  assert canonical == {"income_statement": "struct_is_multi"}
 
-
-def test_select_canonical_render_targets_picks_by_coa_coverage() -> None:
-  """When a CoA mapping is provided, the structure whose elements best
-  cover the mapping's targets wins — even if it has fewer total elements
-  than a richer alternative."""
-  rows = [
-    # Single-step has just Revenues + CostsAndExpenses (2 elements)
-    MagicMock(
-      structure_id="struct_is_single",
-      structure_type="income_statement",
-      element_id="fac:Revenues",
-    ),
-    MagicMock(
-      structure_id="struct_is_single",
-      structure_type="income_statement",
-      element_id="fac:CostsAndExpenses",
-    ),
-    # Multi-step has many MORE elements but doesn't include CostsAndExpenses
-    MagicMock(
-      structure_id="struct_is_multi",
-      structure_type="income_statement",
-      element_id="fac:Revenues",
-    ),
-    MagicMock(
-      structure_id="struct_is_multi",
-      structure_type="income_statement",
-      element_id="fac:CostOfRevenue",
-    ),
-    MagicMock(
-      structure_id="struct_is_multi",
-      structure_type="income_statement",
-      element_id="fac:GrossProfit",
-    ),
-    MagicMock(
-      structure_id="struct_is_multi",
-      structure_type="income_statement",
-      element_id="fac:OperatingExpenses",
-    ),
-    MagicMock(
-      structure_id="struct_is_multi",
-      structure_type="income_statement",
-      element_id="fac:OperatingIncome",
-    ),
-  ]
-
-  # Mapping points the user's CoA at fac:Revenues + fac:CostsAndExpenses —
-  # exactly what Single-step covers and Multi-step does not.
-  session = MagicMock()
-  mapping_targets = [
-    MagicMock(element_id="fac:Revenues"),
-    MagicMock(element_id="fac:CostsAndExpenses"),
-  ]
-  session.execute.return_value.fetchall.return_value = mapping_targets
-
-  canonical = _select_canonical_render_targets(session, rows, mapping_id="map_coa")
-  # Single-step wins despite having FEWER elements — coverage beats size.
-  assert canonical == {"income_statement": "struct_is_single"}
-
-
-def test_select_canonical_render_targets_one_per_block_type() -> None:
-  """A graph with multiple block_types gets exactly one canonical per type."""
-  rows = [
-    MagicMock(
-      structure_id="struct_bs", structure_type="balance_sheet", element_id="elem_assets"
-    ),
-    MagicMock(
-      structure_id="struct_is", structure_type="income_statement", element_id="elem_rev"
-    ),
-    MagicMock(
-      structure_id="struct_cf",
-      structure_type="cash_flow_statement",
-      element_id="elem_cash",
-    ),
-    MagicMock(
-      structure_id="struct_se", structure_type="equity_statement", element_id="elem_re"
-    ),
-  ]
-  session = MagicMock()
-  canonical = _select_canonical_render_targets(session, rows, mapping_id=None)
-  assert canonical == {
-    "balance_sheet": "struct_bs",
-    "income_statement": "struct_is",
-    "cash_flow_statement": "struct_cf",
-    "equity_statement": "struct_se",
+  picked = {
+    "balance_sheet": RenderNetwork("struct_bs", "BS", "roll_up"),
+    "income_statement": RenderNetwork("struct_is", "IS", "arithmetic"),
   }
 
+  def fake_picker(_session, _style_id, stmt_type):
+    if stmt_type not in picked:
+      raise NoNetworkForStatementTypeError("style_x", stmt_type)
+    return picked[stmt_type]
 
-def test_build_structure_mapping_filters_to_canonical_only() -> None:
-  """When two IS variants both contain `fac:Revenues`, only the canonical
-  one ends up in the element→structure dict — no more dict-overwrite-wins."""
+  element_rows = [
+    MagicMock(structure_id="struct_bs", element_id="elem_cash"),
+    MagicMock(structure_id="struct_is", element_id="elem_rev"),
+  ]
+  session.execute.return_value.fetchall.return_value = element_rows
+
+  with patch(_PICKER_PATH, side_effect=fake_picker):
+    elem_map, fs_map = _build_structure_mapping(session, "style_x")
+
+  assert set(fs_map.keys()) == {"struct_bs", "struct_is"}
+  assert "struct_cf" not in fs_map
+  assert "struct_se" not in fs_map
+
+
+def test_build_structure_mapping_returns_empty_when_no_compositions() -> None:
+  """A Reporting Style with no compositions at all returns empty dicts
+  (downstream FactSet creation is a no-op)."""
   session = MagicMock()
 
-  # Use a side_effect to return different result objects per call:
-  # 1st call = the structure-and-elements query, 2nd = mapping-targets query.
-  rows = [
-    MagicMock(
-      structure_id="struct_is_single",
-      structure_type="income_statement",
-      element_id="fac:Revenues",
-    ),
-    MagicMock(
-      structure_id="struct_is_single",
-      structure_type="income_statement",
-      element_id="fac:CostsAndExpenses",
-    ),
-    MagicMock(
-      structure_id="struct_is_multi",
-      structure_type="income_statement",
-      element_id="fac:Revenues",
-    ),
-    MagicMock(
-      structure_id="struct_is_multi",
-      structure_type="income_statement",
-      element_id="fac:CostOfRevenue",
-    ),
-  ]
-  mapping_targets = [
-    MagicMock(element_id="fac:Revenues"),
-    MagicMock(element_id="fac:CostsAndExpenses"),
-  ]
+  def fake_picker(_session, _style_id, stmt_type):
+    raise NoNetworkForStatementTypeError("empty_style", stmt_type)
 
-  call_idx = {"i": 0}
+  with patch(_PICKER_PATH, side_effect=fake_picker):
+    elem_map, fs_map = _build_structure_mapping(session, "empty_style")
 
-  def execute_side(*_args, **_kwargs) -> MagicMock:
-    result = MagicMock()
-    if call_idx["i"] == 0:
-      result.fetchall.return_value = rows
-    else:
-      result.fetchall.return_value = mapping_targets
-    call_idx["i"] += 1
-    return result
-
-  session.execute.side_effect = execute_side
-
-  elem_map, fs_map = _build_structure_mapping(session, "tax_01", mapping_id="map_coa")
-
-  # Single-step wins on coverage; both fac:Revenues and fac:CostsAndExpenses
-  # route to it. fac:CostOfRevenue is dropped because Multi-step lost.
-  assert elem_map == {
-    "fac:Revenues": "struct_is_single",
-    "fac:CostsAndExpenses": "struct_is_single",
-  }
-  assert "fac:CostOfRevenue" not in elem_map
-  assert set(fs_map.keys()) == {"struct_is_single"}
+  assert elem_map == {}
+  assert fs_map == {}
+  # No associations query should fire when no Networks were picked.
+  session.execute.assert_not_called()
 
 
 def test_persist_report_facts_stamps_structure_and_fact_set() -> None:

--- a/tests/operations/roboledger/commands/test_reports.py
+++ b/tests/operations/roboledger/commands/test_reports.py
@@ -7,8 +7,8 @@ from unittest.mock import MagicMock, patch
 
 from robosystems.operations.roboledger.commands.reports import (
   _build_structure_mapping,
-  _create_report_fact_sets,
   _persist_report_facts,
+  _pre_create_report_fact_sets,
 )
 from robosystems.operations.roboledger.reports.network_picker import (
   NoNetworkForStatementTypeError,
@@ -190,64 +190,70 @@ def test_persist_report_facts_stamps_structure_and_fact_set() -> None:
   assert unmapped.fact_set_id is None
 
 
-def test_create_report_fact_sets_one_row_per_structure_with_envelope() -> None:
-  """One FactSet per structure that received facts, period envelope
-  spans the full range of that structure's facts."""
-  session = MagicMock()
-  facts = _FakeFacts(
-    [
-      _FakeFact("elem_rev", 100.0, date(2026, 1, 1), date(2026, 3, 31)),
-      _FakeFact("elem_rev", 110.0, date(2025, 10, 1), date(2025, 12, 31)),
-      _FakeFact("elem_cash", 50.0, date(2026, 3, 31), date(2026, 3, 31)),
-      _FakeFact("elem_unmapped", 1.0, date(2026, 1, 1), date(2026, 3, 31)),
-    ]
-  )
-  elem_map = {"elem_rev": "struct_is", "elem_cash": "struct_bs"}
-  fs_map = {"struct_is": "fs_IS", "struct_bs": "fs_BS"}
+class _FakePeriod:
+  """Stand-in for ``FactPeriodSpec`` — only ``start``/``end`` matter here."""
 
-  _create_report_fact_sets(
-    session,
-    "rep_01",
-    "ent_01",
-    "usr_test",
-    facts,
-    elem_map,
-    fs_map,
-  )
+  def __init__(self, start: date, end: date) -> None:
+    self.start = start
+    self.end = end
+
+
+def test_pre_create_report_fact_sets_one_row_per_picked_structure() -> None:
+  """One FactSet per picked Network — even Networks that will receive no
+  facts (e.g., the demo's CF Network when no cash-flow CoA mappings
+  exist). Period envelope comes from the report's ``periods``, not from
+  facts that haven't been stamped yet."""
+  session = MagicMock()
+  periods = [
+    _FakePeriod(date(2025, 10, 1), date(2025, 12, 31)),
+    _FakePeriod(date(2026, 1, 1), date(2026, 3, 31)),
+  ]
+  fs_map = {
+    "struct_bs": "fs_BS",
+    "struct_is": "fs_IS",
+    "struct_cf": "fs_CF",
+    "struct_se": "fs_SE",
+  }
+
+  _pre_create_report_fact_sets(session, "rep_01", "ent_01", "usr_test", periods, fs_map)
 
   added = [c[0][0] for c in session.add.call_args_list]
-  assert len(added) == 2
+  # Every picked Network gets a row — including ones with no facts.
+  assert len(added) == 4
   by_structure = {fs.structure_id: fs for fs in added}
-
+  assert set(by_structure.keys()) == {
+    "struct_bs",
+    "struct_is",
+    "struct_cf",
+    "struct_se",
+  }
   is_row = by_structure["struct_is"]
   assert is_row.id == "fs_IS"
   assert is_row.factset_type == "report"
   assert is_row.entity_id == "ent_01"
   assert is_row.report_id == "rep_01"
   assert is_row.created_by == "usr_test"
-  # Envelope spans both periods' extent
+  # Envelope spans the full period range from `periods`.
   assert is_row.period_start == date(2025, 10, 1)
   assert is_row.period_end == date(2026, 3, 31)
 
-  bs_row = by_structure["struct_bs"]
-  assert bs_row.period_start == date(2026, 3, 31)
-  assert bs_row.period_end == date(2026, 3, 31)
 
-
-def test_create_report_fact_sets_skips_structures_with_no_dated_facts() -> None:
+def test_pre_create_report_fact_sets_noop_on_empty_inputs() -> None:
+  """No picked Networks → no FactSet rows. No periods → no rows
+  either (we'd have nothing to envelope)."""
   session = MagicMock()
-  facts = _FakeFacts(
-    [
-      _FakeFact("elem_ghost", 0.0, period_start=None, period_end=None),
-    ]
+  _pre_create_report_fact_sets(
+    session, "rep_01", "ent_01", "usr_test", [], {"struct_x": "fs_x"}
   )
-  elem_map = {"elem_ghost": "struct_ghost"}
-  fs_map = {"struct_ghost": "fs_ghost"}
-
-  _create_report_fact_sets(
-    session, "rep_01", "ent_01", "usr_test", facts, elem_map, fs_map
-  )
-
-  # fact_sets.period_end is NOT NULL — a structure with no dated facts
-  # cannot produce a valid FactSet row.
   assert session.add.call_count == 0
+
+  session2 = MagicMock()
+  _pre_create_report_fact_sets(
+    session2,
+    "rep_01",
+    "ent_01",
+    "usr_test",
+    [_FakePeriod(date(2026, 1, 1), date(2026, 3, 31))],
+    {},
+  )
+  assert session2.add.call_count == 0

--- a/tests/operations/roboledger/reads/test_reports_extra.py
+++ b/tests/operations/roboledger/reads/test_reports_extra.py
@@ -158,9 +158,15 @@ class TestGetLiveFinancialStatement:
       _row("Revenue", [50.0, None]),
     ]
 
-    with patch(
-      "robosystems.operations.roboledger.reads.reports.generate_adhoc_private_statement",
-      return_value=(mock_grid, 3),
+    with (
+      patch(
+        "robosystems.operations.roboledger.reads.reports.generate_adhoc_private_statement",
+        return_value=(mock_grid, 3),
+      ),
+      patch(
+        "robosystems.operations.roboledger.reports.network_picker.load_graph_reporting_style",
+        return_value="025f5d48-12ce-5d65-b9eb-4f137a10ef06",
+      ),
     ):
       resp = get_live_financial_statement(
         session,
@@ -196,9 +202,15 @@ class TestGetLiveFinancialStatement:
     mock_grid = MagicMock()
     mock_grid.rows = rows
 
-    with patch(
-      "robosystems.operations.roboledger.reads.reports.generate_adhoc_private_statement",
-      return_value=(mock_grid, 0),
+    with (
+      patch(
+        "robosystems.operations.roboledger.reads.reports.generate_adhoc_private_statement",
+        return_value=(mock_grid, 0),
+      ),
+      patch(
+        "robosystems.operations.roboledger.reports.network_picker.load_graph_reporting_style",
+        return_value="025f5d48-12ce-5d65-b9eb-4f137a10ef06",
+      ),
     ):
       resp = get_live_financial_statement(
         session,
@@ -215,9 +227,15 @@ class TestGetLiveFinancialStatement:
   @pytest.mark.unit
   def test_coa_mapping_missing_propagates(self):
     session = MagicMock()
-    with patch(
-      "robosystems.operations.roboledger.reads.reports.generate_adhoc_private_statement",
-      side_effect=CoaMappingNotFoundError("missing mapping"),
+    with (
+      patch(
+        "robosystems.operations.roboledger.reads.reports.generate_adhoc_private_statement",
+        side_effect=CoaMappingNotFoundError("missing mapping"),
+      ),
+      patch(
+        "robosystems.operations.roboledger.reports.network_picker.load_graph_reporting_style",
+        return_value="025f5d48-12ce-5d65-b9eb-4f137a10ef06",
+      ),
     ):
       with pytest.raises(CoaMappingNotFoundError):
         get_live_financial_statement(

--- a/tests/operations/roboledger/reports/test_network_picker.py
+++ b/tests/operations/roboledger/reports/test_network_picker.py
@@ -1,0 +1,64 @@
+"""Tests for the Reporting Style → Network picker (§3.2 Phase 1)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from robosystems.operations.roboledger.reports.network_picker import (
+  NoNetworkForStatementTypeError,
+  RenderNetwork,
+  get_render_network,
+)
+
+
+@pytest.mark.unit
+def test_get_render_network_returns_composed_network() -> None:
+  """When a composition row exists and points at an active Structure,
+  the picker returns its id/name/CAP."""
+  session = MagicMock()
+  row = MagicMock()
+  row.id = "struct_is_multistep"
+  row.name = "rs-gaap — Income Statement — Multi-step"
+  row.concept_arrangement = "arithmetic"
+  session.execute.return_value.fetchone.return_value = row
+
+  network = get_render_network(session, "025f5d48-style", "income_statement")
+
+  assert isinstance(network, RenderNetwork)
+  assert network.structure_id == "struct_is_multistep"
+  assert network.name == "rs-gaap — Income Statement — Multi-step"
+  assert network.concept_arrangement == "arithmetic"
+
+
+@pytest.mark.unit
+def test_get_render_network_raises_when_composition_missing() -> None:
+  """A Style with no row for this statement_type raises explicitly so
+  the caller can decide whether to skip or fail closed."""
+  session = MagicMock()
+  session.execute.return_value.fetchone.return_value = None
+
+  with pytest.raises(NoNetworkForStatementTypeError) as ctx:
+    get_render_network(session, "511aeedc-banking", "equity_statement")
+  assert ctx.value.reporting_style_id == "511aeedc-banking"
+  assert ctx.value.statement_type == "equity_statement"
+
+
+@pytest.mark.unit
+def test_get_render_network_query_filters_active_structures() -> None:
+  """The picker must join on `is_active = true` so a deactivated Network
+  reads as missing — forces the caller to author a replacement rather
+  than silently rendering against a stale Network."""
+  session = MagicMock()
+  row = MagicMock()
+  row.id = "x"
+  row.name = "x"
+  row.concept_arrangement = None
+  session.execute.return_value.fetchone.return_value = row
+  get_render_network(session, "025f5d48-style", "balance_sheet")
+
+  call_sql = str(session.execute.call_args[0][0])
+  assert "is_active = true" in call_sql
+  # And the join is against reporting_style_networks, not a heuristic.
+  assert "reporting_style_networks" in call_sql

--- a/tests/routers/extensions/roboinvestor/test_operations.py
+++ b/tests/routers/extensions/roboinvestor/test_operations.py
@@ -75,6 +75,7 @@ def _entity_meta(schema_extensions=("roboinvestor",), graph_type="entity"):
     graph_type=graph_type,
     schema_extensions=tuple(schema_extensions),
     is_repository=False,
+    reporting_style_id="025f5d48-12ce-5d65-b9eb-4f137a10ef06",
   )
 
 

--- a/tests/taxonomy/test_classifications_migration_shape.py
+++ b/tests/taxonomy/test_classifications_migration_shape.py
@@ -84,6 +84,7 @@ class TestCopyStats:
       classifications=1,
       association_classifications=7,
       rules=1,
+      reporting_style_networks=1,
     )
     assert stats.association_classifications == 7
-    assert stats.total == 17
+    assert stats.total == 18


### PR DESCRIPTION
## Summary

Introduces the concept of **Reporting Styles** as a first-class entity in the system, enabling graphs to be associated with a specific reporting style that governs how report structures, schedules, and fact grids are resolved. This replaces the previous approach of direct reporting structure resolution with a composition-based model.

## Key Accomplishments

### Reporting Style Foundation
- Added new `reporting_style_network` model and supporting database tables via two extension migrations (`0008_reporting_style`, `0009_facts_fact_set_id_fk`) and one platform migration (`add_reporting_style_id_to_graphs`)
- Introduced `reporting_style_id` on the graph model, linking each graph to its chosen reporting style
- Defined reporting style constants in the configuration layer for consistent reference across the codebase

### Change Reporting Style Operation
- Implemented a full `change-reporting-style` command with validation logic, exposed via a new API router endpoint
- The command validates the target reporting style, updates the graph association, and handles downstream impacts
- Added comprehensive unit tests for the new command covering success paths and validation edge cases

### Network Picker & Report Structure Refactoring
- Extracted a new `network_picker` module to encapsulate the logic for selecting appropriate networks based on the active reporting style
- Refactored `reports` commands and `fact_grid` to use the new Reporting Style composition pattern, significantly simplifying the report generation pipeline (~290 lines of net reduction in `commands/reports.py`)
- Updated schedule service to enforce foreign key constraints on `fact_set_id`

### Taxonomy & Mapping Improvements
- Updated suggest-mapping logic to return `rs-gaap` candidates, with corresponding test adjustments
- Refined taxonomy reads to be reporting-style-aware when resolving structures

### Developer Experience
- Updated demo README to replace direct Python commands with `just` commands for streamlined setup

## Breaking Changes

- **`fact_set_id` foreign key constraint**: Existing data must satisfy the new FK relationship introduced in migration `0009`. Ensure data integrity before applying migrations.
- **Reporting structure resolution API**: Internal interfaces for report structure resolution have changed. Any downstream consumers that directly called into the old resolution logic in `commands/reports.py` or `fact_grid.py` will need to adapt to the new composition-based approach.
- **Suggest mapping response shape**: The mapping suggestion endpoint now returns `rs-gaap` candidates, which may affect clients expecting the previous response format.

## Testing Notes

- New test suites added:
  - `tests/operations/graph/test_reporting_style_command.py` — 220+ lines covering the change-reporting-style command
  - `tests/operations/roboledger/reports/test_network_picker.py` — validates network selection logic
- Existing test suites updated to reflect refactored report commands, taxonomy tool changes, and mapping adjustments
- Report command tests were substantially reworked (reduced from ~580 to ~270 lines) to align with the simplified composition model

## Infrastructure Considerations

- Three new database migrations must be applied in order: the two extension migrations followed by the platform migration
- The `reporting_style` tables and FK constraint should be reviewed for index coverage in production environments
- New API endpoint for changing reporting styles should be included in API gateway/routing configuration and access control policies

---
🤖 Generated with [Claude Code](https://claude.ai/code)

**Branch Info:**
- Source: `feature/reporting-styles`
- Target: `main`
- Type: feature

Co-Authored-By: Claude <noreply@anthropic.com>