### PR TITLE
feat(extensions): non-numeric fact substrate (migration 0021) + calc-overlay precedence fix

### DIFF
--- a/migrations/extensions/versions/0021_nonnumeric_facts.py
+++ b/migrations/extensions/versions/0021_nonnumeric_facts.py
@@ -1,0 +1,97 @@
+"""nonnumeric facts — OLTP Fact gains the non-numeric value path
+
+The graph ``Fact`` node has carried the non-numeric shape (value STRING,
+fact_type, value_type, content_type, decimals) since inception; the OLTP
+``facts`` table was numeric-only (``value FLOAT NOT NULL``), so materialize
+hardcoded the non-numeric slots. This migration closes the asymmetry:
+
+- ``facts``: ``value`` becomes nullable; add ``string_value`` (TEXT),
+  ``fact_type`` ('Numeric' | 'Nonnumeric'), ``value_type`` ('inline' |
+  'external_resource'), ``content_type`` (MIME), ``decimals`` (XBRL
+  @decimals). ``ck_facts_value_shape`` enforces numeric XOR non-numeric.
+- ``elements``: add ``item_type`` (open XBRL item-type vocabulary; the
+  value domain, orthogonal to the structural ``element_type``).
+- ``fact_sets``: widen ``check_fact_set_type`` to admit ``'disclosure'``
+  (standing Document->text-block binding sets).
+
+NOT NULL columns are added with a constant DEFAULT (instant on PG11+) and
+the server default is then dropped so migrated schemas match freshly
+provisioned ones (the model uses Python-side defaults only).
+
+Public schema AND every existing tenant schema get the change via the
+TenantOps fan-out (matches 0019); fresh tenants get it from the model at
+provision (``metadata.create_all``).
+
+Note: the downgrade re-narrows the constraints, restores NOT NULL on
+``value``, and drops the columns — it will fail if Nonnumeric rows or
+'disclosure' FactSets already exist. Expected once the values are in use.
+
+Revision ID: 0021
+Revises: 0020
+Create Date: 2026-07-18
+
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+from migrations.extensions.helpers import TenantOps, for_each_tenant_schema
+
+# revision identifiers, used by Alembic.
+revision = "0021"
+down_revision = "0020"
+branch_labels = None
+depends_on = None
+
+_FACT_TYPE = "fact_type IN ('Numeric', 'Nonnumeric')"
+_VALUE_TYPE = "value_type IN ('inline', 'external_resource')"
+_VALUE_SHAPE = (
+  "(fact_type = 'Numeric' AND value IS NOT NULL AND string_value IS NULL) OR "
+  "(fact_type = 'Nonnumeric' AND string_value IS NOT NULL AND value IS NULL)"
+)
+_FACTSET_WIDENED = "factset_type IN ('report', 'schedule', 'custom', 'disclosure')"
+_FACTSET_ORIGINAL = "factset_type IN ('report', 'schedule', 'custom')"
+
+
+def _apply(conn, schema: str) -> None:
+  t = TenantOps(conn, schema)
+  t.add_column("facts", "string_value", "TEXT")
+  t.add_column("facts", "fact_type", "VARCHAR", nullable=False, default="'Numeric'")
+  t.add_column("facts", "value_type", "VARCHAR", nullable=False, default="'inline'")
+  t.add_column("facts", "content_type", "VARCHAR")
+  t.add_column("facts", "decimals", "VARCHAR")
+  # Existing rows are backfilled from the DEFAULT at ADD time; drop it so
+  # migrated schemas match fresh ones (Python-side defaults only).
+  t.execute("ALTER TABLE {s}.facts ALTER COLUMN fact_type DROP DEFAULT")
+  t.execute("ALTER TABLE {s}.facts ALTER COLUMN value_type DROP DEFAULT")
+  t.alter_column_nullable("facts", "value", nullable=True)
+  t.add_check("facts", "ck_facts_fact_type", _FACT_TYPE)
+  t.add_check("facts", "ck_facts_value_type", _VALUE_TYPE)
+  t.add_check("facts", "ck_facts_value_shape", _VALUE_SHAPE)
+  t.add_column("elements", "item_type", "VARCHAR")
+  t.add_check("fact_sets", "check_fact_set_type", _FACTSET_WIDENED)
+
+
+def _revert(conn, schema: str) -> None:
+  t = TenantOps(conn, schema)
+  t.add_check("fact_sets", "check_fact_set_type", _FACTSET_ORIGINAL)
+  t.drop_column("elements", "item_type")
+  t.drop_constraint("facts", "ck_facts_value_shape")
+  t.drop_constraint("facts", "ck_facts_value_type")
+  t.drop_constraint("facts", "ck_facts_fact_type")
+  t.alter_column_nullable("facts", "value", nullable=False)
+  for col in ("decimals", "content_type", "value_type", "fact_type", "string_value"):
+    t.drop_column("facts", col)
+
+
+def upgrade() -> None:
+  conn = op.get_bind()
+  _apply(conn, "public")
+  for_each_tenant_schema(conn, _apply)
+
+
+def downgrade() -> None:
+  conn = op.get_bind()
+  _revert(conn, "public")
+  for_each_tenant_schema(conn, _revert)

--- a/robosystems/models/api/information_block.py
+++ b/robosystems/models/api/information_block.py
@@ -186,8 +186,8 @@ class FactSetLite(BaseModel):
   factset_type: str = Field(
     ...,
     description=(
-      "'report' | 'schedule' | 'custom'. Enum closure enforced by the "
-      "``public.fact_sets`` CHECK constraint."
+      "'report' | 'schedule' | 'custom' | 'disclosure'. Enum closure "
+      "enforced by the ``public.fact_sets`` CHECK constraint."
     ),
   )
   entity_id: str

--- a/robosystems/models/extensions/element.py
+++ b/robosystems/models/extensions/element.py
@@ -129,6 +129,11 @@ class Element(ExtensionsBase):
   is_abstract = Column(Boolean, nullable=False, default=False)
   is_monetary = Column(Boolean, nullable=False, default=True)
   element_type = Column(String, nullable=False, default="concept")
+  # Value domain (orthogonal to element_type, which is the structural role).
+  # Open XBRL item-type vocabulary — intended values: monetary | string |
+  # date | boolean | shares | decimal | integer | text_block. NULL means
+  # untyped; consumers fall back to is_monetary.
+  item_type = Column(String, nullable=True)
 
   # Hierarchy (parent element — separate from class-subclass classification
   # hierarchy, which lives in associations)

--- a/robosystems/models/extensions/roboledger/fact.py
+++ b/robosystems/models/extensions/roboledger/fact.py
@@ -2,7 +2,14 @@
 
 Bridge between fact generation (Python computation) and graph materialization
 (postgres_scanner reads this table). Each row represents one discrete financial
-data point: an element's aggregated balance for a specific period.
+data point: an element's aggregated balance for a specific period, or a
+non-numeric (string / text-block) value such as a bound disclosure narrative.
+
+A fact is numeric XOR non-numeric: ``fact_type`` discriminates, and the
+``ck_facts_value_shape`` CHECK enforces exactly one of ``value`` /
+``string_value`` populated. This mirrors the graph ``Fact`` node
+(``schemas/extensions/roboledger.py``), which has carried the non-numeric
+shape since inception — the OLTP side caught up in migration 0021.
 
 Every Fact belongs to exactly one FactSet (the parent envelope that pins the
 period bounds and back-references the Report or Schedule that created it).
@@ -25,6 +32,7 @@ from sqlalchemy import (
   ForeignKey,
   Index,
   String,
+  Text,
   text,
 )
 
@@ -49,14 +57,38 @@ class Fact(ExtensionsBase):
       "fact_scope IN ('historical', 'in_scope')",
       name="ck_facts_scope",
     ),
+    CheckConstraint(
+      "fact_type IN ('Numeric', 'Nonnumeric')",
+      name="ck_facts_fact_type",
+    ),
+    CheckConstraint(
+      "value_type IN ('inline', 'external_resource')",
+      name="ck_facts_value_type",
+    ),
+    CheckConstraint(
+      "(fact_type = 'Numeric' AND value IS NOT NULL AND string_value IS NULL) OR "
+      "(fact_type = 'Nonnumeric' AND string_value IS NOT NULL AND value IS NULL)",
+      name="ck_facts_value_shape",
+    ),
   )
 
   id = Column(String, primary_key=True, default=lambda: generate_prefixed_ulid("fact"))
   element_id = Column(String, nullable=False)
-  value = Column(Float, nullable=False)  # natural-sign dollars
+  value = Column(Float, nullable=True)  # natural-sign dollars; NULL for Nonnumeric
+  string_value = Column(Text, nullable=True)  # inline text payload for Nonnumeric
+  fact_type = Column(String, nullable=False, default="Numeric")
+  # value_type is always 'inline' today; 'external_resource' is reserved for
+  # blocks externalized to S3/OpenSearch (the SEC pipeline pattern).
+  value_type = Column(String, nullable=False, default="inline")
+  content_type = Column(String, nullable=True)  # MIME, e.g. 'text/markdown'
+  # XBRL @decimals for numeric facts. NULL means unspecified; materialize
+  # falls back to the legacy '-2' for numeric rows so graph output is stable.
+  decimals = Column(String, nullable=True)
   period_start = Column(Date, nullable=True)
   period_end = Column(Date, nullable=False)
   period_type = Column(String, nullable=False)  # duration or instant
+  # Units apply to numeric facts only; the column keeps its USD default for
+  # all rows, and materialize skips the FACT_HAS_UNIT edge for Nonnumeric.
   unit = Column(String, nullable=False, default="USD")
   entity_id = Column(String, nullable=False)
   structure_id = Column(String, nullable=True)  # structure this fact belongs to
@@ -75,4 +107,5 @@ class Fact(ExtensionsBase):
   created_at = Column(DateTime, nullable=False, default=lambda: datetime.now(UTC))
 
   def __repr__(self) -> str:
-    return f"<Fact {self.element_id} = {self.value}>"
+    shown = self.value if self.value is not None else self.string_value
+    return f"<Fact {self.element_id} = {shown}>"

--- a/robosystems/models/extensions/roboledger/fact_set.py
+++ b/robosystems/models/extensions/roboledger/fact_set.py
@@ -52,7 +52,9 @@ class FactSet(ExtensionsBase):
     Index("idx_fact_sets_entity", "entity_id"),
     Index("idx_fact_sets_report", "report_id"),
     CheckConstraint(
-      "factset_type IN ('report', 'schedule', 'custom')",
+      # 'disclosure' = a standing text-block binding set: the durable
+      # Document->fact bind that report builds snapshot from.
+      "factset_type IN ('report', 'schedule', 'custom', 'disclosure')",
       name="check_fact_set_type",
     ),
   )

--- a/robosystems/models/extensions/structure.py
+++ b/robosystems/models/extensions/structure.py
@@ -53,6 +53,19 @@ CONCEPT_ARRANGEMENT_VALUES: tuple[str, ...] = (
   "compound_fact",
 )
 
+# CAPs whose facts are narrative text blocks (Nonnumeric facts bound from a
+# platform Document) rather than numeric grids. ``level4_detail`` is excluded:
+# cm.xsd level 4 is the numeric detail table, not narrative.
+TEXT_BLOCK_CAPS: frozenset[str] = frozenset(
+  {
+    "text_block",
+    "level1_textblock",
+    "level2_textblock",
+    "level3_textblock",
+    "table_equivalent_textblock",
+  }
+)
+
 
 class Structure(ExtensionsBase):
   __tablename__ = "structures"

--- a/robosystems/operations/extensions/materialize.py
+++ b/robosystems/operations/extensions/materialize.py
@@ -453,17 +453,20 @@ def _staging_sql(graph_id: str, entity_id: str, connstr: str) -> dict[str, str]:
       END                             AS qname,
       e.name,
       e.description,
-      NULL::VARCHAR                   AS item_type,
+      e.item_type                     AS item_type,
       e.balance_type                  AS balance,
       CASE WHEN e.is_placeholder THEN true ELSE false END AS is_abstract,
       false                           AS is_dimension_item,
       false                           AS is_domain_member,
       false                           AS is_hypercube_item,
-      false                           AS is_integer,
-      true                            AS is_numeric,
-      false                           AS is_shares,
+      COALESCE(e.item_type = 'integer', false)  AS is_integer,
+      -- NULL item_type (untyped) keeps the legacy numeric default:
+      -- NULL IN (...) is NULL, COALESCE'd to true.
+      COALESCE(e.item_type IN ('monetary', 'shares', 'decimal', 'integer'), true)
+                                      AS is_numeric,
+      COALESCE(e.item_type = 'shares', false)   AS is_shares,
       false                           AS is_fraction,
-      false                           AS is_textblock,
+      COALESCE(e.item_type = 'text_block', false) AS is_textblock,
       NULL::VARCHAR                   AS uri,
       e.substitution_group            AS substitution_group,
       e.period_type                   AS period_type,
@@ -981,28 +984,42 @@ def _staging_sql(graph_id: str, entity_id: str, connstr: str) -> dict[str, str]:
     FROM postgres_scan('{c}', '{s}', 'facts')
   """
 
