### PR TITLE
Enhance fiscal calendar close process with rule evaluation and FactSet cleanup

### DIFF
--- a/migrations/extensions/versions/0010_drop_facts_report_id.py
+++ b/migrations/extensions/versions/0010_drop_facts_report_id.py
@@ -1,0 +1,115 @@
+"""Drop facts.report_id (§3.5 / §6.5 final retire).
+
+Completes the FactSets migration started in 0009. With the §3.5 rewrite
+of ``create_report`` / ``regenerate_report`` / ``create_schedule``, every
+new ``facts`` row is stamped with both ``structure_id`` and
+``fact_set_id`` (and the parent ``FactSet`` carries the back-pointer to
+``report_id``), making the ``facts.report_id`` column redundant.
+
+Steps per schema (public + every tenant):
+
+1. DELETE any orphan rows where ``fact_set_id IS NULL``. These are
+   pre-§3.5 facts that 0009 already null-ed (because their fact_set_id
+   didn't resolve) or facts written before ``_persist_report_facts``
+   started stamping ``fact_set_id``. Posture matches 0009 — Reporting
+   Style hasn't shipped to prod, blast radius is small. Reports can be
+   regenerated via ``create_report`` / ``regenerate_report``.
+2. Drop the legacy ``check_fact_has_parent`` CHECK constraint.
+3. Drop the ``idx_facts_report`` index.
+4. Drop the ``report_id`` column itself.
+5. Promote ``fact_set_id`` to ``NOT NULL`` — it's now the sole parent
+   pointer.
+6. Swap the ``fk_facts_fact_set_id`` FK from ``ON DELETE SET NULL`` to
+   ``ON DELETE CASCADE``. SET NULL contradicts NOT NULL; CASCADE matches
+   the new invariant that every fact has exactly one parent FactSet.
+
+Revision ID: 0010
+Revises: 0009
+Create Date: 2026-05-13
+"""
+
+from __future__ import annotations
+
+from alembic import op
+from sqlalchemy import text
+
+# revision identifiers, used by Alembic.
+revision = "0010"
+down_revision = "0009"
+branch_labels = None
+depends_on = None
+
+
+_FK_NAME = "fk_facts_fact_set_id"
+
+
+def _drop_report_id(conn, schema: str) -> None:
+  table = "public.facts" if schema == "public" else f'"{schema}".facts'
+  fact_sets = "public.fact_sets" if schema == "public" else f'"{schema}".fact_sets'
+  conn.execute(text(f"DELETE FROM {table} WHERE fact_set_id IS NULL"))
+  conn.execute(
+    text(f"ALTER TABLE {table} DROP CONSTRAINT IF EXISTS check_fact_has_parent")
+  )
+  if schema == "public":
+    conn.execute(text("DROP INDEX IF EXISTS idx_facts_report"))
+  else:
+    conn.execute(text(f'DROP INDEX IF EXISTS "{schema}".idx_facts_report'))
+  conn.execute(text(f"ALTER TABLE {table} DROP COLUMN IF EXISTS report_id"))
+  conn.execute(text(f"ALTER TABLE {table} ALTER COLUMN fact_set_id SET NOT NULL"))
+  # Swap FK: SET NULL → CASCADE (matches new NOT NULL invariant).
+  conn.execute(text(f"ALTER TABLE {table} DROP CONSTRAINT IF EXISTS {_FK_NAME}"))
+  conn.execute(
+    text(
+      f"ALTER TABLE {table} ADD CONSTRAINT {_FK_NAME} "
+      f"FOREIGN KEY (fact_set_id) REFERENCES {fact_sets} (id) "
+      f"ON DELETE CASCADE"
+    )
+  )
+
+
+def _restore_report_id(conn, schema: str) -> None:
+  table = "public.facts" if schema == "public" else f'"{schema}".facts'
+  fact_sets = "public.fact_sets" if schema == "public" else f'"{schema}".fact_sets'
+  # Revert FK to ON DELETE SET NULL before relaxing NOT NULL.
+  conn.execute(text(f"ALTER TABLE {table} DROP CONSTRAINT IF EXISTS {_FK_NAME}"))
+  conn.execute(
+    text(
+      f"ALTER TABLE {table} ADD CONSTRAINT {_FK_NAME} "
+      f"FOREIGN KEY (fact_set_id) REFERENCES {fact_sets} (id) "
+      f"ON DELETE SET NULL"
+    )
+  )
+  conn.execute(text(f"ALTER TABLE {table} ALTER COLUMN fact_set_id DROP NOT NULL"))
+  conn.execute(text(f"ALTER TABLE {table} ADD COLUMN IF NOT EXISTS report_id VARCHAR"))
+  if schema == "public":
+    conn.execute(
+      text("CREATE INDEX IF NOT EXISTS idx_facts_report ON public.facts (report_id)")
+    )
+  else:
+    conn.execute(
+      text(
+        f'CREATE INDEX IF NOT EXISTS idx_facts_report ON "{schema}".facts (report_id)'
+      )
+    )
+  conn.execute(
+    text(
+      f"ALTER TABLE {table} ADD CONSTRAINT check_fact_has_parent "
+      "CHECK (report_id IS NOT NULL OR fact_set_id IS NOT NULL)"
+    )
+  )
+
+
+def upgrade() -> None:
+  conn = op.get_bind()
+  from migrations.extensions.helpers import for_each_tenant_schema
+
+  _drop_report_id(conn, "public")
+  for_each_tenant_schema(conn, _drop_report_id)
+
+
+def downgrade() -> None:
+  conn = op.get_bind()
+  from migrations.extensions.helpers import for_each_tenant_schema
+
+  _restore_report_id(conn, "public")
+  for_each_tenant_schema(conn, _restore_report_id)

