### PR TITLE
docs: add QuickBooks affiliate link where QuickBooks is cited

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Accounting and financial reporting extension — a ledger-grade system of record
 
 Built on the blocks:
 
-- **Close lifecycle** — fiscal calendar, close-target catch-up sequencing, and period close/reopen gated on the balance equation and QuickBooks sync-staleness
+- **Close lifecycle** — fiscal calendar, close-target catch-up sequencing, and period close/reopen gated on the balance equation and [QuickBooks](https://quickbooks.intuit.com/partners/affiliates?cid=par_pim_4TcakSEFQs73) sync-staleness
 - **Mapping** — CoA→GAAP mapping associations plus AI-assisted bulk mapping via the **MappingOperator** (confidence-tiered: auto-approve / review / skip)
 - **Reporting** — multi-period reports rendered from shared facts through a Reporting Style; a report lifecycle (draft → under_review → filed → archived) with publish lists for distribution
 - **Analytical operations** — `live-financial-statement` renders a statement straight from the OLTP ledger (no materialization required); `build-fact-grid` and `financial-statement-analysis` query the materialized XBRL hypercube in the graph

--- a/static/description.md
+++ b/static/description.md
@@ -7,7 +7,7 @@ RoboSystems is an open-source, AI-native financial intelligence platform for acc
 - **Multi-Tenant Architecture**: Isolated database instances with tier-based resource allocation
 - **AI Operator System**: Autonomous financial Operators (Claude/MCP executors) with automatic credit tracking and SSE progress streaming
 - **DuckDB Staging**: High-performance data validation and bulk ingestion pipeline with Parquet optimization
-- **Data Integration**: Connect QuickBooks and SEC XBRL filings in a unified graph
+- **Data Integration**: Connect [QuickBooks](https://quickbooks.intuit.com/partners/affiliates?cid=par_pim_4TcakSEFQs73) and SEC XBRL filings in a unified graph
 - **Document Search**: Upload, index, and search documents with full-text and semantic search via OpenSearch
 - **Shared Repositories**: Access to curated SEC filing data and other shared knowledge graphs
 - **Credit-Based Billing**: AI operations consume token-based credits; database and MCP operations are free


### PR DESCRIPTION
Links the first QuickBooks mention to the QuickBooks (Intuit) affiliate program where QuickBooks is cited in public docs.

- README: Close lifecycle bullet
- `static/description.md` (API/product description): Data Integration bullet

Docs-only, first-mention-only.