### PR TITLE
chore(infra): align worker CloudFormation stack name with convention

### DIFF
--- a/.github/configs/stacks.yml
+++ b/.github/configs/stacks.yml
@@ -151,6 +151,12 @@ prod:
       webserver_service_arn: WebserverServiceArn
       dagster_url: DagsterUrl
 
+  # Background Worker (deployed alongside Dagster, shares its ECS cluster)
+  # ECS resource names remain robosystems-worker-{env} (derived from Environment
+  # in cloudformation/worker.yaml); only the CloudFormation stack name is aligned here.
+  workers:
+    stack_name: RoboSystemsWorkerProd
+
 staging:
   # Core Infrastructure (Uses shared VPC)
   vpc:
@@ -289,6 +295,12 @@ staging:
       daemon_service_arn: DaemonServiceArn
       webserver_service_arn: WebserverServiceArn
       dagster_url: DagsterUrl
+
+  # Background Worker (deployed alongside Dagster, shares its ECS cluster)
+  # ECS resource names remain robosystems-worker-{env} (derived from Environment
+  # in cloudformation/worker.yaml); only the CloudFormation stack name is aligned here.
+  workers:
+    stack_name: RoboSystemsWorkerStaging
 
 # Common patterns for dynamic stack name generation
 patterns:

--- a/.github/workflows/deploy-dagster.yml
+++ b/.github/workflows/deploy-dagster.yml
@@ -103,6 +103,11 @@ on:
         default: "0"
 
       # Worker Configuration
+      worker_stack_name:
+        description: "CloudFormation stack name for the background worker"
+        required: false
+        type: string
+        default: ""
       worker_enabled:
         description: "Enable background worker deployment (true/false)"
         required: false
@@ -410,7 +415,12 @@ jobs:
         if: inputs.worker_enabled == 'true'
         id: deploy-worker
         run: |
-          WORKER_STACK="robosystems-worker-${{ inputs.environment }}"
+          WORKER_STACK="${{ inputs.worker_stack_name }}"
+
+          if [ -z "$WORKER_STACK" ]; then
+            echo "Error: worker_stack_name input is required when worker_enabled is true"
+            exit 1
+          fi
 
           if aws cloudformation describe-stacks --stack-name $WORKER_STACK 2>&1 | grep -q "does not exist"; then
             STACK_ACTION="create-stack"
@@ -489,6 +499,6 @@ jobs:
         if: inputs.worker_enabled == 'true'
         uses: ./.github/actions/monitor-stack-deployment
         with:
-          stack-name: robosystems-worker-${{ inputs.environment }}
+          stack-name: ${{ inputs.worker_stack_name }}
           timeout: "600"
           interval: "10"

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -73,6 +73,7 @@ jobs:
       waf_stack: ${{ steps.load.outputs.waf_stack }}
       cloudtrail_stack: ${{ steps.load.outputs.cloudtrail_stack }}
       dagster_stack: ${{ steps.load.outputs.dagster_stack }}
+      worker_stack: ${{ steps.load.outputs.worker_stack }}
       opensearch_stack: ${{ steps.load.outputs.opensearch_stack }}
       domain_name_root: ${{ steps.load.outputs.domain_name_root }}
       graph_ami_id: ${{ steps.ami.outputs.ami_id }}
@@ -121,6 +122,7 @@ jobs:
           echo "waf_stack=$(./bin/tools/stack-config.sh $ENV waf)" >> $GITHUB_OUTPUT
           echo "cloudtrail_stack=$(./bin/tools/stack-config.sh $ENV cloudtrail)" >> $GITHUB_OUTPUT
           echo "dagster_stack=$(./bin/tools/stack-config.sh $ENV dagster)" >> $GITHUB_OUTPUT
+          echo "worker_stack=$(./bin/tools/stack-config.sh $ENV workers)" >> $GITHUB_OUTPUT
           echo "opensearch_stack=$(./bin/tools/stack-config.sh $ENV opensearch)" >> $GITHUB_OUTPUT
 
           # Domain configuration - leave empty for isolated deployment (no custom domains)
@@ -617,6 +619,7 @@ jobs:
       # Run Job Profiles: hardcoded in deploy-dagster.yml (Light/Standard/Compute/Heavy)
       max_concurrent_runs: ${{ vars.DAGSTER_MAX_CONCURRENT_RUNS_PROD || '20' }}
       # Worker Configuration
+      worker_stack_name: ${{ needs.stack-config.outputs.worker_stack }}
       worker_enabled: ${{ vars.WORKER_ENABLED_PROD || 'false' }}
       worker_cpu: ${{ vars.WORKER_CPU_PROD || '512' }}
       worker_memory: ${{ vars.WORKER_MEMORY_PROD || '1024' }}

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -98,6 +98,7 @@ jobs:
       waf_stack: ${{ steps.load.outputs.waf_stack }}
       cloudtrail_stack: ${{ steps.load.outputs.cloudtrail_stack }}
       dagster_stack: ${{ steps.load.outputs.dagster_stack }}
