### PR TITLE
feat(security): emit security metrics and wire live detective-control alarms

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -333,6 +333,7 @@ jobs:
                 ParameterKey=FargateBase,ParameterValue=${{ inputs.fargate_base }} \
                 ParameterKey=PrometheusStackName,ParameterValue=\"${{ inputs.prometheus_stack_name }}\" \
                 ParameterKey=EmailFromAddress,ParameterValue=\"${{ inputs.aws_sns_alert_email }}\" \
+                ParameterKey=SNSAlertEmail,ParameterValue=\"${{ inputs.aws_sns_alert_email }}\" \
                 ParameterKey=SharedProcessedBucketArn,ParameterValue=\"${{ inputs.shared_processed_bucket_arn }}\" \
                 ParameterKey=DeploymentBucketArn,ParameterValue=\"${{ inputs.deployment_bucket_arn }}\" \
                 ParameterKey=UserDataBucketArn,ParameterValue=\"${{ inputs.user_data_bucket_arn }}\" \

--- a/cloudformation/api.yaml
+++ b/cloudformation/api.yaml
@@ -8,47 +8,36 @@ Parameters:
     AllowedValues:
       - prod
       - staging
-    Description: Environment name (prod or staging)
-    ConstraintDescription: Must be prod or staging
 
   # Infrastructure & Networking
   VpcId:
     Type: AWS::EC2::VPC::Id
-    Description: VPC ID for ECS tasks
   VpcCidr:
     Type: String
     Default: 10.0.0.0/16
-    Description: CIDR block for the VPC
     AllowedPattern: "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/(1[6-9]|2[0-8]))$"
-    ConstraintDescription: Must be a valid CIDR block
   SubnetIds:
     Type: List<AWS::EC2::Subnet::Id>
-    Description: Private subnet IDs for ECS tasks (comma-separated)
   PublicSubnetIds:
     Type: CommaDelimitedList
-    Description: Public subnet IDs for ALB (comma-separated). Required when DomainName is provided.
     Default: ""
 
   # Container & Application Configuration
   ECRRepositoryUrl:
     Type: String
-    Description: Full ECR repository URL (e.g., 123456789.dkr.ecr.us-east-1.amazonaws.com/robosystems)
   ECRImageTag:
     Type: String
-    Description: Docker image tag
     Default: latest
   ContainerPort:
     Type: Number
     Default: 8000
     MinValue: 1
     MaxValue: 65535
-    Description: Port the container listens on
 
   # ECS & Compute Configuration
   Cpu:
     Type: String
     Default: "512"
-    Description: CPU units for ECS task (512 = 0.5 vCPU)
     AllowedValues:
       - "256"
       - "512"
@@ -57,7 +46,6 @@ Parameters:
   Memory:
     Type: String
     Default: "1024"
-    Description: Memory in MiB for ECS task
     AllowedValues:
       - "512"
       - "1024"
@@ -70,43 +58,36 @@ Parameters:
     Default: 1
     MinValue: 1
     MaxValue: 100
-    Description: Minimum number of tasks for auto scaling
   MaxCapacity:
     Type: Number
     Default: 10
     MinValue: 1
     MaxValue: 100
-    Description: Maximum number of tasks for auto scaling
   CPUTargetValue:
     Type: Number
     Default: 70
     MinValue: 1
     MaxValue: 100
-    Description: Target CPU utilization percentage for auto scaling
   MemoryTargetValue:
     Type: Number
     Default: 60
     MinValue: 1
     MaxValue: 100
-    Description: Target Memory utilization percentage for auto scaling
   FargateWeight:
     Type: Number
     Default: 10
     MinValue: 0
     MaxValue: 100
-    Description: Weight for FARGATE capacity provider (On-Demand instances)
   FargateSpotWeight:
     Type: Number
     Default: 90
     MinValue: 0
     MaxValue: 100
-    Description: Weight for FARGATE_SPOT capacity provider (Spot instances)
   FargateBase:
     Type: Number
     Default: 0
     MinValue: 0
     MaxValue: 10
-    Description: Minimum number of tasks guaranteed to run on FARGATE (On-Demand). Set to 1+ for guaranteed availability during Spot shortages.
 
   # Access Mode Configuration
   ApiAccessMode:
@@ -123,15 +104,12 @@ Parameters:
   # Domain & DNS Configuration (Required only when ApiAccessMode=public)
   DomainName:
     Type: String
-    Description: Full domain name for the API (e.g., api.robosystems.ai). Required when ApiAccessMode=public.
     Default: ""
   RootDomainName:
     Type: String
-    Description: Root domain name (e.g., robosystems.ai). Required when ApiAccessMode=public.
     Default: ""
   HostedZoneId:
     Type: String
-    Description: Route53 Hosted Zone ID for the domain. Required when ApiAccessMode=public.
     Default: ""
 
   # Observability & Monitoring
@@ -140,112 +118,86 @@ Parameters:
     Default: 30
     MinValue: 1
     MaxValue: 365
-    Description: CloudWatch log retention in days
   LogRetentionStrategy:
     Type: String
     Default: "standard"
     AllowedValues: ["minimal", "standard", "extended"]
-    Description: "Log retention strategy for cost optimization"
   ContainerInsightsEnabled:
     Type: String
     Default: disabled
     AllowedValues:
       - enabled
       - disabled
-    Description: Enable/disable ECS Container Insights (adds ~$30-40/month in CloudWatch costs per cluster)
   PrometheusStackName:
     Type: String
-    Description: Name of the Prometheus CloudFormation stack for this environment
     Default: ""
 
   # Email Configuration
   EmailFromAddress:
     Type: String
-    Description: Verified email address for sending transactional emails via SES
     Default: "noreply@robosystems.ai"
     AllowedPattern: ^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$
-    ConstraintDescription: Must be a valid email address
 
   # Security Alerting
   SNSAlertEmail:
     Type: String
     Default: ""
-    Description: Email address for security alert notifications (empty disables the security alert topic and alarm actions)
 
   # Frontend URLs (for transactional email links, billing redirects, CORS)
   RoboSystemsAppUrl:
     Type: String
-    Description: RoboSystems frontend URL
     Default: "https://robosystems.ai"
   RoboLedgerAppUrl:
     Type: String
-    Description: RoboLedger frontend URL
     Default: "https://roboledger.ai"
   RoboInvestorAppUrl:
     Type: String
-    Description: RoboInvestor frontend URL
     Default: "https://roboinvestor.ai"
 
   # Cache Configuration
   ValkeyUrl:
     Type: String
