### PR TITLE
fix(security): bound extensions GraphQL query depth, aliases, and tokens

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -269,11 +269,11 @@ SECURITY_AUDIT_ENABLED=false
 # TUNING_QUEUES_TIMEOUT=300
 
 ## Extensions GraphQL query bounds — guard the OLTP pool from deep / alias-heavy
-## / oversized queries (introspection unaffected). Raw env-var names (read by
-## get_tuning_int); SSM: /tuning/graphql/{MAX_DEPTH,MAX_ALIASES,MAX_TOKENS}.
-# EXTENSIONS_GRAPHQL_MAX_DEPTH=15
-# EXTENSIONS_GRAPHQL_MAX_ALIASES=30
-# EXTENSIONS_GRAPHQL_MAX_TOKENS=2000
+## / oversized queries (introspection unaffected).
+## SSM: /tuning/graphql/{MAX_DEPTH,MAX_ALIASES,MAX_TOKENS}.
+# TUNING_GRAPHQL_MAX_DEPTH=15
+# TUNING_GRAPHQL_MAX_ALIASES=30
+# TUNING_GRAPHQL_MAX_TOKENS=2000
 
 ## Circuit Breakers
 # TUNING_CIRCUITS_THRESHOLD=5

--- a/.env.example
+++ b/.env.example
@@ -268,6 +268,13 @@ SECURITY_AUDIT_ENABLED=false
 # TUNING_QUEUES_MAX_PER_USER=10
 # TUNING_QUEUES_TIMEOUT=300
 
+## Extensions GraphQL query bounds — guard the OLTP pool from deep / alias-heavy
+## / oversized queries (introspection unaffected). Raw env-var names (read by
+## get_tuning_int); SSM: /tuning/graphql/{MAX_DEPTH,MAX_ALIASES,MAX_TOKENS}.
+# EXTENSIONS_GRAPHQL_MAX_DEPTH=15
+# EXTENSIONS_GRAPHQL_MAX_ALIASES=30
+# EXTENSIONS_GRAPHQL_MAX_TOKENS=2000
+
 ## Circuit Breakers
 # TUNING_CIRCUITS_THRESHOLD=5
 # TUNING_CIRCUITS_TIMEOUT=60

--- a/robosystems/config/env.py
+++ b/robosystems/config/env.py
@@ -688,6 +688,24 @@ class EnvConfig:
     get_parameter_value("EXTENSIONS_GRAPHQL_ENABLED", "true").lower() == "true",
   )
 
+  # Query-bounding limits for the extensions GraphQL endpoint. The OLTP pool
+  # is small and each resolved field can open a session, so an unbounded
+  # nested / alias-heavy / oversized document is a DoS vector. Defaults are
+  # generous for legitimate nested reads; introspection is unaffected (the
+  # depth limiter does not count introspection fields). SSM-tunable at runtime
+  # (like the other query/pool limits) so a limit can be tightened on abuse or
+  # loosened for a false-positive block without a redeploy —
+  # `just ssm-set <env> tuning/graphql/MAX_DEPTH <n>`.
+  EXTENSIONS_GRAPHQL_MAX_DEPTH = get_tuning_int(
+    "EXTENSIONS_GRAPHQL_MAX_DEPTH", "graphql/MAX_DEPTH", 15
+  )
+  EXTENSIONS_GRAPHQL_MAX_ALIASES = get_tuning_int(
+    "EXTENSIONS_GRAPHQL_MAX_ALIASES", "graphql/MAX_ALIASES", 30
+  )
+  EXTENSIONS_GRAPHQL_MAX_TOKENS = get_tuning_int(
+    "EXTENSIONS_GRAPHQL_MAX_TOKENS", "graphql/MAX_TOKENS", 2000
+  )
+
   # --- Derived: EXTENSIONS_ENABLED ---
   # Whether the extensions PostgreSQL database should open at all.
   # Computed at class-body evaluation time from the per-domain flags

