### PR TITLE
feat: Add Seattle Method demo with end-to-end reconciliation pipeline

### DIFF
--- a/examples/seattle_method_demo/README.md
+++ b/examples/seattle_method_demo/README.md
@@ -64,7 +64,8 @@ introduced by the reconciliation. They become part of the report's
 | JE | Issue |
 |---|---|
 | **JE-205** | Description "Payment for contractor"; TDC on the AP line is `mini:PurchasesInventoryForSaleOnAccount` — but contractor services aren't inventory. Vocabulary misuse. |
-| **JE-225** | Nil-amount placeholder (`Amount = 0` on both lines) — likely a boundary test for nil handling. |
+| **JE-209** | TDC `mini:PaymentOfInterest` on the Cash line was a typo — mini.xsd's canonical concept is `mini:PaymentInterest` (no "Of"). Fixed at source in `fixtures/transactions.csv`; note that the sibling concept `mini:DecreaseFromPaymentOfInterest` on the AccruedExpenses line *does* keep the "Of" (Charlie's own naming is internally inconsistent). |
+| **JE-225** | Boundary test case: "Write off of PPE" with `Amount = 0` on both lines — an entry with no economic substance. Our GL handler correctly rejects it (`must have non-zero D or C`); Charlie's system likely creates $0 facts. The reconciliation delta is $0 either way (no economic activity to attribute), so the four anchor totals are unaffected. Classified as **Methodology gap** (neither side has a bug — both correctly handle a nil entry under their respective semantics). |
 | **JE-226** | Income tax accrual ($400). TDC on the AccruedExpenses line is `mini:InterestAccrued` — should be `IncomeTaxAccrued`. Copy-paste-style bug from the JE-210 interest accrual pattern. |
 
 ## Methodology

--- a/examples/seattle_method_demo/README.md
+++ b/examples/seattle_method_demo/README.md
@@ -34,7 +34,10 @@ just demo-seattle-method --step load
 just demo-seattle-method --step seed-mappings
 just demo-seattle-method --step ingest
 just demo-seattle-method --step author-rollforwards
