### PR TITLE
fix(rate-limits): authed-tier identification + dedicated extensions categories

### DIFF
--- a/robosystems/config/rate_limits.py
+++ b/robosystems/config/rate_limits.py
@@ -51,6 +51,14 @@ class EndpointCategory(str, Enum):
   GRAPH_QUERY = "graph_query"  # Direct Cypher queries
   GRAPH_IMPORT = "graph_import"  # Bulk data imports
 
+  # Extensions surface (OLTP on shared RDS — distinct from LadybugDB categories)
+  EXTENSIONS_GRAPHQL = (
+    "extensions_graphql"  # Typed GraphQL reads: /extensions/{g}/graphql
+  )
+  EXTENSIONS_WRITE = (
+    "extensions_write"  # Command writes + views: /extensions/{d}/{g}/operations/*
+  )
+
   # Table operations (DuckDB staging tables)
   TABLE_QUERY = "table_query"  # SQL queries on staging tables
   TABLE_UPLOAD = "table_upload"  # File uploads to staging tables
@@ -114,6 +122,9 @@ class RateLimitConfig:
       EndpointCategory.GRAPH_SEARCH: (5, RateLimitPeriod.MINUTE),
       EndpointCategory.GRAPH_QUERY: (20, RateLimitPeriod.MINUTE),
       EndpointCategory.GRAPH_IMPORT: (2, RateLimitPeriod.MINUTE),
+      # Extensions surface (OLTP on shared RDS)
+      EndpointCategory.EXTENSIONS_GRAPHQL: (60, RateLimitPeriod.MINUTE),
+      EndpointCategory.EXTENSIONS_WRITE: (30, RateLimitPeriod.MINUTE),
       # Table operations
       EndpointCategory.TABLE_QUERY: (15, RateLimitPeriod.MINUTE),
       EndpointCategory.TABLE_UPLOAD: (5, RateLimitPeriod.MINUTE),
@@ -141,6 +152,9 @@ class RateLimitConfig:
       ),  # Shared OpenSearch t3.medium
       EndpointCategory.GRAPH_QUERY: (60, RateLimitPeriod.MINUTE),
       EndpointCategory.GRAPH_IMPORT: (10, RateLimitPeriod.MINUTE),
+      # Extensions surface (OLTP on shared RDS)
+      EndpointCategory.EXTENSIONS_GRAPHQL: (600, RateLimitPeriod.MINUTE),
+      EndpointCategory.EXTENSIONS_WRITE: (300, RateLimitPeriod.MINUTE),
       # Table operations
       EndpointCategory.TABLE_QUERY: (30, RateLimitPeriod.MINUTE),
       EndpointCategory.TABLE_UPLOAD: (10, RateLimitPeriod.MINUTE),
@@ -169,6 +183,9 @@ class RateLimitConfig:
       ),  # Shared OpenSearch t3.medium
       EndpointCategory.GRAPH_QUERY: (60, RateLimitPeriod.MINUTE),
       EndpointCategory.GRAPH_IMPORT: (10, RateLimitPeriod.MINUTE),
+      # Extensions surface (OLTP on shared RDS)
+      EndpointCategory.EXTENSIONS_GRAPHQL: (600, RateLimitPeriod.MINUTE),
+      EndpointCategory.EXTENSIONS_WRITE: (300, RateLimitPeriod.MINUTE),
       # Table operations
       EndpointCategory.TABLE_QUERY: (30, RateLimitPeriod.MINUTE),
       EndpointCategory.TABLE_UPLOAD: (10, RateLimitPeriod.MINUTE),
@@ -197,6 +214,9 @@ class RateLimitConfig:
       ),  # Shared OpenSearch t3.medium
       EndpointCategory.GRAPH_QUERY: (60, RateLimitPeriod.MINUTE),
       EndpointCategory.GRAPH_IMPORT: (10, RateLimitPeriod.MINUTE),
+      # Extensions surface (OLTP on shared RDS)
+      EndpointCategory.EXTENSIONS_GRAPHQL: (600, RateLimitPeriod.MINUTE),
+      EndpointCategory.EXTENSIONS_WRITE: (300, RateLimitPeriod.MINUTE),
       # Table operations
       EndpointCategory.TABLE_QUERY: (30, RateLimitPeriod.MINUTE),
       EndpointCategory.TABLE_UPLOAD: (10, RateLimitPeriod.MINUTE),
