### PR TITLE
fix(otel): eliminate phantom request-volume; worker observability + DLQ alarm

### DIFF
--- a/.github/workflows/deploy-dagster.yml
+++ b/.github/workflows/deploy-dagster.yml
@@ -143,6 +143,11 @@ on:
         required: false
         type: string
         default: "false"
+      aws_sns_alert_email:
+        description: "Email for worker alerts (e.g. DLQ depth); empty disables alarm notifications"
+        required: false
+        type: string
+        default: ""
 
       # Cache Configuration
       valkey_url:
@@ -447,6 +452,7 @@ jobs:
                 ParameterKey=WorkerMinCount,ParameterValue=${{ inputs.worker_min_count }} \
                 ParameterKey=WorkerMaxCount,ParameterValue=${{ inputs.worker_max_count }} \
                 ParameterKey=WorkerAutoscalingEnabled,ParameterValue=${{ inputs.worker_autoscaling_enabled }} \
+                ParameterKey=SNSAlertEmail,ParameterValue=\"${{ inputs.aws_sns_alert_email }}\" \
                 ParameterKey=DatabaseEndpoint,ParameterValue=${{ inputs.database_endpoint }} \
                 ParameterKey=DatabasePort,ParameterValue=${{ inputs.database_port }} \
                 ParameterKey=DatabaseSecurityGroupId,ParameterValue=${{ inputs.database_sg_id }} \

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -627,6 +627,7 @@ jobs:
       worker_min_count: ${{ vars.WORKER_MIN_COUNT_PROD || '1' }}
       worker_max_count: ${{ vars.WORKER_MAX_COUNT_PROD || '5' }}
       worker_autoscaling_enabled: ${{ vars.WORKER_AUTOSCALING_ENABLED_PROD || 'false' }}
+      aws_sns_alert_email: ${{ vars.AWS_SNS_ALERT_EMAIL }}
       # Capacity Provider Configuration (Spot vs On-Demand)
       daemon_fargate_spot_weight: ${{ vars.DAGSTER_DAEMON_FARGATE_SPOT_WEIGHT_PROD || '0' }}
       webserver_fargate_spot_weight: ${{ vars.DAGSTER_WEBSERVER_FARGATE_SPOT_WEIGHT_PROD || '0' }}

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -644,6 +644,7 @@ jobs:
       worker_min_count: ${{ vars.WORKER_MIN_COUNT_STAGING || '1' }}
       worker_max_count: ${{ vars.WORKER_MAX_COUNT_STAGING || '5' }}
       worker_autoscaling_enabled: ${{ vars.WORKER_AUTOSCALING_ENABLED_STAGING || 'false' }}
+      aws_sns_alert_email: ${{ vars.AWS_SNS_ALERT_EMAIL }}
       # Capacity Provider Configuration (Spot vs On-Demand)
       daemon_fargate_spot_weight: ${{ vars.DAGSTER_DAEMON_FARGATE_SPOT_WEIGHT_STAGING || '80' }}
       webserver_fargate_spot_weight: ${{ vars.DAGSTER_WEBSERVER_FARGATE_SPOT_WEIGHT_STAGING || '80' }}

--- a/bin/tools/grafana/ops.json
+++ b/bin/tools/grafana/ops.json
@@ -43,7 +43,7 @@
         "content": "# API Observability",
         "mode": "markdown"
       },
-      "pluginVersion": "10.4.1",
+      "pluginVersion": "10.4.7",
       "title": " ",
       "transparent": true,
       "type": "text"
