### PR TITLE
chore(infra): harden claude.yml author gate and drop unused id-token

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -33,19 +33,42 @@ jobs:
 
   claude:
     needs: [check-runner-availability]
+    # Defense-in-depth author gate: on top of the action's own permission check,
+    # only run when the triggering actor is a repo OWNER/MEMBER/COLLABORATOR, so a
+    # drive-by comment/issue from an outside account cannot invoke Claude with
+    # repo secrets in scope (this repo is public).
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (
+        github.event_name == 'issue_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+      ) ||
+      (
+        github.event_name == 'pull_request_review_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+      ) ||
+      (
+        github.event_name == 'pull_request_review' &&
+        contains(github.event.review.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)
+      ) ||
+      (
+        github.event_name == 'issues' &&
+        (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association)
+      )
     runs-on: ${{ fromJSON(needs.check-runner-availability.outputs.runner_config) }}
     timeout-minutes: 15
     permissions:
       contents: read
       pull-requests: read
       issues: read
-      id-token: write
       actions: read # Required for Claude to read CI results on PRs
+      # id-token: write intentionally omitted — Claude authenticates with
+      # CLAUDE_CODE_OAUTH_TOKEN and assumes no cloud (OIDC) role in this workflow,
+      # so GitHub OIDC token-minting is not needed. Restore it only if a step
+      # here ever assumes an AWS role via configure-aws-credentials.
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7


### PR DESCRIPTION
## Summary

Hardens the `@claude` workflow trigger conditions and trims an unused permission from the workflow's token scope.

## Changes

- **`.github/workflows/claude.yml`**
  - Each `@claude` trigger (issue comment, PR review comment, PR review, issue body/title) now also requires the triggering actor's `author_association` to be `OWNER`, `MEMBER`, or `COLLABORATOR` — defense-in-depth on top of the action's own permission check.
  - Dropped `id-token: write` from the job permissions: the workflow authenticates via `CLAUDE_CODE_OAUTH_TOKEN` and assumes no cloud (OIDC) role, so GitHub OIDC token-minting is unnecessary. An inline comment documents when it would need restoring.

## Testing

- Not executed in this session — workflow-config-only change with no local test surface; GitHub validates workflow syntax on push. Verify by triggering `@claude` from a maintainer account after merge.
