### PR TITLE
feat(mcp): per-graph instructions for MCP clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The platform provides the core infrastructure that all extensions build on:
 - **Subgraphs (Workspaces)**: AI memory graphs and isolated environments for development and team collaboration
 - **Web Application**: Primary web interface — graph management, the AI query console (natural-language + Cypher over MCP), schema explorer, document search, shared-repository access, and billing — [`robosystems-app`](https://github.com/RoboFinSystems/robosystems-app)
 
-The **core platform API** lives at `/v1` — auth, orgs, billing, graph lifecycle (subgraphs, backups, materialize, tier changes), Cypher, and MCP — with reads as REST `GET`s. Every write — across both the core and extensions surfaces — is a named **`OperationEnvelope`** operation with `Idempotency-Key` support, audit logging, and SSE progress streaming via `/v1/operations/{id}/stream`.
+The **core platform API** lives at `/v1` — auth, orgs, billing, graph lifecycle (subgraphs, backups, materialize, tier changes), Cypher, and MCP — with reads as REST `GET`. Every write — across both the core and extensions surfaces — is a named **`OperationEnvelope`** operation with `Idempotency-Key` support, audit logging, and SSE progress streaming via `/v1/operations/{id}/stream`.
 
 ## Extensions
 
@@ -195,7 +195,7 @@ See the **[Bootstrap Guide](https://github.com/RoboFinSystems/robosystems/wiki/B
 
 ## Architecture
 
-Built end-to-end on open-source engines — PostgreSQL, a columnar graph database, DuckDB, LanceDB, OpenSearch, and Valkey — assembled into a transactional core with a materialized analytical graph and integrated vector search, with no proprietary database lock-in. The components:
+Built end-to-end on open-source engines — PostgreSQL, LadybugDB, DuckDB, LanceDB, OpenSearch, and Valkey — assembled into a transactional core with a materialized analytical graph and integrated vector search, with no proprietary database lock-in. The components:
 
 **Application Layer:**
 

--- a/robosystems/adapters/base.py
+++ b/robosystems/adapters/base.py
@@ -41,6 +41,12 @@ class SharedRepositoryManifest:
   has_semantic_enrichment: bool = False
   sibling_subgraphs: tuple[str, ...] = ()  # ("historical",) → graph_id_historical
 
+  # Agent-facing routing guidance handed to MCP clients via the server's
+  # `instructions` handshake field. Authored per-repo (shared repos have a
+  # fixed, curated tool set, so the text is stable). When None, the MCP layer
+  # falls back to generating instructions from the graph's live tool surface.
+  agent_instructions: str | None = None
+
   # Status
   status: str = "available"  # available, coming_soon
 

--- a/robosystems/adapters/sec/manifest.py
+++ b/robosystems/adapters/sec/manifest.py
@@ -19,6 +19,34 @@ SEC_MANIFEST = SharedRepositoryManifest(
   schema_extensions=("roboledger",),
   has_semantic_enrichment=True,
   sibling_subgraphs=("historical",),  # sec_historical subgraph
+  agent_instructions=(
+    "Connected to the SEC EDGAR knowledge graph (`sec`) — a curated, READ-ONLY "
+    "repository of public-company XBRL financial filings. There is no general "
+    "ledger here and no writes; this surface is for financial analysis and "
+    "exploration.\n"
+    "\n"
+    "START HERE\n"
+    "- `get-example-queries` — working Cypher patterns tailored to this graph's "
+    "schema. Run it before writing your first query.\n"
+    "- `get-graph-schema` — node types, relationships, and properties.\n"
+    "\n"
+    "COMMON TASKS\n"
+    "- A company's financial statements → `financial-statement-analysis` (look "
+    "up by ticker or CIK, with a reporting period).\n"
+    "- Multidimensional fact analysis across entities / periods / dimensions → "
+    "`build-fact-grid`.\n"
+    '- Map a concept like "revenue" to its XBRL element qname → '
+    "`resolve-element`.\n"
+    "- Full-text search across filings → `search-documents`.\n"
+    "- Typed GraphQL reads → `query-graphql`; raw graph traversal → "
+    "`read-graph-cypher`.\n"
+    "\n"
+    "NOTES\n"
+    "- Deeper historical filings live in the `sec_historical` subgraph — switch "
+    "to it with `switch-workspace` when you need older periods.\n"
+    "- This is shared public data: period close, chart-of-accounts mapping, and "
+    "all write operations are unavailable here."
+  ),
   rate_limits={
     "starter": {
       "queries_per_minute": 10,

--- a/robosystems/middleware/mcp/tools/instructions.py
+++ b/robosystems/middleware/mcp/tools/instructions.py
@@ -83,9 +83,12 @@ def build_instructions(
   if has("get-close-playbook"):
     close_lines = [
       "CLOSE / MONTH-END",
-      "- Before setting up or running a close, call `get-close-playbook` FIRST "
-      "— it lays out the exact tool sequence, the setup decisions, and the "
-      "gotchas. Don't improvise the close from individual tool schemas.",
+      (
+        "- Before setting up or running a close, call `get-close-playbook` "
+        "FIRST — it lays out the exact tool sequence, the setup decisions, "
+        "and the gotchas. Don't improvise the close from individual tool "
+        "schemas."
+      ),
     ]
     orient_tools = [
       t for t in ("get-fiscal-calendar", "get-period-close-status") if has(t)

--- a/robosystems/middleware/mcp/tools/instructions.py
+++ b/robosystems/middleware/mcp/tools/instructions.py
@@ -1,0 +1,171 @@
+"""
+Per-graph MCP instructions generator.
+
+Produces the routing guidance handed to MCP clients via the server's
+`instructions` handshake field (and the `switch-workspace` tool result). The
+string is always in the connected agent's context, so it stays short and points
+at the live tool *families* rather than restating each tool's schema — the
+discovery layer that tells an agent which tool to reach for, given an intent.
+
+Two content sources, split by graph stability:
+
+- Shared repositories pass an authored string (`manifest.agent_instructions`),
+  used verbatim — their tool set is fixed and curated, so hand-authored copy is
+  lowest-risk and gives full editorial control.
+- Entity and generic graphs are generated here from the resolved tool-name set.
+  Branching on the names that actually came back means the guidance can never
+  reference a tool the graph doesn't expose, and stays consistent-by-
+  construction with the gating in ``GraphMCPTools``.
+"""
+
+from __future__ import annotations
+
+
+def _block(*lines: str) -> str:
+  """Join non-empty lines with newlines into a single section block."""
+  return "\n".join(line for line in lines if line)
+
+
+def build_instructions(
+  *,
+  graph_id: str,
+  tool_names: set[str],
+  is_shared_repo: bool,
+  read_only: bool,
+  authored_override: str | None = None,
+) -> str | None:
+  """Build the per-graph instructions string for an MCP client.
+
+  Args:
+      graph_id: The active graph identifier.
+      tool_names: Names of the tools actually exposed for this graph.
+      is_shared_repo: Whether this is a shared repository (or subgraph of one).
+      read_only: Whether write operations are disabled for this graph.
+      authored_override: Curated text (shared-repo manifest); used verbatim.
+
+  Returns:
+      The instructions string, or None if there is nothing useful to say.
+  """
+  if authored_override and authored_override.strip():
+    return authored_override.strip()
+
+  has = tool_names.__contains__
+  has_ledger = (
+    has("get-close-playbook") or has("suggest-mapping") or has("get-unmapped-elements")
+  )
+  has_portfolio = has("create-portfolio-block") or has("create-security")
+
+  # Header — adapt to the graph's category.
+  if is_shared_repo:
+    header = (
+      f"Connected to shared repository `{graph_id}` — curated, READ-ONLY data "
+      "for analysis and exploration."
+    )
+  elif has_ledger:
+    header = (
+      f"Connected to a RoboLedger entity graph `{graph_id}` — a live general "
+      "ledger with XBRL-grade financial reporting. Reads and writes."
+    )
+  elif has_portfolio:
+    header = (
+      f"Connected to a RoboInvestor entity graph `{graph_id}` — portfolio and "
+      "investment tracking."
+    )
+  else:
+    header = (
+      f"Connected to a custom property graph `{graph_id}`. No financial schema "
+      "extension is installed."
+    )
+
+  sections: list[str] = [header]
+
+  # Close / month-end — anchored on the playbook tool.
+  if has("get-close-playbook"):
+    close_lines = [
+      "CLOSE / MONTH-END",
+      "- Before setting up or running a close, call `get-close-playbook` FIRST "
+      "— it lays out the exact tool sequence, the setup decisions, and the "
+      "gotchas. Don't improvise the close from individual tool schemas.",
+    ]
+    orient_tools = [
+      t for t in ("get-fiscal-calendar", "get-period-close-status") if has(t)
+    ]
+    if orient_tools:
+      orient = "- Orient with " + " and ".join(f"`{t}`" for t in orient_tools)
+      if has("get-graph-sync-status"):
+        orient += "; check data freshness with `get-graph-sync-status`."
+      else:
+        orient += "."
+      close_lines.append(orient)
+    sections.append(_block(*close_lines))
+
+  # Chart-of-accounts mapping.
+  if has("suggest-mapping") or has("get-unmapped-elements"):
+    sections.append(
+      _block(
+        "CHART OF ACCOUNTS / MAPPING",
+        "- See what's unmapped → `get-unmapped-elements`; get suggestions → "
+        "`suggest-mapping`; inspect structures → `list-mapping-structures` / "
+        "`get-mapping-summary`.",
+      )
+    )
+
+  # Reporting & analysis — only the bits that are live.
+  report_bits: list[str] = []
+  if has("live-financial-statement"):
+    report_bits.append("live statements → `live-financial-statement`")
+  if has("build-fact-grid"):
+    report_bits.append("multidimensional pivots → `build-fact-grid`")
+  if has("financial-statement-analysis"):
+    report_bits.append("company analysis → `financial-statement-analysis`")
+  if report_bits:
+    sections.append(_block("REPORTING & ANALYSIS", "- " + "; ".join(report_bits) + "."))
+
+  # Portfolios & securities.
+  if has_portfolio:
+    sections.append(
+      _block(
+        "PORTFOLIOS & SECURITIES",
+        "- Portfolios → `create-portfolio-block` / `update-portfolio-block`; "
+        "securities → `create-security` / `update-security`.",
+      )
+    )
+
+  # Exploration / querying — present on essentially every graph.
+  explore_lines = ["EXPLORE"]
+  explore_start = [t for t in ("get-graph-schema", "get-example-queries") if has(t)]
+  if explore_start:
+    explore_lines.append(
+      "- Start with " + " and ".join(f"`{t}`" for t in explore_start) + "."
+    )
+  query_bits: list[str] = []
+  if has("query-graphql"):
+    query_bits.append("typed reads → `query-graphql`")
+  if has("read-graph-cypher"):
+    query_bits.append("raw traversal → `read-graph-cypher`")
+  if query_bits:
+    explore_lines.append("- " + "; ".join(query_bits) + ".")
+  if not read_only and has("write-graph-cypher"):
+    explore_lines.append(
+      "- Writes → `write-graph-cypher`, `add-node-table`, `add-relationship-table`."
+    )
+  if len(explore_lines) > 1:
+    sections.append(_block(*explore_lines))
+
+  # Tenant-specific procedure docs (the per-graph layer the generic playbooks
+  # defer to) — only meaningful on a writable entity graph.
+  if has("search-documents") and not is_shared_repo:
+    sections.append(
+      "ALSO run `search-documents` for this company's own procedure and policy "
+      "docs — they capture tenant-specific accounts and quirks the generic "
+      "playbooks can't."
+    )
+
+  if is_shared_repo:
+    sections.append(
+      "This is shared read-only data: period close, mapping, and write "
+      "operations are unavailable here."
+    )
+
+  result = "\n\n".join(s for s in sections if s).strip()
+  return result or None

--- a/robosystems/models/api/graphs/mcp.py
+++ b/robosystems/models/api/graphs/mcp.py
@@ -291,6 +291,14 @@ class MCPToolsResponse(BaseModel):
   tools: list[dict[str, object]] = Field(
     ..., description="List of available MCP tools with their schemas"
   )
+  instructions: str | None = Field(
+    None,
+    description=(
+      "Per-graph routing guidance for MCP clients, tailored to the graph's "
+      "category and live tool set. Clients should pass this to the MCP server's "
+      "`instructions` handshake field so it is always in the agent's context."
+    ),
+  )
 
 
 class MCPToolResult(BaseModel):

--- a/robosystems/routers/graphs/mcp/handlers.py
+++ b/robosystems/routers/graphs/mcp/handlers.py
@@ -198,6 +198,42 @@ class MCPHandler:
 
     return tools
 
+  def get_instructions(self, tools: list[dict[str, Any]]) -> str | None:
+    """Build per-graph routing guidance for the MCP client handshake.
+
+    Derived from the SAME signals that gate the tool list — the resolved
+    tool-name set, shared-repo status, and read-only — so the instructions can
+    never reference a tool this graph doesn't expose. Shared repositories use
+    their manifest's authored ``agent_instructions`` verbatim; entity and
+    generic graphs are generated from the live tool surface.
+    """
+    from robosystems.config.shared_repositories import (
+      get_manifest,
+      is_shared_repository_or_subgraph,
+      resolve_shared_repository_parent,
+    )
+    from robosystems.middleware.mcp.tools.instructions import build_instructions
+
+    is_shared_repo = is_shared_repository_or_subgraph(self.graph_id)
+
+    authored_override: str | None = None
+    if is_shared_repo:
+      try:
+        manifest = get_manifest(resolve_shared_repository_parent(self.graph_id))
+      except ValueError:
+        manifest = None
+      authored_override = getattr(manifest, "agent_instructions", None)
+
+    read_only = bool(getattr(self.mcp_tools, "read_only", is_shared_repo))
+
+    return build_instructions(
+      graph_id=self.graph_id,
+      tool_names={str(tool["name"]) for tool in tools},
+      is_shared_repo=is_shared_repo,
+      read_only=read_only,
+      authored_override=authored_override,
+    )
+
   async def call_tool(self, name: str, arguments: dict[str, Any]) -> dict[str, Any]:
     """Execute an MCP tool call using Graph API backend with comprehensive timeout protection."""
     self._ensure_not_closed()

--- a/robosystems/routers/graphs/mcp/tools.py
+++ b/robosystems/routers/graphs/mcp/tools.py
@@ -117,6 +117,10 @@ async def list_mcp_tools(
 
       enhanced_tools.append(tool)
 
+    # Per-graph routing guidance for the MCP client handshake (derived from the
+    # same tool set, so it can never reference an unavailable tool).
+    instructions = handler.get_instructions(enhanced_tools)
+
     # Record successful operation
     circuit_breaker.record_success(graph_id, "list_tools")
 
@@ -143,7 +147,7 @@ async def list_mcp_tools(
       },
     )
 
-    return MCPToolsResponse(tools=enhanced_tools)
+    return MCPToolsResponse(tools=enhanced_tools, instructions=instructions)
 
   except Exception as e:
     # Record failed operation

--- a/robosystems/routers/graphs/mcp/tools.py
+++ b/robosystems/routers/graphs/mcp/tools.py
@@ -118,8 +118,15 @@ async def list_mcp_tools(
       enhanced_tools.append(tool)
 
     # Per-graph routing guidance for the MCP client handshake (derived from the
-    # same tool set, so it can never reference an unavailable tool).
-    instructions = handler.get_instructions(enhanced_tools)
+    # same tool set, so it can never reference an unavailable tool). Best-effort:
+    # a failure building instructions must never break tool discovery.
+    try:
+      instructions = handler.get_instructions(enhanced_tools)
+    except Exception as instructions_error:
+      logger.warning(
+        f"Failed to build MCP instructions for graph {graph_id}: {instructions_error}"
+      )
+      instructions = None
 
     # Record successful operation
     circuit_breaker.record_success(graph_id, "list_tools")

--- a/static/description.md
+++ b/static/description.md
@@ -64,29 +64,27 @@ Domain extensions (RoboLedger, RoboInvestor) bring their own schema and OLTP tab
 - **Writes** → `POST /extensions/{domain}/{graph_id}/operations/{operation_name}` — named `OperationEnvelope` commands with `Idempotency-Key` and SSE progress
 - **Views** → `POST /extensions/{domain}/{graph_id}/operations/{view_name}` — read-only analytics over the materialized graph
 
-Per-domain flags (`ROBOLEDGER_ENABLED`, `ROBOINVESTOR_ENABLED`) gate both the routers and the GraphQL schema.
+### RoboLedger
 
-### [RoboLedger](https://roboledger.ai)
-
-Accounting and financial reporting extension — a ledger-grade system of record that AI and analysts can both query and operate, broadly implementing the [Seattle Method](http://xbrlsite.com/seattlemethod/). Three block molecules are the authoring substrate:
+[RoboLedger](https://roboledger.ai) is an accounting and financial reporting extension — a ledger-grade system of record that AI and analysts can both query and operate, broadly implementing the [Seattle Method](http://xbrlsite.com/seattlemethod/). Three block molecules are the authoring substrate:
 
 - **Information Blocks** — reportable content (schedules, statements, metrics) bundled with period-versioned fact sets, typed mechanics, and rules; `evaluate-rules` runs arithmetic checks over materialized facts
 - **Event Blocks** — REA event capture: record what happened via an action-verb vocabulary, and a handler registry derives debits/credits across the three-level ledger (Transaction → Entry → LineItem)
-- **Taxonomy Blocks** — accounting frameworks as data: Elements, Associations (presentation / calculation / mapping), Structures, and structural rules in one write; ships `fac` and `rs-gaap` (~2,000 curated US-GAAP concepts)
+- **Taxonomy Blocks** — accounting frameworks as data: Elements, Associations (presentation / calculation / mapping), Structures, and structural rules in one write; Ships with `rs-gaap` (~2,000 curated US-GAAP concepts) as the initial base taxonomy
 
 Built on the blocks:
 
-- **Reads** (GraphQL) — chart of accounts and account trees, transactions, trial balances, taxonomies, mappings, reports, schedules, and fiscal calendar
+- **Reads** (GraphQL) — chart of accounts and account trees, events/transactions, trial balances, financial statements, taxonomies, mappings, reports, schedules, and fiscal calendar
 - **Close lifecycle** — fiscal calendar (`closed_through` / `close_target`) with period close/reopen gated on the balance equation and QuickBooks sync-staleness
 - **Mapping** — CoA→GAAP associations plus AI-assisted bulk mapping via the **MappingOperator** (auto-approve / review / skip)
 - **Reporting** — multi-period statements through a Reporting Style, with a draft → under_review → filed → archived lifecycle and publish lists
-- **Analytical views** — `live-financial-statement` from the OLTP ledger; `build-fact-grid` and `financial-statement-analysis` over the materialized XBRL hypercube
+- **Analytical views** — `live-financial-statement` from the OLTP ledger; `build-fact-grid` and `financial-statement-analysis` over the materialized XBRL graph hypercube
 - **Serialization** — reports to **JSON-LD** (SHACL-validatable) and **XBRL 2.1** (Arelle-validated)
-- **Pipelines** — QuickBooks ELT via dbt/Dagster with a configurable `write_policy`, plus SEC XBRL
+- **Pipelines** — QuickBooks ELT via dbt/Dagster with a configurable `write_policy`
 
-### [RoboInvestor](https://roboinvestor.ai)
+### RoboInvestor
 
-Portfolio management and investment tracking extension — tracks investor holdings and links them back to the companies behind them.
+[RoboInvestor](https://roboinvestor.ai) is a portfolio management and investment tracking extension — tracks investor holdings and links them back to the companies behind them.
 
 - **Portfolio Blocks** — a portfolio with its positions and securities written as one validated envelope (cost basis as integer cents); positions move through an active / disposed / archived lifecycle. Reads expose `portfolios`, `positions`, `holdings` (rolled up by issuer), and the assembled `portfolioBlock`
 - **Securities** — ownership instruments (common stock, warrants, convertible notes, …) with an extensible `terms` blob for instrument-specific detail

--- a/tests/middleware/mcp/tools/test_instructions.py
+++ b/tests/middleware/mcp/tools/test_instructions.py
@@ -1,0 +1,143 @@
+"""Tests for the per-graph MCP instructions generator.
+
+The generator is a pure function over the resolved tool-name set. The core
+invariant — and the reason it's generated rather than hand-authored for entity
+graphs — is that it can never reference a tool the graph doesn't expose. These
+tests pin that invariant plus the per-category routing.
+"""
+
+from __future__ import annotations
+
+from robosystems.middleware.mcp.tools.instructions import build_instructions
+
+# Representative tool sets per graph category.
+_CORE = {"read-graph-cypher", "get-graph-schema", "get-example-queries"}
+_LEDGER = _CORE | {
+  "get-close-playbook",
+  "get-fiscal-calendar",
+  "get-period-close-status",
+  "get-graph-sync-status",
+  "get-unmapped-elements",
+  "suggest-mapping",
+  "list-mapping-structures",
+  "get-mapping-summary",
+  "live-financial-statement",
+  "build-fact-grid",
+  "financial-statement-analysis",
+  "search-documents",
+  "write-graph-cypher",
+  "query-graphql",
+}
+_PORTFOLIO = _CORE | {"create-portfolio-block", "create-security", "query-graphql"}
+
+
+class TestAuthoredOverride:
+  def test_shared_repo_uses_authored_verbatim(self) -> None:
+    authored = "Connected to `sec`.\n\nSTART HERE\n- do the thing."
+    out = build_instructions(
+      graph_id="sec",
+      tool_names=_CORE,
+      is_shared_repo=True,
+      read_only=True,
+      authored_override=authored,
+    )
+    assert out == authored
+
+  def test_blank_override_falls_through_to_generated(self) -> None:
+    out = build_instructions(
+      graph_id="sec",
+      tool_names=_CORE,
+      is_shared_repo=True,
+      read_only=True,
+      authored_override="   ",
+    )
+    assert out is not None
+    assert "READ-ONLY" in out
+
+
+class TestLedgerGraph:
+  def _out(self) -> str:
+    out = build_instructions(
+      graph_id="kgLEDGER",
+      tool_names=_LEDGER,
+      is_shared_repo=False,
+      read_only=False,
+    )
+    assert out is not None
+    return out
+
+  def test_header_identifies_roboledger(self) -> None:
+    assert "RoboLedger entity graph" in self._out()
+
+  def test_close_routes_to_playbook_first(self) -> None:
+    out = self._out()
+    assert "`get-close-playbook` FIRST" in out
+    assert "get-fiscal-calendar" in out
+
+  def test_mapping_section_present(self) -> None:
+    assert "`suggest-mapping`" in self._out()
+
+  def test_writes_listed_when_writable(self) -> None:
+    assert "`write-graph-cypher`" in self._out()
+
+  def test_tenant_docs_hint_present(self) -> None:
+    assert "search-documents" in self._out()
+
+
+class TestGenericGraph:
+  def test_generic_header_and_no_ledger_routing(self) -> None:
+    out = build_instructions(
+      graph_id="kgPLAIN",
+      tool_names=_CORE,
+      is_shared_repo=False,
+      read_only=False,
+    )
+    assert out is not None
+    assert "custom property graph" in out
+    # The invariant: tools not in the set are never named.
+    assert "get-close-playbook" not in out
+    assert "suggest-mapping" not in out
+    assert "write-graph-cypher" not in out
+
+
+class TestPortfolioGraph:
+  def test_header_identifies_roboinvestor(self) -> None:
+    out = build_instructions(
+      graph_id="kgPORT",
+      tool_names=_PORTFOLIO,
+      is_shared_repo=False,
+      read_only=False,
+    )
+    assert out is not None
+    assert "RoboInvestor entity graph" in out
+    assert "`create-security`" in out
+
+
+class TestSharedRepoGenerated:
+  def test_read_only_footer_and_no_writes(self) -> None:
+    out = build_instructions(
+      graph_id="custrepo",
+      tool_names=_CORE | {"write-graph-cypher"},
+      is_shared_repo=True,
+      read_only=True,
+    )
+    assert out is not None
+    assert "shared read-only data" in out
+    # read_only suppresses the write routing even if the tool name leaks in.
+    assert "`write-graph-cypher`" not in out
+
+
+class TestInvariant:
+  def test_only_present_tools_are_referenced(self) -> None:
+    # A ledger graph missing the sync-status tool must not mention it.
+    tools = _LEDGER - {"get-graph-sync-status"}
+    out = build_instructions(
+      graph_id="kgLEDGER",
+      tool_names=tools,
+      is_shared_repo=False,
+      read_only=False,
+    )
+    assert out is not None
+    assert "get-graph-sync-status" not in out
+    # but the orient line still works off the remaining tools
+    assert "get-fiscal-calendar" in out

--- a/tests/routers/graphs/test_mcp_execution.py
+++ b/tests/routers/graphs/test_mcp_execution.py
@@ -192,6 +192,8 @@ class TestMCPEndpoints:
           },
         ]
       )
+      # get_instructions is sync and returns the per-graph routing string
+      mock_handler.get_instructions = Mock(return_value="ROUTING GUIDANCE")
 
       MockHandler.return_value = mock_handler
 
@@ -206,6 +208,7 @@ class TestMCPEndpoints:
       data = response.json()
       assert "tools" in data
       assert len(data["tools"]) >= 2
+      assert data["instructions"] == "ROUTING GUIDANCE"
 
   @pytest.mark.asyncio
   async def test_mcp_unauthorized_access(self, test_user_graph, test_db):


### PR DESCRIPTION
## Summary

Adds a per-graph `instructions` string to the MCP tools response so MCP clients can populate the server's `instructions` handshake field — the always-in-context routing layer that tells a connected agent which tool family to reach for given an intent (e.g. "before a close, call `get-close-playbook`"). Tools alone don't solve this: an agent only calls a tool once it already knows to, whereas `instructions` ships in the initialize handshake and is in context from the first token.

The string is derived from the **same signals that gate the tool list**, so it can never reference a tool the graph doesn't expose.

## Changes

**Manifest — authored source for shared repos**
- `adapters/base.py` — add optional `SharedRepositoryManifest.agent_instructions`. Shared repos have a fixed, curated tool set, so their guidance is hand-authored and used verbatim.
- `adapters/sec/manifest.py` — author SEC's instructions (read-only XBRL exploration: `get-example-queries`, `financial-statement-analysis`, `build-fact-grid`, `resolve-element`, `search-documents`, and the `sec_historical` subgraph).

**Generator — live source for entity/generic graphs**
- `middleware/mcp/tools/instructions.py` (new) — `build_instructions()`: returns the authored override verbatim when present, otherwise generates a routing map by branching on the resolved tool-name set (ledger close/mapping/reporting, investor portfolio, generic explore). Read-only suppresses write routing; the SEC-carries-`roboledger`-but-read-only case is handled correctly because gating is by live tool, not by extension flag.

**Wiring**
- `routers/graphs/mcp/handlers.py` — `MCPHandler.get_instructions(tools)` resolves the shared-repo manifest override (or none) and calls the generator with the same `is_shared_repo` / `read_only` / tool-name signals already in scope.
- `models/api/graphs/mcp.py` — add `MCPToolsResponse.instructions: str | None`.
- `routers/graphs/mcp/tools.py` — populate it in `list_mcp_tools` from the enhanced tool list.

**Docs — unrelated, carried in this branch**
- `README.md`, `static/description.md` — wording/framing tightening (REST `GET`, LadybugDB naming, RoboLedger/RoboInvestor descriptions).

## Testing

- `just test-code` (ruff + format + basedpyright + cf-lint): **clean**.
- `tests/middleware/mcp/tools/test_instructions.py` (new, 11 tests) — per-category routing plus the "never names an absent tool" invariant: **pass**.
- `tests/middleware/mcp/` (589) and router MCP suites `test_mcp.py` / `test_mcp_handlers.py` / `mcp/test_mcp_handlers.py` (55 pass, 4 skipped): **pass**.
- Full `just test-all` not run this session.

## Notes / Follow-ups

- **Client coordination:** the field is inert until the MCP client reads it — see the paired `robosystems-mcp-client` PR (passes it to the `new Server` handshake and inlines it in `switch-workspace` results). The two deploys are **decoupled and safe in either order**: an old client ignores the new field; a new client treats a missing field as no-instructions.
- `agent_instructions` is optional per repo — a future shared repo that doesn't set it falls back to the generated skeleton.
