### PR TITLE
fix(rate-limits): correct graph endpoint categorization and close coverage gaps

### DIFF
--- a/robosystems/config/README.md
+++ b/robosystems/config/README.md
@@ -209,9 +209,10 @@ class EndpointCategory(str, Enum):
     # Graph-scoped endpoints
     GRAPH_READ = "graph_read"              # GET operations
     GRAPH_WRITE = "graph_write"            # POST/PUT/DELETE
-    GRAPH_ANALYTICS = "graph_analytics"    # Heavy computations
-    GRAPH_BACKUP = "graph_backup"
-    GRAPH_SYNC = "graph_sync"
+    GRAPH_ANALYTICS = "graph_analytics"    # Usage analytics (aggregation reads)
+    GRAPH_BACKUP = "graph_backup"          # create-/restore-backup operations
+    GRAPH_MANAGEMENT = "graph_management"  # Lifecycle ops (subgraph/tier/style)
+    GRAPH_SYNC = "graph_sync"              # Connection /sync trigger only
     GRAPH_MCP = "graph_mcp"                # MCP operations
     GRAPH_OPERATOR = "graph_operator"      # AI Operator operations
     GRAPH_SEARCH = "graph_search"          # OpenSearch full-text search
@@ -239,8 +240,10 @@ GRAPH_WRITE: 30/min
 GRAPH_QUERY: 60/min
 GRAPH_OPERATOR: 15/min   # AI Operator operations
 
