### PR TITLE
feat(extensions): materialize is_live flag on ledger-spine nodes

### DIFF
--- a/robosystems/middleware/mcp/tools/constants.py
+++ b/robosystems/middleware/mcp/tools/constants.py
@@ -28,21 +28,28 @@ Note: Element.period_type indicates the expected period type for that metric - d
 # tenant roboledger ledger spine (Event / Transaction / Entry / LineItem). The
 # graph mirrors the FULL ledger including cancelled/replaced rows; readers must
 # filter to live rows or voided/reversed amounts inflate counts and sums.
-LEDGER_STATUS_GUIDANCE = """**⚠️ LEDGER STATUS FILTERING (Event / Entry / Transaction):**
+LEDGER_STATUS_GUIDANCE = """**⚠️ LEDGER STATUS FILTERING (Event / Entry / Transaction / LineItem):**
 The graph is a faithful mirror of the ledger and KEEPS cancelled and replaced rows —
-voided and superseded entries are NOT removed (they are real audit history). When you
-COUNT or AGGREGATE ledger-spine data you MUST filter to live rows, or voided/reversed
-amounts will inflate the result:
-- `Entry.status` ∈ {draft, posted, reversed}. For balances and debit/credit sums,
-  match ONLY `e.status = 'posted'`. `draft` = unposted (includes entries belonging to
-  voided events); `reversed` = superseded by a reversing entry.
-- `Event.status` ∈ {captured, classified, committed, pending, fulfilled, voided,
-  superseded}. EXCLUDE `voided` and `superseded` from counts/sums. For open
-  obligations use the positive set the question implies (e.g. committed/fulfilled/pending).
-- `Transaction` exposes only a `pending` boolean in the graph (NOT the full status),
-  so a voided transaction is indistinguishable at the Transaction node. To measure
-  realized economic effect, aggregate through `Entry`/`LineItem` filtered to
-  `Entry.status = 'posted'` — do NOT sum `Transaction.amount` directly.
-- `Fact` nodes (the XBRL hypercube / published statements) have NO status and are
-  already filtered at generation time — they are always safe to aggregate. This note
-  applies ONLY to the ledger spine, not to Fact queries."""
+voided/superseded events and draft/reversed entries are NOT removed (they are real audit
+history). When you COUNT or AGGREGATE ledger-spine data you MUST restrict to live rows,
+or cancelled amounts inflate the result.
+
+**Use the materialized `is_live` boolean — one rule on EVERY spine node:**
+`(e:Entry) WHERE e.is_live`, `(li:LineItem) WHERE li.is_live`,
+`(ev:Event) WHERE ev.is_live`, `(t:Transaction) WHERE t.is_live`. It is the safe default;
+prefer it over hand-writing per-node status filters (which differ by node and are easy to
+get wrong).
+
+What `is_live` means per node (the equivalent `status` filter, if you need finer control):
+- `Entry.is_live` ⇔ `status = 'posted'` (∈ {draft, posted, reversed}). Only posted entries
+  affect balances; `draft` includes entries of voided events, `reversed` = corrected by a
+  reversing entry.
+- `LineItem.is_live` ⇔ its parent Entry is posted. LineItem has no status of its own; the
+  flag is denormalized so you can filter without joining back to Entry.
+- `Event.is_live` ⇔ `status NOT IN ('voided','superseded')` (∈ {captured, classified,
+  committed, pending, fulfilled, voided, superseded}). It KEEPS open obligations
+  (pending/committed/fulfilled) — for a specific realized set, filter `status` explicitly.
+- `Transaction.is_live` ⇔ `status <> 'void'`. (The `pending` boolean is also still exposed.)
+- `Fact` nodes (the XBRL hypercube / published statements) have NO status and are already
+  filtered at generation time — always safe to aggregate. This note applies ONLY to the
+  ledger spine, not to Fact queries."""

