### PR TITLE
chore(commands): add security / soc2 / cost / reliability review skills

### DIFF
--- a/.claude/commands/cost-review.md
+++ b/.claude/commands/cost-review.md
@@ -1,0 +1,52 @@
+Run a read-only AWS cost & usage review, then produce a cost report and a prioritized savings plan ranked by dollar impact. Pairs with the `cost-analysis-cur-athena` (the $ side) and `prometheus-usage-amp-cli` (the usage-driver side) runbooks for the account-specific query detail.
+
+## Scope & guardrails
+
+- **Read-only.** `describe-*` / `list-*` / `get-*`, Cost Explorer (`ce`), and Athena reads only; never `get-secret-value`. Any change (rightsizing, deleting an idle resource, buying a Savings Plan) needs explicit user confirmation, and destructive actions are the user's to run.
+- **Output is business-confidential — never commit it.** This skill (the *methodology*) is public-safe; its *output* is your **unit economics and margins** (effective cost net of SP/RI is literally the pricing number). Write reports to a git-ignored path (`local/`, scratchpad) or a private Artifact — never to the repo, and don't paste cost figures anywhere shareable.
+- **Effective cost, not headline cost.** Cost Explorer's `AmortizedCost`/`NetAmortizedCost` *net out promotional credits*, hiding structural cost. For unit economics, compute **effective cost net of SP/RI discounts but BEFORE credits** — via the CUR in Athena (see the runbook). CE is fine for a quick total; the CUR is the source of truth for structure.
+
+## Phase 1 — Cost overview & anomalies
+
+```bash
+aws ce get-cost-and-usage --time-period Start=<mo-start>,End=<mo-end> --granularity MONTHLY \
+  --metrics UnblendedCost --group-by Type=DIMENSION,Key=SERVICE --region us-east-1
+aws ce get-anomalies --date-interval StartDate=<start>,EndDate=<end> --region us-east-1
+```
+Then the **effective-cost breakdown by component × environment** from the CUR via Athena — port the canonical queries from the `cost-analysis-cur-athena` runbook (it holds the exact catalog/table/partitions).
+
+## Phase 2 — Rightsizing
+
+`aws compute-optimizer get-*-recommendations` for ECS/Fargate services, RDS, EC2 (LadybugDB tiers), and ElastiCache — look for over-provisioned CPU/memory and downsizing candidates. Cross-check against admission-control/headroom needs before acting.
+
+## Phase 3 — Idle & orphaned (fast wins)
+
+- Unattached EBS volumes, old/orphaned snapshots, stopped-but-billing instances, idle load balancers, unassociated EIPs, orphaned ENIs.
+- **Stale ECR images** (ties to the lifecycle policy — `describe-images`, check the lifecycle rules); **orphaned S3 buckets** (a public/retained bucket with no references is cost *and* security — see `/security-audit`).
+- Old RDS manual snapshots, unused KMS keys.
+
+## Phase 4 — Commitment coverage
+
+`aws ce get-savings-plans-coverage` / `get-reservation-coverage` and `get-savings-plans-purchase-recommendation`. Check **Fargate Spot** weighting (Spot-preferred here) and **ARM/Graviton** adoption (already the default — flag any x86 stragglers).
+
+## Phase 5 — Storage, logs & transfer
+
+- **S3**: storage class distribution, Intelligent-Tiering, lifecycle rules, old-version bloat.
+- **CloudWatch Logs**: per-log-group retention + ingested volume (a common silent cost).
+- **Data transfer**: NAT Gateway data-processing vs VPC endpoints (`VPC_ENDPOINT_MODE`), CloudFront egress.
+
+## Phase 6 — Usage drivers (the "why is it expensive" side)
+
+- **Amazon Managed Prometheus** active-series cardinality + ingestion — the top cost driver for observability. The `aws` CLI can't run PromQL; use the SigV4 signing helpers + canonical cardinality queries in the `prometheus-usage-amp-cli` runbook (top metrics by series, label drill-down, deploy-sawtooth trend).
+- High-cardinality metrics/labels, log volume per service, per-tier graph compute.
+
+## Phase 7 — Tagging & allocation
+
+Untagged/mis-tagged resources (break cost attribution), and confirm the Cost & Usage Report (the `RoboSystemsCUR` stack) is delivering.
+
+## Output — report + savings plan
+
+1. **Cost report** — effective cost by component × environment, trend, and the top cost drivers (deduped: a few services usually dominate).
+2. **Prioritized savings plan** — ranked by **estimated $/month saved × effort**, each item with the concrete action and any risk (e.g. rightsizing vs headroom). Separate *free wins* (delete idle, fix retention, prune images) from *commitment decisions* (Savings Plans) from *architecture* (endpoint mode, tiering).
+
+Keep the framing on **structural/effective cost** (unit economics), not credit-masked totals. Offer to render a private cost dashboard Artifact if useful.