-  tables["Unit"] = """
+  # Units come from the facts actually present (numeric facts only — XBRL
+  # nonNumeric facts carry no unit). The UNION'd static USD row keeps the
+  # legacy ``unit_usd`` node present even for fact-less graphs.
+  tables["Unit"] = f"""
     CREATE OR REPLACE TABLE Unit AS
-    SELECT
-      'unit_usd'                      AS identifier,
-      'iso4217:USD'                   AS uri,
-      'iso4217:USD'                   AS measure,
-      'USD'                           AS value,
+    SELECT DISTINCT
+      'unit_' || lower(unit)          AS identifier,
+      'iso4217:' || unit              AS uri,
+      'iso4217:' || unit              AS measure,
+      unit                            AS value,
       NULL::VARCHAR                   AS numerator_uri,
       NULL::VARCHAR                   AS denominator_uri
+    FROM postgres_scan('{c}', '{s}', 'facts')
+    WHERE fact_type = 'Numeric'
+    UNION
+    SELECT
+      'unit_usd', 'iso4217:USD', 'iso4217:USD', 'USD',
+      NULL::VARCHAR, NULL::VARCHAR
   """
 
+  # decimals: numeric rows fall back to the legacy '-2' when unspecified so
+  # existing graph output is unchanged; Nonnumeric rows pass NULL through
+  # (XBRL nonNumeric facts carry no @decimals).
   tables["Fact"] = f"""
     CREATE OR REPLACE TABLE Fact AS
     SELECT
       id                              AS identifier,
       NULL::VARCHAR                   AS uri,
