### PR TITLE
fix(security): app-layer hardening from SOC 2 review

### DIFF
--- a/robosystems/config/logging.py
+++ b/robosystems/config/logging.py
@@ -83,6 +83,19 @@ class StructuredFormatter(logging.Formatter):
     if hasattr(record, "request_id"):
       log_entry["request_id"] = record.request_id
 
+    # Structured operation-audit payload (who / what / which-tenant / result).
+    # Emitted via extra={"audit": {...}} by middleware.operations.log_operation_audit;
+    # without this the entire audit payload was silently dropped.
+    if hasattr(record, "audit"):
+      log_entry["audit"] = record.audit
+
+    # Security / auth event fields emitted by the security-logging middleware.
+    # Source IP and success flag are required for auth-anomaly detection.
+    if hasattr(record, "ip_address"):
+      log_entry["ip_address"] = record.ip_address
+    if hasattr(record, "success"):
+      log_entry["success"] = record.success
+
     return json.dumps(log_entry, default=str, separators=(",", ":"))
 
 

--- a/robosystems/middleware/auth/utils.py
+++ b/robosystems/middleware/auth/utils.py
@@ -72,6 +72,13 @@ def validate_api_key(api_key: str, db_session: Session | None = None) -> User | 
       user.email = user_data.get("email")
       user.is_active = user_data.get("is_active", True)
 
+      # Reject keys owned by a deactivated user, even when the key row and its
+      # cache entry are still marked active. Deactivation invalidates the cache
+      # entry, but this guard closes the window until that propagates.
+      if not user.is_active:
+        logger.debug(f"API key rejected: owning user inactive: {cache_key[:8]}...")
+        return None
+
       return user
 
   # Cache miss - fall back to database with secure bcrypt verification.
@@ -101,6 +108,13 @@ def validate_api_key(api_key: str, db_session: Session | None = None) -> User | 
 
     # Grab user reference while session is active (triggers lazy load once)
     user = key_record.user
+
+    # Reject keys whose owning user is deactivated. UserAPIKey.get_by_key only
+    # filters on the key's own is_active flag, not the user's — without this a
+    # deactivated user retains full API access via any existing key.
+    if not user.is_active:
+      logger.debug(f"API key rejected: owning user inactive: {cache_key[:8]}...")
+      return None
 
     # Cache positive result with encrypted storage
     try:
@@ -187,6 +201,11 @@ def validate_api_key_with_graph(
       user.email = user_data.get("email")
       user.is_active = user_data.get("is_active", True)
 
+      # Reject keys owned by a deactivated user (see validate_api_key).
+      if not user.is_active:
+        logger.debug(f"API key rejected: owning user inactive: {api_key_hash[:8]}...")
+        return None
+
       # last_used_at is updated on cache miss (below).
       # Skipping it on cache hits avoids DB pool contention under load —
       # the cache TTL ensures it refreshes every few minutes anyway.
@@ -220,6 +239,11 @@ def validate_api_key_with_graph(
 
     # Grab user reference while session is active (triggers lazy load once)
     user = key_record.user
+
+    # Reject keys whose owning user is deactivated (see validate_api_key).
+    if not user.is_active:
+      logger.debug(f"API key rejected: owning user inactive: {api_key_hash[:8]}...")
+      return None
 
     # Check if the user has access to the specified graph
     from ..graph.utils import MultiTenantUtils

--- a/robosystems/middleware/rate_limits/cache.py
+++ b/robosystems/middleware/rate_limits/cache.py
@@ -42,7 +42,7 @@ class RateLimitCache:
     return f"{self.RATE_LIMIT_PREFIX}{identifier}"
 
   def check_rate_limit(
-    self, identifier: str, limit: int, window: int
+    self, identifier: str, limit: int, window: int, fail_closed: bool = False
   ) -> tuple[bool, int]:
     """
     Check if request is within rate limit using sliding window.
@@ -51,6 +51,11 @@ class RateLimitCache:
         identifier: Unique identifier (e.g., user:123, ip:1.2.3.4)
         limit: Maximum requests allowed
         window: Time window in seconds
+        fail_closed: When the limiter backend errors, deny (True) instead of
+            allowing (False). Use for high-value categories such as auth /
+            brute-force where a broken limiter must not silently disable
+            protection. Defaults to False so a limiter outage doesn't take
+            down general traffic.
 
     Returns:
         tuple[bool, int]: (allowed, remaining_requests)
@@ -110,7 +115,16 @@ class RateLimitCache:
 
     except Exception as e:
       logger.error(f"Rate limiting check failed for {identifier}: {e}")
-      # Fail open - allow request if rate limiting is broken
+      if fail_closed:
+        # High-value category (auth/brute-force): a broken limiter must NOT
+        # silently disable protection. Deny, and log distinctly so alerting can
+        # treat this as a limiter-backend incident rather than an attack.
+        logger.error(
+          f"Rate limiter failing CLOSED for {identifier}: denying because the "
+          f"limiter backend is unavailable"
+        )
+        return False, 0
+      # Default: fail open - a limiter outage shouldn't take down general traffic.
       return True, limit
 
   def get_rate_limit_stats(self) -> dict[str, Any]:

--- a/robosystems/middleware/rate_limits/rate_limiting.py
+++ b/robosystems/middleware/rate_limits/rate_limiting.py
@@ -194,7 +194,11 @@ def auth_rate_limit_dependency(request: Request):
     limit = get_int_env("RATE_LIMIT_AUTH", "10")  # 10 attempts
     window = get_int_env("RATE_LIMIT_AUTH_WINDOW", "300")  # 5 minutes
 
-  allowed, remaining = rate_limit_cache.check_rate_limit(identifier, limit, window)
+  # Auth endpoints fail CLOSED: if the limiter backend is down, deny rather
+  # than silently disable brute-force protection on login/register.
+  allowed, remaining = rate_limit_cache.check_rate_limit(
+    identifier, limit, window, fail_closed=True
+  )
 
   if not allowed:
     # Log authentication rate limit violation - this is high risk

--- a/robosystems/models/core/user/user.py
+++ b/robosystems/models/core/user/user.py
@@ -136,10 +136,15 @@ class User(Model):
     """Deactivate the user.
 
     Bumps ``session_version``, which invalidates every JWT issued for this
-    user. If the user is reactivated later, they must re-authenticate —
-    prior tokens cannot resume. This is intentional: a deactivated account
-    is a security boundary, and we don't want suspended/banned/restored
-    accounts to be revivable just by replaying an old token.
+    user, and revokes all of the user's API keys. If the user is reactivated
+    later, they must re-authenticate and regenerate API keys — prior tokens
+    and keys cannot resume. This is intentional: a deactivated account is a
+    security boundary, and we don't want suspended/banned/restored accounts
+    to be revivable just by replaying an old token or a still-valid API key.
+
+    API-key revocation is essential: keys don't carry ``session_version`` and
+    ``UserAPIKey.get_by_key`` filters only on the key's own active flag, so
+    without this a deactivated user would keep full programmatic access.
     """
     self.is_active = False
     self.session_version = (self.session_version or 0) + 1
@@ -148,6 +153,7 @@ class User(Model):
       session.commit()
       session.refresh(self)
       self._invalidate_auth_cache()
+      self._revoke_api_keys(session)
     except SQLAlchemyError:
       session.rollback()
       raise
@@ -175,6 +181,31 @@ class User(Model):
     except SQLAlchemyError:
       session.rollback()
       raise
+
+  def _revoke_api_keys(self, session: Session) -> None:
+    """Deactivate all of this user's active API keys and clear their caches.
+
+    Called on deactivate so programmatic access is revoked alongside JWT
+    invalidation. Each key's ``deactivate`` flips ``is_active`` and invalidates
+    that key's validation-cache entry. Failures are logged per-key but never
+    abort the user deactivation (best-effort); the ``user.is_active`` guard in
+    ``validate_api_key`` is the authoritative backstop if a key is missed.
+    """
+    from .user_api_key import UserAPIKey
+
+    try:
+      active_keys = UserAPIKey.get_active_by_user_id(str(self.id), session)
+    except Exception as e:
+      logger.error(f"Failed to load API keys for deactivated user {self.id}: {e}")
+      return
+
+    for key in active_keys:
+      try:
+        key.deactivate(session)
+      except Exception as e:
+        logger.error(
+          f"Failed to revoke API key {key.id} for deactivated user {self.id}: {e}"
+        )
 
   def _invalidate_auth_cache(self) -> None:
     """Invalidate auth caches derived from this user.

--- a/tests/config/test_logging.py
+++ b/tests/config/test_logging.py
@@ -67,6 +67,43 @@ def test_structured_formatter_includes_optional_fields():
   assert payload["timestamp"].endswith("Z")
 
 
+def test_structured_formatter_includes_audit_and_security_fields():
+  """Operation-audit payload and auth event fields must survive serialization.
+
+  Regression guard: the formatter previously dropped extra={"audit": ...},
+  ip_address, and success, making the operation-audit trail content-free.
+  """
+  formatter = StructuredFormatter()
+  record = logging.LogRecord(
+    name="robosystems.test",
+    level=logging.INFO,
+    pathname=__file__,
+    lineno=10,
+    msg="extensions.operation",
+    args=(),
+    exc_info=None,
+  )
+  record.audit = {
+    "operation": "create-backup",
+    "user_id": "u1",
+    "graph_id": "kg1",
+    "status": "success",
+  }
+  record.ip_address = "203.0.113.7"
+  record.success = False
+
+  payload = json.loads(formatter.format(record))
+
+  assert payload["audit"] == {
+    "operation": "create-backup",
+    "user_id": "u1",
+    "graph_id": "kg1",
+    "status": "success",
+  }
+  assert payload["ip_address"] == "203.0.113.7"
+  assert payload["success"] is False
+
+
 def test_structured_formatter_includes_error_details():
   formatter = StructuredFormatter()
 

--- a/tests/middleware/auth/test_utils.py
+++ b/tests/middleware/auth/test_utils.py
@@ -104,6 +104,60 @@ class TestValidateAPIKey:
     assert validate_api_key("") is None
     assert validate_api_key(None) is None
 
+  @patch("robosystems.middleware.auth.utils.api_key_cache")
+  @patch("robosystems.middleware.auth.utils.UserAPIKey")
+  def test_validate_api_key_cache_hit_inactive_user_rejected(
+    self, mock_api_key_class, mock_cache
+  ):
+    """Cache hit for an active key whose owning user is deactivated is rejected."""
+    api_key = _VALID_TEST_KEY
+    mock_cache.get_cached_api_key_validation.return_value = {
+      "is_active": True,  # the key itself is active
+      "user_data": {
+        "id": "user123",
+        "name": "Test User",
+        "email": "test@example.com",
+        "is_active": False,  # but the owning user is deactivated
+      },
+    }
+
+    result = validate_api_key(api_key)
+
+    assert result is None
+    # Must not fall through to the database either
+    mock_api_key_class.get_by_key.assert_not_called()
+
+  @patch("robosystems.database.SessionFactory")
+  @patch("robosystems.middleware.auth.utils.api_key_cache")
+  @patch("robosystems.middleware.auth.utils.UserAPIKey")
+  @patch("robosystems.middleware.auth.utils.SecurityAuditLogger")
+  def test_validate_api_key_db_inactive_user_rejected(
+    self, mock_audit, mock_api_key_class, mock_cache, mock_session_factory
+  ):
+    """DB path rejects an active key whose owning user is deactivated."""
+    api_key = _VALID_TEST_KEY
+    mock_cache.get_cached_api_key_validation.return_value = None
+
+    mock_sess = Mock()
+    mock_session_factory.return_value = mock_sess
+
+    mock_user = Mock(spec=User)
+    mock_user.id = "user123"
+    mock_user.name = "Test User"
+    mock_user.email = "test@example.com"
+    mock_user.is_active = False  # deactivated user
+
+    mock_key_record = Mock(spec=UserAPIKey)
+    mock_key_record.user = mock_user
+    mock_key_record.is_active = True  # key row still active
+    mock_api_key_class.get_by_key.return_value = mock_key_record
+
+    result = validate_api_key(api_key)
+
+    assert result is None
+    mock_audit.log_auth_success.assert_not_called()
+    mock_sess.close.assert_called_once()
+
 
 class TestValidateAPIKeyWithGraph:
   """Test API key validation with graph access."""
@@ -163,6 +217,53 @@ class TestValidateAPIKeyWithGraph:
     mock_user_graph.user_has_access.assert_called_once()
     mock_key_record.update_last_used.assert_called_once()
     mock_sess.close.assert_called_once()
+
+  @patch("robosystems.database.SessionFactory")
+  @patch("robosystems.middleware.auth.utils.api_key_cache")
+  @patch("robosystems.middleware.auth.utils.UserAPIKey")
+  @patch("robosystems.middleware.auth.utils.GraphUser")
+  @patch(
+    "robosystems.config.shared_repositories.is_shared_repository_or_subgraph",
+    return_value=False,
+  )
+  @patch("robosystems.middleware.auth.utils.SecurityAuditLogger")
+  def test_validate_api_key_with_graph_db_inactive_user_rejected(
+    self,
+    mock_audit,
+    mock_is_shared,
+    mock_user_graph,
+    mock_api_key_class,
+    mock_cache,
+    mock_session_factory,
+  ):
+    """A deactivated user's key is rejected before the graph-access check runs."""
+    api_key = _VALID_TEST_KEY
+    graph_id = "kg1234567890"
+
+    mock_sess = Mock()
+    mock_session_factory.return_value = mock_sess
+
+    mock_cache.get_cached_api_key_validation.return_value = None
+    mock_cache.get_cached_graph_access.return_value = None
+
+    mock_user = Mock(spec=User)
+    mock_user.id = "user123"
+    mock_user.name = "Test User"
+    mock_user.email = "test@example.com"
+    mock_user.is_active = False  # deactivated
+
+    mock_key_record = Mock(spec=UserAPIKey)
+    mock_key_record.user = mock_user
+    mock_key_record.user_id = "user123"
+    mock_key_record.is_active = True  # key row still active
+    mock_api_key_class.get_by_key.return_value = mock_key_record
+
+    result = validate_api_key_with_graph(api_key, graph_id)
+
+    assert result is None
+    # Rejected before the graph-access check ever runs
+    mock_user_graph.user_has_access.assert_not_called()
+    mock_audit.log_auth_success.assert_not_called()
 
   @patch("robosystems.database.SessionFactory")
   @patch("robosystems.middleware.auth.utils.api_key_cache")

--- a/tests/middleware/rate_limits/test_rate_limit_cache.py
+++ b/tests/middleware/rate_limits/test_rate_limit_cache.py
@@ -56,6 +56,22 @@ class TestCheckRateLimit:
     assert allowed is True
     assert remaining == 100
 
+  def test_redis_failure_fail_closed_denies(self, cache):
+    """High-value (auth) categories deny when the limiter backend is down."""
+    cache._redis.eval.side_effect = Exception("Redis down")
+    allowed, remaining = cache.check_rate_limit(
+      "auth_ip:1.2.3.4", 10, 300, fail_closed=True
+    )
+    assert allowed is False
+    assert remaining == 0
+
+  def test_redis_failure_default_still_fails_open(self, cache):
+    """Default (fail_closed=False) preserves fail-open for general traffic."""
+    cache._redis.eval.side_effect = Exception("Redis down")
+    allowed, remaining = cache.check_rate_limit("user:1", 100, 60, fail_closed=False)
+    assert allowed is True
+    assert remaining == 100
+
 
 class TestGetRateLimitStats:
   def test_disabled(self):

--- a/tests/models/core/user/test_user_model.py
+++ b/tests/models/core/user/test_user_model.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from sqlalchemy.exc import SQLAlchemyError
 
-from robosystems.models.core import User
+from robosystems.models.core import User, UserAPIKey
 
 
 class TestUserModel:
@@ -425,6 +425,33 @@ class TestUserModel:
     # Verify in database
     db_user = db_session.query(User).filter_by(id=user.id).first()
     assert db_user.is_active is False
+
+  def test_deactivate_revokes_api_keys(self, db_session):
+    """Deactivating a user revokes all their API keys.
+
+    Regression guard for broken de-provisioning: keys don't carry
+    session_version, so without cascade revocation a deactivated user keeps
+    full programmatic access.
+    """
+    user = User.create(
+      email="revoke-keys@example.com",
+      name="Key User",
+      password_hash="hashed_password",
+      session=db_session,
+    )
+    key1, _ = UserAPIKey.create(user_id=user.id, name="k1", session=db_session)
+    key2, _ = UserAPIKey.create(user_id=user.id, name="k2", session=db_session)
+    assert key1.is_active is True
+    assert key2.is_active is True
+
+    user.deactivate(db_session)
+
+    # No active keys remain for the user
+    assert UserAPIKey.get_active_by_user_id(user.id, db_session) == []
+    db_session.refresh(key1)
+    db_session.refresh(key2)
+    assert key1.is_active is False
+    assert key2.is_active is False
 
   def test_activate_user(self, db_session):
     """Test activating a user."""


### PR DESCRIPTION
## Summary

Three app-layer security fixes surfaced by a SOC 2 readiness review of the platform: broken de-provisioning, fail-open authentication rate limiting, and an operation-audit trail that silently dropped all of its fields. All three are code-level fixes with no schema or infra changes.

This is PR 1 of a 4-part security sprint (the pure-code, zero-ops batch).

## Changes

**De-provisioning — a deactivated user kept full API access (Critical)**
- `middleware/auth/utils.py` — `validate_api_key` and `validate_api_key_with_graph` now reject a key whose **owning user** is deactivated, on both the cache-hit and DB paths. `UserAPIKey.get_by_key` filters only on the key's own `is_active` flag, and API keys carry no `session_version`, so previously a deactivated user retained full programmatic access via any existing key.
- `models/core/user/user.py` — `User.deactivate()` now cascades via `_revoke_api_keys()` to deactivate all of the user's API keys and invalidate each key's validation-cache entry, alongside the existing `session_version` bump. Keys must be regenerated after reactivation (consistent with the method's existing "deactivation is a security boundary" behavior).

**Fail-closed auth rate limiting**
- `middleware/rate_limits/cache.py` — `check_rate_limit` gains a `fail_closed` parameter; when the limiter backend (Valkey) errors, it denies instead of allowing.
- `middleware/rate_limits/rate_limiting.py` — wired `fail_closed=True` into `auth_rate_limit_dependency`, which guards `login`, `register`, `password_reset`, and `email_verification`. General traffic still fails open, so a Valkey outage hardens the auth surface rather than taking down the whole API.

**Audit trail — operation-audit lines were content-free**
- `config/logging.py` — `StructuredFormatter` now serializes the `audit` payload (emitted via `extra={"audit": ...}` by `log_operation_audit`) plus `ip_address` / `success` from the security-logging middleware. The formatter's field allowlist previously omitted these, so the "who / what / which-tenant / result" audit trail was being dropped.

## Testing

- `just test-code` — **passed** (ruff + format + basedpyright: 0 errors, 0 warnings).
- `uv run pytest` on the four affected modules — **81 passed (7 new)**:
  - `tests/middleware/auth/test_utils.py` — inactive-user rejected on cache and DB paths (+ graph variant)
  - `tests/models/core/user/test_user_model.py` — DB-backed `deactivate` revokes all keys
  - `tests/config/test_logging.py` — formatter serializes `audit` / `ip_address` / `success`
  - `tests/middleware/rate_limits/test_rate_limit_cache.py` — fail-closed denies on backend error; default still fails open
- Full `just test-all` suite not run in this session.

## Notes / Follow-ups

- **Fail-closed scope is deliberate.** Only `auth_rate_limit_dependency` (login, register, password_reset, email_verification) fails closed. The other auth-adjacent limiters (sso, jwt-refresh, sensitive-auth, logout, auth-status) still fail open — extending them is a clean follow-up, deferred here to avoid broadening the outage surface during a limiter-backend incident.
- **Operational note:** prod runs a single Valkey node, so a cache outage now returns `429` on those four auth endpoints (no logins until Valkey recovers). This is the intended security tradeoff; the `logger.error("Rate limiter failing CLOSED…")` line is the hook to alert on so an incident reads as a cache outage rather than an unexplained login failure.
- **Reactivation requires new API keys** — deactivation now permanently revokes them.
- Remaining sprint PRs: **PR 2** MCP Cypher hardening (confirmed-exploitable `LOAD`/`ATTACH`/`INSTALL` bypass on the read path), **PR 3** infra/TLS/RDS + staging secret validation, **PR 4** scope down the CI/CD OIDC role.
