### PR TITLE
feat(operators): agentic tool-use loop for the Cypher operator

### DIFF
--- a/robosystems/operations/operators/ai_client.py
+++ b/robosystems/operations/operators/ai_client.py
@@ -8,7 +8,8 @@ Production-grade AI client using AWS Bedrock exclusively for:
 """
 
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import Any
 
 from robosystems.config import BedrockModel, OperatorConfig, env
 from robosystems.logger import logger
@@ -17,7 +18,10 @@ from robosystems.logger import logger
 @dataclass
 class AIMessage:
   role: str
-  content: str
+  # A turn is either plain text or a list of Anthropic content blocks
+  # (tool_use / tool_result). Tool-use loops append block lists; simple
+  # single-shot callers still pass a string.
+  content: str | list[dict[str, Any]]
 
 
 @dataclass
@@ -27,6 +31,9 @@ class AIResponse:
   input_tokens: int
   output_tokens: int
   stop_reason: str | None = None
+  # Full response content blocks (text + tool_use). Populated for tool-use
+  # loops; `content` above is the concatenated text for simple callers.
+  content_blocks: list[dict[str, Any]] = field(default_factory=list)
 
 
 class AIClient:
@@ -121,6 +128,7 @@ class AIClient:
     temperature: float = 0.7,
     model: str | None = None,
     operator_type: str | None = None,
+    tools: list[dict[str, Any]] | None = None,
   ) -> AIResponse:
     """
     Create a message using AWS Bedrock.
@@ -132,13 +140,16 @@ class AIClient:
         temperature: Sampling temperature (0-1)
         model: Optional model name override
         operator_type: Optional operator type for model override lookup
+        tools: Optional Anthropic tool definitions (name/description/
+            input_schema). When provided the model may return tool_use
+            blocks and stop_reason "tool_use" — see AIResponse.content_blocks.
 
     Returns:
         AIResponse with content and token usage
     """
     model_id = self._get_model_id(model, operator_type)
     return await self._bedrock_create_message(
-      messages, system, max_tokens, temperature, model_id
+      messages, system, max_tokens, temperature, model_id, tools
     )
 
   async def _bedrock_create_message(
@@ -148,11 +159,12 @@ class AIClient:
     max_tokens: int,
     temperature: float,
     model: str,
+    tools: list[dict[str, Any]] | None = None,
   ) -> AIResponse:
     """Create message using AWS Bedrock."""
     message_dicts = [{"role": msg.role, "content": msg.content} for msg in messages]
 
-    request_body = {
+    request_body: dict[str, Any] = {
       "anthropic_version": "bedrock-2023-05-31",
       "max_tokens": max_tokens,
       "temperature": temperature,
@@ -161,6 +173,8 @@ class AIClient:
 
     if system:
       request_body["system"] = system
+    if tools:
+      request_body["tools"] = tools
 
     response = self.client.invoke_model(
       modelId=model,
@@ -169,10 +183,20 @@ class AIClient:
 
     response_body = json.loads(response["body"].read())
 
+    # A response may interleave text and tool_use blocks; the first block
+    # is not guaranteed to be text (a pure tool_use turn has none). Join every
+    # text-bearing block for the back-compat `content` string (tool_use blocks
+    # carry no "text" key), and hand back the full block list for tool loops.
+    blocks = response_body.get("content", [])
+    text = "".join(
+      b.get("text", "") for b in blocks if isinstance(b, dict) and "text" in b
+    )
+
     return AIResponse(
-      content=response_body["content"][0]["text"],
+      content=text,
       model=model,
       input_tokens=response_body["usage"]["input_tokens"],
       output_tokens=response_body["usage"]["output_tokens"],
       stop_reason=response_body.get("stop_reason"),
+      content_blocks=blocks,
     )

--- a/robosystems/operations/operators/implementations/cypher.py
+++ b/robosystems/operations/operators/implementations/cypher.py
@@ -1,17 +1,22 @@
-"""CypherOperator — natural language to Cypher query conversion and execution.
+"""CypherOperator — agentic natural-language querying of the graph.
 
-Converts natural language questions into Cypher queries, executes them
-via MCP tools, and returns formatted results. Primary operator for the
-console interface.
+Drives a bounded tool-use loop (``run_tool_loop``): the model discovers the
+schema, writes read-only Cypher, sees query errors and retries, then answers
+in natural language. Returns the last result set as structured ``rows`` so the
+console can render a real table rather than scraping the prose. Primary
+operator for the console interface.
+
+This replaced an earlier single-shot pipeline (fetch truncated schema →
+generate one query → execute once → format) that never showed the model its
+query errors and so failed on basic questions. The loop is the harness that
+makes Claude-via-MCP robust, run in-process on Bedrock.
 """
 
 from __future__ import annotations
 
-import json
 from typing import Any
 
