### PR TITLE
feat: Enhance reporting style resolution and equity entity handling

### DIFF
--- a/examples/roboledger_demo/main.py
+++ b/examples/roboledger_demo/main.py
@@ -102,13 +102,18 @@ def _get_operation_client():
 # ---------------------------------------------------------------------------
 
 
-def create_demo_graph(skeleton: bool = False) -> str:
+def create_demo_graph(skeleton: bool = False, entity_type: str = "corporation") -> str:
   """Create user + roboledger graph via the API.
 
   When ``skeleton=True``, provisions an empty graph (placeholder Entity,
   no synthetic data) under a separate ``.local/config.json`` slot so it
   doesn't collide with the full Cascade demo. The placeholder Entity is
   overwritten by QB CompanyInfo on first sync.
+
+  ``entity_type`` sets the entity's legal form on the create request, which
+  the backend uses to prefill the graph's Reporting Style (partnership →
+  PART, llc → LLC, else corporate). Non-corporate forms use a separate
+  credential slot so they don't collide with the corporate Cascade graph.
   """
   project_root = Path(__file__).resolve().parents[2]
   if str(project_root) not in sys.path:
@@ -144,7 +149,12 @@ def create_demo_graph(skeleton: bool = False) -> str:
   credentials = ensure_user_credentials(context)
   api_key = credentials["api_key"]
 
-  demo_slot = SKELETON_DEMO_NAME if skeleton else DEMO_NAME
+  if skeleton:
+    demo_slot = SKELETON_DEMO_NAME
+  elif entity_type != "corporation":
+    demo_slot = f"{DEMO_NAME}_{entity_type}"
+  else:
+    demo_slot = DEMO_NAME
   existing = get_graph_id(CREDENTIALS_FILE, demo_slot)
   if existing:
     print(f"\nReusing existing graph: {existing}")
@@ -184,22 +194,30 @@ def create_demo_graph(skeleton: bool = False) -> str:
     )
     print(f"\nCreating graph: {SKELETON_GRAPH_NAME}")
   else:
+    # Non-corporate forms get a distinct entity name so the equity-form
+    # variant is obvious in the render; entity_type drives the prefilled
+    # Reporting Style.
+    company_name = (
+      COMPANY_NAME
+      if entity_type == "corporation"
+      else f"Cascade Advisory Group ({entity_type.upper()})"
+    )
     metadata = GraphMetadata(
-      graph_name=COMPANY_NAME,
+      graph_name=company_name,
       description="Boutique management consulting firm — close workflow demo",
       schema_extensions=["roboledger"],
     )
     request = CreateGraphRequest(
       metadata=metadata,
       initial_entity={
-        "name": COMPANY_NAME,
+        "name": company_name,
         "uri": "https://cascadeadvisory.com",
-        "entity_type": "llc",
+        "entity_type": entity_type,
         "ticker": "CAG",
       },
-      tags=["demo", "cascade", "roboledger", "close-workflow"],
+      tags=["demo", "cascade", "roboledger", "close-workflow", entity_type],
     )
-    print(f"\nCreating graph: {COMPANY_NAME}")
+    print(f"\nCreating graph: {company_name}  (entity_type={entity_type})")
   response = api_create_graph(client=client, body=request)
   if response.status_code >= 400:
     body = response.content.decode() if response.content else "(no body)"
@@ -397,9 +415,7 @@ def _build_line_items(
     elem_id = element_lookup.get(elem_code)
     if not elem_id:
       return None
-    out.append(
-      {"element_id": elem_id, "debit_amount": debit, "credit_amount": credit}
-    )
+    out.append({"element_id": elem_id, "debit_amount": debit, "credit_amount": credit})
   return out
 
 
@@ -409,9 +425,7 @@ def _can_split_bill_payment(lines: list[tuple[str, int, int]]) -> bool:
   debits (e.g. payroll tax deposits crediting cash against an existing
   payable) are settlements, not vendor bills — keep those as plain
   journal entries so we don't misroute the AP intermediate."""
-  has_cash_credit = any(
-    code == _CASH_CODE and credit > 0 for code, _, credit in lines
-  )
+  has_cash_credit = any(code == _CASH_CODE and credit > 0 for code, _, credit in lines)
   has_liability_debit = any(
     code.startswith("2") and debit > 0 for code, debit, _ in lines
   )
@@ -545,7 +559,11 @@ def create_business_events(
           "event_type": "bill_received",
           "event_category": "purchase",
           "agent_id": agent_id,
-          "metadata": {**base_metadata, "line_items": br_lines, "memo": f"Bill: {memo}"},
+          "metadata": {
+            **base_metadata,
+            "line_items": br_lines,
+            "memo": f"Bill: {memo}",
+          },
         }
         br_resp = client.create_event_block(graph_id, br_body)
         counts["bill_received"] += 1
@@ -562,7 +580,11 @@ def create_business_events(
           "event_category": "purchase",
           "agent_id": agent_id,
           "discharges_event_id": br_resp.id,
-          "metadata": {**base_metadata, "line_items": bp_lines, "memo": f"Payment of: {memo}"},
+          "metadata": {
+            **base_metadata,
+            "line_items": bp_lines,
+            "memo": f"Payment of: {memo}",
+          },
         }
         client.create_event_block(graph_id, bp_body)
         counts["bill_paid"] += 1
@@ -602,7 +624,9 @@ def create_business_events(
 # ---------------------------------------------------------------------------
 
 
-def create_mappings(graph_id: str, element_lookup: dict[str, str]) -> int:
+def create_mappings(
+  graph_id: str, element_lookup: dict[str, str], entity_type: str = "corporation"
+) -> int:
   """Create mapping associations between CoA elements and rs-gaap reporting concepts.
 
   CoA → rs-gaap is the canonical mapping target (§3.2 Reporting Style).
@@ -613,7 +637,9 @@ def create_mappings(graph_id: str, element_lookup: dict[str, str]) -> int:
   Uses `LedgerClient.create_associations()` — the bulk HTTP API — to
   exercise the same path the frontend UI and MCP tools use.
   """
-  from .mappings import MAPPINGS
+  from .mappings import mappings_for
+
+  mappings = mappings_for(entity_type)
 
   client = _get_ledger_client()
 
@@ -640,11 +666,11 @@ def create_mappings(graph_id: str, element_lookup: dict[str, str]) -> int:
       break
     offset += 1000
 
-  # Walk MAPPINGS and post each association one-by-one through
-  # create-mapping-association which takes a single pair. The demo's
-  # mapping set is ~27 rows so per-call latency is fine.
+  # Walk the (form-aware) mappings and post each association one-by-one
+  # through create-mapping-association which takes a single pair. The
+  # demo's mapping set is ~27 rows so per-call latency is fine.
   created = 0
-  for coa_code, rs_gaap_qname in MAPPINGS:
+  for coa_code, rs_gaap_qname in mappings:
     coa_id = element_lookup.get(coa_code)
     if not coa_id:
       print(f"  WARNING: CoA code {coa_code} not in element_lookup")
@@ -988,7 +1014,9 @@ def generate_fy2025_report(graph_id: str) -> str | None:
     # InformationBlockEnvelope. Earlier this read item.block_type directly
     # and silently rendered "?" for every item.
     block_names = [
-      (i.get("block") or {}).get("name") or (i.get("block") or {}).get("block_type") or "?"
+      (i.get("block") or {}).get("name")
+      or (i.get("block") or {}).get("block_type")
+      or "?"
       for i in items
     ]
     print(f"  Package:      {len(items)} block(s) — {', '.join(block_names)}")
@@ -1012,6 +1040,10 @@ def main() -> None:
   dry_run = "--dry-run" in sys.argv
   with_ai_mapping = "--ai" in sys.argv
   skeleton = "--skeleton" in sys.argv
+  entity_type = next(
+    (a.split("=", 1)[1] for a in sys.argv if a.startswith("--entity-type=")),
+    "corporation",
+  )
   args = [a for a in sys.argv[1:] if not a.startswith("--")]
 
   # Add project root to path
@@ -1067,7 +1099,7 @@ def main() -> None:
   if args:
     graph_id = args[0]
   else:
-    graph_id = create_demo_graph()
+    graph_id = create_demo_graph(entity_type=entity_type)
 
   # Reset prior demo state (the ONLY direct-DB operation)
   print(f"\nResetting demo state for graph {graph_id}...")
@@ -1102,7 +1134,7 @@ def main() -> None:
     run_ai_mapping(graph_id)
   else:
     print("\nCreating CoA → GAAP mappings...")
-    mapping_count = create_mappings(graph_id, element_lookup)
+    mapping_count = create_mappings(graph_id, element_lookup, entity_type=entity_type)
     print(f"  Mappings:     {mapping_count}")
 
   # Initialize fiscal calendar (via HTTP API — exercises initialize op)

--- a/examples/roboledger_demo/mappings.py
+++ b/examples/roboledger_demo/mappings.py
@@ -57,8 +57,14 @@ MAPPINGS: list[tuple[str, str]] = [
   ),  # Accumulated Depreciation (contra-asset)
   # Liabilities
   ("2000", "rs-gaap:AccountsPayableAndAccruedLiabilitiesCurrent"),  # Accounts Payable
-  ("2100", "rs-gaap:AccountsPayableAndAccruedLiabilitiesCurrent"),  # Accrued Liabilities
-  ("2200", "rs-gaap:AccountsPayableAndAccruedLiabilitiesCurrent"),  # Payroll Taxes Payable
+  (
+    "2100",
+    "rs-gaap:AccountsPayableAndAccruedLiabilitiesCurrent",
+  ),  # Accrued Liabilities
+  (
+    "2200",
+    "rs-gaap:AccountsPayableAndAccruedLiabilitiesCurrent",
+  ),  # Payroll Taxes Payable
   # Equity
   ("3000", "rs-gaap:AdditionalPaidInCapital"),  # Owner's Equity
   ("3100", "rs-gaap:RetainedEarningsAccumulatedDeficit"),  # Retained Earnings
@@ -75,9 +81,40 @@ MAPPINGS: list[tuple[str, str]] = [
   ("6000", "rs-gaap:SellingGeneralAndAdministrativeExpense"),  # Office Rent
   ("6100", "rs-gaap:SellingGeneralAndAdministrativeExpense"),  # Software Subscriptions
   ("6200", "rs-gaap:SellingGeneralAndAdministrativeExpense"),  # Cloud Hosting
-  ("6300", "rs-gaap:SellingGeneralAndAdministrativeExpense"),  # Professional Development
+  (
+    "6300",
+    "rs-gaap:SellingGeneralAndAdministrativeExpense",
+  ),  # Professional Development
   ("6400", "rs-gaap:SellingGeneralAndAdministrativeExpense"),  # Business Insurance
   ("6500", "rs-gaap:SellingGeneralAndAdministrativeExpense"),  # Office Supplies
   ("6600", "rs-gaap:SellingGeneralAndAdministrativeExpense"),  # Travel & Entertainment
   ("7000", "rs-gaap:DepreciationDepletionAndAmortization"),  # Depreciation Expense
 ]
+
+
+# Equity CoA (3000 Owner's Equity, 3100 Retained Earnings) maps to the
+# rs-gaap capital concept appropriate to the entity's legal form, so the
+# equity-form Reporting Style (BSC-{CORP,PART,LLC}-…) renders its native
+# capital line. Non-equity mappings are identical across forms.
+_EQUITY_BY_FORM: dict[str, list[tuple[str, str]]] = {
+  "corporation": [
+    ("3000", "rs-gaap:AdditionalPaidInCapital"),
+    ("3100", "rs-gaap:RetainedEarningsAccumulatedDeficit"),
+  ],
+  "partnership": [
+    ("3000", "rs-gaap:PartnersCapital"),
+    ("3100", "rs-gaap:PartnersCapital"),
+  ],
+  "llc": [
+    ("3000", "rs-gaap:MembersEquity"),
+    ("3100", "rs-gaap:MembersEquity"),
+  ],
+}
+
+
+def mappings_for(entity_type: str = "corporation") -> list[tuple[str, str]]:
+  """CoA→rs-gaap mappings with equity rows tuned to the entity legal form."""
+  form = (entity_type or "corporation").strip().lower()
+  equity = _EQUITY_BY_FORM.get(form, _EQUITY_BY_FORM["corporation"])
+  base = [m for m in MAPPINGS if m[0] not in ("3000", "3100")]
+  return base + equity

--- a/examples/seattle_method_demo/main.py
+++ b/examples/seattle_method_demo/main.py
@@ -200,7 +200,7 @@ def step_provision_graph() -> str:
     initial_entity={
       "name": ENTITY_NAME,
       "uri": "https://luca.pacioli.ai/luca/view/0f24fd35e961e167a727b663c75a4c5ec9fb7eb86730d6292f46e6e180fc2018980cd52e/index",
-      "entity_type": "llc",
+      "entity_type": "corporation",
     },
     tags=["demo", "seattle-method", "cross-taxonomy-test", "mini"],
   )

--- a/frameworks/rs-gaap/packages/README.md
+++ b/frameworks/rs-gaap/packages/README.md
@@ -145,6 +145,35 @@ composition.
 3. `just reset-local`, then `change-reporting-style` to the preset's
    Structure id (`uuid5(roleUri, "structure")`) and re-render.
 
+### The equity-form axis (worked example)
+
+The second segment of the code is the entity's legal form
+(`CORP`/`PART`/`LLC`/…). Because composition is per-*statement*, an
+equity-form variant is a **full balance-sheet Structure** that clones the
+corporate asset/liability arcs and swaps only the equity section, plus a
+form-specific Statement-of-Changes rollforward:
+
+- `BS-classified-PART` / `BS-classified-LLC` keep `rs-gaap:StockholdersEquity`
+  as the equity *total* (the calc-DAG plug: `StockholdersEquity = Σ equity
+  leaves`, which already sums `PartnersCapital`/`MembersEquity`), so the
+  balance sheet still foots. They differ from `BS-classified` only in which
+  child the equity section presents — `PartnersCapital` / `MembersEquity`
+  instead of the corporate stack.
+- `Equity-rollforward-PART` / `Equity-rollforward-LLC` root the rollforward
+  at the form's capital concept.
+
+The `Partnership` / `LimitedLiabilityCompany` presets then compose those
+Networks (`BSC-PART-IS02-CF1`, `BSC-LLC-IS02-CF1`) with the shared
+`IS-multistep` + `CashFlow-indirect`. New graphs default to the matching
+Style from the entity's `entity_type` at creation (see
+`operations/graph/reporting_style_defaults.py`).
+
+**Known limit:** auto-derived Retained Earnings is corporate-specific —
+partnerships/LLCs roll undistributed earnings into the capital account, not
+a separate RE line, so a PART/LLC equity section only foots cleanly once
+form-aware earnings rollup lands. `SOLE`/`NFP` need new leaf concepts
+(`ProprietorCapital`, net-asset classes) before they can be authored.
+
 ## Editing packages
 
 The JSON-LD is the source of truth. Edit it directly. We're past the

