### PR TITLE
feat(roboledger): add rebuild-schedule operation

### DIFF
--- a/robosystems/models/api/extensions/schedules.py
+++ b/robosystems/models/api/extensions/schedules.py
@@ -327,6 +327,27 @@ class DeleteScheduleRequest(BaseModel):
   structure_id: str
 
 
+class RebuildScheduleRequest(BaseModel):
+  """Re-run the schedule generator in place on an existing schedule.
+
+  Atomic alternative to delete-then-recreate: the structure id and its
+  element associations are preserved, the old pending obligation chain
+  is voided, the old facts + rules are deleted, and a fresh set of
+  forward facts + a fresh obligation chain are regenerated from the
+  schedule's stored definition (entry_template / schedule_metadata /
+  monthly_amount / period bounds on the Structure's metadata).
+
+  The historical-vs-in-scope split is re-derived from the CURRENT fiscal
+  calendar `closed_through`, so a rebuild re-scopes the schedule to
+  today's close state. Use this to pick up a fixed generator (e.g. the
+  roll-forward direction fix) without orphaning obligations.
+  """
+
+  structure_id: str = Field(
+    ..., description="The schedule structure to regenerate in place."
+  )
+
+
 # Asset disposal is an event block:
 # `create-event-block(event_type='asset_disposed')`. See
 # operations/event_block/python_handlers/asset_disposed.py for the

--- a/robosystems/operations/roboledger/commands/schedules.py
+++ b/robosystems/operations/roboledger/commands/schedules.py
@@ -7,7 +7,7 @@ translate request bodies to service calls and assemble responses.
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 
 from sqlalchemy import or_, select, text
 from sqlalchemy.orm import Session
@@ -20,6 +20,7 @@ from robosystems.models.api.extensions.schedules import (
   DeleteScheduleRequest,
   PromoteObligationsRequest,
   PromoteObligationsResponse,
+  RebuildScheduleRequest,
   ScheduleCreatedResponse,
   UpdateScheduleRequest,
 )
@@ -521,3 +522,230 @@ def delete_schedule(session: Session, body: DeleteScheduleRequest) -> dict:
   session.commit()
 
   return {"deleted": True}
+
+
+def _reconstruct_schedule_definition(
+  session: Session, structure: Structure
+) -> tuple[EntryTemplate, ScheduleMetadata | None, int, date, date]:
+  """Recover the generation inputs for a rebuild from a Structure row.
+
+  Prefers the stored definition on ``metadata_`` (entry_template,
+  schedule_metadata, monthly_amount, period_start, period_end —
+  persisted at create time so the rebuild is unambiguous). For legacy
+  rows written before those scalar keys were stored, derives the period
+  bounds from the schedule's FactSet and ``monthly_amount`` from a
+  non-final duration debit Fact.
+
+  Raises ``ValueError`` when the definition can't be reconstructed.
+  """
+  metadata = structure.metadata_ or {}
+  raw_template = metadata.get("entry_template")
+  if not raw_template:
+    raise ValueError(
+      f"Schedule {structure.id!r} has no entry_template in metadata; cannot rebuild."
+    )
+  entry_template = EntryTemplate(
+    debit_element_id=raw_template["debit_element_id"],
+    credit_element_id=raw_template["credit_element_id"],
+    entry_type=raw_template.get("entry_type", "closing"),
+    memo_template=raw_template.get("memo_template", ""),
+    auto_reverse=raw_template.get("auto_reverse", False),
+  )
+
+  raw_meta = metadata.get("schedule_metadata")
+  schedule_metadata = (
+    ScheduleMetadata(
+      method=raw_meta.get("method", "straight_line"),
+      original_amount=raw_meta.get("original_amount", 0),
+      residual_value=raw_meta.get("residual_value", 0),
+      useful_life_months=raw_meta.get("useful_life_months", 0),
+      asset_element_id=raw_meta.get("asset_element_id"),
+      periodic_amounts=raw_meta.get("periodic_amounts"),
+    )
+    if raw_meta
+    else None
+  )
+
+  # Reproducible scalar inputs — stored at create time on new rows.
+  monthly_amount = metadata.get("monthly_amount")
+  period_start_iso = metadata.get("period_start")
+  period_end_iso = metadata.get("period_end")
+
+  period_start: date | None = (
+    date.fromisoformat(period_start_iso) if period_start_iso else None
+  )
+  period_end: date | None = (
+    date.fromisoformat(period_end_iso) if period_end_iso else None
+  )
+
+  # Legacy fallback: derive period bounds from the schedule's FactSet rows.
+  if period_start is None or period_end is None:
+    bounds = session.execute(
+      select(
+        FactSet.period_start.label("min_start"),
+        FactSet.period_end.label("max_end"),
+      ).where(
+        FactSet.structure_id == structure.id,
+        FactSet.factset_type == "schedule",
+      )
+    ).fetchall()
+    starts = [b.min_start for b in bounds if b.min_start is not None]
+    ends = [b.max_end for b in bounds if b.max_end is not None]
+    if not starts or not ends:
+      raise ValueError(
+        f"Schedule {structure.id!r} has no stored period bounds and no "
+        "schedule FactSet to derive them from; cannot rebuild."
+      )
+    period_start = period_start or min(starts)
+    period_end = period_end or max(ends)
+
+  # Legacy fallback: derive monthly_amount from a non-final duration debit
+  # fact (the per-period straight-line amount, in cents).
+  if monthly_amount is None:
+    debit_fact = session.execute(
+      select(Fact.value)
+      .where(
+        Fact.structure_id == structure.id,
+        Fact.element_id == entry_template.debit_element_id,
+        Fact.period_type == "duration",
+      )
+      .order_by(Fact.period_start.asc())
+      .limit(1)
+    ).scalar()
+    if debit_fact is None:
+      raise ValueError(
+        f"Schedule {structure.id!r} has no stored monthly_amount and no "
+        "duration debit fact to derive it from; cannot rebuild."
+      )
+    monthly_amount = round(float(debit_fact) * 100)
+
+  return (
+    entry_template,
+    schedule_metadata,
+    int(monthly_amount),
+    period_start,
+    period_end,
+  )
+
+
+def rebuild_schedule(
+  session: Session,
+  body: RebuildScheduleRequest,
+  created_by: str = "system",
+) -> ScheduleCreatedResponse:
+  """Re-run the schedule generator in place on an existing schedule.
+
+  Atomic alternative to delete-then-recreate (which orphans the
+  obligation chain). Preserves the structure id, its element
+  associations, and its taxonomy; voids the old pending obligation
+  chain; deletes the old facts, FactSets, and SumEquals rules; then
+  regenerates the forward facts + a fresh obligation chain from the
+  schedule's stored definition.
+
+  The historical-vs-in-scope split is re-derived from the CURRENT fiscal
+  calendar `closed_through`, re-scoping the schedule to today's close
+  state. This is the redo-after-a-generator-fix path (e.g. the
+  roll-forward direction fix).
+
+  Raises:
+      ScheduleNotFoundError: if the schedule does not exist.
+      ValueError: if the schedule's definition can't be reconstructed.
+  """
+  structure = _load_schedule_or_404(session, body.structure_id)
+
+  (
+    entry_template,
+    schedule_metadata,
+    monthly_amount,
+    period_start,
+    period_end,
+  ) = _reconstruct_schedule_definition(session, structure)
+
+  # Re-derive the close watermark from the CURRENT fiscal calendar — a
+  # rebuild re-scopes the schedule to today's close state.
+  closed_through = _calendar_closed_through_date(session)
+
+  service = ScheduleService()
+
+  # Void the old pending obligation chain so the regenerated chain doesn't
+  # double-count and the old pending events can't trip the close gate.
+  service.void_pending_obligations(
+    session,
+    structure=structure,
+    void_reason="schedule_rebuilt",
+  )
+
+  # Cascade-delete the old facts, FactSets, and SumEquals rule(s) — mirror
+  # delete_schedule's cascade, but NOT the Structure, Associations, or
+  # taxonomy (those are preserved). Verification results referencing the
+  # structure or its rules are cleared too so stale rows don't linger.
+  rule_ids = (
+    session.execute(select(Rule.id).where(Rule.target_structure_id == structure.id))
+    .scalars()
+    .all()
+  )
+  verification_filters = [VerificationResult.structure_id == structure.id]
+  if rule_ids:
+    verification_filters.append(VerificationResult.rule_id.in_(rule_ids))
+  session.query(VerificationResult).filter(or_(*verification_filters)).delete(
+    synchronize_session=False
+  )
+  session.query(Fact).filter(Fact.structure_id == structure.id).delete(
+    synchronize_session=False
+  )
+  session.query(FactSet).filter(FactSet.structure_id == structure.id).delete(
+    synchronize_session=False
+  )
+  if rule_ids:
+    session.query(Rule).filter(Rule.id.in_(rule_ids)).delete(synchronize_session=False)
+  session.flush()
+
+  # Regenerate in place — preserves structure id + associations + arcs.
+  structure = service.create_schedule(
+    session,
+    name=structure.name,
+    taxonomy_id=structure.taxonomy_id,
+    element_ids=[],
+    period_start=period_start,
+    period_end=period_end,
+    monthly_amount=monthly_amount,
+    entry_template=entry_template,
+    schedule_metadata=schedule_metadata,
+    created_by=created_by,
+    closed_through=closed_through,
+    existing_structure=structure,
+  )
+
+  count_row = session.execute(
+    text("SELECT COUNT(*) AS cnt FROM facts WHERE structure_id = :sid"),
+    {"sid": structure.id},
+  ).fetchone()
+  period_row = session.execute(
+    text(
+      "SELECT COUNT(DISTINCT (period_start, period_end)) AS cnt "
+      "FROM facts WHERE structure_id = :sid"
+    ),
+    {"sid": structure.id},
+  ).fetchone()
+
+  rule_results = evaluate_rules_for_structure(
+    session,
+    structure.id,
+    period_start=period_start,
+    period_end=period_end,
+    created_by=created_by,
+  )
+
+  session.commit()
+
+  metadata = structure.metadata_ or {}
+  return ScheduleCreatedResponse(
+    structure_id=structure.id,
+    name=structure.name,
+    taxonomy_id=structure.taxonomy_id,
+    total_periods=period_row.cnt if period_row else 0,
+    total_facts=count_row.cnt if count_row else 0,
+    rule_summary=_rule_summary(rule_results),
+    schedule_created_event_id=metadata.get("schedule_created_event_id"),
+    pending_event_count=metadata.get("pending_event_count", 0),
+  )

