### PR TITLE
fix(backup): bundle zstd in image for R2 compressed publish

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -132,6 +132,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
     postgresql-client \
     curl \
     git \
+    zstd \
     && rm -rf /var/lib/apt/lists/* \
     && curl -LsSf https://astral.sh/uv/install.sh | sh \
     && mv /root/.local/bin/uv /usr/local/bin/uv

--- a/robosystems/graph_api/core/backup_service.py
+++ b/robosystems/graph_api/core/backup_service.py
@@ -313,7 +313,7 @@ class OnInstanceBackupService:
   ) -> dict[str, Any]:
     """Compress database with zstd and upload to R2.
 
-    Uses the system zstd binary (pre-installed on Amazon Linux 2023) with
+    Uses the zstd binary bundled in the graph_api container image with
     multithreading for maximum throughput on ARM64 (r7g) instances.
     Temp file is written to EBS-backed directory, not /tmp (RAM-backed).
 


### PR DESCRIPTION
## Summary

The `sec_lbug_r2_publish` Dagster job fails in prod with `FileNotFoundError: [Errno 2] No such file or directory: 'zstd'`. R2 publish is the only backup path that compresses, and it shells out to the `zstd` CLI — which was never installed in the graph_api container image. This bundles `zstd` in the runtime image so the compressed R2 publish can run.

## Changes

- **`Dockerfile`** — add `zstd` to the runtime-stage apt install list. `backup_service._compress_and_upload_replica` runs `zstd -T0 --long -12` via `subprocess.run`, but the `python:3.13-slim` runtime only had `libpq5 libatomic1 postgresql-client curl git`, so the binary was missing on PATH.
- **`robosystems/graph_api/core/backup_service.py`** — correct the stale docstring that claimed zstd was "pre-installed on Amazon Linux 2023" (the runtime is a Debian slim container, and it was never installed there either).

## Context

R2 compression shipped in an earlier commit assuming the `zstd` binary was present; `git log -S zstd -- Dockerfile` confirms it was never added to any image build, so this R2 publish path has never succeeded in prod. S3 publish and replica downloads are unaffected — they use `compression=False` and transfer the raw `.lbug`, so they never needed `zstd`.

## Testing

- `just format` / `just lint` / `just typecheck` — passed (ran via pre-commit hook on this branch).
- Full `just test-all` unit suite — not run (no runtime effect; changes are a Dockerfile dependency and a comment).

## Follow-ups (deploy, not code)

- Deploy the new image, then **ASG-refresh the shared-master graph instance** so it pulls the image with `zstd` (ECR image change, no CloudFormation template change → won't auto-cycle).
- Re-run `sec_lbug_r2_publish` from the Dagster UI to verify.
