### PR TITLE
feat(taxonomy): author disclosure notes per-tenant with automatic footing

### DIFF
--- a/examples/_scenario/runner.py
+++ b/examples/_scenario/runner.py
@@ -638,6 +638,179 @@ def create_mappings(
 
 
 # ---------------------------------------------------------------------------
+# Step 3c: Author disclosure notes (TaxonomyBlock reporting_extension)
+# ---------------------------------------------------------------------------
+
+
+def create_disclosure_notes(
+  graph_id: str,
+  notes: list[dict],
+  element_lookup: dict[str, str],
+) -> tuple[int, int]:
+  """Author per-tenant disclosure note structures and multi-map their members.
+
+  Each note becomes a ``reporting_extension`` TaxonomyBlock: member
+  concepts parented under a library total, one ``regulatory_disclosure``
+  structure with ``concept_arrangement='roll_up'``, and presentation +
+  calculation arcs whose total endpoint IS the library concept. The
+  member CoA accounts are then multi-mapped (member + the library total
+  the episode's ``mappings.py`` already maps), so the face-statement
+  line and the note foot over the same facts. Rendering is fact-driven:
+  ``create-report`` picks the note because its concepts receive facts.
+
+  The create-taxonomy-block operation is posted directly over HTTP for
+  now: the published robosystems-client (0.5.1) predates the
+  ``regulatory_disclosure`` block_type + ``concept_arrangement`` request
+  fields and its generated enum rejects them client-side. Swap to
+  ``LedgerClient.create_taxonomy_block`` once the SDK is regenerated.
+
+  Returns (notes_created, member_mappings_created).
+  """
+  import httpx
+
+  config = _client_config()
+  headers = {"X-API-Key": config["token"], "Content-Type": "application/json"}
+  client = _get_ledger_client()
+
+  taxonomies = client.list_taxonomies(graph_id, taxonomy_type="reporting_standard")
+  rs_gaap = next(
+    (t for t in taxonomies if (t.get("standard") or "").startswith("rs-gaap")), None
+  )
+  if rs_gaap is None:
+    print("  ERROR: rs-gaap reporting standard not found in graph")
+    return 0, 0
+
+  structures = client.list_structures(graph_id, block_type="coa_mapping")
+  mapping_id = structures[0]["id"] if structures else None
+  if mapping_id is None:
+    print("  ERROR: no coa_mapping structure — member multi-mapping skipped")
+
+  notes_created = 0
+  member_mappings = 0
+  for note in notes:
+    struct_name = note["name"]
+    total_qname = note["total_qname"]
+    members = note["members"]
+    payload = {
+      "name": note.get("taxonomy_name", f"{struct_name} Extension"),
+      "taxonomy_type": "reporting_extension",
+      "parent_taxonomy_id": rs_gaap["id"],
+      "description": note.get("description"),
+      "elements": [
+        {
+          "qname": m["qname"],
+          "name": m["name"],
+          "parent_ref": total_qname,
+          "balance_type": "debit",
+          "period_type": "instant",
+          "is_monetary": True,
+        }
+        for m in members
+      ],
+      "structures": [
+        {
+          "name": struct_name,
+          "description": note.get("description"),
+          "block_type": "regulatory_disclosure",
+          "concept_arrangement": "roll_up",
+          "role_uri": note.get("role_uri"),
+        }
+      ],
+      "associations": [
+        *(
+          {
+            "structure_ref": struct_name,
+            "from_ref": total_qname,
+            "to_ref": m["qname"],
+            "association_type": "presentation",
+            "order_value": float(i + 1),
+          }
+          for i, m in enumerate(members)
+        ),
+        *(
+          {
+            "structure_ref": struct_name,
+            "from_ref": total_qname,
+            "to_ref": m["qname"],
+            "association_type": "calculation",
+            "order_value": float(i + 1),
+            "weight": 1.0,
+          }
+          for i, m in enumerate(members)
+        ),
+      ],
+      "rules": [],
+    }
+    resp = httpx.post(
+      f"{BASE_URL}/extensions/roboledger/{graph_id}/operations/create-taxonomy-block",
+      json=payload,
+      headers=headers,
+      timeout=120.0,
+    )
+    if resp.status_code >= 400:
+      print(
+        f"  ERROR: create-taxonomy-block failed ({resp.status_code}): {resp.text[:300]}"
+      )
+      continue
+    envelope = (resp.json() or {}).get("result") or {}
+    notes_created += 1
+
+    member_ids_by_qname = {
+      e.get("qname"): e.get("id") for e in envelope.get("elements", [])
+    }
+    if mapping_id is None:
+      continue
+    for m in members:
+      coa_id = element_lookup.get(m["coa_code"])
+      member_id = member_ids_by_qname.get(m["qname"])
+      if not coa_id or not member_id:
+        print(f"  WARNING: could not multi-map {m['coa_code']} → {m['qname']}")
+        continue
+      client.create_mapping_association(
+        graph_id,
+        mapping_id=mapping_id,
+        from_element_id=coa_id,
+        to_element_id=member_id,
+      )
+      member_mappings += 1
+
+  return notes_created, member_mappings
+
+
+def verify_disclosure_notes(graph_id: str) -> None:
+  """Print the rendered disclosure notes after the report ran.
+
+  Fact-driven proof: the notes only exist in the render output because
+  the report's facts reached their concepts. Prints each note's rows
+  (with the footed total) and its verification summary.
+  """
+  client = _get_ledger_client()
+  blocks = client.list_information_blocks(graph_id, block_type="regulatory_disclosure")
+  if not blocks:
+    print("  WARNING: no disclosure notes rendered")
+    return
+  for block in blocks:
+    # parse_information_blocks snake_cases every key.
+    name = block.get("name") or block.get("display_name") or block.get("id")
+    facts = block.get("facts") or []
+    summary = block.get("verification_summary") or {}
+    rendering = (block.get("view") or {}).get("rendering") or {}
+    rows = rendering.get("rows") or []
+    print(f"  {name}: {len(facts)} facts, {len(rows)} rendered rows")
+    for row in rows:
+      values = row.get("values") or []
+      latest = values[-1] if values else None
+      marker = "Σ" if row.get("is_subtotal") else " "
+      # Report fact values are natural-signed dollars (not cents).
+      amount = f"${latest:,.2f}" if isinstance(latest, (int, float)) else "—"
+      print(f"    {marker} {row.get('element_name')}: {amount}")
+    passed = summary.get("passed", 0)
+    total = summary.get("total", 0)
+    if total:
+      print(f"    Verification: {passed}/{total} rules passed")
+
+
+# ---------------------------------------------------------------------------
 # Step 3b: AI mapping path — requires Bedrock (optional)
 # ---------------------------------------------------------------------------
 
@@ -1045,6 +1218,7 @@ def run_demo(
   documents: list[dict],
   output_dir: Path,
   reveal_prompts: list[str],
+  disclosures: list[dict] | None = None,
   argv: list[str] | None = None,
 ) -> None:
   """Provision a graph and load the full company for one showcase episode.
@@ -1053,6 +1227,9 @@ def run_demo(
   are the episode's counterparties, CoA→rs-gaap mapping callable, and policy
   docs; ``output_dir`` is where the report bundles land; ``reveal_prompts``
   are the episode-specific Beat-4 analysis questions printed at the end.
+  ``disclosures`` (optional) are per-tenant authored disclosure notes (see
+  ``create_disclosure_notes``) — authored after mapping, verified after the
+  report renders them fact-driven.
   """
   argv = sys.argv if argv is None else argv
   dry_run = "--dry-run" in argv
@@ -1134,6 +1311,17 @@ def run_demo(
     )
     print(f"  Mappings:     {mapping_count}")
 
+  # Author disclosure notes (TaxonomyBlock reporting_extension) + member
+  # multi-mapping — after CoA mapping so the note's members and the face
+  # statements share leaves.
+  if disclosures:
+    print("\nAuthoring disclosure notes...")
+    note_count, member_map_count = create_disclosure_notes(
+      graph_id, disclosures, element_lookup
+    )
+    print(f"  Notes:        {note_count}")
+    print(f"  Member maps:  {member_map_count}")
+
   # Initialize fiscal calendar (via HTTP API — exercises initialize op)
   print("\nInitializing fiscal calendar...")
   close_target = initialize_fiscal_calendar(graph_id, scenario)
@@ -1155,6 +1343,12 @@ def run_demo(
   # Generate + file the annual report
   print("\nGenerating annual report...")
   report_id = generate_annual_report(graph_id, scenario, output_dir)
+
+  # Fact-driven disclosure proof — the notes render because the report's
+  # facts reached their concepts (no style composition involved).
+  if disclosures and report_id:
+    print("\nRendered disclosure notes:")
+    verify_disclosure_notes(graph_id)
 
   # Summary
   print("\n" + "=" * 60)

--- a/examples/coffee_roaster_demo/data.py
+++ b/examples/coffee_roaster_demo/data.py
@@ -62,6 +62,8 @@ ACCOUNTS: list[tuple[str, str, str, str, str, str | None]] = [
   ("1210", "Prepaid Software", "asset", "other_current_assets", "debit", None),
   ("1220", "Prepaid Fulfillment", "asset", "other_current_assets", "debit", None),
   ("1400", "Inventory — Green Coffee", "asset", "inventory", "debit", None),
+  ("1410", "Inventory — Roasting WIP", "asset", "inventory", "debit", None),
+  ("1420", "Inventory — Finished Goods", "asset", "inventory", "debit", None),
   ("1500", "Roasting & Packaging Equipment", "asset", "fixed_assets", "debit", None),
   ("1550", "Accumulated Depreciation", "asset", "fixed_assets", "credit", None),
   # Liabilities
@@ -292,8 +294,10 @@ PREPAIDS = [
 
 
 def _opening(start: date) -> list:
-  """Founding balance sheet: cash, on-hand green coffee, the roasting line (net
-  of accumulated depreciation), and paid-in capital + retained earnings."""
+  """Founding balance sheet: cash, on-hand inventory across the three stages
+  (green coffee, roasting WIP, bagged finished goods — the breakdown the
+  inventory-components disclosure note foots), the roasting line (net of
+  accumulated depreciation), and paid-in capital + retained earnings."""
   return [
     (
       start,
@@ -303,10 +307,12 @@ def _opening(start: date) -> list:
       [
         ("1000", 60_000_00, 0),  # Operating cash
         ("1400", 8_000_00, 0),  # Green-coffee inventory on hand
+        ("1410", 3_000_00, 0),  # Roasting WIP on the floor
+        ("1420", 5_000_00, 0),  # Bagged finished goods
         ("1500", 90_000_00, 0),  # Roasting & packaging equipment (gross)
         ("1550", 0, 30_000_00),  # Accumulated depreciation
         ("3000", 0, 100_000_00),  # Paid-in capital
-        ("3100", 0, 28_000_00),  # Retained earnings
+        ("3100", 0, 36_000_00),  # Retained earnings
       ],
     ),
   ]

--- a/examples/coffee_roaster_demo/disclosures.py
+++ b/examples/coffee_roaster_demo/disclosures.py
@@ -1,0 +1,57 @@
+"""Driftline's authored disclosure notes — the report-engine proof.
+
+The inventory-components note is authored **per-tenant** through the
+TaxonomyBlock envelope (``reporting_extension``): three member concepts
+parented under the rs-gaap balance-sheet inventory leaf, one
+``regulatory_disclosure`` structure with ``concept_arrangement='roll_up'``,
+and presentation + calculation arcs whose total **is** the library BS
+leaf. Nothing is added to the framework source — this is the
+extend-and-map path.
+
+Rendering is fact-driven: the note joins the report render set because
+its concepts receive mapped facts (each inventory account multi-maps to
+its member concept AND the BS leaf), so the balance-sheet Inventory line
+and the note total are literally the same fact — the cross-block tie-out
+is definitional, and the note's internal footing (Σ members = total) is
+validated by the auto-emitted RollUp rule.
+"""
+
+from __future__ import annotations
+
+INVENTORY_TOTAL_QNAME = (
+  "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings"
+)
+
+INVENTORY_NOTE: dict = {
+  "taxonomy_name": "Driftline Reporting Extension",
+  "name": "Inventory Components",
+  "description": (
+    "Inventory by stage — green coffee (raw materials), roasting WIP, "
+    "and bagged finished goods — footing to the balance-sheet "
+    "Inventory line."
+  ),
+  "role_uri": (
+    "https://driftlinecoffee.example.com/roles/disclosures/InventoryComponents"
+  ),
+  "total_qname": INVENTORY_TOTAL_QNAME,
+  # (member qname, display name, CoA code multi-mapped to the member)
+  "members": [
+    {
+      "qname": "driftline:InventoryRawMaterials",
+      "name": "Raw Materials — Green Coffee",
+      "coa_code": "1400",
+    },
+    {
+      "qname": "driftline:InventoryWorkInProcess",
+      "name": "Work in Process — Roasting",
+      "coa_code": "1410",
+    },
+    {
+      "qname": "driftline:InventoryFinishedGoods",
+      "name": "Finished Goods — Bagged Coffee",
+      "coa_code": "1420",
+    },
+  ],
+}
+
+DISCLOSURE_NOTES: list[dict] = [INVENTORY_NOTE]

--- a/examples/coffee_roaster_demo/main.py
+++ b/examples/coffee_roaster_demo/main.py
@@ -24,6 +24,7 @@ from examples._scenario.runner import run_demo
 
 from .agents import AGENTS
 from .data import SCENARIO
+from .disclosures import DISCLOSURE_NOTES
 from .mappings import mappings_for
 from .policies import DOCUMENTS
 
@@ -44,6 +45,7 @@ def main() -> None:
     documents=DOCUMENTS,
     output_dir=Path(__file__).resolve().parent / "output",
     reveal_prompts=REVEAL_PROMPTS,
+    disclosures=DISCLOSURE_NOTES,
   )
 
 

--- a/examples/coffee_roaster_demo/mappings.py
+++ b/examples/coffee_roaster_demo/mappings.py
@@ -29,7 +29,14 @@ MAPPINGS: list[tuple[str, str]] = [
   ("1200", "rs-gaap:PrepaidExpenseCurrent"),  # Prepaid insurance
   ("1210", "rs-gaap:PrepaidExpenseCurrent"),  # Prepaid software
   ("1220", "rs-gaap:PrepaidExpenseCurrent"),  # Prepaid fulfillment
+  # All three inventory stages map to the same Classified-BS leaf — and
+  # each ALSO multi-maps to its disclosure member concept (authored in
+  # disclosures.py; the member arcs are created by the disclosure-note
+  # runner step), so the BS line and the inventory-components note foot
+  # over the same facts.
   ("1400", "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings"),
+  ("1410", "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings"),
+  ("1420", "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings"),
   ("1500", "rs-gaap:PropertyPlantAndEquipmentGross"),  # Roasting & packaging equipment
   (
     "1550",

--- a/robosystems/models/api/taxonomy_block.py
+++ b/robosystems/models/api/taxonomy_block.py
@@ -104,12 +104,42 @@ class TaxonomyBlockStructureRequest(BaseModel):
     "reconciliation",
     "policy",
     "metric",
+    "regulatory_disclosure",
   ] = Field(
     ...,
     description=(
       "DB ``structures.block_type`` enum. CoA blocks use "
       "``chart_of_accounts``; reporting extensions use the statement "
-      "family or ``custom``; custom ontology uses ``custom``."
+      "family, ``regulatory_disclosure`` (disclosure notes), or "
+      "``custom``; custom ontology uses ``custom``."
+    ),
+  )
+  concept_arrangement: (
+    Literal[
+      "set",
+      "roll_up",
+      "roll_forward",
+      "roll_forward_info",
+      "adjustment",
+      "variance",
+      "arithmetic",
+      "text_block",
+      "level1_textblock",
+      "level2_textblock",
+      "level3_textblock",
+      "level4_detail",
+      "table_equivalent_textblock",
+      "grid",
+      "compound_fact",
+    ]
+    | None
+  ) = Field(
+    None,
+    description=(
+      "Concept Arrangement Pattern (CAP) — how the structure's concepts "
+      "relate (mirrors the ``structures.concept_arrangement`` CHECK "
+      "vocabulary). A disclosure note footing members to a total is "
+      "``roll_up``. Null leaves the pattern unset."
     ),
   )
   description: str | None = None

--- a/robosystems/operations/information_block/rules/engine.py
+++ b/robosystems/operations/information_block/rules/engine.py
@@ -243,8 +243,10 @@ def _evaluate_rollup_arc_derived(
   reported on this structure (e.g. an IS decomposition rule landing on the CF)
   is skipped, matching the prior evaluator.
 
-  Returns ``None`` when the parent isn't an rs-gaap calc subtotal, so the caller
-  falls back to the frozen-expression evaluator (custom / fac rollups).
+  Returns ``None`` when the parent has no calc children in the merged DAG
+  (global rs-gaap-calculations overlaid with the structure's own calc arcs),
+  so the caller falls back to the frozen-expression evaluator (custom / fac
+  rollups).
   """
   parent_id, parent_qname = _rollup_parent_element_id(session, rule, cache)
   if parent_id is None or parent_id not in calculations:
@@ -380,6 +382,27 @@ def evaluate_rules_for_structure(
     )
 
     calculations = load_rs_gaap_calculations(session)
+    # Tenant-authored roll_up structures (disclosure notes) foot against
+    # their OWN calculation arcs — their parents aren't rs-gaap subtotals,
+    # so the global DAG carries no entry for them. Overlay the structure's
+    # local calc arcs, letting the global DAG win where both define a
+    # parent (statement structures mirror it anyway). Same live-arc
+    # doctrine as the global path: children come from arcs, never from a
+    # frozen enumeration.
+    local_calcs: dict[str, list[tuple[str, float]]] = {}
+    for assoc in sorted(
+      associations,
+      key=lambda x: x.order_value if x.order_value is not None else float("inf"),
+    ):
+      if assoc.association_type != "calculation":
+        continue
+      if assoc.from_element_id is None or assoc.to_element_id is None:
+        continue
+      local_calcs.setdefault(assoc.from_element_id, []).append(
+        (assoc.to_element_id, assoc.weight if assoc.weight is not None else 1.0)
+      )
+    for parent_id, children in local_calcs.items():
+      calculations.setdefault(parent_id, children)
     by_period = _load_period_balances(
       session, structure_id, fact_set_id, period_start, period_end
     )

--- a/robosystems/operations/serialization/xbrl/xbrl_21.py
+++ b/robosystems/operations/serialization/xbrl/xbrl_21.py
@@ -78,7 +78,12 @@ def serialize_to_xbrl_21(bundle: StatementBundle) -> bytes:
   Returns the zip bytes ready to stream as a download or write to
   storage. The shape is a flat zip containing standalone files; the
   full Report Package META-INF directory is not yet wrapped around them.
+
+  Tenant-authored disclosure notes are excluded from this flavor for
+  now (:func:`_strip_disclosure_content`) — they ride in the JSON-LD /
+  holon flavors, whose SHACL validation covers them.
   """
+  bundle = _strip_disclosure_content(bundle)
   buf = io.BytesIO()
   with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
     zf.writestr("instance.xml", _serialize_xml(_build_instance(bundle)))
@@ -108,6 +113,90 @@ def _serialize_xml(root: etree._Element) -> bytes:
     encoding="UTF-8",
     pretty_print=True,
     standalone=True,
+  )
+
+
+def _strip_disclosure_content(bundle: StatementBundle) -> StatementBundle:
+  """Return a bundle without ``regulatory_disclosure`` structures' content.
+
+  Tenant-authored disclosure notes are carried by the JSON-LD / holon
+  flavors (SHACL-validated), but this emitter's conventions are
+  statement-shaped: fixed framework prefixes (an extension concept like
+  ``driftline:X`` has no namespace here), one arc type per Network ELR
+  (a note carries presentation AND calculation arcs on one structure —
+  Arelle flags the duplicate), and no per-fact context typing for
+  non-statement structures. Until the emitter learns those, notes are
+  excluded here rather than shipping an instance Arelle rejects.
+
+  No-op (returns the same object) when the bundle has no disclosure
+  links, i.e. every pre-existing statement bundle.
+  """
+  disclosure_structure_ids = {
+    link.structure_id
+    for group in (
+      bundle.linkbases.presentation_links,
+      bundle.linkbases.calculation_links,
+      bundle.linkbases.definition_links,
+    )
+    for link in group
+    if link.block_type == "regulatory_disclosure"
+  }
+  if not disclosure_structure_ids:
+    return bundle
+
+  linkbases = bundle.linkbases.model_copy(
+    update={
+      "presentation_links": [
+        li
+        for li in bundle.linkbases.presentation_links
+        if li.structure_id not in disclosure_structure_ids
+      ],
+      "calculation_links": [
+        li
+        for li in bundle.linkbases.calculation_links
+        if li.structure_id not in disclosure_structure_ids
+      ],
+      "definition_links": [
+        li
+        for li in bundle.linkbases.definition_links
+        if li.structure_id not in disclosure_structure_ids
+      ],
+    }
+  )
+  facts = [
+    f
+    for f in bundle.facts
+    if f.structure_id is None or f.structure_id not in disclosure_structure_ids
+  ]
+
+  # Keep only concepts still referenced by a surviving fact or arc —
+  # extension concepts referenced solely by the stripped note would
+  # otherwise be declared under a framework namespace they don't belong
+  # to (the fixed-prefix mangle).
+  referenced_qnames = {f.element_qname for f in facts}
+  for group in (
+    linkbases.presentation_links,
+    linkbases.calculation_links,
+    linkbases.definition_links,
+  ):
+    for link in group:
+      for arc in link.arcs:
+        referenced_qnames.add(arc.from_qname)
+        referenced_qnames.add(arc.to_qname)
+  schema_concepts = [c for c in bundle.schema_concepts if c.qname in referenced_qnames]
+
+  # Drop period nodes no surviving fact references so the derived
+  # context set stays minimal.
+  referenced_periods = {f.period_ref for f in facts}
+  period_nodes = [p for p in bundle.period_nodes if p.id in referenced_periods]
+
+  return bundle.model_copy(
+    update={
+      "linkbases": linkbases,
+      "facts": facts,
+      "schema_concepts": schema_concepts,
+      "period_nodes": period_nodes,
+    }
   )
 
 

--- a/robosystems/operations/taxonomy_block/auto_rules.py
+++ b/robosystems/operations/taxonomy_block/auto_rules.py
@@ -26,13 +26,27 @@ Rules emitted:
     NoCycles         — ReportLevelModelStructureRule
     NoOrphanArcs     — ReportLevelModelStructureRule
     ParentBeforeChild — ReportLevelModelStructureRule
+
+  Per-structure (``concept_arrangement='roll_up'`` with calculation arcs):
+    RollUp (rule_pattern) — FundamentalAccountingConceptRelation, one per
+    calc parent. The engine's arc-derived evaluator foots the parent
+    against its live calc children (structure-local arcs overlaid onto
+    the global DAG), so an authored disclosure note gets footing
+    validation the moment its facts land — no hand-authored rule needed.
 """
 
 from __future__ import annotations
 
-from sqlalchemy.orm import Session
+from sqlalchemy import select
+from sqlalchemy.orm import Session, aliased
 
-from robosystems.models.extensions import Rule, Structure, Taxonomy
+from robosystems.models.extensions import (
+  Association,
+  Element,
+  Rule,
+  Structure,
+  Taxonomy,
+)
 
 _AUTO = "auto"
 _STRUCTURE_RULES = "ReportLevelModelStructureRule"
@@ -109,8 +123,111 @@ def emit_auto_rules(
         target_structure_id=structure_id,
         created_by=created_by,
       )
+    if structure.concept_arrangement == "roll_up":
+      _add_rollup_rules(
+        session,
+        taxonomy_id=taxonomy_id,
+        structure=structure,
+        created_by=created_by,
+      )
 
   session.flush()
+
+
+def _add_rollup_rules(
+  session: Session,
+  *,
+  taxonomy_id: str,
+  structure: Structure,
+  created_by: str,
+) -> None:
+  """Emit one structure-scoped RollUp rule per calculation parent.
+
+  Mirrors the seeded ``rs-gaap-rollup-rules`` shape
+  (``generate_rollup_rules.py``: parent-first variables,
+  FundamentalAccountingConceptRelation, pattern ``RollUp``) so the
+  engine's arc-derived evaluator picks it up unchanged. Variables carry
+  ``variable_element_id`` explicitly — authored structures may reference
+  tenant elements whose qname resolution shouldn't be load-bearing.
+
+  No calculation arcs → no rules (a presentation-only roll_up renders
+  but has nothing to foot).
+  """
+  parent_el = aliased(Element)
+  child_el = aliased(Element)
+  rows = session.execute(
+    select(
+      Association.from_element_id,
+      Association.to_element_id,
+      Association.weight,
+      Association.order_value,
+      parent_el.qname.label("parent_qname"),
+      parent_el.name.label("parent_name"),
+      child_el.qname.label("child_qname"),
+      child_el.name.label("child_name"),
+    )
+    .join(parent_el, parent_el.id == Association.from_element_id)
+    .join(child_el, child_el.id == Association.to_element_id)
+    .where(
+      Association.structure_id == str(structure.id),
+      Association.association_type == "calculation",
+    )
+    .order_by(Association.from_element_id, Association.order_value.asc().nulls_last())
+  ).fetchall()
+  if not rows:
+    return
+
+  by_parent: dict[str, list] = {}
+  for row in rows:
+    by_parent.setdefault(row.from_element_id, []).append(row)
+
+  for parent_id, children in by_parent.items():
+    first = children[0]
+    parent_label = (first.parent_qname or first.parent_name or parent_id).split(":")[-1]
+    variables: list[dict[str, str]] = [
+      {
+        "variable_name": parent_label,
+        "variable_qname": first.parent_qname or "",
+        "variable_element_id": parent_id,
+      }
+    ]
+    terms: list[str] = []
+    for child in children:
+      child_label = (
+        child.child_qname or child.child_name or child.to_element_id
+      ).split(":")[-1]
+      variables.append(
+        {
+          "variable_name": child_label,
+          "variable_qname": child.child_qname or "",
+          "variable_element_id": child.to_element_id,
+        }
+      )
+      weight = child.weight if child.weight is not None else 1.0
+      sign = "-" if weight < 0 else "+"
+      terms.append(f"{sign} ${child_label}")
+    expression = f"${parent_label} = {' '.join(terms).lstrip('+ ')}"
+
+    session.add(
+      Rule(
+        taxonomy_id=taxonomy_id,
+        rule_category=_FAC_RULES,
+        rule_pattern="RollUp",
+        rule_check_kind=None,
+        rule_expression=expression,
+        rule_message=(
+          f"Calculation rollup: {parent_label} must equal the calculation "
+          f"sum of its children."
+        ),
+        rule_severity="error",
+        rule_origin=_AUTO,
+        target_kind="structure",
+        target_structure_id=str(structure.id),
+        rule_variables=variables,
+        metadata_={},
+        created_by=created_by,
+      )
+    )
 
 
 def _add(

--- a/robosystems/operations/taxonomy_block/custom_ontology.py
+++ b/robosystems/operations/taxonomy_block/custom_ontology.py
@@ -147,13 +147,19 @@ def create(
 
   structures_by_name: dict[str, Structure] = {}
   for req in payload.structures:
+    # role_uri rides in metadata_ — the column-less convention the
+    # envelope readers already use (metadata_['role_uri']).
+    structure_metadata = dict(req.metadata)
+    if req.role_uri:
+      structure_metadata["role_uri"] = req.role_uri
     structure = Structure(
       name=req.name,
       description=req.description,
       block_type=req.block_type,
+      concept_arrangement=req.concept_arrangement,
       taxonomy_id=taxonomy.id,
       is_active=True,
-      metadata_=dict(req.metadata),
+      metadata_=structure_metadata,
       created_by=created_by,
     )
     session.add(structure)

--- a/robosystems/operations/taxonomy_block/reporting_extension.py
+++ b/robosystems/operations/taxonomy_block/reporting_extension.py
@@ -206,13 +206,19 @@ def create(
 
   structures_by_name: dict[str, Structure] = {}
   for req in payload.structures:
+    # role_uri rides in metadata_ — the column-less convention the
+    # envelope readers already use (metadata_['role_uri']).
+    structure_metadata = dict(req.metadata)
+    if req.role_uri:
+      structure_metadata["role_uri"] = req.role_uri
     structure = Structure(
       name=req.name,
       description=req.description,
       block_type=req.block_type,
+      concept_arrangement=req.concept_arrangement,
       taxonomy_id=taxonomy.id,
       is_active=True,
-      metadata_=dict(req.metadata),
+      metadata_=structure_metadata,
       created_by=created_by,
     )
     session.add(structure)

--- a/robosystems/operations/taxonomy_block/update_apply.py
+++ b/robosystems/operations/taxonomy_block/update_apply.py
@@ -129,13 +129,19 @@ def apply_structures_to_add(
   """Insert new structures; return name→Structure lookup of just the new ones."""
   new_structures_by_name: dict[str, Structure] = {}
   for req in payload.structures_to_add:
+    # role_uri rides in metadata_ — the column-less convention the
+    # envelope readers already use (metadata_['role_uri']).
+    structure_metadata = dict(req.metadata)
+    if req.role_uri:
+      structure_metadata["role_uri"] = req.role_uri
     structure = Structure(
       name=req.name,
       description=req.description,
       block_type=req.block_type,
+      concept_arrangement=req.concept_arrangement,
       taxonomy_id=taxonomy.id,
       is_active=True,
-      metadata_=dict(req.metadata),
+      metadata_=structure_metadata,
       created_by=updated_by,
     )
     session.add(structure)

--- a/tests/operations/information_block/rules/test_rollup_arc_derived.py
+++ b/tests/operations/information_block/rules/test_rollup_arc_derived.py
@@ -243,3 +243,123 @@ class TestRollupRoutingInEngine:
     added = session.add.call_args_list[0][0][0]
     assert added.status == "pass"
     assert added.detail.get("source") == "calc-dag"
+
+  def test_structure_local_calc_arcs_overlay_the_global_dag(self) -> None:
+    """A tenant-authored roll_up note foots against its OWN calc arcs.
+
+    The note's parent (a BS leaf, e.g. the inventory total) has no
+    children in the global rs-gaap-calculations DAG — before the overlay
+    the arc-derived evaluator returned None and the auto RollUp rule fell
+    to the frozen evaluator with nothing to bind. The engine overlays the
+    structure's local calculation associations, so footing derives from
+    live arcs."""
+    session = MagicMock()
+    session.get.return_value = MagicMock(
+      id="struct_note", block_type="regulatory_disclosure"
+    )
+
+    rule_lite = MagicMock()
+    rule_lite.id = "rule_note_rollup"
+    rule_orm = _rule("elem_total", "rs-gaap:InventoryNet")
+    rule_orm.id = "rule_note_rollup"
+
+    def _calc_assoc(child_id: str, order: float) -> MagicMock:
+      a = MagicMock()
+      a.id = f"assoc_{child_id}"
+      a.association_type = "calculation"
+      a.from_element_id = "elem_total"
+      a.to_element_id = child_id
+      a.weight = 1.0
+      a.order_value = order
+      return a
+
+    assoc = MagicMock()
+    assoc.scalars.return_value.all.return_value = [
+      _calc_assoc("elem_raw", 1.0),
+      _calc_assoc("elem_fg", 2.0),
+    ]
+    rules_res = MagicMock()
+    rules_res.scalars.return_value.all.return_value = [rule_orm]
+    session.execute.side_effect = [assoc, rules_res]
+
+    by_period = {
+      _P1: (
+        {"elem_raw": 8000.0, "elem_fg": 5000.0, "elem_total": 13000.0},
+        {"elem_raw", "elem_fg", "elem_total"},
+      )
+    }
+
+    with (
+      patch(
+        "robosystems.operations.information_block.rules.engine.load_rules_for_structure",
+        return_value=[rule_lite],
+      ),
+      patch(
+        # Global DAG has NO entry for the note's parent.
+        "robosystems.operations.roboledger.reports.calc_dag.load_rs_gaap_calculations",
+        return_value={"rs-gaap:Assets": [("rs-gaap:AssetsCurrent", 1.0)]},
+      ),
+      patch(
+        "robosystems.operations.information_block.rules.engine._load_period_balances",
+        return_value=by_period,
+      ),
+    ):
+      results = evaluate_rules_for_structure(
+        session, "struct_note", period_start=_P1[0], period_end=_P1[1]
+      )
+
+    assert len(results) == 1
+    added = session.add.call_args_list[0][0][0]
+    assert added.status == "pass"
+    assert added.detail.get("source") == "calc-dag"
+
+  def test_global_dag_wins_over_local_arcs_for_shared_parent(self) -> None:
+    """When a parent exists in BOTH the global DAG and the structure's
+    local arcs, the global definition wins (statement structures mirror
+    it; overlay must not shadow #883's semantics)."""
+    session = MagicMock()
+    session.get.return_value = MagicMock(id="struct_bs", block_type="balance_sheet")
+
+    rule_lite = MagicMock()
+    rule_lite.id = "rule_bs"
+    rule_orm = _rule("ANC", "rs-gaap:AssetsNoncurrent")
+    rule_orm.id = "rule_bs"
+
+    local = MagicMock()
+    local.id = "assoc_local"
+    local.association_type = "calculation"
+    local.from_element_id = "ANC"
+    local.to_element_id = "WrongChild"
+    local.weight = 1.0
+    local.order_value = 1.0
+
+    assoc = MagicMock()
+    assoc.scalars.return_value.all.return_value = [local]
+    rules_res = MagicMock()
+    rules_res.scalars.return_value.all.return_value = [rule_orm]
+    session.execute.side_effect = [assoc, rules_res]
+
+    # Global children foot; the local WrongChild (0 balance) would fail.
+    by_period = {_P1: ({"PPE": 100.0, "ANC": 100.0}, {"PPE", "ANC"})}
+
+    with (
+      patch(
+        "robosystems.operations.information_block.rules.engine.load_rules_for_structure",
+        return_value=[rule_lite],
+      ),
+      patch(
+        "robosystems.operations.roboledger.reports.calc_dag.load_rs_gaap_calculations",
+        return_value={"ANC": [("PPE", 1.0)]},
+      ),
+      patch(
+        "robosystems.operations.information_block.rules.engine._load_period_balances",
+        return_value=by_period,
+      ),
+    ):
+      results = evaluate_rules_for_structure(
+        session, "struct_bs", period_start=_P1[0], period_end=_P1[1]
+      )
+
+    assert len(results) == 1
+    added = session.add.call_args_list[0][0][0]
+    assert added.status == "pass"

--- a/tests/operations/taxonomy_block/test_auto_rules.py
+++ b/tests/operations/taxonomy_block/test_auto_rules.py
@@ -19,10 +19,32 @@ def _fake_taxonomy(
   return t
 
 
-def _fake_structure(sid: str) -> MagicMock:
+def _fake_structure(sid: str, concept_arrangement: str | None = None) -> MagicMock:
   s = MagicMock()
   s.id = sid
+  s.concept_arrangement = concept_arrangement
   return s
+
+
+def _calc_row(
+  parent_id: str,
+  child_id: str,
+  *,
+  parent_qname: str,
+  child_qname: str,
+  weight: float = 1.0,
+  order_value: float | None = None,
+) -> MagicMock:
+  row = MagicMock()
+  row.from_element_id = parent_id
+  row.to_element_id = child_id
+  row.weight = weight
+  row.order_value = order_value
+  row.parent_qname = parent_qname
+  row.parent_name = parent_qname.split(":")[-1]
+  row.child_qname = child_qname
+  row.child_name = child_qname.split(":")[-1]
+  return row
 
 
 class TestEmitAutoRules:
@@ -175,3 +197,96 @@ class TestEmitAutoRules:
 
     added = [c.args[0] for c in session.add.call_args_list]
     assert all(r.created_by == "seeder_bot" for r in added)
+
+
+class TestRollupEmission:
+  """Auto-emitted RollUp footing rules for authored roll_up structures."""
+
+  def test_roll_up_structure_with_calc_arcs_emits_rollup_rule(self) -> None:
+    session = MagicMock()
+    taxonomy = _fake_taxonomy("reporting_extension", parent_taxonomy_id="lib_1")
+    note = _fake_structure("struct_note", concept_arrangement="roll_up")
+    session.execute.return_value.fetchall.return_value = [
+      _calc_row(
+        "elem_total",
+        "elem_raw",
+        parent_qname="rs-gaap:InventoryNet",
+        child_qname="driftline:InventoryRawMaterials",
+        order_value=1.0,
+      ),
+      _calc_row(
+        "elem_total",
+        "elem_fg",
+        parent_qname="rs-gaap:InventoryNet",
+        child_qname="driftline:InventoryFinishedGoods",
+        order_value=2.0,
+      ),
+    ]
+
+    emit_auto_rules(session, taxonomy, [note], created_by="usr_1")
+
+    added = [c.args[0] for c in session.add.call_args_list]
+    rollups = [r for r in added if r.rule_pattern == "RollUp"]
+    assert len(rollups) == 1
+    rule = rollups[0]
+    assert rule.rule_origin == "auto"
+    assert rule.target_kind == "structure"
+    assert rule.target_structure_id == "struct_note"
+    # Parent-first variables with explicit element ids — qname resolution
+    # must not be load-bearing for tenant-authored concepts.
+    assert rule.rule_variables[0]["variable_element_id"] == "elem_total"
+    assert rule.rule_variables[0]["variable_qname"] == "rs-gaap:InventoryNet"
+    child_ids = {v["variable_element_id"] for v in rule.rule_variables[1:]}
+    assert child_ids == {"elem_raw", "elem_fg"}
+    assert rule.rule_expression == (
+      "$InventoryNet = $InventoryRawMaterials + $InventoryFinishedGoods"
+    )
+
+  def test_negative_weight_renders_minus_term(self) -> None:
+    session = MagicMock()
+    taxonomy = _fake_taxonomy("reporting_extension", parent_taxonomy_id="lib_1")
+    note = _fake_structure("struct_note", concept_arrangement="roll_up")
+    session.execute.return_value.fetchall.return_value = [
+      _calc_row(
+        "elem_net",
+        "elem_gross",
+        parent_qname="ext:Net",
+        child_qname="ext:Gross",
+        order_value=1.0,
+      ),
+      _calc_row(
+        "elem_net",
+        "elem_allowance",
+        parent_qname="ext:Net",
+        child_qname="ext:Allowance",
+        weight=-1.0,
+        order_value=2.0,
+      ),
+    ]
+
+    emit_auto_rules(session, taxonomy, [note], created_by="usr_1")
+
+    added = [c.args[0] for c in session.add.call_args_list]
+    rule = next(r for r in added if r.rule_pattern == "RollUp")
+    assert rule.rule_expression == "$Net = $Gross - $Allowance"
+
+  def test_roll_up_without_calc_arcs_emits_no_rollup(self) -> None:
+    """Presentation-only roll_up renders but has nothing to foot."""
+    session = MagicMock()
+    taxonomy = _fake_taxonomy("reporting_extension", parent_taxonomy_id="lib_1")
+    note = _fake_structure("struct_note", concept_arrangement="roll_up")
+    session.execute.return_value.fetchall.return_value = []
+
+    emit_auto_rules(session, taxonomy, [note], created_by="usr_1")
+
+    added = [c.args[0] for c in session.add.call_args_list]
+    assert not [r for r in added if r.rule_pattern == "RollUp"]
+
+  def test_non_roll_up_structure_skips_rollup_query(self) -> None:
+    session = MagicMock()
+    taxonomy = _fake_taxonomy("reporting_extension", parent_taxonomy_id="lib_1")
+    plain = _fake_structure("struct_plain", concept_arrangement=None)
+
+    emit_auto_rules(session, taxonomy, [plain], created_by="usr_1")
+
+    session.execute.assert_not_called()

--- a/tests/operations/taxonomy_block/test_reporting_extension.py
+++ b/tests/operations/taxonomy_block/test_reporting_extension.py
@@ -16,9 +16,33 @@ from pydantic import ValidationError
 from robosystems.models.api.taxonomy_block import (
   CreateTaxonomyBlockRequest,
   DeleteTaxonomyBlockRequest,
+  TaxonomyBlockStructureRequest,
   UpdateTaxonomyBlockRequest,
 )
 from robosystems.operations.taxonomy_block import reporting_extension
+
+
+def test_structure_request_accepts_disclosure_note_shape() -> None:
+  """A disclosure note is authorable through the envelope: the
+  ``regulatory_disclosure`` block_type plus a CAP from the closed
+  ``concept_arrangement`` vocabulary."""
+  req = TaxonomyBlockStructureRequest(
+    name="Inventory Components",
+    block_type="regulatory_disclosure",
+    concept_arrangement="roll_up",
+    role_uri="https://example.com/roles/disclosures/InventoryComponents",
+  )
+  assert req.block_type == "regulatory_disclosure"
+  assert req.concept_arrangement == "roll_up"
+
+
+def test_structure_request_rejects_unknown_concept_arrangement() -> None:
+  with pytest.raises(ValidationError):
+    TaxonomyBlockStructureRequest(
+      name="Bad CAP",
+      block_type="regulatory_disclosure",
+      concept_arrangement="not_a_cap",  # type: ignore[arg-type]
+    )
 
 
 def test_create_request_rejects_missing_parent() -> None:


### PR DESCRIPTION
## Summary

Part 2 of the disclosure-notes increment (part 1: #885 — the fact-driven render substrate). This PR makes disclosure notes **authorable per-tenant** through the TaxonomyBlock envelope and gives them **automatic footing validation**, proven end-to-end by the Driftline demo. No framework-source edits, no reseed, no schema migration.

- **TaxonomyBlock envelope** (`models/api/taxonomy_block.py` + handlers): `regulatory_disclosure` joins the structure `block_type` Literal; new optional `concept_arrangement` field (the closed CAP vocabulary). All three structure-insert sites persist both, plus the previously-dropped `role_uri` (via the `metadata_['role_uri']` convention the envelope readers already use).
- **Automatic footing** (`auto_rules.py` + `rules/engine.py`): an authored `roll_up` structure with calculation arcs gets a structure-scoped `RollUp` rule at create time (seeded-rule shape, parent-first variables with explicit element ids), and the arc-derived evaluator overlays the structure's own calc arcs onto the global `rs-gaap-calculations` DAG (global wins on shared parents) — extending #883's live-arc doctrine to tenant-authored notes.
- **XBRL 2.1 emitter**: disclosure-note content is excluded from this flavor for now — the emitter's fixed framework prefixes can't declare extension concepts (`driftline:X` mangles into `rs-gaap`), and a note carries both arc types on one structure (Arelle flags duplicate arcs). Notes ride the JSON-LD/holon flavors, which SHACL-validate them. Teaching the emitter extension namespaces + role-split arcs is a scoped follow-up.
- **Driftline demo**: three-stage inventory CoA (green coffee / roasting WIP / finished goods), a `disclosures.py` note spec, a runner step that authors the note via `create-taxonomy-block` and multi-maps each account to its member concept + the BS leaf, and a post-report verification step printing the footed rows.

## E2E proof (local run)

```
Notes:        1
Member maps:  3
Package:      5 block(s) — … , Inventory Components
Arelle:   valid    SHACL: conforms
Inventory Components: 8 facts, 4 rendered rows
  Raw Materials $88,000 + WIP $3,000 + Finished Goods $5,000
  Σ Inventory …: $96,000.00   RollUp verification: pass
```

BS Inventory line unchanged and equal to the note total (same facts — the cross-block tie-out is definitional).

## Notes

- The demo posts `create-taxonomy-block` over raw HTTP (same REST surface) until the Python SDK is regenerated — its generated enum predates the new block_type. Swap to the typed wrapper on the next SDK release.
- Full suite: 2765 passed; the single failure is the known pre-existing local-only ordering flake in `test_incremental_equals_full_load` (fails identically on clean main, passes in isolation and CI).
- 10 new unit tests: envelope shape acceptance/rejection, RollUp auto-emission (incl. negative weights, no-arc and non-roll_up guards), engine overlay (local-arc footing + global-wins-on-shared-parent).