--- a/robosystems/operations/roboledger/commands/schedules.py
+++ b/robosystems/operations/roboledger/commands/schedules.py
@@ -34,6 +34,7 @@ from robosystems.models.extensions import (
   VerificationResult,
 )
 from robosystems.models.extensions.roboledger import Fact
+from robosystems.models.extensions.roboledger.event import Event
 from robosystems.operations.information_block.rules.engine import (
   evaluate_rules_for_structure,
 )
@@ -526,7 +527,7 @@ def delete_schedule(session: Session, body: DeleteScheduleRequest) -> dict:
 
 def _reconstruct_schedule_definition(
   session: Session, structure: Structure
-) -> tuple[EntryTemplate, ScheduleMetadata | None, int, date, date]:
+) -> tuple[EntryTemplate, ScheduleMetadata | None, int, date, date, str | None]:
   """Recover the generation inputs for a rebuild from a Structure row.
 
   Prefers the stored definition on ``metadata_`` (entry_template,
@@ -565,6 +566,13 @@ def _reconstruct_schedule_definition(
     if raw_meta
     else None
   )
+
+  # Audit back-ref to the source transaction — stored in artifact_mechanics
+  # at create time (legacy rows may carry it on metadata_ instead). Recovering
+  # it keeps the rebuilt schedule pointing at its originating transaction.
+  source_transaction_id = (structure.artifact_mechanics or {}).get(
+    "source_transaction_id"
+  ) or (structure.metadata_ or {}).get("source_transaction_id")
 
   # Reproducible scalar inputs — stored at create time on new rows.
   monthly_amount = metadata.get("monthly_amount")
@@ -625,6 +633,7 @@ def _reconstruct_schedule_definition(
     int(monthly_amount),
     period_start,
     period_end,
+    source_transaction_id,
   )
 
 
@@ -659,7 +668,30 @@ def rebuild_schedule(
     monthly_amount,
     period_start,
     period_end,
+    source_transaction_id,
   ) = _reconstruct_schedule_definition(session, structure)
+
+  # Refuse to rebuild underneath posted closing entries — a rebuild
+  # regenerates the facts those entries depend on, which would orphan the
+  # audit trail. Reopen the affected periods first (mirrors truncate_schedule).
+  posted_row = session.execute(
+    text(
+      "SELECT COUNT(*) AS c FROM entries "
+      "WHERE source_structure_id = :sid AND status = 'posted'"
+    ),
+    {"sid": structure.id},
+  ).fetchone()
+  if posted_row and posted_row.c:
+    raise ValueError(
+      f"Cannot rebuild schedule {structure.id!r}: {posted_row.c} posted "
+      "closing entries exist. Reopen those periods first."
+    )
+
+  # Capture the old originator event id so we can supersede it after the
+  # rebuild stamps a fresh one (avoids two unlinked committed originators).
+  old_schedule_created_event_id = (structure.metadata_ or {}).get(
+    "schedule_created_event_id"
+  )
 
   # Re-derive the close watermark from the CURRENT fiscal calendar — a
   # rebuild re-scopes the schedule to today's close state.
@@ -698,6 +730,22 @@ def rebuild_schedule(
   )
   if rule_ids:
     session.query(Rule).filter(Rule.id.in_(rule_ids)).delete(synchronize_session=False)
+
+  # Sweep stale DRAFT closing entries for this structure — the rebuilt
+  # obligation chain re-drafts them on the next promote. Line items first
+  # for the FK. Posted entries are guarded above, so this only hits drafts.
+  session.execute(
+    text(
+      "DELETE FROM line_items WHERE entry_id IN ("
+      "SELECT id FROM entries "
+      "WHERE source_structure_id = :sid AND status = 'draft')"
+    ),
+    {"sid": structure.id},
+  )
+  session.execute(
+    text("DELETE FROM entries WHERE source_structure_id = :sid AND status = 'draft'"),
+    {"sid": structure.id},
+  )
   session.flush()
 
   # Regenerate in place — preserves structure id + associations + arcs.
@@ -714,7 +762,25 @@ def rebuild_schedule(
     created_by=created_by,
     closed_through=closed_through,
     existing_structure=structure,
+    source_transaction_id=source_transaction_id,
   )
+
+  # Supersede the old originator event: the rebuild stamps a fresh
+  # `schedule_created` event, leaving the old one orphaned. Mark it voided
+  # and back-link it to its replacement so the audit chain stays connected.
+  new_schedule_created_event_id = (structure.metadata_ or {}).get(
+    "schedule_created_event_id"
+  )
+  if (
+    old_schedule_created_event_id
+    and new_schedule_created_event_id
+    and old_schedule_created_event_id != new_schedule_created_event_id
+  ):
+    old_evt = session.get(Event, old_schedule_created_event_id)
+    if old_evt is not None:
+      old_evt.status = "voided"
+      old_evt.replaced_by_event_id = new_schedule_created_event_id
+      session.flush()
 
   count_row = session.execute(
     text("SELECT COUNT(*) AS cnt FROM facts WHERE structure_id = :sid"),

--- a/robosystems/operations/roboledger/schedules/service.py
+++ b/robosystems/operations/roboledger/schedules/service.py
@@ -138,7 +138,7 @@ class ScheduleService:
   management.
   """
 
