### PR TITLE
fix(security): viewer read-only enforcement + cypher write-bypass (F1, F2, F11)

### DIFF
--- a/robosystems/middleware/auth/dependencies.py
+++ b/robosystems/middleware/auth/dependencies.py
@@ -459,6 +459,34 @@ async def get_current_user_with_graph(
   )
 
 
+def require_graph_write_role(user_id: str, graph_id: str) -> None:
+  """Assert the user holds a write role (member/admin) on the graph.
+
+  ``viewer`` is read-only; bare graph *membership* (which
+  ``get_current_user_with_graph`` proves) is not sufficient to mutate a graph.
+  This is the single write-role authorization check the command surfaces share
+  — REST command ops (the extensions registrar, content-ops) call it before
+  dispatching, and the MCP surface enforces the same via
+  ``validate_mcp_access(..., "write")``. Opens a short-lived platform session
+  (``GraphUser`` lives in the platform DB, not the per-graph OLTP DB).
+
+  Raises:
+      HTTPException: 403 if the user's role on the graph is read-only.
+  """
+  from robosystems.database import SessionFactory
+  from robosystems.models.core import GraphUser
+
+  session = SessionFactory()
+  try:
+    if not GraphUser.user_has_write_access(user_id, graph_id, session):
+      raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail=f"Write access denied to graph {graph_id}; your role is read-only.",
+      )
+  finally:
+    session.close()
+
+
 async def get_current_user_with_repository_access(
   request: Request,
   repository_id: str,

--- a/robosystems/middleware/extensions.py
+++ b/robosystems/middleware/extensions.py
@@ -37,6 +37,7 @@ from sqlalchemy.exc import ProgrammingError
 from sqlalchemy.orm import Session
 
 from robosystems.database import get_db_session
+from robosystems.middleware.auth.dependencies import require_graph_write_role
 from robosystems.middleware.graph.types import GRAPH_OR_SUBGRAPH_ID_PATTERN
 from robosystems.middleware.operations import (
   IdempotencyCache,
@@ -440,6 +441,12 @@ class OperationRegistrar:
       # parse/format checks before we open a DB session.
       if pre_validate is not None:
         pre_validate(body)
+
+      # Every registrar op is a command (write). The extension gate proves
+      # provisioning and `user_dep` proves graph membership — neither checks
+      # the write role, so a read-only `viewer` would otherwise reach the
+      # OLTP command surface. Enforce member/admin here, fail-closed.
+      require_graph_write_role(str(user.id), graph_id)
 
       ctx = ctx_builder(
         graph_id=graph_id,

--- a/robosystems/operations/document_service.py
+++ b/robosystems/operations/document_service.py
@@ -172,6 +172,15 @@ class DocumentService:
     if doc is None:
       raise KeyError(f"Document {document_id} not found in graph {graph_id}")
 
+    # Enforce the 500k content cap in the kernel. Create + the REST paths cap it
+    # via the Pydantic request models, but the MCP `update-document` tool
+    # forwards raw content with no length check — an uncapped multi-MB update
+    # would bloat the PG row and the OpenSearch re-index.
+    if content is not None and len(content) > 500_000:
+      raise ValueError(
+        f"Content exceeds 500,000 character limit ({len(content):,} chars)"
+      )
+
     if content is not None:
       # _apply_frontmatter returns the Ellipsis sentinel through as `object`;
       # the caller intentionally re-accepts it. Narrow types match the

--- a/robosystems/routers/graphs/content_ops.py
+++ b/robosystems/routers/graphs/content_ops.py
@@ -87,16 +87,25 @@ def _block_shared_repo(graph_id: str) -> None:
     )
 
 
-def _require_graph_write_access(graph_id: str) -> None:
-  """Enforce write-level graph access (subscription state + write role).
+def _require_graph_write_access(graph_id: str, user_id: str) -> None:
+  """Enforce write-level graph access: the member/admin **write role** AND
+  subscription/lifecycle state.
 
-  ``get_current_user_with_graph`` only proves *some* access (incl. viewer);
-  content-op writes must also pass the subscription/lifecycle + write-role checks
-  the resource write surfaces apply. Shared by all content-op write handlers.
+  ``get_current_user_with_graph`` only proves graph *membership* — a read-only
+  ``viewer`` passes it. And ``require_graph_access(require_write=True)`` is a
+  billing/lifecycle gate that takes **no user** (it blocks writes during a
+  subscription grace period, not by role). So both checks are required: the
+  role check is what actually keeps a viewer off the content-op write surface.
+  Shared by all content-op write handlers.
   """
   from robosystems.database import SessionFactory
+  from robosystems.middleware.auth.dependencies import require_graph_write_role
   from robosystems.middleware.billing.enforcement import require_graph_access
 
+  # Write role (member/admin) — viewer is read-only.
+  require_graph_write_role(user_id, graph_id)
+
+  # Subscription/lifecycle gate (blocks writes during a grace period).
   session = SessionFactory()
   try:
     require_graph_access(graph_id, session, require_write=True)
@@ -160,7 +169,7 @@ async def remember_op(
 
   _require_memory_enabled()
   _block_shared_repo(graph_id)
-  _require_graph_write_access(graph_id)
+  _require_graph_write_access(graph_id, str(user.id))
 
   op_name = "remember"
   user_id = str(user.id)
@@ -222,7 +231,7 @@ async def forget_op(
 
   _require_memory_enabled()
   _block_shared_repo(graph_id)
-  _require_graph_write_access(graph_id)
+  _require_graph_write_access(graph_id, str(user.id))
 
   op_name = "forget"
   user_id = str(user.id)
@@ -282,7 +291,7 @@ async def update_memory_op(
 
   _require_memory_enabled()
   _block_shared_repo(graph_id)
-  _require_graph_write_access(graph_id)
+  _require_graph_write_access(graph_id, str(user.id))
 
   op_name = "update-memory"
   user_id = str(user.id)
@@ -354,7 +363,7 @@ async def index_document_op(
 
   _require_search_enabled()
   _block_shared_repo(graph_id)
-  _require_graph_write_access(graph_id)
+  _require_graph_write_access(graph_id, str(user.id))
 
   op_name = "index-document"
   user_id = str(user.id)
@@ -441,7 +450,7 @@ async def delete_document_op(
 
   _require_search_enabled()
   _block_shared_repo(graph_id)
-  _require_graph_write_access(graph_id)
+  _require_graph_write_access(graph_id, str(user.id))
 
   op_name = "delete-document"
   user_id = str(user.id)
@@ -556,7 +565,7 @@ async def ingest_file_op(
   from robosystems.operations.graph.commands.ingest_file import ingest_file_cmd
 
   _block_shared_repo(graph_id)
-  _require_graph_write_access(graph_id)
+  _require_graph_write_access(graph_id, str(user.id))
 
   op_name = "ingest-file"
   user_id = str(user.id)
@@ -637,7 +646,7 @@ async def delete_file_op(
   from robosystems.operations.graph.commands.delete_file import delete_file_cmd
 
   _block_shared_repo(graph_id)
-  _require_graph_write_access(graph_id)
+  _require_graph_write_access(graph_id, str(user.id))
 
   op_name = "delete-file"
   user_id = str(user.id)

--- a/robosystems/routers/graphs/mcp/execute.py
+++ b/robosystems/routers/graphs/mcp/execute.py
@@ -75,6 +75,65 @@ _MCP_SCHEMA_CACHE_TTL = 3600  # 1 hour
 # Lazily initialized on first use to avoid import-time URL resolution issues.
 _mcp_redis_client: Any = None
 
+# Write classification is FAIL-CLOSED: any tool NOT in this read-only allowlist
+# is treated as a write and must pass the member/admin role check (a `viewer`
+# is read-only). This is deliberately an inverted allowlist so that every new
+# tool — including every registrar-generated OLTP command op — defaults to
+# write and cannot silently become viewer-writable.
+#
+# The `read-*-cypher` tools are intentionally ABSENT: they are classified per
+# query by the StatementKernel (they can carry a write statement), handled
+# separately below.
+#
+# When adding a new READ tool, add it here (otherwise viewers can't call it —
+# safe, but over-restrictive). New WRITE tools need no change.
+READ_ONLY_MCP_TOOLS: frozenset[str] = frozenset(
+  {
+    # Graph introspection / exploration
+    "get-graph-info",
+    "get-graph-schema",
+    "get-graphql-schema",
+    "get-graph-sync-status",
+    "get-example-queries",
+    "query-graphql",
+    "list-subgraphs",
+    "switch-workspace",
+    # Financial analysis / reporting reads
+    "financial-statement-analysis",
+    "live-financial-statement",
+    "build-fact-grid",
+    "resolve-element",
+    # Fiscal calendar / close reads
+    "get-fiscal-calendar",
+    "get-period-close-status",
+    "get-close-playbook",
+    "list-period-drafts",
+    # Mapping reads
+    "get-unmapped-elements",
+    "suggest-mapping",
+    "list-mapping-structures",
+    "get-mapping-summary",
+    # Agent reads
+    "get-agent",
+    "list-agents",
+    "agent-activity",
+    # Event block / handler reads
+    "get-event-block",
+    "list-event-blocks",
+    "get-event-handler",
+    "list-event-handlers",
+    # Information block reads
+    "get-information-block",
+    "list-information-blocks",
+    # Document / memory reads
+    "get-document",
+    "list-documents",
+    "get-document-section",
+    "search-documents",
+    "recall",
+  }
+)
+
 
 def _get_mcp_redis_client() -> Any:
   """Return the shared async Redis client for MCP_CACHE, creating it on first call."""
@@ -283,20 +342,22 @@ async def call_mcp_tool(
     # session block below.
     from robosystems.database import SessionFactory
 
-    is_write_query = False
     is_cypher_read_tool = tool_call.name in (
       "read-graph-cypher",
       "read-neo4j-cypher",
       "read-ladybug-cypher",
     )
-    # Schema-mutating / write tools aren't cypher-analyzed; flag them as writes
-    # so write-role authorization applies below (viewer is read-only).
-    if tool_call.name in (
-      "write-graph-cypher",
-      "add-node-table",
-      "add-relationship-table",
-    ):
-      is_write_query = True
+    # Fail-closed write classification: a tool is a WRITE unless it is on the
+    # read-only allowlist. This makes every non-read tool — including all
+    # registrar-generated OLTP command ops (update-journal-entry, close-period,
+    # execute-event-block, the content-op writes, …) — require the member/admin
+    # role via `validate_mcp_access(..., "write")` below, closing the prior
+    # fail-open gap where only three tool names were flagged as writes and a
+    # `viewer` could reach the whole command surface. Cypher read tools are
+    # classified precisely by the StatementKernel (they can carry a write).
+    is_write_query = (not is_cypher_read_tool) and (
+      tool_call.name not in READ_ONLY_MCP_TOOLS
+    )
 
     # Validate access using a short-lived session.  The MCP endpoint's
     # tool execution can take minutes; using a scoped session or FastAPI

--- a/robosystems/security/cypher_analyzer.py
+++ b/robosystems/security/cypher_analyzer.py
@@ -126,16 +126,9 @@ class CypherSecurityAnalyzer:
     # Pattern to find CALL procedures
     self.call_pattern = re.compile(r"\bCALL\s+(\w+)\s*\(", re.IGNORECASE)
 
-    # Pattern to identify comments
-    self.comment_pattern = re.compile(r"(/\*.*?\*/|//.*?$)", re.DOTALL | re.MULTILINE)
-
-    # Pattern to identify string literals (single and double quotes)
-    self.string_pattern = re.compile(
-      r"""(?:"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*')""", re.DOTALL
-    )
-
-    # Pattern to identify backtick-quoted identifiers
-    self.identifier_pattern = re.compile(r"`(?:[^`\\]|\\.)*`", re.DOTALL)
+    # Comments, string literals, and backtick identifiers are masked by the
+    # single-pass scanner in `_clean_query` (not by regex) so an in-string
+    # comment marker can't hide a trailing write keyword.
 
   def analyze_query(self, query: str) -> CypherOperationType:
     """
@@ -298,25 +291,80 @@ class CypherSecurityAnalyzer:
 
   def _clean_query(self, query: str) -> str:
     """
-    Remove comments, strings, and quoted identifiers from the query
-    to avoid false positives in write operation detection.
+    Mask comments, string literals, and backtick-quoted identifiers so that
+    keyword detection only ever sees *code*, not data.
+
+    This is a single left-to-right scan that decides context (string vs.
+    comment vs. identifier vs. code) at each position. A staged
+    strip-comments-then-strings approach is unsafe: a ``//`` (or ``/*``)
+    sequence *inside* a string literal would be treated as a comment and eat a
+    real write keyword that follows the closed string
+    (e.g. ``... WHERE n.x = '//' CREATE (m) ...``), causing a write to be
+    misclassified as a read. Scanning once, quotes toggle string context
+    before any comment marker is honoured, so an in-string ``//`` can never
+    hide the code after the string.
 
     Args:
         query: The original query
 
     Returns:
-        Cleaned query with comments and strings removed
+        Cleaned query with comments blanked and strings/identifiers replaced
+        by neutral placeholder tokens.
     """
-    # Step 1: Remove comments
-    cleaned = self.comment_pattern.sub(" ", query)
+    out: list[str] = []
+    i = 0
+    n = len(query)
+    while i < n:
+      ch = query[i]
 
-    # Step 2: Remove string literals
-    cleaned = self.string_pattern.sub(" STRING_LITERAL ", cleaned)
+      # Line comment: // ... to end of line
+      if ch == "/" and i + 1 < n and query[i + 1] == "/":
+        nl = query.find("\n", i)
+        i = n if nl == -1 else nl
+        out.append(" ")
+        continue
 
-    # Step 3: Remove backtick-quoted identifiers
-    cleaned = self.identifier_pattern.sub(" IDENTIFIER ", cleaned)
+      # Block comment: /* ... */  (unbalanced -> consume to end; the security
+      # pre-check already rejects unbalanced blocks fail-closed)
+      if ch == "/" and i + 1 < n and query[i + 1] == "*":
+        end = query.find("*/", i + 2)
+        i = n if end == -1 else end + 2
+        out.append(" ")
+        continue
 
-    return cleaned
+      # String literal: '...' or "..."  (backslash escapes the next char)
+      if ch == "'" or ch == '"':
+        quote = ch
+        i += 1
+        while i < n:
+          c = query[i]
+          if c == "\\":
+            i += 2
+            continue
+          i += 1
+          if c == quote:
+            break
+        out.append(" STRING_LITERAL ")
+        continue
+
+      # Backtick-quoted identifier
+      if ch == "`":
+        i += 1
+        while i < n:
+          c = query[i]
+          if c == "\\":
+            i += 2
+            continue
+          i += 1
+          if c == "`":
+            break
+        out.append(" IDENTIFIER ")
+        continue
+
+      out.append(ch)
+      i += 1
+
+    return "".join(out)
 
   def _find_write_operations(self, query: str) -> set[str]:
     """

--- a/tests/middleware/auth/test_dependencies.py
+++ b/tests/middleware/auth/test_dependencies.py
@@ -22,6 +22,7 @@ from robosystems.middleware.auth.dependencies import (
   get_current_user_with_repository_access,
   get_optional_user,
   get_repository_user_dependency,
+  require_graph_write_role,
   verify_jwt_claims,
 )
 from robosystems.models.core import User
@@ -1278,3 +1279,31 @@ class TestPerformanceAndCaching:
           assert result.id == user_id
           # API key validation should not be called
           mock_validate_api_key.assert_not_called()
+
+
+class TestRequireGraphWriteRole:
+  """The shared write-role gate used by the command surfaces (appsec F1)."""
+
+  def test_viewer_denied(self):
+    with (
+      patch("robosystems.database.SessionFactory", return_value=Mock()),
+      patch(
+        "robosystems.models.core.GraphUser.user_has_write_access",
+        return_value=False,
+      ),
+    ):
+      with pytest.raises(HTTPException) as exc:
+        require_graph_write_role("user_1", "kg0123456789abcdef")
+      assert exc.value.status_code == status.HTTP_403_FORBIDDEN
+      assert "read-only" in exc.value.detail
+
+  def test_write_role_allowed(self):
+    with (
+      patch("robosystems.database.SessionFactory", return_value=Mock()),
+      patch(
+        "robosystems.models.core.GraphUser.user_has_write_access",
+        return_value=True,
+      ),
+    ):
+      # member/admin -> no raise
+      require_graph_write_role("user_1", "kg0123456789abcdef")

--- a/tests/operations/test_document_service.py
+++ b/tests/operations/test_document_service.py
@@ -196,6 +196,16 @@ class TestUpdateDocument:
     with pytest.raises(KeyError, match="not found"):
       service.update_document("kg_test", "doc_missing", title="New")
 
+  @patch.object(Document, "get_by_id_and_graph")
+  def test_raises_on_oversized_content(self, mock_get):
+    # F11: the kernel caps content so the MCP update-document tool (which
+    # forwards raw content with no length check) can't bypass the 500k limit.
+    mock_get.return_value = _mock_document()
+    service = DocumentService(MagicMock())
+
+    with pytest.raises(ValueError, match="500,000 character limit"):
+      service.update_document("kg_test", "doc_abc123", content="x" * 500_001)
+
 
 @pytest.mark.unit
 class TestDeleteDocument:

--- a/tests/routers/extensions/roboinvestor/test_operations.py
+++ b/tests/routers/extensions/roboinvestor/test_operations.py
@@ -59,6 +59,19 @@ from robosystems.routers.extensions.roboinvestor.operations import (
 
 GRAPH_ID = "kg01234567890abcdef"
 
+
+@pytest.fixture(autouse=True)
+def _bypass_write_role():
+  """Registrar handlers enforce the member/admin write role via
+  ``require_graph_write_role`` (unit-tested in
+  ``tests/middleware/auth/test_dependencies.py``). These direct-call wiring
+  tests use a mock user with no DB-backed ``GraphUser`` row, so no-op it."""
+  with patch(
+    "robosystems.middleware.extensions.require_graph_write_role", return_value=None
+  ):
+    yield
+
+
 # Command-origin patch paths (registrar resolves commands via sys.modules).
 PORTFOLIO_BLOCK = "robosystems.operations.roboinvestor.commands.portfolio_block"
 SECURITIES = "robosystems.operations.roboinvestor.commands.securities"

--- a/tests/routers/extensions/roboledger/test_information_block_ops.py
+++ b/tests/routers/extensions/roboledger/test_information_block_ops.py
@@ -36,6 +36,20 @@ _TEST_ENTRY_TEMPLATE = EntryTemplateRequest(
 )
 
 GRAPH_ID = "kg01234567890abcdef"
+
+
+@pytest.fixture(autouse=True)
+def _bypass_write_role():
+  """Registrar handlers enforce the member/admin write role via
+  ``require_graph_write_role`` (unit-tested in
+  ``tests/middleware/auth/test_dependencies.py``). These direct-call wiring
+  tests use a mock user with no DB-backed ``GraphUser`` row, so no-op it."""
+  with patch(
+    "robosystems.middleware.extensions.require_graph_write_role", return_value=None
+  ):
+    yield
+
+
 CMD_PATH = "robosystems.operations.information_block.commands.create_information_block"
 UPDATE_CMD_PATH = (
   "robosystems.operations.information_block.commands.update_information_block"

--- a/tests/routers/extensions/roboledger/test_operations.py
+++ b/tests/routers/extensions/roboledger/test_operations.py
@@ -52,6 +52,19 @@ from robosystems.routers.extensions.roboledger.operations import (
 GRAPH_ID = "kg01234567890abcdef"
 
 
+@pytest.fixture(autouse=True)
+def _bypass_write_role():
+  """The registrar handler enforces the member/admin write role via
+  ``require_graph_write_role`` (unit-tested in
+  ``tests/middleware/auth/test_dependencies.py``; the deny path is asserted in
+  ``TestRegistrarWriteRoleGate`` below). These direct-call wiring tests use a
+  mock user with no DB-backed ``GraphUser`` row, so no-op the gate here."""
+  with patch(
+    "robosystems.middleware.extensions.require_graph_write_role", return_value=None
+  ):
+    yield
+
+
 def _make_user() -> MagicMock:
   user = MagicMock()
   user.id = "usr_test123"
@@ -1164,3 +1177,28 @@ class TestUpdateEventBlockOp:
         )
     assert exc.value.status_code == 422
     assert "balance" in exc.value.detail
+
+
+class TestRegistrarWriteRoleGate:
+  """appsec F1: every registrar command handler enforces the member/admin
+  write role, so a read-only viewer can't reach the OLTP command surface."""
+
+  @pytest.mark.asyncio
+  async def test_viewer_is_denied(self) -> None:
+    body = UpdateJournalEntryRequest(entry_id="je_abc", memo="x")
+    # Re-patch over the autouse no-op to simulate a read-only viewer.
+    with patch(
+      "robosystems.middleware.extensions.require_graph_write_role",
+      side_effect=HTTPException(
+        status_code=403, detail="Write access denied; your role is read-only."
+      ),
+    ):
+      with pytest.raises(HTTPException) as exc:
+        await update_journal_entry_op(
+          body=body,
+          graph_id=GRAPH_ID,
+          user=_make_user(),
+          idempotency_key=None,
+          cache=_FakeCache(),
+        )
+    assert exc.value.status_code == 403

--- a/tests/routers/graphs/mcp/test_mcp_execute.py
+++ b/tests/routers/graphs/mcp/test_mcp_execute.py
@@ -8,6 +8,7 @@ import pytest
 from fastapi import HTTPException
 
 from robosystems.routers.graphs.mcp.execute import (
+  READ_ONLY_MCP_TOOLS,
   _get_mcp_cache,
   _get_mcp_operation_type,
   _get_user_priority,
@@ -15,6 +16,58 @@ from robosystems.routers.graphs.mcp.execute import (
   _set_mcp_cache,
   execute_tool_directly,
 )
+
+
+class TestWriteClassificationFailClosed:
+  """appsec F1: write-intent must default to write. Any tool NOT on the
+  read-only allowlist is classified as a write and requires the member/admin
+  role, so a viewer can't reach the command surface."""
+
+  def test_dangerous_writes_are_not_read_only(self):
+    for tool in (
+      # registrar-generated OLTP command ops
+      "update-journal-entry",
+      "delete-journal-entry",
+      "close-period",
+      "reopen-period",
+      "execute-event-block",
+      "create-information-block",
+      "delete-information-block",
+      "create-mapping-association",
+      "update-agent",
+      "link-entity-taxonomy",
+      "promote-obligations",
+      # hand-written writes
+      "write-graph-cypher",
+      "add-node-table",
+      "remember",
+      "update-memory",
+      "forget",
+      "create-document",
+      "update-document",
+      "delete-document",
+      "materialize",
+      "set-write-policy",
+      "create-subgraph",
+    ):
+      assert tool not in READ_ONLY_MCP_TOOLS, f"{tool} must classify as a write"
+
+  def test_core_reads_are_read_only(self):
+    for tool in (
+      "get-graph-schema",
+      "search-documents",
+      "recall",
+      "list-documents",
+      "get-document",
+      "financial-statement-analysis",
+      "build-fact-grid",
+      "list-agents",
+    ):
+      assert tool in READ_ONLY_MCP_TOOLS, f"{tool} should be allowed for viewers"
+
+  def test_cypher_read_tools_excluded_from_static_set(self):
+    # These are classified per-query by the StatementKernel, not this set.
+    assert "read-graph-cypher" not in READ_ONLY_MCP_TOOLS
 
 
 def _make_mock_user(user_id="user-123", tier_name=None):

--- a/tests/security/test_cypher_analyzer.py
+++ b/tests/security/test_cypher_analyzer.py
@@ -247,3 +247,49 @@ class TestKeywordContextValidation:
     # "CREATE" should not match inside "RECREATE"
     result = analyzer.analyze_query("MATCH (n) WHERE n.name = 'RECREATED' RETURN n")
     assert result == CypherOperationType.READ
+
+
+class TestInStringCommentMarkerBypass:
+  """Regression: a comment marker (// or /*) inside a string literal must not
+  hide a real write keyword that follows the closed string (appsec F2).
+
+  The old `_clean_query` stripped comments *before* strings, so an in-string
+  ``//`` ate everything to end-of-line — including a trailing CREATE/SET/etc —
+  and the analyzer reported READ. The single-pass scanner masks strings first.
+  """
+
+  # Appendix B payloads — each must classify as a WRITE.
+  @pytest.mark.parametrize(
+    "query",
+    [
+      "MATCH (n) WHERE n.x = '//' CREATE (m:Hacked) RETURN m",
+      'MATCH (n) WHERE n.name = "x//y" SET n.hacked = true RETURN n',
+      'MATCH (n) WHERE n.x = "//" DETACH DELETE n',
+      "MATCH (n) WHERE n.note = '// comment' MERGE (m:Evil {id:1}) RETURN m",
+      # unbalanced /* inside a string -> fail-closed WRITE (pre-check rejects)
+      "MATCH (n) WHERE n.x = '/*' RETURN n",
+    ],
+  )
+  def test_in_string_marker_does_not_hide_write(self, analyzer, query):
+    assert analyzer.is_write_operation(query) is True
+
+  def test_in_string_marker_hides_nothing_when_read(self, analyzer):
+    # An in-string // with no trailing write keyword stays a READ.
+    result = analyzer.analyze_query("MATCH (n) WHERE n.url = 'http://x' RETURN n")
+    assert result == CypherOperationType.READ
+
+  def test_real_line_comment_still_masks_write(self, analyzer):
+    # A genuine trailing line comment (outside any string) is still a comment.
+    result = analyzer.analyze_query("MATCH (n) RETURN n // CREATE (m) here")
+    assert result == CypherOperationType.READ
+
+  def test_real_block_comment_still_masks_write(self, analyzer):
+    result = analyzer.analyze_query("MATCH (n) RETURN n /* CREATE (m) */")
+    assert result == CypherOperationType.READ
+
+  def test_in_string_marker_does_not_hide_admin_verb(self, analyzer):
+    # The same ordering flaw weakened is_admin/is_bulk/is_schema_ddl.
+    assert analyzer.is_admin_operation("MATCH (n) WHERE n.x = '//' ATTACH 'db'") is True
+    assert (
+      analyzer.is_bulk_operation("MATCH (n) WHERE n.x = '//' LOAD FROM 'f'") is True
+    )


### PR DESCRIPTION
## Summary

Phase 1 of the application-security remediation (`specs/application-security-remediation.md`): the **two High findings**, both authorization/validation gaps that let an *authorized-but-under-privileged* principal do more than their grant allows. Launch-relevant — RoboLedger's multi-user graph sharing invites an outside accountant/auditor onto a graph at a role, and the read-only `viewer` promise was not kept. No cross-tenant leak (isolation holds); this closes the intra-graph privilege gaps.

## Findings closed

### F1 (High) — read-only `viewer` could write the whole OLTP command surface
Write-intent defaulted to **read**, so a viewer reached `delete/update-journal-entry`, `close/reopen-period`, `execute-event-block` (posts GL + can trigger QuickBooks write-back), the block/mapping/agent writes, and the content-op document/memory writes — on **both** MCP and REST.

- **MCP** (`routers/graphs/mcp/execute.py`): only 3 tool names were flagged as writes; everything else (incl. all registrar-generated OLTP command ops) fell through to `access_type="read"`, so `validate_mcp_access` ran only the membership check a viewer passes. Inverted to a **fail-closed read-only allowlist** (`READ_ONLY_MCP_TOOLS`) — anything not a known read is a write and requires the member/admin role. New tools default to write.
- **REST registrar** (`middleware/extensions.py`): every command op mounted with `get_current_user_with_graph` (membership only). Enforce the write role in the generated handler — all extension OLTP ops are commands.
- **Content-ops** (`routers/graphs/content_ops.py`): `_require_graph_write_access` *claimed* "subscription + write role" but only ran the billing/lifecycle gate (which takes no user). Added the real role check, threaded the user, corrected the docstring.
- **Single source of truth**: new `require_graph_write_role(user_id, graph_id)` (`middleware/auth/dependencies.py`) wrapping `GraphUser.user_has_write_access`, called by both REST command surfaces; MCP enforces the same via `validate_mcp_access(..., "write")`.
- Analytical **view** reads (`build-fact-grid`) are hand-written, not registrar-mounted → viewers keep read access (no regression).

### F2 (High) — cypher write-detection bypass via in-string comment marker
`cypher_analyzer._clean_query` stripped comments **before** strings, so a `//` (or `/*`) *inside a string literal* made the comment stripper eat a real write keyword after the closed string — `MATCH (n) WHERE n.x = '//' CREATE (m) RETURN m` classified as READ, skipping the read-only rule + the viewer write check on `/query/cypher`, MCP `read-graph-cypher`, and the Operator path. Replaced the strip-comments-then-strings staging with a **single left-to-right scanner** that decides string/comment/identifier context at each position; fail-closed default unchanged. All four Appendix-B PoC payloads now classify WRITE.

### F11 (Low, bundled) — MCP `update-document` bypassed the 500k content cap
Enforced the cap in `DocumentService.update_document` (the kernel) so create/REST/MCP all get it.

## Testing

- `just test-code` green throughout (ruff/format/basedpyright 0/0/0).
- New coverage: `require_graph_write_role` (viewer 403 / member ok); fail-closed classifier (dangerous writes not on the read allowlist, core reads are, cypher-read excluded); registrar handler denies a viewer; F2 PoC payloads + read-side sanity; `update_document` oversized-content cap.
- Blast-radius suites pass: cypher-analyzer 59, extensions 69, graphs/mcp 97, extensions-middleware 58, mcp 609, auth-deps 58, doc-service 14, content-ops 12, roboledger/roboinvestor ops + views.
- Registrar wiring suites get an autouse no-op of the write-role gate (their mock users have no DB-backed `GraphUser` row); a dedicated viewer-denied test asserts the gate fires.

## Follow-ups (not in this PR)

- **F1 residual**: hand-written graph-lifecycle ops in `operations.py` (`materialize` / `set-write-policy` / `create-subgraph`) are covered on MCP by the classifier but still lack a REST-direct write-role check (lower severity than the ledger mutation closed here).
- **Phase 2 (Mediums)**: F3 SSO-token-as-bearer, F4 graph_api engine blocklist, F5 streaming timeout/row-cap, F6 `--forwarded-allow-ips` — separate PR.