+      worker_stack: ${{ steps.load.outputs.worker_stack }}
       opensearch_stack: ${{ steps.load.outputs.opensearch_stack }}
       domain_name_root: ${{ steps.load.outputs.domain_name_root }}
       graph_ami_id: ${{ steps.ami.outputs.ami_id }}
@@ -147,6 +148,7 @@ jobs:
           echo "waf_stack=$(./bin/tools/stack-config.sh $ENV waf)" >> $GITHUB_OUTPUT
           echo "cloudtrail_stack=$(./bin/tools/stack-config.sh $ENV cloudtrail)" >> $GITHUB_OUTPUT
           echo "dagster_stack=$(./bin/tools/stack-config.sh $ENV dagster)" >> $GITHUB_OUTPUT
+          echo "worker_stack=$(./bin/tools/stack-config.sh $ENV workers)" >> $GITHUB_OUTPUT
           echo "opensearch_stack=$(./bin/tools/stack-config.sh $ENV opensearch)" >> $GITHUB_OUTPUT
 
           # Domain configuration - leave empty for isolated deployment (no custom domains)
@@ -634,6 +636,7 @@ jobs:
       # Run Job Profiles: hardcoded in deploy-dagster.yml (Light/Standard/Compute/Heavy)
       max_concurrent_runs: ${{ vars.DAGSTER_MAX_CONCURRENT_RUNS_STAGING || '20' }}
       # Worker Configuration
+      worker_stack_name: ${{ needs.stack-config.outputs.worker_stack }}
       worker_enabled: ${{ vars.WORKER_ENABLED_STAGING || 'false' }}
       worker_cpu: ${{ vars.WORKER_CPU_STAGING || '512' }}
       worker_memory: ${{ vars.WORKER_MEMORY_STAGING || '1024' }}


### PR DESCRIPTION
## Summary

The background-worker CloudFormation stack is the only stack named in kebab-case (`robosystems-worker-{prod,staging}`); every other stack follows the PascalCase `RoboSystems{Component}{Env}` convention defined in `.github/configs/stacks.yml`. The worker name was also the only one **hardcoded inline** in `deploy-dagster.yml` rather than sourced from the central config. This aligns the stack name to `RoboSystemsWorkerProd` / `RoboSystemsWorkerStaging` and routes it through the same `stacks.yml` → `stack-config.sh` path as every other stack.

## Changes

- **`.github/configs/stacks.yml`** — add a `workers` entry under `prod` and `staging` (single source of truth, alongside `dagster`).
- **`.github/workflows/deploy-dagster.yml`** — new `worker_stack_name` input; the deploy step and monitor step read it instead of the inline `robosystems-worker-${env}` string; empty-value guard added so a missing name fails fast when `worker_enabled` is true.
- **`.github/workflows/prod.yml` / `.github/workflows/staging.yml`** — the `stack-config` job resolves `worker_stack` via `stack-config.sh $ENV workers` and passes it through to `deploy-dagster` as `worker_stack_name`.

## Scope note

Only the **CloudFormation stack name** changes. ECS resource names (service, cluster, IAM roles, log group) remain `robosystems-worker-{env}` — they are derived from the `Environment` parameter in `cloudformation/worker.yaml`, and are referenced by Grafana dashboards and `service-refresh.yml`, so they are intentionally untouched.

## ⚠️ Rollout sequencing (required)

CloudFormation can't rename a stack in place — this is a delete + recreate. Because the worker's ECS **service name** (`robosystems-worker-{env}`) is unchanged and the worker deploys into the **shared Dagster cluster**, the old and new stacks would both try to own the same ECS service name. The old kebab-case stacks must be deleted before the next release:

1. Merge this PR.
2. `aws cloudformation delete-stack --stack-name robosystems-worker-staging` → run the staging release, which creates `RoboSystemsWorkerStaging`.
3. `aws cloudformation delete-stack --stack-name robosystems-worker-prod` → then run the prod release.

There is a brief worker gap between delete and the next deploy — fine for background workers, but time it outside any active SEC backfill.

## Testing

- Verified locally that `stack-config.sh` resolves the new names: `prod workers` → `RoboSystemsWorkerProd`, `staging workers` → `RoboSystemsWorkerStaging`; existing `dagster`/`api` names resolve unchanged.
- Confirmed all four edited files parse as valid YAML.
- `just test-all` not run — this is a CI/CD config-only change (no Python touched); validation will come from the staging release exercising the create path.