@@ -199,7 +199,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "10.4.1",
+      "pluginVersion": "10.4.7",
       "targets": [
         {
           "datasource": {
@@ -209,7 +209,7 @@
           "disableTextWrap": false,
           "editorMode": "builder",
           "exemplar": false,
-          "expr": "sum(rate(robosystems_api_requests_total{endpoint=~\"$endpoints\"}[5m])) * 5",
+          "expr": "sum(rate(robosystems_api_requests_total{endpoint=~\"$endpoints\"}[5m])) * 60",
           "format": "time_series",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
@@ -340,7 +340,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "10.4.1",
+      "pluginVersion": "10.4.7",
       "targets": [
         {
           "datasource": {
@@ -451,7 +451,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "topk(15, sum by(endpoint) (rate(robosystems_api_requests_total{endpoint=~\"$endpoints\"}[5m]))) * 5",
+          "expr": "topk(15, sum by(endpoint) (rate(robosystems_api_requests_total{endpoint=~\"$endpoints\"}[5m]))) * 60",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -514,7 +514,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "10.4.1",
+      "pluginVersion": "10.4.7",
       "targets": [
         {
           "datasource": {
@@ -624,7 +624,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "avg by(event_type) (topk(15, rate(robosystems_business_events_total{endpoint=~\"$endpoints\"}[5m]))) * 5",
+          "expr": "avg by(event_type) (topk(15, rate(robosystems_business_events_total{endpoint=~\"$endpoints\"}[5m]))) * 60",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -1871,7 +1871,7 @@
         "content": "# Container Services",
         "mode": "markdown"
       },
-      "pluginVersion": "10.4.1",
+      "pluginVersion": "10.4.7",
       "title": " ",
       "transparent": true,
       "type": "text"
@@ -2535,6 +2535,58 @@
           "region": "default",
           "sqlExpression": "",
           "statistic": "Average"
+        },
+        {
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "${cloudwatch}"
+          },
+          "dimensions": {
+            "ClusterName": "$dagster_cluster",
+            "TaskDefinitionFamily": "$dagster_worker_task"
+          },
+          "expression": "",
+          "hide": false,
+          "id": "",
+          "label": "",
+          "logGroups": [],
+          "matchExact": false,
+          "metricEditorMode": 0,
+          "metricName": "CpuUtilized",
+          "metricQueryType": 0,
+          "namespace": "ECS/ContainerInsights",
+          "period": "",
+          "queryMode": "Metrics",
+          "refId": "E",
+          "region": "default",
+          "sqlExpression": "",
+          "statistic": "Average"
+        },
+        {
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "${cloudwatch}"
+          },
+          "dimensions": {
+            "ClusterName": "$dagster_cluster",
+            "TaskDefinitionFamily": "$dagster_worker_task"
+          },
+          "expression": "",
+          "hide": false,
+          "id": "",
+          "label": "",
+          "logGroups": [],
+          "matchExact": false,
+          "metricEditorMode": 0,
+          "metricName": "CpuReserved",
+          "metricQueryType": 0,
+          "namespace": "ECS/ContainerInsights",
+          "period": "",
+          "queryMode": "Metrics",
+          "refId": "F",
+          "region": "default",
+          "sqlExpression": "",
+          "statistic": "Average"
         }
       ],
       "title": "Dagster CPU Utilization",
@@ -2544,9 +2596,9 @@
           "options": {
             "alias": "Run CPU Utilization",
             "binary": {
-              "left": "CpuUtilized",
+              "left": "robosystems-dagster-run-prod CpuUtilized",
               "operator": "/",
-              "right": "CpuReserved"
+              "right": "robosystems-dagster-run-prod CpuReserved"
             },
             "mode": "binary",
             "reduce": {
@@ -2560,6 +2612,37 @@
             "alias": "Run",
             "binary": {
               "left": "Run CPU Utilization",
+              "operator": "*",
+              "right": "100"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Worker CPU Utilized",
+            "binary": {
+              "left": "robosystems-worker-prod CpuUtilized",
+              "operator": "/",
+              "right": "robosystems-worker-prod CpuReserved"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": false
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Worker",
+            "binary": {
+              "left": "Worker CPU Utilized",
               "operator": "*",
               "right": "100"
             },
@@ -2585,10 +2668,27 @@
               "ECS/ContainerInsights robosystems-dagster-run-prod CpuReserved": true,
               "ECS/ContainerInsights robosystems-dagster-run-prod CpuUtilized": true,
               "Run CPU Utilization": true,
-              "Run Utilization": true
+              "Run Utilization": true,
+              "Worker CPU Utilized": true,
+              "robosystems-dagster-run-prod CpuReserved": true,
+              "robosystems-dagster-run-prod CpuUtilized": true,
+              "robosystems-worker-prod CpuReserved": true,
+              "robosystems-worker-prod CpuUtilized": true
             },
             "includeByName": {},
-            "indexByName": {},
+            "indexByName": {
+              "Daemon": 1,
+              "Run": 3,
+              "Run CPU Utilization": 9,
+              "Time": 0,
+              "Webserver": 2,
+              "Worker": 4,
+              "Worker CPU Utilized": 10,
+              "robosystems-dagster-run-prod CpuReserved": 6,
+              "robosystems-dagster-run-prod CpuUtilized": 5,
+              "robosystems-worker-prod CpuReserved": 8,
+              "robosystems-worker-prod CpuUtilized": 7
+            },
             "renameByName": {
               "AWS/ECS robosystems-dagster-daemon-${env} CPUUtilization": "Daemon",
               "AWS/ECS robosystems-dagster-webserver-${env} CPUUtilization": "Webserver",
@@ -2784,6 +2884,58 @@
           "region": "default",
           "sqlExpression": "",
           "statistic": "Maximum"
+        },
+        {
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "${cloudwatch}"
+          },
+          "dimensions": {
+            "ClusterName": "$dagster_cluster",
+            "TaskDefinitionFamily": "$dagster_worker_task"
+          },
+          "expression": "",
+          "hide": false,
+          "id": "",
+          "label": "Worker Memory Utilized",
+          "logGroups": [],
+          "matchExact": true,
+          "metricEditorMode": 0,
+          "metricName": "MemoryUtilized",
+          "metricQueryType": 0,
+          "namespace": "ECS/ContainerInsights",
+          "period": "",
+          "queryMode": "Metrics",
+          "refId": "E",
+          "region": "default",
+          "sqlExpression": "",
+          "statistic": "Maximum"
+        },
+        {
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "${cloudwatch}"
+          },
+          "dimensions": {
+            "ClusterName": "$dagster_cluster",
+            "TaskDefinitionFamily": "$dagster_worker_task"
+          },
+          "expression": "",
+          "hide": false,
+          "id": "",
+          "label": "Worker Memory Reserved",
+          "logGroups": [],
+          "matchExact": true,
+          "metricEditorMode": 0,
+          "metricName": "MemoryReserved",
+          "metricQueryType": 0,
+          "namespace": "ECS/ContainerInsights",
+          "period": "",
+          "queryMode": "Metrics",
+          "refId": "F",
+          "region": "default",
+          "sqlExpression": "",
+          "statistic": "Maximum"
         }
       ],
       "title": "Dagster Memory Utilization",
@@ -2819,6 +2971,36 @@
           }
         },
         {
+          "id": "calculateField",
+          "options": {
+            "alias": "Worker Memory Utilization",
+            "binary": {
+              "left": "Worker Memory Utilized",
+              "operator": "/",
+              "right": "Worker Memory Reserved"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Worker",
+            "binary": {
+              "left": "Worker Memory Utilization",
+              "operator": "*",
+              "right": "100"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
           "id": "organize",
           "options": {
             "excludeByName": {
@@ -2830,7 +3012,10 @@
               "ECS/ContainerInsights robosystems-dagster-run-${env} MemoryUtilized / ECS/ContainerInsights robosystems-dagster-run-${env} MemoryReserved": true,
               "Run Memory Reserved": true,
               "Run Memory Utilization": true,
-              "Run Memory Utilized": true
+              "Run Memory Utilized": true,
+              "Worker Memory Reserved": true,
+              "Worker Memory Utilization": true,
+              "Worker Memory Utilized": true
             },
             "includeByName": {},
             "indexByName": {},
@@ -2910,7 +3095,7 @@
       },
       "gridPos": {
         "h": 10,
-        "w": 12,
+        "w": 8,
         "x": 0,
         "y": 99
       },
@@ -2939,9 +3124,9 @@
           "expression": "",
           "hide": false,
           "id": "",
-          "label": "",
+          "label": "Task Count",
           "logGroups": [],
-          "matchExact": false,
+          "matchExact": true,
           "metricEditorMode": 0,
           "metricName": "TaskCount",
           "metricQueryType": 0,
@@ -2949,6 +3134,58 @@
           "period": "",
           "queryMode": "Metrics",
           "refId": "C",
+          "region": "default",
+          "sqlExpression": "",
+          "statistic": "Average"
+        },
+        {
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "${cloudwatch}"
+          },
+          "dimensions": {
+            "ClusterName": "$dagster_cluster",
+            "ServiceName": "robosystems-worker-prod"
+          },
+          "expression": "",
+          "hide": false,
+          "id": "",
+          "label": "Worker Desired",
+          "logGroups": [],
+          "matchExact": true,
+          "metricEditorMode": 0,
+          "metricName": "DesiredTaskCount",
+          "metricQueryType": 0,
+          "namespace": "ECS/ContainerInsights",
+          "period": "",
+          "queryMode": "Metrics",
+          "refId": "A",
+          "region": "default",
+          "sqlExpression": "",
+          "statistic": "Average"
+        },
+        {
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "${cloudwatch}"
+          },
+          "dimensions": {
+            "ClusterName": "$dagster_cluster",
+            "ServiceName": "robosystems-worker-prod"
+          },
+          "expression": "",
+          "hide": false,
+          "id": "",
+          "label": "Worker Running",
+          "logGroups": [],
+          "matchExact": true,
+          "metricEditorMode": 0,
+          "metricName": "RunningTaskCount",
+          "metricQueryType": 0,
+          "namespace": "ECS/ContainerInsights",
+          "period": "",
+          "queryMode": "Metrics",
+          "refId": "B",
           "region": "default",
           "sqlExpression": "",
           "statistic": "Average"
@@ -3014,14 +3251,145 @@
               }
             ]
           },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 8,
+        "y": 99
+      },
+      "id": 113,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "${cloudwatch}"
+          },
+          "dimensions": {},
+          "expression": "",
+          "hide": false,
+          "id": "",
+          "label": "Queue",
+          "logGroups": [],
+          "matchExact": true,
+          "metricEditorMode": 0,
+          "metricName": "QueueDepth",
+          "metricQueryType": 0,
+          "namespace": "$worker_queue_cloudwatch",
+          "period": "",
+          "queryMode": "Metrics",
+          "refId": "C",
+          "region": "default",
+          "sqlExpression": "",
+          "statistic": "Average"
+        },
+        {
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "${cloudwatch}"
+          },
+          "dimensions": {},
+          "expression": "",
+          "hide": false,
+          "id": "",
+          "label": "DLQ",
+          "logGroups": [],
+          "matchExact": true,
+          "metricEditorMode": 0,
+          "metricName": "DLQDepth",
+          "metricQueryType": 0,
+          "namespace": "$worker_queue_cloudwatch",
+          "period": "",
+          "queryMode": "Metrics",
+          "refId": "A",
+          "region": "default",
+          "sqlExpression": "",
+          "statistic": "Average"
+        }
+      ],
+      "title": "Worker Queue Depth",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "cloudwatch",
+        "uid": "${cloudwatch}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "vis": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
           "unit": "decbytes"
         },
         "overrides": []
       },
       "gridPos": {
         "h": 10,
-        "w": 12,
-        "x": 12,
+        "w": 8,
+        "x": 16,
         "y": 99
       },
       "id": 63,