-  def create_schedule(
+  def _build_schedule_structure(
     self,
     session: Session,
     *,
@@ -149,78 +149,34 @@ class ScheduleService:
     period_end: date,
     monthly_amount: int,
     entry_template: EntryTemplate,
-    schedule_metadata: ScheduleMetadata | None = None,
+    schedule_metadata: ScheduleMetadata | None,
     created_by: str,
-    closed_through: date | None = None,
-    source_transaction_id: str | None = None,
-  ) -> Structure:
-    """Create a schedule with pre-generated facts.
+    source_transaction_id: str | None,
+  ) -> tuple[Structure, dict, dict, str]:
+    """Create the Structure row, its element associations, and the
+    cm:Debit/cm:Credit has-part posting arcs for a new schedule.
 
-    Creates a structure (type=schedule), associations to the referenced
-    elements, and facts for each monthly period between period_start and
-    period_end.
+    Factored out of :meth:`create_schedule` so the rebuild path
+    (``existing_structure``) can reuse the same fact-generation tail
+    without re-creating the structure, associations, or arcs (those are
+    preserved on rebuild).
 
-    Args:
-        session: Extensions DB session.
-        name: Schedule name (e.g., "Office Furniture Depreciation").
-        taxonomy_id: Taxonomy to attach to. If None, uses or creates
-            a default "Schedules" taxonomy.
-        element_ids: Element IDs to include in the schedule (e.g.,
-            [depreciation_expense_id, accumulated_depreciation_id]).
-        period_start: First period start date.
-        period_end: Last period end date.
-        monthly_amount: Monthly amount in cents (e.g., depreciation per month).
-        entry_template: Template for generating closing entries.
-        schedule_metadata: Informational metadata about the schedule.
-        created_by: User ID.
-        closed_through: If provided, facts with period_end ≤ this date are
-            tagged `fact_scope='historical'` (already reflected in opening
-            balances, ignored by the close workflow). Facts with period_end
-            > closed_through are tagged `in_scope`. None means all facts
-            are in_scope — backward compatible with callers that haven't
-            adopted the fiscal calendar yet.
-
-    Returns:
-        The created Structure.
+    Returns ``(structure, metadata, artifact_mechanics, taxonomy_id)``.
     """
     # Resolve or create taxonomy
     if not taxonomy_id:
       taxonomy_id = self._ensure_schedule_taxonomy(session, created_by)
 
     # Create structure with entry template metadata
-    metadata = {
-      "entry_template": {
-        "debit_element_id": entry_template.debit_element_id,
-        "credit_element_id": entry_template.credit_element_id,
-        "entry_type": entry_template.entry_type,
-        "memo_template": entry_template.memo_template or f"Monthly schedule - {name}",
-        "auto_reverse": entry_template.auto_reverse,
-      },
-    }
-    if schedule_metadata:
-      metadata["schedule_metadata"] = {
-        "method": schedule_metadata.method,
-        "original_amount": schedule_metadata.original_amount,
-        "residual_value": schedule_metadata.residual_value,
-        "useful_life_months": schedule_metadata.useful_life_months,
-        "asset_element_id": schedule_metadata.asset_element_id,
-        "periodic_amounts": schedule_metadata.periodic_amounts,
-      }
-
-    # Stamp the typed artifact_mechanics column alongside the legacy
-    # metadata_ blob so the envelope builder's typed-column read path
-    # works from creation. metadata_ stays populated during the
-    # transition window for backward compatibility with rows written
-    # before artifact_mechanics landed.
-    # periods_with_entries is a transient read-time value (queried from facts),
-    # not a stored property — intentionally excluded here rather than using
-    # ScheduleMechanics.model_dump(); it is injected by the envelope builder.
-    artifact_mechanics: dict[str, object] = {
-      "kind": "closing_entry_generator",
-      "entry_template": metadata["entry_template"],
-      "schedule_metadata": metadata.get("schedule_metadata"),
-      "source_transaction_id": source_transaction_id,
-    }
+    metadata, artifact_mechanics = self._build_schedule_definition_blobs(
+      name=name,
+      monthly_amount=monthly_amount,
+      period_start=period_start,
+      period_end=period_end,
+      entry_template=entry_template,
+      schedule_metadata=schedule_metadata,
+      source_transaction_id=source_transaction_id,
+    )
 
     structure = Structure(
       name=name,
@@ -282,6 +238,157 @@ class ScheduleService:
           association_type="has-part",
           arcrole=CM_HAS_PART_ARCROLE,
           created_by=created_by,
+        )
+      )
+
+    return structure, metadata, artifact_mechanics, taxonomy_id
+
+  @staticmethod
+  def _build_schedule_definition_blobs(
+    *,
+    name: str,
+    monthly_amount: int,
+    period_start: date,
+    period_end: date,
+    entry_template: EntryTemplate,
+    schedule_metadata: ScheduleMetadata | None,
+    source_transaction_id: str | None,
+  ) -> tuple[dict, dict]:
+    """Build the ``metadata_`` and ``artifact_mechanics`` JSONB blobs that
+    persist a schedule's reproducible definition.
+
+    ``monthly_amount`` + ``period_start`` + ``period_end`` are stored
+    alongside the entry template + schedule metadata so a later
+    ``rebuild_schedule`` can reconstruct the exact generation inputs
+    unambiguously (no derivation from facts required).
+    """
+    metadata: dict[str, object] = {
+      "entry_template": {
+        "debit_element_id": entry_template.debit_element_id,
+        "credit_element_id": entry_template.credit_element_id,
+        "entry_type": entry_template.entry_type,
+        "memo_template": entry_template.memo_template or f"Monthly schedule - {name}",
+        "auto_reverse": entry_template.auto_reverse,
+      },
+      # Reproducible generation inputs — let rebuild_schedule reconstruct
+      # the schedule from metadata alone without re-deriving from facts.
+      "monthly_amount": monthly_amount,
+      "period_start": period_start.isoformat(),
+      "period_end": period_end.isoformat(),
+    }
+    if schedule_metadata:
+      metadata["schedule_metadata"] = {
+        "method": schedule_metadata.method,
+        "original_amount": schedule_metadata.original_amount,
+        "residual_value": schedule_metadata.residual_value,
+        "useful_life_months": schedule_metadata.useful_life_months,
+        "asset_element_id": schedule_metadata.asset_element_id,
+        "periodic_amounts": schedule_metadata.periodic_amounts,
+      }
+
+    # Stamp the typed artifact_mechanics column alongside the legacy
+    # metadata_ blob so the envelope builder's typed-column read path
+    # works from creation. metadata_ stays populated during the
+    # transition window for backward compatibility with rows written
+    # before artifact_mechanics landed.
+    # periods_with_entries is a transient read-time value (queried from facts),
+    # not a stored property — intentionally excluded here rather than using
+    # ScheduleMechanics.model_dump(); it is injected by the envelope builder.
+    artifact_mechanics: dict[str, object] = {
+      "kind": "closing_entry_generator",
+      "entry_template": metadata["entry_template"],
+      "schedule_metadata": metadata.get("schedule_metadata"),
+      "source_transaction_id": source_transaction_id,
+      "monthly_amount": monthly_amount,
+      "period_start": period_start.isoformat(),
+      "period_end": period_end.isoformat(),
+    }
+    return metadata, artifact_mechanics
+
+  def create_schedule(
+    self,
+    session: Session,
+    *,
+    name: str,
+    taxonomy_id: str | None,
+    element_ids: list[str],
+    period_start: date,
+    period_end: date,
+    monthly_amount: int,
+    entry_template: EntryTemplate,
+    schedule_metadata: ScheduleMetadata | None = None,
+    created_by: str,
+    closed_through: date | None = None,
+    source_transaction_id: str | None = None,
+    existing_structure: Structure | None = None,
+  ) -> Structure:
+    """Create a schedule with pre-generated facts.
+
+    Creates a structure (type=schedule), associations to the referenced
+    elements, and facts for each monthly period between period_start and
+    period_end.
+
+    Args:
+        session: Extensions DB session.
+        name: Schedule name (e.g., "Office Furniture Depreciation").
+        taxonomy_id: Taxonomy to attach to. If None, uses or creates
+            a default "Schedules" taxonomy.
+        element_ids: Element IDs to include in the schedule (e.g.,
+            [depreciation_expense_id, accumulated_depreciation_id]).
+        period_start: First period start date.
+        period_end: Last period end date.
+        monthly_amount: Monthly amount in cents (e.g., depreciation per month).
+        entry_template: Template for generating closing entries.
+        schedule_metadata: Informational metadata about the schedule.
+        created_by: User ID.
+        closed_through: If provided, facts with period_end ≤ this date are
+            tagged `fact_scope='historical'` (already reflected in opening
+            balances, ignored by the close workflow). Facts with period_end
+            > closed_through are tagged `in_scope`. None means all facts
+            are in_scope — backward compatible with callers that haven't
+            adopted the fiscal calendar yet.
+        existing_structure: When provided, regenerate facts + the
+            obligation chain **in place** on this existing Structure row
+            instead of creating a new one. The structure, its element
+            associations, and its cm has-part arcs are preserved; only
+            the freshly-stamped definition blobs + facts + obligation
+            events are written. The caller (``rebuild_schedule``) is
+            responsible for voiding the old obligation chain and deleting
+            the old facts/rules before invoking this path. ``element_ids``
+            is ignored in this mode (associations are preserved).
+
+    Returns:
+        The created (or rebuilt) Structure.
+    """
+    if existing_structure is not None:
+      structure = existing_structure
+      taxonomy_id = str(structure.taxonomy_id)
+      metadata, artifact_mechanics = self._build_schedule_definition_blobs(
+        name=name,
+        monthly_amount=monthly_amount,
+        period_start=period_start,
+        period_end=period_end,
+        entry_template=entry_template,
+        schedule_metadata=schedule_metadata,
+        source_transaction_id=source_transaction_id,
+      )
+      structure.metadata_ = metadata
+      structure.artifact_mechanics = artifact_mechanics
+      session.flush()
+    else:
+      structure, metadata, artifact_mechanics, taxonomy_id = (
+        self._build_schedule_structure(
+          session,
+          name=name,
+          taxonomy_id=taxonomy_id,
+          element_ids=element_ids,
+          period_start=period_start,
+          period_end=period_end,
+          monthly_amount=monthly_amount,
+          entry_template=entry_template,
+          schedule_metadata=schedule_metadata,
+          created_by=created_by,
+          source_transaction_id=source_transaction_id,
         )
       )
 
@@ -604,6 +711,15 @@ class ScheduleService:
     artifact_mechanics["schedule_created_event_id"] = schedule_created_event_id
     artifact_mechanics["pending_event_count"] = pending_event_count
     structure.artifact_mechanics = artifact_mechanics
+
+    # On the rebuild path the Structure already lives in the DB, so the
+    # in-place JSONB reassignment above must be flagged for SQLAlchemy to
+    # emit the UPDATE (a fresh-create row is dirty regardless).
+    if existing_structure is not None:
+      from sqlalchemy.orm.attributes import flag_modified
+
+      flag_modified(structure, "metadata_")
+      flag_modified(structure, "artifact_mechanics")
 
     session.flush()
     return structure

--- a/robosystems/routers/extensions/roboledger/operations.py
+++ b/robosystems/routers/extensions/roboledger/operations.py
@@ -156,6 +156,8 @@ from robosystems.models.api.extensions.reports import (
 from robosystems.models.api.extensions.schedules import (
   PromoteObligationsRequest,
   PromoteObligationsResponse,
+  RebuildScheduleRequest,
+  ScheduleCreatedResponse,
 )
 from robosystems.models.api.extensions.taxonomies import (
   AssociationResponse,
@@ -343,6 +345,9 @@ from robosystems.operations.roboledger.commands.schedules import (
 )
 from robosystems.operations.roboledger.commands.schedules import (
   promote_obligations as cmd_promote_obligations,
+)
+from robosystems.operations.roboledger.commands.schedules import (
+  rebuild_schedule as cmd_rebuild_schedule,
 )
 from robosystems.operations.roboledger.commands.taxonomies import (
   AssociationNotFoundError,
@@ -1414,6 +1419,43 @@ promote_obligations_op = _registrar.register(
     request_model=PromoteObligationsRequest,
     result_type=PromoteObligationsResponse,
     error_map={ValueError: 422},
+  )
+)
+
+
+# Re-run the schedule generator in place on an existing schedule. Atomic
+# alternative to delete-then-recreate (which orphans the obligation chain):
+# preserves the structure id + element associations + taxonomy, voids the
+# old pending obligation chain, deletes the old facts + rules, and
+# regenerates fresh forward facts + a fresh obligation chain from the
+# schedule's stored definition. Re-scopes historical-vs-in-scope from the
+# CURRENT fiscal calendar `closed_through`. This is the redo-after-a-
+# generator-fix path (e.g. the roll-forward direction fix).
+rebuild_schedule_op = _registrar.register(
+  OperationSpec(
+    name="rebuild-schedule",
+    summary="Rebuild Schedule In Place",
+    description=(
+      "Re-run the schedule generator in place on an existing schedule. "
+      "Atomic alternative to delete-then-recreate (which orphans pending "
+      "obligations): preserves the structure id + element associations + "
+      "taxonomy, voids the old pending obligation chain, deletes the old "
+      "facts and SumEquals rules, and regenerates fresh forward facts + a "
+      "fresh obligation chain from the schedule's stored definition "
+      "(entry_template / schedule_metadata / monthly_amount / period "
+      "bounds). The historical-vs-in-scope split is re-derived from the "
+      "CURRENT fiscal calendar closed_through. Use this to pick up a fixed "
+      "generator (e.g. the roll-forward direction fix) without orphaning "
+      "obligations."
+    ),
+    command=cmd_rebuild_schedule,
+    request_model=RebuildScheduleRequest,
+    result_type=ScheduleCreatedResponse,
+    error_map={
+      ScheduleNotFoundError: 404,
+      ValueError: 422,
+    },
+    mark_stale_reason="schedule_rebuilt",
   )
 )
 

--- a/tests/operations/roboledger/commands/test_schedules.py
+++ b/tests/operations/roboledger/commands/test_schedules.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 
 from robosystems.models.api.extensions.schedules import (
   DeleteScheduleRequest,
+  RebuildScheduleRequest,
   UpdateScheduleRequest,
 )
 from robosystems.models.extensions import (
@@ -19,6 +20,7 @@ from robosystems.models.extensions import (
 from robosystems.models.extensions.roboledger import Fact
 from robosystems.operations.roboledger.commands.schedules import (
   delete_schedule,
+  rebuild_schedule,
   update_schedule,
 )
 
@@ -337,3 +339,201 @@ def test_promote_obligations_maps_result_and_commits() -> None:
   assert resp.error_count == 1
   assert resp.classified_event_ids == ["evt_a", "evt_b"]
   assert resp.errors == [{"event_id": "evt_b", "error": "boom"}]
+
+
+# ─── rebuild_schedule ─────────────────────────────────────────────────────
+
+
+def _rebuild_structure() -> MagicMock:
+  """A schedule Structure whose stored metadata carries a full,
+  reproducible definition (the post-create-schedule shape)."""
+  structure = MagicMock()
+  structure.id = "struct_rebuild"
+  structure.name = "Depreciation Schedule"
+  structure.block_type = "schedule"
+  structure.taxonomy_id = "tax_1"
+  structure.metadata_ = {
+    "entry_template": {
+      "debit_element_id": "elem_dr",
+      "credit_element_id": "elem_cr",
+      "entry_type": "closing",
+      "memo_template": "Monthly depreciation",
+      "auto_reverse": False,
+    },
+    "schedule_metadata": {
+      "method": "straight_line",
+      "original_amount": 120_000,
+      "residual_value": 0,
+      "useful_life_months": 12,
+      "asset_element_id": "elem_asset",
+      "periodic_amounts": None,
+    },
+    "monthly_amount": 10_000,
+    "period_start": "2026-01-01",
+    "period_end": "2026-03-31",
+    "schedule_created_event_id": "evt_old_origin",
+    "pending_event_count": 3,
+  }
+  return structure
+
+
+def _rebuild_session(structure: MagicMock) -> tuple[MagicMock, list[type]]:
+  """Wire a MagicMock session for the rebuild orchestration.
+
+  execute call order:
+    1. _load_schedule_or_404 → scalar_one_or_none → structure
+    2. select(Rule.id) for cascade delete → scalars().all()
+    3. count facts → fetchone
+    4. count distinct periods → fetchone
+  query().filter().delete() captures the deleted models in order.
+  _calendar_closed_through_date uses session.query(FiscalCalendar).first().
+  """
+  deleted_models: list[type] = []
+  session = MagicMock()
+  session.execute.side_effect = [
+    _exec_result(row=structure),  # _load_schedule_or_404
+    _exec_result(scalars_all=["rule_old_1"]),  # select(Rule.id)
+    _exec_result(fetchone_row=MagicMock(cnt=6)),  # count facts
+    _exec_result(fetchone_row=MagicMock(cnt=3)),  # count distinct periods
+  ]
+
+  # session.query(...) is used both by _calendar_closed_through_date
+  # (FiscalCalendar.first() → None) and by the cascade deletes
+  # (.filter().delete()).
+  def _query(model):
+    if model.__name__ == "FiscalCalendar":
+      q = MagicMock()
+      q.first.return_value = None
+      return q
+    return _Query(model, deleted_models)
+
+  session.query.side_effect = _query
+  return session, deleted_models
+
+
+def test_rebuild_schedule_voids_old_obligations_and_regenerates() -> None:
+  from unittest.mock import patch
+
+  structure = _rebuild_structure()
+  session, deleted_models = _rebuild_session(structure)
+
+  # create_schedule returns the (in-place) structure; stamp the fresh chain.
+  rebuilt = structure
+  rebuilt.metadata_ = {
+    **structure.metadata_,
+    "schedule_created_event_id": "evt_new_origin",
+    "pending_event_count": 3,
+  }
+
+  with (
+    patch(
+      "robosystems.operations.roboledger.commands.schedules."
+      "ScheduleService.void_pending_obligations",
+      return_value=3,
+    ) as void,
+    patch(
+      "robosystems.operations.roboledger.commands.schedules."
+      "ScheduleService.create_schedule",
+      return_value=rebuilt,
+    ) as create,
+    patch(
+      "robosystems.operations.roboledger.commands.schedules."
+      "evaluate_rules_for_structure",
+      return_value=[],
+    ),
+  ):
+    resp = rebuild_schedule(
+      session,
+      RebuildScheduleRequest(structure_id="struct_rebuild"),
+      created_by="usr_admin",
+    )
+
+  # Old pending chain voided before regeneration, with the rebuild reason.
+  void.assert_called_once()
+  assert void.call_args.kwargs["structure"] is structure
+  assert void.call_args.kwargs["void_reason"] == "schedule_rebuilt"
+
+  # Regeneration runs in place on the SAME structure (id preserved).
+  create.assert_called_once()
+  ckwargs = create.call_args.kwargs
+  assert ckwargs["existing_structure"] is structure
+  assert ckwargs["taxonomy_id"] == "tax_1"
+  assert ckwargs["monthly_amount"] == 10_000
+  assert ckwargs["period_start"].isoformat() == "2026-01-01"
+  assert ckwargs["period_end"].isoformat() == "2026-03-31"
+  # Definition reconstructed from metadata.
+  assert ckwargs["entry_template"].debit_element_id == "elem_dr"
+  assert ckwargs["schedule_metadata"].original_amount == 120_000
+  assert ckwargs["created_by"] == "usr_admin"
+
+  # Old facts/factsets/rules deleted, but NOT associations or the structure.
+  assert VerificationResult in deleted_models
+  assert Fact in deleted_models
+  assert FactSet in deleted_models
+  assert Rule in deleted_models
+  assert Association not in deleted_models
+  session.delete.assert_not_called()
+
+  session.commit.assert_called_once()
+
+  # Response shape mirrors create_schedule.
+  assert resp.structure_id == "struct_rebuild"
+  assert resp.total_periods == 3
+  assert resp.total_facts == 6
+  assert resp.schedule_created_event_id == "evt_new_origin"
+
+
+def test_rebuild_schedule_preserves_structure_id_and_associations() -> None:
+  """The structure row + its associations survive a rebuild."""
+  from unittest.mock import patch
+
+  structure = _rebuild_structure()
+  session, deleted_models = _rebuild_session(structure)
+
+  with (
+    patch(
+      "robosystems.operations.roboledger.commands.schedules."
+      "ScheduleService.void_pending_obligations",
+      return_value=0,
+    ),
+    patch(
+      "robosystems.operations.roboledger.commands.schedules."
+      "ScheduleService.create_schedule",
+      return_value=structure,
+    ),
+    patch(
+      "robosystems.operations.roboledger.commands.schedules."
+      "evaluate_rules_for_structure",
+      return_value=[],
+    ),
+  ):
+    resp = rebuild_schedule(
+      session,
+      RebuildScheduleRequest(structure_id="struct_rebuild"),
+    )
+
+  # Structure itself is never deleted; associations are preserved.
+  session.delete.assert_not_called()
+  assert Association not in deleted_models
+  assert resp.structure_id == "struct_rebuild"
+
+
+def test_rebuild_schedule_raises_when_definition_unreconstructable() -> None:
+  """A schedule with no stored definition and no facts can't be rebuilt."""
+  import pytest
+
+  structure = MagicMock()
+  structure.id = "struct_legacy"
+  structure.block_type = "schedule"
+  structure.metadata_ = {}  # no entry_template
+
+  session = MagicMock()
+  session.execute.side_effect = [_exec_result(row=structure)]
+
+  with pytest.raises(ValueError, match="entry_template"):
+    rebuild_schedule(
+      session,
+      RebuildScheduleRequest(structure_id="struct_legacy"),
+    )
+
+  session.commit.assert_not_called()

--- a/tests/operations/roboledger/commands/test_schedules.py
+++ b/tests/operations/roboledger/commands/test_schedules.py
@@ -374,28 +374,43 @@ def _rebuild_structure() -> MagicMock:
     "schedule_created_event_id": "evt_old_origin",
     "pending_event_count": 3,
   }
