### PR TITLE
docs(query): correct stale subgraph write-purpose note

### DIFF
--- a/robosystems/routers/graphs/query/execute.py
+++ b/robosystems/routers/graphs/query/execute.py
@@ -165,7 +165,7 @@ async def execute_cypher_query(
         "1. Create file upload: POST /v1/graphs/{graph_id}/tables/{table_name}/files\n"
         "2. Ingest to graph: POST /v1/graphs/{graph_id}/tables/ingest\n"
         "This ensures data integrity and enables pipeline benefits (audit, rollback, validation).\n"
-        "Note: Subgraphs support write operations for development and report creation.",
+        "Note: Subgraphs support write operations for scratch/workspace use (e.g. agent memory).",
       )
 
     # Log write operations on subgraphs for audit


### PR DESCRIPTION
## Summary

Corrects a stale, misleading note in the `POST /v1/graphs/{graph_id}/query` endpoint's 403 (write-on-main-graph) error message. The note described subgraph writes as being for "development and report creation" — a framing left over from an early subgraphs-as-report-authoring prototype that was abandoned in favor of the extensions (OLTP → materialization) architecture. Report/schedule authoring no longer has anything to do with subgraphs; subgraphs are a scratch/workspace/memory surface (e.g. agent memory). This updates the note to match their actual purpose.

## Changes

- `robosystems/routers/graphs/query/execute.py` — in the 403 detail returned when a write (`CREATE/MERGE/SET/DELETE`) is attempted on a main graph, the trailing note changes from:
  - `"Note: Subgraphs support write operations for development and report creation."`
  - to `"Note: Subgraphs support write operations for scratch/workspace use (e.g. agent memory)."`

No behavioral change — the write-blocking logic, status code, and staging-pipeline guidance are unchanged; only the descriptive copy in the existing message is corrected.

## Testing

- Pre-commit hooks ran on commit (ruff lint + format): **all checks passed**, 0 errors/warnings.
- `just test-all` not run — the change is a single user-facing string in an existing error message with no logic change, so there is no behavior to exercise.

## Notes

- This surfaced during a LadybugDB upgrade-feasibility review: the `execute.py` string was the source that mislabeled subgraphs as report-authoring. The endpoint description at `execute.py:90` ("Subgraphs support full writes") and `README.md:16` ("Subgraphs (Workspaces): AI memory graphs and isolated environments…") were already correct and left unchanged.
- A repo-wide sweep (incl. SDKs and frontend repos) found no other stale subgraph-as-report references. One test fixture (`tests/operations/graph/test_subgraph_service.py`) uses an arbitrary subgraph name `_reporting` to verify name-parsing; it makes no purpose claim and was intentionally left as-is.
