### PR TITLE
fix(graph-api): restore internal write path broken by tenant-SQL hardening

### DIFF
--- a/robosystems/adapters/sec/processors/ingestion/staging.py
+++ b/robosystems/adapters/sec/processors/ingestion/staging.py
@@ -401,7 +401,7 @@ class DuckDBStager:
               # DELETE+INSERT is not atomic — if interrupted between steps,
               # deleted rows are lost but recovered automatically on retry
               # since the upsert re-creates the temp table from S3.
-              await client.query_table(
+              await client.execute_write(
                 graph_id=self.graph_id,
                 sql=(
                   f'DELETE FROM "{table_name}" WHERE identifier IN '
@@ -411,7 +411,7 @@ class DuckDBStager:
               )
 
               # Insert all rows from temp (fresh data replaces deleted rows)
-              await client.query_table(
+              await client.execute_write(
                 graph_id=self.graph_id,
                 sql=f'INSERT INTO "{table_name}" SELECT * FROM "{temp_name}"',
                 timeout=timeout,
@@ -851,7 +851,7 @@ class DuckDBStager:
             return False, None, f"{table_name} schema probe failed: {e}"
 
           rename_sql = f'ALTER TABLE "{temp_name}" RENAME TO "{accumulator_name}"'
-          await graph_client.query_table(
+          await graph_client.execute_write(
             graph_id=self.graph_id, sql=rename_sql, timeout=30.0
           )
           current_temp = None
@@ -882,7 +882,7 @@ class DuckDBStager:
         )
 
         merge_start = time.monotonic()
-        await graph_client.query_table(
+        await graph_client.execute_write(
           graph_id=self.graph_id, sql=insert_sql, timeout=float(timeout)
         )
         merge_elapsed = time.monotonic() - merge_start
@@ -927,11 +927,13 @@ class DuckDBStager:
 
       # Drop existing target table before renaming accumulator
       drop_sql = f'DROP TABLE IF EXISTS "{table_name}"'
-      await graph_client.query_table(graph_id=self.graph_id, sql=drop_sql, timeout=30.0)
+      await graph_client.execute_write(
+        graph_id=self.graph_id, sql=drop_sql, timeout=30.0
+      )
 
       # Rename accumulator to final target table
       rename_sql = f'ALTER TABLE "{accumulator_name}" RENAME TO "{table_name}"'
-      await graph_client.query_table(
+      await graph_client.execute_write(
         graph_id=self.graph_id, sql=rename_sql, timeout=30.0
       )
 

--- a/robosystems/graph_api/client/client.py
+++ b/robosystems/graph_api/client/client.py
@@ -1871,6 +1871,44 @@ class GraphClient(BaseGraphClient):
     )
     return response.json()
 
+  async def execute_write(
+    self,
+    graph_id: str,
+    sql: str,
+    parameters: list[Any] | None = None,
+    timeout: float | None = None,
+  ) -> dict[str, Any]:
+    """Execute a write/DDL statement on DuckDB staging (internal write path).
+
+    Read-write companion to :meth:`query_table`. ``query_table`` hits the
+    hardened read-only ``/tables/query`` (SELECT/WITH only); this hits
+    ``/tables/execute``, which runs on the read-write connection with
+    httpfs + postgres_scanner enabled — for ``CREATE TABLE AS SELECT ...
+    postgres_scan(...)`` staging and INSERT/DELETE upserts used by the
+    materialization and ingestion pipelines.
+
+    Args:
+        graph_id: Graph database identifier
+        sql: Write/DDL statement to execute
+        parameters: Optional query parameters for safe value substitution
+        timeout: Optional request timeout in seconds. Use a longer timeout for
+                 DDL like CREATE TABLE AS SELECT.
+
+    Returns:
+        Result payload (columns/rows for statements that return a set).
+    """
+    json_data = {"graph_id": graph_id, "sql": sql}
+    if parameters is not None:
+      json_data["parameters"] = parameters
+
+    response = await self._request(
+      "POST",
+      f"/databases/{graph_id}/tables/execute",
+      json_data=json_data,
+      timeout=timeout,
+    )
+    return response.json()
+
   async def delete_table(self, graph_id: str, table_name: str) -> dict[str, Any]:
     """
     Delete a DuckDB staging table.

--- a/robosystems/graph_api/core/duckdb/manager.py
+++ b/robosystems/graph_api/core/duckdb/manager.py
@@ -894,6 +894,60 @@ class DuckDBTableManager:
       execution_time_ms=execution_time_ms,
     )
 
+  def execute_write(self, request: TableQueryRequest) -> TableQueryResponse:
+    """Execute a write/DDL statement on the read-write staging connection.
+
+    Internal-only companion to ``query_table``. Where ``query_table`` runs
+    tenant SQL on the hardened, sandboxed read-only connection (SELECT/WITH
+    only, external access off, no httpfs/postgres_scanner), this runs on the
+    read-write connection with httpfs + postgres_scanner available — the
+    surface the extensions materializer and connector loaders need for
+    ``CREATE TABLE AS SELECT ... postgres_scan(...)`` staging and
+    INSERT/DELETE upserts.
+
+    NOT reachable from the tenant ``/query/sql`` path: only the internal graph
+    client (materialization, ingestion) calls the ``/tables/execute`` endpoint
+    this backs. It mirrors the existing internal write endpoints
+    (``create_table``, ``insert_into_table``) that the read-only hardening left
+    in place; it adds no surface beyond them.
+    """
+    import time
+
+    start_time = time.time()
+
+    logger.info(f"Executing write for graph {request.graph_id}: {request.sql[:100]}...")
+
+    pool = get_duckdb_pool()
+
+    try:
+      with pool.get_connection(request.graph_id) as conn:
+        if request.parameters:
+          result = conn.execute(request.sql, request.parameters).fetchall()
+        else:
+          result = conn.execute(request.sql).fetchall()
+        description = conn.description
+
+      columns = [desc[0] for desc in description] if description else []
+      rows = [list(row) for row in result]
+      execution_time_ms = (time.time() - start_time) * 1000
+
+      logger.info(f"Write returned {len(rows)} rows in {execution_time_ms:.2f}ms")
+
+      return TableQueryResponse(
+        columns=columns,
+        rows=rows,
+        row_count=len(rows),
+        execution_time_ms=execution_time_ms,
+      )
+    except HTTPException:
+      raise
+    except Exception as e:
+      logger.error(f"Write failed for graph {request.graph_id}: {e}")
+      raise HTTPException(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        detail=f"Query failed: {e!s}",
+      )
+
   def query_table_streaming(self, request: TableQueryRequest, chunk_size: int = 1000):
     """
     Execute SQL query and yield results in chunks for TRUE streaming.

--- a/robosystems/graph_api/routers/databases/tables/query.py
+++ b/robosystems/graph_api/routers/databases/tables/query.py
@@ -197,3 +197,33 @@ async def query_tables(
       status_code=http_status.HTTP_400_BAD_REQUEST,
       detail=f"Query failed: {e!s}",
     )
+
+
+@router.post("/execute", response_model=None)
+async def execute_table_write(
+  graph_id: str = Path(..., description="Graph database identifier"),
+  request: TableQueryRequest = Body(...),
+) -> TableQueryResponse:
+  """Execute a write/DDL statement against DuckDB staging (**internal**).
+
+  Read-write companion to ``POST /query``. ``/query`` runs tenant SQL on the
+  hardened read-only connection (SELECT/WITH only, external access off); this
+  runs on the read-write connection with httpfs + postgres_scanner enabled, for
+  the internal materialization + ingestion paths — ``CREATE TABLE AS
+  SELECT ... postgres_scan(...)`` staging and INSERT/DELETE upserts.
+
+  Not proxied by the tenant ``/query/sql`` surface; only the internal graph
+  client calls it. Mirrors the existing internal write endpoints
+  (``POST /tables`` create, ``POST /tables/{name}/insert``).
+  """
+  request.graph_id = graph_id
+  try:
+    return table_manager.execute_write(request)
+  except HTTPException:
+    raise
+  except Exception as e:
+    logger.error(f"Write failed for graph {graph_id}: {e}")
+    raise HTTPException(
+      status_code=http_status.HTTP_400_BAD_REQUEST,
+      detail=f"Write failed: {e!s}",
+    )

--- a/robosystems/operations/extensions/materialize.py
+++ b/robosystems/operations/extensions/materialize.py
@@ -1591,7 +1591,9 @@ class ExtensionsMaterializer:
 
       try:
         logger.info(f"Staging {table_name} from PostgreSQL → DuckDB")
-        await client.query_table(graph_id, sql.strip(), timeout=120.0)
+        # CREATE TABLE AS SELECT ... postgres_scan(...) — internal write path
+        # (read-only /tables/query rejects DDL + has postgres_scanner disabled).
+        await client.execute_write(graph_id, sql.strip(), timeout=120.0)
         result.tables_staged.append(table_name)
       except Exception as e:
         error_msg = f"Failed to stage {table_name}: {e!s}"

--- a/tests/adapters/sec/processors/ingestion/test_staging.py
+++ b/tests/adapters/sec/processors/ingestion/test_staging.py
@@ -435,11 +435,14 @@ class TestStageIncrementalToDuckDB:
     assert "Entity" in result.table_names
     assert result.total_rows == 50
 
-    # Entity should use create_table (temp), query_table (DELETE+INSERT+COUNT),
-    # and delete_table (cleanup) — NOT insert_into_table
+    # Entity should use create_table (temp), execute_write (DELETE+INSERT),
+    # query_table (COUNT), and delete_table (cleanup) — NOT insert_into_table.
+    # DELETE/INSERT go through the write endpoint; the hardened read-only
+    # query_table only carries the COUNT.
     mock_client.create_table.assert_called_once()
     mock_client.insert_into_table.assert_not_called()
-    assert mock_client.query_table.call_count == 3  # DELETE, INSERT, COUNT
+    assert mock_client.execute_write.call_count == 2  # DELETE, INSERT
+    assert mock_client.query_table.call_count == 1  # COUNT
 
   @pytest.mark.asyncio
   @patch("robosystems.adapters.sec.processors.ingestion.staging.asyncio.sleep")

--- a/tests/graph_api/routers/databases/tables/test_tables_query.py
+++ b/tests/graph_api/routers/databases/tables/test_tables_query.py
@@ -19,6 +19,7 @@ def client(monkeypatch):
   fake_manager = SimpleNamespace(
     query_table=None,
     query_table_streaming=None,
+    execute_write=None,
   )
   monkeypatch.setattr(query, "table_manager", fake_manager)
 
@@ -44,6 +45,50 @@ def test_query_tables_json_response(client):
   payload = response.json()
   assert payload["row_count"] == 1
   assert payload["columns"] == ["id"]
+
+
+def test_execute_table_write_json_response(client):
+  # /tables/execute runs on the read-write connection — DDL/writes are allowed,
+  # unlike the read-only /tables/query surface — so internal materialization
+  # and ingestion can run CREATE TABLE AS / INSERT / DELETE.
+  captured = {}
+
+  def _execute_write(req):
+    captured["sql"] = req.sql
+    return TableQueryResponse(
+      columns=["Count"],
+      rows=[[3]],
+      execution_time_ms=12.0,
+      row_count=1,
+    )
+
+  client.fake_manager.execute_write = _execute_write
+
+  response = client.post(
+    "/databases/graph-123/tables/execute",
+    json={
+      "graph_id": "graph-ignored",
+      "sql": 'CREATE OR REPLACE TABLE "Event" AS SELECT 1 AS id',
+    },
+  )
+
+  assert response.status_code == 200
+  assert captured["sql"].startswith("CREATE OR REPLACE TABLE")
+  assert response.json()["row_count"] == 1
+
+
+def test_execute_table_write_error(client):
+  def _raise(req):
+    raise RuntimeError("boom")
+
+  client.fake_manager.execute_write = _raise
+
+  response = client.post(
+    "/databases/graph-123/tables/execute",
+    json={"graph_id": "graph-ignored", "sql": "INSERT INTO t VALUES (1)"},
+  )
+
+  assert response.status_code == 400
 
 
 def test_query_tables_streaming_ndjson(client):

--- a/tests/operations/extensions/test_materialize.py
+++ b/tests/operations/extensions/test_materialize.py
@@ -467,7 +467,7 @@ class TestExtensionsMaterializer:
 
     mock_client = AsyncMock()
     mock_client.database_exists.return_value = True
-    mock_client.query_table.return_value = {"success": True}
+    mock_client.execute_write.return_value = {"success": True}
     mock_client.materialize_table.return_value = {"rows_ingested": 10}
 
     materializer = ExtensionsMaterializer()
@@ -517,7 +517,7 @@ class TestExtensionsMaterializer:
     mock_client.database_exists.return_value = False
     mock_client.create_database.return_value = {"success": True}
     mock_client.install_schema.return_value = {"success": True}
-    mock_client.query_table.return_value = {"success": True}
+    mock_client.execute_write.return_value = {"success": True}
     mock_client.materialize_table.return_value = {"rows_ingested": 0}
 
     materializer = ExtensionsMaterializer()


### PR DESCRIPTION
## Problem
The read-only hardening of the DuckDB tenant SQL surface (`195fceae`) routed `query_table` / `POST /databases/{g}/tables/query` through a sandboxed read-only connection (SELECT/WITH only, external access off, **no postgres_scanner**). That surface is also shared by *internal* writers, so it broke:

- **Extensions materialization** — `CREATE TABLE AS SELECT … postgres_scan(…)` staging 400'd with *"Only read-only SELECT/WITH queries are allowed on this surface"*, failing `extensions_materialize_job` (the RoboLedger OLTP→OLAP path). Caught by the demo smoke test.
- **SEC ingestion** — its `query_table`-based `DELETE`/`INSERT`/`ALTER`/`DROP` upserts (latent; the read-only `sec_materialize` path was unaffected, which is why `sec_materialize` runs stayed green).

SEC's bulk writes were unaffected — they already use the dedicated `create_table` / `insert_into_table` endpoints, which the hardening left alone.

## Fix
A generic **internal** write endpoint alongside the hardened read one — no change to the tenant read surface:

- `DuckDBTableManager.execute_write` + `POST /databases/{g}/tables/execute` — runs on the read-write connection (httpfs + postgres_scanner), no read-only validation. Internal-only: the tenant `/query/sql` proxy never routes to it, and it mirrors the existing internal write endpoints (`create_table`, `insert_into_table`) — **no surface beyond them**.
- `GraphClient.execute_write` client method.
- Repoint internal writers off `query_table`: extensions materialize CTAS staging + the SEC staging `DELETE`/`INSERT`/`ALTER`/`DROP`. Reads (SELECT/COUNT probes) and the tenant `/query/sql` stay on the hardened read-only `query_table`.

The domain contract stays where it belongs — `ExtensionsMaterializer` + `/operations/materialize?source=extensions` remain the named extensions↔graph contract; the graph-api gains only a generic, domain-agnostic write primitive.

## Verification
- Graph-api probe: `CREATE TABLE` via `/tables/execute` → 200; same via `/tables/query` → **400** (hardening intact); `SELECT` reads it back.
- **`demo-roboledger` materialize completes**: 50 tables, 10,307 rows; report filed, XBRL valid, SHACL conforms.
- New endpoint unit tests; touched suites + `just test-code` (ruff + format + basedpyright) green.