### PR TITLE
fix(security): close cypher write-wall bypass + write-path hardening

### DIFF
--- a/robosystems/middleware/mcp/tools/graph_tools.py
+++ b/robosystems/middleware/mcp/tools/graph_tools.py
@@ -178,7 +178,12 @@ class CreateSubgraphTool:
     fork_parent = bool(arguments.get("fork_parent", False))
     subgraph_type = arguments.get("subgraph_type", "static")
 
-    if not name.isalnum() or not (1 <= len(name) <= 20):
+    from robosystems.middleware.graph.utils.subgraph import validate_subgraph_name
+
+    # Use the canonical ASCII validator (^[a-zA-Z0-9]{1,20}$) rather than
+    # Unicode-permissive str.isalnum(), which admits names like "café" that the
+    # downstream construct_subgraph_id then rejects with a generic error.
+    if not validate_subgraph_name(name):
       return {
         "error": "invalid_name",
         "message": (

--- a/robosystems/routers/graphs/content_ops.py
+++ b/robosystems/routers/graphs/content_ops.py
@@ -511,6 +511,9 @@ async def create_file_upload_op(
     create_file_upload_cmd,
   )
 
+  _block_shared_repo(graph_id)
+  _require_graph_write_access(graph_id, str(user.id))
+
   op_name = "create-file-upload"
   user_id = str(user.id)
   ctx = _ctx(

--- a/robosystems/security/cypher_analyzer.py
+++ b/robosystems/security/cypher_analyzer.py
@@ -347,14 +347,21 @@ class CypherSecurityAnalyzer:
         out.append(" STRING_LITERAL ")
         continue
 
-      # Backtick-quoted identifier
+      # Backtick-quoted identifier. Kuzu/openCypher do NOT use backslash
+      # escaping inside backtick identifiers: a backslash is a literal
+      # character and the identifier closes at the next backtick (an escaped
+      # backtick is written by doubling it). Treating backslash as an escape
+      # here diverged from the engine lexer, letting ``... AS `x\` SET ...``
+      # mask a trailing write keyword — the analyzer swallowed everything
+      # after the escaped backtick while Kuzu closed the identifier and
+      # executed the rest. Close at the FIRST backtick and do not honour
+      # backslash. This is conservative w.r.t. doubled-backtick identifiers
+      # (the analyzer may split them into two tokens), which only ever
+      # over-classifies a write, never hides one.
       if ch == "`":
         i += 1
         while i < n:
           c = query[i]
-          if c == "\\":
-            i += 2
-            continue
           i += 1
           if c == "`":
             break

--- a/tests/routers/graphs/test_content_ops.py
+++ b/tests/routers/graphs/test_content_ops.py
@@ -318,7 +318,11 @@ async def test_create_file_upload_op():
     file_id="gf_1",
     s3_key="user-staging/u/kg_test/t/gf_1/x.parquet",
   )
-  with patch(CREATE_UPLOAD_CMD, new=AsyncMock(return_value=resp)):
+  with (
+    patch(f"{MODULE}._block_shared_repo"),
+    patch(f"{MODULE}._require_graph_write_access"),
+    patch(CREATE_UPLOAD_CMD, new=AsyncMock(return_value=resp)),
+  ):
     env = await create_file_upload_op(
       body,
       graph_id="kg_test",
@@ -334,3 +338,31 @@ async def test_create_file_upload_op():
     "file_id": "gf_1",
     "s3_key": "user-staging/u/kg_test/t/gf_1/x.parquet",
   }
+
+
+async def test_create_file_upload_op_enforces_write_role():
+  # A read-only viewer must be rejected by the write-role gate BEFORE the
+  # command runs — create-file-upload previously skipped this gate (CO-F1).
+  body = FileUploadRequest(
+    file_name="x.parquet", table_name="t", content_type="application/x-parquet"
+  )
+  cmd = AsyncMock()
+  with (
+    patch(f"{MODULE}._block_shared_repo"),
+    patch(
+      f"{MODULE}._require_graph_write_access",
+      side_effect=HTTPException(status_code=403, detail="read-only"),
+    ),
+    patch(CREATE_UPLOAD_CMD, new=cmd),
+  ):
+    with pytest.raises(HTTPException) as e:
+      await create_file_upload_op(
+        body,
+        graph_id="kg_test",
+        user=_user(),
+        idempotency_key=None,
+        cache=MagicMock(),
+        db=MagicMock(),
+      )
+  assert e.value.status_code == 403
+  cmd.assert_not_awaited()

--- a/tests/security/test_cypher_analyzer.py
+++ b/tests/security/test_cypher_analyzer.py
@@ -211,6 +211,61 @@ class TestCleanQuery:
     assert result == CypherOperationType.READ
 
 
+class TestBacktickIdentifierBypass:
+  """Regression tests for the backtick-identifier lexer-differential bypass.
+
+  ``_clean_query`` used to treat backslash as an escape inside backtick-quoted
+  identifiers, so ``... AS `x\\` SET ...`` masked the trailing write while Kuzu
+  closed the identifier at the backtick and executed the write. The analyzer
+  now closes a backtick identifier at the FIRST backtick (backslash is a
+  literal char), matching the engine lexer, so a masked write can no longer
+  slip past classification. Each masked payload below must trip its predicate.
+  """
+
+  MASKED_SET = "MATCH (e) WITH e, 1 AS `y\\` SET e.name = 'x' RETURN e"
+  MASKED_CREATE = "MATCH (n) WITH n AS `x\\` LIMIT 1 CREATE (m:Node {v:1}) RETURN m"
+  MASKED_DETACH_DELETE = "MATCH (n) WITH n AS `z\\` DETACH DELETE n"
+  MASKED_ATTACH = "MATCH (n) WITH n AS `a\\` ATTACH 'other.lbug'"
+  MASKED_LOAD = "MATCH (n) WITH n AS `b\\` LOAD FROM 'f.csv' RETURN 1"
+  MASKED_CREATE_TABLE = (
+    "MATCH (n) WITH n AS `c\\` CREATE NODE TABLE T(id INT64, PRIMARY KEY(id))"
+  )
+
+  def test_clean_query_closes_backtick_at_first_backtick(self, analyzer):
+    # The write keyword after the closed identifier must survive cleaning.
+    cleaned = analyzer._clean_query("MATCH (n) WITH n AS `x\\` CREATE (m:Node)")
+    assert "CREATE" in cleaned.upper()
+
+  def test_masked_set_is_write(self, analyzer):
+    assert is_write_operation(self.MASKED_SET) is True
+    assert analyzer.analyze_query(self.MASKED_SET) in (
+      CypherOperationType.WRITE,
+      CypherOperationType.MIXED,
+    )
+
+  def test_masked_create_is_write(self):
+    assert is_write_operation(self.MASKED_CREATE) is True
+
+  def test_masked_detach_delete_is_write(self):
+    assert is_write_operation(self.MASKED_DETACH_DELETE) is True
+
+  def test_masked_attach_is_admin(self):
+    assert is_admin_operation(self.MASKED_ATTACH) is True
+
+  def test_masked_load_is_bulk(self):
+    assert is_bulk_operation(self.MASKED_LOAD) is True
+
+  def test_masked_create_table_is_schema_ddl(self):
+    assert is_schema_ddl(self.MASKED_CREATE_TABLE) is True
+
+  def test_legitimate_backtick_identifier_still_read(self, analyzer):
+    # A property literally named `CREATE` is an identifier, not a write — the
+    # conservative fix must not over-block ordinary backtick identifiers.
+    assert (
+      analyzer.analyze_query("MATCH (n) RETURN n.`CREATE`") == CypherOperationType.READ
+    )
+
+
 class TestGetWriteOperationDetails:
   """Tests for get_write_operation_details."""
 


### PR DESCRIPTION
## Summary

Hardens write-path authorization on the graph query surface and tightens two input-validation gaps found in a pre-`1.6.0` review. Includes regression tests. Detailed root-cause analysis is tracked privately (not in this public repo).

## Changes

- `security/cypher_analyzer.py` — correctness fix to the query write-classification path so an obfuscated identifier can no longer evade it; the scanner now matches the engine's lexer. Added regression coverage.
- `routers/graphs/content_ops.py` — enforce the graph write-role on `create-file-upload`, matching every other content-op write handler (a read-only viewer is rejected before the command runs).
- `middleware/mcp/tools/graph_tools.py` — use the canonical subgraph-name validator for consistent input validation.

## Testing

- Touched-module unit tests + new regressions: green.
- `just test-code` (ruff + format + basedpyright): clean.
- Behavior verified end-to-end against a local stack.
- Full `just test`: left to CI.
