### PR TITLE
fix(sec): source FactSet filed-provenance from filing metadata + populate REPORT_HAS_FACT_SET

### DIFF
--- a/robosystems/adapters/sec/processors/classify.py
+++ b/robosystems/adapters/sec/processors/classify.py
@@ -27,6 +27,25 @@ from robosystems.logger import logger
 from robosystems.models.api.fact_provenance import FiledProvenance
 from robosystems.utils.uuid import generate_uuid7
 
+
+@dataclass(frozen=True)
+class FilingMeta:
+  """Enriched filing coordinates passed into FactSet construction.
+
+  Sourced from the processor (which holds the SEC report metadata) rather than
+  read back out of the graph: the classify context deliberately carries only an
+  identifier-only Report table, so a ``MATCH (r:Report)`` lookup can never
+  populate these. Stamped onto every FactSet's ``filed`` provenance and used to
+  emit the ``REPORT_HAS_FACT_SET`` (report → its many block FactSets) edges.
+  """
+
+  report_id: str | None = None
+  accession: str | None = None
+  filing_date: str | None = None
+  form: str | None = None
+  filer_cik: str | None = None
+
+
 # ---------------------------------------------------------------------------
 # Disclosure mechanics concept map (Seattle Method taxonomy, 143 entries)
 # ---------------------------------------------------------------------------
@@ -249,12 +268,8 @@ def _generate_ddl() -> list[str]:
       identifier STRING,
       PRIMARY KEY (identifier)
     )""",
-    # Fact and Report: minimal for FactSet building
+    # Fact: minimal for FactSet building
     """CREATE NODE TABLE IF NOT EXISTS Fact (
-      identifier STRING,
-      PRIMARY KEY (identifier)
-    )""",
-    """CREATE NODE TABLE IF NOT EXISTS Report (
       identifier STRING,
       PRIMARY KEY (identifier)
     )""",
@@ -263,7 +278,6 @@ def _generate_ddl() -> list[str]:
     "CREATE REL TABLE IF NOT EXISTS ASSOCIATION_HAS_TO_ELEMENT (FROM Association TO Element)",
     "CREATE REL TABLE IF NOT EXISTS STRUCTURE_HAS_ASSOCIATION (FROM Structure TO Association, association_context STRING)",
     "CREATE REL TABLE IF NOT EXISTS FACT_HAS_ELEMENT (FROM Fact TO Element)",
-    "CREATE REL TABLE IF NOT EXISTS REPORT_HAS_FACT (FROM Report TO Fact, fact_context STRING)",
   ]
 
 
@@ -515,7 +529,9 @@ class AssociationClassifier:
     factset_fact_rels_df: pd.DataFrame
     report_factset_rels_df: pd.DataFrame
 
-  def classify(self, output_dir: Path) -> ClassifyResult:
+  def classify(
+    self, output_dir: Path, filing_meta: FilingMeta | None = None
+  ) -> ClassifyResult:
     """Run classification on a filing's parquet output.
 
     Runs two layers of classification, then builds structure-level FactSets:
@@ -525,6 +541,10 @@ class AssociationClassifier:
 
     Args:
         output_dir: Directory containing nodes/ and relationships/ parquet subdirs.
+        filing_meta: Enriched filing coordinates (accession/filing_date/form/
+            filer_cik + report_id) for stamping FactSet ``filed`` provenance and
+            emitting REPORT_HAS_FACT_SET edges. Sourced from the processor, not
+            the graph — see ``FilingMeta``.
 
     Returns:
         ClassifyResult with classification DataFrames, canonical hints, and FactSet data.
@@ -550,9 +570,7 @@ class AssociationClassifier:
     struct_path = nodes_dir / "Structure.parquet"
     struct_assoc_path = rels_dir / "STRUCTURE_HAS_ASSOCIATION.parquet"
     fact_path = nodes_dir / "Fact.parquet"
-    report_path = nodes_dir / "Report.parquet"
     fact_elem_path = rels_dir / "FACT_HAS_ELEMENT.parquet"
-    report_fact_path = rels_dir / "REPORT_HAS_FACT.parquet"
 
     if not assoc_path.exists() or not elem_path.exists():
       logger.debug("Association or Element parquet not found, skipping classification")
@@ -570,9 +588,7 @@ class AssociationClassifier:
       ctx.load_parquet("Structure", struct_path)
       ctx.load_parquet("STRUCTURE_HAS_ASSOCIATION", struct_assoc_path)
       ctx.load_parquet("Fact", fact_path)
-      ctx.load_parquet("Report", report_path)
       ctx.load_parquet("FACT_HAS_ELEMENT", fact_elem_path)
