### PR TITLE
Refine cash flow calculations, validations, and fact grid logic

### DIFF
--- a/examples/seattle_method_demo/mappings.py
+++ b/examples/seattle_method_demo/mappings.py
@@ -39,7 +39,10 @@ BS_IS_MAPPINGS: list[tuple[str, str]] = [
   # didn't aggregate into Assets / L+E subtotals.
   ("mini:CashAndCashEquivalents", "rs-gaap:CashCashEquivalentsAndShortTermInvestments"),
   ("mini:Receivables", "rs-gaap:ReceivablesNetCurrent"),
-  ("mini:Inventories", "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings"),
+  (
+    "mini:Inventories",
+    "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
+  ),
   ("mini:PropertyPlantAndEquipment", "rs-gaap:PropertyPlantAndEquipmentNet"),
   # AP and Accrued both roll into the same combined BS-Classified leaf
   # (the rs-gaap presentation network doesn't expose them separately
@@ -85,26 +88,26 @@ FLOW_MAPPINGS: list[tuple[str, str]] = [
   # the equity-side of an issuance (mini does).
   ("mini:ProceedsFromInvestmentsByOwner", "rs-gaap:ProceedsFromIssuanceOfCommonStock"),
   ("mini:InvestmentsByOwner", "rs-gaap:ProceedsFromIssuanceOfCommonStock"),
-  # Financing — debt. CF-Indirect's only debt-financing leaf is
-  # ProceedsFromIssuanceOfLongTermDebtAndCapitalSecuritiesNet — a signed
-  # net concept that absorbs both issuances and repayments. Mapping both
-  # mini concepts to it loses the signed split but lands on a leaf that
-  # actually renders.
+  # Financing — debt, GROSS per ASC 230. The CF-Financing calc rollup now
+  # carries the signed gross pair (ProceedsFromIssuanceOfLongTermDebt +
+  # RepaymentsOfLongTermDebt), so issuances and repayments map to their own
+  # leaves and present separately — no longer collapsed onto the signed-net
+  # concept (the prior "lands on a leaf that renders" workaround, now obsolete).
   (
     "mini:ProceedsFromAdditionalLongtermBorrowings",
-    "rs-gaap:ProceedsFromIssuanceOfLongTermDebtAndCapitalSecuritiesNet",
+    "rs-gaap:ProceedsFromIssuanceOfLongTermDebt",
   ),
   (
     "mini:AdditionalLongtermBorrowings",
-    "rs-gaap:ProceedsFromIssuanceOfLongTermDebtAndCapitalSecuritiesNet",
+    "rs-gaap:ProceedsFromIssuanceOfLongTermDebt",
   ),
   (
     "mini:RepaymentLongtermBorrowings",
-    "rs-gaap:ProceedsFromIssuanceOfLongTermDebtAndCapitalSecuritiesNet",
+    "rs-gaap:RepaymentsOfLongTermDebt",
   ),
   (
     "mini:PaymentForReductionOfLongtermBorrowings",
-    "rs-gaap:ProceedsFromIssuanceOfLongTermDebtAndCapitalSecuritiesNet",
+    "rs-gaap:RepaymentsOfLongTermDebt",
   ),
   # Investing — PP&E
   (
@@ -120,7 +123,10 @@ FLOW_MAPPINGS: list[tuple[str, str]] = [
     "mini:IncreaseInReceivablesFromSalesOnAccount",
     "rs-gaap:IncreaseDecreaseInAccountsReceivable",
   ),
-  ("mini:ProceedsFromCollectionOfReceivables", "rs-gaap:IncreaseDecreaseInAccountsReceivable"),
+  (
+    "mini:ProceedsFromCollectionOfReceivables",
+    "rs-gaap:IncreaseDecreaseInAccountsReceivable",
+  ),
   ("mini:CollectionOfReceivables", "rs-gaap:IncreaseDecreaseInAccountsReceivable"),
   # Operating — inventory
   ("mini:PurchasesOfInventoryForSale", "rs-gaap:IncreaseDecreaseInInventories"),
@@ -163,7 +169,10 @@ FLOW_MAPPINGS: list[tuple[str, str]] = [
   # is approximate; the CF rendering will conflate the IS expense
   # and the CF payment).
   ("mini:PaymentInterest", "rs-gaap:InterestExpense"),
-  ("mini:DecreaseFromPaymentOfInterest", "rs-gaap:IncreaseDecreaseInAccruedLiabilities"),
+  (
+    "mini:DecreaseFromPaymentOfInterest",
+    "rs-gaap:IncreaseDecreaseInAccruedLiabilities",
+  ),
   ("mini:InterestAccrued", "rs-gaap:IncreaseDecreaseInAccruedLiabilities"),
   # Operating — D&A
   (

--- a/examples/seattle_method_demo/output/seattle-method-case-1-four-statements.md
+++ b/examples/seattle_method_demo/output/seattle-method-case-1-four-statements.md
@@ -1,7 +1,7 @@
 # Seattle Method Cross-Taxonomy — Test Case 1: Four-Statement Report
 
-**Graph**: `kg19e48e582867f658d601`
-**Report**: `rpt_01KS4EB8J1G24X8D4BQX24F6S2` (published)
+**Graph**: `kg19e5b8b619973b960555`
+**Report**: `rpt_01KSDRQ3YDQHFMZV8KQGE0KAT2` (published)
 **Entity**: Lemonade Stand (Charlie Hoffman Test Case 1)
 **Period**: 2024-01-01 → 2024-03-31 (Current)
 **Comparative**: 2023-10-02 → 2023-12-31 (Prior — zero opening balances)
@@ -110,10 +110,10 @@ The architectural piece that powers this lives in
 | `rs-gaap:DepreciationDepletionAndAmortization` |     Depreciation, Depletion and Amortization | $100.00 | $0.00 |
 | `rs-gaap:OperatingExpenses` |   **Operating Expenses** | $100.00 | $0.00 |
 | `rs-gaap:OperatingIncomeLoss` |   **Operating Income (Loss)** | $2,600.00 | $0.00 |
-| `rs-gaap:InterestExpense` |   Interest Expense, Operating and Nonoperating | $150.00 | $0.00 |
+| `rs-gaap:InterestExpense` |     Interest Expense, Operating and Nonoperating | $150.00 | $0.00 |
+| `rs-gaap:NonoperatingIncomeExpense` |   **Nonoperating Income (Expense)** | $(150.00) | $0.00 |
 | `rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest` |   **Income (Loss) from Continuing Operations before Income Taxes, Noncontrolling Interest** | $2,450.00 | $0.00 |
 | `rs-gaap:IncomeTaxExpenseBenefit` |   Income Tax Expense (Benefit) | $400.00 | $0.00 |
-| `rs-gaap:IncomeLossFromContinuingOperations` |   **Income (Loss) from Continuing Operations, Net of Tax, Attributable to Parent** | $2,050.00 | $0.00 |
 | `rs-gaap:NetIncomeLoss` |   **Net Income (Loss) Attributable to Parent** | $2,050.00 | $0.00 |
 
 ---
@@ -122,7 +122,7 @@ The architectural piece that powers this lives in
 
 - **Structure**: `rs-gaap — Cash Flow Statement — Indirect`
 - **Block type**: `cash_flow_statement`
-- **Row count**: 11
+- **Row count**: 12
 - **Unmapped elements**: 0
 
 | QName | Concept | Current (2024-01-01 → 2024-03-31) | Prior (2023-10-02 → 2023-12-31) |
@@ -135,7 +135,8 @@ The architectural piece that powers this lives in
 | `rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment` |     Payments to Acquire Property, Plant, and Equipment | $(1,000.00) | $0.00 |
 | `rs-gaap:NetCashProvidedByUsedInInvestingActivities` |   **Cash Provided by (Used in) Investing Activity, Including Discontinued Operation** | $(1,000.00) | $0.00 |
 | `rs-gaap:ProceedsFromIssuanceOfCommonStock` |     Proceeds from Issuance of Common Stock | $10,000.00 | $0.00 |
-| `rs-gaap:ProceedsFromIssuanceOfLongTermDebtAndCapitalSecuritiesNet` |     Proceeds from Issuance of Long-Term Debt and Capital Securities, Net | $1,000.00 | $0.00 |
+| `rs-gaap:ProceedsFromIssuanceOfLongTermDebt` |     Proceeds from Issuance of Long-Term Debt | $2,000.00 | $0.00 |
+| `rs-gaap:RepaymentsOfLongTermDebt` |     Repayments of Long-Term Debt | $(1,000.00) | $0.00 |
 | `rs-gaap:NetCashProvidedByUsedInFinancingActivities` |   **Cash Provided by (Used in) Financing Activity, Including Discontinued Operation** | $11,000.00 | $0.00 |
 | `rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease` | **CashAndCashEquivalentsPeriodIncreaseDecrease** | $10,850.00 | $0.00 |
 
@@ -158,12 +159,12 @@ The architectural piece that powers this lives in
 
 ## Provenance
 
-- **Report ID**: `rpt_01KS4EB8J1G24X8D4BQX24F6S2`
-- **Graph**: `kg19e48e582867f658d601`
+- **Report ID**: `rpt_01KSDRQ3YDQHFMZV8KQGE0KAT2`
+- **Graph**: `kg19e5b8b619973b960555`
 - **Taxonomy**: `rs-gaap` (resolved at create-report time)
-- **Mapping**: `struct_01KS4EB57T2TBNH8ZP1A4SSE32`
-- **Created**: 2026-05-21T04:57:49.377958
-- **Last generated**: 2026-05-21T04:57:49.419965
+- **Mapping**: `struct_01KSDRPXVCWT2WTM4HGJQE9SHC`
+- **Created**: 2026-05-24T19:52:13.517931
+- **Last generated**: 2026-05-24T19:52:13.653286
 
 ### How to reproduce
 

--- a/examples/seattle_method_demo/output/seattle-method-case-1.md
+++ b/examples/seattle_method_demo/output/seattle-method-case-1.md
@@ -1,6 +1,6 @@
 # Seattle Method Cross-Taxonomy — Test Case 1 Reconciliation
 
-**Graph**: `kg19e48e582867f658d601`
+**Graph**: `kg19e5b8b619973b960555`
 **Period**: 2024-01-01 → 2024-01-31
 **Dataset**: Charlie Hoffman's lemonade-stand 14-JE Q1 2024 fixture
 **Expected output reference**: [luca.pacioli.ai/luca/view/0f24fd35…](https://luca.pacioli.ai/luca/view/0f24fd35e961e167a727b663c75a4c5ec9fb7eb86730d6292f46e6e180fc2018980cd52e/index)
@@ -145,8 +145,8 @@ Each rollforward IB decomposes its BS source's period delta across declared TDC 
 
 | Flow concept | Value | Matched lines | Event ids |
 |---|---:|---:|---|
-| `mini:PurchasesInventoryForSaleOnAccount` | $(8,000.00) | 2 | evt_01KS4EB64JPXDNM9J74QQ5H5XR, evt_01KS4EB650Y76TQENNCSD78K00 |
-| `mini:DecreaseFromPaymentAccountsPayable` | $7,000.00 | 1 | evt_01KS4EB66AKCNHWNBP0N6AYRTF |
+| `mini:PurchasesInventoryForSaleOnAccount` | $(8,000.00) | 2 | evt_01KSDRPZFX4TYDDJ652J3XVJGG, evt_01KSDRPZGGA1B9JD53MTP9QTFE |
+| `mini:DecreaseFromPaymentAccountsPayable` | $7,000.00 | 1 | evt_01KSDRPZJJ822PKMV2XM5NZNN4 |
 
 ### Accrued Expenses (mini:AccruedExpenses)
 
@@ -154,8 +154,8 @@ Each rollforward IB decomposes its BS source's period delta across declared TDC 
 
 | Flow concept | Value | Matched lines | Event ids |
 |---|---:|---:|---|
-| `mini:InterestAccrued` | $(550.00) | 2 | evt_01KS4EB676YG1KARCE2VX7RPH9, evt_01KS4EB68NZ139TE6AGHHRDS2H |
-| `mini:DecreaseFromPaymentOfInterest` | $150.00 | 1 | evt_01KS4EB66R8FDGYMWHS4TQXQMM |
+| `mini:InterestAccrued` | $(550.00) | 2 | evt_01KSDRPZKQ22QZN204AP6W5X43, evt_01KSDRPZNSHDRXD30C5GQ5F9MS |
+| `mini:DecreaseFromPaymentOfInterest` | $150.00 | 1 | evt_01KSDRPZK2HV2JX8CNG6363CCG |
 
 ### Cash and Cash Equivalents (mini:CashAndCashEquivalents)
 
@@ -163,13 +163,13 @@ Each rollforward IB decomposes its BS source's period delta across declared TDC 
 
 | Flow concept | Value | Matched lines | Event ids |
 |---|---:|---:|---|
-| `mini:ProceedsFromInvestmentsByOwner` | $10,000.00 | 1 | evt_01KS4EB62X0F0CKF49BZQ3KXSW |
-| `mini:ProceedsFromAdditionalLongtermBorrowings` | $2,000.00 | 1 | evt_01KS4EB63N3YR95MDT5QZ27KJ8 |
-| `mini:PaymentForCapitalAdditionsOfPropertyPlantEquipment` | $(1,000.00) | 1 | evt_01KS4EB6412VTPS8F9P1QBAQQ8 |
-| `mini:PaymentInterest` | $(150.00) | 1 | evt_01KS4EB66R8FDGYMWHS4TQXQMM |
-| `mini:ProceedsFromCollectionOfReceivables` | $8,000.00 | 1 | evt_01KS4EB65YEN8W6SJ601WJDQJV |
-| `mini:PaymentOfAccountsPayable` | $(7,000.00) | 1 | evt_01KS4EB66AKCNHWNBP0N6AYRTF |
-| `mini:PaymentForReductionOfLongtermBorrowings` | $(1,000.00) | 1 | evt_01KS4EB66R8FDGYMWHS4TQXQMM |
+| `mini:ProceedsFromInvestmentsByOwner` | $10,000.00 | 1 | evt_01KSDRPZD2ZZFPMYKBKS45FRR3 |
+| `mini:ProceedsFromAdditionalLongtermBorrowings` | $2,000.00 | 1 | evt_01KSDRPZED6JBZ14DSVCYX8C7D |
+| `mini:PaymentForCapitalAdditionsOfPropertyPlantEquipment` | $(1,000.00) | 1 | evt_01KSDRPZF2AB3GF3KGETH1TR0B |
+| `mini:PaymentInterest` | $(150.00) | 1 | evt_01KSDRPZK2HV2JX8CNG6363CCG |
+| `mini:ProceedsFromCollectionOfReceivables` | $8,000.00 | 1 | evt_01KSDRPZJ05WRQXNBQ7A4SD4YX |
+| `mini:PaymentOfAccountsPayable` | $(7,000.00) | 1 | evt_01KSDRPZJJ822PKMV2XM5NZNN4 |
+| `mini:PaymentForReductionOfLongtermBorrowings` | $(1,000.00) | 1 | evt_01KSDRPZK2HV2JX8CNG6363CCG |
 
 ### Inventories (mini:Inventories)
 
@@ -177,9 +177,9 @@ Each rollforward IB decomposes its BS source's period delta across declared TDC 
 
 | Flow concept | Value | Matched lines | Event ids |
 |---|---:|---:|---|
-| `mini:InventoryWrittenOff` | $(300.00) | 1 | evt_01KS4EB67J2ER2ASCF0YKHWFSM |
-| `mini:PurchasesOfInventoryForSale` | $5,000.00 | 1 | evt_01KS4EB64JPXDNM9J74QQ5H5XR |
-| `mini:DecreaseInInventoriesFromSales` | $(2,000.00) | 1 | evt_01KS4EB65GVDZ4VW68VZ4088PE |
+| `mini:InventoryWrittenOff` | $(300.00) | 1 | evt_01KSDRPZM7D7GGZVM49DHESX6G |
+| `mini:PurchasesOfInventoryForSale` | $5,000.00 | 1 | evt_01KSDRPZFX4TYDDJ652J3XVJGG |
+| `mini:DecreaseInInventoriesFromSales` | $(2,000.00) | 1 | evt_01KSDRPZH8ARYNTK2Z8CK5G6HQ |
 
 ### Long-term Debt (mini:LongtermDebt)
 
@@ -187,8 +187,8 @@ Each rollforward IB decomposes its BS source's period delta across declared TDC 
 
 | Flow concept | Value | Matched lines | Event ids |
 |---|---:|---:|---|
-| `mini:AdditionalLongtermBorrowings` | $(2,000.00) | 1 | evt_01KS4EB63N3YR95MDT5QZ27KJ8 |
-| `mini:RepaymentLongtermBorrowings` | $1,000.00 | 1 | evt_01KS4EB66R8FDGYMWHS4TQXQMM |
+| `mini:AdditionalLongtermBorrowings` | $(2,000.00) | 1 | evt_01KSDRPZED6JBZ14DSVCYX8C7D |
+| `mini:RepaymentLongtermBorrowings` | $1,000.00 | 1 | evt_01KSDRPZK2HV2JX8CNG6363CCG |
 
 ### Paid In Capital (mini:PaidInCapital)
 
@@ -196,7 +196,7 @@ Each rollforward IB decomposes its BS source's period delta across declared TDC 
 
 | Flow concept | Value | Matched lines | Event ids |
 |---|---:|---:|---|
-| `mini:InvestmentsByOwner` | $(10,000.00) | 1 | evt_01KS4EB62X0F0CKF49BZQ3KXSW |
+| `mini:InvestmentsByOwner` | $(10,000.00) | 1 | evt_01KSDRPZD2ZZFPMYKBKS45FRR3 |
 
 ### Property, Plant and Equipment (mini:PropertyPlantAndEquipment)
 
@@ -204,8 +204,8 @@ Each rollforward IB decomposes its BS source's period delta across declared TDC 
 
 | Flow concept | Value | Matched lines | Event ids |
 |---|---:|---:|---|
-| `mini:CapitalAdditionsPropertyPlantAndEquipment` | $1,000.00 | 1 | evt_01KS4EB6412VTPS8F9P1QBAQQ8 |
-| `mini:DecreaseFromDepreciationAndAmortization` | $(100.00) | 1 | evt_01KS4EB67ZS8NRFTZQHBR13HR0 |
+| `mini:CapitalAdditionsPropertyPlantAndEquipment` | $1,000.00 | 1 | evt_01KSDRPZF2AB3GF3KGETH1TR0B |
+| `mini:DecreaseFromDepreciationAndAmortization` | $(100.00) | 1 | evt_01KSDRPZMVTCEWHNKK33TKP2ZC |
 
 ### Receivables (mini:Receivables)
 
@@ -213,8 +213,8 @@ Each rollforward IB decomposes its BS source's period delta across declared TDC 
 
 | Flow concept | Value | Matched lines | Event ids |
 |---|---:|---:|---|
-| `mini:IncreaseInReceivablesFromSalesOnAccount` | $8,000.00 | 1 | evt_01KS4EB65GVDZ4VW68VZ4088PE |
-| `mini:CollectionOfReceivables` | $(8,000.00) | 1 | evt_01KS4EB65YEN8W6SJ601WJDQJV |
+| `mini:IncreaseInReceivablesFromSalesOnAccount` | $8,000.00 | 1 | evt_01KSDRPZH8ARYNTK2Z8CK5G6HQ |
+| `mini:CollectionOfReceivables` | $(8,000.00) | 1 | evt_01KSDRPZJ05WRQXNBQ7A4SD4YX |
 
 ## Findings — Classification per Methodology §3.2
 

--- a/frameworks/rs-gaap/packages/rs-gaap-calculations/v1/taxonomy.jsonld
+++ b/frameworks/rs-gaap/packages/rs-gaap-calculations/v1/taxonomy.jsonld
@@ -936,6 +936,15 @@
       "arcWeight": 1.0,
       "arcOrder": 100.0
     },
+    {
+      "@id": "_:rs-gaap-calc-cf-investing-arc-2",
+      "arcFrom": { "@id": "rs-gaap:NetCashProvidedByUsedInInvestingActivities" },
+      "arcTo": { "@id": "rs-gaap:ProceedsFromSaleOfPropertyPlantAndEquipment" },
+      "arcAssociationType": "calculation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-calculations/CF-Investing",
+      "arcWeight": 1.0,
+      "arcOrder": 200.0
+    },
 
     {
       "@id": "_:rs-gaap-calc-cf-financing",
@@ -1040,19 +1049,70 @@
     },
 
     {
-      "@id": "_:rs-gaap-deriv-cf-long-term-debt-net",
-      "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-derivations/CF-LongTermDebtNet",
-      "structureName": "rs-gaap derivation CF — ProceedsFromIssuanceOfLongTermDebtAndCapitalSecuritiesNet = +Δ(LongTermDebtNoncurrent) [debt up = net proceeds, debt down = net repayments]. BS delta recovers net activity, not gross. For gross Proceeds + Repayments disclosure, author a rollforward IB with filter-based attribution (§3.16 Phase 3-4).",
+      "@id": "_:rs-gaap-deriv-cf-ppe-sales",
+      "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-derivations/CF-ProceedsFromSaleOfPropertyPlantAndEquipment",
+      "structureName": "rs-gaap default-flow CF — ProceedsFromSaleOfPropertyPlantAndEquipment is the investing INFLOW default for PropertyPlantAndEquipmentGross. arcWeight sign = cash direction (+1 inflow); paired with PaymentsToAcquirePropertyPlantAndEquipment (-1 outflow). Consumed by the line-level flow fallback in _emit_flow_facts when LineItem.flow_element_id is NULL, NOT by _derive_cash_flow_facts (investing/financing arcs are excluded from net-delta).",
       "blockType": "validation_rules",
       "conceptArrangementPattern": "arithmetic"
     },
     {
-      "@id": "_:rs-gaap-deriv-cf-long-term-debt-net-arc-1",
-      "arcFrom": { "@id": "rs-gaap:ProceedsFromIssuanceOfLongTermDebtAndCapitalSecuritiesNet" },
+      "@id": "_:rs-gaap-deriv-cf-ppe-sales-arc-1",
+      "arcFrom": { "@id": "rs-gaap:ProceedsFromSaleOfPropertyPlantAndEquipment" },
+      "arcTo": { "@id": "rs-gaap:PropertyPlantAndEquipmentGross" },
+      "arcAssociationType": "derivation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-derivations/CF-ProceedsFromSaleOfPropertyPlantAndEquipment",
+      "arcWeight": 1.0,
+      "arcOrder": 100.0
+    },
+
+    {
+      "@id": "_:rs-gaap-deriv-cf-debt-issuance",
+      "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-derivations/CF-ProceedsFromIssuanceOfLongTermDebt",
+      "structureName": "rs-gaap default-flow CF — ProceedsFromIssuanceOfLongTermDebt is the financing INFLOW default for LongTermDebtNoncurrent. arcWeight +1 = inflow (debt line is a credit/increase); paired with RepaymentsOfLongTermDebt (-1 outflow) for gross presentation per ASC 230. Line-level fallback only.",
+      "blockType": "validation_rules",
+      "conceptArrangementPattern": "arithmetic"
+    },
+    {
+      "@id": "_:rs-gaap-deriv-cf-debt-issuance-arc-1",
+      "arcFrom": { "@id": "rs-gaap:ProceedsFromIssuanceOfLongTermDebt" },
       "arcTo": { "@id": "rs-gaap:LongTermDebtNoncurrent" },
       "arcAssociationType": "derivation",
-      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-derivations/CF-LongTermDebtNet",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-derivations/CF-ProceedsFromIssuanceOfLongTermDebt",
       "arcWeight": 1.0,
+      "arcOrder": 100.0
+    },
+
+    {
+      "@id": "_:rs-gaap-deriv-cf-debt-repayment",
+      "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-derivations/CF-RepaymentsOfLongTermDebt",
+      "structureName": "rs-gaap default-flow CF — RepaymentsOfLongTermDebt is the financing OUTFLOW default for LongTermDebtNoncurrent. arcWeight -1 = outflow (debt line is a debit/decrease). Line-level fallback only.",
+      "blockType": "validation_rules",
+      "conceptArrangementPattern": "arithmetic"
+    },
+    {
+      "@id": "_:rs-gaap-deriv-cf-debt-repayment-arc-1",
+      "arcFrom": { "@id": "rs-gaap:RepaymentsOfLongTermDebt" },
+      "arcTo": { "@id": "rs-gaap:LongTermDebtNoncurrent" },
+      "arcAssociationType": "derivation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-derivations/CF-RepaymentsOfLongTermDebt",
+      "arcWeight": -1.0,
+      "arcOrder": 200.0
+    },
+
+    {
+      "@id": "_:rs-gaap-deriv-cf-stock-repurchase",
+      "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-derivations/CF-PaymentsForRepurchaseOfCommonStock",
+      "structureName": "rs-gaap default-flow CF — PaymentsForRepurchaseOfCommonStock is the financing OUTFLOW default for AdditionalPaidInCapital. arcWeight -1 = outflow (equity line is a debit/decrease); paired with ProceedsFromIssuanceOfCommonStock (+1 inflow). Line-level fallback only.",
+      "blockType": "validation_rules",
+      "conceptArrangementPattern": "arithmetic"
+    },
+    {
+      "@id": "_:rs-gaap-deriv-cf-stock-repurchase-arc-1",
+      "arcFrom": { "@id": "rs-gaap:PaymentsForRepurchaseOfCommonStock" },
+      "arcTo": { "@id": "rs-gaap:AdditionalPaidInCapital" },
+      "arcAssociationType": "derivation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-derivations/CF-PaymentsForRepurchaseOfCommonStock",
+      "arcWeight": -1.0,
       "arcOrder": 100.0
     },
 
@@ -1078,11 +1138,29 @@
     {
       "@id": "_:rs-gaap-calc-cf-financing-arc-2",
       "arcFrom": { "@id": "rs-gaap:NetCashProvidedByUsedInFinancingActivities" },
-      "arcTo": { "@id": "rs-gaap:ProceedsFromIssuanceOfLongTermDebtAndCapitalSecuritiesNet" },
+      "arcTo": { "@id": "rs-gaap:ProceedsFromIssuanceOfLongTermDebt" },
       "arcAssociationType": "calculation",
       "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-calculations/CF-Financing",
       "arcWeight": 1.0,
       "arcOrder": 200.0
+    },
+    {
+      "@id": "_:rs-gaap-calc-cf-financing-arc-3",
+      "arcFrom": { "@id": "rs-gaap:NetCashProvidedByUsedInFinancingActivities" },
+      "arcTo": { "@id": "rs-gaap:RepaymentsOfLongTermDebt" },
+      "arcAssociationType": "calculation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-calculations/CF-Financing",
+      "arcWeight": 1.0,
+      "arcOrder": 300.0
+    },
+    {
+      "@id": "_:rs-gaap-calc-cf-financing-arc-4",
+      "arcFrom": { "@id": "rs-gaap:NetCashProvidedByUsedInFinancingActivities" },
+      "arcTo": { "@id": "rs-gaap:PaymentsForRepurchaseOfCommonStock" },
+      "arcAssociationType": "calculation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-calculations/CF-Financing",
+      "arcWeight": 1.0,
+      "arcOrder": 400.0
     }
   ]
 }

--- a/frameworks/rs-gaap/packages/rs-gaap-presentation/v1/taxonomy.jsonld
+++ b/frameworks/rs-gaap/packages/rs-gaap-presentation/v1/taxonomy.jsonld
@@ -8466,6 +8466,14 @@
       "arcOrder": 30210.0
     },
     {
+      "@id": "_:rs-gaap-pres-cf-indirect-arc-12b",
+      "arcFrom": { "@id": "rs-gaap:NetCashProvidedByUsedInInvestingActivities" },
+      "arcTo": { "@id": "rs-gaap:ProceedsFromSaleOfPropertyPlantAndEquipment" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+      "arcOrder": 30220.0
+    },
+    {
       "@id": "_:rs-gaap-pres-cf-indirect-arc-13",
       "arcFrom": { "@id": "rs-gaap:NetCashProvidedByUsedInFinancingActivities" },
       "arcTo": { "@id": "rs-gaap:ProceedsFromIssuanceOfCommonStock" },
@@ -8492,10 +8500,26 @@
     {
       "@id": "_:rs-gaap-pres-cf-indirect-arc-16",
       "arcFrom": { "@id": "rs-gaap:NetCashProvidedByUsedInFinancingActivities" },
-      "arcTo": { "@id": "rs-gaap:ProceedsFromIssuanceOfLongTermDebtAndCapitalSecuritiesNet" },
+      "arcTo": { "@id": "rs-gaap:ProceedsFromIssuanceOfLongTermDebt" },
       "arcAssociationType": "presentation",
       "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
       "arcOrder": 30320.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-cf-indirect-arc-16b",
+      "arcFrom": { "@id": "rs-gaap:NetCashProvidedByUsedInFinancingActivities" },
+      "arcTo": { "@id": "rs-gaap:RepaymentsOfLongTermDebt" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+      "arcOrder": 30330.0
+    },
+    {
+      "@id": "_:rs-gaap-pres-cf-indirect-arc-16c",
+      "arcFrom": { "@id": "rs-gaap:NetCashProvidedByUsedInFinancingActivities" },
+      "arcTo": { "@id": "rs-gaap:PaymentsForRepurchaseOfCommonStock" },
+      "arcAssociationType": "presentation",
+      "arcRoleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+      "arcOrder": 30340.0
     },
 
     {

--- a/robosystems/operations/roboledger/reports/fact_grid.py
+++ b/robosystems/operations/roboledger/reports/fact_grid.py
@@ -238,6 +238,12 @@ def generate_report_facts(
   # fact per period so verification rules scoped to a subtotal can bind.
   _emit_subtotal_facts(session, facts, periods)
 
+  # Reconcile the CF net change in cash against the balance-sheet cash
+  # movement (the acceptance criterion for flow attribution). Warning-only —
+  # the bundle is already generated; a mismatch flags incomplete investing/
+  # financing attribution (dead-branch flow concept or coarse CoA mapping).
+  _check_cash_flow_tie_out(facts, periods)
+
   unmapped_count = _count_unmapped(session, mapping_id, arc_type=arc_type)
 
   return ReportFacts(
@@ -1208,40 +1214,45 @@ def _emit_flow_facts(
   mapping_id: str,
   arc_type: str,
 ) -> None:
-  """Emit **investing/financing** CF facts directly from per-line flow concepts.
+  """Emit **investing/financing** CF facts from per-line economic flows.
 
-  Each LineItem carries a first-class ``flow_element_id`` (the economic flow it
-  represents). For investing + financing flows the period cash flow is the
-  signed movement of the **cash side** of the entry: summing the cash-side
-  line's ``debit - credit`` gives the flow with the correct sign (cash debit =
-  inflow +, cash credit = outflow -). Summing the *non-cash* side instead would
-  require a sign flip, and summing *both* sides double-counts to zero (both
-  sides resolve to the same CF concept) — so we anchor on the cash line.
+  Two passes, combined per flow leaf:
 
-  Operating flows are intentionally skipped: indirect-method operating is
-  NI + non-cash addbacks + ΔWC (handled by ``_derive_cash_flow_facts``), not a
-  flow-sum. Section routing is by the ``activityType`` trait on the resolved
-  rs-gaap flow concept.
+  - **Pass 1 (explicit)** — a LineItem's ``flow_element_id`` is set (manual
+    override, or pre-tagged source like Charlie's mini fixture). The cash line
+    carries the tag; its signed ``debit - credit`` is the flow (cash debit =
+    inflow +, cash credit = outflow -). Anchoring on cash avoids the sign flip
+    and the both-sides double-count.
+  - **Pass 2 (element-default fallback)** — the load-bearing path for real
+    QuickBooks data, which carries no ``flow_element_id``. Each NON-cash line
+    of an untagged, cash-affecting entry routes to its mapped rs-gaap element's
+    DEFAULT inv/fin flow (a ``derivation`` arc, to = BS element, from = flow
+    concept; weight SIGN = cash direction), selected against the line's own
+    ``credit - debit``. The two passes agree in sign because in a balanced
+    entry the cash side is the negation of the non-cash side.
 
-  Runs BEFORE ``_derive_cash_flow_facts`` so that function's "direct fact wins"
-  guard suppresses the (often-defeated) ΔBS derivation arcs for these same CF
-  leaves — e.g. ``PaymentsToAcquirePropertyPlantAndEquipment`` whose ΔGross
-  derivation yields 0 under an all-in-Net PP&E mapping.
+  Operating flows are intentionally absent from both passes: indirect-method
+  operating is NI + non-cash addbacks + ΔWC (``_derive_cash_flow_facts``), not
+  a flow-sum. Section routing is by the ``activityType`` trait on the resolved
+  flow concept, which also keeps the inv/fin ``derivation`` arcs out of the
+  operating net-delta path (they're excluded there by the same trait).
 
   Resolution uses the same ``mapping_id``/``arc_type`` as the balance reader, so
   source-vocabulary flows (mini) and accounts resolve to rs-gaap consistently.
-  Mutates ``facts`` in place.
+  Authoritative for inv/fin flow leaves: replaces any pre-existing fact for the
+  leaf+period. Mutates ``facts`` in place.
   """
   cash_qnames = list(_CASH_ANCHOR_QNAMES)
-  for period in periods:
-    rows = session.execute(
-      text("""
+
+  # Pass 1 — explicit per-line flow tags. The cash line of an entry carries a
+  # ``flow_element_id``; its signed movement (debit - credit) is the flow.
+  explicit_sql = text("""
         SELECT
           COALESCE(fmap.to_element_id, li.flow_element_id) AS flow_id,
           rf.qname AS flow_qname,
           rf.name AS flow_name,
           rf.balance_type AS flow_balance_type,
-          COALESCE(SUM(li.debit_amount - li.credit_amount), 0) AS cash_movement_cents
+          COALESCE(SUM(li.debit_amount - li.credit_amount), 0) AS value_cents
         FROM line_items li
         JOIN entries en ON en.id = li.entry_id
         JOIN elements acct ON acct.id = li.element_id
@@ -1264,41 +1275,109 @@ def _emit_flow_facts(
           AND en.posting_date BETWEEN :start AND :end
           AND COALESCE(racct.qname, acct.qname) = ANY(:cash_qnames)
         GROUP BY flow_id, rf.qname, rf.name, rf.balance_type
-      """),
-      {
-        "arc_type": arc_type,
-        "mapping_id": mapping_id,
-        "start": period.start,
-        "end": period.end,
-        "cash_qnames": cash_qnames,
-      },
-    ).fetchall()
+      """)
 
-    for row in rows:
-      cf_value = cents_to_dollars(row.cash_movement_cents)
-      if cf_value == 0:
+  # Pass 2 — element-default fallback (the load-bearing path for real
+  # QuickBooks data, which carries no flow_element_id). For an entry with no
+  # explicit tag, each NON-cash line routes to its mapped rs-gaap element's
+  # DEFAULT investing/financing flow: a ``derivation`` arc (to = BS element,
+  # from = flow concept) whose weight SIGN encodes cash direction (+1 inflow,
+  # -1 outflow), selected against the line's own ``credit - debit`` — asset-up
+  # = outflow (-), liability/equity-up = inflow (+). The line's ``credit -
+  # debit`` IS the signed cash flow (consistent with Pass 1's cash-anchored
+  # ``debit - credit``, since in a balanced entry the cash side is the
+  # negation of the non-cash side). Gated on (a) the entry actually moving
+  # cash, so accruals don't leak into investing/financing, and (b) no explicit
+  # tag anywhere in the entry, so Pass 1 / manual overrides own those entries.
+  fallback_sql = text("""
+        SELECT
+          rf.id AS flow_id,
+          rf.qname AS flow_qname,
+          rf.name AS flow_name,
+          rf.balance_type AS flow_balance_type,
+          COALESCE(SUM(li.credit_amount - li.debit_amount), 0) AS value_cents
+        FROM line_items li
+        JOIN entries en ON en.id = li.entry_id
+        JOIN elements acct ON acct.id = li.element_id
+        LEFT JOIN associations amap
+          ON amap.from_element_id = li.element_id
+          AND amap.association_type = :arc_type
+          AND amap.structure_id = :mapping_id
+        LEFT JOIN elements racct ON racct.id = amap.to_element_id
+        JOIN associations darc
+          ON darc.to_element_id = COALESCE(amap.to_element_id, li.element_id)
+          AND darc.association_type = 'derivation'
+          AND SIGN(darc.weight) = SIGN(li.credit_amount - li.debit_amount)
+        JOIN elements rf ON rf.id = darc.from_element_id
+        JOIN element_traits et ON et.element_id = rf.id
+        JOIN traits t ON t.id = et.trait_id
+          AND t.category = 'activityType'
+          AND t.identifier IN ('investingActivity', 'financingActivity')
+        WHERE li.flow_element_id IS NULL
+          AND en.status = 'posted'
+          AND en.posting_date BETWEEN :start AND :end
+          AND COALESCE(racct.qname, acct.qname) <> ALL(:cash_qnames)
+          AND EXISTS (
+            SELECT 1 FROM line_items cl
+            JOIN elements ca ON ca.id = cl.element_id
+            LEFT JOIN associations cmap
+              ON cmap.from_element_id = cl.element_id
+              AND cmap.association_type = :arc_type
+              AND cmap.structure_id = :mapping_id
+            LEFT JOIN elements cra ON cra.id = cmap.to_element_id
+            WHERE cl.entry_id = en.id
+              AND COALESCE(cra.qname, ca.qname) = ANY(:cash_qnames)
+          )
+          AND NOT EXISTS (
+            SELECT 1 FROM line_items x
+            WHERE x.entry_id = en.id AND x.flow_element_id IS NOT NULL
+          )
+        GROUP BY rf.id, rf.qname, rf.name, rf.balance_type
+      """)
+
+  for period in periods:
+    params = {
+      "arc_type": arc_type,
+      "mapping_id": mapping_id,
+      "start": period.start,
+      "end": period.end,
+      "cash_qnames": cash_qnames,
+    }
+    # Combine explicit + fallback contributions per flow leaf so a leaf that
+    # receives both (mixed tagged/untagged entries) sums rather than one pass
+    # clobbering the other. Value: [qname, name, balance_type, summed_value].
+    combined: dict[str, list] = {}
+    for sql in (explicit_sql, fallback_sql):
+      for row in session.execute(sql, params).fetchall():
+        agg = combined.get(row.flow_id)
+        if agg is None:
+          agg = [row.flow_qname, row.flow_name, row.flow_balance_type or "debit", 0.0]
+          combined[row.flow_id] = agg
+        agg[3] += cents_to_dollars(row.value_cents)
+
+    for flow_id, (qname, name, balance_type, value) in combined.items():
+      if value == 0:
         continue
-      # This emitter is authoritative for investing/financing flow leaves:
-      # drop any pre-existing fact for this leaf+period (e.g. a 0-valued or
-      # balance-shaped placeholder that some upstream pass materialized) so
-      # the flow-derived value is what renders.
+      # Authoritative for investing/financing flow leaves: drop any pre-existing
+      # fact for this leaf+period (e.g. a 0/instant placeholder) so the
+      # flow-derived value is what renders.
       facts[:] = [
         f
         for f in facts
         if not (
-          f.element_id == row.flow_id
+          f.element_id == flow_id
           and f.period_start == period.start
           and f.period_end == period.end
         )
       ]
       facts.append(
         ReportFact(
-          element_id=row.flow_id,
-          element_qname=row.flow_qname,
-          element_name=row.flow_name,
+          element_id=flow_id,
+          element_qname=qname,
+          element_name=name,
           classification=None,
-          balance_type=row.flow_balance_type or "debit",
-          value=cf_value,
+          balance_type=balance_type,
+          value=value,
           period_start=period.start,
           period_end=period.end,
           period_type="duration",
@@ -1358,11 +1437,24 @@ def _derive_cash_flow_facts(
   # immutability trigger blocks tenants from inserting their own. If
   # tenant-authored derivations land later (§3.16 Phase 4), this query
   # will need a scope (Reporting Style or taxonomy_id).
+  # Operating-only: investing/financing derivation arcs are intentionally
+  # excluded here. Net-delta can't do gross presentation (a period with only a
+  # debt issuance would still emit a spurious repayment off Δdebt) and silently
+  # omits co-mingled flows (ΔPP&E Net nets capex against depreciation). Those
+  # arcs are the DEFAULT-flow lookup for the line-level fallback in
+  # _emit_flow_facts instead, routed by the flow concept's activityType trait.
   rows = session.execute(
     text("""
-      SELECT from_element_id, to_element_id, weight
-      FROM associations
-      WHERE association_type = 'derivation'
+      SELECT a.from_element_id, a.to_element_id, a.weight
+      FROM associations a
+      WHERE a.association_type = 'derivation'
+        AND NOT EXISTS (
+          SELECT 1 FROM element_traits et
+          JOIN traits t ON t.id = et.trait_id
+          WHERE et.element_id = a.from_element_id
+            AND t.category = 'activityType'
+            AND t.identifier IN ('investingActivity', 'financingActivity')
+        )
     """)
   ).fetchall()
   if not rows:
@@ -1432,6 +1524,66 @@ def _derive_cash_flow_facts(
           period_end=current.end,
           period_type="duration",
         )
+      )
+
+
+def _check_cash_flow_tie_out(
+  facts: list[ReportFact], periods: list[PeriodSpec]
+) -> None:
+  """Reconcile the CF net change in cash against the BS cash movement.
+
+  The CF net-change concept (``CashAndCashEquivalentsPeriodIncreaseDecrease``)
+  is, by the calc DAG, Operating + Investing + Financing — so it always foots
+  to the sections internally (``_check_totals_foot`` covers that). The
+  *meaningful* check is whether that net change equals the actual period-over-
+  period movement in the cash balance (ΔCash). A mismatch means the flow
+  attribution is incomplete or wrong — e.g. an investing line routed to a flow
+  concept that isn't in the render structure, or a coarse "PP&E Net" mapping
+  that the gross-grained default arcs can't resolve.
+
+  Warning-only: the bundle is already generated and the BS/CF still render;
+  this surfaces the residual so it's visible rather than silently wrong. It is
+  the acceptance criterion the enrichment work is validated against.
+  """
+  if len(periods) < 2:
+    return
+  cash_by_date: dict[date, float] = {}
+  net_change_by_end: dict[date, float] = {}
+  for f in facts:
+    if f.period_type == "instant" and f.element_qname in _CASH_ANCHOR_QNAMES:
+      cash_by_date[f.period_end] = cash_by_date.get(f.period_end, 0.0) + f.value
+    elif f.element_qname == "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease":
+      net_change_by_end[f.period_end] = (
+        net_change_by_end.get(f.period_end, 0.0) + f.value
+      )
+
+  # Cash balances are instant facts at period boundaries (a period's end is the
+  # next period's opening), so ΔCash for period i is cash(end_i) - cash(end_{i-1})
+  # — the same prior-period-end delta basis as _derive_cash_flow_facts.
+  ordered = sorted(periods, key=lambda p: p.end)
+  for i in range(1, len(ordered)):
+    current, prior = ordered[i], ordered[i - 1]
+    net_change = net_change_by_end.get(current.end)
+    cash_end = cash_by_date.get(current.end)
+    if net_change is None or cash_end is None:
+      continue
+    # A missing opening balance means $0 cash at that boundary (inception) —
+    # default to 0 rather than skip, so a first-period discrepancy (e.g. a
+    # financing leaf that renders but isn't summed) is flagged, not masked.
+    cash_start = cash_by_date.get(prior.end, 0.0)
+    delta_cash = cash_end - cash_start
+    residual = net_change - delta_cash
+    if abs(residual) > 0.01:
+      logger.warning(
+        "CF tie-out mismatch for period ending %s: net change in cash (%.2f) "
+        "≠ ΔCash from balance sheet (%.2f), residual %.2f. Investing/financing "
+        "attribution is likely incomplete (flow concept off the render "
+        "structure, or a coarse CoA mapping the gross default arcs can't "
+        "resolve).",
+        current.end,
+        net_change,
+        delta_cash,
+        residual,
       )
 
 

--- a/robosystems/operations/roboledger/reports/fact_grid.py
+++ b/robosystems/operations/roboledger/reports/fact_grid.py
@@ -1564,8 +1564,23 @@ def _check_cash_flow_tie_out(
   for i in range(1, len(ordered)):
     current, prior = ordered[i], ordered[i - 1]
     net_change = net_change_by_end.get(current.end)
+    if net_change is None:
+      continue
     cash_end = cash_by_date.get(current.end)
-    if net_change is None or cash_end is None:
+    if cash_end is None:
+      # A net-change fact exists but no instant cash balance does — the
+      # reconciliation can't run. Warn rather than skip silently: "couldn't
+      # check" must not look identical to "checked and tied". Causes: the cash
+      # concept isn't in _CASH_ANCHOR_QNAMES, or the balance sheet wasn't
+      # generated for this period.
+      logger.warning(
+        "CF tie-out could not run for period ending %s: net change in cash "
+        "(%.2f) is present but no instant cash-balance fact was found (cash "
+        "concept missing from _CASH_ANCHOR_QNAMES, or balance sheet not "
+        "generated).",
+        current.end,
+        net_change,
+      )
       continue
     # A missing opening balance means $0 cash at that boundary (inception) —
     # default to 0 rather than skip, so a first-period discrepancy (e.g. a

--- a/robosystems/operations/roboledger/reports/guard_rails.py
+++ b/robosystems/operations/roboledger/reports/guard_rails.py
@@ -27,16 +27,22 @@ class ValidationResult:
 def validate_report(block_type: str, rows: list[FactRow]) -> ValidationResult:
   """Run structural and semantic validation for a rendered structure.
 
-  Note: `cash_flow_statement`, `equity_statement`, and
-  `comprehensive_income` are intentionally not handled — the
-  roboledger renderers for those types aren't implemented yet. When
-  they are, re-wire the `_validate_cash_flow` helper below and add
-  equity / comprehensive-income validators.
+  `_check_totals_foot` (shared) is the load-bearing CF check: it verifies the
+  net-change-in-cash line foots to Op + Inv + Fin and that each section foots
+  to its leaves — i.e. the investing/financing flows actually roll up. The
+  cross-statement ΔCash reconciliation (CF net-change == BS cash movement)
+  lives at the fact-bundle level in ``fact_grid._check_cash_flow_tie_out``,
+  since the rendered CF rows carry no independent beginning/ending cash.
+
+  `equity_statement` and `comprehensive_income` remain unhandled until their
+  validators are added.
   """
   if block_type == "income_statement":
     return _validate_income_statement(rows)
   elif block_type == "balance_sheet":
     return _validate_balance_sheet(rows)
+  elif block_type == "cash_flow_statement":
+    return _validate_cash_flow(rows)
   return ValidationResult(checks=["no_validation_rules"])
 
 
@@ -251,14 +257,14 @@ def _validate_balance_sheet(rows: list[FactRow]) -> ValidationResult:
   return result
 
 
-def _validate_cash_flow(  # pyright: ignore[reportUnusedFunction]
-  rows: list[FactRow],
-) -> ValidationResult:
-  """Cash flow validation — retained for when the renderer is implemented.
+def _validate_cash_flow(rows: list[FactRow]) -> ValidationResult:
+  """Cash flow validation — structural footing of the rendered CF.
 
-  Currently unreferenced; `validate_report` does not dispatch to this
-  function. Wire it back into `validate_report` when the CF renderer
-  lands in fact_grid and drop the `reportUnusedFunction` ignore above.
+  `_check_totals_foot` verifies the net-change line foots to Op + Inv + Fin
+  and each section foots to its leaves (so the investing/financing flow facts
+  emitted by ``fact_grid._emit_flow_facts`` actually roll up). The ΔCash
+  reconciliation against the balance sheet is a fact-bundle check
+  (``fact_grid._check_cash_flow_tie_out``), not a per-statement one.
   """
   result = ValidationResult()
 

--- a/tests/operations/roboledger/reports/test_fact_grid.py
+++ b/tests/operations/roboledger/reports/test_fact_grid.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import date
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from robosystems.operations.roboledger.reports.fact_grid import (
   _EQUITY_FLOW_REDUCER_QNAMES,
@@ -13,6 +13,7 @@ from robosystems.operations.roboledger.reports.fact_grid import (
   _append_empty_equity_facts,
   _Balance,
   _build_rows,
+  _check_cash_flow_tie_out,
   _close_prior_periods_to_retained_earnings,
   _close_to_retained_earnings,
   _compute_prior_period,
@@ -1898,33 +1899,36 @@ class TestEmitNetIncomeFacts:
 
 
 class TestEmitFlowFacts:
-  """``_emit_flow_facts`` — investing/financing CF facts from per-line flow
-  concepts. The SQL aggregation (cash-anchor + activityType filtering +
-  flow→rs-gaap resolution) is exercised end-to-end by the Seattle Method demo;
-  these unit tests cover the Python logic: sign, cents→dollars, zero-skip, and
-  the authoritative-replace of a pre-existing placeholder.
+  """``_emit_flow_facts`` — investing/financing CF facts. Two passes per period:
+  Pass 1 (explicit per-line flow tags) and Pass 2 (element-default fallback for
+  untagged QB data). The SQL aggregation (cash-anchor + activityType filtering +
+  direction-by-sign default resolution) is exercised end-to-end by the Seattle
+  Method demo; these unit tests cover the Python logic: sign, cents→dollars,
+  zero-skip, authoritative-replace, and explicit+fallback combination.
   """
 
   S = date(2024, 1, 1)
   E = date(2024, 3, 31)
 
-  def _row(self, flow_id, qname, cash_cents, *, balance_type="debit", name="Flow"):
+  def _row(self, flow_id, qname, value_cents, *, balance_type="debit", name="Flow"):
     return SimpleNamespace(
       flow_id=flow_id,
       flow_qname=qname,
       flow_name=name,
       flow_balance_type=balance_type,
-      cash_movement_cents=cash_cents,
+      value_cents=value_cents,
     )
 
-  def _session(self, *period_rows):
-    """One execute per period; each returns its row list via fetchall()."""
+  def _session(self, *periods):
+    """Two executes per period (explicit pass, then fallback pass). Each period
+    arg is an ``(explicit_rows, fallback_rows)`` tuple."""
     session = MagicMock()
     results = []
-    for rows in period_rows:
-      r = MagicMock()
-      r.fetchall.return_value = list(rows)
-      results.append(r)
+    for explicit_rows, fallback_rows in periods:
+      for rows in (explicit_rows, fallback_rows):
+        r = MagicMock()
+        r.fetchall.return_value = list(rows)
+        results.append(r)
     session.execute.side_effect = results
     return session
 
@@ -1932,10 +1936,17 @@ class TestEmitFlowFacts:
     return [PeriodSpec(self.S, self.E, "Current")]
 
   def test_investing_outflow_emits_negative(self):
-    """Capex: cash-side credit (debit - credit < 0) → negative outflow."""
+    """Capex (explicit): cash-side credit (debit - credit < 0) → negative."""
     facts: list[ReportFact] = []
     session = self._session(
-      [self._row("inv1", "rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment", -100000)]
+      (
+        [
+          self._row(
+            "inv1", "rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment", -100000
+          )
+        ],
+        [],
+      )
     )
     _emit_flow_facts(session, facts, self._period(), "map1", "mapping")
     assert len(facts) == 1
@@ -1945,24 +1956,69 @@ class TestEmitFlowFacts:
     assert facts[0].classification is None
 
   def test_financing_inflow_emits_positive(self):
-    """Stock issuance: cash-side debit (debit - credit > 0) → positive inflow."""
+    """Stock issuance (explicit): cash-side debit (debit - credit > 0) → +."""
     facts: list[ReportFact] = []
     session = self._session(
-      [
-        self._row(
-          "fin1",
-          "rs-gaap:ProceedsFromIssuanceOfCommonStock",
-          1000000,
-          balance_type="credit",
-        )
-      ]
+      (
+        [
+          self._row(
+            "fin1",
+            "rs-gaap:ProceedsFromIssuanceOfCommonStock",
+            1000000,
+            balance_type="credit",
+          )
+        ],
+        [],
+      )
     )
     _emit_flow_facts(session, facts, self._period(), "map1", "mapping")
     assert facts[0].value == 10000.0
 
+  def test_fallback_emits_when_no_explicit_tag(self):
+    """Pass 2: an untagged entry resolves its non-cash line to the element
+    default (the load-bearing path for real QuickBooks data)."""
+    facts: list[ReportFact] = []
+    session = self._session(
+      (
+        [],  # no explicit tags
+        [
+          self._row(
+            "inv1", "rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment", -100000
+          )
+        ],
+      )
+    )
+    _emit_flow_facts(session, facts, self._period(), "map1", "mapping")
+    assert len(facts) == 1
+    assert facts[0].element_id == "inv1"
+    assert facts[0].value == -1000.0
+
+  def test_explicit_and_fallback_combine_for_same_leaf(self):
+    """A flow leaf fed by both passes (mixed tagged/untagged entries) sums —
+    neither pass clobbers the other."""
+    facts: list[ReportFact] = []
+    session = self._session(
+      (
+        [
+          self._row(
+            "inv1", "rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment", -100000
+          )
+        ],
+        [
+          self._row(
+            "inv1", "rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment", -50000
+          )
+        ],
+      )
+    )
+    _emit_flow_facts(session, facts, self._period(), "map1", "mapping")
+    inv = [f for f in facts if f.element_id == "inv1"]
+    assert len(inv) == 1
+    assert inv[0].value == -1500.0
+
   def test_zero_movement_skipped(self):
     facts: list[ReportFact] = []
-    session = self._session([self._row("z", "rs-gaap:Foo", 0)])
+    session = self._session(([self._row("z", "rs-gaap:Foo", 0)], []))
     _emit_flow_facts(session, facts, self._period(), "map1", "mapping")
     assert facts == []
 
@@ -1972,7 +2028,7 @@ class TestEmitFlowFacts:
     suppressed the long-term-debt financing line in the demo."""
     placeholder = ReportFact(
       element_id="fin1",
-      element_qname="rs-gaap:ProceedsFromIssuanceOfLongTermDebtAndCapitalSecuritiesNet",
+      element_qname="rs-gaap:ProceedsFromIssuanceOfLongTermDebt",
       element_name="Debt",
       classification=None,
       balance_type="debit",
@@ -1983,19 +2039,89 @@ class TestEmitFlowFacts:
     )
     facts: list[ReportFact] = [placeholder]
     session = self._session(
-      [
-        self._row(
-          "fin1",
-          "rs-gaap:ProceedsFromIssuanceOfLongTermDebtAndCapitalSecuritiesNet",
-          100000,
-        )
-      ]
+      (
+        [self._row("fin1", "rs-gaap:ProceedsFromIssuanceOfLongTermDebt", 100000)],
+        [],
+      )
     )
     _emit_flow_facts(session, facts, self._period(), "map1", "mapping")
     debt = [f for f in facts if f.element_id == "fin1"]
     assert len(debt) == 1
     assert debt[0].value == 1000.0
     assert debt[0].period_type == "duration"
+
+
+class TestCheckCashFlowTieOut:
+  """``_check_cash_flow_tie_out`` — CF net change in cash vs ΔCash from the BS.
+
+  ΔCash uses the prior-period-end cash balance as the opening (instant facts
+  sit at period boundaries), so the comparison is cash(end) - cash(prior end).
+  """
+
+  P0 = date(2023, 12, 31)
+  P1 = date(2024, 12, 31)
+
+  def _periods(self):
+    return [
+      PeriodSpec(date(2023, 1, 1), self.P0, "Prior"),
+      PeriodSpec(date(2024, 1, 1), self.P1, "Current"),
+    ]
+
+  def _cash(self, value, end):
+    return ReportFact(
+      element_id=f"cash-{end}",
+      element_qname="rs-gaap:CashAndCashEquivalentsAtCarryingValue",
+      element_name="Cash",
+      classification=None,
+      balance_type="debit",
+      value=value,
+      period_start=None,
+      period_end=end,
+      period_type="instant",
+    )
+
+  def _net_change(self, value):
+    return ReportFact(
+      element_id="cfnc",
+      element_qname="rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
+      element_name="Net change in cash",
+      classification=None,
+      balance_type="debit",
+      value=value,
+      period_start=date(2024, 1, 1),
+      period_end=self.P1,
+      period_type="duration",
+    )
+
+  _LOGGER = "robosystems.operations.roboledger.reports.fact_grid.logger"
+
+  def test_ties_no_warning(self):
+    # Cash 1000 → 1850, ΔCash = 850; net change = 850 → ties.
+    facts = [
+      self._cash(1000.0, self.P0),
+      self._cash(1850.0, self.P1),
+      self._net_change(850.0),
+    ]
+    with patch(self._LOGGER) as log:
+      _check_cash_flow_tie_out(facts, self._periods())
+    assert not log.warning.called
+
+  def test_mismatch_warns(self):
+    # ΔCash = 850 but net change reports 800 → residual 50 → warns.
+    facts = [
+      self._cash(1000.0, self.P0),
+      self._cash(1850.0, self.P1),
+      self._net_change(800.0),
+    ]
+    with patch(self._LOGGER) as log:
+      _check_cash_flow_tie_out(facts, self._periods())
+    assert log.warning.called
+
+  def test_single_period_noop(self):
+    facts = [self._cash(1000.0, self.P0), self._net_change(800.0)]
+    with patch(self._LOGGER) as log:
+      _check_cash_flow_tie_out(facts, [PeriodSpec(date(2023, 1, 1), self.P0, "Only")])
+    assert not log.warning.called
 
 
 class TestDeriveCashFlowFacts:

--- a/tests/operations/roboledger/reports/test_fact_grid.py
+++ b/tests/operations/roboledger/reports/test_fact_grid.py
@@ -2123,6 +2123,15 @@ class TestCheckCashFlowTieOut:
       _check_cash_flow_tie_out(facts, [PeriodSpec(date(2023, 1, 1), self.P0, "Only")])
     assert not log.warning.called
 
+  def test_warns_when_no_cash_fact(self):
+    # A net-change fact exists but no instant cash-balance fact does, so the
+    # reconciliation can't run. It must WARN (not silently skip) — "couldn't
+    # check" must be distinguishable from "checked and tied".
+    facts = [self._net_change(800.0)]
+    with patch(self._LOGGER) as log:
+      _check_cash_flow_tie_out(facts, self._periods())
+    assert log.warning.called
+
 
 class TestDeriveCashFlowFacts:
   PRIOR_S = date(2024, 1, 1)


### PR DESCRIPTION
## Summary

Enhances the cash flow statement generation pipeline by refining taxonomy calculations, strengthening guardrail validations, and significantly expanding the fact grid reporting logic. This refactor touches the full vertical slice from taxonomy definitions through calculation engine to output rendering.

## Key Accomplishments

### Taxonomy & Framework Updates
- Extended the **rs-gaap-calculations** taxonomy with new cash flow-related calculation arcs, broadening coverage of operating, investing, and financing activity line items.
- Updated the **rs-gaap-presentation** taxonomy to align presentation linkbases with the new calculation relationships, ensuring consistent statement rendering.

### Fact Grid Enhancements
- Substantially refactored `fact_grid.py` (~250 lines of net additions) to improve how cash flow facts are resolved, aggregated, and laid out in the grid structure.
- Improved handling of edge cases in fact resolution and section subtotals, leading to more accurate multi-period statement output.

### Guardrail Validations
- Strengthened `guard_rails.py` with additional validation rules targeting cash flow statement integrity, including cross-statement consistency checks.

### Mapping & Demo Updates
- Updated Seattle Method demo mappings to reflect refined cash flow categorization logic.
- Regenerated demo output files (`seattle-method-case-1.md`, `seattle-method-case-1-four-statements.md`) to reflect the improved calculations and presentation.

## Breaking Changes

- **Taxonomy schema changes**: Any downstream consumers directly referencing rs-gaap-calculations or rs-gaap-presentation taxonomy arcs may need to update to accommodate new/modified relationship nodes.
- **Fact grid API behavior**: The refactored fact grid logic may produce different output structures for cash flow statements compared to the previous implementation. Consumers of the grid output should verify compatibility.

## Testing Notes

- Expanded `test_fact_grid.py` with ~194 lines of new/modified test cases covering the refined cash flow calculation paths, subtotal logic, and edge cases.
- Existing tests were updated to match the new expected output structures.
- Demo output files serve as additional regression baselines — reviewers should verify the markdown diffs reflect intentional improvements in statement accuracy.

## Infrastructure Considerations

- Taxonomy JSON-LD files have grown meaningfully; teams maintaining taxonomy tooling or caching layers should be aware of the increased payload size.
- No new dependencies or infrastructure requirements introduced.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

**Branch Info:**
- Source: `refactor/flow-cf-refinement`
- Target: `main`
- Type: refactor

Co-Authored-By: Claude <noreply@anthropic.com>