### PR TITLE
fix(schedules): contra-aware roll-forward direction from QB AccountSubType

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -112,7 +112,7 @@ OPENSEARCH_URL=http://robosystems-opensearch:9200
 INTUIT_CLIENT_ID=your-intuit-client-id-here
 INTUIT_CLIENT_SECRET=your-intuit-client-secret-here
 INTUIT_ENVIRONMENT=sandbox
-INTUIT_REDIRECT_URI=http://localhost:8000/auth/callback
+INTUIT_REDIRECT_URI=http://localhost:3001/connections/qb-callback
 
 ## CORS — extra origins for dev (e.g., ngrok tunnels for OAuth callbacks).
 ## Comma-separated. Dev only — staging/prod use hardcoded lists.

--- a/robosystems/adapters/quickbooks/dbt/models/ledger/elements.sql
+++ b/robosystems/adapters/quickbooks/dbt/models/ledger/elements.sql
@@ -35,5 +35,8 @@ select
     'USD'                                       as currency,
     a.is_active,
     false                                       as is_placeholder,
-    json_object('account_type', a.account_type) as metadata
+    json_object(
+      'account_type', a.account_type,
+      'account_sub_type', a.account_sub_type
+    )                                            as metadata
 from accounts a

--- a/robosystems/operations/extensions/loader.py
+++ b/robosystems/operations/extensions/loader.py
@@ -143,16 +143,31 @@ _QB_CONTRA_ASSET_SUB_TYPES: frozenset[str] = frozenset(
 )
 
 
+# Accumulated-* sub-type families that are contra-ASSETS. Used as a
+# forward-compatible catch-all (QB periodically adds new variants, e.g.
+# AccumulatedDepreciationEquipment). Deliberately NOT a bare
+# ``startswith("Accumulated")`` — ``AccumulatedOtherComprehensiveIncome``
+# and ``AccumulatedAdjustment`` are QB *equity* sub-types, not contra-assets.
+_QB_CONTRA_ASSET_SUB_TYPE_PREFIXES: tuple[str, ...] = (
+  "AccumulatedDepreciation",
+  "AccumulatedAmortization",
+  "AccumulatedDepletion",
+)
+
+
 def _is_qb_contra_asset_sub_type(sub_type: str | None) -> bool:
   """True if a QuickBooks AccountSubType denotes a contra-asset.
 
-  Matches the known contra sub-types plus the ``Accumulated*`` family as
-  a forward-compatible catch-all (QB periodically adds new accumulated-*
-  fixed-asset sub-types).
+  Matches the known contra sub-types plus the accumulated
+  depreciation/amortization/depletion families as a forward-compatible
+  catch-all. Other ``Accumulated*`` sub-types (e.g. the equity
+  ``AccumulatedOtherComprehensiveIncome``) are intentionally excluded.
   """
   if not sub_type:
     return False
-  return sub_type in _QB_CONTRA_ASSET_SUB_TYPES or sub_type.startswith("Accumulated")
+  return sub_type in _QB_CONTRA_ASSET_SUB_TYPES or sub_type.startswith(
+    _QB_CONTRA_ASSET_SUB_TYPE_PREFIXES
+  )
 
 
 def _parse_metadata(raw) -> dict:
@@ -923,8 +938,13 @@ class OLTPLoader:
       # A contra-asset is asset-typed in QB but offsets the gross asset —
       # override the account_type's plain ``asset`` trait with
       # ``contraAsset`` so rollups subtract it and the schedule generator
-      # rolls it forward in the accumulate (not deplete) direction.
-      if _is_qb_contra_asset_sub_type(meta.get("account_sub_type")):
+      # rolls it forward in the accumulate (not deplete) direction. Guard on
+      # the asset classification so a non-asset Accumulated-* sub-type (e.g.
+      # the equity AccumulatedOtherComprehensiveIncome) can never be
+      # mislabeled as a contra-asset.
+      if efs_identifier == "asset" and _is_qb_contra_asset_sub_type(
+        meta.get("account_sub_type")
+      ):
         efs_identifier = "contraAsset"
       efs_trait_id = efs_id_by_identifier.get(efs_identifier)
       if efs_trait_id is not None:

--- a/robosystems/operations/extensions/loader.py
+++ b/robosystems/operations/extensions/loader.py
@@ -119,6 +119,42 @@ _QB_ACCOUNT_TYPE_TO_LIQUIDITY: dict[str, str] = {
 }
 
 