+  structure.artifact_mechanics = {
+    "source_transaction_id": "txn_origin",
+    "schedule_created_event_id": "evt_old_origin",
+  }
   return structure
 
 
-def _rebuild_session(structure: MagicMock) -> tuple[MagicMock, list[type]]:
+def _rebuild_session(
+  structure: MagicMock, *, posted_count: int = 0, old_event=None
+) -> tuple[MagicMock, list[type]]:
   """Wire a MagicMock session for the rebuild orchestration.
 
   execute call order:
     1. _load_schedule_or_404 → scalar_one_or_none → structure
-    2. select(Rule.id) for cascade delete → scalars().all()
-    3. count facts → fetchone
-    4. count distinct periods → fetchone
+    2. posted-entry guard → fetchone → MagicMock(c=posted_count)
+    3. select(Rule.id) for cascade delete → scalars().all()
+    4. DELETE line_items (draft sweep) → execute (result unused)
+    5. DELETE entries (draft sweep) → execute (result unused)
+    6. count facts → fetchone
+    7. count distinct periods → fetchone
   query().filter().delete() captures the deleted models in order.
   _calendar_closed_through_date uses session.query(FiscalCalendar).first().
+  session.get(Event, ...) returns ``old_event`` (the supersede path).
   """
   deleted_models: list[type] = []
   session = MagicMock()
   session.execute.side_effect = [
     _exec_result(row=structure),  # _load_schedule_or_404
+    _exec_result(fetchone_row=MagicMock(c=posted_count)),  # posted-entry guard
     _exec_result(scalars_all=["rule_old_1"]),  # select(Rule.id)
+    _exec_result(),  # DELETE line_items (draft sweep)
+    _exec_result(),  # DELETE entries (draft sweep)
     _exec_result(fetchone_row=MagicMock(cnt=6)),  # count facts
     _exec_result(fetchone_row=MagicMock(cnt=3)),  # count distinct periods
   ]
