### PR TITLE
Refactor structure_type to block_type and align canonical vocabulary

### DIFF
--- a/examples/roboledger_demo/main.py
+++ b/examples/roboledger_demo/main.py
@@ -267,7 +267,7 @@ def create_chart_of_accounts(graph_id: str) -> tuple[dict[str, str], str, int]:
         {
           "name": "CoA to US GAAP Mapping",
           "description": "Maps Chart of Accounts to US GAAP reporting concepts",
-          "structure_type": "coa_mapping",
+          "block_type": "coa_mapping",
         },
       ],
       "associations": [],
@@ -571,7 +571,7 @@ def create_mappings(graph_id: str, element_lookup: dict[str, str]) -> int:
   client = _get_ledger_client()
 
   # Find the coa_mapping structure (created during create_chart_of_accounts step)
-  structures = client.list_structures(graph_id, structure_type="coa_mapping")
+  structures = client.list_structures(graph_id, block_type="coa_mapping")
   if not structures:
     print("  ERROR: No mapping structure found")
     return 0
@@ -638,7 +638,7 @@ def run_ai_mapping(graph_id: str) -> None:
   )
 
   ledger = _get_ledger_client()
-  structures = ledger.list_structures(graph_id, structure_type="coa_mapping")
+  structures = ledger.list_structures(graph_id, block_type="coa_mapping")
   if not structures:
     print("  ERROR: No coa_mapping structure found — was the CoA taxonomy created?")
     return
@@ -897,7 +897,7 @@ def generate_fy2025_report(graph_id: str) -> str | None:
   client = _get_ledger_client()
 
   # Find the coa_mapping structure created during the taxonomy seed
-  structures = client.list_structures(graph_id, structure_type="coa_mapping")
+  structures = client.list_structures(graph_id, block_type="coa_mapping")
   if not structures:
     print("  ERROR: No coa_mapping structure — was the CoA created?")
     return None

--- a/migrations/extensions/versions/0001_initial_schema.py
+++ b/migrations/extensions/versions/0001_initial_schema.py
@@ -252,7 +252,7 @@ def upgrade() -> None:
     sa.Column("id", sa.String(), nullable=False),
     sa.Column("name", sa.String(), nullable=False),
     sa.Column("description", sa.String(), nullable=True),
-    sa.Column("structure_type", sa.String(), nullable=False),
+    sa.Column("block_type", sa.String(), nullable=False),
     sa.Column("taxonomy_id", sa.String(), nullable=False),
     sa.Column("graph_structure_id", sa.String(), nullable=True),
     sa.Column("is_active", sa.Boolean(), nullable=False, server_default="true"),
@@ -267,11 +267,11 @@ def upgrade() -> None:
     sa.PrimaryKeyConstraint("id"),
     sa.ForeignKeyConstraint(["taxonomy_id"], ["taxonomies.id"]),
     sa.CheckConstraint(
-      "structure_type IN ("
+      "block_type IN ("
       "'chart_of_accounts', 'income_statement', 'balance_sheet', "
       "'cash_flow_statement', 'equity_statement', 'coa_mapping', 'custom', 'schedule'"
       ")",
-      name="check_structure_type",
+      name="check_block_type",
     ),
     schema="public",
   )
@@ -284,7 +284,7 @@ def upgrade() -> None:
   op.create_index(
     "idx_structures_type",
     "structures",
-    ["structure_type"],
+    ["block_type"],
     schema="public",
   )
 

--- a/migrations/extensions/versions/0002_taxonomy_library.py
+++ b/migrations/extensions/versions/0002_taxonomy_library.py
@@ -155,14 +155,14 @@ _NARROW_ELEMENT_SOURCE_CHECK = (
   "'quickbooks', 'xero', 'plaid', 'native', 'import'"
   ")"
 )
-# Structure.structure_type widens to admit the Phase g.1 block types
+# Structure.block_type widens to admit the Phase g.1 block types
 # (rollforward, reconciliation, policy) required as admissible CHECK
 # values for Phase d (typed artifact_mechanics + rules) and Phase eta
 # (metric block type). Folded into 0002 rather than shipped as a
 # standalone migration since 0002 is still unreleased. See
 # ``local/docs/specs/information-block.md`` section 5.9, Phase g.1.