+# QuickBooks AccountSubType values that denote a contra-asset — an asset-
+# classified account whose balance offsets (reduces) the gross asset it
+# attaches to: accumulated depreciation/amortization/depletion and the
+# allowance for doubtful accounts. QB files these under an asset
+# AccountType ("Fixed Asset", "Other Current Asset") with an "Asset"
+# Classification, so neither ``account_type`` nor the derived
+# ``balance_type`` distinguishes them from a directly-held asset like a
+# prepaid. The AccountSubType is the only signal QB emits — we promote it
+# to the FASB ``contraAsset`` EFS trait at load (instead of the plain
+# ``asset`` trait its account_type implies) so downstream readers — the
+# auto-map agent, rollups, and the schedule roll-forward generator — can
+# tell a balance that accumulates UP toward cost from one that draws DOWN
+# to zero.
+_QB_CONTRA_ASSET_SUB_TYPES: frozenset[str] = frozenset(
+  {
+    "AccumulatedDepreciation",
+    "AccumulatedAmortization",
+    "AccumulatedDepletion",
+    "AccumulatedAmortizationOfOtherAssets",
+    "AllowanceForBadDebts",
+  }
+)
+
+
+def _is_qb_contra_asset_sub_type(sub_type: str | None) -> bool:
+  """True if a QuickBooks AccountSubType denotes a contra-asset.
+
+  Matches the known contra sub-types plus the ``Accumulated*`` family as
+  a forward-compatible catch-all (QB periodically adds new accumulated-*
+  fixed-asset sub-types).
+  """
+  if not sub_type:
+    return False
+  return sub_type in _QB_CONTRA_ASSET_SUB_TYPES or sub_type.startswith("Accumulated")
+
+
 def _parse_metadata(raw) -> dict:
   """Parse metadata from dbt output — may be a dict, JSON string, or None."""
   if isinstance(raw, dict):
@@ -826,7 +862,11 @@ class OLTPLoader:
     # liquidity is an additive narrowing signal — if its trait rows are
     # absent we still emit EFS rather than skipping the element.
     efs_id_by_identifier = _resolve_trait_ids(
-      "elementsOfFinancialStatements", set(type_to_efs.values())
+      "elementsOfFinancialStatements",
+      # ``contraAsset`` is not a target of the account_type map (every QB
+      # asset type maps to plain ``asset``); it's selected per-element
+      # below from the AccountSubType, so resolve its id here too.
+      set(type_to_efs.values()) | {"contraAsset"},
     )
     if not efs_id_by_identifier:
       logger.warning(
@@ -880,6 +920,12 @@ class OLTPLoader:
           elem.id,
         )
         continue
+      # A contra-asset is asset-typed in QB but offsets the gross asset —
+      # override the account_type's plain ``asset`` trait with
+      # ``contraAsset`` so rollups subtract it and the schedule generator
+      # rolls it forward in the accumulate (not deplete) direction.
+      if _is_qb_contra_asset_sub_type(meta.get("account_sub_type")):
+        efs_identifier = "contraAsset"
       efs_trait_id = efs_id_by_identifier.get(efs_identifier)
       if efs_trait_id is not None:
         rows.append(_trait_row(elem.id, efs_trait_id))

--- a/robosystems/operations/roboledger/schedules/service.py
+++ b/robosystems/operations/roboledger/schedules/service.py
@@ -355,7 +355,10 @@ class ScheduleService:
     credit_balance_type = session.execute(
       select(Element.balance_type).where(Element.id == entry_template.credit_element_id)
     ).scalar()