--- a/migrations/extensions/versions/0011_phase_c_required.py
+++ b/migrations/extensions/versions/0011_phase_c_required.py
@@ -1,0 +1,104 @@
+"""Promote Phase C disclosure packages to is_required=true (§3.6).
+
+The four Phase C entries (`rs-gaap-disclosures`,
+`rs-gaap-disclosure-mechanics`, `rs-gaap-reporting-checklist`, the
+`rs-gaap-disclosures-to-rs-gaap-textblocks` bridge) plus
+`rs-gaap-reporting-styles` were originally seeded as `is_required=false`
+in migration 0007 while authoring was in flight. They are now fully
+authored, wired through the framework loader, and load-bearing for
+every tenant (every graph carries a `reporting_style_id` per §3.2 Phase
+1; every tenant receives the disclosure registry via
+`expand_framework_to_pin`).
+
+The runtime impact of the flag is small — `expand_framework_to_pin`
+ignores it — but admin tooling and API surfaces query
+``framework_packages`` directly, so the database needs to reflect
+reality. This migration updates the existing rows; the
+``rs-gaap-base/v1.json`` manifest is the source of truth and was
+flipped in the same PR.
+
+Revision ID: 0011
+Revises: 0010
+Create Date: 2026-05-13
+"""
+
+from __future__ import annotations
+
+from alembic import op
+from sqlalchemy import text
+
+# revision identifiers, used by Alembic.
+revision = "0011"
+down_revision = "0010"
+branch_labels = None
+depends_on = None
+
+
+_PACKAGES_NOW_REQUIRED = (
+  ("rs-gaap-disclosures", "v1"),
+  ("rs-gaap-disclosure-mechanics", "v1"),
+  ("rs-gaap-reporting-checklist", "v1"),
+  ("rs-gaap-reporting-styles", "v1"),
+)
+
+_BRIDGES_NOW_REQUIRED = (("rs-gaap-disclosures-to-rs-gaap-textblocks", "v1"),)
+
+
+def upgrade() -> None:
+  conn = op.get_bind()
+
+  for standard, version in _PACKAGES_NOW_REQUIRED:
+    conn.execute(
+      text(
+        """
+        UPDATE public.framework_packages
+        SET is_required = TRUE
+        WHERE package_standard = :standard AND package_version = :version
+        """
+      ),
+      {"standard": standard, "version": version},
+    )
+
+  for bridge_name, version in _BRIDGES_NOW_REQUIRED:
+    conn.execute(
+      text(
+        """
+        UPDATE public.framework_bridges fb
+        SET is_required = TRUE
+        FROM public.bridges b
+        WHERE fb.bridge_id = b.id
+          AND b.bridge = :bridge AND b.version = :version
+        """
+      ),
+      {"bridge": bridge_name, "version": version},
+    )
+
+
+def downgrade() -> None:
+  conn = op.get_bind()
+
+  for standard, version in _PACKAGES_NOW_REQUIRED:
+    conn.execute(
+      text(
+        """
+        UPDATE public.framework_packages
+        SET is_required = FALSE
+        WHERE package_standard = :standard AND package_version = :version
+        """
+      ),
+      {"standard": standard, "version": version},
+    )
+
+  for bridge_name, version in _BRIDGES_NOW_REQUIRED:
+    conn.execute(
+      text(
+        """
+        UPDATE public.framework_bridges fb
+        SET is_required = FALSE
+        FROM public.bridges b
+        WHERE fb.bridge_id = b.id
+          AND b.bridge = :bridge AND b.version = :version
+        """
+      ),
+      {"bridge": bridge_name, "version": version},
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     # RoboSystems client for demo and testing
-    "robosystems-client==0.3.24",
+    "robosystems-client==0.3.25",
 
     # Testing framework
     "pytest>=8.4.0,<9.0",

--- a/robosystems/middleware/graph/ingestion_limits.py
+++ b/robosystems/middleware/graph/ingestion_limits.py
@@ -1,8 +1,17 @@
 """Graph content limit checking for materialization operations.
 
-Enforces per-operation safety limits (rows per copy, rows per table) to prevent
-OOM during materialization. Instance storage is tracked as a soft limit for
-reporting and alerting — it does not block operations.
+Two limit categories, both hard-blocking at the write path (per
+``tier-capacity-limits.md`` §3.7 Phase 1):
+
+1. **Aggregate storage GB** — the tier-scoped product cap. Bounds
+   instance disk COGS, drives upgrades. Hit at the write path so
+   customers can't pile up data they then can't promote.
+2. **Per-operation row caps** (`max_rows_per_copy`,
+   `max_single_table_rows`) — engineering OOM guardrails. Set per
+   instance class, framed internally; not surfaced as the marketing
+   tier limit.
+
+Both block materialization when exceeded.
 
 Data sources:
 - Row counts: GraphFile.duckdb_row_count (tracked at upload time)
@@ -38,11 +47,13 @@ class IngestionLimitChecker:
     tier: str,
     table_name: str | None = None,
   ) -> dict[str, Any]:
-    """Check if materialization would exceed per-operation safety limits.
+    """Check if materialization would exceed any tier limit.
 
-    Only enforces max_rows_per_copy and max_single_table_rows — these are
-    hard limits to prevent OOM during a single materialization operation.
-    Instance storage capacity is tracked separately as a soft limit.
+    Hard-blocks on three checks (per §3.7 Phase 1):
+
+    - ``max_rows_per_copy`` — OOM guardrail across all pending tables
+    - ``max_single_table_rows`` — OOM guardrail per table
+    - aggregate instance storage GB — product cap
 
     Args:
         db: Database session
@@ -76,17 +87,25 @@ class IngestionLimitChecker:
           f"Table '{tbl_name}' has {row_count:,} rows, exceeding max_single_table_rows limit ({max_single_table:,})"
         )
 
+    # Check aggregate instance storage cap (hard limit — product cap, blocks COGS overruns)
+    storage_check = await cls.check_instance_storage(db, graph_id, tier)
+    if not storage_check["allowed"]:
+      errors.extend(storage_check["errors"])
+
     return {
       "allowed": len(errors) == 0,
       "errors": errors,
       "warnings": warnings,
       "current_usage": {
         "total_pending_rows": total_pending_rows,
+        "total_storage_gb": storage_check["total_storage_gb"],
+        "storage_usage_percentage": storage_check["usage_percentage"],
       },
       "limits": {
         "max_rows_per_copy": max_rows_per_copy,
         "max_single_table_rows": max_single_table,
         "chunk_size_rows": limits.get("chunk_size_rows", 1_000_000),
+        "instance_storage_limit_gb": storage_check["limit_gb"],
       },
       "tier": tier,
     }
@@ -98,10 +117,13 @@ class IngestionLimitChecker:
     graph_id: str,
     tier: str,
   ) -> dict[str, Any]:
-    """Check aggregate storage usage across the entire dedicated instance.
+    """Check aggregate storage usage against the tier's instance cap.
 
-    Sums storage for the parent graph and all subgraphs. This is a soft
-    limit — used for reporting and email alerts, not enforcement.
+    Sums storage for the parent graph and all subgraphs. Returns
+    ``allowed=False`` with a populated ``errors`` list when the
+    aggregate exceeds the tier's ``instance_storage_limit_gb``. Per
+    §3.7 Phase 1 this is a hard product cap, blocking at the write
+    path (folded into :meth:`check_materialization_limits`).
 
     Args:
         db: Database session
@@ -109,7 +131,8 @@ class IngestionLimitChecker:
         tier: Graph tier
 
     Returns:
-        Dict with: total_storage_gb, limit_gb, usage_percentage, status, databases
+        Dict with: allowed, errors, total_storage_gb, limit_gb,
+        usage_percentage, status, databases
     """
     from robosystems.models.core.graph import Graph
 
@@ -156,7 +179,17 @@ class IngestionLimitChecker:
     else:
       instance_status = "healthy"
 
+    errors: list[str] = []
+    if instance_status == "over_limit":
+      errors.append(
+        f"Aggregate instance storage {total_storage_gb:.2f} GB exceeds "
+        f"{tier} limit of {limit_gb:.0f} GB ({usage_percentage:.1f}%). "
+        f"Upgrade tier or reduce data before materializing."
+      )
+
     return {
+      "allowed": len(errors) == 0,
+      "errors": errors,
       "total_storage_gb": total_storage_gb,
       "limit_gb": limit_gb,
       "usage_percentage": usage_percentage,

--- a/robosystems/middleware/mcp/tools/fiscal_calendar_tools.py
+++ b/robosystems/middleware/mcp/tools/fiscal_calendar_tools.py
@@ -267,11 +267,26 @@ class ClosePeriodTool:
           "error": "calendar_not_initialized",
           "message": "Fiscal calendar not initialized for this graph.",
         }
-      return {
+      payload: dict = {
         "error": "not_closeable",
         "message": f"Cannot close period {period!r}.",
         "blockers": exc.blockers,
       }
+      if exc.gate.pending_obligation_count:
+        payload["pending_obligation_count"] = exc.gate.pending_obligation_count
+        payload["pending_obligation_sample"] = [
+          {
+            "event_id": d.event_id,
+            "schedule_id": d.schedule_id,
+            "schedule_name": d.schedule_name,
+            "period": d.period,
+          }
+          for d in exc.gate.pending_obligation_sample
+        ]
+        payload["earliest_pending_period"] = exc.gate.earliest_pending_period
+      if exc.gate.sync_stale_days is not None:
+        payload["sync_stale_days"] = exc.gate.sync_stale_days
+      return payload
     except PeriodNotFoundError as exc:
       return {"error": "period_not_found", "message": str(exc)}
     except UnbalancedLedgerError as exc:

--- a/robosystems/middleware/mcp/tools/fiscal_calendar_tools.py
+++ b/robosystems/middleware/mcp/tools/fiscal_calendar_tools.py
@@ -167,7 +167,11 @@ class ClosePeriodTool:
 3. Validates the BS equation balances for the period
 4. Transitions the FiscalPeriod from open → closed
 5. Advances closed_through; auto-advances close_target if reached
-6. Emits a period_closed audit event
+6. Auto-runs the rule engine for every schedule Structure with facts in
+   the closed period (§3.8). Rule outcomes ride on the response as
+   `rule_summary` / `evaluated_structure_ids` so you can report which
+   schedules passed / failed to the user.
+7. Emits a period_closed audit event
 
 **PARAMETERS:**
 - period (required): YYYY-MM format (e.g., "2026-03")
@@ -180,6 +184,11 @@ class ClosePeriodTool:
 - entries_posted: number of drafts transitioned to posted
 - target_auto_advanced: true if close_target moved forward after this close
 - fiscal_calendar: updated calendar state (same shape as get-fiscal-calendar)
+- rule_summary: aggregated rule-eval tally across every schedule Structure
+  with facts in the closed period — keys: pass / fail / error / skipped.
+  null when no schedules had facts in the period.
+- evaluated_structure_ids: ids of schedule Structures whose rules were
+  evaluated. Pairs with rule_summary.
 
 **GUARDS (422 errors):**
 - Cannot close out of sequence
@@ -260,6 +269,11 @@ class ClosePeriodTool:
           "entries_posted": result.entries_posted,
           "target_auto_advanced": result.target_auto_advanced,
           "fiscal_calendar": fc_payload,
+          # §3.8 — rule eval outcomes from the auto-run on close. Pairs
+          # with the REST `ClosePeriodResponse` shape so agents and
+          # REST consumers see the same surface.
+          "rule_summary": result.rule_summary,
+          "evaluated_structure_ids": list(result.evaluated_structure_ids),
         }
     except CloseGateFailed as exc:
       if exc.no_calendar:

--- a/robosystems/models/api/extensions/fiscal_calendar.py
+++ b/robosystems/models/api/extensions/fiscal_calendar.py
@@ -304,6 +304,21 @@ class ClosePeriodResponse(BaseModel):
     False,
     description="Whether close_target was auto-advanced because it was reached",
   )
+  rule_summary: dict[str, int] | None = Field(
+    None,
+    description=(
+      "Aggregated rule-eval outcome across every schedule Structure with "
+      "facts in the closed period — keys: pass/fail/error/skipped. None when "
+      "no schedules had facts in the period (§3.8 auto-run on close)."
+    ),
+  )
+  evaluated_structure_ids: list[str] = Field(
+    default_factory=list,
+    description=(
+      "ids of schedule Structures whose rules were evaluated during the "
+      "close. Pairs with rule_summary."
+    ),
+  )
 
 
 # ── Draft review (read-only) ──────────────────────────────────────────────

--- a/robosystems/models/extensions/roboledger/fact.py
+++ b/robosystems/models/extensions/roboledger/fact.py
@@ -4,8 +4,11 @@ Bridge between fact generation (Python computation) and graph materialization
 (postgres_scanner reads this table). Each row represents one discrete financial
 data point: an element's aggregated balance for a specific period.
 
-Facts serve both reports (report_id set) and schedules (fact_set_id set).
-At least one of report_id or fact_set_id must be populated.
+Every Fact belongs to exactly one FactSet (the parent envelope that pins the
+period bounds and back-references the Report or Schedule that created it).
+Reports stamp facts via ``_persist_report_facts``; schedules stamp them via
+``ScheduleService``. Both create the FactSet row before the facts that
+reference it (§3.5/§6.5 of information-block.md).
 
 Written by generate_report_facts(), read by ExtensionsMaterializer and
 render_structure_view().
@@ -32,7 +35,6 @@ from robosystems.utils.ulid import generate_prefixed_ulid
 class Fact(ExtensionsBase):
   __tablename__ = "facts"
   __table_args__ = (
-    Index("idx_facts_report", "report_id"),
     Index("idx_facts_element", "element_id"),
     Index("idx_facts_period", "period_start", "period_end"),
     Index("idx_facts_fact_set", "fact_set_id"),
@@ -44,19 +46,12 @@ class Fact(ExtensionsBase):
       postgresql_where=text("fact_scope = 'in_scope'"),
     ),
     CheckConstraint(
-      "report_id IS NOT NULL OR fact_set_id IS NOT NULL",
-      name="check_fact_has_parent",
-    ),
-    CheckConstraint(
       "fact_scope IN ('historical', 'in_scope')",
       name="ck_facts_scope",
     ),
   )
 
   id = Column(String, primary_key=True, default=lambda: generate_prefixed_ulid("fact"))
