### PR TITLE
fix: canonical tenant qnames in materialize + demo disposal cleanup

### DIFF
--- a/examples/roboledger_demo/validate.py
+++ b/examples/roboledger_demo/validate.py
@@ -367,6 +367,29 @@ class _Validator:
     except Exception as exc:
       self._check("SumEquals rule deleted after dispose", False, str(exc))
 
+    # Delete the disposal entry this smoke test drafted into close_target.
+    # The asset_disposed handler posts a real (draft) disposal entry dated on
+    # the last day of close_target; the queued delete_schedule cleanup removes
+    # the throwaway schedule but NOT this entry. Left behind, it lingers as an
+    # orphan draft in the very period the demo then tells the user to close, so
+    # it would post as a spurious extra closing entry. Clean it up here.
+    try:
+      drafts = client.list_period_drafts(self.graph_id, close_target) or {}
+      disposal_ids = [
+        d.get("entry_id")
+        for d in drafts.get("drafts", [])
+        if d.get("memo") == "Validation disposal" and d.get("entry_id")
+      ]
+      for eid in disposal_ids:
+        client.delete_journal_entry(self.graph_id, eid)
+      self._check(
+        "disposal draft cleaned up",
+        len(disposal_ids) >= 1,
+        f"deleted {len(disposal_ids)} draft(s) from {close_target}",
+      )
+    except Exception as exc:
+      self._check("disposal draft cleaned up", False, str(exc))
+
   # ── Ad-hoc rollforward ───────────────────────────────────────────────────
 
   def adhoc_rollforward(self, dr_id: str, cr_id: str) -> None:

--- a/robosystems/operations/extensions/materialize.py
+++ b/robosystems/operations/extensions/materialize.py
@@ -440,11 +440,19 @@ def _staging_sql(graph_id: str, entity_id: str, connstr: str) -> dict[str, str]:
     SELECT
       e.id                            AS identifier,
       CASE
-        WHEN e.external_source = 'quickbooks' THEN 'qb:'
-        WHEN e.external_source = 'xero' THEN 'xero:'
-        WHEN e.external_source = 'plaid' THEN 'plaid:'
-        ELSE 'rl:'
-      END || e.code                   AS qname,
+        WHEN e.external_source = 'quickbooks' THEN 'qb:' || e.code
+        WHEN e.external_source = 'xero' THEN 'xero:' || e.code
+        WHEN e.external_source = 'plaid' THEN 'plaid:' || e.code
+        -- Library/taxonomy concepts (rs-gaap, fac, us-gaap, cm, disclosures,
+        -- styles, …) already carry a canonical namespaced qname; emit it
+        -- verbatim so report-concept facts stay rs-gaap:X, not rl:rs-gaap:X
+        -- (the double prefix broke build-fact-grid and every canonical
+        -- consumer on tenant graphs). Native/import/system CoA accounts keep
+        -- the 'rl:' tenant prefix.
+        WHEN e.source NOT IN ('native', 'import', 'system')
+          THEN COALESCE(e.qname, e.code)
+        ELSE 'rl:' || e.code
+      END                             AS qname,
       e.name,
       e.description,
       NULL::VARCHAR                   AS item_type,

--- a/tests/operations/extensions/test_materialize.py
+++ b/tests/operations/extensions/test_materialize.py
@@ -89,6 +89,16 @@ class TestStagingSql:
     assert "'qb:'" in sql
     assert "'rl:'" in sql
 
+  def test_element_keeps_canonical_taxonomy_qname(self):
+    # Library/taxonomy concepts (rs-gaap, fac, cm, …) already carry a
+    # canonical namespaced qname; the Element staging must emit it verbatim
+    # rather than re-prefixing to 'rl:rs-gaap:X' (which broke build-fact-grid
+    # and every canonical consumer on tenant graphs). Native/import/system
+    # CoA accounts still fall through to the 'rl:' tenant prefix.
+    sql = _staging_sql(GRAPH_ID, ENTITY_ID, CONNSTR)["Element"]
+    assert "COALESCE(e.qname, e.code)" in sql
+    assert "NOT IN ('native', 'import', 'system')" in sql
+
   def test_element_reads_from_elements(self):
     tables = _staging_sql(GRAPH_ID, ENTITY_ID, CONNSTR)
     assert "'elements'" in tables["Element"]


