### PR TITLE
fix(mcp): make the close workflow operable from the MCP surface alone

### DIFF
--- a/robosystems/middleware/mcp/tools/fiscal_calendar_tools.py
+++ b/robosystems/middleware/mcp/tools/fiscal_calendar_tools.py
@@ -89,6 +89,8 @@ class GetFiscalCalendarTool:
       "name": "get-fiscal-calendar",
       "description": """Get the current fiscal calendar state — what period is next to close, what's blocking it.
 
+**NEW TO THE CLOSE? Call `get-close-playbook` first** — it lays out the full tool sequence, the schedule-setup decisions, and the gotchas this tool's output assumes you know.
+
 **WHEN TO USE:**
 - At the START of every close session — check what period you're working on
 - Before calling close-period — verify it will succeed (check `closeable_now`)

--- a/robosystems/middleware/mcp/tools/manager.py
+++ b/robosystems/middleware/mcp/tools/manager.py
@@ -294,6 +294,15 @@ class GraphMCPTools:
       self.get_information_block_tool = GetInformationBlockTool(graph_client)
       self.list_information_blocks_tool = ListInformationBlocksTool(graph_client)
 
+    # Workflow playbook (guidance only — version-locked to this build).
+    # Pure read with no DB access, so it stays available on read-only graphs:
+    # an operator can learn the close workflow before they have write access.
+    self.get_close_playbook_tool = None
+    if self._has_extension("roboledger") and env.ROBOLEDGER_ENABLED:
+      from .playbook_tools import GetClosePlaybookTool
+
+      self.get_close_playbook_tool = GetClosePlaybookTool(graph_client)
+
     # Agent reads (get-agent, list-agents, agent-activity)
     self.get_agent_tool = None
     self.list_agents_tool = None
@@ -554,6 +563,10 @@ class GraphMCPTools:
     surface through the generic information-block read tools.
     """
     tools = []
+    # Playbook first so it's the most prominent close-workflow entry in the
+    # listing — it tells the agent how the rest of these tools compose.
+    if self.get_close_playbook_tool is not None:
+      tools.append(self.get_close_playbook_tool.get_tool_definition())
     if self.get_period_close_status_tool is not None:
       tools.append(self.get_period_close_status_tool.get_tool_definition())
     if self.list_period_drafts_tool is not None:
@@ -976,6 +989,15 @@ class GraphMCPTools:
             "Requires roboledger extension and ROBOLEDGER_ENABLED=true."
           )
         result = await self.list_period_drafts_tool.execute(arguments)
+        return result if return_raw else json.dumps(result, indent=2)
+
+      elif name == "get-close-playbook":
+        if self.get_close_playbook_tool is None:
+          raise ValueError(
+            "get-close-playbook tool is not available. "
+            "Requires roboledger extension and ROBOLEDGER_ENABLED=true."
+          )
+        result = await self.get_close_playbook_tool.execute(arguments)
         return result if return_raw else json.dumps(result, indent=2)
 
       # Information Block read tools (writes are registrar-generated, handled at Layer 0)

