### PR TITLE
chore(infra): auto minor version upgrades + major-version floors for managed engines

### DIFF
--- a/.github/workflows/deploy-postgres.yml
+++ b/.github/workflows/deploy-postgres.yml
@@ -36,10 +36,10 @@ on:
 
       # Database Version Configuration
       postgres_version:
-        description: "PostgreSQL engine version (e.g., 16.11)"
+        description: "PostgreSQL major version floor (e.g., 16). Minors auto-upgrade; bump only for a deliberate major upgrade."
         required: false
         type: string
-        default: "16.11"
+        default: "16"
 
       # Instance Configuration
       instance_size:

--- a/cloudformation/opensearch.yaml
+++ b/cloudformation/opensearch.yaml
@@ -94,12 +94,16 @@ Parameters:
   # Engine Configuration
   EngineVersion:
     Type: String
-    Description: OpenSearch engine version
+    Description: >-
+      OpenSearch engine version. Service-software patches auto-apply
+      (AutoSoftwareUpdateEnabled); bump only for a deliberate major upgrade
+      (e.g. 2.19 -> 3.x, staging-first).
     Default: "OpenSearch_2.19"
     AllowedValues:
       - "OpenSearch_2.19"
-      - "OpenSearch_2.17"
-      - "OpenSearch_2.15"
+      - "OpenSearch_3.1"
+      - "OpenSearch_3.3"
+      - "OpenSearch_3.5"
 
   # Bastion Access (optional)
   BastionSecurityGroupId:

--- a/cloudformation/postgres.yaml
+++ b/cloudformation/postgres.yaml
@@ -25,11 +25,15 @@ Parameters:
   # FORK NOTE: Pin version via DATABASE_POSTGRES_VERSION_<ENV> GitHub variable
   PostgresEngineVersion:
     Type: String
-    Description: PostgreSQL engine version
-    Default: "16.11"
+    Description: >-
+      PostgreSQL major version floor. RDS provisions the preferred minor for
+      this major and AutoMinorVersionUpgrade keeps it current. Bump to the next
+      major (e.g. "17") only for a deliberate, staging-first major upgrade.
+    Default: "16"
     AllowedValues:
-      - "16.11"
-    ConstraintDescription: Must be a supported PostgreSQL version
+      - "16"
+      - "17"
+    ConstraintDescription: Must be a supported PostgreSQL major version
 
   # Instance & Database Configuration
   DBInstanceClass:

--- a/cloudformation/postgres.yaml
+++ b/cloudformation/postgres.yaml
@@ -525,7 +525,12 @@ Resources:
       BackupRetentionPeriod: 30
       PreferredBackupWindow: 03:00-04:00
       PreferredMaintenanceWindow: sun:04:30-sun:05:30
-      AutoMinorVersionUpgrade: false
+      # Auto-apply RDS-vetted minor version upgrades during the maintenance
+      # window. The PostgresEngineVersion pin acts as a provisioning floor;
+      # AWS keeps the running minor current (security/bug fixes) without a
+      # per-minor template/GHA-var bump. Major upgrades stay deliberate
+      # (AllowMajorVersionUpgrade below + an explicit version change).
+      AutoMinorVersionUpgrade: true
       AllowMajorVersionUpgrade: true
       StorageEncrypted: true
       CopyTagsToSnapshot: true

--- a/cloudformation/valkey.yaml
+++ b/cloudformation/valkey.yaml
@@ -51,10 +51,16 @@ Parameters:
   # FORK NOTE: Pin version via VALKEY_VERSION_<ENV> GitHub variable
   ValkeyEngineVersion:
     Type: String
-    Description: Valkey engine version
+    Description: >-
+      Valkey engine version floor (major.minor; ElastiCache does not accept a
+      bare major). AutoMinorVersionUpgrade advances the minor automatically;
+      bump only for a deliberate major upgrade (e.g. "8.1" -> "9.0").
     Default: "8.1"
     AllowedValues:
       - "8.1"
+      - "8.2"
+      - "9.0"
+      - "9.1"
     ConstraintDescription: Must be a supported Valkey version
 
   # Security Configuration
