### PR TITLE
feat(graph): LadybugDB 0.18.1 + Arrow-streaming materialization

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -65,10 +65,10 @@ jobs:
       pull-requests: read
       issues: read
       actions: read # Required for Claude to read CI results on PRs
-      # id-token: write intentionally omitted — Claude authenticates with
-      # CLAUDE_CODE_OAUTH_TOKEN and assumes no cloud (OIDC) role in this workflow,
-      # so GitHub OIDC token-minting is not needed. Restore it only if a step
-      # here ever assumes an AWS role via configure-aws-credentials.
+      id-token: write # Required: claude-code-action mints a GitHub OIDC token to
+        # authenticate to GitHub (setupGitHubToken → getOidcToken), independent of
+        # any cloud role. Without it the action fails: "Could not fetch an OIDC
+        # token." (This is GitHub auth, not AWS — do not drop it as "unused".)
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,10 @@ ARG TARGETARCH=arm64
 ARG LADYBUG_EXT_VERSION=0.18.1
 
 # Create extension directories using internal version (where LadybugDB looks)
+# The duckdb extension is deliberately absent: materialization moved from
+# DuckDB ATTACH to a parquet handoff (LadybugDB 0.14+ creates persistent
+# shadow catalog entries on ATTACH that collide with installed schema).
 RUN mkdir -p /ladybug-extension/${LADYBUG_EXT_VERSION}/linux_${TARGETARCH}/httpfs \
-             /ladybug-extension/${LADYBUG_EXT_VERSION}/linux_${TARGETARCH}/duckdb \
              /ladybug-extension/${LADYBUG_EXT_VERSION}/linux_${TARGETARCH}/vector
 
 # Copy httpfs extension from extension repository (source: repo version, dest: internal version)
@@ -40,31 +42,10 @@ COPY --from=extensions \
     /usr/share/nginx/html/v${LADYBUG_EXT_VERSION}/linux_${TARGETARCH}/httpfs/libhttpfs.lbug_extension \
     /ladybug-extension/${LADYBUG_EXT_VERSION}/linux_${TARGETARCH}/httpfs/libhttpfs.lbug_extension
 
-# Copy duckdb extension (required for DuckDB → LadybugDB direct ingestion)
-# DuckDB extension requires 3 files: main extension + installer + loader
-COPY --from=extensions \
-    /usr/share/nginx/html/v${LADYBUG_EXT_VERSION}/linux_${TARGETARCH}/duckdb/libduckdb.lbug_extension \
-    /ladybug-extension/${LADYBUG_EXT_VERSION}/linux_${TARGETARCH}/duckdb/libduckdb.lbug_extension
-
-COPY --from=extensions \
-    /usr/share/nginx/html/v${LADYBUG_EXT_VERSION}/linux_${TARGETARCH}/duckdb/libduckdb_installer.lbug_extension \
-    /ladybug-extension/${LADYBUG_EXT_VERSION}/linux_${TARGETARCH}/duckdb/libduckdb_installer.lbug_extension
-
-COPY --from=extensions \
-    /usr/share/nginx/html/v${LADYBUG_EXT_VERSION}/linux_${TARGETARCH}/duckdb/libduckdb_loader.lbug_extension \
-    /ladybug-extension/${LADYBUG_EXT_VERSION}/linux_${TARGETARCH}/duckdb/libduckdb_loader.lbug_extension
-
 # Copy vector extension (required for FLOAT[N] column support and vector indexes)
 COPY --from=extensions \
     /usr/share/nginx/html/v${LADYBUG_EXT_VERSION}/linux_${TARGETARCH}/vector/libvector.lbug_extension \
     /ladybug-extension/${LADYBUG_EXT_VERSION}/linux_${TARGETARCH}/vector/libvector.lbug_extension
-
-# DuckDB shared library (required by LadybugDB DuckDB extension): copy the
-# version-matched build shipped in the extension repo's common/ directory —
-# guarantees ABI compatibility with the duckdb extension of the same bundle.
-COPY --from=extensions \
-    /usr/share/nginx/html/v${LADYBUG_EXT_VERSION}/linux_${TARGETARCH}/common/libduckdb.so \
-    /usr/local/lib/libduckdb.so
 
 # Verify LadybugDB extension integrity
 # Basic integrity check: verify files exist, are non-empty, and are valid ELF binaries
@@ -83,13 +64,10 @@ RUN echo "Verifying LadybugDB extension integrity..." && \
         echo "✓ Valid extension: $(basename $ext)"; \
         EXTENSIONS_FOUND=$((EXTENSIONS_FOUND + 1)); \
     done && \
-    if [ "$EXTENSIONS_FOUND" -lt 5 ]; then \
-        echo "ERROR: Expected 5 extension files, found $EXTENSIONS_FOUND" && exit 1; \
+    if [ "$EXTENSIONS_FOUND" -lt 2 ]; then \
+        echo "ERROR: Expected 2 extension files, found $EXTENSIONS_FOUND" && exit 1; \
     fi && \
     echo "Extension integrity verification complete ($EXTENSIONS_FOUND extensions validated)"
-
-# Register libduckdb.so with the dynamic linker
-RUN ldconfig
 
 WORKDIR /build
 
@@ -197,9 +175,6 @@ COPY dagster_home/ /app/dagster_home/
 RUN chmod +x bin/entrypoint.sh
 
 # Copy DuckDB shared library from builder (required by LadybugDB DuckDB extension)
-COPY --from=builder /usr/local/lib/libduckdb.so /usr/local/lib/libduckdb.so
-RUN ldconfig
-
 # Use non-root user for better security
 RUN useradd -m appuser
 # Ensure uv is accessible by appuser
@@ -207,9 +182,10 @@ RUN chown appuser:appuser /usr/local/bin/uv
 # Create data directory for persistent storage
 RUN mkdir -p /app/data && chown -R appuser:appuser /app/data
 # Create extension directory in appuser's home (where LadybugDB looks for extensions)
-# Extensions are stored at ~/.lbug/extension/{VERSION}/{PLATFORM}/{EXTENSION_NAME}/
+# Extensions are stored at ~/.lbdb/extension/{VERSION}/{PLATFORM}/{EXTENSION_NAME}/
+# (the directory moved from ~/.lbug to ~/.lbdb in LadybugDB 0.15+)
 # This is in the container filesystem, NOT persistent volume, so extensions refresh with each deploy
-RUN mkdir -p /home/appuser/.lbug/extension/${LADYBUG_EXT_VERSION}/linux_${TARGETARCH} && chown -R appuser:appuser /home/appuser/.lbug
+RUN mkdir -p /home/appuser/.lbdb/extension/${LADYBUG_EXT_VERSION}/linux_${TARGETARCH} && chown -R appuser:appuser /home/appuser/.lbdb
 # Give appuser write access to /app for log files
 RUN chown -R appuser:appuser /app
 
@@ -218,25 +194,14 @@ COPY --from=builder --chown=appuser:appuser \
     /app/fastembed_cache /app/fastembed_cache
 
 # Copy LadybugDB extensions to user home directory
-# LadybugDB expects extensions at ~/.lbug/extension/{VERSION}/{PLATFORM}/{EXTENSION_NAME}/
+# LadybugDB expects extensions at ~/.lbdb/extension/{VERSION}/{PLATFORM}/{EXTENSION_NAME}/
 COPY --from=builder --chown=appuser:appuser \
     /ladybug-extension/${LADYBUG_EXT_VERSION}/linux_${TARGETARCH}/httpfs \
-    /home/appuser/.lbug/extension/${LADYBUG_EXT_VERSION}/linux_${TARGETARCH}/httpfs
-
-COPY --from=builder --chown=appuser:appuser \
-    /ladybug-extension/${LADYBUG_EXT_VERSION}/linux_${TARGETARCH}/duckdb \
-    /home/appuser/.lbug/extension/${LADYBUG_EXT_VERSION}/linux_${TARGETARCH}/duckdb
+    /home/appuser/.lbdb/extension/${LADYBUG_EXT_VERSION}/linux_${TARGETARCH}/httpfs
 
 COPY --from=builder --chown=appuser:appuser \
     /ladybug-extension/${LADYBUG_EXT_VERSION}/linux_${TARGETARCH}/vector \
-    /home/appuser/.lbug/extension/${LADYBUG_EXT_VERSION}/linux_${TARGETARCH}/vector
-
-# Copy libduckdb.so to the common extension directory where LadybugDB looks for it
-# This is required by the DuckDB extension to actually load DuckDB functionality
-RUN mkdir -p /home/appuser/.lbug/extension/${LADYBUG_EXT_VERSION}/linux_${TARGETARCH}/common
-COPY --from=builder --chown=appuser:appuser \
-    /usr/local/lib/libduckdb.so \
-    /home/appuser/.lbug/extension/${LADYBUG_EXT_VERSION}/linux_${TARGETARCH}/common/libduckdb.so
+    /home/appuser/.lbdb/extension/${LADYBUG_EXT_VERSION}/linux_${TARGETARCH}/vector
 
 # Switch to non-root user
 USER appuser

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,9 +26,9 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
 # Copy LadybugDB extensions from official extension repository
 # Extensions pulled from ghcr.io/ladybugdb/extension-repo:latest
 ARG TARGETARCH=arm64
-# Extension version: pinned to match the real_ladybug Python package for ABI compatibility.
+# Extension version: pinned to match the ladybug Python package for ABI compatibility.
 # This version is used for both the repo source path and the runtime install path.
-ARG LADYBUG_EXT_VERSION=0.13.0
+ARG LADYBUG_EXT_VERSION=0.18.1
 
 # Create extension directories using internal version (where LadybugDB looks)
 RUN mkdir -p /ladybug-extension/${LADYBUG_EXT_VERSION}/linux_${TARGETARCH}/httpfs \
@@ -59,22 +59,12 @@ COPY --from=extensions \
     /usr/share/nginx/html/v${LADYBUG_EXT_VERSION}/linux_${TARGETARCH}/vector/libvector.lbug_extension \
     /ladybug-extension/${LADYBUG_EXT_VERSION}/linux_${TARGETARCH}/vector/libvector.lbug_extension
 
-# Download DuckDB shared library from official release (required by LadybugDB DuckDB extension)
-# DuckDB v1.4.x uses architecture naming: arm64/amd64 (not aarch64)
-RUN DUCKDB_VERSION=1.4.4 && \
-    if [ "${TARGETARCH}" = "arm64" ]; then \
-        DUCKDB_SHA256="c8e20af1e0064bdb7bf79af4d16f17ee8be16803bc98a4df58588bed1301c042"; \
-    elif [ "${TARGETARCH}" = "amd64" ]; then \
-        DUCKDB_SHA256="1ef33048e12235115ac0d277a0aaccbb560e33248144f488b5ac005cd9ba81b5"; \
-    else \
-        echo "ERROR: Unsupported architecture: ${TARGETARCH}" && exit 1; \
-    fi && \
-    curl -L -o /tmp/libduckdb.zip \
-        "https://github.com/duckdb/duckdb/releases/download/v${DUCKDB_VERSION}/libduckdb-linux-${TARGETARCH}.zip" && \
-    unzip -j /tmp/libduckdb.zip "libduckdb.so" -d /usr/local/lib/ && \
-    rm /tmp/libduckdb.zip && \
-    echo "${DUCKDB_SHA256}  /usr/local/lib/libduckdb.so" | sha256sum -c - || \
-        (echo "ERROR: libduckdb.so checksum verification failed!" && exit 1)
+# DuckDB shared library (required by LadybugDB DuckDB extension): copy the
+# version-matched build shipped in the extension repo's common/ directory —
+# guarantees ABI compatibility with the duckdb extension of the same bundle.
+COPY --from=extensions \
+    /usr/share/nginx/html/v${LADYBUG_EXT_VERSION}/linux_${TARGETARCH}/common/libduckdb.so \
+    /usr/local/lib/libduckdb.so
 
 # Verify LadybugDB extension integrity
 # Basic integrity check: verify files exist, are non-empty, and are valid ELF binaries
@@ -147,7 +137,7 @@ FROM python:3.13-slim
 # Accept architecture argument in runtime stage
 ARG TARGETARCH=arm64
 # Must match builder stage — used for extension install paths
-ARG LADYBUG_EXT_VERSION=0.13.0
+ARG LADYBUG_EXT_VERSION=0.18.1
 
 # Set environment variables
 ENV PYTHONUNBUFFERED=1 \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     # OLAP Staging/Vector/Graph Databases
     "duckdb==1.4.4",
     "lancedb>=0.30.0,<0.31",  # hold: 0.33 routes table.to_pandas() through pylance (beta-only); upgrade separately
-    "real-ladybug==0.13.1",
+    "ladybug==0.18.1",
     # OLTP Database (Postgres)
     "alembic>=1.18.0,<2.0",
     "psycopg2-binary>=2.9.0,<3.0",

--- a/robosystems/adapters/sec/processors/classify.py
+++ b/robosystems/adapters/sec/processors/classify.py
@@ -10,7 +10,7 @@ Two classification layers:
    elements against the Seattle Method disclosure mechanics taxonomy (143 mappings).
 
 Results are returned as DataFrames for the existing parquet pipeline to pick up.
-This module uses real_ladybug directly — no Graph API, no HTTP.
+This module uses ladybug directly — no Graph API, no HTTP.
 """
 
 from __future__ import annotations
@@ -290,7 +290,7 @@ class TempLadybugContext:
   """Temporary embedded LadybugDB for per-filing Cypher-based analysis.
 
   Creates a LadybugDB database in a temp directory, installs schema DDL,
