### PR TITLE
feat(mcp): add update-memory + delete-document write tools

### DIFF
--- a/robosystems/middleware/mcp/tools/document_tools.py
+++ b/robosystems/middleware/mcp/tools/document_tools.py
@@ -3,11 +3,12 @@
 Replaces the semantic memory tools (remember-text, recall-text) with full
 document CRUD. Memories become documents with folder="memory".
 
-Four tools:
+Five tools:
 1. create-document: Create a markdown document (PG + OpenSearch)
 2. update-document: Edit an existing document's content or metadata
-3. get-document: Retrieve full document content by ID
-4. list-documents: Browse documents in the graph (filter by folder/source_type)
+3. delete-document: Remove a document from PG + OpenSearch by ID
+4. get-document: Retrieve full document content by ID
+5. list-documents: Browse documents in the graph (filter by folder/source_type)
 
 Discovery (search) is handled by the existing search-documents tool.
 """
@@ -392,6 +393,69 @@ class GetDocumentTool:
     except Exception as e:
       logger.error(f"get-document failed for graph_id={graph_id}: {e}")
       return {"error": "retrieval_failed", "message": str(e)}
+    finally:
+      session.close()
+
+
+class DeleteDocumentTool:
+  """Delete a document by ID from PostgreSQL and OpenSearch."""
+
+  def __init__(self, graph_client):
+    self.client = graph_client
+
+  def get_tool_definition(self) -> dict[str, Any]:
+    return {
+      "name": "delete-document",
+      "description": """Delete a document by ID from the graph's document store.
+
+**WHEN TO USE:**
+- To remove an outdated or incorrect policy/procedure document
+- To clean up a memory note that is no longer relevant
+
+Removes the document from PostgreSQL (source of truth) and its indexed sections
+from OpenSearch. This is permanent — use get-document to review before deleting.""",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "document_id": {
+            "type": "string",
+            "description": "Document ID to delete",
+          },
+        },
+        "required": ["document_id"],
+      },
+    }
+
+  async def execute(self, arguments: dict[str, Any]) -> Any:
+    from robosystems.operations.document_service import DocumentService
+
+    graph_id = self.client.graph_id
+
+    blocked = _block_shared_repository(graph_id)
+    if blocked:
+      return blocked
+
+    access_error = _check_graph_access(graph_id, require_write=True)
+    if access_error:
+      return access_error
+
+    document_id = arguments["document_id"]
+
+    session = _get_platform_session()
+    try:
+      service = DocumentService(session)
+      deleted = service.delete_document(graph_id, document_id)
+      if not deleted:
+        return {"error": "not_found", "message": f"Document '{document_id}' not found"}
+      return {
+        "success": True,
+        "document_id": document_id,
+        "deleted": True,
+        "message": "Document deleted from PostgreSQL and OpenSearch",
+      }
+    except Exception as e:
+      logger.error(f"delete-document failed for graph_id={graph_id}: {e}")
+      return {"error": "delete_failed", "message": str(e)}
     finally:
       session.close()
 

--- a/robosystems/middleware/mcp/tools/manager.py
+++ b/robosystems/middleware/mcp/tools/manager.py
@@ -395,6 +395,7 @@ class GraphMCPTools:
     # writable, non-shared graph. Distinct from the subgraph-Cypher memory tools.
     self.semantic_remember_tool = None
     self.semantic_recall_tool = None
+    self.semantic_update_memory_tool = None
     self.semantic_forget_tool = None
     if (
       env.SEMANTIC_MEMORY_ENABLED
@@ -405,11 +406,13 @@ class GraphMCPTools:
         SemanticForgetTool,
         SemanticRecallTool,
         SemanticRememberTool,
+        SemanticUpdateMemoryTool,
       )
 
       self.semantic_recall_tool = SemanticRecallTool(graph_client)
       if not read_only:
         self.semantic_remember_tool = SemanticRememberTool(graph_client)
+        self.semantic_update_memory_tool = SemanticUpdateMemoryTool(graph_client)
         self.semantic_forget_tool = SemanticForgetTool(graph_client)
 
     # Layer 3: Document management tools (user graphs only, not shared repos)
@@ -418,11 +421,13 @@ class GraphMCPTools:
     # Write tools (create/update) require writable user graphs.
     self.create_document_tool = None
     self.update_document_tool = None
+    self.delete_document_tool = None
     self.get_document_tool = None
     self.list_documents_tool = None
     if env.SEMANTIC_SEARCH_ENABLED and not self._is_shared_repository():
       from .document_tools import (
         CreateDocumentTool,
+        DeleteDocumentTool,
         GetDocumentTool,
         ListDocumentsTool,
         UpdateDocumentTool,
@@ -436,6 +441,7 @@ class GraphMCPTools:
       if not read_only:
         self.create_document_tool = CreateDocumentTool(graph_client)
         self.update_document_tool = UpdateDocumentTool(graph_client)
+        self.delete_document_tool = DeleteDocumentTool(graph_client)
 
     # Cache statistics (inherited from schema tool)
     self._cache_hits = 0
@@ -591,6 +597,8 @@ class GraphMCPTools:
       tools.append(self.semantic_recall_tool.get_tool_definition())
     if self.semantic_remember_tool is not None:
       tools.append(self.semantic_remember_tool.get_tool_definition())
+    if self.semantic_update_memory_tool is not None:
+      tools.append(self.semantic_update_memory_tool.get_tool_definition())
     if self.semantic_forget_tool is not None:
       tools.append(self.semantic_forget_tool.get_tool_definition())
     return tools
@@ -803,6 +811,8 @@ class GraphMCPTools:
       tools.append(self.create_document_tool.get_tool_definition())
     if self.update_document_tool is not None:
       tools.append(self.update_document_tool.get_tool_definition())
+    if self.delete_document_tool is not None:
+      tools.append(self.delete_document_tool.get_tool_definition())
     if self.get_document_tool is not None:
       tools.append(self.get_document_tool.get_tool_definition())
     if self.list_documents_tool is not None:
@@ -1018,6 +1028,16 @@ class GraphMCPTools:
             self._tool_unavailable_reason("recall", "MCP_SEMANTIC_MEMORY_ENABLED")
           )
         result = await self.semantic_recall_tool.execute(arguments)
+        return result if return_raw else json.dumps(result, indent=2)
+
+      elif name == "update-memory":
+        if self.semantic_update_memory_tool is None:
+          raise ValueError(
+            self._tool_unavailable_reason(
+              "update-memory", "MCP_SEMANTIC_MEMORY_ENABLED"
+            )
+          )
+        result = await self.semantic_update_memory_tool.execute(arguments)
         return result if return_raw else json.dumps(result, indent=2)
 
       elif name == "forget":
@@ -1268,6 +1288,14 @@ class GraphMCPTools:
             self._tool_unavailable_reason("update-document", "SEMANTIC_SEARCH_ENABLED")
           )
         result = await self.update_document_tool.execute(arguments)
+        return result if return_raw else json.dumps(result, indent=2)
+
+      elif name == "delete-document":
+        if self.delete_document_tool is None:
+          raise ValueError(
+            self._tool_unavailable_reason("delete-document", "SEMANTIC_SEARCH_ENABLED")
+          )
+        result = await self.delete_document_tool.execute(arguments)
         return result if return_raw else json.dumps(result, indent=2)
 
       elif name == "get-document":

--- a/robosystems/middleware/mcp/tools/semantic_memory_tools.py
+++ b/robosystems/middleware/mcp/tools/semantic_memory_tools.py
@@ -2,8 +2,8 @@
 Semantic memory MCP tools (LanceDB vector store).
 
 Gives AI Operators a stateful memory layer: `remember` (write), `recall` (ranked
-semantic read), `forget` (delete). Thin adapters over the transport-independent
-``MemoryService`` kernel — no business logic here.
+semantic read), `update-memory` (edit in place), `forget` (delete). Thin adapters
+over the transport-independent ``MemoryService`` kernel — no business logic here.
 
 DISTINCT from ``memory_tools.py`` (write-graph-cypher / add-node-table), which is
 structural knowledge-graph construction on memory *subgraphs*. This is the
@@ -188,6 +188,78 @@ class SemanticRecallTool(_SemanticMemoryToolMixin, BaseTool):
           for h in response.hits
         ],
       }
+
+    return await self._with_service(_run)
+
+
+class SemanticUpdateMemoryTool(_SemanticMemoryToolMixin, BaseTool):
+  """Partially update a stored semantic memory by id."""
+
+  def get_tool_definition(self) -> dict[str, Any]:
+    return {
+      "name": "update-memory",
+      "description": (
+        "Update a previously stored semantic memory in place by its id (from a "
+        "prior `remember`/`recall`). Only the fields you supply change; the "
+        "memory is re-embedded when `text` changes. Use to correct or refine a "
+        "memory instead of forgetting and re-remembering (which would mint a new "
+        "id and drop its history)."
+      ),
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "memory_id": {
+            "type": "string",
+            "description": "The memory id to update (e.g. 'mem_...').",
+          },
+          "text": {
+            "type": "string",
+            "description": "New memory content (omit to keep current).",
+          },
+          "memory_type": {
+            "type": "string",
+            "description": "New classifier (omit to keep current).",
+          },
+          "tags": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "New labels (omit to keep current).",
+          },
+        },
+        "required": ["memory_id"],
+        "additionalProperties": False,
+      },
+    }
+
+  async def execute(self, arguments: dict[str, Any]) -> dict[str, Any]:
+    self._log_tool_execution("update-memory", arguments)
+    memory_id = (arguments.get("memory_id") or "").strip()
+    if not memory_id:
+      return {"error": "invalid_input", "message": "memory_id is required"}
+
+    from robosystems.models.api.memory import MemoryUpdateRequest
+
+    # Forward only the fields the caller actually set, so the service (which
+    # keys on model_fields_set) does a true partial update instead of wiping
+    # the omitted fields to NULL.
+    update_fields: dict[str, Any] = {}
+    for field in ("text", "memory_type", "tags"):
+      if field in arguments:
+        update_fields[field] = arguments[field]
+    if not update_fields:
+      return {"error": "invalid_input", "message": "No fields to update"}
+
+    request = MemoryUpdateRequest(**update_fields)
+
+    async def _run(service, graph_id):
+      try:
+        record = await service.update_memory(graph_id, memory_id, request)
+      except Exception as e:
+        logger.error(f"update-memory failed: {e}")
+        raise GraphAPIError(f"update-memory failed: {e}")
+      if record is None:
+        return {"error": "not_found", "message": "Memory not found"}
+      return {"success": True, "memory": record.model_dump(mode="json")}
 
     return await self._with_service(_run)
 

--- a/tests/middleware/mcp/tools/test_document_tools.py
+++ b/tests/middleware/mcp/tools/test_document_tools.py
@@ -8,6 +8,7 @@ import pytest
 
 from robosystems.middleware.mcp.tools.document_tools import (
   CreateDocumentTool,
+  DeleteDocumentTool,
   GetDocumentTool,
   ListDocumentsTool,
   UpdateDocumentTool,
@@ -200,6 +201,77 @@ class TestUpdateDocumentTool:
       )
 
     assert result["error"] == "not_found"
+
+
+class TestDeleteDocumentTool:
+  def test_tool_definition(self, mock_graph_client):
+    tool = DeleteDocumentTool(mock_graph_client)
+    defn = tool.get_tool_definition()
+    assert defn["name"] == "delete-document"
+    assert "document_id" in defn["inputSchema"]["required"]
+
+  @pytest.mark.asyncio
+  async def test_deletes_document(self, mock_graph_client):
+    mock_service = MagicMock()
+    mock_service.delete_document.return_value = True
+
+    mock_session = MagicMock()
+
+    tool = DeleteDocumentTool(mock_graph_client)
+    with (
+      patch(f"{DOC_MODULE}._get_platform_session", return_value=mock_session),
+      patch(f"{DOC_MODULE}._block_shared_repository", return_value=None),
+      patch(f"{DOC_MODULE}._check_graph_access", return_value=None),
+      patch(DOC_SVC, return_value=mock_service),
+    ):
+      result = await tool.execute({"document_id": "doc_01ABC"})
+
+    assert result["success"] is True
+    assert result["document_id"] == "doc_01ABC"
+    mock_service.delete_document.assert_called_once_with("kgtest123", "doc_01ABC")
+
+  @pytest.mark.asyncio
+  async def test_returns_not_found(self, mock_graph_client):
+    mock_service = MagicMock()
+    mock_service.delete_document.return_value = False
+
+    mock_session = MagicMock()
+
+    tool = DeleteDocumentTool(mock_graph_client)
+    with (
+      patch(f"{DOC_MODULE}._get_platform_session", return_value=mock_session),
+      patch(f"{DOC_MODULE}._block_shared_repository", return_value=None),
+      patch(f"{DOC_MODULE}._check_graph_access", return_value=None),
+      patch(DOC_SVC, return_value=mock_service),
+    ):
+      result = await tool.execute({"document_id": "doc_missing"})
+
+    assert result["error"] == "not_found"
+
+  @pytest.mark.asyncio
+  async def test_blocks_shared_repository(self, mock_shared_client):
+    tool = DeleteDocumentTool(mock_shared_client)
+    with patch(
+      f"{DOC_MODULE}._block_shared_repository",
+      return_value={"error": "not_allowed", "message": "shared repo"},
+    ):
+      result = await tool.execute({"document_id": "doc_01ABC"})
+
+    assert result["error"] == "not_allowed"
+
+  @pytest.mark.asyncio
+  async def test_requires_write_access(self, mock_graph_client):
+    tool = DeleteDocumentTool(mock_graph_client)
+    with (
+      patch(f"{DOC_MODULE}._block_shared_repository", return_value=None),
+      patch(
+        f"{DOC_MODULE}._check_graph_access",
+        return_value={"error": "access_denied", "message": "read-only"},
+      ),
+    ):
+      result = await tool.execute({"document_id": "doc_01ABC"})
+
+    assert result["error"] == "access_denied"
 
 
 class TestGetDocumentTool:

--- a/tests/middleware/mcp/tools/test_semantic_memory_tools.py
+++ b/tests/middleware/mcp/tools/test_semantic_memory_tools.py
@@ -1,0 +1,97 @@
+"""Tests for the semantic-memory update-memory MCP tool.
+
+Focused on ``update-memory`` (the write verb added alongside remember/recall/
+forget). The tool is a thin adapter over ``MemoryService.update_memory`` — the
+kernel itself is tested in the operations/memory suite.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from robosystems.middleware.mcp.tools.semantic_memory_tools import (
+  SemanticUpdateMemoryTool,
+)
+
+SEM_MODULE = "robosystems.middleware.mcp.tools.semantic_memory_tools"
+MEMORY_ID = "mem_" + "a" * 32
+
+
+@pytest.fixture
+def mock_graph_client():
+  client = MagicMock()
+  client.graph_id = "kgtest123"
+  return client
+
+
+def _patched_service(mock_service):
+  """Patch the writer-client acquisition + kernel wiring used by _with_service."""
+  mock_client = AsyncMock()
+  return (
+    patch(f"{SEM_MODULE}._block_shared_repo", return_value=None),
+    patch(
+      "robosystems.graph_api.client.factory.get_graph_client",
+      AsyncMock(return_value=mock_client),
+    ),
+    patch(
+      "robosystems.operations.memory.get_memory_service",
+      return_value=mock_service,
+    ),
+  )
+
+
+class TestSemanticUpdateMemoryTool:
+  def test_tool_definition(self, mock_graph_client):
+    tool = SemanticUpdateMemoryTool(mock_graph_client)
+    defn = tool.get_tool_definition()
+    assert defn["name"] == "update-memory"
+    assert defn["inputSchema"]["required"] == ["memory_id"]
+    assert "text" in defn["inputSchema"]["properties"]
+
+  @pytest.mark.asyncio
+  async def test_updates_memory(self, mock_graph_client):
+    mock_record = MagicMock()
+    mock_record.model_dump.return_value = {"id": MEMORY_ID, "text": "revised"}
+    mock_service = MagicMock()
+    mock_service.update_memory = AsyncMock(return_value=mock_record)
+
+    tool = SemanticUpdateMemoryTool(mock_graph_client)
+    p_block, p_client, p_service = _patched_service(mock_service)
+    with p_block, p_client, p_service:
+      result = await tool.execute({"memory_id": MEMORY_ID, "text": "revised"})
+
+    assert result["success"] is True
+    assert result["memory"]["text"] == "revised"
+    # graph_id, memory_id, request forwarded to the kernel
+    call = mock_service.update_memory.await_args
+    assert call.args[0] == "kgtest123"
+    assert call.args[1] == MEMORY_ID
+    # only the field the caller set is present (partial update)
+    request = call.args[2]
+    assert request.model_fields_set == {"text"}
+
+  @pytest.mark.asyncio
+  async def test_rejects_no_fields(self, mock_graph_client):
+    tool = SemanticUpdateMemoryTool(mock_graph_client)
+    result = await tool.execute({"memory_id": MEMORY_ID})
+    assert result["error"] == "invalid_input"
+
+  @pytest.mark.asyncio
+  async def test_requires_memory_id(self, mock_graph_client):
+    tool = SemanticUpdateMemoryTool(mock_graph_client)
+    result = await tool.execute({"text": "revised"})
+    assert result["error"] == "invalid_input"
+
+  @pytest.mark.asyncio
+  async def test_returns_not_found(self, mock_graph_client):
+    mock_service = MagicMock()
+    mock_service.update_memory = AsyncMock(return_value=None)
+
+    tool = SemanticUpdateMemoryTool(mock_graph_client)
+    p_block, p_client, p_service = _patched_service(mock_service)
+    with p_block, p_client, p_service:
+      result = await tool.execute({"memory_id": MEMORY_ID, "text": "revised"})
+
+    assert result["error"] == "not_found"