-      CAST(value AS VARCHAR)          AS value,
+      COALESCE(string_value, CAST(value AS VARCHAR)) AS value,
       value                           AS numeric_value,
-      'Numeric'                       AS fact_type,
-      '-2'                            AS decimals,
-      'inline'                        AS value_type,
-      NULL::VARCHAR                   AS content_type,
+      fact_type                       AS fact_type,
+      CASE WHEN fact_type = 'Numeric'
+           THEN COALESCE(decimals, '-2')
+           ELSE decimals END          AS decimals,
+      value_type                      AS value_type,
+      content_type                    AS content_type,
       false                           AS has_dimensions,
       0::BIGINT                       AS dimension_count
     FROM postgres_scan('{c}', '{s}', 'facts')
@@ -1116,12 +1133,14 @@ def _staging_sql(graph_id: str, entity_id: str, connstr: str) -> dict[str, str]:
     FROM postgres_scan('{c}', '{s}', 'facts')
   """
 
+  # XBRL nonNumeric facts carry no unitRef — numeric facts only.
   tables["FACT_HAS_UNIT"] = f"""
     CREATE OR REPLACE TABLE FACT_HAS_UNIT AS
     SELECT
       id                              AS src,
-      'unit_usd'                      AS dst
+      'unit_' || lower(unit)          AS dst
     FROM postgres_scan('{c}', '{s}', 'facts')
