### PR TITLE
fix(replicas): route shared-replica ALB by least-outstanding-requests

### DIFF
--- a/cloudformation/graph-ladybug-replicas.yaml
+++ b/cloudformation/graph-ladybug-replicas.yaml
@@ -657,6 +657,14 @@ Resources:
       HealthCheckTimeoutSeconds: 10
       HealthyThresholdCount: 2
       UnhealthyThresholdCount: 3
+      TargetGroupAttributes:
+        # Prefer the least-busy replica over round-robin. Round-robin spreads
+        # requests evenly regardless of how loaded each replica already is, so a
+        # replica handling a heavier workload keeps getting its full share;
+        # least_outstanding_requests biases new requests toward replicas with
+        # fewer in-flight requests. Applied in place - no instance cycling.
+        - Key: load_balancing.algorithm.type
+          Value: least_outstanding_requests
       Tags:
         - Key: Environment
           Value: !Ref Environment


### PR DESCRIPTION
Switch the shared-replica target group from the default round-robin to `least_outstanding_requests`, so new requests prefer the replica with the fewest in-flight requests instead of being spread evenly regardless of per-replica load.

Applied in place via `TargetGroupAttributes` — the stack update does not cycle the ASG or reload replica data.

## Test plan
- `cfn-lint` + `aws cloudformation validate-template` pass
- Deploy via the graph/replicas GitHub Actions pipeline; confirm the target group's routing algorithm is `least_outstanding_requests` and replicas stay in service (no ASG cycle)