### PR TITLE
feat(schedules): emit a roll-forward opening balance fact

### DIFF
--- a/robosystems/operations/roboledger/schedules/service.py
+++ b/robosystems/operations/roboledger/schedules/service.py
@@ -383,6 +383,56 @@ class ScheduleService:
         round(c / 100.0, 2) for c in schedule_metadata.periodic_amounts
       ]
 
+    # Roll-forward opening balances. A roll_forward block has a Beginning
+    # Balance, so every rolled balance gets one instant fact at the schedule's
+    # first-period start (accumulated = 0) — making the series Begin → movements
+    # → End rather than starting after the first movement. Same formulas as the
+    # in-loop balance/NBV facts at accumulated_debit == 0: a contra opens at 0;
+    # a directly-credited asset (and the net-book-value asset) opens at gross.
+    if periods:
+      opening_instant = periods[0][0]
+      opening_scope = (
+        "historical"
+        if closed_through and opening_instant <= closed_through
+        else "in_scope"
+      )
+      opening_credit_value = (
+        original_dollars if credit_draws_down and original_dollars is not None else 0.0
+      )
+      session.add(
+        Fact(
+          element_id=entry_template.credit_element_id,
+          value=opening_credit_value,
+          period_start=None,
+          period_end=opening_instant,
+          period_type="instant",
+          unit="USD",
+          entity_id=entity_id,
+          structure_id=structure.id,
+          fact_set_id=fact_set_id,
+          fact_scope=opening_scope,
+        )
+      )
+      if (
+        schedule_metadata
+        and schedule_metadata.asset_element_id
+        and schedule_metadata.asset_element_id != entry_template.credit_element_id
+      ):
+        session.add(
+          Fact(
+            element_id=schedule_metadata.asset_element_id,
+            value=original_dollars or amount_dollars,
+            period_start=None,
+            period_end=opening_instant,
+            period_type="instant",
+            unit="USD",
+            entity_id=entity_id,
+            structure_id=structure.id,
+            fact_set_id=fact_set_id,
+            fact_scope=opening_scope,
+          )
+        )
+
     accumulated_debit = 0.0
 
     for i, (p_start, p_end) in enumerate(periods):

--- a/tests/operations/roboledger/schedules/test_service.py
+++ b/tests/operations/roboledger/schedules/test_service.py
@@ -251,14 +251,14 @@ class TestCreateSchedule:
       for call in session.add.call_args_list
       if hasattr(call[0][0], "fact_scope")
     ]
-    # 2 facts per month x 12 months = 24 fact objects
-    assert len(fact_objects) == 24
+    # 2 facts per month x 12 months = 24, + 1 roll-forward opening = 25
+    assert len(fact_objects) == 25
 
     historical = [f for f in fact_objects if f.fact_scope == "historical"]
     in_scope = [f for f in fact_objects if f.fact_scope == "in_scope"]
 
-    # Jan-Jun (6 months x 2 facts = 12) = historical
-    assert len(historical) == 12
+    # Jan-Jun (6 months x 2 facts = 12) + the opening (period_end Jan 1) = 13
+    assert len(historical) == 13
     # Jul-Dec (6 months x 2 facts = 12) = in_scope
     assert len(in_scope) == 12
 
@@ -294,10 +294,10 @@ class TestCreateSchedule:
       for call in session.add.call_args_list
       if hasattr(call[0][0], "fact_scope")
     ]
-    # Jan (2 facts) + Feb (2 facts) = 4 historical. Mar (2 facts) = 2 in_scope.
+    # Jan (2) + Feb (2) + the opening (period_end Jan 1) = 5 historical. Mar (2) = 2 in_scope.
     historical = [f for f in fact_objects if f.fact_scope == "historical"]
     in_scope = [f for f in fact_objects if f.fact_scope == "in_scope"]
-    assert len(historical) == 4
+    assert len(historical) == 5
     assert len(in_scope) == 2
 
   def test_rounding_prevents_drift(self):
@@ -448,21 +448,33 @@ class TestCreateScheduleCreditDirection:
     ]
 
   def test_contra_credit_accumulates(self):
+    # opening (0) + 3 accumulating endings
     facts = self._credit_facts(_mock_session(), credit_balance_type="credit")