+    WHERE fact_type = 'Numeric'
   """
 
   tables["FACT_HAS_ENTITY"] = f"""

--- a/robosystems/operations/information_block/rules/engine.py
+++ b/robosystems/operations/information_block/rules/engine.py
@@ -91,6 +91,7 @@ def _bind_variables(
       .where(
         Fact.element_id == element_id,
         Fact.fact_scope == "in_scope",
+        Fact.value.is_not(None),
       )
       .order_by(Fact.period_end.desc(), Fact.created_at.desc())
       .limit(1)
@@ -146,7 +147,7 @@ def _bind_sum_variables(
         "SELECT ROUND(SUM(value)::numeric, 2) AS total "
         "FROM facts "
         "WHERE element_id = :eid AND structure_id = :sid "
-        "AND period_type = 'duration'"
+        "AND period_type = 'duration' AND fact_type = 'Numeric'"
       ),
       {"eid": element_id, "sid": structure_id},
     ).fetchone()
@@ -179,8 +180,12 @@ def _load_period_balances(
       .limit(1)
     ).scalar()
 
+  # Numeric facts only — a Nonnumeric (text-block) fact must neither
+  # contribute a 0.0 balance nor mark its element "present" for the
+  # rollup skip guard.
   stmt = select(Fact.element_id, Fact.value, Fact.period_start, Fact.period_end).where(
-    Fact.fact_scope == "in_scope"
+    Fact.fact_scope == "in_scope",
+    Fact.fact_type == "Numeric",
   )
   if fact_set_id is not None:
     stmt = stmt.where(Fact.fact_set_id == fact_set_id)
@@ -389,23 +394,24 @@ def evaluate_rules_for_structure(
   ] = {}
   parent_id_cache: dict[str, str | None] = {}
   if any(r.rule_pattern == "RollUp" for r in rules):
-    if global_calculations is None:
-      from robosystems.operations.roboledger.reports.calc_dag import (
-        load_rs_gaap_calculations,
-      )
+    from robosystems.operations.roboledger.reports.calc_dag import (
+      load_rs_gaap_calculations,
+      merge_calculations,
+    )
 
+    if global_calculations is None:
       calculations = load_rs_gaap_calculations(session)
     else:
-      # Copy the caller-provided global DAG so the per-structure local overlay
-      # below can't leak arcs back into the shared dict across structures.
       calculations = dict(global_calculations)
     # Tenant-authored roll_up structures (disclosure notes) foot against