-    credit_is_contra = _element_is_contra_asset(
+    # Only debit-normal accounts can be contra-assets, so skip the trait
+    # lookup for credit-balance accounts (liabilities, deferred revenue) —
+    # the common case.
+    credit_is_contra = credit_balance_type == "debit" and _element_is_contra_asset(
       session, entry_template.credit_element_id
     )
     credit_draws_down = credit_balance_type == "debit" and not credit_is_contra

--- a/robosystems/operations/roboledger/schedules/service.py
+++ b/robosystems/operations/roboledger/schedules/service.py
@@ -21,6 +21,7 @@ from robosystems.models.api.fact_provenance import (
   AssertedProvenance,
   ScheduleProvenance,
 )
+from robosystems.models.extensions.element_trait import ElementTrait
 from robosystems.models.extensions.roboledger import (
   Association,
   Element,
@@ -32,6 +33,7 @@ from robosystems.models.extensions.roboledger import (
   Taxonomy,
 )
 from robosystems.models.extensions.rule import Rule
+from robosystems.models.extensions.trait import Trait
 from robosystems.operations.roboledger.fact_set import create_fact_set
 from robosystems.utils.ulid import generate_prefixed_ulid
 
@@ -339,19 +341,36 @@ class ScheduleService:
     )
 
     # The credit fact tracks the running balance of the credited account, and
-    # its direction depends on that account's normal balance:
-    #   • credit-balance account (a contra-asset like Accumulated Depreciation,
-    #     or a liability) — the period credit INCREASES it, so the balance
-    #     accumulates from a zero opening: value = accumulated_debit.
-    #   • debit-balance account (a prepaid / other asset credited directly) —
-    #     the period credit DECREASES it, so the balance draws down from its
-    #     opening (the original gross outlay): value = original - accumulated.
-    # Without original_dollars there's no opening to anchor the drawdown, so
-    # fall back to the accumulating form.
+    # its direction depends on that account's role:
+    #   • contra-asset (Accumulated Depreciation/Amortization) or a credit-
+    #     balance account (a liability) — the period credit INCREASES it, so
+    #     the balance accumulates UP from a zero opening: value = accumulated.
+    #   • directly-credited asset (a prepaid) — the period credit DECREASES it,
+    #     so the balance draws DOWN from its opening cost: value = original -
+    #     accumulated.
+    # A contra-asset is asset/debit-normal in QuickBooks, so ``balance_type``
+    # alone can't distinguish it from a prepaid — the contraAsset EFS trait
+    # (applied at sync from the CoA AccountSubType) is the authoritative role
+    # signal. Only a debit-balance, non-contra asset draws down.
     credit_balance_type = session.execute(
       select(Element.balance_type).where(Element.id == entry_template.credit_element_id)
     ).scalar()
-    credit_draws_down = credit_balance_type == "debit" and original_dollars is not None
+    credit_is_contra = _element_is_contra_asset(
+      session, entry_template.credit_element_id
+    )
+    credit_draws_down = credit_balance_type == "debit" and not credit_is_contra
+    # Drawing down needs an opening cost basis. When the author didn't supply
+    # original_amount, derive it from the straight-line curve (monthly x
+    # periods) so the prepaid balance declines from cost to ~0 instead of
+    # falling back to the (wrong-for-a-prepaid) accumulating form. Custom
+    # amortization curves always carry original_amount (validated below), so
+    # this only fills the straight-line gap; contra/accumulate schedules are
+    # untouched (they open at zero and need no cost basis).
+    if credit_draws_down and original_dollars is None and periods:
+      original_dollars = round(amount_dollars * len(periods), 2)
+    # If a draw-down still has no opening (e.g. no periods), fall back to
+    # accumulate rather than emit a garbage curve.
+    credit_draws_down = credit_draws_down and original_dollars is not None
 
     # Custom amortization curve: caller supplies one integer (cents) per
     # period, pre-balanced. The generator uses the explicit values
@@ -1649,6 +1668,34 @@ class ScheduleService:
 
 
 # ── Utility ──────────────────────────────────────────────────────────────
+
+
+def _element_is_contra_asset(session: Session, element_id: str) -> bool:
+  """True if the element carries the FASB ``contraAsset`` EFS trait.
+
+  A contra-asset (accumulated depreciation/amortization, the allowance for
+  doubtful accounts) accumulates *up* toward the gross asset's cost; a
+  directly-credited asset (a prepaid) draws *down* from cost to zero. The
+  two are indistinguishable by ``balance_type`` — QuickBooks types both as
+  asset/debit-normal — so the schedule roll-forward direction is keyed off
+  this trait, which the sync applies from the source CoA's AccountSubType
+  (see ``operations/extensions/loader.py``). Reading the trait keeps this
+  generator source-agnostic rather than re-deriving from QB-specific
+  metadata strings.
+  """
+  return (
+    session.execute(
+      select(ElementTrait.element_id)
+      .join(Trait, Trait.id == ElementTrait.trait_id)
+      .where(
+        ElementTrait.element_id == element_id,
+        Trait.category == "elementsOfFinancialStatements",
+        Trait.identifier == "contraAsset",
+      )
+      .limit(1)
+    ).scalar()
+    is not None
+  )
 
 
 def _generate_monthly_periods(start: date, end: date) -> list[tuple[date, date]]:

--- a/tests/operations/extensions/test_loader.py
+++ b/tests/operations/extensions/test_loader.py
@@ -992,6 +992,41 @@ class TestInboundAutoCommitDecoupledFromWritePolicy:
     assert _source_auto_commits_on_sync("netsuite") is False
 
 
+class TestIsQbContraAssetSubType:
+  """The QB AccountSubType → contra-asset predicate that drives both the
+  contraAsset trait and the schedule roll-forward direction."""
+
+  def test_known_contra_sub_types(self):
+    from robosystems.operations.extensions.loader import _is_qb_contra_asset_sub_type
+
+    for sub_type in (
+      "AccumulatedDepreciation",
+      "AccumulatedAmortization",
+      "AccumulatedDepletion",
+      "AccumulatedAmortizationOfOtherAssets",
+      "AllowanceForBadDebts",
+    ):
+      assert _is_qb_contra_asset_sub_type(sub_type) is True
+
+  def test_accumulated_family_catch_all(self):
+    from robosystems.operations.extensions.loader import _is_qb_contra_asset_sub_type
+
+    # Forward-compat: an unlisted Accumulated* sub-type is still contra.
+    assert _is_qb_contra_asset_sub_type("AccumulatedSomethingNew") is True
+
+  def test_direct_assets_are_not_contra(self):
+    from robosystems.operations.extensions.loader import _is_qb_contra_asset_sub_type
+
+    for sub_type in ("PrepaidExpenses", "Checking", "Inventory", "Vehicles"):
+      assert _is_qb_contra_asset_sub_type(sub_type) is False
+
+  def test_none_and_empty_are_not_contra(self):
+    from robosystems.operations.extensions.loader import _is_qb_contra_asset_sub_type
+
+    assert _is_qb_contra_asset_sub_type(None) is False
+    assert _is_qb_contra_asset_sub_type("") is False
+
+
 class TestApplySourceElementTraits:
   """QB ``AccountType`` → FASB EFS trait translation. Without this,
   QB-imported elements have ``trait IS NULL`` and the auto-map agent
@@ -1053,6 +1088,55 @@ class TestApplySourceElementTraits:
 
     assert inserted == 3
     session.execute.assert_called_once()
+
+  def test_contra_asset_sub_type_maps_to_contra_asset_trait(self):
+    """A QB Accumulated Depreciation account is asset-typed (→ plain
+    ``asset`` by account_type) but its AccountSubType identifies it as a
+    contra — it must get the ``contraAsset`` EFS trait so rollups subtract
+    it and the schedule generator rolls it forward as an accumulator.
+
+    Rows are bulk-inserted (not via ``session.add``), so we make the count
+    unambiguous via trait *resolvability*: only the ``contraAsset`` trait
+    id is resolvable. The contra (override → contraAsset) yields one row;
+    the prepaid (asset → not resolvable) and the noncurrent liquidity row
+    (not resolvable) yield none. A broken override would map the contra to
+    ``asset`` → not resolvable → zero rows.
+    """
+    from robosystems.operations.extensions.loader import OLTPLoader
+
+    elem_accum = MagicMock(
+      id="elem_1",
+      metadata_={
+        "account_type": "Fixed Asset",
+        "account_sub_type": "AccumulatedDepreciation",
+      },
+    )
+    elem_prepaid = MagicMock(
+      id="elem_2",
+      metadata_={
+        "account_type": "Other Current Asset",
+        "account_sub_type": "PrepaidExpenses",
+      },
+    )
+
+    traits = [self._trait("contraAsset", "trt_contra")]
+    session = self._make_loader_session(
+      {"elem_1": elem_accum, "elem_2": elem_prepaid}, traits
+    )
+
+    loader = OLTPLoader()
+    inserted = loader._apply_source_element_traits(
+      session,
+      source="quickbooks",
+      connection_id="conn_1",
+      created_by="user_1",
+      now=datetime.now(UTC),
+    )
+
+    # Only the contra resolves to contraAsset → exactly one row. (Without
+    # the override the contra would resolve to the unresolvable ``asset``
+    # and this would be zero.)
+    assert inserted == 1
 
   def test_qb_account_type_also_translates_to_liquidity_trait(self):
     """Assets/liabilities get a liquidity (current/noncurrent) trait in

--- a/tests/operations/extensions/test_loader.py
+++ b/tests/operations/extensions/test_loader.py
@@ -1008,11 +1008,22 @@ class TestIsQbContraAssetSubType:
     ):
       assert _is_qb_contra_asset_sub_type(sub_type) is True
 
