### PR TITLE
fix(migration): checkpoint before export + pin SEC replica image tag

### DIFF
--- a/.github/workflows/deploy-graph.yml
+++ b/.github/workflows/deploy-graph.yml
@@ -50,6 +50,11 @@ on:
         required: true
         type: string
         description: ECR image tag
+      shared_replica_image_tag:
+        required: false
+        type: string
+        default: ""
+        description: "ECR image tag for the SEC shared replicas only. Callers pass the specific build git tag (like the ECS services) so replicas are pinned to an exact version and don't drift to the moving tag on scale/spot/health boots — keeping the replica engine matched to the S3 sec.lbug it downloads. Empty falls back to ecr_image_tag (writers/master keep the moving tag)."
       # Infrastructure inputs (from graph infrastructure deployment)
       secret_arn:
         required: true
@@ -509,7 +514,9 @@ jobs:
       spot_enabled: ${{ inputs.shared_replicas_spot_enabled }}
       od_base: ${{ inputs.shared_replicas_od_base }}
       spot_weight: ${{ inputs.shared_replicas_spot_weight }}
-      ecr_image_tag: ${{ inputs.ecr_image_tag }}
+      # Replicas can be pinned to a specific engine version independently of the
+      # writers/master (empty falls back to the moving ecr_image_tag).
+      ecr_image_tag: ${{ inputs.shared_replica_image_tag || inputs.ecr_image_tag }}
       # Cache Configuration
       valkey_sg_id: ${{ inputs.valkey_sg_id }}
       valkey_url: ${{ inputs.valkey_url }}

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -478,6 +478,12 @@ jobs:
       ami_id: ${{ needs.stack-config.outputs.graph_ami_id }}
       # Container Configuration - use prod tag for EC2/ASG (container refresh handles updates)
       ecr_image_tag: prod
+      # SEC shared replicas: pin to this build's exact git tag (like the ECS
+      # services), not the moving prod tag, so a scale/spot/health boot pulls a
+      # fixed version instead of drifting ahead of the S3 sec.lbug it reads. For
+      # an engine upgrade, hold the replicas by not redeploying them until the
+      # new sec.lbug is published, then deploy them forward.
+      shared_replica_image_tag: ${{ needs.build.outputs.image_tag }}
       # Infrastructure inputs from graph infrastructure jobs
       secret_arn: ${{ needs.deploy-graph-infra.outputs.secret_arn }}
       volume_registry_table: ${{ needs.deploy-graph-infra.outputs.volume_registry_table }}

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -495,6 +495,12 @@ jobs:
       ami_id: ${{ needs.stack-config.outputs.graph_ami_id }}
       # Container Configuration - use staging tag for EC2/ASG (container refresh handles updates)
       ecr_image_tag: staging
+      # SEC shared replicas: pin to this build's exact git tag (like the ECS
+      # services), not the moving staging tag, so a scale/spot/health boot pulls
+      # a fixed version instead of drifting ahead of the S3 sec.lbug it reads. For
+      # an engine upgrade, hold the replicas by not redeploying them until the
+      # new sec.lbug is published, then deploy them forward.
+      shared_replica_image_tag: ${{ needs.build.outputs.image_tag }}
       # Infrastructure inputs from graph infrastructure jobs
       secret_arn: ${{ needs.deploy-graph-infra.outputs.secret_arn }}
       volume_registry_table: ${{ needs.deploy-graph-infra.outputs.volume_registry_table }}

--- a/robosystems/graph_api/core/migration_service.py
+++ b/robosystems/graph_api/core/migration_service.py
@@ -100,6 +100,25 @@ class MigrationService:
       kwargs["aws_secret_access_key"] = s3_config.get("aws_secret_access_key")
     return boto3.client("s3", **kwargs)
 
