### PR TITLE
fix(operators): tailor cypher operator prompting to graph type

### DIFF
--- a/robosystems/middleware/mcp/tools/example_queries_tool.py
+++ b/robosystems/middleware/mcp/tools/example_queries_tool.py
@@ -104,12 +104,20 @@ List of example queries with explanations, tailored to the actual schema present
 
       # Basic exploration queries (always include)
       if not category or category == "exploration":
+        # Derive the count-by-type query from the labels actually present so we
+        # don't assume an XBRL/SEC shape (Fact/Element/Entity) on a graph that
+        # may not have it.
+        count_labels = node_types[:4] or ["Node"]
+        count_query = " UNION ALL ".join(
+          f"MATCH (n:{lbl}) RETURN '{lbl}' AS node_type, count(n) AS count"
+          for lbl in count_labels
+        )
         examples.append(
           {
             "category": "exploration",
-            "description": "Count all nodes by type",
-            "query": "MATCH (n:Fact) RETURN 'Fact' as node_type, count(n) as count UNION ALL MATCH (n:Element) RETURN 'Element' as node_type, count(n) as count UNION ALL MATCH (n:Entity) RETURN 'Entity' as node_type, count(n) as count",
-            "explanation": "Shows distribution of data across node types",
+            "description": "Count nodes by type",
+            "query": count_query,
+            "explanation": "Distribution across this graph's main node types (derived from the live schema, not assumed).",
           }
         )
         examples.append(
@@ -138,12 +146,12 @@ List of example queries with explanations, tailored to the actual schema present
               "category": "financial",
               "description": "Get company information",
               "query": "MATCH (e:Entity) RETURN e.name, e.cik, e.ticker, e.sic_description LIMIT 25",
-              "explanation": "Entity nodes contain company master data. Filter by ticker (e.ticker = 'MRMD') or CIK for one company — this repo holds thousands of entities, so always LIMIT or filter.",
+              "explanation": "Entity nodes contain company master data. Filter by ticker (e.ticker = 'NVDA') or CIK for one company — this repo holds thousands of entities, so always LIMIT or filter.",
             },
             {
               "category": "financial",
               "description": "⭐ CONSOLIDATED Revenue for one company (cross-filer robust)",
-              "query": """MATCH (f:Fact {has_dimensions: false})-[:FACT_HAS_ELEMENT]->(e:Element), (f)-[:FACT_HAS_ENTITY]->(ent:Entity {ticker: 'MRMD'}), (f)-[:FACT_HAS_PERIOD]->(p:Period {duration_type: 'annual'})
+              "query": """MATCH (f:Fact {has_dimensions: false})-[:FACT_HAS_ELEMENT]->(e:Element), (f)-[:FACT_HAS_ENTITY]->(ent:Entity {ticker: 'NVDA'}), (f)-[:FACT_HAS_PERIOD]->(p:Period {duration_type: 'annual'})
 WHERE e.canonical_concept = 'revenue' AND f.numeric_value IS NOT NULL
 RETURN ent.ticker, e.qname, p.end_date, f.numeric_value AS revenue
 ORDER BY p.end_date DESC LIMIT 10""",
@@ -152,7 +160,7 @@ ORDER BY p.end_date DESC LIMIT 10""",
             {
               "category": "financial",
               "description": "Full income statement by ticker (fast Structure traversal)",
-              "query": """MATCH (ent:Entity {ticker: 'MRMD'})<-[:FACT_HAS_ENTITY]-(f:Fact {has_dimensions: false})-[:FACT_HAS_ELEMENT]->(e:Element),
+              "query": """MATCH (ent:Entity {ticker: 'NVDA'})<-[:FACT_HAS_ENTITY]-(f:Fact {has_dimensions: false})-[:FACT_HAS_ELEMENT]->(e:Element),
       (f)-[:FACT_HAS_PERIOD]->(p:Period {duration_type: 'annual'}),
       (fs:FactSet)-[:FACT_SET_CONTAINS_FACT]->(f),
       (s:Structure {canonical_type: 'income_statement'})-[:STRUCTURE_HAS_FACT_SET]->(fs)
@@ -279,27 +287,18 @@ ORDER BY t.date DESC LIMIT 25""",
           ]
         )
 
-      # Aggregation examples
+      # Aggregation examples — kept anchored on a single labelled set so they
+      # never model the `MATCH (n)` / unfiltered-Fact global scan the operator
+      # is told to avoid (it scans every node and times out on a large graph).
       if not category or category == "aggregations":
-        examples.extend(
-          [
-            {
-              "category": "aggregations",
-              "description": "Group and sum values",
-              "query": """MATCH (f:Fact)
-WHERE f.numeric_value IS NOT NULL
-RETURN 'Fact' as type, sum(f.numeric_value) as total, count(f) as count""",
-              "explanation": "LadybugDB supports aggregation functions like sum(), avg(), count()",
-            },
-            {
-              "category": "aggregations",
-              "description": "Find min/max values",
-              "query": """MATCH (n)
-WHERE n.numeric_value IS NOT NULL
-RETURN min(n.numeric_value) as min_val, max(n.numeric_value) as max_val""",
-              "explanation": "Use min() and max() for range analysis",
-            },
-          ]
+        agg_label = node_types[0] if node_types else "Node"
+        examples.append(
+          {
+            "category": "aggregations",
+            "description": "Aggregate over one labelled set",
+            "query": f"MATCH (n:{agg_label}) RETURN count(n) AS count",
+            "explanation": "count(), sum(), avg(), min(), max() are supported. Always aggregate over ONE labelled, filtered set and anchor first (by ticker, qname, date, or id) — never sum/scan `MATCH (n)` or an unfiltered label across the whole graph.",
+          }
         )
 
       # Add note about available nodes and relationships

--- a/robosystems/operations/operators/implementations/cypher.py
+++ b/robosystems/operations/operators/implementations/cypher.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from typing import Any
 
 from robosystems.config import OperatorConfig
+from robosystems.config.shared_repositories import is_shared_repository_or_subgraph
 from robosystems.operations.operators.base import (
   ExecutionProfile,
   Operator,
@@ -98,8 +99,9 @@ class CypherOperator(Operator):
     max_iterations = int(limits.get("max_tools", 5)) + 1
     max_tokens = int(limits.get("max_output_tokens", 4000))
     output_mode = "answer" if ctx.extra.get("output_mode") == "answer" else "narrative"
+    is_shared = is_shared_repository_or_subgraph(ctx.graph_id)
 
-    system = self._build_system_prompt(max_results, output_mode)
+    system = self._build_system_prompt(max_results, output_mode, is_shared)
 
     result = await run_tool_loop(
       ctx,
@@ -130,7 +132,35 @@ class CypherOperator(Operator):
       confidence_score=self._calculate_confidence(result),
     )
 
-  def _build_system_prompt(self, max_results: int, output_mode: str) -> str:
+  def _build_system_prompt(
+    self, max_results: int, output_mode: str, is_shared: bool
+  ) -> str:
+    if is_shared:
+      # Shared repository (e.g. SEC): thousands of filers, so the selective
+      # anchors are the cross-filer identifiers (ticker/CIK/Report).
+      anchor_rule = (
+        "- Anchor every query on a selective, indexed starting point and expand "
+        "from there — this is a shared repository with thousands of filers. Good "
+        "anchors: an Entity by ticker or CIK, a Report by identifier, an Element "
+        "by qname. Reach broad shared nodes (a Structure by canonical_type, or an "
+        "unfiltered `(f:Fact)`/`(n)` scan) LAST — leading a MATCH with one scans "
+        "the whole graph and times out."
+      )
+    else:
+      # Tenant graph (roboledger / custom): a single company's ledger, not a
+      # multi-filer repository. Ticker/CIK are SEC identifiers and usually null.
+      anchor_rule = (
+        "- Anchor every query on a selective, indexed starting point and expand "
+        "from there; never lead a MATCH with an unfiltered global pattern like "
+        "`(f:Fact)` or `(n)`. This is a single company's graph, not the multi-filer "
+        "SEC repository: there is typically one Entity, and `ticker`/`cik` are SEC "
+        "identifiers that are usually null here — anchor on the Entity itself, an "
+        "`Element`/account by qname, a `Transaction`/`Entry` by date, or a `Period`, "
+        "rather than filtering by ticker or CIK. For accounting questions prefer the "
+        "ledger spine (`Entry`/`Transaction`/`LineItem`) over the XBRL `Fact` "
+        "hypercube unless the question is about a published financial statement."
+      )
+
     prompt = f"""You are a graph database analyst for RoboSystems. You answer the user's question by querying a LadybugDB graph with read-only Cypher.
 
 WORKFLOW:
@@ -144,7 +174,7 @@ CYPHER RULES:
 - Read-only only: MATCH, WHERE, WITH, RETURN, ORDER BY, LIMIT. Never CREATE, SET, DELETE, MERGE, or DROP.
 - Always include a LIMIT (max {max_results}).
 - Use CONTAINS for text search; guard against NULLs with IS NOT NULL.
-- Anchor every query on a selective, indexed starting point (an Entity by ticker, a Report by identifier, an Element by qname) and expand from there. Never start a MATCH from an unfiltered global pattern like `(f:Fact)` or `(n)` on a large graph — it will time out.
+{anchor_rule}
 
 LEDGER DATA (only when the schema has Entry / Transaction / LineItem nodes):
 - The graph keeps cancelled/replaced rows for audit. When counting or summing ledger data, restrict to live rows using the materialized `is_live` boolean — it exists on every spine node (`Entry`, `LineItem`, `Event`, `Transaction`) and is the one rule to remember: `WHERE e.is_live`, `WHERE li.is_live`, `WHERE ev.is_live`, `WHERE t.is_live`. For balances/debit-credit sums, aggregate through live Entry/LineItem (`e.is_live`, ⇔ status = 'posted'), not by summing Transaction.amount. `is_live` keeps open obligations (pending/committed/fulfilled events); for a specific realized set, filter `status` explicitly.


### PR DESCRIPTION
## Summary

The Cypher operator handed an SEC mental model to RoboLedger tenant graphs. Its system prompt and example queries were shaped for the shared SEC repository, so on a single-company ledger graph it steered the model toward anchors and filters (ticker, CIK, SEC `Report`) that return nothing. This tailors the prompting to the graph type.

## Changes

### `operations/operators/implementations/cypher.py`
- The system prompt's anchoring rule now branches on `is_shared_repository_or_subgraph(ctx.graph_id)` (a cheap in-memory registry lookup):
  - **Shared repo (SEC):** keeps the multi-filer framing — anchor on Entity by ticker/CIK, a Report by identifier, or an Element by qname; reach broad shared nodes (`Structure` by `canonical_type`, unfiltered `Fact`/`(n)` scans) last.
  - **Tenant graph (roboledger/custom):** new framing — a single company's graph where `ticker`/`cik` are usually null, so anchor on the Entity itself, an `Element`/account by qname, a `Transaction`/`Entry` by date, or a `Period`, and prefer the ledger spine (`Entry`/`Transaction`/`LineItem`) over the XBRL `Fact` hypercube unless the question is about a published statement.
- `_build_system_prompt` now takes an `is_shared` argument.

### `middleware/mcp/tools/example_queries_tool.py`
- Replaced the `MRMD` sample ticker with `NVDA` (3 spots) to match the `NVDA`/`AAPL` convention already used across the sibling SEC tools (`fact_grid_tool`, `financial_statement_tools`, `resolve_element_tool`).
- Rewrote the `aggregations` examples, which modeled global-scan anti-patterns (`MATCH (n) WHERE n.numeric_value IS NOT NULL`, and `sum()` over every `Fact` across all filers) that directly contradicted the operator's anchoring rule, into a single anchored example plus a note to always aggregate over a filtered, labelled set.
- Derived the `exploration` count-by-type query from the live schema instead of hardcoding `Fact`/`Element`/`Entity`, so it no longer assumes an XBRL shape on graphs that may not have one.

The SEC financial examples remain gated behind `_is_shared_financial_repo()` and the ledger-spine examples remain gated on `Entry`/`Transaction`/`LineItem` — those were already tailored; the leak was the always-on prompt and examples.

## Testing

- `just test` scoped to the affected suites — `tests/operations/operators/` and `tests/middleware/mcp/tools/`: **392 passed**.
- `ruff check`, `ruff format --check`, and `basedpyright` on both changed files: clean. Pre-commit hooks (ruff + format + basedpyright) also passed on commit.
- Full `just test-all` not run in this session.
