### PR TITLE
fix(worker): harden ECS task scale-in protection

### DIFF
--- a/robosystems/worker/consumer.py
+++ b/robosystems/worker/consumer.py
@@ -30,7 +30,10 @@ from robosystems.middleware.sse.operation_manager import (
 from robosystems.worker.cleanup import cleanup_connections
 from robosystems.worker.constants import DEFAULT_TASK_TIMEOUT, TASK_TIMEOUTS
 from robosystems.worker.metrics import QueueDepthPublisher
-from robosystems.worker.task_protection import TaskProtectionManager
+from robosystems.worker.task_protection import (
+  PROTECT_MIN_TIMEOUT_SECONDS,
+  TaskProtectionManager,
+)
 from robosystems.worker.tasks import get_task_handler
 
 logger = logging.getLogger(__name__)
@@ -150,9 +153,12 @@ async def _process_task(
     },
   ):
     timeout = TASK_TIMEOUTS.get(task_type, DEFAULT_TASK_TIMEOUT)
+    # Only long tasks need scale-in protection; short ones drain within the
+    # SIGTERM grace, so protecting them would just churn the ECS API.
+    protect_task = timeout >= PROTECT_MIN_TIMEOUT_SECONDS
     try:
-      # Protect this worker from scale-in termination while it runs the task.
-      await protection.protect()
+      if protect_task:
+        await protection.protect()
       await manager.emit_progress(task_id, "Starting...", progress_percent=0)
 
       handler = handler_cls(task_id, graph_id, user_id, params, manager)
