### PR TITLE
chore(opensearch): parameterize cluster scaling and Multi-AZ as inert GH-var levers

### DIFF
--- a/.github/workflows/deploy-opensearch.yml
+++ b/.github/workflows/deploy-opensearch.yml
@@ -29,8 +29,8 @@ on:
         description: "VPC ID for OpenSearch"
         required: true
         type: string
-      subnet_id:
-        description: "Private subnet ID for OpenSearch (single-AZ)"
+      subnet_ids:
+        description: "Comma-separated private subnet IDs (first is used for single-AZ; first N for Multi-AZ)"
         required: true
         type: string
 
@@ -40,6 +40,36 @@ on:
         required: false
         type: string
         default: "t3.small.search"
+      instance_count:
+        description: "Number of data nodes (1 = single-AZ; >=2 for Multi-AZ)"
+        required: false
+        type: string
+        default: "1"
+      zone_awareness_enabled:
+        description: "Distribute data nodes across AZs (requires instance_count >= 2)"
+        required: false
+        type: string
+        default: "false"
+      availability_zone_count:
+        description: "Number of AZs to spread data nodes across when zone awareness enabled (2 or 3)"
+        required: false
+        type: string
+        default: "2"
+      dedicated_master_enabled:
+        description: "Enable dedicated master nodes (independent HA/quorum lever; recommended at Multi-AZ rollout)"
+        required: false
+        type: string
+        default: "false"
+      dedicated_master_type:
+        description: "Instance type for dedicated masters (used only when enabled; small is fine)"
+        required: false
+        type: string
+        default: "t3.small.search"
+      dedicated_master_count:
+        description: "Number of dedicated masters (used only when enabled; 3 recommended, odd)"
+        required: false
+        type: string
+        default: "3"
       ebs_volume_size:
         description: "EBS volume size in GB"
         required: false
@@ -112,13 +142,26 @@ jobs:
             echo "is_new_stack=false" >> $GITHUB_OUTPUT
           fi
 
-          # Extract first subnet from comma-separated list (single-AZ deployment)
-          SUBNET_ID=$(echo "${{ inputs.subnet_id }}" | cut -d ',' -f1)
+          # Select subnets for the domain. Single-AZ (default) uses the first subnet —
+          # byte-identical to the prior `cut -f1` behavior. Multi-AZ uses the first N
+          # (one per AZ); CFN List<AWS::EC2::Subnet::Id> params need commas escaped as
+          # "\," in the CLI shorthand so the list stays one ParameterValue.
+          if [ "${{ inputs.zone_awareness_enabled }}" = "true" ]; then
+            SUBNET_IDS=$(echo "${{ inputs.subnet_ids }}" | cut -d ',' -f1-${{ inputs.availability_zone_count }} | sed 's/,/\\,/g')
+          else
+            SUBNET_IDS=$(echo "${{ inputs.subnet_ids }}" | cut -d ',' -f1)
+          fi
 
           OPENSEARCH_STACK_PARAMS="ParameterKey=VpcId,ParameterValue=${{ inputs.vpc_id }} \
-                ParameterKey=SubnetId,ParameterValue=${SUBNET_ID} \
+                ParameterKey=SubnetIds,ParameterValue=${SUBNET_IDS} \
                 ParameterKey=Environment,ParameterValue=${{ inputs.environment }} \
                 ParameterKey=InstanceType,ParameterValue=${{ inputs.instance_type }} \
+                ParameterKey=InstanceCount,ParameterValue=${{ inputs.instance_count }} \
+                ParameterKey=ZoneAwarenessEnabled,ParameterValue=${{ inputs.zone_awareness_enabled }} \
+                ParameterKey=AvailabilityZoneCount,ParameterValue=${{ inputs.availability_zone_count }} \
+                ParameterKey=DedicatedMasterEnabled,ParameterValue=${{ inputs.dedicated_master_enabled }} \
+                ParameterKey=DedicatedMasterType,ParameterValue=${{ inputs.dedicated_master_type }} \
+                ParameterKey=DedicatedMasterCount,ParameterValue=${{ inputs.dedicated_master_count }} \
                 ParameterKey=EBSVolumeSize,ParameterValue=${{ inputs.ebs_volume_size }} \
                 ParameterKey=EngineVersion,ParameterValue=OpenSearch_${{ inputs.engine_version }} \
                 ParameterKey=BastionSecurityGroupId,ParameterValue=${{ inputs.bastion_sg_id }} \

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -323,9 +323,15 @@ jobs:
       # AWS Configuration
       aws_region: ${{ vars.AWS_REGION || 'us-east-1' }}
       vpc_id: ${{ needs.deploy-vpc.outputs.vpc_id }}
