### PR TITLE
fix(graph): repair routing location cache read (DatabaseLocation kwarg mismatch)

### DIFF
--- a/robosystems/graph_api/client/factory.py
+++ b/robosystems/graph_api/client/factory.py
@@ -621,7 +621,13 @@ class GraphClientFactory:
     cache_key = cls._get_cache_key("location", actual_graph_id)
     redis_client = await cls._get_redis()
 
-    db_location = None
+    # Routing only needs the instance's private IP and ID. We cache those two
+    # values as plain scalars rather than reconstructing a DatabaseLocation —
+    # the dataclass has required fields (graph_id, availability_zone, status,
+    # created_at) the cache never carried, so reconstruction always raised and
+    # silently disabled the cache.
+    private_ip: str | None = None
+    instance_id: str | None = None
     if redis_client:
       try:
         cached = await redis_client.get(cache_key)
@@ -629,15 +635,15 @@ class GraphClientFactory:
           location_data = json.loads(cached)
           # Verify cache is still fresh (1 minute TTL)
           if time.time() - location_data.get("timestamp", 0) < cls._instance_cache_ttl:
-            from robosystems.middleware.graph.allocation_manager import DatabaseLocation
-
-            db_location = DatabaseLocation(**location_data["location"])
+            location = location_data["location"]
+            private_ip = location["private_ip"]
+            instance_id = location["instance_id"]
             logger.debug(f"Using cached location for {graph_id}")
       except Exception as e:
         logger.warning(f"Redis cache read failed for location: {e}")
 
     # If not cached, look it up - use actual_graph_id for routing
-    if not db_location:
+    if private_ip is None:
       allocation_manager = LadybugAllocationManager(
         environment=environment or env.ENVIRONMENT
       )
@@ -656,14 +662,16 @@ class GraphClientFactory:
           )
         raise RouteError(error_msg)
 
+      private_ip = db_location.private_ip
+      instance_id = db_location.instance_id
+
       # Cache the location
       if redis_client:
         try:
           location_data = {
             "location": {
-              "instance_id": db_location.instance_id,
-              "private_ip": db_location.private_ip,
-              "database_name": db_location.graph_id,
+              "instance_id": instance_id,
+              "private_ip": private_ip,
             },
             "timestamp": time.time(),
           }
@@ -674,13 +682,10 @@ class GraphClientFactory:
           logger.warning(f"Redis cache write failed for location: {e}")
 
     # Create client with the allocated instance's endpoint
-    api_url = f"http://{db_location.private_ip}:8001"
+    api_url = f"http://{private_ip}:8001"
     api_key = env.GRAPH_API_KEY
 
-    logger.info(
-      f"Routing user graph {graph_id} to instance "
-      f"{db_location.instance_id} at {api_url}"
-    )
+    logger.info(f"Routing user graph {graph_id} to instance {instance_id} at {api_url}")
 
     if not api_key:
       logger.error("GRAPH_API_KEY is not set in environment!")
@@ -693,7 +698,7 @@ class GraphClientFactory:
     client._database_name = (
       database_name  # Actual database to use (important for subgraphs)
     )
-    client._instance_id = db_location.instance_id
+    client._instance_id = instance_id
 
     return client
 