+
+  session.get.return_value = old_event
 
   # session.query(...) is used both by _calendar_closed_through_date
   # (FiscalCalendar.first() → None) and by the cascade deletes
@@ -537,3 +552,184 @@ def test_rebuild_schedule_raises_when_definition_unreconstructable() -> None:
     )
 
   session.commit.assert_not_called()
+
+
+def test_rebuild_schedule_guards_posted_entries() -> None:
+  """A schedule with posted closing entries refuses to rebuild."""
+  from unittest.mock import patch
+
+  import pytest
+
+  structure = _rebuild_structure()
+  # Posted-entry guard returns c=2; the rebuild must bail before any
+  # void/regeneration work.
+  session, _ = _rebuild_session(structure, posted_count=2)
+
+  with (
+    patch(
+      "robosystems.operations.roboledger.commands.schedules."
+      "ScheduleService.void_pending_obligations",
+      return_value=0,
+    ) as void,
+    patch(
+      "robosystems.operations.roboledger.commands.schedules."
+      "ScheduleService.create_schedule",
+      return_value=structure,
+    ) as create,
+    pytest.raises(ValueError, match="posted"),
+  ):
+    rebuild_schedule(
+      session,
+      RebuildScheduleRequest(structure_id="struct_rebuild"),
+    )
+
+  # Guard fires before voiding/regeneration and the transaction never commits.
+  void.assert_not_called()
+  create.assert_not_called()
+  session.commit.assert_not_called()
+
+
+def test_rebuild_schedule_preserves_source_transaction_id() -> None:
+  """The source_transaction_id back-ref survives a rebuild — recovered
+  from artifact_mechanics and passed through to create_schedule."""
+  from unittest.mock import patch
+
+  structure = _rebuild_structure()
+  session, _ = _rebuild_session(structure)
+
+  rebuilt = structure
+  rebuilt.metadata_ = {
+    **structure.metadata_,
+    "schedule_created_event_id": "evt_new_origin",
+  }
+
+  with (
+    patch(
+      "robosystems.operations.roboledger.commands.schedules."
+      "ScheduleService.void_pending_obligations",
+      return_value=0,
+    ),
+    patch(
+      "robosystems.operations.roboledger.commands.schedules."
+      "ScheduleService.create_schedule",
+      return_value=rebuilt,
+    ) as create,
+    patch(
+      "robosystems.operations.roboledger.commands.schedules."
+      "evaluate_rules_for_structure",
+      return_value=[],
+    ),
+  ):
+    rebuild_schedule(
+      session,
+      RebuildScheduleRequest(structure_id="struct_rebuild"),
+    )
+
+  create.assert_called_once()
+  assert create.call_args.kwargs["source_transaction_id"] == "txn_origin"
+
+
+def test_rebuild_schedule_supersedes_old_originator() -> None:
+  """After a rebuild the old schedule_created event is voided and back-linked
+  to the new originator."""
+  from unittest.mock import patch
+
+  structure = _rebuild_structure()
+  old_evt = MagicMock()
+  old_evt.id = "evt_old_origin"
+  old_evt.status = "committed"
+  old_evt.replaced_by_event_id = None
+  session, _ = _rebuild_session(structure, old_event=old_evt)
+
+  # create_schedule re-stamps the originator on the in-place structure. Mutate
+  # metadata inside the mock so the OLD id is still readable when rebuild_schedule
+  # captures it (before the void), and the NEW id afterward.
+  def _restamp(*_args, **_kwargs):
+    structure.metadata_ = {
+      **structure.metadata_,
+      "schedule_created_event_id": "evt_new_origin",
+    }
+    return structure
+
+  with (
+    patch(
+      "robosystems.operations.roboledger.commands.schedules."
+      "ScheduleService.void_pending_obligations",
+      return_value=0,
+    ),
+    patch(
+      "robosystems.operations.roboledger.commands.schedules."
+      "ScheduleService.create_schedule",
+      side_effect=_restamp,
+    ),
+    patch(
+      "robosystems.operations.roboledger.commands.schedules."
+      "evaluate_rules_for_structure",
+      return_value=[],
+    ),
+  ):
+    rebuild_schedule(
+      session,
+      RebuildScheduleRequest(structure_id="struct_rebuild"),
+    )
+
+  # Old originator loaded by id, voided, and linked to its replacement.
+  from robosystems.models.extensions.roboledger.event import Event
+
+  session.get.assert_called_once_with(Event, "evt_old_origin")
+  assert old_evt.status == "voided"
+  assert old_evt.replaced_by_event_id == "evt_new_origin"
+
+
+def test_reconstruct_schedule_definition_legacy_fallback() -> None:
+  """A legacy schedule with no scalar inputs derives period bounds from the
+  FactSet and monthly_amount from the first duration debit fact."""
+  from datetime import date
+  from unittest.mock import patch
+
+  from robosystems.operations.roboledger.commands.schedules import (
+    _reconstruct_schedule_definition,
+  )
+
+  structure = MagicMock()
+  structure.id = "struct_legacy"
+  structure.artifact_mechanics = None
+  structure.metadata_ = {
+    "entry_template": {
+      "debit_element_id": "elem_dr",
+      "credit_element_id": "elem_cr",
+    },
+    # No monthly_amount / period_start / period_end → legacy fallbacks fire.
+  }
+
+  session = MagicMock()
+  # 1. FactSet bounds (fetchall) → min_start / max_end rows.
+  bounds_result = MagicMock()
+  bounds_result.fetchall.return_value = [
+    MagicMock(min_start=date(2026, 1, 1), max_end=date(2026, 2, 28)),
+    MagicMock(min_start=date(2026, 2, 1), max_end=date(2026, 3, 31)),
+  ]
+  # 2. first duration debit fact value (scalar) → 10_000.00 dollars.
+  debit_result = MagicMock()
+  debit_result.scalar.return_value = 10_000.0
+  session.execute.side_effect = [bounds_result, debit_result]
+
+  with patch(
+    "robosystems.operations.roboledger.commands.schedules.select",
+    return_value=MagicMock(),
+  ):
+    (
+      entry_template,
+      schedule_metadata,
+      monthly_amount,
+      period_start,
+      period_end,
+      source_transaction_id,
+    ) = _reconstruct_schedule_definition(session, structure)
+
+  assert entry_template.debit_element_id == "elem_dr"
+  assert schedule_metadata is None
+  assert period_start == date(2026, 1, 1)
+  assert period_end == date(2026, 3, 31)
+  assert monthly_amount == 1_000_000  # 10_000.00 * 100 cents
+  assert source_transaction_id is None

