### PR TITLE
chore: strip construction-phase exhaust from tests, migrations, and demo output

### DIFF
--- a/examples/seattle_method_demo/pull_mini.sh
+++ b/examples/seattle_method_demo/pull_mini.sh
@@ -9,9 +9,9 @@
 # We pull from xbrlsite because that's where the URLs in the entry
 # point's linkbaseRef hrefs resolve. The GitHub repo has additional
 # context (fac/, disclosure-mechanics/, disclosures-topics/,
-# reporting-checklist/, type-subtype/) that future work — the Phase
-# δ.2 rule corpus port and the Phase 2.5 enrichment engine — will
-# want; for Test Case 1 the base-taxonomy files are sufficient.
+# reporting-checklist/, type-subtype/) that future work — the rule
+# corpus port and the enrichment engine — will want; for Test Case 1
+# the base-taxonomy files are sufficient.
 
 set -euo pipefail
 

--- a/examples/seattle_method_demo/sample_output/seattle-method-case-1-four-statements.md
+++ b/examples/seattle_method_demo/sample_output/seattle-method-case-1-four-statements.md
@@ -185,4 +185,4 @@ uv run python -m examples.seattle_method_demo.create_report
   source-vocabulary (`mini`) reconciliation, 17/17 exact match against
   Charlie Hoffman's published `luca.pacioli.ai` facts.
 - [`../README.md`](../README.md) — demo orchestrator and methodology
-  (§3.2 reconciliation classification).
+  (reconciliation classification).

--- a/examples/seattle_method_demo/sample_output/seattle-method-case-1-xbrl-diff.md
+++ b/examples/seattle_method_demo/sample_output/seattle-method-case-1-xbrl-diff.md
@@ -106,7 +106,7 @@ Charlie's instance contains **43** additional non-zero current-period concept(s)
 
 ## Four Anchor Totals
 
-Methodology spec §4.6 exit criterion: these four lines must match Charlie's PoC for the test to pass. All amounts are debit-positive cents internally; presentation flips signs per accounting convention.
+These four lines must match Charlie's PoC for the test to pass. All amounts are debit-positive cents internally; presentation flips signs per accounting convention.
 
 | Anchor | Our value |
 |---|---:|
@@ -135,7 +135,7 @@ Every mini concept with non-zero activity in the period. ``Δ debit-positive`` i
 | `mini:RetainedEarnings` | Retained Earnings | equity | instant | $(2,050.00) |
 | `mini:Sales` | Sales | revenue | duration | $(8,000.00) |
 
-## Rollforward Attribution (Phase 2 MVP Filter Engine)
+## Rollforward Attribution
 
 Each rollforward IB decomposes its BS source's period delta across declared TDC filters. Where ``Σ filters == Δ BS``, the rollforward is balanced (residual = 0). A non-zero residual indicates either an unattributed flow or a phantom TDC in the source data (logged at author time).
 
@@ -216,7 +216,7 @@ Each rollforward IB decomposes its BS source's period delta across declared TDC 
 | `mini:IncreaseInReceivablesFromSalesOnAccount` | $8,000.00 | 1 | evt_01KTDR4GC5Y5S042WYZN96SJTZ |
 | `mini:CollectionOfReceivables` | $(8,000.00) | 1 | evt_01KTDR4GCJMDVPTGCWZ825XJV9 |
 
-## Findings — Classification per Methodology §3.2
+## Findings
 
 **Their data quality** (source CSV inconsistencies):
 
@@ -231,8 +231,8 @@ Each rollforward IB decomposes its BS source's period delta across declared TDC 
 
 **Our bug**: none identified.
 
-**Matching**: see Anchor Totals table above + line-by-line concept totals. Compare manually against Charlie's PoC rendering at the expected-output URL — automated HTML diff is a forward-queue enhancement (methodology §3.1 step 5 stretch goal).
+**Matching**: see Anchor Totals table above + line-by-line concept totals. Compare manually against Charlie's PoC rendering at the expected-output URL — an automated HTML diff is a possible future enhancement.
 
 ---
 
-*Reconciliation produced by `examples/seattle_method_demo/reconcile.py` against the Phase 2 MVP rollforward filter engine. See `examples/seattle_method_demo/README.md` for the full methodology and the architectural pattern this test validates.*
+*Reconciliation produced by `examples/seattle_method_demo/reconcile.py` against the rollforward filter engine. See `examples/seattle_method_demo/README.md` for the full methodology and the architectural pattern this test validates.*

--- a/examples/seattle_method_demo/sample_output/seattle-method-case-1.md
+++ b/examples/seattle_method_demo/sample_output/seattle-method-case-1.md
@@ -106,7 +106,7 @@ Charlie's instance contains **43** additional non-zero current-period concept(s)
 
 ## Four Anchor Totals
 
-Methodology spec §4.6 exit criterion: these four lines must match Charlie's PoC for the test to pass. All amounts are debit-positive cents internally; presentation flips signs per accounting convention.
+These four lines must match Charlie's PoC for the test to pass. All amounts are debit-positive cents internally; presentation flips signs per accounting convention.
 
 | Anchor | Our value |
 |---|---:|
@@ -135,7 +135,7 @@ Every mini concept with non-zero activity in the period. ``Δ debit-positive`` i
 | `mini:RetainedEarnings` | Retained Earnings | equity | instant | $(2,050.00) |
 | `mini:Sales` | Sales | revenue | duration | $(8,000.00) |
 
-## Rollforward Attribution (Phase 2 MVP Filter Engine)
+## Rollforward Attribution
 
 Each rollforward IB decomposes its BS source's period delta across declared TDC filters. Where ``Σ filters == Δ BS``, the rollforward is balanced (residual = 0). A non-zero residual indicates either an unattributed flow or a phantom TDC in the source data (logged at author time).
 
@@ -216,7 +216,7 @@ Each rollforward IB decomposes its BS source's period delta across declared TDC 
 | `mini:IncreaseInReceivablesFromSalesOnAccount` | $8,000.00 | 1 | evt_01KTDR4GC5Y5S042WYZN96SJTZ |
 | `mini:CollectionOfReceivables` | $(8,000.00) | 1 | evt_01KTDR4GCJMDVPTGCWZ825XJV9 |
 
-## Findings — Classification per Methodology §3.2
+## Findings
 
 **Their data quality** (source CSV inconsistencies):
 
@@ -231,8 +231,8 @@ Each rollforward IB decomposes its BS source's period delta across declared TDC 
 
 **Our bug**: none identified.
 
-**Matching**: see Anchor Totals table above + line-by-line concept totals. Compare manually against Charlie's PoC rendering at the expected-output URL — automated HTML diff is a forward-queue enhancement (methodology §3.1 step 5 stretch goal).
+**Matching**: see Anchor Totals table above + line-by-line concept totals. Compare manually against Charlie's PoC rendering at the expected-output URL — an automated HTML diff is a possible future enhancement.
 
 ---
 
-*Reconciliation produced by `examples/seattle_method_demo/reconcile.py` against the Phase 2 MVP rollforward filter engine. See `examples/seattle_method_demo/README.md` for the full methodology and the architectural pattern this test validates.*
+*Reconciliation produced by `examples/seattle_method_demo/reconcile.py` against the rollforward filter engine. See `examples/seattle_method_demo/README.md` for the full methodology and the architectural pattern this test validates.*

--- a/migrations/extensions/helpers.py
+++ b/migrations/extensions/helpers.py
@@ -40,8 +40,8 @@ def add_tenant_column(
   The one-call form of the ``op.add_column`` + ``for_each_tenant_schema``
   fan-out pattern, so a migration cannot accidentally update only ``public``
   and leave the column missing in every already-provisioned tenant schema
-  (the silent-in-dev / fails-in-prod trap — see pre-onboarding-readiness §3.9
-  and ``tests/migrations/test_extensions_tenant_fanout.py``). Prefer this over
+  (the silent-in-dev / fails-in-prod trap — see
+  ``tests/migrations/test_extensions_tenant_fanout.py``). Prefer this over
   a bare ``op.add_column`` for any tenant table.
 
   Args:

--- a/migrations/extensions/versions/0001_initial_schema.py
+++ b/migrations/extensions/versions/0001_initial_schema.py
@@ -101,7 +101,7 @@ def upgrade() -> None:
     ["graph_id", "start_date", "end_date"],
   )
 
