### PR TITLE
feat(security): add off-by-default account security baseline stack

### DIFF
--- a/.github/configs/stacks.yml
+++ b/.github/configs/stacks.yml
@@ -146,6 +146,10 @@ prod:
       bucket_name: CloudTrailBucketName
       enabled: CloudTrailEnabled
 
+  # Security Baseline (GuardDuty, Security Hub, Config, Access Analyzer)
+  security:
+    stack_name: RoboSystemsSecurity # Shared between environments (account-global)
+
   # Dagster Orchestration
   dagster:
     stack_name: RoboSystemsDagsterProd
@@ -294,6 +298,10 @@ staging:
       trail_arn: CloudTrailArn
       bucket_name: CloudTrailBucketName
       enabled: CloudTrailEnabled
+
+  # Security Baseline (GuardDuty, Security Hub, Config, Access Analyzer)
+  security:
+    stack_name: RoboSystemsSecurity # Shared between environments (account-global)
 
   # Dagster Orchestration
   dagster:

--- a/.github/workflows/deploy-vpc.yml
+++ b/.github/workflows/deploy-vpc.yml
@@ -88,6 +88,23 @@ on:
         type: string
         default: ""
 
+      # Security Baseline Configuration (account-global detective controls, SOC 2)
+      security_enabled:
+        description: "Enable the account-global security baseline (GuardDuty, Security Hub, Access Analyzer, optional Config + Inspector)"
+        required: false
+        type: string
+        default: "false"
+      security_stack_name:
+        description: "Security baseline CloudFormation stack name"
+        required: false
+        type: string
+        default: "RoboSystemsSecurity"
+      security_config_enabled:
+        description: "Enable the AWS Config recorder inside the security stack (cost scales with resource count)"
+        required: false
+        type: string
+        default: "false"
+
     outputs:
       vpc_id:
         description: "VPC ID"
@@ -349,3 +366,114 @@ jobs:
           stack-name: "${{ inputs.cloudtrail_stack_name }}"
           timeout: "900"
           interval: "10"
+
+  # Security baseline deployment as a separate job (only runs when enabled).
+  # Account-global detective controls — a sibling to the cloudtrail job, gated
+  # on its own SECURITY_ENABLED variable so the two toggle independently.
+  security:
+    needs: deploy
+    if: inputs.security_enabled == 'true'
+    runs-on: ${{ fromJSON(inputs.runner_config) }}
+    timeout-minutes: 15
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          repository: ${{ github.repository }}
+          ref: ${{ github.ref }}
+          token: ${{ github.token }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ inputs.aws_region }}
+
+      - name: Deploy Security Baseline Stack
+        id: deploy-security
+        run: |
+          SECURITY_STACK_NAME="${{ inputs.security_stack_name }}"
+          echo "Deploying security baseline stack: $SECURITY_STACK_NAME"
+
+          if aws cloudformation describe-stacks --stack-name $SECURITY_STACK_NAME 2>&1 | grep -q 'Stack with id .* does not exist'; then
+            STACK_ACTION="create-stack"
+            echo "Creating new security stack $SECURITY_STACK_NAME"
+          else
+            STACK_ACTION="update-stack"
+            echo "Updating existing security stack $SECURITY_STACK_NAME"
+          fi
+
+          # The security services are account-global; VPC deploys as 'shared'
+          # for production, so normalize to 'prod' for tagging.
+          if [ "${{ inputs.environment }}" = "shared" ]; then
+            SECURITY_ENV="prod"
+          else
+            SECURITY_ENV="${{ inputs.environment }}"
+          fi
+
+          SECURITY_PARAMS="ParameterKey=Environment,ParameterValue=$SECURITY_ENV \
+                      ParameterKey=EnableConfig,ParameterValue=${{ inputs.security_config_enabled }}"
+
+          echo "AWS Config recorder enabled: ${{ inputs.security_config_enabled }}"
+
+          if [ "$STACK_ACTION" = "create-stack" ]; then
+            aws cloudformation $STACK_ACTION \
+              --stack-name $SECURITY_STACK_NAME \
+              --template-body file://cloudformation/security.yaml \
+              --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM \
+              --parameters $SECURITY_PARAMS \
+              --tags \
+                Key=Environment,Value=${{ inputs.environment }} \
+                Key=Service,Value=RoboSystems \
+                Key=Component,Value=Security \
+                Key=Repository,Value=${{ github.repository }} \
+                Key=CreatedBy,Value=GitHubActions || {
+                  echo "Failed to create security stack"
+                  exit 1
+                }
+          else
+            UPDATE_OUTPUT=$(aws cloudformation $STACK_ACTION \
+              --stack-name $SECURITY_STACK_NAME \
+              --template-body file://cloudformation/security.yaml \
+              --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM \
+              --parameters $SECURITY_PARAMS \
+              --tags \
+                Key=Environment,Value=${{ inputs.environment }} \
+                Key=Service,Value=RoboSystems \
+                Key=Component,Value=Security \
+                Key=Repository,Value=${{ github.repository }} \
+                Key=CreatedBy,Value=GitHubActions 2>&1) || true
+
+            if echo "$UPDATE_OUTPUT" | grep -q "No updates are to be performed"; then
+              echo "Security stack is already up to date - no changes needed"
+            elif echo "$UPDATE_OUTPUT" | grep -q "error"; then
+              echo "Error updating security stack: $UPDATE_OUTPUT"
+              exit 1
+            else
+              echo "Security stack update initiated successfully"
+            fi
+          fi
+
+      - name: Monitor Security Stack Deployment
+        uses: ./.github/actions/monitor-stack-deployment
+        with:
+          stack-name: "${{ inputs.security_stack_name }}"
+          timeout: "900"
+          interval: "10"
+
+      # Amazon Inspector v2 has no native single-account CloudFormation resource,
+      # so enable it here via the idempotent inspector2:enable API. Re-running is
+      # safe — already-enabled resource types are returned unchanged.
+      - name: Enable Amazon Inspector
+        run: |
+          ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+          echo "Enabling Amazon Inspector (EC2, ECR, LAMBDA) for account $ACCOUNT_ID"
+          aws inspector2 enable \
+            --resource-types EC2 ECR LAMBDA \
+            --account-ids "$ACCOUNT_ID" || {
+              echo "inspector2:enable returned non-zero (may already be enabled) — continuing"
+            }

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -73,6 +73,7 @@ jobs:
       waf_stack: ${{ steps.load.outputs.waf_stack }}
       audit_stack: ${{ steps.load.outputs.audit_stack }}
       cloudtrail_stack: ${{ steps.load.outputs.cloudtrail_stack }}
