### PR TITLE
fix(sec): harden script/style end-tag stripping in iXBRL parser

### DIFF
--- a/robosystems/adapters/sec/ixbrl_parser.py
+++ b/robosystems/adapters/sec/ixbrl_parser.py
@@ -77,10 +77,10 @@ def _strip_html(html: str) -> str:
   if "<table" in html or "<TABLE" in html:
     html = html_tables_to_markdown(html)
   text = re.sub(
-    r"<style[^>]*>.*?</\s*style\s*>", " ", html, flags=re.DOTALL | re.IGNORECASE
+    r"<style[^>]*>.*?</\s*style\b[^>]*>", " ", html, flags=re.DOTALL | re.IGNORECASE
   )
   text = re.sub(
-    r"<script[^>]*>.*?</\s*script\s*>", " ", text, flags=re.DOTALL | re.IGNORECASE
+    r"<script[^>]*>.*?</\s*script\b[^>]*>", " ", text, flags=re.DOTALL | re.IGNORECASE
   )
   # Replace block-level tags with newlines to preserve paragraph structure
   text = re.sub(


### PR DESCRIPTION
## What

Anchor the `<script>` / `<style>` end-tag patterns in `_strip_html` so closing tags carrying trailing junk are stripped.

## Why

The old patterns `</\s*script\s*>` and `</\s*style\s*>` only matched a closing tag whose name was immediately followed by optional whitespace and `>`. A tag like `</script foo>` — or CodeQL's counterexample `</script\t\n bar>` — slipped through, leaving the raw script/style body in the extracted disclosure text.

Resolves **CodeQL `py/bad-tag-filter` (code-scanning alert #516)**.

Note: this is SEC iXBRL HTML → text extraction, not browser-rendered output, so the real-world risk is low (no XSS sink). The fix is correctness/robustness — and it closes the alert.

## Change

```python
r"<style[^>]*>.*?</\s*style\b[^>]*>"
r"<script[^>]*>.*?</\s*script\b[^>]*>"
```

`\b` anchors the tag name; `[^>]*` consumes any attributes/junk up to the close — matching how browsers terminate these elements.

## Verification

- Validated against CodeQL's exact counterexample plus `</script foo="x">` and the well-formed cases
- Existing `tests/adapters/sec/test_ixbrl_parser.py` (28 tests) still pass