--- a/.claude/commands/reliability-review.md
+++ b/.claude/commands/reliability-review.md
@@ -1,0 +1,47 @@
+Run a read-only AWS reliability & resilience review (the Well-Architected Reliability pillar), then produce a report and a prioritized plan. Doubles as **SOC 2 Availability (A1)** evidence. Pairs with the `reliability-review` runbook for the account-specific detail.
+
+## Scope & guardrails
+
+- **Read-only.** `describe-*` / `list-*` / `get-*` only; never `get-secret-value`. Any change (enabling Multi-AZ, standing up a backup plan, adjusting scaling) needs explicit user confirmation; CloudFormation/destructive actions are the user's to run.
+- **Output is sensitive — never commit it.** A reliability report names your single points of failure, backup gaps, and unrecoverable paths — a roadmap for both attackers and adversarial due-diligence. Vault or private Artifact only.
+- **Feeds SOC 2 Availability.** Tag findings that map to CC7.5 / A1 (backups, recovery, capacity) so this doubles as readiness evidence for `/soc2-review`.
+
+## Phase 1 — Redundancy & single points of failure
+
+```bash
+aws rds describe-db-instances --region us-east-1 --query 'DBInstances[].{id:DBInstanceIdentifier,multiAZ:MultiAZ,az:AvailabilityZone}'
+aws elasticache describe-replication-groups --region us-east-1 --query 'ReplicationGroups[].{id:ReplicationGroupId,multiAZ:MultiAZ,automaticFailover:AutomaticFailover}'
+aws ec2 describe-auto-scaling-groups 2>/dev/null; aws autoscaling describe-auto-scaling-groups --region us-east-1 --query 'AutoScalingGroups[].{name:AutoScalingGroupName,min:MinSize,desired:DesiredCapacity,azs:AvailabilityZones}'
+```
+Flag: single-AZ RDS, single-node caches, single-instance/single-AZ services, ASGs with `min=0`/`min=1` on critical paths.
+
+## Phase 2 — Backups & recoverability
+
+- **RDS**: `BackupRetentionPeriod` (>0?), automated-snapshot presence, point-in-time recovery, `DeletionProtection`, backup encryption.
+- **AWS Backup**: `list-backup-plans` / `list-backup-vaults` — is there a **centralized plan with vault-lock**, or only RDS-native snapshots? Coverage of EBS / ElastiCache / S3 beyond RDS.
+- **S3**: versioning on data buckets (tamper/rollback), cross-region replication where warranted.
+- Cross-region / cross-account backup for the truly-critical data.
+
+## Phase 3 — Disaster recovery
+
+Confirm documented **RTO/RPO** targets and — the usual gap — **evidence of an actual restore/DR test**. A backup you've never restored is a hope, not a control. Check the BCDR policy vs. reality.
+
+## Phase 4 — Health, scaling & self-healing
+
+- ALB/target-group health checks and current target health; ECS service desired-vs-running; ASG health-check type + grace.
+- Auto-scaling floors on user-facing services (can it survive an AZ loss and a traffic spike?).
+- Deployment safety: rollback path, blue/green, and cleanup of failed stacks (`ROLLBACK_COMPLETE`) and retained/orphaned resources.
+
+## Phase 5 — State & registry consistency
+
+Stateful reconciliation is a frequent reliability gap: registries/metadata that can **drift from reality** on instance cycling (e.g. DynamoDB instance/graph/volume registries vs. live EC2 after ASG replacement) — is there an on-disk-truth reconciliation, or does drift accumulate silently? Check idempotency + fail-closed behavior on the critical write paths.
+
+## Phase 6 — Quotas & dependency resilience
+
+- Service Quotas headroom on the limits you'd hit under scale/failover (Fargate tasks, EIPs, RDS connections).
+- Circuit breakers / retries / timeouts on external dependencies; fail-closed vs fail-open posture on auth and data paths.
+
+## Output — report + plan
+
+1. **Reliability report** — per-area posture (redundant / single-point / gap), with the blast radius of each SPOF and the recovery story (can we restore, and have we proven it?).
+2. **Prioritized plan** — ranked by (impact of failure × likelihood) ÷ effort. Tag the items that are also **SOC 2 Availability** evidence. Separate quick wins (enable a backup plan, add a health check) from cost-bearing changes (Multi-AZ, cross-region) so the availability-vs-cost tradeoff is explicit.

