### PR TITLE
fix(security): appsec phase 2 — mediums (F3–F6) + Phase-1 carry-overs

### DIFF
--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -180,13 +180,22 @@ configure_dagster() {
 case $DOCKER_PROFILE in
   "api")
     echo "Starting API service..."
+    # F6: --proxy-headers alone trusts X-Forwarded-For from ANY peer only when
+    # --forwarded-allow-ips permits it; uvicorn defaults that allow-list to
+    # 127.0.0.1, so behind the ALB every external client collapses to the ALB's
+    # IP and the per-IP / brute-force limiters degrade to one shared bucket.
+    # Set FORWARDED_ALLOW_IPS to the ALB/VPC CIDR (e.g. "10.0.0.0/16") so the
+    # real client IP is recovered. NEVER set it to "*" — that lets any caller
+    # spoof X-Forwarded-For and fully bypass brute-force protection. Default
+    # stays 127.0.0.1 (behavior-preserving) until the deployment sets the CIDR.
     exec uv run uvicorn main:app \
       --host 0.0.0.0 \
       --port 8000 \
       --loop uvloop \
       --http httptools \
       --access-log \
-      --proxy-headers
+      --proxy-headers \
+      --forwarded-allow-ips "${FORWARDED_ALLOW_IPS:-127.0.0.1}"
     ;;
   "dagster")
     echo "Starting Dagster webserver..."

--- a/cloudformation/api.yaml
+++ b/cloudformation/api.yaml
@@ -686,6 +686,12 @@ Resources:
             # AWS & Container Configuration
             - Name: AWS_REGION
               Value: !Ref AWS::Region
+            # Trust X-Forwarded-For only from inside the VPC (the ALB), so the
+            # per-IP / brute-force limiters see the real client IP instead of
+            # collapsing to the ALB's address (appsec F6). Scoped to the VPC
+            # CIDR — never "*", which would let any caller spoof the header.
+            - Name: FORWARDED_ALLOW_IPS
+              Value: !Ref VpcCidr
             # Cache & Message Queue Configuration
             - Name: VALKEY_URL
               Value: !Ref ValkeyUrl

--- a/robosystems/graph_api/core/ladybug/service.py
+++ b/robosystems/graph_api/core/ladybug/service.py
@@ -166,6 +166,14 @@ def _extract_column_aliases_from_cypher(cypher_query: str) -> list[str]:
     return []
 
 
