### PR TITLE
fix(schedules): draw down directly-credited asset balances

### DIFF
--- a/robosystems/operations/roboledger/schedules/service.py
+++ b/robosystems/operations/roboledger/schedules/service.py
@@ -338,6 +338,21 @@ class ScheduleService:
       else None
     )
 
+    # The credit fact tracks the running balance of the credited account, and
+    # its direction depends on that account's normal balance:
+    #   • credit-balance account (a contra-asset like Accumulated Depreciation,
+    #     or a liability) — the period credit INCREASES it, so the balance
+    #     accumulates from a zero opening: value = accumulated_debit.
+    #   • debit-balance account (a prepaid / other asset credited directly) —
+    #     the period credit DECREASES it, so the balance draws down from its
+    #     opening (the original gross outlay): value = original - accumulated.
+    # Without original_dollars there's no opening to anchor the drawdown, so
+    # fall back to the accumulating form.
+    credit_balance_type = session.execute(
+      select(Element.balance_type).where(Element.id == entry_template.credit_element_id)
+    ).scalar()
+    credit_draws_down = credit_balance_type == "debit" and original_dollars is not None
+
     # Custom amortization curve: caller supplies one integer (cents) per
     # period, pre-balanced. The generator uses the explicit values
     # instead of the straight-line formula. Use cases: day-count
@@ -408,11 +423,17 @@ class ScheduleService:
         )
       )
 
-      # Fact for the accumulated contra amount
+      # Fact for the credited account's running balance — contra accumulates,
+      # a directly-credited asset draws down (see credit_draws_down above).
+      credit_value = (
+        round(original_dollars - accumulated_debit, 2)
+        if credit_draws_down and original_dollars is not None
+        else accumulated_debit
+      )
       session.add(
         Fact(
           element_id=entry_template.credit_element_id,
-          value=accumulated_debit,
+          value=credit_value,
           period_start=p_start,
           period_end=p_end,
           period_type="instant",
@@ -424,8 +445,15 @@ class ScheduleService:
         )
       )
 
