### PR TITLE
fix(migration): pass system-backup bucket from worker to writer

### DIFF
--- a/robosystems/dagster/jobs/migration.py
+++ b/robosystems/dagster/jobs/migration.py
@@ -152,7 +152,9 @@ async def _export_instance(
   start = time.time()
   client = await _get_client(ip)
 
-  export_response = await client.migration_export(source_version, target_version)
+  export_response = await client.migration_export(
+    source_version, target_version, env.USER_DATA_BUCKET
+  )
   task_id = export_response["task_id"]
 
   task_result = await _poll_task(client, task_id)

--- a/robosystems/graph_api/client/client.py
+++ b/robosystems/graph_api/client/client.py
@@ -2075,7 +2075,7 @@ class GraphClient(BaseGraphClient):
   # Migration endpoints
 
   async def migration_export(
-    self, source_version: str, target_version: str
+    self, source_version: str, target_version: str, bucket: str
   ) -> dict[str, Any]:
     """
     Start migration export on this instance.
@@ -2083,6 +2083,8 @@ class GraphClient(BaseGraphClient):
     Args:
         source_version: Current LadybugDB version
         target_version: Target LadybugDB version
+        bucket: S3 bucket for the system backup. The writer container does not
+            resolve USER_DATA_BUCKET itself, so the caller passes it in.
 
     Returns:
         Task ID and monitor URL
@@ -2090,7 +2092,11 @@ class GraphClient(BaseGraphClient):
     response = await self._request(
       "POST",
       "/migration/export",
-      params={"source_version": source_version, "target_version": target_version},
+      params={
+        "source_version": source_version,
+        "target_version": target_version,
+        "bucket": bucket,
+      },
       timeout=30.0,
       retries=0,
     )

--- a/robosystems/graph_api/core/migration_service.py
+++ b/robosystems/graph_api/core/migration_service.py
@@ -101,7 +101,12 @@ class MigrationService:
     return boto3.client("s3", **kwargs)
 
   def _upload_system_backup(
-    self, db_file: Path, graph_id: str, source_version: str, target_version: str
+    self,
+    db_file: Path,
+    graph_id: str,
+    source_version: str,
+    target_version: str,
+    bucket: str,
   ) -> str:
     """Upload .lbug file to S3 as a system backup before migration.
 
@@ -110,10 +115,11 @@ class MigrationService:
     """
     timestamp = datetime.now(UTC)
     s3_key = get_backup_key(graph_id, "system", timestamp, extension=".lbug")
-    # All graph storage (backups included) lives in USER_DATA_BUCKET — see
-    # config/storage/graph.py. env.S3_GRAPH_BUCKET never existed, so this
-    # upload raised AttributeError and aborted every migration export.
-    bucket = env.USER_DATA_BUCKET
+    # The bucket is passed in by the caller. The migration op resolves
+    # USER_DATA_BUCKET in the worker (where it is set) and forwards it, matching
+    # the backup/restore endpoints, which also take the bucket from the request.
+    # The graph-api writer container does not set USER_DATA_BUCKET, so reading it
+    # here would resolve to the bogus default and 404 on upload.
 
     s3_client = self._get_s3_client()
     transfer_config = TransferConfig(
@@ -208,7 +214,7 @@ class MigrationService:
       )
 
   async def export_all_databases(
-    self, task_id: str, source_version: str, target_version: str
+    self, task_id: str, source_version: str, target_version: str, bucket: str
   ) -> None:
     """
     Background task: export all databases to Parquet for version migration.
@@ -279,7 +285,7 @@ class MigrationService:
         # Upload system backup to S3 (safety net)
         db_size = db_file.stat().st_size
         system_backup_key = self._upload_system_backup(
-          db_file, db_name, source_version, target_version
+          db_file, db_name, source_version, target_version, bucket
         )
 
         manifest_databases.append(

--- a/robosystems/graph_api/routers/migration.py
+++ b/robosystems/graph_api/routers/migration.py
@@ -28,6 +28,11 @@ async def export_for_migration(
   background_tasks: BackgroundTasks,
   source_version: str = Query(..., description="Current LadybugDB version"),
   target_version: str = Query(..., description="Target LadybugDB version"),
+  bucket: str = Query(
+    ...,
+    description="S3 bucket for the system backup; the caller resolves "
+    "USER_DATA_BUCKET (this writer container does not set it)",
+  ),
 ) -> MigrationExportResponse:
   """
   Export all databases on this instance for version migration.
@@ -46,7 +51,11 @@ async def export_for_migration(
     },
   )
   background_tasks.add_task(
-    migration_service.export_all_databases, task_id, source_version, target_version
+    migration_service.export_all_databases,
+    task_id,
+    source_version,
+    target_version,
+    bucket,
   )
   return MigrationExportResponse(
     task_id=task_id, monitor_url=f"/tasks/{task_id}/monitor"


### PR DESCRIPTION
## Problem

With the discovery fix (#860) deployed, the migration export got past instance discovery and both writers read their databases — then failed uploading the system backup:

```
NoSuchBucket: robosystems-user — The specified bucket does not exist
```

`_upload_system_backup` read `env.USER_DATA_BUCKET` **on the graph-api writer container, which does not set that variable** — it falls back to the bare `robosystems-user` default. `USER_DATA_BUCKET` is only set in the ECS API and Dagster containers (`api.yaml`, `dagster.yaml`), not in the graph writer. #859 had swapped the (nonexistent) `S3_GRAPH_BUCKET` for `USER_DATA_BUCKET`, which fixed the `AttributeError` but not the resolution on the writer.

## Why the env-var approach is wrong here

The writer **never self-resolves buckets by design**. `backup.py` and `restore.py` both take the S3 bucket as a **request parameter** from the caller (the ECS API/worker, which has `USER_DATA_BUCKET`). Migration export was the first writer-side feature to upload to the user bucket and broke that pattern by reading the env var locally.

## Fix

Thread the bucket the same way every other writer S3 op does — resolve it in the worker and pass it in:

```
op _export_instance  →  client.migration_export(…, bucket=env.USER_DATA_BUCKET)
  →  POST /migration/export?…&bucket=…  →  export_all_databases(…, bucket)
  →  _upload_system_backup(…, bucket)
```

The op runs in the Dagster worker, where `USER_DATA_BUCKET` **is** set. The import side reads local parquet (no bucket), so it's unaffected. The parquet `EXPORT DATABASE` is local and already succeeded in the failed run, so this unblocks the full export.

Audited: no other writer-unset `env.` dependency remains in `migration_service.py`. Ruff + basedpyright clean.