### PR DESCRIPTION
## Summary

Adds the two genuinely-missing, high-value content-op **write** verbs to the MCP surface: `update-memory` (edit a stored semantic memory in place) and `delete-document` (remove an indexed document). Both existed on REST but had no MCP tool — so an AI Operator could `remember`/`recall` but not fix a memory, and `create`/`update` documents but not delete one. Part of the multimodal-knowledge-graph spec's deferred MCP-unification work (§10 Phase 2 deferrals), scoped to the pieces with clear payoff.

## Changes

- **`update-memory`** (`semantic_memory_tools.py`) — partial update over `MemoryService.update_memory`; forwards only caller-set fields so the kernel's `model_fields_set` keying does a true partial (no NULL-wipe of omitted fields). Re-embeds when `text` changes.
- **`delete-document`** (`document_tools.py`) — delete by id over `DocumentService.delete_document` (PostgreSQL + OpenSearch), 404 on miss.
- Both are thin adapters over the **same kernels** the REST content-ops use and share the sibling tools' gates (`_block_shared_repo`/`_block_shared_repository` + write-access) — no duplicated policy/business logic. Tool names match the REST op names exactly (no drift).
- Wired into `GraphMCPTools` (constructor, definition lists, `call_tool` dispatch), gated by the same flags as their families (`MCP_SEMANTIC_MEMORY_ENABLED` / `SEMANTIC_SEARCH_ENABLED`), on writable non-shared graphs only.

## Deferred (deliberately)

The three file-write content-ops — `create-file-upload` / `ingest-file` / `delete-file` — are **not** surfaced on MCP. They need FastAPI-shaped deps (request-scoped session, authenticated `current_user`, `BackgroundTasks`) and model a human/UI upload flow (presign → browser upload → ingest) an Operator wouldn't drive. Deferred until demand-pulled.

## Testing

- `just test-code` → green (ruff, format, basedpyright 0/0/0).
- `just test middleware/mcp/tools/` → 261 pass, incl. 5 new `delete-document` + 5 new `update-memory` tests.
- Live registration smoke-checked: both tools appear in `get_tool_definitions_as_dict()` and instantiate when their flags are on. API restarted.

## Notes

- Additive only — new tools appear; existing tools/schemas unchanged. Connected MCP clients see the new tools on reconnect.
- **No REST/OpenAPI change** (MCP-only) → no SDK/frontend regen needed.