-  def test_accumulated_family_catch_all(self):
+  def test_accumulated_asset_family_catch_all(self):
     from robosystems.operations.extensions.loader import _is_qb_contra_asset_sub_type
 
-    # Forward-compat: an unlisted Accumulated* sub-type is still contra.
-    assert _is_qb_contra_asset_sub_type("AccumulatedSomethingNew") is True
+    # Forward-compat: unlisted depreciation/amortization/depletion variants
+    # are still contra-assets.
+    assert _is_qb_contra_asset_sub_type("AccumulatedDepreciationEquipment") is True
+    assert _is_qb_contra_asset_sub_type("AccumulatedAmortizationLeasehold") is True
+
+  def test_non_asset_accumulated_sub_types_are_not_contra(self):
+    from robosystems.operations.extensions.loader import _is_qb_contra_asset_sub_type
+
+    # AccumulatedOtherComprehensiveIncome / AccumulatedAdjustment are QB
+    # *equity* sub-types — the catch-all must NOT classify them as
+    # contra-assets.
+    assert _is_qb_contra_asset_sub_type("AccumulatedOtherComprehensiveIncome") is False
+    assert _is_qb_contra_asset_sub_type("AccumulatedAdjustment") is False
 
   def test_direct_assets_are_not_contra(self):
     from robosystems.operations.extensions.loader import _is_qb_contra_asset_sub_type