+  def _checkpoint_database(self, graph_id: str) -> None:
+    """Drain the WAL into the .lbug file via the connection pool (single-writer path).
+
+    Run before EXPORT so the on-disk file rolls cleanly to the new engine
+    version. An un-checkpointed v40 WAL tail cannot be replayed by the new engine
+    after an upgrade ("Corrupted wal file. Read out invalid WAL record type."),
+    which 500s every read until the import rebuilds the db; it also leaves the raw
+    .lbug S3 system backup (which excludes the .wal) incomplete. The pool's
+    auto_checkpoint only fires past a size threshold (512 MB for regular graphs),
+    so small graphs never auto-drain — hence the explicit CHECKPOINT. Mirrors
+    OnInstanceBackupService._checkpoint. Best-effort: the caller logs and
+    continues on failure (the parquet export still captures committed WAL data).
+    """
+    from robosystems.graph_api.core.ladybug import get_ladybug_service
+
+    service = get_ladybug_service()
+    with service.db_manager.get_connection(graph_id, read_only=False) as conn:
+      conn.execute("CHECKPOINT")
+
   def _upload_system_backup(
     self,
     db_file: Path,
@@ -260,6 +279,15 @@ class MigrationService:
         export_dir = self.exports_path / db_name
 
         logger.info(f"Exporting {db_name} ({i + 1}/{len(databases)})")
+
+        # Drain the WAL on the OLD engine so the file rolls cleanly to the new
+        # engine version (see _checkpoint_database). Best-effort — never block
+        # the export on it; the parquet export captures committed WAL data
+        # regardless, and the read-only export handle below opens the file next.
+        try:
+          self._checkpoint_database(db_name)
+        except Exception as e:
+          logger.warning(f"CHECKPOINT before export failed for {db_name}: {e}")
 
         db = None
         conn = None


### PR DESCRIPTION
## Summary

Two forward-looking hardening fixes to the LadybugDB engine-migration path, both surfaced while executing the 0.13.1 → 0.18.1 prod upgrade this session.

## Changes

### `migration_service.py` — CHECKPOINT each database before export
- `export_all_databases` opened each db read-only and ran `EXPORT DATABASE` without first draining the WAL.
- The connection pool's `auto_checkpoint` only fires past a 512 MB threshold, so small graphs keep an un-checkpointed WAL tail.
- On a version upgrade the new engine cannot replay a v40 WAL tail (`Corrupted wal file. Read out invalid WAL record type.`) — every read 500s until the import rebuilds the db, and the tail is also missing from the raw-`.lbug` S3 system backup (the `.wal` is not uploaded).
- Adds `_checkpoint_database` (pool single-writer path, mirrors `OnInstanceBackupService._checkpoint`), called per-db before the read-only export handle. Best-effort: a checkpoint failure logs a warning and continues (the parquet export still captures committed WAL data).

### Shared-replica image tag — pin to the build git tag
- The SEC shared replicas read a fixed S3 key (`sec.lbug`) but their launch template used the moving `prod`/`staging` tag, so a scale / spot / health boot pulled whatever the latest image was — for an engine upgrade that jumps the replica engine ahead of the S3 file's storage version.
- Adds a dedicated `shared_replica_image_tag` input to `deploy-graph.yml` (empty falls back to `ecr_image_tag`), wired in `prod.yml`/`staging.yml` to `${{ needs.build.outputs.image_tag }}` — the exact build git tag, like the ECS services. Writers + master intentionally keep the moving tag (they must refresh to newest on ASG cycle).
- Result: a replica boot pulls the exact version last deployed to the fleet and never drifts. Combined with `SHARED_REPLICAS_ENABLED_*=false` (a non-destructive deploy-skip — the flag is only a job `if:` gate, not a CFN param), this lets an engine rollout hold the replica fleet on the old engine until the new-version `sec.lbug` is published, then flip image + file in lockstep.

## Testing
- Pre-commit hook (ruff + format + basedpyright) clean on both commits — 0 errors, 0 warnings, 0 notes.
- Workflow YAML validated (`yaml.safe_load`) for all three `.github/workflows` files.
- `just test-all` not run — needs a local env.
- The migration export/import path was exercised end-to-end in prod this session during the 0.13.1 → 0.18.1 tenant migration, but on code **without** these two changes — that run is exactly what surfaced the WAL read-outage and the image-drift risk. The CHECKPOINT change is therefore not yet exercised end-to-end; validate it in the staging rehearsal of the next engine upgrade.

## Notes
- No behavior change until an engine upgrade: every deploy already stamps the replicas with the same git tag it stamps the ECS services, and the checkpoint no-ops when the WAL is already drained.