--- a/tests/graph_api/client/test_factory.py
+++ b/tests/graph_api/client/test_factory.py
@@ -6,6 +6,7 @@ create_client_sync, pool statistics, and cleanup.
 """
 
 import asyncio
+import json
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -783,6 +784,146 @@ class TestCreateUserGraphClient:
 
         with pytest.raises(RouteError, match="Parent graph kg123 not found"):
           await GraphClientFactory._create_user_graph_client("kg123_dev", "prod", None)
+
+
+class _FakeRedis:
+  """Minimal stateful async Redis stand-in for routing-cache round-trips."""
+
+  def __init__(self):
+    self.store: dict[str, str] = {}
+
+  async def get(self, key):
+    return self.store.get(key)
+
+  async def setex(self, key, _ttl, value):
+    self.store[key] = value
+
+
+@pytest.mark.unit
+class TestUserGraphLocationCache:
+  """Regression coverage for the prod/staging routing location cache (#758).
+
+  The write path stored {instance_id, private_ip, database_name} scalars while
+  the read path tried to reconstruct a DatabaseLocation dataclass — which has
+  required fields the payload never carried, so every read raised and the cache
+  was effectively dead. Routing only needs private_ip + instance_id, so both
+  paths now exchange those scalars directly.
+  """
+
+  @pytest.mark.asyncio
+  async def test_location_cache_round_trips(self):
+    """Write then read of the routing cache must round-trip (no second lookup)."""
+    fake_redis = _FakeRedis()
+
+    mock_location = MagicMock()
+    mock_location.private_ip = "10.0.7.7"
+    mock_location.instance_id = "i-roundtrip"
+
+    with patch(f"{FACTORY_MODULE}.env") as mock_env:
+      mock_env.is_development.return_value = False
+      mock_env.ENVIRONMENT = "prod"
+      mock_env.GRAPH_API_KEY = "prod-key"
+
+      with (
+        patch(f"{FACTORY_MODULE}.parse_subgraph_id", return_value=None),
+        patch.object(
+          GraphClientFactory,
+          "_get_redis",
+          new_callable=AsyncMock,
+          return_value=fake_redis,
+        ),
+        patch(f"{FACTORY_MODULE}.LadybugAllocationManager") as MockAllocManager,
+        patch(f"{FACTORY_MODULE}.GraphClient") as MockClient,
+      ):
+        mock_manager = AsyncMock()
+        MockAllocManager.return_value = mock_manager
+        mock_manager.find_database_location.return_value = mock_location
+        MockClient.return_value = MagicMock()
+
+        # First call misses → allocation lookup + cache write.
+        await GraphClientFactory._create_user_graph_client("kg123", "prod", None)
+        # Second call hits the cache → no second allocation lookup.
+        await GraphClientFactory._create_user_graph_client("kg123", "prod", None)
+
+      assert mock_manager.find_database_location.call_count == 1
+      # Both calls routed to the cached instance IP.
+      assert MockClient.call_args_list[-1].kwargs["base_url"] == "http://10.0.7.7:8001"
+
+  @pytest.mark.asyncio
+  async def test_cache_write_stores_routing_scalars(self):
+    """Cached payload carries only the scalars the read path consumes."""
+    mock_redis = AsyncMock()
+    mock_redis.get.return_value = None  # force a miss
+
+    mock_location = MagicMock()
+    mock_location.private_ip = "10.0.9.9"
+    mock_location.instance_id = "i-fresh"
+
+    with patch(f"{FACTORY_MODULE}.env") as mock_env:
+      mock_env.is_development.return_value = False
+      mock_env.ENVIRONMENT = "prod"
+      mock_env.GRAPH_API_KEY = "prod-key"
+
+      with (
+        patch(f"{FACTORY_MODULE}.parse_subgraph_id", return_value=None),
+        patch.object(
+          GraphClientFactory,
+          "_get_redis",
+          new_callable=AsyncMock,
+          return_value=mock_redis,
+        ),
+        patch(f"{FACTORY_MODULE}.LadybugAllocationManager") as MockAllocManager,
+        patch(f"{FACTORY_MODULE}.GraphClient") as MockClient,
+      ):
+        mock_manager = AsyncMock()
+        MockAllocManager.return_value = mock_manager
+        mock_manager.find_database_location.return_value = mock_location
+        MockClient.return_value = MagicMock()
+
+        await GraphClientFactory._create_user_graph_client("kg123", "prod", None)
+
+    mock_redis.setex.assert_called_once()
+    cached = json.loads(mock_redis.setex.call_args.args[2])
+    assert cached["location"] == {"instance_id": "i-fresh", "private_ip": "10.0.9.9"}
+    assert "database_name" not in cached["location"]
+
+  @pytest.mark.asyncio
+  async def test_cache_hit_skips_allocation_lookup(self):
+    """A fresh cached location routes without touching the allocation manager."""
+    mock_redis = AsyncMock()
+    mock_redis.get.return_value = json.dumps(
+      {
+        "location": {"instance_id": "i-cached", "private_ip": "10.0.5.5"},
+        "timestamp": time.time(),
+      }
+    )
+
+    with patch(f"{FACTORY_MODULE}.env") as mock_env:
+      mock_env.is_development.return_value = False
+      mock_env.ENVIRONMENT = "prod"
+      mock_env.GRAPH_API_KEY = "prod-key"
+
+      with (
+        patch(f"{FACTORY_MODULE}.parse_subgraph_id", return_value=None),
+        patch.object(
+          GraphClientFactory,
+          "_get_redis",
+          new_callable=AsyncMock,
+          return_value=mock_redis,
+        ),
+        patch(f"{FACTORY_MODULE}.LadybugAllocationManager") as MockAllocManager,
+        patch(f"{FACTORY_MODULE}.GraphClient") as MockClient,
+      ):
+        mock_client = MagicMock()
+        MockClient.return_value = mock_client
+
+        await GraphClientFactory._create_user_graph_client("kg123", "prod", None)
+
+      MockAllocManager.assert_not_called()
+      MockClient.assert_called_once_with(
+        base_url="http://10.0.5.5:8001", api_key="prod-key"
+      )
+      assert mock_client._instance_id == "i-cached"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #758. The prod/staging graph routing location cache (Redis, 1-min TTL) was effectively dead: every read raised, so each routing call fell through to a full DynamoDB allocation lookup plus a warning per call. This repairs the read path so the cache actually hits.

## Root cause

The cache write and read shapes never matched:

- **Write** stored `{instance_id, private_ip, database_name}` scalars.
- **Read** reconstructed `DatabaseLocation(**location_data["location"])`.

But `DatabaseLocation` has no `database_name` field, and its `graph_id`, `availability_zone`, `status`, and `created_at` fields are required — none of which the payload carried. So every read raised `DatabaseLocation.__init__() got an unexpected keyword argument 'database_name'`, the location stayed `None`, and routing fell back to the DynamoDB lookup on every call.

## Changes

- **`robosystems/graph_api/client/factory.py`** (`_create_user_graph_client`): routing only consumes `private_ip` and `instance_id`, so both cache paths now exchange those two scalars directly instead of reconstructing the `DatabaseLocation` dataclass. The cache-hit gate changed from `if not db_location:` to `if private_ip is None:` to correctly distinguish a hit from a miss. The unused `database_name` key was dropped from the cached payload, and the now-orphaned local `DatabaseLocation` import was removed.
- **`tests/graph_api/client/test_factory.py`**: added `TestUserGraphLocationCache` with three regression tests:
  - **round-trip** — two routing calls in a row, asserting the second is served from cache so `find_database_location` is called only once (before the fix it was called twice because the read raised).
  - **cache write shape** — the cached payload contains exactly `{instance_id, private_ip}`, no `database_name`.
  - **cache hit skips allocation** — a fresh cached entry routes to the cached IP without touching the allocation manager.

## Testing

- `uv run pytest tests/graph_api/client/test_factory.py` — **64 passed** (61 existing + 3 new).
- `just test-code` (ruff + format + basedpyright + cf-lint) — all green.
- Full `just test-all` suite not run in this session.

## Notes

- Behavior of the 1-min stale-IP window is unchanged from the original intent — a cache hit serves whatever IP was current within the TTL window; the only change is that the cache now functions at all.
- The fix is backward-compatible with any in-flight cached entries: the read keys (`private_ip`, `instance_id`) are present in both the old and new payload shapes.