@@ -270,24 +290,23 @@ class RateLimitConfig:
     Returns:
         The endpoint category or None if not categorized
     """
-    # Extensions surface — both `/extensions/{graph_id}/graphql`
-    # (read) and `/extensions/{domain}/{graph_id}/operations/{op}`
-    # (write) are tenant-scoped, so they map to the same per-tier
-    # buckets as the legacy `/v1/graphs/{graph_id}/...` endpoints did.
+    # Extensions surface — OLTP on shared RDS, so it gets its own buckets
+    # (EXTENSIONS_GRAPHQL / EXTENSIONS_WRITE) independent of the LadybugDB
+    # graph categories, so the two backends can be tuned separately.
     # Checked BEFORE the `/v1/` prefix strip because the extensions
     # surface is mounted at the top level, not under `/v1/`.
     if path.startswith("/extensions/"):
       ext_parts = path[len("/extensions/") :].split("/")
-      # /extensions/{graph_id}/graphql → GRAPH_READ
+      # /extensions/{graph_id}/graphql → EXTENSIONS_GRAPHQL (typed OLTP reads)
       if len(ext_parts) >= 2 and ext_parts[1] == "graphql":
-        return EndpointCategory.GRAPH_READ
-      # /extensions/{domain}/{graph_id}/operations/{op_name} → GRAPH_WRITE
+        return EndpointCategory.EXTENSIONS_GRAPHQL
+      # /extensions/{domain}/{graph_id}/operations/{op_name} → EXTENSIONS_WRITE
+      # (command writes; analytical view operations ride here too for now).
       if len(ext_parts) >= 4 and ext_parts[2] == "operations":
-        return EndpointCategory.GRAPH_WRITE
-      # Fall through to the generic graph-write bucket for any future
-      # extensions endpoint that doesn't match the patterns above —
-      # safer than dropping out to the unbounded default.
-      return EndpointCategory.GRAPH_WRITE
+        return EndpointCategory.EXTENSIONS_WRITE
+      # Any other extensions endpoint (e.g. report bundle download) → the
+      # extensions write bucket rather than dropping to the unbounded default.
+      return EndpointCategory.EXTENSIONS_WRITE
 
     # Remove version prefix
     if path.startswith("/v1/"):

--- a/robosystems/middleware/rate_limits/rate_limiting.py
+++ b/robosystems/middleware/rate_limits/rate_limiting.py
@@ -38,8 +38,19 @@ def _verify_jwt_for_rate_limiting(token: str) -> str | None:
     if not secret_key:
       return None
 
-    # Properly validate JWT signature
-    payload = jwt.decode(token, secret_key, algorithms=["HS256"])
+    # Validate the signature, but skip audience/issuer checks. Tokens are
+    # minted with `aud`/`iss` claims (see middleware/auth/jwt.py), and PyJWT
+    # raises InvalidAudienceError when an `aud` claim is present but no
+    # `audience` is passed to decode(). That exception would be swallowed
+    # below and drop every authenticated request to the anonymous "base"
+    # rate-limit tier. For rate limiting we only need to identify the user,
+    # so the signature is what matters — not aud/iss.
+    payload = jwt.decode(
+      token,
+      secret_key,
+      algorithms=["HS256"],
+      options={"verify_aud": False, "verify_iss": False},
+    )
     return payload.get("user_id")
   except Exception:
     # If JWT is invalid, treat as unauthenticated for rate limiting

--- a/tests/config/test_rate_limits.py
+++ b/tests/config/test_rate_limits.py
@@ -86,6 +86,23 @@ def test_multiplier_can_be_skipped(monkeypatch):
     ("/v1/graphs/abc/import", "POST", EndpointCategory.GRAPH_IMPORT),
     ("/v1/graphs/abc/custom", "POST", EndpointCategory.GRAPH_WRITE),
     ("/v1/graphs/abc/custom", "GET", EndpointCategory.GRAPH_READ),
+    # Extensions surface (OLTP — distinct from LadybugDB graph categories)
+    ("/extensions/kg123/graphql", "POST", EndpointCategory.EXTENSIONS_GRAPHQL),
+    (
+      "/extensions/roboledger/kg123/operations/create-event-block",
+      "POST",
+      EndpointCategory.EXTENSIONS_WRITE,
+    ),
+    (
+      "/extensions/roboledger/kg123/operations/build-fact-grid",
+      "POST",
+      EndpointCategory.EXTENSIONS_WRITE,
+    ),
+    (
+      "/extensions/roboledger/kg123/reports/rep_1/download",
+      "GET",
+      EndpointCategory.EXTENSIONS_WRITE,
+    ),
     # Non-graph endpoints
     ("/v1/auth/login", "POST", EndpointCategory.AUTH),
     ("/v1/tasks/run", "POST", EndpointCategory.TASKS),

--- a/tests/middleware/rate_limits/test_rate_limiting.py
+++ b/tests/middleware/rate_limits/test_rate_limiting.py
@@ -1,11 +1,13 @@
 """Unit tests for rate limiting module."""
 
+from datetime import UTC
 from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
 
 from robosystems.middleware.rate_limits.rate_limiting import (
+  _verify_jwt_for_rate_limiting,
   create_custom_rate_limit_dependency,
   get_int_env,
   get_rate_limit_config,
@@ -87,6 +89,59 @@ class TestGetUserIdentifier:
     request = _make_request(host="1.2.3.4")
     result = get_user_identifier(request)
     assert result == "ip:1.2.3.4"
+
+
+@pytest.mark.unit
+class TestVerifyJwtForRateLimiting:
+  """Real-decode tests for _verify_jwt_for_rate_limiting (no mocks).
+
+  Regression: app tokens are minted with `aud`/`iss` claims (middleware/auth/
+  jwt.py). Decoding without passing audience/issuer must NOT raise — otherwise
+  every authenticated request silently drops to the anonymous "base" rate-limit
+  tier.
+  """
+
+  SECRET = "rate-limit-test-secret"
+
+  def _mint(self, claims):
+    import jwt as pyjwt
+
+    return pyjwt.encode(claims, self.SECRET, algorithm="HS256")
+
+  def _exp(self):
+    from datetime import datetime, timedelta
+
+    return datetime.now(UTC) + timedelta(hours=1)
+
+  def test_token_with_aud_iss_resolves_user(self):
+    from robosystems.config import env
+
+    token = self._mint(
+      {
+        "user_id": "usr_aud_iss",
+        "aud": "robosystems-aud",
+        "iss": "robosystems-iss",
+        "exp": self._exp(),
+      }
+    )
+    with patch.object(env, "JWT_SECRET_KEY", self.SECRET):
+      assert _verify_jwt_for_rate_limiting(token) == "usr_aud_iss"
+
+  def test_token_without_aud_iss_resolves_user(self):
+    from robosystems.config import env
+
+    token = self._mint({"user_id": "usr_plain", "exp": self._exp()})
+    with patch.object(env, "JWT_SECRET_KEY", self.SECRET):
+      assert _verify_jwt_for_rate_limiting(token) == "usr_plain"
+
+  def test_bad_signature_returns_none(self):
+    from robosystems.config import env
+
+    token = self._mint(
+      {"user_id": "usr_x", "aud": "robosystems-aud", "exp": self._exp()}
+    )
+    with patch.object(env, "JWT_SECRET_KEY", "a-different-secret"):
+      assert _verify_jwt_for_rate_limiting(token) is None
 
 
 @pytest.mark.unit

--- a/tests/middleware/rate_limits/test_subscription_rate_limiting.py
+++ b/tests/middleware/rate_limits/test_subscription_rate_limiting.py
@@ -101,41 +101,41 @@ class TestSubscriptionRateLimits:
     )
 
   def test_get_endpoint_category_for_extensions(self):
-    """Extensions paths must map to GRAPH_READ / GRAPH_WRITE buckets.
+    """Extensions paths map to the dedicated EXTENSIONS_* buckets.
 
-    Without this, `subscription_aware_rate_limit_dependency` would
-    look up `None` and fall through to the generic limiter — the
-    original regression that motivated this fix.
+    The extensions surface is OLTP on shared RDS, so it has its own
+    rate-limit categories independent of the LadybugDB graph categories.
+    (Mapping to None would fall through to the generic limiter.)
     """