--- a/robosystems/middleware/mcp/tools/example_queries_tool.py
+++ b/robosystems/middleware/mcp/tools/example_queries_tool.py
@@ -213,30 +213,30 @@ LIMIT 10""",
             },
             {
               "category": "ledger",
-              "description": "⭐ Account balances from POSTED entries only",
+              "description": "⭐ Account balances from LIVE entries only",
               "query": """MATCH (e:Entry)-[:ENTRY_HAS_LINE_ITEM]->(li:LineItem)-[:LINE_ITEM_RELATES_TO_ELEMENT]->(el:Element)
-WHERE e.status = 'posted'
+WHERE e.is_live
 RETURN el.qname, sum(li.debit_amount) AS debits, sum(li.credit_amount) AS credits
 ORDER BY debits DESC LIMIT 25""",
-              "explanation": "CRITICAL: filter `e.status = 'posted'`. The graph keeps draft/reversed entries (and entries of voided events stay as 'draft'); without this filter cancelled amounts inflate every balance.",
+              "explanation": "CRITICAL: filter `e.is_live` (⇔ status = 'posted'). The graph keeps draft/reversed entries (and entries of voided events stay as 'draft'); without this filter cancelled amounts inflate every balance. You can filter LineItem directly too — `li.is_live` denormalizes the parent entry's liveness.",
             },
             {
               "category": "ledger",
-              "description": "Count / sum events excluding voided & superseded",
+              "description": "Count / sum live events (excludes voided & superseded)",
               "query": """MATCH (ev:Event)
-WHERE ev.status <> 'voided' AND ev.status <> 'superseded'
+WHERE ev.is_live
 RETURN ev.event_type, count(ev) AS count, sum(ev.amount) AS total
 ORDER BY count DESC LIMIT 25""",
-              "explanation": "Event.status keeps voided (cancelled) and superseded (replaced) rows for audit. Exclude both from counts/sums. For open obligations instead, match the positive set (e.g. status IN ['committed','fulfilled','pending']).",
+              "explanation": "`ev.is_live` ⇔ status NOT IN ('voided','superseded') — the graph keeps cancelled/replaced events for audit. It keeps open obligations; for a specific realized set, filter `status` explicitly (e.g. status IN ['committed','fulfilled','pending']).",
             },
             {
               "category": "ledger",
-              "description": "Transaction amounts via posted entries (NOT Transaction.amount)",
+              "description": "Transaction amounts via live entries (NOT Transaction.amount)",
               "query": """MATCH (t:Transaction)-[:TRANSACTION_HAS_ENTRY]->(e:Entry)-[:ENTRY_HAS_LINE_ITEM]->(li:LineItem)
-WHERE e.status = 'posted'
+WHERE e.is_live
 RETURN t.number, t.date, sum(li.debit_amount) AS posted_debits
 ORDER BY t.date DESC LIMIT 25""",
-              "explanation": "The Transaction node exposes only a `pending` boolean, NOT the full status — a voided transaction looks identical to a live one. Aggregate realized effect through its posted Entry/LineItem instead of summing Transaction.amount directly.",
+              "explanation": "A voided transaction still holds posted-looking rows; measure realized effect through its live Entry/LineItem (`e.is_live`) rather than summing Transaction.amount directly. To filter transactions themselves, use `t.is_live` (⇔ status <> 'void').",
             },
           ]
         )

--- a/robosystems/operations/extensions/materialize.py
+++ b/robosystems/operations/extensions/materialize.py
@@ -522,6 +522,7 @@ def _staging_sql(graph_id: str, entity_id: str, connstr: str) -> dict[str, str]:
       CAST(occurred_at AS VARCHAR)    AS occurred_at,
       CAST(effective_at AS VARCHAR)   AS effective_at,
       status,
+      (status NOT IN ('voided', 'superseded')) AS is_live,
       source,
       external_id,
       external_url,
@@ -548,6 +549,7 @@ def _staging_sql(graph_id: str, entity_id: str, connstr: str) -> dict[str, str]:
       merchant_name,
       category,
       CASE WHEN status = 'pending' THEN true ELSE false END AS pending,
+      (status <> 'void')              AS is_live,
       CAST(updated_at AS VARCHAR)     AS updated_at
     FROM postgres_scan('{c}', '{s}', 'transactions')
   """
