### PR TITLE
feat: reporting style presets, flow concept FK, and structure-aware rollups

### DIFF
--- a/examples/seattle_method_demo/output/seattle-method-case-1-four-statements.md
+++ b/examples/seattle_method_demo/output/seattle-method-case-1-four-statements.md
@@ -1,7 +1,7 @@
 # Seattle Method Cross-Taxonomy — Test Case 1: Four-Statement Report
 
-**Graph**: `kg19e46c0855a126fb49f3`
-**Report**: `rpt_01KS3CBBR0XK79D4FT8FQATVTJ` (published)
+**Graph**: `kg19e48e582867f658d601`
+**Report**: `rpt_01KS4EB8J1G24X8D4BQX24F6S2` (published)
 **Entity**: Lemonade Stand (Charlie Hoffman Test Case 1)
 **Period**: 2024-01-01 → 2024-03-31 (Current)
 **Comparative**: 2023-10-02 → 2023-12-31 (Prior — zero opening balances)
@@ -122,7 +122,7 @@ The architectural piece that powers this lives in
 
 - **Structure**: `rs-gaap — Cash Flow Statement — Indirect`
 - **Block type**: `cash_flow_statement`
-- **Row count**: 8
+- **Row count**: 11
 - **Unmapped elements**: 0
 
 | QName | Concept | Current (2024-01-01 → 2024-03-31) | Prior (2023-10-02 → 2023-12-31) |
@@ -132,8 +132,11 @@ The architectural piece that powers this lives in
 | `rs-gaap:IncreaseDecreaseInInventories` |     Increase (Decrease) in Inventories | $(2,700.00) | $0.00 |
 | `rs-gaap:IncreaseDecreaseInAccountsPayableAndAccruedLiabilities` |     Increase (Decrease) in Accounts Payable and Accrued Liabilities | $1,400.00 | $0.00 |
 | `rs-gaap:NetCashProvidedByUsedInOperatingActivities` |   **Cash Provided by (Used in) Operating Activity, Including Discontinued Operation** | $850.00 | $0.00 |
+| `rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment` |     Payments to Acquire Property, Plant, and Equipment | $(1,000.00) | $0.00 |
+| `rs-gaap:NetCashProvidedByUsedInInvestingActivities` |   **Cash Provided by (Used in) Investing Activity, Including Discontinued Operation** | $(1,000.00) | $0.00 |
 | `rs-gaap:ProceedsFromIssuanceOfCommonStock` |     Proceeds from Issuance of Common Stock | $10,000.00 | $0.00 |
-| `rs-gaap:NetCashProvidedByUsedInFinancingActivities` |   **Cash Provided by (Used in) Financing Activity, Including Discontinued Operation** | $10,000.00 | $0.00 |
+| `rs-gaap:ProceedsFromIssuanceOfLongTermDebtAndCapitalSecuritiesNet` |     Proceeds from Issuance of Long-Term Debt and Capital Securities, Net | $1,000.00 | $0.00 |
+| `rs-gaap:NetCashProvidedByUsedInFinancingActivities` |   **Cash Provided by (Used in) Financing Activity, Including Discontinued Operation** | $11,000.00 | $0.00 |
 | `rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease` | **CashAndCashEquivalentsPeriodIncreaseDecrease** | $10,850.00 | $0.00 |
 
 ---
@@ -155,12 +158,12 @@ The architectural piece that powers this lives in
 
 ## Provenance
 
-- **Report ID**: `rpt_01KS3CBBR0XK79D4FT8FQATVTJ`
-- **Graph**: `kg19e46c0855a126fb49f3`
+- **Report ID**: `rpt_01KS4EB8J1G24X8D4BQX24F6S2`
+- **Graph**: `kg19e48e582867f658d601`
 - **Taxonomy**: `rs-gaap` (resolved at create-report time)
-- **Mapping**: `struct_01KS3C141WTVM66K68BN6N6EN9`
-- **Created**: 2026-05-20T19:03:41.056953
-- **Last generated**: 2026-05-20T19:03:41.144617
+- **Mapping**: `struct_01KS4EB57T2TBNH8ZP1A4SSE32`
+- **Created**: 2026-05-21T04:57:49.377958
+- **Last generated**: 2026-05-21T04:57:49.419965
 
 ### How to reproduce
 

--- a/examples/seattle_method_demo/output/seattle-method-case-1.md
+++ b/examples/seattle_method_demo/output/seattle-method-case-1.md
@@ -1,6 +1,6 @@
 # Seattle Method Cross-Taxonomy — Test Case 1 Reconciliation
 
