### PR TITLE
fix(security): scope CI/CD OIDC role iam:PassRole to specific services

### DIFF
--- a/cloudformation/bootstrap-oidc.yaml
+++ b/cloudformation/bootstrap-oidc.yaml
@@ -143,7 +143,6 @@ Resources:
                   - iam:AddRoleToInstanceProfile
                   - iam:RemoveRoleFromInstanceProfile
                   - iam:ListInstanceProfilesForRole
-                  - iam:PassRole
                   - iam:CreateServiceLinkedRole
                   - iam:DeleteServiceLinkedRole
                   - iam:GetServiceLinkedRoleDeletionStatus
@@ -158,6 +157,30 @@ Resources:
                   - iam:TagPolicy
                   - iam:UntagPolicy
                 Resource: "*"
+
+              # IAM PassRole — restricted to the AWS services this deployment
+              # actually creates roles for, so the deploy role cannot pass an
+              # arbitrary role to an arbitrary principal. This closes the main
+              # privilege-escalation path that unconditional iam:PassRole opened.
+              # The service list is derived from every Service principal the
+              # cloudformation/ templates create roles for.
+              - Sid: IAMPassRole
+                Effect: Allow
+                Action:
+                  - iam:PassRole
+                Resource: "*"
+                Condition:
+                  StringEquals:
+                    "iam:PassedToService":
+                      - ecs-tasks.amazonaws.com
+                      - lambda.amazonaws.com
+                      - ec2.amazonaws.com
+                      - rds.amazonaws.com
+                      - autoscaling.amazonaws.com
+                      - cloudtrail.amazonaws.com
+                      - delivery.logs.amazonaws.com
+                      - grafana.amazonaws.com
+                      - cloudfront.amazonaws.com
 
               # EC2
               - Sid: EC2


### PR DESCRIPTION
## ⚠️ This modifies the deploy role itself — apply with care

`GitHubActionsRole` is the OIDC role every deploy assumes. It is applied by **rerunning `just bootstrap`**, not the normal deploy pipeline. After merging and applying:

1. **Run a test deploy immediately** to confirm nothing broke.
2. If any deploy step fails with `AccessDenied` on `iam:PassRole`, a service is missing from the `PassedToService` list — add it and re-bootstrap. (The list was deliberately over-included from template evidence to make this unlikely.)

This is PR 4 of a 4-part security sprint (#799, #800, #801). Recommended order: merge all four, then `just bootstrap` + test deploy.

## Summary

Closes the highest-severity finding from the SOC 2 review: the CI/CD OIDC role granted `iam:PassRole` on `Resource: "*"` with **no condition**, bundled with full IAM role/policy management — a privilege-escalation primitive letting anyone who can push to `main`/`release/*`/`v*` (or a compromised Action in that pipeline) pass any role to any principal and take over the account.

## Changes

`cloudformation/bootstrap-oidc.yaml` — split `iam:PassRole` out of the broad `IAM` statement in `GitHubActionsRole` into its own `IAMPassRole` statement gated by an `iam:PassedToService` condition. The allowed services are derived from **every `Service:` principal the `cloudformation/` templates create roles for**: `ecs-tasks`, `lambda`, `ec2`, `rds`, `autoscaling`, `cloudtrail`, `delivery.logs`, `grafana`, `cloudfront`. Mirrors the `PassedToService` pattern already used in `dagster.yaml`.

Net effect: the deploy role can still pass roles to the AWS services it legitimately provisions, but can no longer pass an arbitrary role to an arbitrary/attacker-controlled principal.

## Deliberate scope — deferred follow-ups

Kept narrow and evidence-based so a test deploy has the best chance of passing first try. Deferred (each needs its own iterative deploy validation):

- **`GitHubActionsFrontendRole`** (the High-severity sibling finding) — same `PassRole` fix, but its targets live in the frontend repos' CloudFormation, not visible from here. Best scoped alongside those repos.
- **Permissions boundary on `iam:CreateRole`** — the robust way to fully close role-creation escalation (with `PassRole` scoped, the residual path is create-role-with-admin → pass-to-a-real-service). Bigger change.
- **Narrowing `ec2:*` / `rds:*` / `kms:*`** — least-privilege improvements, not the escalation primitive; enumerating every required action is a deploy-tested job.

## Testing

- `cfn-lint` — **PASS** on `bootstrap-oidc.yaml`.
- `just test-code` (cf-lint-all + ruff/format/basedpyright) — **passed** via pre-commit hook (no application code changed).
- **Not runtime-verified** — an IAM policy change can only be confirmed by applying it (`just bootstrap`) and running a deploy. See the apply caveat above.