@@ -3123,6 +3491,32 @@
           },
           "dimensions": {
             "ClusterName": "$dagster_cluster",
+            "TaskDefinitionFamily": "$dagster_worker_task"
+          },
+          "expression": "",
+          "hide": false,
+          "id": "",
+          "label": "Worker Bytes In",
+          "logGroups": [],
+          "matchExact": true,
+          "metricEditorMode": 0,
+          "metricName": "NetworkRxBytes",
+          "metricQueryType": 0,
+          "namespace": "ECS/ContainerInsights",
+          "period": "",
+          "queryMode": "Metrics",
+          "refId": "G",
+          "region": "default",
+          "sqlExpression": "",
+          "statistic": "Average"
+        },
+        {
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "${cloudwatch}"
+          },
+          "dimensions": {
+            "ClusterName": "$dagster_cluster",
             "TaskDefinitionFamily": "$dagster_daemon_service"
           },
           "expression": "",
@@ -3175,12 +3569,12 @@
           },
           "dimensions": {
             "ClusterName": "$dagster_cluster",
-            "TaskDefinitionFamily": "$dagster_run_task"
+            "TaskDefinitionFamily": "$dagster_worker_task"
           },
           "expression": "",
           "hide": false,
           "id": "",
-          "label": "Run Bytes Out",
+          "label": "Worker Bytes Out",
           "logGroups": [],
           "matchExact": true,
           "metricEditorMode": 0,
@@ -3220,7 +3614,7 @@
         "content": "# Graph Instances",
         "mode": "markdown"
       },
-      "pluginVersion": "10.4.1",
+      "pluginVersion": "10.4.7",
       "title": " ",
       "transparent": true,
       "type": "text"
@@ -3247,7 +3641,7 @@
         "content": "",
         "mode": "html"
       },
-      "pluginVersion": "10.4.1",
+      "pluginVersion": "10.4.7",
       "title": " Shared Replicas",
       "transparent": true,
       "type": "text"
@@ -3657,7 +4051,7 @@
         "content": "",
         "mode": "markdown"
       },
-      "pluginVersion": "10.4.1",
+      "pluginVersion": "10.4.7",
       "title": " Shared Master",
       "transparent": true,
       "type": "text"
@@ -4538,7 +4932,7 @@
         "content": "",
         "mode": "markdown"
       },
-      "pluginVersion": "10.4.1",
+      "pluginVersion": "10.4.7",
       "title": "User Writers",
       "transparent": true,
       "type": "text"
@@ -5417,7 +5811,7 @@
         "content": "",
         "mode": "markdown"
       },
-      "pluginVersion": "10.4.1",
+      "pluginVersion": "10.4.7",
       "title": "Graph Tier Metrics",
       "transparent": true,
       "type": "text"
@@ -6483,7 +6877,7 @@
         "content": "# RDS Postgres",
         "mode": "markdown"
       },