--- a/robosystems/middleware/mcp/tools/playbook_tools.py
+++ b/robosystems/middleware/mcp/tools/playbook_tools.py
@@ -1,0 +1,224 @@
+"""Workflow-playbook MCP tools.
+
+These tools carry no data and touch no database. Their only job is to
+**inform a multi-step workflow** — the canonical tool sequence, the
+decisions an operator has to make, and the gotchas that aren't obvious
+from any single tool's schema. They are the generic-workflow layer of the
+three-layer guidance model (generic playbook → per-tenant procedure doc →
+per-tenant data); see ``local/RoboSystems/specs/mcp-workflow-legibility.md``.
+
+Why a tool and not external docs: the content is **version-locked to the
+deployed build**. It ships in the same image as the tools it describes, so
+it can never drift from the actual tool names, schemas, or sequence — and
+it reaches every MCP client (Claude Code/Cowork *and* raw JSON-RPC
+callers), not just ones that happen to load a skill file.
+
+``get-close-playbook`` is the first one (the month-end close is the
+highest-value, fully-working MCP workflow today). It's a pure read, so it
+stays available on read-only graphs — an operator can learn the workflow
+before they have write access.
+"""
+
+from typing import Any
+
+# ── Playbook content (version-locked to this build) ──────────────────────────
+#
+# Authoritative source for the generic close workflow. Edit here when the
+# tool surface changes; keep tenant-specific steps in the per-tenant
+# procedures document, not in this constant.
+
+_RECURRING_SEQUENCE: list[str] = [
+  "get-fiscal-calendar — orient: read closed_through, close_target, "
+  "closeable_now, blockers, catch_up_sequence. Confirm the period you intend "
+  "to close is exactly closed_through + 1.",
+  "get-period-close-status (period_start/period_end as YYYY-MM-DD) — see "
+  "which schedules are pending / drafted / posted and their amounts.",
+  "promote-obligations (dispatch_handlers=true) — draft every matured "
+  "schedule's closing entry for the period in one sweep. This is how "
+  "schedule-derived drafts come into being; there is no create-closing-entry "
+  "tool. Idempotent.",
+  "(optional) create-event-block(event_type='journal_entry_recorded') — for "
+  "any manual / one-off adjusting entries that aren't schedule-driven.",
+  "list-period-drafts (period as YYYY-MM) — review every draft with DR/CR "
+  "detail; check all_balanced and the QB outbox fields "
+  "(will_publish_to_qb / qb_publish_count / local_only_count).",
+  "Summarize to the user (totals, balance check, per-schedule amounts, what "
+  "will publish to QuickBooks) and get explicit approval.",
+  "close-period (period as YYYY-MM) — atomic: posts the drafts, runs the "
+  "balance-sheet equation check, advances closed_through. Use "
+  "allow_stale_sync=true only when the user has verified QB is complete "
+  "despite a stale sync.",
+]
+
+_INITIATE_SEQUENCE: list[str] = [
+  "Discover the recurring adjusting entries this company books every month "
+  "(depreciation, amortization, prepaid roll-off, accruals). Two "
+  "complementary bootstrap modes — use both:",
+  "  • Derive from history — query a prior posted close to reconstruct the "
+  "recurring entries: read-graph-cypher / financial-statement-analysis, or "
+  "list-period-drafts on an already-closed period. History gives you the "
+  "resulting amounts and the accounts touched.",
+  "  • Interview the user — history gives amounts but NOT the schedule "
+  "parameters (cost basis, useful life, method, roll-off, disposal terms) "
+  "needed for forward-looking schedules. Ask for the source schedules (e.g. "
+  "the depreciation / amortization / prepaid worksheets). You can't infer "
+  "'5-yr straight-line on $2,544' from a $42.41/mo line.",
+  "For each recurring entry, create a schedule with "
+  "create-information-block(block_type='schedule'). See "
+  "SCHEDULE AUTHORING below — especially one-pair-per-schedule.",
+  "(recommended) Write a per-tenant 'Month-End Close Procedures' document "
+  "with create-document capturing THIS company's schedules, accounts, and "
+  "quirks. Have it reference this playbook for the generic mechanics. Future "
+  "closes start by reading it (search-documents).",
+  "Run the first close using the recurring sequence.",
+]
+
+_SCHEDULE_AUTHORING: list[str] = [
+  "ONE SCHEDULE = ONE debit element + ONE credit element pair. The "
+  "entry_template has a single debit_element_id and a single "
+  "credit_element_id — there is no multi-leg form. A real multi-line entry "
+  "(e.g. depreciation across several asset classes) is therefore MULTIPLE "
+  "schedules, one per asset/element pair, each with its own basis and its "
+  "own SumEquals proof. Do not try to cram several accounts into one "
+  "schedule.",
+  "USE COA ELEMENT IDs, NOT QNAMES. debit_element_id / credit_element_id / "
+  "element_ids take chart-of-accounts element ids (the `id` from "
+  "get-unmapped-elements / get-graph-schema), NOT taxonomy qnames like "
+  "'us-gaap:Depreciation'. Discover the real ids first with "
+  "get-unmapped-elements (match by name/code), get-graph-schema, "
+  "suggest-mapping, or read-graph-cypher — never invent them. (The "
+  "rollforward block type is the exception: it takes *_qname fields and "
+  "resolves them server-side.)",
+  "PERIOD HORIZON: period_start..period_end is the schedule's full life — "
+  "for depreciation/amortization that's period_start + useful life; for a "
+  "prepaid it's the roll-off horizon. These schedules are finite by design, "
+  "not open-ended; if you don't know the useful life, that's exactly what "
+  "the interview must establish (history gives the monthly amount, not the "
+  "horizon).",
+  "OMITTING schedule_metadata IS SAFE. The SumEquals proof is only generated "
+  "when you supply original_amount (cost basis); a monthly_amount-only "
+  "schedule simply books monthly_amount each period with no failing rule. "
+  "Add schedule_metadata later when you have the basis/useful life.",
+  "AMOUNTS ARE IN CENTS. monthly_amount and every schedule_metadata amount "
+  "(original_amount, residual_value) are integer cents. $194.83 → 19483.",
+  "STRAIGHT-LINE vs CUSTOM CURVE: the default method distributes "
+  "monthly_amount evenly (final period absorbs rounding). For a non-linear "
+  "curve (effective-interest amortization, variable leases) set "
+  "schedule_metadata.periodic_amounts to explicit per-period cents — its "
+  "length must match the number of months and its sum must equal "
+  "original_amount.",
+  "INITIAL SETUP: set closed_through when a schedule's early facts are "
+  "already reflected in opening balances (so the close workflow ignores "
+  "them as 'historical').",
+]
+
+_KEY_RULES: list[str] = [
+  "PERIOD IDENTIFIERS VARY BY TOOL: list-period-drafts and close-period take "
+  "period='YYYY-MM'; get-period-close-status takes "
+  "period_start/period_end='YYYY-MM-DD'; the schedule payload's "
+  "period_start/period_end are dates ('YYYY-MM-DD'). Match each tool's shape.",
+  "NO create-closing-entry TOOL. Schedule drafts come from "
+  "promote-obligations (sweep) or "
+  "create-event-block(event_type='schedule_entry_due') (single schedule); "
+  "manual entries from create-event-block(event_type='journal_entry_recorded').",
+  "block_type ENUM OVERSTATES CAPABILITY: only 'schedule' and 'rollforward' "
+  "are constructible via create-information-block. The statement types "
+  "(balance_sheet, income_statement, cash_flow_statement, equity_statement, "
+  "comprehensive_income) and 'metric' return HTTP 501 — statements are built "
+  "via create-report.",
+  "CLOSE BLOCKERS: sequence_violation (close in order), period_incomplete "
+  "(month not over yet), sync_stale (QuickBooks sync older than period end), "
+  "calendar_not_initialized. Resolve before close-period; get-fiscal-calendar "
+  "reports them.",
+  "CHECK THE PER-TENANT PROCEDURES DOC FIRST: call search-documents for a "
+  "'close procedures' / 'month-end' document before authoring or closing. It "
+  "captures this company's specifics and should reference this playbook.",
+]
+
+
+def _build_playbook(mode: str) -> dict[str, Any]:
+  """Assemble the playbook payload for the requested mode."""
+  overview = (
+    "The month-end close turns a synced general ledger into a locked, "
+    "reported fiscal period. Recurring adjusting entries (depreciation, "
+    "amortization, prepaid roll-off) are modeled as SCHEDULES that "
+    "auto-emit period obligations; closing a period drafts those entries, "
+    "posts them, and advances the calendar. Run get-close-playbook whenever "
+    "you're unsure of the sequence — it is version-locked to this build."
+  )
+  payload: dict[str, Any] = {
+    "version_note": (
+      "Version-locked to the deployed build: tool names, the sequence, and "
+      "the rules below match the tools currently exposed by this server."
+    ),
+    "mode": mode,
+    "overview": overview,
+  }
+  if mode in ("initiate", "overview"):
+    payload["initiate_first_close"] = _INITIATE_SEQUENCE
+    payload["schedule_authoring"] = _SCHEDULE_AUTHORING
+  if mode in ("recurring", "overview"):
+    payload["recurring_close_sequence"] = _RECURRING_SEQUENCE
+  payload["key_rules"] = _KEY_RULES
+  payload["related_tools"] = [
+    "get-fiscal-calendar",
+    "get-period-close-status",
+    "create-information-block",
+    "promote-obligations",
+    "create-event-block",
+    "list-period-drafts",
+    "close-period",
+    "search-documents",
+    "get-graph-schema",
+    "get-unmapped-elements",
+    "suggest-mapping",
+  ]
+  return payload
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# get-close-playbook
+# ────────────────────────────────────────────────────────────────────────────
+
+
+class GetClosePlaybookTool:
+  """Return the version-locked month-end close playbook (guidance only)."""
+
+  def __init__(self, graph_client):
+    self.client = graph_client
+
+  def get_tool_definition(self) -> dict[str, Any]:
+    return {
+      "name": "get-close-playbook",
+      "description": """Get the canonical month-end close playbook — the tool sequence, the setup decisions, and the gotchas that no single tool's schema makes obvious. **Call this FIRST when setting up or running a close** (or whenever you're unsure what to call next). Guidance only — no data, no side effects, safe on read-only graphs. Version-locked to this build, so it never drifts from the actual tools.
+
+**WHEN TO USE:**
+- Before authoring recurring schedules (depreciation/amortization/prepaid) for the first time → mode="initiate"
+- Before running a monthly close → mode="recurring"
+- Any time the close workflow is unclear → mode="overview" (default)
+
+**ALSO READ:** call `search-documents` for this company's own "close procedures" document — it captures tenant-specific accounts/quirks and references this generic playbook.
+
+**RETURNS:** the close overview, the ordered tool sequence for the chosen mode, schedule-authoring rules (incl. one-schedule-per-debit/credit-pair), and key gotchas (period-identifier shapes, amounts-in-cents, which block types 501, close blockers).""",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "mode": {
+            "type": "string",
+            "enum": ["overview", "initiate", "recurring"],
+            "description": (
+              "Which slice of the playbook to return. 'initiate' = first-time "
+              "setup (bootstrap schedules from history + interview). "
+              "'recurring' = run a monthly close. 'overview' (default) = both."
+            ),
+          },
+        },
+        "required": [],
+      },
+    }
+
+  async def execute(self, arguments: dict[str, Any]) -> Any:
+    mode = arguments.get("mode") or "overview"
+    if mode not in ("overview", "initiate", "recurring"):
+      mode = "overview"
+    return _build_playbook(mode)