-  and cleans up on exit. Uses real_ladybug directly — no Graph API.
+  and cleans up on exit. Uses ladybug directly — no Graph API.
   """
 
   def __init__(self, ddl_statements: list[str] | None = None):
@@ -300,7 +300,7 @@ class TempLadybugContext:
     self._ddl = ddl_statements or _generate_ddl()
 
   def __enter__(self) -> TempLadybugContext:
-    import real_ladybug as lbug
+    import ladybug as lbug
 
     self._tmpdir = tempfile.mkdtemp(prefix="lbug_classify_")
     db_path = str(Path(self._tmpdir) / "classify.lbug")

--- a/robosystems/config/openapi_tags.py
+++ b/robosystems/config/openapi_tags.py
@@ -172,7 +172,7 @@ GRAPH_API_TAGS = [
   },
   {
     "name": "Vector Index",
-    "description": "🔮 Vector index - Build and search vector indexes (LadybugDB HNSW + LanceDB IVF-PQ)",
+    "description": "🔮 Vector index - Build LadybugDB HNSW indexes (searched in Cypher via QUERY_VECTOR_INDEX)",
   },
   {
     "name": "Semantic Memory",

--- a/robosystems/dagster/jobs/extensions.py
+++ b/robosystems/dagster/jobs/extensions.py
@@ -46,8 +46,8 @@ def materialize_extensions_to_graph(
   """Materialize extensions OLTP data to LadybugDB graph.
 
   Uses postgres_scanner to read from the extensions tenant schema,
-  stages into DuckDB, then materializes to LadybugDB via the existing
-  ATTACH + COPY FROM pipeline.
+  stages into DuckDB, then materializes to LadybugDB via the Arrow
+  record-batch streaming handoff (no intermediate file).
   """
   import asyncio
 

--- a/robosystems/graph_api/app.py
+++ b/robosystems/graph_api/app.py
@@ -148,7 +148,9 @@ def create_app() -> FastAPI:
     import shutil
 
     cache_paths_to_clear = [
-      # Current path (after fix): home_dir=base_path, cache at base_path/.lbug/extension
+      # LadybugDB 0.15+ convention: cache at base_path/.lbdb/extension
+      Path(env.LBUG_DATABASE_PATH) / ".lbdb" / "extension",
+      # Pre-0.15 path: home_dir=base_path, cache at base_path/.lbug/extension
       Path(env.LBUG_DATABASE_PATH) / ".lbug" / "extension",
       # Legacy double-nested path: home_dir=base_path/.lbug, cache at base_path/.lbug/.lbug/extension
       Path(env.LBUG_DATABASE_PATH) / ".lbug" / ".lbug" / "extension",

--- a/robosystems/graph_api/core/ladybug/engine.py
+++ b/robosystems/graph_api/core/ladybug/engine.py
@@ -9,7 +9,7 @@ import time
 from pathlib import Path
 from typing import Any
 
-import real_ladybug as lbug
+import ladybug as lbug
 
 from robosystems.config import env
 from robosystems.graph_api.interfaces import GraphEngineInterface, GraphOperation

--- a/robosystems/graph_api/core/ladybug/manager.py
+++ b/robosystems/graph_api/core/ladybug/manager.py
@@ -19,7 +19,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-import real_ladybug as lbug
+import ladybug as lbug
 from fastapi import HTTPException, status
 
 from robosystems.config import env

--- a/robosystems/graph_api/core/ladybug/pool.py
+++ b/robosystems/graph_api/core/ladybug/pool.py
@@ -22,7 +22,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
-import real_ladybug as lbug
+import ladybug as lbug
 
 from robosystems.logger import logger
 

--- a/robosystems/graph_api/core/lance/manager.py
+++ b/robosystems/graph_api/core/lance/manager.py
@@ -1,6 +1,17 @@
 """
 LanceDB Vector Index Manager for Graph API.
 
+DORMANT — NOT DEAD CODE. This is the batch IVF-PQ index builder (build from a
+DuckDB staging query → export as tar.gz). Its only consumer (SEC element-vector
+search) was retired in the 2026-07 embedding cut, so nothing calls build/search/
+export today. It is kept deliberately as the queued IVF-PQ foundation for the
+future `lance` vector-store subgraph (multimodal-knowledge-graph spec §58/§118);
+that subgraph pairs this batch-index side with the incremental-CRUD side of
+`LanceMemoryStore`. The LIVE vector path is instead LadybugDB-native in-graph
+HNSW (`CALL QUERY_VECTOR_INDEX`). Do not remove without retiring the lance
+subgraph plan. (`delete` is the one method still live — called on database drop
+to tear down the whole graph lance dir, including memory.)
+
 Manages per-graph, per-table LanceDB IVF-PQ vector indexes on graph instances.
 Follows the same lifecycle pattern as DuckDB staging:
 

--- a/robosystems/graph_api/core/migration_service.py
+++ b/robosystems/graph_api/core/migration_service.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from typing import Any
 
 import boto3
-import real_ladybug as lbug
+import ladybug as lbug
 from boto3.s3.transfer import TransferConfig
 
 from robosystems.config import env

