### PR TITLE
fix(security): reject subgraph IDs at the extensions GraphQL surface

### DIFF
--- a/robosystems/graphql/context.py
+++ b/robosystems/graphql/context.py
@@ -78,6 +78,7 @@ from robosystems.middleware.auth.dependencies import (
 )
 from robosystems.middleware.extensions import load_graph_metadata
 from robosystems.middleware.graph.types import GRAPH_OR_SUBGRAPH_ID_PATTERN
+from robosystems.middleware.graph.utils.subgraph import is_subgraph
 from robosystems.models.core import User
 
 
@@ -133,6 +134,10 @@ async def get_context(
        then loaded once and its `schema_extensions` + `graph_type` are
        placed on the context so resolvers can enforce the per-domain
        feature gate via `require_extension` without a second lookup.
+
+  - **Subgraph IDs are rejected (403) regardless of auth** — this is
+    the extensions domain-app surface, not a subgraph modality. See
+    the inline guard below.
   """
   has_credentials = bool(api_key) or bool(request.headers.get("Authorization"))
 
@@ -144,6 +149,33 @@ async def get_context(
       raise
     # No credentials at all → anonymous fallthrough for introspection.
     user = None
+
+  # Subgraph guard: a subgraph is a modality container (scratch/knowledge),
+  # not an extensions domain target — a `{parent}_{name}` graph_id has no
+  # extensions schema, so this surface must reject it outright rather than
+  # resolve subgraph→parent for auth and dead-end in schema resolution.
+  # Placed after auth (bad creds still 401, and denials are attributable)
+  # and before `check_graph_access` (which would resolve to the parent).
+  # NOTE: `is_subgraph` — not a naive non-`kg` reject, which would break the
+  # `library` sentinel and shared repositories.
+  if is_subgraph(graph_id):
+    if user is not None:
+      from robosystems.security import SecurityAuditLogger
+
+      SecurityAuditLogger.log_authorization_denied(
+        user_id=str(user.id),
+        resource=graph_id,
+        action="graphql",
+        ip_address=request.client.host if request.client else None,
+        endpoint=f"/extensions/{graph_id}/graphql",
+      )
+    raise HTTPException(
+      status_code=403,
+      detail=(
+        f"Subgraph '{graph_id}' is not addressable via the extensions "
+        "GraphQL endpoint; target the parent graph."
+      ),
+    )
 
   schema_extensions: tuple[str, ...] = ()
   graph_type: str = ""

--- a/robosystems/middleware/mcp/tools/graphql_tool.py
+++ b/robosystems/middleware/mcp/tools/graphql_tool.py
@@ -300,6 +300,21 @@ class GraphqlQueryTool(BaseTool):
   async def execute(self, arguments: dict[str, Any]) -> dict[str, Any]:
     self._log_tool_execution("query-graphql", arguments)
 
+    # Subgraph guard — mirrors the HTTP surface (`graphql/context.py`):
+    # a subgraph is a modality container, not an extensions domain target,
+    # and has no extensions schema. Reject up front instead of letting
+    # resolvers dead-end (or silently resolve to the parent) downstream.
+    from robosystems.middleware.graph.utils.subgraph import is_subgraph
+
+    if is_subgraph(getattr(self.client, "graph_id", "") or ""):
+      return {
+        "error": "invalid_target",
+        "message": (
+          "query-graphql is not available on subgraphs; switch the "
+          "workspace to the parent graph to use the extensions surface"
+        ),
+      }
+
     query = arguments.get("query", "").strip()
     if not query:
       return {"error": "invalid_query", "message": "query is required"}

--- a/tests/graphql/extensions/test_context.py
+++ b/tests/graphql/extensions/test_context.py
@@ -192,3 +192,148 @@ class TestGetContextAuthContract:
         )
 
     assert exc_info.value.status_code == 403
+
+
+SUBGRAPH_ID = f"{GRAPH_ID}_dev"
+
+
+@pytest.mark.asyncio
+class TestSubgraphGuard:
+  """Subgraph IDs are rejected at the extensions GraphQL surface.
+
+  A subgraph is a modality container (scratch/knowledge), not an
+  extensions domain target — auth must NOT resolve subgraph→parent
+  here, and the rejection applies regardless of authentication. The
+  guard is `is_subgraph`-based, so the `library` sentinel and shared
+  repositories are unaffected (a naive non-`kg` reject would break
+  both).
+  """
+
+  async def test_authenticated_subgraph_id_rejected_and_audited(self):
+    """Authenticated request at a subgraph URL → 403 before any
+    parent-resolving access check, with an audit event."""
+    request = _make_request(headers={})
+    user = MagicMock()
+    user.id = "usr_test"
+
+    with (
+      patch(f"{MODULE}.get_current_user", new_callable=AsyncMock, return_value=user),
+      patch(f"{MODULE}.check_graph_access") as mock_check,
+      patch(f"{MODULE}.load_graph_metadata") as mock_meta,
+      patch(
+        "robosystems.security.SecurityAuditLogger.log_authorization_denied"
+      ) as mock_audit,
+    ):
+      with pytest.raises(HTTPException) as exc_info:
+        await get_context(
+          request=request,
+          api_key="rfs_valid",
+          graph_id=SUBGRAPH_ID,
+          db=MagicMock(),
+        )
+
+    assert exc_info.value.status_code == 403
+    # The guard must fire BEFORE check_graph_access — that helper
+    # resolves subgraph→parent, which is exactly the confusion we're
+    # closing off.
+    mock_check.assert_not_called()
+    mock_meta.assert_not_called()
+    mock_audit.assert_called_once()
+    assert mock_audit.call_args.kwargs["resource"] == SUBGRAPH_ID
+
+  async def test_anonymous_subgraph_id_rejected_without_audit(self):
+    """The address itself is invalid for this surface — introspection
+    does not bypass the guard. Anonymous probes are not audit-logged."""
+    request = _make_request(headers={})
+
+    with (
+      patch(
+        f"{MODULE}.get_current_user",
+        new_callable=AsyncMock,
+        side_effect=HTTPException(status_code=401, detail="No credentials"),
+      ),
+      patch(
+        "robosystems.security.SecurityAuditLogger.log_authorization_denied"
+      ) as mock_audit,
+    ):
+      with pytest.raises(HTTPException) as exc_info:
+        await get_context(
+          request=request,
+          api_key=None,
+          graph_id=SUBGRAPH_ID,
+          db=MagicMock(),
+        )
+
+    assert exc_info.value.status_code == 403
+    mock_audit.assert_not_called()
+
+  async def test_shared_repo_subgraph_rejected(self):
+    """Shared-repo subgraphs (e.g. sec_historical) are subgraphs too."""
+    request = _make_request(headers={})
+    user = MagicMock()
+    user.id = "usr_test"
+
+    with (
+      patch(f"{MODULE}.get_current_user", new_callable=AsyncMock, return_value=user),
+      patch(f"{MODULE}.check_graph_access") as mock_check,
+      patch("robosystems.security.SecurityAuditLogger.log_authorization_denied"),
+    ):
+      with pytest.raises(HTTPException) as exc_info:
+        await get_context(
+          request=request,
+          api_key="rfs_valid",
+          graph_id="sec_historical",
+          db=MagicMock(),
+        )
+
+    assert exc_info.value.status_code == 403
+    mock_check.assert_not_called()
+
+  async def test_library_sentinel_unaffected(self):
+    """The `library` sentinel is not a subgraph and must keep working."""
+    request = _make_request(headers={})
+    user = MagicMock()
+
+    with (
+      patch(f"{MODULE}.get_current_user", new_callable=AsyncMock, return_value=user),
+      patch(f"{MODULE}.check_graph_access"),
+      patch(f"{MODULE}.load_graph_metadata") as mock_meta,
+    ):
+      ctx = await get_context(
+        request=request,
+        api_key="rfs_valid",
+        graph_id="library",
+        db=MagicMock(),
+      )
+
+    assert ctx["graph_id"] == "library"
+    assert ctx["schema_extensions"] == ("library",)
+    # Library sentinel has no graph row; metadata must not be loaded.
+    mock_meta.assert_not_called()
+
+  async def test_shared_repository_parent_unaffected(self):
+    """A plain shared-repo ID (no subgraph suffix) passes the guard."""
+    request = _make_request(headers={})
+    user = MagicMock()
+
+    with (
+      patch(f"{MODULE}.get_current_user", new_callable=AsyncMock, return_value=user),
+      patch(f"{MODULE}.check_graph_access") as mock_check,
+      patch(
+        f"{MODULE}.load_graph_metadata",
+        return_value=GraphExtensionContext(
+          graph_type="repository",
+          schema_extensions=(),
+          is_repository=True,
+        ),
+      ),
+    ):
+      ctx = await get_context(
+        request=request,
+        api_key="rfs_valid",
+        graph_id="sec",
+        db=MagicMock(),
+      )
+
+    assert ctx["graph_id"] == "sec"
+    mock_check.assert_called_once_with(user, "sec")

--- a/tests/middleware/mcp/tools/test_graphql_tool.py
+++ b/tests/middleware/mcp/tools/test_graphql_tool.py
@@ -201,6 +201,16 @@ class TestGraphqlQueryTool:
     assert result["error"] == "invalid_query"
 
   @pytest.mark.asyncio
+  async def test_subgraph_workspace_rejected(self, mock_client):
+    """A subgraph-bound workspace has no extensions schema — mirror the
+    HTTP surface and reject before parsing or execution."""
+    mock_client.graph_id = "kg0123456789abcdef_dev"
+    tool = self._make_tool(mock_client)
+    result = await tool.execute({"query": "{ hello }"})
+    assert result["error"] == "invalid_target"
+    assert "parent graph" in result["message"]
+
+  @pytest.mark.asyncio
   async def test_mutation_rejected(self, mock_client):
     tool = self._make_tool(mock_client)
     result = await tool.execute({"query": "mutation { createFoo { id } }"})


### PR DESCRIPTION
## Summary

Closes the last open item from the appsec sprint (multimodal §11 P2): the extensions GraphQL surface (`/extensions/{graph_id}/graphql`) admitted subgraph IDs and passed auth by resolving them to the parent graph, then dead-ended in extensions schema resolution (`_sanitize_schema` rejects `kg…_name`). No data leak today — but the asymmetry (auth resolves subgraph→parent, schema resolution doesn't) is latent risk: a future "helpful" subgraph→parent strip in the schema path would silently serve parent OLTP data at a subgraph address. A subgraph is a modality container (knowledge/scratch), not an extensions domain target, so this surface now rejects subgraph IDs outright.

## Changes

- **`robosystems/graphql/context.py`** — `get_context` rejects any subgraph ID with 403 regardless of authentication, placed after credential resolution (bad creds still get 401) and before `check_graph_access` (the parent-resolving step this closes off). The guard uses `is_subgraph()` — not a naive non-`kg` reject — so the `library` sentinel and shared repositories are unaffected, while shared-repo subgraphs (e.g. `sec_historical`) are also refused. Authenticated attempts emit `log_authorization_denied`, landing on the SOC2 audit trail per the appsec Phase-2 pattern.
- **`robosystems/middleware/mcp/tools/graphql_tool.py`** — MCP `query-graphql` mirrors the guard (returns an `invalid_target` error for subgraph-bound workspaces). It builds its own context and bypasses `get_context`, so the HTTP guard alone would not cover it.
- **`tests/graphql/extensions/test_context.py`** — new `TestSubgraphGuard` class: authenticated rejection fires before `check_graph_access` and is audited; anonymous rejection (introspection does not bypass) is not audited; shared-repo subgraph rejected; `library` sentinel and plain shared-repo IDs keep working.
- **`tests/middleware/mcp/tools/test_graphql_tool.py`** — subgraph-bound workspace is rejected before parse/execution.

## Testing

- `uv run pytest tests/graphql/ tests/middleware/mcp/` — 700 passed.
- `just test-code` (ruff + format + basedpyright + cf-lint) — all checks passed.
- Full `just test-all` not run this session.

## Notes

- Merging this closes the final P2 from the 2026-07 application-security review — CodeQL HIGHs go to 0 in code once merged.
- The `query-interface.md` spec (design vault) was refreshed alongside this change; its §5 "tighten GraphQL" item is what this PR implements.