+# Hard backstop on rows pulled from a single streaming query (F5). Streaming is
+# the large-export path (100x the non-streaming 10k cap), but an unbounded
+# cartesian/variable-length query would otherwise pin an instance pulling rows
+# forever. When hit, the stream stops and the final chunk is flagged `truncated`
+# so the client can detect it and paginate rather than silently losing data.
+MAX_STREAMING_ROWS = 1_000_000
+
+
 def validate_cypher_query(cypher: str) -> None:
   """
   Validate Cypher query for basic safety checks.
@@ -205,6 +213,32 @@ def validate_cypher_query(cypher: str) -> None:
         status_code=status.HTTP_403_FORBIDDEN,
         detail=f"Query contains forbidden keyword: {keyword}",
       )
+
+  # Engine-adjacent hardening (F4): the substring blocklist above misses
+  # LadybugDB/Kuzu's real filesystem/cross-database verbs (LOAD FROM, COPY,
+  # ATTACH, INSTALL, CREATE NODE TABLE) and is trivially evadable. graph_api is
+  # the process holding the embedded engine with disk access; if this path is
+  # reached without the platform kernel (SSRF, misconfig, a future internal
+  # caller), those verbs become arbitrary file read / cross-db read. Reuse the
+  # shared analyzer's tokenizer-based predicates (same ones the MCP write-query
+  # guard uses) as a defense-in-depth backstop. Ordinary graph writes
+  # (CREATE/SET/MERGE/DELETE) stay allowed so writer instances still work;
+  # legitimate DDL/bulk load runs through the dedicated schema-install and
+  # table-materialize paths, which never reach this validator.
+  from robosystems.security.cypher_analyzer import (
+    is_admin_operation,
+    is_bulk_operation,
+    is_schema_ddl,
+  )
+
+  if is_bulk_operation(cypher) or is_admin_operation(cypher) or is_schema_ddl(cypher):
+    raise HTTPException(
+      status_code=status.HTTP_403_FORBIDDEN,
+      detail=(
+        "Query contains an engine-level operation (bulk load, attach/install, "
+        "or schema DDL) that is not permitted on the ad-hoc query endpoint."
+      ),
+    )
 
   # Check query length
   max_query_length = MAX_QUERY_LENGTH
@@ -328,10 +362,37 @@ class LadybugService:
         ) as conn:
           # Execute query with comprehensive error handling
           try:
-            if request.parameters:
-              query_result = conn.execute(translated_cypher, request.parameters)
-            else:
-              query_result = conn.execute(translated_cypher)
+            # F5: bound query planning/execution with a thread-based timeout,
+            # mirroring the non-streaming path. Cancelling the HTTP coroutine
+            # does not stop the engine server-side, so without this an
+            # expensive streaming query could pin the instance.
+            query_timeout = TuningConfig.get_graph_query_timeout()
+
+            def _execute_streaming():
+              if request.parameters:
+                return conn.execute(translated_cypher, request.parameters)
+              return conn.execute(translated_cypher)
+
+            with ThreadPoolExecutor(max_workers=1) as executor:
+              future = executor.submit(_execute_streaming)
+              try:
+                query_result = future.result(timeout=query_timeout)
+              except TimeoutError:
+                future.cancel()
+                logger.warning(
+                  f"Streaming query timeout for {validated_graph_id} "
+                  f"after {query_timeout} seconds"
+                )
+                yield {
+                  "error": f"Query execution timeout ({query_timeout} seconds)",
+                  "error_type": "QueryTimeout",
+                  "chunk_index": 0,
+                  "is_last_chunk": True,
+                  "row_count": 0,
+                  "total_rows_sent": 0,
+                  "execution_time_ms": (time.time() - start_time) * 1000,
+                }
+                return
 
             # Handle case where execute returns a list of QueryResults
             if isinstance(query_result, list):
@@ -433,8 +494,15 @@ class LadybugService:
         chunk_index = 0
         total_rows_sent = 0
         rows_buffer = []
+        truncated = False
 
         while query_result.has_next():
+          # F5: hard row backstop so an unbounded query can't stream forever.
+          if total_rows_sent + len(rows_buffer) >= MAX_STREAMING_ROWS:
+            truncated = True
+            if hasattr(query_result, "close"):
+              query_result.close()
+            break
           row = query_result.get_next()
 
           # Convert row to dict
@@ -467,8 +535,10 @@ class LadybugService:
             total_rows_sent += len(rows_buffer)
             rows_buffer = []
 
-        # Yield final chunk with remaining rows
-        if rows_buffer or chunk_index == 0:  # Always send at least one chunk
+        # Yield final chunk with remaining rows. Always send at least one chunk,
+        # and always send a closing chunk when truncated so the client sees the
+        # flag even if the cap landed exactly on a chunk boundary (empty buffer).
+        if rows_buffer or chunk_index == 0 or truncated:
           execution_time = (time.time() - start_time) * 1000
           chunk_data = {
             "chunk_index": chunk_index,
@@ -479,6 +549,7 @@ class LadybugService:
             "total_rows_sent": total_rows_sent + len(rows_buffer),
             "execution_time_ms": execution_time,
             "database": validated_graph_id,
+            "truncated": truncated,
           }
           yield chunk_data
 

--- a/robosystems/middleware/auth/dependencies.py
+++ b/robosystems/middleware/auth/dependencies.py
@@ -479,6 +479,15 @@ def require_graph_write_role(user_id: str, graph_id: str) -> None:
   session = SessionFactory()
   try:
     if not GraphUser.user_has_write_access(user_id, graph_id, session):
+      # Audit every under-privileged write attempt from the one shared gate:
+      # this covers MCP, the REST registrar, content-ops, and the hand-written
+      # lifecycle ops, and emits the `AuthorizationDenied` detective-control
+      # metric. (No request context here — this is a plain helper, not a dep.)
+      from robosystems.security import SecurityAuditLogger
+
+      SecurityAuditLogger.log_authorization_denied(
+        user_id=user_id, resource=graph_id, action="write"
+      )
       raise HTTPException(
         status_code=status.HTTP_403_FORBIDDEN,
         detail=f"Write access denied to graph {graph_id}; your role is read-only.",

--- a/robosystems/middleware/auth/jwt.py
+++ b/robosystems/middleware/auth/jwt.py
@@ -188,6 +188,18 @@ def verify_jwt_claims(
       audience=env.JWT_AUDIENCE,
     )
 
+    # F3: single-use SSO handoff tokens (`create_sso_token`: {"sso": true},
+    # no jti, unrevocable) must never authenticate as a full session bearer.
+    # They are consumed only at /sso-exchange, which decodes them directly —
+    # not through this function. Reject `sso` here, and reject any non-`access`
+    # token type so a future purpose-scoped token (e.g. an SSE stream token)
+    # can't be replayed as a session bearer. Legacy session tokens minted
+    # before the `type` claim existed have no `type` and are grandfathered.
+    token_type = payload.get("type")
+    if payload.get("sso") or (token_type is not None and token_type != "access"):
+      logger.info("JWT token verification failed: non-access token presented as bearer")
+      return None
+
     # Verify device fingerprint if both token and request fingerprint are available
     if device_fingerprint and payload.get("device_hash"):
       from ...security.device_fingerprinting import create_device_hash
@@ -249,6 +261,7 @@ def create_jwt_token(
   payload = {
     "user_id": user_id,
     "jti": jti,  # JWT ID for revocation tracking
+    "type": "access",  # Session bearer — distinguishes from single-use `sso` tokens
     "session_version": _get_user_session_version(user_id, session=session) or 0,
     "exp": datetime.now(UTC) + timedelta(hours=JWT_EXPIRY_HOURS),
     "iat": datetime.now(UTC),

--- a/robosystems/middleware/auth/jwt.py
+++ b/robosystems/middleware/auth/jwt.py
@@ -198,6 +198,20 @@ def verify_jwt_claims(
     token_type = payload.get("type")
     if payload.get("sso") or (token_type is not None and token_type != "access"):
       logger.info("JWT token verification failed: non-access token presented as bearer")
+      # A signature-valid but wrong-purpose token used as a bearer is a distinct
+      # signal (possible replay of a leaked single-use SSO handoff) that the
+      # generic AUTH_TOKEN_INVALID at the caller would otherwise bury.
+      from ...security import SecurityAuditLogger, SecurityEventType
+
+      SecurityAuditLogger.log_security_event(
+        event_type=SecurityEventType.SUSPICIOUS_ACTIVITY,
+        user_id=payload.get("user_id"),
+        details={
+          "reason": "non_access_token_as_bearer",
+          "token_type": "sso" if payload.get("sso") else token_type,
+        },
+        risk_level="high",
+      )
       return None
 
     # Verify device fingerprint if both token and request fingerprint are available

--- a/robosystems/middleware/extensions.py
+++ b/robosystems/middleware/extensions.py
@@ -437,16 +437,17 @@ class OperationRegistrar:
       idempotency_key: str | None = Header(None, alias="Idempotency-Key"),
       cache: IdempotencyCache = Depends(get_idempotency_cache),
     ) -> OperationEnvelope:
+      # Every registrar op is a command (write). The extension gate proves
+      # provisioning and `user_dep` proves graph membership — neither checks
+      # the write role, so a read-only `viewer` would otherwise reach the
+      # OLTP command surface. Enforce member/admin first, fail-closed, before
+      # running any request-shaping logic for an unauthorized caller.
+      require_graph_write_role(str(user.id), graph_id)
+
       # Optional pre-validation hook — lets specs do lightweight
       # parse/format checks before we open a DB session.
       if pre_validate is not None:
         pre_validate(body)
-
-      # Every registrar op is a command (write). The extension gate proves
-      # provisioning and `user_dep` proves graph membership — neither checks
-      # the write role, so a read-only `viewer` would otherwise reach the
-      # OLTP command surface. Enforce member/admin here, fail-closed.
-      require_graph_write_role(str(user.id), graph_id)
 
       ctx = ctx_builder(
         graph_id=graph_id,

--- a/robosystems/middleware/mcp/tools/registrar.py
+++ b/robosystems/middleware/mcp/tools/registrar.py
@@ -410,6 +410,12 @@ class _RegistrarMCPTool(BaseTool):
     self._log_tool_execution(self.spec.name, arguments)
     graph_id = self.client.graph_id
 
+    # Write-role authorization (member/admin, fail-closed) is enforced upstream
+    # at the MCP dispatch boundary in `execute.py`'s `validate_mcp_access`:
+    # every registrar op is a write, so it is absent from `READ_ONLY_MCP_TOOLS`
+    # and classified as a write there. This layer has no `current_user`, so the
+    # check cannot be repeated here — it is a single enforcement point by design.
+
     # ── 1. Feature gate ─────────────────────────────────────────────────
     try:
       pre_loaded = self._meta_getter() if self._meta_getter else None

--- a/robosystems/routers/graphs/connections/management.py
+++ b/robosystems/routers/graphs/connections/management.py
@@ -9,7 +9,10 @@ from sqlalchemy.orm import Session
 
 from robosystems.database import get_db_session
 from robosystems.logger import logger
-from robosystems.middleware.auth.dependencies import get_current_user_with_graph
+from robosystems.middleware.auth.dependencies import (
+  get_current_user_with_graph,
+  require_graph_write_role,
+)
 from robosystems.middleware.graph.types import GRAPH_OR_SUBGRAPH_ID_PATTERN
 from robosystems.middleware.rate_limits import subscription_aware_rate_limit_dependency
 from robosystems.models.api.common import (
@@ -383,6 +386,11 @@ async def set_connection_write_policy(
   db: Session = Depends(get_db_session),
   _rate_limit: None = Depends(subscription_aware_rate_limit_dependency),
 ) -> ConnectionResponse:
+  # `get_current_user_with_graph` proves graph membership only. Opting a
+  # connection into outbound write-back (e.g. QuickBooks) is a privileged
+  # mutation — a read-only `viewer` must not reach it. Enforce member/admin.
+  require_graph_write_role(str(current_user.id), graph_id)
+
   try:
     connection = await ConnectionService.set_write_policy(
       connection_id=connection_id,

--- a/robosystems/routers/graphs/operations.py
+++ b/robosystems/routers/graphs/operations.py
@@ -22,7 +22,10 @@ from sqlalchemy.orm import Session
 
 from robosystems.database import get_async_db_session
 from robosystems.logger import get_logger
-from robosystems.middleware.auth.dependencies import get_current_user_with_graph
+from robosystems.middleware.auth.dependencies import (
+  get_current_user_with_graph,
+  require_graph_write_role,
+)
 from robosystems.middleware.graph.types import GRAPH_OR_SUBGRAPH_ID_PATTERN
 from robosystems.middleware.operations import (
   IdempotencyCache,
@@ -121,6 +124,10 @@ async def create_subgraph_op(
 
   op_name = "create-subgraph"
   user_id = str(user.id)
+
+  # `get_current_user_with_graph` proves graph membership only; a read-only
+  # `viewer` would otherwise reach this write. Enforce member/admin, fail-closed.
+  require_graph_write_role(user_id, graph_id)
 
   if body.fork_parent:
     # Async path — enqueue worker task, return pending envelope
@@ -876,6 +883,11 @@ async def materialize_op(
 
   op_name = "materialize"
   user_id = str(user.id)
+
+  # `get_current_user_with_graph` proves graph membership only; a read-only
+  # `viewer` would otherwise reach this write. Enforce member/admin, fail-closed.
+  require_graph_write_role(user_id, graph_id)
+
   body_fp = fingerprint_body(body)
 
   replay = await check_idempotency(

--- a/tests/graph_api/core/ladybug/test_service.py
+++ b/tests/graph_api/core/ladybug/test_service.py
@@ -203,6 +203,50 @@ class TestValidateCypherQuery:
     validate_cypher_query(query)  # Should not raise
 
 
+@pytest.mark.unit
+class TestValidateCypherQueryEngineVerbs:
+  """F4: engine-adjacent verbs (bulk load / attach / install / schema DDL) are
+  blocked via the shared analyzer, while ordinary graph writes still pass so
+  writer instances keep working."""
+
+  @pytest.mark.parametrize(
+    "ordinary_write",
+    [
+      "MATCH (n:Person) RETURN n.name",
+      "CREATE (n:Foo {id: 1}) RETURN n",
+      "MATCH (n:Foo) SET n.x = 2 RETURN n",
+      "MERGE (n:Foo {id: 1}) RETURN n",
+      "MATCH (n:Foo) DETACH DELETE n",
+    ],
+  )
+  def test_ordinary_reads_and_writes_pass(self, ordinary_write):
+    """Reads and node/relationship writes are not engine-level operations."""
+    validate_cypher_query(ordinary_write)  # Should not raise
+
+  @pytest.mark.parametrize(
+    "engine_verb",
+    [
+      "LOAD FROM '/etc/passwd' RETURN *",
+      "COPY Person FROM '/tmp/data.csv'",
+      "ATTACH '/other/db.kuzu' AS other",
+      "INSTALL httpfs",
+      "CREATE NODE TABLE Evil(id INT64, PRIMARY KEY(id))",
+      "CREATE REL TABLE Knows(FROM Person TO Person)",
+    ],
+  )
+  def test_engine_verbs_raise_403(self, engine_verb):
+    """Bulk / admin / schema-DDL verbs are rejected on the ad-hoc endpoint."""
+    with pytest.raises(HTTPException) as exc_info:
+      validate_cypher_query(engine_verb)
+    assert exc_info.value.status_code == 403
+
+  def test_in_string_comment_marker_cannot_hide_engine_verb(self):
+    """F2 + F4 compose: an in-string `//` must not mask a trailing COPY."""
+    with pytest.raises(HTTPException) as exc_info:
+      validate_cypher_query("MATCH (n) WHERE n.note = '//' COPY t FROM '/x'")
+    assert exc_info.value.status_code == 403
+
+
 # ---------------------------------------------------------------------------
 # _raise_database_not_found
 # ---------------------------------------------------------------------------
@@ -814,6 +858,98 @@ class TestLadybugServiceStreamingQuery:
       with pytest.raises(HTTPException) as exc_info:
         list(service.execute_query_streaming(request))
       assert exc_info.value.status_code == 404
+
+  def _wire_streaming_result(self, service, mock_query_result):
+    """Attach a mock query result to the service's connection for streaming."""
+    mock_conn = MagicMock()
+    mock_conn.execute.return_value = mock_query_result
+    service.db_manager.list_databases.return_value = ["test_db"]
+    service.db_manager.get_connection.return_value.__enter__ = MagicMock(
+      return_value=mock_conn
+    )
+    service.db_manager.get_connection.return_value.__exit__ = MagicMock(
+      return_value=False
+    )
+
+  def test_streaming_row_cap_truncates(self, service):
+    """F5: pulling past MAX_STREAMING_ROWS stops the stream and flags truncated."""
+    from robosystems.graph_api.models.database import QueryRequest
+
+    mock_query_result = MagicMock()
+    mock_query_result.get_schema.return_value = {"n": "INT64"}
+    mock_query_result.has_next.return_value = True  # effectively unbounded
+    counter = [0]
+
+    def _get_next():
+      counter[0] += 1
+      return (counter[0],)
+
+    mock_query_result.get_next.side_effect = _get_next
+    self._wire_streaming_result(service, mock_query_result)
+
+    request = QueryRequest(database="test_db", cypher="MATCH (n) RETURN n")
+    with patch(f"{SERVICE_MODULE}.MAX_STREAMING_ROWS", 4):
+      chunks = list(service.execute_query_streaming(request, chunk_size=2))
+
+    last = chunks[-1]
+    assert last["is_last_chunk"] is True
+    assert last["truncated"] is True
+    delivered = sum(c.get("row_count", 0) for c in chunks if "error" not in c)
+    assert delivered == 4  # capped at MAX_STREAMING_ROWS, not unbounded
+    mock_query_result.close.assert_called_once()
+
+  def test_streaming_under_cap_is_not_truncated(self, service):
+    """A finite result under the cap streams fully and is not flagged."""
+    from robosystems.graph_api.models.database import QueryRequest
+
+    mock_query_result = MagicMock()
+    mock_query_result.get_schema.return_value = {"n": "INT64"}
+    rows = [(i,) for i in range(3)]
+    idx = [0]
+
+    def _has_next():
+      return idx[0] < len(rows)
+
+    def _get_next():
+      row = rows[idx[0]]
+      idx[0] += 1
+      return row
+
+    mock_query_result.has_next.side_effect = _has_next
+    mock_query_result.get_next.side_effect = _get_next
+    self._wire_streaming_result(service, mock_query_result)
+
+    request = QueryRequest(database="test_db", cypher="MATCH (n) RETURN n")
+    chunks = list(service.execute_query_streaming(request, chunk_size=2))
+
+    assert chunks[-1]["truncated"] is False
+    delivered = sum(c.get("row_count", 0) for c in chunks if "error" not in c)
+    assert delivered == 3
+
+  def test_streaming_timeout_yields_timeout_chunk(self, service):
+    """F5: a query that exceeds the timeout yields a QueryTimeout error chunk."""
+    from robosystems.graph_api.models.database import QueryRequest
+
+    self._wire_streaming_result(service, MagicMock())
+
+    request = QueryRequest(database="test_db", cypher="MATCH (n) RETURN n")
+    with (
+      patch(f"{SERVICE_MODULE}.TuningConfig") as mock_tuning,
+      patch(f"{SERVICE_MODULE}.ThreadPoolExecutor") as MockExecutor,
+    ):
+      mock_tuning.get_graph_query_timeout.return_value = 5
+      mock_executor = MagicMock()
+      MockExecutor.return_value.__enter__ = MagicMock(return_value=mock_executor)
+      MockExecutor.return_value.__exit__ = MagicMock(return_value=False)
+      mock_future = MagicMock()
+      mock_future.result.side_effect = TimeoutError()
+      mock_executor.submit.return_value = mock_future
+
+      chunks = list(service.execute_query_streaming(request))
+
+    assert len(chunks) == 1
+    assert chunks[0]["error_type"] == "QueryTimeout"
+    assert chunks[0]["is_last_chunk"] is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/middleware/auth/test_dependencies.py
+++ b/tests/middleware/auth/test_dependencies.py
@@ -1297,6 +1297,24 @@ class TestRequireGraphWriteRole:
       assert exc.value.status_code == status.HTTP_403_FORBIDDEN
       assert "read-only" in exc.value.detail
 
