### PR TITLE
fix(schema): exclude empty REA/trait tables from the SEC graph

### DIFF
--- a/robosystems/schemas/base.py
+++ b/robosystems/schemas/base.py
@@ -591,3 +591,31 @@ BASE_RELATIONSHIPS = [
     properties=[],
   ),
 ]
+
+
+# ---------------------------------------------------------------------------
+# Reporting-only exclusions
+# ---------------------------------------------------------------------------
+# The REA event/agent substrate (Event, Agent) and the advisory element Trait
+# node live in the base schema because accounting (roboledger) graphs populate
+# them. Reporting-only repositories — the SEC shared repo today — never create
+# economic events, counterparties, or element traits, so these tables stay
+# empty there. They are excluded from a reporting-only graph's schema so the
+# empty node/relationship tables are neither created nor materialized.
+#
+# Consumed by ContextAwareSchemaLoader (schema DDL) and
+# RoboLedgerContext.get_all_table_names_for_context (materialization list);
+# keep both call sites using these constants so the two paths stay in lockstep.
+REPORTING_ONLY_EXCLUDED_NODES: frozenset[str] = frozenset({"Event", "Agent", "Trait"})
+REPORTING_ONLY_EXCLUDED_RELATIONSHIPS: frozenset[str] = frozenset(
+  {
+    "ENTITY_HAS_EVENT",
+    "ENTITY_HAS_AGENT",
+    "ELEMENT_HAS_TRAIT",
+    "EVENT_INVOLVES_AGENT",
+    "EVENT_AFFECTS_RESOURCE",
+    "EVENT_DISCHARGES_EVENT",
+    "EVENT_OBLIGATED_BY_EVENT",
+    "EVENT_REPLACES_EVENT",
+  }
+)

--- a/robosystems/schemas/extensions/roboledger.py
+++ b/robosystems/schemas/extensions/roboledger.py
@@ -437,7 +437,12 @@ class RoboLedgerContext:
         Dictionary mapping table name to entity type ("nodes" or "relationships")
         Order: base nodes, extension nodes, base relationships, extension relationships
     """
-    from ..base import BASE_NODES, BASE_RELATIONSHIPS
+    from ..base import (
+      BASE_NODES,
+      BASE_RELATIONSHIPS,
+      REPORTING_ONLY_EXCLUDED_NODES,
+      REPORTING_ONLY_EXCLUDED_RELATIONSHIPS,
+    )
 
     tables: dict[str, str] = {}
 
@@ -445,10 +450,20 @@ class RoboLedgerContext:
     ext_nodes = cls.get_nodes_for_context(context)
     ext_relationships = cls.get_relationships_for_context(context)
 
+    # Reporting-only contexts (SEC) skip the REA/trait base tables so this
+    # materialization list matches the schema the loader builds — neither
+    # creates nor materializes the empty Event/Agent/Trait tables.
+    reporting_only = context in (cls.SEC_REPOSITORY, cls.REPORTING_ONLY)
+    excluded_nodes = REPORTING_ONLY_EXCLUDED_NODES if reporting_only else frozenset()
+    excluded_rels = (
+      REPORTING_ONLY_EXCLUDED_RELATIONSHIPS if reporting_only else frozenset()
+    )
+
     # Add ALL nodes first (base nodes before extension nodes)
     if include_base:
       for node in BASE_NODES:
-        tables[node.name] = "nodes"
+        if node.name not in excluded_nodes:
+          tables[node.name] = "nodes"
 
     for node in ext_nodes:
       tables[node.name] = "nodes"
@@ -456,7 +471,8 @@ class RoboLedgerContext:
     # Then add ALL relationships (base before extension)
     if include_base:
       for rel in BASE_RELATIONSHIPS:
-        tables[rel.name] = "relationships"
+        if rel.name not in excluded_rels:
+          tables[rel.name] = "relationships"
 
     for rel in ext_relationships:
       tables[rel.name] = "relationships"

--- a/robosystems/schemas/loader.py
+++ b/robosystems/schemas/loader.py
@@ -13,7 +13,12 @@ import pkgutil
 from typing import Any
 
 import robosystems.schemas.extensions as extensions_pkg
-from robosystems.schemas.base import BASE_NODES, BASE_RELATIONSHIPS
+from robosystems.schemas.base import (
+  BASE_NODES,
+  BASE_RELATIONSHIPS,
+  REPORTING_ONLY_EXCLUDED_NODES,
+  REPORTING_ONLY_EXCLUDED_RELATIONSHIPS,
+)
 from robosystems.schemas.models import Node, Relationship
 
 logger = logging.getLogger(__name__)
@@ -426,17 +431,14 @@ class ContextAwareSchemaLoader(LadybugSchemaLoader):
     """
     # For SEC repository, filter out base nodes and relationships that aren't populated
     if context == "sec_repository":