-    # Graph-scoped GraphQL read → GRAPH_READ
+    # Graph-scoped GraphQL read → EXTENSIONS_GRAPHQL
     assert (
       get_endpoint_category("/extensions/kg1a2b3c/graphql", "POST")
-      == EndpointCategory.GRAPH_READ
+      == EndpointCategory.EXTENSIONS_GRAPHQL
     )
     # Subgraph IDs (with underscore) work too
     assert (
       get_endpoint_category("/extensions/kg1a2b3c_dev/graphql", "POST")
-      == EndpointCategory.GRAPH_READ
+      == EndpointCategory.EXTENSIONS_GRAPHQL
     )
-    # RoboLedger operations → GRAPH_WRITE
+    # RoboLedger operations → EXTENSIONS_WRITE
     assert (
       get_endpoint_category(
         "/extensions/roboledger/kg1a2b3c/operations/update-entity", "POST"
       )
-      == EndpointCategory.GRAPH_WRITE
+      == EndpointCategory.EXTENSIONS_WRITE
     )
     assert (
       get_endpoint_category(
         "/extensions/roboledger/kg1a2b3c/operations/close-period", "POST"
       )
-      == EndpointCategory.GRAPH_WRITE
+      == EndpointCategory.EXTENSIONS_WRITE
     )
