### PR TITLE
chore(cors): allow the Holon Viewer origin on the main API

### DIFF
--- a/robosystems/config/env.py
+++ b/robosystems/config/env.py
@@ -1363,12 +1363,16 @@ class EnvConfig:
         "https://roboledger.ai",
         "https://roboinvestor.ai",
         "https://robosystems.ai",
+        # Holon Viewer — static SPA that calls the API client-side with a
+        # user-supplied API key (no app backend of its own).
+        "https://holon.robosystems.ai",
       ]
     elif cls.is_staging():
       return [
         "https://staging.roboledger.ai",
         "https://staging.roboinvestor.ai",
         "https://staging.robosystems.ai",
+        "https://staging.holon.robosystems.ai",
       ]
     else:
       # Development

--- a/tests/config/test_env.py
+++ b/tests/config/test_env.py
@@ -247,6 +247,7 @@ def test_get_main_cors_origins_respects_environment(monkeypatch):
     "https://roboledger.ai",
     "https://roboinvestor.ai",
     "https://robosystems.ai",
+    "https://holon.robosystems.ai",
   ]
 
   monkeypatch.setattr(EnvConfig, "ENVIRONMENT", "staging", raising=False)
@@ -254,6 +255,7 @@ def test_get_main_cors_origins_respects_environment(monkeypatch):
     "https://staging.roboledger.ai",
     "https://staging.roboinvestor.ai",
     "https://staging.robosystems.ai",
+    "https://staging.holon.robosystems.ai",
   ]
 
   monkeypatch.setattr(EnvConfig, "ENVIRONMENT", "dev", raising=False)


### PR DESCRIPTION
## Summary

Adds the **Holon Viewer** origin to the main API CORS allowlist so the static viewer SPA can call the API from the browser. The viewer is static-hosted with no backend of its own — it calls `GET /v1/graphs` and `POST /v1/graphs/sec/query` client-side with a user-supplied API key. Every part of the existing CORS config already supports those requests (methods include `GET`/`POST`/`OPTIONS`, `allow_headers` already includes `X-API-Key` and `Content-Type`); the deployed origin was the only thing missing.

## Changes

- **`robosystems/config/env.py`** — `get_main_cors_origins()`: add `https://holon.robosystems.ai` to the production list and `https://staging.holon.robosystems.ai` to the staging list. (Dev is unchanged — the viewer's dev server proxies API calls, so it stays same-origin and never triggers CORS.)
- **`tests/config/test_env.py`** — update the exact-list assertions for prod and staging to match.

## Testing

- `uv run pytest tests/config/test_env.py -k cors` — **2 passed**.
- Pre-commit gate on commit: ruff check (all passed), ruff format (clean), basedpyright (0 errors / 0 warnings). Full `just test-all` not run in this session.

## Notes / Follow-ups

- **Requires an API redeploy** (`staging.yml` / `prod.yml`) to take effect — CORS origins are baked into `env.py`, not SSM, so this is not a runtime flip.
- Separately, the viewer must be deployed to `holon.robosystems.ai` (its own S3 + CloudFront). Both deploys are needed for the viewer to work in production.
- Pairs with the viewer app PR: RoboFinSystems/robosystems-holon-viewer#5.
