### PR TITLE
feat(audit): retain security-audit logs to S3 + SSM session command logging

### DIFF
--- a/.github/configs/stacks.yml
+++ b/.github/configs/stacks.yml
@@ -122,6 +122,10 @@ prod:
       web_acl_id: WebACLId
       web_acl_arn: WebACLArn
 
+  # Audit Trail Retention (compliance log forwarding)
+  audit:
+    stack_name: RoboSystemsAuditProd
+
   # GitHub Actions Runner
   gha_runner:
     stack_name: RoboSystemsGHARunner # Shared between environments
@@ -267,6 +271,10 @@ staging:
     outputs:
       web_acl_id: WebACLId
       web_acl_arn: WebACLArn
+
+  # Audit Trail Retention (compliance log forwarding)
+  audit:
+    stack_name: RoboSystemsAuditStaging
 
   # Shared Resources (reference same as prod)
   gha_runner:

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -221,6 +221,23 @@ on:
         type: string
         default: "true"
 
+      # Audit Trail Retention (optional)
+      audit_enabled:
+        description: "Enable long-retention forwarding of audit logs to S3"
+        required: false
+        type: string
+        default: "false"
+      audit_stack_name:
+        description: "CloudFormation stack name for the audit stack"
+        required: false
+        type: string
+        default: ""
+      audit_retention_days:
+        description: "Days to retain audit records in S3 (~13 months = 400)"
+        required: false
+        type: string
+        default: "400"
+
       # Notification Configuration
       aws_sns_alert_email:
         description: "Email address for SNS alerts and notifications"
@@ -527,3 +544,97 @@ jobs:
           echo "Geo Blocking: ${{ inputs.waf_enable_geo_blocking }}"
           echo "AWS Managed Rules: ${{ inputs.waf_enable_aws_managed_rules }}"
           echo "Estimated monthly cost: $ESTIMATED_COST"
+
+  # Audit-log retention as separate job (only runs when enabled).
+  # Needs the API stack so the /robosystems/{env}/api log group exists before
+  # the subscription filter attaches to it.
+  audit:
+    needs: deploy
+    if: inputs.audit_enabled == 'true' && inputs.audit_stack_name != ''
+    runs-on: ${{ fromJSON(inputs.runner_config) }}
+    timeout-minutes: 10
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          repository: ${{ github.repository }}
+          ref: ${{ github.ref }}
+          token: ${{ github.token }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ inputs.aws_region }}
+
+      - name: Deploy Audit Stack
+        run: |
+          echo "Deploying audit-log retention forwarding"
+
+          if aws cloudformation describe-stacks --stack-name ${{ inputs.audit_stack_name }} 2>&1 | grep -q 'Stack with id .* does not exist'; then
+            STACK_ACTION="create-stack"
+            echo "Creating new audit stack: ${{ inputs.audit_stack_name }}"
+          else
+            STACK_ACTION="update-stack"
+            echo "Updating existing audit stack: ${{ inputs.audit_stack_name }}"
+          fi
+
+          AUDIT_PARAMS="ParameterKey=Environment,ParameterValue=${{ inputs.environment }}"
+          AUDIT_PARAMS="$AUDIT_PARAMS ParameterKey=RetentionDays,ParameterValue=${{ inputs.audit_retention_days }}"
+
+          if [ "$STACK_ACTION" = "create-stack" ]; then
+            aws cloudformation $STACK_ACTION \
+              --stack-name ${{ inputs.audit_stack_name }} \
+              --template-body file://cloudformation/audit.yaml \
+              --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM \
+              --parameters $AUDIT_PARAMS \
+              --tags \
+                Key=Environment,Value=${{ inputs.environment }} \
+                Key=Service,Value=RoboSystems \
+                Key=Component,Value=Audit \
+                Key=ManagedBy,Value="GitHub Actions"
+
+            echo "Waiting for audit stack creation..."
+            aws cloudformation wait stack-create-complete \
+              --stack-name ${{ inputs.audit_stack_name }} || {
+              echo "Audit stack creation failed"
+              aws cloudformation describe-stack-events \
+                --stack-name ${{ inputs.audit_stack_name }} \
+                --query 'StackEvents[?ResourceStatus==`CREATE_FAILED`].[LogicalResourceId, ResourceStatusReason]' \
+                --output table
+              exit 1
+            }
+          else
+            UPDATE_OUTPUT=$(aws cloudformation $STACK_ACTION \
+              --stack-name ${{ inputs.audit_stack_name }} \
+              --template-body file://cloudformation/audit.yaml \
+              --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM \
+              --parameters $AUDIT_PARAMS \
+              --tags \
+                Key=Environment,Value=${{ inputs.environment }} \
+                Key=Service,Value=RoboSystems \
+                Key=Component,Value=Audit \
+                Key=ManagedBy,Value="GitHub Actions" \
+              2>&1 || true)
+
+            if echo "$UPDATE_OUTPUT" | grep -q "No updates are to be performed"; then
+              echo "No changes detected in audit stack"
+            else
+              echo "Waiting for audit stack update..."
+              aws cloudformation wait stack-update-complete \
+                --stack-name ${{ inputs.audit_stack_name }} || {
+                echo "Audit stack update failed"
+                aws cloudformation describe-stack-events \
+                  --stack-name ${{ inputs.audit_stack_name }} \
+                  --query 'StackEvents[?ResourceStatus==`UPDATE_FAILED`].[LogicalResourceId, ResourceStatusReason]' \
+                  --output table
+                exit 1
+              }
+            fi
+          fi
+
+          echo "Audit stack deployed successfully"

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -71,6 +71,7 @@ jobs:
       grafana_stack: ${{ steps.load.outputs.grafana_stack }}
       bastion_stack: ${{ steps.load.outputs.bastion_stack }}
       waf_stack: ${{ steps.load.outputs.waf_stack }}
