### PR TITLE
chore(docs): repo-wide README accuracy alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,6 @@
 # RoboSystems
 
-RoboSystems is an open-source financial intelligence platform built on a unified operational and analytical graph architecture — a transactional Postgres backbone for ledger-grade correctness paired with an analytical LadybugDB graph for AI retrieval and reporting. Purpose-built for accounting, financial reporting, investment management, and analysis. Powers [RoboLedger](https://roboledger.ai) and [RoboInvestor](https://roboinvestor.ai).
-
-- **Unified Operational + Analytical Graph**: Graph workloads split the same way relational workloads do — transactional stores for writes, analytical stores for queries. Extension schemas drive both a Postgres operational backbone for ledger-grade correctness and a LadybugDB analytical graph for relationship traversal and AI retrieval, bound by a shared schema and Cypher query surface
-- **LadybugDB Graph Database**: Embedded columnar graph database with native DuckDB staging, LanceDB vector search, and tiered infrastructure
-- **Extensions**: Domain schemas that drive OLTP tables, data pipelines, and dedicated frontend apps, all surfaced through the Extensions API. Schema-per-tenant isolation in a single Postgres database; materialized to the graph for analytics
-- **Document Search**: Full-text and semantic search across SEC filings, uploaded documents, and connected sources via OpenSearch
-- **AI-Native Architecture**: Context graphs with embeddings, semantic enrichment, and confidence scoring for LLM-powered analytics
-- **Model Context Protocol (MCP)**: Standardized server and [client](https://www.npmjs.com/package/@robosystems/mcp) for LLM integration with schema-aware tools
-- **Multi-Source Data Integration**: SEC XBRL filings, QuickBooks accounting data via dbt pipelines, and custom financial datasets
-- **Enterprise-Ready Infrastructure**: Multi-tenant architecture with tiered scaling and production-grade query management
-- **Core REST API** (`/v1`): Auth, orgs, billing, graph lifecycle, Cypher, and MCP. Reads as REST GETs; graph lifecycle writes (subgraphs, backups, materialize, tier changes) as named `OperationEnvelope` operations
-- **Extensions API** (`/extensions/{graph_id}`): Strawberry GraphQL for typed reads over extensions OLTP, plus named REST operations for domain writes and analytical views over the materialized graph
-- **Unified Write Contract**: Every write across both surfaces is a named `OperationEnvelope` operation with `Idempotency-Key` support, audit logging, and SSE progress streaming via `/v1/operations/{id}/stream`
+RoboSystems is an open-source, AI-native financial intelligence platform for accounting, financial reporting, and investment management. It gives AI agents and analysts a ledger-grade system of record they can both query and operate — closing the books, producing reports, and analyzing portfolios across accounting, market, and SEC data. Powers [RoboLedger](https://roboledger.ai) and [RoboInvestor](https://roboinvestor.ai).
 
 ## Platform
 
@@ -29,16 +17,16 @@ The platform provides the core infrastructure that all extensions build on:
 
 ## Extensions
 
-Extensions are domain-specific subsystems that bring their own schema, OLTP tables, API routes, data pipelines, and dedicated frontend apps. They share a single PostgreSQL database with schema-per-tenant isolation and materialize to the graph for analytical queries. See [Schema Extensions](/robosystems/schemas/README.md) for the authoring contract.
+Extensions are domain-specific subsystems that bring their own schema, OLTP tables, API routes, data pipelines, and dedicated frontend apps. They share a single PostgreSQL database with schema-per-tenant isolation and materialize to the graph for analytical queries.
+
+The **core platform API** lives at `/v1` — auth, orgs, billing, graph lifecycle (subgraphs, backups, materialize, tier changes), Cypher, and MCP — with reads as REST `GET`s. Every write, across both the core and extensions surfaces, is a named **`OperationEnvelope`** operation with `Idempotency-Key` support, audit logging, and SSE progress streaming via `/v1/operations/{id}/stream`.
 
 The extensions API surface is **graph-scoped at the URL level** — `graph_id` is always a path parameter, never a query argument — and splits reads from writes by transport:
 
 - **Reads** → `POST /extensions/{graph_id}/graphql` — Strawberry GraphQL, GraphiQL in dev, schema composed dynamically from enabled domains
-- **Writes** → `POST /extensions/{roboledger|roboinvestor}/{graph_id}/operations/{operation_name}` — named REST commands (see Unified Write Contract above)
+- **Writes** → `POST /extensions/{roboledger|roboinvestor}/{graph_id}/operations/{operation_name}` — named REST commands
 
 Behind the API is a CQRS operations kernel (`reads/` + `commands/` per domain) that's the single source of truth for business logic — GraphQL resolvers, REST operation routes, and MCP tools all delegate to the same functions. Per-domain feature flags (`ROBOLEDGER_ENABLED`, `ROBOINVESTOR_ENABLED`) gate both the routers and the GraphQL schema composition.
-
-See [GraphQL Extensions](/robosystems/graphql/README.md) for the read-path implementation details, the Strawberry-Pydantic auto-derivation pattern, and the walkthrough for adding a new read field.
 
 ### [RoboLedger](https://roboledger.ai)
 
@@ -47,6 +35,28 @@ Accounting and financial reporting extension. OLTP general ledger in schema-per-
 ### [RoboInvestor](https://roboinvestor.ai)
 
 Portfolio management and investment tracking extension. OLTP database with portfolios, securities, and positions in schema-per-tenant PostgreSQL; 7 GraphQL read fields (portfolios, securities, positions, holdings) and 6 named command operations for portfolio-block CRUD and security CRUD. Securities can link to entities for cross-graph research between investor portfolios and SEC public-company data via the shared repository. Dedicated frontend app.
+
+## AI
+
+### Model Context Protocol (MCP)
+
+- **Financial Analysis**: Natural language queries across enterprise data and public benchmark data
+- **Cross-Database Queries**: Compare user graph data against SEC shared repository data
+- **Tools**: Rich toolkit for graph queries, schema introspection, fact discovery, financial analysis, document search, and AI memory operations
+- **Handler Pool**: Managed MCP handler instances with resource limits
+
+### AI Operator System
+
+- Unified architecture: stateless Operators (Claude/MCP executors) with protocol-based service injection
+- Dual execution: API (sync/SSE) and background worker (Valkey queue + SSE progress)
+- Automatic credit tracking per AI call — Operators cannot forget billing
+- Extensible: add new Operators for new AI workflows; they inherit execution, credit tracking, and progress streaming automatically
+
+### Credit System
+
+- **AI Operations Only**: Credits are consumed exclusively by AI Operator calls (Anthropic Claude via AWS Bedrock)
+- **Token-Based Billing**: Credits based on actual token usage and model cost
+- **MCP Tool Access**: No credits consumed for MCP calls or database operations
 
 ## Quick Start
 
@@ -152,7 +162,7 @@ See the **[Bootstrap Guide](https://github.com/RoboFinSystems/robosystems/wiki/B
 
 ## Architecture
 
-RoboSystems is built on a modern, scalable architecture with:
+Built end-to-end on open-source engines — PostgreSQL, a columnar graph database, DuckDB, LanceDB, OpenSearch, and Valkey — assembled into a transactional core with a materialized analytical graph and integrated vector search, with no proprietary database lock-in. The components:
 
 **Application Layer:**
 
@@ -162,7 +172,7 @@ RoboSystems is built on a modern, scalable architecture with:
 - AI Operator System for autonomous financial operations with automatic credit tracking
 - Dagster for data pipeline orchestration and background jobs
 
-**LadybugDB Graph Database:** ([configuration](/.github/configs/graph.yml))
+**LadybugDB Graph Database:**
 
 - Embedded columnar graph database purpose-built for financial analytics
 - Base + extension schema architecture — extensions define domain models
@@ -173,22 +183,17 @@ RoboSystems is built on a modern, scalable architecture with:
 
 **Data Layer:**
 
-- PostgreSQL for IAM, graph metadata, Dagster, and extension OLTP databases (schema-per-tenant)
+- PostgreSQL (RDS) for IAM, graph metadata, Dagster, and extension OLTP databases (schema-per-tenant)
 - OpenSearch for full-text and semantic document search (BM25 + KNN)
-- Valkey for caching, SSE messaging, and rate limiting
-- AWS S3 for data lake storage and static assets
+- Valkey (ElastiCache) for caching, SSE messaging, and rate limiting
+- S3 for data lake storage and static assets
 - DynamoDB for instance/graph/volume registry
 
 **Infrastructure:**
 
+- CloudFormation deployed via GitHub Actions with OIDC
 - ECS Fargate for API and Dagster
-- EC2 ASG for LadybugDB writer clusters
-- EC2 ALB + ASG for LadybugDB shared replica clusters
-- RDS PostgreSQL + ElastiCache Valkey
-- OpenSearch for full-text and semantic document search
-- CloudFormation infrastructure deployed via GitHub Actions with OIDC
-
-**For detailed architecture documentation, see the [Architecture Overview](https://github.com/RoboFinSystems/robosystems/wiki/Architecture-Overview) in the Wiki.**
+- EC2 (ASG) for LadybugDB writer clusters; EC2 (ALB + ASG) for shared replica clusters
 
 ## SEC Shared Repository
 
@@ -205,29 +210,6 @@ just sec-health          # Check SEC database health
 ```
 
 See [SEC Adapter](/robosystems/adapters/sec/README.md) and [SEC Pipeline](/robosystems/adapters/sec/pipeline/README.md) for detailed documentation.
-
-## AI
-
-### Model Context Protocol (MCP)
-
-- **Financial Analysis**: Natural language queries across enterprise data and public benchmark data
-- **Cross-Database Queries**: Compare user graph data against SEC shared repository data
-- **Tools**: Rich toolkit for graph queries, schema introspection, fact discovery, financial analysis, document search, and AI memory operations
-- **Handler Pool**: Managed MCP handler instances with resource limits
-
-### AI Operator System
-
-- Unified architecture: stateless Operators (Claude/MCP executors) with protocol-based service injection
-- Dual execution: API (sync/SSE) and background worker (Valkey queue + SSE progress)
-- Automatic credit tracking per AI call — Operators cannot forget billing
-- Extensible: new Operators implement `run(ctx)` and register with a decorator
-- See [Operator README](/robosystems/operations/operators/README.md) for details
-
-### Credit System
-
-- **AI Operations Only**: Credits are consumed exclusively by AI Operator calls (Anthropic Claude via AWS Bedrock)
-- **Token-Based Billing**: Credits based on actual token usage and model cost
-- **MCP Tool Access**: No credits consumed for MCP calls or database operations
 
 ## Client Libraries
 
@@ -271,14 +253,31 @@ pip install robosystems-client
 
 ## Documentation
 
-### User Guides (Wiki)
+### Documentation (Wiki)
 
-- **[Getting Started](https://github.com/RoboFinSystems/robosystems/wiki)** - Quick start and overview
-- **[Bootstrap Guide](https://github.com/RoboFinSystems/robosystems/wiki/Bootstrap-Guide)** - Fork and deploy to your AWS account
-- **[Architecture Overview](https://github.com/RoboFinSystems/robosystems/wiki/Architecture-Overview)** - System design and components
-- **[Data Pipeline Guide](https://github.com/RoboFinSystems/robosystems/wiki/Pipeline-Guide)** - Dagster data orchestration and custom integrations
-- **[SEC XBRL Pipeline](https://github.com/RoboFinSystems/robosystems/wiki/SEC-XBRL-Pipeline)** - Working with SEC financial data
-- **[Custom Graph Demo](https://github.com/RoboFinSystems/robosystems/wiki/Custom-Graph-Schema)** - Guide for creating a custom schema graph demo
+**Getting Started & Platform:**
+
+- [Home / Overview](https://github.com/RoboFinSystems/robosystems/wiki) · [Quick Start](https://github.com/RoboFinSystems/robosystems/wiki/Quick-Start) · [Core Concepts](https://github.com/RoboFinSystems/robosystems/wiki/Core-Concepts) · [Architecture Overview](https://github.com/RoboFinSystems/robosystems/wiki/Architecture-Overview) · [Bootstrap Guide](https://github.com/RoboFinSystems/robosystems/wiki/Bootstrap-Guide)
+
+**Operations Layer:**
+
+- [Graphs & Multi-Tenancy](https://github.com/RoboFinSystems/robosystems/wiki/Graphs-and-Multi-Tenancy) · [Authentication & API Keys](https://github.com/RoboFinSystems/robosystems/wiki/Authentication-and-API-Keys) · [Querying the Analytical Graph](https://github.com/RoboFinSystems/robosystems/wiki/Querying-the-Analytical-Graph) · [Graph Operations](https://github.com/RoboFinSystems/robosystems/wiki/Graph-Operations) · [AI Operators & MCP](https://github.com/RoboFinSystems/robosystems/wiki/AI-Operators-and-MCP) · [Shared Repositories](https://github.com/RoboFinSystems/robosystems/wiki/Shared-Repositories) · [Credits & Billing](https://github.com/RoboFinSystems/robosystems/wiki/Credits-and-Billing) · [Pipeline Guide](https://github.com/RoboFinSystems/robosystems/wiki/Pipeline-Guide)
+
+**Extensions Layer:**
+
+- [Extensions Surface Overview](https://github.com/RoboFinSystems/robosystems/wiki/Extensions-Surface-Overview) · [GraphQL Reads](https://github.com/RoboFinSystems/robosystems/wiki/GraphQL-Reads) · [RoboLedger Operations](https://github.com/RoboFinSystems/robosystems/wiki/RoboLedger-Operations) · [RoboInvestor Operations](https://github.com/RoboFinSystems/robosystems/wiki/RoboInvestor-Operations) · [Connecting QuickBooks Locally](https://github.com/RoboFinSystems/robosystems/wiki/Connecting-QuickBooks-Locally)
+
+**Content & Contribution Fabric:**
+
+- [Information Blocks](https://github.com/RoboFinSystems/robosystems/wiki/Information-Blocks) · [Taxonomy & Frameworks](https://github.com/RoboFinSystems/robosystems/wiki/Taxonomy-and-Frameworks) · [Event-Driven Ledger](https://github.com/RoboFinSystems/robosystems/wiki/Event-Driven-Ledger) · [Reporting & Rendering](https://github.com/RoboFinSystems/robosystems/wiki/Reporting-and-Rendering) · [Serialization & Export](https://github.com/RoboFinSystems/robosystems/wiki/Serialization-and-Export)
+
+**Documents & Search:**
+
+- [Search & AI Retrieval](https://github.com/RoboFinSystems/robosystems/wiki/Search-and-AI-Retrieval) · [Document Management](https://github.com/RoboFinSystems/robosystems/wiki/Document-Management) · [File Uploads](https://github.com/RoboFinSystems/robosystems/wiki/File-Uploads)
+
+**Demos:**
+
+- [RoboLedger Demo Walkthrough](https://github.com/RoboFinSystems/robosystems/wiki/RoboLedger-Demo-Walkthrough) · [SEC XBRL Pipeline](https://github.com/RoboFinSystems/robosystems/wiki/SEC-XBRL-Pipeline) · [Custom Graph Schema](https://github.com/RoboFinSystems/robosystems/wiki/Custom-Graph-Schema)
 
 ### Developer Documentation (Codebase)
 
@@ -286,6 +285,7 @@ pip install robosystems-client
 
 - **[Adapters](/robosystems/adapters/README.md)** - External service integrations
 - **[Operations](/robosystems/operations/README.md)** - Business workflow orchestration, CQRS reads/commands kernels for extensions
+- **[AI Operators](/robosystems/operations/operators/README.md)** - AI Operator framework: Claude/MCP executors, credit tracking, SSE streaming
 - **[Schemas](/robosystems/schemas/README.md)** - Graph schema definitions
 - **[Extensions GraphQL](/robosystems/graphql/README.md)** - Strawberry GraphQL read surface, Pydantic auto-derivation, resolver patterns
 - **[Configuration](/robosystems/config/README.md)** - Configuration management

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,7 +10,7 @@ Security controls implemented at the infrastructure, application, and data level
 
 - 30-minute access token expiration (configurable via `JWT_EXPIRY_HOURS`)
 - JTI-based token revocation tracked in Valkey with TTL
-- Automatic token refresh at `/auth/refresh` with 5-second grace period for in-flight requests
+- Automatic token refresh at `/v1/auth/refresh` with 5-second grace period for in-flight requests
 - Issuer and audience claim validation
 - Fails closed on Valkey errors (treats token as revoked)
 

--- a/bin/setup/README.md
+++ b/bin/setup/README.md
@@ -181,7 +181,7 @@ just setup-aws
 | ---------- | ------------------------------- | ------------------------------ |
 | Secret     | `robosystems/prod`              | Production credentials         |
 | Secret     | `robosystems/staging`           | Staging credentials (optional) |
-| SSM Params | `/robosystems/{env}/features/*` | Feature flags (26 params)      |
+| SSM Params | `/robosystems/{env}/features/*` | Feature flags (27 params)      |
 | SSM Params | `/robosystems/{env}/tuning/*`   | Tuning parameters (33 params)  |
 
 **Secrets Manager** (credentials only):
@@ -195,7 +195,6 @@ just setup-aws
   "GRAPH_BACKUP_ENCRYPTION_KEY": "[generated]",
   "INTUIT_CLIENT_ID": "...",
   "INTUIT_CLIENT_SECRET": "...",
-  "PLAID_CLIENT_ID": "...",
   "STRIPE_SECRET_KEY": "...",
   "SEC_GOV_USER_AGENT": "...",
   "TURNSTILE_SECRET_KEY": "..."
@@ -328,7 +327,7 @@ just setup-gha
 | `RDS_PROXY_MAX_CONNECTIONS_PERCENT_*`   | `100`          | Max % of DB max_connections proxy may use    |
 | `RDS_PROXY_CONNECTION_BORROW_TIMEOUT_*` | `120`          | Seconds client waits for a pooled connection |
 
-#### Valkey (Redis) Configuration
+#### Valkey Configuration
 
 | Variable                           | Prod Default              | Description        |
 | ---------------------------------- | ------------------------- | ------------------ |

--- a/cloudformation/README.md
+++ b/cloudformation/README.md
@@ -13,6 +13,7 @@ Infrastructure as Code for deploying RoboSystems to AWS. All templates are deplo
 | `s3.yaml` | Object storage | None | Variable |
 | `api.yaml` | ECS API service | VPC, others | ~$20-50 (Fargate Spot) |
 | `dagster.yaml` | Workflow orchestration | VPC, others | ~$15-30 (Fargate) |
+| `worker.yaml` | Background task worker | VPC, Dagster | ~$10-20 (Fargate) |
 | `bastion.yaml` | Secure SSH access | VPC | Free (SSM only) |
 | `graph-infra.yaml` | Graph DB registries | None | ~$3 (DynamoDB) |
 | `graph-volumes.yaml` | EBS management | VPC, graph-infra | ~$1 (Lambda) |
@@ -63,6 +64,7 @@ Templates have cross-stack dependencies that determine deployment order:
 ├─────────────────────────────────────────────────────────────────────────────┤
 │  api.yaml ◄─────────── ECS Fargate API (depends on VPC, uses SSM params)   │
 │  dagster.yaml ◄──────── Dagster orchestration (depends on VPC)             │
+│  worker.yaml ◄───────── Background task worker (depends on VPC, Dagster)   │
 │  bastion.yaml ◄──────── SSM bastion host (depends on VPC)                  │
 │  graph-ladybug.yaml ◄── LadybugDB writers (depends on VPC, S3, Valkey,     │
 │                         graph-infra, uses SSM params from graph-volumes)   │
@@ -160,11 +162,12 @@ Templates have cross-stack dependencies that determine deployment order:
 | Parameter | Default | Description |
 |-----------|---------|-------------|
 | `Environment` | `prod` | Environment name |
-| `DatabaseInstanceClass` | `db.t4g.micro` | RDS instance type |
-| `AllocatedStorage` | `20` | Storage in GB |
-| `MultiAZ` | `false` | Enable Multi-AZ |
-| `MasterUsername` | `postgres` | Master username |
-| `VpcStackName` | Required | VPC stack name |
+| `DBInstanceClass` | `db.t4g.micro` | RDS instance type |
+| `DBAllocatedStorage` | `20` | Initial storage in GB |
+| `DBMaxAllocatedStorage` | — | Max autoscale storage in GB |
+| `EnableMultiAZ` | `false` | Enable Multi-AZ |
+| `DBUsername` | `postgres` | Master username |
+| `VpcId` | Required | VPC ID |
 
 **Exports**:
 - `{StackName}-DatabaseEndpoint` - RDS endpoint
@@ -179,16 +182,18 @@ Templates have cross-stack dependencies that determine deployment order:
 **Dependencies**: VPC stack
 
 **Key Resources**:
-- `AWS::ElastiCache::ServerlessCache` - Valkey serverless cluster
+- `AWS::ElastiCache::ReplicationGroup` - Valkey cluster (`Engine: valkey`)
 - `AWS::EC2::SecurityGroup` - Cache access security group
 
 **Parameters**:
 | Parameter | Default | Description |
 |-----------|---------|-------------|
 | `Environment` | `prod` | Environment name |
-| `MaximumDataStorage` | `1` | Max storage in GB |
-| `MaximumECPU` | `1000` | Max ECPUs per second |
-| `VpcStackName` | Required | VPC stack name |
+| `NodeType` | `cache.t4g.micro` | ElastiCache node type |
+| `NumCacheNodes` | `1` | Number of cache nodes |
+| `ValkeyEngineVersion` | `8.1` | Valkey engine version |
+| `EnableEncryption` | `true` | Enable encryption in transit/at rest |
+| `VpcId` | Required | VPC ID |
 
 **Exports**:
 - `{StackName}-ValkeyEndpoint` - Valkey endpoint
@@ -270,11 +275,12 @@ Templates have cross-stack dependencies that determine deployment order:
 | Parameter | Default | Description |
 |-----------|---------|-------------|
 | `Environment` | `prod` | Environment name |
-| `ImageTag` | `latest` | Container image tag |
-| `DesiredCount` | `1` | Number of tasks |
-| `CPU` | `256` | Task CPU units |
-| `Memory` | `512` | Task memory (MB) |
-| `VpcStackName` | Required | VPC stack name |
+| `ECRImageTag` | `latest` | Container image tag |
+| `MinCapacity` | `1` | Minimum tasks |
+| `MaxCapacity` | `10` | Maximum tasks |
+| `Cpu` | `512` | Task CPU units |
+| `Memory` | `1024` | Task memory (MB) |
+| `VpcId` | Required | VPC ID |
 
 **Exports**:
 - `{StackName}-ClusterArn` - ECS cluster ARN
@@ -309,6 +315,30 @@ Templates have cross-stack dependencies that determine deployment order:
 - `{StackName}-ClusterArn` - ECS cluster ARN
 - `{StackName}-WebserverServiceArn` - Webserver service ARN
 - `{StackName}-DaemonServiceArn` - Daemon service ARN
+
+---
+
+#### `worker.yaml`
+**Purpose**: Background task worker service on ECS Fargate. Runs the queue consumer for asynchronous work, with optional queue-depth-based autoscaling.
+
+**Dependencies**: VPC, Dagster (reuses the Dagster ECS cluster and VPC-internal security group), PostgreSQL/Valkey (via SSM parameters)
+
+**Key Resources**:
+- `AWS::ECS::Service` - Fargate worker service (on the Dagster cluster)
+- `AWS::ECS::TaskDefinition` - Worker container definition
+- `AWS::ApplicationAutoScaling::ScalableTarget` - Queue-depth autoscaling target
+- `AWS::Logs::LogGroup` - CloudWatch logs
+
+**Parameters**:
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `Environment` | `prod` | Environment name |
+| `ImageTag` | `latest` | Container image tag |
+| `WorkerCpu` | `512` | Task CPU units |
+| `WorkerMemory` | `1024` | Task memory (MB) |
+| `WorkerDesiredCount` | `1` | Static desired count (when autoscaling disabled) |
+| `WorkerMinCount` | `1` | Minimum tasks (always-on baseline) |
+| `WorkerMaxCount` | `5` | Maximum tasks during burst |
 
 ---
 
@@ -423,21 +453,23 @@ The graph database system uses a modular architecture with separate templates fo
 | Parameter | Default | Description |
 |-----------|---------|-------------|
 | `Environment` | `prod` | Environment name |
-| `InstanceType` | `r7g.medium` | EC2 instance type |
-| `MinCapacity` | `0` | Minimum instances |
-| `MaxCapacity` | `2` | Maximum instances |
-| `DesiredCapacity` | `1` | Desired instances |
+| `InstanceType` | Required (per-tier) | EC2 instance type (set per tier from `graph.yml`) |
+| `MinInstances` | `1` | Minimum instances |
+| `MaxInstances` | `10` | Maximum instances |
+| `DatabasesPerInstance` | `1` | Max databases per instance |
 | `VpcStackName` | Required | VPC stack name |
 | `S3StackName` | Required | S3 stack name |
 | `ValkeyStackName` | Required | Valkey stack name |
 | `GraphInfraStackName` | Required | Graph infra stack name |
 
+> DesiredCapacity is intentionally omitted from the ASG; it is managed by the application at runtime.
+
 **Instance Tiers** (configured in `.github/configs/graph.yml`):
 | Tier | Instance Type | Memory | Use Case |
 |------|---------------|--------|----------|
-| ladybug-standard | r7g.medium | 16 GB | Shared/free tier |
-| ladybug-large | r7g.large | 32 GB | Standard subscriptions |
-| ladybug-xlarge | r7g.xlarge | 64 GB | Large subscriptions |
+| ladybug-standard | m7g.large | 8 GB | Cost-efficient entry tier with subgraph support |
+| ladybug-large | r7g.large | 16 GB | Enhanced performance for growing teams |
+| ladybug-xlarge | r7g.xlarge | 32 GB | Maximum performance and scale |
 
 **Exports**:
 - `{StackName}-AutoScalingGroupArn` - ASG ARN
@@ -462,10 +494,10 @@ The graph database system uses a modular architecture with separate templates fo
 | Parameter | Default | Description |
 |-----------|---------|-------------|
 | `Environment` | `prod` | Environment name |
-| `InstanceType` | `r7g.medium` | EC2 instance type |
-| `MinCapacity` | `0` | Minimum replicas |
-| `MaxCapacity` | `3` | Maximum replicas |
-| `DesiredCapacity` | `0` | Desired replicas |
+| `InstanceType` | `m7g.large` | EC2 instance type (smaller than writers) |
+| `MinInstances` | `2` | Minimum replicas (0 for cost-saving mode) |
+| `MaxInstances` | `10` | Maximum replicas |
+| `DesiredCapacity` | `2` | Desired replicas |
 | `VpcStackName` | Required | VPC stack name |
 
 **Exports**:
@@ -650,15 +682,14 @@ gh workflow run deploy-<stack>.yml -f environment=prod
 ### Local Validation
 
 ```bash
-# Validate a template
-just cf-validate cloudformation/api.yaml
+# Lint + validate a single template (pass the name, no path or extension)
+just cf-lint api
 
 # Lint all templates
-just cf-lint
-
-# Validate all templates
-just cf-validate-all
+just cf-lint-all
 ```
+
+`just cf-lint <name>` runs `cfn-lint` and `aws cloudformation validate-template` against `cloudformation/<name>.yaml`.
 
 ### Viewing Stack Status
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,7 +8,7 @@ Comprehensive examples demonstrating RoboSystems' graph database capabilities ac
 # Make sure RoboSystems is running
 just start
 
-# Run all demos in sequence
+# Run all demos in sequence (roboledger → custom-graph → sec)
 just demo
 
 # Or run individual demos
@@ -21,7 +21,41 @@ just demo-world-online
 
 ## Available Demos
 
-### 1. SEC Demo - Public Company Financial Data
+### 1. RoboLedger Demo - End-to-End Accounting Workflow
+
+Full RoboLedger workflow on synthetic data for a boutique consulting firm: bulk OLTP import, taxonomy and schedule blocks, fiscal calendar, a filed annual report, and an AI-driven month-end close. All data flows in through the same HTTP API the frontend UI and MCP tools use.
+
+**Features:**
+
+- Generates a rolling 16-month window ending at the current month
+- Creates a chart of accounts, REA Agents (customers/vendors/employees), and a typed business-event stream
+- Initializes a fiscal calendar with exactly one period ready to close on first run
+- Optional MappingOperator (`--ai`) to map the chart of accounts via the AI Operator (requires Bedrock)
+
+**Usage:**
+
+```bash
+# Run the full demo (creates graph, loads data, creates schedules, uploads policies)
+just demo-roboledger
+
+# Load into an existing graph
+just demo-roboledger <graph_id>
+
+# Skeleton: create user + empty roboledger graph only (then connect a real QuickBooks sandbox manually)
+just demo-roboledger --skeleton
+
+# Use the MappingOperator instead of hardcoded mappings (requires Bedrock)
+just demo-roboledger --ai
+
+# Validate data only
+just demo-roboledger --dry-run
+```
+
+**Location:** `/examples/roboledger_demo/`
+
+**Documentation:** See [README.md](roboledger_demo/README.md) for the full walkthrough
+
+### 2. SEC Demo - Public Company Financial Data
 
 Query real SEC XBRL financial data from public companies.
 
@@ -62,7 +96,7 @@ Any publicly traded US company with SEC filings (e.g., AAPL, MSFT, GOOGL, TSLA, 
 
 **Documentation:** See [README.md](sec_demo/README.md) for detailed guide and query examples
 
-### 2. Custom Graph Demo - Generic Graph Structure
+### 3. Custom Graph Demo - Generic Graph Structure
 
 Demonstrates custom schema creation with people, companies, and projects.
 
@@ -109,7 +143,7 @@ just demo-custom-graph --skip-queries
 
 **Customization:** Edit `schema.json` to define your own node types and relationships
 
-### 3. Seattle Method Demo - Record-to-Report (Charlie Hoffman's "mini")
+### 4. Seattle Method Demo - Record-to-Report (Charlie Hoffman's "mini")
 
 End-to-end accounting proof against Charlie Hoffman's Seattle Method "mini" record-to-report test case: ingest a 14-JE general journal (lemonade stand), map the chart of accounts to rs-gaap, and render a validated 4-statement report.
 
@@ -137,7 +171,7 @@ just demo-seattle-method-create-report
 
 **Documentation:** See [README.md](seattle_method_demo/README.md) for the walkthrough
 
-### 4. World Online Demo - Seattle Method at Scale
+### 5. World Online Demo - Seattle Method at Scale
 
 The scaled-up sibling of the `mini` demo: Charlie Hoffman's "The World Online" dataset — a real-size general ledger tagged against MINI 2026.
 

--- a/examples/roboledger_demo/main.py
+++ b/examples/roboledger_demo/main.py
@@ -1157,7 +1157,7 @@ def main() -> None:
   print("\nInitializing fiscal calendar...")
   close_target = initialize_fiscal_calendar(graph_id)
 
-  # Create schedules (via HTTP API — exercises create-schedule op)
+  # Create schedules (HTTP API — exercises create-information-block op)
   print("\nCreating schedules...")
   schedule_count = create_schedules(graph_id, element_lookup)
   print(f"  Schedules:    {schedule_count}")

--- a/robosystems/adapters/README.md
+++ b/robosystems/adapters/README.md
@@ -51,19 +51,27 @@ adapters/
 │   │   ├── artifact.py          # Artifact builders (element knowledge, structure profiles)
 │   │   └── framework.py         # DuckDBAnalyticsContext (sync context manager)
 │   ├── taxonomy/                # Canonical concept mappings
-│   │   ├── __init__.py          # ConceptTaxonomy registry
+│   │   ├── __init__.py          # CanonicalConcept, get_element_taxonomy, get_structure_taxonomy
 │   │   ├── concepts.py          # Concept type definitions
 │   │   ├── structures.py        # Structure type definitions
 │   │   ├── balance_sheet.py     # Balance sheet concept mappings
 │   │   ├── cash_flow.py         # Cash flow concept mappings
 │   │   └── income_statement.py  # Income statement concept mappings
 │   └── pipeline/                # Dagster orchestration
+│       ├── README.md            # Pipeline documentation
 │       ├── __init__.py          # get_dagster_components() discovery
 │       ├── configs.py           # Run configurations
 │       ├── download.py          # sec_raw_filings asset
 │       ├── process.py           # sec_processed_filings asset
 │       ├── stage.py             # DuckDB staging assets
 │       ├── materialize.py       # LadybugDB materialization assets
+│       ├── artifact.py          # Knowledge artifact generation assets
+│       ├── s3_publish.py        # LadybugDB → S3 publish assets
+│       ├── duckdb_s3_publish.py # DuckDB → S3 publish assets
+│       ├── r2_publish.py        # LadybugDB → Cloudflare R2 publish assets
+│       ├── vector_publish.py    # Vector embedding publish assets
+│       ├── text_index.py        # OpenSearch text/iXBRL indexing assets
+│       ├── entity_sync/         # Entity (company) metadata sync sub-pipeline
 │       ├── jobs.py              # 18 SEC job definitions
 │       └── sensors.py           # 6 sensors + 1 schedule
 └── quickbooks/                  # QuickBooks adapter (private)
@@ -127,7 +135,7 @@ The SEC adapter has three processing layers:
 
 1. **Core pipeline** (`client/`, `processors/`, `pipeline/`) — Downloads XBRL filings from EDGAR, transforms them into graph nodes/relationships, stages in DuckDB, and materializes into LadybugDB.
 
-2. **Enrichment** (`enrichment.py`, `taxonomy/`) — `SemanticEnricher` runs inline during filing processing to add semantic metadata: canonical concept mapping via fastembed embeddings, Structure-level `canonical_type` classification (income_statement, balance_sheet, etc.), and Association-level disclosure classification. Controlled by feature flags `XBRL_SEMANTIC_ENRICHMENT`, `XBRL_ASSOCIATION_CLASSIFICATION`, and `XBRL_GRAPH_REFINEMENT`.
+2. **Enrichment** (`enrichment.py`, `taxonomy/`) — `SemanticEnricher` runs inline during filing processing to add semantic metadata: canonical concept mapping via fastembed embeddings, Structure-level `canonical_type` classification (income_statement, balance_sheet, etc.), and Association-level disclosure classification. Controlled by the `XBRL_SEMANTIC_ENRICHMENT`, `XBRL_ASSOCIATION_CLASSIFICATION`, and `XBRL_GRAPH_REFINEMENT` flags in `adapters/sec/config.py`.
 
 3. **Knowledge artifacts** (`knowledge/`) — Offline Dagster jobs that analyze the full DuckDB corpus to generate confidence-refinement artifacts (`element_knowledge.parquet`, `structure_profiles.parquet`, `structure_consensus.parquet`). These artifacts are loaded at enrichment time to refine classification confidence — crushing bad semantic matches and boosting well-connected elements.
 

--- a/robosystems/admin/README.md
+++ b/robosystems/admin/README.md
@@ -165,13 +165,13 @@ just admin dev migrations current                          # Show version
 
 ## Common Workflows
 
-### Enable Invoice Billing for Enterprise Customer
+### Enable Invoice Billing for a Customer
 
 ```bash
 # Update org to enable invoice billing
 just admin dev orgs update ORG_ID \
   --invoice-billing \
-  --billing-email "ap@enterprise.com" \
+  --billing-email "ap@example.com" \
   --payment-terms "net_30"
 
 # Verify

--- a/robosystems/config/README.md
+++ b/robosystems/config/README.md
@@ -29,8 +29,7 @@ config/
 ├── openapi_tags.py          # OpenAPI tag metadata
 ├── billing/                 # Billing plans and pricing
 │   ├── core.py              # Subscription tiers and base pricing
-│   ├── ai.py                # AI/token-based pricing
-│   └── repositories.py      # Repository pricing
+│   └── ai.py                # AI/token-based pricing
 ├── rate_limits.py           # Burst-focused rate limiting
 ├── credits.py               # Credit costs and allocations
 ├── operators.py             # AI Operator configuration (Bedrock Claude models)

--- a/robosystems/config/README.md
+++ b/robosystems/config/README.md
@@ -38,7 +38,7 @@ config/
 ├── query_queue.py           # Query queue configuration
 ├── shared_repositories.py   # Shared repository registry
 ├── validation.py            # Startup validation
-├── valkey_registry.py       # Redis database allocation
+├── valkey_registry.py       # Valkey database allocation
 └── storage/                 # S3 path configuration (see storage/README.md)
     ├── __init__.py          # Re-exports from shared and graph
     ├── shared.py            # Shared data sources (SEC, FRED, etc.)
@@ -112,7 +112,7 @@ Centralized environment variable management with validation.
 **Usage:**
 
 ```python
-from robosystems.config.env import env
+from robosystems.config import env
 
 # Access typed environment variables
 database_url = env.DATABASE_URL
@@ -148,8 +148,8 @@ SHARED_RAW_BUCKET    # S3 bucket for shared raw data (SEC, FRED, etc.)
 SHARED_PROCESSED_BUCKET  # S3 bucket for shared processed data
 
 # Feature Flags
-ENABLE_RATE_LIMITING # Rate limiting toggle
-ENABLE_CREDITS       # Credit system toggle
+RATE_LIMIT_ENABLED   # Rate limiting toggle
+BILLING_ENABLED      # Credit/billing system toggle
 ```
 
 ### 2. Billing Configuration (`billing/`)
@@ -165,7 +165,7 @@ Defines subscription plans, credit allocations, and AI token pricing.
 
 **Subscription Tiers** (per-graph):
 
-| Tier | Price | Monthly Credits | ~Agent Calls |
+| Tier | Price | Monthly Credits | ~Operator Calls |
 |------|-------|----------------|-------------|
 | ladybug-standard | $149/mo | 8,000 | ~200/mo |
 | ladybug-large | $299/mo | 32,000 | ~800/mo |
@@ -199,27 +199,49 @@ Burst-focused rate limiting for spike protection.
 
 ```python
 class EndpointCategory(str, Enum):
-    AUTH = "auth"                # Login, register
-    GRAPH_READ = "graph_read"    # GET operations
-    GRAPH_WRITE = "graph_write"  # POST/PUT/DELETE
-    GRAPH_QUERY = "graph_query"  # Cypher queries
-    ANALYTICS = "analytics"      # Heavy computations
-    AI = "ai"                    # AI/MCP operations
-    PUBLIC = "public"            # Health checks
+    # Non-graph scoped endpoints
+    AUTH = "auth"                          # Login, register
+    USER_MANAGEMENT = "user_management"
+    TASKS = "tasks"
+    STATUS = "status"                      # Health checks
+    SSE = "sse"                            # Server-Sent Events connections
+    BILLING = "billing"                    # Checkout and payment flows
+
+    # Graph-scoped endpoints
+    GRAPH_READ = "graph_read"              # GET operations
+    GRAPH_WRITE = "graph_write"            # POST/PUT/DELETE
+    GRAPH_ANALYTICS = "graph_analytics"    # Heavy computations
+    GRAPH_BACKUP = "graph_backup"
+    GRAPH_SYNC = "graph_sync"
+    GRAPH_MCP = "graph_mcp"                # MCP operations
+    GRAPH_OPERATOR = "graph_operator"      # AI Operator operations
+    GRAPH_SEARCH = "graph_search"          # OpenSearch full-text search
+
+    # High-cost operations
+    GRAPH_QUERY = "graph_query"            # Direct Cypher queries
+    GRAPH_IMPORT = "graph_import"          # Bulk data imports
+
+    # Extensions surface (OLTP on shared RDS)
+    EXTENSIONS_GRAPHQL = "extensions_graphql"  # Typed GraphQL reads
+    EXTENSIONS_WRITE = "extensions_write"      # Command writes + views
+
+    # Table operations (DuckDB staging tables)
+    TABLE_QUERY = "table_query"            # SQL queries on staging tables
+    TABLE_UPLOAD = "table_upload"          # File uploads to staging tables
+    TABLE_MANAGEMENT = "table_management"  # Table creation/deletion
 ```
 
-**Rate Limits:**
+**Rate Limits** (representative — see `rate_limits.py` for the authoritative table):
 
 ```python
-# Standard tier (1-minute windows)
-GRAPH_READ: 500/min   # 30k/hour possible
-GRAPH_WRITE: 100/min  # 6k/hour possible
-GRAPH_QUERY: 60/min   # 3.6k/hour possible
-AI: 10/min            # 600/hour possible
+# ladybug-standard tier (1-minute windows, base values)
+GRAPH_READ: 120/min
+GRAPH_WRITE: 30/min
+GRAPH_QUERY: 60/min
+GRAPH_OPERATOR: 15/min   # AI Operator operations
 
-# XLarge tier (5x multiplier)
-GRAPH_READ: 2500/min  # 150k/hour possible
-GRAPH_WRITE: 500/min  # 30k/hour possible
+# Larger tiers apply graph.yml api_rate_multiplier (e.g. 1.5x large, higher for xlarge)
+# on top of these base values.
 ```
 
 **Usage:**
@@ -251,7 +273,7 @@ Defines what consumes credits and token-based pricing for AI operations.
 
 **Credit Model:**
 
-- Only AI agent operations consume credits (token-based pricing)
+- Only AI Operator operations consume credits (token-based pricing)
 - All database operations are included with the subscription (no credits)
 - MCP tool access is unlimited (no credits)
 - Storage is included in each tier (no metering)
@@ -317,23 +339,25 @@ Centralized configuration for the AI Operator system.
 **Features:**
 
 - **Model Selection**: AWS Bedrock Claude model configuration
-- **Execution Profiles**: Time/token limits per agent mode
+- **Execution Profiles**: Time/token limits per operator mode
 - **Orchestrator Config**: Routing strategy and fallback settings
-- **Agent-Specific Overrides**: Per-agent model customization
+- **Operator-Specific Overrides**: Per-operator model customization
 
 **Available Models:**
+
+Each `BedrockModel` enum member's value is a short identifier (e.g. `SONNET_4_6.value == "claude-sonnet-4-6"`); it is mapped internally to a regional Bedrock inference profile id (`us.anthropic.*`) shown in the comments below.
 
 ```python
 from robosystems.config import BedrockModel
 
-# Sonnet 4.6 (default) - Regional inference profile
-BedrockModel.SONNET_4_6  # us.anthropic.claude-sonnet-4-6
+# Sonnet 4.6 (default) → us.anthropic.claude-sonnet-4-6
+BedrockModel.SONNET_4_6
 
-# Sonnet 4.5 (fallback) - Regional inference profile
-BedrockModel.SONNET_4_5  # us.anthropic.claude-sonnet-4-5-20250929-v1:0
+# Sonnet 4.5 (fallback) → us.anthropic.claude-sonnet-4-5-20250929-v1:0
+BedrockModel.SONNET_4_5
 
-# Sonnet 4 (last resort) - Regional inference profile
-BedrockModel.SONNET_4    # us.anthropic.claude-sonnet-4-20250514-v1:0
+# Sonnet 4 (last resort) → us.anthropic.claude-sonnet-4-20250514-v1:0
+BedrockModel.SONNET_4
 ```
 
 **Note:** All models use regional inference profiles (`us.*`) for on-demand access without marketplace subscriptions.
@@ -366,10 +390,10 @@ from robosystems.config import OperatorConfig, BedrockModel
 # Get default model ID
 model_id = OperatorConfig.get_bedrock_model_id()
 
-# Get model for specific agent with override
+# Get model for a specific operator with override
 model_id = OperatorConfig.get_bedrock_model_id(
     model=BedrockModel.SONNET_4_5,
-    agent_type="financial"
+    operator_type="financial"
 )
 
 # Get execution profile
@@ -393,9 +417,9 @@ if not validation["valid"]:
     print(f"Issues: {validation['issues']}")
 ```
 
-**Customizing Agent Models:**
+**Customizing Operator Models:**
 
-To use a different model for a specific agent, update `OPERATOR_MODEL_OVERRIDES`:
+To use a different model for a specific operator, update `OPERATOR_MODEL_OVERRIDES`:
 
 ```python
 # In robosystems/config/operators.py
@@ -487,7 +511,7 @@ All business configuration lives in code, not database:
 
 **Credit Costs** (Billing):
 
-- Only AI agent operations consume credits (token-based pricing)
+- Only AI Operator operations consume credits (token-based pricing)
 - All database operations are included (queries, imports, backups, etc.)
 - No multipliers applied to credit costs — same rate for all tiers
 - Credits are billed based on actual AI token usage (input + output tokens)
@@ -522,7 +546,7 @@ os.environ["ENVIRONMENT"] = "test"
 os.environ["DATABASE_URL"] = "postgresql://test"
 
 # Test configuration access
-from robosystems.config.env import env
+from robosystems.config import env
 assert env.is_test()
 assert env.DATABASE_URL == "postgresql://test"
 

--- a/robosystems/config/constants.py
+++ b/robosystems/config/constants.py
@@ -14,9 +14,6 @@ Categories:
 # OPERATIONAL CONSTANTS
 # =============================================================================
 
-# Storage Pricing (fixed business rule)
-STORAGE_CREDITS_PER_GB_PER_DAY = 0.05
-
 # Port Configuration
 MIN_PORT = 1
 MAX_PORT = 65535

--- a/robosystems/config/credits.py
+++ b/robosystems/config/credits.py
@@ -64,7 +64,7 @@ class CreditConfig:
     """
     Get the cost for an operation type.
 
-    Only AI operations (agent_call, ai_analysis) and storage consume credits.
+    Only AI operations (agent_call, ai_analysis) consume credits.
     All other operations including MCP calls are included in the subscription.
 
     Args:

--- a/robosystems/graph_api/README.md
+++ b/robosystems/graph_api/README.md
@@ -497,17 +497,15 @@ with get_graph_client_sync("kg1a2b3c4d5", operation_type="read") as client:
 # Node Configuration
 LBUG_NODE_TYPE=writer                    # writer|shared_master
 CLUSTER_TIER=ladybug-standard            # ladybug-standard|ladybug-large|ladybug-xlarge|ladybug-shared
-LBUG_DATABASE_PATH=/data/lbug-dbs       # Storage location
-LBUG_PORT=8001                           # API port
+LBUG_DATABASE_PATH=/data/lbug-dbs        # Storage location
 
 # Performance Settings
-LBUG_MAX_DATABASES_PER_NODE=10          # Configuration-based limit
-LBUG_MAX_MEMORY_MB=14336                # Total memory allocation
-LBUG_MEMORY_PER_DB_MB=2048              # Per-database memory
-LBUG_CHUNK_SIZE=1000                    # Streaming chunk size
-LBUG_QUERY_TIMEOUT=30                   # Query timeout seconds
-LBUG_MAX_QUERY_LENGTH=10000             # Max query characters
-LBUG_CONNECTION_POOL_SIZE=10            # Connections per database
+LBUG_DATABASES_PER_INSTANCE=10           # Databases per instance
+LBUG_MAX_MEMORY_MB=14336                 # Total memory allocation
+LBUG_MAX_MEMORY_PER_DB_MB=2048           # Per-database memory
+LBUG_CHUNK_SIZE=1000                     # Streaming chunk size
+GRAPH_QUERY_TIMEOUT=30                   # Query timeout seconds
+LBUG_CONNECTION_POOL_SIZE=10             # Connections per database
 
 # Authentication
 GRAPH_API_KEY=                           # API key

--- a/robosystems/graph_api/README.md
+++ b/robosystems/graph_api/README.md
@@ -1,10 +1,10 @@
 # Graph API
 
-High-performance HTTP API server for graph database cluster management. FastAPI-based microservice that provides REST endpoints for multi-tenant graph operations with enterprise-grade reliability and security.
+HTTP API server for graph database cluster management. FastAPI-based microservice that provides REST endpoints for multi-tenant graph operations with connection pooling, circuit breaking, and admission control.
 
 **Backend:**
 
-- **LadybugDB**: High-performance embedded graph database based on columnar storage
+- **LadybugDB**: Embedded graph database built on columnar storage
 
 ## Table of Contents
 
@@ -51,20 +51,32 @@ graph_api/
 ├── __main__.py                 # Module entry point
 │
 ├── client/                     # Python clients
-│   ├── client.py              # Async client implementation
-│   ├── sync_client.py         # Synchronous client
-│   ├── factory.py             # Intelligent routing factory
+│   ├── base.py                # Shared client base (BaseGraphClient)
+│   ├── client.py              # Async client implementation (GraphClient)
+│   ├── factory.py             # Intelligent routing factory + sync helpers
 │   ├── config.py              # Client configuration
 │   └── exceptions.py          # Custom exceptions
 │
-├── core/                      # Core services
-│   ├── ladybug_service.py    # LadybugDB service orchestration
-│   ├── database_manager.py   # Database lifecycle management
-│   ├── duckdb_manager.py     # DuckDB staging database management
-│   ├── duckdb_pool.py        # DuckDB connection pooling
-│   ├── connection_pool.py    # Graph connection pooling
-│   ├── admission_control.py  # Backpressure management
-│   └── metrics_collector.py  # Performance metrics
+├── core/                      # Core services (organized by database technology)
+│   ├── ladybug/              # LadybugDB embedded graph database
+│   │   ├── engine.py         # Low-level database driver
+│   │   ├── pool.py           # Connection pooling
+│   │   ├── manager.py        # Database lifecycle and schema
+│   │   ├── service.py        # Service orchestration
+│   │   ├── config.py         # LadybugDB configuration
+│   │   └── materialization_lock.py  # Single-writer materialization lock
+│   ├── duckdb/               # DuckDB data staging
+│   │   ├── pool.py           # DuckDB connection pooling
+│   │   └── manager.py        # Staging table management
+│   ├── lance/                # LanceDB vector storage
+│   │   └── manager.py        # Vector table management
+│   ├── admission_control.py  # CPU/memory backpressure management
+│   ├── backup_service.py     # Backup/restore service
+│   ├── memory_manager.py     # Memory budget management
+│   ├── migration_service.py  # Graph schema migration service
+│   ├── metrics_collector.py  # Performance metrics
+│   ├── task_manager.py       # Async task coordination
+│   └── task_sse.py           # Server-Sent Events for task progress
 │
 ├── routers/                   # API endpoints
 │   ├── databases/
@@ -77,9 +89,14 @@ graph_api/
 │   │   ├── schema.py         # Schema management
 │   │   ├── metrics.py        # Database metrics
 │   │   ├── backup.py         # Backup operations
-│   │   └── restore.py        # Restore operations
+│   │   ├── restore.py        # Restore operations
+│   │   ├── memory.py         # Per-database memory operations
+│   │   ├── swap.py           # Blue/green database swap
+│   │   └── vector_search.py  # LanceDB vector search
 │   ├── health.py             # Health checks
 │   ├── info.py               # Node information
+│   ├── metrics.py            # Node-level metrics
+│   ├── migration.py          # Schema migration endpoints
 │   └── tasks.py              # Background task tracking
 │
 ├── middleware/
@@ -88,8 +105,10 @@ graph_api/
 │
 └── models/                    # Pydantic models
     ├── database.py           # Database schemas
-    ├── ingestion.py          # Ingestion requests
-    ├── streaming.py          # NDJSON streaming
+    ├── tables.py             # Staging table requests/responses
+    ├── tasks.py              # Task tracking models
+    ├── migration.py          # Migration request/response models
+    ├── fork.py               # Database fork/swap models
     └── cluster.py            # Cluster configuration
 ```
 
@@ -240,7 +259,7 @@ cfn-signal --success --stack ${STACK_NAME} ...
 
 ```http
 POST /databases
-Authorization: X-Graph-API-Key: {api_key}
+X-Graph-API-Key: {api_key}
 Content-Type: application/json
 
 {
@@ -253,7 +272,7 @@ Content-Type: application/json
 
 ```http
 POST /databases/{graph_id}/query
-Authorization: X-Graph-API-Key: {api_key}
+X-Graph-API-Key: {api_key}
 Content-Type: application/json
 
 {
@@ -275,7 +294,7 @@ Content-Type: application/json
 
 ```http
 POST /databases/{graph_id}/tables
-Authorization: X-Graph-API-Key: {api_key}
+X-Graph-API-Key: {api_key}
 Content-Type: application/json
 
 {
@@ -295,7 +314,7 @@ Response: {
 
 ```http
 GET /databases/{graph_id}/tables
-Authorization: X-Graph-API-Key: {api_key}
+X-Graph-API-Key: {api_key}
 
 Response: [
   {
@@ -312,7 +331,7 @@ Response: [
 
 ```http
 POST /databases/{graph_id}/tables/query
-Authorization: X-Graph-API-Key: {api_key}
+X-Graph-API-Key: {api_key}
 Content-Type: application/json
 
 {
@@ -338,7 +357,7 @@ Supports streaming via Accept: application/x-ndjson or text/event-stream headers
 
 ```http
 POST /databases/{graph_id}/tables/{table_name}/materialize
-Authorization: X-Graph-API-Key: {api_key}
+X-Graph-API-Key: {api_key}
 Content-Type: application/json
 
 {
@@ -362,7 +381,7 @@ Use rebuild=true to regenerate the graph database from scratch (safe operation).
 
 ```http
 DELETE /databases/{graph_id}/tables/{table_name}
-Authorization: X-Graph-API-Key: {api_key}
+X-Graph-API-Key: {api_key}
 
 Response: {
   "status": "success",
@@ -415,12 +434,17 @@ Response: {
 
 ## Client Libraries
 
+`GraphClient` (`client.py`, a subclass of `BaseGraphClient`) is the single async
+client. There is no separate sync client class — synchronous access is provided
+by the `get_graph_client_sync` / `create_client_sync` helpers, which return a
+`GraphClient` usable as a sync context manager.
+
 ### Async Client
 
 ```python
-from robosystems.graph_api.client import AsyncGraphClient
+from robosystems.graph_api.client import GraphClient
 
-async with AsyncGraphClient(
+async with GraphClient(
     base_url="http://graph-api:8001",
     api_key="graph_api_..."
 ) as client:
@@ -437,35 +461,32 @@ async with AsyncGraphClient(
     )
 ```
 
-### Sync Client
-
-```python
-from robosystems.graph_api.client import GraphClient
-
-client = GraphClient(
-    base_url="http://graph-api:8001",
-    api_key="graph_api_..."
-)
-
-# Synchronous operations
-data = client.query(
-    graph_id="kg1a2b3c4d5",
-    cypher="MATCH (n) RETURN n LIMIT 10"
-)
-```
-
 ### Client Factory with Intelligent Routing
 
 ```python
-from robosystems.graph_api.client.factory import get_graph_client
+from robosystems.config.graph_tier import GraphTier
+from robosystems.graph_api.client import get_graph_client
 
-# Factory handles routing based on graph type and operation
+# Factory handles routing based on graph type and operation (async)
 client = await get_graph_client(
     graph_id="sec",              # Routes to shared infrastructure
     operation_type="read",        # Could use replica
     environment="prod",
-    tier=InstanceTier.STANDARD
+    tier=GraphTier.LADYBUG_STANDARD
 )
+```
+
+### Sync Access
+
+```python
+from robosystems.graph_api.client import get_graph_client_sync
+
+# Returns a GraphClient usable as a synchronous context manager
+with get_graph_client_sync("kg1a2b3c4d5", operation_type="read") as client:
+    data = client.query(
+        graph_id="kg1a2b3c4d5",
+        cypher="MATCH (n) RETURN n LIMIT 10"
+    )
 ```
 
 ## Configuration
@@ -499,10 +520,10 @@ SHARED_RAW_BUCKET=robosystems-shared-raw-dev  # S3 for shared raw data
 SHARED_PROCESSED_BUCKET=robosystems-shared-processed-dev  # S3 for shared processed data
 
 # Feature Flags
-LBUG_CIRCUIT_BREAKERS_ENABLED=true     # Enable circuit breakers
-LBUG_REDIS_CACHE_ENABLED=true          # Enable Redis caching
-LBUG_RETRY_LOGIC_ENABLED=true          # Enable automatic retries
-LBUG_HEALTH_CHECKS_ENABLED=true        # Enable health checking
+GRAPH_CIRCUIT_BREAKERS_ENABLED=true    # Enable circuit breakers
+GRAPH_REDIS_CACHE_ENABLED=true         # Enable Valkey caching of instance locations
+GRAPH_RETRY_LOGIC_ENABLED=true         # Enable automatic retries
+GRAPH_HEALTH_CHECKS_ENABLED=true       # Enable health checking
 ```
 
 ### Schema Types
@@ -778,7 +799,7 @@ aws autoscaling start-instance-refresh \
 ## Known Limitations
 
 1. **Sequential Ingestion**: Files processed one at a time per database (LadybugDB constraint)
-2. **Connection Limit**: Maximum 3 concurrent connections per database
+2. **Connection Limit**: Default 3 connections per database, configurable via `LBUG_CONNECTION_POOL_SIZE` (10 in production)
 3. **Single Writer**: Only one write operation per database at a time
 4. **No Cross-Database Queries**: Each query scoped to single database
 5. **Volume Attachment**: One EBS volume per database (no striping)

--- a/robosystems/graph_api/client/README.md
+++ b/robosystems/graph_api/client/README.md
@@ -64,7 +64,7 @@ The factory is responsible for intelligent routing decisions based on:
 - **Backend Abstraction**: Consistent HTTP interface regardless of backend
 - **Circuit Breakers**: Prevents cascading failures with configurable thresholds
 - **Connection Pooling**: HTTP/2 connection reuse for efficiency
-- **Redis Caching**: Caches instance locations to reduce lookups
+- **Valkey Caching**: Caches instance locations to reduce lookups
 - **Automatic Failover**: Falls back to alternative endpoints when primary unavailable
 - **Retry Logic**: Exponential backoff with jitter for transient errors
 
@@ -152,7 +152,7 @@ from robosystems.config.graph_tier import GraphTier
 client = await GraphClientFactory.create_client(
     graph_id="kg1a2b3c4d5",           # User graph ID
     operation_type="write",            # Write operation
-    tier=GraphTier.LBUG_LARGE         # Tier determines routing
+    tier=GraphTier.LADYBUG_LARGE      # Tier determines routing
 )
 
 # Perform operations
@@ -222,7 +222,7 @@ GRAPH_API_KEY=graph_api_64chars...           # Authentication key
 GRAPH_RETRY_LOGIC_ENABLED=true               # Enable automatic retries
 GRAPH_CIRCUIT_BREAKERS_ENABLED=true          # Enable circuit breakers
 GRAPH_HEALTH_CHECKS_ENABLED=true             # Enable health checking
-GRAPH_REDIS_CACHE_ENABLED=true               # Enable Redis caching
+GRAPH_REDIS_CACHE_ENABLED=true               # Enable Valkey caching (env var name retains REDIS for compatibility)
 
 # Performance Tuning
 LBUG_CLIENT_TIMEOUT=30                       # Request timeout (seconds)
@@ -242,7 +242,7 @@ VOLUME_REGISTRY_TABLE=robosystems-graph-{env}-volume-registry
 
 ## Instance Discovery Flow
 
-1. **Check Cache**: Redis cache with 5-minute TTL
+1. **Check Cache**: Valkey cache with 5-minute TTL
 2. **Query DynamoDB**: Find instance hosting the graph
 3. **Health Check**: Verify instance is healthy
 4. **Create Client**: Initialize with discovered endpoint
@@ -251,7 +251,7 @@ VOLUME_REGISTRY_TABLE=robosystems-graph-{env}-volume-registry
 ```python
 # Internal discovery flow (handled automatically)
 1. GraphClientFactory.create_client("kg1a2b3c4d5")
-2. → Check Redis: lbug:prod:location:kg1a2b3c4d5
+2. → Check Valkey: lbug:prod:location:kg1a2b3c4d5
 3. → Query DynamoDB: GraphRegistry[graph_id=kg1a2b3c4d5]
 4. → Get instance: i-1234567890 at 10.0.1.100
 5. → Create client: http://10.0.1.100:8001
@@ -286,7 +286,7 @@ keepalive_expiry: 5.0        # Seconds before closing idle
 ### Caching Strategy
 
 ```python
-# Redis caching layers
+# Valkey caching layers
 1. Instance locations: 5-minute TTL
 2. ALB health status: 30-second TTL
 3. Shared master URL: 5-minute TTL

--- a/robosystems/graph_api/core/README.md
+++ b/robosystems/graph_api/core/README.md
@@ -19,22 +19,31 @@ core/
 │
 ├── ladybug/                       # LadybugDB embedded graph database
 │   ├── __init__.py               # LadybugDB exports
-│   ├── engine.py                 # Low-level database driver (18KB)
-│   ├── pool.py                   # Connection pooling (26KB)
-│   ├── manager.py                # Database lifecycle and schema (35KB)
-│   └── service.py                # Service orchestration (35KB)
+│   ├── engine.py                 # Low-level database driver
+│   ├── pool.py                   # Connection pooling
+│   ├── manager.py                # Database lifecycle and schema
+│   ├── service.py                # Service orchestration
+│   ├── config.py                 # LadybugDB configuration
+│   └── materialization_lock.py   # Single-writer materialization lock
 │
 ├── duckdb/                        # DuckDB data staging
 │   ├── __init__.py               # DuckDB exports
-│   ├── pool.py                   # DuckDB connection pooling (21KB)
-│   └── manager.py                # Staging table management (20KB)
+│   ├── pool.py                   # DuckDB connection pooling
+│   └── manager.py                # Staging table management
+│
+├── lance/                         # LanceDB vector storage
+│   ├── __init__.py               # LanceDB exports
+│   └── manager.py                # Vector table management
 │
 └── [shared services]              # Technology-agnostic services
-    ├── admission_control.py      # CPU/memory-based backpressure (6KB)
-    ├── metrics_collector.py      # Performance monitoring (13KB)
-    ├── task_manager.py           # Async task coordination (5KB)
-    ├── task_sse.py               # Server-Sent Events (7KB)
-    └── utils.py                  # Shared utilities (4KB)
+    ├── admission_control.py      # CPU/memory-based backpressure
+    ├── backup_service.py         # Backup/restore service
+    ├── memory_manager.py         # Memory budget management
+    ├── migration_service.py      # Graph schema migration service
+    ├── metrics_collector.py      # Performance monitoring
+    ├── task_manager.py           # Async task coordination
+    ├── task_sse.py               # Server-Sent Events
+    └── utils.py                  # Shared utilities
 ```
 
 ## Technology Stack
@@ -335,7 +344,7 @@ Async operation coordination with Server-Sent Events for real-time progress:
 **Key Features**:
 - **Task Tracking** - Manage long-running operations
 - **Progress Updates** - Real-time status via Server-Sent Events
-- **Redis-Backed** - Distributed task state storage
+- **Valkey-Backed** - Distributed task state storage
 - **Automatic Cleanup** - Task lifecycle management
 
 **Usage**:
@@ -516,7 +525,7 @@ MEMORY_CRITICAL_THRESHOLD=90
 
 ### Task Management
 ```bash
-# Redis configuration for task state
+# Valkey configuration for task state (redis:// URL scheme)
 VALKEY_URL=redis://localhost:6379
 TASK_MANAGER_DB=3
 TASK_TTL_SECONDS=3600

--- a/robosystems/graph_api/core/README.md
+++ b/robosystems/graph_api/core/README.md
@@ -479,10 +479,10 @@ Core services are configured via environment variables:
 ### LadybugDB Configuration
 ```bash
 # Database directory
-LBUG_DATABASE_DIR=/data/lbug-dbs
+LBUG_DATABASE_PATH=/data/lbug-dbs
 
 # Instance limits
-LBUG_MAX_DATABASES_PER_NODE=100
+LBUG_DATABASES_PER_INSTANCE=10
 
 # Node configuration
 LBUG_NODE_TYPE=writer                    # writer, reader, shared_master

--- a/robosystems/graphql/README.md
+++ b/robosystems/graphql/README.md
@@ -10,7 +10,7 @@ POST /extensions/{graph_id}/graphql
 
 The endpoint is **graph-scoped at the URL level**. `graph_id` is a path parameter, not a query argument. Auth and per-graph access are validated by `get_context` before any resolver runs — resolvers read the graph id from `info.context["graph_id"]` via the `require_graph_id(info)` helper instead of taking it as a field argument. This avoids leaking a "wrong graph" failure mode where a client could pass a `graphId` argument that didn't match the URL.
 
-In dev, hitting the endpoint in a browser renders GraphiQL with introspection enabled. In staging/prod, introspection is still allowed (Strawberry default) but the CSP policy is tightened to block the playground UI.
+In dev, hitting the endpoint in a browser renders the GraphiQL playground with introspection enabled. In staging/prod the playground UI is not mounted (`graphql_ide=None` unless `env.is_development()`); introspection over the API itself is still allowed (Strawberry default).
 
 ## What lives here
 
@@ -22,11 +22,17 @@ robosystems/graphql/
 ├── resolvers/
 │   ├── _common.py         # Shared helpers (pagination guards, session opener)
 │   ├── information_block.py  # InformationBlockQuery — always-on (not feature-gated)
+│   ├── taxonomy_block.py  # TaxonomyBlockQuery — always-on (CoA / custom ontology / standards)
+│   ├── library.py         # LibraryQuery — always-on (taxonomy library browse)
 │   ├── ledger.py          # LedgerQuery — roboledger read fields (ROBOLEDGER_ENABLED)
 │   └── investor.py        # InvestorQuery — roboinvestor read fields (ROBOINVESTOR_ENABLED)
 └── types/
+    ├── _pydantic.py       # Shared pydantic→Strawberry derivation helpers
     ├── common.py          # PaginationInfo
     ├── information_block.py  # Strawberry types for InformationBlockEnvelope and its atoms
+    ├── taxonomy_block.py  # Strawberry types for the Taxonomy Block envelope
+    ├── library.py         # Strawberry types for the taxonomy library surface
+    ├── report_package.py  # Strawberry types for report package responses
     ├── ledger.py          # Strawberry types wrapping roboledger Pydantic response models
     └── investor.py        # Same for roboinvestor
 ```
@@ -78,7 +84,12 @@ Resolvers never contain business logic. The same `reads/*.py` modules are called
 ```python
 # graphql/schema.py
 def _build_query_type() -> type:
-    bases: tuple[type, ...] = (InformationBlockQuery, _BaseQuery)
+    bases: tuple[type, ...] = (
+        InformationBlockQuery,
+        TaxonomyBlockQuery,
+        LibraryQuery,
+        _BaseQuery,
+    )
     if env.ROBOLEDGER_ENABLED:
         bases = (LedgerQuery, *bases)
     if env.ROBOINVESTOR_ENABLED:
@@ -88,7 +99,7 @@ def _build_query_type() -> type:
 
 The `Query` root is built at class-construction time from whichever domain mixins are enabled. There are two composition patterns:
 
-**Always-on mixins** (`InformationBlockQuery`) are composed into `bases` unconditionally. They use `open_library_session` so they work on both the library sentinel (`graph_id='library'`) and any tenant graph — reads are driven by the session's `search_path`. The `informationBlock` / `informationBlocks` fields are always present in the schema regardless of which product flags are on.
+**Always-on mixins** (`InformationBlockQuery`, `TaxonomyBlockQuery`, `LibraryQuery`, plus the `_BaseQuery` probe) are composed into `bases` unconditionally. They work on both the library sentinel (`graph_id='library'`) and any tenant graph — reads are driven by the session's `search_path`. The `informationBlock` / `informationBlocks`, taxonomy-block, and library fields are always present in the schema regardless of which product flags are on.
 
 **Domain-gated mixins** (`LedgerQuery`, `InvestorQuery`) are guarded by feature flags. A ledger-only deployment:
 
@@ -98,7 +109,7 @@ The `Query` root is built at class-construction time from whichever domain mixin
 
 This is strictly better than the alternative ("expose everything, throw `INVESTOR_NOT_INITIALIZED` at runtime") because clients can branch on the actual schema shape rather than trial-and-error against runtime errors. The tradeoff is that introspection tooling sees a different schema per deployment. We don't publish a single SDL; the schema is composed dynamically per tenant feature-flag combination.
 
-Per-domain gating also short-circuits the router: if both flags are off, the FastAPI router that mounts `/extensions/{graph_id}/graphql` never mounts at all (see `main.py` line ~369).
+Per-domain gating also short-circuits the router: if both flags are off, the FastAPI router that mounts `/extensions/{graph_id}/graphql` never mounts at all. The mount is gated on `EXTENSIONS_GRAPHQL_ENABLED AND (ROBOLEDGER_ENABLED OR ROBOINVESTOR_ENABLED)` where the app wires up `GraphQLRouter` (the application factory in `main.py`); the flags themselves are defined in `config/env.py`.
 
 **Rule for new resolvers**: if the read is domain-specific (roboledger data, roboinvestor data), gate it behind the appropriate flag by adding the method to `LedgerQuery` or `InvestorQuery`. If the read is cross-domain or must be available regardless of which product domains are on, add it to `InformationBlockQuery` (or a new always-on mixin) and compose it into `bases` without a flag guard.
 

--- a/robosystems/middleware/auth/README.md
+++ b/robosystems/middleware/auth/README.md
@@ -1,31 +1,36 @@
 # Authentication Middleware
 
-This middleware provides comprehensive authentication, authorization, and rate limiting for the RoboSystems platform.
+This middleware provides authentication and authorization for the RoboSystems platform.
 
 ## Overview
 
 The authentication middleware:
 
 - Handles JWT token and API key authentication
-- Implements sophisticated caching for performance
-- Provides credit-based and subscription-based rate limiting
+- Implements caching (Valkey) for performance
 - Manages multi-tenant graph access control
 - Supports Single Sign-On (SSO) across RoboSystems applications
+- Provides admin authentication via AWS Secrets Manager
+
+Rate limiting is a separate concern and lives in
+[`middleware/rate_limits/`](/robosystems/middleware/rate_limits/) — this
+package re-exports two rate-limit dependencies (`graph_scoped_rate_limit_dependency`,
+`subscription_aware_rate_limit_dependency`) for convenience but does not
+implement them.
 
 ## Architecture
 
 ```
 auth/
 ├── __init__.py                  # Module exports
-├── dependencies.py              # FastAPI dependency injection
-├── utils.py                     # Authentication utilities
-├── cache.py                     # Redis/Valkey caching layer
+├── dependencies.py              # FastAPI dependency injection (get_current_user, etc.)
+├── jwt.py                       # JWT create/verify/revoke + SSO token helpers
+├── utils.py                     # API key validation utilities
+├── admin.py                     # AdminAuthMiddleware (AWS Secrets Manager admin key)
+├── cache.py                     # Valkey caching layer (API key + JWT user data)
 ├── cache_validator.py           # Cache validation and refresh
-├── rate_limiting.py             # Rate limiting middleware
-├── credit_rate_limiting.py      # Credit-based rate limiting
-├── subscription_rate_limits.py  # Subscription tier limits
 ├── distributed_lock.py          # Distributed locking for cache
-└── maintenance.py               # Maintenance mode handling
+└── maintenance.py               # API key expiry cleanup functions
 ```
 
 ## Authentication Methods
@@ -36,25 +41,26 @@ Used by frontend applications for user sessions.
 
 **Features:**
 
-- **Storage**: HTTP-only, Secure, SameSite cookies
-- **Cookie Name**: `auth-token`
 - **Algorithm**: HS256
-- **Expiration**: 30 days with auto-refresh
-- **Blacklist Support**: Tokens can be revoked
+- **Expiration**: 30 minutes (`JWT_EXPIRY_HOURS = 0.5` in `config/constants.py`); short-lived access tokens with a refresh flow
+- **Claims**: `user_id`, `jti` (for revocation), `session_version`, `iss`, `aud`, optional `device_hash`
+- **Revocation**: Tokens can be revoked by `jti` (Valkey-backed revocation list with a short refresh grace period)
 
-**Cookie Configuration:**
+The token is created in `jwt.py:create_jwt_token()`:
 
 ```python
-response.set_cookie(
-    key="auth-token",
-    value=token,
-    httponly=True,
-    secure=True,  # HTTPS only
-    samesite="lax",
-    max_age=30 * 24 * 60 * 60,  # 30 days
-    domain=".robosystems.ai"  # Cross-subdomain
-)
+payload = {
+    "user_id": user_id,
+    "jti": jti,                  # JWT ID for revocation tracking
+    "session_version": ...,
+    "exp": datetime.now(UTC) + timedelta(hours=JWT_EXPIRY_HOURS),  # 30 minutes
+    "iat": datetime.now(UTC),
+    "iss": env.JWT_ISSUER,
+    "aud": env.JWT_AUDIENCE,
+}
 ```
+
+Auth routers return the token in the response body (e.g. `expires_in = int(JWT_EXPIRY_HOURS * 3600)`); cookie-based delivery (cookie name `auth-token`) is a frontend concern and is read back by the rate-limit and SSO layers.
 
 ### 2. API Key Authentication
 
@@ -63,16 +69,16 @@ Used for programmatic access and integrations.
 **Features:**
 
 - **Header**: `X-API-Key`
-- **Format**: `rfs[32 random characters]`
-- **Storage**: SHA-256 hashed in database
-- **Graph Scoping**: Keys can be limited to specific graphs
+- **Format**: `rfs` prefix + 64 lowercase hex characters (regex `^rfs[0-9a-f]{64}$`, 67 chars total) — see `utils.py:_API_KEY_FORMAT_RE`
+- **Storage**: bcrypt-hashed in database; SHA-256 of the raw key is used as the cache lookup key
+- **Graph Scoping**: Access is validated per graph via `validate_api_key_with_graph`
 - **Activity Tracking**: Last used timestamp
 
 **Example:**
 
 ```bash
-curl -H "X-API-Key: rfs*" \
-     https://api.robosystems.ai/v1/kg1a2b3c/data
+curl -H "X-API-Key: rfs..." \
+     https://api.robosystems.ai/v1/graphs/kg1a2b3c/...
 ```
 
 ### 3. Single Sign-On (SSO)
@@ -81,9 +87,9 @@ Seamless authentication across RoboSystems applications.
 
 **Flow:**
 
-1. Generate SSO token (60-second TTL)
-2. Exchange token for session
-3. Complete handoff with cookie
+1. Generate SSO token (300-second / 5-minute TTL — `jwt.py:create_sso_token`)
+2. Exchange token for session (single-use, tracked by `token_id`)
+3. Complete handoff
 
 **Supported Applications:**
 
@@ -142,133 +148,34 @@ async def get_graph_data(
 
 ### 2. Authentication Cache (`cache.py`)
 
-High-performance caching using Redis/Valkey.
+Caching using Valkey. The raw API key is never used as a cache key — its
+SHA-256 hash is. Caches both positive and negative results.
 
 **Cache Types:**
 
-#### API Key Cache
+- **API key validation**: hashed-key → user data + `is_active` flag
+- **Graph access**: (hashed-key, graph_id) → boolean access result
+- **JWT user data**: user_id → user data, keyed alongside `session_version` so a
+  session bump invalidates cached JWT users
+- **JWT graph access**: (user_id, graph_id) → boolean access result
 
-- **TTL**: 5 minutes
-- **Key Format**: `api_key:{key_prefix}`
-- **Invalidation**: On key update/deletion
+JWT revocation is tracked separately in Valkey by `jti`
+(`revoked_jwt:{jti}`) with a TTL equal to the token's remaining lifetime
+(see `jwt.py:revoke_jwt_token`).
 
-#### JWT Cache
+### 3. Rate Limiting
 
-- **TTL**: 30 minutes
-- **Key Format**: `jwt:{user_id}`
-- **Blacklist**: `jwt_blacklist:{user_id}`
+Rate limiting is **not** implemented in this package. It lives in
+[`middleware/rate_limits/`](/robosystems/middleware/rate_limits/) —
+burst-focused, subscription-tier-aware limiting with per-tier buckets
+(`ladybug-standard`, `ladybug-large`, `ladybug-xlarge`). The auth
+`__init__.py` re-exports `graph_scoped_rate_limit_dependency` and
+`subscription_aware_rate_limit_dependency` for convenience. See that
+package's source and `config/rate_limits.py` for the actual limits and
+the credit model (only AI operations consume credits; storage is a
+separate credit line; database operations are free).
 
-#### User Session Cache
-
-- **TTL**: 24 hours
-- **Key Format**: `user_session:{user_id}`
-- **Content**: User profile, permissions, limits
-
-**Cache Operations:**
-
-```python
-cache = APIKeyCache()
-
-# Cache API key validation
-await cache.cache_api_key_user(
-    api_key="rbs_xxx",
-    user_id="user_123",
-    user_data={"email": "user@example.com"}
-)
-
-# Get cached user
-user_data = await cache.get_cached_api_key_user("rbs_xxx")
-
-# Invalidate on changes
-await cache.invalidate_user_cache("user_123")
-```
-
-### 3. Rate Limiting (`rate_limiting.py`)
-
-Sliding window rate limiting with Redis backend.
-
-**Default Limits:**
-
-```python
-RATE_LIMITS = {
-    "api_key": 10000,      # per hour
-    "jwt": 1000,           # per hour
-    "anonymous": 100,      # per hour
-    "login": 5,            # per 15 minutes
-    "register": 3,         # per 15 minutes
-}
-```
-
-**Headers Returned:**
-
-- `X-RateLimit-Limit`: Request limit
-- `X-RateLimit-Remaining`: Requests remaining
-- `X-RateLimit-Reset`: Reset timestamp
-
-**Usage:**
-
-```python
-limiter = RateLimitMiddleware()
-
-# Check rate limit
-allowed = await limiter.check_rate_limit(
-    key="user_123",
-    limit=1000,
-    window=3600
-)
-
-if not allowed:
-    raise HTTPException(429, "Rate limit exceeded")
-```
-
-### 4. Credit-Based Rate Limiting (`credit_rate_limiting.py`)
-
-Integrates with the credit system for usage-based limiting.
-
-**Features:**
-
-- **Credit Deduction**: Automatically deducts credits
-- **Pre-flight Checks**: Validates credits before operations
-- **Graceful Degradation**: Returns 402 when credits exhausted
-
-**Credit Costs by Operation:**
-
-```python
-OPERATION_CREDITS = {
-    "api_call": 1,
-    "query": 10,
-    "analytics": 25,
-    "ai_operation": 100,
-}
-```
-
-### 5. Subscription Rate Limits (`subscription_rate_limits.py`)
-
-Tier-based rate limiting.
-
-**Tiers:**
-
-```python
-SUBSCRIPTION_LIMITS = {
-    "standard": {
-        "requests_per_hour": 1000,
-        "queries_per_hour": 100,
-        "ai_calls_per_day": 50,
-    },
-    "enterprise": {
-        "requests_per_hour": 10000,
-        "queries_per_hour": 1000,
-        "ai_calls_per_day": 500,
-    },
-    "premium": {
-        "requests_per_hour": None,  # Unlimited
-        "queries_per_hour": None,
-        "ai_calls_per_day": None,
-    }
-}
-```
-
-### 6. Cache Validator (`cache_validator.py`)
+### 4. Cache Validator (`cache_validator.py`)
 
 Ensures cache consistency with database.
 
@@ -285,30 +192,29 @@ Ensures cache consistency with database.
 3. Update if different
 4. Track validation metrics
 
-### 7. Distributed Lock (`distributed_lock.py`)
+### 5. Distributed Lock (`distributed_lock.py`)
 
-Prevents cache stampedes and race conditions.
-
-**Usage:**
+Prevents cache stampedes and race conditions using a Valkey-backed lock.
 
 ```python
-lock = DistributedLock(redis_client)
-
 async with lock.acquire("user_update:123", timeout=5):
     # Critical section
     await update_user_cache()
     await update_database()
 ```
 
-### 8. Maintenance Mode (`maintenance.py`)
+### 6. Admin Authentication (`admin.py`)
 
-Handles system maintenance gracefully.
+`AdminAuthMiddleware` authenticates admin requests using a bearer token
+compared (constant-time) against the admin key stored in AWS Secrets
+Manager. Exposed via the `admin_auth` singleton and the `require_admin`
+decorator. Distinct from the user-facing API key / JWT flow.
 
-**Features:**
+### 7. API Key Maintenance (`maintenance.py`)
 
-- **Selective Access**: Admin users can still access
-- **Custom Messages**: Configurable maintenance messages
-- **Scheduled Maintenance**: Set start/end times
+Cleanup helpers (not request middleware): `cleanup_expired_api_keys`
+deactivates API keys past their `expires_at`, and `cleanup_jwt_cache_expired`
+reports JWT cache stats (JWT cache expiry is automatic via Valkey TTL).
 
 ## Security Features
 
@@ -321,14 +227,14 @@ Handles system maintenance gracefully.
 ### Token Security
 
 - **JWT Secret**: Strong random key (minimum 32 bytes)
-- **Rotation**: Automatic token refresh every 10 minutes
-- **Revocation**: Immediate blacklisting on logout
+- **Short-lived access tokens**: 30-minute expiry with a refresh flow
+- **Revocation**: Per-`jti` revocation list in Valkey, applied immediately on logout (with a short refresh grace window)
 
 ### API Key Security
 
-- **Generation**: Cryptographically secure (32 bytes)
-- **Prefix**: Identifiable prefix for key type
-- **Hashing**: SHA-256 before storage
+- **Generation**: Cryptographically secure (`secrets.token_hex`, 64 hex chars)
+- **Prefix**: `rfs` prefix identifies the key type
+- **Hashing**: bcrypt-hashed in the database (SHA-256 used only as the cache lookup key)
 - **Rotation**: Support for key rotation
 
 ### Multi-Tenant Security
@@ -345,97 +251,50 @@ Handles system maintenance gracefully.
 ```bash
 # JWT Configuration
 JWT_SECRET_KEY=your-secret-key-minimum-32-bytes
-JWT_ALGORITHM=HS256
-JWT_EXPIRATION_DAYS=30
+JWT_ISSUER=...
+JWT_AUDIENCE=...
+# Token lifetime is JWT_EXPIRY_HOURS in config/constants.py (0.5 = 30 min);
+# it is a constant, not an env var.
 
-# API Key Configuration
-API_KEY_PREFIX=rbs_
-API_KEY_LENGTH=32
-
-# Redis/Valkey Cache
+# Valkey Cache
 VALKEY_URL=redis://localhost:6379
-API_KEY_CACHE_TTL=300
-JWT_CACHE_TTL=1800
-USER_SESSION_CACHE_TTL=86400
 
-# Rate Limiting
+# Rate limiting (configured in middleware/rate_limits/ + config/rate_limits.py)
 RATE_LIMIT_ENABLED=true
-RATE_LIMIT_REDIS_DB=3
-RATE_LIMIT_WINDOW=3600
-
-# SSO Configuration
-SSO_TOKEN_TTL=60
-SSO_SESSION_TTL=300
 ```
 
-### Optional Configuration
-
-```bash
-# Security
-PASSWORD_MIN_LENGTH=8
-PASSWORD_REQUIRE_SPECIAL=true
-PASSWORD_REQUIRE_NUMBERS=true
-MAX_LOGIN_ATTEMPTS=5
-LOCKOUT_DURATION=900
-
-# Performance
-CACHE_WARM_ON_STARTUP=true
-CACHE_BATCH_SIZE=100
-DISTRIBUTED_LOCK_TIMEOUT=5
-
-# Development
-AUTH_DEBUG_MODE=false
-BYPASS_AUTH_ENDPOINTS=[]
-```
+Cache TTLs and Valkey database allocations are managed centrally
+(`config/valkey_registry.py`) rather than via standalone env vars.
 
 ## Integration Examples
 
-### FastAPI Application Setup
-
-```python
-from fastapi import FastAPI
-from robosystems.middleware.auth import (
-    AuthenticationMiddleware,
-    RateLimitMiddleware,
-    MaintenanceMiddleware
-)
-
-app = FastAPI()
-
-# Add middleware in order
-app.add_middleware(MaintenanceMiddleware)
-app.add_middleware(RateLimitMiddleware)
-app.add_middleware(AuthenticationMiddleware)
-```
+This package exposes FastAPI **dependencies**, not ASGI middleware classes.
+Protect endpoints by declaring the dependency in the route signature.
 
 ### Protected Endpoint
 
 ```python
-from robosystems.middleware.auth.dependencies import (
-    get_current_user,
-    require_graph_access
-)
+from robosystems.middleware.auth.dependencies import get_current_user_with_graph
 
 @router.post("/v1/graphs/{graph_id}/expensive-operation")
 async def expensive_operation(
     graph_id: str,
-    user: User = Depends(get_current_user),
-    graph_access = Depends(require_graph_access)
+    user: User = Depends(get_current_user_with_graph),
 ):
-    # User is authenticated and has access to graph
+    # get_current_user_with_graph authenticates AND validates that the
+    # user has access to {graph_id} (the graph_id path param is read by
+    # the dependency). Returns the authenticated User.
     return {"status": "success"}
 ```
 
-### Custom Rate Limiting
+For shared repositories (SEC, etc.) use `get_current_user_with_repository_access`
+or the `get_repository_user_dependency(repository_id, operation_type)` factory.
 
-```python
-from robosystems.middleware.auth.decorators import rate_limit
+### Rate Limiting
 
-@router.get("/api/search")
-@rate_limit(calls=10, period=60)  # 10 calls per minute
-async def search(query: str):
-    return {"results": [...]}
-```
+Rate limiting is applied via dependencies from `middleware/rate_limits/`
+(e.g. `subscription_aware_rate_limit_dependency`,
+`graph_scoped_rate_limit_dependency`), not via decorators in this package.
 
 ## Monitoring
 
@@ -455,30 +314,18 @@ async def search(query: str):
    - Validation frequency
    - Lock contention
 
-3. **Rate Limit Metrics**
-
-   - Limit exceeded events
-   - Usage by tier
-   - Burst patterns
-   - Credit exhaustion
-
-4. **Security Metrics**
+3. **Security Metrics**
    - Failed authentication attempts
    - Suspicious activity patterns
-   - Token blacklist size
+   - JWT revocation list size
    - Permission changes
+
+(Rate-limit metrics are emitted by `middleware/rate_limits/`.)
 
 ### Health Checks
 
-```python
-@router.get("/health/auth")
-async def auth_health():
-    return {
-        "cache": await check_cache_health(),
-        "rate_limiter": await check_rate_limiter_health(),
-        "database": await check_auth_db_health(),
-    }
-```
+Platform health is exposed at `GET /v1/status` (not a per-subsystem
+`/health/auth` endpoint).
 
 ## Troubleshooting
 
@@ -487,22 +334,14 @@ async def auth_health():
 1. **"Invalid token" Errors**
 
    ```bash
-   # Check if token is blacklisted
-   redis-cli -n 2 GET "jwt_blacklist:user_xxx"
-
-   # Clear user cache
-   redis-cli -n 2 DEL "jwt:user_xxx"
+   # Check if a token's jti has been revoked (key: revoked_jwt:{jti})
+   just admin dev cache keys auth --pattern "revoked_jwt:*"
    ```
 
 2. **Rate Limit Issues**
 
-   ```bash
-   # Check current usage
-   redis-cli -n 3 GET "rate_limit:user:123"
-
-   # Reset rate limit (emergency)
-   redis-cli -n 3 DEL "rate_limit:user:123"
-   ```
+   See `middleware/rate_limits/` and `config/rate_limits.py`; inspect
+   rate-limit keys via `just admin dev cache info`.
 
 3. **Cache Inconsistency**
 
@@ -516,13 +355,8 @@ async def auth_health():
 
 4. **SSO Failures**
 
-   ```bash
-   # Check SSO token
-   redis-cli GET "sso_token:xxx"
-
-   # Verify session
-   redis-cli GET "sso_session:xxx"
-   ```
+   SSO tokens are single-use JWTs (5-minute TTL) tracked by `token_id`.
+   Inspect single-use tracking keys via `just admin dev cache info auth`.
 
 ## Best Practices
 
@@ -530,25 +364,19 @@ async def auth_health():
 
    - Rotate JWT secrets regularly
    - Monitor failed authentication attempts
-   - Implement IP-based blocking for attackers
-   - Use secure cookie settings in production
+   - Use secure cookie settings in the frontend
 
 2. **Performance**
 
-   - Enable caching for all authentication checks
-   - Use connection pooling for Redis
-   - Implement cache warming for hot users
+   - Rely on the Valkey cache for authentication checks
    - Monitor cache hit rates
 
 3. **Reliability**
 
-   - Implement circuit breakers for cache
    - Have fallback authentication paths
-   - Monitor rate limit effectiveness
    - Test failover scenarios
 
 4. **Maintenance**
-   - Regular cache cleanup
-   - Monitor blacklist size
-   - Review rate limit settings
+   - Run periodic API key cleanup (`maintenance.py`)
+   - Monitor the JWT revocation list size
    - Audit authentication logs

--- a/robosystems/middleware/billing/README.md
+++ b/robosystems/middleware/billing/README.md
@@ -27,9 +27,9 @@ credits/
 The platform uses a simplified credit model focused exclusively on AI operations:
 
 1. Users receive monthly AI credit allocations based on their tier
-2. ONLY AI operations (Anthropic/OpenAI) consume credits based on actual token usage
+2. ONLY AI operations (Anthropic via Bedrock) consume credits based on actual token usage
 3. All database operations are included (queries, imports, backups, etc.)
-4. Storage is billed separately in USD (not credits) for overages
+4. Storage is included per tier up to a limit; overages are not billed today (no credit or USD metering path exists in code)
 5. AI operations are blocked when credits are exhausted
 
 ### Subscription Tiers (AI Credits)
@@ -111,8 +111,8 @@ INCLUDED_OPERATIONS = [
 
 ```python
 # No multipliers in the simplified model
-# AI operations use actual token counts
-# Storage has fixed per-GB pricing per tier
+# AI operations use actual token counts (minimum charge of 1 credit applied)
+# Storage is included per tier up to a limit (not metered to a charge today)
 # All database operations are included
 ```
 
@@ -141,20 +141,18 @@ from robosystems.operations.graph import CreditService
 router = APIRouter()
 
 @router.post("/v1/graphs/{graph_id}/operator")
-async def agent_endpoint(
+async def operator_endpoint(
     graph_id: str,
     request: OperatorRequest,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db_session)
 ):
-    # Initialize agent
-    agent = FinancialAgent(graph_id, db)
-    
-    # Execute agent (tracks tokens internally)
-    response = await agent.process(request)
-    
-    # Agent automatically consumes credits based on actual tokens
-    # No decorator needed - consumption happens post-operation
+    # The operator orchestrator selects and runs the AI Operator.
+    orchestrator = OperatorOrchestrator(graph_id, db)
+    response = await orchestrator.execute(request)
+
+    # The operator consumes credits post-operation based on actual tokens
+    # (CreditService.consume_ai_tokens). No decorator needed.
     return response
 ```
 
@@ -185,31 +183,37 @@ credit_service.consume_ai_tokens(
     graph_id="kg1a2b3c",
     input_tokens=usage.input_tokens,
     output_tokens=usage.output_tokens,
-    model="anthropic_claude_4_sonnet",
-    operation_type="agent_call",
-    user_id="user_456"
+    model="us.anthropic.claude-sonnet-4-6",  # Bedrock model id
+    operation_description="operator query",
+    user_id="user_456",
 )
 ```
 
-### 4. Storage Overage Handling
+`consume_ai_tokens` takes `operation_description` (a free-text label for the
+transaction), not an `operation_type`. The `model` argument accepts the Bedrock
+profile id (e.g. `us.anthropic.claude-sonnet-4-6`) and is mapped internally to
+the pricing key `anthropic_claude_4_sonnet` in `AIBillingConfig.TOKEN_PRICING`.
 
-```python
-# Storage overages are billed in USD, NOT credits.
-# Credits are AI-only; storage is metered separately by the billing system.
-# Each tier includes storage:
-# - Standard: 10 GB included
-# - Large:    50 GB included
-# - XLarge:   100 GB included
+### 4. Storage Handling
 
-# Monthly storage billing (handled by billing system, billed in USD)
-storage_gb = calculate_storage_usage(graph_id)
-limit_gb = get_storage_limit_for_tier(tier)
+Storage is **included with each tier up to a per-tier limit** and is **not
+billed as an overage today** — not in credits and not in USD. There is no live
+storage metering-to-billing path in the code: the only storage logic is
+limit enforcement.
 
-if storage_gb > limit_gb:
-    overage_gb = storage_gb - limit_gb
-    overage_cost_usd = overage_gb * overage_rate_for_tier(tier)
-    # Billed directly in USD, not credits
-```
+- `CreditService.check_storage_limit()` reports current usage against the
+  graph's `storage_limit_gb` (with an optional admin override). It returns
+  status/recommendations; it does **not** consume credits or compute a charge.
+- A `STORAGE_CREDITS_PER_GB_PER_DAY` constant exists in `config/constants.py`
+  but is currently unreferenced (no code consumes it) — storage credit metering
+  is not implemented.
+- `consume_ai_tokens` is the only credit-consuming entry point; its inline note
+  reads "Storage is included in each tier (no metering/overage)."
+
+The "all database operations are free" guarantee is unaffected: only AI token
+usage consumes credits. If usage-based storage billing is added later, it would
+introduce a new consumption path here; until then, exceeding the limit is a
+gating/limit concern, not a billed event.
 
 ## Monitoring
 

--- a/robosystems/middleware/billing/README.md
+++ b/robosystems/middleware/billing/README.md
@@ -204,9 +204,8 @@ limit enforcement.
 - `CreditService.check_storage_limit()` reports current usage against the
   graph's `storage_limit_gb` (with an optional admin override). It returns
   status/recommendations; it does **not** consume credits or compute a charge.
-- A `STORAGE_CREDITS_PER_GB_PER_DAY` constant exists in `config/constants.py`
-  but is currently unreferenced (no code consumes it) — storage credit metering
-  is not implemented.
+- There is no storage pricing constant or metering code in the billing path —
+  storage credit metering is not implemented.
 - `consume_ai_tokens` is the only credit-consuming entry point; its inline note
   reads "Storage is included in each tier (no metering/overage)."
 

--- a/robosystems/middleware/graph/README.md
+++ b/robosystems/middleware/graph/README.md
@@ -32,18 +32,23 @@ The middleware layer sits above the core services, providing routing, orchestrat
 ```
 middleware/graph/                         # Middleware layer (this module)
 ├── __init__.py                          # Module exports
-├── router.py                            # Main routing logic
-├── clusters.py                          # Cluster configuration and management
-├── repository.py                        # Repository pattern implementation
-├── dependencies.py                      # FastAPI dependency injection
-├── types.py                             # Type definitions and enums
-├── base.py                              # Base classes and interfaces
-├── query_queue.py                       # Query queue with admission control
+├── router.py                            # GraphRouter — main routing logic
+├── repository.py                        # UniversalRepository wrapper (sync/async unification)
+├── base.py                              # Base abstractions (GraphEngineInterface, GraphOperation)
+├── types.py                             # Type definitions, enums, graph-id helpers
+├── query_queue.py                       # QueryQueueManager — admission control + long polling
 ├── admission_control.py                 # System resource monitoring
-├── schema_installer.py                  # Schema installation utilities
+├── execution_strategies.py             # Strategy selection (query vs MCP, load-aware)
+├── ingestion_limits.py                 # Tier storage caps / materialization write-path limits
+├── instance_busy.py                    # DynamoDB busy counter for destructive ops
+├── streaming_wrapper.py                # Streaming query support for Graph API clients
 ├── allocation_manager.py                # DynamoDB-based database allocation
-├── multitenant_utils.py                 # Multi-tenant utilities and validation
-└── utils/                               # Utility modules
+├── dependencies/                        # FastAPI dependency injection
+│   ├── auth.py                         # Auth-checked repository/database dependencies
+│   ├── repositories.py                 # Repository dependencies
+│   └── helpers.py                      # require_entity / require_user_graph / etc.
+└── utils/                               # Utility modules (MultiTenantUtils lives here)
+    ├── __init__.py                     # MultiTenantUtils class
     ├── validation.py                    # Input validation
     ├── database.py                      # Database resolution
     ├── identity.py                      # Graph identity management
@@ -90,42 +95,33 @@ The central routing component that determines where graph operations should be e
 
 ```python
 router = GraphRouter()
-repo = router.get_repository(
+repo = await router.get_repository(   # get_repository is async
     graph_id="kg1a2b3c",
     operation_type="write",
-    tier=GraphTier.LBUG_STANDARD
+    tier=GraphTier.LADYBUG_STANDARD,
 )
 result = await repo.execute_query("MATCH (n) RETURN n LIMIT 10")
 ```
 
-### 2. Cluster Management (`clusters.py`)
+`GraphRouter.get_repository()` delegates routing to
+`graph_api.client.factory.GraphClientFactory` (or returns a direct-file
+`Repository` when `LBUG_ACCESS_PATTERN=direct_file`).
 
-Defines cluster configurations and node types.
+### 2. Graph Type Definitions (`types.py`)
 
-**Node Types:**
+`types.py` is the canonical source for graph-routing enums and graph-id
+helpers (there is no separate `clusters.py`).
 
-- `NodeType.WRITER`: Entity database writers
-- `NodeType.SHARED_MASTER`: Shared repository master (e.g., SEC)
-- `NodeType.SHARED_REPLICA`: Read-only replicas for shared data
+**Enums:**
 
-**Repository Types:**
+- `NodeType`: node roles (e.g. writer / shared master / shared replica)
+- `RepositoryType`: entity vs shared repository
+- `GraphCategory`: `USER`, `SHARED`, `SYSTEM`
+- `AccessPattern`: `READ_ONLY`, `READ_WRITE`, `RESTRICTED`
+- `ConnectionPattern`: connection routing strategy
 
-- `RepositoryType.ENTITY`: User/entity-specific graphs
-- `RepositoryType.SHARED`: Shared repositories (SEC, industry, etc.)
-
-**Cluster Configuration:**
-
-```python
-@dataclass
-class ClusterConfig:
-    cluster_id: str
-    repository_type: RepositoryType
-    writer_node: NodeConfig
-    reader_nodes: List[NodeConfig]
-    alb_endpoint: Optional[str]
-    region: str
-    tier: InstanceTier
-```
+Graph tiers (`LADYBUG_STANDARD`, `LADYBUG_LARGE`, `LADYBUG_XLARGE`) come
+from `config/graph_tier.py:GraphTier`, re-exported by this package.
 
 ### 3. Core Services Integration
 
@@ -146,7 +142,7 @@ The middleware integrates with the core services layer for database access.
 ```python
 # Via middleware routing (recommended)
 router = GraphRouter()
-repo = router.get_repository("kg1a2b3c")
+repo = await router.get_repository("kg1a2b3c")
 result = await repo.execute_query("MATCH (c:Entity) RETURN c")
 
 # Direct core service access (when needed)
@@ -161,30 +157,37 @@ response = await service.execute_query(QueryRequest(
 
 See the [Core Services README](/robosystems/graph_api/core/README.md) for detailed documentation.
 
-### 4. Repository Pattern (`repository.py`)
+### 4. Repository Wrapper (`repository.py`)
 
-Provides a unified interface for graph operations.
+`UniversalRepository` wraps either a direct `Repository` or a Graph API
+`GraphClient` and exposes a unified async (and sync) interface so callers
+don't branch on the underlying type.
 
 **Features:**
 
-- **Abstraction Layer**: Hides implementation details
-- **Async Support**: Full async/await support
-- **Error Handling**: Consistent error handling
-- **Metrics Collection**: Automatic performance tracking
+- **Unification**: Same interface for sync direct repos and async API clients
+- **Async + sync methods**: `execute_query` / `execute_query_sync`, etc.
+- **Streaming**: `execute_query_streaming`
+- **Context managers**: both `async with` and `with`
 
-**Interface:**
+**Selected methods:**
 
 ```python
-class Repository(Protocol):
-    async def execute_query(self, query: str) -> List[Dict[str, Any]]
-    async def execute_transaction(self, queries: List[str]) -> bool
-    async def get_schema(self) -> Dict[str, Any]
-    async def health_check(self) -> Dict[str, Any]
+class UniversalRepository:
+    async def execute_query(self, cypher, parameters=None, ...) -> Any
+    async def execute_query_streaming(self, cypher, ...) -> Any
+    async def execute_transaction(self, queries) -> Any
+    async def get_schema(self) -> list[dict[str, Any]]
+    async def health_check(self) -> dict[str, Any]
+    async def close(self) -> None
 ```
+
+Construct via `create_universal_repository(...)` /
+`get_universal_repository(...)` rather than instantiating directly.
 
 ### 5. Query Queue with Admission Control (`query_queue.py`)
 
-Advanced query queue with admission control and long polling.
+`QueryQueueManager` provides admission control and long polling.
 
 **Features:**
 
@@ -194,25 +197,20 @@ Advanced query queue with admission control and long polling.
 - **Long Polling**: Efficient result waiting
 - **Transparent Queuing**: Executes immediately when capacity available
 
-**Configuration:**
-
-```python
-QUERY_QUEUE_MAX_SIZE = 1000          # Max queries in queue
-QUERY_QUEUE_MAX_CONCURRENT = 50      # Max simultaneous executions
-ADMISSION_MEMORY_THRESHOLD = 85      # Memory usage limit (%)
-ADMISSION_CPU_THRESHOLD = 90         # CPU usage limit (%)
-```
-
 **Usage:**
 
 ```python
-queue = QueryQueue()
+from robosystems.middleware.graph.query_queue import get_query_queue
+
+queue = get_query_queue()
 query_id = await queue.submit_query(
     graph_id="kg1a2b3c",
     query="MATCH (n) RETURN n",
-    priority=5
+    priority=5,
 )
-result = await queue.get_result(query_id, timeout=30)
+# Poll status, then fetch the result:
+status = await queue.get_query_status(query_id)
+result = await queue.get_query_result(query_id)
 ```
 
 ### 6. Admission Control (`admission_control.py`)
@@ -233,44 +231,41 @@ Monitors system resources and controls admission.
 3. Apply probabilistic rejection based on load
 4. Track rejection metrics
 
-### 7. FastAPI Dependencies (`dependencies.py`)
+### 7. FastAPI Dependencies (`dependencies/`)
 
-Dependency injection for FastAPI routes.
+Dependency injection for FastAPI routes lives in the `dependencies/`
+package (`auth.py`, `repositories.py`, `helpers.py`), exported from
+`dependencies/__init__.py`.
 
-**Provided Dependencies:**
+**Provided Dependencies (selected):**
 
-- `get_graph_repository`: Returns repository for graph operations
-- `get_query_queue`: Returns query queue instance
-- `validate_graph_access`: Validates user access to graph
-- `track_credits`: Tracks credit consumption
-
-**Usage:**
+- `get_graph_database`: Resolves + auth-checks the graph for the request
+- `get_graph_repository_with_auth` / `get_universal_repository_with_auth`: Auth-checked repository
+- `get_user_graph_repository` / `get_shared_repository` / `get_main_repository`: Repository by graph kind
+- `get_graph_repository_dependency`: Generic repository dependency
+- `require_entity` / `require_user_graph` / `require_graph_category` (+ `optional_*` variants): Path-param helpers
 
 ```python
-@router.post("/query")
+from robosystems.middleware.graph.dependencies import get_graph_repository_with_auth
+
+@router.post("/v1/graphs/{graph_id}/query")
 async def execute_query(
-    repo: Repository = Depends(get_graph_repository),
-    credits: CreditTracker = Depends(track_credits)
+    repo = Depends(get_graph_repository_with_auth),
 ):
-    result = await repo.execute_query(query)
-    await credits.consume("query", len(result))
-    return result
+    return await repo.execute_query(query)
 ```
 
 ### 8. Type Definitions (`types.py`)
 
-Core type definitions and enums.
-
-**Key Types:**
-
-- `GraphType`: Enum for graph types (ENTITY, SHARED_REPOSITORY)
-- `GraphTier`: Enum for graph tiers (LBUG_STANDARD, LBUG_LARGE, LBUG_XLARGE)
-- `OperationType`: Enum for operations (READ, WRITE, ADMIN)
-- `QueryPriority`: Priority levels (1-10)
+Core type definitions and enums (see §2 for the enum list). `types.py`
+also exposes graph-id helpers (`is_subgraph_id`, `parse_graph_id`,
+`construct_subgraph_id`) and the `GraphIdentity` / `GraphTypeRegistry`
+models. `GraphTier` is imported from `config/graph_tier.py`.
 
 ### 9. Database Allocation (`allocation_manager.py`)
 
-DynamoDB-based allocation manager for graph databases across instances (LadybugDB-specific).
+`LadybugAllocationManager` — DynamoDB-based allocation of graph databases
+across instances.
 
 **Features:**
 
@@ -284,22 +279,25 @@ DynamoDB-based allocation manager for graph databases across instances (LadybugD
 **Usage:**
 
 ```python
-from robosystems.middleware.graph.allocation_manager import LadybugDBAllocationManager
+from robosystems.middleware.graph.allocation_manager import LadybugAllocationManager
 from robosystems.config.graph_tier import GraphTier
 
-manager = LadybugDBAllocationManager(environment="prod")
+manager = LadybugAllocationManager(environment="prod")
 location = await manager.allocate_database(
     entity_id="kg1a2b3c",
-    instance_tier=GraphTier.LBUG_STANDARD
+    instance_tier=GraphTier.LADYBUG_STANDARD,
 )
 print(f"Database allocated to {location.instance_id}")
 ```
 
-### 10. Multi-tenant Utilities (`multitenant_utils.py`)
+### 10. Multi-tenant Utilities (`utils/`)
 
-Core utilities for multi-tenant database operations and validation.
+`MultiTenantUtils` (in `middleware/graph/utils/__init__.py`) aggregates
+static methods from the `utils/` submodules (`validation.py`,
+`database.py`, `identity.py`, `subgraph.py`) for multi-tenant database
+operations and validation.
 
-**Features:**
+**Capabilities:**
 
 - **Database Name Resolution**: Maps graph IDs to database names
 - **Access Pattern Management**: Determines routing strategies
@@ -310,7 +308,7 @@ Core utilities for multi-tenant database operations and validation.
 **Usage:**
 
 ```python
-from robosystems.middleware.graph.multitenant_utils import MultiTenantUtils
+from robosystems.middleware.graph.utils import MultiTenantUtils
 
 # Validate and get database name
 graph_id = MultiTenantUtils.validate_graph_id("kg1a2b3c")
@@ -351,10 +349,10 @@ subgraph_id = construct_subgraph_id("kg1234567890abcdef", "staging")
 
 **Allocation Manager Integration:**
 
-The `LadybugDBAllocationManager.find_database_location()` automatically resolves subgraphs to their parent's location:
+The `LadybugAllocationManager.find_database_location()` automatically resolves subgraphs to their parent's location:
 
 ```python
-manager = LadybugDBAllocationManager(environment="prod")
+manager = LadybugAllocationManager(environment="prod")
 
 # Requesting location for subgraph returns parent's instance location
 location = await manager.find_database_location("kg1234567890abcdef_dev")
@@ -418,7 +416,7 @@ MULTITENANT_MODE=true              # Enable multi-tenant database support
 from robosystems.middleware.graph import GraphRouter
 
 router = GraphRouter()
-repo = router.get_repository("kg1a2b3c")
+repo = await router.get_repository("kg1a2b3c")
 result = await repo.execute_query("MATCH (c:Entity) RETURN c")
 
 # Via core service (direct access when routing not needed)
@@ -435,21 +433,21 @@ response = await service.execute_query(QueryRequest(
 ### With Query Queue
 
 ```python
-from robosystems.middleware.graph import QueryQueue
+from robosystems.middleware.graph.query_queue import get_query_queue
 
-queue = QueryQueue()
+queue = get_query_queue()
 query_id = await queue.submit_query(
     graph_id="kg1a2b3c",
     query="MATCH (n) RETURN count(n)",
-    priority=8
+    priority=8,
 )
-result = await queue.wait_for_result(query_id)
+result = await queue.get_query_result(query_id)
 ```
 
 ### Transaction Execution
 
 ```python
-repo = router.get_repository("kg1a2b3c", operation_type="write")
+repo = await router.get_repository("kg1a2b3c", operation_type="write")
 success = await repo.execute_transaction([
     "CREATE (e:Entity {identifier: 'entity-123', name: 'New Corp'})",
     "CREATE (el:Element {uri: 'http://example.com/element/Cash', qname: 'Cash'})",
@@ -461,12 +459,15 @@ success = await repo.execute_transaction([
 
 ### 1. Credit System
 
-The middleware integrates with the credit system to track usage:
+Credit consumption is intentionally narrow:
 
-- **AI Operations**: Anthropic/OpenAI API calls consume credits (token-based billing)
-- **Database Operations**: All graph queries, imports, backups are FREE (included in subscription)
-- **Storage**: Optional billing mechanism (10 credits/GB/day)
-- Credit tracking happens at the middleware layer before queries reach core services
+- **AI Operations**: Anthropic/OpenAI API calls consume credits (token-based billing) — the only credit-consuming path
+- **Database Operations**: All graph queries, imports, backups are free (included in the subscription tier)
+- **Storage**: Currently limit-enforced, not metered into credits. A
+  `STORAGE_CREDITS_PER_GB_PER_DAY` constant exists in `config/constants.py`
+  but is unreferenced today (see `middleware/billing/README.md`); if
+  usage-based storage billing is added it would be a separate credit line,
+  independent of the AI compute path.
 
 ### 2. Authentication
 
@@ -544,7 +545,7 @@ Common issues and solutions:
 
 ### Configuration
 
-- **[Billing Plans](/robosystems/config/billing.py)** - Subscription tiers and features
+- **[Billing Plans](/robosystems/config/billing/core.py)** - Subscription tiers and features (the `config/billing/` package)
 - **[Rate Limiting](/robosystems/config/rate_limits.py)** - Burst-focused rate limiting
 - **[Graph Tier Configuration](/.github/configs/graph.yml)** - Infrastructure tier specifications
 

--- a/robosystems/middleware/graph/README.md
+++ b/robosystems/middleware/graph/README.md
@@ -204,8 +204,10 @@ from robosystems.middleware.graph.query_queue import get_query_queue
 
 queue = get_query_queue()
 query_id = await queue.submit_query(
+    cypher="MATCH (n) RETURN n",
+    parameters=None,
     graph_id="kg1a2b3c",
-    query="MATCH (n) RETURN n",
+    user_id="user_123",
     priority=5,
 )
 # Poll status, then fetch the result:
@@ -378,10 +380,10 @@ Key environment variables:
 
 ```bash
 # LadybugDB Configuration (core/ladybug/)
-LBUG_DATABASE_DIR=/data/lbug-dbs       # Database directory
-LBUG_MAX_DATABASES_PER_NODE=100        # Instance capacity
-LBUG_MAX_CONNECTIONS_PER_DB=10         # Connection pool size
-LBUG_ACCESS_PATTERN=api_writer         # Access pattern for routing
+LBUG_DATABASE_PATH=/data/lbug-dbs        # Database directory
+LBUG_DATABASES_PER_INSTANCE=10           # Instance capacity
+LBUG_CONNECTION_POOL_SIZE=10             # Connection pool size
+LBUG_ACCESS_PATTERN=api_writer           # Access pattern for routing
 GRAPH_API_URL=                         # Graph API endpoint (dynamic in prod)
 
 # DuckDB Staging Configuration (core/duckdb/)
@@ -437,8 +439,10 @@ from robosystems.middleware.graph.query_queue import get_query_queue
 
 queue = get_query_queue()
 query_id = await queue.submit_query(
+    cypher="MATCH (n) RETURN count(n)",
+    parameters=None,
     graph_id="kg1a2b3c",
-    query="MATCH (n) RETURN count(n)",
+    user_id="user_123",
     priority=8,
 )
 result = await queue.get_query_result(query_id)

--- a/robosystems/middleware/graph/README.md
+++ b/robosystems/middleware/graph/README.md
@@ -463,11 +463,9 @@ Credit consumption is intentionally narrow:
 
 - **AI Operations**: Anthropic/OpenAI API calls consume credits (token-based billing) — the only credit-consuming path
 - **Database Operations**: All graph queries, imports, backups are free (included in the subscription tier)
-- **Storage**: Currently limit-enforced, not metered into credits. A
-  `STORAGE_CREDITS_PER_GB_PER_DAY` constant exists in `config/constants.py`
-  but is unreferenced today (see `middleware/billing/README.md`); if
-  usage-based storage billing is added it would be a separate credit line,
-  independent of the AI compute path.
+- **Storage**: Currently limit-enforced, not metered into credits (see
+  `middleware/billing/README.md`); if usage-based storage billing is added it
+  would be a separate credit line, independent of the AI compute path.
 
 ### 2. Authentication
 

--- a/robosystems/middleware/graph/query_queue.py
+++ b/robosystems/middleware/graph/query_queue.py
@@ -134,7 +134,7 @@ class QueryQueueManager:
     parameters: dict[str, Any] | None,
     graph_id: str,
     user_id: str,
-    credits_required: float,
+    credits_required: float = 0,
     priority: int = 5,
   ) -> str:
     """
@@ -145,7 +145,7 @@ class QueryQueueManager:
         parameters: Query parameters
         graph_id: Target graph
         user_id: User submitting query
-        credits_required: Credits needed for query
+        credits_required: Credits to reserve (not enforced by the queue; default 0)
         priority: Query priority (1-10, higher = more important)
 
     Returns:

--- a/robosystems/middleware/mcp/README.md
+++ b/robosystems/middleware/mcp/README.md
@@ -15,7 +15,7 @@ The MCP middleware:
 - Enables workspace management for isolated development environments
 - Provides data operation tools for staging, querying, and graph materialization
 
-**Operations kernel integration.** MCP tools are a **transport layer**, not a domain. Tools that touch extension OLTP data (ledger schedules, period close, fiscal calendar, CoA→GAAP mapping, reports) delegate directly to the same `operations/roboledger/{reads,commands}/*` functions that the GraphQL resolvers and the named command operation routers call. A schedule created via `create-schedule` MCP tool goes through the exact same `commands/schedules.py` function as one created via `POST /extensions/roboledger/{g}/operations/create-schedule`. This is the single-source-of-truth contract that makes agent-driven workflows byte-identical to UI-driven workflows. Never add business logic to an MCP tool file — wire it into `operations/` and have the tool delegate.
+**Operations kernel integration.** MCP tools are a **transport layer**, not a domain. Tools that touch extension OLTP data (period close, fiscal calendar, CoA→GAAP mapping, information blocks, events) delegate directly to the same `operations/roboledger/{reads,commands}/*` functions that the GraphQL resolvers and the named command operation routers call. An information block created via the `create-information-block` MCP tool goes through the exact same operations function as one created via `POST /extensions/roboledger/{g}/operations/create-information-block`. This is the single-source-of-truth contract that makes agent-driven workflows byte-identical to UI-driven workflows. Never add business logic to an MCP tool file — wire it into `operations/` and have the tool delegate.
 
 ## Architecture
 
@@ -29,9 +29,10 @@ mcp/
 ├── exceptions.py            # MCP-specific exception classes
 └── tools/                   # MCP tool implementations
     ├── base_tool.py         # Base tool interface
+    ├── _gate.py             # Tool gating helpers
     ├── manager.py           # GraphMCPTools — layered tool registry and dispatcher
     ├── registrar.py         # Registry-driven tool generation (infra)
-    ├── constants.py         # Tool name constants
+    ├── constants.py         # Shared tool guidance constants
     │
     │ # Layer 1: Core tools (always available)
     ├── cypher_tool.py       # read-graph-cypher
@@ -47,25 +48,26 @@ mcp/
     │ # Layer 2b: Roboledger OLTP tools (delegate to operations/roboledger/*)
     ├── fiscal_calendar_tools.py    # get-fiscal-calendar, close-period, reopen-period
     ├── schedule_tools.py           # get-period-close-status, list-period-drafts
-    │                               # (create-schedule + siblings are registrar-
-    │                               # generated; schedule envelopes now surface via
-    │                               # information_block_tools)
+    │                               # (schedule envelopes surface via the generic
+    │                               # information_block_tools; there are no
+    │                               # create/update/delete-schedule tools)
     ├── information_block_tools.py  # get-information-block, list-information-blocks
     ├── event_block_tools.py        # get/list/create-event-block (REA business events)
     ├── event_handler_tools.py      # get/list-event-handler (DSL rule rows)
     ├── agent_tools.py              # get-agent, list-agents, agent-activity (REA Agent reads)
     ├── taxonomy_tools.py           # get-unmapped-elements, suggest-mapping,
     │                               # create-mapping-association, get-mapping-summary
+    ├── playbook_tools.py           # get-close-playbook (close-workflow guidance)
     ├── graph_tools.py              # create-subgraph, delete-subgraph, list-subgraphs,
-    │                               # materialize, create-backup, set-write-policy
-    ├── materialization_tools.py    # get-graph-sync-status, materialize-graph
+    │                               # materialize, get-graph-sync-status, create-backup,
+    │                               # set-write-policy, switch-workspace (client-side)
     │
     │ # Layer 3: Document search + management (SEMANTIC_SEARCH_ENABLED)
     ├── search_tools.py      # search-documents, get-document-section
     ├── document_tools.py    # create-document, update-document, get-document, list-documents
     │
     │ # Layer 4: Infrastructure (feature-flag gated)
-    ├── workspace.py         # create/delete/list/switch-workspace (MCP_WORKSPACE_ENABLED)
+    │ # (switch-workspace lives in graph_tools.py; it is a client-side tool)
     └── memory_tools.py      # write-graph-cypher, add-node-table, add-relationship-table (MCP_MEMORY_ENABLED)
 ```
 
@@ -121,17 +123,15 @@ Require `roboledger` in `schema_extensions`, `ROBOLEDGER_ENABLED=true`, the grap
 
 **Schedules (depreciation, amortization, accruals):**
 
-Schedule reads (list, get facts) moved to the generic Information Block
-surface — use `list-information-blocks` with `block_type="schedule"`
-and `get-information-block` instead. Schedule-specific writes stay
-registered for wire compatibility and operate through the unified
-envelope machine under the hood.
+Schedules are an Information Block `block_type`, not a separate tool
+family. There are **no** `create-schedule` / `update-schedule` /
+`delete-schedule` tools (no such OperationSpec is registered).
+
+- **Reads**: use `list-information-blocks` with `block_type="schedule"` and `get-information-block`.
+- **Writes**: use `create-information-block` (and `update-information-block` / `delete-information-block`) with `block_type="schedule"`.
 
 | Tool | Description | Delegates to |
 |------|-------------|--------------|
-| `create-schedule` | Create a schedule structure with pre-generated facts | `commands/schedules.create_schedule` |
-| `update-schedule` | Rename or edit schedule mechanics | `commands/schedules.update_schedule` |
-| `delete-schedule` | Remove a schedule | `commands/schedules.delete_schedule` |
 | `list-period-drafts` | List pending draft entries for a period — surfaces the QB-outbox disposition (`will_publish_to_qb` per draft + `qb_publish_count` / `local_only_count` summary) so the user sees what close will write to QuickBooks | `reads/period_drafts.list_period_drafts` |
 
 Closing-entry drafting (schedule-derived + manual) and schedule
@@ -163,7 +163,7 @@ section. The Python handler registry routes them to `schedule_entry_due`,
 | Tool | Description |
 |------|-------------|
 | `get-graph-sync-status` | Check if the graph needs rebuild after OLTP writes |
-| `materialize-graph` | Trigger the `mark_graph_stale` sensor to rebuild |
+| `materialize` | Trigger an OLTP→OLAP rebuild (replaces the legacy `materialize-graph` name) |
 
 **Event blocks and REA agents (`event_block_tools.py`, `event_handler_tools.py`, `agent_tools.py`):**
 
@@ -205,14 +205,18 @@ Gated by `SEMANTIC_SEARCH_ENABLED`. Document management tools additionally skip 
 
 ### Layer 4: Infrastructure (feature-flag gated)
 
-**Workspaces** (`MCP_WORKSPACE_ENABLED`):
+**Workspaces:**
+
+Only `switch-workspace` is registered. It is a **client-side** tool
+(defined in `graph_tools.py`): the MCP client intercepts it to retarget
+the active graph context before sending; there is no server handler.
+There are no `list-workspaces` / `create-workspace` / `delete-workspace`
+tools — create a subgraph with `create-subgraph` and then point
+`switch-workspace` (or the `graph_id`) at it.
 
 | Tool | Description | Read-only OK |
 |------|-------------|--------------|
-| `list-workspaces` | List available workspaces | Yes |
-| `switch-workspace` | Switch active workspace context | Yes |
-| `create-workspace` | Create subgraph workspace | No |
-| `delete-workspace` | Delete workspace | No |
+| `switch-workspace` | Switch active workspace context (client-side) | Yes |
 
 **Memory / write Cypher** (`MCP_MEMORY_ENABLED`, writable graphs only):
 
@@ -233,7 +237,7 @@ Gated by `SEMANTIC_SEARCH_ENABLED`. Document management tools additionally skip 
 | Manifest `has_semantic_enrichment=True` | `resolve-element` |
 | `FACT_GRID_ENABLED=true` | `build-fact-grid` |
 | `SEMANTIC_SEARCH_ENABLED=true` | Layer 3 (search + document management) |
-| `MCP_WORKSPACE_ENABLED=true` | Layer 4 workspace tools |
+| `MCP_WORKSPACE_ENABLED=true` | Graph-lifecycle tools (`create-subgraph`, `delete-subgraph`, `create-backup`, `switch-workspace`) |
 | `MCP_MEMORY_ENABLED=true` | Layer 4 memory / write-cypher tools |
 
 A tool that would otherwise be unavailable due to any of these gates returns a structured error via `_tool_unavailable_reason` instead of silently no-oping — clients always see a typed reason when a tool isn't mounted in a given context.
@@ -293,12 +297,23 @@ max_lifetime: 3600 seconds (1 hour)
 **Usage:**
 
 ```python
-from robosystems.middleware.mcp import acquire_graph_mcp_client
+# acquire_graph_mcp_client (the pooled context manager) is exposed from
+# the factory module, not the package root. The package root exports
+# create_graph_mcp_client, GraphMCPClient, and GraphMCPTools.
+from robosystems.middleware.mcp.factory import acquire_graph_mcp_client
 
-# Acquire client from pool (recommended)
+# Acquire client from pool (preferred)
 async with acquire_graph_mcp_client(graph_id="kg1a2b3c") as client:
     result = await client.execute_query("MATCH (n) RETURN count(n)")
     # Client automatically returned to pool
+```
+
+For a one-off (non-pooled) client, use the package-level export:
+
+```python
+from robosystems.middleware.mcp import create_graph_mcp_client
+
+client = await create_graph_mcp_client(graph_id="kg1a2b3c")
 ```
 
 ### 3. MCP Tools (`tools/`)
@@ -342,7 +357,7 @@ Comprehensive exception hierarchy for MCP operations.
 - `GraphConnectionError` - Connection to Graph API failed
 - `GraphResourceNotFoundError` - Resource not found
 - `GraphRateLimitError` - Rate limit exceeded
-- `LadybugDBSchemaError` - Schema validation failed
+- `GraphSchemaError` - Schema validation failed
 
 ## Configuration
 
@@ -384,8 +399,8 @@ MCP_MEMORY_ENABLED=false               # Gates Layer 4 memory / write-cypher too
 ### With FastAPI Routes
 
 ```python
-from fastapi import APIRouter, Depends
-from robosystems.middleware.mcp import acquire_graph_mcp_client
+from fastapi import APIRouter
+from robosystems.middleware.mcp.factory import acquire_graph_mcp_client
 
 router = APIRouter()
 
@@ -399,10 +414,11 @@ async def execute_mcp_query(
         return {"results": result}
 ```
 
-### With Agent System
+### With an Operator
 
 ```python
-from robosystems.middleware.mcp import acquire_graph_mcp_client, GraphMCPTools
+from robosystems.middleware.mcp import GraphMCPTools, create_graph_mcp_client
+from robosystems.middleware.mcp.factory import acquire_graph_mcp_client
 
 # Acquire a pooled client for the target graph
 async with acquire_graph_mcp_client(graph_id="sec") as client:
@@ -415,32 +431,38 @@ async with acquire_graph_mcp_client(graph_id="sec") as client:
         read_only=False,
     )
 
-    # Agent uses tools for natural language queries
-    response = await agent.execute({
+    # The Operator uses tools for natural language queries
+    response = await operator.execute({
         "prompt": "What were Apple's total assets in 2023?",
         "tools": tools.get_tool_definitions(),
     })
 ```
 
-Agents that need both graph queries and OLTP writes (like `CloseAgent`, which calls `create-closing-entry` and `close-period`) initialize `GraphMCPTools` with a writable client and `schema_extensions=("roboledger",)` so both Layer 2a (analytical reads) and Layer 2b (OLTP commands) are available.
+An Operator that needs both graph queries and OLTP writes (e.g. a
+close-workflow Operator that calls `close-period` and drafts
+closing entries via `create-event-block`) initializes `GraphMCPTools`
+with a writable client and `schema_extensions=("roboledger",)` so both
+Layer 2a (analytical reads) and Layer 2b (OLTP commands) are available.
+There is no `create-closing-entry` tool — schedule-derived and manual
+drafts both come through `create-event-block`.
 
 ## Troubleshooting
 
 ### Common Issues
 
-**1. Query Timeouts**
+#### 1. Query Timeouts
 
 - Increase `GRAPH_QUERY_TIMEOUT` for complex queries
 - Optimize query patterns (use LIMIT clauses)
 - Check Graph API instance health
 
-**2. Connection Pool Exhausted**
+#### 2. Connection Pool Exhausted
 
 - Increase `MCP_POOL_MAX_CONNECTIONS`
 - Check for connection leaks (missing context manager exits)
 - Review pool lifetime settings
 
-**3. Validation Errors**
+#### 3. Validation Errors
 
 - Check query syntax (must be valid Cypher)
 - Verify query length is within limits

--- a/robosystems/middleware/mcp/tools/information_block_tools.py
+++ b/robosystems/middleware/mcp/tools/information_block_tools.py
@@ -7,10 +7,9 @@ envelope for any registered block type. Two tools:
 2. ``list-information-blocks`` — list blocks, optionally filtered by
    block_type + category.
 
-These are the eventual unified replacement for the block-type-specific
-read tools in ``schedule_tools.py`` (``list-schedule-structures``,
-``get-schedule-facts``). Both surfaces ship in parallel during the
-migration so callers can switch over without a breaking change.
+These replaced the retired block-type-specific schedule reads
+(``list-schedule-structures``, ``get-schedule-facts``); schedule
+envelopes now surface here via ``block_type='schedule'``.
 
 The ``create-information-block`` **write** tool is NOT in this module —
 it's auto-generated from the OperationSpec via
@@ -67,9 +66,9 @@ A typed envelope with:
 - list-information-blocks — browse available blocks
 - create-information-block — build a new block
 
-Note: This is the generic reader. Block-type-specific tools like
-list-schedule-structures and get-schedule-facts still ship but will
-eventually be deprecated in favor of this pair.""",
+Note: This is the generic reader for every block type; the old
+schedule-specific readers (list-schedule-structures, get-schedule-facts)
+were retired in favor of this pair.""",
       "inputSchema": {
         "type": "object",
         "properties": {

--- a/robosystems/middleware/mcp/tools/manager.py
+++ b/robosystems/middleware/mcp/tools/manager.py
@@ -244,9 +244,9 @@ class GraphMCPTools:
     self.get_fiscal_calendar_tool = None
     self.close_period_tool = None
     self.reopen_period_tool = None
-    # Information Block read tools — the eventual unified replacement for
-    # list-schedule-structures + get-schedule-facts. Both ship in parallel
-    # until agent workflows migrate.
+    # Information Block read tools (get/list-information-block) — these
+    # replaced the retired schedule-specific reads (list-schedule-structures,
+    # get-schedule-facts).
     self.get_information_block_tool = None
     self.list_information_blocks_tool = None
     if self._has_extension("roboledger") and env.ROBOLEDGER_ENABLED and not read_only:
@@ -261,9 +261,10 @@ class GraphMCPTools:
       )
 
       # Period-workflow read tools (span multiple blocks; not
-      # Information Block tools). Writes (create-schedule,
-      # update-schedule, delete-schedule) are registrar-generated from
-      # the roboledger OperationSpec declarations; closing-entry
+      # Information Block tools). Schedule writes have no dedicated ops —
+      # they go through create/update/delete-information-block
+      # (block_type='schedule'), registrar-generated from the roboledger
+      # OperationSpec declarations; closing-entry
       # drafting (schedule-derived and manual) goes through
       # create-event-block with event_type='schedule_entry_due'
       # (schedule-derived) or 'journal_entry_recorded' (manual).

--- a/robosystems/middleware/otel/README.md
+++ b/robosystems/middleware/otel/README.md
@@ -44,13 +44,12 @@ Initializes OpenTelemetry providers and auto-instrumentation.
 **Usage:**
 
 ```python
-from robosystems.middleware.otel.setup import setup_opentelemetry
+from robosystems.middleware.otel.setup import setup_telemetry
 
-# Called during application startup
-setup_opentelemetry(
-    service_name="robosystems-api",
-    service_version="1.0.0"
-)
+# Called during application startup with the FastAPI app instance.
+# Service name comes from OTEL_SERVICE_NAME and the version is read
+# from the installed package metadata — neither is passed as an argument.
+setup_telemetry(app)
 ```
 
 ### 2. Metrics Collection (`metrics.py`)
@@ -262,7 +261,10 @@ ENVIRONMENT=prod                      # prod/staging enables OTEL
 
 # Auto-instrumentation
 OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED=true
-OTEL_PYTHON_FASTAPI_EXCLUDED_URLS=/health,/metrics
+# setup.py instruments FastAPI with excluded_urls="status,health" to keep
+# high-frequency load-balancer health checks out of the metrics. The platform
+# health endpoint is GET /v1/status (there is no bare /health route).
+OTEL_PYTHON_FASTAPI_EXCLUDED_URLS=status,health
 
 # AWS Integration (Production)
 AWS_PROMETHEUS_ENDPOINT=https://aps-workspaces.us-east-1.amazonaws.com/workspaces/ws-xxxx/

--- a/robosystems/middleware/robustness/README.md
+++ b/robosystems/middleware/robustness/README.md
@@ -1,412 +1,289 @@
 # Robustness Middleware
 
-This middleware provides circuit breakers and resilience patterns to ensure system stability and graceful degradation under failure conditions.
+This middleware provides a small set of resilience and operational-visibility
+primitives used across the graph endpoints: a per-graph/per-operation circuit
+breaker, hierarchical timeout coordination, structured operation logging, and a
+lightweight operation-metric shim. These are plain helper classes and functions
+— they are constructed and called explicitly inside endpoint handlers, not
+applied as decorators.
 
 ## Overview
 
 The robustness middleware:
-- Implements circuit breaker pattern for external services
-- Provides automatic retry with exponential backoff
-- Handles timeout and failure scenarios gracefully
-- Tracks service health and performance metrics
-- Enables graceful degradation when services fail
+
+- Tracks failures per `(graph_id, operation)` and short-circuits requests to a
+  failing graph (circuit breaker)
+- Provides coordinated, layered timeout budgets so endpoint, queue, tool, and
+  instance timeouts don't conflict
+- Emits structured, in-memory operation logs for debugging and audit
+- Records notable operation outcomes (failures / slow operations), delegating
+  the primary metrics pipeline to OpenTelemetry (`middleware/otel/metrics.py`)
 
 ## Architecture
 
 ```
 robustness/
-├── __init__.py              # Module exports
-├── circuit_breaker.py       # Circuit breaker implementation
-├── decorators.py            # Decorator-based resilience patterns
-├── retry_policies.py        # Retry strategies and policies
-├── health_tracker.py        # Service health monitoring
-└── fallback_handlers.py     # Fallback response strategies
+├── __init__.py              # Public exports
+├── circuit_breaker.py       # CircuitBreakerManager + CircuitState
+├── timeout_coordinator.py   # TimeoutCoordinator + TimeoutConfiguration
+├── operation_logging.py     # OperationLogger + get_operation_logger()
+└── operation_metrics.py     # record_operation_metric + OperationType/OperationStatus
+```
+
+Public exports (`__init__.py`):
+
+```python
+from robosystems.middleware.robustness import (
+    CircuitBreakerManager,
+    TimeoutCoordinator,
+    OperationStatus,
+    OperationType,
+    get_operation_logger,
+    record_operation_metric,
+)
 ```
 
 ## Key Components
 
 ### 1. Circuit Breaker (`circuit_breaker.py`)
 
-Prevents cascading failures by breaking connections to failing services.
+`CircuitBreakerManager` tracks state per `(graph_id, operation)` key and blocks
+requests to a graph/operation that has been failing repeatedly, allowing it to
+recover.
 
-**States:**
-- **CLOSED**: Normal operation, requests pass through
-- **OPEN**: Service failing, requests blocked
-- **HALF_OPEN**: Testing if service recovered
+**State (`CircuitState` dataclass):** `failure_count`, `last_failure_time`,
+`is_open`, `last_success_time`. There is no explicit "half-open" object — once
+`recovery_timeout` elapses, the next `check_circuit` call resets the circuit and
+lets a request through (a one-shot recovery probe).
 
-**Configuration:**
+**Constructor:**
+
 ```python
-class CircuitBreakerConfig:
-    failure_threshold: int = 5         # Failures before opening
-    success_threshold: int = 2         # Successes to close
-    timeout: float = 60.0             # Seconds before half-open
-    expected_exception: type = Exception
+CircuitBreakerManager(
+    failure_threshold: int | None = None,   # default: TuningConfig.get_circuit_breaker_threshold()
+    recovery_timeout: int | None = None,     # default: TuningConfig.get_circuit_breaker_timeout()
+    half_open_max_calls: int = 3,
+)
 ```
+
+When `failure_threshold` / `recovery_timeout` are omitted they are read from
+`TuningConfig` (SSM-tunable at runtime via `circuits/THRESHOLD` and
+`circuits/TIMEOUT`).
+
+**Key methods:**
+
+- `check_circuit(graph_id, operation) -> bool` — call before the operation;
+  raises `HTTPException(503)` with a `Retry-After` header if the circuit is open.
+- `record_success(graph_id, operation)` — resets the failure count and closes
+  the circuit.
+- `record_failure(graph_id, operation, error=None)` — increments the failure
+  count and opens the circuit at the threshold. **Client errors are ignored:**
+  if `error` is a `GraphClientError` (e.g. bad Cypher syntax) it does not count
+  toward tripping the breaker.
+- `get_circuit_status(...)` / `get_all_circuit_status()` — status snapshots for
+  monitoring.
+
+**Usage (the pattern used in the graph routers):**
+
+```python
+from robosystems.middleware.robustness import CircuitBreakerManager
+
+circuit_breaker = CircuitBreakerManager()
+
+# Before the operation — raises HTTP 503 if the circuit is open
+circuit_breaker.check_circuit(graph_id, "analytics_metrics")
+
+try:
+    result = await run_operation()
+    circuit_breaker.record_success(graph_id, "analytics_metrics")
+except Exception as e:
+    circuit_breaker.record_failure(graph_id, "analytics_metrics", error=e)
+    raise
+```
+
+### 2. Timeout Coordinator (`timeout_coordinator.py`)
+
+`TimeoutCoordinator` holds per-operation `TimeoutConfiguration`s with a
+decreasing budget across four layers (`endpoint_timeout > queue_timeout >
+tool_timeout > instance_timeout`) so each layer leaves headroom for the one
+above it. Defaults are defined for `cypher_query`, `read-graph-cypher`,
+`get-graph-schema`, `get-graph-info`, and a `default` fallback.
+
+**Key methods:**
+
+- `get_timeout_config(tool_name) -> TimeoutConfiguration`
+- `get_endpoint_timeout(tool_name)` / `get_queue_timeout(...)` /
+  `get_tool_timeout(...)` / `get_instance_timeout(...)`
+- `validate_timeout_hierarchy(tool_name) -> bool`
+- `get_timeout_summary(tool_name) -> dict`
+- `calculate_timeout(operation_type, complexity_factors=None) -> float` —
+  maps an operation type to a config and scales the endpoint timeout by
+  complexity (row `limit`, `has_search`, `fields_count`), capped at 3x.
 
 **Usage:**
-```python
-from robosystems.middleware.robustness import CircuitBreaker
 
-# Create circuit breaker for external service
-qb_breaker = CircuitBreaker(
-    name="quickbooks_api",
-    failure_threshold=5,
-    timeout=60
+```python
+from robosystems.middleware.robustness import TimeoutCoordinator
+
+timeout_coordinator = TimeoutCoordinator()
+
+operation_timeout = timeout_coordinator.calculate_timeout(
+    operation_type="analytics_query",
+    complexity_factors={"limit": 5000, "has_search": True},
 )
 
-# Use in service calls
-@qb_breaker
-async def call_quickbooks_api():
-    response = await client.get("/api/v1/entity")
-    return response.json()
-
-# Check circuit state
-if qb_breaker.state == CircuitState.OPEN:
-    logger.warning("QuickBooks API circuit is open")
-```
-
-### 2. Resilience Decorators (`decorators.py`)
-
-Decorator-based patterns for common resilience needs.
-
-**Available Decorators:**
-
-#### @retry
-Automatic retry with configurable policies:
-```python
-@retry(
-    max_attempts=3,
-    backoff_factor=2.0,
-    exceptions=(HTTPError, ConnectionError)
-)
-async def fetch_data():
-    return await external_api.get_data()
-```
-
-#### @timeout
-Enforce operation timeouts:
-```python
-@timeout(seconds=30)
-async def long_operation():
-    return await process_large_dataset()
-```
-
-#### @fallback
-Provide fallback responses on failure:
-```python
-@fallback(default_value={"status": "unavailable"})
-async def get_service_status():
-    return await health_check_api()
-```
-
-#### @throttle
-Rate limit operations:
-```python
-@throttle(max_calls=100, period=60)  # 100 calls per minute
-async def api_endpoint():
-    return await process_request()
-```
-
-### 3. Retry Policies (`retry_policies.py`)
-
-Sophisticated retry strategies for different scenarios.
-
-**Built-in Policies:**
-
-#### Exponential Backoff
-```python
-policy = ExponentialBackoff(
-    initial_delay=1.0,
-    max_delay=60.0,
-    factor=2.0,
-    jitter=True
-)
-
-retrier = Retrier(policy=policy, max_attempts=5)
-result = await retrier.execute(operation)
-```
-
-#### Linear Backoff
-```python
-policy = LinearBackoff(
-    delay=5.0,
-    max_attempts=3
+metrics = await asyncio.wait_for(
+    collect_metrics(graph_id),
+    timeout=operation_timeout,
 )
 ```
 
-#### Custom Policy
-```python
-class CustomRetryPolicy(RetryPolicy):
-    def get_delay(self, attempt: int) -> float:
-        # Custom logic
-        return min(attempt * 2, 30)
+### 3. Operation Logger (`operation_logging.py`)
 
-    def should_retry(self, exception: Exception) -> bool:
-        # Retry only specific errors
-        return isinstance(exception, RecoverableError)
-```
+`OperationLogger` provides structured, in-memory operation logging with
+correlation IDs, slow-operation detection, and an audit trail. Retrieve the
+shared singleton via `get_operation_logger()`.
 
-### 4. Health Tracker (`health_tracker.py`)
+Log entries are `OperationLogEntry` dataclasses categorized by
+`OperationLogEventType` (e.g. `OPERATION_START`, `OPERATION_SUCCESS`,
+`OPERATION_FAILURE`, `CIRCUIT_BREAKER_OPEN`, `EXTERNAL_SERVICE_CALL`,
+`CREDIT_OPERATION`, `PERFORMANCE_ALERT`). Entries are kept in a bounded,
+thread-safe in-memory buffer (`max_log_entries`, default 10,000) and also
+written through the standard `logger`.
 
-Monitors service health and performance.
+**Key methods:**
 
-**Features:**
-- **Health Checks**: Periodic service health validation
-- **Metric Collection**: Response times, error rates
-- **Alerting**: Triggers alerts on degradation
-- **Status Reporting**: Provides health dashboards
+- `log_operation_start(...) -> operation_id`
+- `log_operation_success(operation_id, result_metadata=None)`
+- `log_operation_failure(operation_id, error, error_metadata=None)`
+- `operation_context(operation, endpoint, ...)` — context manager that logs
+  start, then success or failure automatically
+- `log_external_service_call(...)`, `log_circuit_breaker_event(...)`,
+  `log_resource_event(...)`, `log_credit_operation(...)`
+- `get_recent_logs(endpoint=None, graph_id=None, event_type=None, ...)` —
+  query the in-memory buffer
 
 **Usage:**
-```python
-tracker = HealthTracker()
 
-# Register service
-tracker.register_service(
-    name="graph_api",
-    health_check=lambda: check_lbug_health(),
-    interval=30  # Check every 30 seconds
+```python
+from robosystems.middleware.robustness import get_operation_logger
+
+operation_logger = get_operation_logger()
+
+# Explicit start/finish
+op_id = operation_logger.log_operation_start(
+    operation="analytics_query",
+    endpoint="/v1/graphs/{graph_id}/analytics",
+    graph_id=graph_id,
+    user_id=user_id,
 )
+try:
+    result = await run_operation()
+    operation_logger.log_operation_success(op_id)
+except Exception as e:
+    operation_logger.log_operation_failure(op_id, e)
+    raise
 
-# Get service status
-status = tracker.get_status("graph_api")
-print(f"Service health: {status.health_score}%")
-print(f"Average latency: {status.avg_latency}ms")
+# Or the context manager equivalent
+with operation_logger.operation_context(
+    "entity_create", endpoint, graph_id=graph_id, user_id=user_id
+) as op_id:
+    result = await some_operation()  # success/failure logged automatically
 ```
 
-### 5. Fallback Handlers (`fallback_handlers.py`)
+### 4. Operation Metrics (`operation_metrics.py`)
 
-Strategies for handling failures gracefully.
+A lightweight shim. The primary metrics pipeline (request duration, errors,
+business events, query queue, SSE) lives in `middleware/otel/metrics.py`. This
+module is retained for two purposes:
 
-**Available Strategies:**
+1. **Circuit-breaker status tracking** — `CircuitBreakerMetrics` (accessed via
+   `get_operation_metrics_collector()`) stores the latest circuit state per
+   `(graph_id, operation)`. `CircuitBreakerManager` updates it internally; you
+   normally don't call it directly.
+2. **`record_operation_metric(...)`** — a backward-compatible logging shim. It
+   logs a warning for any non-`SUCCESS` status or any operation slower than
+   10s; otherwise it is a no-op. It does **not** emit OTel metrics.
 
-#### Cache Fallback
-Return cached data when service fails:
-```python
-@cache_fallback(ttl=300)
-async def get_user_data(user_id: str):
-    return await user_service.get_user(user_id)
-```
+`OperationType` and `OperationStatus` are enums describing the operation
+category and outcome (e.g. `OperationType.ANALYTICS_QUERY`,
+`OperationStatus.SUCCESS` / `FAILURE` / `TIMEOUT` / `CIRCUIT_OPEN` /
+`INSUFFICIENT_CREDITS`).
 
-#### Default Value Fallback
-Return default values on failure:
-```python
-@default_fallback(value={"balance": 0, "status": "unknown"})
-async def get_account_balance(account_id: str):
-    return await banking_api.get_balance(account_id)
-```
-
-#### Degraded Service Fallback
-Provide limited functionality:
-```python
-@degraded_fallback
-async def complex_analysis(data):
-    try:
-        return await ml_service.analyze(data)
-    except ServiceUnavailable:
-        # Return simple analysis instead
-        return basic_analysis(data)
-```
-
-## Integration Patterns
-
-### 1. With External APIs
+**Usage:**
 
 ```python
 from robosystems.middleware.robustness import (
-    CircuitBreaker, retry, timeout
+    record_operation_metric,
+    OperationType,
+    OperationStatus,
 )
 
-class ExternalAPIClient:
-    def __init__(self):
-        self.breaker = CircuitBreaker(
-            name="external_api",
-            failure_threshold=5
+record_operation_metric(
+    operation_type=OperationType.ANALYTICS_QUERY,
+    status=OperationStatus.SUCCESS,
+    duration_ms=operation_duration_ms,
+    endpoint="/v1/graphs/{graph_id}/analytics",
+    graph_id=graph_id,
+    user_id=user_id,
+    operation_name="get_graph_metrics",
+)
+```
+
+## Putting It Together
+
+The graph routers (`routers/graphs/usage.py`, `health.py`, `limits.py`,
+`info.py`, `tables/query.py`, `mcp/handlers.py`) construct these helpers at
+module scope and wire them together inside the handler: check the circuit,
+compute a timeout, run under `asyncio.wait_for`, then record success/failure on
+the breaker and emit logs/metrics.
+
+```python
+circuit_breaker = CircuitBreakerManager()
+timeout_coordinator = TimeoutCoordinator()
+operation_logger = get_operation_logger()
+
+async def handler(graph_id, user_id):
+    start = time.time()
+    try:
+        circuit_breaker.check_circuit(graph_id, "analytics_metrics")
+        timeout = timeout_coordinator.calculate_timeout("analytics_query")
+        result = await asyncio.wait_for(run_operation(graph_id), timeout=timeout)
+        circuit_breaker.record_success(graph_id, "analytics_metrics")
+        record_operation_metric(
+            operation_type=OperationType.ANALYTICS_QUERY,
+            status=OperationStatus.SUCCESS,
+            duration_ms=(time.time() - start) * 1000,
+            endpoint="/v1/graphs/{graph_id}/analytics",
+            graph_id=graph_id,
+            user_id=user_id,
         )
-
-    @retry(max_attempts=3)
-    @timeout(seconds=10)
-    async def call_api(self, endpoint: str):
-        async with self.breaker:
-            response = await httpx.get(f"https://api.example.com{endpoint}")
-            response.raise_for_status()
-            return response.json()
-```
-
-### 2. With Database Operations
-
-```python
-@retry(
-    max_attempts=3,
-    exceptions=(OperationalError, TimeoutError),
-    backoff_factor=1.5
-)
-async def execute_critical_query(query: str):
-    async with get_db_connection() as conn:
-        return await conn.execute(query)
-```
-
-### 3. With Message Queues
-
-```python
-class ResilientQueue:
-    @circuit_breaker(failure_threshold=10)
-    @retry(max_attempts=5)
-    async def publish_message(self, message: dict):
-        await self.queue.publish(message)
-
-    @fallback(default_value=[])
-    async def consume_messages(self, count: int = 10):
-        return await self.queue.consume(count)
+        return result
+    except Exception as e:
+        circuit_breaker.record_failure(graph_id, "analytics_metrics", error=e)
+        raise
 ```
 
 ## Configuration
 
-Environment variables:
-```bash
-# Circuit Breaker Defaults
-CIRCUIT_BREAKER_FAILURE_THRESHOLD=5
-CIRCUIT_BREAKER_SUCCESS_THRESHOLD=2
-CIRCUIT_BREAKER_TIMEOUT=60
-CIRCUIT_BREAKER_HALF_OPEN_REQUESTS=3
+The circuit breaker reads its defaults from `TuningConfig` (SSM-tunable at
+runtime, no redeploy required):
 
-# Retry Defaults
-RETRY_MAX_ATTEMPTS=3
-RETRY_INITIAL_DELAY=1.0
-RETRY_MAX_DELAY=60.0
-RETRY_BACKOFF_FACTOR=2.0
+| Setting              | TuningConfig accessor               | SSM key             |
+| -------------------- | ----------------------------------- | ------------------- |
+| Failure threshold    | `get_circuit_breaker_threshold()`   | `circuits/THRESHOLD`|
+| Recovery timeout (s) | `get_circuit_breaker_timeout()`     | `circuits/TIMEOUT`  |
 
-# Timeout Defaults
-DEFAULT_OPERATION_TIMEOUT=30
-DEFAULT_API_TIMEOUT=10
-DEFAULT_QUERY_TIMEOUT=60
+Timeout budgets are defined in code in `TimeoutCoordinator` (per operation
+type); the operation logger's thresholds (`slow_operation_threshold_ms`,
+`max_log_entries`) are constructor arguments on `OperationLogger`.
 
-# Health Check Configuration
-HEALTH_CHECK_INTERVAL=30
-HEALTH_CHECK_TIMEOUT=5
-HEALTH_CHECK_FAILURE_THRESHOLD=3
-```
+## Notes
 
-## Monitoring & Metrics
-
-### Circuit Breaker Metrics
-- State transitions (closed → open → half-open)
-- Failure rates and counts
-- Success rates after recovery
-- Time spent in each state
-
-### Retry Metrics
-- Retry attempts per operation
-- Success rate after retries
-- Total retry delay added
-- Retry exhaustion events
-
-### Health Metrics
-- Service availability percentage
-- Average response times
-- Error rates by type
-- Health check success rates
-
-## Best Practices
-
-### 1. Choose Appropriate Thresholds
-- Set failure thresholds based on service SLAs
-- Consider traffic patterns when setting timeouts
-- Balance between stability and responsiveness
-
-### 2. Implement Proper Fallbacks
-- Always have a fallback strategy
-- Ensure fallbacks don't cascade failures
-- Test fallback paths regularly
-
-### 3. Monitor Circuit States
-- Alert on circuit breaker openings
-- Track patterns of failures
-- Review and adjust thresholds
-
-### 4. Use Timeouts Wisely
-- Set timeouts slightly above p99 latency
-- Consider downstream timeout budgets
-- Implement timeout hierarchies
-
-### 5. Test Failure Scenarios
-- Regularly test circuit breakers
-- Simulate service failures
-- Verify fallback behaviors
-
-## Common Patterns
-
-### 1. Bulkhead Pattern
-Isolate resources to prevent total failure:
-```python
-# Separate circuit breakers for different operations
-read_breaker = CircuitBreaker(name="db_read")
-write_breaker = CircuitBreaker(name="db_write")
-```
-
-### 2. Timeout Budget
-Allocate timeout budgets across service calls:
-```python
-async def complex_operation(timeout_budget=30):
-    # Allocate timeouts
-    db_timeout = timeout_budget * 0.3
-    api_timeout = timeout_budget * 0.5
-    processing_timeout = timeout_budget * 0.2
-
-    data = await timeout(db_timeout)(fetch_from_db)()
-    enriched = await timeout(api_timeout)(enrich_via_api)(data)
-    return await timeout(processing_timeout)(process)(enriched)
-```
-
-### 3. Adaptive Retry
-Adjust retry strategy based on error types:
-```python
-class AdaptiveRetry:
-    def should_retry(self, error: Exception, attempt: int) -> bool:
-        if isinstance(error, RateLimitError):
-            # Longer delay for rate limits
-            self.delay = 60
-            return attempt < 2
-        elif isinstance(error, NetworkError):
-            # Standard exponential backoff
-            self.delay = 2 ** attempt
-            return attempt < 5
-        return False
-```
-
-## Troubleshooting
-
-### Circuit Breaker Issues
-
-1. **Breaker Opens Too Frequently**
-   - Increase failure threshold
-   - Review timeout settings
-   - Check service health
-
-2. **Breaker Doesn't Close**
-   - Verify success threshold
-   - Check half-open test requests
-   - Review service recovery
-
-### Retry Issues
-
-1. **Too Many Retries**
-   - Reduce max attempts
-   - Implement circuit breakers
-   - Check if errors are recoverable
-
-2. **Retry Storms**
-   - Add jitter to delays
-   - Implement backoff
-   - Use circuit breakers
-
-### Performance Issues
-
-1. **High Latency**
-   - Review timeout settings
-   - Check retry delays
-   - Monitor circuit breaker states
-
-2. **Resource Exhaustion**
-   - Implement bulkheads
-   - Add rate limiting
-   - Review connection pools
+- These helpers are constructed explicitly in handlers; there are no
+  decorators (`@retry` / `@timeout` / `@fallback` / `@throttle`), no retry-policy
+  classes, and no fallback handlers in this module.
+- Retries/backoff, if needed, live with the relevant client/adapter; this
+  module focuses on breaking, timing out, logging, and status tracking.
+- The primary metrics surface is OpenTelemetry — see
+  `middleware/otel/README.md`.

--- a/robosystems/models/api/README.md
+++ b/robosystems/models/api/README.md
@@ -21,6 +21,10 @@ models/api/
 ├── search.py                   # Document search models
 ├── taxonomy_block.py           # Taxonomy Block envelope models (CoA, custom ontology)
 ├── user.py                     # User profile and management models
+├── admin/                      # Admin CLI / dashboard models (cache, credits, graphs, invoice, orgs, subscription, users)
+├── billing/                    # Billing models (checkout, credits, customer, invoice, offering, subscription)
+├── graphs/                     # Graph platform models (core, backups, connections, health, limits, mcp, metrics, operations, operator, query, schema, subgraphs, tables, tier)
+├── views/                      # Analytical view models (fact_grid, view_config, view_response)
 └── extensions/                 # RoboLedger + RoboInvestor request/response models
     ├── account_rollups.py
     ├── accounts.py

--- a/robosystems/models/api/extensions/schedules.py
+++ b/robosystems/models/api/extensions/schedules.py
@@ -303,7 +303,7 @@ class UpdateScheduleRequest(BaseModel):
   NOT editable via this op: period_start, period_end, monthly_amount.
   Those require fact regeneration — fire an event block that terminates
   the schedule (e.g., `asset_disposed`) and create a fresh schedule via
-  `create-schedule`.
+  `create-information-block` (`block_type='schedule'`).
 
   Omitted fields are left unchanged.
   """

--- a/robosystems/models/extensions/README.md
+++ b/robosystems/models/extensions/README.md
@@ -162,7 +162,7 @@ For QuickBooks-sourced data, `Transaction:Entry` is 1:1 (QB is pre-journalized).
 
 RoboLedger **does not have a dedicated `Account` model** for the chart of accounts — the CoA is modeled via `Element` nodes (the same Element model used for XBRL reporting elements). Company-specific accounts and standardized US GAAP reporting elements coexist in the same table, distinguished by their associated `Taxonomy` (`type='chart_of_accounts'` vs `type='reporting'`). The `Association` model then handles CoA → GAAP rollup mappings via the same pattern used for XBRL presentation/calculation links.
 
-This is a deliberate unification — see the Taxonomy System notes for the architectural rationale. The `account.py` file in this directory is reserved for a future split if it's ever needed.
+This is a deliberate unification — see the Taxonomy System notes for the architectural rationale. There is no `account.py` file in this directory; `Account` is simply an alias of `Element` (`Account = Element` in `element.py`) for CoA-flavored call sites.
 
 ## Base class pattern
 

--- a/robosystems/operations/README.md
+++ b/robosystems/operations/README.md
@@ -57,8 +57,8 @@ operations/
 │   ├── envelope.py            # Cross-type atom → Lite projection helpers
 │   ├── schedule.py            # Schedule block type handler (declarative construction)
 │   ├── rollforward.py         # Rollforward block type handler (declarative construction)
-│   ├── statement.py           # Statement block type handlers (compositional, stub)
-│   ├── metric.py              # Metric block type handler (derivative, stub)
+│   ├── statement.py           # Statement block type handlers (compositional build + rendering; CUD stubbed)
+│   ├── metric.py              # Metric block type handler (derivative; placeholder build, facts=[]; CUD stubbed)
 │   ├── classify.py            # Association classifier scaffold (not yet implemented)
 │   └── rules/                 # Rule evaluation engine
 │       ├── engine.py          # evaluate_rules_for_structure — entry point
@@ -77,8 +77,8 @@ operations/
 │   ├── schedules/             # ScheduleService
 │   └── views/                 # Graph-backed analytical queries (build-fact-grid)
 ├── roboinvestor/              # RoboInvestor domain kernel (CQRS subtree)
-│   ├── reads/                 # portfolios, securities, positions, holdings
-│   └── commands/              # portfolios, securities, positions
+│   ├── reads/                 # portfolios, portfolio_block, securities, positions, holdings
+│   └── commands/              # portfolio_block, securities
 ├── operators/                 # AI Operator system (MappingOperator, CypherOperator, future CloseOperator)
 ├── graph/                     # Platform graph database operations
 │   ├── graph_creation_service.py        # Unified graph creation (entity + generic)
@@ -100,15 +100,17 @@ operations/
 
 ## Single-Source-of-Truth Contract
 
-The domain kernels (`roboledger/`, `roboinvestor/`, `information_block/`) are the only place domain logic lives. Three transports call the same functions:
+The domain kernels (`roboledger/`, `roboinvestor/`, `information_block/`) are the only place domain logic lives. Five transports call the same functions:
 
 | Transport | Reads | Writes |
 |-----------|-------|--------|
 | GraphQL (`/extensions/{g}/graphql`) | `resolvers/*.py` → ops `reads/*.py` | — |
 | Named command ops (`/extensions/{domain}/{g}/operations/{op}`) | — | ops `commands/*.py` |
-| MCP tools (`middleware/mcp/tools/*.py`) | same ops `reads/*.py` | same ops `commands/*.py` |
+| Analytical view ops (`/extensions/{domain}/{g}/operations/{view}`, e.g. `build-fact-grid`) | `routers/extensions/{domain}/views.py` → ops `views/*.py` | — |
+| MCP tools (`middleware/mcp/tools/*.py`) | same ops `reads/*.py` + `views/*.py` | same ops `commands/*.py` |
+| AI Operators (`operators/`) | same ops via MCP tools (`ctx.tools`) | same ops via MCP tools |
 
-Adding business logic in a router, resolver, or MCP tool file is a mistake — route it through the ops layer.
+Adding business logic in a router, resolver, view handler, MCP tool, or Operator is a mistake — route it through the ops layer.
 
 ## Extension Domain Kernels (CQRS Pattern)
 
@@ -147,7 +149,9 @@ The registry (`registry.py`) maps `block_type` strings to `BlockTypeRegistryEntr
 | `comprehensive_income` | compositional | `statement.py` | Yes |
 | `metric` | derivative | `metric.py` | No |
 
-Statement and metric dispatch handlers currently raise `NotImplementedError` (→ HTTP 501) — their data models are wired, but the construction logic is not yet implemented.
+Statements are built via `create-report`, not `create-information-block`: the statement handlers in `statement.py` implement the full compositional envelope build plus the server-computed rendering projection (`view.rendering`) on GET. Only the statement *create / update / delete* dispatch handlers are stubs (`make_not_implemented_handler` → HTTP 501).
+
+The metric handler in `metric.py` is a working placeholder — `build_envelope` packs a valid envelope with `facts=[]` until the derivation evaluator that computes metric values from source-block FactSets lands. Only its *create / update / delete* handlers raise `NotImplementedError` (→ HTTP 501).
 
 ## Rule Evaluation Engine
 

--- a/robosystems/operations/operators/README.md
+++ b/robosystems/operations/operators/README.md
@@ -81,6 +81,7 @@ operators/
         mapping/
             operator.py        # MappingOperator — taxonomy mapping operator
             prompt.py       # System prompt for mapping operations
+            constants.py    # Mapping operator constants
 ```
 
 ## Execution Paths

--- a/robosystems/operations/roboledger/commands/fiscal_calendar.py
+++ b/robosystems/operations/roboledger/commands/fiscal_calendar.py
@@ -77,8 +77,8 @@ def initialize_ledger(
   if body.auto_seed_schedules:
     warnings.append(
       "auto_seed_schedules=true is not yet implemented. "
-      "Schedules must be created manually via create-schedule. "
-      "SchedulerAgent support will be added in a follow-up."
+      "Schedules must be created manually via create-information-block "
+      "(block_type='schedule'). Automated seeding will be added in a follow-up."
     )
 
   calendar = service.initialize(

--- a/robosystems/operations/roboledger/commands/schedules.py
+++ b/robosystems/operations/roboledger/commands/schedules.py
@@ -356,7 +356,8 @@ def update_schedule(
 
   Period range and monthly amount are NOT editable — they define the
   fact grid. Fire an event block that terminates the schedule (e.g.,
-  `asset_disposed`) and create a fresh schedule via `create-schedule`.
+  `asset_disposed`) and create a fresh schedule via
+  `create-information-block` (`block_type='schedule'`).
 
   When the entry template changes, all remaining `pending`
   schedule_entry_due obligations are voided and replaced with a fresh

--- a/robosystems/schemas/README.md
+++ b/robosystems/schemas/README.md
@@ -214,7 +214,7 @@ Fiscal calendar / fiscal period stays OLTP-only — operational state (rolling c
 
 The RoboLedger extension models the full accounting domain: financial reporting (XBRL/SEC), general ledger (transactions, journal entries), and chart of accounts (via Element/Association patterns). It uses context-aware loading to present different views depending on the use case.
 
-**Full product extension** with OLTP tables in the `extensions` database (schema-per-tenant), a GraphQL read surface under `/extensions/{graph_id}/graphql` (37 fields), named command operations under `/extensions/roboledger/{graph_id}/operations/*` (~20+ commands), graph-backed analytical view operations over the materialized data, a QuickBooks ELT pipeline, and a dedicated frontend app.
+**Full product extension** with OLTP tables in the `extensions` database (schema-per-tenant), a GraphQL read surface under `/extensions/{graph_id}/graphql` (38 fields), named command operations under `/extensions/roboledger/{graph_id}/operations/*` (~20+ commands), graph-backed analytical view operations over the materialized data, a QuickBooks ELT pipeline, and a dedicated frontend app.
 
 #### Reporting Section (SEC/XBRL)
 

--- a/robosystems/schemas/README.md
+++ b/robosystems/schemas/README.md
@@ -6,7 +6,7 @@ The RoboSystems schema system implements a **base + extensions** architecture fo
 
 **Key Concepts:**
 
-- **Base Schema**: Core nodes shared by all graphs (Entity, Period, Unit, Element, Label, Reference, Taxonomy, Dimension, Structure, Association, Classification)
+- **Base Schema**: Core nodes shared by all graphs (Entity, Period, Unit, Element, Label, Reference, Taxonomy, Dimension, Structure, Association, Trait, Classification, Agent, Event)
 - **Extensions**: Domain schemas that extend the base schema with domain-specific node types and relationships
 - **Context-Aware Loading**: Different views of the same extension based on use case (e.g., SEC reporting vs full accounting)
 - **Product Extensions**: Extensions like RoboLedger and RoboInvestor that grow beyond the graph schema into full product verticals with dedicated databases, API surfaces, data pipelines, and frontend applications
@@ -45,7 +45,7 @@ Each extension defines the domain model for its application — the node types, 
 2. **OLTP Database Schema**: PostgreSQL tables that mirror the schema for transactional workloads
 3. **API Surface**: Endpoints that expose and operate on the domain model
 4. **Data Pipelines**: ETL/ELT jobs that transform external data into the schema
-5. **AI Agent Context**: MCP tools use the schema to understand what queries are valid
+5. **AI Operator Context**: MCP tools use the schema to understand what queries are valid
 6. **Frontend Applications**: UI components are built around the domain model
 
 Not every extension has all of these layers today. Some are schema-only (graph schema). Others — RoboLedger and RoboInvestor — have grown into full product extensions with dedicated infrastructure.
@@ -150,7 +150,7 @@ graph TD
     A[Base Schema] --> B[Core Nodes]
     A --> C[Core Relationships]
     B --> D[Entity]
-    B --> E[User]
+    B --> E[Agent/Event]
     B --> F[Period]
     B --> G[Unit]
     B --> H[Element/Taxonomy]
@@ -177,17 +177,20 @@ The base schema (`base.py`) provides foundational nodes and relationships that a
 
 | Node              | Purpose                                | Key Properties                                 |
 | ----------------- | -------------------------------------- | ---------------------------------------------- |
-| **GraphMetadata** | Database metadata and configuration    | identifier, graph_id, tier, schema_type        |
-| **User**          | System users with authentication       | identifier, email, is_active                   |
 | **Entity**        | Organizations, companies, subsidiaries | identifier, cik, ticker, name, entity_type     |
 | **Agent**         | REA counterparty (customer, vendor, …) | identifier, agent_type, name, source           |
 | **Event**         | REA business event with canonical action verb | identifier, event_type, event_action, status   |
-| **Period**        | Time periods for data                  | start_date, end_date, fiscal_year, period_type |
+| **Period**        | Time periods for data                  | start_date, end_date, period_type              |
 | **Unit**          | Measurement units                      | measure, value, numerator_uri                  |
 | **Element**       | XBRL taxonomy elements                 | qname, period_type, is_numeric                 |
 | **Label**         | Human-readable element labels          | value, type, language                          |
 | **Reference**     | Authoritative element references       | value, type                                    |
 | **Taxonomy**      | Global XBRL taxonomies                 | name, version, namespace                       |
+| **Dimension**     | XBRL dimensional axis/member tags      | axis, member, dimension_type                   |
+| **Structure**     | Named element collection (network)     | network_uri, definition, type                  |
+| **Association**   | Element relationships (calc, present.) | arcrole, order_value, association_type         |
+| **Trait**         | FASB us-gaap metamodel vocabulary (element axes/categories) | identifier, category, type, source |
+| **Classification**| Structural pattern classification for associations | identifier, category, type, source |
 
 `Agent` and `Event` are universal REA primitives — every planned RoboX extension needs them. `Event.event_action` carries the canonical 19-verb action vocabulary (`models/extensions/roboledger/event.py:EVENT_ACTIONS`) refining the coarser `event_category`. The vocabulary converges with Valueflows v1.0; canonical naming is RoboSystems-native. SEC-flavored repositories get the schema with empty tables (no rows loaded).
 
@@ -230,7 +233,7 @@ The RoboLedger extension models the full accounting domain: financial reporting 
 #### Context-Aware Loading
 
 ```python
-# SEC Repository — reporting only (hides transaction tables from AI agents)
+# SEC Repository — reporting only (hides transaction tables from AI Operators)
 loader = get_contextual_schema_loader("repository", "sec")
 
 # Entity Database — full accounting
@@ -279,7 +282,7 @@ The RoboInvestor extension models portfolio management, securities, and position
 ### Memory — AI Memory Schema
 
 - **Nodes**: Concept, Observation, Session
-- **Key Features**: AI knowledge graph for storing concepts and observations across agent sessions
+- **Key Features**: AI knowledge graph for storing concepts and observations across AI Operator sessions
 
 ## Schema Management
 
@@ -301,7 +304,7 @@ loader = get_contextual_schema_loader("repository", "sec")
 ### Building Schemas
 
 ```python
-from robosystems.schemas.runtime.builder import LadybugDBSchemaBuilder
+from robosystems.schemas.runtime.builder import LadybugSchemaBuilder
 
 config = {
     "name": "My Financial Graph",
@@ -309,7 +312,7 @@ config = {
     "extensions": ["roboledger", "roboinvestor"]
 }
 
-builder = LadybugDBSchemaBuilder(config)
+builder = LadybugSchemaBuilder(config)
 builder.load_schemas()
 cypher_ddl = builder.generate_cypher()
 ```
@@ -317,9 +320,9 @@ cypher_ddl = builder.generate_cypher()
 ### Schema Validation
 
 ```python
-from robosystems.schemas.runtime.validator import LadybugDBSchemaValidator
+from robosystems.schemas.runtime.validator import LadybugSchemaValidator
 
-validator = LadybugDBSchemaValidator()
+validator = LadybugSchemaValidator()
 
 # Validate node properties
 validator.validate_node("Entity", {
@@ -446,11 +449,11 @@ config_large = {
 
 ```python
 # SEC public data repository
-# Uses reporting-only view to prevent MCP agent confusion
+# Uses reporting-only view to prevent AI Operator confusion
 loader = get_contextual_schema_loader("repository", "sec")
 
 # This filters out transaction tables that don't exist in SEC data
-# Ensures AI agents only see relevant XBRL/reporting tables
+# Ensures AI Operators only see relevant XBRL/reporting tables
 ```
 
 ### Entity Database Configuration
@@ -488,7 +491,7 @@ ALTER TABLE Entity ADD COLUMN new_field STRING
 1. **Additive Changes**: New nodes/relationships can be added safely
 2. **Property Additions**: Use ALTER TABLE to add new properties
 3. **Breaking Changes**: Require coordinated migration scripts
-4. **Version Tracking**: Track schema versions in GraphMetadata
+4. **Version Tracking**: Track schema/tier metadata on the platform `Graph` model (`models/core/graph/graph.py`), not on a graph node
 
 ## Best Practices
 
@@ -518,7 +521,7 @@ ALTER TABLE Entity ADD COLUMN new_field STRING
 
 ### 5. Security Considerations
 
-- **Access Control**: Implement at USER_HAS_ACCESS relationship
+- **Access Control**: A platform-DB concern — graph access is enforced through the platform models (`models/core/user/`, e.g. `GraphUser`), not via a graph relationship. The base schema has no user/access node.
 - **Data Isolation**: Multi-tenant separation at database level
 - **Audit Trails**: Track all schema modifications
 
@@ -563,6 +566,6 @@ The schema system integrates with the RoboSystems API:
 
 ### MCP Integration
 
-- Context-aware schema exposure to AI agents
+- Context-aware schema exposure to AI Operators
 - Natural language to Cypher query generation
 - Schema-guided response formatting

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,6 +1,6 @@
 # Testing in RoboSystems Service
 
-This directory contains comprehensive tests for the RoboSystems Service application. With 194+ test files covering all major components, the test suite ensures reliability across the platform.
+This directory contains comprehensive tests for the RoboSystems Service application. With 500+ test files covering all major components, the test suite ensures reliability across the platform.
 
 ## Quick Start
 
@@ -49,13 +49,12 @@ The test suite is organized by component, mirroring the application structure:
   - `robustness/` - Circuit breakers, retries, health checks
   - `sse/` - Server-sent events for real-time updates
 - **`models/`** - Database models and schemas
-  - `api/` - API request/response models
-  - `billing/` - Billing and subscription models (customer, subscription, invoice, audit log)
-  - `iam/` - Identity and access management models
+  - `api/` - Pydantic API request/response models
+  - `core/` - Platform SQLAlchemy models (users, orgs, graphs, billing, connections, documents)
 - **`operations/`** - Business logic services
-  - `agents/` - AI agent operations and orchestration
+  - `operators/` - AI Operator operations and orchestration (Claude/MCP executors)
   - `graph/` - Graph database operations (credit service, entity service)
-  - `lbug/` - LadybugDB-specific operations (backup, health monitoring)
+  - `roboledger/`, `roboinvestor/` - Extensions OLTP reads/commands/views
   - `pipeline/` - Data processing pipelines
   - `providers/` - External provider integrations
 
@@ -140,7 +139,7 @@ uv run pytest tests/operations/
 
 # Middleware components
 uv run pytest tests/middleware/auth/
-uv run pytest tests/middleware/credits/
+uv run pytest tests/middleware/billing/
 
 # Adapters
 uv run pytest tests/adapters/
@@ -229,7 +228,7 @@ def test_with_database(test_db):
 
 def test_with_client(client):
     """Make HTTP requests to the API."""
-    response = client.get("/api/health")
+    response = client.get("/v1/status")
     assert response.status_code == 200
 
 def test_with_auth(client_with_mocked_auth):
@@ -256,7 +255,7 @@ Tests run in an isolated environment with specific configuration:
 ### External Services
 
 - **LocalStack**: AWS services (S3, etc.) on `http://localhost:4566`
-- **Valkey/Redis**: Cache and queues on `localhost:6379`
+- **Valkey**: Cache and queues on `localhost:6379`
 - **Graph API**: LadybugDB service on `localhost:8001`
 - **LadybugDB Databases**: Test databases in `./data/lbug-dbs`
 

--- a/tests/middleware/mcp/tools/test_schedule_tools.py
+++ b/tests/middleware/mcp/tools/test_schedule_tools.py
@@ -1,7 +1,8 @@
 """Tests for schedule MCP read tools.
 
-Write tools (`create-schedule`, `update-schedule`, `delete-schedule`)
-are registrar-generated — their execution path is covered by
+Schedule writes have no dedicated ops — they go through
+`create/update/delete-information-block` (`block_type='schedule'`),
+registrar-generated; their execution path is covered by
 `tests/middleware/mcp/test_registrar.py` + the ops-layer tests under
 `tests/operations/roboledger/schedules/`. Closing-entry drafting
 (schedule-derived and manual) runs through `create-event-block` with


### PR DESCRIPTION
## Summary

A repo-wide README/documentation accuracy pass: bring the committed docs back in line with the current code, and fix the code-level drift the review surfaced (stale operation references, a dead constant, an inert required arg). This is docs plus small comment/docstring/dead-code changes — **no behavior change**. Motivated by the open-source launch: these are the docs the technical audience reads when they clone the repo, so accuracy matters.

The work was done as a reviewed sprint: parallel agents reviewed each README in full against the actual code, a second pass applied fixes, and a final adversarial pass re-verified the heavy rewrites (which caught a broken code example and several wrong env-var names that the first pass missed).

## Changes

**Top-level `README.md` (messaging):**
- Value-forward headline ("what RoboSystems is"), open-source-engines framing in the Architecture intro
- Trimmed redundant inline doc links already catalogued in Developer Documentation; dropped architecture overclaims ("shared query surface", novelty/moat framing)

**Subsystem READMEs corrected against code:**
- `middleware/robustness` — **rewritten** (the old one was ~90% fictional) to the four real modules: `CircuitBreakerManager`, `TimeoutCoordinator`, operation logging/metrics
- `middleware/auth` — JWT expiry 30 days → 30 min (`JWT_EXPIRY_HOURS`), removed three documented-but-nonexistent files and their sections, `rfs`+64-hex key format, `get_current_user_with_graph`, SSO TTL
- `middleware/graph` — real file tree, `QueryQueueManager`, `MultiTenantUtils` path, `dependencies/` package, `await` on async calls, corrected `submit_query` example
- `graph_api` (+ `core`, `client`) — nested `core/ladybug` / `core/duckdb` tree, `GraphClient` (dropped nonexistent `AsyncGraphClient` / `sync_client.py`), connection-pool limit, header form
- `config` — real env flags (`RATE_LIMIT_ENABLED` / `BILLING_ENABLED`), real `EndpointCategory` members, `operator_type`, import style, dropped phantom `billing/repositories.py`
- `schemas` / `models/*` / `operations` / `adapters` — real base nodes (+`Trait`, −phantom `GraphMetadata`/`User`), `LadybugSchema*` class names, `Account`-is-an-alias note, missing subdirs, the full five-transport source-of-truth contract, `CanonicalConcept`
- `mcp` — removed unregistered `create/update/delete-schedule` (schedule writes go through `create-information-block(block_type='schedule')`), `materialize-graph` → `materialize`, removed phantom workspace tools + `create-closing-entry`

**Naming / branding sweep:** AI "agent" → Operator (dev-facing), Redis → Valkey, dropped deprecated Professional/Enterprise/Premium tier terms.

**Code-level drift the docs surfaced (comment/docstring/string only):**
- Replaced stale `create-schedule` references — an op that does not exist — with `create-information-block(block_type='schedule')` in a runtime warning (`commands/fiscal_calendar.py`), update docstrings (`commands/schedules.py`, `models/api/extensions/schedules.py`), MCP comments + the `get-information-block` tool description, the demo, and a test docstring
- `config/credits.py` docstring no longer claims storage consumes credits

**Dead code removed / inert API defaulted:**
- Removed `STORAGE_CREDITS_PER_GB_PER_DAY` — unreferenced since the initial release, no metering path, not in `OPERATION_COSTS`
- `query_queue.submit_query`: `credits_required` is reserved but never enforced and is `0` for all non-AI callers; defaulted it to `0` (was required) so the public example doesn't imply graph queries cost credits — backward-compatible, all callers still pass it explicitly

**Env-var name corrections** (`graph` / `graph_api` / `core` READMEs): `LBUG_DATABASE_DIR` → `LBUG_DATABASE_PATH`, `LBUG_MAX_DATABASES_PER_NODE` → `LBUG_DATABASES_PER_INSTANCE`, `LBUG_MAX_CONNECTIONS_PER_DB` / `LBUG_MEMORY_PER_DB_MB` → `LBUG_CONNECTION_POOL_SIZE` / `LBUG_MAX_MEMORY_PER_DB_MB`, `LBUG_QUERY_TIMEOUT` → `GRAPH_QUERY_TIMEOUT`; dropped non-env `LBUG_PORT` and `LBUG_MAX_QUERY_LENGTH`; RoboLedger GraphQL field count 37 → 38.

## Testing

`just test-code` (ruff + format + basedpyright + cf-lint) — **passed, 0 errors**, run after each code-touching batch. The unit-test portion (`just test` / `just test-all`) was **not run**: changes are docs plus comments/docstrings, one backward-compatible 1-line default, and a dead-constant removal — no logic paths changed.

## Notes / Follow-ups (separate tickets, not this PR)

- **Full removal** of `credits_required` / `credits_reserved` from the query queue (signature + dataclass field + 3 call sites) — only defaulted here.
- **Deeper sub-READMEs not in this sweep** — `graph_api/core/ladybug/README.md` and `graph_api/core/duckdb/README.md` carry at least one stale env-var token; worth a follow-up if full coverage is wanted.
