### PR TITLE
fix(sec): load multi-document inline XBRL filings as a document set

### DIFF
--- a/robosystems/adapters/sec/processors/processing.py
+++ b/robosystems/adapters/sec/processors/processing.py
@@ -233,6 +233,20 @@ def process_single_filing_to_memory(
               with open(local_path, "rb") as f:
                 tables[key] = f.read()
 
+      # A processed filing with no facts means extraction silently failed
+      # (e.g. wrong instance document selected). Surface it as an error so
+      # the SourceFile lands in a retryable state instead of masking data
+      # loss as success.
+      if "nodes/Fact" not in tables:
+        return ProcessedFilingResult(
+          success=False,
+          source_file_id=source_file_id,
+          partition_key=partition_key,
+          tables={},
+          filing_date=filing_date,
+          error="XBRL processing produced zero facts",
+        )
+
       return ProcessedFilingResult(
         success=True,
         source_file_id=source_file_id,

--- a/robosystems/adapters/sec/processors/processing.py
+++ b/robosystems/adapters/sec/processors/processing.py
@@ -17,8 +17,33 @@ if TYPE_CHECKING:
   from robosystems.adapters.sec.processors.metadata import SECMetadataLoader
 
 # Import from specific modules to avoid circular imports
+from arelle.UrlUtil import IXDS_DOC_SEPARATOR, IXDS_SURROGATE
+
 from robosystems.adapters.sec.client.edgar import SEC_BASE_URL
 from robosystems.adapters.sec.processors.xbrl_graph import XBRLGraphProcessor
+
+INLINE_XBRL_NAMESPACE = b"http://www.xbrl.org/2013/inlineXBRL"
+
+
+def _inline_xbrl_documents(tmpdir: str, htm_files: list[str]) -> list[str]:
+  """Return the subset of .htm files that are inline XBRL documents.
+
+  Multi-document filings (common for 40-F/20-F) split one logical instance
+  across several files: contexts, units, and schema references live in the
+  primary document while tagged facts live in continuation documents. Each
+  member declares the inline XBRL namespace on its root element, so a head
+  scan is sufficient to identify them.
+  """
+  members = []
+  for f in htm_files:
+    try:
+      with open(os.path.join(tmpdir, f), "rb") as fh:
+        head = fh.read(65536)
+    except OSError:
+      continue
+    if INLINE_XBRL_NAMESPACE in head:
+      members.append(f)
+  return sorted(members)
 
 
 @dataclass
@@ -137,6 +162,18 @@ def process_single_filing_to_memory(
         f"{SEC_BASE_URL}/Archives/edgar/data/{cik_int}/{accno_clean}/{xbrl_files[0]}"
       )
 
+      # Multi-document inline XBRL filings (IXDS) split one logical instance
+      # across several .htm files; they must be loaded together so contexts
+      # defined in the primary document resolve for facts tagged in the others.
+      instance_file_path = os.path.join(tmpdir, xbrl_files[0])
+      ixds_members = _inline_xbrl_documents(tmpdir, htm_files)
+      if len(ixds_members) > 1:
+        instance_file_path = os.path.join(
+          tmpdir, IXDS_SURROGATE
+        ) + IXDS_DOC_SEPARATOR.join(os.path.join(tmpdir, f) for f in ixds_members)
+      elif len(ixds_members) == 1:
+        instance_file_path = os.path.join(tmpdir, ixds_members[0])
+
       # Schema config
       schema_config = {
         "name": "SEC Database Schema",
@@ -171,7 +208,7 @@ def process_single_filing_to_memory(
         sec_filer=sec_filer,
         sec_report=sec_report,
         output_dir=tmpdir,
-        local_file_path=os.path.join(tmpdir, xbrl_files[0]),
+        local_file_path=instance_file_path,
         schema_config=schema_config,
         enricher=enricher,
       )

--- a/robosystems/adapters/sec/processors/xbrl_graph.py
+++ b/robosystems/adapters/sec/processors/xbrl_graph.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pandas as pd
 from arelle import XbrlConst
+from arelle.UrlUtil import IXDS_DOC_SEPARATOR, IXDS_SURROGATE
 
 # Import from specific modules to avoid circular imports
 from robosystems.adapters.sec.client.arelle import ArelleClient
@@ -198,7 +199,19 @@ class XBRLGraphProcessor:
       )
       return
 
-    if not self.instance_path or not os.path.exists(self.instance_path):
+    # An inline XBRL document set is passed as a surrogate path that joins the
+    # member files; validate each member rather than the surrogate itself.
+    if self.instance_path and IXDS_DOC_SEPARATOR in self.instance_path:
+      member_paths = self.instance_path.partition(IXDS_SURROGATE)[2].split(
+        IXDS_DOC_SEPARATOR
+      )
+      instance_exists = bool(member_paths) and all(
+        os.path.exists(p) for p in member_paths
+      )
+    else:
+      instance_exists = bool(self.instance_path) and os.path.exists(self.instance_path)
+
+    if not instance_exists:
       logger.error(f"XBRL instance file not found: {self.instance_path}")
       # Mark report as failed
       if hasattr(self, "report_data") and self.report_data:

--- a/tests/adapters/sec/processors/test_processing.py
+++ b/tests/adapters/sec/processors/test_processing.py
@@ -591,6 +591,8 @@ class TestProcessorOrchestration:
       os.makedirs(nodes_dir, exist_ok=True)
       with open(os.path.join(nodes_dir, "Entity.parquet"), "wb") as f:
         f.write(b"entity parquet data")
+      with open(os.path.join(nodes_dir, "Fact.parquet"), "wb") as f:
+        f.write(b"fact parquet data")
 
       rels_dir = os.path.join(output_dir, "relationships")
       os.makedirs(rels_dir, exist_ok=True)
@@ -615,3 +617,48 @@ class TestProcessorOrchestration:
     assert "nodes/Entity" in result.tables
     assert "relationships/ENTITY_HAS_REPORT" in result.tables
     assert result.tables["nodes/Entity"] == b"entity parquet data"
+
+  @patch("robosystems.adapters.sec.processors.processing.XBRLGraphProcessor")
+  def test_zero_facts_returns_error(self, mock_processor_cls):
+    """Processing that emits no Fact table is a failure, not silent success.
+
+    Guards against wrong-instance-document selection producing empty reports
+    that are marked success and never retried.
+    """
+    zip_data = self._make_zip_bytes(["filing.htm"])
+
+    mock_s3 = MagicMock()
+    mock_s3.download_fileobj.side_effect = lambda bucket, key, buf: buf.write(zip_data)
+
+    mock_loader = MagicMock()
+    mock_loader.get_metadata.return_value = (
+      {"cik": "1045810"},
+      {"form": "10-K", "filingDate": "2024-03-01", "primaryDocument": "filing.htm"},
+    )
+
+    def fake_process():
+      call_kwargs = mock_processor_cls.call_args.kwargs
+      output_dir = call_kwargs["output_dir"]
+      nodes_dir = os.path.join(output_dir, "nodes")
+      os.makedirs(nodes_dir, exist_ok=True)
+      with open(os.path.join(nodes_dir, "Entity.parquet"), "wb") as f:
+        f.write(b"entity parquet data")
+      with open(os.path.join(nodes_dir, "Report.parquet"), "wb") as f:
+        f.write(b"report parquet data")
+
+    mock_processor_instance = MagicMock()
+    mock_processor_instance.process.side_effect = fake_process
+    mock_processor_cls.return_value = mock_processor_instance
+
+    result = process_single_filing_to_memory(
+      storage_key="sec/raw/file.zip",
+      partition_key="2024_1045810_0001045810-24-000001",
+      source_file_id="sf1",
+      s3_client=mock_s3,
+      raw_bucket="bucket",
+      metadata_loader=mock_loader,
+    )
+
+    assert result.success is False
+    assert "zero facts" in result.error
+    assert result.tables == {}

--- a/tests/adapters/sec/processors/test_processing.py
+++ b/tests/adapters/sec/processors/test_processing.py
@@ -10,10 +10,15 @@ from io import BytesIO
 from unittest.mock import MagicMock, patch
 
 import pytest
+from arelle.UrlUtil import IXDS_DOC_SEPARATOR, IXDS_SURROGATE
 
 from robosystems.adapters.sec.processors.processing import (
   ProcessedFilingResult,
   process_single_filing_to_memory,
+)
+
+INLINE_XBRL_HTML = (
+  '<html xmlns:ix="http://www.xbrl.org/2013/inlineXBRL"><body>{}</body></html>'
 )
 
 
@@ -164,12 +169,15 @@ class TestS3DownloadHandling:
 class TestXBRLFileSelection:
   """Tests for XBRL file selection from ZIP contents."""
 
-  def _make_zip_bytes(self, filenames: list[str]) -> bytes:
+  def _make_zip_bytes(
+    self, filenames: list[str], contents: dict[str, str] | None = None
+  ) -> bytes:
     """Helper to create a ZIP in memory with given filenames."""
     buf = BytesIO()
     with zipfile.ZipFile(buf, "w") as zf:
       for name in filenames:
-        zf.writestr(name, f"<content of {name}>")
+        content = (contents or {}).get(name, f"<content of {name}>")
+        zf.writestr(name, content)
     buf.seek(0)
     return buf.read()
 
@@ -242,6 +250,97 @@ class TestXBRLFileSelection:
 
     call_kwargs = mock_processor_cls.call_args.kwargs
     assert "filing.xml" in call_kwargs["local_file_path"]
+
+  @patch("robosystems.adapters.sec.processors.processing.XBRLGraphProcessor")
+  def test_multi_document_inline_xbrl_loads_as_document_set(self, mock_processor_cls):
+    """40-F/20-F style filings with facts split across .htm files load as IXDS.
+
+    Contexts/units/references live in the primary document while facts live
+    in continuation documents (_d2.htm), so the members must be loaded
+    together; untagged exhibits are excluded from the set.
+    """
+    mock_processor_cls.return_value = MagicMock()
+
+    zip_data = self._make_zip_bytes(
+      [
+        "crlbf-20241231.htm",
+        "crlbf-20241231_d2.htm",
+        "aif.htm",
+        "schema.xsd",
+      ],
+      contents={
+        "crlbf-20241231.htm": INLINE_XBRL_HTML.format("cover"),
+        "crlbf-20241231_d2.htm": INLINE_XBRL_HTML.format("financials " * 100),
+        "aif.htm": "<html><body>untagged exhibit</body></html>" * 100,
+      },
+    )
+
+    mock_s3 = MagicMock()
+    mock_s3.download_fileobj.side_effect = lambda bucket, key, buf: buf.write(zip_data)
+
+    mock_loader = MagicMock()
+    mock_loader.get_metadata.return_value = (
+      {"cik": "1832928"},
+      {"form": "40-F", "filingDate": "2025-03-14", "primaryDocument": None},
+    )
+
+    process_single_filing_to_memory(
+      storage_key="sec/raw/file.zip",
+      partition_key="2025_1832928_0001832928-25-000006",
+      source_file_id="sf1",
+      s3_client=mock_s3,
+      raw_bucket="bucket",
+      metadata_loader=mock_loader,
+    )
+
+    local_file_path = mock_processor_cls.call_args.kwargs["local_file_path"]
+    assert IXDS_SURROGATE in local_file_path
+    members = local_file_path.partition(IXDS_SURROGATE)[2].split(IXDS_DOC_SEPARATOR)
+    assert [os.path.basename(m) for m in members] == [
+      "crlbf-20241231.htm",
+      "crlbf-20241231_d2.htm",
+    ]
+
+  @patch("robosystems.adapters.sec.processors.processing.XBRLGraphProcessor")
+  def test_single_inline_xbrl_doc_wins_over_larger_untagged_htm(
+    self, mock_processor_cls
+  ):
+    """The tagged document is loaded even when an untagged exhibit is larger."""
+    mock_processor_cls.return_value = MagicMock()
+
+    zip_data = self._make_zip_bytes(
+      [
+        "filing.htm",
+        "exhibit.htm",
+        "schema.xsd",
+      ],
+      contents={
+        "filing.htm": INLINE_XBRL_HTML.format("tagged"),
+        "exhibit.htm": "<html><body>untagged</body></html>" * 1000,
+      },
+    )
+
+    mock_s3 = MagicMock()
+    mock_s3.download_fileobj.side_effect = lambda bucket, key, buf: buf.write(zip_data)
+
+    mock_loader = MagicMock()
+    mock_loader.get_metadata.return_value = (
+      {"cik": "1045810"},
+      {"form": "10-K", "filingDate": "2024-03-01", "primaryDocument": None},
+    )
+
+    process_single_filing_to_memory(
+      storage_key="sec/raw/file.zip",
+      partition_key="2024_1045810_0001045810-24-000001",
+      source_file_id="sf1",
+      s3_client=mock_s3,
+      raw_bucket="bucket",
+      metadata_loader=mock_loader,
+    )
+
+    local_file_path = mock_processor_cls.call_args.kwargs["local_file_path"]
+    assert IXDS_SURROGATE not in local_file_path
+    assert local_file_path.endswith("filing.htm")
 
   def test_no_xbrl_files_returns_error(self):
     """Returns error when ZIP contains no XBRL files."""


### PR DESCRIPTION
## Summary

SEC XBRL processing selected a single "largest `.htm`" file from each filing's `-xbrl.zip` as the Arelle input. Filings that spread inline XBRL across multiple documents (common for 40-F/20-F foreign-filer forms, and some large domestic 10-Ks), or that contain untagged exhibits bigger than the tagged instance, produced Report nodes with zero facts — recorded as success and never retried. This PR loads multi-document filings as an inline XBRL document set, prefers tagged documents over larger untagged ones, and fails processing when a filing yields no facts so it lands in a retryable state.

## Changes

- **`robosystems/adapters/sec/processors/processing.py`**
  - Detect inline XBRL member documents in the filing zip (namespace scan of `.htm` files).
  - Two or more members → build Arelle's IXDS surrogate path (`IXDS_SURROGATE` + `IXDS_DOC_SEPARATOR` from `arelle.UrlUtil`) so contexts/units/schema references defined in the primary document resolve for facts tagged in continuation documents. The `inlineXbrlDocumentSet` plugin was already loaded by our Arelle client; it just never received a document-set entry point.
  - Exactly one member → load that document even when an untagged exhibit is larger.
  - Zero-fact guard: processing that emits no `nodes/Fact` table returns an error result (→ `SourceFile` marked `error`, retryable) instead of success with an empty report.
  - `report_url` selection is unchanged, so reprocessed facts attach to existing Report node identities.
- **`robosystems/adapters/sec/processors/xbrl_graph.py`**
  - Instance-file existence check is IXDS-aware: validates each member file of a surrogate path rather than the surrogate itself.
- **`tests/adapters/sec/processors/test_processing.py`**
  - New tests: multi-document filings load as a document set (untagged exhibits excluded), tagged document wins over a larger untagged one, zero-fact processing returns an error.
  - Success-path orchestration test updated to include a Fact table.

## Testing

- `uv run pytest tests/adapters/sec` — 1,179 passed, 9 skipped.
- `ruff check` / `ruff format` / `basedpyright` clean on changed files (pre-commit hooks passed on both commits).
- Verified end-to-end locally via `just sec-load` for one representative filing per failure variant: 40-F document-set (CRLBF, CURLF), domestic document-set 10-K (WFC), exhibit-selection 10-K (HL) — all now extract full fact sets with populated fiscal fields; all were previously zero-fact.

## Notes / Follow-ups

- Affected filings already in the shared repository need a selective reprocess after deploy (SourceFile reset → sensor-driven re-run); procedure documented internally.
- A small residue of filings (certain S-1s) appears to carry no tagged instance at all; under the new guard these surface as retryable errors for triage rather than empty reports.
