### PR TITLE
fix(worker): publish queue depth from a background thread

### DIFF
--- a/cloudformation/worker.yaml
+++ b/cloudformation/worker.yaml
@@ -517,7 +517,10 @@ Resources:
       EvaluationPeriods: 1
       Threshold: 2
       ComparisonOperator: GreaterThanThreshold
-      TreatMissingData: notBreaching
+      # Fail open: a gap in published depth errs toward adding capacity rather
+      # than silently not scaling. Scale-in stays notBreaching so a gap never
+      # wrongly scales to zero.
+      TreatMissingData: breaching
       AlarmActions:
         - !Ref WorkerScaleOutPolicy
 

--- a/robosystems/admin/commands/worker.py
+++ b/robosystems/admin/commands/worker.py
@@ -152,9 +152,6 @@ def worker_status(client):
     inflight_keys = list(queue.scan_iter(match="worker:inflight:*", count=100))
     inflight_total = sum(queue.llen(k) for k in inflight_keys)
 
-    # Check leader
-    leader = queue.get("worker:metrics:leader")
-
     console.print()
     console.print("[bold cyan]WORKER STATUS[/bold cyan]")
     console.print("=" * 40)
@@ -163,6 +160,5 @@ def worker_status(client):
       f"  In-flight:      {inflight_total} (across {len(inflight_keys)} workers)"
     )
     console.print(f"  DLQ:            {dlq_depth}")
-    console.print(f"  Metrics leader: {leader or 'none'}")
   finally:
     queue.close()

--- a/robosystems/worker/consumer.py
+++ b/robosystems/worker/consumer.py
@@ -29,7 +29,7 @@ from robosystems.middleware.sse.operation_manager import (
 )
 from robosystems.worker.cleanup import cleanup_connections
 from robosystems.worker.constants import DEFAULT_TASK_TIMEOUT, TASK_TIMEOUTS
-from robosystems.worker.metrics import QueueDepthReporter
+from robosystems.worker.metrics import QueueDepthPublisher
 from robosystems.worker.tasks import get_task_handler
 
 logger = logging.getLogger(__name__)
@@ -51,14 +51,13 @@ async def run() -> None:
 
   worker_id = f"worker-{socket.gethostname()}-{os.getpid()}"
   inflight_key = f"worker:inflight:{worker_id}"
-  depth_reporter = QueueDepthReporter(queue, worker_id)
+  depth_publisher = QueueDepthPublisher()
+  depth_publisher.start()
   logger.info(f"Worker started: {worker_id}")
 
   shutdown_wait = asyncio.create_task(shutdown.wait())
   try:
     while not shutdown.is_set():
-      await depth_reporter.maybe_publish()
-
       # BLMOVE atomically pops from main queue and pushes to inflight list.
       # If the worker crashes, the task stays in inflight for the reaper.
       # Race against shutdown so SIGTERM exits without waiting for BLMOVE timeout.
@@ -91,6 +90,7 @@ async def run() -> None:
       await _process_task(task_data, task_json, queue, inflight_key, manager, worker_id)
   finally:
     logger.info(f"Worker shutting down: {worker_id}")
+    depth_publisher.stop()
     shutdown_wait.cancel()
     try:
       await queue.aclose()

--- a/robosystems/worker/metrics.py
+++ b/robosystems/worker/metrics.py
@@ -54,6 +54,10 @@ class QueueDepthPublisher:
   def stop(self) -> None:
     self._stop.set()
     self._thread.join(timeout=STOP_JOIN_TIMEOUT)
+    if self._thread.is_alive():
+      logger.warning(
+        f"queue-depth-publisher thread did not stop within {STOP_JOIN_TIMEOUT}s"
+      )
 
   def _run(self) -> None:
     """Publish immediately, then every interval until stopped."""
@@ -77,8 +81,8 @@ class QueueDepthPublisher:
     finally:
       try:
         self._queue.close()
-      except Exception:
-        pass
+      except Exception as e:
+        logger.debug(f"Queue client close error on shutdown: {e}")
 
   def _publish_once(self) -> None:
     """Read the queue depth and publish it to CloudWatch (skipped in dev)."""

--- a/robosystems/worker/metrics.py
+++ b/robosystems/worker/metrics.py
@@ -1,92 +1,97 @@
-"""Queue depth metric publishing with leader election.
+"""Queue depth metric publishing via a background daemon thread.
 
