### PR TITLE
fix(migration): export uploads to USER_DATA_BUCKET; dev routing to graph_api

### DIFF
--- a/robosystems/dagster/jobs/migration.py
+++ b/robosystems/dagster/jobs/migration.py
@@ -53,11 +53,19 @@ def _get_writer_instances(
   In prod/staging, queries DynamoDB for healthy instances.
   """
   if env.is_development():
-    context.log.info("Dev mode: using localhost instance")
+    # This op runs inside the Dagster worker container and the migration client
+    # builds http://{private_ip}:8001 — so "localhost" would resolve to the
+    # worker, not graph_api. Use the graph_api host from GRAPH_API_URL
+    # (e.g. "graph-api" under Docker Compose) so the client reaches the right
+    # container. Prod/staging never take this branch (DynamoDB below).
+    from urllib.parse import urlparse
+
+    graph_api_host = urlparse(env.GRAPH_API_URL).hostname or "localhost"
+    context.log.info(f"Dev mode: using graph_api host '{graph_api_host}'")
     return [
       {
         "instance_id": "local",
-        "private_ip": "localhost",
+        "private_ip": graph_api_host,
         "node_type": "dev",
       }
     ]

--- a/robosystems/graph_api/core/migration_service.py
+++ b/robosystems/graph_api/core/migration_service.py
@@ -110,7 +110,10 @@ class MigrationService:
     """
     timestamp = datetime.now(UTC)
     s3_key = get_backup_key(graph_id, "system", timestamp, extension=".lbug")
-    bucket = env.S3_GRAPH_BUCKET
+    # All graph storage (backups included) lives in USER_DATA_BUCKET — see
+    # config/storage/graph.py. env.S3_GRAPH_BUCKET never existed, so this
+    # upload raised AttributeError and aborted every migration export.
+    bucket = env.USER_DATA_BUCKET
 
     s3_client = self._get_s3_client()
     transfer_config = TransferConfig(


### PR DESCRIPTION
## Summary

Two fixes to the LadybugDB engine-migration jobs (`ladybug_migration_export_job` / `import_job`), surfaced by a local dry-run of the export→import flow ahead of the 0.13.1→0.18.1 upgrade. The first is a real bug that aborts the export entirely; the second is a dev-only routing fix.

**This is a prerequisite for the engine upgrade and must deploy on the current (0.13.1) engine *before* the migration window** — the export runs on the currently-deployed image, so the fix has to be live in prod before the export is triggered.

## Changes

**`graph_api/core/migration_service.py` — export bucket (the real bug)**
- `_upload_system_backup` referenced `env.S3_GRAPH_BUCKET`, which is **never defined** in `config/env.py`. The lookup raised `AttributeError` on the first database and aborted the whole export (the upload isn't wrapped, so it's fatal).
- Fixed to `env.USER_DATA_BUCKET` — all graph storage, backups included, lives there per `config/storage/graph.py`, which is what `get_backup_key`'s `graph-backups/` prefix targets.

**`dagster/jobs/migration.py` — dev routing (dev-only)**
- The `env.is_development()` branch of `_get_writer_instances` returned `private_ip="localhost"`, but the op runs inside the Dagster worker container where `localhost` is the worker, not graph_api — so the migration client's `http://localhost:8001` got connection-refused.
- Derive the host from `env.GRAPH_API_URL` (`graph-api` under Compose) instead. Prod/staging never take this branch — they use real private IPs from DynamoDB — so this has zero prod effect; it just lets the migration jobs run in local Docker.

## Testing

Local dry-run on 0.13.1 (`just reset-local` → `demo-roboledger`):
- `ladybug_migration_export_job` (Dagster) now discovers `graph-api` and completes green — previously failed with `local: All connection attempts failed`.
- Export produced 67 parquet files + `migration.json` (4,669 nodes, 44 rel tables) and uploaded the `.lbug` system backup to `s3://robosystems-user/graph-backups/…` — the exact path that previously threw `AttributeError`.
- `just lint` clean on both files.

## Notes

- Rollout order: land + deploy this to prod on 0.13.1 first, then run the migration window (export → deploy 0.18.1 → import). The 0.18.1 upgrade (#858) picks these up from `main`.
- The import path doesn't touch either fix (only export uploads to S3; the routing fix is generic to both jobs).