-      "pluginVersion": "10.4.1",
+      "pluginVersion": "10.4.7",
       "title": " ",
       "transparent": true,
       "type": "text"
@@ -7588,7 +7982,7 @@
         "content": "# OpenSearch",
         "mode": "markdown"
       },
-      "pluginVersion": "10.4.1",
+      "pluginVersion": "10.4.7",
       "title": " ",
       "transparent": true,
       "type": "text"
@@ -7722,12 +8116,11 @@
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
-            "fillOpacity": 10,
+            "fillOpacity": 0,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
               "tooltip": false,
-              "vis": false,
               "viz": false
             },
             "insertNulls": false,
@@ -7737,7 +8130,7 @@
             "scaleDistribution": {
               "type": "linear"
             },
-            "showPoints": "never",
+            "showPoints": "auto",
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -7761,8 +8154,7 @@
                 "value": 80
               }
             ]
-          },
-          "unit": "percent"
+          }
         },
         "overrides": []
       },
@@ -7785,6 +8177,7 @@
           "sort": "none"
         }
       },
+      "pluginVersion": "10.4.1",
       "targets": [
         {
           "datasource": {
@@ -7796,8 +8189,9 @@
             "DomainName": "$opensearch_domain"
           },
           "expression": "",
+          "hide": false,
           "id": "",
-          "label": "",
+          "label": "Avg",
           "logGroups": [],
           "matchExact": true,
           "metricEditorMode": 0,
@@ -7806,7 +8200,7 @@
           "namespace": "AWS/ES",
           "period": "300",
           "queryMode": "Metrics",
-          "refId": "A",
+          "refId": "B",
           "region": "${aws_region}",
           "sqlExpression": "",
           "statistic": "Average"
@@ -8528,7 +8922,7 @@
               }
             ]
           },
-          "unit": "iops"
+          "unit": "none"
         },
         "overrides": []
       },
@@ -8537,6 +8931,116 @@
         "w": 8,
         "x": 16,
         "y": 263
+      },
+      "id": 112,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "${cloudwatch}"
+          },
+          "dimensions": {
+            "ClientId": "$aws_account_id",
+            "DomainName": "$opensearch_domain"
+          },
+          "expression": "",
+          "hide": false,
+          "id": "",
+          "label": "",
+          "logGroups": [],
+          "matchExact": true,
+          "metricEditorMode": 0,
+          "metricName": "KNNHitCount",
+          "metricQueryType": 0,
+          "namespace": "AWS/ES",
+          "period": "300",
+          "queryMode": "Metrics",
+          "refId": "B",
+          "region": "${aws_region}",
+          "sqlExpression": "",
+          "statistic": "Average"
+        }
+      ],
+      "title": "KNN Hits",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "cloudwatch",
+        "uid": "${cloudwatch}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "vis": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "iops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 0,
+        "y": 272
       },
       "id": 88,
       "options": {
@@ -8605,215 +9109,6 @@
         }
       ],
       "title": "Read / Write IOPS",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "cloudwatch",
-        "uid": "${cloudwatch}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "continuous-RdYlGr",
-            "seriesBy": "last"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "vis": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "ClusterStatus.yellow"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "yellow",
-                  "mode": "fixed",
-                  "seriesBy": "last"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "ClusterStatus.green"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "green",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "ClusterStatus.red"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "red",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 8,
-        "x": 0,
-        "y": 272
-      },
-      "id": 111,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "cloudwatch",
-            "uid": "${cloudwatch}"
-          },
-          "dimensions": {
-            "ClientId": "$aws_account_id",
-            "DomainName": "$opensearch_domain"
-          },
-          "expression": "",
-          "hide": false,
-          "id": "",
-          "label": "",
-          "logGroups": [],
-          "matchExact": true,
-          "metricEditorMode": 0,
-          "metricName": "ClusterStatus.green",
-          "metricQueryType": 0,
-          "namespace": "AWS/ES",
-          "period": "300",
-          "queryMode": "Metrics",
-          "refId": "C",
-          "region": "${aws_region}",
-          "sqlExpression": "",
-          "statistic": "Average"
-        },
-        {
-          "datasource": {
-            "type": "cloudwatch",
-            "uid": "${cloudwatch}"
-          },
-          "dimensions": {
-            "ClientId": "$aws_account_id",
-            "DomainName": "$opensearch_domain"
-          },
-          "expression": "",
-          "id": "",
-          "label": "",
-          "logGroups": [],
-          "matchExact": true,
-          "metricEditorMode": 0,
-          "metricName": "ClusterStatus.yellow",
-          "metricQueryType": 0,
-          "namespace": "AWS/ES",
-          "period": "300",
-          "queryMode": "Metrics",
-          "refId": "A",
-          "region": "${aws_region}",
-          "sqlExpression": "",
-          "statistic": "Average"
-        },
-        {
-          "datasource": {
-            "type": "cloudwatch",
-            "uid": "${cloudwatch}"
-          },
-          "dimensions": {
-            "ClientId": "$aws_account_id",
-            "DomainName": "$opensearch_domain"
-          },
-          "expression": "",
-          "hide": false,
-          "id": "",
-          "label": "",
-          "logGroups": [],
-          "matchExact": true,
-          "metricEditorMode": 0,
-          "metricName": "ClusterStatus.red",
-          "metricQueryType": 0,
-          "namespace": "AWS/ES",
-          "period": "300",
-          "queryMode": "Metrics",
-          "refId": "B",
-          "region": "${aws_region}",
-          "sqlExpression": "",
-          "statistic": "Average"
-        }
-      ],
-      "title": "Cluster Status",
       "type": "timeseries"
     },
     {
@@ -9011,7 +9306,8 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "palette-classic"
+            "mode": "continuous-RdYlGr",
+            "seriesBy": "last"
           },
           "custom": {
             "axisBorderShow": false,
@@ -9061,7 +9357,54 @@
           },
           "unit": "none"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ClusterStatus.yellow"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed",
+                  "seriesBy": "last"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ClusterStatus.green"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ClusterStatus.red"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 9,
@@ -9069,7 +9412,7 @@
         "x": 16,
         "y": 272
       },