--- a/robosystems/graphql/schema.py
+++ b/robosystems/graphql/schema.py
@@ -25,6 +25,11 @@ TypeScript and Python SDK facades expect without manual reshape.
 from __future__ import annotations
 
 import strawberry
+from strawberry.extensions import (
+  MaxAliasesLimiter,
+  MaxTokensLimiter,
+  QueryDepthLimiter,
+)
 from strawberry.extensions.tracing.opentelemetry import OpenTelemetryExtensionSync
 from strawberry.types import Info
 
@@ -129,7 +134,18 @@ Query = _build_query_type()
 # resolvers. The async variant would force every test and every sync
 # introspection call to fail with "GraphQL execution failed to complete
 # synchronously."
+# Query-bounding limiters guard the small extensions OLTP pool against
+# pathological documents (deep nesting, alias fan-out, oversized queries) —
+# each resolved field can open a session. Passed as factory callables (not
+# instances) per Strawberry's per-request construction contract. Introspection
+# is unaffected (the depth limiter does not count introspection fields), so SDK
+# codegen still works.
 schema = strawberry.Schema(
   query=Query,
-  extensions=[OpenTelemetryExtensionSync],
+  extensions=[
+    lambda: QueryDepthLimiter(max_depth=env.EXTENSIONS_GRAPHQL_MAX_DEPTH),
+    lambda: MaxAliasesLimiter(max_alias_count=env.EXTENSIONS_GRAPHQL_MAX_ALIASES),
+    lambda: MaxTokensLimiter(max_token_count=env.EXTENSIONS_GRAPHQL_MAX_TOKENS),
+    OpenTelemetryExtensionSync,
+  ],
 )

--- a/tests/graphql/extensions/test_schema_limits.py
+++ b/tests/graphql/extensions/test_schema_limits.py
@@ -1,0 +1,85 @@
+"""Query-bounding limiter tests for the extensions GraphQL schema.
+
+Guards against GraphQL DoS on the small extensions OLTP pool: deeply nested
+queries and alias fan-out (each resolved field can open a session). Verifies
+both the limiter mechanism at our configured values and that the *real* schema
+has the limits wired in.
+"""
+
+from __future__ import annotations
+
+import strawberry
+from strawberry.extensions import MaxAliasesLimiter, QueryDepthLimiter
+
+from robosystems.config import env
+from robosystems.graphql.schema import schema as real_schema
+
+
+@strawberry.type
+class _Node:
+  value: int = 1
+
+  @strawberry.field
+  def child(self) -> _Node:
+    return _Node()
+
+
+def _nested(levels: int) -> str:
+  inner = "value"
+  for _ in range(levels):
+    inner = f"child {{ {inner} }}"
+  return f"{{ {inner} }}"
+
+
+class TestDepthLimiter:
+  def test_rejects_query_deeper_than_max(self) -> None:
+    max_depth = env.EXTENSIONS_GRAPHQL_MAX_DEPTH
+    s = strawberry.Schema(
+      query=_Node, extensions=[lambda: QueryDepthLimiter(max_depth=max_depth)]
+    )
+    result = s.execute_sync(_nested(max_depth + 5))
+    assert result.errors, "an over-deep query must be rejected"
+    assert any("depth" in (e.message or "").lower() for e in result.errors)
+
+  def test_allows_query_within_max(self) -> None:
+    max_depth = env.EXTENSIONS_GRAPHQL_MAX_DEPTH
+    s = strawberry.Schema(
+      query=_Node, extensions=[lambda: QueryDepthLimiter(max_depth=max_depth)]
+    )
+    result = s.execute_sync(_nested(max(1, max_depth - 5)))
+    assert not result.errors, f"an in-bounds query must pass: {result.errors}"
+
+
+class TestAliasLimiter:
+  def test_rejects_alias_fan_out(self) -> None:
+    max_aliases = env.EXTENSIONS_GRAPHQL_MAX_ALIASES
+    s = strawberry.Schema(
+      query=_Node,
+      extensions=[lambda: MaxAliasesLimiter(max_alias_count=max_aliases)],
+    )
+    aliases = " ".join(f"a{i}: value" for i in range(max_aliases + 5))
+    result = s.execute_sync(f"{{ {aliases} }}")
+    assert result.errors, "alias fan-out beyond the cap must be rejected"
+
+
+class TestRealSchemaWiring:
+  """The limiters must actually be attached to the served schema."""
+
+  def test_real_schema_configures_four_extensions(self) -> None:
+    # 3 query-bounding limiters + the OpenTelemetry tracing extension.
+    assert len(real_schema.extensions) == 4
+
+  def test_real_schema_rejects_overdeep_query(self) -> None:
+    """Depth validation runs before resolvers, so no auth context is needed.
+
+    Uses the recursive AccountTreeNode.children path to build a query past the
+    configured maximum; a shallow real query would instead fail later (auth),
+    so we assert specifically on the depth error.
+    """
+    inner = "name"
+    for _ in range(env.EXTENSIONS_GRAPHQL_MAX_DEPTH + 12):
+      inner = f"children {{ {inner} }}"
+    query = f"{{ accountTree {{ roots {{ {inner} }} }} }}"
+    result = real_schema.execute_sync(query)
+    assert result.errors
+    assert any("depth" in (e.message or "").lower() for e in result.errors)


