### PR TITLE
feat(reports): fact-driven disclosure note render substrate

### DIFF
--- a/robosystems/models/api/information_block.py
+++ b/robosystems/models/api/information_block.py
@@ -912,6 +912,7 @@ _LEGACY_BLOCK_TYPES = Literal[
   "cash_flow_statement",
   "equity_statement",
   "comprehensive_income",
+  "regulatory_disclosure",
   "metric",
 ]
 
@@ -922,10 +923,13 @@ class _CreateLegacyArm(BaseModel):
 
   Statement-family blocks (balance_sheet, income_statement,
   cash_flow_statement, equity_statement, comprehensive_income) are
-  constructed via `create-report`, not this endpoint. Metric blocks
-  are recognized but their evaluator has not shipped. Calling this
-  endpoint with one of these block types returns HTTP 501 with a hint
-  pointing to the correct construction path.
+  constructed via `create-report`, not this endpoint. Disclosure
+  structures (regulatory_disclosure) are vocabulary, authored via
+  `create-taxonomy-block`; their facts land when `create-report`
+  picks them. Metric blocks are recognized but their evaluator has
+  not shipped. Calling this endpoint with one of these block types
+  returns HTTP 501 with a hint pointing to the correct construction
+  path.
   """
 
   block_type: _LEGACY_BLOCK_TYPES = Field(

--- a/robosystems/operations/information_block/disclosure.py
+++ b/robosystems/operations/information_block/disclosure.py
@@ -1,0 +1,79 @@
+"""Handler for the ``regulatory_disclosure`` Information Block type.
+
+Disclosure notes are the first render targets beyond the statement
+family — an inventory-by-category note, a PP&E-by-class breakdown, a
+debt-maturity schedule. Like statements they exercise the
+**compositional** construction mode: the Structure (with its
+presentation + calculation arcs) exists before any report runs — either
+library-seeded or tenant-authored through the TaxonomyBlock envelope —
+and per-tenant facts land when ``create-report`` picks the structure
+because its concepts received mapped facts (fact-driven picking in
+``commands/reports.py``; disclosures are NOT composed by the Reporting
+Style, which pins statement layouts only).
+
+The envelope builder is the statement family's, parameterised on the
+block_type — ``_build_rows`` and the hierarchy walker are CAP-agnostic,
+so a ``roll_up`` note renders rows + footed subtotals through the same
+machinery. Two disclosure-specific behaviours layer on top:
+
+- **Arc-less structures return no envelope.** The rs-gaap-disclosures
+  package seeds one identity Structure per disclosure
+  (``disclosures:BalanceSheet`` … — envelope rows with no arcs). Those
+  are disclosure *registry* entries, not renderable blocks; surfacing
+  them would flood ``list-information-blocks`` with empty envelopes.
+- **Display name = the structure's own name** (a note is named by its
+  author/taxonomy, not its type) — handled by the statement builder's
+  fallback.
+
+Creation does not flow through ``create-information-block`` — disclosure
+structures are vocabulary, authored via ``create-taxonomy-block``
+(reporting_extension); the registry installs not-implemented stubs for
+the write slots.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from robosystems.operations.information_block.statement import (
+  _build_statement_envelope,  # type: ignore[reportPrivateUsage]
+)
+
+if TYPE_CHECKING:
+  from sqlalchemy.orm import Session
+
+  from robosystems.models.api.information_block import InformationBlockEnvelope
+
+DISCLOSURE_BLOCK_TYPE = "regulatory_disclosure"
+DISCLOSURE_DISPLAY_NAME = "Disclosure"
+DISCLOSURE_CATEGORY = "Reporting"
+
+
+def build_envelope(
+  session: Session,
+  structure_id: str,
+  fact_set_id: str | None = None,
+) -> InformationBlockEnvelope | None:
+  """Pack the envelope for a disclosure-note structure.
+
+  Returns ``None`` when the structure doesn't exist, isn't a
+  ``regulatory_disclosure``, or carries no arcs (the library's
+  disclosure-identity envelopes — not renderable blocks).
+  """
+  envelope = _build_statement_envelope(
+    session,
+    structure_id,
+    fact_set_id,
+    block_type=DISCLOSURE_BLOCK_TYPE,
+  )
+  if envelope is None or not envelope.connections:
+    return None
+  return envelope
+
+
+__all__ = [
+  "DISCLOSURE_BLOCK_TYPE",
+  "DISCLOSURE_CATEGORY",
+  "DISCLOSURE_DISPLAY_NAME",
+  "build_envelope",
+]