-Only one worker publishes queue depth to CloudWatch, elected via a
-Valkey lock with TTL. If the leader dies, the lock expires and another
-worker takes over automatically.
+Every worker runs its own publisher thread that reports the shared queue
+depth (llen of "worker:tasks") to CloudWatch once per interval. The thread
+is independent of the consume loop, so it keeps publishing even while the
+worker is blocked processing a long-running task — the consume loop only
+returns between tasks, which can be many minutes apart.
+
+All workers publish the same global depth; the scale-out/scale-in alarms
+aggregate with Statistic=Maximum, so concurrent publishers are correct
+(scale out on the peak reading, scale in only when every reading is 0).
 
 The metric powers:
 1. CloudWatch alarms for queue backup detection
 2. ECS auto-scaling policy for worker replicas
 """
 
-import time
-
-from redis.asyncio import Redis
+import threading
+from typing import Any
 
 from robosystems.logger import get_logger
 
 logger = get_logger(__name__)
 
-# Publish at most once per interval (seconds)
-METRIC_PUBLISH_INTERVAL = 60
+# Publish queue depth once per interval (seconds).
+PUBLISH_INTERVAL = 60
 
-# Leader lock TTL — must exceed METRIC_PUBLISH_INTERVAL so the lock
-# doesn't expire between publishes during normal operation.
-LEADER_LOCK_TTL = 90
+# Reliable-queue list that the consumer pops from.
+QUEUE_KEY = "worker:tasks"
 
-LEADER_LOCK_KEY = "worker:metrics:leader"
+# Join timeout when stopping the thread on shutdown.
+STOP_JOIN_TIMEOUT = 5
 
 
-class QueueDepthReporter:
-  """Publishes worker queue depth to CloudWatch via leader election.
+class QueueDepthPublisher:
+  """Publishes worker queue depth to CloudWatch from a daemon thread.
 
-  Only the worker holding the leader lock publishes metrics. Others
-  skip silently. Call maybe_publish() on every consumer loop iteration.
+  Start with start() at worker boot and stop() on shutdown. The thread owns
+  its own synchronous Valkey and CloudWatch clients — it must not share the
+  consume loop's async client across the thread boundary.
   """
 
