### PR TITLE
chore(config): sync .env.example with env.py

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -81,6 +81,8 @@ ADMIN_API_KEY=dev-admin-key-for-testing-only
 POSTGRES_PASSWORD=postgres
 DATABASE_URL=postgresql://postgres:${POSTGRES_PASSWORD}@pg:5432/robosystems
 EXTENSIONS_DATABASE_URL=postgresql://postgres:${POSTGRES_PASSWORD}@pg:5432/extensions
+# Echo all SQL to logs (noisy — handy for local query debugging)
+# DATABASE_ECHO=false
 
 ## Dagster Database Credentials
 DAGSTER_HOST=dagster-webserver
@@ -98,6 +100,7 @@ VALKEY_URL=redis://:${VALKEY_AUTH_TOKEN}@valkey:6379
 
 ## OpenSearch
 OPENSEARCH_URL=http://robosystems-opensearch:9200
+# OPENSEARCH_INDEX=documents
 
 ## JWT Configuration (deployment-specific, in Secrets Manager for prod)
 ## Note: In prod, JWT_ISSUER/JWT_AUDIENCE are set based on API_ACCESS_MODE
@@ -178,6 +181,9 @@ AWS_BEDROCK_SECRET_ACCESS_KEY=your-bedrock-secret-key
 # ROBOLEDGER_ENABLED=true
 # ROBOINVESTOR_ENABLED=true
 # EXTENSIONS_GRAPHQL_ENABLED=true
+# Period-close autopilot: when true the Dagster sensor drafts the closing entry
+# on the same tick a schedule matures. Default false (co-pilot); per-graph column overrides.
+# EXTENSIONS_PROMOTION_AUTO_DISPATCH=false
 
 ## Platform Operations
 USER_REGISTRATION_ENABLED=true
@@ -199,10 +205,14 @@ SECURITY_AUDIT_ENABLED=false
 # DIRECT_GRAPH_MATERIALIZATION_ENABLED=true
 # SUBGRAPH_CREATION_ENABLED=true
 # BACKUP_CREATION_ENABLED=true
+# OPERATOR_POST_ENABLED=true
 # FACT_GRID_ENABLED=true
 # MCP_AUTO_LIMIT_ENABLED=true
 # MCP_WORKSPACE_ENABLED=true
-# MCP_MEMORY_ENABLED=true
+# MCP_GRAPHQL_ENABLED=true
+# Subgraph write/DDL MCP tools (write-graph-cypher, add-node-table,
+# add-relationship-table). Renamed from the former MCP_MEMORY_ENABLED.
+# MCP_SUBGRAPH_OPS_ENABLED=true
 # MCP_SEMANTIC_MEMORY_ENABLED=false
 # AI semantic memory (LanceDB) — master gate (REST + ops + recall + governance);
 # MCP_SEMANTIC_MEMORY_ENABLED is the additional MCP-tool sub-gate.
@@ -211,13 +221,15 @@ SECURITY_AUDIT_ENABLED=false
 ## Shared Repository Operations
 # SHARED_MASTER_READS_ENABLED=true
 # SHARED_MASTER_PARKING_ENABLED=true
-# MCP_VECTOR_SEARCH_ENABLED=false
-# SEMANTIC_SEARCH_ENABLED=false
+# SEMANTIC_SEARCH_ENABLED=true
 
 ## Connection Providers
 # CONNECTIONS_ENABLED=true
 # CONNECTION_SEC_ENABLED=true
 # CONNECTION_QUICKBOOKS_ENABLED=true
+# Route QB Reports API through Intuit's v2 service (ahead of their 2026-08-31
+# hard cutover). Set false to fall back to v1 at runtime. Retires after cutover.
+# INTUIT_REPORTS_TESTING_MIGRATION=true
 
 ## Adapter Pipelines
 # SEC_PIPELINE_ENABLED=true
@@ -312,8 +324,11 @@ GRAPH_SHARED_REPOSITORY_BACKEND=ladybug
 GRAPH_API_URL=http://graph-api:8001
 # GRAPH_API_KEY=your-graph-api-key-here
 
+## Report bundle SHACL validation at publish time (off | warn | strict)
+# REPORT_BUNDLE_SHACL_VALIDATION=off
+
 ## LadybugDB Configuration
-LBUG_DATABASE_PATH=./data/ladybug-dbs
+LBUG_DATABASE_PATH=./data/lbug-dbs
 LBUG_ACCESS_PATTERN=api_auto
 LBUG_NODE_TYPE=writer
 LBUG_MAX_DATABASES_PER_NODE=50
@@ -321,8 +336,14 @@ LBUG_MAX_DATABASES_PER_NODE=50
 ## DuckDB Configuration
 DUCKDB_STAGING_PATH=./data/staging
 
+## Artifact Storage (precomputed Parquet for enrichment refinement)
+# ARTIFACT_PATH=./data/artifacts
+
 ## LanceDB Vector Search Index
 # LANCE_INDEX_PATH=./data/lance
+
+## Arelle (XBRL) runtime cache directory
+# ARELLE_CACHE_DIR=
 
 ## Shared Repository Configuration
 # SHARED_REPLICA_ALB_URL=http://internal-robosystems-shared-prod-xxx.region.elb.amazonaws.com:8001


### PR DESCRIPTION
## Summary

Reconcile `.env.example` with the variables the code actually reads (`robosystems/config/env.py` plus the standalone `graph_api` service). The template had drifted: it documented two flags the code no longer reads and omitted several that it does, so it was no longer a reliable reference for local setup.

## Changes

All in `.env.example`:

- **Removed stale flags** no longer read anywhere in the codebase:
  - `MCP_MEMORY_ENABLED` — renamed to `MCP_SUBGRAPH_OPS_ENABLED` (`env.py:588`)
  - `MCP_VECTOR_SEARCH_ENABLED` — dead
- **Added missing feature flags** the code reads:
  - `OPERATOR_POST_ENABLED`, `MCP_GRAPHQL_ENABLED`, `MCP_SUBGRAPH_OPS_ENABLED`, `EXTENSIONS_PROMOTION_AUTO_DISPATCH`, `INTUIT_REPORTS_TESTING_MIGRATION`
- **Added missing service/runtime config** the code reads:
  - `DATABASE_ECHO`, `OPENSEARCH_INDEX`, `REPORT_BUNDLE_SHACL_VALIDATION`, `ARTIFACT_PATH`, `ARELLE_CACHE_DIR`
- **Corrected drift from code defaults:**
  - `SEMANTIC_SEARCH_ENABLED` documented default `false` → `true` (matches `env.py`)
  - `LBUG_DATABASE_PATH` `./data/ladybug-dbs` → `./data/lbug-dbs` (matches `compose.yaml`, the code default, and the on-disk directory)

Infra-only variables that are CloudFormation-injected in prod and have working local defaults (bucket names, registry tables, ASG names, `CLUSTER_TIER`, `LBUG_ROLE`, the `LBUG_*` tuning knobs) were intentionally left out.

## Testing

Docs-only change (no runtime code touched). Pre-commit hooks ran on commit — ruff lint/format and basedpyright reported `All checks passed! / 0 errors, 0 warnings`. Full `just test-all` not run this session.
