### PR TITLE
fix(search): pin embedding onnxruntime to 1 thread (~5x faster)

### DIFF
--- a/robosystems/operations/search/embeddings.py
+++ b/robosystems/operations/search/embeddings.py
@@ -14,6 +14,13 @@ MODEL_NAME = "BAAI/bge-small-en-v1.5"
 EMBEDDING_DIMENSIONS = 384
 EMBEDDING_MODEL_ID = "fastembed"
 
+# onnxruntime intra-op thread count. Pinned to 1 on purpose: in CPU-limited
+# containers (ECS Fargate), letting onnxruntime auto-size its thread pool
+# oversubscribes the CFS quota — the spin-wait threads contend instead of
+# compute, making embedding ~5x SLOWER. Benchmarked on this workload:
+# threads=None ~1280ms/section vs threads=1 ~240ms/section.
+EMBEDDING_THREADS = 1
+
 
 class EmbeddingService:
   """Text embedding using fastembed (included, no credits)."""
@@ -27,7 +34,7 @@ class EmbeddingService:
     if self._model is None:
       from fastembed import TextEmbedding
 
-      self._model = TextEmbedding(MODEL_NAME)
+      self._model = TextEmbedding(MODEL_NAME, threads=EMBEDDING_THREADS)
       logger.info(f"Loaded embedding model: {MODEL_NAME} ({EMBEDDING_DIMENSIONS}d)")
     return self._model
 


### PR DESCRIPTION
## Summary

Document saves (`POST`/`PUT /v1/graphs/{g}/documents/{id}`) were stalling for **8–17 seconds**. The save synchronously sections → embeds → indexes content into OpenSearch before returning, and the embedding step was pathologically slow — ~1s per section for a tiny 384-dim model that should do hundreds/sec. Root cause: `EmbeddingService` built `TextEmbedding(MODEL_NAME)` with **no `threads` argument**, so onnxruntime auto-sized its intra-op thread pool to the host core count. In a CPU-limited container (ECS Fargate) that oversubscribes the CFS quota — the spin-wait threads contend instead of compute. Pinning `threads=1` makes embedding ~5× faster.

## Changes

- `robosystems/operations/search/embeddings.py`
  - Added `EMBEDDING_THREADS = 1` module constant with a comment explaining the oversubscription pathology and the benchmark that justifies the value.
  - Passed `threads=EMBEDDING_THREADS` to the `TextEmbedding(...)` constructor (previously unset → onnxruntime default).

No output change — thread count only affects intra-op parallelism, not the embedding vectors.

## Benchmark

Measured through the real `EmbeddingService.embed_batch` path, 8-section doc:

| threads | 8-section doc | per section |
| --- | --- | --- |
| None (previous) | ~10.3s cold / ~8.2s warm | ~1280ms |
| **1 (this PR)** | ~2.4s cold / ~1.9s warm | ~240ms |
| 4 | ~2.6s | ~320ms |
| 14 | ~8.4s | ~1050ms |

More threads = slower; `threads=1` is the stable sweet spot.

## Testing

- `just test operations/search` → **74 passed**.
- `just test-code` (ruff + format + basedpyright + cf-lint) → **clean**.
- Manual verification in the running `robosystems-api` container: 8-section doc dropped from ~10.7s to ~2.4s cold / ~1.9s warm via `EmbeddingService`.
- Full `just test-all` suite: not run this session.

## Notes / Follow-ups

- The oversubscription pathology is general to CPU-limited containers, so the win should carry to prod Graviton/Fargate — to be validated after deploy.
- This is the performance half of a two-part document-save investigation. The other half — a WAF rule that capped request bodies at 8 KB instead of the intended 8 MB and surfaced as a browser CORS error — is fixed separately in #821.
- A worker-offload of the embed/index step was considered and deemed unnecessary once embedding is fast enough for synchronous saves.
