### PR TITLE
Post-review cleanup + 3 contained bugfixes (disclosure/rules follow-ups)

### DIFF
--- a/robosystems/models/extensions/structure.py
+++ b/robosystems/models/extensions/structure.py
@@ -26,6 +26,33 @@ from sqlalchemy.dialects.postgresql import JSONB
 from robosystems.db.extensions import ExtensionsBase
 from robosystems.utils.ulid import generate_prefixed_ulid
 
+# Concept Arrangement Pattern (CAP) vocabulary — the single source of truth for
+# the ``structures.concept_arrangement`` CHECK below, the API request Literal in
+# ``models/api/taxonomy_block.py`` (tied here by a drift test), and seed
+# validation. 8 canonical + 5 cm.xsd text-block/detail specializations + 2
+# pseudo (15 total).
+CONCEPT_ARRANGEMENT_VALUES: tuple[str, ...] = (
+  # 8 canonical CAPs
+  "set",
+  "roll_up",
+  "roll_forward",
+  "roll_forward_info",
+  "adjustment",
+  "variance",
+  "arithmetic",
+  "text_block",
+  # 5 cm.xsd text-block / detail specializations (Charlie encodes
+  # text-block level as the CAP itself).
+  "level1_textblock",
+  "level2_textblock",
+  "level3_textblock",
+  "level4_detail",
+  "table_equivalent_textblock",
+  # 2 pseudo-patterns
+  "grid",
+  "compound_fact",
+)
+
 
 class Structure(ExtensionsBase):
   __tablename__ = "structures"
@@ -68,21 +95,13 @@ class Structure(ExtensionsBase):
       ")",
       name="check_block_type",
     ),
-    # Concept Arrangement Pattern (CAP). 8 canonical + 5 cm.xsd
-    # text-block/detail specializations + 2 pseudo (15 total). NULL
-    # allowed for block types that don't declare a default.
+    # Concept Arrangement Pattern (CAP). Vocabulary from
+    # ``CONCEPT_ARRANGEMENT_VALUES`` (single source of truth). NULL allowed
+    # for block types that don't declare a default.
     CheckConstraint(
       "concept_arrangement IS NULL OR concept_arrangement IN ("
-      # 8 canonical CAPs
-      "'set', 'roll_up', 'roll_forward', 'roll_forward_info', "
-      "'adjustment', 'variance', 'arithmetic', 'text_block', "
-      # 5 cm.xsd text-block / detail specializations (Charlie encodes
-      # text-block level as the CAP itself).
-      "'level1_textblock', 'level2_textblock', 'level3_textblock', "
-      "'level4_detail', 'table_equivalent_textblock', "
-      # 2 pseudo-patterns
-      "'grid', 'compound_fact'"
-      ")",
+      + ", ".join(f"'{v}'" for v in CONCEPT_ARRANGEMENT_VALUES)
+      + ")",
       name="check_concept_arrangement",
     ),
     # Member Arrangement Pattern (MAP). 5 canonical, from non-aggregating

--- a/robosystems/operations/information_block/disclosure.py
+++ b/robosystems/operations/information_block/disclosure.py
@@ -35,18 +35,20 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from robosystems.operations.information_block.statement import (
-  _build_statement_envelope,  # type: ignore[reportPrivateUsage]
-)
+from robosystems.operations.information_block.envelope import DISCLOSURE_BLOCK_TYPE
+from robosystems.operations.information_block.statement import make_statement_handlers
 
 if TYPE_CHECKING:
   from sqlalchemy.orm import Session
 
   from robosystems.models.api.information_block import InformationBlockEnvelope
 
-DISCLOSURE_BLOCK_TYPE = "regulatory_disclosure"
 DISCLOSURE_DISPLAY_NAME = "Disclosure"
 DISCLOSURE_CATEGORY = "Reporting"
