### PR TITLE
feat(roboledger): preview which close drafts publish to QuickBooks (outbox read-half)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,10 +6,6 @@
       "Bash(git diff:*)",
       "Bash(git show:*)",
       "Bash(git log:*)",
-      "Bash(git branch --list:*)",
-      "Bash(git branch -a:*)",
-      "Bash(git branch -r:*)",
-      "Bash(git branch -v:*)",
       "Bash(ls:*)",
       "Bash(tree:*)",
       "Bash(wc:*)",
@@ -118,6 +114,11 @@
       "mcp__robosystems__switch-workspace"
     ],
     "ask": [
+      "Bash(git branch --show-current:*)",
+      "Bash(git branch --list:*)",
+      "Bash(git branch -a:*)",
+      "Bash(git branch -r:*)",
+      "Bash(git branch -v:*)",
       "Bash(just gha-set:*)",
       "Bash(just gha-delete:*)",
       "Bash(just ssm-set:*)",

--- a/robosystems/graphql/resolvers/ledger.py
+++ b/robosystems/graphql/resolvers/ledger.py
@@ -766,10 +766,26 @@ class LedgerQuery:
     info: Info[GraphQLContext, None],
     period: str,
   ) -> PeriodDrafts | None:
-    """All draft entries for a fiscal period, ready for review before close."""
+    """All draft entries for a fiscal period, ready for review before close.
+
+    The close-review *outbox*: each draft is annotated with its QB
+    write-back disposition (``willPublishToQb``) and the response carries
+    a publish summary — which drafts `close-period` will push to
+    QuickBooks vs. post locally only.
+    """
+    from robosystems.db.platform import platform_session
+    from robosystems.operations.roboledger.fiscal_calendar.qb_writeback import (
+      resolve_writeback_connection,
+    )
+
+    graph_id = require_graph_id(info)
     try:
+      with platform_session() as platform_db:
+        writeback = resolve_writeback_connection(platform_db, graph_id)
       with _open_session(info, "roboledger") as session:
-        response = reads_period_drafts.list_period_drafts(session, period)
+        response = reads_period_drafts.list_period_drafts(
+          session, period, writeback=writeback
+        )
     except (ValueError, ProgrammingError):
       _raise_ledger_not_initialized()
     return PeriodDrafts.from_pydantic(response)

--- a/robosystems/middleware/mcp/tools/schedule_tools.py
+++ b/robosystems/middleware/mcp/tools/schedule_tools.py
@@ -160,12 +160,19 @@ class ListPeriodDraftsTool:
     }
 
   async def execute(self, arguments: dict[str, Any]) -> Any:
+    from robosystems.db.platform import platform_session
+    from robosystems.operations.roboledger.fiscal_calendar.qb_writeback import (
+      resolve_writeback_connection,
+    )
+
     graph_id = self.client.graph_id
     period = arguments["period"]
 
     try:
+      with platform_session() as platform_db:
+        writeback = resolve_writeback_connection(platform_db, graph_id)
       with extensions_session(graph_id) as session:
-        response = list_period_drafts(session, period)
+        response = list_period_drafts(session, period, writeback=writeback)
         return response.model_dump(mode="json")
     except Exception as exc:
       logger.warning(f"list-period-drafts failed: {exc}")

--- a/robosystems/middleware/mcp/tools/schedule_tools.py
+++ b/robosystems/middleware/mcp/tools/schedule_tools.py
@@ -141,11 +141,15 @@ class ListPeriodDraftsTool:
 **RETURNS:**
 - draft_count, total_debit, total_credit, all_balanced
 - drafts: full list with entry_id, posting_date, memo, source schedule name, line items (element name/code, debit/credit in cents), per-entry balance check
+- will_publish_to_qb (per draft): whether closing the period will publish this draft to QuickBooks (vs. post locally only)
+- qb_publish_count / local_only_count: how many drafts publish to QuickBooks on close vs. post locally only
+- qb_writeback_connection_id / qb_write_policy: the QB connection close would publish to, or null when the graph has no qb_authoritative/hybrid QB connection
 
 **NOTES:**
 - Read-only — no side effects, safe to call repeatedly
 - Returns an empty list if no drafts exist for the period
