### PR TITLE
chore(billing): raise Standard tier to $149 and drop LadybugDB from tier names

### DIFF
--- a/robosystems/config/billing/core.py
+++ b/robosystems/config/billing/core.py
@@ -203,7 +203,7 @@ class BillingConfig:
   ) -> str:
     """Resolve a plan's internal name to its human-readable display name.
 
-    For graphs: "ladybug-standard" -> "LadybugDB Standard"
+    For graphs: "ladybug-standard" -> "Standard"
     For repos:  "sec-advanced"     -> "SEC EDGAR Filings - Pro"
 
     Falls back to the raw plan name when no display mapping is found.

--- a/robosystems/config/billing/core.py
+++ b/robosystems/config/billing/core.py
@@ -33,7 +33,7 @@ DEFAULT_GRAPH_BILLING_PLANS: list[dict[str, Any]] = [
     "name": "ladybug-standard",
     "display_name": "LadybugDB Standard",
     "description": "Dedicated m7g.large LadybugDB infrastructure with subgraph support",
-    "base_price_cents": 9900,  # $99/month
+    "base_price_cents": 14900,  # $149/month
     "monthly_credit_allocation": 8000,  # ~200 agent calls/month
     "backup_downloads_per_month": 10,
     "max_documents": 100,

--- a/robosystems/config/billing/core.py
+++ b/robosystems/config/billing/core.py
@@ -31,8 +31,8 @@ logger = logging.getLogger(__name__)
 DEFAULT_GRAPH_BILLING_PLANS: list[dict[str, Any]] = [
   {
     "name": "ladybug-standard",
-    "display_name": "LadybugDB Standard",
-    "description": "Dedicated m7g.large LadybugDB infrastructure with subgraph support",
+    "display_name": "Standard",
+    "description": "Dedicated m7g.large infrastructure with subgraph support",
     "base_price_cents": 14900,  # $149/month
     "monthly_credit_allocation": 8000,  # ~200 agent calls/month
     "backup_downloads_per_month": 10,
@@ -41,7 +41,7 @@ DEFAULT_GRAPH_BILLING_PLANS: list[dict[str, Any]] = [
   },
   {
     "name": "ladybug-large",
-    "display_name": "LadybugDB Large",
+    "display_name": "Large",
     "description": "Dedicated r7g.large instance - enhanced performance with subgraph support",
     "base_price_cents": 29900,  # $299/month
     "monthly_credit_allocation": 32000,  # ~800 agent calls/month
@@ -51,7 +51,7 @@ DEFAULT_GRAPH_BILLING_PLANS: list[dict[str, Any]] = [
   },
   {
     "name": "ladybug-xlarge",
-    "display_name": "LadybugDB XLarge",
+    "display_name": "XLarge",
     "description": "Dedicated r7g.xlarge instance - maximum performance and scale",
     "base_price_cents": 69900,  # $699/month
     "monthly_credit_allocation": 100000,  # ~2,600 agent calls/month

--- a/robosystems/config/graph_tier.py
+++ b/robosystems/config/graph_tier.py
@@ -597,9 +597,9 @@ class GraphTierConfig:
 
       # Add display name based on tier
       display_names = {
-        "ladybug-standard": "LadybugDB Standard",
-        "ladybug-large": "LadybugDB Large",
-        "ladybug-xlarge": "LadybugDB XLarge",
+        "ladybug-standard": "Standard",
+        "ladybug-large": "Large",
+        "ladybug-xlarge": "XLarge",
         "ladybug-shared": "Shared Repository",
       }
       tier_info["display_name"] = display_names.get(tier_name, writer.get("name"))

--- a/robosystems/dagster/jobs/invoice_billing.py
+++ b/robosystems/dagster/jobs/invoice_billing.py
@@ -34,6 +34,7 @@ def _renew_subscriptions(
   4. Generate a renewal invoice
   5. Log an audit event
   """