-      subnet_id: ${{ needs.deploy-vpc.outputs.private_subnet_ids }}
+      subnet_ids: ${{ needs.deploy-vpc.outputs.private_subnet_ids }}
       # Instance Configuration
       instance_type: ${{ vars.OPENSEARCH_INSTANCE_TYPE_PROD || 't3.medium.search' }}
+      instance_count: ${{ vars.OPENSEARCH_INSTANCE_COUNT_PROD || '1' }}
+      zone_awareness_enabled: ${{ vars.OPENSEARCH_ZONE_AWARENESS_PROD || 'false' }}
+      availability_zone_count: ${{ vars.OPENSEARCH_AZ_COUNT_PROD || '2' }}
+      dedicated_master_enabled: ${{ vars.OPENSEARCH_DEDICATED_MASTER_PROD || 'false' }}
+      dedicated_master_type: ${{ vars.OPENSEARCH_MASTER_TYPE_PROD || 't3.small.search' }}
+      dedicated_master_count: ${{ vars.OPENSEARCH_MASTER_COUNT_PROD || '3' }}
       ebs_volume_size: ${{ vars.OPENSEARCH_EBS_SIZE_PROD || '100' }}
       # Engine Version Configuration
       engine_version: ${{ vars.OPENSEARCH_VERSION_PROD || '2.19' }}

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -340,9 +340,15 @@ jobs:
       # AWS Configuration
       aws_region: ${{ vars.AWS_REGION || 'us-east-1' }}
       vpc_id: ${{ needs.deploy-vpc.outputs.vpc_id }}
-      subnet_id: ${{ needs.deploy-vpc.outputs.private_subnet_ids }}
+      subnet_ids: ${{ needs.deploy-vpc.outputs.private_subnet_ids }}
       # Instance Configuration
       instance_type: ${{ vars.OPENSEARCH_INSTANCE_TYPE_STAGING || 't3.medium.search' }}
+      instance_count: ${{ vars.OPENSEARCH_INSTANCE_COUNT_STAGING || '1' }}
+      zone_awareness_enabled: ${{ vars.OPENSEARCH_ZONE_AWARENESS_STAGING || 'false' }}
+      availability_zone_count: ${{ vars.OPENSEARCH_AZ_COUNT_STAGING || '2' }}
+      dedicated_master_enabled: ${{ vars.OPENSEARCH_DEDICATED_MASTER_STAGING || 'false' }}
+      dedicated_master_type: ${{ vars.OPENSEARCH_MASTER_TYPE_STAGING || 't3.small.search' }}
+      dedicated_master_count: ${{ vars.OPENSEARCH_MASTER_COUNT_STAGING || '3' }}
       ebs_volume_size: ${{ vars.OPENSEARCH_EBS_SIZE_STAGING || '100' }}
       # Engine Version Configuration
       engine_version: ${{ vars.OPENSEARCH_VERSION_STAGING || '2.19' }}

