### PR TITLE
fix(config): honor the documented TUNING_ env-var convention for tunables

### DIFF
--- a/robosystems/config/env.py
+++ b/robosystems/config/env.py
@@ -174,6 +174,17 @@ def get_str_env(key: str, default: str = "") -> str:
   return os.getenv(key, default)
 
 
+def _tuning_env_key(ssm_path: str) -> str:
+  """Env-var name for a tuning param following the documented convention.
+
+  ``TUNING_{CATEGORY}_{KEY}`` derived from the SSM path — e.g.
+  ``"graphql/MAX_DEPTH"`` -> ``"TUNING_GRAPHQL_MAX_DEPTH"``. Mirrors the naming
+  in ``config/tuning.py`` and ``.env.example`` so the documented override
+  convention is actually honored (the raw ``env_key`` still works too).
+  """
+  return "TUNING_" + ssm_path.upper().replace("/", "_")
+
+
 def get_tuning_float(env_key: str, ssm_path: str, default: float) -> float:
   """
   Get a float tuning parameter with layered fallback.
@@ -191,14 +202,16 @@ def get_tuning_float(env_key: str, ssm_path: str, default: float) -> float:
   Returns:
       Float value from the highest-priority source
   """
-  # Priority 1: Environment variable
-  env_value = os.getenv(env_key)
-  if env_value is not None:
-    try:
-      return float(env_value)
-    except (ValueError, TypeError):
-      print(f"Warning: Invalid {env_key} value, using default: {default}")
-      return default
+  # Priority 1: Environment variable — accept both the raw env_key (backward
+  # compat) and the documented TUNING_{CATEGORY}_{KEY} convention.
+  for candidate in (env_key, _tuning_env_key(ssm_path)):
+    env_value = os.getenv(candidate)
+    if env_value is not None:
+      try:
+        return float(env_value)
+      except (ValueError, TypeError):
+        print(f"Warning: Invalid {candidate} value, using default: {default}")
+        return default
 
   # Priority 2: SSM Parameter Store (prod/staging only)
   environment = os.getenv("ENVIRONMENT", "dev")