+      audit_stack: ${{ steps.load.outputs.audit_stack }}
       cloudtrail_stack: ${{ steps.load.outputs.cloudtrail_stack }}
       dagster_stack: ${{ steps.load.outputs.dagster_stack }}
       worker_stack: ${{ steps.load.outputs.worker_stack }}
@@ -120,6 +121,7 @@ jobs:
           echo "grafana_stack=$(./bin/tools/stack-config.sh $ENV monitoring.grafana)" >> $GITHUB_OUTPUT
           echo "bastion_stack=$(./bin/tools/stack-config.sh $ENV bastion)" >> $GITHUB_OUTPUT
           echo "waf_stack=$(./bin/tools/stack-config.sh $ENV waf)" >> $GITHUB_OUTPUT
+          echo "audit_stack=$(./bin/tools/stack-config.sh $ENV audit)" >> $GITHUB_OUTPUT
           echo "cloudtrail_stack=$(./bin/tools/stack-config.sh $ENV cloudtrail)" >> $GITHUB_OUTPUT
           echo "dagster_stack=$(./bin/tools/stack-config.sh $ENV dagster)" >> $GITHUB_OUTPUT
           echo "worker_stack=$(./bin/tools/stack-config.sh $ENV workers)" >> $GITHUB_OUTPUT
@@ -567,6 +569,9 @@ jobs:
       waf_rate_limit_per_ip: ${{ vars.WAF_RATE_LIMIT_PER_IP || '3000' }}
       waf_enable_geo_blocking: ${{ vars.WAF_GEO_BLOCKING_ENABLED || 'false' }}
       waf_enable_aws_managed_rules: ${{ vars.WAF_AWS_MANAGED_RULES_ENABLED || 'true' }}
+      audit_enabled: ${{ vars.AUDIT_ENABLED_PROD || 'false' }}
+      audit_stack_name: ${{ needs.stack-config.outputs.audit_stack }}
+      audit_retention_days: ${{ vars.AUDIT_RETENTION_DAYS || '400' }}
       # S3 Bucket Configuration (from S3 stack outputs)
       shared_processed_bucket_arn: ${{ needs.deploy-s3.outputs.shared_processed_bucket_arn }}
       deployment_bucket_arn: ${{ needs.deploy-s3.outputs.deployment_bucket_arn }}

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -96,6 +96,7 @@ jobs:
       grafana_stack: ${{ steps.load.outputs.grafana_stack }}
       bastion_stack: ${{ steps.load.outputs.bastion_stack }}
       waf_stack: ${{ steps.load.outputs.waf_stack }}
