### PR TITLE
fix(mcp): filter voided/superseded ledger rows in graph query guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Behind the API is a CQRS operations kernel (`reads/` + `commands/` per domain) t
 
 ### [RoboLedger](https://roboledger.ai)
 
-Accounting and financial reporting extension — a ledger-grade system of record that AI and analysts can both query and operate. Writes land as self-describing **molecules**: atomic facts bundled with their structural wiring, rules, and verification in one typed envelope, never bare rows. Three block molecules are the authoring substrate:
+Accounting and financial reporting extension — a ledger-grade system of record that AI and analysts can both query and operate. It broadly implements the [Seattle Method](http://xbrlsite.com/seattlemethod/), a declarative methodology for digital financial reporting. Writes land as self-describing **molecules**: atomic facts bundled with their structural wiring, rules, and verification in one typed envelope, never bare rows. Three block molecules are the authoring substrate:
 
 - **Information Blocks** — the envelope for reportable content: schedules, statements, and metrics bundled with their period-versioned fact sets, typed mechanics, and rules. `evaluate-rules` runs arithmetic checks (EqualTo, RollUp, RollForward, Exists, CoExists) over materialized facts; pinning a fact set separates a live closing book from a frozen report.
 - **Event Blocks** — REA event capture: callers record what happened in the world (a sale, a payment, an asset disposal) through a structured action-verb vocabulary, and a handler registry derives the debits and credits across the three-level ledger (Transaction → Entry → LineItem). Preview handler resolution, execute to post GL atomically, and promote matured obligations (AR/AP, schedule entries) on demand.
@@ -64,7 +64,7 @@ A curated knowledge graph of US public company financial data from SEC EDGAR XBR
 - **Pipeline**: EDGAR → Download → Process (Parquet) → Stage (DuckDB) → Enrich (fastembed) → Materialize (LadybugDB) → Index + Embed (OpenSearch)
 - **Graph**: 14 node types and 24 relationship types modeling the full XBRL reporting hierarchy
 - **Search**: Hybrid BM25 + KNN vector search across XBRL text blocks, narrative sections, and iXBRL disclosures
-- **Enrichment**: Semantic element mapping, statement classification, and disclosure tagging via the [Seattle Method](http://xbrlsite.com/seattlemethod/SeattleMethod.pdf) taxonomy
+- **Enrichment**: Semantic element mapping, statement classification, and disclosure tagging — applying aspects of the Seattle Method to the shared repository's disclosures (the methodology RoboLedger implements more broadly)
 
 See [SEC Adapter](/robosystems/adapters/sec/README.md) for detailed documentation.
 

--- a/robosystems/middleware/mcp/tools/constants.py
+++ b/robosystems/middleware/mcp/tools/constants.py
@@ -23,3 +23,26 @@ Period nodes classify time context into three types:
 - `annual` - ~12 months duration
 - `other` - Non-standard durations
 Note: Element.period_type indicates the expected period type for that metric - different from Period.period_type!"""
+
+# Ledger lifecycle / status filtering — shared across tools that may touch the
+# tenant roboledger ledger spine (Event / Transaction / Entry / LineItem). The
+# graph mirrors the FULL ledger including cancelled/replaced rows; readers must
+# filter to live rows or voided/reversed amounts inflate counts and sums.
+LEDGER_STATUS_GUIDANCE = """**⚠️ LEDGER STATUS FILTERING (Event / Entry / Transaction):**
+The graph is a faithful mirror of the ledger and KEEPS cancelled and replaced rows —
+voided and superseded entries are NOT removed (they are real audit history). When you
+COUNT or AGGREGATE ledger-spine data you MUST filter to live rows, or voided/reversed
+amounts will inflate the result:
+- `Entry.status` ∈ {draft, posted, reversed}. For balances and debit/credit sums,
+  match ONLY `e.status = 'posted'`. `draft` = unposted (includes entries belonging to
+  voided events); `reversed` = superseded by a reversing entry.
+- `Event.status` ∈ {captured, classified, committed, pending, fulfilled, voided,
+  superseded}. EXCLUDE `voided` and `superseded` from counts/sums. For open
+  obligations use the positive set the question implies (e.g. committed/fulfilled/pending).
+- `Transaction` exposes only a `pending` boolean in the graph (NOT the full status),
+  so a voided transaction is indistinguishable at the Transaction node. To measure
+  realized economic effect, aggregate through `Entry`/`LineItem` filtered to
+  `Entry.status = 'posted'` — do NOT sum `Transaction.amount` directly.
+- `Fact` nodes (the XBRL hypercube / published statements) have NO status and are
+  already filtered at generation time — they are always safe to aggregate. This note
+  applies ONLY to the ledger spine, not to Fact queries."""

--- a/robosystems/middleware/mcp/tools/cypher_tool.py
+++ b/robosystems/middleware/mcp/tools/cypher_tool.py
@@ -2,12 +2,16 @@
 Cypher Tool - Executes read-only Cypher queries against the graph database.
 """
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from robosystems.logger import logger
 
 from ..exceptions import GraphAPIError
 from .base_tool import BaseTool
+from .constants import LEDGER_STATUS_GUIDANCE
+
+if TYPE_CHECKING:
+  from ..client import GraphMCPClient
 
 
 class CypherTool(BaseTool):
@@ -15,11 +19,38 @@ class CypherTool(BaseTool):
   Tool for executing read-only Cypher queries.
   """
 
+  def __init__(
+    self,
+    client: "GraphMCPClient",
+    schema_extensions: list[str] | tuple[str, ...] = (),
+  ):
+    super().__init__(client)
+    self.schema_extensions: tuple[str, ...] = tuple(schema_extensions)
+
+  def _has_ledger_spine(self) -> bool:
+    """True only for entity graphs that materialize the roboledger ledger spine.
+
+    The SEC shared repo carries the ``roboledger`` extension too — including the
+    base REA ``Event``/``Agent`` tables (present but empty) — yet not the
+    materialized three-level ledger (Transaction/Entry/LineItem). Because the
+    empty ``Event`` table makes node-presence an unreliable signal, we exclude
+    shared repositories and subgraphs explicitly here.
+    """
+    if "roboledger" not in self.schema_extensions:
+      return False
+    try:
+      from robosystems.config.shared_repositories import (
+        is_shared_repository_or_subgraph,
+      )
+
+      return not is_shared_repository_or_subgraph(self.client.graph_id)
+    except Exception as e:
+      logger.debug(f"Ledger-spine check failed for {self.client.graph_id}: {e}")
+      return False
+
   def get_tool_definition(self) -> dict[str, Any]:
     """Get the tool definition for Cypher queries."""
-    return {
-      "name": "read-graph-cypher",
-      "description": """Execute read-only Cypher queries against the graph database.
+    description = """Execute read-only Cypher queries against the graph database.
 
 **OVERVIEW:**
 Query the graph using Cypher syntax. Use `get-graph-schema` first to discover available node types and relationships.
@@ -52,7 +83,14 @@ MATCH (a)-[r]->(b)
 RETURN DISTINCT labels(a)[0] AS from_type, type(r) AS rel_type, labels(b)[0] AS to_type
 ```
 
-**TIP:** Use `get-graph-schema` to understand what's in the graph before writing complex queries.""",
+**TIP:** Use `get-graph-schema` to understand what's in the graph before writing complex queries."""
+
+    if self._has_ledger_spine():
+      description += "\n\n" + LEDGER_STATUS_GUIDANCE
+
+    return {
+      "name": "read-graph-cypher",
+      "description": description,
       "inputSchema": {
         "type": "object",
         "properties": {

--- a/robosystems/middleware/mcp/tools/example_queries_tool.py
+++ b/robosystems/middleware/mcp/tools/example_queries_tool.py
@@ -7,7 +7,11 @@ from typing import Any
 from robosystems.logger import logger
 
 from .base_tool import BaseTool
-from .constants import PERIOD_TYPE_GUIDANCE, QUERY_PATTERN_GUIDANCE
+from .constants import (
+  LEDGER_STATUS_GUIDANCE,
+  PERIOD_TYPE_GUIDANCE,
+  QUERY_PATTERN_GUIDANCE,
+)
 
 
 class ExampleQueriesTool(BaseTool):
@@ -185,6 +189,54 @@ WHERE r.form = '10-K' OR r.form = '10-Q'
 RETURN r.form, r.filing_date, r.identifier
 LIMIT 10""",
               "explanation": "Report nodes contain SEC filing metadata",
+            },
+          ]
+        )
+
+      # Ledger-spine queries (tenant roboledger graphs that materialize the
+      # OLTP general ledger). These nodes carry lifecycle status and the graph
+      # keeps voided/superseded rows, so every example MUST show the live filter.
+      # Key on Entry/Transaction/LineItem — NOT Event: the base REA Event table
+      # exists (empty) on the SEC shared repo, so including it would surface
+      # these tenant-only examples there.
+      has_ledger_spine = any(
+        n in node_types for n in ("Entry", "Transaction", "LineItem")
+      )
+      if has_ledger_spine and (not category or category == "ledger"):
+        examples.extend(
+          [
+            {
+              "category": "ledger",
+              "description": "⚠️ READ FIRST — ledger status filtering",
+              "info": LEDGER_STATUS_GUIDANCE,
+              "explanation": "The graph keeps voided/superseded/draft rows for audit; the examples below show the required live-row filters.",
+            },
+            {
+              "category": "ledger",
+              "description": "⭐ Account balances from POSTED entries only",
+              "query": """MATCH (e:Entry)-[:ENTRY_HAS_LINE_ITEM]->(li:LineItem)-[:LINE_ITEM_RELATES_TO_ELEMENT]->(el:Element)
+WHERE e.status = 'posted'
+RETURN el.qname, sum(li.debit_amount) AS debits, sum(li.credit_amount) AS credits
+ORDER BY debits DESC LIMIT 25""",
+              "explanation": "CRITICAL: filter `e.status = 'posted'`. The graph keeps draft/reversed entries (and entries of voided events stay as 'draft'); without this filter cancelled amounts inflate every balance.",
+            },
+            {
+              "category": "ledger",
+              "description": "Count / sum events excluding voided & superseded",
+              "query": """MATCH (ev:Event)
+WHERE ev.status <> 'voided' AND ev.status <> 'superseded'
+RETURN ev.event_type, count(ev) AS count, sum(ev.amount) AS total
+ORDER BY count DESC LIMIT 25""",
+              "explanation": "Event.status keeps voided (cancelled) and superseded (replaced) rows for audit. Exclude both from counts/sums. For open obligations instead, match the positive set (e.g. status IN ['committed','fulfilled','pending']).",
+            },
+            {
+              "category": "ledger",
+              "description": "Transaction amounts via posted entries (NOT Transaction.amount)",
+              "query": """MATCH (t:Transaction)-[:TRANSACTION_HAS_ENTRY]->(e:Entry)-[:ENTRY_HAS_LINE_ITEM]->(li:LineItem)
+WHERE e.status = 'posted'
+RETURN t.number, t.date, sum(li.debit_amount) AS posted_debits
+ORDER BY t.date DESC LIMIT 25""",
+              "explanation": "The Transaction node exposes only a `pending` boolean, NOT the full status — a voided transaction looks identical to a live one. Aggregate realized effect through its posted Entry/LineItem instead of summing Transaction.amount directly.",
             },
           ]
         )

--- a/robosystems/middleware/mcp/tools/manager.py
+++ b/robosystems/middleware/mcp/tools/manager.py
@@ -127,7 +127,9 @@ class GraphMCPTools:
     self.validator = GraphQueryValidator()
 
     # Layer 1: Core tools (always available for any graph)
-    self.cypher_tool = CypherTool(graph_client)
+    self.cypher_tool = CypherTool(
+      graph_client, schema_extensions=self.schema_extensions
+    )
     self.schema_tool = SchemaTool(graph_client)
 
     # Layer 1: GraphQL escape-hatch tools (gated by EXTENSIONS_GRAPHQL_ENABLED)

--- a/robosystems/operations/operators/implementations/cypher.py
+++ b/robosystems/operations/operators/implementations/cypher.py
@@ -104,6 +104,33 @@ class CypherOperator(Operator):
     schema_text = self._format_schema_for_ai(schema)
     max_results = self._get_max_results(ctx.mode)
 
+    # The materialized ledger spine only exists in entity graphs with roboledger
+    # materialized — not SEC/generic graphs. Only inject status-filtering guidance
+    # when those nodes are present, or it's noise about nodes that don't exist.
+    # Key on Entry/Transaction/LineItem — NOT Event: the base REA Event table
+    # exists (empty) on the SEC shared repo, so it isn't a reliable signal.
+    node_labels = {item.get("label") for item in schema if item.get("type") == "node"}
+    has_ledger_spine = bool(node_labels & {"Entry", "Transaction", "LineItem"})
+
+    ledger_rule = (
+      """
+8. LEDGER STATUS: the graph keeps cancelled/replaced ledger rows. When counting or
+   aggregating Entry/Event/Transaction data, filter to live rows or voided/reversed
+   amounts inflate the result:
+   - Entry: match only `status = 'posted'` for balances and debit/credit sums.
+   - Event: exclude `voided` and `superseded` (`status <> 'voided' AND status <> 'superseded'`).
+   - Transaction has only a `pending` boolean (no full status) — aggregate realized
+     effect through its posted Entry/LineItem, not by summing Transaction.amount.
+   - Fact nodes have no status and are pre-filtered; this rule is ledger-spine only."""
+      if has_ledger_spine
+      else ""
+    )
+    ledger_pattern = (
+      "\n- Posted GL balances: MATCH (e:Entry)-[:ENTRY_HAS_LINE_ITEM]->(li:LineItem) WHERE e.status = 'posted'"
+      if has_ledger_spine
+      else ""
+    )
+
     system_prompt = f"""You are a Cypher query expert for RoboSystems graph databases.
 
 SCHEMA:
@@ -116,12 +143,12 @@ IMPORTANT RULES:
 4. Always include a LIMIT clause (max {max_results})
 5. Use parameterized queries when possible
 6. Handle NULL values appropriately
-7. Use CONTAINS for text search, not exact matches
+7. Use CONTAINS for text search, not exact matches{ledger_rule}
 
 SCHEMA PATTERNS:
 - Financial facts: MATCH (f:Fact)-[:FACT_HAS_ELEMENT]->(el:Element)
 - Time periods: MATCH (f:Fact)-[:FACT_HAS_PERIOD]->(p:Period)
-- Entities: MATCH (e:Entity)-[:HAS_REPORT]->(r:Report)
+- Entities: MATCH (e:Entity)-[:HAS_REPORT]->(r:Report){ledger_pattern}
 
 Return ONLY the Cypher query, nothing else."""
 


### PR DESCRIPTION
## Summary

The extensions materialization mirrors the **full** OLTP ledger spine (`Event`/`Transaction`/`Entry`/`LineItem`) into the LadybugDB graph, deliberately keeping **voided** and **superseded** rows as audit history. That's correct for an audit-grade store — but it means any ad-hoc or AI-generated Cypher that aggregates the spine **without a status filter** silently counts cancelled rows and inflates totals. This PR adds status-filtering guidance across the raw graph read surface, gated so it only appears on graphs that actually have the ledger spine.

This is the read-side ("Tier 1") guardrail. The durable fix — a materialized `is_live` flag — is captured separately in a design spec (not in this repo; see Notes).

## Why it's safe / scope of the exposure

The authoritative financial reads are **already** status-filtered and unaffected:
- `reads/trial_balance.py`, `reads/account_rollups.py` filter `status='posted'`
- `reads/ar_ap.py` filters `status IN ('committed','fulfilled')`
- statements / fact-grid read the pre-filtered `Fact` hypercube (Facts carry no status)

The exposure is purely the **raw graph query surface** (ad-hoc Cypher, AI Operators generating Cypher), which bypasses the curated reads.

## Changes

- **`middleware/mcp/tools/constants.py`** — new `LEDGER_STATUS_GUIDANCE` constant. States the per-node rule: `Entry` filters `status='posted'`; `Event` excludes `voided`/`superseded`; `Transaction` exposes only a `pending` boolean (no full status) so realized effect must be aggregated through posted `Entry`/`LineItem`; `Fact` is statusless and pre-filtered.
- **`middleware/mcp/tools/cypher_tool.py`** — appends the guidance to the `read-graph-cypher` tool description, gated on `_has_ledger_spine()` (roboledger installed **and** not a shared repo). `CypherTool` now receives `schema_extensions`.
- **`middleware/mcp/tools/manager.py`** — passes `schema_extensions` into `CypherTool` (mirrors the existing `GraphqlQueryTool` wiring).
- **`middleware/mcp/tools/example_queries_tool.py`** — adds a `ledger` example category with three status-filtered worked queries (posted-only balances, voided/superseded-excluded event counts, transaction amounts via posted entries) plus a leading guidance entry. Gated on `Entry`/`Transaction`/`LineItem` node presence. Real relationship names verified against the schema (`TRANSACTION_HAS_ENTRY`, `ENTRY_HAS_LINE_ITEM`, `LINE_ITEM_RELATES_TO_ELEMENT`).
- **`operations/operators/implementations/cypher.py`** — adds a ledger status rule and a posted-GL `SCHEMA PATTERNS` line to the `CypherOperator` system prompt, injected only when the fetched schema contains the spine nodes.

### Gating detail

The node-presence signal keys on `{Entry, Transaction, LineItem}` — **not** `Event`. Verified against the live SEC shared-repo schema: it exposes the base REA `Event`/`Agent` tables (present but empty, `Event` even carries a `status` property) but has no `Transaction`/`Entry`/`LineItem`. Keying on `Event` would have surfaced tenant-only guidance on SEC. The `read-graph-cypher` description has no schema in hand at definition time, so it uses the `roboledger + not-shared-repo` proxy instead — same outcome (SEC excluded, tenant graphs included).

## Testing

- `just test-code` (ruff + format + basedpyright + cf-lint) — **clean** (0 errors/warnings).
- Targeted `uv run pytest tests/middleware/mcp/ tests/operations/operators/ tests/routers/graphs/mcp/ tests/routers/graphs/test_mcp.py` — **passing** (816 then 703 on re-run).
- Full `just test` unit suite — not run in full this session.

## Notes / Follow-ups

- **Tier 2 (durable fix)** is specced separately: materialize an `is_live` boolean onto the ledger-spine nodes so `WHERE n.is_live` becomes the single, hard-to-forget pattern. Additive (no OLTP migration), phased. The spec lives in the team's git-ignored design-docs vault, not this repo.
- Two minor internal reads (`reads/transactions.py` list, `reads/summary.py` counts) lack status filters but are informational only — left out of scope.
