### PR TITLE
fix(graph-api): tolerate schema-removed columns in DuckDB dedup insert

### DIFF
--- a/robosystems/graph_api/core/duckdb/manager.py
+++ b/robosystems/graph_api/core/duckdb/manager.py
@@ -581,6 +581,14 @@ class DuckDBTableManager:
               return '"to" AS dst'
             if null_cols and table_col in null_cols:
               return f'NULL AS "{table_col}"'
+            # Target has a column the source parquet lacks — e.g. a property
+            # removed from the schema after this table was first created (an
+            # older full-rebuild left the column behind; schema evolution only
+            # adds source columns, never drops stale target-only ones). NULL it
+            # rather than referencing a nonexistent source column, which would
+            # raise "Values list 't' does not have a column named ...".
+            if table_col not in parquet_columns:
+              return f'NULL AS "{table_col}"'
             return f't."{table_col}"'
 
           select_expr = ", ".join(_explicit_col_expr(c) for c in post_cols)

--- a/tests/graph_api/test_duckdb_manager.py
+++ b/tests/graph_api/test_duckdb_manager.py
@@ -485,6 +485,76 @@ class TestInsertIntoTable:
     assert '"identifier"' in insert_sql[0]
 
   @patch("robosystems.graph_api.core.duckdb.manager.get_duckdb_pool")
+  def test_insert_deduplicate_true_target_column_absent_from_parquet(
+    self, mock_get_pool
+  ):
+    """Target column missing from the source parquet is NULLed, not selected.
+
+    Regression: a full rebuild created the table with a column (e.g.
+    "classification") that a later schema change dropped from the parquet.
+    Schema evolution only adds source columns, never drops stale target-only
+    ones, so the target-column-driven INSERT must not reference t."classification"
+    (which raises 'Values list "t" does not have a column named ...').
+    """
+    mock_pool = MagicMock()
+    mock_conn = MagicMock()
+    mock_pool.get_connection.return_value.__enter__.return_value = mock_conn
+    mock_get_pool.return_value = mock_pool
+
+    mock_count_before = MagicMock()
+    mock_count_before.fetchone.return_value = (100,)
+
+    # Table has a stale "classification" column left by an older full rebuild.
+    mock_probe = MagicMock()
+    mock_probe.description = [
+      ("identifier", None),
+      ("name", None),
+      ("classification", None),
+      ("embedding", None),
+    ]
+
+    # Current parquet no longer emits "classification".
+    mock_parquet_probe = MagicMock()
+    mock_parquet_probe.description = [
+      ("identifier", None),
+      ("name", None),
+      ("embedding", None),
+    ]
+
+    mock_count_after = MagicMock()
+    mock_count_after.fetchone.return_value = (120,)
+
+    mock_conn.execute.side_effect = [
+      mock_count_before,  # COUNT before
+      mock_probe,  # table schema probe
+      mock_parquet_probe,  # parquet schema probe
+      None,  # INSERT INTO (no ALTER — no new source columns)
+      mock_count_after,  # COUNT after
+      None,  # CHECKPOINT
+    ]
+
+    request = TableCreateRequest(
+      graph_id="test_graph",
+      table_name="Element",
+      s3_pattern="s3://bucket/data/*.parquet",
+      deduplicate=True,
+    )
+
+    response = self.manager.insert_into_table(request)
+
+    assert response.status == "success"
+    execute_calls = [call[0][0] for call in mock_conn.execute.call_args_list]
+    insert_sql = [c for c in execute_calls if "INSERT INTO" in c]
+    assert len(insert_sql) == 1
+    # The stale column is present in the INSERT column list but NULLed in SELECT.
+    assert '"classification"' in insert_sql[0]
+    assert 'NULL AS "classification"' in insert_sql[0]
+    assert 't."classification"' not in insert_sql[0]
+    # Columns that do exist in the parquet are still selected normally.
+    assert 't."identifier"' in insert_sql[0]
+    assert 't."name"' in insert_sql[0]
+
+  @patch("robosystems.graph_api.core.duckdb.manager.get_duckdb_pool")
   def test_insert_deduplicate_true_relationship_src_dst(self, mock_get_pool):
     """deduplicate=True on table with src/dst but parquet with from/to renames columns."""
     mock_pool = MagicMock()


### PR DESCRIPTION
## Summary

SEC `sec_incremental_stage` began failing in prod on step `[4/41] Element` with `Binder Error: Values list "t" does not have a column named "classification"`. The staging DuckDB's `Element` table — created by an old full rebuild (2026-03-23) — still carries a `classification` column that the `classification`→`traits` refactor (`e6053fbb`, 2026-04-25) removed from the Element parquet. The dedup INSERT builds its column list from the **target table** and emitted `t."classification"` against a parquet that no longer has that column.

This PR makes the dedup insert tolerant of that drift: any target column absent from the source parquet is `NULL`-filled instead of selected by name.

## Root cause

- `insert_into_table` (`deduplicate=True`) computes `post_cols` from the existing table schema, then `_explicit_col_expr` mapped every ordinary column to `t."<col>"`.
- Schema evolution only ever **adds** source columns to the target; it never drops a stale target-only column. So once a full rebuild left `classification` behind, it stayed.
- The failure only surfaced after the 2026-07-03 graph_api deploy — the previous build's insert tolerated the surplus target column, the new build referenced it by name. The stale column itself had been latent since March.

## Changes

- **`robosystems/graph_api/core/duckdb/manager.py`** — in `_explicit_col_expr`, add a branch: when a target column is not present in `parquet_columns`, emit `NULL AS "<col>"` (mirroring the existing `null_columns` handling) rather than `t."<col>"`. Covers both incremental inserts and multi-quarter full rebuilds across mixed-schema history.
- **`tests/graph_api/test_duckdb_manager.py`** — add `test_insert_deduplicate_true_target_column_absent_from_parquet`, a regression test asserting the stale column appears in the INSERT column list but is `NULL AS "classification"` in the SELECT (and never `t."classification"`), while columns that do exist in the parquet are still selected normally.

## Testing

- `just test-code` (ruff + format + basedpyright + cf-lint): **passed**.
- Verified the fix end-to-end against a real in-memory DuckDB reproducing the exact prod condition (target `Element` table with a stale `classification` column, parquet without it): insert now **succeeds** and NULL-fills the column for new rows instead of raising the binder error.
- `just test` (unit suite) not run in-session — requires the local Docker stack, which was down; the new mock-based test is exercised by CI.

## Notes

- The prod incident was separately unblocked by dropping the stale column directly on the SEC master's staging DuckDB (`ALTER TABLE "Element" DROP COLUMN "classification"`; verified `Element` is now 21 columns). This PR is the durable guard so the same class of drift — any property removed from a node/relationship schema after a table was first built — can't break staging again.
- A full rebuild was explicitly *not* used as the fix: 2015→2026-Q1 Element parquet still contain `classification`, so `union_by_name` would have reintroduced the column.