+      audit_stack: ${{ steps.load.outputs.audit_stack }}
       cloudtrail_stack: ${{ steps.load.outputs.cloudtrail_stack }}
       dagster_stack: ${{ steps.load.outputs.dagster_stack }}
       worker_stack: ${{ steps.load.outputs.worker_stack }}
@@ -146,6 +147,7 @@ jobs:
           echo "grafana_stack=$(./bin/tools/stack-config.sh $ENV monitoring.grafana)" >> $GITHUB_OUTPUT
           echo "bastion_stack=$(./bin/tools/stack-config.sh $ENV bastion)" >> $GITHUB_OUTPUT
           echo "waf_stack=$(./bin/tools/stack-config.sh $ENV waf)" >> $GITHUB_OUTPUT
+          echo "audit_stack=$(./bin/tools/stack-config.sh $ENV audit)" >> $GITHUB_OUTPUT
           echo "cloudtrail_stack=$(./bin/tools/stack-config.sh $ENV cloudtrail)" >> $GITHUB_OUTPUT
           echo "dagster_stack=$(./bin/tools/stack-config.sh $ENV dagster)" >> $GITHUB_OUTPUT
           echo "worker_stack=$(./bin/tools/stack-config.sh $ENV workers)" >> $GITHUB_OUTPUT
@@ -584,6 +586,9 @@ jobs:
       waf_rate_limit_per_ip: ${{ vars.WAF_RATE_LIMIT_PER_IP || '3000' }}
       waf_enable_geo_blocking: ${{ vars.WAF_GEO_BLOCKING_ENABLED || 'false' }}
       waf_enable_aws_managed_rules: ${{ vars.WAF_AWS_MANAGED_RULES_ENABLED || 'true' }}
+      audit_enabled: ${{ vars.AUDIT_ENABLED_STAGING || 'false' }}
+      audit_stack_name: ${{ needs.stack-config.outputs.audit_stack }}
+      audit_retention_days: ${{ vars.AUDIT_RETENTION_DAYS || '400' }}
       # S3 Bucket Configuration (from S3 stack outputs)
       shared_processed_bucket_arn: ${{ needs.deploy-s3.outputs.shared_processed_bucket_arn }}
       deployment_bucket_arn: ${{ needs.deploy-s3.outputs.deployment_bucket_arn }}

--- a/bin/setup/README.md
+++ b/bin/setup/README.md
@@ -392,6 +392,8 @@ just setup-gha
 | `CLOUDTRAIL_LOG_RETENTION_DAYS`  | `90`     | CloudTrail retention |
 | `CLOUDTRAIL_DATA_EVENTS_ENABLED` | `false`  | Log S3 data events   |
 | `SECRETS_ROTATION_ENABLED_*`     | `false`  | Monthly key rotation |
+| `AUDIT_ENABLED_*`                | `false`  | Retain audit logs to S3 |
+| `AUDIT_RETENTION_DAYS`           | `400`    | Audit S3 retention (days) |
 
 #### WAF Configuration
 

