### PR TITLE
fix(security): TLS policy, RDS deletion protection, staging secret validation

### DIFF
--- a/.github/workflows/deploy-postgres.yml
+++ b/.github/workflows/deploy-postgres.yml
@@ -64,6 +64,13 @@ on:
         type: string
         default: "false"
 
+      # Accidental-deletion protection (recommended on for prod/staging; no added cost)
+      deletion_protection_enabled:
+        description: "Block accidental deletion of the RDS instance (set false only for an intentional teardown)"
+        required: false
+        type: string
+        default: "true"
+
       # RDS Proxy Configuration (off by default)
       rds_proxy_enabled:
         description: "Enable RDS Proxy for connection pooling (costs ~$0.015/vCPU/hour when enabled)"
@@ -156,6 +163,7 @@ jobs:
                 ParameterKey=DBAllocatedStorage,ParameterValue=${{ inputs.allocated_storage }} \
                 ParameterKey=DBMaxAllocatedStorage,ParameterValue=${{ inputs.allocated_max_storage }} \
                 ParameterKey=EnableMultiAZ,ParameterValue=${{ inputs.multi_az_enabled }} \
+                ParameterKey=EnableDeletionProtection,ParameterValue=${{ inputs.deletion_protection_enabled }} \
                 ParameterKey=EnableRDSProxy,ParameterValue=${{ inputs.rds_proxy_enabled }} \
                 ParameterKey=RDSProxyMaxConnectionsPercent,ParameterValue=${{ inputs.rds_proxy_max_connections_percent }} \
                 ParameterKey=RDSProxyConnectionBorrowTimeout,ParameterValue=${{ inputs.rds_proxy_connection_borrow_timeout }} \

--- a/cloudformation/api.yaml
+++ b/cloudformation/api.yaml
@@ -1047,6 +1047,9 @@ Resources:
       LoadBalancerArn: !Ref ApiALB
       Port: 443
       Protocol: HTTPS
+      # Modern TLS only (TLS 1.2 + 1.3). Without an explicit SslPolicy the ALB
+      # default (ELBSecurityPolicy-2016-08) still negotiates TLS 1.0/1.1.
+      SslPolicy: ELBSecurityPolicy-TLS13-1-2-2021-06
       Certificates:
         - CertificateArn: !Ref ApiCertificate
 

--- a/cloudformation/postgres.yaml
+++ b/cloudformation/postgres.yaml
@@ -769,6 +769,12 @@ Outputs:
     Export:
       Name: !Sub ${AWS::StackName}-${Environment}-MultiAZEnabled
 
+  DeletionProtectionEnabled:
+    Description: Whether accidental-deletion protection is enabled on the RDS instance
+    Value: !If [DeletionProtectionCondition, "true", "false"]
+    Export:
+      Name: !Sub ${AWS::StackName}-${Environment}-DeletionProtectionEnabled
+
   PostgresEngineVersionConfigured:
     Description: PostgreSQL engine version configured for this deployment
     Value: !Ref PostgresEngineVersion

--- a/cloudformation/postgres.yaml
+++ b/cloudformation/postgres.yaml
@@ -99,6 +99,16 @@ Parameters:
       - "false"
     ConstraintDescription: Must be true or false
 
+  # Accidental-deletion protection (independent of Multi-AZ; no additional cost)
+  EnableDeletionProtection:
+    Type: String
+    Description: Block accidental deletion of the RDS instance (recommended for prod/staging)
+    Default: "true"
+    AllowedValues:
+      - "true"
+      - "false"
+    ConstraintDescription: Must be true or false
+
   # RDS Proxy Configuration (off by default - billed at ~$0.015/vCPU/hour when enabled)
   # Requires DBPasswordSecret to contain "username" and "password" keys, which the
   # rotation lambda adds on first rotation after this template is deployed. A freshly
@@ -151,6 +161,7 @@ Parameters:
 
 Conditions:
   EnableMultiAZCondition: !Equals [!Ref EnableMultiAZ, "true"]