-    # RoboInvestor operations → GRAPH_WRITE
+    # RoboInvestor operations → EXTENSIONS_WRITE
     assert (
       get_endpoint_category(
         "/extensions/roboinvestor/kg1a2b3c/operations/create-portfolio", "POST"
       )
-      == EndpointCategory.GRAPH_WRITE
+      == EndpointCategory.EXTENSIONS_WRITE
     )
 
   def test_get_subscription_rate_limit(self):


### PR DESCRIPTION
## Summary

While turning on the v1.5.0 extensions surface in production, the GraphQL and connection endpoints started returning 429s during normal use. Two root causes: (1) a JWT-decode bug pinned **every authenticated request to the anonymous `base` tier**, and (2) the extensions OLTP surface was bucketed into the **LadybugDB graph rate-limit categories**, so its limits couldn't be tuned independently and were far too low. This PR fixes both.

## Changes

**Authenticated-tier identification (`middleware/rate_limits/rate_limiting.py`)**
- `_verify_jwt_for_rate_limiting` decoded the session JWT with no `audience`/`issuer` args. Tokens are minted with `aud`/`iss` claims (`middleware/auth/jwt.py`), so PyJWT raised `InvalidAudienceError`, the bare `except` swallowed it, and `get_user_from_request` returned `None` → requests fell back to the `base` tier (e.g. `GRAPH_READ` 30/min, `GRAPH_SYNC` 3/min) instead of `ladybug-standard`.
- Now decodes with `verify_aud`/`verify_iss` disabled — the signature is still enforced; rate-limit identification only needs `user_id`.

**Dedicated extensions categories (`config/rate_limits.py`)**
- New `EndpointCategory.EXTENSIONS_GRAPHQL` and `EXTENSIONS_WRITE`. The extensions surface hits the shared extensions PostgreSQL (RDS) — a different backend/cost profile than LadybugDB — so it now has its own buckets instead of borrowing `GRAPH_READ` / `GRAPH_WRITE`.
- `get_endpoint_category` routes `/extensions/{g}/graphql` → `EXTENSIONS_GRAPHQL` and `/extensions/{d}/{g}/operations/*` (plus the report-download fallthrough) → `EXTENSIONS_WRITE`.
- Per-tier limits added to all four tiers: `base` 60/30, `ladybug-standard|large|xlarge` **600/min reads, 300/min writes** (sized for RDS). LadybugDB `GRAPH_READ`/`GRAPH_QUERY`/`GRAPH_ANALYTICS` are now fully independent.

**Tests**
- `tests/middleware/rate_limits/test_rate_limiting.py`: real-decode (un-mocked) regression tests for `_verify_jwt_for_rate_limiting` — token with `aud`/`iss` resolves the user, token without resolves, bad signature returns `None`. (Existing tests mocked the function entirely, which is how the bug shipped.)
- `tests/config/test_rate_limits.py`: categorization cases for the GraphQL endpoint, an operations write, an analytical view, and the report download.

## Testing

- `just test-code` (ruff + format + basedpyright + cf-lint): **passing**.
- `just test` / unit suite: **not run locally** — a prod SSM DB tunnel occupied `localhost:5432` this session, so pytest's DB fixtures hit prod RDS instead of the local test DB. The new tests are unit-level and will run in CI.

## Notes / Follow-ups

- Analytical view operations (`build-fact-grid`, `live-financial-statement`, `financial-statement-analysis`) ride `EXTENSIONS_WRITE` for now because they share the `operations/{name}` path shape; a precise view-name split (they're actually LadybugDB-backed reads) is a follow-up.
- Surfaced by the same review but **out of scope** here (tracked separately): SSM-tunable rate limits (remove the deploy-lock), the unused tier multiplier / all authenticated users flattened to `ladybug-standard`, the QuickBooks `redirect_uri` drift (authorize reads from the request, token-exchange from env), and a reaper for abandoned `pending_oauth` connections.
- Context: discovered during the production turn-on of the v1.5.0 extensions surface.
