### PR TITLE
fix(dagster): migration writer discovery imports LadybugAllocationManager

### DIFF
--- a/robosystems/dagster/jobs/migration.py
+++ b/robosystems/dagster/jobs/migration.py
@@ -70,9 +70,9 @@ def _get_writer_instances(
       }
     ]
 
-  from robosystems.middleware.graph.allocation_manager import AllocationManager
+  from robosystems.middleware.graph.allocation_manager import LadybugAllocationManager
 
-  manager = AllocationManager()
+  manager = LadybugAllocationManager(environment=env.ENVIRONMENT)
 
   # Paginated scan of ALL instances (not just healthy)
   # Migration needs to reach every instance that has data, even temporarily unhealthy ones


### PR DESCRIPTION
## Problem

The first real prod run of `ladybug_migration_export_job` failed at instance discovery:

```
ImportError: cannot import name 'AllocationManager' from
'robosystems.middleware.graph.allocation_manager'
  migration.py:73 in _get_writer_instances
```

`_get_writer_instances` imported a nonexistent `AllocationManager` and instantiated it with no args. The class is `LadybugAllocationManager`, and its constructor **requires** `environment`. Every other caller across the graph operations already uses `LadybugAllocationManager(environment=env.ENVIRONMENT)`.

## Why it was never caught

This code path only runs in the prod/staging branch of `_get_writer_instances` — dev returns a synthetic `localhost` instance and never imports the manager. So neither local testing nor the earlier migration-job fixes exercised it; it only surfaces on a real multi-instance run. The failure is non-destructive: it dies at discovery, before touching any database.

## Fix

One line — match the working caller pattern:

```python
from robosystems.middleware.graph.allocation_manager import LadybugAllocationManager
manager = LadybugAllocationManager(environment=env.ENVIRONMENT)
```

The rest of the export path (client `migration_export`/`get_task_status`/`migration_cleanup`, `get_graph_client_for_instance`, graph-api `/migration/{export,import,status,cleanup}`) was audited and is present. Ruff + pre-commit clean.