-      "id": 110,
+      "id": 111,
       "options": {
         "legend": {
           "calcs": [],
@@ -9099,7 +9442,58 @@
           "logGroups": [],
           "matchExact": true,
           "metricEditorMode": 0,
-          "metricName": "ThreadpoolBulkRejected",
+          "metricName": "ClusterStatus.green",
+          "metricQueryType": 0,
+          "namespace": "AWS/ES",
+          "period": "300",
+          "queryMode": "Metrics",
+          "refId": "C",
+          "region": "${aws_region}",
+          "sqlExpression": "",
+          "statistic": "Average"
+        },
+        {
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "${cloudwatch}"
+          },
+          "dimensions": {
+            "ClientId": "$aws_account_id",
+            "DomainName": "$opensearch_domain"
+          },
+          "expression": "",
+          "id": "",
+          "label": "",
+          "logGroups": [],
+          "matchExact": true,
+          "metricEditorMode": 0,
+          "metricName": "ClusterStatus.yellow",
+          "metricQueryType": 0,
+          "namespace": "AWS/ES",
+          "period": "300",
+          "queryMode": "Metrics",
+          "refId": "A",
+          "region": "${aws_region}",
+          "sqlExpression": "",
+          "statistic": "Average"
+        },
+        {
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "${cloudwatch}"
+          },
+          "dimensions": {
+            "ClientId": "$aws_account_id",
+            "DomainName": "$opensearch_domain"
+          },
+          "expression": "",
+          "hide": false,
+          "id": "",
+          "label": "",
+          "logGroups": [],
+          "matchExact": true,
+          "metricEditorMode": 0,
+          "metricName": "ClusterStatus.red",
           "metricQueryType": 0,
           "namespace": "AWS/ES",
           "period": "300",
@@ -9110,7 +9504,7 @@
           "statistic": "Average"
         }
       ],
-      "title": "Threadpool Bulk Rejected",
+      "title": "Cluster Status",
       "type": "timeseries"
     },
     {
@@ -9134,7 +9528,7 @@
         "content": "# ElastiCache Valkey",
         "mode": "markdown"
       },
-      "pluginVersion": "10.4.1",
+      "pluginVersion": "10.4.7",
       "title": " ",
       "transparent": true,
       "type": "text"
@@ -10195,726 +10589,6 @@
       ],
       "title": "Network Throughput",
       "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "text",
