### PR TITLE
fix(schedule): carry roll-forward opening balance into envelope

### DIFF
--- a/robosystems/operations/information_block/schedule.py
+++ b/robosystems/operations/information_block/schedule.py
@@ -18,6 +18,8 @@ mode.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
@@ -145,6 +147,22 @@ def _load_schedule_mechanics(
   )
 
 
+def _latest_instant_per_element(facts: Sequence[Fact]) -> list[Fact]:
+  """Keep only the most recent instant fact per element (max ``period_end``).
+
+  Used to pick a roll-forward's carry-in opening balances: among the prior
+  closed periods' ending running-balance instants, only the latest per
+  element is the current window's beginning balance — earlier ones are
+  superseded interior balances and would double up the series.
+  """
+  latest: dict[str, Fact] = {}
+  for fact in facts:
+    current = latest.get(fact.element_id)
+    if current is None or fact.period_end > current.period_end:
+      latest[fact.element_id] = fact
+  return list(latest.values())
+
+
 def build_envelope(
   session: Session, structure_id: str, fact_set_id: str | None = None
 ) -> InformationBlockEnvelope | None:
@@ -201,7 +219,34 @@ def build_envelope(
   ]
   if fact_set_id is not None:
     fact_filters.append(Fact.fact_set_id == fact_set_id)
-  facts = session.execute(select(Fact).where(*fact_filters)).scalars().all()
+  facts = list(session.execute(select(Fact).where(*fact_filters)).scalars().all())
+
+  # Roll-forward carry-in opening balance. A roll_forward series must open
+  # with a valid Beginning Balance, but the first in-scope period's opening
+  # balance *is* the immediately prior (now-closed) period's ending running
+  # balance — an `instant` fact tagged `historical` and thus dropped by the
+  # in_scope filter above. Without it the series arrives as movements + an
+  # ending balance with no beginning. Re-include just the latest historical
+  # `instant` per in-scope balance element (the carry-in balance); historical
+  # `duration` movements stay excluded, so agents still can't re-draft closed
+  # work. Skipped on the FactSet-pinned path (the frozen snapshot is already
+  # self-contained) and when there are no in-scope facts to open.
+  if facts and fact_set_id is None:
+    balance_element_ids = {f.element_id for f in facts if f.period_type == "instant"}
+    if balance_element_ids:
+      historical_instants = (
+        session.execute(
+          select(Fact).where(
+            Fact.structure_id == structure_id,
+            Fact.fact_scope == "historical",
+            Fact.period_type == "instant",
+            Fact.element_id.in_(balance_element_ids),
+          )
+        )
+        .scalars()
+        .all()
+      )
+      facts.extend(_latest_instant_per_element(historical_instants))
 
   # Schedules are tenant-authored; they never have a disclosure mapping.
   # Short-circuit the DB roundtrip — saves a query per envelope on a

