### PR TITLE
fix(extensions): Entry.provenance — expose on graph + permit event_handler in CHECK

### DIFF
--- a/migrations/extensions/versions/0019_widen_entry_provenance_check.py
+++ b/migrations/extensions/versions/0019_widen_entry_provenance_check.py
@@ -1,0 +1,64 @@
+"""widen entry provenance CHECK to include event_handler
+
+The ``ck_entries_provenance`` CHECK shipped in 0001 permitting
+{source_sync, ai_generated, manual_entry, schedule_derived, system_computed}.
+The event-block engine (``operations/event_block/engine.py``) creates entries
+with ``provenance='event_handler'`` — a value the constraint rejected, so the
+first real event-handler-driven GL insert would fail with a CheckViolation.
+Widen the constraint to permit ``event_handler`` (kept in lockstep with
+``ENTRY_PROVENANCE_VALUES`` on the model).
+
+Public schema AND every existing tenant schema get the widened constraint here
+via the TenantOps fan-out (matches 0018); fresh tenants get it from the model's
+CheckConstraint at provision (``metadata.create_all``).
+
+Note: the downgrade re-narrows the constraint and will fail if any
+``provenance='event_handler'`` rows already exist (they would violate the
+narrower CHECK) — expected once the value is in use.
+
+Revision ID: 0019
+Revises: 0018
+Create Date: 2026-07-04
+
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+from migrations.extensions.helpers import TenantOps, for_each_tenant_schema
+
+# revision identifiers, used by Alembic.
+revision = "0019"
+down_revision = "0018"
+branch_labels = None
+depends_on = None
+
+_WIDENED = (
+  "provenance IN ('source_sync', 'ai_generated', 'manual_entry', "
+  "'schedule_derived', 'system_computed', 'event_handler') OR provenance IS NULL"
+)
+_ORIGINAL = (
+  "provenance IN ('source_sync', 'ai_generated', 'manual_entry', "
+  "'schedule_derived', 'system_computed') OR provenance IS NULL"
+)
+
+
+def _widen(conn, schema: str) -> None:
+  TenantOps(conn, schema).add_check("entries", "ck_entries_provenance", _WIDENED)
+
+
+def _narrow(conn, schema: str) -> None:
+  TenantOps(conn, schema).add_check("entries", "ck_entries_provenance", _ORIGINAL)
+
+
+def upgrade() -> None:
+  conn = op.get_bind()
+  _widen(conn, "public")
+  for_each_tenant_schema(conn, _widen)
+
+
+def downgrade() -> None:
+  conn = op.get_bind()
+  _narrow(conn, "public")
+  for_each_tenant_schema(conn, _narrow)

--- a/robosystems/models/api/extensions/fiscal_calendar.py
+++ b/robosystems/models/api/extensions/fiscal_calendar.py
@@ -345,7 +345,10 @@ class DraftEntryResponse(BaseModel):
   memo: str | None = None
   provenance: str | None = Field(
     None,
-    description="Where the entry came from: 'ai_generated', 'manual_entry', etc.",
+    description=(
+      "Where the entry came from (ENTRY_PROVENANCE_VALUES): source_sync, "
+      "ai_generated, manual_entry, schedule_derived, system_computed, event_handler"
+    ),
   )
   source_structure_id: str | None = Field(
     None, description="Schedule structure that generated this entry (if any)"

--- a/robosystems/models/extensions/roboledger/entry.py
+++ b/robosystems/models/extensions/roboledger/entry.py
@@ -23,6 +23,21 @@ from sqlalchemy.dialects.postgresql import JSONB
 from robosystems.db.extensions import ExtensionsBase
 from robosystems.utils.ulid import generate_prefixed_ulid
 
+# Allowed values for Entry.provenance (entry origin). Single source of truth for
+# the model CHECK constraint below AND the value any write path may assign — the
+# `event_handler` value (entries created by the event-block engine) was written
+# in code before it was permitted here, so keep this in lockstep with the write
+# paths (see tests/operations/event_block/test_engine.py). Migrations carry
+# their own static snapshot of this set (they must not import model constants).
+ENTRY_PROVENANCE_VALUES = (
+  "source_sync",
+  "ai_generated",
+  "manual_entry",
+  "schedule_derived",
+  "system_computed",
+  "event_handler",
+)
+
 
 class Entry(ExtensionsBase):
   __tablename__ = "entries"
@@ -48,6 +63,12 @@ class Entry(ExtensionsBase):
     CheckConstraint(
       "type IN ('standard', 'adjusting', 'closing', 'reversing')",
       name="check_entry_type",
+    ),
+    CheckConstraint(
+      "provenance IN ("
+      + ", ".join(f"'{v}'" for v in ENTRY_PROVENANCE_VALUES)
+      + ") OR provenance IS NULL",
+      name="ck_entries_provenance",
     ),
   )
 
@@ -76,7 +97,8 @@ class Entry(ExtensionsBase):
   # Origin tracking — where this entry came from
   provenance = Column(
     String, nullable=True
-  )  # source_sync, ai_generated, manual_entry, schedule_derived, system_computed
+  )  # ENTRY_PROVENANCE_VALUES: source_sync, ai_generated, manual_entry,
+  # schedule_derived, system_computed, event_handler
 
   # Dates
   posting_date = Column(Date, nullable=False)

--- a/robosystems/schemas/extensions/roboledger.py
+++ b/robosystems/schemas/extensions/roboledger.py
@@ -271,7 +271,7 @@ TRANSACTION_NODES = [
       Property(
         name="provenance", type="STRING"
       ),  # entry origin: source_sync | ai_generated | manual_entry |
-      # schedule_derived | system_computed (see ck_entries_provenance)
+      # schedule_derived | system_computed | event_handler (ck_entries_provenance)
       Property(name="updated_at", type="STRING"),
     ],
   ),

--- a/robosystems/schemas/extensions/roboledger.py
+++ b/robosystems/schemas/extensions/roboledger.py
@@ -268,6 +268,10 @@ TRANSACTION_NODES = [
       Property(
         name="reversal_of", type="STRING"
       ),  # Entry identifier this reverses (null if not a reversal)
+      Property(
+        name="provenance", type="STRING"
+      ),  # entry origin: source_sync | ai_generated | manual_entry |
+      # schedule_derived | system_computed (see ck_entries_provenance)
       Property(name="updated_at", type="STRING"),
     ],
   ),

--- a/tests/operations/event_block/test_engine.py
+++ b/tests/operations/event_block/test_engine.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from unittest.mock import MagicMock
 
-from robosystems.models.extensions.roboledger.entry import Entry
+from robosystems.models.extensions.roboledger.entry import (
+  ENTRY_PROVENANCE_VALUES,
+  Entry,
+)
 from robosystems.models.extensions.roboledger.event import Event
 from robosystems.models.extensions.roboledger.event_handler import EventHandler
 from robosystems.models.extensions.roboledger.transaction import Transaction
@@ -56,3 +59,11 @@ def test_apply_handler_links_entry_and_transaction_to_originating_event() -> Non
   assert len(transactions) == 1
   assert transaction.triggered_by_event_id == "evt_invoice"
   assert entry.triggered_by_event_id == "evt_invoice"
+
+  # Regression (ck_entries_provenance / migration 0019): the engine tags its
+  # entries provenance='event_handler'. That value MUST be in the model's
+  # permitted set — before 0019 the DB CHECK rejected it, so the first real
+  # (non-mocked) GL insert would have CheckViolated. This session is a mock,
+  # so it never hit the constraint; assert the invariant explicitly instead.
+  assert entry.provenance == "event_handler"
+  assert entry.provenance in ENTRY_PROVENANCE_VALUES

--- a/tests/operations/extensions/test_materialize.py
+++ b/tests/operations/extensions/test_materialize.py
@@ -188,6 +188,17 @@ class TestREAStaging:
     assert "'entries'" in sql
     assert "e.id = li.entry_id" in sql
 
+  def test_entry_provenance_materialized_and_in_schema(self):
+    """Entry.provenance (origin: manual_entry / schedule_derived / etc.) is
+    carried into the graph AND declared as a schema Property. The materializer
+    has always SELECTed it, but a missing schema Property meant the by-name
+    graph loader silently dropped it — this guards against that regressing."""
+    from robosystems.schemas.extensions.roboledger import TRANSACTION_NODES
+
+    assert "provenance" in _staging_sql(GRAPH_ID, ENTITY_ID, CONNSTR)["Entry"]
+    entry_node = next(n for n in TRANSACTION_NODES if n.name == "Entry")
+    assert "provenance" in {p.name for p in entry_node.properties}
+
   def test_entity_has_agent_and_event_fan_out_from_entity_id(self):
     tables = _staging_sql(GRAPH_ID, ENTITY_ID, CONNSTR)
     assert ENTITY_ID in tables["ENTITY_HAS_AGENT"]


### PR DESCRIPTION
## Summary

Follow-up to #824, covering two related `Entry.provenance` fixes found while wiring the graph side:

1. **Expose `Entry.provenance` on the graph** — the materializer has carried the column since `b282c036`, but the `Entry` node schema never declared a matching `Property`, so the by-name graph loader silently dropped it. It was never queryable via `get-graph-schema` or Cypher.
2. **Fix a latent production bug the first PR uncovered** — the event-block engine writes `provenance='event_handler'`, a value the `ck_entries_provenance` CHECK constraint did not permit, so the first real event-handler-driven GL insert would `CheckViolation`.

## Changes

### Expose provenance on the graph
- **`schemas/extensions/roboledger.py`** — add `Property(name="provenance", type="STRING")` to the `Entry` node (placed after `reversal_of`, matching the staging SELECT order).
- **`tests/operations/extensions/test_materialize.py`** — regression test asserting `Entry.provenance` is both materialized and declared in the schema. The materializer-vs-schema validator only checks drift at the **table** level, not per-column, which is why the gap persisted.

### Permit `event_handler` in the provenance CHECK
- **`models/extensions/roboledger/entry.py`** — add `ENTRY_PROVENANCE_VALUES` as the single source of truth (the 5 original values + `event_handler`) and declare the `ck_entries_provenance` `CheckConstraint` **on the model** — it previously existed only in migration `0001`, so model and DB had drifted.
- **`migrations/extensions/versions/0019_widen_entry_provenance_check.py`** — widens the live constraint across the `public` schema and every existing tenant schema via the `TenantOps` fan-out (matches `0018`). Fresh tenants get it from the model at provision. *(Autogenerate produced only spurious schema-per-tenant FK/index drift and did not detect the CHECK change, so the migration is hand-written — the autogenerated file was discarded.)*
- **`tests/operations/event_block/test_engine.py`** — regression assertion that the value the engine writes (`event_handler`) is in `ENTRY_PROVENANCE_VALUES`. Would have failed pre-fix. (The engine test uses a mocked session that never flushes, which is why the constraint violation went unnoticed — no real-DB fixture exists for this area, so the invariant is asserted at the model level instead.)

## Testing

- `just test` (targeted): `test_engine.py`, `test_materialize.py`, `tests/migrations`, `tests/operations/event_block`, `tests/schemas`, `tests/operations/roboledger/commands` — **all passed** (452 + 42 across the runs).
- `just test-code` — **passed clean** (ruff, format, basedpyright, cf-lint; 0 errors/warnings).
- Migration applied locally (`0019` is head) and the live `ck_entries_provenance` on the `public` schema verified to now include `event_handler`.

## Notes

- `provenance` appears on a graph after its next re-materialization (same blue/green mechanism as #824's `is_live`).
- Migration `0019` `downgrade()` re-narrows the constraint and will fail if any `provenance='event_handler'` rows already exist — expected once the value is in use.
- Production rollout needs the extensions migration applied (`just migrate-up extensions` via the prod tunnel) before/with the deploy, since the code path writes `event_handler`.
