### PR TITLE
feat(sec): report-scoped XBRL labels + drop unused *_context edge props

### DIFF
--- a/robosystems/adapters/sec/processors/xbrl_graph.py
+++ b/robosystems/adapters/sec/processors/xbrl_graph.py
@@ -818,7 +818,6 @@ class XBRLGraphProcessor:
       entity_report_rel = {
         "from": self.entity_data["identifier"],
         "to": report_data["identifier"],
-        "report_context": f"Filing: {report_data.get('form', 'Unknown')}",
       }
       if self.schema_adapter:
         new_entity_report_df = self.schema_adapter.process_dataframe_for_schema(
@@ -1082,7 +1081,6 @@ class XBRLGraphProcessor:
       report_fact_rel = {
         "from": self.report_data["identifier"],
         "to": identifier,
-        "fact_context": f"Fact from {fact_data.get('type', 'unknown')} fact",
       }
       new_report_fact_df = pd.DataFrame([report_fact_rel])
       self.report_facts_df = self.safe_concat(self.report_facts_df, new_report_fact_df)
@@ -1196,7 +1194,6 @@ class XBRLGraphProcessor:
       fact_unit_rel = {
         "from": fact_data["identifier"],
         "to": unit_identifier,
-        "unit_context": f"Unit: {unit_data.get('measure', 'unknown')}",
       }
       new_fact_unit_df = pd.DataFrame([fact_unit_rel])
       self.fact_units_df = self.safe_concat(self.fact_units_df, new_fact_unit_df)
@@ -1470,7 +1467,6 @@ class XBRLGraphProcessor:
     fact_entity_rel = {
       "from": fact_data["identifier"],
       "to": entity_identifier,
-      "entity_context": f"Entity: {entity_id}",
     }
     new_fact_entity_df = pd.DataFrame([fact_entity_rel])
     self.fact_entities_df = self.safe_concat(self.fact_entities_df, new_fact_entity_df)
@@ -1735,7 +1731,6 @@ class XBRLGraphProcessor:
       fact_period_rel = {
         "from": fact_data["identifier"],
         "to": period_identifier,
-        "period_context": f"Period: {period_uri.split('#')[-1] if '#' in period_uri else 'unknown'}",
       }
       new_fact_period_df = pd.DataFrame([fact_period_rel])
       self.fact_periods_df = self.safe_concat(self.fact_periods_df, new_fact_period_df)
@@ -1769,7 +1764,6 @@ class XBRLGraphProcessor:
       report_taxonomy_rel = {
         "from": self.report_data["identifier"],
         "to": taxonomy_identifier,
-        "taxonomy_context": f"Uses taxonomy: {self.taxonomy_uri.split('/')[-1] if '/' in self.taxonomy_uri else 'unknown'}",
       }
       new_report_taxonomy_df = pd.DataFrame([report_taxonomy_rel])
       if (
@@ -1853,7 +1847,6 @@ class XBRLGraphProcessor:
           structure_taxonomy_rel = {
             "from": structure_id,
             "to": self.taxonomy_data["identifier"],
-            "taxonomy_context": f"Taxonomy: {self.taxonomy_data.get('uri', 'unknown')}",
           }
           new_structure_taxonomy_df = pd.DataFrame([structure_taxonomy_rel])
           self.structure_taxonomies_df = self.safe_concat(
@@ -1946,7 +1939,6 @@ class XBRLGraphProcessor:
         structure_assoc_rel = {
           "from": structure_data["identifier"],
           "to": association_id,
-          "association_context": f"Association: {association_data.get('type', 'unknown')}",
         }
         new_structure_assoc_df = pd.DataFrame([structure_assoc_rel])
         self.structure_associations_df = self.safe_concat(
@@ -2121,19 +2113,23 @@ class XBRLGraphProcessor:
       element_label_rel = {
         "from": element_data["identifier"],
         "to": label_identifier,
-        "label_context": f"Label: {label_data.get('type', 'unknown')}",
       }
       new_element_label_df = pd.DataFrame([element_label_rel])
       self.element_labels_df = self.safe_concat(
         self.element_labels_df, new_element_label_df
       )
 
-      # Create taxonomy-label relationship
+      # Create taxonomy-label relationship. On the SEC shared repo the taxonomy
+      # is the filer's per-report extension taxonomy, so this edge is
+      # report-scoped. Carry element_uri so "this report's label for element X"
+      # is an exact lookup — the shared, content-addressed Label pool alone can't
+      # distinguish which element a label belongs to. URI (not qname) keeps the
+      # join exact for filer-extension elements. See sec-label-scoping spec.
       if hasattr(self, "taxonomy_data"):
         taxonomy_label_rel = {
           "from": self.taxonomy_data["identifier"],
           "to": label_identifier,
-          "label_context": f"Taxonomy label: {label_data.get('type', 'unknown')}",
+          "element_uri": element_data.get("uri"),
         }
         new_taxonomy_label_df = pd.DataFrame([taxonomy_label_rel])
         self.taxonomy_labels_df = self.safe_concat(
@@ -2168,7 +2164,6 @@ class XBRLGraphProcessor:
         element_ref_rel = {
           "from": element_data["identifier"],
           "to": reference_identifier,
-          "reference_context": f"Reference: {reference_data.get('type', 'unknown')}",
         }
         new_element_ref_df = pd.DataFrame([element_ref_rel])
         self.element_references_df = self.safe_concat(
@@ -2180,7 +2175,6 @@ class XBRLGraphProcessor:
           taxonomy_ref_rel = {
             "from": self.taxonomy_data["identifier"],
             "to": reference_identifier,
-            "reference_context": f"Taxonomy reference: {reference_data.get('type', 'unknown')}",
           }
           new_taxonomy_ref_df = pd.DataFrame([taxonomy_ref_rel])
           self.taxonomy_references_df = self.safe_concat(

--- a/robosystems/operations/extensions/materialize.py
+++ b/robosystems/operations/extensions/materialize.py
@@ -687,8 +687,7 @@ def _staging_sql(graph_id: str, entity_id: str, connstr: str) -> dict[str, str]:
     CREATE OR REPLACE TABLE ENTITY_HAS_TRANSACTION AS
     SELECT
       '{entity_id}'                   AS src,
-      id                              AS dst,
-      NULL::VARCHAR                   AS transaction_context
+      id                              AS dst
     FROM postgres_scan('{c}', '{s}', 'transactions')
   """
 
@@ -696,8 +695,7 @@ def _staging_sql(graph_id: str, entity_id: str, connstr: str) -> dict[str, str]:
     CREATE OR REPLACE TABLE TRANSACTION_HAS_ENTRY AS
     SELECT
       transaction_id                  AS src,
-      id                              AS dst,
-      NULL::VARCHAR                   AS entry_context
+      id                              AS dst
     FROM postgres_scan('{c}', '{s}', 'entries')
     WHERE transaction_id IS NOT NULL
   """
@@ -706,8 +704,7 @@ def _staging_sql(graph_id: str, entity_id: str, connstr: str) -> dict[str, str]:
     CREATE OR REPLACE TABLE ENTRY_HAS_LINE_ITEM AS
     SELECT
       entry_id                        AS src,
-      id                              AS dst,
-      NULL::VARCHAR                   AS line_item_context
+      id                              AS dst
     FROM postgres_scan('{c}', '{s}', 'line_items')
   """
 
@@ -715,8 +712,7 @@ def _staging_sql(graph_id: str, entity_id: str, connstr: str) -> dict[str, str]:
     CREATE OR REPLACE TABLE LINE_ITEM_RELATES_TO_ELEMENT AS
     SELECT
       id                              AS src,
-      element_id                      AS dst,
-      NULL::VARCHAR                   AS mapping_context
+      element_id                      AS dst
     FROM postgres_scan('{c}', '{s}', 'line_items')
   """
 
@@ -725,8 +721,7 @@ def _staging_sql(graph_id: str, entity_id: str, connstr: str) -> dict[str, str]:
     -- CoA structure → CoA associations
     SELECT
       '{graph_id}_coa'                AS src,
-      child.id || '_assoc'            AS dst,
-      NULL::VARCHAR                   AS association_context
+      child.id || '_assoc'            AS dst
     FROM postgres_scan('{c}', '{s}', 'elements') child
     WHERE child.parent_id IS NOT NULL
       AND child.is_active = true
@@ -734,8 +729,7 @@ def _staging_sql(graph_id: str, entity_id: str, connstr: str) -> dict[str, str]:
     -- Seed structures → seed associations
     SELECT
       structure_id                    AS src,
-      id                              AS dst,
-      NULL::VARCHAR                   AS association_context
+      id                              AS dst
     FROM postgres_scan('{c}', '{s}', 'associations')
     -- See _MATERIALIZED_ASSOCIATION_TYPES for the curated list.
     WHERE association_type IN {_MATERIALIZED_ASSOCIATION_TYPES_SQL}
@@ -1047,8 +1041,7 @@ def _staging_sql(graph_id: str, entity_id: str, connstr: str) -> dict[str, str]:
     CREATE OR REPLACE TABLE STRUCTURE_HAS_TAXONOMY AS
     SELECT
       id                              AS src,
-      taxonomy_id                     AS dst,
-      NULL::VARCHAR                   AS taxonomy_context
+      taxonomy_id                     AS dst
     FROM postgres_scan('{c}', '{s}', 'structures')
     WHERE taxonomy_id IS NOT NULL
       AND block_type NOT IN ('chart_of_accounts', 'coa_mapping')
@@ -1060,8 +1053,7 @@ def _staging_sql(graph_id: str, entity_id: str, connstr: str) -> dict[str, str]:
     -- Native reports (no source_graph_id) belong to the graph's own entity
     SELECT
       '{entity_id}'                   AS src,
-      rd.id                           AS dst,
-      NULL::VARCHAR                   AS filing_context
+      rd.id                           AS dst
     FROM postgres_scan('{c}', '{s}', 'reports') rd
     WHERE rd.generation_status = 'published'
       AND rd.source_graph_id IS NULL
@@ -1069,8 +1061,7 @@ def _staging_sql(graph_id: str, entity_id: str, connstr: str) -> dict[str, str]:
     -- Shared reports belong to the linked entity matching source_graph_id
     SELECT
       e.id                            AS src,
-      rd.id                           AS dst,
-      NULL::VARCHAR                   AS filing_context
+      rd.id                           AS dst
     FROM postgres_scan('{c}', '{s}', 'reports') rd
     JOIN postgres_scan('{c}', '{s}', 'entities') e
       ON e.metadata->>'source_graph_id' = rd.source_graph_id
@@ -1082,8 +1073,7 @@ def _staging_sql(graph_id: str, entity_id: str, connstr: str) -> dict[str, str]:
     CREATE OR REPLACE TABLE REPORT_USES_TAXONOMY AS
     SELECT
       id                              AS src,
-      taxonomy_id                     AS dst,
-      NULL::VARCHAR                   AS taxonomy_context
+      taxonomy_id                     AS dst
     FROM postgres_scan('{c}', '{s}', 'reports')
     WHERE generation_status = 'published'
   """
@@ -1092,8 +1082,7 @@ def _staging_sql(graph_id: str, entity_id: str, connstr: str) -> dict[str, str]:
     CREATE OR REPLACE TABLE REPORT_HAS_FACT AS
     SELECT
       fs.report_id                    AS src,
-      f.id                            AS dst,
-      NULL::VARCHAR                   AS fact_context
+      f.id                            AS dst
     FROM postgres_scan('{c}', '{s}', 'facts') f
     JOIN postgres_scan('{c}', '{s}', 'fact_sets') fs
       ON fs.id = f.fact_set_id
@@ -1115,8 +1104,7 @@ def _staging_sql(graph_id: str, entity_id: str, connstr: str) -> dict[str, str]:
       md5(COALESCE(CAST(period_start AS VARCHAR), 'null')
           || '_' || CAST(period_end AS VARCHAR)
           || '_' || period_type)
-                                      AS dst,
-      NULL::VARCHAR                   AS period_context
+                                      AS dst
     FROM postgres_scan('{c}', '{s}', 'facts')
   """
 
@@ -1124,8 +1112,7 @@ def _staging_sql(graph_id: str, entity_id: str, connstr: str) -> dict[str, str]:
     CREATE OR REPLACE TABLE FACT_HAS_UNIT AS
     SELECT
       id                              AS src,
-      'unit_usd'                      AS dst,
-      NULL::VARCHAR                   AS unit_context
+      'unit_usd'                      AS dst
     FROM postgres_scan('{c}', '{s}', 'facts')
   """
 
@@ -1134,8 +1121,7 @@ def _staging_sql(graph_id: str, entity_id: str, connstr: str) -> dict[str, str]:
     -- Native facts: entity_id references a local entity directly
     SELECT
       rf.id                           AS src,
-      rf.entity_id                    AS dst,
-      NULL::VARCHAR                   AS entity_context
+      rf.entity_id                    AS dst
     FROM postgres_scan('{c}', '{s}', 'facts') rf
     JOIN postgres_scan('{c}', '{s}', 'fact_sets') fs
       ON fs.id = rf.fact_set_id
@@ -1146,8 +1132,7 @@ def _staging_sql(graph_id: str, entity_id: str, connstr: str) -> dict[str, str]:
     -- Shared facts: remap entity_id to the linked entity on this graph
     SELECT
       rf.id                           AS src,
-      e.id                            AS dst,
-      NULL::VARCHAR                   AS entity_context
+      e.id                            AS dst
     FROM postgres_scan('{c}', '{s}', 'facts') rf
     JOIN postgres_scan('{c}', '{s}', 'fact_sets') fs
       ON fs.id = rf.fact_set_id

--- a/robosystems/schemas/README.md
+++ b/robosystems/schemas/README.md
@@ -333,8 +333,8 @@ validator.validate_node("Entity", {
 
 # Validate relationships
 validator.validate_relationship(
-    "Entity", "Report", "ENTITY_HAS_REPORT",
-    {"filing_context": "10-K"}
+    "Entity", "Taxonomy", "ENTITY_HAS_TAXONOMY",
+    {"basis": "reporting", "adoption_context": "required_by_regulation"}
 )
 ```
 

--- a/robosystems/schemas/base.py
+++ b/robosystems/schemas/base.py
@@ -381,18 +381,14 @@ BASE_RELATIONSHIPS = [
     from_node="Element",
     to_node="Label",
     description="Element has human-readable labels (global taxonomy concepts)",
-    properties=[
-      Property(name="label_context", type="STRING"),
-    ],
+    properties=[],
   ),
   Relationship(
     name="ELEMENT_HAS_REFERENCE",
     from_node="Element",
     to_node="Reference",
     description="Element has authoritative references (global taxonomy concepts)",
-    properties=[
-      Property(name="reference_context", type="STRING"),
-    ],
+    properties=[],
   ),
   # Global Taxonomy Structure Relationships
   Relationship(
@@ -400,17 +396,26 @@ BASE_RELATIONSHIPS = [
     from_node="Element",
     to_node="Taxonomy",
     description="Element belongs to a global taxonomy (us-gaap, ifrs-full, etc.)",
-    properties=[
-      Property(name="taxonomy_context", type="STRING"),
-    ],
+    properties=[],
   ),
   Relationship(
     name="TAXONOMY_HAS_LABEL",
     from_node="Taxonomy",
     to_node="Label",
-    description="Global taxonomy defines labels",
+    description="Taxonomy defines a label FOR a specific element. On the SEC "
+    "shared repository the from-Taxonomy is the filer's per-report extension "
+    "taxonomy, so this edge is report-scoped: it says 'this report labels "
+    "element_uri as <Label> under <Label.type> role'. The `element_uri` property "
+    "re-attaches the element the label is for — without it, the report-scoped "
+    "lookup (taxonomy ∩ element via the content-addressed shared Label pool) "
+    "bleeds cross-concept label texts. URI (not qname) is the join key so it "
+    "stays exact for filer-extension elements whose prefix isn't reconstructible "
+    "downstream. See sec-label-scoping spec.",
     properties=[
-      Property(name="label_context", type="STRING"),
+      Property(
+        name="element_uri", type="STRING"
+      ),  # URI (namespace#localName) of the element this label is for —
+      # the report-scoped join key; matches Element.uri and Dimension.{axis,member}_uri
     ],
   ),
   Relationship(
@@ -418,9 +423,7 @@ BASE_RELATIONSHIPS = [
     from_node="Taxonomy",
     to_node="Reference",
     description="Global taxonomy has authoritative references",
-    properties=[
-      Property(name="reference_context", type="STRING"),
-    ],
+    properties=[],
   ),
   # Dimension → Element relationships (axis and member definitions)
   Relationship(
@@ -444,18 +447,14 @@ BASE_RELATIONSHIPS = [
     from_node="Structure",
     to_node="Taxonomy",
     description="Structure belongs to taxonomy",
-    properties=[
-      Property(name="taxonomy_context", type="STRING"),
-    ],
+    properties=[],
   ),
   Relationship(
     name="STRUCTURE_HAS_ASSOCIATION",
     from_node="Structure",
     to_node="Association",
     description="Structure contains element associations",
-    properties=[
-      Property(name="association_context", type="STRING"),
-    ],
+    properties=[],
   ),
   Relationship(
     name="ASSOCIATION_HAS_FROM_ELEMENT",

--- a/robosystems/schemas/extensions/roboledger.py
+++ b/robosystems/schemas/extensions/roboledger.py
@@ -117,18 +117,14 @@ REPORTING_RELATIONSHIPS = [
     from_node="Entity",
     to_node="Report",
     description="Entity has filed reports",
-    properties=[
-      Property(name="filing_context", type="STRING"),
-    ],
+    properties=[],
   ),
   Relationship(
     name="REPORT_HAS_FACT",
     from_node="Report",
     to_node="Fact",
     description="Report contains facts",
-    properties=[
-      Property(name="fact_context", type="STRING"),
-    ],
+    properties=[],
   ),
   Relationship(
     name="FACT_HAS_ELEMENT",
@@ -142,27 +138,21 @@ REPORTING_RELATIONSHIPS = [
     from_node="Fact",
     to_node="Entity",
     description="Fact belongs to reporting entity",
-    properties=[
-      Property(name="entity_context", type="STRING"),
-    ],
+    properties=[],
   ),
   Relationship(
     name="FACT_HAS_PERIOD",
     from_node="Fact",
     to_node="Period",
     description="Fact applies to specific period",
-    properties=[
-      Property(name="period_context", type="STRING"),
-    ],
+    properties=[],
   ),
   Relationship(
     name="FACT_HAS_UNIT",
     from_node="Fact",
     to_node="Unit",
     description="Fact has unit of measurement",
-    properties=[
-      Property(name="unit_context", type="STRING"),
-    ],
+    properties=[],
   ),
   # Fact → Dimension relationship (XBRL dimensional qualifiers)
   Relationship(
@@ -202,9 +192,7 @@ REPORTING_RELATIONSHIPS = [
     from_node="Report",
     to_node="Taxonomy",
     description="Report uses XBRL taxonomy",
-    properties=[
-      Property(name="taxonomy_context", type="STRING"),
-    ],
+    properties=[],
   ),
   # NOTE: STRUCTURE_HAS_ASSOCIATION, ASSOCIATION_HAS_FROM_ELEMENT,
   # ASSOCIATION_HAS_TO_ELEMENT, ASSOCIATION_HAS_CLASSIFICATION, and
@@ -305,9 +293,7 @@ TRANSACTION_RELATIONSHIPS = [
     from_node="Entity",
     to_node="Transaction",
     description="Entity has financial transactions (business events)",
-    properties=[
-      Property(name="transaction_context", type="STRING"),
-    ],
+    properties=[],
   ),
   # Transaction → Entry (one-to-many: a transaction can produce multiple entries)
   Relationship(
@@ -315,9 +301,7 @@ TRANSACTION_RELATIONSHIPS = [
     from_node="Transaction",
     to_node="Entry",
     description="Transaction produces ledger entries (posting, reversal, adjustment)",
-    properties=[
-      Property(name="entry_context", type="STRING"),
-    ],
+    properties=[],
   ),
   # Entry → LineItem (one-to-many: each entry has balanced debit/credit lines)
   Relationship(
@@ -325,9 +309,7 @@ TRANSACTION_RELATIONSHIPS = [
     from_node="Entry",
     to_node="LineItem",
     description="Ledger entry contains line items (debits and credits that must balance)",
-    properties=[
-      Property(name="line_item_context", type="STRING"),
-    ],
+    properties=[],
   ),
   # Entry → Dimension (fund, trust account, product channel, etc.)
   Relationship(
@@ -350,9 +332,7 @@ TRANSACTION_RELATIONSHIPS = [
     from_node="LineItem",
     to_node="Element",
     description="Line item maps to XBRL element for reporting",
-    properties=[
-      Property(name="mapping_context", type="STRING"),
-    ],
+    properties=[],
   ),
   # LineItem → Dimension relationship (department, class, location, project, etc.)
   Relationship(

--- a/tests/adapters/sec/processors/test_xbrl_graph.py
+++ b/tests/adapters/sec/processors/test_xbrl_graph.py
@@ -697,4 +697,96 @@ class TestInitProcessedElements:
     """processed_elements starts as an empty set."""
     processor = _create_processor(temp_output_dir, basic_schema_config)
     assert processor.processed_elements == set()
+
+
+@pytest.mark.unit
+class TestTaxonomyLabelElementUri:
+  """make_element_labels tags each TAXONOMY_HAS_LABEL edge with element_uri.
+
+  On the SEC shared repo the taxonomy is the filer's per-report extension
+  taxonomy, so the edge is report-scoped; element_uri re-attaches the element a
+  label belongs to, which is what makes "this report's label for element X" an
+  exact lookup against the content-addressed shared Label pool. See
+  sec-label-scoping spec (Option A).
+  """
+
+  @staticmethod
+  def _label_rel(role, text, lang="en-US"):
+    rel = MagicMock()
+    rel.toModelObject.role = role
+    rel.toModelObject.text = text
+    rel.toModelObject.xmlLang = lang
+    return rel
+
+  def _run(self, temp_output_dir, basic_schema_config, rels):
+    processor = _create_processor(temp_output_dir, basic_schema_config)
+    processor.labels_df = pd.DataFrame()
+    processor.element_labels_df = pd.DataFrame()
+    processor.taxonomy_labels_df = pd.DataFrame()
+    processor.taxonomy_data = {
+      "identifier": "tax-1",
+      "uri": "http://filer.example.com/20240101",
+    }
+
+    mock_cntlr = MagicMock()
+    mock_cntlr.relationshipSet.return_value.fromModelObject.return_value = rels
+    processor.arelle_cntlr = mock_cntlr
+
+    element_data = {
+      "identifier": "el-ppe",
+      "uri": "http://fasb.org/us-gaap/2024#PropertyPlantAndEquipmentNet",
+      "qname": "us-gaap:PropertyPlantAndEquipmentNet",
+    }
+    processor.make_element_labels(element_data, MagicMock())
+    return processor
+
+  def test_taxonomy_label_carries_element_uri(
+    self, temp_output_dir, basic_schema_config
+  ):
+    rels = [
+      self._label_rel(
+        "http://www.xbrl.org/2003/role/label", "Property and equipment, net"
+      ),
+      self._label_rel(
+        "http://www.xbrl.org/2003/role/totalLabel", "Total property and equipment"
+      ),
+    ]
+    processor = self._run(temp_output_dir, basic_schema_config, rels)
+
+    tax_df = processor.taxonomy_labels_df
+    assert len(tax_df) == 2
+    # every taxonomy→label edge is attributed to the element it labels
+    assert set(tax_df["element_uri"]) == {
+      "http://fasb.org/us-gaap/2024#PropertyPlantAndEquipmentNet"
+    }
+    assert set(tax_df["from"]) == {"tax-1"}
+    # the (report-scoped) taxonomy label + role pair is recoverable per element
+    labels_df = processor.labels_df
+    by_id = dict(zip(labels_df["identifier"], labels_df["value"], strict=True))
+    resolved = {by_id[to] for to in tax_df["to"]}
+    assert resolved == {"Property and equipment, net", "Total property and equipment"}
+
+  def test_no_taxonomy_still_writes_element_labels(
+    self, temp_output_dir, basic_schema_config
+  ):
+    """Without a per-report taxonomy, element→label edges still form; the
+    taxonomy edge is simply skipped (no element_qname to anchor)."""
+    processor = _create_processor(temp_output_dir, basic_schema_config)
+    processor.labels_df = pd.DataFrame()
+    processor.element_labels_df = pd.DataFrame()
+    processor.taxonomy_labels_df = pd.DataFrame()
+    # deliberately no processor.taxonomy_data
+
+    mock_cntlr = MagicMock()
+    mock_cntlr.relationshipSet.return_value.fromModelObject.return_value = [
+      self._label_rel("http://www.xbrl.org/2003/role/label", "Assets")
+    ]
+    processor.arelle_cntlr = mock_cntlr
+
+    processor.make_element_labels(
+      {"identifier": "el-a", "uri": "u", "qname": "us-gaap:Assets"}, MagicMock()
+    )
+
+    assert len(processor.element_labels_df) == 1
+    assert processor.taxonomy_labels_df.empty
     assert isinstance(processor.processed_elements, set)


### PR DESCRIPTION
## Summary

Makes `TAXONOMY_HAS_LABEL` **report-scoped** on the SEC shared repository and drops a set of unused `*_context` descriptor edge properties across the base and roboledger schemas.

On the SEC shared repo the `from`-Taxonomy is the filer's per-report extension taxonomy, so a taxonomy→label edge is inherently report-scoped: it says "*this report* labels `element_uri` as `<Label>`". Because Labels are pooled in a content-addressed store shared across all filings, the report-scoped lookup (taxonomy ∩ element) had no way to re-attach the element a label belongs to, so it bled cross-concept label text. Carrying `element_uri` on the edge makes "this report's label for element X" an exact lookup. URI (not qname) is the join key so it stays exact for filer-extension elements whose prefix isn't reconstructible downstream.

The `*_context` properties being removed were only ever populated with static descriptor strings (e.g. `f"Fact from {type} fact"`) — they carried no analytical value and added width to hundreds of millions of edges.

> **Requires a full SEC shared-repo reprocess to take effect** (edge/node shape change). No reprocess is triggered by merge alone.

## Changes

**Schemas**
- `schemas/base.py` — replace `label_context` with `element_uri` (the report-scoped join key) on `TAXONOMY_HAS_LABEL` and expand its description; drop `*_context` properties from `ELEMENT_HAS_LABEL`, `ELEMENT_HAS_REFERENCE`, `ELEMENT_HAS_TAXONOMY`, `TAXONOMY_HAS_REFERENCE`, `STRUCTURE_HAS_TAXONOMY`, `STRUCTURE_HAS_ASSOCIATION`.
- `schemas/extensions/roboledger.py` — drop `*_context` props from `ENTITY_HAS_REPORT`, `REPORT_HAS_FACT`, `FACT_HAS_ENTITY`, `FACT_HAS_PERIOD`, `FACT_HAS_UNIT`, `REPORT_USES_TAXONOMY`, `ENTITY_HAS_TRANSACTION`, `TRANSACTION_HAS_ENTRY`, `ENTRY_HAS_LINE_ITEM`, `LINE_ITEM_RELATES_TO_ELEMENT`.
- `schemas/README.md` — update the `validate_relationship` example to a still-valid edge.

**SEC ingest**
- `adapters/sec/processors/xbrl_graph.py` — stop emitting the `*_context` descriptor strings on the entity→report, report→fact, fact→unit, fact→entity, fact→period, report→taxonomy, structure→taxonomy, structure→association, element→label, element→reference, and taxonomy→reference edges; tag each `TAXONOMY_HAS_LABEL` edge with `element_uri`.

**Extensions materialize (OLTP→OLAP)**
- `operations/extensions/materialize.py` — drop the matching `NULL::VARCHAR AS *_context` columns from the staging SQL so the extensions OLAP rebuild stays aligned with the trimmed schema.

**Tests**
- `tests/adapters/sec/processors/test_xbrl_graph.py` — add `TestTaxonomyLabelElementUri`: verifies every taxonomy→label edge is attributed to the element it labels via `element_uri`, and that element→label edges still form (taxonomy edge skipped) when no per-report taxonomy is present.

## Testing

- `uv run pytest tests/adapters/sec/processors/test_xbrl_graph.py` — **37 passed**.
- Full `just test-all` not run in this session (needs local stack).

## Notes / Follow-ups

- Follow-up PR (planned): reduce the SEC embedding footprint (drop the stored `FLOAT[384]` vectors + LanceDB semantic-element-search path, keep canonical-concept mapping) and add a uniform SEC fact-provenance stamp. Both are also reprocess-forcing — the intent is to land them before a **single** coordinated SEC reprocess rather than reprocessing twice.
