### PR TITLE
feat(sec): auto-park the shared master around the nightly pipeline

### DIFF
--- a/cloudformation/dagster.yaml
+++ b/cloudformation/dagster.yaml
@@ -491,6 +491,9 @@ Resources:
                 Action:
                   - autoscaling:UpdateAutoScalingGroup
                   - autoscaling:StartInstanceRefresh
+                  # SEC shared-master parking (scale to 0/1 + clear scale-in protection)
+                  - autoscaling:SetDesiredCapacity
+                  - autoscaling:SetInstanceProtection
                 Resource:
                   - !Sub "arn:${AWS::Partition}:autoscaling:${AWS::Region}:${AWS::AccountId}:autoScalingGroup:*:autoScalingGroupName/robosystems-*-${Environment}-asg"
               # CloudFormation for shared replica ALB discovery

--- a/robosystems/adapters/sec/pipeline/__init__.py
+++ b/robosystems/adapters/sec/pipeline/__init__.py
@@ -90,6 +90,8 @@ from robosystems.adapters.sec.pipeline.jobs import (
   sec_ixbrl_index_job,
   sec_lbug_r2_publish_job,
   sec_lbug_s3_publish_job,
+  sec_master_sleep_job,
+  sec_master_wake_job,
   sec_materialize_job,
   sec_narratives_index_job,
   sec_process_job,
@@ -97,6 +99,8 @@ from robosystems.adapters.sec.pipeline.jobs import (
   sec_staged_materialize_job,
   sec_vector_s3_publish_job,
 )
+from robosystems.adapters.sec.pipeline.master_sleep import sec_master_asleep
+from robosystems.adapters.sec.pipeline.master_wake import sec_master_awake
 from robosystems.adapters.sec.pipeline.materialize import (
   sec_graph_materialized,
   sec_historical_materialized,
@@ -111,10 +115,12 @@ from robosystems.adapters.sec.pipeline.sensors import (
   sec_incremental_download_schedule,
   sec_incremental_pipeline_sensor,
   sec_index_retry_sensor,
+  sec_master_sleep_on_failure_sensor,
   sec_post_materialize_publish_sensor,
   sec_post_stage_index_sensor,
   sec_processing_sensor,
   sec_stage_to_materialize_sensor,
+  sec_wake_to_stage_sensor,
 )
 from robosystems.adapters.sec.pipeline.stage import (
   sec_duckdb_incremental_staged,
@@ -156,6 +162,8 @@ def get_dagster_components():
       sec_knowledge_artifacts,
       sec_narratives_indexed,
       sec_ixbrl_disclosures_indexed,
+      sec_master_awake,
+      sec_master_asleep,
     ],
     "jobs": [
       sec_download_job,
@@ -176,6 +184,8 @@ def get_dagster_components():
       sec_historical_lbug_s3_publish_job,
       sec_narratives_index_job,
       sec_ixbrl_index_job,
+      sec_master_wake_job,
+      sec_master_sleep_job,
     ],
     "sensors": [
       sec_processing_sensor,
@@ -184,6 +194,8 @@ def get_dagster_components():
       sec_post_materialize_publish_sensor,
       sec_post_stage_index_sensor,
       sec_index_retry_sensor,
+      sec_wake_to_stage_sensor,
+      sec_master_sleep_on_failure_sensor,
     ],
     "schedules": [
       sec_incremental_download_schedule,
@@ -233,6 +245,11 @@ __all__ = [
   "sec_lbug_r2_published",
   "sec_lbug_s3_publish_job",
   "sec_lbug_s3_published",
+  "sec_master_asleep",
+  "sec_master_awake",
+  "sec_master_sleep_job",
+  "sec_master_sleep_on_failure_sensor",
+  "sec_master_wake_job",
   "sec_materialize_job",
   "sec_narratives_index_job",
   "sec_narratives_indexed",
@@ -248,4 +265,5 @@ __all__ = [
   "sec_staged_materialize_job",
   "sec_vector_s3_publish_job",
   "sec_vector_s3_published",
+  "sec_wake_to_stage_sensor",
 ]

--- a/robosystems/adapters/sec/pipeline/jobs.py
+++ b/robosystems/adapters/sec/pipeline/jobs.py
@@ -49,6 +49,8 @@ from .duckdb_s3_publish import (
   sec_duckdb_s3_published,
   sec_historical_duckdb_s3_published,
 )
+from .master_sleep import sec_master_asleep
+from .master_wake import sec_master_awake
 from .materialize import (
   sec_graph_materialized,
   sec_historical_materialized,
@@ -232,6 +234,41 @@ sec_incremental_stage_job = define_asset_job(
       ],
     },
   },
+)
+
+
+# ============================================================================
+# Shared-master parking (wake before staging, sleep after publish)
+# ============================================================================
+# Bookend ops that scale the SEC shared master to 1 before the master-dependent
+# staging step and back to 0 once artifacts are published to S3. Light
+# on-demand profile — the work is a few AWS API calls plus a health poll.
+
+_MASTER_PARKING_TAGS = {
+  "pipeline": "sec",
+  "phase": "master_parking",
+  "ecs/cpu": "512",
+  "ecs/memory": "2048",
+  "ecs/ephemeral_storage": "21",
+  "ecs/run_task_kwargs": {
+    "capacityProviderStrategy": [
+      {"capacityProvider": "FARGATE", "weight": 1, "base": 1},
+    ],
+  },
+}
+
+sec_master_wake_job = define_asset_job(
+  name="sec_master_wake",
+  description="Scale the SEC shared master to 1 and wait until healthy.",
+  selection=AssetSelection.assets(sec_master_awake),
+  tags=_MASTER_PARKING_TAGS,
+)
+
+sec_master_sleep_job = define_asset_job(
+  name="sec_master_sleep",
+  description="Clear scale-in protection and scale the SEC shared master to 0.",
+  selection=AssetSelection.assets(sec_master_asleep),
+  tags=_MASTER_PARKING_TAGS,
 )
 
 

--- a/robosystems/adapters/sec/pipeline/jobs.py
+++ b/robosystems/adapters/sec/pipeline/jobs.py
@@ -246,7 +246,7 @@ sec_incremental_stage_job = define_asset_job(
 
 _MASTER_PARKING_TAGS = {
   "pipeline": "sec",
-  "phase": "master_parking",
+  # phase is set per-run by the triggering sensor (master_wake / master_sleep)
   "ecs/cpu": "512",
   "ecs/memory": "2048",
   "ecs/ephemeral_storage": "21",

--- a/robosystems/adapters/sec/pipeline/master_parking.py
+++ b/robosystems/adapters/sec/pipeline/master_parking.py
@@ -93,12 +93,20 @@ def _instance_is_running(instance_id: str) -> bool:
 
 
 def _sec_volume_attached_to(instance_id: str) -> bool:
-  """True if the SEC data volume is ``attached`` to ``instance_id`` per registry."""
+  """True if the SEC data volume is ``attached`` to ``instance_id`` per registry.
+
+  Scans all ``sec``-tagged rows and matches only an actually-attached one — a
+  transient stale row (e.g. an old row mid-reattach) must not shadow the real
+  match, since that reattach race is exactly what this gate guards against.
+  """
   table = _dynamodb_resource().Table(env.VOLUME_REGISTRY_TABLE)
-  resp = table.scan()
-  for item in resp.get("Items", []):
-    if SEC_DATABASE in (item.get("databases") or []):
-      return item.get("status") == "attached" and item.get("instance_id") == instance_id
+  for item in table.scan().get("Items", []):
+    if (
+      SEC_DATABASE in (item.get("databases") or [])
+      and item.get("status") == "attached"
+      and item.get("instance_id") == instance_id
+    ):
+      return True
   return False
 
 

--- a/robosystems/adapters/sec/pipeline/master_parking.py
+++ b/robosystems/adapters/sec/pipeline/master_parking.py
@@ -1,0 +1,197 @@
+"""Wake/sleep ("parking") of the SEC shared-master EC2 instance.
+
+Pure boto3 + DynamoDB-registry logic with no Dagster imports, so it stays
+unit-testable and reusable. Drives the same scale-to-1 / scale-to-0 lifecycle
+validated by hand in the 2026-06-30 dry-run, wired into the nightly SEC pipeline
+as bookend ops.
+
+Load-bearing invariant (confirmed in prod): the master ASG runs
+``NewInstancesProtectedFromScaleIn=true``, so a scale-in is *cancelled* unless
+per-instance scale-in protection is cleared first. ``sleep_master`` therefore
+always clears protection before setting desired capacity to 0.
+
+The dev/test skip lives in the Dagster asset layer (``master_wake`` /
+``master_sleep``), not here — these functions always execute their logic so
+they can be unit-tested against mocked boto3.
+"""
+
+import asyncio
+import time
+from typing import Any
+
+import boto3
+
+from robosystems.config import env
+from robosystems.graph_api.client.factory import get_graph_client_for_instance
+from robosystems.logger import logger
+
+SEC_DATABASE = "sec"
+
+
+class MasterWakeTimeout(Exception):
+  """Raised when the shared master does not reach a healthy state in time."""
+
+
+def get_shared_master_asg_name() -> str:
+  """Return the shared-master ASG name (config-driven, never hardcoded)."""
+  return env.SHARED_MASTER_ASG_NAME
+
+
+def _autoscaling_client():
+  region = env.AWS_REGION
+  if env.is_development() and env.AWS_ENDPOINT_URL:
+    return boto3.client(
+      "autoscaling", endpoint_url=env.AWS_ENDPOINT_URL, region_name=region
+    )
+  return boto3.client("autoscaling", region_name=region)
+
+
+def _ec2_client():
+  region = env.AWS_REGION
+  if env.is_development() and env.AWS_ENDPOINT_URL:
+    return boto3.client("ec2", endpoint_url=env.AWS_ENDPOINT_URL, region_name=region)
+  return boto3.client("ec2", region_name=region)
+
+
+def _dynamodb_resource():
+  region = env.AWS_REGION
+  if env.is_development() and env.AWS_ENDPOINT_URL:
+    return boto3.resource(
+      "dynamodb", endpoint_url=env.AWS_ENDPOINT_URL, region_name=region
+    )
+  return boto3.resource("dynamodb", region_name=region)
+
+
+def set_desired_capacity(asg_name: str, desired: int) -> None:
+  """Set the ASG desired capacity (immediate — no cooldown)."""
+  _autoscaling_client().set_desired_capacity(
+    AutoScalingGroupName=asg_name, DesiredCapacity=desired, HonorCooldown=False
+  )
+  logger.info(f"Set desired capacity of ASG {asg_name} to {desired}")
+
+
+def describe_asg_instance_id(asg_name: str) -> str | None:
+  """Return the first instance id in the ASG, or None if it has no instances."""
+  resp = _autoscaling_client().describe_auto_scaling_groups(
+    AutoScalingGroupNames=[asg_name]
+  )
+  groups = resp.get("AutoScalingGroups", [])
+  if not groups:
+    return None
+  instances = groups[0].get("Instances", [])
+  if not instances:
+    return None
+  return instances[0].get("InstanceId")
+
+
+def _instance_is_running(instance_id: str) -> bool:
+  resp = _ec2_client().describe_instances(InstanceIds=[instance_id])
+  for reservation in resp.get("Reservations", []):
+    for inst in reservation.get("Instances", []):
+      return inst.get("State", {}).get("Name") == "running"
+  return False
+
+
+def _sec_volume_attached_to(instance_id: str) -> bool:
+  """True if the SEC data volume is ``attached`` to ``instance_id`` per registry."""
+  table = _dynamodb_resource().Table(env.VOLUME_REGISTRY_TABLE)
+  resp = table.scan()
+  for item in resp.get("Items", []):
+    if SEC_DATABASE in (item.get("databases") or []):
+      return item.get("status") == "attached" and item.get("instance_id") == instance_id
+  return False
+
+
+def _master_registered_healthy(instance_id: str) -> str | None:
+  """Return the private IP if the instance is a healthy shared_master, else None."""
+  table = _dynamodb_resource().Table(env.INSTANCE_REGISTRY_TABLE)
+  item = table.get_item(Key={"instance_id": instance_id}).get("Item")
+  if not item:
+    return None
+  if item.get("node_type") != "shared_master" or item.get("status") != "healthy":
+    return None
+  return item.get("private_ip")
+
+
+async def _graph_api_healthy(private_ip: str) -> bool:
+  client = await get_graph_client_for_instance(private_ip)
+  try:
+    return bool(await client.health_check())
+  except Exception as exc:  # connection refused while booting, etc.
+    logger.info(f"Master /health not ready yet at {private_ip}: {exc}")
+    return False
+  finally:
+    await client.close()
+
+
+async def wait_for_master_healthy(
+  asg_name: str,
+  *,
+  timeout_s: int = 900,
+  poll_interval_s: int = 15,
+) -> dict[str, Any]:
+  """Poll until the shared master is fully ready, else raise ``MasterWakeTimeout``.
+
+  Four independent signals must all hold: EC2 ``running``, the SEC volume
+  reattached (registry ``status=attached``), the instance registered as a
+  healthy ``shared_master``, and a live graph-api ``/health``. The health check
+  hits the instance directly by private IP rather than the 5-minute
+  Redis-cached discovery, so a stale or not-yet-ready master can never
+  green-light staging.
+  """
+  deadline = time.monotonic() + timeout_s
+  last_state = "no-instance"
+  while True:
+    instance_id = describe_asg_instance_id(asg_name)
+    if instance_id:
+      if not _instance_is_running(instance_id):
+        last_state = f"{instance_id}: not running"
+      elif not _sec_volume_attached_to(instance_id):
+        last_state = f"{instance_id}: sec volume not attached"
+      else:
+        private_ip = _master_registered_healthy(instance_id)
+        if not private_ip:
+          last_state = f"{instance_id}: not registered healthy"
+        elif not await _graph_api_healthy(private_ip):
+          last_state = f"{instance_id}: /health not ready"
+        else:
+          logger.info(f"Shared master {instance_id} ({private_ip}) is healthy")
+          return {"instance_id": instance_id, "private_ip": private_ip}
+    if time.monotonic() >= deadline:
+      raise MasterWakeTimeout(
+        f"Shared master did not become healthy within {timeout_s}s "
+        f"(last state: {last_state})"
+      )
+    await asyncio.sleep(poll_interval_s)
+
+
+async def wake_master(*, timeout_s: int | None = None) -> dict[str, Any]:
+  """Scale the shared master to 1 and wait until it is healthy."""
+  asg_name = get_shared_master_asg_name()
+  set_desired_capacity(asg_name, 1)
+  result = await wait_for_master_healthy(
+    asg_name, timeout_s=timeout_s or env.SHARED_MASTER_WAKE_TIMEOUT_S
+  )
+  return {"status": "awake", **result}
+
+
+def sleep_master() -> dict[str, Any]:
+  """Clear scale-in protection then scale the shared master to 0.
+
+  Order is load-bearing: the ASG cancels scale-in while the instance is
+  protected, so protection MUST be cleared before desired capacity drops.
+  Idempotent — a clean no-op when no instance is running.
+  """
+  asg_name = get_shared_master_asg_name()
+  instance_id = describe_asg_instance_id(asg_name)
+  if instance_id:
+    _autoscaling_client().set_instance_protection(
+      InstanceIds=[instance_id],
+      AutoScalingGroupName=asg_name,
+      ProtectedFromScaleIn=False,
+    )
+    logger.info(f"Cleared scale-in protection on {instance_id} in ASG {asg_name}")
+  else:
+    logger.info(f"No instance in ASG {asg_name}; scaling to 0 anyway")
+  set_desired_capacity(asg_name, 0)
+  return {"status": "asleep", "instance_id": instance_id}

--- a/robosystems/adapters/sec/pipeline/master_sleep.py
+++ b/robosystems/adapters/sec/pipeline/master_sleep.py
@@ -1,0 +1,30 @@
+"""Dagster asset: sleep (scale to 0) the SEC shared master after publish.
+
+Terminal step of the nightly incremental chain. Once every artifact is in S3
+the master is dead weight (replicas refresh from S3, never from it), so this
+clears scale-in protection and scales the ASG to 0. It also runs on the failure
+path (via ``sec_master_sleep_on_failure_sensor``) so a broken run never strands
+the master awake. Idempotent — a clean no-op when no instance is running.
+"""
+
+from dagster import AssetExecutionContext, MaterializeResult, asset
+
+from robosystems.config import env
+
+from .master_parking import sleep_master
+
+
+@asset(
+  group_name="sec_pipeline",
+  description="Clear scale-in protection and scale the SEC shared master to 0.",
+  kinds={"aws"},
+  metadata={"pipeline": "sec", "stage": "master_sleep"},
+)
+def sec_master_asleep(context: AssetExecutionContext) -> MaterializeResult:
+  if env.ENVIRONMENT == "dev":
+    context.log.info("Skipping master sleep in dev environment")
+    return MaterializeResult(metadata={"status": "skipped"})
+
+  result = sleep_master()
+  context.log.info(f"Shared master asleep: {result}")
+  return MaterializeResult(metadata={"instance_id": result.get("instance_id") or ""})

--- a/robosystems/adapters/sec/pipeline/master_wake.py
+++ b/robosystems/adapters/sec/pipeline/master_wake.py
@@ -1,0 +1,42 @@
+"""Dagster asset: wake the SEC shared master before staging.
+
+First master-dependent step of the nightly incremental chain. Scales the shared
+master ASG to 1 and blocks until it is genuinely healthy (EC2 running + SEC
+volume reattached + registered healthy + live /health). A wake that cannot
+reach healthy raises ``Failure`` — that failure IS the wake alarm, and it
+prevents any downstream master-dependent step from starting against a
+missing/half-ready master.
+"""
+
+import asyncio
+
+from dagster import AssetExecutionContext, Failure, MaterializeResult, asset
+
+from robosystems.config import env
+
+from .master_parking import MasterWakeTimeout, wake_master
+
+
+@asset(
+  group_name="sec_pipeline",
+  description="Scale the SEC shared master to 1 and wait until it is healthy.",
+  kinds={"aws"},
+  metadata={"pipeline": "sec", "stage": "master_wake"},
+)
+def sec_master_awake(context: AssetExecutionContext) -> MaterializeResult:
+  if env.ENVIRONMENT == "dev":
+    context.log.info("Skipping master wake in dev environment")
+    return MaterializeResult(metadata={"status": "skipped"})
+
+  try:
+    result = asyncio.run(wake_master())
+  except MasterWakeTimeout as exc:
+    raise Failure(description=str(exc)) from exc
+
+  context.log.info(f"Shared master awake: {result}")
+  return MaterializeResult(
+    metadata={
+      "instance_id": result.get("instance_id", ""),
+      "private_ip": result.get("private_ip", ""),
+    }
+  )

--- a/robosystems/adapters/sec/pipeline/sensors.py
+++ b/robosystems/adapters/sec/pipeline/sensors.py
@@ -49,6 +49,8 @@ from .jobs import (
   sec_incremental_stage_job,
   sec_ixbrl_index_job,
   sec_lbug_s3_publish_job,
+  sec_master_sleep_job,
+  sec_master_wake_job,
   sec_materialize_job,
   sec_narratives_index_job,
   sec_process_job,
@@ -386,40 +388,32 @@ def sec_incremental_pipeline_sensor(context: RunStatusSensorContext):
       )
       return
     else:
-      # All partitions drained — trigger incremental DuckDB staging
+      # All partitions drained — wake the shared master; staging is triggered
+      # once it is healthy (sec_wake_to_stage_sensor).
       context.log.info(
-        "All pending files processed across all partitions, triggering DuckDB staging"
+        "All pending files processed across all partitions, waking shared master"
       )
 
-      # Check if stage job is already running
-      active_stage_runs = context.instance.get_runs(
+      # Check if a wake is already running (avoids double-wake on races)
+      active_wake_runs = context.instance.get_runs(
         filters=RunsFilter(
-          job_name="sec_incremental_stage",
+          job_name="sec_master_wake",
           statuses=[DagsterRunStatus.STARTED, DagsterRunStatus.QUEUED],
         ),
         limit=1,
       )
-      if active_stage_runs:
+      if active_wake_runs:
         context.log.info(
-          f"Incremental stage already running (run_id={active_stage_runs[0].run_id}), skipping"
+          f"Master wake already running (run_id={active_wake_runs[0].run_id}), skipping"
         )
         return
 
       yield RunRequest(
-        run_key=f"sec-stage-chain-{batch_id or partition_key}-{dagster_run.run_id[:8]}",
-        job_name="sec_incremental_stage",
-        run_config={
-          "ops": {
-            "sec_duckdb_incremental_staged": {
-              "config": {
-                "graph_id": "sec",
-              }
-            },
-          }
-        },
+        run_key=f"sec-wake-chain-{batch_id or partition_key}-{dagster_run.run_id[:8]}",
+        job_name="sec_master_wake",
         tags={
           "pipeline": "sec",
-          "phase": "incremental_stage",
+          "phase": "master_wake",
           "mode": "incremental",
           "batch_id": batch_id or "",
         },
@@ -450,6 +444,71 @@ def sec_incremental_pipeline_sensor(context: RunStatusSensorContext):
       "phase": "process",
       "mode": "incremental",
       "quarter": partition_key,
+      "batch_id": batch_id or "",
+    },
+  )
+
+
+# ============================================================================
+# SEC Wake to Stage Sensor (Chains Master Wake → DuckDB Staging)
+# ============================================================================
+# The master is awake and healthy; trigger the first master-dependent step.
+
+
+@run_status_sensor(
+  run_status=DagsterRunStatus.SUCCESS,
+  monitored_jobs=[sec_master_wake_job],
+  request_job=sec_incremental_stage_job,
+  default_status=DefaultSensorStatus.STOPPED,  # Enable in Dagster UI when ready
+  minimum_interval_seconds=60,
+  description="Trigger incremental DuckDB staging after the shared master is awake",
+)
+def sec_wake_to_stage_sensor(context: RunStatusSensorContext):
+  """Trigger incremental DuckDB staging once the shared master is awake+healthy."""
+  if env.ENVIRONMENT == "dev":
+    context.log.info("Skipping chain sensor in dev environment")
+    return
+
+  dagster_run = context.dagster_run
+  run_tags = dagster_run.tags or {}
+  if run_tags.get("mode") != "incremental":
+    context.log.info("Run is not incremental mode, skipping chain")
+    return
+
+  batch_id = run_tags.get("batch_id")
+
+  active_runs = context.instance.get_runs(
+    filters=RunsFilter(
+      job_name="sec_incremental_stage",
+      statuses=[DagsterRunStatus.STARTED, DagsterRunStatus.QUEUED],
+    ),
+    limit=1,
+  )
+  if active_runs:
+    context.log.info(
+      f"Incremental stage already running (run_id={active_runs[0].run_id}), skipping"
+    )
+    return
+
+  context.log.info(
+    f"Shared master awake (run_id={dagster_run.run_id}), triggering DuckDB staging"
+  )
+
+  yield RunRequest(
+    run_key=f"sec-stage-chain-{batch_id or dagster_run.run_id[:8]}",
+    run_config={
+      "ops": {
+        "sec_duckdb_incremental_staged": {
+          "config": {
+            "graph_id": "sec",
+          }
+        },
+      }
+    },
+    tags={
+      "pipeline": "sec",
+      "phase": "incremental_stage",
+      "mode": "incremental",
       "batch_id": batch_id or "",
     },
   )
@@ -560,6 +619,7 @@ def sec_stage_to_materialize_sensor(context: RunStatusSensorContext):
     sec_duckdb_s3_publish_job,
     sec_vector_s3_publish_job,
     shared_replicas_refresh_job,
+    sec_master_sleep_job,
   ],
   default_status=DefaultSensorStatus.STOPPED,  # Enable in Dagster UI when ready
   minimum_interval_seconds=60,
@@ -608,9 +668,34 @@ def sec_post_materialize_publish_sensor(context: RunStatusSensorContext):
     context.log.info("DuckDB S3 publish complete, triggering vector index S3 publish")
 
   elif dagster_run.job_name == "sec_vector_s3_publish":
-    next_job_name = "shared_replicas_refresh"
-    next_phase = "replica_refresh"
-    context.log.info("Vector S3 publish complete, triggering replica refresh")
+    # Final publish done — the master is now dead weight (replicas refresh from
+    # S3, never from the master). Trigger the replica refresh AND sleep the
+    # master, in parallel; sleep does not depend on the refresh outcome.
+    context.log.info(
+      "Vector S3 publish complete, triggering replica refresh and master sleep"
+    )
+    for job_name, phase in (
+      ("shared_replicas_refresh", "replica_refresh"),
+      ("sec_master_sleep", "master_sleep"),
+    ):
+      active = context.instance.get_runs(
+        filters=RunsFilter(
+          job_name=job_name,
+          statuses=[DagsterRunStatus.STARTED, DagsterRunStatus.QUEUED],
+        ),
+        limit=1,
+      )
+      if active:
+        context.log.info(
+          f"{job_name} already running (run_id={active[0].run_id}), skipping"
+        )
+        continue
+      yield RunRequest(
+        run_key=f"sec-{phase}-chain-{dagster_run.run_id[:8]}",
+        job_name=job_name,
+        tags={"pipeline": "sec", "phase": phase, "mode": "incremental"},
+      )
+    return
 
   else:
     return
@@ -635,6 +720,69 @@ def sec_post_materialize_publish_sensor(context: RunStatusSensorContext):
     tags={
       "pipeline": "sec",
       "phase": next_phase,
+      "mode": "incremental",
+    },
+  )
+
+
+# ============================================================================
+# SEC Master Sleep-on-Failure Sensor (never strand the master awake)
+# ============================================================================
+# If any incremental master-dependent job fails, the terminal sleep never runs,
+# so scale the master back to 0 here. Sleep is idempotent.
+
+
+@run_status_sensor(
+  run_status=DagsterRunStatus.FAILURE,
+  monitored_jobs=[
+    sec_master_wake_job,
+    sec_incremental_stage_job,
+    sec_materialize_job,
+    sec_lbug_s3_publish_job,
+    sec_duckdb_s3_publish_job,
+    sec_vector_s3_publish_job,
+  ],
+  request_job=sec_master_sleep_job,
+  default_status=DefaultSensorStatus.STOPPED,  # Enable in Dagster UI when ready
+  minimum_interval_seconds=60,
+  description="Sleep the shared master if any incremental master-dependent job fails",
+)
+def sec_master_sleep_on_failure_sensor(context: RunStatusSensorContext):
+  """Never strand the master awake: on any incremental master-dependent job
+  failure, scale it back to 0."""
+  if env.ENVIRONMENT == "dev":
+    context.log.info("Skipping failure sleep sensor in dev environment")
+    return
+
+  dagster_run = context.dagster_run
+  run_tags = dagster_run.tags or {}
+  if run_tags.get("mode") != "incremental":
+    context.log.info("Run is not incremental mode, skipping sleep")
+    return
+
+  active_runs = context.instance.get_runs(
+    filters=RunsFilter(
+      job_name="sec_master_sleep",
+      statuses=[DagsterRunStatus.STARTED, DagsterRunStatus.QUEUED],
+    ),
+    limit=1,
+  )
+  if active_runs:
+    context.log.info(
+      f"Master sleep already running (run_id={active_runs[0].run_id}), skipping"
+    )
+    return
+
+  context.log.warning(
+    f"Incremental job {dagster_run.job_name} failed (run_id={dagster_run.run_id}), "
+    "sleeping shared master to avoid stranding it awake"
+  )
+
+  yield RunRequest(
+    run_key=f"sec-master-sleep-failure-{dagster_run.run_id[:8]}",
+    tags={
+      "pipeline": "sec",
+      "phase": "master_sleep",
       "mode": "incremental",
     },
   )

--- a/robosystems/config/env.py
+++ b/robosystems/config/env.py
@@ -756,6 +756,14 @@ class EnvConfig:
     "VOLUME_REGISTRY_TABLE", f"robosystems-graph-{ENVIRONMENT}-volume-registry"
   )
 
+  # SEC shared-master ASG (off-hours parking / wake). The nightly SEC pipeline
+  # scales this to 1 before staging and back to 0 after publish.
+  SHARED_MASTER_ASG_NAME = get_str_env(
+    "SHARED_MASTER_ASG_NAME",
+    f"robosystems-ladybug-shared-writers-{ENVIRONMENT}-asg",
+  )
+  SHARED_MASTER_WAKE_TIMEOUT_S = get_int_env("SHARED_MASTER_WAKE_TIMEOUT_S", 900)
+
   # Instance Metadata
   EC2_INSTANCE_ID = get_str_env("INSTANCE_ID", "")
   INSTANCE_ID = get_str_env("INSTANCE_ID", "")

--- a/tests/adapters/sec/pipeline/test_init.py
+++ b/tests/adapters/sec/pipeline/test_init.py
@@ -46,17 +46,17 @@ class TestGetDagsterComponents:
     # 2 lbug s3 publish, 2 duckdb s3 publish,
     # 1 vector s3 publish, 1 lbug r2 publish, knowledge artifact,
     # 2 text index (narratives + ixbrl disclosures)
-    assert len(components["assets"]) == 16
+    assert len(components["assets"]) == 18
 
   def test_expected_number_of_jobs(self):
     """Test that the expected number of jobs are registered."""
     components = get_dagster_components()
-    assert len(components["jobs"]) == 18
+    assert len(components["jobs"]) == 20
 
   def test_expected_number_of_sensors(self):
     """Test that the expected number of sensors are registered."""
     components = get_dagster_components()
-    assert len(components["sensors"]) == 6
+    assert len(components["sensors"]) == 8
 
   def test_expected_number_of_schedules(self):
     """Test that the expected number of schedules are registered."""

--- a/tests/adapters/sec/pipeline/test_master_parking.py
+++ b/tests/adapters/sec/pipeline/test_master_parking.py
@@ -1,0 +1,167 @@
+"""Unit tests for SEC shared-master parking (wake/sleep).
+
+Boto3 clients, the DynamoDB registries, and the health client are all mocked;
+these lock in the two load-bearing invariants — the four-signal wake gate and
+the protection-before-scale-down sleep order.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from robosystems.adapters.sec.pipeline import master_parking
+from robosystems.adapters.sec.pipeline.master_parking import (
+  MasterWakeTimeout,
+  get_shared_master_asg_name,
+  sleep_master,
+  wait_for_master_healthy,
+  wake_master,
+)
+
+ASG = "test-shared-asg"
+
+
+def _asg_client(instance_id: str | None = "i-abc") -> MagicMock:
+  client = MagicMock()
+  instances = [{"InstanceId": instance_id}] if instance_id else []
+  client.describe_auto_scaling_groups.return_value = {
+    "AutoScalingGroups": [{"Instances": instances}]
+  }
+  return client
+
+
+def _ec2_client(running: bool = True) -> MagicMock:
+  client = MagicMock()
+  client.describe_instances.return_value = {
+    "Reservations": [
+      {"Instances": [{"State": {"Name": "running" if running else "pending"}}]}
+    ]
+  }
+  return client
+
+
+def _dynamodb(
+  *,
+  vol_status: str = "attached",
+  vol_instance: str = "i-abc",
+  databases=("sec",),
+  node_type: str = "shared_master",
+  inst_status: str = "healthy",
+  private_ip: str | None = "10.0.0.5",
+) -> MagicMock:
+  volume_table = MagicMock()
+  volume_table.scan.return_value = {
+    "Items": [
+      {"databases": list(databases), "status": vol_status, "instance_id": vol_instance}
+    ]
+  }
+  instance_item: dict = {"node_type": node_type, "status": inst_status}
+  if private_ip is not None:
+    instance_item["private_ip"] = private_ip
+  instance_table = MagicMock()
+  instance_table.get_item.return_value = {"Item": instance_item}
+
+  resource = MagicMock()
+  resource.Table.side_effect = lambda name: (
+    volume_table if "volume" in name else instance_table
+  )
+  return resource
+
+
+def _health_client() -> MagicMock:
+  client = MagicMock()
+  client.health_check = AsyncMock(return_value={"status": "ok"})
+  client.close = AsyncMock()
+  return client
+
+
+@pytest.mark.unit
+class TestWakeMaster:
+  @patch.object(master_parking, "_autoscaling_client")
+  @patch.object(master_parking, "_ec2_client")
+  @patch.object(master_parking, "_dynamodb_resource")
+  @patch.object(master_parking, "get_graph_client_for_instance", new_callable=AsyncMock)
+  def test_happy_path(self, m_health, m_ddb, m_ec2, m_asg):
+    asg = _asg_client("i-123")
+    m_asg.return_value = asg
+    m_ec2.return_value = _ec2_client(running=True)
+    m_ddb.return_value = _dynamodb(vol_instance="i-123", private_ip="10.0.0.5")
+    m_health.return_value = _health_client()
+
+    result = asyncio.run(wake_master())
+
+    assert result["status"] == "awake"
+    assert result["instance_id"] == "i-123"
+    assert result["private_ip"] == "10.0.0.5"
+    asg.set_desired_capacity.assert_called_once()
+    assert asg.set_desired_capacity.call_args.kwargs["DesiredCapacity"] == 1
+
+  @patch.object(master_parking, "_autoscaling_client")
+  @patch.object(master_parking, "_ec2_client")
+  @patch.object(master_parking, "_dynamodb_resource")
+  @patch.object(master_parking, "get_graph_client_for_instance", new_callable=AsyncMock)
+  def test_timeout_when_not_registered_healthy(self, m_health, m_ddb, m_ec2, m_asg):
+    m_asg.return_value = _asg_client("i-123")
+    m_ec2.return_value = _ec2_client(running=True)
+    # Instance never reports healthy in the instance registry.
+    m_ddb.return_value = _dynamodb(vol_instance="i-123", inst_status="unhealthy")
+    m_health.return_value = _health_client()
+
+    with pytest.raises(MasterWakeTimeout):
+      asyncio.run(wait_for_master_healthy(ASG, timeout_s=0, poll_interval_s=0))
+
+  @patch.object(master_parking, "_autoscaling_client")
+  @patch.object(master_parking, "_ec2_client")
+  @patch.object(master_parking, "_dynamodb_resource")
+  @patch.object(master_parking, "get_graph_client_for_instance", new_callable=AsyncMock)
+  def test_timeout_when_volume_not_attached(self, m_health, m_ddb, m_ec2, m_asg):
+    m_asg.return_value = _asg_client("i-123")
+    m_ec2.return_value = _ec2_client(running=True)
+    # Volume is present but still detaching (not yet reattached to this instance).
+    m_ddb.return_value = _dynamodb(vol_instance="i-123", vol_status="available")
+    m_health.return_value = _health_client()
+
+    with pytest.raises(MasterWakeTimeout):
+      asyncio.run(wait_for_master_healthy(ASG, timeout_s=0, poll_interval_s=0))
+
+
+@pytest.mark.unit
+class TestSleepMaster:
+  @patch.object(master_parking, "_autoscaling_client")
+  def test_clears_protection_before_scaling_down(self, m_asg):
+    asg = _asg_client("i-xyz")
+    m_asg.return_value = asg
+
+    result = sleep_master()
+
+    assert result == {"status": "asleep", "instance_id": "i-xyz"}
+    # Load-bearing: protection must be cleared BEFORE desired capacity drops,
+    # or the ASG cancels the scale-in and the master strands awake.
+    call_names = [c[0] for c in asg.method_calls]
+    assert call_names == [
+      "describe_auto_scaling_groups",
+      "set_instance_protection",
+      "set_desired_capacity",
+    ]
+    assert asg.set_instance_protection.call_args.kwargs["ProtectedFromScaleIn"] is False
+    assert asg.set_desired_capacity.call_args.kwargs["DesiredCapacity"] == 0
+
+  @patch.object(master_parking, "_autoscaling_client")
+  def test_no_instance_still_scales_to_zero(self, m_asg):
+    asg = _asg_client(instance_id=None)
+    m_asg.return_value = asg
+
+    result = sleep_master()
+
+    assert result["instance_id"] is None
+    asg.set_instance_protection.assert_not_called()
+    asg.set_desired_capacity.assert_called_once()
+    assert asg.set_desired_capacity.call_args.kwargs["DesiredCapacity"] == 0
+
+
+@pytest.mark.unit
+def test_asg_name_from_config():
+  from robosystems.config import env
+
+  assert get_shared_master_asg_name() == env.SHARED_MASTER_ASG_NAME

--- a/tests/adapters/sec/pipeline/test_master_parking.py
+++ b/tests/adapters/sec/pipeline/test_master_parking.py
@@ -161,6 +161,29 @@ class TestSleepMaster:
 
 
 @pytest.mark.unit
+class TestVolumeGate:
+  @patch.object(master_parking, "_dynamodb_resource")
+  def test_ignores_stale_sec_row_and_matches_real_one(self, m_ddb):
+    from robosystems.adapters.sec.pipeline.master_parking import (
+      _sec_volume_attached_to,
+    )
+
+    volume_table = MagicMock()
+    # Stale row for a "sec" volume appears FIRST; the real attached match is later.
+    volume_table.scan.return_value = {
+      "Items": [
+        {"databases": ["sec"], "status": "available", "instance_id": "i-old"},
+        {"databases": ["sec"], "status": "attached", "instance_id": "i-123"},
+      ]
+    }
+    resource = MagicMock()
+    resource.Table.return_value = volume_table
+    m_ddb.return_value = resource
+
+    assert _sec_volume_attached_to("i-123") is True
+
+
+@pytest.mark.unit
 def test_asg_name_from_config():
   from robosystems.config import env
 

--- a/tests/adapters/sec/pipeline/test_sensors.py
+++ b/tests/adapters/sec/pipeline/test_sensors.py
@@ -21,9 +21,11 @@ from robosystems.adapters.sec.pipeline.sensors import (
   _get_quarters_to_scan,
   sec_incremental_download_schedule,
   sec_incremental_pipeline_sensor,
+  sec_master_sleep_on_failure_sensor,
   sec_post_materialize_publish_sensor,
   sec_post_stage_index_sensor,
   sec_stage_to_materialize_sensor,
+  sec_wake_to_stage_sensor,
 )
 
 
@@ -214,10 +216,14 @@ class TestSecIncrementalPipelineSensor:
 
   @patch("robosystems.database.session")
   @patch("robosystems.adapters.sec.pipeline.sensors.env")
-  def test_process_triggers_stage_when_queue_drained(
+  def test_process_triggers_master_wake_when_queue_drained(
     self, mock_env, mock_session_factory
   ):
-    """Test process success triggers staging when no pending files remain."""
+    """Test process success wakes the shared master when no pending files remain.
+
+    Parking design: the drained-queue branch triggers the master wake
+    (sec_master_wake); staging is then chained by sec_wake_to_stage_sensor.
+    """
     mock_env.ENVIRONMENT = "prod"
 
     # Mock SourceFile query returning no pending files
@@ -249,8 +255,8 @@ class TestSecIncrementalPipelineSensor:
 
     assert len(result) == 1
     assert isinstance(result[0], RunRequest)
-    assert result[0].job_name == "sec_incremental_stage"
-    assert result[0].tags["phase"] == "incremental_stage"
+    assert result[0].job_name == "sec_master_wake"
+    assert result[0].tags["phase"] == "master_wake"
     assert result[0].tags["mode"] == "incremental"
 
   @patch("robosystems.database.session")
@@ -809,3 +815,100 @@ class TestSecPostStageIndexSensor:
 
     result = list(sec_post_stage_index_sensor(context))
     assert len(result) == 0
+
+
+@pytest.mark.unit
+class TestSecWakeToStageSensor:
+  """Tests for sec_wake_to_stage_sensor (master wake success -> DuckDB staging)."""
+
+  @patch("robosystems.adapters.sec.pipeline.sensors.env")
+  def test_triggers_stage_on_wake_success(self, mock_env):
+    mock_env.ENVIRONMENT = "prod"
+    context = _build_run_status_context(
+      sensor_name="sec_wake_to_stage_sensor",
+      job_name="sec_master_wake",
+      tags={"mode": "incremental", "batch_id": "20260701-21"},
+    )
+    result = list(sec_wake_to_stage_sensor(context))
+    assert len(result) == 1
+    config = result[0].run_config["ops"]["sec_duckdb_incremental_staged"]["config"]
+    assert config["graph_id"] == "sec"
+    assert result[0].tags["mode"] == "incremental"
+
+  @patch("robosystems.adapters.sec.pipeline.sensors.env")
+  def test_skips_non_incremental(self, mock_env):
+    mock_env.ENVIRONMENT = "prod"
+    context = _build_run_status_context(
+      sensor_name="sec_wake_to_stage_sensor",
+      job_name="sec_master_wake",
+      tags={"mode": "backfill"},
+    )
+    assert list(sec_wake_to_stage_sensor(context)) == []
+
+  @patch("robosystems.adapters.sec.pipeline.sensors.env")
+  def test_skips_when_stage_already_running(self, mock_env):
+    mock_env.ENVIRONMENT = "prod"
+    context = _build_run_status_context(
+      sensor_name="sec_wake_to_stage_sensor",
+      job_name="sec_master_wake",
+      tags={"mode": "incremental"},
+      get_runs_return=[MagicMock()],
+    )
+    assert list(sec_wake_to_stage_sensor(context)) == []
+
+
+@pytest.mark.unit
+class TestSecMasterSleepOnFailureSensor:
+  """Tests for sec_master_sleep_on_failure_sensor (never strand master awake)."""
+
+  @patch("robosystems.adapters.sec.pipeline.sensors.env")
+  def test_sleeps_on_incremental_failure(self, mock_env):
+    mock_env.ENVIRONMENT = "prod"
+    context = _build_run_status_context(
+      sensor_name="sec_master_sleep_on_failure_sensor",
+      job_name="sec_materialize",
+      tags={"mode": "incremental"},
+    )
+    result = list(sec_master_sleep_on_failure_sensor(context))
+    assert len(result) == 1
+    assert result[0].tags["phase"] == "master_sleep"
+
+  @patch("robosystems.adapters.sec.pipeline.sensors.env")
+  def test_skips_non_incremental(self, mock_env):
+    mock_env.ENVIRONMENT = "prod"
+    context = _build_run_status_context(
+      sensor_name="sec_master_sleep_on_failure_sensor",
+      job_name="sec_materialize",
+      tags={"mode": "backfill"},
+    )
+    assert list(sec_master_sleep_on_failure_sensor(context)) == []
+
+  @patch("robosystems.adapters.sec.pipeline.sensors.env")
+  def test_skips_when_sleep_already_running(self, mock_env):
+    mock_env.ENVIRONMENT = "prod"
+    context = _build_run_status_context(
+      sensor_name="sec_master_sleep_on_failure_sensor",
+      job_name="sec_materialize",
+      tags={"mode": "incremental"},
+      get_runs_return=[MagicMock()],
+    )
+    assert list(sec_master_sleep_on_failure_sensor(context)) == []
+
+
+@pytest.mark.unit
+class TestPublishSensorSleepsMaster:
+  """The publish sensor sleeps the master alongside the replica refresh."""
+
+  @patch("robosystems.adapters.sec.pipeline.sensors.env")
+  def test_vector_publish_triggers_refresh_and_sleep(self, mock_env):
+    mock_env.ENVIRONMENT = "prod"
+    context = _build_run_status_context(
+      sensor_name="sec_post_materialize_publish_sensor",
+      job_name="sec_vector_s3_publish",
+      tags={"mode": "incremental"},
+    )
+    result = list(sec_post_materialize_publish_sensor(context))
+    assert {r.job_name for r in result} == {
+      "shared_replicas_refresh",
+      "sec_master_sleep",
+    }


### PR DESCRIPTION
## Summary

Automate SEC shared-master scale-down/up ("parking") as bookend ops inside the nightly incremental Dagster pipeline: scale the master ASG to 1 before the first master-dependent step (staging) and back to 0 after publish. This automates the exact lifecycle validated by hand in the 2026-06-30 dry-run. MVP scope — every new sensor ships `STOPPED`.

## Changes

- **`master_parking.py`** (new) — pure boto3 + DynamoDB-registry helper, no Dagster imports. `wake_master` = `SetDesiredCapacity(1)` + a four-signal health gate: EC2 `running`, the SEC volume reattached in the volume registry (`status=attached`, `databases=["sec"]`), the instance registered `healthy` as `shared_master`, and a live graph-api `/health` hit via a **direct per-IP client** rather than the 5-min Redis-cached discovery (so a stale/not-yet-ready master can't green-light staging). `sleep_master` = clear scale-in protection **then** `SetDesiredCapacity(0)` — order is load-bearing (the ASG cancels the scale-in while the instance is protected). Plus `wait_for_master_healthy` and `MasterWakeTimeout`.
- **`master_wake.py` / `master_sleep.py`** (new) — thin Dagster assets. Wake raises `Failure` on timeout (that failure *is* the wake alarm); both skip in dev.
- **`jobs.py`** — `sec_master_wake_job` + `sec_master_sleep_job` (light on-demand profile).
- **`sensors.py`** — the drained-queue branch of `sec_incremental_pipeline_sensor` now triggers the **wake** (not staging); new `sec_wake_to_stage_sensor` chains wake → DuckDB staging once healthy; `sec_post_materialize_publish_sensor` requests `sec_master_sleep` **alongside** the replica refresh on `sec_vector_s3_publish` success; new `sec_master_sleep_on_failure_sensor` scales the master back to 0 on any incremental master-dependent job failure so a broken run never strands it awake.
- **`__init__.py`** — registers the six new components (assets 16→18, jobs 18→20, sensors 6→8).
- **`config/env.py`** — `SHARED_MASTER_ASG_NAME` (default `robosystems-ladybug-shared-writers-{env}-asg`) + `SHARED_MASTER_WAKE_TIMEOUT_S`.
- **`cloudformation/dagster.yaml`** — adds `autoscaling:SetDesiredCapacity` + `autoscaling:SetInstanceProtection` to the shared `DagsterTaskRole` autoscaling statement (scoped to `robosystems-*-${Environment}-asg`). `DescribeAutoScalingGroups`, `ec2:DescribeInstances`, and DynamoDB reads on `robosystems-graph-${Environment}-*` were already granted.
- **Tests** — `test_master_parking.py` (wake happy path, two health-gate timeouts, the protection-before-scale-down sleep order, no-instance sleep, config); `test_sensors.py` (wake→stage, sleep-on-failure, dual-yield publish, and the updated drained→wake test).

## Testing

- On the changed files: `ruff check` clean, `ruff format` clean, `basedpyright` 0 errors, `cf-lint` clean.
- The 14 unit tests pass, verified by **direct invocation** — this test path's conftest requires Postgres, which was not running locally this session, so `pytest` couldn't run here. They run in CI. Full `just test` not run locally.
- Component import smoke: `get_dagster_components()` loads cleanly with the new pieces.

## Notes / Follow-ups

- **Sensors ship `STOPPED`.** Deploy order: CloudFormation (IAM) first, then code; then validate `sec_master_wake_job` and `sec_master_sleep_job` in isolation from the Dagster Launchpad (desired flips, volume reattaches, `/health` 200, protection clears then scales to 0) before enabling the chain for one observed nightly.
- Requires a prod deploy to take effect; real end-to-end validation is prod-only (the AWS mechanics were validated manually on 2026-06-30).
- MVP scope — deliberately defers manual REST/MCP wake/sleep endpoints, a separate CloudWatch alarm (the wake op's `Failure` already surfaces a failed wake), and a concurrency/busy-counter guard (the pipeline runs one quarter per night after the ET hard cut-over).
- `LBUG_SHARED_MIN_INSTANCES_PROD=0` (the MinSize floor) is already deployed.
