### PR TITLE
fix(waf): stop blocking document/image saves at 8KB body size

### DIFF
--- a/cloudformation/waf.yaml
+++ b/cloudformation/waf.yaml
@@ -201,11 +201,16 @@ Resources:
           Statement:
             OrStatement:
               Statements:
-                # Block requests with body larger than 8MB
+                # Body size guard. WAF only inspects the first 8KB of the
+                # body on regional (ALB) resources, so OversizeHandling MUST be
+                # CONTINUE here — MATCH would treat *any* body over 8KB as a hit
+                # and block it with a 413 (the Size: 8388608 / 8MB threshold is
+                # never actually reached because WAF can't see past 8KB). Real
+                # large-payload limits are enforced at the application layer.
                 - SizeConstraintStatement:
                     FieldToMatch:
                       Body:
-                        OversizeHandling: MATCH
+                        OversizeHandling: CONTINUE
                     ComparisonOperator: GT
                     Size: 8388608
                     TextTransformations:


### PR DESCRIPTION
## Problem

Document PUTs (`PUT /v1/graphs/{g}/documents/{id}`) fail with **`413` for any request body over 8 KB** — e.g. pasting a screenshot (Monaco inlines it as a base64 `data:` URI) or editing markdown content larger than 8 KB. Because the 413 comes from WAF/ALB with no CORS headers, the browser mislabels it as a **CORS error** (`No 'Access-Control-Allow-Origin' header`), with `net::ERR_FAILED 413` underneath.

## Root cause

The `SizeRestrictions` rule (Priority 4) in `cloudformation/waf.yaml` intends to block bodies **> 8 MB**, but used `OversizeHandling: MATCH` on the body field. WAF only inspects the **first 8 KB** of a request body on regional (ALB) resources, so `MATCH` treats *any* body over 8 KB as a hit — the `Size: 8388608` (8 MB) comparison is never actually evaluated. The effective cap was **8 KB, not 8 MB**.

Verified against prod by bisecting body size: ≤ 7 KB → reaches app (`401`/`403`), ≥ 8 KB → `413` from `server: awselb/2.0` with body `{"error": "Request payload too large."}` (the rule's `PayloadTooLarge` custom response).

## Fix

Switch the body field to `OversizeHandling: CONTINUE` so bodies over the inspection window pass through. Real large-payload limits are enforced at the application layer. The separate "headers > 8 KB" sub-rule is unaffected.

## Deploy notes

- CloudFormation change → ships via GitHub Actions to **both prod and staging** (the affected graph is in prod).
- No app/code change; WAF WebACL update only.