### PR TITLE
fix(security): fail closed on missing CAPTCHA secret and Secrets Manager errors

### DIFF
--- a/robosystems/config/secrets_manager.py
+++ b/robosystems/config/secrets_manager.py
@@ -318,9 +318,15 @@ def get_secret_value(key: str, default: str = "") -> str:
     return secrets.get(key, default)
 
   except Exception as e:
-    # Log the error but don't fail - return default
-    logger.warning(f"Failed to retrieve secret '{key}' from Secrets Manager: {e}")
-    return default
+    # We only reach here in prod/staging (dev/test returned the default above).
+    # The inner get_secret() already fails closed for access/other errors by
+    # re-raising; swallowing here would silently substitute a possibly-insecure
+    # default (e.g. an empty encryption/signing key), so surface the failure.
+    # Missing-but-optional secrets do NOT reach this branch — get_secret()
+    # returns {} for ResourceNotFound, and {}.get(key, default) yields the
+    # default without raising.
+    logger.error(f"Failed to retrieve secret '{key}' from Secrets Manager: {e}")
+    raise
 
 
 def get_secret_list_value(

--- a/robosystems/security/captcha.py
+++ b/robosystems/security/captcha.py
@@ -63,6 +63,19 @@ class CaptchaService:
       )
 
     if not self.secret_key:
+      # A missing secret means we cannot verify the token. Fail CLOSED in
+      # deployed environments — an enabled CAPTCHA gate with no secret must
+      # reject, not silently admit every request (bot-registration exposure).
+      # Dev/test fall open for convenience (and normally short-circuit earlier
+      # via CAPTCHA_ENABLED in verify_captcha_or_skip).
+      if env.is_production() or env.is_staging():
+        logger.error(
+          "TURNSTILE_SECRET_KEY not configured while CAPTCHA is enabled - "
+          "failing closed"
+        )
+        return CaptchaVerificationResult(
+          success=False, error_codes=["missing-secret-key"]
+        )
       logger.warning(
         "TURNSTILE_SECRET_KEY not configured - CAPTCHA verification disabled"
       )

--- a/tests/config/test_secrets_manager.py
+++ b/tests/config/test_secrets_manager.py
@@ -222,9 +222,14 @@ class TestSecretValueFunction:
       result = get_secret_value("SHARED_RAW_BUCKET", "default")
       assert result == "robosystems-shared-raw-staging"
 
-  def test_get_secret_value_handles_exceptions(self):
-    """Test that exceptions are caught and defaults returned."""
-    with patch("os.getenv") as mock_getenv, patch("boto3.client") as mock_boto:
+  def test_get_secret_value_fails_closed_in_deployed_env(self):
+    """In prod/staging a failed secret fetch must surface (fail closed), not
+    silently return a default that could be an insecure empty key."""
+    with (
+      patch("os.getenv") as mock_getenv,
+      patch("robosystems.config.secrets_manager.boto3.client") as mock_boto,
+      patch("robosystems.config.secrets_manager._secrets_manager", None),
+    ):
       mock_getenv.side_effect = lambda key, default=None: {
         "ENVIRONMENT": "staging"
       }.get(key, default)
@@ -235,9 +240,9 @@ class TestSecretValueFunction:
       # Setup mock to raise exception
       mock_client.get_secret_value.side_effect = Exception("Network error")
 
-      # Should return default, not raise
-      result = get_secret_value("JWT_SECRET_KEY", "fallback_value")
-      assert result == "fallback_value"
+      # Should propagate, not swallow-and-default
+      with pytest.raises(Exception, match="Network error"):
+        get_secret_value("JWT_SECRET_KEY", "fallback_value")
 
   def test_get_secret_value_default_for_non_prod(self):
     """Non prod/staging environments should return default when not set."""

--- a/tests/security/test_captcha.py
+++ b/tests/security/test_captcha.py
@@ -107,14 +107,32 @@ class TestCaptchaService:
 
   @pytest.mark.asyncio
   @patch("robosystems.security.captcha.env")
-  async def test_verify_turnstile_token_missing_secret(self, mock_env):
-    """Test verification with missing secret key."""
+  async def test_verify_turnstile_token_missing_secret_dev_fails_open(self, mock_env):
+    """Dev/test with no secret falls open (convenience)."""
     mock_env.TURNSTILE_SECRET_KEY = None
+    mock_env.is_production.return_value = False
+    mock_env.is_staging.return_value = False
 
     service = CaptchaService()
     result = await service.verify_turnstile_token("valid_token")
 
     assert result.success is True  # Allows through with warning
+    assert "missing-secret-key" in result.error_codes
+
+  @pytest.mark.asyncio
+  @patch("robosystems.security.captcha.env")
+  async def test_verify_turnstile_token_missing_secret_prod_fails_closed(
+    self, mock_env
+  ):
+    """Prod/staging with an enabled gate but no secret fails closed (rejects)."""
+    mock_env.TURNSTILE_SECRET_KEY = None
+    mock_env.is_production.return_value = True
+    mock_env.is_staging.return_value = False
+
+    service = CaptchaService()
+    result = await service.verify_turnstile_token("valid_token")
+
+    assert result.success is False  # Missing secret must not admit the request
     assert "missing-secret-key" in result.error_codes
 
   @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Two security controls failed in the unsafe direction on misconfiguration/error. Surfaced by a second independent security review (GPT 5.5) and code-verified. Both fixes are environment-gated so dev/test convenience is preserved while prod/staging fail closed.

## Changes

### CAPTCHA (`security/captcha.py`)
`verify_turnstile_token` returned `success=True` when `TURNSTILE_SECRET_KEY` was empty. With `CAPTCHA_ENABLED` on (as in prod), an unset or rotated-away secret would silently admit **every** registration — disabling bot protection with no error surfaced. Now fails **closed** (rejects) in prod/staging; dev/test keep the fail-open convenience (and normally short-circuit earlier via `CAPTCHA_ENABLED` in `verify_captcha_or_skip`).

### Secrets Manager (`config/secrets_manager.py`)
`get_secret_value` wrapped the fetch in a broad `except Exception: return default`, which swallowed the deliberate fail-closed re-raises from the inner `get_secret()` and could substitute a possibly-insecure empty default (e.g. an encryption/signing key) in prod/staging on a fetch error. Now re-raises so the failure surfaces. Missing-but-optional secrets are unaffected — `get_secret()` returns `{}` for `ResourceNotFound`, and `{}.get(key, default)` yields the default without raising. This branch is only reachable in prod/staging (dev/test return the default earlier).

## Deploy safety

- `TURNSTILE_SECRET_KEY` is set in prod and staging, so the CAPTCHA change is a **no-op** in normal operation — it only changes behavior in the (previously silent-fail) misconfigured state.
- The Secrets Manager change is a no-op except during an actual Secrets Manager fetch outage, where failing closed is the intended behavior (the crown-jewel secrets already hard-fail at startup validation).

## Testing

- `uv run pytest` on captcha + secrets_manager + valkey_security + auth_middleware + full auth router suites — **202 passed** (updated the two tests that asserted the old fail-open contracts).
- `just test-code` — **passed** (ruff + format + basedpyright: 0 errors).

## Notes

First of two PRs from the GPT 5.5 review round; pairs with the viewer write-authorization PR (independent, either order).