-**Graph**: `kg19e46c0855a126fb49f3`
+**Graph**: `kg19e48e582867f658d601`
 **Period**: 2024-01-01 → 2024-01-31
 **Dataset**: Charlie Hoffman's lemonade-stand 14-JE Q1 2024 fixture
 **Expected output reference**: [luca.pacioli.ai/luca/view/0f24fd35…](https://luca.pacioli.ai/luca/view/0f24fd35e961e167a727b663c75a4c5ec9fb7eb86730d6292f46e6e180fc2018980cd52e/index)
@@ -145,8 +145,8 @@ Each rollforward IB decomposes its BS source's period delta across declared TDC 
 
 | Flow concept | Value | Matched lines | Event ids |
 |---|---:|---:|---|
-| `mini:PurchasesInventoryForSaleOnAccount` | $(8,000.00) | 2 | evt_01KS3C150C1TD3SC2Q413E7QJD, evt_01KS3C150TME9WAMJ4ESBZJQGA |
-| `mini:DecreaseFromPaymentAccountsPayable` | $7,000.00 | 1 | evt_01KS3C1525GSY7NAXMV2XF2EM4 |
+| `mini:PurchasesInventoryForSaleOnAccount` | $(8,000.00) | 2 | evt_01KS4EB64JPXDNM9J74QQ5H5XR, evt_01KS4EB650Y76TQENNCSD78K00 |
+| `mini:DecreaseFromPaymentAccountsPayable` | $7,000.00 | 1 | evt_01KS4EB66AKCNHWNBP0N6AYRTF |
 
 ### Accrued Expenses (mini:AccruedExpenses)
 
@@ -154,8 +154,8 @@ Each rollforward IB decomposes its BS source's period delta across declared TDC 
 
 | Flow concept | Value | Matched lines | Event ids |
 |---|---:|---:|---|
-| `mini:InterestAccrued` | $(550.00) | 2 | evt_01KS3C152Z2S5Q28XEPEPRX4Z9, evt_01KS3C154NKESZBA7BF9R3VH3T |
-| `mini:DecreaseFromPaymentOfInterest` | $150.00 | 1 | evt_01KS3C152J54YNB2NT2ZZPP3NF |
+| `mini:InterestAccrued` | $(550.00) | 2 | evt_01KS4EB676YG1KARCE2VX7RPH9, evt_01KS4EB68NZ139TE6AGHHRDS2H |
+| `mini:DecreaseFromPaymentOfInterest` | $150.00 | 1 | evt_01KS4EB66R8FDGYMWHS4TQXQMM |
 
 ### Cash and Cash Equivalents (mini:CashAndCashEquivalents)
 
@@ -163,13 +163,13 @@ Each rollforward IB decomposes its BS source's period delta across declared TDC 
 
 | Flow concept | Value | Matched lines | Event ids |
 |---|---:|---:|---|
-| `mini:ProceedsFromInvestmentsByOwner` | $10,000.00 | 1 | evt_01KS3C14YQPPVND2RMYRVWNKBP |
-| `mini:ProceedsFromAdditionalLongtermBorrowings` | $2,000.00 | 1 | evt_01KS3C14ZJ5M4RGW1ZJY92X6YF |
-| `mini:PaymentForCapitalAdditionsOfPropertyPlantEquipment` | $(1,000.00) | 1 | evt_01KS3C14ZZQGP2D2WE6HX7S301 |
-| `mini:PaymentInterest` | $(150.00) | 1 | evt_01KS3C152J54YNB2NT2ZZPP3NF |
-| `mini:ProceedsFromCollectionOfReceivables` | $8,000.00 | 1 | evt_01KS3C151QCTQG75A8CEZ9V44X |
-| `mini:PaymentOfAccountsPayable` | $(7,000.00) | 1 | evt_01KS3C1525GSY7NAXMV2XF2EM4 |
-| `mini:PaymentForReductionOfLongtermBorrowings` | $(1,000.00) | 1 | evt_01KS3C152J54YNB2NT2ZZPP3NF |
+| `mini:ProceedsFromInvestmentsByOwner` | $10,000.00 | 1 | evt_01KS4EB62X0F0CKF49BZQ3KXSW |
+| `mini:ProceedsFromAdditionalLongtermBorrowings` | $2,000.00 | 1 | evt_01KS4EB63N3YR95MDT5QZ27KJ8 |
+| `mini:PaymentForCapitalAdditionsOfPropertyPlantEquipment` | $(1,000.00) | 1 | evt_01KS4EB6412VTPS8F9P1QBAQQ8 |
+| `mini:PaymentInterest` | $(150.00) | 1 | evt_01KS4EB66R8FDGYMWHS4TQXQMM |
+| `mini:ProceedsFromCollectionOfReceivables` | $8,000.00 | 1 | evt_01KS4EB65YEN8W6SJ601WJDQJV |
+| `mini:PaymentOfAccountsPayable` | $(7,000.00) | 1 | evt_01KS4EB66AKCNHWNBP0N6AYRTF |
+| `mini:PaymentForReductionOfLongtermBorrowings` | $(1,000.00) | 1 | evt_01KS4EB66R8FDGYMWHS4TQXQMM |
 
 ### Inventories (mini:Inventories)
 
@@ -177,9 +177,9 @@ Each rollforward IB decomposes its BS source's period delta across declared TDC 
 
 | Flow concept | Value | Matched lines | Event ids |
 |---|---:|---:|---|
-| `mini:InventoryWrittenOff` | $(300.00) | 1 | evt_01KS3C153E2A77J4TTSWDRK7TV |
-| `mini:PurchasesOfInventoryForSale` | $5,000.00 | 1 | evt_01KS3C150C1TD3SC2Q413E7QJD |
-| `mini:DecreaseInInventoriesFromSales` | $(2,000.00) | 1 | evt_01KS3C15198RH9BVPMHNHJNFJD |
+| `mini:InventoryWrittenOff` | $(300.00) | 1 | evt_01KS4EB67J2ER2ASCF0YKHWFSM |
+| `mini:PurchasesOfInventoryForSale` | $5,000.00 | 1 | evt_01KS4EB64JPXDNM9J74QQ5H5XR |
+| `mini:DecreaseInInventoriesFromSales` | $(2,000.00) | 1 | evt_01KS4EB65GVDZ4VW68VZ4088PE |
 
 ### Long-term Debt (mini:LongtermDebt)
 
@@ -187,8 +187,8 @@ Each rollforward IB decomposes its BS source's period delta across declared TDC 
 
 | Flow concept | Value | Matched lines | Event ids |
 |---|---:|---:|---|
-| `mini:AdditionalLongtermBorrowings` | $(2,000.00) | 1 | evt_01KS3C14ZJ5M4RGW1ZJY92X6YF |
-| `mini:RepaymentLongtermBorrowings` | $1,000.00 | 1 | evt_01KS3C152J54YNB2NT2ZZPP3NF |
+| `mini:AdditionalLongtermBorrowings` | $(2,000.00) | 1 | evt_01KS4EB63N3YR95MDT5QZ27KJ8 |
+| `mini:RepaymentLongtermBorrowings` | $1,000.00 | 1 | evt_01KS4EB66R8FDGYMWHS4TQXQMM |
 
 ### Paid In Capital (mini:PaidInCapital)
 
@@ -196,7 +196,7 @@ Each rollforward IB decomposes its BS source's period delta across declared TDC 
 
 | Flow concept | Value | Matched lines | Event ids |
 |---|---:|---:|---|
-| `mini:InvestmentsByOwner` | $(10,000.00) | 1 | evt_01KS3C14YQPPVND2RMYRVWNKBP |
+| `mini:InvestmentsByOwner` | $(10,000.00) | 1 | evt_01KS4EB62X0F0CKF49BZQ3KXSW |
 
 ### Property, Plant and Equipment (mini:PropertyPlantAndEquipment)
 
@@ -204,8 +204,8 @@ Each rollforward IB decomposes its BS source's period delta across declared TDC 
 
 | Flow concept | Value | Matched lines | Event ids |
 |---|---:|---:|---|
-| `mini:CapitalAdditionsPropertyPlantAndEquipment` | $1,000.00 | 1 | evt_01KS3C14ZZQGP2D2WE6HX7S301 |
-| `mini:DecreaseFromDepreciationAndAmortization` | $(100.00) | 1 | evt_01KS3C153XYY73SQ72WC29D5Q0 |
+| `mini:CapitalAdditionsPropertyPlantAndEquipment` | $1,000.00 | 1 | evt_01KS4EB6412VTPS8F9P1QBAQQ8 |
+| `mini:DecreaseFromDepreciationAndAmortization` | $(100.00) | 1 | evt_01KS4EB67ZS8NRFTZQHBR13HR0 |
 
 ### Receivables (mini:Receivables)
 
@@ -213,8 +213,8 @@ Each rollforward IB decomposes its BS source's period delta across declared TDC 
 
 | Flow concept | Value | Matched lines | Event ids |
 |---|---:|---:|---|
-| `mini:IncreaseInReceivablesFromSalesOnAccount` | $8,000.00 | 1 | evt_01KS3C15198RH9BVPMHNHJNFJD |
-| `mini:CollectionOfReceivables` | $(8,000.00) | 1 | evt_01KS3C151QCTQG75A8CEZ9V44X |
+| `mini:IncreaseInReceivablesFromSalesOnAccount` | $8,000.00 | 1 | evt_01KS4EB65GVDZ4VW68VZ4088PE |
+| `mini:CollectionOfReceivables` | $(8,000.00) | 1 | evt_01KS4EB65YEN8W6SJ601WJDQJV |
 
 ## Findings — Classification per Methodology §3.2
 

--- a/frameworks/rs-gaap/packages/README.md
+++ b/frameworks/rs-gaap/packages/README.md
@@ -110,6 +110,41 @@ This keeps SFAC 6 categorization queryable per-element without giving
 it a separate concept namespace, and lets every rs-* framework
 inherit the same axes.
 
+## Adding a Reporting Style preset
+
+A Reporting Style is a **selection vector** over per-statement
+presentation Structures, identified by a 4-segment code
+`{BS-layout}-{equity-form}-{IS-layout}-{CF-method}` (e.g.
+`BSC-CORP-IS01-CF1`). A preset composes one Network (presentation
+Structure) per statement type; switching a graph's Style re-renders its
+statements against the composed Networks.
+
+Adding a preset is **pure package content** — no migration. On a fresh
+`reset-local`, migration `0008` re-reads this package's declarations and
+seeds `reporting_style_networks` for every Style that declares a
+composition.
+
+1. **(Optional) Author a new axis Structure** in
+   `rs-gaap-presentation/v1` if the preset needs a layout that doesn't
+   exist yet. Mirror an existing sibling (e.g. `_:rs-gaap-pres-is-singlestep`
+   mirrors `_:rs-gaap-pres-is-multistep`): a role node with `roleUri`,
+   `structureName`, `blockType`, `conceptArrangementPattern`, then its
+   `presentation` arcs. The calc-DAG (`rs-gaap-calculations`) is global,
+   so a presentation Structure only selects *which* rows render —
+   subtotals like `GrossProfit` are still computed even if not presented.
+2. **Declare the Style** in `rs-gaap-reporting-styles/v1` by adding two
+   fields to the Style's Structure node (the one carrying `roleUri`):
+   - `reportingStyleCode`: the 4-segment code.
+   - `reportingStyleNetworks`: an array of
+     `{"statementType": …, "networkRoleUri": …}`, one per statement type
+     (`balance_sheet`, `income_statement`, `cash_flow_statement`,
+     `equity_statement`). Each `networkRoleUri` is a presentation
+     Structure's `roleUri`.
+   A Style with no `reportingStyleNetworks` (e.g. `Banking`) stays a
+   non-selectable placeholder.
+3. `just reset-local`, then `change-reporting-style` to the preset's
+   Structure id (`uuid5(roleUri, "structure")`) and re-render.
+
 ## Editing packages
 
 The JSON-LD is the source of truth. Edit it directly. We're past the

--- a/frameworks/rs-gaap/packages/rs-gaap-presentation/v1/taxonomy.jsonld
+++ b/frameworks/rs-gaap/packages/rs-gaap-presentation/v1/taxonomy.jsonld
@@ -8188,6 +8188,126 @@
     },
 
     {
+      "@id": "_:rs-gaap-pres-is-singlestep",
+      "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-singlestep",
+      "structureName": "rs-gaap — Income Statement — Single-step",
+      "blockType": "income_statement",
+      "conceptArrangementPattern": "arithmetic"
+    },
+    {
+      "@id": "_:rs-gaap-pres-is-singlestep-arc-1",
+      "arcFrom": { "@id": "rs-gaap:IncomeStatementAbstract" },
+      "arcTo": { "@id": "rs-gaap:Revenues" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-singlestep",
+      "arcOrder": 10100.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-is-singlestep-arc-2",
+      "arcFrom": { "@id": "rs-gaap:Revenues" },
+      "arcTo": { "@id": "rs-gaap:SalesRevenueNet" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-singlestep",
+      "arcOrder": 10110.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-is-singlestep-arc-3",
+      "arcFrom": { "@id": "rs-gaap:Revenues" },
+      "arcTo": { "@id": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-singlestep",
+      "arcOrder": 10120.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-is-singlestep-arc-4",
+      "arcFrom": { "@id": "rs-gaap:IncomeStatementAbstract" },
+      "arcTo": { "@id": "rs-gaap:CostOfRevenue" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-singlestep",
+      "arcOrder": 10200.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-is-singlestep-arc-5",
+      "arcFrom": { "@id": "rs-gaap:CostOfRevenue" },
+      "arcTo": { "@id": "rs-gaap:CostOfGoodsSold" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-singlestep",
+      "arcOrder": 10210.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-is-singlestep-arc-6",
+      "arcFrom": { "@id": "rs-gaap:CostOfRevenue" },
+      "arcTo": { "@id": "rs-gaap:CostOfGoodsSoldExcludingDepreciationDepletionAndAmortization" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-singlestep",
+      "arcOrder": 10220.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-is-singlestep-arc-7",
+      "arcFrom": { "@id": "rs-gaap:IncomeStatementAbstract" },
+      "arcTo": { "@id": "rs-gaap:SellingGeneralAndAdministrativeExpense" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-singlestep",
+      "arcOrder": 10300.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-is-singlestep-arc-8",
+      "arcFrom": { "@id": "rs-gaap:IncomeStatementAbstract" },
+      "arcTo": { "@id": "rs-gaap:ResearchAndDevelopmentExpense" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-singlestep",
+      "arcOrder": 10310.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-is-singlestep-arc-9",
+      "arcFrom": { "@id": "rs-gaap:IncomeStatementAbstract" },
+      "arcTo": { "@id": "rs-gaap:DepreciationDepletionAndAmortization" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-singlestep",
+      "arcOrder": 10320.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-is-singlestep-arc-10",
+      "arcFrom": { "@id": "rs-gaap:IncomeStatementAbstract" },
+      "arcTo": { "@id": "rs-gaap:OtherNonoperatingIncomeExpense" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-singlestep",
+      "arcOrder": 10400.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-is-singlestep-arc-11",
+      "arcFrom": { "@id": "rs-gaap:IncomeStatementAbstract" },
+      "arcTo": { "@id": "rs-gaap:InterestExpense" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-singlestep",
+      "arcOrder": 10500.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-is-singlestep-arc-12",
+      "arcFrom": { "@id": "rs-gaap:IncomeStatementAbstract" },
+      "arcTo": { "@id": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-singlestep",
+      "arcOrder": 10800.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-is-singlestep-arc-13",
+      "arcFrom": { "@id": "rs-gaap:IncomeStatementAbstract" },
+      "arcTo": { "@id": "rs-gaap:IncomeTaxExpenseBenefit" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-singlestep",
+      "arcOrder": 10900.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-is-singlestep-arc-14",
+      "arcFrom": { "@id": "rs-gaap:IncomeStatementAbstract" },
+      "arcTo": { "@id": "rs-gaap:NetIncomeLoss" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-singlestep",
+      "arcOrder": 11200.0
+    },
+
+    {
       "@id": "_:rs-gaap-pres-cf-indirect",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
       "structureName": "rs-gaap — Cash Flow Statement — Indirect",

--- a/frameworks/rs-gaap/packages/rs-gaap-reporting-styles/v1/taxonomy.jsonld
+++ b/frameworks/rs-gaap/packages/rs-gaap-reporting-styles/v1/taxonomy.jsonld
@@ -31,6 +31,9 @@
     "reportingStyleComposesDisclosure": {
       "@id": "https://robosystems.ai/vocab/reportingStyleComposesDisclosure",
       "@type": "@id"
+    },
+    "reportingStyleCode": {
+      "@id": "https://robosystems.ai/vocab/reportingStyleCode"
     }
   },
   "standard": "rs-gaap-reporting-styles",
@@ -69,14 +72,28 @@
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/styles/Default",
       "structureName": "Default Style — Composition",
       "blockType": "custom",
-      "conceptArrangementPattern": "set"
+      "conceptArrangementPattern": "set",
+      "reportingStyleCode": "BSC-CORP-IS02-CF1",
+      "reportingStyleNetworks": [
+        {"statementType": "balance_sheet", "networkRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified"},
+        {"statementType": "income_statement", "networkRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep"},
+        {"statementType": "cash_flow_statement", "networkRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect"},
+        {"statementType": "equity_statement", "networkRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward"}
+      ]
     },
     {
       "@id": "_:style-smallprivate-structure",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/styles/SmallPrivateCompany",
-      "structureName": "Small Private Company Style — Composition",
+      "structureName": "Small Private Company Style — Composition (single-step IS)",
       "blockType": "custom",
-      "conceptArrangementPattern": "set"
+      "conceptArrangementPattern": "set",
+      "reportingStyleCode": "BSC-CORP-IS01-CF1",
+      "reportingStyleNetworks": [
+        {"statementType": "balance_sheet", "networkRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified"},
+        {"statementType": "income_statement", "networkRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-singlestep"},
+        {"statementType": "cash_flow_statement", "networkRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect"},
+        {"statementType": "equity_statement", "networkRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward"}
+      ]
     },
     {
       "@id": "_:style-banking-structure",

--- a/migrations/extensions/versions/0008_reporting_style.py
+++ b/migrations/extensions/versions/0008_reporting_style.py
@@ -19,8 +19,12 @@ This migration is additive:
    doesn't filter on the Style's block_type, and the immutability
    trigger blocks tenant-scope UPDATE on library-seeded rows. Newly
    re-provisioned tenants pick up the corrected type from public.
-4. Seed the Default Style's composition (Balance Sheet / Multi-step IS /
-   Indirect CF / Equity Roll Forward) into ``public.reporting_style_networks``.
+4. Seed every declared Style's composition into
+   ``public.reporting_style_networks``, read data-driven from the
+   reporting-styles package's ``reportingStyleNetworks`` declarations,
+   and stamp each Style's 4-segment ``reportingStyleCode`` into
+   ``structures.metadata``. Adding a preset is pure package content — a
+   ``reset-local`` re-runs this and picks it up with no new migration.
 
 No prod backfill (Reporting Style hasn't shipped): the platform-side
 ``graphs.reporting_style_id`` lands in a sibling migration; local dev
@@ -32,6 +36,9 @@ Create Date: 2026-05-13
 """
 
 from __future__ import annotations
+
+import json
+from pathlib import Path
 
 import sqlalchemy as sa
 from alembic import op
@@ -46,28 +53,61 @@ branch_labels = None
 depends_on = None
 
 
-# ── Reporting Style + Network role URIs (deterministic, library-seeded) ──
+# ── Style compositions are read from the reporting-styles package ─────────
+# at migration time (data-driven). The package declares each Style's
+# 4-segment ``reportingStyleCode`` and its ``reportingStyleNetworks``
+# composition (statement_type → network roleUri); the seeder resolves
+# every roleUri to its deterministic Structure id. Adding a new preset is
+# therefore pure package content — ``reset-local`` re-runs this migration
+# and picks it up with no new migration.
 
-_DEFAULT_STYLE_ROLE = "https://robosystems.ai/seattle/cm-roles/roles/styles/Default"
-_SMALL_PRIVATE_STYLE_ROLE = (
-  "https://robosystems.ai/seattle/cm-roles/roles/styles/SmallPrivateCompany"
-)
-_BANKING_STYLE_ROLE = "https://robosystems.ai/seattle/cm-roles/roles/styles/Banking"
-
-_BS_NETWORK_ROLE = (
-  "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified"
-)
-_IS_NETWORK_ROLE = (
-  "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep"
-)
-_CF_NETWORK_ROLE = (
-  "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect"
-)
-_SE_NETWORK_ROLE = "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward"
+_STYLE_ROLE_PREFIX = "https://robosystems.ai/seattle/cm-roles/roles/styles/"
 
 
 def _structure_id(role_uri: str) -> str:
   return generate_deterministic_uuid(role_uri, namespace="structure")
+
+
+def _read_reporting_styles_package() -> list[dict]:
+  """Load the rs-gaap-reporting-styles package ``@graph`` nodes."""
+  from robosystems.taxonomy.discovery import framework_root, package_path
+
+  pkg = package_path(
+    "rs-gaap-reporting-styles", "v1", framework_root("rs-gaap") / "packages"
+  )
+  return json.loads(Path(pkg).read_text()).get("@graph", [])
+
+
+def _declared_styles() -> list[dict]:
+  """Every Style that declares a composition.
+
+  Returns ``[{"role_uri", "code", "networks": [(stmt, net_role), ...]}]``.
+  Composition-less placeholders (e.g. Banking) are skipped so they stay
+  non-selectable until a composition is authored.
+  """
+  styles: list[dict] = []
+  for node in _read_reporting_styles_package():
+    networks = node.get("reportingStyleNetworks")
+    role_uri = node.get("roleUri")
+    if not networks or not isinstance(role_uri, str):
+      continue
+    styles.append(
+      {
+        "role_uri": role_uri,
+        "code": node.get("reportingStyleCode"),
+        "networks": [(n["statementType"], n["networkRoleUri"]) for n in networks],
+      }
+    )
+  return styles
+
+
+def _all_style_role_uris() -> list[str]:
+  """Every Style Structure roleUri in the package (composed or not)."""
+  return [
+    n["roleUri"]
+    for n in _read_reporting_styles_package()
+    if isinstance(n.get("roleUri"), str) and n["roleUri"].startswith(_STYLE_ROLE_PREFIX)
+  ]
 
 
 # ── block_type CHECK widen (admit 'reporting_style') ──────────────────
@@ -157,63 +197,77 @@ def _drop_rsn_in_tenant(conn, schema: str) -> None:
   conn.execute(text(f'DROP TABLE IF EXISTS "{schema}".reporting_style_networks'))
 
 
-# ── Default Style composition rows (seeded in public only) ────────────────
+# ── Style composition rows (data-driven from the package) ─────────────────
 
 
-_DEFAULT_STYLE_COMPOSITION = [
-  # (statement_type, network_role_uri)
-  ("balance_sheet", _BS_NETWORK_ROLE),
-  ("income_statement", _IS_NETWORK_ROLE),
-  ("cash_flow_statement", _CF_NETWORK_ROLE),
-  ("equity_statement", _SE_NETWORK_ROLE),
-]
+def _seed_style_compositions(conn, schema: str) -> None:
+  """Seed every declared Style's composition into ``{schema}.reporting_style_networks``.
 
-
-def _seed_default_style_composition(conn, schema: str) -> None:
-  """Seed the Default Style's 4 composition rows into ``{schema}.reporting_style_networks``.
-
-  Used for both ``public`` (the library template) and every existing
-  tenant schema. Reporting Style hasn't shipped, so this backfill is
-  safe across all tenants — there's no live composition to overwrite.
-  ``ON CONFLICT DO NOTHING`` keeps it idempotent.
+  Reads each Style's ``reportingStyleNetworks`` from the reporting-styles
+  package and resolves both the Style roleUri and each network roleUri to
+  its deterministic Structure id. Used for both ``public`` (the library
+  template) and every existing tenant schema. Reporting Style hasn't
+  shipped, so this backfill is safe across all tenants — there's no live
+  composition to overwrite. ``ON CONFLICT DO NOTHING`` keeps it idempotent.
   """
-  default_style_id = _structure_id(_DEFAULT_STYLE_ROLE)
   table = (
     "public.reporting_style_networks"
     if schema == "public"
     else f'"{schema}".reporting_style_networks'
   )
-  for statement_type, role in _DEFAULT_STYLE_COMPOSITION:
+  for style in _declared_styles():
+    style_id = _structure_id(style["role_uri"])
+    for statement_type, network_role in style["networks"]:
+      conn.execute(
+        text(
+          f"""
+          INSERT INTO {table} (
+            reporting_style_id, statement_type, network_id, created_by
+          ) VALUES (:style, :stmt, :network, 'library-seeder')
+          ON CONFLICT (reporting_style_id, statement_type) DO NOTHING
+          """
+        ),
+        {
+          "style": style_id,
+          "stmt": statement_type,
+          "network": _structure_id(network_role),
+        },
+      )
+
+
+def _stamp_style_codes(conn) -> None:
+  """Stamp ``reportingStyleCode`` into ``public.structures.metadata`` for
+  every declared Style. Tenant rows pick it up via the library copy on
+  re-provision (the immutability trigger blocks tenant-scope UPDATE)."""
+  for style in _declared_styles():
+    if not style["code"]:
+      continue
     conn.execute(
       text(
-        f"""
-        INSERT INTO {table} (
-          reporting_style_id, statement_type, network_id, created_by
-        ) VALUES (:style, :stmt, :network, 'library-seeder')
-        ON CONFLICT (reporting_style_id, statement_type) DO NOTHING
+        """
+        UPDATE public.structures
+        SET metadata = jsonb_set(
+          COALESCE(metadata, '{}'::jsonb),
+          '{reporting_style_code}',
+          to_jsonb(CAST(:code AS text)),
+          true
+        )
+        WHERE id = :sid
         """
       ),
-      {
-        "style": default_style_id,
-        "stmt": statement_type,
-        "network": _structure_id(role),
-      },
+      {"sid": _structure_id(style["role_uri"]), "code": style["code"]},
     )
 
 
 def _promote_style_structures(conn) -> None:
-  """Flip the 3 placeholder Style Structures in PUBLIC from 'custom' →
+  """Flip every Style Structure in PUBLIC from 'custom' →
   'reporting_style'. Tenant rows are left untouched: the library
   immutability trigger blocks tenant-scope UPDATE, and the picker
   doesn't care about the Style's block_type. Fresh tenants pick
   up the corrected type when ``copy_library_into_tenant`` re-mirrors
   rows from public after this migration runs.
   """
-  ids = [
-    _structure_id(_DEFAULT_STYLE_ROLE),
-    _structure_id(_SMALL_PRIVATE_STYLE_ROLE),
-    _structure_id(_BANKING_STYLE_ROLE),
-  ]
+  ids = [_structure_id(r) for r in _all_style_role_uris()]
   conn.execute(
     text(
       """
@@ -227,11 +281,7 @@ def _promote_style_structures(conn) -> None:
 
 
 def _restore_style_structures(conn) -> None:
-  ids = [
-    _structure_id(_DEFAULT_STYLE_ROLE),
-    _structure_id(_SMALL_PRIVATE_STYLE_ROLE),
-    _structure_id(_BANKING_STYLE_ROLE),
-  ]
+  ids = [_structure_id(r) for r in _all_style_role_uris()]
   conn.execute(
     text(
       """
@@ -283,17 +333,20 @@ def upgrade() -> None:
   # 3. Create reporting_style_networks in every existing tenant schema.
   for_each_tenant_schema(conn, _create_rsn_in_tenant)
 
-  # 4. Promote 3 Style Structures in public from 'custom' →
-  # 'reporting_style'. Tenant rows are left alone (immutability trigger).
+  # 4. Promote every Style Structure in public from 'custom' →
+  # 'reporting_style' and stamp its 4-segment reportingStyleCode into
+  # structures.metadata. Tenant rows are left alone (immutability trigger).
   _promote_style_structures(conn)
+  _stamp_style_codes(conn)
 
-  # 5. Seed Default Style's composition (BS / IS / CF / SE) into public
-  # AND every existing tenant. Backfilling tenants is safe here because
-  # Reporting Style hasn't shipped — there's no live composition to
-  # overwrite. Production tenants don't exist yet; local dev tenants
-  # need the rows for the picker to resolve a Network.
-  _seed_default_style_composition(conn, "public")
-  for_each_tenant_schema(conn, _seed_default_style_composition)
+  # 5. Seed each declared Style's composition into public AND every
+  # existing tenant. Data-driven from the reporting-styles package, so a
+  # new preset is pure content (reset-local re-runs this). Backfilling
+  # tenants is safe here because Reporting Style hasn't shipped — there's
+  # no live composition to overwrite. Production tenants don't exist yet;
+  # local dev tenants need the rows for the picker to resolve a Network.
+  _seed_style_compositions(conn, "public")
+  for_each_tenant_schema(conn, _seed_style_compositions)
 
 
 def downgrade() -> None:

--- a/migrations/extensions/versions/0015_line_item_flow_element.py
+++ b/migrations/extensions/versions/0015_line_item_flow_element.py
@@ -1,0 +1,56 @@
+"""add flow_element_id to line_items
+
+Promote the per-line flow concept from the legacy
+``line_items.metadata['transaction_description_code']`` JSONB string to a
+first-class ``flow_element_id`` FK → elements. Additive + nullable; no
+backfill (the metadata flow tag only landed 2026-05-19 and is carried by
+re-providable demo data, not production rows). Fresh tenants get the column
+via ``metadata.create_all`` at provision; existing tenant schemas (and
+public) get it here.
+
+Revision ID: 0015
+Revises: 0014
+Create Date: 2026-05-20
+
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+from migrations.extensions.helpers import TenantOps, for_each_tenant_schema
+
+# revision identifiers, used by Alembic.
+revision = "0015"
+down_revision = "0014"
+branch_labels = None
+depends_on = None
+
+_FK_NAME = "fk_line_items_flow_element"
+_IDX_NAME = "idx_line_items_flow_element"
+
+
+def _add_flow_element(conn, schema: str) -> None:
+  t = TenantOps(conn, schema)
+  t.add_column("line_items", "flow_element_id", "VARCHAR", nullable=True)
+  t.create_index(_IDX_NAME, "line_items", ["flow_element_id"])
+  t.add_foreign_key("line_items", _FK_NAME, ["flow_element_id"], "elements", ["id"])
+
+
+def _drop_flow_element(conn, schema: str) -> None:
+  t = TenantOps(conn, schema)
+  t.drop_constraint("line_items", _FK_NAME)
+  t.drop_index(_IDX_NAME)
+  t.drop_column("line_items", "flow_element_id")
+
+
+def upgrade() -> None:
+  conn = op.get_bind()
+  _add_flow_element(conn, "public")
+  for_each_tenant_schema(conn, _add_flow_element)
+
+
+def downgrade() -> None:
+  conn = op.get_bind()
+  _drop_flow_element(conn, "public")
+  for_each_tenant_schema(conn, _drop_flow_element)

--- a/robosystems/models/api/extensions/rollforward.py
+++ b/robosystems/models/api/extensions/rollforward.py
@@ -24,17 +24,20 @@ from pydantic import BaseModel, ConfigDict, Field
 
 
 class LineItemMetadataPredicate(BaseModel):
-  """Filter ledger LineItems whose ``metadata_[field]`` is in ``values``.
+  """Filter ledger LineItems by flow concept.
 
-  The single predicate kind shipped in Phase 2 MVP. Sufficient for any
-  source taxonomy that stamps a flow-tag column on each transaction
-  line — mini's ``TransactionDescriptionCode``, future XBRL GL
-  ``GenericFlowCategory`` columns, custom tenant tags.
+  The single predicate kind shipped to date. ``values`` are flow-concept
+  qnames — mini's ``TransactionDescriptionCode`` values, rs-gaap flow
+  concepts (what the enrichment classifier emits for QuickBooks data),
+  future XBRL GL ``GenericFlowCategory`` codes. The engine resolves them
+  to element_ids and matches the first-class ``LineItem.flow_element_id``
+  FK; matched lines aggregate signed into the attributed fact for the
+  period.
 
-  ``field`` is the JSONB key under ``line_items.metadata`` (e.g.
-  ``"transaction_description_code"``). ``values`` is the set of values
-  that route to the filter's target concept; matched LineItems aggregate
-  signed into the attributed fact for the period.
+  ``field`` is **legacy and ignored** — the flow tag used to live in
+  ``line_items.metadata[field]`` but has been promoted to the typed
+  ``flow_element_id`` FK. Retained for wire-compatibility; the engine no
+  longer reads it.
   """
 
   kind: Literal["line_item_metadata_field"] = Field(
@@ -42,20 +45,21 @@ class LineItemMetadataPredicate(BaseModel):
     description="Discriminator value selecting this predicate shape.",
   )
   field: str = Field(
-    ...,
+    "transaction_description_code",
     description=(
-      "JSONB key under ``line_items.metadata`` to match against — e.g. "
-      "``transaction_description_code``. The renderer performs an "
-      "exact-string comparison on the JSONB-extracted text value."
+      "Legacy/ignored. The flow tag now lives in the typed "
+      "``flow_element_id`` FK, not JSONB metadata; the engine no longer "
+      "reads this. Retained for wire-compatibility."
     ),
   )
   values: list[str] = Field(
     ...,
     min_length=1,
     description=(
-      "Metadata values that route to this filter's target concept. "
-      "A LineItem matches when ``metadata[field] ∈ values`` AND the "
-      "line falls within the rollforward's period."
+      "Flow-concept qnames that route to this filter's target concept. "
+      "A LineItem matches when its ``flow_element_id`` is one of the "
+      "elements named here AND the line falls within the rollforward's "
+      "period."
     ),
   )
 

--- a/robosystems/models/extensions/roboledger/line_item.py
+++ b/robosystems/models/extensions/roboledger/line_item.py
@@ -28,6 +28,7 @@ class LineItem(ExtensionsBase):
   __table_args__ = (
     Index("idx_line_items_entry", "entry_id"),
     Index("idx_line_items_element", "element_id"),
+    Index("idx_line_items_flow_element", "flow_element_id"),
     CheckConstraint("debit_amount >= 0", name="check_debit_positive"),
     CheckConstraint("credit_amount >= 0", name="check_credit_positive"),
     CheckConstraint(
@@ -48,6 +49,17 @@ class LineItem(ExtensionsBase):
     String, ForeignKey("entries.id", ondelete="CASCADE"), nullable=False
   )
   element_id = Column(String, ForeignKey("elements.id"), nullable=False)
+
+  # Flow concept (the economic-flow / "transaction description" classification
+  # this line represents — e.g. rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment).
+  # First-class replacement for the legacy metadata['transaction_description_code']
+  # string. Drives rollforward attribution + cash-flow/equity-flow rendering.
+  # Nullable: not every line carries a flow (e.g. simple balance transfers).
+  # Points at the element the source flow tag names directly (rs-gaap when the
+  # enrichment classifier emits rs-gaap-valued tags; the source vocabulary in
+  # cross-taxonomy projections). A valid flow element carries an `activityType`
+  # trait.
+  flow_element_id = Column(String, ForeignKey("elements.id"), nullable=True)
 
   # Financial (minor currency units — cents)
   debit_amount = Column(BigInteger, nullable=False, default=0)

--- a/robosystems/operations/graph/commands/reporting_style.py
+++ b/robosystems/operations/graph/commands/reporting_style.py
@@ -86,7 +86,12 @@ async def change_reporting_style_cmd(
   if not graph:
     raise HTTPException(status_code=404, detail=f"Graph {graph_id!r} not found")
 
-  previous_style_id = str(graph.reporting_style_id)
+  # ``None`` for a freshly provisioned graph with no style pinned yet —
+  # keep it as JSON null in the response rather than the string "None",
+  # and let the no-op check below fall through to a real change.
+  previous_style_id = (
+    str(graph.reporting_style_id) if graph.reporting_style_id else None
+  )
 
   # Same-target is an idempotent no-op so a retry on transient network
   # error doesn't churn the platform row or surface a spurious change

--- a/robosystems/operations/graph/commands/reporting_style.py
+++ b/robosystems/operations/graph/commands/reporting_style.py
@@ -108,7 +108,7 @@ async def change_reporting_style_cmd(
     row = ext.execute(
       text(
         """
-        SELECT id, name, block_type, is_active
+        SELECT id, name, block_type, is_active, metadata
         FROM structures
         WHERE id = :sid
         """
@@ -167,6 +167,12 @@ async def change_reporting_style_cmd(
         ),
       )
 
+  # 4-segment Reporting Style code (e.g. BSC-CORP-IS01-CF1), stamped into
+  # the Style Structure's metadata by migration 0008 from the package's
+  # reportingStyleCode declaration. None for legacy/unstamped Styles.
+  metadata = row.metadata if isinstance(row.metadata, dict) else {}
+  reporting_style_code = metadata.get("reporting_style_code")
+
   # All validation passed — flip the platform-DB column.
   graph.reporting_style_id = new_reporting_style_id
   db.commit()
@@ -176,5 +182,6 @@ async def change_reporting_style_cmd(
     "graph_id": graph_id,
     "previous_reporting_style_id": previous_style_id,
     "reporting_style_id": new_reporting_style_id,
+    "reporting_style_code": reporting_style_code,
     "changed": True,
   }

--- a/robosystems/operations/roboledger/commands/journal_entries.py
+++ b/robosystems/operations/roboledger/commands/journal_entries.py
@@ -35,9 +35,10 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.orm import Session
 
+from robosystems.logger import logger
 from robosystems.models.api.extensions.journal_entries import (
   CreateJournalEntryRequest,
   DeleteJournalEntryRequest,
@@ -111,6 +112,68 @@ class UnbalancedJournalEntryError(ValueError):
 
 
 # ── Helpers ──────────────────────────────────────────────────────────────
+
+
+_FLOW_TAG_KEY = "transaction_description_code"
+
+
+def resolve_flow_element_id(session: Session, metadata: dict | None) -> str | None:
+  """Resolve a line's flow tag (``transaction_description_code`` qname) to its
+  Element id for ``LineItem.flow_element_id``.
+
+  Source-named: points at the element the qname names directly — rs-gaap in
+  production (the enrichment classifier emits rs-gaap-valued tags), the source
+  vocabulary (e.g. ``mini``) in cross-taxonomy projections. Returns ``None`` when
+  the tag is absent or doesn't resolve. Logs (advisory) when the resolved element
+  lacks an ``activityType`` trait — i.e. isn't a recognized flow concept; trait
+  coverage is backfilled in the rs-gaap content phase.
+  """
+  if not metadata:
+    return None
+  qname = metadata.get(_FLOW_TAG_KEY)
+  if not qname:
+    return None
+  row = session.execute(
+    text("SELECT id FROM elements WHERE qname = :qname LIMIT 1"),
+    {"qname": qname},
+  ).fetchone()
+  if row is None:
+    logger.warning(
+      "flow tag %s did not resolve to an element; flow_element_id left NULL", qname
+    )
+    return None
+  element_id = row[0]
+  has_activity_type = session.execute(
+    text(
+      """
+      SELECT 1 FROM element_traits et
+      JOIN traits t ON t.id = et.trait_id
+      WHERE et.element_id = :eid AND t.category = 'activityType'
+      LIMIT 1
+      """
+    ),
+    {"eid": element_id},
+  ).fetchone()
+  if has_activity_type is None:
+    logger.warning(
+      "flow element %s (%s) has no activityType trait — not a recognized flow "
+      "concept (advisory; trait coverage backfilled in the rs-gaap content phase)",
+      qname,
+      element_id,
+    )
+  return element_id
+
+
+def _split_flow_tag(metadata: dict | None) -> dict:
+  """Return a shallow copy of ``metadata`` with the legacy flow-tag key removed.
+
+  The flow concept is now a first-class ``flow_element_id`` FK; the qname no
+  longer rides in JSONB. Other metadata keys (source-system refs, etc.) are
+  preserved.
+  """
+  meta = dict(metadata or {})
+  meta.pop(_FLOW_TAG_KEY, None)
+  return meta
 
 
 def validate_and_normalize_lines(
@@ -274,11 +337,12 @@ def create_journal_entry(
       LineItem(
         entry_id=entry.id,
         element_id=li["element_id"],
+        flow_element_id=resolve_flow_element_id(session, li.get("metadata")),
         debit_amount=li["debit_amount"],
         credit_amount=li["credit_amount"],
         description=li["description"],
         line_order=order,
-        metadata_=li.get("metadata") or {},
+        metadata_=_split_flow_tag(li.get("metadata")),
       )
     )
   session.flush()
@@ -343,11 +407,12 @@ def update_journal_entry(
         LineItem(
           entry_id=entry.id,
           element_id=li["element_id"],
+          flow_element_id=resolve_flow_element_id(session, li.get("metadata")),
           debit_amount=li["debit_amount"],
           credit_amount=li["credit_amount"],
           description=li["description"],
           line_order=order,
-          metadata_=li.get("metadata") or {},
+          metadata_=_split_flow_tag(li.get("metadata")),
         )
       )
 
@@ -434,13 +499,14 @@ def reverse_journal_entry(
       LineItem(
         entry_id=reversing_entry.id,
         element_id=li.element_id,
+        # Carry the flow concept through to the reversal so the rollforward
+        # filter engine sees the offsetting flow on the reversal period.
+        flow_element_id=li.flow_element_id,
         # Flip: original debit → reversal credit, and vice versa.
         debit_amount=int(li.credit_amount),
         credit_amount=int(li.debit_amount),
-        # Preserve per-line metadata on the reversal — flow tags (e.g.
-        # transaction_description_code) need to ride through so the
-        # rollforward filter engine sees the offsetting flow on the
-        # reversal period. Shallow copy is sufficient (JSON-shaped dict).
+        # Preserve any remaining per-line metadata (source-system refs, etc.).
+        # Shallow copy is sufficient (JSON-shaped dict).
         metadata_=dict(li.metadata_ or {}),
         description=(
           f"Reversal of line {li.line_order}"

--- a/robosystems/operations/roboledger/reads/taxonomies.py
+++ b/robosystems/operations/roboledger/reads/taxonomies.py
@@ -275,11 +275,24 @@ def suggest_mapping_candidates(
     .all()
   )
 
+  # Structure-aware rollup guard (info-block §3.7.2): when a Reporting
+  # Style is active and seeded, deny a target only if it actually rolls
+  # up on that Style (its children render). On a thin Style where the
+  # concept IS the leaf, mapping to it is correct. Without a seeded Style
+  # (tests / partial deployments) fall back to the static denylist.
+  rollup_set = (
+    _load_rollup_concepts(session, reporting_style_id) if reporting_style_id else set()
+  )
+
+  def _denied(r) -> bool:
+    if rollup_set:
+      return r.id in rollup_set
+    return r.qname in RS_GAAP_SUBTOTAL_DENYLIST
+
   filtered = [
     r
     for r in rows
-    if r.qname not in RS_GAAP_SUBTOTAL_DENYLIST
-    and (not presentation_set or r.id in presentation_set)
+    if not _denied(r) and (not presentation_set or r.id in presentation_set)
   ]
 
   efs_map = _efs_by_element(session, [r.id for r in filtered])
@@ -387,6 +400,71 @@ def _load_renderable_concepts(
   except (AttributeError, TypeError):
     pass
   return result
+
+
+_ROLLUP_CONCEPTS_ATTR_PREFIX = "_rollup_concepts_cache_"
+
+
+def _load_rollup_concepts(
+  session: Session,
+  reporting_style_id: str,
+) -> set[str]:
+  """Return element_ids that are *rolled up at render* under a Reporting Style.
+
+  A concept is rolled up at render iff it appears as the **parent**
+  (``from_element_id``) of a ``presentation`` arc on one of the Style's
+  rendering structures — its value comes from summing the children the
+  renderer walks, so a CoA account must not map to it (the leaf fact would
+  double-count). A concept that is **not** in this set is a leaf on the
+  active Style, and mapping a CoA account to it is correct.
+
+  This is the structure-aware replacement for the static
+  ``RS_GAAP_SUBTOTAL_DENYLIST`` (info-block §3.7.2): the static list
+  over-denies on thin Style structures where, e.g., ``rs-gaap:Revenues``
+  has no rendering children and is itself the leaf. Empty result = no Style
+  structures seeded → callers fall back to the static denylist.
+
+  Cached on the session keyed by reporting_style_id (same pattern as
+  ``_load_renderable_concepts``).
+  """
+  cache_attr = f"{_ROLLUP_CONCEPTS_ATTR_PREFIX}{reporting_style_id}"
+  cached = getattr(session, cache_attr, None)
+  if isinstance(cached, set):
+    return cached
+
+  rows = session.execute(
+    text("""
+      SELECT DISTINCT a.from_element_id AS element_id
+      FROM reporting_style_networks rsn
+      JOIN associations a ON a.structure_id = rsn.network_id
+      WHERE rsn.reporting_style_id = :rsid
+        AND a.association_type = 'presentation'
+        AND a.from_element_id IS NOT NULL
+        AND a.to_element_id IS NOT NULL
+    """),
+    {"rsid": reporting_style_id},
+  ).fetchall()
+  result = {r.element_id for r in rows}
+  try:
+    setattr(session, cache_attr, result)
+  except (AttributeError, TypeError):
+    pass
+  return result
+
+
+def _is_rolled_up_at_render(
+  session: Session,
+  reporting_style_id: str,
+  concept_id: str,
+) -> bool:
+  """True if ``concept_id`` rolls up at render under the active Style.
+
+  A concept is denied as a CoA mapping target only when its presentation
+  children also render on the Style's structures. If it is the leaf on the
+  active Style, this returns False and mapping to it is allowed. See
+  ``_load_rollup_concepts`` (info-block §3.7.2).
+  """
+  return concept_id in _load_rollup_concepts(session, reporting_style_id)
 
 
 def _load_rs_gaap_presentation_set(session: Session) -> set[str]:
@@ -530,10 +608,20 @@ def expand_to_rs_gaap_candidates(
 
   _NARROW_THRESHOLD = 3
 
-  # Identify equivalents that are themselves valid candidate targets:
-  # not denylisted AND (if a presentation set exists) in the set.
+  # Identify equivalents that are themselves valid candidate targets.
+  # Structure-aware rollup guard (info-block §3.7.2): with a seeded Style,
+  # deny only concepts that roll up on that Style; otherwise fall back to
+  # the static denylist. Then require (if a presentation set exists) the
+  # target to be in the renderable set.
+  rollup_set = (
+    _load_rollup_concepts(session, reporting_style_id) if reporting_style_id else set()
+  )
+
   def _is_valid_target(qname: str | None, eid: str) -> bool:
-    if qname in RS_GAAP_SUBTOTAL_DENYLIST:
+    if rollup_set:
+      if eid in rollup_set:
+        return False
+    elif qname in RS_GAAP_SUBTOTAL_DENYLIST:
       return False
     if presentation_set and eid not in presentation_set:
       return False

--- a/robosystems/operations/roboledger/reports/fact_grid.py
+++ b/robosystems/operations/roboledger/reports/fact_grid.py
@@ -188,12 +188,21 @@ def generate_report_facts(
   # value. Skipped when a direct PPE Net fact already exists.
   _synthesize_ppe_net_facts(session, facts, periods)
 
+  # Emit investing/financing CF facts directly from per-line flow concepts
+  # (LineItem.flow_element_id), routed by the activityType trait. Anchors on
+  # the cash side of each entry so the sign is correct without a flip. Runs
+  # BEFORE _derive_cash_flow_facts so the latter's "direct fact wins" guard
+  # suppresses the fragile ΔBS derivation arcs for these leaves (e.g. capex,
+  # whose ΔGross derivation is defeated by an all-in-Net PP&E mapping).
+  _emit_flow_facts(session, facts, periods, mapping_id, arc_type)
+
   # Derive Cash Flow facts from period-over-period BS deltas (indirect
   # method). Each derivation arc encodes "this CF leaf is the change in
   # this BS source element" with a sign weight for the
   # asset-up=cash-use / liability-up=cash-source convention. Runs after
   # the per-period loop because each derivation reads both the current
-  # and prior period's BS values.
+  # and prior period's BS values. Operating flows land here; investing/
+  # financing were already emitted from flow concepts above.
   _derive_cash_flow_facts(session, facts, periods)
 
   unmapped_count = _count_unmapped(session, mapping_id, arc_type=arc_type)
@@ -987,6 +996,127 @@ def _synthesize_ppe_net_facts(
         period_type="instant",
       )
     )
+
+
+# rs-gaap concepts that represent "cash" for cash-flow attribution. A
+# LineItem whose account resolves to one of these is a cash line; its signed
+# movement (debit - credit) IS the period cash flow for that entry. Curated by
+# qname for the same reason as _EQUITY_FLOW_REDUCER_QNAMES — trait coverage on
+# cash concepts is incomplete, and the set is small and stable.
+_CASH_ANCHOR_QNAMES: frozenset[str] = frozenset(
+  {
+    "rs-gaap:CashCashEquivalentsAndShortTermInvestments",
+    "rs-gaap:CashAndCashEquivalentsAtCarryingValue",
+    "rs-gaap:CashCashEquivalentsRestrictedCashAndRestrictedCashEquivalents",
+    "rs-gaap:Cash",
+    "rs-gaap:CashAndCashEquivalents",
+  }
+)
+
+
+def _emit_flow_facts(
+  session: Session,
+  facts: list[ReportFact],
+  periods: list[PeriodSpec],
+  mapping_id: str,
+  arc_type: str,
+) -> None:
+  """Emit **investing/financing** CF facts directly from per-line flow concepts.
+
+  Each LineItem carries a first-class ``flow_element_id`` (the economic flow it
+  represents). For investing + financing flows the period cash flow is the
+  signed movement of the **cash side** of the entry: summing the cash-side
+  line's ``debit - credit`` gives the flow with the correct sign (cash debit =
+  inflow +, cash credit = outflow -). Summing the *non-cash* side instead would
+  require a sign flip, and summing *both* sides double-counts to zero (both
+  sides resolve to the same CF concept) — so we anchor on the cash line.
+
+  Operating flows are intentionally skipped: indirect-method operating is
+  NI + non-cash addbacks + ΔWC (handled by ``_derive_cash_flow_facts``), not a
+  flow-sum. Section routing is by the ``activityType`` trait on the resolved
+  rs-gaap flow concept.
+
+  Runs BEFORE ``_derive_cash_flow_facts`` so that function's "direct fact wins"
+  guard suppresses the (often-defeated) ΔBS derivation arcs for these same CF
+  leaves — e.g. ``PaymentsToAcquirePropertyPlantAndEquipment`` whose ΔGross
+  derivation yields 0 under an all-in-Net PP&E mapping.
+
+  Resolution uses the same ``mapping_id``/``arc_type`` as the balance reader, so
+  source-vocabulary flows (mini) and accounts resolve to rs-gaap consistently.
+  Mutates ``facts`` in place.
+  """
+  cash_qnames = list(_CASH_ANCHOR_QNAMES)
+  for period in periods:
+    rows = session.execute(
+      text("""
+        SELECT
+          COALESCE(fmap.to_element_id, li.flow_element_id) AS flow_id,
+          rf.qname AS flow_qname,
+          rf.name AS flow_name,
+          rf.balance_type AS flow_balance_type,
+          COALESCE(SUM(li.debit_amount - li.credit_amount), 0) AS cash_movement_cents
+        FROM line_items li
+        JOIN entries en ON en.id = li.entry_id
+        JOIN elements acct ON acct.id = li.element_id
+        LEFT JOIN associations amap
+          ON amap.from_element_id = li.element_id
+          AND amap.association_type = :arc_type
+          AND amap.structure_id = :mapping_id
+        LEFT JOIN elements racct ON racct.id = amap.to_element_id
+        LEFT JOIN associations fmap
+          ON fmap.from_element_id = li.flow_element_id
+          AND fmap.association_type = :arc_type
+          AND fmap.structure_id = :mapping_id
+        JOIN elements rf ON rf.id = COALESCE(fmap.to_element_id, li.flow_element_id)
+        JOIN element_traits et ON et.element_id = rf.id
+        JOIN traits t ON t.id = et.trait_id
+          AND t.category = 'activityType'
+          AND t.identifier IN ('investingActivity', 'financingActivity')
+        WHERE li.flow_element_id IS NOT NULL
+          AND en.status = 'posted'
+          AND en.posting_date BETWEEN :start AND :end
+          AND COALESCE(racct.qname, acct.qname) = ANY(:cash_qnames)
+        GROUP BY flow_id, rf.qname, rf.name, rf.balance_type
+      """),
+      {
+        "arc_type": arc_type,
+        "mapping_id": mapping_id,
+        "start": period.start,
+        "end": period.end,
+        "cash_qnames": cash_qnames,
+      },
+    ).fetchall()
+
+    for row in rows:
+      cf_value = cents_to_dollars(row.cash_movement_cents)
+      if cf_value == 0:
+        continue
+      # This emitter is authoritative for investing/financing flow leaves:
+      # drop any pre-existing fact for this leaf+period (e.g. a 0-valued or
+      # balance-shaped placeholder that some upstream pass materialized) so
+      # the flow-derived value is what renders.
+      facts[:] = [
+        f
+        for f in facts
+        if not (
+          f.element_id == row.flow_id
+          and f.period_start == period.start
+          and f.period_end == period.end
+        )
+      ]
+      facts.append(
+        ReportFact(
+          element_id=row.flow_id,
+          element_qname=row.flow_qname,
+          element_name=row.flow_name,
+          classification=None,
+          balance_type=row.flow_balance_type or "debit",
+          value=cf_value,
+          period_start=period.start,
+          period_end=period.end,
+          period_type="duration",
+        )
+      )
 
 
 def _derive_cash_flow_facts(

--- a/robosystems/operations/roboledger/reports/rollforward_filters.py
+++ b/robosystems/operations/roboledger/reports/rollforward_filters.py
@@ -1,19 +1,18 @@
 """Filter evaluation engine for ``rollforward`` Information Blocks.
 
 Implements **Tier 2 of the rollforward attribution design** from
-``information-block.md`` §4.5. Phase 2 MVP scope: one predicate kind
-(``line_item_metadata_field``) — decompose a BS account's period change
-across declared flow concepts by matching ledger LineItems on a JSONB
-metadata field.
+``information-block.md`` §4.5. Decompose a BS account's period change
+across declared flow concepts by matching ledger LineItems on their
+first-class ``flow_element_id`` FK. Each filter authors flow concepts by
+qname; the engine resolves those to element_ids and matches the FK.
 
 Sibling pattern: ``fact_grid._derive_cash_flow_facts`` (Tier 1 default
 change tag derivation, shipped 2026-05-14). Where Phase 1 derives flow
 facts from period-over-period BS deltas using ``derivation`` arcs, this
-module derives them from per-LineItem flow tags carried on
-``line_items.metadata``. The two are complementary — Tier 1 handles
-legacy data without flow tags, Tier 2 handles data with explicit
-tagging (Charlie Hoffman's mini data; future XBRL GL with
-``GenericFlowCategory``).
+module derives them from per-LineItem flow concepts on
+``line_items.flow_element_id``. The two are complementary — Tier 1
+handles untagged data, Tier 2 handles data with explicit flow tagging
+(Charlie Hoffman's mini data; future XBRL GL with ``GenericFlowCategory``).
 
 **Sign convention**: all internal aggregations are in **debit-positive
 cents** (``debit_amount - credit_amount``). This matches the LineItem
@@ -144,8 +143,7 @@ def evaluate_attribution_filters(
       bs_element_id=bs_element_id,
       filter_target_element_id=f.target_element_id,
       filter_target_qname=f.target_qname,
-      field_name=f.predicate.field,
-      values=f.predicate.values,
+      flow_qnames=f.predicate.values,
       period_start=period_start,
       period_end=period_end,
     )
@@ -249,8 +247,7 @@ def _evaluate_one_filter(
   bs_element_id: str,
   filter_target_element_id: str | None,
   filter_target_qname: str,
-  field_name: str,
-  values: list[str],
+  flow_qnames: list[str],
   period_start: date,
   period_end: date,
 ) -> AttributedFact | None:
@@ -260,8 +257,23 @@ def _evaluate_one_filter(
   Match criteria:
    - LineItem.element_id = BS source (only lines touching the BS account)
    - Entry.posting_date in period AND Entry.status='posted'
-   - LineItem.metadata->>field IN values
+   - LineItem.flow_element_id ∈ the elements named by ``flow_qnames``
+
+  The filter authors flow concepts by qname; resolve them to element_ids
+  once and match the first-class ``flow_element_id`` FK (the predicate's
+  ``values`` are flow-concept qnames). Returns ``None`` when no qname
+  resolves to an element — the same no-match outcome as before.
   """
+  value_ids = [
+    r[0]
+    for r in session.execute(
+      text("SELECT id FROM elements WHERE qname = ANY(:qnames)"),
+      {"qnames": flow_qnames},
+    ).fetchall()
+  ]
+  if not value_ids:
+    return None
+
   rows = session.execute(
     text(
       """
@@ -278,15 +290,14 @@ def _evaluate_one_filter(
       WHERE li.element_id = :element_id
         AND en.posting_date BETWEEN :start AND :end
         AND en.status = 'posted'
-        AND li.metadata ->> :field = ANY(:values)
+        AND li.flow_element_id = ANY(:value_ids)
       """
     ),
     {
       "element_id": bs_element_id,
       "start": period_start,
       "end": period_end,
-      "field": field_name,
-      "values": values,
+      "value_ids": value_ids,
     },
   ).fetchone()
 

--- a/tests/operations/graph/test_reporting_style_command.py
+++ b/tests/operations/graph/test_reporting_style_command.py
@@ -248,6 +248,86 @@ class TestChangeReportingStyleCmd:
     db.commit.assert_called_once()
     db.refresh.assert_called_once_with(graph)
 
+  async def test_happy_path_returns_reporting_style_code(self):
+    """The 4-segment code stamped into the Style Structure's metadata by
+    migration 0008 surfaces in the response."""
+    db = MagicMock()
+    user = _make_user()
+    graph = _make_graph(DEFAULT_STYLE_ID)
+    row = MagicMock()
+    row.id = SMALL_PRIVATE_STYLE_ID
+    row.name = "Small Private Company Style"
+    row.block_type = "reporting_style"
+    row.is_active = True
+    row.metadata = {"reporting_style_code": "BSC-CORP-IS01-CF1"}
+    ext_cm = _make_ext_session(
+      style_row=row, composed_types=list(_REQUIRED_STATEMENT_TYPES)
+    )
+    with (
+      _patch_owner_membership(),
+      patch(f"{_GRAPH}.get_by_id", return_value=graph),
+      patch(_EXT_SESSION, return_value=ext_cm),
+    ):
+      result = await change_reporting_style_cmd(
+        GRAPH_ID, SMALL_PRIVATE_STYLE_ID, user, db
+      )
+
+    assert result["reporting_style_code"] == "BSC-CORP-IS01-CF1"
+
+  async def test_reporting_style_code_none_when_unstamped(self):
+    """Legacy Style rows without a stamped code return ``None`` (not a
+    crash) — metadata may be NULL or lack the key."""
+    db = MagicMock()
+    user = _make_user()
+    graph = _make_graph(DEFAULT_STYLE_ID)
+    row = MagicMock()
+    row.id = SMALL_PRIVATE_STYLE_ID
+    row.name = "Small Private Company Style"
+    row.block_type = "reporting_style"
+    row.is_active = True
+    row.metadata = None
+    ext_cm = _make_ext_session(
+      style_row=row, composed_types=list(_REQUIRED_STATEMENT_TYPES)
+    )
+    with (
+      _patch_owner_membership(),
+      patch(f"{_GRAPH}.get_by_id", return_value=graph),
+      patch(_EXT_SESSION, return_value=ext_cm),
+    ):
+      result = await change_reporting_style_cmd(
+        GRAPH_ID, SMALL_PRIVATE_STYLE_ID, user, db
+      )
+
+    assert result["reporting_style_code"] is None
+
+  async def test_previous_style_none_renders_as_null(self):
+    """A freshly provisioned graph with no style pinned reports
+    ``previous_reporting_style_id`` as JSON null, not the string
+    "None", and still proceeds with the change."""
+    db = MagicMock()
+    user = _make_user()
+    graph = _make_graph(reporting_style_id=None)
+    row = MagicMock()
+    row.id = SMALL_PRIVATE_STYLE_ID
+    row.name = "Small Private Company Style"
+    row.block_type = "reporting_style"
+    row.is_active = True
+    row.metadata = {"reporting_style_code": "BSC-CORP-IS01-CF1"}
+    ext_cm = _make_ext_session(
+      style_row=row, composed_types=list(_REQUIRED_STATEMENT_TYPES)
+    )
+    with (
+      _patch_owner_membership(),
+      patch(f"{_GRAPH}.get_by_id", return_value=graph),
+      patch(_EXT_SESSION, return_value=ext_cm),
+    ):
+      result = await change_reporting_style_cmd(
+        GRAPH_ID, SMALL_PRIVATE_STYLE_ID, user, db
+      )
+
+    assert result["changed"] is True
+    assert result["previous_reporting_style_id"] is None
+
   async def test_legacy_custom_block_type_accepted(self):
     """Existing tenants whose 3 Style rows weren't promoted by 0008
     (immutability trigger leaves tenant copies as 'custom') can still

--- a/tests/operations/roboledger/commands/test_journal_entries.py
+++ b/tests/operations/roboledger/commands/test_journal_entries.py
@@ -32,6 +32,7 @@ from robosystems.operations.roboledger.commands.journal_entries import (
   UnbalancedJournalEntryError,
   create_journal_entry,
   delete_journal_entry,
+  resolve_flow_element_id,
   reverse_journal_entry,
   update_journal_entry,
   validate_and_normalize_lines,
@@ -184,9 +185,10 @@ class TestValidateAndNormalizeLines:
 
 
 class TestLineMetadataPassthrough:
-  """Per-line ``metadata`` rides through the normalization layer onto
-  ``LineItem.metadata_`` — the field that rollforward filter predicates
-  match against.
+  """Per-line ``metadata`` rides through the normalization layer; the flow
+  tag (``transaction_description_code``) is then promoted to the first-class
+  ``LineItem.flow_element_id`` FK at create time and stripped from the stored
+  metadata. Other metadata keys are preserved.
   """
 
   def test_metadata_normalizes_to_dict_when_present(self):
@@ -224,10 +226,15 @@ class TestLineMetadataPassthrough:
 
   @patch(f"{MODULE}._entry_to_response")
   @patch(f"{MODULE}.assert_period_not_closed")
-  def test_create_journal_entry_persists_line_metadata(self, _mock_guard, _mock_resp):
-    """A metadata-bearing line creates a LineItem with metadata_ stamped."""
+  @patch(f"{MODULE}.resolve_flow_element_id")
+  def test_create_journal_entry_promotes_flow_tag(
+    self, mock_resolve, _mock_guard, _mock_resp
+  ):
+    """A flow-tagged line resolves to ``flow_element_id`` and strips the
+    legacy ``transaction_description_code`` key from the stored metadata."""
     from robosystems.models.extensions.roboledger.line_item import LineItem
 
+    mock_resolve.side_effect = ["elem_flow_a", "elem_flow_b"]
     session = MagicMock()
     body = CreateJournalEntryRequest(
       posting_date=_DATE,
@@ -237,7 +244,8 @@ class TestLineMetadataPassthrough:
           element_id="elem_cash",
           debit_amount=10000,
           metadata={
-            "transaction_description_code": "mini:ProceedsFromInvestmentsByOwner"
+            "transaction_description_code": "mini:ProceedsFromInvestmentsByOwner",
+            "source_ref": "JE-201",
           },
         ),
         JournalEntryLineItemInput(
@@ -255,13 +263,49 @@ class TestLineMetadataPassthrough:
       if isinstance(call[0][0], LineItem)
     ]
     assert len(line_adds) == 2
+    # Flow tag promoted to the FK.
+    assert line_adds[0].flow_element_id == "elem_flow_a"
+    assert line_adds[1].flow_element_id == "elem_flow_b"
+    # Legacy key stripped from stored metadata; unrelated keys preserved.
+    assert "transaction_description_code" not in line_adds[0].metadata_
+    assert line_adds[0].metadata_["source_ref"] == "JE-201"
+    assert "transaction_description_code" not in line_adds[1].metadata_
+
+
+class TestResolveFlowElementId:
+  """``resolve_flow_element_id`` maps a line's flow tag (a flow-concept qname)
+  to its Element id for ``LineItem.flow_element_id``."""
+
+  def test_resolves_qname_to_element_id(self):
+    session = MagicMock()
+    el_row = MagicMock()
+    el_row.fetchone.return_value = ("elem_x",)
+    activity_row = MagicMock()
+    activity_row.fetchone.return_value = (1,)  # has an activityType trait
+    session.execute.side_effect = [el_row, activity_row]
     assert (
-      line_adds[0].metadata_["transaction_description_code"]
-      == "mini:ProceedsFromInvestmentsByOwner"
+      resolve_flow_element_id(
+        session, {"transaction_description_code": "mini:CollectionOfReceivables"}
+      )
+      == "elem_x"
     )
+
+  def test_returns_none_when_tag_absent(self):
+    session = MagicMock()
+    assert resolve_flow_element_id(session, None) is None
+    assert resolve_flow_element_id(session, {}) is None
+    assert resolve_flow_element_id(session, {"other": "x"}) is None
+
+  def test_returns_none_when_qname_unresolvable(self):
+    session = MagicMock()
+    miss = MagicMock()
+    miss.fetchone.return_value = None
+    session.execute.side_effect = [miss]
     assert (
-      line_adds[1].metadata_["transaction_description_code"]
-      == "mini:InvestmentsByOwner"
+      resolve_flow_element_id(
+        session, {"transaction_description_code": "mini:NoSuchConcept"}
+      )
+      is None
     )
 
 

--- a/tests/operations/roboledger/reads/test_taxonomies_subtotal_filter.py
+++ b/tests/operations/roboledger/reads/test_taxonomies_subtotal_filter.py
@@ -15,6 +15,8 @@ from robosystems.operations.operators.implementations.mapping.constants import (
   RS_GAAP_SUBTOTAL_DENYLIST,
 )
 from robosystems.operations.roboledger.reads.taxonomies import (
+  _is_rolled_up_at_render,
+  _load_rollup_concepts,
   expand_to_rs_gaap_candidates,
 )
 
@@ -253,3 +255,100 @@ def test_denylist_locks_canonical_rollups():
     "rs-gaap:GrossProfit",
   }
   assert must_be_denylisted.issubset(RS_GAAP_SUBTOTAL_DENYLIST)
+
+
+# ---------------------------------------------------------------------------
+# Structure-aware rollup guard (info-block §3.7.2)
+#
+# The static denylist over-denies on thin Reporting Style structures: a
+# concept like rs-gaap:Revenues is a rollup in the full taxonomy but, on a
+# Style where it has no rendering children, it IS the leaf and a CoA account
+# must be allowed to map to it. _load_rollup_concepts derives the rolled-up
+# set per-Style (concepts that are PARENTS in the Style's presentation arcs);
+# _is_rolled_up_at_render is the single-concept predicate over it.
+# ---------------------------------------------------------------------------
+
+
+def _rollup_session(parent_element_ids):
+  """Session whose reporting_style_networks presentation query returns the
+  given parent (rolled-up) element_ids."""
+  session = MagicMock()
+  q = MagicMock()
+  q.fetchall.return_value = [_row(element_id=eid) for eid in parent_element_ids]
+  session.execute.return_value = q
+  return session
+
+
+def test_load_rollup_concepts_returns_parent_element_ids():
+  session = _rollup_session(["elem_assets", "elem_liabilities"])
+  assert _load_rollup_concepts(session, "style_1") == {
+    "elem_assets",
+    "elem_liabilities",
+  }
+
+
+def test_is_rolled_up_at_render_true_for_parent_concept():
+  """A concept that is a parent on the active Style's structures (its
+  children render) is rolled up — CoA must not map to it."""
+  session = _rollup_session(["elem_assets"])
+  assert _is_rolled_up_at_render(session, "style_1", "elem_assets") is True
+
+
+def test_is_rolled_up_at_render_false_for_leaf_on_thin_style():
+  """The core fix: rs-gaap:Revenues is statically denylisted, but on a thin
+  Style where it has no rendering children it is the leaf. The structure-
+  aware predicate must allow it (returns False = not a rollup here)."""
+  # Only Assets rolls up on this Style; the revenue concept renders as a leaf.
+  session = _rollup_session(["elem_assets"])
+  assert _is_rolled_up_at_render(session, "thin_style", "elem_revenues_leaf") is False
+
+
+def test_is_rolled_up_at_render_false_when_style_unseeded():
+  """A Style with no composed networks yields an empty rollup set, so nothing
+  is treated as a rollup — callers fall back to the static denylist."""
+  session = _rollup_session([])
+  assert _is_rolled_up_at_render(session, "empty_style", "elem_anything") is False
+
+
+def test_expand_structure_aware_allows_leaf_that_is_statically_denylisted():
+  """With a Reporting Style active where rs-gaap:Revenues is a LEAF (not a
+  parent in the Style's networks), expand_to_rs_gaap_candidates must offer
+  it as a candidate even though it is in RS_GAAP_SUBTOTAL_DENYLIST — the
+  structure-aware guard supersedes the static list when a Style is seeded."""
+  equiv_rows = [
+    _row(id="elem_rev", qname="rs-gaap:Revenues", name="Revenues"),
+    _row(id="elem_lic_rev", qname="rs-gaap:LicenseRevenue", name="License Revenue"),
+  ]
+  session = MagicMock()
+  fac_lookup = MagicMock()
+  fac_lookup.fetchone.return_value = _row(qname="fac:Revenues")
+  # reporting_style_id present → presentation_set via _load_renderable_concepts
+  renderable_query = MagicMock()
+  renderable_query.fetchall.return_value = [
+    _row(element_id="elem_rev"),
+    _row(element_id="elem_lic_rev"),
+  ]
+  equiv_query = MagicMock()
+  equiv_query.fetchall.return_value = equiv_rows
+  # rollup set: only some other concept rolls up here — Revenues is a leaf.
+  rollup_query = MagicMock()
+  rollup_query.fetchall.return_value = [_row(element_id="elem_other_rollup")]
+  child_query = MagicMock()
+  child_query.fetchall.return_value = []
+  session.execute.side_effect = [
+    fac_lookup,
+    renderable_query,
+    equiv_query,
+    rollup_query,
+    child_query,
+  ]
+
+  result = expand_to_rs_gaap_candidates(
+    session, "fac_revenues_id", reporting_style_id="thin_style"
+  )
+
+  assert result is not None
+  qnames = {c["qname"] for c in result["candidates"]}
+  # Statically-denylisted, but a leaf on this Style → now offered.
+  assert "rs-gaap:Revenues" in qnames
+  assert "rs-gaap:LicenseRevenue" in qnames

--- a/tests/operations/roboledger/reports/test_fact_grid.py
+++ b/tests/operations/roboledger/reports/test_fact_grid.py
@@ -17,6 +17,7 @@ from robosystems.operations.roboledger.reports.fact_grid import (
   _close_to_retained_earnings,
   _compute_prior_period,
   _derive_cash_flow_facts,
+  _emit_flow_facts,
   _emit_net_income_facts,
   _facts_to_balance_dict,
   _find_close_target,
@@ -1551,6 +1552,107 @@ class TestEmitNetIncomeFacts:
 
 
 # ── _derive_cash_flow_facts ──────────────────────────────────────────────
+
+
+class TestEmitFlowFacts:
+  """``_emit_flow_facts`` — investing/financing CF facts from per-line flow
+  concepts. The SQL aggregation (cash-anchor + activityType filtering +
+  flow→rs-gaap resolution) is exercised end-to-end by the Seattle Method demo;
+  these unit tests cover the Python logic: sign, cents→dollars, zero-skip, and
+  the authoritative-replace of a pre-existing placeholder.
+  """
+
+  S = date(2024, 1, 1)
+  E = date(2024, 3, 31)
+
+  def _row(self, flow_id, qname, cash_cents, *, balance_type="debit", name="Flow"):
+    return SimpleNamespace(
+      flow_id=flow_id,
+      flow_qname=qname,
+      flow_name=name,
+      flow_balance_type=balance_type,
+      cash_movement_cents=cash_cents,
+    )
+
+  def _session(self, *period_rows):
+    """One execute per period; each returns its row list via fetchall()."""
+    session = MagicMock()
+    results = []
+    for rows in period_rows:
+      r = MagicMock()
+      r.fetchall.return_value = list(rows)
+      results.append(r)
+    session.execute.side_effect = results
+    return session
+
+  def _period(self):
+    return [PeriodSpec(self.S, self.E, "Current")]
+
+  def test_investing_outflow_emits_negative(self):
+    """Capex: cash-side credit (debit - credit < 0) → negative outflow."""
+    facts: list[ReportFact] = []
+    session = self._session(
+      [self._row("inv1", "rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment", -100000)]
+    )
+    _emit_flow_facts(session, facts, self._period(), "map1", "mapping")
+    assert len(facts) == 1
+    assert facts[0].element_id == "inv1"
+    assert facts[0].value == -1000.0
+    assert facts[0].period_type == "duration"
+    assert facts[0].classification is None
+
+  def test_financing_inflow_emits_positive(self):
+    """Stock issuance: cash-side debit (debit - credit > 0) → positive inflow."""
+    facts: list[ReportFact] = []
+    session = self._session(
+      [
+        self._row(
+          "fin1",
+          "rs-gaap:ProceedsFromIssuanceOfCommonStock",
+          1000000,
+          balance_type="credit",
+        )
+      ]
+    )
+    _emit_flow_facts(session, facts, self._period(), "map1", "mapping")
+    assert facts[0].value == 10000.0
+
+  def test_zero_movement_skipped(self):
+    facts: list[ReportFact] = []
+    session = self._session([self._row("z", "rs-gaap:Foo", 0)])
+    _emit_flow_facts(session, facts, self._period(), "map1", "mapping")
+    assert facts == []
+
+  def test_replaces_preexisting_placeholder(self):
+    """A pre-existing 0/instant placeholder for the flow leaf is replaced by
+    the flow-derived duration fact — not duplicated. This is the bug that
+    suppressed the long-term-debt financing line in the demo."""
+    placeholder = ReportFact(
+      element_id="fin1",
+      element_qname="rs-gaap:ProceedsFromIssuanceOfLongTermDebtAndCapitalSecuritiesNet",
+      element_name="Debt",
+      classification=None,
+      balance_type="debit",
+      value=0.0,
+      period_start=self.S,
+      period_end=self.E,
+      period_type="instant",
+    )
+    facts: list[ReportFact] = [placeholder]
+    session = self._session(
+      [
+        self._row(
+          "fin1",
+          "rs-gaap:ProceedsFromIssuanceOfLongTermDebtAndCapitalSecuritiesNet",
+          100000,
+        )
+      ]
+    )
+    _emit_flow_facts(session, facts, self._period(), "map1", "mapping")
+    debt = [f for f in facts if f.element_id == "fin1"]
+    assert len(debt) == 1
+    assert debt[0].value == 1000.0
+    assert debt[0].period_type == "duration"
 
 
 class TestDeriveCashFlowFacts:

--- a/tests/operations/roboledger/reports/test_rollforward_filters.py
+++ b/tests/operations/roboledger/reports/test_rollforward_filters.py
@@ -62,36 +62,47 @@ def _filter(
 def _session(
   *, bs_delta_cents: int, filter_results: list[tuple[int, int, list[str]]]
 ) -> MagicMock:
-  """Build a session mock whose ``execute()`` returns the BS-delta query
-  first, then one result per filter in order.
+  """Build a session mock for the engine's query sequence.
+
+  Per period the engine issues: one BS-delta query (``fetchone``), then
+  for each filter a flow-qname → element_id resolution query
+  (``fetchall``) followed by the per-filter aggregation query
+  (``fetchone``). The resolution stub returns one element id per filter so
+  every filter proceeds to aggregation (the no-resolve short-circuit isn't
+  exercised by these aggregation/residual tests).
 
   ``filter_results`` items are ``(value_cents, matched_count, event_ids)``
-  tuples returned by the per-filter aggregation query. Rows are
-  returned as plain tuples — SQLAlchemy Row objects are both indexable
-  and iterable, so tuple stand-ins satisfy both access patterns the
-  engine uses (``row[0]`` for the BS delta, tuple-unpack for filter
-  aggregates).
+  tuples returned by the aggregation query. Rows are returned as plain
+  tuples — SQLAlchemy Row objects are both indexable and iterable, so
+  tuple stand-ins satisfy both access patterns the engine uses.
   """
   session = MagicMock()
 
-  bs_delta_row: tuple = (bs_delta_cents,)
-  filter_rows: list[tuple] = [
-    (value_cents, matched_count, event_ids)
-    for value_cents, matched_count, event_ids in filter_results
-  ]
-  rows_in_order = [bs_delta_row, *filter_rows]
+  results_in_order: list[MagicMock] = []
+
+  bs = MagicMock()
+  bs.fetchone.return_value = (bs_delta_cents,)
+  results_in_order.append(bs)
+
+  for i, (value_cents, matched_count, event_ids) in enumerate(filter_results):
+    resolve = MagicMock()
+    resolve.fetchall.return_value = [(f"elem_flow_{i}",)]
+    results_in_order.append(resolve)
+    agg = MagicMock()
+    agg.fetchone.return_value = (value_cents, matched_count, event_ids)
+    results_in_order.append(agg)
 
   call_count = {"n": 0}
 
   def _execute(*_args, **_kwargs):
-    result = MagicMock()
     idx = call_count["n"]
     call_count["n"] += 1
-    if idx < len(rows_in_order):
-      result.fetchone.return_value = rows_in_order[idx]
-    else:
-      result.fetchone.return_value = None
-    return result
+    if idx < len(results_in_order):
+      return results_in_order[idx]
+    fallback = MagicMock()
+    fallback.fetchone.return_value = None
+    fallback.fetchall.return_value = []
+    return fallback
 
   session.execute.side_effect = _execute
   return session

--- a/tests/taxonomy/test_reporting_style_seeder_shape.py
+++ b/tests/taxonomy/test_reporting_style_seeder_shape.py
@@ -1,0 +1,122 @@
+"""Shape tests for the data-driven Reporting Style seeder in migration 0008.
+
+Static checks — no DB round-trip. Migration 0008 reads each Style's
+``reportingStyleNetworks`` from the ``rs-gaap-reporting-styles`` package
+and seeds ``reporting_style_networks`` + stamps ``reportingStyleCode``.
+"Adding a preset is pure package content" is now load-bearing, so these
+lock the contract a typo in the package or the seeder could break:
+
+- ``_declared_styles`` parses the package into the two composed presets
+  (Default = multi-step IS, SmallPrivate = single-step IS), each with a
+  complete 4-statement composition.
+- Composition-less placeholders (Banking) are skipped but still promoted.
+- ``_stamp_style_codes`` uses ``CAST(:code AS text)`` — guards against
+  the ``:bind::cast`` form that silently fails to bind in SQLAlchemy.
+"""
+
+from __future__ import annotations
+
+# Import migration 0008 via path-based loader because the file name
+# starts with a digit (same trick Alembic uses internally).
+import importlib.util as _util
+from pathlib import Path
+
+_MIGRATION_PATH = (
+  Path(__file__).resolve().parents[2]
+  / "migrations"
+  / "extensions"
+  / "versions"
+  / "0008_reporting_style.py"
+)
+
+_spec = _util.spec_from_file_location("mig_0008", _MIGRATION_PATH)
+assert _spec is not None and _spec.loader is not None
+mig_0008 = _util.module_from_spec(_spec)
+_spec.loader.exec_module(mig_0008)
+
+_REQUIRED = {
+  "balance_sheet",
+  "income_statement",
+  "cash_flow_statement",
+  "equity_statement",
+}
+
+
+class _Conn:
+  """Captures (sql, params) for every execute — no DB round-trip."""
+
+  def __init__(self) -> None:
+    self.calls: list[tuple[str, dict]] = []
+
+  def execute(self, stmt, params=None) -> None:
+    self.calls.append((str(stmt), params or {}))
+
+
+class TestDeclaredStyles:
+  def test_exactly_the_two_composed_presets(self) -> None:
+    codes = {s["code"] for s in mig_0008._declared_styles()}
+    assert codes == {"BSC-CORP-IS02-CF1", "BSC-CORP-IS01-CF1"}
+
+  def test_every_declared_style_has_complete_composition(self) -> None:
+    """The change-reporting-style validator rejects an incomplete
+    composition, so a seeded preset must compose all four statements."""
+    for style in mig_0008._declared_styles():
+      stmt_types = {st for st, _net in style["networks"]}
+      assert stmt_types == _REQUIRED, style["code"]
+
+  def test_is_axis_distinguishes_the_two_presets(self) -> None:
+    """The whole point of the proof slice: IS02 → multi-step network,
+    IS01 → single-step network. Everything else is shared."""
+    by_code = {s["code"]: dict(s["networks"]) for s in mig_0008._declared_styles()}
+    assert by_code["BSC-CORP-IS02-CF1"]["income_statement"].endswith("IS-multistep")
+    assert by_code["BSC-CORP-IS01-CF1"]["income_statement"].endswith("IS-singlestep")
+    # BS / CF / SE are identical across the two presets.
+    for stmt in ("balance_sheet", "cash_flow_statement", "equity_statement"):
+      assert by_code["BSC-CORP-IS02-CF1"][stmt] == by_code["BSC-CORP-IS01-CF1"][stmt], (
+        stmt
+      )
+
+  def test_placeholder_skipped_but_still_promoted(self) -> None:
+    """Banking declares no composition — skipped by the seeder (stays
+    non-selectable) but still listed for the block_type promotion."""
+    declared = {s["role_uri"] for s in mig_0008._declared_styles()}
+    all_styles = set(mig_0008._all_style_role_uris())
+    banking = mig_0008._STYLE_ROLE_PREFIX + "Banking"
+    assert banking in all_styles
+    assert banking not in declared
+
+
+class TestSeedComposition:
+  def test_seeds_one_row_per_statement_per_style(self) -> None:
+    conn = _Conn()
+    mig_0008._seed_style_compositions(conn, "public")
+    # 2 composed presets, 4 statement types each.
+    assert len(conn.calls) == 8
+    for sql, params in conn.calls:
+      assert "public.reporting_style_networks" in sql
+      assert set(params) >= {"style", "stmt", "network"}
+
+  def test_tenant_schema_qualifies_table(self) -> None:
+    conn = _Conn()
+    mig_0008._seed_style_compositions(conn, "kgtest")
+    assert all('"kgtest".reporting_style_networks' in sql for sql, _ in conn.calls)
+
+
+class TestStampStyleCodes:
+  def test_uses_cast_not_bind_then_double_colon(self) -> None:
+    """Regression guard: ``to_jsonb(:code::text)`` silently fails to bind
+    in SQLAlchemy text() (the ``::`` defeats the parser). Must use
+    ``CAST(:code AS text)``."""
+    conn = _Conn()
+    mig_0008._stamp_style_codes(conn)
+    assert conn.calls, "expected at least one UPDATE"
+    for sql, params in conn.calls:
+      assert "CAST(:code AS text)" in sql
+      assert ":code::text" not in sql
+      assert set(params) == {"sid", "code"}
+
+  def test_stamps_every_declared_code(self) -> None:
+    conn = _Conn()
+    mig_0008._stamp_style_codes(conn)
+    stamped = {params["code"] for _sql, params in conn.calls}
+    assert stamped == {"BSC-CORP-IS02-CF1", "BSC-CORP-IS01-CF1"}


### PR DESCRIPTION
## Summary

This PR introduces a significant evolution of the reporting style and cash flow reporting subsystems. It adds support for reporting style presets, promotes flow concepts to first-class foreign keys on line items, implements structure-aware rollup guards for taxonomy-driven reporting styles, and enhances cash flow statement generation by emitting investing and financing facts from flow concepts.

## Key Accomplishments

### Reporting Style Presets & Migration Enhancements
- Overhauled the `0008_reporting_style` migration to support style compositions and preset-based reporting style configuration.
- Extended the `rs-gaap-reporting-styles` taxonomy with new preset definitions, enabling declarative configuration of how financial data is presented.
- Updated the reporting style graph command to align with the new preset model.

### Flow Concept as First-Class FK
- Added a new migration (`0015_line_item_flow_element`) to promote the flow concept to a dedicated foreign key on line items, replacing prior indirect references.
- Updated the `line_item` model and `rollforward` API models to reflect the new FK relationship.
- Adjusted rollforward filter logic to work with the promoted flow element field.

### Structure-Aware Rollup Guards
- Implemented taxonomy-driven subtotal filtering in `taxonomies.py` reads, ensuring rollup aggregations respect the hierarchical structure defined in the presentation taxonomy.
- Added a comprehensive `rs-gaap-presentation` taxonomy (v1) with 120+ lines of structured line item definitions that drive rollup behavior.
- Updated `README.md` for the rs-gaap packages to document the new taxonomy package layout.

### Enhanced Cash Flow Reporting
- Extended journal entry commands to emit investing and financing activity facts derived from flow concepts, broadening the scope of automated cash flow statement generation.
- Enriched the fact grid report to incorporate flow-concept-driven facts, enabling multi-statement output (e.g., four-statement reports including cash flow from investing/financing).

### Updated Example Outputs
- Refreshed Seattle Method demo outputs to reflect the new reporting behavior, including the four-statements variant.

## Breaking Changes

- **Migration dependency**: The new `0015_line_item_flow_element` migration must be applied. Existing deployments will need to run migrations before the updated application code is deployed.
- **Rollforward API model changes**: The `rollforward` API model now references the flow element as a direct FK. API consumers that interact with rollforward data structures may need to update their field references.
- **Reporting style migration rework**: The `0008_reporting_style` migration has been substantially modified. Environments that have already applied the original version should verify migration state compatibility or follow the prescribed upgrade path.

## Testing Notes

- **New test coverage**: Added `test_taxonomies_subtotal_filter.py` (99 lines) for structure-aware rollup guard validation, and expanded `test_fact_grid.py` (+102 lines) to cover flow-concept-driven fact emission.
- **Updated tests**: `test_journal_entries.py` and `test_rollforward_filters.py` have been updated to reflect the new flow element FK and enhanced cash flow fact generation.
- All existing test suites should be run to validate backward compatibility across the reporting pipeline.

## Infrastructure Considerations

- Database migrations must be applied in sequence; the new migration depends on prior schema state.
- The new presentation taxonomy package (`rs-gaap-presentation/v1`) needs to be available in the taxonomy resolution path for structure-aware rollup guards to function correctly.
- Cache invalidation may be necessary for any taxonomy or reporting style caches after deployment, as the preset and composition model changes the shape of resolved style data.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

**Branch Info:**
- Source: `feature/report-styles-v2`
- Target: `main`
- Type: feature

Co-Authored-By: Claude <noreply@anthropic.com>