### PR TITLE
fix(security): close read-graph-cypher LOAD/ATTACH/INSTALL bypass

### DIFF
--- a/robosystems/middleware/mcp/tools/cypher_tool.py
+++ b/robosystems/middleware/mcp/tools/cypher_tool.py
@@ -185,9 +185,35 @@ RETURN DISTINCT labels(a)[0] AS from_type, type(r) AS rel_type, labels(b)[0] AS 
         query: Cypher query to validate
 
     Raises:
-        ValueError: If query contains write operations
+        ValueError: If query contains write, bulk, admin, or schema-DDL operations
     """
     import re
+
+    # Delegate the dangerous categories to the central security analyzer — the
+    # same one the REST /query endpoint uses — so this read path can't diverge
+    # from it. The hand-rolled keyword list below previously missed LOAD / COPY /
+    # ATTACH / INSTALL / EXPORT, letting a "read-only" tool read local files,
+    # reach instance metadata (SSRF), and ATTACH other tenants' databases.
+    from robosystems.security.cypher_analyzer import (
+      is_admin_operation,
+      is_bulk_operation,
+      is_schema_ddl,
+    )
+
+    if is_bulk_operation(query):
+      logger.warning("Blocked bulk operation (COPY/LOAD/IMPORT) in read-graph-cypher")
+      raise ValueError("Only read-only queries are allowed")
+
+    if is_admin_operation(query):
+      logger.warning(
+        "Blocked administrative operation (EXPORT/INSTALL/ATTACH/USE) in "
+        "read-graph-cypher"
+      )
+      raise ValueError("Only read-only queries are allowed")
+
+    if is_schema_ddl(query):
+      logger.warning("Blocked schema DDL in read-graph-cypher")
+      raise ValueError("Only read-only queries are allowed")
 
     # Remove string literals to avoid false positives
     # Replace single-quoted strings with empty placeholder

--- a/tests/middleware/mcp/tools/test_cypher_tool.py
+++ b/tests/middleware/mcp/tools/test_cypher_tool.py
@@ -1,0 +1,71 @@
+"""Tests for CypherTool read-only validation.
+
+Regression guard for the MCP read-path bypass: `read-graph-cypher` previously
+validated with a hand-rolled keyword list that omitted LOAD / COPY / ATTACH /
+INSTALL / EXPORT / USE, allowing a "read-only" tool to read local files, reach
+instance metadata (SSRF), and ATTACH other tenants' databases. It now delegates
+those categories to the central security.cypher_analyzer (the same analyzer the
+REST /query endpoint uses).
+"""
+
+import pytest
+
+from robosystems.middleware.mcp.tools.cypher_tool import CypherTool
+
+
+@pytest.fixture
+def tool() -> CypherTool:
+  # _validate_read_only uses no instance state, so bypass __init__ (which needs
+  # a live GraphMCPClient) and exercise the validator directly.
+  return CypherTool.__new__(CypherTool)
+
+
+class TestValidateReadOnly:
+  """`_validate_read_only` must reject write, bulk, admin, and DDL operations."""
+
+  @pytest.mark.parametrize(
+    "query",
+    [
+      "LOAD FROM '/etc/passwd' RETURN *",
+      "COPY (MATCH (n) RETURN n) TO '/tmp/x.csv'",
+      "IMPORT DATABASE '/tmp/dump'",
+      "ATTACH '/data/other_tenant' AS x (dbtype kuzu)",
+      "INSTALL httpfs",
+      "INSTALL httpfs; LOAD FROM 'http://169.254.169.254/latest/meta-data/' RETURN *",
+      "EXPORT DATABASE '/tmp/dump'",
+      "USE other_database",
+    ],
+  )
+  def test_blocks_bulk_and_admin_operations(self, tool, query):
+    """The previously-missed bulk/admin verbs are now rejected."""
+    with pytest.raises(ValueError, match="read-only"):
+      tool._validate_read_only(query)
+
+  @pytest.mark.parametrize(
+    "query",
+    [
+      "CREATE (n:Foo)",
+      "MATCH (n) SET n.x = 1",
+      "MATCH (n) DELETE n",
+      "MERGE (n:Foo {id: 1})",
+      "MATCH (n) REMOVE n.x",
+      "DROP TABLE Foo",
+    ],
+  )
+  def test_still_blocks_writes(self, tool, query):
+    """Existing write protection is preserved (no regression)."""
+    with pytest.raises(ValueError, match="read-only"):
+      tool._validate_read_only(query)
+
+  @pytest.mark.parametrize(
+    "query",
+    [
+      "MATCH (n:Entity) RETURN n LIMIT 10",
+      "MATCH (a)-[r]->(b) RETURN DISTINCT labels(a)[0], type(r) LIMIT 5",
+      # Bulk keyword appears only inside a string literal — must not false-positive
+      "MATCH (n) WHERE n.name CONTAINS 'load' RETURN n",
+    ],
+  )
+  def test_allows_legitimate_reads(self, tool, query):
+    """Pure reads pass, including bulk keywords quoted inside string literals."""
+    tool._validate_read_only(query)  # should not raise


### PR DESCRIPTION
## Summary

Closes a confirmed-exploitable bypass in the MCP `read-graph-cypher` tool: its read-only validator missed the bulk and admin Cypher verbs, so a "read-only" tool could read arbitrary local files, reach the instance-metadata endpoint (SSRF), and `ATTACH` other tenants' databases — reachable even on the read-only shared repositories (`sec`, `sec_historical`).

This is PR 2 of a 4-part security sprint (following #799).

## The bug

`CypherTool._validate_read_only` validated with a hand-rolled keyword list that only blocked writes (`CREATE`/`SET`/`DELETE`/`REMOVE`/`MERGE`/`DROP`/`DETACH DELETE`/`CALL db.`/`CALL apoc.`). It did **not** block:

- **Bulk:** `LOAD`, `COPY`, `IMPORT` → `LOAD FROM '/etc/passwd' RETURN *` (arbitrary local file read)
- **Admin:** `EXPORT`, `INSTALL`, `ATTACH`, `USE` → `INSTALL httpfs; LOAD FROM 'http://169.254.169.254/...'` (SSRF to IAM credentials), `ATTACH '/data/lbug-dbs/<other_graph>'` (cross-tenant access)

LadybugDB executes these verbs. The REST `/query` endpoint already blocks them via `security.cypher_analyzer`; only the MCP read path diverged.

**Confirmed at runtime:** a `LOAD FROM …` query passed the old validator and reached the engine (HTTP 400 from LadybugDB, i.e. an engine-level error, not a validator rejection).

## Changes

- `middleware/mcp/tools/cypher_tool.py` — `_validate_read_only` now delegates the dangerous categories to the central `security.cypher_analyzer` (the same analyzer the REST `/query` endpoint uses): `is_bulk_operation`, `is_admin_operation`, `is_schema_ddl`. The existing write-keyword and `CALL` checks are preserved, so there is no read-path regression.

## Testing

- `just test-code` — **passed** (ruff + format + basedpyright: 0 errors).
- `uv run pytest` on the MCP suites — **698 passed (17 new)**, no regressions:
  - new `tests/middleware/mcp/tools/test_cypher_tool.py` covers: bulk/admin verbs rejected (incl. the `INSTALL httpfs; LOAD FROM http://169.254.169.254/…` SSRF payload), writes still blocked, and legit reads pass — including a bulk keyword quoted inside a string literal (`CONTAINS 'load'`), which must **not** false-positive.
- Full `just test-all` suite not run in this session.

## Notes / Follow-ups

- **Deeper defense-in-depth deferred.** The strongest fix is to open the query connection `read_only=True` at the Graph API layer so read tools can't execute privileged verbs regardless of keyword lists. That's a larger change into `graph_api`; this PR closes the exploit at the validator and brings MCP in line with REST.
- The false-positive/consistency profile now matches the REST path exactly (both use the shared analyzer), which also reduces the "three divergent validators" drift risk.
- Remaining sprint PRs: **PR 3** infra/TLS/RDS + staging secret validation, **PR 4** scope down the CI/CD OIDC role.
