### PR TITLE
chore(sdk): bump robosystems-client to 0.5.2; demo uses typed wrappers

### DIFF
--- a/examples/_scenario/runner.py
+++ b/examples/_scenario/runner.py
@@ -658,18 +658,8 @@ def create_disclosure_notes(
   line and the note foot over the same facts. Rendering is fact-driven:
   ``create-report`` picks the note because its concepts receive facts.
 
-  The create-taxonomy-block operation is posted directly over HTTP for
-  now: the published robosystems-client (0.5.1) predates the
-  ``regulatory_disclosure`` block_type + ``concept_arrangement`` request
-  fields and its generated enum rejects them client-side. Swap to
-  ``LedgerClient.create_taxonomy_block`` once the SDK is regenerated.
-
   Returns (notes_created, member_mappings_created).
   """
-  import httpx
-
-  config = _client_config()
-  headers = {"X-API-Key": config["token"], "Content-Type": "application/json"}
   client = _get_ledger_client()
 
   taxonomies = client.list_taxonomies(graph_id, taxonomy_type="reporting_standard")
@@ -741,23 +731,14 @@ def create_disclosure_notes(
       ],
       "rules": [],
     }
-    resp = httpx.post(
-      f"{BASE_URL}/extensions/roboledger/{graph_id}/operations/create-taxonomy-block",
-      json=payload,
-      headers=headers,
-      timeout=120.0,
-    )
-    if resp.status_code >= 400:
-      print(
-        f"  ERROR: create-taxonomy-block failed ({resp.status_code}): {resp.text[:300]}"
-      )
+    try:
+      envelope = client.create_taxonomy_block(graph_id, payload)
+    except Exception as e:
+      print(f"  ERROR: create-taxonomy-block failed: {e}")
       continue
-    envelope = (resp.json() or {}).get("result") or {}
     notes_created += 1
 
-    member_ids_by_qname = {
-      e.get("qname"): e.get("id") for e in envelope.get("elements", [])
-    }
+    member_ids_by_qname = {e.qname: e.id for e in (envelope.elements or [])}
     if mapping_id is None:
       continue
     for m in members:
@@ -794,15 +775,8 @@ def create_text_block_notes(
   generated afterward snapshot the standing bindings, so the narrative
   rides the report package, the JSON-LD bundle, and the graph.
 
-  Posted over raw HTTP like ``create_disclosure_notes`` (the published
-  SDK predates both operations' request shapes).
-
   Returns the number of documents bound.
   """
-  import httpx
-
-  config = _client_config()
-  headers = {"X-API-Key": config["token"], "Content-Type": "application/json"}
   client = _get_ledger_client()
 
   if scenario.report_period is None:
@@ -867,21 +841,12 @@ def create_text_block_notes(
       ],
       "rules": [],
     }
-    resp = httpx.post(
-      f"{BASE_URL}/extensions/roboledger/{graph_id}/operations/create-taxonomy-block",
-      json=payload,
-      headers=headers,
-      timeout=120.0,
-    )
-    if resp.status_code >= 400:
-      print(
-        f"  ERROR: create-taxonomy-block failed ({resp.status_code}): {resp.text[:300]}"
-      )
+    try:
+      envelope = client.create_taxonomy_block(graph_id, payload)
+    except Exception as e:
+      print(f"  ERROR: create-taxonomy-block failed: {e}")
       continue
-    envelope = (resp.json() or {}).get("result") or {}
-    structure_id = next(
-      (s.get("id") for s in envelope.get("structures", []) if s.get("id")), None
-    )
+    structure_id = next((s.id for s in (envelope.structures or []) if s.id), None)
     if structure_id is None:
       print(f"  ERROR: no structure id returned for '{struct_name}'")
       continue
@@ -898,17 +863,10 @@ def create_text_block_notes(
         "period_start": period_start.isoformat(),
         "period_end": period_end.isoformat(),
       }
-      bind_resp = httpx.post(
-        f"{BASE_URL}/extensions/roboledger/{graph_id}/operations/bind-text-block",
-        json=bind_payload,
-        headers=headers,
-        timeout=60.0,
-      )
-      if bind_resp.status_code >= 400:
-        print(
-          f"  ERROR: bind-text-block failed ({bind_resp.status_code}): "
-          f"{bind_resp.text[:300]}"
-        )
+      try:
+        client.bind_text_block(graph_id, bind_payload)
+      except Exception as e:
+        print(f"  ERROR: bind-text-block failed: {e}")
         continue
       bound += 1
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     # RoboSystems client for demo and testing
-    "robosystems-client==0.5.2",
+    "robosystems-client==0.5.3",
 
     # Testing framework
     "pytest>=9.0.0,<10.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     # RoboSystems client for demo and testing
-    "robosystems-client==0.5.1",
+    "robosystems-client==0.5.2",
 
     # Testing framework
     "pytest>=9.0.0,<10.0",

--- a/uv.lock
+++ b/uv.lock
@@ -3695,7 +3695,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.34.2,<3.0" },
     { name = "retrying", specifier = ">=1.4.0,<2.0" },
     { name = "rich", marker = "extra == 'dev'", specifier = ">=15.0.0,<16.0" },