--- a/frameworks/rs-gaap/packages/rs-gaap-presentation/v1/taxonomy.jsonld
+++ b/frameworks/rs-gaap/packages/rs-gaap-presentation/v1/taxonomy.jsonld
@@ -8003,23 +8003,6 @@
       "arcOrder": 20460.0
     },
     {
-      "@id": "_:rs-gaap-pres-bs-classified-arc-35",
-      "arcFrom": { "@id": "rs-gaap:StockholdersEquity" },
-      "arcTo": { "@id": "rs-gaap:PartnersCapital" },
-      "arcAssociationType": "presentation",
-      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-      "arcOrder": 20470.0
-    },
-    {
-      "@id": "_:rs-gaap-pres-bs-classified-arc-36",
-      "arcFrom": { "@id": "rs-gaap:StockholdersEquity" },
-      "arcTo": { "@id": "rs-gaap:MembersEquity" },
-      "arcAssociationType": "presentation",
-      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-      "arcOrder": 20480.0
-    },
-
-    {
       "@id": "_:rs-gaap-pres-is-multistep",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
       "structureName": "rs-gaap — Income Statement — Multi-step",
@@ -8496,6 +8479,554 @@
       "arcTo": { "@id": "rs-gaap:PaymentsOfDividends" },
       "arcAssociationType": "presentation",
       "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward",
+      "arcOrder": 40600.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-bs-classified-part",
+      "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified-PART",
+      "structureName": "rs-gaap — Balance Sheet — Classified (Partnership)",
+      "blockType": "balance_sheet",
+      "conceptArrangementPattern": "arithmetic"
+    },
+    {
+      "@id": "_:rs-gaap-pres-bs-classified-part-arc-1",
+      "arcFrom": { "@id": "rs-gaap:Assets" },
+      "arcTo": { "@id": "rs-gaap:AssetsCurrent" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified-PART",
+      "arcOrder": 20100.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-bs-classified-part-arc-2",
+      "arcFrom": { "@id": "rs-gaap:AssetsCurrent" },
+      "arcTo": { "@id": "rs-gaap:CashCashEquivalentsAndShortTermInvestments" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified-PART",
+      "arcOrder": 20110.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-bs-classified-part-arc-3",
+      "arcFrom": { "@id": "rs-gaap:AssetsCurrent" },
+      "arcTo": { "@id": "rs-gaap:ReceivablesNetCurrent" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified-PART",
+      "arcOrder": 20120.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-bs-classified-part-arc-4",
+      "arcFrom": { "@id": "rs-gaap:AssetsCurrent" },
+      "arcTo": { "@id": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified-PART",
+      "arcOrder": 20130.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-bs-classified-part-arc-5",
+      "arcFrom": { "@id": "rs-gaap:AssetsCurrent" },
+      "arcTo": { "@id": "rs-gaap:PrepaidExpenseCurrent" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified-PART",
+      "arcOrder": 20140.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-bs-classified-part-arc-6",
+      "arcFrom": { "@id": "rs-gaap:AssetsCurrent" },
+      "arcTo": { "@id": "rs-gaap:RestrictedCashAndInvestmentsCurrent" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified-PART",
+      "arcOrder": 20150.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-bs-classified-part-arc-7",
+      "arcFrom": { "@id": "rs-gaap:AssetsCurrent" },
+      "arcTo": { "@id": "rs-gaap:OtherAssetsCurrent" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified-PART",
+      "arcOrder": 20160.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-bs-classified-part-arc-8",
+      "arcFrom": { "@id": "rs-gaap:Assets" },
+      "arcTo": { "@id": "rs-gaap:AssetsNoncurrent" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified-PART",
+      "arcOrder": 20200.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-bs-classified-part-arc-9",
+      "arcFrom": { "@id": "rs-gaap:AssetsNoncurrent" },
+      "arcTo": { "@id": "rs-gaap:PropertyPlantAndEquipmentNet" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified-PART",
+      "arcOrder": 20210.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-bs-classified-part-arc-10",
+      "arcFrom": { "@id": "rs-gaap:AssetsNoncurrent" },
+      "arcTo": { "@id": "rs-gaap:IntangibleAssetsNetIncludingGoodwill" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified-PART",
+      "arcOrder": 20220.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-bs-classified-part-arc-11",
+      "arcFrom": { "@id": "rs-gaap:AssetsNoncurrent" },
+      "arcTo": { "@id": "rs-gaap:LongTermInvestmentsAndReceivablesNet" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified-PART",
+      "arcOrder": 20230.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-bs-classified-part-arc-12",
+      "arcFrom": { "@id": "rs-gaap:AssetsNoncurrent" },
+      "arcTo": { "@id": "rs-gaap:OperatingLeaseRightOfUseAsset" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified-PART",
+      "arcOrder": 20240.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-bs-classified-part-arc-13",
+      "arcFrom": { "@id": "rs-gaap:AssetsNoncurrent" },
+      "arcTo": { "@id": "rs-gaap:FinanceLeaseRightOfUseAsset" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified-PART",
+      "arcOrder": 20250.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-bs-classified-part-arc-14",
+      "arcFrom": { "@id": "rs-gaap:AssetsNoncurrent" },
+      "arcTo": { "@id": "rs-gaap:OtherAssetsNoncurrent" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified-PART",
+      "arcOrder": 20260.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-bs-classified-part-arc-15",
+      "arcFrom": { "@id": "rs-gaap:LiabilitiesAndStockholdersEquity" },
+      "arcTo": { "@id": "rs-gaap:Liabilities" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified-PART",
+      "arcOrder": 20300.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-bs-classified-part-arc-16",
+      "arcFrom": { "@id": "rs-gaap:Liabilities" },
+      "arcTo": { "@id": "rs-gaap:LiabilitiesCurrent" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified-PART",
+      "arcOrder": 20310.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-bs-classified-part-arc-17",
+      "arcFrom": { "@id": "rs-gaap:LiabilitiesCurrent" },
+      "arcTo": { "@id": "rs-gaap:AccountsPayableAndAccruedLiabilitiesCurrent" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified-PART",
+      "arcOrder": 20311.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-bs-classified-part-arc-18",
+      "arcFrom": { "@id": "rs-gaap:LiabilitiesCurrent" },
+      "arcTo": { "@id": "rs-gaap:DebtCurrent" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified-PART",
+      "arcOrder": 20312.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-bs-classified-part-arc-19",
+      "arcFrom": { "@id": "rs-gaap:LiabilitiesCurrent" },
+      "arcTo": { "@id": "rs-gaap:DeferredRevenueCurrent" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified-PART",
+      "arcOrder": 20313.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-bs-classified-part-arc-20",
+      "arcFrom": { "@id": "rs-gaap:LiabilitiesCurrent" },
+      "arcTo": { "@id": "rs-gaap:FinanceLeaseLiabilityCurrent" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified-PART",
+      "arcOrder": 20314.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-bs-classified-part-arc-21",
+      "arcFrom": { "@id": "rs-gaap:LiabilitiesCurrent" },
+      "arcTo": { "@id": "rs-gaap:OtherLiabilitiesCurrent" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified-PART",
+      "arcOrder": 20315.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-bs-classified-part-arc-22",
+      "arcFrom": { "@id": "rs-gaap:Liabilities" },
+      "arcTo": { "@id": "rs-gaap:LiabilitiesNoncurrent" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified-PART",
+      "arcOrder": 20320.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-bs-classified-part-arc-23",
+      "arcFrom": { "@id": "rs-gaap:LiabilitiesNoncurrent" },
+      "arcTo": { "@id": "rs-gaap:LongTermDebtAndCapitalLeaseObligations" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified-PART",
+      "arcOrder": 20321.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-bs-classified-part-arc-24",
+      "arcFrom": { "@id": "rs-gaap:LiabilitiesNoncurrent" },
+      "arcTo": { "@id": "rs-gaap:DeferredIncomeTaxLiabilitiesNet" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified-PART",
+      "arcOrder": 20322.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-bs-classified-part-arc-25",
+      "arcFrom": { "@id": "rs-gaap:LiabilitiesNoncurrent" },
+      "arcTo": { "@id": "rs-gaap:DeferredRevenueNoncurrent" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified-PART",
+      "arcOrder": 20323.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-bs-classified-part-arc-26",
+      "arcFrom": { "@id": "rs-gaap:LiabilitiesNoncurrent" },
+      "arcTo": { "@id": "rs-gaap:OperatingLeaseLiabilityNoncurrent" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified-PART",
+      "arcOrder": 20324.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-bs-classified-part-arc-27",
+      "arcFrom": { "@id": "rs-gaap:LiabilitiesNoncurrent" },
+      "arcTo": { "@id": "rs-gaap:OtherLiabilitiesNoncurrent" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified-PART",
+      "arcOrder": 20325.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-bs-classified-part-arc-28",
+      "arcFrom": { "@id": "rs-gaap:LiabilitiesAndStockholdersEquity" },
+      "arcTo": { "@id": "rs-gaap:StockholdersEquity" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified-PART",
+      "arcOrder": 20400.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-bs-classified-part-arc-eq1",
+      "arcFrom": { "@id": "rs-gaap:StockholdersEquity" },
+      "arcTo": { "@id": "rs-gaap:PartnersCapital" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified-PART",
+      "arcOrder": 20410.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-bs-classified-llc",
+      "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified-LLC",
+      "structureName": "rs-gaap — Balance Sheet — Classified (LLC)",
+      "blockType": "balance_sheet",
+      "conceptArrangementPattern": "arithmetic"
+    },
+    {
+      "@id": "_:rs-gaap-pres-bs-classified-llc-arc-1",
+      "arcFrom": { "@id": "rs-gaap:Assets" },
+      "arcTo": { "@id": "rs-gaap:AssetsCurrent" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified-LLC",
+      "arcOrder": 20100.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-bs-classified-llc-arc-2",
+      "arcFrom": { "@id": "rs-gaap:AssetsCurrent" },
+      "arcTo": { "@id": "rs-gaap:CashCashEquivalentsAndShortTermInvestments" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified-LLC",
+      "arcOrder": 20110.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-bs-classified-llc-arc-3",
+      "arcFrom": { "@id": "rs-gaap:AssetsCurrent" },
+      "arcTo": { "@id": "rs-gaap:ReceivablesNetCurrent" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified-LLC",
+      "arcOrder": 20120.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-bs-classified-llc-arc-4",
+      "arcFrom": { "@id": "rs-gaap:AssetsCurrent" },
+      "arcTo": { "@id": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified-LLC",
+      "arcOrder": 20130.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-bs-classified-llc-arc-5",
+      "arcFrom": { "@id": "rs-gaap:AssetsCurrent" },
+      "arcTo": { "@id": "rs-gaap:PrepaidExpenseCurrent" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified-LLC",
+      "arcOrder": 20140.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-bs-classified-llc-arc-6",
+      "arcFrom": { "@id": "rs-gaap:AssetsCurrent" },
+      "arcTo": { "@id": "rs-gaap:RestrictedCashAndInvestmentsCurrent" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified-LLC",
+      "arcOrder": 20150.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-bs-classified-llc-arc-7",
+      "arcFrom": { "@id": "rs-gaap:AssetsCurrent" },
+      "arcTo": { "@id": "rs-gaap:OtherAssetsCurrent" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified-LLC",
+      "arcOrder": 20160.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-bs-classified-llc-arc-8",
+      "arcFrom": { "@id": "rs-gaap:Assets" },
+      "arcTo": { "@id": "rs-gaap:AssetsNoncurrent" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified-LLC",
+      "arcOrder": 20200.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-bs-classified-llc-arc-9",
+      "arcFrom": { "@id": "rs-gaap:AssetsNoncurrent" },
+      "arcTo": { "@id": "rs-gaap:PropertyPlantAndEquipmentNet" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified-LLC",
+      "arcOrder": 20210.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-bs-classified-llc-arc-10",
+      "arcFrom": { "@id": "rs-gaap:AssetsNoncurrent" },
+      "arcTo": { "@id": "rs-gaap:IntangibleAssetsNetIncludingGoodwill" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified-LLC",
+      "arcOrder": 20220.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-bs-classified-llc-arc-11",
+      "arcFrom": { "@id": "rs-gaap:AssetsNoncurrent" },
+      "arcTo": { "@id": "rs-gaap:LongTermInvestmentsAndReceivablesNet" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified-LLC",
+      "arcOrder": 20230.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-bs-classified-llc-arc-12",
+      "arcFrom": { "@id": "rs-gaap:AssetsNoncurrent" },
+      "arcTo": { "@id": "rs-gaap:OperatingLeaseRightOfUseAsset" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified-LLC",
+      "arcOrder": 20240.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-bs-classified-llc-arc-13",
+      "arcFrom": { "@id": "rs-gaap:AssetsNoncurrent" },
+      "arcTo": { "@id": "rs-gaap:FinanceLeaseRightOfUseAsset" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified-LLC",
+      "arcOrder": 20250.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-bs-classified-llc-arc-14",
+      "arcFrom": { "@id": "rs-gaap:AssetsNoncurrent" },
+      "arcTo": { "@id": "rs-gaap:OtherAssetsNoncurrent" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified-LLC",
+      "arcOrder": 20260.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-bs-classified-llc-arc-15",
+      "arcFrom": { "@id": "rs-gaap:LiabilitiesAndStockholdersEquity" },
+      "arcTo": { "@id": "rs-gaap:Liabilities" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified-LLC",
+      "arcOrder": 20300.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-bs-classified-llc-arc-16",
+      "arcFrom": { "@id": "rs-gaap:Liabilities" },
+      "arcTo": { "@id": "rs-gaap:LiabilitiesCurrent" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified-LLC",
+      "arcOrder": 20310.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-bs-classified-llc-arc-17",
+      "arcFrom": { "@id": "rs-gaap:LiabilitiesCurrent" },
+      "arcTo": { "@id": "rs-gaap:AccountsPayableAndAccruedLiabilitiesCurrent" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified-LLC",
+      "arcOrder": 20311.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-bs-classified-llc-arc-18",
+      "arcFrom": { "@id": "rs-gaap:LiabilitiesCurrent" },
+      "arcTo": { "@id": "rs-gaap:DebtCurrent" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified-LLC",
+      "arcOrder": 20312.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-bs-classified-llc-arc-19",
+      "arcFrom": { "@id": "rs-gaap:LiabilitiesCurrent" },
+      "arcTo": { "@id": "rs-gaap:DeferredRevenueCurrent" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified-LLC",
+      "arcOrder": 20313.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-bs-classified-llc-arc-20",
+      "arcFrom": { "@id": "rs-gaap:LiabilitiesCurrent" },
+      "arcTo": { "@id": "rs-gaap:FinanceLeaseLiabilityCurrent" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified-LLC",
+      "arcOrder": 20314.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-bs-classified-llc-arc-21",
+      "arcFrom": { "@id": "rs-gaap:LiabilitiesCurrent" },
+      "arcTo": { "@id": "rs-gaap:OtherLiabilitiesCurrent" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified-LLC",
+      "arcOrder": 20315.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-bs-classified-llc-arc-22",
+      "arcFrom": { "@id": "rs-gaap:Liabilities" },
+      "arcTo": { "@id": "rs-gaap:LiabilitiesNoncurrent" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified-LLC",
+      "arcOrder": 20320.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-bs-classified-llc-arc-23",
+      "arcFrom": { "@id": "rs-gaap:LiabilitiesNoncurrent" },
+      "arcTo": { "@id": "rs-gaap:LongTermDebtAndCapitalLeaseObligations" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified-LLC",
+      "arcOrder": 20321.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-bs-classified-llc-arc-24",
+      "arcFrom": { "@id": "rs-gaap:LiabilitiesNoncurrent" },
+      "arcTo": { "@id": "rs-gaap:DeferredIncomeTaxLiabilitiesNet" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified-LLC",
+      "arcOrder": 20322.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-bs-classified-llc-arc-25",
+      "arcFrom": { "@id": "rs-gaap:LiabilitiesNoncurrent" },
+      "arcTo": { "@id": "rs-gaap:DeferredRevenueNoncurrent" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified-LLC",
+      "arcOrder": 20323.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-bs-classified-llc-arc-26",
+      "arcFrom": { "@id": "rs-gaap:LiabilitiesNoncurrent" },
+      "arcTo": { "@id": "rs-gaap:OperatingLeaseLiabilityNoncurrent" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified-LLC",
+      "arcOrder": 20324.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-bs-classified-llc-arc-27",
+      "arcFrom": { "@id": "rs-gaap:LiabilitiesNoncurrent" },
+      "arcTo": { "@id": "rs-gaap:OtherLiabilitiesNoncurrent" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified-LLC",
+      "arcOrder": 20325.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-bs-classified-llc-arc-28",
+      "arcFrom": { "@id": "rs-gaap:LiabilitiesAndStockholdersEquity" },
+      "arcTo": { "@id": "rs-gaap:StockholdersEquity" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified-LLC",
+      "arcOrder": 20400.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-bs-classified-llc-arc-eq1",
+      "arcFrom": { "@id": "rs-gaap:StockholdersEquity" },
+      "arcTo": { "@id": "rs-gaap:MembersEquity" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified-LLC",
+      "arcOrder": 20410.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-equity-part",
+      "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward-PART",
+      "structureName": "rs-gaap — Statement of Changes in Partners' Capital — Roll Forward",
+      "blockType": "equity_statement",
+      "conceptArrangementPattern": "roll_forward"
+    },
+    {
+      "@id": "_:rs-gaap-pres-equity-part-arc-1",
+      "arcFrom": { "@id": "rs-gaap:PartnersCapital" },
+      "arcTo": { "@id": "rs-gaap:NetIncomeLoss" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward-PART",
+      "arcOrder": 40100.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-equity-part-arc-2",
+      "arcFrom": { "@id": "rs-gaap:PartnersCapital" },
+      "arcTo": { "@id": "rs-gaap:OtherComprehensiveIncomeLossNetOfTax" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward-PART",
+      "arcOrder": 40200.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-equity-part-arc-3",
+      "arcFrom": { "@id": "rs-gaap:PartnersCapital" },
+      "arcTo": { "@id": "rs-gaap:ProceedsFromPartnershipContribution" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward-PART",
+      "arcOrder": 40300.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-equity-part-arc-4",
+      "arcFrom": { "@id": "rs-gaap:PartnersCapital" },
+      "arcTo": { "@id": "rs-gaap:PaymentsOfDividends" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward-PART",
+      "arcOrder": 40600.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-equity-llc",
+      "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward-LLC",
+      "structureName": "rs-gaap — Statement of Changes in Members' Equity — Roll Forward",
+      "blockType": "equity_statement",
+      "conceptArrangementPattern": "roll_forward"
+    },
+    {
+      "@id": "_:rs-gaap-pres-equity-llc-arc-1",
+      "arcFrom": { "@id": "rs-gaap:MembersEquity" },
+      "arcTo": { "@id": "rs-gaap:NetIncomeLoss" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward-LLC",
+      "arcOrder": 40100.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-equity-llc-arc-2",
+      "arcFrom": { "@id": "rs-gaap:MembersEquity" },
+      "arcTo": { "@id": "rs-gaap:OtherComprehensiveIncomeLossNetOfTax" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward-LLC",
+      "arcOrder": 40200.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-equity-llc-arc-3",
+      "arcFrom": { "@id": "rs-gaap:MembersEquity" },
+      "arcTo": { "@id": "rs-gaap:PaymentsOfDividends" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward-LLC",
       "arcOrder": 40600.0
     }
   ]

--- a/frameworks/rs-gaap/packages/rs-gaap-reporting-styles/v1/taxonomy.jsonld
+++ b/frameworks/rs-gaap/packages/rs-gaap-reporting-styles/v1/taxonomy.jsonld
@@ -34,6 +34,9 @@
     },
     "reportingStyleCode": {
       "@id": "https://robosystems.ai/vocab/reportingStyleCode"
+    },
+    "retainedEarningsConcept": {
+      "@id": "https://robosystems.ai/vocab/retainedEarningsConcept"
     }
   },
   "standard": "rs-gaap-reporting-styles",
@@ -66,6 +69,20 @@
       "periodType": "duration",
       "abstract": true
     },
+    {
+      "@id": "styles:Partnership",
+      "label": "Partnership Style",
+      "elementType": "abstract",
+      "periodType": "duration",
+      "abstract": true
+    },
+    {
+      "@id": "styles:LimitedLiabilityCompany",
+      "label": "Limited Liability Company Style",
+      "elementType": "abstract",
+      "periodType": "duration",
+      "abstract": true
+    },
 
     {
       "@id": "_:style-default-structure",
@@ -74,6 +91,7 @@
       "blockType": "custom",
       "conceptArrangementPattern": "set",
       "reportingStyleCode": "BSC-CORP-IS02-CF1",
+      "retainedEarningsConcept": "rs-gaap:RetainedEarningsAccumulatedDeficit",
       "reportingStyleNetworks": [
         {"statementType": "balance_sheet", "networkRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified"},
         {"statementType": "income_statement", "networkRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep"},
@@ -88,6 +106,7 @@
       "blockType": "custom",
       "conceptArrangementPattern": "set",
       "reportingStyleCode": "BSC-CORP-IS01-CF1",
+      "retainedEarningsConcept": "rs-gaap:RetainedEarningsAccumulatedDeficit",
       "reportingStyleNetworks": [
         {"statementType": "balance_sheet", "networkRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified"},
         {"statementType": "income_statement", "networkRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-singlestep"},
@@ -101,6 +120,36 @@
       "structureName": "Banking Style — Composition (placeholder)",
       "blockType": "custom",
       "conceptArrangementPattern": "set"
+    },
+    {
+      "@id": "_:style-partnership-structure",
+      "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/styles/Partnership",
+      "structureName": "Partnership Style — Composition (partners' capital equity)",
+      "blockType": "custom",
+      "conceptArrangementPattern": "set",
+      "reportingStyleCode": "BSC-PART-IS02-CF1",
+      "retainedEarningsConcept": "rs-gaap:PartnersCapital",
+      "reportingStyleNetworks": [
+        {"statementType": "balance_sheet", "networkRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified-PART"},
+        {"statementType": "income_statement", "networkRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep"},
+        {"statementType": "cash_flow_statement", "networkRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect"},
+        {"statementType": "equity_statement", "networkRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward-PART"}
+      ]
+    },
+    {
+      "@id": "_:style-llc-structure",
+      "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/styles/LimitedLiabilityCompany",
+      "structureName": "Limited Liability Company Style — Composition (members' equity)",
+      "blockType": "custom",
+      "conceptArrangementPattern": "set",
+      "reportingStyleCode": "BSC-LLC-IS02-CF1",
+      "retainedEarningsConcept": "rs-gaap:MembersEquity",
+      "reportingStyleNetworks": [
+        {"statementType": "balance_sheet", "networkRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified-LLC"},
+        {"statementType": "income_statement", "networkRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep"},
+        {"statementType": "cash_flow_statement", "networkRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect"},
+        {"statementType": "equity_statement", "networkRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward-LLC"}
+      ]
     },
 
     {
@@ -148,6 +197,40 @@
         {"@id": "disclosures:IncomeStatement"},
         {"@id": "disclosures:CashFlowStatement"},
         {"@id": "disclosures:StatementOfChangesInEquity"}
+      ]
+    },
+
+    {
+      "@id": "styles:Partnership",
+      "reportingStyleComposesDisclosure": [
+        {"@id": "disclosures:BalanceSheet"},
+        {"@id": "disclosures:IncomeStatement"},
+        {"@id": "disclosures:CashFlowStatement"},
+        {"@id": "disclosures:StatementOfChangesInEquity"},
+        {"@id": "disclosures:DocumentAndEntityInformation"},
+        {"@id": "disclosures:NatureOfOperations"},
+        {"@id": "disclosures:SignificantAccountingPolicies"},
+        {"@id": "disclosures:PropertyPlantAndEquipmentDisclosure"},
+        {"@id": "disclosures:DebtDisclosure"},
+        {"@id": "disclosures:CommitmentsDisclosure"},
+        {"@id": "disclosures:RelatedPartyDisclosures"}
+      ]
+    },
+
+    {
+      "@id": "styles:LimitedLiabilityCompany",
+      "reportingStyleComposesDisclosure": [
+        {"@id": "disclosures:BalanceSheet"},
+        {"@id": "disclosures:IncomeStatement"},
+        {"@id": "disclosures:CashFlowStatement"},
+        {"@id": "disclosures:StatementOfChangesInEquity"},
+        {"@id": "disclosures:DocumentAndEntityInformation"},
+        {"@id": "disclosures:NatureOfOperations"},
+        {"@id": "disclosures:SignificantAccountingPolicies"},
+        {"@id": "disclosures:PropertyPlantAndEquipmentDisclosure"},
+        {"@id": "disclosures:DebtDisclosure"},
+        {"@id": "disclosures:CommitmentsDisclosure"},
+        {"@id": "disclosures:RelatedPartyDisclosures"}
       ]
     }
   ]

--- a/migrations/extensions/versions/0008_reporting_style.py
+++ b/migrations/extensions/versions/0008_reporting_style.py
@@ -81,9 +81,12 @@ def _read_reporting_styles_package() -> list[dict]:
 def _declared_styles() -> list[dict]:
   """Every Style that declares a composition.
 
-  Returns ``[{"role_uri", "code", "networks": [(stmt, net_role), ...]}]``.
-  Composition-less placeholders (e.g. Banking) are skipped so they stay
-  non-selectable until a composition is authored.
+  Returns ``[{"role_uri", "code", "close_target", "networks": [(stmt,
+  net_role), ...]}]``. ``close_target`` is the form's earnings-home concept
+  qname (``retainedEarningsConcept``) — where derived cumulative earnings
+  roll for this form (CORP→RetainedEarnings, PART→PartnersCapital,
+  LLC→MembersEquity). Composition-less placeholders (e.g. Banking) are
+  skipped so they stay non-selectable until a composition is authored.
   """
   styles: list[dict] = []
   for node in _read_reporting_styles_package():
@@ -95,6 +98,7 @@ def _declared_styles() -> list[dict]:
       {
         "role_uri": role_uri,
         "code": node.get("reportingStyleCode"),
+        "close_target": node.get("retainedEarningsConcept"),
         "networks": [(n["statementType"], n["networkRoleUri"]) for n in networks],
       }
     )
@@ -259,6 +263,69 @@ def _stamp_style_codes(conn) -> None:
     )
 
 
+def _stamp_close_targets(conn) -> None:
+  """Stamp each composed Style's earnings-home concept into
+  ``public.structures.metadata.retained_earnings_concept``.
+
+  This is the single authoritative close target the fact generator routes
+  derived cumulative earnings to (``fact_grid._find_close_target``). Exactly
+  one per Style by construction (a single declared field) — never a runtime
+  scan that could match many. Validates that the declared concept is
+  actually presented in the Style's balance_sheet Network's equity section,
+  so earnings can't close to a concept the BS doesn't render (which would
+  silently drop them from the equity subtotal). Fails the migration loudly
+  on a mis-declaration.
+  """
+  for style in _declared_styles():
+    target = style["close_target"]
+    if not target:
+      continue
+    bs_role = next(
+      (net for stmt, net in style["networks"] if stmt == "balance_sheet"), None
+    )
+    if bs_role is None:
+      raise RuntimeError(
+        f"Style {style['role_uri']} declares retainedEarningsConcept "
+        f"{target!r} but composes no balance_sheet network."
+      )
+    presented = conn.execute(
+      text(
+        """
+        SELECT 1
+        FROM public.associations a
+        JOIN public.elements e ON e.id = a.to_element_id
+        WHERE a.structure_id = :bs_id
+          AND a.association_type = 'presentation'
+          AND e.qname = :target
+        LIMIT 1
+        """
+      ),
+      {"bs_id": _structure_id(bs_role), "target": target},
+    ).fetchone()
+    if presented is None:
+      raise RuntimeError(
+        f"Style {style['role_uri']} declares retainedEarningsConcept "
+        f"{target!r}, but the balance_sheet network {bs_role!r} does not "
+        f"present it — derived earnings would close to an unrendered "
+        f"concept and drop out of the equity subtotal."
+      )
+    conn.execute(
+      text(
+        """
+        UPDATE public.structures
+        SET metadata = jsonb_set(
+          COALESCE(metadata, '{}'::jsonb),
+          '{retained_earnings_concept}',
+          to_jsonb(CAST(:target AS text)),
+          true
+        )
+        WHERE id = :sid
+        """
+      ),
+      {"sid": _structure_id(style["role_uri"]), "target": target},
+    )
+
+
 def _promote_style_structures(conn) -> None:
   """Flip every Style Structure in PUBLIC from 'custom' →
   'reporting_style'. Tenant rows are left untouched: the library
@@ -338,6 +405,7 @@ def upgrade() -> None:
   # structures.metadata. Tenant rows are left alone (immutability trigger).
   _promote_style_structures(conn)
   _stamp_style_codes(conn)
+  _stamp_close_targets(conn)
 
   # 5. Seed each declared Style's composition into public AND every
   # existing tenant. Data-driven from the reporting-styles package, so a

--- a/robosystems/config/constants.py
+++ b/robosystems/config/constants.py
@@ -210,6 +210,8 @@ class ReportingStyleConstants:
   DEFAULT_STYLE_ID = "025f5d48-12ce-5d65-b9eb-4f137a10ef06"
   SMALL_PRIVATE_COMPANY_STYLE_ID = "921f5214-afd8-565c-8189-50bcc94c0234"
   BANKING_STYLE_ID = "511aeedc-fa99-5fe5-b7f1-67673b7bdb19"
+  PARTNERSHIP_STYLE_ID = "10d05f23-8ea8-5348-b8c9-f1e65bbda4a3"
+  LLC_STYLE_ID = "69bee020-87d6-5e5d-8c1e-9007d8eb8d4f"
 
 
 class PrefixConstants:

--- a/robosystems/models/api/entity_graph.py
+++ b/robosystems/models/api/entity_graph.py
@@ -19,6 +19,10 @@ class EntityCreate(BaseModel):
   state_of_incorporation: str | None = None
   fiscal_year_end: str | None = None
   ein: str | None = None
+  entity_type: str | None = Field(
+    default=None,
+    description="Entity legal form (corporation, llc, partnership, sole_proprietorship, non_profit).",
+  )
   tier: str | None = Field(
     default=None,
     description="Graph tier to create (ladybug-standard, ladybug-large, ladybug-xlarge). If not specified, defaults to ladybug-standard.",
@@ -71,6 +75,7 @@ class EntityUpdate(BaseModel):
   state_of_incorporation: str | None = None
   fiscal_year_end: str | None = None
   ein: str | None = None
+  entity_type: str | None = None
 
   @field_validator("uri")
   @classmethod
@@ -93,6 +98,7 @@ class EntityResponse(BaseModel):
   state_of_incorporation: str | None = None
   fiscal_year_end: str | None = None
   ein: str | None = None
+  entity_type: str | None = None
   created_at: str
   updated_at: str
   tier: str | None = None

--- a/robosystems/models/api/entity_graph.py
+++ b/robosystems/models/api/entity_graph.py
@@ -21,7 +21,10 @@ class EntityCreate(BaseModel):
   ein: str | None = None
   entity_type: str | None = Field(
     default=None,
-    description="Entity legal form (corporation, llc, partnership, sole_proprietorship, non_profit).",
+    description=(
+      "Entity legal form (corporation, llc / limited_liability_company, "
+      "partnership, sole_proprietorship, non_profit)."
+    ),
   )
   tier: str | None = Field(
     default=None,

--- a/robosystems/models/api/graphs/core.py
+++ b/robosystems/models/api/graphs/core.py
@@ -95,8 +95,9 @@ class InitialEntityData(BaseModel):
   entity_type: str | None = Field(
     None,
     description=(
-      "Entity legal form (e.g. 'corporation', 'llc', 'partnership', "
-      "'sole_proprietorship', 'non_profit'). Drives the graph's default "
+      "Entity legal form (e.g. 'corporation', 'llc' / "
+      "'limited_liability_company', 'partnership', 'sole_proprietorship', "
+      "'non_profit'). Drives the graph's default "
       "Reporting Style at creation — partnership and llc get dedicated "
       "equity-form Styles; everything else defaults to corporate. Blank "
       "falls back to corporate."

--- a/robosystems/models/api/graphs/core.py
+++ b/robosystems/models/api/graphs/core.py
@@ -92,6 +92,25 @@ class InitialEntityData(BaseModel):
   state_of_incorporation: str | None = Field(None, description="State of incorporation")
   fiscal_year_end: str | None = Field(None, description="Fiscal year end (MMDD)")
   ein: str | None = Field(None, description="Employer Identification Number")
+  entity_type: str | None = Field(
+    None,
+    description=(
+      "Entity legal form (e.g. 'corporation', 'llc', 'partnership', "
+      "'sole_proprietorship', 'non_profit'). Drives the graph's default "
+      "Reporting Style at creation — partnership and llc get dedicated "
+      "equity-form Styles; everything else defaults to corporate. Blank "
+      "falls back to corporate."
+    ),
+  )
+  reporting_style_id: str | None = Field(
+    None,
+    description=(
+      "Optional explicit Reporting Style Structure id to pin on the graph, "
+      "overriding the entity_type-derived default. Leave blank to derive "
+      "from entity_type. Change later via the change-reporting-style "
+      "operation."
+    ),
+  )
 
 
 class CreateGraphRequest(BaseModel):

--- a/robosystems/models/core/graph/graph.py
+++ b/robosystems/models/core/graph/graph.py
@@ -280,6 +280,7 @@ class Graph(Model):
     is_subgraph: bool = False,
     subgraph_metadata: dict[str, Any] | None = None,
     status: GraphStatus = GraphStatus.ACTIVE,
+    reporting_style_id: str | None = None,
     commit: bool = True,
   ) -> "Graph":
     """Create a new graph metadata entry."""
@@ -322,6 +323,12 @@ class Graph(Model):
       subgraph_metadata=subgraph_metadata,
       status=status.value if isinstance(status, GraphStatus) else status,
     )
+
+    # Only set when caller supplies one; otherwise the column default
+    # (corporate DEFAULT_STYLE_ID) applies. Passing None explicitly would
+    # violate the NOT NULL constraint.
+    if reporting_style_id is not None:
+      graph.reporting_style_id = reporting_style_id
 
     session.add(graph)
     if commit:

--- a/robosystems/operations/graph/graph_creation_service.py
+++ b/robosystems/operations/graph/graph_creation_service.py
@@ -328,7 +328,13 @@ class GraphCreationService:
     from robosystems.models.core import GraphSchema, GraphUser
     from robosystems.models.core.graph import Graph
 
+    from .reporting_style_defaults import resolve_reporting_style_id
     from .table_service import TableService
+
+    # Derive the initial Reporting Style from the entity's legal form (an
+    # explicit reporting_style_id on the request overrides it). Reads the
+    # raw create payload — the tenant schema doesn't exist yet here.
+    reporting_style_id = resolve_reporting_style_id(config.entity_data)
 
     db_gen = get_db_session()
     db = next(db_gen)
@@ -352,6 +358,7 @@ class GraphCreationService:
           "type": config.graph_type,
           "tags": config.tags,
         },
+        reporting_style_id=reporting_style_id,
         commit=False,
       )
 
@@ -449,6 +456,7 @@ class GraphCreationService:
         state_of_incorporation=entity_data.state_of_incorporation,
         fiscal_year_end=entity_data.fiscal_year_end,
         tax_id=entity_data.ein,
+        entity_type=entity_data.entity_type,
         website=entity_data.uri,
         status="active",
         is_parent=True,

--- a/robosystems/operations/graph/reporting_style_defaults.py
+++ b/robosystems/operations/graph/reporting_style_defaults.py
@@ -1,0 +1,48 @@
+"""Derive a graph's initial Reporting Style from the entity's legal form.
+
+Used at graph-creation time only (``_persist_metadata``). The mapping is
+intentionally small and DB-free: it points entity legal forms at the
+library-seeded Style Structure ids. An explicit ``reporting_style_id`` on
+the create request overrides the derived default; everything unknown falls
+back to the corporate Default. Post-creation, the graph-wide setting is
+changed through the ``change-reporting-style`` operation instead.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from robosystems.config.constants import ReportingStyleConstants as _RS
+
+# Entity legal form (lowercased) -> seeded Style Structure id. Only the
+# forms with a dedicated equity-form Style are listed; corporation /
+# subsidiary / sole_proprietorship / non_profit / blank / unknown all fall
+# back to the corporate Default below.
+_ENTITY_TYPE_STYLE: dict[str, str] = {
+  "partnership": _RS.PARTNERSHIP_STYLE_ID,
+  "llc": _RS.LLC_STYLE_ID,
+  "limited_liability_company": _RS.LLC_STYLE_ID,
+}
+
+
+def default_style_for(entity_type: str | None) -> str:
+  """Map an entity legal form to its default Reporting Style id."""
+  if not entity_type:
+    return _RS.DEFAULT_STYLE_ID
+  return _ENTITY_TYPE_STYLE.get(entity_type.strip().lower(), _RS.DEFAULT_STYLE_ID)
+
+
+def resolve_reporting_style_id(entity_data: dict[str, Any] | None) -> str:
+  """Resolve the Reporting Style id to pin on a new graph.
+
+  Precedence: an explicit ``reporting_style_id`` on the create request wins;
+  otherwise it's derived from the entity's ``entity_type``; otherwise the
+  corporate Default. ``entity_data`` is the raw create payload dict (read
+  before the tenant schema exists), so this never touches the database.
+  """
+  if not entity_data:
+    return _RS.DEFAULT_STYLE_ID
+  explicit = entity_data.get("reporting_style_id")
+  if explicit:
+    return str(explicit)
+  return default_style_for(entity_data.get("entity_type"))

--- a/robosystems/operations/roboledger/commands/reports.py
+++ b/robosystems/operations/roboledger/commands/reports.py
@@ -48,6 +48,7 @@ from robosystems.operations.roboledger.reports.fact_grid import generate_report_
 from robosystems.operations.roboledger.reports.network_picker import (
   NoNetworkForStatementTypeError,
   get_render_network,
+  load_close_target_concept,
   load_graph_reporting_style,
 )
 from robosystems.utils.ulid import generate_prefixed_ulid
@@ -348,15 +349,22 @@ def create_report(
   session.add(report_def)
   session.flush()
 
+  # Resolve the active Style's earnings home before generating facts, so
+  # derived cumulative earnings close to the form's capital concept
+  # (CORP→RetainedEarnings, PART→PartnersCapital, LLC→MembersEquity) and
+  # the balance sheet foots for non-corporate forms.
+  reporting_style_id = load_graph_reporting_style(graph_id)
+  close_target = load_close_target_concept(session, reporting_style_id)
+
   facts = generate_report_facts(
     session=session,
     taxonomy_id=resolved_taxonomy_id,
     mapping_id=body.mapping_id,
     periods=periods,
+    close_target_qname=close_target,
   )
 
   entity_id = _get_entity_id(session, graph_id)
-  reporting_style_id = load_graph_reporting_style(graph_id)
   element_to_structures, structure_to_factset = _build_structure_mapping(
     session, reporting_style_id
   )
@@ -450,15 +458,18 @@ def regenerate_report(
   report_def.generation_status = "generating"
   session.flush()
 
+  reporting_style_id = load_graph_reporting_style(graph_id)
+  close_target = load_close_target_concept(session, reporting_style_id)
+
   facts = generate_report_facts(
     session=session,
     taxonomy_id=report_def.taxonomy_id,
     mapping_id=report_def.mapping_id or "",
     periods=periods,
+    close_target_qname=close_target,
   )
 
   entity_id = _get_entity_id(session, graph_id)
-  reporting_style_id = load_graph_reporting_style(graph_id)
   element_to_structures, structure_to_factset = _build_structure_mapping(
     session, reporting_style_id
   )

--- a/robosystems/operations/roboledger/reads/reports.py
+++ b/robosystems/operations/roboledger/reads/reports.py
@@ -47,6 +47,9 @@ from robosystems.operations.roboledger.reports.fact_grid import (
   render_structure_view,
 )
 from robosystems.operations.roboledger.reports.guard_rails import validate_report
+from robosystems.operations.roboledger.reports.network_picker import (
+  load_close_target_concept,
+)
 
 VALID_BLOCK_TYPES = {
   "income_statement",
@@ -139,6 +142,7 @@ def generate_adhoc_private_statement(
     taxonomy_id=resolved_taxonomy_id,
     mapping_id=mapping.id,
     periods=periods,
+    close_target_qname=load_close_target_concept(session, reporting_style_id),
   )
 
   grid = render_structure_view(

--- a/robosystems/operations/roboledger/reports/fact_grid.py
+++ b/robosystems/operations/roboledger/reports/fact_grid.py
@@ -107,6 +107,7 @@ def generate_report_facts(
   taxonomy_id: str,
   mapping_id: str,
   periods: list[PeriodSpec],
+  close_target_qname: str = "rs-gaap:RetainedEarningsAccumulatedDeficit",
 ) -> ReportFacts:
   """Generate facts for all mapped elements across N periods.
 
@@ -118,6 +119,12 @@ def generate_report_facts(
       taxonomy_id: Taxonomy identifier (e.g., "tax_usgaap_reporting").
       mapping_id: Structure ID for the CoA→GAAP mapping.
       periods: Ordered list of period specifications.
+      close_target_qname: The equity concept derived cumulative earnings
+          close to — the active Reporting Style's earnings home
+          (``network_picker.load_close_target_concept``). CORP defaults to
+          ``rs-gaap:RetainedEarningsAccumulatedDeficit``; PART/LLC override
+          to ``PartnersCapital`` / ``MembersEquity`` so earnings land in the
+          form's presented capital line and the BS foots.
 
   Returns:
       ReportFacts with all generated facts and metadata.
@@ -153,13 +160,21 @@ def generate_report_facts(
     # equity values. Pre-seeding the empty equity facts gives the close
     # logic a stable target.
     _append_empty_equity_facts(
-      session, mapping_id, facts, period.start, period.end, arc_type=arc_type
+      session,
+      mapping_id,
+      facts,
+      period.start,
+      period.end,
+      arc_type=arc_type,
+      close_target_qname=close_target_qname,
     )
 
     # Close the current period's temporary accounts (revenue/expense)
     # into retained earnings. For periods where real closing entries
     # have already zeroed the rev/exp accounts, this is a no-op (sum=0).
-    _close_to_retained_earnings(facts, period.start, period.end)
+    _close_to_retained_earnings(
+      facts, period.start, period.end, close_target_qname=close_target_qname
+    )
 
     # For balance sheet accuracy: add cumulative prior-period net income
     # to RE. This always runs from inception — real closing entries
@@ -168,7 +183,13 @@ def generate_report_facts(
     # returns only the still-unclosed portion. Adding that to whatever
     # RE balance the ledger already carries is always correct.
     _close_prior_periods_to_retained_earnings(
-      session, mapping_id, facts, period.start, period.end, arc_type=arc_type
+      session,
+      mapping_id,
+      facts,
+      period.start,
+      period.end,
+      arc_type=arc_type,
+      close_target_qname=close_target_qname,
     )
 
   # Emit rs-gaap:NetIncomeLoss facts for each period. The close logic
@@ -714,15 +735,17 @@ def _append_empty_equity_facts(
   period_start: date,
   period_end: date,
   arc_type: str = "mapping",
+  close_target_qname: str = "rs-gaap:RetainedEarningsAccumulatedDeficit",
 ) -> None:
   """Append zero-balance facts for mapped equity targets without postings.
 
   Equity targets are stock concepts (period_type='instant') — they should
   appear on the BS even when their source CoA element has no current
-  postings. The close-to-RE flow specifically needs the RE-shaped target
-  to exist as a fact so `_find_close_target` can route net income to
-  it. Without this, RE silently disappears and net income lands on
-  whatever other equity fact is present (typically APIC).
+  postings. The close-to-RE flow specifically needs the close-target
+  concept to exist as a fact so `_find_close_target` can route net income
+  to it. ``close_target_qname`` is the active Style's earnings home
+  (CORP→RetainedEarnings, PART→PartnersCapital, LLC→MembersEquity); without
+  materializing it the earnings silently disappear from the form's equity.
   """
   result = session.execute(
     text("""
@@ -773,24 +796,25 @@ def _append_empty_equity_facts(
       )
     )
 
-  # Always materialize rs-gaap:RetainedEarningsAccumulatedDeficit at $0
-  # even when no source CoA element maps to it. This is the QuickBooks /
-  # Xero pattern: RE is a *derived* concept, computed from cumulative
-  # (revenue - expense - dividends) at render time, not a posted GL
-  # balance from period-end closing journal entries. Without this, mini
-  # / FAC / simple CoAs that omit an explicit RE concept can't carry
-  # net income onto the BS - `_close_to_retained_earnings` falls back
-  # to an anonymous fact whose element_id isn't in any presentation
-  # network and silently disappears from the rendered statement.
+  # Always materialize the close-target concept at $0 even when no source
+  # CoA element maps to it. This is the QuickBooks / Xero pattern: earnings
+  # are a *derived* concept, computed from cumulative (revenue - expense -
+  # distributions) at render time, not a posted GL balance from period-end
+  # closing journal entries. The target is form-aware (CORP→RetainedEarnings,
+  # PART→PartnersCapital, LLC→MembersEquity). Without this, simple CoAs that
+  # omit an explicit earnings concept can't carry net income onto the BS —
+  # `_close_to_retained_earnings` falls back to an anonymous fact whose
+  # element_id isn't in any presentation network and silently disappears.
   re_row = session.execute(
     text(
       """
       SELECT id, qname, name, balance_type
       FROM elements
-      WHERE qname = 'rs-gaap:RetainedEarningsAccumulatedDeficit'
+      WHERE qname = :close_target
       LIMIT 1
       """
-    )
+    ),
+    {"close_target": close_target_qname},
   ).fetchone()
   if re_row is not None and re_row.id not in existing_ids:
     already_present = any(
@@ -1297,25 +1321,40 @@ def _find_close_target(
   facts: list[ReportFact],
   period_start: date,
   period_end: date,
+  close_target_qname: str = "rs-gaap:RetainedEarningsAccumulatedDeficit",
 ) -> ReportFact | None:
-  """Find the rs-gaap RetainedEarnings fact to receive the closing entry.
+  """Find the equity fact to receive the closing entry.
 
-  Looks for an equity-classified fact whose qname matches
-  ``*RetainedEarnings*`` or ``*RetainedDeficit*`` — under the
-  rs-gaap-anchored architecture the canonical target is
-  ``rs-gaap:RetainedEarningsAccumulatedDeficit``, materialized at $0
-  by :func:`_append_empty_equity_facts` when the source CoA element has
-  no postings. Returns ``None`` if no such fact exists; caller appends
-  a fresh row (defensive fallback for unmapped graphs).
+  Matches the active Reporting Style's single earnings-home concept
+  (``close_target_qname`` — CORP→RetainedEarnings, PART→PartnersCapital,
+  LLC→MembersEquity), materialized at $0 by
+  :func:`_append_empty_equity_facts` when the source CoA element has no
+  postings. Exact-qname match — there is exactly one close target per Style,
+  so form-specific routing (PartnersCapital / MembersEquity) is fully
+  deterministic.
+
+  Only when targeting the corporate default
+  (``rs-gaap:RetainedEarningsAccumulatedDeficit``) does it also accept any
+  ``*RetainedEarnings*`` / ``*RetainedDeficit*`` shape — legacy support for
+  seed.py us-gaap / FAC taxonomies whose RE concept carries a different
+  qname. Non-default (form-specific) targets never widen, so they can't
+  match the wrong concept.
+
+  Returns ``None`` if no such fact exists; caller appends a fresh row
+  (defensive fallback for unmapped graphs).
   """
+  re_default = close_target_qname == "rs-gaap:RetainedEarningsAccumulatedDeficit"
   for fact in facts:
     if fact.period_start != period_start or fact.period_end != period_end:
       continue
     if fact.classification != "equity":
       continue
-    qname_lower = (fact.element_qname or "").lower()
-    if "retainedearnings" in qname_lower or "retaineddeficit" in qname_lower:
+    if fact.element_qname == close_target_qname:
       return fact
+    if re_default:
+      qname_lower = (fact.element_qname or "").lower()
+      if "retainedearnings" in qname_lower or "retaineddeficit" in qname_lower:
+        return fact
 
   return None
 
@@ -1324,15 +1363,17 @@ def _close_to_retained_earnings(
   facts: list[ReportFact],
   period_start: date,
   period_end: date,
+  close_target_qname: str = "rs-gaap:RetainedEarningsAccumulatedDeficit",
 ) -> None:
-  """Close the current period's revenue/expense into retained earnings.
+  """Close the current period's revenue/expense into the earnings home.
 
-  Computes net income = sum(revenue facts) - sum(expense facts) for the
-  given period and adds it to the rs-gaap:RetainedEarningsAccumulatedDeficit
-  fact materialized by :func:`_append_empty_equity_facts`. On
-  unmapped graphs where no RE fact exists, appends a fresh anonymous row
-  with the canonical rs-gaap qname so downstream rendering still has a
-  bottom line.
+  Computes net income = sum(revenue facts) - sum(expense facts) +
+  equity-flow reducers for the given period and adds it to the
+  ``close_target_qname`` fact materialized by
+  :func:`_append_empty_equity_facts` (the active Style's earnings home —
+  CORP→RetainedEarnings, PART→PartnersCapital, LLC→MembersEquity). On
+  unmapped graphs where no target fact exists, appends a fresh anonymous
+  row with that qname so downstream rendering still has a bottom line.
 
   Mutates the facts list in place.
   """
@@ -1362,7 +1403,9 @@ def _close_to_retained_earnings(
   if net_income == 0.0:
     return
 
-  target = _find_close_target(facts, period_start, period_end)
+  target = _find_close_target(
+    facts, period_start, period_end, close_target_qname=close_target_qname
+  )
   if target is not None:
     target.value += net_income
     return
@@ -1374,16 +1417,17 @@ def _close_to_retained_earnings(
   # surfaces this gap to operators; this warning makes it visible at
   # render time too.
   logger.warning(
-    "close_to_retained_earnings: no rs-gaap RE fact in scope for period "
+    "close_to_retained_earnings: no %s fact in scope for period "
     "%s..%s; appending anonymous fallback row. CoA is missing a mapping "
-    "to an equity RetainedEarnings concept.",
+    "to the Style's earnings-home equity concept.",
+    close_target_qname,
     period_start,
     period_end,
   )
   facts.append(
     ReportFact(
       element_id=_ANON_RE_ELEMENT_ID,
-      element_qname="rs-gaap:RetainedEarningsAccumulatedDeficit",
+      element_qname=close_target_qname,
       element_name="Retained Earnings (Accumulated Deficit)",
       classification="equity",
       balance_type="credit",
@@ -1402,6 +1446,7 @@ def _close_prior_periods_to_retained_earnings(
   period_start: date,
   period_end: date,
   arc_type: str = "mapping",
+  close_target_qname: str = "rs-gaap:RetainedEarningsAccumulatedDeficit",
 ) -> None:
   """Close un-closed cumulative net income into retained earnings.
 
@@ -1527,21 +1572,24 @@ def _close_prior_periods_to_retained_earnings(
   if prior_periods_net_income == 0.0:
     return
 
-  target = _find_close_target(facts, period_start, period_end)
+  target = _find_close_target(
+    facts, period_start, period_end, close_target_qname=close_target_qname
+  )
   if target is not None:
     target.value += prior_periods_net_income
   else:
     logger.warning(
-      "close_prior_periods_to_retained_earnings: no rs-gaap RE fact in "
+      "close_prior_periods_to_retained_earnings: no %s fact in "
       "scope for period %s..%s; appending anonymous fallback row. "
-      "CoA is missing a mapping to an equity RetainedEarnings concept.",
+      "CoA is missing a mapping to the Style's earnings-home equity concept.",
+      close_target_qname,
       period_start,
       period_end,
     )
     facts.append(
       ReportFact(
         element_id=_ANON_RE_ELEMENT_ID,
-        element_qname="rs-gaap:RetainedEarningsAccumulatedDeficit",
+        element_qname=close_target_qname,
         element_name="Retained Earnings (Accumulated Deficit)",
         classification="equity",
         balance_type="credit",

--- a/robosystems/operations/roboledger/reports/fact_grid.py
+++ b/robosystems/operations/roboledger/reports/fact_grid.py
@@ -1316,6 +1316,20 @@ def _compute_prior_period(period_start: date, period_end: date) -> tuple[date, d
 # _append_empty_equity_facts before the close runs.
 _ANON_RE_ELEMENT_ID = "elem_rsgaap_retained_earnings_anon"
 
+# Display labels for the form-aware close targets, used on the anonymous
+# fallback row so a partnership/LLC graph doesn't render "Retained Earnings"
+# for what is actually Partners' Capital / Members' Equity. Falls back to the
+# qname for any concept not in the map.
+_CLOSE_TARGET_LABELS = {
+  "rs-gaap:RetainedEarningsAccumulatedDeficit": "Retained Earnings (Accumulated Deficit)",
+  "rs-gaap:PartnersCapital": "Partners' Capital",
+  "rs-gaap:MembersEquity": "Members' Equity",
+}
+
+
+def _close_target_label(qname: str) -> str:
+  return _CLOSE_TARGET_LABELS.get(qname, qname)
+
 
 def _find_close_target(
   facts: list[ReportFact],
@@ -1428,7 +1442,7 @@ def _close_to_retained_earnings(
     ReportFact(
       element_id=_ANON_RE_ELEMENT_ID,
       element_qname=close_target_qname,
-      element_name="Retained Earnings (Accumulated Deficit)",
+      element_name=_close_target_label(close_target_qname),
       classification="equity",
       balance_type="credit",
       value=net_income,

--- a/robosystems/operations/roboledger/reports/network_picker.py
+++ b/robosystems/operations/roboledger/reports/network_picker.py
@@ -117,3 +117,38 @@ def load_graph_reporting_style(graph_id: str) -> str:
     if graph is None:
       raise LookupError(f"Graph {graph_id!r} not found in platform DB.")
     return str(graph.reporting_style_id)
+
+
+# Corporate default — the form whose accumulated earnings get their own
+# named line. Partnership/LLC/etc. Styles override this in their metadata
+# (stamped from the package's ``retainedEarningsConcept`` by migration 0008).
+DEFAULT_CLOSE_TARGET_CONCEPT = "rs-gaap:RetainedEarningsAccumulatedDeficit"
+
+
+def load_close_target_concept(session: Session, reporting_style_id: str) -> str:
+  """The equity concept derived cumulative earnings close to for this Style.
+
+  Each Reporting Style declares exactly one earnings-home concept
+  (``retainedEarningsConcept`` in the package, stamped into
+  ``structures.metadata.retained_earnings_concept`` by migration 0008):
+  CORP→RetainedEarnings, PART→PartnersCapital, LLC→MembersEquity. A single
+  authoritative value per Style — never a runtime scan. Falls back to the
+  corporate default for unstamped/legacy Styles so behavior is unchanged.
+
+  Args:
+      session: Extensions session with the tenant schema active.
+      reporting_style_id: The graph's ``Graph.reporting_style_id``.
+  """
+  row = session.execute(
+    text(
+      """
+      SELECT metadata ->> 'retained_earnings_concept' AS close_target
+      FROM structures
+      WHERE id = :sid
+      """
+    ),
+    {"sid": reporting_style_id},
+  ).fetchone()
+  if row is None or not row.close_target:
+    return DEFAULT_CLOSE_TARGET_CONCEPT
+  return str(row.close_target)

--- a/robosystems/operations/roboledger/reports/network_picker.py
+++ b/robosystems/operations/roboledger/reports/network_picker.py
@@ -139,6 +139,12 @@ def load_close_target_concept(session: Session, reporting_style_id: str) -> str:
       session: Extensions session with the tenant schema active.
       reporting_style_id: The graph's ``Graph.reporting_style_id``.
   """
+  # Read from the tenant's ``structures`` (search_path), NOT ``public`` —
+  # the Style row is mirrored into each tenant with its stamped metadata by
+  # ``copy_library_into_tenant``, and customer-authored Styles live only in
+  # the tenant. This is consistent with how ``get_render_network`` and the
+  # rest of the renderer read; an explicit ``public.`` prefix would miss
+  # tenant-only Styles.
   row = session.execute(
     text(
       """

--- a/tests/config/test_reporting_style_constants.py
+++ b/tests/config/test_reporting_style_constants.py
@@ -23,6 +23,12 @@ _SMALL_PRIVATE_STYLE_ROLE = (
   "https://robosystems.ai/seattle/cm-roles/roles/styles/SmallPrivateCompany"
 )
 _BANKING_STYLE_ROLE = "https://robosystems.ai/seattle/cm-roles/roles/styles/Banking"
+_PARTNERSHIP_STYLE_ROLE = (
+  "https://robosystems.ai/seattle/cm-roles/roles/styles/Partnership"
+)
+_LLC_STYLE_ROLE = (
+  "https://robosystems.ai/seattle/cm-roles/roles/styles/LimitedLiabilityCompany"
+)
 
 
 @pytest.mark.unit
@@ -43,4 +49,16 @@ class TestReportingStyleConstants:
     assert (
       generate_deterministic_uuid(_BANKING_STYLE_ROLE, namespace="structure")
       == ReportingStyleConstants.BANKING_STYLE_ID
+    )
+
+  def test_partnership_style_id_matches_derivation(self) -> None:
+    assert (
+      generate_deterministic_uuid(_PARTNERSHIP_STYLE_ROLE, namespace="structure")
+      == ReportingStyleConstants.PARTNERSHIP_STYLE_ID
+    )
+
+  def test_llc_style_id_matches_derivation(self) -> None:
+    assert (
+      generate_deterministic_uuid(_LLC_STYLE_ROLE, namespace="structure")
+      == ReportingStyleConstants.LLC_STYLE_ID
     )

--- a/tests/operations/graph/test_graph_creation_reporting_style.py
+++ b/tests/operations/graph/test_graph_creation_reporting_style.py
@@ -1,0 +1,120 @@
+"""Wiring tests for entity-driven Reporting Style + entity_type at provision.
+
+Covers the two seams the resolver feeds into:
+- ``_persist_metadata`` resolves the style from the create payload and passes
+  it to ``Graph.create`` (precedence is unit-tested in
+  ``test_reporting_style_defaults``).
+- ``_provision_entity`` persists ``entity_type`` onto the ``LedgerEntity``
+  (previously dropped on the floor).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from robosystems.config.constants import ReportingStyleConstants as RS
+from robosystems.operations.graph.graph_creation_service import (
+  GraphCreationConfig,
+  GraphCreationService,
+)
+
+_SCHEMA_INFO = {
+  "schema_type": "extensions",
+  "schema_ddl": "CREATE ...",
+  "schema_json": {"base": "base", "extensions": ["roboledger"]},
+  "custom_schema_name": None,
+  "custom_schema_version": None,
+}
+
+
+def _config(entity_data: dict | None) -> GraphCreationConfig:
+  return GraphCreationConfig(
+    user_id="u1",
+    tier="ladybug-standard",
+    graph_name="G",
+    graph_type="entity",
+    schema_extensions=["roboledger"],
+    entity_data=entity_data,
+  )
+
+
+class TestPersistMetadataStyleResolution:
+  def _run(self, entity_data: dict | None) -> dict:
+    """Run _persist_metadata with the DB layer mocked; return Graph.create kwargs."""
+    svc = GraphCreationService()
+    location = MagicMock(instance_id="i-123")
+    db = MagicMock()
+
+    with (
+      patch("robosystems.database.get_db_session", return_value=iter([db])),
+      patch("robosystems.models.core.graph.Graph.create") as m_create,
+      patch("robosystems.models.core.GraphSchema.create"),
+      patch("robosystems.operations.graph.table_service.TableService") as m_table,
+    ):
+      m_table.return_value.create_tables_from_schema.return_value = []
+      svc._persist_metadata(
+        "kg1", "org1", location, _config(entity_data), "CREATE ...", _SCHEMA_INFO
+      )
+      assert m_create.called
+      return m_create.call_args.kwargs
+
+  def test_partnership_entity_pins_part_style(self) -> None:
+    assert (
+      self._run({"name": "P", "uri": "https://p.co", "entity_type": "partnership"})[
+        "reporting_style_id"
+      ]
+      == RS.PARTNERSHIP_STYLE_ID
+    )
+
+  def test_llc_entity_pins_llc_style(self) -> None:
+    assert (
+      self._run({"name": "L", "uri": "https://l.co", "entity_type": "llc"})[
+        "reporting_style_id"
+      ]
+      == RS.LLC_STYLE_ID
+    )
+
+  def test_corporation_pins_default_style(self) -> None:
+    assert (
+      self._run({"name": "C", "uri": "https://c.co", "entity_type": "corporation"})[
+        "reporting_style_id"
+      ]
+      == RS.DEFAULT_STYLE_ID
+    )
+
+  def test_explicit_override_wins(self) -> None:
+    assert (
+      self._run(
+        {
+          "name": "C",
+          "uri": "https://c.co",
+          "entity_type": "partnership",
+          "reporting_style_id": "forced-style",
+        }
+      )["reporting_style_id"]
+      == "forced-style"
+    )
+
+  def test_generic_graph_no_entity_data_uses_default(self) -> None:
+    assert self._run(None)["reporting_style_id"] == RS.DEFAULT_STYLE_ID
+
+
+class TestProvisionEntityPersistsType:
+  async def test_entity_type_is_written_to_ledger_entity(self) -> None:
+    svc = GraphCreationService()
+    config = _config(
+      {"name": "Cascade", "uri": "https://x.co", "entity_type": "partnership"}
+    )
+    session = MagicMock()
+    ext_cm = MagicMock()
+    ext_cm.__enter__.return_value = session
+    ext_cm.__exit__.return_value = False
+
+    with (
+      patch("robosystems.db.extensions.provision_tenant_schema") as m_provision,
+      patch("robosystems.db.extensions.extensions_session", return_value=ext_cm),
+      patch("robosystems.models.extensions.entity.Entity") as m_entity,
+    ):
+      await svc._provision_entity("kg1", config)
+      m_provision.assert_called_once_with("kg1")
+      assert m_entity.call_args.kwargs["entity_type"] == "partnership"

--- a/tests/operations/graph/test_reporting_style_defaults.py
+++ b/tests/operations/graph/test_reporting_style_defaults.py
@@ -1,0 +1,70 @@
+"""Unit tests for entity-driven Reporting Style derivation at provision.
+
+``default_style_for`` maps an entity legal form to a seeded Style id;
+``resolve_reporting_style_id`` applies the precedence used in
+``GraphCreationService._persist_metadata`` (explicit override > derived >
+corporate Default). Pure mapping, no DB.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from robosystems.config.constants import ReportingStyleConstants as RS
+from robosystems.operations.graph.reporting_style_defaults import (
+  default_style_for,
+  resolve_reporting_style_id,
+)
+
+
+class TestDefaultStyleFor:
+  @pytest.mark.parametrize(
+    "entity_type,expected",
+    [
+      ("partnership", RS.PARTNERSHIP_STYLE_ID),
+      ("Partnership", RS.PARTNERSHIP_STYLE_ID),
+      ("  PARTNERSHIP  ", RS.PARTNERSHIP_STYLE_ID),
+      ("llc", RS.LLC_STYLE_ID),
+      ("LLC", RS.LLC_STYLE_ID),
+      ("limited_liability_company", RS.LLC_STYLE_ID),
+      ("corporation", RS.DEFAULT_STYLE_ID),
+      ("subsidiary", RS.DEFAULT_STYLE_ID),
+      ("sole_proprietorship", RS.DEFAULT_STYLE_ID),
+      ("non_profit", RS.DEFAULT_STYLE_ID),
+      ("something_unknown", RS.DEFAULT_STYLE_ID),
+      ("", RS.DEFAULT_STYLE_ID),
+      (None, RS.DEFAULT_STYLE_ID),
+    ],
+  )
+  def test_maps_legal_form_to_style(self, entity_type, expected) -> None:
+    assert default_style_for(entity_type) == expected
+
+
+class TestResolveReportingStyleId:
+  def test_none_or_empty_payload_is_corporate_default(self) -> None:
+    assert resolve_reporting_style_id(None) == RS.DEFAULT_STYLE_ID
+    assert resolve_reporting_style_id({}) == RS.DEFAULT_STYLE_ID
+
+  def test_derives_from_entity_type(self) -> None:
+    assert (
+      resolve_reporting_style_id({"entity_type": "partnership"})
+      == RS.PARTNERSHIP_STYLE_ID
+    )
+    assert resolve_reporting_style_id({"entity_type": "llc"}) == RS.LLC_STYLE_ID
+    assert (
+      resolve_reporting_style_id({"entity_type": "corporation"}) == RS.DEFAULT_STYLE_ID
+    )
+
+  def test_explicit_override_beats_derived_default(self) -> None:
+    # An explicit reporting_style_id wins even when entity_type would map
+    # to a different (or the default) style.
+    assert (
+      resolve_reporting_style_id(
+        {"entity_type": "partnership", "reporting_style_id": "custom-style-id"}
+      )
+      == "custom-style-id"
+    )
+    assert (
+      resolve_reporting_style_id({"reporting_style_id": RS.LLC_STYLE_ID})
+      == RS.LLC_STYLE_ID
+    )

--- a/tests/operations/roboledger/reports/test_fact_grid.py
+++ b/tests/operations/roboledger/reports/test_fact_grid.py
@@ -798,6 +798,105 @@ class TestClosePriorPeriodsToRetainedEarnings:
     assert self._get_re_fact(facts).value == -26_000.0
 
 
+class TestFormAwareCloseTarget:
+  """Derived cumulative earnings close to the active Style's earnings-home
+  concept — CORP→RetainedEarnings, PART→PartnersCapital, LLC→MembersEquity.
+  Exactly one target per Style (a single passed qname), matched exactly so
+  the routing is deterministic (no "scan equity, pick first")."""
+
+  PS = date(2026, 1, 1)
+  PE = date(2026, 1, 31)
+
+  def _equity(self, qname: str, value: float = 0.0) -> ReportFact:
+    return ReportFact(
+      element_id=f"elem_{qname}",
+      element_qname=qname,
+      element_name=qname,
+      classification="equity",
+      balance_type="credit",
+      value=value,
+      period_start=self.PS,
+      period_end=self.PE,
+      period_type="instant",
+    )
+
+  def _flow(self, classification: str, value: float) -> ReportFact:
+    return ReportFact(
+      element_id=f"elem_{classification}",
+      element_qname=f"rs-gaap:{classification}",
+      element_name=classification,
+      classification=classification,
+      balance_type="credit" if classification == "revenue" else "debit",
+      value=value,
+      period_start=self.PS,
+      period_end=self.PE,
+      period_type="duration",
+    )
+
+  def test_find_target_matches_passed_qname_not_other_equity(self):
+    facts = [
+      self._equity("rs-gaap:AdditionalPaidInCapital"),
+      self._equity("rs-gaap:PartnersCapital"),
+    ]
+    target = _find_close_target(
+      facts, self.PS, self.PE, close_target_qname="rs-gaap:PartnersCapital"
+    )
+    assert target is not None
+    assert target.element_qname == "rs-gaap:PartnersCapital"
+
+  def test_find_target_defaults_to_retained_earnings(self):
+    facts = [
+      self._equity("rs-gaap:PartnersCapital"),
+      self._equity("rs-gaap:RetainedEarningsAccumulatedDeficit"),
+    ]
+    target = _find_close_target(facts, self.PS, self.PE)
+    assert target is not None
+    assert target.element_qname == "rs-gaap:RetainedEarningsAccumulatedDeficit"
+
+  def test_find_target_none_when_target_absent(self):
+    facts = [self._equity("rs-gaap:AdditionalPaidInCapital")]
+    assert (
+      _find_close_target(
+        facts, self.PS, self.PE, close_target_qname="rs-gaap:PartnersCapital"
+      )
+      is None
+    )
+
+  def test_close_routes_net_income_to_partners_capital(self):
+    # Partnership: 49,800 contributed capital + 28,387 NI → 78,187 (the
+    # exact figures from the live partnership demo that previously didn't foot).
+    facts = [
+      self._equity("rs-gaap:PartnersCapital", 49_800.0),
+      self._flow("revenue", 175_000.0),
+      self._flow("expense", 146_613.0),
+    ]
+    _close_to_retained_earnings(
+      facts, self.PS, self.PE, close_target_qname="rs-gaap:PartnersCapital"
+    )
+    pc = next(f for f in facts if f.element_qname == "rs-gaap:PartnersCapital")
+    assert pc.value == 78_187.0
+
+  def test_close_defaults_route_to_retained_earnings(self):
+    facts = [
+      self._equity("rs-gaap:RetainedEarningsAccumulatedDeficit", 0.0),
+      self._flow("revenue", 100.0),
+      self._flow("expense", 40.0),
+    ]
+    _close_to_retained_earnings(facts, self.PS, self.PE)
+    re = next(f for f in facts if "RetainedEarnings" in f.element_qname)
+    assert re.value == 60.0
+
+  def test_close_fallback_row_uses_target_qname(self):
+    # No materialized target fact → anonymous fallback carries the form's qname.
+    facts = [self._flow("revenue", 100.0), self._flow("expense", 40.0)]
+    _close_to_retained_earnings(
+      facts, self.PS, self.PE, close_target_qname="rs-gaap:MembersEquity"
+    )
+    appended = next(f for f in facts if f.classification == "equity")
+    assert appended.element_qname == "rs-gaap:MembersEquity"
+    assert appended.value == 60.0
+
+
 class TestInferClassification:
   """Qname/balance_type fallback for elements without FASB traits.
 

--- a/tests/operations/roboledger/reports/test_fact_grid.py
+++ b/tests/operations/roboledger/reports/test_fact_grid.py
@@ -886,14 +886,17 @@ class TestFormAwareCloseTarget:
     re = next(f for f in facts if "RetainedEarnings" in f.element_qname)
     assert re.value == 60.0
 
-  def test_close_fallback_row_uses_target_qname(self):
-    # No materialized target fact → anonymous fallback carries the form's qname.
+  def test_close_fallback_row_uses_target_qname_and_label(self):
+    # No materialized target fact → anonymous fallback carries the form's
+    # qname AND a form-appropriate label (not the corporate "Retained
+    # Earnings" string).
     facts = [self._flow("revenue", 100.0), self._flow("expense", 40.0)]
     _close_to_retained_earnings(
       facts, self.PS, self.PE, close_target_qname="rs-gaap:MembersEquity"
     )
     appended = next(f for f in facts if f.classification == "equity")
     assert appended.element_qname == "rs-gaap:MembersEquity"
+    assert appended.element_name == "Members' Equity"
     assert appended.value == 60.0
 
 

--- a/tests/taxonomy/test_reporting_style_seeder_shape.py
+++ b/tests/taxonomy/test_reporting_style_seeder_shape.py
@@ -21,6 +21,8 @@ from __future__ import annotations
 import importlib.util as _util
 from pathlib import Path
 
+import pytest
+
 _MIGRATION_PATH = (
   Path(__file__).resolve().parents[2]
   / "migrations"
@@ -53,9 +55,14 @@ class _Conn:
 
 
 class TestDeclaredStyles:
-  def test_exactly_the_two_composed_presets(self) -> None:
+  def test_exactly_the_four_composed_presets(self) -> None:
     codes = {s["code"] for s in mig_0008._declared_styles()}
-    assert codes == {"BSC-CORP-IS02-CF1", "BSC-CORP-IS01-CF1"}
+    assert codes == {
+      "BSC-CORP-IS02-CF1",
+      "BSC-CORP-IS01-CF1",
+      "BSC-PART-IS02-CF1",
+      "BSC-LLC-IS02-CF1",
+    }
 
   def test_every_declared_style_has_complete_composition(self) -> None:
     """The change-reporting-style validator rejects an incomplete
@@ -64,17 +71,38 @@ class TestDeclaredStyles:
       stmt_types = {st for st, _net in style["networks"]}
       assert stmt_types == _REQUIRED, style["code"]
 
-  def test_is_axis_distinguishes_the_two_presets(self) -> None:
-    """The whole point of the proof slice: IS02 → multi-step network,
-    IS01 → single-step network. Everything else is shared."""
+  def test_is_axis_distinguishes_the_single_vs_multistep_presets(self) -> None:
+    """IS02 → multi-step network, IS01 → single-step network. Everything
+    else is shared between the two corporate presets."""
     by_code = {s["code"]: dict(s["networks"]) for s in mig_0008._declared_styles()}
     assert by_code["BSC-CORP-IS02-CF1"]["income_statement"].endswith("IS-multistep")
     assert by_code["BSC-CORP-IS01-CF1"]["income_statement"].endswith("IS-singlestep")
-    # BS / CF / SE are identical across the two presets.
+    # BS / CF / SE are identical across the two corporate presets.
     for stmt in ("balance_sheet", "cash_flow_statement", "equity_statement"):
       assert by_code["BSC-CORP-IS02-CF1"][stmt] == by_code["BSC-CORP-IS01-CF1"][stmt], (
         stmt
       )
+
+  def test_equity_form_axis_is_the_only_difference_corp_part_llc(self) -> None:
+    """CORP/PART/LLC share IS-multistep + CashFlow-indirect; only the
+    balance_sheet equity section and the equity_statement rollforward vary
+    by form (the equity-form axis)."""
+    by_code = {s["code"]: dict(s["networks"]) for s in mig_0008._declared_styles()}
+    corp = by_code["BSC-CORP-IS02-CF1"]
+    part = by_code["BSC-PART-IS02-CF1"]
+    llc = by_code["BSC-LLC-IS02-CF1"]
+
+    # IS + CF are held constant across the three forms.
+    for stmt in ("income_statement", "cash_flow_statement"):
+      assert corp[stmt] == part[stmt] == llc[stmt], stmt
+
+    # Equity-form axis: BS + equity_statement networks are form-specific.
+    assert corp["balance_sheet"].endswith("BS-classified")
+    assert part["balance_sheet"].endswith("BS-classified-PART")
+    assert llc["balance_sheet"].endswith("BS-classified-LLC")
+    assert corp["equity_statement"].endswith("Equity-rollforward")
+    assert part["equity_statement"].endswith("Equity-rollforward-PART")
+    assert llc["equity_statement"].endswith("Equity-rollforward-LLC")
 
   def test_placeholder_skipped_but_still_promoted(self) -> None:
     """Banking declares no composition — skipped by the seeder (stays
@@ -90,8 +118,8 @@ class TestSeedComposition:
   def test_seeds_one_row_per_statement_per_style(self) -> None:
     conn = _Conn()
     mig_0008._seed_style_compositions(conn, "public")
-    # 2 composed presets, 4 statement types each.
-    assert len(conn.calls) == 8
+    # 4 composed presets, 4 statement types each.
+    assert len(conn.calls) == 16
     for sql, params in conn.calls:
       assert "public.reporting_style_networks" in sql
       assert set(params) >= {"style", "stmt", "network"}
@@ -119,4 +147,62 @@ class TestStampStyleCodes:
     conn = _Conn()
     mig_0008._stamp_style_codes(conn)
     stamped = {params["code"] for _sql, params in conn.calls}
-    assert stamped == {"BSC-CORP-IS02-CF1", "BSC-CORP-IS01-CF1"}
+    assert stamped == {
+      "BSC-CORP-IS02-CF1",
+      "BSC-CORP-IS01-CF1",
+      "BSC-PART-IS02-CF1",
+      "BSC-LLC-IS02-CF1",
+    }
+
+
+class _Result:
+  def __init__(self, row) -> None:
+    self._row = row
+
+  def fetchone(self):
+    return self._row
+
+
+class _ValidatingConn:
+  """Fake conn for _stamp_close_targets: answers the present-in-BS SELECT
+  with a configurable hit/miss, captures the UPDATEs."""
+
+  def __init__(self, present: bool) -> None:
+    self.present = present
+    self.updates: list[tuple[str, dict]] = []
+
+  def execute(self, stmt, params=None):
+    sql = str(stmt)
+    if "associations" in sql:  # the present-in-BS validation SELECT
+      return _Result((1,) if self.present else None)
+    self.updates.append((sql, params or {}))
+    return _Result(None)
+
+
+class TestCloseTargets:
+  def test_declared_styles_carry_form_close_target(self) -> None:
+    by_code = {s["code"]: s["close_target"] for s in mig_0008._declared_styles()}
+    assert by_code["BSC-CORP-IS02-CF1"] == "rs-gaap:RetainedEarningsAccumulatedDeficit"
+    assert by_code["BSC-CORP-IS01-CF1"] == "rs-gaap:RetainedEarningsAccumulatedDeficit"
+    assert by_code["BSC-PART-IS02-CF1"] == "rs-gaap:PartnersCapital"
+    assert by_code["BSC-LLC-IS02-CF1"] == "rs-gaap:MembersEquity"
+
+  def test_stamps_every_close_target_when_present_in_bs(self) -> None:
+    conn = _ValidatingConn(present=True)
+    mig_0008._stamp_close_targets(conn)
+    stamped = {params["target"] for _sql, params in conn.updates}
+    assert stamped == {
+      "rs-gaap:RetainedEarningsAccumulatedDeficit",
+      "rs-gaap:PartnersCapital",
+      "rs-gaap:MembersEquity",
+    }
+    for sql, params in conn.updates:
+      assert "retained_earnings_concept" in sql
+      assert set(params) == {"sid", "target"}
+
+  def test_raises_when_close_target_absent_from_bs(self) -> None:
+    """The determinism guard: a declared earnings concept the BS doesn't
+    present would silently drop earnings — must fail the migration."""
+    conn = _ValidatingConn(present=False)
+    with pytest.raises(RuntimeError, match="does not"):
+      mig_0008._stamp_close_targets(conn)

--- a/tests/taxonomy/test_rs_gaap_presentation_equity.py
+++ b/tests/taxonomy/test_rs_gaap_presentation_equity.py
@@ -70,3 +70,76 @@ class TestEquityPresentationStructure:
     }
     missing = required - activity_targets
     assert not missing, f"rollforward missing activity arcs to: {missing}"
+
+
+_PRES = "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation"
+
+
+def _bs_equity_children(pkg: TaxonomyPackage, role: str) -> set[str]:
+  """Concepts presented under StockholdersEquity for a given BS role."""
+  return {
+    a.to_qname
+    for a in pkg.associations
+    if a.role == role and a.from_qname == "rs-gaap:StockholdersEquity"
+  }
+
+
+class TestEquityFormVariants:
+  """Phase 4 equity-form axis: CORP balance sheet trimmed to corporate
+  equity; dedicated PART/LLC balance-sheet + Statement-of-Changes
+  structures present the form-appropriate capital concept."""
+
+  def test_corp_bs_equity_dropped_partners_and_members(
+    self, presentation: TaxonomyPackage
+  ) -> None:
+    children = _bs_equity_children(presentation, f"{_PRES}/BS-classified")
+    assert "rs-gaap:PartnersCapital" not in children
+    assert "rs-gaap:MembersEquity" not in children
+    # corporate stack still present
+    assert "rs-gaap:CommonStockValue" in children
+    assert "rs-gaap:RetainedEarningsAccumulatedDeficit" in children
+
+  def test_partnership_bs_presents_partners_capital(
+    self, presentation: TaxonomyPackage
+  ) -> None:
+    roles = {s.role_uri for s in presentation.structures}
+    assert f"{_PRES}/BS-classified-PART" in roles
+    children = _bs_equity_children(presentation, f"{_PRES}/BS-classified-PART")
+    assert children == {"rs-gaap:PartnersCapital"}
+
+  def test_llc_bs_presents_members_equity(self, presentation: TaxonomyPackage) -> None:
+    roles = {s.role_uri for s in presentation.structures}
+    assert f"{_PRES}/BS-classified-LLC" in roles
+    children = _bs_equity_children(presentation, f"{_PRES}/BS-classified-LLC")
+    assert children == {"rs-gaap:MembersEquity"}
+
+  def test_part_llc_bs_clone_full_asset_liability_section(
+    self, presentation: TaxonomyPackage
+  ) -> None:
+    """The form-specific balance sheets are full statements — they clone
+    the corporate asset/liability arcs, only the equity section differs."""
+    corp_non_eq = {
+      (a.from_qname, a.to_qname)
+      for a in presentation.associations
+      if a.role == f"{_PRES}/BS-classified"
+      and a.from_qname != "rs-gaap:StockholdersEquity"
+    }
+    for role in (f"{_PRES}/BS-classified-PART", f"{_PRES}/BS-classified-LLC"):
+      form_non_eq = {
+        (a.from_qname, a.to_qname)
+        for a in presentation.associations
+        if a.role == role and a.from_qname != "rs-gaap:StockholdersEquity"
+      }
+      assert form_non_eq == corp_non_eq, role
+
+  def test_rollforwards_root_at_form_capital_concept(
+    self, presentation: TaxonomyPackage
+  ) -> None:
+    for role, hub in (
+      (f"{_PRES}/Equity-rollforward-PART", "rs-gaap:PartnersCapital"),
+      (f"{_PRES}/Equity-rollforward-LLC", "rs-gaap:MembersEquity"),
+    ):
+      froms = {a.from_qname for a in presentation.associations if a.role == role}
+      assert froms == {hub}, role
+      targets = {a.to_qname for a in presentation.associations if a.role == role}
+      assert "rs-gaap:NetIncomeLoss" in targets


### PR DESCRIPTION
## Summary

This PR introduces comprehensive enhancements to reporting style resolution, equity form presentation, and entity handling throughout the graph creation and reporting pipelines. It extends the RS-GAAP taxonomy with equity-related presentation concepts, adds default reporting style assignment during graph creation, and refactors the fact grid reporting logic to support richer style-aware rendering.

## Key Accomplishments

### Taxonomy & Framework Extensions
- **Expanded RS-GAAP presentation taxonomy** with extensive equity-related concepts (565+ lines of new taxonomy definitions), enabling structured equity statement reporting
- **Extended reporting styles taxonomy** with new style definitions to support equity form presentation
- **Updated the reporting style migration** (`0008_reporting_style`) with richer seeding logic to handle new reporting style shapes and relationships

### Reporting Style Defaults & Graph Creation
- **Added `reporting_style_defaults.py` module** that encapsulates logic for assigning default reporting styles to newly created entity graphs
- **Integrated reporting style defaults into `graph_creation_service`**, ensuring entities are provisioned with appropriate reporting styles at creation time
- **Extended core graph and API models** (`entity_graph.py`, `graphs/core.py`, `graph.py`) with new fields/methods to support reporting style associations

### Fact Grid & Report Rendering
- **Refactored `fact_grid.py`** with significant logic improvements (~136 lines changed) to support style-aware fact grid construction, improving how financial data is organized and presented based on reporting styles
- **Enhanced `network_picker.py`** with additional selection logic for style-driven network resolution
- **Updated report commands and reads** to thread reporting style context through the reporting pipeline

### Configuration
- **Added new reporting style constants** to `config/constants.py` for centralized reference across the codebase

### Demo Updates
- **Substantially updated `roboledger_demo`** main script and mappings to demonstrate equity form reporting capabilities with revised entity mappings
- Minor fix in `seattle_method_demo` for consistency

## Breaking Changes

- **Graph creation API**: Entity graphs now expect/include reporting style context. Consumers of `graph_creation_service` or the graph API models may need to accommodate new fields.
- **Migration `0008_reporting_style`**: Contains structural changes to the reporting style seeder — environments must run this migration to pick up the new taxonomy shapes.
- **Fact grid interface**: The refactored `fact_grid.py` may change the shape of outputs for downstream consumers relying on the previous grid structure.

## Testing

- **New test suites added:**
  - `test_graph_creation_reporting_style.py` — validates reporting style assignment during graph creation (120 lines)
  - `test_reporting_style_defaults.py` — unit tests for the new defaults module (70 lines)
  - `test_fact_grid.py` — expanded coverage for style-aware fact grid behavior (99 new lines)
  - `test_rs_gaap_presentation_equity.py` — validates equity presentation taxonomy structure (73 lines)
- **Extended existing tests:**
  - `test_reporting_style_seeder_shape.py` — significantly expanded to cover new seeder shapes (104+ lines added)
  - `test_reporting_style_constants.py` — covers new constant definitions

All new and modified tests should be run to validate the full reporting style and equity form pipeline.

## Infrastructure Considerations

- **Database migration required**: The updated reporting style migration must be applied before deploying this change to ensure taxonomy data is consistent.
- **Taxonomy package deployment**: The updated RS-GAAP presentation and reporting styles taxonomy packages need to be available in the framework resolution path.
- **Backward compatibility**: Existing graphs without reporting styles will need a backfill strategy or graceful fallback handling (verify defaults module behavior for pre-existing entities).

---
🤖 Generated with [Claude Code](https://claude.ai/code)

**Branch Info:**
- Source: `feature/equity-form`
- Target: `main`
- Type: feature

Co-Authored-By: Claude <noreply@anthropic.com>