-    assert [f.value for f in facts] == [400.0, 800.0, 1200.0]
+    assert [f.value for f in facts] == [0.0, 400.0, 800.0, 1200.0]
 
   def test_directly_credited_asset_draws_down(self):
+    # opening (1200 gross) + 3 drawing-down endings
     facts = self._credit_facts(_mock_session(), credit_balance_type="debit")
-    assert [f.value for f in facts] == [800.0, 400.0, 0.0]
+    assert [f.value for f in facts] == [1200.0, 800.0, 400.0, 0.0]
 
   def test_asset_equals_credit_element_no_double_emit(self):
     # validate.py provisions prepaids with asset_element_id == credit_element_id.
     # The credit fact already carries the drawdown, so the NBV branch must skip
-    # to avoid a duplicate instant fact on the same element/period.
+    # to avoid a duplicate instant fact on the same element/period (opening too).
     facts = self._credit_facts(
       _mock_session(), credit_balance_type="debit", asset_element_id="elem_cr"
     )
-    assert [f.value for f in facts] == [800.0, 400.0, 0.0]
+    assert [f.value for f in facts] == [1200.0, 800.0, 400.0, 0.0]
+
+  def test_opening_balance_fact_at_schedule_start(self):
+    # A roll_forward block needs a Beginning Balance: one instant fact at the
+    # first period's start, accumulated = 0 (gross for a drawdown asset).
+    facts = self._credit_facts(_mock_session(), credit_balance_type="debit")
+    opening = facts[0]
+    assert opening.period_type == "instant"
+    assert opening.period_start is None
+    assert opening.period_end == date(2026, 1, 1)
+    assert opening.value == 1200.0
 
 
 class TestCreateScheduleSumEqualsRule:


### PR DESCRIPTION
## Summary

A schedule is a `roll_forward` block, but it only emitted per-period *ending* balances — so the series started after the first movement, with no **Beginning Balance** (Charlie Hoffman's MINI reference has one on every roll-forward). The opening was only derivable from the JSONB `original_amount`. This emits the opening balance as a first-class fact, making the schedule a faithful `Begin → movements → End` roll-forward.

## Changes

`operations/roboledger/schedules/service.py`
- Emit one **instant opening fact per rolled balance** at the schedule's first-period start (`accumulated = 0`), reusing the same direction logic as the per-period balances:
  - directly-credited asset (prepaid) → opens at the **gross outlay**, then draws down
  - contra (Accumulated Depreciation) → opens at **0**, then accumulates
  - the net-book-value asset (when a distinct `asset_element_id` is tracked) → opens at gross
- The opening carries a **null `period_start`** to mark it as the as-of-start Beginning Balance, distinct from the period-end balances. `fact_scope` follows the same historical/in_scope rule.
- Only the credit/balance side is touched.

`tests/operations/roboledger/schedules/test_service.py`
- Opening value/date for both directions (drawdown gross / contra 0), a dedicated `period_type`/`period_start`/`period_end` assertion, the no-double-emit guard, and the updated historical/in_scope scope counts.

## Testing

- **`ruff` + `basedpyright`**: clean (pre-commit hooks pass).
- **Unit**: 101 schedule-related tests pass (`tests/operations/roboledger/schedules`, `commands/test_schedules.py`, MCP schedule tools, IB schedule handlers, schedule-entry-due).
- **End-to-end** on a fresh `just demo-roboledger`: the Business Insurance prepaid opens `$1,200` (null period_start) then draws down to `$0`; Computer Equipment depreciation's Accumulated Depreciation opens `$0` then accumulates; exactly one opening fact per schedule.
- **`just test-all` full suite**: not run this session.

## Notes

- Builds on the cm framework (#747) and the prepaid drawdown fix (#748).
- The **close path is unaffected** — it reads `entry_template` + the debit-element (movement) facts; the opening is a credit/balance fact. The `SumEquals` rule sums debit movements, also unaffected.
- This makes the schedule an *honest single-movement* roll-forward. Still deferred (with Charlie's MINI as the spec): flow-concept movements (direction + reason), multi-movement roll-forwards (additions + depreciation + disposals), and a server-side roll-forward `view.rendering` so the UI shows Begin/movement/End rather than the current flat fact list.
