### PR TITLE
fix(materialize): blue-green WIP bypasses per-node max_databases cap

### DIFF
--- a/robosystems/operations/extensions/materialize.py
+++ b/robosystems/operations/extensions/materialize.py
@@ -1424,8 +1424,12 @@ class ExtensionsMaterializer:
         logger.info(f"Cleaning up leftover WIP database {wip_id}")
         await client.delete_database(wip_id, preserve_duckdb=True)
 
-      # Step 2: Create fresh WIP database with schema
-      await self._ensure_database(client, wip_id, rebuild=False)
+      # Step 2: Create fresh WIP database with schema. Mark it is_subgraph so
+      # its creation bypasses the per-node max_databases cap — on a dedicated
+      # single-database instance the live primary already fills the quota, and
+      # the transient WIP would otherwise be rejected ("Maximum database
+      # capacity reached"). The WIP is deleted after the swap.
+      await self._ensure_database(client, wip_id, rebuild=False, is_subgraph=True)
 
       # Step 3: Look up which extensions are enabled on this graph so we only
       # stage and materialize tables whose graph node/rel tables actually exist.
@@ -1480,8 +1484,15 @@ class ExtensionsMaterializer:
     client: "GraphClient",
     graph_id: str,
     rebuild: bool,
+    is_subgraph: bool = False,
   ) -> None:
-    """Ensure the LadybugDB database exists with the graph schema."""
+    """Ensure the LadybugDB database exists with the graph schema.
+
+    ``is_subgraph=True`` makes the create bypass the per-node max_databases cap
+    (graph_api exempts is_subgraph creations in manager.py). Used for the
+    transient blue-green WIP so it can be built alongside the live primary on a
+    dedicated single-database instance; the primary still counts against the cap.
+    """
     from robosystems.schemas.loader import get_contextual_schema_loader
 
     db_exists = await client.database_exists(graph_id)
@@ -1493,7 +1504,9 @@ class ExtensionsMaterializer:
 
     if not db_exists:
       logger.info(f"Creating LadybugDB database for {graph_id}")
-      await client.create_database(graph_id, schema_type="entity")
+      await client.create_database(
+        graph_id, schema_type="entity", is_subgraph=is_subgraph
+      )
 
       # Install schemas for all extensions on this graph
       extensions = await self._get_graph_extensions(graph_id)


### PR DESCRIPTION
## Summary

Fixes extensions materialization failing on dedicated single-database instances with `Maximum database capacity reached (1)`. Surfaced on the first production tenant materialization (RoboLedger launch).

The blue-green materializer builds a transient `{graph_id}-wip` database next to the live primary, then swaps. But it created the WIP as a normal database, so on a `ladybug-standard` instance (`databases_per_instance: 1`) the live primary already fills the per-node quota and the WIP create is rejected — failing every rematerialization.

## Root cause

`graph_api` enforces a per-node database cap (`core/ladybug/manager.py:142`) but **exempts `is_subgraph` creations**. The SEC shared blue-green path relies on that exemption (the shared node hosts `sec` + `sec_historical` on `databases_per_instance: 1`). The extensions materializer's `_ensure_database` created the WIP **without** that flag, so it counted against the cap.

## Change

`robosystems/operations/extensions/materialize.py`
- `_ensure_database` gains an `is_subgraph: bool = False` passthrough to `client.create_database`.
- The blue-green WIP create passes `is_subgraph=True`, so the transient WIP bypasses the per-node cap (matching the SEC path). The **primary still counts** against the cap, and the WIP is deleted after the swap — so the allocation model ("1 customer per dedicated instance") is unchanged.

## Testing

- `just test-code` (ruff + format + basedpyright + cf-lint): **passing**.
- `tests/operations/extensions/test_materialize.py`: **not run locally** — the local Docker Postgres was down this session, so the DB-backed fixtures couldn't connect. The existing tests mock `create_database`, so the added kwarg is compatible; CI will run them. **Follow-up:** add an assertion that the blue-green WIP create passes `is_subgraph=True`.

## Notes

- Materializer-only change → ships in the normal app/dagster image; **no graph EC2 ASG refresh** and **no allocation-registry impact**.
- Deployed as a hotfix from `release/1.5.1` ahead of this PR; this PR back-ports the same commit to `main`.
