### PR TITLE
chore(deps): robosystems-client 0.4.0 (content-ops surface)

### DIFF
--- a/examples/custom_graph_demo/memory_subgraph.py
+++ b/examples/custom_graph_demo/memory_subgraph.py
@@ -23,7 +23,7 @@ import sys
 import time
 from pathlib import Path
 
-from robosystems_client.api.query.execute_cypher_query import (
+from robosystems_client.api.query.execute_cypher import (
   sync_detailed as api_execute_query,
 )
 from robosystems_client.api.graph_operations.op_create_subgraph import (
@@ -34,9 +34,9 @@ from robosystems_client.api.subgraphs.list_subgraphs import (
 )
 from robosystems_client.client import AuthenticatedClient
 from robosystems_client.models.create_subgraph_request import CreateSubgraphRequest
-from robosystems_client.models.cypher_query_request import CypherQueryRequest
-from robosystems_client.models.cypher_query_request_parameters_type_0 import (
-  CypherQueryRequestParametersType0,
+from robosystems_client.models.cypher_statement_request import CypherStatementRequest
+from robosystems_client.models.cypher_statement_request_parameters_type_0 import (
+  CypherStatementRequestParametersType0,
 )
 from robosystems_client.models.subgraph_type import SubgraphType
 from robosystems_client.types import UNSET
@@ -51,9 +51,9 @@ CREDENTIALS_FILE = PROJECT_ROOT / ".local" / "config.json"
 DEMO_NAME = "custom_graph_demo"
 
 
-def make_params(params: dict) -> CypherQueryRequestParametersType0:
+def make_params(params: dict) -> CypherStatementRequestParametersType0:
   """Wrap a dict into the generated parameters model."""
-  obj = CypherQueryRequestParametersType0()
+  obj = CypherStatementRequestParametersType0()
   for k, v in params.items():
     obj.additional_properties[k] = v
   return obj
@@ -149,7 +149,7 @@ def execute_query(
   """Execute a Cypher query and print results."""
   print(f"\n   🔍 {description}")
 
-  request = CypherQueryRequest(query=query)
+  request = CypherStatementRequest(query=query)
   response = api_execute_query(graph_id=graph_id, client=client, body=request)
 
   if response.status_code != 200:
@@ -265,7 +265,7 @@ CREATE (c:Concept {
 })
 RETURN c.name AS name
 """
-    request = CypherQueryRequest(query=query, parameters=make_params(concept))
+    request = CypherStatementRequest(query=query, parameters=make_params(concept))
     response = api_execute_query(
       graph_id=subgraph_id, client=client, body=request
     )
@@ -309,7 +309,7 @@ CREATE (o:Observation {
 })
 RETURN o.identifier AS id
 """
-    request = CypherQueryRequest(query=query, parameters=make_params(obs))
+    request = CypherStatementRequest(query=query, parameters=make_params(obs))
     response = api_execute_query(
       graph_id=subgraph_id, client=client, body=request
     )
@@ -339,7 +339,7 @@ CREATE (s:Session {
 })
 RETURN s.name AS name
 """
-  request = CypherQueryRequest(query=query, parameters=make_params(session))
+  request = CypherStatementRequest(query=query, parameters=make_params(session))
   response = api_execute_query(
     graph_id=subgraph_id, client=client, body=request
   )
@@ -428,7 +428,7 @@ RETURN s.name, c.name
   ]
 
   for rel in relationships:
-    request = CypherQueryRequest(
+    request = CypherStatementRequest(
       query=rel["query"], parameters=make_params({"now": now})
     )
     response = api_execute_query(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     # RoboSystems client for demo and testing
-    "robosystems-client==0.3.39",
+    "robosystems-client==0.4.0",
 
     # Testing framework
     "pytest>=9.0.0,<10.0",

--- a/uv.lock
+++ b/uv.lock
@@ -3685,7 +3685,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.34.2,<3.0" },
     { name = "retrying", specifier = ">=1.4.0,<2.0" },
     { name = "rich", marker = "extra == 'dev'", specifier = ">=15.0.0,<16.0" },
-    { name = "robosystems-client", marker = "extra == 'dev'", specifier = "==0.3.39" },
+    { name = "robosystems-client", marker = "extra == 'dev'", specifier = "==0.4.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0,<1.0" },
     { name = "sqlalchemy", specifier = ">=2.0.0,<3.0" },
     { name = "sse-starlette", specifier = ">=3.3.0,<4.0" },
@@ -3708,7 +3708,7 @@ lambda = [
 
 [[package]]
 name = "robosystems-client"
-version = "0.3.39"
+version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -3717,9 +3717,9 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/00/c5/160f54c492b6930f5d283bec02f246270a10a9fc0f78f055013137ac1a7b/robosystems_client-0.3.39.tar.gz", hash = "sha256:a4d01c33b41fb2a4fbd0432157a5b39abe3e3a1064b957556f252dd99dc5503f", size = 403503, upload-time = "2026-07-05T06:16:03.366Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/64/33db81567d0c992e03e7c223d2781efcbaecb6225295ff6eae7c34a51821/robosystems_client-0.4.0.tar.gz", hash = "sha256:db153dbcc8447334301503af607226afaaea14fb981cbb40a9907b704d7dc34a", size = 409107, upload-time = "2026-07-10T08:20:12.238Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5e/5d/4ba3960f820bfc879d69a3d346a017176601e58923f52574fe103a5b8206/robosystems_client-0.3.39-py3-none-any.whl", hash = "sha256:f0742d08375f3b3b21233322d7dfa255f045fd8f1be0b8a6a4deed6cc0bbfea6", size = 936139, upload-time = "2026-07-05T06:16:01.486Z" },
+    { url = "https://files.pythonhosted.org/packages/40/f3/58532aee53587366dae6ac43264aa9c72e7a71f66b83f1e01018d7b0e922/robosystems_client-0.4.0-py3-none-any.whl", hash = "sha256:c7740ea9ae5b42e42bfbc41ed0656c17906c56ed42efb2e2fbd1b919b96b5ae1", size = 956137, upload-time = "2026-07-10T08:20:10.468Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Bumps the `robosystems-client` Python SDK dev dependency from 0.3.39 to 0.4.0 for the content-ops API cutover (breaking regen).

## Changes
- `pyproject.toml`: `robosystems-client==0.3.39` → `==0.4.0` (dev extra). Package version unchanged.
- `uv.lock`: refreshed via `uv lock` — only the robosystems-client block changed (0.3.39 → 0.4.0).
- `examples/custom_graph_demo/memory_subgraph.py`: repointed the one direct low-level Cypher usage:
  - `api.query.execute_cypher_query` → `api.query.execute_cypher`
  - `CypherQueryRequest` → `CypherStatementRequest`
  - `CypherQueryRequestParametersType0` → `CypherStatementRequestParametersType0`

## Not changed
All other `examples/` SDK usage goes through the stable high-level facade wrappers (`clients.query.query`, `clients.files.*`, `clients.documents.*`) or low-level modules unaffected by the rename (`api.graphs`, `api.operations`, `api.subgraphs`, `api.graph_operations`), all verified present in 0.4.0.

## Verification
- `uv lock` resolved robosystems-client 0.4.0; lock diff scoped to that package only.
- Edited example imports cleanly against 0.4.0 (`make_params` returns `CypherStatementRequestParametersType0`).
- `just lint` (repo-wide, examples excluded per ruff config): All checks passed.
- `basedpyright examples/custom_graph_demo/memory_subgraph.py`: 0 errors, 0 warnings, 0 notes.