-    # their OWN calculation arcs — their parents aren't rs-gaap subtotals,
-    # so the global DAG carries no entry for them. Overlay the structure's
-    # local calc arcs, letting the global DAG win where both define a
-    # parent (statement structures mirror it anyway). Same live-arc
-    # doctrine as the global path: children come from arcs, never from a
-    # frozen enumeration.
+    # their OWN calculation arcs. Merge with LOCAL-WINS precedence: a note
+    # that decomposes a global calc parent (Revenues, OperatingExpenses,
+    # ...) foots against its own members, not the statement-level children
+    # absent from its FactSet; the global DAG is the fallback for every
+    # parent the structure doesn't re-arc. Same live-arc doctrine as the
+    # global path: children come from arcs, never from a frozen
+    # enumeration. merge_calculations is pure, so the caller's shared
+    # global dict can't be polluted across structures.
     local_calcs: dict[str, list[tuple[str, float]]] = {}
     for assoc in sorted(
       associations,
@@ -418,8 +424,7 @@ def evaluate_rules_for_structure(
       local_calcs.setdefault(assoc.from_element_id, []).append(
         (assoc.to_element_id, assoc.weight if assoc.weight is not None else 1.0)
       )
-    for parent_id, children in local_calcs.items():
-      calculations.setdefault(parent_id, children)
+    calculations = merge_calculations(calculations, local_calcs)
     by_period = _load_period_balances(
       session, structure_id, fact_set_id, period_start, period_end
     )

--- a/robosystems/operations/information_block/statement.py
+++ b/robosystems/operations/information_block/statement.py
@@ -261,6 +261,9 @@ def _build_statement_rendering(
     elem = elements_by_id.get(f.element_id)
     if elem is None:
       continue
+    if f.value is None:
+      # Nonnumeric (text-block) facts have no place in the numeric grid.
+      continue
     pe = f.period_end
     ps = f.period_start if f.period_start is not None else pe
     report_facts.append(

--- a/robosystems/operations/roboledger/reads/reports.py
+++ b/robosystems/operations/roboledger/reads/reports.py
@@ -773,6 +773,7 @@ def get_statement(
       ) trait_info ON trait_info.element_id = e.id
       WHERE fs.report_id = :report_id
         AND s.block_type = :block_type
+        AND rf.fact_type = 'Numeric'
     """),
     {"report_id": report_id, "block_type": block_type},
   )

--- a/robosystems/operations/roboledger/reports/calc_dag.py
+++ b/robosystems/operations/roboledger/reports/calc_dag.py
@@ -60,6 +60,26 @@ def load_rs_gaap_calculations(
   return calculations
 
 
+def merge_calculations(
+  global_calcs: dict[str, list[tuple[str, float]]],
+  local_calcs: dict[str, list[tuple[str, float]]],
+) -> dict[str, list[tuple[str, float]]]:
+  """Merged DAG for evaluating one structure: LOCAL arcs win per parent.
+
+  A structure's own calculation arcs are its footing spec — a disclosure
+  note that decomposes ``rs-gaap:Revenues`` into its own members must foot
+  against THOSE members, not the global DAG's statement-level children
+  (which are absent from the note's FactSet, so global-wins reported the
+  rollup as skipped or failed). The global DAG remains the fallback for
+  every parent the structure doesn't re-arc — statement subtotals resolve
+  exactly as the fact producer resolved them. Pure: neither input is
+  mutated.
+  """
+  merged = dict(global_calcs)
+  merged.update(local_calcs)
+  return merged
+
+
 def topo_sort_calculations(
   calculations: dict[str, list[tuple[str, float]]],
 ) -> list[str]:

--- a/tests/operations/extensions/test_materialize.py
+++ b/tests/operations/extensions/test_materialize.py
@@ -126,6 +126,54 @@ class TestStagingSql:
     assert "ChartOfAccounts" in tables["Structure"]
 
 
+class TestNonnumericFactStaging:
+  """Migration 0021 closed the OLTP/graph fact asymmetry — the staging SQL
+  must pass the non-numeric slots through instead of hardcoding them."""
+
+  def test_fact_value_coalesces_string_value(self):
+    sql = _staging_sql(GRAPH_ID, ENTITY_ID, CONNSTR)["Fact"]
+    assert "COALESCE(string_value, CAST(value AS VARCHAR))" in sql
+
+  def test_fact_type_and_value_type_pass_through(self):
+    sql = _staging_sql(GRAPH_ID, ENTITY_ID, CONNSTR)["Fact"]
+    # Passed through from the OLTP columns, not hardcoded literals.
+    assert "'Numeric'" not in sql.replace("fact_type = 'Numeric'", "")
+    assert "'inline'" not in sql
+    assert "fact_type" in sql
+    assert "value_type" in sql
+    assert "content_type" in sql
+
+  def test_fact_decimals_fallback_only_for_numeric(self):
+    sql = _staging_sql(GRAPH_ID, ENTITY_ID, CONNSTR)["Fact"]
+    # Legacy '-2' preserved for numeric rows with unspecified decimals;
+    # Nonnumeric rows pass NULL through (no @decimals in XBRL).
+    assert "CASE WHEN fact_type = 'Numeric'" in sql
+    assert "COALESCE(decimals, '-2')" in sql
+
+  def test_unit_table_derives_from_fact_units(self):
+    sql = _staging_sql(GRAPH_ID, ENTITY_ID, CONNSTR)["Unit"]
+    assert "'unit_' || lower(unit)" in sql
+    assert "'iso4217:' || unit" in sql
+    assert "WHERE fact_type = 'Numeric'" in sql
+    # Static USD fallback keeps the legacy node for fact-less graphs.
+    assert "'unit_usd'" in sql
+
+  def test_fact_has_unit_excludes_nonnumeric(self):
+    sql = _staging_sql(GRAPH_ID, ENTITY_ID, CONNSTR)["FACT_HAS_UNIT"]
+    assert "'unit_' || lower(unit)" in sql
+    assert "WHERE fact_type = 'Numeric'" in sql
+
+  def test_element_item_type_passes_through_with_derived_flags(self):
+    sql = _staging_sql(GRAPH_ID, ENTITY_ID, CONNSTR)["Element"]
+    assert "e.item_type" in sql
+    assert "COALESCE(e.item_type = 'text_block', false)" in sql
+    # NULL item_type keeps the legacy numeric default via COALESCE(..., true).
+    assert (
+      "COALESCE(e.item_type IN ('monetary', 'shares', 'decimal', 'integer'), true)"
+      in sql
+    )
+
+
 class TestEdgeForeignKeyGuards:
   """#757 — coa_mapping structures are materialized so curated 'mapping'
   associations have a valid parent Structure, and edge tables semi-join their

--- a/tests/operations/information_block/rules/test_engine.py
+++ b/tests/operations/information_block/rules/test_engine.py
@@ -357,3 +357,63 @@ class TestEvaluateRulesForStructure:
         created_by="test_user",
       )
     assert results == []
+
+
+class TestNumericGuards:
+  """Nonnumeric (text-block) facts are invisible to the numeric rule
+  machinery — every fact-reading query filters to the numeric arm."""
+
+  def test_bind_variables_excludes_null_values(self) -> None:
+    from robosystems.operations.information_block.rules.engine import _bind_variables
+
+    session = MagicMock()
+    rule = _make_rule_orm(
+      variables=[{"variable_name": "Assets", "variable_qname": "fac:Assets"}]
+    )
+    captured: list[str] = []
+
+    elem_result = MagicMock()
+    elem_result.scalar.return_value = "elem_assets"
+    fact_result = MagicMock()
+    fact_result.scalar.return_value = 1000.0
+
+    def _execute(stmt, *args, **kwargs):
+      captured.append(str(stmt))
+      return elem_result if len(captured) == 1 else fact_result
+
+    session.execute.side_effect = _execute
+
+    _bind_variables(session, rule, "struct_bs", None, None)
+
+    assert "value IS NOT NULL" in captured[1]
+
+  def test_bind_sum_variables_filters_to_numeric(self) -> None:
+    from robosystems.operations.information_block.rules.engine import (
+      _bind_sum_variables,
+    )
+
+    session = MagicMock()
+    rule = _make_rule_orm(
+      pattern="SumEquals",
+      variables=[
+        {"variable_name": "periodic_amount", "variable_qname": "fac:DeprExpense"}
+      ],
+    )
+    captured: list[str] = []
+
+    elem_result = MagicMock()
+    elem_result.scalar.return_value = "elem_depr"
+    sum_row = MagicMock()
+    sum_row.total = 1200.0
+    agg_result = MagicMock()
+    agg_result.fetchone.return_value = sum_row
+
+    def _execute(stmt, *args, **kwargs):
+      captured.append(str(stmt))
+      return elem_result if len(captured) == 1 else agg_result
+
+    session.execute.side_effect = _execute
+
+    _bind_sum_variables(session, rule, "struct_sched")
+
+    assert "fact_type = 'Numeric'" in captured[1]

--- a/tests/operations/information_block/rules/test_rollup_arc_derived.py
+++ b/tests/operations/information_block/rules/test_rollup_arc_derived.py
@@ -251,6 +251,25 @@ class TestLoadPeriodBalances:
     assert len(captured) == 1
     assert "fact_set_id" in captured[0]
 
+  def test_filters_to_numeric_facts(self) -> None:
+    """Nonnumeric (text-block) facts must neither contribute a balance nor
+    mark their element present for the rollup skip guard."""
+    session = MagicMock()
+    captured: list[str] = []
+
+    facts_result = MagicMock()
+    facts_result.all.return_value = []
+
+    def _execute(stmt, *args, **kwargs):
+      captured.append(str(stmt))
+      return facts_result
+
+    session.execute.side_effect = _execute
+
+    _load_period_balances(session, "struct_note", "fs_pinned", None, None)
+
+    assert "fact_type" in captured[0]
+
 
 class TestRollupRoutingInEngine:
   def test_rollup_rule_routes_to_arc_derived_path(self) -> None:
@@ -363,34 +382,51 @@ class TestRollupRoutingInEngine:
     assert added.status == "pass"
     assert added.detail.get("source") == "calc-dag"
 
-  def test_global_dag_wins_over_local_arcs_for_shared_parent(self) -> None:
+  def test_local_arcs_win_over_global_dag_for_shared_parent(self) -> None:
     """When a parent exists in BOTH the global DAG and the structure's
-    local arcs, the global definition wins (statement structures mirror
-    it; overlay must not shadow #883's semantics)."""
+    local arcs, the LOCAL definition wins — the structure's own arcs are
+    its footing spec. The canonical shape: a disclosure note decomposes a
+    global calc parent (Revenues, OperatingExpenses, ...) into its own
+    members; the global DAG's statement-level children are absent from
+    the note's FactSet, so global-wins reported the rollup skipped (or a
+    false fail) instead of footing against the note's members."""
     session = MagicMock()
-    session.get.return_value = MagicMock(id="struct_bs", block_type="balance_sheet")
+    session.get.return_value = MagicMock(
+      id="struct_note", block_type="regulatory_disclosure"
+    )
 
     rule_lite = MagicMock()
-    rule_lite.id = "rule_bs"
-    rule_orm = _rule("ANC", "rs-gaap:AssetsNoncurrent")
-    rule_orm.id = "rule_bs"
+    rule_lite.id = "rule_note"
+    rule_orm = _rule("elem_rev", "rs-gaap:Revenues")
+    rule_orm.id = "rule_note"
 
-    local = MagicMock()
-    local.id = "assoc_local"
-    local.association_type = "calculation"
-    local.from_element_id = "ANC"
-    local.to_element_id = "WrongChild"
-    local.weight = 1.0
-    local.order_value = 1.0
+    def _calc_assoc(child_id: str, order: float) -> MagicMock:
+      a = MagicMock()
+      a.id = f"assoc_{child_id}"
+      a.association_type = "calculation"
+      a.from_element_id = "elem_rev"
+      a.to_element_id = child_id
+      a.weight = 1.0
+      a.order_value = order
+      return a
 
     assoc = MagicMock()
-    assoc.scalars.return_value.all.return_value = [local]
+    assoc.scalars.return_value.all.return_value = [
+      _calc_assoc("mem_product", 1.0),
+      _calc_assoc("mem_service", 2.0),
+    ]
     rules_res = MagicMock()
     rules_res.scalars.return_value.all.return_value = [rule_orm]
     session.execute.side_effect = [assoc, rules_res]
 
-    # Global children foot; the local WrongChild (0 balance) would fail.
-    by_period = {_P1: ({"PPE": 100.0, "ANC": 100.0}, {"PPE", "ANC"})}
+    # The note's members foot to its total; the global DAG's statement
+    # child ("stmt_child") is absent from the note's FactSet entirely.
+    by_period = {
+      _P1: (
+        {"mem_product": 3000.0, "mem_service": 2000.0, "elem_rev": 5000.0},
+        {"mem_product", "mem_service", "elem_rev"},
+      )
+    }
 
     with (
       patch(
@@ -399,7 +435,7 @@ class TestRollupRoutingInEngine:
       ),
       patch(
         "robosystems.operations.roboledger.reports.calc_dag.load_rs_gaap_calculations",
-        return_value={"ANC": [("PPE", 1.0)]},
+        return_value={"elem_rev": [("stmt_child", 1.0)]},
       ),
       patch(
         "robosystems.operations.information_block.rules.engine._load_period_balances",
@@ -407,9 +443,10 @@ class TestRollupRoutingInEngine:
       ),
     ):
       results = evaluate_rules_for_structure(
-        session, "struct_bs", period_start=_P1[0], period_end=_P1[1]
+        session, "struct_note", period_start=_P1[0], period_end=_P1[1]
       )
 
     assert len(results) == 1
     added = session.add.call_args_list[0][0][0]
     assert added.status == "pass"
+    assert added.detail.get("source") == "calc-dag"

--- a/tests/operations/information_block/test_statement_handlers.py
+++ b/tests/operations/information_block/test_statement_handlers.py
@@ -460,3 +460,39 @@ class TestBuildHierarchyFromAtoms:
       "struct_balance_sheet", {}, {}, []
     )
     assert hierarchy == []
+
+
+class TestRenderingSkipsNonnumericFacts:
+  def test_null_value_fact_does_not_crash_or_render(self) -> None:
+    """A Nonnumeric fact (value=None) in the FactSet must be skipped by
+    the numeric rendering path — before the guard, ``float(f.value)``
+    raised TypeError."""
+    from types import SimpleNamespace
+
+    session = MagicMock()
+    session.execute.return_value = _exec_result(all_rows=[])
+
+    element = SimpleNamespace(
+      id="elem_policy",
+      qname="driftline:SignificantAccountingPoliciesTextBlock",
+      name="Significant Accounting Policies",
+      balance_type="debit",
+    )
+    text_fact = SimpleNamespace(
+      element_id="elem_policy",
+      value=None,
+      period_start=date(2026, 1, 1),
+      period_end=date(2026, 12, 31),
+      period_type="duration",
+    )
+
+    rendering = statement_handlers._build_statement_rendering(
+      session,
+      elements=[element],  # type: ignore[list-item]
+      associations=[],
+      facts=[text_fact],  # type: ignore[list-item]
+      structure_id="struct_note",
+      block_type="regulatory_disclosure",
+    )
+
+    assert rendering.rows == []

--- a/tests/operations/roboledger/reads/test_reports_extra.py
+++ b/tests/operations/roboledger/reads/test_reports_extra.py
@@ -351,3 +351,14 @@ class TestGetStatementValidBlockTypes:
         report_id="rpt_01",
         block_type="not_a_real_block_type",
       )
