### PR TITLE
feat(taxonomy): cm framework + schedule has-part posting arcs

### DIFF
--- a/frameworks/cm/packages/cm/v1/taxonomy.jsonld
+++ b/frameworks/cm/packages/cm/v1/taxonomy.jsonld
@@ -1,0 +1,49 @@
+{
+  "@context": {
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "xbrli": "http://www.xbrl.org/2003/instance#",
+    "rs": "https://robosystems.ai/vocab/",
+    "cm": "https://github.com/seattlemethod/universal/cm#",
+    "balance": {"@id": "xbrli:balance"},
+    "periodType": {"@id": "xbrli:periodType"},
+    "abstract": {"@id": "rs:abstract", "@type": "xsd:boolean"},
+    "monetary": {"@id": "rs:monetary", "@type": "xsd:boolean"},
+    "elementType": {"@id": "rs:elementType"},
+    "substitutionGroup": {"@id": "rs:substitutionGroup", "@type": "@id"},
+    "source": {"@id": "rs:source"},
+    "label": "rdfs:label",
+    "documentation": "rdfs:comment"
+  },
+  "standard": "cm",
+  "version": "v1",
+  "taxonomy_type": "reporting_standard",
+  "namespace_uri": "https://github.com/seattlemethod/universal/cm#",
+  "description": "Conceptual Model (CM) — minimal universal upper-vocabulary forked from Charlie Hoffman's Seattle Method 'universal' conceptual model (https://github.com/seattlemethod/universal). Seeds the Debit and Credit posting-role concepts that anchor has-part arcs from Chart-of-Accounts elements, making double-entry posting structure a first-class, queryable atom of an Information Block rather than opaque mechanics metadata. Intentionally tiny; expands additively (Thing, Event, Transaction, LineItem) when event serialization pulls them in.",
+  "@graph": [
+    {
+      "@id": "cm:Debit",
+      "label": [{"@language": "en", "@value": "Debit"}],
+      "documentation": [{"@language": "en", "@value": "Conceptual-model Debit posting role. A has-part arc from cm:Debit to a Chart-of-Accounts element declares that element as the debit leg of the structure's posting template."}],
+      "abstract": [{"@type": "xsd:boolean", "@value": true}],
+      "elementType": [{"@value": "abstract"}],
+      "balance": [{"@value": "debit"}],
+      "periodType": [{"@value": "duration"}],
+      "monetary": [{"@type": "xsd:boolean", "@value": false}],
+      "source": [{"@value": "cm"}],
+      "substitutionGroup": [{"@id": "xbrli:item"}]
+    },
+    {
+      "@id": "cm:Credit",
+      "label": [{"@language": "en", "@value": "Credit"}],
+      "documentation": [{"@language": "en", "@value": "Conceptual-model Credit posting role. A has-part arc from cm:Credit to a Chart-of-Accounts element declares that element as the credit leg of the structure's posting template."}],
+      "abstract": [{"@type": "xsd:boolean", "@value": true}],
+      "elementType": [{"@value": "abstract"}],
+      "balance": [{"@value": "credit"}],
+      "periodType": [{"@value": "duration"}],
+      "monetary": [{"@type": "xsd:boolean", "@value": false}],
+      "source": [{"@value": "cm"}],
+      "substitutionGroup": [{"@id": "xbrli:item"}]
+    }
+  ]
+}

--- a/frameworks/cm/v1.json
+++ b/frameworks/cm/v1.json
@@ -1,0 +1,12 @@
+{
+  "framework": "cm",
+  "version": "v1",
+  "title": "Conceptual Model (CM)",
+  "description": "Minimal universal conceptual-model vocabulary forked from Charlie Hoffman's Seattle Method 'universal' model (https://github.com/seattlemethod/universal). Seeds the Debit and Credit posting-role concepts that anchor has-part arcs from Chart-of-Accounts elements, making double-entry posting structure a first-class, queryable atom of an Information Block rather than opaque mechanics metadata. NOT a reporting taxonomy — a foundational substrate. Seeded + tenant-copied with the default pin via rs-gaap depends_on cm. Expands additively (Thing, Event, Transaction, LineItem) when event serialization pulls them in.",
+  "framework_type": "reporting",
+  "depends_on": [],
+  "packages": [
+    {"standard": "cm", "version": "v1", "ordinal": 0, "is_required": true}
+  ],
+  "bridges": []
+}

