### PR TITLE
chore(backup): raise R2 zstd level 12->15 for smaller subscriber download

### DIFF
--- a/robosystems/graph_api/core/backup_service.py
+++ b/robosystems/graph_api/core/backup_service.py
@@ -317,8 +317,13 @@ class OnInstanceBackupService:
     multithreading for maximum throughput on ARM64 (r7g) instances.
     Temp file is written to EBS-backed directory, not /tmp (RAM-backed).
 
-    Compression level 12 with --long (128MB window) is chosen because
-    CPU time is cheap relative to data transfer costs ($0.135/GB through NAT).
+    Level 15 with --long (128MB window) balances egress savings against
+    compress wall-time. The export instance is spun up per-publish and
+    billed for the compression, so higher levels (19+) roughly break even
+    at this file's low (~2.2x) compressibility -- the extra instance-time
+    cancels the egress they save. The window stays at 128MB so subscribers
+    decompress with a plain `zstd -d`; a larger --long window would force a
+    matching `--long` flag on their side for an unmeasured ratio gain.
     """
     logger.info(f"[Task {task_id}] Compressing {db_path.name} with zstd before upload")
 
@@ -334,11 +339,11 @@ class OnInstanceBackupService:
       temp_path = Path(temp_dir)
       compressed_file = temp_path / f"{db_path.stem}.lbug.zst"
 
-      # zstd -T0 (all cores), --long (128MB window), -12 (high compression)
+      # zstd -T0 (all cores), --long (128MB window), -15 (see docstring for level rationale)
       compress_start = datetime.now(UTC)
       try:
         subprocess.run(
-          ["zstd", "-T0", "--long", "-12", str(db_path), "-o", str(compressed_file)],
+          ["zstd", "-T0", "--long", "-15", str(db_path), "-o", str(compressed_file)],
           check=True,
           capture_output=True,
           text=True,


### PR DESCRIPTION
## Summary

Raises the R2 subscriber-download compression from zstd `-12` to `-15` to shrink the published `.lbug.zst`, trading a small amount of one-time compress time for lower per-publish egress. Window and thread flags are unchanged.

## Change

- `robosystems/graph_api/core/backup_service.py` — `zstd -T0 --long -12` → `-15` in `_compress_and_upload_replica`, plus the docstring/rationale (the old comment claimed "CPU time is cheap," which isn't true for this instance — see below).

## Why `-15`, and why not higher

The R2 publish compresses the shared `.lbug` once per publish on the SEC shared-master (`r7g.2xlarge`), which is **spun up for the export and shut down after** — so compression wall-time is real, billed instance-time, not a sunk cost. The tradeoff is instance-hours vs. egress GB:

- **Instance:** r7g.2xlarge on-demand ≈ $0.43/hr
- **Egress:** EC2→R2 ≈ $0.135/GB (NAT)
- **Breakeven:** a higher level pays off only if it saves >~3.2 GB per added hour of compute.

Measured baseline on the real prod file (66.68 GiB local copy): `-12 --long` = **45.57% of raw** — i.e. the `.lbug` is only ~2.2× compressible (already densely encoded columnar data), so higher levels are fighting for scraps. At that compressibility, `-19`/`-22` are ~4–5× slower for ~1–3 more points of ratio, so the extra instance-time roughly cancels the egress they save. `-15` sits at the knee: it grabs the cheap ratio gains over `-12` with a small time penalty, staying clearly net-positive.

The `--long` window is deliberately left at 128 MB (the current default): a larger window could catch long-range redundancy, but it would force every subscriber to decompress with a matching `zstd -d --long=N` flag (default `zstd -d` caps at a 128 MB window), and we have no measurement showing the bigger window actually helps this data. Not worth breaking plain-`zstd -d` decompression for an unmeasured gain.

## Testing

- Pre-commit hooks (ruff / format / basedpyright) — passed.
- Benchmark: the `-12` baseline (45.57%) was measured on the real prod `sec.lbug`; the higher-level comparison runs were aborted to free the dev machine, so `-15` is chosen from the cost model above rather than a completed full sweep. The change is a single zstd argument with identical decompression semantics, so behavior risk is minimal.
- Full unit suite — not run (no runtime logic change).

## Follow-ups (deploy)

- Deploy, then ASG-refresh / re-launch the shared-master so it picks up the new image, and re-run `sec_lbug_r2_publish`.
- The publish log already prints the achieved ratio (`zstd compression complete: X GB -> Y GB (Z%)`) — worth a glance on the first run to confirm `-15`'s real-world ratio and compress time before deciding whether any further tuning is even worth it.
