### PR TITLE
fix(security): don't auto-enable Security Hub default standards

### DIFF
--- a/cloudformation/security.yaml
+++ b/cloudformation/security.yaml
@@ -121,6 +121,11 @@ Resources:
     Properties:
       ControlFindingGenerator: SECURITY_CONTROL
       AutoEnableControls: true
+      # Do not auto-enable default standards on Hub creation — the explicit
+      # SecurityHubFSBP / SecurityHubCIS resources own standards deterministically.
+      # Leaving this on makes the Hub enable FSBP itself, which then collides with
+      # SecurityHubFSBP ("Standards is already enabled") and fails the stack.
+      EnableDefaultStandards: false
       # Hub Tags is a JSON map (not the Key/Value list the other resources use).
       Tags:
         Environment: !Ref Environment


### PR DESCRIPTION
## Summary

Fixes the security baseline stack (`RoboSystemsSecurity`, added in #812) failing to create. The `AWS::SecurityHub::Hub` resource auto-enables the default standards (which include FSBP) on creation, which then collided with the template's explicit `SecurityHubFSBP` standard resource — `ResourceConflictException: Standards is already enabled` — rolling the whole stack back. Setting `EnableDefaultStandards: false` lets the explicit `SecurityHubFSBP` / `SecurityHubCIS` resources own standards deterministically.

## Changes

**`cloudformation/security.yaml`** — add `EnableDefaultStandards: false` to the `SecurityHub` Hub resource (5 lines: the property plus an explanatory comment).

## Testing

- `just cf-lint security` — clean.
- **Validated live in staging.** This exact commit shipped on `release/1.5.12` and deployed successfully: `RoboSystemsSecurity` reached `CREATE_COMPLETE`, with GuardDuty, Security Hub + FSBP, Access Analyzer, and Inspector all enabled (Config off via `SECURITY_CONFIG_ENABLED=false`). The prior deploy without this fix rolled back on the FSBP conflict.
- No application code changed; `just test-all` not run (infra-only).

## Notes / Follow-ups

- Cherry-picked from the `release/1.5.12` hotfix (`3d99863e`) so main carries the fix.
- The related Config delivery-channel ordering fix is already on main via #812; only this FSBP fix was outstanding.
- Expected (not an error): with Config off, Security Hub's FSBP standard sits at `INCOMPLETE` because Config-dependent controls can't evaluate; enabling `SECURITY_CONFIG_ENABLED` later moves it toward `READY`.