-      ctx.load_parquet("REPORT_HAS_FACT", report_fact_path)
 
       # Layer 1: Structural classification
       for classification_type, cypher in CLASSIFICATION_QUERIES.items():
@@ -615,7 +631,7 @@ class AssociationClassifier:
         struct_fs_rels_df,
         fs_fact_rels_df,
         report_fs_rels_df,
-      ) = self._build_structure_factsets(ctx)
+      ) = self._build_structure_factsets(ctx, filing_meta or FilingMeta())
 
     classifications_df = (
       pd.DataFrame(classifications) if classifications else pd.DataFrame()
@@ -735,7 +751,7 @@ class AssociationClassifier:
     return classifications, relationships, canonical_hints
 
   def _build_structure_factsets(
-    self, ctx: TempLadybugContext
+    self, ctx: TempLadybugContext, filing_meta: FilingMeta
   ) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame, pd.DataFrame]:
     """Build pre-computed FactSets per Structure.
 
@@ -754,41 +770,12 @@ class AssociationClassifier:
     factset_fact_rels: list[dict] = []
     report_factset_rels: list[dict] = []
 
-    # SEC filings produce one Report per ingestion; pull its identifier
-    # so each new FactSet can emit a REPORT_HAS_FACT_SET edge. Dedupe
-    # defensively — if a filing somehow loaded multiple Report nodes,
-    # we still emit one edge per (report, fact_set) pair without
-    # multiplying duplicates.
-    report_ids: list[str] = []
-    filing_accession: str | None = None
-    filing_date: str | None = None
-    filing_form: str | None = None
-    try:
-      report_rows = ctx.execute(
-        "MATCH (r:Report) RETURN r.identifier AS report_id, "
-        "r.accession_number AS accession, r.filing_date AS filing_date, "
-        "r.form AS form"
-      )
-      seen: set[str] = set()
-      for row in report_rows:
-        rid = row.get("report_id")
-        if rid and rid not in seen:
-          seen.add(rid)
-          report_ids.append(rid)
-          # SEC loads one Report per ingestion; capture its filing
-          # coordinates once for the FactSet provenance stamp below.
-          if filing_accession is None:
-            filing_accession = row.get("accession")
-            filing_date = row.get("filing_date")
-            filing_form = row.get("form")
-    except Exception as e:
-      # A miss here means REPORT_HAS_FACT_SET edges never land for this
-      # filing — the package query won't be able to traverse from Report
-      # to its FactSets. Log loud enough to be noticed in CloudWatch.
-      logger.warning(
-        f"FactSet report lookup failed; REPORT_HAS_FACT_SET edges will "
-        f"be missing for this filing: {e}"
-      )
+    # Filing coordinates come from the processor (FilingMeta), not a graph
+    # lookup: the classify context carries an identifier-only Report table, so
+    # accession/filing_date/form can only be sourced from the enriched report
+    # metadata passed in. report_id (when present) drives the one-to-many
+    # REPORT_HAS_FACT_SET edges (report → each of its block FactSets).
+    report_ids: list[str] = [filing_meta.report_id] if filing_meta.report_id else []
 
     # Get all structures and their elements (both FROM and TO)
     try:
@@ -801,7 +788,12 @@ class AssociationClassifier:
       )
     except Exception as e:
       logger.debug(f"FactSet structure query failed: {e}")
-      return pd.DataFrame(), pd.DataFrame(), pd.DataFrame()
+      return (
+        pd.DataFrame(),
+        pd.DataFrame(),
+        pd.DataFrame(),
+        pd.DataFrame(),
+      )
 
     # Also get FROM elements per structure
     try:
@@ -821,9 +813,10 @@ class AssociationClassifier:
     # (which carries the OLTP fact_sets.provenance blob).
     provenance_json = FiledProvenance(
       source="sec_edgar",
-      accession=filing_accession,
-      filing_date=filing_date,
-      form=filing_form,
+      accession=filing_meta.accession,
+      filing_date=filing_meta.filing_date,
+      form=filing_meta.form,
+      filer_cik=filing_meta.filer_cik,
     ).model_dump_json()
 
     # Merge FROM and TO element sets per structure

--- a/robosystems/adapters/sec/processors/xbrl_graph.py
+++ b/robosystems/adapters/sec/processors/xbrl_graph.py
@@ -283,10 +283,26 @@ class XBRLGraphProcessor:
       return
 
     try:
-      from robosystems.adapters.sec.processors.classify import AssociationClassifier
+      from robosystems.adapters.sec.processors.classify import (
+        AssociationClassifier,
+        FilingMeta,
+      )
 
       classifier = AssociationClassifier()
-      result = classifier.classify(self.output_dir)
+      # Source filing coordinates from the enriched report/entity metadata the
+      # processor already holds — classify can't read them from its
+      # identifier-only Report table. Feeds FactSet `filed` provenance +
+      # REPORT_HAS_FACT_SET edges.
+      filing_meta = FilingMeta(
+        report_id=self.report_data.get("identifier") if self.report_data else None,
+        accession=self.report_data.get("accession_number")
+        if self.report_data
+        else None,
+        filing_date=self.report_data.get("filing_date") if self.report_data else None,
+        form=self.report_data.get("form") if self.report_data else None,
+        filer_cik=self.entity_data.get("cik") if self.entity_data else None,
+      )
+      result = classifier.classify(self.output_dir, filing_meta)
 
       if not result.classifications_df.empty:
         self.parquet_writer.write_dataframe(

--- a/tests/adapters/sec/test_classify.py
+++ b/tests/adapters/sec/test_classify.py
@@ -4,6 +4,7 @@ Tests TempLadybugContext lifecycle and AssociationClassifier pattern detection
 for RollUp, RollForward, Hypercube, LineItems, MemberList, and Dimension.
 """
 