@@ -233,14 +246,16 @@ def get_tuning_int(env_key: str, ssm_path: str, default: int) -> int:
   Returns:
       Integer value from the highest-priority source
   """
-  # Priority 1: Environment variable
-  env_value = os.getenv(env_key)
-  if env_value is not None:
-    try:
-      return int(env_value)
-    except (ValueError, TypeError):
-      print(f"Warning: Invalid {env_key} value, using default: {default}")
-      return default
+  # Priority 1: Environment variable — accept both the raw env_key (backward
+  # compat) and the documented TUNING_{CATEGORY}_{KEY} convention.
+  for candidate in (env_key, _tuning_env_key(ssm_path)):
+    env_value = os.getenv(candidate)
+    if env_value is not None:
+      try:
+        return int(env_value)
+      except (ValueError, TypeError):
+        print(f"Warning: Invalid {candidate} value, using default: {default}")
+        return default
 
   # Priority 2: SSM Parameter Store (prod/staging only)
   environment = os.getenv("ENVIRONMENT", "dev")

--- a/robosystems/config/env.py
+++ b/robosystems/config/env.py
@@ -210,7 +210,7 @@ def get_tuning_float(env_key: str, ssm_path: str, default: float) -> float:
       try:
         return float(env_value)
       except (ValueError, TypeError):
-        print(f"Warning: Invalid {candidate} value, using default: {default}")
+        print(f"Warning: Invalid {env_key} value, using default: {default}")
         return default
 
   # Priority 2: SSM Parameter Store (prod/staging only)
@@ -254,7 +254,7 @@ def get_tuning_int(env_key: str, ssm_path: str, default: int) -> int:
       try:
         return int(env_value)
       except (ValueError, TypeError):
-        print(f"Warning: Invalid {candidate} value, using default: {default}")
+        print(f"Warning: Invalid {env_key} value, using default: {default}")
         return default
 
   # Priority 2: SSM Parameter Store (prod/staging only)

--- a/tests/config/test_env.py
+++ b/tests/config/test_env.py
@@ -8,6 +8,8 @@ from robosystems.config.env import (
   get_int_env,
   get_list_env,
   get_str_env,
+  get_tuning_float,
+  get_tuning_int,
 )
 
 
@@ -290,3 +292,51 @@ def test_get_valkey_url_with_integer(monkeypatch):
 
   result = EnvConfig.get_valkey_url(5)
   assert result == "redis://base/5"
+
+
+class TestTuningEnvConvention:
+  """get_tuning_int/float honor the documented TUNING_{CATEGORY}_{KEY} env var
+  (derived from the ssm_path) as well as the raw env_key (backward compat)."""
+
+  def test_env_key_derivation(self):
+    from robosystems.config.env import _tuning_env_key
+
+    assert _tuning_env_key("graphql/MAX_DEPTH") == "TUNING_GRAPHQL_MAX_DEPTH"
+    assert (
+      _tuning_env_key("lbug_admission/MEMORY_THRESHOLD")
+      == "TUNING_LBUG_ADMISSION_MEMORY_THRESHOLD"
+    )
+
+  def test_int_honors_tuning_prefix(self, monkeypatch):
+    monkeypatch.delenv("EXTENSIONS_GRAPHQL_MAX_DEPTH", raising=False)
+    monkeypatch.setenv("TUNING_GRAPHQL_MAX_DEPTH", "7")
+
+    assert get_tuning_int("EXTENSIONS_GRAPHQL_MAX_DEPTH", "graphql/MAX_DEPTH", 15) == 7
+
+  def test_int_honors_raw_env_key(self, monkeypatch):
+    monkeypatch.delenv("TUNING_GRAPHQL_MAX_DEPTH", raising=False)
+    monkeypatch.setenv("EXTENSIONS_GRAPHQL_MAX_DEPTH", "9")
+
+    assert get_tuning_int("EXTENSIONS_GRAPHQL_MAX_DEPTH", "graphql/MAX_DEPTH", 15) == 9
+
+  def test_int_raw_env_key_wins_when_both_set(self, monkeypatch):
+    monkeypatch.setenv("EXTENSIONS_GRAPHQL_MAX_DEPTH", "9")
+    monkeypatch.setenv("TUNING_GRAPHQL_MAX_DEPTH", "7")
+
+    assert get_tuning_int("EXTENSIONS_GRAPHQL_MAX_DEPTH", "graphql/MAX_DEPTH", 15) == 9
+
+  def test_int_falls_back_to_default(self, monkeypatch):
+    monkeypatch.setenv("ENVIRONMENT", "dev")
+    monkeypatch.delenv("EXTENSIONS_GRAPHQL_MAX_DEPTH", raising=False)
+    monkeypatch.delenv("TUNING_GRAPHQL_MAX_DEPTH", raising=False)
+
+    assert get_tuning_int("EXTENSIONS_GRAPHQL_MAX_DEPTH", "graphql/MAX_DEPTH", 15) == 15
+
+  def test_float_honors_tuning_prefix(self, monkeypatch):
+    monkeypatch.delenv("LBUG_ADMISSION_MEMORY_THRESHOLD", raising=False)
+    monkeypatch.setenv("TUNING_LBUG_ADMISSION_MEMORY_THRESHOLD", "42.5")
+
+    result = get_tuning_float(
+      "LBUG_ADMISSION_MEMORY_THRESHOLD", "lbug_admission/MEMORY_THRESHOLD", 85.0
+    )
+    assert result == pytest.approx(42.5)


### PR DESCRIPTION
## Summary

Makes the documented `TUNING_{CATEGORY}_{KEY}` env-var override **real** for `get_tuning_int` / `get_tuning_float`. Until now those helpers only read the raw `env_key`, so the `TUNING_*` names advertised in `.env.example` (and implemented in `config/tuning.py`) were never honored as an env-var override for any `get_tuning_*` param.

Closes #804.

## The bug (verified)

```
TUNING_LBUG_ADMISSION_MEMORY_THRESHOLD=99  ->  85.0  (default — ignored)
LBUG_ADMISSION_MEMORY_THRESHOLD=99         ->  99.0  (works)
```

`get_tuning_int/float` called `os.getenv(env_key)` on the raw name only. But the `.env.example` **TUNING PARAMETERS** section, its header (`Env var name: TUNING_{CATEGORY}_{KEY}`), and `config/tuning.py` all use the `TUNING_` prefix — so the documented override silently did nothing for admission, lbug_admission, org-graphs, cache, queues, etc.

## Change

`get_tuning_int` and `get_tuning_float` now resolve in priority order:

1. the raw `env_key` — backward compat, anything relying on it keeps working
2. `TUNING_{CATEGORY}_{KEY}` derived from the `ssm_path` (new `_tuning_env_key` helper, mirroring `config/tuning.py`)
3. SSM (`/tuning/...`, prod/staging only)
4. default

No behavior change for existing raw-name overrides; the documented `TUNING_*` convention now works too, so every entry already in `.env.example` becomes functional with **zero doc rewrite**.

## Testing

- `just test-code` — **passed** (ruff + format + basedpyright: 0 errors).
- `uv run pytest tests/config/test_env.py tests/config/test_tuning.py` — **75 passed (6 new)**: both names resolve, raw `env_key` wins when both are set, default fallback, float variant, and the `_tuning_env_key` derivation.

## Notes

- Surfaced during the #803 review (adding GraphQL query-bounding limits).
- Pairs with **#803**, whose `.env.example` block now uses `TUNING_GRAPHQL_*`. **Merge this before #803** so those documented names resolve as env overrides (SSM + the code defaults work regardless of merge order).
