### PR TITLE
fix(serialization): render concept labels in XBRL/JSON-LD export

### DIFF
--- a/frameworks/rs-gaap/packages/rs-gaap/v1/taxonomy.jsonld
+++ b/frameworks/rs-gaap/packages/rs-gaap/v1/taxonomy.jsonld
@@ -38676,6 +38676,12 @@
           "@type": "xsd:boolean",
           "@value": true
         }
+      ],
+      "rdfs:label": [
+        {
+          "@value": "Income Tax Expense (Benefit), Continuing Operations",
+          "@language": "en"
+        }
       ]
     },
     {
@@ -59070,6 +59076,12 @@
           "@type": "xsd:boolean",
           "@value": true
         }
+      ],
+      "rdfs:label": [
+        {
+          "@value": "Liabilities and Partners' Capital",
+          "@language": "en"
+        }
       ]
     },
     {
@@ -65213,6 +65225,12 @@
         {
           "@type": "xsd:boolean",
           "@value": true
+        }
+      ],
+      "rdfs:label": [
+        {
+          "@value": "Net Interest Income (Loss) After Provision for Loan Losses",
+          "@language": "en"
         }
       ]
     },
@@ -104607,6 +104625,12 @@
           "@type": "xsd:boolean",
           "@value": true
         }
+      ],
+      "rdfs:label": [
+        {
+          "@value": "Secondary Processing Revenue",
+          "@language": "en"
+        }
       ]
     },
     {
@@ -111511,6 +111535,12 @@
         {
           "@type": "xsd:boolean",
           "@value": true
+        }
+      ],
+      "rdfs:label": [
+        {
+          "@value": "Vehicle Toll Revenue",
+          "@language": "en"
         }
       ]
     },

