### PR TITLE
fix(materialize): materialize coa_mapping structure + guard edge FKs

### DIFF
--- a/robosystems/operations/extensions/materialize.py
+++ b/robosystems/operations/extensions/materialize.py
@@ -627,7 +627,13 @@ def _staging_sql(graph_id: str, entity_id: str, connstr: str) -> dict[str, str]:
       1.0::DOUBLE                     AS canonical_confidence,
       NULL::FLOAT[384]                AS embedding
     FROM postgres_scan('{c}', '{s}', 'structures')
-    WHERE block_type NOT IN ('chart_of_accounts', 'coa_mapping')
+    -- Exclude only the real chart_of_accounts structure — the synthetic
+    -- '{graph_id}_coa' node above stands in for it. coa_mapping IS
+    -- materialized so the curated 'mapping' associations (CoA -> rs-gaap)
+    -- have a valid parent Structure; excluding it left every
+    -- STRUCTURE_HAS_ASSOCIATION edge with a dangling FK, failing the whole
+    -- (transactional) COPY and leaving the table empty.
+    WHERE block_type NOT IN ('chart_of_accounts')
       AND is_active = true
   """
 
@@ -723,6 +729,10 @@ def _staging_sql(graph_id: str, entity_id: str, connstr: str) -> dict[str, str]:
     FROM postgres_scan('{c}', '{s}', 'associations')
     -- See _MATERIALIZED_ASSOCIATION_TYPES for the curated list.
     WHERE association_type IN {_MATERIALIZED_ASSOCIATION_TYPES_SQL}
+      -- Drop edges whose structure was not materialized (e.g. inactive) so a
+      -- single dangling FK can't fail the whole transactional COPY. Structure
+      -- nodes are staged before this edge table, so the semi-join is valid.
+      AND structure_id IN (SELECT identifier FROM Structure)
   """
 
   tables["ASSOCIATION_HAS_FROM_ELEMENT"] = f"""
@@ -769,6 +779,11 @@ def _staging_sql(graph_id: str, entity_id: str, connstr: str) -> dict[str, str]:
       element_id                      AS src,
       trait_id                        AS dst
     FROM postgres_scan('{c}', '{s}', 'element_traits')
+    -- Drop rows referencing an element/trait that was not materialized so a
+    -- single dangling FK can't fail the whole transactional COPY. Element and
+    -- Trait nodes are staged before this edge table.
+    WHERE element_id IN (SELECT identifier FROM Element)
+      AND trait_id IN (SELECT identifier FROM "Trait")
   """
 
   # Dimension junction tables (may be empty if no dimensions loaded yet)

--- a/tests/operations/extensions/test_materialize.py
+++ b/tests/operations/extensions/test_materialize.py
@@ -116,6 +116,33 @@ class TestStagingSql:
     assert "ChartOfAccounts" in tables["Structure"]
 
 
+class TestEdgeForeignKeyGuards:
+  """#757 — coa_mapping structures are materialized so curated 'mapping'
+  associations have a valid parent Structure, and edge tables semi-join their
+  node sets so one dangling FK can't fail the whole (transactional) COPY and
+  zero out the table."""
+
+  def test_structure_no_longer_excludes_coa_mapping(self):
+    tables = _staging_sql(GRAPH_ID, ENTITY_ID, CONNSTR)
+    sql = tables["Structure"]
+    # coa_mapping must NOT be in the exclusion list — its 'mapping' associations
+    # reference it as their parent structure.
+    assert "'coa_mapping'" not in sql
+    # the real chart_of_accounts is still excluded (synthetic node replaces it).
+    assert "'chart_of_accounts'" in sql
+
+  def test_structure_has_association_guards_dangling_structure(self):
+    tables = _staging_sql(GRAPH_ID, ENTITY_ID, CONNSTR)
+    sql = tables["STRUCTURE_HAS_ASSOCIATION"]
+    assert "structure_id IN (SELECT identifier FROM Structure)" in sql
+
+  def test_element_has_trait_guards_dangling_refs(self):
+    tables = _staging_sql(GRAPH_ID, ENTITY_ID, CONNSTR)
+    sql = tables["ELEMENT_HAS_TRAIT"]
+    assert "element_id IN (SELECT identifier FROM Element)" in sql
+    assert 'trait_id IN (SELECT identifier FROM "Trait")' in sql
+
+
 class TestREAStaging:
   """REA primitives — Agent + Event nodes + 7 base edges + the
   EVENT_TRIGGERS_TRANSACTION McCarthy bridge edge.


### PR DESCRIPTION
Closes #757.

## Summary
On the first prod tenant's graph, `STRUCTURE_HAS_ASSOCIATION` and `ELEMENT_HAS_TRAIT` materialized **0 rows** — the entire (transactional) LadybugDB COPY of each failed on a single dangling foreign key, leaving associations unlinked from their parent Structure and elements from their traits. `build-fact-grid` and any graph-based structure/calc/mapping traversal were broken on that graph. (OLTP-backed reports were unaffected — they read Postgres, not the graph.)

## Root cause
`'mapping'` is in `_MATERIALIZED_ASSOCIATION_TYPES` (added deliberately so CoA→rs-gaap mappings aren't invisible), but those mapping associations belong to the `coa_mapping` **structure**, which the Structure-node staging *excluded* (`materialize.py:630`). Every mapping edge therefore referenced a non-materialized node, and one bad FK dropped **all ~730** `STRUCTURE_HAS_ASSOCIATION` edges — including the valid CoA / presentation / calculation ones. `ELEMENT_HAS_TRAIT` failed the same way on an `element_traits` row pointing outside the materialized Element set.

Measured live before the fix:

| table | count |
|---|---|
| Structure (nodes) | 54 |
| Association (nodes) | 730 (incl. 75 `mapping`) |
| STRUCTURE_HAS_ASSOCIATION | **0** ❌ |
| ELEMENT_HAS_TRAIT | **0** ❌ |
| ASSOCIATION_HAS_FROM/TO_ELEMENT | 730 / 730 ✅ |

## Fix (two parts)
1. **Intent** — stop excluding `coa_mapping` from Structure nodes (keep excluding the real `chart_of_accounts`, which the synthetic `{graph_id}_coa` node replaces) so mapping associations have a valid parent Structure.
2. **Robustness** — semi-join each edge's endpoints against the staged node tables (`STRUCTURE_HAS_ASSOCIATION` → `Structure`; `ELEMENT_HAS_TRAIT` → `Element`, `Trait`) so a dangling FK is dropped row-wise instead of failing the whole COPY. Node tables stage before edge tables, so the semi-joins are valid.

## Testing
- New `TestEdgeForeignKeyGuards` (3 tests); validated against real `_staging_sql` output.
- `just test-code` green.
- **Post-deploy verification pending**: re-materialize the prod graph and confirm `STRUCTURE_HAS_ASSOCIATION` / `ELEMENT_HAS_TRAIT` go from 0 → populated, then smoke `build-fact-grid`.

Surfaced during the v1.5.x prod launch.