-      # Net book value if we have asset element info
-      if schedule_metadata and schedule_metadata.asset_element_id:
+      # Net book value if we have a DISTINCT asset element. Skip when the asset
+      # is the credited account itself (a direct-drawdown prepaid) — the credit
+      # fact above already carries that account's running balance, so emitting
+      # NBV here would double-stamp the same element/period.
+      if (
+        schedule_metadata
+        and schedule_metadata.asset_element_id
+        and schedule_metadata.asset_element_id != entry_template.credit_element_id
+      ):
         session.add(
           Fact(
             element_id=schedule_metadata.asset_element_id,

--- a/tests/operations/roboledger/schedules/test_service.py
+++ b/tests/operations/roboledger/schedules/test_service.py
@@ -402,22 +402,87 @@ class TestCreateScheduleHasPartArcs:
     assert has_part == []
 
 
+class TestCreateScheduleCreditDirection:
+  """The credit fact tracks the credited account's running balance: a
+  contra-asset (credit-balance) accumulates; a directly-credited debit-balance
+  asset like a prepaid draws down toward zero."""
+
+  def _credit_facts(self, session, *, credit_balance_type, asset_element_id=None):
+    svc = ScheduleService()
+    # execute order: (1) cm role lookup, (2) credit balance_type lookup,
+    # (3) SumEquals qname lookup.
+    cm_roles_row = MagicMock()
+    cm_roles_row.scalars.return_value = []
+    balance_row = MagicMock()
+    balance_row.scalar.return_value = credit_balance_type
+    qname_row = MagicMock()
+    qname_row.scalar.return_value = "fac:Expense"
+    session.execute.side_effect = [cm_roles_row, balance_row, qname_row]
+
+    with patch.object(svc, "_get_entity_id", return_value="ent_01"):
+      svc.create_schedule(
+        session,
+        name="Direction Test",
+        taxonomy_id="tax_01",
+        element_ids=["elem_dr", "elem_cr"],
+        period_start=date(2026, 1, 1),
+        period_end=date(2026, 3, 31),  # 3 monthly periods
+        monthly_amount=40_000,  # $400/mo
+        entry_template=EntryTemplate(
+          debit_element_id="elem_dr", credit_element_id="elem_cr"
+        ),
+        schedule_metadata=ScheduleMetadata(
+          method="straight_line",
+          original_amount=120_000,  # $1,200 total
+          asset_element_id=asset_element_id,
+        ),
+        created_by="usr_test",
+      )
+    added = [c[0][0] for c in session.add.call_args_list]
+    return [
+      f
+      for f in added
+      if type(f).__name__ == "Fact"
+      and f.element_id == "elem_cr"
+      and f.period_type == "instant"
+    ]
+
+  def test_contra_credit_accumulates(self):
+    facts = self._credit_facts(_mock_session(), credit_balance_type="credit")
+    assert [f.value for f in facts] == [400.0, 800.0, 1200.0]
+
+  def test_directly_credited_asset_draws_down(self):
+    facts = self._credit_facts(_mock_session(), credit_balance_type="debit")
+    assert [f.value for f in facts] == [800.0, 400.0, 0.0]
+
+  def test_asset_equals_credit_element_no_double_emit(self):
+    # validate.py provisions prepaids with asset_element_id == credit_element_id.
+    # The credit fact already carries the drawdown, so the NBV branch must skip
+    # to avoid a duplicate instant fact on the same element/period.
+    facts = self._credit_facts(
+      _mock_session(), credit_balance_type="debit", asset_element_id="elem_cr"
+    )
+    assert [f.value for f in facts] == [800.0, 400.0, 0.0]
+
+
 class TestCreateScheduleSumEqualsRule:
   """create_schedule auto-generates a SumEquals Rule when original_amount > 0."""
 
   def _run(self, session, *, original_amount: int | None = 120_000):
     svc = ScheduleService()
     # taxonomy_id is provided so _ensure_schedule_taxonomy is skipped.
-    # Two execute() calls now: (1) the cm:Debit/cm:Credit posting-role lookup
-    # for has-part arcs (no roles in the mock → arcs skipped), then (2) the
-    # Element.qname lookup for the SumEquals rule (when original_dollars is
-    # not None).
+    # Three execute() calls now: (1) the cm:Debit/cm:Credit posting-role lookup
+    # for has-part arcs (no roles in the mock → arcs skipped), (2) the credit
+    # element's balance_type lookup (a contra here → credit fact accumulates),
+    # then (3) the Element.qname lookup for the SumEquals rule.
     cm_roles_row = MagicMock()
     cm_roles_row.scalars.return_value = []
+    credit_balance_row = MagicMock()
+    credit_balance_row.scalar.return_value = "credit"
     debit_qname_row = MagicMock()
     debit_qname_row.scalar.return_value = "fac:DeprExpense"
 
-    session.execute.side_effect = [cm_roles_row, debit_qname_row]
+    session.execute.side_effect = [cm_roles_row, credit_balance_row, debit_qname_row]
 
     metadata = (
       ScheduleMetadata(


### PR DESCRIPTION
## Summary

The schedule credit fact hardcoded `value=accumulated_debit`, which is correct only for a contra-asset (Accumulated Depreciation) or liability that the period credit *increases*. For an asset credited directly (a prepaid), the credit *decreases* the balance — so prepaid amortization schedules rendered their asset **climbing** (e.g. the "Cloud Hosting (AWS Savings Plan)" prepaid growing toward $600) instead of drawing down to zero. This fixes the direction by deriving it from the credited account's normal balance.

## Changes

`operations/roboledger/schedules/service.py`
- Look up the credit element's `balance_type` once per schedule and set the credit fact's running balance accordingly:
  - **credit-balance** account (contra-asset / liability) → accumulates: `value = Σ debits` (unchanged).
  - **debit-balance** account (asset drawn down, e.g. a prepaid) → draws down: `value = original − Σ debits`.
  - Falls back to the accumulating form when there's no `original_amount` to anchor the opening.
- Skip the net-book-value fact when `asset_element_id == credit_element_id` (the `validate.py` prepaid pattern). The credit fact already carries that account's running balance, so emitting NBV would double-stamp the same element/period.

`tests/operations/roboledger/schedules/test_service.py`
- New `TestCreateScheduleCreditDirection`: contra accumulates, directly-credited asset draws down, and the no-double-emit guard.
- Updated the SumEquals rule mock for the new per-schedule `balance_type` lookup.

## Testing

- **`ruff` + `basedpyright`**: clean (pre-commit hooks pass).
- **Unit**: 100 schedule-related tests pass across `tests/operations/roboledger/schedules`, `commands/test_schedules.py`, the MCP schedule tools, the IB schedule handlers, and schedule-entry-due.
- **End-to-end** on a fresh `just demo-roboledger`: the Cloud Hosting prepaid draws down `$550 → $0` over 12 months; the Computer Equipment depreciation contra still accumulates `$133.33 → $266.66 → …`.
- **`just test-all` full suite**: not run this session.

## Notes

- Sits on top of the merged cm framework (#747); the credit-fact direction and the has-part arcs are independent concerns.
- The **close operation is unchanged** — it still reads the debit/credit accounts from the `entry_template` JSONB. This fix only corrects the *displayed running balance* of the credited account, not the generated closing entries.