+      security_stack: ${{ steps.load.outputs.security_stack }}
       dagster_stack: ${{ steps.load.outputs.dagster_stack }}
       worker_stack: ${{ steps.load.outputs.worker_stack }}
       opensearch_stack: ${{ steps.load.outputs.opensearch_stack }}
@@ -123,6 +124,7 @@ jobs:
           echo "waf_stack=$(./bin/tools/stack-config.sh $ENV waf)" >> $GITHUB_OUTPUT
           echo "audit_stack=$(./bin/tools/stack-config.sh $ENV audit)" >> $GITHUB_OUTPUT
           echo "cloudtrail_stack=$(./bin/tools/stack-config.sh $ENV cloudtrail)" >> $GITHUB_OUTPUT
+          echo "security_stack=$(./bin/tools/stack-config.sh $ENV security)" >> $GITHUB_OUTPUT
           echo "dagster_stack=$(./bin/tools/stack-config.sh $ENV dagster)" >> $GITHUB_OUTPUT
           echo "worker_stack=$(./bin/tools/stack-config.sh $ENV workers)" >> $GITHUB_OUTPUT
           echo "opensearch_stack=$(./bin/tools/stack-config.sh $ENV opensearch)" >> $GITHUB_OUTPUT
@@ -197,6 +199,10 @@ jobs:
       cloudtrail_enabled: ${{ vars.CLOUDTRAIL_ENABLED || 'false' }}
       cloudtrail_log_retention_days: ${{ vars.CLOUDTRAIL_LOG_RETENTION_DAYS || '90' }}
       cloudtrail_data_events_enabled: ${{ vars.CLOUDTRAIL_DATA_EVENTS_ENABLED || 'false' }}
+      # Security Baseline Configuration (account-level, not environment-specific)
+      security_enabled: ${{ vars.SECURITY_ENABLED || 'false' }}
+      security_stack_name: ${{ needs.stack-config.outputs.security_stack }}
+      security_config_enabled: ${{ vars.SECURITY_CONFIG_ENABLED || 'false' }}
     secrets: inherit
 
   deploy-s3:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -98,6 +98,7 @@ jobs:
       waf_stack: ${{ steps.load.outputs.waf_stack }}
       audit_stack: ${{ steps.load.outputs.audit_stack }}
       cloudtrail_stack: ${{ steps.load.outputs.cloudtrail_stack }}
+      security_stack: ${{ steps.load.outputs.security_stack }}
       dagster_stack: ${{ steps.load.outputs.dagster_stack }}
       worker_stack: ${{ steps.load.outputs.worker_stack }}
       opensearch_stack: ${{ steps.load.outputs.opensearch_stack }}
@@ -149,6 +150,7 @@ jobs:
           echo "waf_stack=$(./bin/tools/stack-config.sh $ENV waf)" >> $GITHUB_OUTPUT
           echo "audit_stack=$(./bin/tools/stack-config.sh $ENV audit)" >> $GITHUB_OUTPUT
           echo "cloudtrail_stack=$(./bin/tools/stack-config.sh $ENV cloudtrail)" >> $GITHUB_OUTPUT
+          echo "security_stack=$(./bin/tools/stack-config.sh $ENV security)" >> $GITHUB_OUTPUT
           echo "dagster_stack=$(./bin/tools/stack-config.sh $ENV dagster)" >> $GITHUB_OUTPUT
           echo "worker_stack=$(./bin/tools/stack-config.sh $ENV workers)" >> $GITHUB_OUTPUT
           echo "opensearch_stack=$(./bin/tools/stack-config.sh $ENV opensearch)" >> $GITHUB_OUTPUT
@@ -214,6 +216,10 @@ jobs:
       cloudtrail_enabled: ${{ vars.CLOUDTRAIL_ENABLED || 'false' }}
       cloudtrail_log_retention_days: ${{ vars.CLOUDTRAIL_LOG_RETENTION_DAYS || '90' }}
       cloudtrail_data_events_enabled: ${{ vars.CLOUDTRAIL_DATA_EVENTS_ENABLED || 'false' }}
+      # Security Baseline Configuration (account-level, not environment-specific)
+      security_enabled: ${{ vars.SECURITY_ENABLED || 'false' }}
+      security_stack_name: ${{ needs.stack-config.outputs.security_stack }}
+      security_config_enabled: ${{ vars.SECURITY_CONFIG_ENABLED || 'false' }}
     secrets: inherit
 
   deploy-s3:

--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ pip install robosystems-client
 **Security & Compliance:**
 
 - **[SECURITY.md](/SECURITY.md)** - Security control catalog with implementation references
-- **[Security & Compliance (Wiki)](https://github.com/RoboFinSystems/robosystems/wiki/Security-and-Compliance)** - Operator guide: the optional compliance stacks, their toggles, and the SOC 2 posture for forks
+- **[Compliance](https://github.com/RoboFinSystems/robosystems/wiki/Security-and-Compliance)** - Compliance stacks, toggles, and SOC 2 posture
 
 ## API Reference
 

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ pip install robosystems-client
 
 **Getting Started & Platform:**
 
-- [Home / Overview](https://github.com/RoboFinSystems/robosystems/wiki) · [Quick Start](https://github.com/RoboFinSystems/robosystems/wiki/Quick-Start) · [Core Concepts](https://github.com/RoboFinSystems/robosystems/wiki/Core-Concepts) · [Architecture Overview](https://github.com/RoboFinSystems/robosystems/wiki/Architecture-Overview) · [Bootstrap Guide](https://github.com/RoboFinSystems/robosystems/wiki/Bootstrap-Guide)
+- [Home / Overview](https://github.com/RoboFinSystems/robosystems/wiki) · [Quick Start](https://github.com/RoboFinSystems/robosystems/wiki/Quick-Start) · [Core Concepts](https://github.com/RoboFinSystems/robosystems/wiki/Core-Concepts) · [Architecture Overview](https://github.com/RoboFinSystems/robosystems/wiki/Architecture-Overview) · [Bootstrap Guide](https://github.com/RoboFinSystems/robosystems/wiki/Bootstrap-Guide) · [Security & Compliance](https://github.com/RoboFinSystems/robosystems/wiki/Security-and-Compliance)
 
 **Operations Layer:**
 
@@ -340,7 +340,8 @@ pip install robosystems-client
 
 **Security & Compliance:**
 
-- **[SECURITY.md](/SECURITY.md)** - Security features and compliance configuration
+- **[SECURITY.md](/SECURITY.md)** - Security control catalog with implementation references
+- **[Security & Compliance (Wiki)](https://github.com/RoboFinSystems/robosystems/wiki/Security-and-Compliance)** - Operator guide: the optional compliance stacks, their toggles, and the SOC 2 posture for forks
 
 ## API Reference
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -291,6 +291,26 @@ Optional features disabled by default to minimize costs. Configured as CloudForm
 - AES256 encryption at rest
 - Tagged as SOC2-Compliance
 
+### Security Baseline (Detective Controls)
+
+**Implementation:** `cloudformation/security.yaml`
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `SECURITY_ENABLED` (GitHub variable) | Enable/disable the baseline stack | `false` |
+| `EnableGuardDuty` | GuardDuty threat detection | `true` |
+| `EnableSecurityHub` | Security Hub + AWS FSBP standard | `true` |
+| `EnableCISStandard` | Also enable the CIS Foundations benchmark | `false` |
+| `EnableAccessAnalyzer` | IAM Access Analyzer (account scope) | `true` |
+| `EnableConfig` (`SECURITY_CONFIG_ENABLED` GitHub variable) | AWS Config recorder | `false` |
+
+- Account-global shared stack (`RoboSystemsSecurity`), deployed by the gated `security` job in `deploy-vpc.yml` (sibling to the CloudTrail job)
+- GuardDuty, Security Hub (FSBP), and Access Analyzer enable together via `SECURITY_ENABLED`; AWS Config is gated separately (`SECURITY_CONFIG_ENABLED`) as the cost outlier
+- Amazon Inspector v2 is enabled via an idempotent `inspector2:enable` step in the deploy job (no native single-account CloudFormation resource)
+- AWS Config records to a dedicated versioned, AES256-encrypted, retained S3 bucket
+- Deploy-role IAM grants for these services live in `cloudformation/bootstrap-oidc.yaml` (re-run `just bootstrap` before enabling)
+- Tagged as SOC2-Compliance
+
 ### Validation Commands
 
 ```bash
@@ -308,12 +328,20 @@ aws secretsmanager list-secrets --filters Key=name,Values=robosystems
 
 # S3 encryption
 aws s3api get-bucket-encryption --bucket robosystems-deployment-prod
+
+# Security baseline
+aws guardduty list-detectors
+aws securityhub get-enabled-standards
+aws configservice describe-configuration-recorders
+aws accessanalyzer list-analyzers
+aws inspector2 batch-get-account-status
 ```
 
 ### Log Locations
 
 - CloudTrail: `s3://robosystems-cloudtrail-{environment}-{account-id}`
 - VPC Flow Logs: `s3://robosystems-vpc-flow-logs-{environment}-{account-id}`
+- AWS Config: `s3://robosystems-config-{account-id}`
 - Application: CloudWatch `/aws/ecs/{service-name}`
 
 ## Startup Validation

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -236,12 +236,18 @@ Security controls implemented at the infrastructure, application, and data level
   - Operations: data import, timeout, financial transaction
 - Risk level classification: LOW, MEDIUM, HIGH, CRITICAL
 - Controlled by `SECURITY_AUDIT_ENABLED` environment variable
-- Centralized collection via CloudWatch
+- Centralized collection via CloudWatch; emits custom security metrics off the request path (see CloudWatch Integration)
+- Compliance-relevant records (`SECURITY_AUDIT:` marker) forwarded to long-retention S3 storage (see Audit Log Retention)
 
 ### CloudWatch Integration
 
 - Log groups for ECS tasks with configurable retention (default 30 days)
-- `FailedAdminAuthAlarm`: triggers on >5 failed admin auth attempts in 5 minutes
+- Custom security metrics emitted off the request path to the `RoboSystems/Security/{environment}` namespace (`robosystems/security/audit_logger.py`)
+- Alarms (actions wired to the `robosystems-{environment}-security-alerts` SNS topic when an alert email is configured):
+  - `FailedAdminAuthAlarm`: `FailedAdminAuth` > 5 in 5 minutes
+  - `AuthFailureSpikeAlarm`: `AuthFailure` > 50 in 5 minutes
+  - `InjectionAttemptAlarm`: `InjectionAttempt` > 0
+  - `PrivilegeEscalationAlarm`: `PrivilegeEscalationAttempt` > 0
 - Optional Container Insights for deeper metrics
 
 ### Managed Monitoring
@@ -275,6 +281,7 @@ Optional features disabled by default to minimize costs. Configured as CloudForm
 - Multi-region trail with log file validation
 - S3 storage with AES256 encryption and Intelligent-Tiering
 - Automatic lifecycle rules for retention enforcement
+- SSM Session Manager command logging: the `SSM-SessionManagerRunShell` document streams bastion session commands to the `/robosystems/ssm-sessions` CloudWatch log group (400-day retention); deployed with the trail, gated on `EnableCloudTrail`
 - Tagged as SOC2-Compliance
 
 ### VPC Flow Logs
@@ -311,6 +318,20 @@ Optional features disabled by default to minimize costs. Configured as CloudForm
 - Deploy-role IAM grants for these services live in `cloudformation/bootstrap-oidc.yaml` (re-run `just bootstrap` before enabling)
 - Tagged as SOC2-Compliance
 
+### Audit Log Retention
+
+**Implementation:** `cloudformation/audit.yaml`
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `AUDIT_ENABLED_{PROD,STAGING}` (GitHub variable) | Enable/disable the retention pipeline | `false` |
+| `AUDIT_RETENTION_DAYS` (`RetentionDays`) | Days to retain audit records in S3 | `400` |
+
+- CloudWatch Logs subscription filter on `/robosystems/{environment}/api` forwards only compliance records (`SECURITY_AUDIT:` marker and structured operation-audit entries) to Kinesis Data Firehose → a dedicated S3 bucket
+- Bucket is versioned, AES256-encrypted, public-access-blocked, with ~13-month retention (`RetentionDays`)
+- Preserves security evidence beyond the short operational-log retention; entirely log-side (no request-path impact)
+- Tagged as SOC2-Compliance
+
 ### Validation Commands
 
 ```bash
@@ -335,6 +356,10 @@ aws securityhub get-enabled-standards
 aws configservice describe-configuration-recorders
 aws accessanalyzer list-analyzers
 aws inspector2 batch-get-account-status
+
+# Audit log retention + SSM session logs
+aws logs describe-subscription-filters --log-group-name /robosystems/prod/api
+aws logs describe-log-groups --log-group-name-prefix /robosystems/ssm-sessions
 ```
 
 ### Log Locations
@@ -342,6 +367,8 @@ aws inspector2 batch-get-account-status
 - CloudTrail: `s3://robosystems-cloudtrail-{environment}-{account-id}`
 - VPC Flow Logs: `s3://robosystems-vpc-flow-logs-{environment}-{account-id}`
 - AWS Config: `s3://robosystems-config-{account-id}`
+- Audit retention: `s3://robosystems-audit-{environment}-{account-id}`
+- SSM sessions: CloudWatch `/robosystems/ssm-sessions`
 - Application: CloudWatch `/aws/ecs/{service-name}`
 
 ## Startup Validation

--- a/bin/setup/README.md
+++ b/bin/setup/README.md
@@ -383,17 +383,19 @@ just setup-gha
 
 #### Compliance & Security
 
-| Variable                         | Default  | Description          |
-| -------------------------------- | -------- | -------------------- |
-| `VPC_FLOW_LOGS_ENABLED`          | `false`  | Enable VPC flow logs |
-| `VPC_FLOW_LOGS_RETENTION_DAYS`   | `90`     | Flow log retention   |
-| `VPC_FLOW_LOGS_TRAFFIC_TYPE`     | `REJECT` | Traffic type to log  |
-| `CLOUDTRAIL_ENABLED`             | `false`  | Enable CloudTrail    |
-| `CLOUDTRAIL_LOG_RETENTION_DAYS`  | `90`     | CloudTrail retention |
-| `CLOUDTRAIL_DATA_EVENTS_ENABLED` | `false`  | Log S3 data events   |
-| `SECRETS_ROTATION_ENABLED_*`     | `false`  | Monthly key rotation |
-| `AUDIT_ENABLED_*`                | `false`  | Retain audit logs to S3 |
-| `AUDIT_RETENTION_DAYS`           | `400`    | Audit S3 retention (days) |
+| Variable                         | Default  | Description                                                                        |
+| -------------------------------- | -------- | ---------------------------------------------------------------------------------- |
+| `VPC_FLOW_LOGS_ENABLED`          | `false`  | Enable VPC flow logs                                                               |
+| `VPC_FLOW_LOGS_RETENTION_DAYS`   | `90`     | Flow log retention                                                                 |
+| `VPC_FLOW_LOGS_TRAFFIC_TYPE`     | `REJECT` | Traffic type to log                                                                |
+| `CLOUDTRAIL_ENABLED`             | `false`  | Enable CloudTrail                                                                  |
+| `CLOUDTRAIL_LOG_RETENTION_DAYS`  | `90`     | CloudTrail retention                                                               |
+| `CLOUDTRAIL_DATA_EVENTS_ENABLED` | `false`  | Log S3 data events                                                                 |
+| `SECRETS_ROTATION_ENABLED_*`     | `false`  | Monthly key rotation                                                               |
+| `AUDIT_ENABLED_*`                | `false`  | Retain audit logs to S3                                                            |
+| `AUDIT_RETENTION_DAYS`           | `400`    | Audit S3 retention (days)                                                          |
+| `SECURITY_ENABLED`               | `false`  | Enable the security baseline (GuardDuty, Security Hub, Access Analyzer, Inspector) |
+| `SECURITY_CONFIG_ENABLED`        | `false`  | Also enable the AWS Config recorder (cost scales with resource count)              |
 
 #### WAF Configuration
 

--- a/bin/setup/gha.sh
+++ b/bin/setup/gha.sh
@@ -361,6 +361,13 @@ function setup_full_config() {
     gh variable set CLOUDTRAIL_LOG_RETENTION_DAYS --body "90"
     gh variable set CLOUDTRAIL_DATA_EVENTS_ENABLED --body "false"
 
+    # Security Baseline (SOC 2 - Account-level detective controls, not environment-specific)
+    # Disabled by default - enables GuardDuty, Security Hub + FSBP, Access Analyzer, Inspector.
+    # AWS Config is a separate switch (SECURITY_CONFIG_ENABLED) because its cost scales
+    # with resource count. Requires the deploy role grants from bootstrap-oidc (re-run bootstrap).
+    gh variable set SECURITY_ENABLED --body "false"
+    gh variable set SECURITY_CONFIG_ENABLED --body "false"
+
     # Secrets Rotation Configuration (monthly automatic rotation via secrets-rotation.yml)
     # Disabled by default - enable after testing in staging
     gh variable set SECRETS_ROTATION_ENABLED_PROD --body "false"

--- a/cloudformation/bootstrap-oidc.yaml
+++ b/cloudformation/bootstrap-oidc.yaml
@@ -181,6 +181,7 @@ Resources:
                       - delivery.logs.amazonaws.com
                       - grafana.amazonaws.com
                       - cloudfront.amazonaws.com
+                      - config.amazonaws.com
 
               # PassRole for audit-stack service roles — the Firehose delivery
               # role and the CloudWatch Logs subscription-filter role. Scoped to
@@ -343,6 +344,41 @@ Resources:
                 Effect: Allow
                 Action:
                   - firehose:*
+                Resource: "*"
+
+              # Security baseline (security.yaml) — account-global detective
+              # controls. Off by default; these grants let the deploy role create
+              # the stack when SECURITY_ENABLED is turned on. Service-linked-role
+              # creation (GuardDuty/Security Hub/Inspector/Access Analyzer) and the
+              # Config recorder role are already covered by the IAM statements above.
+              - Sid: GuardDuty
+                Effect: Allow
+                Action:
+                  - guardduty:*
+                Resource: "*"
+
+              - Sid: SecurityHub
+                Effect: Allow
+                Action:
+                  - securityhub:*
+                Resource: "*"
+
+              - Sid: Config
+                Effect: Allow
+                Action:
+                  - config:*
+                Resource: "*"
+
+              - Sid: Inspector
+                Effect: Allow
+                Action:
+                  - inspector2:*
+                Resource: "*"
+
+              - Sid: AccessAnalyzer
+                Effect: Allow
+                Action:
+                  - access-analyzer:*
                 Resource: "*"
 
               # SNS

--- a/cloudformation/security.yaml
+++ b/cloudformation/security.yaml
@@ -258,12 +258,16 @@ Resources:
       RecordingMode:
         RecordingFrequency: !Ref ConfigRecordingFrequency
 
-  # A delivery channel must exist before the recorder can record, so order the
-  # recorder after the channel, and the channel after the bucket policy.
+  # The delivery channel can only be created once the configuration recorder
+  # exists (otherwise CloudFormation fails with "configuration recorder is not
+  # available to put delivery channel"), and it needs the bucket policy in place
+  # to write. Order it after both.
   ConfigDeliveryChannel:
     Type: AWS::Config::DeliveryChannel
     Condition: ConfigOn
-    DependsOn: ConfigBucketPolicy
+    DependsOn:
+      - ConfigBucketPolicy
+      - ConfigRecorder
     Properties:
       Name: default
       S3BucketName: !Ref ConfigBucket

--- a/cloudformation/security.yaml
+++ b/cloudformation/security.yaml
@@ -12,6 +12,16 @@ Description: RoboSystems Security Baseline - Account-Global Detective Controls (
 # IAM Access Analyzer. Amazon Inspector v2 has no native single-account
 # CloudFormation resource (enablement is the inspector2:Enable API), so it is
 # turned on by a small idempotent CLI step in the deploy job, not here.
+#
+# Workflow scope: the deploy job wires only Environment + EnableConfig
+# (SECURITY_CONFIG_ENABLED). GuardDuty / Security Hub / Access Analyzer use their
+# template defaults (on) — SECURITY_ENABLED is intentionally all-or-nothing for
+# those three; granular per-service toggling would need additional GH variables.
+#
+# Precondition: these are account-global singletons. If GuardDuty, Security Hub,
+# or Access Analyzer is already enabled out-of-band in the target account, first
+# stack creation fails with an "already exists" error — an account-state
+# precondition, not a permissions gap, so there is no CFN-level guard for it.
 
 Parameters:
   Environment:
@@ -111,6 +121,12 @@ Resources:
     Properties:
       ControlFindingGenerator: SECURITY_CONTROL
       AutoEnableControls: true
+      # Hub Tags is a JSON map (not the Key/Value list the other resources use).
+      Tags:
+        Environment: !Ref Environment
+        Service: !Ref ServiceTag
+        Component: !Ref ComponentTag
+        Purpose: SOC2-Compliance
 
   # AWS Foundational Security Best Practices — the AWS-recommended baseline.
   SecurityHubFSBP:

--- a/cloudformation/security.yaml
+++ b/cloudformation/security.yaml
@@ -1,0 +1,290 @@
+Description: RoboSystems Security Baseline - Account-Global Detective Controls (SOC 2)
+
+# Account/region-global detective services for SOC 2 (CC4/CC6/CC7). Every
+# resource here is a per-account singleton, so this is ONE shared stack
+# (RoboSystemsSecurity) like cloudtrail.yaml — never per-environment, or the
+# second environment's deploy would collide. Deployed by the `security` job in
+# deploy-api's VPC workflow, gated on the SECURITY_ENABLED variable (mirrors
+# CloudTrail). Off by default.
+#
+# Covers: GuardDuty (threat detection), Security Hub (+ FSBP standard),
+# AWS Config (config recorder — the cost outlier, gated separately), and
+# IAM Access Analyzer. Amazon Inspector v2 has no native single-account
+# CloudFormation resource (enablement is the inspector2:Enable API), so it is
+# turned on by a small idempotent CLI step in the deploy job, not here.
+
+Parameters:
+  Environment:
+    Type: String
+    Default: prod
+    AllowedValues:
+      - prod
+      - staging
+    Description: Environment name (tagging only; the services are account-global)
+
+  EnableGuardDuty:
+    Type: String
+    Default: "true"
+    AllowedValues: ["true", "false"]
+    Description: Enable Amazon GuardDuty threat detection
+
+  EnableSecurityHub:
+    Type: String
+    Default: "true"
+    AllowedValues: ["true", "false"]
+    Description: Enable AWS Security Hub with the FSBP standard
+
+  EnableCISStandard:
+    Type: String
+    Default: "false"
+    AllowedValues: ["true", "false"]
+    Description: Also enable the CIS AWS Foundations Benchmark standard (in addition to FSBP)
+
+  EnableAccessAnalyzer:
+    Type: String
+    Default: "true"
+    AllowedValues: ["true", "false"]
+    Description: Enable IAM Access Analyzer (account scope)
+
+  EnableConfig:
+    Type: String
+    Default: "false"
+    AllowedValues: ["true", "false"]
+    Description: Enable AWS Config recorder (cost scales with resource count — off by default)
+
+  ConfigRecordingFrequency:
+    Type: String
+    Default: DAILY
+    AllowedValues:
+      - DAILY
+      - CONTINUOUS
+    Description: Config recording cadence (DAILY is far cheaper than CONTINUOUS)
+
+  ConfigRetentionDays:
+    Type: Number
+    Default: 400
+    MinValue: 1
+    MaxValue: 2555
+    Description: Days to retain Config snapshots in S3 (~13 months for a SOC 2 window)
+
+  ServiceTag:
+    Type: String
+    Default: RoboSystems
+    Description: Service tag for resource identification
+
+  ComponentTag:
+    Type: String
+    Default: Security
+    Description: Component tag for resource identification
+
+Conditions:
+  GuardDutyOn: !Equals [!Ref EnableGuardDuty, "true"]
+  SecurityHubOn: !Equals [!Ref EnableSecurityHub, "true"]
+  CISOn: !And
+    - !Condition SecurityHubOn
+    - !Equals [!Ref EnableCISStandard, "true"]
+  AccessAnalyzerOn: !Equals [!Ref EnableAccessAnalyzer, "true"]
+  ConfigOn: !Equals [!Ref EnableConfig, "true"]
+
+Resources:
+  # --- GuardDuty: continuous threat detection over CloudTrail/VPC/DNS telemetry.
+  GuardDutyDetector:
+    Type: AWS::GuardDuty::Detector
+    Condition: GuardDutyOn
+    Properties:
+      Enable: true
+      FindingPublishingFrequency: FIFTEEN_MINUTES
+      Tags:
+        - Key: Environment
+          Value: !Ref Environment
+        - Key: Service
+          Value: !Ref ServiceTag
+        - Key: Component
+          Value: !Ref ComponentTag
+        - Key: Purpose
+          Value: SOC2-Compliance
+
+  # --- Security Hub: aggregates findings + scores controls against standards.
+  SecurityHub:
+    Type: AWS::SecurityHub::Hub
+    Condition: SecurityHubOn
+    Properties:
+      ControlFindingGenerator: SECURITY_CONTROL
+      AutoEnableControls: true
+
+  # AWS Foundational Security Best Practices — the AWS-recommended baseline.
+  SecurityHubFSBP:
+    Type: AWS::SecurityHub::Standard
+    Condition: SecurityHubOn
+    DependsOn: SecurityHub
+    Properties:
+      StandardsArn: !Sub arn:${AWS::Partition}:securityhub:${AWS::Region}::standards/aws-foundational-security-best-practices/v/1.0.0
+
+  # CIS AWS Foundations Benchmark — optional, in addition to FSBP.
+  SecurityHubCIS:
+    Type: AWS::SecurityHub::Standard
+    Condition: CISOn
+    DependsOn: SecurityHub
+    Properties:
+      StandardsArn: !Sub arn:${AWS::Partition}:securityhub:::ruleset/cis-aws-foundations-benchmark/v/1.2.0
+
+  # --- IAM Access Analyzer: flags resources shared outside the account.
+  AccessAnalyzer:
+    Type: AWS::AccessAnalyzer::Analyzer
+    Condition: AccessAnalyzerOn
+    Properties:
+      AnalyzerName: robosystems-account-analyzer
+      Type: ACCOUNT
+      Tags:
+        - Key: Environment
+          Value: !Ref Environment
+        - Key: Service
+          Value: !Ref ServiceTag
+        - Key: Component
+          Value: !Ref ComponentTag
+        - Key: Purpose
+          Value: SOC2-Compliance
+
+  # --- AWS Config: records resource configuration history for drift/compliance.
+  # Heavier + cost-bearing, so gated behind EnableConfig (default off). Needs a
+  # dedicated S3 bucket, a delivery role, a recorder, and a delivery channel.
+  ConfigBucket:
+    Type: AWS::S3::Bucket
+    Condition: ConfigOn
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      BucketName: !Sub robosystems-config-${AWS::AccountId}
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      VersioningConfiguration:
+        Status: Enabled
+      LifecycleConfiguration:
+        Rules:
+          - Id: ConfigRetention
+            Status: Enabled
+            Transitions:
+              - TransitionInDays: 0
+                StorageClass: INTELLIGENT_TIERING
+            ExpirationInDays: !Ref ConfigRetentionDays
+            NoncurrentVersionExpirationInDays: !Ref ConfigRetentionDays
+      Tags:
+        - Key: Name
+          Value: !Sub ${ServiceTag}-config
+        - Key: Environment
+          Value: !Ref Environment
+        - Key: Service
+          Value: !Ref ServiceTag
+        - Key: Component
+          Value: !Ref ComponentTag
+        - Key: Purpose
+          Value: SOC2-Compliance
+
+  ConfigBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Condition: ConfigOn
+    Properties:
+      Bucket: !Ref ConfigBucket
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: AWSConfigBucketPermissionsCheck
+            Effect: Allow
+            Principal:
+              Service: config.amazonaws.com
+            Action:
+              - s3:GetBucketAcl
+              - s3:ListBucket
+            Resource: !GetAtt ConfigBucket.Arn
+            Condition:
+              StringEquals:
+                "AWS:SourceAccount": !Ref AWS::AccountId
+          - Sid: AWSConfigBucketDelivery
+            Effect: Allow
+            Principal:
+              Service: config.amazonaws.com
+            Action: s3:PutObject
+            Resource: !Sub ${ConfigBucket.Arn}/AWSLogs/${AWS::AccountId}/Config/*
+            Condition:
+              StringEquals:
+                "s3:x-amz-acl": bucket-owner-full-control
+                "AWS:SourceAccount": !Ref AWS::AccountId
+
+  ConfigRole:
+    Type: AWS::IAM::Role
+    Condition: ConfigOn
+    Properties:
+      RoleName: robosystems-config-recorder
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: config.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWS_ConfigRole
+      Policies:
+        - PolicyName: config-s3-delivery
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action: s3:GetBucketAcl
+                Resource: !GetAtt ConfigBucket.Arn
+              - Effect: Allow
+                Action: s3:PutObject
+                Resource: !Sub ${ConfigBucket.Arn}/AWSLogs/${AWS::AccountId}/*
+                Condition:
+                  StringEquals:
+                    "s3:x-amz-acl": bucket-owner-full-control
+
+  ConfigRecorder:
+    Type: AWS::Config::ConfigurationRecorder
+    Condition: ConfigOn
+    Properties:
+      Name: default
+      RoleARN: !GetAtt ConfigRole.Arn
+      RecordingGroup:
+        AllSupported: true
+        IncludeGlobalResourceTypes: true
+      RecordingMode:
+        RecordingFrequency: !Ref ConfigRecordingFrequency
+
+  # A delivery channel must exist before the recorder can record, so order the
+  # recorder after the channel, and the channel after the bucket policy.
+  ConfigDeliveryChannel:
+    Type: AWS::Config::DeliveryChannel
+    Condition: ConfigOn
+    DependsOn: ConfigBucketPolicy
+    Properties:
+      Name: default
+      S3BucketName: !Ref ConfigBucket
+      ConfigSnapshotDeliveryProperties:
+        DeliveryFrequency: TwentyFour_Hours
+
+Outputs:
+  GuardDutyDetectorId:
+    Condition: GuardDutyOn
+    Description: GuardDuty detector id
+    Value: !Ref GuardDutyDetector
+    Export:
+      Name: !Sub ${AWS::StackName}-GuardDutyDetectorId
+
+  ConfigBucketName:
+    Condition: ConfigOn
+    Description: S3 bucket holding AWS Config snapshots
+    Value: !Ref ConfigBucket
+    Export:
+      Name: !Sub ${AWS::StackName}-ConfigBucket
+
+  EstimatedMonthlyCost:
+    Description: Rough monthly cost at low account volume
+    Value: "~$5-15/mo without Config; Config adds cost scaling with resource count (DAILY keeps it low)"

--- a/robosystems/config/env.py
+++ b/robosystems/config/env.py
@@ -981,7 +981,7 @@ class EnvConfig:
   # SEC
   # SEC_GOV_USER_AGENT is a secret identity for API access
   SEC_GOV_USER_AGENT = get_secret_value(
-    "SEC_GOV_USER_AGENT", "RoboSystems hello@robosystems.ai"
+    "SEC_GOV_USER_AGENT", "YourCompany your-email@example.com"
   )
 
   # OpenFIGI (financial identifiers)


### PR DESCRIPTION
## Summary

Adds an **off-by-default** account-global security baseline stack — the AWS detective controls (GuardDuty, Security Hub, IAM Access Analyzer, optional AWS Config, and Amazon Inspector) that were the biggest remaining SOC 2 readiness gap. It's modeled on the existing CloudTrail pattern: one shared stack, deployed by a gated job in the VPC workflow, toggled by a GitHub variable. Nothing turns on until `SECURITY_ENABLED=true` — the code, the repo variables, and the workflow defaults are all off.

## Changes

**`cloudformation/security.yaml`** (new — shared, account-global stack `RoboSystemsSecurity`)
- **GuardDuty** detector, **Security Hub** + the FSBP standard (optional CIS), and **IAM Access Analyzer** (account scope) — enabled when the stack deploys.
- **AWS Config** recorder + dedicated S3 bucket, delivery role, and delivery channel — behind its own `EnableConfig` parameter (default off, `DAILY` recording) because it's the cost outlier.
- **Amazon Inspector v2** has no native single-account CloudFormation resource, so it's enabled by an idempotent `inspector2:enable` step in the deploy job rather than a stack resource.
- Every service is gated by its own `Enable*` parameter; the Config S3 bucket is `Retain`/versioned/encrypted/public-blocked.

**`.github/workflows/deploy-vpc.yml`**
- New `security` job — a sibling to the existing `cloudtrail` job (`needs: deploy`, `if: security_enabled == 'true'`), so the two toggle independently. Deploys the stack, monitors it, then runs the Inspector enable step.
- New workflow inputs: `security_enabled`, `security_stack_name`, `security_config_enabled`.

**`.github/workflows/staging.yml` / `prod.yml`**
- Wire the `security_stack` name through stack-config and feed `SECURITY_ENABLED` / `SECURITY_CONFIG_ENABLED` variables into the VPC deploy call.

**`.github/configs/stacks.yml`**
- `security: RoboSystemsSecurity` (shared between environments) in both the prod and staging blocks.

**`cloudformation/bootstrap-oidc.yaml`** (deploy-role `RoboSystemsDeploymentPolicy`)
- New service grants: `guardduty:*`, `securityhub:*`, `config:*`, `inspector2:*`, `access-analyzer:*`.
- Added `config.amazonaws.com` to the `iam:PassRole` allowlist (for the Config recorder role).
- These pre-empt the same first-deploy IAM failure the audit stack hit with Firehose (#811), so enabling the stack later can't fail on missing permissions. (Service-linked-role creation and role management were already covered.)

**`bin/setup/gha.sh` / `bin/setup/README.md`**
- Seed `SECURITY_ENABLED` and `SECURITY_CONFIG_ENABLED` (both `false`) and document them.

**`SECURITY.md`**
- Document the new security baseline under Compliance Infrastructure (parameters, log location, validation commands).
- Catch up prior undocumented work: the full security-alarm set + `RoboSystems/Security/{env}` metric namespace + SNS topic (#809), the audit-retention pipeline (#810 `audit.yaml`), and SSM Session Manager command logging (#810 `cloudtrail.yaml`).

**Follow-up commits (from self- and review passes)**
- `fix`: order the Config delivery channel after the recorder (avoids a "configuration recorder is not available" failure when Config is enabled).
- `docs`: tag the Security Hub Hub resource; document that the workflow wires only `Environment` + `EnableConfig`, and the account-global "already enabled out-of-band" precondition.

## Testing

- `just cf-lint security` and `just cf-lint bootstrap-oidc` — clean (no warnings/errors).
- `uv run pytest tests/infrastructure/test_cloudformation.py` — 21 passed (the size-limit guard globs all templates; `security.yaml` ~8 KB, `bootstrap-oidc.yaml` still well under the 51,200-byte inline ceiling).
- Workflow + config YAML parse-checked (`deploy-vpc.yml`, `staging.yml`, `prod.yml`, `stacks.yml`).
- `stack-config.sh` resolves `security` → `RoboSystemsSecurity` for both `production` and `staging`.
- No Python/application code changed, so the unit suite is not relevant here; `just test-all` was not run.

## Notes / Follow-ups

- **Off by default, end to end.** The `SECURITY_ENABLED` / `SECURITY_CONFIG_ENABLED` repo variables are set to `false`; the workflow reads `${{ vars.SECURITY_ENABLED || 'false' }}`.
- **Before enabling:** re-run `just bootstrap` so the live deploy role picks up the new grants (same step the audit stack needed).
- **Inspector asymmetry:** enabled automatically by the deploy job, but because it isn't a stack resource, deleting the stack won't disable it — that's a manual `aws inspector2 disable`. Left as an MVP tradeoff over wrapping it in a custom-resource Lambda.
- The Config S3 bucket uses `DeletionPolicy: Retain` (same teardown consideration as the CloudTrail/audit buckets). cfn-guard advisories on the Config bucket (SSL-only policy, access logging) match the existing `audit.yaml`/`cloudtrail.yaml` convention and are outside the enforced `cf-lint`.