-from robosystems.logger import logger
-from robosystems.operations.operators.ai_client import AIMessage
+from robosystems.config import OperatorConfig
 from robosystems.operations.operators.base import (
   ExecutionProfile,
   Operator,
@@ -22,31 +27,46 @@ from robosystems.operations.operators.base import (
 )
 from robosystems.operations.operators.operator_context import OperatorContext
 from robosystems.operations.operators.operator_registry import register_operator
+from robosystems.operations.operators.tool_loop import ToolLoopResult, run_tool_loop
 
 
 @register_operator("cypher")
 class CypherOperator(Operator):
-  """Converts natural language to Cypher queries and executes them."""
+  """Converts natural language to Cypher and answers via a tool-use loop."""
+
+  # Read-only tool allowlist. The loop intersects this with the tools the
+  # graph actually exposes (generic graphs get only schema + cypher; SEC and
+  # roboledger graphs also get example queries, element resolution, GraphQL,
+  # and document search). Write tools are never included.
+  READ_ONLY_TOOLS = [
+    "get-graph-schema",
+    "read-graph-cypher",
+    "get-example-queries",
+    "get-graphql-schema",
+    "query-graphql",
+    "resolve-element",
+    "search-documents",
+  ]
 
   spec = OperatorSpec(
     name="Cypher Operator",
-    description="Converts natural language to Cypher queries and executes them",
+    description="Answers natural-language questions by querying the graph with Cypher",
     capabilities=[
       OperatorCapability.RAG_SEARCH,
       OperatorCapability.ENTITY_ANALYSIS,
       OperatorCapability.CUSTOM,
     ],
-    version="1.0.0",
+    version="2.0.0",
     requires_credits=True,
     execution_profile={
       OperatorMode.QUICK: ExecutionProfile(
-        min_time=2, max_time=5, avg_time=3, tool_calls=2
+        min_time=3, max_time=12, avg_time=6, tool_calls=3
       ),
       OperatorMode.STANDARD: ExecutionProfile(
-        min_time=5, max_time=15, avg_time=10, tool_calls=3
+        min_time=6, max_time=25, avg_time=12, tool_calls=6
       ),
       OperatorMode.EXTENDED: ExecutionProfile(
-        min_time=15, max_time=60, avg_time=30, tool_calls=5
+        min_time=15, max_time=90, avg_time=40, tool_calls=13
       ),
     },
   )
@@ -72,197 +92,76 @@ class CypherOperator(Operator):
     return 0.7
 
   async def run(self, ctx: OperatorContext) -> OperatorResult:
-    await ctx.progress.report("Getting graph schema...", percent=10)
-    schema = await ctx.tools.call_tool("get-graph-schema", {}, return_raw=True)
-
-    await ctx.progress.report("Generating Cypher query...", percent=30)
-    cypher_query = await self._generate_cypher(ctx, schema)
-
-    await ctx.progress.report("Executing query...", percent=60)
-    results = await ctx.tools.call_tool(
-      "read-graph-cypher",
-      {"query": cypher_query, "parameters": {}},
-      return_raw=True,
-    )
-
-    await ctx.progress.report("Formatting results...", percent=90)
-    formatted = await self._format_results(ctx, cypher_query, results)
-
-    return OperatorResult(
-      content=formatted,
-      metadata={
-        "cypher_query": cypher_query,
-        "result_count": len(results) if results else 0,
-      },
-      tools_called=["get-graph-schema", "read-graph-cypher"],
-      confidence_score=self._calculate_confidence(cypher_query, results),
-    )
-
-  async def _generate_cypher(
-    self, ctx: OperatorContext, schema: list[dict[str, Any]]
-  ) -> str:
-    schema_text = self._format_schema_for_ai(schema)
+    limits = OperatorConfig.get_mode_limits(ctx.mode.value)
     max_results = self._get_max_results(ctx.mode)
+    # One iteration per allowed tool call, plus a final answer turn.
+    max_iterations = int(limits.get("max_tools", 5)) + 1
+    max_tokens = int(limits.get("max_output_tokens", 4000))
+    output_mode = "answer" if ctx.extra.get("output_mode") == "answer" else "narrative"
 
-    # The materialized ledger spine only exists in entity graphs with roboledger
-    # materialized — not SEC/generic graphs. Only inject status-filtering guidance
-    # when those nodes are present, or it's noise about nodes that don't exist.
-    # Key on Entry/Transaction/LineItem — NOT Event: the base REA Event table
-    # exists (empty) on the SEC shared repo, so it isn't a reliable signal.
-    node_labels = {item.get("label") for item in schema if item.get("type") == "node"}
-    has_ledger_spine = bool(node_labels & {"Entry", "Transaction", "LineItem"})
+    system = self._build_system_prompt(max_results, output_mode)
 
-    ledger_rule = (
-      """
-8. LEDGER STATUS: the graph keeps cancelled/replaced ledger rows. When counting or
-   aggregating Entry/Event/Transaction data, filter to live rows or voided/reversed
-   amounts inflate the result:
-   - Entry: match only `status = 'posted'` for balances and debit/credit sums.
-   - Event: exclude `voided` and `superseded` (`status <> 'voided' AND status <> 'superseded'`).
-   - Transaction has only a `pending` boolean (no full status) — aggregate realized
-     effect through its posted Entry/LineItem, not by summing Transaction.amount.
-   - Fact nodes have no status and are pre-filtered; this rule is ledger-spine only."""
-      if has_ledger_spine
-      else ""
-    )
-    ledger_pattern = (
-      "\n- Posted GL balances: MATCH (e:Entry)-[:ENTRY_HAS_LINE_ITEM]->(li:LineItem) WHERE e.status = 'posted'"
-      if has_ledger_spine
-      else ""
-    )
-
-    system_prompt = f"""You are a Cypher query expert for RoboSystems graph databases.
-
-SCHEMA:
-{schema_text}
-
-IMPORTANT RULES:
-1. Generate ONLY the Cypher query - no explanations, no markdown formatting
-2. Queries must be read-only (MATCH, RETURN, WHERE, WITH, ORDER BY, LIMIT)
-3. No write operations (CREATE, SET, DELETE, MERGE, DROP)
-4. Always include a LIMIT clause (max {max_results})
-5. Use parameterized queries when possible
-6. Handle NULL values appropriately
-7. Use CONTAINS for text search, not exact matches{ledger_rule}
-
-SCHEMA PATTERNS:
-- Financial facts: MATCH (f:Fact)-[:FACT_HAS_ELEMENT]->(el:Element)
-- Time periods: MATCH (f:Fact)-[:FACT_HAS_PERIOD]->(p:Period)
-- Entities: MATCH (e:Entity)-[:HAS_REPORT]->(r:Report){ledger_pattern}
-
-Return ONLY the Cypher query, nothing else."""
-
-    messages = []
-    if ctx.history:
-      for msg in ctx.history[-5:]:
-        role = (
-          msg.get("role", "user")
-          if isinstance(msg, dict)
-          else getattr(msg, "role", "user")
-        )
-        content = (
-          msg.get("content", "")
-          if isinstance(msg, dict)
-          else getattr(msg, "content", "")
-        )
-        messages.append(AIMessage(role=role, content=content))
-
-    messages.append(
-      AIMessage(
-        role="user",
-        content=f"Convert this natural language query to Cypher:\n\n{ctx.query}",
-      )
-    )
-
-    response = await ctx.ai.create_message(
-      messages=messages,
-      system=system_prompt,
-      max_tokens=2000,
+    result = await run_tool_loop(
+      ctx,
+      system=system,
+      tool_names=self.READ_ONLY_TOOLS,
+      max_iterations=max_iterations,
+      max_tokens=max_tokens,
       temperature=0.3,
-      operation_description="Cypher query generation",
+      operator_type="cypher",
+      operation_description="Cypher query loop",
     )
 
-    cypher_query = response.content.strip()
-    cypher_query = cypher_query.replace("```cypher", "").replace("```", "").strip()
+    await ctx.progress.report("Done", percent=100)
 
-    logger.info(f"Generated Cypher: {cypher_query}")
-    return cypher_query
+    rows = result.rows or []
+    return OperatorResult(
+      content=result.text,
+      metadata={
+        # Structured outputs the console renders directly — no prose scraping.
+        "cypher": result.cypher,
+        "rows": rows,
+        "result_count": len(rows),
+        "hit_step_limit": result.hit_cap,
+        "loop_iterations": result.iterations,
+      },
+      # De-dupe preserving order (a tool may be called several times).
+      tools_called=list(dict.fromkeys(result.tools_called)),
+      confidence_score=self._calculate_confidence(result),
+    )
 
-  async def _format_results(
-    self,
-    ctx: OperatorContext,
-    cypher_query: str,
-    results: list[dict[str, Any]],
-  ) -> str:
-    if not results:
-      return f"No results found for your query.\n\nGenerated Cypher:\n{cypher_query}"
+  def _build_system_prompt(self, max_results: int, output_mode: str) -> str:
+    prompt = f"""You are a graph database analyst for RoboSystems. You answer the user's question by querying a LadybugDB graph with read-only Cypher.
 
-    if ctx.mode == OperatorMode.QUICK:
-      return self._simple_format(cypher_query, results)
+WORKFLOW:
+1. Call `get-graph-schema` first to discover node labels, relationships, and properties — never guess the schema.
+2. If `get-example-queries` is available, use it for working query patterns tuned to this graph.
+3. Write a read-only Cypher query and run it with `read-graph-cypher`.
+4. If a query errors or returns nothing useful, read the error, fix the query, and try again. You have a limited number of steps, so be efficient — don't repeat a failing query unchanged.
+5. When you have the answer, respond in natural language.
 
-    results_sample = results[:10]
-    results_json = json.dumps(results_sample, indent=2, default=str)
+CYPHER RULES:
+- Read-only only: MATCH, WHERE, WITH, RETURN, ORDER BY, LIMIT. Never CREATE, SET, DELETE, MERGE, or DROP.
+- Always include a LIMIT (max {max_results}).
+- Use CONTAINS for text search; guard against NULLs with IS NOT NULL.
+- Anchor every query on a selective, indexed starting point (an Entity by ticker, a Report by identifier, an Element by qname) and expand from there. Never start a MATCH from an unfiltered global pattern like `(f:Fact)` or `(n)` on a large graph — it will time out.
 
-    system_prompt = """You are a helpful assistant that explains graph query results.
-
-Format the results in a clear, concise way that directly answers the user's question.
-If there are patterns or insights in the data, mention them briefly.
-Keep your response focused and actionable."""
-
-    messages = [
-      AIMessage(
-        role="user",
-        content=f"""User asked: "{ctx.query}"
-
-I executed this Cypher query:
-{cypher_query}
-
-Results ({len(results)} total, showing first 10):
-{results_json}
-
-Please explain these results in a clear, natural way.""",
+LEDGER DATA (only when the schema has Entry / Transaction / LineItem nodes):
+- The graph keeps cancelled/replaced rows. When counting or summing ledger data, filter to live rows: match Entry `status = 'posted'` for balances and debit/credit sums; exclude Event rows where `status = 'voided' OR status = 'superseded'`. Aggregate realized amounts through posted Entry/LineItem, not by summing Transaction.amount.
+"""
+    if output_mode == "answer":
+      prompt += (
+        "\nFINAL ANSWER: Give a direct, concise answer — no preamble. The raw "
+        "rows are shown to the user as a table, so don't re-list them."
       )
-    ]
-
-    response = await ctx.ai.create_message(
-      messages=messages,
-      system=system_prompt,
-      max_tokens=1500,
-      temperature=0.5,
-      operation_description="Result formatting",
-    )
-
-    formatted = (
-      f"{response.content}\n\n**Generated Cypher:**\n```cypher\n{cypher_query}\n```"
-    )
-    if len(results) > 10:
-      formatted += f"\n\n*Showing 10 of {len(results)} results*"
-
-    return formatted
-
-  def _simple_format(self, cypher_query: str, results: list[dict[str, Any]]) -> str:
-    formatted = f"**Generated Cypher:**\n```cypher\n{cypher_query}\n```\n\n"
-    formatted += f"**Results:** {len(results)} rows\n\n"
-    if results:
-      sample = results[:5]
-      formatted += "```json\n" + json.dumps(sample, indent=2, default=str) + "\n```"
-      if len(results) > 5:
-        formatted += f"\n\n*Showing 5 of {len(results)} results*"
-    return formatted
-
-  def _format_schema_for_ai(self, schema: list[dict[str, Any]]) -> str:
-    formatted = []
-    for item in schema[:20]:
-      if item.get("type") == "node":
-        props = ", ".join(
-          [f"{p['name']}: {p['type']}" for p in item.get("properties", [])[:5]]
-        )
-        formatted.append(f"Node {item['label']}: {props}")
-      elif item.get("type") == "relationship":
-        formatted.append(
-          f"Relationship {item['label']}: {item.get('from', '?')} -> {item.get('to', '?')}"
-        )
-    return "\n".join(formatted) if formatted else "Schema information not available"
+    else:
+      prompt += (
+        "\nFINAL ANSWER: Briefly explain what you found in clear prose, calling "
+        "out the key figures or patterns. The application shows the raw rows to "
+        "the user as a table, so do NOT draw your own table or re-list every "
+        "row — summarize and interpret."
+      )
+    return prompt
 
   def _get_max_results(self, mode: OperatorMode) -> int:
     return {
@@ -271,13 +170,9 @@ Please explain these results in a clear, natural way.""",
       OperatorMode.EXTENDED: 500,
     }.get(mode, 100)
 
-  def _calculate_confidence(self, cypher_query: str, results: list | None) -> float:
-    if not cypher_query or "ERROR" in cypher_query.upper():
-      return 0.3
-    if results is None:
+  def _calculate_confidence(self, result: ToolLoopResult) -> float:
+    if result.hit_cap:
       return 0.5
-    if len(results) == 0:
-      return 0.6
-    if len(results) > 0:
+    if result.rows:
       return 0.9
-    return 0.7
+    return 0.6

--- a/robosystems/operations/operators/operator_context.py
+++ b/robosystems/operations/operators/operator_context.py
@@ -47,6 +47,14 @@ class ToolAccess(Protocol):
   ) -> Any:
     """Call an MCP tool by name."""
 
+  async def get_tool_schemas(self, names: list[str]) -> list[dict[str, Any]]:
+    """Return Anthropic-shaped tool definitions for the named tools.
+
+    Filters to the subset of `names` that are actually available on this
+    graph (extension/flag-gated tools are omitted) and returns them as
+    `{"name", "description", "input_schema"}` ready to hand to the model.
+    """
+
 
 @dataclass
 class OperatorContext:

--- a/robosystems/operations/operators/tool_access.py
+++ b/robosystems/operations/operators/tool_access.py
@@ -58,6 +58,28 @@ class HttpToolAccess:
       await self.initialize()
     return await self._tools.call_tool(tool_name, arguments, return_raw=return_raw)
 
+  async def get_tool_schemas(self, names: list[str]) -> list[dict[str, Any]]:
+    """Return Anthropic-shaped tool definitions for the requested names.
+
+    The requested `names` are intersected with the tools actually available
+    on this graph (GraphMCPTools gates by schema extension + feature flag),
+    so an operator can ask for a broad read-only allowlist and safely get
+    back only what exists. Remaps the MCP `inputSchema` key to Anthropic's
+    `input_schema`.
+    """
+    if self._tools is None:
+      await self.initialize()
+    wanted = set(names)
+    return [
+      {
+        "name": defn["name"],
+        "description": defn["description"],
+        "input_schema": defn["inputSchema"],
+      }
+      for defn in self._tools.get_tool_definitions_as_dict()
+      if defn["name"] in wanted
+    ]
+
   async def close(self) -> None:
     """Clean up HTTP client connection."""
     if self._client:
@@ -116,6 +138,28 @@ class DirectToolAccess:
       f"Tool '{tool_name}' not registered in DirectToolAccess. "
       f"Use get_tool_instance() to register tool classes first."
     )
+
+  async def get_tool_schemas(self, names: list[str]) -> list[dict[str, Any]]:
+    """Return Anthropic-shaped definitions for registered tool instances.
+
+    DirectToolAccess is used by operators that drive tools imperatively
+    (e.g. MappingOperator), not by the model-driven tool loop. It only
+    knows about tool classes explicitly registered via get_tool_instance,
+    so it reports those; the loop-based operators use HttpToolAccess.
+    """
+    wanted = set(names)
+    schemas: list[dict[str, Any]] = []
+    for tool in self._tool_instances.values():
+      defn = tool.get_tool_definition()
+      if defn.get("name") in wanted:
+        schemas.append(
+          {
+            "name": defn["name"],
+            "description": defn["description"],
+            "input_schema": defn["inputSchema"],
+          }
+        )
+    return schemas
 
   async def close(self) -> None:
     """No-op — no connections to clean up."""

--- a/robosystems/operations/operators/tool_loop.py
+++ b/robosystems/operations/operators/tool_loop.py
@@ -163,7 +163,11 @@ async def run_tool_loop(
         # raising; treat both paths as errors so the model gets the feedback.
         if isinstance(result, dict) and "error" in result:
           is_error = True
-        elif name == "read-graph-cypher" and isinstance(result, list):
+        elif name == "read-graph-cypher" and isinstance(result, list) and result:
+          # Capture the last NON-EMPTY result set so a later exploratory or
+          # zero-row query doesn't wipe the rows that back the answer. If every
+          # query returns empty, last_rows stays None and the console shows no
+          # table — correct for a genuinely empty answer.
           last_rows = result
           last_cypher = args.get("query")
       except Exception as e:  # cypher_tool raises ValueError on bad queries

--- a/robosystems/operations/operators/tool_loop.py
+++ b/robosystems/operations/operators/tool_loop.py
@@ -1,0 +1,215 @@
+"""Bounded, model-driven tool-use loop for operators.
+
+Lets the model choose and call read-only MCP tools, feeds tool errors back
+so it can self-correct, and stops at a bounded iteration count. This is the
+shared harness behind CypherOperator (its first caller) and any future
+read/analysis operator — the same tool-use loop that makes Claude-via-MCP
+robust, run in-process on Bedrock with automatic per-call credit tracking.
+
+Contrast with the old single-shot pipeline: there, Python called two fixed
+tools and the model never saw a query error. Here the model drives the tools
+and every tool error comes back as an ``is_error`` tool_result it can react to.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from robosystems.logger import logger
+from robosystems.operations.operators.ai_client import AIMessage
+
+if TYPE_CHECKING:
+  from robosystems.operations.operators.operator_context import OperatorContext
+
+# Tool results fed back to the model are capped so a large query result can't
+# blow the context window or run up credit spend — the model only needs
+# enough rows to reason about. The full result is captured separately (rows)
+# for the caller/frontend, which paginates.
+_MAX_TOOL_RESULT_CHARS = 12000
+
+_ANSWER_NOW = (
+  "You've reached the step limit. Answer the original question now using the "
+  "results gathered so far. Do not request any more tools."
+)
+
+
+@dataclass
+class ToolLoopResult:
+  """Outcome of a tool-use loop."""
+
+  text: str
+  rows: list[dict[str, Any]] | None = None  # last read-graph-cypher result set
+  cypher: str | None = None  # the query that produced ``rows``
+  tools_called: list[str] = field(default_factory=list)
+  iterations: int = 0
+  hit_cap: bool = False  # stopped at max_iterations rather than by the model
+
+
+def _serialize_tool_result(result: Any) -> str:
+  """JSON-encode a tool result for feedback, capped in size."""
+  text = json.dumps(result, default=str)
+  if len(text) > _MAX_TOOL_RESULT_CHARS:
+    text = text[:_MAX_TOOL_RESULT_CHARS] + f"\n… [truncated; {len(text)} chars total]"
+  return text
+
+
+def _seed_history(ctx: OperatorContext) -> list[AIMessage]:
+  """Convert the last few conversation turns into plain-text messages."""
+  messages: list[AIMessage] = []
+  for msg in ctx.history[-5:]:
+    if isinstance(msg, dict):
+      role = msg.get("role", "user")
+      content = msg.get("content", "")
+    else:
+      role = getattr(msg, "role", "user")
+      content = getattr(msg, "content", "")
+    messages.append(AIMessage(role=role, content=content))
+  return messages
+
+
+async def run_tool_loop(
+  ctx: OperatorContext,
+  *,
+  system: str,
+  tool_names: list[str],
+  max_iterations: int,
+  max_tokens: int,
+  temperature: float = 0.3,
+  operator_type: str | None = None,
+  operation_description: str = "Tool-use loop",
+) -> ToolLoopResult:
+  """Run a bounded tool-use loop and return the model's final answer.
+
+  The model is given the read-only tools named by ``tool_names`` (intersected
+  with what the graph actually exposes) and iterates: call tools → observe
+  results, or errors fed back as ``is_error`` tool_results so it can retry →
+  answer in natural language. Bounded by ``max_iterations``; on hitting the
+  cap, one final turn nudges the model to answer from what it gathered.
+
+  Args:
+      ctx: Operator context (ai, tools, progress, history, query).
+      system: System prompt.
+      tool_names: Read-only tool allowlist to request. Only names actually
+          available on the graph are passed to the model.
+      max_iterations: Maximum model round-trips that may call tools.
+      max_tokens: Max output tokens per model call.
+      temperature: Sampling temperature.
+      operator_type: For model-override lookup + credit audit.
+      operation_description: Credit audit description.
+
+  Returns:
+      ToolLoopResult with the final text, the last Cypher result set (for a
+      table), and loop diagnostics.
+  """
+  tools = await ctx.tools.get_tool_schemas(tool_names)
+  if not tools:
+    logger.warning(
+      "run_tool_loop: none of %s available on graph %s", tool_names, ctx.graph_id
+    )
+
+  messages: list[AIMessage] = _seed_history(ctx)
+  messages.append(AIMessage(role="user", content=ctx.query))
+
+  tools_called: list[str] = []
+  last_rows: list[dict[str, Any]] | None = None
+  last_cypher: str | None = None
+
+  step = 60 // max(max_iterations, 1)
+
+  for iteration in range(max_iterations):
+    await ctx.progress.report(
+      "Thinking..." if iteration == 0 else f"Working (step {iteration + 1})...",
+      percent=min(20 + iteration * step, 85),
+    )
+
+    response = await ctx.ai.create_message(
+      messages=messages,
+      system=system,
+      max_tokens=max_tokens,
+      temperature=temperature,
+      operator_type=operator_type,
+      operation_description=operation_description,
+      tools=tools,
+    )
+
+    # Model produced a final answer (no tool call) — done.
+    if response.stop_reason != "tool_use":
+      return ToolLoopResult(
+        text=response.content,
+        rows=last_rows,
+        cypher=last_cypher,
+        tools_called=tools_called,
+        iterations=iteration + 1,
+      )
+
+    # Replay the assistant turn (text + tool_use blocks) verbatim.
+    messages.append(AIMessage(role="assistant", content=response.content_blocks))
+
+    tool_results: list[dict[str, Any]] = []
+    for block in response.content_blocks:
+      if block.get("type") != "tool_use":
+        continue
+      name = block.get("name", "")
+      tool_use_id = block.get("id", "")
+      args = block.get("input") or {}
+      tools_called.append(name)
+
+      is_error = False
+      try:
+        result = await ctx.tools.call_tool(name, args, return_raw=True)
+        # Registrar/domain tools report failure as {"error": ...} instead of
+        # raising; treat both paths as errors so the model gets the feedback.
+        if isinstance(result, dict) and "error" in result:
+          is_error = True
+        elif name == "read-graph-cypher" and isinstance(result, list):
+          last_rows = result
+          last_cypher = args.get("query")
+      except Exception as e:  # cypher_tool raises ValueError on bad queries
+        logger.info("run_tool_loop tool %s errored: %s", name, e)
+        result = {"error": str(e)}
+        is_error = True
+
+      tool_results.append(
+        {
+          "type": "tool_result",
+          "tool_use_id": tool_use_id,
+          "content": _serialize_tool_result(result),
+          "is_error": is_error,
+        }
+      )
+
+    messages.append(AIMessage(role="user", content=tool_results))
+
+  # Iteration cap reached. Nudge for a final answer, appending the nudge to
+  # the trailing user turn (avoids a second consecutive user message). Keep
+  # `tools` defined so the tool_use/tool_result transcript stays valid.
+  final_messages = list(messages)
+  last = final_messages[-1]
+  if last.role == "user" and isinstance(last.content, list):
+    final_messages[-1] = AIMessage(
+      role="user",
+      content=[*last.content, {"type": "text", "text": _ANSWER_NOW}],
+    )
+  else:
+    final_messages.append(AIMessage(role="user", content=_ANSWER_NOW))
+
+  final = await ctx.ai.create_message(
+    messages=final_messages,
+    system=system,
+    max_tokens=max_tokens,
+    temperature=temperature,
+    operator_type=operator_type,
+    operation_description=operation_description,
+    tools=tools,
+  )
+  return ToolLoopResult(
+    text=final.content
+    or "I gathered results but couldn't compose a final answer within the step limit.",
+    rows=last_rows,
+    cypher=last_cypher,
+    tools_called=tools_called,
+    iterations=max_iterations,
+    hit_cap=True,
+  )

--- a/robosystems/operations/operators/tracked_ai.py
+++ b/robosystems/operations/operators/tracked_ai.py
@@ -48,6 +48,7 @@ class TrackedAIClient:
     model: str | None = None,
     operator_type: str | None = None,
     operation_description: str = "Operator AI call",
+    tools: list[dict[str, Any]] | None = None,
   ) -> AIResponse:
     """Call AI and automatically consume credits.
 
@@ -59,6 +60,9 @@ class TrackedAIClient:
         model: Optional model override.
         operator_type: Optional operator type for model override lookup.
         operation_description: Description for credit audit trail.
+        tools: Optional Anthropic tool definitions. Each call in a tool-use
+            loop flows through here, so tokens and credits accumulate across
+            iterations automatically.
 
     Returns:
         AIResponse with content and token counts.
@@ -70,6 +74,7 @@ class TrackedAIClient:
       temperature=temperature,
       model=model,
       operator_type=operator_type,
+      tools=tools,
     )
 
     # Track tokens

--- a/tests/operations/operators/test_tool_loop.py
+++ b/tests/operations/operators/test_tool_loop.py
@@ -151,6 +151,35 @@ async def test_tool_error_is_fed_back_and_model_retries():
   assert any("Invalid Cypher" in b.get("content", "") for b in blocks)
 
 
+async def test_empty_followup_does_not_clobber_captured_rows():
+  """A later zero-row read-graph-cypher must not wipe the rows from an earlier
+  successful query (finding #2 — last-non-empty wins)."""
+  ai = MagicMock()
+  ai.create_message = AsyncMock(
+    side_effect=[
+      _tool_use("t1", "read-graph-cypher", query="MATCH (e:Entity) RETURN e LIMIT 5"),
+      _tool_use(
+        "t2", "read-graph-cypher", query="MATCH (e:Entity) WHERE e.name='nope' RETURN e"
+      ),
+      _final("Here are the entities."),
+    ]
+  )
+  good_rows = [{"e": 1}, {"e": 2}, {"e": 3}]
+  tools = _tools_mock(call_results=[good_rows, []])  # second query returns []
+  ctx = _ctx(ai, tools)
+
+  result = await run_tool_loop(
+    ctx,
+    system="s",
+    tool_names=["read-graph-cypher"],
+    max_iterations=5,
+    max_tokens=100,
+  )
+
+  assert result.rows == good_rows  # not clobbered by the empty follow-up
+  assert result.cypher == "MATCH (e:Entity) RETURN e LIMIT 5"
+
+
 async def test_error_dict_result_is_flagged_and_not_captured_as_rows():
   """Registrar/domain tools report failure as {"error": ...} rather than
   raising — that path must also be fed back as is_error and not mistaken for

--- a/tests/operations/operators/test_tool_loop.py
+++ b/tests/operations/operators/test_tool_loop.py
@@ -1,0 +1,220 @@
+"""Tests for the bounded tool-use loop (run_tool_loop).
+
+The load-bearing behavior is error feedback: when a tool call fails, the loop
+must feed the error back to the model as an ``is_error`` tool_result so it can
+self-correct — the thing the old single-shot pipeline never did.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from robosystems.operations.operators.ai_client import AIResponse
+from robosystems.operations.operators.base import OperatorMode
+from robosystems.operations.operators.operator_context import OperatorContext
+from robosystems.operations.operators.progress import NoOpProgress
+from robosystems.operations.operators.tool_loop import run_tool_loop
+
+pytestmark = pytest.mark.asyncio
+
+
+def _tool_use(tool_id: str, name: str, **inp) -> AIResponse:
+  """A model turn that calls one tool."""
+  return AIResponse(
+    content="",
+    model="m",
+    input_tokens=10,
+    output_tokens=5,
+    stop_reason="tool_use",
+    content_blocks=[{"type": "tool_use", "id": tool_id, "name": name, "input": inp}],
+  )
+
+
+def _final(text: str) -> AIResponse:
+  """A model turn that answers in natural language."""
+  return AIResponse(
+    content=text,
+    model="m",
+    input_tokens=10,
+    output_tokens=5,
+    stop_reason="end_turn",
+    content_blocks=[{"type": "text", "text": text}],
+  )
+
+
+def _tools_mock(call_results: list) -> MagicMock:
+  tools = MagicMock()
+  tools.get_tool_schemas = AsyncMock(
+    return_value=[
+      {
+        "name": "read-graph-cypher",
+        "description": "run cypher",
+        "input_schema": {"type": "object"},
+      }
+    ]
+  )
+  tools.call_tool = AsyncMock(side_effect=call_results)
+  return tools
+
+
+def _ctx(ai: MagicMock, tools: MagicMock, query: str = "How many companies?"):
+  return OperatorContext(
+    graph_id="kg_test",
+    user_id="u",
+    query=query,
+    mode=OperatorMode.STANDARD,
+    history=[],
+    ai=ai,
+    tools=tools,
+    progress=NoOpProgress(),
+  )
+
+
+def _tool_result_blocks(messages: list) -> list[dict]:
+  """Flatten every tool_result block across a message list."""
+  return [
+    block
+    for msg in messages
+    if isinstance(msg.content, list)
+    for block in msg.content
+    if isinstance(block, dict) and block.get("type") == "tool_result"
+  ]
+
+
+async def test_happy_path_captures_rows_and_cypher():
+  ai = MagicMock()
+  ai.create_message = AsyncMock(
+    side_effect=[
+      _tool_use("t1", "read-graph-cypher", query="MATCH (e:Entity) RETURN count(e)"),
+      _final("There are 42 companies."),
+    ]
+  )
+  rows = [{"count": 42}]
+  tools = _tools_mock(call_results=[rows])
+  ctx = _ctx(ai, tools)
+
+  result = await run_tool_loop(
+    ctx,
+    system="sys",
+    tool_names=["read-graph-cypher"],
+    max_iterations=5,
+    max_tokens=1000,
+  )
+
+  assert result.text == "There are 42 companies."
+  assert result.rows == rows
+  assert result.cypher == "MATCH (e:Entity) RETURN count(e)"
+  assert result.tools_called == ["read-graph-cypher"]
+  assert result.iterations == 2
+  assert result.hit_cap is False
+  tools.get_tool_schemas.assert_awaited_once_with(["read-graph-cypher"])
+  # Tools were handed to the model on the first turn.
+  assert ai.create_message.call_args_list[0].kwargs["tools"]
+
+
+async def test_tool_error_is_fed_back_and_model_retries():
+  """A raised tool error (cypher_tool raises ValueError on a bad query) is
+  returned to the model as an is_error tool_result, and the model retries."""
+  ai = MagicMock()
+  ai.create_message = AsyncMock(
+    side_effect=[
+      _tool_use("t1", "read-graph-cypher", query="MATCH bad syntax"),
+      _tool_use("t2", "read-graph-cypher", query="MATCH (e:Entity) RETURN e LIMIT 1"),
+      _final("Fixed the query and found the answer."),
+    ]
+  )
+  rows = [{"e": 1}]
+  tools = _tools_mock(call_results=[ValueError("Invalid Cypher near 'bad'"), rows])
+  ctx = _ctx(ai, tools)
+
+  result = await run_tool_loop(
+    ctx,
+    system="sys",
+    tool_names=["read-graph-cypher"],
+    max_iterations=5,
+    max_tokens=1000,
+  )
+
+  assert result.text == "Fixed the query and found the answer."
+  assert result.rows == rows
+  assert result.cypher == "MATCH (e:Entity) RETURN e LIMIT 1"
+  assert result.tools_called == ["read-graph-cypher", "read-graph-cypher"]
+  assert result.iterations == 3
+  assert result.hit_cap is False
+
+  # The SECOND model call must have seen the error as an is_error tool_result.
+  second_call_messages = ai.create_message.call_args_list[1].kwargs["messages"]
+  blocks = _tool_result_blocks(second_call_messages)
+  assert any(b.get("is_error") for b in blocks)
+  assert any("Invalid Cypher" in b.get("content", "") for b in blocks)
+
+
+async def test_error_dict_result_is_flagged_and_not_captured_as_rows():
+  """Registrar/domain tools report failure as {"error": ...} rather than
+  raising — that path must also be fed back as is_error and not mistaken for
+  a result set."""
+  ai = MagicMock()
+  ai.create_message = AsyncMock(
+    side_effect=[
+      _tool_use("t1", "read-graph-cypher", query="MATCH (n) RETURN n"),
+      _final("done"),
+    ]
+  )
+  tools = _tools_mock(call_results=[{"error": "boom", "message": "bad request"}])
+  ctx = _ctx(ai, tools)
+
+  result = await run_tool_loop(
+    ctx,
+    system="s",
+    tool_names=["read-graph-cypher"],
+    max_iterations=5,
+    max_tokens=100,
+  )
+
+  assert result.rows is None  # error dict is not a result set
+  blocks = _tool_result_blocks(ai.create_message.call_args_list[1].kwargs["messages"])
+  assert any(b.get("is_error") for b in blocks)
+
+
+async def test_hits_iteration_cap_then_forces_a_final_answer():
+  ai = MagicMock()
+  # The model never stops asking for tools → the loop must cap it.
+  ai.create_message = AsyncMock(
+    side_effect=[
+      _tool_use("t1", "read-graph-cypher", query="MATCH (n) RETURN n LIMIT 1"),
+      _tool_use("t2", "read-graph-cypher", query="MATCH (n) RETURN n LIMIT 1"),
+      _final("Best-effort answer from what I gathered."),
+    ]
+  )
+  rows = [{"n": 1}]
+  tools = _tools_mock(call_results=[rows, rows])
+  ctx = _ctx(ai, tools)
+
+  result = await run_tool_loop(
+    ctx,
+    system="s",
+    tool_names=["read-graph-cypher"],
+    max_iterations=2,
+    max_tokens=100,
+  )
+
+  assert result.hit_cap is True
+  assert result.iterations == 2
+  assert result.text == "Best-effort answer from what I gathered."
+  # 2 loop iterations + 1 forced-final turn.
+  assert ai.create_message.await_count == 3
+
+  final_kwargs = ai.create_message.call_args_list[2].kwargs
+  assert final_kwargs["tools"]  # transcript stays valid
+  # The answer-now nudge is appended to the trailing user turn (no second
+  # consecutive user message).
+  last_user = final_kwargs["messages"][-1]
+  assert last_user.role == "user"
+  assert any(
+    isinstance(b, dict)
+    and b.get("type") == "text"
+    and "step limit" in b.get("text", "")
+    for b in last_user.content
+  )

--- a/tests/operations/test_ai_client.py
+++ b/tests/operations/test_ai_client.py
@@ -394,6 +394,70 @@ class TestAIClientCreateMessage:
     assert "system" not in request_body
 
   @pytest.mark.unit
+  async def test_create_message_with_tools_and_tool_use_response(self):
+    """Tools are sent in the request body; a tool_use response exposes
+    content_blocks and stop_reason so the tool loop can drive it."""
+    client, mock_bedrock = _make_ai_client()
+    from robosystems.operations.operators.ai_client import AIMessage
+
+    response_body = {
+      "content": [
+        {"type": "text", "text": "Let me check."},
+        {
+          "type": "tool_use",
+          "id": "toolu_1",
+          "name": "read-graph-cypher",
+          "input": {"query": "MATCH (n) RETURN n"},
+        },
+      ],
+      "usage": {"input_tokens": 120, "output_tokens": 30},
+      "stop_reason": "tool_use",
+    }
+    mock_body = MagicMock()
+    mock_body.read.return_value = json.dumps(response_body).encode()
+    mock_bedrock.invoke_model.return_value = {"body": mock_body}
+
+    tools = [
+      {
+        "name": "read-graph-cypher",
+        "description": "run cypher",
+        "input_schema": {"type": "object"},
+      }
+    ]
+    result = await client.create_message(
+      messages=[AIMessage(role="user", content="how many nodes?")],
+      tools=tools,
+    )
+
+    request_body = json.loads(mock_bedrock.invoke_model.call_args[1]["body"])
+    assert request_body["tools"] == tools
+
+    assert result.stop_reason == "tool_use"
+    # `content` is the joined text blocks; tool_use carries no text.
+    assert result.content == "Let me check."
+    assert len(result.content_blocks) == 2
+    assert result.content_blocks[1]["name"] == "read-graph-cypher"
+
+  @pytest.mark.unit
+  async def test_create_message_without_tools_omits_tools_key(self):
+    """No tools param → no `tools` key in the Bedrock request body."""
+    client, mock_bedrock = _make_ai_client()
+    from robosystems.operations.operators.ai_client import AIMessage
+
+    response_body = {
+      "content": [{"type": "text", "text": "hi"}],
+      "usage": {"input_tokens": 10, "output_tokens": 5},
+      "stop_reason": "end_turn",
+    }
+    mock_body = MagicMock()
+    mock_body.read.return_value = json.dumps(response_body).encode()
+    mock_bedrock.invoke_model.return_value = {"body": mock_body}
+
+    await client.create_message(messages=[AIMessage(role="user", content="hi")])
+    request_body = json.loads(mock_bedrock.invoke_model.call_args[1]["body"])
+    assert "tools" not in request_body
+
+  @pytest.mark.unit
   async def test_create_message_formats_messages_correctly(self):
     """Test that messages are formatted into the correct dict structure."""
     client, mock_bedrock = _make_ai_client()


### PR DESCRIPTION
## What

Replaces the Cypher operator's single-shot pipeline (fetch truncated schema → generate one query → execute once → format) with a **bounded, model-driven tool-use loop**. The model discovers the schema, writes read-only Cypher, sees tool errors fed back as `is_error` tool_results and self-corrects, then answers in natural language — the loop that makes Claude-via-MCP robust, run in-process on Bedrock.

## Why

The old pipeline never showed the model its query errors, and only saw a schema truncated to 20 nodes × 5 properties — so it frequently failed basic questions.

## Changes

- **AIClient** — send `tools` to Bedrock `invoke_model`; return content blocks + `stop_reason` (robust text join across blocks, tolerant of tool_use-only turns)
- **TrackedAIClient** — `tools` passthrough; per-call credit tracking already accumulates across loop iterations
- **`run_tool_loop`** — reusable bounded loop: error feedback, a read-only tool allowlist, and a forced-answer turn on the iteration cap; captures the last result set + query
- **CypherOperator** — rewritten on the loop; returns `metadata.{cypher, rows, result_count}` so the console renders a real table instead of scraping prose
- Tests: error-feedback retry, error-dict handling, iteration cap, Bedrock tools request/response shape

## Validation (live demo graph)

- *"How many transactions?"* → "489 transactions", correct Cypher, structured rows (2 iterations)
- *"Top 5 accounts by total debits?"* → correct `Entry→LineItem→Element` join, **self-applied the `status = 'posted'` ledger rule**, clean narrative + 5 rows (self-corrected within budget)
- 152 operator/config tests pass; ruff + basedpyright clean

## Cost note

Quick ≈ 26 credits, standard ≈ 170/query — the schema re-fed each iteration is the driver. Follow-up: trim/cache the schema inside the loop.

## Paired frontend

robosystems-app `feature/console-operator-loop` consumes the new `metadata.rows` / `metadata.cypher`.