--- a/tests/operations/roboledger/schedules/test_service.py
+++ b/tests/operations/roboledger/schedules/test_service.py
@@ -331,6 +331,165 @@ class TestCreateSchedule:
         assert round(obj.value, 2) == obj.value, f"Unrounded value: {obj.value}"
 
 
+class TestCreateScheduleExistingStructure:
+  """create_schedule(existing_structure=...) regenerates facts + the
+  obligation chain on an existing Structure WITHOUT re-creating the
+  structure row, its element associations, or its cm has-part arcs."""
+
+  def test_existing_structure_path_skips_structure_and_associations(self):
+    from robosystems.models.extensions.roboledger import Association, Structure
+
+    session = _mock_session()
+    svc = ScheduleService()
+
+    existing = Structure(
+      name="Rebuilt Schedule",
+      block_type="schedule",
+      taxonomy_id="tax_existing",
+      concept_arrangement="roll_forward",
+    )
+    existing.id = "struct_existing_01"
+    existing.metadata_ = {}
+    existing.artifact_mechanics = {}
+
+    with patch.object(svc, "_get_entity_id", return_value="ent_01"):
+      result = svc.create_schedule(
+        session,
+        name="Rebuilt Schedule",
+        # element_ids is ignored in the existing_structure path
+        taxonomy_id=None,
+        element_ids=[],
+        period_start=date(2026, 1, 1),
+        period_end=date(2026, 3, 31),
+        monthly_amount=10_000,
+        entry_template=_make_entry_template(),
+        created_by="usr_test",
+        existing_structure=existing,
+      )
+
+    # The returned structure is the SAME object — id preserved.
+    assert result is existing
+    assert result.id == "struct_existing_01"
+
+    added = [c[0][0] for c in session.add.call_args_list]
+    # No new Structure created — we reused the existing one.
+    assert not any(isinstance(o, Structure) for o in added)
+    # No presentation/has-part associations created (preserved on rebuild).
+    assert not any(isinstance(o, Association) for o in added)
+    # Facts WERE regenerated.
+    facts = [o for o in added if type(o).__name__ == "Fact"]
+    assert len(facts) > 0
+
+  def test_existing_structure_uses_its_own_taxonomy(self):
+    from robosystems.models.extensions.roboledger import Structure
+
+    session = _mock_session()
+    svc = ScheduleService()
+
+    existing = Structure(
+      name="Rebuilt",
+      block_type="schedule",
+      taxonomy_id="tax_keep_me",
+      concept_arrangement="roll_forward",
+    )
+    existing.id = "struct_existing_02"
+    existing.metadata_ = {}
+    existing.artifact_mechanics = {}
+
+    with patch.object(svc, "_get_entity_id", return_value="ent_01"):
+      svc.create_schedule(
+        session,
+        name="Rebuilt",
+        # A different taxonomy_id arg must be ignored — the existing
+        # structure's taxonomy is authoritative on rebuild.
+        taxonomy_id="tax_should_be_ignored",
+        element_ids=[],
+        period_start=date(2026, 1, 1),
+        period_end=date(2026, 1, 31),
+        monthly_amount=10_000,
+        entry_template=_make_entry_template(),
+        created_by="usr_test",
+        existing_structure=existing,
+      )
+
+    assert existing.taxonomy_id == "tax_keep_me"
+
+  def test_existing_structure_restamps_reproducible_definition(self):
+    from robosystems.models.extensions.roboledger import Structure
+
+    session = _mock_session()
+    svc = ScheduleService()
+
+    existing = Structure(
+      name="Rebuilt",
+      block_type="schedule",
+      taxonomy_id="tax_existing",
+      concept_arrangement="roll_forward",
+    )
+    existing.id = "struct_existing_03"
+    existing.metadata_ = {}
+    existing.artifact_mechanics = {}
+
+    with patch.object(svc, "_get_entity_id", return_value="ent_01"):
+      svc.create_schedule(
+        session,
+        name="Rebuilt",
+        taxonomy_id="tax_existing",
+        element_ids=[],
+        period_start=date(2026, 2, 1),
+        period_end=date(2026, 4, 30),
+        monthly_amount=12_345,
+        entry_template=_make_entry_template(),
+        created_by="usr_test",
+        existing_structure=existing,
+      )
+
+    # The reproducible scalar inputs are re-stamped so a subsequent
+    # rebuild stays unambiguous.
+    assert existing.metadata_["monthly_amount"] == 12_345
+    assert existing.metadata_["period_start"] == "2026-02-01"
+    assert existing.metadata_["period_end"] == "2026-04-30"
+    assert existing.artifact_mechanics["monthly_amount"] == 12_345
+    # The obligation chain was materialized in place.
+    assert existing.metadata_["schedule_created_event_id"] is not None
+
+  def test_existing_structure_emits_fresh_obligation_chain(self):
+    from robosystems.models.extensions.roboledger import Event, Structure
+
+    session = _mock_session()
+    svc = ScheduleService()
+
+    existing = Structure(
+      name="Rebuilt",
+      block_type="schedule",
+      taxonomy_id="tax_existing",
+      concept_arrangement="roll_forward",
+    )
+    existing.id = "struct_existing_04"
+    existing.metadata_ = {}
+    existing.artifact_mechanics = {}
+
+    with patch.object(svc, "_get_entity_id", return_value="ent_01"):
+      svc.create_schedule(
+        session,
+        name="Rebuilt",
+        taxonomy_id="tax_existing",
+        element_ids=[],
+        period_start=date(2026, 1, 1),
+        period_end=date(2026, 3, 31),  # 3 periods
+        monthly_amount=10_000,
+        entry_template=_make_entry_template(),
+        created_by="usr_test",
+        existing_structure=existing,
+      )
+
+    events = [c[0][0] for c in session.add.call_args_list if isinstance(c[0][0], Event)]
+    creators = [e for e in events if e.event_type == "schedule_created"]
+    pending = [e for e in events if e.event_type == "schedule_entry_due"]
+    assert len(creators) == 1
+    assert len(pending) == 3
+
+
 class TestCreateScheduleHasPartArcs:
   """create_schedule emits cm:Debit/cm:Credit has-part posting arcs so the
   debit/credit pairing is a first-class, queryable atom of the schedule IB."""