--- a/robosystems/middleware/mcp/tools/playbook_tools.py
+++ b/robosystems/middleware/mcp/tools/playbook_tools.py
@@ -51,6 +51,14 @@ _RECURRING_SEQUENCE: list[str] = [
 ]
 
 _INITIATE_SEQUENCE: list[str] = [
+  "ORIENT FIRST — call get-fiscal-calendar and read `closed_through` (the "
+  "watermark) and `close_target`. `closed_through` may be a BASELINE set at "
+  "initialization (e.g. '2026-05') even when those months were never closed "
+  "period-by-period in RoboLedger — the books were maintained elsewhere "
+  "(QuickBooks) and the watermark says 'treat everything through here as "
+  "already handled'. The first close you'll run is `closed_through + 1`. "
+  "Note this date — every schedule you create must carry the matching "
+  "`closed_through` (see SCHEDULE AUTHORING).",
   "Discover the recurring adjusting entries this company books every month "
   "(depreciation, amortization, prepaid roll-off, accruals). Two "
   "complementary bootstrap modes — use both:",
@@ -65,7 +73,9 @@ _INITIATE_SEQUENCE: list[str] = [
   "'5-yr straight-line on $2,544' from a $42.41/mo line.",
   "For each recurring entry, create a schedule with "
   "create-information-block(block_type='schedule'). See "
-  "SCHEDULE AUTHORING below — especially one-pair-per-schedule.",
+  "SCHEDULE AUTHORING below — especially one-pair-per-schedule and the "
+  "closed_through watermark rule (a schedule that omits it will block the "
+  "first close).",
   "(recommended) Write a per-tenant 'Month-End Close Procedures' document "
   "with create-document capturing THIS company's schedules, accounts, and "
   "quirks. Have it reference this playbook for the generic mechanics. Future "
@@ -107,9 +117,18 @@ _SCHEDULE_AUTHORING: list[str] = [
   "schedule_metadata.periodic_amounts to explicit per-period cents — its "
   "length must match the number of months and its sum must equal "
   "original_amount.",
-  "INITIAL SETUP: set closed_through when a schedule's early facts are "
-  "already reflected in opening balances (so the close workflow ignores "
-  "them as 'historical').",
+  "MATCH THE CALENDAR WATERMARK — set the schedule's closed_through to the "
+  "last day of the calendar's closed_through month (calendar '2026-05' → "
+  "schedule closed_through '2026-05-31'). This flags every period at/before "
+  "the watermark as 'historical' and emits their obligations as 'voided', so "
+  "the close workflow starts drafting at the first open period (e.g. June). "
+  "This is the SAME rule whether those prior months were actually closed in "
+  "RoboLedger or just baseline-watermarked at initialization. WARNING: if "
+  "you omit closed_through (or set it earlier), every pre-watermark period "
+  "becomes a 'pending' obligation, and the first close is BLOCKED with the "
+  "pending_obligations gate (earliest_pending_period pointing months back). "
+  "Conversely, re-drafting an already-closed month creates duplicate "
+  "entries — the watermark prevents both.",
 ]
 
 _KEY_RULES: list[str] = [
@@ -128,8 +147,12 @@ _KEY_RULES: list[str] = [
   "via create-report.",
   "CLOSE BLOCKERS: sequence_violation (close in order), period_incomplete "
   "(month not over yet), sync_stale (QuickBooks sync older than period end), "
-  "calendar_not_initialized. Resolve before close-period; get-fiscal-calendar "
-  "reports them.",
+  "calendar_not_initialized, and pending_obligations (matured "
+  "schedule_entry_due events still 'pending' at/before the period — run "
+  "promote-obligations to draft them, or, if they belong to a "
+  "pre-watermark month that should never close, the schedule's "
+  "closed_through was set wrong; earliest_pending_period names the oldest "
+  "one). Resolve before close-period; get-fiscal-calendar reports them.",
   "CHECK THE PER-TENANT PROCEDURES DOC FIRST: call search-documents for a "
   "'close procedures' / 'month-end' document before authoring or closing. It "
   "captures this company's specifics and should reference this playbook.",

--- a/robosystems/middleware/mcp/tools/registrar.py
+++ b/robosystems/middleware/mcp/tools/registrar.py
@@ -64,11 +64,18 @@ def derive_input_schema(request_model: type[BaseModel]) -> dict[str, Any]:
   Discriminated-union ``RootModel`` request bodies (e.g.
   ``CreateInformationBlockRequest``) emit a schema with top-level
   ``oneOf`` / ``anyOf``. Anthropic's tool-call API rejects top-level
-  unions in tool ``input_schema``; we flatten those into a permissive
-  object envelope here. Strict validation still happens at dispatch
-  time (the registrar re-parses the payload through the original
-  ``request_model``), so the API contract is unchanged — only the
-  MCP-side schema readability is reduced. See
+  unions in tool ``input_schema``; we flatten those into an object
+  envelope here — ``{<discriminator>: enum, payload: …}``. When the
+  union's arms carry **typed** payloads (the schedule arm of
+  ``CreateInformationBlockRequest`` does), the flattener preserves each
+  arm's payload schema under a nested ``payload.anyOf`` and hoists the
+  arms' ``examples`` to the envelope, so a codebase-blind MCP client can
+  see the real field names instead of an opaque blob. Nested unions are
+  safe here — Pydantic ``Optional[...]`` fields already emit nested
+  ``anyOf`` that flow through unchanged; only the *top level* is
+  forbidden. Strict validation still happens at dispatch time (the
+  registrar re-parses the payload through the original
+  ``request_model``), so the wire contract is unchanged. See
   ``_flatten_top_level_union`` below for the envelope shape.
   """
   schema = request_model.model_json_schema(mode="serialization")
@@ -102,18 +109,28 @@ def derive_input_schema(request_model: type[BaseModel]) -> dict[str, Any]:
 
 def _flatten_top_level_union(schema: dict[str, Any]) -> dict[str, Any]:
   """Collapse a top-level ``oneOf`` / ``anyOf`` / ``allOf`` schema into
-  a permissive object envelope that Anthropic's tool API accepts.
+  an object envelope that Anthropic's tool API accepts.
 
   The output shape:
 
-  - When a discriminator is present (Pydantic's standard pattern):
+  - **Typed arms** (at least one arm exposes a structured ``payload``):
+    ``{type: object, properties: {<discriminator>: {type: string,
+    enum: [...]}, payload: {anyOf: [<per-arm payload schema>, …]}},
+    required: [<discriminator>, payload], examples: [...],
+    additionalProperties: True}``. The per-arm payload schemas carry the
+    real field names so a codebase-blind MCP client can construct a valid
+    call; ``examples`` holds the arms' copy-pasteable request bodies.
+
+  - **Untyped arms** (every arm's payload is a freeform ``dict``):
     ``{type: object, properties: {<discriminator>: {type: string,
     enum: [...]}, payload: {type: object, additionalProperties: True}},
-    required: [<discriminator>], additionalProperties: True}``
+    required: [<discriminator>], additionalProperties: True}`` — the
+    permissive shape, since there is nothing structured to advertise.
 
-  - When no discriminator is declared: a permissive object envelope
-    (``additionalProperties: True``) with the original ``description``
-    preserved.
+  - When no discriminator is declared, or the arms don't follow the
+    standard ``{<discriminator>, payload}`` shape: a permissive object
+    envelope (``additionalProperties: True``) with the original
+    ``description`` preserved.
 
   Dispatch-time Pydantic validation still enforces the per-arm shape,
   so callers passing an invalid payload get a clean ValidationError at
@@ -128,36 +145,149 @@ def _flatten_top_level_union(schema: dict[str, Any]) -> dict[str, Any]:
     flattened["description"] = description
 
   discriminator = schema.get("discriminator")
-  if isinstance(discriminator, dict):
-    prop_name = discriminator.get("propertyName")
+  if not isinstance(discriminator, dict):
+    return flattened
+  prop_name = discriminator.get("propertyName")
+  if not prop_name:
+    return flattened
+
+  arms = schema.get("oneOf") or schema.get("anyOf") or []
+  parsed = _parse_union_arms(arms, prop_name)
+
+  if parsed is None:
+    # Arms don't follow the standard ``{<discriminator>, payload}`` shape.
+    # Fall back to a discriminator-only envelope using the mapping keys.
     mapping = discriminator.get("mapping") or {}
-    if prop_name:
-      enum_values = sorted(mapping.keys()) if mapping else None
-      discriminator_schema: dict[str, Any] = {
-        "type": "string",
-        "description": (
-          f"Discriminator — selects the variant. Allowed values: "
-          f"{', '.join(enum_values)}."
-          if enum_values
-          else "Discriminator value selecting the request variant."
-        ),
-      }
-      if enum_values:
-        discriminator_schema["enum"] = enum_values
-      flattened["properties"] = {
-        prop_name: discriminator_schema,
-        "payload": {
-          "type": "object",
-          "description": (
-            "Variant payload. Shape depends on the discriminator value; "
-            "validated against the corresponding Pydantic arm at "
-            "dispatch time."
-          ),
-          "additionalProperties": True,
-        },
-      }
+    enum_values = sorted(mapping.keys()) if mapping else None
+    flattened["properties"] = {
+      prop_name: _discriminator_schema(enum_values),
+    }
+    if enum_values:
       flattened["required"] = [prop_name]
+    return flattened
+
+  enum_values, payload_options, examples = parsed
+  flattened["properties"] = {prop_name: _discriminator_schema(enum_values)}
+
+  has_typed_payload = any(_is_typed_object(opt[1]) for opt in payload_options)
+  if has_typed_payload:
+    flattened["properties"]["payload"] = _payload_anyof_schema(
+      payload_options, prop_name
+    )
+    flattened["required"] = [prop_name, "payload"]
+    if examples:
+      flattened["examples"] = examples
+  else:
+    # Nothing structured to advertise — keep the permissive payload.
+    flattened["properties"]["payload"] = {
+      "type": "object",
+      "description": (
+        "Variant payload. Shape depends on the discriminator value; "
+        "validated against the corresponding Pydantic arm at dispatch time."
+      ),
+      "additionalProperties": True,
+    }
+    flattened["required"] = [prop_name]
   return flattened
+
+
+def _discriminator_schema(enum_values: list[str] | None) -> dict[str, Any]:
+  """Build the JSON-schema fragment for the discriminator property."""
+  out: dict[str, Any] = {
+    "type": "string",
+    "description": (
+      f"Discriminator — selects the variant. Allowed values: {', '.join(enum_values)}."
+      if enum_values
+      else "Discriminator value selecting the request variant."
+    ),
+  }
+  if enum_values:
+    out["enum"] = enum_values
+  return out
+
+
+def _parse_union_arms(
+  arms: list[Any], prop_name: str
+) -> tuple[list[str], list[tuple[list[str], dict[str, Any]]], list[Any]] | None:
+  """Correlate each union arm to its discriminator value(s) + payload schema.
+
+  Returns ``(enum_values, payload_options, examples)`` where
+  ``payload_options`` is ``[(discriminator_values, payload_schema), …]``,
+  or ``None`` when any arm doesn't follow the standard
+  ``{<discriminator>, payload}`` object shape (signalling the caller to
+  fall back to a discriminator-only envelope).
+  """
+  if not arms:
+    return None
+  enum_values: list[str] = []
+  payload_options: list[tuple[list[str], dict[str, Any]]] = []
+  examples: list[Any] = []
+  for arm in arms:
+    if not isinstance(arm, dict):
+      return None
+    props = arm.get("properties")
+    if not isinstance(props, dict):
+      return None
+    values = _discriminator_values(props.get(prop_name))
+    payload_schema = props.get("payload")
+    if not values or not isinstance(payload_schema, dict):
+      return None
+    enum_values.extend(values)
+    payload_options.append((values, payload_schema))
+    for example in arm.get("examples") or []:
+      # Pydantic's ``json_schema_extra`` examples are OpenAPI-style
+      # ``{summary, description, value}`` objects; surface the raw value
+      # so the example is a copy-pasteable request body.
+      if isinstance(example, dict) and "value" in example:
+        examples.append(example["value"])
+      else:
+        examples.append(example)
+  # Dedupe + stabilise the enum for deterministic schemas.
+  enum_values = sorted(dict.fromkeys(enum_values))
+  return enum_values, payload_options, examples
+
+
+def _discriminator_values(disc_prop: Any) -> list[str]:
+  """Extract the discriminator value(s) an arm matches from its property
+  schema — Pydantic emits ``{"const": "x"}`` for a single ``Literal`` and
+  ``{"enum": [...]}`` for a multi-value one.
+  """
+  if not isinstance(disc_prop, dict):
+    return []
+  if "const" in disc_prop:
+    return [str(disc_prop["const"])]
+  enum = disc_prop.get("enum")
+  if isinstance(enum, list):
+    return [str(v) for v in enum]
+  return []
+
+
+def _is_typed_object(payload_schema: dict[str, Any]) -> bool:
+  """True when the payload advertises structured fields worth exposing
+  (an untyped ``dict`` payload renders with no ``properties``)."""
+  return bool(payload_schema.get("properties"))
+
+
+def _payload_anyof_schema(
+  payload_options: list[tuple[list[str], dict[str, Any]]], prop_name: str
+) -> dict[str, Any]:
+  """Build the ``payload`` schema as an ``anyOf`` over each arm's payload,
+  each option annotated with the discriminator value(s) it applies to.
+  """
+  options: list[dict[str, Any]] = []
+  for values, payload_schema in payload_options:
+    option = dict(payload_schema)
+    quoted = ", ".join(f"'{v}'" for v in values)
+    option["title"] = f"payload when {prop_name} is {quoted}"
+    options.append(option)
+  return {
+    "description": (
+      f"Variant payload — its shape depends on `{prop_name}`. Use the "
+      f"anyOf option whose title matches your `{prop_name}`. The example "
+      "request bodies show complete, valid payloads."
+    ),
+    "anyOf": options,
+  }
 
 
 def _inline_refs(node: Any, defs: dict[str, Any]) -> Any:

--- a/robosystems/middleware/mcp/tools/schedule_tools.py
+++ b/robosystems/middleware/mcp/tools/schedule_tools.py
@@ -130,10 +130,17 @@ class ListPeriodDraftsTool:
 - To review exactly what will be committed on close
 
 **WORKFLOW:**
-1. Draft entries via create-closing-entry (one per schedule)
+1. Draft entries come into being two ways — there is no `create-closing-entry`
+   tool:
+   - **Schedule-derived** (depreciation, amortization, prepaid roll-off):
+     call `promote-obligations` to draft every matured schedule entry for the
+     period in one sweep (the on-demand form of the background promoter), or
+     `create-event-block(event_type='schedule_entry_due')` to draft a single
+     schedule's entry.
+   - **Manual adjustments**: `create-event-block(event_type='journal_entry_recorded')`.
 2. Use this tool to review every draft with DR/CR detail
 3. Summarize to the user — total debits/credits, balance check, per-schedule amounts
-4. On user approval, call the close endpoint to commit + close atomically
+4. On user approval, call `close-period` to commit + close atomically
 
 **PARAMETERS:**
 - period: YYYY-MM format (e.g., "2026-03")

--- a/robosystems/middleware/mcp/tools/schedule_tools.py
+++ b/robosystems/middleware/mcp/tools/schedule_tools.py
@@ -14,16 +14,15 @@ with ``blockType="schedule"`` and ``get-information-block``. This
 module stays scoped to tools that operate across blocks rather than
 within one.
 
-Writes (``create-schedule``, ``update-schedule``, ``delete-schedule``)
-are registrar-generated from the roboledger ``OperationSpec``
-declarations. Closing-entry drafting goes through ``create-event-block``
-— ``event_type='schedule_entry_due'`` for schedule-derived drafts,
-``event_type='journal_entry_recorded'`` for free-form manual entries.
-Schedule termination (truncate forward facts) is handled internally by
-the ``asset_disposed`` event handler. The unified
-``create-information-block`` / ``update-information-block`` /
-``delete-information-block`` operations dispatch the same underlying
-schedule commands via the block-type registry.
+Schedule writes have no dedicated ops: schedules are created, updated,
+and deleted through the unified ``create-information-block`` /
+``update-information-block`` / ``delete-information-block`` operations
+(``block_type='schedule'``), which dispatch to the schedule commands via
+the block-type registry. Closing-entry drafting goes through
+``create-event-block`` — ``event_type='schedule_entry_due'`` for
+schedule-derived drafts, ``event_type='journal_entry_recorded'`` for
+free-form manual entries. Schedule termination (truncate forward facts)
+is handled internally by the ``asset_disposed`` event handler.
 """
 
 from datetime import date

--- a/robosystems/models/api/extensions/schedules.py
+++ b/robosystems/models/api/extensions/schedules.py
@@ -16,10 +16,21 @@ EntryType = Literal["standard", "adjusting", "closing", "reversing"]
 
 class EntryTemplateRequest(BaseModel):
   debit_element_id: str = Field(
-    ..., description="Element to debit (e.g., Depreciation Expense)"
+    ...,
+    description=(
+      "CoA element id to debit (e.g. Depreciation Expense). This is a "
+      "chart-of-accounts element id — the `id` returned by "
+      "get-unmapped-elements / get-graph-schema — NOT a taxonomy qname."
+    ),
   )
   credit_element_id: str = Field(
-    ..., description="Element to credit (e.g., Accumulated Depreciation)"
+    ...,
+    description=(
+      "CoA element id to credit (e.g. Accumulated Depreciation). A "
+      "chart-of-accounts element id (see get-unmapped-elements), not a "
+      "taxonomy qname. One template = one debit/credit pair; model a "
+      "multi-account entry as several schedules."
+    ),
   )
   entry_type: EntryType = Field(
     "closing", description="Entry type for generated entries"
@@ -72,7 +83,14 @@ class CreateScheduleRequest(BaseModel):
   taxonomy_id: str | None = Field(
     None, description="Taxonomy ID (auto-creates if omitted)"
   )
-  element_ids: list[str] = Field(..., description="Element IDs to include")
+  element_ids: list[str] = Field(
+    ...,
+    description=(
+      "CoA element ids the schedule touches (the `id` from "
+      "get-unmapped-elements, not taxonomy qnames) — typically the same "
+      "debit + credit ids used in entry_template."
+    ),
+  )
   period_start: date = Field(..., description="First period start")
   period_end: date = Field(..., description="Last period end")
   monthly_amount: int = Field(..., description="Monthly amount in cents")

--- a/robosystems/models/api/extensions/schedules.py
+++ b/robosystems/models/api/extensions/schedules.py
@@ -99,10 +99,15 @@ class CreateScheduleRequest(BaseModel):
   closed_through: date | None = Field(
     None,
     description=(
-      "If provided, facts with period_end ≤ this date are flagged as "
-      "'historical' (already reflected in opening balances, ignored by "
-      "the close workflow). Used during initial ledger setup to create "
-      "schedules whose early facts have already been captured elsewhere."
+      "Watermark for onboarding. Facts with period_end ≤ this date are "
+      "flagged 'historical' and their schedule_entry_due obligations are "
+      "emitted 'voided', so the close workflow starts drafting at the first "
+      "open period. Set this to the last day of the fiscal calendar's "
+      "closed_through month (calendar '2026-05' → '2026-05-31') whether "
+      "those months were actually closed in RoboLedger or just "
+      "baseline-watermarked at initialization. Omitting it (when prior "
+      "periods exist) leaves pre-watermark periods as 'pending' obligations "
+      "that block the first close."
     ),
   )
   source_transaction_id: str | None = Field(

--- a/robosystems/models/api/information_block.py
+++ b/robosystems/models/api/information_block.py
@@ -856,24 +856,30 @@ class _CreateScheduleArm(BaseModel):
         {
           "summary": "5-year straight-line depreciation",
           "description": (
-            "Monthly depreciation schedule for a $50,000 asset "
-            "amortized over 60 months. Each in-scope period produces "
-            "a draft closing entry via `entry_template`."
+            "Monthly depreciation schedule for a $50,000 asset amortized "
+            "over 60 months. Each in-scope period produces a draft closing "
+            "entry via `entry_template`. NOTE: `element_ids` and the "
+            "`entry_template.*_element_id` fields are CoA *element ids* (the "
+            "`id` returned by get-unmapped-elements / get-graph-schema), NOT "
+            "taxonomy qnames — the placeholder tokens below stand in for real "
+            "ids. One schedule models a single debit/credit pair; a "
+            "multi-account entry is several schedules, one per pair."
           ),
           "value": {
             "block_type": "schedule",
             "payload": {
               "name": "Office Building Depreciation",
               "element_ids": [
-                "us-gaap:Depreciation",
-                "us-gaap:AccumulatedDepreciation",
+                "<depreciation_expense_element_id>",
+                "<accumulated_depreciation_element_id>",
               ],
               "period_start": "2026-01-01",
               "period_end": "2030-12-31",
               "monthly_amount": 83333,
               "entry_template": {
-                "debit_element_id": "us-gaap:Depreciation",
-                "credit_element_id": "us-gaap:AccumulatedDepreciation",
+                "debit_element_id": "<depreciation_expense_element_id>",
+                "credit_element_id": "<accumulated_depreciation_element_id>",
+                "entry_type": "adjusting",
               },
             },
           },

--- a/robosystems/routers/extensions/roboledger/__init__.py
+++ b/robosystems/routers/extensions/roboledger/__init__.py
@@ -2,10 +2,11 @@
 
 Hosts two sub-surfaces under `/extensions/roboledger/{graph_id}/`:
 
-- **`/operations/{op_name}`** — command writes (close-period, create-schedule,
-  etc.). Each operation runs through `execute_operation` and returns an
-  `OperationEnvelope`. Implementations live in `operations.py` and delegate
-  to `operations/roboledger/commands/*`.
+- **`/operations/{op_name}`** — command writes (close-period,
+  create-information-block, create-event-block, etc.). Each operation runs
+  through `execute_operation` and returns an `OperationEnvelope`.
+  Implementations live in `operations.py` and delegate to
+  `operations/roboledger/commands/*`.
 
 - **`/views`** — analytical graph-backed reads (XBRL hypercube fact grids).
   Queries the LadybugDB graph schema, not extensions PostgreSQL. Lives here

--- a/robosystems/routers/extensions/roboledger/operations.py
+++ b/robosystems/routers/extensions/roboledger/operations.py
@@ -787,7 +787,12 @@ create_taxonomy_block_op = _registrar.register(
       "taxonomy row plus its structures, elements, associations, and "
       "rules. Dispatches by `taxonomy_type` — `chart_of_accounts` "
       "(declarative tenant CoA) is supported; `reporting_extension` / "
-      "`custom_ontology` / `reporting_standard` are not yet implemented."
+      "`custom_ontology` / `reporting_standard` are not yet implemented. "
+      "NOT the path for a functional close schedule: a structure with "
+      "block_type='schedule' here is a bare ontology row with none of the "
+      "schedule machinery (per-period facts, schedule_entry_due "
+      "obligations, closing-entry generator). To create a working "
+      "schedule use create-information-block(block_type='schedule')."
     ),
     command=cmd_create_taxonomy_block,
     request_model=CreateTaxonomyBlockRequest,

--- a/robosystems/routers/extensions/roboledger/operations.py
+++ b/robosystems/routers/extensions/roboledger/operations.py
@@ -1036,7 +1036,11 @@ create_information_block_op = _registrar.register(
       "the registered block type; `payload` is validated against that "
       "type's creation schema at dispatch. Schedule dispatches to the "
       "existing Schedule machinery; statement block types raise 501 "
-      "(use create-report instead)."
+      "(use create-report instead). Authoring schedules for a close? Call "
+      "`get-close-playbook` (mode='initiate') first — one schedule is a "
+      "single debit/credit element pair, so multi-line entries become "
+      "multiple schedules, and element ids must be real (discover via "
+      "get-graph-schema / get-unmapped-elements / suggest-mapping)."
     ),
     command=cmd_create_information_block,
     request_model=CreateInformationBlockRequest,

--- a/tests/middleware/mcp/test_registrar.py
+++ b/tests/middleware/mcp/test_registrar.py
@@ -138,6 +138,78 @@ class TestDeriveInputSchema:
     assert "rollforward" in schema["properties"]["block_type"]["enum"]
     assert "schedule" in schema["properties"]["block_type"]["enum"]
 
+  def test_typed_arm_union_exposes_payload_fields(self) -> None:
+    """When a discriminated-union arm carries a *typed* payload, the
+    flattener must surface that arm's real fields under a nested
+    ``payload.anyOf`` (no top-level union) so a codebase-blind MCP client
+    can construct a valid call instead of guessing field names. This is
+    the legibility fix — the opposite of the all-untyped permissive path.
+    """
+    from typing import Annotated, Literal
+
+    from pydantic import Discriminator, RootModel
+
+    class _SchedulePayload(BaseModel):
+      name: str = Field(..., description="Schedule name")
+      monthly_amount: int = Field(..., description="Amount in cents")
+
+    class _TypedArm(BaseModel):
+      kind: Literal["sched"]
+      payload: _SchedulePayload
+
+    class _UntypedArm(BaseModel):
+      kind: Literal["legacy"]
+      payload: dict[str, Any] = Field(default_factory=dict)
+
+    class _Req(RootModel[Annotated[_TypedArm | _UntypedArm, Discriminator("kind")]]):
+      """A union mixing a typed arm and an untyped one."""
+
+    schema = derive_input_schema(_Req)
+
+    # Still no top-level union — Anthropic API constraint holds.
+    assert "oneOf" not in schema
+    assert "anyOf" not in schema
+    assert "allOf" not in schema
+
+    assert set(schema["properties"]["kind"]["enum"]) == {"sched", "legacy"}
+    # payload is enriched into an anyOf because at least one arm is typed.
+    payload = schema["properties"]["payload"]
+    assert "anyOf" in payload
+    # The typed arm's real field names are present and discoverable.
+    typed_option = next(
+      o for o in payload["anyOf"] if "'sched'" in (o.get("title") or "")
+    )
+    assert set(typed_option["properties"]) == {"name", "monthly_amount"}
+    # payload becomes required once it carries structure.
+    assert schema["required"] == ["kind", "payload"]
+
+  def test_create_information_block_payload_is_legible(self) -> None:
+    """End-to-end legibility check on the production model: the schedule
+    arm's real fields and a copy-pasteable example must reach the MCP
+    boundary. Regression guard for the 2026-06-17 close-workflow
+    legibility gap — a blind agent could not author schedules because the
+    payload was an opaque ``{additionalProperties: true}`` blob.
+    """
+    from robosystems.models.api.information_block import (
+      CreateInformationBlockRequest,
+    )
+
+    schema = derive_input_schema(CreateInformationBlockRequest)
+    payload = schema["properties"]["payload"]
+    assert "anyOf" in payload
+
+    schedule_option = next(
+      o for o in payload["anyOf"] if "'schedule'" in (o.get("title") or "")
+    )
+    fields = schedule_option.get("properties") or {}
+    # The fields a caller actually needs to set, not invent.
+    for field in ("name", "taxonomy_id", "element_ids", "entry_template"):
+      assert field in fields, f"schedule field {field!r} not exposed"
+
+    # At least one copy-pasteable example body reached the envelope.
+    examples = schema.get("examples") or []
+    assert any(ex.get("block_type") == "schedule" for ex in examples)
+
 
 # ── Error translation ─────────────────────────────────────────────────────
 

--- a/tests/middleware/mcp/tools/test_playbook_tools.py
+++ b/tests/middleware/mcp/tools/test_playbook_tools.py
@@ -1,0 +1,101 @@
+"""Tests for the workflow-playbook MCP tools.
+
+The playbook is guidance-only (no DB, no side effects), so these tests
+focus on (a) the tool definition shape and (b) that each mode returns the
+sections + the load-bearing rules a codebase-blind operator needs. The
+specific phrases asserted here are the ones the 2026-06-17 close-workflow
+legibility gate found missing from the tool surface — keep them.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+from robosystems.middleware.mcp.tools.playbook_tools import GetClosePlaybookTool
+
+
+class _StubClient:
+  graph_id = "kgTEST"
+  user_id = "user_test"
+
+
+def _tool() -> GetClosePlaybookTool:
+  return GetClosePlaybookTool(_StubClient())
+
+
+def _run(mode: str | None = None) -> dict:
+  args = {} if mode is None else {"mode": mode}
+  return asyncio.run(_tool().execute(args))
+
+
+class TestGetClosePlaybookDefinition:
+  def test_definition_shape(self) -> None:
+    d = _tool().get_tool_definition()
+    assert d["name"] == "get-close-playbook"
+    schema = d["inputSchema"]
+    assert schema["required"] == []
+    assert schema["properties"]["mode"]["enum"] == [
+      "overview",
+      "initiate",
+      "recurring",
+    ]
+    # The description points the agent here as the FIRST call.
+    assert "get-close-playbook" not in d["description"]  # don't self-reference
+    assert "Call this FIRST".lower() in d["description"].lower()
+
+
+class TestGetClosePlaybookModes:
+  def test_overview_returns_both_tracks(self) -> None:
+    payload = _run()
+    assert payload["mode"] == "overview"
+    assert "recurring_close_sequence" in payload
+    assert "initiate_first_close" in payload
+    assert "schedule_authoring" in payload
+
+  def test_recurring_excludes_setup(self) -> None:
+    payload = _run("recurring")
+    assert payload["mode"] == "recurring"
+    assert "recurring_close_sequence" in payload
+    assert "initiate_first_close" not in payload
+
+  def test_initiate_includes_setup_and_authoring(self) -> None:
+    payload = _run("initiate")
+    assert payload["mode"] == "initiate"
+    assert "initiate_first_close" in payload
+    assert "schedule_authoring" in payload
+    assert "recurring_close_sequence" not in payload
+
+  def test_invalid_mode_falls_back_to_overview(self) -> None:
+    assert _run("garbage")["mode"] == "overview"
+
+
+class TestGetClosePlaybookContent:
+  def test_carries_the_gate_residual_rules(self) -> None:
+    """The legibility-gate residuals must be teachable from the playbook."""
+    blob = json.dumps(_run())
+    # One schedule = one debit/credit pair (multi-line ⇒ multiple schedules).
+    assert "one per asset/element pair" in blob
+    # The real draft-producing path (no phantom create-closing-entry).
+    assert "promote-obligations" in blob
+    assert "create-closing-entry" in blob  # explicitly named as nonexistent
+    # Element discovery instead of inventing qnames.
+    assert "get-graph-schema" in blob
+    # Amounts in cents.
+    assert "cents" in blob
+    # Period-identifier convention friction.
+    assert "YYYY-MM" in blob
+    # block_type enum overstates capability (statements 501).
+    assert "501" in blob
+    # Per-tenant procedures doc convention.
+    assert "search-documents" in blob
+
+  def test_recurring_sequence_is_ordered_and_complete(self) -> None:
+    seq = " || ".join(_run("recurring")["recurring_close_sequence"])
+    # The canonical chain appears in order.
+    for earlier, later in [
+      ("get-fiscal-calendar", "promote-obligations"),
+      ("promote-obligations", "list-period-drafts"),
+      ("list-period-drafts", "close-period"),
+    ]:
+      assert seq.index(earlier) < seq.index(later), (earlier, later)

--- a/tests/middleware/mcp/tools/test_playbook_tools.py
+++ b/tests/middleware/mcp/tools/test_playbook_tools.py
@@ -89,6 +89,25 @@ class TestGetClosePlaybookContent:
     assert "501" in blob
     # Per-tenant procedures doc convention.
     assert "search-documents" in blob
+    # Onboarding watermark rule + its failure mode (blocked first close).
+    assert "closed_through" in blob
+    assert "pending_obligations" in blob
+
+  def test_initiate_teaches_orient_then_watermark(self) -> None:
+    """The initiate track must tell the agent to read the calendar's
+    closed_through first and stamp the matching watermark on every schedule
+    — the rule that prevents both a blocked first close and duplicate
+    entries for already-handled months.
+    """
+    payload = _run("initiate")
+    init_blob = " || ".join(payload["initiate_first_close"])
+    authoring_blob = " || ".join(payload["schedule_authoring"])
+    # Orient on the calendar before authoring.
+    assert "get-fiscal-calendar" in init_blob
+    assert "closed_through" in init_blob
+    # Authoring carries the watermark-match rule + the blocked-close warning.
+    assert "closed_through" in authoring_blob
+    assert "pending" in authoring_blob.lower()
 
   def test_recurring_sequence_is_ordered_and_complete(self) -> None:
     seq = " || ".join(_run("recurring")["recurring_close_sequence"])


### PR DESCRIPTION
## Summary

Three MCP workflow-legibility fixes surfaced while dogfooding the RoboLedger month-end close through the MCP surface (Claude Cowork / raw MCP). Authoring the recurring schedules turned out to require *codebase awareness* — which is a launch problem, since "multi-company accountant runs closes via Claude" is the headline persona. This PR makes the close workflow operable from the tool surface alone, without reversing the generic Information Block dispatcher architecture.

The gap was localized (a few schema/description seams), not systemic. Each fix was validated by a **codebase-blind agent** given only the generated MCP tool catalog and forbidden from reading source.

## Changes

**Fix #1 — dead link** (`0dc28356`)
- `list-period-drafts` told callers to draft entries via a `create-closing-entry` tool that does not exist. It now names the real draft-producing paths: `promote-obligations` (period sweep), `create-event-block(event_type='schedule_entry_due')` (single schedule), `journal_entry_recorded` (manual).

**Fix #2 — typed payloads at the MCP boundary** (`0dc28356`)
- `derive_input_schema` flattened every discriminated-union `RootModel` body (create/update/delete-information-block) into an opaque `payload: {additionalProperties: true}`, so the typed schedule arm's real fields and its `json_schema_extra` examples never reached the MCP client.
- `_flatten_top_level_union` now correlates each arm to its discriminator value(s); when an arm carries a typed payload it exposes every arm's payload schema under a nested `payload.anyOf` (titled by `block_type`) and hoists the arms' examples to the envelope. Nested unions are safe — `Optional[...]` fields already emit nested `anyOf`. All-untyped unions keep the prior permissive shape, so existing behavior and its regression test are unchanged.
- New regression tests in `tests/middleware/mcp/test_registrar.py`.

**Fix #3 — `get-close-playbook` + element-id legibility** (`b612b386`)
- New `get-close-playbook` MCP tool (`robosystems/middleware/mcp/tools/playbook_tools.py`): version-locked, guidance-only, read-only-safe. Encodes the canonical close chain, the two modes (initiate / recurring), the bootstrap strategy (derive-from-history + interview), and the gotchas no single schema makes obvious — one schedule = one debit/credit element pair, amounts in cents, period-identifier shapes (`YYYY-MM` vs `YYYY-MM-DD`), which block types 501, and close blockers. Wired into `manager.py` (registration + listing + dispatch). This MCP surface has no protocol-level `instructions` field, so discovery is via prominent pointers from `get-fiscal-calendar` and `create-information-block`.
- Element-id bug the gate caught: the schedule machinery resolves debit/credit by CoA `Element.id`, but the `create-information-block` example used taxonomy qnames (`us-gaap:Depreciation`). Fixed the example (placeholder element ids + note) and the `EntryTemplateRequest` / `CreateScheduleRequest` field descriptions to say "CoA element id (from `get-unmapped-elements`), not a qname." The rollforward block type keeps its `*_qname` fields by design.
- New tests in `tests/middleware/mcp/tools/test_playbook_tools.py`.

**Disambiguation + stale-doc cleanup** (`44163621`)
- `create-taxonomy-block` accepts a structure `block_type='schedule'`, but that only writes a bare ontology row (no per-period facts, no `schedule_entry_due` obligations, no closing-entry generator). Its description now points callers to `create-information-block(block_type='schedule')` for a functional schedule.
- Scrubbed stale references to dedicated `create-schedule` / `update-schedule` / `delete-schedule` ops — those were consolidated into the generic Information Block dispatcher; no such ops exist today.

## Testing

- `just test-code` (ruff + format + basedpyright + cf-lint) — **passed** (run repeatedly via the pre-commit hook on each commit).
- `uv run pytest tests/middleware/mcp/` — **574 passed**.
- `uv run pytest tests/routers/extensions/roboledger/` — **passed**.
- `uv run pytest tests/ -k "information_block or schedule or close_period or fiscal"` — **486 passed**.
- Full `just test-all` (unit-test portion) not run in this session.

## Validation — codebase-blind gate runs

A `general-purpose` subagent was handed only the generated MCP tool catalog (JSON) and forbidden from reading source:

- **Gate 1 (after #1+#2):** running a close flipped to YES; the schedule-payload field-name-guessing blocker was resolved ("complete call, all from schema/examples, NOT guessed").
- **Gate 2 (after #3):** the agent called `get-close-playbook` first, derived the one-schedule-per-pair decomposition, used the element-discovery tools, and ran the full close. It also flagged the qname-vs-element-id ambiguity (now fixed) and wrongly worried that omitting `schedule_metadata` would create a failing `SumEquals` rule (verified harmless — the rule only generates when a cost basis is supplied).

## Notes / Follow-ups

- Deferred (demand-pulled, not blockers): per-tenant procedures-doc *seeding* at provision; an auto-extending schedule horizon; a `list-prior-entries-by-account` read tool (`read-graph-cypher` covers it today).
- Considered and deferred: dedicated `create-schedule`/etc. ops (option B). If SDK ergonomics or the constructible-block-type count demand it, the only version worth building is auto-generated *from the block-type registry* so it adds no per-type boilerplate and can't drift — schedule logic stays in `ScheduleService` either way.