+
+
+class TestGetStatementNumericFilter:
+  def test_fact_query_filters_to_numeric(self) -> None:
+    """``get_statement`` renders the numeric grid for a report's block —
+    once FactSets can carry Nonnumeric (text-block) facts, the fact query
+    must exclude them at the SQL level."""
+    import inspect
+
+    src = inspect.getsource(get_statement)
+    assert "rf.fact_type = 'Numeric'" in src

--- a/tests/operations/roboledger/reports/test_calc_dag.py
+++ b/tests/operations/roboledger/reports/test_calc_dag.py
@@ -15,6 +15,7 @@ import pytest
 
 from robosystems.operations.roboledger.reports.calc_dag import (
   load_rs_gaap_calculations,
+  merge_calculations,
   resolve_calc_dag,
   topo_sort_calculations,
 )
@@ -114,3 +115,28 @@ class TestTopoSort:
 
   def test_empty(self) -> None:
     assert topo_sort_calculations({}) == []
+
+
+class TestMergeCalculations:
+  def test_local_wins_per_parent(self) -> None:
+    """A structure's own arcs ARE its footing spec — a note decomposing a
+    global calc parent foots against its own members, not the statement
+    children absent from its FactSet."""
+    global_calcs = {"Revenues": [("StmtChildA", 1.0), ("StmtChildB", 1.0)]}
+    local_calcs = {"Revenues": [("MemProduct", 1.0), ("MemService", 1.0)]}
+    merged = merge_calculations(global_calcs, local_calcs)
+    assert merged["Revenues"] == [("MemProduct", 1.0), ("MemService", 1.0)]
+
+  def test_global_fallback_for_unarced_parents(self) -> None:
+    global_calcs = {"Assets": [("AC", 1.0), ("ANC", 1.0)]}
+    local_calcs = {"InventoryNet": [("Raw", 1.0), ("Finished", 1.0)]}
+    merged = merge_calculations(global_calcs, local_calcs)
+    assert merged["Assets"] == [("AC", 1.0), ("ANC", 1.0)]
+    assert merged["InventoryNet"] == [("Raw", 1.0), ("Finished", 1.0)]
+
+  def test_pure_does_not_mutate_inputs(self) -> None:
+    global_calcs = {"Assets": [("AC", 1.0)]}
+    local_calcs = {"Assets": [("Local", 1.0)]}
+    merge_calculations(global_calcs, local_calcs)
+    assert global_calcs == {"Assets": [("AC", 1.0)]}
+    assert local_calcs == {"Assets": [("Local", 1.0)]}