### PR DESCRIPTION
## Summary

Bounds query cost on the extensions GraphQL endpoint, which previously had no depth or complexity limiting. An authenticated user could send a deeply nested or alias-heavy query and exhaust the small extensions OLTP connection pool (each resolved field can open a session). Pure-code change, unit-tested.

Follow-up from the SOC 2 review (Inj F3) and the natural "PR 5" after the 4-PR sprint (#799–#802).

## Changes

- `graphql/schema.py` — add `QueryDepthLimiter`, `MaxAliasesLimiter`, and `MaxTokensLimiter` to the Strawberry schema, passed as **factory callables** (per Strawberry's per-request construction contract; avoids the deprecated instance-passing form).
- `config/env.py` — three limits, **SSM-tunable at runtime** via `get_tuning_int` under `/tuning/graphql/` (same pattern as the admission/queue/MCP limits), so a limit can be tightened on abuse or loosened for a false-positive block without a code change or redeploy:
  - `EXTENSIONS_GRAPHQL_MAX_DEPTH` → `graphql/MAX_DEPTH` (default **15**)
  - `EXTENSIONS_GRAPHQL_MAX_ALIASES` → `graphql/MAX_ALIASES` (default **30**)
  - `EXTENSIONS_GRAPHQL_MAX_TOKENS` → `graphql/MAX_TOKENS` (default **2000**)

The default SSM params have been created in prod and staging at these paths.

## Why introspection still works

The schema deliberately allows anonymous introspection for SDK codegen. Verified empirically that the depth limiter **does not count introspection fields**, so introspection passes even well below the configured depth — SDK codegen is unaffected.

## Testing

- `just test-code` — **passed** (ruff + format + basedpyright: 0 errors).
- `uv run pytest tests/graphql/ tests/middleware/mcp/tools/test_graphql_tool.py` — **113 passed** (5 new), no regressions.
  - New `tests/graphql/extensions/test_schema_limits.py`: over-deep query rejected at the configured limit, in-bounds query passes, alias fan-out rejected, and — against the **real** schema via the recursive `AccountTreeNode.children` path — a deep query is rejected with `"exceeds maximum operation depth of 15"`, proving the limiter is actually wired in.
- Full `just test-all` suite not run in this session.

## Notes

- Values are read at startup (env class-body), like the other `get_tuning_*` params, so changing an SSM value takes effect on a service refresh — no code change / full redeploy.
- Field-level cost/complexity limiting (beyond depth/alias/token) is a possible future refinement; depth is the primary pool-exhaustion vector and is covered here.