@@ -116,6 +122,12 @@ Mappings:
   ValkeyVersionToFamily:
     "8.1":
       Family: "valkey8"
+    "8.2":
+      Family: "valkey8"
+    "9.0":
+      Family: "valkey9"
+    "9.1":
+      Family: "valkey9"
 
 Conditions:
   IsProduction: !Equals [!Ref Environment, prod]

--- a/cloudformation/valkey.yaml
+++ b/cloudformation/valkey.yaml
@@ -491,7 +491,10 @@ Resources:
       CacheNodeType: !Ref NodeType
       Engine: valkey
       EngineVersion: !Ref ValkeyEngineVersion
-      AutoMinorVersionUpgrade: false
+      # Opt into ElastiCache's minor version upgrade campaign (Valkey 7.2+),
+      # applied during the maintenance window. Keeps the running minor current
+      # without a per-minor template bump; major upgrades stay deliberate.
+      AutoMinorVersionUpgrade: true
       Port: 6379
       # Cluster Configuration
       NumCacheClusters: !Ref NumCacheNodes


### PR DESCRIPTION
## Summary

Establishes a hands-off patching story for the three AWS-managed data engines and restructures their version pins so routine minor patching never needs a code change. RDS PostgreSQL and ElastiCache Valkey now auto-apply engine-vetted minor/patch upgrades in the maintenance window (matching OpenSearch, which already had `AutoSoftwareUpdateEnabled`). Engine-version pins become **provisioning floors**, with `AllowedValues` acting as a fork-flexibility menu.

## Changes

- **`cloudformation/postgres.yaml`**
  - `AutoMinorVersionUpgrade: false → true` — RDS applies its vetted minor target in the maintenance window.
  - `PostgresEngineVersion` → **bare major** (`"16"`), `AllowedValues: ["16","17"]`. RDS resolves the preferred minor and keeps it current; a major upgrade is a `DATABASE_POSTGRES_VERSION_<ENV>` var bump. `18` intentionally not offered yet. Avoids CFN drift (bare major is stable as minors advance).
- **`cloudformation/valkey.yaml`**
  - `AutoMinorVersionUpgrade: false → true` — opts into ElastiCache's minor-version campaign (Valkey 7.2+).
  - ElastiCache rejects a bare major, so keep `major.minor` but widen `AllowedValues` to `8.1/8.2/9.0/9.1` and extend the `ValkeyVersionToFamily` map so a future major bump is a var-only change.
- **`cloudformation/opensearch.yaml`**
  - Floor at current `2.19`; pre-list the `3.x` in-place upgrade targets (`3.1/3.3/3.5`) for fork flexibility; drop the superseded `2.15/2.17`. Service software already auto-updates.
- **`.github/workflows/deploy-postgres.yml`**
  - `postgres_version` input default `"16.11" → "16"` to match the new floor.

## Testing

- `just cf-lint` on all three templates — **passed** (0 errors/warnings).
- Pre-commit hooks (ruff/format) passed on both commits.
- `just test-all` — not run; this is infra-only (CloudFormation + workflow YAML), no application code paths touched.

## Notes / Follow-ups

- **Out-of-band, coordinated with this PR:** `DATABASE_POSTGRES_VERSION_{PROD,STAGING}` GitHub variables set to `16` (required so the new `AllowedValues` validates on the next deploy); the RDS OS `system-update` was opted-in on both instances for the `2026-07-19 04:30Z` maintenance window.
- **First deploy consequence:** the next postgres stack deploy performs a one-time catch-up to the latest `16.x` minor (in-place, brief Single-AZ restart) — schedule it for a low-traffic window.
- **Non-disruptive to apply:** both `AutoMinorVersionUpgrade` flips are CFN "No interruption"; the ongoing minor upgrades land in the existing maintenance windows.
- **Deliberate majors** (Postgres 16→17, Valkey 8→9, OpenSearch 2.19→3.x) remain manual and staging-first; the OpenSearch 3.x path (in-place `UpgradeDomain`, KNN-settings pre-check, single-node/HA considerations) is documented separately.
