### PR TITLE
chore(dagster): default webserver to 0 tasks, scale on demand via tunnels

### DIFF
--- a/.github/workflows/deploy-dagster.yml
+++ b/.github/workflows/deploy-dagster.yml
@@ -64,6 +64,11 @@ on:
         required: false
         type: string
         default: "1024"
+      webserver_desired_count:
+        description: "Webserver tasks (0 = off, scaled up on demand by tunnels.sh; 1 = always on)"
+        required: false
+        type: string
+        default: "0"
       # Run Job Profiles are hardcoded (profile name = fixed resources):
       # - Light:    512 CPU,  2048 MB (0.5 vCPU, 2 GB)  - sensors, simple jobs
       # - Standard: 2048 CPU, 8192 MB (2 vCPU, 8 GB)    - moderate ETL
@@ -308,6 +313,7 @@ jobs:
                 ParameterKey=DaemonMemory,ParameterValue=${{ inputs.daemon_memory }} \
                 ParameterKey=WebserverCpu,ParameterValue=${{ inputs.webserver_cpu }} \
                 ParameterKey=WebserverMemory,ParameterValue=${{ inputs.webserver_memory }} \
+                ParameterKey=WebserverDesiredCount,ParameterValue=${{ inputs.webserver_desired_count }} \
                 ParameterKey=RunJobCpu,ParameterValue=512 \
                 ParameterKey=RunJobMemory,ParameterValue=2048 \
                 ParameterKey=MaxConcurrentRuns,ParameterValue=${{ inputs.max_concurrent_runs }} \

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -613,6 +613,7 @@ jobs:
       daemon_memory: ${{ vars.DAGSTER_DAEMON_MEMORY_PROD || '2048' }}
       webserver_cpu: ${{ vars.DAGSTER_WEBSERVER_CPU_PROD || '512' }}
       webserver_memory: ${{ vars.DAGSTER_WEBSERVER_MEMORY_PROD || '1024' }}
+      webserver_desired_count: ${{ vars.DAGSTER_WEBSERVER_DESIRED_COUNT_PROD || '0' }}
       # Run Job Profiles: hardcoded in deploy-dagster.yml (Light/Standard/Compute/Heavy)
       max_concurrent_runs: ${{ vars.DAGSTER_MAX_CONCURRENT_RUNS_PROD || '20' }}
       # Worker Configuration

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -630,6 +630,7 @@ jobs:
       daemon_memory: ${{ vars.DAGSTER_DAEMON_MEMORY_STAGING || '2048' }}
       webserver_cpu: ${{ vars.DAGSTER_WEBSERVER_CPU_STAGING || '512' }}
       webserver_memory: ${{ vars.DAGSTER_WEBSERVER_MEMORY_STAGING || '1024' }}
+      webserver_desired_count: ${{ vars.DAGSTER_WEBSERVER_DESIRED_COUNT_STAGING || '0' }}
       # Run Job Profiles: hardcoded in deploy-dagster.yml (Light/Standard/Compute/Heavy)
       max_concurrent_runs: ${{ vars.DAGSTER_MAX_CONCURRENT_RUNS_STAGING || '20' }}
       # Worker Configuration

--- a/bin/tools/tunnels.sh
+++ b/bin/tools/tunnels.sh
@@ -20,6 +20,13 @@ API_ENDPOINT=""
 API_INTERNAL_ENDPOINT=""  # Service Discovery endpoint (bypasses ALB)
 API_ACCESS_MODE=""        # internal or public
 
+# Dagster webserver scale-on-demand tracking. The webserver defaults to 0 tasks
+# in CloudFormation (it's UI-only, reachable solely through this tunnel) so an
+# idle UI doesn't cost an on-demand Fargate task. We scale it to 1 while a
+# dagster tunnel is open, then back to 0 on exit.
+ENVIRONMENT=""
+WEBSERVER_SCALED_UP="false"
+
 
 # Colors for output
 RED='\033[0;31m'