-- Line amounts are in cents (divide by 100 for dollar display)""",
+- Line amounts are in cents (divide by 100 for dollar display)
+- This is the close-review *outbox*: surface will_publish_to_qb + the qb_publish_count/local_only_count summary so the user sees what close will write to QuickBooks before committing""",
       "inputSchema": {
         "type": "object",
         "properties": {

--- a/robosystems/models/api/extensions/fiscal_calendar.py
+++ b/robosystems/models/api/extensions/fiscal_calendar.py
@@ -357,6 +357,15 @@ class DraftEntryResponse(BaseModel):
   total_debit: int = Field(..., description="Sum of debit amounts in cents")
   total_credit: int = Field(..., description="Sum of credit amounts in cents")
   balanced: bool = Field(..., description="True if total_debit == total_credit")
+  will_publish_to_qb: bool = Field(
+    False,
+    description=(
+      "True if closing the period will publish this draft to QuickBooks — "
+      "i.e. the graph has a qb_authoritative/hybrid QB connection AND this "
+      "is an RL-originated draft (schedule/manual) not already in QB. False "
+      "means it posts locally only."
+    ),
+  )
 
 
 class PeriodDraftsResponse(BaseModel):
@@ -370,5 +379,28 @@ class PeriodDraftsResponse(BaseModel):
   total_credit: int = Field(..., description="Sum across all drafts, in cents")
   all_balanced: bool = Field(
     ..., description="True if every draft entry has debit == credit"
+  )
+  qb_writeback_connection_id: str | None = Field(
+    None,
+    description=(
+      "Id of the QuickBooks connection these drafts publish to on close, or "
+      "null when the graph has no qb_authoritative/hybrid QB connection (the "
+      "drafts post locally only)."
+    ),
+  )
+  qb_write_policy: str | None = Field(
+    None,
+    description=(
+      "write_policy of the publishing QB connection ('qb_authoritative' / "
+      "'hybrid'), or null when there is no write-back connection."
+    ),
+  )
+  qb_publish_count: int = Field(
+    0,
+    description="Number of drafts that will publish to QuickBooks on close.",
+  )
+  local_only_count: int = Field(
+    0,
+    description="Number of drafts that post locally only (no QB write-back).",
   )
   drafts: list[DraftEntryResponse]

--- a/robosystems/operations/roboledger/fiscal_calendar/close_service.py
+++ b/robosystems/operations/roboledger/fiscal_calendar/close_service.py
@@ -332,51 +332,30 @@ class PeriodCloseService:
     """
     from robosystems.database import SessionFactory as _PlatformSessionFactory
     from robosystems.models.api.event_block import ExecuteEventBlockRequest
-    from robosystems.models.core.connection.connection import Connection
-    from robosystems.models.extensions.roboledger.event import Event
     from robosystems.operations.event_block.commands import execute_event_block
 
-    # Find the first QB connection in qb_authoritative / hybrid mode on
-    # this graph. Most graphs have at most one QB connection; if a
-    # graph has multiple, v1 picks the first by created_at desc.
-    qb_connection_id: str | None = None
-    with _PlatformSessionFactory() as platform_session:
-      candidate = (
-        platform_session.query(Connection)
-        .filter(
-          Connection.graph_id == graph_id,
-          Connection.provider == "quickbooks",
-          Connection.write_policy.in_(("qb_authoritative", "hybrid")),
-          Connection.deleted_at.is_(None),
-        )
-        .order_by(Connection.created_at.desc())
-        .first()
-      )
-      if candidate is None:
-        logger.debug(
-          f"No qb_authoritative QB connection on graph {graph_id}; "
-          f"skipping close-period pre-publish step"
-        )
-        return
-      qb_connection_id = str(candidate.id)
+    from .qb_writeback import (
+      resolve_writeback_connection,
+      select_writeback_eligible_entries,
+    )
 
-    # Find in-period draft entries from RL-originated events.
-    drafts_to_publish = (
-      session.query(Entry, Event)
-      .join(Event, Event.id == Entry.triggered_by_event_id)
-      .filter(
-        Entry.posting_date >= period_start,
-        Entry.posting_date <= period_end,
-        Entry.status == "draft",
-        Event.source.in_(("schedule", "manual")),
-        # Skip events that already have a QB-side id (a previous
-        # close-period attempt or operator-triggered execute-event-block
-        # already published this event — re-attempt would create
-        # duplicate QB entries even with RequestId dedup if the
-        # request_id differs).
-        Event.metadata_["qb_external_id"].astext.is_(None),
+    # Resolve the QB connection close publishes to. Shared with the
+    # outbox read (`list_period_drafts`) so the preview of "what will
+    # publish" can't drift from this actual write.
+    with _PlatformSessionFactory() as platform_session:
+      writeback = resolve_writeback_connection(platform_session, graph_id)
+    if writeback is None:
+      logger.debug(
+        f"No qb_authoritative QB connection on graph {graph_id}; "
+        f"skipping close-period pre-publish step"
       )
-      .all()
+      return
+    qb_connection_id = writeback.connection_id
+
+    # In-period draft entries from RL-originated events not already in QB
+    # (same predicate the outbox read previews — see qb_writeback.py).
+    drafts_to_publish = select_writeback_eligible_entries(
+      session, period_start, period_end
     )
 
     if not drafts_to_publish:

--- a/robosystems/operations/roboledger/fiscal_calendar/qb_writeback.py
+++ b/robosystems/operations/roboledger/fiscal_calendar/qb_writeback.py
@@ -1,0 +1,121 @@
+"""Shared definition of which RoboLedger-originated drafts publish to
+QuickBooks on period close.
+
+Single source of truth for both the close path
+(``close_service._publish_drafts_to_qb``, which actually publishes) and
+the outbox read (``reads.period_drafts.list_period_drafts``, which
+previews what *will* publish). Keeping the predicate here keeps the
+preview from drifting from the actual write — if the two diverged, the
+outbox would show a disclosure the close doesn't honor.
+
+The predicate has two halves:
+
+- **connection** (platform DB): the graph has a non-deleted QuickBooks
+  ``Connection`` whose ``write_policy`` is qb_authoritative / hybrid.
+- **eligible drafts** (extensions DB): in-period ``draft`` entries whose
+  triggering ``Event`` is RL-originated (``source IN ('schedule',
+  'manual')``) and not already in QB (no ``qb_external_id``).
+
+A draft publishes on close iff both hold.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+
+from sqlalchemy import Row
+from sqlalchemy.orm import Session
+
+from robosystems.models.extensions.roboledger.entry import Entry
+from robosystems.models.extensions.roboledger.event import Event
+
+# RL-originated event sources whose draft GL rows write back to QB on
+# close. Synced-in QB transactions (``source='quickbooks'``) already live
+# in QB and are excluded.
+WRITEBACK_EVENT_SOURCES = ("schedule", "manual")
+
+# Connection write policies that publish RL-originated drafts back to the
+# source of truth on close (``native`` does not — RoboSystems is the SoR).
+WRITEBACK_WRITE_POLICIES = ("qb_authoritative", "hybrid")
+
+
+@dataclass(frozen=True)
+class WritebackConnection:
+  """The QB connection (platform DB) that close will publish drafts to."""
+
+  connection_id: str
+  write_policy: str
+
+
+def resolve_writeback_connection(
+  platform_session: Session, graph_id: str
+) -> WritebackConnection | None:
+  """Return the QB connection that close-period would publish to, or None.
+
+  Mirrors the connection selection in
+  ``PeriodCloseService._publish_drafts_to_qb``: the most-recently-created
+  non-deleted QuickBooks connection on the graph whose ``write_policy`` is
+  qb_authoritative / hybrid. Most graphs have at most one; v1 picks the
+  first by ``created_at`` desc when several exist.
+  """
+  from robosystems.models.core.connection.connection import Connection
+
+  candidate = (
+    platform_session.query(Connection)
+    .filter(
+      Connection.graph_id == graph_id,
+      Connection.provider == "quickbooks",
+      Connection.write_policy.in_(WRITEBACK_WRITE_POLICIES),
+      Connection.deleted_at.is_(None),
+    )
+    .order_by(Connection.created_at.desc())
+    .first()
+  )
+  if candidate is None:
+    return None
+  return WritebackConnection(
+    connection_id=str(candidate.id),
+    write_policy=str(candidate.write_policy),
+  )
+
+
+def select_writeback_eligible_entries(
+  session: Session, period_start: date, period_end: date
+) -> list[Row[tuple[Entry, Event]]]:
+  """In-period draft entries from RL-originated events not yet in QB.
+
+  The extensions-side half of the publish predicate, shared by the close
+  path (which publishes these) and the outbox read (which previews them).
+  Connection ``write_policy`` is checked separately (platform DB) — these
+  are the entries that publish *if* a writeback connection exists.
+  """
+  return (
+    session.query(Entry, Event)
+    .join(Event, Event.id == Entry.triggered_by_event_id)
+    .filter(
+      Entry.posting_date >= period_start,
+      Entry.posting_date <= period_end,
+      Entry.status == "draft",
+      Event.source.in_(WRITEBACK_EVENT_SOURCES),
+      Event.metadata_["qb_external_id"].astext.is_(None),
+    )
+    .all()
+  )
+
+
+def writeback_eligible_entry_ids(
+  session: Session, period_start: date, period_end: date
+) -> set[str]:
+  """Entry ids that publish to QB on close — given a writeback connection.
+
+  The outbox read combines this with
+  :func:`resolve_writeback_connection`: an entry's ``will_publish_to_qb``
+  is true iff it is in this set *and* a writeback connection exists.
+  """
+  return {
+    str(entry.id)
+    for entry, _event in select_writeback_eligible_entries(
+      session, period_start, period_end
+    )
+  }

--- a/robosystems/operations/roboledger/reads/period_drafts.py
+++ b/robosystems/operations/roboledger/reads/period_drafts.py
@@ -18,6 +18,10 @@ from robosystems.models.api.extensions.fiscal_calendar import (
   PeriodDraftsResponse,
 )
 from robosystems.operations.roboledger.fiscal_calendar import period_date_range
+from robosystems.operations.roboledger.fiscal_calendar.qb_writeback import (
+  WritebackConnection,
+  writeback_eligible_entry_ids,
+)
 
 _DRAFT_ENTRIES_SQL = text("""
   SELECT
@@ -46,9 +50,28 @@ _DRAFT_ENTRIES_SQL = text("""
 """)
 
 
-def list_period_drafts(session: Session, period: str) -> PeriodDraftsResponse:
-  """Return all draft entries for review within a given YYYY-MM period."""
+def list_period_drafts(
+  session: Session,
+  period: str,
+  writeback: WritebackConnection | None = None,
+) -> PeriodDraftsResponse:
+  """Return all draft entries for review within a given YYYY-MM period.
+
+  This is the close-review *outbox*: every queued draft entry, plus —
+  when ``writeback`` is supplied (the qb_authoritative/hybrid QB
+  connection the caller resolved against the platform DB) — a
+  ``will_publish_to_qb`` flag per draft and a publish summary on the
+  response. The publish predicate is shared with the actual close write
+  (``qb_writeback.py``), so the preview cannot drift from what
+  ``close-period`` does. When ``writeback`` is None (no write-back
+  connection), every draft is local-only.
+  """
   period_start, period_end = period_date_range(period)
+
+  # Drafts that close would publish to QB — but only actually publish if
+  # a write-back connection exists (the `writeback` arg).
+  eligible_ids = writeback_eligible_entry_ids(session, period_start, period_end)
+  has_writeback = writeback is not None
 
   rows = session.execute(
     _DRAFT_ENTRIES_SQL,
@@ -86,6 +109,7 @@ def list_period_drafts(session: Session, period: str) -> PeriodDraftsResponse:
   total_debit = 0
   total_credit = 0
   all_balanced = True
+  qb_publish_count = 0
   for entry_data in by_entry.values():
     line_items = entry_data["line_items"]
     entry_debit = sum(li.debit_amount for li in line_items)
@@ -95,6 +119,11 @@ def list_period_drafts(session: Session, period: str) -> PeriodDraftsResponse:
       all_balanced = False
     total_debit += entry_debit
     total_credit += entry_credit
+    # Publishes on close only if both halves of the predicate hold:
+    # a write-back connection exists AND this draft is eligible.
+    will_publish = has_writeback and entry_data["entry_id"] in eligible_ids
+    if will_publish:
+      qb_publish_count += 1
     drafts.append(
       DraftEntryResponse(
         entry_id=entry_data["entry_id"],
@@ -108,6 +137,7 @@ def list_period_drafts(session: Session, period: str) -> PeriodDraftsResponse:
         total_debit=entry_debit,
         total_credit=entry_credit,
         balanced=balanced,
+        will_publish_to_qb=will_publish,
       )
     )
 
@@ -119,5 +149,9 @@ def list_period_drafts(session: Session, period: str) -> PeriodDraftsResponse:
     total_debit=total_debit,
     total_credit=total_credit,
     all_balanced=all_balanced,
+    qb_writeback_connection_id=writeback.connection_id if writeback else None,
+    qb_write_policy=writeback.write_policy if writeback else None,
+    qb_publish_count=qb_publish_count,
+    local_only_count=len(drafts) - qb_publish_count,
     drafts=drafts,
   )

--- a/robosystems/operations/roboledger/reads/period_drafts.py
+++ b/robosystems/operations/roboledger/reads/period_drafts.py
@@ -69,9 +69,15 @@ def list_period_drafts(
   period_start, period_end = period_date_range(period)
 
   # Drafts that close would publish to QB — but only actually publish if
-  # a write-back connection exists (the `writeback` arg).
-  eligible_ids = writeback_eligible_entry_ids(session, period_start, period_end)
+  # a write-back connection exists. Skip the eligibility query entirely
+  # when there's no connection (the common native/no-connection case),
+  # since the result would be discarded.
   has_writeback = writeback is not None
+  eligible_ids = (
+    writeback_eligible_entry_ids(session, period_start, period_end)
+    if has_writeback
+    else set()
+  )
 
   rows = session.execute(
     _DRAFT_ENTRIES_SQL,

--- a/tests/operations/roboledger/fiscal_calendar/test_qb_writeback.py
+++ b/tests/operations/roboledger/fiscal_calendar/test_qb_writeback.py
@@ -1,0 +1,78 @@
+"""Unit tests for the shared QB write-back predicate (qb_writeback.py).
+
+Covers the connection resolver and the eligible-entry id helper that both
+the close path (`_publish_drafts_to_qb`) and the outbox read
+(`list_period_drafts`) share, so the preview can't drift from the write.
+Mock-based, mirroring the close-service test style.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from robosystems.operations.roboledger.fiscal_calendar.qb_writeback import (
+  WritebackConnection,
+  resolve_writeback_connection,
+  writeback_eligible_entry_ids,
+)
+
+GRAPH_ID = "kg01234567890abcdef"
+
+
+def _platform_session_returning(candidate):
+  """Mock platform session whose Connection query resolves to `candidate`."""
+  session = MagicMock()
+  session.query.return_value.filter.return_value.order_by.return_value.first.return_value = candidate
+  return session
+
+
+class TestResolveWritebackConnection:
+  def test_returns_writeback_connection_when_candidate_exists(self):
+    candidate = SimpleNamespace(id="conn-123", write_policy="qb_authoritative")
+    session = _platform_session_returning(candidate)
+
+    result = resolve_writeback_connection(session, GRAPH_ID)
+
+    assert result == WritebackConnection(
+      connection_id="conn-123", write_policy="qb_authoritative"
+    )
+
+  def test_returns_none_when_no_writeback_connection(self):
+    session = _platform_session_returning(None)
+
+    assert resolve_writeback_connection(session, GRAPH_ID) is None
+
+  def test_coerces_connection_id_to_str(self):
+    candidate = SimpleNamespace(id=42, write_policy="hybrid")
+    session = _platform_session_returning(candidate)
+
+    result = resolve_writeback_connection(session, GRAPH_ID)
+
+    assert result is not None
+    assert result.connection_id == "42"
+    assert result.write_policy == "hybrid"
+
+
+class TestWritebackEligibleEntryIds:
+  def test_extracts_str_entry_ids_from_rows(self):
+    session = MagicMock()
+    rows = [
+      (SimpleNamespace(id="e1"), SimpleNamespace(id="ev1")),
+      (SimpleNamespace(id="e2"), SimpleNamespace(id="ev2")),
+    ]
+    session.query.return_value.join.return_value.filter.return_value.all.return_value = rows
+
+    ids = writeback_eligible_entry_ids(session, date(2026, 1, 1), date(2026, 1, 31))
+
+    assert ids == {"e1", "e2"}
+
+  def test_empty_when_no_eligible_entries(self):
+    session = MagicMock()
+    session.query.return_value.join.return_value.filter.return_value.all.return_value = []
+
+    assert (
+      writeback_eligible_entry_ids(session, date(2026, 1, 1), date(2026, 1, 31))
+      == set()
+    )

--- a/tests/operations/roboledger/reads/test_period_drafts.py
+++ b/tests/operations/roboledger/reads/test_period_drafts.py
@@ -95,7 +95,6 @@ class TestPeriodDraftsDisposition:
 
     resp = list_period_drafts(session, "2026-01", writeback=None)
 
-    _by_id(resp)
     assert all(not d.will_publish_to_qb for d in resp.drafts)
     assert resp.qb_publish_count == 0
     assert resp.local_only_count == 2

--- a/tests/operations/roboledger/reads/test_period_drafts.py
+++ b/tests/operations/roboledger/reads/test_period_drafts.py
@@ -1,0 +1,128 @@
+"""Unit tests for the period-drafts outbox read (list_period_drafts).
+
+Focus: the QB write-back disposition layered on top of the draft listing
+— per-entry `will_publish_to_qb` and the response publish summary —
+under the three cases that matter: a write-back connection with an
+eligible draft, the same drafts with NO write-back connection (all
+local-only), and an ineligible draft (already in QB / synced).
+
+Mock-based: the read does a raw-SQL drafts query (`session.execute`) and
+an ORM eligibility query (`session.query(...)`), so the mock session
+serves both.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from robosystems.operations.roboledger.fiscal_calendar.qb_writeback import (
+  WritebackConnection,
+)
+from robosystems.operations.roboledger.reads.period_drafts import list_period_drafts
+
+
+def _line_row(entry_id: str, line_item_id: str, debit: int, credit: int):
+  """One draft line-item row in the shape `_DRAFT_ENTRIES_SQL` returns."""
+  return SimpleNamespace(
+    entry_id=entry_id,
+    posting_date=date(2026, 1, 15),
+    entry_type="closing",
+    memo=f"memo-{entry_id}",
+    provenance="schedule",
+    source_structure_id=None,
+    source_structure_name=None,
+    line_item_id=line_item_id,
+    element_id=f"el-{line_item_id}",
+    element_code="1000",
+    element_name="Cash",
+    debit_amount=debit,
+    credit_amount=credit,
+    line_description=None,
+  )
+
+
+def _two_balanced_entries_session(eligible_entry_ids):
+  """Mock session: two balanced draft entries (e1, e2); eligibility query
+  returns rows for `eligible_entry_ids`."""
+  draft_rows = [
+    # e1 — balanced (1000 dr / 1000 cr across two lines)
+    _line_row("e1", "li1", 1000, 0),
+    _line_row("e1", "li2", 0, 1000),
+    # e2 — balanced
+    _line_row("e2", "li3", 500, 0),
+    _line_row("e2", "li4", 0, 500),
+  ]
+  eligible_rows = [
+    (SimpleNamespace(id=eid), SimpleNamespace(id=f"ev-{eid}"))
+    for eid in eligible_entry_ids
+  ]
+  session = MagicMock()
+  session.execute.return_value.fetchall.return_value = draft_rows
+  session.query.return_value.join.return_value.filter.return_value.all.return_value = (
+    eligible_rows
+  )
+  return session
+
+
+def _by_id(resp):
+  return {d.entry_id: d for d in resp.drafts}
+
+
+class TestPeriodDraftsDisposition:
+  def test_writeback_connection_marks_eligible_draft(self):
+    session = _two_balanced_entries_session(eligible_entry_ids={"e1"})
+    writeback = WritebackConnection(
+      connection_id="conn-1", write_policy="qb_authoritative"
+    )
+
+    resp = list_period_drafts(session, "2026-01", writeback=writeback)
+
+    drafts = _by_id(resp)
+    assert resp.draft_count == 2
+    assert drafts["e1"].will_publish_to_qb is True
+    assert drafts["e2"].will_publish_to_qb is False
+    assert resp.qb_publish_count == 1
+    assert resp.local_only_count == 1
+    assert resp.qb_writeback_connection_id == "conn-1"
+    assert resp.qb_write_policy == "qb_authoritative"
+
+  def test_no_writeback_connection_is_all_local_only(self):
+    # Even though e1 is eligibility-wise a write-back draft, with no
+    # write-back connection NOTHING publishes — close posts locally only.
+    session = _two_balanced_entries_session(eligible_entry_ids={"e1"})
+
+    resp = list_period_drafts(session, "2026-01", writeback=None)
+
+    _by_id(resp)
+    assert all(not d.will_publish_to_qb for d in resp.drafts)
+    assert resp.qb_publish_count == 0
+    assert resp.local_only_count == 2
+    assert resp.qb_writeback_connection_id is None
+    assert resp.qb_write_policy is None
+
+  def test_ineligible_draft_not_published(self):
+    # No draft is eligible (e.g. already in QB / synced source) → even
+    # with a write-back connection, nothing publishes.
+    session = _two_balanced_entries_session(eligible_entry_ids=set())
+    writeback = WritebackConnection(
+      connection_id="conn-1", write_policy="qb_authoritative"
+    )
+
+    resp = list_period_drafts(session, "2026-01", writeback=writeback)
+
+    assert all(not d.will_publish_to_qb for d in resp.drafts)
+    assert resp.qb_publish_count == 0
+    assert resp.local_only_count == 2
+
+  def test_default_writeback_arg_is_local_only(self):
+    # Back-compat: callers that don't pass `writeback` get the old
+    # behavior plus a clean local-only disposition.
+    session = _two_balanced_entries_session(eligible_entry_ids={"e1", "e2"})
+
+    resp = list_period_drafts(session, "2026-01")
+
+    assert resp.qb_publish_count == 0
+    assert resp.local_only_count == 2
+    assert all(not d.will_publish_to_qb for d in resp.drafts)


### PR DESCRIPTION
## What

Surfaces a QB write-back **disposition** on the period-drafts read so the close-review *outbox* shows which drafts `close-period` will publish to QuickBooks vs. post locally only.

- `qb_writeback.py` — the single "publishes to QB on close" predicate (`resolve_writeback_connection` + `select_writeback_eligible_entries`), shared by **both** the actual close write and the preview so they can't drift.
- `PeriodDraftsResponse` — `will_publish_to_qb` per draft + `qb_publish_count` / `local_only_count` / `qb_writeback_connection_id` / `qb_write_policy` summary (auto-flows to the `periodDrafts` GraphQL type via `@pydantic_type`).
- `list_period_drafts` takes the resolved write-back connection; the GraphQL resolver + `list-period-drafts` MCP tool resolve it (platform DB) and pass it down — no cross-DB join.
- `close_service._publish_drafts_to_qb` refactored onto the shared predicate.

## Why

The **read-half of the Outbox MVP** (`local/docs/specs/outbox.md` §12): the no-surprise-write disclosure for `qb_authoritative`-by-default connections, without a new store or release path — `close-period` stays the release. Outbox reads are GraphQL, never an ops-surface op.

## Test plan

- New: `tests/operations/roboledger/fiscal_calendar/test_qb_writeback.py` + `tests/operations/roboledger/reads/test_period_drafts.py` (9 tests).
- Existing close-service + schedule-tools tests pass (23).
- `just test-code` clean (ruff/format/basedpyright).

## Notes

- Read-only / additive; no migration.
- Consumed by `@robosystems/client` 0.3.38 (published) + the roboledger-app PR.