-  report_id = Column(
-    String, nullable=True
-  )  # set for report facts, null for schedule facts
   element_id = Column(String, nullable=False)
   value = Column(Float, nullable=False)  # natural-sign dollars
   period_start = Column(Date, nullable=True)
@@ -65,13 +60,12 @@ class Fact(ExtensionsBase):
   unit = Column(String, nullable=False, default="USD")
   entity_id = Column(String, nullable=False)
   structure_id = Column(String, nullable=True)  # structure this fact belongs to
-  # FK → fact_sets.id with ON DELETE SET NULL. Soft pointer, like
-  # report_id; the FactSet is created before the fact is stamped
-  # (§3.5/§6.5), so this should never be a dangling reference for new
-  # writes. Historical rows whose ULID didn't resolve were nulled out
-  # by migration 0009 ahead of the FK install.
+  # FK → fact_sets.id with ON DELETE CASCADE. The FactSet is created
+  # before the fact is stamped (§3.5/§6.5). The column is NOT NULL post
+  # migration 0010 — every fact has exactly one parent FactSet; deleting
+  # the FactSet cascades to its facts.
   fact_set_id = Column(
-    String, ForeignKey("fact_sets.id", ondelete="SET NULL"), nullable=True
+    String, ForeignKey("fact_sets.id", ondelete="CASCADE"), nullable=False
   )
   # fact_scope distinguishes "historical" (already reflected in opening balances,
   # ignored by close workflow) from "in_scope" (close workflow drafts entries from

--- a/robosystems/models/extensions/roboledger/fact_set.py
+++ b/robosystems/models/extensions/roboledger/fact_set.py
@@ -7,9 +7,11 @@ Information Block envelope = Structure + FactSet for a given period.
 
 The table provides one period-scoped grouping concept that statements
 and schedules share. ``create_report`` creates a FactSet row first and
-stamps all facts with ``fact_set_id``; the legacy ``report_id`` column
-remains as a back-pointer for readers that have not yet been migrated
-to resolve through FactSet.
+stamps all facts with ``fact_set_id`` (post §3.5 the FK on
+``facts.fact_set_id`` is NOT NULL ON DELETE CASCADE, so deleting the
+FactSet cascades to its facts). FactSet carries its own ``report_id``
+back-pointer to the parent Report — the ``facts.report_id`` column
+was retired in migration 0010.
 """
 
 from datetime import UTC, datetime
@@ -65,8 +67,10 @@ class FactSet(ExtensionsBase):
   # without joining facts.
   entity_id = Column(String, nullable=False)
 
-  # Optional ``report_id`` back-pointer — populated while reports still
-  # live in the ``reports`` table; drops out when ``report_id`` retires.
+  # ``report_id`` back-pointer to the parent Report. Nullable so the
+  # cross-graph share path can mint a FactSet that references a target
+  # Report whose id isn't known until the snapshot is copied; report
+  # facts created via ``create_report`` always populate it.
   report_id = Column(String, nullable=True)
 
   # Provenance + free-form metadata (render config pins, template id at

--- a/robosystems/operations/extensions/materialize.py
+++ b/robosystems/operations/extensions/materialize.py
@@ -794,10 +794,9 @@ def _staging_sql(graph_id: str, entity_id: str, connstr: str) -> dict[str, str]:
 
   tables["FactSet"] = f"""
     CREATE OR REPLACE TABLE FactSet AS
-    SELECT DISTINCT
-      fact_set_id                     AS identifier
-    FROM postgres_scan('{c}', '{s}', 'facts')
-    WHERE fact_set_id IS NOT NULL
+    SELECT
+      id                              AS identifier
+    FROM postgres_scan('{c}', '{s}', 'fact_sets')
   """
 
   # ── Base Ontology Relationships (Entity ↔ Taxonomy) ────────────────────
@@ -876,11 +875,13 @@ def _staging_sql(graph_id: str, entity_id: str, connstr: str) -> dict[str, str]:
   tables["REPORT_HAS_FACT"] = f"""
     CREATE OR REPLACE TABLE REPORT_HAS_FACT AS
     SELECT
-      report_id                       AS src,
-      id                              AS dst,
+      fs.report_id                    AS src,
+      f.id                            AS dst,
       NULL::VARCHAR                   AS fact_context
-    FROM postgres_scan('{c}', '{s}', 'facts')
-    WHERE report_id IS NOT NULL
+    FROM postgres_scan('{c}', '{s}', 'facts') f
+    JOIN postgres_scan('{c}', '{s}', 'fact_sets') fs
+      ON fs.id = f.fact_set_id
+    WHERE fs.report_id IS NOT NULL
   """
 
   tables["FACT_HAS_ELEMENT"] = f"""
@@ -920,8 +921,10 @@ def _staging_sql(graph_id: str, entity_id: str, connstr: str) -> dict[str, str]:
       rf.entity_id                    AS dst,
       NULL::VARCHAR                   AS entity_context
     FROM postgres_scan('{c}', '{s}', 'facts') rf
+    JOIN postgres_scan('{c}', '{s}', 'fact_sets') fs
+      ON fs.id = rf.fact_set_id
     JOIN postgres_scan('{c}', '{s}', 'reports') rd
-      ON rf.report_id = rd.id
+      ON fs.report_id = rd.id
     WHERE rd.source_graph_id IS NULL
     UNION ALL
     -- Shared facts: remap entity_id to the linked entity on this graph
@@ -930,8 +933,10 @@ def _staging_sql(graph_id: str, entity_id: str, connstr: str) -> dict[str, str]:
       e.id                            AS dst,
       NULL::VARCHAR                   AS entity_context
     FROM postgres_scan('{c}', '{s}', 'facts') rf
+    JOIN postgres_scan('{c}', '{s}', 'fact_sets') fs
+      ON fs.id = rf.fact_set_id
     JOIN postgres_scan('{c}', '{s}', 'reports') rd
-      ON rf.report_id = rd.id
+      ON fs.report_id = rd.id
     JOIN postgres_scan('{c}', '{s}', 'entities') e
       ON e.metadata->>'source_graph_id' = rd.source_graph_id
     WHERE rd.source_graph_id IS NOT NULL