@@ -1088,6 +1099,35 @@ class TestApplySourceElementTraits:
 
     assert inserted == 3
     session.execute.assert_called_once()
+
+  def test_equity_accumulated_sub_type_is_not_marked_contra_asset(self):
+    """AccumulatedOtherComprehensiveIncome is a QB *equity* sub-type; the
+    contra override is asset-scoped, so it must keep its equity trait and
+    NOT be promoted to contraAsset. Only ``contraAsset`` is resolvable, so a
+    correct run inserts 0 rows (the AOCI element → equity, unresolvable); a
+    broken override would map it to contraAsset → 1 row."""
+    from robosystems.operations.extensions.loader import OLTPLoader
+
+    elem_aoci = MagicMock(
+      id="elem_1",
+      metadata_={
+        "account_type": "Equity",
+        "account_sub_type": "AccumulatedOtherComprehensiveIncome",
+      },
+    )
+    traits = [self._trait("contraAsset", "trt_contra")]
+    session = self._make_loader_session({"elem_1": elem_aoci}, traits)
+
+    loader = OLTPLoader()
+    inserted = loader._apply_source_element_traits(
+      session,
+      source="quickbooks",
+      connection_id="conn_1",
+      created_by="user_1",
+      now=datetime.now(UTC),
+    )
+
+    assert inserted == 0
 
   def test_contra_asset_sub_type_maps_to_contra_asset_trait(self):
     """A QB Accumulated Depreciation account is asset-typed (→ plain

--- a/tests/operations/roboledger/schedules/test_service.py
+++ b/tests/operations/roboledger/schedules/test_service.py
@@ -418,7 +418,9 @@ class TestCreateScheduleCreditDirection:
   ):
     svc = ScheduleService()
     # execute order: (1) cm role lookup, (2) credit balance_type lookup,
-    # (3) credit contraAsset-trait lookup, (4) SumEquals qname lookup.
+    # (3) credit contraAsset-trait lookup — ONLY when balance_type=='debit'
+    # (the service short-circuits the trait query for credit-balance
+    # accounts), (4) SumEquals qname lookup.
     cm_roles_row = MagicMock()
     cm_roles_row.scalars.return_value = []
     balance_row = MagicMock()
@@ -427,7 +429,11 @@ class TestCreateScheduleCreditDirection:
     contra_row.scalar.return_value = "elem_cr" if is_contra else None
     qname_row = MagicMock()
     qname_row.scalar.return_value = "fac:Expense"
-    session.execute.side_effect = [cm_roles_row, balance_row, contra_row, qname_row]
+    seq = [cm_roles_row, balance_row]
+    if credit_balance_type == "debit":
+      seq.append(contra_row)
+    seq.append(qname_row)
+    session.execute.side_effect = seq
 
     with patch.object(svc, "_get_entity_id", return_value="ent_01"):
       svc.create_schedule(
@@ -512,24 +518,22 @@ class TestCreateScheduleSumEqualsRule:
   def _run(self, session, *, original_amount: int | None = 120_000):
     svc = ScheduleService()
     # taxonomy_id is provided so _ensure_schedule_taxonomy is skipped.
-    # Four execute() calls now: (1) the cm:Debit/cm:Credit posting-role lookup
+    # Three execute() calls: (1) the cm:Debit/cm:Credit posting-role lookup
     # for has-part arcs (no roles in the mock → arcs skipped), (2) the credit
-    # element's balance_type lookup (a contra here → credit fact accumulates),
-    # (3) the credit element's contraAsset-trait lookup, then (4) the
-    # Element.qname lookup for the SumEquals rule.
+    # element's balance_type lookup (a credit-balance contra here → credit
+    # fact accumulates), then (3) the Element.qname lookup for the SumEquals
+    # rule. The contraAsset-trait lookup is short-circuited because the
+    # credit account is credit-balance.
     cm_roles_row = MagicMock()
     cm_roles_row.scalars.return_value = []
     credit_balance_row = MagicMock()
     credit_balance_row.scalar.return_value = "credit"
-    contra_row = MagicMock()
-    contra_row.scalar.return_value = None
     debit_qname_row = MagicMock()
     debit_qname_row.scalar.return_value = "fac:DeprExpense"
 
     session.execute.side_effect = [
       cm_roles_row,
       credit_balance_row,
-      contra_row,
       debit_qname_row,
     ]
 
@@ -576,6 +580,48 @@ class TestCreateScheduleSumEqualsRule:
     added = self._run(session, original_amount=120_000)
     rules = [o for o in added if type(o).__name__ == "Rule"]
     assert rules[0].metadata_["expected_total"] == 1200.0  # cents → dollars
+
+  def test_sum_equals_rule_uses_derived_total_when_no_original_amount(self):
+    """A prepaid created without original_amount (the Harbinger case) still
+    emits a SumEquals rule anchored to the derived total (monthly x periods),
+    not skipped as it would be for a contra/accumulate schedule with no cost
+    basis."""
+    session = _mock_session()
+    svc = ScheduleService()
+    # debit-balance, non-contra credit element ⇒ draws down ⇒ original is
+    # derived ⇒ SumEquals fires. execute order: cm, balance(debit),
+    # contra-trait(None), qname.
+    cm_roles_row = MagicMock()
+    cm_roles_row.scalars.return_value = []
+    balance_row = MagicMock()
+    balance_row.scalar.return_value = "debit"
+    contra_row = MagicMock()
+    contra_row.scalar.return_value = None
+    qname_row = MagicMock()
+    qname_row.scalar.return_value = "fac:Expense"
+    session.execute.side_effect = [cm_roles_row, balance_row, contra_row, qname_row]
+
+    with patch.object(svc, "_get_entity_id", return_value="ent_01"):
+      svc.create_schedule(
+        session,
+        name="Prepaid no-original",
+        taxonomy_id="tax_01",
+        element_ids=["elem_dr", "elem_cr"],
+        period_start=date(2026, 1, 1),
+        period_end=date(2026, 3, 31),  # 3 periods
+        monthly_amount=40_000,  # $400/mo → derived total $1,200
+        entry_template=EntryTemplate(
+          debit_element_id="elem_dr", credit_element_id="elem_cr"
+        ),
+        schedule_metadata=None,  # no original_amount
+        created_by="usr_test",
+      )
+
+    added = [c[0][0] for c in session.add.call_args_list]
+    rules = [o for o in added if type(o).__name__ == "Rule"]
+    assert len(rules) == 1
+    assert rules[0].rule_pattern == "SumEquals"
+    assert rules[0].metadata_["expected_total"] == 1200.0  # 400 x 3, derived
 
   def test_sum_equals_rule_targets_structure(self):
     session = _mock_session()

--- a/tests/operations/roboledger/schedules/test_service.py
+++ b/tests/operations/roboledger/schedules/test_service.py
@@ -407,17 +407,27 @@ class TestCreateScheduleCreditDirection:
   contra-asset (credit-balance) accumulates; a directly-credited debit-balance
   asset like a prepaid draws down toward zero."""
 