-        "uid": "-- Mixed --"
-      },
-      "description": "",
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 311
-      },
-      "id": 112,
-      "options": {
-        "code": {
-          "language": "plaintext",
-          "showLineNumbers": false,
-          "showMiniMap": false
-        },
-        "content": "",
-        "mode": "markdown"
-      },
-      "pluginVersion": "10.4.1",
-      "title": "Worker",
-      "transparent": true,
-      "type": "text"
-    },
-    {
-      "datasource": {
-        "type": "cloudwatch",
-        "uid": "${cloudwatch}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "vis": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 312
-      },
-      "id": 113,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "cloudwatch",
-            "uid": "${cloudwatch}"
-          },
-          "dimensions": {},
-          "expression": "",
-          "id": "",
-          "label": "",
-          "logGroups": [],
-          "matchExact": true,
-          "metricEditorMode": 0,
-          "metricName": "QueueDepth",
-          "metricQueryType": 0,
-          "namespace": "RoboSystems/Worker/${env}",
-          "period": "60",
-          "queryMode": "Metrics",
-          "refId": "A",
-          "region": "${aws_region}",
-          "sqlExpression": "",
-          "statistic": "Maximum"
-        }
-      ],
-      "title": "Worker Queue Depth",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "cloudwatch",
-        "uid": "${cloudwatch}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "vis": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 312
-      },
-      "id": 114,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "cloudwatch",
-            "uid": "${cloudwatch}"
-          },
-          "dimensions": {},
-          "expression": "",
-          "id": "",
-          "label": "",
-          "logGroups": [],
-          "matchExact": true,
-          "metricEditorMode": 0,
-          "metricName": "DLQDepth",
-          "metricQueryType": 0,
-          "namespace": "RoboSystems/Worker/${env}",
-          "period": "60",
-          "queryMode": "Metrics",
-          "refId": "A",
-          "region": "${aws_region}",
-          "sqlExpression": "",
-          "statistic": "Maximum"
-        }
-      ],
-      "title": "Worker DLQ Depth",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "cloudwatch",
-        "uid": "${cloudwatch}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "vis": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 320
-      },
-      "id": 115,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "cloudwatch",
-            "uid": "${cloudwatch}"
-          },
-          "dimensions": {
-            "ClusterName": "$dagster_cluster",
-            "ServiceName": "robosystems-worker-${env}"
-          },
-          "expression": "",
-          "hide": false,
-          "id": "",
-          "label": "Running",
-          "logGroups": [],
-          "matchExact": true,
-          "metricEditorMode": 0,
-          "metricName": "RunningTaskCount",
-          "metricQueryType": 0,
-          "namespace": "ECS/ContainerInsights",
-          "period": "",
-          "queryMode": "Metrics",
-          "refId": "A",
-          "region": "default",
-          "sqlExpression": "",
-          "statistic": "Average"
-        },
-        {
-          "datasource": {
-            "type": "cloudwatch",
-            "uid": "${cloudwatch}"
-          },
-          "dimensions": {
-            "ClusterName": "$dagster_cluster",
-            "ServiceName": "robosystems-worker-${env}"
-          },
-          "expression": "",
-          "hide": false,
-          "id": "",
-          "label": "Desired",
-          "logGroups": [],
-          "matchExact": true,
-          "metricEditorMode": 0,
-          "metricName": "DesiredTaskCount",
-          "metricQueryType": 0,
-          "namespace": "ECS/ContainerInsights",
-          "period": "",
-          "queryMode": "Metrics",
-          "refId": "B",
-          "region": "default",
-          "sqlExpression": "",
-          "statistic": "Average"
-        }
-      ],
-      "title": "Worker Running vs Desired Tasks",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "cloudwatch",
-        "uid": "${cloudwatch}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "vis": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": 3600000,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "max": 100,
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "percent"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 320
-      },
-      "id": 116,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "cloudwatch",
-            "uid": "${cloudwatch}"
-          },
-          "dimensions": {
-            "ClusterName": "$dagster_cluster",
-            "ServiceName": "robosystems-worker-${env}"
-          },
-          "expression": "",
-          "hide": false,
-          "id": "",
-          "label": "Worker",
-          "logGroups": [],
-          "matchExact": true,
-          "metricEditorMode": 0,
-          "metricName": "CPUUtilization",
-          "metricQueryType": 0,
-          "namespace": "AWS/ECS",
-          "period": "",
-          "queryMode": "Metrics",
-          "refId": "A",
-          "region": "default",
-          "sqlExpression": "",
-          "statistic": "Average"
-        }
-      ],
-      "title": "Worker CPU Utilization",
-      "transformations": [
-        {
-          "id": "calculateField",
-          "options": {
-            "alias": "Run CPU Utilization",
-            "binary": {
-              "left": "CpuUtilized",
-              "operator": "/",
-              "right": "CpuReserved"
-            },
-            "mode": "binary",
-            "reduce": {
-              "reducer": "sum"
-            }
-          }
-        },
-        {
-          "id": "calculateField",
-          "options": {
-            "alias": "Run",
-            "binary": {
-              "left": "Run CPU Utilization",
-              "operator": "*",
-              "right": "100"
-            },
-            "mode": "binary",
-            "reduce": {
-              "reducer": "sum"
-            }
-          }
-        },
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "1 -": true,
-              "AWS/ECS robosystems-dagster-daemon-prod CPUUtilization": false,
-              "AWS/ECS robosystems-dagster-webserver-prod CPUUtilization": false,
-              "CpuReserved": true,
-              "CpuUtilized": true,
-              "Dagster Run CPU Utilization": false,
-              "ECS/ContainerInsights robosystems-dagster-run-${env} CpuReserved": true,
-              "ECS/ContainerInsights robosystems-dagster-run-${env} CpuUtilized": true,
-              "ECS/ContainerInsights robosystems-dagster-run-${env} CpuUtilized / ECS/ContainerInsights robosystems-dagster-run-${env} CpuReserved": true,
-              "ECS/ContainerInsights robosystems-dagster-run-prod CpuReserved": true,
-              "ECS/ContainerInsights robosystems-dagster-run-prod CpuUtilized": true,
-              "Run CPU Utilization": true,
-              "Run Utilization": true
-            },
-            "includeByName": {},
-            "indexByName": {},
-            "renameByName": {
-              "AWS/ECS robosystems-dagster-daemon-${env} CPUUtilization": "Daemon",
-              "AWS/ECS robosystems-dagster-webserver-${env} CPUUtilization": "Webserver",
-              "Dagster Run CPU Utilization": "Run"
-            }
-          }
-        }
-      ],
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "cloudwatch",
-        "uid": "${cloudwatch}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "vis": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": 3600000,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "max": 100,
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "percent"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 328
-      },
-      "id": 117,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "cloudwatch",
-            "uid": "${cloudwatch}"
-          },
-          "dimensions": {
-            "ClusterName": "$dagster_cluster",
-            "ServiceName": "robosystems-worker-${env}"
-          },
-          "expression": "",
-          "hide": false,
-          "id": "",
-          "label": "Worker",
-          "logGroups": [],
-          "matchExact": true,
-          "metricEditorMode": 0,
-          "metricName": "MemoryUtilization",
-          "metricQueryType": 0,
-          "namespace": "AWS/ECS",
-          "period": "",
-          "queryMode": "Metrics",
-          "refId": "A",
-          "region": "default",
-          "sqlExpression": "",
-          "statistic": "Maximum"
-        }
-      ],
-      "title": "Worker Memory Utilization",
-      "transformations": [
-        {
-          "id": "calculateField",
-          "options": {
-            "alias": "Run CPU Utilization",
-            "binary": {
-              "left": "CpuUtilized",
-              "operator": "/",
-              "right": "CpuReserved"
-            },
-            "mode": "binary",
-            "reduce": {
-              "reducer": "sum"
-            }
-          }
-        },
-        {
-          "id": "calculateField",
-          "options": {
-            "alias": "Run",
-            "binary": {
-              "left": "Run CPU Utilization",
-              "operator": "*",
-              "right": "100"
-            },
-            "mode": "binary",
-            "reduce": {
-              "reducer": "sum"
-            }
-          }
-        },
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "1 -": true,
-              "AWS/ECS robosystems-dagster-daemon-prod CPUUtilization": false,
-              "AWS/ECS robosystems-dagster-webserver-prod CPUUtilization": false,
-              "CpuReserved": true,
-              "CpuUtilized": true,
-              "Dagster Run CPU Utilization": false,
-              "ECS/ContainerInsights robosystems-dagster-run-${env} CpuReserved": true,
-              "ECS/ContainerInsights robosystems-dagster-run-${env} CpuUtilized": true,
-              "ECS/ContainerInsights robosystems-dagster-run-${env} CpuUtilized / ECS/ContainerInsights robosystems-dagster-run-${env} CpuReserved": true,
-              "ECS/ContainerInsights robosystems-dagster-run-prod CpuReserved": true,
-              "ECS/ContainerInsights robosystems-dagster-run-prod CpuUtilized": true,
-              "Run CPU Utilization": true,
-              "Run Utilization": true
-            },
-            "includeByName": {},
-            "indexByName": {},
-            "renameByName": {
-              "AWS/ECS robosystems-dagster-daemon-${env} CPUUtilization": "Daemon",
-              "AWS/ECS robosystems-dagster-webserver-${env} CPUUtilization": "Webserver",
-              "Dagster Run CPU Utilization": "Run"
-            }
-          }
-        }
-      ],
-      "type": "timeseries"
     }
   ],
   "refresh": "30s",
@@ -11355,6 +11029,59 @@
         "skipUrlSync": false,
         "sort": 0,
         "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "robosystems-worker-prod",
