### PR TITLE
fix(roboledger): guard orphaned schedule obligations from double-posting

### DIFF
--- a/robosystems/operations/event_block/promotion.py
+++ b/robosystems/operations/event_block/promotion.py
@@ -52,6 +52,7 @@ from pydantic import ValidationError
 from sqlalchemy.orm import Session
 
 from robosystems.logger import logger
+from robosystems.models.extensions.roboledger import Structure
 from robosystems.models.extensions.roboledger.event import Event
 from robosystems.operations.event_block.python_handlers import get_python_handler
 from robosystems.operations.event_block.python_handlers.types import (
@@ -66,6 +67,7 @@ class PromotionResult:
   graph_id: str
   classified_event_ids: list[str] = field(default_factory=list)
   dispatched_event_ids: list[str] = field(default_factory=list)
+  voided_orphan_event_ids: list[str] = field(default_factory=list)
   errors: list[tuple[str, str]] = field(default_factory=list)
 
   @property
@@ -75,6 +77,10 @@ class PromotionResult:
   @property
   def dispatched_count(self) -> int:
     return len(self.dispatched_event_ids)
+
+  @property
+  def voided_orphan_count(self) -> int:
+    return len(self.voided_orphan_event_ids)
 
   @property
   def error_count(self) -> int:
@@ -120,6 +126,51 @@ def promote_pending_obligations(
   )
 
   result = PromotionResult(graph_id=graph_id)
+
+  # Orphan guard (Layer 2): an obligation whose schedule structure no longer
+  # exists is orphaned — the schedule was deleted but its register wasn't
+  # voided (e.g. a pre-fix delete, or the void's silent no-op). Never draft an
+  # orphan into a closing entry: void it in place so it stops blocking close,
+  # and surface it. The catch-all that stops a deleted schedule from
+  # double-posting at promotion regardless of how the orphan arose. See
+  # specs/schedule-delete-obligation-integrity.md (Layer 2).
+  if candidates:
+    candidate_schedule_ids = {
+      evt.metadata_.get("schedule_id")
+      for evt in candidates
+      if evt.metadata_ and evt.metadata_.get("schedule_id")
+    }
+    live_schedule_ids: set[str] = set()
+    if candidate_schedule_ids:
+      live_schedule_ids = {
+        sid
+        for (sid,) in session.query(Structure.id)
+        .filter(Structure.id.in_(candidate_schedule_ids))
+        .all()
+      }
+    orphans = [
+      evt
+      for evt in candidates
+      if evt.metadata_
+      and evt.metadata_.get("schedule_id")
+      and evt.metadata_.get("schedule_id") not in live_schedule_ids
+    ]
+    if orphans:
+      orphan_ids = [evt.id for evt in orphans]
+      session.query(Event).filter(
+        Event.id.in_(orphan_ids), Event.status == "pending"
+      ).update({"status": "voided"}, synchronize_session="fetch")
+      result.voided_orphan_event_ids.extend(orphan_ids)
+      for evt in orphans:
+        logger.warning(
+          "promote_pending_obligations[%s]: voided orphan obligation %s — "
+          "schedule %s no longer exists (not drafted)",
+          graph_id,
+          evt.id,
+          evt.metadata_.get("schedule_id"),
+        )
+      orphan_id_set = set(orphan_ids)
+      candidates = [evt for evt in candidates if evt.id not in orphan_id_set]
 
   if not candidates:
     return result

--- a/robosystems/operations/roboledger/schedules/service.py
+++ b/robosystems/operations/roboledger/schedules/service.py
@@ -745,6 +745,24 @@ class ScheduleService:
     metadata = structure.metadata_ or {}
     schedule_created_event_id = metadata.get("schedule_created_event_id")
     if not schedule_created_event_id:
+      # Robust fallback: recover the originator from the obligations' own
+      # link — every schedule_entry_due carries metadata.schedule_id == this
+      # structure's id and obligated_by_event_id == the schedule_created
+      # originator. Structures missing the `schedule_created_event_id` stamp
+      # would otherwise no-op silently here and orphan their pending
+      # obligations on delete (the 2026-06-19 Harbinger defect: 280 phantom
+      # obligations that double-posted at close). See
+      # specs/schedule-delete-obligation-integrity.md.
+      schedule_created_event_id = session.execute(
+        select(Event.obligated_by_event_id)
+        .where(
+          Event.event_type == "schedule_entry_due",
+          Event.metadata_["schedule_id"].astext == structure.id,
+          Event.obligated_by_event_id.isnot(None),
+        )
+        .limit(1)
+      ).scalar()
+    if not schedule_created_event_id:
       return 0
 
     update_values: dict[str, object] = {"status": "voided"}

--- a/tests/operations/event_block/python_handlers/test_asset_disposed.py
+++ b/tests/operations/event_block/python_handlers/test_asset_disposed.py
@@ -330,13 +330,17 @@ class TestVoidPendingObligationsForSchedule:
     session.execute.assert_not_called()
 
   def test_returns_zero_when_structure_predates_stream_2a(self) -> None:
-    """Schedules created before the originator-id stamping land are no-op disposed."""
+    """Schedules created before the originator-id stamping land: with no stamp
+    AND no recoverable obligations, the robust fallback finds nothing, so
+    disposal is a clean no-op (returns 0)."""
     from robosystems.operations.event_block.python_handlers.asset_disposed import (
       _void_pending_obligations_for_schedule,
     )
 
     session = MagicMock()
     session.get.return_value = self._structure_with_event(None)
+    # No stamp on the structure AND the fallback recovery finds no obligations.
+    session.execute.return_value.scalar.return_value = None
 
     voided = _void_pending_obligations_for_schedule(
       session,
@@ -345,4 +349,5 @@ class TestVoidPendingObligationsForSchedule:
     )
 
     assert voided == 0
-    session.execute.assert_not_called()
+    # The fallback recovery select ran; no UPDATE followed.
+    assert session.execute.call_count == 1

--- a/tests/operations/event_block/test_promotion.py
+++ b/tests/operations/event_block/test_promotion.py
@@ -6,6 +6,7 @@ from datetime import UTC, datetime, time
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+from robosystems.models.extensions.roboledger.event import Event
 from robosystems.operations.event_block.promotion import (
   PromotionResult,
   promote_pending_obligations,
@@ -36,13 +37,39 @@ def _pending_event(
   )
 
 
-def _session_returning(events: list[SimpleNamespace]) -> MagicMock:
-  """MagicMock session whose .query(Event).filter(...).all() returns events."""
+def _session_returning(
+  events: list[SimpleNamespace],
+  *,
+  live_schedule_ids: set[str] | None = None,
+) -> MagicMock:
+  """MagicMock session that dispatches by query target.
+
+  - ``query(Event)`` → candidate load (``.all()`` → events) + bulk updates.
+  - ``query(Structure.id)`` → the orphan guard's existence check
+    (``.all()`` → ``[(sid,), ...]`` for the live schedule ids).
+
+  ``live_schedule_ids`` defaults to every schedule_id present on ``events``
+  (i.e. no orphans), so tests that don't exercise the guard behave as before.
+  The Event query mock is exposed as ``session.event_query`` for introspection.
+  """
+  if live_schedule_ids is None:
+    live_schedule_ids = {
+      e.metadata_.get("schedule_id")
+      for e in events
+      if e.metadata_ and e.metadata_.get("schedule_id")
+    }
+  event_query = MagicMock()
+  event_query.filter.return_value = event_query
+  event_query.all.return_value = events
+  struct_query = MagicMock()
+  struct_query.filter.return_value = struct_query
+  struct_query.all.return_value = [(sid,) for sid in live_schedule_ids]
   session = MagicMock()
-  query = MagicMock()
-  query.filter.return_value = query
-  query.all.return_value = events
-  session.query.return_value = query
+  session.query.side_effect = lambda target: (
+    event_query if target is Event else struct_query
+  )
+  session.event_query = event_query
+  session.struct_query = struct_query
   return session
 
 
@@ -76,9 +103,10 @@ class TestCoPilotMode:
 
     assert set(result.classified_event_ids) == {"evt_1", "evt_2"}
     assert result.dispatched_count == 0  # co-pilot — no dispatch
-    # Two .query() calls: one to load candidates, one to bulk-update by id
-    assert session.query.call_count == 2
-    bulk_update_call = session.query.return_value.filter.return_value.update
+    # Three .query() calls now: load candidates, the orphan-guard structure
+    # existence check, and the bulk classify-update by id.
+    assert session.query.call_count == 3
+    bulk_update_call = session.event_query.filter.return_value.update
     bulk_update_call.assert_called_once_with(
       {"status": "classified"}, synchronize_session="fetch"
     )
@@ -243,9 +271,70 @@ class TestQueryShape:
     # The first .filter() call is the candidate load:
     # session.query(Event).filter(event_type, status, occurred_at).all()
     # (The second .filter() is the bulk-update by id list — different shape.)
-    query = session.query.return_value
+    query = session.event_query
     candidate_filter_args = query.filter.call_args_list[0].args
     rendered = " | ".join(str(c) for c in candidate_filter_args)
     assert "events.event_type" in rendered
     assert "events.status" in rendered
     assert "events.occurred_at" in rendered
+
+
+class TestOrphanGuard:
+  """Layer 2: obligations whose schedule structure was deleted are voided in
+  place, never drafted — the catch-all that stops a deleted schedule from
+  double-posting at promotion. See specs/schedule-delete-obligation-integrity.md.
+  """
+
+  def test_orphan_voided_not_classified_copilot(self) -> None:
+    live = _pending_event("evt_live", schedule_id="struct_live")
+    orphan = _pending_event("evt_orphan", schedule_id="struct_deleted")
+    # Only struct_live still exists as a structure row.
+    session = _session_returning([live, orphan], live_schedule_ids={"struct_live"})
+
+    result = promote_pending_obligations(
+      session, "kg_test", as_of=datetime(2026, 2, 1, tzinfo=UTC)
+    )
+
+    assert result.voided_orphan_event_ids == ["evt_orphan"]
+    assert result.voided_orphan_count == 1
+    # The live obligation still classifies; the orphan never does.
+    assert result.classified_event_ids == ["evt_live"]
+    assert "evt_orphan" not in result.classified_event_ids
+
+  def test_orphan_not_dispatched_autopilot(self) -> None:
+    live = _pending_event("evt_live", schedule_id="struct_live")
+    orphan = _pending_event("evt_orphan", schedule_id="struct_deleted")
+    session = _session_returning([live, orphan], live_schedule_ids={"struct_live"})
+
+    handler = MagicMock()
+    handler.metadata_schema.model_validate.return_value = MagicMock()
+    handler.dispatch.return_value = MagicMock()
+
+    with patch(
+      "robosystems.operations.event_block.promotion.get_python_handler",
+      return_value=handler,
+    ):
+      result = promote_pending_obligations(
+        session,
+        "kg_test",
+        as_of=datetime(2026, 2, 1, tzinfo=UTC),
+        dispatch_handlers=True,
+      )
+
+    # Only the live obligation is dispatched into a draft; the orphan is voided.
+    assert result.dispatched_event_ids == ["evt_live"]
+    assert result.voided_orphan_event_ids == ["evt_orphan"]
+    assert handler.dispatch.call_count == 1
+    assert orphan.status != "classified"
+
+  def test_no_orphans_when_all_schedules_live(self) -> None:
+    e1 = _pending_event("evt_1", schedule_id="struct_a")
+    e2 = _pending_event("evt_2", schedule_id="struct_b")
+    session = _session_returning([e1, e2], live_schedule_ids={"struct_a", "struct_b"})
+
+    result = promote_pending_obligations(
+      session, "kg_test", as_of=datetime(2026, 2, 1, tzinfo=UTC)
+    )
+
+    assert result.voided_orphan_count == 0
+    assert set(result.classified_event_ids) == {"evt_1", "evt_2"}

--- a/tests/operations/roboledger/schedules/test_service.py
+++ b/tests/operations/roboledger/schedules/test_service.py
@@ -1021,11 +1021,14 @@ class TestCreateScheduleMaterializesObligations:
     rendered = str(update_stmt.compile(compile_kwargs={"literal_binds": True}))
     assert "replaced_by_event_id='evt_disposal_42'" in rendered.replace(" = ", "=")
 
-  def test_void_pending_obligations_no_op_when_no_originator(self):
-    """Legacy schedules with no schedule_created_event_id return 0 cleanly."""
+  def test_void_pending_obligations_no_op_when_unrecoverable(self):
+    """No stamp AND no recoverable obligations (the fallback finds nothing) → 0."""
     structure = MagicMock()
     structure.metadata_ = {}
+    structure.id = "struct_legacy"
     session = MagicMock()
+    # The fallback recovery select returns no originator id.
+    session.execute.return_value.scalar.return_value = None
 
     svc = ScheduleService()
     voided = svc.void_pending_obligations(
@@ -1033,7 +1036,41 @@ class TestCreateScheduleMaterializesObligations:
     )
 
     assert voided == 0
-    session.execute.assert_not_called()
+    # The fallback recovery select ran, but no UPDATE followed.
+    assert session.execute.call_count == 1
+    session.get.assert_not_called()
+
+  def test_void_pending_obligations_recovers_link_when_stamp_missing(self):
+    """Layer 1 fix: the structure lacks the schedule_created_event_id stamp, but
+    the obligations carry the link (obligated_by_event_id) — recover it and void
+    anyway, instead of silently returning 0.
+
+    This is the 2026-06-19 Harbinger orphan defect: without this fallback the
+    void no-op'd and the delete orphaned 280 pending obligations that then
+    double-posted at close. See specs/schedule-delete-obligation-integrity.md.
+    """
+    structure = MagicMock()
+    structure.metadata_ = {}  # the bug condition: stamp missing
+    structure.id = "struct_orphan"
+
+    originator = MagicMock()
+    originator.metadata_ = {"pending_event_count": 5}
+
+    session = MagicMock()
+    recovery = MagicMock()
+    recovery.scalar.return_value = "evt_origin_recovered"
+    update_result = MagicMock(rowcount=5)
+    session.execute.side_effect = [recovery, update_result]
+    session.get.return_value = originator
+
+    svc = ScheduleService()
+    voided = svc.void_pending_obligations(
+      session, structure=structure, void_reason="schedule_deleted"
+    )
+
+    assert voided == 5
+    assert originator.metadata_["pending_event_count"] == 0
+    assert session.execute.call_count == 2  # recovery select + UPDATE
 
   def test_void_pending_obligations_no_op_when_no_pending_rows(self):
     """When the UPDATE matches zero rows, originator metadata is untouched."""


### PR DESCRIPTION
## Summary

A deleted schedule could leave its forward `schedule_entry_due` obligations orphaned, which the obligation promoter would then draft into **duplicate closing entries** — silently double-posting depreciation/amortization at close. This was found on the Harbinger production tenant (280 phantom obligations across 21 deleted prepaid schedules) and fixed at two layers so it can't recur regardless of how an orphan arises.

The root cause was **not** "delete doesn't cascade-void" — `delete_schedule` already voids its register (since `3e2f53a9`). The bug is that `void_pending_obligations` **silently `return 0`s** when the structure's metadata lacks the `schedule_created_event_id` stamp; the delete then drops the structure anyway, orphaning the obligations with no signal.

## Changes

**Layer 1 — prevent (`robosystems/operations/roboledger/schedules/service.py`)**
- `void_pending_obligations` now recovers the originator from the obligations' own link when the structure stamp is missing — querying `metadata->>'schedule_id' == structure.id` for the shared `obligated_by_event_id` — instead of silently no-opping while pending obligations still exist.
- Because the helper is shared, this also closes the same latent gap on the asset-disposal path.

**Layer 2 — catch-all (`robosystems/operations/event_block/promotion.py`)**
- `promote_pending_obligations` now partitions out obligations whose schedule structure no longer exists, voids them in place (never drafting them into a closing entry), and surfaces them via a new `PromotionResult.voided_orphan_event_ids` field (+ `voided_orphan_count`). Applies to both co-pilot (status-flip) and autopilot (dispatch) modes. This is the defense-in-depth net: even if an orphan arises some other way, the promote sweep refuses to post it.

**Tests**
- `tests/operations/event_block/test_promotion.py` — new `TestOrphanGuard` (orphan voided not classified in co-pilot, not dispatched in autopilot, no-orphans pass-through); `_session_returning` taught to dispatch the new `Structure.id` existence query.
- `tests/operations/roboledger/schedules/test_service.py` — new void link-recovery test; updated the former "no stamp → no-op" test to "no stamp **and** no recoverable obligations → no-op."
- `tests/operations/event_block/python_handlers/test_asset_disposed.py` — updated the disposal predates-stamping test for the same recovery semantics.

## Testing

- `just test-code` (ruff + format + basedpyright + cf-lint) — **passed clean** (0 errors).
- Targeted `uv run pytest` over the affected suites (`test_promotion.py`, `schedules/test_service.py`, `commands/test_schedules.py`, `fiscal_calendar/test_close_service.py`, `python_handlers/test_asset_disposed.py`) — **121 passed**.
- Full `just test-all` not run in this session.

## Notes / Follow-ups

- The Harbinger production tenant was already data-remediated separately (the 280 orphaned obligations voided; fiscal calendar pending count 56 → 35) — this PR prevents recurrence in code; no migration needed.
- Deferred (demand-pulled, captured in the design spec, not in this PR): a delete-safety guard that warns before voiding pending obligations, the `rebuild-schedule` atomic-supersede primitive, and a generic `query-graphql` MCP tool.
- `supersede_pending_obligations` (the schedule-*update* path) shares the same stamp-dependent pattern but is a distinct stale-template concern, intentionally out of scope here; Layer 2 still catches any orphans it could produce.