--- a/tests/operations/roboledger/test_fact_model.py
+++ b/tests/operations/roboledger/test_fact_model.py
@@ -1,0 +1,85 @@
+"""Shape tests for the non-numeric Fact model (migration 0021).
+
+Metadata-level: pin the column shapes, Python-side defaults, and CHECK
+constraint expressions the migration mirrors, so model/migration drift
+surfaces without a database.
+"""
+
+from __future__ import annotations
+
+from robosystems.models.extensions.roboledger.fact import Fact
+from robosystems.models.extensions.roboledger.fact_set import FactSet
+from robosystems.models.extensions.structure import (
+  CONCEPT_ARRANGEMENT_VALUES,
+  TEXT_BLOCK_CAPS,
+)
+
+
+def _check_sql(table, name: str) -> str:
+  for c in table.constraints:
+    if getattr(c, "name", None) == name:
+      return str(c.sqltext)
+  raise AssertionError(f"constraint {name} not found on {table.name}")
+
+
+class TestFactColumns:
+  def test_value_nullable_string_value_added(self) -> None:
+    cols = Fact.__table__.c
+    assert cols.value.nullable is True
+    assert cols.string_value.nullable is True
+    assert cols.content_type.nullable is True
+    assert cols.decimals.nullable is True
+
+  def test_discriminator_defaults(self) -> None:
+    cols = Fact.__table__.c
+    assert cols.fact_type.nullable is False
+    assert cols.fact_type.default is not None
+    assert cols.fact_type.default.arg == "Numeric"
+    assert cols.value_type.nullable is False
+    assert cols.value_type.default is not None
+    assert cols.value_type.default.arg == "inline"
+
+  def test_unit_keeps_usd_default(self) -> None:
+    # Units apply to numeric facts only, but the column stays NOT NULL —
+    # materialize skips the FACT_HAS_UNIT edge for Nonnumeric instead.
+    col = Fact.__table__.c.unit
+    assert col.nullable is False
+    assert col.default is not None
+    assert col.default.arg == "USD"
+
+
+class TestFactChecks:
+  def test_fact_type_closed_vocabulary(self) -> None:
+    sql = _check_sql(Fact.__table__, "ck_facts_fact_type")
+    assert "'Numeric'" in sql
+    assert "'Nonnumeric'" in sql
+
+  def test_value_type_closed_vocabulary(self) -> None:
+    sql = _check_sql(Fact.__table__, "ck_facts_value_type")
+    assert "'inline'" in sql
+    assert "'external_resource'" in sql
+
+  def test_value_shape_xor(self) -> None:
+    """A fact is numeric XOR non-numeric — never both, never neither."""
+    sql = _check_sql(Fact.__table__, "ck_facts_value_shape")
+    assert "fact_type = 'Numeric' AND value IS NOT NULL AND string_value IS NULL" in sql
+    assert (
+      "fact_type = 'Nonnumeric' AND string_value IS NOT NULL AND value IS NULL" in sql
+    )
+
+
+class TestFactSetTypeVocabulary:
+  def test_disclosure_admitted(self) -> None:
+    sql = _check_sql(FactSet.__table__, "check_fact_set_type")
+    for value in ("'report'", "'schedule'", "'custom'", "'disclosure'"):
+      assert value in sql
+
+
+class TestTextBlockCaps:
+  def test_subset_of_canonical_vocabulary(self) -> None:
+    assert set(CONCEPT_ARRANGEMENT_VALUES) >= TEXT_BLOCK_CAPS
+
+  def test_level4_detail_excluded(self) -> None:
+    # cm.xsd level 4 is the numeric detail table, not narrative.
+    assert "level4_detail" not in TEXT_BLOCK_CAPS
+    assert "text_block" in TEXT_BLOCK_CAPS