+  def test_viewer_denial_is_audited(self):
+    """The shared gate emits an authorization-denied audit event."""
+    with (
+      patch("robosystems.database.SessionFactory", return_value=Mock()),
+      patch(
+        "robosystems.models.core.GraphUser.user_has_write_access",
+        return_value=False,
+      ),
+      patch(
+        "robosystems.security.SecurityAuditLogger.log_authorization_denied"
+      ) as mock_audit,
+    ):
+      with pytest.raises(HTTPException):
+        require_graph_write_role("user_1", "kg0123456789abcdef")
+      mock_audit.assert_called_once_with(
+        user_id="user_1", resource="kg0123456789abcdef", action="write"
+      )
+
   def test_write_role_allowed(self):
     with (
       patch("robosystems.database.SessionFactory", return_value=Mock()),

--- a/tests/routers/auth/test_jwt_token_type.py
+++ b/tests/routers/auth/test_jwt_token_type.py
@@ -1,0 +1,96 @@
+"""F3: token-type enforcement in verify_jwt_claims.
+
+Single-use SSO handoff tokens (``create_sso_token`` → {"sso": true}, no jti,
+unrevocable) must never authenticate as a full session bearer. They are
+consumed only at /sso-exchange, which decodes them directly. Session tokens
+carry ``type: "access"``; legacy tokens minted before that claim existed are
+grandfathered so a deploy doesn't invalidate active sessions.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import jwt
+import pytest
+
+from robosystems.config import env
+from robosystems.middleware.auth.jwt import (
+  create_jwt_token,
+  create_sso_token,
+  verify_jwt_claims,
+)
+
+
+@pytest.mark.unit
+class TestJWTTokenType:
+  @pytest.fixture(autouse=True)
+  def _stub_session_version(self):
+    with patch(
+      "robosystems.middleware.auth.jwt._get_user_session_version", return_value=0
+    ):
+      yield
+
+  @pytest.fixture(autouse=True)
+  def _redis_not_revoked(self):
+    """is_jwt_token_revoked() reads Redis; return an empty hash (not revoked)."""
+    mock_redis = MagicMock()
+    mock_redis.hgetall.return_value = {}
+    with patch(
+      "robosystems.middleware.auth.jwt.get_redis_client", return_value=mock_redis
+    ):
+      yield
+
+  def _encode(self, **overrides) -> str:
+    """Mint a raw token with the standard claims, minus/plus overrides."""
+    payload = {
+      "user_id": "usr_1",
+      "session_version": 0,
+      "iss": env.JWT_ISSUER,
+      "aud": env.JWT_AUDIENCE,
+    }
+    payload.update(overrides)
+    return jwt.encode(payload, env.JWT_SECRET_KEY, algorithm="HS256")
+
+  def test_create_jwt_token_embeds_access_type(self):
+    token = create_jwt_token("usr_1")
+    payload = jwt.decode(
+      token,
+      env.JWT_SECRET_KEY,
+      algorithms=["HS256"],
+      options={"verify_exp": False, "verify_aud": False, "verify_iss": False},
+    )
+    assert payload["type"] == "access"
+
+  def test_access_token_is_accepted(self):
+    token = create_jwt_token("usr_1")
+    result = verify_jwt_claims(token)
+    assert result is not None
+    assert result[0] == "usr_1"
+
+  def test_sso_token_is_rejected_as_bearer(self):
+    token, _token_id = create_sso_token("usr_1")
+    # The SSO token is valid at /sso-exchange, but must not pass the general
+    # bearer verification path.
+    assert verify_jwt_claims(token) is None
+
+  def test_legacy_token_without_type_is_grandfathered(self):
+    from datetime import UTC, datetime, timedelta
+
+    # A session token minted before the `type` claim existed — no `type`, no
+    # `sso`. Must still authenticate so a deploy doesn't log everyone out.
+    token = self._encode(
+      exp=datetime.now(UTC) + timedelta(hours=1),
+      iat=datetime.now(UTC),
+    )
+    result = verify_jwt_claims(token)
+    assert result is not None
+    assert result[0] == "usr_1"
+
+  def test_non_access_type_is_rejected(self):
+    from datetime import UTC, datetime, timedelta
+
+    token = self._encode(
+      type="stream",
+      exp=datetime.now(UTC) + timedelta(hours=1),
+      iat=datetime.now(UTC),
+    )
+    assert verify_jwt_claims(token) is None

--- a/tests/routers/auth/test_jwt_token_type.py
+++ b/tests/routers/auth/test_jwt_token_type.py
@@ -72,6 +72,17 @@ class TestJWTTokenType:
     # bearer verification path.
     assert verify_jwt_claims(token) is None
 
+  def test_sso_bearer_rejection_is_audited(self):
+    token, _token_id = create_sso_token("usr_1")
+    with patch(
+      "robosystems.security.SecurityAuditLogger.log_security_event"
+    ) as mock_audit:
+      assert verify_jwt_claims(token) is None
+    assert mock_audit.call_count == 1
+    kwargs = mock_audit.call_args.kwargs
+    assert kwargs["details"]["reason"] == "non_access_token_as_bearer"
+    assert kwargs["details"]["token_type"] == "sso"
+
   def test_legacy_token_without_type_is_grandfathered(self):
     from datetime import UTC, datetime, timedelta
 

--- a/tests/routers/graphs/connections/test_management.py
+++ b/tests/routers/graphs/connections/test_management.py
@@ -1010,6 +1010,14 @@ class TestDeleteConnection:
 class TestSetConnectionWritePolicy:
   """Tests for the set_connection_write_policy endpoint."""
 
+  @pytest.fixture(autouse=True)
+  def _bypass_write_role(self):
+    """These tests use synthetic users with no GraphUser row, so the write-role
+    gate (F1) would 403 before reaching handler logic. The deny path is covered
+    in tests/routers/graphs/test_write_role_gates.py; bypass it here."""
+    with patch(f"{MANAGEMENT_MODULE}.require_graph_write_role"):
+      yield
+
   def _request(self, write_policy: str = "qb_authoritative"):
     from robosystems.models.api.graphs.connections import SetWritePolicyRequest
 

--- a/tests/routers/graphs/test_feature_flags.py
+++ b/tests/routers/graphs/test_feature_flags.py
@@ -403,8 +403,15 @@ class TestGraphOperationFeatureFlags:
         "SUBGRAPH_CREATION_ENABLED",
         False,
       ):
-        with patch(
-          "robosystems.routers.graphs.subgraphs.main.handle_circuit_breaker_check"
+        with (
+          patch(
+            "robosystems.routers.graphs.subgraphs.main.handle_circuit_breaker_check"
+          ),
+          # Isolate the feature-flag assertion from the write-role gate: this
+          # test simulates an authorized (write) user hitting a disabled
+          # feature, so the gate must pass to reach the SUBGRAPH_CREATION_ENABLED
+          # check. The gate itself is covered by test_write_role_gates.py.
+          patch("robosystems.routers.graphs.operations.require_graph_write_role"),
         ):
           request_data = {
             "name": "testsubgraph",
@@ -477,6 +484,9 @@ class TestGraphOperationFeatureFlags:
           patch(
             "robosystems.routers.graphs.subgraphs.main.handle_circuit_breaker_check"
           ),
+          # Pass the write-role gate deterministically (don't rely on leaked
+          # DB state); this test asserts the feature-enabled path, not authz.
+          patch("robosystems.routers.graphs.operations.require_graph_write_role"),
           patch(
             "robosystems.routers.graphs.subgraphs.main.verify_parent_graph_access"
           ) as mock_verify_access,

--- a/tests/routers/graphs/test_write_role_gates.py
+++ b/tests/routers/graphs/test_write_role_gates.py
@@ -1,0 +1,87 @@
+"""Carry-over (a): the F1 fail-closed write-role gate is wired into the
+hand-written REST lifecycle ops that authenticate on graph membership only.
+
+`require_graph_write_role` itself is unit-tested in
+tests/middleware/auth/test_dependencies.py; these assert each call site invokes
+it with the right args and short-circuits (fail-closed) before doing any work,
+so a read-only `viewer` cannot materialize, create a subgraph, or flip a
+connection's outbound write policy.
+"""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+OPS = "robosystems.routers.graphs.operations"
+MGMT = "robosystems.routers.graphs.connections.management"
+
+
+def _deny_gate() -> MagicMock:
+  return MagicMock(
+    side_effect=HTTPException(status_code=403, detail="Write access denied")
+  )
+
+
+@pytest.mark.unit
+class TestLifecycleWriteRoleGates:
+  def test_materialize_denies_viewer(self):
+    from robosystems.routers.graphs.operations import materialize_op
+
+    gate = _deny_gate()
+    with patch(f"{OPS}.require_graph_write_role", gate):
+      with pytest.raises(HTTPException) as exc:
+        asyncio.run(
+          materialize_op(
+            body=MagicMock(),
+            graph_id="kg123",
+            user=SimpleNamespace(id="usr_1"),
+            idempotency_key=None,
+            cache=MagicMock(),
+            db=MagicMock(),
+          )
+        )
+    assert exc.value.status_code == 403
+    gate.assert_called_once_with("usr_1", "kg123")
+
+  def test_create_subgraph_denies_viewer(self):
+    from robosystems.routers.graphs.operations import create_subgraph_op
+
+    gate = _deny_gate()
+    with patch(f"{OPS}.require_graph_write_role", gate):
+      with pytest.raises(HTTPException) as exc:
+        asyncio.run(
+          create_subgraph_op(
+            body=MagicMock(),
+            graph_id="kg123",
+            user=SimpleNamespace(id="usr_1"),
+            idempotency_key=None,
+            cache=MagicMock(),
+            db=MagicMock(),
+          )
+        )
+    assert exc.value.status_code == 403
+    gate.assert_called_once_with("usr_1", "kg123")
+
+  def test_set_write_policy_denies_viewer(self):
+    from robosystems.routers.graphs.connections.management import (
+      set_connection_write_policy,
+    )
+
+    gate = _deny_gate()
+    with patch(f"{MGMT}.require_graph_write_role", gate):
+      with pytest.raises(HTTPException) as exc:
+        asyncio.run(
+          set_connection_write_policy(
+            graph_id="kg123",
+            connection_id="conn_1",
+            request=MagicMock(),
+            current_user=SimpleNamespace(id="usr_1"),
+            db=MagicMock(),
+            _rate_limit=None,
+          )
+        )
+    assert exc.value.status_code == 403
+    gate.assert_called_once_with("usr_1", "kg123")


### PR DESCRIPTION
## Summary

Phase 2 of the application-security remediation (`application-security-remediation.md`): closes the four **Medium** findings from the 2026-07-10 review, plus the carry-overs deferred from the Phase-1 (High) PR #850. No cross-tenant issues — these are authorization/validation/DoS-hardening gaps on the query and command surfaces.

## Changes

### F3 — SSO handoff token accepted as a full bearer (`middleware/auth/jwt.py`)
- `verify_jwt_claims` now rejects any token with `sso` truthy or a non-`access` `type`; `create_jwt_token` stamps `type:"access"`.
- Legacy session tokens with no `type` are **grandfathered** (no logout storm on deploy).
- `/sso-exchange` decodes SSO tokens independently, so the SSO flow is unaffected — **verified no frontend impact** (all three apps hand the SSO token to `/sso-exchange` in the request body, never as a bearer).

### F4 — graph_api engine-adjacent blocklist (`graph_api/core/ladybug/service.py`)
- `validate_cypher_query` now enforces the shared `cypher_analyzer` predicates (`is_bulk_operation`/`is_admin_operation`/`is_schema_ddl`) to block `LOAD`/`COPY`/`ATTACH`/`INSTALL`/`CREATE NODE TABLE` on the ad-hoc query endpoint (mirrors the MCP write-query guard).
- Ordinary graph writes (`CREATE`/`SET`/`MERGE`/`DELETE`) still pass so writer instances work; legitimate DDL/bulk-load runs through the schema-install / table-materialize paths, which never reach this validator.

### F5 — streaming query DoS (`graph_api/core/ladybug/service.py`)
- `execute_query_streaming` gets a thread-based timeout on the initial execute (yields a `QueryTimeout` chunk), mirroring the non-streaming path.
- Adds a `MAX_STREAMING_ROWS` backstop that stops the stream and flags the final chunk `truncated` (so clients can detect and paginate).

### F6 — rate-limit IP collapse behind the ALB (`bin/entrypoint.sh`)
- uvicorn now passes `--forwarded-allow-ips "${FORWARDED_ALLOW_IPS:-127.0.0.1}"` (behavior-preserving default).
- `cloudformation/api.yaml` sets `FORWARDED_ALLOW_IPS` on the API container to `!Ref VpcCidr` (VPC CIDR, default `10.0.0.0/16`) — scoped to in-VPC callers (the ALB), never `*`. So on deploy the per-IP / brute-force limiters recover the real client IP.

### Phase-1 carry-overs
- **F1 residual:** `require_graph_write_role` gate added to the membership-only REST lifecycle ops — `materialize`, `create-subgraph`, `set-write-policy`. (`change-tier` is already org-owner-gated; `delete-subgraph`/`delete-graph`/`create-backup`/`restore-backup` are already admin-gated.)
- Registrar handler checks write-role **before** `pre_validate` (fail-fast authz).
- Enforcement-point comment on `_RegistrarMCPTool.execute` (MCP write-role is enforced upstream in `execute.py`'s `validate_mcp_access`).

### Audit logging (both new denial paths, for the SOC2 trail)
- `require_graph_write_role` emits `log_authorization_denied` (→ `AuthorizationDenied` detective-control metric) on every under-privileged write attempt across all surfaces.
- `verify_jwt_claims` emits a `SUSPICIOUS_ACTIVITY` (high) event when an `sso`/non-`access` token is presented as a bearer.

## Testing
- New/extended unit tests: F3 token-type (6), F4 engine verbs (12), F5 streaming timeout + row-cap truncation (3), lifecycle write-role wiring (3), audit-event assertions (2); `_bypass_write_role` fixture on the write-policy happy-path tests.
- `just test-code` clean (ruff + format + basedpyright + cf-lint).
- ~800 auth/security/graph_api/extensions-suite tests green locally. Full `just test` needs the local stack — not run in-session.

## Follow-ups
- **Post-deploy (F6):** verify the rate limiter sees the real client IP (not the ALB address) once this ships via the deploy workflow — this is a task-def env change, so CloudFormation auto-cycles the API tasks (no manual ASG refresh).
- Phase 3 (Low/hardening — F7–F10, F12) remains.