@@ -562,24 +564,32 @@ def _staging_sql(graph_id: str, entity_id: str, connstr: str) -> dict[str, str]:
       posting_date,
       type,
       status,
+      (status = 'posted')             AS is_live,
       reversal_of,
       provenance,
       CAST(updated_at AS VARCHAR)     AS updated_at
     FROM postgres_scan('{c}', '{s}', 'entries')
   """
 
+  # LineItem has no status of its own; its liveness is its parent Entry's.
+  # Denormalize (e.status = 'posted') as is_live via the entry join so ad-hoc /
+  # AI aggregations anchored at LineItem can filter with `WHERE li.is_live`
+  # without traversing back to Entry. entry_id is NOT NULL, so the inner join
+  # drops no rows.
   tables["LineItem"] = f"""
     CREATE OR REPLACE TABLE LineItem AS
     SELECT
-      id                                         AS identifier,
+      li.id                                      AS identifier,
       NULL::VARCHAR                              AS uri,
-      description,
-      CAST(debit_amount AS DOUBLE) / 100.0       AS debit_amount,
-      CAST(credit_amount AS DOUBLE) / 100.0      AS credit_amount,
+      li.description,
+      CAST(li.debit_amount AS DOUBLE) / 100.0    AS debit_amount,
+      CAST(li.credit_amount AS DOUBLE) / 100.0   AS credit_amount,
       false                                      AS has_dimensions,
       0::BIGINT                                  AS dimension_count,
-      CAST(updated_at AS VARCHAR)                AS updated_at
-    FROM postgres_scan('{c}', '{s}', 'line_items')
+      (e.status = 'posted')                      AS is_live,
+      CAST(li.updated_at AS VARCHAR)             AS updated_at
+    FROM postgres_scan('{c}', '{s}', 'line_items') li
+    JOIN postgres_scan('{c}', '{s}', 'entries') e ON e.id = li.entry_id
   """
 
   tables["Dimension"] = f"""

--- a/robosystems/operations/operators/implementations/cypher.py
+++ b/robosystems/operations/operators/implementations/cypher.py
@@ -147,7 +147,7 @@ CYPHER RULES:
 - Anchor every query on a selective, indexed starting point (an Entity by ticker, a Report by identifier, an Element by qname) and expand from there. Never start a MATCH from an unfiltered global pattern like `(f:Fact)` or `(n)` on a large graph — it will time out.
 
 LEDGER DATA (only when the schema has Entry / Transaction / LineItem nodes):
