### PR TITLE
fix(iam): grant firehose + PassRole to deploy role for audit stack

### DIFF
--- a/cloudformation/bootstrap-oidc.yaml
+++ b/cloudformation/bootstrap-oidc.yaml
@@ -327,6 +327,13 @@ Resources:
                   - cloudtrail:*
                 Resource: "*"
 
+              # Kinesis Data Firehose (audit-log retention forwarding)
+              - Sid: Firehose
+                Effect: Allow
+                Action:
+                  - firehose:*
+                Resource: "*"
+
               # SNS
               - Sid: SNS
                 Effect: Allow

--- a/cloudformation/bootstrap-oidc.yaml
+++ b/cloudformation/bootstrap-oidc.yaml
@@ -182,6 +182,17 @@ Resources:
                       - grafana.amazonaws.com
                       - cloudfront.amazonaws.com
 
+              # PassRole for audit-stack service roles — the Firehose delivery
+              # role and the CloudWatch Logs subscription-filter role. Scoped to
+              # the audit roles by ARN, so no PassedToService condition is needed
+              # (covers both the firehose and logs service principals in one).
+              - Sid: IAMPassRoleAudit
+                Effect: Allow
+                Action:
+                  - iam:PassRole
+                Resource:
+                  - !Sub arn:aws:iam::${AWS::AccountId}:role/robosystems-audit-*
+
               # EC2
               - Sid: EC2
                 Effect: Allow


### PR DESCRIPTION
## Summary

Grants the GitHub Actions OIDC deploy role the two IAM permissions the audit stack (#810) needs. The staging deploy of `RoboSystemsAuditStaging` failed because Kinesis Data Firehose is a service this codebase hadn't used before, so the deploy role had neither `firehose:*` nor `iam:PassRole` for the audit service roles. Both gaps are fixed here; the fix was validated by re-deploying staging to `CREATE_COMPLETE`.

## Changes

**`cloudformation/bootstrap-oidc.yaml`** (deploy role `RoboSystemsDeploymentPolicy`)
- **`firehose:*`** — new `Firehose` statement, matching the existing broad per-service grants (`wafv2:*`, `cloudtrail:*`, `sns:*`). Without it, `AWS::KinesisFirehose::DeliveryStream` creation failed with `not authorized to perform firehose:DescribeDeliveryStream`.
- **`iam:PassRole` for `robosystems-audit-*` roles** — new resource-scoped `IAMPassRoleAudit` statement. The existing `IAMPassRole` is gated by an `iam:PassedToService` allowlist that includes neither `firehose.amazonaws.com` (to pass the Firehose delivery role) nor the `logs` principal (to pass the subscription-filter role). Scoping by role ARN with no service condition covers both audit passes in one grant, without widening the general PassRole allowlist.

`logs:*` already covered `PutSubscriptionFilter`, and `ssm:*` already covered the SSM session document — those deployed fine — so Firehose + its PassRole were the only two gaps.

## Testing

- `cfn-lint -t cloudformation/bootstrap-oidc.yaml` — clean.
- **Validated live on staging**: after `just bootstrap` applied both grants (verified present in the live `RoboSystemsDeploymentPolicy`), the `audit` deploy job succeeded and `RoboSystemsAuditStaging` reached `CREATE_COMPLETE`. Confirmed the full pipeline is wired: audit S3 bucket present, Firehose `ACTIVE` → the bucket, and a subscription filter on `/robosystems/staging/api` (pattern `?SECURITY_AUDIT ?"\"audit\":"`) → the Firehose.
- No application code changed.

## Notes / Follow-ups

- The live deploy role already carries these grants (bootstrapped from this branch to unblock staging), and the role is account-global — so the next **prod** deploy's `audit` job should create `RoboSystemsAuditProd` with no extra steps. This PR is what puts the grants on `main` so a future re-bootstrap from `main` doesn't drop them.
- Optional hardening (deferred): teach the `audit`/`waf` deploy jobs to auto-delete a `ROLLBACK_COMPLETE` stack before re-creating, so a failed first-create self-heals instead of needing a manual stack + retained-bucket cleanup.
