### PR TITLE
feat(examples): DataBook named-graph holon TriG serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,10 @@ RoboSystems is an open-source, AI-native financial intelligence platform for acc
 
 The platform provides the core infrastructure that all extensions build on:
 
-- **Dedicated Infrastructure**: Tiered graph infrastructure with dedicated instances and configurable memory allocation
+- **Dedicated Infrastructure**: Tiered LadybugDB graph infrastructure with dedicated instances and configurable memory allocation
 - **AI Operator System**: Autonomous financial Operators (Claude/MCP executors) with automatic credit tracking and SSE progress streaming.
 - **Shared Repositories**: SEC XBRL filings knowledge graph for context mining and benchmarking
 - **Document Management**: Upload, index, and search documents with full-text and semantic search via OpenSearch
-- **DuckDB Staging System**: High-performance data validation and bulk ingestion pipeline
-- **Dagster Orchestration**: Data pipeline orchestration for SEC filings, QuickBooks sync, backups, billing, and scheduled jobs
 - **Credit-Based Billing**: Flexible credits for AI operations based on token usage
 - **Subgraphs (Workspaces)**: AI memory graphs and isolated environments for development and team collaboration
 - **Web Application**: Primary web interface — graph management, the AI query console (natural-language + Cypher over MCP), schema explorer, document search, shared-repository access, and billing — [`robosystems-app`](https://github.com/RoboFinSystems/robosystems-app)
@@ -57,39 +55,6 @@ Portfolio management and investment tracking extension — tracks investor holdi
 - **Cross-graph research** — a security links to its issuer through a mutual handshake: the investor records the issuer's `source_graph_id`, and the issuer shares a report that materializes its entity in the investor's graph. This joins private holdings to SEC public-company data in the shared repository — the differentiated capability — with authorization enforced at the report-sharing boundary, not the OLTP layer.
 
 Dedicated frontend app: [`roboinvestor-app`](https://github.com/RoboFinSystems/roboinvestor-app).
-
-## SEC Shared Repository
-
-A curated knowledge graph of US public company financial data from SEC EDGAR XBRL filings. Runs on the shared LadybugDB tier, accessible via MCP tools, Cypher queries, and the AI Operator.
-
-- **Pipeline**: EDGAR → Download → Process (Parquet) → Stage (DuckDB) → Enrich (fastembed) → Materialize (LadybugDB) → Index + Embed (OpenSearch)
-- **Graph**: 14 node types and 24 relationship types modeling the full XBRL reporting hierarchy
-- **Search**: Hybrid BM25 + KNN vector search across XBRL text blocks, narrative sections, and iXBRL disclosures
-- **Enrichment**: Semantic element mapping, statement classification, and disclosure tagging — applying aspects of the Seattle Method to the shared repository's disclosures (the methodology RoboLedger implements more broadly)
-
-See [SEC Adapter](/robosystems/adapters/sec/README.md) for detailed documentation.
-
-## AI
-
-### Model Context Protocol (MCP)
-
-- **Financial Analysis**: Natural language queries across enterprise data and public benchmark data
-- **Cross-Database Queries**: Compare user graph data against SEC shared repository data
-- **Tools**: Rich toolkit for graph queries, schema introspection, fact discovery, financial analysis, document search, and AI memory operations
-- **Handler Pool**: Managed MCP handler instances with resource limits
-
-### AI Operator System
-
-- Unified architecture: stateless Operators (Claude/MCP executors) with protocol-based service injection
-- Dual execution: API (sync/SSE) and background worker (Valkey queue + SSE progress)
-- Automatic credit tracking per AI call — Operators cannot forget billing
-- Extensible: add new Operators for new AI workflows; they inherit execution, credit tracking, and progress streaming automatically
-
-### Credit System
-
-- **AI Operations Only**: Credits are consumed exclusively by AI Operator calls (Anthropic Claude via AWS Bedrock)
-- **Token-Based Billing**: Credits based on actual token usage and model cost
-- **MCP Tool Access**: No credits consumed for MCP calls or database operations
 
 ## Quick Start
 
@@ -227,6 +192,39 @@ Built end-to-end on open-source engines — PostgreSQL, LadybugDB, DuckDB, Lance
 - CloudFormation deployed via GitHub Actions with OIDC
 - ECS Fargate for API and Dagster
 - EC2 (ASG) for LadybugDB writer clusters; EC2 (ALB + ASG) for shared replica clusters
+
+## AI
+
+### Model Context Protocol (MCP)
+
+- **Financial Analysis**: Natural language queries across enterprise data and public benchmark data
+- **Cross-Database Queries**: Compare user graph data against SEC shared repository data
+- **Tools**: Rich toolkit for graph queries, schema introspection, fact discovery, financial analysis, document search, and AI memory operations
+- **Handler Pool**: Managed MCP handler instances with resource limits
+
+### AI Operator System
+
+- Unified architecture: stateless Operators (Claude/MCP executors) with protocol-based service injection
+- Dual execution: API (sync/SSE) and background worker (Valkey queue + SSE progress)
+- Automatic credit tracking per AI call — Operators cannot forget billing
+- Extensible: add new Operators for new AI workflows; they inherit execution, credit tracking, and progress streaming automatically
+
+### Credit System
+
+- **AI Operations Only**: Credits are consumed exclusively by AI Operator calls (Anthropic Claude via AWS Bedrock)
+- **Token-Based Billing**: Credits based on actual token usage and model cost
+- **MCP Tool Access**: No credits consumed for MCP calls or database operations
+
+## SEC Shared Repository
+
+A curated knowledge graph of US public company financial data from SEC EDGAR XBRL filings. Runs on the shared LadybugDB tier, accessible via MCP tools, Cypher queries, and the AI Operator.
+
+- **Pipeline**: EDGAR → Download → Process (Parquet) → Stage (DuckDB) → Enrich (fastembed) → Materialize (LadybugDB) → Index + Embed (OpenSearch)
+- **Graph**: 14 node types and 24 relationship types modeling the full XBRL reporting hierarchy
+- **Search**: Hybrid BM25 + KNN vector search across XBRL text blocks, narrative sections, and iXBRL disclosures
+- **Enrichment**: Semantic element mapping, statement classification, and disclosure tagging — applying aspects of the Seattle Method to the shared repository's disclosures (the methodology RoboLedger implements more broadly)
+
+See [SEC Adapter](/robosystems/adapters/sec/README.md) for detailed documentation.
 
 ## Client Libraries
 

--- a/examples/_common/databook.py
+++ b/examples/_common/databook.py
@@ -35,7 +35,7 @@ from collections import defaultdict
 from pathlib import Path
 
 import rdflib
-from rdflib import RDF, Graph, URIRef
+from rdflib import RDF, Dataset, Graph, URIRef
 from rdflib.namespace import Namespace
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -312,8 +312,107 @@ def _render_ib_turtle(src: Graph, ib: URIRef) -> str:
 # ── Frontmatter ──────────────────────────────────────────────────────────────
 
 
+def _triple_count(turtle: str) -> int:
+  """Approximate triple count of a turtle slice for the fold summary — count
+  statement terminators (``;`` / ``.``), skipping ``@prefix`` lines and blanks."""
+  n = 0
+  for line in turtle.splitlines():
+    s = line.strip()
+    if not s or s.startswith("@prefix"):
+      continue
+    if s.endswith(";") or s.endswith("."):
+      n += 1
+  return n
+
+
+def _fold(block_type: str, title: str, turtle: str) -> str:
+  """Collapse a scene turtle slice into a ``<details>`` so the human view (the
+  table) stays clean while the RDF still travels in the same file. Folds
+  *pixels, not bytes* — the triples are all still here for any parser. The
+  blank lines around the fence are required for GitHub-flavored Markdown to
+  render the code block when expanded."""
+  n = _triple_count(turtle)
+  kb = len(turtle.encode("utf-8")) / 1024
+  summary = f"▸ {title} — scene RDF / Turtle ({n} triples · {kb:.1f} KB)"
+  return (
+    f"<details>\n<summary>{summary}</summary>\n\n"
+    f"```turtle {{#{block_type}}}\n{turtle}\n```\n\n"
+    f"</details>"
+  )
+
+
+def _graph_index(
+  root: URIRef,
+  fact_count: int,
+  pins: list[tuple[str, str]],
+  reporting_style: str,
+  holon_name: str,
+) -> list[str]:
+  """The holon map — the decomposition, made explicit, with **resolvable**
+  IRIs. The three published graphs are real named graphs in the companion
+  ``holon.trig`` (``href``): **scene** (facts, also inlined + folded here),
+  **boundary** (calculation arcs) and **projection** (presentation arcs +
+  structures) — boundary/projection also name the versioned framework they
+  derive from. The fourth graph, **lineage** (the ledger), carries no IRI
+  because it is intentionally unpublished: a report is an aggregation of the
+  books, not the books; the inline validation evidence is the published
+  substantiation that the referenced rules hold."""
+  rid = str(root)
+
+  def _pin(needle: str) -> str | None:
+    for fw, ver in pins:
+      if needle in fw:
+        return f"{fw}@{ver}"
+    return None
+
+  calc = _pin("calculation")
+  pres = _pin("presentation")
+  out = [
+    "graph:",
+    f"  facts: {fact_count}",
+    f"  href: {holon_name}",
+    "  graphs:",
+  ]
+  out += [
+    "    - id: scene",
+    f"      iri: {rid}#scene",
+    '      description: "Instance facts — the values this report reports"',
+    "      disposition: inline",
+  ]
+  out += [
+    "    - id: boundary",
+    f"      iri: {rid}#boundary",
+    '      description: "Calculation network — the rollup rules the facts must obey"',
+    "      disposition: reference",
+  ]
+  if calc:
+    out.append(f"      derived_from: {calc}")
+  out += [
+    "    - id: projection",
+    f"      iri: {rid}#projection",
+    '      description: "Presentation network — order, indentation, subtotals"',
+    "      disposition: reference",
+  ]
+  if pres:
+    out.append(f"      derived_from: {pres}")
+  if reporting_style:
+    out.append(f"      reporting_style: {reporting_style}")
+  out += [
+    "    - id: lineage",
+    '      description: "Event lineage — fact → event → entry → line item → CoA"',
+    "      disposition: internal",
+    '      note: "the books, not published — a report is an aggregation of the ledger, which is internal; substantiation available to authorized parties"',
+  ]
+  return out
+
+
 def _frontmatter(
-  g: Graph, root: URIRef, ibs: list[URIRef], columns: list[dict], title: str
+  g: Graph,
+  root: URIRef,
+  ibs: list[URIRef],
+  columns: list[dict],
+  title: str,
+  holon_name: str,
 ) -> str:
   """DataBook frontmatter in Charlie Hoffman's canonical envelope + key order
   (id · type · title · version · created · modified · authors · license ·
@@ -389,6 +488,11 @@ def _frontmatter(
     lines.append(f"    {bt}:")
     lines.append("      type: turtle")
     lines.append(f"      description: {_yaml_str(desc)}")
+  # ── Holon graph map: inline scene · referenced boundary/projection ·
+  #    internal lineage ──
+  fact_count = sum(1 for _ in g.subjects(RDF.type, RS.Fact))
+  reporting_style = str(g.value(root, RS.reportingStyle) or "")
+  lines += _graph_index(root, fact_count, pins, reporting_style, holon_name)
   # ── RoboSystems extension (after the canonical keys) ──
   lines.append("report:")
   lines.append(f"  reporting_style: {g.value(root, RS.reportingStyle) or ''}")
@@ -442,6 +546,79 @@ def _evidence_section(shacl_md: Path | None, xbrl_md: Path | None) -> str:
 # ── Top-level render ─────────────────────────────────────────────────────────
 
 
+def _partition_holon(g: Graph, root: URIRef) -> dict[str, Graph]:
+  """Split the flat report graph into the three *published* holon graphs —
+  ``scene`` (facts, the InformationBlock that groups them, and the
+  element/period/unit/entity/factSet they reference), ``boundary``
+  (calculation arcs) and ``projection`` (presentation arcs + structures). The
+  fourth graph, lineage/event, is intentionally absent: a report is an
+  aggregation of the books, not the books, and the ledger is internal.
+  Everything here already lives in the bundle, so this is a pure repartition —
+  no upstream/ledger access needed."""
+  scene, boundary, projection = Graph(), Graph(), Graph()
+
+  scene_subjects: set[URIRef] = set()
+  for fact in g.subjects(RDF.type, RS.Fact):
+    scene_subjects.add(fact)  # type: ignore[arg-type]
+    for ref in (RS.element, RS.period, RS.unit, RS.entity, RS.factSet):
+      v = g.value(fact, ref)
+      if isinstance(v, URIRef):
+        scene_subjects.add(v)
+  # the InformationBlock molecule groups its facts via the shared factSet
+  # (Fact --factSet--> FactSet <--factSet-- InformationBlock); include it so its
+  # blockType / prefLabel and that grouping link land in scene.
+  for ib in g.subjects(RDF.type, RS.InformationBlock):
+    scene_subjects.add(ib)  # type: ignore[arg-type]
+  for s in scene_subjects:
+    for p, o in g.predicate_objects(s):
+      if p == RS.envelopeJson:
+        continue
+      scene.add((s, p, o))
+
+  for assoc in g.subjects(RDF.type, RS.Association):
+    at = str(g.value(assoc, RS.associationType) or "")
+    target = (
+      boundary if at == "calculation" else projection if at == "presentation" else None
+    )
+    if target is None:
+      continue
+    for p, o in g.predicate_objects(assoc):
+      target.add((assoc, p, o))
+
+  for struct in g.subjects(RDF.type, RS.Structure):
+    for p, o in g.predicate_objects(struct):
+      if p == RS.envelopeJson:
+        continue
+      if p == RS.hasAssociation:
+        at = str(g.value(o, RS.associationType) or "")
+        (boundary if at == "calculation" else projection).add((struct, p, o))
+      else:
+        projection.add((struct, p, o))
+
+  return {"scene": scene, "boundary": boundary, "projection": projection}
+
+
+def write_holon_trig(jsonld_path: Path, out_trig: Path) -> Path:
+  """Serialize the report's published holon as a TriG file with three real
+  named graphs — ``<report>#scene`` / ``#boundary`` / ``#projection`` — derived
+  purely from the on-disk ``.jsonld`` (the machine skin the human DataBook
+  references). The named-graph IRIs are exactly the ones the DataBook's
+  ``graph:`` map declares, so those references resolve to actual content."""
+  g = rdflib.Graph().parse(str(jsonld_path), format="json-ld")
+  root = _root(g)
+
+  ds = Dataset()
+  for prefix, ns in _TURTLE_PREFIXES.items():
+    ds.bind(prefix, ns, replace=True)
+  for name, sub in _partition_holon(g, root).items():
+    ctx = ds.graph(URIRef(f"{root}#{name}"))
+    for triple in sub:
+      ctx.add(triple)
+
+  out_trig.write_text(ds.serialize(format="trig"))
+  return out_trig
+
+
 def write_databook(
   jsonld_path: Path,
   out_md: Path,
@@ -459,6 +636,9 @@ def write_databook(
   root = _root(g)
   columns = _period_columns(g, root)
 
+  out_trig = out_md.parent / (jsonld_path.stem + ".holon.trig")
+  write_holon_trig(jsonld_path, out_trig)
+
   ibs = sorted(
     g.subjects(RDF.type, RS.InformationBlock),
     key=lambda ib: (
@@ -471,15 +651,24 @@ def write_databook(
   entity_name = str(g.value(entity, SKOS.prefLabel) or "") if entity else ""
   title = f"{label} — {entity_name}" if entity_name else label
 
-  parts: list[str] = [_frontmatter(g, root, ibs, columns, title)]  # type: ignore[arg-type]
+  parts: list[str] = [
+    _frontmatter(g, root, ibs, columns, title, out_trig.name)  # type: ignore[arg-type]
+  ]
   parts.append(
     f"\n# {title}\n\n"
-    f"A report **is** a collection of Information Blocks. Each block below is "
-    f"shown twice: a markdown table (human view) and an addressable `turtle` "
-    f"block (machine view — the same facts as RDF), keyed by the id declared in "
-    f"the frontmatter `manifest`. Everything is derived from "
-    f"`{jsonld_path.name}`; the bundle and this DataBook are two skins of one "
-    f"graph.\n"
+    f"A report **is** a collection of Information Blocks, and this DataBook is a "
+    f"projection of one report holon (see the `graph:` map above). The **scene** "
+    f"graph — the facts — renders twice per block here: a markdown table (human "
+    f"view) and a foldable, addressable `turtle` slice (machine view, the same "
+    f"facts as RDF). The **boundary** (calculation) and **projection** "
+    f"(presentation) graphs live as real named graphs in the companion "
+    f"`{out_trig.name}` and derive from their versioned framework — referenced "
+    f"here rather than inlined, since they're shared by every report on that "
+    f"framework. The **lineage** graph — the ledger behind the facts — is "
+    f"internal and not published: a report is an aggregation of the books, not "
+    f"the books. The `Validation evidence` section is the published "
+    f"substantiation that the referenced rules hold. Everything here derives from "
+    f"`{jsonld_path.name}`.\n"
   )
 
   for ib in ibs:
@@ -493,9 +682,8 @@ def write_databook(
       f"- **FactSet**: `{str(g.value(ib, RS.factSet)).rsplit('/', 1)[-1]}`\n"
     )
     parts.append(_render_ib_table(g, ib, columns))  # type: ignore[arg-type]
-    parts.append(f"\n```turtle {{#{bt}}}")
-    parts.append(_render_ib_turtle(g, ib))  # type: ignore[arg-type]
-    parts.append("```\n")
+    turtle = _render_ib_turtle(g, ib)  # type: ignore[arg-type]
+    parts.append("\n" + _fold(bt, heading, turtle) + "\n")
 
   evidence = _evidence_section(shacl_md, xbrl_md)
   if evidence:
@@ -527,6 +715,9 @@ def main() -> None:
     jsonld, out, args.label, shacl_md=args.shacl_md, xbrl_md=args.xbrl_md
   )
   print(f"DataBook: {jsonld.name} → {_rel(written)} ({written.stat().st_size:,} bytes)")
+  holon = written.parent / (jsonld.stem + ".holon.trig")
+  if holon.exists():
+    print(f"  + holon:  {_rel(holon)} ({holon.stat().st_size:,} bytes)")
 
 
 if __name__ == "__main__":

--- a/examples/roboledger_demo/sample_output/roboledger-demo.databook.md
+++ b/examples/roboledger_demo/sample_output/roboledger-demo.databook.md
@@ -40,6 +40,29 @@ manifest:
     equity_statement:
       type: turtle
       description: "rs-gaap — Statement of Changes in Equity — Roll Forward (Total)"
+graph:
+  facts: 41
+  href: roboledger-demo.holon.trig
+  graphs:
+    - id: scene
+      iri: https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45#scene
+      description: "Instance facts — the values this report reports"
+      disposition: inline
+    - id: boundary
+      iri: https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45#boundary
+      description: "Calculation network — the rollup rules the facts must obey"
+      disposition: reference
+      derived_from: rs-gaap-calculations@v1
+    - id: projection
+      iri: https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45#projection
+      description: "Presentation network — order, indentation, subtotals"
+      disposition: reference
+      derived_from: rs-gaap-presentation@v1
+      reporting_style: 025f5d48-12ce-5d65-b9eb-4f137a10ef06
+    - id: lineage
+      description: "Event lineage — fact → event → entry → line item → CoA"
+      disposition: internal
+      note: "the books, not published — a report is an aggregation of the ledger, which is internal; substantiation available to authorized parties"
 report:
   reporting_style: 025f5d48-12ce-5d65-b9eb-4f137a10ef06
   report_id: rpt_01KVF94CFWZ98EPA84K7V2EY45
@@ -66,7 +89,7 @@ report:
 
 # RoboLedger Demo — Cascade Advisory Group LLC
 
-A report **is** a collection of Information Blocks. Each block below is shown twice: a markdown table (human view) and an addressable `turtle` block (machine view — the same facts as RDF), keyed by the id declared in the frontmatter `manifest`. Everything is derived from `roboledger-demo.jsonld`; the bundle and this DataBook are two skins of one graph.
+A report **is** a collection of Information Blocks, and this DataBook is a projection of one report holon (see the `graph:` map above). The **scene** graph — the facts — renders twice per block here: a markdown table (human view) and a foldable, addressable `turtle` slice (machine view, the same facts as RDF). The **boundary** (calculation) and **projection** (presentation) graphs live as real named graphs in the companion `roboledger-demo.holon.trig` and derive from their versioned framework — referenced here rather than inlined, since they're shared by every report on that framework. The **lineage** graph — the ledger behind the facts — is internal and not published: a report is an aggregation of the books, not the books. The `Validation evidence` section is the published substantiation that the referenced rules hold. Everything here derives from `roboledger-demo.jsonld`.
 
 
 ## Balance Sheet
@@ -92,6 +115,9 @@ A report **is** a collection of Information Blocks. Each block below is shown tw
 | `rs-gaap:RetainedEarningsAccumulatedDeficit` |     Retained Earnings (Accumulated Deficit) | $20,120.03 |
 | `rs-gaap:StockholdersEquity` |   **Stockholders' Equity Attributable to Parent** | $69,920.03 |
 | `rs-gaap:LiabilitiesAndStockholdersEquity` | **Liabilities and Equity** | $70,720.03 |
+
+<details>
+<summary>▸ Balance Sheet — scene RDF / Turtle (340 triples · 19.6 KB)</summary>
 
 ```turtle {#balance_sheet}
 @prefix iso4217: <http://www.xbrl.org/2003/iso4217#> .
@@ -479,6 +505,8 @@ rs-gaap:RetainedEarningsAccumulatedDeficit a rs:Element ;
     xbrli:measure iso4217:USD .
 ```
 
+</details>
+
 
 ## Income Statement
 
@@ -498,6 +526,9 @@ rs-gaap:RetainedEarningsAccumulatedDeficit a rs:Element ;
 | `rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest` |   **Income (Loss) from Continuing Operations before Income Taxes, Noncontrolling Interest** | $20,120.03 |
 | `rs-gaap:IncomeLossFromContinuingOperations` |   **Income (Loss) from Continuing Operations, Net of Tax, Attributable to Parent** | $20,120.03 |
 | `rs-gaap:NetIncomeLoss` |   **Net Income (Loss) Attributable to Parent** | $20,120.03 |
+
+<details>
+<summary>▸ Income Statement — scene RDF / Turtle (218 triples · 12.8 KB)</summary>
 
 ```turtle {#income_statement}
 @prefix iso4217: <http://www.xbrl.org/2003/iso4217#> .
@@ -750,6 +781,8 @@ rs-gaap:Revenues a rs:Element ;
     xbrli:measure iso4217:USD .
 ```
 
+</details>
+
 
 ## Cash Flow Statement
 
@@ -770,6 +803,9 @@ rs-gaap:Revenues a rs:Element ;
 | `rs-gaap:ProceedsFromIssuanceOfCommonStock` |     Proceeds from Issuance of Common Stock | $49,800.00 |
 | `rs-gaap:NetCashProvidedByUsedInFinancingActivities` |   Cash Provided by (Used in) Financing Activity, Including Discontinued Operation | $49,800.00 |
 | `rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease` | **Cash and Cash Equivalents, Period Increase (Decrease)** | $63,695.00 |
+
+<details>
+<summary>▸ Cash Flow Statement — scene RDF / Turtle (238 triples · 14.2 KB)</summary>
 
 ```turtle {#cash_flow_statement}
 @prefix iso4217: <http://www.xbrl.org/2003/iso4217#> .
@@ -1044,6 +1080,8 @@ rs-gaap:ProceedsFromIssuanceOfCommonStock a rs:Element ;
     xbrli:measure iso4217:USD .
 ```
 
+</details>
+
 
 ## Statement of Changes in Equity
 
@@ -1056,6 +1094,9 @@ rs-gaap:ProceedsFromIssuanceOfCommonStock a rs:Element ;
 | `rs-gaap:NetIncomeLoss` |   **Net Income (Loss) Attributable to Parent** | $20,120.03 |
 | `rs-gaap:ProceedsFromIssuanceOfCommonStock` |   Proceeds from Issuance of Common Stock | $49,800.00 |
 | `rs-gaap:StockholdersEquity` | **Stockholders' Equity Attributable to Parent** | $69,920.03 |
+
+<details>
+<summary>▸ Statement of Changes in Equity — scene RDF / Turtle (81 triples · 4.9 KB)</summary>
 
 ```turtle {#equity_statement}
 @prefix iso4217: <http://www.xbrl.org/2003/iso4217#> .
@@ -1157,6 +1198,8 @@ rs-gaap:StockholdersEquity a rs:Element ;
 <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/unit/u_USD> a rs:Unit ;
     xbrli:measure iso4217:USD .
 ```
+
+</details>
 
 
 ## Validation evidence

--- a/examples/roboledger_demo/sample_output/roboledger-demo.holon.trig
+++ b/examples/roboledger_demo/sample_output/roboledger-demo.holon.trig
@@ -1,0 +1,2447 @@
+@prefix iso4217: <http://www.xbrl.org/2003/iso4217#> .
+@prefix link: <http://www.xbrl.org/2003/linkbase#> .
+@prefix rs: <https://robosystems.ai/vocab/> .
+@prefix rs-gaap: <https://robosystems.ai/taxonomy/rs-gaap/v1/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xbrli: <http://www.xbrl.org/2003/instance#> .
+@prefix xlink: <http://www.w3.org/1999/xlink#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45#projection> {
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/structure/0b179e5c-5f02-506d-b8d5-860cb10c7694> a rs:Structure ;
+        rs:blockType "equity_statement" ;
+        rs:hasAssociation <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/0>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/1>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/2>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/3>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/4>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/5> ;
+        rs:internalId "0b179e5c-5f02-506d-b8d5-860cb10c7694" ;
+        rs:roleUri "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward" ;
+        rs:structureName "rs-gaap — Statement of Changes in Equity — Roll Forward (Total)" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> a rs:Structure ;
+        rs:blockType "income_statement" ;
+        rs:hasAssociation <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/0>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/1>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/10>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/11>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/12>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/13>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/14>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/15>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/16>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/17>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/18>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/19>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/2>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/20>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/21>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/22>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/23>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/24>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/25>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/26>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/3>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/4>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/5>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/6>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/7>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/8>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/9> ;
+        rs:internalId "47cd6544-03d1-5bc1-8c28-31c0cfa450f9" ;
+        rs:roleUri "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep" ;
+        rs:structureName "rs-gaap — Income Statement — Multi-step" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> a rs:Structure ;
+        rs:blockType "cash_flow_statement" ;
+        rs:hasAssociation <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/0>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/1>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/10>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/11>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/12>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/13>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/14>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/15>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/16>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/17>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/18>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/19>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/2>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/20>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/21>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/22>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/3>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/4>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/5>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/6>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/7>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/8>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/9> ;
+        rs:internalId "5473639a-2dac-56a6-b9e5-38480ea38bc1" ;
+        rs:roleUri "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect" ;
+        rs:structureName "rs-gaap — Cash Flow Statement — Indirect" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> a rs:Structure ;
+        rs:blockType "balance_sheet" ;
+        rs:hasAssociation <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/0>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/1>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/10>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/11>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/12>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/13>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/14>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/15>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/16>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/17>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/18>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/19>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/2>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/20>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/21>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/22>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/23>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/24>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/25>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/26>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/27>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/28>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/29>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/3>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/30>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/31>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/32>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/33>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/34>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/35>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/36>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/37>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/4>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/5>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/6>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/7>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/8>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/9> ;
+        rs:internalId "b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d" ;
+        rs:roleUri "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified" ;
+        rs:structureName "rs-gaap — Balance Sheet — Classified" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/0> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:StockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward> ;
+        xlink:to rs-gaap:NetIncomeLoss ;
+        link:order 40100.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/1> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:StockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward> ;
+        xlink:to rs-gaap:OtherComprehensiveIncomeLossNetOfTax ;
+        link:order 40200.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/2> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:StockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward> ;
+        xlink:to rs-gaap:ProceedsFromIssuanceOfCommonStock ;
+        link:order 40300.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/3> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:StockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward> ;
+        xlink:to rs-gaap:PaymentsForRepurchaseOfCommonStock ;
+        link:order 40400.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/4> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:StockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward> ;
+        xlink:to rs-gaap:ShareBasedCompensation ;
+        link:order 40500.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/5> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:StockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward> ;
+        xlink:to rs-gaap:PaymentsOfDividends ;
+        link:order 40600.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/0> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:IncomeStatementAbstract ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:Revenues ;
+        link:order 10100.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/1> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:Revenues ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax ;
+        link:order 10120.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/10> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:OperatingExpenses ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:DepreciationDepletionAndAmortization ;
+        link:order 10430.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/11> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:OperatingExpenses ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:OtherCostAndExpenseOperating ;
+        link:order 10440.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/12> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:OperatingExpenses ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:RestructuringCharges ;
+        link:order 10443.3333 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/13> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:OperatingExpenses ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:AssetImpairmentCharges ;
+        link:order 10446.6667 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/14> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:IncomeStatementAbstract ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:OperatingIncomeLoss ;
+        link:order 10500.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/15> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:IncomeStatementAbstract ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:NonoperatingIncomeExpense ;
+        link:order 10600.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/16> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NonoperatingIncomeExpense ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:InvestmentIncomeInterest ;
+        link:order 10610.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/17> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NonoperatingIncomeExpense ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:InterestExpense ;
+        link:order 10620.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/18> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NonoperatingIncomeExpense ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:GainLossOnDispositionOfAssets ;
+        link:order 10630.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/19> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NonoperatingIncomeExpense ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:OtherNonoperatingIncomeExpense ;
+        link:order 10640.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/2> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:IncomeStatementAbstract ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:CostOfRevenue ;
+        link:order 10200.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/20> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NonoperatingIncomeExpense ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:ForeignCurrencyTransactionGainLossBeforeTax ;
+        link:order 10643.3333 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/21> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NonoperatingIncomeExpense ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:GainsLossesOnExtinguishmentOfDebt ;
+        link:order 10646.6667 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/22> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:IncomeStatementAbstract ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest ;
+        link:order 10800.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/23> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:IncomeStatementAbstract ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:IncomeTaxExpenseBenefit ;
+        link:order 10900.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/24> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:IncomeStatementAbstract ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:IncomeLossFromContinuingOperations ;
+        link:order 11000.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/25> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:IncomeStatementAbstract ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:IncomeLossFromDiscontinuedOperationsNetOfTax ;
+        link:order 11100.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/26> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:IncomeStatementAbstract ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:NetIncomeLoss ;
+        link:order 11200.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/3> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:CostOfRevenue ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:CostOfGoodsAndServicesSold ;
+        link:order 10210.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/4> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:CostOfRevenue ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:OtherCostOfOperatingRevenue ;
+        link:order 10230.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/5> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:IncomeStatementAbstract ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:GrossProfit ;
+        link:order 10300.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/6> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:IncomeStatementAbstract ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:OperatingExpenses ;
+        link:order 10400.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/7> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:OperatingExpenses ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:GeneralAndAdministrativeExpense ;
+        link:order 10410.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/8> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:OperatingExpenses ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:SellingAndMarketingExpense ;
+        link:order 10415.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/9> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:OperatingExpenses ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:ResearchAndDevelopmentExpense ;
+        link:order 10420.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/0> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:NetCashProvidedByUsedInOperatingActivities ;
+        link:order 30100.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/1> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NetCashProvidedByUsedInOperatingActivities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:NetIncomeLoss ;
+        link:order 30110.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/10> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:NetCashProvidedByUsedInInvestingActivities ;
+        link:order 30200.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/11> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NetCashProvidedByUsedInInvestingActivities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment ;
+        link:order 30210.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/12> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NetCashProvidedByUsedInInvestingActivities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:ProceedsFromSaleOfPropertyPlantAndEquipment ;
+        link:order 30220.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/13> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NetCashProvidedByUsedInInvestingActivities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:PaymentsToAcquireInvestments ;
+        link:order 30230.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/14> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NetCashProvidedByUsedInInvestingActivities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:ProceedsFromSaleMaturityAndCollectionsOfInvestments ;
+        link:order 30240.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/15> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NetCashProvidedByUsedInInvestingActivities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:PaymentsToAcquireIntangibleAssets ;
+        link:order 30250.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/16> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NetCashProvidedByUsedInInvestingActivities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:ProceedsFromSaleOfIntangibleAssets ;
+        link:order 30260.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/17> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:NetCashProvidedByUsedInFinancingActivities ;
+        link:order 30300.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/18> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NetCashProvidedByUsedInFinancingActivities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:ProceedsFromIssuanceOfCommonStock ;
+        link:order 30310.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/19> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NetCashProvidedByUsedInFinancingActivities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:ProceedsFromIssuanceOfLongTermDebt ;
+        link:order 30320.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/2> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NetCashProvidedByUsedInOperatingActivities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:DepreciationDepletionAndAmortization ;
+        link:order 30120.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/20> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NetCashProvidedByUsedInFinancingActivities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:RepaymentsOfLongTermDebt ;
+        link:order 30330.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/21> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NetCashProvidedByUsedInFinancingActivities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:PaymentsForRepurchaseOfCommonStock ;
+        link:order 30340.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/22> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:EffectOfExchangeRateOnCash ;
+        link:order 30400.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/3> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NetCashProvidedByUsedInOperatingActivities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:IncreaseDecreaseInAccountsReceivable ;
+        link:order 30130.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/4> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NetCashProvidedByUsedInOperatingActivities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:IncreaseDecreaseInInventories ;
+        link:order 30140.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/5> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NetCashProvidedByUsedInOperatingActivities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:IncreaseDecreaseInPrepaidExpense ;
+        link:order 30150.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/6> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NetCashProvidedByUsedInOperatingActivities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:IncreaseDecreaseInAccountsPayableAndAccruedLiabilities ;
+        link:order 30160.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/7> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NetCashProvidedByUsedInOperatingActivities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:IncreaseDecreaseInOtherOperatingCapitalNet ;
+        link:order 30170.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/8> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NetCashProvidedByUsedInOperatingActivities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:IncreaseDecreaseInAccruedLiabilities ;
+        link:order 30180.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/9> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NetCashProvidedByUsedInOperatingActivities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:IncreaseDecreaseInAccruedIncomeTaxesPayable ;
+        link:order 30190.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/0> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:Assets ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:AssetsCurrent ;
+        link:order 20100.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/1> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:AssetsCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:CashAndCashEquivalentsAtCarryingValue ;
+        link:order 20110.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/10> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:AssetsNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:Goodwill ;
+        link:order 20220.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/11> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:AssetsNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:IntangibleAssetsNetExcludingGoodwill ;
+        link:order 20225.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/12> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:AssetsNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:LongTermInvestmentsAndReceivablesNet ;
+        link:order 20230.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/13> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:AssetsNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:OperatingLeaseRightOfUseAsset ;
+        link:order 20240.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/14> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:AssetsNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:FinanceLeaseRightOfUseAsset ;
+        link:order 20250.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/15> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:AssetsNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:OtherAssetsNoncurrent ;
+        link:order 20260.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/16> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:LiabilitiesAndStockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:Liabilities ;
+        link:order 20300.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/17> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:Liabilities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:LiabilitiesCurrent ;
+        link:order 20310.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/18> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:LiabilitiesCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:AccountsPayableCurrent ;
+        link:order 20311.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/19> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:LiabilitiesCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:AccruedLiabilitiesCurrent ;
+        link:order 20311.5 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/2> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:AssetsCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:ShortTermInvestments ;
+        link:order 20115.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/20> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:LiabilitiesCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:DebtCurrent ;
+        link:order 20312.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/21> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:LiabilitiesCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:LongTermDebtCurrent ;
+        link:order 20312.5 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/22> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:LiabilitiesCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:DeferredRevenueCurrent ;
+        link:order 20313.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/23> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:LiabilitiesCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:FinanceLeaseLiabilityCurrent ;
+        link:order 20314.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/24> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:LiabilitiesCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:OtherLiabilitiesCurrent ;
+        link:order 20315.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/25> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:Liabilities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:LiabilitiesNoncurrent ;
+        link:order 20320.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/26> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:LiabilitiesNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:LongTermDebtAndCapitalLeaseObligations ;
+        link:order 20321.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/27> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:LiabilitiesNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:DeferredIncomeTaxLiabilitiesNet ;
+        link:order 20322.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/28> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:LiabilitiesNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:DeferredRevenueNoncurrent ;
+        link:order 20323.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/29> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:LiabilitiesNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:OperatingLeaseLiabilityNoncurrent ;
+        link:order 20324.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/3> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:AssetsCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:ReceivablesNetCurrent ;
+        link:order 20120.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/30> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:LiabilitiesNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:OtherLiabilitiesNoncurrent ;
+        link:order 20325.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/31> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:LiabilitiesAndStockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:StockholdersEquity ;
+        link:order 20400.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/32> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:StockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:CommonStockValue ;
+        link:order 20410.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/33> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:StockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:PreferredStockValue ;
+        link:order 20420.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/34> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:StockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:AdditionalPaidInCapital ;
+        link:order 20430.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/35> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:StockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:RetainedEarningsAccumulatedDeficit ;
+        link:order 20440.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/36> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:StockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:AccumulatedOtherComprehensiveIncomeLossNetOfTax ;
+        link:order 20450.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/37> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:StockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:TreasuryStockValue ;
+        link:order 20460.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/4> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:AssetsCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings ;
+        link:order 20130.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/5> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:AssetsCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:PrepaidExpenseCurrent ;
+        link:order 20140.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/6> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:AssetsCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:RestrictedCashAndInvestmentsCurrent ;
+        link:order 20150.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/7> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:AssetsCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:OtherAssetsCurrent ;
+        link:order 20160.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/8> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:Assets ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:AssetsNoncurrent ;
+        link:order 20200.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/9> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:AssetsNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:PropertyPlantAndEquipmentNet ;
+        link:order 20210.0 ;
+        rs:associationType "presentation" .
+}
+
+<https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45#boundary> {
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/0> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:CostOfRevenue ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:CostOfGoodsAndServicesSold ;
+        link:order 100.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/1> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:GrossProfit ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:Revenues ;
+        link:order 100.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/10> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:CostOfRevenue ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:OtherCostOfOperatingRevenue ;
+        link:order 200.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/11> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:GrossProfit ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:CostOfRevenue ;
+        link:order 200.0 ;
+        link:weight -1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/12> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:IncomeLossFromContinuingOperations ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:IncomeTaxExpenseBenefit ;
+        link:order 200.0 ;
+        link:weight -1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/13> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:NonoperatingIncomeExpense ;
+        link:order 200.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/14> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:NetIncomeLoss ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:IncomeLossFromDiscontinuedOperationsNetOfTax ;
+        link:order 200.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/15> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:NonoperatingIncomeExpense ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:InterestExpense ;
+        link:order 200.0 ;
+        link:weight -1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/16> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:OperatingExpenses ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:ResearchAndDevelopmentExpense ;
+        link:order 200.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/17> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:OperatingIncomeLoss ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:OperatingExpenses ;
+        link:order 200.0 ;
+        link:weight -1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/18> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:NonoperatingIncomeExpense ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:GainLossOnDispositionOfAssets ;
+        link:order 300.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/19> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:OperatingExpenses ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:DepreciationDepletionAndAmortization ;
+        link:order 300.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/2> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:IncomeLossFromContinuingOperations ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest ;
+        link:order 100.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/20> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:NonoperatingIncomeExpense ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:OtherNonoperatingIncomeExpense ;
+        link:order 400.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/21> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:OperatingExpenses ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:OtherCostAndExpenseOperating ;
+        link:order 400.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/22> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:NonoperatingIncomeExpense ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:ForeignCurrencyTransactionGainLossBeforeTax ;
+        link:order 403.3333 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/23> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:OperatingExpenses ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:RestructuringCharges ;
+        link:order 403.3333 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/24> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:NonoperatingIncomeExpense ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:GainsLossesOnExtinguishmentOfDebt ;
+        link:order 406.6667 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/25> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:OperatingExpenses ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:AssetImpairmentCharges ;
+        link:order 406.6667 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/3> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:OperatingIncomeLoss ;
+        link:order 100.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/4> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:NetIncomeLoss ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:IncomeLossFromContinuingOperations ;
+        link:order 100.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/5> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:NonoperatingIncomeExpense ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:InvestmentIncomeInterest ;
+        link:order 100.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/6> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:OperatingExpenses ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:GeneralAndAdministrativeExpense ;
+        link:order 100.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/7> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:OperatingIncomeLoss ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:GrossProfit ;
+        link:order 100.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/8> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:Revenues ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax ;
+        link:order 100.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/9> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:OperatingExpenses ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:SellingAndMarketingExpense ;
+        link:order 150.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/0> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:NetCashProvidedByUsedInOperatingActivities ;
+        link:order 100.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/1> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:NetCashProvidedByUsedInInvestingActivities ;
+        link:order 200.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/2> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:NetCashProvidedByUsedInFinancingActivities ;
+        link:order 300.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/3> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:EffectOfExchangeRateOnCash ;
+        link:order 400.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/0> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:Assets ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:AssetsCurrent ;
+        link:order 100.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/1> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:AssetsCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:CashAndCashEquivalentsAtCarryingValue ;
+        link:order 100.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/10> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:Assets ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:AssetsNoncurrent ;
+        link:order 200.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/11> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:AssetsCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:ReceivablesNetCurrent ;
+        link:order 200.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/12> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:AssetsNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:Goodwill ;
+        link:order 200.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/13> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:Liabilities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:LiabilitiesNoncurrent ;
+        link:order 200.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/14> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:LiabilitiesAndStockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:StockholdersEquity ;
+        link:order 200.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/15> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:LiabilitiesCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:DebtCurrent ;
+        link:order 200.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/16> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:LiabilitiesNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:DeferredIncomeTaxLiabilitiesNet ;
+        link:order 200.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/17> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:StockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:PreferredStockValue ;
+        link:order 200.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/18> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:AssetsNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:IntangibleAssetsNetExcludingGoodwill ;
+        link:order 250.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/19> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:LiabilitiesCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:LongTermDebtCurrent ;
+        link:order 250.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/2> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:AssetsNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:PropertyPlantAndEquipmentNet ;
+        link:order 100.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/20> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:AssetsCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings ;
+        link:order 300.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/21> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:AssetsNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:LongTermInvestmentsAndReceivablesNet ;
+        link:order 300.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/22> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:LiabilitiesCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:DeferredRevenueCurrent ;
+        link:order 300.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/23> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:LiabilitiesNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:DeferredRevenueNoncurrent ;
+        link:order 300.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/24> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:StockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:AdditionalPaidInCapital ;
+        link:order 300.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/25> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:AssetsCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:PrepaidExpenseCurrent ;
+        link:order 400.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/26> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:AssetsNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:OperatingLeaseRightOfUseAsset ;
+        link:order 400.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/27> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:LiabilitiesCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:FinanceLeaseLiabilityCurrent ;
+        link:order 400.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/28> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:LiabilitiesNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:OperatingLeaseLiabilityNoncurrent ;
+        link:order 400.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/29> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:StockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:RetainedEarningsAccumulatedDeficit ;
+        link:order 400.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/3> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:Liabilities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:LiabilitiesCurrent ;
+        link:order 100.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/30> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:AssetsCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:RestrictedCashAndInvestmentsCurrent ;
+        link:order 500.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/31> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:AssetsNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:FinanceLeaseRightOfUseAsset ;
+        link:order 500.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/32> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:LiabilitiesCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:OtherLiabilitiesCurrent ;
+        link:order 500.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/33> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:LiabilitiesNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:OtherLiabilitiesNoncurrent ;
+        link:order 500.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/34> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:StockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:AccumulatedOtherComprehensiveIncomeLossNetOfTax ;
+        link:order 500.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/35> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:AssetsCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:OtherAssetsCurrent ;
+        link:order 600.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/36> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:AssetsNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:OtherAssetsNoncurrent ;
+        link:order 600.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/37> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:StockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:TreasuryStockValue ;
+        link:order 600.0 ;
+        link:weight -1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/4> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:LiabilitiesAndStockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:Liabilities ;
+        link:order 100.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/5> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:LiabilitiesCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:AccountsPayableCurrent ;
+        link:order 100.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/6> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:LiabilitiesNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:LongTermDebtAndCapitalLeaseObligations ;
+        link:order 100.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/7> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:StockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:CommonStockValue ;
+        link:order 100.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/8> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:AssetsCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:ShortTermInvestments ;
+        link:order 150.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/9> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:LiabilitiesCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:AccruedLiabilitiesCurrent ;
+        link:order 150.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> rs:hasAssociation <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/0>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/1>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/10>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/11>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/12>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/13>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/14>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/15>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/16>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/17>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/18>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/19>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/2>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/20>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/21>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/22>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/23>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/24>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/25>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/3>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/4>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/5>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/6>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/7>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/8>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/9> .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> rs:hasAssociation <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/0>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/1>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/2>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/3> .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> rs:hasAssociation <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/0>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/1>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/10>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/11>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/12>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/13>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/14>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/15>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/16>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/17>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/18>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/19>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/2>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/20>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/21>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/22>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/23>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/24>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/25>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/26>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/27>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/28>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/29>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/3>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/30>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/31>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/32>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/33>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/34>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/35>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/36>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/37>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/4>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/5>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/6>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/7>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/8>,
+            <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/9> .
+}
+
+<https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45#scene> {
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/fact/fact_01KVF94CHSGBT3DK41K9KMWF6C> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:AccountsPayableCurrent ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/entity/entity_kg19ede919e4299f2e7266> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF94CHNRJ4E25PMT7ZM6Y70> ;
+        rs:internalId "fact_01KVF94CHSGBT3DK41K9KMWF6C" ;
+        rs:numericValue 0.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/period/p_1> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/fact/fact_01KVF94CHSGBT3DK41K9KMWF6D> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:AccruedLiabilitiesCurrent ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/entity/entity_kg19ede919e4299f2e7266> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF94CHNRJ4E25PMT7ZM6Y70> ;
+        rs:internalId "fact_01KVF94CHSGBT3DK41K9KMWF6D" ;
+        rs:numericValue 800.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/period/p_1> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/fact/fact_01KVF94CHSGBT3DK41K9KMWF6E> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:AdditionalPaidInCapital ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/entity/entity_kg19ede919e4299f2e7266> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF94CHNRJ4E25PMT7ZM6Y70> ;
+        rs:internalId "fact_01KVF94CHSGBT3DK41K9KMWF6E" ;
+        rs:numericValue 49800.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/period/p_1> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/fact/fact_01KVF94CHSGBT3DK41K9KMWF6F> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:CashAndCashEquivalentsAtCarryingValue ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/entity/entity_kg19ede919e4299f2e7266> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF94CHNRJ4E25PMT7ZM6Y70> ;
+        rs:internalId "fact_01KVF94CHSGBT3DK41K9KMWF6F" ;
+        rs:numericValue 63695.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/period/p_1> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/fact/fact_01KVF94CHSGBT3DK41K9KMWF6G> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:DepreciationDepletionAndAmortization ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/entity/entity_kg19ede919e4299f2e7266> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF94CHP3SYVSAPNGWCPM7QM> ;
+        rs:internalId "fact_01KVF94CHSGBT3DK41K9KMWF6G" ;
+        rs:numericValue 1374.97 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/fact/fact_01KVF94CHSGBT3DK41K9KMWF6H> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:DepreciationDepletionAndAmortization ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/entity/entity_kg19ede919e4299f2e7266> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF94CHNRJ4E25PMT7ZM6Y71> ;
+        rs:internalId "fact_01KVF94CHSGBT3DK41K9KMWF6H" ;
+        rs:numericValue 1374.97 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/fact/fact_01KVF94CHSGBT3DK41K9KMWF6J> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:GeneralAndAdministrativeExpense ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/entity/entity_kg19ede919e4299f2e7266> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF94CHNRJ4E25PMT7ZM6Y71> ;
+        rs:internalId "fact_01KVF94CHSGBT3DK41K9KMWF6J" ;
+        rs:numericValue 132005.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/fact/fact_01KVF94CHSGBT3DK41K9KMWF6K> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:PrepaidExpenseCurrent ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/entity/entity_kg19ede919e4299f2e7266> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF94CHNRJ4E25PMT7ZM6Y70> ;
+        rs:internalId "fact_01KVF94CHSGBT3DK41K9KMWF6K" ;
+        rs:numericValue 2100.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/period/p_1> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/fact/fact_01KVF94CHSGBT3DK41K9KMWF6M> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:ReceivablesNetCurrent ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/entity/entity_kg19ede919e4299f2e7266> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF94CHNRJ4E25PMT7ZM6Y70> ;
+        rs:internalId "fact_01KVF94CHSGBT3DK41K9KMWF6M" ;
+        rs:numericValue 0.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/period/p_1> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/fact/fact_01KVF94CHSGBT3DK41K9KMWF6N> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/entity/entity_kg19ede919e4299f2e7266> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF94CHNRJ4E25PMT7ZM6Y71> ;
+        rs:internalId "fact_01KVF94CHSGBT3DK41K9KMWF6N" ;
+        rs:numericValue 153500.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/fact/fact_01KVF94CHSGBT3DK41K9KMWF6P> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:RetainedEarningsAccumulatedDeficit ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/entity/entity_kg19ede919e4299f2e7266> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF94CHNRJ4E25PMT7ZM6Y70> ;
+        rs:internalId "fact_01KVF94CHSGBT3DK41K9KMWF6P" ;
+        rs:numericValue 20120.03 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/period/p_1> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/fact/fact_01KVF94CHSGBT3DK41K9KMWF6Q> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:AdditionalPaidInCapital ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/entity/entity_kg19ede919e4299f2e7266> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF94CHNRJ4E25PMT7ZM6Y70> ;
+        rs:internalId "fact_01KVF94CHSGBT3DK41K9KMWF6Q" ;
+        rs:numericValue 0.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/period/p_3> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/fact/fact_01KVF94CHSGBT3DK41K9KMWF6R> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:RetainedEarningsAccumulatedDeficit ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/entity/entity_kg19ede919e4299f2e7266> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF94CHNRJ4E25PMT7ZM6Y70> ;
+        rs:internalId "fact_01KVF94CHSGBT3DK41K9KMWF6R" ;
+        rs:numericValue 0.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/period/p_3> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/fact/fact_01KVF94CHSGBT3DK41K9KMWF6S> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:NetIncomeLoss ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/entity/entity_kg19ede919e4299f2e7266> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF94CHP3SYVSAPNGWCPM7QM> ;
+        rs:internalId "fact_01KVF94CHSGBT3DK41K9KMWF6S" ;
+        rs:numericValue 20120.03 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/fact/fact_01KVF94CHSGBT3DK41K9KMWF6T> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:NetIncomeLoss ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/entity/entity_kg19ede919e4299f2e7266> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF94CHNRJ4E25PMT7ZM6Y71> ;
+        rs:internalId "fact_01KVF94CHSGBT3DK41K9KMWF6T" ;
+        rs:numericValue 20120.03 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/fact/fact_01KVF94CHSGBT3DK41K9KMWF6V> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:NetIncomeLoss ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/entity/entity_kg19ede919e4299f2e7266> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF94CHP3SYVSAPNGWCPM7QN> ;
+        rs:internalId "fact_01KVF94CHSGBT3DK41K9KMWF6V" ;
+        rs:numericValue 20120.03 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/structure/0b179e5c-5f02-506d-b8d5-860cb10c7694> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/fact/fact_01KVF94CHSGBT3DK41K9KMWF6W> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:PropertyPlantAndEquipmentNet ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/entity/entity_kg19ede919e4299f2e7266> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF94CHNRJ4E25PMT7ZM6Y70> ;
+        rs:internalId "fact_01KVF94CHSGBT3DK41K9KMWF6W" ;
+        rs:numericValue 4925.03 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/period/p_1> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/fact/fact_01KVF94CHSGBT3DK41K9KMWF6X> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:ProceedsFromIssuanceOfCommonStock ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/entity/entity_kg19ede919e4299f2e7266> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF94CHP3SYVSAPNGWCPM7QM> ;
+        rs:internalId "fact_01KVF94CHSGBT3DK41K9KMWF6X" ;
+        rs:numericValue 49800.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/fact/fact_01KVF94CHSGBT3DK41K9KMWF6Y> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:ProceedsFromIssuanceOfCommonStock ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/entity/entity_kg19ede919e4299f2e7266> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF94CHP3SYVSAPNGWCPM7QN> ;
+        rs:internalId "fact_01KVF94CHSGBT3DK41K9KMWF6Y" ;
+        rs:numericValue 49800.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/structure/0b179e5c-5f02-506d-b8d5-860cb10c7694> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/fact/fact_01KVF94CHSGBT3DK41K9KMWF6Z> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/entity/entity_kg19ede919e4299f2e7266> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF94CHP3SYVSAPNGWCPM7QM> ;
+        rs:internalId "fact_01KVF94CHSGBT3DK41K9KMWF6Z" ;
+        rs:numericValue -4800.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/fact/fact_01KVF94CHSGBT3DK41K9KMWF70> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:IncreaseDecreaseInPrepaidExpense ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/entity/entity_kg19ede919e4299f2e7266> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF94CHP3SYVSAPNGWCPM7QM> ;
+        rs:internalId "fact_01KVF94CHSGBT3DK41K9KMWF70" ;
+        rs:numericValue -2100.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/fact/fact_01KVF94CHSGBT3DK41K9KMWF71> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:IncreaseDecreaseInAccruedLiabilities ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/entity/entity_kg19ede919e4299f2e7266> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF94CHP3SYVSAPNGWCPM7QM> ;
+        rs:internalId "fact_01KVF94CHSGBT3DK41K9KMWF71" ;
+        rs:numericValue 800.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/fact/fact_01KVF94CHSGBT3DK41K9KMWF72> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:IncreaseDecreaseInOtherOperatingCapitalNet ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/entity/entity_kg19ede919e4299f2e7266> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF94CHP3SYVSAPNGWCPM7QM> ;
+        rs:internalId "fact_01KVF94CHSGBT3DK41K9KMWF72" ;
+        rs:numericValue -1500.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/fact/fact_01KVF94CHSGBT3DK41K9KMWF73> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:LiabilitiesCurrent ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/entity/entity_kg19ede919e4299f2e7266> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF94CHNRJ4E25PMT7ZM6Y70> ;
+        rs:internalId "fact_01KVF94CHSGBT3DK41K9KMWF73" ;
+        rs:numericValue 800.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/period/p_1> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/fact/fact_01KVF94CHSGBT3DK41K9KMWF74> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:Assets ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/entity/entity_kg19ede919e4299f2e7266> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF94CHNRJ4E25PMT7ZM6Y70> ;
+        rs:internalId "fact_01KVF94CHSGBT3DK41K9KMWF74" ;
+        rs:numericValue 70720.03 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/period/p_1> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/fact/fact_01KVF94CHSGBT3DK41K9KMWF75> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/entity/entity_kg19ede919e4299f2e7266> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF94CHP3SYVSAPNGWCPM7QM> ;
+        rs:internalId "fact_01KVF94CHSGBT3DK41K9KMWF75" ;
+        rs:numericValue 63695.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/fact/fact_01KVF94CHSGBT3DK41K9KMWF76> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:AssetsCurrent ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/entity/entity_kg19ede919e4299f2e7266> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF94CHNRJ4E25PMT7ZM6Y70> ;
+        rs:internalId "fact_01KVF94CHSGBT3DK41K9KMWF76" ;
+        rs:numericValue 65795.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/period/p_1> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/fact/fact_01KVF94CHSGBT3DK41K9KMWF77> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:NetCashProvidedByUsedInOperatingActivities ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/entity/entity_kg19ede919e4299f2e7266> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF94CHP3SYVSAPNGWCPM7QM> ;
+        rs:internalId "fact_01KVF94CHSGBT3DK41K9KMWF77" ;
+        rs:numericValue 18695.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/fact/fact_01KVF94CHSGBT3DK41K9KMWF78> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:Liabilities ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/entity/entity_kg19ede919e4299f2e7266> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF94CHNRJ4E25PMT7ZM6Y70> ;
+        rs:internalId "fact_01KVF94CHSGBT3DK41K9KMWF78" ;
+        rs:numericValue 800.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/period/p_1> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/fact/fact_01KVF94CHSGBT3DK41K9KMWF79> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/entity/entity_kg19ede919e4299f2e7266> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF94CHNRJ4E25PMT7ZM6Y71> ;
+        rs:internalId "fact_01KVF94CHSGBT3DK41K9KMWF79" ;
+        rs:numericValue 20120.03 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/fact/fact_01KVF94CHSGBT3DK41K9KMWF7A> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:LiabilitiesAndStockholdersEquity ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/entity/entity_kg19ede919e4299f2e7266> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF94CHNRJ4E25PMT7ZM6Y70> ;
+        rs:internalId "fact_01KVF94CHSGBT3DK41K9KMWF7A" ;
+        rs:numericValue 70720.03 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/period/p_1> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/fact/fact_01KVF94CHSGBT3DK41K9KMWF7B> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:StockholdersEquity ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/entity/entity_kg19ede919e4299f2e7266> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF94CHP3SYVSAPNGWCPM7QN> ;
+        rs:internalId "fact_01KVF94CHSGBT3DK41K9KMWF7B" ;
+        rs:numericValue 69920.03 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/period/p_1> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/structure/0b179e5c-5f02-506d-b8d5-860cb10c7694> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/fact/fact_01KVF94CHSGBT3DK41K9KMWF7C> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:StockholdersEquity ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/entity/entity_kg19ede919e4299f2e7266> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF94CHNRJ4E25PMT7ZM6Y70> ;
+        rs:internalId "fact_01KVF94CHSGBT3DK41K9KMWF7C" ;
+        rs:numericValue 69920.03 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/period/p_1> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/fact/fact_01KVF94CHSGBT3DK41K9KMWF7D> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:AssetsNoncurrent ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/entity/entity_kg19ede919e4299f2e7266> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF94CHNRJ4E25PMT7ZM6Y70> ;
+        rs:internalId "fact_01KVF94CHSGBT3DK41K9KMWF7D" ;
+        rs:numericValue 4925.03 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/period/p_1> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/fact/fact_01KVF94CHSGBT3DK41K9KMWF7E> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:OperatingExpenses ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/entity/entity_kg19ede919e4299f2e7266> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF94CHNRJ4E25PMT7ZM6Y71> ;
+        rs:internalId "fact_01KVF94CHSGBT3DK41K9KMWF7E" ;
+        rs:numericValue 133379.97 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/fact/fact_01KVF94CHSGBT3DK41K9KMWF7F> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:OperatingIncomeLoss ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/entity/entity_kg19ede919e4299f2e7266> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF94CHNRJ4E25PMT7ZM6Y71> ;
+        rs:internalId "fact_01KVF94CHSGBT3DK41K9KMWF7F" ;
+        rs:numericValue 20120.03 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/fact/fact_01KVF94CHSGBT3DK41K9KMWF7G> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:GrossProfit ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/entity/entity_kg19ede919e4299f2e7266> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF94CHNRJ4E25PMT7ZM6Y71> ;
+        rs:internalId "fact_01KVF94CHSGBT3DK41K9KMWF7G" ;
+        rs:numericValue 153500.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/fact/fact_01KVF94CHSGBT3DK41K9KMWF7H> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:NetCashProvidedByUsedInFinancingActivities ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/entity/entity_kg19ede919e4299f2e7266> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF94CHP3SYVSAPNGWCPM7QM> ;
+        rs:internalId "fact_01KVF94CHSGBT3DK41K9KMWF7H" ;
+        rs:numericValue 49800.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/fact/fact_01KVF94CHSGBT3DK41K9KMWF7J> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:Revenues ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/entity/entity_kg19ede919e4299f2e7266> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF94CHNRJ4E25PMT7ZM6Y71> ;
+        rs:internalId "fact_01KVF94CHSGBT3DK41K9KMWF7J" ;
+        rs:numericValue 153500.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/fact/fact_01KVF94CHSGBT3DK41K9KMWF7K> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:NetCashProvidedByUsedInInvestingActivities ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/entity/entity_kg19ede919e4299f2e7266> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF94CHP3SYVSAPNGWCPM7QM> ;
+        rs:internalId "fact_01KVF94CHSGBT3DK41K9KMWF7K" ;
+        rs:numericValue -4800.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/fact/fact_01KVF94CHSGBT3DK41K9KMWF7M> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:IncomeLossFromContinuingOperations ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/entity/entity_kg19ede919e4299f2e7266> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF94CHNRJ4E25PMT7ZM6Y71> ;
+        rs:internalId "fact_01KVF94CHSGBT3DK41K9KMWF7M" ;
+        rs:numericValue 20120.03 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/ib/0b179e5c-5f02-506d-b8d5-860cb10c7694> a rs:InformationBlock ;
+        skos:prefLabel "rs-gaap — Statement of Changes in Equity — Roll Forward (Total)" ;
+        rs:blockType "equity_statement" ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF94CHP3SYVSAPNGWCPM7QN> ;
+        rs:internalId "0b179e5c-5f02-506d-b8d5-860cb10c7694" ;
+        rs:taxonomyId "cf7178a0-e2d4-58df-995a-2f0233d15466" ;
+        rs:taxonomyName "rs-gaap-presentation v1" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/ib/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> a rs:InformationBlock ;
+        skos:prefLabel "rs-gaap — Income Statement — Multi-step" ;
+        rs:blockType "income_statement" ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF94CHNRJ4E25PMT7ZM6Y71> ;
+        rs:internalId "47cd6544-03d1-5bc1-8c28-31c0cfa450f9" ;
+        rs:taxonomyId "cf7178a0-e2d4-58df-995a-2f0233d15466" ;
+        rs:taxonomyName "rs-gaap-presentation v1" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/ib/5473639a-2dac-56a6-b9e5-38480ea38bc1> a rs:InformationBlock ;
+        skos:prefLabel "rs-gaap — Cash Flow Statement — Indirect" ;
+        rs:blockType "cash_flow_statement" ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF94CHP3SYVSAPNGWCPM7QM> ;
+        rs:internalId "5473639a-2dac-56a6-b9e5-38480ea38bc1" ;
+        rs:taxonomyId "cf7178a0-e2d4-58df-995a-2f0233d15466" ;
+        rs:taxonomyName "rs-gaap-presentation v1" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/ib/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> a rs:InformationBlock ;
+        skos:prefLabel "rs-gaap — Balance Sheet — Classified" ;
+        rs:blockType "balance_sheet" ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF94CHNRJ4E25PMT7ZM6Y70> ;
+        rs:internalId "b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d" ;
+        rs:taxonomyId "cf7178a0-e2d4-58df-995a-2f0233d15466" ;
+        rs:taxonomyName "rs-gaap-presentation v1" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/period/p_3> a rs:Period ;
+        xbrli:instant "2024-12-31"^^xsd:date ;
+        xbrli:periodType "instant" .
+
+    rs-gaap:IncreaseDecreaseInAccruedLiabilities a rs:Element ;
+        skos:prefLabel "Increase (Decrease) in Accrued Liabilities" ;
+        xbrli:balance "debit" ;
+        xbrli:periodType "duration" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "e92e6488-dcc7-5877-ad4b-f2498bdf7bae" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:IncreaseDecreaseInOtherOperatingCapitalNet a rs:Element ;
+        skos:prefLabel "Increase (Decrease) in Other Operating Assets and Liabilities, Net" ;
+        xbrli:balance "credit" ;
+        xbrli:periodType "duration" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "a3227fb2-202b-51db-9574-4e60db03c04f" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:IncreaseDecreaseInPrepaidExpense a rs:Element ;
+        skos:prefLabel "Increase (Decrease) in Prepaid Expense" ;
+        xbrli:balance "credit" ;
+        xbrli:periodType "duration" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "550bb6e5-53d0-5267-adb1-baf78093a0b0" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment a rs:Element ;
+        skos:prefLabel "Payments to Acquire Property, Plant, and Equipment" ;
+        xbrli:balance "credit" ;
+        xbrli:periodType "duration" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "ff101489-15f4-573d-967b-24f75e0fc0f6" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:AccountsPayableCurrent a rs:Element ;
+        skos:prefLabel "Accounts Payable, Current" ;
+        xbrli:balance "credit" ;
+        xbrli:periodType "instant" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "9ddbc9d7-c769-5800-8f65-1089d476e5c9" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:AccruedLiabilitiesCurrent a rs:Element ;
+        skos:prefLabel "Accrued Liabilities, Current" ;
+        xbrli:balance "credit" ;
+        xbrli:periodType "instant" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "4decfae2-2ca3-5dd3-8c06-88557583c13d" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:CashAndCashEquivalentsAtCarryingValue a rs:Element ;
+        skos:prefLabel "Cash and Cash Equivalents, at Carrying Value" ;
+        xbrli:balance "debit" ;
+        xbrli:periodType "instant" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "20a6586b-880a-5745-94db-e23d397eb5e1" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:GeneralAndAdministrativeExpense a rs:Element ;
+        skos:prefLabel "General and Administrative Expense" ;
+        xbrli:balance "debit" ;
+        xbrli:periodType "duration" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "f92ba8cb-7ae2-5d40-9d15-9a94e9e3aed4" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:PrepaidExpenseCurrent a rs:Element ;
+        skos:prefLabel "Prepaid Expense, Current" ;
+        xbrli:balance "debit" ;
+        xbrli:periodType "instant" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "2225e348-90bd-53cb-9784-8b5d54980a69" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:PropertyPlantAndEquipmentNet a rs:Element ;
+        skos:prefLabel "Property, Plant and Equipment, Net" ;
+        xbrli:balance "debit" ;
+        xbrli:periodType "instant" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "288099af-5cbb-5f78-8f8a-1a85675fb661" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:ReceivablesNetCurrent a rs:Element ;
+        skos:prefLabel "Receivables, Net, Current" ;
+        xbrli:balance "debit" ;
+        xbrli:periodType "instant" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "44686df3-3871-5c1f-8a08-fc542d69dfa0" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax a rs:Element ;
+        skos:prefLabel "Revenue from Contract with Customer, Excluding Assessed Tax" ;
+        xbrli:balance "credit" ;
+        xbrli:periodType "duration" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "37252918-4301-50e2-8d7e-cf2c76986d15" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:AdditionalPaidInCapital a rs:Element ;
+        skos:prefLabel "Additional Paid in Capital" ;
+        xbrli:balance "credit" ;
+        xbrli:periodType "instant" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "6146605c-0d63-51e1-a523-3450d6abaca3" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:ProceedsFromIssuanceOfCommonStock a rs:Element ;
+        skos:prefLabel "Proceeds from Issuance of Common Stock" ;
+        xbrli:balance "debit" ;
+        xbrli:periodType "duration" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "2eb72b5f-d7e3-5bd5-bf93-be38b6d21820" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:RetainedEarningsAccumulatedDeficit a rs:Element ;
+        skos:prefLabel "Retained Earnings (Accumulated Deficit)" ;
+        xbrli:balance "credit" ;
+        xbrli:periodType "instant" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "a9c87d60-a1e5-506b-a27e-cbf9e14e5113" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:Assets a rs:Element ;
+        skos:prefLabel "Assets" ;
+        xbrli:balance "debit" ;
+        xbrli:periodType "instant" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "a1f04756-41d8-5d35-b821-23aa2f3b2fae" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:DepreciationDepletionAndAmortization a rs:Element ;
+        skos:prefLabel "Depreciation, Depletion and Amortization" ;
+        xbrli:balance "debit" ;
+        xbrli:periodType "duration" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "189a099a-7512-5144-9215-65d837c2c3b5" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:GrossProfit a rs:Element ;
+        skos:prefLabel "Gross Profit" ;
+        xbrli:balance "credit" ;
+        xbrli:periodType "duration" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "a92b3181-9fe7-543c-81d9-13ebd12bbefa" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:IncomeLossFromContinuingOperations a rs:Element ;
+        skos:prefLabel "Income (Loss) from Continuing Operations, Net of Tax, Attributable to Parent" ;
+        xbrli:balance "credit" ;
+        xbrli:periodType "duration" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "d60cabda-7060-5aff-ac98-96371606a738" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest a rs:Element ;
+        skos:prefLabel "Income (Loss) from Continuing Operations before Income Taxes, Noncontrolling Interest" ;
+        xbrli:balance "credit" ;
+        xbrli:periodType "duration" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "6b0b414f-0c76-54f0-8e51-cf53db59ca24" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:LiabilitiesAndStockholdersEquity a rs:Element ;
+        skos:prefLabel "Liabilities and Equity" ;
+        xbrli:balance "credit" ;
+        xbrli:periodType "instant" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "30b2801e-e682-5298-82e6-3670e1d508f1" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:OperatingIncomeLoss a rs:Element ;
+        skos:prefLabel "Operating Income (Loss)" ;
+        xbrli:balance "credit" ;
+        xbrli:periodType "duration" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "16780828-0201-5609-b572-fbe3ebfcb177" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:Revenues a rs:Element ;
+        skos:prefLabel "Revenues" ;
+        xbrli:balance "credit" ;
+        xbrli:periodType "duration" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "b26a6cd4-072f-5bf2-b5d3-ebf928150d6c" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:Liabilities a rs:Element ;
+        skos:prefLabel "Liabilities" ;
+        xbrli:balance "credit" ;
+        xbrli:periodType "instant" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "7af273ac-1cba-5fb3-a1c9-5c5d8fdb9bdf" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:NetCashProvidedByUsedInFinancingActivities a rs:Element ;
+        skos:prefLabel "Cash Provided by (Used in) Financing Activity, Including Discontinued Operation" ;
+        xbrli:balance "debit" ;
+        xbrli:periodType "duration" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "811f1cf5-836c-575f-9f3f-cd7fa477e4e5" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:NetIncomeLoss a rs:Element ;
+        skos:prefLabel "Net Income (Loss) Attributable to Parent" ;
+        xbrli:balance "credit" ;
+        xbrli:periodType "duration" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "27a05717-2370-51c2-a924-db5cbcb48219" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease a rs:Element ;
+        skos:prefLabel "Cash and Cash Equivalents, Period Increase (Decrease)" ;
+        xbrli:balance "debit" ;
+        xbrli:periodType "duration" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "353f790f-1ed1-5b91-880d-8029b4b687cf" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:NetCashProvidedByUsedInInvestingActivities a rs:Element ;
+        skos:prefLabel "Cash Provided by (Used in) Investing Activity, Including Discontinued Operation" ;
+        xbrli:balance "debit" ;
+        xbrli:periodType "duration" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "69b82be1-1145-5686-8613-31da9eb04a72" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:NetCashProvidedByUsedInOperatingActivities a rs:Element ;
+        skos:prefLabel "Cash Provided by (Used in) Operating Activity, Including Discontinued Operation" ;
+        xbrli:balance "debit" ;
+        xbrli:periodType "duration" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "57ccbf45-c970-5bcd-a381-44d96b6b6d94" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/period/p_1> a rs:Period ;
+        xbrli:instant "2025-12-31"^^xsd:date ;
+        xbrli:periodType "instant" .
+
+    rs-gaap:AssetsCurrent a rs:Element ;
+        skos:prefLabel "Assets, Current" ;
+        xbrli:balance "debit" ;
+        xbrli:periodType "instant" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "0fc9ab7e-c5ce-5277-9530-344cc127fe26" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:AssetsNoncurrent a rs:Element ;
+        skos:prefLabel "Assets, Noncurrent" ;
+        xbrli:balance "debit" ;
+        xbrli:periodType "instant" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "841cedeb-4cb0-532a-b0bd-c34846a13a8c" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:LiabilitiesCurrent a rs:Element ;
+        skos:prefLabel "Liabilities, Current" ;
+        xbrli:balance "credit" ;
+        xbrli:periodType "instant" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "efb036ff-3f30-5deb-bee9-1af4cd4b9800" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:OperatingExpenses a rs:Element ;
+        skos:prefLabel "Operating Expenses" ;
+        xbrli:balance "debit" ;
+        xbrli:periodType "duration" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "71fcdebb-7145-5f76-b5e0-b4ccbf2c29d2" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:StockholdersEquity a rs:Element ;
+        skos:prefLabel "Stockholders' Equity Attributable to Parent" ;
+        xbrli:balance "credit" ;
+        xbrli:periodType "instant" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "e3796201-9899-5b7b-9477-659550ba8e68" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/period/p_2> a rs:Period ;
+        xbrli:endDate "2025-12-31"^^xsd:date ;
+        xbrli:periodType "duration" ;
+        xbrli:startDate "2025-01-01"^^xsd:date .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/entity/entity_kg19ede919e4299f2e7266> a rs:Entity ;
+        skos:prefLabel "Cascade Advisory Group LLC" ;
+        rs:country "US" ;
+        rs:internalId "entity_kg19ede919e4299f2e7266" ;
+        rs:legalName "Cascade Advisory Group LLC" .
+
+    <https://robosystems.ai/report/rpt_01KVF94CFWZ98EPA84K7V2EY45/unit/u_USD> a rs:Unit ;
+        xbrli:measure iso4217:USD .
+}
+

--- a/examples/seattle_method_demo/sample_output/seattle-method-case-1.databook.md
+++ b/examples/seattle_method_demo/sample_output/seattle-method-case-1.databook.md
@@ -40,6 +40,29 @@ manifest:
     equity_statement:
       type: turtle
       description: "rs-gaap — Statement of Changes in Equity — Roll Forward (Total)"
+graph:
+  facts: 48
+  href: seattle-method-case-1.holon.trig
+  graphs:
+    - id: scene
+      iri: https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC#scene
+      description: "Instance facts — the values this report reports"
+      disposition: inline
+    - id: boundary
+      iri: https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC#boundary
+      description: "Calculation network — the rollup rules the facts must obey"
+      disposition: reference
+      derived_from: rs-gaap-calculations@v1
+    - id: projection
+      iri: https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC#projection
+      description: "Presentation network — order, indentation, subtotals"
+      disposition: reference
+      derived_from: rs-gaap-presentation@v1
+      reporting_style: 025f5d48-12ce-5d65-b9eb-4f137a10ef06
+    - id: lineage
+      description: "Event lineage — fact → event → entry → line item → CoA"
+      disposition: internal
+      note: "the books, not published — a report is an aggregation of the ledger, which is internal; substantiation available to authorized parties"
 report:
   reporting_style: 025f5d48-12ce-5d65-b9eb-4f137a10ef06
   report_id: rpt_01KVF99WPYN17GS13R5DJY87HC
@@ -66,7 +89,7 @@ report:
 
 # Seattle Method (Test Case 1) — Lemonade Stand (Charlie Hoffman Test Case 1)
 
-A report **is** a collection of Information Blocks. Each block below is shown twice: a markdown table (human view) and an addressable `turtle` block (machine view — the same facts as RDF), keyed by the id declared in the frontmatter `manifest`. Everything is derived from `seattle-method-case-1.jsonld`; the bundle and this DataBook are two skins of one graph.
+A report **is** a collection of Information Blocks, and this DataBook is a projection of one report holon (see the `graph:` map above). The **scene** graph — the facts — renders twice per block here: a markdown table (human view) and a foldable, addressable `turtle` slice (machine view, the same facts as RDF). The **boundary** (calculation) and **projection** (presentation) graphs live as real named graphs in the companion `seattle-method-case-1.holon.trig` and derive from their versioned framework — referenced here rather than inlined, since they're shared by every report on that framework. The **lineage** graph — the ledger behind the facts — is internal and not published: a report is an aggregation of the books, not the books. The `Validation evidence` section is the published substantiation that the referenced rules hold. Everything here derives from `seattle-method-case-1.jsonld`.
 
 
 ## Balance Sheet
@@ -94,6 +117,9 @@ A report **is** a collection of Information Blocks. Each block below is shown tw
 | `rs-gaap:RetainedEarningsAccumulatedDeficit` |     Retained Earnings (Accumulated Deficit) | $2,050.00 |
 | `rs-gaap:StockholdersEquity` |   **Stockholders' Equity Attributable to Parent** | $12,050.00 |
 | `rs-gaap:LiabilitiesAndStockholdersEquity` | **Liabilities and Equity** | $14,450.00 |
+
+<details>
+<summary>▸ Balance Sheet — scene RDF / Turtle (380 triples · 21.9 KB)</summary>
 
 ```turtle {#balance_sheet}
 @prefix iso4217: <http://www.xbrl.org/2003/iso4217#> .
@@ -525,6 +551,8 @@ rs-gaap:RetainedEarningsAccumulatedDeficit a rs:Element ;
     xbrli:measure iso4217:USD .
 ```
 
+</details>
+
 
 ## Income Statement
 
@@ -547,6 +575,9 @@ rs-gaap:RetainedEarningsAccumulatedDeficit a rs:Element ;
 | `rs-gaap:IncomeTaxExpenseBenefit` |   Income Tax Expense (Benefit) | $400.00 |
 | `rs-gaap:IncomeLossFromContinuingOperations` |   **Income (Loss) from Continuing Operations, Net of Tax, Attributable to Parent** | $2,050.00 |
 | `rs-gaap:NetIncomeLoss` |   **Net Income (Loss) Attributable to Parent** | $2,050.00 |
+
+<details>
+<summary>▸ Income Statement — scene RDF / Turtle (278 triples · 16.0 KB)</summary>
 
 ```turtle {#income_statement}
 @prefix iso4217: <http://www.xbrl.org/2003/iso4217#> .
@@ -865,6 +896,8 @@ rs-gaap:Revenues a rs:Element ;
     xbrli:measure iso4217:USD .
 ```
 
+</details>
+
 
 ## Cash Flow Statement
 
@@ -887,6 +920,9 @@ rs-gaap:Revenues a rs:Element ;
 | `rs-gaap:RepaymentsOfLongTermDebt` |     Repayments of Long-Term Debt | $(1,000.00) |
 | `rs-gaap:NetCashProvidedByUsedInFinancingActivities` |   Cash Provided by (Used in) Financing Activity, Including Discontinued Operation | $11,000.00 |
 | `rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease` | **Cash and Cash Equivalents, Period Increase (Decrease)** | $10,850.00 |
+
+<details>
+<summary>▸ Cash Flow Statement — scene RDF / Turtle (278 triples · 16.5 KB)</summary>
 
 ```turtle {#cash_flow_statement}
 @prefix iso4217: <http://www.xbrl.org/2003/iso4217#> .
@@ -1205,6 +1241,8 @@ rs-gaap:RepaymentsOfLongTermDebt a rs:Element ;
     xbrli:measure iso4217:USD .
 ```
 
+</details>
+
 
 ## Statement of Changes in Equity
 
@@ -1217,6 +1255,9 @@ rs-gaap:RepaymentsOfLongTermDebt a rs:Element ;
 | `rs-gaap:NetIncomeLoss` |   **Net Income (Loss) Attributable to Parent** | $2,050.00 |
 | `rs-gaap:ProceedsFromIssuanceOfCommonStock` |   Proceeds from Issuance of Common Stock | $10,000.00 |
 | `rs-gaap:StockholdersEquity` | **Stockholders' Equity Attributable to Parent** | $12,050.00 |
+
+<details>
+<summary>▸ Statement of Changes in Equity — scene RDF / Turtle (81 triples · 5.0 KB)</summary>
 
 ```turtle {#equity_statement}
 @prefix iso4217: <http://www.xbrl.org/2003/iso4217#> .
@@ -1318,6 +1359,8 @@ rs-gaap:StockholdersEquity a rs:Element ;
 <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/unit/u_USD> a rs:Unit ;
     xbrli:measure iso4217:USD .
 ```
+
+</details>
 
 
 ## Validation evidence

--- a/examples/seattle_method_demo/sample_output/seattle-method-case-1.holon.trig
+++ b/examples/seattle_method_demo/sample_output/seattle-method-case-1.holon.trig
@@ -1,0 +1,2601 @@
+@prefix iso4217: <http://www.xbrl.org/2003/iso4217#> .
+@prefix link: <http://www.xbrl.org/2003/linkbase#> .
+@prefix rs: <https://robosystems.ai/vocab/> .
+@prefix rs-gaap: <https://robosystems.ai/taxonomy/rs-gaap/v1/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xbrli: <http://www.xbrl.org/2003/instance#> .
+@prefix xlink: <http://www.w3.org/1999/xlink#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC#boundary> {
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> rs:hasAssociation <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/0>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/1>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/10>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/11>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/12>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/13>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/14>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/15>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/16>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/17>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/18>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/19>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/2>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/20>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/21>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/22>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/23>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/24>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/25>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/3>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/4>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/5>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/6>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/7>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/8>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/9> .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> rs:hasAssociation <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/0>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/1>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/2>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/3> .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> rs:hasAssociation <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/0>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/1>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/10>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/11>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/12>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/13>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/14>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/15>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/16>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/17>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/18>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/19>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/2>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/20>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/21>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/22>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/23>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/24>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/25>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/26>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/27>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/28>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/29>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/3>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/30>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/31>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/32>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/33>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/34>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/35>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/36>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/37>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/4>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/5>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/6>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/7>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/8>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/9> .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/0> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:CostOfRevenue ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:CostOfGoodsAndServicesSold ;
+        link:order 100.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/1> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:GrossProfit ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:Revenues ;
+        link:order 100.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/10> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:CostOfRevenue ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:OtherCostOfOperatingRevenue ;
+        link:order 200.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/11> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:GrossProfit ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:CostOfRevenue ;
+        link:order 200.0 ;
+        link:weight -1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/12> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:IncomeLossFromContinuingOperations ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:IncomeTaxExpenseBenefit ;
+        link:order 200.0 ;
+        link:weight -1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/13> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:NonoperatingIncomeExpense ;
+        link:order 200.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/14> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:NetIncomeLoss ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:IncomeLossFromDiscontinuedOperationsNetOfTax ;
+        link:order 200.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/15> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:NonoperatingIncomeExpense ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:InterestExpense ;
+        link:order 200.0 ;
+        link:weight -1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/16> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:OperatingExpenses ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:ResearchAndDevelopmentExpense ;
+        link:order 200.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/17> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:OperatingIncomeLoss ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:OperatingExpenses ;
+        link:order 200.0 ;
+        link:weight -1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/18> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:NonoperatingIncomeExpense ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:GainLossOnDispositionOfAssets ;
+        link:order 300.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/19> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:OperatingExpenses ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:DepreciationDepletionAndAmortization ;
+        link:order 300.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/2> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:IncomeLossFromContinuingOperations ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest ;
+        link:order 100.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/20> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:NonoperatingIncomeExpense ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:OtherNonoperatingIncomeExpense ;
+        link:order 400.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/21> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:OperatingExpenses ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:OtherCostAndExpenseOperating ;
+        link:order 400.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/22> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:NonoperatingIncomeExpense ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:ForeignCurrencyTransactionGainLossBeforeTax ;
+        link:order 403.3333 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/23> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:OperatingExpenses ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:RestructuringCharges ;
+        link:order 403.3333 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/24> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:NonoperatingIncomeExpense ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:GainsLossesOnExtinguishmentOfDebt ;
+        link:order 406.6667 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/25> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:OperatingExpenses ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:AssetImpairmentCharges ;
+        link:order 406.6667 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/3> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:OperatingIncomeLoss ;
+        link:order 100.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/4> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:NetIncomeLoss ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:IncomeLossFromContinuingOperations ;
+        link:order 100.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/5> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:NonoperatingIncomeExpense ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:InvestmentIncomeInterest ;
+        link:order 100.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/6> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:OperatingExpenses ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:GeneralAndAdministrativeExpense ;
+        link:order 100.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/7> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:OperatingIncomeLoss ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:GrossProfit ;
+        link:order 100.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/8> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:Revenues ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax ;
+        link:order 100.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/9> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:OperatingExpenses ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:SellingAndMarketingExpense ;
+        link:order 150.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/0> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:NetCashProvidedByUsedInOperatingActivities ;
+        link:order 100.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/1> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:NetCashProvidedByUsedInInvestingActivities ;
+        link:order 200.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/2> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:NetCashProvidedByUsedInFinancingActivities ;
+        link:order 300.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/3> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:EffectOfExchangeRateOnCash ;
+        link:order 400.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/0> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:Assets ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:AssetsCurrent ;
+        link:order 100.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/1> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:AssetsCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:CashAndCashEquivalentsAtCarryingValue ;
+        link:order 100.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/10> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:Assets ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:AssetsNoncurrent ;
+        link:order 200.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/11> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:AssetsCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:ReceivablesNetCurrent ;
+        link:order 200.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/12> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:AssetsNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:Goodwill ;
+        link:order 200.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/13> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:Liabilities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:LiabilitiesNoncurrent ;
+        link:order 200.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/14> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:LiabilitiesAndStockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:StockholdersEquity ;
+        link:order 200.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/15> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:LiabilitiesCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:DebtCurrent ;
+        link:order 200.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/16> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:LiabilitiesNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:DeferredIncomeTaxLiabilitiesNet ;
+        link:order 200.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/17> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:StockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:PreferredStockValue ;
+        link:order 200.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/18> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:AssetsNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:IntangibleAssetsNetExcludingGoodwill ;
+        link:order 250.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/19> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:LiabilitiesCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:LongTermDebtCurrent ;
+        link:order 250.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/2> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:AssetsNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:PropertyPlantAndEquipmentNet ;
+        link:order 100.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/20> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:AssetsCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings ;
+        link:order 300.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/21> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:AssetsNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:LongTermInvestmentsAndReceivablesNet ;
+        link:order 300.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/22> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:LiabilitiesCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:DeferredRevenueCurrent ;
+        link:order 300.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/23> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:LiabilitiesNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:DeferredRevenueNoncurrent ;
+        link:order 300.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/24> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:StockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:AdditionalPaidInCapital ;
+        link:order 300.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/25> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:AssetsCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:PrepaidExpenseCurrent ;
+        link:order 400.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/26> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:AssetsNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:OperatingLeaseRightOfUseAsset ;
+        link:order 400.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/27> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:LiabilitiesCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:FinanceLeaseLiabilityCurrent ;
+        link:order 400.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/28> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:LiabilitiesNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:OperatingLeaseLiabilityNoncurrent ;
+        link:order 400.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/29> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:StockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:RetainedEarningsAccumulatedDeficit ;
+        link:order 400.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/3> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:Liabilities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:LiabilitiesCurrent ;
+        link:order 100.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/30> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:AssetsCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:RestrictedCashAndInvestmentsCurrent ;
+        link:order 500.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/31> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:AssetsNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:FinanceLeaseRightOfUseAsset ;
+        link:order 500.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/32> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:LiabilitiesCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:OtherLiabilitiesCurrent ;
+        link:order 500.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/33> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:LiabilitiesNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:OtherLiabilitiesNoncurrent ;
+        link:order 500.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/34> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:StockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:AccumulatedOtherComprehensiveIncomeLossNetOfTax ;
+        link:order 500.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/35> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:AssetsCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:OtherAssetsCurrent ;
+        link:order 600.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/36> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:AssetsNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:OtherAssetsNoncurrent ;
+        link:order 600.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/37> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:StockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:TreasuryStockValue ;
+        link:order 600.0 ;
+        link:weight -1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/4> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:LiabilitiesAndStockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:Liabilities ;
+        link:order 100.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/5> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:LiabilitiesCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:AccountsPayableCurrent ;
+        link:order 100.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/6> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:LiabilitiesNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:LongTermDebtAndCapitalLeaseObligations ;
+        link:order 100.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/7> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:StockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:CommonStockValue ;
+        link:order 100.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/8> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:AssetsCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:ShortTermInvestments ;
+        link:order 150.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/9> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:LiabilitiesCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:AccruedLiabilitiesCurrent ;
+        link:order 150.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+}
+
+<https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC#projection> {
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/structure/0b179e5c-5f02-506d-b8d5-860cb10c7694> a rs:Structure ;
+        rs:blockType "equity_statement" ;
+        rs:hasAssociation <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/0>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/1>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/2>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/3>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/4>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/5> ;
+        rs:internalId "0b179e5c-5f02-506d-b8d5-860cb10c7694" ;
+        rs:roleUri "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward" ;
+        rs:structureName "rs-gaap — Statement of Changes in Equity — Roll Forward (Total)" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/0> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:StockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward> ;
+        xlink:to rs-gaap:NetIncomeLoss ;
+        link:order 40100.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/1> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:StockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward> ;
+        xlink:to rs-gaap:OtherComprehensiveIncomeLossNetOfTax ;
+        link:order 40200.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/2> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:StockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward> ;
+        xlink:to rs-gaap:ProceedsFromIssuanceOfCommonStock ;
+        link:order 40300.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/3> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:StockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward> ;
+        xlink:to rs-gaap:PaymentsForRepurchaseOfCommonStock ;
+        link:order 40400.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/4> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:StockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward> ;
+        xlink:to rs-gaap:ShareBasedCompensation ;
+        link:order 40500.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/5> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:StockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward> ;
+        xlink:to rs-gaap:PaymentsOfDividends ;
+        link:order 40600.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/0> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:IncomeStatementAbstract ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:Revenues ;
+        link:order 10100.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/1> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:Revenues ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax ;
+        link:order 10120.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/10> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:OperatingExpenses ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:DepreciationDepletionAndAmortization ;
+        link:order 10430.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/11> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:OperatingExpenses ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:OtherCostAndExpenseOperating ;
+        link:order 10440.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/12> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:OperatingExpenses ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:RestructuringCharges ;
+        link:order 10443.3333 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/13> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:OperatingExpenses ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:AssetImpairmentCharges ;
+        link:order 10446.6667 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/14> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:IncomeStatementAbstract ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:OperatingIncomeLoss ;
+        link:order 10500.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/15> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:IncomeStatementAbstract ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:NonoperatingIncomeExpense ;
+        link:order 10600.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/16> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NonoperatingIncomeExpense ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:InvestmentIncomeInterest ;
+        link:order 10610.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/17> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NonoperatingIncomeExpense ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:InterestExpense ;
+        link:order 10620.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/18> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NonoperatingIncomeExpense ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:GainLossOnDispositionOfAssets ;
+        link:order 10630.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/19> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NonoperatingIncomeExpense ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:OtherNonoperatingIncomeExpense ;
+        link:order 10640.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/2> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:IncomeStatementAbstract ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:CostOfRevenue ;
+        link:order 10200.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/20> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NonoperatingIncomeExpense ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:ForeignCurrencyTransactionGainLossBeforeTax ;
+        link:order 10643.3333 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/21> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NonoperatingIncomeExpense ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:GainsLossesOnExtinguishmentOfDebt ;
+        link:order 10646.6667 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/22> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:IncomeStatementAbstract ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest ;
+        link:order 10800.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/23> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:IncomeStatementAbstract ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:IncomeTaxExpenseBenefit ;
+        link:order 10900.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/24> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:IncomeStatementAbstract ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:IncomeLossFromContinuingOperations ;
+        link:order 11000.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/25> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:IncomeStatementAbstract ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:IncomeLossFromDiscontinuedOperationsNetOfTax ;
+        link:order 11100.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/26> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:IncomeStatementAbstract ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:NetIncomeLoss ;
+        link:order 11200.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/3> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:CostOfRevenue ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:CostOfGoodsAndServicesSold ;
+        link:order 10210.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/4> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:CostOfRevenue ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:OtherCostOfOperatingRevenue ;
+        link:order 10230.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/5> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:IncomeStatementAbstract ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:GrossProfit ;
+        link:order 10300.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/6> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:IncomeStatementAbstract ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:OperatingExpenses ;
+        link:order 10400.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/7> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:OperatingExpenses ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:GeneralAndAdministrativeExpense ;
+        link:order 10410.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/8> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:OperatingExpenses ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:SellingAndMarketingExpense ;
+        link:order 10415.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/9> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:OperatingExpenses ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:ResearchAndDevelopmentExpense ;
+        link:order 10420.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/0> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:NetCashProvidedByUsedInOperatingActivities ;
+        link:order 30100.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/1> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NetCashProvidedByUsedInOperatingActivities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:NetIncomeLoss ;
+        link:order 30110.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/10> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:NetCashProvidedByUsedInInvestingActivities ;
+        link:order 30200.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/11> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NetCashProvidedByUsedInInvestingActivities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment ;
+        link:order 30210.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/12> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NetCashProvidedByUsedInInvestingActivities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:ProceedsFromSaleOfPropertyPlantAndEquipment ;
+        link:order 30220.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/13> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NetCashProvidedByUsedInInvestingActivities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:PaymentsToAcquireInvestments ;
+        link:order 30230.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/14> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NetCashProvidedByUsedInInvestingActivities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:ProceedsFromSaleMaturityAndCollectionsOfInvestments ;
+        link:order 30240.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/15> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NetCashProvidedByUsedInInvestingActivities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:PaymentsToAcquireIntangibleAssets ;
+        link:order 30250.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/16> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NetCashProvidedByUsedInInvestingActivities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:ProceedsFromSaleOfIntangibleAssets ;
+        link:order 30260.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/17> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:NetCashProvidedByUsedInFinancingActivities ;
+        link:order 30300.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/18> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NetCashProvidedByUsedInFinancingActivities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:ProceedsFromIssuanceOfCommonStock ;
+        link:order 30310.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/19> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NetCashProvidedByUsedInFinancingActivities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:ProceedsFromIssuanceOfLongTermDebt ;
+        link:order 30320.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/2> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NetCashProvidedByUsedInOperatingActivities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:DepreciationDepletionAndAmortization ;
+        link:order 30120.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/20> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NetCashProvidedByUsedInFinancingActivities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:RepaymentsOfLongTermDebt ;
+        link:order 30330.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/21> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NetCashProvidedByUsedInFinancingActivities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:PaymentsForRepurchaseOfCommonStock ;
+        link:order 30340.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/22> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:EffectOfExchangeRateOnCash ;
+        link:order 30400.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/3> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NetCashProvidedByUsedInOperatingActivities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:IncreaseDecreaseInAccountsReceivable ;
+        link:order 30130.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/4> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NetCashProvidedByUsedInOperatingActivities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:IncreaseDecreaseInInventories ;
+        link:order 30140.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/5> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NetCashProvidedByUsedInOperatingActivities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:IncreaseDecreaseInPrepaidExpense ;
+        link:order 30150.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/6> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NetCashProvidedByUsedInOperatingActivities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:IncreaseDecreaseInAccountsPayableAndAccruedLiabilities ;
+        link:order 30160.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/7> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NetCashProvidedByUsedInOperatingActivities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:IncreaseDecreaseInOtherOperatingCapitalNet ;
+        link:order 30170.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/8> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NetCashProvidedByUsedInOperatingActivities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:IncreaseDecreaseInAccruedLiabilities ;
+        link:order 30180.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/9> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NetCashProvidedByUsedInOperatingActivities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:IncreaseDecreaseInAccruedIncomeTaxesPayable ;
+        link:order 30190.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/0> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:Assets ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:AssetsCurrent ;
+        link:order 20100.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/1> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:AssetsCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:CashAndCashEquivalentsAtCarryingValue ;
+        link:order 20110.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/10> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:AssetsNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:Goodwill ;
+        link:order 20220.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/11> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:AssetsNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:IntangibleAssetsNetExcludingGoodwill ;
+        link:order 20225.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/12> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:AssetsNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:LongTermInvestmentsAndReceivablesNet ;
+        link:order 20230.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/13> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:AssetsNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:OperatingLeaseRightOfUseAsset ;
+        link:order 20240.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/14> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:AssetsNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:FinanceLeaseRightOfUseAsset ;
+        link:order 20250.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/15> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:AssetsNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:OtherAssetsNoncurrent ;
+        link:order 20260.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/16> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:LiabilitiesAndStockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:Liabilities ;
+        link:order 20300.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/17> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:Liabilities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:LiabilitiesCurrent ;
+        link:order 20310.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/18> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:LiabilitiesCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:AccountsPayableCurrent ;
+        link:order 20311.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/19> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:LiabilitiesCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:AccruedLiabilitiesCurrent ;
+        link:order 20311.5 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/2> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:AssetsCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:ShortTermInvestments ;
+        link:order 20115.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/20> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:LiabilitiesCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:DebtCurrent ;
+        link:order 20312.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/21> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:LiabilitiesCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:LongTermDebtCurrent ;
+        link:order 20312.5 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/22> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:LiabilitiesCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:DeferredRevenueCurrent ;
+        link:order 20313.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/23> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:LiabilitiesCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:FinanceLeaseLiabilityCurrent ;
+        link:order 20314.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/24> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:LiabilitiesCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:OtherLiabilitiesCurrent ;
+        link:order 20315.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/25> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:Liabilities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:LiabilitiesNoncurrent ;
+        link:order 20320.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/26> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:LiabilitiesNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:LongTermDebtAndCapitalLeaseObligations ;
+        link:order 20321.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/27> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:LiabilitiesNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:DeferredIncomeTaxLiabilitiesNet ;
+        link:order 20322.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/28> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:LiabilitiesNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:DeferredRevenueNoncurrent ;
+        link:order 20323.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/29> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:LiabilitiesNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:OperatingLeaseLiabilityNoncurrent ;
+        link:order 20324.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/3> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:AssetsCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:ReceivablesNetCurrent ;
+        link:order 20120.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/30> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:LiabilitiesNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:OtherLiabilitiesNoncurrent ;
+        link:order 20325.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/31> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:LiabilitiesAndStockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:StockholdersEquity ;
+        link:order 20400.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/32> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:StockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:CommonStockValue ;
+        link:order 20410.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/33> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:StockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:PreferredStockValue ;
+        link:order 20420.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/34> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:StockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:AdditionalPaidInCapital ;
+        link:order 20430.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/35> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:StockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:RetainedEarningsAccumulatedDeficit ;
+        link:order 20440.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/36> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:StockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:AccumulatedOtherComprehensiveIncomeLossNetOfTax ;
+        link:order 20450.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/37> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:StockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:TreasuryStockValue ;
+        link:order 20460.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/4> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:AssetsCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings ;
+        link:order 20130.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/5> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:AssetsCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:PrepaidExpenseCurrent ;
+        link:order 20140.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/6> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:AssetsCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:RestrictedCashAndInvestmentsCurrent ;
+        link:order 20150.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/7> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:AssetsCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:OtherAssetsCurrent ;
+        link:order 20160.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/8> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:Assets ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:AssetsNoncurrent ;
+        link:order 20200.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/9> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:AssetsNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:PropertyPlantAndEquipmentNet ;
+        link:order 20210.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> a rs:Structure ;
+        rs:blockType "income_statement" ;
+        rs:hasAssociation <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/0>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/1>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/10>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/11>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/12>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/13>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/14>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/15>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/16>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/17>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/18>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/19>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/2>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/20>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/21>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/22>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/23>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/24>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/25>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/26>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/3>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/4>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/5>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/6>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/7>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/8>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/9> ;
+        rs:internalId "47cd6544-03d1-5bc1-8c28-31c0cfa450f9" ;
+        rs:roleUri "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep" ;
+        rs:structureName "rs-gaap — Income Statement — Multi-step" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> a rs:Structure ;
+        rs:blockType "cash_flow_statement" ;
+        rs:hasAssociation <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/0>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/1>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/10>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/11>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/12>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/13>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/14>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/15>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/16>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/17>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/18>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/19>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/2>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/20>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/21>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/22>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/3>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/4>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/5>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/6>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/7>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/8>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/9> ;
+        rs:internalId "5473639a-2dac-56a6-b9e5-38480ea38bc1" ;
+        rs:roleUri "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect" ;
+        rs:structureName "rs-gaap — Cash Flow Statement — Indirect" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> a rs:Structure ;
+        rs:blockType "balance_sheet" ;
+        rs:hasAssociation <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/0>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/1>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/10>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/11>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/12>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/13>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/14>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/15>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/16>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/17>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/18>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/19>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/2>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/20>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/21>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/22>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/23>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/24>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/25>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/26>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/27>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/28>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/29>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/3>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/30>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/31>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/32>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/33>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/34>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/35>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/36>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/37>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/4>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/5>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/6>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/7>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/8>,
+            <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/9> ;
+        rs:internalId "b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d" ;
+        rs:roleUri "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified" ;
+        rs:structureName "rs-gaap — Balance Sheet — Classified" .
+}
+
+<https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC#scene> {
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/fact/fact_01KVF99WQY5TRD74A1N9N56G1V> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:AccountsPayableCurrent ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/entity/entity_kg19ede94dda6b99013d06> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF99WQS6G93C6DZDCV964BB> ;
+        rs:internalId "fact_01KVF99WQY5TRD74A1N9N56G1V" ;
+        rs:numericValue 1000.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/period/p_1> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/fact/fact_01KVF99WQY5TRD74A1N9N56G1W> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:AccruedLiabilitiesCurrent ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/entity/entity_kg19ede94dda6b99013d06> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF99WQS6G93C6DZDCV964BB> ;
+        rs:internalId "fact_01KVF99WQY5TRD74A1N9N56G1W" ;
+        rs:numericValue 400.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/period/p_1> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/fact/fact_01KVF99WQY5TRD74A1N9N56G1X> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:AdditionalPaidInCapital ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/entity/entity_kg19ede94dda6b99013d06> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF99WQS6G93C6DZDCV964BB> ;
+        rs:internalId "fact_01KVF99WQY5TRD74A1N9N56G1X" ;
+        rs:numericValue 10000.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/period/p_1> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/fact/fact_01KVF99WQY5TRD74A1N9N56G1Y> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:CashAndCashEquivalentsAtCarryingValue ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/entity/entity_kg19ede94dda6b99013d06> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF99WQS6G93C6DZDCV964BB> ;
+        rs:internalId "fact_01KVF99WQY5TRD74A1N9N56G1Y" ;
+        rs:numericValue 10850.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/period/p_1> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/fact/fact_01KVF99WQY5TRD74A1N9N56G1Z> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:CostOfGoodsAndServicesSold ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/entity/entity_kg19ede94dda6b99013d06> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF99WQS6G93C6DZDCV964BC> ;
+        rs:internalId "fact_01KVF99WQY5TRD74A1N9N56G1Z" ;
+        rs:numericValue 5300.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/fact/fact_01KVF99WQY5TRD74A1N9N56G20> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:DepreciationDepletionAndAmortization ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/entity/entity_kg19ede94dda6b99013d06> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF99WQS6G93C6DZDCV964BD> ;
+        rs:internalId "fact_01KVF99WQY5TRD74A1N9N56G20" ;
+        rs:numericValue 100.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/fact/fact_01KVF99WQY5TRD74A1N9N56G21> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:DepreciationDepletionAndAmortization ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/entity/entity_kg19ede94dda6b99013d06> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF99WQS6G93C6DZDCV964BC> ;
+        rs:internalId "fact_01KVF99WQY5TRD74A1N9N56G21" ;
+        rs:numericValue 100.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/fact/fact_01KVF99WQY5TRD74A1N9N56G22> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:IncomeTaxExpenseBenefit ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/entity/entity_kg19ede94dda6b99013d06> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF99WQS6G93C6DZDCV964BC> ;
+        rs:internalId "fact_01KVF99WQY5TRD74A1N9N56G22" ;
+        rs:numericValue 400.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/fact/fact_01KVF99WQY5TRD74A1N9N56G23> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:InterestExpense ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/entity/entity_kg19ede94dda6b99013d06> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF99WQS6G93C6DZDCV964BC> ;
+        rs:internalId "fact_01KVF99WQY5TRD74A1N9N56G23" ;
+        rs:numericValue 150.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/fact/fact_01KVF99WQY5TRD74A1N9N56G24> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/entity/entity_kg19ede94dda6b99013d06> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF99WQS6G93C6DZDCV964BB> ;
+        rs:internalId "fact_01KVF99WQY5TRD74A1N9N56G24" ;
+        rs:numericValue 2700.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/period/p_1> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/fact/fact_01KVF99WQY5TRD74A1N9N56G25> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:LongTermDebtAndCapitalLeaseObligations ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/entity/entity_kg19ede94dda6b99013d06> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF99WQS6G93C6DZDCV964BB> ;
+        rs:internalId "fact_01KVF99WQY5TRD74A1N9N56G25" ;
+        rs:numericValue 1000.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/period/p_1> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/fact/fact_01KVF99WQY5TRD74A1N9N56G26> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:PropertyPlantAndEquipmentNet ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/entity/entity_kg19ede94dda6b99013d06> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF99WQS6G93C6DZDCV964BB> ;
+        rs:internalId "fact_01KVF99WQY5TRD74A1N9N56G26" ;
+        rs:numericValue 900.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/period/p_1> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/fact/fact_01KVF99WQY5TRD74A1N9N56G27> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:ReceivablesNetCurrent ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/entity/entity_kg19ede94dda6b99013d06> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF99WQS6G93C6DZDCV964BB> ;
+        rs:internalId "fact_01KVF99WQY5TRD74A1N9N56G27" ;
+        rs:numericValue 0.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/period/p_1> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/fact/fact_01KVF99WQY5TRD74A1N9N56G28> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:Revenues ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/entity/entity_kg19ede94dda6b99013d06> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF99WQS6G93C6DZDCV964BC> ;
+        rs:internalId "fact_01KVF99WQY5TRD74A1N9N56G28" ;
+        rs:numericValue 8000.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/fact/fact_01KVF99WQY5TRD74A1N9N56G29> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:RetainedEarningsAccumulatedDeficit ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/entity/entity_kg19ede94dda6b99013d06> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF99WQS6G93C6DZDCV964BB> ;
+        rs:internalId "fact_01KVF99WQY5TRD74A1N9N56G29" ;
+        rs:numericValue 2050.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/period/p_1> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/fact/fact_01KVF99WQY5TRD74A1N9N56G2A> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:AdditionalPaidInCapital ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/entity/entity_kg19ede94dda6b99013d06> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF99WQS6G93C6DZDCV964BB> ;
+        rs:internalId "fact_01KVF99WQY5TRD74A1N9N56G2A" ;
+        rs:numericValue 0.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/period/p_3> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/fact/fact_01KVF99WQY5TRD74A1N9N56G2B> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:RetainedEarningsAccumulatedDeficit ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/entity/entity_kg19ede94dda6b99013d06> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF99WQS6G93C6DZDCV964BB> ;
+        rs:internalId "fact_01KVF99WQY5TRD74A1N9N56G2B" ;
+        rs:numericValue 0.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/period/p_3> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/fact/fact_01KVF99WQY5TRD74A1N9N56G2C> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:NetIncomeLoss ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/entity/entity_kg19ede94dda6b99013d06> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF99WQS6G93C6DZDCV964BD> ;
+        rs:internalId "fact_01KVF99WQY5TRD74A1N9N56G2C" ;
+        rs:numericValue 2050.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/fact/fact_01KVF99WQY5TRD74A1N9N56G2D> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:NetIncomeLoss ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/entity/entity_kg19ede94dda6b99013d06> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF99WQS6G93C6DZDCV964BC> ;
+        rs:internalId "fact_01KVF99WQY5TRD74A1N9N56G2D" ;
+        rs:numericValue 2050.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/fact/fact_01KVF99WQY5TRD74A1N9N56G2E> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:NetIncomeLoss ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/entity/entity_kg19ede94dda6b99013d06> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF99WQS6G93C6DZDCV964BE> ;
+        rs:internalId "fact_01KVF99WQY5TRD74A1N9N56G2E" ;
+        rs:numericValue 2050.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/structure/0b179e5c-5f02-506d-b8d5-860cb10c7694> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/fact/fact_01KVF99WQY5TRD74A1N9N56G2F> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:ProceedsFromIssuanceOfLongTermDebt ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/entity/entity_kg19ede94dda6b99013d06> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF99WQS6G93C6DZDCV964BD> ;
+        rs:internalId "fact_01KVF99WQY5TRD74A1N9N56G2F" ;
+        rs:numericValue 2000.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/fact/fact_01KVF99WQY5TRD74A1N9N56G2G> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:ProceedsFromIssuanceOfCommonStock ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/entity/entity_kg19ede94dda6b99013d06> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF99WQS6G93C6DZDCV964BD> ;
+        rs:internalId "fact_01KVF99WQY5TRD74A1N9N56G2G" ;
+        rs:numericValue 10000.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/fact/fact_01KVF99WQY5TRD74A1N9N56G2H> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:ProceedsFromIssuanceOfCommonStock ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/entity/entity_kg19ede94dda6b99013d06> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF99WQS6G93C6DZDCV964BE> ;
+        rs:internalId "fact_01KVF99WQY5TRD74A1N9N56G2H" ;
+        rs:numericValue 10000.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/structure/0b179e5c-5f02-506d-b8d5-860cb10c7694> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/fact/fact_01KVF99WQY5TRD74A1N9N56G2J> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:RepaymentsOfLongTermDebt ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/entity/entity_kg19ede94dda6b99013d06> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF99WQS6G93C6DZDCV964BD> ;
+        rs:internalId "fact_01KVF99WQY5TRD74A1N9N56G2J" ;
+        rs:numericValue -1000.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/fact/fact_01KVF99WQY5TRD74A1N9N56G2K> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/entity/entity_kg19ede94dda6b99013d06> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF99WQS6G93C6DZDCV964BD> ;
+        rs:internalId "fact_01KVF99WQY5TRD74A1N9N56G2K" ;
+        rs:numericValue -1000.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/fact/fact_01KVF99WQY5TRD74A1N9N56G2M> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:IncreaseDecreaseInInventories ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/entity/entity_kg19ede94dda6b99013d06> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF99WQS6G93C6DZDCV964BD> ;
+        rs:internalId "fact_01KVF99WQY5TRD74A1N9N56G2M" ;
+        rs:numericValue -2700.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/fact/fact_01KVF99WQY5TRD74A1N9N56G2N> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:IncreaseDecreaseInAccruedLiabilities ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/entity/entity_kg19ede94dda6b99013d06> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF99WQS6G93C6DZDCV964BD> ;
+        rs:internalId "fact_01KVF99WQY5TRD74A1N9N56G2N" ;
+        rs:numericValue 400.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/fact/fact_01KVF99WQY5TRD74A1N9N56G2P> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:IncreaseDecreaseInOtherOperatingCapitalNet ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/entity/entity_kg19ede94dda6b99013d06> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF99WQS6G93C6DZDCV964BD> ;
+        rs:internalId "fact_01KVF99WQY5TRD74A1N9N56G2P" ;
+        rs:numericValue 1000.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/fact/fact_01KVF99WQY5TRD74A1N9N56G2Q> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:LiabilitiesCurrent ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/entity/entity_kg19ede94dda6b99013d06> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF99WQS6G93C6DZDCV964BB> ;
+        rs:internalId "fact_01KVF99WQY5TRD74A1N9N56G2Q" ;
+        rs:numericValue 1400.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/period/p_1> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/fact/fact_01KVF99WQY5TRD74A1N9N56G2R> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:Assets ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/entity/entity_kg19ede94dda6b99013d06> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF99WQS6G93C6DZDCV964BB> ;
+        rs:internalId "fact_01KVF99WQY5TRD74A1N9N56G2R" ;
+        rs:numericValue 14450.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/period/p_1> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/fact/fact_01KVF99WQY5TRD74A1N9N56G2S> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/entity/entity_kg19ede94dda6b99013d06> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF99WQS6G93C6DZDCV964BD> ;
+        rs:internalId "fact_01KVF99WQY5TRD74A1N9N56G2S" ;
+        rs:numericValue 10850.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/fact/fact_01KVF99WQY5TRD74A1N9N56G2T> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:LiabilitiesNoncurrent ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/entity/entity_kg19ede94dda6b99013d06> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF99WQS6G93C6DZDCV964BB> ;
+        rs:internalId "fact_01KVF99WQY5TRD74A1N9N56G2T" ;
+        rs:numericValue 1000.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/period/p_1> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/fact/fact_01KVF99WQY5TRD74A1N9N56G2V> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:AssetsCurrent ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/entity/entity_kg19ede94dda6b99013d06> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF99WQS6G93C6DZDCV964BB> ;
+        rs:internalId "fact_01KVF99WQY5TRD74A1N9N56G2V" ;
+        rs:numericValue 13550.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/period/p_1> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/fact/fact_01KVF99WQY5TRD74A1N9N56G2W> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:NetCashProvidedByUsedInOperatingActivities ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/entity/entity_kg19ede94dda6b99013d06> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF99WQS6G93C6DZDCV964BD> ;
+        rs:internalId "fact_01KVF99WQY5TRD74A1N9N56G2W" ;
+        rs:numericValue 850.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/fact/fact_01KVF99WQY5TRD74A1N9N56G2X> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:Liabilities ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/entity/entity_kg19ede94dda6b99013d06> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF99WQS6G93C6DZDCV964BB> ;
+        rs:internalId "fact_01KVF99WQY5TRD74A1N9N56G2X" ;
+        rs:numericValue 2400.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/period/p_1> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/fact/fact_01KVF99WQY5TRD74A1N9N56G2Y> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:NonoperatingIncomeExpense ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/entity/entity_kg19ede94dda6b99013d06> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF99WQS6G93C6DZDCV964BC> ;
+        rs:internalId "fact_01KVF99WQY5TRD74A1N9N56G2Y" ;
+        rs:numericValue -150.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/fact/fact_01KVF99WQY5TRD74A1N9N56G2Z> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/entity/entity_kg19ede94dda6b99013d06> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF99WQS6G93C6DZDCV964BC> ;
+        rs:internalId "fact_01KVF99WQY5TRD74A1N9N56G2Z" ;
+        rs:numericValue 2450.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/fact/fact_01KVF99WQY5TRD74A1N9N56G30> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:LiabilitiesAndStockholdersEquity ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/entity/entity_kg19ede94dda6b99013d06> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF99WQS6G93C6DZDCV964BB> ;
+        rs:internalId "fact_01KVF99WQY5TRD74A1N9N56G30" ;
+        rs:numericValue 14450.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/period/p_1> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/fact/fact_01KVF99WQY5TRD74A1N9N56G31> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:StockholdersEquity ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/entity/entity_kg19ede94dda6b99013d06> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF99WQS6G93C6DZDCV964BE> ;
+        rs:internalId "fact_01KVF99WQY5TRD74A1N9N56G31" ;
+        rs:numericValue 12050.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/period/p_1> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/structure/0b179e5c-5f02-506d-b8d5-860cb10c7694> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/fact/fact_01KVF99WQY5TRD74A1N9N56G32> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:StockholdersEquity ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/entity/entity_kg19ede94dda6b99013d06> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF99WQS6G93C6DZDCV964BB> ;
+        rs:internalId "fact_01KVF99WQY5TRD74A1N9N56G32" ;
+        rs:numericValue 12050.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/period/p_1> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/fact/fact_01KVF99WQY5TRD74A1N9N56G33> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:AssetsNoncurrent ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/entity/entity_kg19ede94dda6b99013d06> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF99WQS6G93C6DZDCV964BB> ;
+        rs:internalId "fact_01KVF99WQY5TRD74A1N9N56G33" ;
+        rs:numericValue 900.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/period/p_1> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/fact/fact_01KVF99WQY5TRD74A1N9N56G34> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:OperatingExpenses ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/entity/entity_kg19ede94dda6b99013d06> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF99WQS6G93C6DZDCV964BC> ;
+        rs:internalId "fact_01KVF99WQY5TRD74A1N9N56G34" ;
+        rs:numericValue 100.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/fact/fact_01KVF99WQY5TRD74A1N9N56G35> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:OperatingIncomeLoss ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/entity/entity_kg19ede94dda6b99013d06> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF99WQS6G93C6DZDCV964BC> ;
+        rs:internalId "fact_01KVF99WQY5TRD74A1N9N56G35" ;
+        rs:numericValue 2600.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/fact/fact_01KVF99WQY5TRD74A1N9N56G36> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:CostOfRevenue ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/entity/entity_kg19ede94dda6b99013d06> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF99WQS6G93C6DZDCV964BC> ;
+        rs:internalId "fact_01KVF99WQY5TRD74A1N9N56G36" ;
+        rs:numericValue 5300.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/fact/fact_01KVF99WQY5TRD74A1N9N56G37> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:GrossProfit ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/entity/entity_kg19ede94dda6b99013d06> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF99WQS6G93C6DZDCV964BC> ;
+        rs:internalId "fact_01KVF99WQY5TRD74A1N9N56G37" ;
+        rs:numericValue 2700.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/fact/fact_01KVF99WQY5TRD74A1N9N56G38> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:NetCashProvidedByUsedInFinancingActivities ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/entity/entity_kg19ede94dda6b99013d06> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF99WQS6G93C6DZDCV964BD> ;
+        rs:internalId "fact_01KVF99WQY5TRD74A1N9N56G38" ;
+        rs:numericValue 11000.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/fact/fact_01KVF99WQY5TRD74A1N9N56G39> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:NetCashProvidedByUsedInInvestingActivities ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/entity/entity_kg19ede94dda6b99013d06> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF99WQS6G93C6DZDCV964BD> ;
+        rs:internalId "fact_01KVF99WQY5TRD74A1N9N56G39" ;
+        rs:numericValue -1000.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/fact/fact_01KVF99WQY5TRD74A1N9N56G3A> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:IncomeLossFromContinuingOperations ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/entity/entity_kg19ede94dda6b99013d06> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF99WQS6G93C6DZDCV964BC> ;
+        rs:internalId "fact_01KVF99WQY5TRD74A1N9N56G3A" ;
+        rs:numericValue 2050.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/ib/0b179e5c-5f02-506d-b8d5-860cb10c7694> a rs:InformationBlock ;
+        skos:prefLabel "rs-gaap — Statement of Changes in Equity — Roll Forward (Total)" ;
+        rs:blockType "equity_statement" ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF99WQS6G93C6DZDCV964BE> ;
+        rs:internalId "0b179e5c-5f02-506d-b8d5-860cb10c7694" ;
+        rs:taxonomyId "cf7178a0-e2d4-58df-995a-2f0233d15466" ;
+        rs:taxonomyName "rs-gaap-presentation v1" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/ib/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> a rs:InformationBlock ;
+        skos:prefLabel "rs-gaap — Income Statement — Multi-step" ;
+        rs:blockType "income_statement" ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF99WQS6G93C6DZDCV964BC> ;
+        rs:internalId "47cd6544-03d1-5bc1-8c28-31c0cfa450f9" ;
+        rs:taxonomyId "cf7178a0-e2d4-58df-995a-2f0233d15466" ;
+        rs:taxonomyName "rs-gaap-presentation v1" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/ib/5473639a-2dac-56a6-b9e5-38480ea38bc1> a rs:InformationBlock ;
+        skos:prefLabel "rs-gaap — Cash Flow Statement — Indirect" ;
+        rs:blockType "cash_flow_statement" ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF99WQS6G93C6DZDCV964BD> ;
+        rs:internalId "5473639a-2dac-56a6-b9e5-38480ea38bc1" ;
+        rs:taxonomyId "cf7178a0-e2d4-58df-995a-2f0233d15466" ;
+        rs:taxonomyName "rs-gaap-presentation v1" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/ib/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> a rs:InformationBlock ;
+        skos:prefLabel "rs-gaap — Balance Sheet — Classified" ;
+        rs:blockType "balance_sheet" ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF99WQS6G93C6DZDCV964BB> ;
+        rs:internalId "b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d" ;
+        rs:taxonomyId "cf7178a0-e2d4-58df-995a-2f0233d15466" ;
+        rs:taxonomyName "rs-gaap-presentation v1" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/period/p_3> a rs:Period ;
+        xbrli:instant "2023-12-31"^^xsd:date ;
+        xbrli:periodType "instant" .
+
+    rs-gaap:IncreaseDecreaseInAccruedLiabilities a rs:Element ;
+        skos:prefLabel "Increase (Decrease) in Accrued Liabilities" ;
+        xbrli:balance "debit" ;
+        xbrli:periodType "duration" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "e92e6488-dcc7-5877-ad4b-f2498bdf7bae" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:IncreaseDecreaseInInventories a rs:Element ;
+        skos:prefLabel "Increase (Decrease) in Inventories" ;
+        xbrli:balance "credit" ;
+        xbrli:periodType "duration" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "c8b0722b-7993-592f-8ef1-5b0964ac8a10" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:IncreaseDecreaseInOtherOperatingCapitalNet a rs:Element ;
+        skos:prefLabel "Increase (Decrease) in Other Operating Assets and Liabilities, Net" ;
+        xbrli:balance "credit" ;
+        xbrli:periodType "duration" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "a3227fb2-202b-51db-9574-4e60db03c04f" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment a rs:Element ;
+        skos:prefLabel "Payments to Acquire Property, Plant, and Equipment" ;
+        xbrli:balance "credit" ;
+        xbrli:periodType "duration" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "ff101489-15f4-573d-967b-24f75e0fc0f6" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:ProceedsFromIssuanceOfLongTermDebt a rs:Element ;
+        skos:prefLabel "Proceeds from Issuance of Long-Term Debt" ;
+        xbrli:balance "debit" ;
+        xbrli:periodType "duration" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "1802f6ae-7d95-5029-af7a-b36015b2c525" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:RepaymentsOfLongTermDebt a rs:Element ;
+        skos:prefLabel "Repayments of Long-Term Debt" ;
+        xbrli:balance "credit" ;
+        xbrli:periodType "duration" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "85890c87-aac7-5702-8f69-b1a14139dc41" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:AccountsPayableCurrent a rs:Element ;
+        skos:prefLabel "Accounts Payable, Current" ;
+        xbrli:balance "credit" ;
+        xbrli:periodType "instant" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "9ddbc9d7-c769-5800-8f65-1089d476e5c9" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:AccruedLiabilitiesCurrent a rs:Element ;
+        skos:prefLabel "Accrued Liabilities, Current" ;
+        xbrli:balance "credit" ;
+        xbrli:periodType "instant" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "4decfae2-2ca3-5dd3-8c06-88557583c13d" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:CashAndCashEquivalentsAtCarryingValue a rs:Element ;
+        skos:prefLabel "Cash and Cash Equivalents, at Carrying Value" ;
+        xbrli:balance "debit" ;
+        xbrli:periodType "instant" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "20a6586b-880a-5745-94db-e23d397eb5e1" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:CostOfGoodsAndServicesSold a rs:Element ;
+        skos:prefLabel "Cost of Product and Service Sold" ;
+        xbrli:balance "debit" ;
+        xbrli:periodType "duration" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "5ca0e51f-dff1-5c2b-94f5-26620852a5f9" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:IncomeTaxExpenseBenefit a rs:Element ;
+        skos:prefLabel "Income Tax Expense (Benefit)" ;
+        xbrli:balance "debit" ;
+        xbrli:periodType "duration" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "d629316b-5674-58d9-afcd-b7e7fd34232d" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:InterestExpense a rs:Element ;
+        skos:prefLabel "Interest Expense, Operating and Nonoperating" ;
+        xbrli:balance "debit" ;
+        xbrli:periodType "duration" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "890e4f8c-8fed-57e2-96fd-e70455201b11" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings a rs:Element ;
+        skos:prefLabel "Inventory, Net of Allowances, Customer Advances and Progress Billings" ;
+        xbrli:balance "debit" ;
+        xbrli:periodType "instant" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "4afa5950-85ac-5a85-a9cb-01c387c6ab08" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:LongTermDebtAndCapitalLeaseObligations a rs:Element ;
+        skos:prefLabel "Long-Term Debt and Lease Obligation" ;
+        xbrli:balance "credit" ;
+        xbrli:periodType "instant" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "091373d9-8a82-51bd-adf8-d09b73beb32e" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:PropertyPlantAndEquipmentNet a rs:Element ;
+        skos:prefLabel "Property, Plant and Equipment, Net" ;
+        xbrli:balance "debit" ;
+        xbrli:periodType "instant" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "288099af-5cbb-5f78-8f8a-1a85675fb661" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:ReceivablesNetCurrent a rs:Element ;
+        skos:prefLabel "Receivables, Net, Current" ;
+        xbrli:balance "debit" ;
+        xbrli:periodType "instant" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "44686df3-3871-5c1f-8a08-fc542d69dfa0" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:AdditionalPaidInCapital a rs:Element ;
+        skos:prefLabel "Additional Paid in Capital" ;
+        xbrli:balance "credit" ;
+        xbrli:periodType "instant" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "6146605c-0d63-51e1-a523-3450d6abaca3" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:ProceedsFromIssuanceOfCommonStock a rs:Element ;
+        skos:prefLabel "Proceeds from Issuance of Common Stock" ;
+        xbrli:balance "debit" ;
+        xbrli:periodType "duration" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "2eb72b5f-d7e3-5bd5-bf93-be38b6d21820" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:RetainedEarningsAccumulatedDeficit a rs:Element ;
+        skos:prefLabel "Retained Earnings (Accumulated Deficit)" ;
+        xbrli:balance "credit" ;
+        xbrli:periodType "instant" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "a9c87d60-a1e5-506b-a27e-cbf9e14e5113" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:Assets a rs:Element ;
+        skos:prefLabel "Assets" ;
+        xbrli:balance "debit" ;
+        xbrli:periodType "instant" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "a1f04756-41d8-5d35-b821-23aa2f3b2fae" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:DepreciationDepletionAndAmortization a rs:Element ;
+        skos:prefLabel "Depreciation, Depletion and Amortization" ;
+        xbrli:balance "debit" ;
+        xbrli:periodType "duration" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "189a099a-7512-5144-9215-65d837c2c3b5" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:GrossProfit a rs:Element ;
+        skos:prefLabel "Gross Profit" ;
+        xbrli:balance "credit" ;
+        xbrli:periodType "duration" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "a92b3181-9fe7-543c-81d9-13ebd12bbefa" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:IncomeLossFromContinuingOperations a rs:Element ;
+        skos:prefLabel "Income (Loss) from Continuing Operations, Net of Tax, Attributable to Parent" ;
+        xbrli:balance "credit" ;
+        xbrli:periodType "duration" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "d60cabda-7060-5aff-ac98-96371606a738" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest a rs:Element ;
+        skos:prefLabel "Income (Loss) from Continuing Operations before Income Taxes, Noncontrolling Interest" ;
+        xbrli:balance "credit" ;
+        xbrli:periodType "duration" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "6b0b414f-0c76-54f0-8e51-cf53db59ca24" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:LiabilitiesAndStockholdersEquity a rs:Element ;
+        skos:prefLabel "Liabilities and Equity" ;
+        xbrli:balance "credit" ;
+        xbrli:periodType "instant" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "30b2801e-e682-5298-82e6-3670e1d508f1" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:OperatingIncomeLoss a rs:Element ;
+        skos:prefLabel "Operating Income (Loss)" ;
+        xbrli:balance "credit" ;
+        xbrli:periodType "duration" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "16780828-0201-5609-b572-fbe3ebfcb177" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:Revenues a rs:Element ;
+        skos:prefLabel "Revenues" ;
+        xbrli:balance "credit" ;
+        xbrli:periodType "duration" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "b26a6cd4-072f-5bf2-b5d3-ebf928150d6c" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:CostOfRevenue a rs:Element ;
+        skos:prefLabel "Cost of Revenue" ;
+        xbrli:balance "debit" ;
+        xbrli:periodType "duration" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "12ab7417-5324-55d6-946e-2456adba47c5" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:Liabilities a rs:Element ;
+        skos:prefLabel "Liabilities" ;
+        xbrli:balance "credit" ;
+        xbrli:periodType "instant" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "7af273ac-1cba-5fb3-a1c9-5c5d8fdb9bdf" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:NetCashProvidedByUsedInFinancingActivities a rs:Element ;
+        skos:prefLabel "Cash Provided by (Used in) Financing Activity, Including Discontinued Operation" ;
+        xbrli:balance "debit" ;
+        xbrli:periodType "duration" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "811f1cf5-836c-575f-9f3f-cd7fa477e4e5" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:NetIncomeLoss a rs:Element ;
+        skos:prefLabel "Net Income (Loss) Attributable to Parent" ;
+        xbrli:balance "credit" ;
+        xbrli:periodType "duration" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "27a05717-2370-51c2-a924-db5cbcb48219" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease a rs:Element ;
+        skos:prefLabel "Cash and Cash Equivalents, Period Increase (Decrease)" ;
+        xbrli:balance "debit" ;
+        xbrli:periodType "duration" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "353f790f-1ed1-5b91-880d-8029b4b687cf" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:NetCashProvidedByUsedInInvestingActivities a rs:Element ;
+        skos:prefLabel "Cash Provided by (Used in) Investing Activity, Including Discontinued Operation" ;
+        xbrli:balance "debit" ;
+        xbrli:periodType "duration" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "69b82be1-1145-5686-8613-31da9eb04a72" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:NetCashProvidedByUsedInOperatingActivities a rs:Element ;
+        skos:prefLabel "Cash Provided by (Used in) Operating Activity, Including Discontinued Operation" ;
+        xbrli:balance "debit" ;
+        xbrli:periodType "duration" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "57ccbf45-c970-5bcd-a381-44d96b6b6d94" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:LiabilitiesNoncurrent a rs:Element ;
+        skos:prefLabel "Liabilities, Noncurrent" ;
+        xbrli:balance "credit" ;
+        xbrli:periodType "instant" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "f41fe34d-88ea-5e20-a781-2d3e256a6abf" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:NonoperatingIncomeExpense a rs:Element ;
+        skos:prefLabel "Nonoperating Income (Expense)" ;
+        xbrli:balance "credit" ;
+        xbrli:periodType "duration" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "45aae2c2-fa56-50c9-b381-df8079e7d33a" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:AssetsCurrent a rs:Element ;
+        skos:prefLabel "Assets, Current" ;
+        xbrli:balance "debit" ;
+        xbrli:periodType "instant" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "0fc9ab7e-c5ce-5277-9530-344cc127fe26" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:AssetsNoncurrent a rs:Element ;
+        skos:prefLabel "Assets, Noncurrent" ;
+        xbrli:balance "debit" ;
+        xbrli:periodType "instant" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "841cedeb-4cb0-532a-b0bd-c34846a13a8c" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:LiabilitiesCurrent a rs:Element ;
+        skos:prefLabel "Liabilities, Current" ;
+        xbrli:balance "credit" ;
+        xbrli:periodType "instant" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "efb036ff-3f30-5deb-bee9-1af4cd4b9800" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:OperatingExpenses a rs:Element ;
+        skos:prefLabel "Operating Expenses" ;
+        xbrli:balance "debit" ;
+        xbrli:periodType "duration" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "71fcdebb-7145-5f76-b5e0-b4ccbf2c29d2" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/period/p_1> a rs:Period ;
+        xbrli:instant "2024-03-31"^^xsd:date ;
+        xbrli:periodType "instant" .
+
+    rs-gaap:StockholdersEquity a rs:Element ;
+        skos:prefLabel "Stockholders' Equity Attributable to Parent" ;
+        xbrli:balance "credit" ;
+        xbrli:periodType "instant" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "e3796201-9899-5b7b-9477-659550ba8e68" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/period/p_2> a rs:Period ;
+        xbrli:endDate "2024-03-31"^^xsd:date ;
+        xbrli:periodType "duration" ;
+        xbrli:startDate "2024-01-01"^^xsd:date .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/entity/entity_kg19ede94dda6b99013d06> a rs:Entity ;
+        skos:prefLabel "Lemonade Stand (Charlie Hoffman Test Case 1)" ;
+        rs:country "US" ;
+        rs:internalId "entity_kg19ede94dda6b99013d06" ;
+        rs:legalName "Lemonade Stand (Charlie Hoffman Test Case 1)" .
+
+    <https://robosystems.ai/report/rpt_01KVF99WPYN17GS13R5DJY87HC/unit/u_USD> a rs:Unit ;
+        xbrli:measure iso4217:USD .
+}
+

--- a/examples/seattle_method_world_online/sample_output/world-online.databook.md
+++ b/examples/seattle_method_world_online/sample_output/world-online.databook.md
@@ -40,6 +40,29 @@ manifest:
     equity_statement:
       type: turtle
       description: "rs-gaap — Statement of Changes in Equity — Roll Forward (Total)"
+graph:
+  facts: 55
+  href: world-online.holon.trig
+  graphs:
+    - id: scene
+      iri: https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM#scene
+      description: "Instance facts — the values this report reports"
+      disposition: inline
+    - id: boundary
+      iri: https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM#boundary
+      description: "Calculation network — the rollup rules the facts must obey"
+      disposition: reference
+      derived_from: rs-gaap-calculations@v1
+    - id: projection
+      iri: https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM#projection
+      description: "Presentation network — order, indentation, subtotals"
+      disposition: reference
+      derived_from: rs-gaap-presentation@v1
+      reporting_style: 025f5d48-12ce-5d65-b9eb-4f137a10ef06
+    - id: lineage
+      description: "Event lineage — fact → event → entry → line item → CoA"
+      disposition: internal
+      note: "the books, not published — a report is an aggregation of the ledger, which is internal; substantiation available to authorized parties"
 report:
   reporting_style: 025f5d48-12ce-5d65-b9eb-4f137a10ef06
   report_id: rpt_01KVF986ZHG0852N6R7P77VEYM
@@ -66,7 +89,7 @@ report:
 
 # The World Online — The World Online (Charlie Hoffman demo)
 
-A report **is** a collection of Information Blocks. Each block below is shown twice: a markdown table (human view) and an addressable `turtle` block (machine view — the same facts as RDF), keyed by the id declared in the frontmatter `manifest`. Everything is derived from `world-online.jsonld`; the bundle and this DataBook are two skins of one graph.
+A report **is** a collection of Information Blocks, and this DataBook is a projection of one report holon (see the `graph:` map above). The **scene** graph — the facts — renders twice per block here: a markdown table (human view) and a foldable, addressable `turtle` slice (machine view, the same facts as RDF). The **boundary** (calculation) and **projection** (presentation) graphs live as real named graphs in the companion `world-online.holon.trig` and derive from their versioned framework — referenced here rather than inlined, since they're shared by every report on that framework. The **lineage** graph — the ledger behind the facts — is internal and not published: a report is an aggregation of the books, not the books. The `Validation evidence` section is the published substantiation that the referenced rules hold. Everything here derives from `world-online.jsonld`.
 
 
 ## Balance Sheet
@@ -93,6 +116,9 @@ A report **is** a collection of Information Blocks. Each block below is shown tw
 | `rs-gaap:RetainedEarningsAccumulatedDeficit` |     Retained Earnings (Accumulated Deficit) | $(1,351,122.32) |
 | `rs-gaap:StockholdersEquity` |   **Stockholders' Equity Attributable to Parent** | $56,524.32 |
 | `rs-gaap:LiabilitiesAndStockholdersEquity` | **Liabilities and Equity** | $3,084,325.68 |
+
+<details>
+<summary>▸ Balance Sheet — scene RDF / Turtle (500 triples · 31.6 KB)</summary>
 
 ```turtle {#balance_sheet}
 @prefix iso4217: <http://www.xbrl.org/2003/iso4217#> .
@@ -656,6 +682,8 @@ rs-gaap:StockholdersEquity a rs:Element ;
     xbrli:measure iso4217:USD .
 ```
 
+</details>
+
 
 ## Income Statement
 
@@ -678,6 +706,9 @@ rs-gaap:StockholdersEquity a rs:Element ;
 | `rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest` |   **Income (Loss) from Continuing Operations before Income Taxes, Noncontrolling Interest** | $(1,351,122.32) |
 | `rs-gaap:IncomeLossFromContinuingOperations` |   **Income (Loss) from Continuing Operations, Net of Tax, Attributable to Parent** | $(1,351,122.32) |
 | `rs-gaap:NetIncomeLoss` |   **Net Income (Loss) Attributable to Parent** | $(1,351,122.32) |
+
+<details>
+<summary>▸ Income Statement — scene RDF / Turtle (278 triples · 16.1 KB)</summary>
 
 ```turtle {#income_statement}
 @prefix iso4217: <http://www.xbrl.org/2003/iso4217#> .
@@ -996,6 +1027,8 @@ rs-gaap:Revenues a rs:Element ;
     xbrli:measure iso4217:USD .
 ```
 
+</details>
+
 
 ## Cash Flow Statement
 
@@ -1012,6 +1045,9 @@ rs-gaap:Revenues a rs:Element ;
 | `rs-gaap:IncreaseDecreaseInOtherOperatingCapitalNet` |     Increase (Decrease) in Other Operating Assets and Liabilities, Net | $1,071,166.25 |
 | `rs-gaap:NetCashProvidedByUsedInOperatingActivities` |   Cash Provided by (Used in) Operating Activity, Including Discontinued Operation | $(1,047,489.70) |
 | `rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease` | **Cash and Cash Equivalents, Period Increase (Decrease)** | $(1,047,489.70) |
+
+<details>
+<summary>▸ Cash Flow Statement — scene RDF / Turtle (158 triples · 9.6 KB)</summary>
 
 ```turtle {#cash_flow_statement}
 @prefix iso4217: <http://www.xbrl.org/2003/iso4217#> .
@@ -1198,6 +1234,8 @@ rs-gaap:NetIncomeLoss a rs:Element ;
     xbrli:measure iso4217:USD .
 ```
 
+</details>
+
 
 ## Statement of Changes in Equity
 
@@ -1209,6 +1247,9 @@ rs-gaap:NetIncomeLoss a rs:Element ;
 |---|---|---:|
 | `rs-gaap:NetIncomeLoss` |   **Net Income (Loss) Attributable to Parent** | $(1,351,122.32) |
 | `rs-gaap:StockholdersEquity` | **Stockholders' Equity Attributable to Parent** | $56,524.32 |
+
+<details>
+<summary>▸ Statement of Changes in Equity — scene RDF / Turtle (74 triples · 4.7 KB)</summary>
 
 ```turtle {#equity_statement}
 @prefix iso4217: <http://www.xbrl.org/2003/iso4217#> .
@@ -1303,6 +1344,8 @@ rs-gaap:StockholdersEquity a rs:Element ;
 <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/unit/u_USD> a rs:Unit ;
     xbrli:measure iso4217:USD .
 ```
+
+</details>
 
 
 ## Validation evidence

--- a/examples/seattle_method_world_online/sample_output/world-online.holon.trig
+++ b/examples/seattle_method_world_online/sample_output/world-online.holon.trig
@@ -1,0 +1,2601 @@
+@prefix iso4217: <http://www.xbrl.org/2003/iso4217#> .
+@prefix link: <http://www.xbrl.org/2003/linkbase#> .
+@prefix rs: <https://robosystems.ai/vocab/> .
+@prefix rs-gaap: <https://robosystems.ai/taxonomy/rs-gaap/v1/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xbrli: <http://www.xbrl.org/2003/instance#> .
+@prefix xlink: <http://www.w3.org/1999/xlink#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM#projection> {
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/structure/0b179e5c-5f02-506d-b8d5-860cb10c7694> a rs:Structure ;
+        rs:blockType "equity_statement" ;
+        rs:hasAssociation <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/0>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/1>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/2>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/3>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/4>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/5> ;
+        rs:internalId "0b179e5c-5f02-506d-b8d5-860cb10c7694" ;
+        rs:roleUri "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward" ;
+        rs:structureName "rs-gaap — Statement of Changes in Equity — Roll Forward (Total)" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> a rs:Structure ;
+        rs:blockType "income_statement" ;
+        rs:hasAssociation <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/0>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/1>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/10>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/11>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/12>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/13>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/14>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/15>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/16>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/17>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/18>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/19>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/2>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/20>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/21>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/22>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/23>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/24>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/25>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/26>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/3>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/4>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/5>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/6>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/7>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/8>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/9> ;
+        rs:internalId "47cd6544-03d1-5bc1-8c28-31c0cfa450f9" ;
+        rs:roleUri "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep" ;
+        rs:structureName "rs-gaap — Income Statement — Multi-step" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> a rs:Structure ;
+        rs:blockType "cash_flow_statement" ;
+        rs:hasAssociation <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/0>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/1>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/10>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/11>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/12>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/13>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/14>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/15>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/16>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/17>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/18>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/19>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/2>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/20>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/21>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/22>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/3>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/4>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/5>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/6>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/7>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/8>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/9> ;
+        rs:internalId "5473639a-2dac-56a6-b9e5-38480ea38bc1" ;
+        rs:roleUri "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect" ;
+        rs:structureName "rs-gaap — Cash Flow Statement — Indirect" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> a rs:Structure ;
+        rs:blockType "balance_sheet" ;
+        rs:hasAssociation <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/0>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/1>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/10>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/11>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/12>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/13>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/14>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/15>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/16>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/17>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/18>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/19>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/2>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/20>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/21>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/22>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/23>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/24>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/25>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/26>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/27>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/28>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/29>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/3>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/30>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/31>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/32>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/33>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/34>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/35>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/36>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/37>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/4>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/5>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/6>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/7>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/8>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/9> ;
+        rs:internalId "b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d" ;
+        rs:roleUri "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified" ;
+        rs:structureName "rs-gaap — Balance Sheet — Classified" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/0> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:StockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward> ;
+        xlink:to rs-gaap:NetIncomeLoss ;
+        link:order 40100.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/1> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:StockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward> ;
+        xlink:to rs-gaap:OtherComprehensiveIncomeLossNetOfTax ;
+        link:order 40200.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/2> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:StockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward> ;
+        xlink:to rs-gaap:ProceedsFromIssuanceOfCommonStock ;
+        link:order 40300.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/3> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:StockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward> ;
+        xlink:to rs-gaap:PaymentsForRepurchaseOfCommonStock ;
+        link:order 40400.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/4> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:StockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward> ;
+        xlink:to rs-gaap:ShareBasedCompensation ;
+        link:order 40500.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/5> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:StockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward> ;
+        xlink:to rs-gaap:PaymentsOfDividends ;
+        link:order 40600.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/0> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:IncomeStatementAbstract ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:Revenues ;
+        link:order 10100.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/1> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:Revenues ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax ;
+        link:order 10120.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/10> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:OperatingExpenses ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:DepreciationDepletionAndAmortization ;
+        link:order 10430.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/11> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:OperatingExpenses ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:OtherCostAndExpenseOperating ;
+        link:order 10440.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/12> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:OperatingExpenses ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:RestructuringCharges ;
+        link:order 10443.3333 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/13> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:OperatingExpenses ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:AssetImpairmentCharges ;
+        link:order 10446.6667 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/14> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:IncomeStatementAbstract ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:OperatingIncomeLoss ;
+        link:order 10500.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/15> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:IncomeStatementAbstract ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:NonoperatingIncomeExpense ;
+        link:order 10600.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/16> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NonoperatingIncomeExpense ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:InvestmentIncomeInterest ;
+        link:order 10610.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/17> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NonoperatingIncomeExpense ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:InterestExpense ;
+        link:order 10620.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/18> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NonoperatingIncomeExpense ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:GainLossOnDispositionOfAssets ;
+        link:order 10630.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/19> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NonoperatingIncomeExpense ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:OtherNonoperatingIncomeExpense ;
+        link:order 10640.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/2> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:IncomeStatementAbstract ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:CostOfRevenue ;
+        link:order 10200.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/20> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NonoperatingIncomeExpense ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:ForeignCurrencyTransactionGainLossBeforeTax ;
+        link:order 10643.3333 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/21> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NonoperatingIncomeExpense ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:GainsLossesOnExtinguishmentOfDebt ;
+        link:order 10646.6667 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/22> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:IncomeStatementAbstract ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest ;
+        link:order 10800.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/23> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:IncomeStatementAbstract ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:IncomeTaxExpenseBenefit ;
+        link:order 10900.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/24> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:IncomeStatementAbstract ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:IncomeLossFromContinuingOperations ;
+        link:order 11000.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/25> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:IncomeStatementAbstract ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:IncomeLossFromDiscontinuedOperationsNetOfTax ;
+        link:order 11100.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/26> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:IncomeStatementAbstract ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:NetIncomeLoss ;
+        link:order 11200.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/3> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:CostOfRevenue ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:CostOfGoodsAndServicesSold ;
+        link:order 10210.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/4> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:CostOfRevenue ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:OtherCostOfOperatingRevenue ;
+        link:order 10230.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/5> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:IncomeStatementAbstract ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:GrossProfit ;
+        link:order 10300.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/6> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:IncomeStatementAbstract ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:OperatingExpenses ;
+        link:order 10400.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/7> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:OperatingExpenses ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:GeneralAndAdministrativeExpense ;
+        link:order 10410.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/8> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:OperatingExpenses ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:SellingAndMarketingExpense ;
+        link:order 10415.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/9> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:OperatingExpenses ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:ResearchAndDevelopmentExpense ;
+        link:order 10420.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/0> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:NetCashProvidedByUsedInOperatingActivities ;
+        link:order 30100.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/1> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NetCashProvidedByUsedInOperatingActivities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:NetIncomeLoss ;
+        link:order 30110.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/10> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:NetCashProvidedByUsedInInvestingActivities ;
+        link:order 30200.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/11> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NetCashProvidedByUsedInInvestingActivities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment ;
+        link:order 30210.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/12> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NetCashProvidedByUsedInInvestingActivities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:ProceedsFromSaleOfPropertyPlantAndEquipment ;
+        link:order 30220.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/13> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NetCashProvidedByUsedInInvestingActivities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:PaymentsToAcquireInvestments ;
+        link:order 30230.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/14> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NetCashProvidedByUsedInInvestingActivities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:ProceedsFromSaleMaturityAndCollectionsOfInvestments ;
+        link:order 30240.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/15> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NetCashProvidedByUsedInInvestingActivities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:PaymentsToAcquireIntangibleAssets ;
+        link:order 30250.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/16> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NetCashProvidedByUsedInInvestingActivities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:ProceedsFromSaleOfIntangibleAssets ;
+        link:order 30260.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/17> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:NetCashProvidedByUsedInFinancingActivities ;
+        link:order 30300.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/18> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NetCashProvidedByUsedInFinancingActivities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:ProceedsFromIssuanceOfCommonStock ;
+        link:order 30310.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/19> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NetCashProvidedByUsedInFinancingActivities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:ProceedsFromIssuanceOfLongTermDebt ;
+        link:order 30320.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/2> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NetCashProvidedByUsedInOperatingActivities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:DepreciationDepletionAndAmortization ;
+        link:order 30120.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/20> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NetCashProvidedByUsedInFinancingActivities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:RepaymentsOfLongTermDebt ;
+        link:order 30330.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/21> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NetCashProvidedByUsedInFinancingActivities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:PaymentsForRepurchaseOfCommonStock ;
+        link:order 30340.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/22> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:EffectOfExchangeRateOnCash ;
+        link:order 30400.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/3> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NetCashProvidedByUsedInOperatingActivities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:IncreaseDecreaseInAccountsReceivable ;
+        link:order 30130.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/4> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NetCashProvidedByUsedInOperatingActivities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:IncreaseDecreaseInInventories ;
+        link:order 30140.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/5> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NetCashProvidedByUsedInOperatingActivities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:IncreaseDecreaseInPrepaidExpense ;
+        link:order 30150.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/6> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NetCashProvidedByUsedInOperatingActivities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:IncreaseDecreaseInAccountsPayableAndAccruedLiabilities ;
+        link:order 30160.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/7> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NetCashProvidedByUsedInOperatingActivities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:IncreaseDecreaseInOtherOperatingCapitalNet ;
+        link:order 30170.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/8> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NetCashProvidedByUsedInOperatingActivities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:IncreaseDecreaseInAccruedLiabilities ;
+        link:order 30180.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/9> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:NetCashProvidedByUsedInOperatingActivities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:IncreaseDecreaseInAccruedIncomeTaxesPayable ;
+        link:order 30190.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/0> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:Assets ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:AssetsCurrent ;
+        link:order 20100.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/1> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:AssetsCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:CashAndCashEquivalentsAtCarryingValue ;
+        link:order 20110.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/10> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:AssetsNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:Goodwill ;
+        link:order 20220.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/11> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:AssetsNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:IntangibleAssetsNetExcludingGoodwill ;
+        link:order 20225.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/12> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:AssetsNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:LongTermInvestmentsAndReceivablesNet ;
+        link:order 20230.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/13> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:AssetsNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:OperatingLeaseRightOfUseAsset ;
+        link:order 20240.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/14> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:AssetsNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:FinanceLeaseRightOfUseAsset ;
+        link:order 20250.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/15> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:AssetsNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:OtherAssetsNoncurrent ;
+        link:order 20260.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/16> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:LiabilitiesAndStockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:Liabilities ;
+        link:order 20300.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/17> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:Liabilities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:LiabilitiesCurrent ;
+        link:order 20310.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/18> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:LiabilitiesCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:AccountsPayableCurrent ;
+        link:order 20311.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/19> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:LiabilitiesCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:AccruedLiabilitiesCurrent ;
+        link:order 20311.5 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/2> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:AssetsCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:ShortTermInvestments ;
+        link:order 20115.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/20> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:LiabilitiesCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:DebtCurrent ;
+        link:order 20312.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/21> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:LiabilitiesCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:LongTermDebtCurrent ;
+        link:order 20312.5 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/22> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:LiabilitiesCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:DeferredRevenueCurrent ;
+        link:order 20313.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/23> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:LiabilitiesCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:FinanceLeaseLiabilityCurrent ;
+        link:order 20314.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/24> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:LiabilitiesCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:OtherLiabilitiesCurrent ;
+        link:order 20315.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/25> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:Liabilities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:LiabilitiesNoncurrent ;
+        link:order 20320.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/26> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:LiabilitiesNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:LongTermDebtAndCapitalLeaseObligations ;
+        link:order 20321.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/27> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:LiabilitiesNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:DeferredIncomeTaxLiabilitiesNet ;
+        link:order 20322.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/28> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:LiabilitiesNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:DeferredRevenueNoncurrent ;
+        link:order 20323.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/29> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:LiabilitiesNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:OperatingLeaseLiabilityNoncurrent ;
+        link:order 20324.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/3> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:AssetsCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:ReceivablesNetCurrent ;
+        link:order 20120.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/30> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:LiabilitiesNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:OtherLiabilitiesNoncurrent ;
+        link:order 20325.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/31> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:LiabilitiesAndStockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:StockholdersEquity ;
+        link:order 20400.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/32> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:StockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:CommonStockValue ;
+        link:order 20410.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/33> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:StockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:PreferredStockValue ;
+        link:order 20420.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/34> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:StockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:AdditionalPaidInCapital ;
+        link:order 20430.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/35> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:StockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:RetainedEarningsAccumulatedDeficit ;
+        link:order 20440.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/36> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:StockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:AccumulatedOtherComprehensiveIncomeLossNetOfTax ;
+        link:order 20450.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/37> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:StockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:TreasuryStockValue ;
+        link:order 20460.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/4> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:AssetsCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings ;
+        link:order 20130.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/5> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:AssetsCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:PrepaidExpenseCurrent ;
+        link:order 20140.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/6> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:AssetsCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:RestrictedCashAndInvestmentsCurrent ;
+        link:order 20150.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/7> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:AssetsCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:OtherAssetsCurrent ;
+        link:order 20160.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/8> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:Assets ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:AssetsNoncurrent ;
+        link:order 20200.0 ;
+        rs:associationType "presentation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/9> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/parent-child> ;
+        xlink:from rs-gaap:AssetsNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:PropertyPlantAndEquipmentNet ;
+        link:order 20210.0 ;
+        rs:associationType "presentation" .
+}
+
+<https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM#boundary> {
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/0> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:CostOfRevenue ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:CostOfGoodsAndServicesSold ;
+        link:order 100.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/1> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:GrossProfit ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:Revenues ;
+        link:order 100.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/10> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:CostOfRevenue ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:OtherCostOfOperatingRevenue ;
+        link:order 200.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/11> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:GrossProfit ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:CostOfRevenue ;
+        link:order 200.0 ;
+        link:weight -1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/12> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:IncomeLossFromContinuingOperations ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:IncomeTaxExpenseBenefit ;
+        link:order 200.0 ;
+        link:weight -1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/13> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:NonoperatingIncomeExpense ;
+        link:order 200.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/14> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:NetIncomeLoss ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:IncomeLossFromDiscontinuedOperationsNetOfTax ;
+        link:order 200.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/15> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:NonoperatingIncomeExpense ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:InterestExpense ;
+        link:order 200.0 ;
+        link:weight -1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/16> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:OperatingExpenses ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:ResearchAndDevelopmentExpense ;
+        link:order 200.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/17> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:OperatingIncomeLoss ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:OperatingExpenses ;
+        link:order 200.0 ;
+        link:weight -1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/18> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:NonoperatingIncomeExpense ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:GainLossOnDispositionOfAssets ;
+        link:order 300.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/19> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:OperatingExpenses ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:DepreciationDepletionAndAmortization ;
+        link:order 300.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/2> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:IncomeLossFromContinuingOperations ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest ;
+        link:order 100.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/20> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:NonoperatingIncomeExpense ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:OtherNonoperatingIncomeExpense ;
+        link:order 400.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/21> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:OperatingExpenses ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:OtherCostAndExpenseOperating ;
+        link:order 400.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/22> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:NonoperatingIncomeExpense ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:ForeignCurrencyTransactionGainLossBeforeTax ;
+        link:order 403.3333 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/23> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:OperatingExpenses ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:RestructuringCharges ;
+        link:order 403.3333 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/24> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:NonoperatingIncomeExpense ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:GainsLossesOnExtinguishmentOfDebt ;
+        link:order 406.6667 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/25> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:OperatingExpenses ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:AssetImpairmentCharges ;
+        link:order 406.6667 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/3> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:OperatingIncomeLoss ;
+        link:order 100.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/4> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:NetIncomeLoss ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:IncomeLossFromContinuingOperations ;
+        link:order 100.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/5> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:NonoperatingIncomeExpense ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:InvestmentIncomeInterest ;
+        link:order 100.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/6> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:OperatingExpenses ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:GeneralAndAdministrativeExpense ;
+        link:order 100.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/7> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:OperatingIncomeLoss ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:GrossProfit ;
+        link:order 100.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/8> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:Revenues ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax ;
+        link:order 100.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/9> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:OperatingExpenses ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep> ;
+        xlink:to rs-gaap:SellingAndMarketingExpense ;
+        link:order 150.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/0> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:NetCashProvidedByUsedInOperatingActivities ;
+        link:order 100.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/1> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:NetCashProvidedByUsedInInvestingActivities ;
+        link:order 200.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/2> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:NetCashProvidedByUsedInFinancingActivities ;
+        link:order 300.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/3> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect> ;
+        xlink:to rs-gaap:EffectOfExchangeRateOnCash ;
+        link:order 400.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/0> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:Assets ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:AssetsCurrent ;
+        link:order 100.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/1> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:AssetsCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:CashAndCashEquivalentsAtCarryingValue ;
+        link:order 100.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/10> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:Assets ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:AssetsNoncurrent ;
+        link:order 200.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/11> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:AssetsCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:ReceivablesNetCurrent ;
+        link:order 200.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/12> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:AssetsNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:Goodwill ;
+        link:order 200.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/13> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:Liabilities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:LiabilitiesNoncurrent ;
+        link:order 200.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/14> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:LiabilitiesAndStockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:StockholdersEquity ;
+        link:order 200.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/15> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:LiabilitiesCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:DebtCurrent ;
+        link:order 200.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/16> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:LiabilitiesNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:DeferredIncomeTaxLiabilitiesNet ;
+        link:order 200.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/17> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:StockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:PreferredStockValue ;
+        link:order 200.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/18> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:AssetsNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:IntangibleAssetsNetExcludingGoodwill ;
+        link:order 250.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/19> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:LiabilitiesCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:LongTermDebtCurrent ;
+        link:order 250.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/2> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:AssetsNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:PropertyPlantAndEquipmentNet ;
+        link:order 100.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/20> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:AssetsCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings ;
+        link:order 300.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/21> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:AssetsNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:LongTermInvestmentsAndReceivablesNet ;
+        link:order 300.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/22> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:LiabilitiesCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:DeferredRevenueCurrent ;
+        link:order 300.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/23> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:LiabilitiesNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:DeferredRevenueNoncurrent ;
+        link:order 300.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/24> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:StockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:AdditionalPaidInCapital ;
+        link:order 300.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/25> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:AssetsCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:PrepaidExpenseCurrent ;
+        link:order 400.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/26> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:AssetsNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:OperatingLeaseRightOfUseAsset ;
+        link:order 400.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/27> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:LiabilitiesCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:FinanceLeaseLiabilityCurrent ;
+        link:order 400.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/28> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:LiabilitiesNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:OperatingLeaseLiabilityNoncurrent ;
+        link:order 400.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/29> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:StockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:RetainedEarningsAccumulatedDeficit ;
+        link:order 400.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/3> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:Liabilities ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:LiabilitiesCurrent ;
+        link:order 100.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/30> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:AssetsCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:RestrictedCashAndInvestmentsCurrent ;
+        link:order 500.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/31> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:AssetsNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:FinanceLeaseRightOfUseAsset ;
+        link:order 500.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/32> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:LiabilitiesCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:OtherLiabilitiesCurrent ;
+        link:order 500.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/33> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:LiabilitiesNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:OtherLiabilitiesNoncurrent ;
+        link:order 500.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/34> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:StockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:AccumulatedOtherComprehensiveIncomeLossNetOfTax ;
+        link:order 500.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/35> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:AssetsCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:OtherAssetsCurrent ;
+        link:order 600.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/36> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:AssetsNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:OtherAssetsNoncurrent ;
+        link:order 600.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/37> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:StockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:TreasuryStockValue ;
+        link:order 600.0 ;
+        link:weight -1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/4> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:LiabilitiesAndStockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:Liabilities ;
+        link:order 100.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/5> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:LiabilitiesCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:AccountsPayableCurrent ;
+        link:order 100.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/6> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:LiabilitiesNoncurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:LongTermDebtAndCapitalLeaseObligations ;
+        link:order 100.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/7> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:StockholdersEquity ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:CommonStockValue ;
+        link:order 100.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/8> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:AssetsCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:ShortTermInvestments ;
+        link:order 150.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/9> a rs:Association ;
+        xlink:arcrole <http://www.xbrl.org/2003/arcrole/summation-item> ;
+        xlink:from rs-gaap:LiabilitiesCurrent ;
+        xlink:role <https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified> ;
+        xlink:to rs-gaap:AccruedLiabilitiesCurrent ;
+        link:order 150.0 ;
+        link:weight 1.0 ;
+        rs:associationType "calculation" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> rs:hasAssociation <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/0>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/1>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/10>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/11>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/12>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/13>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/14>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/15>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/16>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/17>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/18>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/19>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/2>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/20>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/21>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/22>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/23>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/24>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/25>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/3>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/4>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/5>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/6>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/7>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/8>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/9> .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> rs:hasAssociation <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/0>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/1>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/2>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/3> .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> rs:hasAssociation <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/0>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/1>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/10>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/11>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/12>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/13>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/14>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/15>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/16>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/17>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/18>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/19>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/2>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/20>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/21>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/22>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/23>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/24>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/25>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/26>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/27>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/28>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/29>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/3>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/30>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/31>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/32>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/33>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/34>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/35>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/36>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/37>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/4>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/5>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/6>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/7>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/8>,
+            <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/9> .
+}
+
+<https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM#scene> {
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/fact/fact_01KVF987AQFJ05VRCK1T2RVXVB> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:AccountsPayableCurrent ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/entity/entity_kg19ede9348fb40461119b> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF987AKGKJ5M2RR990D4NKJ> ;
+        rs:internalId "fact_01KVF987AQFJ05VRCK1T2RVXVB" ;
+        rs:numericValue 2689452.3100000005 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/period/p_1> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/fact/fact_01KVF987AQFJ05VRCK1T2RVXVC> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:AdditionalPaidInCapital ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/entity/entity_kg19ede9348fb40461119b> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF987AKGKJ5M2RR990D4NKJ> ;
+        rs:internalId "fact_01KVF987AQFJ05VRCK1T2RVXVC" ;
+        rs:numericValue 1407646.64 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/period/p_1> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/fact/fact_01KVF987AQFJ05VRCK1T2RVXVD> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:CashAndCashEquivalentsAtCarryingValue ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/entity/entity_kg19ede9348fb40461119b> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF987AKGKJ5M2RR990D4NKJ> ;
+        rs:internalId "fact_01KVF987AQFJ05VRCK1T2RVXVD" ;
+        rs:numericValue -648551.94 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/period/p_1> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/fact/fact_01KVF987AQFJ05VRCK1T2RVXVE> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:CostOfGoodsAndServicesSold ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/entity/entity_kg19ede9348fb40461119b> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF987AKGKJ5M2RR990D4NKK> ;
+        rs:internalId "fact_01KVF987AQFJ05VRCK1T2RVXVE" ;
+        rs:numericValue 886041.1799999999 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/fact/fact_01KVF987AQFJ05VRCK1T2RVXVF> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:DepreciationDepletionAndAmortization ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/entity/entity_kg19ede9348fb40461119b> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF987AKGKJ5M2RR990D4NKM> ;
+        rs:internalId "fact_01KVF987AQFJ05VRCK1T2RVXVF" ;
+        rs:numericValue 21428.16 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/fact/fact_01KVF987AQFJ05VRCK1T2RVXVG> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:DepreciationDepletionAndAmortization ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/entity/entity_kg19ede9348fb40461119b> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF987AKGKJ5M2RR990D4NKK> ;
+        rs:internalId "fact_01KVF987AQFJ05VRCK1T2RVXVG" ;
+        rs:numericValue 21428.16 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/fact/fact_01KVF987AQFJ05VRCK1T2RVXVH> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:GeneralAndAdministrativeExpense ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/entity/entity_kg19ede9348fb40461119b> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF987AKGKJ5M2RR990D4NKK> ;
+        rs:internalId "fact_01KVF987AQFJ05VRCK1T2RVXVH" ;
+        rs:numericValue 3049867.27 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/fact/fact_01KVF987AQFJ05VRCK1T2RVXVJ> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:InterestExpense ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/entity/entity_kg19ede9348fb40461119b> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF987AKGKJ5M2RR990D4NKK> ;
+        rs:internalId "fact_01KVF987AQFJ05VRCK1T2RVXVJ" ;
+        rs:numericValue -2165.929999999993 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/fact/fact_01KVF987AQFJ05VRCK1T2RVXVK> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/entity/entity_kg19ede9348fb40461119b> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF987AKGKJ5M2RR990D4NKJ> ;
+        rs:internalId "fact_01KVF987AQFJ05VRCK1T2RVXVK" ;
+        rs:numericValue 451842.18999999994 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/period/p_1> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/fact/fact_01KVF987AQFJ05VRCK1T2RVXVM> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:LongTermDebtAndCapitalLeaseObligations ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/entity/entity_kg19ede9348fb40461119b> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF987AKGKJ5M2RR990D4NKJ> ;
+        rs:internalId "fact_01KVF987AQFJ05VRCK1T2RVXVM" ;
+        rs:numericValue 338349.05 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/period/p_1> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/fact/fact_01KVF987AQFJ05VRCK1T2RVXVN> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:PropertyPlantAndEquipmentNet ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/entity/entity_kg19ede9348fb40461119b> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF987AKGKJ5M2RR990D4NKJ> ;
+        rs:internalId "fact_01KVF987AQFJ05VRCK1T2RVXVN" ;
+        rs:numericValue 1245567.1600000001 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/period/p_1> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/fact/fact_01KVF987AQFJ05VRCK1T2RVXVP> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:ReceivablesNetCurrent ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/entity/entity_kg19ede9348fb40461119b> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF987AKGKJ5M2RR990D4NKJ> ;
+        rs:internalId "fact_01KVF987AQFJ05VRCK1T2RVXVP" ;
+        rs:numericValue 2035468.27 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/period/p_1> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/fact/fact_01KVF987AQFJ05VRCK1T2RVXVQ> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:Revenues ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/entity/entity_kg19ede9348fb40461119b> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF987AKGKJ5M2RR990D4NKK> ;
+        rs:internalId "fact_01KVF987AQFJ05VRCK1T2RVXVQ" ;
+        rs:numericValue 2604048.36 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/fact/fact_01KVF987AQFJ05VRCK1T2RVXVR> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:RetainedEarningsAccumulatedDeficit ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/entity/entity_kg19ede9348fb40461119b> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF987AKGKJ5M2RR990D4NKJ> ;
+        rs:internalId "fact_01KVF987AQFJ05VRCK1T2RVXVR" ;
+        rs:numericValue -1351122.3200000003 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/period/p_1> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/fact/fact_01KVF987AQFJ05VRCK1T2RVXVS> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:AccountsPayableCurrent ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/entity/entity_kg19ede9348fb40461119b> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF987AKGKJ5M2RR990D4NKJ> ;
+        rs:internalId "fact_01KVF987AQFJ05VRCK1T2RVXVS" ;
+        rs:numericValue 1595349.42 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/period/p_3> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/fact/fact_01KVF987AQFJ05VRCK1T2RVXVT> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:AdditionalPaidInCapital ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/entity/entity_kg19ede9348fb40461119b> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF987AKGKJ5M2RR990D4NKJ> ;
+        rs:internalId "fact_01KVF987AQFJ05VRCK1T2RVXVT" ;
+        rs:numericValue 1407646.64 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/period/p_3> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/fact/fact_01KVF987AQFJ05VRCK1T2RVXVV> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:CashAndCashEquivalentsAtCarryingValue ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/entity/entity_kg19ede9348fb40461119b> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF987AKGKJ5M2RR990D4NKJ> ;
+        rs:internalId "fact_01KVF987AQFJ05VRCK1T2RVXVV" ;
+        rs:numericValue 398937.76 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/period/p_3> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/fact/fact_01KVF987AQFJ05VRCK1T2RVXVW> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/entity/entity_kg19ede9348fb40461119b> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF987AKGKJ5M2RR990D4NKJ> ;
+        rs:internalId "fact_01KVF987AQFJ05VRCK1T2RVXVW" ;
+        rs:numericValue 467010.2 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/period/p_3> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/fact/fact_01KVF987AQFJ05VRCK1T2RVXVX> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:LongTermDebtAndCapitalLeaseObligations ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/entity/entity_kg19ede9348fb40461119b> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF987AKGKJ5M2RR990D4NKJ> ;
+        rs:internalId "fact_01KVF987AQFJ05VRCK1T2RVXVX" ;
+        rs:numericValue 361285.69 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/period/p_3> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/fact/fact_01KVF987AQFJ05VRCK1T2RVXVY> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:PropertyPlantAndEquipmentNet ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/entity/entity_kg19ede9348fb40461119b> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF987AKGKJ5M2RR990D4NKJ> ;
+        rs:internalId "fact_01KVF987AQFJ05VRCK1T2RVXVY" ;
+        rs:numericValue 1266995.3199999998 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/period/p_3> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/fact/fact_01KVF987AQFJ05VRCK1T2RVXVZ> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:ReceivablesNetCurrent ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/entity/entity_kg19ede9348fb40461119b> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF987AKGKJ5M2RR990D4NKJ> ;
+        rs:internalId "fact_01KVF987AQFJ05VRCK1T2RVXVZ" ;
+        rs:numericValue 1231338.4700000002 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/period/p_3> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/fact/fact_01KVF987AQFJ05VRCK1T2RVXW0> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:RetainedEarningsAccumulatedDeficit ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/entity/entity_kg19ede9348fb40461119b> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF987AKGKJ5M2RR990D4NKJ> ;
+        rs:internalId "fact_01KVF987AQFJ05VRCK1T2RVXW0" ;
+        rs:numericValue 0.0 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/period/p_3> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/fact/fact_01KVF987AQFJ05VRCK1T2RVXW1> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:NetIncomeLoss ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/entity/entity_kg19ede9348fb40461119b> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF987AKGKJ5M2RR990D4NKM> ;
+        rs:internalId "fact_01KVF987AQFJ05VRCK1T2RVXW1" ;
+        rs:numericValue -1351122.3199999998 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/fact/fact_01KVF987AQFJ05VRCK1T2RVXW2> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:NetIncomeLoss ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/entity/entity_kg19ede9348fb40461119b> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF987AKGKJ5M2RR990D4NKK> ;
+        rs:internalId "fact_01KVF987AQFJ05VRCK1T2RVXW2" ;
+        rs:numericValue -1351122.3199999998 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/fact/fact_01KVF987AQFJ05VRCK1T2RVXW3> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:NetIncomeLoss ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/entity/entity_kg19ede9348fb40461119b> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF987AKGKJ5M2RR990D4NKN> ;
+        rs:internalId "fact_01KVF987AQFJ05VRCK1T2RVXW3" ;
+        rs:numericValue -1351122.3199999998 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/structure/0b179e5c-5f02-506d-b8d5-860cb10c7694> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/fact/fact_01KVF987AQFJ05VRCK1T2RVXW4> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:IncreaseDecreaseInInventories ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/entity/entity_kg19ede9348fb40461119b> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF987AKGKJ5M2RR990D4NKM> ;
+        rs:internalId "fact_01KVF987AQFJ05VRCK1T2RVXW4" ;
+        rs:numericValue 15168.010000000068 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/fact/fact_01KVF987AQFJ05VRCK1T2RVXW5> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:IncreaseDecreaseInAccountsReceivable ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/entity/entity_kg19ede9348fb40461119b> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF987AKGKJ5M2RR990D4NKM> ;
+        rs:internalId "fact_01KVF987AQFJ05VRCK1T2RVXW5" ;
+        rs:numericValue -804129.7999999998 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/fact/fact_01KVF987AQFJ05VRCK1T2RVXW6> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:IncreaseDecreaseInOtherOperatingCapitalNet ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/entity/entity_kg19ede9348fb40461119b> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF987AKGKJ5M2RR990D4NKM> ;
+        rs:internalId "fact_01KVF987AQFJ05VRCK1T2RVXW6" ;
+        rs:numericValue 1071166.2499999998 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/fact/fact_01KVF987AQFJ05VRCK1T2RVXW7> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:LiabilitiesCurrent ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/entity/entity_kg19ede9348fb40461119b> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF987AKGKJ5M2RR990D4NKJ> ;
+        rs:internalId "fact_01KVF987AQFJ05VRCK1T2RVXW7" ;
+        rs:numericValue 2689452.3100000005 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/period/p_1> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/fact/fact_01KVF987AQFJ05VRCK1T2RVXW8> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:Assets ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/entity/entity_kg19ede9348fb40461119b> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF987AKGKJ5M2RR990D4NKJ> ;
+        rs:internalId "fact_01KVF987AQFJ05VRCK1T2RVXW8" ;
+        rs:numericValue 3084325.68 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/period/p_1> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/fact/fact_01KVF987AQFJ05VRCK1T2RVXW9> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/entity/entity_kg19ede9348fb40461119b> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF987AKGKJ5M2RR990D4NKM> ;
+        rs:internalId "fact_01KVF987AQFJ05VRCK1T2RVXW9" ;
+        rs:numericValue -1047489.6999999998 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/fact/fact_01KVF987AQFJ05VRCK1T2RVXWA> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:LiabilitiesNoncurrent ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/entity/entity_kg19ede9348fb40461119b> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF987AKGKJ5M2RR990D4NKJ> ;
+        rs:internalId "fact_01KVF987AQFJ05VRCK1T2RVXWA" ;
+        rs:numericValue 338349.05 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/period/p_1> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/fact/fact_01KVF987AQFJ05VRCK1T2RVXWB> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:AssetsCurrent ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/entity/entity_kg19ede9348fb40461119b> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF987AKGKJ5M2RR990D4NKJ> ;
+        rs:internalId "fact_01KVF987AQFJ05VRCK1T2RVXWB" ;
+        rs:numericValue 1838758.52 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/period/p_1> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/fact/fact_01KVF987AQFJ05VRCK1T2RVXWC> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:NetCashProvidedByUsedInOperatingActivities ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/entity/entity_kg19ede9348fb40461119b> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF987AKGKJ5M2RR990D4NKM> ;
+        rs:internalId "fact_01KVF987AQFJ05VRCK1T2RVXWC" ;
+        rs:numericValue -1047489.6999999998 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/fact/fact_01KVF987AQFJ05VRCK1T2RVXWD> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:Liabilities ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/entity/entity_kg19ede9348fb40461119b> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF987AKGKJ5M2RR990D4NKJ> ;
+        rs:internalId "fact_01KVF987AQFJ05VRCK1T2RVXWD" ;
+        rs:numericValue 3027801.3600000003 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/period/p_1> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/fact/fact_01KVF987AQFJ05VRCK1T2RVXWE> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:NonoperatingIncomeExpense ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/entity/entity_kg19ede9348fb40461119b> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF987AKGKJ5M2RR990D4NKK> ;
+        rs:internalId "fact_01KVF987AQFJ05VRCK1T2RVXWE" ;
+        rs:numericValue 2165.929999999993 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/fact/fact_01KVF987AQFJ05VRCK1T2RVXWF> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/entity/entity_kg19ede9348fb40461119b> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF987AKGKJ5M2RR990D4NKK> ;
+        rs:internalId "fact_01KVF987AQFJ05VRCK1T2RVXWF" ;
+        rs:numericValue -1351122.3200000003 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/fact/fact_01KVF987AQFJ05VRCK1T2RVXWG> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:LiabilitiesAndStockholdersEquity ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/entity/entity_kg19ede9348fb40461119b> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF987AKGKJ5M2RR990D4NKJ> ;
+        rs:internalId "fact_01KVF987AQFJ05VRCK1T2RVXWG" ;
+        rs:numericValue 3084325.6799999997 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/period/p_1> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/fact/fact_01KVF987AQFJ05VRCK1T2RVXWH> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:StockholdersEquity ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/entity/entity_kg19ede9348fb40461119b> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF987AKGKJ5M2RR990D4NKN> ;
+        rs:internalId "fact_01KVF987AQFJ05VRCK1T2RVXWH" ;
+        rs:numericValue 56524.3199999996 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/period/p_1> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/structure/0b179e5c-5f02-506d-b8d5-860cb10c7694> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/fact/fact_01KVF987AQFJ05VRCK1T2RVXWJ> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:StockholdersEquity ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/entity/entity_kg19ede9348fb40461119b> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF987AKGKJ5M2RR990D4NKJ> ;
+        rs:internalId "fact_01KVF987AQFJ05VRCK1T2RVXWJ" ;
+        rs:numericValue 56524.3199999996 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/period/p_1> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/fact/fact_01KVF987AQFJ05VRCK1T2RVXWK> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:AssetsNoncurrent ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/entity/entity_kg19ede9348fb40461119b> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF987AKGKJ5M2RR990D4NKJ> ;
+        rs:internalId "fact_01KVF987AQFJ05VRCK1T2RVXWK" ;
+        rs:numericValue 1245567.1600000001 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/period/p_1> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/fact/fact_01KVF987AQFJ05VRCK1T2RVXWM> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:OperatingExpenses ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/entity/entity_kg19ede9348fb40461119b> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF987AKGKJ5M2RR990D4NKK> ;
+        rs:internalId "fact_01KVF987AQFJ05VRCK1T2RVXWM" ;
+        rs:numericValue 3071295.43 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/fact/fact_01KVF987AQFJ05VRCK1T2RVXWN> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:OperatingIncomeLoss ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/entity/entity_kg19ede9348fb40461119b> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF987AKGKJ5M2RR990D4NKK> ;
+        rs:internalId "fact_01KVF987AQFJ05VRCK1T2RVXWN" ;
+        rs:numericValue -1353288.2500000002 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/fact/fact_01KVF987AQFJ05VRCK1T2RVXWP> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:CostOfRevenue ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/entity/entity_kg19ede9348fb40461119b> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF987AKGKJ5M2RR990D4NKK> ;
+        rs:internalId "fact_01KVF987AQFJ05VRCK1T2RVXWP" ;
+        rs:numericValue 886041.1799999999 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/fact/fact_01KVF987AQFJ05VRCK1T2RVXWQ> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:GrossProfit ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/entity/entity_kg19ede9348fb40461119b> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF987AKGKJ5M2RR990D4NKK> ;
+        rs:internalId "fact_01KVF987AQFJ05VRCK1T2RVXWQ" ;
+        rs:numericValue 1718007.18 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/fact/fact_01KVF987AQFJ05VRCK1T2RVXWR> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:IncomeLossFromContinuingOperations ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/entity/entity_kg19ede9348fb40461119b> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF987AKGKJ5M2RR990D4NKK> ;
+        rs:internalId "fact_01KVF987AQFJ05VRCK1T2RVXWR" ;
+        rs:numericValue -1351122.3200000003 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/period/p_2> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/fact/fact_01KVF987AQFJ05VRCK1T2RVXWS> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:LiabilitiesCurrent ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/entity/entity_kg19ede9348fb40461119b> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF987AKGKJ5M2RR990D4NKJ> ;
+        rs:internalId "fact_01KVF987AQFJ05VRCK1T2RVXWS" ;
+        rs:numericValue 1595349.42 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/period/p_3> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/fact/fact_01KVF987AQFJ05VRCK1T2RVXWT> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:Assets ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/entity/entity_kg19ede9348fb40461119b> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF987AKGKJ5M2RR990D4NKJ> ;
+        rs:internalId "fact_01KVF987AQFJ05VRCK1T2RVXWT" ;
+        rs:numericValue 3364281.75 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/period/p_3> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/fact/fact_01KVF987AQFJ05VRCK1T2RVXWV> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:LiabilitiesNoncurrent ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/entity/entity_kg19ede9348fb40461119b> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF987AKGKJ5M2RR990D4NKJ> ;
+        rs:internalId "fact_01KVF987AQFJ05VRCK1T2RVXWV" ;
+        rs:numericValue 361285.69 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/period/p_3> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/fact/fact_01KVF987AQFJ05VRCK1T2RVXWW> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:AssetsCurrent ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/entity/entity_kg19ede9348fb40461119b> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF987AKGKJ5M2RR990D4NKJ> ;
+        rs:internalId "fact_01KVF987AQFJ05VRCK1T2RVXWW" ;
+        rs:numericValue 2097286.43 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/period/p_3> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/fact/fact_01KVF987AQFJ05VRCK1T2RVXWX> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:Liabilities ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/entity/entity_kg19ede9348fb40461119b> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF987AKGKJ5M2RR990D4NKJ> ;
+        rs:internalId "fact_01KVF987AQFJ05VRCK1T2RVXWX" ;
+        rs:numericValue 1956635.1099999999 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/period/p_3> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/fact/fact_01KVF987AQFJ05VRCK1T2RVXWY> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:LiabilitiesAndStockholdersEquity ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/entity/entity_kg19ede9348fb40461119b> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF987AKGKJ5M2RR990D4NKJ> ;
+        rs:internalId "fact_01KVF987AQFJ05VRCK1T2RVXWY" ;
+        rs:numericValue 3364281.75 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/period/p_3> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/fact/fact_01KVF987AQFJ05VRCK1T2RVXWZ> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:StockholdersEquity ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/entity/entity_kg19ede9348fb40461119b> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF987AKGKJ5M2RR990D4NKN> ;
+        rs:internalId "fact_01KVF987AQFJ05VRCK1T2RVXWZ" ;
+        rs:numericValue 1407646.64 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/period/p_3> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/structure/0b179e5c-5f02-506d-b8d5-860cb10c7694> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/fact/fact_01KVF987AQFJ05VRCK1T2RVXX0> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:StockholdersEquity ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/entity/entity_kg19ede9348fb40461119b> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF987AKGKJ5M2RR990D4NKJ> ;
+        rs:internalId "fact_01KVF987AQFJ05VRCK1T2RVXX0" ;
+        rs:numericValue 1407646.64 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/period/p_3> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/fact/fact_01KVF987AQFJ05VRCK1T2RVXX1> a rs:Fact ;
+        rs:decimals "INF" ;
+        rs:element rs-gaap:AssetsNoncurrent ;
+        rs:entity <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/entity/entity_kg19ede9348fb40461119b> ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF987AKGKJ5M2RR990D4NKJ> ;
+        rs:internalId "fact_01KVF987AQFJ05VRCK1T2RVXX1" ;
+        rs:numericValue 1266995.3199999998 ;
+        rs:period <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/period/p_3> ;
+        rs:structure <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> ;
+        rs:unit <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/unit/u_USD> .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/ib/0b179e5c-5f02-506d-b8d5-860cb10c7694> a rs:InformationBlock ;
+        skos:prefLabel "rs-gaap — Statement of Changes in Equity — Roll Forward (Total)" ;
+        rs:blockType "equity_statement" ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF987AKGKJ5M2RR990D4NKN> ;
+        rs:internalId "0b179e5c-5f02-506d-b8d5-860cb10c7694" ;
+        rs:taxonomyId "cf7178a0-e2d4-58df-995a-2f0233d15466" ;
+        rs:taxonomyName "rs-gaap-presentation v1" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/ib/47cd6544-03d1-5bc1-8c28-31c0cfa450f9> a rs:InformationBlock ;
+        skos:prefLabel "rs-gaap — Income Statement — Multi-step" ;
+        rs:blockType "income_statement" ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF987AKGKJ5M2RR990D4NKK> ;
+        rs:internalId "47cd6544-03d1-5bc1-8c28-31c0cfa450f9" ;
+        rs:taxonomyId "cf7178a0-e2d4-58df-995a-2f0233d15466" ;
+        rs:taxonomyName "rs-gaap-presentation v1" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/ib/5473639a-2dac-56a6-b9e5-38480ea38bc1> a rs:InformationBlock ;
+        skos:prefLabel "rs-gaap — Cash Flow Statement — Indirect" ;
+        rs:blockType "cash_flow_statement" ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF987AKGKJ5M2RR990D4NKM> ;
+        rs:internalId "5473639a-2dac-56a6-b9e5-38480ea38bc1" ;
+        rs:taxonomyId "cf7178a0-e2d4-58df-995a-2f0233d15466" ;
+        rs:taxonomyName "rs-gaap-presentation v1" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/ib/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d> a rs:InformationBlock ;
+        skos:prefLabel "rs-gaap — Balance Sheet — Classified" ;
+        rs:blockType "balance_sheet" ;
+        rs:factSet <https://robosystems.ai/factset/fs_01KVF987AKGKJ5M2RR990D4NKJ> ;
+        rs:internalId "b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d" ;
+        rs:taxonomyId "cf7178a0-e2d4-58df-995a-2f0233d15466" ;
+        rs:taxonomyName "rs-gaap-presentation v1" .
+
+    rs-gaap:IncreaseDecreaseInAccountsReceivable a rs:Element ;
+        skos:prefLabel "Increase (Decrease) in Accounts Receivable" ;
+        xbrli:balance "credit" ;
+        xbrli:periodType "duration" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "93175d59-983c-5012-910f-3dfbf07ce327" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:IncreaseDecreaseInInventories a rs:Element ;
+        skos:prefLabel "Increase (Decrease) in Inventories" ;
+        xbrli:balance "credit" ;
+        xbrli:periodType "duration" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "c8b0722b-7993-592f-8ef1-5b0964ac8a10" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:IncreaseDecreaseInOtherOperatingCapitalNet a rs:Element ;
+        skos:prefLabel "Increase (Decrease) in Other Operating Assets and Liabilities, Net" ;
+        xbrli:balance "credit" ;
+        xbrli:periodType "duration" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "a3227fb2-202b-51db-9574-4e60db03c04f" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:CostOfGoodsAndServicesSold a rs:Element ;
+        skos:prefLabel "Cost of Product and Service Sold" ;
+        xbrli:balance "debit" ;
+        xbrli:periodType "duration" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "5ca0e51f-dff1-5c2b-94f5-26620852a5f9" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:GeneralAndAdministrativeExpense a rs:Element ;
+        skos:prefLabel "General and Administrative Expense" ;
+        xbrli:balance "debit" ;
+        xbrli:periodType "duration" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "f92ba8cb-7ae2-5d40-9d15-9a94e9e3aed4" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:InterestExpense a rs:Element ;
+        skos:prefLabel "Interest Expense, Operating and Nonoperating" ;
+        xbrli:balance "debit" ;
+        xbrli:periodType "duration" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "890e4f8c-8fed-57e2-96fd-e70455201b11" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:AccountsPayableCurrent a rs:Element ;
+        skos:prefLabel "Accounts Payable, Current" ;
+        xbrli:balance "credit" ;
+        xbrli:periodType "instant" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "9ddbc9d7-c769-5800-8f65-1089d476e5c9" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:AdditionalPaidInCapital a rs:Element ;
+        skos:prefLabel "Additional Paid in Capital" ;
+        xbrli:balance "credit" ;
+        xbrli:periodType "instant" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "6146605c-0d63-51e1-a523-3450d6abaca3" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:CashAndCashEquivalentsAtCarryingValue a rs:Element ;
+        skos:prefLabel "Cash and Cash Equivalents, at Carrying Value" ;
+        xbrli:balance "debit" ;
+        xbrli:periodType "instant" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "20a6586b-880a-5745-94db-e23d397eb5e1" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings a rs:Element ;
+        skos:prefLabel "Inventory, Net of Allowances, Customer Advances and Progress Billings" ;
+        xbrli:balance "debit" ;
+        xbrli:periodType "instant" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "4afa5950-85ac-5a85-a9cb-01c387c6ab08" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:LongTermDebtAndCapitalLeaseObligations a rs:Element ;
+        skos:prefLabel "Long-Term Debt and Lease Obligation" ;
+        xbrli:balance "credit" ;
+        xbrli:periodType "instant" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "091373d9-8a82-51bd-adf8-d09b73beb32e" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:PropertyPlantAndEquipmentNet a rs:Element ;
+        skos:prefLabel "Property, Plant and Equipment, Net" ;
+        xbrli:balance "debit" ;
+        xbrli:periodType "instant" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "288099af-5cbb-5f78-8f8a-1a85675fb661" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:ReceivablesNetCurrent a rs:Element ;
+        skos:prefLabel "Receivables, Net, Current" ;
+        xbrli:balance "debit" ;
+        xbrli:periodType "instant" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "44686df3-3871-5c1f-8a08-fc542d69dfa0" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:RetainedEarningsAccumulatedDeficit a rs:Element ;
+        skos:prefLabel "Retained Earnings (Accumulated Deficit)" ;
+        xbrli:balance "credit" ;
+        xbrli:periodType "instant" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "a9c87d60-a1e5-506b-a27e-cbf9e14e5113" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:DepreciationDepletionAndAmortization a rs:Element ;
+        skos:prefLabel "Depreciation, Depletion and Amortization" ;
+        xbrli:balance "debit" ;
+        xbrli:periodType "duration" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "189a099a-7512-5144-9215-65d837c2c3b5" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:GrossProfit a rs:Element ;
+        skos:prefLabel "Gross Profit" ;
+        xbrli:balance "credit" ;
+        xbrli:periodType "duration" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "a92b3181-9fe7-543c-81d9-13ebd12bbefa" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:IncomeLossFromContinuingOperations a rs:Element ;
+        skos:prefLabel "Income (Loss) from Continuing Operations, Net of Tax, Attributable to Parent" ;
+        xbrli:balance "credit" ;
+        xbrli:periodType "duration" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "d60cabda-7060-5aff-ac98-96371606a738" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest a rs:Element ;
+        skos:prefLabel "Income (Loss) from Continuing Operations before Income Taxes, Noncontrolling Interest" ;
+        xbrli:balance "credit" ;
+        xbrli:periodType "duration" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "6b0b414f-0c76-54f0-8e51-cf53db59ca24" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:OperatingIncomeLoss a rs:Element ;
+        skos:prefLabel "Operating Income (Loss)" ;
+        xbrli:balance "credit" ;
+        xbrli:periodType "duration" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "16780828-0201-5609-b572-fbe3ebfcb177" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:Revenues a rs:Element ;
+        skos:prefLabel "Revenues" ;
+        xbrli:balance "credit" ;
+        xbrli:periodType "duration" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "b26a6cd4-072f-5bf2-b5d3-ebf928150d6c" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:Assets a rs:Element ;
+        skos:prefLabel "Assets" ;
+        xbrli:balance "debit" ;
+        xbrli:periodType "instant" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "a1f04756-41d8-5d35-b821-23aa2f3b2fae" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:LiabilitiesAndStockholdersEquity a rs:Element ;
+        skos:prefLabel "Liabilities and Equity" ;
+        xbrli:balance "credit" ;
+        xbrli:periodType "instant" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "30b2801e-e682-5298-82e6-3670e1d508f1" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:CostOfRevenue a rs:Element ;
+        skos:prefLabel "Cost of Revenue" ;
+        xbrli:balance "debit" ;
+        xbrli:periodType "duration" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "12ab7417-5324-55d6-946e-2456adba47c5" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:Liabilities a rs:Element ;
+        skos:prefLabel "Liabilities" ;
+        xbrli:balance "credit" ;
+        xbrli:periodType "instant" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "7af273ac-1cba-5fb3-a1c9-5c5d8fdb9bdf" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:NetIncomeLoss a rs:Element ;
+        skos:prefLabel "Net Income (Loss) Attributable to Parent" ;
+        xbrli:balance "credit" ;
+        xbrli:periodType "duration" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "27a05717-2370-51c2-a924-db5cbcb48219" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease a rs:Element ;
+        skos:prefLabel "Cash and Cash Equivalents, Period Increase (Decrease)" ;
+        xbrli:balance "debit" ;
+        xbrli:periodType "duration" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "353f790f-1ed1-5b91-880d-8029b4b687cf" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:NetCashProvidedByUsedInOperatingActivities a rs:Element ;
+        skos:prefLabel "Cash Provided by (Used in) Operating Activity, Including Discontinued Operation" ;
+        xbrli:balance "debit" ;
+        xbrli:periodType "duration" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "57ccbf45-c970-5bcd-a381-44d96b6b6d94" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:LiabilitiesNoncurrent a rs:Element ;
+        skos:prefLabel "Liabilities, Noncurrent" ;
+        xbrli:balance "credit" ;
+        xbrli:periodType "instant" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "f41fe34d-88ea-5e20-a781-2d3e256a6abf" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:NonoperatingIncomeExpense a rs:Element ;
+        skos:prefLabel "Nonoperating Income (Expense)" ;
+        xbrli:balance "credit" ;
+        xbrli:periodType "duration" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "45aae2c2-fa56-50c9-b381-df8079e7d33a" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/period/p_1> a rs:Period ;
+        xbrli:instant "2028-12-31"^^xsd:date ;
+        xbrli:periodType "instant" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/period/p_3> a rs:Period ;
+        xbrli:instant "2023-12-31"^^xsd:date ;
+        xbrli:periodType "instant" .
+
+    rs-gaap:OperatingExpenses a rs:Element ;
+        skos:prefLabel "Operating Expenses" ;
+        xbrli:balance "debit" ;
+        xbrli:periodType "duration" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "71fcdebb-7145-5f76-b5e0-b4ccbf2c29d2" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:AssetsCurrent a rs:Element ;
+        skos:prefLabel "Assets, Current" ;
+        xbrli:balance "debit" ;
+        xbrli:periodType "instant" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "0fc9ab7e-c5ce-5277-9530-344cc127fe26" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:AssetsNoncurrent a rs:Element ;
+        skos:prefLabel "Assets, Noncurrent" ;
+        xbrli:balance "debit" ;
+        xbrli:periodType "instant" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "841cedeb-4cb0-532a-b0bd-c34846a13a8c" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    rs-gaap:LiabilitiesCurrent a rs:Element ;
+        skos:prefLabel "Liabilities, Current" ;
+        xbrli:balance "credit" ;
+        xbrli:periodType "instant" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "efb036ff-3f30-5deb-bee9-1af4cd4b9800" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/period/p_2> a rs:Period ;
+        xbrli:endDate "2028-12-31"^^xsd:date ;
+        xbrli:periodType "duration" ;
+        xbrli:startDate "2024-01-01"^^xsd:date .
+
+    rs-gaap:StockholdersEquity a rs:Element ;
+        skos:prefLabel "Stockholders' Equity Attributable to Parent" ;
+        xbrli:balance "credit" ;
+        xbrli:periodType "instant" ;
+        rs:abstract false ;
+        rs:elementType "concept" ;
+        rs:internalId "e3796201-9899-5b7b-9477-659550ba8e68" ;
+        rs:monetary true ;
+        rs:source "rs-gaap" ;
+        rs:substitutionGroup xbrli:item .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/entity/entity_kg19ede9348fb40461119b> a rs:Entity ;
+        skos:prefLabel "The World Online (Charlie Hoffman demo)" ;
+        rs:country "US" ;
+        rs:internalId "entity_kg19ede9348fb40461119b" ;
+        rs:legalName "The World Online (Charlie Hoffman demo)" .
+
+    <https://robosystems.ai/report/rpt_01KVF986ZHG0852N6R7P77VEYM/unit/u_USD> a rs:Unit ;
+        xbrli:measure iso4217:USD .
+}
+


### PR DESCRIPTION
## Summary

Extends the examples' DataBook converter to render each published report as a four-graph holon (scene / boundary / projection / lineage), derived **purely from the on-disk JSON-LD bundle** — no upstream or encoder change. Adds a sibling `.holon.trig` with real, resolvable named graphs so the holon is directly SPARQL-queryable with plain `rdflib`, with no triplestore or external tooling. Also a small README polish.

## Changes

### DataBook named-graph holon serialization (`examples/_common/databook.py`)

- **Scene RDF folded** into `<details>` blocks so the human-readable tables stay front-and-center (the RDF still travels in-file).
- **`graph:` holon map** in the frontmatter declaring `scene` / `boundary` / `projection` with resolvable IRIs and the versioned framework each derives from. `lineage` (the ledger) is marked **internal / unpublished** — a report is an aggregation of the books, not the books.
- **Sibling `<name>.holon.trig`** carrying three real named graphs (`<report>#scene` / `#boundary` / `#projection`), so the map's IRIs resolve to actual content. `scene` includes the `InformationBlock` nodes so facts group into their statement via the shared `factSet`.
- Regenerated the **seattle-method**, **roboledger**, and **world-online** sample databooks and added their `.holon.trig`.

### README polish

- Name LadybugDB explicitly in the infrastructure bullet.
- Drop the DuckDB-staging and Dagster-orchestration bullets from the headline feature list (both still covered under Architecture).
- Move the AI and SEC Shared Repository sections below Quick Start so the setup path comes first.

## Testing

- `uv run ruff check` / `ruff format` on the converter — clean; pre-commit hooks passed on both commits (0 errors).
- Regenerated all three sample databooks + `.holon.trig`; verified each trig round-trip parses with `rdflib` (3 named graphs each) and the fact → `InformationBlock` grouping is SPARQL-queryable via the shared `factSet`.
- `just test-all` (full unit suite): **not run** — change is confined to `examples/` demo tooling and generated sample artifacts; no production code, API, or migrations touched.

## Notes

- The demo generators (`download_bundles.py`, the two `main.py`) already call the converter, so a fresh demo run now emits the `.holon.trig` automatically — no further wiring needed.
