### PR TITLE
fix(graph): scope backup/connection lookups and OAuth redirect override

### DIFF
--- a/robosystems/models/core/graph/graph_backup.py
+++ b/robosystems/models/core/graph/graph_backup.py
@@ -151,6 +151,20 @@ class GraphBackup(Model):
     return session.query(cls).filter(cls.id == backup_id).first()
 
   @classmethod
+  def get_by_id_and_graph(
+    cls, backup_id: str, graph_id: str, session: Session
+  ) -> Optional["GraphBackup"]:
+    """Get a backup by ID, scoped to its owning graph.
+
+    Use this for any caller that already authorized ``graph_id`` (e.g. a
+    URL path scope) — it prevents reaching another graph's backup with a
+    guessed backup_id, since the lookup never matches across graphs.
+    """
+    return (
+      session.query(cls).filter(cls.id == backup_id, cls.graph_id == graph_id).first()
+    )
+
+  @classmethod
   def get_by_graph_id(
     cls,
     graph_id: str,

--- a/robosystems/operations/connection_service.py
+++ b/robosystems/operations/connection_service.py
@@ -138,9 +138,7 @@ class ConnectionService:
 
       # Enforce graph scope when provided (connection_id is caller-supplied)
       if graph_id and conn.graph_id != graph_id:
-        logger.warning(
-          "Connection %s does not belong to graph %s", connection_id, graph_id
-        )
+        logger.warning("Connection %s not in requested graph scope", connection_id)
         return None
 
       # Check user access (system user can access any connection)
@@ -342,9 +340,7 @@ class ConnectionService:
 
       # Enforce graph scope when provided (connection_id is caller-supplied)
       if graph_id and conn.graph_id != graph_id:
-        logger.warning(
-          "Connection %s does not belong to graph %s", connection_id, graph_id
-        )
+        logger.warning("Connection %s not in requested graph scope", connection_id)
         return False
 
       # Deactivate credentials (already soft-deletion via is_active=False)

--- a/robosystems/operations/connection_service.py
+++ b/robosystems/operations/connection_service.py
@@ -119,7 +119,9 @@ class ConnectionService:
     Args:
         connection_id: Connection identifier
         user_id: Optional user filter (SYSTEM_USER_ID bypasses)
-        graph_id: Unused (kept for backward compat)
+        graph_id: When set, the connection must belong to this graph — pass
+            the URL scope the caller already authorized so a guessed
+            connection_id can't reach another graph's connection.
         db_session: Optional existing database session
 
     Returns:
@@ -132,6 +134,13 @@ class ConnectionService:
       conn = Connection.get_by_id(connection_id, session)
       if not conn:
         logger.warning("Connection not found: %s", connection_id)
+        return None
+
+      # Enforce graph scope when provided (connection_id is caller-supplied)
+      if graph_id and conn.graph_id != graph_id:
+        logger.warning(
+          "Connection %s does not belong to graph %s", connection_id, graph_id
+        )
         return None
 
       # Check user access (system user can access any connection)
@@ -314,7 +323,9 @@ class ConnectionService:
     Args:
         connection_id: Connection identifier
         user_id: User performing the deletion
-        graph_id: Unused (kept for backward compat)
+        graph_id: When set, the connection must belong to this graph — pass
+            the URL scope the caller already authorized so a guessed
+            connection_id can't delete another graph's connection.
         db_session: Optional existing database session
 
     Returns:
@@ -327,6 +338,13 @@ class ConnectionService:
       conn = Connection.get_by_id(connection_id, session)
       if not conn:
         logger.warning(f"Connection {connection_id} not found for deletion")
+        return False
+
+      # Enforce graph scope when provided (connection_id is caller-supplied)
+      if graph_id and conn.graph_id != graph_id:
+        logger.warning(
+          "Connection %s does not belong to graph %s", connection_id, graph_id
+        )
         return False
 
       # Deactivate credentials (already soft-deletion via is_active=False)

--- a/robosystems/operations/graph/engine/backup_manager.py
+++ b/robosystems/operations/graph/engine/backup_manager.py
@@ -165,10 +165,15 @@ class BackupManager:
       # Get backup record from database
       db_session = SessionLocal()
       try:
-        backup = GraphBackup.get_by_id(backup_id, db_session)
+        # Scope the lookup to graph_id — access to graph_id is authorized by
+        # the route dependency, but the backup_id is caller-supplied, so a
+        # bare get_by_id would let one graph fetch another graph's backup.
+        backup = GraphBackup.get_by_id_and_graph(backup_id, graph_id, db_session)
 
         if not backup:
-          logger.warning(f"Backup {backup_id} not found in database")
+          logger.warning(
+            f"Backup {backup_id} not found in database for graph {graph_id}"
+          )
           return None
 
         # Check if backup is completed

--- a/robosystems/operations/providers/oauth_handler.py
+++ b/robosystems/operations/providers/oauth_handler.py
@@ -5,7 +5,7 @@ import hashlib
 import secrets
 from datetime import UTC, datetime, timedelta
 from typing import Any, Protocol
-from urllib.parse import urlencode
+from urllib.parse import urlencode, urlparse
 
 # Third-party
 import httpx
@@ -123,6 +123,25 @@ class OAuthHandler:
   def __init__(self, provider: OAuthProviderProtocol):
     self.provider = provider
 
+  @staticmethod
+  def _validate_redirect_uri(redirect_uri: str) -> None:
+    """Reject a client-supplied redirect_uri outside the trusted origins.
+
+    The value is echoed into the provider authorize URL and replayed at
+    token exchange, so an unconstrained value lets a caller redirect the
+    authorization code to an arbitrary host. Allow only the origins we
+    already trust for the frontends (the CORS allowlist); the server-built
+    default is exempt because it isn't caller-controlled.
+    """
+    parsed = urlparse(redirect_uri)
+    origin = f"{parsed.scheme}://{parsed.netloc}"
+    if origin not in env.get_main_cors_origins():
+      logger.warning("Rejected OAuth redirect_uri outside allowed origins: %s", origin)
+      raise HTTPException(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        detail="redirect_uri is not an allowed origin",
+      )
+
   def get_authorization_url(
     self, connection_id: str, user_id: str, redirect_uri: str | None = None
   ) -> tuple[str, str]:
@@ -131,6 +150,9 @@ class OAuthHandler:
     if not redirect_uri:
       base_url = env.ROBOSYSTEMS_API_URL
       redirect_uri = f"{base_url}/v1/oauth/callback/{self.provider.name}"
+    else:
+      # Caller-supplied override — must be a trusted frontend origin.
+      self._validate_redirect_uri(redirect_uri)
 
     # Create state for security validation
     state = OAuthState.create(connection_id, user_id, redirect_uri)

--- a/robosystems/routers/graphs/connections/management.py
+++ b/robosystems/routers/graphs/connections/management.py
@@ -147,7 +147,9 @@ async def create_connection(
     )
 
     # Get the created connection
-    connection = await ConnectionService.get_connection(connection_id, current_user.id)
+    connection = await ConnectionService.get_connection(
+      connection_id, current_user.id, graph_id=graph_id
+    )
 
     if not connection:
       raise create_error_response(
@@ -322,7 +324,9 @@ async def get_connection(
   _rate_limit: None = Depends(subscription_aware_rate_limit_dependency),
 ) -> ConnectionResponse:
   try:
-    connection = await ConnectionService.get_connection(connection_id, current_user.id)
+    connection = await ConnectionService.get_connection(
+      connection_id, current_user.id, graph_id=graph_id
+    )
 
     if not connection:
       raise create_error_response(
@@ -443,7 +447,9 @@ async def delete_connection(
 ):
   try:
     # Get connection before deletion for cleanup
-    connection = await ConnectionService.get_connection(connection_id, current_user.id)
+    connection = await ConnectionService.get_connection(
+      connection_id, current_user.id, graph_id=graph_id
+    )
 
     if not connection:
       raise create_error_response(

--- a/robosystems/routers/graphs/connections/oauth.py
+++ b/robosystems/routers/graphs/connections/oauth.py
@@ -49,7 +49,7 @@ async def init_oauth(
   try:
     # Get connection to verify it exists and get provider
     connection = await ConnectionService.get_connection(
-      request.connection_id, current_user.id
+      request.connection_id, current_user.id, graph_id=graph_id
     )
 
     if not connection:
@@ -149,7 +149,9 @@ async def oauth_callback(
     redirect_uri = state_data["redirect_uri"]
 
     # Get connection
-    connection = await ConnectionService.get_connection(connection_id, current_user.id)
+    connection = await ConnectionService.get_connection(
+      connection_id, current_user.id, graph_id=graph_id
+    )
 
     if not connection:
       raise create_error_response(
@@ -225,7 +227,7 @@ async def oauth_callback(
             pending.delete(db)
           # Pull the refreshed dict for downstream auto-sync.
           connection = await ConnectionService.get_connection(
-            revived_id, current_user.id, db_session=db
+            revived_id, current_user.id, graph_id=graph_id, db_session=db
           )
 
       # Route subsequent writes at the revived id if reuse happened,

--- a/robosystems/routers/graphs/connections/sync.py
+++ b/robosystems/routers/graphs/connections/sync.py
@@ -122,7 +122,9 @@ async def sync_connection(
     )
 
     # Get connection details
-    connection = await ConnectionService.get_connection(connection_id, current_user.id)
+    connection = await ConnectionService.get_connection(
+      connection_id, current_user.id, graph_id=graph_id
+    )
 
     if not connection:
       raise create_error_response(

--- a/tests/models/core/graph/test_graph_backup.py
+++ b/tests/models/core/graph/test_graph_backup.py
@@ -152,6 +152,26 @@ class TestGraphBackupModel:
     not_found = GraphBackup.get_by_id("backup_nonexistent", db_session)
     assert not_found is None
 
+  def test_get_by_id_and_graph(self, db_session):
+    """get_by_id_and_graph scopes the lookup to the owning graph (IDOR guard)."""
+    backup = GraphBackup.create(
+      graph_id="kg_owner",
+      database_name="owner_db",
+      backup_type=BackupType.FULL.value,
+      s3_bucket="bucket",
+      s3_key="owner.tar.gz",
+      session=db_session,
+    )
+
+    # Matching graph resolves the record
+    found = GraphBackup.get_by_id_and_graph(backup.id, "kg_owner", db_session)
+    assert found is not None
+    assert found.id == backup.id
+
+    # A different graph cannot reach it even with the correct backup_id
+    wrong_graph = GraphBackup.get_by_id_and_graph(backup.id, "kg_other", db_session)
+    assert wrong_graph is None
+
   def test_get_by_graph_id(self, db_session):
     """Test getting backups for a specific graph."""
     # Create multiple backups for same graph

--- a/tests/operations/graph/engine/test_backup_manager.py
+++ b/tests/operations/graph/engine/test_backup_manager.py
@@ -498,18 +498,20 @@ class TestBackupManager:
     ):
       mock_session = MagicMock()
       mock_session_local.return_value = mock_session
-      mock_graph_backup.get_by_id.return_value = mock_backup
+      mock_graph_backup.get_by_id_and_graph.return_value = mock_backup
 
       # Test get_backup_download_url
       url = await backup_manager.get_backup_download_url(
         graph_id, backup_id, expires_in=3600
       )
       assert url == "https://presigned-url.com"
-      mock_graph_backup.get_by_id.assert_called_once_with(backup_id, mock_session)
+      mock_graph_backup.get_by_id_and_graph.assert_called_once_with(
+        backup_id, graph_id, mock_session
+      )
 
       # Test encrypted backup download (should return None)
       mock_backup.encryption_enabled = True
-      mock_graph_backup.get_by_id.reset_mock()
+      mock_graph_backup.get_by_id_and_graph.reset_mock()
 
       url = await backup_manager.get_backup_download_url(graph_id, backup_id)
       assert url is None

--- a/tests/operations/graph/engine/test_backup_manager_extended.py
+++ b/tests/operations/graph/engine/test_backup_manager_extended.py
@@ -302,7 +302,7 @@ class TestGetBackupDownloadUrl:
     ):
       mock_session = MagicMock()
       mock_sl.return_value = mock_session
-      mock_gb.get_by_id.return_value = mock_backup
+      mock_gb.get_by_id_and_graph.return_value = mock_backup
 
       url = await manager.get_backup_download_url("graph1", "bk_abc", 7200)
 
@@ -316,7 +316,7 @@ class TestGetBackupDownloadUrl:
     ):
       mock_session = MagicMock()
       mock_sl.return_value = mock_session
-      mock_gb.get_by_id.return_value = None
+      mock_gb.get_by_id_and_graph.return_value = None
 
       url = await manager.get_backup_download_url("graph1", "bk_none")
 
@@ -334,7 +334,7 @@ class TestGetBackupDownloadUrl:
     ):
       mock_session = MagicMock()
       mock_sl.return_value = mock_session
-      mock_gb.get_by_id.return_value = mock_backup
+      mock_gb.get_by_id_and_graph.return_value = mock_backup
 
       url = await manager.get_backup_download_url("graph1", "bk_inc")
 
@@ -352,7 +352,7 @@ class TestGetBackupDownloadUrl:
     ):
       mock_session = MagicMock()
       mock_sl.return_value = mock_session
-      mock_gb.get_by_id.return_value = mock_backup
+      mock_gb.get_by_id_and_graph.return_value = mock_backup
 
       # encrypted -> raises ValueError internally, caught and returns None
       url = await manager.get_backup_download_url("graph1", "bk_enc")
@@ -380,7 +380,7 @@ class TestGetBackupDownloadUrl:
     ):
       mock_session = MagicMock()
       mock_sl.return_value = mock_session
-      mock_gb.get_by_id.return_value = mock_backup
+      mock_gb.get_by_id_and_graph.return_value = mock_backup
 
       url = await manager.get_backup_download_url("graph1", "bk_ls")
 

--- a/tests/operations/providers/test_oauth_handler.py
+++ b/tests/operations/providers/test_oauth_handler.py
@@ -131,7 +131,9 @@ class TestOAuthState:
 
 @pytest.mark.unit
 class TestOAuthHandlerAuthorizationUrl:
-  def test_generates_url_with_redirect(self):
+  @patch(f"{MODULE}.env")
+  def test_generates_url_with_redirect(self, mock_env):
+    mock_env.get_main_cors_origins.return_value = ["https://myapp.com"]
     handler = OAuthHandler(MockProvider())
 
     url, state = handler.get_authorization_url(
@@ -146,6 +148,22 @@ class TestOAuthHandlerAuthorizationUrl:
     assert "access_type=offline" in url
     assert f"state={state}" in url
     assert isinstance(state, str)
+
+  @patch(f"{MODULE}.env")
+  def test_rejects_redirect_uri_outside_allowlist(self, mock_env):
+    """A client-supplied redirect_uri outside the trusted origins is rejected
+    (open-redirect / auth-code-theft guard)."""
+    mock_env.get_main_cors_origins.return_value = ["https://roboledger.ai"]
+    handler = OAuthHandler(MockProvider())
+
+    with pytest.raises(HTTPException) as exc_info:
+      handler.get_authorization_url(
+        "conn_1", "usr_1", redirect_uri="https://attacker.example.com/callback"
+      )
+
+    assert exc_info.value.status_code == 400
+    # The flow never started — no state was persisted.
+    assert OAuthState._states == {}
 
   @patch(f"{MODULE}.env")
   def test_generates_url_with_default_redirect(self, mock_env):

--- a/tests/operations/test_connection_service.py
+++ b/tests/operations/test_connection_service.py
@@ -201,6 +201,26 @@ class TestGetConnection:
 
   @pytest.mark.asyncio
   @pytest.mark.unit
+  async def test_wrong_graph_returns_none(self):
+    """A connection in a different graph must not be reachable by guessing
+    its id from another graph's scope (IDOR guard)."""
+    mock_session = MagicMock()
+    mock_conn = _make_mock_connection(graph_id="kg_other", user_id="usr_123")
+
+    with patch(f"{MODULE}.Connection") as MockConn:
+      MockConn.get_by_id.return_value = mock_conn
+
+      result = await ConnectionService.get_connection(
+        connection_id="conn_test123",
+        user_id="usr_123",
+        graph_id="kg_test",
+        db_session=mock_session,
+      )
+
+    assert result is None
+
+  @pytest.mark.asyncio
+  @pytest.mark.unit
   async def test_system_user_bypasses_access_check(self):
     mock_session = MagicMock()
     mock_conn = _make_mock_connection(user_id="usr_other")
@@ -404,6 +424,27 @@ class TestDeleteConnection:
     mock_conn.soft_delete.assert_called_once()
     # Hard-delete is NOT called — that would orphan tenant data.
     mock_conn.delete.assert_not_called()
+
+  @pytest.mark.asyncio
+  @pytest.mark.unit
+  async def test_wrong_graph_returns_false(self):
+    """A connection in a different graph must not be deletable by guessing
+    its id from another graph's scope (IDOR guard)."""
+    mock_session = MagicMock()
+    mock_conn = _make_mock_connection(graph_id="kg_other", user_id="usr_123")
+
+    with patch(f"{MODULE}.Connection") as MockConn:
+      MockConn.get_by_id.return_value = mock_conn
+
+      result = await ConnectionService.delete_connection(
+        connection_id="conn_1",
+        user_id="usr_123",
+        graph_id="kg_test",
+        db_session=mock_session,
+      )
+
+    assert result is False
+    mock_conn.soft_delete.assert_not_called()
 
   @pytest.mark.asyncio
   @pytest.mark.unit

--- a/tests/routers/graphs/connections/test_management.py
+++ b/tests/routers/graphs/connections/test_management.py
@@ -716,8 +716,9 @@ class TestGetConnection:
 
   @pytest.mark.unit
   @pytest.mark.asyncio
-  async def test_get_connection_passes_user_id(self):
-    """Service is called with the authenticated user's ID."""
+  async def test_get_connection_passes_user_id_and_graph_scope(self):
+    """Service is called with the authenticated user's ID and the URL graph
+    scope, so a connection_id can't reach another graph's connection."""
     mock_user = _make_mock_user(user_id="usr_specific")
     mock_db = MagicMock()
     connection_dict = _make_connection_dict()
@@ -735,7 +736,7 @@ class TestGetConnection:
         _rate_limit=None,
       )
 
-    mock_get.assert_called_once_with(CONNECTION_ID, "usr_specific")
+    mock_get.assert_called_once_with(CONNECTION_ID, "usr_specific", graph_id=GRAPH_ID)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Correctness fixes so that resource lookups consistently respect the `graph_id` from the request URL, and so that an optional OAuth `redirect_uri` override is constrained to the configured allowed origins. Previously a couple of direct-by-id lookups ignored the surrounding graph scope, and the OAuth redirect override was accepted as-is.

## Changes

**Backup download — scope the lookup to the graph**
- Added `GraphBackup.get_by_id_and_graph(backup_id, graph_id, session)`, mirroring the existing `Document.get_by_id_and_graph` helper.
- `backup_manager.get_backup_download_url` now resolves the backup scoped to the URL `graph_id` instead of by `backup_id` alone, so a backup belonging to a different graph resolves as "not found" rather than returning a download URL.

**Connection lookups — honor the `graph_id` argument**
- `ConnectionService.get_connection` and `delete_connection` previously accepted `graph_id` but ignored it. They now return `None`/`False` when the connection belongs to a different graph, matching the behavior already implemented in `set_write_policy`.
- Updated the graph-scoped call sites in `routers/graphs/connections/{management,sync,oauth}.py` to pass the URL `graph_id` through.

**OAuth `redirect_uri` override — validate against allowed origins**
- A client-supplied `redirect_uri` override is now checked against the configured frontend origins (`env.get_main_cors_origins()`) and rejected with a 400 if its origin isn't allowed. The server-built default is unchanged (it isn't caller-supplied).
- Validation happens once in `get_authorization_url`; the callback reads the value back from the server-side `OAuthState`, so the vetted value is what's replayed at token exchange.

**Tests**
- New: graph-scoped backup lookup (`test_get_by_id_and_graph`), connection graph-scope (`get_connection` / `delete_connection` wrong-graph cases), and OAuth redirect override validation (allowed origin passes, disallowed origin → 400).
- Updated existing backup-manager and connection-router tests for the new lookup signatures.

## Testing

`just test-all` — passed (full unit suite + dbt + ruff + format + basedpyright + cf-lint).
