### PR TITLE
fix(sec): route read-only analysis views to read endpoint

### DIFF
--- a/robosystems/adapters/sec/mcp/report_resolver.py
+++ b/robosystems/adapters/sec/mcp/report_resolver.py
@@ -63,7 +63,10 @@ async def resolve_sec_report(
   )
 
   try:
-    repository = await get_graph_repository(graph_id)
+    # Read-only resolution against the shared SEC repo — route to the replica
+    # ALB via operation_type="read"; the default "write" path resolves the
+    # shared master (DynamoDB discovery + retry) and times out the MCP tool.
+    repository = await get_graph_repository(graph_id, operation_type="read")
     rows = await repository.execute_query(query, parameters)
     if rows:
       return rows[0]

--- a/robosystems/operations/roboledger/views/fact_query.py
+++ b/robosystems/operations/roboledger/views/fact_query.py
@@ -256,7 +256,10 @@ async def query_fact_grid(
   query += "\nWHERE " + "\n  AND ".join(where_clauses)
   query += return_clause
 
-  repository = await get_graph_repository(graph_id)
+  # Read-only analytical query — route to read endpoint. On shared repos (SEC)
+  # this hits the replica ALB rather than the shared master's slow discovery
+  # path; on tenant graphs operation_type is ignored (single instance).
+  repository = await get_graph_repository(graph_id, operation_type="read")
   results = await repository.execute_query(query, parameters)
 
   base_columns = ["element_id", "element_name", "period_end", "value", "unit"]

--- a/robosystems/operations/roboledger/views/financial_statement_query.py
+++ b/robosystems/operations/roboledger/views/financial_statement_query.py
@@ -128,7 +128,12 @@ async def query_financial_statement(
     "LIMIT $limit"
   )
 
-  repository = await get_graph_repository(graph_id)
+  # Read-only analytical query. ``operation_type="read"`` is load-bearing for
+  # shared repositories (SEC): it routes to the replica ALB instead of the
+  # shared master, whose discovery path (DynamoDB lookup + retry/backoff) blows
+  # past the MCP tool timeout. For tenant entity graphs the user-graph router
+  # ignores operation_type (single instance per graph), so this is a no-op there.
+  repository = await get_graph_repository(graph_id, operation_type="read")
   return await repository.execute_query(query, parameters)
 
 

--- a/tests/adapters/sec/mcp/test_report_resolver.py
+++ b/tests/adapters/sec/mcp/test_report_resolver.py
@@ -66,6 +66,19 @@ class TestResolveSecReport:
 
   @pytest.mark.asyncio
   @pytest.mark.unit
+  async def test_routes_to_read_endpoint(self, mock_repository):
+    """Read-only resolution must route to the read endpoint (replica ALB on the
+    shared SEC repo). The default "write" path resolves the shared master
+    (DynamoDB discovery + retry) and times out the MCP tool. Regression guard."""
+    with patch(
+      "robosystems.adapters.sec.mcp.report_resolver.get_graph_repository",
+      return_value=mock_repository,
+    ) as mock_get_repo:
+      await resolve_sec_report(MOCK_GRAPH, ticker="NVDA")
+    assert mock_get_repo.call_args.kwargs.get("operation_type") == "read"
+
+  @pytest.mark.asyncio
+  @pytest.mark.unit
   async def test_fiscal_year_filter_threaded(self, mock_repository):
     with patch(
       "robosystems.adapters.sec.mcp.report_resolver.get_graph_repository",

--- a/tests/operations/roboledger/views/test_fact_query.py
+++ b/tests/operations/roboledger/views/test_fact_query.py
@@ -83,6 +83,17 @@ class TestIsTicker:
 class TestQueryFactGrid:
   @pytest.mark.asyncio
   @pytest.mark.unit
+  async def test_routes_to_read_endpoint(self, mock_repository):
+    """Read-only analytical query: must acquire the repository with
+    operation_type="read" so shared repos (SEC) route to the replica ALB.
+    The default "write" path resolves the shared master (DynamoDB discovery +
+    retry) and times out the MCP tool. Regression guard for that bug."""
+    with patch(PATCH_REPO, return_value=mock_repository) as mock_get_repo:
+      await query_fact_grid(MOCK_GRAPH_ID, elements=["us-gaap:Assets"])
+    assert mock_get_repo.call_args.kwargs.get("operation_type") == "read"
+
+  @pytest.mark.asyncio
+  @pytest.mark.unit
   async def test_single_element_uses_inline_anchor(self, mock_repository):
     """Single qname → inline `(el:Element {qname: 'x'})` for fast lookup."""
     with patch(PATCH_REPO, return_value=mock_repository):

--- a/tests/operations/roboledger/views/test_financial_statement_query.py
+++ b/tests/operations/roboledger/views/test_financial_statement_query.py
@@ -59,6 +59,25 @@ class TestQueryFinancialStatement:
 
   @pytest.mark.asyncio
   @pytest.mark.unit
+  async def test_routes_to_read_endpoint(self, mock_repository):
+    """This is a read-only analytical query: it must acquire the repository
+    with operation_type="read". On shared repos that routes to the replica ALB;
+    the default "write" path resolves the shared master (DynamoDB discovery +
+    retry) and times out the MCP tool. Regression guard for that bug."""
+    with patch(
+      "robosystems.operations.roboledger.views.financial_statement_query.get_graph_repository",
+      return_value=mock_repository,
+    ) as mock_get_repo:
+      await query_financial_statement(
+        MOCK_GRAPH,
+        statement_type="income_statement",
+        report_id="rpt_abc",
+      )
+
+    assert mock_get_repo.call_args.kwargs.get("operation_type") == "read"
+
+  @pytest.mark.asyncio
+  @pytest.mark.unit
   async def test_ticker_path(self, mock_repository):
     with patch(
       "robosystems.operations.roboledger.views.financial_statement_query.get_graph_repository",


### PR DESCRIPTION
## Problem

`financial-statement-analysis`, `build-fact-grid`, and SEC ticker auto-resolution time out (25s MCP tool limit) against the SEC shared repository — while the identical read-only Cypher returns instantly via `read-graph-cypher`.

## Root cause

All three acquire their graph repository via `get_graph_repository(graph_id)`, which **defaults `operation_type="write"`**. On shared repositories that routes to the shared **master** — `_get_shared_master_url()` does DynamoDB discovery + `@with_retry` backoff + circuit-breaker checks, then hits a single writer instance — rather than the replica ALB.

The MCP client factory already does the right thing for the cypher tool: `middleware/mcp/factory.py` builds the client with `operation_type="read"` for shared repos, so `read-graph-cypher` rides the fast replica path. These three ops-layer view helpers bypassed `self.client` and re-acquired a repository with the write default, undoing that routing.

The query itself is not the problem — proven by running the exact statement query (inlined literals **and** the tool's real `$report_id`/`$statement_type`/`$limit` parameters) through `read-graph-cypher`: full NVDA income statement, 54 rows, sub-second.

## Fix

Pass `operation_type="read"` at the three read-only call sites:

- `operations/roboledger/views/financial_statement_query.py`
- `operations/roboledger/views/fact_query.py` (build-fact-grid)
- `adapters/sec/mcp/report_resolver.py`

Safe on both routes:
- **SEC shared repo** → routes to the replica ALB (the fix).
- **Tenant entity graph** → no-op: `_create_user_graph_client` ignores `operation_type` (single LadybugDB instance per graph serves both reads and writes).

These are genuinely read-only analytical queries on both routes, so a single blanket `"read"` is correct and keeps the view layer schema-agnostic.

## Why it escaped notice

The bug is **prod/staging-only**. In dev, shared-repo routing collapses both read and write to the local Graph API endpoint, so it never reproduces locally. The footprint is also small — every other `get_graph_repository` / `get_universal_repository` call site in the codebase already passes `operation_type` explicitly.

## Tests

- Added 3 regression guards asserting each view acquires the repository with `operation_type="read"`.
- `just test-code` — ruff + format + basedpyright + cf-lint all pass.
- 71 tests pass across the five affected test files.

## End-to-end confirmation

Since it can't reproduce locally, the true confirmation is calling `financial-statement-analysis` / `build-fact-grid` against the SEC repo once this is deployed — they should return instead of timing out at 25s.