### PR TITLE
Add rollup rule evaluation and subtotal fact emission for rs-gaap

### DIFF
--- a/frameworks/fac/packages/fac-rules/v1/taxonomy.jsonld
+++ b/frameworks/fac/packages/fac-rules/v1/taxonomy.jsonld
@@ -1,10 +1,6 @@
 {
   "@context": {
-    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
-    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
-    "xsd": "http://www.w3.org/2001/XMLSchema#",
-    "fac": "http://www.xbrlsite.com/fac#",
-    "sfac6": "http://xbrlsite.com/seattlemethod/sfac6#",
+    "rs-gaap": "https://robosystems.ai/taxonomy/rs-gaap/v1/",
     "rs": "https://robosystems.ai/vocab/",
     "ruleCategory": {
       "@id": "https://robosystems.ai/vocab/ruleCategory"
@@ -22,8 +18,7 @@
       "@id": "https://robosystems.ai/vocab/targetKind"
     },
     "targetRef": {
-      "@id": "https://robosystems.ai/vocab/targetRef",
-      "@type": "@id"
+      "@id": "https://robosystems.ai/vocab/targetRef"
     },
     "ruleVariables": {
       "@id": "https://robosystems.ai/vocab/ruleVariables",
@@ -43,9 +38,7 @@
     },
     "ruleOrigin": {
       "@id": "https://robosystems.ai/vocab/ruleOrigin"
-    },
-    "label": "rdfs:label",
-    "documentation": "rdfs:comment"
+    }
   },
   "standard": "fac-rules",
   "version": "v1",
@@ -54,359 +47,88 @@
   "default_block_type": "validation_rules",
   "forked_from": {
     "author": "Charlie Hoffman",
-    "url": "http://xbrlsite.com/seattlemethod/cm/cm.xsd",
-    "format": "XBRL Formula + Disclosure Mechanics linkbases (Seattle Method conceptual model)"
+    "url": "https://github.com/seattlemethod/proof (fac/rules-consistency)",
+    "format": "XBRL Formula Value Assertions (Seattle Method)"
   },
-  "forked_at": "2026-04-21",
+  "forked_at": "2026-05-21",
   "upstream_tracking": "frozen",
-  "description": "Seattle Method verification rules — 14 rules harvested from Charlie Hoffman's XBRL Formula and Disclosure Mechanics linkbases at local/taxonomies/seattle_method_full/. v1 rules (7) carried forward verbatim. v2 additions (formula): sfac6-rule-is-identity (IS01 single-step income identity), sfac6-rule-cna-identity (CNA01 not-for-profit identity). v2 additions (disclosure mechanics): sfac6-rule-{bs-requires-liabilities, bs-requires-equity, ci-requires-ci-concept, ci-requires-revenues, ce-requires-equity}. Rules using sfac6: qnames (Revenues, Expenses, Gains, Losses, ComprehensiveIncome, ChangeInNetAssets) evaluate to 'skipped' until sfac6 elements are added to the element seed — the rules are correct, the binding returns None. Skipped rule families: SE01/SHE01 rollforward (period-specific variable binding, both EquityBalanceStart and EquityBalanceEnd map to the same qname at different periods — engine would bind both to the same fact giving an incorrect result); sfac6-formula-arithmetic-other (multi-period cross-statement identity, requires temporal-aware fact selection). Re-run this harvester (local/scripts/harvest_fac_rules.py) to regenerate.",
+  "description": "L1 cross-tree consistency identities harvested from Charlie Hoffman's PROOF fac/rules-consistency and rewritten to rs-gaap subtotal concepts (info-block \u00a76.1 Package II.a). EqualTo rules, element-scoped to the LHS subtotal so they fire against any rendered statement presenting it. Only the genuine cross-tree identities are kept (BS0 Assets=L+E, BS01 Assets=LiabilitiesAndEquity, IS04 CI=NI+OCI); rollup-shaped Consistency rules (BS02/03/04, CF01) are covered by the rs-gaap-rollup-rules L2 package, and FAC/SFAC6-aggregate rules (BS06 NetAssets, IS02, IS03) have no rs-gaap subtotal target. Regenerate via local/scripts/harvest_proof_rules.py.",
   "@graph": [
     {
-      "@id": "_:fac-rule-bs-identity",
+      "@id": "_:rs-gaap-rule-bs-identity",
       "ruleCategory": "FundamentalAccountingConceptRelation",
       "rulePattern": "EqualTo",
       "ruleExpression": "$Assets = ($Liabilities + $Equity)",
       "ruleTarget": {
-        "targetKind": "structure",
-        "targetRef": {
-          "@id": "http://www.xbrlsite.com/seattlemethod/conceptual-model/cm-roles/roles/fac-calculations/BS2"
-        }
+        "targetKind": "element",
+        "targetRef": "rs-gaap:Assets"
       },
       "ruleVariables": [
         {
           "variableName": "Assets",
-          "variableQname": "fac:Assets"
+          "variableQname": "rs-gaap:Assets"
         },
         {
           "variableName": "Liabilities",
-          "variableQname": "fac:Liabilities"
+          "variableQname": "rs-gaap:Liabilities"
         },
         {
           "variableName": "Equity",
-          "variableQname": "fac:Equity"
+          "variableQname": "rs-gaap:StockholdersEquity"
         }
       ],
-      "ruleMessage": "Balance Sheet identity: Assets must equal Liabilities plus Equity.",
+      "ruleMessage": "Balance Sheet identity: total Assets must equal Liabilities plus Equity.",
+      "ruleSeverity": "error",
       "ruleOrigin": "forked"
     },
     {
-      "@id": "_:fac-rule-gross-profit",
+      "@id": "_:rs-gaap-rule-bs-balances",
       "ruleCategory": "FundamentalAccountingConceptRelation",
       "rulePattern": "EqualTo",
-      "ruleExpression": "$GrossProfit = ($Revenues - $CostOfRevenue)",
+      "ruleExpression": "$Assets = $LiabilitiesAndEquity",
       "ruleTarget": {
-        "targetKind": "structure",
-        "targetRef": {
-          "@id": "http://www.xbrlsite.com/seattlemethod/conceptual-model/cm-roles/roles/fac-calculations/IS1"
-        }
-      },
-      "ruleVariables": [
-        {
-          "variableName": "GrossProfit",
-          "variableQname": "fac:GrossProfit"
-        },
-        {
-          "variableName": "Revenues",
-          "variableQname": "fac:Revenues"
-        },
-        {
-          "variableName": "CostOfRevenue",
-          "variableQname": "fac:CostOfRevenue"
-        }
-      ],
-      "ruleMessage": "Income Statement consistency: Gross Profit must equal Revenues minus Cost of Revenue.",
-      "ruleOrigin": "forked"
-    },
-    {
-      "@id": "_:fac-rule-equity-rollforward",
-      "ruleCategory": "FundamentalAccountingConceptRelation",
-      "rulePattern": "RollForward",
-      "ruleExpression": "$EquityBegin + $ComprehensiveIncome = $EquityEnd",
-      "ruleTarget": {
-        "targetKind": "structure",
-        "targetRef": {
-          "@id": "http://www.xbrlsite.com/seattlemethod/conceptual-model/cm-roles/roles/fac-presentation/ComprehensiveIncome-breakdown"
-        }
-      },
-      "ruleVariables": [
-        {
-          "variableName": "EquityBegin",
-          "variableQname": "fac:Equity"
-        },
-        {
-          "variableName": "ComprehensiveIncome",
-          "variableQname": "fac:ComprehensiveIncomeLoss"
-        },
-        {
-          "variableName": "EquityEnd",
-          "variableQname": "fac:Equity"
-        }
-      ],
-      "ruleMessage": "Equity rollforward: ending Equity must equal beginning Equity plus Comprehensive Income (simplified SE01 — full rollforward with investments and distributions lands when those concepts are seeded).",
-      "ruleOrigin": "forked"
-    },
-    {
-      "@id": "_:fac-rule-assets-decomposition",
-      "ruleCategory": "FundamentalAccountingConceptRelation",
-      "rulePattern": "RollUp",
-      "ruleExpression": "$Assets = ($CurrentAssets + $NoncurrentAssets)",
-      "ruleTarget": {
-        "targetKind": "structure",
-        "targetRef": {
-          "@id": "http://www.xbrlsite.com/seattlemethod/conceptual-model/cm-roles/roles/fac-calculations/BS3"
-        }
+        "targetKind": "element",
+        "targetRef": "rs-gaap:Assets"
       },
       "ruleVariables": [
         {
           "variableName": "Assets",
-          "variableQname": "fac:Assets"
+          "variableQname": "rs-gaap:Assets"
         },
         {
-          "variableName": "CurrentAssets",
-          "variableQname": "fac:CurrentAssets"
-        },
-        {
-          "variableName": "NoncurrentAssets",
-          "variableQname": "fac:NoncurrentAssets"
+          "variableName": "LiabilitiesAndEquity",
+          "variableQname": "rs-gaap:LiabilitiesAndStockholdersEquity"
         }
       ],
-      "ruleMessage": "Classified Balance Sheet: total Assets must roll up from Current Assets plus Noncurrent Assets.",
+      "ruleMessage": "Balance Sheet balances: total Assets must equal total Liabilities and Equity.",
+      "ruleSeverity": "error",
       "ruleOrigin": "forked"
     },
     {
-      "@id": "_:fac-rule-report-requires-bs",
-      "ruleCategory": "ReportLevelModelStructureRule",
-      "rulePattern": "Exists",
-      "ruleExpression": "exists($BalanceSheet)",
-      "ruleTarget": {
-        "targetKind": "structure",
-        "targetRef": {
-          "@id": "http://www.xbrlsite.com/seattlemethod/conceptual-model/cm-roles/roles/fac-presentation/BS-classified"
-        }
-      },
-      "ruleVariables": [
-        {
-          "variableName": "BalanceSheet",
-          "variableQname": "fac:Assets"
-        }
-      ],
-      "ruleMessage": "Financial report must include a Balance Sheet disclosure.",
-      "ruleOrigin": "forked"
-    },
-    {
-      "@id": "_:fac-rule-is-requires-ci",
-      "ruleCategory": "ReportLevelModelStructureRule",
-      "rulePattern": "CoExists",
-      "ruleExpression": "exists($IncomeStatement) implies exists($ComprehensiveIncome)",
-      "ruleTarget": {
-        "targetKind": "structure",
-        "targetRef": {
-          "@id": "http://www.xbrlsite.com/seattlemethod/conceptual-model/cm-roles/roles/fac-presentation/ComprehensiveIncome"
-        }
-      },
-      "ruleVariables": [
-        {
-          "variableName": "IncomeStatement",
-          "variableQname": "fac:NetIncomeLoss"
-        },
-        {
-          "variableName": "ComprehensiveIncome",
-          "variableQname": "fac:ComprehensiveIncomeLoss"
-        }
-      ],
-      "ruleMessage": "If an Income Statement is reported, a Statement of Comprehensive Income is required.",
-      "ruleOrigin": "forked"
-    },
-    {
-      "@id": "_:fac-rule-bs-requires-assets",
-      "ruleCategory": "ReportLevelModelStructureRule",
-      "rulePattern": "Exists",
-      "ruleExpression": "exists($Assets)",
-      "ruleTarget": {
-        "targetKind": "structure",
-        "targetRef": {
-          "@id": "http://www.xbrlsite.com/seattlemethod/conceptual-model/cm-roles/roles/fac-presentation/BS-classified"
-        }
-      },
-      "ruleVariables": [
-        {
-          "variableName": "Assets",
-          "variableQname": "fac:Assets"
-        }
-      ],
-      "ruleMessage": "Balance Sheet must report a top-level Assets concept.",
-      "ruleOrigin": "forked"
-    },
-    {
-      "@id": "_:sfac6-rule-is-identity",
+      "@id": "_:rs-gaap-rule-ci-identity",
       "ruleCategory": "FundamentalAccountingConceptRelation",
       "rulePattern": "EqualTo",
-      "ruleExpression": "$ComprehensiveIncome = ($Revenues - $Expenses + $Gains - $Losses)",
+      "ruleExpression": "$ComprehensiveIncomeLoss = ($NetIncomeLoss + $OtherComprehensiveIncome)",
       "ruleTarget": {
-        "targetKind": "structure",
-        "targetRef": {
-          "@id": "http://www.xbrlsite.com/seattlemethod/conceptual-model/cm-roles/roles/fac-presentation/ComprehensiveIncome"
-        }
+        "targetKind": "element",
+        "targetRef": "rs-gaap:ComprehensiveIncomeNetOfTax"
       },
       "ruleVariables": [
         {
-          "variableName": "ComprehensiveIncome",
-          "variableQname": "sfac6:ComprehensiveIncome"
+          "variableName": "ComprehensiveIncomeLoss",
+          "variableQname": "rs-gaap:ComprehensiveIncomeNetOfTax"
         },
         {
-          "variableName": "Expenses",
-          "variableQname": "sfac6:Expenses"
+          "variableName": "NetIncomeLoss",
+          "variableQname": "rs-gaap:NetIncomeLoss"
         },
         {
-          "variableName": "Gains",
-          "variableQname": "sfac6:Gains"
-        },
-        {
-          "variableName": "Losses",
-          "variableQname": "sfac6:Losses"
-        },
-        {
-          "variableName": "Revenues",
-          "variableQname": "sfac6:Revenues"
+          "variableName": "OtherComprehensiveIncome",
+          "variableQname": "rs-gaap:OtherComprehensiveIncomeLossNetOfTax"
         }
       ],
-      "ruleMessage": "Income Statement single-step identity: Comprehensive Income must equal Revenues minus Expenses plus Gains minus Losses. Source: sfac6-formula-consistency-IS01.xml (Arithmetic_IS01). Uses sfac6: qnames — evaluates once sfac6 elements are seeded.",
-      "ruleOrigin": "forked"
-    },
-    {
-      "@id": "_:sfac6-rule-cna-identity",
-      "ruleCategory": "FundamentalAccountingConceptRelation",
-      "rulePattern": "EqualTo",
-      "ruleExpression": "$ChangeInNetAssets = ($Revenues - $Expenses + $Gains - $Losses)",
-      "ruleTarget": {
-        "targetKind": "structure",
-        "targetRef": {
-          "@id": "http://www.xbrlsite.com/seattlemethod/conceptual-model/cm-roles/roles/fac-presentation/ComprehensiveIncome"
-        }
-      },
-      "ruleVariables": [
-        {
-          "variableName": "ChangeInNetAssets",
-          "variableQname": "sfac6:ChangeInNetAssets"
-        },
-        {
-          "variableName": "Expenses",
-          "variableQname": "sfac6:Expenses"
-        },
-        {
-          "variableName": "Gains",
-          "variableQname": "sfac6:Gains"
-        },
-        {
-          "variableName": "Losses",
-          "variableQname": "sfac6:Losses"
-        },
-        {
-          "variableName": "Revenues",
-          "variableQname": "sfac6:Revenues"
-        }
-      ],
-      "ruleMessage": "Not-for-profit identity: Change in Net Assets must equal Revenues minus Expenses plus Gains minus Losses. Source: sfac6-formula-consistency-CNA01.xml (Arithmetic_CNA01). Uses sfac6: qnames — evaluates once sfac6 elements are seeded.",
-      "ruleOrigin": "forked"
-    },
-    {
-      "@id": "_:sfac6-rule-bs-requires-liabilities",
-      "ruleCategory": "DisclosureMechanicsRule",
-      "rulePattern": "Exists",
-      "ruleExpression": "exists($Liabilities)",
-      "ruleTarget": {
-        "targetKind": "structure",
-        "targetRef": {
-          "@id": "http://www.xbrlsite.com/seattlemethod/conceptual-model/cm-roles/roles/fac-presentation/BS-classified"
-        }
-      },
-      "ruleVariables": [
-        {
-          "variableName": "Liabilities",
-          "variableQname": "fac:Liabilities"
-        }
-      ],
-      "ruleMessage": "Balance Sheet must report a top-level Liabilities concept. Source: dm-BalanceSheet-rules-def.xml.",
-      "ruleOrigin": "forked"
-    },
-    {
-      "@id": "_:sfac6-rule-bs-requires-equity",
-      "ruleCategory": "DisclosureMechanicsRule",
-      "rulePattern": "Exists",
-      "ruleExpression": "exists($Equity)",
-      "ruleTarget": {
-        "targetKind": "structure",
-        "targetRef": {
-          "@id": "http://www.xbrlsite.com/seattlemethod/conceptual-model/cm-roles/roles/fac-presentation/BS-classified"
-        }
-      },
-      "ruleVariables": [
-        {
-          "variableName": "Equity",
-          "variableQname": "fac:Equity"
-        }
-      ],
-      "ruleMessage": "Balance Sheet must report a top-level Equity concept. Source: dm-BalanceSheet-rules-def.xml.",
-      "ruleOrigin": "forked"
-    },
-    {
-      "@id": "_:sfac6-rule-ci-requires-ci-concept",
-      "ruleCategory": "DisclosureMechanicsRule",
-      "rulePattern": "Exists",
-      "ruleExpression": "exists($ComprehensiveIncome)",
-      "ruleTarget": {
-        "targetKind": "structure",
-        "targetRef": {
-          "@id": "http://www.xbrlsite.com/seattlemethod/conceptual-model/cm-roles/roles/fac-presentation/ComprehensiveIncome"
-        }
-      },
-      "ruleVariables": [
-        {
-          "variableName": "ComprehensiveIncome",
-          "variableQname": "sfac6:ComprehensiveIncome"
-        }
-      ],
-      "ruleMessage": "Comprehensive Income disclosure must report a ComprehensiveIncome concept. Source: dm-ComprehensiveIncome-rules-def.xml.",
-      "ruleOrigin": "forked"
-    },
-    {
-      "@id": "_:sfac6-rule-ci-requires-revenues",
-      "ruleCategory": "DisclosureMechanicsRule",
-      "rulePattern": "Exists",
-      "ruleExpression": "exists($Revenues)",
-      "ruleTarget": {
-        "targetKind": "structure",
-        "targetRef": {
-          "@id": "http://www.xbrlsite.com/seattlemethod/conceptual-model/cm-roles/roles/fac-presentation/ComprehensiveIncome"
-        }
-      },
-      "ruleVariables": [
-        {
-          "variableName": "Revenues",
-          "variableQname": "sfac6:Revenues"
-        }
-      ],
-      "ruleMessage": "Comprehensive Income disclosure must report a Revenues concept. Source: dm-ComprehensiveIncome-rules-def.xml.",
-      "ruleOrigin": "forked"
-    },
-    {
-      "@id": "_:sfac6-rule-ce-requires-equity",
-      "ruleCategory": "DisclosureMechanicsRule",
-      "rulePattern": "Exists",
-      "ruleExpression": "exists($Equity)",
-      "ruleTarget": {
-        "targetKind": "structure",
-        "targetRef": {
-          "@id": "http://www.xbrlsite.com/seattlemethod/conceptual-model/cm-roles/roles/fac-presentation/ComprehensiveIncome-breakdown"
-        }
-      },
-      "ruleVariables": [
-        {
-          "variableName": "Equity",
-          "variableQname": "fac:Equity"
-        }
-      ],
-      "ruleMessage": "Changes in Equity disclosure must report an Equity concept. Source: dm-ChangesInEquity-rules-def.xml.",
+      "ruleMessage": "Comprehensive Income identity: Comprehensive Income must equal Net Income plus Other Comprehensive Income.",
+      "ruleSeverity": "error",
       "ruleOrigin": "forked"
     }
   ]