### PR DESCRIPTION
## Summary

Adds a `rebuild-schedule` operation that **re-runs the schedule generator in place** on an existing schedule's stored definition — preserving the structure id, its element associations, and its taxonomy, while voiding the old pending obligation chain and regenerating the forward facts + a fresh obligation chain.

This is the atomic alternative to delete-then-recreate, which **orphans the pending obligation chain** (the failure mode fixed in #770). It's the redo-after-a-generator-fix path — e.g. picking up the roll-forward direction fix on existing schedules — without structure-id churn or orphaned obligations.

## Changes

**`create_schedule` refactor (behavior-preserving)** — `robosystems/operations/roboledger/schedules/service.py`
- Extracted the structure-build (Structure row + element associations + cm has-part arcs) into `_build_schedule_structure(...)`, and the metadata/`artifact_mechanics` JSONB construction into a shared `_build_schedule_definition_blobs(...)` helper.
- Added an `existing_structure: Structure | None = None` param. When `None` (default): behaves exactly as before — the existing `create_schedule` test suite is the regression guard and passes unchanged. When provided: reuses the structure, re-stamps the definition blobs (with `flag_modified`), and **skips** structure creation, associations, and arc emission — only the facts + obligation chain regenerate. The fact-generation tail + `_materialize_pending_obligations` run identically for both paths.
- The reproducible scalar inputs (`monthly_amount`, `period_start`, `period_end`) are now persisted in `metadata_` / `artifact_mechanics` so a rebuild reconstructs the definition unambiguously.

**`rebuild_schedule` command** — `robosystems/operations/roboledger/commands/schedules.py`
- `_reconstruct_schedule_definition`: recovers the generation inputs from `metadata_`; for legacy rows missing the scalar keys, derives period bounds from the schedule's `FactSet` and `monthly_amount` from a non-final duration debit fact; raises `ValueError` if unreconstructable.
- `rebuild_schedule`: re-derives `closed_through` from the **current** fiscal calendar (re-scopes to today's close state), voids the old pending chain (`void_reason="schedule_rebuilt"`), cascade-deletes old VerificationResults / Facts / FactSets / SumEquals Rules (**not** the Structure, Associations, or taxonomy), regenerates via `create_schedule(..., existing_structure=structure)`, re-runs the rule engine, and returns a `ScheduleCreatedResponse`.

**Wire-up**
- `RebuildScheduleRequest(structure_id)` — `robosystems/models/api/extensions/schedules.py`.
- Registered `rebuild-schedule` as an `OperationSpec` (projects to REST + MCP + SDK; `ScheduleNotFoundError` → 404, `ValueError` → 422) — `robosystems/routers/extensions/roboledger/operations.py`.

## Testing

- `tests/operations/roboledger/schedules/test_service.py` — `TestCreateScheduleExistingStructure` (4): the `existing_structure` path skips structure/association creation, uses the structure's own taxonomy, re-stamps the reproducible definition, and emits a fresh obligation chain.
- `tests/operations/roboledger/commands/test_schedules.py` — `rebuild_schedule` (3): voids old obligations and regenerates, preserves the structure id + associations, and raises when the definition is unreconstructable.
- `uv run pytest tests/operations/roboledger/ tests/operations/event_block/ -q` → **739 passed** (and an independent re-run of the directly-affected suites → 101 passed).
- `just test-code` (ruff + format + basedpyright + cf-lint) → **passed clean, 0 errors**.
- Full `just test-all` not run in this session.

## Notes

- No DB migration — `monthly_amount`/`period_start`/`period_end` are additive JSONB keys; existing schedules fall back to deriving them from facts.
- Relationship to #770: that PR fixed the *correctness* hole (orphaned obligations no longer double-post); this PR removes the *workflow* that created them — `rebuild-schedule` replaces the create-new-then-delete-old dance with an atomic in-place regenerate.
