### PR TITLE
fix(rules): validate RollUp against live calc arcs, not frozen enumeration

### DIFF
--- a/robosystems/operations/information_block/rules/engine.py
+++ b/robosystems/operations/information_block/rules/engine.py
@@ -35,6 +35,7 @@ One query per variable (N+1 is fine for 3-5 variables per rule).
 from __future__ import annotations
 
 from datetime import date
+from typing import Any
 
 from sqlalchemy import select, text
 from sqlalchemy.orm import Session
@@ -51,6 +52,9 @@ from robosystems.operations.information_block.envelope import load_rules_for_str
 from robosystems.operations.information_block.rules.evaluators import (
   EvaluationOutcome,
   evaluate_rule,
+)
+from robosystems.operations.information_block.rules.expressions import (
+  EQUALITY_TOLERANCE,
 )
 
 
@@ -152,6 +156,160 @@ def _bind_sum_variables(
   return bindings
 
 
+def _load_period_balances(
+  session: Session,
+  structure_id: str,
+  fact_set_id: str | None,
+  period_start: date | None,
+  period_end: date | None,
+) -> dict[tuple[date | None, date | None], tuple[dict[str, float], set[str]]]:
+  """Group in-scope facts into per-period ``(balances, present)`` — SUMMING
+  every fact for an element+period, the way the fact producer does (a single
+  element can carry multiple facts in one period, e.g. a derived flow plus a
+  reconciling plug). Scoped by ``fact_set_id`` when pinned, else
+  ``structure_id``, within the period window.
+  """
+  stmt = select(Fact.element_id, Fact.value, Fact.period_start, Fact.period_end).where(
+    Fact.fact_scope == "in_scope"
+  )
+  if fact_set_id is not None:
+    stmt = stmt.where(Fact.fact_set_id == fact_set_id)
+  else:
+    stmt = stmt.where(Fact.structure_id == structure_id)
+  if period_end is not None:
+    stmt = stmt.where(Fact.period_end <= period_end)
+  if period_start is not None:
+    stmt = stmt.where(Fact.period_start >= period_start)
+
+  by_period: dict[
+    tuple[date | None, date | None], tuple[dict[str, float], set[str]]
+  ] = {}
+  for row in session.execute(stmt).all():
+    key = (row.period_start, row.period_end)
+    balances, present = by_period.setdefault(key, ({}, set()))
+    if row.value is not None:
+      balances[row.element_id] = balances.get(row.element_id, 0.0) + float(row.value)
+    present.add(row.element_id)
+  return by_period
+
+
+def _rollup_parent_element_id(
+  session: Session, rule: Rule, cache: dict[str, str | None]
+) -> tuple[str | None, str]:
+  """Resolve a RollUp rule's parent (the LHS = first variable) to an element_id.
+
+  Prefers an explicit ``variable_element_id`` (tenant CoA elements have a null
+  qname); otherwise resolves the qname, cached across rules in one run.
+  """
+  variables = rule.rule_variables or []
+  if not variables:
+    return None, ""
+  v0 = variables[0]
+  qname = v0.get("variable_qname", "") or ""
+  explicit = v0.get("variable_element_id")
+  if explicit:
+    return explicit, qname
+  if qname in cache:
+    return cache[qname], qname
+  element_id = session.execute(
+    select(Element.id).where(Element.qname == qname).limit(1)
+  ).scalar()
+  cache[qname] = element_id
+  return element_id, qname
+
+
+def _evaluate_rollup_arc_derived(
+  session: Session,
+  rule: Rule,
+  by_period: dict[tuple[date | None, date | None], tuple[dict[str, float], set[str]]],
+  calculations: dict[str, list[tuple[str, float]]],
+  cache: dict[str, str | None],
+) -> EvaluationOutcome | None:
+  """Evaluate a RollUp against the parent's DIRECT rs-gaap-calculations children.
+
+  Standard XBRL calculation semantics: a summation parent is checked against the
+  weighted sum of its *direct* calc children (each parent validated on its own
+  rule; the tree holds by induction). Children come from the live calc arcs —
+  not the rule's frozen enumeration — so a subtotal footing over a sibling
+  concept (``...ExcludingGoodwill`` where the frozen rule named
+  ``...IncludingGoodwill``) passes, and multi-fact-per-period elements sum
+  (``_load_period_balances`` already summed them). Compares against the parent's
+  own reported value, so a genuine mismatch still fails.
+
+  Crucially it uses only the parent's *direct* children and each element's own
+  reported balance — NOT a global DAG resolution — so an element that appears in
+  a different statement's calc path (e.g. DDA as both a CF add-back and an IS
+  expense) can't contaminate the sum. A rollup whose direct children aren't
+  reported on this structure (e.g. an IS decomposition rule landing on the CF)
+  is skipped, matching the prior evaluator.
+
+  Returns ``None`` when the parent isn't an rs-gaap calc subtotal, so the caller
+  falls back to the frozen-expression evaluator (custom / fac rollups).
+  """
+  parent_id, parent_qname = _rollup_parent_element_id(session, rule, cache)
+  if parent_id is None or parent_id not in calculations:
+    return None
+
+  parent_label = parent_qname.split(":")[-1] if parent_qname else parent_id
+  children = calculations.get(parent_id, [])
+  periods = [key for key, (_, present) in by_period.items() if parent_id in present]
+  if not periods:
+    return EvaluationOutcome(
+      status="skipped",
+      message=f"no fact bound for subtotal: {parent_label}",
+      detail={"parent": parent_qname, "source": "calc-dag"},
+    )
+
+  tolerance = EQUALITY_TOLERANCE
+  if rule.metadata_ and isinstance(rule.metadata_, dict):
+    tolerance = float(rule.metadata_.get("tolerance", EQUALITY_TOLERANCE))
+
+  per_period: list[dict[str, Any]] = []
+  for key in sorted(periods, key=lambda k: (k[1] is None, k[1] or date.min)):
+    balances, present = by_period[key]
+    # Skip a period where the subtotal is reported but none of its direct calc
+    # children are present here — nothing to foot against (e.g. an IS
+    # decomposition rule evaluated on the CF statement).
+    if not any(cid in present for cid, _ in children):
+      continue
+    children_sum = sum(balances.get(cid, 0.0) * w for cid, w in children)
+    reported = balances.get(parent_id, 0.0)
+    residual = reported - children_sum
+    per_period.append(
+      {
+        "period_end": str(key[1]) if key[1] is not None else None,
+        "reported": reported,
+        "children_sum": children_sum,
+        "residual": residual,
+        "passed": abs(residual) <= tolerance,
+      }
+    )
+
+  if not per_period:
+    return EvaluationOutcome(
+      status="skipped",
+      message="subtotal reported but none of its rollup children are present here",
+      detail={"parent": parent_qname, "source": "calc-dag"},
+    )
+  failed = [p for p in per_period if not p["passed"]]
+  if not failed:
+    return EvaluationOutcome(
+      status="pass",
+      detail={"parent": parent_qname, "source": "calc-dag", "periods": per_period},
+    )
+  worst = max(failed, key=lambda p: abs(p["residual"]))
+  return EvaluationOutcome(
+    status="fail",
+    message=f"rollup failed; residual = {abs(worst['residual']):.2f}",
+    detail={
+      "parent": parent_qname,
+      "source": "calc-dag",
+      "tolerance": tolerance,
+      "periods": per_period,
+    },
+  )
+
+
 def evaluate_rules_for_structure(
   session: Session,
   structure_id: str,
@@ -206,24 +364,50 @@ def evaluate_rules_for_structure(
   rules = session.execute(select(Rule).where(Rule.id.in_(rule_ids))).scalars().all()
   rule_map = {r.id: r for r in rules}
 
+  # Arc-derived RollUp prep. RollUp rules are re-derived from the live
+  # rs-gaap-calculations DAG (mirroring the fact producer) rather than the
+  # rule's frozen child enumeration bound one-fact-per-qname, which reported
+  # false failures when a subtotal foots over a sibling concept or over two
+  # facts in one period. Loaded once per structure, only when a RollUp exists.
+  calculations: dict[str, list[tuple[str, float]]] = {}
+  by_period: dict[
+    tuple[date | None, date | None], tuple[dict[str, float], set[str]]
+  ] = {}
+  parent_id_cache: dict[str, str | None] = {}
+  if any(r.rule_pattern == "RollUp" for r in rules):
+    from robosystems.operations.roboledger.reports.calc_dag import (
+      load_rs_gaap_calculations,
+    )
+
+    calculations = load_rs_gaap_calculations(session)
+    by_period = _load_period_balances(
+      session, structure_id, fact_set_id, period_start, period_end
+    )
+
   results: list[VerificationResult] = []
   for rule_lite in rule_lites:
     rule = rule_map.get(rule_lite.id)
     if rule is None:
       continue
     try:
-      if rule.rule_pattern == "SumEquals":
-        bindings = _bind_sum_variables(session, rule, structure_id)
-      else:
-        bindings = _bind_variables(
-          session,
-          rule,
-          structure_id,
-          period_start,
-          period_end,
-          fact_set_id=fact_set_id,
+      outcome: EvaluationOutcome | None = None
+      if rule.rule_pattern == "RollUp" and calculations:
+        outcome = _evaluate_rollup_arc_derived(
+          session, rule, by_period, calculations, parent_id_cache
         )
-      outcome = evaluate_rule(rule, bindings)
+      if outcome is None:
+        if rule.rule_pattern == "SumEquals":
+          bindings = _bind_sum_variables(session, rule, structure_id)
+        else:
+          bindings = _bind_variables(
+            session,
+            rule,
+            structure_id,
+            period_start,
+            period_end,
+            fact_set_id=fact_set_id,
+          )
+        outcome = evaluate_rule(rule, bindings)
     except Exception as exc:
       outcome = EvaluationOutcome(
         status="error",

--- a/robosystems/operations/roboledger/reports/calc_dag.py
+++ b/robosystems/operations/roboledger/reports/calc_dag.py
@@ -1,0 +1,123 @@
+"""Shared rs-gaap calculation-DAG loading + bottom-up subtotal resolution.
+
+The single source of truth for "resolve subtotal values over the
+``rs-gaap-calculations`` DAG". Extracted from ``fact_grid.py`` so the fact
+PRODUCER (``_emit_subtotal_facts``, ``_reconcile_operating_to_cash``) and the
+rollup VALIDATOR (``information_block.rules``) derive subtotals *identically* —
+the validator must mirror the producer or it re-derives the rollup wrong. The
+frozen-enumeration ``RollUp`` evaluator did exactly that: it summed a hardcoded
+child list bound one-fact-per-qname, so a subtotal footing over a sibling
+concept (``IntangibleAssetsNetExcludingGoodwill`` vs the enumerated
+``...IncludingGoodwill``) or over two facts in one period reported a false
+failure. Deriving children from the arcs — the way the producer already does —
+closes that class.
+
+Resolution semantics (unchanged from the original inline copies in fact_grid):
+
+- children come from ``association_type='calculation'`` arcs of the
+  ``rs-gaap-calculations`` taxonomy standard (direct parent→child + weight);
+- a DIRECT fact for an element wins over the calc sum (calc is the fallback for
+  an un-reported subtotal, never an override), keyed on PRESENCE not a non-zero
+  test so a legitimately-zero direct fact isn't overwritten by the calc sum;
+- an absent summand contributes 0;
+- targets are resolved in topological order, so a subtotal whose summand is
+  itself a subtotal (e.g. ``...IncludingGoodwill`` = ``...ExcludingGoodwill`` +
+  ``Goodwill``) is resolved from its own children first and collapses to the
+  present leaf.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+
+def load_rs_gaap_calculations(
+  session: Session,
+) -> dict[str, list[tuple[str, float]]]:
+  """Load the rs-gaap-calculations DAG as ``parent_element_id → [(child_id, weight)]``.
+
+  Global to the taxonomy standard (not scoped to any one report structure) —
+  which is what makes subtotal resolution independent of which presentation
+  structure is being rendered or validated. This is the same query the fact
+  producer runs (``fact_grid._emit_subtotal_facts``).
+  """
+  rows = session.execute(
+    text("""
+      SELECT a.from_element_id AS parent, a.to_element_id AS child, a.weight
+      FROM associations a
+      JOIN structures s ON s.id = a.structure_id
+      JOIN taxonomies t ON t.id = s.taxonomy_id
+      WHERE a.association_type = 'calculation'
+        AND t.standard = 'rs-gaap-calculations'
+      ORDER BY a.order_value
+    """)
+  ).fetchall()
+  calculations: dict[str, list[tuple[str, float]]] = {}
+  for r in rows:
+    weight = float(r.weight) if r.weight is not None else 1.0
+    calculations.setdefault(r.parent, []).append((r.child, weight))
+  return calculations
+
+
+def topo_sort_calculations(
+  calculations: dict[str, list[tuple[str, float]]],
+) -> list[str]:
+  """Return calc subtotal targets in topological dependency order.
+
+  When calcs chain (e.g., GrossProfit = Rev - COGS, then OperatingIncome =
+  GrossProfit - OpEx, then NetIncome = OperatingIncome - Tax), resolution must
+  compute them in order so each depends on the already-resolved values of the
+  prior ones. Targets with no internal dependencies come first.
+  """
+  targets = set(calculations.keys())
+  # Edge: target → target it depends on (when its summand is itself a calc
+  # target). Inputs that are leaves (not calc targets) don't create edges.
+  deps: dict[str, set[str]] = {t: set() for t in targets}
+  for target, sources in calculations.items():
+    for src_id, _ in sources:
+      if src_id in targets:
+        deps[target].add(src_id)
+
+  # Kahn's algorithm: emit nodes with no remaining deps; remove from graph.
+  ready = [t for t, d in deps.items() if not d]
+  ordered: list[str] = []
+  while ready:
+    n = ready.pop(0)
+    ordered.append(n)
+    for other, other_deps in deps.items():
+      if n in other_deps:
+        other_deps.discard(n)
+        if not other_deps and other not in ordered and other not in ready:
+          ready.append(other)
+  # Any remaining targets indicate a cycle in the calc DAG — emit them last in
+  # arbitrary order. (Cycles are rejected upstream at authoring/framework-build;
+  # this degrades rather than crashes if one slips through.)
+  for t in targets:
+    if t not in ordered:
+      ordered.append(t)
+  return ordered
+
+
+def resolve_calc_dag(
+  balances: dict[str, float],
+  present: set[str],
+  calculations: dict[str, list[tuple[str, float]]],
+  order: list[str] | None = None,
+) -> dict[str, float]:
+  """Resolve every calc target bottom-up: direct fact wins, else Σ child·weight.
+
+  ``balances`` maps ``element_id → summed fact value`` for the period; ``present``
+  is the set of element_ids that have a direct fact (presence, not non-zero).
+  Returns the resolved value map — a superset of ``balances`` that also carries
+  each computed subtotal, so callers can read both a subtotal and the leaves
+  under it. Pass a precomputed ``order`` to avoid re-sorting across periods.
+  """
+  if order is None:
+    order = topo_sort_calculations(calculations)
+  computed: dict[str, float] = dict(balances)
+  for elem_id in order:
+    direct = computed.get(elem_id, 0.0)
+    summed = sum(computed.get(src, 0.0) * w for src, w in calculations.get(elem_id, ()))
+    computed[elem_id] = direct if elem_id in present else summed
+  return computed

--- a/robosystems/operations/roboledger/reports/fact_grid.py
+++ b/robosystems/operations/roboledger/reports/fact_grid.py
@@ -20,6 +20,11 @@ from sqlalchemy.orm import Session
 
 from robosystems.logger import logger
 from robosystems.models.api.extensions import cents_to_dollars
+from robosystems.operations.roboledger.reports.calc_dag import (
+  load_rs_gaap_calculations,
+  resolve_calc_dag,
+  topo_sort_calculations,
+)
 
 # ── Data classes ──────────────────────────────────────────────────────────
 
@@ -996,23 +1001,9 @@ def _emit_subtotal_facts(
   Must run LAST in ``generate_report_facts`` so every leaf + derived fact
   (NetIncomeLoss, PP&E net, CF flows) is in place. Mutates ``facts``.
   """
-  rows = session.execute(
-    text("""
-      SELECT a.from_element_id AS parent, a.to_element_id AS child, a.weight
-      FROM associations a
-      JOIN structures s ON s.id = a.structure_id
-      JOIN taxonomies t ON t.id = s.taxonomy_id
-      WHERE a.association_type = 'calculation'
-        AND t.standard = 'rs-gaap-calculations'
-      ORDER BY a.order_value
-    """)
-  ).fetchall()
-  if not rows:
+  calculations = load_rs_gaap_calculations(session)
+  if not calculations:
     return
-  calculations: dict[str, list[tuple[str, float]]] = {}
-  for r in rows:
-    weight = float(r.weight) if r.weight is not None else 1.0
-    calculations.setdefault(r.parent, []).append((r.child, weight))
 
   target_ids = list(calculations.keys())
   meta = {
@@ -1026,7 +1017,7 @@ def _emit_subtotal_facts(
     ).fetchall()
   }
 
-  order = _topo_sort_calculations(calculations)
+  order = topo_sort_calculations(calculations)
 
   for period in periods:
     balances: dict[str, float] = {}
@@ -1036,18 +1027,9 @@ def _emit_subtotal_facts(
         balances[f.element_id] = balances.get(f.element_id, 0.0) + f.value
         present.add(f.element_id)
 
-    # Topological resolution — a direct fact wins over the calc result
-    # (calc is the fallback for un-reported subtotals, never an override
-    # of an authoritative direct fact). The "direct wins" test keys off
-    # PRESENCE (``elem_id in present``), not a non-zero value: a
-    # legitimately-zero direct fact (e.g. a seeded equity component, or a
-    # subtotal reported as 0) must not be overwritten by the calc sum, or
-    # a downstream subtotal that depends on it inherits the wrong summand.
-    computed: dict[str, float] = dict(balances)
-    for elem_id in order:
-      direct = computed.get(elem_id, 0.0)
-      summed = sum(computed.get(src, 0.0) * w for src, w in calculations[elem_id])
-      computed[elem_id] = direct if elem_id in present else summed
+    # Resolve subtotals bottom-up (direct fact wins over Σ child·weight,
+    # keyed on presence) — shared with the rollup validator via calc_dag.
+    computed = resolve_calc_dag(balances, present, calculations, order)
 
     for elem_id in target_ids:
       # Already a fact (leaf-mapped or a prior derived emit like
@@ -1644,24 +1626,10 @@ def _reconcile_operating_to_cash(
 
   # rs-gaap-calculations DAG — same source/resolution as _emit_subtotal_facts,
   # so the net-change we compute here matches what the renderer will show.
-  rows = session.execute(
-    text("""
-      SELECT a.from_element_id AS parent, a.to_element_id AS child, a.weight
-      FROM associations a
-      JOIN structures s ON s.id = a.structure_id
-      JOIN taxonomies t ON t.id = s.taxonomy_id
-      WHERE a.association_type = 'calculation'
-        AND t.standard = 'rs-gaap-calculations'
-      ORDER BY a.order_value
-    """)
-  ).fetchall()
-  if not rows:
+  calculations = load_rs_gaap_calculations(session)
+  if not calculations:
     return
-  calculations: dict[str, list[tuple[str, float]]] = {}
-  for r in rows:
-    weight = float(r.weight) if r.weight is not None else 1.0
-    calculations.setdefault(r.parent, []).append((r.child, weight))
-  order = _topo_sort_calculations(calculations)
+  order = topo_sort_calculations(calculations)
 
   # Cash-balance (instant) anchors by period boundary — a period's end is the
   # next period's opening, same prior-period-end delta basis as the tie-out.
@@ -1686,11 +1654,7 @@ def _reconcile_operating_to_cash(
       if f.period_start == current.start and f.period_end == current.end:
         balances[f.element_id] = balances.get(f.element_id, 0.0) + f.value
         present.add(f.element_id)
-    computed: dict[str, float] = dict(balances)
-    for elem_id in order:
-      direct = computed.get(elem_id, 0.0)
-      summed = sum(computed.get(src, 0.0) * w for src, w in calculations[elem_id])
-      computed[elem_id] = direct if elem_id in present else summed
+    computed = resolve_calc_dag(balances, present, calculations, order)
     derived_net_change = computed.get(net_change_id, 0.0)
 
     residual = cash_delta - derived_net_change
@@ -2502,48 +2466,6 @@ def _load_calculations(
   return calculations
 
 
-def _topo_sort_calculations(
-  calculations: dict[str, list[tuple[str, float]]],
-) -> list[str]:
-  """Return calc subtotal targets in topological dependency order.
-
-  When calcs chain (e.g., GrossProfit = Rev - COGS, then OperatingIncome =
-  GrossProfit - OpEx, then NetIncome = OperatingIncome - Tax), the renderer
-  must compute them in order so each depends on the resolved values of the
-  prior ones. Returns target ids in the order they should be computed.
-  Targets with no internal dependencies come first.
-  """
-  targets = set(calculations.keys())
-  # Edge: target → target it depends on (when its summand is itself a
-  # calc target). Inputs that are leaves (not calc targets) don't create
-  # edges.
-  deps: dict[str, set[str]] = {t: set() for t in targets}
-  for target, sources in calculations.items():
-    for src_id, _ in sources:
-      if src_id in targets:
-        deps[target].add(src_id)
-
-  # Kahn's algorithm: emit nodes with no remaining deps; remove from graph.
-  ready = [t for t, d in deps.items() if not d]
-  ordered: list[str] = []
-  while ready:
-    n = ready.pop(0)
-    ordered.append(n)
-    for other, other_deps in deps.items():
-      if n in other_deps:
-        other_deps.discard(n)
-        if not other_deps and other not in ordered and other not in ready:
-          ready.append(other)
-  # Any remaining targets indicate a cycle in the calc DAG — emit them
-  # last in arbitrary order. The renderer's existing behavior is to use
-  # whatever values are present, so a cycle just means one iteration of
-  # stale values rather than a crash.
-  for t in targets:
-    if t not in ordered:
-      ordered.append(t)
-  return ordered
-
-
 def _balance_value(
   balances: dict[str, _Balance],
   element_id: str,
@@ -2668,7 +2590,7 @@ def _build_rows(
   # in pass 1 (mapping arc landed at this anchor), prefer it over the
   # calc result — calc is the fallback path for subtotals not directly
   # reported, not an override of authoritative direct facts.
-  for elem_id in _topo_sort_calculations(calculations):
+  for elem_id in topo_sort_calculations(calculations):
     sources = calculations[elem_id]
     for i in range(n_periods):
       # Keep an authoritative pass-1 value (direct fact or reported-leaf

--- a/tests/operations/information_block/rules/test_rollup_arc_derived.py
+++ b/tests/operations/information_block/rules/test_rollup_arc_derived.py
@@ -1,0 +1,245 @@
+"""Tests for the arc-derived RollUp validator.
+
+Regression coverage for the false-failure classes found on live reports:
+(1) a Balance Sheet subtotal footing over a sibling concept
+(``...ExcludingGoodwill`` is the actual calc child, where the frozen rule
+enumerated ``...IncludingGoodwill``); (2) a Cash Flow operating subtotal that
+reconciles only when BOTH facts for one element+period are summed; and (3) an
+income-statement decomposition rule (``NetIncomeLoss = ContinuingOps +
+DiscontinuedOps``) landing on the Cash Flow statement, which must be SKIPPED —
+not resolved through a different statement's calc path.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from robosystems.operations.information_block.rules.engine import (
+  _evaluate_rollup_arc_derived,
+  _load_period_balances,
+  evaluate_rules_for_structure,
+)
+
+_P1 = (date(2025, 1, 1), date(2025, 12, 31))
+_P2 = (date(2026, 1, 1), date(2026, 12, 31))
+
+
+def _rule(parent_id: str, parent_qname: str, metadata: dict | None = None) -> MagicMock:
+  rule = MagicMock()
+  rule.rule_pattern = "RollUp"
+  rule.rule_variables = [
+    {
+      "variable_name": parent_qname.split(":")[-1],
+      "variable_qname": parent_qname,
+      "variable_element_id": parent_id,  # avoids a session qname lookup
+    }
+  ]
+  rule.metadata_ = metadata or {}
+  return rule
+
+
+def _eval(rule, by_period, calcs):
+  return _evaluate_rollup_arc_derived(MagicMock(), rule, by_period, calcs, {})
+
+
+class TestEvaluateRollupArcDerived:
+  def test_balance_sheet_sibling_concept_passes(self) -> None:
+    # The calc arc names the actual mapped leaf (ExcludingGoodwill); the frozen
+    # rule enumerated IncludingGoodwill and failed by exactly 5966.27.
+    calcs = {
+      "AssetsNoncurrent": [
+        ("PPE", 1.0),
+        ("ExcludingGoodwill", 1.0),
+        ("Other", 1.0),
+        ("Goodwill", 1.0),  # absent → 0
+      ],
+    }
+    balances = {
+      "PPE": 8901.31,
+      "ExcludingGoodwill": 5966.27,
+      "Other": 83569.82,
+      "AssetsNoncurrent": 98437.40,
+    }
+    outcome = _eval(
+      _rule("AssetsNoncurrent", "rs-gaap:AssetsNoncurrent"),
+      {_P1: (balances, set(balances))},
+      calcs,
+    )
+    assert outcome is not None
+    assert outcome.status == "pass"
+    assert outcome.detail["source"] == "calc-dag"
+
+  def test_cash_flow_operating_sums_multiple_facts(self) -> None:
+    # by_period balances already carry the SUMMED OtherOpCap
+    # (+4782.70 + -1601.30 = 3181.40); the operating subtotal foots.
+    calcs = {
+      "NetCashOperating": [
+        ("NetIncome", 1.0),
+        ("DDA", 1.0),
+        ("AR", 1.0),
+        ("Prepaid", 1.0),
+        ("OtherOpCap", 1.0),
+      ]
+    }
+    balances = {
+      "NetIncome": -22356.10,
+      "DDA": 1124.84,
+      "AR": 20156.25,
+      "Prepaid": -348.0,
+      "OtherOpCap": 3181.40,
+      "NetCashOperating": 1758.39,
+    }
+    outcome = _eval(
+      _rule("NetCashOperating", "rs-gaap:NetCashProvidedByUsedInOperatingActivities"),
+      {_P2: (balances, set(balances))},
+      calcs,
+    )
+    assert outcome is not None
+    assert outcome.status == "pass"
+
+  def test_cross_statement_rule_skipped_not_failed(self) -> None:
+    # NetIncomeLoss = ContinuingOps + DiscontinuedOps is an IS rule; on the CF
+    # statement NetIncomeLoss is present (an add-back) but neither child is —
+    # so it must skip, NOT fail by resolving DDA through the IS expense path.
+    calcs = {"NetIncomeLoss": [("ContinuingOps", 1.0), ("DiscontinuedOps", 1.0)]}
+    balances = {"NetIncomeLoss": 13823.36, "DDA": 1216.64}  # children absent
+    outcome = _eval(
+      _rule("NetIncomeLoss", "rs-gaap:NetIncomeLoss"),
+      {_P1: (balances, set(balances))},
+      calcs,
+    )
+    assert outcome is not None
+    assert outcome.status == "skipped"
+    assert "children are present" in (outcome.message or "")
+
+  def test_real_discrepancy_fails_not_tautology(self) -> None:
+    # Parent reported independently at 100000 but children sum to 92471.13 —
+    # a genuine mismatch must still fail (the check is not vacuous).
+    calcs = {"AssetsNoncurrent": [("PPE", 1.0), ("Other", 1.0)]}
+    balances = {"PPE": 8901.31, "Other": 83569.82, "AssetsNoncurrent": 100000.0}
+    outcome = _eval(
+      _rule("AssetsNoncurrent", "rs-gaap:AssetsNoncurrent"),
+      {_P1: (balances, set(balances))},
+      calcs,
+    )
+    assert outcome is not None
+    assert outcome.status == "fail"
+    assert "residual" in (outcome.message or "")
+
+  def test_returns_none_for_non_calc_parent(self) -> None:
+    # Parent not in the rs-gaap calc DAG → fall back to the frozen evaluator.
+    calcs = {"AssetsNoncurrent": [("PPE", 1.0)]}
+    outcome = _eval(
+      _rule("CustomThing", "acme:CustomThing"),
+      {_P1: ({"CustomThing": 5.0}, {"CustomThing"})},
+      calcs,
+    )
+    assert outcome is None
+
+  def test_skipped_when_parent_absent_all_periods(self) -> None:
+    calcs = {"LiabilitiesNoncurrent": [("LTDebt", 1.0)]}
+    outcome = _eval(
+      _rule("LiabilitiesNoncurrent", "rs-gaap:LiabilitiesNoncurrent"),
+      {_P1: ({"LTDebt": 100.0}, {"LTDebt"})},
+      calcs,
+    )
+    assert outcome is not None
+    assert outcome.status == "skipped"
+    assert "LiabilitiesNoncurrent" in (outcome.message or "")
+
+  def test_multi_period_fails_if_any_period_fails(self) -> None:
+    calcs = {"AssetsNoncurrent": [("PPE", 1.0)]}
+    by_period = {
+      _P1: ({"PPE": 100.0, "AssetsNoncurrent": 100.0}, {"PPE", "AssetsNoncurrent"}),
+      _P2: ({"PPE": 100.0, "AssetsNoncurrent": 150.0}, {"PPE", "AssetsNoncurrent"}),
+    }
+    outcome = _eval(
+      _rule("AssetsNoncurrent", "rs-gaap:AssetsNoncurrent"), by_period, calcs
+    )
+    assert outcome is not None
+    assert outcome.status == "fail"
+    assert "50" in (outcome.message or "")
+
+  def test_tolerance_from_metadata_allows_rounding(self) -> None:
+    calcs = {"AssetsNoncurrent": [("PPE", 1.0)]}
+    balances = {"PPE": 100.0, "AssetsNoncurrent": 100.004}  # 0.004 drift
+    outcome = _eval(
+      _rule(
+        "AssetsNoncurrent", "rs-gaap:AssetsNoncurrent", metadata={"tolerance": 0.01}
+      ),
+      {_P1: (balances, set(balances))},
+      calcs,
+    )
+    assert outcome is not None
+    assert outcome.status == "pass"
+
+
+class TestLoadPeriodBalances:
+  def test_sums_multiple_facts_per_element_period(self) -> None:
+    session = MagicMock()
+    rows = [
+      SimpleNamespace(
+        element_id="OtherOpCap", value=4782.70, period_start=_P2[0], period_end=_P2[1]
+      ),
+      SimpleNamespace(
+        element_id="OtherOpCap", value=-1601.30, period_start=_P2[0], period_end=_P2[1]
+      ),
+      SimpleNamespace(
+        element_id="NetIncome", value=-22356.10, period_start=_P2[0], period_end=_P2[1]
+      ),
+    ]
+    exec_result = MagicMock()
+    exec_result.all.return_value = rows
+    session.execute.return_value = exec_result
+
+    by_period = _load_period_balances(session, "struct_cf", None, None, None)
+    balances, present = by_period[_P2]
+    assert balances["OtherOpCap"] == pytest.approx(3181.40)
+    assert "NetIncome" in present
+
+
+class TestRollupRoutingInEngine:
+  def test_rollup_rule_routes_to_arc_derived_path(self) -> None:
+    session = MagicMock()
+    session.get.return_value = MagicMock(id="struct_bs", block_type="balance_sheet")
+
+    rule_lite = MagicMock()
+    rule_lite.id = "rule_rollup"
+    rule_orm = _rule("ANC", "rs-gaap:AssetsNoncurrent")
+    rule_orm.id = "rule_rollup"
+
+    calcs = {"ANC": [("PPE", 1.0)]}
+    by_period = {_P1: ({"PPE": 100.0, "ANC": 100.0}, {"PPE", "ANC"})}
+
+    assoc = MagicMock()
+    assoc.scalars.return_value.all.return_value = []
+    rules_res = MagicMock()
+    rules_res.scalars.return_value.all.return_value = [rule_orm]
+    session.execute.side_effect = [assoc, rules_res]
+
+    with (
+      patch(
+        "robosystems.operations.information_block.rules.engine.load_rules_for_structure",
+        return_value=[rule_lite],
+      ),
+      patch(
+        "robosystems.operations.roboledger.reports.calc_dag.load_rs_gaap_calculations",
+        return_value=calcs,
+      ),
+      patch(
+        "robosystems.operations.information_block.rules.engine._load_period_balances",
+        return_value=by_period,
+      ),
+    ):
+      results = evaluate_rules_for_structure(
+        session, "struct_bs", period_start=_P1[0], period_end=_P1[1]
+      )
+
+    assert len(results) == 1
+    added = session.add.call_args_list[0][0][0]
+    assert added.status == "pass"
+    assert added.detail.get("source") == "calc-dag"

--- a/tests/operations/roboledger/reports/test_arithmetic_cap_compilation.py
+++ b/tests/operations/roboledger/reports/test_arithmetic_cap_compilation.py
@@ -13,9 +13,11 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
+from robosystems.operations.roboledger.reports.calc_dag import (
+  topo_sort_calculations as _topo_sort_calculations,
+)
 from robosystems.operations.roboledger.reports.fact_grid import (
   _load_calculations,
-  _topo_sort_calculations,
 )
 
 

--- a/tests/operations/roboledger/reports/test_calc_dag.py
+++ b/tests/operations/roboledger/reports/test_calc_dag.py
@@ -1,0 +1,116 @@
+"""Unit tests for the shared calc-DAG resolver (``calc_dag.py``).
+
+These pin the resolution semantics the fact producer and the rollup validator
+now share: direct-fact-wins-on-presence, absent-summand-is-zero, weighted sums,
+and — the load-bearing one — transitive resolution through an intermediate
+subtotal, which is what lets a subtotal foot over a sibling concept.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from robosystems.operations.roboledger.reports.calc_dag import (
+  load_rs_gaap_calculations,
+  resolve_calc_dag,
+  topo_sort_calculations,
+)
+
+
+class TestResolveCalcDag:
+  def test_direct_fact_wins_over_calc_sum(self) -> None:
+    calcs = {"Assets": [("AC", 1.0), ("ANC", 1.0)]}
+    balances = {"AC": 120.0, "ANC": 30.0, "Assets": 999.0}
+    computed = resolve_calc_dag(balances, {"AC", "ANC", "Assets"}, calcs)
+    assert computed["Assets"] == 999.0  # authoritative direct fact, not 150
+
+  def test_absent_subtotal_computed_from_children(self) -> None:
+    calcs = {"AC": [("Cash", 1.0), ("AR", 1.0)]}
+    computed = resolve_calc_dag({"Cash": 100.0, "AR": 20.0}, {"Cash", "AR"}, calcs)
+    assert computed["AC"] == 120.0
+
+  def test_weighted_subtraction(self) -> None:
+    calcs = {"GrossProfit": [("Rev", 1.0), ("COGS", -1.0)]}
+    computed = resolve_calc_dag(
+      {"Rev": 175000.0, "COGS": 60000.0}, {"Rev", "COGS"}, calcs
+    )
+    assert computed["GrossProfit"] == 115000.0
+
+  def test_absent_summand_is_zero(self) -> None:
+    calcs = {"AC": [("Cash", 1.0), ("AR", 1.0)]}
+    computed = resolve_calc_dag({"Cash": 100.0}, {"Cash"}, calcs)
+    assert computed["AC"] == 100.0
+
+  def test_transitive_including_excluding_goodwill(self) -> None:
+    """The Balance Sheet false-failure case. The subtotal rolls up
+    ``...IncludingGoodwill``, but the tenant's fact is ``...ExcludingGoodwill``
+    (a child of Including). Transitive resolution collapses Including to the
+    present Excluding leaf, so AssetsNoncurrent foots — where the frozen
+    enumeration failed by exactly 5966.27."""
+    calcs = {
+      "AssetsNoncurrent": [("PPE", 1.0), ("IncludingGoodwill", 1.0), ("Other", 1.0)],
+      "IncludingGoodwill": [("ExcludingGoodwill", 1.0), ("Goodwill", 1.0)],
+    }
+    balances = {"PPE": 8901.31, "ExcludingGoodwill": 5966.27, "Other": 83569.82}
+    computed = resolve_calc_dag(balances, set(balances), calcs)
+    assert computed["IncludingGoodwill"] == pytest.approx(5966.27)
+    assert computed["AssetsNoncurrent"] == pytest.approx(98437.40)
+
+  def test_chaining_resolves_regardless_of_dict_order(self) -> None:
+    calcs = {
+      "NetIncome": [("OperatingIncome", 1.0), ("Tax", -1.0)],
+      "OperatingIncome": [("GrossProfit", 1.0), ("OpEx", -1.0)],
+      "GrossProfit": [("Rev", 1.0), ("COGS", -1.0)],
+    }
+    balances = {"Rev": 1000.0, "COGS": 400.0, "OpEx": 150.0, "Tax": 90.0}
+    computed = resolve_calc_dag(balances, set(balances), calcs)
+    assert computed["GrossProfit"] == 600.0
+    assert computed["OperatingIncome"] == 450.0
+    assert computed["NetIncome"] == 360.0
+
+  def test_zero_direct_fact_wins_over_calc_sum(self) -> None:
+    """Presence, not non-zero: a direct 0 subtotal isn't overwritten by its
+    calc sum, so a downstream parent inherits the authoritative 0."""
+    calcs = {"Parent": [("SubA", 1.0), ("SubB", 1.0)], "SubA": [("Leaf1", 1.0)]}
+    balances = {"SubA": 0.0, "Leaf1": 100.0, "SubB": 50.0}
+    computed = resolve_calc_dag(balances, {"SubA", "Leaf1", "SubB"}, calcs)
+    assert computed["Parent"] == 50.0
+
+  def test_precomputed_order_is_honored(self) -> None:
+    calcs = {"AC": [("Cash", 1.0)]}
+    order = topo_sort_calculations(calcs)
+    computed = resolve_calc_dag({"Cash": 5.0}, {"Cash"}, calcs, order)
+    assert computed["AC"] == 5.0
+
+
+class TestLoadRsGaapCalculations:
+  def test_builds_parent_children_map_with_default_weight(self) -> None:
+    session = MagicMock()
+    result = MagicMock()
+    result.fetchall.return_value = [
+      SimpleNamespace(parent="Assets", child="AC", weight=1.0),
+      SimpleNamespace(parent="Assets", child="ANC", weight=None),  # → default 1.0
+      SimpleNamespace(parent="GP", child="COGS", weight=-1.0),
+    ]
+    session.execute.return_value = result
+    calcs = load_rs_gaap_calculations(session)
+    assert calcs["Assets"] == [("AC", 1.0), ("ANC", 1.0)]
+    assert calcs["GP"] == [("COGS", -1.0)]
+
+
+class TestTopoSort:
+  def test_dependencies_ordered_before_dependents(self) -> None:
+    calcs = {
+      "NetIncome": [("OperatingIncome", 1.0)],
+      "OperatingIncome": [("GrossProfit", 1.0)],
+      "GrossProfit": [("Rev", 1.0)],
+    }
+    order = topo_sort_calculations(calcs)
+    assert order.index("GrossProfit") < order.index("OperatingIncome")
+    assert order.index("OperatingIncome") < order.index("NetIncome")
+
+  def test_empty(self) -> None:
+    assert topo_sort_calculations({}) == []


### PR DESCRIPTION
## Problem

RollUp verification produced **false failures** on reports whose statements were actually correct. The evaluator bound one fact per `$variable` against a child list frozen into the rule at generation time, so it missed:

- a subtotal footing over a **sibling concept** — e.g. the data maps to `IntangibleAssetsNetExcludingGoodwill` while the rule enumerated `...IncludingGoodwill`; the residual equalled exactly the unbound leaf;
- an element carrying **two facts in one period** (a derived flow plus a reconciling plug) — only one was bound.

In both cases the reported subtotal was right; the checker just couldn't see the leaf.

## Fix

Re-derive a RollUp's children from the **live `rs-gaap-calculations` arcs** and sum the in-scope child facts per period, comparing against the parent's own reported value — the same child derivation the fact producer already uses. This follows standard XBRL calculation semantics:

- **direct children only**, from the arcs (not a frozen enumeration);
- **sum all facts** for an element+period (fixes the multi-fact case);
- **skip when none of the direct children are present**, so an income-statement decomposition rule (`NetIncomeLoss = ContinuingOps + DiscontinuedOps`) landing on the cash-flow statement is skipped rather than resolved through an unrelated calc path.

Non-`rs-gaap` parents fall back to the existing frozen-expression evaluator; non-`RollUp` rules are untouched. A genuine parent-vs-children mismatch still fails (the check is not vacuous).

Also extracts the shared calc-DAG loader/resolver into `reports/calc_dag.py`, de-duplicating the two identical inline resolution loops in the fact producer (`fact_grid`).

## Verification

- 806 unit/integration tests + `test-code` (ruff/format/basedpyright/cf-lint) green; new coverage in `test_calc_dag.py` and `test_rollup_arc_derived.py` (including the exact sibling-concept, multi-fact, and cross-statement-skip cases).
- E2E through the real MCP → API path on a local tenant across four statements (Balance Sheet, Cash Flow, multi-step Income Statement, Equity): **20 rules, zero false failures** — every result is a footing pass or a legitimate skip, and the `GrossProfit → OperatingIncome → NetIncome` chain passes.
