### PR TITLE
chore(graph): default SEC replicas to moving tag, pin only for storage upgrades

### DIFF
--- a/.github/workflows/deploy-graph.yml
+++ b/.github/workflows/deploy-graph.yml
@@ -54,7 +54,7 @@ on:
         required: false
         type: string
         default: ""
-        description: "ECR image tag for the SEC shared replicas only. Callers pass the specific build git tag (like the ECS services) so replicas are pinned to an exact version and don't drift to the moving tag on scale/spot/health boots — keeping the replica engine matched to the S3 sec.lbug it downloads. Empty falls back to ecr_image_tag (writers/master keep the moving tag)."
+        description: "Optional pin for the SEC shared replicas ONLY. Empty (default) → falls back to ecr_image_tag (the moving prod/staging tag), so ECRImageTag stays constant across deploys and CloudFormation does not cycle the replica fleet — the daily shared_replicas_refresh is the only routine boot. Set to a specific build git tag ONLY during a storage-format-breaking engine upgrade, so a scale/spot/health boot can't pull a new engine before the new-format sec.lbug is published; clear it once the fleet is on the new engine. Driven via SHARED_REPLICA_IMAGE_TAG_{PROD,STAGING} vars. See runbooks/sec-reprocessing.md."
       # Infrastructure inputs (from graph infrastructure deployment)
       secret_arn:
         required: true

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -478,12 +478,15 @@ jobs:
       ami_id: ${{ needs.stack-config.outputs.graph_ami_id }}
       # Container Configuration - use prod tag for EC2/ASG (container refresh handles updates)
       ecr_image_tag: prod
-      # SEC shared replicas: pin to this build's exact git tag (like the ECS
-      # services), not the moving prod tag, so a scale/spot/health boot pulls a
-      # fixed version instead of drifting ahead of the S3 sec.lbug it reads. For
-      # an engine upgrade, hold the replicas by not redeploying them until the
-      # new sec.lbug is published, then deploy them forward.
-      shared_replica_image_tag: ${{ needs.build.outputs.image_tag }}
+      # SEC shared replicas track the moving prod tag by default (no per-deploy
+      # ECRImageTag change → CloudFormation doesn't cycle the fleet; the daily
+      # shared_replicas_refresh is the only routine boot). Leave
+      # shared_replica_image_tag unset for that. Pin it ONLY during a
+      # storage-format-breaking engine upgrade, so a boot can't pull a new engine
+      # before the new-format sec.lbug is published — set a
+      # SHARED_REPLICA_IMAGE_TAG_PROD var for the migration window, then clear it.
+      # See runbooks/sec-reprocessing.md §"storage-format engine upgrade".
+      shared_replica_image_tag: ${{ vars.SHARED_REPLICA_IMAGE_TAG_PROD || '' }}
       # Infrastructure inputs from graph infrastructure jobs
       secret_arn: ${{ needs.deploy-graph-infra.outputs.secret_arn }}
       volume_registry_table: ${{ needs.deploy-graph-infra.outputs.volume_registry_table }}

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -495,12 +495,15 @@ jobs:
       ami_id: ${{ needs.stack-config.outputs.graph_ami_id }}
       # Container Configuration - use staging tag for EC2/ASG (container refresh handles updates)
       ecr_image_tag: staging
-      # SEC shared replicas: pin to this build's exact git tag (like the ECS
-      # services), not the moving staging tag, so a scale/spot/health boot pulls
-      # a fixed version instead of drifting ahead of the S3 sec.lbug it reads. For
-      # an engine upgrade, hold the replicas by not redeploying them until the
-      # new sec.lbug is published, then deploy them forward.
-      shared_replica_image_tag: ${{ needs.build.outputs.image_tag }}
+      # SEC shared replicas track the moving staging tag by default (no per-deploy
+      # ECRImageTag change → CloudFormation doesn't cycle the fleet; the daily
+      # shared_replicas_refresh is the only routine boot). Leave
+      # shared_replica_image_tag unset for that. Pin it ONLY during a
+      # storage-format-breaking engine upgrade, so a boot can't pull a new engine
+      # before the new-format sec.lbug is published — set a
+      # SHARED_REPLICA_IMAGE_TAG_STAGING var for the migration window, then clear it.
+      # See runbooks/sec-reprocessing.md §"storage-format engine upgrade".
+      shared_replica_image_tag: ${{ vars.SHARED_REPLICA_IMAGE_TAG_STAGING || '' }}
       # Infrastructure inputs from graph infrastructure jobs
       secret_arn: ${{ needs.deploy-graph-infra.outputs.secret_arn }}
       volume_registry_table: ${{ needs.deploy-graph-infra.outputs.volume_registry_table }}


### PR DESCRIPTION
## Summary

The SEC shared-replica fleet was pinned to each build's git tag (`shared_replica_image_tag: ${{ needs.build.outputs.image_tag }}`), so every deploy changed the CloudFormation `ECRImageTag` launch-template property and CloudFormation cycled the whole fleet — on top of the daily `shared_replicas_refresh`. That's the churn we want to avoid.

The pin's only real value is across a **storage-format-breaking** engine upgrade (0.13→0.18, storage v42), where a fresh replica boot could pull a new engine against an old-format `sec.lbug`. In steady state — any storage-compatible engine bump — a newer engine reads the same-format file fine, so the moving tag is safe.

## Changes

- **`prod.yml` / `staging.yml`** — callers now pass `shared_replica_image_tag: ${{ vars.SHARED_REPLICA_IMAGE_TAG_{PROD,STAGING} || '' }}`. Empty by default → falls back to the moving `prod`/`staging` tag → `ECRImageTag` is constant across deploys → CloudFormation no longer cycles the replica fleet.
- **`deploy-graph.yml`** — keeps the optional `shared_replica_image_tag` input + `|| ecr_image_tag` fallback as a dormant lever; description rewritten to the pin-only-during-storage-upgrade model.

The migration lever is now a GHA var (`SHARED_REPLICA_IMAGE_TAG_{PROD,STAGING}`) rather than a hard-coded caller expression: pin via `just gha-set …` + deploy, clear when the fleet is across the boundary. This replaces the console-edit + `SHARED_REPLICAS_ENABLED=false` approach, which a routine deploy silently reverted to `prod`. The storage-upgrade coordination sequence is documented in the `sec-reprocessing` runbook.

## Deploy note

The **first prod deploy after merge cycles the replicas once** (flips `ECRImageTag` from the git tag back to `prod` — a one-time launch-template change). After that, deploys leave the fleet alone; only the daily refresh cycles it.