-- The graph keeps cancelled/replaced rows. When counting or summing ledger data, filter to live rows: match Entry `status = 'posted'` for balances and debit/credit sums; exclude Event rows where `status = 'voided' OR status = 'superseded'`. Aggregate realized amounts through posted Entry/LineItem, not by summing Transaction.amount.
+- The graph keeps cancelled/replaced rows for audit. When counting or summing ledger data, restrict to live rows using the materialized `is_live` boolean — it exists on every spine node (`Entry`, `LineItem`, `Event`, `Transaction`) and is the one rule to remember: `WHERE e.is_live`, `WHERE li.is_live`, `WHERE ev.is_live`, `WHERE t.is_live`. For balances/debit-credit sums, aggregate through live Entry/LineItem (`e.is_live`, ⇔ status = 'posted'), not by summing Transaction.amount. `is_live` keeps open obligations (pending/committed/fulfilled events); for a specific realized set, filter `status` explicitly.
 """
     if output_mode == "answer":
       prompt += (

--- a/robosystems/schemas/base.py
+++ b/robosystems/schemas/base.py
@@ -329,6 +329,9 @@ BASE_NODES = [
         name="status", type="STRING"
       ),  # captured | classified | committed | pending | fulfilled | voided | superseded
       Property(
+        name="is_live", type="BOOLEAN"
+      ),  # status NOT IN ('voided','superseded') — safe default for counts/sums
+      Property(
         name="source", type="STRING"
       ),  # manual|system|schedule|quickbooks|xero|plaid
       Property(name="external_id", type="STRING"),

--- a/robosystems/schemas/extensions/roboledger.py
+++ b/robosystems/schemas/extensions/roboledger.py
@@ -240,6 +240,9 @@ TRANSACTION_NODES = [
       Property(name="merchant_name", type="STRING"),
       Property(name="category", type="STRING"),
       Property(name="pending", type="BOOLEAN"),
+      Property(
+        name="is_live", type="BOOLEAN"
+      ),  # status <> 'void' — live-row filter for counts/sums
       Property(name="updated_at", type="STRING"),
     ],
   ),
@@ -259,6 +262,9 @@ TRANSACTION_NODES = [
       ),  # When it hits the books (may differ from transaction date)
       Property(name="type", type="STRING"),  # standard, adjusting, closing, reversing
       Property(name="status", type="STRING"),  # draft, posted, reversed
+      Property(
+        name="is_live", type="BOOLEAN"
+      ),  # status = 'posted' — the only status that affects balances
       Property(
         name="reversal_of", type="STRING"
       ),  # Entry identifier this reverses (null if not a reversal)
@@ -281,6 +287,9 @@ TRANSACTION_NODES = [
       Property(
         name="dimension_count", type="INT64"
       ),  # Number of dimensional qualifiers (0=no dimensions)
+      Property(
+        name="is_live", type="BOOLEAN"
+      ),  # denormalized parent Entry.is_live (parent status = 'posted')
       Property(name="updated_at", type="STRING"),
     ],
   ),

--- a/tests/operations/extensions/test_materialize.py
+++ b/tests/operations/extensions/test_materialize.py
@@ -168,6 +168,26 @@ class TestREAStaging:
     tables = _staging_sql(GRAPH_ID, ENTITY_ID, CONNSTR)
     assert "CAST(amount AS DOUBLE) / 100.0" in tables["Event"]
 
+  def test_ledger_spine_carries_is_live_flag(self):
+    """Every ledger-spine node materializes an is_live boolean so ad-hoc /
+    AI Cypher can restrict to live rows with one uniform `WHERE n.is_live`
+    instead of a non-uniform per-node status filter."""
+    tables = _staging_sql(GRAPH_ID, ENTITY_ID, CONNSTR)
+    assert "(status NOT IN ('voided', 'superseded')) AS is_live" in tables["Event"]
+    assert "(status <> 'void')" in tables["Transaction"]
+    assert "(status = 'posted')" in tables["Entry"]
+    for node in ("Event", "Transaction", "Entry", "LineItem"):
+      assert "is_live" in tables[node]
+
+  def test_line_item_is_live_denormalizes_parent_entry(self):
+    """LineItem has no status column; its liveness is its parent Entry's,
+    joined in at materialization so `WHERE li.is_live` needs no Entry hop.
+    entry_id is NOT NULL, so the inner join drops no rows."""
+    sql = _staging_sql(GRAPH_ID, ENTITY_ID, CONNSTR)["LineItem"]
+    assert "(e.status = 'posted')" in sql
+    assert "'entries'" in sql
+    assert "e.id = li.entry_id" in sql
+
   def test_entity_has_agent_and_event_fan_out_from_entity_id(self):
     tables = _staging_sql(GRAPH_ID, ENTITY_ID, CONNSTR)
     assert ENTITY_ID in tables["ENTITY_HAS_AGENT"]


### PR DESCRIPTION
## Summary

The extensions materialization mirrors the **full** ledger spine (`Event`, `Transaction`, `Entry`, `LineItem`) into the graph — including cancelled/replaced rows — which is correct for audit history but leaves the **read side** exposed: any AI-generated or ad-hoc Cypher that counts/sums the spine without a status filter silently includes voided/reversed rows and inflates results. The correct per-node filter was non-uniform and easy to forget, and `Transaction` was worse — the `pending`-only projection dropped the full status, making a voided transaction indistinguishable at the node.

This collapses that to **one rule — `WHERE n.is_live`** — by materializing a computed `is_live` boolean onto every spine node, and flips the existing Tier 1 read guidance to lead with it. Additive and safe: no OLTP migration, the graph is a rebuildable projection, and existing `status` filters keep working unchanged.

## Changes

**Materializer** (`operations/extensions/materialize.py`) — computed `is_live` on all four spine tables:
- `Event` → `status NOT IN ('voided','superseded')`
- `Transaction` → `status <> 'void'` (the `pending` boolean is kept for back-compat)
- `Entry` → `status = 'posted'`
- `LineItem` → denormalized parent `Entry.is_live` via an **inner join to `entries`** (`entry_id` is `NOT NULL`, so the join drops no rows). Lets balance rollups filter with `WHERE li.is_live` without a hop back to Entry.

**Schema** — `Property(name="is_live", type="BOOLEAN")` added to `Event` (`schemas/base.py`) and `Transaction`/`Entry`/`LineItem` (`schemas/extensions/roboledger.py`) so the flag surfaces in `get-graph-schema`. The graph loader reconciles source→target columns **by name** and already supports a property added mid-schema, so the new column aligns safely on rebuild.

**Read guidance flipped to lead with `is_live`** (keeping the per-node `status` filters as the "why"):
- `LEDGER_STATUS_GUIDANCE` (`middleware/mcp/tools/constants.py`)
- The three ledger example queries (`middleware/mcp/tools/example_queries_tool.py`)
- The `CypherOperator` system prompt (`operations/operators/implementations/cypher.py`)

**Tests** (`tests/operations/extensions/test_materialize.py`) — two new cases asserting `is_live` on all four tables and the LineItem entry-join.

## Design notes

- **Why a flag on all four nodes and not just Transaction?** Liveness does **not** cascade top-down. A reversal (`journal_entries.py:519`) marks the original `Entry.status='reversed'` and posts a *new* `posted` reversing entry without touching the parent Transaction — so a live Transaction routinely holds a `reversed` + a `posted` entry at once. Filtering only at Transaction would double-count; you must filter at Entry/LineItem. Ad-hoc queries also anchor at different nodes (balance rollups start at `LineItem → Element` and never touch Transaction), so each node needs to be independently filterable.
- **`Transaction.is_live` is uniformity insurance, not load-bearing.** `Transaction.status ∈ (pending, posted, void)`, but nothing in the codebase currently sets `'void'` (voiding happens at the Event/Entry layers). It's kept so the "one rule, every node" contract holds — dropping it reintroduces the non-uniform footgun.

## Testing

- `just test` — **full unit suite passed**: 10,679 passed, 15 skipped, 101 deselected (~7.5 min).
- `just test-code` — **passed clean**: ruff, format, basedpyright, cf-lint (0 errors/warnings).
- Pre-commit hooks passed on commit.

## Follow-ups / deployment note

- `is_live` only appears in a graph **after re-materialization** (blue/green rebuild or forced `materialize`). Because the guidance flip ships in the same branch, there's a window where guidance advises `WHERE n.is_live` but a not-yet-rebuilt graph lacks the column (query returns empty / binder error). Low-risk pre-launch (demo graphs are freshly materialized; few/no prod tenant graphs), but the clean rollout is **deploy → rematerialize existing tenant graphs → guidance is correct**. The staleness sensor rebuilds them on the next OLTP write regardless.
- Deliberately **skipped** the optional Phase 4 query-validator nudge (warning-only checks on AI Cypher — low value, added surface).

@claude review