-    Description: Valkey ElastiCache endpoint URL from Valkey stack
     AllowedPattern: ^rediss?://.*:[0-9]+$
-    ConstraintDescription: Must be a valid Redis URL (redis://host:port or rediss://host:port)
   ValkeyClientSecurityGroupId:
     Type: String
-    Description: Security group ID for applications connecting to Valkey
     AllowedPattern: ^sg-[0-9a-f]+$
-    ConstraintDescription: Must be a valid security group ID
   OpenSearchEndpoint:
     Type: String
-    Description: OpenSearch domain endpoint URL (empty if not deployed)
     Default: ""
   OpenSearchClientSecurityGroupId:
     Type: String
-    Description: Security group ID for applications connecting to OpenSearch (empty if not deployed)
     Default: ""
   BastionSecurityGroupId:
     Type: String
-    Description: Security group ID for bastion host (for SSM tunnel access to admin API)
     AllowedPattern: ^sg-[0-9a-f]+$
-    ConstraintDescription: Must be a valid security group ID
 
   # Tagging Configuration
   ServiceTag:
     Type: String
     Default: RoboSystems
-    Description: Service tag for resource identification and billing
   ComponentTag:
     Type: String
     Default: API
-    Description: Component tag for resource identification and billing
 
   # PostgreSQL Configuration (from Postgres stack outputs)
   DatabaseEndpoint:
     Type: String
-    Description: "PostgreSQL database endpoint hostname"
   DatabasePort:
     Type: String
-    Description: "PostgreSQL database port"
     Default: "5432"
 
   # Lambda Configuration (container-based)
   LambdaImageUri:
     Type: String
-    Description: ECR image URI for Lambda functions (container-based deployment)
     Default: ""
 
   # S3 Bucket Configuration (from S3 stack outputs)
   SharedProcessedBucketArn:
     Type: String
-    Description: ARN of shared processed data bucket (from S3 stack output)
   DeploymentBucketArn:
     Type: String
-    Description: ARN of deployment bucket (from S3 stack output)
   UserDataBucketArn:
     Type: String
-    Description: ARN of user data bucket (from S3 stack output)
 
 Conditions:
   HasObservabilityStack: !Not [!Equals [!Ref PrometheusStackName, ""]]
@@ -1167,10 +1119,9 @@ Resources:
         - Key: ManagedBy
           Value: CloudFormation
 
-  # CloudWatch alarm for failed admin authentications
-  # Security alert topic — email subscription for the detective-control alarms
-  # below. Only created when an alert email is supplied (HasAlertEmail); the
-  # alarms still exist without it, just with no action.
+  # Security alert topic + detective-control alarms. Topic created only when an
+  # alert email is supplied (HasAlertEmail); alarms always exist, actions wired
+  # only when the topic is present. Metrics come from SecurityAuditLogger.
   SecurityAlertTopic:
     Type: AWS::SNS::Topic
     Condition: HasAlertEmail
@@ -1180,21 +1131,12 @@ Resources:
       Subscription:
         - Endpoint: !Ref SNSAlertEmail
           Protocol: email
-      Tags:
-        - Key: Environment
-          Value: !Ref Environment
-        - Key: Service
-          Value: !Ref ServiceTag
-        - Key: Component
-          Value: !Ref ComponentTag
-        - Key: CreatedBy
-          Value: CloudFormation
 
   FailedAdminAuthAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub robosystems-${Environment}-api-failed-admin-auth
-      AlarmDescription: Alert on multiple failed admin authentication attempts
+      AlarmDescription: Multiple failed admin authentication attempts
       MetricName: FailedAdminAuth
       Namespace: !Sub "RoboSystems/Security/${Environment}"
       Statistic: Sum
@@ -1206,12 +1148,11 @@ Resources:
       AlarmActions:
         !If [HasAlertEmail, [!Ref SecurityAlertTopic], !Ref "AWS::NoValue"]
 
-  # Spike in authentication failures — possible credential-stuffing / brute force.
   AuthFailureSpikeAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub robosystems-${Environment}-api-auth-failure-spike
-      AlarmDescription: Alert on a spike in authentication failures across the API
+      AlarmDescription: Spike in auth failures (possible credential stuffing)
       MetricName: AuthFailure
       Namespace: !Sub "RoboSystems/Security/${Environment}"
       Statistic: Sum
@@ -1223,12 +1164,11 @@ Resources:
       AlarmActions:
         !If [HasAlertEmail, [!Ref SecurityAlertTopic], !Ref "AWS::NoValue"]
 
-  # Any detected injection / path-traversal attempt is worth a page.
   InjectionAttemptAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub robosystems-${Environment}-api-injection-attempt
-      AlarmDescription: Alert on any detected injection or path-traversal attempt
+      AlarmDescription: Detected injection or path-traversal attempt
       MetricName: InjectionAttempt
       Namespace: !Sub "RoboSystems/Security/${Environment}"
       Statistic: Sum
@@ -1240,12 +1180,11 @@ Resources:
       AlarmActions:
         !If [HasAlertEmail, [!Ref SecurityAlertTopic], !Ref "AWS::NoValue"]
 
-  # Any detected privilege-escalation attempt is worth a page.
   PrivilegeEscalationAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub robosystems-${Environment}-api-privilege-escalation
-      AlarmDescription: Alert on any detected privilege-escalation attempt
+      AlarmDescription: Detected privilege-escalation attempt
       MetricName: PrivilegeEscalationAttempt
       Namespace: !Sub "RoboSystems/Security/${Environment}"
       Statistic: Sum
@@ -1429,73 +1368,59 @@ Resources:
 
 Outputs:
   ApiAccessMode:
-    Description: API access mode (public or internal)
     Value: !Ref ApiAccessMode
   ApiUrl:
-    Description: URL of the API endpoint
     Value: !If
       - IsPublicWithDomain
       - !Sub https://${DomainName}
       - !Sub http://${ApiALB.DNSName}
   LoadBalancerDNS:
-    Description: DNS of the Load Balancer
     Value: !GetAtt ApiALB.DNSName
     Export:
       Name: !Sub ${AWS::StackName}-LoadBalancerDNS
   LoadBalancerScheme:
-    Description: ALB scheme (internet-facing or internal)
     Value: !If [IsPublicWithDomain, internet-facing, internal]
   ClusterName:
-    Description: Name of the ECS Cluster
     Value: !Ref ApiCluster
   ECRRepositoryUsed:
-    Description: ECR Repository used for Docker images
     Value: !Sub ${ECRRepositoryUrl}:${ECRImageTag}
     Export:
       Name: !Sub ${AWS::StackName}-${Environment}-ECRRepositoryUsed
   ApiScalingTarget:
-    Description: Auto Scaling Target Resource ID
     Value: !Sub service/robosystems-api-${Environment}-cluster/robosystems-api-${Environment}-service
   CertificateArn:
     Condition: IsPublicWithDomain
-    Description: ACM Certificate ARN
     Value: !Ref ApiCertificate
     Export:
       Name: !Sub ${AWS::StackName}-${Environment}-CertificateArn
   ApiALBArn:
-    Description: ARN of the API Application Load Balancer
     Value: !Ref ApiALB
     Export:
       Name: !Sub ${AWS::StackName}-ApiALBArn
 
   ApiSecurityGroupId:
-    Description: Security group ID for API ECS tasks (for Dagster access)
     Value: !Ref ApiSecurityGroup
     Export:
       Name: !Sub ${AWS::StackName}-ApiSecurityGroupId
 
   # Admin Key Outputs
   AdminKeySecretArn:
-    Description: ARN of the admin key secret
     Value: !Ref AdminKeySecret
     Export:
       Name: !Sub ${AWS::StackName}-AdminKeySecretArn
 
   # Service Discovery Outputs
   ApiServiceDiscoveryEndpoint:
-    Description: Internal DNS endpoint for direct API access (bypasses ALB)
     Value: !Sub api.${Environment}.robosystems.local
     Export:
       Name: !Sub ${AWS::StackName}-ServiceDiscoveryEndpoint
 
   ApiServiceDiscoveryNamespaceId:
-    Description: Service Discovery namespace ID (can be shared with other services)
     Value: !Ref ApiNamespace
     Export:
       Name: !Sub ${AWS::StackName}-ServiceDiscoveryNamespaceId
 
   ApiServiceDiscoveryNamespaceArn:
-    Description: Service Discovery namespace ARN
     Value: !GetAtt ApiNamespace.Arn
     Export:
       Name: !Sub ${AWS::StackName}-ServiceDiscoveryNamespaceArn

--- a/cloudformation/api.yaml
+++ b/cloudformation/api.yaml
@@ -166,6 +166,12 @@ Parameters:
     AllowedPattern: ^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$
     ConstraintDescription: Must be a valid email address
 
+  # Security Alerting
+  SNSAlertEmail:
+    Type: String
+    Default: ""
+    Description: Email address for security alert notifications (empty disables the security alert topic and alarm actions)
+
   # Frontend URLs (for transactional email links, billing redirects, CORS)
   RoboSystemsAppUrl:
     Type: String
@@ -250,6 +256,7 @@ Conditions:
   IsPublicWithDomain: !Equals [!Ref ApiAccessMode, "public"]
   IsInternal: !Equals [!Ref ApiAccessMode, "internal"]
   HasOpenSearch: !Not [!Equals [!Ref OpenSearchEndpoint, ""]]
+  HasAlertEmail: !Not [!Equals [!Ref SNSAlertEmail, ""]]
 
 Mappings:
   LogRetentionPolicies:
@@ -332,14 +339,16 @@ Resources:
                 Action:
                   - cloudformation:DescribeStacks
                 Resource: "*"
-              # CloudWatch metrics for allocation monitoring
+              # CloudWatch metrics for allocation monitoring + security alerting
               - Effect: Allow
                 Action:
                   - cloudwatch:PutMetricData
                 Resource: "*"
                 Condition:
                   StringEquals:
-                    "cloudwatch:namespace": !Sub "RoboSystems/Graph/${Environment}"
+                    "cloudwatch:namespace":
+                      - !Sub "RoboSystems/Graph/${Environment}"
+                      - !Sub "RoboSystems/Security/${Environment}"
               # Auto Scaling permissions for capacity checks and scale-up triggers
               - Effect: Allow
                 Action:
@@ -1159,19 +1168,94 @@ Resources:
           Value: CloudFormation
 
   # CloudWatch alarm for failed admin authentications
+  # Security alert topic — email subscription for the detective-control alarms
+  # below. Only created when an alert email is supplied (HasAlertEmail); the
+  # alarms still exist without it, just with no action.
+  SecurityAlertTopic:
+    Type: AWS::SNS::Topic
+    Condition: HasAlertEmail
+    Properties:
+      TopicName: !Sub robosystems-${Environment}-security-alerts
+      DisplayName: !Sub RoboSystems ${Environment} Security Alerts
+      Subscription:
+        - Endpoint: !Ref SNSAlertEmail
+          Protocol: email
+      Tags:
+        - Key: Environment
+          Value: !Ref Environment
+        - Key: Service
+          Value: !Ref ServiceTag
+        - Key: Component
+          Value: !Ref ComponentTag
+        - Key: CreatedBy
+          Value: CloudFormation
+
   FailedAdminAuthAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub robosystems-${Environment}-api-failed-admin-auth
       AlarmDescription: Alert on multiple failed admin authentication attempts
       MetricName: FailedAdminAuth
-      Namespace: RoboSystems/Admin
+      Namespace: !Sub "RoboSystems/Security/${Environment}"
       Statistic: Sum
       Period: 300
       EvaluationPeriods: 1
       Threshold: 5
       ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
+      AlarmActions:
+        !If [HasAlertEmail, [!Ref SecurityAlertTopic], !Ref "AWS::NoValue"]
+
+  # Spike in authentication failures — possible credential-stuffing / brute force.
+  AuthFailureSpikeAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub robosystems-${Environment}-api-auth-failure-spike
+      AlarmDescription: Alert on a spike in authentication failures across the API
+      MetricName: AuthFailure
+      Namespace: !Sub "RoboSystems/Security/${Environment}"
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 50
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      AlarmActions:
+        !If [HasAlertEmail, [!Ref SecurityAlertTopic], !Ref "AWS::NoValue"]
+
+  # Any detected injection / path-traversal attempt is worth a page.
+  InjectionAttemptAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub robosystems-${Environment}-api-injection-attempt
+      AlarmDescription: Alert on any detected injection or path-traversal attempt
+      MetricName: InjectionAttempt
+      Namespace: !Sub "RoboSystems/Security/${Environment}"
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 0
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      AlarmActions:
+        !If [HasAlertEmail, [!Ref SecurityAlertTopic], !Ref "AWS::NoValue"]
+
+  # Any detected privilege-escalation attempt is worth a page.
+  PrivilegeEscalationAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub robosystems-${Environment}-api-privilege-escalation
+      AlarmDescription: Alert on any detected privilege-escalation attempt
+      MetricName: PrivilegeEscalationAttempt
+      Namespace: !Sub "RoboSystems/Security/${Environment}"
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 0
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      AlarmActions:
+        !If [HasAlertEmail, [!Ref SecurityAlertTopic], !Ref "AWS::NoValue"]
 
   # ===========================================
   # API Key Rotation Lambda

--- a/robosystems/middleware/auth/admin.py
+++ b/robosystems/middleware/auth/admin.py
@@ -122,7 +122,7 @@ class AdminAuthMiddleware:
       extra={
         "admin_key_id": key_metadata["key_id"],
         "admin_name": key_metadata["name"],
-        "ip_address": request.client.host,
+        "ip_address": request.client.host if request.client else None,
       },
     )
 