+          "value": "robosystems-worker-prod"
+        },
+        "datasource": {
+          "type": "cloudwatch",
+          "uid": "${cloudwatch}"
+        },
+        "definition": "",
+        "hide": 2,
+        "includeAll": false,
+        "label": "",
+        "multi": false,
+        "name": "dagster_worker_task",
+        "options": [],
+        "query": {
+          "dimensionKey": "TaskDefinitionFamily",
+          "metricName": "CpuUtilized",
+          "namespace": "ECS/ContainerInsights",
+          "queryType": "dimensionValues",
+          "refId": "CloudWatchVariableQueryEditor-VariableQuery",
+          "region": "default"
+        },
+        "refresh": 1,
+        "regex": "robosystems-worker-${env}",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "RoboSystems/Worker/prod",
+          "value": "RoboSystems/Worker/prod"
+        },
+        "hide": 2,
+        "includeAll": false,
+        "label": "",
+        "multi": false,
+        "name": "worker_queue_cloudwatch",
+        "options": [
+          {
+            "selected": true,
+            "text": "RoboSystems/Worker/prod",
+            "value": "RoboSystems/Worker/prod"
+          }
+        ],
+        "query": "RoboSystems/Worker/${env}",
+        "skipUrlSync": false,
+        "type": "custom"
       },
       {
         "current": {

--- a/bin/tools/grafana/ops.json
+++ b/bin/tools/grafana/ops.json
@@ -2496,7 +2496,7 @@
           "expression": "",
           "hide": false,
           "id": "",
-          "label": "",
+          "label": "Run CPU Utilized",
           "logGroups": [],
           "matchExact": false,
           "metricEditorMode": 0,
@@ -2522,7 +2522,7 @@
           "expression": "",
           "hide": false,
           "id": "",
-          "label": "",
+          "label": "Run CPU Reserved",
           "logGroups": [],
           "matchExact": false,
           "metricEditorMode": 0,
@@ -2548,7 +2548,7 @@
           "expression": "",
           "hide": false,
           "id": "",
-          "label": "",
+          "label": "Worker CPU Utilized",
           "logGroups": [],
           "matchExact": false,
           "metricEditorMode": 0,
@@ -2574,7 +2574,7 @@
           "expression": "",
           "hide": false,
           "id": "",
-          "label": "",
+          "label": "Worker CPU Reserved",
           "logGroups": [],
           "matchExact": false,
           "metricEditorMode": 0,
@@ -2596,9 +2596,9 @@
           "options": {
             "alias": "Run CPU Utilization",
             "binary": {
-              "left": "robosystems-dagster-run-prod CpuUtilized",
+              "left": "Run CPU Utilized robosystems-dagster-run-prod CpuUtilized",
               "operator": "/",
-              "right": "robosystems-dagster-run-prod CpuReserved"
+              "right": "Run CPU Reserved robosystems-dagster-run-prod CpuReserved"
             },
             "mode": "binary",
             "reduce": {
@@ -2626,9 +2626,9 @@
           "options": {
             "alias": "Worker CPU Utilized",
             "binary": {
-              "left": "robosystems-worker-prod CpuUtilized",
+              "left": "Worker CPU Utilized robosystems-worker-prod CpuUtilized",
               "operator": "/",
-              "right": "robosystems-worker-prod CpuReserved"
+              "right": "Worker CPU Reserved robosystems-worker-prod CpuReserved"
             },
             "mode": "binary",
             "reduce": {
@@ -2667,9 +2667,13 @@
               "ECS/ContainerInsights robosystems-dagster-run-${env} CpuUtilized / ECS/ContainerInsights robosystems-dagster-run-${env} CpuReserved": true,
               "ECS/ContainerInsights robosystems-dagster-run-prod CpuReserved": true,
               "ECS/ContainerInsights robosystems-dagster-run-prod CpuUtilized": true,
+              "Run CPU Reserved robosystems-dagster-run-prod CpuReserved": true,
               "Run CPU Utilization": true,
+              "Run CPU Utilized robosystems-dagster-run-prod CpuUtilized": true,
               "Run Utilization": true,
+              "Worker CPU Reserved robosystems-worker-prod CpuReserved": true,
               "Worker CPU Utilized": true,
+              "Worker CPU Utilized robosystems-worker-prod CpuUtilized": true,
               "robosystems-dagster-run-prod CpuReserved": true,
               "robosystems-dagster-run-prod CpuUtilized": true,
               "robosystems-worker-prod CpuReserved": true,

--- a/cloudformation/worker.yaml
+++ b/cloudformation/worker.yaml
@@ -125,6 +125,11 @@ Parameters:
     MaxValue: 365
     Description: CloudWatch log retention in days
 
+  SNSAlertEmail:
+    Type: String
+    Default: ""
+    Description: Email for worker alerts (e.g. DLQ depth); empty disables alarm notifications
+
   # Tagging Configuration
   ServiceTag:
     Type: String
@@ -144,6 +149,7 @@ Parameters:
 Conditions:
   HasOpenSearch: !Not [!Equals [!Ref OpenSearchEndpoint, ""]]
   AutoscalingEnabled: !Equals [!Ref WorkerAutoscalingEnabled, "true"]
+  HasAlertEmail: !Not [!Equals [!Ref SNSAlertEmail, ""]]
 
 Resources:
   # ========================================
@@ -580,6 +586,53 @@ Resources:
       AlarmActions:
         - !Ref WorkerScaleInPolicy
 
+  # ========================================
+  # ALERTING
+  # ========================================
+  WorkerNotificationTopic:
+    Condition: HasAlertEmail
+    Type: AWS::SNS::Topic
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      TopicName: !Sub robosystems-worker-${Environment}-alerts
+      DisplayName: !Sub RoboSystems Worker ${Environment} Alerts
+      Subscription:
+        - Endpoint: !Ref SNSAlertEmail
+          Protocol: email
+      Tags:
+        - Key: Name
+          Value: !Sub robosystems-worker-notifications-${Environment}
+        - Key: Environment
+          Value: !Ref Environment
+        - Key: Service
+          Value: !Ref ServiceTag
+        - Key: Component
+          Value: !Ref ComponentTag
+        - Key: CreatedBy
+          Value: CloudFormation
+
+  WorkerDLQDepthAlarm:
+    Condition: HasAlertEmail
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub robosystems-worker-dlq-depth-${Environment}
+      AlarmDescription: >-
+        Worker dead-letter queue has one or more messages - a job failed
+        permanently and needs investigation.
+      Namespace: !Sub RoboSystems/Worker/${Environment}
+      MetricName: DLQDepth
+      Statistic: Maximum
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      # Only an actual DLQ message pages; a gap in published depth is not an
+      # alertable condition (worker liveness is covered elsewhere).
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - !Ref WorkerNotificationTopic
+
 Outputs:
   WorkerServiceArn:
     Description: ARN of the worker ECS service
@@ -592,3 +645,8 @@ Outputs:
     Value: !GetAtt WorkerTaskDefinition.TaskDefinitionArn
     Export:
       Name: !Sub ${AWS::StackName}-WorkerTaskDefinitionArn
+
+  WorkerNotificationTopicArn:
+    Condition: HasAlertEmail
+    Description: ARN of the worker alerts SNS topic
+    Value: !Ref WorkerNotificationTopic

--- a/robosystems/middleware/otel/setup.py
+++ b/robosystems/middleware/otel/setup.py
@@ -14,6 +14,7 @@ Features:
 """
 
 import logging
+import socket
 from importlib.metadata import version as pkg_version
 
 from fastapi import FastAPI
@@ -63,9 +64,17 @@ def _create_resource() -> Resource:
     "service.name": service_name,
     "service.version": service_version,
     "deployment.environment": env.ENVIRONMENT,
+    # Unique per-process identity so each task/replica maps to its own
+    # Prometheus series (via the `instance` label). Without it, every ECS
+    # task exports its cumulative OTel counters into one shared series;
+    # rate() then misreads the interleaved per-task samples as constant
+    # counter resets and inflates request/event volume metrics massively.
+    # On ECS Fargate the hostname is the unique container ID.
+    "service.instance.id": socket.gethostname(),
   }
 
   # Parse additional resource attributes from environment
+  # (an explicit service.instance.id here still wins, since it overrides above)
   if resource_attributes:
     try:
       for attr in resource_attributes.split(","):


### PR DESCRIPTION
## Summary

Started as an investigation into the ops dashboard's "Request Volume" panel, which climbed monotonically over each deployment's uptime and reset to ~0 on every deploy. Root cause: the API exports **cumulative** OTel counters, but the resource carried **no `service.instance.id`**, so all ECS tasks wrote into a single Prometheus series (no `instance` label). With ≥2 tasks the shared series flip-flops between their independent cumulative values every export, and `rate()` reads each downward step as a counter reset — inflating request/event volume by orders of magnitude. Real `/v1/graphs/{graph_id}/query` traffic was ~2–3 requests/**hour**; the dashboard showed ~400/min.

The fix is one line in the OTel resource. While in here, the investigation also turned up dashboard accuracy/observability gaps and a missing alarm, fixed alongside.

## Changes

### `fix(otel)` — root cause
- `robosystems/middleware/otel/setup.py`: set `service.instance.id` (= `socket.gethostname()`, the ECS container id) in the OTel resource so each task maps to its own `instance`-labeled series. Per-series `rate()` is then clean-monotonic and `sum(rate(...))` aggregates true volume. Bounded by task count (≈2), not an unbounded-cardinality risk.

### `feat/fix(grafana)` — ops dashboard (`bin/tools/grafana/ops.json`)
- Layer the worker (`robosystems-worker-prod`, runs in the dagster cluster) into the Dagster section: CPU/memory overlaid by task family, combined Queue/DLQ depth panel, and **Worker Running vs Desired** tasks (autoscaling observability — completes the panels from `5bca20f8`).
- Fix request-volume / business-event panels: `rate(...[5m])` is per-second and was scaled `*5` under a req/min axis — corrected to `*60`.
- Add the OpenSearch KNN Hits panel; label the worker/run CPU series to match the Memory panel.

### `feat(worker)` — DLQ alarm
- `cloudformation/worker.yaml`: `SNSAlertEmail` param (default empty), `WorkerNotificationTopic` (SNS) + `WorkerDLQDepthAlarm` (`DLQDepth >= 1`), both gated on a `HasAlertEmail` condition so they're a no-op when no email is configured. Matches the per-stack notification pattern (opensearch/valkey/graph-*). `TreatMissingData=notBreaching` so only an actual dead-letter pages.
- `deploy-dagster.yml`: thread a new `aws_sns_alert_email` input → `SNSAlertEmail`.
- `staging.yml` / `prod.yml`: pass `vars.AWS_SNS_ALERT_EMAIL` to the dagster deploy (same as every other stack).

## Testing / validation

- **Confirmed the root cause against prod AMP**: single series for the query endpoint, `resets()` = 60/hour (one per 60s export), raw 15s samples oscillating `368 ↔ 226` (the two tasks' cumulative counts), `increase[1h]` = ~22k vs the counter actually moving +2. Confirmed prod runs 2 API tasks and that no metric carries an `instance` label.
- **Verified every new dashboard series returns live data** (worker CPU/mem by `TaskDefinitionFamily`, `RunningTaskCount`/`DesiredTaskCount` by `ServiceName`, `QueueDepth`/`DLQDepth`).
- `just cf-lint worker` (cfn-lint + validate-template) clean; all three workflow YAMLs parse; `ruff`/`format`/`basedpyright` clean on `setup.py`.

## Rollout notes

- **`setup.py` fix takes effect on the next API deploy.** After it, the Request Volume / Top Business Events lines drop to their true (near-zero) values and stop the climb-and-reset sawtooth. No dashboard change is needed for correctness — the `*60` edit is axis accuracy only.
- **DLQ alarm takes effect on the next dagster/worker deploy** (through the pipeline). `AWS_SNS_ALERT_EMAIL` is already set (`joey@robofin.systems`); AWS will send a one-time **SNS subscription confirmation** email that must be clicked before the alarm delivers.