@@ -207,7 +213,8 @@ async def _process_task(
 
     finally:
       # Clear scale-in protection — worker is idle again and safe to terminate.
-      await protection.unprotect()
+      if protect_task:
+        await protection.unprotect()
       # Remove from inflight — task completed (successfully or not)
       await queue.lrem(inflight_key, 1, task_json)
       cleanup_connections()

--- a/robosystems/worker/task_protection.py
+++ b/robosystems/worker/task_protection.py
@@ -76,6 +76,8 @@ class TaskProtectionManager:
       logger.warning(f"Task scale-in protection (enabled={enabled}) failed: {e}")
 
   def _set_protection_sync(self, enabled: bool) -> None:
+    # Metadata is fetched once and cached, so _load_metadata (and its
+    # retry-then-disable logic) only runs until the first success.
     if self._task_arn is None and not self._load_metadata():
       return
 
@@ -131,7 +133,7 @@ class TaskProtectionManager:
 
       # Tight timeouts + capped retries so a slow/throttled ECS control plane
       # can't stall task processing (protect() is awaited before the handler
-      # runs). Worst case ~14s rather than botocore's ~5-minute default.
+      # runs). Worst case well under 20s rather than botocore's ~5-min default.
       self._ecs_client = boto3.client(
         "ecs",
         config=Config(

--- a/robosystems/worker/task_protection.py
+++ b/robosystems/worker/task_protection.py
@@ -34,6 +34,15 @@ PROTECTION_EXPIRES_MINUTES = 90
 # Timeout for the one-shot metadata fetch.
 METADATA_TIMEOUT_SECONDS = 2
 
+# Only protect tasks whose timeout exceeds the worker's SIGTERM grace
+# (StopTimeout = 119s). Shorter tasks always drain before SIGKILL on scale-in,
+# so protecting them would just churn the ECS API.
+PROTECT_MIN_TIMEOUT_SECONDS = 120
+
+# Disable protection only after this many consecutive metadata-fetch failures,
+# so a single transient blip doesn't permanently turn it off.
+MAX_METADATA_FAILURES = 10
+
 
 class TaskProtectionManager:
   """Marks the running ECS task protected/unprotected from scale-in.
@@ -49,6 +58,7 @@ class TaskProtectionManager:
     self._cluster: str | None = None
     self._task_arn: str | None = None
     self._ecs_client: Any = None
+    self._metadata_failures = 0
 
   async def protect(self) -> None:
     await self._set_protection(True)
@@ -90,7 +100,8 @@ class TaskProtectionManager:
   def _load_metadata(self) -> bool:
     """Fetch cluster + task ARN from the ECS metadata endpoint.
 
-    Returns False and disables the manager if metadata is unavailable.
+    Returns True on success. A transient failure returns False but leaves the
+    manager enabled so the next call retries; only repeated failures disable it.
     """
     try:
       with urllib.request.urlopen(
@@ -99,17 +110,34 @@ class TaskProtectionManager:
         meta = json.loads(resp.read())
       self._cluster = meta["Cluster"]
       self._task_arn = meta["TaskARN"]
+      self._metadata_failures = 0
       return True
     except Exception as e:
-      logger.warning(
-        f"Could not read ECS task metadata; scale-in protection disabled: {e}"
-      )
-      self._enabled = False
+      self._metadata_failures += 1
+      if self._metadata_failures >= MAX_METADATA_FAILURES:
+        self._enabled = False
+        logger.warning(
+          f"Could not read ECS task metadata after {self._metadata_failures} "
+          f"attempts; scale-in protection disabled: {e}"
+        )
+      else:
+        logger.warning(f"Could not read ECS task metadata; will retry: {e}")
       return False
 
   def _get_ecs_client(self) -> Any:
     if self._ecs_client is None:
       import boto3
+      from botocore.config import Config
 
-      self._ecs_client = boto3.client("ecs")
+      # Tight timeouts + capped retries so a slow/throttled ECS control plane
+      # can't stall task processing (protect() is awaited before the handler
+      # runs). Worst case ~14s rather than botocore's ~5-minute default.
+      self._ecs_client = boto3.client(
+        "ecs",
+        config=Config(
+          connect_timeout=2,
+          read_timeout=5,
+          retries={"max_attempts": 2, "mode": "standard"},
+        ),
+      )
     return self._ecs_client

--- a/tests/worker/test_consumer.py
+++ b/tests/worker/test_consumer.py
@@ -82,6 +82,22 @@ async def test_protects_and_unprotects_around_task(mock_queue, mock_manager):
 
 
 @pytest.mark.asyncio
+async def test_short_task_skips_protection(mock_queue, mock_manager):
+  """A task below the protection threshold makes no ECS protection calls."""
+  protection = AsyncMock()
+  with (
+    patch("robosystems.worker.consumer.TASK_TIMEOUTS", {}),
+    patch("robosystems.worker.consumer.DEFAULT_TASK_TIMEOUT", 60),
+    patch("robosystems.worker.consumer.PROTECT_MIN_TIMEOUT_SECONDS", 120),
+  ):
+    await _call_process_task(
+      _make_task_data(), mock_queue, mock_manager, protection=protection
+    )
+  protection.protect.assert_not_awaited()
+  protection.unprotect.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 @patch("robosystems.worker.consumer.cleanup_connections")
 @patch("robosystems.worker.consumer.get_tracer")
 async def test_happy_path(mock_tracer, mock_cleanup, mock_manager, mock_queue):

--- a/tests/worker/test_consumer.py
+++ b/tests/worker/test_consumer.py
@@ -58,15 +58,27 @@ def _make_task_data(task_type="test_success", **overrides):
 
 
 async def _call_process_task(
-  task_data, mock_queue, mock_manager, worker_id="worker-test-1"
+  task_data, mock_queue, mock_manager, worker_id="worker-test-1", protection=None
 ):
   """Helper to call _process_task with the correct signature."""
   task_json = json.dumps(task_data)
   inflight_key = f"worker:inflight:{worker_id}"
-  protection = AsyncMock()
+  protection = protection or AsyncMock()
   await _process_task(
     task_data, task_json, mock_queue, inflight_key, mock_manager, worker_id, protection
   )
+  return protection
+
+
+@pytest.mark.asyncio
+async def test_protects_and_unprotects_around_task(mock_queue, mock_manager):
+  """A protected task wraps execution in protect()/unprotect()."""
+  protection = AsyncMock()
+  await _call_process_task(
+    _make_task_data(), mock_queue, mock_manager, protection=protection
+  )
+  protection.protect.assert_awaited_once()
+  protection.unprotect.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/worker/test_task_protection.py
+++ b/tests/worker/test_task_protection.py
@@ -5,7 +5,9 @@ import json
 import os
 from unittest.mock import MagicMock, patch
 
+from robosystems.worker.constants import DEFAULT_TASK_TIMEOUT, TASK_TIMEOUTS
 from robosystems.worker.task_protection import (
+  MAX_METADATA_FAILURES,
   METADATA_URI_ENV,
   PROTECTION_EXPIRES_MINUTES,
   TaskProtectionManager,
@@ -55,14 +57,18 @@ def test_load_metadata_parses_cluster_and_task():
   assert mgr._task_arn == TASK_ARN
 
 
-def test_metadata_failure_disables_manager():
+def test_metadata_failure_retries_then_disables():
+  """A single metadata blip retries; only repeated failures disable."""
   mgr = _enabled_manager()
   with patch(
     "robosystems.worker.task_protection.urllib.request.urlopen",
     side_effect=OSError("metadata unreachable"),
   ):
     assert mgr._load_metadata() is False
-  assert mgr._enabled is False
+    assert mgr._enabled is True  # one blip does not disable
+    for _ in range(MAX_METADATA_FAILURES):
+      mgr._load_metadata()
+  assert mgr._enabled is False  # repeated failures eventually disable
 
 
 def test_protect_calls_update_task_protection_with_expiry():
@@ -97,3 +103,23 @@ def test_unprotect_omits_expiry():
   kwargs = ecs.update_task_protection.call_args.kwargs
   assert kwargs["protectionEnabled"] is False
   assert "expiresInMinutes" not in kwargs
+
+
+def test_set_protection_swallows_client_error():
+  """A failing update_task_protection is logged, never raised (best-effort)."""
+  mgr = _enabled_manager()
+  mgr._cluster = CLUSTER
+  mgr._task_arn = TASK_ARN
+  ecs = MagicMock()
+  ecs.update_task_protection.side_effect = RuntimeError("ECS throttled")
+  mgr._ecs_client = ecs
+
+  # Must not raise.
+  asyncio.run(mgr.protect())
+  asyncio.run(mgr.unprotect())
+
+
+def test_protection_lease_outlives_longest_task():
+  """The protection lease must exceed the longest task timeout."""
+  longest = max([*TASK_TIMEOUTS.values(), DEFAULT_TASK_TIMEOUT])
+  assert longest < PROTECTION_EXPIRES_MINUTES * 60


### PR DESCRIPTION
## Summary

Follow-up to the ECS task scale-in protection added in `5bca20f8`. An adversarial review of that commit surfaced one blocker and several should-fixes; this hardens the protection path so it can't degrade live task processing. The protection code runs in prod ECS regardless of whether autoscaling is enabled, so these matter before the next worker deploy — not only once autoscaling is on.

## Changes

- **`robosystems/worker/task_protection.py`**
  - **Bound the ECS API call (blocker):** the boto3 `ecs` client is now built with `Config(connect_timeout=2, read_timeout=5, retries={"max_attempts": 2})`. `protect()` is `await`ed *before* the handler runs, so botocore's default 60s×5 retry behavior (~5 min) on a slow/throttled control plane would have stalled the very task it's meant to protect. Worst case is now ~14s.
  - **No permanent self-disable on a transient blip:** a failed metadata fetch increments a counter and only disables protection after `MAX_METADATA_FAILURES` (10) consecutive misses, resetting on success. Previously a single 2s-timeout hiccup on the first read disabled protection for the entire worker-process lifetime.
- **`robosystems/worker/consumer.py`**
  - **Only protect long tasks:** protect/unprotect now fire only when the task's timeout `>= PROTECT_MIN_TIMEOUT_SECONDS` (120s, the worker's `StopTimeout=119` SIGTERM grace). Short tasks (60s types) drain before SIGKILL on scale-in anyway, so protecting them was 2 needless ECS control-plane calls per task — a throttling risk on a busy worker.
- **Tests (`tests/worker/`)**
  - `protect()` swallows an ECS API error without raising (the best-effort contract).
  - protect/unprotect actually fire around a processed task.
  - Invariant guard: `PROTECTION_EXPIRES_MINUTES * 60 > max(TASK_TIMEOUTS)` — fails CI if a task timeout is later bumped past the 90-minute protection lease.
  - Updated the metadata-failure test to assert the new retry-then-disable behavior.

## Testing

- `just test worker` → **37 passed** (4 new/updated worker tests).
- `just test-code` (ruff + format + basedpyright + cfn-lint) → clean.

## Notes / Follow-ups

- The `5bca20f8` parent landed directly on `main` (no PR); this is its review-driven follow-up.
- Not done here (deferred, separate concern): switching from the boto3 control-plane API to the in-container task-protection endpoint (`${ECS_CONTAINER_METADATA_URI_V4}/task-protection/v1/state`), which would drop the `ecs:UpdateTaskProtection` IAM grant and the SDK round-trip entirely. The boto3 path is hardened and well-understood; the endpoint swap is an optimization for later.
- Worker autoscaling itself stays disabled (`WORKER_AUTOSCALING_ENABLED_*=false`); enabling it remains a staging-first ops step.
