### PR TITLE
chore(create-feature): default VS Code task to no dep update

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -383,7 +383,7 @@
       "id": "updateDependencies",
       "type": "pickString",
       "description": "Update dependencies after creating branch:",
-      "default": "yes",
+      "default": "no",
       "options": ["yes", "no"]
     },
     {


### PR DESCRIPTION
## What
Default the **Create Feature** VS Code task's `updateDependencies` picker to `no`.

## Why
#740 flipped the script + justfile defaults to `no`, but the VS Code task passes `${input:updateDependencies}` explicitly and that picker still defaulted to `yes` — overriding the script default and pre-selecting a dependency refresh on branch creation.

## Change
- `.vscode/tasks.json`: `updateDependencies` input default `no` (was `yes`); `yes` stays selectable.

Follow-up to #740 (which the VS Code task layer was missing).