### PR TITLE
chore(create-feature): default branch creation to no dep update

### DIFF
--- a/bin/tools/create-feature.sh
+++ b/bin/tools/create-feature.sh
@@ -9,7 +9,7 @@ set -e
 BRANCH_TYPE=${1:-feature}
 BRANCH_NAME=${2:-}
 BASE_BRANCH=${3:-main}
-UPDATE_DEPS=${4:-yes}
+UPDATE_DEPS=${4:-no}
 
 # Validate branch type
 if [[ "$BRANCH_TYPE" != "feature" && "$BRANCH_TYPE" != "bugfix" && "$BRANCH_TYPE" != "hotfix" && "$BRANCH_TYPE" != "chore" && "$BRANCH_TYPE" != "refactor" ]]; then
@@ -80,7 +80,9 @@ git push -u origin $FULL_BRANCH
 echo ""
 echo "🎉 Successfully created and checked out $FULL_BRANCH"
 
-# Update dependencies if requested (default: yes)
+# Update dependencies only when explicitly requested (default: no).
+# Pass "yes" as the 4th arg to refresh deps on the new branch; otherwise
+# branch creation leaves the lockfile untouched.
 if [[ "$UPDATE_DEPS" == "yes" ]]; then
   echo ""
   echo "📦 Updating dependencies..."

--- a/justfile
+++ b/justfile
@@ -242,7 +242,7 @@ demo-world-online-statement-reconcile *args="":
 ## CI/CD ##
 
 # Create a feature branch
-create-feature type="feature" name="" base="main" update="yes":
+create-feature type="feature" name="" base="main" update="no":
     @bin/tools/create-feature.sh {{type}} {{name}} {{base}} {{update}}
 
 # Create a release branch from main with deployment option


### PR DESCRIPTION
## What

Flip the `update_deps` default in `just create-feature` / `bin/tools/create-feature.sh` from `yes` to `no`.

## Why

Branch creation ran `just update` by default, refreshing the entire `uv.lock` on every new branch. That swept unrelated dependency churn into focused branches — surfaced while creating a branch for an unrelated security fix, where the branch suddenly wanted to bump every package.

## Change

- `bin/tools/create-feature.sh`: `UPDATE_DEPS=${4:-no}` (was `yes`) + clarified the guard comment
- `justfile`: recipe default `update="no"` (was `"yes"`)

Pass `yes` as the 4th arg to opt into a dependency refresh when that's actually intended:

```
just create-feature feature my-branch main yes
```

Self-validated: the companion bugfix branch was created after this change and ran with **no** dep refresh.