### PR TITLE
fix(dagster): prevent concurrent sec_process runs per SEC quarter

### DIFF
--- a/dagster_home/dagster.yaml
+++ b/dagster_home/dagster.yaml
@@ -69,6 +69,14 @@ run_coordinator:
     max_concurrent_runs: 2
     dequeue_use_threads: true
     dequeue_num_workers: 2
+    # Parity with dagster_prod.yaml: one running job per quarterly partition
+    # (the sec_processing_sensor is skipped in dev, so this is documentation of
+    # intent here, but keeps the two configs from drifting).
+    tag_concurrency_limits:
+      - key: "quarter"
+        limit: 1
+        value:
+          applyLimitPerUniqueValue: true
 
 # Telemetry - disable for privacy
 telemetry:

--- a/dagster_home/dagster_prod.yaml
+++ b/dagster_home/dagster_prod.yaml
@@ -91,6 +91,21 @@ run_coordinator:
     max_concurrent_runs:
       env: DAGSTER_MAX_CONCURRENT_RUNS
     dequeue_interval_seconds: 5
+    # Enforce one running job per quarterly partition. The sec_processing_sensor
+    # tags every sec_process run (and its auto-retries) with `quarter`. Its own
+    # active-run guard only checks STARTED/QUEUED, so it races Dagster's async
+    # auto-retry: a Spot-killed run sits in FAILURE+will_retry limbo (neither
+    # STARTED nor QUEUED) while its retry has not enqueued yet, and a sensor tick
+    # landing in that gap submits a second run for the same quarter. Two runs then
+    # process the partition concurrently and emit duplicate parquet part files
+    # (benign — DuckDB staging dedups on identifier / (from,to) — but wasteful).
+    # This limit queues the second run instead; by the time it dequeues the winner
+    # has drained the quarter's pending SourceFiles, so it no-ops.
+    tag_concurrency_limits:
+      - key: "quarter"
+        limit: 1
+        value:
+          applyLimitPerUniqueValue: true
 
 # Telemetry - disable for privacy
 telemetry:

--- a/robosystems/adapters/sec/pipeline/jobs.py
+++ b/robosystems/adapters/sec/pipeline/jobs.py
@@ -106,8 +106,16 @@ sec_process_job = define_asset_job(
   tags={
     "pipeline": "sec",
     "phase": "process",
-    # Retry on Spot reclaim: S3 cache means retries skip already-processed filings.
-    "dagster/max_retries": 5,
+    # No dagster/max_retries here on purpose: the sec_processing_sensor is the
+    # single recovery authority. It re-triggers any quarter with pending
+    # SourceFiles every 5 min (skipping already-processed filings via the S3
+    # cache + SourceFile status), so a Spot-killed run is picked up on the next
+    # tick. Dagster's async auto-retry was redundant with that and raced the
+    # sensor's active-run guard (which only sees STARTED/QUEUED), spawning a
+    # second concurrent run for the same quarter → duplicate parquet part files.
+    # Omitting the tag disables auto-retry for THIS job only; global
+    # run_retries stays on for jobs that carry the tag. tag_concurrency_limits
+    # on `quarter` (dagster_prod.yaml) is the structural backstop.
     # Enhanced profile: 4 vCPU, 16 GB, 50 GB storage - embedding enrichment is memory-intensive
     "ecs/cpu": "4096",
     "ecs/memory": "16384",


### PR DESCRIPTION
## Summary

Prevent two Dagster runs from processing the same SEC quarterly partition concurrently. A Spot-terminated `sec_process` run and a fresh sensor submission could run at once, emitting duplicate parquet part files. Fixed at the root (remove the redundant recovery trigger) plus a structural backstop.

## Background

There were **two independent recovery mechanisms** for a failed `sec_process` run, and the race was the seam between them:

1. **Dagster auto-retry** (`run_retries.enabled` + `dagster/max_retries: 5` on the job) — fires ~60s after a failure.
2. **`sec_processing_sensor`** — every 5 min, re-triggers any quarter with pending `SourceFiles` and no active run.

Both recover a Spot kill *identically* — re-run the quarter, skip already-processed filings via the S3 cache + `SourceFile` status. They are functionally redundant. The race:

1. Spot kill → run goes `FAILURE` + `will_retry: true` (no longer `STARTED`/`QUEUED`).
2. ~60s window: the retry isn't enqueued yet, but the quarter's `SourceFiles` are still `pending`.
3. A sensor tick landing in that gap sees "no active run + pending files" → submits a second run.
4. Auto-retry then enqueues the retry. Both run concurrently on the same partition.

The duplicate output is **benign** — DuckDB staging dedups nodes on `identifier` and relationships on `(from, to)` (`graph_api/core/duckdb/manager.py:242-266`), so no duplicate rows reach LadybugDB — but it wastes ~2× compute and breaks the intended one-run-per-partition invariant. Observed on 6 quarters in the 2026-07 SEC reprocess (2020-Q2, 2021-Q1, 2023-Q1, 2024-Q4, 2026-Q1, 2026-Q2), confirmed from the Dagster run records (root `FAILURE`+`will_retry`, its auto-retry, and an independent sensor-tick run overlapping ~76 min).

## Changes

**Root fix — remove the redundant recovery trigger:**
- **`robosystems/adapters/sec/pipeline/jobs.py`** — drop `dagster/max_retries` from `sec_process_job`. The sensor is now the single recovery authority; a Spot-killed run is re-picked on the next 5-min tick. Per the prod config (*"Without the tag, no retries occur"*), this disables auto-retry for **this job only** — global `run_retries` and other jobs' retries (e.g. the OpenSearch index job at `jobs.py:478`) are untouched.

**Structural backstop — enforce the invariant regardless of trigger:**
- **`dagster_home/dagster_prod.yaml`** — add `tag_concurrency_limits: [{ key: quarter, limit: 1, value: { applyLimitPerUniqueValue: true } }]` to the `QueuedRunCoordinator`. Any concurrent submission for a quarter (manual trigger, incremental chain, future code) now queues instead of running; when it dequeues, the winner has drained the quarter's `SourceFiles`, so it no-ops.
- **`dagster_home/dagster.yaml`** (dev) — same block for parity (the sensor is skipped in dev; documents intent, prevents config drift).

## Testing

- YAML parse + schema-shape validated for both coordinator configs (`yaml.safe_load`, `tag_concurrency_limits` well-formed).
- `ruff check` + `ruff format --check` clean on `jobs.py`; pre-commit hooks green on both commits.
- Full `just test-all` **not run** — config + a single tag removal, no logic touched, and the suite needs a local env.

## Notes / Follow-ups

- **Recovery latency: ~60s → ≤5 min** (one sensor tick). Bounded — a single tick recovers *all* killed quarters at once (the sensor iterates every pending quarter). Negligible for a multi-day drain.
- **Requires a daemon restart to take effect** (config baked into the image; entrypoint copies `dagster_prod.yaml → dagster.yaml` at start). **Intended to land with the post-reprocess/cutover deploy — not mid-freeze.** The in-flight 2026-07 reprocess is unaffected (stage dedup already protects the data).
- One caveat of removing auto-retry: the currently-disabled incremental `download→process→stage` chain relies on the processing sensor being enabled to recover a killed process step. In the sensor-driven model that's always true; the `tag_concurrency_limits` backstop covers the rest.
