### PR TITLE
Upgrade FastAPI to 0.139 (adapt connections router to lazy include_router)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
 ]
 dependencies = [
     # Web Framework & API
-    "fastapi>=0.135.0,<1.0",
+    "fastapi>=0.139.0,<1.0",
     "starlette>=1.3.1,<2.0",
     "sse-starlette>=3.3.0,<4.0",
     "strawberry-graphql[fastapi]>=0.314.0,<1.0",

--- a/robosystems/routers/graphs/connections/__init__.py
+++ b/robosystems/routers/graphs/connections/__init__.py
@@ -6,50 +6,30 @@ CRUD management, sync, and OAuth authentication.
 """
 
 from fastapi import APIRouter
-from fastapi.routing import APIRoute
 
 from .management import router as management_router
 from .oauth import router as oauth_router
 from .options import router as options_router
 from .sync import router as sync_router
 
-
-def sort_routes_for_docs_and_matching(routes: list[APIRoute]) -> list[APIRoute]:
-  """Sort routes by priority for correct FastAPI matching and documentation order."""
-  return sorted(routes, key=lambda r: (getattr(r, "priority", 999), r.path))
-
-
 # Create main connections router
 router = APIRouter(tags=["Connections"])
 
-# Include operation routers
+# Include the operation routers (static paths) before the management routes.
+# FastAPI matches static path segments ahead of path parameters, so a request
+# to /options resolves to the options handler rather than /{connection_id}.
+# Declaration order (static routers first) reinforces this — no manual route
+# priority sorting is needed. (FastAPI <0.137 required the sort; 0.137 made
+# include_router lazy and added native static-over-parameter matching.)
 router.include_router(sync_router)
 router.include_router(options_router)
 router.include_router(oauth_router)
 
-# Add management routes manually (has empty paths so needs manual addition)
+# Management routes use empty paths, so include_router can't prefix them
+# cleanly — append them directly (after the static routers) and tag them.
 for route in management_router.routes:
   if not hasattr(route, "tags") or not route.tags:
     route.tags = ["Connections"]
   router.routes.append(route)
-
-# Set priorities on all routes
-for route in router.routes:
-  has_params = "{" in route.path and "}" in route.path
-
-  if route.path in [""]:
-    route.priority = 10 if not has_params else 20
-  elif "/options" in route.path:
-    route.priority = 12 if not has_params else 22
-  elif "/oauth" in route.path:
-    route.priority = 14 if not has_params else 24
-  elif "/{connection_id}" in route.path:
-    route.priority = 15 if not has_params else 25
-  elif "/sync" in route.path:
-    route.priority = 16 if not has_params else 26
-  else:
-    route.priority = 999
-
-router.routes = sort_routes_for_docs_and_matching(router.routes)
 
 __all__ = ["router"]

--- a/tests/routers/graphs/connections/test_routing.py
+++ b/tests/routers/graphs/connections/test_routing.py
@@ -1,0 +1,52 @@
+"""
+Route-ordering guardrail for the connections router.
+
+The static ``/options`` route must resolve ahead of the parameterized
+``/{connection_id}`` route (both are GET on the same path segment), otherwise
+``GET .../connections/options`` would be captured as ``connection_id="options"``.
+
+Prior to FastAPI 0.137 this was enforced with a manual ``.priority`` sort over
+``router.routes``. FastAPI 0.137 made ``include_router`` lazy (child routes live
+inside an ``_IncludedRouter`` wrapper) and added native static-over-parameter
+matching, so the sort was removed. This test locks the invariant in place so a
+future refactor can't silently reintroduce the ambiguity.
+"""
+
+from robosystems.routers.graphs.connections import router
+
+
+def _entry_paths(entry) -> list[str]:
+  """The path(s) an entry in ``router.routes`` represents.
+
+  A plain ``APIRoute`` has its own ``path``; an ``_IncludedRouter`` (lazy
+  include) exposes its children via ``original_router.routes``.
+  """
+  if hasattr(entry, "path"):
+    return [entry.path]
+  original = getattr(entry, "original_router", None)
+  return [getattr(child, "path", "") for child in getattr(original, "routes", [])]
+
+
+def _first_index(paths_by_entry: list[list[str]], target: str) -> int:
+  for i, paths in enumerate(paths_by_entry):
+    if target in paths:
+      return i
+  raise AssertionError(f"{target} not found among connections routes")
+
+
+def test_options_resolves_before_connection_id():
+  paths_by_entry = [_entry_paths(e) for e in router.routes]
+  assert _first_index(paths_by_entry, "/options") < _first_index(
+    paths_by_entry, "/{connection_id}"
+  )
+
+
+def test_connections_router_exposes_expected_paths():
+  all_paths = {p for e in router.routes for p in _entry_paths(e)}
+  for expected in (
+    "/options",
+    "/{connection_id}",
+    "/{connection_id}/sync",
+    "/oauth/init",
+  ):
+    assert expected in all_paths

--- a/uv.lock
+++ b/uv.lock
@@ -1099,7 +1099,7 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.136.3"
+version = "0.139.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -1108,9 +1108,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/2d/ff8d91d7b564d464629a0fd50a4489c97fcb836ac230bf3a7269232a9b1f/fastapi-0.136.3.tar.gz", hash = "sha256:e487fae93ad408e6f47641ee4dfe389864fd7bec92e547ea8498fc13f43e83ab", size = 396410, upload-time = "2026-05-23T18:53:15.192Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/af/a5f50ccfa659ec1802cb4ca842c23f06d906a8cc9aef6016a2caeea3d4ed/fastapi-0.139.0.tar.gz", hash = "sha256:99ab7b2d92223c76d6cf10757ab3f89d45b38267fc20b2a136cf02f6beac3145", size = 423016, upload-time = "2026-07-01T16:35:33.436Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl", hash = "sha256:3d2a69bdf04b7e9f3afa292c3bc7a98816bbfafa10bc9b45f3f3700d2f761620", size = 117481, upload-time = "2026-05-23T18:53:16.924Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/7c/8e3c6ad324ea5cb36604fc3f968554887891c316d9dfde57761611d907ad/fastapi-0.139.0-py3-none-any.whl", hash = "sha256:cf15e1e9e667ddb0ad63811e60bd11390d1aac838ca4a7a23f421807b2308189", size = 130339, upload-time = "2026-07-01T16:35:32.19Z" },
 ]
 
 [[package]]
@@ -3642,7 +3642,7 @@ requires-dist = [
     { name = "dbt-duckdb", specifier = ">=1.10.0,<2.0" },
     { name = "duckdb", specifier = "==1.4.4" },
     { name = "email-validator", specifier = ">=2.2.0,<3.0" },
-    { name = "fastapi", specifier = ">=0.135.0,<1.0" },
+    { name = "fastapi", specifier = ">=0.139.0,<1.0" },
     { name = "fastembed", specifier = ">=0.8.0,<1.0" },
     { name = "holidays", specifier = ">=0.76.0,<1.0" },
     { name = "httptools", specifier = ">=0.6.0,<1.0" },


### PR DESCRIPTION
## What

Completes the FastAPI 0.136.3 → **0.139.0** upgrade that the routine Dependabot bump (#795, closed) couldn't land on its own.

## Why it wasn't a plain bump

FastAPI 0.137 made `include_router()` **lazy**: child routes now live inside an `_IncludedRouter` wrapper in `.routes` instead of being flattened, and the framework added **native static-over-parameter matching** (`effective_low_priority_routes`). Our `routers/graphs/connections/__init__.py` had a manual route-priority sort that iterated `.routes` accessing `.path` — it crashed on the wrapper (`AttributeError: '_IncludedRouter' object has no attribute 'path'` at conftest import) and is now redundant.

## Changes

- `pyproject.toml` / `uv.lock` — fastapi `>=0.139.0,<1.0`, locked to 0.139.0 (lockfile churn is fastapi-only; starlette was already 1.3.1).
- `routers/graphs/connections/__init__.py` — remove the priority-sort hack. Correct matching is preserved by declaration order (static routers included before the `/{connection_id}` management routes) plus FastAPI's native static-first matching. `subgraphs`/`backups` were unaffected (they only touch leaf-router `.tags`, never `.path`).
- `tests/routers/graphs/connections/test_routing.py` — **new** guardrail asserting `/options` resolves before `/{connection_id}`, locking in the invariant the deleted sort used to protect.

## Validation

- Full unit suite: **10601 passed**, 15 skipped, under fastapi 0.139.
- Connections + logout router tests: 99 passed (incl. the 15 `/options` resolution tests).
- ruff lint + format, basedpyright, cf-lint: all clean.

## Note (out of scope)

Two pre-existing FastAPI deprecation warnings surfaced (not introduced here): `example`→`examples` in `credits.py`, `regex`→`pattern` in `schema/export.py`. Still functional; worth a follow-up before the `<1.0` ceiling.