### PR DESCRIPTION
## Summary

Two independent bugs surfaced while probing the RoboLedger demo end-to-end (demos → REST API → local MCP), each in the demo/materialization seam rather than the core engine:

1. **Tenant materialization double-prefixed canonical taxonomy qnames** — report-concept facts landed as `rl:rs-gaap:StockholdersEquity` instead of the canonical `rs-gaap:StockholdersEquity`, breaking `build-fact-grid` and every canonical consumer on tenant graphs.
2. **The RoboLedger demo left an orphan disposal draft** in the close period, so the AI month-end close saw a spurious extra entry.

Both are fixed and validated against a fresh demo run.

## Changes

**Extensions materialization** (`robosystems/operations/extensions/materialize.py`)
- The `Element` staging `CASE` prepended the tenant `rl:` namespace to *every* element code — including already-qualified taxonomy concepts (`rs-gaap:…`) — producing `rl:rs-gaap:X`. The elements table already stores the correct `qname` (concepts as `rs-gaap:X`, native accounts as `coa:NNNN`), so the reconstruction was both redundant and wrong for concepts.
- Now routes library/taxonomy sources (`rs-gaap`, `fac`, `us-gaap`, `cm`, `disclosures`, `styles`, …) through their stored canonical qname via `COALESCE(e.qname, e.code)`. Native/import/system CoA accounts keep the `rl:` tenant prefix; QuickBooks/Xero/Plaid keep their source prefix — so no behavior change for anything except the previously-broken concept qnames.

**Test** (`tests/operations/extensions/test_materialize.py`)
- Added `test_element_keeps_canonical_taxonomy_qname` asserting the `COALESCE(e.qname, e.code)` branch and the `NOT IN ('native', 'import', 'system')` guard are present, so the canonical-concept behavior can't silently regress. Existing `test_element_uses_qname_prefix` still passes (both `'qb:'` and `'rl:'` literals remain).

**Demo validation** (`examples/roboledger_demo/validate.py`)
- `dispose_smoke_test` fires a real `asset_disposed` event dated on the last day of `close_target`, which drafts a balanced disposal entry into that period. The queued `delete_schedule` cleanup removed the throwaway schedule but not the drafted entry, so every demo run orphaned a `Validation disposal` draft in the very period the demo then tells the user to close.
- Added cleanup after the assertions: look the entry up by memo via `list_period_drafts(close_target)` and `delete_journal_entry` it. The validation suite now reports a `disposal draft cleaned up` check (42/42).

## Testing

- `just test-code` → **green** (ruff, format, basedpyright 0 errors / 0 warnings / 0 notes). Also re-run by the pre-commit hooks on both commits.
- `tests/operations/extensions/test_materialize.py` → **41 passed** (includes the 2 new canonical-qname assertions).
- End-to-end: fresh `just demo-roboledger` on a clean graph → **42/42** validation checks (incl. the new disposal-cleanup check), materialize 50 tables / 10,297 rows, report filed, **SHACL conforms**, **Arelle valid**.
- `build-fact-grid` A/B against old (pre-fix) vs new (post-fix) graphs confirms the fix: canonical `rs-gaap:NetIncomeLoss` returns the fact on the new graph but `[]` on the old (which still needs `rl:rs-gaap:…`); report structure is byte-identical (10 FactSets, 335 facts, 42 distinct qnames), only the concept namespace changed.
- Full `just test` unit suite: **not run this session** (targeted materialize suite + `test-code` were run instead).

## Notes / Follow-ups

- Raw CoA account facts intentionally still carry the graph-side `rl:` prefix (`rl:1200`) while the OLTP stores `coa:1200`. Left as-is — the reported issue was the *concept* qnames, and aligning accounts is a larger, separate change. Possible future cleanup.
- Considered and **declined**: unifying the `build-fact-grid` response envelope between the REST operation (`presentations.pivot_table`) and the MCP tool (flat records). Both delegate to the same `query_fact_grid` kernel; the differing shapes are deliberate for their two consumers (render path vs. LLM), and a flat `records` presentation would just duplicate data already returned.