-  def _credit_facts(self, session, *, credit_balance_type, asset_element_id=None):
+  def _credit_facts(
+    self,
+    session,
+    *,
+    credit_balance_type,
+    asset_element_id=None,
+    is_contra=False,
+    original_amount=120_000,
+  ):
     svc = ScheduleService()
     # execute order: (1) cm role lookup, (2) credit balance_type lookup,
-    # (3) SumEquals qname lookup.
+    # (3) credit contraAsset-trait lookup, (4) SumEquals qname lookup.
     cm_roles_row = MagicMock()
     cm_roles_row.scalars.return_value = []
     balance_row = MagicMock()
     balance_row.scalar.return_value = credit_balance_type
+    contra_row = MagicMock()
+    contra_row.scalar.return_value = "elem_cr" if is_contra else None
     qname_row = MagicMock()
     qname_row.scalar.return_value = "fac:Expense"
-    session.execute.side_effect = [cm_roles_row, balance_row, qname_row]
+    session.execute.side_effect = [cm_roles_row, balance_row, contra_row, qname_row]
 
     with patch.object(svc, "_get_entity_id", return_value="ent_01"):
       svc.create_schedule(
@@ -433,7 +443,7 @@ class TestCreateScheduleCreditDirection:
         ),
         schedule_metadata=ScheduleMetadata(
           method="straight_line",
-          original_amount=120_000,  # $1,200 total
+          original_amount=original_amount,  # 0 ⇒ derive from monthly x periods
           asset_element_id=asset_element_id,
         ),
         created_by="usr_test",