+import json
 from pathlib import Path
 
 import pandas as pd
@@ -13,6 +14,7 @@ from robosystems.adapters.sec.processors.classify import (
   DISCLOSURE_CONCEPT_MAP,
   DISCLOSURE_TO_CANONICAL,
   AssociationClassifier,
+  FilingMeta,
   TempLadybugContext,
   _generate_ddl,
 )
@@ -1049,6 +1051,134 @@ class TestStructureFactSets:
 
     # FactSet should contain all 3 facts (rev, cogs, and unrelated — all reference structure elements)
     assert len(result.factset_fact_rels_df) == 3
+
+  def test_filing_meta_stamps_provenance_and_report_edges(self, tmp_path):
+    """FilingMeta populates FactSet `filed` provenance detail + REPORT_HAS_FACT_SET.
+
+    Regression for the provenance-sourcing fix: coordinates come from the
+    passed-in FilingMeta (the classify context can't read them from its
+    identifier-only Report table), and report_id drives the one-to-many
+    report → block-FactSet edges.
+    """
+    elements = [
+      {
+        "identifier": "elem_rev",
+        "qname": "us-gaap:Revenues",
+        "name": "Revenues",
+        "period_type": "duration",
+        "classification": None,
+        "balance": "credit",
+        "uri": "http://example.com#Revenues",
+      },
+    ]
+    associations = [
+      {
+        "identifier": "assoc1",
+        "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+        "order_value": 1.0,
+        "association_type": "Presentation",
+        "weight": None,
+        "root": "True",
+        "preferred_label": None,
+      },
+    ]
+    structures = [{"identifier": "struct_is"}]
+    struct_assoc_rels = [
+      {"from": "struct_is", "to": "assoc1", "association_context": "pres"},
+    ]
+    to_rels = [{"from": "assoc1", "to": "elem_rev"}]
+    facts = [{"identifier": "fact_rev"}]
+    fact_element_rels = [{"from": "fact_rev", "to": "elem_rev"}]
+
+    output_dir = _make_test_data(
+      tmp_path,
+      associations,
+      elements,
+      from_rels=[],
+      to_rels=to_rels,
+      structures=structures,
+      struct_assoc_rels=struct_assoc_rels,
+      facts=facts,
+      fact_element_rels=fact_element_rels,
+    )
+
+    filing_meta = FilingMeta(
+      report_id="report1",
+      accession="0001045810-25-000023",
+      filing_date="2025-02-26",
+      form="10-K",
+      filer_cik="0001045810",
+    )
+    result = AssociationClassifier().classify(output_dir, filing_meta)
+
+    # One FactSet, with fully-populated `filed` provenance detail.
+    assert len(result.factsets_df) == 1
+    provenance = json.loads(result.factsets_df.iloc[0]["provenance"])
+    assert provenance["origin"] == "filed"
+    assert provenance["source"] == "sec_edgar"
+    assert provenance["accession"] == "0001045810-25-000023"
+    assert provenance["filing_date"] == "2025-02-26"
+    assert provenance["form"] == "10-K"
+    assert provenance["filer_cik"] == "0001045810"
+
+    # Report → FactSet edge (one-to-many report→block containment).
+    assert len(result.report_factset_rels_df) == 1
+    edge = result.report_factset_rels_df.iloc[0]
+    assert edge["from"] == "report1"
+    assert edge["to"] == result.factsets_df.iloc[0]["identifier"]
+
+  def test_no_filing_meta_yields_null_provenance_no_report_edges(self, tmp_path):
+    """Without FilingMeta, FactSets still build — detail-null provenance and no
+    REPORT_HAS_FACT_SET edges — a graceful, non-crashing fallback."""
+    elements = [
+      {
+        "identifier": "elem_rev",
+        "qname": "us-gaap:Revenues",
+        "name": "Revenues",
+        "period_type": "duration",
+        "classification": None,
+        "balance": "credit",
+        "uri": "http://example.com#Revenues",
+      },
+    ]
+    associations = [
+      {
+        "identifier": "assoc1",
+        "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+        "order_value": 1.0,
+        "association_type": "Presentation",
+        "weight": None,
+        "root": "True",
+        "preferred_label": None,
+      },
+    ]
+    structures = [{"identifier": "struct_is"}]
+    struct_assoc_rels = [
+      {"from": "struct_is", "to": "assoc1", "association_context": "pres"},
+    ]
+    to_rels = [{"from": "assoc1", "to": "elem_rev"}]
+    facts = [{"identifier": "fact_rev"}]
+    fact_element_rels = [{"from": "fact_rev", "to": "elem_rev"}]
+
+    output_dir = _make_test_data(
+      tmp_path,
+      associations,
+      elements,
+      from_rels=[],
+      to_rels=to_rels,
+      structures=structures,
+      struct_assoc_rels=struct_assoc_rels,
+      facts=facts,
+      fact_element_rels=fact_element_rels,
+    )
+
+    result = AssociationClassifier().classify(output_dir)
+
+    assert len(result.factsets_df) == 1
+    provenance = json.loads(result.factsets_df.iloc[0]["provenance"])
+    assert provenance["origin"] == "filed"
+    assert provenance["accession"] is None
+    assert result.report_factset_rels_df.empty
 
   def test_two_structures_separate_factsets(self, tmp_path):
     """Two structures in same report get independent FactSets."""