--- a/robosystems/operations/information_block/README.md
+++ b/robosystems/operations/information_block/README.md
@@ -91,7 +91,7 @@ results = evaluate_rules_for_structure(
 
 The engine loads rules via `envelope.load_rules_for_structure` (so element- and association-scoped rules are included), binds `$Variable` names to fact values via qname lookup, dispatches to the per-pattern evaluator, writes one `VerificationResult` row per rule, and returns the written rows. `session.flush()` is called before returning; the caller owns `commit`.
 
-**Binding semantics**: schedule facts are structure-scoped (`Fact.structure_id`). Statement facts are currently report-scoped (`Fact.report_id`, `structure_id=NULL`) — the engine falls back to the most recent matching report for non-schedule blocks until report-write paths stamp `structure_id` on every fact.
+**Binding semantics**: every fact is structure-scoped (`Fact.structure_id`) and FactSet-anchored (`Fact.fact_set_id`) post §3.5. Reports stamp those fields via `_persist_report_facts`; schedules stamp them via `ScheduleService`. The engine filters by `structure_id` (or `fact_set_id` when the caller pins one) — no report-id fallback is needed.
 
 **Expression safety**: `expressions.py` rewrites `$Variable` → `_var_Name`, normalizes bare `=` → `==`, parses with `ast.parse(mode='eval')`, then walks the AST through a whitelist. `eval()` is never called — the AST is evaluated recursively by `_eval_arith`.
 

--- a/robosystems/operations/information_block/rules/engine.py
+++ b/robosystems/operations/information_block/rules/engine.py
@@ -119,11 +119,17 @@ def _bind_sum_variables(
     if element_id is None:
       bindings[name] = None
       continue
+    # Match `_bind_variables` semantics — only sum facts the close
+    # workflow considers in-scope. Historical facts (already absorbed
+    # into opening balances) would otherwise inflate SumEquals checks
+    # that compare against a schedule's contracted total.
     row = session.execute(
       text(
         "SELECT ROUND(SUM(value)::numeric, 2) AS total "
         "FROM facts "
-        "WHERE element_id = :eid AND structure_id = :sid AND period_type = 'duration'"
+        "WHERE element_id = :eid AND structure_id = :sid "
+        "AND period_type = 'duration' "
+        "AND fact_scope = 'in_scope'"
       ),
       {"eid": element_id, "sid": structure_id},
     ).fetchone()

--- a/robosystems/operations/information_block/rules/engine.py
+++ b/robosystems/operations/information_block/rules/engine.py
@@ -25,12 +25,9 @@ For each ``{variable_name, variable_qname}`` entry in
    (the pattern evaluator surfaces this as ``skipped`` or ``fail``).
 3. Resolve ``element_id`` + period window → fact value via the facts
    table (``fact_scope = 'in_scope'``, most recent ``period_end`` first).
-   Structure-scoped facts win. If no structure fact exists, facts from
-   the latest matching statement/report are accepted via one pinned
-   ``report_id`` because report-write paths currently write
-   structure-agnostic facts (``structure_id`` / ``fact_set_id`` are not
-   yet stamped on every fact). Schedules do not use that fallback;
-   their own generated facts are the source of truth. None on miss.
+   Facts are filtered by ``structure_id`` (or ``fact_set_id`` when the
+   caller pins one); post §3.5 every fact has both stamped at write
+   time, so no legacy report-id fallback is needed. None on miss.
 
 One query per variable (N+1 is fine for 3-5 variables per rule).
 """
@@ -45,7 +42,6 @@ from sqlalchemy.orm import Session
 from robosystems.models.extensions import (
   Association,
   Element,
-  Report,
   Rule,
   Structure,
   VerificationResult,
@@ -65,8 +61,6 @@ def _bind_variables(
   period_start: date | None,
   period_end: date | None,
   fact_set_id: str | None = None,
-  allow_report_fallback: bool = True,
-  fallback_report_id: str | None = None,
 ) -> dict[str, float | None]:
   """Resolve each ``$Variable`` in a rule to a fact value or ``None``."""
   bindings: dict[str, float | None] = {}
@@ -100,55 +94,11 @@ def _bind_variables(
 
     if fact_set_id is not None:
       stmt = base_stmt.where(Fact.fact_set_id == fact_set_id)
-      value: float | None = session.execute(stmt).scalar()
-      bindings[name] = value
-      continue
-
-    # Structure-scoped facts are authoritative for declarative blocks
-    # such as schedules. Statement/report facts are currently
-    # structure-agnostic (report_id set, structure_id null), so fall
-    # back to those only when the block has no direct fact for the
-    # requested variable.
-    stmt = base_stmt.where(Fact.structure_id == structure_id)
-    value = session.execute(stmt).scalar()
-    if value is None and allow_report_fallback and fallback_report_id is not None:
-      report_stmt = base_stmt.where(
-        Fact.structure_id.is_(None),
-        Fact.report_id == fallback_report_id,
-      )
-      value = session.execute(report_stmt).scalar()
-    bindings[name] = value
+    else:
+      stmt = base_stmt.where(Fact.structure_id == structure_id)
+    bindings[name] = session.execute(stmt).scalar()
 
   return bindings
-
-
-def _latest_report_id_for_fallback(
-  session: Session,
-  element_ids: set[str],
-  period_start: date | None,
-  period_end: date | None,
-) -> str | None:
-  """Pick one report for all structure-agnostic fact fallback bindings."""
-  if not element_ids:
-    return None
-
-  stmt = (
-    select(Report.id)
-    .join(Fact, Fact.report_id == Report.id)
-    .where(
-      Fact.element_id.in_(element_ids),
-      Fact.fact_scope == "in_scope",
-      Fact.structure_id.is_(None),
-      Fact.report_id.is_not(None),
-    )
-    .order_by(Report.created_at.desc(), Report.id.desc())
-    .limit(1)
-  )
-  if period_end is not None:
-    stmt = stmt.where(Fact.period_end <= period_end)
-  if period_start is not None:
-    stmt = stmt.where(Fact.period_start >= period_start)
-  return session.execute(stmt).scalar()
 
 
 def _bind_sum_variables(
@@ -234,12 +184,6 @@ def evaluate_rules_for_structure(
   rule_ids = [r.id for r in rule_lites]
   rules = session.execute(select(Rule).where(Rule.id.in_(rule_ids))).scalars().all()
   rule_map = {r.id: r for r in rules}
-  allow_report_fallback = structure.structure_type != "schedule"
-  fallback_report_id = (
-    _latest_report_id_for_fallback(session, element_ids, period_start, period_end)
-    if allow_report_fallback and fact_set_id is None
-    else None
-  )
 
   results: list[VerificationResult] = []
   for rule_lite in rule_lites:
@@ -257,8 +201,6 @@ def evaluate_rules_for_structure(
           period_start,
           period_end,
           fact_set_id=fact_set_id,
-          allow_report_fallback=allow_report_fallback,
-          fallback_report_id=fallback_report_id,
         )
       outcome = evaluate_rule(rule, bindings)
     except Exception as exc:

--- a/robosystems/operations/roboledger/commands/fiscal_calendar.py
+++ b/robosystems/operations/roboledger/commands/fiscal_calendar.py
@@ -189,6 +189,8 @@ def close_period(
     period=result.period,
     entries_posted=result.entries_posted,
     target_auto_advanced=result.target_auto_advanced,
+    rule_summary=result.rule_summary,
+    evaluated_structure_ids=list(result.evaluated_structure_ids),
   )
 
 

--- a/robosystems/operations/roboledger/commands/reports.py
+++ b/robosystems/operations/roboledger/commands/reports.py
@@ -199,27 +199,33 @@ def _persist_report_facts(
   report_id: str,
   facts,
   entity_id: str,
-  element_to_structure: dict[str, str] | None = None,
-  structure_to_factset: dict[str, str] | None = None,
+  element_to_structure: dict[str, str],
+  structure_to_factset: dict[str, str],
 ) -> None:
   """Clear any existing facts for this report and persist the new set.
 
-  If `element_to_structure` / `structure_to_factset` are provided, each
-  Fact is stamped with `structure_id` and `fact_set_id` so the Information
-  Block envelope can resolve its FactSet row. `report_id` is still set —
-  the CHECK constraint requires at least one of the two to be non-null.
+  Every persisted Fact is stamped with ``structure_id`` and
+  ``fact_set_id`` — the FactSet is the sole parent pointer post §3.5.
+  Facts whose element isn't reached by any Network in the picked
+  Reporting Style are skipped: there's no Network to render them
+  through, so they can't be stamped with a structure_id, and the
+  fact_set_id NOT NULL constraint would reject them.
   """
   session.execute(
-    text("DELETE FROM facts WHERE report_id = :report_id"),
+    text(
+      "DELETE FROM facts WHERE fact_set_id IN "
+      "(SELECT id FROM fact_sets WHERE report_id = :report_id)"
+    ),
     {"report_id": report_id},
   )
-  elem_map = element_to_structure or {}
-  fs_map = structure_to_factset or {}
   for fact in facts.facts:
-    structure_id = elem_map.get(fact.element_id)
-    fact_set_id = fs_map.get(structure_id) if structure_id else None
+    structure_id = element_to_structure.get(fact.element_id)
+    if structure_id is None:
+      continue
+    fact_set_id = structure_to_factset.get(structure_id)
+    if fact_set_id is None:
+      continue
     rf = Fact(
-      report_id=report_id,
       element_id=fact.element_id,
       value=fact.value,
       period_start=fact.period_start,
@@ -437,15 +443,9 @@ def regenerate_report(
     session, reporting_style_id
   )
   # Stale rows from the prior generation must clear before fresh ULIDs
-  # land. Order matters once the facts → fact_sets FK exists (§6.5):
-  # facts go first (they reference fact_sets), then fact_sets. The
-  # ``_persist_report_facts`` call below also DELETEs by report_id —
-  # idempotent here, but doing the explicit fact delete first keeps
-  # the FK ordering correct even before SQLAlchemy autoflushes.
-  session.execute(
-    text("DELETE FROM facts WHERE report_id = :report_id"),
-    {"report_id": report_def.id},
-  )
+  # land. Post §3.5 the FK `facts.fact_set_id → fact_sets.id` is
+  # ON DELETE CASCADE, so dropping the parent fact_sets cleans the
+  # child facts in one statement.
   session.execute(
     text("DELETE FROM fact_sets WHERE report_id = :report_id"),
     {"report_id": report_def.id},
@@ -616,10 +616,7 @@ def delete_report(session: Session, report_id: str, acting_user_id: str) -> bool
       f"retiring; deletion is only available for 'draft' or 'under_review'."
     )
 
-  session.execute(
-    text("DELETE FROM facts WHERE report_id = :report_id"),
-    {"report_id": report_id},
-  )
+  # Post §3.5: facts cascade from their parent fact_sets on delete.
   session.execute(
     text("DELETE FROM fact_sets WHERE report_id = :report_id"),
     {"report_id": report_id},
@@ -692,9 +689,11 @@ def share_report(
 
     fact_rows = source_session.execute(
       text("""
-        SELECT id, report_id, element_id, value, period_start, period_end,
-               period_type, unit, entity_id, fact_set_id, created_at
-        FROM facts WHERE report_id = :report_id
+        SELECT f.id, f.element_id, f.value, f.period_start, f.period_end,
+               f.period_type, f.unit, f.entity_id, f.created_at
+        FROM facts f
+        JOIN fact_sets fs ON fs.id = f.fact_set_id
+        WHERE fs.report_id = :report_id
       """),
       {"report_id": report_id},
     ).fetchall()
@@ -789,14 +788,32 @@ def _share_to_target(
       target_session.add(shared_report)
       target_session.flush()
 
+      # Cross-graph share: source-graph structure_id references rows in
+      # the source tenant schema and is meaningless in the target.
+      # Populating target Networks per-structure on share is expand-pass
+      # work. For now we stamp every shared fact against a single
+      # cross-graph FactSet that back-references the shared report; the
+      # period envelope spans all incoming facts.
+      starts = [
+        fd["period_start"] for fd in source_facts if fd.get("period_start") is not None
+      ]
+      ends = [
+        fd["period_end"] for fd in source_facts if fd.get("period_end") is not None
+      ]
+      shared_fact_set = FactSet(
+        structure_id=None,
+        period_start=min(starts) if starts else None,
+        period_end=max(ends) if ends else None,
+        factset_type="report",
+        entity_id=source_facts[0]["entity_id"] if source_facts else "",
+        report_id=shared_report.id,
+        created_by=shared_by,
+      )
+      target_session.add(shared_fact_set)
+      target_session.flush()
+
       for fact_data in source_facts:
-        # Cross-graph share: source-graph structure_id/fact_set_id
-        # reference rows in the source tenant schema and are meaningless
-        # in the target. Drop both on copy — shared facts identify
-        # themselves via report_id alone. Populating target FactSet rows
-        # per-structure on share is expand-pass work.
         rf = Fact(
-          report_id=shared_report.id,
           element_id=fact_data["element_id"],
           value=fact_data["value"],
           period_start=fact_data["period_start"],
@@ -804,6 +821,7 @@ def _share_to_target(
           period_type=fact_data["period_type"],
           unit=fact_data["unit"],
           entity_id=fact_data["entity_id"],
+          fact_set_id=shared_fact_set.id,
         )
         target_session.add(rf)
 

--- a/robosystems/operations/roboledger/commands/schedules.py
+++ b/robosystems/operations/roboledger/commands/schedules.py
@@ -385,6 +385,18 @@ def update_schedule(
       created_by=updated_by,
     )
 
+  # §3.8 — re-run rule engine when the template changes, since the
+  # underlying fact shape may have moved. No-op when the template was
+  # unchanged (existing verification_results stay authoritative).
+  rule_summary: dict[str, int] | None = None
+  if template_changed:
+    rule_results = evaluate_rules_for_structure(
+      session,
+      structure.id,
+      created_by=updated_by,
+    )
+    rule_summary = _rule_summary(rule_results)
+
   session.commit()
 
   # Recount for response (same as create_schedule response shape)
@@ -406,6 +418,7 @@ def update_schedule(
     taxonomy_id=structure.taxonomy_id,
     total_periods=period_row.cnt if period_row else 0,
     total_facts=count_row.cnt if count_row else 0,
+    rule_summary=rule_summary,
   )
 
 

--- a/robosystems/operations/roboledger/fiscal_calendar/close_service.py
+++ b/robosystems/operations/roboledger/fiscal_calendar/close_service.py
@@ -90,6 +90,13 @@ class PeriodCloseResult:
   target_auto_advanced: bool
   calendar: FiscalCalendar
   was_reclose: bool
+  # §3.8 auto-run rules on close. None if no schedules with facts in the
+  # period had rules attached. Otherwise a dict tallying outcomes:
+  # {"pass": int, "fail": int, "error": int, "skipped": int}.
+  rule_summary: dict[str, int] | None = None
+  # ids of schedule Structures whose rules were evaluated. Empty when no
+  # schedule structures had facts in the closed period.
+  evaluated_structure_ids: tuple[str, ...] = ()
 
 
 # ────────────────────────────────────────────────────────────────────────────
@@ -229,10 +236,25 @@ class PeriodCloseService:
       and calendar.close_target_period is not None
     )
 
+    # 6. §3.8 — Auto-run rules on schedules with facts in the closing
+    # period. Rule failures are isolated from the close result: the close
+    # succeeds even if a rule errors, and the failure surfaces only in
+    # rule_summary / verification_results for downstream inspection. This
+    # keeps the close path as the "single source of truth" while letting
+    # the validation panel accumulate fresh results without an explicit
+    # `POST /evaluate-rules` call.
+    rule_summary, evaluated_ids = self._evaluate_schedule_rules_in_period(
+      session,
+      period_start=period_start,
+      period_end=period_end,
+      actor_id=actor_id,
+    )
+
     logger.info(
       f"Period {period} closed for graph {graph_id}: "
       f"entries_posted={entries_posted} reclose={is_reclose} "
-      f"target_auto_advanced={target_auto_advanced}"
+      f"target_auto_advanced={target_auto_advanced} "
+      f"rule_summary={rule_summary}"
     )
 
     return PeriodCloseResult(
@@ -241,6 +263,8 @@ class PeriodCloseService:
       target_auto_advanced=target_auto_advanced,
       calendar=calendar,
       was_reclose=is_reclose,
+      rule_summary=rule_summary,
+      evaluated_structure_ids=evaluated_ids,
     )
 
   # ── Private helpers ────────────────────────────────────────────────────
@@ -275,6 +299,70 @@ class PeriodCloseService:
     total_credit = int(row.total_credit) if row else 0
     if total_debit != total_credit:
       raise UnbalancedLedgerError(total_debit, total_credit)
+
+  def _evaluate_schedule_rules_in_period(
+    self,
+    session: Session,
+    *,
+    period_start,
+    period_end,
+    actor_id: str,
+  ) -> tuple[dict[str, int] | None, tuple[str, ...]]:
+    """Run the rule engine for every schedule Structure with facts in the
+    closing period. Returns (rule_summary, evaluated_structure_ids).
+
+    Failures from individual rule evaluations are caught and logged —
+    they cannot break the close path, which has already succeeded by
+    the time this is called. The rule engine itself already converts
+    binding/dispatch failures into ``VerificationResult`` rows with
+    ``status='error'``; this wrapper guards against an outright engine
+    exception (e.g., schema-level issue) for robustness.
+    """
+    # Lazy import — keeps the close service free of information-block
+    # dependencies at module import time.
+    from robosystems.operations.information_block.rules.engine import (
+      evaluate_rules_for_structure,
+    )
+
+    structure_ids = (
+      session.execute(
+        text(
+          """
+          SELECT DISTINCT s.id
+          FROM structures s
+          JOIN facts f ON f.structure_id = s.id
+          WHERE s.structure_type = 'schedule'
+            AND f.fact_scope = 'in_scope'
+            AND f.period_end >= :period_start
+            AND f.period_end <= :period_end
+          """
+        ),
+        {"period_start": period_start, "period_end": period_end},
+      )
+      .scalars()
+      .all()
+    )
+
+    if not structure_ids:
+      return None, ()
+
+    tally: dict[str, int] = {"pass": 0, "fail": 0, "error": 0, "skipped": 0}
+    for sid in structure_ids:
+      try:
+        rows = evaluate_rules_for_structure(
+          session,
+          sid,
+          period_start=period_start,
+          period_end=period_end,
+          created_by=actor_id,
+        )
+      except Exception as exc:
+        logger.warning(f"Rule eval failed for structure {sid} during close: {exc}")
+        continue
+      for row in rows:
+        tally[row.status] = tally.get(row.status, 0) + 1
+
+    return tally, tuple(structure_ids)
 
   @staticmethod
   def _audit_note(note: str | None, *, allow_stale_sync: bool) -> str | None:

--- a/robosystems/operations/roboledger/fiscal_calendar/close_service.py
+++ b/robosystems/operations/roboledger/fiscal_calendar/close_service.py
@@ -40,15 +40,19 @@ class PeriodCloseError(Exception):
 class CloseGateFailed(PeriodCloseError):
   """Raised when the closeable gate rejects the request.
 
-  `blockers` is the full list from `CloseableGateResult.blockers`.
-  `no_calendar` is True when the sole blocker is NO_CALENDAR — callers
-  typically surface this as 404 rather than 422.
+  Carries the full :class:`CloseableGateResult` so callers can surface
+  the enriched payload (``pending_obligation_count``,
+  ``pending_obligation_sample``, ``earliest_pending_period``,
+  ``sync_stale_days``) without re-fetching the calendar. ``blockers``
+  / ``no_calendar`` are kept as direct attributes for the common
+  branches; full detail lives on ``gate``.
   """
 
-  def __init__(self, blockers: list[str]):
-    super().__init__(f"Cannot close period: blockers={blockers}")
-    self.blockers = blockers
-    self.no_calendar = CloseableGateResult.NO_CALENDAR in blockers
+  def __init__(self, gate: CloseableGateResult):
+    super().__init__(f"Cannot close period: blockers={gate.blockers}")
+    self.gate = gate
+    self.blockers = gate.blockers
+    self.no_calendar = CloseableGateResult.NO_CALENDAR in gate.blockers
 
 
 class PeriodNotFoundError(PeriodCloseError):
@@ -152,7 +156,7 @@ class PeriodCloseService:
       allow_stale_sync=allow_stale_sync,
     )
     if not gate.is_closeable:
-      raise CloseGateFailed(gate.blockers)
+      raise CloseGateFailed(gate)
 
     period_start, period_end = period_date_range(period)
 

--- a/robosystems/operations/roboledger/fiscal_calendar/close_service.py
+++ b/robosystems/operations/roboledger/fiscal_calendar/close_service.py
@@ -328,6 +328,12 @@ class PeriodCloseService:
       evaluate_rules_for_structure,
     )
 
+    # Unqualified table names — relies on `extensions_session(graph_id)`
+    # having SET the tenant's search_path before this method runs. The
+    # close service is only called from that session context (REST
+    # handler + MCP tool both go through `cmd_close_period`); any future
+    # refactor that bypasses the tenant session must qualify these
+    # tables explicitly to avoid silently querying the wrong schema.
     structure_ids = (
       session.execute(
         text(

--- a/robosystems/operations/roboledger/reads/reports.py
+++ b/robosystems/operations/roboledger/reads/reports.py
@@ -455,6 +455,7 @@ def get_statement(
              rf.period_type, e.qname, e.name,
              trait_info.identifier AS trait, e.balance_type
       FROM facts rf
+      JOIN fact_sets fs ON fs.id = rf.fact_set_id
       JOIN elements e ON e.id = rf.element_id
       LEFT JOIN (
         SELECT et.element_id, t.identifier
@@ -463,7 +464,7 @@ def get_statement(
         WHERE et.is_primary = TRUE
           AND t.category = 'elementsOfFinancialStatements'
       ) trait_info ON trait_info.element_id = e.id
-      WHERE rf.report_id = :report_id
+      WHERE fs.report_id = :report_id
     """),
     {"report_id": report_id},
   )

