### PR TITLE
feat: Add AR/AP duality support with event handlers and ledger reads

### DIFF
--- a/robosystems/adapters/quickbooks/dbt/models/ledger/transactions.sql
+++ b/robosystems/adapters/quickbooks/dbt/models/ledger/transactions.sql
@@ -16,23 +16,23 @@ with entries as (
   select * from {{ ref('stg_qb_journal_entries') }}
 ),
 invoice_headers as (
-  select tx_type, tx_id, agent_external_id, agent_type
+  select tx_type, tx_id, agent_external_id, agent_type, linked_txns
   from {{ ref('stg_qb_invoice_headers') }}
 ),
 bill_headers as (
-  select tx_type, tx_id, agent_external_id, agent_type
+  select tx_type, tx_id, agent_external_id, agent_type, linked_txns
   from {{ ref('stg_qb_bill_headers') }}
 ),
 payment_headers as (
-  select tx_type, tx_id, agent_external_id, agent_type
+  select tx_type, tx_id, agent_external_id, agent_type, linked_txns
   from {{ ref('stg_qb_payment_headers') }}
 ),
 bill_payment_headers as (
-  select tx_type, tx_id, agent_external_id, agent_type
+  select tx_type, tx_id, agent_external_id, agent_type, linked_txns
   from {{ ref('stg_qb_bill_payment_headers') }}
 ),
 sales_receipt_headers as (
-  select tx_type, tx_id, agent_external_id, agent_type
+  select tx_type, tx_id, agent_external_id, agent_type, linked_txns
   from {{ ref('stg_qb_sales_receipt_headers') }}
 ),
 purchase_headers as (
@@ -40,7 +40,7 @@ purchase_headers as (
   -- The Python flattener emits multiple header rows per Purchase (one per
   -- candidate tx_type JournalReport might use for that PaymentType), so the
   -- LEFT JOIN below resolves to whichever flavor matched.
-  select tx_type, tx_id, agent_external_id, agent_type
+  select tx_type, tx_id, agent_external_id, agent_type, linked_txns
   from {{ ref('stg_qb_purchase_headers') }}
 ),
 all_headers as (
@@ -125,7 +125,13 @@ select
       else 'adjustment'
     end                                                as event_category,
     h.agent_external_id                                as agent_external_id,
-    h.agent_type                                       as agent_type
+    h.agent_type                                       as agent_type,
+    -- linked_txns is a JSON-stringified [{txn_id, txn_type}] list,
+    -- populated only for Payment + BillPayment headers; defaults to
+    -- '[]' elsewhere. The loader forwards it to event metadata as
+    -- qb_linked_txns; the payment_received / bill_paid handlers walk
+    -- it to set discharges_event_id.
+    coalesce(h.linked_txns, '[]')                      as linked_txns
 from entries e
 left join all_headers h
   on h.tx_type = e.tx_type and h.tx_id = e.tx_number

--- a/robosystems/adapters/quickbooks/dbt/models/staging/stg_qb_bill_headers.sql
+++ b/robosystems/adapters/quickbooks/dbt/models/staging/stg_qb_bill_headers.sql
@@ -16,5 +16,6 @@ select
   cast("currency" as varchar) as currency,
   cast("memo" as varchar) as memo,
   cast("agent_external_id" as varchar) as agent_external_id,
-  cast("agent_type" as varchar) as agent_type
+  cast("agent_type" as varchar) as agent_type,
+  cast("linked_txns" as varchar) as linked_txns
 from source

--- a/robosystems/adapters/quickbooks/dbt/models/staging/stg_qb_bill_payment_headers.sql
+++ b/robosystems/adapters/quickbooks/dbt/models/staging/stg_qb_bill_payment_headers.sql
@@ -16,5 +16,6 @@ select
   cast("currency" as varchar) as currency,
   cast("memo" as varchar) as memo,
   cast("agent_external_id" as varchar) as agent_external_id,
-  cast("agent_type" as varchar) as agent_type
+  cast("agent_type" as varchar) as agent_type,
+  cast("linked_txns" as varchar) as linked_txns
 from source

--- a/robosystems/adapters/quickbooks/dbt/models/staging/stg_qb_invoice_headers.sql
+++ b/robosystems/adapters/quickbooks/dbt/models/staging/stg_qb_invoice_headers.sql
@@ -16,5 +16,6 @@ select
   cast("currency" as varchar) as currency,
   cast("memo" as varchar) as memo,
   cast("agent_external_id" as varchar) as agent_external_id,
-  cast("agent_type" as varchar) as agent_type
+  cast("agent_type" as varchar) as agent_type,
+  cast("linked_txns" as varchar) as linked_txns
 from source

--- a/robosystems/adapters/quickbooks/dbt/models/staging/stg_qb_payment_headers.sql
+++ b/robosystems/adapters/quickbooks/dbt/models/staging/stg_qb_payment_headers.sql
@@ -16,5 +16,6 @@ select
   cast("currency" as varchar) as currency,
   cast("memo" as varchar) as memo,
   cast("agent_external_id" as varchar) as agent_external_id,
-  cast("agent_type" as varchar) as agent_type
+  cast("agent_type" as varchar) as agent_type,
+  cast("linked_txns" as varchar) as linked_txns
 from source

--- a/robosystems/adapters/quickbooks/dbt/models/staging/stg_qb_purchase_headers.sql
+++ b/robosystems/adapters/quickbooks/dbt/models/staging/stg_qb_purchase_headers.sql
@@ -16,5 +16,6 @@ select
   cast("currency" as varchar) as currency,
   cast("memo" as varchar) as memo,
   cast("agent_external_id" as varchar) as agent_external_id,
-  cast("agent_type" as varchar) as agent_type
+  cast("agent_type" as varchar) as agent_type,
+  cast("linked_txns" as varchar) as linked_txns
 from source

--- a/robosystems/adapters/quickbooks/dbt/models/staging/stg_qb_sales_receipt_headers.sql
+++ b/robosystems/adapters/quickbooks/dbt/models/staging/stg_qb_sales_receipt_headers.sql
@@ -16,5 +16,6 @@ select
   cast("currency" as varchar) as currency,
   cast("memo" as varchar) as memo,
   cast("agent_external_id" as varchar) as agent_external_id,
-  cast("agent_type" as varchar) as agent_type
+  cast("agent_type" as varchar) as agent_type,
+  cast("linked_txns" as varchar) as linked_txns
 from source

--- a/robosystems/adapters/quickbooks/dbt/seeds/raw_bill_headers.csv
+++ b/robosystems/adapters/quickbooks/dbt/seeds/raw_bill_headers.csv
@@ -1,2 +1,2 @@
-tx_type,tx_id,external_id,txn_date,doc_number,total_amount,currency,memo,agent_external_id,agent_type
-Bill,77,Bill_77,2026-02-05,BILL-77,500.00,USD,Office supplies,qb_vend_1,vendor
+tx_type,tx_id,external_id,txn_date,doc_number,total_amount,currency,memo,agent_external_id,agent_type,linked_txns
+Bill,77,Bill_77,2026-02-05,BILL-77,500.00,USD,Office supplies,qb_vend_1,vendor,[]

--- a/robosystems/adapters/quickbooks/dbt/seeds/raw_bill_payment_headers.csv
+++ b/robosystems/adapters/quickbooks/dbt/seeds/raw_bill_payment_headers.csv
@@ -1,2 +1,2 @@
-tx_type,tx_id,external_id,txn_date,doc_number,total_amount,currency,memo,agent_external_id,agent_type
-BillPayment,55,BillPayment_55,2026-02-15,CHK-1001,500.00,USD,Paid Bill_77,qb_vend_1,vendor
+tx_type,tx_id,external_id,txn_date,doc_number,total_amount,currency,memo,agent_external_id,agent_type,linked_txns
+BillPayment,55,BillPayment_55,2026-02-15,CHK-1001,500.00,USD,Paid Bill_77,qb_vend_1,vendor,"[{""txn_id"":""77"",""txn_type"":""Bill""}]"

--- a/robosystems/adapters/quickbooks/dbt/seeds/raw_invoice_headers.csv
+++ b/robosystems/adapters/quickbooks/dbt/seeds/raw_invoice_headers.csv
@@ -1,2 +1,2 @@
-tx_type,tx_id,external_id,txn_date,doc_number,total_amount,currency,memo,agent_external_id,agent_type
-Invoice,42,Invoice_42,2026-02-01,INV-42,1000.00,USD,Consulting services,qb_cust_1,customer
+tx_type,tx_id,external_id,txn_date,doc_number,total_amount,currency,memo,agent_external_id,agent_type,linked_txns
+Invoice,42,Invoice_42,2026-02-01,INV-42,1000.00,USD,Consulting services,qb_cust_1,customer,[]

--- a/robosystems/adapters/quickbooks/dbt/seeds/raw_payment_headers.csv
+++ b/robosystems/adapters/quickbooks/dbt/seeds/raw_payment_headers.csv
@@ -1,2 +1,2 @@
-tx_type,tx_id,external_id,txn_date,doc_number,total_amount,currency,memo,agent_external_id,agent_type
-Payment,99,Payment_99,2026-02-10,PMT-99,1000.00,USD,Receipt against INV-42,qb_cust_1,customer
+tx_type,tx_id,external_id,txn_date,doc_number,total_amount,currency,memo,agent_external_id,agent_type,linked_txns
+Payment,99,Payment_99,2026-02-10,PMT-99,1000.00,USD,Receipt against INV-42,qb_cust_1,customer,"[{""txn_id"":""42"",""txn_type"":""Invoice""}]"

--- a/robosystems/adapters/quickbooks/dbt/seeds/raw_purchase_headers.csv
+++ b/robosystems/adapters/quickbooks/dbt/seeds/raw_purchase_headers.csv
@@ -1,5 +1,5 @@
-tx_type,tx_id,external_id,txn_date,doc_number,total_amount,currency,memo,agent_external_id,agent_type
-Cash Expense,201,Purchase_201,2026-02-08,EXP-201,42.50,USD,Office supplies (cash),qb_vend_2,vendor
-Expense,201,Purchase_201,2026-02-08,EXP-201,42.50,USD,Office supplies (cash),qb_vend_2,vendor
-Check,202,Purchase_202,2026-02-15,CHK-1042,1250.00,USD,Monthly rent,qb_vend_3,vendor
-Credit Card Expense,203,Purchase_203,2026-02-22,,89.99,USD,SaaS subscription,qb_vend_4,vendor
+tx_type,tx_id,external_id,txn_date,doc_number,total_amount,currency,memo,agent_external_id,agent_type,linked_txns
+Cash Expense,201,Purchase_201,2026-02-08,EXP-201,42.50,USD,Office supplies (cash),qb_vend_2,vendor,[]
+Expense,201,Purchase_201,2026-02-08,EXP-201,42.50,USD,Office supplies (cash),qb_vend_2,vendor,[]
+Check,202,Purchase_202,2026-02-15,CHK-1042,1250.00,USD,Monthly rent,qb_vend_3,vendor,[]
+Credit Card Expense,203,Purchase_203,2026-02-22,,89.99,USD,SaaS subscription,qb_vend_4,vendor,[]

--- a/robosystems/adapters/quickbooks/dbt/seeds/raw_sales_receipt_headers.csv
+++ b/robosystems/adapters/quickbooks/dbt/seeds/raw_sales_receipt_headers.csv
@@ -1,2 +1,2 @@
-tx_type,tx_id,external_id,txn_date,doc_number,total_amount,currency,memo,agent_external_id,agent_type
-SalesReceipt,88,SalesReceipt_88,2026-02-20,SR-200,250.00,USD,Cash sale,qb_cust_2,customer
+tx_type,tx_id,external_id,txn_date,doc_number,total_amount,currency,memo,agent_external_id,agent_type,linked_txns
+SalesReceipt,88,SalesReceipt_88,2026-02-20,SR-200,250.00,USD,Cash sale,qb_cust_2,customer,[]

--- a/robosystems/adapters/quickbooks/pipeline/utils.py
+++ b/robosystems/adapters/quickbooks/pipeline/utils.py
@@ -324,8 +324,38 @@ def flatten_employees(raw: list[Any]) -> list[dict[str, Any]]:
   return _flatten_party(raw, "employee", {})
 
 
+def _extract_linked_txns(data: dict[str, Any]) -> str:
+  """Pull LinkedTxn[] refs from a QB Payment/BillPayment's Line array.
+
+  QB Payment / BillPayment carry one or more ``Line`` entries; each line
+  has a ``LinkedTxn`` list naming the Invoice (for Payment) or Bill (for
+  BillPayment) it settles. QB's canonical TxnType strings ("Invoice",
+  "Bill") align with the composite-id prefix used everywhere else in
+  this pipeline, so the discharge handler can reconstruct the
+  originating event's ``external_id`` as ``"{TxnType}_{TxnId}"``.
+
+  Returns a JSON-stringified list of ``{txn_id, txn_type}`` dicts; empty
+  string-encoded list when nothing's linked. JSON string (not dict /
+  list) because the downstream parquet → DuckDB → dbt path needs a
+  scalar column type.
+  """
+  refs: list[dict[str, str]] = []
+  for line in data.get("Line", []) or []:
+    for linked in line.get("LinkedTxn", []) or []:
+      txn_id = str(linked.get("TxnId", "") or "")
+      txn_type = str(linked.get("TxnType", "") or "")
+      if txn_id and txn_type:
+        refs.append({"txn_id": txn_id, "txn_type": txn_type})
+  return json.dumps(refs)
+
+
 def _flatten_txn_header(
-  raw_list: list[Any], qb_class: str, agent_ref_field: str, agent_type: str
+  raw_list: list[Any],
+  qb_class: str,
+  agent_ref_field: str,
+  agent_type: str,
+  *,
+  extract_linked_txns: bool = False,
 ) -> list[dict[str, Any]]:
   """Shared flattener for Invoice / Bill / Payment headers.
 
@@ -336,6 +366,12 @@ def _flatten_txn_header(
 
   ``qb_class`` matches the prefix used by ``parse_journal_report`` to build
   composite tx ids (e.g. ``Invoice_123``).
+
+  ``extract_linked_txns`` opt-in surfaces QB's LinkedTxn[] refs into the
+  ``linked_txns`` column for header types that carry duality links
+  (Payment → Invoice, BillPayment → Bill). All other header types emit
+  an empty JSON array so the UNION ALL in transactions.sql sees a
+  consistent column shape.
 
   Per-class field notes:
   - ``DocNumber`` exists on Invoice and Bill but NOT on Payment (per Intuit
@@ -358,6 +394,7 @@ def _flatten_txn_header(
         "memo": data.get("PrivateNote", "") or "",
         "agent_external_id": str(agent_ref.get("value", "")) if agent_ref else "",
         "agent_type": agent_type,
+        "linked_txns": _extract_linked_txns(data) if extract_linked_txns else "[]",
       }
     )
   return rows
@@ -372,11 +409,15 @@ def flatten_bill_headers(raw: list[Any]) -> list[dict[str, Any]]:
 
 
 def flatten_payment_headers(raw: list[Any]) -> list[dict[str, Any]]:
-  return _flatten_txn_header(raw, "Payment", "CustomerRef", "customer")
+  return _flatten_txn_header(
+    raw, "Payment", "CustomerRef", "customer", extract_linked_txns=True
+  )
 
 
 def flatten_bill_payment_headers(raw: list[Any]) -> list[dict[str, Any]]:
-  return _flatten_txn_header(raw, "BillPayment", "VendorRef", "vendor")
+  return _flatten_txn_header(
+    raw, "BillPayment", "VendorRef", "vendor", extract_linked_txns=True
+  )
 
 
 def flatten_sales_receipt_headers(raw: list[Any]) -> list[dict[str, Any]]:
@@ -436,6 +477,9 @@ def flatten_purchase_headers(raw: list[Any]) -> list[dict[str, Any]]:
       "memo": data.get("PrivateNote", "") or "",
       "agent_external_id": str(entity_ref.get("value", "")) if entity_ref else "",
       "agent_type": agent_type,
+      # Purchases (cash-side expenses) are not settlements; LinkedTxn
+      # is empty.
+      "linked_txns": "[]",
     }
     for candidate in candidate_tx_types:
       rows.append({**base_row, "tx_type": candidate})
@@ -566,6 +610,9 @@ _TXN_HEADER_SCHEMA = {
   "memo": "str",
   "agent_external_id": "str",
   "agent_type": "str",
+  # JSON-stringified [{txn_id, txn_type}] list — populated only for
+  # Payment + BillPayment headers; other types emit "[]".
+  "linked_txns": "str",
 }
 
 

--- a/robosystems/graphql/resolvers/ledger.py
+++ b/robosystems/graphql/resolvers/ledger.py
@@ -45,6 +45,8 @@ from robosystems.graphql.types.ledger import (
   MappedTrialBalance,
   MappingCoverage,
   MappingDetail,
+  OpenBalanceAggregate,
+  OpenBalanceByAgent,
   PeriodCloseStatus,
   PeriodDrafts,
   PublishListDetail,
@@ -68,6 +70,9 @@ from robosystems.operations.roboledger.reads import (
 )
 from robosystems.operations.roboledger.reads import (
   agent as reads_agent,
+)
+from robosystems.operations.roboledger.reads import (
+  ar_ap as reads_ar_ap,
 )
 from robosystems.operations.roboledger.reads import (
   closing_book as reads_closing_book,
@@ -216,6 +221,57 @@ class LedgerQuery:
     except (ValueError, ProgrammingError):
       _raise_ledger_not_initialized()
     return [Agent.from_pydantic(r) for r in responses]
+
+  # ── AR / AP open balances ───────────────────────────────────────────────
+
+  @strawberry.field
+  def open_receivables(self, info: Info[GraphQLContext, None]) -> OpenBalanceAggregate:
+    """Graph-wide open AR — total + counterparty count + open invoice count.
+
+    Derived from the event duality chain: sum of unsettled
+    ``invoice_issued`` / ``sales_receipt_recorded`` amounts minus
+    discharges pointed at them. See ``event-driven-ledger.md`` §5.1.
+    """
+    try:
+      with _open_session(info, "roboledger") as session:
+        response = reads_ar_ap.compute_open_receivables(session)
+    except (ValueError, ProgrammingError):
+      _raise_ledger_not_initialized()
+    return OpenBalanceAggregate.from_pydantic(response)
+
+  @strawberry.field
+  def open_payables(self, info: Info[GraphQLContext, None]) -> OpenBalanceAggregate:
+    """Graph-wide open AP — symmetric to ``open_receivables``."""
+    try:
+      with _open_session(info, "roboledger") as session:
+        response = reads_ar_ap.compute_open_payables(session)
+    except (ValueError, ProgrammingError):
+      _raise_ledger_not_initialized()
+    return OpenBalanceAggregate.from_pydantic(response)
+
+  @strawberry.field
+  def open_receivables_by_agent(
+    self, info: Info[GraphQLContext, None]
+  ) -> list[OpenBalanceByAgent]:
+    """Per-counterparty open AR rows, ordered by absolute balance descending."""
+    try:
+      with _open_session(info, "roboledger") as session:
+        responses = reads_ar_ap.list_open_receivables_by_agent(session)
+    except (ValueError, ProgrammingError):
+      _raise_ledger_not_initialized()
+    return [OpenBalanceByAgent.from_pydantic(r) for r in responses]
+
+  @strawberry.field
+  def open_payables_by_agent(
+    self, info: Info[GraphQLContext, None]
+  ) -> list[OpenBalanceByAgent]:
+    """Per-counterparty open AP rows, ordered by absolute balance descending."""
+    try:
+      with _open_session(info, "roboledger") as session:
+        responses = reads_ar_ap.list_open_payables_by_agent(session)
+    except (ValueError, ProgrammingError):
+      _raise_ledger_not_initialized()
+    return [OpenBalanceByAgent.from_pydantic(r) for r in responses]
 
   # ── Event blocks (inbox) ────────────────────────────────────────────────
 

--- a/robosystems/graphql/types/ledger.py
+++ b/robosystems/graphql/types/ledger.py
@@ -53,6 +53,12 @@ from robosystems.models.api.extensions.accounts import (
 from robosystems.models.api.extensions.agent import (
   LedgerAgentResponse as PydanticAgentResponse,
 )
+from robosystems.models.api.extensions.ar_ap import (
+  OpenBalanceAggregate as PydanticOpenBalanceAggregate,
+)
+from robosystems.models.api.extensions.ar_ap import (
+  OpenBalanceByAgent as PydanticOpenBalanceByAgent,
+)
 from robosystems.models.api.extensions.closing_book import (
   ClosingBookCategory as PydanticClosingBookCategory,
 )
@@ -249,6 +255,52 @@ class Agent:
       updated_at=row.updated_at,
       created_by=row.created_by,
     )
+
+  @strawberry.field
+  def open_receivable(self, info: strawberry.Info) -> OpenBalanceByAgent | None:
+    """This agent's open AR balance, or null when fully settled.
+
+    Single-agent lookup; resolves in one SQL round-trip. Querying this
+    on a paginated `agents` list triggers N+1 — wrap with a dataloader
+    when list views need it. The drill-in detail flow (one agent at a
+    time) is the supported v1 use case.
+    """
+    from robosystems.graphql.resolvers._common import open_extensions_session
+    from robosystems.operations.roboledger.reads import ar_ap as reads_ar_ap
+
+    with open_extensions_session(info, "roboledger") as session:
+      response = reads_ar_ap.get_open_receivable_for_agent(session, self.id)
+    if response is None:
+      return None
+    return OpenBalanceByAgent.from_pydantic(response)
+
+  @strawberry.field
+  def open_payable(self, info: strawberry.Info) -> OpenBalanceByAgent | None:
+    """This agent's open AP balance, or null when fully settled.
+
+    Same N+1 caveat as ``open_receivable``.
+    """
+    from robosystems.graphql.resolvers._common import open_extensions_session
+    from robosystems.operations.roboledger.reads import ar_ap as reads_ar_ap
+
+    with open_extensions_session(info, "roboledger") as session:
+      response = reads_ar_ap.get_open_payable_for_agent(session, self.id)
+    if response is None:
+      return None
+    return OpenBalanceByAgent.from_pydantic(response)
+
+
+# ── AR / AP open balances ─────────────────────────────────────────────────
+
+
+@pydantic_type(model=PydanticOpenBalanceAggregate, all_fields=True)
+class OpenBalanceAggregate:
+  """Graph-wide open AR or AP totals (event-driven-ledger.md §5.1)."""
+
+
+@pydantic_type(model=PydanticOpenBalanceByAgent, all_fields=True)
+class OpenBalanceByAgent:
+  """Per-counterparty open balance row."""
 
 
 # ── Event blocks (inbox) ──────────────────────────────────────────────────

--- a/robosystems/models/api/extensions/__init__.py
+++ b/robosystems/models/api/extensions/__init__.py
@@ -11,6 +11,10 @@ from .accounts import (
   AccountTreeNode,
   AccountTreeResponse,
 )
+from .ar_ap import (
+  OpenBalanceAggregate,
+  OpenBalanceByAgent,
+)
 from .closing_book import (
   ClosingBookCategory,
   ClosingBookItem,
@@ -106,6 +110,8 @@ __all__ = [
   "LiveFinancialStatementRequest",
   "LiveFinancialStatementResponse",
   "LiveStatementFactRow",
+  "OpenBalanceAggregate",
+  "OpenBalanceByAgent",
   "PortfolioBlockEnvelope",
   "PortfolioBlockPortfolioFields",
   "PortfolioBlockPortfolioPatch",

--- a/robosystems/models/api/extensions/ar_ap.py
+++ b/robosystems/models/api/extensions/ar_ap.py
@@ -1,0 +1,65 @@
+"""AR/AP response models — open-balance projections derived from the event
+duality chain (event-driven-ledger.md §5.1).
+
+AR ("Accounts Receivable") = sum of ``invoice_issued`` events minus
+matching ``payment_received`` discharges. AP ("Accounts Payable") =
+sum of ``bill_received`` events minus matching ``bill_paid``
+discharges. Numbers come straight from ``events.amount`` — no GL roll
+required — so an open balance is auditable in one query.
+
+Amounts are stored in minor currency units (cents); response models
+preserve that for backend math. UI layers display-format on render.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class OpenBalanceAggregate(BaseModel):
+  """Graph-wide open AR or open AP aggregate.
+
+  ``total_open_cents`` is the sum of unsettled originating-event
+  balances; ``counterparty_count`` is the number of distinct agents
+  with at least one open invoice or bill. The currency is uniform
+  per graph today (mixed-currency books would need a per-currency
+  breakdown — out of scope for v1).
+  """
+
+  model_config = ConfigDict(from_attributes=True)
+
+  total_open_cents: int = Field(
+    ..., description="Sum of unsettled balances in minor currency units."
+  )
+  counterparty_count: int = Field(
+    ..., description="Distinct agents with at least one open balance."
+  )
+  open_event_count: int = Field(
+    ..., description="Distinct originating events with a nonzero open balance."
+  )
+  currency: str = Field("USD", description="Currency code (uniform per graph).")
+
+
+class OpenBalanceByAgent(BaseModel):
+  """Per-agent open balance row.
+
+  Used for both the aging-by-counterparty list and the per-Agent
+  GraphQL field. ``open_balance_cents`` reflects only the unsettled
+  remainder (sum of originating amounts minus sum of discharges) so
+  partial-payment chains net out correctly.
+  """
+
+  model_config = ConfigDict(from_attributes=True)
+
+  agent_id: str
+  open_balance_cents: int = Field(
+    ...,
+    description=(
+      "Unsettled originating-event amounts minus discharges, in minor "
+      "currency units. Positive for normal AR/AP; negative when overpaid."
+    ),
+  )
+  open_event_count: int = Field(
+    ..., description="Number of originating events with nonzero balance for this agent."
+  )
+  currency: str = Field("USD")

--- a/robosystems/operations/event_block/python_handlers/bill_paid.py
+++ b/robosystems/operations/event_block/python_handlers/bill_paid.py
@@ -1,0 +1,68 @@
+"""Bill paid event handler — AP-side duality resolution.
+
+Symmetric counterpart to ``payment_received``. The QB BillPayment row
+arrives with the same nested-entries metadata shape as
+``journal_entry_recorded`` (DR AP / CR Cash); the journal handler
+writes the GL rows unchanged, and this handler resolves the discharge
+link so ``event.discharges_event_id`` points at the originating
+``bill_received`` event.
+
+See ``payment_received`` for the matching algorithm — same two-stage
+lookup (LinkedTxn first, qb_reference_number ↔ qb_doc_number fallback)
+with the candidate event-type set restricted to AP origins.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from robosystems.models.api.event_block import CreateEventBlockRequest
+from robosystems.models.extensions.roboledger.event import Event
+
+from .journal_entry_recorded import (
+  JournalEntryRecordedMetadata,
+)
+from .journal_entry_recorded import (
+  dispatch as journal_dispatch,
+)
+from .journal_entry_recorded import (
+  dispatch_preview as journal_dispatch_preview,
+)
+from .payment_received import _link_discharge
+from .types import EventBlockPythonHandler, HandlerPreview, HandlerResult
+
+# Event types whose row a bill_paid event is allowed to discharge.
+# Bill is the canonical AP scenario. Excluded: VendorCredit (negative
+# AP, separate flow), JournalEntry (no AP semantic).
+_AP_ORIGINATING_TYPES: tuple[str, ...] = ("bill_received",)
+
+
+def dispatch(
+  session: Session,
+  event: Event,
+  metadata: JournalEntryRecordedMetadata,
+  created_by: str,
+) -> HandlerResult:
+  """Run the journal-entry GL writes, then stamp the discharge link."""
+  result = journal_dispatch(session, event, metadata, created_by)
+  _link_discharge(session, event, _AP_ORIGINATING_TYPES)
+  return result
+
+
+def dispatch_preview(
+  session: Session,
+  body: CreateEventBlockRequest,
+  metadata: JournalEntryRecordedMetadata,
+) -> HandlerPreview:
+  """Preview is identical to journal_entry_recorded — see payment_received."""
+  return journal_dispatch_preview(session, body, metadata)
+
+
+BILL_PAID_HANDLER = EventBlockPythonHandler(
+  event_type="bill_paid",
+  display_name="Bill Paid",
+  metadata_schema=JournalEntryRecordedMetadata,
+  target_status="classified",
+  dispatch=dispatch,
+  dispatch_preview=dispatch_preview,
+)

--- a/robosystems/operations/event_block/python_handlers/payment_received.py
+++ b/robosystems/operations/event_block/python_handlers/payment_received.py
@@ -59,6 +59,20 @@ from .journal_entry_recorded import (
 )
 from .types import EventBlockPythonHandler, HandlerPreview, HandlerResult
 
+# Originating events in these terminal states can never legitimately
+# receive a discharge — a voided invoice was retracted; a superseded
+# one was replaced by a successor that owns its own discharge chain.
+# Linking a fresh payment to either would leave a stale pointer the
+# moment the originating row changes hands. We deliberately do NOT
+# exclude ``captured`` / ``classified`` here: a single QB sync batch
+# captures invoices and payments together, and handler firing order
+# inside the loader's auto-commit pass is dict-iteration order, not
+# guaranteed chronological. Allowing pre-commit invoices to be linked
+# keeps the in-batch case working — the AR aggregate separately
+# filters originating events by ``status IN ('committed', 'fulfilled')``
+# so an unlinked-but-still-captured invoice can't pollute open totals.
+_TERMINAL_INVALID_STATUSES: tuple[str, ...] = ("voided", "superseded")
+
 
 def _resolve_by_linked_txns(
   session: Session,
@@ -74,6 +88,8 @@ def _resolve_by_linked_txns(
   ``_flatten_txn_header``. Returns the first event whose event_type is
   in the allowed set — guards against a Payment's LinkedTxn pointing
   at, say, a CreditMemo, which would not be a valid discharge target.
+  Voided / superseded originating events are excluded so a payment
+  doesn't end up pointing at a row that was retracted or replaced.
   """
   if not linked_txns:
     return None
@@ -90,6 +106,7 @@ def _resolve_by_linked_txns(
       Event.source == source,
       Event.external_id.in_(candidate_ext_ids),
       Event.event_type.in_(candidate_event_types),
+      Event.status.notin_(_TERMINAL_INVALID_STATUSES),
     )
     .order_by(Event.occurred_at.asc())
   )
@@ -111,7 +128,8 @@ def _resolve_by_reference_number(
   across long-running tenants). When ``agent_id`` is NULL on the
   payment we still attempt the lookup but only match invoices with
   NULL ``agent_id`` — never silently cross-link an unscoped payment to
-  someone's invoice.
+  someone's invoice. Voided / superseded events are excluded for the
+  same reason as in ``_resolve_by_linked_txns``.
   """
   if not reference_number:
     return None
@@ -121,6 +139,7 @@ def _resolve_by_reference_number(
       Event.source == source,
       Event.event_type.in_(candidate_event_types),
       Event.metadata_["qb_doc_number"].astext == reference_number,
+      Event.status.notin_(_TERMINAL_INVALID_STATUSES),
     )
     .order_by(Event.occurred_at.asc())
   )

--- a/robosystems/operations/event_block/python_handlers/payment_received.py
+++ b/robosystems/operations/event_block/python_handlers/payment_received.py
@@ -1,0 +1,249 @@
+"""Payment received event handler — AR-side duality resolution.
+
+QB Payment events arrive with the same nested-entries metadata shape as
+``journal_entry_recorded`` (the GL side is identical — a balanced DR
+Cash / CR AR entry), plus a ``qb_linked_txns`` blob that names the
+invoice this payment settles. This handler delegates the GL writes to
+the journal handler unchanged, then resolves the discharge link:
+``event.discharges_event_id`` points at the originating
+``invoice_issued`` event.
+
+Resolution order:
+  1. ``metadata.qb_linked_txns`` — each ref is ``{txn_id, txn_type}``,
+     and the originating event's ``external_id`` is
+     ``f"{txn_type}_{txn_id}"`` by construction in the QB importer.
+     This is QB's canonical "this payment settles those invoices"
+     vocabulary; trust it when present.
+  2. Fallback: ``metadata.qb_reference_number`` ↔ originating event's
+     ``metadata.qb_doc_number``, scoped to the same ``agent_id`` and
+     ``source``. Used when LinkedTxn is missing (older payments,
+     manual entries imported via spreadsheet).
+
+Idempotency: a re-sync that re-fires the handler skips resolution when
+``discharges_event_id`` is already set, so handler retries are
+no-cost.
+
+What's deliberately not done in v1:
+
+- Multi-invoice splits. QB's Payment.Line may carry multiple LinkedTxn
+  refs (one payment settling N invoices, each line for a different
+  amount). We capture all refs in metadata but only link
+  ``discharges_event_id`` to the first match; the remaining refs stay
+  queryable in metadata for a future per-line linkage table. The
+  ``sale.amount - SUM(discharges.amount)`` AR query still works for
+  single-invoice payments and undercounts for splits; correctness for
+  splits is a follow-up once a customer actually has them.
+- Bidirectional update. We set ``discharges_event_id`` on the payment;
+  the invoice's row is left untouched. Querying "what payments
+  settled invoice X?" runs in the opposite direction off this same
+  column, so a back-reference is redundant.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from robosystems.logger import logger
+from robosystems.models.api.event_block import CreateEventBlockRequest
+from robosystems.models.extensions.roboledger.event import Event
+
+from .journal_entry_recorded import (
+  JournalEntryRecordedMetadata,
+)
+from .journal_entry_recorded import (
+  dispatch as journal_dispatch,
+)
+from .journal_entry_recorded import (
+  dispatch_preview as journal_dispatch_preview,
+)
+from .types import EventBlockPythonHandler, HandlerPreview, HandlerResult
+
+
+def _resolve_by_linked_txns(
+  session: Session,
+  *,
+  source: str,
+  linked_txns: list[dict[str, str]],
+  candidate_event_types: tuple[str, ...],
+) -> Event | None:
+  """Look up the originating event by composite external_id.
+
+  Each LinkedTxn ref is ``{txn_id, txn_type}``; the originating event's
+  ``external_id`` is ``f"{txn_type}_{txn_id}"`` by construction in
+  ``_flatten_txn_header``. Returns the first event whose event_type is
+  in the allowed set — guards against a Payment's LinkedTxn pointing
+  at, say, a CreditMemo, which would not be a valid discharge target.
+  """
+  if not linked_txns:
+    return None
+  candidate_ext_ids = [
+    f"{ref['txn_type']}_{ref['txn_id']}"
+    for ref in linked_txns
+    if ref.get("txn_id") and ref.get("txn_type")
+  ]
+  if not candidate_ext_ids:
+    return None
+  stmt = (
+    select(Event)
+    .where(
+      Event.source == source,
+      Event.external_id.in_(candidate_ext_ids),
+      Event.event_type.in_(candidate_event_types),
+    )
+    .order_by(Event.occurred_at.asc())
+  )
+  return session.execute(stmt).scalars().first()
+
+
+def _resolve_by_reference_number(
+  session: Session,
+  *,
+  source: str,
+  reference_number: str,
+  agent_id: str | None,
+  candidate_event_types: tuple[str, ...],
+) -> Event | None:
+  """Fallback match: payment.qb_reference_number ↔ invoice.qb_doc_number.
+
+  Requires same ``agent_id`` to disambiguate when two unrelated
+  customers/vendors happen to share a doc number (rare but possible
+  across long-running tenants). When ``agent_id`` is NULL on the
+  payment we still attempt the lookup but only match invoices with
+  NULL ``agent_id`` — never silently cross-link an unscoped payment to
+  someone's invoice.
+  """
+  if not reference_number:
+    return None
+  stmt = (
+    select(Event)
+    .where(
+      Event.source == source,
+      Event.event_type.in_(candidate_event_types),
+      Event.metadata_["qb_doc_number"].astext == reference_number,
+    )
+    .order_by(Event.occurred_at.asc())
+  )
+  if agent_id is None:
+    stmt = stmt.where(Event.agent_id.is_(None))
+  else:
+    stmt = stmt.where(Event.agent_id == agent_id)
+  return session.execute(stmt).scalars().first()
+
+
+def _resolve_originating_event(
+  session: Session,
+  payment: Event,
+  *,
+  candidate_event_types: tuple[str, ...],
+) -> Event | None:
+  """Find the originating event a payment discharges.
+
+  Walks the two-stage match (LinkedTxn → reference_number). Returns
+  ``None`` when nothing matches — the payment lands without a
+  ``discharges_event_id``, which is the correct steady state for
+  payments that genuinely don't settle a tracked obligation (e.g.,
+  cash-basis income with no AR cycle).
+  """
+  raw_meta = payment.metadata_ or {}
+  linked_txns = raw_meta.get("qb_linked_txns") or []
+  if isinstance(linked_txns, list):
+    match = _resolve_by_linked_txns(
+      session,
+      source=payment.source,
+      linked_txns=linked_txns,
+      candidate_event_types=candidate_event_types,
+    )
+    if match is not None:
+      return match
+
+  reference_number = (raw_meta.get("qb_reference_number") or "").strip()
+  if reference_number:
+    return _resolve_by_reference_number(
+      session,
+      source=payment.source,
+      reference_number=reference_number,
+      agent_id=payment.agent_id,
+      candidate_event_types=candidate_event_types,
+    )
+  return None
+
+
+def _link_discharge(
+  session: Session,
+  payment: Event,
+  candidate_event_types: tuple[str, ...],
+) -> None:
+  """Resolve and stamp ``discharges_event_id`` if not already set.
+
+  Idempotent — a re-fire that finds the column already populated skips
+  the lookup entirely. When no originating event matches, leaves the
+  column NULL and logs an info-level note so re-sync miss-rate is
+  observable but not noisy.
+  """
+  if payment.discharges_event_id is not None:
+    return
+  originating = _resolve_originating_event(
+    session, payment, candidate_event_types=candidate_event_types
+  )
+  if originating is None:
+    logger.info(
+      "payment_received event %s (ext=%s): no originating event matched "
+      "via LinkedTxn or reference_number — left unlinked",
+      payment.id,
+      payment.external_id,
+    )
+    return
+  payment.discharges_event_id = originating.id
+  logger.info(
+    "payment_received event %s discharges event %s (type=%s, ext=%s)",
+    payment.id,
+    originating.id,
+    originating.event_type,
+    originating.external_id,
+  )
+
+
+# Event types whose row a payment_received event is allowed to discharge.
+# Invoice is the canonical AR scenario; SalesReceipt is included because
+# QB occasionally emits a SalesReceipt + later Payment pair (e.g., a
+# deposit applied to a previously-recorded receipt). Excluded:
+# JournalEntry (no AR semantic), CreditMemo (negative AR, separate flow).
+_AR_ORIGINATING_TYPES: tuple[str, ...] = ("invoice_issued", "sales_receipt_recorded")
+
+
+def dispatch(
+  session: Session,
+  event: Event,
+  metadata: JournalEntryRecordedMetadata,
+  created_by: str,
+) -> HandlerResult:
+  """Run the journal-entry GL writes, then stamp the discharge link."""
+  result = journal_dispatch(session, event, metadata, created_by)
+  _link_discharge(session, event, _AR_ORIGINATING_TYPES)
+  return result
+
+
+def dispatch_preview(
+  session: Session,
+  body: CreateEventBlockRequest,
+  metadata: JournalEntryRecordedMetadata,
+) -> HandlerPreview:
+  """Preview is identical to journal_entry_recorded.
+
+  The discharge resolution only runs on real dispatch (it reads
+  committed metadata + cross-event state). Preview returns the GL plan
+  unchanged — call sites that need to verify the discharge link
+  would resolve correctly can probe via a dry-run dispatch in tests.
+  """
+  return journal_dispatch_preview(session, body, metadata)
+
+
+PAYMENT_RECEIVED_HANDLER = EventBlockPythonHandler(
+  event_type="payment_received",
+  display_name="Payment Received",
+  metadata_schema=JournalEntryRecordedMetadata,
+  target_status="classified",
+  dispatch=dispatch,
+  dispatch_preview=dispatch_preview,
+)

--- a/robosystems/operations/event_block/python_handlers/registry.py
+++ b/robosystems/operations/event_block/python_handlers/registry.py
@@ -13,8 +13,10 @@ Adding a new handler:
 from __future__ import annotations
 
 from .asset_disposed import ASSET_DISPOSED_HANDLER
+from .bill_paid import BILL_PAID_HANDLER
 from .journal_entry_recorded import JOURNAL_ENTRY_RECORDED_HANDLER
 from .journal_entry_reversed import JOURNAL_ENTRY_REVERSED_HANDLER
+from .payment_received import PAYMENT_RECEIVED_HANDLER
 from .schedule_created import SCHEDULE_CREATED_HANDLER
 from .schedule_entry_due import SCHEDULE_ENTRY_DUE_HANDLER
 from .types import EventBlockPythonHandler
@@ -25,14 +27,16 @@ EVENT_BLOCK_PYTHON_REGISTRY: dict[str, EventBlockPythonHandler] = {
   SCHEDULE_ENTRY_DUE_HANDLER.event_type: SCHEDULE_ENTRY_DUE_HANDLER,
   JOURNAL_ENTRY_RECORDED_HANDLER.event_type: JOURNAL_ENTRY_RECORDED_HANDLER,
   JOURNAL_ENTRY_REVERSED_HANDLER.event_type: JOURNAL_ENTRY_REVERSED_HANDLER,
-  # QB source-class events all dispatch through the journal handler — they post
-  # journal entries on approve and only differ in inbox display + filtering.
-  # Class-specific handlers (revenue recognition, payment-discharges-invoice)
-  # are post-Phase-2 work; see event-driven-ledger.md Phase 4b/4c.
+  # AR/AP duality handlers — same GL shape as journal_entry_recorded
+  # plus a post-dispatch step that resolves discharges_event_id to the
+  # originating invoice/bill via QB's LinkedTxn refs (with a
+  # reference_number fallback). See event-driven-ledger.md §5.1.
+  PAYMENT_RECEIVED_HANDLER.event_type: PAYMENT_RECEIVED_HANDLER,
+  BILL_PAID_HANDLER.event_type: BILL_PAID_HANDLER,
+  # Remaining QB source-class events still dispatch through the journal
+  # handler — same GL shape, no class-specific side effect yet.
   "invoice_issued": JOURNAL_ENTRY_RECORDED_HANDLER,
   "bill_received": JOURNAL_ENTRY_RECORDED_HANDLER,
-  "payment_received": JOURNAL_ENTRY_RECORDED_HANDLER,
-  "bill_paid": JOURNAL_ENTRY_RECORDED_HANDLER,
   "sales_receipt_recorded": JOURNAL_ENTRY_RECORDED_HANDLER,
   # Additional QB source-class events (Phase 2.5, §3.14 of roadmap): the
   # QB importer used to collapse 7 transaction types into

--- a/robosystems/operations/extensions/loader.py
+++ b/robosystems/operations/extensions/loader.py
@@ -978,6 +978,33 @@ class OLTPLoader:
       # different domain (captured / classified / committed / voided /
       # fulfilled). The two field names overlap because both are coupled
       # to the handler's wire contract.
+      # qb_linked_txns is a list of {txn_id, txn_type} refs naming the
+      # invoices/bills this payment settles (Payment/BillPayment only;
+      # other types pass through an empty list). dbt emits this as a
+      # JSON string; parse to native list so the metadata blob carries
+      # a structured shape the payment_received / bill_paid handlers
+      # can walk without re-parsing on every dispatch.
+      linked_txns_raw = txn.get("linked_txns")
+      qb_linked_txns: list[dict[str, str]] = []
+      if linked_txns_raw:
+        try:
+          parsed = json.loads(linked_txns_raw)
+          if isinstance(parsed, list):
+            qb_linked_txns = [
+              {
+                "txn_id": str(r.get("txn_id", "")),
+                "txn_type": str(r.get("txn_type", "")),
+              }
+              for r in parsed
+              if isinstance(r, dict) and r.get("txn_id") and r.get("txn_type")
+            ]
+        except (ValueError, TypeError) as e:
+          logger.warning(
+            "Failed to parse linked_txns for QB event %s: %s — proceeding with empty list",
+            ext_id,
+            e,
+          )
+
       metadata_blob = {
         "status": jeh_status,
         "qb_txn_type": qb_txn_type,
@@ -992,6 +1019,7 @@ class OLTPLoader:
         "qb_category": str(txn.get("category")) if txn.get("category") else None,
         "qb_source_class": qb_txn_type,
         "qb_agent_external_id": agent_ext_id or None,
+        "qb_linked_txns": qb_linked_txns,
         "connection_id": connection_id,
         "entries": hardened_entries,
       }

--- a/robosystems/operations/information_block/rules/engine.py
+++ b/robosystems/operations/information_block/rules/engine.py
@@ -119,17 +119,21 @@ def _bind_sum_variables(
     if element_id is None:
       bindings[name] = None
       continue
-    # Match `_bind_variables` semantics — only sum facts the close
-    # workflow considers in-scope. Historical facts (already absorbed
-    # into opening balances) would otherwise inflate SumEquals checks
-    # that compare against a schedule's contracted total.
+    # SumEquals checks a structural invariant — Σ(periodic facts) ==
+    # contracted total — so it must sum every periodic fact on the
+    # structure regardless of `fact_scope`. Filtering to `in_scope`
+    # would silently break schedules that bisect `closed_through`:
+    # only the post-close tail would be summed, but `expected_total`
+    # still encodes the full contract amount, producing spurious
+    # failures. Schedule facts aren't replicated into GL line items,
+    # so summing historical periods here doesn't double-count
+    # anything that landed in opening balances.
     row = session.execute(
       text(
         "SELECT ROUND(SUM(value)::numeric, 2) AS total "
         "FROM facts "
         "WHERE element_id = :eid AND structure_id = :sid "
-        "AND period_type = 'duration' "
-        "AND fact_scope = 'in_scope'"
+        "AND period_type = 'duration'"
       ),
       {"eid": element_id, "sid": structure_id},
     ).fetchone()

--- a/robosystems/operations/roboledger/reads/ar_ap.py
+++ b/robosystems/operations/roboledger/reads/ar_ap.py
@@ -1,0 +1,208 @@
+"""Open AR / AP reads driven by the event duality chain.
+
+Open balance = sum of originating-event amounts minus sum of discharging-event
+amounts that point at them. The math runs on ``events.amount`` directly,
+so the answer is one SQL query and doesn't depend on GL roll-up. See
+``event-driven-ledger.md`` §5.1 for the design rationale.
+
+The originating event-type set is config — AR uses ``invoice_issued`` (+
+``sales_receipt_recorded`` for QB-imported deposit applications); AP
+uses ``bill_received``. The discharge side is whichever event whose
+``discharges_event_id`` happens to point at an originating row, so we
+don't have to enumerate payment event types — the FK is the contract.
+
+Status filter: only ``committed`` and ``fulfilled`` events contribute.
+Captured/classified events represent inbox-pending data the operator
+hasn't approved yet; counting them would inflate AR/AP with unconfirmed
+amounts. Voided/superseded events are excluded for the obvious reason.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from sqlalchemy import case, func, select
+from sqlalchemy.orm import Session
+
+from robosystems.models.api.extensions.ar_ap import (
+  OpenBalanceAggregate,
+  OpenBalanceByAgent,
+)
+from robosystems.models.extensions.roboledger.event import Event
+
+# Event types that originate an AR obligation (something the entity is
+# owed). QB-imported invoices and sales receipts both produce AR rows
+# whose ``discharges_event_id`` can be pointed at by a later payment.
+_AR_ORIGINATING_TYPES: tuple[str, ...] = ("invoice_issued", "sales_receipt_recorded")
+
+# Event types that originate an AP obligation (something the entity owes).
+_AP_ORIGINATING_TYPES: tuple[str, ...] = ("bill_received",)
+
+# Status values that contribute to open-balance math. ``captured`` and
+# ``classified`` are pre-handler / inbox-pending; ``voided`` /
+# ``superseded`` are terminal off-ramps that shouldn't count.
+_OPEN_BALANCE_STATUSES: tuple[str, ...] = ("committed", "fulfilled")
+
+
+def _build_open_balance_subquery(
+  *,
+  originating_types: Iterable[str],
+):
+  """Per-event open-balance subquery: amount minus sum of discharges.
+
+  Returns a Core Selectable that yields ``(originating_id, agent_id,
+  open_amount, currency)`` for each originating event. ``open_amount``
+  is signed (positive for normal AR/AP; negative when overpaid). Rows
+  with no discharges still appear — the LEFT JOIN coalesces NULL to 0.
+
+  Implementation: aliases the events table at the Core level so the
+  self-join (originating events LEFT JOIN their discharging events)
+  compiles with a distinct table alias. ORM-level ``aliased(Event)``
+  doesn't propagate through ``Event.__table__.outerjoin(...)`` and
+  emits ``"events" specified more than once`` against Postgres.
+  """
+  originating = Event.__table__
+  discharges = Event.__table__.alias("discharges_e")
+  return (
+    select(
+      originating.c.id.label("originating_id"),
+      originating.c.agent_id.label("agent_id"),
+      (
+        func.coalesce(originating.c.amount, 0)
+        - func.coalesce(func.sum(discharges.c.amount), 0)
+      ).label("open_amount"),
+      originating.c.currency.label("currency"),
+    )
+    .select_from(
+      originating.outerjoin(
+        discharges,
+        (discharges.c.discharges_event_id == originating.c.id)
+        & (discharges.c.status.in_(_OPEN_BALANCE_STATUSES)),
+      )
+    )
+    .where(
+      originating.c.event_type.in_(tuple(originating_types)),
+      originating.c.status.in_(_OPEN_BALANCE_STATUSES),
+      originating.c.amount.is_not(None),
+    )
+    .group_by(
+      originating.c.id,
+      originating.c.agent_id,
+      originating.c.amount,
+      originating.c.currency,
+    )
+  )
+
+
+def _aggregate(
+  session: Session, *, originating_types: Iterable[str]
+) -> OpenBalanceAggregate:
+  """Roll a per-event subquery into the graph-wide totals."""
+  per_event = _build_open_balance_subquery(
+    originating_types=originating_types
+  ).subquery("per_event")
+  nonzero = per_event.c.open_amount != 0
+  row = session.execute(
+    select(
+      func.coalesce(func.sum(per_event.c.open_amount), 0).label("total_open"),
+      func.count(func.distinct(case((nonzero, per_event.c.agent_id)))).label(
+        "counterparty_count"
+      ),
+      func.count(case((nonzero, per_event.c.originating_id))).label("open_event_count"),
+      func.coalesce(func.max(per_event.c.currency), "USD").label("currency"),
+    )
+  ).one()
+  return OpenBalanceAggregate(
+    total_open_cents=int(row.total_open or 0),
+    counterparty_count=int(row.counterparty_count or 0),
+    open_event_count=int(row.open_event_count or 0),
+    currency=str(row.currency or "USD"),
+  )
+
+
+def _by_agent(
+  session: Session,
+  *,
+  originating_types: Iterable[str],
+  agent_id: str | None,
+) -> list[OpenBalanceByAgent]:
+  """Per-agent open-balance rows.
+
+  When ``agent_id`` is None, returns one row per agent with any
+  nonzero open balance, ordered by absolute balance descending.
+  When ``agent_id`` is set, returns at most one row (the matching
+  agent, or [] when zero).
+
+  Agents with NULL on the originating events are aggregated under a
+  single NULL key — the caller can decide whether to surface them.
+  """
+  per_event = _build_open_balance_subquery(
+    originating_types=originating_types
+  ).subquery("per_event")
+  stmt = (
+    select(
+      per_event.c.agent_id,
+      func.coalesce(func.sum(per_event.c.open_amount), 0).label("open_balance"),
+      func.count(
+        case((per_event.c.open_amount != 0, per_event.c.originating_id))
+      ).label("open_event_count"),
+      func.coalesce(func.max(per_event.c.currency), "USD").label("currency"),
+    )
+    .group_by(per_event.c.agent_id)
+    .having(func.coalesce(func.sum(per_event.c.open_amount), 0) != 0)
+  )
+  if agent_id is not None:
+    stmt = stmt.where(per_event.c.agent_id == agent_id)
+  else:
+    stmt = stmt.order_by(func.abs(func.sum(per_event.c.open_amount)).desc())
+  rows = session.execute(stmt).all()
+  return [
+    OpenBalanceByAgent(
+      agent_id=str(r.agent_id) if r.agent_id else "",
+      open_balance_cents=int(r.open_balance),
+      open_event_count=int(r.open_event_count),
+      currency=str(r.currency or "USD"),
+    )
+    for r in rows
+  ]
+
+
+# ---- Public read surface ----------------------------------------------------
+
+
+def compute_open_receivables(session: Session) -> OpenBalanceAggregate:
+  """Graph-wide open AR — total + counterparty count."""
+  return _aggregate(session, originating_types=_AR_ORIGINATING_TYPES)
+
+
+def compute_open_payables(session: Session) -> OpenBalanceAggregate:
+  """Graph-wide open AP — total + counterparty count."""
+  return _aggregate(session, originating_types=_AP_ORIGINATING_TYPES)
+
+
+def list_open_receivables_by_agent(
+  session: Session,
+) -> list[OpenBalanceByAgent]:
+  """Open AR per counterparty, descending by absolute balance."""
+  return _by_agent(session, originating_types=_AR_ORIGINATING_TYPES, agent_id=None)
+
+
+def list_open_payables_by_agent(session: Session) -> list[OpenBalanceByAgent]:
+  """Open AP per counterparty, descending by absolute balance."""
+  return _by_agent(session, originating_types=_AP_ORIGINATING_TYPES, agent_id=None)
+
+
+def get_open_receivable_for_agent(
+  session: Session, agent_id: str
+) -> OpenBalanceByAgent | None:
+  """One agent's open AR — None when the agent has no open balance."""
+  rows = _by_agent(session, originating_types=_AR_ORIGINATING_TYPES, agent_id=agent_id)
+  return rows[0] if rows else None
+
+
+def get_open_payable_for_agent(
+  session: Session, agent_id: str
+) -> OpenBalanceByAgent | None:
+  """One agent's open AP — None when the agent has no open balance."""
+  rows = _by_agent(session, originating_types=_AP_ORIGINATING_TYPES, agent_id=agent_id)
+  return rows[0] if rows else None

--- a/tests/adapters/qb/pipeline/test_utils.py
+++ b/tests/adapters/qb/pipeline/test_utils.py
@@ -1,8 +1,126 @@
 """Tests for QuickBooks pipeline utility functions."""
 
+import json
 from datetime import datetime, timedelta
 
 import pytest
+
+
+@pytest.mark.unit
+class TestExtractLinkedTxns:
+  """LinkedTxn[] capture from QB Payment / BillPayment Line[] arrays."""
+
+  def test_pulls_single_linked_txn_from_one_line(self):
+    from robosystems.adapters.quickbooks.pipeline.utils import _extract_linked_txns
+
+    payment = {
+      "Id": "789",
+      "Line": [
+        {
+          "Amount": 100.0,
+          "LinkedTxn": [{"TxnId": "5", "TxnType": "Invoice"}],
+        }
+      ],
+    }
+
+    refs = json.loads(_extract_linked_txns(payment))
+    assert refs == [{"txn_id": "5", "txn_type": "Invoice"}]
+
+  def test_aggregates_refs_across_multiple_lines(self):
+    """One payment applied to two invoices surfaces both refs in order."""
+    from robosystems.adapters.quickbooks.pipeline.utils import _extract_linked_txns
+
+    payment = {
+      "Line": [
+        {"Amount": 100.0, "LinkedTxn": [{"TxnId": "5", "TxnType": "Invoice"}]},
+        {"Amount": 50.0, "LinkedTxn": [{"TxnId": "6", "TxnType": "Invoice"}]},
+      ],
+    }
+
+    refs = json.loads(_extract_linked_txns(payment))
+    assert refs == [
+      {"txn_id": "5", "txn_type": "Invoice"},
+      {"txn_id": "6", "txn_type": "Invoice"},
+    ]
+
+  def test_empty_line_array_yields_empty_json_list(self):
+    from robosystems.adapters.quickbooks.pipeline.utils import _extract_linked_txns
+
+    assert _extract_linked_txns({"Line": []}) == "[]"
+    assert _extract_linked_txns({}) == "[]"
+
+  def test_skips_refs_missing_either_field(self):
+    """A LinkedTxn entry without TxnId or TxnType is silently dropped."""
+    from robosystems.adapters.quickbooks.pipeline.utils import _extract_linked_txns
+
+    payment = {
+      "Line": [
+        {
+          "Amount": 100.0,
+          "LinkedTxn": [
+            {"TxnId": "5", "TxnType": "Invoice"},  # OK
+            {"TxnId": "", "TxnType": "Invoice"},  # Drop
+            {"TxnId": "6"},  # Drop
+            {"TxnType": "Bill"},  # Drop
+          ],
+        }
+      ],
+    }
+
+    refs = json.loads(_extract_linked_txns(payment))
+    assert refs == [{"txn_id": "5", "txn_type": "Invoice"}]
+
+
+@pytest.mark.unit
+class TestFlattenPaymentHeaders:
+  """Flatten Payment/BillPayment headers WITH linked_txns capture."""
+
+  def test_payment_carries_linked_txn_refs(self):
+    from robosystems.adapters.quickbooks.pipeline.utils import flatten_payment_headers
+
+    class _FakePayment:
+      def to_dict(self):
+        return {
+          "Id": "789",
+          "TxnDate": "2026-04-15",
+          "DocNumber": "",
+          "TotalAmt": 100.0,
+          "CurrencyRef": {"value": "USD"},
+          "PrivateNote": "Thanks!",
+          "CustomerRef": {"value": "C-1"},
+          "Line": [
+            {"Amount": 100.0, "LinkedTxn": [{"TxnId": "5", "TxnType": "Invoice"}]}
+          ],
+        }
+
+    rows = flatten_payment_headers([_FakePayment()])
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["tx_type"] == "Payment"
+    assert row["tx_id"] == "789"
+    assert row["external_id"] == "Payment_789"
+    assert row["agent_external_id"] == "C-1"
+    assert row["agent_type"] == "customer"
+    assert json.loads(row["linked_txns"]) == [{"txn_id": "5", "txn_type": "Invoice"}]
+
+  def test_invoice_header_carries_empty_linked_txns(self):
+    """Non-payment headers default linked_txns to '[]' for UNION shape parity."""
+    from robosystems.adapters.quickbooks.pipeline.utils import flatten_invoice_headers
+
+    class _FakeInvoice:
+      def to_dict(self):
+        return {
+          "Id": "42",
+          "TxnDate": "2026-03-31",
+          "DocNumber": "INV-001",
+          "TotalAmt": 100.0,
+          "CurrencyRef": {"value": "USD"},
+          "PrivateNote": "",
+          "CustomerRef": {"value": "C-1"},
+        }
+
+    rows = flatten_invoice_headers([_FakeInvoice()])
+    assert rows[0]["linked_txns"] == "[]"
 
 
 @pytest.mark.unit

--- a/tests/operations/event_block/python_handlers/test_bill_paid.py
+++ b/tests/operations/event_block/python_handlers/test_bill_paid.py
@@ -1,0 +1,76 @@
+"""Tests for the bill_paid Python handler — AP-side duality resolution.
+
+Bill-paid shares the linkage helper with payment_received; this file
+only verifies (a) the AP candidate type set, (b) that the dispatcher
+wires the link step after journal_dispatch. Detailed match-algorithm
+coverage lives in ``test_payment_received.py``.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+from robosystems.models.extensions.roboledger.event import Event
+from robosystems.operations.event_block.python_handlers.bill_paid import (
+  _AP_ORIGINATING_TYPES,
+  dispatch,
+)
+
+
+def _scalar_first_result(value):
+  result = MagicMock()
+  result.scalars.return_value.first.return_value = value
+  return result
+
+
+def test_ap_candidate_types_contain_only_bill_received() -> None:
+  assert _AP_ORIGINATING_TYPES == ("bill_received",)
+
+
+def test_dispatch_runs_journal_then_links_to_bill() -> None:
+  bill = Event(
+    id="evt_bill",
+    event_type="bill_received",
+    event_category="purchase",
+    event_class="economic",
+    agent_id="agt_vendor",
+    occurred_at=datetime(2026, 3, 31, tzinfo=UTC),
+    source="quickbooks",
+    external_id="Bill_7",
+    status="committed",
+    amount=4200,
+    currency="USD",
+    metadata_={"qb_doc_number": "BIL-7"},
+    created_by="usr_test",
+  )
+  bill_payment = Event(
+    id="evt_billpay",
+    event_type="bill_paid",
+    event_category="purchase",
+    event_class="economic",
+    agent_id="agt_vendor",
+    occurred_at=datetime(2026, 4, 5, tzinfo=UTC),
+    source="quickbooks",
+    external_id="BillPayment_99",
+    status="captured",
+    amount=4200,
+    currency="USD",
+    metadata_={"qb_linked_txns": [{"txn_id": "7", "txn_type": "Bill"}]},
+    created_by="usr_test",
+  )
+  session = MagicMock()
+  session.execute.return_value = _scalar_first_result(bill)
+  metadata = MagicMock()
+
+  with patch(
+    "robosystems.operations.event_block.python_handlers.bill_paid.journal_dispatch"
+  ) as mock_journal:
+    mock_journal.return_value = MagicMock(
+      entry_ids=["je_bp"], transaction_ids=["txn_bp"]
+    )
+    result = dispatch(session, bill_payment, metadata, created_by="usr_test")
+
+  mock_journal.assert_called_once_with(session, bill_payment, metadata, "usr_test")
+  assert bill_payment.discharges_event_id == "evt_bill"
+  assert result.entry_ids == ["je_bp"]

--- a/tests/operations/event_block/python_handlers/test_payment_received.py
+++ b/tests/operations/event_block/python_handlers/test_payment_received.py
@@ -10,6 +10,7 @@ import pytest
 from robosystems.models.extensions.roboledger.event import Event
 from robosystems.operations.event_block.python_handlers.payment_received import (
   _AR_ORIGINATING_TYPES,
+  _TERMINAL_INVALID_STATUSES,
   _link_discharge,
   _resolve_by_linked_txns,
   _resolve_by_reference_number,
@@ -119,6 +120,31 @@ class TestResolveByLinkedTxns:
 
     assert match is None
     session.execute.assert_not_called()
+
+  def test_excludes_voided_and_superseded_originators(self) -> None:
+    """Terminal-invalid statuses must not appear as discharge targets.
+
+    `captured` / `classified` are intentionally allowed so a sync batch
+    that fires the payment handler before its sibling invoice handler
+    still links — the AR aggregate separately filters originating
+    events by `committed`/`fulfilled`, so a pre-commit invoice can't
+    pollute open totals if the link is set early.
+    """
+    session = MagicMock()
+    session.execute.return_value = _scalar_first_result(None)
+
+    _resolve_by_linked_txns(
+      session,
+      source="quickbooks",
+      linked_txns=[{"txn_id": "42", "txn_type": "Invoice"}],
+      candidate_event_types=_AR_ORIGINATING_TYPES,
+    )
+
+    sent_stmt = str(session.execute.call_args.args[0])
+    # SQLAlchemy compiles `notin_(("voided", "superseded"))` to NOT IN.
+    assert "NOT IN" in sent_stmt
+    assert True  # sanity ref
+    assert set(_TERMINAL_INVALID_STATUSES) == {"voided", "superseded"}
 
 
 class TestResolveByReferenceNumber:

--- a/tests/operations/event_block/python_handlers/test_payment_received.py
+++ b/tests/operations/event_block/python_handlers/test_payment_received.py
@@ -1,0 +1,283 @@
+"""Tests for the payment_received Python handler — AR-side duality resolution."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from robosystems.models.extensions.roboledger.event import Event
+from robosystems.operations.event_block.python_handlers.payment_received import (
+  _AR_ORIGINATING_TYPES,
+  _link_discharge,
+  _resolve_by_linked_txns,
+  _resolve_by_reference_number,
+  dispatch,
+)
+
+
+def _make_payment_event(
+  *,
+  event_id: str = "evt_pay",
+  metadata: dict | None = None,
+  agent_id: str | None = "agt_cust",
+  discharges_event_id: str | None = None,
+) -> Event:
+  """Build an in-memory Event row (not session-attached)."""
+  evt = Event(
+    id=event_id,
+    event_type="payment_received",
+    event_category="sales",
+    event_class="economic",
+    agent_id=agent_id,
+    occurred_at=datetime(2026, 4, 15, tzinfo=UTC),
+    source="quickbooks",
+    external_id="Payment_123",
+    status="captured",
+    amount=10000,
+    currency="USD",
+    metadata_=metadata or {},
+    created_by="usr_test",
+  )
+  evt.discharges_event_id = discharges_event_id
+  return evt
+
+
+def _make_invoice_event(
+  *,
+  event_id: str = "evt_inv",
+  agent_id: str | None = "agt_cust",
+  qb_doc_number: str | None = "INV-001",
+) -> Event:
+  return Event(
+    id=event_id,
+    event_type="invoice_issued",
+    event_category="sales",
+    event_class="economic",
+    agent_id=agent_id,
+    occurred_at=datetime(2026, 3, 31, tzinfo=UTC),
+    source="quickbooks",
+    external_id="Invoice_42",
+    status="committed",
+    amount=10000,
+    currency="USD",
+    metadata_={"qb_doc_number": qb_doc_number},
+    created_by="usr_test",
+  )
+
+
+def _scalar_first_result(value):
+  result = MagicMock()
+  result.scalars.return_value.first.return_value = value
+  return result
+
+
+class TestResolveByLinkedTxns:
+  def test_returns_first_match_when_linked_txn_resolves(self) -> None:
+    """LinkedTxn names {Invoice, 42} → look up event with external_id 'Invoice_42'."""
+    invoice = _make_invoice_event()
+    session = MagicMock()
+    session.execute.return_value = _scalar_first_result(invoice)
+
+    match = _resolve_by_linked_txns(
+      session,
+      source="quickbooks",
+      linked_txns=[{"txn_id": "42", "txn_type": "Invoice"}],
+      candidate_event_types=_AR_ORIGINATING_TYPES,
+    )
+
+    assert match is invoice
+    sent_stmt = str(session.execute.call_args.args[0])
+    assert "events.external_id IN" in sent_stmt or "external_id" in sent_stmt
+
+  def test_returns_none_for_empty_linked_txns(self) -> None:
+    session = MagicMock()
+    match = _resolve_by_linked_txns(
+      session,
+      source="quickbooks",
+      linked_txns=[],
+      candidate_event_types=_AR_ORIGINATING_TYPES,
+    )
+    assert match is None
+    session.execute.assert_not_called()
+
+  def test_skips_refs_missing_either_field(self) -> None:
+    """A LinkedTxn with empty TxnId or TxnType is dropped, not matched."""
+    session = MagicMock()
+    session.execute.return_value = _scalar_first_result(None)
+
+    match = _resolve_by_linked_txns(
+      session,
+      source="quickbooks",
+      linked_txns=[
+        {"txn_id": "", "txn_type": "Invoice"},
+        {"txn_id": "99", "txn_type": ""},
+      ],
+      candidate_event_types=_AR_ORIGINATING_TYPES,
+    )
+
+    assert match is None
+    session.execute.assert_not_called()
+
+
+class TestResolveByReferenceNumber:
+  def test_scopes_by_agent_when_present(self) -> None:
+    invoice = _make_invoice_event()
+    session = MagicMock()
+    session.execute.return_value = _scalar_first_result(invoice)
+
+    match = _resolve_by_reference_number(
+      session,
+      source="quickbooks",
+      reference_number="INV-001",
+      agent_id="agt_cust",
+      candidate_event_types=_AR_ORIGINATING_TYPES,
+    )
+
+    assert match is invoice
+    # Verify the agent scope made it into the WHERE clause; the
+    # compiled SQL should reference agent_id rather than IS NULL.
+    sent_stmt = str(session.execute.call_args.args[0])
+    assert "agent_id" in sent_stmt
+
+  def test_returns_none_for_empty_reference(self) -> None:
+    session = MagicMock()
+    match = _resolve_by_reference_number(
+      session,
+      source="quickbooks",
+      reference_number="",
+      agent_id="agt_cust",
+      candidate_event_types=_AR_ORIGINATING_TYPES,
+    )
+    assert match is None
+    session.execute.assert_not_called()
+
+  def test_restricts_to_null_agent_when_payment_unscoped(self) -> None:
+    """A payment with agent_id=None never silently links to someone else's invoice."""
+    session = MagicMock()
+    session.execute.return_value = _scalar_first_result(None)
+
+    _resolve_by_reference_number(
+      session,
+      source="quickbooks",
+      reference_number="INV-001",
+      agent_id=None,
+      candidate_event_types=_AR_ORIGINATING_TYPES,
+    )
+
+    sent_stmt = str(session.execute.call_args.args[0])
+    # `Event.agent_id.is_(None)` compiles to `IS NULL`.
+    assert "IS NULL" in sent_stmt
+
+
+class TestLinkDischarge:
+  def test_idempotent_when_already_linked(self) -> None:
+    """Re-fires that hit an already-linked event do not re-query."""
+    payment = _make_payment_event(discharges_event_id="evt_existing")
+    session = MagicMock()
+
+    _link_discharge(session, payment, _AR_ORIGINATING_TYPES)
+
+    assert payment.discharges_event_id == "evt_existing"
+    session.execute.assert_not_called()
+
+  def test_linked_txns_win_over_reference_number(self) -> None:
+    """Both signals present; LinkedTxn-resolved match is used."""
+    invoice = _make_invoice_event(event_id="evt_linked")
+    payment = _make_payment_event(
+      metadata={
+        "qb_linked_txns": [{"txn_id": "42", "txn_type": "Invoice"}],
+        "qb_reference_number": "INV-999",  # Would resolve elsewhere if fallback ran
+      },
+    )
+    session = MagicMock()
+    session.execute.return_value = _scalar_first_result(invoice)
+
+    _link_discharge(session, payment, _AR_ORIGINATING_TYPES)
+
+    assert payment.discharges_event_id == "evt_linked"
+    # Only one query — LinkedTxn matched, fallback never ran.
+    assert session.execute.call_count == 1
+
+  def test_falls_back_to_reference_number_when_linked_txn_misses(self) -> None:
+    invoice = _make_invoice_event(event_id="evt_fallback")
+    payment = _make_payment_event(
+      metadata={
+        "qb_linked_txns": [{"txn_id": "99", "txn_type": "Invoice"}],
+        "qb_reference_number": "INV-001",
+      },
+    )
+    session = MagicMock()
+    session.execute.side_effect = [
+      _scalar_first_result(None),  # LinkedTxn miss
+      _scalar_first_result(invoice),  # reference_number hit
+    ]
+
+    _link_discharge(session, payment, _AR_ORIGINATING_TYPES)
+
+    assert payment.discharges_event_id == "evt_fallback"
+    assert session.execute.call_count == 2
+
+  def test_leaves_unlinked_when_no_signal_matches(self) -> None:
+    payment = _make_payment_event(
+      metadata={"qb_linked_txns": [], "qb_reference_number": ""}
+    )
+    session = MagicMock()
+
+    _link_discharge(session, payment, _AR_ORIGINATING_TYPES)
+
+    assert payment.discharges_event_id is None
+    # No metadata signals → no DB call at all.
+    session.execute.assert_not_called()
+
+  def test_leaves_unlinked_when_both_lookups_miss(self) -> None:
+    payment = _make_payment_event(
+      metadata={
+        "qb_linked_txns": [{"txn_id": "99", "txn_type": "Invoice"}],
+        "qb_reference_number": "INV-001",
+      }
+    )
+    session = MagicMock()
+    session.execute.side_effect = [
+      _scalar_first_result(None),
+      _scalar_first_result(None),
+    ]
+
+    _link_discharge(session, payment, _AR_ORIGINATING_TYPES)
+
+    assert payment.discharges_event_id is None
+    assert session.execute.call_count == 2
+
+
+class TestDispatch:
+  def test_runs_journal_dispatch_then_links_discharge(self) -> None:
+    payment = _make_payment_event(
+      metadata={"qb_linked_txns": [{"txn_id": "42", "txn_type": "Invoice"}]}
+    )
+    invoice = _make_invoice_event(event_id="evt_inv_linked")
+    session = MagicMock()
+    session.execute.return_value = _scalar_first_result(invoice)
+    metadata = MagicMock()
+
+    with patch(
+      "robosystems.operations.event_block.python_handlers.payment_received.journal_dispatch"
+    ) as mock_journal:
+      mock_journal.return_value = MagicMock(
+        entry_ids=["je_1"], transaction_ids=["txn_1"]
+      )
+
+      result = dispatch(session, payment, metadata, created_by="usr_test")
+
+    mock_journal.assert_called_once_with(session, payment, metadata, "usr_test")
+    assert payment.discharges_event_id == "evt_inv_linked"
+    assert result.entry_ids == ["je_1"]
+
+
+@pytest.mark.parametrize(
+  ("originating_type",), [("invoice_issued",), ("sales_receipt_recorded",)]
+)
+def test_ar_candidate_types_include_invoices_and_sales_receipts(
+  originating_type,
+) -> None:
+  assert originating_type in _AR_ORIGINATING_TYPES

--- a/tests/operations/event_block/python_handlers/test_registry.py
+++ b/tests/operations/event_block/python_handlers/test_registry.py
@@ -12,11 +12,17 @@ from robosystems.operations.event_block.python_handlers.asset_disposed import (
   ASSET_DISPOSED_HANDLER,
   AssetDisposedMetadata,
 )
+from robosystems.operations.event_block.python_handlers.bill_paid import (
+  BILL_PAID_HANDLER,
+)
 from robosystems.operations.event_block.python_handlers.journal_entry_recorded import (
   JOURNAL_ENTRY_RECORDED_HANDLER,
 )
 from robosystems.operations.event_block.python_handlers.journal_entry_reversed import (
   JOURNAL_ENTRY_REVERSED_HANDLER,
+)
+from robosystems.operations.event_block.python_handlers.payment_received import (
+  PAYMENT_RECEIVED_HANDLER,
 )
 from robosystems.operations.event_block.python_handlers.schedule_entry_due import (
   SCHEDULE_ENTRY_DUE_HANDLER,
@@ -45,14 +51,27 @@ def test_unknown_event_type_returns_none() -> None:
 
 
 def test_qb_source_class_event_types_share_journal_handler() -> None:
-  """Phase 2: QB source-class events all dispatch through JOURNAL_ENTRY_RECORDED_HANDLER.
-  They differ in inbox display only; on approve they post journal entries via
-  the same handler."""
+  """QB source-class events with no class-specific side effect dispatch
+  through JOURNAL_ENTRY_RECORDED_HANDLER. They differ in inbox display
+  and event_category only; on approve they post journal entries via
+  the same handler. Payment / bill-payment are deliberately excluded —
+  they have dedicated handlers that also set discharges_event_id."""
   assert get_python_handler("invoice_issued") is JOURNAL_ENTRY_RECORDED_HANDLER
   assert get_python_handler("bill_received") is JOURNAL_ENTRY_RECORDED_HANDLER
-  assert get_python_handler("payment_received") is JOURNAL_ENTRY_RECORDED_HANDLER
-  assert get_python_handler("bill_paid") is JOURNAL_ENTRY_RECORDED_HANDLER
   assert get_python_handler("sales_receipt_recorded") is JOURNAL_ENTRY_RECORDED_HANDLER
+
+
+def test_payment_received_uses_dedicated_handler() -> None:
+  """AR-side duality: payment_received resolves discharges_event_id back
+  to the originating invoice. The GL writes still go through the journal
+  handler (delegated inside dispatch); the registry entry, however, is
+  the AR-aware handler — not the bare journal one."""
+  assert get_python_handler("payment_received") is PAYMENT_RECEIVED_HANDLER
+
+
+def test_bill_paid_uses_dedicated_handler() -> None:
+  """AP-side duality — symmetric to payment_received."""
+  assert get_python_handler("bill_paid") is BILL_PAID_HANDLER
 
 
 def test_registry_value_is_frozen() -> None:

--- a/tests/operations/roboledger/reads/test_ar_ap.py
+++ b/tests/operations/roboledger/reads/test_ar_ap.py
@@ -1,0 +1,112 @@
+"""Smoke tests for AR/AP read operations.
+
+The math is one SQL query with a subquery + filtered aggregate — too
+complex to mock meaningfully without re-implementing it in the
+assertions. These tests verify (a) the SQL compiles against a real
+Postgres dialect, (b) the candidate event-type sets are wired
+correctly, and (c) the response shape matches the Pydantic contract.
+Numerical correctness is validated end-to-end via the QB sandbox
+verification step (see roadmap §5.1 exit).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from sqlalchemy.dialects import postgresql
+
+from robosystems.operations.roboledger.reads import ar_ap as reads_ar_ap
+from robosystems.operations.roboledger.reads.ar_ap import (
+  _AP_ORIGINATING_TYPES,
+  _AR_ORIGINATING_TYPES,
+  _OPEN_BALANCE_STATUSES,
+  _build_open_balance_subquery,
+)
+
+
+def test_originating_type_sets_are_disjoint_and_explicit() -> None:
+  """AR and AP must never share an originating event type — a single
+  event can't be both a receivable and a payable."""
+  assert set(_AR_ORIGINATING_TYPES).isdisjoint(set(_AP_ORIGINATING_TYPES))
+  assert "invoice_issued" in _AR_ORIGINATING_TYPES
+  assert "sales_receipt_recorded" in _AR_ORIGINATING_TYPES
+  assert "bill_received" in _AP_ORIGINATING_TYPES
+
+
+def test_open_balance_statuses_exclude_pending_and_voided() -> None:
+  """Captured / classified are inbox-pending; voided / superseded are
+  terminal off-ramps — neither should count toward an open balance."""
+  assert set(_OPEN_BALANCE_STATUSES) == {"committed", "fulfilled"}
+  assert "captured" not in _OPEN_BALANCE_STATUSES
+  assert "voided" not in _OPEN_BALANCE_STATUSES
+
+
+def test_subquery_filters_on_originating_types() -> None:
+  """The originating-type WHERE clause carries through to the compiled SQL."""
+  stmt = _build_open_balance_subquery(originating_types=_AR_ORIGINATING_TYPES)
+  compiled = str(
+    stmt.compile(dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True})
+  )
+  assert "invoice_issued" in compiled
+  assert "sales_receipt_recorded" in compiled
+  # The subquery should sum discharges via a LEFT OUTER JOIN onto Event itself.
+  assert "LEFT OUTER JOIN events" in compiled
+  assert "discharges_event_id" in compiled
+
+
+def test_aggregate_compiles_against_postgres() -> None:
+  """End-to-end SQL build — every column reference resolves."""
+  session = MagicMock()
+  fake_row = MagicMock(
+    total_open=12345, counterparty_count=3, open_event_count=5, currency="USD"
+  )
+  session.execute.return_value.one.return_value = fake_row
+
+  response = reads_ar_ap.compute_open_receivables(session)
+  assert response.total_open_cents == 12345
+  assert response.counterparty_count == 3
+  assert response.open_event_count == 5
+  assert response.currency == "USD"
+
+
+def test_aggregate_handles_zero_state() -> None:
+  """An empty events table returns zeros, not NULLs."""
+  session = MagicMock()
+  fake_row = MagicMock(
+    total_open=None, counterparty_count=None, open_event_count=None, currency=None
+  )
+  session.execute.return_value.one.return_value = fake_row
+
+  response = reads_ar_ap.compute_open_payables(session)
+  assert response.total_open_cents == 0
+  assert response.counterparty_count == 0
+  assert response.open_event_count == 0
+  assert response.currency == "USD"  # default fallback
+
+
+def test_by_agent_returns_empty_list_when_no_rows() -> None:
+  session = MagicMock()
+  session.execute.return_value.all.return_value = []
+  assert reads_ar_ap.list_open_receivables_by_agent(session) == []
+  assert reads_ar_ap.list_open_payables_by_agent(session) == []
+
+
+def test_by_agent_per_agent_lookup() -> None:
+  """Single-agent variant returns at most one row."""
+  session = MagicMock()
+  fake_row = MagicMock(
+    agent_id="agt_cust", open_balance=5000, open_event_count=2, currency="USD"
+  )
+  session.execute.return_value.all.return_value = [fake_row]
+
+  response = reads_ar_ap.get_open_receivable_for_agent(session, "agt_cust")
+  assert response is not None
+  assert response.agent_id == "agt_cust"
+  assert response.open_balance_cents == 5000
+  assert response.open_event_count == 2
+
+
+def test_by_agent_returns_none_when_agent_has_no_open_balance() -> None:
+  session = MagicMock()
+  session.execute.return_value.all.return_value = []
+  assert reads_ar_ap.get_open_payable_for_agent(session, "agt_vendor") is None


### PR DESCRIPTION
## Summary

Introduces Accounts Receivable / Accounts Payable (AR/AP) duality handling across the platform, spanning data modeling, event processing, GraphQL APIs, and ledger read operations. This feature enables the system to properly track and reconcile the dual nature of AR/AP transactions — where a receivable or payable on one side corresponds to a payment or bill settlement on the other.

## Key Accomplishments

### Data Layer (dbt Models)
- Enhanced the `transactions.sql` ledger model to account for AR/AP duality in transaction aggregation
- Updated six QuickBooks staging models (`bill_headers`, `bill_payment_headers`, `invoice_headers`, `payment_headers`, `purchase_headers`, `sales_receipt_headers`) to surface fields needed for AR/AP tracking

### API Models & GraphQL
- Added new `ar_ap.py` API extension model defining the data structures for AR/AP duality
- Exposed AR/AP duality data through new GraphQL types and resolvers in the ledger domain
- Registered the new extension in the extensions module

### Event Handlers
- **`bill_paid` handler** — processes bill payment events, linking AP settlements to their originating bills
- **`payment_received` handler** — processes incoming payment events, linking AR settlements to their originating invoices; includes comprehensive logic (~250 lines) for matching and reconciliation
- Updated the handler registry to include both new handlers

### Ledger Read Operations
- Added `ar_ap.py` read module (~208 lines) providing query operations for AR/AP balances, aging, and duality lookups

### Pipeline Utilities
- Extended QuickBooks pipeline utilities to support AR/AP-specific data extraction and transformation

### Extensions Loader
- Updated the extensions loader to discover and wire up the new AR/AP extension

### Rules Engine
- Modified the information block rules engine to incorporate AR/AP duality awareness in rule evaluation

## Breaking Changes

None expected. All changes are additive — new handlers, new models, new read operations, and new GraphQL types/resolvers. Existing staging models received additional columns but no removals or renames.

## Testing

- **New test suites added:**
  - `test_bill_paid.py` — 76 lines covering bill payment event handler scenarios
  - `test_payment_received.py` — 283 lines with comprehensive coverage of payment received logic including edge cases and reconciliation matching
  - `test_ar_ap.py` (reads) — 112 lines testing AR/AP ledger read operations
- **Existing tests updated:**
  - `test_utils.py` — expanded with 118 additional lines for new pipeline utility functions
  - `test_registry.py` — updated to validate registration of the two new event handlers

Total new/modified test coverage: ~600+ lines across 5 test files.

## Infrastructure Considerations

- The dbt model changes will require a `dbt run` on the affected staging and ledger models to materialize the new columns in the data warehouse
- The new GraphQL types and resolvers will be available immediately upon deployment without schema migration, but clients should be updated to leverage the new AR/AP query capabilities
- The event handler registry changes are backward-compatible; the new handlers will only fire for their respective event types

---
🤖 Generated with [Claude Code](https://claude.ai/code)

**Branch Info:**
- Source: `feature/ar-ap-duality`
- Target: `main`
- Type: feature

Co-Authored-By: Claude <noreply@anthropic.com>