### PR TITLE
fix(mcp): anchor SEC graph queries to avoid full-scan timeouts

### DIFF
--- a/robosystems/middleware/mcp/client.py
+++ b/robosystems/middleware/mcp/client.py
@@ -414,8 +414,12 @@ class GraphMCPClient:
           continue
 
         if table_type.upper() == "NODE":
-          # Use static common properties instead of querying each table
+          # Prefer the curated property map for well-known nodes (nice
+          # ordering); for everything else introspect the real columns from
+          # the catalog so the schema isn't reported as a misleading guess.
           sample_properties = self._get_common_properties(table_name)
+          if sample_properties is None:
+            sample_properties = await self._introspect_node_properties(table_name)
 
           schema_info.append(
             {
@@ -451,8 +455,15 @@ class GraphMCPClient:
       sanitized = self._sanitize_error_message(e, "schema retrieval")
       raise GraphAPIError(sanitized)
 
-  def _get_common_properties(self, node_name: str) -> list[str]:
-    """Get commonly used properties for node types."""
+  def _get_common_properties(self, node_name: str) -> list[str] | None:
+    """Curated query-hint properties for well-known node types.
+
+    Returns ``None`` for node types not in the map so the caller can
+    introspect real columns from the catalog instead of emitting a generic
+    guess (the old behavior reported every uncurated node — Structure,
+    Dimension, FactSet, Taxonomy, … — as ``identifier/name/value/...``,
+    which is wrong for most of them).
+    """
     common_props = {
       "Entity": [
         "name",
@@ -486,9 +497,36 @@ class GraphMCPClient:
       "Connection": ["provider", "status", "last_sync", "realm_id", "connection_id"],
       "Unit": ["measure", "numerator_uri", "denominator_uri"],
     }
-    return common_props.get(
-      node_name, ["identifier", "name", "value", "created_at", "updated_at"]
-    )
+    return common_props.get(node_name)
+
+  async def _introspect_node_properties(self, node_name: str) -> list[str]:
+    """Fetch real column names for a node table from the catalog.
+
+    Uses ``CALL TABLE_INFO`` — a catalog lookup, not a data scan, so it is
+    O(1) even on 100M+ node databases. Drops high-dimensional vector
+    columns (embeddings) since they are noise as query hints. Falls back to
+    the legacy generic list only if the catalog call fails.
+    """
+    try:
+      rows = await self.execute_query(
+        f"CALL TABLE_INFO('{node_name}') RETURN name, type"
+      )
+    except Exception as e:  # pragma: no cover - defensive catalog fallback
+      logger.warning(f"TABLE_INFO introspection failed for {node_name}: {e}")
+      return ["identifier", "name", "value", "created_at", "updated_at"]
+
+    properties: list[str] = []
+    for row in rows:
+      col_name = row.get("name", "")
+      col_type = (row.get("type", "") or "").upper()
+      if not col_name:
+        continue
+      # Skip fixed-size array columns (e.g. embedding FLOAT[384]) — not
+      # useful as a Cypher query hint and noisy in the schema output.
+      if "[" in col_type:
+        continue
+      properties.append(col_name)
+    return properties or ["identifier"]
 
   def _get_node_description(self, node_name: str) -> str:
     """Get description for common node types (base + roboledger extension only)."""

--- a/robosystems/middleware/mcp/tools/example_queries_tool.py
+++ b/robosystems/middleware/mcp/tools/example_queries_tool.py
@@ -133,17 +133,29 @@ List of example queries with explanations, tailored to the actual schema present
             {
               "category": "financial",
               "description": "Get company information",
-              "query": "MATCH (e:Entity) RETURN e.name, e.cik, e.ticker, e.sic_description",
-              "explanation": "Entity nodes contain company master data",
+              "query": "MATCH (e:Entity) RETURN e.name, e.cik, e.ticker, e.sic_description LIMIT 25",
+              "explanation": "Entity nodes contain company master data. Filter by ticker (e.ticker = 'MRMD') or CIK for one company — this repo holds thousands of entities, so always LIMIT or filter.",
             },
             {
               "category": "financial",
-              "description": "⭐ CONSOLIDATED Revenue (use has_dimensions=false!)",
-              "query": """MATCH (f:Fact {has_dimensions: false})-[:FACT_HAS_ELEMENT]->(e:Element {qname: 'us-gaap:Revenues'}), (f)-[:FACT_HAS_PERIOD]->(p:Period)
-WHERE f.numeric_value IS NOT NULL
-RETURN p.end_date, p.duration_type, f.numeric_value as revenue
+              "description": "⭐ CONSOLIDATED Revenue for one company (cross-filer robust)",
+              "query": """MATCH (f:Fact {has_dimensions: false})-[:FACT_HAS_ELEMENT]->(e:Element), (f)-[:FACT_HAS_ENTITY]->(ent:Entity {ticker: 'MRMD'}), (f)-[:FACT_HAS_PERIOD]->(p:Period {duration_type: 'annual'})
+WHERE e.canonical_concept = 'revenue' AND f.numeric_value IS NOT NULL
+RETURN ent.ticker, e.qname, p.end_date, f.numeric_value AS revenue
 ORDER BY p.end_date DESC LIMIT 10""",
-              "explanation": "⚠️ CRITICAL: has_dimensions=false filters out segment breakdowns. Use comma-separated patterns in single MATCH for performance.",
+              "explanation": "⚠️ has_dimensions=false drops segment breakdowns (consolidated totals only). Filter on e.canonical_concept ('revenue', 'net_income', ...) rather than a single qname — revenue is tagged us-gaap:Revenues by some filers and us-gaap:RevenueFromContractWithCustomerExcludingAssessedTax by others, and canonical_concept normalizes across both. Use the resolve-element tool to discover concepts.",
+            },
+            {
+              "category": "financial",
+              "description": "Full income statement by ticker (fast Structure traversal)",
+              "query": """MATCH (ent:Entity {ticker: 'MRMD'})<-[:FACT_HAS_ENTITY]-(f:Fact {has_dimensions: false})-[:FACT_HAS_ELEMENT]->(e:Element),
+      (f)-[:FACT_HAS_PERIOD]->(p:Period {duration_type: 'annual'}),
+      (fs:FactSet)-[:FACT_SET_CONTAINS_FACT]->(f),
+      (s:Structure {canonical_type: 'income_statement'})-[:STRUCTURE_HAS_FACT_SET]->(fs)
+WHERE f.numeric_value IS NOT NULL
+RETURN DISTINCT e.qname, f.numeric_value AS value, p.end_date
+ORDER BY p.end_date DESC LIMIT 40""",
+              "explanation": "Pull a whole statement via Structure.canonical_type (income_statement | balance_sheet | cash_flow_statement | equity_statement). ⚠️ ANCHOR ON THE ENTITY (or a Report) FIRST and reach Structure LAST — ~53k filings share canonical_type='income_statement', so leading the MATCH with the Structure node scans them all and times out. For balance sheets, filter Period {period_type: 'instant'} instead of duration_type.",
             },
             {
               "category": "financial",
@@ -243,7 +255,7 @@ RETURN min(n.numeric_value) as min_val, max(n.numeric_value) as max_val""",
         {
           "category": "reference",
           "description": "Available node types in this graph",
-          "info": f"Node types: {', '.join(node_types[:10])}",
+          "info": f"Node types: {', '.join(node_types)}",
           "explanation": "Use these labels in your MATCH patterns",
         }
       )
@@ -252,7 +264,7 @@ RETURN min(n.numeric_value) as min_val, max(n.numeric_value) as max_val""",
           {
             "category": "reference",
             "description": "Available relationship types",
-            "info": f"Relationships: {', '.join(rel_types[:10])}",
+            "info": f"Relationships: {', '.join(rel_types)}",
             "explanation": "Use these in relationship patterns like -[:TYPE]->",
           }
         )

--- a/robosystems/operations/roboledger/views/fact_query.py
+++ b/robosystems/operations/roboledger/views/fact_query.py
@@ -185,13 +185,24 @@ async def query_fact_grid(
   entity_list = entities if entities else ([entity] if entity else None)
   entity_pattern, entity_where = _build_entity_match(entity_list, parameters)
 
-  match_parts = [
-    f"(f:Fact)-[:FACT_HAS_ELEMENT]->{element_pattern}",
-    "(f)-[:FACT_HAS_PERIOD]->(p:Period)",
-    "(f)-[:FACT_HAS_UNIT]->(u:Unit)",
-  ]
+  # Anchor the traversal on the Entity when an entity filter is present so the
+  # planner seeds from the ~thousands of Entity nodes (single tickers are
+  # inline-anchored to one) and never full-scans the 100M+ Fact nodes that
+  # leading with (f:Fact) forces. Multi-entity / CIK / name comparisons lost
+  # the single-ticker inline anchor and degraded to a full Fact scan (25s+
+  # timeout) before this; leading with Entity keeps them sub-second.
   if entity_pattern:
-    match_parts.append(f"(f)-[:FACT_HAS_ENTITY]->{entity_pattern}")
+    match_parts = [
+      f"{entity_pattern}<-[:FACT_HAS_ENTITY]-(f:Fact)-[:FACT_HAS_ELEMENT]->{element_pattern}",
+      "(f)-[:FACT_HAS_PERIOD]->(p:Period)",
+      "(f)-[:FACT_HAS_UNIT]->(u:Unit)",
+    ]
+  else:
+    match_parts = [
+      f"(f:Fact)-[:FACT_HAS_ELEMENT]->{element_pattern}",
+      "(f)-[:FACT_HAS_PERIOD]->(p:Period)",
+      "(f)-[:FACT_HAS_UNIT]->(u:Unit)",
+    ]
 
   where_clauses = ["f.has_dimensions = false", *element_where, *entity_where]
 

--- a/robosystems/operations/roboledger/views/financial_statement_query.py
+++ b/robosystems/operations/roboledger/views/financial_statement_query.py
@@ -26,14 +26,24 @@ async def query_financial_statement(
   period_type: str | None = None,
   limit: int = 50,
 ) -> list[dict[str, Any]]:
-  """Run the `Structure → FactSet → Fact` traversal for a statement.
+  """Run the `Fact → FactSet → Structure` traversal for a statement.
 
-  Either ``report_id`` or ``ticker`` must be provided:
+  Either ``report_id`` or ``ticker`` must be provided. **Both paths lead
+  with the selective, indexed anchor and reach the globally-scoped
+  ``Structure {canonical_type: ...}`` node LAST**, through facts that are
+  already constrained:
 
-  - ``report_id`` (fast path): starts from the Report node and
-    intersects with FactSet membership. Selective and planner-friendly.
-  - ``ticker`` (slower): Structure-first traversal anchored on the
-    matching Entity. Used when a caller doesn't know the report id.
+  - ``report_id`` path: anchors on the single ``Report`` node, expands to
+    its facts, then up to each fact's FactSet and that FactSet's Structure.
+  - ``ticker`` path: anchors on the single ``Entity`` node, same expansion.
+
+  This ordering matters. ``canonical_type`` is not indexed and ~53k
+  ``Structure`` nodes share ``income_statement`` on the SEC repo (one per
+  filing). Leading with ``(s:Structure {canonical_type})`` makes the
+  planner scan every such structure → every FactSet → millions of facts
+  before intersecting down to one report, which times out. Leading with
+  the indexed anchor (``Report.identifier`` / ``Entity.ticker``) keeps the
+  intermediate result set to a single filer's facts.
 
   ``period_type`` drives inline ``Period`` filters:
 
@@ -65,33 +75,39 @@ async def query_financial_statement(
 
   period_match = f"(f)-[:FACT_HAS_PERIOD]->(p:Period{period_props})"
 
+  # Reach the globally-scoped Structure node LAST, through already-constrained
+  # facts. The standalone Structure anchor is the FactSet→Structure tail —
+  # never the scan root. See the docstring for why ordering is load-bearing.
+  structure_match = (
+    "(s:Structure {canonical_type: $statement_type})"
+    + "-[:STRUCTURE_HAS_FACT_SET]->(fs)"
+  )
+  factset_match = "(fs:FactSet)-[:FACT_SET_CONTAINS_FACT]->(f)"
+
   if report_id:
-    # Fast path: anchor on Report, intersect with FactSet.
+    # Anchor on the single indexed Report node.
     match_parts = [
-      (
-        "(s:Structure {canonical_type: $statement_type})"
-        + "-[:STRUCTURE_HAS_FACT_SET]->(fs:FactSet)"
-      ),
       (
         "(r:Report {identifier: $report_id})"
         + "-[:REPORT_HAS_FACT]->(f:Fact {has_dimensions: false})"
         + "-[:FACT_HAS_ELEMENT]->(e:Element)"
       ),
-      "(fs)-[:FACT_SET_CONTAINS_FACT]->(f)",
       period_match,
+      factset_match,
+      structure_match,
     ]
     parameters["report_id"] = report_id
   else:
-    # Ticker path: Structure-first traversal, anchor on Entity.
+    # Anchor on the single indexed Entity node.
     match_parts = [
       (
-        "(s:Structure {canonical_type: $statement_type})"
-        + "-[:STRUCTURE_HAS_FACT_SET]->(fs:FactSet)"
-        + "-[:FACT_SET_CONTAINS_FACT]->(f:Fact {has_dimensions: false})"
+        "(ent:Entity {ticker: $ticker})"
+        + "<-[:FACT_HAS_ENTITY]-(f:Fact {has_dimensions: false})"
         + "-[:FACT_HAS_ELEMENT]->(e:Element)"
       ),
       period_match,
-      "(f)-[:FACT_HAS_ENTITY]->(ent:Entity {ticker: $ticker})",
+      factset_match,
+      structure_match,
     ]
     parameters["ticker"] = ticker
 

--- a/tests/middleware/mcp/test_client.py
+++ b/tests/middleware/mcp/test_client.py
@@ -595,7 +595,7 @@ class TestGraphMCPConfigurableSchema:
   @pytest.mark.asyncio
   @pytest.mark.unit
   async def test_schema_all_tables_listed(self, mock_async_graph_client, monkeypatch):
-    """Test that all tables are listed in schema (no counts for performance)."""
+    """All tables are listed; uncurated nodes report real catalog columns."""
 
     # Mock table response - includes nodes and relationships
     tables_response = [
@@ -604,9 +604,18 @@ class TestGraphMCPConfigurableSchema:
       {"name": "OtherTable", "type": "NODE"},
       {"name": "HAS_CUSTOM", "type": "REL"},
     ]
-
+    # Uncurated node types are not in the static property map, so get_schema
+    # introspects each one's real columns via a TABLE_INFO catalog lookup
+    # (cheap — no data scan) instead of emitting a generic guess.
+    table_info_response = [
+      {"name": "identifier", "type": "STRING"},
+      {"name": "label", "type": "STRING"},
+    ]
     mock_async_graph_client.query.side_effect = [
-      {"data": tables_response, "execution_time_ms": 10},  # SHOW_TABLES only
+      {"data": tables_response, "execution_time_ms": 10},  # SHOW_TABLES
+      {"data": table_info_response, "execution_time_ms": 5},  # CustomTable1
+      {"data": table_info_response, "execution_time_ms": 5},  # CustomTable2
+      {"data": table_info_response, "execution_time_ms": 5},  # OtherTable
     ]
 
     with patch("robosystems.middleware.mcp.client.httpx.AsyncClient"):
@@ -618,10 +627,12 @@ class TestGraphMCPConfigurableSchema:
       # Verify all tables are listed (3 nodes + 1 relationship)
       assert len(schema) == 4
 
-      # Check that all node tables are present (no counts)
+      # Check that all node tables are present (no counts) and that their
+      # properties came from catalog introspection, not the generic guess.
       custom1 = next(s for s in schema if s["label"] == "CustomTable1")
       assert custom1["type"] == "node"
       assert "count" not in custom1
+      assert custom1["sample_properties"] == ["identifier", "label"]
 
       custom2 = next(s for s in schema if s["label"] == "CustomTable2")
       assert custom2["type"] == "node"
@@ -635,9 +646,9 @@ class TestGraphMCPConfigurableSchema:
       assert "from_node" in has_custom
       assert "to_node" in has_custom
 
-      # Verify only 1 query (SHOW_TABLES)
+      # 1 SHOW_TABLES + 1 TABLE_INFO per uncurated node table (no data scans).
       query_calls = list(mock_async_graph_client.query.call_args_list)
-      assert len(query_calls) == 1
+      assert len(query_calls) == 4
 
 
 class TestGraphMCPFactory:

--- a/tests/middleware/mcp/test_client_extended.py
+++ b/tests/middleware/mcp/test_client_extended.py
@@ -327,9 +327,30 @@ class TestSchemaInference:
 
   def test_get_common_properties_unknown_node(self):
     client = _create_client()
-    props = client._get_common_properties("UnknownNode")
+    # Unknown nodes return None so get_schema introspects real columns from
+    # the catalog instead of emitting a misleading generic guess.
+    assert client._get_common_properties("UnknownNode") is None
+
+  @pytest.mark.asyncio
+  async def test_introspect_node_properties_uses_catalog(self):
+    client = _create_client()
+    client.execute_query = AsyncMock(
+      return_value=[
+        {"name": "identifier", "type": "STRING"},
+        {"name": "canonical_type", "type": "STRING"},
+        {"name": "embedding", "type": "FLOAT[384]"},  # vector noise — dropped
+      ]
+    )
+    props = await client._introspect_node_properties("Structure")
+    assert props == ["identifier", "canonical_type"]
+    assert "embedding" not in props
+
+  @pytest.mark.asyncio
+  async def test_introspect_node_properties_falls_back_on_error(self):
+    client = _create_client()
+    client.execute_query = AsyncMock(side_effect=RuntimeError("catalog down"))
+    props = await client._introspect_node_properties("Structure")
     assert "identifier" in props
-    assert "name" in props
 
   def test_get_node_description_known(self):
     client = _create_client()


### PR DESCRIPTION
## Summary

Pre-ship stress test of the **SEC shared-repository MCP surface** surfaced two 25-second tool timeouts on real data, plus two exploration-tool papercuts. All four are fixed here. The timeouts share one root cause: on the ~294M-node SEC graph, LadybugDB's planner seeds the traversal from the **first node written in the MATCH**, so leading with a non-selective anchor forces a full scan. **No API contract or schema changes — query construction and tool-description tuning only.**

Validated directly against the live SEC graph (MRMD / GTBIF / TCNNF) via `read-graph-cypher`: every corrected query shape returns sub-second across income statement, balance sheet, cash flow, and multi-company comparison.

## Changes

**Timeout fixes (graph-backed views)**

- **`operations/roboledger/views/financial_statement_query.py`** — `financial-statement-analysis` led with `(s:Structure {canonical_type: ...})`, but ~53.6k Structure nodes share each `canonical_type` (one per filing), so it scanned them all → factsets → facts before narrowing to one report. Now leads with the indexed `Report.identifier` (or `Entity.ticker`) and reaches `Structure` **last** via `FactSet`. Both the report-id and ticker paths were rewritten; the period filters and dedup are unchanged.
- **`operations/roboledger/views/fact_query.py`** — `build-fact-grid` inline-anchored a *single* ticker (fast) but a multi-entity `entities:[...]` filter degraded to a WHERE clause while the MATCH still led with `(f:Fact)` → full Fact scan. Now anchors on the `Entity` whenever any entity filter is present (single or multi); the no-entity path is unchanged.

**Exploration-tool tuning (`middleware/mcp/`)**

- **`client.py`** — `get-graph-schema` reported a generic `identifier/name/value/created_at/updated_at` guess for any node type not in the curated map (wrong for Structure, Dimension, FactSet, Taxonomy, and 7 others). `_get_common_properties` now returns `None` for uncurated nodes, and `get_schema` introspects real columns via `CALL TABLE_INFO` (a catalog lookup, not a data scan), dropping fixed-size vector/embedding columns. Falls back to the legacy list if the catalog call fails.
- **`tools/example_queries_tool.py`** — de-truncated the node/relationship reference lists (were capped at `[:10]` of 17 nodes / 33 rels); bounded the company-info example with `LIMIT`; replaced the flagship revenue example (queried `us-gaap:Revenues`, which is empty for modern filers that tag `RevenueFromContractWithCustomerExcludingAssessedTax`) with a cross-filer-robust `canonical_concept` query; added a correct full-statement-by-ticker traversal example that documents the anchor-ordering rule.

**Tests**

- **`tests/middleware/mcp/test_client.py`** — updated the schema test to supply `TABLE_INFO` responses for uncurated tables and assert the introspected columns + the corrected catalog-call count.
- **`tests/middleware/mcp/test_client_extended.py`** — `_get_common_properties` unknown-node now asserts `None`; added two tests for `_introspect_node_properties` (catalog success with embedding-column filtering, and error fallback).

## Testing

- `uv run pytest` over `tests/operations/roboledger/views/` and `tests/middleware/mcp/` — **624 passed**.
- `uv run ruff check` + `ruff format` + `uv run basedpyright` on all changed source files — **clean (0 errors/warnings)**.
- Pre-commit hooks passed on commit (formatting + typecheck).
- Full `just test-all` not run in this session.

**Validation caveat:** the running SEC MCP server executes deployed code, so the tools themselves will keep timing out until this ships. The fixes were validated by running the corrected Cypher shapes directly against the same live graph (sub-second), not by re-invoking the MCP tools.

## Notes / Follow-ups

- **Not in scope (noted during the stress test):** OLTP/tenant tools (`list-information-blocks`, event/close tools) are mounted on the SEC surface but cleanly reject with a cryptic `"Invalid graph_id for schema name: sec"` — a surfacing decision, not a quick fix. A no-entity multi-concept `build-fact-grid` is also unbounded (returns all filers); it should likely require an entity filter or carry a cap.