-  def __init__(self, queue: Redis, worker_id: str) -> None:
-    self.queue = queue
-    self.worker_id = worker_id
-    self._last_publish_time: float = 0
-    self._cloudwatch_client = None
-
-  async def maybe_publish(self) -> None:
-    """Publish queue depth if we're the leader and interval has elapsed."""
-    now = time.time()
-    if now - self._last_publish_time < METRIC_PUBLISH_INTERVAL:
-      return
-
-    # Try to acquire or confirm leader lock
-    acquired = await self.queue.set(
-      LEADER_LOCK_KEY, self.worker_id, nx=True, ex=LEADER_LOCK_TTL
+  def __init__(self) -> None:
+    self._stop = threading.Event()
+    self._thread = threading.Thread(
+      target=self._run, name="queue-depth-publisher", daemon=True
     )
-    if not acquired:
-      current_leader = await self.queue.get(LEADER_LOCK_KEY)
-      if current_leader != self.worker_id:
-        return
+    self._queue: Any = None
+    self._cloudwatch_client: Any = None
 
-    # We're the leader — refresh lock and publish
-    await self.queue.set(LEADER_LOCK_KEY, self.worker_id, ex=LEADER_LOCK_TTL)
+  def start(self) -> None:
+    self._thread.start()
 
-    depth = await self.queue.llen("worker:tasks")
-    self._last_publish_time = now
+  def stop(self) -> None:
+    self._stop.set()
+    self._thread.join(timeout=STOP_JOIN_TIMEOUT)
 
+  def _run(self) -> None:
+    """Publish immediately, then every interval until stopped."""
+    from robosystems.config.valkey_registry import (
+      ValkeyDatabase,
+      create_redis_client,
+    )
+
+    self._queue = create_redis_client(
+      ValkeyDatabase.WORKER_QUEUE, decode_responses=True
+    )
     try:
-      await self._publish_to_cloudwatch(depth)
-    except Exception as e:
-      logger.warning(f"Failed to publish queue depth metric: {e}")
+      while True:
+        try:
+          self._publish_once()
+        except Exception as e:
+          # A transient Valkey/CloudWatch error must never kill the thread.
+          logger.warning(f"Failed to publish queue depth metric: {e}")
+        if self._stop.wait(PUBLISH_INTERVAL):
+          break
+    finally:
+      try:
+        self._queue.close()
+      except Exception:
+        pass
 
-  async def _publish_to_cloudwatch(self, depth: int) -> None:
-    """Publish queue depth to CloudWatch. Skipped in dev."""
+  def _publish_once(self) -> None:
+    """Read the queue depth and publish it to CloudWatch (skipped in dev)."""
     from robosystems.config import env
+
+    depth = self._queue.llen(QUEUE_KEY)
 
     if env.ENVIRONMENT == "dev":
       logger.debug(f"Queue depth: {depth} (CloudWatch publish skipped in dev)")
       return
 
-    import asyncio
-
-    await asyncio.to_thread(self._publish_sync, depth, env.ENVIRONMENT)
-
-  def _publish_sync(self, depth: int, environment: str) -> None:
-    """Synchronous CloudWatch publish (runs in thread)."""
-    if self._cloudwatch_client is None:
-      import boto3
-
-      self._cloudwatch_client = boto3.client("cloudwatch")
-
-    namespace = f"RoboSystems/Worker/{environment}"
-    self._cloudwatch_client.put_metric_data(
+    namespace = f"RoboSystems/Worker/{env.ENVIRONMENT}"
+    self._get_cloudwatch_client().put_metric_data(
       Namespace=namespace,
       MetricData=[
         {
@@ -97,3 +102,10 @@ class QueueDepthReporter:
       ],
     )
     logger.debug(f"Published queue depth {depth} to {namespace}")
+
+  def _get_cloudwatch_client(self) -> Any:
+    if self._cloudwatch_client is None:
+      import boto3
+
+      self._cloudwatch_client = boto3.client("cloudwatch")
+    return self._cloudwatch_client

--- a/tests/worker/test_metrics.py
+++ b/tests/worker/test_metrics.py
@@ -1,0 +1,62 @@
+"""Tests for the worker queue-depth publisher."""
+
+from unittest.mock import MagicMock, patch
+
+from robosystems.config import env
+from robosystems.worker.metrics import QUEUE_KEY, QueueDepthPublisher
+
+
+def test_publish_once_emits_queue_depth_to_cloudwatch():
+  """Outside dev, _publish_once reads llen and publishes the depth."""
+  publisher = QueueDepthPublisher()
+  publisher._queue = MagicMock()
+  publisher._queue.llen.return_value = 7
+  cloudwatch = MagicMock()
+  publisher._cloudwatch_client = cloudwatch
+
+  with patch.object(env, "ENVIRONMENT", "prod"):
+    publisher._publish_once()
+
+  publisher._queue.llen.assert_called_once_with(QUEUE_KEY)
+  cloudwatch.put_metric_data.assert_called_once()
+  kwargs = cloudwatch.put_metric_data.call_args.kwargs
+  assert kwargs["Namespace"] == "RoboSystems/Worker/prod"
+  metric = kwargs["MetricData"][0]
+  assert metric["MetricName"] == "QueueDepth"
+  assert metric["Value"] == 7
+  assert metric["Unit"] == "Count"
+
+
+def test_publish_once_skips_cloudwatch_in_dev():
+  """In dev, the depth is read but never published to CloudWatch."""
+  publisher = QueueDepthPublisher()
+  publisher._queue = MagicMock()
+  publisher._queue.llen.return_value = 3
+  cloudwatch = MagicMock()
+  publisher._cloudwatch_client = cloudwatch
+
+  with patch.object(env, "ENVIRONMENT", "dev"):
+    publisher._publish_once()
+
+  publisher._queue.llen.assert_called_once_with(QUEUE_KEY)
+  cloudwatch.put_metric_data.assert_not_called()
+
+
+def test_start_then_stop_runs_and_joins_cleanly():
+  """The daemon thread starts, publishes at least once, and stops without error."""
+  fake_queue = MagicMock()
+  fake_queue.llen.return_value = 0
+
+  with patch(
+    "robosystems.config.valkey_registry.create_redis_client",
+    return_value=fake_queue,
+  ):
+    publisher = QueueDepthPublisher()
+    publisher.start()
+    publisher.stop()
+
+  # Thread joined within the stop timeout.
+  assert not publisher._thread.is_alive()
+  # It owned and closed its own sync client.
+  fake_queue.llen.assert_called_with(QUEUE_KEY)
+  fake_queue.close.assert_called_once()

--- a/tests/worker/test_metrics.py
+++ b/tests/worker/test_metrics.py
@@ -60,3 +60,29 @@ def test_start_then_stop_runs_and_joins_cleanly():
   # It owned and closed its own sync client.
   fake_queue.llen.assert_called_with(QUEUE_KEY)
   fake_queue.close.assert_called_once()
+
+
+def test_run_continues_after_publish_error():
+  """A failing _publish_once is caught; the loop keeps publishing."""
+  fake_queue = MagicMock()
+  publisher = QueueDepthPublisher()
+  publish_calls = []
+
+  def publish_side_effect():
+    publish_calls.append(1)
+    if len(publish_calls) == 1:
+      raise ValueError("transient CloudWatch error")
+
+  with (
+    patch(
+      "robosystems.config.valkey_registry.create_redis_client",
+      return_value=fake_queue,
+    ),
+    patch.object(publisher, "_publish_once", side_effect=publish_side_effect),
+    patch.object(publisher._stop, "wait", side_effect=[False, True]),
+  ):
+    publisher._run()
+
+  # Two iterations ran despite the first raising — the thread didn't die.
+  assert len(publish_calls) == 2
+  fake_queue.close.assert_called_once()


### PR DESCRIPTION
## Summary

Worker autoscaling is driven by a `QueueDepth` CloudWatch metric. It was published from inside the consume loop (`QueueDepthReporter.maybe_publish`), called once per iteration *before* `await _process_task(...)`. While a worker processed a task the loop never returned to publish — and several task types run far longer than the 60s publish interval (`extensions_materialize` 1800s, `dagster_job_monitor` 3600s, `graph_tier_upgrade` 3600s, `operator` 600s). At `WORKER_MIN_COUNT=1` a single busy worker went blind for the whole task duration, so the scale-out signal stalled exactly when the queue was backing up behind it.

This is prerequisite work for turning worker autoscaling on — `WORKER_AUTOSCALING_ENABLED_PROD` stays `false`; this PR only makes the signal reliable.

## Changes

- **`robosystems/worker/metrics.py`** — replace the async, leader-elected `QueueDepthReporter` with `QueueDepthPublisher`, a daemon thread that owns its own **sync** Valkey client and publishes `QueueDepth` to the `RoboSystems/Worker/{environment}` namespace every 60s. Running off the consume loop in an OS thread makes it immune to event-loop starvation from the handlers' unguarded blocking calls (sync boto3/SQLAlchemy). Dev still skips the CloudWatch publish.
- **Drop leader election** — every worker publishes the same global `llen("worker:tasks")`. This is correct under the alarms' `Statistic: Maximum` (scale-out on the peak reading, scale-in only when all readings are 0) and removes the 90s leader-failover gap. ≤5 `PutMetricData`/min at `WORKER_MAX_COUNT=5`; the worker IAM role already scopes `cloudwatch:PutMetricData` to this namespace.
- **`robosystems/worker/consumer.py`** — start the publisher at boot, remove the per-loop `maybe_publish()` call, `stop()`/join in `finally`.
- **`robosystems/admin/commands/worker.py`** — drop the now-dead `Metrics leader` line from `worker status`.
- **`cloudformation/worker.yaml`** — flip the scale-out alarm to `TreatMissingData: breaching` (fail open, so a publishing gap errs toward adding capacity); scale-in stays `notBreaching` so a gap never wrongly scales to zero. No effect until autoscaling is enabled (alarms are `Condition: AutoscalingEnabled`).
- **`tests/worker/test_metrics.py`** — new unit tests: publish path (namespace + metric), dev-skip, clean start/stop.

## Testing

- `just test worker` → 27 passed (3 new).
- `just test-code` (ruff + format + basedpyright + cfn-lint) → clean.
- `cfn-lint cloudformation/worker.yaml` → clean.

## Follow-ups (not in this PR)

- Flip `WORKER_AUTOSCALING_ENABLED_PROD=true` once the metric is verified in prod (requires a worker stack redeploy — it gates a CloudFormation `Condition`, not a runtime flag).
- Scale-in / long-task robustness: with autoscaling on, scale-in terminates a worker the same as a deploy — SIGKILL at `StopTimeout=119s` mid-task, after which the reaper only requeues once the full task timeout elapses (crash-tuned), stalling long tasks ~20–30 min. Worth addressing (graceful requeue-on-SIGTERM, scale-in protection, or moving long-running task types off the autoscaled pool) before enabling autoscaling.