--- a/frameworks/rs-gaap/packages/rs-gaap-calculations/v1/taxonomy.jsonld
+++ b/frameworks/rs-gaap/packages/rs-gaap-calculations/v1/taxonomy.jsonld
@@ -70,6 +70,15 @@
       "arcWeight": 1.0,
       "arcOrder": 200.0
     },
+    {
+      "@id": "_:rs-gaap-calc-is-rev-arc-3",
+      "arcFrom": { "@id": "rs-gaap:Revenues" },
+      "arcTo": { "@id": "rs-gaap:OtherSalesRevenueNet" },
+      "arcAssociationType": "calculation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-calculations/IS-Rev",
+      "arcWeight": 1.0,
+      "arcOrder": 300.0
+    },
 
     {
       "@id": "_:rs-gaap-calc-is-cor",
@@ -95,6 +104,15 @@
       "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-calculations/IS-COR",
       "arcWeight": 1.0,
       "arcOrder": 200.0
+    },
+    {
+      "@id": "_:rs-gaap-calc-is-cor-arc-3",
+      "arcFrom": { "@id": "rs-gaap:CostOfRevenue" },
+      "arcTo": { "@id": "rs-gaap:OtherCostOfOperatingRevenue" },
+      "arcAssociationType": "calculation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-calculations/IS-COR",
+      "arcWeight": 1.0,
+      "arcOrder": 300.0
     },
 
     {
@@ -157,6 +175,15 @@
       "arcWeight": 1.0,
       "arcOrder": 300.0
     },
