### PR TITLE
chore(opensearch): add memory alarms and widen instance-type options

### DIFF
--- a/cloudformation/opensearch.yaml
+++ b/cloudformation/opensearch.yaml
@@ -369,6 +369,78 @@ Resources:
         - Key: CreatedBy
           Value: CloudFormation
 
+  OpenSearchJVMMemoryPressureAlarm:
+    Type: AWS::CloudWatch::Alarm
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      AlarmName: !Sub "robosystems-opensearch-${Environment}-high-jvm-memory"
+      AlarmDescription: >-
+        OpenSearch JVM heap pressure >= 80% sustained — trim old documents or
+        scale the instance before the ~85% circuit breaker starts blocking writes
+      MetricName: JVMMemoryPressure
+      Namespace: AWS/ES
+      Statistic: Maximum
+      Period: 300
+      EvaluationPeriods: 3
+      Threshold: 80
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Dimensions:
+        - Name: DomainName
+          Value: !Ref OpenSearchDomain
+        - Name: ClientId
+          Value: !Ref "AWS::AccountId"
+      AlarmActions:
+        - !Ref OpenSearchNotificationTopic
+      TreatMissingData: notBreaching
+      Tags:
+        - Key: Name
+          Value: !Sub "robosystems-opensearch-${Environment}-high-jvm-memory"
+        - Key: Environment
+          Value: !Ref Environment
+        - Key: Service
+          Value: !Ref ServiceTag
+        - Key: Component
+          Value: !Ref ComponentTag
+        - Key: CreatedBy
+          Value: CloudFormation
+
+  OpenSearchWritesBlockedAlarm:
+    Type: AWS::CloudWatch::Alarm
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      AlarmName: !Sub "robosystems-opensearch-${Environment}-writes-blocked"
+      AlarmDescription: >-
+        OpenSearch is blocking index writes — cluster has hit a memory or storage
+        wall and needs immediate attention (trim documents, scale, or expand EBS)
+      MetricName: ClusterIndexWritesBlocked
+      Namespace: AWS/ES
+      Statistic: Maximum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Dimensions:
+        - Name: DomainName
+          Value: !Ref OpenSearchDomain
+        - Name: ClientId
+          Value: !Ref "AWS::AccountId"
+      AlarmActions:
+        - !Ref OpenSearchNotificationTopic
+      TreatMissingData: notBreaching
+      Tags:
+        - Key: Name
+          Value: !Sub "robosystems-opensearch-${Environment}-writes-blocked"
+        - Key: Environment
+          Value: !Ref Environment
+        - Key: Service
+          Value: !Ref ServiceTag
+        - Key: Component
+          Value: !Ref ComponentTag
+        - Key: CreatedBy
+          Value: CloudFormation
+
 Outputs:
   OpenSearchEndpoint:
     Description: OpenSearch domain endpoint

--- a/cloudformation/opensearch.yaml
+++ b/cloudformation/opensearch.yaml
@@ -22,18 +22,24 @@ Parameters:
     Description: OpenSearch instance type
     Default: t3.small.search
     AllowedValues:
-      # T3 - Burstable (cost-effective for variable loads)
+      # T3 - Burstable x86 (default; OpenSearch offers no Graviton burstable)
       - t3.small.search    # 2 GB RAM, up to 100 GB EBS
       - t3.medium.search   # 4 GB RAM, up to 200 GB EBS
-      # M6g - General Purpose Graviton2
-      - m6g.large.search   # 8 GB RAM
-      - m6g.xlarge.search  # 16 GB RAM
+      # M7g - General Purpose Graviton3
+      - m7g.large.search   # 8 GB RAM
+      - m7g.xlarge.search  # 16 GB RAM
       # R6g - Memory Optimized Graviton2
       - r6g.large.search   # 16 GB RAM
       - r6g.xlarge.search  # 32 GB RAM
       # R7g - Memory Optimized Graviton3
+      - r7g.medium.search  # 8 GB RAM (smallest Graviton option)
       - r7g.large.search   # 16 GB RAM
       - r7g.xlarge.search  # 32 GB RAM
+      - r7g.2xlarge.search # 64 GB RAM
+      # R8g - Memory Optimized Graviton4
+      - r8g.medium.search  # 8 GB RAM
+      - r8g.large.search   # 16 GB RAM
+      - r8g.xlarge.search  # 32 GB RAM
 
   EBSVolumeSize:
     Type: Number


### PR DESCRIPTION
## Summary

Closes a monitoring gap on the prod OpenSearch domain and widens the selectable
instance-type ladder. Motivated by a cost/capacity review of the single
`robosystems-prod` search node: the domain runs 24/7 on-demand and we're moving
it from r6g toward a reserved r7g instance — but JVM heap pressure (the metric
that actually drives the trim-or-scale decision) was previously unmonitored, and
the type couldn't be changed to a newer generation without a template edit.

## Changes

**CloudWatch alarms** (`cloudformation/opensearch.yaml`) — both wired to the
existing `robosystems-opensearch-${Environment}-alerts` SNS topic, matching the
established alarm pattern:

- `high-jvm-memory` — `JVMMemoryPressure >= 80%` sustained 15 min (3× 5-min
  periods). Lead indicator for trimming old documents / scaling, ahead of the
  ~85% circuit breaker that starts blocking writes.
- `writes-blocked` — `ClusterIndexWritesBlocked >= 1`. Backstop that fires when
  the cluster hits a memory or storage wall.

Previously only `cluster-red` and `low-storage` were monitored.

**Instance-type `AllowedValues`** — widened so `OPENSEARCH_INSTANCE_TYPE_*` can
override to any of these without a further template change:

- added `r7g.medium` (smallest Graviton option), `r7g.2xlarge` (scale-up headroom)
- added the `r8g` (Graviton4) memory tier: `medium` / `large` / `xlarge`
- replaced prev-gen `m6g` general-purpose with current-gen `m7g`
- **default stays `t3.small`** (burstable x86 — OpenSearch offers no Graviton
  burstable); the GHA var overrides it

All added instance types were verified against the OpenSearch on-demand price list.

## Testing

- `just cf-lint opensearch` — passed (0 errors, 0 warnings).
- Pre-commit hooks (ruff / format) passed on both commits.
- `just test-all` not run — infra-only YAML change, no Python touched.

## Notes / Follow-ups

- **Related operational change, not in this diff:** the `OPENSEARCH_INSTANCE_TYPE_PROD`
  GitHub Actions variable was set to `r7g.large.search`. Because that var is now
  flipped, the next `deploy-opensearch.yml` run ships these alarms **and**
  triggers the r6g→r7g blue/green migration together. Run it in a low-traffic
  window — the domain is single-node / single-AZ, so expect a brief cutover
  interruption (endpoint is preserved, no data loss).
- After r7g is live and healthy, purchase the `r7g.large.search` 3-yr No Upfront
  reserved instance (must come last — it can only match a running r7g node).
