### PR TITLE
fix(tunnels): restore configured webserver desired count on exit, not 0

### DIFF
--- a/bin/tools/tunnels.sh
+++ b/bin/tools/tunnels.sh
@@ -20,10 +20,12 @@ API_ENDPOINT=""
 API_INTERNAL_ENDPOINT=""  # Service Discovery endpoint (bypasses ALB)
 API_ACCESS_MODE=""        # internal or public
 
-# Dagster webserver scale-on-demand tracking. The webserver defaults to 0 tasks
-# in CloudFormation (it's UI-only, reachable solely through this tunnel) so an
-# idle UI doesn't cost an on-demand Fargate task. We scale it to 1 while a
-# dagster tunnel is open, then back to 0 on exit.
+# Dagster webserver scale-on-demand tracking. The webserver is UI-only and
+# reachable solely through this tunnel, so when its configured desired count
+# (DAGSTER_WEBSERVER_DESIRED_COUNT_<ENV>) is 0 an idle UI costs no Fargate task.
+# We scale it to 1 while a dagster tunnel is open, then restore the configured
+# desired count on exit — so prod deployments that keep it up (for API-triggered
+# Dagster jobs) are NOT scaled back to 0.
 ENVIRONMENT=""
 WEBSERVER_SCALED_UP="false"
 WEBSERVER_WAIT_PID=""  # background `ecs wait services-stable` PID (overlaps with bastion boot)
@@ -414,12 +416,26 @@ wait_webserver_ready() {
 
 scale_webserver_down() {
     local environment=$1
-    echo -e "${YELLOW}Scaling Dagster webserver back down (-> 0)...${NC}"
+    # Restore the configured baseline desired count instead of forcing 0. When
+    # prod keeps the webserver up so API-triggered Dagster jobs (qb_sync,
+    # extensions materialize, etc.) can submit through it,
+    # DAGSTER_WEBSERVER_DESIRED_COUNT_<ENV> is >0 and the tunnel must not drop it.
+    local env_upper baseline
+    env_upper=$(echo "$environment" | tr '[:lower:]' '[:upper:]')
+    baseline=$(gh variable get "DAGSTER_WEBSERVER_DESIRED_COUNT_${env_upper}" 2>/dev/null || echo "0")
+    [[ "$baseline" =~ ^[0-9]+$ ]] || baseline=0
+
+    if [[ "$baseline" -ge 1 ]]; then
+        echo -e "${GREEN}✓ Leaving Dagster webserver at its configured desired count (${baseline})${NC}"
+        return 0
+    fi
+
+    echo -e "${YELLOW}Scaling Dagster webserver back down (-> ${baseline})...${NC}"
     aws ecs update-service \
         --cluster "robosystems-dagster-${environment}-cluster" \
         --service "robosystems-dagster-webserver-${environment}" \
-        --desired-count 0 --region "${AWS_REGION:-us-east-1}" >/dev/null 2>&1 || true
-    echo -e "${GREEN}✓ Dagster webserver scaled to 0${NC}"
+        --desired-count "$baseline" --region "${AWS_REGION:-us-east-1}" >/dev/null 2>&1 || true
+    echo -e "${GREEN}✓ Dagster webserver scaled to ${baseline}${NC}"
 }
 
 start_ssm_tunnel() {


### PR DESCRIPTION
## Summary

The dagster tunnel (`bin/tools/tunnels.sh`) scales the Dagster webserver 0→1 on open and **hardcoded it back to 0 on close**. Prod now keeps the webserver up because API-triggered Dagster jobs (`qb_sync`, extensions `materialize`, …) submit through its GraphQL endpoint — so the tunnel's on-close scale-to-0 repeatedly dropped the webserver out from under those jobs. This caused the QB-sync and materialize *"Failed to resolve webserver.dagster.prod.robosystems.local"* failures during the launch turn-on.

## Change

`scale_webserver_down` now reads `DAGSTER_WEBSERVER_DESIRED_COUNT_<ENV>` and restores **that** baseline instead of forcing `0` — skipping the scale-down entirely when the baseline is ≥1. The tunnel therefore never scales the webserver below its configured desired count, while still scaling back to 0 in environments that genuinely keep it at 0. The scale-**up** path is unchanged (it already no-ops when the webserver is already running).

## Testing

- `bash -n bin/tools/tunnels.sh` passes. Local developer tooling only — not deployed, no app/CI behavior change.

## Notes

- Companion to setting `DAGSTER_WEBSERVER_DESIRED_COUNT_PROD=1` during the launch turn-on (so API-triggered Dagster jobs can submit). With that var at 1, opening/closing a prod dagster tunnel no longer disrupts running jobs.