### PR DESCRIPTION
## Summary

First half of the text-block-facts increment (report-engine M3): the OLTP fact model gains the non-numeric value path the graph Fact node has always had, and materialize passes it through instead of hardcoding.

- **Schema (extensions migration 0021, TenantOps fan-out):** `facts.value` nullable + `string_value`/`fact_type`/`value_type`/`content_type`/`decimals` with a numeric-XOR-nonnumeric CHECK; `elements.item_type`; `fact_sets` admits `'disclosure'`; `TEXT_BLOCK_CAPS` named next to the CAP vocabulary.
- **Materialize passthrough:** non-numeric slots read from the row; Unit nodes + `FACT_HAS_UNIT` derive from `facts.unit` (numeric facts only) instead of pinning USD; Element `item_type`/`is_textblock` mapped through. Existing graph output is byte-identical (verified on the showcase demo: same fact_type/decimals/value_type, single `unit_usd`, 1:1 unit edges, legacy element flags).
- **Numeric-reader guards:** rules engine binding/summing/balances, statement rendering, and the statement read query filter to numeric facts.
- **Rules-engine precedence fix:** structure-local calculation arcs now win over the global calc DAG per parent (`calc_dag.merge_calculations`), so a disclosure note decomposing a global calc parent foots against its own members. Global remains the fallback.

No writer behavior changes in this PR — the authoring surface (Document→text-block bind, picker, envelope rendering) follows in the second PR.

## Testing

- Full `tests/operations/` + `tests/taxonomy/` + `tests/migrations/` without maxfail: 2887 passed.
- Migration applied locally to public + both tenant schemas and verified column/constraint shape.
- Coffee-roaster showcase demo end-to-end on the migrated stack: statements + inventory note render identically, 25 rules pass / 0 fail, Arelle valid, SHACL conforms.