### PR TITLE
fix(materialize): blue-green WIP inherits source graph extensions

### DIFF
--- a/robosystems/operations/extensions/materialize.py
+++ b/robosystems/operations/extensions/materialize.py
@@ -1533,6 +1533,13 @@ class ExtensionsMaterializer:
     from robosystems.db.platform import SessionFactory
     from robosystems.models.core import Graph
 
+    # Blue-green builds a transient "{graph_id}-wip" database that is not itself
+    # a row in the platform DB. Resolve the source graph so the WIP inherits the
+    # source's full extension set (e.g. roboinvestor) — otherwise the lookup
+    # misses and we fall back to roboledger-only, leaving the WIP without the
+    # roboinvestor node tables and breaking materialization of Portfolio et al.
+    graph_id = graph_id.removesuffix("-wip")
+
     try:
       with SessionFactory() as session:
         graph = session.execute(

--- a/tests/operations/extensions/test_materialize.py
+++ b/tests/operations/extensions/test_materialize.py
@@ -468,3 +468,44 @@ class TestExtensionsMaterializer:
       result = await materializer.materialize(GRAPH_ID)
 
     assert result.graph_id == GRAPH_ID
+
+  @pytest.mark.asyncio
+  async def test_get_graph_extensions_strips_wip_suffix(self):
+    """Blue-green builds a transient ``{graph_id}-wip`` database that is not a
+    row in the platform DB. ``_get_graph_extensions`` must strip the ``-wip``
+    suffix and resolve the source graph so the WIP inherits the source's full
+    extension set — otherwise the lookup misses, falls back to roboledger-only,
+    and materializing roboinvestor tables (Portfolio, …) fails."""
+    from robosystems.operations.extensions.materialize import ExtensionsMaterializer
+
+    base_id = "kg19ed34f81c37ba3f31fa"
+    captured = {}
+
+    class _FakeGraph:
+      schema_extensions = ["roboledger", "roboinvestor"]
+
+    class _FakeResult:
+      def scalar_one_or_none(self):
+        return _FakeGraph() if captured.get("id") == base_id else None
+
+    class _FakeSession:
+      def __enter__(self):
+        return self
+
+      def __exit__(self, *exc):
+        return False
+
+      def execute(self, stmt):
+        captured["id"] = next(iter(stmt.compile().params.values()))
+        return _FakeResult()
+
+    materializer = ExtensionsMaterializer()
+    with patch(
+      "robosystems.db.platform.SessionFactory",
+      return_value=_FakeSession(),
+    ):
+      exts = await materializer._get_graph_extensions(f"{base_id}-wip")
+
+    # -wip stripped before the lookup, so the source graph's extensions resolve
+    assert captured["id"] == base_id
+    assert exts == ["roboledger", "roboinvestor"]


### PR DESCRIPTION
## Summary

Blue-green extensions materialization builds a transient `{graph_id}-wip` LadybugDB database and resolved its schema via `_get_graph_extensions(wip_id)`. The `-wip` id is not a row in the platform DB, so the lookup missed and fell back to **roboledger-only** — leaving the WIP without the roboinvestor node tables and failing materialization with `Binder exception: Table Portfolio does not exist` for any graph that has roboinvestor enabled.

Fix: strip the `-wip` suffix at the top of `_get_graph_extensions` so the WIP inherits the **source graph's full extension set**. No-op for real graph_ids (none end in `-wip`).

## Why it was never seen before
Needs two conditions to co-occur, first true on the first prod tenant (Harbinger):
1. A graph whose `schema_extensions` actually includes `roboinvestor` (else the `['roboledger']` fallback is coincidentally correct). RoboInvestor was only enabled in prod this launch.
2. The **blue-green path** (`db_exists and rebuild`). The direct (first-materialize) path uses the real `graph_id` and was unaffected — only a *re-materialize* hits the `-wip` lookup.

## Follow-on to #754
This is the second of the two dedicated-single-DB-instance blue-green bugs. #754 fixed the per-node capacity cap (`is_subgraph=True` on the WIP create); this fixes the WIP schema-extension resolution. Same family, surfaced in sequence on the first prod tenant.

## Testing
- New regression test `test_get_graph_extensions_strips_wip_suffix`.
- `just test-code` green; validated against the real code path.
- **Verified live in prod** (already shipped via `release/1.5.1` @ `b958bf13`): WIP built with `['roboledger', 'roboinvestor']`, Portfolio/Security/Position materialized, blue-green swap completed (55 tables, 28,985 rows), graph `fresh` with 10,879 nodes.