### PR TITLE
fix(sec): declare sec_master_wake in the pipeline sensor request_jobs

### DIFF
--- a/robosystems/adapters/sec/pipeline/sensors.py
+++ b/robosystems/adapters/sec/pipeline/sensors.py
@@ -293,7 +293,7 @@ def sec_incremental_download_schedule(context):
 @run_status_sensor(
   run_status=DagsterRunStatus.SUCCESS,
   monitored_jobs=[sec_download_job, sec_process_job],
-  request_jobs=[sec_process_job, sec_incremental_stage_job],
+  request_jobs=[sec_process_job, sec_master_wake_job],
   default_status=DefaultSensorStatus.STOPPED,  # Enable in Dagster UI when ready
   minimum_interval_seconds=60,
   description="Chain: download → process (batched) → stage. Self-contained incremental pipeline.",

--- a/tests/adapters/sec/pipeline/test_sensors.py
+++ b/tests/adapters/sec/pipeline/test_sensors.py
@@ -945,3 +945,29 @@ class TestPublishSensorSleepsMaster:
       "shared_replicas_refresh",
       "sec_master_sleep",
     }
+
+
+@pytest.mark.unit
+class TestSensorRequestJobsDeclared:
+  """Every job a sensor yields must be declared in its ``request_jobs``, or
+  Dagster rejects the RunRequest at tick time. Calling the sensor function
+  directly (as the other tests do) does NOT exercise that validation, so these
+  assert the declaration explicitly — the gap that shipped the sec_master_wake
+  "Expected one of [...]" prod error.
+  """
+
+  def test_pipeline_sensor_declares_wake(self):
+    names = {j.name for j in sec_incremental_pipeline_sensor.jobs}
+    assert "sec_master_wake" in names  # drained-queue branch yields this
+    assert "sec_process" in names
+
+  def test_wake_to_stage_declares_stage(self):
+    assert "sec_incremental_stage" in {j.name for j in sec_wake_to_stage_sensor.jobs}
+
+  def test_publish_sensor_declares_sleep_and_refresh(self):
+    names = {j.name for j in sec_post_materialize_publish_sensor.jobs}
+    assert {"sec_master_sleep", "shared_replicas_refresh"} <= names
+
+  def test_failure_sensor_declares_sleep(self):
+    names = {j.name for j in sec_master_sleep_on_failure_sensor.jobs}
+    assert "sec_master_sleep" in names


### PR DESCRIPTION
## Summary

Hotfix for a prod Dagster sensor error introduced by #790. `sec_incremental_pipeline_sensor`'s drained-queue branch now yields a `sec_master_wake` RunRequest, but `request_jobs` was never updated — it still listed `sec_incremental_stage` (now requested by `sec_wake_to_stage_sensor` instead). Dagster validates the allowed set at tick time, so the sensor threw:

> `Sensor returned a RunRequest with job_name sec_master_wake. Expected one of: ['sec_process', 'sec_incremental_stage']`

This severs the nightly chain at the `process → wake` handoff (nothing past `process` runs, and the sleep op can't auto-park the master).

## Changes

- **`adapters/sec/pipeline/sensors.py`** — `sec_incremental_pipeline_sensor.request_jobs` → `[sec_process_job, sec_master_wake_job]`. That sensor yields only `sec_process` (download/process branches) and `sec_master_wake` (drained branch); staging is requested downstream by `sec_wake_to_stage_sensor`. Audited the other three master-touching sensors — `sec_wake_to_stage_sensor` (`request_job=sec_incremental_stage_job`), `sec_post_materialize_publish_sensor` (`sec_master_sleep_job` present), and `sec_master_sleep_on_failure_sensor` (`request_job=sec_master_sleep_job`) were already correct.
- **`tests/adapters/sec/pipeline/test_sensors.py`** — new `TestSensorRequestJobsDeclared`: asserts every master-touching sensor declares the jobs it yields via `sensor.jobs` (pipeline→wake, wake→stage, publish→sleep+refresh, failure→sleep). This is the tick-time validation that calling the sensor function directly (as the existing tests do) bypasses — the exact gap that let this ship.

## Testing

- `ruff check` / `ruff format` / `basedpyright` — clean on both files.
- The 4 new regression tests pass, verified by direct invocation (the pytest conftest needs Postgres, which was not running in this session). Confirmed post-fix that `sec_incremental_pipeline_sensor.jobs == ['sec_master_wake', 'sec_process']`.
- Full `just test` not run locally.

## Notes / Follow-ups

- **Root cause of the test miss:** the existing sensor unit tests invoke the sensor function directly, which does not exercise Dagster's tick-time `request_jobs` validation. The new class closes that gap by asserting the declaration.
- Deploy this before relying on the automated nightly chain from #790 — until it lands, the SEC pipeline is severed past `process`, and the master won't auto-park.