-just demo-seattle-method --step reconcile
+
+# Reconcile (not a --step of the orchestrator; runs separately
+# because it consumes the graph the orchestrator just built).
+just demo-seattle-method-reconcile <graph_id>
 ```
 
 ## What Gets Created

--- a/examples/seattle_method_demo/README.md
+++ b/examples/seattle_method_demo/README.md
@@ -1,0 +1,100 @@
+# Seattle Method Cross-Taxonomy Demo
+
+End-to-end exercise of the **cross-taxonomy projection** methodology
+(Test Case 1 in [`METHODOLOGY.md`](METHODOLOGY.md)) using
+Charlie Hoffman's *Seattle Method* `mini` reporting framework and his
+published 14-transaction Q1 2024 lemonade-stand dataset.
+
+The demo proves that the RoboSystems three-block architecture
+(TaxonomyBlock + EventBlock + InformationBlock) can ingest an external
+XBRL reporting taxonomy, ingest transactions tagged with that
+taxonomy's flow concepts, decompose period changes via filter-based
+attribution (the `rollforward` block-type, Phase 2 MVP), and render
+the result in both the source vocabulary AND our canonical `rs-gaap`
+vocabulary from the same fact set.
+
+The reconciliation report — comparing our output to Charlie's
+expected output at
+[`luca.pacioli.ai/luca/view/0f24fd35…`](https://luca.pacioli.ai/luca/view/0f24fd35e961e167a727b663c75a4c5ec9fb7eb86730d6292f46e6e180fc2018980cd52e/index) —
+is the primary external-facing artifact.
+
+## Quick Start
+
+```bash
+# Make sure the stack is running
+just start
+
+# Run the demo end-to-end (provisions test graph, pulls mini, ingests
+# the 14 JEs, authors rollforwards, renders, reconciles)
+just demo-seattle-method
+
+# Or run a single step
+just demo-seattle-method --step pull
+just demo-seattle-method --step load
+just demo-seattle-method --step seed-mappings
+just demo-seattle-method --step ingest
+just demo-seattle-method --step author-rollforwards
+just demo-seattle-method --step reconcile
+```
+
+## What Gets Created
+
+| Step | Artifact |
+|---|---|
+| `pull` | `local/taxonomies/mini/` — 30 XBRL artifacts curled from `xbrlsite.azurewebsites.net` (gitignored — re-fetched on demand) |
+| `provision` | A dedicated test graph (e.g. `kg_seattle_method_<timestamp>`) — isolated from real customer data |
+| `load` | 239 mini concepts as Elements + presentation/calculation/definition/formula linkbase arcs as Associations |
+| `seed-mappings` | ~36 mini→rs-gaap derivation Associations (BS/IS/CF/SE leaves touched by the 14-JE dataset) |
+| `ingest` | 14 Events (one per JournalEntryID), 14 Entries, ~32 LineItems — each LineItem.metadata_['transaction_description_code'] stamped from CSV |
+| `author-rollforwards` | 8 rollforward IBs (one per BS leaf with activity) — Cash, Receivables, Inventories, PP&E, AP, Accrued, LTD, PaidInCapital |
+| `reconcile` | `local/reports/seattle-method-case-1.md` — line-by-line comparison of our output vs. Charlie's PoC, classified per the methodology spec §3.2 |
+
+## Fixtures
+
+- **`fixtures/transactions.csv`** — Charlie's 14-JE lemonade-stand dataset (JE-201 through JE-226, Q1 2024, single entity). Committed; sourced from Charlie Hoffman directly on 2026-05-19.
+
+The mini taxonomy artifacts themselves are NOT committed — `pull_mini.sh` fetches them on demand from `xbrlsite.azurewebsites.net` into `local/taxonomies/mini/` (gitignored). This keeps the repo small and lets us pick up upstream taxonomy changes without re-vendoring.
+
+## Known Data-Quality Findings (Pre-Reconciliation)
+
+These are identified during input review on 2026-05-19, NOT
+introduced by the reconciliation. They become part of the report's
+"Their data quality" section per the methodology classification.
+
+| JE | Issue |
+|---|---|
+| **JE-205** | Description "Payment for contractor"; TDC on the AP line is `mini:PurchasesInventoryForSaleOnAccount` — but contractor services aren't inventory. Vocabulary misuse. |
+| **JE-225** | Nil-amount placeholder (`Amount = 0` on both lines) — likely a boundary test for nil handling. |
+| **JE-226** | Income tax accrual ($400). TDC on the AccruedExpenses line is `mini:InterestAccrued` — should be `IncomeTaxAccrued`. Copy-paste-style bug from the JE-210 interest accrual pattern. |
+
+## Methodology
+
+See [`METHODOLOGY.md`](METHODOLOGY.md) for the full methodology spec —
+the 5-step pipeline, reconciliation report format, finding
+classification rubric (matching / methodology gap / our bug / their
+data quality), and forward queue of future test cases.
+
+## Architectural Dependencies
+
+- **Phase 2 MVP rollforward block-type** — `block_type='rollforward'`,
+  `RollforwardMechanics` Pydantic, single-predicate filter engine
+  (`line_item_metadata_field`). See
+  `robosystems/operations/information_block/rollforward.py` and
+  `robosystems/operations/roboledger/reports/rollforward_filters.py`.
+- **Per-line metadata plumbing** —
+  `JournalEntryLineItemInput.metadata` flows through to
+  `LineItem.metadata_`, where the filter engine reads it.
+- **TaxonomyBlock + Element + Association infrastructure** — used as-is
+  (this demo authors per-tenant, not library-scoped).
+
+## Out of Scope
+
+- Phase 2.5 enrichment engine (the rules + Operator + manual layer
+  that populates `LineItem.metadata_['transaction_description_code']`
+  for legacy QB data without flow tags). Charlie's data ships with
+  flow tags pre-stamped; we use them as-is. For real QB data the
+  enrichment layer is the load-bearing piece.
+- Manual attribution (Tier 3) — this dataset is fully
+  transaction-attributable.
+- Test Cases 1.1 (1-transaction), 1.2 (22k-transaction), 2 (SEC us-gaap),
+  3 (IFRS), 4 (FDTA) — queued in [`METHODOLOGY.md`](METHODOLOGY.md) §5.

--- a/examples/seattle_method_demo/author_rollforwards.py
+++ b/examples/seattle_method_demo/author_rollforwards.py
@@ -71,43 +71,6 @@ def _get_ledger_client():
   )
 
 
-def _post_operation_raw(graph_id: str, op_name: str, payload: dict) -> dict:
-  """POST directly to the extensions operation endpoint via httpx.
-
-  Bypasses the typed SDK because ``rollforward`` was added to the
-  ``CreateInformationBlockRequest`` discriminated union AFTER the SDK
-  was last regenerated — the SDK still only knows ``CreateLegacyArm``
-  and ``CreateScheduleArm`` as valid body types. The operation
-  endpoint itself accepts JSON dicts and validates against the
-  current server-side Pydantic model, so we can author rollforward
-  IBs without an SDK regenerate.
-
-  TODO: drop this helper and call
-  ``client.create_information_block()`` once the SDK is regenerated
-  to include ``CreateRollforwardArm``.
-  """
-  import httpx
-
-  config_path = Path(".local/config.json")
-  with config_path.open() as f:
-    cfg = json.load(f)
-  base_url = cfg.get("base_url", "http://localhost:8000")
-  api_key = cfg["api_key"]
-
-  url = f"{base_url}/extensions/roboledger/{graph_id}/operations/{op_name}"
-  response = httpx.post(
-    url,
-    json=payload,
-    headers={"X-API-Key": api_key, "Content-Type": "application/json"},
-    timeout=30.0,
-  )
-  if response.status_code >= 400:
-    raise RuntimeError(
-      f"POST {op_name} → {response.status_code}: {response.text[:500]}"
-    )
-  return response.json()
-
-
 def _find_mini_taxonomy_id(client, graph_id: str) -> str | None:
   """Find the mini CoA taxonomy_id on the graph by name."""
   taxonomies = client.list_taxonomies(graph_id) or []
@@ -172,38 +135,52 @@ def _collect_tdcs_per_bs_leaf(csv_path: Path) -> dict[str, list[str]]:
   return dict(tdcs_per_account)
 
 
-def _build_rollforward_payload(
-  bs_qname: str, tdcs: list[str]
-) -> dict:
-  """Build the ``create-information-block`` payload for one rollforward.
+def _build_rollforward_arm(bs_qname: str, tdcs: list[str]):
+  """Build a typed ``CreateRollforwardArm`` for one rollforward IB.
 
   No ``default_change_tag_qname`` — Charlie's TDCs cover every line,
   so the residual should be zero. If a residual appears at render
   time, ``validation_mode='residual_as_default'`` (the default) will
   surface it as a synthetic ``#residual`` fact, which becomes the
   signal of an untagged JE — a useful audit artifact.
+
+  Uses the typed SDK models (``CreateRollforwardArm``,
+  ``CreateRollforwardRequest``, ``AttributionFilter``,
+  ``LineItemMetadataPredicate``) shipped in
+  ``robosystems-client==0.3.30+``. Replaces the prior raw-dict
+  payload that went through ``httpx`` to bypass the SDK; the SDK
+  now has the typed arm available via ``client.create_information_block``.
   """
+  # Lazy imports — the SDK module is heavy and the script may dry-run.
+  from robosystems_client.models.attribution_filter import AttributionFilter
+  from robosystems_client.models.create_rollforward_arm import CreateRollforwardArm
+  from robosystems_client.models.create_rollforward_request import (
+    CreateRollforwardRequest,
+  )
+  from robosystems_client.models.line_item_metadata_predicate import (
+    LineItemMetadataPredicate,
+  )
+
   short = bs_qname.removeprefix("mini:")
-  return {
-    "block_type": "rollforward",
-    "payload": {
-      "name": f"{short} Rollforward (Seattle Method Test Case 1)",
-      "bs_source_qname": bs_qname,
-      "default_change_tag_qname": None,
-      "attribution_filters": [
-        {
-          "target_qname": tdc,
-          "predicate": {
-            "kind": "line_item_metadata_field",
-            "field": "transaction_description_code",
-            "values": [tdc],
-          },
-        }
-        for tdc in tdcs
-      ],
-      "validation_mode": "residual_as_default",
-    },
-  }
+  filters = [
+    AttributionFilter(
+      target_qname=tdc,
+      predicate=LineItemMetadataPredicate(
+        field="transaction_description_code",
+        values=[tdc],
+      ),
+    )
+    for tdc in tdcs
+  ]
+  payload = CreateRollforwardRequest(
+    name=f"{short} Rollforward (Seattle Method Test Case 1)",
+    bs_source_qname=bs_qname,
+    attribution_filters=filters,
+  )
+  return CreateRollforwardArm(
+    block_type="rollforward",
+    payload=payload,
+  )
 
 
 def author_rollforwards(
@@ -254,19 +231,16 @@ def author_rollforwards(
     if valid:
       filtered_per_account[bs_qname] = valid
 
-  # Bypass the typed SDK — see _post_operation_raw docstring.
+  # Typed SDK call — robosystems-client>=0.3.30 ships
+  # ``LedgerClient.create_information_block`` which accepts the
+  # discriminated-union arm directly. No raw httpx shim needed.
   created = 0
   for bs_qname, tdcs in filtered_per_account.items():
-    payload = _build_rollforward_payload(bs_qname, tdcs)
+    body = _build_rollforward_arm(bs_qname, tdcs)
     try:
-      response = _post_operation_raw(
-        graph_id, "create-information-block", payload
-      )
-      # OperationEnvelope shape: {result: {...envelope...}, operation_id, status}
-      envelope = response.get("result") or response
-      ib_id = envelope.get("id", "?")
+      envelope = client.create_information_block(graph_id, body)
       created += 1
-      print(f"  ✓ {bs_qname:<40} → IB {ib_id} ({len(tdcs)} filters)")
+      print(f"  ✓ {bs_qname:<40} → IB {envelope.id} ({len(tdcs)} filters)")
     except Exception as exc:  # noqa: BLE001
       warnings.append(f"{bs_qname}: {exc}")
       print(f"  ✗ {bs_qname}: {exc}")

--- a/examples/seattle_method_demo/author_rollforwards.py
+++ b/examples/seattle_method_demo/author_rollforwards.py
@@ -39,7 +39,11 @@ import json
 from collections import defaultdict
 from pathlib import Path
 
-CSV_PATH = Path("examples/seattle_method_demo/fixtures/transactions.csv")
+# Resolve relative to this file so the script works regardless of the
+# caller's CWD — matches the pattern ``main.py`` uses.
+CSV_PATH = (
+  Path(__file__).resolve().parent / "fixtures" / "transactions.csv"
+)
 
 # The eight balance-sheet leaves in mini that have activity in Charlie's
 # 14-JE dataset. Each gets its own rollforward IB.

--- a/examples/seattle_method_demo/author_rollforwards.py
+++ b/examples/seattle_method_demo/author_rollforwards.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""Author rollforward IBs for every BS leaf with activity.
+
+Reads ``fixtures/transactions.csv``, groups LineItems by BS-leaf
+account, derives the unique ``TransactionDescriptionCode`` set per
+account, and creates one ``block_type='rollforward'`` IB per BS leaf
+via ``create-information-block``. Each filter targets the
+corresponding mini flow concept.
+
+Pre-condition: ``load_taxonomy.py``, ``seed_mappings.py``, and
+``ingest_transactions.py`` have all run against this graph.
+
+Why auto-derive instead of hardcoding the §4.4 table:
+
+- Filter values stay in lockstep with the actual data. If Charlie's
+  CSV gains/loses a TDC, the rollforwards re-derive correctly on
+  the next run.
+- Future cross-taxonomy test cases (us-gaap, IFRS) reuse the same
+  pattern by pointing at a different CSV.
+- The §4.4 table in ``cross-taxonomy-projection.md`` becomes the
+  *expected* output, which the dry-run prints for review.
+
+The eight BS leaves (instant period_type, monetary, balance-bearing)
+in Charlie's dataset are listed in ``BS_LEAVES`` — hardcoded because
+the loader currently doesn't expose period_type via the LedgerClient
+list_elements endpoint. When that surfaces, this can become a
+dynamic query.
+
+Usage:
+    uv run python -m examples.seattle_method_demo.author_rollforwards <graph_id>
+    uv run python -m examples.seattle_method_demo.author_rollforwards <graph_id> --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from collections import defaultdict
+from pathlib import Path
+
+CSV_PATH = Path("examples/seattle_method_demo/fixtures/transactions.csv")
+
+# The eight balance-sheet leaves in mini that have activity in Charlie's
+# 14-JE dataset. Each gets its own rollforward IB.
+BS_LEAVES: tuple[str, ...] = (
+  "mini:CashAndCashEquivalents",
+  "mini:Receivables",
+  "mini:Inventories",
+  "mini:PropertyPlantAndEquipment",
+  "mini:AccountsPayable",
+  "mini:AccruedExpenses",
+  "mini:LongtermDebt",
+  "mini:PaidInCapital",
+)
+
+
+def _get_ledger_client():
+  from robosystems_client.clients.ledger_client import LedgerClient
+
+  config_path = Path(".local/config.json")
+  if not config_path.exists():
+    raise SystemExit("Missing .local/config.json — run `just demo-user` first.")
+  with config_path.open() as f:
+    cfg = json.load(f)
+  return LedgerClient(
+    {
+      "base_url": cfg.get("base_url", "http://localhost:8000"),
+      "token": cfg["api_key"],
+    }
+  )
+
+
+def _post_operation_raw(graph_id: str, op_name: str, payload: dict) -> dict:
+  """POST directly to the extensions operation endpoint via httpx.
+
+  Bypasses the typed SDK because ``rollforward`` was added to the
+  ``CreateInformationBlockRequest`` discriminated union AFTER the SDK
+  was last regenerated — the SDK still only knows ``CreateLegacyArm``
+  and ``CreateScheduleArm`` as valid body types. The operation
+  endpoint itself accepts JSON dicts and validates against the
+  current server-side Pydantic model, so we can author rollforward
+  IBs without an SDK regenerate.
+
+  TODO: drop this helper and call
+  ``client.create_information_block()`` once the SDK is regenerated
+  to include ``CreateRollforwardArm``.
+  """
+  import httpx
+
+  config_path = Path(".local/config.json")
+  with config_path.open() as f:
+    cfg = json.load(f)
+  base_url = cfg.get("base_url", "http://localhost:8000")
+  api_key = cfg["api_key"]
+
+  url = f"{base_url}/extensions/roboledger/{graph_id}/operations/{op_name}"
+  response = httpx.post(
+    url,
+    json=payload,
+    headers={"X-API-Key": api_key, "Content-Type": "application/json"},
+    timeout=30.0,
+  )
+  if response.status_code >= 400:
+    raise RuntimeError(
+      f"POST {op_name} → {response.status_code}: {response.text[:500]}"
+    )
+  return response.json()
+
+
+def _find_mini_taxonomy_id(client, graph_id: str) -> str | None:
+  """Find the mini CoA taxonomy_id on the graph by name."""
+  taxonomies = client.list_taxonomies(graph_id) or []
+  for tax in taxonomies:
+    if "mini" in (tax.get("name") or "").lower():
+      return tax.get("id")
+  return None
+
+
+def _build_known_mini_qname_set(client, graph_id: str) -> set[str]:
+  """List every mini Element qname on the graph (by taxonomy_id).
+
+  Used to pre-filter rollforward target qnames — phantom TDCs that
+  appear in the source CSV but not in mini.xsd would crash the
+  create handler. Pre-filtering drops them with a warning instead.
+
+  Mini elements get ``source='native'`` (CHECK constraint), so we
+  scope by ``taxonomy_id`` instead of ``source``.
+  """
+  taxonomy_id = _find_mini_taxonomy_id(client, graph_id)
+  if not taxonomy_id:
+    raise SystemExit(
+      "No mini CoA taxonomy found on this graph. Did load_taxonomy.py run?"
+    )
+  known: set[str] = set()
+  offset = 0
+  page_size = 1000
+  while True:
+    page = client.list_elements(
+      graph_id, taxonomy_id=taxonomy_id, limit=page_size, offset=offset
+    )
+    items = (page or {}).get("elements", [])
+    if not items:
+      break
+    for e in items:
+      if e.get("qname"):
+        known.add(e["qname"])
+    if len(items) < page_size:
+      break
+    offset += page_size
+  return known
+
+
+def _collect_tdcs_per_bs_leaf(csv_path: Path) -> dict[str, list[str]]:
+  """Return ``{bs_qname: [unique_tdc_qnames_in_csv_order]}``.
+
+  Walks the CSV and records each (account, TDC) pair. Insertion order
+  is preserved so the rollforward filters appear in the same order
+  they'd be listed in a hand-authored §4.4 table — which is the order
+  they first show up in Charlie's transaction stream.
+  """
+  tdcs_per_account: dict[str, list[str]] = defaultdict(list)
+  seen: dict[str, set[str]] = defaultdict(set)
+  with csv_path.open(encoding="utf-8-sig") as f:
+    reader = csv.DictReader(f)
+    for row in reader:
+      account = row["GeneralLedgerAccountCode"]
+      tdc = row["TransactionDescriptionCode"]
+      if account in BS_LEAVES and tdc and tdc not in seen[account]:
+        tdcs_per_account[account].append(tdc)
+        seen[account].add(tdc)
+  return dict(tdcs_per_account)
+
+
+def _build_rollforward_payload(
+  bs_qname: str, tdcs: list[str]
+) -> dict:
+  """Build the ``create-information-block`` payload for one rollforward.
+
+  No ``default_change_tag_qname`` — Charlie's TDCs cover every line,
+  so the residual should be zero. If a residual appears at render
+  time, ``validation_mode='residual_as_default'`` (the default) will
+  surface it as a synthetic ``#residual`` fact, which becomes the
+  signal of an untagged JE — a useful audit artifact.
+  """
+  short = bs_qname.removeprefix("mini:")
+  return {
+    "block_type": "rollforward",
+    "payload": {
+      "name": f"{short} Rollforward (Seattle Method Test Case 1)",
+      "bs_source_qname": bs_qname,
+      "default_change_tag_qname": None,
+      "attribution_filters": [
+        {
+          "target_qname": tdc,
+          "predicate": {
+            "kind": "line_item_metadata_field",
+            "field": "transaction_description_code",
+            "values": [tdc],
+          },
+        }
+        for tdc in tdcs
+      ],
+      "validation_mode": "residual_as_default",
+    },
+  }
+
+
+def author_rollforwards(
+  graph_id: str, csv_path: Path = CSV_PATH, dry_run: bool = False
+) -> tuple[int, list[str]]:
+  """Walk the BS leaves and create one rollforward IB each.
+
+  Returns ``(created_count, warnings)``.
+  """
+  tdcs_per_account = _collect_tdcs_per_bs_leaf(csv_path)
+
+  print(
+    f"Derived filter sets from {csv_path.name} — "
+    f"{len(tdcs_per_account)}/{len(BS_LEAVES)} BS leaves have activity:"
+  )
+  for bs in BS_LEAVES:
+    tdcs = tdcs_per_account.get(bs, [])
+    short = bs.removeprefix("mini:")
+    print(f"  {short:<35} {len(tdcs)} filter(s)")
+    for tdc in tdcs:
+      print(f"    → {tdc}")
+
+  if dry_run:
+    print(f"\nDry run — would create {len(tdcs_per_account)} rollforward IB(s).")
+    return len(tdcs_per_account), []
+
+  # Pre-filter: drop target qnames that don't resolve to a loaded
+  # mini Element on this graph. Charlie's CSV contains at least one
+  # phantom TDC (``mini:PaymentOfInterest`` — present in his data
+  # but absent from mini.xsd); the create handler would crash on it,
+  # so we drop with a warning and let the reconciliation report's
+  # "Their data quality" section consume the finding.
+  client = _get_ledger_client()
+  known_qnames = _build_known_mini_qname_set(client, graph_id)
+
+  warnings: list[str] = []
+  filtered_per_account: dict[str, list[str]] = {}
+  for bs_qname, tdcs in tdcs_per_account.items():
+    valid = [t for t in tdcs if t in known_qnames]
+    dropped = [t for t in tdcs if t not in known_qnames]
+    for d in dropped:
+      msg = (
+        f"phantom TDC {d!r} on {bs_qname}: in CSV but not in loaded "
+        f"mini taxonomy — dropping from filter list"
+      )
+      warnings.append(msg)
+      print(f"  ⚠️  {msg}")
+    if valid:
+      filtered_per_account[bs_qname] = valid
+
+  # Bypass the typed SDK — see _post_operation_raw docstring.
+  created = 0
+  for bs_qname, tdcs in filtered_per_account.items():
+    payload = _build_rollforward_payload(bs_qname, tdcs)
+    try:
+      response = _post_operation_raw(
+        graph_id, "create-information-block", payload
+      )
+      # OperationEnvelope shape: {result: {...envelope...}, operation_id, status}
+      envelope = response.get("result") or response
+      ib_id = envelope.get("id", "?")
+      created += 1
+      print(f"  ✓ {bs_qname:<40} → IB {ib_id} ({len(tdcs)} filters)")
+    except Exception as exc:  # noqa: BLE001
+      warnings.append(f"{bs_qname}: {exc}")
+      print(f"  ✗ {bs_qname}: {exc}")
+
+  return created, warnings
+
+
+def main() -> None:
+  parser = argparse.ArgumentParser(
+    description="Author rollforward IBs for the 8 BS leaves with activity.",
+  )
+  parser.add_argument("graph_id", help="Target graph id.")
+  parser.add_argument(
+    "--csv",
+    type=Path,
+    default=CSV_PATH,
+    help="Path to the transactions CSV.",
+  )
+  parser.add_argument(
+    "--dry-run",
+    action="store_true",
+    help="Print the filter sets that would be created; do not call the API.",
+  )
+  args = parser.parse_args()
+
+  created, warnings = author_rollforwards(args.graph_id, args.csv, dry_run=args.dry_run)
+
+  if warnings:
+    print(f"\n{len(warnings)} IB creation(s) failed:")
+    for w in warnings:
+      print(f"  ⚠️  {w}")
+
+  action = "Would create" if args.dry_run else "Created"
+  print(f"\n{action} {created} rollforward IB(s).")
+
+
+if __name__ == "__main__":
+  main()

--- a/examples/seattle_method_demo/fixtures/expected_facts_mini.csv
+++ b/examples/seattle_method_demo/fixtures/expected_facts_mini.csv
@@ -1,0 +1,795 @@
+﻿ReportingEntityAspect,CalendarPeriodAspect,Concept,FactValue,Units,Rounding,FactID,Sequence
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryAmount,0,iso4217:USD,INF,FACT066cec9f,7
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,mini:CashAndCashEquivalents,10850,iso4217:USD,INF,FACTede45aa0,1
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,mini:Receivables,0,iso4217:USD,INF,FACT368ed40a,2
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,mini:PropertyPlantAndEquipment,900,iso4217:USD,INF,FACT95d65830,4
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,mini:Inventories,2700,iso4217:USD,INF,FACT57459f21,3
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,mini:AccountsPayable,1000,iso4217:USD,INF,FACT2d3b5016,5
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,mini:AccruedExpenses,400,iso4217:USD,INF,FACT491741e2,6
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,mini:LongtermDebt,1000,iso4217:USD,INF,FACTf1fa49c4,7
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,mini:PropertyPlantAndEquipment,0,iso4217:USD,INF,FACT8080a2d1,13
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,mini:RetainedEarnings,2050,iso4217:USD,INF,FACT22a5a2b6,9
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,mini:LongtermDebt,0,iso4217:USD,INF,FACT37f35857,16
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,mini:Receivables,0,iso4217:USD,INF,FACT5c41bb03,11
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,mini:CheckSum,0,iso4217:USD,INF,FACTe4acb325,10
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,mini:PaidInCapital,10000,iso4217:USD,INF,FACT9a48aa90,8
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,mini:AccountsPayable,0,iso4217:USD,INF,FACTeb324185,14
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,mini:Inventories,0,iso4217:USD,INF,FACT386daaf7,12
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,mini:AccruedExpenses,0,iso4217:USD,INF,FACTec99d6fd,15
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,mini:CashAndCashEquivalents,0,iso4217:USD,INF,FACT4a260018,19
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:ProceedsFromAdditionalLongtermBorrowings,2000,iso4217:USD,INF,FACT421365c0,22
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,mini:PaidInCapital,0,iso4217:USD,INF,FACT8f1e5071,17
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,mini:CheckSum,0,iso4217:USD,INF,FACT914c8eb2,20
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,mini:RetainedEarnings,0,iso4217:USD,INF,FACT4d8d9760,18
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:NetIncomeLoss,2050,iso4217:USD,INF,FACTfafe6de6,23
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:DistributionsToOwner,0,iso4217:USD,INF,FACTb6effbaf,26
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:ProceedsFromCollectionOfReceivables,8000,iso4217:USD,INF,FACT29a18694,21
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:InvestmentsByOwner,10000,iso4217:USD,INF,FACT263f7434,25
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:ProceedsFromInvestmentsByOwner,10000,iso4217:USD,INF,FACT47f43f1f,24
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:IncreaseInReceivablesFromSalesOnAccount,8000,iso4217:USD,INF,FACT0e02f389,27
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:PaymentForCapitalAdditionsOfPropertyPlantEquipment,1000,iso4217:USD,INF,FACT68044f06,34
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:CollectionOfReceivables,8000,iso4217:USD,INF,FACTd0e94720,35
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:BadDebtsWrittenOff,0,iso4217:USD,INF,FACTaa978817,37
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:PaymentForReductionOfLongtermBorrowings,1000,iso4217:USD,INF,FACTb36ec1ac,33
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:AdditionsToAllowanceForBadDebts,0,iso4217:USD,INF,FACT127a8031,36
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:PaymentOfAccountsPayable,7000,iso4217:USD,INF,FACTb4c556d4,32
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:DecreaseFromPaymentOfInterest,150,iso4217:USD,INF,FACTdf77b580,31
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:InterestAccrued,550,iso4217:USD,INF,FACT679abda6,30
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:PurchasesOfInventoryForSale,5000,iso4217:USD,INF,FACT6a2ee27d,28
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:CapitalAdditionsPropertyPlantAndEquipment,1000,iso4217:USD,INF,FACT6d857505,29
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:PurchasesInventoryForSaleOnAccount,8000,iso4217:USD,INF,FACTbbe16b8a,46
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:DecreaseInInventoriesFromSales,2000,iso4217:USD,INF,FACT179ddaee,38
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:InventoryWrittenOff,300,iso4217:USD,INF,FACTc9100e9b,39
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:PropertyPlantAndEquipmentWrittenOff,0,iso4217:USD,INF,FACT1a4fe5e9,41
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:DecreaseFromPaymentAccountsPayable,7000,iso4217:USD,INF,FACTb47f992a,42
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:PaymentForDistributionsToOwner,0,iso4217:USD,INF,FACT68be80f8,44
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:DecreaseFromDepreciationAndAmortization,100,iso4217:USD,INF,FACTc4c2319c,40
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:RepaymentLongtermBorrowings,1000,iso4217:USD,INF,FACT6af24d5f,43
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:AdditionalLongtermBorrowings,2000,iso4217:USD,INF,FACTbc4afcf2,47
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:PaymentInterest,150,iso4217:USD,INF,FACTb633548d,45
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:CheckSumChanges,0,iso4217:USD,INF,FACT67207258,48
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:Sales,8000,iso4217:USD,INF,FACTb9ada62d,49
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:OperatingExpenses,100,iso4217:USD,INF,FACT108c8268,57
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:IncomeTaxExpenseBenefit,400,iso4217:USD,INF,FACTcc4d9bba,55
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:SalesGeneralAndAdministrativeExpenses,0,iso4217:USD,INF,FACT1af52a17,51
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:CostsOfSales,5300,iso4217:USD,INF,FACTaa437c6b,50
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:InterestExpense,150,iso4217:USD,INF,FACTc63433c5,53
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:GrossProfitLoss,2700,iso4217:USD,INF,FACT791c9719,56
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:DepreciationAndAmortization,100,iso4217:USD,INF,FACT768265b9,52
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:GainLossOnSalePropertyPlantEquipment,0,iso4217:USD,INF,FACTa5dd8ecb,54
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:OperatingIncomeLoss,2600,iso4217:USD,INF,FACTe63cd1a0,58
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:IncomeLossFromContinuingOperationsBeforeTax,2450,iso4217:USD,INF,FACT3afdc872,60
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:IncreasesDecreasesFromTransfersFromLongterm,0,iso4217:USD,INF,FACT54a02aa7,65
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,mini:CashEquivalents,0,iso4217:USD,INF,FACTdb4f8f74,602
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,mini:CurrentPortionOfLongtermDebt,0,iso4217:USD,INF,FACT374997a9,62
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,mini:CurrentPortionOfLongtermDebt,0,iso4217:USD,INF,FACT3d565f0a,61
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:NonoperatingIncomeExpenses,-150,iso4217:USD,INF,FACT38b105d5,59
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:PaymentOfDividends,0,iso4217:USD,INF,FACT530bbddf,64
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:Dividends,0,iso4217:USD,INF,FACT30e200d1,63
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,mini:TradeReceivables,0,iso4217:USD,INF,FACT6bf9d908,603
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:IncreasesDecreasesFromTransfersFromCurrentPortion,0,iso4217:USD,INF,FACT8fcaa40d,66
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,mini:Cash,10850,iso4217:USD,INF,FACTb8a6327a,601
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,mini:WorkInProgress,0,iso4217:USD,INF,FACT7df05991,606
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,mini:FinishedGoods,0,iso4217:USD,INF,FACTb738c0da,605
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,mini:Land,0,iso4217:USD,INF,FACTa1314043,608
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,mini:TradePayables,1000,iso4217:USD,INF,FACT83c27240,613
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,mini:PropertyPlantAndEquipmentGross,1000,iso4217:USD,INF,FACTc2d8fd4d,611
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,mini:Equipment,1000,iso4217:USD,INF,FACT726eab31,610
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,mini:Buildings,0,iso4217:USD,INF,FACT773eec2f,609
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,mini:OtherReceivables,0,iso4217:USD,INF,FACT078e96a6,604
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,mini:AccumulatedDepreciation,100,iso4217:USD,INF,FACTaeafb2e3,612
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,mini:RawMaterial,2700,iso4217:USD,INF,FACTcd460fed,607
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,mini:MaturesInOneYear,1000,iso4217:USD,INF,FACT52b73449,617
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,mini:MaturesInFourYears,0,iso4217:USD,INF,FACT3905d71d,620
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,mini:OtherSecuredLoans,1000,iso4217:USD,INF,FACTe7ee63b4,616
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,mini:MaturesInThreeYears,0,iso4217:USD,INF,FACT81e8df3b,619
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,mini:MortgageLoans,0,iso4217:USD,INF,FACT5f036b92,615
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,mini:OtherPayables,0,iso4217:USD,INF,FACT3b2f7a66,614
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,mini:MaturesInFiveYears,0,iso4217:USD,INF,FACT5d29c6e9,621
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,mini:CashEquivalents,0,iso4217:USD,INF,FACT9fba01f8,624
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,mini:Cash,0,iso4217:USD,INF,FACT904ac8da,623
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,mini:MaturesThereafter,0,iso4217:USD,INF,FACTe5c4cecf,622
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,mini:MaturesInTwoYears,0,iso4217:USD,INF,FACT5d47fd6b,618
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,mini:Land,0,iso4217:USD,INF,FACT7cf42d5f,630
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,mini:TradeReceivables,0,iso4217:USD,INF,FACTfb96100c,625
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,mini:Buildings,0,iso4217:USD,INF,FACT18d83cab,631
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,mini:PropertyPlantAndEquipmentGross,0,iso4217:USD,INF,FACTcb87d7d9,633
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,mini:WorkInProgress,0,iso4217:USD,INF,FACT9024f358,628
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,mini:Equipment,0,iso4217:USD,INF,FACTa035348d,632
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,mini:FinishedGoods,0,iso4217:USD,INF,FACT9fd43a7a,627
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,mini:OtherReceivables,0,iso4217:USD,INF,FACT437b182a,626
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,mini:AccumulatedDepreciation,0,iso4217:USD,INF,FACT736adfff,634
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,mini:RawMaterial,0,iso4217:USD,INF,FACTc4192579,629
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,mini:MaturesInOneYear,0,iso4217:USD,INF,FACTb1f918ee,639
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,mini:OtherSecuredLoans,0,iso4217:USD,INF,FACTd5d5091a,638
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,mini:TradePayables,0,iso4217:USD,INF,FACT1746ce0b,635
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,mini:MaturesInFiveYears,0,iso4217:USD,INF,FACTbe67ea4e,643
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,mini:MaturesInFourYears,0,iso4217:USD,INF,FACTda4bfbba,642
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,mini:MortgageLoans,0,iso4217:USD,INF,FACT6d38013c,637
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,mini:MaturesInTwoYears,0,iso4217:USD,INF,FACT091410c8,640
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:NatureBusinessTextBlock,ABC Company operates a pop up lemonade stand.,,,FACT7f0284fd,700
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,mini:MaturesThereafter,0,iso4217:USD,INF,FACT068ae268,644
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,mini:OtherPayables,0,iso4217:USD,INF,FACTafabc62d,636
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,mini:MaturesInThreeYears,0,iso4217:USD,INF,FACTd5bb3298,641
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:AccountsPayablePoliciesTextBlock,Accounts payable consists of invoices received from suppliers which have not been paid as of the ...,,,FACTb189ed77,707
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,mini:NoncurrentAssets,900,iso4217:USD,INF,FACT45a22581,102
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:InventoriesPoliciesTextBlock,Inventory consists of lemons and is values at the lower of cost or market value using the FIFO me...,,,FACTd5a5fc83,704
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:CashAndCashEquivalentsPoliciesTextBlock,Cash and cash equivalents consists of a bank demand deposit.,,,FACT6fdd1f41,702
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,mini:CurrentAssets,13550,iso4217:USD,INF,FACTf04434e3,101
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,mini:Assets,14450,iso4217:USD,INF,FACT9b98ec35,103
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:BasisReportingTextBlock,These financial statements are presented using the MINI financial reporting scheme using US dolla...,,,FACT68768839,701
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:LongtermDebtPoliciesTextBlock,Long term debt consists of a note payable with a local bank secured by the equipment financed.,,,FACT731a2a66,708
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:PropertyPlantAndEquipmentPoliciesTextBlock,Property plant  and equipment consists of refrigeration equipment that is depreciated over five …,,,FACT6d48f4a5,705
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:ReceivablesPoliciesTextBlock,Accounts receivable are extended to all customers. ¬†Bad debts are written off after 90 days.,,,FACT03aa50ef,703
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:RevenueRecognitionPoliciesTextBlock,Revenues is recognized when earned using accrual accounting.,,,FACT0964e551,706
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,mini:CurrentLiabilities,1400,iso4217:USD,INF,FACT99633c53,104
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,mini:CurrentAssets,0,iso4217:USD,INF,FACTe9d346da,110
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,mini:CurrentLiabilities,0,iso4217:USD,INF,FACTfb4010c1,113
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,mini:LiabilitiesAndEquity,14450,iso4217:USD,INF,FACT3fdceab6,108
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,mini:NoncurrentLiabilities,1000,iso4217:USD,INF,FACTe1e62302,105
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,mini:Assets,0,iso4217:USD,INF,FACT92671871,112
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,mini:Equity,0,iso4217:USD,INF,FACTee78d1a2,109
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,mini:NoncurrentAssets,0,iso4217:USD,INF,FACT909cc817,111
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,mini:Liabilities,2400,iso4217:USD,INF,FACTe64db47a,106
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,mini:Equity,12050,iso4217:USD,INF,FACT3d273ad0,107
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,coa:PayrollImprest,9000,iso4217:USD,INF,FACT0d4a9c30,29
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,mini:Liabilities,0,iso4217:USD,INF,FACTf139b8be,115
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:NetCashFlowFinancingActivities,10850,iso4217:USD,INF,FACT4468b41d,118
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,coa:PettyCash,850,iso4217:USD,INF,FACTba575d34,31
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,coa:BankOfAmericaGeneralChecking,1000,iso4217:USD,INF,FACT081adb2e,27
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,mini:NoncurrentLiabilities,0,iso4217:USD,INF,FACT4ea601a3,114
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:NetCashFlowInvestingActivities,-1000,iso4217:USD,INF,FACT57866e5b,119
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:NetCashFlowOperatingActivities,1000,iso4217:USD,INF,FACTf4dee261,117
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,mini:LiabilitiesAndEquity,0,iso4217:USD,INF,FACT98a9adcf,116
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:NetCashFlow,10850,iso4217:USD,INF,FACT3e167b2a,120
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,coa:RetainedEarnings,2050,iso4217:USD,INF,FACT8b5379f5,43
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,coa:NotePayableToBankOfAmerica,1000,iso4217:USD,INF,FACTf74cb026,41
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,coa:DepreciationAndAmortizationExpenses,100,iso4217:USD,INF,FACTc5290199,845
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,coa:FurnitureAndFixtures,900,iso4217:USD,INF,FACT2b3ab435,37
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,coa:AccountsPayable,1000,iso4217:USD,INF,FACT9977322f,39
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,coa:OtherNonoperatingExpenses,150,iso4217:USD,INF,FACTcb36a0db,841
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,coa:InventoriesOnHand,2700,iso4217:USD,INF,FACTdecc5101,35
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,coa:AccountsReceivable,0,iso4217:USD,INF,FACTd46cdf3d,33
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,coa:SalesOnAccount,8000,iso4217:USD,INF,FACT680e26bf,553
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,ekg:GeneralExpenses,0,iso4217:USD,INF,FACT316c3b47,837
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,coa:CostsOfGoodsSold,5300,iso4217:USD,INF,FACT5de7b5e0,833
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,coa:PropertyAndEquipmentWrittenOff,0,iso4217:USD,INF,FACT49e36964,849
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,coa:PayrollImprest,0,iso4217:USD,INF,FACT1321042e,18313
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,coa:NotePayableToBankOfAmerica,0,iso4217:USD,INF,FACT716ad39e,18319
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,coa:BankOfAmericaGeneralChecking,0,iso4217:USD,INF,FACT06f70c56,18312
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,coa:PettyCash,0,iso4217:USD,INF,FACTa4b69808,18314
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,coa:FurnitureAndFixtures,0,iso4217:USD,INF,FACTe8ca973c,18317
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,coa:InventoriesOnHand,0,iso4217:USD,INF,FACTc11f0521,18316
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,coa:ProvisionForIncomeTaxes,400,iso4217:USD,INF,FACTc6b0eb6a,853
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,coa:AccountsPayable,0,iso4217:USD,INF,FACT0aab6149,18318
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,coa:AccountsReceivable,0,iso4217:USD,INF,FACT6fa98b73,18315
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,coa:RetainedEarnings,0,iso4217:USD,INF,FACTb79f4381,18320
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCode,JE-201,,,FACT24f40ddd,4632
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEconomicEntity,30810137d58f76b84afd,,,FACTc47cb167,4664
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEconomicEntity,30810137d58f76b84afd,,,FACTe0d5aadb,4665
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCode,JE-201,,,FACT4189892d,4633
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEconomicEntity,30810137d58f76b84afd,,,FACTfca041d6,4666
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEconomicEntity,30810137d58f76b84afd,,,FACTeafa519b,4673
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEconomicEntity,30810137d58f76b84afd,,,FACT11cab363,4668
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEconomicEntity,30810137d58f76b84afd,,,FACTcf205a7d,4670
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEconomicEntity,30810137d58f76b84afd,,,FACTb618dc6b,4672
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEconomicEntity,30810137d58f76b84afd,,,FACT85383f1a,4667
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEconomicEntity,30810137d58f76b84afd,,,FACTc7257bf0,4669
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEconomicEntity,30810137d58f76b84afd,,,FACTf1e20510,4674
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEconomicEntity,30810137d58f76b84afd,,,FACT892284fd,4671
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEconomicEntity,30810137d58f76b84afd,,,FACT8d8d0a38,4677
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEconomicEntity,30810137d58f76b84afd,,,FACT814988a2,4681
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEconomicEntity,30810137d58f76b84afd,,,FACT05045e62,4676
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEconomicEntity,30810137d58f76b84afd,,,FACT4f3591f3,4675
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEconomicEntity,30810137d58f76b84afd,,,FACTf73ee40e,4682
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEconomicEntity,30810137d58f76b84afd,,,FACT02c4e715,4679
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEconomicEntity,30810137d58f76b84afd,,,FACT68f7a3ca,4678
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEconomicEntity,30810137d58f76b84afd,,,FACT3fb83655,4680
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEconomicEntity,30810137d58f76b84afd,,,FACTb6d21a14,4687
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEconomicEntity,30810137d58f76b84afd,,,FACT4451cf4a,4689
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEconomicEntity,30810137d58f76b84afd,,,FACT05ff9b64,4684
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEconomicEntity,30810137d58f76b84afd,,,FACT5de9d05a,4683
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEconomicEntity,30810137d58f76b84afd,,,FACT7a3cec56,4685
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEconomicEntity,30810137d58f76b84afd,,,FACTff8ca0ff,4688
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEconomicEntity,30810137d58f76b84afd,,,FACT9996fc06,4686
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEconomicEntity,30810137d58f76b84afd,,,FACT20cd7fd9,4690
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEconomicEntity,30810137d58f76b84afd,,,FACTd7166464,4692
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCode,JE-202,,,FACT900a4abc,4634
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEconomicEntity,30810137d58f76b84afd,,,FACT6788b89f,4693
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEconomicEntity,30810137d58f76b84afd,,,FACTc6556e04,4691
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEconomicEntity,30810137d58f76b84afd,,,FACT7a5b1bc7,4694
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEconomicEntity,30810137d58f76b84afd,,,FACT07ee1c73,4695
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCode,JE-202,,,FACT8668b3a6,4635
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCode,JE-203,,,FACTb0beeda2,4637
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCode,JE-205,,,FACT871351d6,4640
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCode,JE-204,,,FACT9bb7b968,4638
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCode,JE-203,,,FACT648f5639,4636
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCode,JE-206,,,FACT2c59afbd,4642
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCode,JE-205,,,FACT25cd01ba,4641
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCode,JE-206,,,FACT7dd72be8,4643
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCode,JE-204,,,FACTb126a345,4639
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCode,JE-209,,,FACT56dde9da,4650
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCode,JE-208,,,FACT8d9562c2,4649
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCode,JE-207,,,FACTc8e3ac3d,4647
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCode,JE-206,,,FACTc47a3bbf,4644
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCode,JE-209,,,FACTd53aab02,4651
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCode,JE-206,,,FACT74850be7,4645
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCode,JE-207,,,FACTabb9a781,4646
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCode,JE-208,,,FACT1e2eebef,4648
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCode,JE-209,,,FACT669844c4,4652
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCode,JE-209,,,FACTe3588277,4653
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCode,JE-223,,,FACT5413b79d,4656
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCode,JE-223,,,FACTe3f7bd3a,4657
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCode,JE-210,,,FACTf511e5d7,4654
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCode,JE-224,,,FACTa51dfb52,4658
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCode,JE-210,,,FACT998475e9,4655
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCode,JE-224,,,FACTe9ed3d16,4659
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCode,JE-226,,,FACT18970154,4662
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDate,1/1/24,,,FACTbdf0c331,4696
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCode,JE-225,,,FACTbe459b2d,4660
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDate,1/1/24,,,FACTc7e38251,4697
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCode,JE-226,,,FACT2620b7e9,4663
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCode,JE-225,,,FACT194a846e,4661
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDate,1/2/24,,,FACTa83b4383,4698
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDate,1/5/24,,,FACT1ba36482,4701
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDate,1/5/24,,,FACT491eedf1,4700
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDate,1/10/24,,,FACTd394d71d,4702
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDate,1/10/24,,,FACTf3657a47,4703
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDate,1/2/24,,,FACT925d76a0,4699
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDate,1/15/24,,,FACT2f6e04b3,4704
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDate,1/15/24,,,FACT3ec9fd21,4705
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDate,1/16/24,,,FACT160d8abb,4706
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDate,1/20/24,,,FACT95c460cf,4710
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDate,1/16/24,,,FACT997a36b2,4708
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDate,1/16/24,,,FACTb5525d26,4707
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDate,1/16/24,,,FACT2709b922,4709
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDate,1/25/24,,,FACT26a9a271,4717
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDate,1/24/24,,,FACTd282376b,4718
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDate,1/20/24,,,FACT05fda608,4711
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDate,1/21/24,,,FACTce9ece35,4713
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDate,1/28/24,,,FACTe940d373,4720
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDate,1/25/24,,,FACT4b80898c,4715
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDate,1/28/24,,,FACT8747590f,4721
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDate,1/24/24,,,FACTac5bc978,4719
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDate,1/21/24,,,FACT47f6511d,4712
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDate,1/25/24,,,FACT0ef19d39,4714
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDate,1/25/24,,,FACT852d5ce0,4716
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDate,1/28/24,,,FACT310b8754,4722
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryConcept,mini:PaidInCapital,,,FACT6cb5e1dc,17471
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDate,1/29/24,,,FACTdf42e833,4727
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDate,1/28/24,,,FACT0605feae,4723
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDate,1/29/24,,,FACT1ac9cb8a,4726
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDate,1/28/24,,,FACT290f1c7d,4724
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryConcept,mini:CashAndCashEquivalents,,,FACT9b3faea3,17470
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDate,1/28/24,,,FACT9d987c58,4725
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryConcept,mini:CashAndCashEquivalents,,,FACT099fee60,17472
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryConcept,mini:AccountsPayable,,,FACTc18dc918,17477
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryConcept,mini:CostsOfSales,,,FACTb377a481,17478
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryConcept,mini:Inventories,,,FACTfa77c6d3,17476
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryConcept,mini:LongtermDebt,,,FACT0feeb078,17473
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryConcept,mini:CashAndCashEquivalents,,,FACTd051e11b,17475
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryConcept,mini:PropertyPlantAndEquipment,,,FACTf89288d5,17474
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryConcept,mini:AccountsPayable,,,FACT6c2ae928,17479
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryConcept,mini:Receivables,,,FACT81860ed2,17480
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryConcept,mini:CashAndCashEquivalents,,,FACTac3ba1c3,17489
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryConcept,mini:Inventories,,,FACTe6fef751,17483
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryConcept,mini:InterestExpense,,,FACT285060d4,17492
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryConcept,mini:CostsOfSales,,,FACT383089e1,17482
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryConcept,mini:AccruedExpenses,,,FACT7f9e1914,17493
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryConcept,mini:CashAndCashEquivalents,,,FACT99507afe,17487
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryConcept,mini:Sales,,,FACT24f720db,17481
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryConcept,mini:CashAndCashEquivalents,,,FACT9b5212fc,17484
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryConcept,mini:AccountsPayable,,,FACT1df24dbf,17486
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryConcept,mini:CashAndCashEquivalents,,,FACTf43a7583,17490
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryConcept,mini:AccruedExpenses,,,FACTd57d8a42,17491
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryConcept,mini:CostsOfSales,,,FACT39971a81,17494
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryConcept,mini:LongtermDebt,,,FACT3abf1524,17488
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryConcept,mini:Receivables,,,FACT1e56355f,17485
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryConcept,mini:Inventories,,,FACT54f7b7dd,17495
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryConcept,mini:AccruedExpenses,,,FACT14dd98ee,17501
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryConcept,mini:NonoperatingIncomeExpenses,,,FACT72880dc7,17499
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryConcept,mini:PropertyPlantAndEquipment,,,FACTac0cdaeb,17497
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryConcept,mini:DepreciationAndAmortization,,,FACT0f7d97e4,17496
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryConcept,mini:IncomeTaxExpenseBenefit,,,FACT3bde0873,17500
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryConcept,mini:PropertyPlantAndEquipment,,,FACTb91d18b6,17498
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEventTypeCode,mini:ProceedsFromInvestmentsByOwner,,,FACTb5329057,17502
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEventTypeCode,mini:PurchasesOfInventoryForSale,,,FACTab533899,17508
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEventTypeCode,mini:InvestmentsByOwner,,,FACTe8d6c1e7,17503
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEventTypeCode,mini:PurchasesInventoryForSaleOnAccount,,,FACT704f5e55,17509
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEventTypeCode,mini:ProceedsFromAdditionalLongtermBorrowings,,,FACT00f6fe08,17504
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEventTypeCode,mini:CapitalAdditionsPropertyPlantAndEquipment,,,FACTd4ccc948,17506
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEventTypeCode,mini:AdditionalLongtermBorrowings,,,FACT0a24fca8,17505
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEventTypeCode,mini:NetIncomeLoss,,,FACTe5e1f7b1,17510
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEventTypeCode,mini:PaymentForCapitalAdditionsOfPropertyPlantEquipment,,,FACTd5fe7806,17507
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEventTypeCode,mini:NetIncomeLoss,,,FACT44169066,17513
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEventTypeCode,mini:ProceedsFromCollectionOfReceivables,,,FACT2bacd5ec,17516
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEventTypeCode,mini:NetIncomeLoss,,,FACT9098d708,17514
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEventTypeCode,mini:PurchasesInventoryForSaleOnAccount,,,FACTea4ce800,17511
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEventTypeCode,mini:IncreaseInReceivablesFromSalesOnAccount,,,FACTda029914,17512
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEventTypeCode,mini:DecreaseInInventoriesFromSales,,,FACT9d3800fa,17515
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEventTypeCode,mini:DecreaseFromPaymentAccountsPayable,,,FACT10177083,17518
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEventTypeCode,mini:CollectionOfReceivables,,,FACT2f23ae90,17517
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEventTypeCode,mini:NetIncomeLoss,,,FACT685b0903,17524
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEventTypeCode,mini:PaymentForReductionOfLongtermBorrowings,,,FACT15cb6daa,17521
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEventTypeCode,mini:RepaymentLongtermBorrowings,,,FACTa507f59c,17520
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEventTypeCode,mini:DecreaseFromPaymentOfInterest,,,FACT67aba4ae,17523
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEventTypeCode,mini:PaymentOfAccountsPayable,,,FACT4cc38729,17519
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEventTypeCode,mini:PaymentOfInterest,,,FACT309b2d1d,17522
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEventTypeCode,mini:NetIncomeLoss,,,FACT41bb4914,17526
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEventTypeCode,mini:InventoryWrittenOff,,,FACT6e5f046e,17527
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEventTypeCode,mini:InterestAccrued,,,FACT7b9438c7,17525
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEventTypeCode,mini:NetIncomeLoss,,,FACT28a8634a,17531
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEventTypeCode,mini:PropertyPlantAndEquipmentWrittenOff,,,FACT877f4fac,17530
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEventTypeCode,mini:NetIncomeLoss,,,FACT454c520b,17528
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEventTypeCode,mini:DecreaseFromDepreciationAndAmortization,,,FACT67fd19dc,17529
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryAmount,-10000,iso4217:USD,INF,FACT82d75b84,17567
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryAmount,-2000,iso4217:USD,INF,FACTa9a6da83,17569
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEventTypeCode,mini:InterestAccrued,,,FACTbcbd75af,17533
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryEventTypeCode,mini:NetIncomeLoss,,,FACT5d4b9406,17532
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryAmount,-1000,iso4217:USD,INF,FACT698d669c,17571
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryAmount,10000,iso4217:USD,INF,FACT496b3c38,17566
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryAmount,1000,iso4217:USD,INF,FACT7877599e,17570
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryAmount,2000,iso4217:USD,INF,FACTd773d5ad,17568
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryAmount,-3000,iso4217:USD,INF,FACT92fe835c,17575
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryAmount,-5000,iso4217:USD,INF,FACT0d6c452c,17573
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryAmount,5000,iso4217:USD,INF,FACTac60e97f,17572
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryAmount,-2000,iso4217:USD,INF,FACT510167c3,17579
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryAmount,3000,iso4217:USD,INF,FACT660586ac,17574
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryAmount,2000,iso4217:USD,INF,FACT189bf623,17578
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryAmount,8000,iso4217:USD,INF,FACTe23dc2bb,17576
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryAmount,-8000,iso4217:USD,INF,FACTb2895afe,17577
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryAmount,-1000,iso4217:USD,INF,FACT8aa27ce2,17585
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryAmount,1000,iso4217:USD,INF,FACT6dc89314,17584
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryAmount,8000,iso4217:USD,INF,FACT0813e484,17580
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryAmount,-7000,iso4217:USD,INF,FACT140e5570,17583
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryAmount,-150,iso4217:USD,INF,FACTe15773b2,17586
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryAmount,-8000,iso4217:USD,INF,FACTb13d1b5d,17581
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryAmount,7000,iso4217:USD,INF,FACT5fa319c5,17582
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryAmount,100,iso4217:USD,INF,FACTbae91b1f,17592
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryAmount,150,iso4217:USD,INF,FACTdc3e18e5,17588
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryAmount,-150,iso4217:USD,INF,FACT5e89653e,17589
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryAmount,-300,iso4217:USD,INF,FACT04466ddb,17591
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryAmount,-100,iso4217:USD,INF,FACT4a2fd0ae,17593
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryAmount,150,iso4217:USD,INF,FACTdaefc386,17587
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryAmount,300,iso4217:USD,INF,FACTa848ce1a,17590
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryAmount,-400,iso4217:USD,INF,FACT271ca2f9,17597
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryAmount,0,iso4217:USD,INF,FACTb0c739ed,17595
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCurrency,iso4217:USD,,,FACT06f2b9b9,17599
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryAmount,400,iso4217:USD,INF,FACTcf5d0e5d,17596
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCurrency,iso4217:USD,,,FACT92dd935e,17598
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryAmount,0,iso4217:USD,INF,FACTa07b55e6,17594
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCurrency,iso4217:USD,,,FACT3f1cce41,17601
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCurrency,iso4217:USD,,,FACT39b5a220,17600
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCurrency,iso4217:USD,,,FACT782b96da,17602
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCurrency,iso4217:USD,,,FACT31a49912,17604
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCurrency,iso4217:USD,,,FACT61d83199,17607
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCurrency,iso4217:USD,,,FACTa677b561,17603
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCurrency,iso4217:USD,,,FACT63530141,17606
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCurrency,iso4217:USD,,,FACTe28dd10d,17609
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCurrency,iso4217:USD,,,FACT045fef61,17605
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCurrency,iso4217:USD,,,FACT9071ad5f,17608
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCurrency,iso4217:USD,,,FACT6a58a6e6,17610
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCurrency,iso4217:USD,,,FACT64124a29,17612
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCurrency,iso4217:USD,,,FACTad192e48,17614
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCurrency,iso4217:USD,,,FACT4000f59f,17615
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCurrency,iso4217:USD,,,FACT35d8ecec,17616
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCurrency,iso4217:USD,,,FACT86250ef8,17611
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCurrency,iso4217:USD,,,FACT32c33b07,17613
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCurrency,iso4217:USD,,,FACTd6f8ce9a,17617
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCurrency,iso4217:USD,,,FACT656a32de,17618
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCurrency,iso4217:USD,,,FACTd244c2e6,17620
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCurrency,iso4217:USD,,,FACT3047c502,17619
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCurrency,iso4217:USD,,,FACT99095965,17622
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCurrency,iso4217:USD,,,FACT1bf3f0ac,17621
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCurrency,iso4217:USD,,,FACTcd86040f,17624
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCurrency,iso4217:USD,,,FACTb34caeee,17623
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDescription,Investment by owner to open a lemonade stand.,,,FACT6f184573,17535
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCurrency,iso4217:USD,,,FACTe483a6d3,17629
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCurrency,iso4217:USD,,,FACT70fe2656,17626
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCurrency,iso4217:USD,,,FACT266bd87b,17625
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCurrency,iso4217:USD,,,FACT07d9f604,17628
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryCurrency,iso4217:USD,,,FACT467f5b3d,17627
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDescription,Investment by owner to open a lemonade stand.,,,FACTd94fb272,17534
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDescription,Sales on account.,,,FACT935f46af,17544
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDescription,Payment for  contractor to work the lemonade stand.,,,FACT9d11d5fc,17543
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDescription,Purchase of lemons to put intoinventory on account.,,,FACTa7d2f94b,17540
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDescription,Long term borrowing to purchase refrigerator.,,,FACT1991cb54,17536
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDescription,Purchase of refrigerator  using cash from additional borrowings.,,,FACT0bf4b0e7,17538
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDescription,Long term borrowing to purchase refrigerator.,,,FACT590d36ce,17537
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDescription,Purchase of lemons to put intoinventory on account.,,,FACTc067d8f9,17541
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDescription,Purchase of refrigerator  using cash from additional borrowings.,,,FACT73439c24,17539
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDescription,Payment for  contractor to work the lemonade stand.,,,FACTdba6cc30,17542
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDescription,Sales on account.,,,FACTcce98bcd,17545
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDescription,Payment of accounts payable.,,,FACT89f75a0c,17550
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDescription,Costs related to sales on account.,,,FACT7d39fd3a,17546
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDescription,Payment of accounts payable.,,,FACTc364b2b0,17551
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDescription,Collection of accounts receivable.,,,FACTaa0c72c1,17548
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDescription,Costs related to sales on account.,,,FACTc326a8e2,17547
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDescription,Collection of accounts receivable.,,,FACTe2b60232,17549
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDescription,Closing entry. Inventory write offs, adjust to physical.,,FACT2dc03ba1,17558
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDescription,Payment of long term debt including accrued interest.,,,FACT001ede2b,17554
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDescription,Payment of long term debt including accrued interest.,,,FACT4ca93b3c,17553
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDescription,Accrual of interest on debt.,,,FACT19b46033,17556
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDescription,Payment of long term debt including accrued interest.,,,FACTda06685f,17552
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDescription,Payment of long term debt including accrued interest.,,,FACTec1cc5bb,17555
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDescription,Accrual of interest on debt.,,,FACTbfb2dad9,17557
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDescription,Closing entry. Depreciation and amortization expensed.,,,FACT95c7304b,17560
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDescription,Closing entry.  Book taxes.,,,FACT1ae4cbef,17565
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDescription,Closing entry.  Book taxes.,,,FACT3e3cd3f4,17564
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDescription,Closing entry. Inventory write offs, adjust to physical.,,FACTebf8c88f,17559
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDescription,Closing entry. Depreciation and amortization expensed.,,,FACTe00082f1,17561
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDescription,Closing entry. Write of of PPE.,,,FACT4563ae32,17562
+30810137d58f76b84afd | http://xbrlsite.com/id,2024-01-01 | 2024-12-31,gl:EntryDescription,Closing entry. Write of of PPE.,,,FACT7c86f38f,17563
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:CostsOfSales,0,iso4217:USD,INF,FACT288dabb3,18015
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:Sales,8000,iso4217:USD,INF,FACTa0d07b03,18010
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,coa:SalesOnAccount,8000,iso4217:USD,INF,FACT418f0a8e,18008
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,coa:SalesOnAccount,0,iso4217:USD,INF,FACTbc0e6533,18009
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:Sales,0,iso4217:USD,INF,FACT55a7aa5a,18011
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,ekg:GeneralExpenses,0,iso4217:USD,INF,FACT540bb633,18016
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:CostsOfSales,5300,iso4217:USD,INF,FACTc87ec59a,18014
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,coa:CostsOfGoodsSold,0,iso4217:USD,INF,FACTe99ec235,18013
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,coa:CostsOfGoodsSold,5300,iso4217:USD,INF,FACTa1aa4bec,18012
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,ekg:GeneralExpenses,0,iso4217:USD,INF,FACT44d0b061,18017
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:SalesGeneralAndAdministrativeExpenses,0,iso4217:USD,INF,FACT0d3d6960,18018
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:InterestExpense,150,iso4217:USD,INF,FACT0bd02f46,18022
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,coa:DepreciationAndAmortizationExpenses,100,iso4217:USD,INF,FACTc86b9deb,18024
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,coa:OtherNonoperatingExpenses,0,iso4217:USD,INF,FACT57a19f29,18021
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:DepreciationAndAmortization,100,iso4217:USD,INF,FACT7fcb250c,18026
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:InterestExpense,0,iso4217:USD,INF,FACT33cd574e,18023
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:SalesGeneralAndAdministrativeExpenses,0,iso4217:USD,INF,FACTe2a19be3,18019
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,coa:OtherNonoperatingExpenses,150,iso4217:USD,INF,FACTc6d6ed83,18020
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,coa:DepreciationAndAmortizationExpenses,0,iso4217:USD,INF,FACTd7fca738,18025
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:DepreciationAndAmortization,0,iso4217:USD,INF,FACT96cfe679,18027
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,coa:ProvisionForIncomeTaxes,0,iso4217:USD,INF,FACT0a7c5883,18033
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,coa:ProvisionForIncomeTaxes,400,iso4217:USD,INF,FACT8483c071,18032
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,coa:PropertyAndEquipmentWrittenOff,0,iso4217:USD,INF,FACT113e0f12,18028
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:GainLossOnSalePropertyPlantEquipment,0,iso4217:USD,INF,FACTa377e616,18030
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:GainLossOnSalePropertyPlantEquipment,0,iso4217:USD,INF,FACTef63496f,18031
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,coa:PropertyAndEquipmentWrittenOff,0,iso4217:USD,INF,FACTe2891dc0,18029
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:IncomeTaxExpenseBenefit,400,iso4217:USD,INF,FACT50dc7d33,18034
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,mini:IncomeTaxExpenseBenefit,0,iso4217:USD,INF,FACTa4a53478,18035
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,mini:CashAndCashEquivalents,10850,iso4217:USD,INF,FACTb0d66b46,18070
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,coa:BankOfAmericaGeneralChecking,1000,iso4217:USD,INF,FACT2f26506c,18064
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,coa:PettyCash,850,iso4217:USD,INF,FACT41c0f1ce,18068
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,coa:PayrollImprest,9000,iso4217:USD,INF,FACTfc9f88bb,18066
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,mini:CashAndCashEquivalents,0,iso4217:USD,INF,FACT42686bc4,18071
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,coa:BankOfAmericaGeneralChecking,0,iso4217:USD,INF,FACT23ad8cf6,18065
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,coa:PettyCash,0,iso4217:USD,INF,FACT54133798,18069
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,coa:PayrollImprest,0,iso4217:USD,INF,FACTcce64f49,18067
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,coa:AccountsReceivable,0,iso4217:USD,INF,FACT84411685,18108
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,coa:InventoriesOnHand,2700,iso4217:USD,INF,FACTbc5f7f59,18112
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,coa:InventoriesOnHand,0,iso4217:USD,INF,FACT37859de2,18113
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,coa:AccountsReceivable,0,iso4217:USD,INF,FACTf167049f,18109
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,mini:TradeReceivables,0,iso4217:USD,INF,FACTdb153877,18111
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,mini:Inventories,0,iso4217:USD,INF,FACT88f42baf,18115
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,mini:TradeReceivables,0,iso4217:USD,INF,FACT971db80c,18110
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,coa:FurnitureAndFixtures,900,iso4217:USD,INF,FACTf5884622,18260
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,mini:Inventories,2700,iso4217:USD,INF,FACT05bde895,18114
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,mini:PropertyPlantAndEquipment,900,iso4217:USD,INF,FACTa59cd98b,18262
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,mini:PropertyPlantAndEquipment,0,iso4217:USD,INF,FACT13c95371,18263
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,coa:AccountsPayable,1000,iso4217:USD,INF,FACTfb8b39a4,18264
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,mini:LongtermDebt,1000,iso4217:USD,INF,FACTcc6b22be,18270
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,coa:FurnitureAndFixtures,0,iso4217:USD,INF,FACT66f2eb81,18261
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,mini:TradePayables,1000,iso4217:USD,INF,FACT35e3623b,18266
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,coa:AccountsPayable,0,iso4217:USD,INF,FACTf58b1be5,18265
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,mini:TradePayables,0,iso4217:USD,INF,FACT3a2bfa41,18267
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,coa:NotePayableToBankOfAmerica,1000,iso4217:USD,INF,FACT6780d932,18268
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,coa:RetainedEarnings,2050,iso4217:USD,INF,FACT9c327b48,18272
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,coa:BankOfAmericaGeneralChecking,0,iso4217:USD,INF,FACT21617198,18815
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,mini:RetainedEarnings,2050,iso4217:USD,INF,FACTe0da513d,18274
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,mini:LongtermDebt,0,iso4217:USD,INF,FACTcf802afb,18271
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,coa:PayrollImprest,0,iso4217:USD,INF,FACT3f598ea5,18817
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,coa:NotePayableToBankOfAmerica,0,iso4217:USD,INF,FACTbdd5096c,18269
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,coa:RetainedEarnings,0,iso4217:USD,INF,FACT69c0bb28,18273
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,coa:BankOfAmericaGeneralChecking,0,iso4217:USD,INF,FACT95b2cd66,18814
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,mini:RetainedEarnings,0,iso4217:USD,INF,FACT8ac7c7d9,18275
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,coa:PayrollImprest,0,iso4217:USD,INF,FACT9f559c6c,18816
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,coa:PettyCash,0,iso4217:USD,INF,FACT83c6c3b0,18818
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,mini:TradeReceivables,0,iso4217:USD,INF,FACT202ff4e6,18825
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,mini:TradeReceivables,0,iso4217:USD,INF,FACTab1cb0d9,18824
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,mini:CashAndCashEquivalents,0,iso4217:USD,INF,FACT819dd9d8,18820
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,coa:PettyCash,0,iso4217:USD,INF,FACTc1129458,18819
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,coa:InventoriesOnHand,0,iso4217:USD,INF,FACT5c0cc019,18826
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,coa:AccountsReceivable,0,iso4217:USD,INF,FACTe8e46ea7,18823
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,mini:CashAndCashEquivalents,0,iso4217:USD,INF,FACTf32c6401,18821
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,coa:AccountsReceivable,0,iso4217:USD,INF,FACT23fe1652,18822
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,mini:Inventories,0,iso4217:USD,INF,FACTcf6b2ecf,18829
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,coa:FurnitureAndFixtures,0,iso4217:USD,INF,FACT90c9b2cc,18831
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,coa:FurnitureAndFixtures,0,iso4217:USD,INF,FACTb2a17889,18830
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,mini:PropertyPlantAndEquipment,0,iso4217:USD,INF,FACT599c8826,18832
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,coa:InventoriesOnHand,0,iso4217:USD,INF,FACT40c4a836,18827
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,coa:AccountsPayable,0,iso4217:USD,INF,FACT812d9299,18834
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,mini:Inventories,0,iso4217:USD,INF,FACTb74b4521,18828
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,mini:TradePayables,0,iso4217:USD,INF,FACT24621ade,18836
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,mini:PropertyPlantAndEquipment,0,iso4217:USD,INF,FACTde6afcbc,18833
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,coa:RetainedEarnings,0,iso4217:USD,INF,FACTcfae830d,18843
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,coa:AccountsPayable,0,iso4217:USD,INF,FACT857912e1,18835
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,mini:TradePayables,0,iso4217:USD,INF,FACT85774951,18837
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,mini:LongtermDebt,0,iso4217:USD,INF,FACTa9ba43a2,18841
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,mini:LongtermDebt,0,iso4217:USD,INF,FACT4d9e937b,18840
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,coa:NotePayableToBankOfAmerica,0,iso4217:USD,INF,FACT69ff88dc,18838
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,mini:RetainedEarnings,0,iso4217:USD,INF,FACT76dc3c19,18844
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,coa:NotePayableToBankOfAmerica,0,iso4217:USD,INF,FACT2c9aa11a,18839
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,coa:RetainedEarnings,0,iso4217:USD,INF,FACT6137c585,18842
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,mini:RetainedEarnings,0,iso4217:USD,INF,FACT9c760c40,18845
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,ekg:RealAccountsCheckSum,0,iso4217:USD,INF,FACTefae0bd0,18265
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,ekg:TemporaryAccountsCheckSum,-2050,iso4217:USD,INF,FACTe434ccec,18266
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,ekg:AccruedExpenses,400,iso4217:USD,INF,FACT4bd6b0dc,18270
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,ekg:PaidInCapital,10000,iso4217:USD,INF,FACT4ec72e61,18268
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,ekg:AccruedExpenses,0,iso4217:USD,INF,,18849
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,ekg:PaidInCapital,0,iso4217:USD,INF,,18850
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,ekg:RealAccountsCheckSum,0,iso4217:USD,INF,,18851
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,ekg:AccruedExpenses,400,iso4217:USD,INF,FACTdd016c4f,18880
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,ekg:AccruedExpenses,0,iso4217:USD,INF,FACT18efde08,18881
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,ekg:AccruedExpenses,0,iso4217:USD,INF,FACTf4c5a103,18882
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,ekg:AccruedExpenses,0,iso4217:USD,INF,FACT726357d9,18883
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,mini:AccruedExpenses,400,iso4217:USD,INF,FACT13604187,18884
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,mini:AccruedExpenses,0,iso4217:USD,INF,FACTb902f58a,18885
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,mini:AccruedExpenses,0,iso4217:USD,INF,FACT656f15d7,18886
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,mini:AccruedExpenses,0,iso4217:USD,INF,FACTa1ee7271,18887
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,ekg:PaidInCapital,10000,iso4217:USD,INF,FACTa1cf1da3,18916
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,ekg:PaidInCapital,0,iso4217:USD,INF,FACT6c793f01,18917
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,ekg:PaidInCapital,0,iso4217:USD,INF,FACT07ae8930,18918
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,ekg:PaidInCapital,0,iso4217:USD,INF,FACT76697b6e,18919
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,mini:PaidInCapital,10000,iso4217:USD,INF,FACTb9a4eb65,18920
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,mini:PaidInCapital,0,iso4217:USD,INF,FACT813bbec8,18921
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,mini:PaidInCapital,0,iso4217:USD,INF,FACT4e6410ab,18922
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,mini:PaidInCapital,0,iso4217:USD,INF,FACTec4b5020,18923
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,fac:Assets,14450,iso4217:USD,INF,FACTa8a60099,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,fac:NoncurrentAssets,900,iso4217:USD,INF,FACT18a74b24,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,fac:Liabilities,2400,iso4217:USD,INF,FACTc1810829,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,fac:CurrentAssets,13550,iso4217:USD,INF,FACT1fbbc19d,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,fac:CurrentLiabilities,1400,iso4217:USD,INF,FACTc4d14f37,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,fac:EquityAttributableToNoncontrollingInterest,0,iso4217:USD,INF,FACT1f0cdc5c,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,fac:GrossProfit,2700,iso4217:USD,INF,FACT7ce56152,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,fac:Revenues,8000,iso4217:USD,INF,FACTc37ad84f,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,fac:LiabilitiesAndEquity,14450,iso4217:USD,INF,FACT71375e55,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,fac:NoncurrentLiabilities,1000,iso4217:USD,INF,FACT1df70c3a,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,fac:Equity,12050,iso4217:USD,INF,FACTc62a9f51,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,fac:CostOfRevenue,5300,iso4217:USD,INF,FACT1a5c9b42,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/24,fac:EquityAttributableToControllingInterest,12050,iso4217:USD,INF,FACT17578206,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,fac:IncomeTaxExpenseBenefit,400,iso4217:USD,INF,FACTcc53372e,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,fac:ProfitLossAttributableToNoncontrollingInterest,0,iso4217:USD,INF,FACTce1ffa89,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,fac:NonoperatingIncomeLossIncludingInterestAndDebtExpense,-150,iso4217:USD,INF,FACT79b5264c,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,fac:OperatingExpenses,100,iso4217:USD,INF,FACT12dee35b,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,fac:OtherOperatingIncomeExpenses,0,iso4217:USD,INF,FACTa0936541,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,fac:IncomeLossFromContinuingOperationsBeforeTax,2450,iso4217:USD,INF,FACTc4086974,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,fac:ProfitLoss,2050,iso4217:USD,INF,FACT1025333d,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,fac:OperatingIncomeLoss,2600,iso4217:USD,INF,FACTcea8e748,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,fac:IncomeLossFromDiscontinuedOperationsNetOfTax,0,iso4217:USD,INF,FACTa738f239,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,fac:IncomeLossFromContinuingOperationsAfterTax,2050,iso4217:USD,INF,FACT15757423,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,fac:ProfitLossAttributableToControllingInterests,2050,iso4217:USD,INF,FACTa0247880,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,fac:ProfitLossAvailableToControllingInterestsBasic,2050,iso4217:USD,INF,FACT7c527c93,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,fac:PreferenceSharesDividendsOtherAdjustments,0,iso4217:USD,INF,FACT79023b8d,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,fac:OtherComprehensiveIncomeLoss,0,iso4217:USD,INF,FACT1269fe9a,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,fac:ComprehensiveIncomeLossAttributableToParent,2050,iso4217:USD,INF,FACT18c970a6,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,fac:ComprehensiveIncomeLoss,2050,iso4217:USD,INF,FACTa5743f9e,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,fac:ComprehensiveIncomeLossAttributableToNoncontrollingInterest,0,iso4217:USD,INF,FACTafd4b1a2,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,fac:NetCashFlowFromOperatingActivitiesContinuing,1000,iso4217:USD,INF,FACTc9b46df1,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,fac:NetCashFlowFromOperatingActivities,1000,iso4217:USD,INF,FACT15c269e2,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,fac:NetCashFlowFromOperatingActivitiesDiscontinued,0,iso4217:USD,INF,FACT7bf9ebeb,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,fac:NetCashFlowFromInvestingActivitiesContinuing,-1000,iso4217:USD,INF,FACTda5ab7b7,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,fac:NetCashFlowFromInvestingActivitiesDiscontinued,0,iso4217:USD,INF,FACT6d4776b3,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,fac:NetCashFlowFromInvestingActivities,-1000,iso4217:USD,INF,FACT037cf4ba,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,fac:NetCashFlowFromFinancingActivitiesDiscontinued,0,iso4217:USD,INF,FACTb13172a0,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,fac:NetCashFlowFromFinancingActivitiesContinuing,10850,iso4217:USD,INF,FACT062cb3a4,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,fac:NetCashFlowFromFinancingActivities,10850,iso4217:USD,INF,FACT681731ad,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,fac:NetCashFlowContinuing,10850,iso4217:USD,INF,FACT62b7bf91,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,fac:NetCashFlowDiscontinued,0,iso4217:USD,INF,FACT6aece1cb,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,fac:NetCashFlow,10850,iso4217:USD,INF,FACT04d763c2,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2024-01-01 | 2024-12-31,fac:ExchangeGainsLosses,0,iso4217:USD,INF,FACTb3caa2c6,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,fac:Assets,0,iso4217:USD,INF,FACT018724dc,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,fac:CurrentAssets,0,iso4217:USD,INF,FACTb69ae5d8,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,fac:NoncurrentAssets,0,iso4217:USD,INF,FACT6fbca6d5,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,fac:Liabilities,0,iso4217:USD,INF,FACT069bae65,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,fac:NoncurrentLiabilities,0,iso4217:USD,INF,FACT68a02c6c,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,fac:CurrentLiabilities,0,iso4217:USD,INF,FACTb1866f61,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,fac:EquityAttributableToNoncontrollingInterest,0,iso4217:USD,INF,FACTdaedaa76,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,fac:EquityAttributableToControllingInterest,0,iso4217:USD,INF,FACTdfbded68,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,fac:Equity,0,iso4217:USD,INF,FACT03cbe97b,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/23,fac:LiabilitiesAndEquity,0,iso4217:USD,INF,FACTbe76a643,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2023-01-01 | 2023-12-31,fac:CostOfRevenue,0,iso4217:USD,INF,FACTb62df819,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2023-01-01 | 2023-12-31,fac:Revenues,0,iso4217:USD,INF,FACT096b6747,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2023-01-01 | 2023-12-31,fac:OtherOperatingIncomeExpenses,0,iso4217:USD,INF,FACT6a5bfc0a,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2023-01-01 | 2023-12-31,fac:OperatingExpenses,0,iso4217:USD,INF,FACTd8167a10,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2023-01-01 | 2023-12-31,fac:GrossProfit,0,iso4217:USD,INF,FACT6f0bbb14,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2023-01-01 | 2023-12-31,fac:NonoperatingIncomeLossIncludingInterestAndDebtExpense,0,iso4217:USD,INF,FACTd5c44517,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2023-01-01 | 2023-12-31,fac:OperatingIncomeLoss,0,iso4217:USD,INF,FACTb37dbf07,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2023-01-01 | 2023-12-31,fac:IncomeTaxExpenseBenefit,0,iso4217:USD,INF,FACT0ce2061a,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2023-01-01 | 2023-12-31,fac:IncomeLossFromContinuingOperationsBeforeTax,0,iso4217:USD,INF,FACTbbffc71e,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2023-01-01 | 2023-12-31,fac:IncomeLossFromContinuingOperationsAfterTax,0,iso4217:USD,INF,FACT09b24104,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2023-01-01 | 2023-12-31,fac:IncomeLossFromDiscontinuedOperationsNetOfTax,0,iso4217:USD,INF,FACTbeaf8000,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2023-01-01 | 2023-12-31,fac:ProfitLossAttributableToControllingInterests,0,iso4217:USD,INF,FACT6d294d31,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2023-01-01 | 2023-12-31,fac:ProfitLoss,0,iso4217:USD,INF,FACTd0940209,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2023-01-01 | 2023-12-31,fac:ProfitLossAttributableToNoncontrollingInterest,0,iso4217:USD,INF,FACTda348c35,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2023-01-01 | 2023-12-31,fac:PreferenceSharesDividendsOtherAdjustments,0,iso4217:USD,INF,FACT6572136b,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2023-01-01 | 2023-12-31,fac:OtherComprehensiveIncomeLoss,0,iso4217:USD,INF,FACTb9041778,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2023-01-01 | 2023-12-31,fac:ProfitLossAvailableToControllingInterestsBasic,0,iso4217:USD,INF,FACT0b499162,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2023-01-01 | 2023-12-31,fac:ComprehensiveIncomeLoss,0,iso4217:USD,INF,FACT09055cc5,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2023-01-01 | 2023-12-31,fac:ComprehensiveIncomeLossAttributableToNoncontrollingInterest,0,iso4217:USD,INF,FACT673edecc,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2023-01-01 | 2023-12-31,fac:ComprehensiveIncomeLossAttributableToParent,0,iso4217:USD,INF,FACTbe189dc1,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2023-01-01 | 2023-12-31,fac:NetCashFlowFromOperatingActivitiesDiscontinued,0,iso4217:USD,INF,FACT626e99d2,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2023-01-01 | 2023-12-31,fac:NetCashFlowFromOperatingActivitiesContinuing,0,iso4217:USD,INF,FACTd57358d6,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2023-01-01 | 2023-12-31,fac:NetCashFlowFromOperatingActivities,0,iso4217:USD,INF,FACT0c551bdb,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2023-01-01 | 2023-12-31,fac:NetCashFlowFromInvestingActivitiesContinuing,0,iso4217:USD,INF,FACTb1e854e3,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2023-01-01 | 2023-12-31,fac:NetCashFlowFromInvestingActivitiesDiscontinued,0,iso4217:USD,INF,FACT06f595e7,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2023-01-01 | 2023-12-31,fac:NetCashFlowFromFinancingActivitiesContinuing,0,iso4217:USD,INF,FACTd2d8cfae,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2023-01-01 | 2023-12-31,fac:NetCashFlowFromInvestingActivities,0,iso4217:USD,INF,FACTd78888b0,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2023-01-01 | 2023-12-31,fac:NetCashFlowFromFinancingActivitiesDiscontinued,0,iso4217:USD,INF,FACTbce34da7,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2023-01-01 | 2023-12-31,fac:NetCashFlowFromFinancingActivities,0,iso4217:USD,INF,FACT96251a7c,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2023-01-01 | 2023-12-31,fac:NetCashFlowContinuing,0,iso4217:USD,INF,FACT4f035971,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2023-01-01 | 2023-12-31,fac:ExchangeGainsLosses,0,iso4217:USD,INF,FACT4a531e6f,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2023-01-01 | 2023-12-31,fac:NetCashFlowDiscontinued,0,iso4217:USD,INF,FACTf81e9875,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/22,fac:Assets,0,iso4217:USD,INF,FACT2ec8125a,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2023-01-01 | 2023-12-31,fac:NetCashFlow,0,iso4217:USD,INF,FACT93755d62,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/22,fac:CurrentAssets,0,iso4217:USD,INF,FACT918e8d04,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/22,fac:NoncurrentAssets,0,iso4217:USD,INF,FACT48a8ce09,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/22,fac:CurrentLiabilities,0,iso4217:USD,INF,FACTfae54813,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/22,fac:Liabilities,0,iso4217:USD,INF,FACTffb50f0d,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/22,fac:NoncurrentLiabilities,0,iso4217:USD,INF,FACT4df88917,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/22,fac:EquityAttributableToControllingInterest,0,iso4217:USD,INF,FACTfdf9c2aa,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/22,fac:EquityAttributableToNoncontrollingInterest,0,iso4217:USD,INF,FACT4ae403ae,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/22,fac:Equity,0,iso4217:USD,INF,FACT93c240a3,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/22,fac:LiabilitiesAndEquity,0,iso4217:USD,INF,FACT969207bd,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2022-01-01 | 2022-12-31,fac:CostOfRevenue,0,iso4217:USD,INF,FACTf2090b88,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2022-01-01 | 2022-12-31,fac:Revenues,0,iso4217:USD,INF,FACT4fb444b0,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2022-01-01 | 2022-12-31,fac:OtherOperatingIncomeExpenses,0,iso4217:USD,INF,FACT913990c5,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2022-01-01 | 2022-12-31,fac:GrossProfit,0,iso4217:USD,INF,FACT4d4f94d6,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2022-01-01 | 2022-12-31,fac:OperatingExpenses,0,iso4217:USD,INF,FACT262451c1,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2022-01-01 | 2022-12-31,fac:OperatingIncomeLoss,0,iso4217:USD,INF,FACT9e761f78,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2022-01-01 | 2022-12-31,fac:IncomeLossFromContinuingOperationsBeforeTax,0,iso4217:USD,INF,FACT42001b6b,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2022-01-01 | 2022-12-31,fac:NonoperatingIncomeLossIncludingInterestAndDebtExpense,0,iso4217:USD,INF,FACT2c3b9962,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2022-01-01 | 2022-12-31,fac:IncomeTaxExpenseBenefit,0,iso4217:USD,INF,FACTffbd5453,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2022-01-01 | 2022-12-31,fac:IncomeLossFromContinuingOperationsAfterTax,0,iso4217:USD,INF,FACT99dd8800,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2022-01-01 | 2022-12-31,fac:ProfitLoss,0,iso4217:USD,INF,FACT23127603,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2022-01-01 | 2022-12-31,fac:IncomeLossFromDiscontinuedOperationsNetOfTax,0,iso4217:USD,INF,FACT9c8dcf1e,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2022-01-01 | 2022-12-31,fac:NetCashFlowFromFinancingActivitiesDiscontinued,0,iso4217:USD,INF,FACT80fde7f8,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2022-01-01 | 2022-12-31,fac:ProfitLossAttributableToControllingInterests,0,iso4217:USD,INF,FACTfa34350e,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2022-01-01 | 2022-12-31,fac:ComprehensiveIncomeLossAttributableToNoncontrollingInterest,0,iso4217:USD,INF,FACT23a56bc2,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2022-01-01 | 2022-12-31,fac:NetCashFlowFromInvestingActivities,0,iso4217:USD,INF,FACTeb9622ef,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2022-01-01 | 2022-12-31,fac:OtherComprehensiveIncomeLoss,0,iso4217:USD,INF,FACTfd9fa276,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2022-01-01 | 2022-12-31,fac:NetCashFlowFromInvestingActivitiesContinuing,0,iso4217:USD,INF,FACT240efcba,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2022-01-01 | 2022-12-31,fac:ProfitLossAvailableToControllingInterestsBasic,0,iso4217:USD,INF,FACT93a4207f,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2022-01-01 | 2022-12-31,fac:NetCashFlowFromOperatingActivitiesContinuing,0,iso4217:USD,INF,FACT4d9ee9cb,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2022-01-01 | 2022-12-31,fac:NetCashFlowFromFinancingActivities,0,iso4217:USD,INF,FACT8a5d69c4,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2022-01-01 | 2022-12-31,fac:ProfitLossAttributableToNoncontrollingInterest,0,iso4217:USD,INF,FACT4879b314,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2022-01-01 | 2022-12-31,fac:NetCashFlowFromOperatingActivitiesDiscontinued,0,iso4217:USD,INF,FACTf023a6f3,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2022-01-01 | 2022-12-31,fac:ComprehensiveIncomeLoss,0,iso4217:USD,INF,FACT96f46761,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2022-01-01 | 2022-12-31,fac:NetCashFlowFromFinancingActivitiesContinuing,0,iso4217:USD,INF,FACTeec665f1,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2022-01-01 | 2022-12-31,fac:NetCashFlowFromOperatingActivities,0,iso4217:USD,INF,FACT96437aa0,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2022-01-01 | 2022-12-31,fac:NetCashFlowFromInvestingActivitiesDiscontinued,0,iso4217:USD,INF,FACT85ada0e6,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2022-01-01 | 2022-12-31,fac:PreferenceSharesDividendsOtherAdjustments,0,iso4217:USD,INF,FACT2642311d,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2022-01-01 | 2022-12-31,fac:ComprehensiveIncomeLossAttributableToParent,0,iso4217:USD,INF,FACT48ceaed5,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2022-01-01 | 2022-12-31,fac:NetCashFlow,0,iso4217:USD,INF,FACT851abd27,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/21,fac:CurrentAssets,0,iso4217:USD,INF,FACT569c7016,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/21,fac:Assets,0,iso4217:USD,INF,FACTeb213f2e,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2022-01-01 | 2022-12-31,fac:NetCashFlowContinuing,0,iso4217:USD,INF,FACT5b207493,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/21,fac:CurrentLiabilities,0,iso4217:USD,INF,FACT8a335246,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2022-01-01 | 2022-12-31,fac:ExchangeGainsLosses,0,iso4217:USD,INF,FACT37573b3d,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/21,fac:NoncurrentAssets,0,iso4217:USD,INF,FACT30fcac45,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2022-01-01 | 2022-12-31,fac:NetCashFlowDiscontinued,0,iso4217:USD,INF,FACTe96df289,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/21,fac:Liabilities,0,iso4217:USD,INF,FACT35aceb5b,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/21,fac:NoncurrentLiabilities,0,iso4217:USD,INF,FACTe408d04f,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/21,fac:EquityAttributableToControllingInterest,0,iso4217:USD,INF,FACTe1589751,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/21,fac:LiabilitiesAndEquity,0,iso4217:USD,INF,FACT54be8633,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2021-01-01 | 2021-12-31,fac:Revenues,0,iso4217:USD,INF,FACTe6f30029,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/21,fac:Equity,0,iso4217:USD,INF,FACT3a85043a,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2021-01-01 | 2021-12-31,fac:GrossProfit,0,iso4217:USD,INF,FACT022e59ea,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2021-01-01 | 2021-12-31,fac:OperatingExpenses,0,iso4217:USD,INF,FACT6c15dbe3,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2021-01-01 | 2021-12-31,fac:OperatingIncomeLoss,0,iso4217:USD,INF,FACTb7c84888,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/21,fac:EquityAttributableToNoncontrollingInterest,0,iso4217:USD,INF,FACT8f631558,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2021-01-01 | 2021-12-31,fac:CostOfRevenue,0,iso4217:USD,INF,FACT69459cfd,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2021-01-01 | 2021-12-31,fac:OtherOperatingIncomeExpenses,0,iso4217:USD,INF,FACT66b555df,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2021-01-01 | 2021-12-31,fac:IncomeLossFromContinuingOperationsBeforeTax,0,iso4217:USD,INF,FACT0299442b,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2021-01-01 | 2021-12-31,fac:ProfitLossAttributableToNoncontrollingInterest,0,iso4217:USD,INF,FACT6e591644,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2021-01-01 | 2021-12-31,fac:NonoperatingIncomeLossIncludingInterestAndDebtExpense,0,iso4217:USD,INF,FACT0585ce92,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2021-01-01 | 2021-12-31,fac:IncomeLossFromContinuingOperationsAfterTax,0,iso4217:USD,INF,FACTdeef4038,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2021-01-01 | 2021-12-31,fac:PreferenceSharesDividendsOtherAdjustments,0,iso4217:USD,INF,FACT66db6e5d,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2021-01-01 | 2021-12-31,fac:IncomeLossFromDiscontinuedOperationsNetOfTax,0,iso4217:USD,INF,FACT07c90335,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2021-01-01 | 2021-12-31,fac:IncomeTaxExpenseBenefit,0,iso4217:USD,INF,FACT6ca2c622,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2021-01-01 | 2021-12-31,fac:ProfitLoss,0,iso4217:USD,INF,FACT0d698d09,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2021-01-01 | 2021-12-31,fac:ProfitLossAttributableToControllingInterests,0,iso4217:USD,INF,FACTdc14905e,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2021-01-01 | 2021-12-31,fac:ComprehensiveIncomeLossAttributableToParent,0,iso4217:USD,INF,FACT6170f925,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2021-01-01 | 2021-12-31,fac:OtherComprehensiveIncomeLoss,0,iso4217:USD,INF,FACT638b2943,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2021-01-01 | 2021-12-31,fac:NetCashFlowFromOperatingActivitiesContinuing,0,iso4217:USD,INF,FACT6420be3b,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2021-01-01 | 2021-12-31,fac:NetCashFlowFromOperatingActivities,0,iso4217:USD,INF,FACTd171b298,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2021-01-01 | 2021-12-31,fac:ComprehensiveIncomeLossAttributableToNoncontrollingInterest,0,iso4217:USD,INF,FACT0a1b3c32,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2021-01-01 | 2021-12-31,fac:NetCashFlowFromInvestingActivitiesContinuing,0,iso4217:USD,INF,FACT0857f195,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2021-01-01 | 2021-12-31,fac:ProfitLossAvailableToControllingInterestsBasic,0,iso4217:USD,INF,FACT08e0ec54,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2021-01-01 | 2021-12-31,fac:ComprehensiveIncomeLoss,0,iso4217:USD,INF,FACT692ba77f,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2021-01-01 | 2021-12-31,fac:NetCashFlowFromOperatingActivitiesDiscontinued,0,iso4217:USD,INF,FACT633c3482,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2021-01-01 | 2021-12-31,fac:NetCashFlowDiscontinued,0,iso4217:USD,INF,FACT72293ea2,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2021-01-01 | 2021-12-31,fac:NetCashFlowFromFinancingActivitiesContinuing,0,iso4217:USD,INF,FACT61c7e4e4,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2021-01-01 | 2021-12-31,fac:ExchangeGainsLosses,0,iso4217:USD,INF,FACTc7cf2fc0,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2021-01-01 | 2021-12-31,fac:NetCashFlowFromInvestingActivities,0,iso4217:USD,INF,FACT6497a3fa,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2021-01-01 | 2021-12-31,fac:NetCashFlowFromFinancingActivities,0,iso4217:USD,INF,FACT1942fbb5,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2021-01-01 | 2021-12-31,fac:NetCashFlowContinuing,0,iso4217:USD,INF,FACT1c12bcab,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2021-01-01 | 2021-12-31,fac:NetCashFlowFromInvestingActivitiesDiscontinued,0,iso4217:USD,INF,FACT02f77fa9,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2021-01-01 | 2021-12-31,fac:NetCashFlowFromFinancingActivitiesDiscontinued,0,iso4217:USD,INF,FACT777979bc,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/20,fac:Assets,0,iso4217:USD,INF,FACTc29f68de,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/20,fac:CurrentAssets,0,iso4217:USD,INF,FACT1ca5a16a,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2021-01-01 | 2021-12-31,fac:NetCashFlow,0,iso4217:USD,INF,FACTa9f4adc9,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/20,fac:NoncurrentAssets,0,iso4217:USD,INF,FACT729e2363,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/20,fac:EquityAttributableToNoncontrollingInterest,0,iso4217:USD,INF,FACT1e5e710c,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/20,fac:CurrentLiabilities,0,iso4217:USD,INF,FACT13556848,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/20,fac:Liabilities,0,iso4217:USD,INF,FACT19f5e674,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/20,fac:NoncurrentLiabilities,0,iso4217:USD,INF,FACT1b0e3612,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/20,fac:EquityAttributableToControllingInterest,0,iso4217:USD,INF,FACT7065f305,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2020-01-01 | 2020-12-31,fac:OperatingIncomeLoss,0,iso4217:USD,INF,FACTca1d10c7,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2020-01-01 | 2020-12-31,fac:GrossProfit,0,iso4217:USD,INF,FACT11779e6d,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2020-01-01 | 2020-12-31,fac:OtherOperatingIncomeExpenses,0,iso4217:USD,INF,FACTa42692ce,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2020-01-01 | 2020-12-31,fac:Revenues,0,iso4217:USD,INF,FACTcaaa0d06,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/20,fac:LiabilitiesAndEquity,0,iso4217:USD,INF,FACTa4918f0f,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2020-01-01 | 2020-12-31,fac:NonoperatingIncomeLossIncludingInterestAndDebtExpense,0,iso4217:USD,INF,FACTcf4d57d9,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/20,fac:Equity,0,iso4217:USD,INF,FACT16dc0915,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2020-01-01 | 2020-12-31,fac:CostOfRevenue,0,iso4217:USD,INF,FACT7717423e,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2020-01-01 | 2020-12-31,fac:OperatingExpenses,0,iso4217:USD,INF,FACT1427d973,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2020-01-01 | 2020-12-31,fac:IncomeTaxExpenseBenefit,0,iso4217:USD,INF,FACT1490c4b2,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2020-01-01 | 2020-12-31,fac:PreferenceSharesDividendsOtherAdjustments,0,iso4217:USD,INF,FACT34f61d55,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2020-01-01 | 2020-12-31,fac:ProfitLossAvailableToControllingInterestsBasic,0,iso4217:USD,INF,FACT3cad430f,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2020-01-01 | 2020-12-31,fac:IncomeLossFromContinuingOperationsAfterTax,0,iso4217:USD,INF,FACT7aab46bb,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2020-01-01 | 2020-12-31,fac:IncomeLossFromDiscontinuedOperationsNetOfTax,0,iso4217:USD,INF,FACTc8e6c0a1,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2020-01-01 | 2020-12-31,fac:ProfitLossAttributableToControllingInterests,0,iso4217:USD,INF,FACT553d567e,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2020-01-01 | 2020-12-31,fac:ProfitLossAttributableToNoncontrollingInterest,0,iso4217:USD,INF,FACTe770d064,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2020-01-01 | 2020-12-31,fac:ProfitLoss,0,iso4217:USD,INF,FACT3b06d477,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2020-01-01 | 2020-12-31,fac:IncomeLossFromContinuingOperationsBeforeTax,0,iso4217:USD,INF,FACTa176d5d0,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2020-01-01 | 2020-12-31,fac:ComprehensiveIncomeLossAttributableToParent,0,iso4217:USD,INF,FACTe7c7cda5,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2020-01-01 | 2020-12-31,fac:NetCashFlowFromOperatingActivitiesDiscontinued,0,iso4217:USD,INF,FACTe8370487,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2020-01-01 | 2020-12-31,fac:OtherComprehensiveIncomeLoss,0,iso4217:USD,INF,FACT5296c106,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2020-01-01 | 2020-12-31,fac:NetCashFlowFromInvestingActivities,0,iso4217:USD,INF,FACT3355d173,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2020-01-01 | 2020-12-31,fac:NetCashFlowFromInvestingActivitiesContinuing,0,iso4217:USD,INF,FACT8b079fca,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2020-01-01 | 2020-12-31,fac:ComprehensiveIncomeLossAttributableToNoncontrollingInterest,0,iso4217:USD,INF,FACT89fc4fac,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2020-01-01 | 2020-12-31,fac:ComprehensiveIncomeLoss,0,iso4217:USD,INF,FACT39fd0411,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2020-01-01 | 2020-12-31,fac:NetCashFlowFromOperatingActivitiesContinuing,0,iso4217:USD,INF,FACTe2978abb,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2020-01-01 | 2020-12-31,fac:NetCashFlowFromOperatingActivities,0,iso4217:USD,INF,FACTe06c5add,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2020-01-01 | 2020-12-31,fac:NetCashFlowFromInvestingActivitiesDiscontinued,0,iso4217:USD,INF,FACTe53c1dc3,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2020-01-01 | 2020-12-31,fac:NetCashFlowContinuing,0,iso4217:USD,INF,FACT34fe460b,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2020-01-01 | 2020-12-31,fac:NetCashFlow,0,iso4217:USD,INF,FACTe00a3a01,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/19,fac:Assets,0,iso4217:USD,INF,FACT3c7c3e12,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/19,fac:CurrentAssets,0,iso4217:USD,INF,FACT36dcb02e,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/19,fac:EquityAttributableToNoncontrollingInterest,0,iso4217:USD,INF,FACTea1da9fc,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/19,fac:Equity,0,iso4217:USD,INF,FACTe246f7a6,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2020-01-01 | 2020-12-31,fac:NetCashFlowFromFinancingActivitiesDiscontinued,0,iso4217:USD,INF,FACTef23d560,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2020-01-01 | 2020-12-31,fac:NetCashFlowFromFinancingActivitiesContinuing,0,iso4217:USD,INF,FACT81185769,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/19,fac:NoncurrentAssets,0,iso4217:USD,INF,FACTe7a1ad79,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/19,fac:CurrentLiabilities,0,iso4217:USD,INF,FACTe5ed60de,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/19,fac:LiabilitiesAndEquity,0,iso4217:USD,INF,FACT8c7d75af,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/19,fac:EquityAttributableToControllingInterest,0,iso4217:USD,INF,FACT399b64cd,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/19,fac:Liabilities,0,iso4217:USD,INF,FACT55ec2b63,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,12/31/19,fac:NoncurrentLiabilities,0,iso4217:USD,INF,FACT8bd6e2d7,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2019-01-01 | 2019-12-31,fac:Revenues,0,iso4217:USD,INF,FACTe716b0b8,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2020-01-01 | 2020-12-31,fac:NetCashFlowFromFinancingActivities,0,iso4217:USD,INF,FACT529e9a58,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2020-01-01 | 2020-12-31,fac:NetCashFlowDiscontinued,0,iso4217:USD,INF,FACT31ae0115,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2020-01-01 | 2020-12-31,fac:ExchangeGainsLosses,0,iso4217:USD,INF,FACT8e31b808,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2019-01-01 | 2019-12-31,fac:CostOfRevenue,0,iso4217:USD,INF,FACT9f93afe9,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2019-01-01 | 2019-12-31,fac:IncomeTaxExpenseBenefit,0,iso4217:USD,INF,FACT9a74f536,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2019-01-01 | 2019-12-31,fac:NonoperatingIncomeLossIncludingInterestAndDebtExpense,0,iso4217:USD,INF,FACTf353fd86,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2019-01-01 | 2019-12-31,fac:GrossProfit,0,iso4217:USD,INF,FACTf4f86afe,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2019-01-01 | 2019-12-31,fac:OperatingIncomeLoss,0,iso4217:USD,INF,FACT411e7b9c,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2019-01-01 | 2019-12-31,fac:IncomeLossFromContinuingOperationsBeforeTax,0,iso4217:USD,INF,FACTf44f773f,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2019-01-01 | 2019-12-31,fac:OtherOperatingIncomeExpenses,0,iso4217:USD,INF,FACT906366cb,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2019-01-01 | 2019-12-31,fac:OperatingExpenses,0,iso4217:USD,INF,FACT9ac3e8f7,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2019-01-01 | 2019-12-31,fac:IncomeLossFromContinuingOperationsAfterTax,0,iso4217:USD,INF,FACT2839732c,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2019-01-01 | 2019-12-31,fac:IncomeLossFromDiscontinuedOperationsNetOfTax,0,iso4217:USD,INF,FACTf11f3021,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2019-01-01 | 2019-12-31,fac:ProfitLossAttributableToControllingInterests,0,iso4217:USD,INF,FACT2ac2a34a,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2019-01-01 | 2019-12-31,fac:ComprehensiveIncomeLoss,0,iso4217:USD,INF,FACT9ffd946b,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2019-01-01 | 2019-12-31,fac:ProfitLossAvailableToControllingInterestsBasic,0,iso4217:USD,INF,FACTfe36df40,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2019-01-01 | 2019-12-31,fac:PreferenceSharesDividendsOtherAdjustments,0,iso4217:USD,INF,FACT900d5d49,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2019-01-01 | 2019-12-31,fac:ComprehensiveIncomeLossAttributableToNoncontrollingInterest,0,iso4217:USD,INF,FACTfccd0f26,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2019-01-01 | 2019-12-31,fac:ComprehensiveIncomeLossAttributableToParent,0,iso4217:USD,INF,FACT97a6ca31,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2019-01-01 | 2019-12-31,fac:ProfitLossAttributableToNoncontrollingInterest,0,iso4217:USD,INF,FACT988f2550,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2019-01-01 | 2019-12-31,fac:ProfitLoss,0,iso4217:USD,INF,FACTfbbfbe1d,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2019-01-01 | 2019-12-31,fac:NetCashFlowFromOperatingActivitiesContinuing,0,iso4217:USD,INF,FACT92f68d2f,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2019-01-01 | 2019-12-31,fac:OtherComprehensiveIncomeLoss,0,iso4217:USD,INF,FACT955d1a57,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2019-01-01 | 2019-12-31,fac:NetCashFlowFromFinancingActivities,0,iso4217:USD,INF,FACT5c13df27,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2019-01-01 | 2019-12-31,fac:NetCashFlowFromOperatingActivitiesDiscontinued,0,iso4217:USD,INF,FACT37cf07f1,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2019-01-01 | 2019-12-31,fac:NetCashFlowFromOperatingActivities,0,iso4217:USD,INF,FACT858281eb,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2019-01-01 | 2019-12-31,fac:NetCashFlowFromInvestingActivities,0,iso4217:USD,INF,FACT8779518d,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2019-01-01 | 2019-12-31,fac:NetCashFlowContinuing,0,iso4217:USD,INF,FACTee5e593d,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2019-01-01 | 2019-12-31,fac:NetCashFlowFromInvestingActivitiesContinuing,0,iso4217:USD,INF,FACT5ca4c2e6,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2019-01-01 | 2019-12-31,fac:NetCashFlowFromFinancingActivitiesDiscontinued,0,iso4217:USD,INF,FACT85359c2a,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2019-01-01 | 2019-12-31,fac:NetCashFlowFromFinancingActivitiesContinuing,0,iso4217:USD,INF,FACT3534d797,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2019-01-01 | 2019-12-31,fac:NetCashFlowFromInvestingActivitiesDiscontinued,0,iso4217:USD,INF,FACT56044cda,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2019-01-01 | 2019-12-31,fac:ExchangeGainsLosses,0,iso4217:USD,INF,FACT3583ca56,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2019-01-01 | 2019-12-31,fac:NetCashFlow,0,iso4217:USD,INF,FACT5ee80f41,
+30810137d58f76b84afd | http://standards.iso.org/iso/17442,2019-01-01 | 2019-12-31,fac:NetCashFlowDiscontinued,0,iso4217:USD,INF,FACT3dd8940c,

--- a/examples/seattle_method_demo/fixtures/transactions.csv
+++ b/examples/seattle_method_demo/fixtures/transactions.csv
@@ -1,0 +1,33 @@
+﻿JournalEntryID,EconomicEntityIdentifier,TransactionPeriod,Account,GeneralLedgerAccountCode,TransactionDescriptionCode,Amount,Units,Rounding,Balance,EffectiveValue,Sequence,TransactionDescription,DocumentID,Flag,Key
+JE-201,30810137d58f76b84afd,1/1/24,000-1100-00,mini:CashAndCashEquivalents,mini:ProceedsFromInvestmentsByOwner,10000,iso4217:USD,2,D,10000,1,Investment by owner to open a lemonade stand.,,No,176
+JE-201,30810137d58f76b84afd,1/1/24,000-3100-00,mini:PaidInCapital,mini:InvestmentsByOwner,10000,iso4217:USD,2,C,-10000,2,Investment by owner to open a lemonade stand.,,No,177
+JE-202,30810137d58f76b84afd,1/2/24,000-1100-00,mini:CashAndCashEquivalents,mini:ProceedsFromAdditionalLongtermBorrowings,2000,iso4217:USD,2,D,2000,1,Long term borrowing to purchase refrigerator.,,No,178
+JE-202,30810137d58f76b84afd,1/2/24,000-2300-00,mini:LongtermDebt,mini:AdditionalLongtermBorrowings,2000,iso4217:USD,2,C,-2000,2,Long term borrowing to purchase refrigerator.,,No,179
+JE-203,30810137d58f76b84afd,1/5/24,000-1500-00,mini:PropertyPlantAndEquipment,mini:CapitalAdditionsPropertyPlantAndEquipment,1000,iso4217:USD,2,D,1000,1,Purchase of refrigerator using cash from additional borrowings.,,No,180
+JE-203,30810137d58f76b84afd,1/5/24,000-1100-00,mini:CashAndCashEquivalents,mini:PaymentForCapitalAdditionsOfPropertyPlantEquipment,1000,iso4217:USD,2,C,-1000,2,Purchase of refrigerator using cash from additional borrowings.,,No,181
+JE-204,30810137d58f76b84afd,1/10/24,000-1300-00,mini:Inventories,mini:PurchasesOfInventoryForSale,5000,iso4217:USD,2,D,5000,1,Purchase of lemons to put intoinventory on account.,,No,182
+JE-204,30810137d58f76b84afd,1/10/24,000-2150-00,mini:AccountsPayable,mini:PurchasesInventoryForSaleOnAccount,5000,iso4217:USD,2,C,-5000,2,Purchase of lemons to put intoinventory on account.,,No,183
+JE-205,30810137d58f76b84afd,1/15/24,000-5100-00,mini:CostsOfSales,mini:NetIncomeLoss,3000,iso4217:USD,2,D,3000,1,Payment for contractor to work the lemonade stand.,,No,184
+JE-205,30810137d58f76b84afd,1/15/24,000-2150-00,mini:AccountsPayable,mini:PurchasesInventoryForSaleOnAccount,3000,iso4217:USD,2,C,-3000,2,Payment for contractor to work the lemonade stand.,,No,185
+JE-206,30810137d58f76b84afd,1/16/24,000-1200-00,mini:Receivables,mini:IncreaseInReceivablesFromSalesOnAccount,8000,iso4217:USD,2,D,8000,1,Sales on account.,,No,186
+JE-206,30810137d58f76b84afd,1/16/24,000-4100-00,mini:Sales,mini:NetIncomeLoss,8000,iso4217:USD,2,C,-8000,2,Sales on account.,,No,187
+JE-206,30810137d58f76b84afd,1/16/24,000-5100-00,mini:CostsOfSales,mini:NetIncomeLoss,2000,iso4217:USD,2,D,2000,3,Costs related to sales on account.,,No,188
+JE-206,30810137d58f76b84afd,1/16/24,000-1300-00,mini:Inventories,mini:DecreaseInInventoriesFromSales,2000,iso4217:USD,2,C,-2000,4,Costs related to sales on account.,,No,189
+JE-207,30810137d58f76b84afd,1/20/24,000-1100-00,mini:CashAndCashEquivalents,mini:ProceedsFromCollectionOfReceivables,8000,iso4217:USD,2,D,8000,1,Collection of accounts receivable.,,No,190
+JE-207,30810137d58f76b84afd,1/20/24,000-1200-00,mini:Receivables,mini:CollectionOfReceivables,8000,iso4217:USD,2,C,-8000,2,Collection of accounts receivable.,,No,191
+JE-208,30810137d58f76b84afd,1/21/24,000-2150-00,mini:AccountsPayable,mini:DecreaseFromPaymentAccountsPayable,7000,iso4217:USD,2,D,7000,1,Payment of accounts payable.,,No,192
+JE-208,30810137d58f76b84afd,1/21/24,000-1100-00,mini:CashAndCashEquivalents,mini:PaymentOfAccountsPayable,7000,iso4217:USD,2,C,-7000,2,Payment of accounts payable.,,No,193
+JE-209,30810137d58f76b84afd,1/25/24,000-2300-00,mini:LongtermDebt,mini:RepaymentLongtermBorrowings,1000,iso4217:USD,2,D,1000,1,Payment of long term debt including accrued interest.,,No,194
+JE-209,30810137d58f76b84afd,1/25/24,000-1100-00,mini:CashAndCashEquivalents,mini:PaymentForReductionOfLongtermBorrowings,1000,iso4217:USD,2,C,-1000,2,Payment of long term debt including accrued interest.,,No,195
+JE-209,30810137d58f76b84afd,1/25/24,000-1100-00,mini:CashAndCashEquivalents,mini:PaymentOfInterest,150,iso4217:USD,2,C,-150,3,Payment of long term debt including accrued interest.,,No,211
+JE-209,30810137d58f76b84afd,1/25/24,000-2160-00,mini:AccruedExpenses,mini:DecreaseFromPaymentOfInterest,150,iso4217:USD,2,D,150,4,Payment of long term debt including accrued interest.,,No,196
+JE-210,30810137d58f76b84afd,1/24/24,000-5400-00,mini:InterestExpense,mini:NetIncomeLoss,150,iso4217:USD,2,D,150,1,Accrual of interest on debt.,,No,197
+JE-210,30810137d58f76b84afd,1/24/24,000-2160-00,mini:AccruedExpenses,mini:InterestAccrued,150,iso4217:USD,2,C,-150,2,Accrual of interest on debt.,,No,198
+JE-223,30810137d58f76b84afd,1/28/24,000-5100-00,mini:CostsOfSales,mini:NetIncomeLoss,300,iso4217:USD,2,D,300,1,"Closing entry. Inventory write offs, adjust to physical.",,No,203
+JE-223,30810137d58f76b84afd,1/28/24,000-1300-00,mini:Inventories,mini:InventoryWrittenOff,300,iso4217:USD,2,C,-300,2,"Closing entry. Inventory write offs, adjust to physical.",,No,204
+JE-224,30810137d58f76b84afd,1/28/24,000-5200-00,mini:DepreciationAndAmortization,mini:NetIncomeLoss,100,iso4217:USD,2,D,100,1,Closing entry. Depreciation and amortization expensed.,,No,205
+JE-224,30810137d58f76b84afd,1/28/24,000-1500-00,mini:PropertyPlantAndEquipment,mini:DecreaseFromDepreciationAndAmortization,100,iso4217:USD,2,C,-100,2,Closing entry. Depreciation and amortization expensed.,,No,206
+JE-225,30810137d58f76b84afd,1/28/24,000-1500-00,mini:PropertyPlantAndEquipment,mini:PropertyPlantAndEquipmentWrittenOff,0,iso4217:USD,2,D,0,1,Closing entry. Write of of PPE.,,No,207
+JE-225,30810137d58f76b84afd,1/28/24,000-5500-00,mini:NonoperatingIncomeExpenses,mini:NetIncomeLoss,0,iso4217:USD,2,C,0,2,Closing entry. Write of of PPE.,,No,208
+JE-226,30810137d58f76b84afd,1/29/24,000-6100-00,mini:IncomeTaxExpenseBenefit,mini:NetIncomeLoss,400,iso4217:USD,2,D,400,1,Closing entry. Book taxes.,,No,209
+JE-226,30810137d58f76b84afd,1/29/24,000-2160-00,mini:AccruedExpenses,mini:InterestAccrued,400,iso4217:USD,2,C,-400,2,Closing entry. Book taxes.,,No,210

--- a/examples/seattle_method_demo/fixtures/transactions.csv
+++ b/examples/seattle_method_demo/fixtures/transactions.csv
@@ -19,7 +19,7 @@ JE-208,30810137d58f76b84afd,1/21/24,000-2150-00,mini:AccountsPayable,mini:Decrea
 JE-208,30810137d58f76b84afd,1/21/24,000-1100-00,mini:CashAndCashEquivalents,mini:PaymentOfAccountsPayable,7000,iso4217:USD,2,C,-7000,2,Payment of accounts payable.,,No,193
 JE-209,30810137d58f76b84afd,1/25/24,000-2300-00,mini:LongtermDebt,mini:RepaymentLongtermBorrowings,1000,iso4217:USD,2,D,1000,1,Payment of long term debt including accrued interest.,,No,194
 JE-209,30810137d58f76b84afd,1/25/24,000-1100-00,mini:CashAndCashEquivalents,mini:PaymentForReductionOfLongtermBorrowings,1000,iso4217:USD,2,C,-1000,2,Payment of long term debt including accrued interest.,,No,195
-JE-209,30810137d58f76b84afd,1/25/24,000-1100-00,mini:CashAndCashEquivalents,mini:PaymentOfInterest,150,iso4217:USD,2,C,-150,3,Payment of long term debt including accrued interest.,,No,211
+JE-209,30810137d58f76b84afd,1/25/24,000-1100-00,mini:CashAndCashEquivalents,mini:PaymentInterest,150,iso4217:USD,2,C,-150,3,Payment of long term debt including accrued interest.,,No,211
 JE-209,30810137d58f76b84afd,1/25/24,000-2160-00,mini:AccruedExpenses,mini:DecreaseFromPaymentOfInterest,150,iso4217:USD,2,D,150,4,Payment of long term debt including accrued interest.,,No,196
 JE-210,30810137d58f76b84afd,1/24/24,000-5400-00,mini:InterestExpense,mini:NetIncomeLoss,150,iso4217:USD,2,D,150,1,Accrual of interest on debt.,,No,197
 JE-210,30810137d58f76b84afd,1/24/24,000-2160-00,mini:AccruedExpenses,mini:InterestAccrued,150,iso4217:USD,2,C,-150,2,Accrual of interest on debt.,,No,198

--- a/examples/seattle_method_demo/ingest_transactions.py
+++ b/examples/seattle_method_demo/ingest_transactions.py
@@ -46,7 +46,11 @@ from collections import defaultdict
 from datetime import date, datetime
 from pathlib import Path
 
-CSV_PATH = Path("examples/seattle_method_demo/fixtures/transactions.csv")
+# Resolve relative to this file so the script works regardless of the
+# caller's CWD — matches the pattern ``main.py`` uses.
+CSV_PATH = (
+  Path(__file__).resolve().parent / "fixtures" / "transactions.csv"
+)
 
 
 def _get_ledger_client():

--- a/examples/seattle_method_demo/ingest_transactions.py
+++ b/examples/seattle_method_demo/ingest_transactions.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+"""Ingest Charlie Hoffman's 14-JE lemonade-stand dataset.
+
+Reads ``fixtures/transactions.csv``, groups by ``JournalEntryID``,
+and posts one event per JE via ``create-event-block`` with
+``apply_handlers=True``. Each line carries its ``TransactionDescriptionCode``
+on ``metadata['transaction_description_code']`` — the field the
+rollforward filter engine matches against (Phase 2 MVP per-line
+metadata plumbing).
+
+Pre-condition: ``load_taxonomy.py`` + ``seed_mappings.py`` have run
+against this graph (the JE lines reference mini concepts by
+element_external_id, which the journal_entry_recorded handler
+resolves against the Element table).
+
+CSV column convention (Charlie's format):
+
+- ``JournalEntryID``: e.g. "JE-201"
+- ``EconomicEntityIdentifier``: ignored (single entity in this dataset)
+- ``TransactionPeriod``: posting date in ``M/D/YY`` format
+- ``Account``: legacy CoA code (e.g. "000-1100-00"); preserved on
+  ``LineItem.metadata['source_account_code']`` for audit but not used
+  for element resolution
+- ``GeneralLedgerAccountCode``: the mini qname (e.g.
+  "mini:CashAndCashEquivalents") — used as the LineItem element
+  reference
+- ``TransactionDescriptionCode``: the flow concept (e.g.
+  "mini:ProceedsFromInvestmentsByOwner") — stamped on
+  LineItem.metadata for rollforward attribution
+- ``Amount``: whole dollars (multiply by 100 for cents)
+- ``Balance``: "D" for debit, "C" for credit
+- ``Sequence``: line order within the JE
+- ``TransactionDescription``: per-line memo
+
+Usage:
+    uv run python -m examples.seattle_method_demo.ingest_transactions <graph_id>
+    uv run python -m examples.seattle_method_demo.ingest_transactions <graph_id> --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from collections import defaultdict
+from datetime import date, datetime
+from pathlib import Path
+
+CSV_PATH = Path("examples/seattle_method_demo/fixtures/transactions.csv")
+
+
+def _get_ledger_client():
+  from robosystems_client.clients.ledger_client import LedgerClient
+
+  config_path = Path(".local/config.json")
+  if not config_path.exists():
+    raise SystemExit("Missing .local/config.json — run `just demo-user` first.")
+  with config_path.open() as f:
+    cfg = json.load(f)
+  return LedgerClient(
+    {
+      "base_url": cfg.get("base_url", "http://localhost:8000"),
+      "token": cfg["api_key"],
+    }
+  )
+
+
+def _parse_date(raw: str) -> date:
+  """Parse Charlie's ``M/D/YY`` format → date.
+
+  Two-digit years are assumed to be 20YY (the dataset is Q1 2024).
+  """
+  m, d, y = raw.split("/")
+  year = int(y)
+  if year < 100:
+    year += 2000
+  return date(year, int(m), int(d))
+
+
+def _read_csv_grouped(csv_path: Path) -> dict[str, list[dict]]:
+  """Read the CSV → {JournalEntryID: [line_row_dict, ...]}.
+
+  Preserves CSV row order; rows within a JE are sorted by Sequence on
+  the way out so JE-209's 4 lines stay in their intended order.
+  """
+  by_je: dict[str, list[dict]] = defaultdict(list)
+  # Charlie's CSV is UTF-8 BOM-prefixed; ``utf-8-sig`` strips the BOM
+  # so ``JournalEntryID`` parses cleanly as the first column header.
+  with csv_path.open(encoding="utf-8-sig") as f:
+    reader = csv.DictReader(f)
+    for row in reader:
+      je_id = row["JournalEntryID"]
+      by_je[je_id].append(row)
+
+  # Sort each JE's lines by Sequence (string-numeric in the CSV).
+  for je_id, rows in by_je.items():
+    rows.sort(key=lambda r: int(r["Sequence"]))
+  return dict(by_je)
+
+
+def _find_mini_taxonomy_id(client, graph_id: str) -> str | None:
+  """Find the mini CoA taxonomy_id on the graph by name."""
+  taxonomies = client.list_taxonomies(graph_id) or []
+  for tax in taxonomies:
+    if "mini" in (tax.get("name") or "").lower():
+      return tax.get("id")
+  return None
+
+
+def _build_qname_to_element_id_map(client, graph_id: str) -> dict[str, str]:
+  """Resolve every ``mini:*`` qname to its element_id on the graph.
+
+  Mini elements get persisted with ``source='native'`` (the source
+  CHECK constraint doesn't admit 'mini'), so we look them up by
+  taxonomy_id rather than source.
+  """
+  taxonomy_id = _find_mini_taxonomy_id(client, graph_id)
+  if not taxonomy_id:
+    raise SystemExit(
+      "No mini CoA taxonomy found on this graph. Did load_taxonomy.py run?"
+    )
+  out: dict[str, str] = {}
+  offset = 0
+  page_size = 1000
+  while True:
+    page = client.list_elements(
+      graph_id, taxonomy_id=taxonomy_id, limit=page_size, offset=offset
+    )
+    items = (page or {}).get("elements", [])
+    if not items:
+      break
+    for e in items:
+      if e.get("qname"):
+        out[e["qname"]] = e["id"]
+    if len(items) < page_size:
+      break
+    offset += page_size
+  return out
+
+
+def _build_event_payload(
+  je_id: str, rows: list[dict], qname_to_id: dict[str, str]
+) -> dict:
+  """Build a single ``create-event-block`` request from a JE's rows.
+
+  Flat-shape (single-entry) journal_entry_recorded metadata: one
+  ``line_items`` list, ``posting_date``, ``memo``. Each line carries
+  ``element_external_id`` (the mini qname) and per-line metadata
+  with ``transaction_description_code``.
+
+  ``source`` is ``manual`` — Charlie's data isn't from any of our
+  integrated sources (QB, Plaid, etc.), and the events DB CHECK
+  constraint only admits {manual, system, schedule, quickbooks, xero,
+  plaid}. ``manual`` is the closest semantic fit.
+  """
+  posting = _parse_date(rows[0]["TransactionPeriod"])
+
+  # Use the first line's description as the entry-level memo. Each line
+  # also carries its own description.
+  memo = rows[0]["TransactionDescription"]
+
+  line_items: list[dict] = []
+  for row in rows:
+    amount_dollars = int(row["Amount"])
+    amount_cents = amount_dollars * 100
+    balance = row["Balance"]
+    debit = amount_cents if balance == "D" else 0
+    credit = amount_cents if balance == "C" else 0
+
+    mini_qname = row["GeneralLedgerAccountCode"]
+    tdc = row["TransactionDescriptionCode"]
+    legacy_code = row["Account"]
+
+    element_id = qname_to_id.get(mini_qname)
+    if not element_id:
+      raise ValueError(
+        f"JE {je_id} line references {mini_qname!r}, which has no "
+        f"matching Element on this graph. Check load_taxonomy.py output."
+      )
+    line_items.append(
+      {
+        "element_id": element_id,
+        "debit_amount": debit,
+        "credit_amount": credit,
+        "description": row["TransactionDescription"],
+        "metadata": {
+          "transaction_description_code": tdc,
+          "source_account_code": legacy_code,
+          "mini_qname": mini_qname,
+        },
+      }
+    )
+
+  # Pick an event_category from REA's vocabulary. Best-fit per JE
+  # would require parsing the description; for this fixture we use
+  # 'adjustment' as a catch-all neutral category — the GL impact is
+  # what matters for the reconciliation, not the REA classification.
+  event_category = _pick_event_category(rows[0]["TransactionDescription"])
+
+  occurred_at = datetime.combine(posting, datetime.min.time()).isoformat() + "Z"
+
+  return {
+    "event_type": "journal_entry_recorded",
+    "event_category": event_category,
+    "event_class": "economic",
+    "source": "manual",
+    "external_id": f"seattle_method:{je_id}",
+    "occurred_at": occurred_at,
+    "description": f"Charlie Hoffman test case {je_id}: {memo}",
+    "apply_handlers": True,
+    "metadata": {
+      "posting_date": posting.isoformat(),
+      "memo": memo,
+      "status": "posted",
+      "type": _pick_entry_type(rows[0]["TransactionDescription"]),
+      "line_items": line_items,
+      "seattle_method_je_id": je_id,
+    },
+  }
+
+
+def _pick_event_category(description: str) -> str:
+  """Best-effort REA category from the JE description string."""
+  d = description.lower()
+  if "investment" in d or "borrowing" in d or "long term debt" in d:
+    return "financing"
+  if "sales" in d:
+    return "sales"
+  if "purchase" in d or "payment for" in d or "payment of" in d:
+    return "purchase"
+  if "collection" in d:
+    return "treasury"
+  if "depreciation" in d or "amortization" in d or "write off" in d or "taxes" in d:
+    return "adjustment"
+  if "interest" in d:
+    return "treasury"
+  return "adjustment"
+
+
+def _pick_entry_type(description: str) -> str:
+  """Detect closing entries — JE-223..226 are explicitly closing."""
+  if "closing entry" in description.lower():
+    return "closing"
+  if "accrual" in description.lower():
+    return "adjusting"
+  return "standard"
+
+
+def ingest(
+  graph_id: str, csv_path: Path = CSV_PATH, dry_run: bool = False
+) -> tuple[int, list[str]]:
+  """Walk the CSV's JEs and post each one via create-event-block.
+
+  Returns ``(events_created, warnings)``.
+  """
+  if not csv_path.exists():
+    raise SystemExit(f"Transactions CSV not found at {csv_path}")
+
+  grouped = _read_csv_grouped(csv_path)
+  print(f"Found {len(grouped)} JournalEntry(ies) in {csv_path.name}")
+
+  if dry_run:
+    # Build payloads with a fake mapping so dry-run validates shape.
+    fake_map = {
+      row["GeneralLedgerAccountCode"]: f"elem_dry_{row['GeneralLedgerAccountCode']}"
+      for rows in grouped.values()
+      for row in rows
+    }
+    for je_id, rows in sorted(grouped.items()):
+      payload = _build_event_payload(je_id, rows, fake_map)
+      print(
+        f"  {je_id}: {len(payload['metadata']['line_items'])} line(s), "
+        f"posting_date={payload['metadata']['posting_date']}, "
+        f"category={payload['event_category']}, "
+        f"type={payload['metadata']['type']}"
+      )
+    return len(grouped), []
+
+  client = _get_ledger_client()
+  print("Resolving mini qnames to element_ids on the graph…")
+  qname_to_id = _build_qname_to_element_id_map(client, graph_id)
+  print(f"  {len(qname_to_id)} mini element(s) found")
+
+  warnings: list[str] = []
+  created = 0
+  for je_id, rows in sorted(grouped.items()):
+    payload = _build_event_payload(je_id, rows, qname_to_id)
+    try:
+      response = client.create_event_block(graph_id, payload)
+      created += 1
+      print(f"  ✓ {je_id} → event {response.id} status={response.status}")
+    except Exception as exc:  # noqa: BLE001 — surface every failure for diagnosis
+      warnings.append(f"{je_id}: {exc}")
+      print(f"  ✗ {je_id}: {exc}")
+
+  return created, warnings
+
+
+def main() -> None:
+  parser = argparse.ArgumentParser(
+    description="Ingest Charlie's 14-JE lemonade-stand dataset as Events.",
+  )
+  parser.add_argument("graph_id", help="Target graph id.")
+  parser.add_argument(
+    "--csv",
+    type=Path,
+    default=CSV_PATH,
+    help="Path to the transactions CSV.",
+  )
+  parser.add_argument(
+    "--dry-run",
+    action="store_true",
+    help="Build payloads + report shape; do not call the API.",
+  )
+  args = parser.parse_args()
+
+  created, warnings = ingest(args.graph_id, args.csv, dry_run=args.dry_run)
+
+  if warnings:
+    print(f"\n{len(warnings)} JE(s) failed:")
+    for w in warnings:
+      print(f"  ⚠️  {w}")
+
+  action = "Would create" if args.dry_run else "Created"
+  print(f"\n{action} {created} event(s).")
+
+
+if __name__ == "__main__":
+  main()

--- a/examples/seattle_method_demo/load_taxonomy.py
+++ b/examples/seattle_method_demo/load_taxonomy.py
@@ -38,7 +38,6 @@ Usage:
 from __future__ import annotations
 
 import argparse
-import sys
 import xml.etree.ElementTree as ET
 from collections import defaultdict
 from dataclasses import dataclass, field

--- a/examples/seattle_method_demo/load_taxonomy.py
+++ b/examples/seattle_method_demo/load_taxonomy.py
@@ -1,0 +1,534 @@
+#!/usr/bin/env python3
+"""Load the Seattle Method ``mini`` reporting framework as a CoA.
+
+Parses Charlie Hoffman's mini XBRL taxonomy (already pulled into
+``local/taxonomies/mini/`` by ``pull_mini.sh``) and ingests it as a
+``chart_of_accounts`` Taxonomy Block — identical shape to how a
+QuickBooks CoA import or a hand-authored CoA (see
+``examples.roboledger_demo.create_chart_of_accounts``) lands in the
+system. Mini concepts become Element rows; mini's presentation
+linkbases supply the parent_ref hierarchy.
+
+**Sources parsed** (all under ``local/taxonomies/mini/``):
+
+- ``mini.xsd`` — concept declarations: name, type, ``xbrli:balance``,
+  ``xbrli:periodType``, ``substitutionGroup`` (for abstract/hypercube
+  detection).
+- ``mini-lab.xml`` — human-readable labels (the Element ``name`` field).
+- ``mini-pre-*.xml`` — presentation linkbases. Each file is one
+  XBRL Network covering one statement or disclosure. A concept can
+  appear in multiple networks; we use a canonical-parent priority
+  (BalanceSheet > IncomeStatement > CashFlowStatement > ChangesInEquity
+  > roll-forwards > everything else) so each Element ends up with a
+  single deterministic parent_ref.
+
+**Why this is a CoA shape, not a "load the full taxonomy" shape**:
+Charlie's mini collapses the chart-of-accounts and the reporting
+framework into one structure (his "fix the process" thesis — every GL
+account IS its own reporting concept). We treat it the same way our
+QB sync treats QB accounts — as a tenant CoA. Future cross-taxonomy
+test cases (us-gaap, IFRS) would each be loaded the same way into
+their own tenant graphs.
+
+Usage:
+    uv run python -m examples.seattle_method_demo.load_taxonomy <graph_id>
+    uv run python -m examples.seattle_method_demo.load_taxonomy <graph_id> --taxonomy-dir <path>
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import xml.etree.ElementTree as ET
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# ── XBRL namespaces ──────────────────────────────────────────────────────
+
+NS_XSD = "{http://www.w3.org/2001/XMLSchema}"
+NS_XLINK = "{http://www.w3.org/1999/xlink}"
+NS_LINK = "{http://www.xbrl.org/2003/linkbase}"
+NS_XBRLI = "{http://www.xbrl.org/2003/instance}"
+
+# Canonical-parent priority. When a concept appears in multiple
+# presentation networks, the first match wins. The order reflects
+# accounting practice: BS positions outrank IS / CF / SE outranks
+# detail roll-forwards outranks subclassification disclosures.
+PRESENTATION_PRIORITY = (
+  "mini-pre-BalanceSheet.xml",
+  "mini-pre-IncomeStatement.xml",
+  "mini-pre-CashFlowStatement.xml",
+  "mini-pre-ChangesInEquity.xml",
+  "mini-pre-CashAndCashEquivalents.xml",
+  "mini-pre-Receivables.xml",
+  "mini-pre-Inventories.xml",
+  "mini-pre-PropertyPlantAndEquipment.xml",
+  "mini-pre-AccountsPayable.xml",
+  "mini-pre-AccruedExpenses.xml",
+  "mini-pre-LongTermDebt.xml",
+  "mini-pre-PaidInCapital.xml",
+  "mini-pre-RetainedEarnings.xml",
+)
+
+
+# ── Domain types ─────────────────────────────────────────────────────────
+
+
+@dataclass
+class Concept:
+  """One mini concept parsed from mini.xsd."""
+
+  name: str  # local name, e.g. "CashAndCashEquivalents"
+  type: str  # e.g. "xbrli:monetaryItemType"
+  substitution_group: str
+  period_type: str | None
+  balance_type: str | None
+  label: str = ""  # filled from mini-lab.xml
+
+  @property
+  def qname(self) -> str:
+    return f"mini:{self.name}"
+
+  @property
+  def is_monetary(self) -> bool:
+    return self.type.endswith("monetaryItemType")
+
+  @property
+  def is_hypercube(self) -> bool:
+    return self.substitution_group.endswith("hypercubeItem")
+
+  @property
+  def is_abstract(self) -> bool:
+    # A concept is structural (abstract/roll-up/line-items container)
+    # when it's not monetary and not a hypercube. Mini uses
+    # ``stringItemType`` for these.
+    return not self.is_monetary and not self.is_hypercube
+
+  @property
+  def element_type(self) -> str:
+    """Map to RoboSystems Element.element_type enum."""
+    if self.is_hypercube:
+      return "hypercube"
+    if self.is_abstract:
+      return "abstract"
+    return "concept"
+
+
+@dataclass
+class PresentationArc:
+  """One parent-child arc from a mini-pre-*.xml linkbase."""
+
+  parent_concept: str  # local name
+  child_concept: str  # local name
+  source_file: str
+  order: float
+
+
+@dataclass
+class ParsedTaxonomy:
+  concepts: dict[str, Concept] = field(default_factory=dict)
+  arcs_by_child: dict[str, list[PresentationArc]] = field(
+    default_factory=lambda: defaultdict(list)
+  )
+
+
+# ── Parsing ──────────────────────────────────────────────────────────────
+
+
+def parse_concepts(xsd_path: Path) -> dict[str, Concept]:
+  """Parse mini.xsd → {name: Concept}."""
+  tree = ET.parse(xsd_path)
+  root = tree.getroot()
+  out: dict[str, Concept] = {}
+  for el in root.iter(f"{NS_XSD}element"):
+    name = el.attrib.get("name")
+    if not name:
+      continue
+    out[name] = Concept(
+      name=name,
+      type=el.attrib.get("type", ""),
+      substitution_group=el.attrib.get("substitutionGroup", ""),
+      period_type=el.attrib.get(f"{NS_XBRLI}periodType"),
+      balance_type=el.attrib.get(f"{NS_XBRLI}balance"),
+    )
+  return out
+
+
+def parse_labels(lab_path: Path, concepts: dict[str, Concept]) -> None:
+  """Parse mini-lab.xml → fill ``Concept.label`` in place.
+
+  Mini labels live as ``<label xml:lang="en">…</label>`` resources
+  bound via ``<labelArc xlink:from=concept xlink:to=label>``. The
+  locator's ``xlink:href="mini.xsd#mini_ConceptName"`` is how we
+  recover the concept name. We use the standard
+  ``http://www.xbrl.org/2003/role/label`` role and ignore the
+  negated/total/period-start variants.
+  """
+  tree = ET.parse(lab_path)
+  root = tree.getroot()
+
+  # Build locator label → concept name from <loc> elements.
+  loc_to_concept: dict[str, str] = {}
+  for loc in root.iter(f"{NS_LINK}loc"):
+    href = loc.attrib.get(f"{NS_XLINK}href", "")
+    if "#mini_" not in href:
+      continue
+    concept_name = href.split("#mini_", 1)[1]
+    locator_label = loc.attrib.get(f"{NS_XLINK}label", "")
+    if locator_label:
+      loc_to_concept[locator_label] = concept_name
+
+  # Build labelArc resource label → locator label.
+  resource_to_concept: dict[str, str] = {}
+  for arc in root.iter(f"{NS_LINK}labelArc"):
+    from_ = arc.attrib.get(f"{NS_XLINK}from", "")
+    to_ = arc.attrib.get(f"{NS_XLINK}to", "")
+    if from_ in loc_to_concept:
+      resource_to_concept[to_] = loc_to_concept[from_]
+
+  # Pull label text for the standard label role.
+  for label in root.iter(f"{NS_LINK}label"):
+    role = label.attrib.get(f"{NS_XLINK}role", "")
+    if role != "http://www.xbrl.org/2003/role/label":
+      continue
+    resource_label = label.attrib.get(f"{NS_XLINK}label", "")
+    concept_name = resource_to_concept.get(resource_label)
+    if concept_name and concept_name in concepts:
+      concepts[concept_name].label = (label.text or "").strip()
+
+
+def parse_presentation_arcs(
+  pre_path: Path,
+) -> list[PresentationArc]:
+  """Parse one mini-pre-*.xml → list of parent-child arcs."""
+  tree = ET.parse(pre_path)
+  root = tree.getroot()
+
+  # Locator label → concept name within this file.
+  loc_to_concept: dict[str, str] = {}
+  for loc in root.iter(f"{NS_LINK}loc"):
+    href = loc.attrib.get(f"{NS_XLINK}href", "")
+    if "#mini_" not in href:
+      continue
+    concept_name = href.split("#mini_", 1)[1]
+    locator_label = loc.attrib.get(f"{NS_XLINK}label", "")
+    if locator_label:
+      loc_to_concept[locator_label] = concept_name
+
+  arcs: list[PresentationArc] = []
+  for arc in root.iter(f"{NS_LINK}presentationArc"):
+    parent_label = arc.attrib.get(f"{NS_XLINK}from", "")
+    child_label = arc.attrib.get(f"{NS_XLINK}to", "")
+    parent_name = loc_to_concept.get(parent_label)
+    child_name = loc_to_concept.get(child_label)
+    if not parent_name or not child_name:
+      continue
+    try:
+      order = float(arc.attrib.get("order", "0"))
+    except ValueError:
+      order = 0.0
+    arcs.append(
+      PresentationArc(
+        parent_concept=parent_name,
+        child_concept=child_name,
+        source_file=pre_path.name,
+        order=order,
+      )
+    )
+  return arcs
+
+
+def parse_all(taxonomy_dir: Path) -> ParsedTaxonomy:
+  """Parse the full mini taxonomy from ``taxonomy_dir``."""
+  parsed = ParsedTaxonomy()
+  parsed.concepts = parse_concepts(taxonomy_dir / "mini.xsd")
+  parse_labels(taxonomy_dir / "mini-lab.xml", parsed.concepts)
+
+  # Pull arcs from every mini-pre-*.xml; index by child for fast
+  # canonical-parent selection.
+  for pre_path in sorted(taxonomy_dir.glob("mini-pre-*.xml")):
+    arcs = parse_presentation_arcs(pre_path)
+    for a in arcs:
+      parsed.arcs_by_child[a.child_concept].append(a)
+  return parsed
+
+
+# ── Hierarchy resolution ─────────────────────────────────────────────────
+
+
+def pick_canonical_parent(
+  arcs: list[PresentationArc],
+) -> PresentationArc | None:
+  """Pick the canonical parent arc for a child concept.
+
+  Strategy: prefer arcs from higher-priority presentation files
+  (BS > IS > CF > SE > roll-forwards > others). Ties broken by
+  insertion order. Returns None if the concept has no presentation
+  arcs (a true root).
+  """
+  if not arcs:
+    return None
+  priority_index = {name: i for i, name in enumerate(PRESENTATION_PRIORITY)}
+  default_rank = len(PRESENTATION_PRIORITY)
+  return min(
+    arcs,
+    key=lambda a: (priority_index.get(a.source_file, default_rank), a.order),
+  )
+
+
+# ── Element payload construction ─────────────────────────────────────────
+
+
+def build_element_payloads(
+  parsed: ParsedTaxonomy,
+) -> list[dict]:
+  """Build the elements list for ``create_taxonomy_block``.
+
+  **Filter rule**: only **monetary concepts** (the ~92 leaves with
+  ``xbrli:balance``) become CoA elements. The other ~98 mini concepts
+  (hypercubes, line-items containers, abstract roll-ups, text-block
+  policies) are XBRL structural plumbing — they're load-bearing for
+  rendering presentation networks but they aren't GL-postable
+  accounts. The CoA validator requires every element to declare a
+  ``trait`` from a fixed enum (asset/liability/equity/contraAsset/
+  temporaryEquity/revenue/expense/income/gain/loss); only monetary
+  leaves cleanly satisfy that — matches how QB CoAs land (flat list
+  of balance-bearing accounts).
+
+  **Hierarchy**: ``parent_ref=None`` for every leaf — the mini
+  hierarchy lives in the presentation linkbases, not in CoA
+  parent-child relationships among the monetary leaves themselves.
+  This mirrors how QB sync produces a flat CoA when the source
+  doesn't carry sub-account nesting between balance-bearing accounts.
+
+  Excluded structural concepts can be loaded as a separate
+  ``custom_ontology`` Taxonomy Block later if their presentation
+  hierarchy is needed for rendering.
+  """
+  payloads: list[dict] = []
+
+  for name, concept in sorted(parsed.concepts.items()):
+    if not concept.is_monetary:
+      # Skip XBRL plumbing — not a CoA leaf.
+      continue
+    trait = _derive_trait(concept)
+    if trait is None:
+      # Shouldn't happen for monetary concepts, but be defensive.
+      continue
+    payloads.append(
+      {
+        "qname": concept.qname,
+        "name": concept.label or concept.name,
+        "trait": trait,
+        "balance_type": concept.balance_type,
+        "element_type": "concept",
+        "period_type": concept.period_type,
+        "is_monetary": True,
+        "description": None,
+        "code": concept.qname,  # mini's qname doubles as the CoA code
+        "sub_classification": None,
+        # Flat CoA — mini's parent_ref hierarchy lives in the
+        # presentation linkbases (loadable separately as a
+        # custom_ontology block if rendering needs it).
+        "parent_ref": None,
+        "metadata": {
+          "source_taxonomy": "seattle-method-mini",
+          "concept_type": concept.type,
+          "substitution_group": concept.substitution_group,
+        },
+      }
+    )
+
+  return payloads
+
+
+def _derive_trait(concept: Concept) -> str | None:
+  """Best-effort FASB trait classification for a monetary concept.
+
+  Mini doesn't carry an explicit trait per concept, so we infer from
+  ``balance_type`` + ``period_type``:
+
+  - instant + debit → ``asset``
+  - instant + credit → ``liability`` (the most common case; equity
+    concepts like ``PaidInCapital`` get re-classified by name below)
+  - duration + debit → ``expense``
+  - duration + credit → ``revenue``
+
+  Equity-side concepts (PaidInCapital, RetainedEarnings, etc.) are
+  detected by name suffix and re-classified to ``equity``. Mapping
+  refinement against rs-gaap happens separately via the
+  MappingOperator path; the validator just needs *a* valid trait
+  from {asset, liability, equity, contraAsset, contraLiability,
+  contraEquity, temporaryEquity, revenue, expense, income, gain, loss}.
+  """
+  if concept.is_hypercube or not concept.is_monetary:
+    return None
+
+  if concept.period_type == "instant":
+    # BS concepts. Equity-side concepts get re-classified by name —
+    # PaidInCapital, RetainedEarnings, CommonStockValue, etc. are
+    # credit-balance like liabilities but the canonical CoA trait is
+    # ``equity``. Name-detection runs only inside the instant branch
+    # so duration-flow concepts (e.g. ``ChangesInRetainedEarnings``)
+    # don't trip the equity check — they're flow concepts that hit
+    # the revenue/expense classification below.
+    equity_markers = (
+      "paidincapital",
+      "retainedearnings",
+      "commonstock",
+      "preferredstock",
+      "treasurystock",
+    )
+    lower = concept.name.lower()
+    if any(m in lower for m in equity_markers):
+      return "equity"
+    return "asset" if concept.balance_type == "debit" else "liability"
+
+  # period_type == 'duration' → income statement / flow concept
+  return "revenue" if concept.balance_type == "credit" else "expense"
+
+
+# ── HTTP client + upload ─────────────────────────────────────────────────
+
+
+def _get_ledger_client():
+  """Construct a LedgerClient from saved credentials.
+
+  Mirrors the helper in ``examples.roboledger_demo.main``."""
+  import json
+
+  from robosystems_client.clients.ledger_client import LedgerClient
+
+  config_path = Path(".local/config.json")
+  if not config_path.exists():
+    raise SystemExit(
+      "Missing .local/config.json — run `just demo-user` first to create credentials."
+    )
+  with config_path.open() as f:
+    cfg = json.load(f)
+  return LedgerClient(
+    {
+      "base_url": cfg.get("base_url", "http://localhost:8000"),
+      "token": cfg["api_key"],
+    }
+  )
+
+
+def upload_taxonomy(graph_id: str, elements: list[dict]) -> str:
+  """Create the mini CoA via ``create_taxonomy_block``.
+
+  Returns the new taxonomy_id. Idempotent: if a taxonomy with
+  ``name="Seattle Method mini CoA"`` already exists on the graph,
+  returns its existing id instead of recreating (which would fail
+  on the unique-qname constraint).
+  """
+  client = _get_ledger_client()
+
+  # Idempotency check — re-runs against the same graph reuse the
+  # existing taxonomy rather than colliding on unique-qname.
+  existing_taxonomies = client.list_taxonomies(graph_id) or []
+  for tax in existing_taxonomies:
+    if (tax.get("name") or "").lower().startswith("seattle method"):
+      print(f"  Reusing existing mini CoA taxonomy: {tax.get('id')}")
+      return tax.get("id")
+
+  envelope = client.create_taxonomy_block(
+    graph_id,
+    {
+      "name": "Seattle Method mini CoA",
+      "taxonomy_type": "chart_of_accounts",
+      "description": (
+        "Chart of accounts loaded from Charlie Hoffman's mini "
+        "reporting framework (https://github.com/seattlemethod/mini). "
+        "Each mini concept lands as one Element with the presentation "
+        "linkbase supplying parent_ref hierarchy. Per Charlie's "
+        "'fix the process' thesis, mini concepts ARE the chart of "
+        "accounts — there's no separate CoA→reporting mapping step "
+        "to wire."
+      ),
+      "elements": elements,
+      "structures": [
+        {
+          "name": "mini to rs-gaap Mapping",
+          "description": (
+            "Maps mini CoA concepts to rs-gaap reporting concepts. "
+            "Populated by ``seed_mappings.py``."
+          ),
+          "block_type": "coa_mapping",
+        },
+      ],
+      "associations": [],
+      "rules": [],
+    },
+  )
+  return envelope.id
+
+
+# ── Main ─────────────────────────────────────────────────────────────────
+
+
+def main() -> None:
+  parser = argparse.ArgumentParser(
+    description="Load the Seattle Method mini taxonomy as a CoA on a graph.",
+  )
+  parser.add_argument(
+    "graph_id",
+    help="Target graph id (e.g. kg_seattle_method_test)",
+  )
+  parser.add_argument(
+    "--taxonomy-dir",
+    type=Path,
+    default=Path("local/taxonomies/mini"),
+    help="Directory containing the pulled mini artifacts.",
+  )
+  parser.add_argument(
+    "--dry-run",
+    action="store_true",
+    help="Parse + build payloads; print summary; do not upload.",
+  )
+  args = parser.parse_args()
+
+  if not args.taxonomy_dir.exists():
+    raise SystemExit(
+      f"Taxonomy dir {args.taxonomy_dir} does not exist. "
+      "Run `examples/seattle_method_demo/pull_mini.sh` first."
+    )
+
+  print(f"Parsing mini taxonomy from {args.taxonomy_dir} …")
+  parsed = parse_all(args.taxonomy_dir)
+  print(f"  Concepts:                  {len(parsed.concepts)}")
+  print(
+    f"  Concepts with labels:      "
+    f"{sum(1 for c in parsed.concepts.values() if c.label)}"
+  )
+  print(
+    f"  Concepts with parent arc:  "
+    f"{sum(1 for c in parsed.concepts if c in parsed.arcs_by_child)}"
+  )
+  print(
+    f"  Monetary concepts:         "
+    f"{sum(1 for c in parsed.concepts.values() if c.is_monetary)}"
+  )
+
+  payloads = build_element_payloads(parsed)
+  print(f"  Built {len(payloads)} element payload(s)")
+
+  if args.dry_run:
+    sample = payloads[:8]
+    print("\nFirst 8 element payloads (sample):")
+    for p in sample:
+      parent = p["parent_ref"] or "(top-level)"
+      balance = p["balance_type"] or "—"
+      trait = p["trait"] or "—"
+      print(f"  {p['qname']:<55} parent={parent:<55} trait={trait} balance={balance}")
+    print("\nDry run — no upload performed.")
+    return
+
+  print(f"\nUploading to graph {args.graph_id} …")
+  taxonomy_id = upload_taxonomy(args.graph_id, payloads)
+  print(f"✓ Created taxonomy {taxonomy_id} with {len(payloads)} elements")
+
+
+if __name__ == "__main__":
+  main()

--- a/examples/seattle_method_demo/main.py
+++ b/examples/seattle_method_demo/main.py
@@ -1,0 +1,384 @@
+#!/usr/bin/env python3
+"""Seattle Method Cross-Taxonomy Demo — orchestrator.
+
+End-to-end driver for Test Case 1 (mini / Charlie Hoffman 14-JE
+lemonade-stand dataset). Provisions a dedicated test graph, pulls
+the mini taxonomy artifacts, loads them as a CoA, seeds the
+mini→rs-gaap mappings, ingests the 14 JEs, and authors the 8
+rollforward IBs.
+
+Mirrors the structure of ``examples.roboledger_demo.main`` — one
+``LedgerClient``-driven orchestrator with discrete steps that can be
+re-run individually via ``--step``.
+
+Reconciliation (the rendered comparison against
+``luca.pacioli.ai/luca/view/0f24fd35…``) lives in
+``reconcile.py`` and is invoked separately; see the README's
+"What Gets Created" section for the full step list.
+
+Usage:
+    uv run python -m examples.seattle_method_demo.main                       # Create new graph + run every step
+    uv run python -m examples.seattle_method_demo.main --graph <id>          # Run against an existing graph
+    uv run python -m examples.seattle_method_demo.main --step pull           # Run a single step
+    uv run python -m examples.seattle_method_demo.main --dry-run             # Validate + report; no API calls
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+from . import author_rollforwards as auth_rf_mod
+from . import ingest_transactions as ingest_mod
+from . import load_taxonomy as load_mod
+from . import seed_mappings as seed_mod
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PULL_SCRIPT = REPO_ROOT / "examples" / "seattle_method_demo" / "pull_mini.sh"
+TAXONOMY_DIR = REPO_ROOT / "local" / "taxonomies" / "mini"
+CSV_PATH = REPO_ROOT / "examples" / "seattle_method_demo" / "fixtures" / "transactions.csv"
+
+BASE_URL = "http://localhost:8000"
+CREDENTIALS_FILE = Path(".local/config.json")
+
+DEMO_NAME = "seattle_method_test"
+GRAPH_DISPLAY_NAME = "Seattle Method Cross-Taxonomy Test"
+ENTITY_NAME = "Lemonade Stand (Charlie Hoffman Test Case 1)"
+
+
+# ── Client helpers ───────────────────────────────────────────────────────
+
+
+def _client_config() -> dict[str, str]:
+  config_path = Path(".local/config.json")
+  if not config_path.exists():
+    raise SystemExit(
+      "Missing .local/config.json — run `just demo-user` first to create credentials."
+    )
+  with config_path.open() as f:
+    cfg = json.load(f)
+  return {
+    "base_url": cfg.get("base_url", "http://localhost:8000"),
+    "token": cfg["api_key"],
+  }
+
+
+def _get_ledger_client():
+  from robosystems_client.clients.ledger_client import LedgerClient
+
+  return LedgerClient(_client_config())
+
+
+def _get_graph_client():
+  from robosystems_client.clients.graph_client import GraphClient
+
+  return GraphClient(_client_config())
+
+
+# ── Steps ────────────────────────────────────────────────────────────────
+
+
+def step_pull() -> None:
+  """Step 1 — Pull mini taxonomy from xbrlsite into local/taxonomies/mini/."""
+  print("─" * 70)
+  print("Step 1 — pull mini taxonomy")
+  print("─" * 70)
+  result = subprocess.run(
+    ["bash", str(PULL_SCRIPT)], cwd=str(REPO_ROOT), check=False
+  )
+  if result.returncode != 0:
+    raise SystemExit(f"pull_mini.sh exited with code {result.returncode}")
+
+
+def step_provision_graph() -> str:
+  """Step 2 — Create a dedicated test graph for this run.
+
+  Returns the new graph_id. Reuses the credentials flow from
+  ``examples.roboledger_demo.main.create_demo_graph`` — same
+  ``CredentialContext`` / ``ensure_user_credentials`` /
+  ``save_graph_id`` plumbing — but stores under its own slot
+  (``seattle_method_test``) so it doesn't collide with the
+  RoboLedger demo's graph. Idempotent: re-runs reuse the same graph
+  unless that slot is cleared in ``.local/config.json``.
+  """
+  print("─" * 70)
+  print("Step 2 — provision test graph")
+  print("─" * 70)
+
+  # Re-use roboledger_demo's credential helpers — generic enough to
+  # handle any per-demo slot.
+  project_root = REPO_ROOT
+  if str(project_root) not in sys.path:
+    sys.path.insert(0, str(project_root))
+
+  from examples.credentials.utils import (
+    CredentialContext,
+    ensure_user_credentials,
+    get_graph_id,
+    save_graph_id,
+  )
+
+  context = CredentialContext(
+    base_url=BASE_URL,
+    credentials_path=CREDENTIALS_FILE,
+    force=False,
+    default_name_prefix="Seattle Method Demo",
+    default_email_prefix="seattle_method_demo",
+    api_key_prefix="Seattle Method Demo Key",
+    display_title="Seattle Method Cross-Taxonomy Demo Setup",
+  )
+  credentials = ensure_user_credentials(context)
+  api_key = credentials["api_key"]
+
+  existing = get_graph_id(CREDENTIALS_FILE, DEMO_NAME)
+  if existing:
+    print(f"  Reusing existing graph: {existing}")
+    return existing
+
+  from robosystems_client.api.graphs.create_graph import (
+    sync_detailed as api_create_graph,
+  )
+  from robosystems_client.api.operations.get_operation_status import (
+    sync_detailed as api_get_operation_status,
+  )
+  from robosystems_client.client import AuthenticatedClient
+  from robosystems_client.models import CreateGraphRequest, GraphMetadata
+
+  client = AuthenticatedClient(
+    base_url=BASE_URL,
+    token=api_key,
+    prefix="",
+    auth_header_name="X-API-Key",
+  )
+
+  metadata = GraphMetadata(
+    graph_name=GRAPH_DISPLAY_NAME,
+    description=(
+      "Cross-taxonomy projection test — Charlie Hoffman's mini "
+      "reporting framework loaded as a CoA, his 14-JE lemonade-stand "
+      "dataset ingested, rollforward IBs authored. See "
+      "examples/seattle_method_demo/README.md."
+    ),
+    schema_extensions=["roboledger"],
+  )
+  request = CreateGraphRequest(
+    metadata=metadata,
+    initial_entity={
+      "name": ENTITY_NAME,
+      "uri": "https://luca.pacioli.ai/luca/view/0f24fd35e961e167a727b663c75a4c5ec9fb7eb86730d6292f46e6e180fc2018980cd52e/index",
+      "entity_type": "llc",
+    },
+    tags=["demo", "seattle-method", "cross-taxonomy-test", "mini"],
+  )
+  print(f"  Creating graph: {GRAPH_DISPLAY_NAME}")
+  response = api_create_graph(client=client, body=request)
+  if response.status_code >= 400:
+    body = response.content.decode() if response.content else "(no body)"
+    raise SystemExit(f"Failed to create graph: HTTP {response.status_code}\n  {body}")
+  if not response.parsed:
+    raise SystemExit(
+      f"Failed to create graph: empty response (HTTP {response.status_code})"
+    )
+
+  parsed = response.parsed
+  graph_id = getattr(parsed, "graph_id", None)
+  operation_id = getattr(parsed, "operation_id", None)
+  if isinstance(parsed, dict):
+    graph_id = parsed.get("graph_id")
+    operation_id = parsed.get("operation_id")
+
+  if not graph_id and operation_id:
+    print(f"  Queued (operation: {operation_id}), waiting...")
+    for _ in range(30):
+      time.sleep(2)
+      status_resp = api_get_operation_status(operation_id=operation_id, client=client)
+      if not status_resp.parsed:
+        continue
+      status_data = status_resp.parsed
+      if isinstance(status_data, dict):
+        status = status_data.get("status")
+        result = status_data.get("result", {})
+      elif hasattr(status_data, "additional_properties"):
+        props = status_data.additional_properties
+        status = props.get("status")
+        result = props.get("result", {})
+      else:
+        status = getattr(status_data, "status", None)
+        result = getattr(status_data, "result", {})
+
+      if status == "completed":
+        graph_id = result.get("graph_id") if isinstance(result, dict) else None
+        break
+      if status == "failed":
+        error = result.get("error") if isinstance(result, dict) else "unknown"
+        raise SystemExit(f"Graph creation failed: {error}")
+
+  if not graph_id:
+    raise SystemExit("Timed out waiting for graph creation")
+
+  save_graph_id(
+    CREDENTIALS_FILE, DEMO_NAME, graph_id, time.strftime("%Y-%m-%d %H:%M:%S")
+  )
+  print(f"  ✓ Provisioned graph {graph_id}")
+  return graph_id
+
+
+def step_load_taxonomy(graph_id: str, dry_run: bool = False) -> None:
+  """Step 3 — Load mini.xsd + linkbases as a CoA TaxonomyBlock."""
+  print("─" * 70)
+  print(f"Step 3 — load mini taxonomy → graph {graph_id}")
+  print("─" * 70)
+  if not TAXONOMY_DIR.exists():
+    raise SystemExit(
+      f"{TAXONOMY_DIR} missing — run step 'pull' first or re-run end-to-end."
+    )
+  parsed = load_mod.parse_all(TAXONOMY_DIR)
+  payloads = load_mod.build_element_payloads(parsed)
+  print(
+    f"  Parsed {len(parsed.concepts)} concepts, built {len(payloads)} element payloads"
+  )
+  if dry_run:
+    print("  (dry-run — no upload)")
+    return
+  taxonomy_id = load_mod.upload_taxonomy(graph_id, payloads)
+  print(f"  ✓ Created taxonomy {taxonomy_id}")
+
+
+def step_seed_mappings(graph_id: str, dry_run: bool = False) -> None:
+  """Step 4 — Seed mini→rs-gaap derivation associations."""
+  print("─" * 70)
+  print(f"Step 4 — seed mini→rs-gaap mappings → graph {graph_id}")
+  print("─" * 70)
+  created, warnings = seed_mod.seed_mappings(graph_id, dry_run=dry_run)
+  for w in warnings:
+    print(f"  ⚠️  {w}")
+  action = "Would create" if dry_run else "Created"
+  print(f"  {action} {created} association(s)")
+
+
+def step_ingest_transactions(graph_id: str, dry_run: bool = False) -> None:
+  """Step 5 — Ingest the 14 JEs via create-event-block."""
+  print("─" * 70)
+  print(f"Step 5 — ingest 14 JEs → graph {graph_id}")
+  print("─" * 70)
+  created, warnings = ingest_mod.ingest(graph_id, CSV_PATH, dry_run=dry_run)
+  for w in warnings:
+    print(f"  ⚠️  {w}")
+  action = "Would create" if dry_run else "Created"
+  print(f"  {action} {created} event(s)")
+
+
+def step_author_rollforwards(graph_id: str, dry_run: bool = False) -> None:
+  """Step 6 — Author 8 rollforward IBs (one per BS leaf with activity)."""
+  print("─" * 70)
+  print(f"Step 6 — author rollforward IBs → graph {graph_id}")
+  print("─" * 70)
+  created, warnings = auth_rf_mod.author_rollforwards(
+    graph_id, CSV_PATH, dry_run=dry_run
+  )
+  for w in warnings:
+    print(f"  ⚠️  {w}")
+  action = "Would create" if dry_run else "Created"
+  print(f"  {action} {created} rollforward IB(s)")
+
+
+# ── Step registry ────────────────────────────────────────────────────────
+
+STEPS = {
+  "pull": ("Pull mini taxonomy artifacts", step_pull),
+  "provision": ("Provision a dedicated test graph", step_provision_graph),
+  "load": ("Load mini as a CoA TaxonomyBlock", step_load_taxonomy),
+  "seed-mappings": ("Seed mini→rs-gaap derivation associations", step_seed_mappings),
+  "ingest": ("Ingest the 14 JEs as Events", step_ingest_transactions),
+  "author-rollforwards": (
+    "Author rollforward IBs for every BS leaf with activity",
+    step_author_rollforwards,
+  ),
+}
+
+
+# ── Main ─────────────────────────────────────────────────────────────────
+
+
+def main() -> None:
+  parser = argparse.ArgumentParser(
+    description="Seattle Method Cross-Taxonomy Demo orchestrator.",
+    formatter_class=argparse.RawDescriptionHelpFormatter,
+    epilog="Steps:\n"
+    + "\n".join(f"  {k:<22} {v[0]}" for k, v in STEPS.items()),
+  )
+  parser.add_argument(
+    "--graph",
+    metavar="GRAPH_ID",
+    help="Run against an existing graph instead of provisioning a new one.",
+  )
+  parser.add_argument(
+    "--step",
+    choices=list(STEPS.keys()),
+    help="Run a single step only.",
+  )
+  parser.add_argument(
+    "--dry-run",
+    action="store_true",
+    help="Validate + report; do not write to the API.",
+  )
+  args = parser.parse_args()
+
+  # Single-step mode.
+  if args.step:
+    fn = STEPS[args.step][1]
+    if args.step == "pull":
+      fn()
+    elif args.step == "provision":
+      graph_id = fn()
+      print(f"\nProvisioned graph: {graph_id}")
+      print(f"To continue: --graph {graph_id} --step <next>")
+    else:
+      if not args.graph:
+        raise SystemExit(
+          f"--step {args.step} requires --graph <id> "
+          "(or run end-to-end without --step to provision one)."
+        )
+      fn(args.graph, dry_run=args.dry_run)
+    return
+
+  # Full end-to-end run.
+  print("Seattle Method Cross-Taxonomy Demo — full run")
+  print()
+
+  # Step 1 — pull
+  step_pull()
+  print()
+
+  # Step 2 — provision (or reuse)
+  if args.graph:
+    graph_id = args.graph
+    print(f"Step 2 — using existing graph {graph_id}")
+    print()
+  else:
+    graph_id = step_provision_graph()
+    print()
+
+  # Step 3-6 — sequential
+  step_load_taxonomy(graph_id, dry_run=args.dry_run)
+  print()
+  step_seed_mappings(graph_id, dry_run=args.dry_run)
+  print()
+  step_ingest_transactions(graph_id, dry_run=args.dry_run)
+  print()
+  step_author_rollforwards(graph_id, dry_run=args.dry_run)
+  print()
+
+  print("─" * 70)
+  print(f"✓ End-to-end demo run complete against graph {graph_id}")
+  print("─" * 70)
+  print()
+  print("Next: uv run python -m examples.seattle_method_demo.reconcile " + graph_id)
+
+
+if __name__ == "__main__":
+  main()

--- a/examples/seattle_method_demo/mappings.py
+++ b/examples/seattle_method_demo/mappings.py
@@ -1,0 +1,150 @@
+"""mini → rs-gaap concept mapping table.
+
+The canonical bridge from Charlie Hoffman's mini reporting framework
+to RoboSystems' rs-gaap canonical reporting taxonomy. Two scopes:
+
+1. **BS / IS leaves** — mini's monetary instant/duration concepts that
+   appear on the Balance Sheet or Income Statement, mapped to their
+   rs-gaap equivalents. The 14 leaves needed for Test Case 1's 14 JEs
+   plus the surrounding sub-rollup concepts.
+2. **Flow concepts (TDCs)** — mini's ``TransactionDescriptionCode``
+   values from Charlie's CSV, mapped to rs-gaap CF / SE roll-forward
+   concepts. These drive the per-line ``transaction_description_code``
+   metadata that the rollforward filter engine matches against.
+
+Mapping decisions where mini and rs-gaap diverge are flagged inline
+with ``# NOTE:``. The reconciliation report's "Their data quality" /
+"Methodology gap" sections will surface any cases where the bridge
+loses precision.
+
+Seeded via ``seed_mappings.py`` as ``association_type='derivation'``
+arcs (same arc type Phase 1 rollforward uses for default change tag
+derivation).
+"""
+
+from __future__ import annotations
+
+# ── BS / IS leaves ────────────────────────────────────────────────────────
+#
+# (mini qname, rs-gaap qname) — straight 1:1 mappings for the concepts
+# Charlie's 14-JE dataset touches. mini's instant concepts (BS) → rs-gaap
+# BS concepts; mini's duration concepts (IS) → rs-gaap IS concepts.
+
+BS_IS_MAPPINGS: list[tuple[str, str]] = [
+  # Balance sheet — instant / monetary
+  ("mini:CashAndCashEquivalents", "rs-gaap:CashAndCashEquivalentsAtCarryingValue"),
+  ("mini:Receivables", "rs-gaap:AccountsReceivableNetCurrent"),
+  ("mini:Inventories", "rs-gaap:InventoryNet"),
+  ("mini:PropertyPlantAndEquipment", "rs-gaap:PropertyPlantAndEquipmentNet"),
+  ("mini:AccountsPayable", "rs-gaap:AccountsPayableCurrent"),
+  ("mini:AccruedExpenses", "rs-gaap:AccruedLiabilitiesCurrent"),
+  ("mini:LongtermDebt", "rs-gaap:LongTermDebt"),
+  ("mini:PaidInCapital", "rs-gaap:AdditionalPaidInCapital"),
+  # Income statement — duration / monetary
+  ("mini:Sales", "rs-gaap:Revenues"),
+  # NOTE: mini:CostsOfSales conflates COGS and services-cost. rs-gaap
+  # splits these; pick CostOfGoodsSold as the dominant case for Charlie's
+  # lemonade-stand fixtures (contractor labor in JE-205 is mis-tagged
+  # per the README's data-quality findings).
+  ("mini:CostsOfSales", "rs-gaap:CostOfGoodsSold"),
+  ("mini:DepreciationAndAmortization", "rs-gaap:DepreciationDepletionAndAmortization"),
+  ("mini:InterestExpense", "rs-gaap:InterestExpense"),
+  (
+    "mini:NonoperatingIncomeExpenses",
+    "rs-gaap:OtherNonoperatingIncomeExpense",
+  ),
+  ("mini:IncomeTaxExpenseBenefit", "rs-gaap:IncomeTaxExpenseBenefit"),
+]
+
+
+# ── Flow concepts (TDCs) ──────────────────────────────────────────────────
+#
+# Every value of mini's ``TransactionDescriptionCode`` column in
+# Charlie's CSV, mapped to the rs-gaap CF / SE flow concept it
+# represents. These drive the rollforward filter targets.
+#
+# Some mini flow concepts appear on BOTH sides of a JE (the BS-line
+# perspective and the equity-or-flow perspective), e.g. owner
+# investment shows up as ``ProceedsFromInvestmentsByOwner`` on the
+# Cash line and ``InvestmentsByOwner`` on the equity line — both map
+# to ``rs-gaap:ProceedsFromIssuanceOfCommonStock`` (or its
+# equity-statement analog).
+
+FLOW_MAPPINGS: list[tuple[str, str]] = [
+  # Financing — equity contribution. Both sides of the JE (the Cash
+  # debit and the PaidInCapital credit) collapse to the same rs-gaap
+  # flow concept since rs-gaap doesn't distinguish the cash-side from
+  # the equity-side of an issuance (mini does).
+  ("mini:ProceedsFromInvestmentsByOwner", "rs-gaap:ProceedsFromIssuanceOfCommonStock"),
+  ("mini:InvestmentsByOwner", "rs-gaap:ProceedsFromIssuanceOfCommonStock"),
+  # Financing — debt
+  (
+    "mini:ProceedsFromAdditionalLongtermBorrowings",
+    "rs-gaap:ProceedsFromIssuanceOfLongTermDebt",
+  ),
+  ("mini:AdditionalLongtermBorrowings", "rs-gaap:ProceedsFromIssuanceOfLongTermDebt"),
+  ("mini:RepaymentLongtermBorrowings", "rs-gaap:RepaymentsOfLongTermDebt"),
+  (
+    "mini:PaymentForReductionOfLongtermBorrowings",
+    "rs-gaap:RepaymentsOfLongTermDebt",
+  ),
+  # Investing — PP&E
+  (
+    "mini:CapitalAdditionsPropertyPlantAndEquipment",
+    "rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment",
+  ),
+  (
+    "mini:PaymentForCapitalAdditionsOfPropertyPlantEquipment",
+    "rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment",
+  ),
+  # Operating — receivables
+  (
+    "mini:IncreaseInReceivablesFromSalesOnAccount",
+    "rs-gaap:IncreaseDecreaseInAccountsReceivable",
+  ),
+  ("mini:ProceedsFromCollectionOfReceivables", "rs-gaap:IncreaseDecreaseInAccountsReceivable"),
+  ("mini:CollectionOfReceivables", "rs-gaap:IncreaseDecreaseInAccountsReceivable"),
+  # Operating — inventory
+  ("mini:PurchasesOfInventoryForSale", "rs-gaap:IncreaseDecreaseInInventories"),
+  # NOTE: mini:PurchasesInventoryForSaleOnAccount is the AP-side TDC
+  # for an inventory purchase on account. rs-gaap collapses this with
+  # IncreaseDecreaseInAccountsPayable since the AP delta IS the
+  # operating-activity adjustment.
+  ("mini:PurchasesInventoryForSaleOnAccount", "rs-gaap:IncreaseDecreaseInAccountsPayable"),
+  ("mini:DecreaseInInventoriesFromSales", "rs-gaap:IncreaseDecreaseInInventories"),
+  ("mini:InventoryWrittenOff", "rs-gaap:InventoryWriteDown"),
+  # Operating — AP
+  ("mini:DecreaseFromPaymentAccountsPayable", "rs-gaap:IncreaseDecreaseInAccountsPayable"),
+  ("mini:PaymentOfAccountsPayable", "rs-gaap:IncreaseDecreaseInAccountsPayable"),
+  # Operating — interest accruals.
+  # NOTE: mini's canonical concept is ``PaymentInterest`` (not
+  # ``PaymentOfInterest``) — Charlie's CSV originally had the typo;
+  # we fixed it in fixtures/transactions.csv to match the taxonomy.
+  # NOTE: rs-gaap doesn't carry a clean "InterestPaid" CF concept in
+  # our currently-loaded library — the canonical
+  # ``rs-gaap:InterestPaidNet`` is part of the broader rs-gaap corpus
+  # but not in our subset. We map mini:PaymentInterest to
+  # ``rs-gaap:InterestExpense`` as the closest available concept —
+  # surfaces as "Library gap" in the reconciliation report (mapping
+  # is approximate; the CF rendering will conflate the IS expense
+  # and the CF payment).
+  ("mini:PaymentInterest", "rs-gaap:InterestExpense"),
+  ("mini:DecreaseFromPaymentOfInterest", "rs-gaap:IncreaseDecreaseInAccruedLiabilities"),
+  ("mini:InterestAccrued", "rs-gaap:IncreaseDecreaseInAccruedLiabilities"),
+  # Operating — D&A
+  (
+    "mini:DecreaseFromDepreciationAndAmortization",
+    "rs-gaap:DepreciationDepletionAndAmortization",
+  ),
+  # PPE write-off (JE-225's nil placeholder)
+  (
+    "mini:PropertyPlantAndEquipmentWrittenOff",
+    "rs-gaap:GainLossOnDispositionOfAssets",
+  ),
+  # Net income roll-up (the IS-side TDC every IS line carries)
+  ("mini:NetIncomeLoss", "rs-gaap:NetIncomeLoss"),
+]
+
+
+# Combined list — what ``seed_mappings.py`` walks.
+ALL_MAPPINGS: list[tuple[str, str]] = BS_IS_MAPPINGS + FLOW_MAPPINGS

--- a/examples/seattle_method_demo/output/seattle-method-case-1.md
+++ b/examples/seattle_method_demo/output/seattle-method-case-1.md
@@ -11,136 +11,136 @@
 
 Compared **17** concept(s) against Charlie's luca.pacioli.ai export (`fixtures/expected_facts_mini.csv`). **17 exact match** • **0 delta**. Total absolute delta: **$0.00**.
 
-| Concept | Our value | Charlie's value | Δ | |
-|---|---:|---:|---:|---|
-| `mini:AccountsPayable` | $1,000.00 | $1,000.00 | $0.00 | ✓ |
-| `mini:AccruedExpenses` | $400.00 | $400.00 | $0.00 | ✓ |
-| `mini:CashAndCashEquivalents` | $10,850.00 | $10,850.00 | $0.00 | ✓ |
-| `mini:CostsOfSales` | $5,300.00 | $5,300.00 | $0.00 | ✓ |
-| `mini:DepreciationAndAmortization` | $100.00 | $100.00 | $0.00 | ✓ |
-| `mini:IncomeTaxExpenseBenefit` | $400.00 | $400.00 | $0.00 | ✓ |
-| `mini:InterestExpense` | $150.00 | $150.00 | $0.00 | ✓ |
-| `mini:Inventories` | $2,700.00 | $2,700.00 | $0.00 | ✓ |
-| `mini:LongtermDebt` | $1,000.00 | $1,000.00 | $0.00 | ✓ |
-| `mini:PaidInCapital` | $10,000.00 | $10,000.00 | $0.00 | ✓ |
-| `mini:PropertyPlantAndEquipment` | $900.00 | $900.00 | $0.00 | ✓ |
-| `mini:Receivables` | $0.00 | $0.00 | $0.00 | ✓ |
-| `mini:Sales` | $8,000.00 | $8,000.00 | $0.00 | ✓ |
-| `mini:Assets` | $14,450.00 | $14,450.00 | $0.00 | ✓ |
-| `mini:LiabilitiesAndEquity` | $14,450.00 | $14,450.00 | $0.00 | ✓ |
-| `mini:NetIncomeLoss` | $2,050.00 | $2,050.00 | $0.00 | ✓ |
-| `mini:NetCashFlow` | $10,850.00 | $10,850.00 | $0.00 | ✓ |
+| Concept                            |  Our value | Charlie's value |     Δ |     |
+| ---------------------------------- | ---------: | --------------: | ----: | --- |
+| `mini:AccountsPayable`             |  $1,000.00 |       $1,000.00 | $0.00 | ✓   |
+| `mini:AccruedExpenses`             |    $400.00 |         $400.00 | $0.00 | ✓   |
+| `mini:CashAndCashEquivalents`      | $10,850.00 |      $10,850.00 | $0.00 | ✓   |
+| `mini:CostsOfSales`                |  $5,300.00 |       $5,300.00 | $0.00 | ✓   |
+| `mini:DepreciationAndAmortization` |    $100.00 |         $100.00 | $0.00 | ✓   |
+| `mini:IncomeTaxExpenseBenefit`     |    $400.00 |         $400.00 | $0.00 | ✓   |
+| `mini:InterestExpense`             |    $150.00 |         $150.00 | $0.00 | ✓   |
+| `mini:Inventories`                 |  $2,700.00 |       $2,700.00 | $0.00 | ✓   |
+| `mini:LongtermDebt`                |  $1,000.00 |       $1,000.00 | $0.00 | ✓   |
+| `mini:PaidInCapital`               | $10,000.00 |      $10,000.00 | $0.00 | ✓   |
+| `mini:PropertyPlantAndEquipment`   |    $900.00 |         $900.00 | $0.00 | ✓   |
+| `mini:Receivables`                 |      $0.00 |           $0.00 | $0.00 | ✓   |
+| `mini:Sales`                       |  $8,000.00 |       $8,000.00 | $0.00 | ✓   |
+| `mini:Assets`                      | $14,450.00 |      $14,450.00 | $0.00 | ✓   |
+| `mini:LiabilitiesAndEquity`        | $14,450.00 |      $14,450.00 | $0.00 | ✓   |
+| `mini:NetIncomeLoss`               |  $2,050.00 |       $2,050.00 | $0.00 | ✓   |
+| `mini:NetCashFlow`                 | $10,850.00 |      $10,850.00 | $0.00 | ✓   |
 
 ## Four Anchor Totals
 
 Methodology spec §4.6 exit criterion: these four lines must match Charlie's PoC for the test to pass. All amounts are debit-positive cents internally; presentation flips signs per accounting convention.
 
-| Anchor | Our value |
-|---|---:|
-| Total Assets | $14,450.00 |
+| Anchor                     |  Our value |
+| -------------------------- | ---------: |
+| Total Assets               | $14,450.00 |
 | Total Liabilities & Equity | $14,450.00 |
-| Net Income | $2,050.00 |
-| Net Cash Change | $10,850.00 |
+| Net Income                 |  $2,050.00 |
+| Net Cash Change            | $10,850.00 |
 
 ## Concept-Level Period Totals
 
-Every mini concept with non-zero activity in the period. ``Δ debit-positive`` is the period flow (Σ DR − Σ CR). For instant/asset concepts this equals the period-ending balance (Charlie's data starts from zero). For duration concepts this is the period income/expense.
+Every mini concept with non-zero activity in the period. `Δ debit-positive` is the period flow (Σ DR − Σ CR). For instant/asset concepts this equals the period-ending balance (Charlie's data starts from zero). For duration concepts this is the period income/expense.
 
-| QName | Label | Trait | Period | Δ debit-positive |
-|---|---|---|---|---:|
-| `mini:AccountsPayable` | Accounts Payable | liability | instant | $(1,000.00) |
-| `mini:AccruedExpenses` | Accrued Expenses | liability | instant | $(400.00) |
-| `mini:CashAndCashEquivalents` | Cash and Cash Equivalents | asset | instant | $10,850.00 |
-| `mini:CostsOfSales` | Costs of Sales | expense | duration | $5,300.00 |
-| `mini:DepreciationAndAmortization` | Depreciation and Amortization | expense | duration | $100.00 |
-| `mini:IncomeTaxExpenseBenefit` | Income Tax Expense (Benefit) | expense | duration | $400.00 |
-| `mini:InterestExpense` | Interest Expense | expense | duration | $150.00 |
-| `mini:Inventories` | Inventories | asset | instant | $2,700.00 |
-| `mini:LongtermDebt` | Long-term Debt | liability | instant | $(1,000.00) |
-| `mini:PaidInCapital` | Paid In Capital | equity | instant | $(10,000.00) |
-| `mini:PropertyPlantAndEquipment` | Property, Plant and Equipment | asset | instant | $900.00 |
-| `mini:Sales` | Sales | revenue | duration | $(8,000.00) |
+| QName                              | Label                         | Trait     | Period   | Δ debit-positive |
+| ---------------------------------- | ----------------------------- | --------- | -------- | ---------------: |
+| `mini:AccountsPayable`             | Accounts Payable              | liability | instant  |      $(1,000.00) |
+| `mini:AccruedExpenses`             | Accrued Expenses              | liability | instant  |        $(400.00) |
+| `mini:CashAndCashEquivalents`      | Cash and Cash Equivalents     | asset     | instant  |       $10,850.00 |
+| `mini:CostsOfSales`                | Costs of Sales                | expense   | duration |        $5,300.00 |
+| `mini:DepreciationAndAmortization` | Depreciation and Amortization | expense   | duration |          $100.00 |
+| `mini:IncomeTaxExpenseBenefit`     | Income Tax Expense (Benefit)  | expense   | duration |          $400.00 |
+| `mini:InterestExpense`             | Interest Expense              | expense   | duration |          $150.00 |
+| `mini:Inventories`                 | Inventories                   | asset     | instant  |        $2,700.00 |
+| `mini:LongtermDebt`                | Long-term Debt                | liability | instant  |      $(1,000.00) |
+| `mini:PaidInCapital`               | Paid In Capital               | equity    | instant  |     $(10,000.00) |
+| `mini:PropertyPlantAndEquipment`   | Property, Plant and Equipment | asset     | instant  |          $900.00 |
+| `mini:Sales`                       | Sales                         | revenue   | duration |      $(8,000.00) |
 
 ## Rollforward Attribution (Phase 2 MVP Filter Engine)
 
-Each rollforward IB decomposes its BS source's period delta across declared TDC filters. Where ``Σ filters == Δ BS``, the rollforward is balanced (residual = 0). A non-zero residual indicates either an unattributed flow or a phantom TDC in the source data (logged at author time).
+Each rollforward IB decomposes its BS source's period delta across declared TDC filters. Where `Σ filters == Δ BS`, the rollforward is balanced (residual = 0). A non-zero residual indicates either an unattributed flow or a phantom TDC in the source data (logged at author time).
 
 ### Accounts Payable (mini:AccountsPayable)
 
 **Δ BS** (debit-positive): $(1,000.00)
 
-| Flow concept | Value | Matched lines | Event ids |
-|---|---:|---:|---|
-| `mini:PurchasesInventoryForSaleOnAccount` | $(8,000.00) | 2 | evt_01KS18CJYCY2EGHWDDG4V3N0KS, evt_01KS18CJYTHAGV7DEVXBPD0AH8 |
-| `mini:DecreaseFromPaymentAccountsPayable` | $7,000.00 | 1 | evt_01KS18CK03546J6MQQGAXVP3MQ |
+| Flow concept                              |       Value | Matched lines | Event ids                                                      |
+| ----------------------------------------- | ----------: | ------------: | -------------------------------------------------------------- |
+| `mini:PurchasesInventoryForSaleOnAccount` | $(8,000.00) |             2 | evt_01KS18CJYCY2EGHWDDG4V3N0KS, evt_01KS18CJYTHAGV7DEVXBPD0AH8 |
+| `mini:DecreaseFromPaymentAccountsPayable` |   $7,000.00 |             1 | evt_01KS18CK03546J6MQQGAXVP3MQ                                 |
 
 ### Accrued Expenses (mini:AccruedExpenses)
 
 **Δ BS** (debit-positive): $(400.00)
 
-| Flow concept | Value | Matched lines | Event ids |
-|---|---:|---:|---|
-| `mini:DecreaseFromPaymentOfInterest` | $150.00 | 1 | evt_01KS18CK0JQ9CQMBMCVQFWRD20 |
-| `mini:InterestAccrued` | $(550.00) | 2 | evt_01KS18CK12DAEKR7CJ0A6Z0JXG, evt_01KS18CK32P9EYV8NXM2BMBZNF |
+| Flow concept                         |     Value | Matched lines | Event ids                                                      |
+| ------------------------------------ | --------: | ------------: | -------------------------------------------------------------- |
+| `mini:DecreaseFromPaymentOfInterest` |   $150.00 |             1 | evt_01KS18CK0JQ9CQMBMCVQFWRD20                                 |
+| `mini:InterestAccrued`               | $(550.00) |             2 | evt_01KS18CK12DAEKR7CJ0A6Z0JXG, evt_01KS18CK32P9EYV8NXM2BMBZNF |
 
 ### Cash and Cash Equivalents (mini:CashAndCashEquivalents)
 
 **Δ BS** (debit-positive): $10,850.00
 
-| Flow concept | Value | Matched lines | Event ids |
-|---|---:|---:|---|
-| `mini:ProceedsFromInvestmentsByOwner` | $10,000.00 | 1 | evt_01KS18CJW6TPZ8PVXQ255G1EPZ |
-| `mini:ProceedsFromAdditionalLongtermBorrowings` | $2,000.00 | 1 | evt_01KS18CJX6M2H9R79CTZKB8A96 |
-| `mini:PaymentForCapitalAdditionsOfPropertyPlantEquipment` | $(1,000.00) | 1 | evt_01KS18CJXQHAW8WY76ADT79NB4 |
-| `mini:ProceedsFromCollectionOfReceivables` | $8,000.00 | 1 | evt_01KS18CJZPDZZT124FZ58EPQMF |
-| `mini:PaymentOfAccountsPayable` | $(7,000.00) | 1 | evt_01KS18CK03546J6MQQGAXVP3MQ |
-| `mini:PaymentForReductionOfLongtermBorrowings` | $(1,000.00) | 1 | evt_01KS18CK0JQ9CQMBMCVQFWRD20 |
-| `mini:PaymentInterest` | $(150.00) | 1 | evt_01KS18CK0JQ9CQMBMCVQFWRD20 |
+| Flow concept                                              |       Value | Matched lines | Event ids                      |
+| --------------------------------------------------------- | ----------: | ------------: | ------------------------------ |
+| `mini:ProceedsFromInvestmentsByOwner`                     |  $10,000.00 |             1 | evt_01KS18CJW6TPZ8PVXQ255G1EPZ |
+| `mini:ProceedsFromAdditionalLongtermBorrowings`           |   $2,000.00 |             1 | evt_01KS18CJX6M2H9R79CTZKB8A96 |
+| `mini:PaymentForCapitalAdditionsOfPropertyPlantEquipment` | $(1,000.00) |             1 | evt_01KS18CJXQHAW8WY76ADT79NB4 |
+| `mini:ProceedsFromCollectionOfReceivables`                |   $8,000.00 |             1 | evt_01KS18CJZPDZZT124FZ58EPQMF |
+| `mini:PaymentOfAccountsPayable`                           | $(7,000.00) |             1 | evt_01KS18CK03546J6MQQGAXVP3MQ |
+| `mini:PaymentForReductionOfLongtermBorrowings`            | $(1,000.00) |             1 | evt_01KS18CK0JQ9CQMBMCVQFWRD20 |
+| `mini:PaymentInterest`                                    |   $(150.00) |             1 | evt_01KS18CK0JQ9CQMBMCVQFWRD20 |
 
 ### Inventories (mini:Inventories)
 
 **Δ BS** (debit-positive): $2,700.00
 
-| Flow concept | Value | Matched lines | Event ids |
-|---|---:|---:|---|
-| `mini:PurchasesOfInventoryForSale` | $5,000.00 | 1 | evt_01KS18CJYCY2EGHWDDG4V3N0KS |
-| `mini:DecreaseInInventoriesFromSales` | $(2,000.00) | 1 | evt_01KS18CJZAS0E693A2S8Y6R9GJ |
-| `mini:InventoryWrittenOff` | $(300.00) | 1 | evt_01KS18CK1V7W9CDXRWFN3A90M7 |
+| Flow concept                          |       Value | Matched lines | Event ids                      |
+| ------------------------------------- | ----------: | ------------: | ------------------------------ |
+| `mini:PurchasesOfInventoryForSale`    |   $5,000.00 |             1 | evt_01KS18CJYCY2EGHWDDG4V3N0KS |
+| `mini:DecreaseInInventoriesFromSales` | $(2,000.00) |             1 | evt_01KS18CJZAS0E693A2S8Y6R9GJ |
+| `mini:InventoryWrittenOff`            |   $(300.00) |             1 | evt_01KS18CK1V7W9CDXRWFN3A90M7 |
 
 ### Long-term Debt (mini:LongtermDebt)
 
 **Δ BS** (debit-positive): $(1,000.00)
 
-| Flow concept | Value | Matched lines | Event ids |
-|---|---:|---:|---|
-| `mini:AdditionalLongtermBorrowings` | $(2,000.00) | 1 | evt_01KS18CJX6M2H9R79CTZKB8A96 |
-| `mini:RepaymentLongtermBorrowings` | $1,000.00 | 1 | evt_01KS18CK0JQ9CQMBMCVQFWRD20 |
+| Flow concept                        |       Value | Matched lines | Event ids                      |
+| ----------------------------------- | ----------: | ------------: | ------------------------------ |
+| `mini:AdditionalLongtermBorrowings` | $(2,000.00) |             1 | evt_01KS18CJX6M2H9R79CTZKB8A96 |
+| `mini:RepaymentLongtermBorrowings`  |   $1,000.00 |             1 | evt_01KS18CK0JQ9CQMBMCVQFWRD20 |
 
 ### Paid In Capital (mini:PaidInCapital)
 
 **Δ BS** (debit-positive): $(10,000.00)
 
-| Flow concept | Value | Matched lines | Event ids |
-|---|---:|---:|---|
-| `mini:InvestmentsByOwner` | $(10,000.00) | 1 | evt_01KS18CJW6TPZ8PVXQ255G1EPZ |
+| Flow concept              |        Value | Matched lines | Event ids                      |
+| ------------------------- | -----------: | ------------: | ------------------------------ |
+| `mini:InvestmentsByOwner` | $(10,000.00) |             1 | evt_01KS18CJW6TPZ8PVXQ255G1EPZ |
 
 ### Property, Plant and Equipment (mini:PropertyPlantAndEquipment)
 
 **Δ BS** (debit-positive): $900.00
 
-| Flow concept | Value | Matched lines | Event ids |
-|---|---:|---:|---|
-| `mini:CapitalAdditionsPropertyPlantAndEquipment` | $1,000.00 | 1 | evt_01KS18CJXQHAW8WY76ADT79NB4 |
-| `mini:DecreaseFromDepreciationAndAmortization` | $(100.00) | 1 | evt_01KS18CK28WKSZ428QJ34NGJ2A |
+| Flow concept                                     |     Value | Matched lines | Event ids                      |
+| ------------------------------------------------ | --------: | ------------: | ------------------------------ |
+| `mini:CapitalAdditionsPropertyPlantAndEquipment` | $1,000.00 |             1 | evt_01KS18CJXQHAW8WY76ADT79NB4 |
+| `mini:DecreaseFromDepreciationAndAmortization`   | $(100.00) |             1 | evt_01KS18CK28WKSZ428QJ34NGJ2A |
 
 ### Receivables (mini:Receivables)
 
 **Δ BS** (debit-positive): $0.00
 
-| Flow concept | Value | Matched lines | Event ids |
-|---|---:|---:|---|
-| `mini:IncreaseInReceivablesFromSalesOnAccount` | $8,000.00 | 1 | evt_01KS18CJZAS0E693A2S8Y6R9GJ |
-| `mini:CollectionOfReceivables` | $(8,000.00) | 1 | evt_01KS18CJZPDZZT124FZ58EPQMF |
+| Flow concept                                   |       Value | Matched lines | Event ids                      |
+| ---------------------------------------------- | ----------: | ------------: | ------------------------------ |
+| `mini:IncreaseInReceivablesFromSalesOnAccount` |   $8,000.00 |             1 | evt_01KS18CJZAS0E693A2S8Y6R9GJ |
+| `mini:CollectionOfReceivables`                 | $(8,000.00) |             1 | evt_01KS18CJZPDZZT124FZ58EPQMF |
 
 ## Findings — Classification per Methodology §3.2
 
@@ -161,4 +161,4 @@ Each rollforward IB decomposes its BS source's period delta across declared TDC 
 
 ---
 
-*Reconciliation produced by `examples/seattle_method_demo/reconcile.py` against the Phase 2 MVP rollforward filter engine. See `examples/seattle_method_demo/README.md` for the full methodology and `local/docs/specs/cross-taxonomy-projection.md` for the architectural pattern this test validates.*
+_Reconciliation produced by `examples/seattle_method_demo/reconcile.py` against the Phase 2 MVP rollforward filter engine. See `examples/seattle_method_demo/README.md` for the full methodology and `local/docs/specs/cross-taxonomy-projection.md` for the architectural pattern this test validates._

--- a/examples/seattle_method_demo/output/seattle-method-case-1.md
+++ b/examples/seattle_method_demo/output/seattle-method-case-1.md
@@ -1,6 +1,6 @@
 # Seattle Method Cross-Taxonomy — Test Case 1 Reconciliation
 
-**Graph**: `kg19e42863c047fe080ee2`
+**Graph**: `kg19e431edebd7ee935597`
 **Period**: 2024-01-01 → 2024-01-31
 **Dataset**: Charlie Hoffman's lemonade-stand 14-JE Q1 2024 fixture
 **Expected output reference**: [luca.pacioli.ai/luca/view/0f24fd35…](https://luca.pacioli.ai/luca/view/0f24fd35e961e167a727b663c75a4c5ec9fb7eb86730d6292f46e6e180fc2018980cd52e/index)
@@ -71,8 +71,8 @@ Each rollforward IB decomposes its BS source's period delta across declared TDC 
 
 | Flow concept                              |       Value | Matched lines | Event ids                                                      |
 | ----------------------------------------- | ----------: | ------------: | -------------------------------------------------------------- |
-| `mini:PurchasesInventoryForSaleOnAccount` | $(8,000.00) |             2 | evt_01KS18CJYCY2EGHWDDG4V3N0KS, evt_01KS18CJYTHAGV7DEVXBPD0AH8 |
-| `mini:DecreaseFromPaymentAccountsPayable` |   $7,000.00 |             1 | evt_01KS18CK03546J6MQQGAXVP3MQ                                 |
+| `mini:PurchasesInventoryForSaleOnAccount` | $(8,000.00) |             2 | evt_01KS1HXXYWTPMWCYP8TQEMT9RY, evt_01KS1HXXZ8Y5E90GQC2488KQRV |
+| `mini:DecreaseFromPaymentAccountsPayable` |   $7,000.00 |             1 | evt_01KS1HXY0HABV2ZRZ55X8BK6XE                                 |
 
 ### Accrued Expenses (mini:AccruedExpenses)
 
@@ -80,8 +80,8 @@ Each rollforward IB decomposes its BS source's period delta across declared TDC 
 
 | Flow concept                         |     Value | Matched lines | Event ids                                                      |
 | ------------------------------------ | --------: | ------------: | -------------------------------------------------------------- |
-| `mini:DecreaseFromPaymentOfInterest` |   $150.00 |             1 | evt_01KS18CK0JQ9CQMBMCVQFWRD20                                 |
-| `mini:InterestAccrued`               | $(550.00) |             2 | evt_01KS18CK12DAEKR7CJ0A6Z0JXG, evt_01KS18CK32P9EYV8NXM2BMBZNF |
+| `mini:DecreaseFromPaymentOfInterest` |   $150.00 |             1 | evt_01KS1HXY0WRXH8CYDWJH254C7Q                                 |
+| `mini:InterestAccrued`               | $(550.00) |             2 | evt_01KS1HXY17R0FAC547FZ5CF6YR, evt_01KS1HXY2GCHS9CZMA3KE04STH |
 
 ### Cash and Cash Equivalents (mini:CashAndCashEquivalents)
 
@@ -89,13 +89,13 @@ Each rollforward IB decomposes its BS source's period delta across declared TDC 
 
 | Flow concept                                              |       Value | Matched lines | Event ids                      |
 | --------------------------------------------------------- | ----------: | ------------: | ------------------------------ |
-| `mini:ProceedsFromInvestmentsByOwner`                     |  $10,000.00 |             1 | evt_01KS18CJW6TPZ8PVXQ255G1EPZ |
-| `mini:ProceedsFromAdditionalLongtermBorrowings`           |   $2,000.00 |             1 | evt_01KS18CJX6M2H9R79CTZKB8A96 |
-| `mini:PaymentForCapitalAdditionsOfPropertyPlantEquipment` | $(1,000.00) |             1 | evt_01KS18CJXQHAW8WY76ADT79NB4 |
-| `mini:ProceedsFromCollectionOfReceivables`                |   $8,000.00 |             1 | evt_01KS18CJZPDZZT124FZ58EPQMF |
-| `mini:PaymentOfAccountsPayable`                           | $(7,000.00) |             1 | evt_01KS18CK03546J6MQQGAXVP3MQ |
-| `mini:PaymentForReductionOfLongtermBorrowings`            | $(1,000.00) |             1 | evt_01KS18CK0JQ9CQMBMCVQFWRD20 |
-| `mini:PaymentInterest`                                    |   $(150.00) |             1 | evt_01KS18CK0JQ9CQMBMCVQFWRD20 |
+| `mini:ProceedsFromInvestmentsByOwner`                     |  $10,000.00 |             1 | evt_01KS1HXXX2WPFAJXKEPTDPR1KW |
+| `mini:ProceedsFromAdditionalLongtermBorrowings`           |   $2,000.00 |             1 | evt_01KS1HXXXZTCGZ95HSV74R8Q1B |
+| `mini:PaymentForCapitalAdditionsOfPropertyPlantEquipment` | $(1,000.00) |             1 | evt_01KS1HXXYE4Y1V90MYQFYEQA91 |
+| `mini:ProceedsFromCollectionOfReceivables`                |   $8,000.00 |             1 | evt_01KS1HXY046BPHHJ0F8WRAPCNK |
+| `mini:PaymentOfAccountsPayable`                           | $(7,000.00) |             1 | evt_01KS1HXY0HABV2ZRZ55X8BK6XE |
+| `mini:PaymentForReductionOfLongtermBorrowings`            | $(1,000.00) |             1 | evt_01KS1HXY0WRXH8CYDWJH254C7Q |
+| `mini:PaymentInterest`                                    |   $(150.00) |             1 | evt_01KS1HXY0WRXH8CYDWJH254C7Q |
 
 ### Inventories (mini:Inventories)
 
@@ -103,9 +103,9 @@ Each rollforward IB decomposes its BS source's period delta across declared TDC 
 
 | Flow concept                          |       Value | Matched lines | Event ids                      |
 | ------------------------------------- | ----------: | ------------: | ------------------------------ |
-| `mini:PurchasesOfInventoryForSale`    |   $5,000.00 |             1 | evt_01KS18CJYCY2EGHWDDG4V3N0KS |
-| `mini:DecreaseInInventoriesFromSales` | $(2,000.00) |             1 | evt_01KS18CJZAS0E693A2S8Y6R9GJ |
-| `mini:InventoryWrittenOff`            |   $(300.00) |             1 | evt_01KS18CK1V7W9CDXRWFN3A90M7 |
+| `mini:PurchasesOfInventoryForSale`    |   $5,000.00 |             1 | evt_01KS1HXXYWTPMWCYP8TQEMT9RY |
+| `mini:DecreaseInInventoriesFromSales` | $(2,000.00) |             1 | evt_01KS1HXXZPFCNXKTTG5QDREMQH |
+| `mini:InventoryWrittenOff`            |   $(300.00) |             1 | evt_01KS1HXY1J8YQ5WBNRYJVDS7XR |
 
 ### Long-term Debt (mini:LongtermDebt)
 
@@ -113,8 +113,8 @@ Each rollforward IB decomposes its BS source's period delta across declared TDC 
 
 | Flow concept                        |       Value | Matched lines | Event ids                      |
 | ----------------------------------- | ----------: | ------------: | ------------------------------ |
-| `mini:AdditionalLongtermBorrowings` | $(2,000.00) |             1 | evt_01KS18CJX6M2H9R79CTZKB8A96 |
-| `mini:RepaymentLongtermBorrowings`  |   $1,000.00 |             1 | evt_01KS18CK0JQ9CQMBMCVQFWRD20 |
+| `mini:AdditionalLongtermBorrowings` | $(2,000.00) |             1 | evt_01KS1HXXXZTCGZ95HSV74R8Q1B |
+| `mini:RepaymentLongtermBorrowings`  |   $1,000.00 |             1 | evt_01KS1HXY0WRXH8CYDWJH254C7Q |
 
 ### Paid In Capital (mini:PaidInCapital)
 
@@ -122,7 +122,7 @@ Each rollforward IB decomposes its BS source's period delta across declared TDC 
 
 | Flow concept              |        Value | Matched lines | Event ids                      |
 | ------------------------- | -----------: | ------------: | ------------------------------ |
-| `mini:InvestmentsByOwner` | $(10,000.00) |             1 | evt_01KS18CJW6TPZ8PVXQ255G1EPZ |
+| `mini:InvestmentsByOwner` | $(10,000.00) |             1 | evt_01KS1HXXX2WPFAJXKEPTDPR1KW |
 
 ### Property, Plant and Equipment (mini:PropertyPlantAndEquipment)
 
@@ -130,8 +130,8 @@ Each rollforward IB decomposes its BS source's period delta across declared TDC 
 
 | Flow concept                                     |     Value | Matched lines | Event ids                      |
 | ------------------------------------------------ | --------: | ------------: | ------------------------------ |
-| `mini:CapitalAdditionsPropertyPlantAndEquipment` | $1,000.00 |             1 | evt_01KS18CJXQHAW8WY76ADT79NB4 |
-| `mini:DecreaseFromDepreciationAndAmortization`   | $(100.00) |             1 | evt_01KS18CK28WKSZ428QJ34NGJ2A |
+| `mini:CapitalAdditionsPropertyPlantAndEquipment` | $1,000.00 |             1 | evt_01KS1HXXYE4Y1V90MYQFYEQA91 |
+| `mini:DecreaseFromDepreciationAndAmortization`   | $(100.00) |             1 | evt_01KS1HXY1W2PKRQRMSYH2VDZB6 |
 
 ### Receivables (mini:Receivables)
 
@@ -139,8 +139,8 @@ Each rollforward IB decomposes its BS source's period delta across declared TDC 
 
 | Flow concept                                   |       Value | Matched lines | Event ids                      |
 | ---------------------------------------------- | ----------: | ------------: | ------------------------------ |
-| `mini:IncreaseInReceivablesFromSalesOnAccount` |   $8,000.00 |             1 | evt_01KS18CJZAS0E693A2S8Y6R9GJ |
-| `mini:CollectionOfReceivables`                 | $(8,000.00) |             1 | evt_01KS18CJZPDZZT124FZ58EPQMF |
+| `mini:IncreaseInReceivablesFromSalesOnAccount` |   $8,000.00 |             1 | evt_01KS1HXXZPFCNXKTTG5QDREMQH |
+| `mini:CollectionOfReceivables`                 | $(8,000.00) |             1 | evt_01KS1HXY046BPHHJ0F8WRAPCNK |
 
 ## Findings — Classification per Methodology §3.2
 

--- a/examples/seattle_method_demo/output/seattle-method-case-1.md
+++ b/examples/seattle_method_demo/output/seattle-method-case-1.md
@@ -11,136 +11,136 @@
 
 Compared **17** concept(s) against Charlie's luca.pacioli.ai export (`fixtures/expected_facts_mini.csv`). **17 exact match** • **0 delta**. Total absolute delta: **$0.00**.
 
-| Concept                            |  Our value | Charlie's value |     Δ |     |
-| ---------------------------------- | ---------: | --------------: | ----: | --- |
-| `mini:AccountsPayable`             |  $1,000.00 |       $1,000.00 | $0.00 | ✓   |
-| `mini:AccruedExpenses`             |    $400.00 |         $400.00 | $0.00 | ✓   |
-| `mini:CashAndCashEquivalents`      | $10,850.00 |      $10,850.00 | $0.00 | ✓   |
-| `mini:CostsOfSales`                |  $5,300.00 |       $5,300.00 | $0.00 | ✓   |
-| `mini:DepreciationAndAmortization` |    $100.00 |         $100.00 | $0.00 | ✓   |
-| `mini:IncomeTaxExpenseBenefit`     |    $400.00 |         $400.00 | $0.00 | ✓   |
-| `mini:InterestExpense`             |    $150.00 |         $150.00 | $0.00 | ✓   |
-| `mini:Inventories`                 |  $2,700.00 |       $2,700.00 | $0.00 | ✓   |
-| `mini:LongtermDebt`                |  $1,000.00 |       $1,000.00 | $0.00 | ✓   |
-| `mini:PaidInCapital`               | $10,000.00 |      $10,000.00 | $0.00 | ✓   |
-| `mini:PropertyPlantAndEquipment`   |    $900.00 |         $900.00 | $0.00 | ✓   |
-| `mini:Receivables`                 |      $0.00 |           $0.00 | $0.00 | ✓   |
-| `mini:Sales`                       |  $8,000.00 |       $8,000.00 | $0.00 | ✓   |
-| `mini:Assets`                      | $14,450.00 |      $14,450.00 | $0.00 | ✓   |
-| `mini:LiabilitiesAndEquity`        | $14,450.00 |      $14,450.00 | $0.00 | ✓   |
-| `mini:NetIncomeLoss`               |  $2,050.00 |       $2,050.00 | $0.00 | ✓   |
-| `mini:NetCashFlow`                 | $10,850.00 |      $10,850.00 | $0.00 | ✓   |
+| Concept | Our value | Charlie's value | Δ | |
+|---|---:|---:|---:|---|
+| `mini:AccountsPayable` | $1,000.00 | $1,000.00 | $0.00 | ✓ |
+| `mini:AccruedExpenses` | $400.00 | $400.00 | $0.00 | ✓ |
+| `mini:CashAndCashEquivalents` | $10,850.00 | $10,850.00 | $0.00 | ✓ |
+| `mini:CostsOfSales` | $5,300.00 | $5,300.00 | $0.00 | ✓ |
+| `mini:DepreciationAndAmortization` | $100.00 | $100.00 | $0.00 | ✓ |
+| `mini:IncomeTaxExpenseBenefit` | $400.00 | $400.00 | $0.00 | ✓ |
+| `mini:InterestExpense` | $150.00 | $150.00 | $0.00 | ✓ |
+| `mini:Inventories` | $2,700.00 | $2,700.00 | $0.00 | ✓ |
+| `mini:LongtermDebt` | $1,000.00 | $1,000.00 | $0.00 | ✓ |
+| `mini:PaidInCapital` | $10,000.00 | $10,000.00 | $0.00 | ✓ |
+| `mini:PropertyPlantAndEquipment` | $900.00 | $900.00 | $0.00 | ✓ |
+| `mini:Receivables` | $0.00 | $0.00 | $0.00 | ✓ |
+| `mini:Sales` | $8,000.00 | $8,000.00 | $0.00 | ✓ |
+| `mini:Assets` | $14,450.00 | $14,450.00 | $0.00 | ✓ |
+| `mini:LiabilitiesAndEquity` | $14,450.00 | $14,450.00 | $0.00 | ✓ |
+| `mini:NetIncomeLoss` | $2,050.00 | $2,050.00 | $0.00 | ✓ |
+| `mini:NetCashFlow` | $10,850.00 | $10,850.00 | $0.00 | ✓ |
 
 ## Four Anchor Totals
 
 Methodology spec §4.6 exit criterion: these four lines must match Charlie's PoC for the test to pass. All amounts are debit-positive cents internally; presentation flips signs per accounting convention.
 
-| Anchor                     |  Our value |
-| -------------------------- | ---------: |
-| Total Assets               | $14,450.00 |
+| Anchor | Our value |
+|---|---:|
+| Total Assets | $14,450.00 |
 | Total Liabilities & Equity | $14,450.00 |
-| Net Income                 |  $2,050.00 |
-| Net Cash Change            | $10,850.00 |
+| Net Income | $2,050.00 |
+| Net Cash Change | $10,850.00 |
 
 ## Concept-Level Period Totals
 
-Every mini concept with non-zero activity in the period. `Δ debit-positive` is the period flow (Σ DR − Σ CR). For instant/asset concepts this equals the period-ending balance (Charlie's data starts from zero). For duration concepts this is the period income/expense.
+Every mini concept with non-zero activity in the period. ``Δ debit-positive`` is the period flow (Σ DR − Σ CR). For instant/asset concepts this equals the period-ending balance (Charlie's data starts from zero). For duration concepts this is the period income/expense.
 
-| QName                              | Label                         | Trait     | Period   | Δ debit-positive |
-| ---------------------------------- | ----------------------------- | --------- | -------- | ---------------: |
-| `mini:AccountsPayable`             | Accounts Payable              | liability | instant  |      $(1,000.00) |
-| `mini:AccruedExpenses`             | Accrued Expenses              | liability | instant  |        $(400.00) |
-| `mini:CashAndCashEquivalents`      | Cash and Cash Equivalents     | asset     | instant  |       $10,850.00 |
-| `mini:CostsOfSales`                | Costs of Sales                | expense   | duration |        $5,300.00 |
-| `mini:DepreciationAndAmortization` | Depreciation and Amortization | expense   | duration |          $100.00 |
-| `mini:IncomeTaxExpenseBenefit`     | Income Tax Expense (Benefit)  | expense   | duration |          $400.00 |
-| `mini:InterestExpense`             | Interest Expense              | expense   | duration |          $150.00 |
-| `mini:Inventories`                 | Inventories                   | asset     | instant  |        $2,700.00 |
-| `mini:LongtermDebt`                | Long-term Debt                | liability | instant  |      $(1,000.00) |
-| `mini:PaidInCapital`               | Paid In Capital               | equity    | instant  |     $(10,000.00) |
-| `mini:PropertyPlantAndEquipment`   | Property, Plant and Equipment | asset     | instant  |          $900.00 |
-| `mini:Sales`                       | Sales                         | revenue   | duration |      $(8,000.00) |
+| QName | Label | Trait | Period | Δ debit-positive |
+|---|---|---|---|---:|
+| `mini:AccountsPayable` | Accounts Payable | liability | instant | $(1,000.00) |
+| `mini:AccruedExpenses` | Accrued Expenses | liability | instant | $(400.00) |
+| `mini:CashAndCashEquivalents` | Cash and Cash Equivalents | asset | instant | $10,850.00 |
+| `mini:CostsOfSales` | Costs of Sales | expense | duration | $5,300.00 |
+| `mini:DepreciationAndAmortization` | Depreciation and Amortization | expense | duration | $100.00 |
+| `mini:IncomeTaxExpenseBenefit` | Income Tax Expense (Benefit) | expense | duration | $400.00 |
+| `mini:InterestExpense` | Interest Expense | expense | duration | $150.00 |
+| `mini:Inventories` | Inventories | asset | instant | $2,700.00 |
+| `mini:LongtermDebt` | Long-term Debt | liability | instant | $(1,000.00) |
+| `mini:PaidInCapital` | Paid In Capital | equity | instant | $(10,000.00) |
+| `mini:PropertyPlantAndEquipment` | Property, Plant and Equipment | asset | instant | $900.00 |
+| `mini:Sales` | Sales | revenue | duration | $(8,000.00) |
 
 ## Rollforward Attribution (Phase 2 MVP Filter Engine)
 
-Each rollforward IB decomposes its BS source's period delta across declared TDC filters. Where `Σ filters == Δ BS`, the rollforward is balanced (residual = 0). A non-zero residual indicates either an unattributed flow or a phantom TDC in the source data (logged at author time).
+Each rollforward IB decomposes its BS source's period delta across declared TDC filters. Where ``Σ filters == Δ BS``, the rollforward is balanced (residual = 0). A non-zero residual indicates either an unattributed flow or a phantom TDC in the source data (logged at author time).
 
 ### Accounts Payable (mini:AccountsPayable)
 
 **Δ BS** (debit-positive): $(1,000.00)
 
-| Flow concept                              |       Value | Matched lines | Event ids                                                      |
-| ----------------------------------------- | ----------: | ------------: | -------------------------------------------------------------- |
-| `mini:PurchasesInventoryForSaleOnAccount` | $(8,000.00) |             2 | evt_01KS1HXXYWTPMWCYP8TQEMT9RY, evt_01KS1HXXZ8Y5E90GQC2488KQRV |
-| `mini:DecreaseFromPaymentAccountsPayable` |   $7,000.00 |             1 | evt_01KS1HXY0HABV2ZRZ55X8BK6XE                                 |
+| Flow concept | Value | Matched lines | Event ids |
+|---|---:|---:|---|
+| `mini:PurchasesInventoryForSaleOnAccount` | $(8,000.00) | 2 | evt_01KS1HXXYWTPMWCYP8TQEMT9RY, evt_01KS1HXXZ8Y5E90GQC2488KQRV |
+| `mini:DecreaseFromPaymentAccountsPayable` | $7,000.00 | 1 | evt_01KS1HXY0HABV2ZRZ55X8BK6XE |
 
 ### Accrued Expenses (mini:AccruedExpenses)
 
 **Δ BS** (debit-positive): $(400.00)
 
-| Flow concept                         |     Value | Matched lines | Event ids                                                      |
-| ------------------------------------ | --------: | ------------: | -------------------------------------------------------------- |
-| `mini:DecreaseFromPaymentOfInterest` |   $150.00 |             1 | evt_01KS1HXY0WRXH8CYDWJH254C7Q                                 |
-| `mini:InterestAccrued`               | $(550.00) |             2 | evt_01KS1HXY17R0FAC547FZ5CF6YR, evt_01KS1HXY2GCHS9CZMA3KE04STH |
+| Flow concept | Value | Matched lines | Event ids |
+|---|---:|---:|---|
+| `mini:DecreaseFromPaymentOfInterest` | $150.00 | 1 | evt_01KS1HXY0WRXH8CYDWJH254C7Q |
+| `mini:InterestAccrued` | $(550.00) | 2 | evt_01KS1HXY17R0FAC547FZ5CF6YR, evt_01KS1HXY2GCHS9CZMA3KE04STH |
 
 ### Cash and Cash Equivalents (mini:CashAndCashEquivalents)
 
 **Δ BS** (debit-positive): $10,850.00
 
-| Flow concept                                              |       Value | Matched lines | Event ids                      |
-| --------------------------------------------------------- | ----------: | ------------: | ------------------------------ |
-| `mini:ProceedsFromInvestmentsByOwner`                     |  $10,000.00 |             1 | evt_01KS1HXXX2WPFAJXKEPTDPR1KW |
-| `mini:ProceedsFromAdditionalLongtermBorrowings`           |   $2,000.00 |             1 | evt_01KS1HXXXZTCGZ95HSV74R8Q1B |
-| `mini:PaymentForCapitalAdditionsOfPropertyPlantEquipment` | $(1,000.00) |             1 | evt_01KS1HXXYE4Y1V90MYQFYEQA91 |
-| `mini:ProceedsFromCollectionOfReceivables`                |   $8,000.00 |             1 | evt_01KS1HXY046BPHHJ0F8WRAPCNK |
-| `mini:PaymentOfAccountsPayable`                           | $(7,000.00) |             1 | evt_01KS1HXY0HABV2ZRZ55X8BK6XE |
-| `mini:PaymentForReductionOfLongtermBorrowings`            | $(1,000.00) |             1 | evt_01KS1HXY0WRXH8CYDWJH254C7Q |
-| `mini:PaymentInterest`                                    |   $(150.00) |             1 | evt_01KS1HXY0WRXH8CYDWJH254C7Q |
+| Flow concept | Value | Matched lines | Event ids |
+|---|---:|---:|---|
+| `mini:ProceedsFromInvestmentsByOwner` | $10,000.00 | 1 | evt_01KS1HXXX2WPFAJXKEPTDPR1KW |
+| `mini:ProceedsFromAdditionalLongtermBorrowings` | $2,000.00 | 1 | evt_01KS1HXXXZTCGZ95HSV74R8Q1B |
+| `mini:PaymentForCapitalAdditionsOfPropertyPlantEquipment` | $(1,000.00) | 1 | evt_01KS1HXXYE4Y1V90MYQFYEQA91 |
+| `mini:ProceedsFromCollectionOfReceivables` | $8,000.00 | 1 | evt_01KS1HXY046BPHHJ0F8WRAPCNK |
+| `mini:PaymentOfAccountsPayable` | $(7,000.00) | 1 | evt_01KS1HXY0HABV2ZRZ55X8BK6XE |
+| `mini:PaymentForReductionOfLongtermBorrowings` | $(1,000.00) | 1 | evt_01KS1HXY0WRXH8CYDWJH254C7Q |
+| `mini:PaymentInterest` | $(150.00) | 1 | evt_01KS1HXY0WRXH8CYDWJH254C7Q |
 
 ### Inventories (mini:Inventories)
 
 **Δ BS** (debit-positive): $2,700.00
 
-| Flow concept                          |       Value | Matched lines | Event ids                      |
-| ------------------------------------- | ----------: | ------------: | ------------------------------ |
-| `mini:PurchasesOfInventoryForSale`    |   $5,000.00 |             1 | evt_01KS1HXXYWTPMWCYP8TQEMT9RY |
-| `mini:DecreaseInInventoriesFromSales` | $(2,000.00) |             1 | evt_01KS1HXXZPFCNXKTTG5QDREMQH |
-| `mini:InventoryWrittenOff`            |   $(300.00) |             1 | evt_01KS1HXY1J8YQ5WBNRYJVDS7XR |
+| Flow concept | Value | Matched lines | Event ids |
+|---|---:|---:|---|
+| `mini:PurchasesOfInventoryForSale` | $5,000.00 | 1 | evt_01KS1HXXYWTPMWCYP8TQEMT9RY |
+| `mini:DecreaseInInventoriesFromSales` | $(2,000.00) | 1 | evt_01KS1HXXZPFCNXKTTG5QDREMQH |
+| `mini:InventoryWrittenOff` | $(300.00) | 1 | evt_01KS1HXY1J8YQ5WBNRYJVDS7XR |
 
 ### Long-term Debt (mini:LongtermDebt)
 
 **Δ BS** (debit-positive): $(1,000.00)
 
-| Flow concept                        |       Value | Matched lines | Event ids                      |
-| ----------------------------------- | ----------: | ------------: | ------------------------------ |
-| `mini:AdditionalLongtermBorrowings` | $(2,000.00) |             1 | evt_01KS1HXXXZTCGZ95HSV74R8Q1B |
-| `mini:RepaymentLongtermBorrowings`  |   $1,000.00 |             1 | evt_01KS1HXY0WRXH8CYDWJH254C7Q |
+| Flow concept | Value | Matched lines | Event ids |
+|---|---:|---:|---|
+| `mini:AdditionalLongtermBorrowings` | $(2,000.00) | 1 | evt_01KS1HXXXZTCGZ95HSV74R8Q1B |
+| `mini:RepaymentLongtermBorrowings` | $1,000.00 | 1 | evt_01KS1HXY0WRXH8CYDWJH254C7Q |
 
 ### Paid In Capital (mini:PaidInCapital)
 
 **Δ BS** (debit-positive): $(10,000.00)
 
-| Flow concept              |        Value | Matched lines | Event ids                      |
-| ------------------------- | -----------: | ------------: | ------------------------------ |
-| `mini:InvestmentsByOwner` | $(10,000.00) |             1 | evt_01KS1HXXX2WPFAJXKEPTDPR1KW |
+| Flow concept | Value | Matched lines | Event ids |
+|---|---:|---:|---|
+| `mini:InvestmentsByOwner` | $(10,000.00) | 1 | evt_01KS1HXXX2WPFAJXKEPTDPR1KW |
 
 ### Property, Plant and Equipment (mini:PropertyPlantAndEquipment)
 
 **Δ BS** (debit-positive): $900.00
 
-| Flow concept                                     |     Value | Matched lines | Event ids                      |
-| ------------------------------------------------ | --------: | ------------: | ------------------------------ |
-| `mini:CapitalAdditionsPropertyPlantAndEquipment` | $1,000.00 |             1 | evt_01KS1HXXYE4Y1V90MYQFYEQA91 |
-| `mini:DecreaseFromDepreciationAndAmortization`   | $(100.00) |             1 | evt_01KS1HXY1W2PKRQRMSYH2VDZB6 |
+| Flow concept | Value | Matched lines | Event ids |
+|---|---:|---:|---|
+| `mini:CapitalAdditionsPropertyPlantAndEquipment` | $1,000.00 | 1 | evt_01KS1HXXYE4Y1V90MYQFYEQA91 |
+| `mini:DecreaseFromDepreciationAndAmortization` | $(100.00) | 1 | evt_01KS1HXY1W2PKRQRMSYH2VDZB6 |
 
 ### Receivables (mini:Receivables)
 
 **Δ BS** (debit-positive): $0.00
 
-| Flow concept                                   |       Value | Matched lines | Event ids                      |
-| ---------------------------------------------- | ----------: | ------------: | ------------------------------ |
-| `mini:IncreaseInReceivablesFromSalesOnAccount` |   $8,000.00 |             1 | evt_01KS1HXXZPFCNXKTTG5QDREMQH |
-| `mini:CollectionOfReceivables`                 | $(8,000.00) |             1 | evt_01KS1HXY046BPHHJ0F8WRAPCNK |
+| Flow concept | Value | Matched lines | Event ids |
+|---|---:|---:|---|
+| `mini:IncreaseInReceivablesFromSalesOnAccount` | $8,000.00 | 1 | evt_01KS1HXXZPFCNXKTTG5QDREMQH |
+| `mini:CollectionOfReceivables` | $(8,000.00) | 1 | evt_01KS1HXY046BPHHJ0F8WRAPCNK |
 
 ## Findings — Classification per Methodology §3.2
 
@@ -161,4 +161,4 @@ Each rollforward IB decomposes its BS source's period delta across declared TDC 
 
 ---
 
-_Reconciliation produced by `examples/seattle_method_demo/reconcile.py` against the Phase 2 MVP rollforward filter engine. See `examples/seattle_method_demo/README.md` for the full methodology and `local/docs/specs/cross-taxonomy-projection.md` for the architectural pattern this test validates._
+*Reconciliation produced by `examples/seattle_method_demo/reconcile.py` against the Phase 2 MVP rollforward filter engine. See `examples/seattle_method_demo/README.md` for the full methodology and `local/docs/specs/cross-taxonomy-projection.md` for the architectural pattern this test validates.*

--- a/examples/seattle_method_demo/output/seattle-method-case-1.md
+++ b/examples/seattle_method_demo/output/seattle-method-case-1.md
@@ -1,0 +1,164 @@
+# Seattle Method Cross-Taxonomy — Test Case 1 Reconciliation
+
+**Graph**: `kg19e42863c047fe080ee2`
+**Period**: 2024-01-01 → 2024-01-31
+**Dataset**: Charlie Hoffman's lemonade-stand 14-JE Q1 2024 fixture
+**Expected output reference**: [luca.pacioli.ai/luca/view/0f24fd35…](https://luca.pacioli.ai/luca/view/0f24fd35e961e167a727b663c75a4c5ec9fb7eb86730d6292f46e6e180fc2018980cd52e/index)
+
+---
+
+## Automated Diff vs. Charlie's Published Facts
+
+Compared **17** concept(s) against Charlie's luca.pacioli.ai export (`fixtures/expected_facts_mini.csv`). **17 exact match** • **0 delta**. Total absolute delta: **$0.00**.
+
+| Concept | Our value | Charlie's value | Δ | |
+|---|---:|---:|---:|---|
+| `mini:AccountsPayable` | $1,000.00 | $1,000.00 | $0.00 | ✓ |
+| `mini:AccruedExpenses` | $400.00 | $400.00 | $0.00 | ✓ |
+| `mini:CashAndCashEquivalents` | $10,850.00 | $10,850.00 | $0.00 | ✓ |
+| `mini:CostsOfSales` | $5,300.00 | $5,300.00 | $0.00 | ✓ |
+| `mini:DepreciationAndAmortization` | $100.00 | $100.00 | $0.00 | ✓ |
+| `mini:IncomeTaxExpenseBenefit` | $400.00 | $400.00 | $0.00 | ✓ |
+| `mini:InterestExpense` | $150.00 | $150.00 | $0.00 | ✓ |
+| `mini:Inventories` | $2,700.00 | $2,700.00 | $0.00 | ✓ |
+| `mini:LongtermDebt` | $1,000.00 | $1,000.00 | $0.00 | ✓ |
+| `mini:PaidInCapital` | $10,000.00 | $10,000.00 | $0.00 | ✓ |
+| `mini:PropertyPlantAndEquipment` | $900.00 | $900.00 | $0.00 | ✓ |
+| `mini:Receivables` | $0.00 | $0.00 | $0.00 | ✓ |
+| `mini:Sales` | $8,000.00 | $8,000.00 | $0.00 | ✓ |
+| `mini:Assets` | $14,450.00 | $14,450.00 | $0.00 | ✓ |
+| `mini:LiabilitiesAndEquity` | $14,450.00 | $14,450.00 | $0.00 | ✓ |
+| `mini:NetIncomeLoss` | $2,050.00 | $2,050.00 | $0.00 | ✓ |
+| `mini:NetCashFlow` | $10,850.00 | $10,850.00 | $0.00 | ✓ |
+
+## Four Anchor Totals
+
+Methodology spec §4.6 exit criterion: these four lines must match Charlie's PoC for the test to pass. All amounts are debit-positive cents internally; presentation flips signs per accounting convention.
+
+| Anchor | Our value |
+|---|---:|
+| Total Assets | $14,450.00 |
+| Total Liabilities & Equity | $14,450.00 |
+| Net Income | $2,050.00 |
+| Net Cash Change | $10,850.00 |
+
+## Concept-Level Period Totals
+
+Every mini concept with non-zero activity in the period. ``Δ debit-positive`` is the period flow (Σ DR − Σ CR). For instant/asset concepts this equals the period-ending balance (Charlie's data starts from zero). For duration concepts this is the period income/expense.
+
+| QName | Label | Trait | Period | Δ debit-positive |
+|---|---|---|---|---:|
+| `mini:AccountsPayable` | Accounts Payable | liability | instant | $(1,000.00) |
+| `mini:AccruedExpenses` | Accrued Expenses | liability | instant | $(400.00) |
+| `mini:CashAndCashEquivalents` | Cash and Cash Equivalents | asset | instant | $10,850.00 |
+| `mini:CostsOfSales` | Costs of Sales | expense | duration | $5,300.00 |
+| `mini:DepreciationAndAmortization` | Depreciation and Amortization | expense | duration | $100.00 |
+| `mini:IncomeTaxExpenseBenefit` | Income Tax Expense (Benefit) | expense | duration | $400.00 |
+| `mini:InterestExpense` | Interest Expense | expense | duration | $150.00 |
+| `mini:Inventories` | Inventories | asset | instant | $2,700.00 |
+| `mini:LongtermDebt` | Long-term Debt | liability | instant | $(1,000.00) |
+| `mini:PaidInCapital` | Paid In Capital | equity | instant | $(10,000.00) |
+| `mini:PropertyPlantAndEquipment` | Property, Plant and Equipment | asset | instant | $900.00 |
+| `mini:Sales` | Sales | revenue | duration | $(8,000.00) |
+
+## Rollforward Attribution (Phase 2 MVP Filter Engine)
+
+Each rollforward IB decomposes its BS source's period delta across declared TDC filters. Where ``Σ filters == Δ BS``, the rollforward is balanced (residual = 0). A non-zero residual indicates either an unattributed flow or a phantom TDC in the source data (logged at author time).
+
+### Accounts Payable (mini:AccountsPayable)
+
+**Δ BS** (debit-positive): $(1,000.00)
+
+| Flow concept | Value | Matched lines | Event ids |
+|---|---:|---:|---|
+| `mini:PurchasesInventoryForSaleOnAccount` | $(8,000.00) | 2 | evt_01KS18CJYCY2EGHWDDG4V3N0KS, evt_01KS18CJYTHAGV7DEVXBPD0AH8 |
+| `mini:DecreaseFromPaymentAccountsPayable` | $7,000.00 | 1 | evt_01KS18CK03546J6MQQGAXVP3MQ |
+
+### Accrued Expenses (mini:AccruedExpenses)
+
+**Δ BS** (debit-positive): $(400.00)
+
+| Flow concept | Value | Matched lines | Event ids |
+|---|---:|---:|---|
+| `mini:DecreaseFromPaymentOfInterest` | $150.00 | 1 | evt_01KS18CK0JQ9CQMBMCVQFWRD20 |
+| `mini:InterestAccrued` | $(550.00) | 2 | evt_01KS18CK12DAEKR7CJ0A6Z0JXG, evt_01KS18CK32P9EYV8NXM2BMBZNF |
+
+### Cash and Cash Equivalents (mini:CashAndCashEquivalents)
+
+**Δ BS** (debit-positive): $10,850.00
+
+| Flow concept | Value | Matched lines | Event ids |
+|---|---:|---:|---|
+| `mini:ProceedsFromInvestmentsByOwner` | $10,000.00 | 1 | evt_01KS18CJW6TPZ8PVXQ255G1EPZ |
+| `mini:ProceedsFromAdditionalLongtermBorrowings` | $2,000.00 | 1 | evt_01KS18CJX6M2H9R79CTZKB8A96 |
+| `mini:PaymentForCapitalAdditionsOfPropertyPlantEquipment` | $(1,000.00) | 1 | evt_01KS18CJXQHAW8WY76ADT79NB4 |
+| `mini:ProceedsFromCollectionOfReceivables` | $8,000.00 | 1 | evt_01KS18CJZPDZZT124FZ58EPQMF |
+| `mini:PaymentOfAccountsPayable` | $(7,000.00) | 1 | evt_01KS18CK03546J6MQQGAXVP3MQ |
+| `mini:PaymentForReductionOfLongtermBorrowings` | $(1,000.00) | 1 | evt_01KS18CK0JQ9CQMBMCVQFWRD20 |
+| `mini:PaymentInterest` | $(150.00) | 1 | evt_01KS18CK0JQ9CQMBMCVQFWRD20 |
+
+### Inventories (mini:Inventories)
+
+**Δ BS** (debit-positive): $2,700.00
+
+| Flow concept | Value | Matched lines | Event ids |
+|---|---:|---:|---|
+| `mini:PurchasesOfInventoryForSale` | $5,000.00 | 1 | evt_01KS18CJYCY2EGHWDDG4V3N0KS |
+| `mini:DecreaseInInventoriesFromSales` | $(2,000.00) | 1 | evt_01KS18CJZAS0E693A2S8Y6R9GJ |
+| `mini:InventoryWrittenOff` | $(300.00) | 1 | evt_01KS18CK1V7W9CDXRWFN3A90M7 |
+
+### Long-term Debt (mini:LongtermDebt)
+
+**Δ BS** (debit-positive): $(1,000.00)
+
+| Flow concept | Value | Matched lines | Event ids |
+|---|---:|---:|---|
+| `mini:AdditionalLongtermBorrowings` | $(2,000.00) | 1 | evt_01KS18CJX6M2H9R79CTZKB8A96 |
+| `mini:RepaymentLongtermBorrowings` | $1,000.00 | 1 | evt_01KS18CK0JQ9CQMBMCVQFWRD20 |
+
+### Paid In Capital (mini:PaidInCapital)
+
+**Δ BS** (debit-positive): $(10,000.00)
+
+| Flow concept | Value | Matched lines | Event ids |
+|---|---:|---:|---|
+| `mini:InvestmentsByOwner` | $(10,000.00) | 1 | evt_01KS18CJW6TPZ8PVXQ255G1EPZ |
+
+### Property, Plant and Equipment (mini:PropertyPlantAndEquipment)
+
+**Δ BS** (debit-positive): $900.00
+
+| Flow concept | Value | Matched lines | Event ids |
+|---|---:|---:|---|
+| `mini:CapitalAdditionsPropertyPlantAndEquipment` | $1,000.00 | 1 | evt_01KS18CJXQHAW8WY76ADT79NB4 |
+| `mini:DecreaseFromDepreciationAndAmortization` | $(100.00) | 1 | evt_01KS18CK28WKSZ428QJ34NGJ2A |
+
+### Receivables (mini:Receivables)
+
+**Δ BS** (debit-positive): $0.00
+
+| Flow concept | Value | Matched lines | Event ids |
+|---|---:|---:|---|
+| `mini:IncreaseInReceivablesFromSalesOnAccount` | $8,000.00 | 1 | evt_01KS18CJZAS0E693A2S8Y6R9GJ |
+| `mini:CollectionOfReceivables` | $(8,000.00) | 1 | evt_01KS18CJZPDZZT124FZ58EPQMF |
+
+## Findings — Classification per Methodology §3.2
+
+**Their data quality** (source CSV inconsistencies):
+
+- **JE-205** — Description "Payment for contractor" but TDC on the AP line is `mini:PurchasesInventoryForSaleOnAccount`. Contractor services aren't inventory; vocabulary misuse.
+- **JE-209** — TDC `mini:PaymentOfInterest` was a typo for `mini:PaymentInterest` (the canonical mini.xsd concept name). Fixed at source in `fixtures/transactions.csv` prior to ingest. Note that `mini:DecreaseFromPaymentOfInterest` (the AccruedExpenses-side TDC) keeps the "Of" — Charlie's naming is internally inconsistent.
+- **JE-226** — Income tax accrual ($400) but TDC is `mini:InterestAccrued` instead of `IncomeTaxAccrued`. Copy-paste-style bug from the JE-210 interest pattern.
+
+**Methodology gap** (architecturally aligned, semantically distinct):
+
+- **JE-225** — "Write off of PPE" with `Amount = 0` on both lines. Boundary test case. Our GL handler rejects nil-amount entries (`must have non-zero D or C`); Charlie's system likely creates `$0` facts. Reconciliation delta is `$0` either way; the four anchor totals are unaffected.
+- **rs-gaap library subset** — Two flow concepts in `mappings.py` don't exist in our currently-loaded rs-gaap library: `rs-gaap:InterestPaidNet` (mapped through to the closest available `rs-gaap:InterestExpense`) and `rs-gaap:StockIssuedDuringPeriodValueNewIssues` (mapped through to `rs-gaap:ProceedsFromIssuanceOfCommonStock`). Approximation; future library expansion closes the gap.
+
+**Our bug**: none identified.
+
+**Matching**: see Anchor Totals table above + line-by-line concept totals. Compare manually against Charlie's PoC rendering at the expected-output URL — automated HTML diff is a forward-queue enhancement (methodology §3.1 step 5 stretch goal).
+
+---
+
+*Reconciliation produced by `examples/seattle_method_demo/reconcile.py` against the Phase 2 MVP rollforward filter engine. See `examples/seattle_method_demo/README.md` for the full methodology and `local/docs/specs/cross-taxonomy-projection.md` for the architectural pattern this test validates.*

--- a/examples/seattle_method_demo/pull_mini.sh
+++ b/examples/seattle_method_demo/pull_mini.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Pull Charlie Hoffman's mini reporting framework from xbrlsite into
+# local/taxonomies/mini/ (gitignored).
+#
+# Parses mini-entryPoint.xsd for the linkbase file list, then curls each
+# referenced file. Idempotent — re-runs overwrite the local copy.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+OUT_DIR="$REPO_ROOT/local/taxonomies/mini"
+
+BASE_URL="https://xbrlsite.azurewebsites.net/2023/reporting-scheme/mini/base-taxonomy"
+
+mkdir -p "$OUT_DIR"
+
+echo "Pulling mini taxonomy → $OUT_DIR"
+
+# Pull the entry point + concept schema first.
+for f in mini-entryPoint.xsd mini.xsd; do
+  if curl -fsSL "$BASE_URL/$f" -o "$OUT_DIR/$f"; then
+    echo "  ✓ $f"
+  else
+    echo "  ✗ $f (required — aborting)" >&2
+    exit 1
+  fi
+done
+
+# Parse linkbase file refs from the entry point. Each linkbaseRef has
+# `xlink:href='mini-foo.xml'`; we extract the unique set.
+mapfile -t LINKBASES < <(
+  grep -oE "xlink:href='[^']+'" "$OUT_DIR/mini-entryPoint.xsd" \
+    | sed -E "s/xlink:href='([^']+)'/\1/" \
+    | sort -u
+)
+
+echo
+echo "Found ${#LINKBASES[@]} linkbase reference(s) in mini-entryPoint.xsd"
+echo
+
+pulled=0
+failed=()
+for f in "${LINKBASES[@]}"; do
+  # Skip schema files (already pulled).
+  case "$f" in
+    *.xsd) continue ;;
+  esac
+  if curl -fsSL "$BASE_URL/$f" -o "$OUT_DIR/$f"; then
+    pulled=$((pulled + 1))
+  else
+    failed+=("$f")
+  fi
+done
+
+echo "Pulled $pulled linkbase file(s) to $OUT_DIR"
+if [ ${#failed[@]} -gt 0 ]; then
+  echo
+  echo "Failed (${#failed[@]}):"
+  for f in "${failed[@]}"; do
+    echo "  ✗ $f"
+  done
+fi
+
+echo
+echo "Total files: $(ls "$OUT_DIR" | wc -l | tr -d ' ')"
+echo
+echo "Next: uv run python -m examples.seattle_method_demo.load_taxonomy"

--- a/examples/seattle_method_demo/pull_mini.sh
+++ b/examples/seattle_method_demo/pull_mini.sh
@@ -4,6 +4,14 @@
 #
 # Parses mini-entryPoint.xsd for the linkbase file list, then curls each
 # referenced file. Idempotent — re-runs overwrite the local copy.
+#
+# Authoritative upstream: https://github.com/seattlemethod/mini
+# We pull from xbrlsite because that's where the URLs in the entry
+# point's linkbaseRef hrefs resolve. The GitHub repo has additional
+# context (fac/, disclosure-mechanics/, disclosures-topics/,
+# reporting-checklist/, type-subtype/) that future work — the Phase
+# δ.2 rule corpus port and the Phase 2.5 enrichment engine — will
+# want; for Test Case 1 the base-taxonomy files are sufficient.
 
 set -euo pipefail
 

--- a/examples/seattle_method_demo/reconcile.py
+++ b/examples/seattle_method_demo/reconcile.py
@@ -35,8 +35,8 @@ from __future__ import annotations
 
 import argparse
 import csv
+import os
 import re
-from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import date
 from pathlib import Path
@@ -54,7 +54,14 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 DEMO_ROOT = REPO_ROOT / "examples" / "seattle_method_demo"
 DEFAULT_REPORT_PATH = DEMO_ROOT / "output" / "seattle-method-case-1.md"
 EXPECTED_FACTS_PATH = DEMO_ROOT / "fixtures" / "expected_facts_mini.csv"
-EXTENSIONS_DB_URL = "postgresql://postgres:postgres@localhost:5432/extensions"
+# Filter engine needs a direct SQLAlchemy session (Phase 2 MVP boundary
+# per ``information-block.md`` §4.5; Phase 3 wires it into
+# ``build_envelope`` so we can drop this entirely). Reads
+# ``EXTENSIONS_DATABASE_URL`` from the process env — the
+# ``just demo-seattle-method-reconcile`` recipe loads ``.env.local``
+# which sets this. If you invoke ``reconcile.py`` outside the justfile,
+# export the var yourself.
+EXTENSIONS_DB_URL = os.environ.get("EXTENSIONS_DATABASE_URL")
 SAFE_GRAPH_ID = re.compile(r"^kg[a-zA-Z0-9_]+$")
 
 
@@ -124,6 +131,27 @@ class ReconciliationReport:
 # ── DB queries ───────────────────────────────────────────────────────────
 
 
+def _read_graph_id_from_credentials() -> str | None:
+  """Read the ``seattle_method_test`` graph slot from ``.local/config.json``.
+
+  Returns ``None`` if the file or slot doesn't exist — caller surfaces
+  a friendly "run the orchestrator first" message. The slot is saved
+  by ``main.step_provision_graph`` via
+  ``examples.credentials.utils.save_graph_id``.
+  """
+  import json
+
+  config_path = Path(".local/config.json")
+  if not config_path.exists():
+    return None
+  try:
+    cfg = json.loads(config_path.read_text())
+  except (OSError, json.JSONDecodeError):
+    return None
+  slot = (cfg.get("graphs") or {}).get("seattle_method_test") or {}
+  return slot.get("graph_id")
+
+
 def _get_ledger_client():
   """Construct a LedgerClient from saved credentials.
 
@@ -160,6 +188,12 @@ def _open_session(graph_id: str) -> Session:
   if not SAFE_GRAPH_ID.match(graph_id):
     raise SystemExit(
       f"Refusing to use graph_id {graph_id!r} — must match {SAFE_GRAPH_ID.pattern}"
+    )
+  if not EXTENSIONS_DB_URL:
+    raise SystemExit(
+      "EXTENSIONS_DATABASE_URL is not set. Run via "
+      "`just demo-seattle-method-reconcile <graph_id>` (which loads "
+      ".env.local), or export the env var manually."
     )
   engine = create_engine(EXTENSIONS_DB_URL)
   session_factory = sessionmaker(bind=engine)
@@ -669,7 +703,16 @@ def main() -> None:
     description="Reconcile the Seattle Method Test Case 1 demo against "
     "Charlie Hoffman's expected output. Produces a markdown report.",
   )
-  parser.add_argument("graph_id", help="The seattle_method_test graph id.")
+  parser.add_argument(
+    "graph_id",
+    nargs="?",
+    default=None,
+    help=(
+      "The graph id to reconcile. If omitted, reads the "
+      "``seattle_method_test`` slot from ``.local/config.json`` "
+      "(populated by ``just demo-seattle-method``)."
+    ),
+  )
   parser.add_argument(
     "--period-start",
     type=date.fromisoformat,
@@ -681,6 +724,32 @@ def main() -> None:
     type=date.fromisoformat,
     default=date(2024, 1, 31),
     help="Period end (default 2024-01-31).",
+  )
+  # The diff-period labels are deliberately separate from
+  # --period-start/--period-end because Charlie's PoC reports BS
+  # positions at his calendar-year-end ("12/31/24") and IS/CF flows
+  # across the full calendar year ("2024-01-01 | 2024-12-31") even
+  # though the underlying JEs are only in January. Other test cases
+  # (us-gaap, IFRS) will publish facts with different period labels;
+  # they need their own values here. Defaults match Charlie's mini
+  # CSV export format for Test Case 1.
+  parser.add_argument(
+    "--diff-label-instant",
+    default="12/31/24",
+    help=(
+      "Period label expected on Charlie's instant facts (BS positions). "
+      "Default matches his mini CSV export for Test Case 1; override for "
+      "other test cases."
+    ),
+  )
+  parser.add_argument(
+    "--diff-label-duration",
+    default="2024-01-01 | 2024-12-31",
+    help=(
+      "Period label expected on Charlie's duration facts (IS / CF flows). "
+      "Default matches his mini CSV export for Test Case 1; override for "
+      "other test cases."
+    ),
   )
   parser.add_argument(
     "--out",
@@ -701,7 +770,19 @@ def main() -> None:
   )
   args = parser.parse_args()
 
-  print(f"Reconciling graph {args.graph_id} for {args.period_start}..{args.period_end}")
+  # Fall back to the orchestrator's saved graph slot if not passed
+  # explicitly — mirrors how ``just demo-roboledger`` reads from
+  # ``.local/config.json`` without requiring the caller to remember
+  # the graph id.
+  graph_id = args.graph_id or _read_graph_id_from_credentials()
+  if not graph_id:
+    raise SystemExit(
+      "No graph_id provided and no ``seattle_method_test`` slot found "
+      "in ``.local/config.json``. Run ``just demo-seattle-method`` first "
+      "(to provision a graph + save the slot), then re-run reconcile."
+    )
+
+  print(f"Reconciling graph {graph_id} for {args.period_start}..{args.period_end}")
 
   client = _get_ledger_client()
 
@@ -711,18 +792,18 @@ def main() -> None:
   # the engine into ``build_envelope`` so the IB envelope returns
   # populated facts and this script becomes pure-API.
   concepts = _load_concept_totals_via_graphql(
-    client, args.graph_id, args.period_start, args.period_end
+    client, graph_id, args.period_start, args.period_end
   )
   print(f"  Loaded {len(concepts)} concept(s) with period activity (via GraphQL trialBalance)")
   bs_label_by_qname = {c.qname: c.label for c in concepts}
 
-  rollforwards = _load_rollforward_ibs_via_graphql(client, args.graph_id)
+  rollforwards = _load_rollforward_ibs_via_graphql(client, graph_id)
   print(
     f"  Loaded {len(rollforwards)} rollforward IB(s) (via GraphQL informationBlocks)"
   )
 
   # Filter engine still runs against a direct session — Phase 2 MVP.
-  session = _open_session(args.graph_id)
+  session = _open_session(graph_id)
   try:
     results = _evaluate_all_rollforwards(
       session, rollforwards, args.period_start, args.period_end, bs_label_by_qname
@@ -736,7 +817,7 @@ def main() -> None:
     session.close()
 
   report = ReconciliationReport(
-    graph_id=args.graph_id,
+    graph_id=graph_id,
     period_start=args.period_start,
     period_end=args.period_end,
     concept_totals=concepts,
@@ -746,15 +827,15 @@ def main() -> None:
   if not args.no_diff and args.expected_facts.exists():
     expected = _load_expected_facts(args.expected_facts)
     print(f"\nLoaded {len(expected)} expected fact(s) from {args.expected_facts.name}")
-    # Charlie's BS facts use "12/31/24" (period-end) and IS/CF flows
-    # use "2024-01-01 | 2024-12-31" (full-year duration). Match
-    # our instant concepts to the first, duration concepts to the
-    # second.
+    # Match our instant concepts to Charlie's instant-period label;
+    # duration concepts to his duration-period label. Defaults match
+    # Charlie's mini CSV export for Test Case 1; CLI override the
+    # labels for other test cases.
     report.diff_lines = _build_diff(
       ours=concepts,
       expected=expected,
-      period_label_for_instants="12/31/24",
-      period_label_for_durations="2024-01-01 | 2024-12-31",
+      period_label_for_instants=args.diff_label_instant,
+      period_label_for_durations=args.diff_label_duration,
     )
     # Also compare our computed anchor totals to Charlie's published
     # aggregates. These are concepts Charlie publishes as facts but
@@ -762,10 +843,14 @@ def main() -> None:
     totals = _anchor_totals(concepts)
     expected_by_key = {(f.concept, f.period_label): f.value_cents for f in expected}
     anchor_pairs = [
-      ("mini:Assets", "12/31/24", totals["Total Assets"]),
-      ("mini:LiabilitiesAndEquity", "12/31/24", totals["Total Liabilities & Equity"]),
-      ("mini:NetIncomeLoss", "2024-01-01 | 2024-12-31", totals["Net Income"]),
-      ("mini:NetCashFlow", "2024-01-01 | 2024-12-31", totals["Net Cash Change"]),
+      ("mini:Assets", args.diff_label_instant, totals["Total Assets"]),
+      (
+        "mini:LiabilitiesAndEquity",
+        args.diff_label_instant,
+        totals["Total Liabilities & Equity"],
+      ),
+      ("mini:NetIncomeLoss", args.diff_label_duration, totals["Net Income"]),
+      ("mini:NetCashFlow", args.diff_label_duration, totals["Net Cash Change"]),
     ]
     for concept, period_label, our_value in anchor_pairs:
       key = (concept, period_label)

--- a/examples/seattle_method_demo/reconcile.py
+++ b/examples/seattle_method_demo/reconcile.py
@@ -1,34 +1,34 @@
 #!/usr/bin/env python3
 """Reconciliation harness — Step 7 of the Seattle Method demo.
 
-Reads the rollforward IBs + ledger LineItems on the test graph,
-invokes the Phase 2 MVP filter engine for each rollforward to
-produce attributed facts, computes the four anchor totals (Total
-Assets, Total Liabilities & Equity, Net Income, Net Cash Change),
-and emits a markdown report to ``local/reports/seattle-method-case-1.md``.
+Reads concept totals + rollforward IBs via the **GraphQL facade**
+(`LedgerClient.get_trial_balance`, `LedgerClient.list_information_blocks`),
+parses the rollforward IB's typed mechanics, invokes the Phase 2
+MVP filter engine for each rollforward against a direct DB session,
+computes the four anchor totals (Total Assets, Total Liabilities &
+Equity, Net Income, Net Cash Change), and writes a markdown report
+to ``examples/seattle_method_demo/output/seattle-method-case-1.md``.
 
-The report follows the methodology-spec §3 structure:
+**Architecture note** — this is hand-written GraphQL consumption.
+Forward work in [`python-client-graphql.md`](../../local/docs/specs/python-client-graphql.md)
+replaces the hand-written Python GraphQL query strings + ``dict[str, Any]``
+returns with codegen-generated Pydantic models via ``ariadne-codegen``.
+The trigger condition the spec calls out ("a new GraphQL surface that
+the Python client genuinely needs to consume — e.g. rollforward
+RollforwardMechanics") has now fired. Phase 1 of that work
+(~1 day) replaces every ``client.list_information_blocks(...)
+→ dict`` hop here with a typed Pydantic response.
 
-1. **Test inputs** — graph id, period, pipeline metadata
-2. **Pipeline summary** — counts (concepts loaded, mappings seeded,
-   events ingested, rollforward IBs authored)
-3. **BS / IS / CF / SE totals** — our computed numbers per statement
-4. **Rollforward attribution details** — per BS leaf, the flow
-   decomposition the filter engine produced, with ``event_ids``
-   provenance
-5. **Findings classification** — matching / methodology gap / our
-   bug / their data quality, with line-cited rationale
-
-Connects to the extensions DB directly (host-side) rather than
-going through the API — the filter engine wants a SQLAlchemy
-``Session``, and computing BS positions / IS totals is straight SQL
-over ``line_items`` / ``entries``. This mirrors how a real
-reconciliation harness would run in a Dagster job or scheduled
-analytic — not a customer-facing API call.
+The filter engine itself still runs against a direct SQLAlchemy
+session — that's the Phase 2 MVP boundary documented in
+[`information-block.md`](../../local/docs/specs/information-block.md) §4.5.
+Phase 3 wires filter evaluation into ``build_envelope`` so the
+attributed facts arrive populated in the IB envelope; this script
+becomes purely API-driven at that point.
 
 Usage:
     uv run python -m examples.seattle_method_demo.reconcile <graph_id>
-    uv run python -m examples.seattle_method_demo.reconcile <graph_id> --period 2024-01
+    uv run python -m examples.seattle_method_demo.reconcile <graph_id> --no-diff
 """
 
 from __future__ import annotations
@@ -124,6 +124,30 @@ class ReconciliationReport:
 # ── DB queries ───────────────────────────────────────────────────────────
 
 
+def _get_ledger_client():
+  """Construct a LedgerClient from saved credentials.
+
+  Mirrors the helper used across the demo scripts. The GraphQL
+  facade methods (``get_trial_balance``, ``list_information_blocks``)
+  hang off this client.
+  """
+  import json
+
+  from robosystems_client.clients.ledger_client import LedgerClient
+
+  config_path = Path(".local/config.json")
+  if not config_path.exists():
+    raise SystemExit("Missing .local/config.json — run `just demo-user` first.")
+  with config_path.open() as f:
+    cfg = json.load(f)
+  return LedgerClient(
+    {
+      "base_url": cfg.get("base_url", "http://localhost:8000"),
+      "token": cfg["api_key"],
+    }
+  )
+
+
 def _open_session(graph_id: str) -> Session:
   """Open a SQLAlchemy session scoped to the graph's schema.
 
@@ -144,51 +168,84 @@ def _open_session(graph_id: str) -> Session:
   return session
 
 
-def _load_concept_totals(
-  session: Session, period_start: date, period_end: date
+def _load_concept_totals_via_graphql(
+  client, graph_id: str, period_start: date, period_end: date
 ) -> list[ConceptTotal]:
-  """Sum (debit - credit) per mini concept across the period.
+  """Load per-concept period totals via the GraphQL trialBalance query.
 
-  Joins line_items → entries (for posting_date filter + status) →
-  elements (for qname/label/balance_type/period_type/trait). Only
-  posted entries count.
+  Replaces the prior direct-DB query against ``line_items``. The
+  ``trialBalance`` resolver does the same aggregation server-side
+  (Σ DR, Σ CR, net per account) — which means this script consumes
+  the same query surface a frontend or MCP agent would.
+
+  Returns ``ConceptTotal`` shapes scoped to ``mini:`` qnames only;
+  rs-gaap and other taxonomies on the graph are filtered out
+  client-side (the GraphQL query returns every CoA account).
+
+  The trialBalance response shape per row:
+  ``{account_id, account_code (=qname), account_name, trait,
+  account_type, total_debits, total_credits, net_balance}``.
+  Values come back as floats in dollars; we multiply by 100 for
+  internal cents-precision.
+
+  TODO: replace with codegen-generated typed response model when
+  ``python-client-graphql.md`` Phase 1 lands.
   """
-  rows = session.execute(
-    text(
-      """
-      SELECT
-        e.qname,
-        e.name,
-        e.balance_type,
-        e.period_type,
-        COALESCE(SUM(li.debit_amount - li.credit_amount), 0) AS dr_pos_cents
-      FROM line_items li
-      JOIN entries en ON en.id = li.entry_id
-      JOIN elements e ON e.id = li.element_id
-      WHERE en.posting_date BETWEEN :start AND :end
-        AND en.status = 'posted'
-        AND e.qname LIKE 'mini:%'
-      GROUP BY e.qname, e.name, e.balance_type, e.period_type
-      ORDER BY e.qname
-      """
-    ),
-    {"start": period_start, "end": period_end},
-  ).fetchall()
-  return [
-    ConceptTotal(
-      qname=r[0],
-      label=r[1] or r[0],
-      balance_type=r[2],
-      period_type=r[3] or "duration",
-      # Trait isn't a direct column on elements (it lives via
-      # ``classifications`` row joins). For reconciliation we derive
-      # it inline from balance_type + period_type + name — same
-      # logic ``load_taxonomy._derive_trait`` used at load time.
-      trait=_derive_trait_from_concept(r[0], r[2], r[3]),
-      debit_positive_cents=int(r[4]),
+  data = client.get_trial_balance(
+    graph_id,
+    start_date=period_start.isoformat(),
+    end_date=period_end.isoformat(),
+  )
+  rows = (data or {}).get("rows", []) or []
+
+  totals: list[ConceptTotal] = []
+  for r in rows:
+    # ``account_code`` carries the mini qname (set at load time —
+    # see ``load_taxonomy.build_element_payloads``).
+    qname = r.get("account_code") or ""
+    if not qname.startswith("mini:"):
+      continue
+    dollars_dr = float(r.get("total_debits") or 0)
+    dollars_cr = float(r.get("total_credits") or 0)
+    # Filter on "had activity" not "non-zero net" — Charlie's
+    # Receivables has $8K DR + $8K CR netting to $0, but it's
+    # legitimate activity that the diff should compare.
+    if dollars_dr == 0 and dollars_cr == 0:
+      continue
+    debit_positive_cents = int(round((dollars_dr - dollars_cr) * 100))
+    # trialBalance doesn't return period_type or balance_type
+    # directly — they live on the Element row. Derive period_type
+    # from trait (instant for asset/liability/equity, duration for
+    # revenue/expense). For balance_type, infer from trait + sign.
+    trait = r.get("trait")
+    period_type = _period_type_from_trait(trait)
+    balance_type = _balance_type_from_trait(trait)
+    totals.append(
+      ConceptTotal(
+        qname=qname,
+        label=r.get("account_name") or qname,
+        balance_type=balance_type,
+        period_type=period_type,
+        trait=trait,
+        debit_positive_cents=debit_positive_cents,
+      )
     )
-    for r in rows
-  ]
+  totals.sort(key=lambda c: c.qname)
+  return totals
+
+
+def _period_type_from_trait(trait: str | None) -> str:
+  """Instant for BS concepts (asset/liability/equity), duration for IS."""
+  if trait in ("asset", "liability", "equity", "contraAsset", "contraLiability"):
+    return "instant"
+  return "duration"
+
+
+def _balance_type_from_trait(trait: str | None) -> str:
+  """Debit for asset/expense/loss; credit for liability/equity/revenue/income/gain."""
+  if trait in ("asset", "contraLiability", "contraEquity", "expense", "loss"):
+    return "debit"
+  return "credit"
 
 
 def _load_expected_facts(csv_path: Path) -> list[ExpectedFact]:
@@ -313,25 +370,38 @@ def _derive_trait_from_concept(
   return "revenue" if balance_type == "credit" else "expense"
 
 
-def _load_rollforward_ibs(session: Session) -> list[tuple[str, RollforwardMechanics]]:
-  """Return [(structure_id, RollforwardMechanics), …] for every
-  rollforward IB on the graph."""
-  rows = session.execute(
-    text(
-      """
-      SELECT id, name, artifact_mechanics
-      FROM structures
-      WHERE block_type = 'rollforward'
-      ORDER BY name
-      """
-    )
-  ).fetchall()
+def _load_rollforward_ibs_via_graphql(
+  client, graph_id: str
+) -> list[tuple[str, RollforwardMechanics]]:
+  """Return [(structure_id, RollforwardMechanics), …] via GraphQL.
+
+  Uses ``LedgerClient.list_information_blocks(block_type='rollforward')``
+  — the same query the frontend / MCP / any external client would
+  hit. The envelope's ``artifact.mechanics`` field carries the
+  typed ``RollforwardMechanics`` JSON; we re-validate it through
+  Pydantic to recover the typed shape (the hand-written GraphQL
+  parser returns ``dict[str, Any]``, the documented
+  ``python-client-graphql.md`` Phase 1 work replaces that with
+  typed Pydantic on the response).
+
+  Note: the IB envelope's ``facts`` field is empty in Phase 2 MVP
+  (see ``information_block/rollforward.py:build_envelope``). The
+  filter engine still runs separately to produce attributed facts —
+  Phase 3 wires that into the envelope so this script can drop the
+  direct-session step entirely.
+
+  TODO: replace with codegen-generated typed response model when
+  ``python-client-graphql.md`` Phase 1 lands.
+  """
+  blocks = client.list_information_blocks(graph_id, block_type="rollforward")
   out: list[tuple[str, RollforwardMechanics]] = []
-  for r in rows:
-    if not r[2]:
+  for block in blocks or []:
+    artifact = block.get("artifact") or {}
+    raw_mechanics = artifact.get("mechanics")
+    if not raw_mechanics:
       continue
-    mechanics = RollforwardMechanics.model_validate(r[2])
-    out.append((r[0], mechanics))
+    mechanics = RollforwardMechanics.model_validate(raw_mechanics)
+    out.append((block.get("id", ""), mechanics))
   return out
 
 
@@ -633,15 +703,27 @@ def main() -> None:
 
   print(f"Reconciling graph {args.graph_id} for {args.period_start}..{args.period_end}")
 
+  client = _get_ledger_client()
+
+  # Read paths go through GraphQL (the same surface a frontend or
+  # MCP agent would hit). The filter engine is still invoked
+  # against a direct session — Phase 2 MVP boundary; Phase 3 wires
+  # the engine into ``build_envelope`` so the IB envelope returns
+  # populated facts and this script becomes pure-API.
+  concepts = _load_concept_totals_via_graphql(
+    client, args.graph_id, args.period_start, args.period_end
+  )
+  print(f"  Loaded {len(concepts)} concept(s) with period activity (via GraphQL trialBalance)")
+  bs_label_by_qname = {c.qname: c.label for c in concepts}
+
+  rollforwards = _load_rollforward_ibs_via_graphql(client, args.graph_id)
+  print(
+    f"  Loaded {len(rollforwards)} rollforward IB(s) (via GraphQL informationBlocks)"
+  )
+
+  # Filter engine still runs against a direct session — Phase 2 MVP.
   session = _open_session(args.graph_id)
   try:
-    concepts = _load_concept_totals(session, args.period_start, args.period_end)
-    print(f"  Loaded {len(concepts)} concept(s) with period activity")
-    bs_label_by_qname = {c.qname: c.label for c in concepts}
-
-    rollforwards = _load_rollforward_ibs(session)
-    print(f"  Loaded {len(rollforwards)} rollforward IB(s)")
-
     results = _evaluate_all_rollforwards(
       session, rollforwards, args.period_start, args.period_end, bs_label_by_qname
     )

--- a/examples/seattle_method_demo/reconcile.py
+++ b/examples/seattle_method_demo/reconcile.py
@@ -1,0 +1,506 @@
+#!/usr/bin/env python3
+"""Reconciliation harness — Step 7 of the Seattle Method demo.
+
+Reads the rollforward IBs + ledger LineItems on the test graph,
+invokes the Phase 2 MVP filter engine for each rollforward to
+produce attributed facts, computes the four anchor totals (Total
+Assets, Total Liabilities & Equity, Net Income, Net Cash Change),
+and emits a markdown report to ``local/reports/seattle-method-case-1.md``.
+
+The report follows the methodology-spec §3 structure:
+
+1. **Test inputs** — graph id, period, pipeline metadata
+2. **Pipeline summary** — counts (concepts loaded, mappings seeded,
+   events ingested, rollforward IBs authored)
+3. **BS / IS / CF / SE totals** — our computed numbers per statement
+4. **Rollforward attribution details** — per BS leaf, the flow
+   decomposition the filter engine produced, with ``event_ids``
+   provenance
+5. **Findings classification** — matching / methodology gap / our
+   bug / their data quality, with line-cited rationale
+
+Connects to the extensions DB directly (host-side) rather than
+going through the API — the filter engine wants a SQLAlchemy
+``Session``, and computing BS positions / IS totals is straight SQL
+over ``line_items`` / ``entries``. This mirrors how a real
+reconciliation harness would run in a Dagster job or scheduled
+analytic — not a customer-facing API call.
+
+Usage:
+    uv run python -m examples.seattle_method_demo.reconcile <graph_id>
+    uv run python -m examples.seattle_method_demo.reconcile <graph_id> --period 2024-01
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import Session, sessionmaker
+
+from robosystems.models.api.information_block import RollforwardMechanics
+from robosystems.operations.roboledger.reports.rollforward_filters import (
+  AttributedFact,
+  evaluate_attribution_filters,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_REPORT_PATH = REPO_ROOT / "local" / "reports" / "seattle-method-case-1.md"
+EXTENSIONS_DB_URL = "postgresql://postgres:postgres@localhost:5432/extensions"
+SAFE_GRAPH_ID = re.compile(r"^kg[a-zA-Z0-9_]+$")
+
+
+@dataclass
+class ConceptTotal:
+  """Sum of (debit - credit) on one concept across a period."""
+
+  qname: str
+  label: str
+  balance_type: str  # 'debit' | 'credit'
+  period_type: str  # 'instant' | 'duration'
+  trait: str | None
+  debit_positive_cents: int
+
+
+@dataclass
+class RollforwardResult:
+  """One rollforward IB's filter engine output for a period."""
+
+  bs_qname: str
+  bs_label: str
+  delta_cents: int  # ΔBS over the period (debit-positive)
+  attributed: list[AttributedFact]
+  residual_cents: int
+
+
+@dataclass
+class ReconciliationReport:
+  graph_id: str
+  period_start: date
+  period_end: date
+  concept_totals: list[ConceptTotal]
+  rollforward_results: list[RollforwardResult]
+
+
+# ── DB queries ───────────────────────────────────────────────────────────
+
+
+def _open_session(graph_id: str) -> Session:
+  """Open a SQLAlchemy session scoped to the graph's schema.
+
+  ``search_path`` is set so all subsequent queries against
+  ``elements`` / ``line_items`` / ``entries`` / ``structures`` land
+  in the right tenant schema. graph_id is validated against a strict
+  regex before interpolation (SET search_path doesn't accept bind
+  parameters).
+  """
+  if not SAFE_GRAPH_ID.match(graph_id):
+    raise SystemExit(
+      f"Refusing to use graph_id {graph_id!r} — must match {SAFE_GRAPH_ID.pattern}"
+    )
+  engine = create_engine(EXTENSIONS_DB_URL)
+  session_factory = sessionmaker(bind=engine)
+  session = session_factory()
+  session.execute(text(f"SET search_path TO {graph_id}, public"))
+  return session
+
+
+def _load_concept_totals(
+  session: Session, period_start: date, period_end: date
+) -> list[ConceptTotal]:
+  """Sum (debit - credit) per mini concept across the period.
+
+  Joins line_items → entries (for posting_date filter + status) →
+  elements (for qname/label/balance_type/period_type/trait). Only
+  posted entries count.
+  """
+  rows = session.execute(
+    text(
+      """
+      SELECT
+        e.qname,
+        e.name,
+        e.balance_type,
+        e.period_type,
+        COALESCE(SUM(li.debit_amount - li.credit_amount), 0) AS dr_pos_cents
+      FROM line_items li
+      JOIN entries en ON en.id = li.entry_id
+      JOIN elements e ON e.id = li.element_id
+      WHERE en.posting_date BETWEEN :start AND :end
+        AND en.status = 'posted'
+        AND e.qname LIKE 'mini:%'
+      GROUP BY e.qname, e.name, e.balance_type, e.period_type
+      ORDER BY e.qname
+      """
+    ),
+    {"start": period_start, "end": period_end},
+  ).fetchall()
+  return [
+    ConceptTotal(
+      qname=r[0],
+      label=r[1] or r[0],
+      balance_type=r[2],
+      period_type=r[3] or "duration",
+      # Trait isn't a direct column on elements (it lives via
+      # ``classifications`` row joins). For reconciliation we derive
+      # it inline from balance_type + period_type + name — same
+      # logic ``load_taxonomy._derive_trait`` used at load time.
+      trait=_derive_trait_from_concept(r[0], r[2], r[3]),
+      debit_positive_cents=int(r[4]),
+    )
+    for r in rows
+  ]
+
+
+def _derive_trait_from_concept(
+  qname: str, balance_type: str | None, period_type: str | None
+) -> str | None:
+  """Mirror ``load_taxonomy._derive_trait`` — instant+debit → asset;
+  instant+credit → liability (or equity by name match);
+  duration+debit → expense; duration+credit → revenue."""
+  if not balance_type or not period_type:
+    return None
+  if period_type == "instant":
+    name_lower = qname.lower()
+    equity_markers = (
+      "paidincapital",
+      "retainedearnings",
+      "commonstock",
+      "preferredstock",
+      "treasurystock",
+    )
+    if any(m in name_lower for m in equity_markers):
+      return "equity"
+    return "asset" if balance_type == "debit" else "liability"
+  return "revenue" if balance_type == "credit" else "expense"
+
+
+def _load_rollforward_ibs(session: Session) -> list[tuple[str, RollforwardMechanics]]:
+  """Return [(structure_id, RollforwardMechanics), …] for every
+  rollforward IB on the graph."""
+  rows = session.execute(
+    text(
+      """
+      SELECT id, name, artifact_mechanics
+      FROM structures
+      WHERE block_type = 'rollforward'
+      ORDER BY name
+      """
+    )
+  ).fetchall()
+  out: list[tuple[str, RollforwardMechanics]] = []
+  for r in rows:
+    if not r[2]:
+      continue
+    mechanics = RollforwardMechanics.model_validate(r[2])
+    out.append((r[0], mechanics))
+  return out
+
+
+def _evaluate_all_rollforwards(
+  session: Session,
+  rollforwards: list[tuple[str, RollforwardMechanics]],
+  period_start: date,
+  period_end: date,
+  bs_label_by_qname: dict[str, str],
+) -> list[RollforwardResult]:
+  """Run the filter engine for every rollforward IB; collect results."""
+  results: list[RollforwardResult] = []
+  for _structure_id, mech in rollforwards:
+    facts = evaluate_attribution_filters(session, mech, period_start, period_end)
+    # Compute the BS delta from the facts (matching + residual sum =
+    # ΔBS by construction in residual_as_default mode).
+    delta = sum(f.value_cents for f in facts)
+    residual = sum(f.value_cents for f in facts if f.is_residual)
+    results.append(
+      RollforwardResult(
+        bs_qname=mech.bs_source_qname,
+        bs_label=bs_label_by_qname.get(mech.bs_source_qname, mech.bs_source_qname),
+        delta_cents=delta,
+        attributed=[f for f in facts if not f.is_residual],
+        residual_cents=residual,
+      )
+    )
+  return results
+
+
+# ── Anchor totals ────────────────────────────────────────────────────────
+
+
+def _anchor_totals(concepts: list[ConceptTotal]) -> dict[str, int]:
+  """Compute the four anchor totals from concept-level period sums.
+
+  - **Total Assets** = sum of debit-positive instant + asset concepts
+    (period activity, not ending balance — for Q1 2024 with no
+    opening balances this equals ending positions).
+  - **Total Liabilities & Equity** = sum of credit-positive instant
+    liability/equity concepts **plus implicit Retained Earnings**.
+    The accounting equation requires ``Assets = Liabilities +
+    Equity``, where Equity = PaidInCapital + RetainedEarnings, and
+    RetainedEarnings = opening RE + Net Income − Dividends. Charlie's
+    lemonade-stand fixture starts from zero balances and posts no
+    closing entry to RE during the period, so RE-ending = Net Income.
+    We add Net Income to L&E to close the accounting equation
+    (otherwise L&E < Assets by exactly the period's net income).
+  - **Net Income** = revenues less expenses (duration concepts).
+  - **Net Cash Change** = delta on ``mini:CashAndCashEquivalents``.
+
+  All in debit-positive cents internally; sign-flipped for
+  presentation where convention requires it.
+  """
+  totals = {
+    "Total Assets": 0,
+    "Total Liabilities & Equity": 0,
+    "Net Income": 0,
+    "Net Cash Change": 0,
+  }
+
+  for c in concepts:
+    if c.trait == "asset" and c.period_type == "instant":
+      totals["Total Assets"] += c.debit_positive_cents
+    elif c.trait in ("liability", "equity") and c.period_type == "instant":
+      # Credit-balance — flip sign so the total is presented as
+      # positive when liabilities/equity grew over the period.
+      totals["Total Liabilities & Equity"] += -c.debit_positive_cents
+    elif c.period_type == "duration":
+      if c.trait == "revenue":
+        # Revenues are credit-balance; positive net = inflow.
+        totals["Net Income"] += -c.debit_positive_cents
+      elif c.trait == "expense":
+        # Expenses reduce income.
+        totals["Net Income"] += -c.debit_positive_cents
+
+    if c.qname == "mini:CashAndCashEquivalents":
+      totals["Net Cash Change"] = c.debit_positive_cents
+
+  # Implicit Retained Earnings: Net Income flows into RE at period-end.
+  # Without it, the accounting equation doesn't close for a startup's
+  # first-period reconciliation (no opening RE to inherit).
+  totals["Total Liabilities & Equity"] += totals["Net Income"]
+
+  return totals
+
+
+# ── Markdown rendering ──────────────────────────────────────────────────
+
+
+def _fmt_cents(cents: int) -> str:
+  """Format integer cents as ``$X,XXX.XX`` (negative → parentheses)."""
+  dollars = cents / 100.0
+  if dollars < 0:
+    return f"$({abs(dollars):,.2f})"
+  return f"${dollars:,.2f}"
+
+
+def render_markdown(report: ReconciliationReport) -> str:
+  """Build the markdown reconciliation report."""
+  out: list[str] = []
+  out.append("# Seattle Method Cross-Taxonomy — Test Case 1 Reconciliation")
+  out.append("")
+  out.append(f"**Graph**: `{report.graph_id}`")
+  out.append(f"**Period**: {report.period_start} → {report.period_end}")
+  out.append(f"**Dataset**: Charlie Hoffman's lemonade-stand 14-JE Q1 2024 fixture")
+  out.append(f"**Expected output reference**: "
+             "[luca.pacioli.ai/luca/view/0f24fd35…](https://luca.pacioli.ai/luca/view/0f24fd35e961e167a727b663c75a4c5ec9fb7eb86730d6292f46e6e180fc2018980cd52e/index)")
+  out.append("")
+  out.append("---")
+  out.append("")
+
+  # Anchor totals
+  out.append("## Four Anchor Totals")
+  out.append("")
+  out.append("Methodology spec §4.6 exit criterion: these four lines must "
+             "match Charlie's PoC for the test to pass. All amounts are "
+             "debit-positive cents internally; presentation flips signs "
+             "per accounting convention.")
+  out.append("")
+  totals = _anchor_totals(report.concept_totals)
+  out.append("| Anchor | Our value |")
+  out.append("|---|---:|")
+  for label, cents in totals.items():
+    out.append(f"| {label} | {_fmt_cents(cents)} |")
+  out.append("")
+
+  # Concept-level period totals
+  out.append("## Concept-Level Period Totals")
+  out.append("")
+  out.append("Every mini concept with non-zero activity in the period. "
+             "``Δ debit-positive`` is the period flow (Σ DR − Σ CR). For "
+             "instant/asset concepts this equals the period-ending "
+             "balance (Charlie's data starts from zero). For duration "
+             "concepts this is the period income/expense.")
+  out.append("")
+  out.append("| QName | Label | Trait | Period | Δ debit-positive |")
+  out.append("|---|---|---|---|---:|")
+  for c in report.concept_totals:
+    if c.debit_positive_cents == 0:
+      continue
+    out.append(
+      f"| `{c.qname}` | {c.label} | {c.trait or '—'} | "
+      f"{c.period_type} | {_fmt_cents(c.debit_positive_cents)} |"
+    )
+  out.append("")
+
+  # Rollforward attribution detail
+  out.append("## Rollforward Attribution (Phase 2 MVP Filter Engine)")
+  out.append("")
+  out.append("Each rollforward IB decomposes its BS source's period "
+             "delta across declared TDC filters. Where ``Σ filters == "
+             "Δ BS``, the rollforward is balanced (residual = 0). A "
+             "non-zero residual indicates either an unattributed flow "
+             "or a phantom TDC in the source data (logged at author time).")
+  out.append("")
+  for rf in report.rollforward_results:
+    out.append(f"### {rf.bs_label} ({rf.bs_qname})")
+    out.append("")
+    out.append(f"**Δ BS** (debit-positive): {_fmt_cents(rf.delta_cents)}")
+    if rf.residual_cents:
+      out.append(f"**Residual**: {_fmt_cents(rf.residual_cents)}")
+    out.append("")
+    if not rf.attributed:
+      out.append("_No attributed facts (no matching activity in period)._")
+      out.append("")
+      continue
+    out.append("| Flow concept | Value | Matched lines | Event ids |")
+    out.append("|---|---:|---:|---|")
+    for f in rf.attributed:
+      events = ", ".join(f.event_ids[:3])
+      if len(f.event_ids) > 3:
+        events += f", … (+{len(f.event_ids) - 3})"
+      out.append(
+        f"| `{f.target_qname}` | {_fmt_cents(f.value_cents)} | "
+        f"{f.matched_line_count} | {events or '—'} |"
+      )
+    out.append("")
+
+  # Findings
+  out.append("## Findings — Classification per Methodology §3.2")
+  out.append("")
+  out.append("**Their data quality** (source CSV inconsistencies):")
+  out.append("")
+  out.append("- **JE-205** — Description \"Payment for contractor\" but "
+             "TDC on the AP line is `mini:PurchasesInventoryForSaleOnAccount`. "
+             "Contractor services aren't inventory; vocabulary misuse.")
+  out.append("- **JE-209** — TDC `mini:PaymentOfInterest` was a typo for "
+             "`mini:PaymentInterest` (the canonical mini.xsd concept name). "
+             "Fixed at source in `fixtures/transactions.csv` prior to "
+             "ingest. Note that `mini:DecreaseFromPaymentOfInterest` (the "
+             "AccruedExpenses-side TDC) keeps the \"Of\" — Charlie's "
+             "naming is internally inconsistent.")
+  out.append("- **JE-226** — Income tax accrual ($400) but TDC is "
+             "`mini:InterestAccrued` instead of `IncomeTaxAccrued`. "
+             "Copy-paste-style bug from the JE-210 interest pattern.")
+  out.append("")
+  out.append("**Methodology gap** (architecturally aligned, semantically distinct):")
+  out.append("")
+  out.append("- **JE-225** — \"Write off of PPE\" with `Amount = 0` on "
+             "both lines. Boundary test case. Our GL handler rejects "
+             "nil-amount entries (`must have non-zero D or C`); Charlie's "
+             "system likely creates `$0` facts. Reconciliation delta is "
+             "`$0` either way; the four anchor totals are unaffected.")
+  out.append("- **rs-gaap library subset** — Two flow concepts in "
+             "`mappings.py` don't exist in our currently-loaded rs-gaap "
+             "library: `rs-gaap:InterestPaidNet` (mapped through to the "
+             "closest available `rs-gaap:InterestExpense`) and "
+             "`rs-gaap:StockIssuedDuringPeriodValueNewIssues` (mapped "
+             "through to `rs-gaap:ProceedsFromIssuanceOfCommonStock`). "
+             "Approximation; future library expansion closes the gap.")
+  out.append("")
+  out.append("**Our bug**: none identified.")
+  out.append("")
+  out.append("**Matching**: see Anchor Totals table above + line-by-line "
+             "concept totals. Compare manually against Charlie's PoC "
+             "rendering at the expected-output URL — automated HTML diff "
+             "is a forward-queue enhancement (methodology §3.1 step 5 "
+             "stretch goal).")
+  out.append("")
+
+  # Footer
+  out.append("---")
+  out.append("")
+  out.append("*Reconciliation produced by "
+             "`examples/seattle_method_demo/reconcile.py` against the "
+             "Phase 2 MVP rollforward filter engine. See "
+             "`examples/seattle_method_demo/README.md` for the full "
+             "methodology and `local/docs/specs/cross-taxonomy-projection.md` "
+             "for the architectural pattern this test validates.*")
+
+  return "\n".join(out) + "\n"
+
+
+# ── Main ─────────────────────────────────────────────────────────────────
+
+
+def main() -> None:
+  parser = argparse.ArgumentParser(
+    description="Reconcile the Seattle Method Test Case 1 demo against "
+    "Charlie Hoffman's expected output. Produces a markdown report.",
+  )
+  parser.add_argument("graph_id", help="The seattle_method_test graph id.")
+  parser.add_argument(
+    "--period-start",
+    type=date.fromisoformat,
+    default=date(2024, 1, 1),
+    help="Period start (default 2024-01-01).",
+  )
+  parser.add_argument(
+    "--period-end",
+    type=date.fromisoformat,
+    default=date(2024, 1, 31),
+    help="Period end (default 2024-01-31).",
+  )
+  parser.add_argument(
+    "--out",
+    type=Path,
+    default=DEFAULT_REPORT_PATH,
+    help="Output markdown report path.",
+  )
+  args = parser.parse_args()
+
+  print(f"Reconciling graph {args.graph_id} for {args.period_start}..{args.period_end}")
+
+  session = _open_session(args.graph_id)
+  try:
+    concepts = _load_concept_totals(session, args.period_start, args.period_end)
+    print(f"  Loaded {len(concepts)} concept(s) with period activity")
+    bs_label_by_qname = {c.qname: c.label for c in concepts}
+
+    rollforwards = _load_rollforward_ibs(session)
+    print(f"  Loaded {len(rollforwards)} rollforward IB(s)")
+
+    results = _evaluate_all_rollforwards(
+      session, rollforwards, args.period_start, args.period_end, bs_label_by_qname
+    )
+    for r in results:
+      print(
+        f"    {r.bs_qname:<40} Δ={_fmt_cents(r.delta_cents)} "
+        f"attributed={len(r.attributed)} residual={_fmt_cents(r.residual_cents)}"
+      )
+  finally:
+    session.close()
+
+  report = ReconciliationReport(
+    graph_id=args.graph_id,
+    period_start=args.period_start,
+    period_end=args.period_end,
+    concept_totals=concepts,
+    rollforward_results=results,
+  )
+
+  args.out.parent.mkdir(parents=True, exist_ok=True)
+  args.out.write_text(render_markdown(report))
+  print(f"\n✓ Report written → {args.out}")
+
+  totals = _anchor_totals(concepts)
+  print("\nFour anchor totals:")
+  for label, cents in totals.items():
+    print(f"  {label:<30} {_fmt_cents(cents)}")
+
+
+if __name__ == "__main__":
+  main()

--- a/examples/seattle_method_demo/reconcile.py
+++ b/examples/seattle_method_demo/reconcile.py
@@ -34,9 +34,10 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import csv
 import re
 from collections import defaultdict
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import date
 from pathlib import Path
 
@@ -50,7 +51,9 @@ from robosystems.operations.roboledger.reports.rollforward_filters import (
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-DEFAULT_REPORT_PATH = REPO_ROOT / "local" / "reports" / "seattle-method-case-1.md"
+DEMO_ROOT = REPO_ROOT / "examples" / "seattle_method_demo"
+DEFAULT_REPORT_PATH = DEMO_ROOT / "output" / "seattle-method-case-1.md"
+EXPECTED_FACTS_PATH = DEMO_ROOT / "fixtures" / "expected_facts_mini.csv"
 EXTENSIONS_DB_URL = "postgresql://postgres:postgres@localhost:5432/extensions"
 SAFE_GRAPH_ID = re.compile(r"^kg[a-zA-Z0-9_]+$")
 
@@ -79,12 +82,43 @@ class RollforwardResult:
 
 
 @dataclass
+class ExpectedFact:
+  """One concept value from Charlie's published luca.pacioli.ai export."""
+
+  concept: str  # e.g. "mini:CashAndCashEquivalents"
+  period_label: str  # raw "12/31/24" or "2024-01-01 | 2024-12-31"
+  value_cents: int  # dollars from CSV × 100
+  fact_id: str
+
+
+@dataclass
+class ReconciliationLine:
+  """One line of the automated diff against Charlie's published facts."""
+
+  concept: str
+  our_cents: int
+  expected_cents: int
+
+  @property
+  def delta_cents(self) -> int:
+    return self.our_cents - self.expected_cents
+
+  @property
+  def status(self) -> str:
+    if self.delta_cents == 0:
+      return "match"
+    return "delta"
+
+
+@dataclass
 class ReconciliationReport:
   graph_id: str
   period_start: date
   period_end: date
   concept_totals: list[ConceptTotal]
   rollforward_results: list[RollforwardResult]
+  diff_lines: list[ReconciliationLine] = field(default_factory=list)
+  diff_summary: dict[str, int] = field(default_factory=dict)
 
 
 # ── DB queries ───────────────────────────────────────────────────────────
@@ -155,6 +189,105 @@ def _load_concept_totals(
     )
     for r in rows
   ]
+
+
+def _load_expected_facts(csv_path: Path) -> list[ExpectedFact]:
+  """Parse Charlie's luca.pacioli.ai export → list of ExpectedFact.
+
+  The CSV ships with a UTF-8 BOM and uses pipe-separated multi-value
+  columns for the entity identifier and the calendar period aspect.
+  We only care about ``Concept``, ``FactValue``, ``CalendarPeriodAspect``,
+  and ``FactID`` — the rest is irrelevant for the anchor-total diff.
+
+  Values come in whole dollars in the export (rounding=INF means
+  no decimal places); we multiply by 100 for cents-internal storage
+  so comparison against our LineItem.amount_cents (already in cents)
+  is direct.
+  """
+  out: list[ExpectedFact] = []
+  with csv_path.open(encoding="utf-8-sig") as f:
+    reader = csv.DictReader(f)
+    for row in reader:
+      raw_value = (row.get("FactValue") or "").strip()
+      if not raw_value:
+        continue
+      try:
+        dollars = float(raw_value)
+      except ValueError:
+        # Non-numeric facts (text blocks, etc.) — skip for diff.
+        continue
+      out.append(
+        ExpectedFact(
+          concept=row["Concept"],
+          period_label=row["CalendarPeriodAspect"],
+          value_cents=int(round(dollars * 100)),
+          fact_id=row["FactID"],
+        )
+      )
+  return out
+
+
+def _build_diff(
+  ours: list[ConceptTotal],
+  expected: list[ExpectedFact],
+  period_label_for_instants: str,
+  period_label_for_durations: str,
+) -> list[ReconciliationLine]:
+  """Diff our concept totals against Charlie's expected facts.
+
+  Charlie publishes both instant (e.g. ``12/31/24`` BS positions)
+  and duration (e.g. ``2024-01-01 | 2024-12-31`` IS / CF flows)
+  facts. We pick the matching period label per concept based on
+  ``period_type`` so we compare apples-to-apples.
+
+  Our debit-positive convention means we need to sign-flip credit-
+  balance instant concepts (liabilities, equity) and credit-balance
+  duration concepts (revenues) to match Charlie's presentation
+  values, which are always positive when the concept is naturally
+  growing.
+  """
+  expected_by_concept_period: dict[tuple[str, str], int] = {}
+  for f in expected:
+    expected_by_concept_period.setdefault((f.concept, f.period_label), f.value_cents)
+
+  diff_lines: list[ReconciliationLine] = []
+  for c in ours:
+    period_label = (
+      period_label_for_instants
+      if c.period_type == "instant"
+      else period_label_for_durations
+    )
+    key = (c.qname, period_label)
+    if key not in expected_by_concept_period:
+      continue
+
+    # Sign convention: Charlie's published values are
+    # presentation-positive (assets positive when grown, liabilities
+    # positive when grown). Ours are debit-positive (credit-balance
+    # concepts come in negative). Sign-flip credit-balance concepts
+    # so the diff is meaningful.
+    our_signed = (
+      c.debit_positive_cents
+      if c.balance_type == "debit"
+      else -c.debit_positive_cents
+    )
+    diff_lines.append(
+      ReconciliationLine(
+        concept=c.qname,
+        our_cents=our_signed,
+        expected_cents=expected_by_concept_period[key],
+      )
+    )
+  return diff_lines
+
+
+def _summarize_diff(lines: list[ReconciliationLine]) -> dict[str, int]:
+  return {
+    "lines_compared": len(lines),
+    "exact_match": sum(1 for ln in lines if ln.status == "match"),
+    "delta": sum(1 for ln in lines if ln.status == "delta"),
+    "total_abs_delta_cents": sum(abs(ln.delta_cents) for ln in lines),
+  }
 
 
 def _derive_trait_from_concept(
@@ -311,6 +444,31 @@ def render_markdown(report: ReconciliationReport) -> str:
   out.append("---")
   out.append("")
 
+  # Auto-diff against Charlie's published facts
+  if report.diff_lines:
+    summary = report.diff_summary
+    out.append("## Automated Diff vs. Charlie's Published Facts")
+    out.append("")
+    out.append(
+      f"Compared **{summary['lines_compared']}** concept(s) against "
+      f"Charlie's luca.pacioli.ai export "
+      f"(`fixtures/expected_facts_mini.csv`). "
+      f"**{summary['exact_match']} exact match** • "
+      f"**{summary['delta']} delta**. "
+      f"Total absolute delta: **{_fmt_cents(summary['total_abs_delta_cents'])}**."
+    )
+    out.append("")
+    out.append("| Concept | Our value | Charlie's value | Δ | |")
+    out.append("|---|---:|---:|---:|---|")
+    for ln in report.diff_lines:
+      mark = "✓" if ln.status == "match" else "⚠️"
+      out.append(
+        f"| `{ln.concept}` | {_fmt_cents(ln.our_cents)} | "
+        f"{_fmt_cents(ln.expected_cents)} | "
+        f"{_fmt_cents(ln.delta_cents)} | {mark} |"
+      )
+    out.append("")
+
   # Anchor totals
   out.append("## Four Anchor Totals")
   out.append("")
@@ -460,6 +618,17 @@ def main() -> None:
     default=DEFAULT_REPORT_PATH,
     help="Output markdown report path.",
   )
+  parser.add_argument(
+    "--expected-facts",
+    type=Path,
+    default=EXPECTED_FACTS_PATH,
+    help="Charlie's luca.pacioli.ai mini facts export (CSV). Skip with --no-diff.",
+  )
+  parser.add_argument(
+    "--no-diff",
+    action="store_true",
+    help="Skip the automated diff against Charlie's expected facts.",
+  )
   args = parser.parse_args()
 
   print(f"Reconciling graph {args.graph_id} for {args.period_start}..{args.period_end}")
@@ -491,6 +660,52 @@ def main() -> None:
     concept_totals=concepts,
     rollforward_results=results,
   )
+
+  if not args.no_diff and args.expected_facts.exists():
+    expected = _load_expected_facts(args.expected_facts)
+    print(f"\nLoaded {len(expected)} expected fact(s) from {args.expected_facts.name}")
+    # Charlie's BS facts use "12/31/24" (period-end) and IS/CF flows
+    # use "2024-01-01 | 2024-12-31" (full-year duration). Match
+    # our instant concepts to the first, duration concepts to the
+    # second.
+    report.diff_lines = _build_diff(
+      ours=concepts,
+      expected=expected,
+      period_label_for_instants="12/31/24",
+      period_label_for_durations="2024-01-01 | 2024-12-31",
+    )
+    # Also compare our computed anchor totals to Charlie's published
+    # aggregates. These are concepts Charlie publishes as facts but
+    # our pipeline computes as scalars (no direct LineItem activity).
+    totals = _anchor_totals(concepts)
+    expected_by_key = {(f.concept, f.period_label): f.value_cents for f in expected}
+    anchor_pairs = [
+      ("mini:Assets", "12/31/24", totals["Total Assets"]),
+      ("mini:LiabilitiesAndEquity", "12/31/24", totals["Total Liabilities & Equity"]),
+      ("mini:NetIncomeLoss", "2024-01-01 | 2024-12-31", totals["Net Income"]),
+      ("mini:NetCashFlow", "2024-01-01 | 2024-12-31", totals["Net Cash Change"]),
+    ]
+    for concept, period_label, our_value in anchor_pairs:
+      key = (concept, period_label)
+      if key in expected_by_key:
+        report.diff_lines.append(
+          ReconciliationLine(
+            concept=concept,
+            our_cents=our_value,
+            expected_cents=expected_by_key[key],
+          )
+        )
+    report.diff_summary = _summarize_diff(report.diff_lines)
+    print(
+      f"  Diff: {report.diff_summary['exact_match']}/"
+      f"{report.diff_summary['lines_compared']} exact match • "
+      f"{report.diff_summary['delta']} delta • "
+      f"|Δ|={_fmt_cents(report.diff_summary['total_abs_delta_cents'])}"
+    )
+  elif args.no_diff:
+    print("\nSkipping diff (--no-diff)")
+  else:
+    print(f"\nExpected facts CSV not found at {args.expected_facts}; skipping diff")
 
   args.out.parent.mkdir(parents=True, exist_ok=True)
   args.out.write_text(render_markdown(report))

--- a/examples/seattle_method_demo/seed_mappings.py
+++ b/examples/seattle_method_demo/seed_mappings.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Seed mini → rs-gaap mapping associations on a graph.
+
+Walks the curated mapping table in ``mappings.py`` and posts one
+``create_mapping_association`` per pair. Mirrors the shape of
+``examples.roboledger_demo.main.create_mappings`` — the difference is
+only the source vocabulary (mini concepts vs. native CoA codes).
+
+Pre-condition: ``load_taxonomy.py`` has already run against this graph
+(creates the mini CoA + the empty ``mini to rs-gaap Mapping``
+structure). rs-gaap is assumed available as a library taxonomy on the
+graph.
+
+Usage:
+    uv run python -m examples.seattle_method_demo.seed_mappings <graph_id>
+    uv run python -m examples.seattle_method_demo.seed_mappings <graph_id> --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from .mappings import ALL_MAPPINGS, BS_IS_MAPPINGS, FLOW_MAPPINGS
+
+
+def _get_ledger_client():
+  """Mirrors the helper in load_taxonomy.py / roboledger_demo.main."""
+  from robosystems_client.clients.ledger_client import LedgerClient
+
+  config_path = Path(".local/config.json")
+  if not config_path.exists():
+    raise SystemExit(
+      "Missing .local/config.json — run `just demo-user` first."
+    )
+  with config_path.open() as f:
+    cfg = json.load(f)
+  return LedgerClient(
+    {
+      "base_url": cfg.get("base_url", "http://localhost:8000"),
+      "token": cfg["api_key"],
+    }
+  )
+
+
+def _find_mini_taxonomy_id(client, graph_id: str) -> str | None:
+  """Find the mini CoA taxonomy_id on the graph by name.
+
+  Mini Elements are loaded with ``source='native'`` (the Element
+  source CHECK constraint only admits a fixed enum that doesn't
+  include 'mini'), so we can't filter on ``source='mini'`` to find
+  them. Filter by ``taxonomy_id`` instead — which we look up by
+  name once at the start of the script.
+  """
+  taxonomies = client.list_taxonomies(graph_id) or []
+  for tax in taxonomies:
+    if "mini" in (tax.get("name") or "").lower():
+      return tax.get("id")
+  return None
+
+
+def _build_qname_lookup_by_taxonomy(
+  client, graph_id: str, taxonomy_id: str
+) -> dict[str, str]:
+  """Page through ``list_elements(taxonomy_id=…)`` → {qname: element_id}."""
+  out: dict[str, str] = {}
+  offset = 0
+  page_size = 1000
+  while True:
+    page = client.list_elements(
+      graph_id, taxonomy_id=taxonomy_id, limit=page_size, offset=offset
+    )
+    items = (page or {}).get("elements", [])
+    if not items:
+      break
+    for e in items:
+      if e.get("qname"):
+        out[e["qname"]] = e["id"]
+    if len(items) < page_size:
+      break
+    offset += page_size
+  return out
+
+
+def _build_qname_lookup(
+  client, graph_id: str, source: str
+) -> dict[str, str]:
+  """Page through ``list_elements(source=…)`` → {qname: element_id}.
+
+  Used for rs-gaap (which uses the canonical source filter).
+  """
+  out: dict[str, str] = {}
+  offset = 0
+  page_size = 1000
+  while True:
+    page = client.list_elements(
+      graph_id, source=source, limit=page_size, offset=offset
+    )
+    items = (page or {}).get("elements", [])
+    if not items:
+      break
+    for e in items:
+      if e.get("qname"):
+        out[e["qname"]] = e["id"]
+    if len(items) < page_size:
+      break
+    offset += page_size
+  return out
+
+
+def _find_mapping_structure(client, graph_id: str) -> str:
+  """Return the structure_id of the mini→rs-gaap mapping structure.
+
+  ``load_taxonomy.py`` creates this as ``block_type='coa_mapping'``
+  alongside the CoA elements. We look it up by block_type.
+  """
+  structures = client.list_structures(graph_id, block_type="coa_mapping")
+  if not structures:
+    raise SystemExit(
+      "No coa_mapping structure found on this graph. Did you run "
+      "load_taxonomy.py first?"
+    )
+  # Prefer the one named "mini to rs-gaap Mapping" if multiple exist.
+  for s in structures:
+    if "mini" in (s.get("name") or "").lower():
+      return s["id"]
+  return structures[0]["id"]
+
+
+def seed_mappings(graph_id: str, dry_run: bool = False) -> tuple[int, list[str]]:
+  """Seed every (mini, rs-gaap) pair in ``ALL_MAPPINGS`` as a derivation
+  association on the graph.
+
+  Returns ``(created_count, warnings)``. Warnings collect cases where
+  a mini or rs-gaap qname didn't resolve to an Element — usually means
+  the taxonomy wasn't fully loaded or the qname has a typo in
+  ``mappings.py``.
+  """
+  client = _get_ledger_client()
+
+  print(f"Resolving mini concept ids on graph {graph_id} …")
+  mini_taxonomy_id = _find_mini_taxonomy_id(client, graph_id)
+  if not mini_taxonomy_id:
+    raise SystemExit(
+      "No mini CoA taxonomy found on this graph. Did load_taxonomy.py run?"
+    )
+  mini_lookup = _build_qname_lookup_by_taxonomy(
+    client, graph_id, mini_taxonomy_id
+  )
+  print(f"  {len(mini_lookup)} mini concept(s) found (taxonomy {mini_taxonomy_id})")
+
+  print(f"Resolving rs-gaap concept ids on graph {graph_id} …")
+  rsgaap_lookup = _build_qname_lookup(client, graph_id, source="rs-gaap")
+  print(f"  {len(rsgaap_lookup)} rs-gaap concept(s) found")
+
+  print(f"Mapping table: {len(BS_IS_MAPPINGS)} BS/IS + {len(FLOW_MAPPINGS)} flow")
+  print(f"  Total to seed: {len(ALL_MAPPINGS)}")
+
+  mapping_id = _find_mapping_structure(client, graph_id)
+  print(f"  Mapping structure: {mapping_id}")
+
+  warnings: list[str] = []
+  created = 0
+  for mini_qname, rsgaap_qname in ALL_MAPPINGS:
+    mini_id = mini_lookup.get(mini_qname)
+    rsgaap_id = rsgaap_lookup.get(rsgaap_qname)
+    if not mini_id:
+      warnings.append(f"mini qname not found: {mini_qname}")
+      continue
+    if not rsgaap_id:
+      warnings.append(f"rs-gaap qname not found: {rsgaap_qname}")
+      continue
+    if dry_run:
+      created += 1
+      continue
+    client.create_mapping_association(
+      graph_id,
+      mapping_id=mapping_id,
+      from_element_id=mini_id,
+      to_element_id=rsgaap_id,
+    )
+    created += 1
+
+  return created, warnings
+
+
+def main() -> None:
+  parser = argparse.ArgumentParser(
+    description="Seed mini→rs-gaap mapping associations.",
+  )
+  parser.add_argument("graph_id", help="Target graph id.")
+  parser.add_argument(
+    "--dry-run",
+    action="store_true",
+    help="Resolve lookups + report counts; do not write associations.",
+  )
+  args = parser.parse_args()
+
+  created, warnings = seed_mappings(args.graph_id, dry_run=args.dry_run)
+
+  if warnings:
+    print("\nWarnings:")
+    for w in warnings:
+      print(f"  ⚠️  {w}")
+
+  action = "Would create" if args.dry_run else "Created"
+  print(f"\n{action} {created} mapping association(s).")
+  if warnings:
+    print(f"({len(warnings)} pair(s) skipped — see warnings above.)")
+    sys.exit(1 if not args.dry_run else 0)
+
+
+if __name__ == "__main__":
+  main()

--- a/justfile
+++ b/justfile
@@ -206,6 +206,10 @@ demo-custom-graph *args="":
 demo-seattle-method *args="":
     UV_ENV_FILE={{_local_env}} uv run python -m examples.seattle_method_demo.main {{args}}
 
+# Render the Seattle Method reconciliation report for a graph after the main demo has run
+demo-seattle-method-reconcile *args="":
+    UV_ENV_FILE={{_local_env}} uv run python -m examples.seattle_method_demo.reconcile {{args}}
+
 
 ## CI/CD ##
 

--- a/justfile
+++ b/justfile
@@ -202,6 +202,10 @@ demo-roboledger *args="":
 demo-custom-graph *args="":
     UV_ENV_FILE={{_local_env}} uv run python -m examples.custom_graph_demo.main {{args}}
 
+# Run Seattle Method cross-taxonomy demo (Test Case 1 — Charlie Hoffman's mini, 14 JEs). Flags: --dry-run, --step <name>, --graph <id>
+demo-seattle-method *args="":
+    UV_ENV_FILE={{_local_env}} uv run python -m examples.seattle_method_demo.main {{args}}
+
 
 ## CI/CD ##
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     # RoboSystems client for demo and testing
-    "robosystems-client==0.3.28",
+    "robosystems-client==0.3.30",
 
     # Testing framework
     "pytest>=8.4.0,<9.0",

--- a/uv.lock
+++ b/uv.lock
@@ -3459,7 +3459,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.32.0,<3.0" },
     { name = "retrying", specifier = ">=1.4.0,<2.0" },
     { name = "rich", marker = "extra == 'dev'", specifier = ">=14.0.0,<15.0" },
-    { name = "robosystems-client", marker = "extra == 'dev'", specifier = "==0.3.28" },
+    { name = "robosystems-client", marker = "extra == 'dev'", specifier = "==0.3.30" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0,<1.0" },
     { name = "sqlalchemy", specifier = ">=2.0.0,<3.0" },
     { name = "sse-starlette", specifier = ">=3.3.0,<4.0" },
@@ -3482,7 +3482,7 @@ lambda = [
 
 [[package]]
 name = "robosystems-client"
-version = "0.3.28"
+version = "0.3.30"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -3491,9 +3491,9 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2b/ed/00257c9ed328ff578bd7cfa9dfd1ab2954bd69af2cd7eb8e58c671a49cdc/robosystems_client-0.3.28.tar.gz", hash = "sha256:b0e923e3e3ed12d22158e65daf9ce3481baa4ce5f3263a3acef591beea8f8172", size = 377535, upload-time = "2026-05-17T23:32:20.727Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/9a/ee1223fdf50a7bdf0bd54688fe2a6c15a73e3fbfc62c9f2d8332e2ccbc9d/robosystems_client-0.3.30.tar.gz", hash = "sha256:39688b445a9f98cf3ace523f985af304898f0c6fca578030ef82e7b48bf856e5", size = 389895, upload-time = "2026-05-20T01:58:46.423Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/2f/4dcdec45fedaa81001dc9e9a1de680566fc00c03535a784e407a1928d3d5/robosystems_client-0.3.28-py3-none-any.whl", hash = "sha256:fb777dd822d0ae7bde20e8a1e2d2b7fa1e4e1b398e689666c8dce1cbed3b0114", size = 880033, upload-time = "2026-05-17T23:32:19.037Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/2d/6cb77715477ab3a4d23f39382e68272d20cfa3a68231e5a4963c18047874/robosystems_client-0.3.30-py3-none-any.whl", hash = "sha256:40e8f5430a14d17c91eb8bb9419f44c809c12f73293becaec89ec98c67d3b7b5", size = 908814, upload-time = "2026-05-20T01:58:44.641Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Introduces a comprehensive Seattle Method demonstration example that showcases an end-to-end financial reconciliation workflow — from taxonomy loading and transaction ingestion through to roll-forward authoring and reconciliation report generation. This feature branch also includes a minor dependency bump for the `robosystems-client` SDK.

## Key Accomplishments

### Seattle Method Demo (`examples/seattle_method_demo/`)
- **README & documentation**: Added a detailed README explaining the Seattle Method concept, demo structure, and how to run each step of the pipeline.
- **Taxonomy loading** (`load_taxonomy.py`): Script to bootstrap the required accounting taxonomy into the system.
- **Transaction ingestion** (`ingest_transactions.py`): Parses and ingests sample transaction fixtures into the platform.
- **Mapping definitions** (`mappings.py`, `seed_mappings.py`): Defines and seeds the association mappings between transaction categories and taxonomy line items.
- **Roll-forward authoring** (`author_rollforwards.py`): Generates roll-forward entries using typed SDK models from the updated `robosystems-client` (v0.3.30).
- **Reconciliation** (`reconcile.py`): Refactored to utilize GraphQL for data retrieval, producing a structured reconciliation report comparing ingested facts against expected values.
- **Orchestrator** (`main.py`): Ties all pipeline steps together into a single runnable demo flow.
- **Fixtures**: Includes sample transaction data (`transactions.csv`) and expected facts (`expected_facts_mini.csv`) for a reproducible test case.
- **Report output**: Ships a pre-generated reconciliation report (`seattle-method-case-1.md`) for Test Case 1.
- **Data pull script** (`pull_mini.sh`): Helper script for pulling a minimal dataset to support the demo.

### SDK & Dependencies
- Bumped `robosystems-client` to **0.3.30** to leverage typed SDK models in roll-forward authoring.
- Picked up transitive dependency updates: `strawberry-graphql` 0.315.1 → 0.315.4, `idna` 3.13 → 3.15.

### Build System
- Added convenience task entries in the `justfile` for running the demo pipeline.

## Breaking Changes

None. All changes are additive — new example files and a patch-level SDK bump.

## Testing Notes

- The demo is self-contained under `examples/seattle_method_demo/` with bundled fixture data, making it straightforward to validate end-to-end.
- The pre-generated reconciliation report (`seattle-method-case-1.md`) can serve as a baseline for regression comparison.
- Verify that the `robosystems-client` v0.3.30 typed models are correctly used in `author_rollforwards.py` and that GraphQL-based data retrieval in `reconcile.py` returns expected results against a running backend.

## Infrastructure Considerations

- The demo requires a running backend instance with GraphQL support to execute the full pipeline; ensure the target environment is available before running.
- The updated SDK version should be compatible with existing backend deployments but should be verified against staging before production use.
- New fixture files add ~800 lines of CSV data to the repository; this is intentional for reproducibility but worth noting for repo size awareness.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

**Branch Info:**
- Source: `feature/seattle-method-demo`
- Target: `main`
- Type: feature

Co-Authored-By: Claude <noreply@anthropic.com>