--- a/robosystems/middleware/auth/admin.py
+++ b/robosystems/middleware/auth/admin.py
@@ -9,6 +9,7 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 from ...config.secrets_manager import get_secrets_manager
 from ...logger import get_logger
+from ...security.audit_logger import SecurityAuditLogger
 
 logger = get_logger(__name__)
 
@@ -98,7 +99,14 @@ class AdminAuthMiddleware:
     key_metadata = self.verify_admin_key(api_key)
 
     if not key_metadata:
-      logger.warning(f"Invalid admin key attempted from IP: {request.client.host}")
+      client_ip = request.client.host if request.client else None
+      logger.warning(f"Invalid admin key attempted from IP: {client_ip}")
+      SecurityAuditLogger.log_admin_auth_failure(
+        reason="invalid_admin_key",
+        ip_address=client_ip,
+        endpoint=str(request.url.path),
+        user_agent=request.headers.get("User-Agent"),
+      )
       raise HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
         detail="Invalid admin API key",

--- a/robosystems/security/audit_logger.py
+++ b/robosystems/security/audit_logger.py
@@ -51,6 +51,72 @@ class SecurityEventType(Enum):
   GRAPH_DELETED = "graph_deleted"
 
 
+# CloudWatch metrics: the compliance/alerting-relevant subset of security
+# events is published to RoboSystems/Security/{env} so the detective-control
+# alarms in cloudformation/api.yaml can actually fire. Operational events
+# (email_sent, auth_success, operation_timeout, …) are deliberately excluded
+# to keep the metric stream low-volume and the alarms meaningful.
+_METRIC_FOR_EVENT: dict[SecurityEventType, str] = {
+  SecurityEventType.AUTH_FAILURE: "AuthFailure",
+  SecurityEventType.AUTH_TOKEN_EXPIRED: "AuthFailure",
+  SecurityEventType.AUTH_TOKEN_INVALID: "AuthFailure",
+  SecurityEventType.API_KEY_INVALID: "AuthFailure",
+  SecurityEventType.API_KEY_EXPIRED: "AuthFailure",
+  SecurityEventType.AUTHORIZATION_DENIED: "AuthorizationDenied",
+  SecurityEventType.INJECTION_ATTEMPT: "InjectionAttempt",
+  SecurityEventType.PATH_TRAVERSAL_ATTEMPT: "InjectionAttempt",
+  SecurityEventType.PRIVILEGE_ESCALATION_ATTEMPT: "PrivilegeEscalationAttempt",
+}
+
+# Emitted in addition to AuthFailure when the failure is on the admin surface,
+# so FailedAdminAuthAlarm has a dedicated, low-noise trigger.
+_ADMIN_AUTH_FAILURE_METRIC = "FailedAdminAuth"
+
+# Auth-failure event types that count as an admin failure when details.admin is set.
+_ADMIN_FLAGGABLE_EVENTS = frozenset(
+  {
+    SecurityEventType.AUTH_FAILURE,
+    SecurityEventType.API_KEY_INVALID,
+    SecurityEventType.AUTH_TOKEN_INVALID,
+  }
+)
+
+_cloudwatch_client: Any = None
+
+
+def _get_cloudwatch_client() -> Any:
+  global _cloudwatch_client
+  if _cloudwatch_client is None:
+    import boto3
+
+    _cloudwatch_client = boto3.client("cloudwatch", region_name=env.AWS_REGION)
+  return _cloudwatch_client
+
+
+def _publish_security_metrics(metric_names: list[str]) -> None:
+  """Publish security alerting metrics to CloudWatch.
+
+  Best-effort and prod/staging-only: skipped where there is no CloudWatch or
+  credentials (dev/test), and never allowed to raise into the caller — a
+  metrics failure must never break an auth or authorization path.
+  """
+  if not metric_names:
+    return
+  if not (env.is_production() or env.is_staging()):
+    return
+  try:
+    namespace = f"RoboSystems/Security/{env.ENVIRONMENT}"
+    _get_cloudwatch_client().put_metric_data(
+      Namespace=namespace,
+      MetricData=[
+        {"MetricName": name, "Value": 1, "Unit": "Count"} for name in metric_names
+      ],
+    )
+  except Exception as e:
+    # Metrics are best-effort; a publish failure must not affect the request.
+    logger.debug(f"Failed to publish security metric(s) {metric_names}: {e}")
+
+
 class SecurityAuditLogger:
   """Centralized security audit logging."""
 
