### PR TITLE
feat(examples): DataBook serialization for report bundles

### DIFF
--- a/examples/_common/databook.py
+++ b/examples/_common/databook.py
@@ -11,8 +11,9 @@ A RoboSystems Report maps onto the pattern almost 1:1: the report **is** a
 collection of Information Blocks, and each IB renders two ways —
 
 * a **markdown table** (the human view of the block's facts), and
-* an addressable ``turtle`` fenced block ``{#ib-...}`` (the machine view —
-  the same facts as RDF, which reads far better than the JSON-LD).
+* an addressable ``turtle`` fenced block ``{#<block_type>}`` keyed to the
+  frontmatter ``manifest`` (the machine view — the same facts as RDF, which
+  reads far better than the JSON-LD).
 
 Everything is derived from the on-disk ``.jsonld`` artifact (same design as
 ``validate.py``): no API, no database, no container. The DataBook therefore
@@ -71,12 +72,27 @@ _BLOCK_ORDER: dict[str, int] = {
   "equity_statement": 3,
 }
 
+# Friendly section headings keyed by block_type (the IB prefLabel — e.g.
+# "rs-gaap — Balance Sheet — Classified" — goes in the manifest description).
+_BLOCK_TITLES: dict[str, str] = {
+  "balance_sheet": "Balance Sheet",
+  "income_statement": "Income Statement",
+  "cash_flow_statement": "Cash Flow Statement",
+  "equity_statement": "Statement of Changes in Equity",
+}
+
 
 def _rel(p: Path) -> str:
   try:
     return str(p.resolve().relative_to(REPO_ROOT))
   except ValueError:
     return str(p)
+
+
+def _yaml_str(s: str) -> str:
+  """Double-quoted YAML scalar with real Unicode preserved (em-dash, arrows)
+  rather than ``\\uXXXX`` escapes — matches Charlie's hand-authored examples."""
+  return json.dumps(s, ensure_ascii=False)
 
 
 def _fmt_money(v: float | None) -> str:
@@ -296,10 +312,40 @@ def _render_ib_turtle(src: Graph, ib: URIRef) -> str:
 # ── Frontmatter ──────────────────────────────────────────────────────────────
 
 
-def _frontmatter(g: Graph, root: URIRef, ibs: list[URIRef], columns: list[dict]) -> str:
+def _frontmatter(
+  g: Graph, root: URIRef, ibs: list[URIRef], columns: list[dict], title: str
+) -> str:
+  """DataBook frontmatter in Charlie Hoffman's canonical envelope + key order
+  (id · type · title · version · created · modified · authors · license ·
+  description · tags · provenance · manifest), so the ``databook`` CLI parses
+  it; see seattlemethod/prototypes ``md-examples/``. RoboSystems-specific
+  metadata lives in a ``report`` extension block after the canonical keys."""
   meta = g.value(root, RS.reportMeta)
   entity = g.value(root, RS.entity)
   entity_name = str(g.value(entity, SKOS.prefLabel) or "") if entity else ""
+
+  def _meta(pred: URIRef) -> str | None:
+    val = g.value(meta, pred) if meta is not None else None
+    return str(val) if val is not None else None
+
+  # 1.0 → 1.0.0: the canonical `version` is semver.
+  version = str(g.value(root, RS.serializationVersion) or "1.0")
+  version += ".0" * max(0, 2 - version.count("."))
+  created = _meta(RS.filedAt) or _meta(RS.sharedAt)  # doc date, when known
+
+  report_id = _meta(RS.reportId)
+  generation = _meta(RS.generationCount)
+  filing_status = _meta(RS.filingStatus) or "draft"
+  src_graph = _meta(RS.sourceGraphId)
+
+  source = entity_name or "RoboSystems graph"
+  if src_graph:
+    source += f" (graph {src_graph})"
+  method = "Materialized RoboSystems Report"
+  if report_id:
+    method += f" {report_id}"
+  if generation:
+    method += f" (generation {generation}, {filing_status})"
 
   pins: list[tuple[str, str]] = []
   for pin in g.objects(root, RS.frameworkPins):
@@ -309,50 +355,58 @@ def _frontmatter(g: Graph, root: URIRef, ibs: list[URIRef], columns: list[dict])
       pins.append((fw, ver))
 
   lines: list[str] = ["---"]
+  # ── Canonical DataBook envelope (key order matters to the databook CLI) ──
   lines.append(f"id: {root}")
-  lines.append("type: databook")
-  lines.append("vocab: https://w3id.org/databook/ns#")
-  lines.append(
-    f'serialization_version: "{g.value(root, RS.serializationVersion) or ""}"'
-  )
+  lines.append("type: DataBook")
+  lines.append(f"title: {_yaml_str(title)}")
+  lines.append(f"version: {version}")
+  if created:
+    lines.append(f"created: {created}")
+    lines.append(f"modified: {created}")
+  lines.append("authors:")
+  lines.append('  - name: "RoboSystems Report Engine"')
+  lines.append("license: CC-BY-4.0")
+  lines.append("description: >")
+  lines.append("  Published financial report as a DataBook — the report as a")
+  lines.append("  collection of Information Blocks (balance sheet, income")
+  lines.append("  statement, cash flow, statement of changes in equity), each a")
+  lines.append("  table plus an addressable RDF/Turtle slice, with SHACL + XBRL")
+  lines.append("  2.1 validation evidence inlined.")
+  lines.append("tags:")
+  for tag in ("financial", "reporting", "xbrl", "rs-gaap", "databook"):
+    lines.append(f"  - {tag}")
+  lines.append("provenance:")
+  lines.append(f"  source: {_yaml_str(source)}")
+  lines.append(f"  method: {_yaml_str(method)}")
+  lines.append("manifest:")
+  lines.append("  entrypoints:")
+  for ib in ibs:
+    lines.append(f"    - block: {g.value(ib, RS.blockType)}")
+  lines.append("  blocks:")
+  for ib in ibs:
+    bt = str(g.value(ib, RS.blockType) or "block")
+    desc = str(g.value(ib, SKOS.prefLabel) or bt)
+    lines.append(f"    {bt}:")
+    lines.append("      type: turtle")
+    lines.append(f"      description: {_yaml_str(desc)}")
+  # ── RoboSystems extension (after the canonical keys) ──
   lines.append("report:")
   lines.append(f"  reporting_style: {g.value(root, RS.reportingStyle) or ''}")
-  if entity_name:
-    lines.append(f"  entity: {json.dumps(entity_name)}")
+  if report_id:
+    lines.append(f"  report_id: {report_id}")
+  if generation:
+    lines.append(f"  generation_count: {generation}")
+  lines.append(f"  filing_status: {filing_status}")
+  if src_graph:
+    lines.append(f"  source_graph_id: {src_graph}")
   lines.append("  periods:")
   for c in columns:
     lines.append(
-      f"    - {{ label: {json.dumps(c['label'])}, start: {c['start']}, end: {c['end']} }}"
+      f"    - {{ label: {_yaml_str(c['label'])}, start: {c['start']}, end: {c['end']} }}"
     )
   lines.append("  framework_pins:")
   for fw, ver in pins:
     lines.append(f"    - {{ framework: {fw}, version: {ver} }}")
-
-  # The process stamp — RoboSystems report-engine provenance, DataBook-shaped.
-  lines.append("process:")
-  lines.append("  transformer: robosystems-report-engine")
-  if meta is not None:
-    for key, pred in (
-      ("report_id", RS.reportId),
-      ("generation_count", RS.generationCount),
-      ("filing_status", RS.filingStatus),
-      ("filed_at", RS.filedAt),
-      ("supersedes_id", RS.supersedesId),
-      ("source_graph_id", RS.sourceGraphId),
-      ("source_report_id", RS.sourceReportId),
-      ("shared_at", RS.sharedAt),
-    ):
-      val = g.value(meta, pred)
-      if val is not None:
-        lines.append(f"  {key}: {val}")
-
-  lines.append("information_blocks:")
-  for ib in ibs:
-    bt = str(g.value(ib, RS.blockType) or "")
-    lines.append(
-      f"  - {{ id: {g.value(ib, RS.internalId)}, block_type: {bt}, anchor: ib-{bt} }}"
-    )
-  lines.append("license: CC-BY-4.0")
   lines.append("---")
   return "\n".join(lines)
 
@@ -413,28 +467,33 @@ def write_databook(
     ),
   )
 
-  parts: list[str] = [_frontmatter(g, root, ibs, columns)]  # type: ignore[arg-type]
+  entity = g.value(root, RS.entity)
+  entity_name = str(g.value(entity, SKOS.prefLabel) or "") if entity else ""
+  title = f"{label} — {entity_name}" if entity_name else label
+
+  parts: list[str] = [_frontmatter(g, root, ibs, columns, title)]  # type: ignore[arg-type]
   parts.append(
-    f"\n# {label} — Report DataBook\n\n"
+    f"\n# {title}\n\n"
     f"A report **is** a collection of Information Blocks. Each block below is "
     f"shown twice: a markdown table (human view) and an addressable `turtle` "
-    f"block (machine view — the same facts as RDF). Frontmatter carries the "
-    f"report's provenance *process stamp*. Everything here is derived from "
+    f"block (machine view — the same facts as RDF), keyed by the id declared in "
+    f"the frontmatter `manifest`. Everything is derived from "
     f"`{jsonld_path.name}`; the bundle and this DataBook are two skins of one "
     f"graph.\n"
   )
 
   for ib in ibs:
     bt = str(g.value(ib, RS.blockType) or "block")
-    name = str(g.value(ib, SKOS.prefLabel) or bt)
-    parts.append(f"\n## {name}  {{#ib-{bt}}}\n")
-    parts.append(f"- **Block type**: `{bt}`")
+    struct_label = str(g.value(ib, SKOS.prefLabel) or bt)
+    heading = _BLOCK_TITLES.get(bt, struct_label)
+    parts.append(f"\n## {heading}\n")
+    parts.append(f"- **Structure**: {struct_label}")
     parts.append(f"- **Information Block**: `{g.value(ib, RS.internalId)}`")
     parts.append(
       f"- **FactSet**: `{str(g.value(ib, RS.factSet)).rsplit('/', 1)[-1]}`\n"
     )
     parts.append(_render_ib_table(g, ib, columns))  # type: ignore[arg-type]
-    parts.append(f"\n```turtle {{#ib-{bt}-rdf}}")
+    parts.append(f"\n```turtle {{#{bt}}}")
     parts.append(_render_ib_turtle(g, ib))  # type: ignore[arg-type]
     parts.append("```\n")
 

--- a/examples/_common/databook.py
+++ b/examples/_common/databook.py
@@ -1,0 +1,474 @@
+#!/usr/bin/env python3
+"""Render a published Report's JSON-LD bundle as a **DataBook** markdown file.
+
+A DataBook (Kurt Cagle / Charlie Hoffman, ``https://w3id.org/databook/ns#``)
+is a single self-describing markdown file that carries human-readable prose,
+machine-processable RDF, and a provenance "process stamp" together: YAML
+frontmatter + typed fenced code blocks + prose. This is the publication/
+transport skin for a report — *not* a storage substrate.
+
+A RoboSystems Report maps onto the pattern almost 1:1: the report **is** a
+collection of Information Blocks, and each IB renders two ways —
+
+* a **markdown table** (the human view of the block's facts), and
+* an addressable ``turtle`` fenced block ``{#ib-...}`` (the machine view —
+  the same facts as RDF, which reads far better than the JSON-LD).
+
+Everything is derived from the on-disk ``.jsonld`` artifact (same design as
+``validate.py``): no API, no database, no container. The DataBook therefore
+*regenerates from the artifact it describes* — which is exactly the
+portability claim the format is built on.
+
+Usage:
+    uv run python -m examples._common.databook \
+        --jsonld examples/roboledger_demo/output/roboledger-demo.jsonld \
+        --label  "RoboLedger Demo"
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from collections import defaultdict
+from pathlib import Path
+
+import rdflib
+from rdflib import RDF, Graph, URIRef
+from rdflib.namespace import Namespace
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+RS = Namespace("https://robosystems.ai/vocab/")
+XBRLI = Namespace("http://www.xbrl.org/2003/instance#")
+XLINK = Namespace("http://www.w3.org/1999/xlink#")
+LINK = Namespace("http://www.xbrl.org/2003/linkbase#")
+SKOS = Namespace("http://www.w3.org/2004/02/skos/core#")
+
+# Prefixes bound on every emitted turtle slice so concept qnames compact
+# (rs-gaap:Assets rather than the full IRI) — mirrors the encoder's bindings.
+_TURTLE_PREFIXES: dict[str, str] = {
+  "rs": str(RS),
+  "rs-gaap": "https://robosystems.ai/taxonomy/rs-gaap/v1/",
+  "disclosures": "https://robosystems.ai/taxonomy/rs-gaap/disclosures/v1/",
+  "fac": "http://www.xbrlsite.com/fac#",
+  "us-gaap": "http://fasb.org/us-gaap/",
+  "dei": "http://xbrl.sec.gov/dei/",
+  "skos": str(SKOS),
+  "xbrli": str(XBRLI),
+  "xlink": str(XLINK),
+  "link": str(LINK),
+  "iso4217": "http://www.xbrl.org/2003/iso4217#",
+  "xsd": "http://www.w3.org/2001/XMLSchema#",
+}
+
+# Stable display order for the canonical statement IBs; anything else falls
+# after these, in graph order.
+_BLOCK_ORDER: dict[str, int] = {
+  "balance_sheet": 0,
+  "income_statement": 1,
+  "cash_flow_statement": 2,
+  "equity_statement": 3,
+}
+
+
+def _rel(p: Path) -> str:
+  try:
+    return str(p.resolve().relative_to(REPO_ROOT))
+  except ValueError:
+    return str(p)
+
+
+def _fmt_money(v: float | None) -> str:
+  if v is None:
+    return "—"
+  if v < 0:
+    return f"$({abs(v):,.2f})"
+  return f"${v:,.2f}"
+
+
+def _qname(uri: URIRef) -> str:
+  """Compact a concept IRI to ``prefix:Local`` using the known prefixes."""
+  s = str(uri)
+  for prefix, ns in _TURTLE_PREFIXES.items():
+    if s.startswith(ns):
+      return f"{prefix}:{s[len(ns) :]}"
+  return s.rsplit("/", 1)[-1]
+
+
+def _humanize(uri: URIRef) -> str:
+  """Readable concept name when the bundle carries no ``skos:prefLabel`` —
+  split the CamelCase local name into words (``AssetsCurrent`` → ``Assets
+  Current``). A graceful fallback for older bundles that predate label emit."""
+  local = _qname(uri).split(":", 1)[-1]
+  return re.sub(r"(?<=[a-z0-9])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])", " ", local)
+
+
+# ── Report-level extraction ──────────────────────────────────────────────────
+
+
+def _root(g: Graph) -> URIRef:
+  root = next(g.subjects(RDF.type, RS.Report), None)
+  if root is None:
+    raise SystemExit("No rs:Report node in bundle — is this a report bundle?")
+  return root  # type: ignore[return-value]
+
+
+def _period_columns(g: Graph, root: URIRef) -> list[dict]:
+  cols = []
+  for col in g.objects(root, RS.periods):
+    cols.append(
+      {
+        "node": col,
+        "start": str(g.value(col, RS.start) or ""),
+        "end": str(g.value(col, RS.end) or ""),
+        "label": str(g.value(col, SKOS.prefLabel) or ""),
+      }
+    )
+  return sorted(cols, key=lambda c: (c["start"], c["end"]))
+
+
+def _fact_end_date(g: Graph, fact: URIRef) -> str:
+  """The period end a fact lands in — instant for BS, endDate for flows."""
+  period = g.value(fact, RS.period)
+  if period is None:
+    return ""
+  inst = g.value(period, XBRLI.instant)
+  return str(inst or g.value(period, XBRLI.endDate) or "")
+
+
+def _presentation_order(g: Graph, structure: URIRef) -> dict[URIRef, tuple[int, int]]:
+  """Post-order the structure's presentation arcs → {concept: (order, depth)}.
+
+  Traversal is **post-order** so a total renders *after* its components — the
+  financial-statement convention (cash + receivables … then *Assets, Current*;
+  the section subtotals last). ``order`` is the flattened post-order position
+  (drives row order); ``depth`` is the tree depth (drives indentation). Roots
+  are visited by their subtree's leading arc order, so the balance sheet's two
+  roots (Assets, then Liabilities and Equity) come out in the right sequence.
+  """
+  children: dict[URIRef, list[tuple[float, URIRef]]] = defaultdict(list)
+  froms: set[URIRef] = set()
+  tos: set[URIRef] = set()
+  for assoc in g.objects(structure, RS.hasAssociation):
+    if str(g.value(assoc, RS.associationType)) != "presentation":
+      continue
+    frm = g.value(assoc, XLINK["from"])
+    to = g.value(assoc, XLINK.to)
+    if frm is None or to is None:
+      continue
+    order = g.value(assoc, LINK.order)
+    children[frm].append((float(order) if order is not None else 0.0, to))  # type: ignore[arg-type]
+    froms.add(frm)  # type: ignore[arg-type]
+    tos.add(to)  # type: ignore[arg-type]
+  for kids in children.values():
+    kids.sort(key=lambda t: t[0])
+
+  out: dict[URIRef, tuple[int, int]] = {}
+  seen: set[URIRef] = set()
+  counter = 0
+
+  def walk(node: URIRef, depth: int) -> None:
+    nonlocal counter
+    if node in seen:
+      return
+    seen.add(node)
+    for _, child in children.get(node, []):
+      walk(child, depth + 1)
+    out[node] = (counter, depth)  # assigned after children → total comes last
+    counter += 1
+
+  def root_key(root: URIRef) -> float:
+    kids = children.get(root, [])
+    return kids[0][0] if kids else 0.0
+
+  for root in sorted(froms - tos, key=root_key):
+    walk(root, 0)
+  return out
+
+
+def _calc_subtotals(g: Graph) -> set[URIRef]:
+  """Concepts that are calculation parents — the authoritative subtotal set.
+
+  A presentation leaf can still be a subtotal: Gross Profit / Operating Income
+  / Net Income are *siblings* in the presentation tree but *parents* in the
+  calculation tree (they sum other concepts). Bolding off the calc tree marks
+  exactly those, matching the live ``statement`` renderer's ``isSubtotal``.
+  """
+  out: set[URIRef] = set()
+  for assoc in g.subjects(RS.associationType, rdflib.Literal("calculation")):
+    frm = g.value(assoc, XLINK["from"])
+    if isinstance(frm, URIRef):
+      out.add(frm)
+  return out
+
+
+def _structure_for_block(g: Graph, block_type: str) -> URIRef | None:
+  for struct in g.subjects(RDF.type, RS.Structure):
+    if str(g.value(struct, RS.blockType)) == block_type:
+      return struct  # type: ignore[return-value]
+  return None
+
+
+# ── Per-IB markdown table ────────────────────────────────────────────────────
+
+
+def _render_ib_table(g: Graph, ib: URIRef, columns: list[dict]) -> str:
+  fact_set = g.value(ib, RS.factSet)
+  block_type = str(g.value(ib, RS.blockType) or "")
+  structure = _structure_for_block(g, block_type)
+  order = _presentation_order(g, structure) if structure is not None else {}
+  subtotals = _calc_subtotals(g)
+
+  # Collect this IB's facts, keyed by element, with a value per period column.
+  col_end = {c["end"]: i for i, c in enumerate(columns)}
+  by_element: dict[URIRef, list[float | None]] = {}
+  for fact in g.subjects(RDF.type, RS.Fact):
+    if g.value(fact, RS.factSet) != fact_set:
+      continue
+    element = g.value(fact, RS.element)
+    if element is None:
+      continue
+    value = g.value(fact, RS.numericValue)
+    idx = col_end.get(_fact_end_date(g, fact))
+    row = by_element.setdefault(element, [None] * len(columns))  # type: ignore[arg-type]
+    if idx is not None and value is not None:
+      row[idx] = float(value)
+
+  def sort_key(el: URIRef) -> tuple[int, str]:
+    o = order.get(el)
+    return (o[0] if o else 10_000, str(el))
+
+  header_cols = " | ".join(f"{c['label']}" for c in columns)
+  sep = " | ".join(["---:"] * len(columns))
+  lines = [f"| QName | Concept | {header_cols} |", f"|---|---|{sep}|"]
+  for element in sorted(by_element, key=sort_key):
+    _, depth = order.get(element, (0, 0))
+    is_subtotal = element in subtotals
+    label = str(g.value(element, SKOS.prefLabel) or _humanize(element))
+    indent = "  " * depth
+    bold = "**" if is_subtotal else ""
+    name = f"{indent}{bold}{label}{bold}"
+    values = " | ".join(_fmt_money(v) for v in by_element[element])
+    lines.append(f"| `{_qname(element)}` | {name} | {values} |")
+  return "\n".join(lines)
+
+
+# ── Per-IB turtle slice ──────────────────────────────────────────────────────
+
+
+def _bind_prefixes(g: Graph) -> None:
+  for prefix, ns in _TURTLE_PREFIXES.items():
+    g.bind(prefix, ns, replace=True)
+
+
+def _render_ib_turtle(src: Graph, ib: URIRef) -> str:
+  """A focused turtle graph for one IB: the block node + its facts + the
+  elements / periods / units those facts reference. The bulky ``envelopeJson``
+  literal is dropped for readability (it lives in the JSON-LD bundle)."""
+  out = Graph()
+  _bind_prefixes(out)
+  fact_set = src.value(ib, RS.factSet)
+
+  for p, o in src.predicate_objects(ib):
+    if p == RS.envelopeJson:
+      continue
+    out.add((ib, p, o))
+
+  referenced: set[URIRef] = set()
+  for fact in src.subjects(RDF.type, RS.Fact):
+    if src.value(fact, RS.factSet) != fact_set:
+      continue
+    for p, o in src.predicate_objects(fact):
+      out.add((fact, p, o))
+    for ref_pred in (RS.element, RS.period, RS.unit, RS.entity):
+      ref = src.value(fact, ref_pred)
+      if isinstance(ref, URIRef):
+        referenced.add(ref)
+
+  for node in referenced:
+    for p, o in src.predicate_objects(node):
+      out.add((node, p, o))
+
+  return out.serialize(format="turtle").strip()
+
+
+# ── Frontmatter ──────────────────────────────────────────────────────────────
+
+
+def _frontmatter(g: Graph, root: URIRef, ibs: list[URIRef], columns: list[dict]) -> str:
+  meta = g.value(root, RS.reportMeta)
+  entity = g.value(root, RS.entity)
+  entity_name = str(g.value(entity, SKOS.prefLabel) or "") if entity else ""
+
+  pins: list[tuple[str, str]] = []
+  for pin in g.objects(root, RS.frameworkPins):
+    fw = str(g.value(pin, RS.framework) or "")
+    ver = str(g.value(pin, RS.version) or "")
+    if (fw, ver) not in pins:
+      pins.append((fw, ver))
+
+  lines: list[str] = ["---"]
+  lines.append(f"id: {root}")
+  lines.append("type: databook")
+  lines.append("vocab: https://w3id.org/databook/ns#")
+  lines.append(
+    f'serialization_version: "{g.value(root, RS.serializationVersion) or ""}"'
+  )
+  lines.append("report:")
+  lines.append(f"  reporting_style: {g.value(root, RS.reportingStyle) or ''}")
+  if entity_name:
+    lines.append(f"  entity: {json.dumps(entity_name)}")
+  lines.append("  periods:")
+  for c in columns:
+    lines.append(
+      f"    - {{ label: {json.dumps(c['label'])}, start: {c['start']}, end: {c['end']} }}"
+    )
+  lines.append("  framework_pins:")
+  for fw, ver in pins:
+    lines.append(f"    - {{ framework: {fw}, version: {ver} }}")
+
+  # The process stamp — RoboSystems report-engine provenance, DataBook-shaped.
+  lines.append("process:")
+  lines.append("  transformer: robosystems-report-engine")
+  if meta is not None:
+    for key, pred in (
+      ("report_id", RS.reportId),
+      ("generation_count", RS.generationCount),
+      ("filing_status", RS.filingStatus),
+      ("filed_at", RS.filedAt),
+      ("supersedes_id", RS.supersedesId),
+      ("source_graph_id", RS.sourceGraphId),
+      ("source_report_id", RS.sourceReportId),
+      ("shared_at", RS.sharedAt),
+    ):
+      val = g.value(meta, pred)
+      if val is not None:
+        lines.append(f"  {key}: {val}")
+
+  lines.append("information_blocks:")
+  for ib in ibs:
+    bt = str(g.value(ib, RS.blockType) or "")
+    lines.append(
+      f"  - {{ id: {g.value(ib, RS.internalId)}, block_type: {bt}, anchor: ib-{bt} }}"
+    )
+  lines.append("license: CC-BY-4.0")
+  lines.append("---")
+  return "\n".join(lines)
+
+
+# ── Validation evidence (self-contained proof) ───────────────────────────────
+
+
+def _evidence_section(shacl_md: Path | None, xbrl_md: Path | None) -> str:
+  """Inline the (short) SHACL + Arelle verdict reports so the DataBook carries
+  its own proof. Each report's ``# H1`` becomes a ``###`` subsection and its
+  inner ``##`` headings demote to ``####`` to nest under the block sections."""
+  blocks: list[str] = []
+  for path, fallback in ((shacl_md, "SHACL conformance"), (xbrl_md, "XBRL 2.1")):
+    if path is None or not path.exists():
+      continue
+    body = path.read_text().strip()
+    title = fallback
+    if body.startswith("# "):
+      first, _, rest = body.partition("\n")
+      title = first[2:].strip()
+      body = rest.strip()
+    blocks.append(f"### {title}\n\n{re.sub(r'(?m)^## ', '#### ', body)}")
+  if not blocks:
+    return ""
+  return (
+    "\n## Validation evidence\n\n"
+    "Independent, standards-grade checks of the same bundle this DataBook "
+    "renders — embedded so the artifact travels with its own proof.\n\n"
+    + "\n\n".join(blocks)
+  )
+
+
+# ── Top-level render ─────────────────────────────────────────────────────────
+
+
+def write_databook(
+  jsonld_path: Path,
+  out_md: Path,
+  label: str,
+  *,
+  shacl_md: Path | None = None,
+  xbrl_md: Path | None = None,
+) -> Path:
+  """Render the JSON-LD report bundle at ``jsonld_path`` to a DataBook ``.md``.
+
+  When ``shacl_md`` / ``xbrl_md`` are given, their verdict reports are inlined
+  as a trailing evidence section so the DataBook is fully self-contained.
+  """
+  g = rdflib.Graph().parse(str(jsonld_path), format="json-ld")
+  root = _root(g)
+  columns = _period_columns(g, root)
+
+  ibs = sorted(
+    g.subjects(RDF.type, RS.InformationBlock),
+    key=lambda ib: (
+      _BLOCK_ORDER.get(str(g.value(ib, RS.blockType)), 99),
+      str(g.value(ib, RS.blockType)),
+    ),
+  )
+
+  parts: list[str] = [_frontmatter(g, root, ibs, columns)]  # type: ignore[arg-type]
+  parts.append(
+    f"\n# {label} — Report DataBook\n\n"
+    f"A report **is** a collection of Information Blocks. Each block below is "
+    f"shown twice: a markdown table (human view) and an addressable `turtle` "
+    f"block (machine view — the same facts as RDF). Frontmatter carries the "
+    f"report's provenance *process stamp*. Everything here is derived from "
+    f"`{jsonld_path.name}`; the bundle and this DataBook are two skins of one "
+    f"graph.\n"
+  )
+
+  for ib in ibs:
+    bt = str(g.value(ib, RS.blockType) or "block")
+    name = str(g.value(ib, SKOS.prefLabel) or bt)
+    parts.append(f"\n## {name}  {{#ib-{bt}}}\n")
+    parts.append(f"- **Block type**: `{bt}`")
+    parts.append(f"- **Information Block**: `{g.value(ib, RS.internalId)}`")
+    parts.append(
+      f"- **FactSet**: `{str(g.value(ib, RS.factSet)).rsplit('/', 1)[-1]}`\n"
+    )
+    parts.append(_render_ib_table(g, ib, columns))  # type: ignore[arg-type]
+    parts.append(f"\n```turtle {{#ib-{bt}-rdf}}")
+    parts.append(_render_ib_turtle(g, ib))  # type: ignore[arg-type]
+    parts.append("```\n")
+
+  evidence = _evidence_section(shacl_md, xbrl_md)
+  if evidence:
+    parts.append(evidence)
+
+  out_md.write_text("\n".join(parts) + "\n")
+  return out_md
+
+
+# ── CLI ──────────────────────────────────────────────────────────────────────
+
+
+def main() -> None:
+  parser = argparse.ArgumentParser(description="Render a report bundle as a DataBook.")
+  parser.add_argument("--jsonld", type=Path, required=True, help="JSON-LD bundle in")
+  parser.add_argument(
+    "--out", type=Path, help="DataBook .md out (default: *.databook.md)"
+  )
+  parser.add_argument("--shacl-md", type=Path, help="SHACL validation .md to inline")
+  parser.add_argument("--xbrl-md", type=Path, help="XBRL validation .md to inline")
+  parser.add_argument("--label", required=True)
+  args = parser.parse_args()
+
+  jsonld = args.jsonld.resolve()
+  if not jsonld.exists():
+    raise SystemExit(f"{jsonld} missing — run the demo's download-bundles step.")
+  out = args.out or jsonld.with_suffix("").with_suffix(".databook.md")
+  written = write_databook(
+    jsonld, out, args.label, shacl_md=args.shacl_md, xbrl_md=args.xbrl_md
+  )
+  print(f"DataBook: {jsonld.name} → {_rel(written)} ({written.stat().st_size:,} bytes)")
+
+
+if __name__ == "__main__":
+  main()

--- a/examples/roboledger_demo/download_bundles.py
+++ b/examples/roboledger_demo/download_bundles.py
@@ -67,6 +67,7 @@ def download_bundles_for_report(
 
   # Validate the just-received artifacts on the host — container-free:
   # JSON-LD → SHACL (ontology conformance), XBRL zip → Arelle (XBRL 2.1).
+  from examples._common.databook import write_databook
   from examples._common.validate import validate_arelle, validate_shacl
 
   shacl_md = out_dir / "roboledger-demo-shacl-validation.md"
@@ -75,6 +76,19 @@ def download_bundles_for_report(
   valid = validate_arelle(out_dir / XBRL_PATH.name, xbrl_md, "RoboLedger")
   print(f"  SHACL:        {shacl_md} ({'conforms' if conforms else 'VIOLATIONS'})")
   print(f"  Arelle:       {xbrl_md} ({'valid' if valid else 'INVALID'})")
+
+  # DataBook: one self-describing markdown file — the report as a collection of
+  # Information Blocks (each a table + an addressable turtle slice), with the
+  # SHACL/Arelle verdicts inlined as evidence (Charlie Hoffman's serialization).
+  databook_md = out_dir / "roboledger-demo.databook.md"
+  write_databook(
+    out_dir / JSONLD_PATH.name,
+    databook_md,
+    "RoboLedger Demo",
+    shacl_md=shacl_md,
+    xbrl_md=xbrl_md,
+  )
+  print(f"  DataBook:     {databook_md}")
 
 
 def main() -> None:

--- a/examples/roboledger_demo/sample_output/roboledger-demo.databook.md
+++ b/examples/roboledger_demo/sample_output/roboledger-demo.databook.md
@@ -1,13 +1,52 @@
 ---
 id: https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2
-type: databook
-vocab: https://w3id.org/databook/ns#
-serialization_version: "1.0"
+type: DataBook
+title: "RoboLedger Demo — Cascade Advisory Group LLC"
+version: 1.0.0
+authors:
+  - name: "RoboSystems Report Engine"
+license: CC-BY-4.0
+description: >
+  Published financial report as a DataBook — the report as a
+  collection of Information Blocks (balance sheet, income
+  statement, cash flow, statement of changes in equity), each a
+  table plus an addressable RDF/Turtle slice, with SHACL + XBRL
+  2.1 validation evidence inlined.
+tags:
+  - financial
+  - reporting
+  - xbrl
+  - rs-gaap
+  - databook
+provenance:
+  source: "Cascade Advisory Group LLC"
+  method: "Materialized RoboSystems Report rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2 (generation 1, draft)"
+manifest:
+  entrypoints:
+    - block: balance_sheet
+    - block: income_statement
+    - block: cash_flow_statement
+    - block: equity_statement
+  blocks:
+    balance_sheet:
+      type: turtle
+      description: "rs-gaap — Balance Sheet — Classified"
+    income_statement:
+      type: turtle
+      description: "rs-gaap — Income Statement — Multi-step"
+    cash_flow_statement:
+      type: turtle
+      description: "rs-gaap — Cash Flow Statement — Indirect"
+    equity_statement:
+      type: turtle
+      description: "rs-gaap — Statement of Changes in Equity — Roll Forward (Total)"
 report:
   reporting_style: 025f5d48-12ce-5d65-b9eb-4f137a10ef06
-  entity: "Cascade Advisory Group LLC"
+  report_id: rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2
+  generation_count: 1
+  filing_status: draft
   periods:
-    - { label: "2024-01-02 \u2192 2025-12-31", start: 2024-01-02, end: 2025-12-31 }
+    - { label: "2024-01-02 → 2025-12-31", start: 2024-01-02, end: 2025-12-31 }
   framework_pins:
     - { framework: fac-traits, version: v1 }
     - { framework: fac, version: v1 }
@@ -27,27 +66,16 @@ report:
     - { framework: rs-gaap-rollup-rules, version: v1 }
     - { framework: fac-to-rs-gaap, version: v1 }
     - { framework: rs-gaap-disclosures-to-rs-gaap-textblocks, version: v1 }
-process:
-  transformer: robosystems-report-engine
-  report_id: rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2
-  generation_count: 1
-  filing_status: draft
-information_blocks:
-  - { id: b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d, block_type: balance_sheet, anchor: ib-balance_sheet }
-  - { id: 47cd6544-03d1-5bc1-8c28-31c0cfa450f9, block_type: income_statement, anchor: ib-income_statement }
-  - { id: 5473639a-2dac-56a6-b9e5-38480ea38bc1, block_type: cash_flow_statement, anchor: ib-cash_flow_statement }
-  - { id: 0b179e5c-5f02-506d-b8d5-860cb10c7694, block_type: equity_statement, anchor: ib-equity_statement }
-license: CC-BY-4.0
 ---
 
-# RoboLedger Demo — Report DataBook
+# RoboLedger Demo — Cascade Advisory Group LLC
 
-A report **is** a collection of Information Blocks. Each block below is shown twice: a markdown table (human view) and an addressable `turtle` block (machine view — the same facts as RDF). Frontmatter carries the report's provenance *process stamp*. Everything here is derived from `roboledger-demo.jsonld`; the bundle and this DataBook are two skins of one graph.
+A report **is** a collection of Information Blocks. Each block below is shown twice: a markdown table (human view) and an addressable `turtle` block (machine view — the same facts as RDF), keyed by the id declared in the frontmatter `manifest`. Everything is derived from `roboledger-demo.jsonld`; the bundle and this DataBook are two skins of one graph.
 
 
-## rs-gaap — Balance Sheet — Classified  {#ib-balance_sheet}
+## Balance Sheet
 
-- **Block type**: `balance_sheet`
+- **Structure**: rs-gaap — Balance Sheet — Classified
 - **Information Block**: `b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d`
 - **FactSet**: `fs_01KSV8AYSKTWGGB1B7WWF5R33M`
 
@@ -68,7 +96,7 @@ A report **is** a collection of Information Blocks. Each block below is shown tw
 | `rs-gaap:StockholdersEquity` |   **Stockholders Equity** | $78,186.70 |
 | `rs-gaap:LiabilitiesAndStockholdersEquity` | **Liabilities And Stockholders Equity** | $78,986.70 |
 
-```turtle {#ib-balance_sheet-rdf}
+```turtle {#balance_sheet}
 @prefix iso4217: <http://www.xbrl.org/2003/iso4217#> .
 @prefix rs: <https://robosystems.ai/vocab/> .
 @prefix rs-gaap: <https://robosystems.ai/taxonomy/rs-gaap/v1/> .
@@ -419,9 +447,9 @@ rs-gaap:RetainedEarningsAccumulatedDeficit a rs:Element ;
 ```
 
 
-## rs-gaap — Income Statement — Multi-step  {#ib-income_statement}
+## Income Statement
 
-- **Block type**: `income_statement`
+- **Structure**: rs-gaap — Income Statement — Multi-step
 - **Information Block**: `47cd6544-03d1-5bc1-8c28-31c0cfa450f9`
 - **FactSet**: `fs_01KSV8AYSKTWGGB1B7WWF5R33N`
 
@@ -438,7 +466,7 @@ rs-gaap:RetainedEarningsAccumulatedDeficit a rs:Element ;
 | `rs-gaap:IncomeLossFromContinuingOperations` |   **Income Loss From Continuing Operations** | $28,386.70 |
 | `rs-gaap:NetIncomeLoss` |   **Net Income Loss** | $28,386.70 |
 
-```turtle {#ib-income_statement-rdf}
+```turtle {#income_statement}
 @prefix iso4217: <http://www.xbrl.org/2003/iso4217#> .
 @prefix rs: <https://robosystems.ai/vocab/> .
 @prefix rs-gaap: <https://robosystems.ai/taxonomy/rs-gaap/v1/> .
@@ -680,9 +708,9 @@ rs-gaap:SellingGeneralAndAdministrativeExpense a rs:Element ;
 ```
 
 
-## rs-gaap — Cash Flow Statement — Indirect  {#ib-cash_flow_statement}
+## Cash Flow Statement
 
-- **Block type**: `cash_flow_statement`
+- **Structure**: rs-gaap — Cash Flow Statement — Indirect
 - **Information Block**: `5473639a-2dac-56a6-b9e5-38480ea38bc1`
 - **FactSet**: `fs_01KSV8AYSKTWGGB1B7WWF5R33P`
 
@@ -699,7 +727,7 @@ rs-gaap:SellingGeneralAndAdministrativeExpense a rs:Element ;
 | `rs-gaap:NetCashProvidedByUsedInFinancingActivities` |   Net Cash Provided By Used In Financing Activities | $49,800.00 |
 | `rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease` | **Cash And Cash Equivalents Period Increase Decrease** | $73,620.00 |
 
-```turtle {#ib-cash_flow_statement-rdf}
+```turtle {#cash_flow_statement}
 @prefix iso4217: <http://www.xbrl.org/2003/iso4217#> .
 @prefix rs: <https://robosystems.ai/vocab/> .
 @prefix rs-gaap: <https://robosystems.ai/taxonomy/rs-gaap/v1/> .
@@ -941,9 +969,9 @@ rs-gaap:ProceedsFromIssuanceOfCommonStock a rs:Element ;
 ```
 
 
-## rs-gaap — Statement of Changes in Equity — Roll Forward (Total)  {#ib-equity_statement}
+## Statement of Changes in Equity
 
-- **Block type**: `equity_statement`
+- **Structure**: rs-gaap — Statement of Changes in Equity — Roll Forward (Total)
 - **Information Block**: `0b179e5c-5f02-506d-b8d5-860cb10c7694`
 - **FactSet**: `fs_01KSV8AYSKTWGGB1B7WWF5R33Q`
 
@@ -953,7 +981,7 @@ rs-gaap:ProceedsFromIssuanceOfCommonStock a rs:Element ;
 | `rs-gaap:ProceedsFromIssuanceOfCommonStock` |   Proceeds From Issuance Of Common Stock | $49,800.00 |
 | `rs-gaap:StockholdersEquity` | **Stockholders Equity** | $78,186.70 |
 
-```turtle {#ib-equity_statement-rdf}
+```turtle {#equity_statement}
 @prefix iso4217: <http://www.xbrl.org/2003/iso4217#> .
 @prefix rs: <https://robosystems.ai/vocab/> .
 @prefix rs-gaap: <https://robosystems.ai/taxonomy/rs-gaap/v1/> .

--- a/examples/roboledger_demo/sample_output/roboledger-demo.databook.md
+++ b/examples/roboledger_demo/sample_output/roboledger-demo.databook.md
@@ -1,0 +1,1090 @@
+---
+id: https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2
+type: databook
+vocab: https://w3id.org/databook/ns#
+serialization_version: "1.0"
+report:
+  reporting_style: 025f5d48-12ce-5d65-b9eb-4f137a10ef06
+  entity: "Cascade Advisory Group LLC"
+  periods:
+    - { label: "2024-01-02 \u2192 2025-12-31", start: 2024-01-02, end: 2025-12-31 }
+  framework_pins:
+    - { framework: fac-traits, version: v1 }
+    - { framework: fac, version: v1 }
+    - { framework: fac-presentation, version: v1 }
+    - { framework: fac-calculations, version: v1 }
+    - { framework: fac-rules, version: v1 }
+    - { framework: rs-gaap, version: v1 }
+    - { framework: rs-gaap-traits, version: v1 }
+    - { framework: rs-gaap-hierarchy, version: v1 }
+    - { framework: rs-gaap-presentation, version: v1 }
+    - { framework: rs-gaap-calculations, version: v1 }
+    - { framework: rs-gaap-type-subtype, version: v1 }
+    - { framework: rs-gaap-disclosures, version: v1 }
+    - { framework: rs-gaap-disclosure-mechanics, version: v1 }
+    - { framework: rs-gaap-reporting-checklist, version: v1 }
+    - { framework: rs-gaap-reporting-styles, version: v1 }
+    - { framework: rs-gaap-rollup-rules, version: v1 }
+    - { framework: fac-to-rs-gaap, version: v1 }
+    - { framework: rs-gaap-disclosures-to-rs-gaap-textblocks, version: v1 }
+process:
+  transformer: robosystems-report-engine
+  report_id: rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2
+  generation_count: 1
+  filing_status: draft
+information_blocks:
+  - { id: b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d, block_type: balance_sheet, anchor: ib-balance_sheet }
+  - { id: 47cd6544-03d1-5bc1-8c28-31c0cfa450f9, block_type: income_statement, anchor: ib-income_statement }
+  - { id: 5473639a-2dac-56a6-b9e5-38480ea38bc1, block_type: cash_flow_statement, anchor: ib-cash_flow_statement }
+  - { id: 0b179e5c-5f02-506d-b8d5-860cb10c7694, block_type: equity_statement, anchor: ib-equity_statement }
+license: CC-BY-4.0
+---
+
+# RoboLedger Demo — Report DataBook
+
+A report **is** a collection of Information Blocks. Each block below is shown twice: a markdown table (human view) and an addressable `turtle` block (machine view — the same facts as RDF). Frontmatter carries the report's provenance *process stamp*. Everything here is derived from `roboledger-demo.jsonld`; the bundle and this DataBook are two skins of one graph.
+
+
+## rs-gaap — Balance Sheet — Classified  {#ib-balance_sheet}
+
+- **Block type**: `balance_sheet`
+- **Information Block**: `b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d`
+- **FactSet**: `fs_01KSV8AYSKTWGGB1B7WWF5R33M`
+
+| QName | Concept | 2024-01-02 → 2025-12-31 |
+|---|---|---:|
+| `rs-gaap:CashCashEquivalentsAndShortTermInvestments` |     Cash Cash Equivalents And Short Term Investments | $72,120.00 |
+| `rs-gaap:ReceivablesNetCurrent` |     Receivables Net Current | $0.00 |
+| `rs-gaap:PrepaidExpenseCurrent` |     Prepaid Expense Current | $2,100.00 |
+| `rs-gaap:AssetsCurrent` |   **Assets Current** | $74,220.00 |
+| `rs-gaap:PropertyPlantAndEquipmentNet` |     Property Plant And Equipment Net | $4,766.70 |
+| `rs-gaap:AssetsNoncurrent` |   **Assets Noncurrent** | $4,766.70 |
+| `rs-gaap:Assets` | **Assets** | $78,986.70 |
+| `rs-gaap:AccountsPayableAndAccruedLiabilitiesCurrent` |       Accounts Payable And Accrued Liabilities Current | $800.00 |
+| `rs-gaap:LiabilitiesCurrent` |     **Liabilities Current** | $800.00 |
+| `rs-gaap:Liabilities` |   **Liabilities** | $800.00 |
+| `rs-gaap:AdditionalPaidInCapital` |     Additional Paid In Capital | $49,800.00 |
+| `rs-gaap:RetainedEarningsAccumulatedDeficit` |     Retained Earnings Accumulated Deficit | $28,386.70 |
+| `rs-gaap:StockholdersEquity` |   **Stockholders Equity** | $78,186.70 |
+| `rs-gaap:LiabilitiesAndStockholdersEquity` | **Liabilities And Stockholders Equity** | $78,986.70 |
+
+```turtle {#ib-balance_sheet-rdf}
+@prefix iso4217: <http://www.xbrl.org/2003/iso4217#> .
+@prefix rs: <https://robosystems.ai/vocab/> .
+@prefix rs-gaap: <https://robosystems.ai/taxonomy/rs-gaap/v1/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xbrli: <http://www.xbrl.org/2003/instance#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/fact/fact_01KSV8AYSRWVB9R93FRYJXAM0Y> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:AccountsPayableAndAccruedLiabilitiesCurrent ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/entity/entity_kg19e75ce934a3a00a17ea> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV8AYSKTWGGB1B7WWF5R33M> ;
+    rs:internalId "fact_01KSV8AYSRWVB9R93FRYJXAM0Y" ;
+    rs:numericValue 800.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/period/p_1> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/fact/fact_01KSV8AYSRWVB9R93FRYJXAM0Z> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:AdditionalPaidInCapital ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/entity/entity_kg19e75ce934a3a00a17ea> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV8AYSKTWGGB1B7WWF5R33M> ;
+    rs:internalId "fact_01KSV8AYSRWVB9R93FRYJXAM0Z" ;
+    rs:numericValue 49800.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/period/p_1> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/fact/fact_01KSV8AYSRWVB9R93FRYJXAM10> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:CashCashEquivalentsAndShortTermInvestments ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/entity/entity_kg19e75ce934a3a00a17ea> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV8AYSKTWGGB1B7WWF5R33M> ;
+    rs:internalId "fact_01KSV8AYSRWVB9R93FRYJXAM10" ;
+    rs:numericValue 72120.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/period/p_1> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/fact/fact_01KSV8AYSRWVB9R93FRYJXAM13> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:PrepaidExpenseCurrent ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/entity/entity_kg19e75ce934a3a00a17ea> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV8AYSKTWGGB1B7WWF5R33M> ;
+    rs:internalId "fact_01KSV8AYSRWVB9R93FRYJXAM13" ;
+    rs:numericValue 2100.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/period/p_1> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/fact/fact_01KSV8AYSRWVB9R93FRYJXAM14> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:ReceivablesNetCurrent ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/entity/entity_kg19e75ce934a3a00a17ea> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV8AYSKTWGGB1B7WWF5R33M> ;
+    rs:internalId "fact_01KSV8AYSRWVB9R93FRYJXAM14" ;
+    rs:numericValue 0.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/period/p_1> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/fact/fact_01KSV8AYSRWVB9R93FRYJXAM17> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:RetainedEarningsAccumulatedDeficit ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/entity/entity_kg19e75ce934a3a00a17ea> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV8AYSKTWGGB1B7WWF5R33M> ;
+    rs:internalId "fact_01KSV8AYSRWVB9R93FRYJXAM17" ;
+    rs:numericValue 28386.70000000001 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/period/p_1> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/fact/fact_01KSV8AYSRWVB9R93FRYJXAM18> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:AdditionalPaidInCapital ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/entity/entity_kg19e75ce934a3a00a17ea> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV8AYSKTWGGB1B7WWF5R33M> ;
+    rs:internalId "fact_01KSV8AYSRWVB9R93FRYJXAM18" ;
+    rs:numericValue 0.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/period/p_2> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/fact/fact_01KSV8AYSRWVB9R93FRYJXAM19> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:RetainedEarningsAccumulatedDeficit ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/entity/entity_kg19e75ce934a3a00a17ea> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV8AYSKTWGGB1B7WWF5R33M> ;
+    rs:internalId "fact_01KSV8AYSRWVB9R93FRYJXAM19" ;
+    rs:numericValue 0.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/period/p_2> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/fact/fact_01KSV8AYSRWVB9R93FRYJXAM1D> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:PropertyPlantAndEquipmentNet ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/entity/entity_kg19e75ce934a3a00a17ea> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV8AYSKTWGGB1B7WWF5R33M> ;
+    rs:internalId "fact_01KSV8AYSRWVB9R93FRYJXAM1D" ;
+    rs:numericValue 4766.7 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/period/p_1> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/fact/fact_01KSV8AYSRWVB9R93FRYJXAM1M> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:LiabilitiesAndStockholdersEquity ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/entity/entity_kg19e75ce934a3a00a17ea> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV8AYSKTWGGB1B7WWF5R33M> ;
+    rs:internalId "fact_01KSV8AYSRWVB9R93FRYJXAM1M" ;
+    rs:numericValue 78986.70000000001 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/period/p_1> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/fact/fact_01KSV8AYSRWVB9R93FRYJXAM1P> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:Assets ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/entity/entity_kg19e75ce934a3a00a17ea> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV8AYSKTWGGB1B7WWF5R33M> ;
+    rs:internalId "fact_01KSV8AYSRWVB9R93FRYJXAM1P" ;
+    rs:numericValue 78986.7 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/period/p_1> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/fact/fact_01KSV8AYSRWVB9R93FRYJXAM1S> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:AssetsCurrent ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/entity/entity_kg19e75ce934a3a00a17ea> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV8AYSKTWGGB1B7WWF5R33M> ;
+    rs:internalId "fact_01KSV8AYSRWVB9R93FRYJXAM1S" ;
+    rs:numericValue 74220.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/period/p_1> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/fact/fact_01KSV8AYSRWVB9R93FRYJXAM1W> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:Liabilities ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/entity/entity_kg19e75ce934a3a00a17ea> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV8AYSKTWGGB1B7WWF5R33M> ;
+    rs:internalId "fact_01KSV8AYSRWVB9R93FRYJXAM1W" ;
+    rs:numericValue 800.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/period/p_1> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/fact/fact_01KSV8AYSRWVB9R93FRYJXAM1Y> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:AssetsNoncurrent ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/entity/entity_kg19e75ce934a3a00a17ea> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV8AYSKTWGGB1B7WWF5R33M> ;
+    rs:internalId "fact_01KSV8AYSRWVB9R93FRYJXAM1Y" ;
+    rs:numericValue 4766.7 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/period/p_1> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/fact/fact_01KSV8AYSRWVB9R93FRYJXAM1Z> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:LiabilitiesCurrent ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/entity/entity_kg19e75ce934a3a00a17ea> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV8AYSKTWGGB1B7WWF5R33M> ;
+    rs:internalId "fact_01KSV8AYSRWVB9R93FRYJXAM1Z" ;
+    rs:numericValue 800.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/period/p_1> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/fact/fact_01KSV8AYSRWVB9R93FRYJXAM22> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:StockholdersEquity ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/entity/entity_kg19e75ce934a3a00a17ea> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV8AYSKTWGGB1B7WWF5R33M> ;
+    rs:internalId "fact_01KSV8AYSRWVB9R93FRYJXAM22" ;
+    rs:numericValue 78186.70000000001 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/period/p_1> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/ib/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> a rs:InformationBlock ;
+    skos:prefLabel "rs-gaap — Balance Sheet — Classified" ;
+    rs:blockType "balance_sheet" ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV8AYSKTWGGB1B7WWF5R33M> ;
+    rs:internalId "b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d" ;
+    rs:taxonomyId "cf7178a0-e2d4-58df-995a-2f0233d15466" ;
+    rs:taxonomyName "rs-gaap-presentation v1" .
+
+rs-gaap:AccountsPayableAndAccruedLiabilitiesCurrent a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "instant" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "7c177cde-7755-53f3-8512-e60b35a5b5c6" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:Assets a rs:Element ;
+    xbrli:balance "debit" ;
+    xbrli:periodType "instant" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "a1f04756-41d8-5d35-b821-23aa2f3b2fae" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:AssetsCurrent a rs:Element ;
+    xbrli:balance "debit" ;
+    xbrli:periodType "instant" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "0fc9ab7e-c5ce-5277-9530-344cc127fe26" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:AssetsNoncurrent a rs:Element ;
+    xbrli:balance "debit" ;
+    xbrli:periodType "instant" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "841cedeb-4cb0-532a-b0bd-c34846a13a8c" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:CashCashEquivalentsAndShortTermInvestments a rs:Element ;
+    xbrli:balance "debit" ;
+    xbrli:periodType "instant" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "319dac01-1574-50b7-9124-959febd6c28e" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:Liabilities a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "instant" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "7af273ac-1cba-5fb3-a1c9-5c5d8fdb9bdf" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:LiabilitiesAndStockholdersEquity a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "instant" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "30b2801e-e682-5298-82e6-3670e1d508f1" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:LiabilitiesCurrent a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "instant" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "efb036ff-3f30-5deb-bee9-1af4cd4b9800" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:PrepaidExpenseCurrent a rs:Element ;
+    xbrli:balance "debit" ;
+    xbrli:periodType "instant" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "2225e348-90bd-53cb-9784-8b5d54980a69" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:PropertyPlantAndEquipmentNet a rs:Element ;
+    xbrli:balance "debit" ;
+    xbrli:periodType "instant" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "288099af-5cbb-5f78-8f8a-1a85675fb661" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:ReceivablesNetCurrent a rs:Element ;
+    xbrli:balance "debit" ;
+    xbrli:periodType "instant" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "44686df3-3871-5c1f-8a08-fc542d69dfa0" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:StockholdersEquity a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "instant" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "e3796201-9899-5b7b-9477-659550ba8e68" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+<https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/period/p_2> a rs:Period ;
+    xbrli:instant "2024-12-31"^^xsd:date ;
+    xbrli:periodType "instant" .
+
+rs-gaap:AdditionalPaidInCapital a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "instant" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "6146605c-0d63-51e1-a523-3450d6abaca3" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:RetainedEarningsAccumulatedDeficit a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "instant" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "a9c87d60-a1e5-506b-a27e-cbf9e14e5113" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+<https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/period/p_1> a rs:Period ;
+    xbrli:instant "2025-12-31"^^xsd:date ;
+    xbrli:periodType "instant" .
+
+<https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/entity/entity_kg19e75ce934a3a00a17ea> a rs:Entity ;
+    skos:prefLabel "Cascade Advisory Group LLC" ;
+    rs:country "US" ;
+    rs:internalId "entity_kg19e75ce934a3a00a17ea" ;
+    rs:legalName "Cascade Advisory Group LLC" .
+
+<https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/unit/u_USD> a rs:Unit ;
+    xbrli:measure iso4217:USD .
+```
+
+
+## rs-gaap — Income Statement — Multi-step  {#ib-income_statement}
+
+- **Block type**: `income_statement`
+- **Information Block**: `47cd6544-03d1-5bc1-8c28-31c0cfa450f9`
+- **FactSet**: `fs_01KSV8AYSKTWGGB1B7WWF5R33N`
+
+| QName | Concept | 2024-01-02 → 2025-12-31 |
+|---|---|---:|
+| `rs-gaap:SalesRevenueNet` |     Sales Revenue Net | $175,000.00 |
+| `rs-gaap:Revenues` |   **Revenues** | $175,000.00 |
+| `rs-gaap:GrossProfit` |   **Gross Profit** | $175,000.00 |
+| `rs-gaap:SellingGeneralAndAdministrativeExpense` |     Selling General And Administrative Expense | $145,080.00 |
+| `rs-gaap:DepreciationDepletionAndAmortization` |     Depreciation Depletion And Amortization | $1,533.30 |
+| `rs-gaap:OperatingExpenses` |   **Operating Expenses** | $146,613.30 |
+| `rs-gaap:OperatingIncomeLoss` |   **Operating Income Loss** | $28,386.70 |
+| `rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest` |   **Income Loss From Continuing Operations Before Income Taxes Extraordinary Items Noncontrolling Interest** | $28,386.70 |
+| `rs-gaap:IncomeLossFromContinuingOperations` |   **Income Loss From Continuing Operations** | $28,386.70 |
+| `rs-gaap:NetIncomeLoss` |   **Net Income Loss** | $28,386.70 |
+
+```turtle {#ib-income_statement-rdf}
+@prefix iso4217: <http://www.xbrl.org/2003/iso4217#> .
+@prefix rs: <https://robosystems.ai/vocab/> .
+@prefix rs-gaap: <https://robosystems.ai/taxonomy/rs-gaap/v1/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xbrli: <http://www.xbrl.org/2003/instance#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/fact/fact_01KSV8AYSRWVB9R93FRYJXAM11> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:DepreciationDepletionAndAmortization ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/entity/entity_kg19e75ce934a3a00a17ea> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV8AYSKTWGGB1B7WWF5R33N> ;
+    rs:internalId "fact_01KSV8AYSRWVB9R93FRYJXAM11" ;
+    rs:numericValue 1533.3 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/period/p_3> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/fact/fact_01KSV8AYSRWVB9R93FRYJXAM15> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:SalesRevenueNet ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/entity/entity_kg19e75ce934a3a00a17ea> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV8AYSKTWGGB1B7WWF5R33N> ;
+    rs:internalId "fact_01KSV8AYSRWVB9R93FRYJXAM15" ;
+    rs:numericValue 175000.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/period/p_3> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/fact/fact_01KSV8AYSRWVB9R93FRYJXAM16> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:SellingGeneralAndAdministrativeExpense ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/entity/entity_kg19e75ce934a3a00a17ea> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV8AYSKTWGGB1B7WWF5R33N> ;
+    rs:internalId "fact_01KSV8AYSRWVB9R93FRYJXAM16" ;
+    rs:numericValue 145080.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/period/p_3> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/fact/fact_01KSV8AYSRWVB9R93FRYJXAM1A> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:NetIncomeLoss ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/entity/entity_kg19e75ce934a3a00a17ea> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV8AYSKTWGGB1B7WWF5R33N> ;
+    rs:internalId "fact_01KSV8AYSRWVB9R93FRYJXAM1A" ;
+    rs:numericValue 28386.70000000001 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/period/p_3> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/fact/fact_01KSV8AYSRWVB9R93FRYJXAM1K> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:OperatingExpenses ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/entity/entity_kg19e75ce934a3a00a17ea> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV8AYSKTWGGB1B7WWF5R33N> ;
+    rs:internalId "fact_01KSV8AYSRWVB9R93FRYJXAM1K" ;
+    rs:numericValue 146613.3 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/period/p_3> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/fact/fact_01KSV8AYSRWVB9R93FRYJXAM1Q> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:Revenues ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/entity/entity_kg19e75ce934a3a00a17ea> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV8AYSKTWGGB1B7WWF5R33N> ;
+    rs:internalId "fact_01KSV8AYSRWVB9R93FRYJXAM1Q" ;
+    rs:numericValue 175000.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/period/p_3> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/fact/fact_01KSV8AYSRWVB9R93FRYJXAM1R> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:OperatingIncomeLoss ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/entity/entity_kg19e75ce934a3a00a17ea> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV8AYSKTWGGB1B7WWF5R33N> ;
+    rs:internalId "fact_01KSV8AYSRWVB9R93FRYJXAM1R" ;
+    rs:numericValue 28386.70000000001 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/period/p_3> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/fact/fact_01KSV8AYSRWVB9R93FRYJXAM1V> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:GrossProfit ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/entity/entity_kg19e75ce934a3a00a17ea> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV8AYSKTWGGB1B7WWF5R33N> ;
+    rs:internalId "fact_01KSV8AYSRWVB9R93FRYJXAM1V" ;
+    rs:numericValue 175000.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/period/p_3> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/fact/fact_01KSV8AYSRWVB9R93FRYJXAM23> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/entity/entity_kg19e75ce934a3a00a17ea> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV8AYSKTWGGB1B7WWF5R33N> ;
+    rs:internalId "fact_01KSV8AYSRWVB9R93FRYJXAM23" ;
+    rs:numericValue 28386.70000000001 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/period/p_3> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/fact/fact_01KSV8AYSRWVB9R93FRYJXAM24> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:IncomeLossFromContinuingOperations ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/entity/entity_kg19e75ce934a3a00a17ea> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV8AYSKTWGGB1B7WWF5R33N> ;
+    rs:internalId "fact_01KSV8AYSRWVB9R93FRYJXAM24" ;
+    rs:numericValue 28386.70000000001 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/period/p_3> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/ib/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> a rs:InformationBlock ;
+    skos:prefLabel "rs-gaap — Income Statement — Multi-step" ;
+    rs:blockType "income_statement" ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV8AYSKTWGGB1B7WWF5R33N> ;
+    rs:internalId "47cd6544-03d1-5bc1-8c28-31c0cfa450f9" ;
+    rs:taxonomyId "cf7178a0-e2d4-58df-995a-2f0233d15466" ;
+    rs:taxonomyName "rs-gaap-presentation v1" .
+
+rs-gaap:DepreciationDepletionAndAmortization a rs:Element ;
+    xbrli:balance "debit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "189a099a-7512-5144-9215-65d837c2c3b5" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:GrossProfit a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "a92b3181-9fe7-543c-81d9-13ebd12bbefa" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:IncomeLossFromContinuingOperations a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "d60cabda-7060-5aff-ac98-96371606a738" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "6b0b414f-0c76-54f0-8e51-cf53db59ca24" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:NetIncomeLoss a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "27a05717-2370-51c2-a924-db5cbcb48219" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:OperatingExpenses a rs:Element ;
+    xbrli:balance "debit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "71fcdebb-7145-5f76-b5e0-b4ccbf2c29d2" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:OperatingIncomeLoss a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "16780828-0201-5609-b572-fbe3ebfcb177" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:Revenues a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "b26a6cd4-072f-5bf2-b5d3-ebf928150d6c" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:SalesRevenueNet a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "7c122782-e96d-5288-93a6-1f42089d701d" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:SellingGeneralAndAdministrativeExpense a rs:Element ;
+    xbrli:balance "debit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "050fac09-f306-514d-80ef-f0d10ce05de9" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+<https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/entity/entity_kg19e75ce934a3a00a17ea> a rs:Entity ;
+    skos:prefLabel "Cascade Advisory Group LLC" ;
+    rs:country "US" ;
+    rs:internalId "entity_kg19e75ce934a3a00a17ea" ;
+    rs:legalName "Cascade Advisory Group LLC" .
+
+<https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/period/p_3> a rs:Period ;
+    xbrli:endDate "2025-12-31"^^xsd:date ;
+    xbrli:periodType "duration" ;
+    xbrli:startDate "2025-01-01"^^xsd:date .
+
+<https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/unit/u_USD> a rs:Unit ;
+    xbrli:measure iso4217:USD .
+```
+
+
+## rs-gaap — Cash Flow Statement — Indirect  {#ib-cash_flow_statement}
+
+- **Block type**: `cash_flow_statement`
+- **Information Block**: `5473639a-2dac-56a6-b9e5-38480ea38bc1`
+- **FactSet**: `fs_01KSV8AYSKTWGGB1B7WWF5R33P`
+
+| QName | Concept | 2024-01-02 → 2025-12-31 |
+|---|---|---:|
+| `rs-gaap:NetIncomeLoss` |     **Net Income Loss** | $28,386.70 |
+| `rs-gaap:DepreciationDepletionAndAmortization` |     Depreciation Depletion And Amortization | $1,533.30 |
+| `rs-gaap:IncreaseDecreaseInPrepaidExpense` |     Increase Decrease In Prepaid Expense | $(2,100.00) |
+| `rs-gaap:IncreaseDecreaseInAccountsPayableAndAccruedLiabilities` |     Increase Decrease In Accounts Payable And Accrued Liabilities | $800.00 |
+| `rs-gaap:NetCashProvidedByUsedInOperatingActivities` |   Net Cash Provided By Used In Operating Activities | $28,620.00 |
+| `rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment` |     Payments To Acquire Property Plant And Equipment | $(4,800.00) |
+| `rs-gaap:NetCashProvidedByUsedInInvestingActivities` |   Net Cash Provided By Used In Investing Activities | $(4,800.00) |
+| `rs-gaap:ProceedsFromIssuanceOfCommonStock` |     Proceeds From Issuance Of Common Stock | $49,800.00 |
+| `rs-gaap:NetCashProvidedByUsedInFinancingActivities` |   Net Cash Provided By Used In Financing Activities | $49,800.00 |
+| `rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease` | **Cash And Cash Equivalents Period Increase Decrease** | $73,620.00 |
+
+```turtle {#ib-cash_flow_statement-rdf}
+@prefix iso4217: <http://www.xbrl.org/2003/iso4217#> .
+@prefix rs: <https://robosystems.ai/vocab/> .
+@prefix rs-gaap: <https://robosystems.ai/taxonomy/rs-gaap/v1/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xbrli: <http://www.xbrl.org/2003/instance#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/fact/fact_01KSV8AYSRWVB9R93FRYJXAM12> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:DepreciationDepletionAndAmortization ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/entity/entity_kg19e75ce934a3a00a17ea> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV8AYSKTWGGB1B7WWF5R33P> ;
+    rs:internalId "fact_01KSV8AYSRWVB9R93FRYJXAM12" ;
+    rs:numericValue 1533.3 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/period/p_3> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/fact/fact_01KSV8AYSRWVB9R93FRYJXAM1C> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:NetIncomeLoss ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/entity/entity_kg19e75ce934a3a00a17ea> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV8AYSKTWGGB1B7WWF5R33P> ;
+    rs:internalId "fact_01KSV8AYSRWVB9R93FRYJXAM1C" ;
+    rs:numericValue 28386.70000000001 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/period/p_3> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/fact/fact_01KSV8AYSRWVB9R93FRYJXAM1E> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:ProceedsFromIssuanceOfCommonStock ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/entity/entity_kg19e75ce934a3a00a17ea> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV8AYSKTWGGB1B7WWF5R33P> ;
+    rs:internalId "fact_01KSV8AYSRWVB9R93FRYJXAM1E" ;
+    rs:numericValue 49800.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/period/p_3> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/fact/fact_01KSV8AYSRWVB9R93FRYJXAM1G> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/entity/entity_kg19e75ce934a3a00a17ea> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV8AYSKTWGGB1B7WWF5R33P> ;
+    rs:internalId "fact_01KSV8AYSRWVB9R93FRYJXAM1G" ;
+    rs:numericValue -4800.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/period/p_3> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/fact/fact_01KSV8AYSRWVB9R93FRYJXAM1H> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:IncreaseDecreaseInAccountsPayableAndAccruedLiabilities ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/entity/entity_kg19e75ce934a3a00a17ea> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV8AYSKTWGGB1B7WWF5R33P> ;
+    rs:internalId "fact_01KSV8AYSRWVB9R93FRYJXAM1H" ;
+    rs:numericValue 800.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/period/p_3> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/fact/fact_01KSV8AYSRWVB9R93FRYJXAM1J> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:IncreaseDecreaseInPrepaidExpense ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/entity/entity_kg19e75ce934a3a00a17ea> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV8AYSKTWGGB1B7WWF5R33P> ;
+    rs:internalId "fact_01KSV8AYSRWVB9R93FRYJXAM1J" ;
+    rs:numericValue -2100.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/period/p_3> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/fact/fact_01KSV8AYSRWVB9R93FRYJXAM1N> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:NetCashProvidedByUsedInOperatingActivities ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/entity/entity_kg19e75ce934a3a00a17ea> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV8AYSKTWGGB1B7WWF5R33P> ;
+    rs:internalId "fact_01KSV8AYSRWVB9R93FRYJXAM1N" ;
+    rs:numericValue 28620.00000000001 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/period/p_3> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/fact/fact_01KSV8AYSRWVB9R93FRYJXAM1T> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:NetCashProvidedByUsedInInvestingActivities ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/entity/entity_kg19e75ce934a3a00a17ea> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV8AYSKTWGGB1B7WWF5R33P> ;
+    rs:internalId "fact_01KSV8AYSRWVB9R93FRYJXAM1T" ;
+    rs:numericValue -4800.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/period/p_3> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/fact/fact_01KSV8AYSRWVB9R93FRYJXAM1X> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:NetCashProvidedByUsedInFinancingActivities ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/entity/entity_kg19e75ce934a3a00a17ea> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV8AYSKTWGGB1B7WWF5R33P> ;
+    rs:internalId "fact_01KSV8AYSRWVB9R93FRYJXAM1X" ;
+    rs:numericValue 49800.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/period/p_3> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/fact/fact_01KSV8AYSRWVB9R93FRYJXAM20> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/entity/entity_kg19e75ce934a3a00a17ea> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV8AYSKTWGGB1B7WWF5R33P> ;
+    rs:internalId "fact_01KSV8AYSRWVB9R93FRYJXAM20" ;
+    rs:numericValue 73620.00000000001 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/period/p_3> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/ib/5473639a-2dac-56a6-b9e5-38480ea38bc1> a rs:InformationBlock ;
+    skos:prefLabel "rs-gaap — Cash Flow Statement — Indirect" ;
+    rs:blockType "cash_flow_statement" ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV8AYSKTWGGB1B7WWF5R33P> ;
+    rs:internalId "5473639a-2dac-56a6-b9e5-38480ea38bc1" ;
+    rs:taxonomyId "cf7178a0-e2d4-58df-995a-2f0233d15466" ;
+    rs:taxonomyName "rs-gaap-presentation v1" .
+
+rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease a rs:Element ;
+    xbrli:balance "debit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "353f790f-1ed1-5b91-880d-8029b4b687cf" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:DepreciationDepletionAndAmortization a rs:Element ;
+    xbrli:balance "debit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "189a099a-7512-5144-9215-65d837c2c3b5" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:IncreaseDecreaseInAccountsPayableAndAccruedLiabilities a rs:Element ;
+    xbrli:balance "debit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "dc7408c9-cba5-5697-8254-32ac46485214" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:IncreaseDecreaseInPrepaidExpense a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "550bb6e5-53d0-5267-adb1-baf78093a0b0" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:NetCashProvidedByUsedInFinancingActivities a rs:Element ;
+    xbrli:balance "debit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "811f1cf5-836c-575f-9f3f-cd7fa477e4e5" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:NetCashProvidedByUsedInInvestingActivities a rs:Element ;
+    xbrli:balance "debit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "69b82be1-1145-5686-8613-31da9eb04a72" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:NetCashProvidedByUsedInOperatingActivities a rs:Element ;
+    xbrli:balance "debit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "57ccbf45-c970-5bcd-a381-44d96b6b6d94" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:NetIncomeLoss a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "27a05717-2370-51c2-a924-db5cbcb48219" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "ff101489-15f4-573d-967b-24f75e0fc0f6" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:ProceedsFromIssuanceOfCommonStock a rs:Element ;
+    xbrli:balance "debit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "2eb72b5f-d7e3-5bd5-bf93-be38b6d21820" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+<https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/entity/entity_kg19e75ce934a3a00a17ea> a rs:Entity ;
+    skos:prefLabel "Cascade Advisory Group LLC" ;
+    rs:country "US" ;
+    rs:internalId "entity_kg19e75ce934a3a00a17ea" ;
+    rs:legalName "Cascade Advisory Group LLC" .
+
+<https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/period/p_3> a rs:Period ;
+    xbrli:endDate "2025-12-31"^^xsd:date ;
+    xbrli:periodType "duration" ;
+    xbrli:startDate "2025-01-01"^^xsd:date .
+
+<https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/unit/u_USD> a rs:Unit ;
+    xbrli:measure iso4217:USD .
+```
+
+
+## rs-gaap — Statement of Changes in Equity — Roll Forward (Total)  {#ib-equity_statement}
+
+- **Block type**: `equity_statement`
+- **Information Block**: `0b179e5c-5f02-506d-b8d5-860cb10c7694`
+- **FactSet**: `fs_01KSV8AYSKTWGGB1B7WWF5R33Q`
+
+| QName | Concept | 2024-01-02 → 2025-12-31 |
+|---|---|---:|
+| `rs-gaap:NetIncomeLoss` |   **Net Income Loss** | $28,386.70 |
+| `rs-gaap:ProceedsFromIssuanceOfCommonStock` |   Proceeds From Issuance Of Common Stock | $49,800.00 |
+| `rs-gaap:StockholdersEquity` | **Stockholders Equity** | $78,186.70 |
+
+```turtle {#ib-equity_statement-rdf}
+@prefix iso4217: <http://www.xbrl.org/2003/iso4217#> .
+@prefix rs: <https://robosystems.ai/vocab/> .
+@prefix rs-gaap: <https://robosystems.ai/taxonomy/rs-gaap/v1/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xbrli: <http://www.xbrl.org/2003/instance#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/fact/fact_01KSV8AYSRWVB9R93FRYJXAM1B> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:NetIncomeLoss ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/entity/entity_kg19e75ce934a3a00a17ea> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV8AYSKTWGGB1B7WWF5R33Q> ;
+    rs:internalId "fact_01KSV8AYSRWVB9R93FRYJXAM1B" ;
+    rs:numericValue 28386.70000000001 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/period/p_3> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/structure/0b179e5c-5f02-506d-b8d5-860cb10c7694> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/fact/fact_01KSV8AYSRWVB9R93FRYJXAM1F> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:ProceedsFromIssuanceOfCommonStock ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/entity/entity_kg19e75ce934a3a00a17ea> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV8AYSKTWGGB1B7WWF5R33Q> ;
+    rs:internalId "fact_01KSV8AYSRWVB9R93FRYJXAM1F" ;
+    rs:numericValue 49800.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/period/p_3> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/structure/0b179e5c-5f02-506d-b8d5-860cb10c7694> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/fact/fact_01KSV8AYSRWVB9R93FRYJXAM21> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:StockholdersEquity ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/entity/entity_kg19e75ce934a3a00a17ea> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV8AYSKTWGGB1B7WWF5R33Q> ;
+    rs:internalId "fact_01KSV8AYSRWVB9R93FRYJXAM21" ;
+    rs:numericValue 78186.70000000001 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/period/p_1> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/structure/0b179e5c-5f02-506d-b8d5-860cb10c7694> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/ib/0b179e5c-5f02-506d-b8d5-860cb10c7694> a rs:InformationBlock ;
+    skos:prefLabel "rs-gaap — Statement of Changes in Equity — Roll Forward (Total)" ;
+    rs:blockType "equity_statement" ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV8AYSKTWGGB1B7WWF5R33Q> ;
+    rs:internalId "0b179e5c-5f02-506d-b8d5-860cb10c7694" ;
+    rs:taxonomyId "cf7178a0-e2d4-58df-995a-2f0233d15466" ;
+    rs:taxonomyName "rs-gaap-presentation v1" .
+
+<https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/period/p_1> a rs:Period ;
+    xbrli:instant "2025-12-31"^^xsd:date ;
+    xbrli:periodType "instant" .
+
+rs-gaap:NetIncomeLoss a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "27a05717-2370-51c2-a924-db5cbcb48219" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:ProceedsFromIssuanceOfCommonStock a rs:Element ;
+    xbrli:balance "debit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "2eb72b5f-d7e3-5bd5-bf93-be38b6d21820" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:StockholdersEquity a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "instant" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "e3796201-9899-5b7b-9477-659550ba8e68" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+<https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/period/p_3> a rs:Period ;
+    xbrli:endDate "2025-12-31"^^xsd:date ;
+    xbrli:periodType "duration" ;
+    xbrli:startDate "2025-01-01"^^xsd:date .
+
+<https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/entity/entity_kg19e75ce934a3a00a17ea> a rs:Entity ;
+    skos:prefLabel "Cascade Advisory Group LLC" ;
+    rs:country "US" ;
+    rs:internalId "entity_kg19e75ce934a3a00a17ea" ;
+    rs:legalName "Cascade Advisory Group LLC" .
+
+<https://robosystems.ai/report/rpt_01KSV8AYR7KX2R3HJP2SYY1GZ2/unit/u_USD> a rs:Unit ;
+    xbrli:measure iso4217:USD .
+```
+
+
+## Validation evidence
+
+Independent, standards-grade checks of the same bundle this DataBook renders — embedded so the artifact travels with its own proof.
+
+### RoboLedger — SHACL Ontology Conformance
+
+#### Result: ✅ **Conforms to RoboSystems RDF Ontology v1**
+
+- **Bundle**: `roboledger-demo.jsonld`
+- **Graph triples**: 2,709
+- **rs:Fact nodes**: 39
+- **rs:Association nodes**: 150
+- **rs:Element nodes**: 87
+- **SHACL shapes checked**: 8 (positive instance shapes + negative shapes banning the retired dialects)
+
+Validated on the host with **pyshacl** against `frameworks/ontology/v1/shapes.ttl` — the *same* shapes that gate the framework seeds and the publish-time bundle validation, run here directly on the on-disk artifact (no API, no database, no container). Conformance means every `rs:Fact` references its aspects directly (`rs:element`/`rs:entity`/`rs:period`/`rs:unit` — no XBRL `context`), every `rs:Association` carries `xlink:from`/`to` + `xlink:arcrole`, and none of the retired dialects (`xbrli:contextRef`, `arcFrom`, direct `summationOf`) appear.
+
+#### Violations
+
+_None._ Zero violations.
+
+### RoboLedger — XBRL 2.1 Validation (Arelle)
+
+#### Result: ✅ **Valid XBRL 2.1**
+
+- **Package**: `roboledger-demo.zip` (12,342 bytes)
+- **Files in zip**: 5 (`instance.xml, report-cal.xml, report-lab.xml, report-pre.xml, report.xsd`)
+- **Facts loaded by Arelle**: 34
+- **Load errors**: 0
+- **Validation errors**: 0
+
+Validated on the host with **Arelle** (the de-facto XBRL processor, also used by SEC EDGAR) directly against the on-disk report package — no API, no container. Zero load + validation errors is the structural-correctness claim: the output is valid XBRL 2.1, consumable by any standards-compliant processor. This is **base XBRL 2.1** validation; SEC/EFM disclosure-system checks are not enabled (the instance isn't an SEC filing).
+
+#### Errors
+
+_None._ Arelle reported no load errors and no XBRL 2.1 validation errors against the emitted instance + schema + linkbases.

--- a/examples/seattle_method_demo/main.py
+++ b/examples/seattle_method_demo/main.py
@@ -419,6 +419,34 @@ def step_validate(graph_id: str, dry_run: bool = False) -> None:
   if result.returncode != 0:
     raise SystemExit(f"validate exited with code {result.returncode}")
 
+  # DataBook: assemble the validated bundle into one self-describing markdown
+  # file (Charlie Hoffman's serialization) — report = collection of Information
+  # Blocks, each a table + an addressable turtle slice, with the SHACL/Arelle
+  # verdicts (just written above) inlined as embedded evidence.
+  databook = subprocess.run(
+    [
+      "uv",
+      "run",
+      "python",
+      "-m",
+      "examples._common.databook",
+      "--jsonld",
+      str(out_dir / "seattle-method-case-1.jsonld"),
+      "--out",
+      str(out_dir / "seattle-method-case-1.databook.md"),
+      "--shacl-md",
+      str(out_dir / "seattle-method-case-1-shacl-validation.md"),
+      "--xbrl-md",
+      str(out_dir / "seattle-method-case-1-xbrl-validation.md"),
+      "--label",
+      "Seattle Method (Test Case 1)",
+    ],
+    cwd=str(REPO_ROOT),
+    check=False,
+  )
+  if databook.returncode != 0:
+    raise SystemExit(f"databook exited with code {databook.returncode}")
+
 
 def step_create_report(graph_id: str, dry_run: bool = False) -> None:
   """Step 8 — Materialize the 4-IB rs-gaap Report + render markdown.

--- a/examples/seattle_method_demo/sample_output/seattle-method-case-1.databook.md
+++ b/examples/seattle_method_demo/sample_output/seattle-method-case-1.databook.md
@@ -1,13 +1,52 @@
 ---
 id: https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6
-type: databook
-vocab: https://w3id.org/databook/ns#
-serialization_version: "1.0"
+type: DataBook
+title: "Seattle Method (Test Case 1) — Lemonade Stand (Charlie Hoffman Test Case 1)"
+version: 1.0.0
+authors:
+  - name: "RoboSystems Report Engine"
+license: CC-BY-4.0
+description: >
+  Published financial report as a DataBook — the report as a
+  collection of Information Blocks (balance sheet, income
+  statement, cash flow, statement of changes in equity), each a
+  table plus an addressable RDF/Turtle slice, with SHACL + XBRL
+  2.1 validation evidence inlined.
+tags:
+  - financial
+  - reporting
+  - xbrl
+  - rs-gaap
+  - databook
+provenance:
+  source: "Lemonade Stand (Charlie Hoffman Test Case 1)"
+  method: "Materialized RoboSystems Report rpt_01KTDR4JFECMQWRA5ZHNT81XB6 (generation 1, draft)"
+manifest:
+  entrypoints:
+    - block: balance_sheet
+    - block: income_statement
+    - block: cash_flow_statement
+    - block: equity_statement
+  blocks:
+    balance_sheet:
+      type: turtle
+      description: "rs-gaap — Balance Sheet — Classified"
+    income_statement:
+      type: turtle
+      description: "rs-gaap — Income Statement — Multi-step"
+    cash_flow_statement:
+      type: turtle
+      description: "rs-gaap — Cash Flow Statement — Indirect"
+    equity_statement:
+      type: turtle
+      description: "rs-gaap — Statement of Changes in Equity — Roll Forward (Total)"
 report:
   reporting_style: 025f5d48-12ce-5d65-b9eb-4f137a10ef06
-  entity: "Lemonade Stand (Charlie Hoffman Test Case 1)"
+  report_id: rpt_01KTDR4JFECMQWRA5ZHNT81XB6
+  generation_count: 1
+  filing_status: draft
   periods:
-    - { label: "2023-10-02 \u2192 2024-03-31", start: 2023-10-02, end: 2024-03-31 }
+    - { label: "2023-10-02 → 2024-03-31", start: 2023-10-02, end: 2024-03-31 }
   framework_pins:
     - { framework: fac-traits, version: v1 }
     - { framework: rs-gaap, version: v1 }
@@ -22,27 +61,16 @@ report:
     - { framework: rs-gaap-reporting-styles, version: v1 }
     - { framework: rs-gaap-rollup-rules, version: v1 }
     - { framework: rs-gaap-rules, version: v1 }
-process:
-  transformer: robosystems-report-engine
-  report_id: rpt_01KTDR4JFECMQWRA5ZHNT81XB6
-  generation_count: 1
-  filing_status: draft
-information_blocks:
-  - { id: b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d, block_type: balance_sheet, anchor: ib-balance_sheet }
-  - { id: 47cd6544-03d1-5bc1-8c28-31c0cfa450f9, block_type: income_statement, anchor: ib-income_statement }
-  - { id: 5473639a-2dac-56a6-b9e5-38480ea38bc1, block_type: cash_flow_statement, anchor: ib-cash_flow_statement }
-  - { id: 0b179e5c-5f02-506d-b8d5-860cb10c7694, block_type: equity_statement, anchor: ib-equity_statement }
-license: CC-BY-4.0
 ---
 
-# Seattle Method (Test Case 1) — Report DataBook
+# Seattle Method (Test Case 1) — Lemonade Stand (Charlie Hoffman Test Case 1)
 
-A report **is** a collection of Information Blocks. Each block below is shown twice: a markdown table (human view) and an addressable `turtle` block (machine view — the same facts as RDF). Frontmatter carries the report's provenance *process stamp*. Everything here is derived from `seattle-method-case-1.jsonld`; the bundle and this DataBook are two skins of one graph.
+A report **is** a collection of Information Blocks. Each block below is shown twice: a markdown table (human view) and an addressable `turtle` block (machine view — the same facts as RDF), keyed by the id declared in the frontmatter `manifest`. Everything is derived from `seattle-method-case-1.jsonld`; the bundle and this DataBook are two skins of one graph.
 
 
-## rs-gaap — Balance Sheet — Classified  {#ib-balance_sheet}
+## Balance Sheet
 
-- **Block type**: `balance_sheet`
+- **Structure**: rs-gaap — Balance Sheet — Classified
 - **Information Block**: `b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d`
 - **FactSet**: `fs_01KTDR4JG477A3VNMHZFPE28MP`
 
@@ -66,7 +94,7 @@ A report **is** a collection of Information Blocks. Each block below is shown tw
 | `rs-gaap:StockholdersEquity` |   **Stockholders Equity** | $12,050.00 |
 | `rs-gaap:LiabilitiesAndStockholdersEquity` | **Liabilities And Stockholders Equity** | $14,450.00 |
 
-```turtle {#ib-balance_sheet-rdf}
+```turtle {#balance_sheet}
 @prefix iso4217: <http://www.xbrl.org/2003/iso4217#> .
 @prefix rs: <https://robosystems.ai/vocab/> .
 @prefix rs-gaap: <https://robosystems.ai/taxonomy/rs-gaap/v1/> .
@@ -480,9 +508,9 @@ rs-gaap:RetainedEarningsAccumulatedDeficit a rs:Element ;
 ```
 
 
-## rs-gaap — Income Statement — Multi-step  {#ib-income_statement}
+## Income Statement
 
-- **Block type**: `income_statement`
+- **Structure**: rs-gaap — Income Statement — Multi-step
 - **Information Block**: `47cd6544-03d1-5bc1-8c28-31c0cfa450f9`
 - **FactSet**: `fs_01KTDR4JG477A3VNMHZFPE28MQ`
 
@@ -502,7 +530,7 @@ rs-gaap:RetainedEarningsAccumulatedDeficit a rs:Element ;
 | `rs-gaap:IncomeLossFromContinuingOperations` |   **Income Loss From Continuing Operations** | $2,050.00 |
 | `rs-gaap:NetIncomeLoss` |   **Net Income Loss** | $2,050.00 |
 
-```turtle {#ib-income_statement-rdf}
+```turtle {#income_statement}
 @prefix iso4217: <http://www.xbrl.org/2003/iso4217#> .
 @prefix rs: <https://robosystems.ai/vocab/> .
 @prefix rs-gaap: <https://robosystems.ai/taxonomy/rs-gaap/v1/> .
@@ -807,9 +835,9 @@ rs-gaap:Revenues a rs:Element ;
 ```
 
 
-## rs-gaap — Cash Flow Statement — Indirect  {#ib-cash_flow_statement}
+## Cash Flow Statement
 
-- **Block type**: `cash_flow_statement`
+- **Structure**: rs-gaap — Cash Flow Statement — Indirect
 - **Information Block**: `5473639a-2dac-56a6-b9e5-38480ea38bc1`
 - **FactSet**: `fs_01KTDR4JG477A3VNMHZFPE28MR`
 
@@ -829,7 +857,7 @@ rs-gaap:Revenues a rs:Element ;
 | `rs-gaap:NetCashProvidedByUsedInFinancingActivities` |   Net Cash Provided By Used In Financing Activities | $11,000.00 |
 | `rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease` | **Cash And Cash Equivalents Period Increase Decrease** | $10,850.00 |
 
-```turtle {#ib-cash_flow_statement-rdf}
+```turtle {#cash_flow_statement}
 @prefix iso4217: <http://www.xbrl.org/2003/iso4217#> .
 @prefix rs: <https://robosystems.ai/vocab/> .
 @prefix rs-gaap: <https://robosystems.ai/taxonomy/rs-gaap/v1/> .
@@ -1134,9 +1162,9 @@ rs-gaap:RepaymentsOfLongTermDebt a rs:Element ;
 ```
 
 
-## rs-gaap — Statement of Changes in Equity — Roll Forward (Total)  {#ib-equity_statement}
+## Statement of Changes in Equity
 
-- **Block type**: `equity_statement`
+- **Structure**: rs-gaap — Statement of Changes in Equity — Roll Forward (Total)
 - **Information Block**: `0b179e5c-5f02-506d-b8d5-860cb10c7694`
 - **FactSet**: `fs_01KTDR4JG477A3VNMHZFPE28MS`
 
@@ -1146,7 +1174,7 @@ rs-gaap:RepaymentsOfLongTermDebt a rs:Element ;
 | `rs-gaap:ProceedsFromIssuanceOfCommonStock` |   Proceeds From Issuance Of Common Stock | $10,000.00 |
 | `rs-gaap:StockholdersEquity` | **Stockholders Equity** | $12,050.00 |
 
-```turtle {#ib-equity_statement-rdf}
+```turtle {#equity_statement}
 @prefix iso4217: <http://www.xbrl.org/2003/iso4217#> .
 @prefix rs: <https://robosystems.ai/vocab/> .
 @prefix rs-gaap: <https://robosystems.ai/taxonomy/rs-gaap/v1/> .

--- a/examples/seattle_method_demo/sample_output/seattle-method-case-1.databook.md
+++ b/examples/seattle_method_demo/sample_output/seattle-method-case-1.databook.md
@@ -1,0 +1,1283 @@
+---
+id: https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6
+type: databook
+vocab: https://w3id.org/databook/ns#
+serialization_version: "1.0"
+report:
+  reporting_style: 025f5d48-12ce-5d65-b9eb-4f137a10ef06
+  entity: "Lemonade Stand (Charlie Hoffman Test Case 1)"
+  periods:
+    - { label: "2023-10-02 \u2192 2024-03-31", start: 2023-10-02, end: 2024-03-31 }
+  framework_pins:
+    - { framework: fac-traits, version: v1 }
+    - { framework: rs-gaap, version: v1 }
+    - { framework: rs-gaap-traits, version: v1 }
+    - { framework: rs-gaap-hierarchy, version: v1 }
+    - { framework: rs-gaap-presentation, version: v1 }
+    - { framework: rs-gaap-calculations, version: v1 }
+    - { framework: rs-gaap-type-subtype, version: v1 }
+    - { framework: rs-gaap-references, version: v1 }
+    - { framework: rs-gaap-labels, version: v1 }
+    - { framework: rs-gaap-disclosures, version: v1 }
+    - { framework: rs-gaap-reporting-styles, version: v1 }
+    - { framework: rs-gaap-rollup-rules, version: v1 }
+    - { framework: rs-gaap-rules, version: v1 }
+process:
+  transformer: robosystems-report-engine
+  report_id: rpt_01KTDR4JFECMQWRA5ZHNT81XB6
+  generation_count: 1
+  filing_status: draft
+information_blocks:
+  - { id: b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d, block_type: balance_sheet, anchor: ib-balance_sheet }
+  - { id: 47cd6544-03d1-5bc1-8c28-31c0cfa450f9, block_type: income_statement, anchor: ib-income_statement }
+  - { id: 5473639a-2dac-56a6-b9e5-38480ea38bc1, block_type: cash_flow_statement, anchor: ib-cash_flow_statement }
+  - { id: 0b179e5c-5f02-506d-b8d5-860cb10c7694, block_type: equity_statement, anchor: ib-equity_statement }
+license: CC-BY-4.0
+---
+
+# Seattle Method (Test Case 1) — Report DataBook
+
+A report **is** a collection of Information Blocks. Each block below is shown twice: a markdown table (human view) and an addressable `turtle` block (machine view — the same facts as RDF). Frontmatter carries the report's provenance *process stamp*. Everything here is derived from `seattle-method-case-1.jsonld`; the bundle and this DataBook are two skins of one graph.
+
+
+## rs-gaap — Balance Sheet — Classified  {#ib-balance_sheet}
+
+- **Block type**: `balance_sheet`
+- **Information Block**: `b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d`
+- **FactSet**: `fs_01KTDR4JG477A3VNMHZFPE28MP`
+
+| QName | Concept | 2023-10-02 → 2024-03-31 |
+|---|---|---:|
+| `rs-gaap:CashAndCashEquivalentsAtCarryingValue` |     Cash And Cash Equivalents At Carrying Value | $10,850.00 |
+| `rs-gaap:ReceivablesNetCurrent` |     Receivables Net Current | $0.00 |
+| `rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings` |     Inventory Net Of Allowances Customer Advances And Progress Billings | $2,700.00 |
+| `rs-gaap:AssetsCurrent` |   **Assets Current** | $13,550.00 |
+| `rs-gaap:PropertyPlantAndEquipmentNet` |     Property Plant And Equipment Net | $900.00 |
+| `rs-gaap:AssetsNoncurrent` |   **Assets Noncurrent** | $900.00 |
+| `rs-gaap:Assets` | **Assets** | $14,450.00 |
+| `rs-gaap:AccountsPayableCurrent` |       Accounts Payable Current | $1,000.00 |
+| `rs-gaap:AccruedLiabilitiesCurrent` |       Accrued Liabilities Current | $400.00 |
+| `rs-gaap:LiabilitiesCurrent` |     **Liabilities Current** | $1,400.00 |
+| `rs-gaap:LongTermDebtAndCapitalLeaseObligations` |       Long Term Debt And Capital Lease Obligations | $1,000.00 |
+| `rs-gaap:LiabilitiesNoncurrent` |     **Liabilities Noncurrent** | $1,000.00 |
+| `rs-gaap:Liabilities` |   **Liabilities** | $2,400.00 |
+| `rs-gaap:AdditionalPaidInCapital` |     Additional Paid In Capital | $10,000.00 |
+| `rs-gaap:RetainedEarningsAccumulatedDeficit` |     Retained Earnings Accumulated Deficit | $2,050.00 |
+| `rs-gaap:StockholdersEquity` |   **Stockholders Equity** | $12,050.00 |
+| `rs-gaap:LiabilitiesAndStockholdersEquity` | **Liabilities And Stockholders Equity** | $14,450.00 |
+
+```turtle {#ib-balance_sheet-rdf}
+@prefix iso4217: <http://www.xbrl.org/2003/iso4217#> .
+@prefix rs: <https://robosystems.ai/vocab/> .
+@prefix rs-gaap: <https://robosystems.ai/taxonomy/rs-gaap/v1/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xbrli: <http://www.xbrl.org/2003/instance#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/fact/fact_01KTDR4JG96ZEXVW49FE91K10K> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:AccountsPayableCurrent ;
+    rs:entity <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/entity/entity_kg19e9b82353aed511343b> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KTDR4JG477A3VNMHZFPE28MP> ;
+    rs:internalId "fact_01KTDR4JG96ZEXVW49FE91K10K" ;
+    rs:numericValue 1000.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/period/p_1> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/fact/fact_01KTDR4JG96ZEXVW49FE91K10M> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:AccruedLiabilitiesCurrent ;
+    rs:entity <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/entity/entity_kg19e9b82353aed511343b> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KTDR4JG477A3VNMHZFPE28MP> ;
+    rs:internalId "fact_01KTDR4JG96ZEXVW49FE91K10M" ;
+    rs:numericValue 400.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/period/p_1> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/fact/fact_01KTDR4JG96ZEXVW49FE91K10N> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:AdditionalPaidInCapital ;
+    rs:entity <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/entity/entity_kg19e9b82353aed511343b> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KTDR4JG477A3VNMHZFPE28MP> ;
+    rs:internalId "fact_01KTDR4JG96ZEXVW49FE91K10N" ;
+    rs:numericValue 10000.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/period/p_1> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/fact/fact_01KTDR4JG96ZEXVW49FE91K10P> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:CashAndCashEquivalentsAtCarryingValue ;
+    rs:entity <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/entity/entity_kg19e9b82353aed511343b> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KTDR4JG477A3VNMHZFPE28MP> ;
+    rs:internalId "fact_01KTDR4JG96ZEXVW49FE91K10P" ;
+    rs:numericValue 10850.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/period/p_1> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/fact/fact_01KTDR4JG96ZEXVW49FE91K10W> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings ;
+    rs:entity <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/entity/entity_kg19e9b82353aed511343b> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KTDR4JG477A3VNMHZFPE28MP> ;
+    rs:internalId "fact_01KTDR4JG96ZEXVW49FE91K10W" ;
+    rs:numericValue 2700.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/period/p_1> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/fact/fact_01KTDR4JG96ZEXVW49FE91K10X> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:LongTermDebtAndCapitalLeaseObligations ;
+    rs:entity <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/entity/entity_kg19e9b82353aed511343b> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KTDR4JG477A3VNMHZFPE28MP> ;
+    rs:internalId "fact_01KTDR4JG96ZEXVW49FE91K10X" ;
+    rs:numericValue 1000.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/period/p_1> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/fact/fact_01KTDR4JG96ZEXVW49FE91K10Y> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:PropertyPlantAndEquipmentNet ;
+    rs:entity <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/entity/entity_kg19e9b82353aed511343b> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KTDR4JG477A3VNMHZFPE28MP> ;
+    rs:internalId "fact_01KTDR4JG96ZEXVW49FE91K10Y" ;
+    rs:numericValue 900.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/period/p_1> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/fact/fact_01KTDR4JG96ZEXVW49FE91K10Z> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:ReceivablesNetCurrent ;
+    rs:entity <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/entity/entity_kg19e9b82353aed511343b> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KTDR4JG477A3VNMHZFPE28MP> ;
+    rs:internalId "fact_01KTDR4JG96ZEXVW49FE91K10Z" ;
+    rs:numericValue 0.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/period/p_1> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/fact/fact_01KTDR4JG96ZEXVW49FE91K111> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:RetainedEarningsAccumulatedDeficit ;
+    rs:entity <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/entity/entity_kg19e9b82353aed511343b> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KTDR4JG477A3VNMHZFPE28MP> ;
+    rs:internalId "fact_01KTDR4JG96ZEXVW49FE91K111" ;
+    rs:numericValue 2050.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/period/p_1> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/fact/fact_01KTDR4JG96ZEXVW49FE91K112> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:AdditionalPaidInCapital ;
+    rs:entity <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/entity/entity_kg19e9b82353aed511343b> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KTDR4JG477A3VNMHZFPE28MP> ;
+    rs:internalId "fact_01KTDR4JG96ZEXVW49FE91K112" ;
+    rs:numericValue 0.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/period/p_3> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/fact/fact_01KTDR4JG96ZEXVW49FE91K113> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:RetainedEarningsAccumulatedDeficit ;
+    rs:entity <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/entity/entity_kg19e9b82353aed511343b> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KTDR4JG477A3VNMHZFPE28MP> ;
+    rs:internalId "fact_01KTDR4JG96ZEXVW49FE91K113" ;
+    rs:numericValue 0.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/period/p_3> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/fact/fact_01KTDR4JG96ZEXVW49FE91K11H> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:StockholdersEquity ;
+    rs:entity <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/entity/entity_kg19e9b82353aed511343b> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KTDR4JG477A3VNMHZFPE28MP> ;
+    rs:internalId "fact_01KTDR4JG96ZEXVW49FE91K11H" ;
+    rs:numericValue 12050.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/period/p_1> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/fact/fact_01KTDR4JG96ZEXVW49FE91K11J> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:Liabilities ;
+    rs:entity <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/entity/entity_kg19e9b82353aed511343b> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KTDR4JG477A3VNMHZFPE28MP> ;
+    rs:internalId "fact_01KTDR4JG96ZEXVW49FE91K11J" ;
+    rs:numericValue 2400.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/period/p_1> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/fact/fact_01KTDR4JG96ZEXVW49FE91K11N> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:LiabilitiesCurrent ;
+    rs:entity <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/entity/entity_kg19e9b82353aed511343b> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KTDR4JG477A3VNMHZFPE28MP> ;
+    rs:internalId "fact_01KTDR4JG96ZEXVW49FE91K11N" ;
+    rs:numericValue 1400.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/period/p_1> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/fact/fact_01KTDR4JG96ZEXVW49FE91K11P> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:LiabilitiesNoncurrent ;
+    rs:entity <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/entity/entity_kg19e9b82353aed511343b> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KTDR4JG477A3VNMHZFPE28MP> ;
+    rs:internalId "fact_01KTDR4JG96ZEXVW49FE91K11P" ;
+    rs:numericValue 1000.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/period/p_1> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/fact/fact_01KTDR4JG96ZEXVW49FE91K11R> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:AssetsNoncurrent ;
+    rs:entity <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/entity/entity_kg19e9b82353aed511343b> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KTDR4JG477A3VNMHZFPE28MP> ;
+    rs:internalId "fact_01KTDR4JG96ZEXVW49FE91K11R" ;
+    rs:numericValue 900.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/period/p_1> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/fact/fact_01KTDR4JG96ZEXVW49FE91K11S> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:LiabilitiesAndStockholdersEquity ;
+    rs:entity <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/entity/entity_kg19e9b82353aed511343b> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KTDR4JG477A3VNMHZFPE28MP> ;
+    rs:internalId "fact_01KTDR4JG96ZEXVW49FE91K11S" ;
+    rs:numericValue 14450.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/period/p_1> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/fact/fact_01KTDR4JG96ZEXVW49FE91K11W> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:Assets ;
+    rs:entity <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/entity/entity_kg19e9b82353aed511343b> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KTDR4JG477A3VNMHZFPE28MP> ;
+    rs:internalId "fact_01KTDR4JG96ZEXVW49FE91K11W" ;
+    rs:numericValue 14450.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/period/p_1> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/fact/fact_01KTDR4JG96ZEXVW49FE91K120> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:AssetsCurrent ;
+    rs:entity <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/entity/entity_kg19e9b82353aed511343b> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KTDR4JG477A3VNMHZFPE28MP> ;
+    rs:internalId "fact_01KTDR4JG96ZEXVW49FE91K120" ;
+    rs:numericValue 13550.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/period/p_1> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/ib/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> a rs:InformationBlock ;
+    skos:prefLabel "rs-gaap — Balance Sheet — Classified" ;
+    rs:blockType "balance_sheet" ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KTDR4JG477A3VNMHZFPE28MP> ;
+    rs:internalId "b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d" ;
+    rs:taxonomyId "cf7178a0-e2d4-58df-995a-2f0233d15466" ;
+    rs:taxonomyName "rs-gaap-presentation v1" .
+
+rs-gaap:AccountsPayableCurrent a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "instant" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "9ddbc9d7-c769-5800-8f65-1089d476e5c9" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:AccruedLiabilitiesCurrent a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "instant" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "4decfae2-2ca3-5dd3-8c06-88557583c13d" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:Assets a rs:Element ;
+    xbrli:balance "debit" ;
+    xbrli:periodType "instant" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "a1f04756-41d8-5d35-b821-23aa2f3b2fae" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:AssetsCurrent a rs:Element ;
+    xbrli:balance "debit" ;
+    xbrli:periodType "instant" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "0fc9ab7e-c5ce-5277-9530-344cc127fe26" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:AssetsNoncurrent a rs:Element ;
+    xbrli:balance "debit" ;
+    xbrli:periodType "instant" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "841cedeb-4cb0-532a-b0bd-c34846a13a8c" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:CashAndCashEquivalentsAtCarryingValue a rs:Element ;
+    xbrli:balance "debit" ;
+    xbrli:periodType "instant" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "20a6586b-880a-5745-94db-e23d397eb5e1" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings a rs:Element ;
+    xbrli:balance "debit" ;
+    xbrli:periodType "instant" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "4afa5950-85ac-5a85-a9cb-01c387c6ab08" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:Liabilities a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "instant" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "7af273ac-1cba-5fb3-a1c9-5c5d8fdb9bdf" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:LiabilitiesAndStockholdersEquity a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "instant" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "30b2801e-e682-5298-82e6-3670e1d508f1" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:LiabilitiesCurrent a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "instant" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "efb036ff-3f30-5deb-bee9-1af4cd4b9800" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:LiabilitiesNoncurrent a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "instant" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "f41fe34d-88ea-5e20-a781-2d3e256a6abf" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:LongTermDebtAndCapitalLeaseObligations a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "instant" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "091373d9-8a82-51bd-adf8-d09b73beb32e" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:PropertyPlantAndEquipmentNet a rs:Element ;
+    xbrli:balance "debit" ;
+    xbrli:periodType "instant" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "288099af-5cbb-5f78-8f8a-1a85675fb661" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:ReceivablesNetCurrent a rs:Element ;
+    xbrli:balance "debit" ;
+    xbrli:periodType "instant" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "44686df3-3871-5c1f-8a08-fc542d69dfa0" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:StockholdersEquity a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "instant" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "e3796201-9899-5b7b-9477-659550ba8e68" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/period/p_3> a rs:Period ;
+    xbrli:instant "2023-12-31"^^xsd:date ;
+    xbrli:periodType "instant" .
+
+rs-gaap:AdditionalPaidInCapital a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "instant" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "6146605c-0d63-51e1-a523-3450d6abaca3" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:RetainedEarningsAccumulatedDeficit a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "instant" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "a9c87d60-a1e5-506b-a27e-cbf9e14e5113" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/period/p_1> a rs:Period ;
+    xbrli:instant "2024-03-31"^^xsd:date ;
+    xbrli:periodType "instant" .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/entity/entity_kg19e9b82353aed511343b> a rs:Entity ;
+    skos:prefLabel "Lemonade Stand (Charlie Hoffman Test Case 1)" ;
+    rs:country "US" ;
+    rs:internalId "entity_kg19e9b82353aed511343b" ;
+    rs:legalName "Lemonade Stand (Charlie Hoffman Test Case 1)" .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/unit/u_USD> a rs:Unit ;
+    xbrli:measure iso4217:USD .
+```
+
+
+## rs-gaap — Income Statement — Multi-step  {#ib-income_statement}
+
+- **Block type**: `income_statement`
+- **Information Block**: `47cd6544-03d1-5bc1-8c28-31c0cfa450f9`
+- **FactSet**: `fs_01KTDR4JG477A3VNMHZFPE28MQ`
+
+| QName | Concept | 2023-10-02 → 2024-03-31 |
+|---|---|---:|
+| `rs-gaap:Revenues` |   **Revenues** | $8,000.00 |
+| `rs-gaap:CostOfGoodsAndServicesSold` |     Cost Of Goods And Services Sold | $5,300.00 |
+| `rs-gaap:CostOfRevenue` |   **Cost Of Revenue** | $5,300.00 |
+| `rs-gaap:GrossProfit` |   **Gross Profit** | $2,700.00 |
+| `rs-gaap:DepreciationDepletionAndAmortization` |     Depreciation Depletion And Amortization | $100.00 |
+| `rs-gaap:OperatingExpenses` |   **Operating Expenses** | $100.00 |
+| `rs-gaap:OperatingIncomeLoss` |   **Operating Income Loss** | $2,600.00 |
+| `rs-gaap:InterestExpense` |     Interest Expense | $150.00 |
+| `rs-gaap:NonoperatingIncomeExpense` |   **Nonoperating Income Expense** | $(150.00) |
+| `rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest` |   **Income Loss From Continuing Operations Before Income Taxes Extraordinary Items Noncontrolling Interest** | $2,450.00 |
+| `rs-gaap:IncomeTaxExpenseBenefit` |   Income Tax Expense Benefit | $400.00 |
+| `rs-gaap:IncomeLossFromContinuingOperations` |   **Income Loss From Continuing Operations** | $2,050.00 |
+| `rs-gaap:NetIncomeLoss` |   **Net Income Loss** | $2,050.00 |
+
+```turtle {#ib-income_statement-rdf}
+@prefix iso4217: <http://www.xbrl.org/2003/iso4217#> .
+@prefix rs: <https://robosystems.ai/vocab/> .
+@prefix rs-gaap: <https://robosystems.ai/taxonomy/rs-gaap/v1/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xbrli: <http://www.xbrl.org/2003/instance#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/fact/fact_01KTDR4JG96ZEXVW49FE91K10Q> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:CostOfGoodsAndServicesSold ;
+    rs:entity <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/entity/entity_kg19e9b82353aed511343b> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KTDR4JG477A3VNMHZFPE28MQ> ;
+    rs:internalId "fact_01KTDR4JG96ZEXVW49FE91K10Q" ;
+    rs:numericValue 5300.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/period/p_2> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/fact/fact_01KTDR4JG96ZEXVW49FE91K10S> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:DepreciationDepletionAndAmortization ;
+    rs:entity <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/entity/entity_kg19e9b82353aed511343b> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KTDR4JG477A3VNMHZFPE28MQ> ;
+    rs:internalId "fact_01KTDR4JG96ZEXVW49FE91K10S" ;
+    rs:numericValue 100.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/period/p_2> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/fact/fact_01KTDR4JG96ZEXVW49FE91K10T> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:IncomeTaxExpenseBenefit ;
+    rs:entity <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/entity/entity_kg19e9b82353aed511343b> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KTDR4JG477A3VNMHZFPE28MQ> ;
+    rs:internalId "fact_01KTDR4JG96ZEXVW49FE91K10T" ;
+    rs:numericValue 400.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/period/p_2> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/fact/fact_01KTDR4JG96ZEXVW49FE91K10V> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:InterestExpense ;
+    rs:entity <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/entity/entity_kg19e9b82353aed511343b> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KTDR4JG477A3VNMHZFPE28MQ> ;
+    rs:internalId "fact_01KTDR4JG96ZEXVW49FE91K10V" ;
+    rs:numericValue 150.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/period/p_2> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/fact/fact_01KTDR4JG96ZEXVW49FE91K110> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:Revenues ;
+    rs:entity <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/entity/entity_kg19e9b82353aed511343b> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KTDR4JG477A3VNMHZFPE28MQ> ;
+    rs:internalId "fact_01KTDR4JG96ZEXVW49FE91K110" ;
+    rs:numericValue 8000.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/period/p_2> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/fact/fact_01KTDR4JG96ZEXVW49FE91K115> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:NetIncomeLoss ;
+    rs:entity <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/entity/entity_kg19e9b82353aed511343b> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KTDR4JG477A3VNMHZFPE28MQ> ;
+    rs:internalId "fact_01KTDR4JG96ZEXVW49FE91K115" ;
+    rs:numericValue 2050.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/period/p_2> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/fact/fact_01KTDR4JG96ZEXVW49FE91K11F> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:IncomeLossFromContinuingOperations ;
+    rs:entity <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/entity/entity_kg19e9b82353aed511343b> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KTDR4JG477A3VNMHZFPE28MQ> ;
+    rs:internalId "fact_01KTDR4JG96ZEXVW49FE91K11F" ;
+    rs:numericValue 2050.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/period/p_2> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/fact/fact_01KTDR4JG96ZEXVW49FE91K11M> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:OperatingIncomeLoss ;
+    rs:entity <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/entity/entity_kg19e9b82353aed511343b> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KTDR4JG477A3VNMHZFPE28MQ> ;
+    rs:internalId "fact_01KTDR4JG96ZEXVW49FE91K11M" ;
+    rs:numericValue 2600.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/period/p_2> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/fact/fact_01KTDR4JG96ZEXVW49FE91K11T> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:GrossProfit ;
+    rs:entity <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/entity/entity_kg19e9b82353aed511343b> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KTDR4JG477A3VNMHZFPE28MQ> ;
+    rs:internalId "fact_01KTDR4JG96ZEXVW49FE91K11T" ;
+    rs:numericValue 2700.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/period/p_2> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/fact/fact_01KTDR4JG96ZEXVW49FE91K11X> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:NonoperatingIncomeExpense ;
+    rs:entity <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/entity/entity_kg19e9b82353aed511343b> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KTDR4JG477A3VNMHZFPE28MQ> ;
+    rs:internalId "fact_01KTDR4JG96ZEXVW49FE91K11X" ;
+    rs:numericValue -150.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/period/p_2> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/fact/fact_01KTDR4JG96ZEXVW49FE91K11Y> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:CostOfRevenue ;
+    rs:entity <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/entity/entity_kg19e9b82353aed511343b> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KTDR4JG477A3VNMHZFPE28MQ> ;
+    rs:internalId "fact_01KTDR4JG96ZEXVW49FE91K11Y" ;
+    rs:numericValue 5300.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/period/p_2> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/fact/fact_01KTDR4JG96ZEXVW49FE91K121> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:OperatingExpenses ;
+    rs:entity <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/entity/entity_kg19e9b82353aed511343b> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KTDR4JG477A3VNMHZFPE28MQ> ;
+    rs:internalId "fact_01KTDR4JG96ZEXVW49FE91K121" ;
+    rs:numericValue 100.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/period/p_2> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/fact/fact_01KTDR4JG96ZEXVW49FE91K122> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest ;
+    rs:entity <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/entity/entity_kg19e9b82353aed511343b> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KTDR4JG477A3VNMHZFPE28MQ> ;
+    rs:internalId "fact_01KTDR4JG96ZEXVW49FE91K122" ;
+    rs:numericValue 2450.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/period/p_2> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/ib/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> a rs:InformationBlock ;
+    skos:prefLabel "rs-gaap — Income Statement — Multi-step" ;
+    rs:blockType "income_statement" ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KTDR4JG477A3VNMHZFPE28MQ> ;
+    rs:internalId "47cd6544-03d1-5bc1-8c28-31c0cfa450f9" ;
+    rs:taxonomyId "cf7178a0-e2d4-58df-995a-2f0233d15466" ;
+    rs:taxonomyName "rs-gaap-presentation v1" .
+
+rs-gaap:CostOfGoodsAndServicesSold a rs:Element ;
+    xbrli:balance "debit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "5ca0e51f-dff1-5c2b-94f5-26620852a5f9" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:CostOfRevenue a rs:Element ;
+    xbrli:balance "debit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "12ab7417-5324-55d6-946e-2456adba47c5" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:DepreciationDepletionAndAmortization a rs:Element ;
+    xbrli:balance "debit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "189a099a-7512-5144-9215-65d837c2c3b5" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:GrossProfit a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "a92b3181-9fe7-543c-81d9-13ebd12bbefa" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:IncomeLossFromContinuingOperations a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "d60cabda-7060-5aff-ac98-96371606a738" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "6b0b414f-0c76-54f0-8e51-cf53db59ca24" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:IncomeTaxExpenseBenefit a rs:Element ;
+    xbrli:balance "debit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "d629316b-5674-58d9-afcd-b7e7fd34232d" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:InterestExpense a rs:Element ;
+    xbrli:balance "debit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "890e4f8c-8fed-57e2-96fd-e70455201b11" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:NetIncomeLoss a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "27a05717-2370-51c2-a924-db5cbcb48219" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:NonoperatingIncomeExpense a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "45aae2c2-fa56-50c9-b381-df8079e7d33a" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:OperatingExpenses a rs:Element ;
+    xbrli:balance "debit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "71fcdebb-7145-5f76-b5e0-b4ccbf2c29d2" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:OperatingIncomeLoss a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "16780828-0201-5609-b572-fbe3ebfcb177" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:Revenues a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "b26a6cd4-072f-5bf2-b5d3-ebf928150d6c" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/entity/entity_kg19e9b82353aed511343b> a rs:Entity ;
+    skos:prefLabel "Lemonade Stand (Charlie Hoffman Test Case 1)" ;
+    rs:country "US" ;
+    rs:internalId "entity_kg19e9b82353aed511343b" ;
+    rs:legalName "Lemonade Stand (Charlie Hoffman Test Case 1)" .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/period/p_2> a rs:Period ;
+    xbrli:endDate "2024-03-31"^^xsd:date ;
+    xbrli:periodType "duration" ;
+    xbrli:startDate "2024-01-01"^^xsd:date .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/unit/u_USD> a rs:Unit ;
+    xbrli:measure iso4217:USD .
+```
+
+
+## rs-gaap — Cash Flow Statement — Indirect  {#ib-cash_flow_statement}
+
+- **Block type**: `cash_flow_statement`
+- **Information Block**: `5473639a-2dac-56a6-b9e5-38480ea38bc1`
+- **FactSet**: `fs_01KTDR4JG477A3VNMHZFPE28MR`
+
+| QName | Concept | 2023-10-02 → 2024-03-31 |
+|---|---|---:|
+| `rs-gaap:NetIncomeLoss` |     **Net Income Loss** | $2,050.00 |
+| `rs-gaap:DepreciationDepletionAndAmortization` |     Depreciation Depletion And Amortization | $100.00 |
+| `rs-gaap:IncreaseDecreaseInInventories` |     Increase Decrease In Inventories | $(2,700.00) |
+| `rs-gaap:IncreaseDecreaseInOtherOperatingCapitalNet` |     Increase Decrease In Other Operating Capital Net | $1,000.00 |
+| `rs-gaap:IncreaseDecreaseInAccruedLiabilities` |     Increase Decrease In Accrued Liabilities | $400.00 |
+| `rs-gaap:NetCashProvidedByUsedInOperatingActivities` |   Net Cash Provided By Used In Operating Activities | $850.00 |
+| `rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment` |     Payments To Acquire Property Plant And Equipment | $(1,000.00) |
+| `rs-gaap:NetCashProvidedByUsedInInvestingActivities` |   Net Cash Provided By Used In Investing Activities | $(1,000.00) |
+| `rs-gaap:ProceedsFromIssuanceOfCommonStock` |     Proceeds From Issuance Of Common Stock | $10,000.00 |
+| `rs-gaap:ProceedsFromIssuanceOfLongTermDebt` |     Proceeds From Issuance Of Long Term Debt | $2,000.00 |
+| `rs-gaap:RepaymentsOfLongTermDebt` |     Repayments Of Long Term Debt | $(1,000.00) |
+| `rs-gaap:NetCashProvidedByUsedInFinancingActivities` |   Net Cash Provided By Used In Financing Activities | $11,000.00 |
+| `rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease` | **Cash And Cash Equivalents Period Increase Decrease** | $10,850.00 |
+
+```turtle {#ib-cash_flow_statement-rdf}
+@prefix iso4217: <http://www.xbrl.org/2003/iso4217#> .
+@prefix rs: <https://robosystems.ai/vocab/> .
+@prefix rs-gaap: <https://robosystems.ai/taxonomy/rs-gaap/v1/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xbrli: <http://www.xbrl.org/2003/instance#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/fact/fact_01KTDR4JG96ZEXVW49FE91K10R> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:DepreciationDepletionAndAmortization ;
+    rs:entity <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/entity/entity_kg19e9b82353aed511343b> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KTDR4JG477A3VNMHZFPE28MR> ;
+    rs:internalId "fact_01KTDR4JG96ZEXVW49FE91K10R" ;
+    rs:numericValue 100.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/period/p_2> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/fact/fact_01KTDR4JG96ZEXVW49FE91K114> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:NetIncomeLoss ;
+    rs:entity <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/entity/entity_kg19e9b82353aed511343b> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KTDR4JG477A3VNMHZFPE28MR> ;
+    rs:internalId "fact_01KTDR4JG96ZEXVW49FE91K114" ;
+    rs:numericValue 2050.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/period/p_2> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/fact/fact_01KTDR4JG96ZEXVW49FE91K117> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:ProceedsFromIssuanceOfLongTermDebt ;
+    rs:entity <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/entity/entity_kg19e9b82353aed511343b> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KTDR4JG477A3VNMHZFPE28MR> ;
+    rs:internalId "fact_01KTDR4JG96ZEXVW49FE91K117" ;
+    rs:numericValue 2000.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/period/p_2> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/fact/fact_01KTDR4JG96ZEXVW49FE91K118> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:ProceedsFromIssuanceOfCommonStock ;
+    rs:entity <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/entity/entity_kg19e9b82353aed511343b> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KTDR4JG477A3VNMHZFPE28MR> ;
+    rs:internalId "fact_01KTDR4JG96ZEXVW49FE91K118" ;
+    rs:numericValue 10000.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/period/p_2> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/fact/fact_01KTDR4JG96ZEXVW49FE91K11A> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:RepaymentsOfLongTermDebt ;
+    rs:entity <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/entity/entity_kg19e9b82353aed511343b> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KTDR4JG477A3VNMHZFPE28MR> ;
+    rs:internalId "fact_01KTDR4JG96ZEXVW49FE91K11A" ;
+    rs:numericValue -1000.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/period/p_2> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/fact/fact_01KTDR4JG96ZEXVW49FE91K11B> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment ;
+    rs:entity <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/entity/entity_kg19e9b82353aed511343b> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KTDR4JG477A3VNMHZFPE28MR> ;
+    rs:internalId "fact_01KTDR4JG96ZEXVW49FE91K11B" ;
+    rs:numericValue -1000.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/period/p_2> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/fact/fact_01KTDR4JG96ZEXVW49FE91K11C> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:IncreaseDecreaseInAccruedLiabilities ;
+    rs:entity <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/entity/entity_kg19e9b82353aed511343b> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KTDR4JG477A3VNMHZFPE28MR> ;
+    rs:internalId "fact_01KTDR4JG96ZEXVW49FE91K11C" ;
+    rs:numericValue 400.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/period/p_2> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/fact/fact_01KTDR4JG96ZEXVW49FE91K11D> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:IncreaseDecreaseInInventories ;
+    rs:entity <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/entity/entity_kg19e9b82353aed511343b> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KTDR4JG477A3VNMHZFPE28MR> ;
+    rs:internalId "fact_01KTDR4JG96ZEXVW49FE91K11D" ;
+    rs:numericValue -2700.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/period/p_2> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/fact/fact_01KTDR4JG96ZEXVW49FE91K11E> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:IncreaseDecreaseInOtherOperatingCapitalNet ;
+    rs:entity <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/entity/entity_kg19e9b82353aed511343b> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KTDR4JG477A3VNMHZFPE28MR> ;
+    rs:internalId "fact_01KTDR4JG96ZEXVW49FE91K11E" ;
+    rs:numericValue 1000.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/period/p_2> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/fact/fact_01KTDR4JG96ZEXVW49FE91K11K> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:NetCashProvidedByUsedInOperatingActivities ;
+    rs:entity <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/entity/entity_kg19e9b82353aed511343b> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KTDR4JG477A3VNMHZFPE28MR> ;
+    rs:internalId "fact_01KTDR4JG96ZEXVW49FE91K11K" ;
+    rs:numericValue 850.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/period/p_2> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/fact/fact_01KTDR4JG96ZEXVW49FE91K11Q> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease ;
+    rs:entity <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/entity/entity_kg19e9b82353aed511343b> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KTDR4JG477A3VNMHZFPE28MR> ;
+    rs:internalId "fact_01KTDR4JG96ZEXVW49FE91K11Q" ;
+    rs:numericValue 10850.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/period/p_2> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/fact/fact_01KTDR4JG96ZEXVW49FE91K11V> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:NetCashProvidedByUsedInFinancingActivities ;
+    rs:entity <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/entity/entity_kg19e9b82353aed511343b> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KTDR4JG477A3VNMHZFPE28MR> ;
+    rs:internalId "fact_01KTDR4JG96ZEXVW49FE91K11V" ;
+    rs:numericValue 11000.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/period/p_2> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/fact/fact_01KTDR4JG96ZEXVW49FE91K11Z> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:NetCashProvidedByUsedInInvestingActivities ;
+    rs:entity <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/entity/entity_kg19e9b82353aed511343b> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KTDR4JG477A3VNMHZFPE28MR> ;
+    rs:internalId "fact_01KTDR4JG96ZEXVW49FE91K11Z" ;
+    rs:numericValue -1000.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/period/p_2> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/ib/5473639a-2dac-56a6-b9e5-38480ea38bc1> a rs:InformationBlock ;
+    skos:prefLabel "rs-gaap — Cash Flow Statement — Indirect" ;
+    rs:blockType "cash_flow_statement" ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KTDR4JG477A3VNMHZFPE28MR> ;
+    rs:internalId "5473639a-2dac-56a6-b9e5-38480ea38bc1" ;
+    rs:taxonomyId "cf7178a0-e2d4-58df-995a-2f0233d15466" ;
+    rs:taxonomyName "rs-gaap-presentation v1" .
+
+rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease a rs:Element ;
+    xbrli:balance "debit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "353f790f-1ed1-5b91-880d-8029b4b687cf" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:DepreciationDepletionAndAmortization a rs:Element ;
+    xbrli:balance "debit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "189a099a-7512-5144-9215-65d837c2c3b5" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:IncreaseDecreaseInAccruedLiabilities a rs:Element ;
+    xbrli:balance "debit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "e92e6488-dcc7-5877-ad4b-f2498bdf7bae" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:IncreaseDecreaseInInventories a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "c8b0722b-7993-592f-8ef1-5b0964ac8a10" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:IncreaseDecreaseInOtherOperatingCapitalNet a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "a3227fb2-202b-51db-9574-4e60db03c04f" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:NetCashProvidedByUsedInFinancingActivities a rs:Element ;
+    xbrli:balance "debit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "811f1cf5-836c-575f-9f3f-cd7fa477e4e5" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:NetCashProvidedByUsedInInvestingActivities a rs:Element ;
+    xbrli:balance "debit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "69b82be1-1145-5686-8613-31da9eb04a72" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:NetCashProvidedByUsedInOperatingActivities a rs:Element ;
+    xbrli:balance "debit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "57ccbf45-c970-5bcd-a381-44d96b6b6d94" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:NetIncomeLoss a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "27a05717-2370-51c2-a924-db5cbcb48219" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "ff101489-15f4-573d-967b-24f75e0fc0f6" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:ProceedsFromIssuanceOfCommonStock a rs:Element ;
+    xbrli:balance "debit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "2eb72b5f-d7e3-5bd5-bf93-be38b6d21820" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:ProceedsFromIssuanceOfLongTermDebt a rs:Element ;
+    xbrli:balance "debit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "1802f6ae-7d95-5029-af7a-b36015b2c525" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:RepaymentsOfLongTermDebt a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "85890c87-aac7-5702-8f69-b1a14139dc41" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/entity/entity_kg19e9b82353aed511343b> a rs:Entity ;
+    skos:prefLabel "Lemonade Stand (Charlie Hoffman Test Case 1)" ;
+    rs:country "US" ;
+    rs:internalId "entity_kg19e9b82353aed511343b" ;
+    rs:legalName "Lemonade Stand (Charlie Hoffman Test Case 1)" .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/period/p_2> a rs:Period ;
+    xbrli:endDate "2024-03-31"^^xsd:date ;
+    xbrli:periodType "duration" ;
+    xbrli:startDate "2024-01-01"^^xsd:date .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/unit/u_USD> a rs:Unit ;
+    xbrli:measure iso4217:USD .
+```
+
+
+## rs-gaap — Statement of Changes in Equity — Roll Forward (Total)  {#ib-equity_statement}
+
+- **Block type**: `equity_statement`
+- **Information Block**: `0b179e5c-5f02-506d-b8d5-860cb10c7694`
+- **FactSet**: `fs_01KTDR4JG477A3VNMHZFPE28MS`
+
+| QName | Concept | 2023-10-02 → 2024-03-31 |
+|---|---|---:|
+| `rs-gaap:NetIncomeLoss` |   **Net Income Loss** | $2,050.00 |
+| `rs-gaap:ProceedsFromIssuanceOfCommonStock` |   Proceeds From Issuance Of Common Stock | $10,000.00 |
+| `rs-gaap:StockholdersEquity` | **Stockholders Equity** | $12,050.00 |
+
+```turtle {#ib-equity_statement-rdf}
+@prefix iso4217: <http://www.xbrl.org/2003/iso4217#> .
+@prefix rs: <https://robosystems.ai/vocab/> .
+@prefix rs-gaap: <https://robosystems.ai/taxonomy/rs-gaap/v1/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xbrli: <http://www.xbrl.org/2003/instance#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/fact/fact_01KTDR4JG96ZEXVW49FE91K116> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:NetIncomeLoss ;
+    rs:entity <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/entity/entity_kg19e9b82353aed511343b> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KTDR4JG477A3VNMHZFPE28MS> ;
+    rs:internalId "fact_01KTDR4JG96ZEXVW49FE91K116" ;
+    rs:numericValue 2050.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/period/p_2> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/structure/0b179e5c-5f02-506d-b8d5-860cb10c7694> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/fact/fact_01KTDR4JG96ZEXVW49FE91K119> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:ProceedsFromIssuanceOfCommonStock ;
+    rs:entity <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/entity/entity_kg19e9b82353aed511343b> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KTDR4JG477A3VNMHZFPE28MS> ;
+    rs:internalId "fact_01KTDR4JG96ZEXVW49FE91K119" ;
+    rs:numericValue 10000.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/period/p_2> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/structure/0b179e5c-5f02-506d-b8d5-860cb10c7694> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/fact/fact_01KTDR4JG96ZEXVW49FE91K11G> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:StockholdersEquity ;
+    rs:entity <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/entity/entity_kg19e9b82353aed511343b> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KTDR4JG477A3VNMHZFPE28MS> ;
+    rs:internalId "fact_01KTDR4JG96ZEXVW49FE91K11G" ;
+    rs:numericValue 12050.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/period/p_1> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/structure/0b179e5c-5f02-506d-b8d5-860cb10c7694> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/ib/0b179e5c-5f02-506d-b8d5-860cb10c7694> a rs:InformationBlock ;
+    skos:prefLabel "rs-gaap — Statement of Changes in Equity — Roll Forward (Total)" ;
+    rs:blockType "equity_statement" ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KTDR4JG477A3VNMHZFPE28MS> ;
+    rs:internalId "0b179e5c-5f02-506d-b8d5-860cb10c7694" ;
+    rs:taxonomyId "cf7178a0-e2d4-58df-995a-2f0233d15466" ;
+    rs:taxonomyName "rs-gaap-presentation v1" .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/period/p_1> a rs:Period ;
+    xbrli:instant "2024-03-31"^^xsd:date ;
+    xbrli:periodType "instant" .
+
+rs-gaap:NetIncomeLoss a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "27a05717-2370-51c2-a924-db5cbcb48219" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:ProceedsFromIssuanceOfCommonStock a rs:Element ;
+    xbrli:balance "debit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "2eb72b5f-d7e3-5bd5-bf93-be38b6d21820" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:StockholdersEquity a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "instant" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "e3796201-9899-5b7b-9477-659550ba8e68" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/period/p_2> a rs:Period ;
+    xbrli:endDate "2024-03-31"^^xsd:date ;
+    xbrli:periodType "duration" ;
+    xbrli:startDate "2024-01-01"^^xsd:date .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/entity/entity_kg19e9b82353aed511343b> a rs:Entity ;
+    skos:prefLabel "Lemonade Stand (Charlie Hoffman Test Case 1)" ;
+    rs:country "US" ;
+    rs:internalId "entity_kg19e9b82353aed511343b" ;
+    rs:legalName "Lemonade Stand (Charlie Hoffman Test Case 1)" .
+
+<https://robosystems.ai/report/rpt_01KTDR4JFECMQWRA5ZHNT81XB6/unit/u_USD> a rs:Unit ;
+    xbrli:measure iso4217:USD .
+```
+
+
+## Validation evidence
+
+Independent, standards-grade checks of the same bundle this DataBook renders — embedded so the artifact travels with its own proof.
+
+### Seattle Method (Test Case 1) — SHACL Ontology Conformance
+
+#### Result: ✅ **Conforms to RoboSystems RDF Ontology v1**
+
+- **Bundle**: `seattle-method-case-1.jsonld`
+- **Graph triples**: 2,955
+- **rs:Fact nodes**: 48
+- **rs:Association nodes**: 162
+- **rs:Element nodes**: 93
+- **SHACL shapes checked**: 8 (positive instance shapes + negative shapes banning the retired dialects)
+
+Validated on the host with **pyshacl** against `frameworks/ontology/v1/shapes.ttl` — the *same* shapes that gate the framework seeds and the publish-time bundle validation, run here directly on the on-disk artifact (no API, no database, no container). Conformance means every `rs:Fact` references its aspects directly (`rs:element`/`rs:entity`/`rs:period`/`rs:unit` — no XBRL `context`), every `rs:Association` carries `xlink:from`/`to` + `xlink:arcrole`, and none of the retired dialects (`xbrli:contextRef`, `arcFrom`, direct `summationOf`) appear.
+
+#### Violations
+
+_None._ Zero violations.
+
+### Seattle Method (Test Case 1) — XBRL 2.1 Validation (Arelle)
+
+#### Result: ✅ **Valid XBRL 2.1**
+
+- **Package**: `seattle-method-case-1.zip` (13,503 bytes)
+- **Files in zip**: 5 (`instance.xml, report-cal.xml, report-lab.xml, report-pre.xml, report.xsd`)
+- **Facts loaded by Arelle**: 43
+- **Load errors**: 0
+- **Validation errors**: 0
+
+Validated on the host with **Arelle** (the de-facto XBRL processor, also used by SEC EDGAR) directly against the on-disk report package — no API, no container. Zero load + validation errors is the structural-correctness claim: the output is valid XBRL 2.1, consumable by any standards-compliant processor. This is **base XBRL 2.1** validation; SEC/EFM disclosure-system checks are not enabled (the instance isn't an SEC filing).
+
+#### Errors
+
+_None._ Arelle reported no load errors and no XBRL 2.1 validation errors against the emitted instance + schema + linkbases.

--- a/examples/seattle_method_world_online/main.py
+++ b/examples/seattle_method_world_online/main.py
@@ -449,6 +449,34 @@ def step_validate(graph_id: str, dry_run: bool = False) -> None:
   if result.returncode != 0:
     raise SystemExit(f"validate exited with code {result.returncode}")
 
+  # DataBook: assemble the validated bundle into one self-describing markdown
+  # file (Charlie Hoffman's serialization) — report = collection of Information
+  # Blocks, each a table + an addressable turtle slice, with the SHACL/Arelle
+  # verdicts (just written above) inlined as embedded evidence.
+  databook = subprocess.run(
+    [
+      "uv",
+      "run",
+      "python",
+      "-m",
+      "examples._common.databook",
+      "--jsonld",
+      str(out_dir / "world-online.jsonld"),
+      "--out",
+      str(out_dir / "world-online.databook.md"),
+      "--shacl-md",
+      str(out_dir / "world-online-shacl-validation.md"),
+      "--xbrl-md",
+      str(out_dir / "world-online-xbrl-validation.md"),
+      "--label",
+      "The World Online",
+    ],
+    cwd=str(REPO_ROOT),
+    check=False,
+  )
+  if databook.returncode != 0:
+    raise SystemExit(f"databook exited with code {databook.returncode}")
+
 
 # ── Step registry ──────────────────────────────────────────────────────────
 

--- a/examples/seattle_method_world_online/sample_output/world-online.databook.md
+++ b/examples/seattle_method_world_online/sample_output/world-online.databook.md
@@ -1,0 +1,1309 @@
+---
+id: https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4
+type: DataBook
+title: "The World Online — The World Online (Charlie Hoffman demo)"
+version: 1.0.0
+authors:
+  - name: "RoboSystems Report Engine"
+license: CC-BY-4.0
+description: >
+  Published financial report as a DataBook — the report as a
+  collection of Information Blocks (balance sheet, income
+  statement, cash flow, statement of changes in equity), each a
+  table plus an addressable RDF/Turtle slice, with SHACL + XBRL
+  2.1 validation evidence inlined.
+tags:
+  - financial
+  - reporting
+  - xbrl
+  - rs-gaap
+  - databook
+provenance:
+  source: "The World Online (Charlie Hoffman demo)"
+  method: "Materialized RoboSystems Report rpt_01KSV87YSV6H8A6NSRA5HGPDS4 (generation 1, draft)"
+manifest:
+  entrypoints:
+    - block: balance_sheet
+    - block: income_statement
+    - block: cash_flow_statement
+    - block: equity_statement
+  blocks:
+    balance_sheet:
+      type: turtle
+      description: "rs-gaap — Balance Sheet — Classified"
+    income_statement:
+      type: turtle
+      description: "rs-gaap — Income Statement — Multi-step"
+    cash_flow_statement:
+      type: turtle
+      description: "rs-gaap — Cash Flow Statement — Indirect"
+    equity_statement:
+      type: turtle
+      description: "rs-gaap — Statement of Changes in Equity — Roll Forward (Total)"
+report:
+  reporting_style: 025f5d48-12ce-5d65-b9eb-4f137a10ef06
+  report_id: rpt_01KSV87YSV6H8A6NSRA5HGPDS4
+  generation_count: 1
+  filing_status: draft
+  periods:
+    - { label: "2018-12-31 → 2028-12-31", start: 2018-12-31, end: 2028-12-31 }
+  framework_pins:
+    - { framework: fac-traits, version: v1 }
+    - { framework: fac, version: v1 }
+    - { framework: fac-presentation, version: v1 }
+    - { framework: fac-calculations, version: v1 }
+    - { framework: fac-rules, version: v1 }
+    - { framework: rs-gaap, version: v1 }
+    - { framework: rs-gaap-traits, version: v1 }
+    - { framework: rs-gaap-hierarchy, version: v1 }
+    - { framework: rs-gaap-presentation, version: v1 }
+    - { framework: rs-gaap-calculations, version: v1 }
+    - { framework: rs-gaap-type-subtype, version: v1 }
+    - { framework: rs-gaap-disclosures, version: v1 }
+    - { framework: rs-gaap-disclosure-mechanics, version: v1 }
+    - { framework: rs-gaap-reporting-checklist, version: v1 }
+    - { framework: rs-gaap-reporting-styles, version: v1 }
+    - { framework: rs-gaap-rollup-rules, version: v1 }
+    - { framework: fac-to-rs-gaap, version: v1 }
+    - { framework: rs-gaap-disclosures-to-rs-gaap-textblocks, version: v1 }
+---
+
+# The World Online — The World Online (Charlie Hoffman demo)
+
+A report **is** a collection of Information Blocks. Each block below is shown twice: a markdown table (human view) and an addressable `turtle` block (machine view — the same facts as RDF), keyed by the id declared in the frontmatter `manifest`. Everything is derived from `world-online.jsonld`; the bundle and this DataBook are two skins of one graph.
+
+
+## Balance Sheet
+
+- **Structure**: rs-gaap — Balance Sheet — Classified
+- **Information Block**: `b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d`
+- **FactSet**: `fs_01KSV87Z3AX8S6W5QVAHDW0H06`
+
+| QName | Concept | 2018-12-31 → 2028-12-31 |
+|---|---|---:|
+| `rs-gaap:CashCashEquivalentsAndShortTermInvestments` |     Cash Cash Equivalents And Short Term Investments | $(648,551.94) |
+| `rs-gaap:ReceivablesNetCurrent` |     Receivables Net Current | $2,035,468.27 |
+| `rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings` |     Inventory Net Of Allowances Customer Advances And Progress Billings | $451,842.19 |
+| `rs-gaap:AssetsCurrent` |   **Assets Current** | $1,838,758.52 |
+| `rs-gaap:PropertyPlantAndEquipmentNet` |     Property Plant And Equipment Net | $1,245,567.16 |
+| `rs-gaap:AssetsNoncurrent` |   **Assets Noncurrent** | $1,245,567.16 |
+| `rs-gaap:Assets` | **Assets** | $3,084,325.68 |
+| `rs-gaap:AccountsPayableAndAccruedLiabilitiesCurrent` |       Accounts Payable And Accrued Liabilities Current | $2,689,452.31 |
+| `rs-gaap:LiabilitiesCurrent` |     **Liabilities Current** | $2,689,452.31 |
+| `rs-gaap:LongTermDebtAndCapitalLeaseObligations` |       Long Term Debt And Capital Lease Obligations | $338,349.05 |
+| `rs-gaap:LiabilitiesNoncurrent` |     **Liabilities Noncurrent** | $338,349.05 |
+| `rs-gaap:Liabilities` |   **Liabilities** | $3,027,801.36 |
+| `rs-gaap:AdditionalPaidInCapital` |     Additional Paid In Capital | $1,407,646.64 |
+| `rs-gaap:RetainedEarningsAccumulatedDeficit` |     Retained Earnings Accumulated Deficit | $(1,351,122.32) |
+| `rs-gaap:StockholdersEquity` |   **Stockholders Equity** | $56,524.32 |
+| `rs-gaap:LiabilitiesAndStockholdersEquity` | **Liabilities And Stockholders Equity** | $3,084,325.68 |
+
+```turtle {#balance_sheet}
+@prefix iso4217: <http://www.xbrl.org/2003/iso4217#> .
+@prefix rs: <https://robosystems.ai/vocab/> .
+@prefix rs-gaap: <https://robosystems.ai/taxonomy/rs-gaap/v1/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xbrli: <http://www.xbrl.org/2003/instance#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/fact/fact_01KSV87Z3E68G4DS8XWEDWETA4> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:AccountsPayableAndAccruedLiabilitiesCurrent ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/entity/entity_kg19e75cd88a3785aae2c6> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV87Z3AX8S6W5QVAHDW0H06> ;
+    rs:internalId "fact_01KSV87Z3E68G4DS8XWEDWETA4" ;
+    rs:numericValue 2689452.3100000005 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/period/p_1> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/fact/fact_01KSV87Z3E68G4DS8XWEDWETA5> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:AdditionalPaidInCapital ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/entity/entity_kg19e75cd88a3785aae2c6> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV87Z3AX8S6W5QVAHDW0H06> ;
+    rs:internalId "fact_01KSV87Z3E68G4DS8XWEDWETA5" ;
+    rs:numericValue 1407646.64 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/period/p_1> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/fact/fact_01KSV87Z3E68G4DS8XWEDWETA6> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:CashCashEquivalentsAndShortTermInvestments ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/entity/entity_kg19e75cd88a3785aae2c6> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV87Z3AX8S6W5QVAHDW0H06> ;
+    rs:internalId "fact_01KSV87Z3E68G4DS8XWEDWETA6" ;
+    rs:numericValue -648551.94 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/period/p_1> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/fact/fact_01KSV87Z3E68G4DS8XWEDWETAB> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/entity/entity_kg19e75cd88a3785aae2c6> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV87Z3AX8S6W5QVAHDW0H06> ;
+    rs:internalId "fact_01KSV87Z3E68G4DS8XWEDWETAB" ;
+    rs:numericValue 451842.18999999994 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/period/p_1> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/fact/fact_01KSV87Z3E68G4DS8XWEDWETAC> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:LongTermDebtAndCapitalLeaseObligations ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/entity/entity_kg19e75cd88a3785aae2c6> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV87Z3AX8S6W5QVAHDW0H06> ;
+    rs:internalId "fact_01KSV87Z3E68G4DS8XWEDWETAC" ;
+    rs:numericValue 338349.05 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/period/p_1> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/fact/fact_01KSV87Z3E68G4DS8XWEDWETAD> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:PropertyPlantAndEquipmentNet ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/entity/entity_kg19e75cd88a3785aae2c6> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV87Z3AX8S6W5QVAHDW0H06> ;
+    rs:internalId "fact_01KSV87Z3E68G4DS8XWEDWETAD" ;
+    rs:numericValue 1245567.1600000001 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/period/p_1> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/fact/fact_01KSV87Z3E68G4DS8XWEDWETAE> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:ReceivablesNetCurrent ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/entity/entity_kg19e75cd88a3785aae2c6> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV87Z3AX8S6W5QVAHDW0H06> ;
+    rs:internalId "fact_01KSV87Z3E68G4DS8XWEDWETAE" ;
+    rs:numericValue 2035468.27 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/period/p_1> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/fact/fact_01KSV87Z3E68G4DS8XWEDWETAH> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:RetainedEarningsAccumulatedDeficit ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/entity/entity_kg19e75cd88a3785aae2c6> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV87Z3AX8S6W5QVAHDW0H06> ;
+    rs:internalId "fact_01KSV87Z3E68G4DS8XWEDWETAH" ;
+    rs:numericValue -1351122.3200000003 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/period/p_1> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/fact/fact_01KSV87Z3E68G4DS8XWEDWETAJ> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:AccountsPayableAndAccruedLiabilitiesCurrent ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/entity/entity_kg19e75cd88a3785aae2c6> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV87Z3AX8S6W5QVAHDW0H06> ;
+    rs:internalId "fact_01KSV87Z3E68G4DS8XWEDWETAJ" ;
+    rs:numericValue 1595349.42 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/period/p_3> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/fact/fact_01KSV87Z3E68G4DS8XWEDWETAK> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:AdditionalPaidInCapital ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/entity/entity_kg19e75cd88a3785aae2c6> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV87Z3AX8S6W5QVAHDW0H06> ;
+    rs:internalId "fact_01KSV87Z3E68G4DS8XWEDWETAK" ;
+    rs:numericValue 1407646.64 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/period/p_3> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/fact/fact_01KSV87Z3E68G4DS8XWEDWETAM> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:CashCashEquivalentsAndShortTermInvestments ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/entity/entity_kg19e75cd88a3785aae2c6> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV87Z3AX8S6W5QVAHDW0H06> ;
+    rs:internalId "fact_01KSV87Z3E68G4DS8XWEDWETAM" ;
+    rs:numericValue 398937.76 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/period/p_3> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/fact/fact_01KSV87Z3E68G4DS8XWEDWETAN> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/entity/entity_kg19e75cd88a3785aae2c6> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV87Z3AX8S6W5QVAHDW0H06> ;
+    rs:internalId "fact_01KSV87Z3E68G4DS8XWEDWETAN" ;
+    rs:numericValue 467010.2 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/period/p_3> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/fact/fact_01KSV87Z3E68G4DS8XWEDWETAP> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:LongTermDebtAndCapitalLeaseObligations ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/entity/entity_kg19e75cd88a3785aae2c6> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV87Z3AX8S6W5QVAHDW0H06> ;
+    rs:internalId "fact_01KSV87Z3E68G4DS8XWEDWETAP" ;
+    rs:numericValue 361285.69 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/period/p_3> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/fact/fact_01KSV87Z3E68G4DS8XWEDWETAQ> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:PropertyPlantAndEquipmentNet ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/entity/entity_kg19e75cd88a3785aae2c6> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV87Z3AX8S6W5QVAHDW0H06> ;
+    rs:internalId "fact_01KSV87Z3E68G4DS8XWEDWETAQ" ;
+    rs:numericValue 1266995.3199999998 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/period/p_3> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/fact/fact_01KSV87Z3E68G4DS8XWEDWETAR> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:ReceivablesNetCurrent ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/entity/entity_kg19e75cd88a3785aae2c6> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV87Z3AX8S6W5QVAHDW0H06> ;
+    rs:internalId "fact_01KSV87Z3E68G4DS8XWEDWETAR" ;
+    rs:numericValue 1231338.4700000002 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/period/p_3> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/fact/fact_01KSV87Z3E68G4DS8XWEDWETAS> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:RetainedEarningsAccumulatedDeficit ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/entity/entity_kg19e75cd88a3785aae2c6> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV87Z3AX8S6W5QVAHDW0H06> ;
+    rs:internalId "fact_01KSV87Z3E68G4DS8XWEDWETAS" ;
+    rs:numericValue 0.0 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/period/p_3> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/fact/fact_01KSV87Z3E68G4DS8XWEDWETB1> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:LiabilitiesAndStockholdersEquity ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/entity/entity_kg19e75cd88a3785aae2c6> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV87Z3AX8S6W5QVAHDW0H06> ;
+    rs:internalId "fact_01KSV87Z3E68G4DS8XWEDWETB1" ;
+    rs:numericValue 3084325.6799999997 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/period/p_1> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/fact/fact_01KSV87Z3E68G4DS8XWEDWETB3> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:Assets ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/entity/entity_kg19e75cd88a3785aae2c6> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV87Z3AX8S6W5QVAHDW0H06> ;
+    rs:internalId "fact_01KSV87Z3E68G4DS8XWEDWETB3" ;
+    rs:numericValue 3084325.68 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/period/p_1> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/fact/fact_01KSV87Z3E68G4DS8XWEDWETB5> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:LiabilitiesNoncurrent ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/entity/entity_kg19e75cd88a3785aae2c6> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV87Z3AX8S6W5QVAHDW0H06> ;
+    rs:internalId "fact_01KSV87Z3E68G4DS8XWEDWETB5" ;
+    rs:numericValue 338349.05 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/period/p_1> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/fact/fact_01KSV87Z3E68G4DS8XWEDWETB6> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:AssetsCurrent ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/entity/entity_kg19e75cd88a3785aae2c6> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV87Z3AX8S6W5QVAHDW0H06> ;
+    rs:internalId "fact_01KSV87Z3E68G4DS8XWEDWETB6" ;
+    rs:numericValue 1838758.52 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/period/p_1> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/fact/fact_01KSV87Z3E68G4DS8XWEDWETB8> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:Liabilities ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/entity/entity_kg19e75cd88a3785aae2c6> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV87Z3AX8S6W5QVAHDW0H06> ;
+    rs:internalId "fact_01KSV87Z3E68G4DS8XWEDWETB8" ;
+    rs:numericValue 3027801.3600000003 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/period/p_1> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/fact/fact_01KSV87Z3E68G4DS8XWEDWETBA> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:AssetsNoncurrent ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/entity/entity_kg19e75cd88a3785aae2c6> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV87Z3AX8S6W5QVAHDW0H06> ;
+    rs:internalId "fact_01KSV87Z3E68G4DS8XWEDWETBA" ;
+    rs:numericValue 1245567.1600000001 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/period/p_1> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/fact/fact_01KSV87Z3E68G4DS8XWEDWETBC> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:LiabilitiesCurrent ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/entity/entity_kg19e75cd88a3785aae2c6> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV87Z3AX8S6W5QVAHDW0H06> ;
+    rs:internalId "fact_01KSV87Z3E68G4DS8XWEDWETBC" ;
+    rs:numericValue 2689452.3100000005 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/period/p_1> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/fact/fact_01KSV87Z3E68G4DS8XWEDWETBF> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:StockholdersEquity ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/entity/entity_kg19e75cd88a3785aae2c6> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV87Z3AX8S6W5QVAHDW0H06> ;
+    rs:internalId "fact_01KSV87Z3E68G4DS8XWEDWETBF" ;
+    rs:numericValue 56524.3199999996 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/period/p_1> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/fact/fact_01KSV87Z3E68G4DS8XWEDWETBJ> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:LiabilitiesAndStockholdersEquity ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/entity/entity_kg19e75cd88a3785aae2c6> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV87Z3AX8S6W5QVAHDW0H06> ;
+    rs:internalId "fact_01KSV87Z3E68G4DS8XWEDWETBJ" ;
+    rs:numericValue 3364281.75 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/period/p_3> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/fact/fact_01KSV87Z3E68G4DS8XWEDWETBK> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:Assets ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/entity/entity_kg19e75cd88a3785aae2c6> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV87Z3AX8S6W5QVAHDW0H06> ;
+    rs:internalId "fact_01KSV87Z3E68G4DS8XWEDWETBK" ;
+    rs:numericValue 3364281.75 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/period/p_3> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/fact/fact_01KSV87Z3E68G4DS8XWEDWETBM> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:LiabilitiesNoncurrent ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/entity/entity_kg19e75cd88a3785aae2c6> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV87Z3AX8S6W5QVAHDW0H06> ;
+    rs:internalId "fact_01KSV87Z3E68G4DS8XWEDWETBM" ;
+    rs:numericValue 361285.69 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/period/p_3> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/fact/fact_01KSV87Z3E68G4DS8XWEDWETBN> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:AssetsCurrent ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/entity/entity_kg19e75cd88a3785aae2c6> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV87Z3AX8S6W5QVAHDW0H06> ;
+    rs:internalId "fact_01KSV87Z3E68G4DS8XWEDWETBN" ;
+    rs:numericValue 2097286.43 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/period/p_3> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/fact/fact_01KSV87Z3E68G4DS8XWEDWETBP> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:Liabilities ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/entity/entity_kg19e75cd88a3785aae2c6> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV87Z3AX8S6W5QVAHDW0H06> ;
+    rs:internalId "fact_01KSV87Z3E68G4DS8XWEDWETBP" ;
+    rs:numericValue 1956635.1099999999 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/period/p_3> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/fact/fact_01KSV87Z3E68G4DS8XWEDWETBQ> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:AssetsNoncurrent ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/entity/entity_kg19e75cd88a3785aae2c6> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV87Z3AX8S6W5QVAHDW0H06> ;
+    rs:internalId "fact_01KSV87Z3E68G4DS8XWEDWETBQ" ;
+    rs:numericValue 1266995.3199999998 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/period/p_3> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/fact/fact_01KSV87Z3E68G4DS8XWEDWETBR> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:LiabilitiesCurrent ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/entity/entity_kg19e75cd88a3785aae2c6> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV87Z3AX8S6W5QVAHDW0H06> ;
+    rs:internalId "fact_01KSV87Z3E68G4DS8XWEDWETBR" ;
+    rs:numericValue 1595349.42 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/period/p_3> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/fact/fact_01KSV87Z3E68G4DS8XWEDWETBT> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:StockholdersEquity ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/entity/entity_kg19e75cd88a3785aae2c6> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV87Z3AX8S6W5QVAHDW0H06> ;
+    rs:internalId "fact_01KSV87Z3E68G4DS8XWEDWETBT" ;
+    rs:numericValue 1407646.64 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/period/p_3> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/ib/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> a rs:InformationBlock ;
+    skos:prefLabel "rs-gaap — Balance Sheet — Classified" ;
+    rs:blockType "balance_sheet" ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV87Z3AX8S6W5QVAHDW0H06> ;
+    rs:internalId "b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d" ;
+    rs:taxonomyId "cf7178a0-e2d4-58df-995a-2f0233d15466" ;
+    rs:taxonomyName "rs-gaap-presentation v1" .
+
+rs-gaap:AccountsPayableAndAccruedLiabilitiesCurrent a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "instant" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "7c177cde-7755-53f3-8512-e60b35a5b5c6" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:AdditionalPaidInCapital a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "instant" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "6146605c-0d63-51e1-a523-3450d6abaca3" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:Assets a rs:Element ;
+    xbrli:balance "debit" ;
+    xbrli:periodType "instant" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "a1f04756-41d8-5d35-b821-23aa2f3b2fae" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:AssetsCurrent a rs:Element ;
+    xbrli:balance "debit" ;
+    xbrli:periodType "instant" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "0fc9ab7e-c5ce-5277-9530-344cc127fe26" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:AssetsNoncurrent a rs:Element ;
+    xbrli:balance "debit" ;
+    xbrli:periodType "instant" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "841cedeb-4cb0-532a-b0bd-c34846a13a8c" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:CashCashEquivalentsAndShortTermInvestments a rs:Element ;
+    xbrli:balance "debit" ;
+    xbrli:periodType "instant" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "319dac01-1574-50b7-9124-959febd6c28e" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings a rs:Element ;
+    xbrli:balance "debit" ;
+    xbrli:periodType "instant" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "4afa5950-85ac-5a85-a9cb-01c387c6ab08" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:Liabilities a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "instant" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "7af273ac-1cba-5fb3-a1c9-5c5d8fdb9bdf" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:LiabilitiesAndStockholdersEquity a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "instant" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "30b2801e-e682-5298-82e6-3670e1d508f1" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:LiabilitiesCurrent a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "instant" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "efb036ff-3f30-5deb-bee9-1af4cd4b9800" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:LiabilitiesNoncurrent a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "instant" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "f41fe34d-88ea-5e20-a781-2d3e256a6abf" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:LongTermDebtAndCapitalLeaseObligations a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "instant" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "091373d9-8a82-51bd-adf8-d09b73beb32e" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:PropertyPlantAndEquipmentNet a rs:Element ;
+    xbrli:balance "debit" ;
+    xbrli:periodType "instant" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "288099af-5cbb-5f78-8f8a-1a85675fb661" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:ReceivablesNetCurrent a rs:Element ;
+    xbrli:balance "debit" ;
+    xbrli:periodType "instant" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "44686df3-3871-5c1f-8a08-fc542d69dfa0" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:RetainedEarningsAccumulatedDeficit a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "instant" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "a9c87d60-a1e5-506b-a27e-cbf9e14e5113" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:StockholdersEquity a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "instant" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "e3796201-9899-5b7b-9477-659550ba8e68" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/period/p_1> a rs:Period ;
+    xbrli:instant "2028-12-31"^^xsd:date ;
+    xbrli:periodType "instant" .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/period/p_3> a rs:Period ;
+    xbrli:instant "2023-12-31"^^xsd:date ;
+    xbrli:periodType "instant" .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/entity/entity_kg19e75cd88a3785aae2c6> a rs:Entity ;
+    skos:prefLabel "The World Online (Charlie Hoffman demo)" ;
+    rs:country "US" ;
+    rs:internalId "entity_kg19e75cd88a3785aae2c6" ;
+    rs:legalName "The World Online (Charlie Hoffman demo)" .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/unit/u_USD> a rs:Unit ;
+    xbrli:measure iso4217:USD .
+```
+
+
+## Income Statement
+
+- **Structure**: rs-gaap — Income Statement — Multi-step
+- **Information Block**: `47cd6544-03d1-5bc1-8c28-31c0cfa450f9`
+- **FactSet**: `fs_01KSV87Z3AX8S6W5QVAHDW0H07`
+
+| QName | Concept | 2018-12-31 → 2028-12-31 |
+|---|---|---:|
+| `rs-gaap:Revenues` |   **Revenues** | $2,604,048.36 |
+| `rs-gaap:CostOfGoodsSold` |     Cost Of Goods Sold | $886,041.18 |
+| `rs-gaap:CostOfRevenue` |   **Cost Of Revenue** | $886,041.18 |
+| `rs-gaap:GrossProfit` |   **Gross Profit** | $1,718,007.18 |
+| `rs-gaap:SellingGeneralAndAdministrativeExpense` |     Selling General And Administrative Expense | $3,049,867.27 |
+| `rs-gaap:DepreciationDepletionAndAmortization` |     Depreciation Depletion And Amortization | $21,428.16 |
+| `rs-gaap:OperatingExpenses` |   **Operating Expenses** | $3,071,295.43 |
+| `rs-gaap:OperatingIncomeLoss` |   **Operating Income Loss** | $(1,353,288.25) |
+| `rs-gaap:InterestExpense` |     Interest Expense | $(2,165.93) |
+| `rs-gaap:NonoperatingIncomeExpense` |   **Nonoperating Income Expense** | $2,165.93 |
+| `rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest` |   **Income Loss From Continuing Operations Before Income Taxes Extraordinary Items Noncontrolling Interest** | $(1,351,122.32) |
+| `rs-gaap:IncomeLossFromContinuingOperations` |   **Income Loss From Continuing Operations** | $(1,351,122.32) |
+| `rs-gaap:NetIncomeLoss` |   **Net Income Loss** | $(1,351,122.32) |
+
+```turtle {#income_statement}
+@prefix iso4217: <http://www.xbrl.org/2003/iso4217#> .
+@prefix rs: <https://robosystems.ai/vocab/> .
+@prefix rs-gaap: <https://robosystems.ai/taxonomy/rs-gaap/v1/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xbrli: <http://www.xbrl.org/2003/instance#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/fact/fact_01KSV87Z3E68G4DS8XWEDWETA7> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:CostOfGoodsSold ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/entity/entity_kg19e75cd88a3785aae2c6> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV87Z3AX8S6W5QVAHDW0H07> ;
+    rs:internalId "fact_01KSV87Z3E68G4DS8XWEDWETA7" ;
+    rs:numericValue 886041.1799999999 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/period/p_2> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/fact/fact_01KSV87Z3E68G4DS8XWEDWETA8> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:DepreciationDepletionAndAmortization ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/entity/entity_kg19e75cd88a3785aae2c6> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV87Z3AX8S6W5QVAHDW0H07> ;
+    rs:internalId "fact_01KSV87Z3E68G4DS8XWEDWETA8" ;
+    rs:numericValue 21428.16 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/period/p_2> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/fact/fact_01KSV87Z3E68G4DS8XWEDWETAA> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:InterestExpense ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/entity/entity_kg19e75cd88a3785aae2c6> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV87Z3AX8S6W5QVAHDW0H07> ;
+    rs:internalId "fact_01KSV87Z3E68G4DS8XWEDWETAA" ;
+    rs:numericValue -2165.929999999993 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/period/p_2> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/fact/fact_01KSV87Z3E68G4DS8XWEDWETAF> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:Revenues ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/entity/entity_kg19e75cd88a3785aae2c6> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV87Z3AX8S6W5QVAHDW0H07> ;
+    rs:internalId "fact_01KSV87Z3E68G4DS8XWEDWETAF" ;
+    rs:numericValue 2604048.36 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/period/p_2> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/fact/fact_01KSV87Z3E68G4DS8XWEDWETAG> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:SellingGeneralAndAdministrativeExpense ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/entity/entity_kg19e75cd88a3785aae2c6> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV87Z3AX8S6W5QVAHDW0H07> ;
+    rs:internalId "fact_01KSV87Z3E68G4DS8XWEDWETAG" ;
+    rs:numericValue 3049867.27 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/period/p_2> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/fact/fact_01KSV87Z3E68G4DS8XWEDWETAT> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:NetIncomeLoss ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/entity/entity_kg19e75cd88a3785aae2c6> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV87Z3AX8S6W5QVAHDW0H07> ;
+    rs:internalId "fact_01KSV87Z3E68G4DS8XWEDWETAT" ;
+    rs:numericValue -1351122.3199999998 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/period/p_2> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/fact/fact_01KSV87Z3E68G4DS8XWEDWETB0> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:OperatingExpenses ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/entity/entity_kg19e75cd88a3785aae2c6> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV87Z3AX8S6W5QVAHDW0H07> ;
+    rs:internalId "fact_01KSV87Z3E68G4DS8XWEDWETB0" ;
+    rs:numericValue 3071295.43 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/period/p_2> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/fact/fact_01KSV87Z3E68G4DS8XWEDWETB4> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:OperatingIncomeLoss ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/entity/entity_kg19e75cd88a3785aae2c6> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV87Z3AX8S6W5QVAHDW0H07> ;
+    rs:internalId "fact_01KSV87Z3E68G4DS8XWEDWETB4" ;
+    rs:numericValue -1353288.2500000002 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/period/p_2> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/fact/fact_01KSV87Z3E68G4DS8XWEDWETB7> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:GrossProfit ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/entity/entity_kg19e75cd88a3785aae2c6> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV87Z3AX8S6W5QVAHDW0H07> ;
+    rs:internalId "fact_01KSV87Z3E68G4DS8XWEDWETB7" ;
+    rs:numericValue 1718007.18 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/period/p_2> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/fact/fact_01KSV87Z3E68G4DS8XWEDWETB9> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:CostOfRevenue ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/entity/entity_kg19e75cd88a3785aae2c6> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV87Z3AX8S6W5QVAHDW0H07> ;
+    rs:internalId "fact_01KSV87Z3E68G4DS8XWEDWETB9" ;
+    rs:numericValue 886041.1799999999 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/period/p_2> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/fact/fact_01KSV87Z3E68G4DS8XWEDWETBB> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:NonoperatingIncomeExpense ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/entity/entity_kg19e75cd88a3785aae2c6> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV87Z3AX8S6W5QVAHDW0H07> ;
+    rs:internalId "fact_01KSV87Z3E68G4DS8XWEDWETBB" ;
+    rs:numericValue 2165.929999999993 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/period/p_2> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/fact/fact_01KSV87Z3E68G4DS8XWEDWETBG> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/entity/entity_kg19e75cd88a3785aae2c6> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV87Z3AX8S6W5QVAHDW0H07> ;
+    rs:internalId "fact_01KSV87Z3E68G4DS8XWEDWETBG" ;
+    rs:numericValue -1351122.3200000003 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/period/p_2> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/fact/fact_01KSV87Z3E68G4DS8XWEDWETBH> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:IncomeLossFromContinuingOperations ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/entity/entity_kg19e75cd88a3785aae2c6> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV87Z3AX8S6W5QVAHDW0H07> ;
+    rs:internalId "fact_01KSV87Z3E68G4DS8XWEDWETBH" ;
+    rs:numericValue -1351122.3200000003 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/period/p_2> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/ib/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> a rs:InformationBlock ;
+    skos:prefLabel "rs-gaap — Income Statement — Multi-step" ;
+    rs:blockType "income_statement" ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV87Z3AX8S6W5QVAHDW0H07> ;
+    rs:internalId "47cd6544-03d1-5bc1-8c28-31c0cfa450f9" ;
+    rs:taxonomyId "cf7178a0-e2d4-58df-995a-2f0233d15466" ;
+    rs:taxonomyName "rs-gaap-presentation v1" .
+
+rs-gaap:CostOfGoodsSold a rs:Element ;
+    xbrli:balance "debit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "b9fdd02a-e336-5359-a2eb-303b560094bd" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:CostOfRevenue a rs:Element ;
+    xbrli:balance "debit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "12ab7417-5324-55d6-946e-2456adba47c5" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:DepreciationDepletionAndAmortization a rs:Element ;
+    xbrli:balance "debit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "189a099a-7512-5144-9215-65d837c2c3b5" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:GrossProfit a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "a92b3181-9fe7-543c-81d9-13ebd12bbefa" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:IncomeLossFromContinuingOperations a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "d60cabda-7060-5aff-ac98-96371606a738" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "6b0b414f-0c76-54f0-8e51-cf53db59ca24" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:InterestExpense a rs:Element ;
+    xbrli:balance "debit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "890e4f8c-8fed-57e2-96fd-e70455201b11" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:NetIncomeLoss a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "27a05717-2370-51c2-a924-db5cbcb48219" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:NonoperatingIncomeExpense a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "45aae2c2-fa56-50c9-b381-df8079e7d33a" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:OperatingExpenses a rs:Element ;
+    xbrli:balance "debit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "71fcdebb-7145-5f76-b5e0-b4ccbf2c29d2" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:OperatingIncomeLoss a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "16780828-0201-5609-b572-fbe3ebfcb177" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:Revenues a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "b26a6cd4-072f-5bf2-b5d3-ebf928150d6c" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:SellingGeneralAndAdministrativeExpense a rs:Element ;
+    xbrli:balance "debit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "050fac09-f306-514d-80ef-f0d10ce05de9" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/entity/entity_kg19e75cd88a3785aae2c6> a rs:Entity ;
+    skos:prefLabel "The World Online (Charlie Hoffman demo)" ;
+    rs:country "US" ;
+    rs:internalId "entity_kg19e75cd88a3785aae2c6" ;
+    rs:legalName "The World Online (Charlie Hoffman demo)" .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/period/p_2> a rs:Period ;
+    xbrli:endDate "2028-12-31"^^xsd:date ;
+    xbrli:periodType "duration" ;
+    xbrli:startDate "2024-01-01"^^xsd:date .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/unit/u_USD> a rs:Unit ;
+    xbrli:measure iso4217:USD .
+```
+
+
+## Cash Flow Statement
+
+- **Structure**: rs-gaap — Cash Flow Statement — Indirect
+- **Information Block**: `5473639a-2dac-56a6-b9e5-38480ea38bc1`
+- **FactSet**: `fs_01KSV87Z3AX8S6W5QVAHDW0H08`
+
+| QName | Concept | 2018-12-31 → 2028-12-31 |
+|---|---|---:|
+| `rs-gaap:NetIncomeLoss` |     **Net Income Loss** | $(1,351,122.32) |
+| `rs-gaap:DepreciationDepletionAndAmortization` |     Depreciation Depletion And Amortization | $21,428.16 |
+| `rs-gaap:IncreaseDecreaseInAccountsReceivable` |     Increase Decrease In Accounts Receivable | $(804,129.80) |
+| `rs-gaap:IncreaseDecreaseInInventories` |     Increase Decrease In Inventories | $15,168.01 |
+| `rs-gaap:IncreaseDecreaseInAccountsPayableAndAccruedLiabilities` |     Increase Decrease In Accounts Payable And Accrued Liabilities | $1,094,102.89 |
+| `rs-gaap:NetCashProvidedByUsedInOperatingActivities` |   Net Cash Provided By Used In Operating Activities | $(1,024,553.06) |
+| `rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease` | **Cash And Cash Equivalents Period Increase Decrease** | $(1,024,553.06) |
+
+```turtle {#cash_flow_statement}
+@prefix iso4217: <http://www.xbrl.org/2003/iso4217#> .
+@prefix rs: <https://robosystems.ai/vocab/> .
+@prefix rs-gaap: <https://robosystems.ai/taxonomy/rs-gaap/v1/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xbrli: <http://www.xbrl.org/2003/instance#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/fact/fact_01KSV87Z3E68G4DS8XWEDWETA9> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:DepreciationDepletionAndAmortization ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/entity/entity_kg19e75cd88a3785aae2c6> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV87Z3AX8S6W5QVAHDW0H08> ;
+    rs:internalId "fact_01KSV87Z3E68G4DS8XWEDWETA9" ;
+    rs:numericValue 21428.16 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/period/p_2> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/fact/fact_01KSV87Z3E68G4DS8XWEDWETAW> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:NetIncomeLoss ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/entity/entity_kg19e75cd88a3785aae2c6> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV87Z3AX8S6W5QVAHDW0H08> ;
+    rs:internalId "fact_01KSV87Z3E68G4DS8XWEDWETAW" ;
+    rs:numericValue -1351122.3199999998 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/period/p_2> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/fact/fact_01KSV87Z3E68G4DS8XWEDWETAX> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:IncreaseDecreaseInAccountsPayableAndAccruedLiabilities ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/entity/entity_kg19e75cd88a3785aae2c6> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV87Z3AX8S6W5QVAHDW0H08> ;
+    rs:internalId "fact_01KSV87Z3E68G4DS8XWEDWETAX" ;
+    rs:numericValue 1094102.8900000006 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/period/p_2> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/fact/fact_01KSV87Z3E68G4DS8XWEDWETAY> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:IncreaseDecreaseInAccountsReceivable ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/entity/entity_kg19e75cd88a3785aae2c6> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV87Z3AX8S6W5QVAHDW0H08> ;
+    rs:internalId "fact_01KSV87Z3E68G4DS8XWEDWETAY" ;
+    rs:numericValue -804129.7999999998 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/period/p_2> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/fact/fact_01KSV87Z3E68G4DS8XWEDWETAZ> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:IncreaseDecreaseInInventories ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/entity/entity_kg19e75cd88a3785aae2c6> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV87Z3AX8S6W5QVAHDW0H08> ;
+    rs:internalId "fact_01KSV87Z3E68G4DS8XWEDWETAZ" ;
+    rs:numericValue 15168.010000000068 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/period/p_2> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/fact/fact_01KSV87Z3E68G4DS8XWEDWETB2> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:NetCashProvidedByUsedInOperatingActivities ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/entity/entity_kg19e75cd88a3785aae2c6> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV87Z3AX8S6W5QVAHDW0H08> ;
+    rs:internalId "fact_01KSV87Z3E68G4DS8XWEDWETB2" ;
+    rs:numericValue -1024553.059999999 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/period/p_2> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/fact/fact_01KSV87Z3E68G4DS8XWEDWETBD> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/entity/entity_kg19e75cd88a3785aae2c6> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV87Z3AX8S6W5QVAHDW0H08> ;
+    rs:internalId "fact_01KSV87Z3E68G4DS8XWEDWETBD" ;
+    rs:numericValue -1024553.059999999 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/period/p_2> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/ib/5473639a-2dac-56a6-b9e5-38480ea38bc1> a rs:InformationBlock ;
+    skos:prefLabel "rs-gaap — Cash Flow Statement — Indirect" ;
+    rs:blockType "cash_flow_statement" ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV87Z3AX8S6W5QVAHDW0H08> ;
+    rs:internalId "5473639a-2dac-56a6-b9e5-38480ea38bc1" ;
+    rs:taxonomyId "cf7178a0-e2d4-58df-995a-2f0233d15466" ;
+    rs:taxonomyName "rs-gaap-presentation v1" .
+
+rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease a rs:Element ;
+    xbrli:balance "debit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "353f790f-1ed1-5b91-880d-8029b4b687cf" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:DepreciationDepletionAndAmortization a rs:Element ;
+    xbrli:balance "debit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "189a099a-7512-5144-9215-65d837c2c3b5" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:IncreaseDecreaseInAccountsPayableAndAccruedLiabilities a rs:Element ;
+    xbrli:balance "debit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "dc7408c9-cba5-5697-8254-32ac46485214" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:IncreaseDecreaseInAccountsReceivable a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "93175d59-983c-5012-910f-3dfbf07ce327" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:IncreaseDecreaseInInventories a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "c8b0722b-7993-592f-8ef1-5b0964ac8a10" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:NetCashProvidedByUsedInOperatingActivities a rs:Element ;
+    xbrli:balance "debit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "57ccbf45-c970-5bcd-a381-44d96b6b6d94" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:NetIncomeLoss a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "27a05717-2370-51c2-a924-db5cbcb48219" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/entity/entity_kg19e75cd88a3785aae2c6> a rs:Entity ;
+    skos:prefLabel "The World Online (Charlie Hoffman demo)" ;
+    rs:country "US" ;
+    rs:internalId "entity_kg19e75cd88a3785aae2c6" ;
+    rs:legalName "The World Online (Charlie Hoffman demo)" .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/period/p_2> a rs:Period ;
+    xbrli:endDate "2028-12-31"^^xsd:date ;
+    xbrli:periodType "duration" ;
+    xbrli:startDate "2024-01-01"^^xsd:date .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/unit/u_USD> a rs:Unit ;
+    xbrli:measure iso4217:USD .
+```
+
+
+## Statement of Changes in Equity
+
+- **Structure**: rs-gaap — Statement of Changes in Equity — Roll Forward (Total)
+- **Information Block**: `0b179e5c-5f02-506d-b8d5-860cb10c7694`
+- **FactSet**: `fs_01KSV87Z3AX8S6W5QVAHDW0H09`
+
+| QName | Concept | 2018-12-31 → 2028-12-31 |
+|---|---|---:|
+| `rs-gaap:NetIncomeLoss` |   **Net Income Loss** | $(1,351,122.32) |
+| `rs-gaap:StockholdersEquity` | **Stockholders Equity** | $56,524.32 |
+
+```turtle {#equity_statement}
+@prefix iso4217: <http://www.xbrl.org/2003/iso4217#> .
+@prefix rs: <https://robosystems.ai/vocab/> .
+@prefix rs-gaap: <https://robosystems.ai/taxonomy/rs-gaap/v1/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xbrli: <http://www.xbrl.org/2003/instance#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/fact/fact_01KSV87Z3E68G4DS8XWEDWETAV> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:NetIncomeLoss ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/entity/entity_kg19e75cd88a3785aae2c6> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV87Z3AX8S6W5QVAHDW0H09> ;
+    rs:internalId "fact_01KSV87Z3E68G4DS8XWEDWETAV" ;
+    rs:numericValue -1351122.3199999998 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/period/p_2> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/structure/0b179e5c-5f02-506d-b8d5-860cb10c7694> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/fact/fact_01KSV87Z3E68G4DS8XWEDWETBE> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:StockholdersEquity ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/entity/entity_kg19e75cd88a3785aae2c6> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV87Z3AX8S6W5QVAHDW0H09> ;
+    rs:internalId "fact_01KSV87Z3E68G4DS8XWEDWETBE" ;
+    rs:numericValue 56524.3199999996 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/period/p_1> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/structure/0b179e5c-5f02-506d-b8d5-860cb10c7694> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/fact/fact_01KSV87Z3E68G4DS8XWEDWETBS> a rs:Fact ;
+    rs:decimals "INF" ;
+    rs:element rs-gaap:StockholdersEquity ;
+    rs:entity <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/entity/entity_kg19e75cd88a3785aae2c6> ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV87Z3AX8S6W5QVAHDW0H09> ;
+    rs:internalId "fact_01KSV87Z3E68G4DS8XWEDWETBS" ;
+    rs:numericValue 1407646.64 ;
+    rs:period <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/period/p_3> ;
+    rs:structure <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/structure/0b179e5c-5f02-506d-b8d5-860cb10c7694> ;
+    rs:unit <https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/unit/u_USD> .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/ib/0b179e5c-5f02-506d-b8d5-860cb10c7694> a rs:InformationBlock ;
+    skos:prefLabel "rs-gaap — Statement of Changes in Equity — Roll Forward (Total)" ;
+    rs:blockType "equity_statement" ;
+    rs:factSet <https://robosystems.ai/factset/fs_01KSV87Z3AX8S6W5QVAHDW0H09> ;
+    rs:internalId "0b179e5c-5f02-506d-b8d5-860cb10c7694" ;
+    rs:taxonomyId "cf7178a0-e2d4-58df-995a-2f0233d15466" ;
+    rs:taxonomyName "rs-gaap-presentation v1" .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/period/p_1> a rs:Period ;
+    xbrli:instant "2028-12-31"^^xsd:date ;
+    xbrli:periodType "instant" .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/period/p_2> a rs:Period ;
+    xbrli:endDate "2028-12-31"^^xsd:date ;
+    xbrli:periodType "duration" ;
+    xbrli:startDate "2024-01-01"^^xsd:date .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/period/p_3> a rs:Period ;
+    xbrli:instant "2023-12-31"^^xsd:date ;
+    xbrli:periodType "instant" .
+
+rs-gaap:NetIncomeLoss a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "duration" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "27a05717-2370-51c2-a924-db5cbcb48219" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+rs-gaap:StockholdersEquity a rs:Element ;
+    xbrli:balance "credit" ;
+    xbrli:periodType "instant" ;
+    rs:abstract false ;
+    rs:elementType "concept" ;
+    rs:internalId "e3796201-9899-5b7b-9477-659550ba8e68" ;
+    rs:monetary true ;
+    rs:source "rs-gaap" ;
+    rs:substitutionGroup xbrli:item .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/entity/entity_kg19e75cd88a3785aae2c6> a rs:Entity ;
+    skos:prefLabel "The World Online (Charlie Hoffman demo)" ;
+    rs:country "US" ;
+    rs:internalId "entity_kg19e75cd88a3785aae2c6" ;
+    rs:legalName "The World Online (Charlie Hoffman demo)" .
+
+<https://robosystems.ai/report/rpt_01KSV87YSV6H8A6NSRA5HGPDS4/unit/u_USD> a rs:Unit ;
+    xbrli:measure iso4217:USD .
+```
+
+
+## Validation evidence
+
+Independent, standards-grade checks of the same bundle this DataBook renders — embedded so the artifact travels with its own proof.
+
+### The World Online — SHACL Ontology Conformance
+
+#### Result: ✅ **Conforms to RoboSystems RDF Ontology v1**
+
+- **Bundle**: `world-online.jsonld`
+- **Graph triples**: 2,885
+- **rs:Fact nodes**: 55
+- **rs:Association nodes**: 150
+- **rs:Element nodes**: 87
+- **SHACL shapes checked**: 8 (positive instance shapes + negative shapes banning the retired dialects)
+
+Validated on the host with **pyshacl** against `frameworks/ontology/v1/shapes.ttl` — the *same* shapes that gate the framework seeds and the publish-time bundle validation, run here directly on the on-disk artifact (no API, no database, no container). Conformance means every `rs:Fact` references its aspects directly (`rs:element`/`rs:entity`/`rs:period`/`rs:unit` — no XBRL `context`), every `rs:Association` carries `xlink:from`/`to` + `xlink:arcrole`, and none of the retired dialects (`xbrli:contextRef`, `arcFrom`, direct `summationOf`) appear.
+
+#### Violations
+
+_None._ Zero violations.
+
+### The World Online — XBRL 2.1 Validation (Arelle)
+
+#### Result: ✅ **Valid XBRL 2.1**
+
+- **Package**: `world-online.zip` (12,728 bytes)
+- **Files in zip**: 5 (`instance.xml, report-cal.xml, report-lab.xml, report-pre.xml, report.xsd`)
+- **Facts loaded by Arelle**: 50
+- **Load errors**: 0
+- **Validation errors**: 0
+
+Validated on the host with **Arelle** (the de-facto XBRL processor, also used by SEC EDGAR) directly against the on-disk report package — no API, no container. Zero load + validation errors is the structural-correctness claim: the output is valid XBRL 2.1, consumable by any standards-compliant processor. This is **base XBRL 2.1** validation; SEC/EFM disclosure-system checks are not enabled (the instance isn't an SEC filing).
+
+#### Errors
+
+_None._ Arelle reported no load errors and no XBRL 2.1 validation errors against the emitted instance + schema + linkbases.


### PR DESCRIPTION
## Summary

Adds a **DataBook** serialization for published report bundles — one self-describing markdown file that presents a report as a collection of Information Blocks (Charlie Hoffman / Kurt Cagle's DataBook pattern). It's a demo-layer (`examples/`) artifact writer: it reads the on-disk `.jsonld` bundle and emits a `.databook.md` with no API, DB, or container — the same container-free design as `examples/_common/validate.py`. This is the publication/transport skin for a report; it does not change the backend serialization kernel.

## Changes

**New writer — `examples/_common/databook.py`**
- Parses a published report's JSON-LD bundle and renders, per Information Block: a hierarchy-ordered markdown table (human view) + an addressable ` ```turtle {#block_type} ` slice (machine view, qnames compacted to `rs-gaap:Assets`).
- Tables are reconstructed from the bundle's presentation arcs with **post-order** traversal (components first, totals last — the financial-statement convention) and the two balance-sheet roots ordered by subtree arc order.
- Subtotals are bolded from the **calculation** tree, so presentation-leaf subtotals (Gross Profit, Net Income) are marked correctly.
- Frontmatter matches Charlie's published canonical envelope from `seattlemethod/prototypes` `md-examples/` (and the key order Kurt's `databook` CLI enforces): `type: DataBook`, `title`, `version` (semver), `created`/`modified`, `authors`, `license`, `description`, `tags`, `provenance{source, method}`, `manifest{entrypoints, blocks}` keyed by `block_type`. RoboSystems-specific metadata (reporting style, report id, periods, framework pins) lives in a `report` extension after the canonical keys.
- Self-contained: optional `--shacl-md` / `--xbrl-md` inline the SHACL + Arelle verdict reports as embedded evidence.
- Graceful CamelCase fallback for older bundles that predate `skos:prefLabel` emit; Unicode (em-dash, arrows) preserved in YAML.
- Importable `write_databook(...)` plus a standalone CLI.

**Demo wiring**
- `examples/roboledger_demo/download_bundles.py` — emits the DataBook after the SHACL/Arelle validation step (verdicts inlined).
- `examples/seattle_method_demo/main.py` — emits the DataBook in `step_validate` (after the verdict files are written).

**Reference artifacts**
- `roboledger-demo.databook.md` and `seattle-method-case-1.databook.md` committed under each demo's `sample_output/`, generated from the committed reference bundles.

## Testing

- `just test-code` (ruff + format + basedpyright + cf-lint) — **passed** (0 errors).
- Generated both DataBooks from the committed `sample_output/` bundles; verified output is valid YAML, `type: DataBook`, canonical frontmatter key order, and `manifest.blocks` keyed by `block_type`.
- `just test` (unit suite) — **not run** this session (examples-only change; no production code or tests touched).

## Notes / Follow-ups

- Scope is `examples/` only — no backend, SDK, or API changes.
- The committed `sample_output/` bundles predate element-label emit, so the reference DataBooks show the humanized CamelCase fallback rather than curated labels; a fresh `just demo-*` run produces curated labels (the current pipeline's `output/` bundle is fully labeled). A `sample_output/` refresh is a separate follow-up (needs the stack up).
- Not yet validated against Kurt Cagle's actual `databook` CLI (verified the spec/shape by hand); a live `databook head` round-trip check is worth doing before relying on tool interop.
- Deferred: promote to a first-class `databook` download flavor in the serialization kernel (`download_report_bundle(format="databook")`) so it's available to SDK/clients, not just demos.
