### PR TITLE
fix(mcp): hide roboledger OLTP tools on shared repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The platform provides the core infrastructure that all extensions build on:
 - **Dagster Orchestration**: Data pipeline orchestration for SEC filings, QuickBooks sync, backups, billing, and scheduled jobs
 - **Credit-Based Billing**: Flexible credits for AI operations based on token usage
 - **Subgraphs (Workspaces)**: AI memory graphs and isolated environments for development and team collaboration
+- **Web Application**: Primary web interface — graph management, the AI query console (natural-language + Cypher over MCP), schema explorer, document search, shared-repository access, and billing — [`robosystems-app`](https://github.com/RoboFinSystems/robosystems-app)
 
 The **core platform API** lives at `/v1` — auth, orgs, billing, graph lifecycle (subgraphs, backups, materialize, tier changes), Cypher, and MCP — with reads as REST `GET`s. Every write — across both the core and extensions surfaces — is a named **`OperationEnvelope`** operation with `Idempotency-Key` support, audit logging, and SSE progress streaming via `/v1/operations/{id}/stream`.
 
@@ -45,7 +46,7 @@ Built on the blocks:
 - **Serialization** — reports serialize to web-native **JSON-LD** (stored, SHACL-validatable) and filing-grade **XBRL 2.1** (rebuilt on demand, Arelle-validated)
 - **Pipelines & data** — QuickBooks ELT via dbt/Dagster with a configurable `write_policy`, and SEC XBRL financial reporting
 
-Dedicated frontend app (`roboledger-app`).
+Dedicated frontend app: [`roboledger-app`](https://github.com/RoboFinSystems/roboledger-app).
 
 ### [RoboInvestor](https://roboinvestor.ai)
 
@@ -55,7 +56,7 @@ Portfolio management and investment tracking extension — tracks investor holdi
 - **Securities** — register and maintain ownership instruments (common stock, warrants, convertible notes, …) with an extensible `terms` blob for instrument-specific detail (strike price, liquidation preference, vesting)
 - **Cross-graph research** — a security links to its issuer through a mutual handshake: the investor records the issuer's `source_graph_id`, and the issuer shares a report that materializes its entity in the investor's graph. This joins private holdings to SEC public-company data in the shared repository — the differentiated capability — with authorization enforced at the report-sharing boundary, not the OLTP layer.
 
-Dedicated frontend app (`roboinvestor-app`).
+Dedicated frontend app: [`roboinvestor-app`](https://github.com/RoboFinSystems/roboinvestor-app).
 
 ## SEC Shared Repository
 

--- a/robosystems/middleware/mcp/tools/manager.py
+++ b/robosystems/middleware/mcp/tools/manager.py
@@ -281,12 +281,17 @@ class GraphMCPTools:
       self.close_period_tool = ClosePeriodTool(graph_client)
       self.reopen_period_tool = ReopenPeriodTool(graph_client)
 
-    # Information Block reads are pure reads and must stay available on
-    # read-only graphs. Same gate pattern as document_tools below:
-    # extension + flag only, no read_only guard.
+    # Information Block reads stay available on read-only *tenant* graphs (no
+    # read_only guard) but are excluded on shared repos: they read the
+    # extensions OLTP DB, which has no per-graph schema for a shared repo like
+    # 'sec' (the call fails with "Invalid graph_id for schema name: sec").
     self.get_information_block_tool = None
     self.list_information_blocks_tool = None
-    if self._has_extension("roboledger") and env.ROBOLEDGER_ENABLED:
+    if (
+      self._has_extension("roboledger")
+      and env.ROBOLEDGER_ENABLED
+      and not self._is_shared_repository()
+    ):
       from .information_block_tools import (
         GetInformationBlockTool,
         ListInformationBlocksTool,
@@ -296,10 +301,16 @@ class GraphMCPTools:
       self.list_information_blocks_tool = ListInformationBlocksTool(graph_client)
 
     # Workflow playbook (guidance only — version-locked to this build).
-    # Pure read with no DB access, so it stays available on read-only graphs:
-    # an operator can learn the close workflow before they have write access.
+    # Pure read with no DB access, so it stays available on read-only tenant
+    # graphs: an operator can learn the close workflow before they have write
+    # access. Excluded on shared repos — the close workflow is a roboledger
+    # tenant concept with no meaning on a shared repository like 'sec'.
     self.get_close_playbook_tool = None
-    if self._has_extension("roboledger") and env.ROBOLEDGER_ENABLED:
+    if (
+      self._has_extension("roboledger")
+      and env.ROBOLEDGER_ENABLED
+      and not self._is_shared_repository()
+    ):
       from .playbook_tools import GetClosePlaybookTool
 
       self.get_close_playbook_tool = GetClosePlaybookTool(graph_client)
@@ -308,7 +319,11 @@ class GraphMCPTools:
     self.get_agent_tool = None
     self.list_agents_tool = None
     self.agent_activity_tool = None
-    if self._has_extension("roboledger") and env.ROBOLEDGER_ENABLED:
+    if (
+      self._has_extension("roboledger")
+      and env.ROBOLEDGER_ENABLED
+      and not self._is_shared_repository()
+    ):
       from .agent_tools import AgentActivityTool, GetAgentTool, ListAgentsTool
 
       self.get_agent_tool = GetAgentTool(graph_client)
@@ -318,17 +333,26 @@ class GraphMCPTools:
     # Event Handler reads (get-event-handler, list-event-handlers)
     self.get_event_handler_tool = None
     self.list_event_handlers_tool = None
-    if self._has_extension("roboledger") and env.ROBOLEDGER_ENABLED:
+    if (
+      self._has_extension("roboledger")
+      and env.ROBOLEDGER_ENABLED
+      and not self._is_shared_repository()
+    ):
       from .event_handler_tools import GetEventHandlerTool, ListEventHandlersTool
 
       self.get_event_handler_tool = GetEventHandlerTool(graph_client)
       self.list_event_handlers_tool = ListEventHandlersTool(graph_client)
 
     # Event Block reads (get-event-block, list-event-blocks) — same gate as
-    # information block reads: available on read-only graphs.
+    # information block reads: read-only tenant graphs yes, shared repos no
+    # (extensions OLTP DB has no schema for a shared repo).
     self.get_event_block_tool = None
     self.list_event_blocks_tool = None
-    if self._has_extension("roboledger") and env.ROBOLEDGER_ENABLED:
+    if (
+      self._has_extension("roboledger")
+      and env.ROBOLEDGER_ENABLED
+      and not self._is_shared_repository()
+    ):
       from .event_block_tools import GetEventBlockTool, ListEventBlocksTool
 
       self.get_event_block_tool = GetEventBlockTool(graph_client)

--- a/tests/middleware/mcp/tools/test_manager_helpers.py
+++ b/tests/middleware/mcp/tools/test_manager_helpers.py
@@ -125,6 +125,51 @@ class TestGetToolDefinitionHelpers:
     assert tools.financial_statement_analysis_tool is not None
     assert tools.live_financial_statement_tool is None
 
+  def test_oltp_read_tools_absent_on_shared_repo(self, mock_client):
+    """Roboledger OLTP read tools (information blocks, agents, event handlers,
+    event blocks, close playbook) read the extensions OLTP DB, which has no
+    schema for a shared repo. They must NOT be advertised on SEC — they error
+    with "Invalid graph_id for schema name: sec" if called."""
+    mock_client.graph_id = "sec"
+    with (
+      patch.object(GraphMCPTools, "_should_include_semantic_tools", return_value=False),
+      patch.object(GraphMCPTools, "_is_shared_repository", return_value=True),
+      patch("robosystems.middleware.mcp.tools.manager.env") as mock_env,
+    ):
+      mock_env.MCP_WORKSPACE_ENABLED = False
+      mock_env.MCP_MEMORY_ENABLED = False
+      mock_env.FACT_GRID_ENABLED = False
+      tools = GraphMCPTools(mock_client, schema_extensions=["roboledger"])
+
+    # OLTP-backed read tools are not constructed on shared repos.
+    assert tools.get_information_block_tool is None
+    assert tools.list_information_blocks_tool is None
+    assert tools.get_agent_tool is None
+    assert tools.list_agents_tool is None
+    assert tools.agent_activity_tool is None
+    assert tools.get_event_handler_tool is None
+    assert tools.list_event_handlers_tool is None
+    assert tools.get_event_block_tool is None
+    assert tools.list_event_blocks_tool is None
+    assert tools.get_close_playbook_tool is None
+
+    names = {d["name"] for d in tools._get_curated_tool_definitions()}
+    leaked = names & {
+      "list-information-blocks",
+      "get-information-block",
+      "list-agents",
+      "get-agent",
+      "agent-activity",
+      "list-event-handlers",
+      "get-event-handler",
+      "list-event-blocks",
+      "get-event-block",
+      "get-close-playbook",
+    }
+    assert not leaked, f"OLTP tenant tools leaked onto shared repo: {leaked}"
+    # Graph-backed analytical reads still belong on the shared repo.
+    assert "financial-statement-analysis" in names
+
 
 class TestCallToolErrors:
   @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Follow-up to #773. The SEC shared-repo MCP surface was advertising roboledger **tenant** tools that can't work there — they read the extensions OLTP database, which has no per-graph schema for a shared repo, so they errored with `"Invalid graph_id for schema name: sec"` when called. This hides them on shared repositories. Also links the three frontend app repos from the README. **MCP tool gating + docs only — no business-logic changes.**

## Changes

**MCP tool gating** (`middleware/mcp/tools/manager.py`)

Shared repos (SEC) declare `schema_extensions=["roboledger"]` on purpose, so that graph-backed roboledger tools (`financial-statement-analysis`, `build-fact-grid`, `resolve-element`) — which query LadybugDB and work fine — are exposed. But five tool blocks were gated by **only** `_has_extension("roboledger") and env.ROBOLEDGER_ENABLED`, missing the `not _is_shared_repository()` guard that siblings like `live-financial-statement` already carry. Added that guard so these drop out of both the advertised tool list and the dispatch path on shared repos:

- `get-/list-information-block`
- `get-/list-agents`, `agent-activity`
- `get-/list-event-handlers`
- `get-/list-event-blocks`
- `get-close-playbook` (no DB access, but a roboledger close-workflow concept with no meaning on a shared repository)

Graph-backed analytical reads remain available on shared repos. Also corrected three comments that claimed these tools "stay available on read-only graphs" without the shared-repo caveat.

**Tests** (`tests/middleware/mcp/tools/test_manager_helpers.py`)

Added `test_oltp_read_tools_absent_on_shared_repo` — constructs the tool manager for `sec` and asserts none of the ten tool names leak into the curated definitions, while `financial-statement-analysis` still does.

**Docs** (`README.md`)

Linked the frontend app repos: `robosystems-app` from the Platform bullets (described as the platform web interface — graph management, AI query console, schema explorer, document search, billing — not just a dashboard), and `roboledger-app` / `roboinvestor-app` from their extension sections.

## Testing

- `uv run pytest tests/middleware/mcp/ tests/routers/graphs/mcp/` — **670 passed**.
- `uv run ruff check` + `ruff format` + `uv run basedpyright` on the changed source — **clean (0 errors/warnings)**.
- Pre-commit hooks passed on both commits.
- Verified the three README repo links resolve (all three repos are public) via `gh repo view`.
- Full `just test-all` not run in this session.

## Notes / Follow-ups

- This is purely a surfacing fix — the tools themselves are unchanged and continue to work on roboledger tenant graphs (including read-only ones). Takes effect once deployed; the running MCP server still advertises the tenant tools on `sec` until then.
- Still open from the #773 stress test (not in this PR): a no-entity multi-concept `build-fact-grid` is unbounded (returns all filers) and should likely require an entity filter or carry a cap.
