### PR TITLE
fix(infra): size shared replicas at r7g.large with an 8GB sec buffer pool

### DIFF
--- a/.github/configs/graph.yml
+++ b/.github/configs/graph.yml
@@ -299,13 +299,20 @@ production:
       depends_on: ladybug-shared # Only deploy after shared master exists
 
       # Instance type (scaling/enabled via GHA variables: SHARED_REPLICAS_*_PROD)
-      # Memory overrides for replica hardware (m7g.large = 8GB RAM)
+      # Memory overrides for replica hardware (r7g.large = 16GB RAM)
       # These override the writer's 10GB settings which exceed container capacity
       instance:
-        type: m7g.large # General purpose ARM64 - cost-effective for read-only (8GB RAM)
-        max_memory_mb: 5120 # 5GB available (8GB - 2GB OS - 1GB app overhead)
-        memory_per_db_mb: 3584 # 3.5GB for parent databases (sec)
-        memory_per_subgraph_mb: 2048 # 2GB for subgraphs (sec_historical) - oversubscribed
+        # r7g.large (16GB) memory-optimized. The prior m7g.large (8GB) tripped the
+        # admission-control guard (85% of *instance* RAM, psutil-based — see
+        # graph_api/core/admission_control.py) during full-report reads on
+        # LadybugDB 0.18: buffer pool + query working set + OS crossed ~6.8GB and
+        # latched into 503s that /health never reflected, so the ALB kept routing.
+        # 16GB leaves ~3GB of working-set headroom above an 8GB buffer pool.
+        # Replicas serve sec ONLY (SHARED_REPOSITORIES=sec); sec_historical stays
+        # on the shared master.
+        type: r7g.large # 16GB RAM, 2 vCPUs, memory-optimized ARM64 - read-only replica
+        max_memory_mb: 10240 # 10GB LadybugDB cap (pool + query exec); keeps the instance under the 85% guard (~13.6GB of 16GB)
+        memory_per_db_mb: 8192 # 8GB buffer pool for sec (was 3.5GB) - 2.3x cache for the ~110GB graph
         duckdb_memory_limit: "0" # No DuckDB queries on replicas
         duckdb_max_threads: 0 # No DuckDB queries on replicas
 

--- a/cloudformation/graph-ladybug-replicas.yaml
+++ b/cloudformation/graph-ladybug-replicas.yaml
@@ -33,14 +33,14 @@ Parameters:
     Description: Amazon Linux 2023 ARM64 AMI ID
   InstanceType:
     Type: String
-    Default: m7g.large
-    Description: EC2 instance type for replicas (smaller than writers)
+    Default: r7g.large
+    Description: EC2 instance type for replicas (16GB+ memory-optimized; must hold the sec buffer pool + working set under the 85% admission guard)
     AllowedValues:
-      - m7g.large
-      - m7g.xlarge
-      - r7g.medium
-      - r7g.large
-      - r7g.xlarge
+      - m7g.large # 8GB — staging/legacy only; under-provisioned for prod sec reads
+      - m7g.xlarge # 16GB
+      - r7g.large # 16GB — prod default
+      - r7g.xlarge # 32GB
+      - r7g.2xlarge # 64GB
 
   # S3 Database Configuration (Updated by Dagster job)
   SharedDatabaseS3Prefix:
@@ -512,14 +512,17 @@ Resources:
           LaunchTemplateSpecification:
             LaunchTemplateId: !Ref ReplicaLaunchTemplate
             Version: !GetAtt ReplicaLaunchTemplate.LatestVersionNumber
-          # Spot pool diversification: 8 GB ARM64 alternatives to primary InstanceType
+          # Spot pool diversification: 16 GB ARM64 memory-optimized alternatives to
+          # the primary (r7g.large). Every alternative MUST match the primary's
+          # 16 GB — 8 GB types (and burstable t4g) trip the admission-control memory
+          # guard on the ~110 GB sec graph under full-report reads, latching into
+          # 503s. Spread across Graviton2/3/4 + m/r families for capacity depth.
           Overrides:
             - InstanceType: !Ref InstanceType
-            - InstanceType: m6g.large
-            - InstanceType: t4g.large
-            - InstanceType: r6g.medium
-            - InstanceType: r7g.medium
-            - InstanceType: r8g.medium
+            - InstanceType: r6g.large
+            - InstanceType: r8g.large
+            - InstanceType: m7g.xlarge
+            - InstanceType: m6g.xlarge
         InstancesDistribution:
           OnDemandBaseCapacity:
             !If [IsSpotEnabled, !Ref SpotOnDemandBaseCapacity, 0]


### PR DESCRIPTION
Formalizes to `main` the shared-replica sizing fix already deployed to prod via `release/1.6.3` (cherry-pick of `f55ddacf`). **No prod behavior change** — prod already runs this; this stops a future `main` deploy from reverting replicas to m7g.large.

## Problem

The m7g.large (8GB) shared read-replicas loaded the reprocessed **sec** graph (~110GB) and served light queries, but **wedged on the first full-report read**. The admission controller (`graph_api/core/admission_control.py`) rejects queries once memory exceeds **85% of total *instance* RAM** (`psutil.virtual_memory().percent` — instance-wide, not the container cgroup). On 8GB, buffer pool (3.5GB) + query working set + OS crossed ~6.8GB and **latched** into 503s (the buffer pool caches pages and stays warm). `/health` returns 200 regardless of memory, so the ALB never pulled the target — it kept routing to a node 503-ing every query. LadybugDB 0.18 sits materially heavier at rest than 0.13, roughly doubling the replica memory footprint.

## Fix

**`.github/configs/graph.yml`** (`production.replicas[0]`, the `shared-replicas` tier):
- `type: m7g.large → r7g.large` (16GB, memory-optimized)
- `memory_per_db_mb: 3584 → 8192` (8GB sec buffer pool, 2.3× cache for the ~110GB graph)
- `max_memory_mb: 5120 → 10240`
- dropped `memory_per_subgraph_mb` — replicas serve **sec only** (`SHARED_REPOSITORIES_PROD=sec`); sec_historical stays on the master

**`cloudformation/graph-ladybug-replicas.yaml`**:
- `InstanceType` default `m7g.large → r7g.large` (+ AllowedValues annotated)
- Spot pool `Overrides` were **all 8GB / burstable** (m6g.large, t4g.large, r6g/r7g/r8g.medium) → replaced with **16GB memory-optimized ARM64** (r6g.large, r8g.large, m7g.xlarge, m6g.xlarge) so Spot can't place an under-provisioned node that re-wedges

## Wiring

Instance type flows via the CFN `InstanceType` param (deploy reads `.production.replicas[0].instance.type`) → replica **stack deploy**. The buffer pool is **not** a CFN param — the graph-api reads its tier's `memory_per_db_mb` from the graph.yml **baked into the container image** at runtime, so it takes effect on the next **image build**.

## Validation (prod, r7g.large)

- `Database 'sec' created - ... buffer pool: 8192 MB` — new config live
- **Zero** admission-control rejections since boot under real full-report load; all sec queries 200 OK
- Report render (holon viewer) confirmed with proper XBRL labels

Companion GHA vars set for the steady-state HA profile: 2× On-Demand r7g.large baseline (`DESIRED`/`MIN`/`OD_BASE`=2, Spot for burst above 2).