### PR TITLE
feat(sec): incremental LadybugDB materialization mode

### DIFF
--- a/robosystems/adapters/sec/pipeline/__init__.py
+++ b/robosystems/adapters/sec/pipeline/__init__.py
@@ -114,6 +114,7 @@ from robosystems.adapters.sec.pipeline.sensors import (
   sec_incremental_pipeline_sensor,
   sec_index_retry_sensor,
   sec_master_sleep_on_failure_sensor,
+  sec_materialize_reconcile_schedule,
   sec_post_materialize_publish_sensor,
   sec_post_stage_index_sensor,
   sec_processing_sensor,
@@ -194,6 +195,7 @@ def get_dagster_components():
     ],
     "schedules": [
       sec_incremental_download_schedule,
+      sec_materialize_reconcile_schedule,
     ],
   }
 
@@ -246,6 +248,7 @@ __all__ = [
   "sec_master_sleep_on_failure_sensor",
   "sec_master_wake_job",
   "sec_materialize_job",
+  "sec_materialize_reconcile_schedule",
   "sec_narratives_index_job",
   "sec_narratives_indexed",
   "sec_post_materialize_publish_sensor",

--- a/robosystems/adapters/sec/pipeline/__init__.py
+++ b/robosystems/adapters/sec/pipeline/__init__.py
@@ -114,7 +114,6 @@ from robosystems.adapters.sec.pipeline.sensors import (
   sec_incremental_pipeline_sensor,
   sec_index_retry_sensor,
   sec_master_sleep_on_failure_sensor,
-  sec_materialize_reconcile_schedule,
   sec_post_materialize_publish_sensor,
   sec_post_stage_index_sensor,
   sec_processing_sensor,
@@ -195,7 +194,6 @@ def get_dagster_components():
     ],
     "schedules": [
       sec_incremental_download_schedule,
-      sec_materialize_reconcile_schedule,
     ],
   }
 