--- a/robosystems/operations/information_block/envelope.py
+++ b/robosystems/operations/information_block/envelope.py
@@ -526,7 +526,17 @@ def _disclosure_qname_for_type(session: Session, block_type: str) -> str | None:
 
   Uses ``metadata->>'role_uri'`` JSONB access and the matching expression
   index (``idx_structures_role_uri``) for a single fast lookup.
+
+  Only meaningful for the statement family, where block_type →
+  disclosure is 1:1. ``regulatory_disclosure`` is many-to-many (every
+  Note shares the type), so a type-level lookup would return an
+  arbitrary library note — those structures resolve their identity from
+  their own role_uri (case 1 in
+  :func:`load_disclosure_id_for_structure`) or not at all.
   """
+  if block_type == "regulatory_disclosure":
+    return None
+
   cached = _DISCLOSURE_QNAME_BY_TYPE.get(block_type, _MISSING)
   if cached is not _MISSING:
     return cached  # type: ignore[return-value]

--- a/robosystems/operations/information_block/registry.py
+++ b/robosystems/operations/information_block/registry.py
@@ -33,6 +33,7 @@ from robosystems.models.api.information_block import (
   ScheduleMechanics,
   StatementMechanics,
 )
+from robosystems.operations.information_block import disclosure as disclosure_handlers
 from robosystems.operations.information_block import metric as metric_handlers
 from robosystems.operations.information_block import rollforward as rollforward_handlers
 from robosystems.operations.information_block import schedule as schedule_handlers
@@ -220,6 +221,59 @@ EQUITY_STATEMENT_BLOCK = _make_statement_entry("equity_statement", "pie-chart")
 COMPREHENSIVE_INCOME_BLOCK = _make_statement_entry("comprehensive_income", "activity")
 
 
+# ── Disclosure notes (compositional) ───────────────────────────────────────
+
+DISCLOSURE_BLOCK = BlockTypeRegistryEntry(
+  id=disclosure_handlers.DISCLOSURE_BLOCK_TYPE,
+  display_name=disclosure_handlers.DISCLOSURE_DISPLAY_NAME,
+  display_plural="Disclosures",
+  category=disclosure_handlers.DISCLOSURE_CATEGORY,
+  icon="file-text",
+  description=(
+    "Disclosure note — a reporting structure beyond the statement "
+    "family (inventory by category, PP&E by class, debt maturities). "
+    "Renders when its concepts receive mapped facts from a Report run; "
+    "disclosures are fact-driven, not composed by the Reporting Style. "
+    "The structure itself is vocabulary, authored via "
+    "create-taxonomy-block, not create-information-block."
+  ),
+  concept_arrangement_default="roll_up",
+  member_arrangement_default=None,
+  mechanics_schema=StatementMechanics,
+  create_request_model=_EmptyPayload,
+  update_request_model=_EmptyPayload,
+  delete_request_model=_EmptyPayload,
+  construction_mode="compositional",
+  dispatch_create=make_not_implemented_handler(
+    "create-regulatory-disclosure-block",
+    "Disclosure blocks are not created through "
+    "create-information-block — the disclosure structure is vocabulary "
+    "(elements + presentation/calculation arcs), authored via "
+    "`create-taxonomy-block`. Its facts materialize when "
+    "`create-report` runs and the mapped ledger reaches the "
+    "disclosure's concepts.",
+  ),
+  dispatch_update=make_not_implemented_handler(
+    "update-regulatory-disclosure-block",
+    "Disclosure blocks are not updated through "
+    "update-information-block — edit the underlying structure via "
+    "`update-taxonomy-block`, then `regenerate-report` to refresh "
+    "facts.",
+  ),
+  dispatch_delete=make_not_implemented_handler(
+    "delete-regulatory-disclosure-block",
+    "Disclosure blocks are not deleted through "
+    "delete-information-block — remove the underlying structure via "
+    "`delete-taxonomy-block`.",
+  ),
+  dispatch_build_envelope=disclosure_handlers.build_envelope,
+  # Library-seeded disclosure rows are arc-less identity envelopes —
+  # build_envelope returns None for them, and the sentinel shouldn't
+  # list them either.
+  surfaces_in_library=False,
+)
+
+
 # ── Metric (derivative) ────────────────────────────────────────────────────
 
 METRIC_BLOCK = BlockTypeRegistryEntry(
@@ -275,6 +329,7 @@ REGISTRY: dict[str, BlockTypeRegistryEntry] = {
   CASH_FLOW_STATEMENT_BLOCK.id: CASH_FLOW_STATEMENT_BLOCK,
   EQUITY_STATEMENT_BLOCK.id: EQUITY_STATEMENT_BLOCK,
   COMPREHENSIVE_INCOME_BLOCK.id: COMPREHENSIVE_INCOME_BLOCK,
+  DISCLOSURE_BLOCK.id: DISCLOSURE_BLOCK,
   METRIC_BLOCK.id: METRIC_BLOCK,
 }
 
@@ -301,6 +356,7 @@ __all__ = [
   "BALANCE_SHEET_BLOCK",
   "CASH_FLOW_STATEMENT_BLOCK",
   "COMPREHENSIVE_INCOME_BLOCK",
+  "DISCLOSURE_BLOCK",
   "EQUITY_STATEMENT_BLOCK",
   "INCOME_STATEMENT_BLOCK",
   "METRIC_BLOCK",

--- a/robosystems/operations/information_block/statement.py
+++ b/robosystems/operations/information_block/statement.py
@@ -158,7 +158,13 @@ def _build_statement_envelope(
     block_type=block_type,
   )
 
-  display_name, _display_plural = STATEMENT_DISPLAY[block_type]
+  # Statement-family types carry fixed display strings; block types that
+  # share this builder without an entry (regulatory_disclosure) display
+  # as the structure's own name — a disclosure note is named by its
+  # author/taxonomy, not by its type.
+  display_name, _display_plural = STATEMENT_DISPLAY.get(
+    block_type, (structure.name, structure.name)
+  )
   disclosure_id = load_disclosure_id_for_structure(session, structure.id)
   _elements_by_id = {e.id: e for e in atoms.elements}
   return InformationBlockEnvelope(

--- a/robosystems/operations/roboledger/commands/reports.py
+++ b/robosystems/operations/roboledger/commands/reports.py
@@ -157,12 +157,51 @@ _RENDER_TARGET_STATEMENT_TYPES: tuple[str, ...] = (
 )
 
 
+def _pick_disclosure_structures(
+  session: Session,
+  fact_element_ids: set[str],
+) -> list[str]:
+  """Disclosure structures whose concepts actually received facts.
+
+  Disclosures are not composed by the Reporting Style — styles pin
+  statement layouts only. A disclosure renders because the mapped
+  ledger produced values for its concepts (the forward/Reportability
+  direction): pick every active ``regulatory_disclosure`` structure
+  owning at least one presentation arc whose endpoint elements
+  intersect the generated facts' elements.
+
+  The library's disclosure-identity envelopes (``disclosures:*`` rows
+  with no arcs) never match the presentation-arc requirement, and a
+  tenant with no arc-bearing disclosure structures gets an empty list —
+  the picker is inert until a disclosure structure with content exists.
+  """
+  if not fact_element_ids:
+    return []
+  rows = session.execute(
+    text(
+      """
+      SELECT DISTINCT a.structure_id AS structure_id
+      FROM associations a
+      JOIN structures s ON s.id = a.structure_id
+      WHERE s.block_type = 'regulatory_disclosure'
+        AND s.is_active IS TRUE
+        AND a.association_type = 'presentation'
+        AND (a.to_element_id = ANY(:element_ids)
+             OR a.from_element_id = ANY(:element_ids))
+      """
+    ),
+    {"element_ids": list(fact_element_ids)},
+  ).fetchall()
+  return [row.structure_id for row in rows]
+
+
 def _build_structure_mapping(
   session: Session,
   reporting_style_id: str,
+  fact_element_ids: set[str] | None = None,
 ) -> tuple[dict[str, list[str]], dict[str, str]]:
   """Return (element_id→[structure_ids], structure_id→fact_set_id) for the