-      # NOTE: User, GraphMetadata, and Connection nodes have been removed from base.py
-      # They are now managed exclusively in PostgreSQL, not in LadybugDB graphs.
-      # These exclusions are kept for backward compatibility but are no longer needed.
-      excluded_base_nodes = (
-        set()
-      )  # No exclusions needed - platform nodes removed from base
+      # Reporting-only repos never populate the REA event/agent substrate or
+      # element traits, so those base tables are excluded (see base.py).
+      excluded_base_nodes = set(REPORTING_ONLY_EXCLUDED_NODES)
       all_nodes = [node for node in BASE_NODES if node.name not in excluded_base_nodes]
 
-      # These base relationships are not populated by SEC data
-      # NOTE: USER_HAS_ACCESS and ENTITY_HAS_CONNECTION removed from base.py
-      excluded_base_rels = {
+      # Base relationships not populated by SEC data: the REA/trait edges plus
+      # legacy lineage/hierarchy edges that carry no SEC rows.
+      excluded_base_rels = REPORTING_ONLY_EXCLUDED_RELATIONSHIPS | {
         "ENTITY_EVOLVED_FROM",
         "ENTITY_OWNS_ENTITY",
         "ELEMENT_IN_TAXONOMY",

--- a/tests/schemas/test_schema_loader.py
+++ b/tests/schemas/test_schema_loader.py
@@ -211,6 +211,35 @@ class TestContextAwareSchemaLoader:
     loader = ContextAwareSchemaLoader(extension="roboledger", context="full_accounting")
     assert len(loader.nodes) > 0
 
+  def test_sec_materialization_list_excludes_rea_substrate(self):
+    """The materialization table list (get_all_table_names_for_context) must
+    agree with the loader-built DDL: SEC excludes the REA/trait base tables;
+    FULL_ACCOUNTING keeps them. Prevents empty Event/Agent/Trait tables from
+    being created or materialized on the SEC graph."""
+    from robosystems.schemas.extensions.roboledger import RoboLedgerContext
+
+    sec = RoboLedgerContext.get_all_table_names_for_context(
+      RoboLedgerContext.SEC_REPOSITORY
+    )
+    for name in ("Event", "Agent", "Trait", "ENTITY_HAS_EVENT", "ELEMENT_HAS_TRAIT"):
+      assert name not in sec, f"{name} should not be materialized on SEC"
+
+    full = RoboLedgerContext.get_all_table_names_for_context(
+      RoboLedgerContext.FULL_ACCOUNTING
+    )
+    for name in ("Event", "Agent", "Trait"):
+      assert name in full, f"{name} must remain for accounting graphs"
+
+    # The materialization list and the loader-built DDL must produce the same
+    # SEC node set, or a table would be materialized into a schema that lacks it.
+    ddl_nodes = set(
+      ContextAwareSchemaLoader(
+        extension="roboledger", context="sec_repository"
+      ).nodes.keys()
+    )
+    mat_nodes = {k for k, v in sec.items() if v == "nodes"}
+    assert ddl_nodes == mat_nodes
+
   def test_get_contextual_schema_loader_sec(self):
     loader = get_contextual_schema_loader("repository", "sec")
     assert isinstance(loader, ContextAwareSchemaLoader)
@@ -238,9 +267,10 @@ class TestREAPrimitives:
   """REA primitives: Agent + Event in base, EVENT_TRIGGERS_TRANSACTION
   bridge in roboledger TRANSACTION layer.
 
-  Validates that the placement holds in the loader: REA primitives reach
-  every consumer (including SEC) as base nodes, while the McCarthy bridge
-  edge is correctly scoped to roboledger TRANSACTION_RELATIONSHIPS and
+  Validates the placement in the loader: REA primitives reach accounting
+  consumers (default + roboledger application) as base nodes, but are
+  excluded from reporting-only repositories (SEC), which never populate
+  them. The McCarthy bridge edge is roboledger TRANSACTION-scoped and also
   absent from SEC.
   """
 
@@ -254,12 +284,31 @@ class TestREAPrimitives:
     assert "Agent" in loader.nodes
     assert "Event" in loader.nodes
 
-  def test_agent_and_event_in_sec_repository(self):
-    """Base nodes flow through to SEC. Tables stay empty (no rows
-    loaded), but the schema includes them."""
+  def test_rea_substrate_excluded_from_sec_repository(self):
+    """REA Event/Agent and element Traits live in base for accounting graphs,
+    but reporting-only repos (SEC) never populate them — so they're excluded
+    from the SEC schema entirely (neither created nor materialized as empty
+    tables)."""
     loader = ContextAwareSchemaLoader(extension="roboledger", context="sec_repository")
-    assert "Agent" in loader.nodes
-    assert "Event" in loader.nodes
+    assert "Agent" not in loader.nodes
+    assert "Event" not in loader.nodes
+    assert "Trait" not in loader.nodes
+    for edge in (
+      "ENTITY_HAS_AGENT",
+      "ENTITY_HAS_EVENT",
+      "ELEMENT_HAS_TRAIT",
+      "EVENT_INVOLVES_AGENT",
+      "EVENT_AFFECTS_RESOURCE",
+      "EVENT_OBLIGATED_BY_EVENT",
+      "EVENT_DISCHARGES_EVENT",
+      "EVENT_REPLACES_EVENT",
+    ):
+      assert edge not in loader.relationships, (
+        f"REA edge should be excluded from SEC: {edge}"
+      )
+    # Reporting substrate stays.
+    assert "Fact" in loader.nodes
+    assert "Report" in loader.nodes
 
   def test_rea_edges_in_default_loader(self):
     loader = get_schema_loader()


### PR DESCRIPTION
## Summary

The SEC shared repository is a **reporting-only** graph, but its schema was carrying three empty node tables — `Event`, `Agent`, `Trait` — plus eight incident relationship tables that SEC ingestion never populates. They reached the SEC graph because both schema-composition paths add **all** of `BASE_NODES` / `BASE_RELATIONSHIPS` wholesale, and the REA event/agent substrate and the advisory element `Trait` node live in the base schema (accounting/roboledger graphs do populate them). This prunes them from reporting-only contexts so they're neither created nor materialized on the SEC graph.

Confirmed empty on the live SEC graph before this change: `Event` 0, `Agent` 0, `Trait` 0 (and `ENTITY_HAS_EVENT` / `ENTITY_HAS_AGENT` / `ELEMENT_HAS_TRAIT` 0).

## Changes

- **`schemas/base.py`** — add `REPORTING_ONLY_EXCLUDED_NODES` (`Event`, `Agent`, `Trait`) and `REPORTING_ONLY_EXCLUDED_RELATIONSHIPS` (`ENTITY_HAS_EVENT`, `ENTITY_HAS_AGENT`, `ELEMENT_HAS_TRAIT`, `EVENT_INVOLVES_AGENT`, `EVENT_AFFECTS_RESOURCE`, `EVENT_DISCHARGES_EVENT`, `EVENT_OBLIGATED_BY_EVENT`, `EVENT_REPLACES_EVENT`) as the single source of truth, with a comment explaining why they're base-but-excluded-for-reporting.
- **`schemas/loader.py`** — `ContextAwareSchemaLoader(context="sec_repository")` now excludes those base nodes/rels from the generated schema **DDL** (extends the existing exclusion block, which previously only dropped a few legacy lineage/hierarchy edges).
- **`schemas/extensions/roboledger.py`** — `RoboLedgerContext.get_all_table_names_for_context` skips the same tables for `SEC_REPOSITORY` / `REPORTING_ONLY`, so the **materialization table list** matches the DDL (a table can't be materialized into a schema that doesn't declare it).
- **`tests/schemas/test_schema_loader.py`** — flipped `test_agent_and_event_in_sec_repository` (which asserted the old "REA flows through to SEC" behavior) into `test_rea_substrate_excluded_from_sec_repository`; updated the `TestREAPrimitives` docstring; added `test_sec_materialization_list_excludes_rea_substrate` asserting the materialize list excludes the REA/trait tables, that `FULL_ACCOUNTING` still includes them, and that the DDL and materialize-list node sets are identical.

`FULL_ACCOUNTING` (roboledger tenant graphs) is untouched — those still get `Event`/`Agent`/`Trait` from base.

## Testing

- `uv run pytest tests/schemas/ tests/adapters/sec/processors/ tests/operations/extensions/test_materialize.py` — **761 passed**.
- `uv run ruff check robosystems/schemas/` + `ruff format` + `uv run basedpyright` on the changed source — **clean (0 errors/warnings)**.
- Pre-commit hooks passed on commit.
- Manual verification against the live SEC graph + a Python harness on the loader: SEC node set drops **17 → 14** (`Event`/`Agent`/`Trait` removed), all reporting nodes (`Fact`/`FactSet`/`Report`/`Element`/`Structure`/`Entity`) intact, and the DDL node set equals the materialization node set.
- Full `just test-all` not run in this session.

## Notes / Follow-ups

- **No migration / manual rebuild.** The SEC graph rebuilds nightly from DuckDB; the next build emits the pruned schema and skips the empty tables. The currently-running graph keeps them until the next rebuild after deploy.
- Removing the empty `Event` table from SEC also eliminates the root cause of a separate gating false-positive (a node-presence heuristic that treated SEC's empty base `Event` table as a ledger signal). The discriminator fix for that, on `bugfix/graph-ledger-status-guidance`, keys on `Entry`/`Transaction`/`LineItem` and remains correct and more robust regardless.
- Pre-existing, out of scope: the DDL loader also excludes a few legacy base edges (`ENTITY_EVOLVED_FROM`, `ENTITY_OWNS_ENTITY`, …) that the materialize list still includes; harmless because those carry no SEC rows and are skipped at load. Left as-is.
