### PR TITLE
chore(rds): add configurable Performance Insights (Database Insights)

### DIFF
--- a/.github/workflows/deploy-postgres.yml
+++ b/.github/workflows/deploy-postgres.yml
@@ -88,6 +88,18 @@ on:
         type: string
         default: "120"
 
+      # Performance Insights (CloudWatch Database Insights - Standard mode; free at 7-day retention)
+      performance_insights_enabled:
+        description: "Enable RDS Performance Insights / Database Insights Standard mode"
+        required: false
+        type: string
+        default: "false"
+      performance_insights_retention_days:
+        description: "Performance Insights retention in days (7 = free tier; 31/62/93/186/372/731 = paid)"
+        required: false
+        type: string
+        default: "7"
+
       # Lambda Configuration
       lambda_image_uri:
         description: "ECR image URI for Lambda functions (container-based deployment)"
@@ -167,6 +179,8 @@ jobs:
                 ParameterKey=EnableRDSProxy,ParameterValue=${{ inputs.rds_proxy_enabled }} \
                 ParameterKey=RDSProxyMaxConnectionsPercent,ParameterValue=${{ inputs.rds_proxy_max_connections_percent }} \
                 ParameterKey=RDSProxyConnectionBorrowTimeout,ParameterValue=${{ inputs.rds_proxy_connection_borrow_timeout }} \
+                ParameterKey=EnablePerformanceInsights,ParameterValue=${{ inputs.performance_insights_enabled }} \
+                ParameterKey=PerformanceInsightsRetentionPeriod,ParameterValue=${{ inputs.performance_insights_retention_days }} \
                 ParameterKey=VpcId,ParameterValue=${{ inputs.vpc_id }} \
                 ParameterKey=SubnetId1,ParameterValue=$(echo ${{ inputs.subnet_ids }} | cut -d ',' -f1) \
                 ParameterKey=SubnetId2,ParameterValue=$(echo ${{ inputs.subnet_ids }} | cut -d ',' -f2) \

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -275,6 +275,9 @@ jobs:
       rds_proxy_enabled: ${{ vars.RDS_PROXY_ENABLED_PROD || 'false' }}
       rds_proxy_max_connections_percent: ${{ vars.RDS_PROXY_MAX_CONNECTIONS_PERCENT_PROD || '100' }}
       rds_proxy_connection_borrow_timeout: ${{ vars.RDS_PROXY_CONNECTION_BORROW_TIMEOUT_PROD || '120' }}
+      # Performance Insights (Database Insights Standard mode - enabled via DATABASE_PI_ENABLED_PROD; free at 7-day retention)
+      performance_insights_enabled: ${{ vars.DATABASE_PI_ENABLED_PROD || 'false' }}
+      performance_insights_retention_days: ${{ vars.DATABASE_PI_RETENTION_DAYS_PROD || '7' }}
       # Lambda Configuration (container-based)
       lambda_image_uri: ${{ needs.build.outputs.lambda_image }}
       # Other Configuration

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -292,6 +292,9 @@ jobs:
       rds_proxy_enabled: ${{ vars.RDS_PROXY_ENABLED_STAGING || 'false' }}
       rds_proxy_max_connections_percent: ${{ vars.RDS_PROXY_MAX_CONNECTIONS_PERCENT_STAGING || '100' }}
       rds_proxy_connection_borrow_timeout: ${{ vars.RDS_PROXY_CONNECTION_BORROW_TIMEOUT_STAGING || '120' }}
+      # Performance Insights (Database Insights Standard mode - off by default in staging)
+      performance_insights_enabled: ${{ vars.DATABASE_PI_ENABLED_STAGING || 'false' }}
+      performance_insights_retention_days: ${{ vars.DATABASE_PI_RETENTION_DAYS_STAGING || '7' }}
       # Lambda Configuration (container-based)
       lambda_image_uri: ${{ needs.build.outputs.lambda_image }}
       # Other Configuration

--- a/cloudformation/postgres.yaml
+++ b/cloudformation/postgres.yaml
@@ -148,6 +148,32 @@ Parameters:
     Description: Email for SNS alerts
     ConstraintDescription: Must be a valid email address
 
+  # Performance Insights / CloudWatch Database Insights (Standard mode).
+  # Free at the default 7-day retention; longer retention is billed per vCPU/month.
+  # RDS for PostgreSQL has no instance-class restriction, so this is safe on t4g.micro.
+  EnablePerformanceInsights:
+    Type: String
+    Description: Enable RDS Performance Insights / Database Insights Standard mode
+    Default: "false"
+    AllowedValues:
+      - "true"
+      - "false"
+    ConstraintDescription: Must be true or false
+  PerformanceInsightsRetentionPeriod:
+    Type: Number
+    Description: Performance Insights retention in days (7 = free tier; 31/62/93/186/372
+      are month*31; 731 = 24 months). Ignored when EnablePerformanceInsights=false.
+    Default: 7
+    AllowedValues:
+      - 7
+      - 31
+      - 62
+      - 93
+      - 186
+      - 372
+      - 731
+    ConstraintDescription: Must be 7 or a valid Performance Insights retention value
+
   # Tagging Configuration
   ServiceTag:
     Type: String
