### PR TITLE
fix(serialization): align text-block vocabulary with report-components

### DIFF
--- a/frameworks/ontology/v1/shapes.ttl
+++ b/frameworks/ontology/v1/shapes.ttl
@@ -17,6 +17,10 @@
 #################################################################
 
 # ── Positive: a Fact references its aspects directly (no context) ──
+# A numeric fact carries rs:unit + rs:numericValue; a non-numeric (text /
+# textBlock) fact carries rs:stringValue and no unit. Both are Facts; the
+# value predicate distinguishes them (rs:factType records which). Kept in
+# lockstep with the xbrl-holon converter's vendored copy of this shape.
 rs:FactShape a sh:NodeShape ;
   sh:targetClass rs:Fact ;
   sh:property [
@@ -29,7 +33,12 @@ rs:FactShape a sh:NodeShape ;
     sh:path rs:unit ; sh:maxCount 1 ;
     sh:message "rs:Fact may reference at most one rs:unit." ] ;
   sh:property [
-    sh:path rs:numericValue ; sh:datatype xsd:decimal ; sh:maxCount 1 ] .
+    sh:path rs:numericValue ; sh:datatype xsd:decimal ; sh:maxCount 1 ] ;
+  sh:property [
+    sh:path rs:stringValue ; sh:maxCount 1 ;
+    sh:message "rs:Fact may carry at most one rs:stringValue (non-numeric value)." ] ;
+  sh:property [
+    sh:path rs:factType ; sh:maxCount 1 ] .
 
 # ── Positive: a reified Association carries XBRL arc vocabulary ──
 rs:AssociationShape a sh:NodeShape ;

--- a/robosystems/arelle/context.py
+++ b/robosystems/arelle/context.py
@@ -142,9 +142,13 @@ CANONICAL_CONTEXT: dict = {
   "numericValue": {"@id": f"{RS_VOCAB}numericValue", "@type": "xsd:decimal"},
   "decimals": {"@id": f"{RS_VOCAB}decimals"},
   # Non-numeric (text-block) fact arm — string value, no unit/decimals.
+  # Vocabulary matches what @robosystems/report-components consumes:
+  # rs:stringValue for the text payload, rs:itemType on the concept
+  # ('textBlock' gates the narrative rendering arm).
   "factType": {"@id": f"{RS_VOCAB}factType"},
-  "value": {"@id": f"{RS_VOCAB}value", "@type": "xsd:string"},
+  "stringValue": {"@id": f"{RS_VOCAB}stringValue", "@type": "xsd:string"},
   "contentType": {"@id": f"{RS_VOCAB}contentType"},
+  "itemType": {"@id": f"{RS_VOCAB}itemType"},
   # Period node — period kind uses XBRL's instant/duration vocabulary
   "instant": {"@id": "xbrli:instant", "@type": "xsd:date"},
   "startDate": {"@id": "xbrli:startDate", "@type": "xsd:date"},

--- a/robosystems/operations/serialization/bundle.py
+++ b/robosystems/operations/serialization/bundle.py
@@ -142,6 +142,10 @@ class BundleElement(BaseModel):
   )
   substitution_group: str | None = None
   source: str
+  # Value domain in the wire vocabulary (camelCase: 'textBlock', 'monetary',
+  # ...). Translated from the OLTP snake_case item_type at projection time;
+  # 'textBlock' gates the narrative rendering arm in report-components.
+  item_type: str | None = None
 
 
 # ── Linkbases (XBRL linkbase content) ──────────────────────────────────────