+    {
+      "@id": "_:rs-gaap-calc-is-opex-arc-4",
+      "arcFrom": { "@id": "rs-gaap:OperatingExpenses" },
+      "arcTo": { "@id": "rs-gaap:OtherCostAndExpenseOperating" },
+      "arcAssociationType": "calculation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-calculations/IS-OpEx",
+      "arcWeight": 1.0,
+      "arcOrder": 400.0
+    },
 
     {
       "@id": "_:rs-gaap-calc-is-opinc",
@@ -194,11 +221,38 @@
     {
       "@id": "_:rs-gaap-calc-is-nonop-arc-1",
       "arcFrom": { "@id": "rs-gaap:NonoperatingIncomeExpense" },
-      "arcTo": { "@id": "rs-gaap:OtherNonoperatingIncomeExpense" },
+      "arcTo": { "@id": "rs-gaap:InvestmentIncomeInterest" },
       "arcAssociationType": "calculation",
       "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-calculations/IS-NonOp",
       "arcWeight": 1.0,
       "arcOrder": 100.0
+    },
+    {
+      "@id": "_:rs-gaap-calc-is-nonop-arc-2",
+      "arcFrom": { "@id": "rs-gaap:NonoperatingIncomeExpense" },
+      "arcTo": { "@id": "rs-gaap:InterestExpense" },
+      "arcAssociationType": "calculation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-calculations/IS-NonOp",
+      "arcWeight": -1.0,
+      "arcOrder": 200.0
+    },
+    {
+      "@id": "_:rs-gaap-calc-is-nonop-arc-3",
+      "arcFrom": { "@id": "rs-gaap:NonoperatingIncomeExpense" },
+      "arcTo": { "@id": "rs-gaap:GainLossOnDispositionOfAssets" },
+      "arcAssociationType": "calculation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-calculations/IS-NonOp",
+      "arcWeight": 1.0,
+      "arcOrder": 300.0
+    },
+    {
+      "@id": "_:rs-gaap-calc-is-nonop-arc-4",
+      "arcFrom": { "@id": "rs-gaap:NonoperatingIncomeExpense" },
+      "arcTo": { "@id": "rs-gaap:OtherNonoperatingIncomeExpense" },
+      "arcAssociationType": "calculation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-calculations/IS-NonOp",
+      "arcWeight": 1.0,
+      "arcOrder": 400.0
     },
 
     {
@@ -226,16 +280,6 @@
       "arcWeight": 1.0,
       "arcOrder": 200.0
     },
-    {
-      "@id": "_:rs-gaap-calc-is-pretax-arc-3",
-      "arcFrom": { "@id": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest" },
-      "arcTo": { "@id": "rs-gaap:InterestExpense" },
-      "arcAssociationType": "calculation",
-      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-calculations/IS-PreTax",
-      "arcWeight": -1.0,
-      "arcOrder": 300.0
-    },
-
     {
       "@id": "_:rs-gaap-calc-is-conops",
       "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-calculations/IS-ContinuingOps",

--- a/frameworks/rs-gaap/packages/rs-gaap-presentation/v1/taxonomy.jsonld
+++ b/frameworks/rs-gaap/packages/rs-gaap-presentation/v1/taxonomy.jsonld
@@ -8034,6 +8034,14 @@
       "arcOrder": 10120.0
     },
     {
+      "@id": "_:rs-gaap-pres-is-multistep-arc-rev-other",
+      "arcFrom": { "@id": "rs-gaap:Revenues" },
+      "arcTo": { "@id": "rs-gaap:OtherSalesRevenueNet" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+      "arcOrder": 10130.0
+    },
+    {
       "@id": "_:rs-gaap-pres-is-multistep-arc-4",
       "arcFrom": { "@id": "rs-gaap:IncomeStatementAbstract" },
       "arcTo": { "@id": "rs-gaap:CostOfRevenue" },
@@ -8056,6 +8064,14 @@
       "arcAssociationType": "presentation",
       "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
       "arcOrder": 10220.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-is-multistep-arc-cor-other",
+      "arcFrom": { "@id": "rs-gaap:CostOfRevenue" },
+      "arcTo": { "@id": "rs-gaap:OtherCostOfOperatingRevenue" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+      "arcOrder": 10230.0
     },
     {
       "@id": "_:rs-gaap-pres-is-multistep-arc-7",
@@ -8098,6 +8114,14 @@
       "arcOrder": 10430.0
     },
     {
+      "@id": "_:rs-gaap-pres-is-multistep-arc-opex-other",
+      "arcFrom": { "@id": "rs-gaap:OperatingExpenses" },
+      "arcTo": { "@id": "rs-gaap:OtherCostAndExpenseOperating" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+      "arcOrder": 10440.0
+    },
+    {
       "@id": "_:rs-gaap-pres-is-multistep-arc-12",
       "arcFrom": { "@id": "rs-gaap:IncomeStatementAbstract" },
       "arcTo": { "@id": "rs-gaap:OperatingIncomeLoss" },
@@ -8116,18 +8140,34 @@
     {
       "@id": "_:rs-gaap-pres-is-multistep-arc-14",
       "arcFrom": { "@id": "rs-gaap:NonoperatingIncomeExpense" },
-      "arcTo": { "@id": "rs-gaap:OtherNonoperatingIncomeExpense" },
+      "arcTo": { "@id": "rs-gaap:InvestmentIncomeInterest" },
       "arcAssociationType": "presentation",
       "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
       "arcOrder": 10610.0
     },
     {
-      "@id": "_:rs-gaap-pres-is-multistep-arc-15",
-      "arcFrom": { "@id": "rs-gaap:IncomeStatementAbstract" },
+      "@id": "_:rs-gaap-pres-is-multistep-arc-nonop-intexp",
+      "arcFrom": { "@id": "rs-gaap:NonoperatingIncomeExpense" },
       "arcTo": { "@id": "rs-gaap:InterestExpense" },
       "arcAssociationType": "presentation",
       "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-      "arcOrder": 10700.0
+      "arcOrder": 10620.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-is-multistep-arc-nonop-gainloss",
+      "arcFrom": { "@id": "rs-gaap:NonoperatingIncomeExpense" },
+      "arcTo": { "@id": "rs-gaap:GainLossOnDispositionOfAssets" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+      "arcOrder": 10630.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-is-multistep-arc-15",
+      "arcFrom": { "@id": "rs-gaap:NonoperatingIncomeExpense" },
+      "arcTo": { "@id": "rs-gaap:OtherNonoperatingIncomeExpense" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+      "arcOrder": 10640.0
     },
     {
       "@id": "_:rs-gaap-pres-is-multistep-arc-16",
@@ -8202,6 +8242,14 @@
       "arcOrder": 10120.0
     },
     {
+      "@id": "_:rs-gaap-pres-is-singlestep-arc-rev-other",
+      "arcFrom": { "@id": "rs-gaap:Revenues" },
+      "arcTo": { "@id": "rs-gaap:OtherSalesRevenueNet" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-singlestep",
+      "arcOrder": 10130.0
+    },
+    {
       "@id": "_:rs-gaap-pres-is-singlestep-arc-4",
       "arcFrom": { "@id": "rs-gaap:IncomeStatementAbstract" },
       "arcTo": { "@id": "rs-gaap:CostOfRevenue" },
@@ -8224,6 +8272,14 @@
       "arcAssociationType": "presentation",
       "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-singlestep",
       "arcOrder": 10220.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-is-singlestep-arc-cor-other",
+      "arcFrom": { "@id": "rs-gaap:CostOfRevenue" },
+      "arcTo": { "@id": "rs-gaap:OtherCostOfOperatingRevenue" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-singlestep",
+      "arcOrder": 10230.0
     },
     {
       "@id": "_:rs-gaap-pres-is-singlestep-arc-7",
@@ -8264,6 +8320,22 @@
       "arcAssociationType": "presentation",
       "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-singlestep",
       "arcOrder": 10500.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-is-singlestep-arc-nonop-intinc",
+      "arcFrom": { "@id": "rs-gaap:IncomeStatementAbstract" },
+      "arcTo": { "@id": "rs-gaap:InvestmentIncomeInterest" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-singlestep",
+      "arcOrder": 10510.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-is-singlestep-arc-nonop-gainloss",
+      "arcFrom": { "@id": "rs-gaap:IncomeStatementAbstract" },
+      "arcTo": { "@id": "rs-gaap:GainLossOnDispositionOfAssets" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-singlestep",
+      "arcOrder": 10520.0
     },
     {
       "@id": "_:rs-gaap-pres-is-singlestep-arc-12",

--- a/frameworks/rs-gaap/packages/rs-gaap-rollup-rules/v1/taxonomy.jsonld
+++ b/frameworks/rs-gaap/packages/rs-gaap-rollup-rules/v1/taxonomy.jsonld
@@ -1,0 +1,756 @@
+{
+  "@context": {
+    "rs-gaap": "https://robosystems.ai/taxonomy/rs-gaap/v1/",
+    "rs": "https://robosystems.ai/vocab/",
+    "ruleCategory": {
+      "@id": "https://robosystems.ai/vocab/ruleCategory"
+    },
+    "rulePattern": {
+      "@id": "https://robosystems.ai/vocab/rulePattern"
+    },
+    "ruleExpression": {
+      "@id": "https://robosystems.ai/vocab/ruleExpression"
+    },
+    "ruleTarget": {
+      "@id": "https://robosystems.ai/vocab/ruleTarget"
+    },
+    "targetKind": {
+      "@id": "https://robosystems.ai/vocab/targetKind"
+    },
+    "targetRef": {
+      "@id": "https://robosystems.ai/vocab/targetRef"
+    },
+    "ruleVariables": {
+      "@id": "https://robosystems.ai/vocab/ruleVariables",
+      "@container": "@list"
+    },
+    "variableName": {
+      "@id": "https://robosystems.ai/vocab/variableName"
+    },
+    "variableQname": {
+      "@id": "https://robosystems.ai/vocab/variableQname"
+    },
+    "ruleMessage": {
+      "@id": "https://robosystems.ai/vocab/ruleMessage"
+    },
+    "ruleSeverity": {
+      "@id": "https://robosystems.ai/vocab/ruleSeverity"
+    },
+    "ruleOrigin": {
+      "@id": "https://robosystems.ai/vocab/ruleOrigin"
+    }
+  },
+  "standard": "rs-gaap-rollup-rules",
+  "version": "v1",
+  "taxonomy_type": "rules",
+  "namespace_uri": "https://robosystems.ai/taxonomy/rs-gaap/rollup-rules/",
+  "default_block_type": "validation_rules",
+  "origin": "native",
+  "created_at": "2026-05-21",
+  "description": "L2 calc-arc RollUp verification rules \u2014 one rule per subtotal parent in rs-gaap-calculations/v1 ($Parent = \u03a3 weighted children). RoboSystems-native (info-block \u00a76.1 Package II.a). Element-scoped to the parent concept so the rule fires against any rendered statement that presents that subtotal, across all equity-form variants. The RollUp evaluator treats a missing RHS child as 0 (matching the renderer); a missing parent subtotal skips. Regenerate via robosystems.taxonomy.scripts.generate_rollup_rules from rs-gaap-calculations/v1.",
+  "@graph": [
+    {
+      "@id": "_:rs-gaap-rollup-bs-assets",
+      "ruleCategory": "FundamentalAccountingConceptRelation",
+      "rulePattern": "RollUp",
+      "ruleExpression": "$Assets = ($AssetsCurrent + $AssetsNoncurrent)",
+      "ruleTarget": {
+        "targetKind": "element",
+        "targetRef": "rs-gaap:Assets"
+      },
+      "ruleVariables": [
+        {
+          "variableName": "Assets",
+          "variableQname": "rs-gaap:Assets"
+        },
+        {
+          "variableName": "AssetsCurrent",
+          "variableQname": "rs-gaap:AssetsCurrent"
+        },
+        {
+          "variableName": "AssetsNoncurrent",
+          "variableQname": "rs-gaap:AssetsNoncurrent"
+        }
+      ],
+      "ruleMessage": "Calculation rollup: rs-gaap:Assets = rs-gaap:AssetsCurrent + rs-gaap:AssetsNoncurrent",
+      "ruleSeverity": "error",
+      "ruleOrigin": "native"
+    },
+    {
+      "@id": "_:rs-gaap-rollup-bs-currentassets",
+      "ruleCategory": "FundamentalAccountingConceptRelation",
+      "rulePattern": "RollUp",
+      "ruleExpression": "$AssetsCurrent = ($CashCashEquivalentsAndShortTermInvestments + $ReceivablesNetCurrent + $InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings + $PrepaidExpenseCurrent + $RestrictedCashAndInvestmentsCurrent + $OtherAssetsCurrent)",
+      "ruleTarget": {
+        "targetKind": "element",
+        "targetRef": "rs-gaap:AssetsCurrent"
+      },
+      "ruleVariables": [
+        {
+          "variableName": "AssetsCurrent",
+          "variableQname": "rs-gaap:AssetsCurrent"
+        },
+        {
+          "variableName": "CashCashEquivalentsAndShortTermInvestments",
+          "variableQname": "rs-gaap:CashCashEquivalentsAndShortTermInvestments"
+        },
+        {
+          "variableName": "ReceivablesNetCurrent",
+          "variableQname": "rs-gaap:ReceivablesNetCurrent"
+        },
+        {
+          "variableName": "InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
+          "variableQname": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings"
+        },
+        {
+          "variableName": "PrepaidExpenseCurrent",
+          "variableQname": "rs-gaap:PrepaidExpenseCurrent"
+        },
+        {
+          "variableName": "RestrictedCashAndInvestmentsCurrent",
+          "variableQname": "rs-gaap:RestrictedCashAndInvestmentsCurrent"
+        },
+        {
+          "variableName": "OtherAssetsCurrent",
+          "variableQname": "rs-gaap:OtherAssetsCurrent"
+        }
+      ],
+      "ruleMessage": "Calculation rollup: rs-gaap:AssetsCurrent = \u03a3 rs-gaap current-asset leaves",
+      "ruleSeverity": "error",
+      "ruleOrigin": "native"
+    },
+    {
+      "@id": "_:rs-gaap-rollup-bs-currentliabilities",
+      "ruleCategory": "FundamentalAccountingConceptRelation",
+      "rulePattern": "RollUp",
+      "ruleExpression": "$LiabilitiesCurrent = ($AccountsPayableAndAccruedLiabilitiesCurrent + $DebtCurrent + $DeferredRevenueCurrent + $FinanceLeaseLiabilityCurrent + $OtherLiabilitiesCurrent)",
+      "ruleTarget": {
+        "targetKind": "element",
+        "targetRef": "rs-gaap:LiabilitiesCurrent"
+      },
+      "ruleVariables": [
+        {
+          "variableName": "LiabilitiesCurrent",
+          "variableQname": "rs-gaap:LiabilitiesCurrent"
+        },
+        {
+          "variableName": "AccountsPayableAndAccruedLiabilitiesCurrent",
+          "variableQname": "rs-gaap:AccountsPayableAndAccruedLiabilitiesCurrent"
+        },
+        {
+          "variableName": "DebtCurrent",
+          "variableQname": "rs-gaap:DebtCurrent"
+        },
+        {
+          "variableName": "DeferredRevenueCurrent",
+          "variableQname": "rs-gaap:DeferredRevenueCurrent"
+        },
+        {
+          "variableName": "FinanceLeaseLiabilityCurrent",
+          "variableQname": "rs-gaap:FinanceLeaseLiabilityCurrent"
+        },
+        {
+          "variableName": "OtherLiabilitiesCurrent",
+          "variableQname": "rs-gaap:OtherLiabilitiesCurrent"
+        }
+      ],
+      "ruleMessage": "Calculation rollup: rs-gaap:LiabilitiesCurrent = \u03a3 rs-gaap current-liability leaves",
+      "ruleSeverity": "error",
+      "ruleOrigin": "native"
+    },
+    {
+      "@id": "_:rs-gaap-rollup-bs-equity",
+      "ruleCategory": "FundamentalAccountingConceptRelation",
+      "rulePattern": "RollUp",
+      "ruleExpression": "$StockholdersEquity = ($CommonStockValue + $PreferredStockValue + $AdditionalPaidInCapital + $RetainedEarningsAccumulatedDeficit + $AccumulatedOtherComprehensiveIncomeLossNetOfTax - $TreasuryStockValue + $PartnersCapital + $MembersEquity)",
+      "ruleTarget": {
+        "targetKind": "element",
+        "targetRef": "rs-gaap:StockholdersEquity"
+      },
+      "ruleVariables": [
+        {
+          "variableName": "StockholdersEquity",
+          "variableQname": "rs-gaap:StockholdersEquity"
+        },
+        {
+          "variableName": "CommonStockValue",
+          "variableQname": "rs-gaap:CommonStockValue"
+        },
+        {
+          "variableName": "PreferredStockValue",
+          "variableQname": "rs-gaap:PreferredStockValue"
+        },
+        {
+          "variableName": "AdditionalPaidInCapital",
+          "variableQname": "rs-gaap:AdditionalPaidInCapital"
+        },
+        {
+          "variableName": "RetainedEarningsAccumulatedDeficit",
+          "variableQname": "rs-gaap:RetainedEarningsAccumulatedDeficit"
+        },
+        {
+          "variableName": "AccumulatedOtherComprehensiveIncomeLossNetOfTax",
+          "variableQname": "rs-gaap:AccumulatedOtherComprehensiveIncomeLossNetOfTax"
+        },
+        {
+          "variableName": "TreasuryStockValue",
+          "variableQname": "rs-gaap:TreasuryStockValue"
+        },
+        {
+          "variableName": "PartnersCapital",
+          "variableQname": "rs-gaap:PartnersCapital"
+        },
+        {
+          "variableName": "MembersEquity",
+          "variableQname": "rs-gaap:MembersEquity"
+        }
+      ],
+      "ruleMessage": "Calculation rollup: rs-gaap:StockholdersEquity = \u03a3 rs-gaap equity leaves (Treasury weight=-1)",
+      "ruleSeverity": "error",
+      "ruleOrigin": "native"
+    },
+    {
+      "@id": "_:rs-gaap-rollup-bs-liabilities",
+      "ruleCategory": "FundamentalAccountingConceptRelation",
+      "rulePattern": "RollUp",
+      "ruleExpression": "$Liabilities = ($LiabilitiesCurrent + $LiabilitiesNoncurrent)",
+      "ruleTarget": {
+        "targetKind": "element",
+        "targetRef": "rs-gaap:Liabilities"
+      },
+      "ruleVariables": [
+        {
+          "variableName": "Liabilities",
+          "variableQname": "rs-gaap:Liabilities"
+        },
+        {
+          "variableName": "LiabilitiesCurrent",
+          "variableQname": "rs-gaap:LiabilitiesCurrent"
+        },
+        {
+          "variableName": "LiabilitiesNoncurrent",
+          "variableQname": "rs-gaap:LiabilitiesNoncurrent"
+        }
+      ],
+      "ruleMessage": "Calculation rollup: rs-gaap:Liabilities = rs-gaap:LiabilitiesCurrent + rs-gaap:LiabilitiesNoncurrent",
+      "ruleSeverity": "error",
+      "ruleOrigin": "native"
+    },
+    {
+      "@id": "_:rs-gaap-rollup-bs-liabilitiesandstockholdersequity",
+      "ruleCategory": "FundamentalAccountingConceptRelation",
+      "rulePattern": "RollUp",
+      "ruleExpression": "$LiabilitiesAndStockholdersEquity = ($Liabilities + $StockholdersEquity)",
+      "ruleTarget": {
+        "targetKind": "element",
+        "targetRef": "rs-gaap:LiabilitiesAndStockholdersEquity"
+      },
+      "ruleVariables": [
+        {
+          "variableName": "LiabilitiesAndStockholdersEquity",
+          "variableQname": "rs-gaap:LiabilitiesAndStockholdersEquity"
+        },
+        {
+          "variableName": "Liabilities",
+          "variableQname": "rs-gaap:Liabilities"
+        },
+        {
+          "variableName": "StockholdersEquity",
+          "variableQname": "rs-gaap:StockholdersEquity"
+        }
+      ],
+      "ruleMessage": "Calculation rollup: rs-gaap:LiabilitiesAndStockholdersEquity = rs-gaap:Liabilities + rs-gaap:StockholdersEquity",
+      "ruleSeverity": "error",
+      "ruleOrigin": "native"
+    },
+    {
+      "@id": "_:rs-gaap-rollup-bs-noncurrentassets",
+      "ruleCategory": "FundamentalAccountingConceptRelation",
+      "rulePattern": "RollUp",
+      "ruleExpression": "$AssetsNoncurrent = ($PropertyPlantAndEquipmentNet + $IntangibleAssetsNetIncludingGoodwill + $LongTermInvestmentsAndReceivablesNet + $OperatingLeaseRightOfUseAsset + $FinanceLeaseRightOfUseAsset + $OtherAssetsNoncurrent)",
+      "ruleTarget": {
+        "targetKind": "element",
+        "targetRef": "rs-gaap:AssetsNoncurrent"
+      },
+      "ruleVariables": [
+        {
+          "variableName": "AssetsNoncurrent",
+          "variableQname": "rs-gaap:AssetsNoncurrent"
+        },
+        {
+          "variableName": "PropertyPlantAndEquipmentNet",
+          "variableQname": "rs-gaap:PropertyPlantAndEquipmentNet"
+        },
+        {
+          "variableName": "IntangibleAssetsNetIncludingGoodwill",
+          "variableQname": "rs-gaap:IntangibleAssetsNetIncludingGoodwill"
+        },
+        {
+          "variableName": "LongTermInvestmentsAndReceivablesNet",
+          "variableQname": "rs-gaap:LongTermInvestmentsAndReceivablesNet"
+        },
+        {
+          "variableName": "OperatingLeaseRightOfUseAsset",
+          "variableQname": "rs-gaap:OperatingLeaseRightOfUseAsset"
+        },
+        {
+          "variableName": "FinanceLeaseRightOfUseAsset",
+          "variableQname": "rs-gaap:FinanceLeaseRightOfUseAsset"
+        },
+        {
+          "variableName": "OtherAssetsNoncurrent",
+          "variableQname": "rs-gaap:OtherAssetsNoncurrent"
+        }
+      ],
+      "ruleMessage": "Calculation rollup: rs-gaap:AssetsNoncurrent = \u03a3 rs-gaap noncurrent-asset leaves",
+      "ruleSeverity": "error",
+      "ruleOrigin": "native"
+    },
+    {
+      "@id": "_:rs-gaap-rollup-bs-noncurrentliabilities",
+      "ruleCategory": "FundamentalAccountingConceptRelation",
+      "rulePattern": "RollUp",
+      "ruleExpression": "$LiabilitiesNoncurrent = ($LongTermDebtAndCapitalLeaseObligations + $DeferredIncomeTaxLiabilitiesNet + $DeferredRevenueNoncurrent + $OperatingLeaseLiabilityNoncurrent + $OtherLiabilitiesNoncurrent)",
+      "ruleTarget": {
+        "targetKind": "element",
+        "targetRef": "rs-gaap:LiabilitiesNoncurrent"
+      },
+      "ruleVariables": [
+        {
+          "variableName": "LiabilitiesNoncurrent",
+          "variableQname": "rs-gaap:LiabilitiesNoncurrent"
+        },
+        {
+          "variableName": "LongTermDebtAndCapitalLeaseObligations",
+          "variableQname": "rs-gaap:LongTermDebtAndCapitalLeaseObligations"
+        },
+        {
+          "variableName": "DeferredIncomeTaxLiabilitiesNet",
+          "variableQname": "rs-gaap:DeferredIncomeTaxLiabilitiesNet"
+        },
+        {
+          "variableName": "DeferredRevenueNoncurrent",
+          "variableQname": "rs-gaap:DeferredRevenueNoncurrent"
+        },
+        {
+          "variableName": "OperatingLeaseLiabilityNoncurrent",
+          "variableQname": "rs-gaap:OperatingLeaseLiabilityNoncurrent"
+        },
+        {
+          "variableName": "OtherLiabilitiesNoncurrent",
+          "variableQname": "rs-gaap:OtherLiabilitiesNoncurrent"
+        }
+      ],
+      "ruleMessage": "Calculation rollup: rs-gaap:LiabilitiesNoncurrent = \u03a3 rs-gaap noncurrent-liability leaves",
+      "ruleSeverity": "error",
+      "ruleOrigin": "native"
+    },
+    {
+      "@id": "_:rs-gaap-rollup-cf-financing",
+      "ruleCategory": "FundamentalAccountingConceptRelation",
+      "rulePattern": "RollUp",
+      "ruleExpression": "$NetCashProvidedByUsedInFinancingActivities = ($ProceedsFromIssuanceOfCommonStock + $ProceedsFromIssuanceOfLongTermDebtAndCapitalSecuritiesNet)",
+      "ruleTarget": {
+        "targetKind": "element",
+        "targetRef": "rs-gaap:NetCashProvidedByUsedInFinancingActivities"
+      },
+      "ruleVariables": [
+        {
+          "variableName": "NetCashProvidedByUsedInFinancingActivities",
+          "variableQname": "rs-gaap:NetCashProvidedByUsedInFinancingActivities"
+        },
+        {
+          "variableName": "ProceedsFromIssuanceOfCommonStock",
+          "variableQname": "rs-gaap:ProceedsFromIssuanceOfCommonStock"
+        },
+        {
+          "variableName": "ProceedsFromIssuanceOfLongTermDebtAndCapitalSecuritiesNet",
+          "variableQname": "rs-gaap:ProceedsFromIssuanceOfLongTermDebtAndCapitalSecuritiesNet"
+        }
+      ],
+      "ruleMessage": "Calculation rollup: rs-gaap:NetCashProvidedByUsedInFinancingActivities = \u03a3 proceeds \u2212 \u03a3 payments",
+      "ruleSeverity": "error",
+      "ruleOrigin": "native"
+    },
+    {
+      "@id": "_:rs-gaap-rollup-cf-investing",
+      "ruleCategory": "FundamentalAccountingConceptRelation",
+      "rulePattern": "RollUp",
+      "ruleExpression": "$NetCashProvidedByUsedInInvestingActivities = ($PaymentsToAcquirePropertyPlantAndEquipment)",
+      "ruleTarget": {
+        "targetKind": "element",
+        "targetRef": "rs-gaap:NetCashProvidedByUsedInInvestingActivities"
+      },
+      "ruleVariables": [
+        {
+          "variableName": "NetCashProvidedByUsedInInvestingActivities",
+          "variableQname": "rs-gaap:NetCashProvidedByUsedInInvestingActivities"
+        },
+        {
+          "variableName": "PaymentsToAcquirePropertyPlantAndEquipment",
+          "variableQname": "rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment"
+        }
+      ],
+      "ruleMessage": "Calculation rollup: rs-gaap:NetCashProvidedByUsedInInvestingActivities = \u03a3 Investing leaves (each pre-signed: outflows negative, proceeds positive)",
+      "ruleSeverity": "error",
+      "ruleOrigin": "native"
+    },
+    {
+      "@id": "_:rs-gaap-rollup-cf-netchange",
+      "ruleCategory": "FundamentalAccountingConceptRelation",
+      "rulePattern": "RollUp",
+      "ruleExpression": "$CashAndCashEquivalentsPeriodIncreaseDecrease = ($NetCashProvidedByUsedInOperatingActivities + $NetCashProvidedByUsedInInvestingActivities + $NetCashProvidedByUsedInFinancingActivities + $EffectOfExchangeRateOnCash)",
+      "ruleTarget": {
+        "targetKind": "element",
+        "targetRef": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease"
+      },
+      "ruleVariables": [
+        {
+          "variableName": "CashAndCashEquivalentsPeriodIncreaseDecrease",
+          "variableQname": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease"
+        },
+        {
+          "variableName": "NetCashProvidedByUsedInOperatingActivities",
+          "variableQname": "rs-gaap:NetCashProvidedByUsedInOperatingActivities"
+        },
+        {
+          "variableName": "NetCashProvidedByUsedInInvestingActivities",
+          "variableQname": "rs-gaap:NetCashProvidedByUsedInInvestingActivities"
+        },
+        {
+          "variableName": "NetCashProvidedByUsedInFinancingActivities",
+          "variableQname": "rs-gaap:NetCashProvidedByUsedInFinancingActivities"
+        },
+        {
+          "variableName": "EffectOfExchangeRateOnCash",
+          "variableQname": "rs-gaap:EffectOfExchangeRateOnCash"
+        }
+      ],
+      "ruleMessage": "Calculation rollup: rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease = Op + Inv + Fin + Exchange",
+      "ruleSeverity": "error",
+      "ruleOrigin": "native"
+    },
+    {
+      "@id": "_:rs-gaap-rollup-cf-operating",
+      "ruleCategory": "FundamentalAccountingConceptRelation",
+      "rulePattern": "RollUp",
+      "ruleExpression": "$NetCashProvidedByUsedInOperatingActivities = ($NetIncomeLoss + $DepreciationDepletionAndAmortization + $IncreaseDecreaseInAccountsReceivable + $IncreaseDecreaseInInventories + $IncreaseDecreaseInPrepaidExpense + $IncreaseDecreaseInAccountsPayableAndAccruedLiabilities + $IncreaseDecreaseInOtherOperatingCapitalNet + $IncreaseDecreaseInAccruedLiabilities + $IncreaseDecreaseInAccruedIncomeTaxesPayable)",
+      "ruleTarget": {
+        "targetKind": "element",
+        "targetRef": "rs-gaap:NetCashProvidedByUsedInOperatingActivities"
+      },
+      "ruleVariables": [
+        {
+          "variableName": "NetCashProvidedByUsedInOperatingActivities",
+          "variableQname": "rs-gaap:NetCashProvidedByUsedInOperatingActivities"
+        },
+        {
+          "variableName": "NetIncomeLoss",
+          "variableQname": "rs-gaap:NetIncomeLoss"
+        },
+        {
+          "variableName": "DepreciationDepletionAndAmortization",
+          "variableQname": "rs-gaap:DepreciationDepletionAndAmortization"
+        },
+        {
+          "variableName": "IncreaseDecreaseInAccountsReceivable",
+          "variableQname": "rs-gaap:IncreaseDecreaseInAccountsReceivable"
+        },
+        {
+          "variableName": "IncreaseDecreaseInInventories",
+          "variableQname": "rs-gaap:IncreaseDecreaseInInventories"
+        },
+        {
+          "variableName": "IncreaseDecreaseInPrepaidExpense",
+          "variableQname": "rs-gaap:IncreaseDecreaseInPrepaidExpense"
+        },
+        {
+          "variableName": "IncreaseDecreaseInAccountsPayableAndAccruedLiabilities",
+          "variableQname": "rs-gaap:IncreaseDecreaseInAccountsPayableAndAccruedLiabilities"
+        },
+        {
+          "variableName": "IncreaseDecreaseInOtherOperatingCapitalNet",
+          "variableQname": "rs-gaap:IncreaseDecreaseInOtherOperatingCapitalNet"
+        },
+        {
+          "variableName": "IncreaseDecreaseInAccruedLiabilities",
+          "variableQname": "rs-gaap:IncreaseDecreaseInAccruedLiabilities"
+        },
+        {
+          "variableName": "IncreaseDecreaseInAccruedIncomeTaxesPayable",
+          "variableQname": "rs-gaap:IncreaseDecreaseInAccruedIncomeTaxesPayable"
+        }
+      ],
+      "ruleMessage": "Calculation rollup: rs-gaap:NetCashProvidedByUsedInOperatingActivities = NetIncomeLoss + DDA + \u03a3 working-capital deltas (indirect method)",
+      "ruleSeverity": "error",
+      "ruleOrigin": "native"
+    },
+    {
+      "@id": "_:rs-gaap-rollup-is-continuingops",
+      "ruleCategory": "FundamentalAccountingConceptRelation",
+      "rulePattern": "RollUp",
+      "ruleExpression": "$IncomeLossFromContinuingOperations = ($IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest - $IncomeTaxExpenseBenefit)",
+      "ruleTarget": {
+        "targetKind": "element",
+        "targetRef": "rs-gaap:IncomeLossFromContinuingOperations"
+      },
+      "ruleVariables": [
+        {
+          "variableName": "IncomeLossFromContinuingOperations",
+          "variableQname": "rs-gaap:IncomeLossFromContinuingOperations"
+        },
+        {
+          "variableName": "IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
+          "variableQname": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest"
+        },
+        {
+          "variableName": "IncomeTaxExpenseBenefit",
+          "variableQname": "rs-gaap:IncomeTaxExpenseBenefit"
+        }
+      ],
+      "ruleMessage": "Calculation rollup: rs-gaap:IncomeLossFromContinuingOperations = PreTax \u2212 IncomeTaxExpenseBenefit",
+      "ruleSeverity": "error",
+      "ruleOrigin": "native"
+    },
+    {
+      "@id": "_:rs-gaap-rollup-is-cor",
+      "ruleCategory": "FundamentalAccountingConceptRelation",
+      "rulePattern": "RollUp",
+      "ruleExpression": "$CostOfRevenue = ($CostOfGoodsSold + $CostOfGoodsSoldExcludingDepreciationDepletionAndAmortization + $OtherCostOfOperatingRevenue)",
+      "ruleTarget": {
+        "targetKind": "element",
+        "targetRef": "rs-gaap:CostOfRevenue"
+      },
+      "ruleVariables": [
+        {
+          "variableName": "CostOfRevenue",
+          "variableQname": "rs-gaap:CostOfRevenue"
+        },
+        {
+          "variableName": "CostOfGoodsSold",
+          "variableQname": "rs-gaap:CostOfGoodsSold"
+        },
+        {
+          "variableName": "CostOfGoodsSoldExcludingDepreciationDepletionAndAmortization",
+          "variableQname": "rs-gaap:CostOfGoodsSoldExcludingDepreciationDepletionAndAmortization"
+        },
+        {
+          "variableName": "OtherCostOfOperatingRevenue",
+          "variableQname": "rs-gaap:OtherCostOfOperatingRevenue"
+        }
+      ],
+      "ruleMessage": "Calculation rollup: rs-gaap:CostOfRevenue = \u03a3 rs-gaap COGS leaves",
+      "ruleSeverity": "error",
+      "ruleOrigin": "native"
+    },
+    {
+      "@id": "_:rs-gaap-rollup-is-grossprofit",
+      "ruleCategory": "FundamentalAccountingConceptRelation",
+      "rulePattern": "RollUp",
+      "ruleExpression": "$GrossProfit = ($Revenues - $CostOfRevenue)",
+      "ruleTarget": {
+        "targetKind": "element",
+        "targetRef": "rs-gaap:GrossProfit"
+      },
+      "ruleVariables": [
+        {
+          "variableName": "GrossProfit",
+          "variableQname": "rs-gaap:GrossProfit"
+        },
+        {
+          "variableName": "Revenues",
+          "variableQname": "rs-gaap:Revenues"
+        },
+        {
+          "variableName": "CostOfRevenue",
+          "variableQname": "rs-gaap:CostOfRevenue"
+        }
+      ],
+      "ruleMessage": "Calculation rollup: rs-gaap:GrossProfit = rs-gaap:Revenues \u2212 rs-gaap:CostOfRevenue",
+      "ruleSeverity": "error",
+      "ruleOrigin": "native"
+    },
+    {
+      "@id": "_:rs-gaap-rollup-is-netincome",
+      "ruleCategory": "FundamentalAccountingConceptRelation",
+      "rulePattern": "RollUp",
+      "ruleExpression": "$NetIncomeLoss = ($IncomeLossFromContinuingOperations + $IncomeLossFromDiscontinuedOperationsNetOfTax)",
+      "ruleTarget": {
+        "targetKind": "element",
+        "targetRef": "rs-gaap:NetIncomeLoss"
+      },
+      "ruleVariables": [
+        {
+          "variableName": "NetIncomeLoss",
+          "variableQname": "rs-gaap:NetIncomeLoss"
+        },
+        {
+          "variableName": "IncomeLossFromContinuingOperations",
+          "variableQname": "rs-gaap:IncomeLossFromContinuingOperations"
+        },
+        {
+          "variableName": "IncomeLossFromDiscontinuedOperationsNetOfTax",
+          "variableQname": "rs-gaap:IncomeLossFromDiscontinuedOperationsNetOfTax"
+        }
+      ],
+      "ruleMessage": "Calculation rollup: rs-gaap:NetIncomeLoss = ContinuingOps + DiscontinuedOps",
+      "ruleSeverity": "error",
+      "ruleOrigin": "native"
+    },
+    {
+      "@id": "_:rs-gaap-rollup-is-nonop",
+      "ruleCategory": "FundamentalAccountingConceptRelation",
+      "rulePattern": "RollUp",
+      "ruleExpression": "$NonoperatingIncomeExpense = ($InvestmentIncomeInterest - $InterestExpense + $GainLossOnDispositionOfAssets + $OtherNonoperatingIncomeExpense)",
+      "ruleTarget": {
+        "targetKind": "element",
+        "targetRef": "rs-gaap:NonoperatingIncomeExpense"
+      },
+      "ruleVariables": [
+        {
+          "variableName": "NonoperatingIncomeExpense",
+          "variableQname": "rs-gaap:NonoperatingIncomeExpense"
+        },
+        {
+          "variableName": "InvestmentIncomeInterest",
+          "variableQname": "rs-gaap:InvestmentIncomeInterest"
+        },
+        {
+          "variableName": "InterestExpense",
+          "variableQname": "rs-gaap:InterestExpense"
+        },
+        {
+          "variableName": "GainLossOnDispositionOfAssets",
+          "variableQname": "rs-gaap:GainLossOnDispositionOfAssets"
+        },
+        {
+          "variableName": "OtherNonoperatingIncomeExpense",
+          "variableQname": "rs-gaap:OtherNonoperatingIncomeExpense"
+        }
+      ],
+      "ruleMessage": "Calculation rollup: rs-gaap:NonoperatingIncomeExpense = \u03a3 rs-gaap nonoperating leaves",
+      "ruleSeverity": "error",
+      "ruleOrigin": "native"
+    },
+    {
+      "@id": "_:rs-gaap-rollup-is-operatingincome",
+      "ruleCategory": "FundamentalAccountingConceptRelation",
+      "rulePattern": "RollUp",
+      "ruleExpression": "$OperatingIncomeLoss = ($GrossProfit - $OperatingExpenses)",
+      "ruleTarget": {
+        "targetKind": "element",
+        "targetRef": "rs-gaap:OperatingIncomeLoss"
+      },
+      "ruleVariables": [
+        {
+          "variableName": "OperatingIncomeLoss",
+          "variableQname": "rs-gaap:OperatingIncomeLoss"
+        },
+        {
+          "variableName": "GrossProfit",
+          "variableQname": "rs-gaap:GrossProfit"
+        },
+        {
+          "variableName": "OperatingExpenses",
+          "variableQname": "rs-gaap:OperatingExpenses"
+        }
+      ],
+      "ruleMessage": "Calculation rollup: rs-gaap:OperatingIncomeLoss = rs-gaap:GrossProfit \u2212 rs-gaap:OperatingExpenses",
+      "ruleSeverity": "error",
+      "ruleOrigin": "native"
+    },
+    {
+      "@id": "_:rs-gaap-rollup-is-opex",
+      "ruleCategory": "FundamentalAccountingConceptRelation",
+      "rulePattern": "RollUp",
+      "ruleExpression": "$OperatingExpenses = ($SellingGeneralAndAdministrativeExpense + $ResearchAndDevelopmentExpense + $DepreciationDepletionAndAmortization + $OtherCostAndExpenseOperating)",
+      "ruleTarget": {
+        "targetKind": "element",
+        "targetRef": "rs-gaap:OperatingExpenses"
+      },
+      "ruleVariables": [
+        {
+          "variableName": "OperatingExpenses",
+          "variableQname": "rs-gaap:OperatingExpenses"
+        },
+        {
+          "variableName": "SellingGeneralAndAdministrativeExpense",
+          "variableQname": "rs-gaap:SellingGeneralAndAdministrativeExpense"
+        },
+        {
+          "variableName": "ResearchAndDevelopmentExpense",
+          "variableQname": "rs-gaap:ResearchAndDevelopmentExpense"
+        },
+        {
+          "variableName": "DepreciationDepletionAndAmortization",
+          "variableQname": "rs-gaap:DepreciationDepletionAndAmortization"
+        },
+        {
+          "variableName": "OtherCostAndExpenseOperating",
+          "variableQname": "rs-gaap:OtherCostAndExpenseOperating"
+        }
+      ],
+      "ruleMessage": "Calculation rollup: rs-gaap:OperatingExpenses = \u03a3 rs-gaap operating expense leaves",
+      "ruleSeverity": "error",
+      "ruleOrigin": "native"
+    },
+    {
+      "@id": "_:rs-gaap-rollup-is-pretax",
+      "ruleCategory": "FundamentalAccountingConceptRelation",
+      "rulePattern": "RollUp",
+      "ruleExpression": "$IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest = ($OperatingIncomeLoss + $NonoperatingIncomeExpense)",
+      "ruleTarget": {
+        "targetKind": "element",
+        "targetRef": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest"
+      },
+      "ruleVariables": [
+        {
+          "variableName": "IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
+          "variableQname": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest"
+        },
+        {
+          "variableName": "OperatingIncomeLoss",
+          "variableQname": "rs-gaap:OperatingIncomeLoss"
+        },
+        {
+          "variableName": "NonoperatingIncomeExpense",
+          "variableQname": "rs-gaap:NonoperatingIncomeExpense"
+        }
+      ],
+      "ruleMessage": "Calculation rollup: rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxes... = OperatingIncomeLoss + NonoperatingIncomeExpense \u2212 InterestExpense",
+      "ruleSeverity": "error",
+      "ruleOrigin": "native"
+    },
+    {
+      "@id": "_:rs-gaap-rollup-is-rev",
+      "ruleCategory": "FundamentalAccountingConceptRelation",
+      "rulePattern": "RollUp",
+      "ruleExpression": "$Revenues = ($SalesRevenueNet + $RevenueFromContractWithCustomerExcludingAssessedTax + $OtherSalesRevenueNet)",
+      "ruleTarget": {
+        "targetKind": "element",
+        "targetRef": "rs-gaap:Revenues"
+      },
+      "ruleVariables": [
+        {
+          "variableName": "Revenues",
+          "variableQname": "rs-gaap:Revenues"
+        },
+        {
+          "variableName": "SalesRevenueNet",
+          "variableQname": "rs-gaap:SalesRevenueNet"
+        },
+        {
+          "variableName": "RevenueFromContractWithCustomerExcludingAssessedTax",
+          "variableQname": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax"
+        },
+        {
+          "variableName": "OtherSalesRevenueNet",
+          "variableQname": "rs-gaap:OtherSalesRevenueNet"
+        }
+      ],
+      "ruleMessage": "Calculation rollup: rs-gaap:Revenues = \u03a3 rs-gaap revenue leaves",
+      "ruleSeverity": "error",
+      "ruleOrigin": "native"
+    }
+  ]
+}

--- a/frameworks/rs-gaap/packages/rs-gaap-rollup-rules/v1/taxonomy.jsonld
+++ b/frameworks/rs-gaap/packages/rs-gaap-rollup-rules/v1/taxonomy.jsonld
@@ -46,7 +46,6 @@
   "namespace_uri": "https://robosystems.ai/taxonomy/rs-gaap/rollup-rules/",
   "default_block_type": "validation_rules",
   "origin": "native",
-  "created_at": "2026-05-21",
   "description": "L2 calc-arc RollUp verification rules \u2014 one rule per subtotal parent in rs-gaap-calculations/v1 ($Parent = \u03a3 weighted children). RoboSystems-native (info-block \u00a76.1 Package II.a). Element-scoped to the parent concept so the rule fires against any rendered statement that presents that subtotal, across all equity-form variants. The RollUp evaluator treats a missing RHS child as 0 (matching the renderer); a missing parent subtotal skips. Regenerate via robosystems.taxonomy.scripts.generate_rollup_rules from rs-gaap-calculations/v1.",
   "@graph": [
     {

--- a/frameworks/rs-gaap/v1.json
+++ b/frameworks/rs-gaap/v1.json
@@ -17,7 +17,8 @@
     {"standard": "rs-gaap-disclosures",          "version": "v1", "ordinal": 6, "is_required": true},
     {"standard": "rs-gaap-disclosure-mechanics", "version": "v1", "ordinal": 7, "is_required": true},
     {"standard": "rs-gaap-reporting-checklist",  "version": "v1", "ordinal": 8, "is_required": true},
-    {"standard": "rs-gaap-reporting-styles",     "version": "v1", "ordinal": 9, "is_required": true}
+    {"standard": "rs-gaap-reporting-styles",     "version": "v1", "ordinal": 9, "is_required": true},
+    {"standard": "rs-gaap-rollup-rules",         "version": "v1", "ordinal": 10, "is_required": true}
   ],
   "bridges": [
     {"bridge": "fac-to-rs-gaap",                            "version": "v1", "ordinal": 0, "is_required": true},

--- a/robosystems/operations/information_block/rules/evaluators.py
+++ b/robosystems/operations/information_block/rules/evaluators.py
@@ -144,9 +144,22 @@ def _evaluate_rollup(rule: Any, bindings: dict[str, float | None]) -> Evaluation
     tolerance = float(rule.metadata_.get("tolerance", EQUALITY_TOLERANCE))
 
   # RHS children with no fact default to 0 (sum-of-present-children).
-  defaulted = [
-    n for n in variable_names if n not in required and bindings.get(n) is None
-  ]
+  rhs_names = [n for n in variable_names if n not in required]
+  defaulted = [n for n in rhs_names if bindings.get(n) is None]
+  # Parent present but NONE of its rollup children reported here: the
+  # rollup is vacuous (nothing to sum), which happens when an
+  # element-scoped rule fires in a statement that lists the subtotal as a
+  # standalone line but doesn't decompose it (e.g. NetIncomeLoss on the
+  # Cash Flow / Equity statements, where it's an input/total, not a
+  # rollup of ContinuingOps + Discontinued). Skip rather than report a
+  # spurious failure — the rule still evaluates in the subtotal's home
+  # statement where the children ARE presented.
+  if rhs_names and len(defaulted) == len(rhs_names):
+    return EvaluationOutcome(
+      status="skipped",
+      message="subtotal reported but none of its rollup children are present here",
+      detail={"bindings": _serializable(bindings), "absent_children": defaulted},
+    )
   bound: dict[str, float] = {
     n: (float(bindings[n]) if bindings.get(n) is not None else 0.0)
     for n in variable_names

--- a/robosystems/operations/information_block/rules/evaluators.py
+++ b/robosystems/operations/information_block/rules/evaluators.py
@@ -2,8 +2,12 @@
 
 Maps each ``rule_pattern`` value to an evaluation strategy:
 
-* ``EqualTo`` / ``RollUp`` / ``RollForward`` — arithmetic equality via
-  the safe AST parser; ``pass`` when ``abs(lhs - rhs) <= tolerance``.
+* ``EqualTo`` / ``RollForward`` — strict arithmetic equality via the
+  safe AST parser; ``pass`` when ``abs(lhs - rhs) <= tolerance``; any
+  unbound variable → ``skipped``.
+* ``RollUp`` — ``$Parent = Σ children``; the parent subtotal (LHS) must
+  be bound, but a missing RHS child is treated as 0 (the renderer sums
+  only present children); ``skipped`` only when the parent is unbound.
 * ``Exists`` — ``pass`` when the first variable's bound value is not
   ``None`` (i.e., a fact exists for that concept in the period).
 * ``CoExists`` — ``pass`` when *all* variables are bound or *all* are
@@ -23,6 +27,7 @@ from robosystems.operations.information_block.rules.expressions import (
   EQUALITY_TOLERANCE,
   InvalidRuleExpression,
   evaluate_equality,
+  lhs_variable_names,
   parse_arithmetic_expression,
 )
 
@@ -36,7 +41,7 @@ class EvaluationOutcome:
   detail: dict[str, Any] = field(default_factory=dict)
 
 
-_EQUALITY_PATTERNS = frozenset({"EqualTo", "RollUp", "RollForward"})
+_EQUALITY_PATTERNS = frozenset({"EqualTo", "RollForward"})
 
 
 def evaluate_rule(rule: Any, bindings: dict[str, float | None]) -> EvaluationOutcome:
@@ -49,6 +54,8 @@ def evaluate_rule(rule: Any, bindings: dict[str, float | None]) -> EvaluationOut
   pattern = rule.rule_pattern
   if pattern in _EQUALITY_PATTERNS:
     return _evaluate_equality_pattern(rule, bindings)
+  if pattern == "RollUp":
+    return _evaluate_rollup(rule, bindings)
   if pattern == "Exists":
     return _evaluate_exists(rule, bindings)
   if pattern == "CoExists":
@@ -94,6 +101,70 @@ def _evaluate_equality_pattern(
       "bindings": _serializable(bindings),
       "residual": residual,
       "tolerance": tolerance,
+    },
+  )
+
+
+def _evaluate_rollup(rule: Any, bindings: dict[str, float | None]) -> EvaluationOutcome:
+  """Evaluate a ``RollUp`` rule (``$Parent = Σ children``).
+
+  Unlike strict :func:`_evaluate_equality_pattern`, a missing RHS child
+  is treated as 0 — the renderer sums only the children that have facts
+  (all-zero rows are dropped), so a report that presents two of a
+  subtotal's six possible children must still satisfy the rollup. The
+  parent subtotal (the LHS) MUST be bound; if it isn't, the subtotal
+  wasn't reported, so there's nothing to verify → ``skipped``.
+  """
+  variable_names = [v["variable_name"] for v in (rule.rule_variables or [])]
+  if not variable_names:
+    return EvaluationOutcome(
+      status="skipped", message="RollUp rule has no variables", detail={}
+    )
+  try:
+    parsed = parse_arithmetic_expression(rule.rule_expression, variable_names)
+    required = lhs_variable_names(parsed)
+  except InvalidRuleExpression as exc:
+    return EvaluationOutcome(
+      status="error", message=str(exc), detail={"expression": rule.rule_expression}
+    )
+
+  missing_subtotal = [n for n in required if bindings.get(n) is None]
+  if missing_subtotal:
+    return EvaluationOutcome(
+      status="skipped",
+      message=f"no fact bound for subtotal: {', '.join(missing_subtotal)}",
+      detail={
+        "bindings": _serializable(bindings),
+        "missing_subtotal": missing_subtotal,
+      },
+    )
+
+  tolerance = EQUALITY_TOLERANCE
+  if rule.metadata_ and isinstance(rule.metadata_, dict):
+    tolerance = float(rule.metadata_.get("tolerance", EQUALITY_TOLERANCE))
+
+  # RHS children with no fact default to 0 (sum-of-present-children).
+  defaulted = [
+    n for n in variable_names if n not in required and bindings.get(n) is None
+  ]
+  bound: dict[str, float] = {
+    n: (float(bindings[n]) if bindings.get(n) is not None else 0.0)
+    for n in variable_names
+  }
+  try:
+    passed, residual = evaluate_equality(parsed, bound, tolerance=tolerance)
+  except InvalidRuleExpression as exc:
+    return EvaluationOutcome(
+      status="error", message=str(exc), detail={"expression": rule.rule_expression}
+    )
+  return EvaluationOutcome(
+    status="pass" if passed else "fail",
+    message=None if passed else f"rollup failed; residual = {residual:.2f}",
+    detail={
+      "bindings": _serializable(bindings),
+      "residual": residual,
+      "tolerance": tolerance,
+      "children_defaulted_to_zero": defaulted,
     },
   )
 

--- a/robosystems/operations/information_block/rules/expressions.py
+++ b/robosystems/operations/information_block/rules/expressions.py
@@ -162,6 +162,38 @@ def evaluate_equality(
   return residual <= tolerance, residual
 
 
+def variable_names_in(node: ast.AST) -> list[str]:
+  """Return the rule variable names (``$Name`` → ``Name``) used in a subtree.
+
+  Walks the AST for ``_var_`` identifiers (the preprocessed form of
+  ``$Name``) and strips the prefix. Order follows ``ast.walk``.
+  """
+  names: list[str] = []
+  for child in ast.walk(node):
+    if isinstance(child, ast.Name) and child.id.startswith("_var_"):
+      names.append(child.id[len("_var_") :])
+  return names
+
+
+def lhs_variable_names(parsed: ParsedExpression) -> list[str]:
+  """Variable names on the left of the equality — the subtotal being checked.
+
+  Used by the ``RollUp`` evaluator to distinguish the parent subtotal
+  (which must have a bound fact) from the RHS children (a missing child
+  is treated as 0, matching the renderer's sum-of-present-children).
+  """
+  body = parsed.tree.body
+  if (
+    not isinstance(body, ast.Compare)
+    or len(body.ops) != 1
+    or not isinstance(body.ops[0], ast.Eq)
+  ):
+    raise InvalidRuleExpression(
+      f"expected a single LHS = RHS expression, got: {ast.dump(body)}"
+    )
+  return variable_names_in(body.left)
+
+
 def evaluate_arithmetic(parsed: ParsedExpression, values: dict[str, float]) -> float:
   """Evaluate a single arithmetic expression (no equality) to a float.
 
@@ -180,5 +212,7 @@ __all__ = [
   "ParsedExpression",
   "evaluate_arithmetic",
   "evaluate_equality",
+  "lhs_variable_names",
   "parse_arithmetic_expression",
+  "variable_names_in",
 ]

--- a/robosystems/operations/operators/implementations/mapping/constants.py
+++ b/robosystems/operations/operators/implementations/mapping/constants.py
@@ -82,18 +82,21 @@ FAC_TO_RS_GAAP_FALLBACK: dict[str, str] = {
   # paid-in catch-all that isn't a rollup.
   "fac:Equity": "rs-gaap:AdditionalPaidInCapital",
   "fac:EquityAttributableToParent": "rs-gaap:AdditionalPaidInCapital",
-  # Revenues
-  "fac:Revenues": "rs-gaap:OtherIncome",
-  "fac:OtherOperatingIncomeExpenses": "rs-gaap:OtherIncome",
+  # Revenues — OtherSalesRevenueNet is the operating-revenue catch-all
+  # leaf wired under rs-gaap:Revenues (NOT OtherIncome, which is
+  # non-operating and isn't a child of the Revenues rollup → would drop).
+  "fac:Revenues": "rs-gaap:OtherSalesRevenueNet",
+  "fac:OtherOperatingIncomeExpenses": "rs-gaap:OtherCostAndExpenseOperating",
   "fac:NonoperatingIncomeLoss": "rs-gaap:OtherNonoperatingIncomeExpense",
-  # Cost of Revenue — note: rs-gaap:CostOfRevenue itself is a rollup;
-  # CostOfGoodsAndServicesSold is the catch-all leaf.
-  "fac:CostOfRevenue": "rs-gaap:CostOfGoodsAndServicesSold",
-  "fac:CostOfRevenueGoods": "rs-gaap:CostOfGoodsAndServicesSold",
-  "fac:CostOfRevenueServices": "rs-gaap:CostOfGoodsAndServicesSold",
-  # Operating expenses
+  # Cost of Revenue — rs-gaap:CostOfRevenue itself is a rollup;
+  # OtherCostOfOperatingRevenue is the catch-all leaf wired under it.
+  "fac:CostOfRevenue": "rs-gaap:OtherCostOfOperatingRevenue",
+  "fac:CostOfRevenueGoods": "rs-gaap:OtherCostOfOperatingRevenue",
+  "fac:CostOfRevenueServices": "rs-gaap:OtherCostOfOperatingRevenue",
+  # Operating expenses — OtherCostAndExpenseOperating is the catch-all
+  # leaf wired under rs-gaap:OperatingExpenses.
   "fac:OperatingExpenses": "rs-gaap:OtherCostAndExpenseOperating",
-  "fac:ExciseAndSalesTaxes": "rs-gaap:TaxesExcludingIncomeAndExciseTaxes",
+  "fac:ExciseAndSalesTaxes": "rs-gaap:OtherCostAndExpenseOperating",
 }
 
 # Confidence stamp for fallback-driven mappings. Below

--- a/robosystems/operations/roboledger/commands/reports.py
+++ b/robosystems/operations/roboledger/commands/reports.py
@@ -178,14 +178,24 @@ def _build_structure_mapping(
   if not picked_structure_ids:
     return {}, {}
 
+  # Map BOTH endpoints of every arc to the structure, not just
+  # ``to_element_id``. A subtotal that sits at the top of its tree
+  # (e.g. ``rs-gaap:Assets``, ``rs-gaap:LiabilitiesAndStockholdersEquity``)
+  # appears only as a ``from_element_id`` (parent), so a to-only mapping
+  # never stamps its persisted subtotal fact into the structure's FactSet
+  # — and the balance-identity rule scoped to it can't bind. Abstract
+  # parents carry no facts, so including ``from_element_id`` is harmless
+  # for them and load-bearing for top-level subtotals.
   rows = session.execute(
     text(
       """
-      SELECT DISTINCT
-        a.structure_id AS structure_id,
-        a.to_element_id AS element_id
+      SELECT DISTINCT a.structure_id AS structure_id, a.to_element_id AS element_id
       FROM associations a
-      WHERE a.structure_id = ANY(:struct_ids)
+      WHERE a.structure_id = ANY(:struct_ids) AND a.to_element_id IS NOT NULL
+      UNION
+      SELECT DISTINCT a.structure_id AS structure_id, a.from_element_id AS element_id
+      FROM associations a
+      WHERE a.structure_id = ANY(:struct_ids) AND a.from_element_id IS NOT NULL
       """
     ),
     {"struct_ids": picked_structure_ids},
@@ -246,6 +256,15 @@ def _persist_report_facts(
         fact_set_id=fact_set_id,
       )
       session.add(rf)
+
+  # Flush so every fact is visible to the rule-evaluation binds that
+  # follow. The session runs ``autoflush=False``, and
+  # ``_evaluate_report_structures`` iterates structures in
+  # non-deterministic set order; without an explicit flush here the
+  # FIRST structure evaluated would bind against unflushed facts and
+  # spuriously ``skip`` every rule (the terminal flush inside the first
+  # ``evaluate_rules_for_structure`` would only rescue the later ones).
+  session.flush()
 
 
 def _pre_create_report_fact_sets(

--- a/robosystems/operations/roboledger/reports/fact_grid.py
+++ b/robosystems/operations/roboledger/reports/fact_grid.py
@@ -226,6 +226,12 @@ def generate_report_facts(
   # financing were already emitted from flow concepts above.
   _derive_cash_flow_facts(session, facts, periods)
 
+  # Persist the calc-DAG subtotals (Assets, Revenues, GrossProfit,
+  # StockholdersEquity, …) as facts. Runs last so every leaf + derived
+  # fact above is in place; the rollup reads them and emits one subtotal
+  # fact per period so verification rules scoped to a subtotal can bind.
+  _emit_subtotal_facts(session, facts, periods)
+
   unmapped_count = _count_unmapped(session, mapping_id, arc_type=arc_type)
 
   return ReportFacts(
@@ -901,6 +907,108 @@ def _emit_net_income_facts(
         period_type="duration",
       )
     )
+
+
+def _emit_subtotal_facts(
+  session: Session,
+  facts: list[ReportFact],
+  periods: list[PeriodSpec],
+) -> None:
+  """Emit one fact per rs-gaap calculation subtotal, per period.
+
+  Subtotals (Assets, Revenues, GrossProfit, StockholdersEquity, …) are
+  otherwise computed only at render time (``_build_rows``) and never
+  persisted, so a verification rule scoped to a subtotal never binds a
+  fact and silently ``skipped``s. This walks the ``rs-gaap-calculations``
+  DAG bottom-up over the already-emitted leaf + derived facts, applying
+  the same ``Σ child·weight`` resolution the renderer uses, and emits a
+  fact for each subtotal not already present.
+
+  Consistency with display is by construction: the persisted value is the
+  same topological calc resolution ``_build_rows`` runs, so the renderer's
+  "prefer direct fact, else sum children" logic reads the persisted
+  subtotal and shows the identical number. A subtotal that already has a
+  direct fact (e.g. ``NetIncomeLoss`` from the close) is left untouched —
+  its authoritative value wins, exactly as in ``_build_rows``.
+
+  Must run LAST in ``generate_report_facts`` so every leaf + derived fact
+  (NetIncomeLoss, PP&E net, CF flows) is in place. Mutates ``facts``.
+  """
+  rows = session.execute(
+    text("""
+      SELECT a.from_element_id AS parent, a.to_element_id AS child, a.weight
+      FROM associations a
+      JOIN structures s ON s.id = a.structure_id
+      JOIN taxonomies t ON t.id = s.taxonomy_id
+      WHERE a.association_type = 'calculation'
+        AND t.standard = 'rs-gaap-calculations'
+      ORDER BY a.order_value
+    """)
+  ).fetchall()
+  if not rows:
+    return
+  calculations: dict[str, list[tuple[str, float]]] = {}
+  for r in rows:
+    weight = float(r.weight) if r.weight is not None else 1.0
+    calculations.setdefault(r.parent, []).append((r.child, weight))
+
+  target_ids = list(calculations.keys())
+  meta = {
+    m.id: m
+    for m in session.execute(
+      text(
+        "SELECT id, qname, name, balance_type, period_type "
+        "FROM elements WHERE id = ANY(:ids)"
+      ),
+      {"ids": target_ids},
+    ).fetchall()
+  }
+
+  order = _topo_sort_calculations(calculations)
+
+  for period in periods:
+    balances: dict[str, float] = {}
+    present: set[str] = set()
+    for f in facts:
+      if f.period_start == period.start and f.period_end == period.end:
+        balances[f.element_id] = balances.get(f.element_id, 0.0) + f.value
+        present.add(f.element_id)
+
+    # Topological resolution — direct fact wins over the calc result,
+    # matching ``_build_rows`` (calc is the fallback for un-reported
+    # subtotals, never an override of an authoritative direct fact).
+    computed: dict[str, float] = dict(balances)
+    for elem_id in order:
+      direct = computed.get(elem_id, 0.0)
+      summed = sum(computed.get(src, 0.0) * w for src, w in calculations[elem_id])
+      computed[elem_id] = direct if direct != 0.0 else summed
+
+    for elem_id in target_ids:
+      # Already a fact (leaf-mapped or a prior derived emit like
+      # NetIncomeLoss) → leave it; the direct value is authoritative.
+      if elem_id in present:
+        continue
+      value = computed.get(elem_id, 0.0)
+      # Zero subtotals are dropped by the renderer and have nothing to
+      # verify — skip so the facts table isn't padded with empties.
+      if value == 0.0:
+        continue
+      m = meta.get(elem_id)
+      if m is None:
+        continue
+      facts.append(
+        ReportFact(
+          element_id=elem_id,
+          element_qname=m.qname,
+          element_name=m.name or m.qname,
+          classification=None,  # subtotals aren't leaf revenue/expense
+          balance_type=m.balance_type or "credit",
+          value=value,
+          period_start=period.start,
+          period_end=period.end,
+          period_type=m.period_type or "instant",
+        )
+      )
 
 
 def _synthesize_ppe_net_facts(

--- a/robosystems/operations/roboledger/reports/fact_grid.py
+++ b/robosystems/operations/roboledger/reports/fact_grid.py
@@ -974,14 +974,18 @@ def _emit_subtotal_facts(
         balances[f.element_id] = balances.get(f.element_id, 0.0) + f.value
         present.add(f.element_id)
 
-    # Topological resolution — direct fact wins over the calc result,
-    # matching ``_build_rows`` (calc is the fallback for un-reported
-    # subtotals, never an override of an authoritative direct fact).
+    # Topological resolution — a direct fact wins over the calc result
+    # (calc is the fallback for un-reported subtotals, never an override
+    # of an authoritative direct fact). The "direct wins" test keys off
+    # PRESENCE (``elem_id in present``), not a non-zero value: a
+    # legitimately-zero direct fact (e.g. a seeded equity component, or a
+    # subtotal reported as 0) must not be overwritten by the calc sum, or
+    # a downstream subtotal that depends on it inherits the wrong summand.
     computed: dict[str, float] = dict(balances)
     for elem_id in order:
       direct = computed.get(elem_id, 0.0)
       summed = sum(computed.get(src, 0.0) * w for src, w in calculations[elem_id])
-      computed[elem_id] = direct if direct != 0.0 else summed
+      computed[elem_id] = direct if elem_id in present else summed
 
     for elem_id in target_ids:
       # Already a fact (leaf-mapped or a prior derived emit like

--- a/robosystems/taxonomy/scripts/__init__.py
+++ b/robosystems/taxonomy/scripts/__init__.py
@@ -1,0 +1,7 @@
+"""One-time taxonomy generation scripts.
+
+These build JSON-LD seed packages from in-repo source data (e.g. calc
+arcs). They are dev/build tools — the committed artifact is the JSON-LD
+output under ``frameworks/``, not the script run. Pure builder functions
+are unit-tested; ``main()`` writes the package to disk.
+"""

--- a/robosystems/taxonomy/scripts/generate_rollup_rules.py
+++ b/robosystems/taxonomy/scripts/generate_rollup_rules.py
@@ -181,7 +181,6 @@ def build_package(rules: list[dict]) -> dict:
     "namespace_uri": "https://robosystems.ai/taxonomy/rs-gaap/rollup-rules/",
     "default_block_type": "validation_rules",
     "origin": "native",
-    "created_at": "2026-05-21",
     "description": (
       "L2 calc-arc RollUp verification rules — one rule per subtotal parent "
       "in rs-gaap-calculations/v1 ($Parent = Σ weighted children). "

--- a/robosystems/taxonomy/scripts/generate_rollup_rules.py
+++ b/robosystems/taxonomy/scripts/generate_rollup_rules.py
@@ -1,0 +1,211 @@
+"""Generate L2 calc-arc RollUp rules from ``rs-gaap-calculations/v1``.
+
+Each calculation Network in ``rs-gaap-calculations`` declares a subtotal
+parent (``arcFrom``) and its weighted children (``arcTo`` + ``arcWeight``).
+This script walks those Networks and emits one ``RollUp`` verification
+rule per parent — ``$Parent = Σ child_i * weight_i`` — into the
+``rs-gaap-rollup-rules/v1`` package, making calc-DAG consistency explicit
+and queryable in Verification Results (today it's only enforced
+implicitly by the renderer's guard rails).
+
+Rules are **element-scoped** to the parent concept (``targetKind:
+"element"``, ``targetRef`` = the parent qname). The rule engine evaluates
+rules against the *rendered* presentation Network and binds facts from
+that Network's FactSet; element-scoping to the parent makes the rule fire
+whenever a rendered statement presents that subtotal — across every
+equity-form Balance Sheet variant and Reporting Style — without coupling
+to a specific presentation role-URI.
+
+The ``RollUp`` evaluator treats a missing RHS child as 0 (matching the
+renderer, which sums only the children that have facts); a missing parent
+subtotal skips. See ``operations/information_block/rules/evaluators.py``.
+
+Run: ``uv run python -m robosystems.taxonomy.scripts.generate_rollup_rules``
+The committed artifact is the JSON-LD output, not this script.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+_FRAMEWORKS = Path(__file__).resolve().parents[3] / "frameworks"
+_CALC_SOURCE = (
+  _FRAMEWORKS
+  / "rs-gaap"
+  / "packages"
+  / "rs-gaap-calculations"
+  / "v1"
+  / "taxonomy.jsonld"
+)
+_OUTPUT = (
+  _FRAMEWORKS
+  / "rs-gaap"
+  / "packages"
+  / "rs-gaap-rollup-rules"
+  / "v1"
+  / "taxonomy.jsonld"
+)
+
+_VOCAB = "https://robosystems.ai/vocab/"
+
+_CONTEXT = {
+  "rs-gaap": "https://robosystems.ai/taxonomy/rs-gaap/v1/",
+  "rs": _VOCAB,
+  "ruleCategory": {"@id": f"{_VOCAB}ruleCategory"},
+  "rulePattern": {"@id": f"{_VOCAB}rulePattern"},
+  "ruleExpression": {"@id": f"{_VOCAB}ruleExpression"},
+  "ruleTarget": {"@id": f"{_VOCAB}ruleTarget"},
+  "targetKind": {"@id": f"{_VOCAB}targetKind"},
+  # NOTE: targetRef is a literal qname here (NOT @type:@id). The library
+  # creator resolves element targets by ``Element.qname`` match, so the
+  # raw "rs-gaap:Foo" string must survive parsing un-expanded.
+  "targetRef": {"@id": f"{_VOCAB}targetRef"},
+  "ruleVariables": {"@id": f"{_VOCAB}ruleVariables", "@container": "@list"},
+  "variableName": {"@id": f"{_VOCAB}variableName"},
+  "variableQname": {"@id": f"{_VOCAB}variableQname"},
+  "ruleMessage": {"@id": f"{_VOCAB}ruleMessage"},
+  "ruleSeverity": {"@id": f"{_VOCAB}ruleSeverity"},
+  "ruleOrigin": {"@id": f"{_VOCAB}ruleOrigin"},
+}
+
+
+def _local(qname: str) -> str:
+  """``rs-gaap:Assets`` -> ``Assets`` (the rule-expression variable name)."""
+  return qname.split(":", 1)[1] if ":" in qname else qname
+
+
+def _role_slug(role_uri: str) -> str:
+  """``.../rs-gaap-calculations/BS-Assets`` -> ``bs-assets`` (stable @id suffix)."""
+  return role_uri.rstrip("/").rsplit("/", 1)[-1].lower()
+
+
+def _build_expression(parent: str, children: list[tuple[str, float]]) -> str:
+  """``$Parent = ($childA + $childB - $childC ...)``.
+
+  Weight +1 -> ``+``, -1 -> ``-``, otherwise an explicit ``* weight`` term.
+  """
+  parts: list[str] = []
+  for idx, (child_qname, weight) in enumerate(children):
+    var = f"${_local(child_qname)}"
+    if weight == 1.0:
+      sign, term = "+", var
+    elif weight == -1.0:
+      sign, term = "-", var
+    else:
+      # Render -0.0 cleanly and keep weight literal for non-unit weights.
+      sign, term = "+", f"({var} * {weight})"
+    if idx == 0:
+      parts.append(term if sign == "+" else f"-{term}")
+    else:
+      parts.append(f"{sign} {term}")
+  rhs = " ".join(parts)
+  return f"${_local(parent)} = ({rhs})"
+
+
+def build_rollup_rules(graph: list[dict]) -> list[dict]:
+  """Pure transform: calc ``@graph`` -> list of RollUp rule nodes.
+
+  Groups calculation arcs by ``arcRoleUri`` (one Network = one subtotal
+  parent), then emits one RollUp rule per Network. Deterministic order:
+  by role-URI suffix.
+  """
+  role_name: dict[str, str] = {}
+  # role_uri -> (parent_qname, [(child_qname, weight, order)])
+  groups: dict[str, list[tuple[str, float, float]]] = {}
+  parents: dict[str, str] = {}
+
+  for node in graph:
+    if "roleUri" in node:
+      role_name[node["roleUri"]] = node.get("structureName", "")
+      continue
+    if "arcFrom" not in node:
+      continue
+    if node.get("arcAssociationType") != "calculation":
+      continue
+    role = node["arcRoleUri"]
+    parent = node["arcFrom"]["@id"]
+    child = node["arcTo"]["@id"]
+    weight = float(node.get("arcWeight", 1.0))
+    order = float(node.get("arcOrder", 0.0))
+    if role in parents and parents[role] != parent:
+      raise ValueError(
+        f"calc Network {role!r} has multiple parents "
+        f"({parents[role]!r} and {parent!r}); a RollUp rule needs one parent"
+      )
+    parents[role] = parent
+    groups.setdefault(role, []).append((child, weight, order))
+
+  rules: list[dict] = []
+  for role in sorted(groups, key=_role_slug):
+    parent = parents[role]
+    children_sorted = sorted(groups[role], key=lambda t: t[2])
+    children = [(cq, w) for cq, w, _ in children_sorted]
+
+    variables = [{"variableName": _local(parent), "variableQname": parent}]
+    for child_qname, _w in children:
+      variables.append(
+        {"variableName": _local(child_qname), "variableQname": child_qname}
+      )
+
+    formula = role_name.get(role, "")
+    message = (
+      f"Calculation rollup ({_role_slug(role)}): {_local(parent)} must equal "
+      f"the calculation sum of its children."
+    )
+    if "—" in formula:
+      message = f"Calculation rollup: {formula.split('—', 1)[1].strip()}"
+
+    rules.append(
+      {
+        "@id": f"_:rs-gaap-rollup-{_role_slug(role)}",
+        "ruleCategory": "FundamentalAccountingConceptRelation",
+        "rulePattern": "RollUp",
+        "ruleExpression": _build_expression(parent, children),
+        "ruleTarget": {"targetKind": "element", "targetRef": parent},
+        "ruleVariables": variables,
+        "ruleMessage": message,
+        "ruleSeverity": "error",
+        "ruleOrigin": "native",
+      }
+    )
+  return rules
+
+
+def build_package(rules: list[dict]) -> dict:
+  return {
+    "@context": _CONTEXT,
+    "standard": "rs-gaap-rollup-rules",
+    "version": "v1",
+    "taxonomy_type": "rules",
+    "namespace_uri": "https://robosystems.ai/taxonomy/rs-gaap/rollup-rules/",
+    "default_block_type": "validation_rules",
+    "origin": "native",
+    "created_at": "2026-05-21",
+    "description": (
+      "L2 calc-arc RollUp verification rules — one rule per subtotal parent "
+      "in rs-gaap-calculations/v1 ($Parent = Σ weighted children). "
+      "RoboSystems-native (info-block §6.1 Package II.a). Element-scoped to the "
+      "parent concept so the rule fires against any rendered statement that "
+      "presents that subtotal, across all equity-form variants. The RollUp "
+      "evaluator treats a missing RHS child as 0 (matching the renderer); a "
+      "missing parent subtotal skips. Regenerate via "
+      "robosystems.taxonomy.scripts.generate_rollup_rules from rs-gaap-calculations/v1."
+    ),
+    "@graph": rules,
+  }
+
+
+def main() -> None:
+  graph = json.loads(_CALC_SOURCE.read_text())["@graph"]
+  rules = build_rollup_rules(graph)
+  package = build_package(rules)
+  _OUTPUT.parent.mkdir(parents=True, exist_ok=True)
+  _OUTPUT.write_text(json.dumps(package, indent=2) + "\n")
+  print(f"Wrote {len(rules)} RollUp rules to {_OUTPUT.relative_to(_FRAMEWORKS.parent)}")
+  for rule in rules:
+    print(f"  {rule['@id']:42s} {rule['ruleExpression']}")
+
+
+if __name__ == "__main__":
+  main()

--- a/tests/operations/information_block/rules/test_evaluators.py
+++ b/tests/operations/information_block/rules/test_evaluators.py
@@ -89,6 +89,53 @@ class TestRollUpPattern:
     outcome = evaluate_rule(rule, {"Total": 1001.0, "Part1": 600.0, "Part2": 400.0})
     assert outcome.status == "fail"
 
+  def _three_part_rule(self) -> MagicMock:
+    return _make_rule(
+      pattern="RollUp",
+      expression="$Total = ($Part1 + $Part2 + $Part3)",
+      variables=[
+        {"variable_name": "Total", "variable_qname": "rs-gaap:Total"},
+        {"variable_name": "Part1", "variable_qname": "rs-gaap:Part1"},
+        {"variable_name": "Part2", "variable_qname": "rs-gaap:Part2"},
+        {"variable_name": "Part3", "variable_qname": "rs-gaap:Part3"},
+      ],
+    )
+
+  def test_missing_child_treated_as_zero_passes(self) -> None:
+    """The renderer drops all-zero rows, so a rollup must still pass when
+    an unreported child is absent — it's summed as 0."""
+    rule = self._three_part_rule()
+    outcome = evaluate_rule(
+      rule, {"Total": 1000.0, "Part1": 600.0, "Part2": 400.0, "Part3": None}
+    )
+    assert outcome.status == "pass"
+    assert outcome.detail["children_defaulted_to_zero"] == ["Part3"]
+
+  def test_missing_child_treated_as_zero_can_fail(self) -> None:
+    """A present subtotal that doesn't equal the sum of its present
+    children is a genuine rollup violation (not masked by the 0 default)."""
+    rule = self._three_part_rule()
+    outcome = evaluate_rule(
+      rule, {"Total": 1000.0, "Part1": 600.0, "Part2": 300.0, "Part3": None}
+    )
+    assert outcome.status == "fail"
+    assert "rollup failed" in (outcome.message or "")
+
+  def test_skipped_when_parent_subtotal_missing(self) -> None:
+    """No parent fact means the subtotal wasn't reported — nothing to
+    verify, so skip rather than treat the LHS as 0."""
+    rule = self._three_part_rule()
+    outcome = evaluate_rule(
+      rule, {"Total": None, "Part1": 600.0, "Part2": 400.0, "Part3": None}
+    )
+    assert outcome.status == "skipped"
+    assert "subtotal" in (outcome.message or "")
+
+  def test_skipped_when_no_variables(self) -> None:
+    rule = _make_rule(pattern="RollUp", expression="$X = $Y", variables=[])
+    outcome = evaluate_rule(rule, {})
+    assert outcome.status == "skipped"
+
 
 class TestRollForwardPattern:
   def test_pass_when_equal(self) -> None:

--- a/tests/operations/information_block/rules/test_evaluators.py
+++ b/tests/operations/information_block/rules/test_evaluators.py
@@ -131,6 +131,18 @@ class TestRollUpPattern:
     assert outcome.status == "skipped"
     assert "subtotal" in (outcome.message or "")
 
+  def test_skipped_when_all_children_absent(self) -> None:
+    """Parent present but EVERY child absent → vacuous rollup → skip, not
+    a spurious fail. Happens when an element-scoped rule fires in a
+    statement that lists the subtotal as a standalone line without
+    decomposing it (e.g. NetIncomeLoss on the CF / Equity statements)."""
+    rule = self._three_part_rule()
+    outcome = evaluate_rule(
+      rule, {"Total": 1000.0, "Part1": None, "Part2": None, "Part3": None}
+    )
+    assert outcome.status == "skipped"
+    assert "none of its rollup children" in (outcome.message or "")
+
   def test_skipped_when_no_variables(self) -> None:
     rule = _make_rule(pattern="RollUp", expression="$X = $Y", variables=[])
     outcome = evaluate_rule(rule, {})

--- a/tests/operations/information_block/rules/test_expressions.py
+++ b/tests/operations/information_block/rules/test_expressions.py
@@ -8,8 +8,25 @@ from robosystems.operations.information_block.rules.expressions import (
   EQUALITY_TOLERANCE,
   InvalidRuleExpression,
   evaluate_equality,
+  lhs_variable_names,
   parse_arithmetic_expression,
 )
+
+
+class TestLhsVariableNames:
+  def test_returns_only_left_side_variables(self) -> None:
+    """The RollUp evaluator uses this to find the parent subtotal (LHS),
+    which must be bound; RHS children default to 0 when missing."""
+    parsed = parse_arithmetic_expression(
+      "$Assets = ($AssetsCurrent + $AssetsNoncurrent)",
+      ["Assets", "AssetsCurrent", "AssetsNoncurrent"],
+    )
+    assert lhs_variable_names(parsed) == ["Assets"]
+
+  def test_raises_when_not_an_equality(self) -> None:
+    parsed = parse_arithmetic_expression("$A + $B", ["A", "B"])
+    with pytest.raises(InvalidRuleExpression):
+      lhs_variable_names(parsed)
 
 
 class TestParseArithmeticExpression:

--- a/tests/operations/roboledger/reports/test_subtotal_facts.py
+++ b/tests/operations/roboledger/reports/test_subtotal_facts.py
@@ -113,3 +113,47 @@ class TestEmitSubtotalFacts:
     facts = [_leaf("PPE", 0.0)]
     _emit_subtotal_facts(_session(dag, ["AssetsNoncurrent"]), facts, [_P])
     assert all(f.element_id != "AssetsNoncurrent" for f in facts)
+
+  def test_zero_direct_fact_wins_over_calc_sum_for_downstream(self) -> None:
+    """A calc target with a zero-valued DIRECT fact must contribute its 0
+    to a downstream subtotal — 'direct wins' keys off presence, not a
+    non-zero test. Regression for the zero-value bypass: with a non-zero
+    test, SubA would wrongly resolve to its calc sum (100) and Parent
+    would be 150 instead of 50."""
+    dag = [
+      _dag_row("SubA", "Leaf1", 1.0),  # SubA is a target with a direct 0.0 fact
+      _dag_row("Parent", "SubA", 1.0),
+      _dag_row("Parent", "SubB", 1.0),
+    ]
+    facts = [
+      _leaf("SubA", 0.0),  # authoritative direct fact = 0 (present)
+      _leaf("Leaf1", 100.0),  # SubA's calc sum would be 100 — must NOT win
+      _leaf("SubB", 50.0),
+    ]
+    _emit_subtotal_facts(_session(dag, ["SubA", "Parent"]), facts, [_P])
+    parent = next(f for f in facts if f.element_id == "Parent")
+    assert parent.value == 50.0  # SubA contributes its direct 0, not the 100 sum
+
+  def test_subtotals_computed_per_period_independently(self) -> None:
+    """Each period's subtotal sums only that period's leaves — no bleed."""
+    p2 = PeriodSpec(start=date(2024, 1, 1), end=date(2024, 12, 31), label="FY2024")
+
+    def leaf_p(eid: str, value: float, period: PeriodSpec) -> ReportFact:
+      return ReportFact(
+        element_id=eid,
+        element_qname=f"rs-gaap:{eid}",
+        element_name=eid,
+        classification="asset",
+        balance_type="debit",
+        value=value,
+        period_start=period.start,
+        period_end=period.end,
+        period_type="instant",
+      )
+
+    dag = [_dag_row("AssetsCurrent", "Cash", 1.0)]
+    facts = [leaf_p("Cash", 100.0, _P), leaf_p("Cash", 200.0, p2)]
+    _emit_subtotal_facts(_session(dag, ["AssetsCurrent"]), facts, [_P, p2])
+    ac = {f.period_start: f.value for f in facts if f.element_id == "AssetsCurrent"}
+    assert ac[_P.start] == 100.0
+    assert ac[p2.start] == 200.0

--- a/tests/operations/roboledger/reports/test_subtotal_facts.py
+++ b/tests/operations/roboledger/reports/test_subtotal_facts.py
@@ -1,0 +1,115 @@
+"""Unit tests for ``_emit_subtotal_facts`` — persisting calc-DAG subtotals.
+
+The function walks the rs-gaap-calculations DAG bottom-up over the
+already-emitted leaf facts and emits one fact per subtotal, so verification
+rules scoped to a subtotal can bind (info-block §6.1). The session is mocked
+so the rollup math is tested without a database.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from robosystems.operations.roboledger.reports.fact_grid import (
+  PeriodSpec,
+  ReportFact,
+  _emit_subtotal_facts,
+)
+
+_P = PeriodSpec(start=date(2025, 1, 1), end=date(2025, 12, 31), label="FY2025")
+
+
+def _leaf(eid: str, value: float) -> ReportFact:
+  return ReportFact(
+    element_id=eid,
+    element_qname=f"rs-gaap:{eid}",
+    element_name=eid,
+    classification="asset",
+    balance_type="debit",
+    value=value,
+    period_start=_P.start,
+    period_end=_P.end,
+    period_type="instant",
+  )
+
+
+def _dag_row(parent: str, child: str, weight: float) -> SimpleNamespace:
+  return SimpleNamespace(parent=parent, child=child, weight=weight)
+
+
+def _meta_row(eid: str) -> SimpleNamespace:
+  return SimpleNamespace(
+    id=eid,
+    qname=f"rs-gaap:{eid}",
+    name=eid,
+    balance_type="debit",
+    period_type="instant",
+  )
+
+
+def _session(dag_rows: list, target_ids: list[str]) -> MagicMock:
+  """Mock session: 1st execute → DAG rows, 2nd execute → element meta."""
+  session = MagicMock()
+  dag_result = MagicMock()
+  dag_result.fetchall.return_value = dag_rows
+  meta_result = MagicMock()
+  meta_result.fetchall.return_value = [_meta_row(t) for t in target_ids]
+  session.execute.side_effect = [dag_result, meta_result]
+  return session
+
+
+# DAG: AssetsCurrent = Cash + AR; AssetsNoncurrent = PPE;
+#      Assets = AssetsCurrent + AssetsNoncurrent
+_DAG = [
+  _dag_row("AssetsCurrent", "Cash", 1.0),
+  _dag_row("AssetsCurrent", "AR", 1.0),
+  _dag_row("AssetsNoncurrent", "PPE", 1.0),
+  _dag_row("Assets", "AssetsCurrent", 1.0),
+  _dag_row("Assets", "AssetsNoncurrent", 1.0),
+]
+_TARGETS = ["AssetsCurrent", "AssetsNoncurrent", "Assets"]
+
+
+class TestEmitSubtotalFacts:
+  def test_emits_subtotals_bottom_up(self) -> None:
+    facts = [_leaf("Cash", 100.0), _leaf("AR", 20.0), _leaf("PPE", 30.0)]
+    _emit_subtotal_facts(_session(_DAG, _TARGETS), facts, [_P])
+    by_id = {f.element_id: f.value for f in facts}
+    assert by_id["AssetsCurrent"] == 120.0  # 100 + 20
+    assert by_id["AssetsNoncurrent"] == 30.0
+    assert by_id["Assets"] == 150.0  # 120 + 30 (depends on the computed children)
+
+  def test_weighted_subtraction(self) -> None:
+    dag = [
+      _dag_row("GrossProfit", "Revenues", 1.0),
+      _dag_row("GrossProfit", "CostOfRevenue", -1.0),
+    ]
+    facts = [_leaf("Revenues", 175000.0), _leaf("CostOfRevenue", 60000.0)]
+    _emit_subtotal_facts(_session(dag, ["GrossProfit"]), facts, [_P])
+    gp = next(f for f in facts if f.element_id == "GrossProfit")
+    assert gp.value == 115000.0  # 175000 - 60000
+
+  def test_direct_fact_wins_not_overwritten(self) -> None:
+    """A subtotal that already has a fact (e.g. NetIncomeLoss from the
+    close) is left untouched — no duplicate, original value preserved."""
+    dag = [
+      _dag_row("Assets", "AssetsCurrent", 1.0),
+      _dag_row("Assets", "AssetsNoncurrent", 1.0),
+    ]
+    facts = [
+      _leaf("AssetsCurrent", 120.0),
+      _leaf("AssetsNoncurrent", 30.0),
+      _leaf("Assets", 999.0),  # authoritative direct fact
+    ]
+    _emit_subtotal_facts(_session(dag, ["Assets"]), facts, [_P])
+    assets = [f for f in facts if f.element_id == "Assets"]
+    assert len(assets) == 1
+    assert assets[0].value == 999.0
+
+  def test_zero_subtotal_not_emitted(self) -> None:
+    dag = [_dag_row("AssetsNoncurrent", "PPE", 1.0)]
+    facts = [_leaf("PPE", 0.0)]
+    _emit_subtotal_facts(_session(dag, ["AssetsNoncurrent"]), facts, [_P])
+    assert all(f.element_id != "AssetsNoncurrent" for f in facts)

--- a/tests/taxonomy/test_fac_rules_seed.py
+++ b/tests/taxonomy/test_fac_rules_seed.py
@@ -1,11 +1,14 @@
 """Tests for the fac-rules/v1 JSON-LD seed.
 
 Pure data tests — parses the seed via
-:func:`robosystems.taxonomy.loader.load_taxonomy_package`
-and asserts the shape Phase δ.3 ships: 14 forked rules drawn from three
-rule categories and five rule patterns, every `$Variable` bound via
-`rule_variables`, every rule scoped to a known fac-calculations /
-fac-presentation Structure role URI.
+:func:`robosystems.taxonomy.loader.load_taxonomy_package` and asserts the
+shape Package II.a ships: L1 cross-tree consistency identities harvested
+from Charlie Hoffman's PROOF and **rewritten to rs-gaap subtotal
+concepts**, element-scoped so they fire against any rendered statement
+that presents the subtotal (info-block §6.1). The prior FAC-keyed,
+structure-scoped 14-rule seed (which evaluated to ``skipped`` because our
+facts are rs-gaap-keyed) is superseded; rollup-shaped identities now live
+in ``rs-gaap-rollup-rules/v1`` (L2).
 """
 
 from __future__ import annotations
@@ -50,94 +53,69 @@ class TestPackageMetadata:
   def test_package_carries_no_elements_or_associations(
     self, package: TaxonomyPackage
   ) -> None:
-    """fac-rules/v1 is rule-only. Elements and associations are seeded
-    by the sibling fac-calculations/v1 and fac-presentation/v1 packages.
-    """
+    """fac-rules/v1 is rule-only. Elements are seeded by rs-gaap/v1."""
     assert package.elements == []
     assert package.associations == []
 
 
-class TestRuleCount:
-  def test_has_fourteen_rules(self, rules: list[RuleSpec]) -> None:
-    """Phase δ.3 expands the seed to 14 rules: 7 from Phase δ.2 plus
-    2 harvested from XBRL formula linkbases (IS / CNA identities) and
-    5 from disclosure-mechanics definition linkbases."""
-    assert len(rules) == 14
+class TestRuleContent:
+  def test_has_three_cross_tree_identities(self, rules: list[RuleSpec]) -> None:
+    """Only the genuine cross-tree identities are kept (BS0, BS01, IS04);
+    rollup-shaped Consistency rules move to rs-gaap-rollup-rules (L2) and
+    FAC/SFAC6-aggregate rules have no rs-gaap subtotal target."""
+    assert len(rules) == 3
+    assert {r.id for r in rules} == {
+      "rs-gaap-rule-bs-identity",
+      "rs-gaap-rule-bs-balances",
+      "rs-gaap-rule-ci-identity",
+    }
 
+  def test_only_fac_relation_category(self, rules: list[RuleSpec]) -> None:
+    assert {r.rule_category for r in rules} == {"FundamentalAccountingConceptRelation"}
 
-class TestRuleEnums:
-  def test_all_categories_are_known(self, rules: list[RuleSpec]) -> None:
+  def test_only_equal_to_pattern(self, rules: list[RuleSpec]) -> None:
+    """Cross-tree identities are strict equalities (all subtotals must be
+    present); lenient rollups live in the L2 package."""
+    assert {r.rule_pattern for r in rules} == {"EqualTo"}
+
+  def test_all_categories_and_patterns_are_known(self, rules: list[RuleSpec]) -> None:
     for rule in rules:
       assert rule.rule_category in RULE_CATEGORY_VALUES
-
-  def test_all_patterns_are_known(self, rules: list[RuleSpec]) -> None:
-    for rule in rules:
       assert rule.rule_pattern in RULE_PATTERN_VALUES
 
-  def test_seed_covers_three_categories(self, rules: list[RuleSpec]) -> None:
-    """Three of eight cm:VerificationRule categories seeded in Phase δ.3:
-    the two from δ.2 plus DisclosureMechanicsRule harvested from the
-    Seattle Method dm definition linkbases."""
-    categories = {rule.rule_category for rule in rules}
-    assert categories == {
-      "FundamentalAccountingConceptRelation",
-      "ReportLevelModelStructureRule",
-      "DisclosureMechanicsRule",
-    }
-
-  def test_seed_covers_five_patterns(self, rules: list[RuleSpec]) -> None:
-    """Five of ten cm:BusinessRulePattern mechanisms used in Phase δ.2."""
-    patterns = {rule.rule_pattern for rule in rules}
-    assert patterns == {
-      "EqualTo",
-      "RollForward",
-      "RollUp",
-      "Exists",
-      "CoExists",
-    }
-
-
-class TestRuleOrigin:
   def test_all_rules_are_forked(self, rules: list[RuleSpec]) -> None:
-    """Every seeded rule transcribes an upstream Seattle Method artifact
-    — no 'native' authorship before Phase δ.3's engine ships."""
+    """Each transcribes an upstream PROOF Consistency assertion."""
     for rule in rules:
       assert rule.rule_origin == "forked"
 
-
-class TestRuleSeverity:
   def test_all_rules_default_to_error(self, rules: list[RuleSpec]) -> None:
-    """The seed omits `ruleSeverity`; the Pydantic default populates all
-    7 rules to `error` — these are hard constraints."""
     for rule in rules:
       assert rule.rule_severity == "error"
 
 
 class TestRuleTargets:
-  def test_every_rule_targets_a_structure(self, rules: list[RuleSpec]) -> None:
+  def test_every_rule_is_element_scoped(self, rules: list[RuleSpec]) -> None:
+    """Element-scoping (to the LHS subtotal) makes a rule fire whenever a
+    rendered statement presents that concept — across every equity-form
+    Balance Sheet variant — without coupling to a presentation role-URI."""
     for rule in rules:
-      assert rule.rule_target is not None, (
-        f"rule {rule.id} missing rule_target — Phase δ.2 seeds structure-scoped "
-        f"rules only"
-      )
-      assert rule.rule_target.target_kind == "structure"
+      assert rule.rule_target is not None, f"rule {rule.id} missing rule_target"
+      assert rule.rule_target.target_kind == "element"
 
-  def test_every_target_ref_is_a_fac_role_uri(self, rules: list[RuleSpec]) -> None:
-    """Rules reference Structures seeded by fac-calculations/v1 and
-    fac-presentation/v1 — their role URIs are under cm-roles/roles/{fac-*}/."""
-    prefix = "http://www.xbrlsite.com/seattlemethod/conceptual-model/cm-roles/roles/"
+  def test_every_target_ref_is_an_rs_gaap_qname(self, rules: list[RuleSpec]) -> None:
+    """The library creator resolves element targets by ``Element.qname``,
+    so the ref must be the literal rs-gaap qname (un-expanded)."""
     for rule in rules:
       assert rule.rule_target is not None
-      assert rule.rule_target.target_ref.startswith(prefix), (
-        f"rule {rule.id} has unexpected target_ref {rule.rule_target.target_ref}"
+      assert rule.rule_target.target_ref.startswith("rs-gaap:"), (
+        f"rule {rule.id} target_ref {rule.rule_target.target_ref} is not rs-gaap"
       )
 
 
 class TestRuleExpressionsBindVariables:
   def test_every_dollar_variable_is_bound(self, rules: list[RuleSpec]) -> None:
     """Every `$Variable` in `rule_expression` must appear in
-    `rule_variables` — Phase δ.3's engine looks bindings up by name, and
-    an unbound variable is a seed bug that would only fail at runtime."""
+    `rule_variables` — the engine looks bindings up by name."""
     for rule in rules:
       referenced = set(VARIABLE_PATTERN.findall(rule.rule_expression))
       bound = {v.variable_name for v in rule.rule_variables}
@@ -147,26 +125,24 @@ class TestRuleExpressionsBindVariables:
         f"rule_variables bind only {sorted(bound)}"
       )
 
-  def test_every_bound_variable_has_a_qname(self, rules: list[RuleSpec]) -> None:
+  def test_every_variable_qname_is_rs_gaap(self, rules: list[RuleSpec]) -> None:
+    """Variables resolve against rs-gaap-keyed facts — the FAC->rs-gaap
+    rewrite is the whole point of the Package II.a harvest."""
     for rule in rules:
       for variable in rule.rule_variables:
-        assert variable.variable_qname, (
-          f"rule {rule.id}: variable {variable.variable_name} missing qname"
-        )
-        assert ":" in variable.variable_qname, (
-          f"rule {rule.id}: variable qname {variable.variable_qname} must be "
-          f"prefix:local"
+        assert variable.variable_qname.startswith("rs-gaap:"), (
+          f"rule {rule.id}: variable {variable.variable_name} qname "
+          f"{variable.variable_qname} must be rs-gaap"
         )
 
 
 class TestRuleIdShape:
   def test_ids_have_known_prefix(self, rules: list[RuleSpec]) -> None:
-    """Blank-node local ids prefix with `fac-rule-` (Phase δ.2 rules) or
-    `sfac6-rule-` (Phase δ.3 formula/dm harvested rules). The writer
-    rewrites to a deterministic UUID5 at seed time."""
+    """Blank-node local ids prefix with `rs-gaap-rule-` (the rewritten
+    L1 identities). The writer rewrites to a deterministic UUID5."""
     for rule in rules:
-      assert "fac-rule-" in rule.id or "sfac6-rule-" in rule.id, (
-        f"rule id {rule.id!r} should contain 'fac-rule-' or 'sfac6-rule-'"
+      assert rule.id.startswith("rs-gaap-rule-"), (
+        f"rule id {rule.id!r} should start with 'rs-gaap-rule-'"
       )
 
   def test_ids_are_unique(self, rules: list[RuleSpec]) -> None:

--- a/tests/taxonomy/test_fallback_buckets_wired.py
+++ b/tests/taxonomy/test_fallback_buckets_wired.py
@@ -1,0 +1,69 @@
+"""Every MappingOperator fallback bucket must be a wired calc leaf.
+
+``FAC_TO_RS_GAAP_FALLBACK`` is the per-FAC "Other" bucket the
+MappingOperator falls back to when AI refinement can't pick a specific
+rs-gaap concept. If a fallback target is NOT a child in the rs-gaap
+calculation DAG (or is itself a rollup parent), a CoA account routed
+there silently drops out of its subtotal at render — the exact failure
+that motivated wiring the revenue/COGS/OpEx ``Other`` leaves
+(info-block §3.7 / mapping leaves-only model). This test pins the
+invariant so the constant and the calc package can't drift apart.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from robosystems.operations.operators.implementations.mapping.constants import (
+  FAC_TO_RS_GAAP_FALLBACK,
+)
+from robosystems.taxonomy.discovery import framework_root
+
+_CALC_PATH = (
+  framework_root("rs-gaap")
+  / "packages"
+  / "rs-gaap-calculations"
+  / "v1"
+  / "taxonomy.jsonld"
+)
+
+
+@pytest.fixture(scope="module")
+def calc_sets() -> tuple[set[str], set[str]]:
+  """(calc children, calc parents) for ``calculation`` arcs."""
+  graph = json.loads(_CALC_PATH.read_text())["@graph"]
+  children = {
+    n["arcTo"]["@id"] for n in graph if n.get("arcAssociationType") == "calculation"
+  }
+  parents = {
+    n["arcFrom"]["@id"] for n in graph if n.get("arcAssociationType") == "calculation"
+  }
+  return children, parents
+
+
+class TestFallbackBucketsWired:
+  def test_every_fallback_target_is_a_wired_calc_leaf(
+    self, calc_sets: tuple[set[str], set[str]]
+  ) -> None:
+    children, parents = calc_sets
+    broken = {
+      fac: tgt
+      for fac, tgt in FAC_TO_RS_GAAP_FALLBACK.items()
+      if tgt not in children or tgt in parents
+    }
+    assert not broken, (
+      "fallback targets that don't roll up (not a calc child, or are a "
+      f"rollup parent) — a CoA routed here would silently drop: {broken}"
+    )
+
+  def test_revenue_and_cogs_buckets_are_the_operating_catch_alls(self) -> None:
+    """Regression for the QB revenue/COGS gap: the fallback must point at
+    the operating-revenue / operating-cost catch-all leaves wired under
+    Revenues / CostOfRevenue — NOT OtherIncome (non-operating, unwired)."""
+    assert FAC_TO_RS_GAAP_FALLBACK["fac:Revenues"] == "rs-gaap:OtherSalesRevenueNet"
+    assert (
+      FAC_TO_RS_GAAP_FALLBACK["fac:CostOfRevenue"]
+      == "rs-gaap:OtherCostOfOperatingRevenue"
+    )

--- a/tests/taxonomy/test_rollup_rules_seed.py
+++ b/tests/taxonomy/test_rollup_rules_seed.py
@@ -1,0 +1,170 @@
+"""Tests for the rs-gaap-rollup-rules/v1 L2 package + its generator.
+
+The package is generated from rs-gaap-calculations/v1 by
+``robosystems.taxonomy.scripts.generate_rollup_rules`` — one ``RollUp``
+rule per calc-arc subtotal parent (info-block §6.1 Package II.a). These
+tests pin the committed artifact's shape and the pure builder's transform.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from robosystems.taxonomy.discovery import framework_root
+from robosystems.taxonomy.loader import (
+  RULE_CATEGORY_VALUES,
+  RULE_PATTERN_VALUES,
+  load_taxonomy_package,
+)
+from robosystems.taxonomy.model import RuleSpec, TaxonomyPackage
+from robosystems.taxonomy.scripts.generate_rollup_rules import build_rollup_rules
+
+SEED_PATH = (
+  framework_root("rs-gaap")
+  / "packages"
+  / "rs-gaap-rollup-rules"
+  / "v1"
+  / "taxonomy.jsonld"
+)
+
+
+@pytest.fixture(scope="module")
+def package() -> TaxonomyPackage:
+  return load_taxonomy_package(SEED_PATH)
+
+
+@pytest.fixture(scope="module")
+def rules(package: TaxonomyPackage) -> list[RuleSpec]:
+  return package.rules
+
+
+class TestPackageShape:
+  def test_metadata(self, package: TaxonomyPackage) -> None:
+    assert package.standard == "rs-gaap-rollup-rules"
+    assert package.version == "v1"
+    assert package.taxonomy_type == "rules"
+
+  def test_one_rule_per_calc_parent(self, rules: list[RuleSpec]) -> None:
+    """rs-gaap-calculations/v1 has 21 distinct subtotal parents."""
+    assert len(rules) == 21
+
+  def test_all_rollup_native_fac_relation(self, rules: list[RuleSpec]) -> None:
+    for rule in rules:
+      assert rule.rule_pattern == "RollUp"
+      assert rule.rule_category == "FundamentalAccountingConceptRelation"
+      assert rule.rule_origin == "native"
+      assert rule.rule_category in RULE_CATEGORY_VALUES
+      assert rule.rule_pattern in RULE_PATTERN_VALUES
+
+  def test_element_scoped_to_rs_gaap_parent(self, rules: list[RuleSpec]) -> None:
+    """Element-scoping to the parent (a literal rs-gaap qname) is what
+    makes the rule fire across every equity-form statement variant."""
+    for rule in rules:
+      assert rule.rule_target is not None
+      assert rule.rule_target.target_kind == "element"
+      assert rule.rule_target.target_ref.startswith("rs-gaap:")
+      # The parent (LHS / first variable) IS the element target.
+      assert rule.rule_variables[0].variable_qname == rule.rule_target.target_ref
+
+  def test_all_variable_qnames_are_rs_gaap(self, rules: list[RuleSpec]) -> None:
+    for rule in rules:
+      for variable in rule.rule_variables:
+        assert variable.variable_qname.startswith("rs-gaap:")
+
+  def test_balance_sheet_identity_present(self, rules: list[RuleSpec]) -> None:
+    by_id = {r.id: r for r in rules}
+    assets = by_id["rs-gaap-rollup-bs-assets"]
+    assert assets.rule_expression == "$Assets = ($AssetsCurrent + $AssetsNoncurrent)"
+
+
+class TestBuilder:
+  def test_groups_arcs_into_one_rule_per_parent(self) -> None:
+    graph = [
+      {
+        "@id": "_:net",
+        "roleUri": "https://x/roles/calc/IS-GrossProfit",
+        "structureName": "calc — rs-gaap:GrossProfit = rs-gaap:Revenues - rs-gaap:CostOfRevenue",
+      },
+      {
+        "@id": "_:a1",
+        "arcFrom": {"@id": "rs-gaap:GrossProfit"},
+        "arcTo": {"@id": "rs-gaap:Revenues"},
+        "arcAssociationType": "calculation",
+        "arcRoleUri": "https://x/roles/calc/IS-GrossProfit",
+        "arcWeight": 1.0,
+        "arcOrder": 100.0,
+      },
+      {
+        "@id": "_:a2",
+        "arcFrom": {"@id": "rs-gaap:GrossProfit"},
+        "arcTo": {"@id": "rs-gaap:CostOfRevenue"},
+        "arcAssociationType": "calculation",
+        "arcRoleUri": "https://x/roles/calc/IS-GrossProfit",
+        "arcWeight": -1.0,
+        "arcOrder": 200.0,
+      },
+    ]
+    rules = build_rollup_rules(graph)
+    assert len(rules) == 1
+    rule = rules[0]
+    assert rule["@id"] == "_:rs-gaap-rollup-is-grossprofit"
+    assert rule["rulePattern"] == "RollUp"
+    assert rule["ruleExpression"] == "$GrossProfit = ($Revenues - $CostOfRevenue)"
+    assert rule["ruleTarget"] == {
+      "targetKind": "element",
+      "targetRef": "rs-gaap:GrossProfit",
+    }
+    # parent first, then children in arcOrder
+    assert [v["variableQname"] for v in rule["ruleVariables"]] == [
+      "rs-gaap:GrossProfit",
+      "rs-gaap:Revenues",
+      "rs-gaap:CostOfRevenue",
+    ]
+
+  def test_children_sorted_by_arc_order(self) -> None:
+    graph = [
+      {
+        "@id": "_:b2",
+        "arcFrom": {"@id": "rs-gaap:P"},
+        "arcTo": {"@id": "rs-gaap:Second"},
+        "arcAssociationType": "calculation",
+        "arcRoleUri": "https://x/r/N",
+        "arcWeight": 1.0,
+        "arcOrder": 200.0,
+      },
+      {
+        "@id": "_:b1",
+        "arcFrom": {"@id": "rs-gaap:P"},
+        "arcTo": {"@id": "rs-gaap:First"},
+        "arcAssociationType": "calculation",
+        "arcRoleUri": "https://x/r/N",
+        "arcWeight": 1.0,
+        "arcOrder": 100.0,
+      },
+    ]
+    rule = build_rollup_rules(graph)[0]
+    assert rule["ruleExpression"] == "$P = ($First + $Second)"
+
+  def test_rejects_multiple_parents_in_one_network(self) -> None:
+    graph = [
+      {
+        "@id": "_:c1",
+        "arcFrom": {"@id": "rs-gaap:P1"},
+        "arcTo": {"@id": "rs-gaap:X"},
+        "arcAssociationType": "calculation",
+        "arcRoleUri": "https://x/r/N",
+        "arcWeight": 1.0,
+        "arcOrder": 100.0,
+      },
+      {
+        "@id": "_:c2",
+        "arcFrom": {"@id": "rs-gaap:P2"},
+        "arcTo": {"@id": "rs-gaap:Y"},
+        "arcAssociationType": "calculation",
+        "arcRoleUri": "https://x/r/N",
+        "arcWeight": 1.0,
+        "arcOrder": 200.0,
+      },
+    ]
+    with pytest.raises(ValueError, match="multiple parents"):
+      build_rollup_rules(graph)


### PR DESCRIPTION
## Summary

Introduces a complete rollup rules pipeline for the rs-gaap framework — from taxonomy-level rule definitions through evaluation logic to subtotal fact emission in report generation. This feature enables automatic computation and reporting of subtotal/rollup values derived from constituent line items in financial statements.

## Key Accomplishments

### Taxonomy & Framework Changes
- **New `rs-gaap-rollup-rules` taxonomy package**: Adds 756+ lines of rollup rule definitions in JSONLD format, codifying how line items roll up into subtotals and totals under rs-gaap (e.g., revenue components summing to total revenue, expense items rolling into operating income, etc.)
- **Updated rs-gaap framework manifest** (`v1.json`) to include the new rollup rules package as a dependency
- **Refined `fac-rules` taxonomy**: Streamlined the FAC rules taxonomy (significant reduction of ~350 lines), likely removing rules that are now better expressed as rollup rules or cleaning up redundancies
- **Enhanced `rs-gaap-calculations` and `rs-gaap-presentation` taxonomies**: Adjusted calculation relationships and presentation hierarchies to align with the new rollup structure

### Evaluation Engine Enhancements
- **Extended rule evaluators** to support rollup evaluation logic, enabling the system to process rollup-type rules and compute aggregated values from child facts
- **New expression types** in the rules expression module to represent rollup/summation semantics
- **Updated mapping constants** to support new concept mappings and fallback bucket wiring needed by rollup computations

### Report Generation
- **Subtotal fact emission in `fact_grid.py`**: The report generation pipeline now computes and emits subtotal facts based on evaluated rollup rules, enriching the output fact grid with derived totals
- **Updated report command orchestration** to integrate subtotal fact generation into the reporting workflow

### Codegen Tooling
- **New rollup rule generation script**: Automates the creation of rollup rule taxonomy entries from calculation relationships, ensuring consistency and reducing manual authoring errors. This supports maintainability as the taxonomy evolves.

## Breaking Changes

- **FAC rules taxonomy significantly reduced**: Downstream consumers relying on specific rule entries in `fac-rules/v1/taxonomy.jsonld` that were removed or restructured may need updates.
- **Framework manifest change**: The rs-gaap v1 framework now requires the `rs-gaap-rollup-rules` package; any deployment or taxonomy loading logic must account for this new dependency.
- **Report output shape change**: Reports now include subtotal facts that were not previously emitted, which may affect downstream consumers or comparisons against baseline outputs.

## Testing

- **`test_subtotal_facts.py`** (new): Validates that the fact grid correctly computes and emits subtotal facts from rollup rules
- **`test_rollup_rules_seed.py`** (new): Verifies the rollup rules taxonomy loads correctly and contains expected rule definitions
- **`test_fallback_buckets_wired.py`** (new): Ensures all concepts referenced in rollup rules have proper fallback bucket mappings, preventing runtime lookup failures
- **`test_evaluators.py`** and **`test_expressions.py`**: Extended with cases covering the new rollup evaluation paths
- **`test_fac_rules_seed.py`**: Updated to reflect the revised FAC rules taxonomy structure

## Infrastructure Considerations

- The new rollup rules taxonomy package must be included in any taxonomy distribution or deployment artifact alongside the existing rs-gaap packages.
- Taxonomy generation tooling has been added to support reproducible builds of rollup rules from source calculation relationships; CI pipelines may benefit from incorporating validation that generated artifacts are up to date.
- The mapping constants update may affect any caching or precomputation layers that depend on the concept mapping table size or contents.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

**Branch Info:**
- Source: `feature/report-styles-rollups`
- Target: `main`
- Type: feature

Co-Authored-By: Claude <noreply@anthropic.com>