-  # -- Fiscal Calendar (tenant-scoped; see specs/ledger-close-workflow.md) --
+  # -- Fiscal Calendar (tenant-scoped) --
   # Per-graph rolling close state: closed_through_period (system-maintained)
   # and close_target_period (user-settable). One row per tenant.
   op.create_table(

--- a/migrations/extensions/versions/0002_taxonomy_library.py
+++ b/migrations/extensions/versions/0002_taxonomy_library.py
@@ -124,10 +124,9 @@ _WIDENED_ELEMENT_SOURCE_CHECK = (
   "source IN ("
   "'fac', 'rs-gaap', 'us-gaap', 'ifrs', "
   "'quickbooks', 'xero', 'plaid', 'native', 'import', 'system', "
-  # rs-gaap framework extension packages (Phase C). Each declares
-  # a sibling namespace anchored to the rs-gaap framework. See
-  # migration 0007 for the same widen applied to already-deployed
-  # tenant schemas.
+  # rs-gaap framework extension packages. Each declares a sibling
+  # namespace anchored to the rs-gaap framework. See migration 0007
+  # for the same widen applied to already-deployed tenant schemas.
   "'disclosures', 'checklist', 'styles'"
   ")"
 )
@@ -158,11 +157,11 @@ _NARROW_ELEMENT_SOURCE_CHECK = (
   "'quickbooks', 'xero', 'plaid', 'native', 'import'"
   ")"
 )
-# Structure.block_type widens to admit the Phase g.1 block types
-# (rollforward, reconciliation, policy) required as admissible CHECK
-# values for Phase d (typed artifact_mechanics + rules) and Phase eta
-# (metric block type). Folded into 0002 rather than shipped as a
-# standalone migration since 0002 is still unreleased.
+# Structure.block_type widens to admit the working-paper / schedule block
+# types (rollforward, reconciliation, policy) required as admissible CHECK
+# values for typed artifact_mechanics + rules and the metric block type.
+# Folded into 0002 rather than shipped as a standalone migration since 0002
+# is still unreleased.
 _WIDENED_BLOCK_TYPE_CHECK = (
   "block_type IN ("
   # Renderable financial-statement presentations
@@ -190,7 +189,7 @@ _NARROW_BLOCK_TYPE_CHECK = (
   ")"
 )
 
-# Phase d.2 — Seattle Method rule taxonomy: 8 VerificationRule categories
+# Seattle Method rule taxonomy: 8 VerificationRule categories
 # x 10 BusinessRulePattern mechanisms. These match the CHECK constraints on
 # public.rules.rule_category / rule_pattern and the RULE_CATEGORY_VALUES /
 # RULE_PATTERN_VALUES frozensets in loader.py.
@@ -226,12 +225,10 @@ _RULE_PATTERN_KIND_XOR_CHECK = (
   "OR (rule_pattern IS NULL AND rule_check_kind IS NOT NULL)"
 )
 # Concept Arrangement Pattern (CAP) — 8 canonical + 5 cm.xsd
-# text-block/detail specializations + 2 pseudo (15 total) per
-# information-block.md §3.2.1. Charlie encodes text-block level as the
-# CAP itself (Blocks PDF §1.9.1; PROOF disclosure-mechanics rules
-# point disclosures at cm_LevelNTextBlock via
-# disclosure-hasConceptArrangementPattern). NULL allowed for block
-# types that don't yet declare a default.
+# text-block/detail specializations + 2 pseudo (15 total). Text-block
+# level is encoded as the CAP itself: disclosures point at
+# cm_LevelNTextBlock via disclosure-hasConceptArrangementPattern. NULL
+# allowed for block types that don't yet declare a default.
 _CONCEPT_ARRANGEMENT_CHECK = (
   "concept_arrangement IS NULL OR concept_arrangement IN ("
   "'set', 'roll_up', 'roll_forward', 'roll_forward_info', "
@@ -241,9 +238,8 @@ _CONCEPT_ARRANGEMENT_CHECK = (
   "'grid', 'compound_fact'"
   ")"
 )
-# Member Arrangement Pattern (MAP) — 5 canonical per
-# information-block.md §3.2.2. NULL allowed for non-hypercube block
-# types.
+# Member Arrangement Pattern (MAP) — 5 canonical. NULL allowed for
+# non-hypercube block types.
 _MEMBER_ARRANGEMENT_CHECK = (
   "member_arrangement IS NULL OR member_arrangement IN ("
   "'is_a', 'whole_part', 'nested_whole_part', "
@@ -434,11 +430,10 @@ def _widen_tenant_checks(conn, schema: str) -> None:
 def _backfill_reporting_standard(conn, schema: str) -> None:
   """Rename library-locked ``reporting`` rows to ``reporting_standard``.
 
-  Part of the Phase 2 Taxonomy Block rename. Library-origin reporting
-  taxonomies (``is_locked=true``) carry the new ``reporting_standard``
-  type; tenant rows created under the old ``reporting`` name (none exist
-  today but the filter is defensive) stay as-is until the narrowing step
-  in a future phase."""
+  Library-origin reporting taxonomies (``is_locked=true``) carry the new
+  ``reporting_standard`` type; tenant rows created under the old
+  ``reporting`` name (none exist today but the filter is defensive) stay
+  as-is until a later narrowing step."""
   conn.execute(
     text(
       f"UPDATE {schema}.taxonomies "
@@ -502,7 +497,7 @@ def _add_substitution_group_column(conn, schema: str) -> None:
 
 
 def _add_phase_theta_columns_to_tenant(conn, schema: str) -> None:
-  """Add Phase theta canonical-concept columns to a tenant's elements table.
+  """Add canonical-concept columns to a tenant's elements table.
 
   Three additive columns the MappingAgent + classifier use for
   cross-tenant concept unification. Nullable (or empty-list-defaulted)
@@ -529,7 +524,7 @@ def _add_phase_theta_columns_to_tenant(conn, schema: str) -> None:
 
 
 def _add_phase_d_columns_to_tenant(conn, schema: str) -> None:
-  """Add Phase d typed-mechanics columns to a tenant's structures table.
+  """Add typed-mechanics columns to a tenant's structures table.
 
   Mirror of the public-schema DDL earlier in the upgrade. Nullable so
   existing tenant Schedule rows (which only carry ``metadata_`` today)
@@ -572,7 +567,7 @@ def _backfill_tenant_schedule_mechanics(conn, schema: str) -> None:
   """Lift Schedule mechanics out of ``metadata_`` into typed columns.
 
   Schedule rows in tenant schemas carry ``entry_template`` + ``schedule_metadata``
-  inside the ``metadata_`` JSONB blob today. Phase d moves them into the
+  inside the ``metadata_`` JSONB blob today. This moves them into the
   typed ``artifact_mechanics`` column (discriminated-union-arm shape keyed
   on ``kind='closing_entry_generator'``) and stamps
   ``concept_arrangement='roll_forward'`` to match the registry default.
@@ -606,9 +601,8 @@ def _backfill_library_into_tenant(conn, schema: str) -> None:
   Order is load-bearing: schema changes first, then copy, then triggers.
   """
   _widen_tenant_checks(conn, schema)
-  # Phase 2 Taxonomy Block rename: flip any pre-existing locked
-  # ``reporting`` rows in the tenant schema to ``reporting_standard``
-  # before the library copy unions new rows in.
+  # Flip any pre-existing locked ``reporting`` rows in the tenant schema
+  # to ``reporting_standard`` before the library copy unions new rows in.
   _backfill_reporting_standard(conn, schema)
   _drop_old_element_columns(conn, schema)
   _add_substitution_group_column(conn, schema)
@@ -778,7 +772,7 @@ def _create_tenant_library_tables(conn, schema: str) -> None:
     )
   )
 
-  # Phase d.2 — verification rules. Polymorphic target (structure/element/
+  # Verification rules. Polymorphic target (structure/element/
   # association) enforced via CHECK; FKs point at the same-schema parent
   # tables so tenant rows can't reference public library ids.
   conn.execute(
@@ -913,12 +907,12 @@ def upgrade() -> None:
   )
 
   # ──────────────────────────────────────────────────────────────────────
-  # 2b. Phase theta — canonical-concept columns for cross-tenant unification.
+  # 2b. Canonical-concept columns for cross-tenant unification.
   # ──────────────────────────────────────────────────────────────────────
   # agent_id groups elements that refer to the same cross-tenant concept;
   # aliases collects alternate spellings / qname variants; embedding
   # stores a sentence embedding the MappingAgent + classifier use for
-  # similarity lookups. Seeding happens in a follow-up — the blitz only
+  # similarity lookups. Seeding happens in a follow-up — this only
   # lands the columns.
   op.add_column("elements", sa.Column("agent_id", sa.String(), nullable=True))
   op.add_column(
@@ -993,21 +987,21 @@ def upgrade() -> None:
   op.create_check_constraint(
     "check_taxonomy_type", "taxonomies", _WIDENED_TAXONOMY_TYPE_CHECK
   )
-  # Phase 2 Taxonomy Block rename: 0001-seeded library reporting rows
-  # carry ``taxonomy_type='reporting'``; flip them to the new
-  # ``reporting_standard`` value so subsequent tenant code (Block writer,
-  # library browser) sees the canonical form. The widened CHECK still
-  # admits ``'reporting'`` transitionally so this UPDATE validates.
+  # 0001-seeded library reporting rows carry ``taxonomy_type='reporting'``;
+  # flip them to the new ``reporting_standard`` value so subsequent tenant
+  # code (Block writer, library browser) sees the canonical form. The
+  # widened CHECK still admits ``'reporting'`` transitionally so this
+  # UPDATE validates.
   _backfill_reporting_standard(op.get_bind(), "public")
-  # Phase g.1: widen structures.block_type to admit rollforward,
-  # reconciliation, policy. Pure vocabulary expansion — no data change.
+  # Widen structures.block_type to admit rollforward, reconciliation,
+  # policy. Pure vocabulary expansion — no data change.
   op.drop_constraint("check_block_type", "structures", type_="check")
   op.create_check_constraint(
     "check_block_type", "structures", _WIDENED_BLOCK_TYPE_CHECK
   )
 
-  # Phase d: typed artifact_mechanics + Information-Model axis columns
-  # on public.structures. Folded into 0002 because 0002 is still
+  # Typed artifact_mechanics + Information-Model axis columns on
+  # public.structures. Folded into 0002 because 0002 is still
   # unreleased; shipping as a standalone migration would force a second
   # tenant-schema round-trip. Nullable on add so library loaders and
   # existing rows (none in public yet at this point in the upgrade, but
@@ -1224,7 +1218,7 @@ def upgrade() -> None:
   )
 
   # ──────────────────────────────────────────────────────────────────────
-  # 6b. Phase d.2 — verification rules table.
+  # 6b. Verification rules table.
   # ──────────────────────────────────────────────────────────────────────
   # Polymorphic target: nullable FKs to structures / elements /
   # associations, with a CHECK that exactly one (or none, for global
@@ -1315,9 +1309,9 @@ def upgrade() -> None:
   # ──────────────────────────────────────────────────────────────────────
   # 7. Load JSON-LD seeds — two-pass to let arcs cross package boundaries.
   # ──────────────────────────────────────────────────────────────────────
-  # Phase 1 writes every package's elements + trait vocabulary;
-  # phase 2 writes every package's associations + trait/classification
-  # assignments. Splitting the phases means an arc in one seed can
+  # Pass 1 writes every package's elements + trait vocabulary;
+  # pass 2 writes every package's associations + trait/classification
+  # assignments. Splitting the passes means an arc in one seed can
   # reference an element defined in ANY other seed regardless of the
   # SEED_FILES order — without the split, arcs targeting elements that
   # only a later seed defines are silently dropped.
@@ -1346,7 +1340,7 @@ def upgrade() -> None:
       _, counts = create_library_taxonomy_elements(session, package)
       session.flush()
       print(
-        f"    [phase 1] elements={counts['elements']} labels={counts['labels']} "
+        f"    [pass 1] elements={counts['elements']} labels={counts['labels']} "
         f"references={counts['references']} structures={counts['structures']} "
         f"traits={counts['traits']} classifications={counts['classifications']}"
       )
@@ -1355,7 +1349,7 @@ def upgrade() -> None:
       counts = create_library_arcs(session, package)
       session.flush()
       print(
-        f"  [phase 2] {package.name}: "
+        f"  [pass 2] {package.name}: "
         f"associations={counts['associations']} "
         f"(skipped={counts['associations_skipped']}) "
         f"trait_assignments={counts['trait_assignments']} "
@@ -1364,7 +1358,7 @@ def upgrade() -> None:
         f"(skipped={counts['classification_assignments_skipped']})"
       )
 
-    # Phase 3 — rules. Runs after phase 2 so association-targeted rules can
+    # Pass 3 — rules. Runs after pass 2 so association-targeted rules can
     # resolve (though none of the seeded fac-rules use that target_kind yet).
     for package in loaded_packages:
       if not package.rules:
@@ -1372,32 +1366,32 @@ def upgrade() -> None:
       counts = create_library_rules(session, package)
       session.flush()
       print(
-        f"  [phase 3] {package.name}: "
+        f"  [pass 3] {package.name}: "
         f"rules={counts['rules']} (skipped={counts['rules_skipped']})"
       )
 
-    # Phase 4 — prune the empty catch-all default structures. Arc-routing now
+    # Pass 4 — prune the empty catch-all default structures. Arc-routing now
     # lands every arc on a named structure, leaving each package's seeded
     # "default structure" fallback empty; drop them here (after rules load, so
     # a rule-targeted default is never removed) so they aren't copied into
     # every tenant library.
     pruned = prune_empty_default_structures(session)
     session.flush()
-    print(f"  [phase 4] pruned {pruned} empty default structure(s)")
+    print(f"  [pass 4] pruned {pruned} empty default structure(s)")
   finally:
     session.close()
 
-  # Phase d backfill on public.structures: set concept/member_arrangement
+  # Backfill on public.structures: set concept/member_arrangement
   # + empty statement_renderer mechanics for the four library-seeded
   # statement block types. Has to run BEFORE copy_library_into_tenant so
   # the tenant copy picks up populated values rather than NULL.
   #
   # ``concept_arrangement`` and ``member_arrangement`` are only set when
   # NULL — the seed loader (``loader._extract_structures``) already
-  # writes Charlie's Concept Arrangement Pattern (``arithmetic`` /
+  # writes the Concept Arrangement Pattern (``arithmetic`` /
   # ``roll_forward`` / etc.) explicitly per Disclosure Structure when the
   # seed declares ``conceptArrangementPattern``. This backfill is the
-  # legacy default for pre-Stage-2 seeds that don't declare a CAP.
+  # legacy default for older seeds that don't declare a CAP.
   conn.execute(
     text(
       """
@@ -1429,13 +1423,13 @@ def upgrade() -> None:
 def downgrade() -> None:
   conn = op.get_bind()
 
-  # Tenant teardown: drop triggers, restore narrow CHECKs, drop Phase d
-  # columns, restore the old classification columns (best-effort —
-  # values can't be recovered losslessly once the junction has been
-  # used, so we leave them NULL).
+  # Tenant teardown: drop triggers, restore narrow CHECKs, drop the
+  # typed-mechanics columns, restore the old classification columns
+  # (best-effort — values can't be recovered losslessly once the junction
+  # has been used, so we leave them NULL).
   def _teardown_tenant(conn, schema: str) -> None:
     _drop_triggers_for_tenant(conn, schema)
-    # Reverse the Phase 2 Taxonomy Block rename before narrowing the
+    # Reverse the reporting_standard rename before narrowing the
     # CHECK so the locked library rows pass the 0001-era constraint.
     _reverse_backfill_reporting(conn, schema)
     _restore_narrow_tenant_checks(conn, schema)
@@ -1489,7 +1483,7 @@ def downgrade() -> None:
   )
   conn.execute(text("DELETE FROM public.taxonomies WHERE is_shared = true"))
 
-  # Drop rules table (Phase d.2). IF EXISTS on the indexes because a
+  # Drop rules table. IF EXISTS on the indexes because a
   # mid-transition downgrade from a partial run might not have created them.
   conn.execute(text("DROP INDEX IF EXISTS public.idx_rules_category"))
   conn.execute(text("DROP INDEX IF EXISTS public.idx_rules_target_taxonomy"))
@@ -1499,7 +1493,7 @@ def downgrade() -> None:
   conn.execute(text("DROP INDEX IF EXISTS public.idx_rules_taxonomy"))
   conn.execute(text("DROP TABLE IF EXISTS public.rules"))
 
-  # Drop association_classifications junction (Phase epsilon).
+  # Drop association_classifications junction.
   op.drop_index(
     "idx_association_classifications_primary",
     table_name="association_classifications",
@@ -1544,7 +1538,7 @@ def downgrade() -> None:
   op.create_check_constraint(
     "check_element_source", "elements", _NARROW_ELEMENT_SOURCE_CHECK
   )
-  # Reverse the Phase 2 Taxonomy Block rename on public before narrowing
+  # Reverse the reporting_standard rename on public before narrowing
   # the CHECK so the locked library rows pass the 0001-era constraint.
   _reverse_backfill_reporting(op.get_bind(), "public")
   op.drop_constraint("check_taxonomy_type", "taxonomies", type_="check")
@@ -1554,17 +1548,16 @@ def downgrade() -> None:
   op.drop_constraint("check_block_type", "structures", type_="check")
   op.create_check_constraint("check_block_type", "structures", _NARROW_BLOCK_TYPE_CHECK)
 
-  # Drop Phase d CAP/MAP CHECKs before dropping the columns they
-  # constrain.
+  # Drop the CAP/MAP CHECKs before dropping the columns they constrain.
   for check in ("check_member_arrangement", "check_concept_arrangement"):
     conn.execute(
       text(f"ALTER TABLE public.structures DROP CONSTRAINT IF EXISTS {check}")
     )
 
-  # Drop Phase d columns from public.structures (tenant-schema columns
-  # were dropped above in _teardown_tenant). IF EXISTS makes this safe
-  # when downgrading from a mid-transition state where an earlier
-  # migration run installed 0002 before the Phase δ columns existed.
+  # Drop the typed-mechanics columns from public.structures (tenant-schema
+  # columns were dropped above in _teardown_tenant). IF EXISTS makes this
+  # safe when downgrading from a mid-transition state where an earlier
+  # migration run installed 0002 before those columns existed.
   for col in (
     "template_id",
     "renderer_note",
@@ -1574,7 +1567,7 @@ def downgrade() -> None:
   ):
     conn.execute(text(f"ALTER TABLE public.structures DROP COLUMN IF EXISTS {col}"))
 
-  # Drop Phase theta canonical-concept columns.
+  # Drop the canonical-concept columns.
   op.drop_index(
     "idx_elements_agent_id",
     table_name="elements",

--- a/migrations/extensions/versions/0003_fact_sets.py
+++ b/migrations/extensions/versions/0003_fact_sets.py
@@ -1,6 +1,6 @@
-"""Phase zeta — fact_sets table.
+"""fact_sets table.
 
-Data-model landing for the FactSet concept (spec §5.3). A FactSet is a
+Data-model landing for the FactSet concept. A FactSet is a
 period-specific instantiation of a Structure — one row groups the facts
 produced for that Structure in that period. Replaces the implicit
 ``report_id``-carries-period / free-string ``fact_set_id`` split with a
@@ -11,7 +11,7 @@ This migration ships only the table. Backfill of existing rows, the
 on write, and the eventual ``report_id`` retirement are expand-pass
 work. Indexes on ``structure_id``, ``period_start/end``, ``entity_id``,
 and ``report_id`` match the query patterns the envelope builder will use
-once the Phase ζ dimensional reads land.
+once the dimensional reads land.
 
 Revision ID: 0003
 Revises: 0002

--- a/migrations/extensions/versions/0004_verification_results_and_templates.py
+++ b/migrations/extensions/versions/0004_verification_results_and_templates.py
@@ -1,6 +1,6 @@
-"""Phase iota — verification_results + structure_templates tables.
+"""verification_results + structure_templates tables.
 
-Data-model landing for the Phase iota infrastructure (spec §Phase iota):
+Data-model landing for the verification infrastructure:
 
 - ``verification_results`` persists the outcome of evaluating a Rule
   against a FactSet / Structure. The engine producer ships in a
@@ -9,8 +9,8 @@ Data-model landing for the Phase iota infrastructure (spec §Phase iota):
   Results" tab have a durable home to read from.
 - ``structure_templates`` holds reusable layout / mechanics presets
   that Structures can pin via the existing
-  ``structures.template_id`` column (landed in Phase δ.1). Template
-  content is expand-pass work.
+  ``structures.template_id`` column. Template content is expand-pass
+  work.
 
 Both tables land in public + every tenant schema. FKs reference the
 same-schema parent tables so library-origin rows keep referential

--- a/migrations/extensions/versions/0008_reporting_style.py
+++ b/migrations/extensions/versions/0008_reporting_style.py
@@ -1,8 +1,7 @@
 """Reporting Style — pick-one-at-provision composition layer.
 
-Phase 1 of roadmap §3.2: every entity graph picks a Reporting Style
-(Charlie Hoffman's term) at provision; the picker reads it deterministically
-to resolve which Network renders each statement type.
+Every entity graph picks a Reporting Style at provision; the picker reads
+it deterministically to resolve which Network renders each statement type.
 
 This migration is additive:
 

--- a/migrations/extensions/versions/0009_facts_fact_set_id_fk.py
+++ b/migrations/extensions/versions/0009_facts_fact_set_id_fk.py
@@ -1,4 +1,4 @@
-"""facts.fact_set_id → fact_sets.id FK (§3.5 Phase 1 of §6.5).
+"""facts.fact_set_id → fact_sets.id FK.
 
 Promotes ``facts.fact_set_id`` from an unconstrained string to a real
 FK against ``fact_sets.id``. Pairs with the create_report /
@@ -8,7 +8,7 @@ stamping facts.
 Steps per schema (public + every tenant):
 
 1. NULL out any orphan ``fact_set_id`` values on ``facts`` that don't
-   resolve to an existing FactSet. The pre-§3.5 code path could stamp
+   resolve to an existing FactSet. The earlier code path could stamp
    a ULID on a fact even when ``_create_report_fact_sets``
    subsequently skipped the row (e.g., facts whose ``period_end`` was
    NULL). Reporting Style hasn't shipped to prod so the local-dev

--- a/migrations/extensions/versions/0010_drop_facts_report_id.py
+++ b/migrations/extensions/versions/0010_drop_facts_report_id.py
@@ -1,6 +1,6 @@
-"""Drop facts.report_id (§3.5 / §6.5 final retire).
+"""Drop facts.report_id (final retire).
 
-Completes the FactSets migration started in 0009. With the §3.5 rewrite
+Completes the FactSets migration started in 0009. With the rewrite
 of ``create_report`` / ``regenerate_report`` / ``create_schedule``, every
 new ``facts`` row is stamped with both ``structure_id`` and
 ``fact_set_id`` (and the parent ``FactSet`` carries the back-pointer to
@@ -9,7 +9,7 @@ new ``facts`` row is stamped with both ``structure_id`` and
 Steps per schema (public + every tenant):
 
 1. DELETE any orphan rows where ``fact_set_id IS NULL``. These are
-   pre-§3.5 facts that 0009 already null-ed (because their fact_set_id
+   older facts that 0009 already null-ed (because their fact_set_id
    didn't resolve) or facts written before ``_persist_report_facts``
    started stamping ``fact_set_id``. Posture matches 0009 — Reporting
    Style hasn't shipped to prod, blast radius is small. Reports can be

--- a/migrations/extensions/versions/0011_phase_c_required.py
+++ b/migrations/extensions/versions/0011_phase_c_required.py
@@ -1,4 +1,4 @@
-"""Promote Phase C disclosure packages to is_required=true (§3.6).
+"""Promote Phase C disclosure packages to is_required=true.
 
 The four Phase C entries (`rs-gaap-disclosures`,
 `rs-gaap-disclosure-mechanics`, `rs-gaap-reporting-checklist`, the
@@ -6,16 +6,15 @@ The four Phase C entries (`rs-gaap-disclosures`,
 `rs-gaap-reporting-styles` were originally seeded as `is_required=false`
 in migration 0007 while authoring was in flight. They are now fully
 authored, wired through the framework loader, and load-bearing for
-every tenant (every graph carries a `reporting_style_id` per §3.2 Phase
-1; every tenant receives the disclosure registry via
-`expand_framework_to_pin`).
+every tenant (every graph carries a `reporting_style_id`; every tenant
+receives the disclosure registry via `expand_framework_to_pin`).
 
 The runtime impact of the flag is small — `expand_framework_to_pin`
 ignores it — but admin tooling and API surfaces query
 ``framework_packages`` directly, so the database needs to reflect
 reality. This migration updates the existing rows; the
 ``rs-gaap/v1.json`` manifest is the source of truth and was
-flipped in the same PR.
+flipped alongside it.
 
 Revision ID: 0011
 Revises: 0010

--- a/migrations/extensions/versions/0012_event_action.py
+++ b/migrations/extensions/versions/0012_event_action.py
@@ -1,10 +1,10 @@
 """Add event_action column to events with canonical 19-verb CHECK.
 
 Adopts a canonical action-verb vocabulary as the refinement of
-`event_category` per `ontology-alignment.md` §4.6. The 19 verbs
-disambiguate concepts ERPs typically conflate — `transferCustody` vs
-`transferAllRights` is the load-bearing distinction for consignment,
-drop-shipping, marketplace settlement, and escrow. The vocabulary
+`event_category`. The 19 verbs disambiguate concepts ERPs typically
+conflate — `transferCustody` vs `transferAllRights` is the load-bearing
+distinction for consignment, drop-shipping, marketplace settlement, and
+escrow. The vocabulary
 converges with Valueflows (Foster / Pavlik / Haugen v1.0), which we
 treat as inspiration; canonical naming on our side stays
 RoboSystems-native (`event_action` / `EVENT_ACTIONS`).

--- a/migrations/extensions/versions/0013_payload_drift_and_element_upsert.py
+++ b/migrations/extensions/versions/0013_payload_drift_and_element_upsert.py
@@ -1,22 +1,22 @@
-"""Add events.payload_drift + elements UPSERT unique key (Wave 1).
+"""Add events.payload_drift + elements UPSERT unique key.
 
-Wave 1 re-sync fidelity per `quickbooks-adapter.md` §4.6.0 — closes the
-documented-spec-vs-actual-code gaps verified against real prod data on
+Re-sync fidelity for the QuickBooks adapter — closes the gaps between
+documented behavior and actual code, verified against real prod data on
 2026-05-18:
 
-- **G3** — `idx_elements_upsert_key`: partial UNIQUE on
+- `idx_elements_upsert_key`: partial UNIQUE on
   `(external_source, connection_id, external_id)` where both fields
   are non-null. Defense-in-depth for the loader's lookup-then-update
-  path (W4); preserves `elem_*` ULIDs across syncs so downstream
+  path; preserves `elem_*` ULIDs across syncs so downstream
   Associations and IB Fact references hold their FK targets stable.
   Closes the rare duplicate-insert race between concurrent syncs that
-  the per-connection sync lock (Phase 3 B7) will close fully.
+  the per-connection sync lock will close fully.
 
-- **G4** — `events.payload_drift`: boolean flag, default false. Set
+- `events.payload_drift`: boolean flag, default false. Set
   true when an adapter re-sync surfaces a payload diff against a
   `committed`/`fulfilled` event. Drifted payload stashes at
   `metadata_['drift_payload']`; the live payload stays unchanged
-  (handler-approved entries are immutable to re-sync per §2.5).
+  (handler-approved entries are immutable to re-sync).
 
 - `idx_events_payload_drift`: partial index for the reconciliation
   queue read path. Most events carry `drift=false` at all times so the
@@ -53,7 +53,7 @@ depends_on = None
 
 def _add_in_tenant(conn, schema: str) -> None:
   t = TenantOps(conn, schema)
-  # G4 — payload_drift column + read-path index
+  # payload_drift column + read-path index
   t.add_column(
     "events",
     "payload_drift",
@@ -67,7 +67,7 @@ def _add_in_tenant(conn, schema: str) -> None:
     ["payload_drift"],
     where="payload_drift = true",
   )
-  # G3 — Element UPSERT key
+  # Element UPSERT key
   t.create_index(
     f"idx_{schema}_elements_upsert_key",
     "elements",

--- a/migrations/extensions/versions/0014_event_qb_external_id_index.py
+++ b/migrations/extensions/versions/0014_event_qb_external_id_index.py
@@ -1,6 +1,6 @@
 """Add events.metadata->>'qb_external_id' partial expression index.
 
-Phase 4 §4.2 step 4 — cross-source matcher. The loader's
+Cross-source matcher. The loader's
 `_capture_transactions_as_events` checks each incoming
 `source='quickbooks'` row against this index to detect round-tripped
 RoboSystems-originated events (events whose `metadata.qb_external_id`

--- a/migrations/platform/versions/17c5e1e50d67_add_reporting_style_id_to_graphs.py
+++ b/migrations/platform/versions/17c5e1e50d67_add_reporting_style_id_to_graphs.py
@@ -1,10 +1,10 @@
 """add reporting_style_id to graphs
 
-Phase 1 of roadmap §3.2: every entity graph picks a Reporting Style
-at provision. The value is a Structure id in the per-tenant extensions
-schema (the same deterministic library UUID lives in every tenant's
-``structures`` table); the renderer picker reads this column to resolve
-which Network fills each statement-type slot.
+Every entity graph picks a Reporting Style at provision. The value is a
+Structure id in the per-tenant extensions schema (the same deterministic
+library UUID lives in every tenant's ``structures`` table); the renderer
+picker reads this column to resolve which Network fills each
+statement-type slot.
 
 NOT NULL with a server default so the column applies cleanly to any
 existing rows (Postgres uses the default to fill them before enforcing

--- a/migrations/platform/versions/f06051a09081_add_connections_deleted_at_for_soft_.py
+++ b/migrations/platform/versions/f06051a09081_add_connections_deleted_at_for_soft_.py
@@ -1,22 +1,21 @@
-"""Add connections.deleted_at + write_policy (Phase 3 B6 + Phase 4 §4.2).
+"""Add connections.deleted_at + write_policy.
 
 Two cohesive additions to the `connections` table, consolidated into a
 single migration since they ship in the same branch and both shape the
-post-Wave-1 connection-lifecycle story:
+connection-lifecycle story:
 
-1. **`deleted_at`** (Phase 3 B6, `quickbooks-adapter.md` §4.6.2) —
-   nullable timestamp. When set, the row is hidden from default lookups
-   (`get_by_id`, `get_by_graph_and_provider`, `get_all_for_graph`,
-   `list_filtered`) and the user-facing API surface treats the
-   connection as gone. Replaces the old hard-delete path which orphaned
-   all connection_id-scoped tenant rows.
+1. **`deleted_at`** — nullable timestamp. When set, the row is hidden
+   from default lookups (`get_by_id`, `get_by_graph_and_provider`,
+   `get_all_for_graph`, `list_filtered`) and the user-facing API surface
+   treats the connection as gone. Replaces the old hard-delete path which
+   orphaned all connection_id-scoped tenant rows.
 
-2. **`idx_connections_soft_deleted_realm`** (Phase 3 B6 reuse-on-re-OAuth)
+2. **`idx_connections_soft_deleted_realm`** (reuse-on-re-OAuth)
    — partial index supporting the OAuth callback's reuse query: a
    re-OAuth to the same QB realm finds the prior soft-deleted row via
    `(graph_id, provider, realm_id)` and revives it in place.
 
-3. **`write_policy`** (Phase 4 §4.2) — per-connection authorization flag
+3. **`write_policy`** — per-connection authorization flag
    governing whether RoboSystems-originated events publish to the
    source-of-truth system. Replaces the loader's legacy
    `_SOURCE_AUTO_COMMITS` hardcode (`"quickbooks": True`) with a
@@ -52,7 +51,7 @@ depends_on = None
 
 
 def upgrade() -> None:
-  # B6 — soft-delete primitives
+  # Soft-delete primitives
   op.add_column(
     "connections",
     sa.Column("deleted_at", sa.DateTime(), nullable=True),
@@ -65,7 +64,7 @@ def upgrade() -> None:
     postgresql_where="deleted_at IS NOT NULL",
   )
 
-  # Phase 4 §4.2 — write_policy authorization flag
+  # write_policy authorization flag
   op.add_column(
     "connections",
     sa.Column(

--- a/robosystems/adapters/quickbooks/dbt/models/ledger/transactions.sql
+++ b/robosystems/adapters/quickbooks/dbt/models/ledger/transactions.sql
@@ -4,7 +4,7 @@
   )
 }}
 
--- Phase 2: enrich JournalReport-derived transactions with class-specific
+-- Enrich JournalReport-derived transactions with class-specific
 -- event_type, event_category, and agent_external_id by LEFT JOINing the
 -- per-class header staging models on the composite tx id (e.g. Invoice_123).
 --
@@ -78,8 +78,8 @@ select
     -- display forms verbatim because that's what flows through the
     -- composite Id parse in stg_qb_journal_entries. Each branch routes
     -- to the closest matching entry in the open event_type vocabulary
-    -- (see event-driven-ledger.md §3) so downstream consumers can branch
-    -- on event_type without sniffing metadata.qb_txn_type.
+    -- so downstream consumers can branch on event_type without sniffing
+    -- metadata.qb_txn_type.
     case
       when e.tx_type = 'Invoice'                    then 'invoice_issued'
       when e.tx_type = 'Bill'                       then 'bill_received'
@@ -159,10 +159,10 @@ select
     -- qb_linked_txns; the payment_received / bill_paid handlers walk
     -- it to set discharges_event_id.
     coalesce(h.linked_txns, '[]')                      as linked_txns,
-    -- Phase 5: per-entity SyncToken from QB. NULL for JournalReport-only
-    -- rows (JournalEntry / Deposit / Transfer) where we don't fetch a
-    -- header — these get backfilled via §4.3.2's NULL-token UPSERT branch
-    -- on the next sync that fetches the entity directly.
+    -- Per-entity SyncToken from QB. NULL for JournalReport-only rows
+    -- (JournalEntry / Deposit / Transfer) where we don't fetch a header —
+    -- these get backfilled via the NULL-token UPSERT branch on the next
+    -- sync that fetches the entity directly.
     h.sync_token                                       as sync_token
 from entries e
 left join all_headers h

--- a/tests/adapters/qb/client/test_api.py
+++ b/tests/adapters/qb/client/test_api.py
@@ -345,7 +345,7 @@ class TestQBClient:
     mock_entry2 = Mock()
     mock_entry2.to_dict.return_value = {"id": "2", "amount": 200.00}
 
-    # Phase 2: get_journal_entries paginates via Entity.all() (no count).
+    # get_journal_entries paginates via Entity.all() (no count).
     mock_journal_entry.all.side_effect = [
       [mock_entry1, mock_entry2],  # First page
       [],  # Empty page → stop
@@ -426,7 +426,7 @@ class TestQBClient:
       "JournalReport", {"start_date": "2023-01-01"}
     )
 
-  # ---- Phase 5 §4.3.4 — CDC endpoint -----------------------------------
+  # ---- CDC endpoint -----------------------------------------------------
 
   def _make_cdc_client(self, realm_id="1234567890123456789"):
     """Construct a QBClient with just enough state to call cdc()."""
@@ -735,7 +735,7 @@ class TestQBClient:
 
 
 class TestTokenPersistence:
-  """Phase 3 A1 — rotated refresh tokens persist to ConnectionCredentials.
+  """Rotated refresh tokens persist to ConnectionCredentials.
 
   Intuit rotates the refresh_token on every refresh(). Without the
   persistence path, the rotated value dies with the QBClient instance
@@ -867,9 +867,9 @@ class TestTokenPersistence:
 
 
 class TestAuthFailureHandling:
-  """Phase 3 A2 — AuthClientError + transient network errors get clean
+  """AuthClientError + transient network errors get clean
   QBAuthFailedError surfaces. AuthClientError additionally flips the
-  connection to needs_reauth (B5)."""
+  connection to needs_reauth."""
 
   @patch(
     "robosystems.operations.connection_service.ConnectionService."
@@ -950,7 +950,7 @@ class TestAuthFailureHandling:
 
 
 class TestRetryBehavior:
-  """Phase 3 A3 — tenacity retries 429/5xx on every QB API call."""
+  """tenacity retries 429/5xx on every QB API call."""
 
   def test_retry_on_429_then_succeeds(self):
     """A 429 followed by a 200 should retry transparently and return

--- a/tests/adapters/qb/pipeline/test_extract.py
+++ b/tests/adapters/qb/pipeline/test_extract.py
@@ -23,7 +23,7 @@ _PATCH_WORK_DIR = (
 )
 _PATCH_WRITE = "robosystems.adapters.quickbooks.pipeline.extract.write_extract_parquet"
 
-# Phase 2 party + transaction-header flatteners — patched so the mock client's
+# Party + transaction-header flatteners — patched so the mock client's
 # auto-generated Mock() return values for get_customers / get_vendors etc. don't
 # break iteration in the flatten functions.
 _PATCH_FLATTEN_CUSTOMERS = (
@@ -56,7 +56,8 @@ _PATCH_FLATTEN_PURCHASES = (
 
 
 def _wire_phase2_client_methods(mock_client):
-  """Wire all Phase 2 client methods on a Mock so iteration doesn't break."""
+  """Wire the party + header client methods on a Mock so iteration
+  doesn't break."""
   mock_client.get_customers.return_value = []
   mock_client.get_vendors.return_value = []
   mock_client.get_employees.return_value = []
@@ -426,7 +427,7 @@ class TestQbExtractSuccess:
     MockQBClient.assert_called_once_with(
       realm_id="realm_abc",
       qb_credentials=credentials_dict,
-      # Phase 3 A1 — connection_id enables rotated-token persistence
+      # connection_id enables rotated-token persistence
       connection_id="conn_abc",
     )
 
@@ -699,7 +700,7 @@ class TestQbExtractMetadata:
 
 @pytest.mark.unit
 class TestMultiCurrencyGuard:
-  """Phase 3 A4 — non-USD realms fail loudly at extract time."""
+  """Non-USD realms fail loudly at extract time."""
 
   def test_assert_usd_only_passes_when_all_rows_are_usd(self):
     """Mixed empty + USD rows pass through silently."""

--- a/tests/adapters/qb/pipeline/test_load.py
+++ b/tests/adapters/qb/pipeline/test_load.py
@@ -101,15 +101,15 @@ class TestQbLoadAsset:
       connection_id=config.connection_id,
       duckdb_path=work_dir / "quickbooks.duckdb",
       created_by=config.user_id,
-      # Wave 1 G2 — incremental sync passes the empty-string since_date as
-      # None (the asset translates the QBSyncConfig default) and the
-      # explicit full_rebuild=False so the loader skips the pre-sync wipe.
+      # Incremental sync passes the empty-string since_date as None (the
+      # asset translates the QBSyncConfig default) and the explicit
+      # full_rebuild=False so the loader skips the pre-sync wipe.
       full_rebuild=False,
       since_date=None,
     )
 
   def test_load_returns_row_counts_in_metadata(self, tmp_path):
-    """Phase 2 metadata: elements/dimensions structural + event counters."""
+    """Metadata: elements/dimensions structural + event counters."""
     from robosystems.adapters.quickbooks.pipeline.load import qb_load
 
     config = _make_config()
@@ -151,7 +151,7 @@ class TestQbLoadAsset:
     assert result.metadata["dropped_empty_transactions"] == 0
     # total_rows = elements + dimensions + events_captured + events_updated
     # + agents_inserted + agents_updated (= 3 + 1 + 7 + 2 + 4 + 1 = 18)
-    # transactions/entries/line_items always 0 in Phase 2
+    # transactions/entries/line_items are always 0 on the capture path
     assert result.metadata["total_rows"] == 18
     assert "transactions" not in result.metadata
     assert "entries" not in result.metadata
@@ -184,8 +184,8 @@ class TestQbLoadAsset:
     mock_sync.assert_called_once()
 
   def test_load_advances_cdc_watermark(self, tmp_path):
-    """Phase 5 §4.3.4 — _advance_cdc_watermark is called after a successful
-    load, with a datetime captured at load start."""
+    """_advance_cdc_watermark is called after a successful load, with a
+    datetime captured at load start."""
     from datetime import datetime
 
     from robosystems.adapters.quickbooks.pipeline.load import qb_load

--- a/tests/adapters/qb/pipeline/test_utils.py
+++ b/tests/adapters/qb/pipeline/test_utils.py
@@ -620,7 +620,7 @@ class TestWriteExtractParquet:
         output_dir, accounts, journal_entries, journal_lines, company_info
       )
 
-    # Phase 2: 4 original files (accounts, journal_entries, journal_lines,
+    # 4 original files (accounts, journal_entries, journal_lines,
     # company_info) + 6 first-batch (customers, vendors, employees, invoice_headers,
     # bill_headers, payment_headers) + 2 second-batch (bill_payment_headers,
     # sales_receipt_headers) + 1 third-batch (purchase_headers) = 13 total.

--- a/tests/adapters/sec/knowledge/test_classifiers.py
+++ b/tests/adapters/sec/knowledge/test_classifiers.py
@@ -1,7 +1,7 @@
 """Tests for disclosure-seeded statement classification.
 
-Tests DISCLOSURE_TO_STATEMENT mapping and the Phase 2 BFS from
-disclosure root elements in StatementClassifier.
+Tests DISCLOSURE_TO_STATEMENT mapping and the BFS from disclosure root
+elements in StatementClassifier.
 """
 
 import networkit as nk

--- a/tests/arelle/test_pipeline.py
+++ b/tests/arelle/test_pipeline.py
@@ -6,7 +6,7 @@ and `frameworks/rs-gaap/bridges/` (fac-to-rs-gaap mapping).
 They exercise the serializer/loader round-trip and the TaxonomyPackage
 shape, but not the extractor (which needs a live ModelXbrl).
 
-Extractor unit tests are Phase 1 work — they require either a mocked
+Extractor unit tests are not covered here — they require either a mocked
 Arelle model or a lightweight fixture package.
 """
 
@@ -100,7 +100,7 @@ class TestFacRoundTrip:
 class TestFacMappingRoundTrip:
   """Equivalence arcs live in the `fac-to-rs-gaap/v1` mapping seed, not in
   the FAC concept seed — the architecture deliberately separates concept
-  definitions from cross-taxonomy bridges (see `taxonomy-library.md`).
+  definitions from cross-taxonomy bridges.
   """
 
   def test_has_equivalence_arcs(self) -> None:

--- a/tests/middleware/graph/test_ingestion_limits.py
+++ b/tests/middleware/graph/test_ingestion_limits.py
@@ -92,7 +92,7 @@ class TestCheckMaterializationLimits:
 
   @pytest.mark.asyncio
   async def test_storage_over_limit_blocks_materialization(self):
-    """§3.7 Phase 1: aggregate instance storage over cap blocks materialization."""
+    """Aggregate instance storage over cap blocks materialization."""
     mock_db = MagicMock()
     with (
       patch.object(
@@ -268,14 +268,14 @@ class TestCheckInstanceStorage:
 
     assert result["status"] == "over_limit"
     assert result["usage_percentage"] == 105.0
-    # §3.7 Phase 1: over_limit populates blocking errors
+    # over_limit populates blocking errors
     assert result["allowed"] is False
     assert len(result["errors"]) == 1
     assert "exceeds" in result["errors"][0]
 
   @pytest.mark.asyncio
   async def test_healthy_status_is_allowed(self):
-    """§3.7 Phase 1: under-cap status returns allowed=True with empty errors."""
+    """Under-cap status returns allowed=True with empty errors."""
     mock_db = MagicMock()
     with (
       patch.object(

--- a/tests/middleware/mcp/tools/test_fiscal_calendar_tools.py
+++ b/tests/middleware/mcp/tools/test_fiscal_calendar_tools.py
@@ -141,9 +141,9 @@ class TestClosePeriodToolHappyPath:
 
   @pytest.mark.asyncio
   async def test_response_includes_rule_summary_and_evaluated_structure_ids(self):
-    """§3.8 — the MCP close-period response must carry the same rule
-    eval fields the REST ClosePeriodResponse exposes so agents can
-    report which schedule rules passed / failed after a close."""
+    """The MCP close-period response must carry the same rule eval
+    fields the REST ClosePeriodResponse exposes so agents can report
+    which schedule rules passed / failed after a close."""
     tool = ClosePeriodTool(_client(user_id="usr_abc"))
     response = _close_response(
       rule_summary={"pass": 3, "fail": 0, "error": 0, "skipped": 0},
@@ -246,8 +246,8 @@ class TestClosePeriodToolErrors:
 
   @pytest.mark.asyncio
   async def test_pending_obligations_enriches_detail(self):
-    """§3.12 follow-up: pending_obligations blocker surfaces count + sample
-    + earliest_pending_period on the close-period response."""
+    """pending_obligations blocker surfaces count + sample +
+    earliest_pending_period on the close-period response."""
     from robosystems.operations.roboledger.fiscal_calendar.service import (
       PendingObligationDetail,
     )

--- a/tests/middleware/mcp/tools/test_graph_tools.py
+++ b/tests/middleware/mcp/tools/test_graph_tools.py
@@ -1,4 +1,4 @@
-"""Tests for Phase 4 graph-lifecycle MCP tools.
+"""Tests for the graph-lifecycle MCP tools.
 
 Covers the six tools in `middleware/mcp/tools/graph_tools.py`:
 
@@ -15,7 +15,7 @@ connection tool `SetWritePolicyTool`.
 Shared-repo gate coverage (the primary defense-in-depth concern) lives
 in `tests/routers/graphs/test_ops_shared_repo_gates.py`. This file
 focuses on definition shape + non-repo error paths + happy path so the
-Phase 4 refactor is exercised beyond manager-level wiring.
+tools are exercised beyond manager-level wiring.
 """
 
 from __future__ import annotations

--- a/tests/middleware/mcp/tools/test_taxonomy_tools.py
+++ b/tests/middleware/mcp/tools/test_taxonomy_tools.py
@@ -161,8 +161,8 @@ class TestSuggestMappingTool:
     source = _element(
       id="elem_1", name="Product Revenue", trait="revenue", source="quickbooks"
     )
-    # Post-§3.1.5 #3: suggest-mapping returns rs-gaap candidates only
-    # (the §3.2 Reporting Style picker targets rs-gaap Networks).
+    # suggest-mapping returns rs-gaap candidates only
+    # (the Reporting Style picker targets rs-gaap Networks).
     candidates = [
       _element(
         id="gaap_1",

--- a/tests/migrations/test_extensions_tenant_fanout.py
+++ b/tests/migrations/test_extensions_tenant_fanout.py
@@ -11,8 +11,7 @@ tenant table WITHOUT that fan-out reaches only ``public``. It is **silent in
 dev** (dev tenants are always freshly provisioned at head, so they get the
 column from the model) and a **runtime failure in prod** (the column is missing
 in every existing customer schema). This guard fails CI before such a migration
-ships — the first ``0019+`` against a live tenant is where the trap first bites
-(see ``local/docs/specs/pre-onboarding-readiness.md`` §3.9).
+ships — the first ``0019+`` against a live tenant is where the trap first bites.
 
 Scope/limitation: this is a file-level heuristic. It catches the common trap —
 a migration that issues tenant-table DDL with *no* fan-out at all. It does not

--- a/tests/models/core/connection/test_connection.py
+++ b/tests/models/core/connection/test_connection.py
@@ -96,7 +96,7 @@ class TestConnectionCreate:
 class TestConnectionGetById:
   def test_returns_connection(self):
     """The lookup chain is `.filter(id).filter(deleted_at IS NULL).first()`
-    by default — Phase 3 B6 added the deleted_at filter."""
+    by default — the deleted_at filter excludes soft-deleted rows."""
     session = MagicMock()
     mock_conn = MagicMock(spec=Connection)
     # Chain: query → filter (id) → filter (deleted_at) → first
@@ -153,7 +153,7 @@ class TestConnectionGetAllForGraph:
 class TestConnectionListFiltered:
   def test_no_filters(self):
     """Even with no explicit filters, the deleted_at IS NULL filter
-    runs by default (Phase 3 B6)."""
+    runs by default."""
     session = MagicMock()
     query = session.query.return_value
     # query.filter(deleted_at IS NULL) → order_by → all
@@ -258,7 +258,7 @@ class TestConnectionUpdateLastSync:
 
 @pytest.mark.unit
 class TestConnectionAdvanceCdcWatermark:
-  """Phase 5 §4.3.4 — CDC watermark advance helper."""
+  """CDC watermark advance helper."""
 
   def test_advances_watermark_aware_to_naive_utc(self):
     """A tz-aware datetime gets stripped to naive UTC before persisting."""
@@ -551,8 +551,8 @@ class TestConnectionRepr:
 
 @pytest.mark.unit
 class TestSoftDelete:
-  """Phase 3 B6 — soft_delete + restore preserve the row, lookups
-  filter `deleted_at IS NULL` by default."""
+  """soft_delete + restore preserve the row, lookups filter
+  `deleted_at IS NULL` by default."""
 
   def test_soft_delete_sets_deleted_at(self):
     conn = Connection(

--- a/tests/operations/event_block/python_handlers/test_registry.py
+++ b/tests/operations/event_block/python_handlers/test_registry.py
@@ -109,14 +109,13 @@ def test_asset_disposed_metadata_rejects_negative_proceeds() -> None:
 
 
 def test_registry_has_expected_handlers() -> None:
-  """Event types dispatched by the Python registry. Phase 2 added QB
+  """Event types dispatched by the Python registry. The set includes QB
   source-class types (invoice_issued / bill_received / payment_received /
-  bill_paid / sales_receipt_recorded) and Phase 2.5 (§3.14 of roadmap)
-  added the 6 additional types that QB JournalReport surfaces when
-  Purchase / Deposit / Credit Card Credit / Inventory Adjustment rows
-  flow through. All share the journal_entry_recorded handler — the
-  on-approve GL shape is identical; the distinct keys let the inbox
-  filter by source class."""
+  bill_paid / sales_receipt_recorded) plus the 6 additional types that
+  QB JournalReport surfaces when Purchase / Deposit / Credit Card Credit /
+  Inventory Adjustment rows flow through. All share the
+  journal_entry_recorded handler — the on-approve GL shape is identical;
+  the distinct keys let the inbox filter by source class."""
   assert set(EVENT_BLOCK_PYTHON_REGISTRY.keys()) == {
     "asset_disposed",
     "schedule_created",

--- a/tests/operations/event_block/test_execute.py
+++ b/tests/operations/event_block/test_execute.py
@@ -1,4 +1,4 @@
-"""Tests for `execute_event_block` (Phase 4 §4.2).
+"""Tests for `execute_event_block`.
 
 Covers the four observable behaviors of the write-back path:
 
@@ -296,8 +296,8 @@ class TestExecuteEventBlockQBReject:
   drafts stay draft, last_outbound_error captured."""
 
   def test_invalid_amount_type_raises_qbwritebackerror(self):
-    """H2 — non-int amounts (e.g., float) raise QBWritebackError
-    instead of silently truncating via int()."""
+    """Non-int amounts (e.g., float) raise QBWritebackError instead of
+    silently truncating via int()."""
     from unittest.mock import MagicMock
 
     from robosystems.operations.event_block.qb_writeback import (
@@ -376,8 +376,8 @@ class TestExecuteEventBlockQBReject:
 
 @pytest.mark.unit
 class TestSaveWithRetry:
-  """C1 — `_save_with_retry` retries transient transport errors and
-  wraps them as `QBWritebackError` rather than letting
+  """`_save_with_retry` retries transient transport errors and wraps them
+  as `QBWritebackError` rather than letting
   `requests.exceptions.RequestException` propagate uncaught (which
   would surface as a 500 instead of a typed write-back error)."""
 

--- a/tests/operations/extensions/test_loader.py
+++ b/tests/operations/extensions/test_loader.py
@@ -211,10 +211,10 @@ class TestOLTPLoader:
       created_by="user_123",
     )
 
-    # Phase 2: transactional dbt rows are captured as a single event_block
-    # per QB transaction (apply_handlers=False). GL rows (Transaction /
-    # Entry / LineItem) get created later by the handler at approval time;
-    # the sync itself produces 0 of them.
+    # Transactional dbt rows are captured as a single event_block per QB
+    # transaction (apply_handlers=False). GL rows (Transaction / Entry /
+    # LineItem) get created later by the handler at approval time; the
+    # sync itself produces 0 of them.
     assert result.elements == 2
     assert result.transactions == 0
     assert result.entries == 0
@@ -234,7 +234,7 @@ class TestOLTPLoader:
     mock_ext_session,
     mock_provision,
   ):
-    """`full_rebuild=True` triggers the pre-sync wipe per Wave 1 contract.
+    """`full_rebuild=True` triggers the pre-sync wipe.
 
     The wipe is scoped to captured/classified events plus GL cascade.
     Voided/committed/fulfilled events survive the wipe.
@@ -269,10 +269,10 @@ class TestOLTPLoader:
     mock_ext_session,
     mock_provision,
   ):
-    """Default (incremental) sync skips the pre-sync DELETE per Wave 1 G2.
+    """Default (incremental) sync skips the pre-sync DELETE.
 
-    Only operator-explicit `full_rebuild=True` triggers the wipe.
-    Without it, neither `since_date` nor the default lookback should
+    Contract: only operator-explicit `full_rebuild=True` triggers the
+    wipe. Without it, neither `since_date` nor the default lookback should
     fire the wipe — history outside the sync window must survive.
     """
     from robosystems.operations.extensions.loader import OLTPLoader
@@ -303,7 +303,7 @@ class TestOLTPLoader:
     )
     assert delete_call_count == 0, (
       f"Incremental sync invoked .delete() {delete_call_count} times — "
-      "Wave 1 G2 contract violated. Only full_rebuild=True should wipe."
+      "only full_rebuild=True should wipe."
     )
 
   @patch("robosystems.db.extensions.provision_tenant_schema")
@@ -367,12 +367,12 @@ class TestOLTPLoader:
     mock_ext_session,
     mock_provision,
   ):
-    """Phase 2: line_items without a parent entry/transaction are
-    silently dropped during the per-transaction grouping. The canonical
-    record is the event_block; orphan lines have no transaction context
-    to attach to and aren't actionable, so they don't generate errors —
-    the upstream dbt staging is responsible for ensuring entry/txn rows
-    exist before line_items reference them."""
+    """line_items without a parent entry/transaction are silently dropped
+    during the per-transaction grouping. The canonical record is the
+    event_block; orphan lines have no transaction context to attach to and
+    aren't actionable, so they don't generate errors — the upstream dbt
+    staging is responsible for ensuring entry/txn rows exist before
+    line_items reference them."""
     from robosystems.operations.extensions.loader import OLTPLoader
 
     orphan_lines = [
@@ -430,7 +430,7 @@ class TestOLTPLoader:
 
 
 class TestCaptureTransactionsAsEvents:
-  """Phase 2 capture path — UPSERT semantics + post-approval safety."""
+  """Capture path — UPSERT semantics + post-approval safety."""
 
   def _dbt_data(self) -> dict:
     """Single QB JournalEntry with two line items (one debit, one credit)."""
@@ -556,10 +556,9 @@ class TestCaptureTransactionsAsEvents:
     not have its live payload overwritten by a re-sync — that would
     silently undo the user's approval and detach the resulting GL rows.
 
-    Wave 1 G4 (`quickbooks-adapter.md` §4.6.0): when the adapter
-    re-surfaces a different payload for a committed event, we set
-    `payload_drift=True` and stash the incoming payload under
-    `metadata_['drift_payload']` for the reconciliation queue. The
+    When the adapter re-surfaces a different payload for a committed
+    event, we set `payload_drift=True` and stash the incoming payload
+    under `metadata_['drift_payload']` for the reconciliation queue. The
     live fields (`evt.metadata_['entries']`, etc.) stay unchanged.
     """
     from robosystems.operations.extensions.loader import OLTPLoader
@@ -814,8 +813,8 @@ class TestCaptureAutoCommit:
     assert result.dispatch_failed == 1
     evt = session.add_all.call_args.args[0][0]
     assert evt.status == "captured"
-    # Phase 3 B8: dispatch error metadata stamped on the event so the
-    # inbox UI can show typed remediation prompts.
+    # Dispatch error metadata stamped on the event so the inbox UI can
+    # show typed remediation prompts.
     assert evt.metadata_["dispatch_error"] == "unknown_error"
     assert "element_external_id not resolved" in evt.metadata_["dispatch_error_message"]
     assert "dispatch_error_at" in evt.metadata_
@@ -823,7 +822,7 @@ class TestCaptureAutoCommit:
 
   def test_dispatch_error_classifier_maps_known_exception_types(self):
     """The classifier maps known exception type names to typed codes
-    that the inbox UI uses for remediation prompts (Phase 3 B8)."""
+    that the inbox UI uses for remediation prompts."""
     from robosystems.operations.extensions.loader import _classify_dispatch_error
 
     class ElementResolutionError(Exception):
@@ -1355,7 +1354,7 @@ class TestCaptureHardening:
 
 
 class TestCaptureAgentsFromQB:
-  """Phase 2: agent UPSERT keyed on (connection_id, source, external_id)."""
+  """Agent UPSERT keyed on (connection_id, source, external_id)."""
 
   def _agents_data(self) -> dict:
     return {
@@ -1500,8 +1499,8 @@ class TestCaptureAgentsFromQB:
     session.query.assert_called_with(Agent)
 
   def test_sync_token_persists_on_insert(self):
-    """Phase 5 step 1 (§4.3.1) — Agent insert path stamps
-    metadata_['qb_sync_token'] when the dbt row carries a SyncToken."""
+    """Agent insert path stamps metadata_['qb_sync_token'] when the dbt
+    row carries a SyncToken."""
     from robosystems.operations.extensions.loader import OLTPLoader
 
     session = MagicMock()
@@ -1539,8 +1538,8 @@ class TestCaptureAgentsFromQB:
     assert new_agents[0].metadata_["qb_sync_token"] == "7"
 
   def test_sync_token_refreshes_on_existing_agent(self):
-    """Phase 5 step 1 — re-sync of an existing agent merges new SyncToken
-    into metadata_ in-place without dropping other JSONB keys."""
+    """Re-sync of an existing agent merges new SyncToken into metadata_
+    in-place without dropping other JSONB keys."""
     from robosystems.operations.extensions.loader import OLTPLoader
 
     existing = MagicMock()
@@ -1583,8 +1582,8 @@ class TestCaptureAgentsFromQB:
     assert existing.metadata_["custom_field"] == "preserved"
 
   def test_missing_sync_token_leaves_existing_metadata_untouched(self):
-    """Phase 5 step 1 — when a row carries no SyncToken (e.g. pre-Phase-5
-    backfill), we don't overwrite the live metadata with a None value."""
+    """When a row carries no SyncToken (e.g. a backfill row), we don't
+    overwrite the live metadata with a None value."""
     from robosystems.operations.extensions.loader import OLTPLoader
 
     existing = MagicMock()
@@ -1608,7 +1607,7 @@ class TestCaptureAgentsFromQB:
           "tax_id": "",
           "is_1099_recipient": False,
           "is_active": True,
-          # no sync_token field — simulates a pre-Phase-5 backfill row
+          # no sync_token field — simulates a backfill row
         }
       ],
     }
@@ -1627,7 +1626,7 @@ class TestCaptureAgentsFromQB:
 
 
 class TestCaptureWithEventTypeAndAgent:
-  """Phase 2: source-class fidelity + agent linkage from the transactions mart."""
+  """Source-class fidelity + agent linkage from the transactions mart."""
 
   def _dbt_with_invoice(self) -> dict:
     """Invoice transaction with event_type / agent_external_id from header join."""
@@ -1648,7 +1647,7 @@ class TestCaptureWithEventTypeAndAgent:
           "description": "Consulting services",
           "source_id": "Invoice_42",
           "status": "posted",
-          # Phase 2 columns from the per-class header join in transactions.sql:
+          # Columns from the per-class header join in transactions.sql:
           "event_type": "invoice_issued",
           "event_category": "sales",
           "agent_external_id": "qb_cust_1",
@@ -1741,7 +1740,7 @@ class TestCaptureWithEventTypeAndAgent:
     from robosystems.operations.extensions.loader import OLTPLoader
 
     dbt = self._dbt_with_invoice()
-    # Strip Phase 2 columns
+    # Strip the event_type / agent columns
     dbt["transactions"][0].pop("event_type", None)
     dbt["transactions"][0].pop("event_category", None)
     dbt["transactions"][0].pop("agent_external_id", None)

--- a/tests/operations/extensions/test_loader_resync.py
+++ b/tests/operations/extensions/test_loader_resync.py
@@ -1,19 +1,16 @@
-"""Wave 1 re-ingest harness — `quickbooks-adapter.md` §4.6.0 W5.
+"""Re-ingest harness for the QuickBooks loader.
 
-Asserts the four documented re-sync fidelity invariants survive a second
-loader run. Companion to the unit tests in `test_loader.py` that cover
-single-call behavior; this file specifically targets the Wave 1
-spec-vs-code gap scenarios verified on 2026-05-18.
+Asserts the four re-sync fidelity invariants survive a second loader run.
+Companion to the unit tests in `test_loader.py` that cover single-call
+behavior; this file specifically targets the re-sync fidelity scenarios:
 
-Each scenario maps to a §2.5.1 gap:
-
-- G1 — Voided events survive re-sync (`test_voided_event_survives_resync`).
-- G2 — Incremental sync skips pre-sync DELETE
+- Voided events survive re-sync (`test_voided_event_survives_resync`).
+- Incremental sync skips the pre-sync DELETE
   (`test_incremental_sync_does_not_wipe_history`; full assertion lives in
   ``test_loader.test_load_incremental_skips_pre_sync_wipe``).
-- G3 — Element UPSERT preserves `elem_*` ULIDs
+- Element UPSERT preserves `elem_*` ULIDs
   (`test_element_upsert_preserves_ulid`).
-- G4 — Payload drift on committed event flagged without mutating live
+- Payload drift on a committed event is flagged without mutating the live
   payload (covered by
   ``test_loader.test_capture_flags_drift_on_committed_event``).
 """
@@ -76,12 +73,12 @@ def _dbt_data_single_je() -> dict:
   }
 
 
-class TestG1VoidedEventSurvivesResync:
-  """G1 — operator-voided events must persist through re-sync.
+class TestVoidedEventSurvivesResync:
+  """Operator-voided events must persist through re-sync.
 
-  Today's bug: the unconditional pre-sync DELETE wipes all events for
-  the connection, including voided ones, so the rejected entry
-  re-appears in the inbox. Wave 1 W2 scopes the DELETE to
+  Failure mode this guards against: an unconditional pre-sync DELETE
+  would wipe all events for the connection, including voided ones, so the
+  rejected entry would re-appear in the inbox. The DELETE is scoped to
   ``captured``/``classified`` only.
   """
 
@@ -126,8 +123,8 @@ class TestG1VoidedEventSurvivesResync:
     session.add_all.assert_not_called()
 
 
-class TestG2IncrementalSkipsWipe:
-  """G2 — incremental sync (no `full_rebuild`) must not wipe history.
+class TestIncrementalSkipsWipe:
+  """Incremental sync (no `full_rebuild`) must not wipe history.
 
   The bulk of this assertion lives at the `load()` level in
   ``test_loader.test_load_incremental_skips_pre_sync_wipe``. This class
@@ -135,7 +132,7 @@ class TestG2IncrementalSkipsWipe:
   """
 
   def test_load_signature_supports_since_date_and_full_rebuild(self):
-    """The two Wave 1 contract params are part of `load()`'s signature."""
+    """The two contract params are part of `load()`'s signature."""
     import inspect
 
     from robosystems.operations.extensions.loader import OLTPLoader
@@ -149,9 +146,9 @@ class TestG2IncrementalSkipsWipe:
 
 
 class TestCrossSourceMatcher:
-  """Phase 4 §4.2 step 4 — cross-source matcher recognises QB rows
-  that are round-trips of a previously write-backed RL-originated
-  event. Stamps confirmation, skips INSERT + handler re-fire."""
+  """The cross-source matcher recognises QB rows that are round-trips of
+  a previously write-backed RL-originated event. Stamps confirmation,
+  skips INSERT + handler re-fire."""
 
   def _dbt_data(self):
     """One QB transaction whose external_id was already write-backed
@@ -246,13 +243,13 @@ class TestCrossSourceMatcher:
     assert result.dropped_empty_transactions == 1
 
 
-class TestG3ElementUpsertPreservesUlid:
-  """G3 — Element UPSERT keeps `elem_*` ULIDs stable across syncs.
+class TestElementUpsertPreservesUlid:
+  """Element UPSERT keeps `elem_*` ULIDs stable across syncs.
 
-  Today's bug: delete-then-insert regenerates every ULID on every sync,
-  breaking downstream FK targets (user-curated Associations, IB Facts,
-  cached element_id references). Wave 1 W4 switches the element load
-  to lookup-then-update or insert, matching the Agent UPSERT pattern.
+  Failure mode this guards against: delete-then-insert would regenerate
+  every ULID on every sync, breaking downstream FK targets (user-curated
+  Associations, IB Facts, cached element_id references). The element load
+  uses lookup-then-update or insert, matching the Agent UPSERT pattern.
   """
 
   @patch("robosystems.db.extensions.provision_tenant_schema")
@@ -335,15 +332,15 @@ class TestG3ElementUpsertPreservesUlid:
     )
 
 
-class TestPhase5SyncTokenCapture:
-  """Phase 5 step 1 (§4.3.1) — SyncToken flows from dbt transaction row
-  into Event.metadata_['qb_sync_token'].
+class TestSyncTokenCapture:
+  """SyncToken flows from the dbt transaction row into
+  Event.metadata_['qb_sync_token'].
 
-  Step 2 (§4.3.2) will add the freshness-gate UPSERT logic. This class
-  asserts the capture path only — that the value is persisted on insert
-  and on the captured/classified UPSERT branch, and that a SyncToken
-  bump on a committed event (with no other payload change) does NOT
-  trigger a false drift flag.
+  This class asserts the capture path only — that the value is persisted
+  on insert and on the captured/classified UPSERT branch, and that a
+  SyncToken bump on a committed event (with no other payload change) does
+  NOT trigger a false drift flag. The freshness-gate UPSERT logic is
+  covered separately.
   """
 
   def _dbt_data_with_sync_token(self, sync_token: str | None) -> dict:
@@ -460,12 +457,12 @@ class TestPhase5SyncTokenCapture:
     # is doing its job.
     assert result.drift_detected == 0
     assert committed.payload_drift is False
-    # Live payload untouched per §2.5 immutability.
+    # Live payload untouched — a committed event's payload is immutable.
     assert "drift_payload" not in committed.metadata_
 
 
-class TestPhase5SyncTokenGate:
-  """Phase 5 step 2 (§4.3.2) — SyncToken freshness gate on the UPSERT path.
+class TestSyncTokenGate:
+  """SyncToken freshness gate on the UPSERT path.
 
   The gate runs BEFORE the status branches:
 
@@ -570,7 +567,7 @@ class TestPhase5SyncTokenGate:
     assert captured.metadata_["qb_sync_token"] == "7"
 
   def test_null_existing_token_proceeds_backfill(self):
-    """Pre-Phase-5 row with no SyncToken in metadata_ → 'no_info' decision,
+    """A row with no SyncToken in metadata_ → 'no_info' decision,
     proceeds to UPSERT, SyncToken gets backfilled."""
     from robosystems.operations.extensions.loader import OLTPLoader
 
@@ -578,7 +575,7 @@ class TestPhase5SyncTokenGate:
     captured.external_id = "JE_500"
     captured.status = "captured"
     captured.id = "evt_captured"
-    captured.metadata_ = {}  # pre-Phase-5: no qb_sync_token key
+    captured.metadata_ = {}  # no qb_sync_token key (backfill row)
     captured.payload_drift = False
 
     session = MagicMock()
@@ -600,9 +597,9 @@ class TestPhase5SyncTokenGate:
     assert captured.metadata_["qb_sync_token"] == "4"
 
   def test_committed_event_with_fresh_token_advances_live_token(self):
-    """Phase 5 step 2 — even when a committed event sees no business-payload
-    drift, a bumped SyncToken still advances the live event's qb_sync_token
-    so the next sync's gate comparison stays accurate."""
+    """Even when a committed event sees no business-payload drift, a
+    bumped SyncToken still advances the live event's qb_sync_token so the
+    next sync's gate comparison stays accurate."""
     from robosystems.operations.extensions.loader import OLTPLoader
 
     # First, build what a normal capture's metadata would look like for
@@ -649,7 +646,7 @@ class TestPhase5SyncTokenGate:
 
 
 class TestCompareSyncTokens:
-  """Phase 5 §4.3.2 — pure-function freshness comparison."""
+  """Pure-function freshness comparison."""
 
   def test_decisions(self):
     from robosystems.operations.extensions.loader import _compare_sync_tokens
@@ -667,15 +664,13 @@ class TestCompareSyncTokens:
     assert _compare_sync_tokens("5", "abc") == "no_info"
 
 
-class TestPhase5IdempotentReingest:
-  """Phase 5 step 6 (§4.3.5) — idempotent re-ingest harness.
+class TestIdempotentReingest:
+  """Idempotent re-ingest harness.
 
-  Five scenarios from the spec. Implementation: synthetic dbt-data
-  fixtures hit ``_capture_transactions_as_events`` directly (no live
-  QB sandbox required for the test harness — the gate semantics are
-  the contract being asserted). When a recorded-fixture set lands
-  later (§4.3.5 future work), this class is the shape the recorded
-  test would replace.
+  Synthetic dbt-data fixtures hit ``_capture_transactions_as_events``
+  directly (no live QB sandbox required for the test harness — the gate
+  semantics are the contract being asserted). When a recorded-fixture set
+  lands later, this class is the shape the recorded test would replace.
   """
 
   def _fixture(self, sync_token: str | None) -> dict:
@@ -708,8 +703,8 @@ class TestPhase5IdempotentReingest:
     return evt
 
   def test_scenario_2_resync_identical_is_noop(self):
-    """Spec §4.3.5 scenario 2 — re-sync of an already-current row is
-    a SyncToken-gate ``same`` skip; nothing mutates."""
+    """Re-sync of an already-current row is a SyncToken-gate ``same``
+    skip; nothing mutates."""
     from robosystems.operations.extensions.loader import OLTPLoader
 
     captured = self._make_existing_event(status="captured", sync_token="5")
@@ -733,9 +728,8 @@ class TestPhase5IdempotentReingest:
     session.add_all.assert_not_called()
 
   def test_scenario_4_out_of_order_replay_skipped_stale(self):
-    """Spec §4.3.5 scenario 4 — forged out-of-order CDC batch: live
-    token is newer than incoming. Gate flags ``stale``, nothing
-    mutates, no errors raised."""
+    """Forged out-of-order CDC batch: live token is newer than incoming.
+    Gate flags ``stale``, nothing mutates, no errors raised."""
     from robosystems.operations.extensions.loader import OLTPLoader
 
     captured = self._make_existing_event(status="captured", sync_token="12")
@@ -763,9 +757,9 @@ class TestPhase5IdempotentReingest:
     assert result.drift_detected == 0
 
   def test_scenario_5_committed_drift_flagged_live_payload_immutable(self):
-    """Spec §4.3.5 scenario 5 — a ``committed`` event whose QB-side
-    payload changed gets ``payload_drift=True`` + ``drift_payload``
-    captured in metadata, but the live business payload is untouched.
+    """A ``committed`` event whose QB-side payload changed gets
+    ``payload_drift=True`` + ``drift_payload`` captured in metadata, but
+    the live business payload is untouched.
 
     The bumped SyncToken also advances the live ``qb_sync_token`` so
     the next gate comparison reflects current state — bookkeeping
@@ -831,7 +825,7 @@ class TestPhase5IdempotentReingest:
       assert captured_blob.metadata_[key] == value
 
   def test_two_consecutive_syncs_produce_same_state(self):
-    """Spec §4.3.5 scenario 2 — running the same dbt data through
+    """Running the same dbt data through
     ``_capture_transactions_as_events`` twice leaves the snapshot
     tuple ``(external_id, qb_sync_token, status, payload_drift)``
     unchanged on the second run. The SyncToken gate flags 'same' and
@@ -841,8 +835,8 @@ class TestPhase5IdempotentReingest:
     re-tries for captured-but-stuck events) IS expected to advance
     across re-syncs — that's the intentional inbox-retry mechanism
     that lets a previously-failed event commit once mappings improve.
-    The spec's idempotency snapshot is the tuple above, not the full
-    metadata blob.
+    The idempotency snapshot is the tuple above, not the full metadata
+    blob.
     """
     from robosystems.operations.extensions.loader import OLTPLoader
 
@@ -885,7 +879,7 @@ class TestPhase5IdempotentReingest:
     assert second_result.updated == 0
     assert second_result.skipped_same_sync_token == 1
     assert second_result.drift_detected == 0
-    # The §4.3.5 snapshot tuple is unchanged across the re-sync.
+    # The snapshot tuple is unchanged across the re-sync.
     second_snapshot = {
       "external_id": new_event.external_id,
       "qb_sync_token": new_event.metadata_.get("qb_sync_token"),

--- a/tests/operations/extensions/test_materialize.py
+++ b/tests/operations/extensions/test_materialize.py
@@ -117,7 +117,7 @@ class TestStagingSql:
 
 
 class TestREAStaging:
-  """Phase 1 REA primitives — Agent + Event nodes + 7 base edges + the
+  """REA primitives — Agent + Event nodes + 7 base edges + the
   EVENT_TRIGGERS_TRANSACTION McCarthy bridge edge.
   """
 
@@ -222,7 +222,7 @@ class TestTableOrdering:
       "Taxonomy",
       "Period",
       "Unit",
-      # REA primitives — universal across RoboX extensions (ontology-alignment §4)
+      # REA primitives — universal across RoboX extensions
       "Agent",
       "Event",
     }
@@ -263,7 +263,7 @@ class TestTableOrdering:
       "ASSOCIATION_HAS_FROM_ELEMENT",
       "ASSOCIATION_HAS_TO_ELEMENT",
       "ELEMENT_HAS_TRAIT",
-      # REA edges (ontology-alignment §4.2-§4.3)
+      # REA edges
       "ENTITY_HAS_AGENT",
       "ENTITY_HAS_EVENT",
       "EVENT_INVOLVES_AGENT",

--- a/tests/operations/graph/test_reporting_style_command.py
+++ b/tests/operations/graph/test_reporting_style_command.py
@@ -1,5 +1,5 @@
 # pyright: reportGeneralTypeIssues=false, reportArgumentType=false
-"""Tests for ``change_reporting_style_cmd`` (Phase 2 of §3.2)."""
+"""Tests for ``change_reporting_style_cmd``."""
 
 from __future__ import annotations
 

--- a/tests/operations/information_block/rules/test_engine.py
+++ b/tests/operations/information_block/rules/test_engine.py
@@ -103,8 +103,8 @@ class TestBindVariables:
 
   def test_structure_binding_queries_facts_table_once(self) -> None:
     """Without a pinned fact_set_id the engine queries facts by
-    structure_id only — post §3.5 every fact has structure_id stamped,
-    so no report-id fallback is needed."""
+    structure_id only — every fact has structure_id stamped, so no
+    report-id fallback is needed."""
     from robosystems.operations.information_block.rules.engine import _bind_variables
 
     session = MagicMock()

--- a/tests/operations/information_block/test_envelope_rules.py
+++ b/tests/operations/information_block/test_envelope_rules.py
@@ -1,4 +1,4 @@
-"""Tests for Phase δ.2 rule packing in the Information Block envelope.
+"""Tests for rule packing in the Information Block envelope.
 
 Exercises :func:`rule_to_lite` and :func:`load_rules_for_structure`
 from :mod:`robosystems.operations.information_block.envelope` with a

--- a/tests/operations/information_block/test_registry.py
+++ b/tests/operations/information_block/test_registry.py
@@ -59,7 +59,7 @@ class TestRegistry:
 
   def test_list_registered_returns_all_entries(self) -> None:
     entries = list_registered()
-    # Schedule + rollforward (Phase 2 MVP) + 5 statement block types + metric.
+    # Schedule + rollforward + 5 statement block types + metric.
     assert [e.id for e in entries] == [
       "schedule",
       "rollforward",

--- a/tests/operations/information_block/test_rollforward_handlers.py
+++ b/tests/operations/information_block/test_rollforward_handlers.py
@@ -1,4 +1,4 @@
-"""Rollforward handler tests — Phase 2 MVP authoring surface.
+"""Rollforward handler tests — authoring surface.
 
 Exercises create / update / delete / build_envelope for the
 ``rollforward`` block-type. Filter evaluation is tested separately in
@@ -231,10 +231,10 @@ class TestBuildEnvelope:
       result = rollforward_handlers.build_envelope(session, "struct_missing")
     assert result is None
 
-  def test_envelope_has_empty_facts_phase2_mvp(self) -> None:
-    """Phase 2 MVP doesn't persist rollforward facts; build_envelope
-    returns the typed mechanics + empty facts list. Filter evaluation
-    is performed directly by callers (the reconciliation harness)."""
+  def test_envelope_has_empty_facts(self) -> None:
+    """build_envelope does not persist rollforward facts; it returns the
+    typed mechanics + empty facts list. Filter evaluation is performed
+    directly by callers (the reconciliation harness)."""
     structure = MagicMock()
     structure.id = "struct_rf_01"
     structure.name = "Cash Rollforward"

--- a/tests/operations/information_block/test_verification_summary.py
+++ b/tests/operations/information_block/test_verification_summary.py
@@ -1,4 +1,4 @@
-"""Unit tests for ``build_verification_summary`` — the §7.12 panel aggregate.
+"""Unit tests for ``build_verification_summary`` — the panel aggregate.
 
 The helper aggregates a block's verification results into overall counts
 plus a per-``rule_category`` breakdown, resolving each result's category by

--- a/tests/operations/roboledger/commands/test_reports.py
+++ b/tests/operations/roboledger/commands/test_reports.py
@@ -180,8 +180,8 @@ def test_persist_report_facts_stamps_structure_and_fact_set() -> None:
   )
 
   added_facts = [c[0][0] for c in session.add.call_args_list]
-  # Unmapped fact is skipped — facts.fact_set_id is NOT NULL post §3.5 so
-  # a fact with no Network can't be persisted.
+  # Unmapped fact is skipped — facts.fact_set_id is NOT NULL so a fact
+  # with no Network can't be persisted.
   assert len(added_facts) == 2
 
   rev = next(f for f in added_facts if f.element_id == "elem_rev")

--- a/tests/operations/roboledger/commands/test_schedules.py
+++ b/tests/operations/roboledger/commands/test_schedules.py
@@ -151,7 +151,7 @@ def test_update_schedule_keeps_omitted_metadata_null_in_typed_mechanics() -> Non
 
 
 def test_update_schedule_template_change_triggers_supersession() -> None:
-  """Stream 2.E: changing entry_template voids + re-materializes pending events."""
+  """Changing entry_template voids + re-materializes pending events."""
   from unittest.mock import patch
 
   from robosystems.models.api.extensions.schedules import EntryTemplateRequest
@@ -208,7 +208,7 @@ def test_update_schedule_template_change_triggers_supersession() -> None:
   kwargs = supersede.call_args.kwargs
   assert kwargs["structure"] is structure
   assert kwargs["created_by"] == "usr_admin"
-  # §3.8: template change re-runs the rule engine.
+  # Template change re-runs the rule engine.
   eval_rules.assert_called_once()
   rule_kwargs = eval_rules.call_args.kwargs
   assert eval_rules.call_args.args[1] == "struct_sched"

--- a/tests/operations/roboledger/fiscal_calendar/test_close_service.py
+++ b/tests/operations/roboledger/fiscal_calendar/test_close_service.py
@@ -403,13 +403,13 @@ class TestStaleSyncAudit:
 
 
 # ────────────────────────────────────────────────────────────────────────────
-# §3.8 — Auto-run rules on close
+# Auto-run rules on close
 # ────────────────────────────────────────────────────────────────────────────
 
 
 class TestCloseAutoRunsRules:
   """Verify the close service evaluates rules for schedules with facts in
-  the closing period (§3.8 rule-engine auto-run)."""
+  the closing period (rule-engine auto-run)."""
 
   def _session_with_schedules_and_rule_results(
     self, fp, schedule_ids: list[str], rule_results_per_struct: dict
@@ -421,7 +421,7 @@ class TestCloseAutoRunsRules:
     session = _mock_session_with_fp(fp)
 
     # Override session.execute to return the BS row first, then the
-    # schedule id list for the new §3.8 query.
+    # schedule id list for the rule-engine auto-run query.
     bs_row = MagicMock()
     bs_row.total_debit = 0
     bs_row.total_credit = 0
@@ -532,9 +532,8 @@ class TestCloseAutoRunsRules:
 
 
 class TestClosePrePublishWriteback:
-  """Phase 4 §4.2 — `_publish_drafts_to_qb` runs between BS pre-flight
-  and draft→posted. QB rejections raise `WritebackFailed` and roll
-  back the entire close."""
+  """`_publish_drafts_to_qb` runs between BS pre-flight and draft→posted.
+  QB rejections raise `WritebackFailed` and roll back the entire close."""
 
   def test_no_qb_authoritative_connection_skips_pre_publish(self):
     """Graph has no QB connection in qb_authoritative mode → no work

--- a/tests/operations/roboledger/fiscal_calendar/test_service.py
+++ b/tests/operations/roboledger/fiscal_calendar/test_service.py
@@ -3,7 +3,8 @@
 These are unit tests with a stubbed session. The service's query shape is
 simple enough (`session.query(FiscalCalendar).filter(...).one_or_none()`,
 plus `session.add()` / `session.flush()`) that we can emulate it with a
-lightweight in-memory store. Full integration tests land with Phase 2.
+lightweight in-memory store. Full integration tests are not yet
+implemented.
 """
 
 from __future__ import annotations
@@ -386,7 +387,7 @@ class TestAdvanceClosedThrough:
     assert before <= calendar.last_close_at <= after
 
   def test_first_advance_rejects_non_earliest_open_period(self):
-    """F3: when closed_through is None, the first advance must match the
+    """When closed_through is None, the first advance must match the
     earliest open FiscalPeriod. Anything later strands the earlier months.
     """
     from unittest.mock import patch as _patch
@@ -398,7 +399,7 @@ class TestAdvanceClosedThrough:
         svc.advance_closed_through(session, GRAPH_ID, "2026-03", actor_id="u1")
 
   def test_first_advance_accepts_earliest_open_period(self):
-    """F3: first advance to the correct earliest open period is allowed."""
+    """First advance to the correct earliest open period is allowed."""
     from unittest.mock import patch as _patch
 
     svc, session = _service()
@@ -711,7 +712,7 @@ class TestCloseableGate:
 
   def test_first_close_must_be_earliest_open_period(self):
     """When closed_through is None, the gate must require the earliest open
-    FiscalPeriod, not accept any arbitrary period (F3).
+    FiscalPeriod, not accept any arbitrary period.
     """
     from unittest.mock import patch as _patch
 
@@ -757,13 +758,13 @@ class TestCloseableGate:
 
 
 # ────────────────────────────────────────────────────────────────────────────
-# closeable_gate — pending obligations gate (Stream 2.D)
+# closeable_gate — pending obligations gate
 # ────────────────────────────────────────────────────────────────────────────
 
 
 class TestPendingObligationsGate:
-  """Stream 2.D: a period cannot be closed while `pending` schedule_entry_due
-  events exist for any period that has occurred at or before the period_end.
+  """A period cannot be closed while `pending` schedule_entry_due events
+  exist for any period that has occurred at or before the period_end.
   """
 
   @staticmethod

--- a/tests/operations/roboledger/reads/test_ar_ap.py
+++ b/tests/operations/roboledger/reads/test_ar_ap.py
@@ -6,7 +6,7 @@ assertions. These tests verify (a) the SQL compiles against a real
 Postgres dialect, (b) the candidate event-type sets are wired
 correctly, and (c) the response shape matches the Pydantic contract.
 Numerical correctness is validated end-to-end via the QB sandbox
-verification step (see roadmap §5.1 exit).
+verification step.
 """
 
 from __future__ import annotations

--- a/tests/operations/roboledger/reads/test_taxonomies_subtotal_filter.py
+++ b/tests/operations/roboledger/reads/test_taxonomies_subtotal_filter.py
@@ -258,7 +258,7 @@ def test_denylist_locks_canonical_rollups():
 
 
 # ---------------------------------------------------------------------------
-# Structure-aware rollup guard (info-block §3.7.2)
+# Structure-aware rollup guard
 #
 # The static denylist over-denies on thin Reporting Style structures: a
 # concept like rs-gaap:Revenues is a rollup in the full taxonomy but, on a

--- a/tests/operations/roboledger/reports/test_network_picker.py
+++ b/tests/operations/roboledger/reports/test_network_picker.py
@@ -1,4 +1,4 @@
-"""Tests for the Reporting Style → Network picker (§3.2 Phase 1)."""
+"""Tests for the Reporting Style → Network picker."""
 
 from __future__ import annotations
 

--- a/tests/operations/roboledger/reports/test_rollforward_filters.py
+++ b/tests/operations/roboledger/reports/test_rollforward_filters.py
@@ -1,10 +1,10 @@
-"""Tests for the rollforward filter evaluation engine (Phase 2 MVP).
+"""Tests for the rollforward filter evaluation engine.
 
 Covers :func:`evaluate_attribution_filters` aggregation, residual
 handling under each validation_mode, and audit ``event_ids[]``
 provenance. Mocks at the ``session.execute`` boundary — the engine is
 SQL-driven, and re-running the SQL through a live test DB would
-require fixtures that the rest of the Phase 2 MVP doesn't need.
+require fixtures this evaluation path doesn't otherwise need.
 """
 
 from __future__ import annotations

--- a/tests/operations/roboledger/reports/test_subtotal_facts.py
+++ b/tests/operations/roboledger/reports/test_subtotal_facts.py
@@ -2,8 +2,8 @@
 
 The function walks the rs-gaap-calculations DAG bottom-up over the
 already-emitted leaf facts and emits one fact per subtotal, so verification
-rules scoped to a subtotal can bind (info-block §6.1). The session is mocked
-so the rollup math is tested without a database.
+rules scoped to a subtotal can bind. The session is mocked so the rollup
+math is tested without a database.
 """
 
 from __future__ import annotations

--- a/tests/operations/serialization/test_xbrl_emitter.py
+++ b/tests/operations/serialization/test_xbrl_emitter.py
@@ -1,6 +1,6 @@
 """Unit tests for the XBRL 2.1 emitter (``xbrl/xbrl_21.py``).
 
-Covers each output file of the Phase 1b flat zip independently:
+Covers each output file of the flat zip independently:
 
 * ``instance.xml`` — XBRL root, schemaRef, contexts, units, facts
 * ``report.xsd`` — concept declarations + linkbaseRefs
@@ -208,7 +208,7 @@ class TestZipLayout:
 
   def test_zip_is_deflated_not_stored(self) -> None:
     """Verify the zip uses ZIP_DEFLATED for compression so payloads
-    stay small. The 5-file Phase 1b structure shouldn't approach
+    stay small. The 5-file flat-zip structure shouldn't approach
     even 100KB after compression for typical bundles."""
     zip_bytes = serialize_to_xbrl_21(_bundle(with_arcs=True))
     zf = _zip_open(zip_bytes)

--- a/tests/operations/taxonomy_block/test_auto_rules.py
+++ b/tests/operations/taxonomy_block/test_auto_rules.py
@@ -1,4 +1,4 @@
-"""Tests for Phase 2.3.1 structural auto-rule emission."""
+"""Tests for structural auto-rule emission."""
 
 from __future__ import annotations
 
@@ -109,8 +109,8 @@ class TestEmitAutoRules:
 
   def test_all_auto_rules_populate_check_kind_not_pattern(self) -> None:
     """XOR contract: all auto-rules are structural (rule_check_kind set,
-    rule_pattern is None). See information-block.md §5.2.2 + the
-    check_rule_pattern_kind_xor CHECK constraint on the rules table."""
+    rule_pattern is None). Enforced by the check_rule_pattern_kind_xor
+    CHECK constraint on the rules table."""
     session = MagicMock()
     taxonomy = _fake_taxonomy("chart_of_accounts", parent_taxonomy_id="lib_1")
     emit_auto_rules(

--- a/tests/operations/taxonomy_block/test_custom_ontology.py
+++ b/tests/operations/taxonomy_block/test_custom_ontology.py
@@ -23,7 +23,7 @@ def test_create_rejects_wrong_taxonomy_type() -> None:
 
 
 def test_update_rejects_missing_taxonomy() -> None:
-  """Phase 2.4: update is live; unknown taxonomy_id raises ValueError."""
+  """Update is live; unknown taxonomy_id raises ValueError."""
   session = MagicMock()
   session.get.return_value = None
   payload = UpdateTaxonomyBlockRequest(taxonomy_id="tx_1")
@@ -33,7 +33,7 @@ def test_update_rejects_missing_taxonomy() -> None:
 
 
 def test_delete_rejects_missing_taxonomy() -> None:
-  """Phase 2.4: delete is live; unknown taxonomy_id raises ValueError."""
+  """Delete is live; unknown taxonomy_id raises ValueError."""
   session = MagicMock()
   session.get.return_value = None
   payload = DeleteTaxonomyBlockRequest(taxonomy_id="tx_1", reason="cleanup")

--- a/tests/operations/taxonomy_block/test_library_creator.py
+++ b/tests/operations/taxonomy_block/test_library_creator.py
@@ -1,13 +1,14 @@
-"""Tests for the library_creator operations module (Phase 2.7).
+"""Tests for the library_creator operations module.
 
 All tests use MagicMock sessions — the module's three functions translate
 TaxonomyPackage → session.execute(pg_insert(...)) calls. We verify:
   - Deterministic ID helpers produce stable, unique values.
-  - Phase 1 writes the right number of rows for a given package.
+  - The first pass writes the right number of rows for a given package.
   - Elements with disallowed sources are skipped.
-  - Phase 2 DB-resolves qnames (via session.execute scalar) and skips
-    unresolved arcs.
-  - Phase 3 resolves polymorphic rule targets and skips unsupported kinds.
+  - The second pass DB-resolves qnames (via session.execute scalar) and
+    skips unresolved arcs.
+  - The third pass resolves polymorphic rule targets and skips
+    unsupported kinds.
 """
 
 from __future__ import annotations
@@ -63,7 +64,7 @@ class TestIdHelpers:
     )
 
   def test_element_id_version_stable(self) -> None:
-    # C1 — a concept keeps one id across framework versions, so tenant
+    # A concept keeps one id across framework versions, so tenant
     # CoA→rs-gaap mappings survive a version bump. The trailing /vN/ segment
     # must not participate in the derived id.
     v1 = _element_id("https://robosystems.ai/taxonomy/rs-gaap/v1/", "rs-gaap:Assets")
@@ -147,7 +148,7 @@ def _make_package(
   )
 
 
-# ── Phase 1 tests ─────────────────────────────────────────────────────────────
+# ── First-pass tests (write taxonomy + elements) ──────────────────────────────
 
 
 class TestCreateLibraryTaxonomyElements:
@@ -214,7 +215,7 @@ class TestCreateLibraryTaxonomyElements:
     assert counts["traits"] == 0
 
 
-# ── Phase 2 tests ─────────────────────────────────────────────────────────────
+# ── Second-pass tests (resolve qnames + write arcs) ───────────────────────────
 
 
 class TestCreateLibraryArcs:
@@ -259,7 +260,7 @@ class TestCreateLibraryArcs:
     assert counts["associations_skipped"] == 0
 
   def test_association_reseed_updates_value_columns(self) -> None:
-    # Gap B — re-seeding an existing arc must UPDATE its value columns in place
+    # Re-seeding an existing arc must UPDATE its value columns in place
     # (calc weight / presentation order), not silently skip on id conflict.
     from sqlalchemy.dialects import postgresql
 
@@ -312,7 +313,7 @@ class TestCreateLibraryArcs:
     assert counts["trait_assignments_skipped"] == 0
 
 
-# ── Phase 3 tests ─────────────────────────────────────────────────────────────
+# ── Third-pass tests (resolve rule targets + write rules) ─────────────────────
 
 
 class TestCreateLibraryRules:

--- a/tests/operations/taxonomy_block/test_registry.py
+++ b/tests/operations/taxonomy_block/test_registry.py
@@ -1,4 +1,4 @@
-"""Smoke tests for the Taxonomy Block registry after Phase 2.2 completion."""
+"""Smoke tests for the Taxonomy Block registry."""
 
 from __future__ import annotations
 

--- a/tests/operations/taxonomy_block/test_reporting_extension.py
+++ b/tests/operations/taxonomy_block/test_reporting_extension.py
@@ -75,7 +75,7 @@ def test_create_rejects_non_reporting_standard_parent() -> None:
 
 
 def test_update_rejects_missing_taxonomy() -> None:
-  """Phase 2.4: update is live; unknown taxonomy_id raises ValueError."""
+  """Update is live; unknown taxonomy_id raises ValueError."""
   session = MagicMock()
   session.get.return_value = None
   payload = UpdateTaxonomyBlockRequest(taxonomy_id="tx_1")
@@ -85,7 +85,7 @@ def test_update_rejects_missing_taxonomy() -> None:
 
 
 def test_delete_rejects_missing_taxonomy() -> None:
-  """Phase 2.4: delete is live; unknown taxonomy_id raises ValueError."""
+  """Delete is live; unknown taxonomy_id raises ValueError."""
   session = MagicMock()
   session.get.return_value = None
   payload = DeleteTaxonomyBlockRequest(taxonomy_id="tx_1", reason="cleanup")

--- a/tests/operations/taxonomy_block/test_update.py
+++ b/tests/operations/taxonomy_block/test_update.py
@@ -356,7 +356,7 @@ class TestValidateAssociationsToRemove:
     assert issues == []
 
 
-# ── Phase 2.4.1 — apply helper unit tests ──────────────────────────────────
+# ── Apply helper unit tests ─────────────────────────────────────────────────
 
 
 class TestApplyElementsToUpdate:

--- a/tests/operations/test_connection_service.py
+++ b/tests/operations/test_connection_service.py
@@ -379,9 +379,9 @@ class TestDeleteConnection:
   @pytest.mark.asyncio
   @pytest.mark.unit
   async def test_soft_deletes_connection_and_deactivates_creds(self):
-    """Phase 3 B6: delete_connection now soft-deletes (preserves the row
-    with deleted_at stamped) rather than hard-deleting. Tenant-side
-    events/agents/elements scoped to the connection_id stay attached."""
+    """delete_connection soft-deletes (preserves the row with deleted_at
+    stamped) rather than hard-deleting. Tenant-side events/agents/elements
+    scoped to the connection_id stay attached."""
     mock_session = MagicMock()
     mock_conn = _make_mock_connection()
     mock_cred = _make_mock_credentials()
@@ -934,7 +934,7 @@ class TestConnectionServiceSessionManagement:
 
 
 class TestMarkNeedsReauthSync:
-  """Phase 3 B5 — sync helper flips the connection to needs_reauth."""
+  """Sync helper flips the connection to needs_reauth."""
 
   @pytest.mark.unit
   def test_helper_flips_status(self):

--- a/tests/routers/extensions/roboledger/test_operations.py
+++ b/tests/routers/extensions/roboledger/test_operations.py
@@ -400,11 +400,10 @@ class TestAutoMapElementsOp:
 #
 # The 12 raw CRUD ops (create/update/delete-taxonomy, create/update/delete-
 # structure, create/update/delete-element, create-associations, update/delete-
-# association) were retired from the public REST + MCP surface in Phase 1 of
-# the Taxonomy Block refactor. The
+# association) were retired from the public REST + MCP surface in favor of
+# the Taxonomy Block envelope. The
 # underlying `cmd_*` functions remain for internal seeders and continue to be
 # covered by `tests/operations/roboledger/commands/test_{taxonomies,elements}.py`.
-# Phase 2 introduces the Taxonomy Block envelope and its own test suite.
 # ═══════════════════════════════════════════════════════════════════════════
 
 
@@ -472,7 +471,7 @@ def _balanced_lines() -> list[JournalEntryLineItemInput]:
   ]
 
 
-# TestCreateJournalEntryOp removed in Phase 4a: the `create-journal-entry`
+# TestCreateJournalEntryOp removed: the `create-journal-entry`
 # OperationSpec was retired in favor of
 # `create-event-block(event_type='journal_entry_recorded')`. See
 # tests/operations/event_block/python_handlers/
@@ -617,7 +616,7 @@ class TestDeleteJournalEntryOp:
 # for coverage of the event-driven path.
 
 
-# ── Filing lifecycle ops (Plan C) ──────────────────────────────────────────
+# ── Filing lifecycle ops ────────────────────────────────────────────────────
 
 
 def _make_filed_report_response() -> ReportResponse:
@@ -959,7 +958,7 @@ def _make_event_envelope(status: str = "committed"):
 
 class TestUpdateEventBlockOp:
   """Router-level tests for update-event-block — covers the error-map
-  contract for handler-firing failures introduced in Phase 4."""
+  contract for handler-firing failures."""
 
   def _request(self, **overrides):
     from robosystems.models.api.event_block import UpdateEventBlockRequest

--- a/tests/routers/graphs/connections/test_oauth.py
+++ b/tests/routers/graphs/connections/test_oauth.py
@@ -346,9 +346,9 @@ class TestOAuthCallback:
         f"{OAUTH_MODULE}.ConnectionService.update",
         new_callable=AsyncMock,
       ),
-      # Phase 3 B6: the OAuth callback now checks for a soft-deleted
-      # prior connection matching the returned realm. Happy path: no
-      # prior match, proceed with the freshly-created connection_id.
+      # The OAuth callback checks for a soft-deleted prior connection
+      # matching the returned realm. Happy path: no prior match, proceed
+      # with the freshly-created connection_id.
       patch(
         "robosystems.models.core.connection.connection.Connection."
         "find_soft_deleted_for_realm",
@@ -381,9 +381,9 @@ class TestOAuthCallback:
   @pytest.mark.unit
   @pytest.mark.asyncio
   async def test_oauth_callback_revives_soft_deleted_connection(self):
-    """Phase 3 B6: re-OAuthing to a realm that has a soft-deleted prior
-    connection revives the prior in place rather than minting a new
-    connection_id. Preserves the tenant-side events/agents/elements."""
+    """Re-OAuthing to a realm that has a soft-deleted prior connection
+    revives the prior in place rather than minting a new connection_id.
+    Preserves the tenant-side events/agents/elements."""
     mock_user = _make_mock_user()
     mock_db = MagicMock()
     request = _make_oauth_callback_request()

--- a/tests/routers/graphs/connections/test_sync.py
+++ b/tests/routers/graphs/connections/test_sync.py
@@ -99,11 +99,11 @@ class TestSyncConnection:
 
   @pytest.fixture(autouse=True)
   def _bypass_sync_lock(self):
-    """Phase 3 B7 — the sync endpoint acquires a `DistributedLock`
-    against the real Valkey LOCKS database. Unit tests run sequentially
-    against shared Valkey state, so the first test's lock for
-    `conn_test456` would 409 every subsequent test for the same
-    connection_id (TTL is 30 min). Patch the lock to always acquire.
+    """The sync endpoint acquires a `DistributedLock` against the real
+    Valkey LOCKS database. Unit tests run sequentially against shared
+    Valkey state, so the first test's lock for `conn_test456` would 409
+    every subsequent test for the same connection_id (TTL is 30 min).
+    Patch the lock to always acquire.
 
     Tests that specifically cover the 409 contention path mock this
     differently per-test.
@@ -460,7 +460,7 @@ class TestSyncConnection:
     # The autouse `_bypass_sync_lock` fixture stamps a mock-acquired
     # lock_id into `effective_options` as `sync_lock_id`. Assert on
     # the subset of keys the test cares about, then verify the lock id
-    # was passed through (Phase 3 B7 release-on-completion plumbing).
+    # was passed through (release-on-completion plumbing).
     sync_mock.assert_awaited_once()
     call_args = sync_mock.await_args
     assert call_args.args[0] == "quickbooks"
@@ -512,10 +512,10 @@ class TestSyncConnection:
         cache=_make_mock_cache(),
       )
 
-    # Phase 3 B7: even with no caller-supplied sync_options, the
-    # endpoint plumbs a `sync_lock_id` through to the registry so
-    # qb_load can release the B7 lock on completion. Assert the
-    # options dict contains exactly that one key.
+    # Even with no caller-supplied sync_options, the endpoint plumbs a
+    # `sync_lock_id` through to the registry so qb_load can release the
+    # lock on completion. Assert the options dict contains exactly that
+    # one key.
     sync_mock.assert_awaited_once()
     call_args = sync_mock.await_args
     assert call_args.args[0] == "quickbooks"

--- a/tests/schemas/test_schema_loader.py
+++ b/tests/schemas/test_schema_loader.py
@@ -235,13 +235,13 @@ class TestContextAwareSchemaLoader:
 
 
 class TestREAPrimitives:
-  """Phase 1 ontology alignment: Agent + Event in base, EVENT_TRIGGERS_TRANSACTION
+  """REA primitives: Agent + Event in base, EVENT_TRIGGERS_TRANSACTION
   bridge in roboledger TRANSACTION layer.
 
-  Validates that the spec §4.5 placement decision actually holds in the loader:
-  REA primitives reach every consumer (including SEC) as base nodes, while the
-  McCarthy bridge edge is correctly scoped to roboledger TRANSACTION_RELATIONSHIPS
-  and absent from SEC.
+  Validates that the placement holds in the loader: REA primitives reach
+  every consumer (including SEC) as base nodes, while the McCarthy bridge
+  edge is correctly scoped to roboledger TRANSACTION_RELATIONSHIPS and
+  absent from SEC.
   """
 
   def test_agent_and_event_in_default_loader(self):
@@ -256,7 +256,7 @@ class TestREAPrimitives:
 
   def test_agent_and_event_in_sec_repository(self):
     """Base nodes flow through to SEC. Tables stay empty (no rows
-    loaded), but the schema includes them per spec §4.5 Option A."""
+    loaded), but the schema includes them."""
     loader = ContextAwareSchemaLoader(extension="roboledger", context="sec_repository")
     assert "Agent" in loader.nodes
     assert "Event" in loader.nodes
@@ -295,9 +295,9 @@ class TestREAPrimitives:
     assert "EVENT_TRIGGERS_TRANSACTION" not in loader.relationships
 
   def test_fiscal_nodes_not_in_graph_layer(self):
-    """FiscalCalendar / FiscalPeriod stay OLTP-only per the §2.1 test
-    (operational state, not curated business truth). Guards against
-    accidental re-introduction during future graph work."""
+    """FiscalCalendar / FiscalPeriod stay OLTP-only (operational state,
+    not curated business truth). Guards against accidental
+    re-introduction during future graph work."""
     loader = get_contextual_schema_loader("application", "roboledger")
     assert "FiscalCalendar" not in loader.nodes
     assert "FiscalPeriod" not in loader.nodes

--- a/tests/taxonomy/test_disclosures_seed.py
+++ b/tests/taxonomy/test_disclosures_seed.py
@@ -1,5 +1,5 @@
-"""Shape tests for the four Phase C packages plus the disclosures-to-
-textblocks bridge.
+"""Shape tests for the four disclosure-layer packages plus the
+disclosures-to-textblocks bridge.
 
 These tests exercise the JSON-LD loader against each new artifact to
 confirm:
@@ -90,10 +90,9 @@ class TestDisclosuresPackage:
   def test_cap_values_use_canonical_vocabulary(
     self, disclosures: TaxonomyPackage
   ) -> None:
-    """Vocab alignment (2026-05-15) maps the seed CAPs onto Charlie's
-    canonical enumeration. `component` and `hierarchy` collapsed to
-    `set`; `level1_textblock` retained as the cm.xsd specialization.
-    See information-block.md §3.2.1."""
+    """Vocab alignment maps the seed CAPs onto the canonical enumeration.
+    `component` and `hierarchy` collapsed to `set`; `level1_textblock`
+    retained as the cm.xsd specialization."""
     cap_values = {s.concept_arrangement for s in disclosures.structures}
     assert "set" in cap_values
     assert "level1_textblock" in cap_values

--- a/tests/taxonomy/test_fac_neutrality.py
+++ b/tests/taxonomy/test_fac_neutrality.py
@@ -1,7 +1,7 @@
 """Invariant: ``fac`` is the framework-neutral accounting substrate.
 
 The architecture splits responsibilities cleanly (see
-``frameworks/fac/packages/README.md`` and [[framework-scope-fac-vs-rsgaap]]):
+``frameworks/fac/packages/README.md``):
 
 - ``fac`` holds high-level concepts + the universal trait vocabulary that
   persist regardless of regulatory regime (us-gaap, ifrs, irs, …).

--- a/tests/taxonomy/test_fallback_buckets_wired.py
+++ b/tests/taxonomy/test_fallback_buckets_wired.py
@@ -5,9 +5,9 @@ MappingOperator falls back to when AI refinement can't pick a specific
 rs-gaap concept. If a fallback target is NOT a child in the rs-gaap
 calculation DAG (or is itself a rollup parent), a CoA account routed
 there silently drops out of its subtotal at render — the exact failure
-that motivated wiring the revenue/COGS/OpEx ``Other`` leaves
-(info-block §3.7 / mapping leaves-only model). This test pins the
-invariant so the constant and the calc package can't drift apart.
+that motivated wiring the revenue/COGS/OpEx ``Other`` leaves under the
+leaves-only mapping model. This test pins the invariant so the constant
+and the calc package can't drift apart.
 """
 
 from __future__ import annotations

--- a/tests/taxonomy/test_rollup_rules_seed.py
+++ b/tests/taxonomy/test_rollup_rules_seed.py
@@ -2,8 +2,8 @@
 
 The package is generated from rs-gaap-calculations/v1 by
 ``robosystems.taxonomy.scripts.generate_rollup_rules`` — one ``RollUp``
-rule per calc-arc subtotal parent (info-block §6.1 Package II.a). These
-tests pin the committed artifact's shape and the pure builder's transform.
+rule per calc-arc subtotal parent. These tests pin the committed
+artifact's shape and the pure builder's transform.
 """
 
 from __future__ import annotations

--- a/tests/taxonomy/test_rs_gaap_presentation_equity.py
+++ b/tests/taxonomy/test_rs_gaap_presentation_equity.py
@@ -1,8 +1,7 @@
 """Shape tests for the rs-gaap Statement of Changes in Equity presentation.
 
-Under the rs-gaap-anchored architecture (§3.2 + the rs-gaap-everything-at-the-
-reporting-layer rewrite), the roll-forward hangs directly off
-``rs-gaap:StockholdersEquity`` — no fac scaffolding. The activity arcs
+Under the rs-gaap-anchored architecture, the roll-forward hangs directly
+off ``rs-gaap:StockholdersEquity`` — no fac scaffolding. The activity arcs
 are the rs-gaap concepts the statement displays as change rows: NetIncomeLoss,
 OCI, issuance, repurchase, share-based compensation, dividends.
 
@@ -85,7 +84,7 @@ def _bs_equity_children(pkg: TaxonomyPackage, role: str) -> set[str]:
 
 
 class TestEquityFormVariants:
-  """Phase 4 equity-form axis: CORP balance sheet trimmed to corporate
+  """Equity-form axis: CORP balance sheet trimmed to corporate
   equity; dedicated PART/LLC balance-sheet + Statement-of-Changes
   structures present the form-appropriate capital concept."""
 

--- a/tests/taxonomy/test_rs_gaap_rules_seed.py
+++ b/tests/taxonomy/test_rs_gaap_rules_seed.py
@@ -2,10 +2,10 @@
 
 Pure data tests — parses the seed via
 :func:`robosystems.taxonomy.loader.load_taxonomy_package` and asserts the
-shape Package II.a ships: L1 cross-tree consistency identities harvested
+shape it ships: L1 cross-tree consistency identities harvested
 from Charlie Hoffman's PROOF and **rewritten to rs-gaap subtotal
 concepts**, element-scoped so they fire against any rendered statement
-that presents the subtotal (info-block §6.1). The prior FAC-keyed,
+that presents the subtotal. The prior FAC-keyed,
 structure-scoped 14-rule seed (which evaluated to ``skipped`` because our
 facts are rs-gaap-keyed) is superseded; rollup-shaped identities now live
 in ``rs-gaap-rollup-rules/v1`` (L2).
@@ -132,7 +132,7 @@ class TestRuleExpressionsBindVariables:
 
   def test_every_variable_qname_is_rs_gaap(self, rules: list[RuleSpec]) -> None:
     """Variables resolve against rs-gaap-keyed facts — the FAC->rs-gaap
-    rewrite is the whole point of the Package II.a harvest."""
+    rewrite is the whole point of the harvest."""
     for rule in rules:
       for variable in rule.rule_variables:
         assert variable.variable_qname.startswith("rs-gaap:"), (

--- a/tests/taxonomy/test_rules_migration_shape.py
+++ b/tests/taxonomy/test_rules_migration_shape.py
@@ -1,4 +1,4 @@
-"""Shape tests for Phase δ.2 rule plumbing across the migration surface.
+"""Shape tests for rule plumbing across the migration surface.
 
 Static checks — no DB round-trip. The extensions-DB migration harness
 lives in the dev loop (``just migrate-up extensions`` + CI dry runs);
@@ -98,7 +98,7 @@ class TestSeedFiles:
     assert ("rs-gaap-rules", "v1") in seeded_paths
 
   def test_phase_c_packages_pinned_in_framework_manifest(self) -> None:
-    """The four Phase C packages + bridge are declared in
+    """The four disclosure-layer packages + bridge are declared in
     rs-gaap@v1's manifest. ``is_required: false`` lets the
     framework resolve gracefully even if a deployment is missing
     them, but the manifest entries must be present."""
@@ -118,9 +118,9 @@ class TestSeedFiles:
 
 
 class TestPhaseCCheckWidens:
-  """Phase C added new namespace prefixes and a new association_type
-  that need to land in 0002's CHECK constants for fresh DBs (and 0007
-  for already-deployed tenant schemas).
+  """The disclosure-layer packages added new namespace prefixes and a new
+  association_type that need to land in 0002's CHECK constants for fresh
+  DBs (and 0007 for already-deployed tenant schemas).
 
   Drift here would surface as a CHECK violation on first INSERT — the
   most common authoring footgun when adding a new package."""


### PR DESCRIPTION
## What

Second pass of the construction-exhaust cleanup (follow-on to #734, which
covered in-repo READMEs and source-code comments). Removes dangling references
to private, never-published planning specs from the remaining surfaces an
open-source reader can't resolve:

- **Tests** (51 files) — phase/wave/gap labels, `*.md §x` spec citations, and
  `[[wikilink]]` slugs stripped from docstrings/comments. A handful of test
  classes/functions whose *names* embedded private plan labels
  (`TestG1…`, `…_phase2_mvp`) are renamed to behavior-named equivalents
  (verified no external references; collection unchanged).
- **Migrations** (14 files, extensions + platform) — same cleanup, confined to
  docstrings/comments. `0002`'s pass-describing comments reworded `Phase N` →
  `Pass N` for self-consistency (and the matching runtime log strings).
- **dbt** — `transactions.sql` comment cleanup.
- **Demo output** — stale `seattle_method_demo` case-1 sample outputs (generated
  by an earlier `reconcile.py` since cleaned) re-synced; each edited line now
  matches the current generator verbatim, so a future `just demo` reproduces
  them unchanged.

## Safety

- Edits are confined to prose: **no** test logic, assertion values, expected
  data, SQL/DDL, or `revision`/`down_revision` identifiers changed.
- **Kept** legitimate references: public `XBRL 2.1 §5.x` / FASB ASC citations,
  migration identifiers, real code/file references, and the `phase_c` concept
  (coupled to the retained `0011_phase_c_required` migration).

## Verification

- `just test-code` clean (ruff + format + basedpyright 0/0/0 + cf-lint).
- `pytest --co` collects all 5102 tests; renamed identifiers resolve.
- `py_compile` passes on every changed `.py`.
- Residual-exhaust scan over `migrations/`, `tests/`, `examples/` returns clean
  (only legitimate public-spec citations and Python data literals remain).