### PR TITLE
docs(mcp): pin install spec to @robosystems/mcp@latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ RoboSystems provides comprehensive client libraries for building applications:
 AI integration client for connecting Claude and other LLMs to RoboSystems.
 
 ```bash
-npx -y @robosystems/mcp
+npx -y @robosystems/mcp@latest
 ```
 
 - **Features**: Claude Desktop integration, natural language queries, graph traversal, financial analysis

--- a/static/description.md
+++ b/static/description.md
@@ -102,14 +102,14 @@ Built on the blocks:
 
 Model Context Protocol client for AI agent integration - [@robosystems/mcp](https://www.npmjs.com/package/@robosystems/mcp)
 
-**Usage**: `npx -y @robosystems/mcp`
+**Usage**: `npx -y @robosystems/mcp@latest`
 
 ```
 {
   "mcpServers": {
     "robosystems": {
       "command": "npx",
-      "args": ["-y", "@robosystems/mcp"],
+      "args": ["-y", "@robosystems/mcp@latest"],
       "env": {
         "ROBOSYSTEMS_API_URL": "https://api.robosystems.ai",
         "ROBOSYSTEMS_API_KEY": "rfs*",


### PR DESCRIPTION
## Summary
Flip the MCP client install spec in docs from bare `@robosystems/mcp` to `@robosystems/mcp@latest`.

## Why
`npx -y @robosystems/mcp` (bare name) runs an already-installed copy — a global install or `_npx` cache entry — **without checking the registry**, so a stale version silently wins and published client updates don't propagate (a global `@0.3.9` shadowed `0.3.10` twice). The `@latest` tag forces npx to resolve the current published version.

## Changes
- `README.md` — usage snippet
- `static/description.md` — usage line + MCP config `args`

## Testing
Docs only — no code paths affected.

Part of a cross-repo sweep making `@latest` the baseline for every copy-paste install spec (robosystems-app, roboinvestor-app, roboledger-app, robosystems-mcp-client, wiki).