--- a/robosystems/operations/serialization/bundle.py
+++ b/robosystems/operations/serialization/bundle.py
@@ -412,6 +412,7 @@ def build_report_bundle(
   from robosystems.models.core.graph.graph import Graph
   from robosystems.models.extensions.association import Association
   from robosystems.models.extensions.element import Element
+  from robosystems.models.extensions.element_label import ElementLabel
   from robosystems.models.extensions.entity import Entity
   from robosystems.models.extensions.roboledger.fact import Fact
   from robosystems.models.extensions.roboledger.fact_set import FactSet
@@ -553,8 +554,27 @@ def build_report_bundle(
     country=entity.address_country,
   )
 
+  # Standard display labels (role=standard, en) for the bundled concepts — the
+  # XBRL label-linkbase + JSON-LD skos:prefLabel source. element.name is the
+  # human label for most concepts but the bare localname for single-word
+  # fundamentals (Assets, Cash, Liabilities, Revenues, Goodwill, …); sourcing
+  # the standard label here keeps those from collapsing to the QName in arelle.
+  standard_label_by_id: dict[str, str] = {}
+  if elements_by_id:
+    standard_label_by_id = {
+      str(eid): txt
+      for eid, txt in session.execute(
+        select(ElementLabel.element_id, ElementLabel.text).where(
+          ElementLabel.element_id.in_(list(elements_by_id)),
+          ElementLabel.role == "standard",
+          ElementLabel.language == "en",
+        )
+      )
+    }
+
   schema_concepts = [
-    _element_to_bundle(elements_by_id[eid]) for eid in sorted(elements_by_id)
+    _element_to_bundle(elements_by_id[eid], standard_label_by_id.get(eid))
+    for eid in sorted(elements_by_id)
   ]
   linkbases = _associations_to_linkbases(associations, structures_by_id, elements_by_id)
   period_nodes, period_ref_for_fact = _mint_periods(facts)
@@ -656,13 +676,16 @@ def _period_metas_for_report(report: Any, fact_sets: list[Any]) -> list[PeriodMe
   return []
 
 
-def _element_to_bundle(e: Any) -> BundleElement:
+def _element_to_bundle(e: Any, standard_label: str | None = None) -> BundleElement:
   return BundleElement(
     id=str(e.id),
     qname=str(e.qname or e.name),
     namespace=e.namespace,
     name=str(e.name),
-    label=e.description,
+    # The standard label linkbase entry is the authoritative display label
+    # (skos:prefLabel / XBRL standard label); fall back to the element's
+    # description only when no standard label exists.
+    label=standard_label or e.description,
     balance_type=e.balance_type if e.balance_type in {"debit", "credit"} else None,
     period_type=str(e.period_type),
     is_abstract=bool(e.is_abstract),

--- a/tests/operations/serialization/test_bundle_producer.py
+++ b/tests/operations/serialization/test_bundle_producer.py
@@ -147,6 +147,23 @@ class TestElementToBundle:
     b = _element_to_bundle(e)
     assert b.balance_type is None
 
+  def test_standard_label_overrides_description(self) -> None:
+    """The standard label-linkbase entry is authoritative over the element's
+    description as the concept's display label."""
+    e = _FakeElement(
+      id="elem_01", qname="rs-gaap:Assets", name="Assets", description="Total Assets"
+    )
+    assert _element_to_bundle(e, "Assets").label == "Assets"
+
+  def test_standard_label_sourced_when_name_equals_localname(self) -> None:
+    """Regression: a single-word fundamental (name == QName localpart, no
+    description) carries no label without a sourced standard label — which is
+    why Assets/Cash/Liabilities/Revenues collapsed to their QName in the
+    XBRL/JSON-LD export. With the standard label sourced, it survives."""
+    e = _FakeElement(id="elem_01", qname="rs-gaap:Assets", name="Assets")
+    assert _element_to_bundle(e, None).label is None  # pre-fix behaviour
+    assert _element_to_bundle(e, "Assets").label == "Assets"  # the fix
+
 
 # ── _associations_to_linkbases ────────────────────────────────────────
 

--- a/tests/operations/serialization/test_xbrl_emitter.py
+++ b/tests/operations/serialization/test_xbrl_emitter.py
@@ -696,6 +696,18 @@ class TestLabelLinkbase:
     assert arc.get(f"{{{NS_XLINK}}}from") == loc.get(f"{{{NS_XLINK}}}label")
     assert arc.get(f"{{{NS_XLINK}}}to") == label_el.get(f"{{{NS_XLINK}}}label")
 
+  def test_single_word_label_equal_to_localname_is_emitted(self) -> None:
+    # Regression: a fundamental whose standard label equals its QName local
+    # part ("Assets" for rs-gaap:Assets) must still emit a label. The bundle
+    # now sources the standard label (bundle._element_to_bundle), so arelle
+    # shows "Assets" rather than falling back to "rs-gaap:Assets".
+    bundle = _single_concept_bundle(label="Assets", facts=[_fact("f1", 100.0)])
+    root = _parse(serialize_to_xbrl_21(bundle), "report-lab.xml")
+    link = root.find(f"{{{NS_LINK}}}labelLink")
+    assert link is not None
+    label_el = link.find(f"{{{NS_LINK}}}label")
+    assert label_el is not None and label_el.text == "Assets"
+
 
 class TestFactDedup:
   def _facts_in(self, zip_bytes: bytes) -> list[etree._Element]:


### PR DESCRIPTION
## Summary

Fundamental concepts (`Assets`, `Cash`, `Liabilities`, `Revenues`, `Goodwill`, …) rendered as their **QName** (`rs-gaap:Assets`) instead of their label in the XBRL export (arelle) and the JSON-LD `skos:prefLabel`. Root cause: the serialization bundle sourced the concept label from `element.description` (NULL for these) rather than the standard label linkbase, and the QName-echo suppression then dropped the `element.name` fallback for single-word concepts whose name equals the QName localpart. This sources the standard label instead, and backfills standard labels for 5 concepts that genuinely had none.

## Changes

**Serialization — `operations/serialization/bundle.py`**
- `BundleElement.label` is now sourced from `element_labels` (role=`standard`, lang=`en`), falling back to `element.description` only when no standard label exists. Adds a scoped `ElementLabel` query in `build_report_bundle` and a `standard_label` param on `_element_to_bundle`.
- Fixes the 9 affected single-word fundamentals (`Assets`, `Cash`, `Communication`, `Depletion`, `Depreciation`, `Goodwill`, `Land`, `Liabilities`, `Revenues`) in **both** the XBRL label linkbase and JSON-LD `skos:prefLabel` (`jsonld.py` emits `prefLabel` from `BundleElement.label`), and broadly improves prefLabel coverage (previously the near-always-null description).
- 3 regression tests: standard label overrides description; sourced when `name == localname`; a single-word label equal to the localname is emitted in the label linkbase.

**Taxonomy data — `frameworks/rs-gaap/packages/rs-gaap/v1/taxonomy.jsonld`**
- Added `rdfs:label` (the standard label) to 5 previously-unlabeled concepts: `IncomeTaxExpenseBenefitContinuingOperations`, `LiabilitiesAndPartnersCapital`, `NetInterestIncomeLossAfterProvisionForLoanLosses`, `SecondaryProcessingRevenue`, `VehicleTollRevenue`. All 5 are **tenant-excluded verticals**, so this affects only the public library / full-taxonomy export (the library-browser view where they showed as QNames); it needs a library reseed to land.

## Testing

- `uv run pytest tests/operations/serialization/` → **125 passed** (incl. the 3 new).
- `ruff check` / `ruff format` / `basedpyright` on changed files → clean.
- Verified the data path: `rs-gaap:Assets` has `element_labels` role=`standard` text="Assets" in the seeded library, so the new query sources it.
- **Not** regenerated an actual arelle export this session; the 5 added labels require `just reset-local` to reach the public library. `just test-all` not run.

## Notes / Follow-ups

- Tenant exports were already covered by the serialization fix (the 9 fundamentals have standard labels seeded); the 5 JSON-LD additions only affect the public / full-taxonomy export.
- `_concept_label`'s `name == localname` suppression is retained as a final fallback for concepts with neither a standard label nor a description (acceptable — truly unlabeled → QName).