+  DeletionProtectionCondition: !Equals [!Ref EnableDeletionProtection, "true"]
   RDSProxyEnabledCondition: !Equals [!Ref EnableRDSProxy, "true"]
 
 Resources:
@@ -480,7 +491,8 @@ Resources:
         - !GetAtt RDSSecurityGroup.GroupId
       PubliclyAccessible: false
       MultiAZ: !If [EnableMultiAZCondition, true, false]
-      BackupRetentionPeriod: 7
+      DeletionProtection: !If [DeletionProtectionCondition, true, false]
+      BackupRetentionPeriod: 30
       PreferredBackupWindow: 03:00-04:00
       PreferredMaintenanceWindow: sun:04:30-sun:05:30
       AutoMinorVersionUpgrade: false

--- a/main.py
+++ b/main.py
@@ -103,8 +103,9 @@ async def lifespan(app: FastAPI):
     logger.info(f"Configuration validated successfully: {config_summary}")
   except Exception as e:
     logger.error(f"Configuration validation failed: {e}")
-    if env.ENVIRONMENT == "prod":
-      # Fail fast in prod; continue in dev so local iteration isn't blocked.
+    if env.ENVIRONMENT in ("prod", "staging"):
+      # Fail fast in prod and staging; continue in dev/test so local iteration
+      # isn't blocked.
       raise
     logger.warning("Continuing with invalid configuration (development mode)")
 

--- a/robosystems/config/validation.py
+++ b/robosystems/config/validation.py
@@ -43,8 +43,8 @@ class EnvValidator:
         f"Only 'ladybug' is supported."
       )
 