@@ -248,7 +246,6 @@ __all__ = [
   "sec_master_sleep_on_failure_sensor",
   "sec_master_wake_job",
   "sec_materialize_job",
-  "sec_materialize_reconcile_schedule",
   "sec_narratives_index_job",
   "sec_narratives_indexed",
   "sec_post_materialize_publish_sensor",

--- a/robosystems/adapters/sec/pipeline/configs.py
+++ b/robosystems/adapters/sec/pipeline/configs.py
@@ -5,6 +5,7 @@ for maintainability and reuse.
 """
 
 from datetime import UTC, datetime
+from typing import Literal
 
 from dagster import Config, StaticPartitionsDefinition
 from pydantic import Field
@@ -209,10 +210,17 @@ class SECMaterializeConfig(Config):
 
   Options:
     graph_id: Target graph ID (default: "sec")
+    materialize_mode: "full" (default) rebuilds the LadybugDB database then COPYs
+                   every table (assumes an empty target — the reconciliation
+                   path). "incremental" skips the rebuild and COPYs only rows not
+                   already in the populated graph (per-table keyset anti-join),
+                   safe to run repeatedly against the live graph. Takes precedence
+                   over rebuild_graph — incremental never rebuilds.
     rebuild_graph: If True (default), delete and recreate the LadybugDB database
                    with the roboledger SEC schema before materializing.
                    DuckDB staging is preserved. Set to False only for retry scenarios
                    where you want to resume without losing existing graph data.
+                   Ignored when materialize_mode == "incremental".
     batch_materialization: If True (default), use hash-based batching for tables
                            with more rows than materialization_batch_size.
     materialization_batch_size: Rows per batch when batch_materialization is enabled
@@ -220,7 +228,8 @@ class SECMaterializeConfig(Config):
   """
 
   graph_id: str = "sec"  # Target graph ID
-  rebuild_graph: bool = True  # Rebuild LadybugDB before materialization
+  materialize_mode: Literal["full", "incremental"] = "full"
+  rebuild_graph: bool = True  # Rebuild LadybugDB before materialization (full mode)
   batch_materialization: bool = True  # Hash-based batching for large tables
   materialization_batch_size: int = Field(
     default=20_000_000, ge=1_000_000

--- a/robosystems/adapters/sec/pipeline/materialize.py
+++ b/robosystems/adapters/sec/pipeline/materialize.py
@@ -51,8 +51,15 @@ def sec_graph_materialized(
 
   from robosystems.adapters.sec import XBRLDuckDBGraphProcessor
 
-  context.log.info(f"Materializing graph from DuckDB staging: {config.graph_id}")
-  if config.rebuild_graph:
+  context.log.info(
+    f"Materializing graph from DuckDB staging: {config.graph_id} "
+    f"(mode={config.materialize_mode})"
+  )
+  if config.materialize_mode == "incremental":
+    context.log.info(
+      "Incremental mode - COPYing only new rows into the existing graph (no rebuild)"
+    )
+  elif config.rebuild_graph:
     context.log.info("Rebuild requested - will delete and recreate LadybugDB database")
 
   # Boost LadybugDB memory before materialization (only applies to ladybug-shared tier)
@@ -90,6 +97,7 @@ def sec_graph_materialized(
         batch_materialization=config.batch_materialization,
         batch_size=config.materialization_batch_size,
         progress_callback=dagster_progress,
+        materialize_mode=config.materialize_mode,
       )
       return result
     finally:
@@ -147,7 +155,8 @@ def sec_graph_materialized(
   return MaterializeResult(
     metadata={
       "graph_id": config.graph_id,
-      "rebuild_graph": config.rebuild_graph,
+      "materialize_mode": config.materialize_mode,
+      "rebuild_graph": config.rebuild_graph and config.materialize_mode == "full",
       "status": result.status,
       "total_rows_ingested": result.total_rows_ingested,
       "duration_ms": result.duration_ms,
@@ -243,6 +252,7 @@ def sec_historical_materialized(
         batch_materialization=config.batch_materialization,
         batch_size=config.materialization_batch_size,
         progress_callback=dagster_progress,
+        materialize_mode=config.materialize_mode,
       )
       return result
     finally:
@@ -298,7 +308,8 @@ def sec_historical_materialized(
   return MaterializeResult(
     metadata={
       "graph_id": graph_id,
-      "rebuild_graph": config.rebuild_graph,
+      "materialize_mode": config.materialize_mode,
+      "rebuild_graph": config.rebuild_graph and config.materialize_mode == "full",
       "status": result.status,
       "total_rows_ingested": result.total_rows_ingested,
       "duration_ms": result.duration_ms,

--- a/robosystems/adapters/sec/pipeline/sensors.py
+++ b/robosystems/adapters/sec/pipeline/sensors.py
@@ -7,9 +7,10 @@ Nightly Pipeline (enable all for automated daily updates):
 - Phase 1 (Download): sec_incremental_download_schedule triggers at 9pm EST weekdays
 - Phase 2+3 (Process+Stage): sec_incremental_pipeline_sensor chains
   download → process (batched loop) → stage (DuckDB INSERT)
-- Phase 4 (Materialize): sec_stage_to_materialize_sensor chains stage → full graph rebuild
+- Phase 4 (Materialize): sec_stage_to_materialize_sensor chains stage → materialize
+  (incremental Mon-Thu; full rebuild on the Friday ET run as a weekly reconciliation)
 - Phase 5 (Publish+Refresh): sec_post_materialize_publish_sensor chains
-  materialize → lbug S3 publish → duckdb S3 publish → replica refresh
+  materialize → lbug S3 publish → duckdb S3 publish → replica refresh → master sleep
 - Phase 5c (Text Index): sec_post_stage_index_sensor chains
   stage → textblocks index + narratives index (parallel, incremental)
 
@@ -17,11 +18,15 @@ Backfill Processing (enable for bulk/manual processing):
 - sec_processing_sensor: Discovers pending SourceFiles, triggers batch processing per quarter
 
 Nightly flow: New data is added to existing DuckDB tables (INSERT with dedup),
-then the LadybugDB graph is fully rebuilt from DuckDB. The sec graph (2024+ only)
-is small enough for nightly rebuilds (~75GB vs ~300GB monolith).
+then only the new rows are COPYed into the existing LadybugDB graph (keyset
+anti-join). The Friday ET run instead does a full rebuild from DuckDB to
+reconcile drift. The whole chain wakes the master at the start and sleeps it
+after publish, so reconciliation reuses that lifecycle rather than a separate
+schedule.
 """
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
+from zoneinfo import ZoneInfo
 
 from dagster import (
   DagsterRunStatus,
@@ -535,16 +540,21 @@ def sec_wake_to_stage_sensor(context: RunStatusSensorContext):
   description="Trigger incremental graph materialization after DuckDB staging completes",
 )
 def sec_stage_to_materialize_sensor(context: RunStatusSensorContext):
-  """Trigger incremental LadybugDB materialization after DuckDB staging completes.
+  """Trigger LadybugDB materialization after DuckDB staging completes.
 
   Part of the nightly pipeline chain:
-    process → stage (DuckDB INSERT) → materialize (incremental) → S3 publish
+    process → stage (DuckDB INSERT) → materialize → S3 publish
 
-  After new data is added to DuckDB, only the new rows are COPYed into the
-  existing LadybugDB graph (per-table keyset anti-join) — no full rebuild. A
-  periodic full-rebuild reconciliation (sec_materialize_reconcile_schedule)
-  erases any incremental drift. S3 publishes are handled by
-  sec_post_materialize_publish_sensor.
+  Mon-Thu nights materialize **incrementally** - only new rows are COPYed into
+  the existing graph (per-table keyset anti-join), no rebuild. The **Friday** ET
+  run does a **full rebuild** instead: a weekly reconciliation from the same
+  DuckDB staging (source of truth) that erases any incremental drift (partial
+  batch failures, un-refreshed mutable Entity attributes, hash-batch edge cases).
+  Reconciliation rides this same chain — wake → stage → materialize → publish →
+  sleep — rather than a separate schedule, so the master lifecycle and S3 publish
+  are reused for both modes. S3 publishes are handled by
+  sec_post_materialize_publish_sensor (which keys off the mode:incremental tag,
+  set for both).
   """
   if env.ENVIRONMENT == "dev":
     context.log.info("Skipping chain sensor in dev environment")
@@ -572,9 +582,36 @@ def sec_stage_to_materialize_sensor(context: RunStatusSensorContext):
     )
     return
 
+  # Friday ET run = weekly full-rebuild reconciliation; other nights incremental.
+  et_now = datetime.now(ZoneInfo("America/New_York"))
+  materialize_mode = "full" if et_now.weekday() == 4 else "incremental"
+  if materialize_mode == "full":
+    # Guard against a second full in the same window — e.g. a Thursday chain that
+    # spilled past ET midnight also reads as Friday. One full rebuild per week is
+    # enough; fall back to incremental if one already ran in the last 3 days.
+    try:
+      recent_full = context.instance.get_run_records(
+        filters=RunsFilter(
+          job_name="sec_materialize",
+          statuses=[DagsterRunStatus.SUCCESS],
+          tags={"materialize_mode": "full"},
+        ),
+        limit=1,
+        ascending=False,
+      )
+      if recent_full and (
+        datetime.now(UTC) - recent_full[0].create_timestamp < timedelta(days=3)
+      ):
+        materialize_mode = "incremental"
+        context.log.info("Full rebuild already ran this week — using incremental")
+    except Exception as guard_err:
+      context.log.warning(
+        f"Could not check recent full rebuilds ({guard_err}); proceeding with full"
+      )
+
   context.log.info(
     f"DuckDB staging completed (run_id={dagster_run.run_id}), "
-    "triggering incremental LadybugDB materialization from DuckDB"
+    f"triggering {materialize_mode} LadybugDB materialization from DuckDB"
   )
 
   yield RunRequest(
@@ -584,7 +621,7 @@ def sec_stage_to_materialize_sensor(context: RunStatusSensorContext):
         "sec_graph_materialized": {
           "config": {
             "graph_id": "sec",
-            "materialize_mode": "incremental",
+            "materialize_mode": materialize_mode,
           }
         },
       }
@@ -592,68 +629,10 @@ def sec_stage_to_materialize_sensor(context: RunStatusSensorContext):
     tags={
       "pipeline": "sec",
       "phase": "materialize",
+      # mode:incremental marks the chain lineage (the publish + sleep sensors key
+      # off it) for BOTH incremental and Friday full-rebuild runs.
       "mode": "incremental",
-      "materialize_mode": "incremental",
-    },
-  )
-
-
-@schedule(
-  job=sec_materialize_job,
-  cron_schedule="0 6 * * 0",  # 6am ET Sunday — outside the weekday incremental window
-  default_status=DefaultScheduleStatus.STOPPED,  # Enable in Dagster UI when ready
-  execution_timezone="America/New_York",
-)
-def sec_materialize_reconcile_schedule(context):
-  """Weekly full-rebuild reconciliation of the sec graph.
-
-  The nightly chain materializes incrementally (append-only). A periodic full
-  rebuild from the same DuckDB staging (the source of truth) erases any
-  incremental drift — partial batch failures, un-refreshed mutable Entity
-  attributes, hash-batch edge cases. Runs Sunday morning ET, clear of the
-  weekday incremental window.
-
-  Skips if a materialize is already in flight (e.g. an incremental chain mid-run)
-  to avoid two writers on the same graph. Enable in the Dagster UI when ready.
-  """
-  if env.ENVIRONMENT == "dev":
-    context.log.info("Skipping reconcile schedule in dev environment")
-    return
-
-  active_runs = context.instance.get_runs(
-    filters=RunsFilter(
-      job_name="sec_materialize",
-      statuses=[DagsterRunStatus.STARTED, DagsterRunStatus.QUEUED],
-    ),
-    limit=1,
-  )
-  if active_runs:
-    context.log.info(
-      f"Materialize job already running (run_id={active_runs[0].run_id}), "
-      "skipping weekly reconcile"
-    )
-    return
-
-  ts = context.scheduled_execution_time.strftime("%Y%m%d")
-  context.log.info("Triggering weekly full-rebuild reconciliation of sec graph")
-
-  yield RunRequest(
-    run_key=f"sec-materialize-reconcile-{ts}",
-    run_config={
-      "ops": {
-        "sec_graph_materialized": {
-          "config": {
-            "graph_id": "sec",
-            "materialize_mode": "full",
-            "rebuild_graph": True,
-          }
-        },
-      }
-    },
-    tags={
-      "pipeline": "sec",
-      "phase": "reconcile",
-      "materialize_mode": "full",
+      "materialize_mode": materialize_mode,
     },
   )
 

--- a/robosystems/adapters/sec/pipeline/sensors.py
+++ b/robosystems/adapters/sec/pipeline/sensors.py
@@ -532,17 +532,19 @@ def sec_wake_to_stage_sensor(context: RunStatusSensorContext):
   request_job=sec_materialize_job,
   default_status=DefaultSensorStatus.STOPPED,  # Enable in Dagster UI when ready
   minimum_interval_seconds=60,
-  description="Trigger full graph rebuild after incremental DuckDB staging completes",
+  description="Trigger incremental graph materialization after DuckDB staging completes",
 )
 def sec_stage_to_materialize_sensor(context: RunStatusSensorContext):
-  """Trigger full LadybugDB rebuild after incremental DuckDB staging completes.
+  """Trigger incremental LadybugDB materialization after DuckDB staging completes.
 
   Part of the nightly pipeline chain:
-    process → stage (DuckDB INSERT) → materialize (full rebuild) → S3 publish
+    process → stage (DuckDB INSERT) → materialize (incremental) → S3 publish
 
-  After new data is added to DuckDB, the LadybugDB graph is fully rebuilt.
-  The sec graph (2024+ only, ~75GB) is small enough for nightly rebuilds.
-  S3 publishes are handled by sec_post_materialize_publish_sensor.
+  After new data is added to DuckDB, only the new rows are COPYed into the
+  existing LadybugDB graph (per-table keyset anti-join) — no full rebuild. A
+  periodic full-rebuild reconciliation (sec_materialize_reconcile_schedule)
+  erases any incremental drift. S3 publishes are handled by
+  sec_post_materialize_publish_sensor.
   """
   if env.ENVIRONMENT == "dev":
     context.log.info("Skipping chain sensor in dev environment")
@@ -572,7 +574,7 @@ def sec_stage_to_materialize_sensor(context: RunStatusSensorContext):
 
   context.log.info(
     f"DuckDB staging completed (run_id={dagster_run.run_id}), "
-    "triggering full LadybugDB rebuild from DuckDB"
+    "triggering incremental LadybugDB materialization from DuckDB"
   )
 
   yield RunRequest(
@@ -582,7 +584,7 @@ def sec_stage_to_materialize_sensor(context: RunStatusSensorContext):
         "sec_graph_materialized": {
           "config": {
             "graph_id": "sec",
-            "rebuild_graph": True,
+            "materialize_mode": "incremental",
           }
         },
       }
@@ -591,6 +593,67 @@ def sec_stage_to_materialize_sensor(context: RunStatusSensorContext):
       "pipeline": "sec",
       "phase": "materialize",
       "mode": "incremental",
+      "materialize_mode": "incremental",
+    },
+  )
+
+
+@schedule(
+  job=sec_materialize_job,
+  cron_schedule="0 6 * * 0",  # 6am ET Sunday — outside the weekday incremental window
+  default_status=DefaultScheduleStatus.STOPPED,  # Enable in Dagster UI when ready
+  execution_timezone="America/New_York",
+)
+def sec_materialize_reconcile_schedule(context):
+  """Weekly full-rebuild reconciliation of the sec graph.
+
+  The nightly chain materializes incrementally (append-only). A periodic full
+  rebuild from the same DuckDB staging (the source of truth) erases any
+  incremental drift — partial batch failures, un-refreshed mutable Entity
+  attributes, hash-batch edge cases. Runs Sunday morning ET, clear of the
+  weekday incremental window.
+
+  Skips if a materialize is already in flight (e.g. an incremental chain mid-run)
+  to avoid two writers on the same graph. Enable in the Dagster UI when ready.
+  """
+  if env.ENVIRONMENT == "dev":
+    context.log.info("Skipping reconcile schedule in dev environment")
+    return
+
+  active_runs = context.instance.get_runs(
+    filters=RunsFilter(
+      job_name="sec_materialize",
+      statuses=[DagsterRunStatus.STARTED, DagsterRunStatus.QUEUED],
+    ),
+    limit=1,
+  )
+  if active_runs:
+    context.log.info(
+      f"Materialize job already running (run_id={active_runs[0].run_id}), "
+      "skipping weekly reconcile"
+    )
+    return
+
+  ts = context.scheduled_execution_time.strftime("%Y%m%d")
+  context.log.info("Triggering weekly full-rebuild reconciliation of sec graph")
+
+  yield RunRequest(
+    run_key=f"sec-materialize-reconcile-{ts}",
+    run_config={
+      "ops": {
+        "sec_graph_materialized": {
+          "config": {
+            "graph_id": "sec",
+            "materialize_mode": "full",
+            "rebuild_graph": True,
+          }
+        },
+      }
+    },
+    tags={
+      "pipeline": "sec",
+      "phase": "reconcile",
+      "materialize_mode": "full",
     },
   )
 

--- a/robosystems/adapters/sec/processors/ingestion/materialization.py
+++ b/robosystems/adapters/sec/processors/ingestion/materialization.py
@@ -66,6 +66,7 @@ class LadybugMaterializer:
     batch_materialization: bool = True,
     batch_size: int = MATERIALIZATION_BATCH_SIZE,
     progress_callback: ProgressCallback | None = None,
+    materialize_mode: str = "full",
   ) -> MaterializeResult:
     """
     Materialize LadybugDB graph from existing DuckDB staging.
@@ -88,6 +89,10 @@ class LadybugMaterializer:
                      for large tables to prevent OOM.
         batch_size: Rows per batch (default: 20M).
         progress_callback: Optional callback for progress logging.
+        materialize_mode: "full" (default) rebuilds the graph then COPYs every
+                     table (assumes an empty target). "incremental" skips the
+                     rebuild and COPYs only rows not already in the populated
+                     graph (per-table keyset anti-join in the Graph API).
 
     Returns:
         MaterializeResult with rows ingested per table
@@ -95,7 +100,14 @@ class LadybugMaterializer:
     start_time = time.time()
     log_progress = make_progress_logger(progress_callback)
 
-    log_progress(f"Starting materialization from DuckDB for graph {self.graph_id}")
+    incremental = materialize_mode == "incremental"
+    # Incremental never rebuilds — it appends into the existing populated graph.
+    do_rebuild = rebuild and not incremental
+
+    log_progress(
+      f"Starting materialization from DuckDB for graph {self.graph_id} "
+      f"(mode={materialize_mode})"
+    )
 
     try:
       # Step 1: Determine which tables to materialize (schema-driven)
@@ -130,7 +142,7 @@ class LadybugMaterializer:
         )
 
       # Step 3: Rebuild or ensure LadybugDB database exists
-      if rebuild:
+      if do_rebuild:
         logger.info(
           "Step 3: Rebuilding LadybugDB database (DuckDB staging preserved)..."
         )
@@ -159,6 +171,7 @@ class LadybugMaterializer:
         batch_materialization=batch_materialization,
         batch_size=batch_size,
         progress_callback=log_progress,
+        incremental=incremental,
       )
 
       duration = time.time() - start_time
@@ -297,6 +310,7 @@ class LadybugMaterializer:
     batch_materialization: bool = True,
     batch_size: int = MATERIALIZATION_BATCH_SIZE,
     progress_callback: ProgressCallback | None = None,
+    incremental: bool = False,
   ) -> dict[str, Any]:
     """
     Trigger ingestion for all tables into LadybugDB graph via Graph API.
@@ -309,6 +323,9 @@ class LadybugMaterializer:
         batch_materialization: If True (default), use batching for large tables.
         batch_size: Rows per batch (default: 20M).
         progress_callback: Optional callback for progress logging
+        incremental: If True, each table's COPY anti-joins against the existing
+            graph so only new rows are ingested (populated-graph append). If
+            False (default), COPY assumes an empty target (full rebuild path).
 
     Returns:
         Ingestion results with statistics
@@ -361,6 +378,7 @@ class LadybugMaterializer:
               batch_num=batch_num,
               num_batches=num_batches,
               timeout=CHUNKED_MATERIALIZATION_TIMEOUT,
+              incremental=incremental,
             )
 
             batch_rows = response.get("rows_ingested", 0)
@@ -399,6 +417,7 @@ class LadybugMaterializer:
             graph_id=self.graph_id,
             table_name=table_name,
             timeout=timeout,
+            incremental=incremental,
           )
 
           rows_ingested = response.get("rows_ingested", 0)

--- a/robosystems/graph_api/client/client.py
+++ b/robosystems/graph_api/client/client.py
@@ -1954,6 +1954,7 @@ class GraphClient(BaseGraphClient):
     materialize_embeddings: bool = False,
     timeout: float = 600.0,
     source_graph_id: str | None = None,
+    incremental: bool = False,
   ) -> dict[str, Any]:
     """
     Materialize a DuckDB staging table into the graph database.
@@ -1972,6 +1973,9 @@ class GraphClient(BaseGraphClient):
         timeout: Request timeout in seconds. Default 600s (10 min) for large bulk operations.
         source_graph_id: Read DuckDB staging from this graph instead of graph_id.
             Used by blue-green materialization.
+        incremental: COPY only rows not already in the target graph (anti-join
+            against a keyset snapshot) instead of assuming an empty target. Use
+            when materializing into a POPULATED graph (skips the full rebuild).
 
     Returns:
         Materialization response with rows materialized and timing
@@ -1990,6 +1994,9 @@ class GraphClient(BaseGraphClient):
 
     if source_graph_id is not None:
       json_data["source_graph_id"] = source_graph_id
+
+    if incremental:
+      json_data["incremental"] = True
 
     response = await self._request(
       "POST",

--- a/robosystems/graph_api/models/tables.py
+++ b/robosystems/graph_api/models/tables.py
@@ -152,6 +152,13 @@ class TableMaterializationRequest(BaseModel):
     default=False,
     description="Whether to materialize embedding columns to LadybugDB. Default false — embeddings stay in DuckDB staging only.",
   )
+  incremental: bool = Field(
+    default=False,
+    description="Incremental mode: COPY only rows not already in the target graph "
+    "(anti-join the export against a keyset snapshot of existing node identifiers / "
+    "relationship (src,dst) pairs) instead of assuming an empty target. Default false "
+    "= full materialization (assumes a freshly rebuilt, empty graph).",
+  )
 
   class Config:
     extra = "forbid"

--- a/robosystems/graph_api/routers/databases/tables/materialize.py
+++ b/robosystems/graph_api/routers/databases/tables/materialize.py
@@ -1,4 +1,5 @@
 import re
+from pathlib import Path as FilePath
 
 import pyarrow as pa
 from fastapi import APIRouter, Body, Depends, HTTPException, Path
@@ -51,6 +52,51 @@ def _copy_result_rows(result, fallback: int) -> int:
   except Exception:
     return fallback
   return fallback
+
+
+def _incr_keyset_path(graph_id: str, table_name: str) -> FilePath:
+  """Local path for a table's incremental keyset snapshot.
+
+  Under DUCKDB_STAGING_PATH (instance-local EBS, colocated with staging) but NOT
+  a ``.duckdb``/``.lbug`` file, so it is never published to S3. Transient —
+  deleted after the table's incremental run.
+  """
+  return (
+    FilePath(env.DUCKDB_STAGING_PATH) / "incr_keys" / graph_id / f"{table_name}.parquet"
+  )
+
+
+def _export_incremental_keyset(
+  ladybug_service,
+  graph_id: str,
+  table_name: str,
+  is_rel: bool,
+  snapshot_path: FilePath,
+) -> None:
+  """Stream the target graph's existing keys for ``table_name`` into a parquet
+  snapshot the DuckDB export SELECT can anti-join against, so only new rows are
+  COPYed.
+
+  Node keyset = ``identifier``; relationship keyset = ``(src, dst)`` via a
+  traversal. Uses LadybugDB's server-side ``COPY (query) TO parquet`` so the
+  whole keyset never materializes in Python — a 200M-edge keyset would be ~15 GB.
+  An empty graph writes a 0-row parquet, so the anti-join passes every staged row
+  and the first run degrades cleanly to a full load.
+  """
+  snapshot_path.parent.mkdir(parents=True, exist_ok=True)
+  esc_path = str(snapshot_path).replace("'", "''")
+  if is_rel:
+    query = (
+      f"MATCH (a)-[:{table_name}]->(b) RETURN a.identifier AS src, b.identifier AS dst"
+    )
+  else:
+    query = f"MATCH (n:{table_name}) RETURN n.identifier AS identifier"
+  with ladybug_service.db_manager.connection_pool.get_connection(graph_id) as conn:
+    conn.execute("CALL timeout=3600000")  # 60 min: large rel traversals
+    try:
+      conn.execute(f"COPY ({query}) TO '{esc_path}'")
+    finally:
+      conn.execute("CALL timeout=120000")  # reset to 2 minutes
 
 
 # Type mapping from LadybugDB types to DuckDB-compatible cast types
@@ -255,6 +301,11 @@ async def _materialize_table_impl(
 ) -> TableMaterializationResponse:
   import time
 
+  # Incremental keyset snapshot (assigned only in incremental mode); referenced
+  # again in the cleanup section, so bind it up front.
+  incremental = False
+  snapshot_path: FilePath | None = None
+
   try:
     # Blue-green: read DuckDB from source graph if specified, otherwise from target
     duckdb_graph_id = request.source_graph_id or graph_id
@@ -303,6 +354,9 @@ async def _materialize_table_impl(
         ).fetchall()
         column_names = [col[0] for col in source_columns]
         has_file_id = "file_id" in column_names
+        is_node = "identifier" in column_names
+        is_rel = "src" in column_names and "dst" in column_names
+        incremental = request.incremental and (is_node or is_rel)
 
         # Columns to NULL out (keep column for schema match, but skip data).
         # Embeddings stay in DuckDB staging for LanceDB vector search; materializing
@@ -323,9 +377,9 @@ async def _materialize_table_impl(
         if has_hash_batching:
           assert request.batch_num is not None and request.num_batches is not None
 
-          if "identifier" in column_names:
+          if is_node:
             hash_col = "identifier"
-          elif "src" in column_names and "dst" in column_names:
+          elif is_rel:
             hash_col = "src || '|' || dst"
           else:
             hash_col = column_names[0] if column_names else "rowid"
@@ -343,14 +397,61 @@ async def _materialize_table_impl(
           file_filter = f"file_id IN ({file_ids_placeholders})"
           query_params.extend(request.file_ids)
 
-        # Build WHERE clause combining file filter and batch clause
-        where = ""
-        if file_filter and batch_clause:
-          where = f" WHERE {file_filter} AND ({batch_clause.replace(' WHERE ', '')})"
-        elif file_filter:
-          where = f" WHERE {file_filter}"
-        elif batch_clause:
-          where = batch_clause
+        # Incremental: export the target graph's existing keys to a parquet
+        # snapshot (once per table, reused across hash batches) and anti-join the
+        # export SELECT against it so ONLY new rows are COPYed. Mandatory for
+        # correctness against a POPULATED graph — a duplicate node PK COPY
+        # hard-fails, and a duplicate (src,dst) edge COPY silently duplicates
+        # (both verified on the 0.18 fork). An empty graph yields an empty
+        # snapshot, so the anti-join passes everything (first run == full load).
+        #
+        # Mutable-attribute tables (SEC: only Entity) ride the same anti-join —
+        # NEW rows are added, but a CHANGED attribute of an ALREADY-materialized
+        # node is NOT refreshed here. A node-level DELETE+re-COPY can't fix that:
+        # DETACH DELETE drops the node's edges (verified), orphaning e.g.
+        # FACT_HAS_ENTITY. Attribute refresh is therefore a responsibility of the
+        # periodic full reconciliation rebuild; a bulk UNWIND+SET/MERGE upsert
+        # (edge-preserving) is the future path if sub-reconciliation freshness is
+        # needed.
+        incr_clause = ""
+        if incremental:
+          snapshot_path = _incr_keyset_path(graph_id, table_name)
+          # Export once per table: on batch 0 / single-pass, or self-heal if a
+          # later batch finds the snapshot missing (crash between batches).
+          need_export = (
+            not has_hash_batching
+            or request.batch_num == 0
+            or not snapshot_path.exists()
+          )
+          if need_export:
+            _export_incremental_keyset(
+              ladybug_service, graph_id, table_name, is_rel, snapshot_path
+            )
+          esc_snapshot = str(snapshot_path).replace("'", "''")
+          if is_rel:
+            incr_clause = (
+              f"NOT EXISTS (SELECT 1 FROM read_parquet('{esc_snapshot}') k "
+              "WHERE k.src = t.src AND k.dst = t.dst)"
+            )
+          else:
+            incr_clause = (
+              f"NOT EXISTS (SELECT 1 FROM read_parquet('{esc_snapshot}') k "
+              "WHERE k.identifier = t.identifier)"
+            )
+
+        # Combine file-filter, hash-batch, and incremental anti-join predicates.
+        where_fragments: list[str] = []
+        if file_filter:
+          where_fragments.append(file_filter)
+        if batch_clause:
+          where_fragments.append(batch_clause.replace(" WHERE ", "", 1))
+        if incr_clause:
+          where_fragments.append(incr_clause)
+        where = (
+          " WHERE " + " AND ".join(f"({frag})" for frag in where_fragments)
+          if where_fragments
+          else ""
+        )
 
         # Columns to exclude from materialization
         exclude_cols: set[str] = set()
@@ -383,7 +484,11 @@ async def _materialize_table_impl(
         # the write into LadybugDB's CSR storage is still a copy, unavoidable for
         # a persistent, traversable graph. Batching bounds peak memory; DECIMAL
         # (postgres_scan-staged NUMERIC) rides through the Arrow types natively.
-        select_sql = f"SELECT {select_expr} FROM {table_name}{where}"
+        # Alias the source as `t` so the incremental anti-join subquery can
+        # qualify outer columns (t.identifier / t.src / t.dst). Single-table FROM,
+        # so the unqualified columns in select_expr / file_filter / batch predicate
+        # still resolve to `t`.
+        select_sql = f"SELECT {select_expr} FROM {table_name} AS t{where}"
         if query_params:
           arrow_reader = duck_conn.execute(select_sql, query_params).fetch_record_batch(
             ARROW_STREAM_BATCH_ROWS
@@ -466,6 +571,19 @@ async def _materialize_table_impl(
       logger.debug(f"Released DuckDB connections for {duckdb_graph_id}")
     except Exception as release_err:
       logger.warning(f"Failed to release DuckDB connections: {release_err}")
+
+    # Incremental: drop the keyset snapshot after the last (or only) batch. On a
+    # mid-run failure it lingers and is self-healed by the next batch-0 overwrite.
+    if incremental and snapshot_path is not None:
+      is_last_batch = (
+        request.num_batches is None or request.batch_num == request.num_batches - 1
+      )
+      if is_last_batch:
+        try:
+          snapshot_path.unlink(missing_ok=True)
+          logger.debug(f"Removed incremental keyset snapshot for {table_name}")
+        except Exception as snap_err:
+          logger.warning(f"Could not remove incremental keyset snapshot: {snap_err}")
 
     return TableMaterializationResponse(
       status="success",

--- a/robosystems/graph_api/routers/databases/tables/materialize.py
+++ b/robosystems/graph_api/routers/databases/tables/materialize.py
@@ -54,6 +54,12 @@ def _copy_result_rows(result, fallback: int) -> int:
   return fallback
 
 
+# graph_id and table_name reach the path builder from URL path params; both are
+# registry/schema identifiers (alphanumeric + _ / -). Validate before using them
+# to construct a filesystem path so a crafted value cannot escape the staging dir.
+_SAFE_PATH_COMPONENT = re.compile(r"[A-Za-z0-9_-]+")
+
+
 def _incr_keyset_path(graph_id: str, table_name: str) -> FilePath:
   """Local path for a table's incremental keyset snapshot.
 
@@ -61,6 +67,10 @@ def _incr_keyset_path(graph_id: str, table_name: str) -> FilePath:
   a ``.duckdb``/``.lbug`` file, so it is never published to S3. Transient —
   deleted after the table's incremental run.
   """
+  if not _SAFE_PATH_COMPONENT.fullmatch(graph_id):
+    raise ValueError(f"Unsafe graph_id for keyset snapshot path: {graph_id!r}")
+  if not _SAFE_PATH_COMPONENT.fullmatch(table_name):
+    raise ValueError(f"Unsafe table_name for keyset snapshot path: {table_name!r}")
   return (
     FilePath(env.DUCKDB_STAGING_PATH) / "incr_keys" / graph_id / f"{table_name}.parquet"
   )

--- a/tests/adapters/sec/pipeline/test_init.py
+++ b/tests/adapters/sec/pipeline/test_init.py
@@ -61,10 +61,9 @@ class TestGetDagsterComponents:
   def test_expected_number_of_schedules(self):
     """Test that the expected number of schedules are registered."""
     components = get_dagster_components()
-    # incremental download + weekly full-rebuild reconciliation
-    assert len(components["schedules"]) == 2
-    schedule_names = {s.name for s in components["schedules"]}
-    assert "sec_materialize_reconcile_schedule" in schedule_names
+    # Only the incremental download schedule — the weekly full-rebuild
+    # reconciliation rides the nightly chain (Friday full), not a separate schedule.
+    assert len(components["schedules"]) == 1
 
   def test_asset_names_include_core_pipeline(self):
     """Test that core pipeline assets are included."""

--- a/tests/adapters/sec/pipeline/test_init.py
+++ b/tests/adapters/sec/pipeline/test_init.py
@@ -61,7 +61,10 @@ class TestGetDagsterComponents:
   def test_expected_number_of_schedules(self):
     """Test that the expected number of schedules are registered."""
     components = get_dagster_components()
-    assert len(components["schedules"]) == 1
+    # incremental download + weekly full-rebuild reconciliation
+    assert len(components["schedules"]) == 2
+    schedule_names = {s.name for s in components["schedules"]}
+    assert "sec_materialize_reconcile_schedule" in schedule_names
 
   def test_asset_names_include_core_pipeline(self):
     """Test that core pipeline assets are included."""

--- a/tests/graph_api/routers/databases/tables/test_incremental_materialize.py
+++ b/tests/graph_api/routers/databases/tables/test_incremental_materialize.py
@@ -10,13 +10,16 @@ the incremental mode rests on:
 
 so the anti-join must produce a graph identical to a from-empty full load, add
 no duplicate edges, and be idempotent (a re-run with no new staging adds 0 rows).
+
+COPY is done via parquet files here (dedup/anti-join semantics are transport-
+independent — the production handler streams the same rows over Arrow instead).
 """
 
 from types import SimpleNamespace
 
 import duckdb
 import ladybug as lbug
-import pyarrow as pa
+import pyarrow.parquet as pq
 import pytest
 
 from robosystems.graph_api.routers.databases.tables.materialize import (
@@ -40,20 +43,16 @@ def _ladybug_service(conn):
   return SimpleNamespace(db_manager=SimpleNamespace(connection_pool=pool))
 
 
-def _copy_arrow(conn, table_name, arrow_tbl):
-  """COPY an Arrow table into ladybug via the by-name replacement scan (same
-  pattern as the production materialize handler)."""
-  copy_batch = arrow_tbl  # noqa: F841 - resolved by name via replacement scan
-  conn.execute(f"COPY {table_name} FROM copy_batch")
+def _load(conn, duck, table_name, select_sql, out_path):
+  """DuckDB SELECT -> parquet -> ladybug COPY. Returns rows COPYed."""
+  duck.execute(f"COPY ({select_sql}) TO '{out_path}' (FORMAT parquet)")
+  rows = pq.read_metadata(str(out_path)).num_rows
+  if rows:
+    conn.execute(f"COPY {table_name} FROM '{out_path}'")
+  return rows
 
 
-def _arrow(duck, sql):
-  return pa.Table.from_batches(list(duck.execute(sql).fetch_record_batch(1000)))
-
-
-def _antijoin_select(
-  table_name: str, select_expr: str, snapshot_path, is_rel: bool
-) -> str:
+def _antijoin_select(table_name, select_expr, snapshot_path, is_rel):
   """Mirror the handler's incremental anti-join SELECT (materialize.py)."""
   esc = str(snapshot_path).replace("'", "''")
   if is_rel:
@@ -69,21 +68,15 @@ def _antijoin_select(
   return f"SELECT {select_expr} FROM {table_name} AS t WHERE ({incr})"
 
 
-def _incremental_copy(gc, duck, table_name, select_expr, is_rel, snapshot_path):
+def _incremental_copy(gc, duck, table_name, select_expr, is_rel, tmp_path, tag):
   """Reproduce the server incremental path for one table: export keyset ->
-  anti-join SELECT -> replacement-scan COPY. Returns rows COPYed."""
+  anti-join SELECT -> COPY only the delta. Returns rows COPYed."""
+  snapshot_path = tmp_path / f"{tag}_keys.parquet"
   _export_incremental_keyset(
     _ladybug_service(gc), "sec", table_name, is_rel, snapshot_path
   )
-  reader = duck.execute(
-    _antijoin_select(table_name, select_expr, snapshot_path, is_rel)
-  ).fetch_record_batch(1_000_000)
-  copied = 0
-  for batch in reader:
-    copy_batch = pa.Table.from_batches([batch])  # noqa: F841 - resolved by name
-    gc.execute(f"COPY {table_name} FROM copy_batch")
-    copied += batch.num_rows
-  return copied
+  select_sql = _antijoin_select(table_name, select_expr, snapshot_path, is_rel)
+  return _load(gc, duck, table_name, select_sql, tmp_path / f"{tag}_delta.parquet")
 
 
 def _new_graph(path):
@@ -119,6 +112,19 @@ def test_incr_keyset_path_is_transient_local(monkeypatch):
   assert ".lbug" not in p.as_posix() and ".duckdb" not in p.as_posix()
 
 
+@pytest.mark.parametrize("bad", ["../etc", "a/b", "sec/../sec", "."])
+def test_incr_keyset_path_rejects_traversal(bad, monkeypatch):
+  """graph_id / table_name are URL path params — a traversal attempt must raise,
+  not build a path outside the staging dir."""
+  from robosystems.config import env
+
+  monkeypatch.setattr(env, "DUCKDB_STAGING_PATH", "/data/staging", raising=False)
+  with pytest.raises(ValueError):
+    _incr_keyset_path(bad, "Fact")
+  with pytest.raises(ValueError):
+    _incr_keyset_path("sec", bad)
+
+
 @pytest.mark.integration
 def test_incremental_equals_full_load(tmp_path):
   """Incremental COPY into a populated graph == a full load of the same staging,
@@ -132,23 +138,25 @@ def test_incremental_equals_full_load(tmp_path):
 
   # ---- Path A: full load into a fresh graph ------------------------------
   _, full = _new_graph(tmp_path / "full.lbug")
-  _copy_arrow(full, "N", _arrow(duck, "SELECT identifier, name FROM N"))
-  _copy_arrow(full, "R", _arrow(duck, "SELECT src, dst FROM R"))
+  _load(full, duck, "N", "SELECT identifier, name FROM N", tmp_path / "fa_n.parquet")
+  _load(full, duck, "R", "SELECT src, dst FROM R", tmp_path / "fa_r.parquet")
   full_counts = _counts(full)
 
   # ---- Path B: pre-populate a graph, then incremental-COPY the same staging
   _, incr = _new_graph(tmp_path / "incr.lbug")
-  _copy_arrow(
-    incr, "N", pa.table({"identifier": ["a", "b", "c"], "name": ["A", "B", "C"]})
+  duck.execute(
+    "CREATE TABLE seed_n AS SELECT * FROM N WHERE identifier IN ('a','b','c')"
   )
-  _copy_arrow(incr, "R", pa.table({"src": ["a"], "dst": ["b"]}))
+  duck.execute("CREATE TABLE seed_r AS SELECT * FROM R WHERE src='a' AND dst='b'")
+  _load(
+    incr, duck, "N", "SELECT identifier, name FROM seed_n", tmp_path / "seed_n.parquet"
+  )
+  _load(incr, duck, "R", "SELECT src, dst FROM seed_r", tmp_path / "seed_r.parquet")
 
   added_n = _incremental_copy(
-    incr, duck, "N", "identifier, name", False, tmp_path / "N.parquet"
+    incr, duck, "N", "identifier, name", False, tmp_path, "n1"
   )
-  added_r = _incremental_copy(
-    incr, duck, "R", '"src", "dst"', True, tmp_path / "R.parquet"
-  )
+  added_r = _incremental_copy(incr, duck, "R", '"src", "dst"', True, tmp_path, "r1")
   incr_counts = _counts(incr)
 
   # only new rows added this run
@@ -164,11 +172,9 @@ def test_incremental_equals_full_load(tmp_path):
 
   # ---- idempotency: re-run with no new staging adds nothing, does not crash
   again_n = _incremental_copy(
-    incr, duck, "N", "identifier, name", False, tmp_path / "N2.parquet"
+    incr, duck, "N", "identifier, name", False, tmp_path, "n2"
   )
-  again_r = _incremental_copy(
-    incr, duck, "R", '"src", "dst"', True, tmp_path / "R2.parquet"
-  )
+  again_r = _incremental_copy(incr, duck, "R", '"src", "dst"', True, tmp_path, "r2")
   assert again_n == 0 and again_r == 0
   assert _counts(incr) == (5, 3)
 
@@ -182,9 +188,7 @@ def test_incremental_empty_graph_degrades_to_full_load(tmp_path):
   duck.execute("INSERT INTO N VALUES ('a','A'),('b','B')")
 
   _, c = _new_graph(tmp_path / "empty.lbug")  # N exists but is empty
-  added = _incremental_copy(
-    c, duck, "N", "identifier, name", False, tmp_path / "N.parquet"
-  )
+  added = _incremental_copy(c, duck, "N", "identifier, name", False, tmp_path, "n")
   assert added == 2
   assert (
     c.execute("MATCH (n:N) RETURN count(*)").get_as_arrow().column(0)[0].as_py() == 2

--- a/tests/graph_api/routers/databases/tables/test_incremental_materialize.py
+++ b/tests/graph_api/routers/databases/tables/test_incremental_materialize.py
@@ -1,0 +1,191 @@
+"""Incremental materialization: keyset-export + anti-join parity tests.
+
+Exercises the REAL helpers (`_export_incremental_keyset`, `_incr_keyset_path`)
+against real ladybug + duckdb engines, proving that an incremental COPY into a
+populated graph yields the SAME graph as a full load — the correctness contract
+the incremental mode rests on:
+
+  - node dup PRIMARY KEY COPY hard-fails  -> node anti-join is mandatory
+  - rel dup (src,dst) COPY silently duplicates -> rel anti-join is mandatory
+
+so the anti-join must produce a graph identical to a from-empty full load, add
+no duplicate edges, and be idempotent (a re-run with no new staging adds 0 rows).
+"""
+
+from types import SimpleNamespace
+
+import duckdb
+import ladybug as lbug
+import pyarrow as pa
+import pytest
+
+from robosystems.graph_api.routers.databases.tables.materialize import (
+  _export_incremental_keyset,
+  _incr_keyset_path,
+)
+
+
+def _ladybug_service(conn):
+  """Minimal stand-in exposing db_manager.connection_pool.get_connection(...)
+  so the real _export_incremental_keyset runs against a plain ladybug conn."""
+
+  class _Ctx:
+    def __enter__(self):
+      return conn
+
+    def __exit__(self, *exc):
+      return False
+
+  pool = SimpleNamespace(get_connection=lambda _graph_id: _Ctx())
+  return SimpleNamespace(db_manager=SimpleNamespace(connection_pool=pool))
+
+
+def _copy_arrow(conn, table_name, arrow_tbl):
+  """COPY an Arrow table into ladybug via the by-name replacement scan (same
+  pattern as the production materialize handler)."""
+  copy_batch = arrow_tbl  # noqa: F841 - resolved by name via replacement scan
+  conn.execute(f"COPY {table_name} FROM copy_batch")
+
+
+def _arrow(duck, sql):
+  return pa.Table.from_batches(list(duck.execute(sql).fetch_record_batch(1000)))
+
+
+def _antijoin_select(
+  table_name: str, select_expr: str, snapshot_path, is_rel: bool
+) -> str:
+  """Mirror the handler's incremental anti-join SELECT (materialize.py)."""
+  esc = str(snapshot_path).replace("'", "''")
+  if is_rel:
+    incr = (
+      f"NOT EXISTS (SELECT 1 FROM read_parquet('{esc}') k "
+      "WHERE k.src = t.src AND k.dst = t.dst)"
+    )
+  else:
+    incr = (
+      f"NOT EXISTS (SELECT 1 FROM read_parquet('{esc}') k "
+      "WHERE k.identifier = t.identifier)"
+    )
+  return f"SELECT {select_expr} FROM {table_name} AS t WHERE ({incr})"
+
+
+def _incremental_copy(gc, duck, table_name, select_expr, is_rel, snapshot_path):
+  """Reproduce the server incremental path for one table: export keyset ->
+  anti-join SELECT -> replacement-scan COPY. Returns rows COPYed."""
+  _export_incremental_keyset(
+    _ladybug_service(gc), "sec", table_name, is_rel, snapshot_path
+  )
+  reader = duck.execute(
+    _antijoin_select(table_name, select_expr, snapshot_path, is_rel)
+  ).fetch_record_batch(1_000_000)
+  copied = 0
+  for batch in reader:
+    copy_batch = pa.Table.from_batches([batch])  # noqa: F841 - resolved by name
+    gc.execute(f"COPY {table_name} FROM copy_batch")
+    copied += batch.num_rows
+  return copied
+
+
+def _new_graph(path):
+  g = lbug.Database(str(path), read_only=False)
+  c = lbug.Connection(g)
+  c.execute(
+    "CREATE NODE TABLE N(identifier STRING, name STRING, PRIMARY KEY(identifier))"
+  )
+  c.execute("CREATE REL TABLE R(FROM N TO N)")
+  return g, c
+
+
+def _counts(c):
+  n = c.execute("MATCH (n:N) RETURN count(*)").get_as_arrow().column(0)[0].as_py()
+  r = (
+    c.execute("MATCH (:N)-[e:R]->(:N) RETURN count(*)")
+    .get_as_arrow()
+    .column(0)[0]
+    .as_py()
+  )
+  return n, r
+
+
+def test_incr_keyset_path_is_transient_local(monkeypatch):
+  """Snapshot lives under DUCKDB_STAGING_PATH/incr_keys — never a .duckdb/.lbug
+  file (so it is never published to S3)."""
+  from robosystems.config import env
+
+  monkeypatch.setattr(env, "DUCKDB_STAGING_PATH", "/data/staging", raising=False)
+  p = _incr_keyset_path("sec", "FACT_HAS_ELEMENT")
+  assert p.as_posix() == "/data/staging/incr_keys/sec/FACT_HAS_ELEMENT.parquet"
+  assert p.suffix == ".parquet"
+  assert ".lbug" not in p.as_posix() and ".duckdb" not in p.as_posix()
+
+
+@pytest.mark.integration
+def test_incremental_equals_full_load(tmp_path):
+  """Incremental COPY into a populated graph == a full load of the same staging,
+  with no duplicate edges and full idempotency."""
+  # Shared staging (the source of truth): superset of the pre-populated graph.
+  duck = duckdb.connect(str(tmp_path / "staging.duckdb"))
+  duck.execute("CREATE TABLE N(identifier VARCHAR, name VARCHAR)")
+  duck.execute("INSERT INTO N VALUES ('a','A'),('b','B'),('c','C'),('d','D'),('e','E')")
+  duck.execute("CREATE TABLE R(src VARCHAR, dst VARCHAR)")
+  duck.execute("INSERT INTO R VALUES ('a','b'),('b','c'),('c','d')")
+
+  # ---- Path A: full load into a fresh graph ------------------------------
+  _, full = _new_graph(tmp_path / "full.lbug")
+  _copy_arrow(full, "N", _arrow(duck, "SELECT identifier, name FROM N"))
+  _copy_arrow(full, "R", _arrow(duck, "SELECT src, dst FROM R"))
+  full_counts = _counts(full)
+
+  # ---- Path B: pre-populate a graph, then incremental-COPY the same staging
+  _, incr = _new_graph(tmp_path / "incr.lbug")
+  _copy_arrow(
+    incr, "N", pa.table({"identifier": ["a", "b", "c"], "name": ["A", "B", "C"]})
+  )
+  _copy_arrow(incr, "R", pa.table({"src": ["a"], "dst": ["b"]}))
+
+  added_n = _incremental_copy(
+    incr, duck, "N", "identifier, name", False, tmp_path / "N.parquet"
+  )
+  added_r = _incremental_copy(
+    incr, duck, "R", '"src", "dst"', True, tmp_path / "R.parquet"
+  )
+  incr_counts = _counts(incr)
+
+  # only new rows added this run
+  assert added_n == 2  # d, e
+  assert added_r == 2  # b->c, c->d
+  # parity: incremental graph == full-load graph
+  assert incr_counts == full_counts == (5, 3)
+  # no duplicate edges (a->b was seeded AND in staging, must appear once)
+  dup = incr.execute(
+    "MATCH (a:N)-[e:R]->(b:N) RETURN a.identifier, b.identifier, count(*) AS c"
+  ).get_as_arrow()
+  assert max(dup.column("c").to_pylist()) == 1
+
+  # ---- idempotency: re-run with no new staging adds nothing, does not crash
+  again_n = _incremental_copy(
+    incr, duck, "N", "identifier, name", False, tmp_path / "N2.parquet"
+  )
+  again_r = _incremental_copy(
+    incr, duck, "R", '"src", "dst"', True, tmp_path / "R2.parquet"
+  )
+  assert again_n == 0 and again_r == 0
+  assert _counts(incr) == (5, 3)
+
+
+@pytest.mark.integration
+def test_incremental_empty_graph_degrades_to_full_load(tmp_path):
+  """First run against an empty graph: the keyset export is empty, the anti-join
+  passes everything, and every staged row loads."""
+  duck = duckdb.connect(str(tmp_path / "staging.duckdb"))
+  duck.execute("CREATE TABLE N(identifier VARCHAR, name VARCHAR)")
+  duck.execute("INSERT INTO N VALUES ('a','A'),('b','B')")
+
+  _, c = _new_graph(tmp_path / "empty.lbug")  # N exists but is empty
+  added = _incremental_copy(
+    c, duck, "N", "identifier, name", False, tmp_path / "N.parquet"
+  )
+  assert added == 2
+  assert (
+    c.execute("MATCH (n:N) RETURN count(*)").get_as_arrow().column(0)[0].as_py() == 2
+  )


### PR DESCRIPTION
## Summary

Adds an **incremental materialization mode** for the SEC LadybugDB pipeline. Today every run does a full LadybugDB rebuild (delete the graph, recreate, COPY every table). This adds a mode that COPYs only rows not already in the populated graph — via a per-table keyset anti-join — keeping the full rebuild as a periodic reconciliation path. It is entirely **default-off**: the new server flag defaults to `false`, and both the sensor branch and the reconciliation schedule ship `default_status=STOPPED`, so merging has zero effect on prod until deliberately enabled in the Dagster UI.

The SEC graph is additive-only except `Entity`, and every node id is a deterministic UUID5 of its source URI, so "already loaded" is decidable by a key match — which is what makes the anti-join sound.

## Why the anti-join is mandatory (verified empirically on ladybug 0.18.1)

- **Node**: COPYing a row whose PRIMARY KEY already exists **hard-fails** (raises, aborts the batch). `ignore_errors=true` is not an option — it silently drops ~37% of valid rows on 0.18 (per the standing comment in `materialize.py`).
- **Relationship**: all SEC rel tables are `MANY_MANY` with no PK, so re-COPYing an existing `(src,dst)` edge **silently duplicates** it.

So COPYing the delta requires filtering out both existing node PKs and existing edges — a correctness requirement, not an optimization. The existing COPY handler already appends into a populated table; it only needs to be fed rows that are genuinely new.

## How it works

The diff runs **server-side** in the Graph API (`_materialize_table_impl`), where DuckDB staging and the `.lbug` file are colocated:

1. Export the target graph's existing keys to a transient parquet snapshot via ladybug's server-side `COPY (MATCH … RETURN …) TO 'file.parquet'` — node keyset = `identifier`, rel keyset = `(src,dst)`. Streaming server-side, so a 200M-edge keyset never materializes in Python memory.
2. Anti-join the DuckDB export SELECT against that snapshot (`… FROM {table} AS t WHERE NOT EXISTS (SELECT 1 FROM read_parquet(snapshot) k WHERE k.identifier = t.identifier)`), reusing the existing DuckDB→Arrow→COPY path unchanged. Only the surviving delta rows are ingested.

The snapshot lives under `DUCKDB_STAGING_PATH/incr_keys/` (instance-local, never published to S3), is exported once per table and reused across hash batches (a DuckDB temp table can't survive the per-call connection-pool teardown), and is cleaned up after the last batch (with batch-0 self-heal on a mid-run crash). An empty graph yields an empty snapshot, so the anti-join passes everything and the first run degrades cleanly to a full load.

**Entity** (the only mutable SEC node table) rides the same anti-join — new entities are added; a *changed attribute* of an already-materialized entity is refreshed by the periodic full reconciliation, not sub-reconciliation. A node-level DELETE+re-COPY can't be used: `DETACH DELETE` drops the node's edges (verified), which would orphan `FACT_HAS_ENTITY`.

## Changes

- **`graph_api/models/tables.py`** — `incremental: bool = False` on `TableMaterializationRequest`.
- **`graph_api/routers/databases/tables/materialize.py`** — `_export_incremental_keyset` + `_incr_keyset_path` helpers; node/rel detection; keyset snapshot lifecycle; the WHERE builder refactored into a fragment list that composes the file-filter, hash-batch, and incremental anti-join predicates; the export SELECT aliased `FROM {table} AS t` so the subquery can qualify outer columns.
- **`graph_api/client/client.py`** — `incremental` param on the `materialize_table` shim (forwarded only when true).
- **`adapters/sec/processors/ingestion/materialization.py`** — `materialize_mode` threaded through `materialize_from_duckdb` → `_trigger_ingestion` → both `materialize_table` calls; incremental skips the rebuild branch.
- **`adapters/sec/pipeline/configs.py`** — `materialize_mode: Literal["full","incremental"]` on `SECMaterializeConfig` (takes precedence over `rebuild_graph`).
- **`adapters/sec/pipeline/materialize.py`** — assets pass `materialize_mode` through and report it in run metadata.
- **`adapters/sec/pipeline/sensors.py`** — `sec_stage_to_materialize_sensor` now emits `materialize_mode: "incremental"`; new `sec_materialize_reconcile_schedule` (weekly full rebuild, STOPPED). Registered in `__init__.py`.
- **`tests/…/test_incremental_materialize.py`** — real-engine (ladybug + duckdb) tests exercising the actual helpers: incremental == full-load parity, no duplicate edges, idempotency (a re-run with no new staging ingests 0 rows), empty-graph-degrades-to-full, and the snapshot-path contract.

## Testing

- `just test-code` (ruff + format + basedpyright + cf-lint): **passed** (0 errors).
- New `test_incremental_materialize.py` (3 tests, real engines): **passed**.
- Existing `test_tables_materialize.py` + `tests/adapters/sec/pipeline/test_materialize.py` (19 tests): **passed** — no regression from the WHERE refactor / `AS t` alias.
- Design de-risked with standalone scripts against ladybug 0.18.1 (node dup-PK hard-fail, rel silent-dup, `COPY (query) TO parquet` support incl. empty/overwrite, `DETACH DELETE` edge cascade).
- Full `just test-all` unit suite: **not run** in this session (needs local env).

## Notes / Follow-ups

- **Enable-gate, not merge-gate.** Before enabling in prod, run one incremental materialize in staging and time the keyset export for the largest rel tables (`FACT_HAS_ELEMENT`, `ASSOCIATION_HAS_*`) against the ~40-min HTTP budget. That measurement decides whether to enable as-is or build the optimization below first.
- **Cost profile.** This is O(N)-read / O(Δ)-write: the CSR-write of every row (the expensive part of a full rebuild) is avoided, but the rel keyset export is a full traversal and the DuckDB anti-join scans the full staging table. Cost still scales with graph size, not changeset size — it reduces full-rebuild *frequency* (nightly → weekly reconciliation), it doesn't eliminate it.
- **Future O(Δ) path (no rewrite).** Capture the staging-insert delta (a `run_id`/`ingested_at` tag or `INSERT … RETURNING`) and use it as a candidate set, pushing only candidate keys through the LadybugDB anti-join — makes the export O(Δ) too. The current anti-join stays the correctness backbone.
- **Reconciliation cadence** defaulted to weekly (Sun 06:00 ET); confirm before enabling.
- `sec_historical` (frozen corpus) stays full-only.
