### PR TITLE
fix(rate-limits): point shared-repo upsell messages at robosystems.ai/billing

### DIFF
--- a/robosystems/config/shared_repositories.py
+++ b/robosystems/config/shared_repositories.py
@@ -276,6 +276,8 @@ def is_endpoint_allowed(endpoint: str, repo_id: str | None = None) -> bool:
 
 def get_all_repository_pricing() -> dict:
   """Get complete pricing information for all repository plans."""
+  from robosystems.config import env
+
   _ensure_loaded()
 
   # Build plans dict keyed by plan string from manifests
@@ -298,7 +300,7 @@ def get_all_repository_pricing() -> dict:
     "plans": plans,
     "repositories": repositories,
     "billing_model": "No credit consumption for queries, rate-limited by subscription tier",
-    "upgrade_url": "https://roboledger.ai/upgrade",
+    "upgrade_url": f"{env.ROBOSYSTEMS_URL}/billing",
   }
 
 

--- a/robosystems/middleware/rate_limits/repository_rate_limits.py
+++ b/robosystems/middleware/rate_limits/repository_rate_limits.py
@@ -105,6 +105,8 @@ class DualLayerRateLimiter:
     Returns:
         Dict with allowed status and details
     """
+    from robosystems.config import env
+
     # Only shared repositories (including subgraphs like sec_historical) are
     # gated here; other graphs rely on the upstream burst dependency alone.
     if not is_shared_repository_or_subgraph(graph_id):
@@ -128,7 +130,7 @@ class DualLayerRateLimiter:
         "allowed": False,
         "reason": "no_access",
         "message": f"Access to {graph_id} repository requires a paid subscription",
-        "upgrade_url": "/upgrade",
+        "upgrade_url": f"{env.ROBOSYSTEMS_URL}/billing",
       }
 
     repo_check = await self._check_repository_limit(

--- a/robosystems/routers/graphs/mcp/execute.py
+++ b/robosystems/routers/graphs/mcp/execute.py
@@ -368,7 +368,7 @@ async def call_mcp_tool(
       if not repo_access:
         raise HTTPException(
           status_code=http_status.HTTP_403_FORBIDDEN,
-          detail=f"Access to {graph_id.upper()} repository requires a subscription. Visit https://roboledger.ai/pricing",
+          detail=f"Access to {graph_id.upper()} repository requires a subscription. Visit {env.ROBOSYSTEMS_URL}/billing",
         )
 
       # Get Redis client for rate limiting with proper ElastiCache support
@@ -394,7 +394,7 @@ async def call_mcp_tool(
           if reason == "no_access":
             raise HTTPException(
               status_code=http_status.HTTP_403_FORBIDDEN,
-              detail=f"{message}. Subscribe at https://roboledger.ai/pricing",
+              detail=f"{message}. Subscribe at {env.ROBOSYSTEMS_URL}/billing",
             )
           elif reason == "endpoint_not_allowed":
             raise HTTPException(
@@ -406,7 +406,7 @@ async def call_mcp_tool(
             raise HTTPException(
               status_code=http_status.HTTP_429_TOO_MANY_REQUESTS,
               detail=f"{message}. Limit: {detail.get('limit', 0)} per {detail.get('window', 'period')}. "
-              f"Upgrade for higher limits at https://roboledger.ai/pricing",
+              f"Upgrade for higher limits at {env.ROBOSYSTEMS_URL}/billing",
               headers={
                 "Retry-After": str(detail.get("retry_after", 60)),
                 "X-RateLimit-Repository": graph_id,

--- a/robosystems/routers/graphs/query/execute.py
+++ b/robosystems/routers/graphs/query/execute.py
@@ -814,7 +814,7 @@ async def _check_shared_repository_limits(
     raise HTTPException(
       status_code=http_status.HTTP_403_FORBIDDEN,
       detail=f"You don't have access to the '{graph_id}' repository. "
-      "Subscribe at https://roboledger.ai/upgrade",
+      f"Subscribe at {env.ROBOSYSTEMS_URL}/billing",
     )
 
   # Rate limiting is optional - skip if disabled (dev environments)
@@ -853,7 +853,7 @@ async def _check_shared_repository_limits(
       if reason == "no_access":
         raise HTTPException(
           status_code=http_status.HTTP_403_FORBIDDEN,
-          detail=f"{message}. Subscribe at https://roboledger.ai/upgrade",
+          detail=f"{message}. Subscribe at {env.ROBOSYSTEMS_URL}/billing",
         )
       elif reason == "endpoint_not_allowed":
         raise HTTPException(status_code=http_status.HTTP_403_FORBIDDEN, detail=message)
@@ -862,7 +862,7 @@ async def _check_shared_repository_limits(
         raise HTTPException(
           status_code=http_status.HTTP_429_TOO_MANY_REQUESTS,
           detail=f"{message}. Limit: {detail.get('limit', 0)} per {detail.get('window', 'period')}. "
-          f"Upgrade for higher limits at https://roboledger.ai/upgrade",
+          f"Upgrade for higher limits at {env.ROBOSYSTEMS_URL}/billing",
         )
       else:
         raise HTTPException(

--- a/robosystems/routers/graphs/search.py
+++ b/robosystems/routers/graphs/search.py
@@ -78,7 +78,7 @@ async def _check_search_rate_limit(
     raise HTTPException(
       status_code=http_status.HTTP_403_FORBIDDEN,
       detail=f"Access to {graph_id.upper()} repository requires a subscription. "
-      "Visit https://roboledger.ai/pricing",
+      f"Visit {env.ROBOSYSTEMS_URL}/billing",
     )
 
   redis_client = create_async_redis_client(ValkeyDatabase.RATE_LIMITS)


### PR DESCRIPTION
## Summary

Shared-repository rate-limit and access-denied messages linked users to `https://roboledger.ai/upgrade` — a nonexistent path on a domain that has no billing surface. The MCP and search paths pointed at `https://roboledger.ai/pricing`, an inconsistent second wrong URL for the same situation. Billing lives only on **robosystems.ai**, so this routes all of these messages to `{env.ROBOSYSTEMS_URL}/billing`, matching how the existing Stripe return/cancel URLs are already built (`routers/billing/customer.py`, `operations/providers/payment_provider.py`).

## Changes

- **`routers/graphs/query/execute.py`** — direct-query shared-repo path: 403 no-access, 403 limiter `no_access`, and the 429 `repository_limit` message now use `{env.ROBOSYSTEMS_URL}/billing`.
- **`routers/graphs/mcp/execute.py`** — MCP tool-call path: same three branches, previously pointing at `/pricing`.
- **`routers/graphs/search.py`** — search 403 no-access message, previously `/pricing`.
- **`config/shared_repositories.py`** — `upgrade_url` in the `get_all_repository_pricing()` metadata payload; added a function-local `env` import.
- **`middleware/rate_limits/repository_rate_limits.py`** — `upgrade_url` in the limiter's `no_access` result dict (was a bare relative `"/upgrade"`); added a method-local `env` import.

All strings now derive from `env.ROBOSYSTEMS_URL` instead of a hardcoded domain, removing both the wrong-domain/wrong-path bug and the `/upgrade`-vs-`/pricing` inconsistency.

## Testing

- `uv run ruff check` on the five changed files — **passed**.
- Pre-commit hook (lint + format + typecheck) ran on commit — **passed** (0 errors, 0 warnings, all files formatted).
- Full `just test-all` unit suite — **not run** in this session.

## Notes

- This is a copy-only, user-facing-string change; no endpoint, schema, or behavior changes.
- The `upgrade_url` dict fields in `shared_repositories.py` and `repository_rate_limits.py` are not currently consumed by any reader — corrected for consistency so they're right if wired up later.
- Backend only. If any frontend app or SDK hardcodes `roboledger.ai/upgrade` in its own error handling, that's a separate change in those repos.