-  Reporting Style composed for this graph.
+  Reporting Style composed for this graph, plus fact-picked disclosures.
 
   Walks ``reporting_style_networks`` to pick one Network per statement
   type, then enumerates each Network's association rows to map elements →
@@ -172,6 +211,11 @@ def _build_structure_mapping(
   be stamped onto every owning structure's FactSet so each block's
   renderer can resolve its calc rollups locally. Pre-generates a
   fact_set_id ULID per picked structure.
+
+  ``fact_element_ids`` (the elements the just-generated report facts
+  touch) drives the disclosure half: disclosure structures are NOT
+  style-composed — they join the render set when their concepts
+  received facts (:func:`_pick_disclosure_structures`).
 
   Networks for statement types the Style doesn't compose are skipped
   silently — a Style is free to omit, say, the comprehensive_income
@@ -198,6 +242,10 @@ def _build_structure_mapping(
       # ``comprehensive_income``).
       continue
     picked_structure_ids.append(network.structure_id)
+
+  for disclosure_id in _pick_disclosure_structures(session, fact_element_ids or set()):
+    if disclosure_id not in picked_structure_ids:
+      picked_structure_ids.append(disclosure_id)
 
   if not picked_structure_ids:
     return {}, {}
@@ -525,7 +573,9 @@ def create_report(
   )
 
   element_to_structures, structure_to_factset = _build_structure_mapping(
-    session, reporting_style_id
+    session,
+    reporting_style_id,
+    fact_element_ids={f.element_id for f in facts.facts},
   )
   # Create fact_sets rows first so the facts we stamp reference a row
   # that already exists, letting the DB enforce facts.fact_set_id →
@@ -648,7 +698,9 @@ def regenerate_report(
   )
 
   element_to_structures, structure_to_factset = _build_structure_mapping(
-    session, reporting_style_id
+    session,
+    reporting_style_id,
+    fact_element_ids={f.element_id for f in facts.facts},
   )
   # Stale rows from the prior generation must clear before fresh ULIDs
   # land. The FK `facts.fact_set_id → fact_sets.id` is ON DELETE CASCADE,

--- a/tests/operations/information_block/test_disclosure_handlers.py
+++ b/tests/operations/information_block/test_disclosure_handlers.py
@@ -1,0 +1,185 @@
+"""Disclosure handler tests — registry entry + dispatch_build_envelope.
+
+``regulatory_disclosure`` is the first render target beyond the
+statement family. It shares the statement envelope builder
+(parameterised on block_type) with two disclosure-specific behaviours:
+arc-less structures (the library's disclosure-identity envelopes)
+return no envelope, and the display name falls back to the structure's
+own name (a note is named by its author/taxonomy, not its type).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from robosystems.operations.information_block import disclosure as disclosure_handlers
+from robosystems.operations.information_block.registry import REGISTRY
+
+
+def _exec_result(
+  *,
+  scalars_all: list[Any] | None = None,
+  scalar: Any = None,
+  all_rows: list[Any] | None = None,
+) -> MagicMock:
+  """Build a MagicMock shaped like a SQLAlchemy Result object."""
+  result = MagicMock()
+  if scalars_all is not None:
+    result.scalars.return_value.all.return_value = scalars_all
+  if all_rows is not None:
+    result.all.return_value = all_rows
+  if scalar is not None:
+    result.scalar.return_value = scalar
+  else:
+    result.scalar.return_value = None
+  return result
+
+
+def _make_disclosure_structure(
+  *,
+  structure_id: str = "struct_inventory_note",
+  name: str = "Inventory, by Category",
+) -> MagicMock:
+  """Shape a MagicMock like a tenant-authored disclosure Structure row."""
+  structure = MagicMock()
+  structure.id = structure_id
+  structure.block_type = "regulatory_disclosure"
+  structure.name = name
+  structure.description = None
+  structure.taxonomy_id = "tax_extension"
+  structure.artifact_mechanics = None
+  structure.concept_arrangement = "roll_up"
+  structure.member_arrangement = None
+  structure.renderer_note = None
+  structure.metadata_ = {}
+  return structure
+
+
+class TestRegistryEntry:
+  def test_regulatory_disclosure_is_registered(self) -> None:
+    entry = REGISTRY["regulatory_disclosure"]
+    assert entry.construction_mode == "compositional"
+    assert entry.concept_arrangement_default == "roll_up"
+    # Library-seeded disclosure rows are arc-less identity envelopes —
+    # they must not surface on the library sentinel.
+    assert entry.surfaces_in_library is False
+
+  def test_create_points_at_taxonomy_block(self) -> None:
+    entry = REGISTRY["regulatory_disclosure"]
+    with pytest.raises(NotImplementedError, match="create-taxonomy-block"):
+      entry.dispatch_create(MagicMock(), MagicMock(), "usr_test")
+
+  def test_update_points_at_taxonomy_block(self) -> None:
+    entry = REGISTRY["regulatory_disclosure"]
+    with pytest.raises(NotImplementedError, match="update-taxonomy-block"):
+      entry.dispatch_update(MagicMock(), MagicMock(), "usr_test")
+
+  def test_delete_points_at_taxonomy_block(self) -> None:
+    entry = REGISTRY["regulatory_disclosure"]
+    with pytest.raises(NotImplementedError, match="delete-taxonomy-block"):
+      entry.dispatch_delete(MagicMock(), MagicMock(), "usr_test")
+
+
+class TestBuildEnvelope:
+  def test_returns_none_when_structure_missing(self) -> None:
+    session = MagicMock()
+    session.get.return_value = None
+    assert disclosure_handlers.build_envelope(session, "struct_missing") is None
+
+  def test_returns_none_for_wrong_block_type(self) -> None:
+    """A statement structure must not surface through the disclosure handler."""
+    session = MagicMock()
+    structure = MagicMock()
+    structure.block_type = "balance_sheet"
+    session.get.return_value = structure
+    assert disclosure_handlers.build_envelope(session, "struct_bs") is None
+
+  def test_returns_none_for_arcless_identity_envelope(self) -> None:
+    """The library's ``disclosures:*`` identity rows carry no arcs — they
+    are disclosure registry entries, not renderable blocks, and must not
+    leak into ``list-information-blocks`` as empty envelopes."""
+    session = MagicMock()
+    session.get.return_value = _make_disclosure_structure(
+      structure_id="struct_ppe_disclosure",
+      name="Property, Plant and Equipment Disclosure",
+    )
+    # Query order with no associations: fact_set → taxonomy name →
+    # associations → rules → verification_results.
+    session.execute.side_effect = [
+      _exec_result(scalar=None),
+      _exec_result(scalar="rs-gaap"),
+      _exec_result(scalars_all=[]),  # associations — arc-less
+      _exec_result(scalars_all=[]),
+      _exec_result(scalars_all=[]),
+    ]
+    assert disclosure_handlers.build_envelope(session, "struct_ppe_disclosure") is None
+
+  def test_renders_arc_bearing_note_with_structure_name_as_display(self) -> None:
+    """An arc-bearing note builds an envelope; display name is the
+    structure's own name, not a type-level constant."""
+    session = MagicMock()
+    structure = _make_disclosure_structure()
+    session.get.return_value = structure
+
+    association = MagicMock()
+    association.id = "assoc_note_1"
+    association.from_element_id = "elem_inventory_total"
+    association.to_element_id = "elem_raw_materials"
+    association.association_type = "presentation"
+    association.arcrole = "http://…/parent-child"
+    association.order_value = 1.0
+    association.weight = None
+
+    elem_total = MagicMock()
+    elem_total.id = "elem_inventory_total"
+    elem_total.qname = (
+      "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings"
+    )
+    elem_total.name = "Inventory"
+    elem_total.code = None
+    elem_total.element_type = "concept"
+    elem_total.is_abstract = False
+    elem_total.is_monetary = True
+    elem_total.balance_type = "debit"
+    elem_total.period_type = "instant"
+
+    elem_raw = MagicMock()
+    elem_raw.id = "elem_raw_materials"
+    elem_raw.qname = "ext:InventoryRawMaterials"
+    elem_raw.name = "Raw Materials"
+    elem_raw.code = None
+    elem_raw.element_type = "concept"
+    elem_raw.is_abstract = False
+    elem_raw.is_monetary = True
+    elem_raw.balance_type = "debit"
+    elem_raw.period_type = "instant"
+
+    # Query order with associations: fact_set → taxonomy name →
+    # associations → elements → rules → association classifications →
+    # verification_results.
+    session.execute.side_effect = [
+      _exec_result(scalar=None),
+      _exec_result(scalar="Driftline Extension"),
+      _exec_result(scalars_all=[association]),
+      _exec_result(scalars_all=[elem_total, elem_raw]),
+      _exec_result(scalars_all=[]),
+      _exec_result(all_rows=[]),
+      _exec_result(scalars_all=[]),
+    ]
+
+    envelope = disclosure_handlers.build_envelope(session, "struct_inventory_note")
+
+    assert envelope is not None
+    assert envelope.block_type == "regulatory_disclosure"
+    assert envelope.name == "Inventory, by Category"
+    assert envelope.display_name == "Inventory, by Category"
+    assert envelope.category == "Reporting"
+    assert envelope.information_model.concept_arrangement == "roll_up"
+    assert len(envelope.connections) == 1
+    assert {e.id for e in envelope.elements} == {
+      "elem_inventory_total",
+      "elem_raw_materials",
+    }

--- a/tests/operations/information_block/test_registry.py
+++ b/tests/operations/information_block/test_registry.py
@@ -59,11 +59,12 @@ class TestRegistry:
 
   def test_list_registered_returns_all_entries(self) -> None:
     entries = list_registered()
-    # Schedule + rollforward + 5 statement block types + metric.
+    # Schedule + rollforward + 5 statement block types + disclosure + metric.
     assert [e.id for e in entries] == [
       "schedule",
       "rollforward",
       *STATEMENT_BLOCK_IDS,
+      "regulatory_disclosure",
       "metric",
     ]
 

--- a/tests/operations/roboledger/commands/test_reports.py
+++ b/tests/operations/roboledger/commands/test_reports.py
@@ -14,6 +14,7 @@ from robosystems.operations.roboledger.commands.reports import (
   ReportNotFoundError,
   _build_structure_mapping,
   _persist_report_facts,
+  _pick_disclosure_structures,
   _pre_create_report_fact_sets,
   _share_to_target,
   regenerate_report,
@@ -140,6 +141,99 @@ def test_build_structure_mapping_returns_empty_when_no_compositions() -> None:
   assert fs_map == {}
   # No associations query should fire when no Networks were picked.
   session.execute.assert_not_called()
+
+
+def test_pick_disclosure_structures_short_circuits_on_empty_fact_ids() -> None:
+  """No generated facts → no disclosure query at all."""
+  session = MagicMock()
+  assert _pick_disclosure_structures(session, set()) == []
+  session.execute.assert_not_called()
+
+
+def test_pick_disclosure_structures_queries_by_fact_elements() -> None:
+  """The picker matches active regulatory_disclosure structures whose
+  presentation-arc endpoints intersect the generated facts' elements."""
+  session = MagicMock()
+  session.execute.return_value.fetchall.return_value = [
+    MagicMock(structure_id="struct_note"),
+  ]
+
+  picked = _pick_disclosure_structures(session, {"elem_raw", "elem_fg"})
+
+  assert picked == ["struct_note"]
+  sql = str(session.execute.call_args.args[0])
+  assert "regulatory_disclosure" in sql
+  assert "presentation" in sql
+  params = session.execute.call_args.args[1]
+  assert set(params["element_ids"]) == {"elem_raw", "elem_fg"}
+
+
+def test_build_structure_mapping_merges_fact_picked_disclosures() -> None:
+  """Disclosures are fact-driven, not style-composed: a disclosure
+  structure whose concepts received facts joins the picked set alongside
+  the style's statement Networks, gets its own FactSet ULID, and its
+  elements land in the element→structure map."""
+  session = MagicMock()
+
+  picked = {
+    "balance_sheet": RenderNetwork("struct_bs", "BS", "roll_up"),
+    "income_statement": RenderNetwork("struct_is", "IS", "arithmetic"),
+    "cash_flow_statement": RenderNetwork("struct_cf", "CF", "arithmetic"),
+    "equity_statement": RenderNetwork("struct_se", "SE", "roll_forward"),
+  }
+
+  def fake_picker(_session, _style_id, stmt_type):
+    return picked[stmt_type]
+
+  disclosure_rows = MagicMock()
+  disclosure_rows.fetchall.return_value = [MagicMock(structure_id="struct_note")]
+  association_rows = MagicMock()
+  association_rows.fetchall.return_value = [
+    MagicMock(structure_id="struct_bs", element_id="elem_inventory"),
+    MagicMock(structure_id="struct_note", element_id="elem_inventory"),
+    MagicMock(structure_id="struct_note", element_id="elem_raw"),
+  ]
+  # Execute order: disclosure picker query, then the association-endpoint
+  # mapping query over all picked structures.
+  session.execute.side_effect = [disclosure_rows, association_rows]
+
+  with patch(_PICKER_PATH, side_effect=fake_picker):
+    elem_map, fs_map = _build_structure_mapping(
+      session, "025f5d48-style", fact_element_ids={"elem_inventory", "elem_raw"}
+    )
+
+  assert "struct_note" in fs_map
+  # The shared BS-leaf element is stamped into BOTH the statement and the
+  # note — the definitional cross-block tie-out.
+  assert sorted(elem_map["elem_inventory"]) == ["struct_bs", "struct_note"]
+  assert elem_map["elem_raw"] == ["struct_note"]
+  assert len(set(fs_map.values())) == 5
+
+
+def test_build_structure_mapping_without_fact_ids_skips_disclosure_query() -> None:
+  """Callers that don't pass fact_element_ids get the pre-disclosure
+  behaviour: statement Networks only, one associations query."""
+  session = MagicMock()
+
+  picked = {
+    "balance_sheet": RenderNetwork("struct_bs", "BS", "roll_up"),
+    "income_statement": RenderNetwork("struct_is", "IS", "arithmetic"),
+    "cash_flow_statement": RenderNetwork("struct_cf", "CF", "arithmetic"),
+    "equity_statement": RenderNetwork("struct_se", "SE", "roll_forward"),
+  }
+
+  def fake_picker(_session, _style_id, stmt_type):
+    return picked[stmt_type]
+
+  session.execute.return_value.fetchall.return_value = [
+    MagicMock(structure_id="struct_bs", element_id="elem_cash"),
+  ]
+
+  with patch(_PICKER_PATH, side_effect=fake_picker):
+    _elem_map, fs_map = _build_structure_mapping(session, "025f5d48-style")
+
+  assert set(fs_map.keys()) == {"struct_bs", "struct_is", "struct_cf", "struct_se"}
+  assert session.execute.call_count == 1
 
 
 def test_persist_report_facts_stamps_structure_and_fact_set() -> None:


### PR DESCRIPTION
## Summary

Report-engine increment two, part 1 of 2 — the render substrate that lets disclosure notes exist beyond the four statements. A `regulatory_disclosure` structure now joins the report render set when its concepts receive mapped facts: **disclosures are fact-driven, not composed by the Reporting Style** (styles pin statement layouts only; a disclosure exists because the ledger has values for its concepts).

- **Fact-driven picking** (`commands/reports.py`): `_pick_disclosure_structures` selects active `regulatory_disclosure` structures owning ≥1 presentation arc whose endpoints intersect the generated facts' elements; merged additively into `_build_structure_mapping`, so FactSet pre-creation, the multi-target fact fan-out, and report-time rule evaluation handle notes with zero further changes. A CoA leaf mapped to both a face-statement line and a note concept stamps its fact into both FactSets — the cross-block tie-out is definitional.
- **Envelope read** (`information_block/`): new `regulatory_disclosure` registry entry, compositional read-only. The envelope builder reuses the statement family's CAP-agnostic rendering internals; display name comes from the structure's own name. Create/update/delete return 501 pointing at the TaxonomyBlock envelope (disclosure structures are vocabulary).
- **List hygiene**: the library's arc-less disclosure-identity rows (`disclosures:*`) build no envelope, so they never surface as empty blocks; `_disclosure_qname_for_type` guards the many-to-many block type from claiming an arbitrary library note's identity.

Inert in production: no library disclosure structure carries arcs today, so nothing renders differently for any tenant until a disclosure structure with content exists. No schema change, no migration.

**Part 2 (follow-up PR)**: TaxonomyBlock authoring (`regulatory_disclosure` + `concept_arrangement` on the envelope), auto RollUp rule emission with structure-local arc-derived footing, and the Driftline inventory-by-category demo proof.

## Testing

- 8 new disclosure-handler tests (registry shape, 501 trio, arc-less → None, wrong-type → None, arc-bearing note renders with structure-name display)
- 4 new picking tests (empty-set short-circuit, query shape, merge with statement networks + shared-element multi-stamping, no-fact_element_ids back-compat)
- Registry drift tests extended (union coverage via the legacy 501 arm)
- Full suite: 2765 passed; one pre-existing local-only ordering flake in `test_incremental_equals_full_load` fails identically on clean `main` (passes in isolation and in CI — unrelated to this diff)
- `just test-code` clean (ruff + format + basedpyright + cf-lint)