--- a/bin/setup/gha.sh
+++ b/bin/setup/gha.sh
@@ -506,6 +506,14 @@ function setup_full_config() {
         gh variable set WAF_ENABLED_STAGING --body "false"
     fi
 
+    # Audit Trail Retention (environment-specific) - disabled by default
+    # Forwards security-audit logs to a long-retention S3 bucket when enabled.
+    gh variable set AUDIT_ENABLED_PROD --body "false"
+    gh variable set AUDIT_RETENTION_DAYS --body "400"
+    if $setup_staging; then
+        gh variable set AUDIT_ENABLED_STAGING --body "false"
+    fi
+
     # Infrastructure Configuration
     gh variable set VPC_MAX_AVAILABILITY_ZONES --body "2"
     # VPC Endpoint Mode: 'gateway' (free S3+DynamoDB), 'minimal' (~$22/mo), 'full' (~$45/mo)

--- a/cloudformation/audit.yaml
+++ b/cloudformation/audit.yaml
@@ -1,0 +1,199 @@
+Description: RoboSystems Audit Service - Long-Retention Forwarding of Security-Audit Logs to S3
+
+# Forwards ONLY the compliance-relevant audit records out of the API log group
+# (/robosystems/{env}/api) to a dedicated, long-retention S3 bucket, so security
+# evidence survives the short operational-log retention. Entirely log-side: a
+# CloudWatch Logs subscription filter -> Kinesis Firehose -> S3. No application
+# code and nothing on the request path. Deployed by the `audit` job in
+# deploy-api.yml, gated on the AUDIT_ENABLED_{PROD,STAGING} variable (mirrors WAF).
+
+Parameters:
+  # Environment
+  Environment:
+    Type: String
+    Description: Environment name (e.g., prod, staging)
+    Default: prod
+    AllowedValues:
+      - prod
+      - staging
+    ConstraintDescription: Must be prod or staging
+
+  # Retention
+  RetentionDays:
+    Type: Number
+    Description: Days to retain audit records in S3 (default ~13 months for a SOC 2 Type II window)
+    Default: 400
+    MinValue: 1
+    MaxValue: 2555
+
+  # Tagging Configuration
+  ServiceTag:
+    Type: String
+    Description: Service tag for resource identification and billing
+    Default: RoboSystems
+  ComponentTag:
+    Type: String
+    Description: Component tag for resource identification and billing
+    Default: Audit
+
+Resources:
+  # Durable, versioned, private bucket for the retained audit evidence.
+  AuditBucket:
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      BucketName: !Sub robosystems-audit-${Environment}-${AWS::AccountId}
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      VersioningConfiguration:
+        Status: Enabled
+      LifecycleConfiguration:
+        Rules:
+          - Id: AuditRetention
+            Status: Enabled
+            Transitions:
+              - TransitionInDays: 0
+                StorageClass: INTELLIGENT_TIERING
+            ExpirationInDays: !Ref RetentionDays
+            NoncurrentVersionExpirationInDays: !Ref RetentionDays
+      Tags:
+        - Key: Name
+          Value: !Sub ${ServiceTag}-audit-${Environment}
+        - Key: Environment
+          Value: !Ref Environment
+        - Key: Service
+          Value: !Ref ServiceTag
+        - Key: Component
+          Value: !Ref ComponentTag
+        - Key: Purpose
+          Value: SOC2-Compliance
+        - Key: CreatedBy
+          Value: CloudFormation
+
+  # Error/diagnostics stream for the Firehose delivery (short retention).
+  FirehoseLogGroup:
+    Type: AWS::Logs::LogGroup
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Retain
+    Properties:
+      LogGroupName: !Sub /robosystems/${Environment}/audit-firehose
+      RetentionInDays: 30
+
+  FirehoseLogStream:
+    Type: AWS::Logs::LogStream
+    Properties:
+      LogGroupName: !Ref FirehoseLogGroup
+      LogStreamName: S3Delivery
+
+  # Role Firehose assumes to write delivered records to the audit bucket.
+  FirehoseRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub robosystems-audit-firehose-${Environment}
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: firehose.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: !Sub robosystems-audit-firehose-${Environment}
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:AbortMultipartUpload
+                  - s3:GetBucketLocation
+                  - s3:GetObject
+                  - s3:ListBucket
+                  - s3:ListBucketMultipartUploads
+                  - s3:PutObject
+                Resource:
+                  - !GetAtt AuditBucket.Arn
+                  - !Sub ${AuditBucket.Arn}/*
+              - Effect: Allow
+                Action:
+                  - logs:PutLogEvents
+                Resource: !GetAtt FirehoseLogGroup.Arn
+
+  # Direct-put Firehose stream: subscription filter -> here -> S3 (gzip, buffered).
+  AuditFirehose:
+    Type: AWS::KinesisFirehose::DeliveryStream
+    Properties:
+      DeliveryStreamName: !Sub robosystems-audit-${Environment}
+      DeliveryStreamType: DirectPut
+      ExtendedS3DestinationConfiguration:
+        BucketARN: !GetAtt AuditBucket.Arn
+        RoleARN: !GetAtt FirehoseRole.Arn
+        Prefix: !Sub audit/${Environment}/
+        ErrorOutputPrefix: !Sub audit-errors/${Environment}/
+        BufferingHints:
+          IntervalInSeconds: 300
+          SizeInMBs: 5
+        CompressionFormat: GZIP
+        CloudWatchLoggingOptions:
+          Enabled: true
+          LogGroupName: !Ref FirehoseLogGroup
+          LogStreamName: !Ref FirehoseLogStream
+
+  # Role CloudWatch Logs assumes to push matching events into Firehose.
+  SubscriptionFilterRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub robosystems-audit-cwl-${Environment}
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: !Sub logs.${AWS::Region}.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: !Sub robosystems-audit-cwl-${Environment}
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - firehose:PutRecord
+                  - firehose:PutRecordBatch
+                Resource: !GetAtt AuditFirehose.Arn
+
+  # Forward only audit records from the API log group. The pattern OR-matches the
+  # two audit streams: SecurityAuditLogger's "SECURITY_AUDIT:" messages and the
+  # operation-audit records (structured "audit": key). Operational INFO stays put.
+  AuditSubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      LogGroupName: !Sub /robosystems/${Environment}/api
+      FilterName: !Sub robosystems-audit-${Environment}
+      FilterPattern: '?SECURITY_AUDIT ?"\"audit\":"'
+      DestinationArn: !GetAtt AuditFirehose.Arn
+      RoleArn: !GetAtt SubscriptionFilterRole.Arn
+
+Outputs:
+  AuditBucketName:
+    Description: S3 bucket retaining the forwarded audit records
+    Value: !Ref AuditBucket
+    Export:
+      Name: !Sub ${AWS::StackName}-AuditBucket
+
+  AuditFirehoseArn:
+    Description: ARN of the audit Firehose delivery stream
+    Value: !GetAtt AuditFirehose.Arn
+    Export:
+      Name: !Sub ${AWS::StackName}-AuditFirehoseArn
+
+  EstimatedMonthlyCost:
+    Description: Rough monthly cost (Firehose + S3 at audit-event volume)
+    Value: "~$1-3/month (Firehose ingestion + S3 storage at low audit volume)"

--- a/cloudformation/cloudtrail.yaml
+++ b/cloudformation/cloudtrail.yaml
@@ -185,6 +185,57 @@ Resources:
         - Key: Purpose
           Value: SOC2-Compliance
 
+  # SSM Session Manager command logging — captures the commands run during
+  # bastion `start-session` shells (admin-tunnel accountability beyond
+  # CloudTrail's "who connected"). The SSM-SessionManagerRunShell document is
+  # account/region-global, so it lives in this single shared stack rather than
+  # the per-env bastion stacks (which would collide on the reserved name). The
+  # bastion instance role already carries logs:CreateLogStream/PutLogEvents.
+  SessionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Condition: CreateCloudTrail
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      LogGroupName: /robosystems/ssm-sessions
+      RetentionInDays: 400
+      Tags:
+        - Key: Environment
+          Value: !Ref Environment
+        - Key: Service
+          Value: !Ref ServiceTag
+        - Key: Component
+          Value: !Ref ComponentTag
+        - Key: Purpose
+          Value: SOC2-Compliance
+
+  SessionManagerPreferences:
+    Type: AWS::SSM::Document
+    Condition: CreateCloudTrail
+    Properties:
+      Name: SSM-SessionManagerRunShell
+      DocumentType: Session
+      DocumentFormat: JSON
+      Content:
+        schemaVersion: "1.0"
+        description: Session Manager preferences with CloudWatch command logging
+        sessionType: Standard_Stream
+        inputs:
+          cloudWatchLogGroupName: !Ref SessionLogGroup
+          cloudWatchEncryptionEnabled: false
+          cloudWatchStreamingEnabled: true
+          idleSessionTimeout: "20"
+          runAsEnabled: false
+          shellProfile:
+            linux: ""
+      Tags:
+        - Key: Environment
+          Value: !Ref Environment
+        - Key: Service
+          Value: !Ref ServiceTag
+        - Key: Component
+          Value: !Ref ComponentTag
+
 Outputs:
   CloudTrailArn:
     Description: ARN of the CloudTrail


### PR DESCRIPTION
## Summary

P2 of the audit-observability spec plus the RC-6 SSM residual. Compliance-relevant audit records currently live in the 7-day `/robosystems/{env}/api` log group, commingled with operational INFO — there's no long-lived, separate evidence trail. And admin bastion sessions record *who connected* (CloudTrail) but not *what ran*. This PR adds both, **infra-only and gated OFF by default** (no application code, nothing on the request path).

## Changes

**Audit-log retention — `cloudformation/audit.yaml` (new, modeled on `waf.yaml`)**
- A CloudWatch Logs **subscription filter** on `/robosystems/${Environment}/api` forwards ONLY audit records — filter pattern `?SECURITY_AUDIT ?"\"audit\":"` OR-matches the two audit streams (`SecurityAuditLogger`'s `SECURITY_AUDIT:` messages and the operation-audit records that carry a structured `"audit":` key). Operational INFO stays in the short-retention group.
- Filter → **Kinesis Firehose** (`DirectPut`, GZIP, 5 MB / 300 s buffering) → a dedicated **S3 audit bucket**: versioned, all-public-access-blocked, AES256, `INTELLIGENT_TIERING`, with a **13-month lifecycle** (`RetentionDays` param, default 400). Two IAM roles (Firehose→S3, CloudWatch-Logs→Firehose) and a short-retention Firehose error log group round it out.
- Chose this log-side forward over the spec's tentative "dedicated log group + in-app shipper": the ECS `awslogs` driver ships all stdout to one group, so that option would mean an in-process CloudWatch-Logs writer — new app-runtime surface and the event-loop risk the P1 review flagged. This keeps everything off the request path.

**Deploy wiring — gated `audit` job (no new workflow)**
- `deploy-api.yml`: three new optional inputs (`audit_enabled`, `audit_stack_name`, `audit_retention_days`) and a new `audit` job that mirrors the existing `waf` job (`needs: deploy` so the API log group exists before the filter attaches; create/update/wait with the standard failure diagnostics).
- `stacks.yml`: `audit` stack entries in both env blocks (`RoboSystemsAudit{Prod,Staging}`), auto-resolved by the generic `stack-config.sh`.
- `staging.yml` / `prod.yml`: `audit_stack` stack-config output + echo, and `audit_enabled`/`audit_stack_name`/`audit_retention_days` passed to the api job — identical pattern to WAF. Toggle: `AUDIT_ENABLED_{PROD,STAGING}` (default `false`).

**SSM session command logging — `cloudformation/cloudtrail.yaml`**
- Adds an account-global `SSM-SessionManagerRunShell` (`AWS::SSM::Document`, `DocumentType: Session`) that streams shell commands to a new **400-day `/robosystems/ssm-sessions`** CloudWatch log group. Placed in the single shared `RoboSystemsCloudTrail` stack because the document name is account/region-global (the per-env bastion stacks would collide on it). The bastion instance role already carries `logs:CreateLogStream/PutLogEvents`, so no IAM change. Both resources are gated on the existing `CreateCloudTrail` condition.

## Testing

- `cfn-lint -t cloudformation/*.yaml` — clean (CI parity).
- `pytest tests/infrastructure/test_cloudformation.py` — **20 passed** (the new `audit.yaml` is auto-covered by the parametrized size/validity checks; `api.yaml` is untouched, so its inline-limit test still passes).
- `stack-config.sh {prod,staging} audit` → `RoboSystemsAudit{Prod,Staging}`.
- All three workflows + `stacks.yml` parse as YAML.
- No Python changed, so no unit tests apply. `aws cloudformation validate-template` and live deploy were **not run** (no AWS session in this environment) — CI runs cfn-lint; the items below are first-deploy-verify.

## Notes / Follow-ups

- **Rollout is opt-in.** Audit retention stays off until `AUDIT_ENABLED_{PROD,STAGING}` is set to `true`, then a deploy creates the stack.
- **SSM logging deploys with the CloudTrail stack** on the next staging/prod run (`CLOUDTRAIL_ENABLED` is already `true`) — it is not behind a separate toggle. **First-deploy risk:** if a console-created `SSM-SessionManagerRunShell` already exists in the account, the CFN create collides — import or rename if so.
- **First-deploy-verify (data, easily adjusted):** the subscription-filter pattern (tune if it under/over-matches); and CWL→Firehose delivers gzipped CloudWatch-Logs-format records, so S3 objects are double-gzip — a Firehose processing Lambda to emit clean JSON is a deferred P3 nicety, along with S3 Object Lock/WORM.
