### PR TITLE
fix(sec): key incremental quarter selection off Eastern time

### DIFF
--- a/robosystems/adapters/sec/__init__.py
+++ b/robosystems/adapters/sec/__init__.py
@@ -1,12 +1,12 @@
 """SEC EDGAR adapter for XBRL financial data extraction."""
 
-from datetime import UTC, datetime
+from datetime import datetime
+from zoneinfo import ZoneInfo
 
-# Quarter overlap window for incremental updates.
-# SEC filings submitted near quarter-end may not appear in EFTS for 1-2 days
-# due to SEC indexing delays and UTC/EST timing differences. We scan the
-# previous quarter during the first N days of a new quarter to catch these.
-QUARTER_OVERLAP_DAYS = 5
+# SEC filings follow the US-market (Eastern) calendar. The nightly pipeline runs
+# at 21:00 ET; on a quarter's last day that is already the next day in UTC, so
+# quarter selection must key off Eastern time, not the container's UTC clock.
+EASTERN = ZoneInfo("America/New_York")
 
 _LAZY_IMPORTS = {
   "SEC_BASE_URL": "robosystems.adapters.sec.client",
@@ -43,70 +43,32 @@ def get_current_quarter(now: datetime | None = None) -> tuple[int, int]:
   """Get the current year and quarter.
 
   Args:
-      now: Optional datetime to use (defaults to UTC now).
+      now: Optional datetime to use (defaults to Eastern-time now, matching the
+          SEC filing calendar).
 
   Returns:
       Tuple of (year, quarter) where quarter is 1-4.
   """
   if now is None:
-    now = datetime.now(UTC)
+    now = datetime.now(EASTERN)
   quarter = (now.month - 1) // 3 + 1
   return now.year, quarter
 
 
-def get_previous_quarter(year: int, quarter: int) -> tuple[int, int]:
-  """Get the previous quarter given a year and quarter.
-
-  Args:
-      year: The year.
-      quarter: The quarter (1-4).
-
-  Returns:
-      Tuple of (year, quarter) for the previous quarter.
-  """
-  if quarter == 1:
-    return year - 1, 4
-  return year, quarter - 1
-
-
-def is_in_quarter_overlap_window(now: datetime | None = None) -> bool:
-  """Check if we're in the quarter overlap window (first N days of a new quarter).
-
-  During this window, we should also scan the previous quarter to catch
-  late-indexed filings from the prior quarter.
-
-  Args:
-      now: Optional datetime to use (defaults to UTC now).
-
-  Returns:
-      True if we're in the overlap window.
-  """
-  if now is None:
-    now = datetime.now(UTC)
-  _, quarter = get_current_quarter(now)
-  quarter_start_month = (quarter - 1) * 3 + 1
-  return now.month == quarter_start_month and now.day <= QUARTER_OVERLAP_DAYS
-
-
 def get_quarters_to_scan(now: datetime | None = None) -> list[str]:
-  """Get list of partition keys (quarters) to scan for incremental updates.
+  """Get the partition key(s) to scan for the incremental nightly download.
 
-  Always scans current quarter. Also scans previous quarter during the
-  overlap window (first N days of a new quarter).
+  Hard cut-over: exactly one quarter per run — the current (Eastern-time)
+  quarter. There is no previous-quarter overlap; the final batch of a quarter is
+  trusted to capture that quarter's filings. Quarter selection keys off Eastern
+  time so the last-day-of-quarter run (21:00 ET, already next-day in UTC) stays
+  on the correct quarter.
 
   Args:
-      now: Optional datetime to use (defaults to UTC now).
+      now: Optional datetime to use (defaults to Eastern-time now).
 
   Returns:
-      List of partition keys like ["2025-Q1"] or ["2025-Q1", "2024-Q4"].
+      Single-element list of partition keys, e.g. ["2026-Q2"].
   """
-  if now is None:
-    now = datetime.now(UTC)
   year, quarter = get_current_quarter(now)
-  quarters = [f"{year}-Q{quarter}"]
-
-  if is_in_quarter_overlap_window(now):
-    prev_year, prev_quarter = get_previous_quarter(year, quarter)
-    quarters.append(f"{prev_year}-Q{prev_quarter}")
-
-  return quarters
+  return [f"{year}-Q{quarter}"]

--- a/robosystems/adapters/sec/pipeline/sensors.py
+++ b/robosystems/adapters/sec/pipeline/sensors.py
@@ -311,9 +311,9 @@ def sec_incremental_pipeline_sensor(context: RunStatusSensorContext):
   via the S3 filing cache. This sensor re-triggers process runs until the
   queue is drained across all partitions, then hands off to staging.
 
-  At quarter boundaries, the download schedule scans two quarters (current +
-  previous). This sensor waits for both partitions to fully drain before
-  triggering staging, ensuring DuckDB receives a complete batch.
+  The download schedule scans exactly one quarter per run (hard cut-over, keyed
+  off Eastern time), so there is normally a single partition to drain before
+  staging.
 
   The stage_to_materialize_sensor handles the next step (stage → materialize).
   """

--- a/robosystems/adapters/sec/pipeline/sensors.py
+++ b/robosystems/adapters/sec/pipeline/sensors.py
@@ -222,20 +222,20 @@ def sec_processing_sensor(context: SensorEvaluationContext):
 # ============================================================================
 
 
-def _get_quarters_to_scan() -> list[str]:
-  """Get quarters to scan for incremental download.
+def _get_quarters_to_scan(now: datetime | None = None) -> list[str]:
+  """Get the single quarter to scan for the incremental nightly download.
 
-  Always scans current quarter. Also scans previous quarter during the first
-  several days of a new quarter to catch late-indexed filings (filings submitted
-  near quarter-end may not appear in EFTS for 1-2 days due to SEC indexing delays
-  and UTC/EST timing differences).
+  Hard cut-over: one quarter per run, keyed off Eastern time. Pass the
+  schedule's ``scheduled_execution_time`` so the last-day-of-quarter run
+  (21:00 ET, already next-day in UTC) stays on the correct quarter instead of
+  rolling to the next quarter by the container's UTC clock.
 
   Returns:
-      List of partition keys like ["2025-Q1"] or ["2025-Q1", "2024-Q4"]
+      Single-element list of partition keys like ["2026-Q2"]
   """
   from robosystems.adapters.sec import get_quarters_to_scan
 
-  return get_quarters_to_scan()
+  return get_quarters_to_scan(now)
 
 
 @schedule(
@@ -245,10 +245,12 @@ def _get_quarters_to_scan() -> list[str]:
   execution_timezone="America/New_York",
 )
 def sec_incremental_download_schedule(context):
-  """Incremental SEC download at 9pm EST on weekdays.
+  """Incremental SEC download at 9pm ET on weekdays.
 
-  Part of the automated incremental pipeline. Downloads new filings for
-  current quarter (and previous quarter at quarter boundaries).
+  Part of the automated incremental pipeline. Downloads new filings for the
+  current quarter only (hard cut-over). The quarter is keyed off the schedule's
+  Eastern execution time, so the last-day-of-quarter run stays on the correct
+  quarter instead of rolling forward by the container's UTC clock.
 
   Chain: download → process → stage → materialize → S3 sync
 
@@ -256,8 +258,8 @@ def sec_incremental_download_schedule(context):
   """
   from robosystems.adapters.sec.pipeline.configs import SECDownloadConfig
 
-  quarters = _get_quarters_to_scan()
-  context.log.info(f"Incremental download for quarters: {quarters}")
+  quarters = _get_quarters_to_scan(context.scheduled_execution_time)
+  context.log.info(f"Incremental download for quarter: {quarters[0]}")
 
   # Generate batch_id to track all jobs from this schedule tick
   # Used by downstream sensors to wait for all quarters to complete

--- a/robosystems/adapters/sec/processors/ingestion/staging.py
+++ b/robosystems/adapters/sec/processors/ingestion/staging.py
@@ -268,26 +268,18 @@ class DuckDBStager:
     Returns:
         StagingResult with tables staged and row counts (net new rows)
     """
-    from robosystems.adapters.sec import (
-      get_current_quarter,
-      get_previous_quarter,
-      is_in_quarter_overlap_window,
-    )
+    from robosystems.adapters.sec import get_current_quarter
 
     start_time = time.time()
     log_progress = make_progress_logger(progress_callback)
 
-    # Default to current year/quarter
-    now = datetime.now(UTC)
+    # Default to the current Eastern-time quarter (SEC filing calendar). Hard
+    # cut-over: stage exactly the target quarter, with no previous-quarter
+    # overlap.
     if year is None or quarter is None:
-      year, quarter = get_current_quarter(now)
+      year, quarter = get_current_quarter()
 
-    # Build list of quarters to scan (current + previous during overlap period)
     quarters_to_scan: list[tuple[int, int]] = [(year, quarter)]
-
-    if is_in_quarter_overlap_window(now):
-      prev_year, prev_quarter = get_previous_quarter(year, quarter)
-      quarters_to_scan.append((prev_year, prev_quarter))
 
     quarters_str = ", ".join(f"{y}-Q{q}" for y, q in quarters_to_scan)
     logger.info(

--- a/tests/adapters/sec/pipeline/test_sensors.py
+++ b/tests/adapters/sec/pipeline/test_sensors.py
@@ -9,6 +9,7 @@ This file covers the incremental pipeline chain sensors:
 
 from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
+from zoneinfo import ZoneInfo
 
 import pytest
 from dagster import (
@@ -582,19 +583,20 @@ class TestSecIncrementalDownloadSchedule:
     assert result[0].tags["mode"] == "incremental"
 
   @patch("robosystems.adapters.sec.pipeline.sensors._get_quarters_to_scan")
-  def test_yields_multiple_quarters_at_boundary(self, mock_quarters):
-    """Test schedule yields two RunRequests at quarter boundary."""
-    mock_quarters.return_value = ["2025-Q1", "2024-Q4"]
+  def test_yields_single_quarter_keyed_off_et_tick(self, mock_quarters):
+    """Hard cut-over: one RunRequest, quarter derived from the ET tick time."""
+    mock_quarters.return_value = ["2026-Q2"]
 
-    context = build_schedule_context(
-      scheduled_execution_time=datetime(2025, 1, 2, 21, 0, tzinfo=UTC)
-    )
+    # 2026-06-30 21:00 ET is already 2026-07-01 in UTC; the schedule must key
+    # the quarter off the ET scheduled time, not the container UTC clock.
+    sched = datetime(2026, 6, 30, 21, 0, tzinfo=ZoneInfo("America/New_York"))
+    context = build_schedule_context(scheduled_execution_time=sched)
 
     result = list(sec_incremental_download_schedule(context))
 
-    assert len(result) == 2
-    partition_keys = {r.partition_key for r in result}
-    assert partition_keys == {"2025-Q1", "2024-Q4"}
+    assert len(result) == 1
+    assert result[0].partition_key == "2026-Q2"
+    mock_quarters.assert_called_once_with(sched)
 
   @patch("robosystems.adapters.sec.pipeline.sensors._get_quarters_to_scan")
   def test_run_keys_include_batch_id(self, mock_quarters):
@@ -642,17 +644,48 @@ class TestGetQuartersToScan:
     mock_get_quarters.assert_called_once()
 
   @patch("robosystems.adapters.sec.get_quarters_to_scan")
-  def test_returns_list_of_partition_keys(self, mock_get_quarters):
-    """Test returns properly formatted partition keys."""
-    mock_get_quarters.return_value = ["2025-Q1", "2024-Q4"]
+  def test_returns_single_partition_key(self, mock_get_quarters):
+    """Hard cut-over: exactly one properly formatted partition key."""
+    mock_get_quarters.return_value = ["2026-Q2"]
 
     result = _get_quarters_to_scan()
 
     assert isinstance(result, list)
-    assert len(result) == 2
-    for key in result:
-      parts = key.split("-Q")
-      assert len(parts) == 2
+    assert len(result) == 1
+    parts = result[0].split("-Q")
+    assert len(parts) == 2
+
+
+@pytest.mark.unit
+class TestQuarterSelectionEasternHardCutover:
+  """Regression tests for the ET-keyed, single-quarter hard cut-over.
+
+  The bug: quarter was computed from the container's UTC clock, so the 21:00 ET
+  run on a quarter's last day (already next-day in UTC) rolled to the next
+  quarter and also fired a spurious previous-quarter overlap run.
+  """
+
+  def test_last_evening_of_q2_stays_q2(self):
+    from robosystems.adapters.sec import get_current_quarter, get_quarters_to_scan
+
+    # 2026-06-30 21:00 ET == 2026-07-01 01:00 UTC — must resolve to Q2, not Q3.
+    now = datetime(2026, 6, 30, 21, 0, tzinfo=ZoneInfo("America/New_York"))
+    assert get_current_quarter(now) == (2026, 2)
+    assert get_quarters_to_scan(now) == ["2026-Q2"]
+
+  def test_first_evening_of_q3_is_q3_only(self):
+    from robosystems.adapters.sec import get_quarters_to_scan
+
+    # First day of Q3 — no previous-quarter (Q2) overlap under hard cut-over.
+    now = datetime(2026, 7, 1, 21, 0, tzinfo=ZoneInfo("America/New_York"))
+    assert get_quarters_to_scan(now) == ["2026-Q3"]
+
+  def test_always_single_quarter(self):
+    from robosystems.adapters.sec import get_quarters_to_scan
+
+    # A few days into a new quarter — still exactly one quarter (no overlap).
+    now = datetime(2026, 7, 3, 21, 0, tzinfo=ZoneInfo("America/New_York"))
+    assert get_quarters_to_scan(now) == ["2026-Q3"]
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

The nightly incremental SEC download selected its quarter from the container's **UTC clock**, so the 21:00 ET run on a quarter's last day (already the next day in UTC) rolled forward to the next quarter — and, because it also ran a "previous-quarter overlap," fired a second run for the prior quarter. On 2026-06-30 this produced two runs: **Q3 (empty — not Q3 yet)** and **Q2 (the real data)**.

This keys quarter selection off **Eastern time** (the SEC filing calendar) and does a **hard cut-over**: exactly one quarter per run, no previous-quarter overlap.

- `2026-06-30 21:00 ET` → `["2026-Q2"]`
- `2026-07-01 21:00 ET` → `["2026-Q3"]`

## Changes

- **`adapters/sec/__init__.py`** — `get_current_quarter()` and `get_quarters_to_scan()` default to Eastern (`America/New_York`) instead of UTC; `get_quarters_to_scan()` now returns a single current quarter. Removed the overlap machinery (`is_in_quarter_overlap_window`, `get_previous_quarter`, `QUARTER_OVERLAP_DAYS`).
- **`adapters/sec/pipeline/sensors.py`** — the incremental download schedule keys the quarter off `context.scheduled_execution_time` (already tz-aware in `America/New_York`) and yields a single `RunRequest`; `_get_quarters_to_scan()` threads that time through.
- **`adapters/sec/processors/ingestion/staging.py`** — incremental DuckDB staging stages exactly the target quarter; removed its own UTC-based overlap block (same `datetime.now(UTC)` bug).
- **`tests/adapters/sec/pipeline/test_sensors.py`** — replaced the obsolete "two quarters at boundary" test; added ET regression tests locking in `6/30 21:00 ET → 2026-Q2`, `7/1 → 2026-Q3`, and single-quarter-always.

## Testing

- Import smoke exercised the real functions: `6/30 21:00 ET → ['2026-Q2']`, `7/1 21:00 ET → ['2026-Q3']`.
- Pre-commit gate green: `ruff` clean, `ruff format` clean, `basedpyright` 0 errors.
- Unit tests written but **not executed locally** — this test path's conftest requires Postgres and the local stack was down this session. They run in CI.

## Notes

- **Deliberate trade-off:** the removed overlap re-scanned the previous quarter for the first 5 days of a new quarter to catch filings SEC indexes 1–5 days late. Hard cut-over drops that — a filing filed near quarter-end but indexed after the cut-over could be missed. We trust the final batch of each quarter to capture its filings.
- Surfaced while dry-running the SEC shared-master off-hours parking: with the master parked, the spurious empty Q3 run failed loudly (`staging: Connection error: All connection attempts failed`) instead of silently doing nothing.
