### PR TITLE
fix(auth): enforce write role on graph writes; viewer is read-only

### DIFF
--- a/robosystems/models/core/graph/graph_user.py
+++ b/robosystems/models/core/graph/graph_user.py
@@ -166,6 +166,29 @@ class GraphUser(Model):
     )
 
   @classmethod
+  def user_has_write_access(cls, user_id: str, graph_id: str, session: Session) -> bool:
+    """
+    Check if a user has write access to a specific graph.
+
+    Write access requires the 'admin' or 'member' role; 'viewer' is read-only.
+    For subgraphs (e.g., 'kg123_dev'), this method checks write access to the
+    parent graph ('kg123') since subgraphs inherit permissions from their parent.
+    """
+    from robosystems.middleware.graph.types import parse_graph_id
+
+    # Resolve subgraph to parent graph for permission check
+    # Subgraphs inherit parent's permissions
+    parent_id, _ = parse_graph_id(graph_id)
+
+    graph_user = (
+      session.query(cls)
+      .filter(cls.user_id == user_id, cls.graph_id == parent_id)
+      .first()
+    )
+
+    return graph_user is not None and graph_user.role in ("admin", "member")
+
+  @classmethod
   def user_has_admin_access(cls, user_id: str, graph_id: str, session: Session) -> bool:
     """
     Check if a user has admin access to a specific graph.

--- a/robosystems/routers/graphs/mcp/execute.py
+++ b/robosystems/routers/graphs/mcp/execute.py
@@ -315,6 +315,15 @@ async def call_mcp_tool(
           detail=f"Write operations not allowed on shared repository '{graph_id}'",
         )
 
+    # Schema-mutating / write tools aren't query-analyzed above; flag them as
+    # writes so write-role authorization applies below (viewer is read-only).
+    if tool_call.name in (
+      "write-graph-cypher",
+      "add-node-table",
+      "add-relationship-table",
+    ):
+      is_write_query = True
+
     # Validate access using a short-lived session.  The MCP endpoint's
     # tool execution can take minutes; using a scoped session or FastAPI
     # db dependency would hold a pool connection for the entire duration.

--- a/robosystems/routers/graphs/mcp/handlers.py
+++ b/robosystems/routers/graphs/mcp/handlers.py
@@ -66,7 +66,15 @@ async def validate_mcp_access(
     # User graph - validate graph access
     from robosystems.models.core import GraphUser
 
-    if not GraphUser.user_has_access(current_user.id, graph_id, db):
+    if operation_type in ("write", "admin"):
+      # Write/admin tools require the 'member' or 'admin' role; 'viewer' is
+      # read-only. Bare membership is not sufficient for mutations.
+      if not GraphUser.user_has_write_access(current_user.id, graph_id, db):
+        raise HTTPException(
+          status_code=403,
+          detail=f"Write access denied to graph {graph_id}; your role is read-only.",
+        )
+    elif not GraphUser.user_has_access(current_user.id, graph_id, db):
       raise HTTPException(status_code=403, detail=f"Access denied to graph {graph_id}")
 
 

--- a/robosystems/routers/graphs/query/execute.py
+++ b/robosystems/routers/graphs/query/execute.py
@@ -216,6 +216,21 @@ async def execute_cypher_query(
         detail=f"Write operations not allowed on shared repository '{graph_id}'",
       )
 
+    # Enforce role-based write access on user subgraphs (viewer is read-only).
+    # At this point a write is confirmed to target a non-shared subgraph.
+    if is_write:
+      from robosystems.models.core.graph.graph_user import GraphUser
+
+      if not GraphUser.user_has_write_access(current_user.id, graph_id, session):
+        logger.warning(
+          f"User {current_user.id} with read-only role attempted write on {graph_id}"
+        )
+        raise HTTPException(
+          status_code=http_status.HTTP_403_FORBIDDEN,
+          detail="Write operations require the 'member' or 'admin' role for this "
+          "graph. Your access is read-only (viewer).",
+        )
+
     # Apply dual-layer rate limiting for shared repositories
     await _check_shared_repository_limits(
       graph_id=graph_id, user=current_user, session=session, endpoint="query"

--- a/tests/models/core/graph/test_graph_user_integration.py
+++ b/tests/models/core/graph/test_graph_user_integration.py
@@ -399,3 +399,19 @@ class TestGraphUserIntegration:
     assert GraphUser.user_has_access(admin_user.id, graph.graph_id, test_db) is True
     assert GraphUser.user_has_access(member_user.id, graph.graph_id, test_db) is True
     assert GraphUser.user_has_access(viewer_user.id, graph.graph_id, test_db) is True
+
+    # Write access requires admin or member role; viewer is read-only
+    assert (
+      GraphUser.user_has_write_access(admin_user.id, graph.graph_id, test_db) is True
+    )
+    assert (
+      GraphUser.user_has_write_access(member_user.id, graph.graph_id, test_db) is True
+    )
+    assert (
+      GraphUser.user_has_write_access(viewer_user.id, graph.graph_id, test_db) is False
+    )
+    # A user with no relationship to the graph has no write access
+    assert (
+      GraphUser.user_has_write_access("nonexistent-user", graph.graph_id, test_db)
+      is False
+    )

--- a/tests/routers/graphs/mcp/test_mcp_handlers.py
+++ b/tests/routers/graphs/mcp/test_mcp_handlers.py
@@ -101,6 +101,43 @@ class TestValidateMcpAccess:
       assert exc_info.value.status_code == 403
 
   @pytest.mark.asyncio
+  async def test_user_graph_write_requires_write_role(self):
+    """Write operations on a user graph require the write role, not bare membership."""
+    with (
+      patch(
+        "robosystems.config.shared_repositories.is_shared_repository_or_subgraph",
+        return_value=False,
+      ),
+      patch(
+        "robosystems.models.core.GraphUser.user_has_write_access",
+        return_value=True,
+      ) as mock_write,
+    ):
+      await validate_mcp_access(
+        "kg01234567890abcdef", _make_mock_user(), Mock(), "write"
+      )
+      mock_write.assert_called_once()
+
+  @pytest.mark.asyncio
+  async def test_user_graph_write_denied_for_readonly_role(self):
+    """A read-only (viewer) member is denied write access despite membership."""
+    with (
+      patch(
+        "robosystems.config.shared_repositories.is_shared_repository_or_subgraph",
+        return_value=False,
+      ),
+      patch(
+        "robosystems.models.core.GraphUser.user_has_write_access",
+        return_value=False,
+      ),
+    ):
+      with pytest.raises(HTTPException) as exc_info:
+        await validate_mcp_access(
+          "kg01234567890abcdef", _make_mock_user(), Mock(), "write"
+        )
+      assert exc_info.value.status_code == 403
+
+  @pytest.mark.asyncio
   async def test_shared_repo_subgraph_access(self):
     """Test access validation for shared repository subgraph."""
     with (


### PR DESCRIPTION
## Summary

Enforces the documented `viewer` = read-only role, which was previously unenforced. Surfaced by a second independent security review (GPT 5.5) and code-verified: `GraphUser` exposed only `user_has_access` (membership boolean) and `user_has_admin_access` (role == admin), so every non-admin write path authorized on **bare membership** and never distinguished `member` from `viewer`. A `viewer` could mutate **subgraphs** through both the REST Cypher query endpoint and the MCP write tools.

## The gap (verified)

- `GraphUser.role` stores `admin` / `member` / `viewer` and the docstring documents `viewer` as read-only — but nothing read the role on write paths.
- REST: the query endpoint blocks main-graph writes for all roles and shared-repo writes for everyone, then allows subgraph writes with only an audit log — no role check.
- MCP: `write-graph-cypher`, `add-node-table`, `add-relationship-table` weren't in the write-detection list, so they resolved to `access_type="read"` and `validate_mcp_access` only checked membership.

Blast radius is bounded: main-graph writes stay blocked for all roles (staging-pipeline only), shared repositories stay read-only for everyone, and creating/deleting a subgraph still requires `admin`. The exposure is specifically: once an admin creates a subgraph, a `viewer` could mutate it. (Latent in prod today — multi-user sharing is off — which makes this a good pre-sharing fix.)

## Changes

- **`models/core/graph/graph_user.py`** — add `user_has_write_access(user_id, graph_id, session)` → `role in {admin, member}`, with the same subgraph→parent resolution as the sibling helpers.
- **`routers/graphs/query/execute.py`** — enforce `user_has_write_access` on the subgraph write branch (placed after the shared-repo block, where a write is confirmed to target a non-shared user subgraph). Returns 403 for viewers.
- **`routers/graphs/mcp/handlers.py`** — `validate_mcp_access` requires the write role (not bare membership) when `operation_type` is `write`/`admin` on user graphs.
- **`routers/graphs/mcp/execute.py`** — flag the three write tools as writes so they resolve to `access_type="write"` and reach the write check.
- **Tests** — extend the model role test with write-access assertions (admin/member ✓, viewer ✗, no-membership ✗); add MCP `validate_mcp_access` write-role tests (granted with write role, 403 for read-only).

## Testing

- `uv run pytest` on the model + MCP handler + query + mcp-execute suites — **89 passed**.
- `just test-code` — **passed** (ruff + format + basedpyright: 0 errors).

## Notes

- Second of two PRs from the GPT 5.5 review round; pairs with the fail-closed hardening PR (independent, either order).
- Deliberately scoped to graph writes (Cypher + MCP), matching the review finding. Extension operation endpoints (CQRS command writes) are a separate authz surface and out of scope here.