--- a/frameworks/rs-gaap/v1.json
+++ b/frameworks/rs-gaap/v1.json
@@ -5,7 +5,8 @@
   "description": "Sovereign rs-gaap leaf catalog (curated from FASB us-gaap) with named Disclosures, Disclosure Mechanics, presentation/rendering machinery, and Reporting Styles for vertical/filer-profile flavoring (Default, Small Private Company, Banking, Insurance, Mining, etc.). Depends on the fac framework for the universal accounting concept substrate and trait vocabulary; rs-gaap-traits/v1 binds those traits to rs-gaap elements (seeds the element_traits junction). The default framework pinned by every tenant graph filing under US GAAP.",
   "framework_type": "reporting",
   "depends_on": [
-    {"framework": "fac", "version": "v1"}
+    {"framework": "fac", "version": "v1"},
+    {"framework": "cm", "version": "v1"}
   ],
   "packages": [
     {"standard": "rs-gaap",                      "version": "v1", "ordinal": 0, "is_required": true},

--- a/migrations/extensions/versions/0002_taxonomy_library.py
+++ b/migrations/extensions/versions/0002_taxonomy_library.py
@@ -127,7 +127,9 @@ _WIDENED_ELEMENT_SOURCE_CHECK = (
   # rs-gaap framework extension packages. Each declares a sibling
   # namespace anchored to the rs-gaap framework. See migration 0007
   # for the same widen applied to already-deployed tenant schemas.
-  "'disclosures', 'checklist', 'styles'"
+  # 'cm' — Conceptual Model framework (cm:Debit/cm:Credit posting roles),
+  # seeded here via rs-gaap depends_on cm and tenant-copied with the pin.
+  "'disclosures', 'checklist', 'styles', 'cm'"
   ")"
 )
 _WIDENED_TAXONOMY_TYPE_CHECK = (

--- a/migrations/extensions/versions/0007_frameworks_bridges.py
+++ b/migrations/extensions/versions/0007_frameworks_bridges.py
@@ -256,7 +256,10 @@ _WIDENED_ELEMENT_SOURCE_CHECK = (
   "source IN ("
   "'fac', 'rs-gaap', 'us-gaap', 'ifrs', "
   "'quickbooks', 'xero', 'plaid', 'native', 'import', 'system', "
-  "'disclosures', 'checklist', 'styles'"
+  # 'cm' — Conceptual Model framework (cm:Debit/cm:Credit posting roles).
+  # Re-applied here so the DROP+ADD over already-seeded public + tenant
+  # schemas (which now contain cm rows) doesn't fail constraint validation.
+  "'disclosures', 'checklist', 'styles', 'cm'"
   ")"
 )
 _PRIOR_ELEMENT_SOURCE_CHECK = (

--- a/robosystems/arelle/context.py
+++ b/robosystems/arelle/context.py
@@ -75,6 +75,11 @@ CANONICAL_CONTEXT: dict = {
   "dei": "http://xbrl.sec.gov/dei/",
   # Seattle Method conceptual-model role URIs (Charlie's CM namespace)
   "cm-roles": "http://www.xbrlsite.com/seattlemethod/conceptual-model/cm-roles/roles/",
+  # cm — Seattle Method 'universal' conceptual model (Charlie Hoffman). The
+  # Debit/Credit posting-role concepts anchor has-part arcs from Chart-of-
+  # Accounts elements. '#' fragment separator so concept IRIs compact to
+  # cm:Debit / cm:Credit.
+  "cm": "https://github.com/seattlemethod/universal/cm#",
   # RoboSystems vocabulary
   "rs": RS_VOCAB,
   # Concept attributes — XBRL vocabulary where XBRL defines the attribute

--- a/robosystems/db/extensions.py
+++ b/robosystems/db/extensions.py
@@ -222,9 +222,10 @@ def _widen_library_checks(conn, schema: str) -> None:
 
   Matches the widening applied in the 0002 migration so a fresh provision
   lands in the same state as a backfilled tenant (admits ``equivalence``,
-  ``general-special``, ``essence-alias`` association types and the
-  ``fac``/``rs-gaap`` element sources, the rules taxonomy type, and the
-  full Information Block structure-type vocabulary that the library uses).
+  ``general-special``, ``essence-alias``, ``has-part`` association types
+  and the ``fac``/``rs-gaap``/``cm`` element sources, the rules taxonomy
+  type, and the full Information Block structure-type vocabulary that the
+  library uses).
   """
   widened_assoc = (
     "association_type IN ("
@@ -235,7 +236,10 @@ def _widen_library_checks(conn, schema: str) -> None:
     "'definition', "
     # 'derivation' arcs map BS leaves to their CF default change tags
     # (rs-gaap-calculations).
-    "'derivation'"
+    "'derivation', "
+    # 'has-part' arcs declare cm:Debit/cm:Credit posting legs on schedule
+    # structures (the cm framework).
+    "'has-part'"
     ")"
   )
   widened_source = (
@@ -244,7 +248,10 @@ def _widen_library_checks(conn, schema: str) -> None:
     "'quickbooks', 'xero', 'plaid', 'native', 'import', 'system', "
     # rs-gaap framework extension packages anchored to
     # sibling namespaces of rs-gaap.
-    "'disclosures', 'checklist', 'styles'"
+    "'disclosures', 'checklist', 'styles', "
+    # cm — Conceptual Model framework (cm:Debit/cm:Credit posting roles),
+    # tenant-copied with the default pin.
+    "'cm'"
     ")"
   )
   widened_taxonomy_type = (

--- a/robosystems/models/extensions/association.py
+++ b/robosystems/models/extensions/association.py
@@ -45,7 +45,11 @@ class Association(ExtensionsBase):
     CheckConstraint(
       "association_type IN ("
       "'presentation', 'calculation', 'mapping', 'derivation', "
-      "'equivalence', 'general-special', 'essence-alias'"
+      "'equivalence', 'general-special', 'essence-alias', "
+      # 'has-part' — Conceptual Model posting arcs: cm:Debit/cm:Credit
+      # ─has-part→ a CoA element, declaring the debit/credit legs of a
+      # schedule's posting template as first-class atoms.
+      "'has-part'"
       ")",
       name="check_association_type",
     ),

--- a/robosystems/models/extensions/element.py
+++ b/robosystems/models/extensions/element.py
@@ -103,7 +103,10 @@ class Element(ExtensionsBase):
       # taxonomy seed (e.g., struct_balance_sheet) and is intentionally NOT
       # in COA_SOURCES so those rows never appear in the Chart of Accounts.
       "source IN ('fac', 'rs-gaap', 'us-gaap', 'ifrs', "
-      "'quickbooks', 'xero', 'plaid', 'native', 'import', 'system')",
+      "'quickbooks', 'xero', 'plaid', 'native', 'import', 'system', "
+      # 'cm' — Conceptual Model posting-role concepts (cm:Debit/cm:Credit),
+      # tenant-copied with the default pin so schedule has-part arcs resolve.
+      "'cm')",
       name="check_element_source",
     ),
   )

--- a/robosystems/operations/extensions/materialize.py
+++ b/robosystems/operations/extensions/materialize.py
@@ -33,6 +33,7 @@ from robosystems.logger import logger
 #   equivalence      — FAC ↔ rs-gaap bridge
 #   definition       — XBRL definition arcs (dimensions, hypercubes)
 #   derivation       — derived-from arcs
+#   has-part         — cm:Debit/cm:Credit posting-role arcs (schedule debit/credit legs)
 # Limiting to a single type makes any of these invisible to the graph
 # renderer. Originally scoped to 'presentation' only, which made CoA→rs-gaap
 # mappings invisible (and reports empty) even when the mappings existed in
@@ -46,6 +47,7 @@ _MATERIALIZED_ASSOCIATION_TYPES: tuple[str, ...] = (
   "equivalence",
   "definition",
   "derivation",
+  "has-part",
 )
 _MATERIALIZED_ASSOCIATION_TYPES_SQL = (
   "(" + ", ".join(f"'{t}'" for t in _MATERIALIZED_ASSOCIATION_TYPES) + ")"

--- a/robosystems/operations/roboledger/schedules/service.py
+++ b/robosystems/operations/roboledger/schedules/service.py
@@ -35,6 +35,11 @@ from robosystems.models.extensions.rule import Rule
 from robosystems.operations.roboledger.fact_set import create_fact_set
 from robosystems.utils.ulid import generate_prefixed_ulid
 
+# Charlie Hoffman's Seattle Method "universal" conceptual-model has-part
+# arcrole. A cm:Debit / cm:Credit ─has-part→ CoA-element arc declares that
+# element as the debit / credit leg of a schedule's posting template.
+CM_HAS_PART_ARCROLE = "https://github.com/seattlemethod/universal/cm/arcrole/has-part"
+
 # ── Data classes ─────────────────────────────────────────────────────────
 
 
@@ -241,6 +246,42 @@ class ScheduleService:
         created_by=created_by,
       )
       session.add(assoc)
+
+    # Emit Conceptual-Model has-part posting arcs so the debit/credit pairing
+    # lives as first-class, queryable atoms of the schedule IB (its envelope
+    # `connections`) rather than only as opaque entry_template mechanics:
+    #   cm:Debit  ─has-part→ debit account
+    #   cm:Credit ─has-part→ credit account
+    # Mirrors Charlie's classic-transactions posting model. Best-effort — if
+    # the cm library concepts aren't seeded in this tenant (provisioned before
+    # the cm framework landed), skip silently; entry_template remains the
+    # generation source of truth.
+    cm_role_ids = {
+      e.qname: e.id
+      for e in session.execute(
+        select(Element).where(
+          Element.source == "cm",
+          Element.qname.in_(("cm:Debit", "cm:Credit")),
+        )
+      ).scalars()
+    }
+    for role_qname, account_element_id in (
+      ("cm:Debit", entry_template.debit_element_id),
+      ("cm:Credit", entry_template.credit_element_id),
+    ):
+      role_id = cm_role_ids.get(role_qname)
+      if role_id is None or account_element_id is None:
+        continue
+      session.add(
+        Association(
+          structure_id=structure.id,
+          from_element_id=role_id,
+          to_element_id=account_element_id,
+          association_type="has-part",
+          arcrole=CM_HAS_PART_ARCROLE,
+          created_by=created_by,
+        )
+      )
 
     # Generate facts for each monthly period
     fact_set_id = generate_prefixed_ulid("fs")

--- a/robosystems/operations/taxonomy_block/library_creator.py
+++ b/robosystems/operations/taxonomy_block/library_creator.py
@@ -73,6 +73,8 @@ _ALLOWED_SOURCES = frozenset(
     "disclosures",
     "checklist",
     "styles",
+    # cm — Conceptual Model framework (cm:Debit/cm:Credit posting roles).
+    "cm",
   }
 )
 

--- a/tests/operations/roboledger/schedules/test_service.py
+++ b/tests/operations/roboledger/schedules/test_service.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from robosystems.operations.roboledger.schedules.service import (
+  CM_HAS_PART_ARCROLE,
   EntryTemplate,
   ScheduleMetadata,
   ScheduleService,
@@ -78,6 +79,10 @@ def _mock_session():
 
   session = MagicMock()
   session.execute.return_value = MagicMock()
+  # The cm:Debit/cm:Credit posting-role lookup (for has-part arcs) iterates
+  # execute().scalars(); default to empty so schedules in the mock simply skip
+  # the arcs unless a test wires the roles in explicitly.
+  session.execute.return_value.scalars.return_value = []
 
   def _stamp_structure_id(obj):
     if isinstance(obj, Structure) and getattr(obj, "id", None) is None:
@@ -326,18 +331,93 @@ class TestCreateSchedule:
         assert round(obj.value, 2) == obj.value, f"Unrounded value: {obj.value}"
 
 
+class TestCreateScheduleHasPartArcs:
+  """create_schedule emits cm:Debit/cm:Credit has-part posting arcs so the
+  debit/credit pairing is a first-class, queryable atom of the schedule IB."""
+
+  def test_emits_has_part_arcs_when_cm_roles_present(self):
+    session = _mock_session()
+    svc = ScheduleService()
+
+    cm_debit = MagicMock(id="elem_cm_debit", qname="cm:Debit")
+    cm_credit = MagicMock(id="elem_cm_credit", qname="cm:Credit")
+    cm_result = MagicMock()
+    cm_result.scalars.return_value = [cm_debit, cm_credit]
+    # taxonomy_id provided (no taxonomy lookup) and no original_amount (no
+    # SumEquals rule), so the cm role lookup is the only execute() call.
+    session.execute.return_value = cm_result
+
+    with patch.object(svc, "_get_entity_id", return_value="ent_01"):
+      svc.create_schedule(
+        session,
+        name="Prepaid Amortization",
+        taxonomy_id="tax_01",
+        element_ids=["elem_expense", "elem_prepaid"],
+        period_start=date(2026, 1, 1),
+        period_end=date(2026, 3, 31),
+        monthly_amount=5000,
+        entry_template=EntryTemplate(
+          debit_element_id="elem_expense",
+          credit_element_id="elem_prepaid",
+        ),
+        created_by="usr_test",
+      )
+
+    added = [call[0][0] for call in session.add.call_args_list]
+    has_part = [
+      o
+      for o in added
+      if type(o).__name__ == "Association" and o.association_type == "has-part"
+    ]
+    assert len(has_part) == 2
+    by_from = {a.from_element_id: a for a in has_part}
+    assert by_from["elem_cm_debit"].to_element_id == "elem_expense"
+    assert by_from["elem_cm_credit"].to_element_id == "elem_prepaid"
+    for a in has_part:
+      assert a.arcrole == CM_HAS_PART_ARCROLE
+      assert a.structure_id is not None
+
+  def test_no_has_part_arcs_when_cm_roles_absent(self):
+    session = _mock_session()  # default execute().scalars() → []
+    svc = ScheduleService()
+    with patch.object(svc, "_get_entity_id", return_value="ent_01"):
+      svc.create_schedule(
+        session,
+        name="No CM Roles",
+        taxonomy_id="tax_01",
+        element_ids=["elem_a", "elem_b"],
+        period_start=date(2026, 1, 1),
+        period_end=date(2026, 1, 31),
+        monthly_amount=5000,
+        entry_template=_make_entry_template(),
+        created_by="usr_test",
+      )
+    added = [call[0][0] for call in session.add.call_args_list]
+    has_part = [
+      o
+      for o in added
+      if type(o).__name__ == "Association"
+      and getattr(o, "association_type", None) == "has-part"
+    ]
+    assert has_part == []
+
+
 class TestCreateScheduleSumEqualsRule:
   """create_schedule auto-generates a SumEquals Rule when original_amount > 0."""
 
   def _run(self, session, *, original_amount: int | None = 120_000):
     svc = ScheduleService()
     # taxonomy_id is provided so _ensure_schedule_taxonomy is skipped.
-    # The only execute call in create_schedule is the Element.qname lookup
-    # for the SumEquals rule (when original_dollars is not None).
+    # Two execute() calls now: (1) the cm:Debit/cm:Credit posting-role lookup
+    # for has-part arcs (no roles in the mock → arcs skipped), then (2) the
+    # Element.qname lookup for the SumEquals rule (when original_dollars is
+    # not None).
+    cm_roles_row = MagicMock()
+    cm_roles_row.scalars.return_value = []
     debit_qname_row = MagicMock()
     debit_qname_row.scalar.return_value = "fac:DeprExpense"
 
-    session.execute.side_effect = [debit_qname_row]
+    session.execute.side_effect = [cm_roles_row, debit_qname_row]
 
     metadata = (
       ScheduleMetadata(

--- a/tests/taxonomy/test_canonical_concepts_migration_shape.py
+++ b/tests/taxonomy/test_canonical_concepts_migration_shape.py
@@ -75,3 +75,23 @@ class TestMetricTypeInStructureCheck:
 
     extensions_db._widen_library_checks(FakeConn(), "kg0123456789abcdef")
     assert any("structures" in stmt and "'metric'" in stmt for stmt in statements)
+
+  def test_fresh_tenant_check_widener_admits_cm_and_has_part(self) -> None:
+    """The cm framework introduces source='cm' (cm:Debit / cm:Credit) and
+    schedule posting arcs use association_type='has-part'. Both must be in
+    the fresh-provision widener, or tenant-copy of the cm elements and
+    schedule creation fail with a CheckViolation (the graph-creation failure
+    this regression guards against)."""
+    statements: list[str] = []
+
+    class FakeConn:
+      def execute(self, statement):
+        statements.append(str(statement))
+
+    extensions_db._widen_library_checks(FakeConn(), "kg0123456789abcdef")
+    assert any("elements" in s and "'cm'" in s for s in statements), (
+      "check_element_source widener must admit source='cm'"
+    )
+    assert any("associations" in s and "'has-part'" in s for s in statements), (
+      "check_association_type widener must admit association_type='has-part'"
+    )


### PR DESCRIPTION
## Summary

Adds a lightweight `cm` conceptual-model framework (forked from Charlie Hoffman's Seattle Method "universal" model) seeding `cm:Debit` / `cm:Credit` posting-role concepts, and emits them as `has-part` association arcs on schedules. This moves a schedule's debit/credit pairing out of opaque JSONB `entry_template` metadata into first-class, queryable atoms of the Information Block — present in the OLTP envelope's `connections` **and** materialized to the graph (Cypher-queryable).

## Changes

**New `cm` framework** (`frameworks/cm/`)
- Manifest + `taxonomy.jsonld` seeding `cm:Debit` / `cm:Credit` (abstract, non-monetary, `source='cm'`, namespace `https://github.com/seattlemethod/universal/cm#`).
- `rs-gaap` `depends_on cm` so it seeds into `public` and tenant-copies with the default pin.
- `CANONICAL_CONTEXT` (`arelle/context.py`) registers the cm namespace so concept IRIs compact to `cm:Debit` / `cm:Credit`.

**CHECK widenings** — `source='cm'` and `association_type='has-part'`
- Models (`models/extensions/element.py`, `association.py`) and the library-creator allow-list.
- Migration `0002`/`0007` widened-source constants (public schema).
- `_widen_library_checks` (`db/extensions.py`) — the authoritative CHECK for **tenant** schemas (it re-applies its own constraints over the model's at provision time). Missing `cm`/`has-part` here caused graph creation to fail with a `CheckViolation` during tenant-copy; this is the fix.

**Schedule emit** (`operations/roboledger/schedules/service.py`)
- `create_schedule` writes `cm:Debit ─has-part→ debit account` and `cm:Credit ─has-part→ credit account` into the schedule Structure. Best-effort (skips silently if cm isn't seeded in the tenant); dual-writes alongside the existing `entry_template`, which stays authoritative for closing-entry generation.

**Materialization** (`operations/extensions/materialize.py`)
- `has-part` added to `_MATERIALIZED_ASSOCIATION_TYPES` so the arcs reach the graph as `Association` nodes, not just OLTP.

**Tests**
- `has-part` emit coverage (roles-present / roles-absent) + mock fix for the new cm role lookup (`schedules/test_service.py`).
- Regression test that the tenant-provision widener admits `cm` + `has-part` (`test_canonical_concepts_migration_shape.py`) — guards the exact bug the e2e caught.

## Testing

- **`ruff` + `basedpyright`**: clean (pre-commit hooks pass on all three commits).
- **Targeted unit suites**: 402 passing across `tests/taxonomy`, `tests/operations/extensions`, `tests/operations/roboledger/schedules`, `tests/migrations`, and graph-creation.
- **End-to-end** on a fresh `just reset-local` + `just demo-roboledger`: graph provisions cleanly, cm copies into the tenant schema, 6 schedules emit **12 `has-part` arcs in OLTP**, and **all 12 materialize to the graph** (verified via `lbug-query`). The e2e is what surfaced the tenant-provision widener bug (graph creation `CheckViolation`); it's fixed and regression-tested, and a second fresh-stack run provisions cleanly.
- **`just test-all` full suite**: not run this session (needs the full local env beyond the targeted subsets).

## Notes / Follow-ups (deferred — local-only this pass)

- **Prod**: a forward migration to widen prod's `public` + existing-tenant CHECKs for `cm`/`has-part`, seed cm into prod `public`, and additively backfill cm:Debit/Credit + the has-part arcs into the already-provisioned tenant (provision-time immutability). The `0002`/`0007` edits only affect fresh replays.
- The model-level CHECK edits are effectively documentation — the authoritative DB constraints come from the migrations (public) and `_widen_library_checks` (tenants).
- Future direction (captured, not in this PR): promote schedule `schedule_metadata` numeric attributes to header facts; the non-numeric `Fact` value path; the schedule flow+stock remodel. All ride the same deferred backfill, and schedules are regenerable from their JSONB so the projection is deterministic.