-    # Critical variables that must be set in production
-    if env_config.ENVIRONMENT == "prod":
+    # Critical variables that must be set in production and staging
+    if env_config.ENVIRONMENT in ("prod", "staging"):
       required_prod_vars = {
         "DATABASE_URL": "PostgreSQL connection string",
         "JWT_SECRET_KEY": "JWT signing key (must not be default)",
@@ -74,10 +74,15 @@ class EnvValidator:
       for var_name, description in required_prod_vars.items():
         value = getattr(env_config, var_name, None)
         if not value:
-          errors.append(f"{var_name}: {description} is required in production")
+          errors.append(
+            f"{var_name}: {description} is required in {env_config.ENVIRONMENT}"
+          )
         elif var_name == "JWT_SECRET_KEY":
           if "development" in str(value).lower() or "dev-jwt" in str(value).lower():
-            errors.append(f"{var_name}: Must not use development default in production")
+            errors.append(
+              f"{var_name}: Must not use the development default in "
+              f"{env_config.ENVIRONMENT}"
+            )
           elif len(str(value)) < 32:
             errors.append(f"{var_name}: Must be at least 32 characters for security")
 

--- a/robosystems/models/core/connection/connection_credentials.py
+++ b/robosystems/models/core/connection/connection_credentials.py
@@ -55,13 +55,27 @@ class ConnectionCredentials(Model):
 
   @staticmethod
   def _get_encryption_key() -> bytes:
-    """Get or generate encryption key from environment."""
+    """Get or generate the credential-encryption key.
+
+    In prod/staging ``CONNECTION_CREDENTIALS_KEY`` MUST be set explicitly. Only
+    dev/test/local may fall back to a key derived from ``JWT_SECRET_KEY`` — a
+    fast, unsalted derivation that must never protect real customer credentials
+    and must never share key material with the token-signing secret in a
+    deployed environment.
+    """
     key = env.CONNECTION_CREDENTIALS_KEY
     if not key:
-      # In production, this MUST be set in environment
-      # For development, derive from JWT_SECRET_KEY for consistency
+      # Never allow the weak JWT-derived fallback in prod/staging. Startup
+      # validation also requires the key there; this is defense-in-depth.
+      if env.ENVIRONMENT in ("prod", "staging"):
+        raise ValueError(
+          f"CONNECTION_CREDENTIALS_KEY must be set in {env.ENVIRONMENT}; "
+          "refusing to derive a credential key from JWT_SECRET_KEY."
+        )
+      # Dev/test/local only: derive a deterministic key from JWT_SECRET_KEY.
       logger.warning(
-        "CONNECTION_CREDENTIALS_KEY is not set. Falling back to JWT_SECRET_KEY for development."
+        "CONNECTION_CREDENTIALS_KEY is not set; deriving a dev-only key from "
+        "JWT_SECRET_KEY. Do not rely on this outside local development."
       )
       jwt_secret = env.JWT_SECRET_KEY
       if jwt_secret:

--- a/tests/config/test_validation.py
+++ b/tests/config/test_validation.py
@@ -153,6 +153,31 @@ class TestEnvValidator:
       warning_calls = [call[0][0] for call in mock_logger.warning.call_args_list]
       assert any("GRAPH_API_KEY" in msg for msg in warning_calls)
 
+  def test_validate_required_vars_staging_environment_success(self):
+    """Staging enforces the same critical vars as prod and passes when all set."""
+    env_config = MockEnvConfig()
+    env_config.ENVIRONMENT = "staging"
+    env_config.GRAPH_API_KEY = "test-api-key"
+
+    with patch("os.getenv", return_value=None):
+      with patch("robosystems.config.validation.logger") as mock_logger:
+        EnvValidator.validate_required_vars(env_config)
+        mock_logger.info.assert_called_with("Configuration validation passed")
+
+  def test_validate_required_vars_staging_missing_credentials_key(self):
+    """Staging now fails when CONNECTION_CREDENTIALS_KEY is missing (was prod-only)."""
+    env_config = MockEnvConfig()
+    env_config.ENVIRONMENT = "staging"
+    env_config.GRAPH_API_KEY = "test-api-key"
+    env_config.CONNECTION_CREDENTIALS_KEY = None
+
+    with patch("os.getenv", return_value=None):
+      with pytest.raises(ConfigValidationError) as exc_info:
+        EnvValidator.validate_required_vars(env_config)
+
+    error_msg = str(exc_info.value)
+    assert "CONNECTION_CREDENTIALS_KEY" in error_msg or "errors" in error_msg
+
   def test_validate_urls_valid(self):
     """Test validation passes for valid URLs."""
     env_config = MockEnvConfig()

--- a/tests/models/core/connection/test_connection_credentials.py
+++ b/tests/models/core/connection/test_connection_credentials.py
@@ -93,6 +93,39 @@ class TestConnectionCredentialsModel:
     mock_logger.error.assert_called()
 
   @patch("robosystems.models.core.connection.connection_credentials.env")
+  def test_get_encryption_key_prod_refuses_jwt_fallback(self, mock_env):
+    """Prod refuses the weak JWT-derived fallback and raises when the key is unset."""
+    mock_env.CONNECTION_CREDENTIALS_KEY = None
+    mock_env.JWT_SECRET_KEY = "some_jwt_secret_value_long_enough_for_validation"
+    mock_env.ENVIRONMENT = "prod"
+
+    with pytest.raises(ValueError, match="CONNECTION_CREDENTIALS_KEY must be set"):
+      ConnectionCredentials._get_encryption_key()
+
+  @patch("robosystems.models.core.connection.connection_credentials.env")
+  def test_get_encryption_key_staging_refuses_jwt_fallback(self, mock_env):
+    """Staging refuses the weak JWT-derived fallback and raises when the key is unset."""
+    mock_env.CONNECTION_CREDENTIALS_KEY = None
+    mock_env.JWT_SECRET_KEY = "some_jwt_secret_value_long_enough_for_validation"
+    mock_env.ENVIRONMENT = "staging"
+
+    with pytest.raises(ValueError, match="CONNECTION_CREDENTIALS_KEY must be set"):
+      ConnectionCredentials._get_encryption_key()
+
+  @patch("robosystems.models.core.connection.connection_credentials.env")
+  @patch("robosystems.models.core.connection.connection_credentials.logger")
+  def test_get_encryption_key_dev_allows_jwt_fallback(self, mock_logger, mock_env):
+    """Dev/local may still derive a key from JWT_SECRET_KEY (convenience only)."""
+    mock_env.CONNECTION_CREDENTIALS_KEY = None
+    mock_env.JWT_SECRET_KEY = "test_jwt_secret_key_123"
+    mock_env.ENVIRONMENT = "dev"
+
+    key = ConnectionCredentials._get_encryption_key()
+
+    assert key is not None
+    mock_logger.warning.assert_called_once()
+
+  @patch("robosystems.models.core.connection.connection_credentials.env")
   @patch("robosystems.models.core.connection.connection_credentials.logger")
   def test_get_encryption_key_invalid_format(self, mock_logger, mock_env):
     """Test error when encryption key has invalid format."""


### PR DESCRIPTION
## Summary

Infrastructure and configuration hardening from the SOC 2 review: modern TLS on the public ALB, RDS deletion protection + longer backup retention, and secret validation that now covers staging (not just prod).

This is PR 3 of a 4-part security sprint (following #799, #800). It mixes CloudFormation (verified by `cfn-lint`, needs a staging deploy to confirm) with pure-code config changes (unit-tested).

## ⚠️ Deploy gate — read before merging to staging

This PR makes staging **fail-fast on startup if `CONNECTION_CREDENTIALS_KEY` is not set** in the staging secret (`robosystems/staging`). That's the intended fix (staging previously booted unvalidated), but it means:

1. **Before this reaches staging**, confirm `CONNECTION_CREDENTIALS_KEY` exists in the staging secret.
2. If staging has been running on the JWT-derived fallback, set a real key there first — existing sandbox QuickBooks connections were encrypted under the old derived key and would need re-authorization.

Prod already requires this key (and boots), so prod is unaffected.

## Changes

**ALB TLS (`cloudformation/api.yaml`)**
- Pin `SslPolicy: ELBSecurityPolicy-TLS13-1-2-2021-06` on the public HTTPS listener. Without an explicit policy the ALB default (`ELBSecurityPolicy-2016-08`) still negotiates TLS 1.0/1.1.

**RDS (`cloudformation/postgres.yaml`)**
- Add `DeletionProtection` via a new `EnableDeletionProtection` parameter (default `true`) + condition — protects the prod/staging DB from accidental deletion. Overridable to `false` when an intentional teardown is needed.
- Raise `BackupRetentionPeriod` from 7 to 30 days.
- **Multi-AZ intentionally left off** (deliberate cost decision) — these two are the no-added-capacity-cost insurance items.

**Secret validation (`config/validation.py`, `main.py`)**
- Extend the required-secret checks (`DATABASE_URL`, `JWT_SECRET_KEY`, `VALKEY_URL`, `AWS_REGION`, `CONNECTION_CREDENTIALS_KEY`) and the startup fail-fast from `prod` to `prod`+`staging`. The Stripe `sk_test_` prod-only check is left as-is (staging legitimately uses test keys).

**Credential-key fallback (`models/core/connection/connection_credentials.py`)**
- `_get_encryption_key` now refuses the weak, unsalted JWT-derived fallback in prod/staging and raises; the fallback remains only for dev/test/local. Defense-in-depth behind the startup validation above.

## Testing

- `cfn-lint` — **PASS** on both `postgres.yaml` and `api.yaml`.
- `just test-code` — **passed** (ruff + format + basedpyright: 0 errors).
- `uv run pytest` on the affected modules — **53 passed (5 new)**:
  - `tests/config/test_validation.py` — staging now enforces critical vars (success + missing-`CONNECTION_CREDENTIALS_KEY` failure)
  - `tests/models/core/connection/test_connection_credentials.py` — prod/staging refuse the JWT fallback; dev still allows it
- CloudFormation changes are `cfn-lint`-validated only; **staging deploy required** to confirm the TLS policy and RDS settings apply cleanly.
- Full `just test-all` suite not run in this session.

## Notes / Follow-ups

- S3 versioning on the user-data/backup bucket (the source-of-truth Parquet recovery angle) was scoped out of this PR — candidate follow-up.
- Remaining sprint PR: **PR 4** scope down the CI/CD OIDC role (the account-takeover primitive) — deployed carefully on its own since it modifies the deploy role itself.
