### PR TITLE
fix(materialize): restore complete relationship ingestion on ladybug 0.18

### DIFF
--- a/robosystems/adapters/sec/pipeline/entity_sync/load.py
+++ b/robosystems/adapters/sec/pipeline/entity_sync/load.py
@@ -200,7 +200,6 @@ async def _load_tables(
         mat_result = await client.materialize_table(
           graph_id=config.graph_id,
           table_name=table_name,
-          ignore_errors=True,
         )
         rows = mat_result.get("rows_ingested", 0) if mat_result else 0
         total_rows += rows

--- a/robosystems/adapters/sec/processors/ingestion/materialization.py
+++ b/robosystems/adapters/sec/processors/ingestion/materialization.py
@@ -358,7 +358,6 @@ class LadybugMaterializer:
             response = await graph_client.materialize_table(
               graph_id=self.graph_id,
               table_name=table_name,
-              ignore_errors=True,
               batch_num=batch_num,
               num_batches=num_batches,
               timeout=CHUNKED_MATERIALIZATION_TIMEOUT,
@@ -399,7 +398,6 @@ class LadybugMaterializer:
           response = await graph_client.materialize_table(
             graph_id=self.graph_id,
             table_name=table_name,
-            ignore_errors=True,
             timeout=timeout,
           )
 

--- a/robosystems/dagster/jobs/graph.py
+++ b/robosystems/dagster/jobs/graph.py
@@ -163,7 +163,6 @@ class MaterializeGraphConfig(Config):
   user_id: str
   force: bool = False
   rebuild: bool = False
-  ignore_errors: bool = True
   materialize_embeddings: bool = False
   operation_id: str | None = None  # For SSE result updates
 
@@ -605,7 +604,6 @@ def materialize_file_to_graph(
       client.materialize_table(
         graph_id=graph_id,
         table_name=table_name,
-        ignore_errors=True,
         file_ids=[file_id],
       )
     )
@@ -689,7 +687,6 @@ def materialize_staged_file(
       client.materialize_table(
         graph_id=config.graph_id,
         table_name=config.table_name,
-        ignore_errors=True,
         file_ids=[config.file_id],
       )
     )
@@ -808,7 +805,7 @@ def materialize_graph_tables(
   graph_id = config.graph_id
   context.log.info(
     f"Starting graph materialization for {graph_id} "
-    f"(force={config.force}, rebuild={config.rebuild}, ignore_errors={config.ignore_errors})"
+    f"(force={config.force}, rebuild={config.rebuild})"
   )
 
   with db.get_session() as session:
@@ -1005,7 +1002,6 @@ def materialize_graph_tables(
               graph_id=graph_id,
               table_name=table_name,
               tier=graph_record.graph_tier or "ladybug-standard",
-              ignore_errors=config.ignore_errors,
               materialize_embeddings=config.materialize_embeddings,
               file_ids=None,
             )
@@ -1018,16 +1014,16 @@ def materialize_graph_tables(
           context.log.info(f"Materialized {table_name}: {rows_ingested:,} rows")
 
         except Exception as e:
+          # Fail fast: a failed table means missing data.
           context.log.error(f"Failed to materialize table {table_name}: {e}")
-          if not config.ignore_errors:
-            raise Failure(
-              description=f"Materialization failed on table {table_name}: {e!s}",
-              metadata={
-                "graph_id": graph_id,
-                "table_name": table_name,
-                "error": str(e),
-              },
-            )
+          raise Failure(
+            description=f"Materialization failed on table {table_name}: {e!s}",
+            metadata={
+              "graph_id": graph_id,
+              "table_name": table_name,
+              "error": str(e),
+            },
+          )
 
       # Mark graph as fresh
       context.log.info("[95%] Marking graph as fresh")

--- a/robosystems/graph_api/README.md
+++ b/robosystems/graph_api/README.md
@@ -782,7 +782,7 @@ aws autoscaling start-instance-refresh \
 
 #### Ingestion Optimization
 
-- Use `ignore_errors=true` for duplicate handling
+- Duplicates are deduplicated in DuckDB staging; materialization uses a plain COPY (ignore_errors is intentionally unused — LadybugDB 0.18 silently drops valid rows with it)
 - Batch multiple files in single request
 - Higher priority (1-10) for urgent data
 - Monitor queue depth metrics

--- a/robosystems/graph_api/client/client.py
+++ b/robosystems/graph_api/client/client.py
@@ -1948,7 +1948,6 @@ class GraphClient(BaseGraphClient):
     self,
     graph_id: str,
     table_name: str,
-    ignore_errors: bool = True,
     file_ids: list[str] | None = None,
     batch_num: int | None = None,
     num_batches: int | None = None,
@@ -1966,7 +1965,6 @@ class GraphClient(BaseGraphClient):
     Args:
         graph_id: Graph database identifier
         table_name: Table name to materialize
-        ignore_errors: Continue on row errors
         file_ids: Optional list of file IDs to materialize. If None, materializes all rows.
         batch_num: Current batch number (0-indexed) for hash-based batching.
         num_batches: Total number of batches. Each row goes to one batch based on hash(key) % num_batches.
@@ -1978,7 +1976,7 @@ class GraphClient(BaseGraphClient):
     Returns:
         Materialization response with rows materialized and timing
     """
-    json_data: dict[str, Any] = {"ignore_errors": ignore_errors}
+    json_data: dict[str, Any] = {}
 
     if file_ids is not None:
       json_data["file_ids"] = file_ids
@@ -2043,7 +2041,6 @@ class GraphClient(BaseGraphClient):
     parent_graph_id: str,
     subgraph_id: str,
     tables: list[str] | None = None,
-    ignore_errors: bool = True,
   ) -> dict[str, Any]:
     """
     Fork data from parent graph's DuckDB directly into subgraph's LadybugDB.
@@ -2057,7 +2054,6 @@ class GraphClient(BaseGraphClient):
         parent_graph_id: Parent graph to copy data from
         subgraph_id: Subgraph to copy data to
         tables: List of table names to copy (empty list = all tables)
-        ignore_errors: Continue ingestion on row errors
 
     Returns:
         Fork response with tables copied, row counts, and timing
@@ -2067,7 +2063,6 @@ class GraphClient(BaseGraphClient):
       f"/databases/{subgraph_id}/tables/{subgraph_id}/fork-from/{parent_graph_id}",
       json_data={
         "tables": tables or [],
-        "ignore_errors": ignore_errors,
       },
     )
     return response.json()

--- a/robosystems/graph_api/core/duckdb/manager.py
+++ b/robosystems/graph_api/core/duckdb/manager.py
@@ -209,8 +209,12 @@ class DuckDBTableManager:
     via DuckDB's external aggregation, unlike ROW_NUMBER which can OOM on large datasets.
     See: https://duckdb.org/2024/03/29/external-aggregation
 
-    NOTE: Deduplication is required here because LadybugDB's ignore_errors=true
-    only works for COPY FROM files, NOT for COPY FROM attached DuckDB tables.
+    NOTE: Deduplication is required here because materialization uses a plain
+    COPY (no ignore_errors — LadybugDB 0.18's ignore_errors path silently drops
+    valid rows in proportion to batch size). LadybugDB enforces unique node
+    primary keys and unique relationship (from,to) pairs, so any duplicate that
+    reached it would hard-fail the COPY. Dedup in staging is what keeps the
+    clean COPY both safe and complete.
 
     Args:
         quoted_table: Quoted table name (e.g., '"table_name"')

--- a/robosystems/graph_api/models/fork.py
+++ b/robosystems/graph_api/models/fork.py
@@ -14,9 +14,6 @@ class ForkFromParentRequest(BaseModel):
     default_factory=list,
     description="List of table names to copy from parent, or empty for all tables",
   )
-  ignore_errors: bool = Field(
-    default=True, description="Continue materialization on row errors"
-  )
 
   class Config:
     extra = "forbid"

--- a/robosystems/graph_api/models/tables.py
+++ b/robosystems/graph_api/models/tables.py
@@ -116,9 +116,6 @@ class TableQueryResponse(BaseModel):
 class TableMaterializationRequest(BaseModel):
   """Request to materialize DuckDB table data into LadybugDB."""
 
-  ignore_errors: bool = Field(
-    default=True, description="Continue materialization on row errors"
-  )
   file_ids: list[str] | None = Field(
     default=None,
     description="Optional list of file IDs to materialize. If None, materializes all files (full materialization).",

--- a/robosystems/graph_api/routers/databases/tables/materialize.py
+++ b/robosystems/graph_api/routers/databases/tables/materialize.py
@@ -406,7 +406,6 @@ async def _materialize_table_impl(
         else:
           logger.info(f"COPY {table_name} → {graph_id}")
 
-        copy_suffix = " (ignore_errors=true)" if request.ignore_errors else ""
         rows_ingested = 0
         with ladybug_service.db_manager.connection_pool.get_connection(
           graph_id
@@ -420,7 +419,11 @@ async def _materialize_table_impl(
               # local's name MUST match the identifier in the COPY statement.
               # The F841 suppression is real: the engine reads it, the linter can't see that.
               copy_batch = pa.Table.from_batches([arrow_batch])  # noqa: F841
-              result = conn.execute(f"COPY {table_name} FROM copy_batch{copy_suffix}")
+              # No ignore_errors: LadybugDB 0.18's COPY (ignore_errors=true)
+              # silently drops VALID rows in proportion to batch size (~37% at
+              # 20M). Staging dedupes and all nodes load before any relationship,
+              # so a plain COPY is both correct and complete. Do NOT re-add it.
+              result = conn.execute(f"COPY {table_name} FROM copy_batch")
               rows_ingested += _copy_result_rows(result, arrow_batch.num_rows)
           finally:
             conn.execute("CALL timeout=120000")  # reset to 2 minutes
@@ -618,7 +621,6 @@ async def _fork_from_parent_duckdb_impl(
             f"SELECT {select_expr} FROM {table_name}"
           ).fetch_record_batch(ARROW_STREAM_BATCH_ROWS)
 
-          copy_suffix = " (ignore_errors=true)" if request.ignore_errors else ""
           table_rows = 0
           logger.info(f"Copying {table_name} from parent to subgraph")
           try:
@@ -626,12 +628,15 @@ async def _fork_from_parent_duckdb_impl(
             for arrow_batch in arrow_reader:
               # `copy_batch` is resolved by name from this frame (replacement scan).
               copy_batch = pa.Table.from_batches([arrow_batch])  # noqa: F841
-              result = conn.execute(f"COPY {table_name} FROM copy_batch{copy_suffix}")
+              # Plain COPY — see the note in materialize_table: ladybug 0.18's
+              # ignore_errors path silently drops valid rows.
+              result = conn.execute(f"COPY {table_name} FROM copy_batch")
               table_rows += _copy_result_rows(result, arrow_batch.num_rows)
           except Exception as table_err:
+            # Fail fast: a copy error on clean, ordered staging is a real problem,
+            # not something to swallow (that would silently lose a whole table).
             logger.error(f"Failed to copy {table_name}: {table_err}")
-            if not request.ignore_errors:
-              raise
+            raise
           finally:
             conn.execute("CALL timeout=120000")  # reset to 2 minutes
 

--- a/robosystems/graph_api/routers/databases/tables/materialize.py
+++ b/robosystems/graph_api/routers/databases/tables/materialize.py
@@ -21,16 +21,19 @@ from robosystems.middleware.graph.instance_busy import (
 )
 
 # Max rows per Arrow record batch streamed from DuckDB into a single LadybugDB
-# COPY. This is an inner memory-safety cap, NOT the primary batch size -- callers
-# already bound each materialize request via their own OUTER batching:
-#   - SEC pipeline: hash-batching at MATERIALIZATION_BATCH_SIZE (20M rows/call)
-#   - tenant/direct: chunked_materialization at the tier's chunk_size_rows
-# Keeping this cap >= those outer sizes means each call materializes in ONE COPY.
-# Each COPY is its own transaction + WAL commit + auto-checkpoint check, so
-# per-table cost is dominated by COPY COUNT, not row throughput: at the old 100k a
-# 19M SEC hash-batch fanned out into ~190 COPYs (~8s each) and `Element` took 644s
-# vs ~60s for the pre-0.18 single-COPY path. At 25M each hash-batch is one COPY
-# again; the shared master's 50 GB buffer pool + spill-to-disk absorbs it.
+# COPY. Sized at/above the outer batchers (SEC hash-batching at
+# MATERIALIZATION_BATCH_SIZE = 20M/call; tenant/direct chunked_materialization at
+# the tier chunk_size_rows) so each already-bounded call materializes in ONE COPY.
+# Per-table cost is dominated by COPY COUNT -- each COPY is its own transaction +
+# WAL commit + checkpoint check -- not row throughput: at the old 100k a 19M SEC
+# hash-batch fanned into ~190 COPYs (~8s each) and Element took 644s vs ~60s for
+# the pre-0.18 single-COPY path.
+# Safe at this size only because the materialize connections SET
+# arrow_large_buffer_size=true (in the get_connection blocks below): DuckDB then
+# emits 64-bit LargeString offsets, lifting Arrow's 2 GiB (2^31) regular-string-
+# buffer cap that a wide column like Fact.uri (~128 B/row XBRL concept URIs, not
+# externalizable) otherwise overflows at ~19M rows, ABORTING the process. Verified
+# locally that ladybug's COPY reader accepts Arrow LargeString.
 ARROW_STREAM_BATCH_ROWS = 25_000_000
 
 
@@ -268,6 +271,10 @@ async def _materialize_table_impl(
 
     try:
       with duckdb_pool.get_connection(duckdb_graph_id) as duck_conn:
+        # 64-bit Arrow string offsets: wide columns (e.g. Fact.uri ~128 B/row)
+        # otherwise overflow Arrow's 2 GiB regular-string-buffer cap when a large
+        # batch streams as one record batch, aborting the process.
+        duck_conn.execute("SET arrow_large_buffer_size=true")
         # Flush WAL so the parquet export sees all committed staging data
         checkpoint_with_retry(duck_conn, duckdb_graph_id, context="DuckDB")
 
@@ -592,6 +599,8 @@ async def _fork_from_parent_duckdb_impl(
         duckdb_pool.get_connection(parent_graph_id) as duck_conn,
         ladybug_service.db_manager.connection_pool.get_connection(subgraph_id) as conn,
       ):
+        # See main path: 64-bit Arrow string offsets to avoid the 2 GiB cap.
+        duck_conn.execute("SET arrow_large_buffer_size=true")
         for table_name in tables_to_copy:
           source_columns = duck_conn.execute(
             "SELECT column_name, data_type FROM information_schema.columns "

--- a/robosystems/middleware/mcp/tools/graph_tools.py
+++ b/robosystems/middleware/mcp/tools/graph_tools.py
@@ -459,7 +459,6 @@ class MaterializeTool:
         "  graph_type if omitted.\n"
         "- dry_run: Validate without writing (returns a preview synchronously).\n"
         "- rebuild: Drop existing data and rebuild from scratch.\n"
-        "- ignore_errors: Continue past non-fatal row errors (default true).\n"
         "- force: Materialize even if the graph is already up-to-date.\n"
         "- materialize_embeddings: Generate vector embeddings during rebuild.\n\n"
         "**RETURNS:** `operation_id` — subscribe to "
@@ -472,7 +471,6 @@ class MaterializeTool:
           "source": {"type": "string", "enum": ["staged", "extensions"]},
           "dry_run": {"type": "boolean", "default": False},
           "rebuild": {"type": "boolean", "default": False},
-          "ignore_errors": {"type": "boolean", "default": True},
           "force": {"type": "boolean", "default": False},
           "materialize_embeddings": {"type": "boolean", "default": False},
         },

--- a/robosystems/models/api/graphs/operations.py
+++ b/robosystems/models/api/graphs/operations.py
@@ -95,9 +95,6 @@ class MaterializeOp(BaseModel):
   rebuild: bool = Field(
     default=False, description="Rebuild the graph from scratch, dropping existing data"
   )
-  ignore_errors: bool = Field(
-    default=True, description="Continue past non-fatal row errors"
-  )
   dry_run: bool = Field(
     default=False, description="Validate tables without writing to the graph"
   )

--- a/robosystems/operations/extensions/materialize.py
+++ b/robosystems/operations/extensions/materialize.py
@@ -1647,7 +1647,6 @@ class ExtensionsMaterializer:
         response = await client.materialize_table(
           graph_id=graph_id,
           table_name=table_name,
-          ignore_errors=True,
           timeout=300.0,
           source_graph_id=source_graph_id,
         )

--- a/robosystems/operations/graph/commands/materialize.py
+++ b/robosystems/operations/graph/commands/materialize.py
@@ -141,7 +141,6 @@ async def materialize_cmd(
         "source": source,
         "force": body.force,
         "rebuild": body.rebuild,
-        "ignore_errors": body.ignore_errors,
       },
     )
 
@@ -179,7 +178,6 @@ async def materialize_cmd(
         params={
           "force": body.force,
           "rebuild": body.rebuild,
-          "ignore_errors": body.ignore_errors,
           "materialize_embeddings": body.materialize_embeddings,
           "lock_key": lock_key,
         },
@@ -201,7 +199,6 @@ async def materialize_cmd(
         user_id=str(current_user.id),
         force=body.force,
         rebuild=body.rebuild,
-        ignore_errors=body.ignore_errors,
         materialize_embeddings=body.materialize_embeddings,
       )
       response = await enqueue_task(

--- a/robosystems/operations/graph/engine/chunked_materialization.py
+++ b/robosystems/operations/graph/engine/chunked_materialization.py
@@ -28,7 +28,6 @@ async def materialize_table_chunked(
   graph_id: str,
   table_name: str,
   tier: str,
-  ignore_errors: bool = True,
   materialize_embeddings: bool = False,
   file_ids: list[str] | None = None,
 ) -> dict[str, Any]:
@@ -43,7 +42,6 @@ async def materialize_table_chunked(
       graph_id: Graph database identifier.
       table_name: DuckDB staging table to materialize.
       tier: Graph tier name (e.g. "ladybug-standard").
-      ignore_errors: Continue on row errors (passed through to each chunk).
       materialize_embeddings: Include embedding columns and build HNSW vector indexes.
       file_ids: Optional file ID filter (passed through; chunking still applies).
 
@@ -62,7 +60,6 @@ async def materialize_table_chunked(
       table_name=table_name,
       row_count=row_count,
       chunk_size=chunk_size,
-      ignore_errors=ignore_errors,
       materialize_embeddings=materialize_embeddings,
       file_ids=file_ids,
     )
@@ -71,7 +68,6 @@ async def materialize_table_chunked(
   result = await client.materialize_table(
     graph_id=graph_id,
     table_name=table_name,
-    ignore_errors=ignore_errors,
     materialize_embeddings=materialize_embeddings,
     file_ids=file_ids,
     timeout=CHUNK_TIMEOUT,
@@ -123,7 +119,6 @@ async def _materialize_batched(
   table_name: str,
   row_count: int,
   chunk_size: int,
-  ignore_errors: bool,
   materialize_embeddings: bool,
   file_ids: list[str] | None,
 ) -> dict[str, Any]:
@@ -142,7 +137,6 @@ async def _materialize_batched(
       response = await client.materialize_table(
         graph_id=graph_id,
         table_name=table_name,
-        ignore_errors=ignore_errors,
         materialize_embeddings=materialize_embeddings,
         file_ids=file_ids,
         batch_num=batch_num,
@@ -157,12 +151,11 @@ async def _materialize_batched(
       )
 
     except Exception as exc:
+      # Fail fast: a failed batch means missing data, not something to skip.
       logger.error(
         f"  [{table_name}] Batch {batch_num + 1}/{num_batches} failed: {exc}"
       )
-      if not ignore_errors:
-        raise
-      # With ignore_errors, log and continue to next batch
+      raise
 
   logger.info(
     f"Chunked materialization complete for {table_name}: "

--- a/robosystems/operations/graph/engine/direct_materialization.py
+++ b/robosystems/operations/graph/engine/direct_materialization.py
@@ -34,7 +34,6 @@ async def materialize_graph_directly(
   graph_id: str,
   force: bool = False,
   rebuild: bool = False,
-  ignore_errors: bool = True,
   materialize_embeddings: bool = False,
   operation_id: str | None = None,
 ) -> dict[str, Any]:
@@ -48,7 +47,6 @@ async def materialize_graph_directly(
       graph_id: Graph database identifier
       force: Force materialization even if graph is not stale
       rebuild: Delete and recreate graph database before materialization
-      ignore_errors: Continue ingestion on row errors
       materialize_embeddings: Include embedding columns and build HNSW vector indexes
       operation_id: Optional SSE operation ID for progress tracking
 
@@ -65,8 +63,7 @@ async def materialize_graph_directly(
   manager = get_operation_manager()
 
   logger.info(
-    f"Direct materialization starting for {graph_id} "
-    f"(force={force}, rebuild={rebuild}, ignore_errors={ignore_errors})"
+    f"Direct materialization starting for {graph_id} (force={force}, rebuild={rebuild})"
   )
 
   if operation_id:
@@ -271,7 +268,6 @@ async def materialize_graph_directly(
             graph_id=graph_id,
             table_name=table_name,
             tier=graph_record.graph_tier or "ladybug-standard",
-            ignore_errors=ignore_errors,
             materialize_embeddings=materialize_embeddings,
             file_ids=None,
           )
@@ -283,9 +279,9 @@ async def materialize_graph_directly(
           logger.info(f"Materialized {table_name}: {rows_ingested:,} rows")
 
         except Exception as e:
+          # Fail fast: a failed table means missing data.
           logger.error(f"Failed to materialize table {table_name}: {e}")
-          if not ignore_errors:
-            raise
+          raise
 
       # Mark graph as fresh
       logger.info("[95%] Marking graph as fresh")

--- a/robosystems/operations/graph/subgraph_service.py
+++ b/robosystems/operations/graph/subgraph_service.py
@@ -932,7 +932,6 @@ class SubgraphService:
         parent_graph_id=parent_graph_id,
         subgraph_id=subgraph_id,
         tables=tables_to_copy if tables_to_copy else None,
-        ignore_errors=True,
       )
 
       tables_copied = result.get("tables_copied", [])

--- a/robosystems/operations/graph/tasks/graph_materialization.py
+++ b/robosystems/operations/graph/tasks/graph_materialization.py
@@ -31,7 +31,6 @@ class GraphMaterializationTask(BaseTask):
 
     force = self.params.get("force", False)
     rebuild = self.params.get("rebuild", False)
-    ignore_errors = self.params.get("ignore_errors", True)
     materialize_embeddings = self.params.get("materialize_embeddings", False)
     lock_key = self.params.get("lock_key")
 
@@ -44,7 +43,6 @@ class GraphMaterializationTask(BaseTask):
         graph_id=self.graph_id,
         force=force,
         rebuild=rebuild,
-        ignore_errors=ignore_errors,
         materialize_embeddings=materialize_embeddings,
         operation_id=self.task_id,
       )

--- a/tests/graph_api/routers/databases/tables/test_tables_materialize.py
+++ b/tests/graph_api/routers/databases/tables/test_tables_materialize.py
@@ -31,7 +31,7 @@ def test_materialize_rejects_read_only(monkeypatch, app_client):
 
   response = client.post(
     "/databases/graph-123/tables/Entity/materialize",
-    json={"ignore_errors": True},
+    json={},
   )
 
   assert response.status_code == 403
@@ -69,7 +69,7 @@ def test_materialize_endpoint_publishes_busy_counter(monkeypatch, app_client):
     client = TestClient(app_client)
     response = client.post(
       "/databases/graph-123/tables/Entity/materialize",
-      json={"ignore_errors": True},
+      json={},
     )
 
   assert response.status_code == 200, response.text
@@ -121,7 +121,7 @@ def test_fork_endpoint_publishes_busy_counter(monkeypatch, app_client):
     client = TestClient(app_client)
     response = client.post(
       "/databases/sub-1/tables/sub-1/fork-from/parent-1",
-      json={"ignore_errors": True},
+      json={},
     )
 
   assert response.status_code == 200, response.text
@@ -157,7 +157,7 @@ def test_materialize_endpoint_decrements_counter_on_failure(monkeypatch, app_cli
     with pytest.raises(RuntimeError, match="simulated COPY failure"):
       client.post(
         "/databases/graph-123/tables/Entity/materialize",
-        json={"ignore_errors": True},
+        json={},
       )
 
   assert counter_mock.await_count == 2

--- a/tests/graph_api/test_subgraph_fork.py
+++ b/tests/graph_api/test_subgraph_fork.py
@@ -77,7 +77,6 @@ async def test_fork_parent_data():
       assert call_args[1]["parent_graph_id"] == "kg1234567890abcdef"
       assert call_args[1]["subgraph_id"] == "kg1234567890abcdef_dev"
       assert call_args[1]["tables"] == ["Element", "Transaction"]
-      assert call_args[1]["ignore_errors"] is True
     finally:
       # Restore original env
       env.GRAPH_API_URL = original_url

--- a/tests/middleware/mcp/tools/test_graph_tools.py
+++ b/tests/middleware/mcp/tools/test_graph_tools.py
@@ -302,9 +302,7 @@ class TestMaterializeExecute:
       new=AsyncMock(),
     ) as mock_cmd:
       mock_cmd.return_value = {"status": "pending", "operation_id": "op_abc"}
-      result = await MaterializeTool(_client()).execute(
-        {"rebuild": True, "ignore_errors": True}
-      )
+      result = await MaterializeTool(_client()).execute({"rebuild": True})
     assert result["status"] == "pending"
     assert result["operation_id"] == "op_abc"
     mock_cmd.assert_awaited_once()

--- a/tests/operations/graph/engine/test_chunked_materialization.py
+++ b/tests/operations/graph/engine/test_chunked_materialization.py
@@ -35,7 +35,6 @@ class TestMaterializeTableChunked:
     client.materialize_table.assert_called_once_with(
       graph_id="kg123",
       table_name="Entity",
-      ignore_errors=True,
       materialize_embeddings=False,
       file_ids=None,
       timeout=CHUNK_TIMEOUT,
@@ -97,37 +96,8 @@ class TestMaterializeTableChunked:
     assert "batch_num" not in client.materialize_table.call_args.kwargs
 
   @pytest.mark.asyncio
-  async def test_chunk_failure_with_ignore_errors_continues(self):
-    """With ignore_errors=True, batch failures are logged and skipped."""
-    client = AsyncMock()
-    client.query_table.return_value = {"rows": [[2_000_000]]}
-    client.materialize_table.side_effect = [
-      {"rows_ingested": 900_000},
-      Exception("OOM on batch 2"),
-      {"rows_ingested": 100_000},  # never reached for 2 batches
-    ]
-
-    with patch(
-      "robosystems.operations.graph.engine.chunked_materialization.GraphTierConfig"
-    ) as mock_config:
-      mock_config.get_graph_limits.return_value = {"chunk_size_rows": 1_000_000}
-
-      result = await materialize_table_chunked(
-        client=client,
-        graph_id="kg123",
-        table_name="Entity",
-        tier="ladybug-standard",
-        ignore_errors=True,
-      )
-
-    # Only first batch's rows counted; second failed
-    assert result["rows_ingested"] == 900_000
-    assert result["chunked"] is True
-    assert result["batches"] == 2
-
-  @pytest.mark.asyncio
-  async def test_chunk_failure_with_ignore_errors_false_raises(self):
-    """With ignore_errors=False, batch failures propagate immediately."""
+  async def test_chunk_failure_raises(self):
+    """Batch failures propagate immediately (fail-fast — no silent skip)."""
     client = AsyncMock()
     client.query_table.return_value = {"rows": [[2_000_000]]}
     client.materialize_table.side_effect = [
@@ -148,7 +118,6 @@ class TestMaterializeTableChunked:
         graph_id="kg123",
         table_name="Entity",
         tier="ladybug-standard",
-        ignore_errors=False,
       )
 
   @pytest.mark.asyncio

--- a/tests/operations/graph/engine/test_direct_materialization.py
+++ b/tests/operations/graph/engine/test_direct_materialization.py
@@ -73,7 +73,6 @@ class TestMaterializeGraphDirectly:
         graph_id=graph_id,
         force=False,
         rebuild=False,
-        ignore_errors=True,
         operation_id="op123",
       )
 
@@ -325,69 +324,8 @@ class TestMaterializeGraphDirectly:
       assert calls[1].kwargs["table_name"] == "EntityRelationship"
 
   @pytest.mark.asyncio
-  async def test_error_handling_continues_on_ignore_errors(self, mock_db_session):
-    """Test that errors are ignored when ignore_errors=True."""
-    graph_id = "kg1234567890abcdef"
-
-    with (
-      patch("robosystems.graph_api.client.factory.GraphClientFactory") as mock_factory,
-      patch(
-        "robosystems.middleware.sse.operation_manager.get_operation_manager"
-      ) as mock_get_manager,
-      patch("robosystems.models.core.Graph") as mock_graph_class,
-      patch("robosystems.models.core.GraphFile") as mock_file_class,
-      patch("robosystems.models.core.GraphTable"),
-      patch("robosystems.dagster.reporting.report_asset_materialization"),
-    ):
-      mock_graph = Mock()
-      mock_graph.graph_stale = True
-      mock_graph.graph_stale_reason = "new_data"
-      mock_graph.graph_metadata = {}
-      mock_graph_class.get_by_id.return_value = mock_graph
-
-      mock_file_class.recover_stale_files.return_value = []
-
-      # Two tables
-      table1 = Mock()
-      table1.table_name = "Entity1"
-      table1.table_type = "node"
-
-      table2 = Mock()
-      table2.table_name = "Entity2"
-      table2.table_type = "node"
-
-      mock_db_session.query.return_value.join.return_value.filter.return_value.filter.return_value.distinct.return_value.all.return_value = [
-        table1,
-        table2,
-      ]
-      mock_db_session.query.return_value.join.return_value.filter.return_value.filter.return_value.distinct.return_value.count.return_value = 0
-
-      # First table fails, second succeeds
-      mock_client = AsyncMock()
-      mock_client.materialize_table.side_effect = [
-        Exception("Failed"),
-        {"rows_ingested": 50},
-      ]
-      mock_factory.create_client = AsyncMock(return_value=mock_client)
-
-      mock_manager = Mock()
-      mock_manager.emit_progress = AsyncMock()
-      mock_manager.complete_operation = AsyncMock()
-      mock_get_manager.return_value = mock_manager
-
-      result = await materialize_graph_directly(
-        db=mock_db_session,
-        graph_id=graph_id,
-        ignore_errors=True,
-      )
-
-      assert result["status"] == "success"
-      assert result["total_rows"] == 50
-      assert "Entity2" in result["tables_materialized"]
-
-  @pytest.mark.asyncio
-  async def test_error_raised_when_ignore_errors_false(self, mock_db_session):
-    """Test that errors are raised when ignore_errors=False."""
+  async def test_error_raised_on_table_failure(self, mock_db_session):
+    """A table materialization failure fails the operation (fail-fast)."""
     graph_id = "kg1234567890abcdef"
 
     with (
@@ -428,7 +366,6 @@ class TestMaterializeGraphDirectly:
       result = await materialize_graph_directly(
         db=mock_db_session,
         graph_id=graph_id,
-        ignore_errors=False,
         operation_id="op123",
       )
 


### PR DESCRIPTION
## Summary

Two materialize-path fixes required to rebuild the SEC graph on LadybugDB 0.18. Together they restore complete, correct materialization at scale. The primary fix (ignore_errors) is new; the Arrow-buffer fix already shipped as the 1.6.1 hotfix and is included here for the merge to `main`.

## The bugs

### 1. `ignore_errors=true` silently drops valid rows (primary)

LadybugDB 0.18's `COPY ... (ignore_errors=true)` discards **valid** rows in proportion to the Arrow batch size:

| batch size | rows dropped |
| ---------- | ------------ |
| 5M | 2.8% |
| 10M | 17% |
| 20M | 37% |

On the full SEC rebuild (~20M-row, wide-string hash-batches) this collapsed **every relationship table to ~11.5% of its rows** — nodes loaded 100%, edges lost ~88% (e.g. `FACT_HAS_ELEMENT` 8.8M of 76.4M; `STRUCTURE_HAS_FACT_SET` 529K of 4.47M). The hash-batch `WHERE` was correct (100% coverage, verified) and all endpoint nodes were present, so the loss was entirely inside the COPY.

`ignore_errors` is also unnecessary: DuckDB staging already dedupes nodes (on `identifier`) and relationships (on `from`/`to`), and the schema materializes **all nodes before any relationship**, so every FK resolves. Removing it restores 100% (verified locally at 20M- and 40M-row batches).

### 2. Arrow 2 GiB string-buffer cap (already shipped as 1.6.1 hotfix)

The `Fact` node's `uri` column overflows Arrow's 2 GiB per-column regular-string buffer on ~19M-row batches. `SET arrow_large_buffer_size=true` makes DuckDB emit 64-bit LargeString offsets; ladybug's `COPY FROM <arrow>` reads LargeString (verified against a real Fact part-file). Batch stays 25M (one COPY per 20M hash-batch).

## Changes

- **`graph_api/.../materialize.py`** — plain `COPY` at both sites (no `ignore_errors`); `arrow_large_buffer_size=true` on both DuckDB connections; fork path **fails fast** on a copy error instead of swallowing it.
- **Full `ignore_errors` removal** across the materialize chain: the two graph-api request models, three client methods, the chunked/direct/Dagster/extensions/entity_sync/subgraph/SEC callers, the materialize command, the `MaterializeOp` API model (regenerates the SDKs), and the MCP `MaterializeTool` schema.
- **All materialize error handlers now fail fast** — a failed table/batch means missing data and is surfaced loudly (the tenant extensions loop keeps its deliberate per-table continue).
- Updated the staging-dedup rationale comment (`duckdb/manager.py`) + README; updated affected tests (dropped the obsolete "continues on ignore_errors" cases).

**Out of scope:** the separate file-based ingest path (`operations/graph/engine/ingest.py`, `COPY FROM 'file.parquet'`) and the unused `ingest` client/models — a different mechanism, left untouched.

## Testing

- Root cause and fix proven locally against `ladybug==0.18.1`: `ignore_errors=true` drops 37% at 20M rows; a plain COPY loads **100% at both 20M and 40M** rows.
- `basedpyright` clean across the repo (pre-commit hook); `ruff check`/`format` clean.
- Updated 5 test files. The unit suite runs in CI — the local Docker stack was down this session, so `just test` was not run locally.

## Rollout

Requires the new image on the shared master, then a **re-materialize only** (the staged `sec.duckdb` persists — no reprocess/restage). Verify edges ≈ nodes (`FACT_HAS_ELEMENT` ≈ 76.4M, `STRUCTURE_HAS_FACT_SET` ≈ 4.47M, 1:1 with nodes), then rebuild `sec_historical` → cutover/publish. The current prod `sec` graph is broken (~11.5% edges) and **unpublished**; the old graph still serves on the replicas.
