### PR TITLE
fix(sec): make externalized fact URLs work under LocalStack

### DIFF
--- a/bin/setup/localstack-init.sh
+++ b/bin/setup/localstack-init.sh
@@ -30,9 +30,12 @@ awslocal s3api create-bucket \
   --bucket robosystems-public-data \
   --region us-east-1 || echo "Bucket robosystems-public-data already exists"
 
+# NOTE: the S3 API key is MaxAgeSeconds (not MaxAge — that silently fails
+# param validation and leaves the bucket with no CORS, blocking browser
+# fetches of externalized fact HTML from the frontends).
 awslocal s3api put-bucket-cors \
   --bucket robosystems-public-data \
-  --cors-configuration '{"CORSRules":[{"AllowedOrigins":["*"],"AllowedMethods":["GET","HEAD"],"AllowedHeaders":["*"],"MaxAge":3600}]}' || echo "CORS already configured for robosystems-public-data"
+  --cors-configuration '{"CORSRules":[{"AllowedOrigins":["*"],"AllowedMethods":["GET","HEAD"],"AllowedHeaders":["*"],"ExposeHeaders":["ETag","Content-Length","Content-Type"],"MaxAgeSeconds":3600}]}' || echo "WARNING: failed to configure CORS for robosystems-public-data"
 
 # Note: deployment and logs buckets are infrastructure-only (prod/staging)
 # They're not needed for local development

--- a/robosystems/adapters/sec/pipeline/text_index.py
+++ b/robosystems/adapters/sec/pipeline/text_index.py
@@ -31,6 +31,7 @@ from robosystems.config import env
 from robosystems.config.storage.shared import (
   DataSourceType,
   get_processed_key,
+  get_public_data_url,
   get_raw_key,
 )
 from robosystems.logger import logger
@@ -532,12 +533,9 @@ def sec_narratives_indexed(
                 Body=section.content.encode("utf-8"),
                 ContentType="text/plain; charset=utf-8",
               )
-              if cdn_url:
-                content_url_value = f"{cdn_url}/{narrative_key}"
-              else:
-                content_url_value = (
-                  f"https://{public_bucket}.s3.amazonaws.com/{narrative_key}"
-                )
+              content_url_value = get_public_data_url(
+                public_bucket, narrative_key, cdn_url
+              )
             except Exception as e:
               context.log.debug(f"Failed to externalize {narrative_key}: {e}")
 

--- a/robosystems/adapters/sec/processors/textblock.py
+++ b/robosystems/adapters/sec/processors/textblock.py
@@ -2,6 +2,7 @@ import hashlib
 from datetime import datetime
 from typing import Any
 
+from robosystems.config.storage.shared import get_public_data_url
 from robosystems.config.tuning import TuningConfig
 from robosystems.logger import logger
 
@@ -82,10 +83,7 @@ class TextBlockExternalizer:
         logger.debug(
           f"S3 object already exists for content hash {content_hash[:CONTENT_HASH_LOG_LENGTH]}: {s3_key}"
         )