--- a/.claude/commands/security-audit.md
+++ b/.claude/commands/security-audit.md
@@ -1,0 +1,93 @@
+Run a read-only AWS + GitHub security-posture review, then produce a findings report and a prioritized remediation plan. This is an infrastructure/cloud posture audit (detective controls, live findings, data protection) — distinct from `/security-review`, which reviews pending code changes.
+
+## Scope & guardrails
+
+- **Read-only by default.** Use only `describe-*` / `list-*` / `get-*` and `gh` reads. **Never** run `get-secret-value`. Any change — enabling a service, creating a suppression/archive rule, deleting a resource, deploying a stack — requires **explicit in-the-moment user confirmation**, and destructive/CloudFormation actions are the user's to run.
+- **Outputs are sensitive — never commit them.** This skill (the *methodology*) is safe in a public repo; its *output* — a report of live findings, exposed resources, and disabled controls — is a reconnaissance roadmap for an attacker. Write reports to a git-ignored path (`local/`, the scratchpad) or an ephemeral private Artifact. **Never commit a findings report, account ID, resource ARN, or CVE inventory to the repo.**
+- **Context.** Discover the account at runtime (`aws sts get-caller-identity`); region defaults to `us-east-1`; the robosystems deployment runs `prod` + `staging` in one shared account. Detective services are account-global singletons and several **ship off** (gated by GitHub variables — see the compliance stacks below). Frontend images live in ECR repos `robosystems-app` / `roboledger-app` / `roboinvestor-app`; the backend image is `robosystems`.
+- **Parallelize the sweep.** Phases 1–6 are independent read-only sweeps — fan them out with the Agent tool (one agent per phase) and synthesize the results in the main loop. A denied/empty CLI call is itself a finding (service not enabled, or the role lacks the read perm — say which).
+
+## Phase 1 — Detective controls: are they ON?
+
+The core question. For each, report ENABLED / PARTIAL / MISSING with the value seen:
+
+```bash
+aws sts get-caller-identity
+aws cloudtrail describe-trails --region us-east-1        # + get-trail-status: IsLogging, multi-region, log-file validation
+aws configservice describe-configuration-recorders --region us-east-1        # recorder running?
+aws guardduty list-detectors --region us-east-1
+aws securityhub describe-hub --region us-east-1           # InvalidAccessException = not subscribed
+aws inspector2 batch-get-account-status --region us-east-1
+aws accessanalyzer list-analyzers --region us-east-1
+aws s3control get-public-access-block --account-id <ACCOUNT_ID>   # account-level BPA
+aws ec2 get-ebs-encryption-by-default --region us-east-1
+aws ec2 describe-flow-logs --region us-east-1            # per VPC (check the default VPC too)
+```
+
+## Phase 2 — Triage the live findings
+
+For each detective service that IS on, pull and *triage* findings (don't just dump counts):
+
+**Amazon Inspector** (usually the loudest — container/host CVEs):
+- Aggregate by severity, by repo (`list-finding-aggregations --aggregation-type REPOSITORY`), and by CVE (`--aggregation-type TITLE`). **Dedup**: the same CVE is replicated across many image copies — N findings ≈ a handful of distinct CVEs × many images.
+- Check **fix availability** (`fixAvailable` filter) — if ~100% have fixes, it's a stale-image backlog, not an incident.
+- Classify each CVE: **base-image OS/runtime** (openssl, glibc, node) → one base-image bump clears many at once; **language deps** (npm/pip) → bump the package or add an override; **no upstream fix** (`fixedInVersion=NotAvailable`) → suppress.
+- Watch for **inert vendored lockfiles** (e.g. a `package.json`/`package-lock.json` bundled in a non-node image with no `node_modules`) — Inspector flags declared deps that never run; strip the lockfile from the image instead of chasing the CVE.
+- Check the Inspector **`ecrConfiguration.rescanDuration`** (`get-configuration`) — that, not the ECR lifecycle policy, is the real scan-surface knob.
+
+**IAM Access Analyzer** (external/public exposure — the highest-signal, fastest-actionable):
+- `list-findings-v2`. Classify each ACTIVE finding: **by-design** (SSO/OIDC federation roles, intentionally-public content/CDN buckets) → archive; **real exposure** (a resource that shouldn't be public/shared) → fix or retire.
+- Confirm "intentional" against IaC/source before accepting — grep the CloudFormation/config that defines the resource.
+
+**GuardDuty**: `list-findings` — usually 0 on a freshly enabled detector (it flags *activity*, not config). Report clean, note it's baselining.
+
+**Security Hub**: `get-enabled-standards` — FSBP `INCOMPLETE` with `NO_AVAILABLE_CONFIGURATION_RECORDER` is expected when Config is off (the control-scoring half is dormant); note it, don't treat it as failure.
+
+## Phase 3 — Data protection & resilience
+
+```bash
+aws rds describe-db-instances --region us-east-1        # StorageEncrypted, BackupRetentionPeriod, MultiAZ, DeletionProtection, PubliclyAccessible
+aws elasticache describe-replication-groups --region us-east-1   # AtRest + Transit encryption
+aws s3api list-buckets                                  # per relevant bucket: get-bucket-encryption, get-public-access-block, get-bucket-versioning
+aws secretsmanager list-secrets --region us-east-1      # RotationEnabled (never read values)
+aws kms list-keys --region us-east-1                    # CMK vs AWS-managed; get-key-rotation-status on CMKs
+aws backup list-backup-plans --region us-east-1         # centralized backup vs RDS-native snapshots only
+aws opensearch list-domain-names --region us-east-1     # EncryptionAtRest, NodeToNode, EnforceHTTPS
+```
+
+## Phase 4 — IAM hygiene
+
+`get-account-summary`, `get-account-password-policy`, `list-users`, and the credential report (`generate-credential-report` → `get-credential-report`) for: root MFA, root access keys, IAM users without MFA, oldest active access-key age. If these reads are blocked by the session's permission policy, mark them **"verify"**, not "gap".
+
+## Phase 5 — GitHub posture (optional; `gh`)
+
+Org 2FA (`gh api orgs/<org>`), branch protection / rulesets on `main` (required approvals, admin bypass, strict checks, signed commits), secret scanning + push protection, Dependabot alerts + updates, CodeQL. For a single-member org, "require independent review" is structurally unmet — document as a compensating control, don't assert it.
+
+## Phase 6 — Codebase controls inventory (optional)
+
+Read `SECURITY.md` (control catalog) and the `robosystems/security/` modules. Note the **optional compliance stacks and their GitHub-variable toggles** (all off by default): `SECURITY_ENABLED` (`cloudformation/security.yaml` — the detective baseline; needs `just bootstrap` re-run first for deploy-role IAM), `SECURITY_CONFIG_ENABLED` (AWS Config — cost outlier), `CLOUDTRAIL_ENABLED`, `AUDIT_ENABLED_*`, `VPC_FLOW_LOGS_ENABLED`, `SECRETS_ROTATION_ENABLED_*`, `WAF_ENABLED_*`.
+
+## Output — report + prioritized plan
+
+Produce two things:
+
+1. **Report** — a per-control table (ENABLED / PARTIAL / MISSING / VERIFY) grouped by area, plus a triaged findings summary (deduped counts by severity, what's actionable vs suppress vs accepted). Call out what's already solid so it isn't re-litigated.
+2. **Prioritized remediation plan** — ranked by impact × effort, each item with the concrete action. Where SOC 2 is in play, tag each item **"before"** (technical toggles you flip yourself — do these early so evidence accrues; the Type II clock only counts time a control was running) vs **"with the auditor"** (scoping, policies, attestation). Flag which items are one-variable toggles vs real work.
+
+If the result is worth sharing visually, offer to render it as an Artifact (a readiness dashboard).
+
+## Remediation patterns (the playbook)
+
+- **Detective services off** → enable via the gated compliance stacks (flip the GH var + deploy; re-`bootstrap` first for `SECURITY_ENABLED`). Turn the cheap/free-trial ones (GuardDuty, Access Analyzer, Security Hub, Inspector) on and leave them on; gate **Config** separately (cost).
+- **Inspector no-fix CVE** → `aws inspector2 create-filter --action SUPPRESS` scoped to `{"vulnerabilityId":[EQUALS <cve>],"fixAvailable":[EQUALS "NO"]}` so it **auto-un-suppresses when a patch ships**.
+- **Inspector base-image CVEs** → bump the base image, **staying in-major** when `engines`/runtime constrain it (e.g. node `>=22` → latest `22.x`); verify the lockfile churn is scoped.
+- **Inspector inert vendored lockfile** → strip it from the image (`RUN find … -name 'package*.json' -delete`), don't bump a dep that never runs.
+- **Access Analyzer intentional finding** → `create-archive-rule` scoped to the resource ARN / path, then `apply-archive-rule` to clear existing.
+- **Access Analyzer orphaned exposed resource** → confirm migration/references, then **retire** it (delete removes the exposure at the source — user runs the delete).
+- **Stale-image drift** → the deployed image lags the lockfile; a rebuild alone clears already-fixed deps.
+
+## Notes
+
+- Detective services are account-global singletons — a per-env stack would collide; they live in one shared stack (`cloudformation/security.yaml`, like `cloudtrail.yaml`).
+- `AWS::SecurityHub::Hub` auto-enables default standards — set `EnableDefaultStandards: false` if the stack also declares explicit `Standard` resources, or they collide.
+- A `CREATE_FAILED`→`ROLLBACK_COMPLETE` stack must be deleted before redeploy; `DeletionPolicy: Retain` buckets survive and must be cleaned up manually.

--- a/.claude/commands/security-audit.md
+++ b/.claude/commands/security-audit.md
@@ -31,7 +31,7 @@ For each detective service that IS on, pull and *triage* findings (don't just du
 **Amazon Inspector** (usually the loudest — container/host CVEs):
 - Aggregate by severity, by repo (`list-finding-aggregations --aggregation-type REPOSITORY`), and by CVE (`--aggregation-type TITLE`). **Dedup**: the same CVE is replicated across many image copies — N findings ≈ a handful of distinct CVEs × many images.
 - Check **fix availability** (`fixAvailable` filter) — if ~100% have fixes, it's a stale-image backlog, not an incident.
-- Classify each CVE: **base-image OS/runtime** (openssl, glibc, node) → one base-image bump clears many at once; **language deps** (npm/pip) → bump the package or add an override; **no upstream fix** (`fixedInVersion=NotAvailable`) → suppress.
+- Classify each CVE: **base-image OS/runtime** (openssl, glibc, node) → one base-image bump clears many at once (stay **in-major** when the runtime/`engines` constrains it); **language deps** (npm/pip) → if the flagged dep is a **devDependency-only transitive** (test/build tooling — jsdom, vitest, eslint), exclude it from the runtime image (`npm ci --omit=dev`, don't copy dev `node_modules` into the runner stage) rather than override it — that clears the whole devDep CVE class; only override a genuine *runtime* transitive; **no upstream fix** (`fixedInVersion=NotAvailable`) → suppress.
 - Watch for **inert vendored lockfiles** (e.g. a `package.json`/`package-lock.json` bundled in a non-node image with no `node_modules`) — Inspector flags declared deps that never run; strip the lockfile from the image instead of chasing the CVE.
 - Check the Inspector **`ecrConfiguration.rescanDuration`** (`get-configuration`) — that, not the ECR lifecycle policy, is the real scan-surface knob.
 

--- a/.claude/commands/soc2-review.md
+++ b/.claude/commands/soc2-review.md
@@ -1,0 +1,46 @@
+Assess SOC 2 readiness: map the security posture to the Trust Services Criteria, inventory policies and evidence, and produce a readiness dashboard plus a before-vs-with-the-auditor remediation plan. This is the compliance-framed companion to `/security-audit` (which gathers the raw posture).
+
+## Scope & guardrails
+
+- **Read-only by default**, same as `/security-audit` — describe/list/get and `gh` reads only; never `get-secret-value`; every change needs explicit user confirmation.
+- **The readiness report is sensitive — never commit it.** The *methodology* (this skill) is public-safe; the *output* names your exact unmet controls, disabled services, and audit weaknesses — a roadmap for both attackers and adversarial due-diligence. Write it to a git-ignored path (`local/`, scratchpad) or an ephemeral private Artifact. Never commit the readiness report to the repo.
+- **Not attestation or legal advice.** This is engineering-readiness guidance. Only a **licensed CPA firm** can determine SOC 2 compliance and issue a report — say so in the output.
+
+## Step 1 — Gather the posture
+
+Run `/security-audit` (or its Phase 1–6 sweep) for the live control state + findings. Then read the code-level and documentary controls:
+- `SECURITY.md` (control catalog) and `robosystems/security/` modules.
+- The written **policy set** and any risk-acceptance register (in the git-ignored design vault `local/RoboSystems/` if present — e.g. `ref/security.md`, `policies/`). Note which of the auditor-expected policies exist vs are missing (infosec, access control, change management, incident response, BCDR, vendor/supplier risk, risk assessment, data classification/retention, encryption/key management, SDLC, HR/acceptable-use).
+
+## Step 2 — Map to the Trust Services Criteria
+
+Assess each criterion **Have / Partial / Gap** on both control *design* AND whether *operating evidence* exists:
+
+- **CC1** Control Environment — governance, org structure, policies (note: a single-member org can't meet segregation-of-duties; document as a compensating control, not "met").
+- **CC2** Communication & Information — internal + external commitments.
+- **CC3** Risk Assessment — a dated, standalone assessment + register (not just folded into a policy).
+- **CC4** Monitoring — CloudTrail, security alarms, Config/Security Hub (control-scoring is dormant while Config is off).
+- **CC5** Control Activities — the technical control set in practice.
+- **CC6** Logical & Physical Access (the largest) — auth, RBAC, encryption in transit + at rest, **MFA enforcement**, tenant isolation.
+- **CC7** System Operations — GuardDuty/Inspector detection, incident response, recovery/DR.
+- **CC8** Change Management — PR gates, branch protection/required reviews, CI/CD.
+- **CC9** Risk Mitigation — vendor/supplier management, BCDR, insurance.
+- Optional categories that fit a financial-data platform: **Availability (A1)** (backups, Multi-AZ, capacity, DR-test evidence) and **Confidentiality (C1)** (classification, retention, disposal).
+
+## Step 3 — Separate design from operating evidence (the core SOC 2 truth)
+
+A SOC 2 report attests to *an organization operating a system over time* — not to code.
+- **Type I** = controls designed + in place at a point in time. The reference architecture nearly pre-meets the *technical* half → a fast Type I head start.
+- **Type II** = operating effectiveness across an observation window (commonly 3–12 months). It **can't be inherited or backdated** — evidence must accrue while controls run.
+- So tag every gap: **"before the auditor"** = technical toggles you flip yourself (do these *early* — the Type II clock only counts time a control was actually running) vs **"with the auditor"** = scoping the report type + window, finalizing policies, the in-period pen test, and the attestation itself.
+
+## Step 4 — Produce the deliverables
+
+1. **Readiness dashboard** as an Artifact (load the `artifact-design` skill first): a scorecard (solid / partial / gap), the **before-vs-with-the-auditor** split, a turn-on queue of the off-by-default controls, the TSC coverage matrix (CC1–CC9 + A/C), a "what's already solid" list, and the path to a report (flip toggles → readiness/gap assessment → observation window → CPA attestation).
+2. **Prioritized readiness plan** — ranked, each item flagged before/with-auditor and one-variable-toggle vs real work.
+
+## SOC 2 posture notes (weave into the narrative)
+
+- Only a licensed CPA firm can issue the report; compliance platforms (Vanta / Drata / Secureframe) automate evidence collection and connect you to a partner audit firm — the common fast path.
+- **Fork inheritance:** a fork inherits control *design* (a Type I head start), never Type II operating evidence — the forker runs their own audit. See `local/RoboSystems/` specs on the managed-BYOC model, where an operator running client deployments carries the SOC 2 and clients inherit it as a subservice organization (enables a fleet audit + audit-firm partnership).
+- Keep the framing **modest and honest** — "audit-ready design + evidence infrastructure," never "SOC 2 certified."


### PR DESCRIPTION
## Summary

Adds a suite of read-only operational **review skills** (slash commands), encapsulating the AWS posture / compliance / cost / reliability reviews as repeatable methodology — so they're inheritable by forks, not one-off. Each is the generic, public, *scrubbed* methodology; the deep, account-specific detail lives in paired runbooks in the git-ignored design vault (routed via a skill↔runbook pairing rule in the local instructions).

## Changes

- **`.claude/commands/security-audit.md`** — `/security-audit`: detective-controls check (CloudTrail/Config/GuardDuty/Security Hub/Inspector/Access Analyzer/BPA/flow-logs) + findings triage (Inspector dedup/fix-availability/suppress-no-fix + devDep-omit, Access Analyzer classify→archive/retire) + data protection + IAM hygiene + GitHub posture → report + remediation plan.
- **`.claude/commands/soc2-review.md`** — `/soc2-review`: maps the posture to the Trust Services Criteria (CC1–CC9 + Availability/Confidentiality), inventories policies/evidence, separates design (Type I) from operating evidence (Type II), and produces a readiness dashboard + before-vs-with-the-auditor plan.
- **`.claude/commands/cost-review.md`** — `/cost-review`: cost & usage optimization (Cost Explorer + CUR/Athena effective cost, rightsizing, idle/orphaned, commitment coverage, storage/logs/transfer, AMP cardinality) → report + savings plan. Extra guardrail: output is business-confidential (unit economics).
- **`.claude/commands/reliability-review.md`** — `/reliability-review`: Well-Architected reliability audit (redundancy/SPOFs, backups + recoverability, DR-test evidence, self-healing, registry/state drift); doubles as SOC 2 Availability (A1) evidence.

## Why these are OK to ship publicly

The **methodology** is safe to open-source — read-only audit playbooks that make the repo a compliance-ready reference architecture forks inherit. Guardrails enforce the line:
- Every skill carries an explicit **output-secrecy** guard: findings/reports (live exposures, disabled controls, cost figures, account IDs) are reconnaissance/business-confidential material and must never be committed — outputs go to a git-ignored path or a private Artifact.
- No account identifiers are hardcoded (account discovered at runtime).

## Testing

- Pre-commit hook (ruff/format/basedpyright/cf-lint) passed on each commit.
- Documentation-only slash commands; no application code changed. Markdown matches the existing `.claude/commands/*` convention (description-first line, no H1).