--- a/tests/operations/information_block/test_schedule_handlers.py
+++ b/tests/operations/information_block/test_schedule_handlers.py
@@ -8,6 +8,7 @@ with a mocked SQLAlchemy session.
 from __future__ import annotations
 
 from datetime import date
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -32,6 +33,30 @@ def _exec_result(
     result.scalars.return_value.all.return_value = scalars_all
   result.scalar.return_value = scalar
   return result
+
+
+def _fact(
+  fact_id: str,
+  element_id: str,
+  value: float,
+  *,
+  period_type: str,
+  period_end: date,
+  period_start: date | None = None,
+  fact_scope: str = "in_scope",
+) -> SimpleNamespace:
+  """A minimal Fact-like stub with the attributes ``fact_to_lite`` reads."""
+  return SimpleNamespace(
+    id=fact_id,
+    element_id=element_id,
+    value=value,
+    period_start=period_start,
+    period_end=period_end,
+    period_type=period_type,
+    unit="USD",
+    fact_scope=fact_scope,
+    fact_set_id="fs_01",
+  )
 
 
 def _body() -> CreateScheduleRequest:
@@ -327,3 +352,138 @@ class TestBuildEnvelope:
     # Sanity check: BinaryExpression import is exercised so we don't
     # silently lose the type if the SQLAlchemy WHERE shape changes.
     del BinaryExpression
+
+    # The pin path is self-contained — no carry-in query is issued (only
+    # the 7 base + facts calls; no 8th historical-instant lookup).
+    assert len(session.execute.call_args_list) == 7
+
+  def test_carry_in_reincludes_prior_period_ending_balance(self) -> None:
+    """The first open period's beginning balance = the prior closed
+    period's ending running-balance instant, which the in_scope filter
+    drops as historical. build_envelope must re-include the latest
+    historical instant per in-scope balance element so the roll-forward
+    opens with a valid Beginning Balance — and only the latest one, not
+    every superseded interior balance."""
+    session = MagicMock()
+    structure = MagicMock()
+    structure.id = "struct_dep"
+    structure.block_type = "schedule"
+    structure.name = "Prepaid Amortization"
+    structure.description = None
+    structure.taxonomy_id = "tax_01"
+    structure.concept_arrangement = "roll_forward"
+    structure.member_arrangement = None
+    structure.renderer_note = None
+    structure.artifact_mechanics = {
+      "kind": "closing_entry_generator",
+      "entry_template": {
+        "debit_element_id": "elem_exp",
+        "credit_element_id": "elem_prepaid",
+      },
+    }
+    structure.metadata_ = {}
+    session.get.return_value = structure
+
+    # In-scope window: one movement (duration) + one ending balance (instant)
+    # on the running-balance element.
+    in_scope_instant = _fact(
+      "f_jun_bal",
+      "elem_prepaid",
+      33.96,
+      period_type="instant",
+      period_end=date(2026, 6, 30),
+    )
+    in_scope_movement = _fact(
+      "f_jun_mov",
+      "elem_exp",
+      2.83,
+      period_type="duration",
+      period_start=date(2026, 6, 1),
+      period_end=date(2026, 6, 30),
+    )
+    # Historical instants on the same balance element: an old interior
+    # balance and the immediately-prior (May) ending balance = carry-in.
+    hist_old = _fact(
+      "f_apr_bal",
+      "elem_prepaid",
+      39.62,
+      period_type="instant",
+      period_end=date(2026, 4, 30),
+      fact_scope="historical",
+    )
+    hist_boundary = _fact(
+      "f_may_bal",
+      "elem_prepaid",
+      36.79,
+      period_type="instant",
+      period_end=date(2026, 5, 31),
+      fact_scope="historical",
+    )
+
+    session.execute.side_effect = [
+      _exec_result(scalar=None),  # latest fact set → None
+      _exec_result(scalar="US GAAP"),  # taxonomy name
+      _exec_result(scalars_all=[]),  # associations
+      _exec_result(scalars_all=[]),  # rules
+      _exec_result(scalars_all=[]),  # verification results
+      _exec_result(scalar=0),  # periods_with_entries
+      _exec_result(scalars_all=[in_scope_instant, in_scope_movement]),  # in-scope
+      _exec_result(scalars_all=[hist_old, hist_boundary]),  # carry-in candidates
+    ]
+
+    envelope = schedule_handlers.build_envelope(session, "struct_dep")
+    assert envelope is not None
+
+    # The carry-in query targets historical instants on the in-scope
+    # balance element(s).
+    carry_in_query = session.execute.call_args_list[7].args[0]
+    where_clause = str(carry_in_query.compile(compile_kwargs={"literal_binds": True}))
+    assert "fact_scope = 'historical'" in where_clause
+    assert "period_type = 'instant'" in where_clause
+    assert "elem_prepaid" in where_clause
+
+    # Envelope carries the 2 in-scope facts + the boundary carry-in only —
+    # the superseded April balance is dropped.
+    fact_ids = {f.id for f in envelope.facts}
+    assert fact_ids == {"f_jun_bal", "f_jun_mov", "f_may_bal"}
+    carry_in = next(f for f in envelope.facts if f.id == "f_may_bal")
+    assert carry_in.fact_scope == "historical"
+    assert carry_in.value == 36.79
+
+  def test_no_carry_in_when_schedule_has_no_in_scope_facts(self) -> None:
+    """A fully-closed schedule (no in-scope facts) issues no carry-in
+    query — there's no open window to give a beginning balance to."""
+    session = MagicMock()
+    structure = MagicMock()
+    structure.id = "struct_closed"
+    structure.block_type = "schedule"
+    structure.name = "Closed Schedule"
+    structure.description = None
+    structure.taxonomy_id = "tax_01"
+    structure.concept_arrangement = "roll_forward"
+    structure.member_arrangement = None
+    structure.renderer_note = None
+    structure.artifact_mechanics = {
+      "kind": "closing_entry_generator",
+      "entry_template": {
+        "debit_element_id": "elem_exp",
+        "credit_element_id": "elem_prepaid",
+      },
+    }
+    structure.metadata_ = {}
+    session.get.return_value = structure
+    session.execute.side_effect = [
+      _exec_result(scalar=None),  # latest fact set → None
+      _exec_result(scalar="US GAAP"),  # taxonomy name
+      _exec_result(scalars_all=[]),  # associations
+      _exec_result(scalars_all=[]),  # rules
+      _exec_result(scalars_all=[]),  # verification results
+      _exec_result(scalar=0),  # periods_with_entries
+      _exec_result(scalars_all=[]),  # facts (empty — fully closed)
+    ]
+
+    envelope = schedule_handlers.build_envelope(session, "struct_closed")
+    assert envelope is not None
+    assert envelope.facts == []
+    # No 8th (carry-in) query.
+    assert len(session.execute.call_args_list) == 7


### PR DESCRIPTION
## Summary

A roll-forward schedule must open with a valid Beginning Balance, but the close-book schedule envelope was arriving with none — only the current month's movement and ending balance. This fixes the root cause: `build_envelope` was filtering the schedule's facts to `fact_scope == "in_scope"` only, which drops the prior (now-closed) period's ending running-balance instant — and that instant *is* the first open period's opening balance.

## Changes

- **`robosystems/operations/information_block/schedule.py`**
  - After the in-scope fact load, re-include the **latest `historical` `instant` per in-scope balance element** — the carry-in opening balance. Historical `duration` movements stay excluded, so agents still can't re-draft closed work.
  - The carry-in query is skipped on the FactSet-pinned rehydration path (the frozen snapshot is already self-contained) and when there are no in-scope facts to open.
  - Added a small pure helper `_latest_instant_per_element` (keeps only the most-recent instant per element) so only the true boundary balance is carried in, not superseded interior balances.
- **`tests/operations/information_block/test_schedule_handlers.py`**
  - `test_carry_in_reincludes_prior_period_ending_balance` — the carry-in query targets historical instants on the in-scope balance element(s), and the envelope includes only the boundary balance (superseded interior balances dropped).
  - `test_no_carry_in_when_schedule_has_no_in_scope_facts` — a fully-closed schedule issues no carry-in query.

## Behavior / compatibility

Purely additive to the returned `facts` list — no schema, pydantic model, or GraphQL type changed (`FactLite.fact_scope` already carried `historical | in_scope`). **No SDK regeneration or version bump required.** The paired frontend change (roboledger-app) reconstructs Beginning → Movement → Ending from these facts and degrades gracefully until this ships.

## Testing

- `just test operations/information_block/test_schedule_handlers.py` — 11 passed (incl. 2 new)
- `just test operations/information_block` — 212 passed
- `just typecheck` — 0 errors; `just lint` — All checks passed