-        if self.cdn_url:
-          external_url = f"{self.cdn_url}/{s3_key}"
-        else:
-          external_url = f"https://{self.bucket}.s3.amazonaws.com/{s3_key}"
+        external_url = get_public_data_url(self.bucket, s3_key, self.cdn_url)
 
         result = {
           "url": external_url,
@@ -98,10 +96,7 @@ class TextBlockExternalizer:
 
       self.upload_queue.append((value_str, self.bucket, s3_key))
 
-      if self.cdn_url:
-        external_url = f"{self.cdn_url}/{s3_key}"
-      else:
-        external_url = f"https://{self.bucket}.s3.amazonaws.com/{s3_key}"
+      external_url = get_public_data_url(self.bucket, s3_key, self.cdn_url)
 
       self.upload_map[fact_id] = {
         "url": external_url,

--- a/robosystems/config/storage/shared.py
+++ b/robosystems/config/storage/shared.py
@@ -266,6 +266,56 @@ def get_artifact_r2_key(name: str) -> str:
 
 
 # =============================================================================
+# Public Data URL Helpers
+# =============================================================================
+
+
+def get_public_data_url(bucket: str, key: str, cdn_url: str | None = None) -> str:
+  """Build a browser-reachable URL for an object in the public-data bucket.
+
+  Externalized SEC content (large XBRL text blocks, narrative sections) is
+  uploaded to the public-data bucket, and its URL is persisted on the graph
+  Fact / OpenSearch document for later retrieval by the frontend. This
+  resolves that URL so it works across environments:
+
+    1. CDN (prod/staging): ``{cdn_url}/{key}`` when a CloudFront distribution
+       is configured.
+    2. LocalStack (dev): path-style against the *browser-reachable* endpoint
+       (``AWS_S3_PRESIGN_ENDPOINT_URL`` — e.g. ``http://localhost:4566`` —
+       falling back to ``AWS_ENDPOINT_URL``). The pipeline uploads through a
+       docker-DNS hostname (``http://localstack:4566``) that isn't reachable
+       from the host browser, so the stored URL must use the localhost one.
+    3. Real AWS without a CDN: the virtual-hosted-style public S3 URL.
+
+  Args:
+      bucket: The public-data bucket name the object was uploaded to.
+      key: The object key within the bucket (leading slash optional).
+      cdn_url: Optional CDN base URL; when truthy it takes precedence over
+          both the LocalStack and raw-S3 forms.
+
+  Returns:
+      An absolute URL to the object.
+
+  Example:
+      >>> get_public_data_url("robosystems-public-data", "2025/320193/f.html")
+      'https://robosystems-public-data.s3.amazonaws.com/2025/320193/f.html'
+  """
+  from robosystems.config import env
+
+  key = key.lstrip("/")
+
+  if cdn_url:
+    return f"{cdn_url.rstrip('/')}/{key}"
+
+  endpoint = env.AWS_S3_PRESIGN_ENDPOINT_URL or env.AWS_ENDPOINT_URL
+  if endpoint:
+    # LocalStack (and other custom S3 endpoints) use path-style addressing.
+    return f"{endpoint.rstrip('/')}/{bucket}/{key}"
+
+  return f"https://{bucket}.s3.amazonaws.com/{key}"
+
+
+# =============================================================================
 # DuckDB Staging Path Helpers
 # =============================================================================
 

--- a/tests/adapters/sec/processors/test_textblock_externalizer.py
+++ b/tests/adapters/sec/processors/test_textblock_externalizer.py
@@ -271,7 +271,11 @@ class TestQueueValueForS3:
 
     assert result is not None
     assert result["content_type"] == "text/plain"
-    assert "s3.amazonaws.com" in result["url"]
+    # No CDN configured: the URL points at the browser-reachable LocalStack
+    # endpoint (pytest sets AWS_ENDPOINT_URL=http://localhost:4566), path-style,
+    # never the production virtual-hosted s3.amazonaws.com host.
+    assert "localhost:4566/test-bucket/" in result["url"]
+    assert "s3.amazonaws.com" not in result["url"]
 
   def test_queue_value_cache_hit(self, mock_s3_client, entity_data, report_data):
     externalizer = TextBlockExternalizer(

--- a/tests/config/test_storage_shared.py
+++ b/tests/config/test_storage_shared.py
@@ -1,5 +1,8 @@
 """Shared data source storage configuration tests."""
 
+from unittest.mock import patch
+
+from robosystems.config.env import EnvConfig
 from robosystems.config.storage.shared import (
   DATA_SOURCES,
   DataSourceConfig,
@@ -7,6 +10,7 @@ from robosystems.config.storage.shared import (
   get_data_source,
   get_processed_key,
   get_processed_uri,
+  get_public_data_url,
   get_raw_key,
   get_raw_uri,
   is_source_enabled,
@@ -119,3 +123,65 @@ class TestIsSourceEnabled:
 
   def test_fred_disabled(self):
     assert is_source_enabled(DataSourceType.FRED) is False
+
+
+class TestGetPublicDataUrl:
+  """Tests for get_public_data_url environment-aware resolution."""
+
+  def test_cdn_takes_precedence(self):
+    with patch.object(EnvConfig, "AWS_ENDPOINT_URL", "http://localstack:4566"):
+      result = get_public_data_url(
+        "robosystems-public-data",
+        "2025/320193/fact_abc.html",
+        cdn_url="https://cdn.example.com",
+      )
+    assert result == "https://cdn.example.com/2025/320193/fact_abc.html"
+
+  def test_localstack_prefers_presign_endpoint(self):
+    with (
+      patch.object(EnvConfig, "AWS_S3_PRESIGN_ENDPOINT_URL", "http://localhost:4566"),
+      patch.object(EnvConfig, "AWS_ENDPOINT_URL", "http://localstack:4566"),
+    ):
+      result = get_public_data_url(
+        "robosystems-public-data", "2025/320193/fact_abc.html"
+      )
+    # Path-style against the browser-reachable localhost endpoint, not the
+    # docker-DNS localstack hostname the pipeline uploads through.
+    assert (
+      result
+      == "http://localhost:4566/robosystems-public-data/2025/320193/fact_abc.html"
+    )
+
+  def test_localstack_falls_back_to_endpoint_url(self):
+    with (
+      patch.object(EnvConfig, "AWS_S3_PRESIGN_ENDPOINT_URL", ""),
+      patch.object(EnvConfig, "AWS_ENDPOINT_URL", "http://localstack:4566"),
+    ):
+      result = get_public_data_url(
+        "robosystems-public-data", "2025/320193/fact_abc.html"
+      )
+    assert (
+      result
+      == "http://localstack:4566/robosystems-public-data/2025/320193/fact_abc.html"
+    )
+
+  def test_real_aws_without_cdn(self):
+    with (
+      patch.object(EnvConfig, "AWS_S3_PRESIGN_ENDPOINT_URL", ""),
+      patch.object(EnvConfig, "AWS_ENDPOINT_URL", ""),
+    ):
+      result = get_public_data_url(
+        "robosystems-public-data", "2025/320193/fact_abc.html"
+      )
+    assert (
+      result
+      == "https://robosystems-public-data.s3.amazonaws.com/2025/320193/fact_abc.html"
+    )
+
+  def test_leading_slash_stripped(self):
+    with (
+      patch.object(EnvConfig, "AWS_S3_PRESIGN_ENDPOINT_URL", ""),
+      patch.object(EnvConfig, "AWS_ENDPOINT_URL", ""),
+    ):
+      result = get_public_data_url("bucket", "/path/to/obj.html")
+    assert result == "https://bucket.s3.amazonaws.com/path/to/obj.html"


### PR DESCRIPTION
## Summary

In dev, externalized SEC fact HTML (large XBRL text blocks offloaded to the public-data bucket) was unusable from the LocalStack frontends for two independent reasons: the persisted URL was built with a hardcoded **production** S3 host (unreachable), and — once the host was fixed — the LocalStack bucket returned **no CORS headers**, so the browser blocked the fetch. This PR makes the full externalized-fact path work end-to-end under LocalStack.

## Changes

**Browser-reachable URL construction**
- New `get_public_data_url(bucket, key, cdn_url)` in `robosystems/config/storage/shared.py` — a single source of truth for building externalized-content URLs across environments: CDN when configured → LocalStack **path-style** against the browser-reachable endpoint (`AWS_S3_PRESIGN_ENDPOINT_URL`, falling back to `AWS_ENDPOINT_URL`) → virtual-hosted public S3 otherwise. The dev pipeline uploads through a docker-DNS host (`localstack:4566`) that isn't reachable from the host browser, so the persisted URL must use the `localhost` presign endpoint.
- Replaced the two hardcoded-host construction sites with the helper: `adapters/sec/processors/textblock.py` (`TextBlockExternalizer`, both the object-exists and queue paths) and `adapters/sec/pipeline/text_index.py` (narrative-section indexing).

**LocalStack public-data CORS**
- `bin/setup/localstack-init.sh` used `"MaxAge"` in the `put-bucket-cors` config, but the S3 API key is **`MaxAgeSeconds`** — so the command failed parameter validation on *every* setup, and the trailing `|| echo "CORS already configured"` masked the failure as success. The bucket therefore had no CORS at all, blocking browser fetches of the fact HTML from the frontends. Corrected to `MaxAgeSeconds`, added `ExposeHeaders` (ETag/Content-Length/Content-Type), and replaced the misleading fallback with a real `WARNING:` so this can't silently recur.

**Tests**
- Added `TestGetPublicDataUrl` in `tests/config/test_storage_shared.py` covering CDN precedence, presign-endpoint preference, `AWS_ENDPOINT_URL` fallback, real-AWS virtual-hosted form, and leading-slash stripping (patches `EnvConfig` class attributes).
- Updated `tests/adapters/sec/processors/test_textblock_externalizer.py` — the old assertion encoded the buggy production-only behavior; it now asserts the browser-reachable LocalStack host and that the prod host is absent.

## Testing

- **Code-quality gate green via pre-commit on both commits** (ruff + format + basedpyright): `0 errors, 0 warnings, 0 notes`.
- Affected unit suites (`tests/config`, `tests/adapters/sec/processors`) run green during development. Full `just test-all` not re-run in this session.
- **Verified end-to-end in a live LocalStack dev env:**
  - All 211 externalized-fact URLs in the `sec` graph resolve to the LocalStack `localhost` endpoint (path-style), none to the prod S3 host — confirmed via MCP Cypher over the graph.
  - The public-data bucket returns `Access-Control-Allow-Origin` on both GET and preflight `OPTIONS` after the fix — confirmed via `curl`.
  - Frontend fetch/render confirmed working by the reporter.

## Notes / Follow-ups

- **Content-Type (deferred):** externalized objects are stored as `Content-Type: binary/octet-stream` because `TextBlockExternalizer.process_batch_uploads` calls `batch_upload_strings(content_type=None)`, dropping the `text/html`/`text/plain` it computes. Harmless for `fetch().text()`; a problem only if the frontend navigates/iframes the URL directly (browser downloads instead of renders). Not addressed here.
- **Prod unaffected by the CORS bug:** the prod bucket's CORS is defined natively in `cloudformation/s3.yaml` (CFN's `CorsRule` property is genuinely `MaxAge`), so it doesn't share this shell-script defect.
