### PR TITLE
docs(api): align Swagger descriptions with README framing

### DIFF
--- a/static/description.md
+++ b/static/description.md
@@ -1,20 +1,22 @@
-RoboSystems is an open-source financial intelligence platform with a unified operational and analytical graph architecture. The platform powers [RoboLedger](https://roboledger.ai) for accounting analytics and [RoboInvestor](https://roboinvestor.ai) for investment research, while the knowledge graphs are managed using the [RoboSystems](https://robosystems.ai) app. Build financial knowledge graphs, integrate accounting systems, analyze SEC filings, and leverage AI-powered insights with enterprise-grade security.
+RoboSystems is an open-source, AI-native financial intelligence platform for accounting, financial reporting, and investment management. It gives AI agents and analysts a ledger-grade system of record they can both query and operate — closing the books, producing reports, and analyzing portfolios across accounting, market, and SEC data. The platform powers [RoboLedger](https://roboledger.ai) for accounting and [RoboInvestor](https://roboinvestor.ai) for investment research, with knowledge graphs managed through the [RoboSystems](https://robosystems.ai) app.
 
 ## Core Features
 
-- **Unified Operational + Analytical Graph**: Operational state and analytical graph unified under a shared schema and Cypher query surface
+- **Unified Graph Architecture**: A transactional core with a materialized analytical graph under one schema and Cypher surface
 - **Graph Database**: Build knowledge graphs with LadybugDB for modeling financial relationships and multi-dimensional analytics
 - **Multi-Tenant Architecture**: Isolated database instances with tier-based resource allocation
-- **AI Agent Integration**: MCP (Model Context Protocol) support enables AI agents to query and analyze your knowledge graphs
+- **AI Operator System**: Autonomous financial Operators (Claude/MCP executors) with automatic credit tracking and SSE progress streaming
 - **DuckDB Staging**: High-performance data validation and bulk ingestion pipeline with Parquet optimization
 - **Data Integration**: Connect QuickBooks and SEC XBRL filings in a unified graph
+- **Document Search**: Upload, index, and search documents with full-text and semantic search via OpenSearch
 - **Shared Repositories**: Access to curated SEC filing data and other shared knowledge graphs
+- **Credit-Based Billing**: AI operations consume token-based credits; database and MCP operations are free
 
 ## API Modules
 
 ### Graph Operations
 
-The core platform surface for querying and managing graphs
+The core platform surface for querying and managing graphs. Reads are REST `GET`s; every write is a named `OperationEnvelope` operation (`/operations/{op_name}`) with `Idempotency-Key` support, audit logging, and SSE progress at `/v1/operations/{id}/stream`.
 
 **Query and data access:**
 
@@ -38,10 +40,16 @@ The core platform surface for querying and managing graphs
 - **change-tier**: Change graph infrastructure tier with Stripe billing integration
 - **materialize**: Ingest DuckDB-staged tables or OLTP data into the graph (direct or Dagster-orchestrated)
 
-### MCP & Agents
+### Documents & Search
 
-- **MCP**: Model Context Protocol for AI agent graph tools and queries
-- **Agents**: Claude-powered financial analysis and report generation
+- **Documents**: Upload, list, retrieve, update, and delete documents attached to a graph
+- **Search**: Full-text and semantic (BM25 + KNN) search across graph documents via OpenSearch, with section-level retrieval
+- **Files**: Manage uploaded files — create upload, list, inspect, update status, and delete
+
+### MCP & AI Operators
+
+- **MCP**: Model Context Protocol — schema-aware graph tools and queries for AI agents and assistants
+- **AI Operators**: Autonomous Claude/MCP executors for financial analysis and report generation, with automatic credit tracking and SSE progress (sync, SSE, or background worker)
 
 ### Data Synchronization
 
@@ -50,30 +58,39 @@ The core platform surface for querying and managing graphs
 
 ### Extensions Surface
 
-Domain extensions (RoboLedger, RoboInvestor) are graph-scoped with a clear split between reads, writes, and view operations:
+Domain extensions (RoboLedger, RoboInvestor) bring their own schema and OLTP tables on a schema-per-tenant PostgreSQL database, and materialize to the graph for analytics. Content is authored as **block molecules** — self-describing envelopes bundling atomic facts with their structure, rules, and verification. The surface is **graph-scoped at the URL level** (`graph_id` is a path parameter, never a query argument), split by transport:
 
-- **Reads** → GraphQL at `POST /extensions/{graph_id}/graphql` with a schema composed dynamically from enabled domains
-- **Writes** → named command operations at `POST /extensions/{domain}/{graph_id}/operations/{operation_name}`
-- **Views** → graph-backed read-only analytics views at `POST /extensions/{domain}/{graph_id}/operations/{view_name}`
+- **Reads** → GraphQL at `POST /extensions/{graph_id}/graphql` — schema composed dynamically from enabled domains
+- **Writes** → `POST /extensions/{domain}/{graph_id}/operations/{operation_name}` — named `OperationEnvelope` commands with `Idempotency-Key` and SSE progress
+- **Views** → `POST /extensions/{domain}/{graph_id}/operations/{view_name}` — read-only analytics over the materialized graph
 
-### RoboLedger
+Per-domain flags (`ROBOLEDGER_ENABLED`, `ROBOINVESTOR_ENABLED`) gate both the routers and the GraphQL schema.
 
-- **Chart of Accounts**: View accounts and hierarchical account trees synced from connected systems
-- **Transactions**: List and inspect transactions with entries and line items
-- **Trial Balance**: Generate trial balances with optional date filtering
-- **Taxonomies**: US GAAP reporting taxonomy with structures, elements, and associations
-- **Mappings**: Map chart of accounts to GAAP reporting concepts with AI auto-mapping
-- **Reports**: Create, view, and share multi-period financial statements (income statement, balance sheet)
-- **Schedules**: Depreciation, amortization, and accrual schedules with monthly fact generation and period close workflow
-- **Fiscal Calendar**: Track close cadence with `closed_through` / `close_target` pointers, period close gates, and reopen workflow
-- **Publish Lists**: Share reports to other graphs via managed distribution lists
+### [RoboLedger](https://roboledger.ai)
 
-### RoboInvestor
+Accounting and financial reporting extension — a ledger-grade system of record that AI and analysts can both query and operate, broadly implementing the [Seattle Method](http://xbrlsite.com/seattlemethod/). Three block molecules are the authoring substrate:
 
-- **Portfolios**: Create and manage investment portfolios with metadata and classification
-- **Securities**: Track securities with optional entity linking for cross-graph research
-- **Positions**: Record holdings with cost basis, quantity, and date tracking
-- **Holdings**: Aggregate portfolio holdings grouped by entity with current valuations
+- **Information Blocks** — reportable content (schedules, statements, metrics) bundled with period-versioned fact sets, typed mechanics, and rules; `evaluate-rules` runs arithmetic checks over materialized facts
+- **Event Blocks** — REA event capture: record what happened via an action-verb vocabulary, and a handler registry derives debits/credits across the three-level ledger (Transaction → Entry → LineItem)
+- **Taxonomy Blocks** — accounting frameworks as data: Elements, Associations (presentation / calculation / mapping), Structures, and structural rules in one write; ships `fac` and `rs-gaap` (~2,000 curated US-GAAP concepts)
+
+Built on the blocks:
+
+- **Reads** (GraphQL) — chart of accounts and account trees, transactions, trial balances, taxonomies, mappings, reports, schedules, and fiscal calendar
+- **Close lifecycle** — fiscal calendar (`closed_through` / `close_target`) with period close/reopen gated on the balance equation and QuickBooks sync-staleness
+- **Mapping** — CoA→GAAP associations plus AI-assisted bulk mapping via the **MappingOperator** (auto-approve / review / skip)
+- **Reporting** — multi-period statements through a Reporting Style, with a draft → under_review → filed → archived lifecycle and publish lists
+- **Analytical views** — `live-financial-statement` from the OLTP ledger; `build-fact-grid` and `financial-statement-analysis` over the materialized XBRL hypercube
+- **Serialization** — reports to **JSON-LD** (SHACL-validatable) and **XBRL 2.1** (Arelle-validated)
+- **Pipelines** — QuickBooks ELT via dbt/Dagster with a configurable `write_policy`, plus SEC XBRL
+
+### [RoboInvestor](https://roboinvestor.ai)
+
+Portfolio management and investment tracking extension — tracks investor holdings and links them back to the companies behind them.
+
+- **Portfolio Blocks** — a portfolio with its positions and securities written as one validated envelope (cost basis as integer cents); positions move through an active / disposed / archived lifecycle. Reads expose `portfolios`, `positions`, `holdings` (rolled up by issuer), and the assembled `portfolioBlock`
+- **Securities** — ownership instruments (common stock, warrants, convertible notes, …) with an extensible `terms` blob for instrument-specific detail
+- **Cross-graph research** — a security links to its issuer via a mutual handshake (the issuer shares a report that materializes its entity in the investor's graph), joining private holdings to SEC public-company data in the shared repository
 
 ### User & Access
 

--- a/static/graph-api-description.md
+++ b/static/graph-api-description.md
@@ -5,7 +5,7 @@ High-performance REST API for LadybugDB graph database operations. Provides mult
 - **Multi-Tenant Architecture**: Isolated database instances per graph with API key authentication
 - **Cypher Query Execution**: Run graph queries with streaming results and batching support
 - **Data Ingestion**: DuckDB staging from S3 Parquet, PostgreSQL (postgres_scanner), and queries
-- **Backup & Restore**: Full database backups with encryption and point-in-time recovery
+- **Backup & Restore**: On-demand full database backups with optional encryption and compression
 - **Health & Monitoring**: Real-time health checks, metrics, and task tracking
 - **Vector Search**: LanceDB-powered semantic search across graph data
 
@@ -23,7 +23,7 @@ High-performance REST API for LadybugDB graph database operations. Provides mult
 - Execute Cypher queries with full OpenCypher support
 - Streaming results via NDJSON for large datasets
 - Configurable batch sizes and timeouts
-- Query plan analysis and optimization
+- Parameterized queries with admission-control backpressure
 
 ### Data Operations
 
@@ -34,16 +34,20 @@ High-performance REST API for LadybugDB graph database operations. Provides mult
 
 ### Backup & Recovery
 
-- On-demand full database backups
-- Automated backup scheduling
-- Point-in-time recovery
-- Backup encryption and compression
+- On-demand full database backups via multipart S3 upload
+- Multiple backup formats: encrypted ZIP, raw `.lbug` for the replica fleet, and zstd-compressed downloads to Cloudflare R2 for subscribers
+- DuckDB staging snapshots for analytics and local development
+- Restore from S3 backups with optional pre-restore safety backup
 
 ## Architecture
 
 ### Deployment Model
 
-**Writer Nodes**: Full read/write access for user databases and shared repositories (port 8001)
+**Writer Nodes**: Full read/write access for user (entity) databases (port 8001)
+
+**Shared Master**: Read/write node for shared-repository ingestion and publishing (SEC, etc.)
+
+**Shared Replicas**: Read-only fleet that downloads published `.lbug` / `.duckdb` databases from S3 on boot
 
 **Backend**: LadybugDB — embedded columnar graph database
 


### PR DESCRIPTION
## Summary

Realigns the two Swagger/OpenAPI description docs — `static/description.md` (main API) and `static/graph-api-description.md` (Graph API) — with the current `README.md` framing. The main-API doc had drifted: a flat feature-list extensions surface, the stale "unified operational + analytical graph" positioning, "AI Agent" naming instead of the Operator framing, and no Documents/Search module despite those routers existing. The Graph API doc gets backup, query, and deployment-model refinements. Docs only — no code changes.

## Changes

### `static/description.md` (main API description)

- **Extensions surface** — reframed around **block molecules** and the CQRS reads/writes/views split, graph-scoped URLs (`graph_id` as a path param), and the per-domain feature flags, matching the README:
  - **RoboLedger** — restructured around the three authoring molecules (Information / Event / Taxonomy Blocks), then "built on the blocks" capabilities (reads, close lifecycle, mapping, reporting, analytical views, serialization, pipelines). Every prior flat bullet (CoA, transactions, trial balance, etc.) is preserved, folded into the GraphQL **Reads** bullet.
  - **RoboInvestor** — restructured around **Portfolio Blocks**, Securities, and Cross-graph research.
- **Platform framing** — top intro updated to the README's AI-native, *query-and-operate system-of-record* positioning; `Unified Operational + Analytical Graph` feature renamed to **Unified Graph Architecture** (README's "transactional core + materialized analytical graph" language); Graph Operations intro now states the **reads-as-`GET` / writes-as-`OperationEnvelope`** contract.
- **AI Operator naming** — `AI Agent Integration` feature → **AI Operator System**; `MCP & Agents` module → **MCP & AI Operators** (the `Agents` bullet → `AI Operators`). "AI agents/assistants" kept where correct (the agent-facing MCP protocol and the external MCP-client section), as the README does.
- **New + filled gaps** — added a **Documents & Search** API module (Documents CRUD · BM25+KNN search + section retrieval · Files) and **Document Search** + **Credit-Based Billing** Core Feature bullets.

### `static/graph-api-description.md` (Graph API description)

- **Backup & Recovery** — expanded to reflect the real surface: on-demand full backups via multipart S3 upload; multiple formats (encrypted ZIP, raw `.lbug` for the replica fleet, zstd-compressed R2 downloads for subscribers); DuckDB staging snapshots; restore with optional pre-restore safety backup.
- **Query** — `Query plan analysis and optimization` → parameterized queries with admission-control backpressure.
- **Deployment model** — Writer Nodes scoped to user/entity databases, plus new **Shared Master** (ingestion/publishing) and **Shared Replicas** (read-only fleet downloading published `.lbug` / `.duckdb` from S3) roles.

## Testing

- Pre-commit hooks ran on commit (ruff lint + format): **all checks passed**, 0 errors/warnings.
- `just test-all` not run — documentation-only change (Swagger description markdown), no code paths affected.

## Notes

- Separate from #778, which is the one-line code fix correcting the subgraph write-purpose string (`report creation` → `scratch/workspace use`). The same subgraph-purpose correction is reflected in this doc's extensions framing.
- All claims are grounded in `README.md` (extensions/platform/AI framing) and the actual `routers/graphs/{documents,search,files}` endpoints.