@@ -96,6 +162,38 @@ class SecurityAuditLogger:
 
     # Log as structured JSON for security monitoring
     logger.warning(f"SECURITY_AUDIT: {json.dumps(audit_data)}")
+
+    # Publish the alerting metric for the compliance-relevant subset so the
+    # CloudWatch detective-control alarms can fire (no-op outside prod/staging).
+    metric_names: list[str] = []
+    metric = _METRIC_FOR_EVENT.get(event_type)
+    if metric:
+      metric_names.append(metric)
+    if (details or {}).get("admin") and event_type in _ADMIN_FLAGGABLE_EVENTS:
+      metric_names.append(_ADMIN_AUTH_FAILURE_METRIC)
+    _publish_security_metrics(metric_names)
+
+  @staticmethod
+  def log_admin_auth_failure(
+    reason: str,
+    ip_address: str | None = None,
+    endpoint: str | None = None,
+    user_agent: str | None = None,
+  ):
+    """Log an admin-surface authentication failure.
+
+    Flags the event as admin so a dedicated ``FailedAdminAuth`` CloudWatch
+    metric is emitted alongside the generic ``AuthFailure`` signal, giving
+    ``FailedAdminAuthAlarm`` a low-noise trigger.
+    """
+    SecurityAuditLogger.log_security_event(
+      event_type=SecurityEventType.AUTH_FAILURE,
+      ip_address=ip_address,
+      user_agent=user_agent,
+      endpoint=endpoint,
+      details={"admin": True, "failure_reason": reason},
+      risk_level="high",
+    )
 
   @staticmethod
   def log_auth_failure(

--- a/robosystems/security/audit_logger.py
+++ b/robosystems/security/audit_logger.py
@@ -6,6 +6,8 @@ authorization violations, and suspicious activities.
 """
 
 import json
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime
 from enum import Enum
 from typing import Any
@@ -81,31 +83,49 @@ _ADMIN_FLAGGABLE_EVENTS = frozenset(
   }
 )
 
+# Metric publishing runs OFF the request path. log_security_event is called
+# synchronously from async auth handlers (get_current_user, AdminAuthMiddleware),
+# so a blocking put_metric_data would stall the whole event loop — worst during
+# an auth-failure spike, which is exactly when these alarms matter. Publish on a
+# small bounded thread pool instead, with short client timeouts, and shed load
+# past _METRIC_MAX_INFLIGHT rather than let work queue without bound under a flood.
+_METRIC_MAX_INFLIGHT = 256
+
 _cloudwatch_client: Any = None
+_metric_executor: ThreadPoolExecutor | None = None
+_metric_inflight = 0
+_metric_lock = threading.Lock()
 
 
 def _get_cloudwatch_client() -> Any:
   global _cloudwatch_client
   if _cloudwatch_client is None:
     import boto3
+    from botocore.config import Config
 
-    _cloudwatch_client = boto3.client("cloudwatch", region_name=env.AWS_REGION)
+    # Short timeouts + no retries: a stalled CloudWatch endpoint must fail fast,
+    # never hold a pool thread (or, historically, the event loop) for ~60s.
+    _cloudwatch_client = boto3.client(
+      "cloudwatch",
+      region_name=env.AWS_REGION,
+      config=Config(connect_timeout=2, read_timeout=3, retries={"max_attempts": 1}),
+    )
   return _cloudwatch_client
 
 
-def _publish_security_metrics(metric_names: list[str]) -> None:
-  """Publish security alerting metrics to CloudWatch.
+def _get_metric_executor() -> ThreadPoolExecutor:
+  global _metric_executor
+  if _metric_executor is None:
+    _metric_executor = ThreadPoolExecutor(
+      max_workers=2, thread_name_prefix="security-metrics"
+    )
+  return _metric_executor
 
-  Best-effort and prod/staging-only: skipped where there is no CloudWatch or
-  credentials (dev/test), and never allowed to raise into the caller — a
-  metrics failure must never break an auth or authorization path.
-  """
-  if not metric_names:
-    return
-  if not (env.is_production() or env.is_staging()):
-    return
+
+def _put_metric_data(namespace: str, metric_names: list[str]) -> None:
+  """Blocking CloudWatch publish — runs on the metric pool, never the caller."""
+  global _metric_inflight
   try:
-    namespace = f"RoboSystems/Security/{env.ENVIRONMENT}"
     _get_cloudwatch_client().put_metric_data(
       Namespace=namespace,
       MetricData=[
@@ -113,8 +133,39 @@ def _publish_security_metrics(metric_names: list[str]) -> None:
       ],
     )
   except Exception as e:
-    # Metrics are best-effort; a publish failure must not affect the request.
+    # Metrics are best-effort; a publish failure must not surface anywhere.
     logger.debug(f"Failed to publish security metric(s) {metric_names}: {e}")
+  finally:
+    with _metric_lock:
+      _metric_inflight -= 1
+
+
+def _publish_security_metrics(metric_names: list[str]) -> None:
+  """Queue security alerting metrics for CloudWatch, off the request path.
+
+  Best-effort and prod/staging-only: skipped where there is no CloudWatch or
+  credentials (dev/test). The actual publish runs on a bounded thread pool so it
+  never blocks the (often async) auth path, and load is shed past
+  ``_METRIC_MAX_INFLIGHT`` so a flood can't grow the queue without bound. Never
+  raises into the caller.
+  """
+  global _metric_inflight
+  if not metric_names:
+    return
+  if not (env.is_production() or env.is_staging()):
+    return
+  with _metric_lock:
+    if _metric_inflight >= _METRIC_MAX_INFLIGHT:
+      return
+    _metric_inflight += 1
+  namespace = f"RoboSystems/Security/{env.ENVIRONMENT}"
+  try:
+    _get_metric_executor().submit(_put_metric_data, namespace, list(metric_names))
+  except Exception as e:
+    # Executor rejected the task (e.g. interpreter shutdown) — release the slot.
+    with _metric_lock:
+      _metric_inflight -= 1
+    logger.debug(f"Failed to queue security metric(s) {metric_names}: {e}")
 
 
 class SecurityAuditLogger:

--- a/tests/security/test_audit_metrics.py
+++ b/tests/security/test_audit_metrics.py
@@ -10,11 +10,20 @@ from unittest.mock import Mock, patch
 import pytest
 from fastapi import HTTPException
 
+import robosystems.security.audit_logger as audit_mod
 from robosystems.security.audit_logger import (
   SecurityAuditLogger,
   SecurityEventType,
   _publish_security_metrics,
 )
+
+
+class _InlineExecutor:
+  """Runs submitted callables synchronously so tests can assert on the effect."""
+
+  def submit(self, fn, *args, **kwargs):
+    fn(*args, **kwargs)
+    return None
 
 
 class TestSecurityMetricMapping:
@@ -101,33 +110,55 @@ class TestSecurityMetricMapping:
 
 
 class TestPublishSecurityMetrics:
-  """``_publish_security_metrics`` is prod/staging-only and best-effort."""
+  """``_publish_security_metrics`` is prod/staging-only, off-thread, best-effort."""
+
+  @pytest.fixture(autouse=True)
+  def _reset_inflight(self):
+    audit_mod._metric_inflight = 0
+    yield
+    audit_mod._metric_inflight = 0
 
   @patch("robosystems.security.audit_logger.env")
   def test_skipped_when_not_prod_or_staging(self, mock_env):
     mock_env.is_production.return_value = False
     mock_env.is_staging.return_value = False
-    with patch(
-      "robosystems.security.audit_logger._get_cloudwatch_client"
-    ) as mock_client:
+    with patch("robosystems.security.audit_logger._get_metric_executor") as mock_exec:
       _publish_security_metrics(["AuthFailure"])
-      mock_client.assert_not_called()
+      mock_exec.assert_not_called()
 
   @patch("robosystems.security.audit_logger.env")
   def test_empty_metric_list_is_noop(self, mock_env):
     mock_env.is_production.return_value = True
     mock_env.is_staging.return_value = False
-    with patch(
-      "robosystems.security.audit_logger._get_cloudwatch_client"
-    ) as mock_client:
+    with patch("robosystems.security.audit_logger._get_metric_executor") as mock_exec:
       _publish_security_metrics([])
-      mock_client.assert_not_called()
+      mock_exec.assert_not_called()
 
+  @patch("robosystems.security.audit_logger._get_metric_executor")
   @patch("robosystems.security.audit_logger.env")
-  def test_publishes_to_security_namespace_in_production(self, mock_env):
+  def test_offloads_to_executor_not_inline(self, mock_env, mock_exec):
+    # The publish must be handed to the thread pool, never run on the caller.
     mock_env.is_production.return_value = True
     mock_env.is_staging.return_value = False
     mock_env.ENVIRONMENT = "prod"
+    executor = Mock()
+    mock_exec.return_value = executor
+    with patch(
+      "robosystems.security.audit_logger._get_cloudwatch_client"
+    ) as mock_client:
+      _publish_security_metrics(["AuthFailure"])
+      # Submitted to the pool; the blocking CloudWatch call did NOT run inline.
+      executor.submit.assert_called_once()
+      assert executor.submit.call_args.args[0] is audit_mod._put_metric_data
+      mock_client.assert_not_called()
+
+  @patch("robosystems.security.audit_logger._get_metric_executor")
+  @patch("robosystems.security.audit_logger.env")
+  def test_publishes_to_security_namespace_in_production(self, mock_env, mock_exec):
+    mock_env.is_production.return_value = True
+    mock_env.is_staging.return_value = False
+    mock_env.ENVIRONMENT = "prod"
+    mock_exec.return_value = _InlineExecutor()
     cw = Mock()
     with patch(
       "robosystems.security.audit_logger._get_cloudwatch_client", return_value=cw
@@ -140,11 +171,13 @@ class TestPublishSecurityMetrics:
     assert names == {"AuthFailure", "FailedAdminAuth"}
     assert all(m["Value"] == 1 and m["Unit"] == "Count" for m in kwargs["MetricData"])
 
+  @patch("robosystems.security.audit_logger._get_metric_executor")
   @patch("robosystems.security.audit_logger.env")
-  def test_publishes_in_staging(self, mock_env):
+  def test_publishes_in_staging(self, mock_env, mock_exec):
     mock_env.is_production.return_value = False
     mock_env.is_staging.return_value = True
     mock_env.ENVIRONMENT = "staging"
+    mock_exec.return_value = _InlineExecutor()
     cw = Mock()
     with patch(
       "robosystems.security.audit_logger._get_cloudwatch_client", return_value=cw
@@ -154,11 +187,13 @@ class TestPublishSecurityMetrics:
       "RoboSystems/Security/staging"
     )
 
+  @patch("robosystems.security.audit_logger._get_metric_executor")
   @patch("robosystems.security.audit_logger.env")
-  def test_publish_failure_is_swallowed(self, mock_env):
+  def test_publish_failure_is_swallowed(self, mock_env, mock_exec):
     mock_env.is_production.return_value = True
     mock_env.is_staging.return_value = False
     mock_env.ENVIRONMENT = "prod"
+    mock_exec.return_value = _InlineExecutor()
     cw = Mock()
     cw.put_metric_data.side_effect = RuntimeError("cloudwatch unavailable")
     with patch(
@@ -166,6 +201,18 @@ class TestPublishSecurityMetrics:
     ):
       # Must not raise — metrics are best-effort and never break the caller.
       _publish_security_metrics(["AuthFailure"])
+    # In-flight slot is released even when the publish raises.
+    assert audit_mod._metric_inflight == 0
+
+  @patch("robosystems.security.audit_logger._get_metric_executor")
+  @patch("robosystems.security.audit_logger.env")
+  def test_sheds_load_past_inflight_cap(self, mock_env, mock_exec):
+    mock_env.is_production.return_value = True
+    mock_env.is_staging.return_value = False
+    mock_env.ENVIRONMENT = "prod"
+    with patch.object(audit_mod, "_METRIC_MAX_INFLIGHT", 0):
+      _publish_security_metrics(["AuthFailure"])
+      mock_exec.assert_not_called()
 
 
 class TestAdminAuthFailurePath:

--- a/tests/security/test_audit_metrics.py
+++ b/tests/security/test_audit_metrics.py
@@ -1,0 +1,220 @@
+"""Tests for security audit metric emission.
+
+Covers the CloudWatch metric side of ``SecurityAuditLogger`` — the detective-
+control signal that powers the alarms in ``cloudformation/api.yaml`` — and the
+admin auth-failure path that feeds the ``FailedAdminAuth`` metric.
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from robosystems.security.audit_logger import (
+  SecurityAuditLogger,
+  SecurityEventType,
+  _publish_security_metrics,
+)
+
+
+class TestSecurityMetricMapping:
+  """``log_security_event`` maps the compliance subset to CloudWatch metrics."""
+
+  @patch("robosystems.security.audit_logger._publish_security_metrics")
+  def test_injection_attempt_emits_metric(self, mock_publish):
+    SecurityAuditLogger.log_security_event(
+      event_type=SecurityEventType.INJECTION_ATTEMPT,
+    )
+    mock_publish.assert_called_once_with(["InjectionAttempt"])
+
+  @patch("robosystems.security.audit_logger._publish_security_metrics")
+  def test_path_traversal_maps_to_injection(self, mock_publish):
+    SecurityAuditLogger.log_security_event(
+      event_type=SecurityEventType.PATH_TRAVERSAL_ATTEMPT,
+    )
+    mock_publish.assert_called_once_with(["InjectionAttempt"])
+
+  @patch("robosystems.security.audit_logger._publish_security_metrics")
+  def test_authorization_denied_emits_metric(self, mock_publish):
+    SecurityAuditLogger.log_security_event(
+      event_type=SecurityEventType.AUTHORIZATION_DENIED,
+    )
+    mock_publish.assert_called_once_with(["AuthorizationDenied"])
+
+  @patch("robosystems.security.audit_logger._publish_security_metrics")
+  def test_privilege_escalation_emits_metric(self, mock_publish):
+    SecurityAuditLogger.log_security_event(
+      event_type=SecurityEventType.PRIVILEGE_ESCALATION_ATTEMPT,
+    )
+    mock_publish.assert_called_once_with(["PrivilegeEscalationAttempt"])
+
+  @patch("robosystems.security.audit_logger._publish_security_metrics")
+  def test_auth_failure_variants_map_to_auth_failure(self, mock_publish):
+    for event_type in (
+      SecurityEventType.AUTH_FAILURE,
+      SecurityEventType.API_KEY_INVALID,
+      SecurityEventType.API_KEY_EXPIRED,
+      SecurityEventType.AUTH_TOKEN_EXPIRED,
+      SecurityEventType.AUTH_TOKEN_INVALID,
+    ):
+      mock_publish.reset_mock()
+      SecurityAuditLogger.log_security_event(event_type=event_type)
+      mock_publish.assert_called_once_with(["AuthFailure"])
+
+  @patch("robosystems.security.audit_logger._publish_security_metrics")
+  def test_operational_events_emit_no_metric(self, mock_publish):
+    for event_type in (
+      SecurityEventType.EMAIL_SENT,
+      SecurityEventType.AUTH_SUCCESS,
+      SecurityEventType.OPERATION_TIMEOUT,
+      SecurityEventType.RATE_LIMIT_EXCEEDED,
+    ):
+      mock_publish.reset_mock()
+      SecurityAuditLogger.log_security_event(event_type=event_type)
+      mock_publish.assert_called_once_with([])
+
+  @patch("robosystems.security.audit_logger._publish_security_metrics")
+  def test_admin_flag_adds_failed_admin_metric(self, mock_publish):
+    SecurityAuditLogger.log_admin_auth_failure(
+      reason="invalid_admin_key",
+      ip_address="203.0.113.7",
+      endpoint="/admin/v1/graphs",
+    )
+    mock_publish.assert_called_once_with(["AuthFailure", "FailedAdminAuth"])
+
+  @patch("robosystems.security.audit_logger._publish_security_metrics")
+  def test_non_admin_auth_failure_omits_admin_metric(self, mock_publish):
+    SecurityAuditLogger.log_security_event(
+      event_type=SecurityEventType.AUTH_FAILURE,
+      details={"failure_reason": "bad password"},
+    )
+    mock_publish.assert_called_once_with(["AuthFailure"])
+
+  @patch("robosystems.security.audit_logger._publish_security_metrics")
+  def test_admin_flag_ignored_for_non_auth_events(self, mock_publish):
+    # A stray admin flag on an unrelated event must not synthesize FailedAdminAuth.
+    SecurityAuditLogger.log_security_event(
+      event_type=SecurityEventType.INJECTION_ATTEMPT,
+      details={"admin": True},
+    )
+    mock_publish.assert_called_once_with(["InjectionAttempt"])
+
+
+class TestPublishSecurityMetrics:
+  """``_publish_security_metrics`` is prod/staging-only and best-effort."""
+
+  @patch("robosystems.security.audit_logger.env")
+  def test_skipped_when_not_prod_or_staging(self, mock_env):
+    mock_env.is_production.return_value = False
+    mock_env.is_staging.return_value = False
+    with patch(
+      "robosystems.security.audit_logger._get_cloudwatch_client"
+    ) as mock_client:
+      _publish_security_metrics(["AuthFailure"])
+      mock_client.assert_not_called()
+
+  @patch("robosystems.security.audit_logger.env")
+  def test_empty_metric_list_is_noop(self, mock_env):
+    mock_env.is_production.return_value = True
+    mock_env.is_staging.return_value = False
+    with patch(
+      "robosystems.security.audit_logger._get_cloudwatch_client"
+    ) as mock_client:
+      _publish_security_metrics([])
+      mock_client.assert_not_called()
+
+  @patch("robosystems.security.audit_logger.env")
+  def test_publishes_to_security_namespace_in_production(self, mock_env):
+    mock_env.is_production.return_value = True
+    mock_env.is_staging.return_value = False
+    mock_env.ENVIRONMENT = "prod"
+    cw = Mock()
+    with patch(
+      "robosystems.security.audit_logger._get_cloudwatch_client", return_value=cw
+    ):
+      _publish_security_metrics(["AuthFailure", "FailedAdminAuth"])
+    cw.put_metric_data.assert_called_once()
+    kwargs = cw.put_metric_data.call_args.kwargs
+    assert kwargs["Namespace"] == "RoboSystems/Security/prod"
+    names = {m["MetricName"] for m in kwargs["MetricData"]}
+    assert names == {"AuthFailure", "FailedAdminAuth"}
+    assert all(m["Value"] == 1 and m["Unit"] == "Count" for m in kwargs["MetricData"])
+
+  @patch("robosystems.security.audit_logger.env")
+  def test_publishes_in_staging(self, mock_env):
+    mock_env.is_production.return_value = False
+    mock_env.is_staging.return_value = True
+    mock_env.ENVIRONMENT = "staging"
+    cw = Mock()
+    with patch(
+      "robosystems.security.audit_logger._get_cloudwatch_client", return_value=cw
+    ):
+      _publish_security_metrics(["InjectionAttempt"])
+    assert cw.put_metric_data.call_args.kwargs["Namespace"] == (
+      "RoboSystems/Security/staging"
+    )
+
+  @patch("robosystems.security.audit_logger.env")
+  def test_publish_failure_is_swallowed(self, mock_env):
+    mock_env.is_production.return_value = True
+    mock_env.is_staging.return_value = False
+    mock_env.ENVIRONMENT = "prod"
+    cw = Mock()
+    cw.put_metric_data.side_effect = RuntimeError("cloudwatch unavailable")
+    with patch(
+      "robosystems.security.audit_logger._get_cloudwatch_client", return_value=cw
+    ):
+      # Must not raise — metrics are best-effort and never break the caller.
+      _publish_security_metrics(["AuthFailure"])
+
+
+class TestAdminAuthFailurePath:
+  """``AdminAuthMiddleware`` records + metricizes invalid admin key attempts."""
+
+  async def test_invalid_admin_key_logs_and_raises(self):
+    from robosystems.middleware.auth.admin import AdminAuthMiddleware
+
+    mw = AdminAuthMiddleware()
+    request = Mock()
+    request.headers = {"Authorization": "Bearer wrong-key", "User-Agent": "pytest"}
+    request.client.host = "203.0.113.7"
+    request.url.path = "/admin/v1/graphs"
+
+    with (
+      patch.object(mw, "verify_admin_key", return_value=None),
+      patch(
+        "robosystems.middleware.auth.admin.SecurityAuditLogger.log_admin_auth_failure"
+      ) as mock_log,
+    ):
+      with pytest.raises(HTTPException) as exc_info:
+        await mw(request)
+
+    assert exc_info.value.status_code == 401
+    mock_log.assert_called_once()
+    kwargs = mock_log.call_args.kwargs
+    assert kwargs["reason"] == "invalid_admin_key"
+    assert kwargs["ip_address"] == "203.0.113.7"
+    assert kwargs["endpoint"] == "/admin/v1/graphs"
+
+  async def test_valid_admin_key_does_not_log_failure(self):
+    from robosystems.middleware.auth.admin import AdminAuthMiddleware
+
+    mw = AdminAuthMiddleware()
+    request = Mock()
+    request.headers = {"Authorization": "Bearer good-key", "User-Agent": "pytest"}
+    request.client.host = "203.0.113.7"
+    request.url.path = "/admin/v1/graphs"
+
+    with (
+      patch.object(
+        mw,
+        "verify_admin_key",
+        return_value={"key_id": "admin", "name": "Admin API Key", "permissions": ["*"]},
+      ),
+      patch(
+        "robosystems.middleware.auth.admin.SecurityAuditLogger.log_admin_auth_failure"
+      ) as mock_log,
+    ):
+      await mw(request)
+
+    mock_log.assert_not_called()


### PR DESCRIPTION
## Summary

Makes the API's security detective controls actually work. Today `FailedAdminAuthAlarm` in `api.yaml` watches a metric that is **never emitted** (the admin-key failure path only `logger.warning`s) and has **no `AlarmActions`**, so it can never fire and would notify no one if it did. Auth failures, injection attempts, and privilege-escalation events are logged but never turned into metrics or alarms. This PR emits those signals as CloudWatch metrics from the single `SecurityAuditLogger` chokepoint and wires them to live, email-backed alarms.

This is **P1** of the audit & observability work — the metrics + alarming slice. Audit-stream retention (the 13-month Type-II trail) and SSM session command-logging are deliberately left as follow-ups.

## Changes

**Metric emission (`robosystems/security/audit_logger.py`)**
- Publish the compliance-relevant subset of security events to `RoboSystems/Security/{env}` from `log_security_event`: `AuthFailure`, `AuthorizationDenied`, `InjectionAttempt` (incl. path-traversal), `PrivilegeEscalationAttempt`. Operational events (`email_sent`, `auth_success`, `operation_timeout`, `rate_limit_exceeded`) are intentionally excluded to keep the stream low-volume and the alarms meaningful.
- Emission is **best-effort and prod/staging-only** — no-op where there's no CloudWatch/credentials, and it never raises into the caller (a metrics failure must not break an auth path).
- Add `log_admin_auth_failure`, which flags the event as admin so a dedicated `FailedAdminAuth` metric is emitted alongside the generic `AuthFailure`.
- Chose `put_metric_data` over EMF: `StructuredFormatter` wraps every log record, so a root-level EMF `_aws` block would not survive the formatter; security events are low-volume, so the per-event API call cost is negligible.

**Admin failure path (`robosystems/middleware/auth/admin.py`)**
- Invalid admin-key attempts now go through `SecurityAuditLogger.log_admin_auth_failure` (previously only a `logger.warning`), so they are both audit-logged and feed `FailedAdminAuth`. Also hardened the client-IP read against a missing `request.client`.

**CloudFormation (`cloudformation/api.yaml`)**
- Add `SNSAlertEmail` param + `HasAlertEmail` condition + `SecurityAlertTopic` (SNS email subscription, created only when an alert email is supplied).
- Repoint `FailedAdminAuthAlarm` from the dead `RoboSystems/Admin` namespace to the live `RoboSystems/Security/${Environment}` and wire its `AlarmActions` to the topic.
- Add companion alarms → same topic: `AuthFailureSpikeAlarm`, `InjectionAttemptAlarm` (>0), `PrivilegeEscalationAlarm` (>0).
- Widen the task role's `cloudwatch:PutMetricData` condition to include the Security namespace.
- Alarms always exist; `AlarmActions` are conditional on `HasAlertEmail` so the stack still deploys cleanly if no email is set.

**Deploy wiring (`.github/workflows/deploy-api.yml`)**
- Thread `SNSAlertEmail` into the api stack params. The `aws_sns_alert_email` input already reaches this deploy (staging/prod pass `vars.AWS_SNS_ALERT_EMAIL`), so no changes to `staging.yml`/`prod.yml` were needed.

**Tests (`tests/security/test_audit_metrics.py`)**
- 16 unit tests: event→metric mapping (incl. admin flag → `FailedAdminAuth`, operational events → no metric), the prod/staging guard, best-effort swallow-on-failure, and the admin middleware failure path both logging and raising 401.

## Testing

- `uv run pytest tests/security/test_audit_metrics.py` — 16 passed.
- `uv run pytest tests/security/ tests/middleware/auth/ tests/routers/admin/` — 721 passed (no regressions).
- `ruff check` / `ruff format --check` / `basedpyright` on changed files — clean. Pre-commit hooks (ruff + format + basedpyright over the repo) passed on commit.
- `cfn-lint -t cloudformation/api.yaml` — clean. (`aws cloudformation validate-template` not run — SSO token expired locally; CI runs it.)
- Full `just test-all` not run locally.

## Notes / Follow-ups

- **P2 — audit-stream retention**: route the audit-event subset to a durable ≥13-month sink (dedicated log group + a compliance retention tier), keeping operational INFO short. This is the actual SOC 2 Type-II evidence trail.
- **SSM session command-logging** (RC-6 residual): cross-stack (account-level `SSM-SessionManagerRunShell` doc + instance-role IAM on the graph/bastion stacks) — deferred to its own change.
- **Behavioral note**: `SNSAlertEmail` is currently set to the same value as `EmailFromAddress` (both from `aws_sns_alert_email`), matching the existing deploy wiring. If a dedicated ops/security distribution list is preferred, that's a one-line workflow change later.