+
+# The statement family's envelope builder, bound to this block_type — the
+# public factory, so disclosure.py doesn't reach for statement internals.
+_build_disclosure_envelope = make_statement_handlers(DISCLOSURE_BLOCK_TYPE)
 
 
 def build_envelope(
@@ -60,12 +62,7 @@ def build_envelope(
   ``regulatory_disclosure``, or carries no arcs (the library's
   disclosure-identity envelopes — not renderable blocks).
   """
-  envelope = _build_statement_envelope(
-    session,
-    structure_id,
-    fact_set_id,
-    block_type=DISCLOSURE_BLOCK_TYPE,
-  )
+  envelope = _build_disclosure_envelope(session, structure_id, fact_set_id)
   if envelope is None or not envelope.connections:
     return None
   return envelope

--- a/robosystems/operations/information_block/envelope.py
+++ b/robosystems/operations/information_block/envelope.py
@@ -38,6 +38,11 @@ from robosystems.models.extensions import (
 )
 from robosystems.models.extensions.roboledger import Fact, FactSet
 
+# The disclosure-note block_type string. Defined here — the lowest module in
+# the statement/disclosure import cluster — so envelope.py, disclosure.py
+# (re-export), and the serialization/report paths share one canonical value.
+DISCLOSURE_BLOCK_TYPE = "regulatory_disclosure"
+
 
 def element_to_lite(element: Element) -> ElementLite:
   """Project an :class:`Element` ORM row onto :class:`ElementLite`."""
@@ -534,7 +539,7 @@ def _disclosure_qname_for_type(session: Session, block_type: str) -> str | None:
   their own role_uri (case 1 in
   :func:`load_disclosure_id_for_structure`) or not at all.
   """
-  if block_type == "regulatory_disclosure":
+  if block_type == DISCLOSURE_BLOCK_TYPE:
     return None
 
   cached = _DISCLOSURE_QNAME_BY_TYPE.get(block_type, _MISSING)

--- a/robosystems/operations/information_block/reads.py
+++ b/robosystems/operations/information_block/reads.py
@@ -13,13 +13,14 @@ changes to this module.
 
 from __future__ import annotations
 
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from sqlalchemy.orm import Session
 
 from robosystems.models.api.information_block import InformationBlockEnvelope
-from robosystems.models.extensions import Structure
+from robosystems.models.extensions import Association, Structure
 from robosystems.models.extensions.roboledger import FactSet
 from robosystems.operations.information_block import registry as registry_module
+from robosystems.operations.information_block.envelope import DISCLOSURE_BLOCK_TYPE
 
 
 def get_information_block(
@@ -116,10 +117,21 @@ def list_information_blocks(
   # Without this, library-seeded statements (dozens per tenant graph)
   # swamp the default `limit=50` and a user browsing without filters
   # never sees their schedules.
+  # A disclosure structure renders only when it owns a presentation arc; the
+  # rs-gaap-disclosures package seeds ~17 arc-less `disclosures:*` identity rows
+  # per tenant whose envelopes build to None. Excluding them at the SQL level
+  # keeps them out of the LIMIT/OFFSET window so pages don't come back short.
+  has_presentation_arc = (
+    select(Association.id)
+    .where(Association.structure_id == Structure.id)
+    .where(Association.association_type == "presentation")
+    .exists()
+  )
   query = (
     select(Structure)
     .where(Structure.block_type.in_(candidate_ids))
     .where(Structure.is_active.is_(True))
+    .where(or_(Structure.block_type != DISCLOSURE_BLOCK_TYPE, has_presentation_arc))
     .order_by(
       (Structure.created_by == "library-seeder").asc(),
       Structure.block_type,

--- a/robosystems/operations/information_block/rules/engine.py
+++ b/robosystems/operations/information_block/rules/engine.py
@@ -47,14 +47,12 @@ from robosystems.models.extensions import (
   Structure,
   VerificationResult,
 )
-from robosystems.models.extensions.roboledger import Fact
+from robosystems.models.extensions.roboledger import Fact, FactSet
 from robosystems.operations.information_block.envelope import load_rules_for_structure
 from robosystems.operations.information_block.rules.evaluators import (
   EvaluationOutcome,
   evaluate_rule,
-)
-from robosystems.operations.information_block.rules.expressions import (
-  EQUALITY_TOLERANCE,
+  rule_tolerance,
 )
 
 
@@ -166,15 +164,28 @@ def _load_period_balances(
   """Group in-scope facts into per-period ``(balances, present)`` — SUMMING
   every fact for an element+period, the way the fact producer does (a single
   element can carry multiple facts in one period, e.g. a derived flow plus a
-  reconciling plug). Scoped by ``fact_set_id`` when pinned, else
-  ``structure_id``, within the period window.
+  reconciling plug), within the period window.
+
+  Scoped to a single FactSet: pinned when ``fact_set_id`` is given, else the
+  LATEST FactSet for the structure. The FactSet is the summing unit on purpose
+  — two coexisting reports over the same period both stamp this structure, so a
+  bare ``structure_id`` scope would sum across reports and double every balance.
   """
+  if fact_set_id is None:
+    fact_set_id = session.execute(
+      select(FactSet.id)
+      .where(FactSet.structure_id == structure_id)
+      .order_by(FactSet.created_at.desc(), FactSet.id.desc())
+      .limit(1)
+    ).scalar()
+
   stmt = select(Fact.element_id, Fact.value, Fact.period_start, Fact.period_end).where(
     Fact.fact_scope == "in_scope"
   )
   if fact_set_id is not None:
     stmt = stmt.where(Fact.fact_set_id == fact_set_id)
   else:
+    # No FactSet exists for this structure (never reported) — no balances.
     stmt = stmt.where(Fact.structure_id == structure_id)
   if period_end is not None:
     stmt = stmt.where(Fact.period_end <= period_end)
@@ -262,9 +273,7 @@ def _evaluate_rollup_arc_derived(
       detail={"parent": parent_qname, "source": "calc-dag"},
     )
 
-  tolerance = EQUALITY_TOLERANCE
-  if rule.metadata_ and isinstance(rule.metadata_, dict):
-    tolerance = float(rule.metadata_.get("tolerance", EQUALITY_TOLERANCE))
+  tolerance = rule_tolerance(rule)
 
   per_period: list[dict[str, Any]] = []
   for key in sorted(periods, key=lambda k: (k[1] is None, k[1] or date.min)):
@@ -320,6 +329,7 @@ def evaluate_rules_for_structure(
   period_start: date | None = None,
   period_end: date | None = None,
   created_by: str = "engine",
+  global_calculations: dict[str, list[tuple[str, float]]] | None = None,
 ) -> list[VerificationResult]:
   """Evaluate every rule scoped to ``structure_id`` and persist results.
 
@@ -370,18 +380,25 @@ def evaluate_rules_for_structure(
   # rs-gaap-calculations DAG (mirroring the fact producer) rather than the
   # rule's frozen child enumeration bound one-fact-per-qname, which reported
   # false failures when a subtotal foots over a sibling concept or over two
-  # facts in one period. Loaded once per structure, only when a RollUp exists.
+  # facts in one period. The global DAG is reused from ``global_calculations``
+  # when the caller precomputed it (a report run evaluates many structures),
+  # else loaded here — only when a RollUp rule exists.
   calculations: dict[str, list[tuple[str, float]]] = {}
   by_period: dict[
     tuple[date | None, date | None], tuple[dict[str, float], set[str]]
   ] = {}
   parent_id_cache: dict[str, str | None] = {}
   if any(r.rule_pattern == "RollUp" for r in rules):
-    from robosystems.operations.roboledger.reports.calc_dag import (
-      load_rs_gaap_calculations,
-    )
+    if global_calculations is None:
+      from robosystems.operations.roboledger.reports.calc_dag import (
+        load_rs_gaap_calculations,
+      )
 
-    calculations = load_rs_gaap_calculations(session)
+      calculations = load_rs_gaap_calculations(session)
+    else:
+      # Copy the caller-provided global DAG so the per-structure local overlay
+      # below can't leak arcs back into the shared dict across structures.
+      calculations = dict(global_calculations)
     # Tenant-authored roll_up structures (disclosure notes) foot against
     # their OWN calculation arcs — their parents aren't rs-gaap subtotals,
     # so the global DAG carries no entry for them. Overlay the structure's

--- a/robosystems/operations/information_block/rules/evaluators.py
+++ b/robosystems/operations/information_block/rules/evaluators.py
@@ -44,6 +44,19 @@ class EvaluationOutcome:
 _EQUALITY_PATTERNS = frozenset({"EqualTo", "RollForward"})
 
 
+def rule_tolerance(rule: Any) -> float:
+  """Resolve the equality tolerance for a rule.
+
+  Uses the per-rule ``metadata_['tolerance']`` override when present, else the
+  default ``EQUALITY_TOLERANCE``. Single source for every evaluator + the
+  engine's arc-derived RollUp path.
+  """
+  metadata = rule.metadata_
+  if isinstance(metadata, dict):
+    return float(metadata.get("tolerance", EQUALITY_TOLERANCE))
+  return EQUALITY_TOLERANCE
+
+
 def evaluate_rule(rule: Any, bindings: dict[str, float | None]) -> EvaluationOutcome:
   """Dispatch rule evaluation based on ``rule.rule_pattern``.
 
@@ -80,9 +93,7 @@ def _evaluate_equality_pattern(
       message=f"no fact bound for variables: {', '.join(missing)}",
       detail={"bindings": _serializable(bindings), "missing": missing},
     )
-  tolerance = EQUALITY_TOLERANCE
-  if rule.metadata_ and isinstance(rule.metadata_, dict):
-    tolerance = float(rule.metadata_.get("tolerance", EQUALITY_TOLERANCE))
+  tolerance = rule_tolerance(rule)
 
   bound: dict[str, float] = {n: float(bindings[n]) for n in variable_names}  # type: ignore[arg-type]
   try:
@@ -139,9 +150,7 @@ def _evaluate_rollup(rule: Any, bindings: dict[str, float | None]) -> Evaluation
       },
     )
 
-  tolerance = EQUALITY_TOLERANCE
-  if rule.metadata_ and isinstance(rule.metadata_, dict):
-    tolerance = float(rule.metadata_.get("tolerance", EQUALITY_TOLERANCE))
+  tolerance = rule_tolerance(rule)
 
   # RHS children with no fact default to 0 (sum-of-present-children).
   rhs_names = [n for n in variable_names if n not in required]
@@ -224,7 +233,7 @@ def _evaluate_sum_equals(
       detail={},
     )
   expected = float((rule.metadata_ or {}).get("expected_total", 0))
-  tolerance = float((rule.metadata_ or {}).get("tolerance", EQUALITY_TOLERANCE))
+  tolerance = rule_tolerance(rule)
   passed = abs(actual - expected) <= tolerance
   return EvaluationOutcome(
     status="pass" if passed else "fail",

--- a/robosystems/operations/roboledger/commands/fiscal_calendar.py
+++ b/robosystems/operations/roboledger/commands/fiscal_calendar.py
@@ -235,6 +235,16 @@ def reopen_period(
     actor_type=actor_type,
     note=note,
   )
+  # Re-stamp schedule facts the retreated boundary has re-opened: the reopened
+  # window's facts were tagged 'historical' at generation and must return to
+  # 'in_scope' so the roll-forward carry-in and the re-close see the movement.
+  # Function-level import — commands.schedules ↔ information_block.schedule form
+  # a module-load cycle that a top-level import here would trip.
+  from robosystems.operations.roboledger.commands.schedules import (
+    reinstate_reopened_schedule_scopes,
+  )
+
+  reinstate_reopened_schedule_scopes(session)
   session.commit()
 
   has_sync, last_sync_at = qb_sync_state(platform_db, graph_id)

--- a/robosystems/operations/roboledger/commands/reports.py
+++ b/robosystems/operations/roboledger/commands/reports.py
@@ -39,6 +39,7 @@ from robosystems.models.extensions import (
   ReportShare,
 )
 from robosystems.operations.aws.s3 import S3Client
+from robosystems.operations.information_block.envelope import DISCLOSURE_BLOCK_TYPE
 from robosystems.operations.information_block.rules.engine import (
   evaluate_rules_for_structure,
 )
@@ -52,6 +53,9 @@ from robosystems.operations.roboledger.reads.reports import (
   periods_to_json,
   report_to_response,
   resolve_entity_name,
+)
+from robosystems.operations.roboledger.reports.calc_dag import (
+  load_rs_gaap_calculations,
 )
 from robosystems.operations.roboledger.reports.fact_grid import generate_report_facts
 from robosystems.operations.roboledger.reports.network_picker import (
@@ -135,6 +139,10 @@ def _evaluate_report_structures(
   for f in facts.facts:
     for sid in element_to_structures.get(f.element_id, ()):
       structures_with_facts.add(sid)
+  # The rs-gaap-calculations DAG is invariant across structures within this
+  # report run — load it once and share it (each structure still gets its own
+  # local-arc overlay from a copy) rather than re-querying per structure.
+  global_calculations = load_rs_gaap_calculations(session)
   all_results = []
   for structure_id in structures_with_facts:
     results = evaluate_rules_for_structure(
@@ -144,6 +152,7 @@ def _evaluate_report_structures(
       period_start=period_start,
       period_end=period_end,
       created_by=created_by,
+      global_calculations=global_calculations,
     )
     all_results.extend(results)
   return _rule_summary(all_results)
@@ -183,14 +192,17 @@ def _pick_disclosure_structures(
       SELECT DISTINCT a.structure_id AS structure_id
       FROM associations a
       JOIN structures s ON s.id = a.structure_id
-      WHERE s.block_type = 'regulatory_disclosure'
+      WHERE s.block_type = :disclosure_block_type
         AND s.is_active IS TRUE
         AND a.association_type = 'presentation'
         AND (a.to_element_id = ANY(:element_ids)
              OR a.from_element_id = ANY(:element_ids))
       """
     ),
-    {"element_ids": list(fact_element_ids)},
+    {
+      "disclosure_block_type": DISCLOSURE_BLOCK_TYPE,
+      "element_ids": list(fact_element_ids),
+    },
   ).fetchall()
   return [row.structure_id for row in rows]
 

--- a/robosystems/operations/roboledger/commands/schedules.py
+++ b/robosystems/operations/roboledger/commands/schedules.py
@@ -80,6 +80,39 @@ def _calendar_closed_through_date(session: Session):
   return period_end
 
 
+def reinstate_reopened_schedule_scopes(session: Session) -> int:
+  """Promote schedule facts the retreated close boundary has re-opened.
+
+  Schedule fact scope (``historical`` vs ``in_scope``) is stamped at
+  generation from ``closed_through`` (``period_end <= closed_through`` →
+  historical). ``reopen-period`` moves ``closed_through`` backward but does not
+  re-stamp existing facts, so a reopened month's facts stay ``historical``: its
+  movement drops out of the roll-forward (the carry-in then renders that
+  month's ending balance as the opening balance) and the re-close skips it.
+  Flip the now-open window back to ``in_scope`` so every reader agrees with the
+  calendar. Returns the number of facts re-stamped. Idempotent — a no-op when
+  the boundary didn't move (e.g. reopening an older period).
+  """
+  from sqlalchemy import text
+
+  closed_through = _calendar_closed_through_date(session)
+  result = session.execute(
+    text(
+      """
+      UPDATE facts
+      SET fact_scope = 'in_scope'
+      WHERE fact_scope = 'historical'
+        AND structure_id IN (
+          SELECT id FROM structures WHERE block_type = 'schedule'
+        )
+        AND (:closed_through IS NULL OR period_end > :closed_through)
+      """
+    ),
+    {"closed_through": closed_through},
+  )
+  return result.rowcount or 0
+
+
 def _build_closing_entry_response(result) -> ClosingEntryResponse:
   """Map a ScheduleService ClosingEntryResult to the wire response."""
   reversal_resp = None

--- a/robosystems/operations/serialization/xbrl/xbrl_21.py
+++ b/robosystems/operations/serialization/xbrl/xbrl_21.py
@@ -26,6 +26,7 @@ from decimal import Decimal
 
 from lxml import etree
 
+from robosystems.operations.information_block.envelope import DISCLOSURE_BLOCK_TYPE
 from robosystems.operations.serialization.bundle import (
   BundleArc,
   BundleContext,
@@ -139,7 +140,7 @@ def _strip_disclosure_content(bundle: StatementBundle) -> StatementBundle:
       bundle.linkbases.definition_links,
     )
     for link in group
-    if link.block_type == "regulatory_disclosure"
+    if link.block_type == DISCLOSURE_BLOCK_TYPE
   }
   if not disclosure_structure_ids:
     return bundle
@@ -190,12 +191,18 @@ def _strip_disclosure_content(bundle: StatementBundle) -> StatementBundle:
   referenced_periods = {f.period_ref for f in facts}
   period_nodes = [p for p in bundle.period_nodes if p.id in referenced_periods]
 
+  # Drop units no surviving fact references (a unit used only by a stripped
+  # note's facts would leave an unreferenced <xbrli:unit> in the instance).
+  referenced_units = {f.unit_ref for f in facts}
+  units = [u for u in bundle.units if u.id in referenced_units]
+
   return bundle.model_copy(
     update={
       "linkbases": linkbases,
       "facts": facts,
       "schema_concepts": schema_concepts,
       "period_nodes": period_nodes,
+      "units": units,
     }
   )
 

--- a/robosystems/operations/taxonomy_block/_helpers.py
+++ b/robosystems/operations/taxonomy_block/_helpers.py
@@ -7,6 +7,41 @@ modules don't drift on the common derivations.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+from robosystems.models.extensions.structure import Structure
+
+if TYPE_CHECKING:
+  from robosystems.models.api.taxonomy_block import TaxonomyBlockStructureRequest
+
+
+def structure_from_request(
+  req: TaxonomyBlockStructureRequest,
+  *,
+  taxonomy_id: str,
+  created_by: str,
+) -> Structure:
+  """Project a structure request onto a new ``Structure`` row.
+
+  Centralizes the request→Structure derivation — block_type,
+  concept_arrangement, and the role_uri-rides-in-``metadata_`` convention the
+  envelope readers rely on — so the create / update / ontology handlers don't
+  drift as request fields are added. The caller still ``session.add``s the row.
+  """
+  structure_metadata = dict(req.metadata)
+  if req.role_uri:
+    structure_metadata["role_uri"] = req.role_uri
+  return Structure(
+    name=req.name,
+    description=req.description,
+    block_type=req.block_type,
+    concept_arrangement=req.concept_arrangement,
+    taxonomy_id=taxonomy_id,
+    is_active=True,
+    metadata_=structure_metadata,
+    created_by=created_by,
+  )
+
 
 def qname_for(
   standard: str | None,
@@ -25,4 +60,4 @@ def qname_for(
   return f"{ns}:{token}"
 
 
-__all__ = ["qname_for"]
+__all__ = ["qname_for", "structure_from_request"]

--- a/robosystems/operations/taxonomy_block/custom_ontology.py
+++ b/robosystems/operations/taxonomy_block/custom_ontology.py
@@ -34,7 +34,10 @@ from robosystems.models.extensions import (
   Structure,
   Taxonomy,
 )
-from robosystems.operations.taxonomy_block._helpers import qname_for
+from robosystems.operations.taxonomy_block._helpers import (
+  qname_for,
+  structure_from_request,
+)
 from robosystems.operations.taxonomy_block.auto_rules import emit_auto_rules
 from robosystems.operations.taxonomy_block.cascade import (
   cascade_delete_taxonomy,
@@ -147,20 +150,8 @@ def create(
 
   structures_by_name: dict[str, Structure] = {}
   for req in payload.structures:
-    # role_uri rides in metadata_ — the column-less convention the
-    # envelope readers already use (metadata_['role_uri']).
-    structure_metadata = dict(req.metadata)
-    if req.role_uri:
-      structure_metadata["role_uri"] = req.role_uri
-    structure = Structure(
-      name=req.name,
-      description=req.description,
-      block_type=req.block_type,
-      concept_arrangement=req.concept_arrangement,
-      taxonomy_id=taxonomy.id,
-      is_active=True,
-      metadata_=structure_metadata,
-      created_by=created_by,
+    structure = structure_from_request(
+      req, taxonomy_id=taxonomy.id, created_by=created_by
     )
     session.add(structure)
     structures_by_name[req.name] = structure

--- a/robosystems/operations/taxonomy_block/reporting_extension.py
+++ b/robosystems/operations/taxonomy_block/reporting_extension.py
@@ -42,7 +42,10 @@ from robosystems.models.extensions import (
   Taxonomy,
   Trait,
 )
-from robosystems.operations.taxonomy_block._helpers import qname_for
+from robosystems.operations.taxonomy_block._helpers import (
+  qname_for,
+  structure_from_request,
+)
 from robosystems.operations.taxonomy_block.auto_rules import emit_auto_rules
 from robosystems.operations.taxonomy_block.cascade import (
   cascade_delete_taxonomy,
@@ -206,20 +209,8 @@ def create(
 
   structures_by_name: dict[str, Structure] = {}
   for req in payload.structures:
-    # role_uri rides in metadata_ — the column-less convention the
-    # envelope readers already use (metadata_['role_uri']).
-    structure_metadata = dict(req.metadata)
-    if req.role_uri:
-      structure_metadata["role_uri"] = req.role_uri
-    structure = Structure(
-      name=req.name,
-      description=req.description,
-      block_type=req.block_type,
-      concept_arrangement=req.concept_arrangement,
-      taxonomy_id=taxonomy.id,
-      is_active=True,
-      metadata_=structure_metadata,
-      created_by=created_by,
+    structure = structure_from_request(
+      req, taxonomy_id=taxonomy.id, created_by=created_by
     )
     session.add(structure)
     structures_by_name[req.name] = structure

--- a/robosystems/operations/taxonomy_block/update_apply.py
+++ b/robosystems/operations/taxonomy_block/update_apply.py
@@ -28,6 +28,7 @@ from robosystems.models.extensions import (
   Structure,
   Taxonomy,
 )
+from robosystems.operations.taxonomy_block._helpers import structure_from_request
 from robosystems.operations.taxonomy_block.rule_persistence import (
   persist_tenant_rules,
 )
@@ -129,20 +130,8 @@ def apply_structures_to_add(
   """Insert new structures; return name→Structure lookup of just the new ones."""
   new_structures_by_name: dict[str, Structure] = {}
   for req in payload.structures_to_add:
-    # role_uri rides in metadata_ — the column-less convention the
-    # envelope readers already use (metadata_['role_uri']).
-    structure_metadata = dict(req.metadata)
-    if req.role_uri:
-      structure_metadata["role_uri"] = req.role_uri
-    structure = Structure(
-      name=req.name,
-      description=req.description,
-      block_type=req.block_type,
-      concept_arrangement=req.concept_arrangement,
-      taxonomy_id=taxonomy.id,
-      is_active=True,
-      metadata_=structure_metadata,
-      created_by=updated_by,
+    structure = structure_from_request(
+      req, taxonomy_id=taxonomy.id, created_by=updated_by
     )
     session.add(structure)
     new_structures_by_name[req.name] = structure

--- a/tests/operations/information_block/rules/test_rollup_arc_derived.py
+++ b/tests/operations/information_block/rules/test_rollup_arc_derived.py
@@ -201,6 +201,56 @@ class TestLoadPeriodBalances:
     assert balances["OtherOpCap"] == pytest.approx(3181.40)
     assert "NetIncome" in present
 
+  def test_unpinned_scopes_to_latest_fact_set_not_structure(self) -> None:
+    """Unpinned evaluation resolves the latest FactSet and scopes facts to it,
+    rather than a bare structure_id scope that would sum facts across every
+    coexisting report that stamped the structure (doubling every balance)."""
+    session = MagicMock()
+    captured: list[str] = []
+
+    fs_result = MagicMock()
+    fs_result.scalar.return_value = "fs_latest"
+    facts_result = MagicMock()
+    facts_result.all.return_value = [
+      SimpleNamespace(
+        element_id="Cash", value=100.0, period_start=_P1[0], period_end=_P1[1]
+      ),
+    ]
+
+    def _execute(stmt, *args, **kwargs):
+      captured.append(str(stmt))
+      return fs_result if len(captured) == 1 else facts_result
+
+    session.execute.side_effect = _execute
+
+    by_period = _load_period_balances(session, "struct_bs", None, None, None)
+
+    # First query resolves the latest FactSet for the structure.
+    assert "fact_sets" in captured[0]
+    # Facts query is scoped to the resolved fact_set_id, not the structure.
+    assert "fact_set_id" in captured[1]
+    assert "structure_id" not in captured[1]
+    assert by_period[_P1][0]["Cash"] == pytest.approx(100.0)
+
+  def test_pinned_skips_fact_set_resolution(self) -> None:
+    """A pinned ``fact_set_id`` scopes directly — no latest-FactSet lookup."""
+    session = MagicMock()
+    captured: list[str] = []
+
+    facts_result = MagicMock()
+    facts_result.all.return_value = []
+
+    def _execute(stmt, *args, **kwargs):
+      captured.append(str(stmt))
+      return facts_result
+
+    session.execute.side_effect = _execute
+
+    _load_period_balances(session, "struct_bs", "fs_pinned", None, None)
+
+    assert len(captured) == 1
+    assert "fact_set_id" in captured[0]
+
 
 class TestRollupRoutingInEngine:
   def test_rollup_rule_routes_to_arc_derived_path(self) -> None:

--- a/tests/operations/information_block/test_reads.py
+++ b/tests/operations/information_block/test_reads.py
@@ -132,6 +132,28 @@ class TestListInformationBlocks:
     assert len(result) == 1
     assert result[0] is expected
 
+  def test_listing_query_guards_arcless_disclosure_rows(self) -> None:
+    """The listing query excludes regulatory_disclosure structures with no
+    presentation arc (the arc-less `disclosures:*` identity rows) so they
+    don't consume LIMIT/OFFSET slots and return short pages."""
+    session = MagicMock()
+    captured: list[str] = []
+
+    def _execute(stmt, *args, **kwargs):
+      captured.append(str(stmt))
+      result = MagicMock()
+      result.scalars.return_value.all.return_value = []
+      return result
+
+    session.execute.side_effect = _execute
+    list_information_blocks(session, library_sentinel=False)
+
+    sql = captured[0]
+    # A block_type guard plus a correlated presentation-arc EXISTS.
+    assert "block_type !=" in sql
+    assert "EXISTS" in sql
+    assert "association_type" in sql
+
   def test_category_filter_narrows_to_matching_block_types(self) -> None:
     """Category 'Nonexistent' matches no registered block type — empty
     result without a DB query. Phase b categories in use are 'Close'

--- a/tests/operations/roboledger/commands/test_reports.py
+++ b/tests/operations/roboledger/commands/test_reports.py
@@ -162,9 +162,10 @@ def test_pick_disclosure_structures_queries_by_fact_elements() -> None:
 
   assert picked == ["struct_note"]
   sql = str(session.execute.call_args.args[0])
-  assert "regulatory_disclosure" in sql
+  assert "block_type = :disclosure_block_type" in sql
   assert "presentation" in sql
   params = session.execute.call_args.args[1]
+  assert params["disclosure_block_type"] == "regulatory_disclosure"
   assert set(params["element_ids"]) == {"elem_raw", "elem_fg"}
 
 

--- a/tests/operations/roboledger/commands/test_schedules.py
+++ b/tests/operations/roboledger/commands/test_schedules.py
@@ -733,3 +733,50 @@ def test_reconstruct_schedule_definition_legacy_fallback() -> None:
   assert period_end == date(2026, 3, 31)
   assert monthly_amount == 1_000_000  # 10_000.00 * 100 cents
   assert source_transaction_id is None
+
+
+def test_reinstate_reopened_schedule_scopes_promotes_now_open_facts() -> None:
+  """After the close boundary retreats, schedule facts beyond it flip
+  ``historical`` → ``in_scope`` so the reopened month's movement is visible."""
+  from datetime import date
+  from unittest.mock import patch
+
+  from robosystems.operations.roboledger.commands import schedules as sched_cmds
+
+  session = MagicMock()
+  exec_result = MagicMock()
+  exec_result.rowcount = 3
+  session.execute.return_value = exec_result
+
+  with patch.object(
+    sched_cmds, "_calendar_closed_through_date", return_value=date(2026, 2, 28)
+  ):
+    n = sched_cmds.reinstate_reopened_schedule_scopes(session)
+
+  assert n == 3
+  stmt_arg, params = session.execute.call_args[0]
+  sql = str(stmt_arg)
+  assert "UPDATE facts" in sql
+  assert "fact_scope = 'in_scope'" in sql
+  assert "block_type = 'schedule'" in sql
+  assert params == {"closed_through": date(2026, 2, 28)}
+
+
+def test_reinstate_reopened_schedule_scopes_handles_null_boundary() -> None:
+  """When no period remains closed (boundary → None), all historical schedule
+  facts reopen — the SQL guards NULL so every period is now in scope."""
+  from unittest.mock import patch
+
+  from robosystems.operations.roboledger.commands import schedules as sched_cmds
+
+  session = MagicMock()
+  exec_result = MagicMock()
+  exec_result.rowcount = 5
+  session.execute.return_value = exec_result
+
+  with patch.object(sched_cmds, "_calendar_closed_through_date", return_value=None):
+    n = sched_cmds.reinstate_reopened_schedule_scopes(session)
+
+  assert n == 5
+  _stmt, params = session.execute.call_args[0]
+  assert params == {"closed_through": None}

--- a/tests/operations/taxonomy_block/test_reporting_extension.py
+++ b/tests/operations/taxonomy_block/test_reporting_extension.py
@@ -8,6 +8,7 @@ isn't of type ``reporting_standard``.
 
 from __future__ import annotations
 
+from typing import get_args
 from unittest.mock import MagicMock
 
 import pytest
@@ -19,6 +20,7 @@ from robosystems.models.api.taxonomy_block import (
   TaxonomyBlockStructureRequest,
   UpdateTaxonomyBlockRequest,
 )
+from robosystems.models.extensions.structure import CONCEPT_ARRANGEMENT_VALUES
 from robosystems.operations.taxonomy_block import reporting_extension
 
 
@@ -43,6 +45,19 @@ def test_structure_request_rejects_unknown_concept_arrangement() -> None:
       block_type="regulatory_disclosure",
       concept_arrangement="not_a_cap",  # type: ignore[arg-type]
     )
+
+
+def test_concept_arrangement_literal_matches_canonical_vocabulary() -> None:
+  """Drift guard: the API request ``concept_arrangement`` Literal must stay in
+  lockstep with ``CONCEPT_ARRANGEMENT_VALUES`` — the single source that also
+  builds the ``structures.concept_arrangement`` DB CHECK constraint."""
+  annotation = TaxonomyBlockStructureRequest.model_fields[
+    "concept_arrangement"
+  ].annotation
+  literal_values: set[str] = set()
+  for arg in get_args(annotation):
+    literal_values.update(get_args(arg))
+  assert literal_values == set(CONCEPT_ARRANGEMENT_VALUES)
 
 
 def test_create_request_rejects_missing_parent() -> None:

--- a/tests/taxonomy/test_disclosures_seed.py
+++ b/tests/taxonomy/test_disclosures_seed.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import pytest
 
+from robosystems.models.extensions.structure import CONCEPT_ARRANGEMENT_VALUES
 from robosystems.taxonomy import load_taxonomy_package
 from robosystems.taxonomy.discovery import framework_root
 from robosystems.taxonomy.model import TaxonomyPackage
@@ -96,24 +97,8 @@ class TestDisclosuresPackage:
     cap_values = {s.concept_arrangement for s in disclosures.structures}
     assert "set" in cap_values
     assert "level1_textblock" in cap_values
-    # All values must be in the canonical 15-value CAP enumeration.
-    canonical = {
-      "set",
-      "roll_up",
-      "roll_forward",
-      "roll_forward_info",
-      "adjustment",
-      "variance",
-      "arithmetic",
-      "text_block",
-      "level1_textblock",
-      "level2_textblock",
-      "level3_textblock",
-      "level4_detail",
-      "table_equivalent_textblock",
-      "grid",
-      "compound_fact",
-    }
+    # All values must be in the canonical CAP enumeration (single source).
+    canonical = set(CONCEPT_ARRANGEMENT_VALUES)
     assert cap_values - {None} <= canonical, (
       f"Non-canonical CAP values in seed: {cap_values - canonical - {None}}"
     )


### PR DESCRIPTION
Follow-ups from a deep review of the v1.6.5→main range (PRs #881–#886). The larger disclosure-hardening findings (only reachable under authoring patterns no tenant does yet) are queued as a gate for the next disclosure increment; this PR ships the safe cleanup plus three bugfixes that affect shipped behavior today. **No schema migration** (the CAP-vocabulary refactor emits byte-identical CHECK SQL).

## Bugfixes
- **rules:** unpinned `evaluate-rules` (no `fact_set_id`) summed facts across every coexisting report that stamped a structure, doubling balances and risking a false RollUp failure attributed to a stale report. Now scopes to the latest FactSet per structure (the FactSet is the summing unit, so within-report multi-facts still sum).
- **schedule:** `reopen-period` retreated `closed_through` but never re-stamped schedule fact scopes, so a reopened month's movement dropped out of the roll-forward (its ending balance rendered as the opening balance) and the re-close skipped it. Reopen now promotes the now-open window's facts back to `in_scope`.
- **reports:** the ~17 arc-less `disclosures:*` identity rows entered `list-information-blocks` pages (built to `None` after LIMIT/OFFSET), returning short pages. The listing query now excludes disclosure structures with no presentation arc.

## Cleanup (no behavior change)
Single-sourced the `concept_arrangement` vocabulary (+ drift test), extracted `structure_from_request` and `rule_tolerance` helpers, one `DISCLOSURE_BLOCK_TYPE` constant, public-factory use in `disclosure.py`, XBRL unit pruning, and a per-report shared calc-DAG load.

## Verification
Full unit suite green (only the known pre-existing `test_incremental_equals_full_load` local-ordering flake, which passes in isolation); ruff/format/basedpyright/cf-lint clean; the reopen re-stamp SQL validated against the live schema; new unit tests for each fix.