### PR DESCRIPTION
## Summary

Fixes SEC `FactSet.provenance` landing detail-null and `REPORT_HAS_FACT_SET` staying empty after the #832/#833 shape changes. Both share one root cause and are fixed together so the upcoming full SEC shared-repo reprocess produces a complete graph in a single pass.

Found during local dry-run validation of the reprocess (`just sec-reset` → `sec-pipeline` → verify), before touching prod.

## Problem

- Every `FactSet.provenance` serialized as `{"origin":"filed","source":"sec_edgar","accession":null,"filing_date":null,"filer_cik":null,"form":null}` — structurally present (the #833 goal), but with all filing coordinates null.
- `REPORT_HAS_FACT_SET` = 0 edges (also 0 in live prod — pre-existing, not a regression from these PRs).

## Root cause

`classify.py::_build_structure_factsets` sourced the filing coordinates by running `MATCH (r:Report) RETURN r.accession_number, …` against the classify `TempLadybugContext`. That context deliberately creates a **minimal, identifier-only** `Report` table ("for FactSet building"), so those columns never exist there — the lookup returns empty without erroring, yielding null provenance detail **and** no `report_ids` (hence no report→factset edges).

## Fix

- Add a `FilingMeta` dataclass and thread the enriched filing coordinates (`report_id`, `accession`, `filing_date`, `form`, `filer_cik`) from the processor — which already holds them in `self.report_data` + `self.entity_data["cik"]` — into `classify()` / `_build_structure_factsets()`.
- Stamp `FiledProvenance` (now including `filer_cik`) directly from `FilingMeta`; **no graph lookup**. Provenance stays a self-contained, per-FactSet grounding descriptor.
- Build `REPORT_HAS_FACT_SET` as a **one-to-many report → block-FactSet containment** from `filing_meta.report_id`, matching the Charlie-Hoffman FactSet=Block model (Report → Fragment → Block/FactSet → Fact; each block bound to a Structure). The old 1:1 "one FactSet per report" notion is retired.
- Remove the now-dead `Report`/`REPORT_HAS_FACT` context DDL + parquet loads.
- Fix a latent arity bug: the structure-query exception path returned 3 DataFrames where the caller unpacks 4.

## Validation

- Local reprocess (2 companies) on the fix: `FactSet.provenance` detail fully populated (e.g. `accession":"0000950170-25-010491","filing_date":"2025-01-29","filer_cik":"0000789019","form":"10-Q"`); `REPORT_HAS_FACT_SET` = 1588 (= `STRUCTURE_HAS_FACT_SET` = total FactSets); `FACT_SET_CONTAINS_FACT` = 35,417.
- 142 unit tests pass (109 related + 33 classify, including 2 new regression tests covering the `FilingMeta` path and the graceful no-meta fallback).
- ruff, format, basedpyright clean.

## Deploy note

This must reach `main` **before** the prod SEC shared-repo reprocess deploy, so the master emits populated provenance + report→factset edges in the same rebuild (avoids a second full-corpus reprocess).