--- a/robosystems/routers/extensions/roboledger/operations.py
+++ b/robosystems/routers/extensions/roboledger/operations.py
@@ -125,6 +125,7 @@ from robosystems.models.api.extensions.fiscal_calendar import (
   FiscalCalendarResponse,
   InitializeLedgerRequest,
   InitializeLedgerResponse,
+  PendingObligationDetailResponse,
   ReopenPeriodRequest,
   SetCloseTargetRequest,
 )
@@ -1526,13 +1527,16 @@ async def close_period_op(
       }
       if e.gate.pending_obligation_count:
         detail["pending_obligation_count"] = e.gate.pending_obligation_count
+        # Route through the Pydantic response model so the error-detail
+        # shape stays aligned with the calendar-read shape; if the model
+        # gains a field, this serialization picks it up automatically.
         detail["pending_obligation_sample"] = [
-          {
-            "event_id": d.event_id,
-            "schedule_id": d.schedule_id,
-            "schedule_name": d.schedule_name,
-            "period": d.period,
-          }
+          PendingObligationDetailResponse(
+            event_id=d.event_id,
+            schedule_id=d.schedule_id,
+            schedule_name=d.schedule_name,
+            period=d.period,
+          ).model_dump()
           for d in e.gate.pending_obligation_sample
         ]
         detail["earliest_pending_period"] = e.gate.earliest_pending_period

--- a/robosystems/routers/extensions/roboledger/operations.py
+++ b/robosystems/routers/extensions/roboledger/operations.py
@@ -1520,13 +1520,25 @@ async def close_period_op(
             "Fiscal calendar not initialized. Call /operations/initialize first."
           ),
         )