@@ -701,6 +705,14 @@ def _period_metas_for_report(report: Any, fact_sets: list[Any]) -> list[PeriodMe
   return []
 
 
+def _wire_item_type(item_type: str | None) -> str | None:
+  """OLTP snake_case value domain → wire camelCase ('text_block' → 'textBlock')."""
+  if not item_type:
+    return None
+  head, *rest = str(item_type).split("_")
+  return head + "".join(part.capitalize() for part in rest)
+
+
 def _element_to_bundle(e: Any, standard_label: str | None = None) -> BundleElement:
   return BundleElement(
     id=str(e.id),
@@ -718,6 +730,7 @@ def _element_to_bundle(e: Any, standard_label: str | None = None) -> BundleEleme
     element_type=str(e.element_type),
     substitution_group=e.substitution_group,
     source=str(e.source),
+    item_type=_wire_item_type(getattr(e, "item_type", None)),
   )
 
 

--- a/robosystems/operations/serialization/rdf/jsonld.py
+++ b/robosystems/operations/serialization/rdf/jsonld.py
@@ -275,6 +275,10 @@ def _add_schema_concepts(g: Graph, bundle: StatementBundle, root: URIRef) -> Non
     g.add((uri, RS.monetary, Literal(concept.is_monetary, datatype=XSD.boolean)))
     g.add((uri, RS.abstract, Literal(concept.is_abstract, datatype=XSD.boolean)))
     g.add((uri, RS.elementType, Literal(concept.element_type)))
+    if concept.item_type:
+      # Wire value domain ('textBlock', 'monetary', ...) — 'textBlock'
+      # gates the narrative rendering arm in report-components.
+      g.add((uri, RS.itemType, Literal(concept.item_type)))
     if concept.label:
       g.add((uri, SKOS.prefLabel, Literal(concept.label)))
     if concept.substitution_group:
@@ -450,8 +454,9 @@ def _add_facts(g: Graph, bundle: StatementBundle, root: URIRef) -> None:
       g.add((uri, RS.decimals, Literal(fact.decimals)))
     if fact.text_value is not None:
       # Nonnumeric (text-block) arm — string value, no unit/decimals
-      # (XBRL nonNumeric facts carry neither).
-      g.add((uri, RS.value, Literal(fact.text_value, datatype=XSD.string)))
+      # (XBRL nonNumeric facts carry neither). rs:stringValue is the
+      # predicate @robosystems/report-components reads for narrative.
+      g.add((uri, RS.stringValue, Literal(fact.text_value, datatype=XSD.string)))
       if fact.content_type:
         g.add((uri, RS.contentType, Literal(fact.content_type)))
     g.add((uri, RS.internalId, Literal(fact.id)))

--- a/robosystems/operations/serialization/rdf/jsonld.py
+++ b/robosystems/operations/serialization/rdf/jsonld.py
@@ -443,7 +443,11 @@ def _add_facts(g: Graph, bundle: StatementBundle, root: URIRef) -> None:
     g.add((uri, RS.element, _concept_uri(fact.element_qname)))
     g.add((uri, RS.entity, _scoped(root, "entity", fact.entity_ref)))
     g.add((uri, RS.period, _scoped(root, "period", fact.period_ref)))
-    g.add((uri, RS.factType, Literal(fact.fact_type)))
+    # Wire casing is lowercase ('numeric' / 'nonnumeric') — matching the
+    # xbrl-holon converter, the other producer of this vocabulary. The
+    # OLTP/graph columns keep their capitalized values; this is a
+    # boundary translation like item_type's snake->camel.
+    g.add((uri, RS.factType, Literal(fact.fact_type.lower())))
     if fact.value is not None:
       # Numeric arm — value + unit + decimals, unchanged shape.
       if fact.unit_ref is not None:

--- a/tests/operations/serialization/test_bundle_producer.py
+++ b/tests/operations/serialization/test_bundle_producer.py
@@ -832,3 +832,37 @@ class TestBundleIncludesDisclosureEnvelopes:
     src = inspect.getsource(bundle_mod.build_report_bundle)
     assert "build_disclosure_envelope" in src
     assert "DISCLOSURE_BLOCK_TYPE" in src
+
+
+class TestWireItemType:
+  def test_snake_to_camel(self) -> None:
+    from robosystems.operations.serialization.bundle import _wire_item_type
+
+    assert _wire_item_type("text_block") == "textBlock"
+    assert _wire_item_type("monetary") == "monetary"
+    assert _wire_item_type("per_share") == "perShare"
+    assert _wire_item_type(None) is None
+    assert _wire_item_type("") is None
+
+  def test_element_projection_carries_item_type(self) -> None:
+    from types import SimpleNamespace
+
+    from robosystems.operations.serialization.bundle import _element_to_bundle
+
+    row = SimpleNamespace(
+      id="elem_tb",
+      qname="driftline:InventoryPolicyTextBlock",
+      namespace=None,
+      name="InventoryPolicyTextBlock",
+      description=None,
+      balance_type="debit",
+      period_type="duration",
+      is_abstract=False,
+      is_monetary=False,
+      element_type="concept",
+      substitution_group=None,
+      source="native",
+      item_type="text_block",
+    )
+    be = _element_to_bundle(row)
+    assert be.item_type == "textBlock"

--- a/tests/operations/serialization/test_jsonld_encoder.py
+++ b/tests/operations/serialization/test_jsonld_encoder.py
@@ -381,14 +381,32 @@ class TestNonnumericFacts:
     bundle.facts.append(_text_fact())
     g = build_graph(bundle)
     uri = URIRef(f"{_root(g)}/fact/fact_txt")
-    assert (uri, RS.value, None) in g
-    text_literal = next(g.objects(uri, RS.value))
+    # rs:stringValue is the predicate report-components reads — NOT rs:value.
+    assert (uri, RS.stringValue, None) in g
+    text_literal = next(g.objects(uri, RS.stringValue))
     assert "FIFO" in str(text_literal)
     assert (uri, RS.factType, Literal("Nonnumeric")) in g
     assert (uri, RS.contentType, Literal("text/markdown")) in g
     assert (uri, RS.numericValue, None) not in g
     assert (uri, RS.unit, None) not in g
     assert (uri, RS.decimals, None) not in g
+
+  def test_text_block_concept_declares_item_type(self) -> None:
+    bundle = _bundle()
+    bundle.schema_concepts.append(
+      BundleElement(
+        id="PolicyTB",
+        qname="driftline:InventoryPolicyTextBlock",
+        name="InventoryPolicyTextBlock",
+        period_type="duration",
+        is_monetary=False,
+        source="native",
+        item_type="textBlock",
+      )
+    )
+    g = build_graph(bundle)
+    uri = next(g.subjects(RS.itemType, Literal("textBlock")))
+    assert "InventoryPolicyTextBlock" in str(uri)
 
   def test_numeric_fact_arm_unchanged(self) -> None:
     bundle = _bundle()

--- a/tests/operations/serialization/test_jsonld_encoder.py
+++ b/tests/operations/serialization/test_jsonld_encoder.py
@@ -385,7 +385,8 @@ class TestNonnumericFacts:
     assert (uri, RS.stringValue, None) in g
     text_literal = next(g.objects(uri, RS.stringValue))
     assert "FIFO" in str(text_literal)
-    assert (uri, RS.factType, Literal("Nonnumeric")) in g
+    # Wire casing is lowercase, matching the xbrl-holon converter.
+    assert (uri, RS.factType, Literal("nonnumeric")) in g
     assert (uri, RS.contentType, Literal("text/markdown")) in g
     assert (uri, RS.numericValue, None) not in g
     assert (uri, RS.unit, None) not in g
@@ -415,7 +416,7 @@ class TestNonnumericFacts:
     uri = URIRef(f"{_root(g)}/fact/fact_01")
     assert (uri, RS.numericValue, None) in g
     assert (uri, RS.unit, None) in g
-    assert (uri, RS.factType, Literal("Numeric")) in g
+    assert (uri, RS.factType, Literal("numeric")) in g
 
   def test_text_fact_bundle_keeps_shacl_conformance(self) -> None:
     bundle = _bundle()


### PR DESCRIPTION
## Summary

Bound text-block disclosures rendered in the holon viewer as a numeric grid of em-dashes. The JSON-LD emitter used `rs:value` for narrative payloads, but the rendering ecosystem (`@robosystems/report-components`) reads `rs:stringValue` and gates its narrative arm on the concept's `rs:itemType` (`'textBlock'`) — neither of which the tenant bundle carried.

- Emit `rs:stringValue` for Nonnumeric facts (replacing `rs:value`; `factType`/`contentType` unchanged).
- Project `Element.item_type` into `BundleElement` with snake→camel wire translation (`text_block` → `textBlock`) and declare `rs:itemType` on schema concepts.
- Canonical context terms updated to match.

Companion PR in report-components adds markdown rendering for `contentType: text/markdown`; with this fix alone the narrative already renders through the library's existing text-block arm.

## Testing

- Serialization + information-block + roboledger suites: 1070 passed; `just test-code` clean.
- Demo regenerated: the holon bundle carries 3 `stringValue` facts, 3 `itemType: textBlock` concepts, `contentType: text/markdown`, SHACL conforms, Arelle valid.