### PR TITLE
fix(migrations): fail-closed daemon entrypoint on migration failure

### DIFF
--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -205,7 +205,7 @@ case $DOCKER_PROFILE in
     # This mirrors the previous beat scheduler behavior
     if [[ "${RUN_MIGRATIONS:-}" == "true" ]]; then
       ensure_database_exists "${DAGSTER_POSTGRES_DB:-dagster}" || echo "Dagster database check failed, but continuing..."
-      run_db_init || echo "Database initialization failed, but continuing..."
+      run_db_init || { echo "✗ Database initialization failed — aborting daemon boot"; exit 1; }
     fi
 
     exec uv run dagster-daemon run \


### PR DESCRIPTION
## Summary

Makes the Dagster daemon entrypoint **fail-closed** on a migration failure. The dagster-daemon profile ran `run_db_init || echo "...continuing..."` and then `exec`'d the daemon regardless, so a failed platform **or** extensions migration would boot a half-migrated daemon and mount the surface silently.

Surfaced while validating the extensions production-release runbook, whose "fail-closed" safety claim was not actually true in code. This is on the critical path of the first-ever extensions DB creation (`0001→0018`), where a partial migration failure must be a visible deploy failure, not a silent half-migrated boot.

## Changes

- **`bin/entrypoint.sh`** (dagster-daemon profile): `run_db_init` failure now exits non-zero (`|| { echo "✗ Database initialization failed — aborting daemon boot"; exit 1; }`) instead of logging and continuing. A failed migration aborts the daemon boot → a visible ECS deploy failure.

## Behavior / safety

- Only fires at **daemon boot** (the daemon is a singleton and the sole migration runner), not in the steady-state hot path.
- `alembic upgrade head` is **idempotent**, so a *transient* failure self-heals on the ECS restart, while a *genuinely bad* migration crash-loops — which is the intended visible-deploy-failure signal.
- Also closes the same swallow-and-continue gap for **platform** migrations, not just extensions.

## Testing

- `just format` / lint ran via the pre-commit hook on commit — **all checks passed** (1525 files formatted, 0 errors, 0 warnings).
- `bash -n bin/entrypoint.sh` — syntax OK.
- Full `just test-all` not run this session (shell-only change; no Python touched).
- **Validate the abort path on the staging dress-rehearsal** (force a bad migration, confirm the daemon refuses to boot) before this rides into the extensions turn-on release.

## Notes / follow-ups

- The adjacent Dagster-DB existence check (`ensure_database_exists "dagster" || echo "...continuing..."`, line 207) was **intentionally left** as log-and-continue — different failure mode, lower stakes (the daemon fails to start on its own if that DB is truly missing). Tightening it for consistency is optional.