+  from robosystems.config.billing import BillingConfig
   from robosystems.models.core.billing import (
     BillingAuditLog,
     BillingCustomer,
@@ -100,10 +101,14 @@ def _renew_subscriptions(
         old_period_end = subscription.current_period_end
         subscription.renew_period(session)
 
+        plan_config = BillingConfig.get_subscription_plan(subscription.plan_name)
+        tier_label = (
+          plan_config["display_name"] if plan_config else subscription.plan_name
+        )
         invoice = generate_subscription_invoice(
           subscription=subscription,
           customer=customer,
-          description=f"{subscription.plan_name} subscription renewal",
+          description=f"Graph subscription renewal — {tier_label}",
           session=session,
         )
 

--- a/robosystems/dagster/jobs/invoice_billing.py
+++ b/robosystems/dagster/jobs/invoice_billing.py
@@ -108,7 +108,7 @@ def _renew_subscriptions(
         invoice = generate_subscription_invoice(
           subscription=subscription,
           customer=customer,
-          description=f"Graph subscription renewal — {tier_label}",
+          description=f"Graph subscription renewal - {tier_label}",
           session=session,
         )
 

--- a/robosystems/models/api/graphs/subgraphs.py
+++ b/robosystems/models/api/graphs/subgraphs.py
@@ -180,7 +180,7 @@ class ListSubgraphsResponse(BaseModel):
 
   subgraphs_enabled: bool = Field(
     ...,
-    description="Whether subgraphs are enabled for this tier (requires LadybugDB Large/XLarge)",
+    description="Whether subgraphs are enabled for this tier (requires Large/XLarge tier)",
   )
 
   subgraph_count: int = Field(..., description="Total number of subgraphs", ge=0)

--- a/robosystems/operations/graph/provisioning_service.py
+++ b/robosystems/operations/graph/provisioning_service.py
@@ -154,7 +154,7 @@ async def run_graph_provisioning(
           generate_subscription_invoice(
             subscription=subscription,
             customer=customer,
-            description=f"Graph subscription — {tier_label}",
+            description=f"Graph subscription - {tier_label}",
             session=db,
           )
           logger.info(f"Generated invoice for subscription {subscription_id}")

--- a/robosystems/operations/graph/provisioning_service.py
+++ b/robosystems/operations/graph/provisioning_service.py
@@ -145,10 +145,16 @@ async def run_graph_provisioning(
       if not subscription.stripe_subscription_id:
         customer = BillingCustomer.get_by_user_id(user_id, db)
         if customer and customer.invoice_billing_enabled:
+          from robosystems.config.billing import BillingConfig
+
+          plan_config = BillingConfig.get_subscription_plan(subscription.plan_name)
+          tier_label = (
+            plan_config["display_name"] if plan_config else subscription.plan_name
+          )
           generate_subscription_invoice(
             subscription=subscription,
             customer=customer,
-            description=f"Graph Database Subscription - {subscription.plan_name}",
+            description=f"Graph subscription — {tier_label}",
             session=db,
           )
           logger.info(f"Generated invoice for subscription {subscription_id}")

--- a/tests/config/billing/test_core.py
+++ b/tests/config/billing/test_core.py
@@ -19,7 +19,7 @@ def test_get_subscription_plan_returns_plan_with_credit_allocation():
   assert plan is not None
   assert plan["name"] == "ladybug-standard"
   assert plan["monthly_credit_allocation"] == 8000  # ~200 agent calls/month
-  assert plan["base_price_cents"] == 9900  # $99/month
+  assert plan["base_price_cents"] == 14900  # $149/month
 
 
 def test_get_subscription_plan_returns_none_for_unknown_tier():


### PR DESCRIPTION
## Summary

Two billing changes, isolated to config + presentation layers:

1. **Standard tier price: $99 → $149/mo.**
2. **Drop the "LadybugDB" brand from customer-facing tier names** — display names become `Standard` / `Large` / `XLarge`. The tenant is branded as a "graph"; LadybugDB stays as engine attribution on landing/marketing only, never the leading subscription name.

## Changes

- `config/billing/core.py` — Standard `base_price_cents` 9900 → 14900; tier `display_name`s drop "LadybugDB"; Standard `description` drops "LadybugDB"; `get_plan_display_name` docstring example updated.
- `config/graph_tier.py` — tier `display_names` map drops "LadybugDB" (the SEC "Shared Repository" label is unchanged).
- `models/api/graphs/subgraphs.py` — field description now reads "requires Large/XLarge tier".
- `dagster/jobs/invoice_billing.py` + `operations/graph/provisioning_service.py` — invoice line-item descriptions resolve the human display name with a "Graph" context (e.g. `Graph subscription - Standard`) instead of rendering the raw internal id (`ladybug-standard`); falls back to the plan name if no config match.
- `tests/config/billing/test_core.py` — price assertion updated to 14900.

**Internal tier IDs (`ladybug-standard`, etc.) and the `GraphTier` enum are unchanged — this is verbiage-only.** The frontend subscription UI renders `display_name`/`plan_display_name` from the API, so it updates with no frontend change.

## Pricing behavior — not a breaking change for existing customers

- **Existing subscribers are grandfathered automatically.** Invoicing reads `subscription.base_price_cents`, which is snapshotted at subscription-creation time — so existing Standard subscribers keep their current rate. Only **new** subscriptions snapshot the $149 config price.
- **No Stripe action required.** There is no graph product/price in Stripe today; the existing graph customer is billed via the platform's manual-invoice path (not a Stripe subscription). A new $149 Stripe price would only be created the first time a graph checkout ever runs through Stripe.

## Testing

- `just test-all`: **10406 passed**.
- Billing config, subscriptions router (incl. display-name mocks), and invoice tests pass; CodeQL clean.

## Follow-ups (non-blocking)

- Unit test for the new invoice-description format + the unknown-plan fallback.
- Consolidate the tier display-name mapping that currently lives in both `core.py` and `graph_tier.py` (single source of truth).