-    { name = "robosystems-client", marker = "extra == 'dev'", specifier = "==0.5.1" },
+    { name = "robosystems-client", marker = "extra == 'dev'", specifier = "==0.5.2" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0,<1.0" },
     { name = "sqlalchemy", specifier = ">=2.0.0,<3.0" },
     { name = "sse-starlette", specifier = ">=3.3.0,<4.0" },
@@ -3718,7 +3718,7 @@ lambda = [
 
 [[package]]
 name = "robosystems-client"
-version = "0.5.1"
+version = "0.5.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -3726,9 +3726,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/85/d3/e486643e2b2667b4e4f02c47b2bea51f7649e4308921078547c8157e2f56/robosystems_client-0.5.1.tar.gz", hash = "sha256:52b29af4ed3a33314e06e62363d94fb171ebe5f8b821158dc4ff6afc6c892729", size = 408066, upload-time = "2026-07-13T02:19:28.319Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/70/038319cddbeffd6171b2b8ce36e13a6bb5e6e6195f379c50cca3bac71165/robosystems_client-0.5.2.tar.gz", hash = "sha256:314090149f2d8c975f34926337db6f7b3ab31e5441aebc144c99ddfe41bd31a6", size = 411702, upload-time = "2026-07-19T06:40:28.524Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ab/bb/4ef3d4aa57f518c6888bb78bcb043aad3cbab3199d68bc56392bf1d13412/robosystems_client-0.5.1-py3-none-any.whl", hash = "sha256:273fb5aa3d92cd7bf37c4ed0dd1dcf91d670b4c13583a484e889e2785ac68f56", size = 954902, upload-time = "2026-07-13T02:19:26.33Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/90/310e9e9225184502070622684d247008ae2e1444fd6a13c4dfa21bead946/robosystems_client-0.5.2-py3-none-any.whl", hash = "sha256:a733648a24ea0ba3c5574262fcbff085e6089165acd8137d00c8ec9f58e3a870", size = 963955, upload-time = "2026-07-19T06:40:26.976Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -3695,7 +3695,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.34.2,<3.0" },
     { name = "retrying", specifier = ">=1.4.0,<2.0" },
     { name = "rich", marker = "extra == 'dev'", specifier = ">=15.0.0,<16.0" },
-    { name = "robosystems-client", marker = "extra == 'dev'", specifier = "==0.5.2" },
+    { name = "robosystems-client", marker = "extra == 'dev'", specifier = "==0.5.3" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0,<1.0" },
     { name = "sqlalchemy", specifier = ">=2.0.0,<3.0" },
     { name = "sse-starlette", specifier = ">=3.3.0,<4.0" },
@@ -3718,7 +3718,7 @@ lambda = [
 
 [[package]]
 name = "robosystems-client"
-version = "0.5.2"
+version = "0.5.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -3726,9 +3726,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5e/70/038319cddbeffd6171b2b8ce36e13a6bb5e6e6195f379c50cca3bac71165/robosystems_client-0.5.2.tar.gz", hash = "sha256:314090149f2d8c975f34926337db6f7b3ab31e5441aebc144c99ddfe41bd31a6", size = 411702, upload-time = "2026-07-19T06:40:28.524Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/c6/42f874018af79d5f98095f27ad9bdf6579e8b4b3cd24feedb9be0dcfa9f3/robosystems_client-0.5.3.tar.gz", hash = "sha256:1ce8eb8824f6d4b233c45085bcf45925fac5ca5ab12c14faf65b5094022cf32d", size = 411720, upload-time = "2026-07-19T06:56:48.499Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/90/310e9e9225184502070622684d247008ae2e1444fd6a13c4dfa21bead946/robosystems_client-0.5.2-py3-none-any.whl", hash = "sha256:a733648a24ea0ba3c5574262fcbff085e6089165acd8137d00c8ec9f58e3a870", size = 963955, upload-time = "2026-07-19T06:40:26.976Z" },
+    { url = "https://files.pythonhosted.org/packages/68/cd/97962742e6dbddf045fec89a609649eb8e4c53800d42d13aed59784c64fb/robosystems_client-0.5.3-py3-none-any.whl", hash = "sha256:6206c05cbb070654dfc489c9e5bd0f4de8cb43dbccfcb3d169d1f8fb2dc2708f", size = 963972, upload-time = "2026-07-19T06:56:47.009Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Consumes the freshly published `robosystems-client` 0.5.3: the showcase runner's two raw-HTTP call sites (`create-taxonomy-block` for both disclosure note shapes, `bind-text-block` for the policy binds) swap to the typed `LedgerClient` wrappers, closing the TODO left when the previous client release rejected the disclosure request fields. 0.5.3 also carries the GraphQL query-document fix (robosystems-python-client #141), so narrative disclosure envelopes round-trip completely.

## Testing

- `just test-code` clean.
- Showcase demo end-to-end on the typed client: note authored, 3 documents bound, annual report filed, Arelle valid, SHACL conforms, zero errors — and the verify step prints each bound policy's narrative head through `list_information_blocks`.