### PR TITLE
Fix QuickBooks CoA accounts to link to Chart of Accounts taxonomy

### DIFF
--- a/robosystems/operations/extensions/loader.py
+++ b/robosystems/operations/extensions/loader.py
@@ -1518,7 +1518,7 @@ class OLTPLoader:
     Idempotent — skips creation of each piece if it already exists.
     """
     from robosystems.db.extensions import extensions_session
-    from robosystems.models.extensions import EntityTaxonomy
+    from robosystems.models.extensions import Element, EntityTaxonomy
     from robosystems.models.extensions.entity import Entity
     from robosystems.models.extensions.roboledger import Structure, Taxonomy
     from robosystems.utils.ulid import generate_prefixed_ulid
@@ -1546,6 +1546,28 @@ class OLTPLoader:
           session.add(existing_coa)
           session.flush()
           logger.info(f"Created CoA taxonomy for {graph_id}: {existing_coa.id}")
+
+        # Link the source's synced accounts to the CoA taxonomy. The element
+        # load runs before this taxonomy exists, so synced accounts land with
+        # taxonomy_id=NULL — and then never surface under the taxonomy in the
+        # Library UI (which filters by taxonomy_id). Backfill here so they do.
+        # This matches the manual create-element path (which sets taxonomy_id
+        # directly); without it the sync path diverges from the manual one.
+        # Scoped to NULL so re-syncs leave already-linked rows untouched.
+        relinked = (
+          session.query(Element)
+          .filter(
+            Element.external_source == source,
+            Element.taxonomy_id.is_(None),
+          )
+          .update({Element.taxonomy_id: existing_coa.id}, synchronize_session=False)
+        )
+        if relinked:
+          session.flush()
+          logger.info(
+            f"Linked {relinked} {source} CoA element(s) → taxonomy "
+            f"{existing_coa.id} for {graph_id}"
+          )
 
         # Ensure the graph's entity is linked to the CoA taxonomy as its
         # primary chart_of_accounts basis. This materializes to


### PR DESCRIPTION
## Summary

Links synced QuickBooks Chart of Accounts (CoA) accounts to the Chart of Accounts taxonomy during the loading process. Previously, accounts synced from QuickBooks were not being associated with the appropriate taxonomy, leaving them disconnected from the taxonomy hierarchy.

## Key Accomplishments

- **Taxonomy Linking**: Extended the loader to automatically associate QuickBooks-synced CoA accounts with the Chart of Accounts taxonomy after ingestion
- **Seamless Integration**: Added taxonomy lookup and linking logic within the existing loader extension pipeline, ensuring accounts are properly categorized without requiring manual intervention
- **Minimal Footprint**: Achieved the fix with a focused ~23-line addition to the loader module, keeping the change surgical and low-risk

## Breaking Changes

None. This is an additive fix that enhances the existing sync behavior without modifying any current interfaces or data contracts.

## Testing Notes

- Verify that newly synced QuickBooks CoA accounts are correctly linked to the Chart of Accounts taxonomy after a sync operation
- Confirm that previously synced accounts (if re-processed) also get linked appropriately
- Validate that the taxonomy lookup handles edge cases gracefully (e.g., taxonomy not found, accounts already linked)
- Test with various QuickBooks account types to ensure all CoA account categories are properly associated

## Infrastructure Considerations

- Ensure the Chart of Accounts taxonomy exists in the target environment prior to running the sync; otherwise, the linking step may need to handle the absence gracefully
- No database migrations or schema changes are required
- No new dependencies introduced

---
🤖 Generated with [Claude Code](https://claude.ai/code)

**Branch Info:**
- Source: `fix/qb-coa-taxonomy-link`
- Target: `main`
- Type: feature

Co-Authored-By: Claude <noreply@anthropic.com>