### PR TITLE
chore(skills): add deploy, migrate, and incident operational skills

### DIFF
--- a/.claude/commands/deploy.md
+++ b/.claude/commands/deploy.md
@@ -1,0 +1,63 @@
+Monitor a deployment run — pinpoint why it failed, drive it to green on a re-run, and verify health. Deploys go through GitHub Actions (`workflow_dispatch`); this skill is about watching and diagnosing them, not replacing the pipeline. Pairs with the `deployment-monitoring` runbook for account-specific stack names and failure classes.
+
+## When this runs
+
+Most deploys (~95%) go green untouched and need no attention. The real use case is the other 5%: **a deploy failed, and you're re-running it and want eyes on this one.** Optimize for that — get to the failing job fast, classify it, fix the cause, re-trigger, and confirm the app is healthy afterward.
+
+## Scope & guardrails
+
+- **`gh` reads are free; the deploy trigger is not.** Reading runs, jobs, and logs (`gh run list/view/watch`) needs no confirmation. **Triggering or re-triggering a deploy** (`gh workflow run`, `just deploy`) is an outward-facing action — confirm the target (env + ref) with the user first, and default to watching a run they already started.
+- **AWS is read-only here.** `describe-*` / `list-*` only. CloudFormation changes and stack deletions are the user's to run — never `create-stack`/`update-stack`/`delete-stack` directly.
+- **Never deploy the default branch to prod without the release flow.** Production deploys ride a version tag / release branch produced by the release workflow; ad-hoc `main`→prod is not the path.
+- **Output can be sensitive.** Failure logs name internal hostnames, stack names, and resource IDs. Don't paste raw infra detail into anything public; summarize.
+
+## 1. Find the run
+
+Identify env (`staging` | `prod`) and which run you're looking at. If the user didn't say, ask or infer from context.
+
+```bash
+gh run list --workflow=staging.yml --limit 5     # or prod.yml
+gh run view <run-id>                              # job-level status
+gh run watch <run-id>                             # live, if it's in flight
+```
+
+The deploy is one large workflow of dependent jobs (build/test → infra stacks → app services → post-deploy refresh). A single failed job fails the run. Find the **first** failed job — downstream failures are usually just the cascade.
+
+## 2. Pinpoint the failure
+
+```bash
+gh run view <run-id> --log-failed      # logs for only the failed step(s)
+```
+
+Classify by which stage broke — each has a different fix and blast radius:
+
+- **Test / build** — code problem, no infra touched. Safe to fix and re-run; nothing was deployed.
+- **Infrastructure stack (CloudFormation)** — a stack update failed. The dangerous class: a stack left in a rollback state usually **can't be updated again** until it's resolved, so a naive re-run fails identically. See the runbook.
+- **App service (API / orchestrator)** — the container-based services roll out on the new image tag; a failure here is often a bad image, a failed health check, or a migration abort (see `/migrate`).
+- **Post-deploy refresh** — the graph tier cycles its instances separately from the app services; this can wait on in-flight work or fail on health, without the app deploy being bad.
+
+## 3. Remediate, then re-deploy
+
+Fix the root cause first (code fix + merge, a stuck stack resolved, a config/variable corrected). Then, **with the user's confirmation**, re-trigger:
+
+```bash
+just deploy staging          # or: just deploy prod <tag>
+# equivalently: gh workflow run staging.yml --ref <branch-or-tag>
+```
+
+Note the deploy workflow is **serialized** (a concurrency group) — a new run queues behind any in-flight one rather than cancelling it. Don't fire a second deploy expecting it to preempt the first.
+
+## 4. Verify health
+
+A green workflow means the pipeline finished, not that the app is serving. Confirm the API process is answering:
+
+```bash
+curl -sf https://<api-host>/v1/status && echo OK      # public API over HTTPS
+# if the API is in internal mode: tunnel first, then curl http://localhost:8000/v1/status
+```
+
+`/v1/status` is a **liveness** probe — it returns healthy whenever the process is up; it does **not** check the database, cache, or graph. A 200 means "the API is serving HTTP," not "the stack is healthy." Confirm the rest yourself: the app service (running vs desired count), recent errors in its log group, and — if the deploy carried a migration — the orchestrator boot logs (`/migrate`).
+
+## Output
+
+A short status: what failed and at which stage, the root cause, what you changed, the re-run link, and the post-deploy health result. If nothing failed, say so — don't manufacture work.

