### PR TITLE
chore(docker): strip vendored EDGAR iXViewer node lockfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -180,6 +180,13 @@ COPY robosystems/ /app/robosystems/
 RUN rm -rf /app/robosystems/adapters/sec/arelle
 # Copy builder's complete arelle directory (includes EDGAR + cache + bundles)
 COPY --from=builder /build/robosystems/adapters/sec/arelle/ /app/robosystems/adapters/sec/arelle/
+# Strip vendored Node manifests from the bundled SEC EDGAR iXViewer. node_modules is
+# never installed or executed in this Python image — only the compiled viewer assets
+# are served — so these lockfiles serve only to trip Inspector's SBOM scanner on inert
+# third-party deps (e.g. lodash, flatted). Removing them clears those container-image
+# findings with no functional impact.
+RUN find /app/robosystems/adapters/sec/arelle -type f \
+    \( -name package-lock.json -o -name package.json -o -name yarn.lock \) -delete
 # Copy reporting-framework library (top-level, peer to robosystems/;
 # loaded by extensions migrations at provision time). Resolved via
 # FRAMEWORKS_DIR in robosystems/taxonomy/discovery.py.


### PR DESCRIPTION
## Summary

Removes the vendored SEC EDGAR iXViewer Node manifests from the runtime image so they stop tripping Amazon Inspector's container-image SBOM scanner. `node_modules` is never installed or executed in this Python (`python:3.13-slim`) image — only the compiled viewer assets are served — so the `package.json` / `package-lock.json` files under `adapters/sec/arelle/EDGAR/view/` only serve to surface inert third-party deps (e.g. `lodash`, `flatted`) as CVE findings. Deleting the manifests clears those findings with no functional impact.

## Changes

**`Dockerfile`** — after the arelle directory is copied into the runtime stage, add a scoped `find … -delete` that removes `package.json` / `package-lock.json` / `yarn.lock` under `adapters/sec/arelle`. All matches are under `EDGAR/view/` (the iXViewer: `ixviewer-plus/` and `ixviewer/gulp/`).

## Testing

- Confirmed the strip scope from the working tree: the only Node manifests under `adapters/sec/arelle` are the four iXViewer files under `EDGAR/view/` — nothing Python-adjacent, so the delete is safe.
- Traced the finding source via the Inspector CLI: `lodash` (4.17.21) and `flatted` (2.0.1) were reported against the `robosystems` ECR image, sourced from those lockfiles; `node_modules` is not shipped, so it's lockfile-only detection.
- Image not rebuilt in this session (heavy); the change is a scoped `find`/`-delete` after the existing arelle copy. No application code changed.

## Notes / Follow-ups

- Complements the account-level Inspector work: the two no-fix OS CVEs (`glibc` CVE-2026-5450, `perl` CVE-2026-12087) were suppressed via Inspector filters scoped to `fixAvailable=NO` (auto-un-suppress when a Debian patch ships).
- The `robosystems` base image already runs `apt-get upgrade -y` in both stages, so no base-image bump is needed here. The openssl/node criticals belong to the node-based app image repos (`robosystems-app` / `roboledger-app` / `roboinvestor-app`) and are fixed there (node base-image bump + npm bumps).