--- a/robosystems/graph_api/routers/databases/tables/materialize.py
+++ b/robosystems/graph_api/routers/databases/tables/materialize.py
@@ -343,9 +343,10 @@ async def _materialize_table_impl(
 
         export_dir = f"{env.DUCKDB_STAGING_PATH}/materialize-exports"
         os.makedirs(export_dir, exist_ok=True)
-        export_path = (
-          f"{export_dir}/{duckdb_graph_id}_{table_name}_{uuid4().hex}.parquet"
-        )
+        # Filename is a bare UUID — never interpolate the request-supplied
+        # graph_id / table_name into a filesystem path (path traversal). The
+        # graph/table identity is carried in the surrounding log lines.
+        export_path = f"{export_dir}/{uuid4().hex}.parquet"
 
         export_sql = (
           f"COPY (SELECT {select_expr} FROM {table_name}{where}) "
@@ -463,7 +464,7 @@ async def _materialize_table_impl(
           os.remove(export_path)
           logger.debug(f"Cleaned up parquet export: {export_path}")
         except FileNotFoundError:
-          pass
+          pass  # already gone (export never created, or removed on a retry) — nothing to clean
         except Exception as rm_err:
           logger.warning(f"Failed to remove parquet export {export_path}: {rm_err}")
 
@@ -482,7 +483,7 @@ async def _materialize_table_impl(
       try:
         os.remove(export_path)
       except OSError:
-        pass
+        pass  # best-effort cleanup on the export-stage failure path; original error is re-raised below
     raise HTTPException(
       status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
       detail=f"Failed to materialize table: {outer_err!s}",
@@ -619,9 +620,9 @@ async def _fork_from_parent_duckdb_impl(
             [(col[0], col[1]) for col in source_columns],
             exclude_cols=exclude_cols,
           )
-          export_path = (
-            f"{export_dir}/{parent_graph_id}_{table_name}_{uuid4().hex}.parquet"
-          )
+          # Bare-UUID filename — never interpolate the request-supplied
+          # parent_graph_id / table_name into a filesystem path (path traversal).
+          export_path = f"{export_dir}/{uuid4().hex}.parquet"
           duck_conn.execute(
             f"COPY (SELECT {select_expr} FROM {table_name}) "
             f"TO '{export_path}' (FORMAT parquet)"
@@ -704,7 +705,7 @@ async def _fork_from_parent_duckdb_impl(
         try:
           os.remove(export_path)
         except OSError:
-          pass
+          pass  # best-effort cleanup; a leftover export is harmless staging cruft
       if exports:
         logger.info(f"Cleaned up {len(exports)} parquet exports")
 

--- a/robosystems/graph_api/routers/databases/tables/materialize.py
+++ b/robosystems/graph_api/routers/databases/tables/materialize.py
@@ -21,8 +21,8 @@ from robosystems.middleware.graph.instance_busy import (
 )
 
 # Rows per Arrow record batch streamed from DuckDB into LadybugDB. Bounds peak
-# memory during the zero-copy handoff — the table never fully materializes in
-# RAM regardless of its size.
+# memory — the table streams through in batches rather than materializing fully
+# in RAM regardless of its size.
 ARROW_STREAM_BATCH_ROWS = 100_000
 
 
@@ -361,11 +361,13 @@ async def _materialize_table_impl(
             null_cols=null_cols,
           )
 
-        # Stream DuckDB → Arrow record batches → LadybugDB COPY. No intermediate
-        # file: DuckDB emits Arrow batches straight from its result vectors and
-        # LadybugDB scans each batch's buffers directly (the zero-copy handoff).
-        # Batching bounds peak memory regardless of table size; DECIMAL columns
-        # (postgres_scan-staged NUMERIC) ride through the Arrow types natively.
+        # Stream DuckDB → Arrow record batches → LadybugDB COPY, no intermediate
+        # file. DuckDB hands its result vectors to Arrow (zero-copy for most
+        # types); LadybugDB reads those buffers and builds its own graph storage.
+        # The transport avoids the parquet serialization + disk round-trip — but
+        # the write into LadybugDB's CSR storage is still a copy, unavoidable for
+        # a persistent, traversable graph. Batching bounds peak memory; DECIMAL
+        # (postgres_scan-staged NUMERIC) rides through the Arrow types natively.
         select_sql = f"SELECT {select_expr} FROM {table_name}{where}"
         if query_params:
           arrow_reader = duck_conn.execute(select_sql, query_params).fetch_record_batch(

--- a/robosystems/graph_api/routers/databases/tables/materialize.py
+++ b/robosystems/graph_api/routers/databases/tables/materialize.py
@@ -1,3 +1,6 @@
+import os
+from uuid import uuid4
+
 from fastapi import APIRouter, Body, Depends, HTTPException, Path
 from fastapi import status as http_status
 
@@ -66,29 +69,31 @@ def _get_target_columns(
     return None
 
 
-_RECONCILE_IGNORE_COLS = frozenset({"file_id", "from", "to", "src", "dst"})
+def _build_type_safe_select(
+  source_columns: list[tuple[str, str]],
+  exclude_cols: set[str] | None = None,
+  null_cols: set[str] | None = None,
+) -> str:
+  """Build a SELECT for parquet export when the target schema is unknown.
 
-
-def _needs_reconciliation(
-  target_columns: list[tuple[str, str]] | None,
-  source_column_names: list[str],
-) -> bool:
-  """Return True when source columns don't match target columns by name AND order.
-
-  LadybugDB COPY is positional, so a source table whose column names match the
-  target's but in a different order will silently misalign data into the wrong
-  columns. This commonly happens when a new property is added in the middle of
-  an existing node schema and the DuckDB staging table evolves via
-  `ALTER TABLE ADD COLUMN` (which appends at the end). A pure set comparison
-  misses this; we compare ordered lists.
-
-  `from`/`to`/`src`/`dst`/`file_id` are excluded — they're implicit/synthetic.
+  Preserves source column order; casts DECIMAL columns to DOUBLE because
+  LadybugDB's parquet reader rejects DECIMAL converted types (postgres_scan
+  stages Postgres NUMERIC as DuckDB DECIMAL). Columns in null_cols are
+  exported as typed NULLs (preserving column count for positional COPY).
   """
-  if not target_columns:
-    return False
-  target_order = [c[0] for c in target_columns if c[0] not in _RECONCILE_IGNORE_COLS]
-  source_order = [c for c in source_column_names if c not in _RECONCILE_IGNORE_COLS]
-  return target_order != source_order
+  exclude = exclude_cols or set()
+  nullify = null_cols or set()
+  parts = []
+  for col_name, duck_type in source_columns:
+    if col_name in exclude:
+      continue
+    if col_name in nullify:
+      parts.append(f'NULL::{duck_type} AS "{col_name}"')
+    elif duck_type.upper().startswith("DECIMAL"):
+      parts.append(f'CAST("{col_name}" AS DOUBLE) AS "{col_name}"')
+    else:
+      parts.append(f'"{col_name}"')
+  return ", ".join(parts)
 
 
 def _build_reconciled_select(
@@ -216,31 +221,25 @@ async def _materialize_table_impl(
 ) -> TableMaterializationResponse:
   import time
 
+  export_path: str | None = None
+
   try:
     # Blue-green: read DuckDB from source graph if specified, otherwise from target
     duckdb_graph_id = request.source_graph_id or graph_id
-    duck_path = f"{env.DUCKDB_STAGING_PATH}/{duckdb_graph_id}.duckdb"
 
-    # CRITICAL: Checkpoint DuckDB to flush WAL to main database BEFORE LadybugDB attaches
-    # LadybugDB's DuckDB extension creates a new session that won't see uncommitted WAL data
-    logger.debug(
-      f"Checkpointing DuckDB database before LadybugDB materialization: {duck_path}"
-    )
     from robosystems.graph_api.core.duckdb import get_duckdb_pool
 
     duckdb_pool = get_duckdb_pool()
-    temp_table_name = f"{table_name}_temp_materialization"
 
     # Get target table schema from LadybugDB for column reconciliation
-    # This handles schema evolution: parquet files missing new columns or
+    # This handles schema evolution: staging tables missing new columns or
     # having mistyped NULL columns (e.g., DuckDB infers all-NULL as INT32
     # but target expects FLOAT[384])
     target_columns = _get_target_columns(ladybug_service, graph_id, table_name)
 
-    # Check if table exists, create temp copy without file_id
-    temp_table_created = False
     try:
       with duckdb_pool.get_connection(duckdb_graph_id) as duck_conn:
+        # Flush WAL so the parquet export sees all committed staging data
         checkpoint_with_retry(duck_conn, duckdb_graph_id, context="DuckDB")
 
         # Check if table exists
@@ -261,21 +260,13 @@ async def _materialize_table_impl(
             execution_time_ms=0.0,
           )
 
-        # Drop temp table if it exists from previous failed run
-        try:
-          duck_conn.execute(f"DROP TABLE IF EXISTS {temp_table_name}")
-        except Exception:
-          pass
-
-        # Check if file_id column exists in the table
-        columns_result = duck_conn.execute(
-          "SELECT column_name FROM information_schema.columns WHERE table_name = ?",
+        source_columns = duck_conn.execute(
+          "SELECT column_name, data_type FROM information_schema.columns "
+          "WHERE table_name = ? ORDER BY ordinal_position",
           [table_name],
         ).fetchall()
-        column_names = [col[0] for col in columns_result]
+        column_names = [col[0] for col in source_columns]
         has_file_id = "file_id" in column_names
-
-        needs_reconciliation = _needs_reconciliation(target_columns, column_names)
 
         # Columns to NULL out (keep column for schema match, but skip data).
         # Embeddings stay in DuckDB staging for LanceDB vector search; materializing
@@ -288,140 +279,102 @@ async def _materialize_table_impl(
             f"(pass materialize_embeddings=true to include)"
           )
 
-        # Optimization: Skip temp table when not needed (no file_id, no batching, no filter, no reconciliation, no null cols)
+        # Build WHERE clause for batched materialization
+        batch_clause = ""
         has_hash_batching = (
           request.num_batches is not None and request.batch_num is not None
         )
-        can_skip_temp_table = (
-          not has_file_id
-          and not has_hash_batching
-          and not request.file_ids
-          and not needs_reconciliation
-          and not null_cols
+        if has_hash_batching:
+          assert request.batch_num is not None and request.num_batches is not None
+
+          if "identifier" in column_names:
+            hash_col = "identifier"
+          elif "src" in column_names and "dst" in column_names:
+            hash_col = "src || '|' || dst"
+          else:
+            hash_col = column_names[0] if column_names else "rowid"
+
+          batch_clause = f" WHERE abs(hash({hash_col}::VARCHAR)) % {request.num_batches} = {request.batch_num}"
+          logger.info(
+            f"Using hash-based batching for {table_name}: batch {request.batch_num + 1}/{request.num_batches}"
+          )
+
+        # Build file filter clause
+        file_filter = ""
+        query_params: list[str] = []
+        if request.file_ids and has_file_id:
+          file_ids_placeholders = ", ".join(["?" for _ in request.file_ids])
+          file_filter = f"file_id IN ({file_ids_placeholders})"
+          query_params.extend(request.file_ids)
+
+        # Build WHERE clause combining file filter and batch clause
+        where = ""
+        if file_filter and batch_clause:
+          where = f" WHERE {file_filter} AND ({batch_clause.replace(' WHERE ', '')})"
+        elif file_filter:
+          where = f" WHERE {file_filter}"
+        elif batch_clause:
+          where = batch_clause
+
+        # Columns to exclude from materialization
+        exclude_cols: set[str] = set()
+        if has_file_id:
+          exclude_cols.add("file_id")
+
+        # Build the export SELECT. When the LadybugDB target schema is known,
+        # reconcile to it — target column order, NULLs for missing columns,
+        # and casts to the target types. The casts double as parquet type
+        # normalization: LadybugDB's parquet reader rejects DECIMAL converted
+        # types, and postgres_scan-staged NUMERIC columns arrive as DECIMAL.
+        if target_columns:
+          select_expr = _build_reconciled_select(
+            target_columns,
+            column_names,
+            table_name,
+            exclude_cols=exclude_cols,
+            null_cols=null_cols,
+          )
+        else:
+          select_expr = _build_type_safe_select(
+            [(col[0], col[1]) for col in source_columns],
+            exclude_cols=exclude_cols,
+            null_cols=null_cols,
+          )
+
+        export_dir = f"{env.DUCKDB_STAGING_PATH}/materialize-exports"
+        os.makedirs(export_dir, exist_ok=True)
+        export_path = (
+          f"{export_dir}/{duckdb_graph_id}_{table_name}_{uuid4().hex}.parquet"
         )
 
-        if can_skip_temp_table:
-          # Fast path: COPY directly from source table
-          logger.info(f"Using direct COPY for {table_name} (no temp table needed)")
-          temp_table_created = False
+        export_sql = (
+          f"COPY (SELECT {select_expr} FROM {table_name}{where}) "
+          f"TO '{export_path}' (FORMAT parquet)"
+        )
+        if query_params:
+          duck_conn.execute(export_sql, query_params)
         else:
-          # Build WHERE clause for batched materialization
-          batch_clause = ""
+          duck_conn.execute(export_sql)
 
-          if has_hash_batching:
-            assert request.batch_num is not None and request.num_batches is not None
-
-            if "identifier" in column_names:
-              hash_col = "identifier"
-            elif "src" in column_names and "dst" in column_names:
-              hash_col = "src || '|' || dst"
-            else:
-              hash_col = column_names[0] if column_names else "rowid"
-
-            batch_clause = f" WHERE abs(hash({hash_col}::VARCHAR)) % {request.num_batches} = {request.batch_num}"
-            logger.info(
-              f"Using hash-based batching for {table_name}: batch {request.batch_num + 1}/{request.num_batches}"
-            )
-
-          # Build file filter clause
-          file_filter = ""
-          query_params: list[str] = []
-          if request.file_ids and has_file_id:
-            file_ids_placeholders = ", ".join(["?" for _ in request.file_ids])
-            file_filter = f"file_id IN ({file_ids_placeholders})"
-            query_params.extend(request.file_ids)
-
-          # Build WHERE clause combining file filter and batch clause
-          where = ""
-          if file_filter and batch_clause:
-            where = f" WHERE {file_filter} AND ({batch_clause.replace(' WHERE ', '')})"
-          elif file_filter:
-            where = f" WHERE {file_filter}"
-          elif batch_clause:
-            where = batch_clause
-
-          # Columns to exclude from materialization
-          exclude_cols: set[str] = set()
-          if has_file_id:
-            exclude_cols.add("file_id")
-
-          # Build SELECT expression
-          # Force reconciliation when nulling columns — the reconciled path
-          # iterates target columns (not source), so column count always matches.
-          use_reconciliation = (needs_reconciliation or null_cols) and target_columns
-          if use_reconciliation:
-            select_expr = _build_reconciled_select(
-              target_columns,
-              column_names,
-              table_name,
-              exclude_cols=exclude_cols,
-              null_cols=null_cols,
-            )
-            logger.debug(
-              f"Reconciling columns for {table_name} "
-              f"(source: {len(column_names)}, target: {len(target_columns)})"
-            )
-          elif exclude_cols:
-            exclude_list = ", ".join(exclude_cols)
-            select_expr = f"* EXCLUDE ({exclude_list})"
-          else:
-            select_expr = "*"
-
-          create_sql = (
-            f"CREATE TABLE {temp_table_name} AS "
-            f"SELECT {select_expr} FROM {table_name}{where}"
+        if request.file_ids:
+          logger.info(
+            f"Exported {table_name} to parquet with {len(request.file_ids)} file(s)"
           )
-          if query_params:
-            duck_conn.execute(create_sql, query_params)
-          else:
-            duck_conn.execute(create_sql)
-
-          if request.file_ids:
-            logger.info(
-              f"Created temp DuckDB table {temp_table_name} with {len(request.file_ids)} file(s)"
-            )
-          elif has_hash_batching:
-            assert request.batch_num is not None and request.num_batches is not None
-            logger.info(
-              f"Created temp DuckDB table {temp_table_name} for hash-based materialization "
-              f"(batch {request.batch_num + 1}/{request.num_batches})"
-            )
-          else:
-            logger.debug(
-              f"Created temp DuckDB table {temp_table_name} for full materialization"
-            )
-          temp_table_created = True
+        elif has_hash_batching:
+          assert request.batch_num is not None and request.num_batches is not None
+          logger.info(
+            f"Exported {table_name} to parquet "
+            f"(batch {request.batch_num + 1}/{request.num_batches})"
+          )
+        else:
+          logger.debug(f"Exported {table_name} to parquet for full materialization")
 
     except Exception as err:
-      logger.error(f"Could not prepare DuckDB table for materialization: {err}")
+      logger.error(f"Could not export DuckDB table for materialization: {err}")
       raise
 
     try:
       with ladybug_service.db_manager.connection_pool.get_connection(graph_id) as conn:
-        # Install and load DuckDB extension - LadybugDB finds it at
-        # ~/.lbug/extension/{VERSION}/{PLATFORM}/duckdb/ (bundled in Docker image)
-        try:
-          conn.execute("INSTALL duckdb")
-          conn.execute("LOAD duckdb")
-          logger.debug("Loaded DuckDB extension")
-        except Exception as e:
-          if "already loaded" not in str(e).lower():
-            logger.warning(f"Failed to load DuckDB extension: {e}")
-            raise
-
-        # Detach first if already attached
-        try:
-          conn.execute("DETACH duck")
-        except Exception:
-          pass
-
-        # Attach DuckDB database
-        conn.execute(f"ATTACH '{duck_path}' AS duck (DBTYPE duckdb)")
-        logger.debug(f"Attached DuckDB database: {duck_path}")
-
-        # Determine source table for COPY (temp table or direct source)
-        source_table = table_name if not temp_table_created else temp_table_name
-
         if request.file_ids:
           logger.info(
             f"COPY {table_name} → {graph_id} ({len(request.file_ids)} file(s))"
@@ -430,11 +383,9 @@ async def _materialize_table_impl(
           logger.info(f"COPY {table_name} → {graph_id}")
 
         if request.ignore_errors:
-          copy_query = (
-            f"COPY {table_name} FROM duck.{source_table} (ignore_errors=true)"
-          )
+          copy_query = f"COPY {table_name} FROM '{export_path}' (ignore_errors=true)"
         else:
-          copy_query = f"COPY {table_name} FROM duck.{source_table}"
+          copy_query = f"COPY {table_name} FROM '{export_path}'"
 
         # Set extended timeout for COPY operations (30 minutes)
         # Default connection timeout is 120s, but large tables like Fact
@@ -506,27 +457,32 @@ async def _materialize_table_impl(
       )
 
     finally:
-      # Clean up temp table and release DuckDB memory
-      if temp_table_created:
-        # Drop temp table
+      # Clean up the parquet export and release DuckDB memory
+      if export_path:
         try:
-          with duckdb_pool.get_connection(duckdb_graph_id) as duck_conn:
-            duck_conn.execute(f"DROP TABLE IF EXISTS {temp_table_name}")
-            logger.debug(f"Cleaned up temp DuckDB table: {temp_table_name}")
-        except Exception as drop_err:
-          logger.warning(f"Failed to drop temp table {temp_table_name}: {drop_err}")
+          os.remove(export_path)
+          logger.debug(f"Cleaned up parquet export: {export_path}")
+        except FileNotFoundError:
+          pass
+        except Exception as rm_err:
+          logger.warning(f"Failed to remove parquet export {export_path}: {rm_err}")
 
-        # Checkpoint and release connections (always attempt even if drop failed)
-        try:
-          with duckdb_pool.get_connection(duckdb_graph_id) as duck_conn:
-            duck_conn.execute("CHECKPOINT")
-          duckdb_pool.close_database_connections(duckdb_graph_id)
-          logger.debug(f"Released DuckDB connections for {duckdb_graph_id}")
-        except Exception as release_err:
-          logger.warning(f"Failed to release DuckDB connections: {release_err}")
+      try:
+        with duckdb_pool.get_connection(duckdb_graph_id) as duck_conn:
+          duck_conn.execute("CHECKPOINT")
+        duckdb_pool.close_database_connections(duckdb_graph_id)
+        logger.debug(f"Released DuckDB connections for {duckdb_graph_id}")
+      except Exception as release_err:
+        logger.warning(f"Failed to release DuckDB connections: {release_err}")
 
   except Exception as outer_err:
-    logger.error(f"Failed during table preparation or materialization: {outer_err}")
+    logger.error(f"Failed during table export or materialization: {outer_err}")
+    # An export-stage failure skips the inner finally — remove the file here too
+    if export_path:
+      try:
+        os.remove(export_path)
+      except OSError:
+        pass
     raise HTTPException(
       status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
       detail=f"Failed to materialize table: {outer_err!s}",
@@ -641,77 +597,55 @@ async def _fork_from_parent_duckdb_impl(
         detail="No tables to copy",
       )
 
-    # Create temp physical tables in parent DuckDB for each table (excluding file_id if exists)
-    temp_tables = []
+    # Export each table (excluding file_id) to parquet, then COPY into the
+    # subgraph. Parquet handoff replaces the previous DuckDB-ATTACH path —
+    # LadybugDB 0.14+ creates persistent shadow catalog entries on ATTACH
+    # that collide with installed schema.
+    export_dir = f"{env.DUCKDB_STAGING_PATH}/materialize-exports"
+    exports: list[tuple[str, str]] = []
     try:
+      os.makedirs(export_dir, exist_ok=True)
       with duckdb_pool.get_connection(parent_graph_id) as duck_conn:
         for table_name in tables_to_copy:
-          temp_table = f"{table_name}_temp_fork"
-          temp_tables.append(temp_table)
-
-          # Drop if exists from previous failed run
-          duck_conn.execute(f"DROP TABLE IF EXISTS {temp_table}")
-
-          # Check if file_id column exists in the table
-          columns_result = duck_conn.execute(
-            "SELECT column_name FROM information_schema.columns WHERE table_name = ?",
+          source_columns = duck_conn.execute(
+            "SELECT column_name, data_type FROM information_schema.columns "
+            "WHERE table_name = ? ORDER BY ordinal_position",
             [table_name],
           ).fetchall()
-          column_names = [col[0] for col in columns_result]
-          has_file_id = "file_id" in column_names
+          exclude_cols = (
+            {"file_id"} if any(col[0] == "file_id" for col in source_columns) else set()
+          )
+          select_expr = _build_type_safe_select(
+            [(col[0], col[1]) for col in source_columns],
+            exclude_cols=exclude_cols,
+          )
+          export_path = (
+            f"{export_dir}/{parent_graph_id}_{table_name}_{uuid4().hex}.parquet"
+          )
+          duck_conn.execute(
+            f"COPY (SELECT {select_expr} FROM {table_name}) "
+            f"TO '{export_path}' (FORMAT parquet)"
+          )
+          exports.append((table_name, export_path))
+        logger.info(f"Exported {len(exports)} parent DuckDB tables to parquet for fork")
 
-          # Create physical temp table without file_id (if it exists)
-          if has_file_id:
-            duck_conn.execute(
-              f"CREATE TABLE {temp_table} AS SELECT * EXCLUDE (file_id) FROM {table_name}"
-            )
-          else:
-            duck_conn.execute(
-              f"CREATE TABLE {temp_table} AS SELECT * FROM {table_name}"
-            )
-        logger.info(f"Created {len(temp_tables)} temp tables in parent DuckDB for fork")
-
-      # Connect to subgraph LadybugDB and attach parent DuckDB
       total_rows = 0
       tables_copied = []
 
       with ladybug_service.db_manager.connection_pool.get_connection(
         subgraph_id
       ) as conn:
-        # Install and load DuckDB extension - LadybugDB finds it at
-        # ~/.lbug/extension/{VERSION}/{PLATFORM}/duckdb/ (bundled in Docker image)
-        try:
-          conn.execute("INSTALL duckdb")
-          conn.execute("LOAD duckdb")
-          logger.debug("Loaded DuckDB extension")
-        except Exception as e:
-          if "already loaded" not in str(e).lower():
-            logger.warning(f"Failed to load DuckDB extension: {e}")
-            raise
-
-        # Detach first if already attached
-        try:
-          conn.execute("DETACH parent_duck")
-        except Exception:
-          pass
-
-        # Attach parent DuckDB as 'parent_duck'
-        conn.execute(f"ATTACH '{parent_duck_path}' AS parent_duck (DBTYPE duckdb)")
-        logger.info(f"Attached parent DuckDB: {parent_duck_path}")
-
-        # Copy each table from the temp tables we created in parent DuckDB
-        for idx, table_name in enumerate(tables_to_copy):
+        # Copy each table from its parquet export
+        for table_name, export_path in exports:
           try:
-            temp_table = temp_tables[idx]
-
             if request.ignore_errors:
               copy_query = (
-                f"COPY {table_name} FROM parent_duck.{temp_table} (ignore_errors=true)"
+                f"COPY {table_name} FROM '{export_path}' (ignore_errors=true)"
               )
             else:
-              copy_query = f"COPY {table_name} FROM parent_duck.{temp_table}"
+              copy_query = f"COPY {table_name} FROM '{export_path}'"
 
-            logger.info(f"Copying {table_name} from parent to subgraph")
+            logger.info(f"Copying {table_name} from parent export to subgraph")
             # Set extended timeout for COPY operations (30 minutes)
             try:
               conn.execute("CALL timeout=3600000")  # 60 minutes
@@ -740,12 +674,6 @@ async def _fork_from_parent_duckdb_impl(
             if not request.ignore_errors:
               raise
 
-      # Detach parent DuckDB
-      try:
-        conn.execute("DETACH parent_duck")
-      except Exception:
-        pass
-
       execution_time_ms = (time.time() - start_time) * 1000
 
       logger.info(
@@ -771,15 +699,14 @@ async def _fork_from_parent_duckdb_impl(
       )
 
     finally:
-      # Clean up temp tables
-      if temp_tables:
+      # Clean up parquet exports
+      for _, export_path in exports:
         try:
-          with duckdb_pool.get_connection(parent_graph_id) as duck_conn:
-            for temp_table in temp_tables:
-              duck_conn.execute(f"DROP TABLE IF EXISTS {temp_table}")
-            logger.info(f"Cleaned up {len(temp_tables)} temp tables from parent DuckDB")
-        except Exception as cleanup_err:
-          logger.warning(f"Failed to clean up temp tables: {cleanup_err}")
+          os.remove(export_path)
+        except OSError:
+          pass
+      if exports:
+        logger.info(f"Cleaned up {len(exports)} parquet exports")
 
   except Exception as outer_err:
     logger.error(f"Failed during fork preparation: {outer_err}")

--- a/robosystems/graph_api/routers/databases/tables/materialize.py
+++ b/robosystems/graph_api/routers/databases/tables/materialize.py
@@ -1,6 +1,6 @@
-import os
-from uuid import uuid4
+import re
 
+import pyarrow as pa
 from fastapi import APIRouter, Body, Depends, HTTPException, Path
 from fastapi import status as http_status
 
@@ -19,6 +19,28 @@ from robosystems.middleware.graph.instance_busy import (
   OP_KIND_MATERIALIZATION,
   instance_busy,
 )
+
+# Rows per Arrow record batch streamed from DuckDB into LadybugDB. Bounds peak
+# memory during the zero-copy handoff — the table never fully materializes in
+# RAM regardless of its size.
+ARROW_STREAM_BATCH_ROWS = 100_000
+
+
+def _copy_result_rows(result, fallback: int) -> int:
+  """Ingested-row count from a LadybugDB COPY result, or ``fallback`` if the
+  result message can't be parsed."""
+  try:
+    if result is not None and hasattr(result, "get_as_arrow"):
+      arrow_table = result.get_as_arrow()
+      if arrow_table.num_rows > 0 and arrow_table.num_columns > 0:
+        msg = str(arrow_table.column(0)[0].as_py())
+        match = re.search(r"(\d+)\s+tuples?", msg)
+        if match:
+          return int(match.group(1))
+  except Exception:
+    return fallback
+  return fallback
+
 
 # Type mapping from LadybugDB types to DuckDB-compatible cast types
 _LBUG_TO_DUCK_TYPE = {
@@ -74,12 +96,13 @@ def _build_type_safe_select(
   exclude_cols: set[str] | None = None,
   null_cols: set[str] | None = None,
 ) -> str:
-  """Build a SELECT for parquet export when the target schema is unknown.
+  """Build the export SELECT when the target LadybugDB schema is unknown.
 
-  Preserves source column order; casts DECIMAL columns to DOUBLE because
-  LadybugDB's parquet reader rejects DECIMAL converted types (postgres_scan
-  stages Postgres NUMERIC as DuckDB DECIMAL). Columns in null_cols are
-  exported as typed NULLs (preserving column count for positional COPY).
+  Preserves source column order and casts DECIMAL to DOUBLE — LadybugDB has no
+  DECIMAL type (its numeric target columns are DOUBLE), and postgres_scan
+  stages Postgres NUMERIC as DuckDB DECIMAL, so casting at the source keeps the
+  Arrow types unambiguous. Columns in null_cols become typed NULLs (preserving
+  column count for positional COPY).
   """
   exclude = exclude_cols or set()
   nullify = null_cols or set()
@@ -221,8 +244,6 @@ async def _materialize_table_impl(
 ) -> TableMaterializationResponse:
   import time
 
-  export_path: str | None = None
-
   try:
     # Blue-green: read DuckDB from source graph if specified, otherwise from target
     duckdb_graph_id = request.source_graph_id or graph_id
@@ -322,10 +343,9 @@ async def _materialize_table_impl(
           exclude_cols.add("file_id")
 
         # Build the export SELECT. When the LadybugDB target schema is known,
-        # reconcile to it — target column order, NULLs for missing columns,
-        # and casts to the target types. The casts double as parquet type
-        # normalization: LadybugDB's parquet reader rejects DECIMAL converted
-        # types, and postgres_scan-staged NUMERIC columns arrive as DECIMAL.
+        # reconcile to it — target column order, NULLs for missing columns, and
+        # casts to the target types (which also normalize postgres_scan-staged
+        # NUMERIC to DOUBLE, since LadybugDB has no DECIMAL type).
         if target_columns:
           select_expr = _build_reconciled_select(
             target_columns,
@@ -341,149 +361,102 @@ async def _materialize_table_impl(
             null_cols=null_cols,
           )
 
-        export_dir = f"{env.DUCKDB_STAGING_PATH}/materialize-exports"
-        os.makedirs(export_dir, exist_ok=True)
-        # Filename is a bare UUID — never interpolate the request-supplied
-        # graph_id / table_name into a filesystem path (path traversal). The
-        # graph/table identity is carried in the surrounding log lines.
-        export_path = f"{export_dir}/{uuid4().hex}.parquet"
-
-        export_sql = (
-          f"COPY (SELECT {select_expr} FROM {table_name}{where}) "
-          f"TO '{export_path}' (FORMAT parquet)"
-        )
+        # Stream DuckDB → Arrow record batches → LadybugDB COPY. No intermediate
+        # file: DuckDB emits Arrow batches straight from its result vectors and
+        # LadybugDB scans each batch's buffers directly (the zero-copy handoff).
+        # Batching bounds peak memory regardless of table size; DECIMAL columns
+        # (postgres_scan-staged NUMERIC) ride through the Arrow types natively.
+        select_sql = f"SELECT {select_expr} FROM {table_name}{where}"
         if query_params:
-          duck_conn.execute(export_sql, query_params)
-        else:
-          duck_conn.execute(export_sql)
-
-        if request.file_ids:
-          logger.info(
-            f"Exported {table_name} to parquet with {len(request.file_ids)} file(s)"
-          )
-        elif has_hash_batching:
-          assert request.batch_num is not None and request.num_batches is not None
-          logger.info(
-            f"Exported {table_name} to parquet "
-            f"(batch {request.batch_num + 1}/{request.num_batches})"
+          arrow_reader = duck_conn.execute(select_sql, query_params).fetch_record_batch(
+            ARROW_STREAM_BATCH_ROWS
           )
         else:
-          logger.debug(f"Exported {table_name} to parquet for full materialization")
+          arrow_reader = duck_conn.execute(select_sql).fetch_record_batch(
+            ARROW_STREAM_BATCH_ROWS
+          )
 
-    except Exception as err:
-      logger.error(f"Could not export DuckDB table for materialization: {err}")
-      raise
-
-    try:
-      with ladybug_service.db_manager.connection_pool.get_connection(graph_id) as conn:
         if request.file_ids:
           logger.info(
             f"COPY {table_name} → {graph_id} ({len(request.file_ids)} file(s))"
           )
+        elif has_hash_batching:
+          assert request.batch_num is not None and request.num_batches is not None
+          logger.info(
+            f"COPY {table_name} → {graph_id} "
+            f"(batch {request.batch_num + 1}/{request.num_batches})"
+          )
         else:
           logger.info(f"COPY {table_name} → {graph_id}")
 
-        if request.ignore_errors:
-          copy_query = f"COPY {table_name} FROM '{export_path}' (ignore_errors=true)"
-        else:
-          copy_query = f"COPY {table_name} FROM '{export_path}'"
-
-        # Set extended timeout for COPY operations (30 minutes)
-        # Default connection timeout is 120s, but large tables like Fact
-        # can take 2-3 minutes with millions of rows
-        try:
-          conn.execute("CALL timeout=3600000")  # 60 minutes
-          logger.debug(f"Executing: {copy_query}")
-          result = conn.execute(copy_query)
-        finally:
-          # Always reset timeout to default after COPY
-          conn.execute("CALL timeout=120000")  # 2 minutes
-
-      rows_ingested = 0
-      if result and hasattr(result, "get_as_arrow"):
-        arrow_table = result.get_as_arrow()
-        if arrow_table.num_rows > 0 and arrow_table.num_columns > 0:
-          result_msg = str(arrow_table.column(0)[0].as_py())
-          import re
-
-          match = re.search(r"(\d+)\s+tuples?", result_msg)
-          if match:
-            rows_ingested = int(match.group(1))
-
-      execution_time_ms = (time.time() - start_time) * 1000
-
-      logger.info(
-        f"Materialized {rows_ingested} rows from {table_name} in {execution_time_ms / 1000:.1f}s"
-      )
-
-      # Checkpoint and release LadybugDB memory
-      # This prevents memory accumulation during multi-table materialization
-      try:
+        copy_suffix = " (ignore_errors=true)" if request.ignore_errors else ""
+        rows_ingested = 0
         with ladybug_service.db_manager.connection_pool.get_connection(
           graph_id
         ) as conn:
+          # Extended timeout: large tables (Fact) can take minutes per batch.
+          try:
+            conn.execute("CALL timeout=3600000")  # 60 minutes
+            for arrow_batch in arrow_reader:
+              # `copy_batch` is resolved BY NAME from this frame — LadybugDB
+              # scans the Arrow object via a Python replacement scan, so the
+              # local's name MUST match the identifier in the COPY statement.
+              # The F841 suppression is real: the engine reads it, the linter can't see that.
+              copy_batch = pa.Table.from_batches([arrow_batch])  # noqa: F841
+              result = conn.execute(f"COPY {table_name} FROM copy_batch{copy_suffix}")
+              rows_ingested += _copy_result_rows(result, arrow_batch.num_rows)
+          finally:
+            conn.execute("CALL timeout=120000")  # reset to 2 minutes
+
+    except Exception as err:
+      logger.error(f"Could not materialize DuckDB table {table_name}: {err}")
+      raise
+
+    execution_time_ms = (time.time() - start_time) * 1000
+    logger.info(
+      f"Materialized {rows_ingested} rows from {table_name} in {execution_time_ms / 1000:.1f}s"
+    )
+
+    # Checkpoint and release LadybugDB memory (prevents accumulation across a
+    # multi-table materialization run).
+    try:
+      with ladybug_service.db_manager.connection_pool.get_connection(graph_id) as conn:
+        conn.execute("CHECKPOINT")
+        logger.debug(f"Checkpointed LadybugDB after {table_name} materialization")
+
+        # Build vector index when embeddings are materialized (single-pass only).
+        # For batched requests, the caller rebuilds the index after all batches
+        # complete — creating it on batch 1 would only index partial data.
+        is_batched = request.batch_num is not None
+        if request.materialize_embeddings and not is_batched:
+          ladybug_service.db_manager.create_vector_index(conn, table_name)
           conn.execute("CHECKPOINT")
-          logger.debug(f"Checkpointed LadybugDB after {table_name} materialization")
 
-          # Build vector index when embeddings are materialized (single-pass only).
-          # For batched requests, the caller rebuilds the index after all batches
-          # complete — creating it on batch 1 would only index partial data.
-          is_batched = request.batch_num is not None
-          if request.materialize_embeddings and not is_batched:
-            ladybug_service.db_manager.create_vector_index(conn, table_name)
-            conn.execute("CHECKPOINT")
-
-        # Release buffer pool memory - data is safe on disk now
-        ladybug_service.db_manager.connection_pool.force_database_cleanup(
-          graph_id, aggressive=True
-        )
-        logger.debug(f"Released LadybugDB memory after {table_name} materialization")
-      except Exception as cleanup_err:
-        # Log but don't fail - materialization succeeded
-        logger.warning(f"Could not release LadybugDB memory: {cleanup_err}")
-
-      return TableMaterializationResponse(
-        status="success",
-        graph_id=graph_id,
-        table_name=table_name,
-        rows_ingested=rows_ingested,
-        execution_time_ms=execution_time_ms,
+      ladybug_service.db_manager.connection_pool.force_database_cleanup(
+        graph_id, aggressive=True
       )
+      logger.debug(f"Released LadybugDB memory after {table_name} materialization")
+    except Exception as cleanup_err:
+      # Log but don't fail — materialization already succeeded.
+      logger.warning(f"Could not release LadybugDB memory: {cleanup_err}")
 
-    except Exception as e:
-      logger.error(f"Failed to materialize table {table_name}: {e}")
-      raise HTTPException(
-        status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
-        detail=f"Failed to materialize table: {e!s}",
-      )
+    # Release DuckDB staging connections.
+    try:
+      duckdb_pool.close_database_connections(duckdb_graph_id)
+      logger.debug(f"Released DuckDB connections for {duckdb_graph_id}")
+    except Exception as release_err:
+      logger.warning(f"Failed to release DuckDB connections: {release_err}")
 
-    finally:
-      # Clean up the parquet export and release DuckDB memory
-      if export_path:
-        try:
-          os.remove(export_path)
-          logger.debug(f"Cleaned up parquet export: {export_path}")
-        except FileNotFoundError:
-          pass  # already gone (export never created, or removed on a retry) — nothing to clean
-        except Exception as rm_err:
-          logger.warning(f"Failed to remove parquet export {export_path}: {rm_err}")
-
-      try:
-        with duckdb_pool.get_connection(duckdb_graph_id) as duck_conn:
-          duck_conn.execute("CHECKPOINT")
-        duckdb_pool.close_database_connections(duckdb_graph_id)
-        logger.debug(f"Released DuckDB connections for {duckdb_graph_id}")
-      except Exception as release_err:
-        logger.warning(f"Failed to release DuckDB connections: {release_err}")
+    return TableMaterializationResponse(
+      status="success",
+      graph_id=graph_id,
+      table_name=table_name,
+      rows_ingested=rows_ingested,
+      execution_time_ms=execution_time_ms,
+    )
 
   except Exception as outer_err:
-    logger.error(f"Failed during table export or materialization: {outer_err}")
-    # An export-stage failure skips the inner finally — remove the file here too
-    if export_path:
-      try:
-        os.remove(export_path)
-      except OSError:
-        pass  # best-effort cleanup on the export-stage failure path; original error is re-raised below
+    logger.error(f"Failed during table materialization: {outer_err}")
     raise HTTPException(
       status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
       detail=f"Failed to materialize table: {outer_err!s}",
@@ -598,15 +571,17 @@ async def _fork_from_parent_duckdb_impl(
         detail="No tables to copy",
       )
 
-    # Export each table (excluding file_id) to parquet, then COPY into the
-    # subgraph. Parquet handoff replaces the previous DuckDB-ATTACH path —
-    # LadybugDB 0.14+ creates persistent shadow catalog entries on ATTACH
-    # that collide with installed schema.
-    export_dir = f"{env.DUCKDB_STAGING_PATH}/materialize-exports"
-    exports: list[tuple[str, str]] = []
+    # Stream each parent table (excluding file_id) DuckDB → Arrow → subgraph
+    # LadybugDB, no intermediate file. Replaces the previous DuckDB-ATTACH path:
+    # LadybugDB 0.14+ creates persistent shadow catalog entries on ATTACH that
+    # collide with installed schema.
+    total_rows = 0
+    tables_copied: list[str] = []
     try:
-      os.makedirs(export_dir, exist_ok=True)
-      with duckdb_pool.get_connection(parent_graph_id) as duck_conn:
+      with (
+        duckdb_pool.get_connection(parent_graph_id) as duck_conn,
+        ladybug_service.db_manager.connection_pool.get_connection(subgraph_id) as conn,
+      ):
         for table_name in tables_to_copy:
           source_columns = duck_conn.execute(
             "SELECT column_name, data_type FROM information_schema.columns "
@@ -620,63 +595,32 @@ async def _fork_from_parent_duckdb_impl(
             [(col[0], col[1]) for col in source_columns],
             exclude_cols=exclude_cols,
           )
-          # Bare-UUID filename — never interpolate the request-supplied
-          # parent_graph_id / table_name into a filesystem path (path traversal).
-          export_path = f"{export_dir}/{uuid4().hex}.parquet"
-          duck_conn.execute(
-            f"COPY (SELECT {select_expr} FROM {table_name}) "
-            f"TO '{export_path}' (FORMAT parquet)"
-          )
-          exports.append((table_name, export_path))
-        logger.info(f"Exported {len(exports)} parent DuckDB tables to parquet for fork")
+          arrow_reader = duck_conn.execute(
+            f"SELECT {select_expr} FROM {table_name}"
+          ).fetch_record_batch(ARROW_STREAM_BATCH_ROWS)
 
-      total_rows = 0
-      tables_copied = []
-
-      with ladybug_service.db_manager.connection_pool.get_connection(
-        subgraph_id
-      ) as conn:
-        # Copy each table from its parquet export
-        for table_name, export_path in exports:
+          copy_suffix = " (ignore_errors=true)" if request.ignore_errors else ""
+          table_rows = 0
+          logger.info(f"Copying {table_name} from parent to subgraph")
           try:
-            if request.ignore_errors:
-              copy_query = (
-                f"COPY {table_name} FROM '{export_path}' (ignore_errors=true)"
-              )
-            else:
-              copy_query = f"COPY {table_name} FROM '{export_path}'"
-
-            logger.info(f"Copying {table_name} from parent export to subgraph")
-            # Set extended timeout for COPY operations (30 minutes)
-            try:
-              conn.execute("CALL timeout=3600000")  # 60 minutes
-              result = conn.execute(copy_query)
-            finally:
-              # Always reset timeout to default after COPY
-              conn.execute("CALL timeout=120000")  # 2 minutes
-
-            rows_ingested = 0
-            if result and hasattr(result, "get_as_arrow"):
-              arrow_table = result.get_as_arrow()
-              if arrow_table.num_rows > 0 and arrow_table.num_columns > 0:
-                result_msg = str(arrow_table.column(0)[0].as_py())
-                import re
-
-                match = re.search(r"(\d+)\s+tuples?", result_msg)
-                if match:
-                  rows_ingested = int(match.group(1))
-
-            total_rows += rows_ingested
-            tables_copied.append(table_name)
-            logger.info(f"[OK] Copied {table_name}: {rows_ingested} rows")
-
+            conn.execute("CALL timeout=3600000")  # 60 minutes
+            for arrow_batch in arrow_reader:
+              # `copy_batch` is resolved by name from this frame (replacement scan).
+              copy_batch = pa.Table.from_batches([arrow_batch])  # noqa: F841
+              result = conn.execute(f"COPY {table_name} FROM copy_batch{copy_suffix}")
+              table_rows += _copy_result_rows(result, arrow_batch.num_rows)
           except Exception as table_err:
             logger.error(f"Failed to copy {table_name}: {table_err}")
             if not request.ignore_errors:
               raise
+          finally:
+            conn.execute("CALL timeout=120000")  # reset to 2 minutes
+
+          total_rows += table_rows
+          tables_copied.append(table_name)
+          logger.info(f"[OK] Copied {table_name}: {table_rows} rows")
 
       execution_time_ms = (time.time() - start_time) * 1000
-
       logger.info(
         f"Fork completed: {len(tables_copied)} tables, {total_rows:,} rows in {execution_time_ms / 1000:.1f}s"
       )
@@ -698,16 +642,6 @@ async def _fork_from_parent_duckdb_impl(
         status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
         detail=f"Failed to fork data: {e!s}",
       )
-
-    finally:
-      # Clean up parquet exports
-      for _, export_path in exports:
-        try:
-          os.remove(export_path)
-        except OSError:
-          pass  # best-effort cleanup; a leftover export is harmless staging cruft
-      if exports:
-        logger.info(f"Cleaned up {len(exports)} parquet exports")
 
   except Exception as outer_err:
     logger.error(f"Failed during fork preparation: {outer_err}")

--- a/robosystems/graph_api/routers/databases/vector_search.py
+++ b/robosystems/graph_api/routers/databases/vector_search.py
@@ -1,14 +1,20 @@
 """
 Vector index management endpoints for Graph API.
 
-Supports two backends via explicit `backend` field:
+Two backends via the `backend` field:
 
-  - **lance** (default): LanceDB IVF-PQ indexes built from DuckDB staging queries.
-    Used for shared repositories (SEC) where replicas need exported indexes.
+  - **hnsw** — the LIVE path. LadybugDB-native HNSW index on a materialized
+    table. Built here (the materialize path calls build with backend='hnsw');
+    *searched in Cypher* via CALL QUERY_VECTOR_INDEX, NOT the /search route.
+    This is what supplyflow-backend uses.
 
-  - **hnsw**: LadybugDB native HNSW indexes on materialized graph data.
-    Used for user/custom graphs where vector search runs via Cypher
-    (CALL QUERY_VECTOR_INDEX).
+  - **lance** — DORMANT (not dead). LanceDB IVF-PQ built from a DuckDB staging
+    query + tar.gz export. Its original consumer (SEC element-vector search) was
+    retired in the 2026-07 embedding cut; it is kept as the queued IVF-PQ
+    foundation for the future `lance` vector-store subgraph — which, unlike
+    LadybugDB, exposes vector search over THESE routes rather than Cypher
+    (multimodal-knowledge-graph spec §58/§118). Distinct from Semantic Memory
+    (the incremental-CRUD specialization of the same modality).
 
 Endpoints:
 

--- a/robosystems/middleware/graph/utils/subgraph.py
+++ b/robosystems/middleware/graph/utils/subgraph.py
@@ -14,10 +14,14 @@ from ..types import SUBGRAPH_NAME_PATTERN as SUBGRAPH_NAME_PATTERN_STR
 
 
 class SubgraphType(Enum):
-  """Types of subgraphs (for future expansion)."""
+  """Types of subgraphs.
+
+  NOTE: this enum is currently unused — the API-layer SubgraphType in
+  models/api/graphs/subgraphs.py is the live one. Kept minimal; candidate
+  for removal.
+  """
 
   STATIC = "static"  # Traditional environment-based subgraphs
-  VERSIONED = "versioned"  # Git-like version control (future)
 
 
 class SubgraphInfo(NamedTuple):

--- a/robosystems/middleware/mcp/tools/graph_tools.py
+++ b/robosystems/middleware/mcp/tools/graph_tools.py
@@ -138,7 +138,7 @@ class CreateSubgraphTool:
         "**PARAMETERS:**\n"
         "- name: Alphanumeric only, 1-20 chars (no hyphens or underscores)\n"
         "- fork_parent: Copy all parent data into the new subgraph\n"
-        "- subgraph_type: `static` (default) or `knowledge` (auto-includes the knowledge schema)\n\n"
+        "- subgraph_type: `static` (default), `knowledge` (auto-includes the knowledge schema), or `empty` (bare database, no schema — define your own)\n\n"
         "**RETURNS:** `subgraph_id` (format: `{parent_graph_id}_{name}`) — use it "
         "as the `graph_id` in future tool calls to target the new subgraph."
       ),

--- a/robosystems/models/api/graphs/subgraphs.py
+++ b/robosystems/models/api/graphs/subgraphs.py
@@ -14,8 +14,9 @@ from pydantic import BaseModel, Field, field_validator
 class SubgraphType(str, Enum):
   """Types of subgraphs."""
 
-  STATIC = "static"  # Traditional environment-based subgraphs
-  VERSIONED = "versioned"  # Git-like version control (future)
+  STATIC = "static"  # Inherits the parent's base schema + extensions
+  KNOWLEDGE = "knowledge"  # Knowledge-only schema (no base), for graph construction
+  EMPTY = "empty"  # Bare database — no base schema, no extensions; define your own
 
 
 class CreateSubgraphRequest(BaseModel):
@@ -52,7 +53,11 @@ class CreateSubgraphRequest(BaseModel):
 
   subgraph_type: SubgraphType = Field(
     SubgraphType.STATIC,
-    description="Type of subgraph (currently only 'static' is supported)",
+    description=(
+      "Type of subgraph: 'static' (parent's base + extensions), "
+      "'knowledge' (knowledge-only schema), or 'empty' (bare database, "
+      "no schema)."
+    ),
   )
 
   metadata: dict[str, object] | None = Field(

--- a/robosystems/operations/extensions/materialize.py
+++ b/robosystems/operations/extensions/materialize.py
@@ -6,7 +6,8 @@ regardless of which connector (QuickBooks, Xero, Plaid, native) put it there.
 
 Uses DuckDB's postgres_scanner extension to read directly from the extensions
 database, transform OLTP rows into graph-shaped staging tables, then materialize
-via the existing ATTACH + COPY FROM pipeline.
+via the Arrow record-batch streaming handoff (DuckDB result vectors → Arrow →
+LadybugDB COPY, no intermediate file).
 
 Architecture:
   Dagster sensor / worker task → ExtensionsMaterializer.materialize(graph_id, entity_id)

--- a/robosystems/operations/graph/subgraph_service.py
+++ b/robosystems/operations/graph/subgraph_service.py
@@ -249,17 +249,26 @@ class SubgraphService:
         is_subgraph=True,  # Bypass max_databases check for Enterprise/Premium
       )
 
-      # Install schema with extensions using the same pattern as entity graph creation
-      logger.info(
-        f"Installing schema with extensions: {schema_extensions} (include_base={include_base})"
-      )
-      ddl = await self._generate_schema_ddl(
-        schema_extensions or [], include_base=include_base
-      )
-
-      result = await client.install_schema(graph_id=database_name, custom_ddl=ddl)
-      logger.info(f"Schema installation completed: {result}")
-      logger.info(f"Installed schema with {len(schema_extensions or [])} extensions")
+      # Install schema with extensions using the same pattern as entity graph creation.
+      # An empty subgraph (no base, no extensions) generates no DDL — skip the
+      # install entirely and leave a bare database for the caller to define.
+      if not include_base and not schema_extensions:
+        logger.info("Empty subgraph — no schema installed (bare database)")
+      else:
+        logger.info(
+          f"Installing schema with extensions: {schema_extensions} (include_base={include_base})"
+        )
+        ddl = await self._generate_schema_ddl(
+          schema_extensions or [], include_base=include_base
+        )
+        if ddl.strip():
+          result = await client.install_schema(graph_id=database_name, custom_ddl=ddl)
+          logger.info(f"Schema installation completed: {result}")
+          logger.info(
+            f"Installed schema with {len(schema_extensions or [])} extensions"
+          )
+        else:
+          logger.info("Generated schema was empty — no DDL to install")
 
       logger.info(f"Successfully created subgraph database {subgraph_id}")
 
@@ -327,14 +336,19 @@ class SubgraphService:
     try:
       # Build schema extensions list
       include_base = True
-      # Legacy "memory" alias accepted for backward compat; canonical is "knowledge".
-      if subgraph_type in ("knowledge", "memory"):
+      if subgraph_type == "knowledge":
         # Knowledge subgraphs get only the knowledge extension (no base Entity/Period/etc.)
         extensions = ["knowledge"]
         include_base = False
         logger.info(
           "Using knowledge-only schema (no base schema) for knowledge subgraph"
         )
+      elif subgraph_type == "empty":
+        # Empty subgraphs get a bare database — no base schema, no extensions.
+        # The caller defines their own schema afterward via DDL.
+        extensions = []
+        include_base = False
+        logger.info("Creating empty subgraph (bare database, no schema)")
       else:
         extensions = list(parent_graph.schema_extensions or [])
 

--- a/robosystems/schemas/runtime/builder.py
+++ b/robosystems/schemas/runtime/builder.py
@@ -228,7 +228,7 @@ def apply_schema_to_database(database_path: str, config: dict[str, Any]):
       database_path: Path to LadybugDB database
       config: Schema configuration dictionary
   """
-  import real_ladybug as lbug
+  import ladybug as lbug
 
   db = lbug.Database(database_path)
   conn = lbug.Connection(db)

--- a/robosystems/scripts/graph_health.py
+++ b/robosystems/scripts/graph_health.py
@@ -102,7 +102,7 @@ class GraphHealthChecker:
       return result
 
     try:
-      import real_ladybug as lbug
+      import ladybug as lbug
 
       db = lbug.Database(self.database_path)
       conn = lbug.Connection(db)
@@ -177,9 +177,9 @@ class GraphHealthChecker:
       logger.info(f"  Status: {result.status}")
 
     except ImportError:
-      logger.warning("  real_ladybug not available for direct access")
+      logger.warning("  ladybug not available for direct access")
       result.status = "unavailable"
-      result.errors.append("real_ladybug module not available")
+      result.errors.append("ladybug module not available")
     except Exception as e:
       logger.error(f"  Direct access failed: {e}")
       result.status = "error"

--- a/robosystems/scripts/lbug_query.py
+++ b/robosystems/scripts/lbug_query.py
@@ -16,7 +16,7 @@ import argparse
 import sys
 from pathlib import Path
 
-import real_ladybug as lbug
+import ladybug as lbug
 
 from robosystems.utils.query_output import (
   print_csv,

--- a/tests/graph_api/core/ladybug/test_manager.py
+++ b/tests/graph_api/core/ladybug/test_manager.py
@@ -145,8 +145,8 @@ class TestLadybugDatabaseManagerCreateDatabase:
     request = DatabaseCreateRequest(graph_id="newdb", schema_type="entity")
 
     with (
-      patch("real_ladybug.Database"),
-      patch("real_ladybug.Connection") as mock_conn_cls,
+      patch("ladybug.Database"),
+      patch("ladybug.Connection") as mock_conn_cls,
     ):
       mock_conn = MagicMock()
       mock_conn_cls.return_value = mock_conn
@@ -171,8 +171,8 @@ class TestLadybugDatabaseManagerCreateDatabase:
     request = DatabaseCreateRequest(graph_id="sec", schema_type="shared")
 
     with (
-      patch("real_ladybug.Database") as mock_db_cls,
-      patch("real_ladybug.Connection") as mock_conn_cls,
+      patch("ladybug.Database") as mock_db_cls,
+      patch("ladybug.Connection") as mock_conn_cls,
     ):
       mock_conn = MagicMock()
       mock_conn_cls.return_value = mock_conn
@@ -199,7 +199,7 @@ class TestLadybugDatabaseManagerCreateDatabase:
     request = DatabaseCreateRequest(graph_id="faildb", schema_type="entity")
 
     with (
-      patch("real_ladybug.Database", side_effect=RuntimeError("DB create failed")),
+      patch("ladybug.Database", side_effect=RuntimeError("DB create failed")),
       patch(
         "robosystems.graph_api.core.ladybug.config.get_database_memory_config",
         return_value=256,
@@ -219,8 +219,8 @@ class TestLadybugDatabaseManagerCreateDatabase:
     )
 
     with (
-      patch("real_ladybug.Database"),
-      patch("real_ladybug.Connection") as mock_conn_cls,
+      patch("ladybug.Database"),
+      patch("ladybug.Connection") as mock_conn_cls,
     ):
       mock_conn = MagicMock()
       mock_conn_cls.return_value = mock_conn

--- a/tests/graph_api/core/ladybug/test_pool.py
+++ b/tests/graph_api/core/ladybug/test_pool.py
@@ -362,7 +362,7 @@ class TestLadybugConnectionPoolForceDatabaseCleanup:
     pool._pools["sec"] = {}
 
     with (
-      patch("real_ladybug.Connection") as mock_conn_cls,
+      patch("ladybug.Connection") as mock_conn_cls,
       patch("gc.collect"),
     ):
       mock_temp_conn = MagicMock()

--- a/tests/graph_api/routers/databases/tables/test_tables_materialize.py
+++ b/tests/graph_api/routers/databases/tables/test_tables_materialize.py
@@ -184,8 +184,8 @@ def test_type_safe_select_preserves_order_and_passthrough():
 
 
 def test_type_safe_select_casts_decimal_to_double():
-  """postgres_scan stages Postgres NUMERIC as DuckDB DECIMAL, whose parquet
-  converted type LadybugDB's reader rejects — it must be cast to DOUBLE."""
+  """postgres_scan stages Postgres NUMERIC as DuckDB DECIMAL; LadybugDB has no
+  DECIMAL type (numeric targets are DOUBLE), so it's cast at the source."""
   source = [
     ("identifier", "VARCHAR"),
     ("amount", "DECIMAL(18,2)"),

--- a/tests/graph_api/routers/databases/tables/test_tables_materialize.py
+++ b/tests/graph_api/routers/databases/tables/test_tables_materialize.py
@@ -169,66 +169,43 @@ def test_materialize_endpoint_decrements_counter_on_failure(monkeypatch, app_cli
 
 
 # ---------------------------------------------------------------------------
-# _needs_reconciliation
+# _build_type_safe_select
 # ---------------------------------------------------------------------------
 
 
-def test_needs_reconciliation_returns_false_when_target_unknown():
-  assert materialize._needs_reconciliation(None, ["identifier", "type"]) is False
-
-
-def test_needs_reconciliation_false_when_orders_match():
-  target = [
-    ("identifier", "STRING"),
-    ("category", "STRING"),
-    ("type", "STRING"),
-    ("source", "STRING"),
-    ("confidence", "DOUBLE"),
+def test_type_safe_select_preserves_order_and_passthrough():
+  source = [
+    ("src", "VARCHAR"),
+    ("dst", "VARCHAR"),
+    ("weight", "DOUBLE"),
   ]
-  source = ["identifier", "category", "type", "source", "confidence"]
-  assert materialize._needs_reconciliation(target, source) is False
+  expr = materialize._build_type_safe_select(source)
+  assert expr == '"src", "dst", "weight"'
 
 
-def test_needs_reconciliation_true_on_set_mismatch():
-  target = [
-    ("identifier", "STRING"),
-    ("category", "STRING"),
-    ("type", "STRING"),
+def test_type_safe_select_casts_decimal_to_double():
+  """postgres_scan stages Postgres NUMERIC as DuckDB DECIMAL, whose parquet
+  converted type LadybugDB's reader rejects — it must be cast to DOUBLE."""
+  source = [
+    ("identifier", "VARCHAR"),
+    ("amount", "DECIMAL(18,2)"),
   ]
-  # Source missing "category" entirely.
-  source = ["identifier", "type"]
-  assert materialize._needs_reconciliation(target, source) is True
+  expr = materialize._build_type_safe_select(source)
+  assert '"identifier"' in expr
+  assert 'CAST("amount" AS DOUBLE) AS "amount"' in expr
 
 
-def test_needs_reconciliation_true_on_order_mismatch_only():
-  """Same column names, different order — must reconcile.
-
-  Regression: a mid-schema ADD COLUMN (e.g. Classification.category) caused
-  DuckDB ALTER TABLE ADD COLUMN to append the new column at the end, while
-  the LadybugDB target had it in position 2. Set comparison missed this and
-  let positional COPY misalign data into the wrong columns.
-  """
-  target = [
-    ("identifier", "STRING"),
-    ("category", "STRING"),
-    ("type", "STRING"),
-    ("source", "STRING"),
-    ("confidence", "DOUBLE"),
+def test_type_safe_select_excludes_and_nulls():
+  source = [
+    ("identifier", "VARCHAR"),
+    ("embedding", "FLOAT[384]"),
+    ("file_id", "VARCHAR"),
   ]
-  # DuckDB schema-evolved layout: category appended at end.
-  source = ["identifier", "type", "source", "confidence", "category"]
-  assert materialize._needs_reconciliation(target, source) is True
-
-
-def test_needs_reconciliation_ignores_implicit_and_synthetic_cols():
-  """file_id (synthetic) and from/to/src/dst (implicit on rel tables) don't count."""
-  target = [
-    ("prop_a", "STRING"),
-    ("prop_b", "STRING"),
-  ]
-  # Source has from/to and file_id surrounding the props in matching order.
-  source = ["from", "to", "prop_a", "prop_b", "file_id"]
-  assert materialize._needs_reconciliation(target, source) is False
+  expr = materialize._build_type_safe_select(
+    source, exclude_cols={"file_id"}, null_cols={"embedding"}
+  )
+  assert "file_id" not in expr
+  assert 'NULL::FLOAT[384] AS "embedding"' in expr
 
 
 # ---------------------------------------------------------------------------

--- a/tests/graph_api/test_connection_pool.py
+++ b/tests/graph_api/test_connection_pool.py
@@ -97,8 +97,8 @@ class TestLadybugConnectionPool:
     assert pool.health_check_interval == timedelta(minutes=5)
     assert pool.cleanup_interval == timedelta(minutes=10)
 
-  @patch("real_ladybug.Database")
-  @patch("real_ladybug.Connection")
+  @patch("ladybug.Database")
+  @patch("ladybug.Connection")
   def test_get_connection_context_manager(self, mock_conn_class, mock_db_class):
     """Test connection retrieval using context manager."""
     # Mock LadybugDB classes
@@ -164,8 +164,8 @@ class TestLadybugConnectionPool:
 
     mock_result.close.assert_called_once()
 
-  @patch("real_ladybug.Database")
-  @patch("real_ladybug.Connection")
+  @patch("ladybug.Database")
+  @patch("ladybug.Connection")
   def test_connection_reuse(self, mock_conn_class, mock_db_class):
     """Test connection reuse from pool."""
     # Mock LadybugDB classes
@@ -200,8 +200,8 @@ class TestLadybugConnectionPool:
     assert pool._stats["connections_created"] == 1
     assert pool._stats["connections_reused"] == 1
 
-  @patch("real_ladybug.Database")
-  @patch("real_ladybug.Connection")
+  @patch("ladybug.Database")
+  @patch("ladybug.Connection")
   def test_max_connections_per_database(self, mock_conn_class, mock_db_class):
     """Test connection limit enforcement per database."""
     # Mock LadybugDB classes to return different instances
@@ -246,8 +246,8 @@ class TestLadybugConnectionPool:
     close_calls = sum(1 for mock_conn in mock_conns if mock_conn.close.called)
     assert close_calls >= 1
 
-  @patch("real_ladybug.Database")
-  @patch("real_ladybug.Connection")
+  @patch("ladybug.Database")
+  @patch("ladybug.Connection")
   def test_connection_ttl_expiry(self, mock_conn_class, mock_db_class):
     """Test connection TTL expiry and cleanup."""
     # Mock LadybugDB classes
@@ -292,8 +292,8 @@ class TestLadybugConnectionPool:
     mock_conn.close.assert_called()
     # Database is not closed until all connections are closed or invalidated
 
-  @patch("real_ladybug.Database")
-  @patch("real_ladybug.Connection")
+  @patch("ladybug.Database")
+  @patch("ladybug.Connection")
   def test_connection_health_check_failure(self, mock_conn_class, mock_db_class):
     """Test connection health check failure and recovery."""
     # Mock LadybugDB classes
@@ -339,8 +339,8 @@ class TestLadybugConnectionPool:
     assert "db1" in pool._locks
     assert "db2" in pool._locks
 
-  @patch("real_ladybug.Database")
-  @patch("real_ladybug.Connection")
+  @patch("ladybug.Database")
+  @patch("ladybug.Connection")
   def test_connection_validity_check(self, mock_conn_class, mock_db_class):
     """Test connection validity checking."""
     pool = LadybugConnectionPool(
@@ -389,8 +389,8 @@ class TestLadybugConnectionPool:
     assert pool._is_connection_valid(expired_conn_info) is False
     assert pool._is_connection_valid(unhealthy_conn_info) is False
 
-  @patch("real_ladybug.Database")
-  @patch("real_ladybug.Connection")
+  @patch("ladybug.Database")
+  @patch("ladybug.Connection")
   def test_cleanup_expired_connections(self, mock_conn_class, mock_db_class):
     """Test cleanup of expired connections."""
     # Mock LadybugDB classes
@@ -425,8 +425,8 @@ class TestLadybugConnectionPool:
     # Database is not closed until all connections are closed or invalidated
     assert len(pool._pools.get("test_db", {})) == 0
 
-  @patch("real_ladybug.Database")
-  @patch("real_ladybug.Connection")
+  @patch("ladybug.Database")
+  @patch("ladybug.Connection")
   def test_maintenance_task_scheduling(self, mock_conn_class, mock_db_class):
     """Test automatic maintenance task scheduling."""
     pool = LadybugConnectionPool(
@@ -450,8 +450,8 @@ class TestLadybugConnectionPool:
     pool._cleanup_expired_connections.assert_called_once()
     pool._check_connection_health.assert_called_once()
 
-  @patch("real_ladybug.Database")
-  @patch("real_ladybug.Connection")
+  @patch("ladybug.Database")
+  @patch("ladybug.Connection")
   def test_get_stats(self, mock_conn_class, mock_db_class):
     """Test connection pool statistics retrieval."""
     # Mock LadybugDB classes
@@ -489,8 +489,8 @@ class TestLadybugConnectionPool:
     assert stats["configuration"]["max_connections_per_db"] == 5
     assert stats["configuration"]["connection_ttl_minutes"] == 30
 
-  @patch("real_ladybug.Database")
-  @patch("real_ladybug.Connection")
+  @patch("ladybug.Database")
+  @patch("ladybug.Connection")
   def test_close_database_connections(self, mock_conn_class, mock_db_class):
     """Test closing all connections for a specific database."""
     # Mock LadybugDB classes
@@ -524,8 +524,8 @@ class TestLadybugConnectionPool:
     assert "db2" in pool._pools
     assert len(pool._pools.get("db1", {})) == 0
 
-  @patch("real_ladybug.Database")
-  @patch("real_ladybug.Connection")
+  @patch("ladybug.Database")
+  @patch("ladybug.Connection")
   def test_close_all_connections(self, mock_conn_class, mock_db_class):
     """Test closing all connections in the pool."""
     # Mock LadybugDB classes
@@ -561,7 +561,7 @@ class TestLadybugConnectionPool:
     assert len(pool._pools) == 0
     assert len(pool._locks) == 0
 
-  @patch("real_ladybug.Database")
+  @patch("ladybug.Database")
   def test_connection_creation_error_handling(self, mock_db_class):
     """Test error handling during connection creation."""
     # Mock LadybugDB database creation failure
@@ -600,8 +600,8 @@ class TestLadybugConnectionPool:
     # Verify locks were created correctly
     assert len(pool._locks) == 3  # db_0, db_1, db_2
 
-  @patch("real_ladybug.Database")
-  @patch("real_ladybug.Connection")
+  @patch("ladybug.Database")
+  @patch("ladybug.Connection")
   def test_lru_connection_selection(self, mock_conn_class, mock_db_class):
     """Test least recently used connection selection."""
     # Mock LadybugDB classes
@@ -710,8 +710,8 @@ class TestConnectionPoolIntegration:
     try:
       # Mock LadybugDB to avoid segmentation faults
       with (
-        patch("real_ladybug.Database") as mock_db_class,
-        patch("real_ladybug.Connection") as mock_conn_class,
+        patch("ladybug.Database") as mock_db_class,
+        patch("ladybug.Connection") as mock_conn_class,
       ):
         # Setup mocks
         mock_db = MagicMock()
@@ -803,8 +803,8 @@ class TestConnectionPoolIntegration:
     try:
       # Mock LadybugDB to avoid segmentation faults
       with (
-        patch("real_ladybug.Database") as mock_db_class,
-        patch("real_ladybug.Connection") as mock_conn_class,
+        patch("ladybug.Database") as mock_db_class,
+        patch("ladybug.Connection") as mock_conn_class,
       ):
         # Setup mocks
         mock_db = MagicMock()

--- a/tests/graph_api/test_database_manager.py
+++ b/tests/graph_api/test_database_manager.py
@@ -123,8 +123,8 @@ class TestLadybugDatabaseManager:
     )
 
   @patch("robosystems.graph_api.core.ladybug.manager.initialize_connection_pool")
-  @patch("real_ladybug.Database")
-  @patch("real_ladybug.Connection")
+  @patch("ladybug.Database")
+  @patch("ladybug.Connection")
   def test_create_database_success_entity_schema(
     self, mock_conn_class, mock_db_class, mock_init_pool
   ):
@@ -177,8 +177,8 @@ class TestLadybugDatabaseManager:
     # New implementation uses connection pool, no direct database/connection storage
 
   @patch("robosystems.graph_api.core.ladybug.manager.initialize_connection_pool")
-  @patch("real_ladybug.Database")
-  @patch("real_ladybug.Connection")
+  @patch("ladybug.Database")
+  @patch("ladybug.Connection")
   def test_create_database_read_only(
     self, mock_conn_class, mock_db_class, mock_init_pool
   ):
@@ -263,7 +263,7 @@ class TestLadybugDatabaseManager:
     assert "already exists" in str(exc_info.value.detail)
 
   @patch("robosystems.graph_api.core.ladybug.manager.initialize_connection_pool")
-  @patch("real_ladybug.Database")
+  @patch("ladybug.Database")
   def test_create_database_lbug_error_cleanup(self, mock_db_class, mock_init_pool):
     """Test database creation error handling and cleanup."""
     from fastapi import HTTPException
@@ -749,8 +749,8 @@ class TestLadybugDatabaseManagerIntegration:
 
     # Mock LadybugDB to avoid segmentation faults while testing concurrency logic
     with (
-      patch("real_ladybug.Database") as mock_db_class,
-      patch("real_ladybug.Connection") as mock_conn_class,
+      patch("ladybug.Database") as mock_db_class,
+      patch("ladybug.Connection") as mock_conn_class,
     ):
       # Setup mocks
       mock_db = MagicMock()

--- a/tests/models/api/test_graph_core_models.py
+++ b/tests/models/api/test_graph_core_models.py
@@ -326,7 +326,9 @@ class TestCreateSubgraphRequest:
 class TestSubgraphType:
   def test_enum_values(self):
     assert SubgraphType.STATIC == "static"
-    assert SubgraphType.VERSIONED == "versioned"
+    assert SubgraphType.KNOWLEDGE == "knowledge"
+    assert SubgraphType.EMPTY == "empty"
+    assert {e.value for e in SubgraphType} == {"static", "knowledge", "empty"}
 
 
 @pytest.mark.unit

--- a/uv.lock
+++ b/uv.lock
@@ -1728,6 +1728,30 @@ wheels = [
 ]
 
 [[package]]
+name = "ladybug"
+version = "0.18.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/8f/f598687c2d6a56f7465ffeaf3a1f32681102b137c1af221803f40a8186b5/ladybug-0.18.1.tar.gz", hash = "sha256:f9566e4b09a1d8d1a2860bf87daa81d9063abe59ab6c814f45c6190ce3cb5ea8", size = 10273916, upload-time = "2026-07-10T02:46:33.663Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/f6/4e8aad7a6d6df932df209a47b2043850c331ca5fcf85333a80bf634ec43f/ladybug-0.18.1-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:a1d32a368d762d8e7f5d20d04b221605480a14d90df160483d21e060d3cf8803", size = 7196587, upload-time = "2026-07-10T02:45:58.7Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/10/4637c8aa013cd8f9387577307cd17f1ce5b9edaad07b4281626a742c8f15/ladybug-0.18.1-cp313-cp313-macosx_15_0_x86_64.whl", hash = "sha256:0147a7ba0a8cc16cdcbe0e41b6975362b3ac538166bcdcdee8c31f8741289cfb", size = 7395594, upload-time = "2026-07-10T02:46:00.501Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/73/c63af0455da4a1b006c1ed4e87fe8e575e771a5937c77f49a9afb967f41c/ladybug-0.18.1-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6dd802d4fbda4d85f35f6053774c4b32cf0710e6bf4d5530cf675838c04a6d9d", size = 9863965, upload-time = "2026-07-10T02:46:02.352Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/88/e5133c98759afb4b999cc586d7b8821d43d45c911a8cc6c5164567a5b228/ladybug-0.18.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f56da914290887a28856a619963cf8f4790dd016a05aefc24eca9c7c629f0038", size = 10926151, upload-time = "2026-07-10T02:46:04.784Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/9e/a92e9dd1c24d146c81cc019ba9ea2ba09bd648deda5eef18e75a70465b77/ladybug-0.18.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:b27d86cfa5084161863868b6dc43630f7f92d1add304578bc79bbfbc5b64c3cd", size = 10722982, upload-time = "2026-07-10T02:46:06.967Z" },
+    { url = "https://files.pythonhosted.org/packages/77/d5/c5a5e939c69f44a36a4189453b14a8ef289cd497ffe1d0c80d38bfb078bb/ladybug-0.18.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:bfb78cad2e2f117e1c6f7192b5c20771d22fec32b396453a4b9f7fa26d9efe64", size = 11341896, upload-time = "2026-07-10T02:46:09.375Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/de/011e71430e79e781d7d2fb522f1e02555103e715b393f0443211dcbadba1/ladybug-0.18.1-cp313-cp313-win_amd64.whl", hash = "sha256:db0a0fbc8dd996960264bb0460e2c8b93f82808f73554f17c14ee5572f80db5a", size = 8394105, upload-time = "2026-07-10T02:46:12.107Z" },
+    { url = "https://files.pythonhosted.org/packages/65/c6/24fae739f47f94ae969ab61c58cd7ac4404fafa5d9943cedf2925e1efdbb/ladybug-0.18.1-cp313-cp313-win_arm64.whl", hash = "sha256:e18da6956443306da73afa8ab6248b826f3cbd18e58cd8b75ccb2ed152e98df1", size = 8146017, upload-time = "2026-07-10T02:46:14.225Z" },
+    { url = "https://files.pythonhosted.org/packages/32/33/2abc3eb4e47db622df2da3a8ffe7c0321cd05f3b26ee6d84e6691b519532/ladybug-0.18.1-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:e29de8a8e4462cbaf0638932ae88acf1014906faf1e176bf1248a50be1f48bed", size = 7196976, upload-time = "2026-07-10T02:46:16.504Z" },
+    { url = "https://files.pythonhosted.org/packages/91/10/bbc76476d87058e6d62b24a7f659a104a601a06686c5871b41eefe98299d/ladybug-0.18.1-cp314-cp314-macosx_15_0_x86_64.whl", hash = "sha256:5d7b5f2ba40f56273ab1862c1ef7dbb8316eceaf1cb2a99d1e6fe34764358edd", size = 7396050, upload-time = "2026-07-10T02:46:18.284Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/75/a3af0d6f60ae44eb8d4648b428e1d1e0d3f6b2b5f02b98fd16c7397c0c8d/ladybug-0.18.1-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f9525353720a5d9afd340ba8a918e6caad98bad00aa505b69d81f08797353765", size = 9864502, upload-time = "2026-07-10T02:46:20.236Z" },
+    { url = "https://files.pythonhosted.org/packages/50/67/267b8a0eda9ec048b3ef27f1c0716cd1823a26c51f421d9a364f35b9764e/ladybug-0.18.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:351d033cb82343b80e3bf887e9a6c85bd2929b4bd9ab7b479deacd2e5ac30811", size = 10925936, upload-time = "2026-07-10T02:46:22.422Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/d1ff6846da3e152b2cd608405a4ecc9c6fb37d46f3433a92a109a2d56f86/ladybug-0.18.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:91652582c248a3cd54c7ca345608d7b29ee7a09878af030559bf3e87ee4ce4b8", size = 10723514, upload-time = "2026-07-10T02:46:24.633Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/3e/7f228ec85d3e8bb2038679a73cc4cfcd894b49ae54bf39a2069f5ba38fa2/ladybug-0.18.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4ea19cbcd56eabc40787844c5111acea3bb94cfd74db3f2fb4153f4d81a6b711", size = 11341937, upload-time = "2026-07-10T02:46:26.743Z" },
+    { url = "https://files.pythonhosted.org/packages/80/19/498c5fcee513576cd3ef86c7f392134aa1cc2ecc46cbdfbce89090228576/ladybug-0.18.1-cp314-cp314-win_amd64.whl", hash = "sha256:49ea83010eefcf9f98658d814b8813232dc49e2cdf6e1e60e6878ac4da06cca9", size = 8663398, upload-time = "2026-07-10T02:46:29.102Z" },
+    { url = "https://files.pythonhosted.org/packages/88/24/3d07a2589f01aae4e517b9b61ebfd125276e5e867301ad6c5cd5f2ec5e25/ladybug-0.18.1-cp314-cp314-win_arm64.whl", hash = "sha256:edb383f670e292f61f5c9759d0f8367849d2270c222e143c53849cd79e226380", size = 8402723, upload-time = "2026-07-10T02:46:31.507Z" },
+]
+
+[[package]]
 name = "lance-namespace"
 version = "0.8.6"
 source = { registry = "https://pypi.org/simple" }
@@ -3351,20 +3375,6 @@ html = [
 ]
 
 [[package]]
-name = "real-ladybug"
-version = "0.13.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a3/39/7c20bae9c9b86a47009aa03e7c9cee12dddbeae2da746842170a6d224fe2/real_ladybug-0.13.1.tar.gz", hash = "sha256:f43e86ddaaab21ff45199e13cbee09a0bd47d045f6bd39165afcd93ffec89bb8", size = 9948289, upload-time = "2026-01-02T20:24:11.435Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/6a/2c8f8bd2fa2e025aa47e652a16ed901ce07156844fb1ba9da8457c8cf18c/real_ladybug-0.13.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:115288b0efd5f909a30f935e41d4a6a02f4ed6167c8c6690505fdcae42b47f9f", size = 3785101, upload-time = "2026-01-02T20:24:02.126Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/0f/0b40662f3a03232282313dbcef45dcf416837ee977b4f59aa6884f27bbe5/real_ladybug-0.13.1-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:05ffff38e550c361670bbf9c66d2bba812e8b8b1730910d1a4f3ca0ff6eebde1", size = 6379814, upload-time = "2026-01-02T20:24:03.573Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/d0/de5ca2bfb96b3652a63a4d88de0cf20a9a0046bd47f3afe09bcee0a758f4/real_ladybug-0.13.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b68854c71917cb85a929a6317f223880d2c7e2e508472972b8623599cf32bf8", size = 7174447, upload-time = "2026-01-02T20:24:05.105Z" },
-    { url = "https://files.pythonhosted.org/packages/12/31/84c444c906b9a2c7bd7f0076540fa010c4ad108a97128f9684cf0651640b/real_ladybug-0.13.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f4a64cdc978c5f609246989a09a12683922c9baf26c33832c523c41a4efa333d", size = 7585139, upload-time = "2026-01-02T20:24:06.598Z" },
-    { url = "https://files.pythonhosted.org/packages/98/ec/44ed84d1b48eb14d511b68eaf16cd3956cf9cc10346a0730723200fe5008/real_ladybug-0.13.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4eb973a25a72e5894bf5a61e1210fece4919b9bde5494c3ac0f1151bec0dbea1", size = 8272155, upload-time = "2026-01-02T20:24:08.296Z" },
-    { url = "https://files.pythonhosted.org/packages/28/4a/284a9d6fc20ce5258427bb14dd78188b49f8bb00d62871ae3f9dcf2647d4/real_ladybug-0.13.1-cp313-cp313-win_amd64.whl", hash = "sha256:d5b8b07d691b1327beb47b073f78506d11978000e01693c6554670b95e4ed76a", size = 4831018, upload-time = "2026-01-02T20:24:09.955Z" },
-]
-
-[[package]]
 name = "redis"
 version = "8.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3561,6 +3571,7 @@ dependencies = [
     { name = "httpx-sse" },
     { name = "icebug" },
     { name = "intuit-oauth" },
+    { name = "ladybug" },
     { name = "lancedb" },
     { name = "lxml" },
     { name = "numpy" },
@@ -3585,7 +3596,6 @@ dependencies = [
     { name = "python-ulid" },
     { name = "pyyaml" },
     { name = "rdflib" },
-    { name = "real-ladybug" },
     { name = "redis" },
     { name = "requests" },
     { name = "retrying" },
@@ -3650,6 +3660,7 @@ requires-dist = [
     { name = "httpx-sse", specifier = ">=0.4.0" },
     { name = "icebug", specifier = ">=12.0,<13.0" },
     { name = "intuit-oauth", specifier = ">=1.2.0,<2.0" },
+    { name = "ladybug", specifier = "==0.18.1" },
     { name = "lancedb", specifier = ">=0.30.0,<0.31" },
     { name = "lxml", specifier = ">=6.1.0,<7.0" },
     { name = "moto", extras = ["s3"], marker = "extra == 'dev'", specifier = ">=5.2.2,<6.0" },
@@ -3680,7 +3691,6 @@ requires-dist = [
     { name = "python-ulid", specifier = ">=3.0.0" },
     { name = "pyyaml", specifier = ">=6.0.0,<7.0" },
     { name = "rdflib", specifier = ">=7.0.0,<8.0" },
-    { name = "real-ladybug", specifier = "==0.13.1" },
     { name = "redis", specifier = ">=8.0.0,<9.0" },
     { name = "requests", specifier = ">=2.34.2,<3.0" },
     { name = "retrying", specifier = ">=1.4.0,<2.0" },


### PR DESCRIPTION
## Summary

Upgrades the graph engine from `real-ladybug` 0.13.1 to `ladybug` 0.18.1 (the package was renamed on PyPI), and replaces the DuckDB **ATTACH** materialization path with an **in-memory Arrow streaming** handoff — the change that makes the upgrade possible. LadybugDB 0.14+ creates persistent shadow catalog entries when ATTACHing a DuckDB database, which collide with the installed graph schema and break every graph build; probing on 0.18.1 confirmed the behavior persists with no workaround (ATTACH options, staging-name prefixes, post-DETACH DROP all fail).

The new path: DuckDB emits Arrow record batches straight from its result vectors (`fetch_record_batch`), and LadybugDB scans each batch's buffers via `COPY <Table> FROM <batch>` — no intermediate file. A first cut used a parquet file as the intermediary; that was superseded because the disk round-trip is a regression at SEC scale (millions of nodes shouldn't serialize to disk and back).

**On "zero-copy" (to be precise):** end-to-end is *not* zero-copy. A persistent, traversable graph requires LadybugDB to build its own CSR adjacency storage, so the data is always materialized into `.lbug` — true of ATTACH, parquet, and Arrow alike. Zero-copy applies only to the DuckDB→Arrow step (result vectors → Arrow buffers, no serialization). What this PR eliminates vs. parquet is the *intermediate* serialization + disk round-trip; vs. ATTACH it swaps DuckDB-storage-format deserialization for an in-memory Arrow scan and dodges the shadow-catalog bug.

## Changes

**Dependency + imports**
- `pyproject.toml` / `uv.lock`: `real-ladybug==0.13.1` → `ladybug==0.18.1`
- `import real_ladybug as lbug` → `import ladybug as lbug` across 8 modules + 4 test files

**Materialization (`graph_api/routers/databases/tables/materialize.py`)**
- `_materialize_table_impl` and `_fork_from_parent_duckdb_impl` stream DuckDB→Arrow→LadybugDB. Temp tables, `INSTALL/LOAD duckdb`, ATTACH/DETACH, and (in the interim) the parquet file are all gone. Both connections stay open and the copy interleaves per batch, bounding peak memory.
- The DuckDB batch is scanned by LadybugDB via a Python replacement scan — the local variable name must match the identifier in the COPY string (documented API pattern; `# noqa: F841` because the linter can't see the engine's frame read).
- The export SELECT is reconciled to the target schema when known (column order, NULL fill, target-type casts); otherwise DECIMAL→DOUBLE. LadybugDB has no DECIMAL type and `postgres_scan` stages Postgres NUMERIC (ledger amounts) as DuckDB DECIMAL, so it's cast at the source. `_needs_reconciliation` removed — reconciliation is unconditional now.

**Image (`Dockerfile`)**
- Drops the duckdb lbug extension (3 files) and `libduckdb.so` from both stages — unused after the refactor; httpfs + vector remain.
- Extension install path moved `~/.lbug/extension/` → `~/.lbdb/extension/` (the 0.15+ location); `graph_api/app.py` stale-cache clearing covers both generations.

**Docs/comments** — corrected stale "ATTACH pipeline" references in `operations/extensions/materialize.py` + `dagster/jobs/extensions.py`, and scoped the zero-copy wording to the DuckDB→Arrow step.

**CI** — restored `id-token: write` on the Claude review workflow (a prior hardening pass dropped it as "unused", but `claude-code-action` needs it to mint a GitHub OIDC token).

## Storage/migration semantics (verified, drives the rollout)

- A **checkpointed** v40 (0.13.1) database opens on 0.18.1 and auto-upgrades in place to v42; an un-checkpointed WAL fails replay — checkpoint on the old version first.
- The upgrade is **one-way per file** (0.13.1 refuses v42). Rollback is restore-from-backup, never re-open.
- **Read-only** open of a v40 file on 0.18.1 works and leaves it at v40 — shared replicas can run the new engine against existing S3 files.
- `EXPORT DATABASE` (0.13.1) → `IMPORT DATABASE` (0.18.1) round-trips cleanly, so the existing `ladybug_migration_export_job` / `import_job` pair is the prod migration vehicle.

## Coverage

Every DuckDB→LadybugDB materialization routes through `client.materialize_table()` / `client.fork_from_parent()` (SEC, extensions/tenant, generic-graph, chunked, subgraph fork) — the two functions this PR converts. `grep "DBTYPE duckdb"` across non-test code is empty: no ATTACH-based copy remains. The file-based `COPY FROM <file>` paths (generic-graph ingest, backup restore, SEC classify) are a separate mechanism that never used ATTACH and are unaffected.

## Testing

- `just test-all` green (unit + dbt + ruff + format + basedpyright + cf-lint) prior to the last doc-only commits.
- End-to-end on a clean-wipe local stack on 0.18.1:
  - SEC load from scratch (download → process → stage → materialize): 36/36 tables, 19,151 nodes, no frame-scan failures.
  - RoboLedger demo (tenant `postgres_scan` NUMERIC path): filed FY 2025 report, SHACL conforms, Arelle-valid XBRL, fact amounts precise to the cent (133.33 / 266.66 / 399.99 / 533.32) — confirming NUMERIC→DECIMAL→Arrow→DOUBLE preserves value.
- Isolated 0.18.1 probes: constructor kwargs, DDL, node/rel COPY FROM Arrow (incl. `ignore_errors`), streaming record batches, the storage-version matrix, and the replacement-scan resolving through the connection-pool context manager.

## Notes

- Deploying requires the graph-engine migration for existing v40 databases (export → deploy → import); the night-window sequence, verification, and rollback are documented internally.
- Arrow-vs-parquet throughput at SEC scale is now moot (no disk), but the next SEC materialization pass will give real numbers.
- `create_arrow_table` was investigated as a way to avoid the replacement-scan variable-name coupling; it creates a separate node table rather than a COPY source, so the replacement scan stays.