@@ -35,6 +42,11 @@ cleanup_on_exit() {
 
     # Kill any background SSM sessions
     pkill -f "session-manager-plugin" 2>/dev/null || true
+
+    # Scale the Dagster webserver back down if this session brought it up
+    if [[ "$WEBSERVER_SCALED_UP" == "true" && -n "${ENVIRONMENT:-}" ]]; then
+        scale_webserver_down "$ENVIRONMENT"
+    fi
 
     # Prompt user to optionally stop the bastion
     if [[ -n "${BASTION_INSTANCE_ID:-}" ]] && [[ -t 0 ]]; then
@@ -339,6 +351,52 @@ check_bastion_status() {
         echo "The instance may not have the SSM agent installed or proper IAM permissions."
         exit 1
     fi
+}
+
+scale_webserver_up() {
+    local environment=$1
+    local cluster="robosystems-dagster-${environment}-cluster"
+    local service="robosystems-dagster-webserver-${environment}"
+
+    echo -e "${BLUE}Ensuring Dagster webserver is running...${NC}"
+
+    local desired
+    desired=$(aws ecs describe-services \
+        --cluster "$cluster" --services "$service" \
+        --query 'services[0].desiredCount' --output text \
+        --region "$AWS_REGION" 2>/dev/null || echo "")
+
+    if [[ -z "$desired" || "$desired" == "None" ]]; then
+        echo -e "${YELLOW}Warning: Dagster webserver service not found; skipping scale-up${NC}"
+        return 0
+    fi
+
+    if [[ "$desired" -ge 1 ]]; then
+        echo -e "${GREEN}✓ Dagster webserver already running${NC}"
+        return 0
+    fi
+
+    echo -e "${YELLOW}Starting Dagster webserver (scale 0 -> 1)...${NC}"
+    aws ecs update-service \
+        --cluster "$cluster" --service "$service" \
+        --desired-count 1 --region "$AWS_REGION" >/dev/null
+    WEBSERVER_SCALED_UP="true"
+
+    echo -e "${BLUE}Waiting for Dagster webserver to become healthy (cold start ~1-2 min)...${NC}"
+    aws ecs wait services-stable \
+        --cluster "$cluster" --services "$service" \
+        --region "$AWS_REGION"
+    echo -e "${GREEN}✓ Dagster webserver is running${NC}"
+}
+
+scale_webserver_down() {
+    local environment=$1
+    echo -e "${YELLOW}Scaling Dagster webserver back down (-> 0)...${NC}"
+    aws ecs update-service \
+        --cluster "robosystems-dagster-${environment}-cluster" \
+        --service "robosystems-dagster-webserver-${environment}" \
+        --desired-count 0 --region "${AWS_REGION:-us-east-1}" >/dev/null 2>&1 || true
+    echo -e "${GREEN}✓ Dagster webserver scaled to 0${NC}"
 }
 
 start_ssm_tunnel() {
@@ -734,6 +792,17 @@ main() {
 
     # Check and start bastion if needed
     check_bastion_status "$environment"
+
+    # Remember the environment so cleanup_on_exit can scale the webserver back down
+    ENVIRONMENT="$environment"
+
+    # The Dagster webserver defaults to 0 tasks (cost); bring it up on demand
+    # only for the services that actually need it.
+    case $service in
+        dagster|all)
+            scale_webserver_up "$environment"
+            ;;
+    esac
 
     # Set up tunnels based on service
     case $service in

--- a/cloudformation/dagster.yaml
+++ b/cloudformation/dagster.yaml
@@ -51,6 +51,12 @@ Parameters:
     Default: "1024"
     Description: Memory in MiB for Dagster webserver
     AllowedValues: ["1024", "2048", "4096"]
+  WebserverDesiredCount:
+    Type: Number
+    Default: 0
+    MinValue: 0
+    MaxValue: 1
+    Description: Webserver tasks. 0 = off by default (UI-only, reached via bin/tools/tunnels.sh which scales it to 1 on demand); 1 = always on.
   # Run Job Configuration (Fargate)
   # Default task definition provides base resources. Jobs override via Dagster tags:
   #   ecs/cpu, ecs/memory, ecs/ephemeral_storage, ecs/run_task_kwargs
@@ -966,7 +972,7 @@ Resources:
     Properties:
       ServiceName: !Sub robosystems-dagster-webserver-${Environment}
       Cluster: !Ref DagsterCluster
-      DesiredCount: 1 # Always 1 - no ALB for load distribution
+      DesiredCount: !Ref WebserverDesiredCount # Default 0 (off); bin/tools/tunnels.sh scales to 1 on demand. Override via DAGSTER_WEBSERVER_DESIRED_COUNT_<ENV>
       CapacityProviderStrategy:
         - CapacityProvider: FARGATE_SPOT
           Weight: !Ref WebserverFargateSpotWeight


### PR DESCRIPTION
## Summary

The Dagster webserver is UI-only and reachable solely through the SSM tunnel (`bin/tools/tunnels.sh`) — no ALB, `AssignPublicIp: DISABLED`. Running it at `DesiredCount: 1` around the clock burns an idle on-demand Fargate task for a UI nobody can reach without opening a tunnel. This defaults the webserver to **0 tasks** and has the tunnel script scale it `0 → 1` on demand, then back to `0` on exit — mirroring the pattern already shipped in supplyflow-backend.

The daemon service is untouched, so schedules/sensors/job orchestration keep running 24/7; only the idle UI is scaled down.

## Changes

- **`cloudformation/dagster.yaml`** — new `WebserverDesiredCount` parameter (default `0`, range 0–1); `WebserverService.DesiredCount` now `!Ref`s it instead of the hardcoded `1`.
- **`.github/workflows/deploy-dagster.yml`** — new `webserver_desired_count` input (default `"0"`), threaded through as `ParameterKey=WebserverDesiredCount`.
- **`.github/workflows/prod.yml` / `staging.yml`** — pass `webserver_desired_count` from `vars.DAGSTER_WEBSERVER_DESIRED_COUNT_<ENV>` (default `'0'`). Both GHA variables have been set to `0`.
- **`bin/tools/tunnels.sh`** — `scale_webserver_up`/`scale_webserver_down` (against `robosystems-dagster-${env}-cluster` / `robosystems-dagster-webserver-${env}`), `WEBSERVER_SCALED_UP`/`ENVIRONMENT` tracking, scale-down in the `cleanup_on_exit` trap, and a `dagster|all` scale-up in `main()` after the bastion check. Scale-up is idempotent (skips if already ≥1) and degrades gracefully if the service is missing.

## Testing

- `cfn-lint cloudformation/dagster.yaml` — clean, no findings.
- `bash -n bin/tools/tunnels.sh` — syntax OK.
- Pre-commit hooks (ruff/format) passed on commit.
- Full `just test-all` / live `aws cloudformation validate-template` not run (no live SSO session this session).

## Notes / Follow-ups

- **Takes effect on next dagster deploy.** Until the stack is deployed via Actions, the running webserver stays at `DesiredCount: 1`.
- **IAM**: the identity running `just tunnel` needs `ecs:DescribeServices` + `ecs:UpdateService` on the dagster cluster (currently only ec2/ssm). Without it, scale-up prints a warning and tunnels anyway — to a webserver still at 0. Worth confirming before relying on it.
- Cold start adds ~1–2 min to the first `just tunnel <env> dagster` while the task starts (`ecs wait services-stable`).
- Prod webserver currently runs 100% on-demand Fargate (`DAGSTER_WEBSERVER_FARGATE_SPOT_WEIGHT_PROD = 0`), so the idle-cost saving in prod is a full on-demand task; staging (80% Spot) saves less.
- To pin the webserver always-on for an environment, set `DAGSTER_WEBSERVER_DESIRED_COUNT_<ENV> = 1`.