--- a/.claude/commands/incident.md
+++ b/.claude/commands/incident.md
@@ -1,0 +1,49 @@
+A signal says something is wrong — a customer report, an internal user, an alarm email, a spike. This skill gives you a fast, ordered headstart on **where to look**: triage the signal to a likely subsystem, gather the state that confirms or rules it out, and hand back a crisp picture (impact, likely cause, next action). Pairs with the `incident-triage` runbook for the account's known failure classes and exact log groups.
+
+## Goal
+
+Compress time-to-orientation. You're not expected to fix everything from here — you're expected to answer, quickly and with evidence: **what's broken, how bad, since when, and what changed.** Breadth before depth: check the obvious surfaces in parallel, then drill into the one that lights up.
+
+## Scope & guardrails
+
+- **Read-only triage.** `describe-*` / `list-*` / `get-*`, log reads, `gh` reads. Any remediation — restarting a service, cycling an instance, rolling back, editing data — is a separate, **confirmed** step, not part of triage. Never `get-secret-value`.
+- **Output is sensitive — never commit it.** Incident notes name live hostnames, resource IDs, error contents, maybe customer identifiers. Keep them in the scratchpad or a private channel; never in the repo, never in a public Artifact.
+- **State the confidence.** Distinguish *confirmed* (you saw the error/alarm) from *suspected* (fits the pattern). A wrong confident diagnosis sends everyone the wrong way.
+
+## 1. Pin the signal
+
+Get concrete before searching. From whoever/whatever raised it: **what** is failing (an endpoint? a product surface? everything?), **who** is affected (one tenant or all?), **when** it started, and **what changed** near then. A single-tenant issue and a platform-wide outage need completely different first moves.
+
+Immediately check "what changed": the most recent deploy is the highest-prior cause.
+
+```bash
+gh run list --workflow=prod.yml --limit 5      # last deploys: when, success/fail, by whom
+```
+
+## 2. Is the platform up? (breadth, in parallel)
+
+Sweep the front-to-back surfaces at once; whichever is unhealthy narrows everything. Fan these out:
+
+- **API liveness** — the status endpoint (`/v1/status`); is the API answering HTTP at all? It's a **liveness** probe only — a 200 says the process is up, *not* that its dependencies are healthy, so don't stop here.
+- **Active alarms** — `aws cloudwatch describe-alarms --state-value ALARM` — what's already firing, and since when.
+- **App/orchestrator services** — running-vs-desired counts; anything crash-looping or scaled to zero.
+- **Datastores** — primary database, cache, and the graph tier reachable and healthy.
+- **Recent errors** — the API and worker log groups for an error spike aligned to the start time.
+
+A denied/empty read is itself information (permission gap, or the thing genuinely isn't there) — say which.
+
+## 3. Drill into the surface that lit up
+
+Follow the one unhealthy signal down. Correlate its onset to the deploy timeline from step 1 — an error wall that starts at a deploy time points at that release (roll forward/back); one with no deploy nearby points at infra, a dependency, data, or load. The runbook lists this system's **recurring failure classes** and the tell for each — consult it, because the same handful of issues recur and each has a known fingerprint and fix.
+
+## 4. Hand back a picture
+
+Produce a short incident summary:
+
+- **Impact** — what's broken, who's affected, blast radius.
+- **Timeline** — when it started; what changed near then (deploy? config? load?).
+- **Evidence** — the alarms/log lines/health results you actually saw (confirmed vs suspected).
+- **Likely cause** — best current hypothesis, with confidence.
+- **Recommended next action** — roll back, restart, scale, escalate — framed as a proposal for the user to approve, not an action already taken.
+
+Keep it tight enough to paste into a status update. If triage is inconclusive, say so and name the next diagnostic — don't force a conclusion.

--- a/.claude/commands/migrate.md
+++ b/.claude/commands/migrate.md
@@ -1,0 +1,42 @@
+Verify that a release's database migrations applied cleanly. In this system migrations run automatically on the orchestrator daemon's boot during a deploy — so "running a migration" is almost always **watching that boot succeed**, not invoking anything by hand. Pairs with the `migration-monitoring` runbook for exact service/log-group names and the manual fallback.
+
+## How migrations actually run here
+
+- The **orchestrator daemon** is a singleton (desired count 1). On boot in staging/prod it runs the schema migrations *before* the daemon comes up: platform database first, then the extensions database (only when a product domain that uses it is enabled).
+- Migrations are **fail-closed**: if a migration errors, the entrypoint aborts and the daemon does **not** start. A bad migration therefore surfaces as a daemon that won't boot / a crash-looping task — not as silent drift.
+- This means the schema is migrated as part of the normal deploy of the release that carries it. There is no separate "migrate" button for the common case.
+
+## When this runs
+
+- **Common (~99%)**: a release includes a migration and you want to confirm it landed → tail the daemon boot logs during/after the deploy for the success marker, and confirm the daemon reached a running state.
+- **Rare (<1%)**: migrations must be applied out-of-band (daemon can't boot, or you're forcing a schema change ahead of the app). That's the manual path — a tunnel to the bastion + the migrate recipe — and it's in the runbook.
+
+## Scope & guardrails
+
+- **Reading logs is free; applying a migration is not.** Tailing the daemon's log group and checking task health need no confirmation. The **manual apply path mutates the production schema** — confirm with the user, and never run it speculatively.
+- **Two databases, two histories.** Platform and extensions migrate independently. When something's off, say *which* database — the log lines and the migrate recipe are per-database.
+- **Autogenerate only.** If a fix requires a *new* migration, it comes from updating the model + autogenerating — never hand-author one against prod.
+
+## 1. Watch the boot (common path)
+
+During the deploy, the daemon's boot log is where migrations report. You're looking for the migration-start lines, the per-database success markers, and then the daemon actually starting. Read the log group for the orchestrator daemon (name in the runbook) around the deploy time, or scope to the newest log stream.
+
+Confirm two things:
+1. The migration success marker printed (platform, and extensions if enabled).
+2. The daemon task is **running** (not crash-looping) — a booted daemon is the real proof the migration passed, because a failed migration aborts boot.
+
+## 2. If the daemon won't boot
+
+A daemon stuck restarting right after a release almost always means the migration failed. Pull the boot log and find the abort line — it names which database and the underlying error (a bad revision, a type/constraint autogenerate missed, a missing dependency). This is a code/migration fix, re-cut into a new build — not something to paper over by editing prod.
+
+## 3. Manual apply (rare fallback)
+
+Only when the automatic path can't run and the user has confirmed. There are two manual paths and they differ in **coverage**: a bastion-run helper that applies the **platform** database (creds handled for you), and a tunnel + per-database migrate recipe that can also apply **extensions**. Check the current revision before and after. Exact commands are in the runbook — pick the path that covers the database you actually need.
+
+## A note on the other "migration"
+
+This system also has a **graph-data version migration** (export/import of graph databases across engine versions, run as orchestrator jobs around a graph-engine upgrade). That's a different operation from the schema migrations above — don't conflate them. If the task is a graph-engine version bump, that's the export/import jobs, not this.
+
+## Output
+
+State plainly: did the migration apply, on which database(s), and is the daemon healthy? If it failed, name the database, quote the abort line, and describe the fix — don't declare success off a green *workflow* alone; confirm the daemon booted.


### PR DESCRIPTION
## Summary

Adds three Claude Code skills covering the operational "execute-safely" surface — watching a deploy, verifying a migration, and triaging an incident. Until now the repo's skills were all read-only *audit* reviews (cost / security / soc2 / reliability); these are the first that support acting during a live operational event. Each is the generic, public methodology; the account-specific detail lives in paired **private, git-ignored runbooks** (not in this PR).

## Changes

- **`.claude/commands/deploy.md`** (`/deploy`) — framed on the failure case (re-run a failed deploy and watch this one): find the first failed job, classify by stage (test/build vs CloudFormation vs ECS service vs graph refresh), remediate, re-trigger with confirmation, verify health. Calls out that `/v1/status` is a **liveness** probe, not a stack-health check.
- **`.claude/commands/migrate.md`** (`/migrate`) — migrations run on the Dagster daemon's boot (singleton, fail-closed → a bad migration aborts boot), so "monitoring" = confirming the daemon booted. Documents the two manual fallback paths and that they differ in database coverage (bastion helper is platform-only).
- **`.claude/commands/incident.md`** (`/incident`) — triage a "something's wrong" signal: pin what changed (last deploy), breadth-sweep the surfaces, hand back an impact / cause / next-action picture. No specific incidents cited (public methodology).

## Testing

Docs-only change (skill markdown; no runtime code). Pre-commit hooks (ruff format/lint) passed on commit — `0 errors, 0 warnings`. `just test-all` not applicable and not run (no code paths touched).

## Notes

- These pair with private runbooks under `local/RoboSystems/runbooks/` (`deployment-monitoring`, `migration-monitoring`, `incident-triage`) that carry the real stack/service names, log groups, and known failure classes — intentionally git-ignored, not committed.
- All three were verified against the live account during authoring (correct ECS service names, CloudWatch log groups, migration-on-boot behavior, `/v1/status` semantics), which corrected several initial pattern-guesses.