-      raise HTTPException(
-        status_code=422,
-        detail={
-          "message": f"Cannot close period {body.period!r}.",
-          "blockers": e.blockers,
-        },
-      )
+      detail: dict = {
+        "message": f"Cannot close period {body.period!r}.",
+        "blockers": e.blockers,
+      }
+      if e.gate.pending_obligation_count:
+        detail["pending_obligation_count"] = e.gate.pending_obligation_count
+        detail["pending_obligation_sample"] = [
+          {
+            "event_id": d.event_id,
+            "schedule_id": d.schedule_id,
+            "schedule_name": d.schedule_name,
+            "period": d.period,
+          }
+          for d in e.gate.pending_obligation_sample
+        ]
+        detail["earliest_pending_period"] = e.gate.earliest_pending_period
+      if e.gate.sync_stale_days is not None:
+        detail["sync_stale_days"] = e.gate.sync_stale_days
+      raise HTTPException(status_code=422, detail=detail)
     except PeriodNotFoundError as e:
       raise HTTPException(status_code=404, detail=str(e))
     except UnbalancedLedgerError as e:

--- a/robosystems/taxonomy/frameworks/rs-gaap-base/v1.json
+++ b/robosystems/taxonomy/frameworks/rs-gaap-base/v1.json
@@ -16,13 +16,13 @@
     {"standard": "fac-presentation",             "version": "v1", "ordinal": 8,  "is_required": true},
     {"standard": "type-subtype",                 "version": "v1", "ordinal": 9,  "is_required": true},
     {"standard": "fac-rules",                    "version": "v1", "ordinal": 10, "is_required": true},
-    {"standard": "rs-gaap-disclosures",          "version": "v1", "ordinal": 11, "is_required": false},
-    {"standard": "rs-gaap-disclosure-mechanics", "version": "v1", "ordinal": 12, "is_required": false},
-    {"standard": "rs-gaap-reporting-checklist",  "version": "v1", "ordinal": 13, "is_required": false},
-    {"standard": "rs-gaap-reporting-styles",     "version": "v1", "ordinal": 14, "is_required": false}
+    {"standard": "rs-gaap-disclosures",          "version": "v1", "ordinal": 11, "is_required": true},
+    {"standard": "rs-gaap-disclosure-mechanics", "version": "v1", "ordinal": 12, "is_required": true},
+    {"standard": "rs-gaap-reporting-checklist",  "version": "v1", "ordinal": 13, "is_required": true},
+    {"standard": "rs-gaap-reporting-styles",     "version": "v1", "ordinal": 14, "is_required": true}
   ],
   "bridges": [
     {"bridge": "fac-to-rs-gaap",                            "version": "v1", "ordinal": 0, "is_required": true},
-    {"bridge": "rs-gaap-disclosures-to-rs-gaap-textblocks", "version": "v1", "ordinal": 1, "is_required": false}
+    {"bridge": "rs-gaap-disclosures-to-rs-gaap-textblocks", "version": "v1", "ordinal": 1, "is_required": true}
   ]
 }

--- a/tests/middleware/graph/test_ingestion_limits.py
+++ b/tests/middleware/graph/test_ingestion_limits.py
@@ -91,6 +91,53 @@ class TestCheckMaterializationLimits:
     assert any("max_single_table_rows" in e for e in result["errors"])
 
   @pytest.mark.asyncio
