### PR TITLE
fix(graph-api): size Arrow COPY chunk above the hash-batch (25M) to fix SEC materialize

### DIFF
--- a/robosystems/graph_api/routers/databases/tables/materialize.py
+++ b/robosystems/graph_api/routers/databases/tables/materialize.py
@@ -20,10 +20,18 @@ from robosystems.middleware.graph.instance_busy import (
   instance_busy,
 )
 
-# Rows per Arrow record batch streamed from DuckDB into LadybugDB. Bounds peak
-# memory — the table streams through in batches rather than materializing fully
-# in RAM regardless of its size.
-ARROW_STREAM_BATCH_ROWS = 100_000
+# Max rows per Arrow record batch streamed from DuckDB into a single LadybugDB
+# COPY. This is an inner memory-safety cap, NOT the primary batch size -- callers
+# already bound each materialize request via their own OUTER batching:
+#   - SEC pipeline: hash-batching at MATERIALIZATION_BATCH_SIZE (20M rows/call)
+#   - tenant/direct: chunked_materialization at the tier's chunk_size_rows
+# Keeping this cap >= those outer sizes means each call materializes in ONE COPY.
+# Each COPY is its own transaction + WAL commit + auto-checkpoint check, so
+# per-table cost is dominated by COPY COUNT, not row throughput: at the old 100k a
+# 19M SEC hash-batch fanned out into ~190 COPYs (~8s each) and `Element` took 644s
+# vs ~60s for the pre-0.18 single-COPY path. At 25M each hash-batch is one COPY
+# again; the shared master's 50 GB buffer pool + spill-to-disk absorbs it.
+ARROW_STREAM_BATCH_ROWS = 25_000_000
 
 
 def _copy_result_rows(result, fallback: int) -> int:


### PR DESCRIPTION
## Summary

Fixes a severe SEC materialize slowdown introduced by the ladybug 0.18 upgrade: raise `ARROW_STREAM_BATCH_ROWS` from 100k to **25M** so each materialize call COPYs in one shot instead of fanning out into hundreds of tiny COPYs.

## Background

The 0.18 materialize rewrite streams each table from DuckDB as Arrow record batches and issues **one `COPY` per batch** (`ARROW_STREAM_BATCH_ROWS = 100_000`). But callers already bound each materialize request with their **own outer batching**:

- **SEC pipeline** → hash-batching at `MATERIALIZATION_BATCH_SIZE` (20M rows per call)
- **Tenant/direct** → `chunked_materialization` at the tier's `chunk_size_rows`

So the 100k inner chunk re-split every already-bounded call into hundreds of tiny COPYs. Each COPY is its own transaction + WAL commit + auto-checkpoint check, so per-table cost is dominated by **COPY count**, not row throughput:

- `Element` (7.8M rows, single call) → 78 COPYs × ~8s ≈ **644s** (vs ~60s on the pre-0.18 single-COPY path)
- a 19M SEC hash-batch → ~190 COPYs
- full SEC rebuild (`Fact` 76M, `FACT_SET_CONTAINS_FACT` 152M, four `FACT_HAS_*` at 68–76M) projected to **~12h**, making the rebuild impractical

Observed live while rebuilding the `sec` graph on the shared master (r7g.2xlarge, 0.18).

## Changes

- **`robosystems/graph_api/routers/databases/tables/materialize.py`** — `ARROW_STREAM_BATCH_ROWS`: `100_000` → `25_000_000` (just above the 20M SEC hash-batch). Each outer-bounded call now materializes in a single COPY, restoring pre-0.18 throughput. Rewrote the constant's comment to document that this is an **inner memory-safety cap** deferring to the callers' outer batching (SEC hash-batching / tenant `chunk_size_rows`), not the primary batch size — so the layering isn't mistaken for redundancy again.

## Why 25M is memory-safe

Peak batch memory is bounded by the callers' outer batching, not by this cap: SEC hash-batches to ≤20M rows/call and the tenant path to its tier `chunk_size_rows`. The pre-0.18 path already did ~19M-row single COPYs on this instance, and the shared master runs a 50 GB buffer pool + spill-to-disk. The 25M value only ensures the inner streamer doesn't sub-split a ≤20M call.

## Cleanup investigation

The user asked to remove any unused/confusing batch concepts. Verified first — **nothing is dead**:

- `chunk_size_rows` (tier `graph_limits`) is **live**: it's the batch size for the tenant/direct path (`operations/graph/engine/chunked_materialization.py`). Removing it would break tenant materialization.
- `MATERIALIZATION_BATCH_SIZE` (20M) and `SECMaterializeConfig.materialization_batch_size` (20M) duplicate the *value* but both are used; left as-is to avoid a cross-module import into the SEC adapter (known circular-import footguns).

So the "cleanup" here is documentation (the rewritten comment) rather than deletion.

## Testing

- `ruff check` + `ruff format --check` clean; pre-commit hooks green.
- Full suite **not run** — single-constant change in the graph-api; needs a local env, and the real validation is the re-run materialize on the shared master (pre-0.18 timings expected).

## Deploy / rollout

Requires the new image on the shared master. Plan: merge → cut a patch release (builds/pushes `:prod`) → cycle the master onto it (the staged `sec.duckdb` + data volume persist, so staging is **not** repeated) → re-run `sec_materialize`. This is part of the in-flight SEC 0.18 rebuild / replica-heal.