@@ -452,9 +462,28 @@ class TestCreateScheduleCreditDirection:
     facts = self._credit_facts(_mock_session(), credit_balance_type="credit")
     assert [f.value for f in facts] == [0.0, 400.0, 800.0, 1200.0]
 
+  def test_debit_balance_contra_accumulates(self):
+    # A QuickBooks Accumulated Depreciation account is asset/debit-normal but
+    # carries the contraAsset trait — balance_type would (wrongly) say "draws
+    # down", the trait makes it accumulate UP to cost like the contra it is.
+    facts = self._credit_facts(
+      _mock_session(), credit_balance_type="debit", is_contra=True
+    )
+    assert [f.value for f in facts] == [0.0, 400.0, 800.0, 1200.0]
+
   def test_directly_credited_asset_draws_down(self):
     # opening (1200 gross) + 3 drawing-down endings
     facts = self._credit_facts(_mock_session(), credit_balance_type="debit")
+    assert [f.value for f in facts] == [1200.0, 800.0, 400.0, 0.0]
+
+  def test_prepaid_without_original_derives_opening_and_draws_down(self):
+    # The Harbinger first-close bug: a prepaid schedule created without
+    # original_amount used to fall back to accumulating (balance climbing to
+    # cost). The opening cost is now derived from monthly x periods so the
+    # prepaid balance declines from cost to zero.
+    facts = self._credit_facts(
+      _mock_session(), credit_balance_type="debit", original_amount=0
+    )
     assert [f.value for f in facts] == [1200.0, 800.0, 400.0, 0.0]
 
   def test_asset_equals_credit_element_no_double_emit(self):
@@ -483,18 +512,26 @@ class TestCreateScheduleSumEqualsRule:
   def _run(self, session, *, original_amount: int | None = 120_000):
     svc = ScheduleService()
     # taxonomy_id is provided so _ensure_schedule_taxonomy is skipped.
-    # Three execute() calls now: (1) the cm:Debit/cm:Credit posting-role lookup
+    # Four execute() calls now: (1) the cm:Debit/cm:Credit posting-role lookup
     # for has-part arcs (no roles in the mock → arcs skipped), (2) the credit
     # element's balance_type lookup (a contra here → credit fact accumulates),
-    # then (3) the Element.qname lookup for the SumEquals rule.
+    # (3) the credit element's contraAsset-trait lookup, then (4) the
+    # Element.qname lookup for the SumEquals rule.
     cm_roles_row = MagicMock()
     cm_roles_row.scalars.return_value = []
     credit_balance_row = MagicMock()
     credit_balance_row.scalar.return_value = "credit"
+    contra_row = MagicMock()
+    contra_row.scalar.return_value = None
     debit_qname_row = MagicMock()
     debit_qname_row.scalar.return_value = "fac:DeprExpense"
 