@@ -163,6 +189,7 @@ Conditions:
   EnableMultiAZCondition: !Equals [!Ref EnableMultiAZ, "true"]
   DeletionProtectionCondition: !Equals [!Ref EnableDeletionProtection, "true"]
   RDSProxyEnabledCondition: !Equals [!Ref EnableRDSProxy, "true"]
+  PerformanceInsightsEnabledCondition: !Equals [!Ref EnablePerformanceInsights, "true"]
 
 Resources:
   # Common IAM policy for EC2 instances
@@ -492,6 +519,9 @@ Resources:
       PubliclyAccessible: false
       MultiAZ: !If [EnableMultiAZCondition, true, false]
       DeletionProtection: !If [DeletionProtectionCondition, true, false]
+      EnablePerformanceInsights: !If [PerformanceInsightsEnabledCondition, true, false]
+      PerformanceInsightsRetentionPeriod:
+        !If [PerformanceInsightsEnabledCondition, !Ref PerformanceInsightsRetentionPeriod, !Ref "AWS::NoValue"]
       BackupRetentionPeriod: 30
       PreferredBackupWindow: 03:00-04:00
       PreferredMaintenanceWindow: sun:04:30-sun:05:30
@@ -774,6 +804,12 @@ Outputs:
     Value: !If [DeletionProtectionCondition, "true", "false"]
     Export:
       Name: !Sub ${AWS::StackName}-${Environment}-DeletionProtectionEnabled
+
+  PerformanceInsightsEnabled:
+    Description: Whether Performance Insights / Database Insights Standard mode is enabled
+    Value: !If [PerformanceInsightsEnabledCondition, "true", "false"]
+    Export:
+      Name: !Sub ${AWS::StackName}-${Environment}-PerformanceInsightsEnabled
 
   PostgresEngineVersionConfigured:
     Description: PostgreSQL engine version configured for this deployment


### PR DESCRIPTION
## Summary

Adds RDS Performance Insights (CloudWatch Database Insights, Standard mode) as a configurable option on the Postgres stack. Both enablement and retention are driven by GitHub variables so they can be flipped per-environment without a code change. Prod turns PI on at 7-day (free) retention; staging stays off. It was previously off everywhere — the `AWS::RDS::DBInstance` had no monitoring properties at all.

## Changes

**`cloudformation/postgres.yaml`**
- New parameters `EnablePerformanceInsights` (true/false, default `false`) and `PerformanceInsightsRetentionPeriod` (default `7`; `AllowedValues` constrained to the valid PI set: 7/31/62/93/186/372/731).
- New condition `PerformanceInsightsEnabledCondition`.
- On `RDSDBInstance`: `EnablePerformanceInsights` toggled from the condition; `PerformanceInsightsRetentionPeriod` passed only when PI is enabled (`AWS::NoValue` otherwise, since RDS rejects a retention period on a disabled instance). No `PerformanceInsightsKMSKeyId` set → RDS uses the default `aws/rds` key.
- New `PerformanceInsightsEnabled` stack output, matching the existing MultiAZ/DeletionProtection output pattern.

**`.github/workflows/deploy-postgres.yml`**
- Two new reusable-workflow inputs (`performance_insights_enabled`, `performance_insights_retention_days`, defaults `false`/`7`), wired into the `POSTGRES_STACK_PARAMS` list passed to CloudFormation.

**`.github/workflows/prod.yml`** — passes `performance_insights_enabled: ${{ vars.DATABASE_PI_ENABLED_PROD || 'false' }}` and retention from `DATABASE_PI_RETENTION_DAYS_PROD || '7'`.

**`.github/workflows/staging.yml`** — passes `performance_insights_enabled: ${{ vars.DATABASE_PI_ENABLED_STAGING || 'false' }}` and retention from `DATABASE_PI_RETENTION_DAYS_STAGING || '7'`.

All code fallbacks default to `false`; behavior is governed by the GitHub variables (already set: `DATABASE_PI_ENABLED_PROD=true`, `DATABASE_PI_ENABLED_STAGING=false`, retention `7` for both).

## Testing

- `just cf-lint postgres` — passed (0 errors/warnings).
- YAML parse check on all three workflow files — passed.
- Full `just test-all` not run (infra/config-only change; no application code touched).

## Notes

- Enabling PI is a no-downtime RDS modify — no reboot when the prod stack updates.
- 7-day retention is free; anything longer is billed per vCPU-month.
- No instance-class blocker: RDS for PostgreSQL has no micro/small restriction, so staging's `t4g.micro` qualifies if ever flipped on.
- Nothing takes effect until the Postgres stack deploys through the pipeline — the GitHub variable values alone don't touch RDS.