+  async def test_storage_over_limit_blocks_materialization(self):
+    """§3.7 Phase 1: aggregate instance storage over cap blocks materialization."""
+    mock_db = MagicMock()
+    with (
+      patch.object(
+        IngestionLimitChecker,
+        "_get_pending_row_counts",
+        return_value={"Entity": 1000},
+      ),
+      patch.object(
+        IngestionLimitChecker,
+        "_get_database_size_bytes",
+        new_callable=AsyncMock,
+        return_value=25 * 1024**3,  # 25 GB on a 20 GB tier
+      ),
+      patch(
+        "robosystems.models.core.graph.Graph.get_subgraphs",
+        return_value=[],
+      ),
+      patch(
+        "robosystems.middleware.graph.ingestion_limits.GraphTierConfig.get_instance_storage_limit_gb",
+        return_value=20.0,
+      ),
+      patch(
+        "robosystems.middleware.graph.ingestion_limits.GraphTierConfig.get_graph_limits",
+        return_value={
+          "instance_storage_limit_gb": 20,
+          "max_rows_per_copy": 2_000_000,
+          "max_single_table_rows": 5_000_000,
+          "chunk_size_rows": 1_000_000,
+          "warn_at_percentage": 80,
+        },
+      ),
+    ):
+      result = await IngestionLimitChecker.check_materialization_limits(
+        db=mock_db,
+        graph_id="kg_test",
+        tier="ladybug-standard",
+      )
+
+    assert result["allowed"] is False
+    assert any("instance storage" in e for e in result["errors"])
+    assert result["current_usage"]["total_storage_gb"] == 25.0
+    assert result["current_usage"]["storage_usage_percentage"] == 125.0
+    assert result["limits"]["instance_storage_limit_gb"] == 20.0
+
+  @pytest.mark.asyncio
   async def test_no_node_or_relationship_blocking(self):
     """Test that materialization is never blocked by node/relationship counts.
 
@@ -221,6 +268,43 @@ class TestCheckInstanceStorage:
 
     assert result["status"] == "over_limit"
     assert result["usage_percentage"] == 105.0
+    # §3.7 Phase 1: over_limit populates blocking errors
+    assert result["allowed"] is False
+    assert len(result["errors"]) == 1
+    assert "exceeds" in result["errors"][0]
+
+  @pytest.mark.asyncio
+  async def test_healthy_status_is_allowed(self):
+    """§3.7 Phase 1: under-cap status returns allowed=True with empty errors."""
+    mock_db = MagicMock()
+    with (
+      patch.object(
+        IngestionLimitChecker,
+        "_get_database_size_bytes",
+        new_callable=AsyncMock,
+        return_value=5 * 1024**3,
+      ),
+      patch(
+        "robosystems.models.core.graph.Graph.get_subgraphs",
+        return_value=[],
+      ),
+      patch(
+        "robosystems.middleware.graph.ingestion_limits.GraphTierConfig.get_instance_storage_limit_gb",
+        return_value=20.0,
+      ),
+      patch(
+        "robosystems.middleware.graph.ingestion_limits.GraphTierConfig.get_graph_limits",
+        return_value={"warn_at_percentage": 80},
+      ),
+    ):
+      result = await IngestionLimitChecker.check_instance_storage(
+        db=mock_db,
+        graph_id="kg_test",
+        tier="ladybug-standard",
+      )
+
+    assert result["allowed"] is True
+    assert result["errors"] == []
 
   @pytest.mark.asyncio
   async def test_aggregates_subgraphs(self):

--- a/tests/middleware/mcp/tools/test_fiscal_calendar_tools.py
+++ b/tests/middleware/mcp/tools/test_fiscal_calendar_tools.py
@@ -185,7 +185,9 @@ class TestClosePeriodToolErrors:
   @pytest.mark.asyncio
   async def test_gate_failed_returns_not_closeable(self):
     result = await self._run_with_side_effect(
-      CloseGateFailed(blockers=[CloseableGateResult.SEQUENCE])
+      CloseGateFailed(
+        CloseableGateResult(is_closeable=False, blockers=[CloseableGateResult.SEQUENCE])
+      )
     )
     assert result["error"] == "not_closeable"
     assert CloseableGateResult.SEQUENCE in result["blockers"]
@@ -193,9 +195,47 @@ class TestClosePeriodToolErrors:
   @pytest.mark.asyncio
   async def test_no_calendar_returns_calendar_not_initialized(self):
     result = await self._run_with_side_effect(
-      CloseGateFailed(blockers=[CloseableGateResult.NO_CALENDAR])
+      CloseGateFailed(
+        CloseableGateResult(
+          is_closeable=False, blockers=[CloseableGateResult.NO_CALENDAR]
+        )
+      )
     )
     assert result["error"] == "calendar_not_initialized"
+
+  @pytest.mark.asyncio
+  async def test_pending_obligations_enriches_detail(self):
+    """§3.12 follow-up: pending_obligations blocker surfaces count + sample
+    + earliest_pending_period on the close-period response."""
+    from robosystems.operations.roboledger.fiscal_calendar.service import (
+      PendingObligationDetail,
+    )
+
+    result = await self._run_with_side_effect(
+      CloseGateFailed(
+        CloseableGateResult(
+          is_closeable=False,
+          blockers=[CloseableGateResult.PENDING_OBLIGATIONS],
+          pending_obligation_count=3,
+          pending_obligation_sample=[
+            PendingObligationDetail(
+              event_id="evt_1",
+              schedule_id="struct_dep",
+              schedule_name="Computer Depreciation",
+              period="2026-04",
+            ),
+          ],
+          earliest_pending_period="2026-04",
+        )
+      )
+    )
+    assert result["error"] == "not_closeable"
+    assert result["pending_obligation_count"] == 3
+    assert result["pending_obligation_sample"][0]["schedule_name"] == (
+      "Computer Depreciation"
+    )
+    assert result["earliest_pending_period"] == "2026-04"
+    assert "sync_stale_days" not in result  # only populated when sync blocker active
 
   @pytest.mark.asyncio
   async def test_period_not_found_error(self):

--- a/tests/middleware/mcp/tools/test_fiscal_calendar_tools.py
+++ b/tests/middleware/mcp/tools/test_fiscal_calendar_tools.py
@@ -140,6 +140,47 @@ class TestClosePeriodToolHappyPath:
     assert call.kwargs["allow_stale_sync"] is False
 
   @pytest.mark.asyncio
+  async def test_response_includes_rule_summary_and_evaluated_structure_ids(self):
+    """§3.8 — the MCP close-period response must carry the same rule
+    eval fields the REST ClosePeriodResponse exposes so agents can
+    report which schedule rules passed / failed after a close."""
+    tool = ClosePeriodTool(_client(user_id="usr_abc"))
+    response = _close_response(
+      rule_summary={"pass": 3, "fail": 0, "error": 0, "skipped": 0},
+      evaluated_structure_ids=["struct_dep", "struct_amort"],
+    )
+
+    with (
+      _patch_sessions(),
+      patch(f"{MODULE}.ops_close_period", return_value=response),
+    ):
+      result = await tool.execute({"period": "2026-01"})
+
+    assert result["rule_summary"] == {
+      "pass": 3,
+      "fail": 0,
+      "error": 0,
+      "skipped": 0,
+    }
+    assert result["evaluated_structure_ids"] == ["struct_dep", "struct_amort"]
+
+  @pytest.mark.asyncio
+  async def test_response_handles_null_rule_summary(self):
+    """No schedules with facts in the period → rule_summary is None,
+    evaluated_structure_ids is an empty list. The MCP shape stays stable."""
+    tool = ClosePeriodTool(_client(user_id="usr_abc"))
+    response = _close_response()  # rule_summary defaults to None
+
+    with (
+      _patch_sessions(),
+      patch(f"{MODULE}.ops_close_period", return_value=response),
+    ):
+      result = await tool.execute({"period": "2026-01"})
+
+    assert result["rule_summary"] is None
+    assert result["evaluated_structure_ids"] == []
+
+  @pytest.mark.asyncio
   async def test_actor_id_falls_back_to_graph_scoped_sentinel(self):
     """When the MCP client has no user_id, fall back to mcp:{graph_id}
     so audit logs stay traceable per tenant (matches ReopenPeriodTool)."""

--- a/tests/operations/information_block/rules/test_engine.py
+++ b/tests/operations/information_block/rules/test_engine.py
@@ -85,43 +85,9 @@ class TestBindVariables:
     bindings = _bind_variables(session, rule, "struct_bs", None, None)
     assert bindings == {"Assets": None}
 
-  def test_falls_back_to_report_fact_when_structure_fact_missing(self) -> None:
-    """Report facts are structure-agnostic until the FactSet expand pass;
-    the rule engine should still bind them after structure facts miss."""
-    from robosystems.operations.information_block.rules.engine import _bind_variables
-
-    session = MagicMock()
-    rule = _make_rule_orm(
-      variables=[{"variable_name": "Assets", "variable_qname": "fac:Assets"}]
-    )
-    session.execute.side_effect = [
-      _scalar("elem_assets"),
-      _scalar(None),
-      _scalar(1000.0),
-    ]
-    bindings = _bind_variables(
-      session,
-      rule,
-      "struct_bs",
-      None,
-      None,
-      fallback_report_id="rep_latest",
-    )
-    assert bindings == {"Assets": 1000.0}
-
-  def test_does_not_fall_back_to_unpinned_report_fact(self) -> None:
-    from robosystems.operations.information_block.rules.engine import _bind_variables
-
-    session = MagicMock()
-    rule = _make_rule_orm(
-      variables=[{"variable_name": "Assets", "variable_qname": "fac:Assets"}]
-    )
-    session.execute.side_effect = [_scalar("elem_assets"), _scalar(None)]
-    bindings = _bind_variables(session, rule, "struct_bs", None, None)
-    assert bindings == {"Assets": None}
-    assert session.execute.call_count == 2
-
-  def test_fact_set_binding_does_not_fall_back_to_report_fact(self) -> None:
+  def test_fact_set_binding_queries_facts_table_once(self) -> None:
+    """With a pinned fact_set_id the engine queries facts by fact_set_id
+    only (one query for element lookup + one for the fact)."""
     from robosystems.operations.information_block.rules.engine import _bind_variables
 
     session = MagicMock()
@@ -135,7 +101,10 @@ class TestBindVariables:
     assert bindings == {"Assets": None}
     assert session.execute.call_count == 2
 
-  def test_can_disable_report_fallback_for_schedule_rules(self) -> None:
+  def test_structure_binding_queries_facts_table_once(self) -> None:
+    """Without a pinned fact_set_id the engine queries facts by
+    structure_id only — post §3.5 every fact has structure_id stamped,
+    so no report-id fallback is needed."""
     from robosystems.operations.information_block.rules.engine import _bind_variables
 
     session = MagicMock()
@@ -143,14 +112,7 @@ class TestBindVariables:
       variables=[{"variable_name": "Assets", "variable_qname": "fac:Assets"}]
     )
     session.execute.side_effect = [_scalar("elem_assets"), _scalar(None)]
-    bindings = _bind_variables(
-      session,
-      rule,
-      "struct_schedule",
-      None,
-      None,
-      allow_report_fallback=False,
-    )
+    bindings = _bind_variables(session, rule, "struct_bs", None, None)
     assert bindings == {"Assets": None}
     assert session.execute.call_count == 2
 
@@ -265,38 +227,6 @@ class TestBindSumVariables:
     bindings = _bind_sum_variables(session, rule, "struct_sched")
     assert bindings == {}
     session.execute.assert_not_called()
-
-
-class TestLatestReportFallback:
-  def test_returns_none_without_structure_elements(self) -> None:
-    from robosystems.operations.information_block.rules.engine import (
-      _latest_report_id_for_fallback,
-    )
-
-    session = MagicMock()
-    assert _latest_report_id_for_fallback(session, set(), None, None) is None
-    session.execute.assert_not_called()
-
-  def test_returns_latest_matching_report_id(self) -> None:
-    from robosystems.operations.information_block.rules.engine import (
-      _latest_report_id_for_fallback,
-    )
-
-    session = MagicMock()
-    session.execute.return_value = _scalar("rep_latest")
-
-    report_id = _latest_report_id_for_fallback(
-      session,
-      {"elem_assets", "elem_equity"},
-      date(2025, 1, 1),
-      date(2025, 12, 31),
-    )
-
-    assert report_id == "rep_latest"
-    stmt = str(session.execute.call_args.args[0])
-    assert "reports.created_at DESC" in stmt
-    assert "facts.report_id IS NOT NULL" in stmt
-    assert "facts.structure_id IS NULL" in stmt
 
 
 class TestEvaluateRulesForStructure:

--- a/tests/operations/roboledger/commands/test_reports.py
+++ b/tests/operations/roboledger/commands/test_reports.py
@@ -169,25 +169,19 @@ def test_persist_report_facts_stamps_structure_and_fact_set() -> None:
   )
 
   added_facts = [c[0][0] for c in session.add.call_args_list]
-  assert len(added_facts) == 3
+  # Unmapped fact is skipped — facts.fact_set_id is NOT NULL post §3.5 so
+  # a fact with no Network can't be persisted.
+  assert len(added_facts) == 2
 
   rev = next(f for f in added_facts if f.element_id == "elem_rev")
   cash = next(f for f in added_facts if f.element_id == "elem_cash")
-  unmapped = next(f for f in added_facts if f.element_id == "elem_unmapped")
 
-  assert rev.report_id == "rep_01"
   assert rev.structure_id == "struct_is"
   assert rev.fact_set_id == "fs_IS"
   assert rev.entity_id == "ent_01"
 
   assert cash.structure_id == "struct_bs"
   assert cash.fact_set_id == "fs_BS"
-
-  # Facts whose elements aren't mapped to a report-eligible structure
-  # still persist (report_id satisfies the CHECK), but carry no
-  # structure/fact_set linkage.
-  assert unmapped.structure_id is None
-  assert unmapped.fact_set_id is None
 
 
 class _FakePeriod:

--- a/tests/operations/roboledger/commands/test_schedules.py
+++ b/tests/operations/roboledger/commands/test_schedules.py
@@ -178,11 +178,17 @@ def test_update_schedule_template_change_triggers_supersession() -> None:
     _exec_result(fetchone_row=MagicMock(cnt=12)),
   ]
 
-  with patch(
-    "robosystems.operations.roboledger.commands.schedules."
-    "ScheduleService.supersede_pending_obligations",
-    return_value=12,
-  ) as supersede:
+  with (
+    patch(
+      "robosystems.operations.roboledger.commands.schedules."
+      "ScheduleService.supersede_pending_obligations",
+      return_value=12,
+    ) as supersede,
+    patch(
+      "robosystems.operations.roboledger.commands.schedules.evaluate_rules_for_structure",
+      return_value=[],
+    ) as eval_rules,
+  ):
     update_schedule(
       session,
       UpdateScheduleRequest(
@@ -202,6 +208,11 @@ def test_update_schedule_template_change_triggers_supersession() -> None:
   kwargs = supersede.call_args.kwargs
   assert kwargs["structure"] is structure
   assert kwargs["created_by"] == "usr_admin"
+  # §3.8: template change re-runs the rule engine.
+  eval_rules.assert_called_once()
+  rule_kwargs = eval_rules.call_args.kwargs
+  assert eval_rules.call_args.args[1] == "struct_sched"
+  assert rule_kwargs["created_by"] == "usr_admin"
 
 
 def test_update_schedule_no_template_change_skips_supersession() -> None:

--- a/tests/operations/roboledger/fiscal_calendar/test_close_service.py
+++ b/tests/operations/roboledger/fiscal_calendar/test_close_service.py
@@ -438,11 +438,6 @@ class TestCloseAutoRunsRules:
     )
     return session, eval_patcher
 
-  def _result(status: str):  # type: ignore[no-redef]
-    r = MagicMock()
-    r.status = status
-    return r
-
   def test_rule_summary_aggregates_across_schedules(self):
     fcs = _mock_fcs(gate_result=CloseableGateResult(is_closeable=True))
     svc = PeriodCloseService(fcs)

--- a/tests/operations/roboledger/fiscal_calendar/test_close_service.py
+++ b/tests/operations/roboledger/fiscal_calendar/test_close_service.py
@@ -400,3 +400,137 @@ class TestStaleSyncAudit:
 
     call = fcs.advance_closed_through.call_args
     assert call.kwargs["note"] == "month-end close"
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# §3.8 — Auto-run rules on close
+# ────────────────────────────────────────────────────────────────────────────
+
+
+class TestCloseAutoRunsRules:
+  """Verify the close service evaluates rules for schedules with facts in
+  the closing period (§3.8 rule-engine auto-run)."""
+
+  def _session_with_schedules_and_rule_results(
+    self, fp, schedule_ids: list[str], rule_results_per_struct: dict
+  ):
+    """Build a session whose schedule query returns the given structure
+    ids and whose rule eval returns the configured results per id."""
+    from unittest.mock import patch
+
+    session = _mock_session_with_fp(fp)
+
+    # Override session.execute to return the BS row first, then the
+    # schedule id list for the new §3.8 query.
+    bs_row = MagicMock()
+    bs_row.total_debit = 0
+    bs_row.total_credit = 0
+    bs_exec = MagicMock()
+    bs_exec.fetchone.return_value = bs_row
+    schedules_exec = MagicMock()
+    schedules_exec.scalars.return_value.all.return_value = schedule_ids
+    session.execute.side_effect = [bs_exec, schedules_exec]
+
+    eval_patcher = patch(
+      "robosystems.operations.information_block.rules.engine."
+      "evaluate_rules_for_structure",
+      side_effect=lambda s, sid, **kw: rule_results_per_struct.get(sid, []),
+    )
+    return session, eval_patcher
+
+  def _result(status: str):  # type: ignore[no-redef]
+    r = MagicMock()
+    r.status = status
+    return r
+
+  def test_rule_summary_aggregates_across_schedules(self):
+    fcs = _mock_fcs(gate_result=CloseableGateResult(is_closeable=True))
+    svc = PeriodCloseService(fcs)
+
+    _r = lambda status: MagicMock(status=status)  # noqa: E731
+    session, eval_patcher = self._session_with_schedules_and_rule_results(
+      _fp(status="open"),
+      schedule_ids=["struct_a", "struct_b"],
+      rule_results_per_struct={
+        "struct_a": [_r("pass"), _r("pass"), _r("fail")],
+        "struct_b": [_r("pass"), _r("error")],
+      },
+    )
+
+    with eval_patcher as mock_eval:
+      result = svc.close(
+        session,
+        GRAPH_ID,
+        "2026-01",
+        actor_id="usr_1",
+        has_sync_connection=False,
+        last_sync_at=None,
+      )
+
+    assert result.rule_summary == {"pass": 3, "fail": 1, "error": 1, "skipped": 0}
+    assert result.evaluated_structure_ids == ("struct_a", "struct_b")
+    assert mock_eval.call_count == 2
+
+  def test_no_schedules_returns_none_summary(self):
+    fcs = _mock_fcs(gate_result=CloseableGateResult(is_closeable=True))
+    svc = PeriodCloseService(fcs)
+
+    session, eval_patcher = self._session_with_schedules_and_rule_results(
+      _fp(status="open"), schedule_ids=[], rule_results_per_struct={}
+    )
+
+    with eval_patcher as mock_eval:
+      result = svc.close(
+        session,
+        GRAPH_ID,
+        "2026-01",
+        actor_id="usr_1",
+        has_sync_connection=False,
+        last_sync_at=None,
+      )
+
+    assert result.rule_summary is None
+    assert result.evaluated_structure_ids == ()
+    mock_eval.assert_not_called()
+
+  def test_rule_eval_failure_isolated_from_close_success(self):
+    """A bare exception out of the rule engine is logged and skipped — the
+    close still succeeds with whatever results were tallied beforehand."""
+    fcs = _mock_fcs(gate_result=CloseableGateResult(is_closeable=True))
+    svc = PeriodCloseService(fcs)
+
+    _r = lambda status: MagicMock(status=status)  # noqa: E731
+    session = _mock_session_with_fp(_fp(status="open"))
+    bs_row = MagicMock()
+    bs_row.total_debit = 0
+    bs_row.total_credit = 0
+    bs_exec = MagicMock()
+    bs_exec.fetchone.return_value = bs_row
+    schedules_exec = MagicMock()
+    schedules_exec.scalars.return_value.all.return_value = ["struct_ok", "struct_bad"]
+    session.execute.side_effect = [bs_exec, schedules_exec]
+
+    from unittest.mock import patch
+
+    def _eval(session, sid, **kw):
+      if sid == "struct_bad":
+        raise RuntimeError("schema mismatch")
+      return [_r("pass")]
+
+    with patch(
+      "robosystems.operations.information_block.rules.engine."
+      "evaluate_rules_for_structure",
+      side_effect=_eval,
+    ):
+      result = svc.close(
+        session,
+        GRAPH_ID,
+        "2026-01",
+        actor_id="usr_1",
+        has_sync_connection=False,
+        last_sync_at=None,
+      )
+
+    # close succeeded — only the good schedule's results land in the summary
+    assert result.rule_summary == {"pass": 1, "fail": 0, "error": 0, "skipped": 0}
+    assert result.evaluated_structure_ids == ("struct_ok", "struct_bad")

--- a/uv.lock
+++ b/uv.lock
@@ -3459,7 +3459,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.32.0,<3.0" },
     { name = "retrying", specifier = ">=1.4.0,<2.0" },
     { name = "rich", marker = "extra == 'dev'", specifier = ">=14.0.0,<15.0" },
-    { name = "robosystems-client", marker = "extra == 'dev'", specifier = "==0.3.24" },
+    { name = "robosystems-client", marker = "extra == 'dev'", specifier = "==0.3.25" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0,<1.0" },
     { name = "sqlalchemy", specifier = ">=2.0.0,<3.0" },
     { name = "sse-starlette", specifier = ">=3.3.0,<4.0" },
@@ -3482,7 +3482,7 @@ lambda = [
 
 [[package]]
 name = "robosystems-client"
-version = "0.3.24"
+version = "0.3.25"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -3491,9 +3491,9 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cb/45/f92dbc277301bd92fba54e0398420e52b57dfad31ae0475adcdba55e08b2/robosystems_client-0.3.24.tar.gz", hash = "sha256:7b0f9ebae68d8367a04c5e4c76bf53f6973e00db868038c65986d9d7e2fb3175", size = 375128, upload-time = "2026-05-07T23:42:53.478Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/48/db/5fc442fc488655e38e871c4ce328fe2eb13e8e743a86d5c1252943f07c3c/robosystems_client-0.3.25.tar.gz", hash = "sha256:607ef07a3506b2575631c36648826015dcdcf468cf8af8c8c03fbc9f5987de72", size = 378275, upload-time = "2026-05-14T03:00:25.389Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/65/15ceafc9b45889d8ba4e991e24068368f22c6e4e9e85206081117f9aff92/robosystems_client-0.3.24-py3-none-any.whl", hash = "sha256:af0a9702cbbb8a5ab82f8670083ac9dec8bb8be159e39412496dc9c9b536fdf4", size = 871904, upload-time = "2026-05-07T23:42:51.218Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/92/83e30e0f4a5fd0e573b6cab1da3d19cfb18d109afb37f13f1d4a575aec5f/robosystems_client-0.3.25-py3-none-any.whl", hash = "sha256:e44fe39c35756e06efb32481f9371ae35594754d101b8ede8e0c4457fbb43b97", size = 878671, upload-time = "2026-05-14T03:00:20.489Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This PR enhances the fiscal calendar close process by integrating rule evaluation, restructures FactSet and report relationships for improved data integrity, and provides more detailed error reporting when gate closure fails due to pending obligations.

## Key Accomplishments

### Fiscal Calendar Close Enhancements
- Enhanced the fiscal calendar close service with rule evaluation capabilities, ensuring that closing a fiscal period validates all required obligations before proceeding.
- `CloseGateFailed` and `HTTPException` responses now include detailed pending obligations information, giving consumers clear visibility into what's blocking a period close.
- Added new API model extensions for fiscal calendar to support richer close-process responses.

### FactSet & Report Relationship Refactoring
- Dropped the `report_id` foreign key from the facts table (migration `0010`), decoupling facts from direct report associations in favor of the FactSet relationship.
- Added `phase_c_required` constraint (migration `0011`) to enforce data integrity at the database level.
- Updated FactSet and Fact models to reflect the new relationship structure, improving how facts are associated with reporting periods.

### Rules Engine Simplification
- Significantly reduced complexity in the information block rules engine (~70 lines removed), extracting and relocating rule evaluation logic to the fiscal calendar close service where it is contextually relevant.

### Ingestion Limits & Graph Middleware
- Enhanced ingestion limits logic with additional validation and guard rails.
- Expanded MCP fiscal calendar tools with richer functionality for close operations.

### Dependency Updates
- Updated `robosystems-client` to version 0.3.25.

### Taxonomy
- Minor adjustments to the `rs-gaap-base/v1.json` framework definition.

## Breaking Changes

- **Database migrations required**: Two new migrations (`0010_drop_facts_report_id` and `0011_phase_c_required`) alter the facts table schema. The removal of `report_id` from facts is a structural change that may affect downstream queries or services relying on direct fact-to-report joins.
- **API response changes**: `CloseGateFailed` errors now return a different response shape that includes pending obligations detail. Consumers parsing these errors should be updated accordingly.
- **Rules engine interface**: The rules engine has been simplified; any external callers relying on the previous evaluation interface within the information block rules module should migrate to the fiscal calendar close service.

## Testing Notes

- Comprehensive test coverage added for the fiscal calendar close service (`test_close_service.py` — 134 new lines).
- New tests for ingestion limits middleware (84 new lines).
- Expanded tests for MCP fiscal calendar tools, schedule commands, and report commands.
- Rules engine tests were reduced in tandem with the code simplification, confirming the migration of responsibility.
- All existing test files for affected modules have been updated to reflect the new behavior.

## Infrastructure Considerations

- Two new database migrations must be applied in sequence before deployment. Ensure migration rollout is coordinated, especially in environments where the `report_id` column on facts may still be referenced.
- The updated `robosystems-client` dependency (0.3.25) should be verified for compatibility across all deployed services consuming this library.
- The lock file (`uv.lock`) has been updated accordingly.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

**Branch Info:**
- Source: `feature/factset-cleanup`
- Target: `main`
- Type: feature

Co-Authored-By: Claude <noreply@anthropic.com>