-    session.execute.side_effect = [cm_roles_row, credit_balance_row, debit_qname_row]
+    session.execute.side_effect = [
+      cm_roles_row,
+      credit_balance_row,
+      contra_row,
+      debit_qname_row,
+    ]
 
     metadata = (
       ScheduleMetadata(


### PR DESCRIPTION
## Summary

Prepaid amortization schedules rendered their asset balance **climbing toward cost** instead of **depleting to zero**, while depreciation/amortization schedules (which use a contra account) were correct. The fix gives the schedule generator chart-of-accounts role awareness so a directly-credited asset (a prepaid) draws down from cost while a contra-asset (accumulated depreciation/amortization) accumulates up — driven by data QuickBooks already emits.

Surfaced during the first production close (Harbinger FinLab).

## Root cause

QuickBooks files contra-assets (Accumulated Depreciation/Amortization) under an asset `AccountType` (`Fixed Asset`) with `Classification=Asset` — identical top-level classification to a prepaid (`Other Current Asset`). Our dbt `normal_balance` macro maps both to `balance_type='debit'`, so balance_type alone cannot distinguish them. The one field that *does* distinguish them — QB's `AccountSubType` (`AccumulatedDepreciation` vs `PrepaidExpenses`) — was being **dropped at load** (the `Element` table kept only `metadata.account_type`).

The earlier partial fix keyed the draw-down on `balance_type` (unreliable, as above) **and** required `original_amount` (absent on these schedules), so neither branch ever fired.

## Changes

- **dbt** (`adapters/quickbooks/dbt/models/ledger/elements.sql`) — persist `account_sub_type` into `Element.metadata` (JSONB; no migration).
- **loader** (`operations/extensions/loader.py`) — add `_QB_CONTRA_ASSET_SUB_TYPES` + `_is_qb_contra_asset_sub_type`; in `_apply_source_element_traits`, a contra sub-type now receives the FASB **`contraAsset`** `elementsOfFinancialStatements` trait instead of the plain `asset` its account_type implies. Robust contra identification *at element creation* — also correct for rollups and the auto-map agent, not just schedules.
- **schedule service** (`operations/roboledger/schedules/service.py`) — add `_element_is_contra_asset` (reads the `contraAsset` trait, so it's source-agnostic); drive roll-forward direction off it (`credit_draws_down = balance_type=='debit' and not is_contra`); and when `original_amount` is absent, derive the opening cost from the straight-line curve (`monthly x periods`) so a prepaid declines from cost to ~0 (this also correctly anchors the final-period rounding, NBV, and the SumEquals rule).
- **tests** — `tests/operations/extensions/test_loader.py`: contra sub-type maps to the `contraAsset` trait, plus the `_is_qb_contra_asset_sub_type` predicate (known sub-types, `Accumulated*` catch-all, direct assets, None/empty). `tests/operations/roboledger/schedules/test_service.py`: debit-balance contra accumulates; prepaid without `original_amount` derives the opening and draws down; updated the existing mock execute-ordering for the new contra-trait query.
- **`.env.example`** — correct `INTUIT_REDIRECT_URI` to the actual roboledger-app callback (`http://localhost:3001/connections/qb-callback`); the old `http://localhost:8000/auth/callback` was wrong.

## Testing

- `just test` (full unit suite) — **10537 passed, 15 skipped** (~7m).
- `just test-code` (ruff + format + basedpyright + cf-lint) — **clean** (also runs via pre-commit on each commit).
- **End-to-end on a live QuickBooks sandbox** (full-rebuild sync through the real pipeline): `metadata.account_sub_type` persisted; the contra got the `contraAsset` trait (prepaid got `asset`); `_element_is_contra_asset()` returned True/False correctly on the real synced elements. Same generator, $100/mo over 3 periods, no `original_amount`: prepaid **depletes** 300 -> 0, depreciation **accumulates** 0 -> 300.

## Notes / Follow-ups

- **No DB migration** — the contra signal rides in the existing JSONB `metadata`.
- **Existing graphs need a re-sync** to apply the `contraAsset` trait / `metadata.account_sub_type` to already-loaded elements; new syncs are correct from the start. Harbinger remediation: re-sync, then re-create the prepaid schedules to pick up the corrected (depleting) roll-forward. Depreciation/amortization schedules were already accumulating correctly.
- GL postings were never affected — only the roll-forward **balance tracking** for directly-credited assets.
