### PR TITLE
feat(migration): standalone ladybug migration cleanup job

### DIFF
--- a/robosystems/dagster/definitions.py
+++ b/robosystems/dagster/definitions.py
@@ -72,6 +72,7 @@ from robosystems.dagster.jobs.invoice_billing import (
   invoice_subscription_renewal_job,
 )
 from robosystems.dagster.jobs.migration import (
+  ladybug_migration_cleanup_job,
   ladybug_migration_export_job,
   ladybug_migration_import_job,
 )
@@ -219,6 +220,7 @@ all_jobs = [
   # Platform: Version migration (manually triggered)
   ladybug_migration_export_job,
   ladybug_migration_import_job,
+  ladybug_migration_cleanup_job,
   # Platform: Notifications
   send_email_job,
   # Adapter: SEC pipeline

--- a/robosystems/dagster/jobs/migration.py
+++ b/robosystems/dagster/jobs/migration.py
@@ -1,13 +1,14 @@
 """Dagster jobs for LadybugDB version migration.
 
-Two jobs orchestrate migration across the fleet:
+Three jobs orchestrate migration across the fleet:
 1. Export job (pre-deploy): exports all databases on each instance
 2. Import job (post-deploy): imports exported databases on each instance
+3. Cleanup job (post-verify): deletes the .pre-migration rollback backups
 
-Both jobs discover instances from DynamoDB, skipping shared replicas
+All jobs discover instances from DynamoDB, skipping shared replicas
 (replicas re-attach from S3 and don't need export/import).
 
-Instances are processed in parallel — each instance exports/imports
+Instances are processed in parallel — each instance exports/imports/cleans
 its own local databases independently.
 """
 
@@ -38,6 +39,13 @@ class MigrationImportConfig(Config):
   skip_instances: list[str] = []
   include_shared_master: bool = False
   cleanup: bool = False
+
+
+class MigrationCleanupConfig(Config):
+  """Configuration for migration cleanup job."""
+
+  skip_instances: list[str] = []
+  include_shared_master: bool = False
 
 
 def _get_writer_instances(
@@ -178,7 +186,14 @@ async def _import_instance(
   # Check if migration is pending
   status = await client.migration_status()
   if not status.get("migration_pending"):
-    return {"instance_id": instance_id, "status": "no_migration_pending"}
+    # Nothing to import. Still honor cleanup so a rerun with cleanup=True removes
+    # leftover .pre-migration backups on instances whose migration already
+    # completed (the whole point of the standalone cleanup path). The endpoint
+    # self-guards and no-ops when there is nothing to clean.
+    result = {"instance_id": instance_id, "status": "no_migration_pending"}
+    if cleanup:
+      result["cleanup"] = await client.migration_cleanup()
+    return result
 
   start = time.time()
   import_response = await client.migration_import()
@@ -197,6 +212,27 @@ async def _import_instance(
     "status": "success",
     "duration_seconds": round(duration, 1),
     **result_data,
+  }
+
+
+async def _cleanup_instance(instance_id: str, ip: str) -> dict[str, Any]:
+  """Delete .pre-migration backup files on a single instance. Returns result dict.
+
+  Idempotent: the /migration/cleanup endpoint refuses while a migration is in
+  progress or migration.json still exists, and no-ops when there are no
+  .pre-migration files to remove.
+  """
+  start = time.time()
+  client = await _get_client(ip)
+
+  cleanup_result = await client.migration_cleanup()
+  duration = time.time() - start
+
+  return {
+    "instance_id": instance_id,
+    "status": "success",
+    "duration_seconds": round(duration, 1),
+    "cleanup": cleanup_result,
   }
 
 
@@ -363,6 +399,77 @@ def import_all_instances(
   }
 
 
+@op
+def cleanup_all_instances(
+  context: OpExecutionContext, config: MigrationCleanupConfig
+) -> dict:
+  """Delete .pre-migration rollback backups on each writer instance.
+
+  Standalone teardown to run AFTER a migration is verified good. The import
+  job's cleanup only fires on instances that still had a pending migration, so
+  once migration.json is gone the backups linger; this reclaims them fleet-wide.
+  All instances are cleaned in parallel; each is idempotent (no-op when there is
+  nothing to clean).
+
+  Set include_shared_master=true to also clean a shared master (it must be awake
+  for its volume to be attached — e.g. run this inside a wake window).
+  """
+  instances = _get_writer_instances(context, config.include_shared_master)
+
+  # Separate skipped from active
+  active = []
+  results = []
+  for inst in instances:
+    instance_id = inst.get("instance_id", "unknown")
+    if instance_id in config.skip_instances:
+      context.log.info(f"Skipping instance {instance_id}")
+      results.append({"instance_id": instance_id, "status": "skipped"})
+    else:
+      active.append(inst)
+
+  if active:
+    context.log.info(f"Cleaning up {len(active)} instances in parallel")
+
+    coros = [
+      _cleanup_instance(
+        inst.get("instance_id", "unknown"),
+        inst.get("private_ip", "localhost"),
+      )
+      for inst in active
+    ]
+    instance_ids = [inst.get("instance_id", "unknown") for inst in active]
+
+    parallel_results = asyncio.run(_run_parallel(coros, instance_ids))
+    results.extend(parallel_results)
+
+  # Log results
+  for r in results:
+    if r["status"] == "success":
+      context.log.info(
+        f"  {r['instance_id']}: cleanup {r.get('cleanup', {})} "
+        f"in {r.get('duration_seconds', '?')}s"
+      )
+    elif r["status"] == "failed":
+      context.log.error(f"  {r['instance_id']}: {r.get('error', 'unknown error')}")
+
+  succeeded = sum(1 for r in results if r["status"] == "success")
+  failed = sum(1 for r in results if r["status"] == "failed")
+  skipped = sum(1 for r in results if r["status"] == "skipped")
+
+  context.log.info(
+    f"Cleanup complete: {succeeded} succeeded, {failed} failed, {skipped} skipped"
+  )
+
+  if failed > 0:
+    errors = [r["error"] for r in results if r["status"] == "failed"]
+    raise RuntimeError(f"Cleanup failed on {failed} instance(s): {'; '.join(errors)}")
+
+  return {
+    "instances": results,
+    "summary": {"succeeded": succeeded, "failed": failed, "skipped": skipped},
+  }
+
+
 @job(tags={"dagster/priority": "1"})
 def ladybug_migration_export_job():
   """Export all databases on writer instances for version migration.
@@ -379,3 +486,15 @@ def ladybug_migration_import_job():
   Run AFTER deploying the new LadybugDB version.
   """
   import_all_instances()
+
+
+@job(tags={"dagster/priority": "1"})
+def ladybug_migration_cleanup_job():
+  """Delete .pre-migration rollback backups on writer instances.
+
+  Run AFTER a migration is verified good, to reclaim the backup space. Safe to
+  run anytime — idempotent and a no-op where there is nothing to clean. This is
+  the standalone teardown; the import job only cleans instances that still had a
+  pending migration.
+  """
+  cleanup_all_instances()

--- a/tests/dagster/test_migration_jobs.py
+++ b/tests/dagster/test_migration_jobs.py
@@ -1,0 +1,144 @@
+"""Tests for the LadybugDB migration jobs — cleanup job + import cleanup gate."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from dagster import JobDefinition, build_op_context
+
+from robosystems.dagster.jobs.migration import (
+  MigrationCleanupConfig,
+  MigrationImportConfig,
+  _cleanup_instance,
+  _import_instance,
+  cleanup_all_instances,
+  ladybug_migration_cleanup_job,
+)
+
+MIGRATION = "robosystems.dagster.jobs.migration"
+
+
+def _fake_client(**methods):
+  client = MagicMock()
+  for name, retval in methods.items():
+    setattr(client, name, AsyncMock(return_value=retval))
+  return client
+
+
+class TestCleanupJobDefinition:
+  @pytest.mark.unit
+  def test_job_is_defined_with_single_op(self):
+    assert isinstance(ladybug_migration_cleanup_job, JobDefinition)
+    op_names = {op.name for op in ladybug_migration_cleanup_job.all_node_defs}
+    assert op_names == {"cleanup_all_instances"}
+
+  @pytest.mark.unit
+  def test_job_priority_tag(self):
+    assert ladybug_migration_cleanup_job.tags.get("dagster/priority") == "1"
+
+  @pytest.mark.unit
+  def test_registered_in_definitions(self):
+    from robosystems.dagster.definitions import all_jobs
+
+    assert ladybug_migration_cleanup_job in all_jobs
+
+
+class TestCleanupInstance:
+  @pytest.mark.unit
+  async def test_calls_migration_cleanup(self):
+    client = _fake_client(migration_cleanup={"removed_files": 3})
+    with patch(f"{MIGRATION}._get_client", new=AsyncMock(return_value=client)):
+      result = await _cleanup_instance("i-1", "10.0.0.1")
+
+    client.migration_cleanup.assert_awaited_once()
+    assert result["instance_id"] == "i-1"
+    assert result["status"] == "success"
+    assert result["cleanup"] == {"removed_files": 3}
+
+
+class TestImportCleanupGate:
+  """The A-fix: cleanup=True must fire even when no migration is pending."""
+
+  @pytest.mark.unit
+  async def test_cleanup_runs_when_not_pending(self):
+    client = _fake_client(
+      migration_status={"migration_pending": False},
+      migration_cleanup={"removed_files": 2},
+    )
+    with patch(f"{MIGRATION}._get_client", new=AsyncMock(return_value=client)):
+      result = await _import_instance("i-1", "10.0.0.1", cleanup=True)
+
+    client.migration_cleanup.assert_awaited_once()
+    assert result["status"] == "no_migration_pending"
+    assert result["cleanup"] == {"removed_files": 2}
+
+  @pytest.mark.unit
+  async def test_no_cleanup_when_not_pending_and_flag_off(self):
+    client = _fake_client(
+      migration_status={"migration_pending": False},
+      migration_cleanup={"removed_files": 0},
+    )
+    with patch(f"{MIGRATION}._get_client", new=AsyncMock(return_value=client)):
+      result = await _import_instance("i-1", "10.0.0.1", cleanup=False)
+
+    client.migration_cleanup.assert_not_awaited()
+    assert result["status"] == "no_migration_pending"
+    assert "cleanup" not in result
+
+
+class TestCleanupAllInstancesOp:
+  @pytest.mark.unit
+  def test_fans_out_over_writers(self):
+    instances = [
+      {"instance_id": "i-1", "private_ip": "10.0.0.1", "node_type": "shared_master"},
+      {"instance_id": "i-2", "private_ip": "10.0.0.2", "node_type": "standard"},
+    ]
+    client = _fake_client(migration_cleanup={"removed_files": 1})
+    with (
+      patch(f"{MIGRATION}._get_writer_instances", return_value=instances),
+      patch(f"{MIGRATION}._get_client", new=AsyncMock(return_value=client)),
+    ):
+      out = cleanup_all_instances(
+        build_op_context(), MigrationCleanupConfig(include_shared_master=True)
+      )
+
+    assert out["summary"] == {"succeeded": 2, "failed": 0, "skipped": 0}
+    assert client.migration_cleanup.await_count == 2
+
+  @pytest.mark.unit
+  def test_skips_listed_instances(self):
+    instances = [
+      {"instance_id": "i-1", "private_ip": "10.0.0.1", "node_type": "standard"},
+      {"instance_id": "i-2", "private_ip": "10.0.0.2", "node_type": "standard"},
+    ]
+    client = _fake_client(migration_cleanup={"removed_files": 0})
+    with (
+      patch(f"{MIGRATION}._get_writer_instances", return_value=instances),
+      patch(f"{MIGRATION}._get_client", new=AsyncMock(return_value=client)),
+    ):
+      out = cleanup_all_instances(
+        build_op_context(), MigrationCleanupConfig(skip_instances=["i-1"])
+      )
+
+    assert out["summary"]["skipped"] == 1
+    assert out["summary"]["succeeded"] == 1
+    assert client.migration_cleanup.await_count == 1
+
+  @pytest.mark.unit
+  def test_raises_on_instance_failure(self):
+    instances = [
+      {"instance_id": "i-1", "private_ip": "10.0.0.1", "node_type": "standard"},
+    ]
+    client = MagicMock()
+    client.migration_cleanup = AsyncMock(side_effect=RuntimeError("boom"))
+    with (
+      patch(f"{MIGRATION}._get_writer_instances", return_value=instances),
+      patch(f"{MIGRATION}._get_client", new=AsyncMock(return_value=client)),
+    ):
+      with pytest.raises(RuntimeError, match="Cleanup failed on 1 instance"):
+        cleanup_all_instances(build_op_context(), MigrationCleanupConfig())
+
+
+@pytest.mark.unit
+def test_import_config_still_has_cleanup_flag():
+  """The import job keeps its cleanup flag (A-fix is behavioral, not schema)."""
+  assert MigrationImportConfig().cleanup is False


### PR DESCRIPTION
## Summary

Adds a **standalone Dagster job to tear down LadybugDB `.pre-migration` rollback backups** after an engine migration, and fixes the import op so its `cleanup` flag actually works post-migration. Both are manually-triggered, one-off jobs alongside the existing export/import migration jobs.

## Problem

After a LadybugDB engine migration (e.g. the 0.13→0.18.1 upgrade), each writer keeps a `.pre-migration` backup for rollback safety. The only way to remove them was re-running the import job with `cleanup: true` — but `_import_instance` early-returns `no_migration_pending` (once `migration.json` is gone) **before** its cleanup block, so that rerun is a no-op and the backups linger fleet-wide. The working teardown path (`POST /migration/cleanup`) had no orchestration.

## Changes

- **`robosystems/dagster/jobs/migration.py`**
  - New `ladybug_migration_cleanup_job` + `cleanup_all_instances` op + `_cleanup_instance` helper — fans out over `_get_writer_instances(...)` calling `POST /migration/cleanup` per writer in parallel, mirroring the export/import ops. `MigrationCleanupConfig` exposes `skip_instances` and `include_shared_master`.
  - Idempotent: the `/cleanup` endpoint self-guards (refuses while a migration is in progress or `migration.json` still exists) and no-ops when there are no `.pre-migration` files.
  - Fixed `_import_instance` to honor `cleanup=True` even when no migration is pending, so an import rerun with cleanup on still reclaims backups.
- **`robosystems/dagster/definitions.py`** — registered the cleanup job.
- **`tests/dagster/test_migration_jobs.py`** — unit tests for the op fan-out, the import cleanup gate (fires when not pending / not when the flag is off), skip handling, and failure aggregation.

## How to run

One-off in the Dagster UI, like the export/import jobs:

```yaml
ops:
  cleanup_all_instances:
    config:
      include_shared_master: false   # continuously-running writers
      skip_instances: []
```

Run with `include_shared_master: false` to clean the tenant writer tiers; run again with `include_shared_master: true` **while the SEC shared master is awake** (its volume must be attached) to clean it too.

## Testing

- `just test-code` (ruff + format + basedpyright + cf-lint): **passed** (0 errors).
- Logic verified against real Dagster + mocked graph clients (op fan-out, import cleanup gate, skip handling, failure aggregation all pass).
- The `tests/dagster/` suite needs the local Postgres stack (autouse DB fixture), which wasn't running in this session — it runs in CI. Full `just test-all` unit suite: **not run** locally.

## Notes

- Behavior-only change to the migration flow; no schema/config removals. Manually triggered — no schedule/sensor, so zero effect until run.
