### PR TITLE
feat(qb): cut JournalReport over to Intuit v2 reporting service

### DIFF
--- a/robosystems/adapters/quickbooks/client/api.py
+++ b/robosystems/adapters/quickbooks/client/api.py
@@ -507,17 +507,27 @@ class QBClient:
     return self._paginate(JournalEntry)
 
   @_QB_RETRY
-  def get_transactions(self, start_date=None, end_date=None):
-    """Fetch JournalReport — no longer the transactional source.
+  def get_transactions(self, start_date=None, end_date=None, testing_migration=None):
+    """Fetch JournalReport — still the live GL posting source (extract.py).
 
-    Kept for backward compat with any external callers; the QB pipeline now
-    pulls Invoice / Bill / Payment / JournalEntry per-entity instead.
+    When ``testing_migration`` is True — or, when left None, the
+    ``INTUIT_REPORTS_TESTING_MIGRATION`` config flag is set — the request is
+    routed through Intuit's modernized "v2" reporting service via the
+    ``testing_migration`` query param. This is a temporary Intuit-side
+    migration switch: after the 2026-08-31 cutover the v2 service serves all
+    Reports API responses unconditionally and the param becomes a no-op.
+    See https://medium.com/intuitdev/upcoming-changes-to-reports-apis-5083ec9aadce
     """
     params = {}
     if start_date:
       params["start_date"] = start_date
     if end_date:
       params["end_date"] = end_date
+    if testing_migration is None:
+      testing_migration = env.INTUIT_REPORTS_TESTING_MIGRATION
+    if testing_migration:
+      # Presence of the key is what routes to v2; value is ignored by Intuit.
+      params["testing_migration"] = "true"
     transactions = self.client.get_report("JournalReport", params)
     return transactions
 

--- a/robosystems/adapters/quickbooks/pipeline/extract.py
+++ b/robosystems/adapters/quickbooks/pipeline/extract.py
@@ -150,6 +150,8 @@ def qb_extract(
     )
     context.log.info(f"Incremental: fetching transactions from {start_date}")
 
+  # testing_migration defaults to the INTUIT_REPORTS_TESTING_MIGRATION flag,
+  # so this routes through Intuit's v2 reporting service unless SSM-disabled.
   report = client.get_transactions(start_date=start_date, end_date=end_date)
   journal_entries, journal_lines = parse_journal_report(report)
 

--- a/robosystems/config/env.py
+++ b/robosystems/config/env.py
@@ -629,6 +629,20 @@ class EnvConfig:
     get_parameter_value("CONNECTION_QUICKBOOKS_ENABLED", "true").lower() == "true",
   )
 
+  # Routes QB Reports API calls (JournalReport — our live GL posting source)
+  # through Intuit's modernized "v2" reporting service via the
+  # `testing_migration` query param. Defaults TRUE: we cut over to v2 ahead of
+  # Intuit's 2026-08-31 hard cutover (validated to parse identically to v1).
+  # Set FALSE via SSM (features/INTUIT_REPORTS_TESTING_MIGRATION) to fall back
+  # to v1 at runtime with no redeploy — but ONLY until 2026-08-31, after which
+  # Intuit serves v2 unconditionally and the param becomes a no-op. Retire this
+  # flag (and the get_transactions param) once that cutover lands.
+  # https://medium.com/intuitdev/upcoming-changes-to-reports-apis-5083ec9aadce
+  INTUIT_REPORTS_TESTING_MIGRATION = get_bool_env(
+    "INTUIT_REPORTS_TESTING_MIGRATION",
+    get_parameter_value("INTUIT_REPORTS_TESTING_MIGRATION", "true").lower() == "true",
+  )
+
   # ==========================================================================
   # EXTENSIONS — RoboLedger & RoboInvestor product surfaces
   # ==========================================================================
@@ -922,20 +936,6 @@ class EnvConfig:
     "INTUIT_REDIRECT_URI", "http://localhost:8000/auth/callback"
   )
   INTUIT_ENVIRONMENT = get_secret_value("INTUIT_ENVIRONMENT", "sandbox")
-
-  # Routes QB Reports API calls (JournalReport — our live GL posting source)
-  # through Intuit's modernized "v2" reporting service via the
-  # `testing_migration` query param. Defaults TRUE: we cut over to v2 ahead of
-  # Intuit's 2026-08-31 hard cutover (validated to parse identically to v1).
-  # Set FALSE via SSM (features/INTUIT_REPORTS_TESTING_MIGRATION) to fall back
-  # to v1 at runtime with no redeploy — but ONLY until 2026-08-31, after which
-  # Intuit serves v2 unconditionally and the param becomes a no-op. Retire this
-  # flag (and the get_transactions param) once that cutover lands.
-  # https://medium.com/intuitdev/upcoming-changes-to-reports-apis-5083ec9aadce
-  INTUIT_REPORTS_TESTING_MIGRATION = get_bool_env(
-    "INTUIT_REPORTS_TESTING_MIGRATION",
-    get_parameter_value("INTUIT_REPORTS_TESTING_MIGRATION", "true").lower() == "true",
-  )
 
   # SEC
   # SEC_GOV_USER_AGENT is a secret identity for API access

--- a/robosystems/config/env.py
+++ b/robosystems/config/env.py
@@ -923,6 +923,20 @@ class EnvConfig:
   )
   INTUIT_ENVIRONMENT = get_secret_value("INTUIT_ENVIRONMENT", "sandbox")
 
+  # Routes QB Reports API calls (JournalReport — our live GL posting source)
+  # through Intuit's modernized "v2" reporting service via the
+  # `testing_migration` query param. Defaults TRUE: we cut over to v2 ahead of
+  # Intuit's 2026-08-31 hard cutover (validated to parse identically to v1).
+  # Set FALSE via SSM (features/INTUIT_REPORTS_TESTING_MIGRATION) to fall back
+  # to v1 at runtime with no redeploy — but ONLY until 2026-08-31, after which
+  # Intuit serves v2 unconditionally and the param becomes a no-op. Retire this
+  # flag (and the get_transactions param) once that cutover lands.
+  # https://medium.com/intuitdev/upcoming-changes-to-reports-apis-5083ec9aadce
+  INTUIT_REPORTS_TESTING_MIGRATION = get_bool_env(
+    "INTUIT_REPORTS_TESTING_MIGRATION",
+    get_parameter_value("INTUIT_REPORTS_TESTING_MIGRATION", "true").lower() == "true",
+  )
+
   # SEC
   # SEC_GOV_USER_AGENT is a secret identity for API access
   SEC_GOV_USER_AGENT = get_secret_value(

--- a/tests/adapters/qb/client/test_api.py
+++ b/tests/adapters/qb/client/test_api.py
@@ -383,8 +383,11 @@ class TestQBClient:
     mock_transactions = {"transactions": [{"id": "1", "amount": 150.00}]}
     mock_qb_client.get_report.return_value = mock_transactions
 
-    # Execute
-    result = client.get_transactions("2023-01-01", "2023-12-31")
+    # Execute — testing_migration=False isolates date handling from the
+    # now-default-on v2 flag (covered separately below).
+    result = client.get_transactions(
+      "2023-01-01", "2023-12-31", testing_migration=False
+    )
 
     # Verify
     assert result == mock_transactions
@@ -401,8 +404,8 @@ class TestQBClient:
     mock_transactions = {"transactions": []}
     mock_qb_client.get_report.return_value = mock_transactions
 
-    # Execute
-    result = client.get_transactions()
+    # Execute (testing_migration=False to isolate from the default-on v2 flag)
+    result = client.get_transactions(testing_migration=False)
 
     # Verify
     assert result == mock_transactions
@@ -417,13 +420,51 @@ class TestQBClient:
     mock_transactions = {"transactions": [{"id": "1"}]}
     mock_qb_client.get_report.return_value = mock_transactions
 
-    # Execute
-    result = client.get_transactions("2023-01-01")
+    # Execute (testing_migration=False to isolate from the default-on v2 flag)
+    result = client.get_transactions("2023-01-01", testing_migration=False)
 
     # Verify
     assert result == mock_transactions
     mock_qb_client.get_report.assert_called_once_with(
       "JournalReport", {"start_date": "2023-01-01"}
+    )
+
+  def test_get_transactions_testing_migration_explicit(self, mock_qb_client):
+    """Explicit testing_migration=True routes the request through Intuit's v2
+    reporting service via the `testing_migration` query param."""
+    client = QBClient.__new__(QBClient)
+    client.client = mock_qb_client
+    mock_qb_client.get_report.return_value = {"transactions": []}
+
+    client.get_transactions("2023-01-01", "2023-12-31", testing_migration=True)
+
+    mock_qb_client.get_report.assert_called_once_with(
+      "JournalReport",
+      {
+        "start_date": "2023-01-01",
+        "end_date": "2023-12-31",
+        "testing_migration": "true",
+      },
+    )
+
+  @patch("robosystems.adapters.quickbooks.client.api.env")
+  def test_get_transactions_testing_migration_from_flag(self, mock_env, mock_qb_client):
+    """With no explicit arg, the INTUIT_REPORTS_TESTING_MIGRATION config flag
+    decides whether the v2 param is sent."""
+    mock_env.INTUIT_REPORTS_TESTING_MIGRATION = True
+    client = QBClient.__new__(QBClient)
+    client.client = mock_qb_client
+    mock_qb_client.get_report.return_value = {"transactions": []}
+
+    client.get_transactions("2023-01-01", "2023-12-31")
+
+    mock_qb_client.get_report.assert_called_once_with(
+      "JournalReport",
+      {
+        "start_date": "2023-01-01",
+        "end_date": "2023-12-31",
+        "testing_migration": "true",
+      },
     )
 
   # ---- CDC endpoint -----------------------------------------------------

--- a/tests/adapters/qb/client/test_api.py
+++ b/tests/adapters/qb/client/test_api.py
@@ -467,6 +467,21 @@ class TestQBClient:
       },
     )
 
+  @patch("robosystems.adapters.quickbooks.client.api.env")
+  def test_get_transactions_v1_fallback_when_flag_false(self, mock_env, mock_qb_client):
+    """The SSM kill switch: with the flag off and no explicit arg, the
+    `testing_migration` param is omitted and we stay on v1."""
+    mock_env.INTUIT_REPORTS_TESTING_MIGRATION = False
+    client = QBClient.__new__(QBClient)
+    client.client = mock_qb_client
+    mock_qb_client.get_report.return_value = {"transactions": []}
+
+    client.get_transactions("2023-01-01", "2023-12-31")
+
+    mock_qb_client.get_report.assert_called_once_with(
+      "JournalReport", {"start_date": "2023-01-01", "end_date": "2023-12-31"}
+    )
+
   # ---- CDC endpoint -----------------------------------------------------
 
   def _make_cdc_client(self, realm_id="1234567890123456789"):

--- a/tests/adapters/qb/pipeline/test_utils.py
+++ b/tests/adapters/qb/pipeline/test_utils.py
@@ -442,6 +442,10 @@ class TestParseJournalReport:
         ],
       }
 
+    # Two transaction groups, each closed by its own typed Section/Summary
+    # row — so the test proves group ISOLATION (no bleed), not just that a
+    # single transaction parses.
+    section_row = {"type": "Section", "Summary": {"ColData": [{"value": "Total"}]}}
     report = {
       # v2 #10 — Header always present; parser ignores it, must not choke
       "Header": {
@@ -453,6 +457,7 @@ class TestParseJournalReport:
       "Columns": {"Column": [{"ColTitle": "Date"}, {"ColTitle": "Transaction Type"}]},
       "Rows": {
         "Row": [
+          # Group 1 — Invoice 101: DR AR 500 / CR Revenue 500
           _v2_data_row(
             "2024-03-15",
             "Invoice",
@@ -475,29 +480,59 @@ class TestParseJournalReport:
             "",
             "500.00",
           ),
-          # v2 #8 — group/summary row is now typed "Section" but still
-          # carries the Summary payload the parser keys group breaks off.
-          {"type": "Section", "Summary": {"ColData": [{"value": "Total"}]}},
+          section_row,
+          # Group 2 — JournalEntry 202: DR Cash 300 / CR Revenue 300
+          _v2_data_row(
+            "2024-03-20",
+            "Journal Entry",
+            "202",
+            "JE-9",
+            "Cash sale",
+            "Cash",
+            "3",
+            "300.00",
+            "",
+          ),
+          _v2_data_row(
+            "",
+            "",
+            "",
+            "",
+            "Cash sale",
+            "Revenue",
+            "2",
+            "",
+            "300.00",
+          ),
+          section_row,
         ]
       },
     }
 
     entries, lines = parse_journal_report(report)
 
-    assert len(entries) == 1
-    assert entries[0]["Id"] == "Invoice_101"
+    # Group isolation: two distinct entries, lines attributed to the right one.
+    assert [e["Id"] for e in entries] == ["Invoice_101", "JournalEntry_202"]
     assert entries[0]["TxnDate"] == "2024-03-15"
     assert entries[0]["DocNumber"] == "INV-001"
     assert entries[0]["TotalAmt"] == 500.0
+    assert entries[1]["TxnDate"] == "2024-03-20"
+    assert entries[1]["TotalAmt"] == 300.0
 
-    assert len(lines) == 2
+    assert len(lines) == 4
+    # Group 1 lines belong to the Invoice...
+    assert {line_["journal_entry_id"] for line_ in lines[:2]} == {"Invoice_101"}
     assert lines[0]["PostingType"] == "Debit"
-    assert lines[0]["Amount"] == 500.0
     assert lines[0]["AccountRef_value"] == "1"
     assert lines[1]["PostingType"] == "Credit"
-    assert lines[1]["Amount"] == 500.0
     assert lines[1]["AccountRef_value"] == "2"
-    # Double-entry still balances after v2 reshaping.
+    # ...and group 2 lines belong to the JournalEntry — the second group did
+    # NOT bleed into the first.
+    assert {line_["journal_entry_id"] for line_ in lines[2:]} == {"JournalEntry_202"}
+    assert lines[2]["AccountRef_value"] == "3"
+    assert lines[2]["Amount"] == 300.0
+
+    # Double-entry still balances overall after v2 reshaping.
     assert sum(
       line_["Amount"] for line_ in lines if line_["PostingType"] == "Debit"
     ) == (sum(line_["Amount"] for line_ in lines if line_["PostingType"] == "Credit"))

--- a/tests/adapters/qb/pipeline/test_utils.py
+++ b/tests/adapters/qb/pipeline/test_utils.py
@@ -409,6 +409,99 @@ class TestParseJournalReport:
     assert lines[1]["PostingType"] == "Credit"
     assert lines[1]["AccountRef_value"] == "2"
 
+  def test_v2_modernized_report_shape(self):
+    """Parser survives Intuit's modernized (v2) Reports API response shape.
+
+    Covers the documented v2 differences that can surface in a JournalReport
+    (https://medium.com/intuitdev/upcoming-changes-to-reports-apis-5083ec9aadce):
+      #1  null amounts always come back as "" (already handled — asserted here)
+      #8  rows carry a `type` field: "Section" for group/summary rows,
+          "Data" for leaf rows (v1 omitted it / mislabeled empty sections)
+      #10 Header block with StartPeriod/EndPeriod always present
+      — extra trailing ColData columns appended by v2 must be ignored
+
+    The load-bearing invariant: group boundaries are still keyed off the
+    `Summary` payload, so transactions don't bleed together when v2 also
+    stamps `type: "Section"` on that row.
+    """
+    from robosystems.adapters.quickbooks.pipeline.utils import parse_journal_report
+
+    def _v2_data_row(date, tx_type, tx_id, num, memo, account, account_id, dr, cr):
+      return {
+        "type": "Data",  # v2 #8 — leaf rows are now typed
+        "ColData": [
+          {"value": date},
+          {"value": tx_type, "id": tx_id},
+          {"value": num},
+          {"value": ""},  # Name
+          {"value": memo},
+          {"value": account, "id": account_id},
+          {"value": dr},  # v2 #1 — "" when no value (never 0 / absent)
+          {"value": cr},
+          {"value": "USD"},  # v2 may append columns — must be ignored
+        ],
+      }
+
+    report = {
+      # v2 #10 — Header always present; parser ignores it, must not choke
+      "Header": {
+        "ReportName": "JournalReport",
+        "StartPeriod": "2024-03-01",
+        "EndPeriod": "2024-03-31",
+        "Currency": "USD",
+      },
+      "Columns": {"Column": [{"ColTitle": "Date"}, {"ColTitle": "Transaction Type"}]},
+      "Rows": {
+        "Row": [
+          _v2_data_row(
+            "2024-03-15",
+            "Invoice",
+            "101",
+            "INV-001",
+            "Service revenue",
+            "Accounts Receivable",
+            "1",
+            "500.00",
+            "",
+          ),
+          _v2_data_row(
+            "",
+            "",
+            "",
+            "",
+            "Service revenue",
+            "Revenue",
+            "2",
+            "",
+            "500.00",
+          ),
+          # v2 #8 — group/summary row is now typed "Section" but still
+          # carries the Summary payload the parser keys group breaks off.
+          {"type": "Section", "Summary": {"ColData": [{"value": "Total"}]}},
+        ]
+      },
+    }
+
+    entries, lines = parse_journal_report(report)
+
+    assert len(entries) == 1
+    assert entries[0]["Id"] == "Invoice_101"
+    assert entries[0]["TxnDate"] == "2024-03-15"
+    assert entries[0]["DocNumber"] == "INV-001"
+    assert entries[0]["TotalAmt"] == 500.0
+
+    assert len(lines) == 2
+    assert lines[0]["PostingType"] == "Debit"
+    assert lines[0]["Amount"] == 500.0
+    assert lines[0]["AccountRef_value"] == "1"
+    assert lines[1]["PostingType"] == "Credit"
+    assert lines[1]["Amount"] == 500.0
+    assert lines[1]["AccountRef_value"] == "2"
+    # Double-entry still balances after v2 reshaping.
+    assert sum(
+      line_["Amount"] for line_ in lines if line_["PostingType"] == "Debit"
+    ) == (sum(line_["Amount"] for line_ in lines if line_["PostingType"] == "Credit"))
+
   def test_empty_report(self):
     from robosystems.adapters.quickbooks.pipeline.utils import parse_journal_report
 


### PR DESCRIPTION
## Summary

Intuit is migrating the QuickBooks Reports APIs to its modernized ("v2") reporting service. After the **2026-08-31** cutover, all Reports responses are served by v2 unconditionally and the temporary `testing_migration` opt-in param becomes a no-op. `JournalReport` is our **live GL posting source** (`adapters/quickbooks/pipeline/extract.py`), so this PR cuts it over to v2 ahead of the deadline — under our control, with v1 still reachable as a runtime fallback until the cutover.

Validated non-destructively against a live sandbox tenant's full history before defaulting it on: v1 and v2 parse **byte-identically** (129 transactions / 339 lines / $81,064.53, balanced both ways), no nested rows, unchanged 8-column shape. The only structural difference is v2 dropping redundant per-transaction header rows, which `parse_journal_report` already skips. The migration is effectively a no-op for our parser.

## Changes

- **`config/env.py`** — new `INTUIT_REPORTS_TESTING_MIGRATION` flag, **default `true`**. Set `false` via SSM (`features/INTUIT_REPORTS_TESTING_MIGRATION`) to fall back to v1 at runtime with no redeploy (only meaningful until the 2026-08-31 cutover).
- **`adapters/quickbooks/client/api.py`** — `QBClient.get_transactions` takes a `testing_migration` arg (defaults to the config flag); when set, appends `testing_migration` to the JournalReport request so it routes through Intuit's v2 service.
- **`tests/adapters/qb/pipeline/test_utils.py`** — `test_v2_modernized_report_shape`: parser regression guard covering the documented v2 changes that can surface in a JournalReport (typed `Section`/`Data` rows, Header block with StartPeriod/EndPeriod, empty-string nulls, extra trailing columns) and asserting group boundaries still hold.
- **`tests/adapters/qb/client/test_api.py`** — two tests for the param (explicit arg + flag-driven); the three existing date-handling tests pass `testing_migration=False` to stay isolated from the now-default-on flag.

## Testing

- `uv run pytest tests/adapters/qb/` — **143 passed**.
- `ruff check`, `ruff format --check`, `basedpyright` on changed files — clean (also confirmed by the pre-commit hook).
- **Live validation:** ran a non-destructive v1-vs-v2 `JournalReport` diff against a connected sandbox tenant (full history) — parsed output byte-identical, balanced, no nesting.
- Full `just test-all` — not run in this session.

## Notes / Follow-ups

- **After 2026-08-31:** remove the flag and the `get_transactions` param (dead code once Intuit forces v2 server-side).
- If the QB Phase 6 work (JournalReport retirement → per-entity `Line[]` synthesis) lands first, this flag is moot — JournalReport is no longer called.
- Rollout posture: deploy with v2 on; if anything looks off in production, flip the SSM flag to `false` for an instant fallback to v1.