-# Larger tiers apply graph.yml api_rate_multiplier (e.g. 1.5x large, higher for xlarge)
-# on top of these base values.
+# Burst enforcement is deliberately tier-flat: the limiter classifies every
+# authenticated user as ladybug-standard. Per-tier differentiation is governed
+# by the credit system (volume), not by a rate-limit multiplier. The
+# graph.yml api_rate_multiplier is surfaced for display (see /limits) only.
 ```
 
 **Usage:**
@@ -251,9 +254,6 @@ from robosystems.config.rate_limits import RateLimitConfig, EndpointCategory
 # Get limits for tier and operation — returns (limit, window_seconds) or None
 result = RateLimitConfig.get_rate_limit("large", EndpointCategory.GRAPH_QUERY)
 limit, window_seconds = result  # e.g. (300, 60)
-
-# Or apply the tier-config multiplier
-RateLimitConfig.get_rate_limit_with_multiplier("xlarge", EndpointCategory.GRAPH_READ)
 
 # Classify a request path/method into a category
 category = RateLimitConfig.get_endpoint_category(path, method)

--- a/robosystems/config/rate_limits.py
+++ b/robosystems/config/rate_limits.py
@@ -363,11 +363,13 @@ class RateLimitConfig:
 
       # Graph lifecycle operations — POST /operations/{op_name}. Dedicated
       # buckets so expensive rebuild/backup work can't be abused by sharing
-      # the generic write limit.
+      # the generic write limit. Match the op-name segment specifically rather
+      # than the whole path, so a graph_id can't accidentally route the bucket.
       elif endpoint_type == "operations":
-        if "backup" in path:  # create-backup, restore-backup
+        op_name = path_parts[3] if len(path_parts) > 3 else ""
+        if "backup" in op_name:  # create-backup, restore-backup
           return EndpointCategory.GRAPH_BACKUP
-        elif "materialize" in path:  # heavy OLAP rebuild
+        elif "materialize" in op_name:  # heavy OLAP rebuild
           return EndpointCategory.GRAPH_IMPORT
         else:  # create/delete subgraph, delete-graph, change-tier/style
           return EndpointCategory.GRAPH_MANAGEMENT

--- a/robosystems/config/rate_limits.py
+++ b/robosystems/config/rate_limits.py
@@ -7,8 +7,6 @@ and endpoint categories.
 
 from enum import Enum
 
-from .graph_tier import get_tier_api_rate_multiplier
-
 
 class RateLimitPeriod(str, Enum):
   """Time periods for rate limiting."""
@@ -42,6 +40,7 @@ class EndpointCategory(str, Enum):
   GRAPH_WRITE = "graph_write"
   GRAPH_ANALYTICS = "graph_analytics"
   GRAPH_BACKUP = "graph_backup"
+  GRAPH_MANAGEMENT = "graph_management"  # Lifecycle ops (subgraph/tier/style)
   GRAPH_SYNC = "graph_sync"
   GRAPH_MCP = "graph_mcp"
   GRAPH_OPERATOR = "graph_operator"
@@ -116,6 +115,7 @@ class RateLimitConfig:
       EndpointCategory.GRAPH_WRITE: (10, RateLimitPeriod.MINUTE),
       EndpointCategory.GRAPH_ANALYTICS: (5, RateLimitPeriod.MINUTE),
       EndpointCategory.GRAPH_BACKUP: (2, RateLimitPeriod.MINUTE),
+      EndpointCategory.GRAPH_MANAGEMENT: (3, RateLimitPeriod.MINUTE),
       EndpointCategory.GRAPH_SYNC: (3, RateLimitPeriod.MINUTE),
       EndpointCategory.GRAPH_MCP: (5, RateLimitPeriod.MINUTE),
       EndpointCategory.GRAPH_OPERATOR: (3, RateLimitPeriod.MINUTE),
@@ -143,6 +143,7 @@ class RateLimitConfig:
       EndpointCategory.GRAPH_WRITE: (30, RateLimitPeriod.MINUTE),
       EndpointCategory.GRAPH_ANALYTICS: (15, RateLimitPeriod.MINUTE),
       EndpointCategory.GRAPH_BACKUP: (5, RateLimitPeriod.MINUTE),
+      EndpointCategory.GRAPH_MANAGEMENT: (10, RateLimitPeriod.MINUTE),
       EndpointCategory.GRAPH_SYNC: (10, RateLimitPeriod.MINUTE),
       EndpointCategory.GRAPH_MCP: (30, RateLimitPeriod.MINUTE),
       EndpointCategory.GRAPH_OPERATOR: (15, RateLimitPeriod.MINUTE),
@@ -161,7 +162,10 @@ class RateLimitConfig:
       EndpointCategory.TABLE_MANAGEMENT: (15, RateLimitPeriod.MINUTE),
     },
     # ladybug-large: r7g.large (16GB, 2 vCPU)
-    # Same base values as standard — graph.yml api_rate_multiplier (1.5x) handles scaling
+    # Identical enforcement to standard: the API limiter classifies all
+    # authenticated users as ladybug-standard, so these per-tier tables are
+    # reference/parity only. Burst protection is deliberately tier-flat;
+    # per-tier volume is governed by credits, not by a rate-limit multiplier.
     "ladybug-large": {
       EndpointCategory.AUTH: (20, RateLimitPeriod.MINUTE),
       EndpointCategory.USER_MANAGEMENT: (60, RateLimitPeriod.MINUTE),
@@ -174,6 +178,7 @@ class RateLimitConfig:
       EndpointCategory.GRAPH_WRITE: (30, RateLimitPeriod.MINUTE),
       EndpointCategory.GRAPH_ANALYTICS: (15, RateLimitPeriod.MINUTE),
       EndpointCategory.GRAPH_BACKUP: (5, RateLimitPeriod.MINUTE),
+      EndpointCategory.GRAPH_MANAGEMENT: (10, RateLimitPeriod.MINUTE),
       EndpointCategory.GRAPH_SYNC: (10, RateLimitPeriod.MINUTE),
       EndpointCategory.GRAPH_MCP: (30, RateLimitPeriod.MINUTE),
       EndpointCategory.GRAPH_OPERATOR: (15, RateLimitPeriod.MINUTE),
@@ -192,7 +197,8 @@ class RateLimitConfig:
       EndpointCategory.TABLE_MANAGEMENT: (15, RateLimitPeriod.MINUTE),
     },
     # ladybug-xlarge: r7g.xlarge (32GB, 4 vCPU)
-    # Same base values as standard — graph.yml api_rate_multiplier (2.5x) handles scaling
+    # Identical enforcement to standard (see ladybug-large note): reference/
+    # parity only; the limiter treats all authenticated users as standard.
     "ladybug-xlarge": {
       EndpointCategory.AUTH: (20, RateLimitPeriod.MINUTE),
       EndpointCategory.USER_MANAGEMENT: (60, RateLimitPeriod.MINUTE),
@@ -205,6 +211,7 @@ class RateLimitConfig:
       EndpointCategory.GRAPH_WRITE: (30, RateLimitPeriod.MINUTE),
       EndpointCategory.GRAPH_ANALYTICS: (15, RateLimitPeriod.MINUTE),
       EndpointCategory.GRAPH_BACKUP: (5, RateLimitPeriod.MINUTE),
+      EndpointCategory.GRAPH_MANAGEMENT: (10, RateLimitPeriod.MINUTE),
       EndpointCategory.GRAPH_SYNC: (10, RateLimitPeriod.MINUTE),
       EndpointCategory.GRAPH_MCP: (30, RateLimitPeriod.MINUTE),
       EndpointCategory.GRAPH_OPERATOR: (15, RateLimitPeriod.MINUTE),
@@ -245,36 +252,6 @@ class RateLimitConfig:
 
     limit, period = limit_config
     return limit, period.to_seconds()
-
-  @classmethod
-  def get_rate_limit_with_multiplier(
-    cls, tier: str, category: EndpointCategory, use_tier_config: bool = True
-  ) -> tuple[int, int] | None:
-    """
-    Get rate limit with optional tier config multiplier applied.
-
-    Args:
-        tier: Subscription tier
-        category: Endpoint category
-        use_tier_config: If True, apply multiplier from tier config
-
-    Returns:
-        Tuple of (limit, window_seconds) or None if not configured
-    """
-    # Get base rate limit
-    base_result = cls.get_rate_limit(tier, category)
-    if not base_result:
-      return None
-
-    base_limit, window_seconds = base_result
-
-    # Apply tier config multiplier if enabled
-    if use_tier_config:
-      multiplier = get_tier_api_rate_multiplier(tier)
-      adjusted_limit = int(base_limit * multiplier)
-      return adjusted_limit, window_seconds
-
-    return base_limit, window_seconds
 
   @classmethod
   def get_endpoint_category(
@@ -365,21 +342,46 @@ class RateLimitConfig:
       elif endpoint_type == "search":
         return EndpointCategory.GRAPH_SEARCH
 
-      # Backup operations
-      elif endpoint_type == "graph" and "backup" in path:
-        return EndpointCategory.GRAPH_BACKUP
+      # Schema inspection / export / validation — all read-only
+      elif endpoint_type == "schema":
+        return EndpointCategory.GRAPH_READ
 
-      # Direct queries
-      elif endpoint_type == "graph" and "query" in path:
+      # Direct Cypher queries — POST /v1/graphs/{graph_id}/query, so the
+      # segment after graph_id (endpoint_type) is "query". This previously
+      # checked `endpoint_type == "graph"`, which never matches the real
+      # route, so every query (including read-only shared repos like SEC)
+      # fell through to the GRAPH_WRITE default below and reported the
+      # misleading "graph write operations" limit.
+      elif endpoint_type == "query":
         return EndpointCategory.GRAPH_QUERY
 
-      # Analytics
-      elif endpoint_type == "graph" and "analytics" in path:
+      # Usage analytics — aggregation-heavy reads get a dedicated bucket
+      # (the endpoint segment is "analytics"; this previously checked
+      # `endpoint_type == "graph"` and never matched).
+      elif endpoint_type == "analytics":
         return EndpointCategory.GRAPH_ANALYTICS
 
-      # Sync operations
-      elif endpoint_type in ["sync", "connections"]:
-        return EndpointCategory.GRAPH_SYNC
+      # Graph lifecycle operations — POST /operations/{op_name}. Dedicated
+      # buckets so expensive rebuild/backup work can't be abused by sharing
+      # the generic write limit.
+      elif endpoint_type == "operations":
+        if "backup" in path:  # create-backup, restore-backup
+          return EndpointCategory.GRAPH_BACKUP
+        elif "materialize" in path:  # heavy OLAP rebuild
+          return EndpointCategory.GRAPH_IMPORT
+        else:  # create/delete subgraph, delete-graph, change-tier/style
+          return EndpointCategory.GRAPH_MANAGEMENT
+
+      # Connection management (reads/mutations) + the data-sync trigger.
+      # Only the actual /sync call belongs in the tight sync bucket; listing
+      # connections, options, and OAuth callbacks are ordinary reads/writes.
+      elif endpoint_type == "connections":
+        if "sync" in path:
+          return EndpointCategory.GRAPH_SYNC
+        elif method in ["POST", "PUT", "DELETE", "PATCH"]:
+          return EndpointCategory.GRAPH_WRITE
+        else:
+          return EndpointCategory.GRAPH_READ
 
       # Import operations
       elif "import" in path or "ingest" in path:

--- a/robosystems/middleware/rate_limits/repository_rate_limits.py
+++ b/robosystems/middleware/rate_limits/repository_rate_limits.py
@@ -1,8 +1,10 @@
 """
 Repository-specific rate limiting for shared repositories like SEC.
 
-This module implements the second layer of rate limiting specifically for
-shared repositories, working in conjunction with the existing burst protection.
+This module implements the subscription-plan *volume* limits for shared
+repositories. Per-request *burst* protection is handled upstream by the
+per-tier FastAPI dependency (``subscription_aware_rate_limit_dependency``),
+so this layer only enforces the manifest's per-plan volume caps.
 
 IMPORTANT: Both direct API queries and MCP queries are included.
 Rate limits are applied to prevent abuse and ensure fair usage across tiers.
@@ -14,7 +16,6 @@ from enum import Enum
 
 import redis.asyncio as redis
 
-from robosystems.config.rate_limits import EndpointCategory, RateLimitConfig
 from robosystems.config.shared_repositories import (
   get_rate_limits as _get_rate_limits,
 )
@@ -72,9 +73,12 @@ class SharedRepositoryRateLimits:
 
 class DualLayerRateLimiter:
   """
-  Implements two-layer rate limiting:
-  1. Burst protection (existing) - prevents API abuse
-  2. Repository limits (new) - subscription-based volume control
+  Enforce shared-repository subscription-plan *volume* limits.
+
+  Per-request burst protection is applied upstream by the per-tier FastAPI
+  dependency (``subscription_aware_rate_limit_dependency``); this class only
+  layers the manifest's per-plan volume caps on top for shared repos. (The
+  name is historical — there is now a single layer here.)
   """
 
   def __init__(self, redis_client: redis.Redis):
@@ -86,110 +90,59 @@ class DualLayerRateLimiter:
     graph_id: str,
     operation: str,
     endpoint: str,
-    user_tier: str,
     repository_plan: str | None = None,
   ) -> dict:
     """
-    Check both burst and repository-specific limits.
+    Check shared-repository per-plan volume limits.
 
     Args:
         user_id: User making the request
-        graph_id: Graph ID (could be "sec" for shared repo)
-        operation: Operation type (query, mcp, agent, export)
+        graph_id: Graph ID (could be "sec"/"sec_historical" for a shared repo)
+        operation: Operation type (query, mcp, search)
         endpoint: The actual endpoint being called
-        user_tier: User's subscription tier (for burst limits)
         repository_plan: Repository subscription plan (for volume limits)
 
     Returns:
         Dict with allowed status and details
     """
+    # Only shared repositories (including subgraphs like sec_historical) are
+    # gated here; other graphs rely on the upstream burst dependency alone.
+    if not is_shared_repository_or_subgraph(graph_id):
+      return {"allowed": True, "repo": None}
 
-    # Check if this is a shared repository (including subgraphs like sec_historical)
-    if is_shared_repository_or_subgraph(graph_id):
-      # Resolve subgraph to parent for policy lookups
-      parent_repo_id = resolve_shared_repository_parent(graph_id)
+    # Resolve subgraph to parent for policy + subscription lookups
+    parent_repo_id = resolve_shared_repository_parent(graph_id)
 
-      # First check if the endpoint is even allowed
-      if not SharedRepositoryRateLimits.is_endpoint_allowed(parent_repo_id, endpoint):
-        return {
-          "allowed": False,
-          "reason": "endpoint_not_allowed",
-          "message": f"Endpoint '{endpoint}' is not allowed for shared repository '{graph_id}'",
-          "allowed_endpoints": list(AllowedSharedEndpoints),
-        }
-
-      # Check if user has access (subscription required - must have valid plan)
-      if not repository_plan:
-        return {
-          "allowed": False,
-          "reason": "no_access",
-          "message": f"Access to {graph_id} repository requires a paid subscription",
-          "upgrade_url": "/upgrade",
-        }
-
-    # Layer 1: Check burst protection (existing system)
-    burst_check = await self._check_burst_limit(user_id, operation, user_tier)
-    if not burst_check["allowed"]:
+    # The endpoint must be allowed for shared repositories
+    if not SharedRepositoryRateLimits.is_endpoint_allowed(parent_repo_id, endpoint):
       return {
         "allowed": False,
-        "reason": "burst_limit",
-        "detail": burst_check,
-        "message": "Rate limit exceeded (burst protection)",
+        "reason": "endpoint_not_allowed",
+        "message": f"Endpoint '{endpoint}' is not allowed for shared repository '{graph_id}'",
+        "allowed_endpoints": list(AllowedSharedEndpoints),
       }
 
-    # Layer 2: Check repository-specific limits (if applicable)
-    repo_check = None
-    if is_shared_repository_or_subgraph(graph_id) and repository_plan:
-      parent_id = resolve_shared_repository_parent(graph_id)
-      repo_check = await self._check_repository_limit(
-        user_id, parent_id, operation, repository_plan
-      )
-      if not repo_check["allowed"]:
-        return {
-          "allowed": False,
-          "reason": "repository_limit",
-          "detail": repo_check,
-          "message": f"Repository {operation} limit exceeded for {repository_plan} plan",
-        }
+    # Access requires a valid (paid) subscription plan
+    if not repository_plan:
+      return {
+        "allowed": False,
+        "reason": "no_access",
+        "message": f"Access to {graph_id} repository requires a paid subscription",
+        "upgrade_url": "/upgrade",
+      }
 
-    return {
-      "allowed": True,
-      "burst": burst_check,
-      "repo": repo_check if is_shared_repository_or_subgraph(graph_id) else None,
-    }
+    repo_check = await self._check_repository_limit(
+      user_id, parent_repo_id, operation, repository_plan
+    )
+    if not repo_check["allowed"]:
+      return {
+        "allowed": False,
+        "reason": "repository_limit",
+        "detail": repo_check,
+        "message": f"Repository {operation} limit exceeded for {repository_plan} plan",
+      }
 
-  async def _check_burst_limit(self, user_id: str, operation: str, tier: str) -> dict:
-    """Check existing burst protection limits."""
-    category = self._operation_to_category(operation)
-    limit_config = RateLimitConfig.get_rate_limit(tier, category)
-
-    if not limit_config:
-      return {"allowed": True}
-
-    limit, window = limit_config
-
-    # Use sliding window counter
-    now = int(datetime.now(UTC).timestamp())
-    window_start = now - window
-    key = f"burst:{user_id}:{operation}"
-
-    # Remove old entries and count current window
-    pipe = self.redis.pipeline()
-    pipe.zremrangebyscore(key, 0, window_start)
-    pipe.zadd(key, {str(now): now})
-    pipe.zcount(key, window_start, now)
-    pipe.expire(key, window)
-    results = await pipe.execute()
-
-    count = results[2]
-
-    return {
-      "allowed": count <= limit,
-      "limit": limit,
-      "current": count,
-      "window": window,
-      "reset_at": now + window,
-    }
+    return {"allowed": True, "repo": repo_check}
 
   async def _check_repository_limit(
     self, user_id: str, repository: str, operation: str, plan: str
@@ -278,16 +231,6 @@ class DualLayerRateLimiter:
 
     return {"allowed": True, "checks": checks}
 
-  def _operation_to_category(self, operation: str) -> EndpointCategory:
-    """Map operation to endpoint category for burst limits."""
-    mapping = {
-      "query": EndpointCategory.GRAPH_QUERY,
-      "mcp": EndpointCategory.GRAPH_MCP,
-      "operator": EndpointCategory.GRAPH_OPERATOR,
-      "search": EndpointCategory.GRAPH_SEARCH,
-    }
-    return mapping.get(operation, EndpointCategory.GRAPH_READ)
-
   async def get_usage_stats(self, user_id: str, repository: str, plan: str) -> dict:
     """Get current usage statistics for a user."""
     limits = SharedRepositoryRateLimits.get_limits(repository, plan)
@@ -301,15 +244,15 @@ class DualLayerRateLimiter:
     for operation in ["query", "mcp", "agent", "search"]:
       operation_stats = {}
 
-      # Check each time window
-      for window, fmt in [
-        ("minute", "%Y%m%d%H%M"),
-        ("hour", "%Y%m%d%H"),
-        ("day", "%Y%m%d"),
+      # Check each time window. The token must match exactly what
+      # _check_repository_limit writes ("min"/"hour"/"day") — using
+      # window[:3] produced "hou" for the hour bucket and silently read 0.
+      for window, token, fmt in [
+        ("minute", "min", "%Y%m%d%H%M"),
+        ("hour", "hour", "%Y%m%d%H"),
+        ("day", "day", "%Y%m%d"),
       ]:
-        key = (
-          f"repo:{repository}:{user_id}:{operation}:{window[:3]}:{now.strftime(fmt)}"
-        )
+        key = f"repo:{repository}:{user_id}:{operation}:{token}:{now.strftime(fmt)}"
         count = await self.redis.get(key)
         operation_stats[window] = int(count) if count else 0
 

--- a/robosystems/routers/graphs/documents.py
+++ b/robosystems/routers/graphs/documents.py
@@ -10,6 +10,7 @@ from starlette import status as http_status
 
 from robosystems.database import SessionFactory
 from robosystems.middleware.auth.dependencies import get_current_user_with_graph
+from robosystems.middleware.rate_limits import subscription_aware_rate_limit_dependency
 from robosystems.models.api.common import RESOURCE_ERROR_RESPONSES
 from robosystems.models.api.search import (
   DocumentDetailResponse,
@@ -25,7 +26,11 @@ from robosystems.operations.document_service import DocumentService
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(prefix="/documents", tags=["Documents"])
+router = APIRouter(
+  prefix="/documents",
+  tags=["Documents"],
+  dependencies=[Depends(subscription_aware_rate_limit_dependency)],
+)
 
 
 def _block_shared_repository(graph_id: str) -> None:

--- a/robosystems/routers/graphs/mcp/execute.py
+++ b/robosystems/routers/graphs/mcp/execute.py
@@ -337,19 +337,28 @@ async def call_mcp_tool(
     try:
       await validate_mcp_access(graph_id, current_user, sess, access_type)
 
-      # Look up shared-repo subscription while session is still open
-      if MultiTenantUtils.is_shared_repository(graph_id):
+      # Look up shared-repo subscription while session is still open.
+      # Covers subgraphs (e.g. sec_historical) too — subscriptions live on
+      # the parent, so resolve to it before the lookup, matching the query
+      # path in query/execute.py::_check_shared_repository_limits.
+      if MultiTenantUtils.is_shared_repository_or_subgraph(graph_id):
+        from robosystems.config.shared_repositories import (
+          resolve_shared_repository_parent,
+        )
         from robosystems.models.core.user.user_repository import UserRepository
 
         repo_access = UserRepository.get_by_user_and_repository(
-          current_user.id, graph_id, sess
+          current_user.id, resolve_shared_repository_parent(graph_id), sess
         )
     finally:
       sess.close()
 
-    # Apply dual-layer rate limiting for shared repositories
+    # Apply dual-layer rate limiting for shared repositories (incl. subgraphs)
     # Rate limiting is optional - skip if disabled (dev environments)
-    if MultiTenantUtils.is_shared_repository(graph_id) and env.RATE_LIMIT_ENABLED:
+    if (
+      MultiTenantUtils.is_shared_repository_or_subgraph(graph_id)
+      and env.RATE_LIMIT_ENABLED
+    ):
       from robosystems.config.valkey_registry import (
         ValkeyDatabase,
         create_async_redis_client,
@@ -368,19 +377,13 @@ async def call_mcp_tool(
       try:
         limiter = DualLayerRateLimiter(redis_client)
 
-        # Get user's subscription tier for burst protection
-        user_tier = "ladybug-standard"  # Default for authenticated users
-        if hasattr(current_user, "subscription") and current_user.subscription:
-          if current_user.subscription.billing_plan:
-            user_tier = current_user.subscription.billing_plan.name
-
-        # Check both rate limit layers
+        # Check shared-repository per-plan volume limits (burst protection is
+        # already enforced upstream by subscription_aware_rate_limit_dependency).
         limit_check = await limiter.check_limits(
           user_id=str(current_user.id),
           graph_id=graph_id,
           operation="mcp",
           endpoint=f"mcp/call-tool/{tool_call.name}",
-          user_tier=user_tier,
           repository_plan=repo_access.repository_plan,
         )
 
@@ -397,18 +400,6 @@ async def call_mcp_tool(
             raise HTTPException(
               status_code=http_status.HTTP_403_FORBIDDEN,
               detail=message,
-            )
-          elif reason == "burst_limit":
-            detail = limit_check.get("detail", {})
-            raise HTTPException(
-              status_code=http_status.HTTP_429_TOO_MANY_REQUESTS,
-              detail=f"Rate limit exceeded: {detail.get('current', 0)}/{detail.get('limit', 0)} "
-              f"requests per {detail.get('window', 0)} seconds",
-              headers={
-                "Retry-After": str(detail.get("window", 60)),
-                "X-RateLimit-Limit": str(detail.get("limit", 0)),
-                "X-RateLimit-Remaining": str(detail.get("remaining", 0)),
-              },
             )
           elif reason == "repository_limit":
             detail = limit_check.get("detail", {})

--- a/robosystems/routers/graphs/query/execute.py
+++ b/robosystems/routers/graphs/query/execute.py
@@ -833,19 +833,16 @@ async def _check_shared_repository_limits(
   try:
     limiter = DualLayerRateLimiter(redis_client)
 
-    # Get user's subscription tier (for burst protection)
-    user_tier = getattr(user, "subscription_tier", "ladybug-standard")
-
     # repo_access already fetched above for access check
     repo_plan = repo_access.repository_plan if repo_access else None
 
-    # Check both rate limit layers
+    # Check shared-repository per-plan volume limits (burst protection is
+    # already enforced upstream by subscription_aware_rate_limit_dependency).
     limit_check = await limiter.check_limits(
       user_id=user.id,
       graph_id=graph_id,
       operation="query",  # Direct queries
       endpoint=endpoint,
-      user_tier=user_tier,
       repository_plan=repo_plan,
     )
 
@@ -860,13 +857,6 @@ async def _check_shared_repository_limits(
         )
       elif reason == "endpoint_not_allowed":
         raise HTTPException(status_code=http_status.HTTP_403_FORBIDDEN, detail=message)
-      elif reason == "burst_limit":
-        detail = limit_check.get("detail", {})
-        raise HTTPException(
-          status_code=http_status.HTTP_429_TOO_MANY_REQUESTS,
-          detail=f"Rate limit exceeded: {detail.get('current', 0)}/{detail.get('limit', 0)} "
-          f"requests per {detail.get('window', 0)} seconds",
-        )
       elif reason == "repository_limit":
         detail = limit_check.get("detail", {})
         raise HTTPException(

--- a/robosystems/routers/graphs/search.py
+++ b/robosystems/routers/graphs/search.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from starlette import status as http_status
 
 from robosystems.middleware.auth.dependencies import get_current_user_with_graph
+from robosystems.middleware.rate_limits import subscription_aware_rate_limit_dependency
 from robosystems.models.api.common import RESOURCE_ERROR_RESPONSES
 from robosystems.models.api.search import (
   DocumentSection,
@@ -17,7 +18,14 @@ from robosystems.operations.search import get_search_service
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(prefix="/search", tags=["Search"])
+# Per-tier burst limiting (GRAPH_SEARCH) applies to ALL graphs, shared or
+# user-owned — OpenSearch is a shared resource. The shared-repo per-plan
+# volume caps in _check_search_rate_limit run on top for SEC et al.
+router = APIRouter(
+  prefix="/search",
+  tags=["Search"],
+  dependencies=[Depends(subscription_aware_rate_limit_dependency)],
+)
 
 
 def _require_search_service():
@@ -77,14 +85,12 @@ async def _check_search_rate_limit(
 
   try:
     limiter = DualLayerRateLimiter(redis_client)
-    user_tier = getattr(current_user, "subscription_tier", None) or "ladybug-standard"
 
     limit_check = await limiter.check_limits(
       user_id=str(current_user.id),
       graph_id=graph_id,
       operation="search",
       endpoint=endpoint,
-      user_tier=user_tier,
       repository_plan=repo_access.repository_plan,
     )
 

--- a/robosystems/routers/graphs/subgraphs/info.py
+++ b/robosystems/routers/graphs/subgraphs/info.py
@@ -11,6 +11,7 @@ from robosystems.logger import api_logger, log_metric, logger
 from robosystems.middleware.auth.dependencies import get_current_user_with_graph
 from robosystems.middleware.graph.types import GRAPH_ID_PATTERN, SUBGRAPH_NAME_PATTERN
 from robosystems.middleware.otel.metrics import endpoint_metrics_decorator
+from robosystems.middleware.rate_limits import subscription_aware_rate_limit_dependency
 from robosystems.models.api.common import RESOURCE_ERROR_RESPONSES
 from robosystems.models.api.graphs.subgraphs import SubgraphResponse, SubgraphType
 from robosystems.models.core.user import User
@@ -23,7 +24,7 @@ from .utils import (
   record_operation_start,
 )
 
-router = APIRouter()
+router = APIRouter(dependencies=[Depends(subscription_aware_rate_limit_dependency)])
 
 
 @router.get(

--- a/robosystems/routers/graphs/subgraphs/main.py
+++ b/robosystems/routers/graphs/subgraphs/main.py
@@ -17,6 +17,7 @@ from robosystems.logger import api_logger, log_metric, logger
 from robosystems.middleware.auth.dependencies import get_current_user_with_graph
 from robosystems.middleware.graph.types import GRAPH_ID_PATTERN
 from robosystems.middleware.otel.metrics import endpoint_metrics_decorator
+from robosystems.middleware.rate_limits import subscription_aware_rate_limit_dependency
 from robosystems.models.api.common import RESOURCE_ERROR_RESPONSES
 from robosystems.models.api.graphs.subgraphs import (
   CreateSubgraphRequest,
@@ -41,7 +42,7 @@ from .utils import (
   verify_subgraph_tier_support,
 )
 
-router = APIRouter()
+router = APIRouter(dependencies=[Depends(subscription_aware_rate_limit_dependency)])
 
 
 async def get_database_size_mb(graph_id: str) -> float | None:

--- a/robosystems/routers/graphs/subgraphs/quota.py
+++ b/robosystems/routers/graphs/subgraphs/quota.py
@@ -12,6 +12,7 @@ from robosystems.logger import api_logger, log_metric, logger
 from robosystems.middleware.auth.dependencies import get_current_user_with_graph
 from robosystems.middleware.graph.types import GRAPH_ID_PATTERN
 from robosystems.middleware.otel.metrics import endpoint_metrics_decorator
+from robosystems.middleware.rate_limits import subscription_aware_rate_limit_dependency
 from robosystems.models.api.common import RESOURCE_ERROR_RESPONSES
 from robosystems.models.api.graphs.subgraphs import SubgraphQuotaResponse
 from robosystems.models.core.graph import Graph
@@ -25,7 +26,7 @@ from .utils import (
   verify_parent_graph_access,
 )
 
-router = APIRouter()
+router = APIRouter(dependencies=[Depends(subscription_aware_rate_limit_dependency)])
 
 
 @router.get(

--- a/tests/config/test_rate_limits.py
+++ b/tests/config/test_rate_limits.py
@@ -23,40 +23,6 @@ def test_unknown_tier_falls_back_to_base_limits():
   assert window == RateLimitPeriod.MINUTE.to_seconds()
 
 
-def test_rate_limit_with_multiplier_adjusts_value(monkeypatch):
-  monkeypatch.setattr(
-    "robosystems.config.rate_limits.get_tier_api_rate_multiplier",
-    lambda tier: 2.5,
-  )
-
-  adjusted_limit, window = RateLimitConfig.get_rate_limit_with_multiplier(
-    "ladybug-standard", EndpointCategory.GRAPH_READ
-  )
-
-  base_limit = RateLimitConfig.SUBSCRIPTION_RATE_LIMITS["ladybug-standard"][
-    EndpointCategory.GRAPH_READ
-  ][0]
-  assert adjusted_limit == int(base_limit * 2.5)
-  assert window == RateLimitPeriod.MINUTE.to_seconds()
-
-
-def test_multiplier_can_be_skipped(monkeypatch):
-  monkeypatch.setattr(
-    "robosystems.config.rate_limits.get_tier_api_rate_multiplier",
-    lambda tier: 99,
-  )
-
-  limit_without_multiplier, window = RateLimitConfig.get_rate_limit_with_multiplier(
-    "ladybug-standard", EndpointCategory.GRAPH_READ, use_tier_config=False
-  )
-
-  base_limit, expected_window = RateLimitConfig.get_rate_limit(
-    "ladybug-standard", EndpointCategory.GRAPH_READ
-  )
-  assert limit_without_multiplier == base_limit
-  assert window == expected_window == RateLimitPeriod.MINUTE.to_seconds()
-
-
 @pytest.mark.parametrize(
   "path,method,expected",
   [
@@ -79,10 +45,43 @@ def test_multiplier_can_be_skipped(monkeypatch):
     # Search endpoints (OpenSearch)
     ("/v1/graphs/abc/search", "POST", EndpointCategory.GRAPH_SEARCH),
     ("/v1/graphs/abc/search/doc123", "GET", EndpointCategory.GRAPH_SEARCH),
-    ("/v1/graphs/abc/graph/backup", "POST", EndpointCategory.GRAPH_BACKUP),
-    ("/v1/graphs/abc/graph/query", "POST", EndpointCategory.GRAPH_QUERY),
-    ("/v1/graphs/abc/graph/analytics", "GET", EndpointCategory.GRAPH_ANALYTICS),
-    ("/v1/graphs/abc/sync/start", "POST", EndpointCategory.GRAPH_SYNC),
+    # Direct Cypher query (real route: no /graph segment)
+    ("/v1/graphs/abc/query", "POST", EndpointCategory.GRAPH_QUERY),
+    # Schema surface is read-only (info/export/validate)
+    ("/v1/graphs/abc/schema", "GET", EndpointCategory.GRAPH_READ),
+    ("/v1/graphs/abc/schema/validate", "POST", EndpointCategory.GRAPH_READ),
+    # Usage analytics — dedicated bucket
+    ("/v1/graphs/abc/analytics", "GET", EndpointCategory.GRAPH_ANALYTICS),
+    ("/v1/graphs/abc/analytics/usage", "GET", EndpointCategory.GRAPH_ANALYTICS),
+    # Backup list is a read; download too
+    ("/v1/graphs/abc/backups", "GET", EndpointCategory.GRAPH_READ),
+    # Graph lifecycle operations get dedicated buckets
+    (
+      "/v1/graphs/abc/operations/create-backup",
+      "POST",
+      EndpointCategory.GRAPH_BACKUP,
+    ),
+    (
+      "/v1/graphs/abc/operations/restore-backup",
+      "POST",
+      EndpointCategory.GRAPH_BACKUP,
+    ),
+    ("/v1/graphs/abc/operations/materialize", "POST", EndpointCategory.GRAPH_IMPORT),
+    (
+      "/v1/graphs/abc/operations/create-subgraph",
+      "POST",
+      EndpointCategory.GRAPH_MANAGEMENT,
+    ),
+    (
+      "/v1/graphs/abc/operations/change-tier",
+      "POST",
+      EndpointCategory.GRAPH_MANAGEMENT,
+    ),
+    # Connections: reads/writes are ordinary; only the sync trigger is GRAPH_SYNC
+    ("/v1/graphs/abc/connections", "GET", EndpointCategory.GRAPH_READ),
+    ("/v1/graphs/abc/connections", "POST", EndpointCategory.GRAPH_WRITE),
+    ("/v1/graphs/abc/connections/options", "GET", EndpointCategory.GRAPH_READ),
+    ("/v1/graphs/abc/connections/c1/sync", "POST", EndpointCategory.GRAPH_SYNC),
     ("/v1/graphs/abc/import", "POST", EndpointCategory.GRAPH_IMPORT),
     ("/v1/graphs/abc/custom", "POST", EndpointCategory.GRAPH_WRITE),
     ("/v1/graphs/abc/custom", "GET", EndpointCategory.GRAPH_READ),

--- a/tests/middleware/rate_limits/test_repository_rate_limits.py
+++ b/tests/middleware/rate_limits/test_repository_rate_limits.py
@@ -1,6 +1,6 @@
 """Repository-specific rate limiting tests."""
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -51,14 +51,9 @@ class TestDualLayerRateLimiter:
   @pytest.fixture
   def mock_redis(self):
     redis = AsyncMock()
-    # pipeline() is sync in redis.asyncio — returns a Pipeline, not a coroutine
-    pipe = MagicMock()
-    pipe.zremrangebyscore = MagicMock()
-    pipe.zadd = MagicMock()
-    pipe.zcount = MagicMock()
-    pipe.expire = MagicMock()
-    pipe.execute = AsyncMock(return_value=[0, True, 1, True])
-    redis.pipeline = MagicMock(return_value=pipe)
+    # Repository volume limits use INCR + EXPIRE. Default: first hit in window.
+    redis.incr = AsyncMock(return_value=1)
+    redis.expire = AsyncMock(return_value=True)
     return redis
 
   @pytest.fixture
@@ -72,8 +67,7 @@ class TestDualLayerRateLimiter:
       graph_id="sec",
       operation="query",
       endpoint="backup",
-      user_tier="ladybug-standard",
-      repository_plan="sec-starter",
+      repository_plan="starter",
     )
     assert result["allowed"] is False
     assert result["reason"] == "endpoint_not_allowed"
@@ -85,60 +79,46 @@ class TestDualLayerRateLimiter:
       graph_id="sec",
       operation="query",
       endpoint="query",
-      user_tier="ladybug-standard",
       repository_plan=None,
     )
     assert result["allowed"] is False
     assert result["reason"] == "no_access"
 
   @pytest.mark.asyncio
-  async def test_burst_limit_exceeded(self, limiter, mock_redis):
-    # Mock pipeline properly for async context manager
-    pipe = MagicMock()
-    pipe.zremrangebyscore = MagicMock()
-    pipe.zadd = MagicMock()
-    pipe.zcount = MagicMock()
-    pipe.expire = MagicMock()
-    pipe.execute = AsyncMock(return_value=[0, True, 1000, True])
-    mock_redis.pipeline.return_value = pipe
-
+  async def test_repository_volume_limit_exceeded(self, limiter, mock_redis):
+    # Push the per-window counter above the starter plan's queries_per_minute.
+    mock_redis.incr = AsyncMock(return_value=10_000)
     result = await limiter.check_limits(
       user_id="u1",
       graph_id="sec",
       operation="query",
       endpoint="query",
-      user_tier="ladybug-standard",
-      repository_plan="sec-starter",
+      repository_plan="starter",
     )
-    assert isinstance(result, dict)
+    assert result["allowed"] is False
+    assert result["reason"] == "repository_limit"
 
   @pytest.mark.asyncio
-  async def test_allowed_non_shared_repo(self, limiter, mock_redis):
-    pipe = MagicMock()
-    pipe.zremrangebyscore = MagicMock()
-    pipe.zadd = MagicMock()
-    pipe.zcount = MagicMock()
-    pipe.expire = MagicMock()
-    pipe.execute = AsyncMock(return_value=[0, True, 1, True])
-    mock_redis.pipeline.return_value = pipe
-
+  async def test_allowed_within_repository_limits(self, limiter):
     result = await limiter.check_limits(
       user_id="u1",
-      graph_id="kg123",  # NOT a shared repo
+      graph_id="sec",
       operation="query",
       endpoint="query",
-      user_tier="ladybug-standard",
+      repository_plan="starter",
     )
     assert result["allowed"] is True
 
-  def test_operation_to_category(self, limiter):
-    from robosystems.config.rate_limits import EndpointCategory
-
-    assert limiter._operation_to_category("query") == EndpointCategory.GRAPH_QUERY
-    assert limiter._operation_to_category("mcp") == EndpointCategory.GRAPH_MCP
-    assert limiter._operation_to_category("operator") == EndpointCategory.GRAPH_OPERATOR
-    assert limiter._operation_to_category("search") == EndpointCategory.GRAPH_SEARCH
-    assert limiter._operation_to_category("unknown") == EndpointCategory.GRAPH_READ
+  @pytest.mark.asyncio
+  async def test_allowed_non_shared_repo(self, limiter):
+    result = await limiter.check_limits(
+      user_id="u1",
+      graph_id="kg123",  # NOT a shared repo — burst handled upstream
+      operation="query",
+      endpoint="query",
+    )
+    assert result["allowed"] is True
+    assert result["repo"] is None
 
   @pytest.mark.asyncio
   async def test_get_usage_stats_no_limits(self, limiter):

--- a/tests/middleware/rate_limits/test_router_dependencies.py
+++ b/tests/middleware/rate_limits/test_router_dependencies.py
@@ -1,0 +1,43 @@
+"""Guard tests: the rate-limit dependency stays wired on graph routers.
+
+These routers had (or gained) router-level rate limiting. Because
+``tests/conftest.py`` overrides ``subscription_aware_rate_limit_dependency``
+to a no-op, the request-path integration suites would NOT catch an accidental
+removal of the wiring — so assert the declaration directly.
+"""
+
+import pytest
+
+from robosystems.middleware.rate_limits import subscription_aware_rate_limit_dependency
+
+
+def _declares_rate_limit(router) -> bool:
+  """True if the router declares the subscription-aware rate-limit dependency."""
+  return any(
+    getattr(dep, "dependency", None) is subscription_aware_rate_limit_dependency
+    for dep in router.dependencies
+  )
+
+
+def _import_router(module_path: str):
+  import importlib
+
+  return importlib.import_module(module_path).router
+
+
+@pytest.mark.parametrize(
+  "module_path",
+  [
+    "robosystems.routers.graphs.search",
+    "robosystems.routers.graphs.documents",
+    "robosystems.routers.graphs.subgraphs.main",
+    "robosystems.routers.graphs.subgraphs.info",
+    "robosystems.routers.graphs.subgraphs.quota",
+  ],
+)
+def test_router_declares_subscription_rate_limit(module_path):
+  router = _import_router(module_path)
+  assert _declares_rate_limit(router), (
+    f"{module_path} lost its subscription_aware_rate_limit_dependency — "
+    "search/documents/subgraphs endpoints must stay rate-limited on user graphs"
+  )

--- a/tests/middleware/rate_limits/test_subscription_rate_limiting.py
+++ b/tests/middleware/rate_limits/test_subscription_rate_limiting.py
@@ -47,21 +47,26 @@ class TestSubscriptionRateLimits:
       get_endpoint_category("/v1/graphs/kg1a2b3c/operator/query")
       == EndpointCategory.GRAPH_OPERATOR
     )
+    # Real route is POST /v1/graphs/{graph_id}/query (not /graph/query/cypher).
+    # Must be GRAPH_QUERY — never GRAPH_WRITE — even for read-only shared repos.
     assert (
-      get_endpoint_category("/v1/graphs/kg1a2b3c/graph/query/cypher")
+      get_endpoint_category("/v1/graphs/kg1a2b3c/query", "POST")
       == EndpointCategory.GRAPH_QUERY
     )
+    # Data sync lives under connections; only the /sync trigger is GRAPH_SYNC,
+    # while connection reads are ordinary GRAPH_READ.
     assert (
-      get_endpoint_category("/v1/graphs/kg1a2b3c/graph/analytics/metrics")
-      == EndpointCategory.GRAPH_ANALYTICS
-    )
-    assert (
-      get_endpoint_category("/v1/graphs/kg1a2b3c/graph/backup/create")
-      == EndpointCategory.GRAPH_BACKUP
-    )
-    assert (
-      get_endpoint_category("/v1/graphs/kg1a2b3c/sync/quickbooks")
+      get_endpoint_category("/v1/graphs/kg1a2b3c/connections/c1/sync", "POST")
       == EndpointCategory.GRAPH_SYNC
+    )
+    assert (
+      get_endpoint_category("/v1/graphs/kg1a2b3c/connections", "GET")
+      == EndpointCategory.GRAPH_READ
+    )
+    # Lifecycle operations get their own management bucket
+    assert (
+      get_endpoint_category("/v1/graphs/kg1a2b3c/operations/create-subgraph", "POST")
+      == EndpointCategory.GRAPH_MANAGEMENT
     )
 
   def test_should_use_subscription_limits(self):

--- a/tests/middleware/rate_limits/test_subscription_rate_limits.py
+++ b/tests/middleware/rate_limits/test_subscription_rate_limits.py
@@ -59,17 +59,16 @@ class TestSubscriptionRateLimits:
     )
 
   def test_get_endpoint_category_query_endpoints(self):
-    """Test endpoint categorization for query endpoints."""
-    query_paths = [
-      "/v1/graphs/kg1234/query",
-      "/v1/graphs/sec/query",
-      "/v1/abc123/cypher",
-    ]
+    """POST /v1/graphs/{graph_id}/query must be GRAPH_QUERY, not GRAPH_WRITE.
 
-    for path in query_paths:
-      category = get_endpoint_category(path, "POST")
-      # Should be categorized appropriately
-      assert category is None or isinstance(category, EndpointCategory)
+    Regression guard: the direct-query branch used to require
+    `endpoint_type == "graph"`, which never matched the real route, so
+    queries (including read-only shared repos like SEC) fell through to the
+    GRAPH_WRITE default and surfaced a misleading "graph write operations"
+    rate-limit error.
+    """
+    for path in ["/v1/graphs/kg1234/query", "/v1/graphs/sec/query"]:
+      assert get_endpoint_category(path, "POST") == EndpointCategory.GRAPH_QUERY
 
   def test_get_endpoint_category_ingestion_endpoints(self):
     """Test endpoint categorization for ingestion endpoints."""


### PR DESCRIPTION
## Summary

Fixes a rate-limiting bug where read-only SEC (shared-repo) queries reported
`Rate limit exceeded for graph write operations.`, and cleans up the wider
graph rate-limiting surface it exposed. The categorizer matched several routes
against a stale `endpoint_type == "graph"` condition that never corresponds to a
real route (paths are `/v1/graphs/{id}/query`, not `/.../graph/query`), so
direct Cypher queries fell through to the generic write default. While in here,
the change corrects mis-bucketed routes, gives expensive lifecycle operations
dedicated limits, removes a redundant limiter layer, and closes endpoints that
had no rate limiting at all.

## Changes

**Endpoint categorization** (`config/rate_limits.py`)
- `/query` → `GRAPH_QUERY` (was `GRAPH_WRITE` via the POST catch-all — the reported bug)
- `/analytics` → `GRAPH_ANALYTICS`; `/schema*` → `GRAPH_READ` (validate was mis-bucketed as write)
- `connections`: reads → `GRAPH_READ`, writes → `GRAPH_WRITE`, and only the `/sync` trigger stays `GRAPH_SYNC` (previously *every* connections route got the tight 3/min sync bucket)
- graph lifecycle ops (`/operations/{op}`) get dedicated buckets: `create-`/`restore-backup` → `GRAPH_BACKUP`, `materialize` → `GRAPH_IMPORT`, and a new `GRAPH_MANAGEMENT` category for subgraph/tier/style ops
- removed the dead `get_rate_limit_with_multiplier` (never called in the live path — all authenticated users are classified `ladybug-standard`) and fixed the comments/README that claimed a tier multiplier scaled enforcement

**Shared-repo limiter** (`middleware/rate_limits/repository_rate_limits.py` + query/mcp/search callers)
- collapsed the `DualLayerRateLimiter` to a single subscription-plan *volume* layer; the per-request *burst* limit it re-derived duplicated the upstream subscription dependency (same category, tier, and 60/min) under a separate counter
- dropped `_check_burst_limit` / `_operation_to_category` / the `user_tier` plumbing and the now-dead `burst_limit` branches in the callers
- MCP path now gates on `is_shared_repository_or_subgraph` (was exact-parent `is_shared_repository`) and resolves subgraph → parent for the subscription lookup, so `sec_historical` gets the SEC per-plan limits like the query path (authorization already covered subgraphs via `validate_mcp_access`)
- fixed `get_usage_stats` hour bucket: the read key used `window[:3]` (`"hou"`) but writes use `"hour"`, so hour usage always read 0

**Coverage gaps closed** (search / documents / subgraphs routers)
- `/search` now applies the per-tier burst limiter (`GRAPH_SEARCH`) on all graphs — previously only shared repos were limited, so user-graph search was unbounded
- `documents/*` and `subgraphs/*` had no rate-limit dependency at all; attached the subscription limiter at the router level

## Testing

Run this session, all green:
- `just test` — full unit suite: **10,706 passed, 15 skipped, 0 failed**
- `just test-code` — ruff + format (1541 files) + basedpyright (0 errors) + cf-lint: **all passed**
- Verified the categorizer output for ~25 real routes and confirmed the router-level dependency attaches to every newly-wired search/documents/subgraphs route

## Notes / Follow-ups (not in this PR)

- `/v1/operations/{id}/status` and `DELETE` still use the generic limiter rather than a subscription bucket — intentional, since forcing a tight bucket would throttle status polling.
- Cosmetic dead code remains: `AllowedSharedEndpoints` / `BLOCKED_SHARED_ENDPOINTS` disagree with the SEC manifest, and `SharedRepositoryRateLimits.is_endpoint_allowed` ignores its `repository` arg (latent only — single shared repo today).
- `limits.py` still *displays* multiplier-based numbers that don't match the now-flat enforcement; left as a separate display-vs-reality question.