-_WIDENED_STRUCTURE_TYPE_CHECK = (
-  "structure_type IN ("
+_WIDENED_BLOCK_TYPE_CHECK = (
+  "block_type IN ("
   # Renderable financial-statement presentations
   "'income_statement', 'balance_sheet', "
   "'cash_flow_statement', 'equity_statement', "
@@ -176,13 +176,13 @@ _WIDENED_STRUCTURE_TYPE_CHECK = (
   # disclosures, crosswalks between taxonomies. Filtered out of the
   # report-package render path; surfaced through their own consumption
   # paths (rule engine, disclosure registry, mapping resolver).
-  "'validation_rules', 'disclosure', 'taxonomy_mapping', "
+  "'validation_rules', 'regulatory_disclosure', 'taxonomy_mapping', "
   # Escape hatch
   "'custom'"
   ")"
 )
-_NARROW_STRUCTURE_TYPE_CHECK = (
-  "structure_type IN ("
+_NARROW_BLOCK_TYPE_CHECK = (
+  "block_type IN ("
   "'chart_of_accounts', 'income_statement', 'balance_sheet', "
   "'cash_flow_statement', 'equity_statement', 'coa_mapping', 'custom', 'schedule'"
   ")"
@@ -206,13 +206,40 @@ _RULE_CATEGORY_CHECK = (
   ")"
 )
 _RULE_PATTERN_CHECK = (
-  "rule_pattern IN ("
+  "rule_pattern IS NULL OR rule_pattern IN ("
   "'Adjustment', 'CoExists', 'EqualTo', 'Exists', 'GreaterThan', "
   "'GreaterThanOrEqualToZero', 'LessThan', 'RollForward', 'RollUp', "
-  "'SumEquals', 'Variance', "
+  "'SumEquals', 'Variance'"
+  ")"
+)
+_RULE_CHECK_KIND_CHECK = (
+  "rule_check_kind IS NULL OR rule_check_kind IN ("
   "'LeafHasClassification', 'LibraryOriginImmutability', "
   "'NoCycles', 'NoOrphanArcs', 'ParentBeforeChild', "
   "'UniqueQNameInTaxonomy'"
+  ")"
+)
+_RULE_PATTERN_KIND_XOR_CHECK = (
+  "(rule_pattern IS NOT NULL AND rule_check_kind IS NULL) "
+  "OR (rule_pattern IS NULL AND rule_check_kind IS NOT NULL)"
+)
+# Concept Arrangement Pattern (CAP) — 8 canonical + 2 pseudo per
+# information-block.md §3.2.1. NULL allowed for block types that don't
+# yet declare a default.
+_CONCEPT_ARRANGEMENT_CHECK = (
+  "concept_arrangement IS NULL OR concept_arrangement IN ("
+  "'set', 'roll_up', 'roll_forward', 'roll_forward_info', "
+  "'adjustment', 'variance', 'arithmetic', 'text_block', "
+  "'grid', 'compound_fact'"
+  ")"
+)
+# Member Arrangement Pattern (MAP) — 5 canonical per
+# information-block.md §3.2.2. NULL allowed for non-hypercube block
+# types.
+_MEMBER_ARRANGEMENT_CHECK = (
+  "member_arrangement IS NULL OR member_arrangement IN ("
+  "'is_a', 'whole_part', 'nested_whole_part', "
+  "'two_dimension_aggregation', 'complex_aggregating_whole_part'"
   ")"
 )
 _RULE_SEVERITY_CHECK = "rule_severity IN ('info', 'warning', 'error')"
@@ -386,7 +413,7 @@ def _widen_tenant_checks(conn, schema: str) -> None:
   t.add_check("associations", "check_association_type", _WIDENED_ASSOCIATION_CHECK)
   t.add_check("elements", "check_element_source", _WIDENED_ELEMENT_SOURCE_CHECK)
   t.add_check("taxonomies", "check_taxonomy_type", _WIDENED_TAXONOMY_TYPE_CHECK)
-  t.add_check("structures", "check_structure_type", _WIDENED_STRUCTURE_TYPE_CHECK)
+  t.add_check("structures", "check_block_type", _WIDENED_BLOCK_TYPE_CHECK)
 
 
 def _backfill_reporting_standard(conn, schema: str) -> None:
@@ -424,7 +451,7 @@ def _restore_narrow_tenant_checks(conn, schema: str) -> None:
   t.add_check("associations", "check_association_type", _NARROW_ASSOCIATION_CHECK)
   t.add_check("elements", "check_element_source", _NARROW_ELEMENT_SOURCE_CHECK)
   t.add_check("taxonomies", "check_taxonomy_type", _NARROW_TAXONOMY_TYPE_CHECK)
-  t.add_check("structures", "check_structure_type", _NARROW_STRUCTURE_TYPE_CHECK)
+  t.add_check("structures", "check_block_type", _NARROW_BLOCK_TYPE_CHECK)
 
 
 def _drop_old_element_columns(conn, schema: str) -> None:
@@ -498,16 +525,20 @@ def _add_phase_d_columns_to_tenant(conn, schema: str) -> None:
   t.add_column("structures", "concept_arrangement", "VARCHAR")
   t.add_column("structures", "member_arrangement", "VARCHAR")
   t.add_column("structures", "artifact_mechanics", "JSONB")
-  t.add_column("structures", "parenthetical_note", "VARCHAR")
+  t.add_column("structures", "renderer_note", "VARCHAR")
   t.add_column("structures", "template_id", "VARCHAR")
+  t.add_check("structures", "check_concept_arrangement", _CONCEPT_ARRANGEMENT_CHECK)
+  t.add_check("structures", "check_member_arrangement", _MEMBER_ARRANGEMENT_CHECK)
 
 
 def _drop_phase_d_columns_from_tenant(conn, schema: str) -> None:
   """Reverse of :func:`_add_phase_d_columns_to_tenant` for downgrade."""
   t = TenantOps(conn, schema)
+  t.drop_constraint("structures", "check_member_arrangement")
+  t.drop_constraint("structures", "check_concept_arrangement")
   for col in (
     "template_id",
-    "parenthetical_note",
+    "renderer_note",
     "artifact_mechanics",
     "member_arrangement",
     "concept_arrangement",
@@ -548,7 +579,7 @@ def _backfill_tenant_schedule_mechanics(conn, schema: str) -> None:
                 COALESCE(metadata -> 'schedule_metadata', 'null'::jsonb)
             )
           )
-      WHERE structure_type = 'schedule'
+      WHERE block_type = 'schedule'
       """
     )
   )
@@ -946,11 +977,11 @@ def upgrade() -> None:
   # library browser) sees the canonical form. The widened CHECK still
   # admits ``'reporting'`` transitionally so this UPDATE validates.
   _backfill_reporting_standard(op.get_bind(), "public")
-  # Phase g.1: widen structures.structure_type to admit rollforward,
+  # Phase g.1: widen structures.block_type to admit rollforward,
   # reconciliation, policy. Pure vocabulary expansion — no data change.
-  op.drop_constraint("check_structure_type", "structures", type_="check")
+  op.drop_constraint("check_block_type", "structures", type_="check")
   op.create_check_constraint(
-    "check_structure_type", "structures", _WIDENED_STRUCTURE_TYPE_CHECK
+    "check_block_type", "structures", _WIDENED_BLOCK_TYPE_CHECK
   )
 
   # Phase d: typed artifact_mechanics + Information-Model axis columns
@@ -984,12 +1015,25 @@ def upgrade() -> None:
   )
   op.add_column(
     "structures",
-    sa.Column("parenthetical_note", sa.String(), nullable=True),
+    sa.Column("renderer_note", sa.String(), nullable=True),
     schema="public",
   )
   op.add_column(
     "structures",
     sa.Column("template_id", sa.String(), nullable=True),
+    schema="public",
+  )
+  # CAP + MAP CHECK constraints on public.structures.
+  op.create_check_constraint(
+    "check_concept_arrangement",
+    "structures",
+    _CONCEPT_ARRANGEMENT_CHECK,
+    schema="public",
+  )
+  op.create_check_constraint(
+    "check_member_arrangement",
+    "structures",
+    _MEMBER_ARRANGEMENT_CHECK,
     schema="public",
   )
 
@@ -1170,7 +1214,8 @@ def upgrade() -> None:
     sa.Column("id", sa.String(), nullable=False),
     sa.Column("taxonomy_id", sa.String(), nullable=False),
     sa.Column("rule_category", sa.String(), nullable=False),
-    sa.Column("rule_pattern", sa.String(), nullable=False),
+    sa.Column("rule_pattern", sa.String(), nullable=True),
+    sa.Column("rule_check_kind", sa.String(), nullable=True),
     sa.Column("rule_expression", sa.Text(), nullable=False),
     sa.Column("rule_message", sa.Text(), nullable=True),
     sa.Column("rule_severity", sa.String(), nullable=False, server_default="error"),
@@ -1209,6 +1254,10 @@ def upgrade() -> None:
     sa.PrimaryKeyConstraint("id"),
     sa.CheckConstraint(_RULE_CATEGORY_CHECK, name="check_rule_category"),
     sa.CheckConstraint(_RULE_PATTERN_CHECK, name="check_rule_pattern"),
+    sa.CheckConstraint(_RULE_CHECK_KIND_CHECK, name="check_rule_check_kind"),
+    sa.CheckConstraint(
+      _RULE_PATTERN_KIND_XOR_CHECK, name="check_rule_pattern_kind_xor"
+    ),
     sa.CheckConstraint(_RULE_SEVERITY_CHECK, name="check_rule_severity"),
     sa.CheckConstraint(_RULE_ORIGIN_CHECK, name="check_rule_origin"),
     sa.CheckConstraint(
@@ -1325,11 +1374,11 @@ def upgrade() -> None:
       """
       UPDATE public.structures
       SET concept_arrangement = COALESCE(concept_arrangement, 'roll_up'),
-          member_arrangement = COALESCE(member_arrangement, 'aggregation'),
+          member_arrangement = COALESCE(member_arrangement, 'whole_part'),
           artifact_mechanics = jsonb_build_object(
             'kind', 'statement_renderer'
           )
-      WHERE structure_type IN (
+      WHERE block_type IN (
         'balance_sheet', 'income_statement',
         'cash_flow_statement', 'equity_statement'
       )
@@ -1473,10 +1522,15 @@ def downgrade() -> None:
   op.create_check_constraint(
     "check_taxonomy_type", "taxonomies", _NARROW_TAXONOMY_TYPE_CHECK
   )
-  op.drop_constraint("check_structure_type", "structures", type_="check")
-  op.create_check_constraint(
-    "check_structure_type", "structures", _NARROW_STRUCTURE_TYPE_CHECK
-  )
+  op.drop_constraint("check_block_type", "structures", type_="check")
+  op.create_check_constraint("check_block_type", "structures", _NARROW_BLOCK_TYPE_CHECK)
+
+  # Drop Phase d CAP/MAP CHECKs before dropping the columns they
+  # constrain.
+  for check in ("check_member_arrangement", "check_concept_arrangement"):
+    conn.execute(
+      text(f"ALTER TABLE public.structures DROP CONSTRAINT IF EXISTS {check}")
+    )
 
   # Drop Phase d columns from public.structures (tenant-schema columns
   # were dropped above in _teardown_tenant). IF EXISTS makes this safe
@@ -1484,7 +1538,7 @@ def downgrade() -> None:
   # migration run installed 0002 before the Phase δ columns existed.
   for col in (
     "template_id",
-    "parenthetical_note",
+    "renderer_note",
     "artifact_mechanics",
     "member_arrangement",
     "concept_arrangement",

--- a/migrations/extensions/versions/0002_taxonomy_library.py
+++ b/migrations/extensions/versions/0002_taxonomy_library.py
@@ -223,13 +223,19 @@ _RULE_PATTERN_KIND_XOR_CHECK = (
   "(rule_pattern IS NOT NULL AND rule_check_kind IS NULL) "
   "OR (rule_pattern IS NULL AND rule_check_kind IS NOT NULL)"
 )
-# Concept Arrangement Pattern (CAP) — 8 canonical + 2 pseudo per
-# information-block.md §3.2.1. NULL allowed for block types that don't
-# yet declare a default.
+# Concept Arrangement Pattern (CAP) — 8 canonical + 5 cm.xsd
+# text-block/detail specializations + 2 pseudo (15 total) per
+# information-block.md §3.2.1. Charlie encodes text-block level as the
+# CAP itself (Blocks PDF §1.9.1; PROOF disclosure-mechanics rules
+# point disclosures at cm_LevelNTextBlock via
+# disclosure-hasConceptArrangementPattern). NULL allowed for block
+# types that don't yet declare a default.
 _CONCEPT_ARRANGEMENT_CHECK = (
   "concept_arrangement IS NULL OR concept_arrangement IN ("
   "'set', 'roll_up', 'roll_forward', 'roll_forward_info', "
   "'adjustment', 'variance', 'arithmetic', 'text_block', "
+  "'level1_textblock', 'level2_textblock', 'level3_textblock', "
+  "'level4_detail', 'table_equivalent_textblock', "
   "'grid', 'compound_fact'"
   ")"
 )

--- a/migrations/extensions/versions/0007_frameworks_bridges.py
+++ b/migrations/extensions/versions/0007_frameworks_bridges.py
@@ -340,6 +340,13 @@ _WIDENED_BLOCK_TYPE_CHECK = (
   "'custom'"
   ")"
 )
+# Represents the CHECK constraint state *immediately before* this
+# migration runs (i.e., the post-0002 state). Used for downgrade only.
+# Includes 'regulatory_disclosure' (not 'disclosure') because 0002 was
+# rewritten in place during the 2026-05-15 vocabulary alignment;
+# `regulatory_disclosure` IS the canonical pre-0007 state. Don't
+# "restore" it to `disclosure` — that state never existed in a
+# deployed DB.
 _PRIOR_BLOCK_TYPE_CHECK = (
   "block_type IN ("
   "'income_statement', 'balance_sheet', "

--- a/migrations/extensions/versions/0007_frameworks_bridges.py
+++ b/migrations/extensions/versions/0007_frameworks_bridges.py
@@ -323,65 +323,61 @@ def _restore_association_type_check(conn, schema: str) -> None:
   )
 
 
-# Widen the structures.structure_type CHECK to admit 'comprehensive_income'
+# Widen the structures.block_type CHECK to admit 'comprehensive_income'
 # so the rs-gaap-disclosures package can carry the Statement of
 # Comprehensive Income with its own type (previously conflated with
-# 'income_statement'). The renderer dispatches by structure_type, so the
+# 'income_statement'). The renderer dispatches by block_type, so the
 # unconflation only takes effect once existing tenant schemas accept the
 # new value at the DB layer.
-_WIDENED_STRUCTURE_TYPE_CHECK = (
-  "structure_type IN ("
+_WIDENED_BLOCK_TYPE_CHECK = (
+  "block_type IN ("
   "'income_statement', 'balance_sheet', "
   "'cash_flow_statement', 'equity_statement', "
   "'comprehensive_income', "
   "'schedule', 'rollforward', 'reconciliation', 'policy', 'metric', "
   "'chart_of_accounts', 'coa_mapping', "
-  "'validation_rules', 'disclosure', 'taxonomy_mapping', "
+  "'validation_rules', 'regulatory_disclosure', 'taxonomy_mapping', "
   "'custom'"
   ")"
 )
-_PRIOR_STRUCTURE_TYPE_CHECK = (
-  "structure_type IN ("
+_PRIOR_BLOCK_TYPE_CHECK = (
+  "block_type IN ("
   "'income_statement', 'balance_sheet', "
   "'cash_flow_statement', 'equity_statement', "
   "'schedule', 'rollforward', 'reconciliation', 'policy', 'metric', "
   "'chart_of_accounts', 'coa_mapping', "
-  "'validation_rules', 'disclosure', 'taxonomy_mapping', "
+  "'validation_rules', 'regulatory_disclosure', 'taxonomy_mapping', "
   "'custom'"
   ")"
 )
 
 
-def _widen_structure_type_check(conn, schema: str) -> None:
-  """Drop and re-add the structures.structure_type CHECK with the widened list."""
+def _widen_block_type_check(conn, schema: str) -> None:
+  """Drop and re-add the structures.block_type CHECK with the widened list."""
   if schema == "public":
     table = "public.structures"
   else:
     table = f'"{schema}".structures'
-  conn.execute(
-    text(f"ALTER TABLE {table} DROP CONSTRAINT IF EXISTS check_structure_type")
-  )
+  conn.execute(text(f"ALTER TABLE {table} DROP CONSTRAINT IF EXISTS check_block_type"))
   conn.execute(
     text(
-      f"ALTER TABLE {table} ADD CONSTRAINT check_structure_type "
-      f"CHECK ({_WIDENED_STRUCTURE_TYPE_CHECK})"
+      f"ALTER TABLE {table} ADD CONSTRAINT check_block_type "
+      f"CHECK ({_WIDENED_BLOCK_TYPE_CHECK})"
     )
   )
 
 
-def _restore_structure_type_check(conn, schema: str) -> None:
-  """Inverse of :func:`_widen_structure_type_check` for downgrade."""
+def _restore_block_type_check(conn, schema: str) -> None:
+  """Inverse of :func:`_widen_block_type_check` for downgrade."""
   if schema == "public":
     table = "public.structures"
   else:
     table = f'"{schema}".structures'
-  conn.execute(
-    text(f"ALTER TABLE {table} DROP CONSTRAINT IF EXISTS check_structure_type")
-  )
+  conn.execute(text(f"ALTER TABLE {table} DROP CONSTRAINT IF EXISTS check_block_type"))
   conn.execute(
     text(
-      f"ALTER TABLE {table} ADD CONSTRAINT check_structure_type "
-      f"CHECK ({_PRIOR_STRUCTURE_TYPE_CHECK})"
+      f"ALTER TABLE {table} ADD CONSTRAINT check_block_type "
+      f"CHECK ({_PRIOR_BLOCK_TYPE_CHECK})"
     )
   )
 
@@ -622,8 +618,8 @@ def upgrade() -> None:
   _widen_association_type_check(conn, "public")
   for_each_tenant_schema(conn, _widen_association_type_check)
 
-  _widen_structure_type_check(conn, "public")
-  for_each_tenant_schema(conn, _widen_structure_type_check)
+  _widen_block_type_check(conn, "public")
+  for_each_tenant_schema(conn, _widen_block_type_check)
 
   # ── clean up spurious prefixed CHECK constraints left by an old ──
   # version of this migration that used schema-prefixed names. Those
@@ -649,8 +645,8 @@ def downgrade() -> None:
   _drop_role_uri_index(conn, "public")
   for_each_tenant_schema(conn, _drop_role_uri_index)
 
-  _restore_structure_type_check(conn, "public")
-  for_each_tenant_schema(conn, _restore_structure_type_check)
+  _restore_block_type_check(conn, "public")
+  for_each_tenant_schema(conn, _restore_block_type_check)
 
   _restore_element_source_check(conn, "public")
   for_each_tenant_schema(conn, _restore_element_source_check)

--- a/migrations/extensions/versions/0008_reporting_style.py
+++ b/migrations/extensions/versions/0008_reporting_style.py
@@ -6,7 +6,7 @@ to resolve which Network renders each statement type.
 
 This migration is additive:
 
-1. Widen ``structures.check_structure_type`` to admit ``'reporting_style'``
+1. Widen ``structures.check_block_type`` to admit ``'reporting_style'``
    (public + every existing tenant schema). Replaces the 0007 widen.
 2. Create ``public.reporting_style_networks`` — the typed composition
    table ``(reporting_style_id, statement_type) → network_id``. Mirrors
@@ -14,9 +14,9 @@ This migration is additive:
    ``CREATE SCHEMA IF NOT EXISTS`` + ``metadata.create_all``) lands the
    table for fresh tenants and existing tenants get it via the loop.
 3. Promote the three placeholder Style Structures from
-   ``structure_type='custom'`` → ``'reporting_style'`` in **public only**.
+   ``block_type='custom'`` → ``'reporting_style'`` in **public only**.
    Existing tenant rows keep their legacy ``'custom'`` type — the picker
-   doesn't filter on the Style's structure_type, and the immutability
+   doesn't filter on the Style's block_type, and the immutability
    trigger blocks tenant-scope UPDATE on library-seeded rows. Newly
    re-provisioned tenants pick up the corrected type from public.
 4. Seed the Default Style's composition (Balance Sheet / Multi-step IS /
@@ -70,57 +70,53 @@ def _structure_id(role_uri: str) -> str:
   return generate_deterministic_uuid(role_uri, namespace="structure")
 
 
-# ── structure_type CHECK widen (admit 'reporting_style') ──────────────────
+# ── block_type CHECK widen (admit 'reporting_style') ──────────────────
 
 
-_WIDENED_STRUCTURE_TYPE_CHECK = (
-  "structure_type IN ("
+_WIDENED_BLOCK_TYPE_CHECK = (
+  "block_type IN ("
   "'income_statement', 'balance_sheet', "
   "'cash_flow_statement', 'equity_statement', "
   "'comprehensive_income', "
   "'schedule', 'rollforward', 'reconciliation', 'policy', 'metric', "
   "'chart_of_accounts', 'coa_mapping', "
-  "'validation_rules', 'disclosure', 'taxonomy_mapping', "
+  "'validation_rules', 'regulatory_disclosure', 'taxonomy_mapping', "
   "'reporting_style', "
   "'custom'"
   ")"
 )
 # Same set as 0007's widen — restored on downgrade.
-_PRIOR_STRUCTURE_TYPE_CHECK = (
-  "structure_type IN ("
+_PRIOR_BLOCK_TYPE_CHECK = (
+  "block_type IN ("
   "'income_statement', 'balance_sheet', "
   "'cash_flow_statement', 'equity_statement', "
   "'comprehensive_income', "
   "'schedule', 'rollforward', 'reconciliation', 'policy', 'metric', "
   "'chart_of_accounts', 'coa_mapping', "
-  "'validation_rules', 'disclosure', 'taxonomy_mapping', "
+  "'validation_rules', 'regulatory_disclosure', 'taxonomy_mapping', "
   "'custom'"
   ")"
 )
 
 
-def _widen_structure_type_check(conn, schema: str) -> None:
+def _widen_block_type_check(conn, schema: str) -> None:
   table = "public.structures" if schema == "public" else f'"{schema}".structures'
-  conn.execute(
-    text(f"ALTER TABLE {table} DROP CONSTRAINT IF EXISTS check_structure_type")
-  )
+  conn.execute(text(f"ALTER TABLE {table} DROP CONSTRAINT IF EXISTS check_block_type"))
   conn.execute(
     text(
-      f"ALTER TABLE {table} ADD CONSTRAINT check_structure_type "
-      f"CHECK ({_WIDENED_STRUCTURE_TYPE_CHECK})"
+      f"ALTER TABLE {table} ADD CONSTRAINT check_block_type "
+      f"CHECK ({_WIDENED_BLOCK_TYPE_CHECK})"
     )
   )
 
 
-def _restore_structure_type_check(conn, schema: str) -> None:
+def _restore_block_type_check(conn, schema: str) -> None:
   table = "public.structures" if schema == "public" else f'"{schema}".structures'
-  conn.execute(
-    text(f"ALTER TABLE {table} DROP CONSTRAINT IF EXISTS check_structure_type")
-  )
+  conn.execute(text(f"ALTER TABLE {table} DROP CONSTRAINT IF EXISTS check_block_type"))
   conn.execute(
     text(
-      f"ALTER TABLE {table} ADD CONSTRAINT check_structure_type "
-      f"CHECK ({_PRIOR_STRUCTURE_TYPE_CHECK})"
+      f"ALTER TABLE {table} ADD CONSTRAINT check_block_type "
+      f"CHECK ({_PRIOR_BLOCK_TYPE_CHECK})"
     )
   )
 
@@ -204,7 +200,7 @@ def _promote_style_structures(conn) -> None:
   """Flip the 3 placeholder Style Structures in PUBLIC from 'custom' →
   'reporting_style'. Tenant rows are left untouched: the library
   immutability trigger blocks tenant-scope UPDATE, and the picker
-  doesn't care about the Style's structure_type. Fresh tenants pick
+  doesn't care about the Style's block_type. Fresh tenants pick
   up the corrected type when ``copy_library_into_tenant`` re-mirrors
   rows from public after this migration runs.
   """
@@ -217,8 +213,8 @@ def _promote_style_structures(conn) -> None:
     text(
       """
       UPDATE public.structures
-      SET structure_type = 'reporting_style'
-      WHERE id = ANY(:ids) AND structure_type = 'custom'
+      SET block_type = 'reporting_style'
+      WHERE id = ANY(:ids) AND block_type = 'custom'
       """
     ),
     {"ids": ids},
@@ -235,8 +231,8 @@ def _restore_style_structures(conn) -> None:
     text(
       """
       UPDATE public.structures
-      SET structure_type = 'custom'
-      WHERE id = ANY(:ids) AND structure_type = 'reporting_style'
+      SET block_type = 'custom'
+      WHERE id = ANY(:ids) AND block_type = 'reporting_style'
       """
     ),
     {"ids": ids},
@@ -247,9 +243,9 @@ def upgrade() -> None:
   conn = op.get_bind()
   from migrations.extensions.helpers import for_each_tenant_schema
 
-  # 1. Widen structure_type CHECK in public + every tenant schema.
-  _widen_structure_type_check(conn, "public")
-  for_each_tenant_schema(conn, _widen_structure_type_check)
+  # 1. Widen block_type CHECK in public + every tenant schema.
+  _widen_block_type_check(conn, "public")
+  for_each_tenant_schema(conn, _widen_block_type_check)
 
   # 2. Create reporting_style_networks table in public (Alembic op).
   op.create_table(
@@ -299,7 +295,7 @@ def downgrade() -> None:
   conn = op.get_bind()
   from migrations.extensions.helpers import for_each_tenant_schema
 
-  # Reverse step 4 + 5: restore Style structure_types + drop composition rows.
+  # Reverse step 4 + 5: restore Style block_types + drop composition rows.
   conn.execute(text("TRUNCATE TABLE public.reporting_style_networks"))
   _restore_style_structures(conn)
 
@@ -308,5 +304,5 @@ def downgrade() -> None:
   op.drop_table("reporting_style_networks")
 
   # Reverse the CHECK widen.
-  _restore_structure_type_check(conn, "public")
-  for_each_tenant_schema(conn, _restore_structure_type_check)
+  _restore_block_type_check(conn, "public")
+  for_each_tenant_schema(conn, _restore_block_type_check)

--- a/migrations/extensions/versions/0008_reporting_style.py
+++ b/migrations/extensions/versions/0008_reporting_style.py
@@ -85,7 +85,12 @@ _WIDENED_BLOCK_TYPE_CHECK = (
   "'custom'"
   ")"
 )
-# Same set as 0007's widen — restored on downgrade.
+# Same set as 0007's widen — restored on downgrade. Represents the
+# CHECK constraint state *immediately before* this migration runs
+# (i.e., post-0007). Uses 'regulatory_disclosure' because the rename
+# landed in 0002 (rewritten in place during the 2026-05-15 vocabulary
+# alignment); the old 'disclosure' value never existed in a deployed
+# DB.
 _PRIOR_BLOCK_TYPE_CHECK = (
   "block_type IN ("
   "'income_statement', 'balance_sheet', "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     # RoboSystems client for demo and testing
-    "robosystems-client==0.3.26",
+    "robosystems-client==0.3.27",
 
     # Testing framework
     "pytest>=8.4.0,<9.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     # RoboSystems client for demo and testing
-    "robosystems-client==0.3.25",
+    "robosystems-client==0.3.26",
 
     # Testing framework
     "pytest>=8.4.0,<9.0",

--- a/robosystems/adapters/quickbooks/pipeline/load.py
+++ b/robosystems/adapters/quickbooks/pipeline/load.py
@@ -226,7 +226,7 @@ def _trigger_auto_map_if_needed(
       structure = (
         session.query(Structure)
         .filter(
-          Structure.structure_type == "coa_mapping",
+          Structure.block_type == "coa_mapping",
           Structure.is_active.is_(True),
         )
         .order_by(Structure.created_at.asc())

--- a/robosystems/adapters/sec/enrichment.py
+++ b/robosystems/adapters/sec/enrichment.py
@@ -105,7 +105,7 @@ def parse_structure_definition(
 def classify_structure_heuristic(
   name: str | None,
   definition: str | None,
-  structure_type: str | None = None,
+  block_type: str | None = None,
 ) -> tuple[str | None, float]:
   """Classify a structure into a canonical statement type using keyword heuristics.
 
@@ -118,7 +118,7 @@ def classify_structure_heuristic(
       Confidence is capped at 0.85 for heuristic matches.
   """
   # Only classify Statement structures — Disclosures are not primary financial statements
-  if structure_type and structure_type.lower() not in ("statement", ""):
+  if block_type and block_type.lower() not in ("statement", ""):
     return (None, 0.0)
 
   text = ""

--- a/robosystems/adapters/sec/processors/xbrl_graph.py
+++ b/robosystems/adapters/sec/processors/xbrl_graph.py
@@ -536,18 +536,18 @@ class XBRLGraphProcessor:
       for idx, row in self.structures_df.iterrows():
         name = parsed_names[len(canonical_types)]
         definition = row.get("definition", "")
-        structure_type = row.get("type")
+        block_type = row.get("type")
         heuristic_type, heuristic_conf = classify_structure_heuristic(
-          name, definition, structure_type=structure_type
+          name, definition, block_type=block_type
         )
         if heuristic_type:
           canonical_types.append(heuristic_type)
           canonical_confidences.append(heuristic_conf)
-        elif structure_type != "Statement":
+        elif block_type != "Statement":
           # For Disclosure structures, attempt disclosure composition classification
           disc_type = None
           disc_conf = None
-          if structure_type == "Disclosure" and XBRL_GRAPH_REFINEMENT:
+          if block_type == "Disclosure" and XBRL_GRAPH_REFINEMENT:
             struct_id = row.get("identifier")
             elements = structure_element_map.get(struct_id, []) if struct_id else []
             if elements:

--- a/robosystems/arelle/context.py
+++ b/robosystems/arelle/context.py
@@ -107,7 +107,7 @@ CANONICAL_CONTEXT: dict = {
   "citation": {"@id": f"{RS_VOCAB}citation"},
   # Structure (extended link roles)
   "structureName": {"@id": f"{RS_VOCAB}structureName"},
-  "structureType": {"@id": f"{RS_VOCAB}structureType"},
+  "blockType": {"@id": f"{RS_VOCAB}blockType"},
   "roleUri": {"@id": f"{RS_VOCAB}roleUri"},
 }
 

--- a/robosystems/db/extensions.py
+++ b/robosystems/db/extensions.py
@@ -257,9 +257,9 @@ def _widen_library_checks(conn, schema: str) -> None:
   # (``migrations/extensions/versions/0002_taxonomy_library.py``).
   # ``copy_library_into_tenant`` mirrors rows from ``public.structures``
   # — a tenant-side CHECK narrower than public's silently fails graph
-  # creation when the library introduces a new structure_type value.
-  widened_structure_type = (
-    "structure_type IN ("
+  # creation when the library introduces a new block_type value.
+  widened_block_type = (
+    "block_type IN ("
     # Renderable financial-statement presentations
     "'income_statement', 'balance_sheet', "
     "'cash_flow_statement', 'equity_statement', "
@@ -271,7 +271,7 @@ def _widen_library_checks(conn, schema: str) -> None:
     # Reference-taxonomy structure kinds (XBRL network roles distinct
     # from presentation): formal calculation rules, named SEC/regulatory
     # disclosures, crosswalks between taxonomies.
-    "'validation_rules', 'disclosure', 'taxonomy_mapping', "
+    "'validation_rules', 'regulatory_disclosure', 'taxonomy_mapping', "
     # Reporting Style — the bundle a company picks (Phase 1 of §3.2);
     # composes Networks per statement_type via reporting_style_networks.
     "'reporting_style', "
@@ -315,14 +315,13 @@ def _widen_library_checks(conn, schema: str) -> None:
   )
   conn.execute(
     text(
-      f'ALTER TABLE "{schema}".structures '
-      f"DROP CONSTRAINT IF EXISTS check_structure_type"
+      f'ALTER TABLE "{schema}".structures DROP CONSTRAINT IF EXISTS check_block_type'
     )
   )
   conn.execute(
     text(
       f'ALTER TABLE "{schema}".structures '
-      f"ADD CONSTRAINT check_structure_type CHECK ({widened_structure_type})"
+      f"ADD CONSTRAINT check_block_type CHECK ({widened_block_type})"
     )
   )
 

--- a/robosystems/graphql/resolvers/ledger.py
+++ b/robosystems/graphql/resolvers/ledger.py
@@ -595,13 +595,13 @@ class LedgerQuery:
     self,
     info: Info[GraphQLContext, None],
     taxonomy_id: str | None = None,
-    structure_type: str | None = None,
+    block_type: str | None = None,
   ) -> StructureList | None:
     """List active structures."""
     try:
       with _open_session(info, "roboledger") as session:
         response = reads_taxonomies.list_structures(
-          session, taxonomy_id=taxonomy_id, structure_type=structure_type
+          session, taxonomy_id=taxonomy_id, block_type=block_type
         )
     except (ValueError, ProgrammingError):
       _raise_ledger_not_initialized()
@@ -797,9 +797,9 @@ class LedgerQuery:
     self,
     info: Info[GraphQLContext, None],
     report_id: str,
-    structure_type: str,
+    block_type: str,
   ) -> Statement | None:
-    """Rendered financial statement for a report + structure_type."""
+    """Rendered financial statement for a report + block_type."""
     graph_id = require_graph_id(info)
     # Reporting Style is pre-loaded onto the context at request build
     # time (graphql/context.py) so this resolver doesn't reopen a
@@ -811,7 +811,7 @@ class LedgerQuery:
           session,
           graph_id,
           report_id,
-          structure_type,
+          block_type,
           reporting_style_id=reporting_style_id,
         )
     except reads_reports.StatementStructureNotFoundError:

--- a/robosystems/graphql/resolvers/library.py
+++ b/robosystems/graphql/resolvers/library.py
@@ -324,14 +324,14 @@ class LibraryQuery:
     self,
     info: Info[GraphQLContext, None],
     taxonomy_id: strawberry.ID | None = None,
-    structure_type: str | None = None,
+    block_type: str | None = None,
   ) -> list[LibraryStructure]:
     """List structures (extended link roles) — BS, IS, custom, etc."""
     with _open_session(info) as session:
       rows = list_structures(
         session,
         taxonomy_id=str(taxonomy_id) if taxonomy_id else None,
-        structure_type=structure_type,
+        block_type=block_type,
       )
       return [LibraryStructure.from_pydantic(r) for r in rows]
 

--- a/robosystems/graphql/types/information_block.py
+++ b/robosystems/graphql/types/information_block.py
@@ -168,7 +168,7 @@ class Artifact:
   """The block's producible-artifact envelope (topic, template, mechanics)."""
 
   topic: str | None
-  parenthetical_note: str | None
+  renderer_note: str | None
   template: MechanicsPayload | None
   mechanics: MechanicsPayload
 
@@ -176,7 +176,7 @@ class Artifact:
   def from_pydantic(cls, artifact: PydanticArtifact) -> Artifact:
     return cls(
       topic=artifact.topic,
-      parenthetical_note=artifact.parenthetical_note,
+      renderer_note=artifact.renderer_note,
       template=artifact.template,
       # Pydantic's discriminated union dumps cleanly to a JSON object
       # including the `kind` tag; the client can branch on that.

--- a/robosystems/graphql/types/taxonomy_block.py
+++ b/robosystems/graphql/types/taxonomy_block.py
@@ -73,7 +73,7 @@ class TaxonomyBlockStructure:
 
   id: str
   name: str
-  structure_type: str
+  block_type: str
   description: str | None
   role_uri: str | None
 
@@ -82,7 +82,7 @@ class TaxonomyBlockStructure:
     return cls(
       id=s.id,
       name=s.name,
-      structure_type=s.structure_type,
+      block_type=s.block_type,
       description=s.description,
       role_uri=s.role_uri,
     )

--- a/robosystems/middleware/mcp/tools/taxonomy_tools.py
+++ b/robosystems/middleware/mcp/tools/taxonomy_tools.py
@@ -62,7 +62,7 @@ class ListMappingStructuresTool:
   that you get from here
 
 **RETURNS:**
-List of mapping structures with id, name, structure_type, taxonomy_id.
+List of mapping structures with id, name, block_type, taxonomy_id.
 Most tenants have exactly one `coa_mapping` structure ("CoA to US GAAP
 Mapping"); deployments that target multiple taxonomies (fac + rs-gaap)
 will have several.""",
@@ -84,7 +84,7 @@ will have several.""",
             {
               "id": s.id,
               "name": s.name,
-              "structure_type": s.structure_type,
+              "block_type": s.block_type,
               "taxonomy_id": s.taxonomy_id,
             }
             for s in result.structures

--- a/robosystems/models/api/extensions/closing_book.py
+++ b/robosystems/models/api/extensions/closing_book.py
@@ -16,7 +16,7 @@ class ClosingBookItem(BaseModel):
   id: str
   name: str
   item_type: str
-  structure_type: str | None = None
+  block_type: str | None = None
   report_id: str | None = None
   status: str | None = None
 

--- a/robosystems/models/api/extensions/report_package.py
+++ b/robosystems/models/api/extensions/report_package.py
@@ -104,7 +104,7 @@ class ReportPackageItem(BaseModel):
     0,
     description=(
       "Display position in the package. Derived from "
-      "``Structure.structure_type`` ordering (BS → IS → CF → Equity → "
+      "``Structure.block_type`` ordering (BS → IS → CF → Equity → "
       "Schedule), with ties broken by ``fact_set.created_at``."
     ),
   )

--- a/robosystems/models/api/extensions/reports.py
+++ b/robosystems/models/api/extensions/reports.py
@@ -262,7 +262,7 @@ class StructureSummary(BaseModel):
 
   id: str = Field(..., description="Structure identifier.")
   name: str = Field(..., description="Human-readable structure name.")
-  structure_type: str = Field(
+  block_type: str = Field(
     ...,
     description=(
       "Structure category: `balance_sheet`, `income_statement`, "
@@ -422,7 +422,7 @@ class StatementResponse(BaseModel):
   )
   structure_id: str = Field(..., description="Structure projected for this statement.")
   structure_name: str = Field(..., description="Human-readable structure name.")
-  structure_type: str = Field(
+  block_type: str = Field(
     ...,
     description=(
       "Structure category: `balance_sheet`, `income_statement`, "

--- a/robosystems/models/api/extensions/taxonomies.py
+++ b/robosystems/models/api/extensions/taxonomies.py
@@ -66,7 +66,7 @@ class StructureResponse(BaseModel):
   """One structure header — a renderable section within a taxonomy
   (balance sheet, income statement, schedule, etc.).
 
-  ``structure_type`` drives presentation: 'balance_sheet',
+  ``block_type`` drives presentation: 'balance_sheet',
   'income_statement', 'cash_flow_statement', 'equity_statement',
   'schedule', 'chart_of_accounts', 'coa_mapping', 'rollforward', etc.
   """
@@ -74,7 +74,7 @@ class StructureResponse(BaseModel):
   id: str
   name: str
   description: str | None = None
-  structure_type: str
+  block_type: str
   taxonomy_id: str
   is_active: bool
 
@@ -92,13 +92,13 @@ class CreateStructureRequest(BaseModel):
   # omitted from this Literal even though the DB CHECK constraint allows them.
   # The roboledger CF and CI renderers aren't implemented yet, so API
   # requests to *create* those structures are rejected at the Pydantic
-  # layer. Any pre-existing rows with those structure_types would only
+  # layer. Any pre-existing rows with those block_types would only
   # round-trip through this model if a write path validates it — the read
   # path uses `str`-typed response models and is unaffected. Confirmed no
   # rows in local/demo as of this commit; staging should be spot-checked
   # before rollout. SEC XBRL cash-flow parsing is a separate pipeline and
   # is unaffected. When the renderers land, add both back here.
-  structure_type: Literal[
+  block_type: Literal[
     "chart_of_accounts",
     "income_statement",
     "balance_sheet",
@@ -240,7 +240,7 @@ class MappingDetailResponse(BaseModel):
 
   id: str
   name: str
-  structure_type: str
+  block_type: str
   taxonomy_id: str
   associations: list[AssociationResponse]
   total_associations: int
@@ -453,7 +453,7 @@ class DeleteTaxonomyRequest(BaseModel):
 
 
 class UpdateStructureRequest(BaseModel):
-  """Update mutable fields on a structure. `structure_type` and
+  """Update mutable fields on a structure. `block_type` and
   `taxonomy_id` are immutable."""
 
   structure_id: str

--- a/robosystems/models/api/graphs/operations.py
+++ b/robosystems/models/api/graphs/operations.py
@@ -91,7 +91,7 @@ class ChangeReportingStyleOp(BaseModel):
 
   Switches the graph to a different Reporting Style. The target Style
   must be a library- or customer-authored Structure with
-  ``structure_type='reporting_style'`` and a complete composition
+  ``block_type='reporting_style'`` and a complete composition
   (one Network per required statement type — BS / IS / CF / SE). Filed
   Reports are unaffected because each ``Report`` already pins its own
   ``structure_id`` per FactSet at create-time; new reports use the new
@@ -105,7 +105,7 @@ class ChangeReportingStyleOp(BaseModel):
       "Structure id of the target Reporting Style (e.g., "
       "`025f5d48-12ce-5d65-b9eb-4f137a10ef06` for the library-seeded "
       "Default Style). Must resolve to a Structure with "
-      "structure_type='reporting_style' that has a complete composition "
+      "block_type='reporting_style' that has a complete composition "
       "in the graph's tenant schema."
     ),
   )

--- a/robosystems/models/api/information_block.py
+++ b/robosystems/models/api/information_block.py
@@ -81,7 +81,7 @@ class ClassificationLite(BaseModel):
     ...,
     description=(
       "Vocabulary identifier within the category — e.g. 'RollUp', "
-      "'aggregation', 'AssetsRollUp'."
+      "'whole_part', 'AssetsRollUp'."
     ),
   )
   is_primary: bool = Field(
@@ -282,13 +282,26 @@ class RuleLite(BaseModel):
       "XBRLTechnicalSyntaxRule."
     ),
   )
-  rule_pattern: str = Field(
-    ...,
+  rule_pattern: str | None = Field(
+    None,
     description=(
-      "One of 10 cm:BusinessRulePattern mechanisms — Adjustment, "
+      "Arithmetic / logical pattern evaluated over fact values. "
+      "One of 11 cm:BusinessRulePattern mechanisms — Adjustment, "
       "CoExists, EqualTo, Exists, GreaterThan, "
       "GreaterThanOrEqualToZero, LessThan, RollForward, RollUp, "
-      "Variance."
+      "SumEquals, Variance. Null when the rule is a structural check "
+      "(see rule_check_kind)."
+    ),
+  )
+  rule_check_kind: str | None = Field(
+    None,
+    description=(
+      "Model-structure check kind evaluated over the association graph. "
+      "One of 6 kinds — LeafHasClassification, "
+      "LibraryOriginImmutability, NoCycles, NoOrphanArcs, "
+      "ParentBeforeChild, UniqueQNameInTaxonomy. Null when the rule is "
+      "an arithmetic pattern (see rule_pattern). Exactly one of "
+      "rule_pattern / rule_check_kind is non-null per rule."
     ),
   )
   rule_expression: str
@@ -470,7 +483,12 @@ class InformationModelResponse(BaseModel):
     ),
   )
   member_arrangement: str | None = Field(
-    None, description="aggregation | nonaggregation, or null if non-hypercube."
+    None,
+    description=(
+      "is_a | whole_part | nested_whole_part | "
+      "two_dimension_aggregation | complex_aggregating_whole_part, "
+      "or null if non-hypercube."
+    ),
   )
 
 
@@ -480,7 +498,7 @@ class ArtifactResponse(BaseModel):
   topic: str | None = Field(
     None, description="Structure.description — the block's human-readable topic."
   )
-  parenthetical_note: str | None = Field(
+  renderer_note: str | None = Field(
     None, description="e.g. 'in thousands', 'except per share'."
   )
   template: dict[str, Any] | None = Field(

--- a/robosystems/models/api/library.py
+++ b/robosystems/models/api/library.py
@@ -86,7 +86,7 @@ class LibraryStructureResponse(BaseModel):
 
   id: str
   name: str
-  structure_type: str = Field(
+  block_type: str = Field(
     ...,
     description="balance_sheet | income_statement | cash_flow_statement | custom | …",
   )

--- a/robosystems/models/api/taxonomy_block.py
+++ b/robosystems/models/api/taxonomy_block.py
@@ -161,6 +161,15 @@ class TaxonomyBlockRuleRequest(BaseModel):
   Exactly one of ``target_structure_ref``, ``target_element_qname``, or
   ``target_taxonomy_self`` must be set (or all null for a global rule).
   The ``model_validator`` enforces this contract at the Pydantic layer.
+
+  Only **arithmetic** rule patterns are user-creatable via this API
+  (the ``rule_pattern`` Literal below). The 6 model-structure check
+  kinds (``NoCycles``, ``NoOrphanArcs``, ``ParentBeforeChild``,
+  ``LeafHasClassification``, ``LibraryOriginImmutability``,
+  ``UniqueQNameInTaxonomy``) are system-managed — they're auto-emitted
+  by :func:`emit_auto_rules` at taxonomy-block creation time and
+  populate ``rules.rule_check_kind`` instead of ``rule_pattern``. See
+  information-block.md §5.2.2 for the axis split.
   """
 
   name: str = Field(..., description="Rule identifier, unique within envelope.")
@@ -549,14 +558,21 @@ class TaxonomyBlockAssociation(BaseModel):
 
 
 class TaxonomyBlockRule(BaseModel):
-  """Rule projection for the Taxonomy Block envelope."""
+  """Rule projection for the Taxonomy Block envelope.
+
+  Exactly one of ``rule_pattern`` (arithmetic) or ``rule_check_kind``
+  (model-structure) is non-null per row, enforced by the
+  ``check_rule_pattern_kind_xor`` DB constraint. See
+  information-block.md §5.2.2.
+  """
 
   model_config = ConfigDict(from_attributes=True)
 
   id: str
   name: str
   rule_category: str
-  rule_pattern: str
+  rule_pattern: str | None = None
+  rule_check_kind: str | None = None
   rule_expression: str
   severity: str = "error"
   origin: str = Field(

--- a/robosystems/models/api/taxonomy_block.py
+++ b/robosystems/models/api/taxonomy_block.py
@@ -91,7 +91,7 @@ class TaxonomyBlockStructureRequest(BaseModel):
   name: str = Field(
     ..., description="Envelope-local structure name (unique within envelope)."
   )
-  structure_type: Literal[
+  block_type: Literal[
     "chart_of_accounts",
     "custom",
     "balance_sheet",
@@ -107,7 +107,7 @@ class TaxonomyBlockStructureRequest(BaseModel):
   ] = Field(
     ...,
     description=(
-      "DB ``structures.structure_type`` enum. CoA blocks use "
+      "DB ``structures.block_type`` enum. CoA blocks use "
       "``chart_of_accounts``; reporting extensions use the statement "
       "family or ``custom``; custom ontology uses ``custom``."
     ),
@@ -337,7 +337,7 @@ class CreateTaxonomyBlockRequest(BaseModel):
             },
           ],
           "structures": [
-            {"name": "main", "structure_type": "chart_of_accounts"},
+            {"name": "main", "block_type": "chart_of_accounts"},
           ],
         },
         {
@@ -354,7 +354,7 @@ class CreateTaxonomyBlockRequest(BaseModel):
             },
           ],
           "structures": [
-            {"name": "income_statement", "structure_type": "income_statement"},
+            {"name": "income_statement", "block_type": "income_statement"},
           ],
         },
       ]
@@ -528,7 +528,7 @@ class TaxonomyBlockStructure(BaseModel):
 
   id: str
   name: str
-  structure_type: str
+  block_type: str
   description: str | None = None
   role_uri: str | None = None
 

--- a/robosystems/models/extensions/classification.py
+++ b/robosystems/models/extensions/classification.py
@@ -3,9 +3,13 @@
 Covers the three association-level categories attached to Associations via
 `association_classifications`:
 
-- `concept_arrangement` — Charlie's FAC patterns (RollUp, RollForward,
-  Adjustment, Variance, Set, MemberAggregation, Textblock, …)
-- `member_arrangement`  — Aggregation / Nonaggregation
+- `concept_arrangement` — Charlie's 8 canonical Concept Arrangement
+  Patterns + 2 pseudo (Set, RollUp, RollForward, RollForwardInfo,
+  Adjustment, Variance, Arithmetic, TextBlock + Grid, CompoundFact per
+  information-block.md §3.2.1)
+- `member_arrangement`  — Charlie's 5-pattern aggregation spectrum:
+  IsA / WholePart / NestedWholePart / TwoDimensionAggregation /
+  ComplexAggregatingWholePart (information-block.md §3.2.2)
 - `named_disclosure`    — SEC disclosure mechanics catalog (AssetsRollUp,
   CashFlowStatement, …)
 

--- a/robosystems/models/extensions/rule.py
+++ b/robosystems/models/extensions/rule.py
@@ -73,16 +73,32 @@ class Rule(ExtensionsBase):
       ")",
       name="check_rule_category",
     ),
+    # Arithmetic / logical rule patterns. Evaluated by the AST evaluator
+    # over fact values. Exactly one of rule_pattern / rule_check_kind is
+    # populated (see check_rule_pattern_kind_xor below).
     CheckConstraint(
-      "rule_pattern IN ("
+      "rule_pattern IS NULL OR rule_pattern IN ("
       "'Adjustment', 'CoExists', 'EqualTo', 'Exists', 'GreaterThan', "
       "'GreaterThanOrEqualToZero', 'LessThan', 'RollForward', 'RollUp', "
-      "'SumEquals', 'Variance', "
+      "'SumEquals', 'Variance'"
+      ")",
+      name="check_rule_pattern",
+    ),
+    # Model-structure check kinds. Walk associations / classifications
+    # rather than facts; need a separate evaluator path.
+    CheckConstraint(
+      "rule_check_kind IS NULL OR rule_check_kind IN ("
       "'LeafHasClassification', 'LibraryOriginImmutability', "
       "'NoCycles', 'NoOrphanArcs', 'ParentBeforeChild', "
       "'UniqueQNameInTaxonomy'"
       ")",
-      name="check_rule_pattern",
+      name="check_rule_check_kind",
+    ),
+    # XOR: exactly one of rule_pattern / rule_check_kind is non-null.
+    CheckConstraint(
+      "(rule_pattern IS NOT NULL AND rule_check_kind IS NULL) "
+      "OR (rule_pattern IS NULL AND rule_check_kind IS NOT NULL)",
+      name="check_rule_pattern_kind_xor",
     ),
     CheckConstraint(
       "rule_severity IN ('info', 'warning', 'error')",
@@ -118,7 +134,11 @@ class Rule(ExtensionsBase):
   taxonomy_id = Column(String, ForeignKey("taxonomies.id"), nullable=False)
 
   rule_category = Column(String, nullable=False)
-  rule_pattern = Column(String, nullable=False)
+  # Exactly one of rule_pattern (arithmetic) or rule_check_kind
+  # (structural) is populated per row; the other is NULL. See the
+  # check_rule_pattern_kind_xor CHECK constraint above.
+  rule_pattern = Column(String, nullable=True)
+  rule_check_kind = Column(String, nullable=True)
   rule_expression = Column(Text, nullable=False)
   rule_message = Column(Text, nullable=True)
   rule_severity = Column(String, nullable=False, default="error")
@@ -147,4 +167,5 @@ class Rule(ExtensionsBase):
   created_by = Column(String, nullable=False, default="system")
 
   def __repr__(self) -> str:
-    return f"<Rule {self.rule_category}/{self.rule_pattern} id={self.id}>"
+    kind = self.rule_pattern or self.rule_check_kind
+    return f"<Rule {self.rule_category}/{kind} id={self.id}>"

--- a/robosystems/models/extensions/structure.py
+++ b/robosystems/models/extensions/structure.py
@@ -68,13 +68,20 @@ class Structure(ExtensionsBase):
       ")",
       name="check_block_type",
     ),
-    # Concept Arrangement Pattern (CAP). 8 canonical + 2 pseudo. See
+    # Concept Arrangement Pattern (CAP). 8 canonical + 5 cm.xsd
+    # text-block/detail specializations + 2 pseudo (15 total). See
     # information-block.md §3.2.1. NULL allowed for block types that
     # don't yet declare a default.
     CheckConstraint(
       "concept_arrangement IS NULL OR concept_arrangement IN ("
+      # 8 canonical CAPs
       "'set', 'roll_up', 'roll_forward', 'roll_forward_info', "
       "'adjustment', 'variance', 'arithmetic', 'text_block', "
+      # 5 cm.xsd text-block / detail specializations (Charlie encodes
+      # text-block level as the CAP itself; see Blocks PDF §1.9.1).
+      "'level1_textblock', 'level2_textblock', 'level3_textblock', "
+      "'level4_detail', 'table_equivalent_textblock', "
+      # 2 pseudo-patterns
       "'grid', 'compound_fact'"
       ")",
       name="check_concept_arrangement",
@@ -114,9 +121,19 @@ class Structure(ExtensionsBase):
   # for the canonical Concept Arrangement Pattern and Member Arrangement
   # Pattern enumerations from Charlie Hoffman's Seattle Method.
   #
-  # concept_arrangement — 8 canonical CAPs plus 2 pseudo-patterns:
-  #   set | roll_up | roll_forward | roll_forward_info | adjustment |
-  #   variance | arithmetic | text_block | grid | compound_fact.
+  # concept_arrangement — 8 canonical CAPs + 5 cm.xsd text-block /
+  # detail specializations + 2 pseudo-patterns (15 total). The
+  # specializations mirror seattlemethod/universal/cm.xsd — Charlie
+  # encodes text-block "level" as a first-class CAP value, not a
+  # separate axis (Blocks PDF §1.9.1; PROOF disclosure-mechanics).
+  #
+  #   Canonical (8):     set | roll_up | roll_forward | roll_forward_info
+  #                      | adjustment | variance | arithmetic | text_block
+  #   cm.xsd ext (5):    level1_textblock | level2_textblock |
+  #                      level3_textblock | level4_detail |
+  #                      table_equivalent_textblock
+  #   Pseudo (2):        grid | compound_fact
+  #
   # Nullable until every block type declares a default. CHECK constraint
   # below enforces the closed vocabulary.
   concept_arrangement = Column(String, nullable=True)

--- a/robosystems/models/extensions/structure.py
+++ b/robosystems/models/extensions/structure.py
@@ -31,7 +31,7 @@ class Structure(ExtensionsBase):
   __tablename__ = "structures"
   __table_args__ = (
     Index("idx_structures_taxonomy", "taxonomy_id"),
-    Index("idx_structures_type", "structure_type"),
+    Index("idx_structures_type", "block_type"),
     # Expression index over metadata->>'role_uri' to support the
     # ``load_disclosure_id_for_structure`` LIKE lookup. ``role_uri`` is
     # stored inside the metadata JSONB blob, not as a top-level column.
@@ -40,7 +40,7 @@ class Structure(ExtensionsBase):
       sqlalchemy_text("(metadata->>'role_uri')"),
     ),
     CheckConstraint(
-      "structure_type IN ("
+      "block_type IN ("
       # Renderable financial-statement presentations (the user-facing forms)
       "'income_statement', 'balance_sheet', "
       "'cash_flow_statement', 'equity_statement', "
@@ -57,7 +57,7 @@ class Structure(ExtensionsBase):
       # of the report-package render path; surfaced through their own
       # consumption paths (rule engine, disclosure registry, mapping
       # resolver).
-      "'validation_rules', 'disclosure', 'taxonomy_mapping', "
+      "'validation_rules', 'regulatory_disclosure', 'taxonomy_mapping', "
       # Reporting Style — the bundle a company picks (Charlie Hoffman's
       # term). One per entity graph, set at provision via
       # graphs.reporting_style_id; composes Networks per statement_type
@@ -66,7 +66,28 @@ class Structure(ExtensionsBase):
       # Escape hatch for everything that doesn't fit the above
       "'custom'"
       ")",
-      name="check_structure_type",
+      name="check_block_type",
+    ),
+    # Concept Arrangement Pattern (CAP). 8 canonical + 2 pseudo. See
+    # information-block.md §3.2.1. NULL allowed for block types that
+    # don't yet declare a default.
+    CheckConstraint(
+      "concept_arrangement IS NULL OR concept_arrangement IN ("
+      "'set', 'roll_up', 'roll_forward', 'roll_forward_info', "
+      "'adjustment', 'variance', 'arithmetic', 'text_block', "
+      "'grid', 'compound_fact'"
+      ")",
+      name="check_concept_arrangement",
+    ),
+    # Member Arrangement Pattern (MAP). 5 canonical, from non-aggregating
+    # to fully aggregating. See information-block.md §3.2.2. NULL allowed
+    # for non-hypercube block types.
+    CheckConstraint(
+      "member_arrangement IS NULL OR member_arrangement IN ("
+      "'is_a', 'whole_part', 'nested_whole_part', "
+      "'two_dimension_aggregation', 'complex_aggregating_whole_part'"
+      ")",
+      name="check_member_arrangement",
     ),
   )
 
@@ -78,7 +99,7 @@ class Structure(ExtensionsBase):
   description = Column(String, nullable=True)
 
   # Type
-  structure_type = Column(String, nullable=False)
+  block_type = Column(String, nullable=False)
 
   # Taxonomy membership
   taxonomy_id = Column(String, ForeignKey("taxonomies.id"), nullable=False)
@@ -89,14 +110,21 @@ class Structure(ExtensionsBase):
   # State
   is_active = Column(Boolean, nullable=False, default=True)
 
-  # Information Model axis columns.
-  # concept_arrangement: roll_up | roll_forward | variance | adjustment |
-  # set | arithmetic | textblock. Nullable until every block type
-  # declares a default; the CHECK constraint is intentionally absent so
-  # the vocabulary can expand without a migration round-trip.
+  # Information Model axis columns. See information-block.md §3.2.1-§3.2.2
+  # for the canonical Concept Arrangement Pattern and Member Arrangement
+  # Pattern enumerations from Charlie Hoffman's Seattle Method.
+  #
+  # concept_arrangement — 8 canonical CAPs plus 2 pseudo-patterns:
+  #   set | roll_up | roll_forward | roll_forward_info | adjustment |
+  #   variance | arithmetic | text_block | grid | compound_fact.
+  # Nullable until every block type declares a default. CHECK constraint
+  # below enforces the closed vocabulary.
   concept_arrangement = Column(String, nullable=True)
-  # member_arrangement: aggregation | nonaggregation. Null for
-  # non-hypercube block types.
+  # member_arrangement — 5 canonical MAPs along the aggregation spectrum
+  # from non-aggregating to fully aggregating:
+  #   is_a | whole_part | nested_whole_part |
+  #   two_dimension_aggregation | complex_aggregating_whole_part.
+  # Null for non-hypercube block types.
   member_arrangement = Column(String, nullable=True)
 
   # Typed Artifact Mechanics. Pydantic discriminated union (see
@@ -105,8 +133,11 @@ class Structure(ExtensionsBase):
   # column alongside ``metadata_``.
   artifact_mechanics = Column(JSONB, nullable=True)
 
-  # Renderer caveat, e.g. "(in thousands, except per share)".
-  parenthetical_note = Column(String, nullable=True)
+  # Renderer caveat, e.g. "(in thousands, except per share)". NOT XBRL
+  # parenthetical explanation — Charlie's parenthetical is fact-level via
+  # XBRL footnotes (Framework p.8). This is a Structure-level renderer
+  # hint, our extension; see information-block.md §1.7.
+  renderer_note = Column(String, nullable=True)
 
   # Nullable FK to ``structure_templates``. No FK constraint yet so
   # writes that pin a template don't require coordinated lifecycle with
@@ -127,4 +158,4 @@ class Structure(ExtensionsBase):
   created_by = Column(String, nullable=False, default="system")
 
   def __repr__(self) -> str:
-    return f"<Structure {self.name} ({self.structure_type})>"
+    return f"<Structure {self.name} ({self.block_type})>"

--- a/robosystems/operations/event_block/python_handlers/_disposal_plan.py
+++ b/robosystems/operations/event_block/python_handlers/_disposal_plan.py
@@ -62,7 +62,7 @@ def compute_disposal_plan(
   structure = session.execute(
     select(Structure).where(
       Structure.id == structure_id,
-      Structure.structure_type == "schedule",
+      Structure.block_type == "schedule",
     )
   ).scalar_one_or_none()
   if structure is None:

--- a/robosystems/operations/event_block/python_handlers/schedule_entry_due.py
+++ b/robosystems/operations/event_block/python_handlers/schedule_entry_due.py
@@ -107,7 +107,7 @@ def dispatch_preview(
   from robosystems.models.extensions import Structure
 
   structure = session.get(Structure, metadata.schedule_id)
-  if structure is None or structure.structure_type != "schedule":
+  if structure is None or structure.block_type != "schedule":
     return HandlerPreview(
       would_succeed=False,
       planned_entries=[],

--- a/robosystems/operations/extensions/loader.py
+++ b/robosystems/operations/extensions/loader.py
@@ -1202,9 +1202,7 @@ class OLTPLoader:
         # Check if a mapping structure already exists
         existing_mapping = (
           session.query(Structure)
-          .filter(
-            Structure.structure_type == "coa_mapping", Structure.is_active.is_(True)
-          )
+          .filter(Structure.block_type == "coa_mapping", Structure.is_active.is_(True))
           .first()
         )
 
@@ -1213,7 +1211,7 @@ class OLTPLoader:
             id=generate_prefixed_ulid("struct"),
             name="CoA to US GAAP Mapping",
             description="Maps Chart of Accounts to US GAAP reporting concepts",
-            structure_type="coa_mapping",
+            block_type="coa_mapping",
             taxonomy_id=existing_coa.id,
             is_active=True,
             created_by=created_by,

--- a/robosystems/operations/extensions/materialize.py
+++ b/robosystems/operations/extensions/materialize.py
@@ -512,13 +512,13 @@ def _staging_sql(graph_id: str, entity_id: str, connstr: str) -> dict[str, str]:
       NULL::VARCHAR                   AS network_uri,
       description                     AS definition,
       NULL::VARCHAR                   AS number,
-      structure_type                  AS type,
+      block_type                  AS type,
       name,
-      structure_type                  AS canonical_type,
+      block_type                  AS canonical_type,
       1.0::DOUBLE                     AS canonical_confidence,
       NULL::FLOAT[384]                AS embedding
     FROM postgres_scan('{c}', '{s}', 'structures')
-    WHERE structure_type NOT IN ('chart_of_accounts', 'coa_mapping')
+    WHERE block_type NOT IN ('chart_of_accounts', 'coa_mapping')
       AND is_active = true
   """
 
@@ -835,7 +835,7 @@ def _staging_sql(graph_id: str, entity_id: str, connstr: str) -> dict[str, str]:
       NULL::VARCHAR                   AS taxonomy_context
     FROM postgres_scan('{c}', '{s}', 'structures')
     WHERE taxonomy_id IS NOT NULL
-      AND structure_type NOT IN ('chart_of_accounts', 'coa_mapping')
+      AND block_type NOT IN ('chart_of_accounts', 'coa_mapping')
       AND is_active = true
   """
 

--- a/robosystems/operations/graph/commands/reporting_style.py
+++ b/robosystems/operations/graph/commands/reporting_style.py
@@ -2,7 +2,7 @@
 
 Synchronous platform-DB update. Validates the target Style is a
 library- or customer-authored Structure with
-``structure_type='reporting_style'`` and has a complete composition
+``block_type='reporting_style'`` and has a complete composition
 (one Network per required statement_type) in the graph's tenant
 schema. Then flips ``graphs.reporting_style_id``.
 
@@ -47,7 +47,7 @@ async def change_reporting_style_cmd(
       graph_id: Target graph (path parameter).
       new_reporting_style_id: Structure id of the target Style — must
           exist in the graph's tenant extensions schema with
-          ``structure_type='reporting_style'`` and have a complete
+          ``block_type='reporting_style'`` and have a complete
           composition.
       current_user: Authenticated caller. Must be an organization
           owner — the Reporting Style governs every render the org
@@ -63,7 +63,7 @@ async def change_reporting_style_cmd(
       HTTPException 403: caller is not an org member, or not an owner.
       HTTPException 404: graph not found.
       HTTPException 422: target Style not found in tenant, has wrong
-          structure_type, or has an incomplete composition.
+          block_type, or has an incomplete composition.
   """
   from robosystems.db.extensions import extensions_session
   from robosystems.models.core import OrgRole, OrgUser
@@ -108,7 +108,7 @@ async def change_reporting_style_cmd(
     row = ext.execute(
       text(
         """
-        SELECT id, name, structure_type, is_active
+        SELECT id, name, block_type, is_active
         FROM structures
         WHERE id = :sid
         """
@@ -126,13 +126,13 @@ async def change_reporting_style_cmd(
     # Accept legacy 'custom' rows so existing tenants whose Style rows
     # weren't promoted by migration 0008 (immutability trigger leaves
     # tenant copies alone) can still be selected. The picker doesn't
-    # filter on structure_type either.
-    if row.structure_type not in ("reporting_style", "custom"):
+    # filter on block_type either.
+    if row.block_type not in ("reporting_style", "custom"):
       raise HTTPException(
         status_code=422,
         detail=(
-          f"Structure {new_reporting_style_id!r} has structure_type="
-          f"{row.structure_type!r}; expected 'reporting_style' "
+          f"Structure {new_reporting_style_id!r} has block_type="
+          f"{row.block_type!r}; expected 'reporting_style' "
           f"(or 'custom' for legacy tenants whose Style rows weren't "
           f"promoted by migration 0008)."
         ),

--- a/robosystems/operations/information_block/README.md
+++ b/robosystems/operations/information_block/README.md
@@ -55,7 +55,7 @@ The compositional family (statements) and the derivative family (metrics) raise 
 
 3. **Register the entry** in `registry.py` — add a `BlockTypeRegistryEntry` literal and insert it into `REGISTRY`. That's it: the generic REST ops (`create-information-block`, etc.) and MCP tools pick it up automatically via the registry.
 
-4. **Widen the DB CHECK constraint** — add the new `structure_type` value to `migrations/extensions/versions/` and to `_widen_library_checks` in `db/extensions.py`.
+4. **Widen the DB CHECK constraint** — add the new `block_type` value to `migrations/extensions/versions/` and to `_widen_library_checks` in `db/extensions.py`.
 
 ## Envelope Assembly
 

--- a/robosystems/operations/information_block/envelope.py
+++ b/robosystems/operations/information_block/envelope.py
@@ -273,6 +273,7 @@ def rule_to_lite(rule: Rule) -> RuleLite:
     id=rule.id,
     rule_category=rule.rule_category,
     rule_pattern=rule.rule_pattern,
+    rule_check_kind=rule.rule_check_kind,
     rule_expression=rule.rule_expression,
     rule_target=target,
     rule_variables=variables,
@@ -350,7 +351,7 @@ def load_base_envelope_atoms(
   """Load every atom shared by Information Block envelope builders.
 
   Returns ``None`` when the Structure doesn't exist or its
-  ``structure_type`` doesn't match ``expected_block_type`` — handlers
+  ``block_type`` doesn't match ``expected_block_type`` — handlers
   surface that as a clean miss to :func:`get_information_block`. Loading
   order: Structure -> taxonomy name -> associations -> elements -> rules
   -> classifications -> fact_set -> verification_results, matching the
@@ -364,7 +365,7 @@ def load_base_envelope_atoms(
   from robosystems.models.extensions import Taxonomy
 
   structure = session.get(Structure, structure_id)
-  if structure is None or structure.structure_type != expected_block_type:
+  if structure is None or structure.block_type != expected_block_type:
     return None
 
   # Validate the FactSet pin (when provided) before doing the heavy
@@ -428,9 +429,9 @@ def load_base_envelope_atoms(
 
 _DISCLOSURE_ROLE_PREFIX = "https://robosystems.ai/seattle/cm-roles/roles/disclosures/"
 
-# Module-level cache keyed by structure_type. The rs-gaap-disclosures
+# Module-level cache keyed by block_type. The rs-gaap-disclosures
 # package is library-seeded and immutable, so the mapping from
-# structure_type (e.g. 'balance_sheet') to disclosure qname
+# block_type (e.g. 'balance_sheet') to disclosure qname
 # (e.g. 'disclosures:BalanceSheet') is global for the process lifetime.
 # A miss caches None so we don't re-query for types that have no
 # corresponding disclosure (validation_rules, taxonomy_mapping, schedules).
@@ -454,20 +455,20 @@ def _structure_role_uri(structure: Structure) -> str | None:
   return value if isinstance(value, str) else None
 
 
-def _disclosure_qname_for_type(session: Session, structure_type: str) -> str | None:
-  """Memoized lookup: structure_type -> disclosures:<Name> qname.
+def _disclosure_qname_for_type(session: Session, block_type: str) -> str | None:
+  """Memoized lookup: block_type -> disclosures:<Name> qname.
 
   Uses ``metadata->>'role_uri'`` JSONB access and the matching expression
   index (``idx_structures_role_uri``) for a single fast lookup.
   """
-  cached = _DISCLOSURE_QNAME_BY_TYPE.get(structure_type, _MISSING)
+  cached = _DISCLOSURE_QNAME_BY_TYPE.get(block_type, _MISSING)
   if cached is not _MISSING:
     return cached  # type: ignore[return-value]
 
   role_uri = session.execute(
     select(Structure.metadata_["role_uri"].astext)
     .where(
-      Structure.structure_type == structure_type,
+      Structure.block_type == block_type,
       Structure.metadata_["role_uri"].astext.like(f"{_DISCLOSURE_ROLE_PREFIX}%"),
     )
     .limit(1)
@@ -479,7 +480,7 @@ def _disclosure_qname_for_type(session: Session, structure_type: str) -> str | N
   else:
     qname = f"disclosures:{role_uri[len(_DISCLOSURE_ROLE_PREFIX) :]}"
 
-  _DISCLOSURE_QNAME_BY_TYPE[structure_type] = qname
+  _DISCLOSURE_QNAME_BY_TYPE[block_type] = qname
   return qname
 
 
@@ -494,14 +495,14 @@ def load_disclosure_id_for_structure(session: Session, structure_id: str) -> str
      statement entries themselves.
 
   2. The structure is a renderable presentation (e.g. ``BS-classified``)
-     with a statement-level structure_type. Look up the
-     disclosure-namespace structure that shares the same structure_type
+     with a statement-level block_type. Look up the
+     disclosure-namespace structure that shares the same block_type
      — for statement types (balance_sheet, income_statement,
      cash_flow_statement, equity_statement, comprehensive_income) this
-     is a 1:1 match. Returns ``None`` for structure_types that have no
+     is a 1:1 match. Returns ``None`` for block_types that have no
      corresponding disclosure (validation_rules, taxonomy_mapping, etc.).
 
-  The structure_type -> disclosure qname mapping is memoized at module
+  The block_type -> disclosure qname mapping is memoized at module
   level via :data:`_DISCLOSURE_QNAME_BY_TYPE`; library-seeded disclosure
   rows are immutable so the cache is safe for the process lifetime.
   """
@@ -516,10 +517,10 @@ def load_disclosure_id_for_structure(session: Session, structure_id: str) -> str
   if role_uri.startswith(_DISCLOSURE_ROLE_PREFIX):
     return f"disclosures:{role_uri[len(_DISCLOSURE_ROLE_PREFIX) :]}"
 
-  if target.structure_type is None:
+  if target.block_type is None:
     return None
 
-  return _disclosure_qname_for_type(session, target.structure_type)
+  return _disclosure_qname_for_type(session, target.block_type)
 
 
 __all__ = [

--- a/robosystems/operations/information_block/metric.py
+++ b/robosystems/operations/information_block/metric.py
@@ -56,7 +56,7 @@ def build_envelope(
   del fact_set_id  # see TODO above; metric FactSet wiring lands later
 
   structure = session.get(Structure, structure_id)
-  if structure is None or structure.structure_type != METRIC_BLOCK_TYPE:
+  if structure is None or structure.block_type != METRIC_BLOCK_TYPE:
     return None
 
   if structure.artifact_mechanics:
@@ -85,7 +85,7 @@ def build_envelope(
     ),
     artifact=ArtifactResponse(
       topic=structure.description,
-      parenthetical_note=structure.parenthetical_note,
+      renderer_note=structure.renderer_note,
       template=None,
       mechanics=mechanics,
     ),

--- a/robosystems/operations/information_block/reads.py
+++ b/robosystems/operations/information_block/reads.py
@@ -39,9 +39,9 @@ def get_information_block(
   if structure is None:
     return None
   try:
-    entry = registry_module.get(structure.structure_type)
+    entry = registry_module.get(structure.block_type)
   except KeyError:
-    # Existing rows whose structure_type isn't a registered block type
+    # Existing rows whose block_type isn't a registered block type
     # surface as ``None`` rather than raising — the envelope just can't
     # be built.
     return None
@@ -56,7 +56,7 @@ def get_information_block_for_fact_set(
   Looks up the FactSet's Structure, then dispatches the registered
   block-type handler with the explicit fact_set pin. Returns ``None``
   when the FactSet doesn't exist, has no Structure, or its
-  ``structure_type`` isn't a registered block type.
+  ``block_type`` isn't a registered block type.
 
   Used by the Report Block read path: each ReportBlockItem pins a
   ``fact_set_id``; assembling the envelope for that item is exactly
@@ -118,11 +118,11 @@ def list_information_blocks(
   # never sees their schedules.
   query = (
     select(Structure)
-    .where(Structure.structure_type.in_(candidate_ids))
+    .where(Structure.block_type.in_(candidate_ids))
     .where(Structure.is_active.is_(True))
     .order_by(
       (Structure.created_by == "library-seeder").asc(),
-      Structure.structure_type,
+      Structure.block_type,
       Structure.name,
     )
     .limit(limit)
@@ -133,7 +133,7 @@ def list_information_blocks(
   envelopes: list[InformationBlockEnvelope] = []
   for structure in rows:
     try:
-      entry = registry_module.get(structure.structure_type)
+      entry = registry_module.get(structure.block_type)
     except KeyError:
       continue
     envelope = entry.dispatch_build_envelope(session, structure.id)

--- a/robosystems/operations/information_block/registry.py
+++ b/robosystems/operations/information_block/registry.py
@@ -130,7 +130,7 @@ def _make_statement_entry(block_type: str, icon: str) -> BlockTypeRegistryEntry:
       f"create-report, not create-information-block."
     ),
     concept_arrangement_default="roll_up",
-    member_arrangement_default="aggregation",
+    member_arrangement_default="whole_part",
     mechanics_schema=StatementMechanics,
     create_request_model=_EmptyPayload,
     update_request_model=_EmptyPayload,

--- a/robosystems/operations/information_block/schedule.py
+++ b/robosystems/operations/information_block/schedule.py
@@ -223,7 +223,7 @@ def build_envelope(
     ),
     artifact=ArtifactResponse(
       topic=structure.description,
-      parenthetical_note=structure.parenthetical_note,
+      renderer_note=structure.renderer_note,
       template=None,
       mechanics=mechanics,
     ),

--- a/robosystems/operations/information_block/statement.py
+++ b/robosystems/operations/information_block/statement.py
@@ -19,7 +19,7 @@ entry are the not-implemented stubs built by
 **Rendering projection.** As of Plan B (2026-04-25) the envelope
 populates ``view.rendering`` with the server-computed statement grid
 (rows + periods + validation). This replaces the legacy
-``getStatement(reportId, structureType)`` REST path: frontend
+``getStatement(reportId, blockType)`` REST path: frontend
 ``BlockView`` consumes ``envelope.view.rendering`` directly, no
 client-side rollup or hierarchy walk needed. The pure in-memory rollup
 helpers (``_build_rows``, ``_facts_to_balance_dict``, ``_natural_sign``)
@@ -172,11 +172,11 @@ def _build_statement_envelope(
     disclosure_id=disclosure_id,
     information_model=InformationModelResponse(
       concept_arrangement=structure.concept_arrangement or "roll_up",
-      member_arrangement=structure.member_arrangement or "aggregation",
+      member_arrangement=structure.member_arrangement or "whole_part",
     ),
     artifact=ArtifactResponse(
       topic=structure.description,
-      parenthetical_note=structure.parenthetical_note,
+      renderer_note=structure.renderer_note,
       template=None,
       mechanics=mechanics,
     ),

--- a/robosystems/operations/information_block/types.py
+++ b/robosystems/operations/information_block/types.py
@@ -40,7 +40,7 @@ class BlockTypeRegistryEntry:
 
   id: str
   """Stable discriminator — e.g. 'schedule'. Matches the block_type
-  string on the wire and the ``structure_type`` value in the DB."""
+  string on the wire and the ``block_type`` value in the DB."""
 
   display_name: str
   """Human-readable singular name, e.g. 'Schedule'."""

--- a/robosystems/operations/library/reads/elements.py
+++ b/robosystems/operations/library/reads/elements.py
@@ -524,7 +524,7 @@ def get_element_arcs(
     .where(
       (Taxonomy.taxonomy_type == "mapping")
       | (Taxonomy.taxonomy_type == "classification-assignment")
-      | (Structure.structure_type == "coa_mapping")
+      | (Structure.block_type == "coa_mapping")
     )
   )
 

--- a/robosystems/operations/library/reads/structures.py
+++ b/robosystems/operations/library/reads/structures.py
@@ -14,7 +14,7 @@ def _structure_to_response(structure: Structure) -> LibraryStructureResponse:
   return LibraryStructureResponse(
     id=structure.id,
     name=structure.name,
-    structure_type=structure.structure_type,
+    block_type=structure.block_type,
     taxonomy_id=structure.taxonomy_id,
     role_uri=role_uri,
     is_active=structure.is_active,
@@ -24,15 +24,15 @@ def _structure_to_response(structure: Structure) -> LibraryStructureResponse:
 def list_structures(
   session: Session,
   taxonomy_id: str | None = None,
-  structure_type: str | None = None,
+  block_type: str | None = None,
 ) -> list[LibraryStructureResponse]:
   """List structures, optionally filtered by taxonomy or type."""
   query = select(Structure)
   if taxonomy_id is not None:
     query = query.where(Structure.taxonomy_id == taxonomy_id)
-  if structure_type is not None:
-    query = query.where(Structure.structure_type == structure_type)
-  query = query.order_by(Structure.structure_type, Structure.name)
+  if block_type is not None:
+    query = query.where(Structure.block_type == block_type)
+  query = query.order_by(Structure.block_type, Structure.name)
 
   structures = session.execute(query).scalars().all()
   return [_structure_to_response(s) for s in structures]

--- a/robosystems/operations/roboledger/commands/schedules.py
+++ b/robosystems/operations/roboledger/commands/schedules.py
@@ -298,7 +298,7 @@ def _load_schedule_or_404(session: Session, structure_id: str) -> Structure:
   structure = session.execute(
     select(Structure).where(
       Structure.id == structure_id,
-      Structure.structure_type == "schedule",
+      Structure.block_type == "schedule",
     )
   ).scalar_one_or_none()
   if structure is None:

--- a/robosystems/operations/roboledger/commands/taxonomies.py
+++ b/robosystems/operations/roboledger/commands/taxonomies.py
@@ -133,7 +133,7 @@ def _structure_to_response(row: Structure) -> StructureResponse:
     id=row.id,
     name=row.name,
     description=row.description,
-    structure_type=row.structure_type,
+    block_type=row.block_type,
     taxonomy_id=row.taxonomy_id,
     is_active=row.is_active,
   )
@@ -178,7 +178,7 @@ def create_structure(
     id=generate_prefixed_ulid("struct"),
     name=body.name,
     description=body.description,
-    structure_type=body.structure_type,
+    block_type=body.block_type,
     taxonomy_id=body.taxonomy_id,
     created_by=created_by,
   )
@@ -377,7 +377,7 @@ def update_structure(
   (``create-taxonomy-block`` / ``update-taxonomy-block``); this is
   invoked indirectly by those operations.
 
-  `structure_type` and `taxonomy_id` are immutable.
+  `block_type` and `taxonomy_id` are immutable.
   Raises `StructureNotFoundError` if the structure does not exist.
   """
   structure = session.execute(

--- a/robosystems/operations/roboledger/fiscal_calendar/close_service.py
+++ b/robosystems/operations/roboledger/fiscal_calendar/close_service.py
@@ -341,7 +341,7 @@ class PeriodCloseService:
           SELECT DISTINCT s.id
           FROM structures s
           JOIN facts f ON f.structure_id = s.id
-          WHERE s.structure_type = 'schedule'
+          WHERE s.block_type = 'schedule'
             AND f.fact_scope = 'in_scope'
             AND f.period_end >= :period_start
             AND f.period_end <= :period_end

--- a/robosystems/operations/roboledger/reads/account_rollups.py
+++ b/robosystems/operations/roboledger/reads/account_rollups.py
@@ -109,7 +109,7 @@ def get_account_rollups(
     mapping = session.execute(
       select(Structure)
       .where(
-        Structure.structure_type == "coa_mapping",
+        Structure.block_type == "coa_mapping",
         Structure.is_active.is_(True),
       )
       .limit(1)

--- a/robosystems/operations/roboledger/reads/closing_book.py
+++ b/robosystems/operations/roboledger/reads/closing_book.py
@@ -69,11 +69,11 @@ def get_closing_book_structures(session: Session) -> ClosingBookStructuresRespon
     types_list = ", ".join(f"'{t}'" for t in _STATEMENT_TYPES)
     stmt_result = session.execute(
       text(f"""
-        SELECT id, name, structure_type FROM structures
+        SELECT id, name, block_type FROM structures
         WHERE taxonomy_id = :taxonomy_id
-          AND structure_type IN ({types_list})
+          AND block_type IN ({types_list})
           AND is_active = true
-        ORDER BY structure_type
+        ORDER BY block_type
       """),
       {"taxonomy_id": latest_report.taxonomy_id},
     )
@@ -81,9 +81,9 @@ def get_closing_book_structures(session: Session) -> ClosingBookStructuresRespon
     statement_items = [
       ClosingBookItem(
         id=r.id,
-        name=_STATEMENT_LABELS.get(r.structure_type, r.name),
+        name=_STATEMENT_LABELS.get(r.block_type, r.name),
         item_type="statement",
-        structure_type=r.structure_type,
+        block_type=r.block_type,
         report_id=latest_report.id,
       )
       for r in stmt_result
@@ -97,7 +97,7 @@ def get_closing_book_structures(session: Session) -> ClosingBookStructuresRespon
     session.execute(
       select(Structure)
       .where(
-        Structure.structure_type == "coa_mapping",
+        Structure.block_type == "coa_mapping",
         Structure.is_active.is_(True),
       )
       .order_by(Structure.name)
@@ -122,7 +122,7 @@ def get_closing_book_structures(session: Session) -> ClosingBookStructuresRespon
     session.execute(
       select(Structure)
       .where(
-        Structure.structure_type == "schedule",
+        Structure.block_type == "schedule",
         Structure.is_active.is_(True),
       )
       .order_by(Structure.name)
@@ -137,7 +137,7 @@ def get_closing_book_structures(session: Session) -> ClosingBookStructuresRespon
         id=s.id,
         name=s.name,
         item_type="schedule",
-        structure_type="schedule",
+        block_type="schedule",
       )
       for s in schedules
     ]

--- a/robosystems/operations/roboledger/reads/reports.py
+++ b/robosystems/operations/roboledger/reads/reports.py
@@ -48,7 +48,7 @@ from robosystems.operations.roboledger.reports.fact_grid import (
 )
 from robosystems.operations.roboledger.reports.guard_rails import validate_report
 
-VALID_STRUCTURE_TYPES = {
+VALID_BLOCK_TYPES = {
   "income_statement",
   "balance_sheet",
   "equity_statement",
@@ -81,7 +81,7 @@ ANALYSIS_STATEMENT_TYPES: tuple[str, ...] = (
 
 
 class StatementStructureNotFoundError(LookupError):
-  """Raised when a statement's structure_type isn't in the report's taxonomy."""
+  """Raised when a statement's block_type isn't in the report's taxonomy."""
 
 
 class CoaMappingNotFoundError(LookupError):
@@ -118,7 +118,7 @@ def generate_adhoc_private_statement(
   mapping workflow yet — the caller translates to a user-facing tip.
   """
   mapping = (
-    session.query(Structure).filter(Structure.structure_type == "coa_mapping").first()
+    session.query(Structure).filter(Structure.block_type == "coa_mapping").first()
   )
   if mapping is None:
     raise CoaMappingNotFoundError(
@@ -143,7 +143,7 @@ def generate_adhoc_private_statement(
   grid = render_structure_view(
     session=session,
     facts=facts.facts,
-    structure_type=statement_type,
+    block_type=statement_type,
     periods=periods,
     reporting_style_id=reporting_style_id,
   )
@@ -195,17 +195,16 @@ def load_structures(session: Session, taxonomy_id: str) -> list[StructureSummary
   """Load available (statement-ish) structures for a taxonomy."""
   result = session.execute(
     text("""
-      SELECT id, name, structure_type FROM structures
+      SELECT id, name, block_type FROM structures
       WHERE taxonomy_id = :taxonomy_id
-        AND structure_type NOT IN ('chart_of_accounts', 'coa_mapping')
+        AND block_type NOT IN ('chart_of_accounts', 'coa_mapping')
         AND is_active = true
-      ORDER BY structure_type
+      ORDER BY block_type
     """),
     {"taxonomy_id": taxonomy_id},
   )
   return [
-    StructureSummary(id=r.id, name=r.name, structure_type=r.structure_type)
-    for r in result
+    StructureSummary(id=r.id, name=r.name, block_type=r.block_type) for r in result
   ]
 
 
@@ -299,7 +298,7 @@ def get_report(session: Session, report_id: str) -> ReportResponse | None:
 # Display order for the package mode — drives ``ReportPackageItem.display_order``
 # when a Structure has no explicit ordering metadata of its own. New
 # statement-family block types should be added here as they're seeded.
-_STRUCTURE_TYPE_DISPLAY_ORDER: dict[str, int] = {
+_BLOCK_TYPE_DISPLAY_ORDER: dict[str, int] = {
   "balance_sheet": 1,
   "income_statement": 2,
   "cash_flow_statement": 3,
@@ -321,7 +320,7 @@ def get_report_package(
   the package without per-section refetches.
 
   Returns ``None`` when the Report doesn't exist. Items are ordered by
-  ``Structure.structure_type`` (BS → IS → CF → Equity → Schedule) with
+  ``Structure.block_type`` (BS → IS → CF → Equity → Schedule) with
   ties broken by ``fact_set.created_at``.
   """
   from robosystems.models.api.extensions.report_package import (
@@ -359,12 +358,12 @@ def get_report_package(
       # skipped — they're a real data row but the package mode has no
       # way to render them.
       continue
-    structure_type = structure.structure_type if structure is not None else None
+    block_type = structure.block_type if structure is not None else None
     items.append(
       ReportPackageItem(
         fact_set_id=fs.id,
         structure_id=fs.structure_id,
-        display_order=_STRUCTURE_TYPE_DISPLAY_ORDER.get(structure_type or "", 50),
+        display_order=_BLOCK_TYPE_DISPLAY_ORDER.get(block_type or "", 50),
         block=envelope,
       )
     )
@@ -401,13 +400,13 @@ def get_statement(
   session: Session,
   graph_id: str,
   report_id: str,
-  structure_type: str,
+  block_type: str,
   reporting_style_id: str | None = None,
 ) -> StatementResponse | None:
-  """Render a financial statement for a report + structure_type.
+  """Render a financial statement for a report + block_type.
 
   Returns `None` when the report itself doesn't exist. Raises
-  `StatementStructureNotFoundError` when the structure_type isn't in
+  `StatementStructureNotFoundError` when the block_type isn't in
   the report's taxonomy. The caller translates both into HTTP 404s.
 
   ``reporting_style_id`` resolves the graph's active Style (§3.2 Phase 1).
@@ -417,10 +416,10 @@ def get_statement(
   round-trip; if omitted, falls back to ``load_graph_reporting_style``
   which opens its own platform session.
   """
-  if structure_type not in VALID_STRUCTURE_TYPES:
+  if block_type not in VALID_BLOCK_TYPES:
     raise ValueError(
-      f"Invalid structure_type '{structure_type}'. "
-      f"Must be one of: {', '.join(sorted(VALID_STRUCTURE_TYPES))}"
+      f"Invalid block_type '{block_type}'. "
+      f"Must be one of: {', '.join(sorted(VALID_BLOCK_TYPES))}"
     )
 
   report_def = session.get(Report, report_id)
@@ -439,7 +438,7 @@ def get_statement(
       report_id=report_def.id,
       structure_id="",
       structure_name="",
-      structure_type=structure_type,
+      block_type=block_type,
     )
 
   # Classification (FASB elementsOfFinancialStatements trait) is resolved via
@@ -489,7 +488,7 @@ def get_statement(
       report_id=report_def.id,
       structure_id="",
       structure_name="",
-      structure_type=structure_type,
+      block_type=block_type,
       periods=[PeriodSpec(start=p.start, end=p.end, label=p.label) for p in periods],
     )
 
@@ -502,15 +501,15 @@ def get_statement(
   grid = render_structure_view(
     session=session,
     facts=facts,
-    structure_type=structure_type,
+    block_type=block_type,
     periods=periods,
     reporting_style_id=reporting_style_id,
   )
 
   if not grid.structure_id:
-    raise StatementStructureNotFoundError(structure_type)
+    raise StatementStructureNotFoundError(block_type)
 
-  validation = validate_report(structure_type, grid.rows)
+  validation = validate_report(block_type, grid.rows)
 
   rows = [
     FactRowResponse(
@@ -540,7 +539,7 @@ def get_statement(
     report_id=report_def.id,
     structure_id=grid.structure_id,
     structure_name=grid.structure_name,
-    structure_type=structure_type,
+    block_type=block_type,
     periods=[PeriodSpec(start=p.start, end=p.end, label=p.label) for p in grid.periods],
     rows=rows,
     validation=validation_resp,

--- a/robosystems/operations/roboledger/reads/taxonomies.py
+++ b/robosystems/operations/roboledger/reads/taxonomies.py
@@ -560,7 +560,7 @@ def _structure_to_response(row: Structure) -> StructureResponse:
     id=row.id,
     name=row.name,
     description=row.description,
-    structure_type=row.structure_type,
+    block_type=row.block_type,
     taxonomy_id=row.taxonomy_id,
     is_active=row.is_active,
   )
@@ -570,14 +570,14 @@ def list_structures(
   session: Session,
   *,
   taxonomy_id: str | None = None,
-  structure_type: str | None = None,
+  block_type: str | None = None,
 ) -> StructureListResponse:
   """List active structures, optionally filtered by taxonomy + type."""
   query = select(Structure).where(Structure.is_active.is_(True))
   if taxonomy_id:
     query = query.where(Structure.taxonomy_id == taxonomy_id)
-  if structure_type:
-    query = query.where(Structure.structure_type == structure_type)
+  if block_type:
+    query = query.where(Structure.block_type == block_type)
   rows = session.execute(query.order_by(Structure.name)).scalars().all()
   return StructureListResponse(structures=[_structure_to_response(r) for r in rows])
 
@@ -586,12 +586,12 @@ def list_structures(
 
 
 def list_mappings(session: Session) -> StructureListResponse:
-  """List all active mapping structures (structure_type = 'coa_mapping')."""
+  """List all active mapping structures (block_type = 'coa_mapping')."""
   rows = (
     session.execute(
       select(Structure)
       .where(
-        Structure.structure_type == "coa_mapping",
+        Structure.block_type == "coa_mapping",
         Structure.is_active.is_(True),
       )
       .order_by(Structure.name)
@@ -653,7 +653,7 @@ def get_mapping_detail(
   return MappingDetailResponse(
     id=structure.id,
     name=structure.name,
-    structure_type=structure.structure_type,
+    block_type=structure.block_type,
     taxonomy_id=structure.taxonomy_id,
     associations=associations,
     total_associations=len(associations),

--- a/robosystems/operations/roboledger/reports/fact_grid.py
+++ b/robosystems/operations/roboledger/reports/fact_grid.py
@@ -80,7 +80,7 @@ class FactGrid:
 
   structure_id: str
   structure_name: str
-  structure_type: str
+  block_type: str
   periods: list[PeriodSpec]
   rows: list[FactRow] = field(default_factory=list)
   unmapped_count: int = 0
@@ -213,7 +213,7 @@ def generate_report_facts(
 def render_structure_view(
   session: Session,
   facts: list[ReportFact],
-  structure_type: str,
+  block_type: str,
   periods: list[PeriodSpec],
   reporting_style_id: str,
 ) -> FactGrid:
@@ -231,7 +231,7 @@ def render_structure_view(
   Args:
       session: Extensions database session.
       facts: Pre-generated ReportFact objects (from generate_report_facts).
-      structure_type: Structure type to render (income_statement, balance_sheet, etc.).
+      block_type: Structure type to render (income_statement, balance_sheet, etc.).
       periods: Ordered list of period specifications for columns.
       reporting_style_id: The graph's Reporting Style id
           (``Graph.reporting_style_id``). Resolves which Network this
@@ -246,13 +246,13 @@ def render_structure_view(
     structure_name,
     concept_arrangement,
     hierarchy,
-  ) = _load_reporting_structure(session, structure_type, reporting_style_id)
+  ) = _load_reporting_structure(session, block_type, reporting_style_id)
 
   if not hierarchy:
     return FactGrid(
       structure_id=structure_id or "",
       structure_name=structure_name or "",
-      structure_type=structure_type,
+      block_type=block_type,
       periods=periods,
     )
 
@@ -281,7 +281,7 @@ def render_structure_view(
   return FactGrid(
     structure_id=structure_id,
     structure_name=structure_name,
-    structure_type=structure_type,
+    block_type=block_type,
     periods=periods,
     rows=rows,
   )

--- a/robosystems/operations/roboledger/reports/fact_grid.py
+++ b/robosystems/operations/roboledger/reports/fact_grid.py
@@ -1350,8 +1350,9 @@ def _load_reporting_structure(
 
   Returns (structure_id, structure_name, concept_arrangement, root_nodes).
   ``concept_arrangement`` is Charlie's CAP declared on the Disclosure
-  (``arithmetic`` / ``roll_up`` / ``roll_forward`` / ``hierarchy``);
-  the renderer uses it to pick a compilation strategy.
+  (``arithmetic`` / ``roll_up`` / ``roll_forward`` / ``set`` / ...);
+  the renderer uses it to pick a compilation strategy. See
+  information-block.md §3.2.1 for the canonical 15-value enumeration.
 
   When the Reporting Style doesn't compose a Network for this statement
   type, returns the empty tuple — callers treat that as "no statement

--- a/robosystems/operations/roboledger/reports/guard_rails.py
+++ b/robosystems/operations/roboledger/reports/guard_rails.py
@@ -24,7 +24,7 @@ class ValidationResult:
   warnings: list[str] = field(default_factory=list)
 
 
-def validate_report(structure_type: str, rows: list[FactRow]) -> ValidationResult:
+def validate_report(block_type: str, rows: list[FactRow]) -> ValidationResult:
   """Run structural and semantic validation for a rendered structure.
 
   Note: `cash_flow_statement`, `equity_statement`, and
@@ -33,9 +33,9 @@ def validate_report(structure_type: str, rows: list[FactRow]) -> ValidationResul
   they are, re-wire the `_validate_cash_flow` helper below and add
   equity / comprehensive-income validators.
   """
-  if structure_type == "income_statement":
+  if block_type == "income_statement":
     return _validate_income_statement(rows)
-  elif structure_type == "balance_sheet":
+  elif block_type == "balance_sheet":
     return _validate_balance_sheet(rows)
   return ValidationResult(checks=["no_validation_rules"])
 

--- a/robosystems/operations/roboledger/reports/network_picker.py
+++ b/robosystems/operations/roboledger/reports/network_picker.py
@@ -5,7 +5,7 @@ statement type, return the Network Structure the renderer should walk.
 Single source of truth for both the saved-report path
 (``commands/reports.py``) and the live-statement path
 (``reports/fact_grid.py``); replaces the prior "latest active by
-structure_type" + CoA-coverage scoring fallbacks.
+block_type" + CoA-coverage scoring fallbacks.
 
 Composition lives in ``reporting_style_networks`` (one row per
 ``(reporting_style_id, statement_type)``); the Default Style ships

--- a/robosystems/operations/roboledger/schedules/service.py
+++ b/robosystems/operations/roboledger/schedules/service.py
@@ -213,7 +213,7 @@ class ScheduleService:
 
     structure = Structure(
       name=name,
-      structure_type="schedule",
+      block_type="schedule",
       taxonomy_id=taxonomy_id,
       concept_arrangement="roll_forward",
       artifact_mechanics=artifact_mechanics,
@@ -754,7 +754,7 @@ class ScheduleService:
           AND f.fact_scope = 'in_scope'
         LEFT JOIN best_entry be ON be.source_structure_id = s.id
         LEFT JOIN reversal r ON r.reversal_of = be.entry_id
-        WHERE s.structure_type = 'schedule'
+        WHERE s.block_type = 'schedule'
           AND s.is_active = true
         ORDER BY s.name
       """),
@@ -846,7 +846,7 @@ class ScheduleService:
     """
     # Load structure with entry template
     structure = session.get(Structure, structure_id)
-    if not structure or structure.structure_type != "schedule":
+    if not structure or structure.block_type != "schedule":
       raise ValueError(f"Schedule structure '{structure_id}' not found")
 
     template = (structure.metadata_ or {}).get("entry_template")
@@ -1276,7 +1276,7 @@ class ScheduleService:
       )
 
     structure = session.get(Structure, structure_id)
-    if not structure or structure.structure_type != "schedule":
+    if not structure or structure.block_type != "schedule":
       raise ValueError(f"Schedule structure '{structure_id}' not found")
 
     # Check there are any facts, and that new_end_date is within range

--- a/robosystems/operations/taxonomy_block/auto_rules.py
+++ b/robosystems/operations/taxonomy_block/auto_rules.py
@@ -61,7 +61,7 @@ def emit_auto_rules(
     session,
     taxonomy_id=taxonomy_id,
     rule_category=_XBRL_RULES,
-    rule_pattern="UniqueQNameInTaxonomy",
+    rule_check_kind="UniqueQNameInTaxonomy",
     rule_message="Every element qname must be unique within this taxonomy.",
     target_kind="taxonomy",
     target_taxonomy_id=taxonomy_id,
@@ -73,7 +73,7 @@ def emit_auto_rules(
       session,
       taxonomy_id=taxonomy_id,
       rule_category=_STRUCTURE_RULES,
-      rule_pattern="LibraryOriginImmutability",
+      rule_check_kind="LibraryOriginImmutability",
       rule_message="Library-origin elements in the parent taxonomy cannot be mutated.",
       target_kind="taxonomy",
       target_taxonomy_id=taxonomy_id,
@@ -85,7 +85,7 @@ def emit_auto_rules(
       session,
       taxonomy_id=taxonomy_id,
       rule_category=_FAC_RULES,
-      rule_pattern="LeafHasClassification",
+      rule_check_kind="LeafHasClassification",
       rule_message="Every leaf element must have an EFS classification.",
       target_kind="taxonomy",
       target_taxonomy_id=taxonomy_id,
@@ -94,7 +94,7 @@ def emit_auto_rules(
 
   for structure in structures:
     structure_id = str(structure.id)
-    for pattern, message in (
+    for check_kind, message in (
       ("NoCycles", "The structure must contain no cycles."),
       ("NoOrphanArcs", "Every arc endpoint must reference a declared element."),
       ("ParentBeforeChild", "Parent elements must precede their children in ordering."),
@@ -103,7 +103,7 @@ def emit_auto_rules(
         session,
         taxonomy_id=taxonomy_id,
         rule_category=_STRUCTURE_RULES,
-        rule_pattern=pattern,
+        rule_check_kind=check_kind,
         rule_message=message,
         target_kind="structure",
         target_structure_id=structure_id,
@@ -118,18 +118,22 @@ def _add(
   *,
   taxonomy_id: str,
   rule_category: str,
-  rule_pattern: str,
+  rule_check_kind: str,
   rule_message: str,
   target_kind: str,
   target_taxonomy_id: str | None = None,
   target_structure_id: str | None = None,
   created_by: str,
 ) -> None:
+  """Persist a structural auto-rule. All auto-rules are model-structure
+  checks (no fact-value arithmetic), so they populate rule_check_kind
+  rather than rule_pattern."""
   session.add(
     Rule(
       taxonomy_id=taxonomy_id,
       rule_category=rule_category,
-      rule_pattern=rule_pattern,
+      rule_pattern=None,
+      rule_check_kind=rule_check_kind,
       rule_expression="",
       rule_message=rule_message,
       rule_severity="error",

--- a/robosystems/operations/taxonomy_block/chart_of_accounts.py
+++ b/robosystems/operations/taxonomy_block/chart_of_accounts.py
@@ -265,7 +265,7 @@ def create(
     structure = Structure(
       name=req.name,
       description=req.description,
-      structure_type=req.structure_type,
+      block_type=req.block_type,
       taxonomy_id=taxonomy.id,
       is_active=True,
       metadata_=dict(req.metadata),
@@ -528,7 +528,7 @@ def build_envelope(session: Session, taxonomy_id: str) -> TaxonomyBlockEnvelope 
     TaxonomyBlockStructure(
       id=s.id,
       name=s.name,
-      structure_type=s.structure_type,
+      block_type=s.block_type,
       description=s.description,
       role_uri=None,
     )

--- a/robosystems/operations/taxonomy_block/custom_ontology.py
+++ b/robosystems/operations/taxonomy_block/custom_ontology.py
@@ -150,7 +150,7 @@ def create(
     structure = Structure(
       name=req.name,
       description=req.description,
-      structure_type=req.structure_type,
+      block_type=req.block_type,
       taxonomy_id=taxonomy.id,
       is_active=True,
       metadata_=dict(req.metadata),
@@ -384,7 +384,7 @@ def build_envelope(session: Session, taxonomy_id: str) -> TaxonomyBlockEnvelope 
     TaxonomyBlockStructure(
       id=s.id,
       name=s.name,
-      structure_type=s.structure_type,
+      block_type=s.block_type,
       description=s.description,
       role_uri=None,
     )

--- a/robosystems/operations/taxonomy_block/library_creator.py
+++ b/robosystems/operations/taxonomy_block/library_creator.py
@@ -270,7 +270,7 @@ def create_library_taxonomy_elements(
         id=struct_id,
         name=structure.name,
         description=None,
-        structure_type=structure.structure_type,
+        block_type=structure.block_type,
         concept_arrangement=structure.concept_arrangement,
         taxonomy_id=taxonomy_id,
         is_active=True,
@@ -289,7 +289,7 @@ def create_library_taxonomy_elements(
       id=default_struct_id,
       name=f"{package.name} — default structure",
       description=None,
-      structure_type="custom",
+      block_type="custom",
       taxonomy_id=taxonomy_id,
       is_active=True,
       metadata={"role_uri": default_role},
@@ -362,7 +362,7 @@ def _bulk_resolve_element_period_types(
 
 # rs-gaap qname prefixes that identify cash-flow-statement concepts.
 # Used to disambiguate duration concepts (IS vs CF) when a presentation
-# package declares both structure_types but no per-arc role.
+# package declares both block_types but no per-arc role.
 _CF_QNAME_PATTERNS: tuple[str, ...] = (
   "CashAndCashEquivalents",
   "NetCashProvided",
@@ -378,7 +378,7 @@ _CF_QNAME_PATTERNS: tuple[str, ...] = (
 
 
 def _build_arc_router(
-  structure_type_to_id: dict[str, str],
+  block_type_to_id: dict[str, str],
 ):
   """Return a callable that routes a parent arc to a structure_id by
   the parent element's period_type + qname when the source seed lacks
@@ -401,14 +401,14 @@ def _build_arc_router(
   parent relationships land on the catchall "default structure" and
   the BS/IS/CF structures stay empty.
   """
-  if "balance_sheet" not in structure_type_to_id:
+  if "balance_sheet" not in block_type_to_id:
     return None
-  if "income_statement" not in structure_type_to_id:
+  if "income_statement" not in block_type_to_id:
     return None
 
-  bs_id = structure_type_to_id["balance_sheet"]
-  is_id = structure_type_to_id["income_statement"]
-  cf_id = structure_type_to_id.get("cash_flow_statement")
+  bs_id = block_type_to_id["balance_sheet"]
+  is_id = block_type_to_id["income_statement"]
+  cf_id = block_type_to_id.get("cash_flow_statement")
 
   def _route(parent_qname: str, parent_period_type: str | None) -> str | None:
     if parent_period_type == "instant":
@@ -455,14 +455,14 @@ def create_library_arcs(
 
   default_struct_id = _structure_id(_default_role_uri(package))
 
-  # Build {structure_type → struct_id} so the per-arc router can land
+  # Build {block_type → struct_id} so the per-arc router can land
   # each association on the right declared structure when the seed
   # lacks per-arc role qualifiers (see ``_build_arc_router``).
-  structure_type_to_id: dict[str, str] = {}
+  block_type_to_id: dict[str, str] = {}
   for spec in package.structures:
     sid = _structure_id(spec.role_uri)
-    structure_type_to_id.setdefault(spec.structure_type, sid)
-  arc_router = _build_arc_router(structure_type_to_id)
+    block_type_to_id.setdefault(spec.block_type, sid)
+  arc_router = _build_arc_router(block_type_to_id)
 
   # Bulk-resolve all qnames needed by associations and trait assignments
   # in one query to avoid O(N) round trips for large packages.

--- a/robosystems/operations/taxonomy_block/reporting_extension.py
+++ b/robosystems/operations/taxonomy_block/reporting_extension.py
@@ -209,7 +209,7 @@ def create(
     structure = Structure(
       name=req.name,
       description=req.description,
-      structure_type=req.structure_type,
+      block_type=req.block_type,
       taxonomy_id=taxonomy.id,
       is_active=True,
       metadata_=dict(req.metadata),
@@ -503,7 +503,7 @@ def build_envelope(session: Session, taxonomy_id: str) -> TaxonomyBlockEnvelope 
     TaxonomyBlockStructure(
       id=s.id,
       name=s.name,
-      structure_type=s.structure_type,
+      block_type=s.block_type,
       description=s.description,
       role_uri=None,
     )

--- a/robosystems/operations/taxonomy_block/reporting_standard.py
+++ b/robosystems/operations/taxonomy_block/reporting_standard.py
@@ -163,7 +163,7 @@ def build_envelope(session: Session, taxonomy_id: str) -> TaxonomyBlockEnvelope 
     TaxonomyBlockStructure(
       id=s.id,
       name=s.name,
-      structure_type=s.structure_type,
+      block_type=s.block_type,
       description=s.description,
       role_uri=None,
     )

--- a/robosystems/operations/taxonomy_block/rule_reads.py
+++ b/robosystems/operations/taxonomy_block/rule_reads.py
@@ -76,6 +76,7 @@ def _rule_to_lite(rule: Rule, qname_by_element_id: dict[str, str]) -> TaxonomyBl
     name=name,
     rule_category=rule.rule_category,
     rule_pattern=rule.rule_pattern,
+    rule_check_kind=rule.rule_check_kind,
     rule_expression=rule.rule_expression,
     severity=rule.rule_severity,
     origin=rule.rule_origin,

--- a/robosystems/operations/taxonomy_block/update_apply.py
+++ b/robosystems/operations/taxonomy_block/update_apply.py
@@ -132,7 +132,7 @@ def apply_structures_to_add(
     structure = Structure(
       name=req.name,
       description=req.description,
-      structure_type=req.structure_type,
+      block_type=req.block_type,
       taxonomy_id=taxonomy.id,
       is_active=True,
       metadata_=dict(req.metadata),

--- a/robosystems/operations/taxonomy_block/update_validator.py
+++ b/robosystems/operations/taxonomy_block/update_validator.py
@@ -154,7 +154,7 @@ def validate_update_envelope(
     virtual_structures.append(
       TaxonomyBlockStructureRequest(
         name=patch.name if patch and patch.name is not None else str(s.name),
-        structure_type=str(s.structure_type),
+        block_type=str(s.block_type),
         description=(
           patch.description
           if patch and patch.description is not None

--- a/robosystems/taxonomy/bridges/fac-to-rs-gaap/v1/taxonomy.jsonld
+++ b/robosystems/taxonomy/bridges/fac-to-rs-gaap/v1/taxonomy.jsonld
@@ -106,8 +106,8 @@
     "structureName": {
       "@id": "https://robosystems.ai/vocab/structureName"
     },
-    "structureType": {
-      "@id": "https://robosystems.ai/vocab/structureType"
+    "blockType": {
+      "@id": "https://robosystems.ai/vocab/blockType"
     },
     "roleUri": {
       "@id": "https://robosystems.ai/vocab/roleUri"
@@ -116,7 +116,7 @@
   "standard": "fac-to-rs-gaap",
   "version": "v1",
   "taxonomy_type": "mapping",
-  "default_structure_type": "taxonomy_mapping",
+  "default_block_type": "taxonomy_mapping",
   "namespace_uri": "https://robosystems.ai/taxonomy/fac-to-rs-gaap/v1/",
   "origin": "native",
   "created_at": "2026-04-20",

--- a/robosystems/taxonomy/bridges/rs-gaap-disclosures-to-rs-gaap-textblocks/v1/taxonomy.jsonld
+++ b/robosystems/taxonomy/bridges/rs-gaap-disclosures-to-rs-gaap-textblocks/v1/taxonomy.jsonld
@@ -7,8 +7,8 @@
     "structureName": {
       "@id": "https://robosystems.ai/vocab/structureName"
     },
-    "structureType": {
-      "@id": "https://robosystems.ai/vocab/structureType"
+    "blockType": {
+      "@id": "https://robosystems.ai/vocab/blockType"
     },
     "roleUri": {
       "@id": "https://robosystems.ai/vocab/roleUri"
@@ -29,14 +29,14 @@
   "target_namespace": "rs-gaap",
   "origin": "native",
   "created_at": "2026-05-10",
-  "default_structure_type": "taxonomy_mapping",
+  "default_block_type": "taxonomy_mapping",
   "description": "Bridge package — equivalence arcs from rs-gaap-disclosures qnames to underlying rs-gaap text-block elements. Mirrors Charlie Hoffman's disclosure-equivalentTextblock arcrole (e.g. disclosures:PropertyPlantAndEquipmentDisclosure ↔ us-gaap:PropertyPlantAndEquipmentDisclosureTextBlock). v1 ships an empty arc set because rs-gaap currently has no TextBlock-type elements; arcs will populate as either (a) rs-gaap is extended with text-block leaves, or (b) a sibling rs-gaap-to-us-gaap bridge is authored for SEC-export framework variants.",
   "@graph": [
     {
       "@id": "_:bridge-disclosures-to-textblocks",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/bridges/rs-gaap-disclosures-to-rs-gaap-textblocks",
       "structureName": "rs-gaap-disclosures → rs-gaap text-blocks (v1, placeholder)",
-      "structureType": "taxonomy_mapping",
+      "blockType": "taxonomy_mapping",
       "conceptArrangementPattern": "set"
     }
   ]

--- a/robosystems/taxonomy/loaders/jsonld_loader.py
+++ b/robosystems/taxonomy/loaders/jsonld_loader.py
@@ -65,7 +65,22 @@ RULE_PATTERN_VALUES: frozenset[str] = frozenset(
     "LessThan",
     "RollForward",
     "RollUp",
+    "SumEquals",
     "Variance",
+  }
+)
+# Model-structure check kinds — walked over the association graph rather
+# than evaluated over fact values. Disjoint from RULE_PATTERN_VALUES; the
+# Rule.rule_pattern / Rule.rule_check_kind XOR CHECK enforces exactly one
+# is populated per row.
+RULE_CHECK_KIND_VALUES: frozenset[str] = frozenset(
+  {
+    "LeafHasClassification",
+    "LibraryOriginImmutability",
+    "NoCycles",
+    "NoOrphanArcs",
+    "ParentBeforeChild",
+    "UniqueQNameInTaxonomy",
   }
 )
 
@@ -606,15 +621,15 @@ def _extract_rules(graph: Graph) -> list[RuleSpec]:
 
 
 def _extract_structures(
-  graph: Graph, default_structure_type: str | None = None
+  graph: Graph, default_block_type: str | None = None
 ) -> list[StructureSpec]:
   """Extract extended link roles as structures.
 
-  Resolution order for ``structure_type``:
+  Resolution order for ``block_type``:
 
-  1. Explicit ``structureType`` on the role node — authoritative;
+  1. Explicit ``blockType`` on the role node — authoritative;
      used by presentation packages that carry per-structure types.
-  2. ``default_structure_type`` from the package — set by mapping /
+  2. ``default_block_type`` from the package — set by mapping /
      rules / disclosure packages to override the role-uri name
      heuristic that would otherwise mistake (e.g.) a fac-to-rs-gaap
      crosswalk role for a balance_sheet just because the role URI
@@ -627,7 +642,7 @@ def _extract_structures(
   structures: list[StructureSpec] = []
   role_pred = URIRef(f"{RS_NS}roleUri")
   name_pred = URIRef(f"{RS_NS}structureName")
-  type_pred = URIRef(f"{RS_NS}structureType")
+  type_pred = URIRef(f"{RS_NS}blockType")
   cap_pred = URIRef(f"{RS_NS}conceptArrangementPattern")
   for subject, role_uri in graph.subject_objects(role_pred):
     names = list(graph.objects(subject, name_pred))
@@ -635,8 +650,8 @@ def _extract_structures(
     explicit_types = list(graph.objects(subject, type_pred))
     if explicit_types:
       stype = str(explicit_types[0])
-    elif default_structure_type is not None:
-      stype = default_structure_type
+    elif default_block_type is not None:
+      stype = default_block_type
     else:
       role_str = str(role_uri).lower()
       if "balancesheet" in role_str or "/bs-" in role_str or "/bs/" in role_str:
@@ -656,7 +671,7 @@ def _extract_structures(
         stype = "custom"
 
     # Concept Arrangement Pattern: explicit field wins; otherwise default
-    # by structure_type.
+    # by block_type.
     explicit_caps = list(graph.objects(subject, cap_pred))
     if explicit_caps:
       cap: str | None = str(explicit_caps[0])
@@ -667,15 +682,15 @@ def _extract_structures(
       StructureSpec(
         name=name,
         role_uri=str(role_uri),
-        structure_type=stype,
+        block_type=stype,
         concept_arrangement=cap,
       )
     )
   return structures
 
 
-def _default_concept_arrangement(structure_type: str) -> str | None:
-  """Default Concept Arrangement Pattern per structure_type when seed
+def _default_concept_arrangement(block_type: str) -> str | None:
+  """Default Concept Arrangement Pattern per block_type when seed
   doesn't declare one explicitly. Charlie's vocabulary."""
   return {
     "income_statement": "arithmetic",
@@ -683,7 +698,7 @@ def _default_concept_arrangement(structure_type: str) -> str | None:
     "cash_flow_statement": "arithmetic",
     "equity_statement": "roll_forward",
     "validation_rules": "arithmetic",
-  }.get(structure_type)
+  }.get(block_type)
 
 
 def load_taxonomy_package(path: Path | str) -> TaxonomyPackage:
@@ -705,7 +720,7 @@ def load_taxonomy_package(path: Path | str) -> TaxonomyPackage:
   namespace_uri = doc.get("namespace_uri", "")
   description = doc.get("description")
   taxonomy_type = doc.get("taxonomy_type", "reporting_standard")
-  default_structure_type = doc.get("default_structure_type")
+  default_block_type = doc.get("default_block_type")
   name = f"{standard} {version}"
 
   # Parse with rdflib — it handles the @context expansion
@@ -735,7 +750,7 @@ def load_taxonomy_package(path: Path | str) -> TaxonomyPackage:
         elements.append(element)
 
   associations = _extract_associations(graph)
-  structures = _extract_structures(graph, default_structure_type=default_structure_type)
+  structures = _extract_structures(graph, default_block_type=default_block_type)
   trait_assignments = _extract_trait_assignments(graph)
   rules = _extract_rules(graph)
 
@@ -769,7 +784,7 @@ def load_taxonomy_package(path: Path | str) -> TaxonomyPackage:
     trait_assignments=trait_assignments,
     rules=rules,
     taxonomy_type=taxonomy_type,
-    default_structure_type=default_structure_type,
+    default_block_type=default_block_type,
     is_shared=True,
     description=description,
   )

--- a/robosystems/taxonomy/model.py
+++ b/robosystems/taxonomy/model.py
@@ -157,7 +157,7 @@ class StructureSpec(BaseModel):
 
   name: str = Field(..., description="Human-readable name")
   role_uri: str = Field(..., description="Full XBRL extended link role URI")
-  structure_type: str = Field(
+  block_type: str = Field(
     "custom",
     description=(
       "balance_sheet | income_statement | cash_flow_statement | "
@@ -183,7 +183,7 @@ class StructureSpec(BaseModel):
       "  level3_textblock — third-level note\n"
       "  level4_textblock — fourth-level note\n"
       "  textblock        — generic note text block (legacy alias)\n"
-      "When None, the renderer falls back to a per-structure_type default "
+      "When None, the renderer falls back to a per-block_type default "
       "(income_statement / balance_sheet / cash_flow_statement → arithmetic; "
       "equity_statement → roll_forward; validation_rules → arithmetic)."
     ),
@@ -331,11 +331,11 @@ class TaxonomyPackage(BaseModel):
   is_shared: bool = Field(True, description="Shared across tenants (library-origin)")
   description: str | None = Field(None)
 
-  default_structure_type: str | None = Field(
+  default_block_type: str | None = Field(
     None,
     description=(
-      "Package-level default for ``StructureSpec.structure_type`` when a "
-      "structure has no explicit ``structureType`` and no role-uri "
+      "Package-level default for ``StructureSpec.block_type`` when a "
+      "structure has no explicit ``blockType`` and no role-uri "
       "heuristic match. Used by 'mapping' / 'rules' / 'disclosure' "
       "packages to override the role-uri name heuristic that would "
       "otherwise mistake (e.g.) a fac-to-rs-gaap crosswalk role for a "

--- a/robosystems/taxonomy/packages/fac-calculations/v1/taxonomy.jsonld
+++ b/robosystems/taxonomy/packages/fac-calculations/v1/taxonomy.jsonld
@@ -33,8 +33,8 @@
     "structureName": {
       "@id": "https://robosystems.ai/vocab/structureName"
     },
-    "structureType": {
-      "@id": "https://robosystems.ai/vocab/structureType"
+    "blockType": {
+      "@id": "https://robosystems.ai/vocab/blockType"
     },
     "roleUri": {
       "@id": "https://robosystems.ai/vocab/roleUri"
@@ -52,133 +52,133 @@
       "@id": "_:fac-calc-bs1",
       "roleUri": "http://www.xbrlsite.com/seattlemethod/conceptual-model/cm-roles/roles/fac-calculations/BS1",
       "structureName": "FAC BS1 \u2014 Equity = Parent + Noncontrolling",
-      "structureType": "validation_rules"
+      "blockType": "validation_rules"
     },
     {
       "@id": "_:fac-calc-bs2",
       "roleUri": "http://www.xbrlsite.com/seattlemethod/conceptual-model/cm-roles/roles/fac-calculations/BS2",
       "structureName": "FAC BS2 \u2014 Assets = Liabilities + Equity",
-      "structureType": "validation_rules"
+      "blockType": "validation_rules"
     },
     {
       "@id": "_:fac-calc-bs3",
       "roleUri": "http://www.xbrlsite.com/seattlemethod/conceptual-model/cm-roles/roles/fac-calculations/BS3",
       "structureName": "FAC BS3 \u2014 Assets = Current + Noncurrent (classified BS)",
-      "structureType": "validation_rules"
+      "blockType": "validation_rules"
     },
     {
       "@id": "_:fac-calc-bs4",
       "roleUri": "http://www.xbrlsite.com/seattlemethod/conceptual-model/cm-roles/roles/fac-calculations/BS4",
       "structureName": "FAC BS4 \u2014 Liabilities = Current + Noncurrent (classified BS)",
-      "structureType": "validation_rules"
+      "blockType": "validation_rules"
     },
     {
       "@id": "_:fac-calc-bs5",
       "roleUri": "http://www.xbrlsite.com/seattlemethod/conceptual-model/cm-roles/roles/fac-calculations/BS5",
       "structureName": "FAC BS5 \u2014 L+E = Liabilities + Commitments + Temp. Equity + Equity",
-      "structureType": "validation_rules"
+      "blockType": "validation_rules"
     },
     {
       "@id": "_:fac-calc-is1",
       "roleUri": "http://www.xbrlsite.com/seattlemethod/conceptual-model/cm-roles/roles/fac-calculations/IS1",
       "structureName": "FAC IS1 \u2014 Gross Profit = Revenues \u2212 Cost of Revenue (multi-step)",
-      "structureType": "validation_rules"
+      "blockType": "validation_rules"
     },
     {
       "@id": "_:fac-calc-is2",
       "roleUri": "http://www.xbrlsite.com/seattlemethod/conceptual-model/cm-roles/roles/fac-calculations/IS2",
       "structureName": "FAC IS2 \u2014 Operating Income = Gross Profit \u2212 Operating Exp. + Other Operating (multi-step)",
-      "structureType": "validation_rules"
+      "blockType": "validation_rules"
     },
     {
       "@id": "_:fac-calc-is3",
       "roleUri": "http://www.xbrlsite.com/seattlemethod/conceptual-model/cm-roles/roles/fac-calculations/IS3",
       "structureName": "FAC IS3 \u2014 Income Before Equity-Method Investments = Operating + Nonoperating \u2212 Interest & Debt",
-      "structureType": "validation_rules"
+      "blockType": "validation_rules"
     },
     {
       "@id": "_:fac-calc-is4",
       "roleUri": "http://www.xbrlsite.com/seattlemethod/conceptual-model/cm-roles/roles/fac-calculations/IS4",
       "structureName": "FAC IS4 \u2014 Income from Continuing Ops Before Tax = Before Equity-Method + Equity-Method Investments",
-      "structureType": "validation_rules"
+      "blockType": "validation_rules"
     },
     {
       "@id": "_:fac-calc-is5",
       "roleUri": "http://www.xbrlsite.com/seattlemethod/conceptual-model/cm-roles/roles/fac-calculations/IS5",
       "structureName": "FAC IS5 \u2014 Income from Continuing Ops After Tax = Before Tax \u2212 Income Tax Expense",
-      "structureType": "validation_rules"
+      "blockType": "validation_rules"
     },
     {
       "@id": "_:fac-calc-is6",
       "roleUri": "http://www.xbrlsite.com/seattlemethod/conceptual-model/cm-roles/roles/fac-calculations/IS6",
       "structureName": "FAC IS6 \u2014 Net Income = Continuing (After Tax) + Discontinued (Net of Tax)",
-      "structureType": "validation_rules"
+      "blockType": "validation_rules"
     },
     {
       "@id": "_:fac-calc-is7",
       "roleUri": "http://www.xbrlsite.com/seattlemethod/conceptual-model/cm-roles/roles/fac-calculations/IS7",
       "structureName": "FAC IS7 \u2014 Net Income = Parent + Noncontrolling",
-      "structureType": "validation_rules"
+      "blockType": "validation_rules"
     },
     {
       "@id": "_:fac-calc-is8",
       "roleUri": "http://www.xbrlsite.com/seattlemethod/conceptual-model/cm-roles/roles/fac-calculations/IS8",
       "structureName": "FAC IS8 \u2014 NI Available to Common (Basic) = Parent \u2212 Preferred Dividends & Other",
-      "structureType": "validation_rules"
+      "blockType": "validation_rules"
     },
     {
       "@id": "_:fac-calc-is9",
       "roleUri": "http://www.xbrlsite.com/seattlemethod/conceptual-model/cm-roles/roles/fac-calculations/IS9",
       "structureName": "FAC IS9 \u2014 Comprehensive Income = Parent + Noncontrolling",
-      "structureType": "validation_rules"
+      "blockType": "validation_rules"
     },
     {
       "@id": "_:fac-calc-is10",
       "roleUri": "http://www.xbrlsite.com/seattlemethod/conceptual-model/cm-roles/roles/fac-calculations/IS10",
       "structureName": "FAC IS10 \u2014 Comprehensive Income = Net Income + Other Comprehensive Income",
-      "structureType": "validation_rules"
+      "blockType": "validation_rules"
     },
     {
       "@id": "_:fac-calc-is11",
       "roleUri": "http://www.xbrlsite.com/seattlemethod/conceptual-model/cm-roles/roles/fac-calculations/IS11",
       "structureName": "FAC IS11 \u2014 Operating Income = Revenues \u2212 Costs&Expenses + Other Operating (single-step)",
-      "structureType": "validation_rules"
+      "blockType": "validation_rules"
     },
     {
       "@id": "_:fac-calc-cf1",
       "roleUri": "http://www.xbrlsite.com/seattlemethod/conceptual-model/cm-roles/roles/fac-calculations/CF1",
       "structureName": "FAC CF1 \u2014 Net Cash Flow = Operating + Investing + Financing + Exchange Gain/Loss",
-      "structureType": "validation_rules"
+      "blockType": "validation_rules"
     },
     {
       "@id": "_:fac-calc-cf2",
       "roleUri": "http://www.xbrlsite.com/seattlemethod/conceptual-model/cm-roles/roles/fac-calculations/CF2",
       "structureName": "FAC CF2 \u2014 Net Cash Flows Continuing = Operating + Investing + Financing (Continuing)",
-      "structureType": "validation_rules"
+      "blockType": "validation_rules"
     },
     {
       "@id": "_:fac-calc-cf3",
       "roleUri": "http://www.xbrlsite.com/seattlemethod/conceptual-model/cm-roles/roles/fac-calculations/CF3",
       "structureName": "FAC CF3 \u2014 Net Cash Flows Discontinued = Operating + Investing + Financing (Discontinued)",
-      "structureType": "validation_rules"
+      "blockType": "validation_rules"
     },
     {
       "@id": "_:fac-calc-cf4",
       "roleUri": "http://www.xbrlsite.com/seattlemethod/conceptual-model/cm-roles/roles/fac-calculations/CF4",
       "structureName": "FAC CF4 \u2014 Operating Net Cash Flow = Continuing + Discontinued",
-      "structureType": "validation_rules"
+      "blockType": "validation_rules"
     },
     {
       "@id": "_:fac-calc-cf5",
       "roleUri": "http://www.xbrlsite.com/seattlemethod/conceptual-model/cm-roles/roles/fac-calculations/CF5",
       "structureName": "FAC CF5 \u2014 Investing Net Cash Flow = Continuing + Discontinued",
-      "structureType": "validation_rules"
+      "blockType": "validation_rules"
     },
     {
       "@id": "_:fac-calc-cf6",
       "roleUri": "http://www.xbrlsite.com/seattlemethod/conceptual-model/cm-roles/roles/fac-calculations/CF6",
       "structureName": "FAC CF6 \u2014 Financing Net Cash Flow = Continuing + Discontinued",
-      "structureType": "validation_rules"
+      "blockType": "validation_rules"
     },
     {
       "@id": "_:fac-calc-bs1-arc-1",

--- a/robosystems/taxonomy/packages/fac-presentation/v1/taxonomy.jsonld
+++ b/robosystems/taxonomy/packages/fac-presentation/v1/taxonomy.jsonld
@@ -26,8 +26,8 @@
     "structureName": {
       "@id": "https://robosystems.ai/vocab/structureName"
     },
-    "structureType": {
-      "@id": "https://robosystems.ai/vocab/structureType"
+    "blockType": {
+      "@id": "https://robosystems.ai/vocab/blockType"
     },
     "roleUri": {
       "@id": "https://robosystems.ai/vocab/roleUri"
@@ -43,109 +43,109 @@
       "@id": "_:fac-pres-bs-classified",
       "roleUri": "http://www.xbrlsite.com/seattlemethod/conceptual-model/cm-roles/roles/fac-presentation/BS-classified",
       "structureName": "FAC \u2014 Balance Sheet \u2014 Classified",
-      "structureType": "balance_sheet"
+      "blockType": "balance_sheet"
     },
     {
       "@id": "_:fac-pres-bs-unclassified",
       "roleUri": "http://www.xbrlsite.com/seattlemethod/conceptual-model/cm-roles/roles/fac-presentation/BS-unclassified",
       "structureName": "FAC \u2014 Balance Sheet \u2014 Unclassified",
-      "structureType": "balance_sheet"
+      "blockType": "balance_sheet"
     },
     {
       "@id": "_:fac-pres-is-multistep",
       "roleUri": "http://www.xbrlsite.com/seattlemethod/conceptual-model/cm-roles/roles/fac-presentation/IS-multistep",
       "structureName": "FAC \u2014 Income Statement \u2014 Multi-step",
-      "structureType": "income_statement"
+      "blockType": "income_statement"
     },
     {
       "@id": "_:fac-pres-is-singlestep",
       "roleUri": "http://www.xbrlsite.com/seattlemethod/conceptual-model/cm-roles/roles/fac-presentation/IS-singlestep",
       "structureName": "FAC \u2014 Income Statement \u2014 Single-step",
-      "structureType": "income_statement"
+      "blockType": "income_statement"
     },
     {
       "@id": "_:fac-pres-is-insurance",
       "roleUri": "http://www.xbrlsite.com/seattlemethod/conceptual-model/cm-roles/roles/fac-presentation/IS-insurance",
       "structureName": "FAC \u2014 Income Statement \u2014 Insurance-based",
-      "structureType": "income_statement"
+      "blockType": "income_statement"
     },
     {
       "@id": "_:fac-pres-is-interest",
       "roleUri": "http://www.xbrlsite.com/seattlemethod/conceptual-model/cm-roles/roles/fac-presentation/IS-interest",
       "structureName": "FAC \u2014 Income Statement \u2014 Interest-based (Banking)",
-      "structureType": "income_statement"
+      "blockType": "income_statement"
     },
     {
       "@id": "_:fac-pres-is-securities",
       "roleUri": "http://www.xbrlsite.com/seattlemethod/conceptual-model/cm-roles/roles/fac-presentation/IS-securities",
       "structureName": "FAC \u2014 Income Statement \u2014 Securities-based",
-      "structureType": "income_statement"
+      "blockType": "income_statement"
     },
     {
       "@id": "_:fac-pres-comprehensiveincome",
       "roleUri": "http://www.xbrlsite.com/seattlemethod/conceptual-model/cm-roles/roles/fac-presentation/ComprehensiveIncome",
       "structureName": "FAC \u2014 Statement of Comprehensive Income",
-      "structureType": "equity_statement"
+      "blockType": "equity_statement"
     },
     {
       "@id": "_:fac-pres-cashflow",
       "roleUri": "http://www.xbrlsite.com/seattlemethod/conceptual-model/cm-roles/roles/fac-presentation/CashFlow",
       "structureName": "FAC \u2014 Cash Flow Statement",
-      "structureType": "cash_flow_statement"
+      "blockType": "cash_flow_statement"
     },
     {
       "@id": "_:fac-pres-niac-breakdown",
       "roleUri": "http://www.xbrlsite.com/seattlemethod/conceptual-model/cm-roles/roles/fac-presentation/NIAC-breakdown",
       "structureName": "FAC \u2014 Net Income Available to Common Stockholders \u2014 Breakdown",
-      "structureType": "income_statement"
+      "blockType": "income_statement"
     },
     {
       "@id": "_:fac-pres-netincome-breakdown",
       "roleUri": "http://www.xbrlsite.com/seattlemethod/conceptual-model/cm-roles/roles/fac-presentation/NetIncome-breakdown",
       "structureName": "FAC \u2014 Net Income \u2014 Parent/Noncontrolling Breakdown",
-      "structureType": "income_statement"
+      "blockType": "income_statement"
     },
     {
       "@id": "_:fac-pres-comprehensiveincome-breakdown",
       "roleUri": "http://www.xbrlsite.com/seattlemethod/conceptual-model/cm-roles/roles/fac-presentation/ComprehensiveIncome-breakdown",
       "structureName": "FAC \u2014 Comprehensive Income \u2014 Parent/Noncontrolling Breakdown",
-      "structureType": "equity_statement"
+      "blockType": "equity_statement"
     },
     {
       "@id": "_:fac-pres-cashflow-breakdown",
       "roleUri": "http://www.xbrlsite.com/seattlemethod/conceptual-model/cm-roles/roles/fac-presentation/CashFlow-breakdown",
       "structureName": "FAC \u2014 Cash Flow \u2014 Continuing/Discontinued Breakdown",
-      "structureType": "cash_flow_statement"
+      "blockType": "cash_flow_statement"
     },
     {
       "@id": "_:fac-pres-generalinformation",
       "roleUri": "http://www.xbrlsite.com/seattlemethod/conceptual-model/cm-roles/roles/fac-presentation/GeneralInformation",
       "structureName": "FAC \u2014 General Information Hierarchy",
-      "structureType": "custom"
+      "blockType": "custom"
     },
     {
       "@id": "_:fac-pres-basicinformation",
       "roleUri": "http://www.xbrlsite.com/seattlemethod/conceptual-model/cm-roles/roles/fac-presentation/BasicInformation",
       "structureName": "FAC \u2014 Basic Information Hierarchy",
-      "structureType": "custom"
+      "blockType": "custom"
     },
     {
       "@id": "_:fac-pres-keyratios",
       "roleUri": "http://www.xbrlsite.com/seattlemethod/conceptual-model/cm-roles/roles/fac-presentation/KeyRatios",
       "structureName": "FAC \u2014 Key Ratios Hierarchy",
-      "structureType": "custom"
+      "blockType": "custom"
     },
     {
       "@id": "_:fac-pres-otherinformation",
       "roleUri": "http://www.xbrlsite.com/seattlemethod/conceptual-model/cm-roles/roles/fac-presentation/OtherInformation",
       "structureName": "FAC \u2014 Other Information Hierarchy",
-      "structureType": "custom"
+      "blockType": "custom"
     },
     {
       "@id": "_:fac-pres-validationresults",
       "roleUri": "http://www.xbrlsite.com/seattlemethod/conceptual-model/cm-roles/roles/fac-presentation/ValidationResults",
       "structureName": "FAC \u2014 Validation Results Hierarchy",
-      "structureType": "custom"
+      "blockType": "custom"
     },
     {
       "@id": "_:fac-pres-bs-classified-arc-1",

--- a/robosystems/taxonomy/packages/fac-rules/v1/taxonomy.jsonld
+++ b/robosystems/taxonomy/packages/fac-rules/v1/taxonomy.jsonld
@@ -51,7 +51,7 @@
   "version": "v1",
   "namespace_uri": "http://www.xbrlsite.com/fac/rules/",
   "taxonomy_type": "rules",
-  "default_structure_type": "validation_rules",
+  "default_block_type": "validation_rules",
   "forked_from": {
     "author": "Charlie Hoffman",
     "url": "http://xbrlsite.com/seattlemethod/cm/cm.xsd",

--- a/robosystems/taxonomy/packages/fac/v1/taxonomy.jsonld
+++ b/robosystems/taxonomy/packages/fac/v1/taxonomy.jsonld
@@ -106,8 +106,8 @@
     "structureName": {
       "@id": "https://robosystems.ai/vocab/structureName"
     },
-    "structureType": {
-      "@id": "https://robosystems.ai/vocab/structureType"
+    "blockType": {
+      "@id": "https://robosystems.ai/vocab/blockType"
     },
     "roleUri": {
       "@id": "https://robosystems.ai/vocab/roleUri"

--- a/robosystems/taxonomy/packages/rs-gaap-calculations/v1/taxonomy.jsonld
+++ b/robosystems/taxonomy/packages/rs-gaap-calculations/v1/taxonomy.jsonld
@@ -5,8 +5,8 @@
     "structureName": {
       "@id": "https://robosystems.ai/vocab/structureName"
     },
-    "structureType": {
-      "@id": "https://robosystems.ai/vocab/structureType"
+    "blockType": {
+      "@id": "https://robosystems.ai/vocab/blockType"
     },
     "roleUri": {
       "@id": "https://robosystems.ai/vocab/roleUri"
@@ -49,7 +49,7 @@
       "@id": "_:rs-gaap-calc-is-rev",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-calculations/IS-Rev",
       "structureName": "rs-gaap calc IS-Rev — rs-gaap:Revenues = Σ rs-gaap revenue leaves",
-      "structureType": "validation_rules",
+      "blockType": "validation_rules",
       "conceptArrangementPattern": "arithmetic"
     },
     {
@@ -75,7 +75,7 @@
       "@id": "_:rs-gaap-calc-is-cor",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-calculations/IS-COR",
       "structureName": "rs-gaap calc IS-COR — rs-gaap:CostOfRevenue = Σ rs-gaap COGS leaves",
-      "structureType": "validation_rules",
+      "blockType": "validation_rules",
       "conceptArrangementPattern": "arithmetic"
     },
     {
@@ -101,7 +101,7 @@
       "@id": "_:rs-gaap-calc-is-gross",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-calculations/IS-GrossProfit",
       "structureName": "rs-gaap calc IS-GrossProfit — rs-gaap:GrossProfit = rs-gaap:Revenues − rs-gaap:CostOfRevenue",
-      "structureType": "validation_rules",
+      "blockType": "validation_rules",
       "conceptArrangementPattern": "arithmetic"
     },
     {
@@ -127,7 +127,7 @@
       "@id": "_:rs-gaap-calc-is-opex",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-calculations/IS-OpEx",
       "structureName": "rs-gaap calc IS-OpEx — rs-gaap:OperatingExpenses = Σ rs-gaap operating expense leaves",
-      "structureType": "validation_rules",
+      "blockType": "validation_rules",
       "conceptArrangementPattern": "arithmetic"
     },
     {
@@ -162,7 +162,7 @@
       "@id": "_:rs-gaap-calc-is-opinc",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-calculations/IS-OperatingIncome",
       "structureName": "rs-gaap calc IS-OperatingIncome — rs-gaap:OperatingIncomeLoss = rs-gaap:GrossProfit − rs-gaap:OperatingExpenses",
-      "structureType": "validation_rules",
+      "blockType": "validation_rules",
       "conceptArrangementPattern": "arithmetic"
     },
     {
@@ -188,7 +188,7 @@
       "@id": "_:rs-gaap-calc-is-nonop",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-calculations/IS-NonOp",
       "structureName": "rs-gaap calc IS-NonOp — rs-gaap:NonoperatingIncomeExpense = Σ rs-gaap nonoperating leaves",
-      "structureType": "validation_rules",
+      "blockType": "validation_rules",
       "conceptArrangementPattern": "arithmetic"
     },
     {
@@ -205,7 +205,7 @@
       "@id": "_:rs-gaap-calc-is-pretax",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-calculations/IS-PreTax",
       "structureName": "rs-gaap calc IS-PreTax — rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxes... = OperatingIncomeLoss + NonoperatingIncomeExpense − InterestExpense",
-      "structureType": "validation_rules",
+      "blockType": "validation_rules",
       "conceptArrangementPattern": "arithmetic"
     },
     {
@@ -240,7 +240,7 @@
       "@id": "_:rs-gaap-calc-is-conops",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-calculations/IS-ContinuingOps",
       "structureName": "rs-gaap calc IS-ContinuingOps — rs-gaap:IncomeLossFromContinuingOperations = PreTax − IncomeTaxExpenseBenefit",
-      "structureType": "validation_rules",
+      "blockType": "validation_rules",
       "conceptArrangementPattern": "arithmetic"
     },
     {
@@ -266,7 +266,7 @@
       "@id": "_:rs-gaap-calc-is-netinc",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-calculations/IS-NetIncome",
       "structureName": "rs-gaap calc IS-NetIncome — rs-gaap:NetIncomeLoss = ContinuingOps + DiscontinuedOps",
-      "structureType": "validation_rules",
+      "blockType": "validation_rules",
       "conceptArrangementPattern": "arithmetic"
     },
     {
@@ -292,7 +292,7 @@
       "@id": "_:rs-gaap-calc-bs-assets",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-calculations/BS-Assets",
       "structureName": "rs-gaap calc BS-Assets — rs-gaap:Assets = rs-gaap:AssetsCurrent + rs-gaap:AssetsNoncurrent",
-      "structureType": "validation_rules",
+      "blockType": "validation_rules",
       "conceptArrangementPattern": "arithmetic"
     },
     {
@@ -318,7 +318,7 @@
       "@id": "_:rs-gaap-calc-bs-current-assets",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-calculations/BS-CurrentAssets",
       "structureName": "rs-gaap calc BS-CurrentAssets — rs-gaap:AssetsCurrent = Σ rs-gaap current-asset leaves",
-      "structureType": "validation_rules",
+      "blockType": "validation_rules",
       "conceptArrangementPattern": "arithmetic"
     },
     {
@@ -380,7 +380,7 @@
       "@id": "_:rs-gaap-calc-bs-noncurrent-assets",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-calculations/BS-NoncurrentAssets",
       "structureName": "rs-gaap calc BS-NoncurrentAssets — rs-gaap:AssetsNoncurrent = Σ rs-gaap noncurrent-asset leaves",
-      "structureType": "validation_rules",
+      "blockType": "validation_rules",
       "conceptArrangementPattern": "arithmetic"
     },
     {
@@ -442,7 +442,7 @@
       "@id": "_:rs-gaap-calc-bs-liabilities",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-calculations/BS-Liabilities",
       "structureName": "rs-gaap calc BS-Liabilities — rs-gaap:Liabilities = rs-gaap:LiabilitiesCurrent + rs-gaap:LiabilitiesNoncurrent",
-      "structureType": "validation_rules",
+      "blockType": "validation_rules",
       "conceptArrangementPattern": "arithmetic"
     },
     {
@@ -468,7 +468,7 @@
       "@id": "_:rs-gaap-calc-bs-current-liab",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-calculations/BS-CurrentLiabilities",
       "structureName": "rs-gaap calc BS-CurrentLiabilities — rs-gaap:LiabilitiesCurrent = Σ rs-gaap current-liability leaves",
-      "structureType": "validation_rules",
+      "blockType": "validation_rules",
       "conceptArrangementPattern": "arithmetic"
     },
     {
@@ -521,7 +521,7 @@
       "@id": "_:rs-gaap-calc-bs-noncurrent-liab",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-calculations/BS-NoncurrentLiabilities",
       "structureName": "rs-gaap calc BS-NoncurrentLiabilities — rs-gaap:LiabilitiesNoncurrent = Σ rs-gaap noncurrent-liability leaves",
-      "structureType": "validation_rules",
+      "blockType": "validation_rules",
       "conceptArrangementPattern": "arithmetic"
     },
     {
@@ -574,7 +574,7 @@
       "@id": "_:rs-gaap-calc-bs-equity",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-calculations/BS-Equity",
       "structureName": "rs-gaap calc BS-Equity — rs-gaap:StockholdersEquity = Σ rs-gaap equity leaves (Treasury weight=-1)",
-      "structureType": "validation_rules",
+      "blockType": "validation_rules",
       "conceptArrangementPattern": "arithmetic"
     },
     {
@@ -654,7 +654,7 @@
       "@id": "_:rs-gaap-calc-bs-liab-equity",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-calculations/BS-LiabilitiesAndStockholdersEquity",
       "structureName": "rs-gaap calc BS-LiabilitiesAndStockholdersEquity — rs-gaap:LiabilitiesAndStockholdersEquity = rs-gaap:Liabilities + rs-gaap:StockholdersEquity",
-      "structureType": "validation_rules",
+      "blockType": "validation_rules",
       "conceptArrangementPattern": "arithmetic"
     },
     {
@@ -680,7 +680,7 @@
       "@id": "_:rs-gaap-calc-cf-net-change",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-calculations/CF-NetChange",
       "structureName": "rs-gaap calc CF-NetChange — rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease = Op + Inv + Fin + Exchange",
-      "structureType": "validation_rules",
+      "blockType": "validation_rules",
       "conceptArrangementPattern": "arithmetic"
     },
     {
@@ -724,7 +724,7 @@
       "@id": "_:rs-gaap-calc-cf-operating",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-calculations/CF-Operating",
       "structureName": "rs-gaap calc CF-Operating — rs-gaap:NetCashProvidedByUsedInOperatingActivities = NetIncomeLoss + DDA + Σ working-capital deltas (indirect method)",
-      "structureType": "validation_rules",
+      "blockType": "validation_rules",
       "conceptArrangementPattern": "arithmetic"
     },
     {
@@ -795,7 +795,7 @@
       "@id": "_:rs-gaap-deriv-cf-ar",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-derivations/CF-AccountsReceivable",
       "structureName": "rs-gaap derivation CF — IncreaseDecreaseInAccountsReceivable = -Δ(ReceivablesNetCurrent) [asset up = cash use]",
-      "structureType": "validation_rules",
+      "blockType": "validation_rules",
       "conceptArrangementPattern": "arithmetic"
     },
     {
@@ -812,7 +812,7 @@
       "@id": "_:rs-gaap-deriv-cf-inventory",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-derivations/CF-Inventory",
       "structureName": "rs-gaap derivation CF — IncreaseDecreaseInInventories = -Δ(InventoryNetOfAllowances...) [asset up = cash use]",
-      "structureType": "validation_rules",
+      "blockType": "validation_rules",
       "conceptArrangementPattern": "arithmetic"
     },
     {
@@ -829,7 +829,7 @@
       "@id": "_:rs-gaap-deriv-cf-prepaid",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-derivations/CF-PrepaidExpense",
       "structureName": "rs-gaap derivation CF — IncreaseDecreaseInPrepaidExpense = -Δ(PrepaidExpenseCurrent) [asset up = cash use]",
-      "structureType": "validation_rules",
+      "blockType": "validation_rules",
       "conceptArrangementPattern": "arithmetic"
     },
     {
@@ -846,7 +846,7 @@
       "@id": "_:rs-gaap-deriv-cf-ap",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-derivations/CF-AccountsPayable",
       "structureName": "rs-gaap derivation CF — IncreaseDecreaseInAccountsPayableAndAccruedLiabilities = +Δ(AccountsPayableAndAccruedLiabilitiesCurrent) [liab up = cash source]",
-      "structureType": "validation_rules",
+      "blockType": "validation_rules",
       "conceptArrangementPattern": "arithmetic"
     },
     {
@@ -863,7 +863,7 @@
       "@id": "_:rs-gaap-deriv-cf-other-op",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-derivations/CF-OtherOperatingCapital",
       "structureName": "rs-gaap derivation CF — IncreaseDecreaseInOtherOperatingCapitalNet = +Δ(OtherLiabilitiesCurrent) [catch-all working capital]",
-      "structureType": "validation_rules",
+      "blockType": "validation_rules",
       "conceptArrangementPattern": "arithmetic"
     },
     {
@@ -880,7 +880,7 @@
       "@id": "_:rs-gaap-calc-cf-investing",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-calculations/CF-Investing",
       "structureName": "rs-gaap calc CF-Investing — rs-gaap:NetCashProvidedByUsedInInvestingActivities = Σ Investing leaves (each pre-signed: outflows negative, proceeds positive)",
-      "structureType": "validation_rules",
+      "blockType": "validation_rules",
       "conceptArrangementPattern": "arithmetic"
     },
     {
@@ -897,7 +897,7 @@
       "@id": "_:rs-gaap-calc-cf-financing",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-calculations/CF-Financing",
       "structureName": "rs-gaap calc CF-Financing — rs-gaap:NetCashProvidedByUsedInFinancingActivities = Σ proceeds − Σ payments",
-      "structureType": "validation_rules",
+      "blockType": "validation_rules",
       "conceptArrangementPattern": "arithmetic"
     },
     {
@@ -914,7 +914,7 @@
       "@id": "_:rs-gaap-deriv-cf-ppe-purchases",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-derivations/CF-PaymentsToAcquirePropertyPlantAndEquipment",
       "structureName": "rs-gaap derivation CF — PaymentsToAcquirePropertyPlantAndEquipment = -Δ(PropertyPlantAndEquipmentGross) [purchases of gross PP&E = cash outflow; PPE Gross is the right BS source because ΔGross isolates purchases from depreciation activity, unlike ΔNet which conflates them]",
-      "structureType": "validation_rules",
+      "blockType": "validation_rules",
       "conceptArrangementPattern": "arithmetic"
     },
     {
@@ -931,7 +931,7 @@
       "@id": "_:rs-gaap-deriv-cf-stock-proceeds",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-derivations/CF-ProceedsFromIssuanceOfCommonStock",
       "structureName": "rs-gaap derivation CF — ProceedsFromIssuanceOfCommonStock = +Δ(AdditionalPaidInCapital) [APIC up = stock issuance proceeds, rendered positive in Financing section]",
-      "structureType": "validation_rules",
+      "blockType": "validation_rules",
       "conceptArrangementPattern": "arithmetic"
     },
     {
@@ -948,7 +948,7 @@
       "@id": "_:rs-gaap-deriv-cf-accrued-liabilities",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-derivations/CF-AccruedLiabilities",
       "structureName": "rs-gaap derivation CF — IncreaseDecreaseInAccruedLiabilities = +Δ(AccruedLiabilitiesCurrent) [liab up = cash source]",
-      "structureType": "validation_rules",
+      "blockType": "validation_rules",
       "conceptArrangementPattern": "arithmetic"
     },
     {
@@ -965,7 +965,7 @@
       "@id": "_:rs-gaap-deriv-cf-income-taxes-payable",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-derivations/CF-IncomeTaxesPayable",
       "structureName": "rs-gaap derivation CF — IncreaseDecreaseInAccruedIncomeTaxesPayable = +Δ(AccruedIncomeTaxesCurrent) [liab up = cash source]",
-      "structureType": "validation_rules",
+      "blockType": "validation_rules",
       "conceptArrangementPattern": "arithmetic"
     },
     {
@@ -982,7 +982,7 @@
       "@id": "_:rs-gaap-deriv-cf-dda-from-accum",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-derivations/CF-DDA-FromAccumulated",
       "structureName": "rs-gaap derivation CF — DepreciationDepletionAndAmortization = +Δ(AccumulatedDepreciationDepletionAndAmortizationPropertyPlantAndEquipment) [contra-asset up = expense incurred, add-back to NI]. Fallback when tenant maps Accumulated Depreciation as a BS leaf instead of mapping Depreciation Expense to DDA directly; the double-count guard in _derive_cash_flow_facts skips if a direct DDA fact already exists from the IS side.",
-      "structureType": "validation_rules",
+      "blockType": "validation_rules",
       "conceptArrangementPattern": "arithmetic"
     },
     {
@@ -999,7 +999,7 @@
       "@id": "_:rs-gaap-deriv-cf-long-term-debt-net",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-derivations/CF-LongTermDebtNet",
       "structureName": "rs-gaap derivation CF — ProceedsFromIssuanceOfLongTermDebtAndCapitalSecuritiesNet = +Δ(LongTermDebtNoncurrent) [debt up = net proceeds, debt down = net repayments]. BS delta recovers net activity, not gross. For gross Proceeds + Repayments disclosure, author a rollforward IB with filter-based attribution (§3.16 Phase 3-4).",
-      "structureType": "validation_rules",
+      "blockType": "validation_rules",
       "conceptArrangementPattern": "arithmetic"
     },
     {

--- a/robosystems/taxonomy/packages/rs-gaap-disclosure-mechanics/v1/taxonomy.jsonld
+++ b/robosystems/taxonomy/packages/rs-gaap-disclosure-mechanics/v1/taxonomy.jsonld
@@ -7,8 +7,8 @@
     "structureName": {
       "@id": "https://robosystems.ai/vocab/structureName"
     },
-    "structureType": {
-      "@id": "https://robosystems.ai/vocab/structureType"
+    "blockType": {
+      "@id": "https://robosystems.ai/vocab/blockType"
     },
     "roleUri": {
       "@id": "https://robosystems.ai/vocab/roleUri"
@@ -31,7 +31,7 @@
   "namespace_uri": "https://robosystems.ai/taxonomy/rs-gaap/disclosure-mechanics/v1/",
   "origin": "native",
   "created_at": "2026-05-10",
-  "default_structure_type": "validation_rules",
+  "default_block_type": "validation_rules",
   "description": "Disclosure Mechanics rules per rs-gaap Disclosure. Two arcrole patterns dominate: (1) reportedDisclosure-requiresDisclosure for composition (BalanceSheet → AssetsRollUp), and (2) conceptArrangementPattern-requiresConcept for concept binding (AssetsRollUp → rs-gaap:Assets). Mirrors Charlie Hoffman's seattlemethod arcrole vocabulary so a future Arelle harvest of his theory file lands into the same association rows.",
   "@graph": [
 
@@ -39,7 +39,7 @@
       "@id": "_:dm-balance-sheet",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/dm/BalanceSheet",
       "structureName": "BalanceSheet — Disclosure Mechanics",
-      "structureType": "validation_rules",
+      "blockType": "validation_rules",
       "conceptArrangementPattern": "component"
     },
     {
@@ -54,7 +54,7 @@
       "@id": "_:dm-income-statement",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/dm/IncomeStatement",
       "structureName": "IncomeStatement — Disclosure Mechanics",
-      "structureType": "validation_rules",
+      "blockType": "validation_rules",
       "conceptArrangementPattern": "component"
     },
     {
@@ -69,7 +69,7 @@
       "@id": "_:dm-changes-equity",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/dm/StatementOfChangesInEquity",
       "structureName": "StatementOfChangesInEquity — Disclosure Mechanics",
-      "structureType": "validation_rules",
+      "blockType": "validation_rules",
       "conceptArrangementPattern": "component"
     },
     {
@@ -83,7 +83,7 @@
       "@id": "_:dm-assets-rollup",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/dm/AssetsRollUp",
       "structureName": "AssetsRollUp — Disclosure Mechanics",
-      "structureType": "validation_rules",
+      "blockType": "validation_rules",
       "conceptArrangementPattern": "roll_up"
     },
     {
@@ -101,7 +101,7 @@
       "@id": "_:dm-liab-equity-rollup",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/dm/LiabilitiesAndEquityRollUp",
       "structureName": "LiabilitiesAndEquityRollUp — Disclosure Mechanics",
-      "structureType": "validation_rules",
+      "blockType": "validation_rules",
       "conceptArrangementPattern": "roll_up"
     },
     {
@@ -119,7 +119,7 @@
       "@id": "_:dm-current-assets-rollup",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/dm/CurrentAssetsRollUp",
       "structureName": "CurrentAssetsRollUp — Disclosure Mechanics",
-      "structureType": "validation_rules",
+      "blockType": "validation_rules",
       "conceptArrangementPattern": "roll_up"
     },
     {
@@ -133,7 +133,7 @@
       "@id": "_:dm-noncurrent-assets-rollup",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/dm/NoncurrentAssetsRollUp",
       "structureName": "NoncurrentAssetsRollUp — Disclosure Mechanics",
-      "structureType": "validation_rules",
+      "blockType": "validation_rules",
       "conceptArrangementPattern": "roll_up"
     },
     {
@@ -147,7 +147,7 @@
       "@id": "_:dm-current-liabilities-rollup",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/dm/CurrentLiabilitiesRollUp",
       "structureName": "CurrentLiabilitiesRollUp — Disclosure Mechanics",
-      "structureType": "validation_rules",
+      "blockType": "validation_rules",
       "conceptArrangementPattern": "roll_up"
     },
     {
@@ -161,7 +161,7 @@
       "@id": "_:dm-noncurrent-liabilities-rollup",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/dm/NoncurrentLiabilitiesRollUp",
       "structureName": "NoncurrentLiabilitiesRollUp — Disclosure Mechanics",
-      "structureType": "validation_rules",
+      "blockType": "validation_rules",
       "conceptArrangementPattern": "roll_up"
     },
     {
@@ -175,7 +175,7 @@
       "@id": "_:dm-revenues-rollup",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/dm/RevenuesRollUp",
       "structureName": "RevenuesRollUp — Disclosure Mechanics",
-      "structureType": "validation_rules",
+      "blockType": "validation_rules",
       "conceptArrangementPattern": "roll_up"
     },
     {
@@ -189,7 +189,7 @@
       "@id": "_:dm-operating-expenses-rollup",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/dm/OperatingExpensesRollUp",
       "structureName": "OperatingExpensesRollUp — Disclosure Mechanics",
-      "structureType": "validation_rules",
+      "blockType": "validation_rules",
       "conceptArrangementPattern": "roll_up"
     },
     {
@@ -203,7 +203,7 @@
       "@id": "_:dm-equity-rollforward",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/dm/EquityRollForward",
       "structureName": "EquityRollForward — Disclosure Mechanics",
-      "structureType": "validation_rules",
+      "blockType": "validation_rules",
       "conceptArrangementPattern": "roll_forward"
     },
     {
@@ -217,7 +217,7 @@
       "@id": "_:dm-cash-flow",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/dm/CashFlowStatement",
       "structureName": "CashFlowStatement — Disclosure Mechanics",
-      "structureType": "validation_rules",
+      "blockType": "validation_rules",
       "conceptArrangementPattern": "component"
     },
     {
@@ -231,7 +231,7 @@
       "@id": "_:dm-comprehensive-income",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/dm/StatementOfComprehensiveIncome",
       "structureName": "StatementOfComprehensiveIncome — Disclosure Mechanics",
-      "structureType": "validation_rules",
+      "blockType": "validation_rules",
       "conceptArrangementPattern": "component"
     },
     {
@@ -245,7 +245,7 @@
       "@id": "_:dm-long-term-debt-maturities",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/dm/LongTermDebtMaturities",
       "structureName": "LongTermDebtMaturities — Disclosure Mechanics",
-      "structureType": "validation_rules",
+      "blockType": "validation_rules",
       "conceptArrangementPattern": "roll_up"
     },
     {
@@ -259,7 +259,7 @@
       "@id": "_:dm-goodwill-rollforward",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/dm/GoodwillRollForward",
       "structureName": "GoodwillRollForward — Disclosure Mechanics",
-      "structureType": "validation_rules",
+      "blockType": "validation_rules",
       "conceptArrangementPattern": "roll_forward"
     },
     {

--- a/robosystems/taxonomy/packages/rs-gaap-disclosure-mechanics/v1/taxonomy.jsonld
+++ b/robosystems/taxonomy/packages/rs-gaap-disclosure-mechanics/v1/taxonomy.jsonld
@@ -40,7 +40,7 @@
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/dm/BalanceSheet",
       "structureName": "BalanceSheet — Disclosure Mechanics",
       "blockType": "validation_rules",
-      "conceptArrangementPattern": "component"
+      "conceptArrangementPattern": "set"
     },
     {
       "@id": "disclosures:BalanceSheet",
@@ -55,7 +55,7 @@
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/dm/IncomeStatement",
       "structureName": "IncomeStatement — Disclosure Mechanics",
       "blockType": "validation_rules",
-      "conceptArrangementPattern": "component"
+      "conceptArrangementPattern": "set"
     },
     {
       "@id": "disclosures:IncomeStatement",
@@ -70,7 +70,7 @@
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/dm/StatementOfChangesInEquity",
       "structureName": "StatementOfChangesInEquity — Disclosure Mechanics",
       "blockType": "validation_rules",
-      "conceptArrangementPattern": "component"
+      "conceptArrangementPattern": "set"
     },
     {
       "@id": "disclosures:StatementOfChangesInEquity",
@@ -218,7 +218,7 @@
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/dm/CashFlowStatement",
       "structureName": "CashFlowStatement — Disclosure Mechanics",
       "blockType": "validation_rules",
-      "conceptArrangementPattern": "component"
+      "conceptArrangementPattern": "set"
     },
     {
       "@id": "disclosures:CashFlowStatement",
@@ -232,7 +232,7 @@
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/dm/StatementOfComprehensiveIncome",
       "structureName": "StatementOfComprehensiveIncome — Disclosure Mechanics",
       "blockType": "validation_rules",
-      "conceptArrangementPattern": "component"
+      "conceptArrangementPattern": "set"
     },
     {
       "@id": "disclosures:StatementOfComprehensiveIncome",

--- a/robosystems/taxonomy/packages/rs-gaap-disclosures/v1/taxonomy.jsonld
+++ b/robosystems/taxonomy/packages/rs-gaap-disclosures/v1/taxonomy.jsonld
@@ -52,7 +52,7 @@
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/disclosures/BalanceSheet",
       "structureName": "Balance Sheet",
       "blockType": "balance_sheet",
-      "conceptArrangementPattern": "component",
+      "conceptArrangementPattern": "set",
       "secType": "statement"
     },
     {
@@ -64,7 +64,7 @@
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/disclosures/IncomeStatement",
       "structureName": "Income Statement",
       "blockType": "income_statement",
-      "conceptArrangementPattern": "component",
+      "conceptArrangementPattern": "set",
       "secType": "statement"
     },
     {
@@ -76,7 +76,7 @@
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/disclosures/CashFlowStatement",
       "structureName": "Cash Flow Statement",
       "blockType": "cash_flow_statement",
-      "conceptArrangementPattern": "component",
+      "conceptArrangementPattern": "set",
       "secType": "statement"
     },
     {
@@ -100,7 +100,7 @@
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/disclosures/StatementOfComprehensiveIncome",
       "structureName": "Statement of Comprehensive Income",
       "blockType": "comprehensive_income",
-      "conceptArrangementPattern": "component",
+      "conceptArrangementPattern": "set",
       "secType": "statement"
     },
     {
@@ -220,7 +220,7 @@
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/disclosures/DocumentAndEntityInformation",
       "structureName": "Document and Entity Information",
       "blockType": "regulatory_disclosure",
-      "conceptArrangementPattern": "hierarchy",
+      "conceptArrangementPattern": "set",
       "secType": "document"
     },
     {

--- a/robosystems/taxonomy/packages/rs-gaap-disclosures/v1/taxonomy.jsonld
+++ b/robosystems/taxonomy/packages/rs-gaap-disclosures/v1/taxonomy.jsonld
@@ -22,8 +22,8 @@
     "structureName": {
       "@id": "https://robosystems.ai/vocab/structureName"
     },
-    "structureType": {
-      "@id": "https://robosystems.ai/vocab/structureType"
+    "blockType": {
+      "@id": "https://robosystems.ai/vocab/blockType"
     },
     "roleUri": {
       "@id": "https://robosystems.ai/vocab/roleUri"
@@ -51,7 +51,7 @@
       "abstract": true,
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/disclosures/BalanceSheet",
       "structureName": "Balance Sheet",
-      "structureType": "balance_sheet",
+      "blockType": "balance_sheet",
       "conceptArrangementPattern": "component",
       "secType": "statement"
     },
@@ -63,7 +63,7 @@
       "abstract": true,
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/disclosures/IncomeStatement",
       "structureName": "Income Statement",
-      "structureType": "income_statement",
+      "blockType": "income_statement",
       "conceptArrangementPattern": "component",
       "secType": "statement"
     },
@@ -75,7 +75,7 @@
       "abstract": true,
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/disclosures/CashFlowStatement",
       "structureName": "Cash Flow Statement",
-      "structureType": "cash_flow_statement",
+      "blockType": "cash_flow_statement",
       "conceptArrangementPattern": "component",
       "secType": "statement"
     },
@@ -87,7 +87,7 @@
       "abstract": true,
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/disclosures/StatementOfChangesInEquity",
       "structureName": "Statement of Changes in Equity",
-      "structureType": "equity_statement",
+      "blockType": "equity_statement",
       "conceptArrangementPattern": "roll_forward",
       "secType": "statement"
     },
@@ -99,7 +99,7 @@
       "abstract": true,
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/disclosures/StatementOfComprehensiveIncome",
       "structureName": "Statement of Comprehensive Income",
-      "structureType": "comprehensive_income",
+      "blockType": "comprehensive_income",
       "conceptArrangementPattern": "component",
       "secType": "statement"
     },
@@ -111,7 +111,7 @@
       "abstract": true,
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/disclosures/AssetsRollUp",
       "structureName": "Assets Roll Up",
-      "structureType": "validation_rules",
+      "blockType": "validation_rules",
       "conceptArrangementPattern": "roll_up",
       "secType": "statement_component"
     },
@@ -123,7 +123,7 @@
       "abstract": true,
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/disclosures/LiabilitiesAndEquityRollUp",
       "structureName": "Liabilities and Equity Roll Up",
-      "structureType": "validation_rules",
+      "blockType": "validation_rules",
       "conceptArrangementPattern": "roll_up",
       "secType": "statement_component"
     },
@@ -135,7 +135,7 @@
       "abstract": true,
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/disclosures/CurrentAssetsRollUp",
       "structureName": "Current Assets Roll Up",
-      "structureType": "validation_rules",
+      "blockType": "validation_rules",
       "conceptArrangementPattern": "roll_up",
       "secType": "statement_component"
     },
@@ -147,7 +147,7 @@
       "abstract": true,
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/disclosures/NoncurrentAssetsRollUp",
       "structureName": "Noncurrent Assets Roll Up",
-      "structureType": "validation_rules",
+      "blockType": "validation_rules",
       "conceptArrangementPattern": "roll_up",
       "secType": "statement_component"
     },
@@ -159,7 +159,7 @@
       "abstract": true,
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/disclosures/CurrentLiabilitiesRollUp",
       "structureName": "Current Liabilities Roll Up",
-      "structureType": "validation_rules",
+      "blockType": "validation_rules",
       "conceptArrangementPattern": "roll_up",
       "secType": "statement_component"
     },
@@ -171,7 +171,7 @@
       "abstract": true,
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/disclosures/NoncurrentLiabilitiesRollUp",
       "structureName": "Noncurrent Liabilities Roll Up",
-      "structureType": "validation_rules",
+      "blockType": "validation_rules",
       "conceptArrangementPattern": "roll_up",
       "secType": "statement_component"
     },
@@ -183,7 +183,7 @@
       "abstract": true,
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/disclosures/RevenuesRollUp",
       "structureName": "Revenues Roll Up",
-      "structureType": "validation_rules",
+      "blockType": "validation_rules",
       "conceptArrangementPattern": "roll_up",
       "secType": "statement_component"
     },
@@ -195,7 +195,7 @@
       "abstract": true,
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/disclosures/OperatingExpensesRollUp",
       "structureName": "Operating Expenses Roll Up",
-      "structureType": "validation_rules",
+      "blockType": "validation_rules",
       "conceptArrangementPattern": "roll_up",
       "secType": "statement_component"
     },
@@ -207,7 +207,7 @@
       "abstract": true,
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/disclosures/EquityRollForward",
       "structureName": "Equity Roll Forward",
-      "structureType": "validation_rules",
+      "blockType": "validation_rules",
       "conceptArrangementPattern": "roll_forward",
       "secType": "statement_component"
     },
@@ -219,7 +219,7 @@
       "abstract": true,
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/disclosures/DocumentAndEntityInformation",
       "structureName": "Document and Entity Information",
-      "structureType": "disclosure",
+      "blockType": "regulatory_disclosure",
       "conceptArrangementPattern": "hierarchy",
       "secType": "document"
     },
@@ -231,7 +231,7 @@
       "abstract": true,
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/disclosures/NatureOfOperations",
       "structureName": "Nature of Operations",
-      "structureType": "disclosure",
+      "blockType": "regulatory_disclosure",
       "conceptArrangementPattern": "level1_textblock",
       "secType": "disclosure"
     },
@@ -243,7 +243,7 @@
       "abstract": true,
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/disclosures/SignificantAccountingPolicies",
       "structureName": "Significant Accounting Policies",
-      "structureType": "disclosure",
+      "blockType": "regulatory_disclosure",
       "conceptArrangementPattern": "level1_textblock",
       "secType": "disclosure"
     },
@@ -255,7 +255,7 @@
       "abstract": true,
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/disclosures/PropertyPlantAndEquipmentDisclosure",
       "structureName": "Property, Plant and Equipment Disclosure",
-      "structureType": "disclosure",
+      "blockType": "regulatory_disclosure",
       "conceptArrangementPattern": "level1_textblock",
       "secType": "disclosure"
     },
@@ -267,7 +267,7 @@
       "abstract": true,
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/disclosures/GoodwillRollForward",
       "structureName": "Goodwill Roll Forward",
-      "structureType": "disclosure",
+      "blockType": "regulatory_disclosure",
       "conceptArrangementPattern": "roll_forward",
       "secType": "disclosure"
     },
@@ -279,7 +279,7 @@
       "abstract": true,
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/disclosures/IntangibleAssetsDisclosure",
       "structureName": "Intangible Assets Disclosure",
-      "structureType": "disclosure",
+      "blockType": "regulatory_disclosure",
       "conceptArrangementPattern": "level1_textblock",
       "secType": "disclosure"
     },
@@ -291,7 +291,7 @@
       "abstract": true,
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/disclosures/DebtDisclosure",
       "structureName": "Debt Disclosure",
-      "structureType": "disclosure",
+      "blockType": "regulatory_disclosure",
       "conceptArrangementPattern": "level1_textblock",
       "secType": "disclosure"
     },
@@ -303,7 +303,7 @@
       "abstract": true,
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/disclosures/LongTermDebtMaturities",
       "structureName": "Long-Term Debt Maturities",
-      "structureType": "disclosure",
+      "blockType": "regulatory_disclosure",
       "conceptArrangementPattern": "roll_up",
       "secType": "disclosure"
     },
@@ -315,7 +315,7 @@
       "abstract": true,
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/disclosures/IncomeTaxDisclosure",
       "structureName": "Income Tax Disclosure",
-      "structureType": "disclosure",
+      "blockType": "regulatory_disclosure",
       "conceptArrangementPattern": "level1_textblock",
       "secType": "disclosure"
     },
@@ -327,7 +327,7 @@
       "abstract": true,
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/disclosures/DeferredTaxAssetsAndLiabilities",
       "structureName": "Deferred Tax Assets and Liabilities",
-      "structureType": "disclosure",
+      "blockType": "regulatory_disclosure",
       "conceptArrangementPattern": "roll_up",
       "secType": "disclosure"
     },
@@ -339,7 +339,7 @@
       "abstract": true,
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/disclosures/EarningsPerShareDisclosures",
       "structureName": "Earnings Per Share Disclosures",
-      "structureType": "disclosure",
+      "blockType": "regulatory_disclosure",
       "conceptArrangementPattern": "level1_textblock",
       "secType": "disclosure"
     },
@@ -351,7 +351,7 @@
       "abstract": true,
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/disclosures/SegmentReportingDisclosure",
       "structureName": "Segment Reporting Disclosure",
-      "structureType": "disclosure",
+      "blockType": "regulatory_disclosure",
       "conceptArrangementPattern": "level1_textblock",
       "secType": "disclosure"
     },
@@ -363,7 +363,7 @@
       "abstract": true,
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/disclosures/CommitmentsDisclosure",
       "structureName": "Commitments Disclosure",
-      "structureType": "disclosure",
+      "blockType": "regulatory_disclosure",
       "conceptArrangementPattern": "level1_textblock",
       "secType": "disclosure"
     },
@@ -375,7 +375,7 @@
       "abstract": true,
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/disclosures/ContingenciesDisclosure",
       "structureName": "Contingencies Disclosure",
-      "structureType": "disclosure",
+      "blockType": "regulatory_disclosure",
       "conceptArrangementPattern": "level1_textblock",
       "secType": "disclosure"
     },
@@ -387,7 +387,7 @@
       "abstract": true,
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/disclosures/LeasesOfLesseeDisclosure",
       "structureName": "Leases of Lessee Disclosure",
-      "structureType": "disclosure",
+      "blockType": "regulatory_disclosure",
       "conceptArrangementPattern": "level1_textblock",
       "secType": "disclosure"
     },
@@ -399,7 +399,7 @@
       "abstract": true,
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/disclosures/ShareBasedCompensationDisclosure",
       "structureName": "Share-Based Compensation Disclosure",
-      "structureType": "disclosure",
+      "blockType": "regulatory_disclosure",
       "conceptArrangementPattern": "level1_textblock",
       "secType": "disclosure"
     },
@@ -411,7 +411,7 @@
       "abstract": true,
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/disclosures/RelatedPartyDisclosures",
       "structureName": "Related Party Disclosures",
-      "structureType": "disclosure",
+      "blockType": "regulatory_disclosure",
       "conceptArrangementPattern": "level1_textblock",
       "secType": "disclosure"
     }

--- a/robosystems/taxonomy/packages/rs-gaap-hierarchy/v1/taxonomy.jsonld
+++ b/robosystems/taxonomy/packages/rs-gaap-hierarchy/v1/taxonomy.jsonld
@@ -70,7 +70,7 @@
   "standard": "rs-gaap-hierarchy",
   "version": "v1",
   "taxonomy_type": "mapping",
-  "default_structure_type": "taxonomy_mapping",
+  "default_block_type": "taxonomy_mapping",
   "namespace_uri": "https://robosystems.ai/taxonomy/rs-gaap-hierarchy/v1/",
   "origin": "native",
   "created_at": "2026-04-20",

--- a/robosystems/taxonomy/packages/rs-gaap-presentation/v1/taxonomy.jsonld
+++ b/robosystems/taxonomy/packages/rs-gaap-presentation/v1/taxonomy.jsonld
@@ -5,8 +5,8 @@
     "structureName": {
       "@id": "https://robosystems.ai/vocab/structureName"
     },
-    "structureType": {
-      "@id": "https://robosystems.ai/vocab/structureType"
+    "blockType": {
+      "@id": "https://robosystems.ai/vocab/blockType"
     },
     "roleUri": {
       "@id": "https://robosystems.ai/vocab/roleUri"
@@ -54,19 +54,19 @@
       "@id": "_:rs-gaap-pres-bs",
       "roleUri": "http://www.xbrlsite.com/seattlemethod/conceptual-model/cm-roles/roles/rs-gaap-presentation/rs-gaap-pres-bs",
       "structureName": "rs-gaap — Balance Sheet presentation",
-      "structureType": "balance_sheet"
+      "blockType": "balance_sheet"
     },
     {
       "@id": "_:rs-gaap-pres-is",
       "roleUri": "http://www.xbrlsite.com/seattlemethod/conceptual-model/cm-roles/roles/rs-gaap-presentation/rs-gaap-pres-is",
       "structureName": "rs-gaap — Income Statement presentation",
-      "structureType": "income_statement"
+      "blockType": "income_statement"
     },
     {
       "@id": "_:rs-gaap-pres-cf",
       "roleUri": "http://www.xbrlsite.com/seattlemethod/conceptual-model/cm-roles/roles/rs-gaap-presentation/rs-gaap-pres-cf",
       "structureName": "rs-gaap — Cash Flow Statement presentation",
-      "structureType": "cash_flow_statement"
+      "blockType": "cash_flow_statement"
     },
     {
       "@id": "rs-gaap:AccountsNotesAndLoansReceivableNetCurrent",
@@ -7727,7 +7727,7 @@
       "@id": "_:rs-gaap-pres-bs-classified",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
       "structureName": "rs-gaap — Balance Sheet — Classified",
-      "structureType": "balance_sheet",
+      "blockType": "balance_sheet",
       "conceptArrangementPattern": "arithmetic"
     },
     {
@@ -8023,7 +8023,7 @@
       "@id": "_:rs-gaap-pres-is-multistep",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
       "structureName": "rs-gaap — Income Statement — Multi-step",
-      "structureType": "income_statement",
+      "blockType": "income_statement",
       "conceptArrangementPattern": "arithmetic"
     },
     {
@@ -8191,7 +8191,7 @@
       "@id": "_:rs-gaap-pres-cf-indirect",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
       "structureName": "rs-gaap — Cash Flow Statement — Indirect",
-      "structureType": "cash_flow_statement",
+      "blockType": "cash_flow_statement",
       "conceptArrangementPattern": "arithmetic"
     },
     {
@@ -8327,7 +8327,7 @@
       "@id": "_:rs-gaap-pres-equity",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward",
       "structureName": "rs-gaap — Statement of Changes in Equity — Roll Forward (Total)",
-      "structureType": "equity_statement",
+      "blockType": "equity_statement",
       "conceptArrangementPattern": "roll_forward"
     },
     {

--- a/robosystems/taxonomy/packages/rs-gaap-reporting-checklist/v1/taxonomy.jsonld
+++ b/robosystems/taxonomy/packages/rs-gaap-reporting-checklist/v1/taxonomy.jsonld
@@ -19,8 +19,8 @@
     "structureName": {
       "@id": "https://robosystems.ai/vocab/structureName"
     },
-    "structureType": {
-      "@id": "https://robosystems.ai/vocab/structureType"
+    "blockType": {
+      "@id": "https://robosystems.ai/vocab/blockType"
     },
     "roleUri": {
       "@id": "https://robosystems.ai/vocab/roleUri"
@@ -43,7 +43,7 @@
   "namespace_uri": "https://robosystems.ai/taxonomy/rs-gaap/reporting-checklist/v1/",
   "origin": "native",
   "created_at": "2026-05-10",
-  "default_structure_type": "validation_rules",
+  "default_block_type": "validation_rules",
   "description": "Reporting Checklist (DR rules) — what disclosures a 'general purpose financial report' requires vs may have. Mirrors Charlie Hoffman's reportingChecklist arcrole vocabulary (financialReport-requiresDisclosure, financialReport-possibleDisclosure). Declares one abstract checklist:GeneralPurposeFinancialReport subject and arcs to the disclosures it scopes.",
   "@graph": [
     {
@@ -58,7 +58,7 @@
       "@id": "_:dr-checklist",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/dr/ReportingChecklist",
       "structureName": "Reporting Checklist — General Purpose Financial Report",
-      "structureType": "validation_rules",
+      "blockType": "validation_rules",
       "conceptArrangementPattern": "set"
     },
 

--- a/robosystems/taxonomy/packages/rs-gaap-reporting-styles/v1/taxonomy.jsonld
+++ b/robosystems/taxonomy/packages/rs-gaap-reporting-styles/v1/taxonomy.jsonld
@@ -19,8 +19,8 @@
     "structureName": {
       "@id": "https://robosystems.ai/vocab/structureName"
     },
-    "structureType": {
-      "@id": "https://robosystems.ai/vocab/structureType"
+    "blockType": {
+      "@id": "https://robosystems.ai/vocab/blockType"
     },
     "roleUri": {
       "@id": "https://robosystems.ai/vocab/roleUri"
@@ -39,7 +39,7 @@
   "namespace_uri": "https://robosystems.ai/taxonomy/rs-gaap/reporting-styles/v1/",
   "origin": "native",
   "created_at": "2026-05-10",
-  "default_structure_type": "custom",
+  "default_block_type": "custom",
   "description": "Reporting Styles — composition profiles that pin specific Disclosures for a vertical / filer profile. Each Style is an abstract subject with reportingStyle-composesDisclosure arcs naming the disclosures it includes. Mirrors Charlie Hoffman's seattlemethod ReportingStyles concept (the COMID-BSC-CF1-… composition schemas at auditchain.finance) but anchored to rs-gaap disclosures instead of fac/us-gaap concepts. v1 ships three minimal styles; vertical-specific styles (banking, insurance) are placeholders until customer demand surfaces.",
   "@graph": [
     {
@@ -68,21 +68,21 @@
       "@id": "_:style-default-structure",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/styles/Default",
       "structureName": "Default Style — Composition",
-      "structureType": "custom",
+      "blockType": "custom",
       "conceptArrangementPattern": "set"
     },
     {
       "@id": "_:style-smallprivate-structure",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/styles/SmallPrivateCompany",
       "structureName": "Small Private Company Style — Composition",
-      "structureType": "custom",
+      "blockType": "custom",
       "conceptArrangementPattern": "set"
     },
     {
       "@id": "_:style-banking-structure",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/styles/Banking",
       "structureName": "Banking Style — Composition (placeholder)",
-      "structureType": "custom",
+      "blockType": "custom",
       "conceptArrangementPattern": "set"
     },
 

--- a/robosystems/taxonomy/packages/type-subtype/v1/taxonomy.jsonld
+++ b/robosystems/taxonomy/packages/type-subtype/v1/taxonomy.jsonld
@@ -106,8 +106,8 @@
     "structureName": {
       "@id": "https://robosystems.ai/vocab/structureName"
     },
-    "structureType": {
-      "@id": "https://robosystems.ai/vocab/structureType"
+    "blockType": {
+      "@id": "https://robosystems.ai/vocab/blockType"
     },
     "roleUri": {
       "@id": "https://robosystems.ai/vocab/roleUri"
@@ -116,7 +116,7 @@
   "standard": "type-subtype",
   "version": "v1",
   "taxonomy_type": "mapping",
-  "default_structure_type": "disclosure",
+  "default_block_type": "regulatory_disclosure",
   "namespace_uri": "http://xbrlsite.com/type-subtype/",
   "forked_from": {
     "author": "Charlie Hoffman (Seattle Method)",

--- a/robosystems/taxonomy/seed.py
+++ b/robosystems/taxonomy/seed.py
@@ -658,13 +658,13 @@ STRUCTURES = [
   {
     "id": STRUCT_IS_ID,
     "name": "US GAAP Income Statement",
-    "structure_type": "income_statement",
+    "block_type": "income_statement",
     "taxonomy_id": TAXONOMY_ID,
   },
   {
     "id": STRUCT_BS_ID,
     "name": "US GAAP Balance Sheet",
-    "structure_type": "balance_sheet",
+    "block_type": "balance_sheet",
     "taxonomy_id": TAXONOMY_ID,
   },
 ]
@@ -745,14 +745,14 @@ def seed_reporting_taxonomy(connection) -> None:
   for s in STRUCTURES:
     connection.execute(
       text("""
-                INSERT INTO public.structures (id, name, structure_type, taxonomy_id,
+                INSERT INTO public.structures (id, name, block_type, taxonomy_id,
                     is_active, metadata, created_by)
                 VALUES (:id, :name, :type, :tax_id, true, '{}'::jsonb, 'system')
             """),
       {
         "id": s["id"],
         "name": s["name"],
-        "type": s["structure_type"],
+        "type": s["block_type"],
         "tax_id": s["taxonomy_id"],
       },
     )
@@ -991,7 +991,7 @@ def seed_tenant_reporting_taxonomy(connection, schema: str) -> None:
   )
 
   struct_cols = (
-    "id, name, description, structure_type, taxonomy_id, graph_structure_id, "
+    "id, name, description, block_type, taxonomy_id, graph_structure_id, "
     "is_active, metadata, created_at, updated_at, created_by"
   )
   connection.execute(

--- a/robosystems/taxonomy/writers/tenant_writer.py
+++ b/robosystems/taxonomy/writers/tenant_writer.py
@@ -43,9 +43,9 @@ _ELEMENT_REFERENCE_COLS = (
 )
 
 _STRUCTURE_COLS = (
-  "id, name, description, structure_type, taxonomy_id, graph_structure_id, "
+  "id, name, description, block_type, taxonomy_id, graph_structure_id, "
   "is_active, concept_arrangement, member_arrangement, artifact_mechanics, "
-  "parenthetical_note, template_id, metadata, created_at, updated_at, created_by"
+  "renderer_note, template_id, metadata, created_at, updated_at, created_by"
 )
 
 _ASSOCIATION_COLS = (
@@ -75,8 +75,8 @@ _ASSOC_CLASSIFICATION_COLS = (
 )
 
 _RULE_COLS = (
-  "id, taxonomy_id, rule_category, rule_pattern, rule_expression, "
-  "rule_message, rule_severity, rule_origin, target_kind, "
+  "id, taxonomy_id, rule_category, rule_pattern, rule_check_kind, "
+  "rule_expression, rule_message, rule_severity, rule_origin, target_kind, "
   "target_structure_id, target_element_id, target_association_id, "
   "target_taxonomy_id, rule_variables, metadata, created_at, updated_at, created_by"
 )

--- a/tests/adapters/sec/test_structure_classification.py
+++ b/tests/adapters/sec/test_structure_classification.py
@@ -8,7 +8,7 @@ class TestClassifyStructureHeuristic:
     stype, conf = classify_structure_heuristic(
       "CONSOLIDATED STATEMENTS OF INCOME",
       "0001001 - Statement - CONSOLIDATED STATEMENTS OF INCOME",
-      structure_type="Statement",
+      block_type="Statement",
     )
     assert stype == "income_statement"
     assert conf == 0.85
@@ -17,7 +17,7 @@ class TestClassifyStructureHeuristic:
     stype, conf = classify_structure_heuristic(
       "CONSOLIDATED BALANCE SHEETS",
       "0001002 - Statement - CONSOLIDATED BALANCE SHEETS",
-      structure_type="Statement",
+      block_type="Statement",
     )
     assert stype == "balance_sheet"
     assert conf == 0.85
@@ -26,7 +26,7 @@ class TestClassifyStructureHeuristic:
     stype, conf = classify_structure_heuristic(
       "CONSOLIDATED STATEMENTS OF CASH FLOWS",
       "0001003 - Statement - CONSOLIDATED STATEMENTS OF CASH FLOWS",
-      structure_type="Statement",
+      block_type="Statement",
     )
     assert stype == "cash_flow_statement"
     assert conf == 0.85
@@ -35,7 +35,7 @@ class TestClassifyStructureHeuristic:
     stype, conf = classify_structure_heuristic(
       "CONSOLIDATED STATEMENTS OF STOCKHOLDERS' EQUITY",
       "0001004 - Statement - CONSOLIDATED STATEMENTS OF STOCKHOLDERS' EQUITY",
-      structure_type="Statement",
+      block_type="Statement",
     )
     assert stype == "equity_statement"
     assert conf == 0.85
@@ -44,7 +44,7 @@ class TestClassifyStructureHeuristic:
     stype, conf = classify_structure_heuristic(
       "CONSOLIDATED STATEMENTS OF COMPREHENSIVE INCOME",
       "0001005 - Statement - CONSOLIDATED STATEMENTS OF COMPREHENSIVE INCOME",
-      structure_type="Statement",
+      block_type="Statement",
     )
     assert stype == "comprehensive_income"
     assert conf == 0.85
@@ -53,17 +53,17 @@ class TestClassifyStructureHeuristic:
     stype, conf = classify_structure_heuristic(
       "CONSOLIDATED BALANCE SHEETS [Parenthetical]",
       "0001002 - Statement - CONSOLIDATED BALANCE SHEETS [Parenthetical]",
-      structure_type="Statement",
+      block_type="Statement",
     )
     assert stype == "balance_sheet"
     assert conf == 0.75
 
-  def test_disclosure_skipped_by_structure_type(self):
-    """Disclosure structures should be skipped when structure_type is provided."""
+  def test_disclosure_skipped_by_block_type(self):
+    """Disclosure structures should be skipped when block_type is provided."""
     stype, conf = classify_structure_heuristic(
       "Balance Sheet Components - Inventories (Details)",
       "995410 - Disclosure - Balance Sheet Components - Inventories (Details)",
-      structure_type="Disclosure",
+      block_type="Disclosure",
     )
     assert stype is None
     assert conf == 0.0
@@ -73,7 +73,7 @@ class TestClassifyStructureHeuristic:
     stype, conf = classify_structure_heuristic(
       "Cash Flows (Details)",
       "995415 - Disclosure - Cash Flows (Details)",
-      structure_type="Disclosure",
+      block_type="Disclosure",
     )
     assert stype is None
     assert conf == 0.0
@@ -97,7 +97,7 @@ class TestClassifyStructureHeuristic:
     stype, conf = classify_structure_heuristic(
       "CONSOLIDATED STATEMENTS OF OPERATIONS",
       "0001001 - Statement - CONSOLIDATED STATEMENTS OF OPERATIONS",
-      structure_type="Statement",
+      block_type="Statement",
     )
     assert stype == "income_statement"
     assert conf == 0.85
@@ -111,22 +111,22 @@ class TestClassifyStructureHeuristic:
     assert stype == "comprehensive_income"
     assert conf == 0.85
 
-  def test_unknown_structure_type_still_classifies(self):
-    """When structure_type is None, classification proceeds normally."""
+  def test_unknown_block_type_still_classifies(self):
+    """When block_type is None, classification proceeds normally."""
     stype, conf = classify_structure_heuristic(
       "CONSOLIDATED BALANCE SHEETS",
       "0001002 - Statement - CONSOLIDATED BALANCE SHEETS",
-      structure_type=None,
+      block_type=None,
     )
     assert stype == "balance_sheet"
     assert conf == 0.85
 
-  def test_empty_structure_type_still_classifies(self):
-    """When structure_type is empty string, classification proceeds normally."""
+  def test_empty_block_type_still_classifies(self):
+    """When block_type is empty string, classification proceeds normally."""
     stype, conf = classify_structure_heuristic(
       "CONSOLIDATED BALANCE SHEETS",
       "0001002 - Statement - CONSOLIDATED BALANCE SHEETS",
-      structure_type="",
+      block_type="",
     )
     assert stype == "balance_sheet"
     assert conf == 0.85

--- a/tests/graphql/extensions/test_information_block.py
+++ b/tests/graphql/extensions/test_information_block.py
@@ -205,7 +205,7 @@ def _statement_envelope(
     display_name=display_name,
     category="Reporting",
     information_model=InformationModelResponse(
-      concept_arrangement="roll_up", member_arrangement="aggregation"
+      concept_arrangement="roll_up", member_arrangement="whole_part"
     ),
     artifact=ArtifactResponse(mechanics=StatementMechanics()),
   )
@@ -232,7 +232,7 @@ class TestStatementInformationBlocks:
     assert data["blockType"] == "balance_sheet"
     assert data["category"] == "Reporting"
     assert data["informationModel"]["conceptArrangement"] == "roll_up"
-    assert data["informationModel"]["memberArrangement"] == "aggregation"
+    assert data["informationModel"]["memberArrangement"] == "whole_part"
     assert data["artifact"]["mechanics"]["kind"] == "statement_renderer"
 
   def test_balance_sheet_filter_surfaces_on_library_sentinel(self) -> None:

--- a/tests/operations/event_block/python_handlers/test_disposal_plan.py
+++ b/tests/operations/event_block/python_handlers/test_disposal_plan.py
@@ -21,7 +21,7 @@ def _make_structure(
 ) -> MagicMock:
   structure = MagicMock()
   structure.id = "struct_schedule"
-  structure.structure_type = "schedule"
+  structure.block_type = "schedule"
   structure.artifact_mechanics = {
     "schedule_metadata": {
       "original_amount": original_amount,

--- a/tests/operations/event_block/python_handlers/test_schedule_entry_due.py
+++ b/tests/operations/event_block/python_handlers/test_schedule_entry_due.py
@@ -135,7 +135,7 @@ class TestDispatchPreview:
     metadata = _make_metadata()
 
     structure = MagicMock()
-    structure.structure_type = "schedule"
+    structure.block_type = "schedule"
     structure.name = "Office Equipment"
     structure.metadata_ = {
       "entry_template": {
@@ -171,7 +171,7 @@ class TestDispatchPreview:
     metadata = _make_metadata()
 
     structure = MagicMock()
-    structure.structure_type = "schedule"
+    structure.block_type = "schedule"
     structure.name = "Office Equipment"
     structure.metadata_ = {
       "entry_template": {
@@ -209,7 +209,7 @@ class TestDispatchPreview:
     metadata = _make_metadata()
 
     structure = MagicMock()
-    structure.structure_type = "schedule"
+    structure.block_type = "schedule"
     structure.metadata_ = {}
     session.get.return_value = structure
 

--- a/tests/operations/graph/test_reporting_style_command.py
+++ b/tests/operations/graph/test_reporting_style_command.py
@@ -151,13 +151,13 @@ class TestChangeReportingStyleCmd:
     assert "not found" in ctx.value.detail.lower()
     db.commit.assert_not_called()
 
-  async def test_wrong_structure_type_422(self):
+  async def test_wrong_block_type_422(self):
     db = MagicMock()
     user = _make_user()
     row = MagicMock()
     row.id = "wrong-type-id"
     row.name = "Some Random Structure"
-    row.structure_type = "balance_sheet"  # not a Reporting Style
+    row.block_type = "balance_sheet"  # not a Reporting Style
     row.is_active = True
     ext_cm = _make_ext_session(style_row=row, composed_types=None)
     with (
@@ -168,7 +168,7 @@ class TestChangeReportingStyleCmd:
       with pytest.raises(HTTPException) as ctx:
         await change_reporting_style_cmd(GRAPH_ID, "wrong-type-id", user, db)
     assert ctx.value.status_code == 422
-    assert "structure_type" in ctx.value.detail
+    assert "block_type" in ctx.value.detail
     # Legacy hint mentioned so tenants whose Style rows weren't
     # promoted by migration 0008 know 'custom' is also accepted.
     assert "custom" in ctx.value.detail
@@ -180,7 +180,7 @@ class TestChangeReportingStyleCmd:
     row = MagicMock()
     row.id = SMALL_PRIVATE_STYLE_ID
     row.name = "Small Private Company Style"
-    row.structure_type = "reporting_style"
+    row.block_type = "reporting_style"
     row.is_active = False
     ext_cm = _make_ext_session(style_row=row, composed_types=None)
     with (
@@ -201,7 +201,7 @@ class TestChangeReportingStyleCmd:
     row = MagicMock()
     row.id = SMALL_PRIVATE_STYLE_ID
     row.name = "Small Private Company Style"
-    row.structure_type = "reporting_style"
+    row.block_type = "reporting_style"
     row.is_active = True
     # Only BS + IS composed; CF + SE missing.
     ext_cm = _make_ext_session(
@@ -226,7 +226,7 @@ class TestChangeReportingStyleCmd:
     row = MagicMock()
     row.id = SMALL_PRIVATE_STYLE_ID
     row.name = "Small Private Company Style"
-    row.structure_type = "reporting_style"
+    row.block_type = "reporting_style"
     row.is_active = True
     ext_cm = _make_ext_session(
       style_row=row, composed_types=list(_REQUIRED_STATEMENT_TYPES)
@@ -248,17 +248,17 @@ class TestChangeReportingStyleCmd:
     db.commit.assert_called_once()
     db.refresh.assert_called_once_with(graph)
 
-  async def test_legacy_custom_structure_type_accepted(self):
+  async def test_legacy_custom_block_type_accepted(self):
     """Existing tenants whose 3 Style rows weren't promoted by 0008
     (immutability trigger leaves tenant copies as 'custom') can still
-    be selected — the picker doesn't filter on structure_type either."""
+    be selected — the picker doesn't filter on block_type either."""
     db = MagicMock()
     user = _make_user()
     graph = _make_graph(DEFAULT_STYLE_ID)
     row = MagicMock()
     row.id = SMALL_PRIVATE_STYLE_ID
     row.name = "Small Private Company Style — Composition"
-    row.structure_type = "custom"  # legacy tenant row
+    row.block_type = "custom"  # legacy tenant row
     row.is_active = True
     ext_cm = _make_ext_session(
       style_row=row, composed_types=list(_REQUIRED_STATEMENT_TYPES)

--- a/tests/operations/information_block/rules/test_engine.py
+++ b/tests/operations/information_block/rules/test_engine.py
@@ -250,7 +250,7 @@ class TestEvaluateRulesForStructure:
     )
 
     session = MagicMock()
-    session.get.return_value = MagicMock(id="struct_bs", structure_type="schedule")
+    session.get.return_value = MagicMock(id="struct_bs", block_type="schedule")
     session.execute.return_value = _scalars()
 
     with patch(
@@ -267,7 +267,7 @@ class TestEvaluateRulesForStructure:
     )
 
     session = MagicMock()
-    session.get.return_value = MagicMock(id="struct_bs", structure_type="schedule")
+    session.get.return_value = MagicMock(id="struct_bs", block_type="schedule")
 
     rule_lite = MagicMock()
     rule_lite.id = "rule_crash"
@@ -300,7 +300,7 @@ class TestEvaluateRulesForStructure:
     )
 
     session = MagicMock()
-    session.get.return_value = MagicMock(id="struct_bs", structure_type="schedule")
+    session.get.return_value = MagicMock(id="struct_bs", block_type="schedule")
 
     rule_lite = MagicMock()
     rule_lite.id = "rule_eq"
@@ -341,7 +341,7 @@ class TestEvaluateRulesForStructure:
     )
 
     session = MagicMock()
-    session.get.return_value = MagicMock(id="struct_bs", structure_type="schedule")
+    session.get.return_value = MagicMock(id="struct_bs", block_type="schedule")
     session.execute.return_value = _scalars()
 
     with patch(

--- a/tests/operations/information_block/test_envelope_classifications.py
+++ b/tests/operations/information_block/test_envelope_classifications.py
@@ -103,7 +103,7 @@ class TestLoadClassificationsForAssociations:
     session = MagicMock()
     cls_rollup = _make_classification(identifier="RollUp")
     cls_aggr = _make_classification(
-      cls_id="cls_aggr", category="member_arrangement", identifier="aggregation"
+      cls_id="cls_aggr", category="member_arrangement", identifier="whole_part"
     )
     cls_hyper = _make_classification(
       cls_id="cls_hyper", category="concept_arrangement", identifier="Hypercube"
@@ -121,7 +121,7 @@ class TestLoadClassificationsForAssociations:
     assert len(result["assoc_2"]) == 1
     assert result["assoc_1"][0].identifier == "RollUp"
     assert result["assoc_1"][0].is_primary is True
-    assert result["assoc_1"][1].identifier == "aggregation"
+    assert result["assoc_1"][1].identifier == "whole_part"
     assert result["assoc_1"][1].is_primary is False
     assert result["assoc_2"][0].identifier == "Hypercube"
 

--- a/tests/operations/information_block/test_envelope_rules.py
+++ b/tests/operations/information_block/test_envelope_rules.py
@@ -37,6 +37,7 @@ def _make_rule(
   rule.id = rule_id
   rule.rule_category = category
   rule.rule_pattern = pattern
+  rule.rule_check_kind = None
   rule.rule_expression = expression
   rule.target_kind = target_kind
   rule.target_structure_id = target_structure_id

--- a/tests/operations/information_block/test_load_disclosure_id_for_structure.py
+++ b/tests/operations/information_block/test_load_disclosure_id_for_structure.py
@@ -5,11 +5,11 @@ Three branches covered:
 1. Target structure IS a disclosure-namespace structure -> derive qname
    from its own role_uri.
 2. Target is a renderable presentation -> look up the
-   disclosure-namespace sibling by structure_type.
+   disclosure-namespace sibling by block_type.
 3. No match (validation_rules, taxonomy_mapping, schedules) -> ``None``.
 
 Also confirms the module-level type cache short-circuits subsequent
-calls for the same structure_type.
+calls for the same block_type.
 """
 
 from __future__ import annotations
@@ -34,7 +34,7 @@ def _clear_cache() -> Any:
   _DISCLOSURE_QNAME_BY_TYPE.clear()
 
 
-def _make_structure(*, role_uri: str | None, structure_type: str | None) -> Any:
+def _make_structure(*, role_uri: str | None, block_type: str | None) -> Any:
   """Build a mock Structure ORM row.
 
   ``role_uri`` lives inside the ``metadata_`` JSONB blob (see
@@ -44,7 +44,7 @@ def _make_structure(*, role_uri: str | None, structure_type: str | None) -> Any:
   """
   s = MagicMock()
   s.metadata_ = {"role_uri": role_uri} if role_uri is not None else {}
-  s.structure_type = structure_type
+  s.block_type = block_type
   return s
 
 
@@ -53,7 +53,7 @@ class TestDirectDisclosureRoleUri:
     session = MagicMock()
     session.get.return_value = _make_structure(
       role_uri=f"{_DISCLOSURE_ROLE_PREFIX}BalanceSheet",
-      structure_type="balance_sheet",
+      block_type="balance_sheet",
     )
     assert (
       load_disclosure_id_for_structure(session, "struct_bs_disclosure")
@@ -66,7 +66,7 @@ class TestDirectDisclosureRoleUri:
     session = MagicMock()
     session.get.return_value = _make_structure(
       role_uri=f"{_DISCLOSURE_ROLE_PREFIX}LeasesOfLesseeDisclosure",
-      structure_type="disclosure",
+      block_type="regulatory_disclosure",
     )
     assert (
       load_disclosure_id_for_structure(session, "struct_leases")
@@ -77,11 +77,11 @@ class TestDirectDisclosureRoleUri:
 class TestStructureTypeFallback:
   def test_presentation_finds_matching_disclosure(self) -> None:
     """A BS-classified presentation should resolve to disclosures:BalanceSheet
-    via the structure_type lookup."""
+    via the block_type lookup."""
     session = MagicMock()
     session.get.return_value = _make_structure(
       role_uri="https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-      structure_type="balance_sheet",
+      block_type="balance_sheet",
     )
     # The fallback query selects metadata->>'role_uri' (a string), not the row
     session.execute.return_value.scalar.return_value = (
@@ -95,17 +95,17 @@ class TestStructureTypeFallback:
     assert session.execute.call_count == 1
 
   def test_cache_short_circuits_second_call_with_same_type(self) -> None:
-    """The N+1 fix: 2 envelopes of the same structure_type should issue
+    """The N+1 fix: 2 envelopes of the same block_type should issue
     only 1 fallback query thanks to the module-level cache."""
     session = MagicMock()
     session.get.side_effect = [
       _make_structure(
         role_uri="https://.../IS-multistep",
-        structure_type="income_statement",
+        block_type="income_statement",
       ),
       _make_structure(
         role_uri="https://.../IS-singlestep",
-        structure_type="income_statement",
+        block_type="income_statement",
       ),
     ]
     session.execute.return_value.scalar.return_value = (
@@ -130,11 +130,11 @@ class TestNoMatch:
   def test_target_without_role_uri_returns_none(self) -> None:
     session = MagicMock()
     session.get.return_value = _make_structure(
-      role_uri=None, structure_type="balance_sheet"
+      role_uri=None, block_type="balance_sheet"
     )
     assert load_disclosure_id_for_structure(session, "no_role") is None
 
-  def test_unknown_structure_type_returns_none(
+  def test_unknown_block_type_returns_none(
     self, monkeypatch: pytest.MonkeyPatch
   ) -> None:
     """validation_rules and taxonomy_mapping should resolve to None
@@ -142,7 +142,7 @@ class TestNoMatch:
     session = MagicMock()
     session.get.return_value = _make_structure(
       role_uri="https://.../rs-gaap-calculations/IS-Rev",
-      structure_type="validation_rules",
+      block_type="validation_rules",
     )
     session.execute.return_value.scalar.return_value = None
 
@@ -151,7 +151,7 @@ class TestNoMatch:
     session2 = MagicMock()
     session2.get.return_value = _make_structure(
       role_uri="https://.../rs-gaap-calculations/IS-COR",
-      structure_type="validation_rules",
+      block_type="validation_rules",
     )
     assert load_disclosure_id_for_structure(session2, "struct_calc2") is None
     session2.execute.assert_not_called()

--- a/tests/operations/information_block/test_metric_handlers.py
+++ b/tests/operations/information_block/test_metric_handlers.py
@@ -27,7 +27,7 @@ class TestBuildEnvelope:
   def test_returns_none_when_structure_wrong_type(self) -> None:
     session = MagicMock()
     structure = MagicMock()
-    structure.structure_type = "schedule"
+    structure.block_type = "schedule"
     session.get.return_value = structure
     assert metric_handlers.build_envelope(session, "struct_other") is None
 
@@ -35,13 +35,13 @@ class TestBuildEnvelope:
     session = MagicMock()
     structure = MagicMock()
     structure.id = "struct_metric_1"
-    structure.structure_type = "metric"
+    structure.block_type = "metric"
     structure.name = "Debt-to-Equity Ratio"
     structure.description = "D/E covenant test"
     structure.taxonomy_id = "tax_01"
     structure.concept_arrangement = "arithmetic"
     structure.member_arrangement = None
-    structure.parenthetical_note = None
+    structure.renderer_note = None
     structure.artifact_mechanics = {
       "kind": "metric",
       "source_block_ids": ["struct_bs"],
@@ -74,13 +74,13 @@ class TestBuildEnvelope:
     session = MagicMock()
     structure = MagicMock()
     structure.id = "struct_metric_2"
-    structure.structure_type = "metric"
+    structure.block_type = "metric"
     structure.name = "Gross Margin"
     structure.description = None
     structure.taxonomy_id = "tax_02"
     structure.concept_arrangement = None
     structure.member_arrangement = None
-    structure.parenthetical_note = None
+    structure.renderer_note = None
     structure.artifact_mechanics = None
     session.get.return_value = structure
     session.execute.side_effect = [

--- a/tests/operations/information_block/test_reads.py
+++ b/tests/operations/information_block/test_reads.py
@@ -57,19 +57,19 @@ class TestGetInformationBlock:
     assert get_information_block(session, "struct_missing") is None
 
   def test_unknown_block_type_returns_none(self) -> None:
-    """Structures with a structure_type not yet modeled in the registry
+    """Structures with a block_type not yet modeled in the registry
     (e.g., legacy ``custom`` or ``chart_of_accounts`` rows) return None
     rather than raising — can't build the envelope."""
     session = MagicMock()
     structure = MagicMock()
-    structure.structure_type = "chart_of_accounts"
+    structure.block_type = "chart_of_accounts"
     session.get.return_value = structure
     assert get_information_block(session, "struct_coa") is None
 
   def test_dispatches_to_schedule_handler(self) -> None:
     session = MagicMock()
     structure = MagicMock()
-    structure.structure_type = "schedule"
+    structure.block_type = "schedule"
     session.get.return_value = structure
     expected = _envelope("struct_1")
     mock_build = MagicMock(return_value=expected)
@@ -120,7 +120,7 @@ class TestListInformationBlocks:
     session = MagicMock()
     structure = MagicMock()
     structure.id = "struct_1"
-    structure.structure_type = "schedule"
+    structure.block_type = "schedule"
     session.execute.return_value.scalars.return_value.all.return_value = [structure]
     expected = _envelope("struct_1")
     mock_build = MagicMock(return_value=expected)
@@ -154,15 +154,15 @@ class TestListInformationBlocks:
     session.execute.assert_not_called()
 
   def test_skips_structures_whose_block_type_is_unregistered(self) -> None:
-    """If the DB returns a Structure row whose structure_type is not
+    """If the DB returns a Structure row whose block_type is not
     registered (legacy row, or mid-migration), it's skipped cleanly."""
     session = MagicMock()
     schedule_row = MagicMock()
     schedule_row.id = "struct_s"
-    schedule_row.structure_type = "schedule"
+    schedule_row.block_type = "schedule"
     coa_row = MagicMock()
     coa_row.id = "struct_coa"
-    coa_row.structure_type = "chart_of_accounts"  # not in registry yet
+    coa_row.block_type = "chart_of_accounts"  # not in registry yet
     session.execute.return_value.scalars.return_value.all.return_value = [
       schedule_row,
       coa_row,
@@ -189,7 +189,7 @@ class TestListInformationBlocks:
     session.execute.assert_called_once()
 
   def test_list_surfaces_statement_blocks_on_tenant_graph(self) -> None:
-    """A tenant Structure with ``structure_type='balance_sheet'`` flows
+    """A tenant Structure with ``block_type='balance_sheet'`` flows
     through the statement handler and surfaces its envelope."""
     from robosystems.operations.information_block.registry import (
       BALANCE_SHEET_BLOCK,
@@ -198,7 +198,7 @@ class TestListInformationBlocks:
     session = MagicMock()
     bs_row = MagicMock()
     bs_row.id = "struct_balance_sheet"
-    bs_row.structure_type = "balance_sheet"
+    bs_row.block_type = "balance_sheet"
     session.execute.return_value.scalars.return_value.all.return_value = [bs_row]
 
     expected = InformationBlockEnvelope(
@@ -208,7 +208,7 @@ class TestListInformationBlocks:
       display_name="Balance Sheet",
       category="Reporting",
       information_model=InformationModelResponse(
-        concept_arrangement="roll_up", member_arrangement="aggregation"
+        concept_arrangement="roll_up", member_arrangement="whole_part"
       ),
       artifact=ArtifactResponse(mechanics=StatementMechanics()),
     )
@@ -259,7 +259,7 @@ class TestGetInformationBlockForFactSet:
     fs.id = "fs_01"
     fs.structure_id = "struct_coa"
     structure = MagicMock()
-    structure.structure_type = "chart_of_accounts"
+    structure.block_type = "chart_of_accounts"
     session = self._patched_session(fact_set=fs, structure=structure)
 
     assert get_information_block_for_fact_set(session, "fs_01") is None
@@ -270,7 +270,7 @@ class TestGetInformationBlockForFactSet:
     fs.id = "fs_01"
     fs.structure_id = "struct_1"
     structure = MagicMock()
-    structure.structure_type = "schedule"
+    structure.block_type = "schedule"
     session = self._patched_session(fact_set=fs, structure=structure)
 
     expected = _envelope("struct_1")

--- a/tests/operations/information_block/test_registry.py
+++ b/tests/operations/information_block/test_registry.py
@@ -95,7 +95,7 @@ class TestStatementRegistration:
     assert entry.category == "Reporting"
     assert entry.construction_mode == "compositional"
     assert entry.concept_arrangement_default == "roll_up"
-    assert entry.member_arrangement_default == "aggregation"
+    assert entry.member_arrangement_default == "whole_part"
     assert entry.mechanics_schema is StatementMechanics
     # All four statement block types surface on the library sentinel
     # because their Structures live in public.structures.

--- a/tests/operations/information_block/test_schedule_handlers.py
+++ b/tests/operations/information_block/test_schedule_handlers.py
@@ -112,7 +112,7 @@ class TestBuildEnvelope:
   def test_returns_none_when_structure_wrong_type(self) -> None:
     session = MagicMock()
     structure = MagicMock()
-    structure.structure_type = "balance_sheet"
+    structure.block_type = "balance_sheet"
     session.get.return_value = structure
     assert schedule_handlers.build_envelope(session, "struct_other") is None
 
@@ -126,13 +126,13 @@ class TestBuildEnvelope:
     session = MagicMock()
     structure = MagicMock()
     structure.id = "struct_abc"
-    structure.structure_type = "schedule"
+    structure.block_type = "schedule"
     structure.name = "Equipment Depreciation"
     structure.description = "Depreciation schedule — equipment"
     structure.taxonomy_id = "tax_01"
     structure.concept_arrangement = "roll_forward"
     structure.member_arrangement = None
-    structure.parenthetical_note = None
+    structure.renderer_note = None
     structure.artifact_mechanics = {
       "kind": "closing_entry_generator",
       "entry_template": {
@@ -198,13 +198,13 @@ class TestBuildEnvelope:
     session = MagicMock()
     structure = MagicMock()
     structure.id = "struct_corrupted"
-    structure.structure_type = "schedule"
+    structure.block_type = "schedule"
     structure.name = "Corrupted"
     structure.description = None
     structure.taxonomy_id = "tax_01"
     structure.concept_arrangement = None
     structure.member_arrangement = None
-    structure.parenthetical_note = None
+    structure.renderer_note = None
     structure.artifact_mechanics = None
     structure.metadata_ = {}  # no entry_template key
     session.get.return_value = structure
@@ -231,13 +231,13 @@ class TestBuildEnvelope:
     session = MagicMock()
     structure = MagicMock()
     structure.id = "struct_legacy"
-    structure.structure_type = "schedule"
+    structure.block_type = "schedule"
     structure.name = "Legacy Schedule"
     structure.description = None
     structure.taxonomy_id = "tax_01"
     structure.concept_arrangement = None  # pre-backfill, read default
     structure.member_arrangement = None
-    structure.parenthetical_note = None
+    structure.renderer_note = None
     structure.artifact_mechanics = None
     structure.metadata_ = {
       "entry_template": {
@@ -274,13 +274,13 @@ class TestBuildEnvelope:
     session = MagicMock()
     structure = MagicMock()
     structure.id = "struct_dep"
-    structure.structure_type = "schedule"
+    structure.block_type = "schedule"
     structure.name = "Equipment Depreciation"
     structure.description = None
     structure.taxonomy_id = "tax_01"
     structure.concept_arrangement = "roll_forward"
     structure.member_arrangement = None
-    structure.parenthetical_note = None
+    structure.renderer_note = None
     structure.artifact_mechanics = {
       "kind": "closing_entry_generator",
       "entry_template": {

--- a/tests/operations/information_block/test_statement_handlers.py
+++ b/tests/operations/information_block/test_statement_handlers.py
@@ -50,7 +50,7 @@ def _make_statement_structure(
   taxonomy_id: str = "tax_usgaap",
   artifact_mechanics: dict[str, Any] | None = None,
   concept_arrangement: str | None = "roll_up",
-  member_arrangement: str | None = "aggregation",
+  member_arrangement: str | None = "whole_part",
 ) -> MagicMock:
   """Shape a MagicMock like a Structure row for a statement block.
 
@@ -59,7 +59,7 @@ def _make_statement_structure(
   """
   structure = MagicMock()
   structure.id = structure_id
-  structure.structure_type = block_type
+  structure.block_type = block_type
   structure.name = name
   structure.description = description
   structure.taxonomy_id = taxonomy_id
@@ -70,7 +70,7 @@ def _make_statement_structure(
   )
   structure.concept_arrangement = concept_arrangement
   structure.member_arrangement = member_arrangement
-  structure.parenthetical_note = None
+  structure.renderer_note = None
   return structure
 
 
@@ -145,7 +145,7 @@ class TestBuildEnvelope:
     """A ``schedule`` structure must not surface through the BS handler."""
     session = MagicMock()
     structure = MagicMock()
-    structure.structure_type = "schedule"
+    structure.block_type = "schedule"
     session.get.return_value = structure
     build = statement_handlers.make_statement_handlers("balance_sheet")
     assert build(session, "struct_other") is None
@@ -183,7 +183,7 @@ class TestBuildEnvelope:
     assert envelope.taxonomy_id == "tax_usgaap"
     assert envelope.taxonomy_name == "US GAAP"
     assert envelope.information_model.concept_arrangement == "roll_up"
-    assert envelope.information_model.member_arrangement == "aggregation"
+    assert envelope.information_model.member_arrangement == "whole_part"
     assert envelope.artifact.topic == "Assets + Liabilities + Equity"
     assert envelope.artifact.mechanics.kind == "statement_renderer"
     assert envelope.elements == []

--- a/tests/operations/roboledger/reads/test_reports_package.py
+++ b/tests/operations/roboledger/reads/test_reports_package.py
@@ -4,7 +4,7 @@ Verifies the read path that drives ``/reports/[id]`` in package mode:
 load Report metadata, look up its FactSets via ``fact_sets.report_id``,
 rehydrate each as an ``InformationBlockEnvelope`` via
 ``get_information_block_for_fact_set``, and order items by
-``Structure.structure_type`` (BS → IS → CF → Equity → Schedule).
+``Structure.block_type`` (BS → IS → CF → Equity → Schedule).
 """
 
 from __future__ import annotations
@@ -56,10 +56,10 @@ def _make_fact_set(*, fs_id: str, structure_id: str) -> MagicMock:
   return fs
 
 
-def _make_structure(*, structure_id: str, structure_type: str) -> MagicMock:
+def _make_structure(*, structure_id: str, block_type: str) -> MagicMock:
   s = MagicMock()
   s.id = structure_id
-  s.structure_type = structure_type
+  s.block_type = block_type
   return s
 
 
@@ -93,7 +93,7 @@ def test_returns_none_when_report_missing() -> None:
     assert get_report_package(session, "rpt_missing") is None
 
 
-def test_assembles_items_ordered_by_structure_type() -> None:
+def test_assembles_items_ordered_by_block_type() -> None:
   """IS comes back from the SQL query before BS; the result still puts
   BS (display_order=1) ahead of IS (display_order=2)."""
   session = MagicMock()
@@ -101,10 +101,8 @@ def test_assembles_items_ordered_by_structure_type() -> None:
 
   fs_is = _make_fact_set(fs_id="fs_is", structure_id="struct_is")
   fs_bs = _make_fact_set(fs_id="fs_bs", structure_id="struct_bs")
-  struct_is = _make_structure(
-    structure_id="struct_is", structure_type="income_statement"
-  )
-  struct_bs = _make_structure(structure_id="struct_bs", structure_type="balance_sheet")
+  struct_is = _make_structure(structure_id="struct_is", block_type="income_statement")
+  struct_bs = _make_structure(structure_id="struct_bs", block_type="balance_sheet")
 
   # Return order: IS first, BS second — to prove the read sorts deterministically.
   session.execute.return_value.all.return_value = [
@@ -140,10 +138,8 @@ def test_skips_fact_sets_with_unregistered_block_types() -> None:
 
   fs_known = _make_fact_set(fs_id="fs_bs", structure_id="struct_bs")
   fs_unknown = _make_fact_set(fs_id="fs_x", structure_id="struct_x")
-  struct_bs = _make_structure(structure_id="struct_bs", structure_type="balance_sheet")
-  struct_x = _make_structure(
-    structure_id="struct_x", structure_type="chart_of_accounts"
-  )
+  struct_bs = _make_structure(structure_id="struct_bs", block_type="balance_sheet")
+  struct_x = _make_structure(structure_id="struct_x", block_type="chart_of_accounts")
   session.execute.return_value.all.return_value = [
     (fs_known, struct_bs),
     (fs_unknown, struct_x),
@@ -186,14 +182,14 @@ def test_carries_filing_lifecycle_fields_through() -> None:
   assert pkg.items == []
 
 
-def test_unknown_structure_type_falls_back_to_default_order() -> None:
-  """Custom / future structure_types not in the display-order map land at the
+def test_unknown_block_type_falls_back_to_default_order() -> None:
+  """Custom / future block_types not in the display-order map land at the
   fallback slot (50) — between statements (1-4) and schedules (100)."""
   session = MagicMock()
   session.get.return_value = _make_report_def()
 
   fs = _make_fact_set(fs_id="fs_custom", structure_id="struct_custom")
-  structure = _make_structure(structure_id="struct_custom", structure_type="custom")
+  structure = _make_structure(structure_id="struct_custom", block_type="custom")
   session.execute.return_value.all.return_value = [(fs, structure)]
 
   envelope = _envelope("struct_custom", "custom")

--- a/tests/operations/roboledger/schedules/test_service.py
+++ b/tests/operations/roboledger/schedules/test_service.py
@@ -970,7 +970,7 @@ class TestCreateScheduleMaterializesObligations:
 class TestCreateClosingEntry:
   def _mock_schedule_structure(self):
     struct = MagicMock()
-    struct.structure_type = "schedule"
+    struct.block_type = "schedule"
     struct.name = "Office Furniture Depreciation"
     struct.metadata_ = {
       "entry_template": {
@@ -1000,7 +1000,7 @@ class TestCreateClosingEntry:
   def test_raises_for_missing_template(self):
     session = _mock_session()
     struct = MagicMock()
-    struct.structure_type = "schedule"
+    struct.block_type = "schedule"
     struct.metadata_ = {}
     session.get.return_value = struct
     svc = ScheduleService()
@@ -1386,7 +1386,7 @@ class TestTruncateSchedule:
   def _mock_schedule_structure(self, metadata: dict | None = None):
     struct = MagicMock()
     struct.id = "struct_01"
-    struct.structure_type = "schedule"
+    struct.block_type = "schedule"
     struct.name = "Computer Equipment Depreciation"
     struct.metadata_ = metadata or {
       "entry_template": {

--- a/tests/operations/taxonomy_block/test_auto_rules.py
+++ b/tests/operations/taxonomy_block/test_auto_rules.py
@@ -107,6 +107,22 @@ class TestEmitAutoRules:
     added = [c.args[0] for c in session.add.call_args_list]
     assert all(r.rule_origin == "auto" for r in added)
 
+  def test_all_auto_rules_populate_check_kind_not_pattern(self) -> None:
+    """XOR contract: all auto-rules are structural (rule_check_kind set,
+    rule_pattern is None). See information-block.md §5.2.2 + the
+    check_rule_pattern_kind_xor CHECK constraint on the rules table."""
+    session = MagicMock()
+    taxonomy = _fake_taxonomy("chart_of_accounts", parent_taxonomy_id="lib_1")
+    emit_auto_rules(
+      session,
+      taxonomy,
+      [_fake_structure("s1")],
+      created_by="usr_1",
+    )
+    added = [c.args[0] for c in session.add.call_args_list]
+    assert all(r.rule_pattern is None for r in added)
+    assert all(r.rule_check_kind is not None for r in added)
+
   def test_taxonomy_level_rules_use_taxonomy_target_kind(self) -> None:
     session = MagicMock()
     taxonomy = _fake_taxonomy()

--- a/tests/operations/taxonomy_block/test_auto_rules.py
+++ b/tests/operations/taxonomy_block/test_auto_rules.py
@@ -32,7 +32,7 @@ class TestEmitAutoRules:
     emit_auto_rules(session, taxonomy, [], created_by="usr_1")
 
     added = [c.args[0] for c in session.add.call_args_list]
-    patterns = {r.rule_pattern for r in added}
+    patterns = {r.rule_check_kind for r in added}
     assert patterns == {"UniqueQNameInTaxonomy"}
     session.flush.assert_called_once()
 
@@ -43,7 +43,7 @@ class TestEmitAutoRules:
     emit_auto_rules(session, taxonomy, [s1], created_by="usr_1")
 
     added = [c.args[0] for c in session.add.call_args_list]
-    patterns = {r.rule_pattern for r in added}
+    patterns = {r.rule_check_kind for r in added}
     assert {"NoCycles", "NoOrphanArcs", "ParentBeforeChild"}.issubset(patterns)
 
   def test_two_structures_emit_six_structure_rules(self) -> None:
@@ -65,7 +65,7 @@ class TestEmitAutoRules:
     emit_auto_rules(session, taxonomy, [], created_by="usr_1")
 
     added = [c.args[0] for c in session.add.call_args_list]
-    patterns = {r.rule_pattern for r in added}
+    patterns = {r.rule_check_kind for r in added}
     assert "LeafHasClassification" in patterns
 
   def test_non_coa_does_not_emit_leaf_has_classification(self) -> None:
@@ -74,7 +74,7 @@ class TestEmitAutoRules:
     emit_auto_rules(session, taxonomy, [], created_by="usr_1")
 
     added = [c.args[0] for c in session.add.call_args_list]
-    patterns = {r.rule_pattern for r in added}
+    patterns = {r.rule_check_kind for r in added}
     assert "LeafHasClassification" not in patterns
 
   def test_extend_mode_emits_library_origin_immutability(self) -> None:
@@ -83,7 +83,7 @@ class TestEmitAutoRules:
     emit_auto_rules(session, taxonomy, [], created_by="usr_1")
 
     added = [c.args[0] for c in session.add.call_args_list]
-    patterns = {r.rule_pattern for r in added}
+    patterns = {r.rule_check_kind for r in added}
     assert "LibraryOriginImmutability" in patterns
 
   def test_declarative_mode_does_not_emit_library_origin_immutability(self) -> None:
@@ -92,7 +92,7 @@ class TestEmitAutoRules:
     emit_auto_rules(session, taxonomy, [], created_by="usr_1")
 
     added = [c.args[0] for c in session.add.call_args_list]
-    patterns = {r.rule_pattern for r in added}
+    patterns = {r.rule_check_kind for r in added}
     assert "LibraryOriginImmutability" not in patterns
 
   def test_all_auto_rules_carry_auto_origin(self) -> None:

--- a/tests/operations/taxonomy_block/test_library_creator.py
+++ b/tests/operations/taxonomy_block/test_library_creator.py
@@ -171,7 +171,7 @@ class TestCreateLibraryTaxonomyElements:
     structure = StructureSpec(
       name="Balance Sheet",
       role_uri="http://role/bs",
-      structure_type="balance_sheet",
+      block_type="balance_sheet",
     )
     package = _make_package(structures=[structure])
     _, counts = create_library_taxonomy_elements(session, package)

--- a/tests/operations/taxonomy_block/test_validators.py
+++ b/tests/operations/taxonomy_block/test_validators.py
@@ -99,7 +99,7 @@ class TestUniqueness:
     assert any(i.code == "duplicate_element_qname" for i in issues)
 
   def test_duplicate_structure_name_rejected(self) -> None:
-    s = TaxonomyBlockStructureRequest(name="main", structure_type="chart_of_accounts")
+    s = TaxonomyBlockStructureRequest(name="main", block_type="chart_of_accounts")
     payload = _basic_coa(structures=[s, s.model_copy()])
     issues = validate_create_envelope(payload, _session_empty())
     assert any(i.code == "duplicate_structure_name" for i in issues)
@@ -118,7 +118,7 @@ class TestStructuralIntegrity:
       for n in ("A", "B", "C")
     ]
     structures = [
-      TaxonomyBlockStructureRequest(name="main", structure_type="chart_of_accounts")
+      TaxonomyBlockStructureRequest(name="main", block_type="chart_of_accounts")
     ]
     associations = [
       TaxonomyBlockAssociationRequest(
@@ -159,7 +159,7 @@ class TestStructuralIntegrity:
       for n in ("A", "B", "C")
     ]
     structures = [
-      TaxonomyBlockStructureRequest(name="main", structure_type="chart_of_accounts")
+      TaxonomyBlockStructureRequest(name="main", block_type="chart_of_accounts")
     ]
     associations = [
       TaxonomyBlockAssociationRequest(

--- a/tests/taxonomy/test_canonical_concepts_migration_shape.py
+++ b/tests/taxonomy/test_canonical_concepts_migration_shape.py
@@ -48,10 +48,10 @@ class TestTenantWriterCols:
 
 
 class TestMetricTypeInStructureCheck:
-  def test_metric_is_allowed_structure_type(self) -> None:
+  def test_metric_is_allowed_block_type(self) -> None:
     """The Phase η metric block type must be admissible in the widened
-    structure_type CHECK so tenant Structures can be created with it."""
-    assert "'metric'" in mig_0002._WIDENED_STRUCTURE_TYPE_CHECK
+    block_type CHECK so tenant Structures can be created with it."""
+    assert "'metric'" in mig_0002._WIDENED_BLOCK_TYPE_CHECK
 
   def test_metric_is_allowed_by_runtime_structure_model(self) -> None:
     """Fresh tenant schemas are created from SQLAlchemy metadata, so the
@@ -59,14 +59,14 @@ class TestMetricTypeInStructureCheck:
     checks = [
       c
       for c in Structure.__table__.constraints
-      if isinstance(c, CheckConstraint) and c.name == "check_structure_type"
+      if isinstance(c, CheckConstraint) and c.name == "check_block_type"
     ]
     assert len(checks) == 1
     assert "'metric'" in str(checks[0].sqltext)
 
   def test_fresh_tenant_check_widener_mentions_metric(self) -> None:
     """Provisioning widens checks after metadata create_all; it must not
-    narrow the freshly-created structure_type vocabulary."""
+    narrow the freshly-created block_type vocabulary."""
     statements: list[str] = []
 
     class FakeConn:

--- a/tests/taxonomy/test_disclosures_seed.py
+++ b/tests/taxonomy/test_disclosures_seed.py
@@ -88,15 +88,37 @@ class TestDisclosuresPackage:
     ):
       assert required in qnames, f"Primary statement {required} missing"
 
-  def test_cap_values_use_extended_vocabulary(
+  def test_cap_values_use_canonical_vocabulary(
     self, disclosures: TaxonomyPackage
   ) -> None:
-    """Phase C extends the CAP enum with `component`, `level1_textblock`,
-    and `hierarchy`. Verify those values round-trip from JSON-LD."""
+    """Vocab alignment (2026-05-15) maps the seed CAPs onto Charlie's
+    canonical enumeration. `component` and `hierarchy` collapsed to
+    `set`; `level1_textblock` retained as the cm.xsd specialization.
+    See information-block.md §3.2.1."""
     cap_values = {s.concept_arrangement for s in disclosures.structures}
-    assert "component" in cap_values
+    assert "set" in cap_values
     assert "level1_textblock" in cap_values
-    assert "hierarchy" in cap_values
+    # All values must be in the canonical 15-value CAP enumeration.
+    canonical = {
+      "set",
+      "roll_up",
+      "roll_forward",
+      "roll_forward_info",
+      "adjustment",
+      "variance",
+      "arithmetic",
+      "text_block",
+      "level1_textblock",
+      "level2_textblock",
+      "level3_textblock",
+      "level4_detail",
+      "table_equivalent_textblock",
+      "grid",
+      "compound_fact",
+    }
+    assert cap_values - {None} <= canonical, (
+      f"Non-canonical CAP values in seed: {cap_values - canonical - {None}}"
+    )
 
 
 class TestDisclosureMechanicsPackage:

--- a/tests/taxonomy/test_rs_gaap_calculations_bs_cf.py
+++ b/tests/taxonomy/test_rs_gaap_calculations_bs_cf.py
@@ -47,7 +47,7 @@ class TestBalanceSheetCalcs:
   def test_arithmetic_pattern(self, calculations: TaxonomyPackage) -> None:
     for s in calculations.structures:
       if s.name in self.EXPECTED_NAMES:
-        assert s.structure_type == "validation_rules"
+        assert s.block_type == "validation_rules"
         assert s.concept_arrangement == "arithmetic"
 
   def test_top_level_identity_uses_rs_gaap_subhubs(

--- a/tests/taxonomy/test_rs_gaap_presentation_equity.py
+++ b/tests/taxonomy/test_rs_gaap_presentation_equity.py
@@ -43,9 +43,9 @@ class TestEquityPresentationStructure:
     names = [s.name for s in presentation.structures]
     assert EQUITY_STRUCTURE_NAME in names
 
-  def test_structure_type_and_pattern(self, presentation: TaxonomyPackage) -> None:
+  def test_block_type_and_pattern(self, presentation: TaxonomyPackage) -> None:
     s = next(s for s in presentation.structures if s.name == EQUITY_STRUCTURE_NAME)
-    assert s.structure_type == "equity_statement"
+    assert s.block_type == "equity_statement"
     assert s.concept_arrangement == "roll_forward"
     assert s.role_uri == EQUITY_ROLE_URI
 

--- a/tests/taxonomy/test_seed.py
+++ b/tests/taxonomy/test_seed.py
@@ -196,8 +196,8 @@ class TestStructures:
     # Cash Flow Statement is intentionally not seeded — see seed.py.
     assert len(STRUCTURES) == 2
 
-  def test_structure_types(self):
-    types = {s["structure_type"] for s in STRUCTURES}
+  def test_block_types(self):
+    types = {s["block_type"] for s in STRUCTURES}
     assert types == {"income_statement", "balance_sheet"}
 
   def test_all_reference_taxonomy(self):

--- a/uv.lock
+++ b/uv.lock
@@ -3459,7 +3459,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.32.0,<3.0" },
     { name = "retrying", specifier = ">=1.4.0,<2.0" },
     { name = "rich", marker = "extra == 'dev'", specifier = ">=14.0.0,<15.0" },
-    { name = "robosystems-client", marker = "extra == 'dev'", specifier = "==0.3.26" },
+    { name = "robosystems-client", marker = "extra == 'dev'", specifier = "==0.3.27" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0,<1.0" },
     { name = "sqlalchemy", specifier = ">=2.0.0,<3.0" },
     { name = "sse-starlette", specifier = ">=3.3.0,<4.0" },
@@ -3482,7 +3482,7 @@ lambda = [
 
 [[package]]
 name = "robosystems-client"
-version = "0.3.26"
+version = "0.3.27"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -3491,9 +3491,9 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/de/a1/24f283a22f80cb45b96df7fbc7ea9e7fb927ae3de6457316457b6fdf6221/robosystems_client-0.3.26.tar.gz", hash = "sha256:27642972b1b812d1f9c93009bc823f194423b053151b1f8396be6833b05f6152", size = 378495, upload-time = "2026-05-16T04:45:25.791Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/d2/958138f1bd6076edcad619542350a596f48c32a6024c994c85ca422fde1d/robosystems_client-0.3.27.tar.gz", hash = "sha256:801f2d509497a4a10b04ae47bcfc41e436efacad1090c0f40ab348bc9ceb7e36", size = 379041, upload-time = "2026-05-16T05:04:31.239Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/36/2e/98fc1577ce0822e1b5cf02a04e545d42237192d7c61b2254014cc54f8c33/robosystems_client-0.3.26-py3-none-any.whl", hash = "sha256:e8b9f23efa767a9bdd56631ad51f8230db11ef89e0652ad3b7e297855488ea78", size = 879026, upload-time = "2026-05-16T04:45:23.531Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/53/d611ea220e5806c6db35df01562affbdaccd24212aeea06eee51e361b741/robosystems_client-0.3.27-py3-none-any.whl", hash = "sha256:8ff77f5e446ce5581a7bf40ea862af95b7bb1f40b20a146b8bd5647aa17d2695", size = 879570, upload-time = "2026-05-16T05:04:29.506Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -3459,7 +3459,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.32.0,<3.0" },
     { name = "retrying", specifier = ">=1.4.0,<2.0" },
     { name = "rich", marker = "extra == 'dev'", specifier = ">=14.0.0,<15.0" },
-    { name = "robosystems-client", marker = "extra == 'dev'", specifier = "==0.3.25" },
+    { name = "robosystems-client", marker = "extra == 'dev'", specifier = "==0.3.26" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0,<1.0" },
     { name = "sqlalchemy", specifier = ">=2.0.0,<3.0" },
     { name = "sse-starlette", specifier = ">=3.3.0,<4.0" },
@@ -3482,7 +3482,7 @@ lambda = [
 
 [[package]]
 name = "robosystems-client"
-version = "0.3.25"
+version = "0.3.26"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -3491,9 +3491,9 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/48/db/5fc442fc488655e38e871c4ce328fe2eb13e8e743a86d5c1252943f07c3c/robosystems_client-0.3.25.tar.gz", hash = "sha256:607ef07a3506b2575631c36648826015dcdcf468cf8af8c8c03fbc9f5987de72", size = 378275, upload-time = "2026-05-14T03:00:25.389Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/a1/24f283a22f80cb45b96df7fbc7ea9e7fb927ae3de6457316457b6fdf6221/robosystems_client-0.3.26.tar.gz", hash = "sha256:27642972b1b812d1f9c93009bc823f194423b053151b1f8396be6833b05f6152", size = 378495, upload-time = "2026-05-16T04:45:25.791Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4f/92/83e30e0f4a5fd0e573b6cab1da3d19cfb18d109afb37f13f1d4a575aec5f/robosystems_client-0.3.25-py3-none-any.whl", hash = "sha256:e44fe39c35756e06efb32481f9371ae35594754d101b8ede8e0c4457fbb43b97", size = 878671, upload-time = "2026-05-14T03:00:20.489Z" },
+    { url = "https://files.pythonhosted.org/packages/36/2e/98fc1577ce0822e1b5cf02a04e545d42237192d7c61b2254014cc54f8c33/robosystems_client-0.3.26-py3-none-any.whl", hash = "sha256:e8b9f23efa767a9bdd56631ad51f8230db11ef89e0652ad3b7e297855488ea78", size = 879026, upload-time = "2026-05-16T04:45:23.531Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Large-scale vocabulary alignment refactor that renames `structure_type` to `block_type` across the entire codebase and updates concept arrangement patterns in taxonomy definitions to use canonical terminology. This touches 101 files spanning models, operations, migrations, taxonomy packages, GraphQL types, adapters, and tests.

## Key Accomplishments

### Terminology Alignment: `structure_type` → `block_type`
- Renamed the `structure_type` field/column to `block_type` across all layers of the stack: database models, API models, GraphQL types/resolvers, operations, and test fixtures
- Updated all references in information block, taxonomy block, and library operations
- Migrated database schema definitions and migration scripts to reflect the new column name
- Ensured consistent usage in SEC adapters, QuickBooks pipeline, Arelle context, and MCP middleware tools

### Canonical Vocabulary Updates for Taxonomy Packages
- Updated concept arrangement patterns across all taxonomy JSON-LD packages (FAC, RS-GAAP hierarchy, presentations, calculations, disclosures, reporting styles, bridges, etc.) to align with the canonical vocabulary
- Refined structure models (`robosystems/models/extensions/structure.py`) and rule models with expanded type definitions and updated enum values
- Updated classification models to match the new vocabulary
- Aligned taxonomy seed data and JSON-LD loaders with the revised terminology

### Migration Updates
- Modified initial schema migration (`0001`), taxonomy library migration (`0002`), frameworks/bridges migration (`0007`), and reporting style migration (`0008`) to use `block_type` and updated arrangement patterns
- Updated extension database helpers to match the new schema

## Breaking Changes

- **Database schema change**: `structure_type` column renamed to `block_type` — requires migration execution before deployment
- **API contract change**: Any external consumers referencing `structure_type` in GraphQL queries, API responses, or model serializations will need to update to `block_type`
- **Taxonomy package changes**: Updated arrangement pattern values in JSON-LD taxonomy files may affect downstream taxonomy consumers or cached taxonomy data

## Testing Notes

- All 28 affected test files have been updated to use the new `block_type` terminology
- Tests cover the full scope of changes: information block operations (envelope, metric, statement, schedule, reads, registry, rules), taxonomy block operations (auto rules, library creator, validators), event block handlers, reporting style commands, SEC structure classification, GraphQL extensions, roboledger reports/schedules, and taxonomy seed/presentation/calculation tests
- Verify that migration scripts apply cleanly on existing databases and that no residual `structure_type` references remain

## Infrastructure Considerations

- Database migrations must be run as part of deployment to rename the column and update seeded taxonomy data
- Any cached taxonomy data or materialized views referencing `structure_type` or old arrangement pattern values should be invalidated/rebuilt
- Downstream services or integrations consuming the GraphQL API or taxonomy packages should be coordinated for the vocabulary change

---
🤖 Generated with [Claude Code](https://claude.ai/code)

**Branch Info:**
- Source: `refactor/info-block-alignment`
- Target: `main`
- Type: refactor

Co-Authored-By: Claude <noreply@anthropic.com>