--- a/bin/setup/gha.sh
+++ b/bin/setup/gha.sh
@@ -393,11 +393,17 @@ function setup_full_config() {
     gh variable set OPENSEARCH_INSTANCE_TYPE_PROD --body "t3.medium.search"
     gh variable set OPENSEARCH_EBS_SIZE_PROD --body "100"
     gh variable set OPENSEARCH_VERSION_PROD --body "2.19"
+    # Scaling / HA — minimal single-node install. AZ count rides the workflow default;
+    # set the switches (count/zone) to roll out Multi-AZ later (see specs/opensearch-scaling-ha).
+    gh variable set OPENSEARCH_INSTANCE_COUNT_PROD --body "1"
+    gh variable set OPENSEARCH_ZONE_AWARENESS_PROD --body "false"
     if $setup_staging; then
         gh variable set OPENSEARCH_ENABLED_STAGING --body "false"
         gh variable set OPENSEARCH_INSTANCE_TYPE_STAGING --body "t3.medium.search"
         gh variable set OPENSEARCH_EBS_SIZE_STAGING --body "100"
         gh variable set OPENSEARCH_VERSION_STAGING --body "2.19"
+        gh variable set OPENSEARCH_INSTANCE_COUNT_STAGING --body "1"
+        gh variable set OPENSEARCH_ZONE_AWARENESS_STAGING --body "false"
     fi
 
     # LadybugDB Writer Configuration - Standard Tier

--- a/cloudformation/opensearch.yaml
+++ b/cloudformation/opensearch.yaml
@@ -12,9 +12,11 @@ Parameters:
   VpcId:
     Type: AWS::EC2::VPC::Id
     Description: VPC ID for OpenSearch deployment
-  SubnetId:
-    Type: AWS::EC2::Subnet::Id
-    Description: Private subnet ID for OpenSearch domain (single-AZ)
+  SubnetIds:
+    Type: List<AWS::EC2::Subnet::Id>
+    Description: >-
+      Private subnet IDs for the OpenSearch domain. One subnet = single-AZ
+      (today's default); pass 2-3 subnets (one per AZ) at the Multi-AZ rollout.
 
   # Instance Configuration
   InstanceType:
@@ -46,7 +48,48 @@ Parameters:
     Description: EBS volume size in GB
     Default: 100
     MinValue: 10
-    MaxValue: 1000
+    MaxValue: 2048
+
+  # Cluster Scaling / High Availability (all default to today's single-node domain)
+  InstanceCount:
+    Type: Number
+    Description: >-
+      Number of data nodes. 1 = single-node (default). Set >=2 (with
+      ZoneAwarenessEnabled and one subnet per AZ) for a Multi-AZ cluster.
+    Default: 1
+    MinValue: 1
+    MaxValue: 10
+  ZoneAwarenessEnabled:
+    Type: String
+    Description: Distribute data nodes across AZs (requires InstanceCount >= 2 and matching subnets)
+    Default: "false"
+    AllowedValues: ["true", "false"]
+  AvailabilityZoneCount:
+    Type: Number
+    Description: Number of AZs to spread data nodes across when ZoneAwarenessEnabled
+    Default: 2
+    AllowedValues: [2, 3]
+
+  # Dedicated master nodes — an INDEPENDENT HA/quorum lever, separate from data-node scaling.
+  # Off by default. Masters hold no data and serve neither reads nor writes; they only manage
+  # cluster state. At Multi-AZ rollout: 3 masters (odd, for quorum), sized small.
+  DedicatedMasterEnabled:
+    Type: String
+    Description: Enable dedicated master nodes for cluster-management stability + quorum (independent of InstanceCount)
+    Default: "false"
+    AllowedValues: ["true", "false"]
+  DedicatedMasterType:
+    Type: String
+    Description: >-
+      Instance type for dedicated masters (used only when enabled). Small is fine — masters
+      manage cluster state, not queries. Note: t3 works for standard Multi-AZ; Multi-AZ-with-
+      Standby requires a current-gen/Graviton type (e.g. m7g.large.search).
+    Default: t3.small.search
+  DedicatedMasterCount:
+    Type: Number
+    Description: Number of dedicated masters (used only when enabled). 3 recommended; never even, never 1.
+    Default: 3
+    AllowedValues: [3, 5]
 
   # Engine Configuration
   EngineVersion:
@@ -84,6 +127,8 @@ Parameters:
 Conditions:
   IsProduction: !Equals [!Ref Environment, prod]
   HasBastion: !Not [!Equals [!Ref BastionSecurityGroupId, ""]]
+  IsZoneAware: !Equals [!Ref ZoneAwarenessEnabled, "true"]
+  HasDedicatedMaster: !Equals [!Ref DedicatedMasterEnabled, "true"]
 
 Resources:
   # Security Group for OpenSearch Domain
@@ -155,12 +200,18 @@ Resources:
       DomainName: !Sub "robosystems-${Environment}"
       EngineVersion: !Ref EngineVersion
 
-      # Cluster Configuration — single node, no dedicated masters
+      # Cluster Configuration — parameterized; defaults preserve the single-node domain
       ClusterConfig:
         InstanceType: !Ref InstanceType
-        InstanceCount: 1
-        DedicatedMasterEnabled: false
-        ZoneAwarenessEnabled: false
+        InstanceCount: !Ref InstanceCount
+        DedicatedMasterEnabled: !If [HasDedicatedMaster, true, false]
+        DedicatedMasterType: !If [HasDedicatedMaster, !Ref DedicatedMasterType, !Ref "AWS::NoValue"]
+        DedicatedMasterCount: !If [HasDedicatedMaster, !Ref DedicatedMasterCount, !Ref "AWS::NoValue"]
+        ZoneAwarenessEnabled: !If [IsZoneAware, true, false]
+        ZoneAwarenessConfig: !If
+          - IsZoneAware
+          - AvailabilityZoneCount: !Ref AvailabilityZoneCount
+          - !Ref "AWS::NoValue"
         WarmEnabled: false
 
       # Storage
@@ -171,10 +222,9 @@ Resources:
         Iops: 3000
         Throughput: 125
 
-      # VPC Configuration — private subnet only
+      # VPC Configuration — one subnet (single-AZ) or one-per-AZ (Multi-AZ)
       VPCOptions:
-        SubnetIds:
-          - !Ref SubnetId
+        SubnetIds: !Ref SubnetIds
         SecurityGroupIds:
           - !Ref OpenSearchSecurityGroup
 


### PR DESCRIPTION
## Summary

Makes OpenSearch node count, zone-awareness, and dedicated masters GitHub-variable-driven so the single→Multi-AZ transition becomes a **variable flip** rather than a template change. Every new parameter defaults to today's exact single-node domain, so the resolved CloudFormation template is unchanged — an inert no-op today, with the levers live to control later. No application behavior changes; no Python touched.

## Context

The prod OpenSearch domain is single-node / single-AZ / 0-replica. Only *vertical* scaling (instance type, EBS, version) was GH-var-driven; node count and Multi-AZ were hardcoded in the template, so "flip a var to go Multi-AZ" was not true. This closes that gap **without changing the running domain** — prod stays 1 instance / no Multi-AZ. When Multi-AZ is later needed, it becomes a var flip + a `put_settings` + a 2nd RI, not a rebuild.

## Changes

**`cloudformation/opensearch.yaml`**
- `SubnetId` (single `AWS::EC2::Subnet::Id`) → `SubnetIds` (`List<AWS::EC2::Subnet::Id>`); `VPCOptions.SubnetIds` is now `!Ref SubnetIds`. Default resolves to the same single first subnet.
- **Lever 1 (capacity/AZ):** new `InstanceCount`, `ZoneAwarenessEnabled`, `AvailabilityZoneCount` params; `ClusterConfig` `InstanceCount` / `ZoneAwarenessEnabled` / `ZoneAwarenessConfig` are driven by them (via an `IsZoneAware` condition), defaulting to `1` / `false` / absent — identical to the prior hardcoded values.
- **Lever 2 (HA/quorum):** new `DedicatedMasterEnabled` (+ `DedicatedMasterType` / `DedicatedMasterCount`), gated behind a `HasDedicatedMaster` condition; renders the same hardcoded `DedicatedMasterEnabled: false` by default. Masters are a control-plane role (no data, no reads/writes), hence a separate/smaller instance type.
- `EBSVolumeSize` `MaxValue` `1000` → `2048`.

**`.github/workflows/deploy-opensearch.yml`**
- Renamed input `subnet_id` → `subnet_ids`; added `instance_count` / `zone_awareness_enabled` / `availability_zone_count` / `dedicated_master_*` inputs (single-node defaults).
- Subnet selection: single-AZ uses the first subnet (byte-identical to the prior `cut -f1`); the Multi-AZ branch passes the first N subnets with comma-escaping for the CFN list param.
- Threads the new params into the stack deploy call.

**`.github/workflows/{prod,staging}.yml`**
- Wired the new inputs to `OPENSEARCH_*_{PROD,STAGING}` vars with single-node fallbacks; renamed `subnet_id` → `subnet_ids` (now consistent with every other stack, which already used plural `subnet_ids`).

**`bin/setup/gha.sh`**
- Seeds only the minimal single-node switches (`OPENSEARCH_INSTANCE_COUNT=1`, `OPENSEARCH_ZONE_AWARENESS=false`) per env; the AZ-count and master knobs ride the workflow `||` defaults until rollout.

## Testing

- `cfn-lint cloudformation/opensearch.yaml` — **pass** (exit 0)
- `aws cloudformation validate-template` — **pass** (exit 0)
- `just test-code` (ruff + format + basedpyright + cf-lint) — **pass**; no Python changed.
- `just test` (unit suite) — **Not run** (no Python touched, no behavior change).

## Notes / Follow-ups

- **Inertness verification gate:** the "no-op" claim is verified statically (defaults render identical values), but the load-bearing confirmation is a CloudFormation **change-set showing an empty diff** against the live prod stack. That can't run without a write to prod, so it happens at the first prod deploy carrying this branch. If the diff isn't empty, the `SubnetId → SubnetIds` type change is the suspect.
- **Prod vars already set:** `OPENSEARCH_INSTANCE_COUNT_PROD=1`, `OPENSEARCH_ZONE_AWARENESS_PROD=false` (keeps prod exactly as today).
- **Replica count intentionally excluded** — it's a runtime `put_settings` on the live index at rollout, not app config (an env var would only apply at index creation and would need threading through both index-creators).
- **To go Multi-AZ later** (all var flips, no code): `OPENSEARCH_INSTANCE_COUNT_PROD=2` + `OPENSEARCH_ZONE_AWARENESS_PROD=true` + `OPENSEARCH_DEDICATED_MASTER_PROD=true` → deploy → `put_settings` replicas=1 → buy the 2nd RI.
