### PR TITLE
fix(worker): inject Dagster postgres env for runless asset reporting

### DIFF
--- a/cloudformation/worker.yaml
+++ b/cloudformation/worker.yaml
@@ -429,8 +429,25 @@ Resources:
               - !Ref "AWS::NoValue"
             - Name: AWS_REGION
               Value: !Ref AWS::Region
+            # Dagster event-log storage — lets worker tasks report runless
+            # AssetMaterialization events to the Dagster asset catalog
+            # (graph_creation, subgraph_creation, graph_tier_upgrade,
+            # extensions_materialize). Without these the baked dagster.yaml's
+            # postgres storage can't resolve, and DagsterInstance.get() fails.
+            - Name: DAGSTER_HOME
+              Value: /app/dagster_home
+            - Name: DAGSTER_POSTGRES_HOST
+              Value: !Ref DatabaseEndpoint
+            - Name: DAGSTER_POSTGRES_PORT
+              Value: !Ref DatabasePort
+            - Name: DAGSTER_POSTGRES_USER
+              Value: "postgres"
+            - Name: DAGSTER_POSTGRES_DB
+              Value: dagster
           Secrets:
             - Name: POSTGRES_PASSWORD
+              ValueFrom: !Sub "arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:robosystems/${Environment}/postgres:POSTGRES_PASSWORD::"
+            - Name: DAGSTER_POSTGRES_PASSWORD
               ValueFrom: !Sub "arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:robosystems/${Environment}/postgres:POSTGRES_PASSWORD::"
 
   # ========================================


### PR DESCRIPTION
## Summary
The worker ECS task (`cloudformation/worker.yaml`) had **no `DAGSTER_*` env at all**, while the API (`api.yaml`) and Dagster (`dagster.yaml`) stacks both carry the full block. The worker image bakes `DAGSTER_HOME` + a `dagster.yaml` whose event-log storage is sourced from `DAGSTER_POSTGRES_*` env vars — so when a worker task calls `report_asset_materialization`, `DagsterInstance.get()` fails to construct (`DAGSTER_POSTGRES_USER … is not set`) and the report is dropped. It's fire-and-forget with success logged at DEBUG, so it went unnoticed.

This means **every** worker-task asset report has silently failed: `graph_creation`, `subgraph_creation`, `graph_tier_upgrade`, and `extensions_materialize`.

## Fix
Add `DAGSTER_HOME` + `DAGSTER_POSTGRES_{HOST,PORT,USER,DB}` and the `DAGSTER_POSTGRES_PASSWORD` secret to the worker container, mirroring `api.yaml`. Worker-emitted `AssetMaterialization`s then land in the Dagster asset catalog alongside the API- and job-emitted ones.

## Evidence (triangulated)
1. **Code** — `worker.yaml` had zero `DAGSTER_*`; `api.yaml`/`dagster.yaml` have the full block.
2. **Logs** — the only two `Failed to report AssetMaterialization` events in 18h of prod worker logs were the two worker tasks: `graph_creation` (Harbinger provisioning, 02:01 UTC) and `extensions_materialize` (18:31 UTC).
3. **Dagster UI** — every visible asset event (e.g. `user_graph_file_staging`) is API- or job-emitted (those stacks have the env); none are worker-emitted.

## Deploy note
Requires a **worker-stack deploy** (separate lifecycle from the materialize hotfix already live on `release/1.5.1`). cfn-lint passes.

## Testing
- `just cf-lint worker` ✓
- Observability-only; no app/runtime code change.

Surfaced during the v1.5.x prod launch — the manual extensions materialize ran fine in the worker but never appeared in the Dagster UI.