### PR TITLE
Harden the taxonomy-block authoring surface

### DIFF
--- a/examples/_scenario/runner.py
+++ b/examples/_scenario/runner.py
@@ -758,6 +758,101 @@ def create_disclosure_notes(
   return notes_created, member_mappings
 
 
+def update_disclosure_notes(graph_id: str, notes: list[dict]) -> int:
+  """Grow authored notes via ``update-taxonomy-block`` — the update-path probe.
+
+  For each note carrying an ``update_member``, adds that member element
+  plus presentation + calculation arcs to the existing note structure
+  through the update operation, then asserts the note's auto RollUp
+  footing rule was re-derived to include it (the rule is derived state —
+  the update path must refresh it, not leave the creation-time freeze).
+
+  Returns the number of members added.
+  """
+  client = _get_ledger_client()
+
+  updates = [n for n in notes if n.get("update_member")]
+  if not updates:
+    return 0
+
+  taxonomies = client.list_taxonomies(graph_id, taxonomy_type="reporting_extension")
+  by_name = {t.get("name"): t for t in taxonomies}
+  structures = client.list_structures(graph_id, block_type="regulatory_disclosure")
+  structure_by_name = {s.get("name"): s for s in structures}
+
+  added = 0
+  for note in updates:
+    member = note["update_member"]
+    taxonomy = by_name.get(note.get("taxonomy_name", f"{note['name']} Extension"))
+    structure = structure_by_name.get(note["name"])
+    if taxonomy is None or structure is None:
+      print(f"  ERROR: could not locate taxonomy/structure for {note['name']!r}")
+      continue
+
+    order = float(len(note["members"]) + 1)
+    payload = {
+      "taxonomy_id": taxonomy["id"],
+      "elements_to_add": [
+        {
+          "qname": member["qname"],
+          "name": member["name"],
+          "parent_ref": note["total_qname"],
+          "balance_type": "debit",
+          "period_type": "instant",
+          "is_monetary": True,
+        }
+      ],
+      "associations_to_add": [
+        {
+          "structure_ref": note["name"],
+          "from_ref": note["total_qname"],
+          "to_ref": member["qname"],
+          "association_type": "presentation",
+          "order_value": order,
+        },
+        {
+          "structure_ref": note["name"],
+          "from_ref": note["total_qname"],
+          "to_ref": member["qname"],
+          "association_type": "calculation",
+          "order_value": order,
+          "weight": 1.0,
+        },
+      ],
+    }
+    try:
+      client.update_taxonomy_block(graph_id, payload)
+    except Exception as e:
+      print(f"  ERROR: update-taxonomy-block failed: {e}")
+      continue
+
+    block = client.get_information_block(graph_id, structure["id"]) or {}
+    rollups = [
+      r for r in (block.get("rules") or []) if r.get("rule_pattern") == "RollUp"
+    ]
+    refreshed = any(
+      member["qname"]
+      in {v.get("variable_qname") for v in (r.get("rule_variables") or [])}
+      for r in rollups
+    )
+    child_count = max(
+      (len(r.get("rule_variables") or []) - 1 for r in rollups), default=0
+    )
+    if not refreshed:
+      print(
+        f"  ERROR: footing rule for {note['name']!r} was NOT refreshed "
+        f"with {member['qname']} — update-path auto-rule refresh failed"
+      )
+      continue
+    print(
+      f"  {note['name']}: +{member['qname']} "
+      f"(footing rule refreshed, {child_count} children)"
+    )
+    added += 1
+
+  return added
+
+
 def create_text_block_notes(
   graph_id: str,
   text_blocks: list[dict],
@@ -1436,6 +1531,12 @@ def run_demo(
     )
     print(f"  Notes:        {note_count}")
     print(f"  Member maps:  {member_map_count}")
+
+    # Grow a note through update-taxonomy-block — proves the update path
+    # re-derives the auto footing rule (not just creation-time emission).
+    updated_members = update_disclosure_notes(graph_id, disclosures)
+    if updated_members:
+      print(f"  Updated:      +{updated_members} member (via update-taxonomy-block)")
 
   # Initialize fiscal calendar (via HTTP API — exercises initialize op)
   print("\nInitializing fiscal calendar...")

--- a/examples/coffee_roaster_demo/disclosures.py
+++ b/examples/coffee_roaster_demo/disclosures.py
@@ -52,6 +52,14 @@ INVENTORY_NOTE: dict = {
       "coa_code": "1420",
     },
   ],
+  # Added AFTER creation via update-taxonomy-block — exercises the
+  # update-path auto-rule refresh (the footing rule must re-derive to
+  # include this member). Unmapped on purpose: no facts, so the note
+  # still foots (a missing child sums as 0) while proving the refresh.
+  "update_member": {
+    "qname": "driftline:InventoryPackagingSupplies",
+    "name": "Packaging Supplies — Bags & Labels",
+  },
 }
 
 DISCLOSURE_NOTES: list[dict] = [INVENTORY_NOTE]

--- a/robosystems/models/api/taxonomy_block.py
+++ b/robosystems/models/api/taxonomy_block.py
@@ -85,6 +85,28 @@ class TaxonomyBlockElementRequest(BaseModel):
   metadata: dict[str, Any] = Field(default_factory=dict)
 
 
+ConceptArrangement = Literal[
+  "set",
+  "roll_up",
+  "roll_forward",
+  "roll_forward_info",
+  "adjustment",
+  "variance",
+  "arithmetic",
+  "text_block",
+  "level1_textblock",
+  "level2_textblock",
+  "level3_textblock",
+  "level4_detail",
+  "table_equivalent_textblock",
+  "grid",
+  "compound_fact",
+]
+"""Concept Arrangement Pattern (CAP) value domain — mirrors the
+``structures.concept_arrangement`` CHECK constraint
+(``CONCEPT_ARRANGEMENT_VALUES`` in ``models/extensions/structure.py``)."""
+
+
 class TaxonomyBlockStructureRequest(BaseModel):
   """Structure definition inside a Taxonomy Block envelope."""
 
@@ -114,26 +136,7 @@ class TaxonomyBlockStructureRequest(BaseModel):
       "``custom``; custom ontology uses ``custom``."
     ),
   )
-  concept_arrangement: (
-    Literal[
-      "set",
-      "roll_up",
-      "roll_forward",
-      "roll_forward_info",
-      "adjustment",
-      "variance",
-      "arithmetic",
-      "text_block",
-      "level1_textblock",
-      "level2_textblock",
-      "level3_textblock",
-      "level4_detail",
-      "table_equivalent_textblock",
-      "grid",
-      "compound_fact",
-    ]
-    | None
-  ) = Field(
+  concept_arrangement: ConceptArrangement | None = Field(
     None,
     description=(
       "Concept Arrangement Pattern (CAP) — how the structure's concepts "
@@ -416,12 +419,19 @@ class ElementUpdatePatch(BaseModel):
 
 
 class StructureUpdatePatch(BaseModel):
-  """Partial-update patch for a single structure, keyed by structure_id."""
+  """Partial-update patch for a single structure, keyed by structure_id.
+
+  ``concept_arrangement`` makes a mis-CAP'd structure repairable in
+  place (e.g. promoting a ``set`` note to ``roll_up`` so it gains a
+  footing rule); ``block_type`` stays immutable — it drives block-type
+  routing, so changing it is a re-create, not an edit.
+  """
 
   structure_id: str = Field(..., description="Structure id to update.")
   name: str | None = None
   description: str | None = None
   role_uri: str | None = None
+  concept_arrangement: ConceptArrangement | None = None
   metadata: dict[str, Any] | None = None
 
 

--- a/robosystems/operations/information_block/rules/engine.py
+++ b/robosystems/operations/information_block/rules/engine.py
@@ -54,6 +54,11 @@ from robosystems.operations.information_block.rules.evaluators import (
   evaluate_rule,
   rule_tolerance,
 )
+from robosystems.operations.information_block.rules.expressions import (
+  InvalidRuleExpression,
+  lhs_variable_names,
+  parse_arithmetic_expression,
+)
 
 
 def _bind_variables(
@@ -71,6 +76,11 @@ def _bind_variables(
     qname = var.get("variable_qname", "")
     if not name:
       continue
+    if name in bindings:
+      # Bindings are name-keyed: a repeated name would silently merge two
+      # elements (one double-counted, one dropped). Raise so the per-rule
+      # handler records status='error' instead of a wrong verdict.
+      raise ValueError(f"duplicate variable_name {name!r} in rule variables")
 
     # Prefer an explicit element id when the rule carries one. Tenant CoA
     # elements have a null qname (they key on `code`), so qname resolution
@@ -122,6 +132,9 @@ def _bind_sum_variables(
     qname = var.get("variable_qname", "")
     if not name:
       continue
+    if name in bindings:
+      # Same guard as _bind_variables — name-keyed bindings must be unique.
+      raise ValueError(f"duplicate variable_name {name!r} in rule variables")
     # Prefer an explicit element id (CoA elements have null qname — see
     # _bind_variables); schedule SumEquals rules carry variable_element_id.
     element_id: str | None = (
@@ -209,20 +222,44 @@ def _load_period_balances(
   return by_period
 
 
+def _rollup_parent_variable(rule: Rule) -> dict | None:
+  """Pick the ``rule_variables`` entry naming the RollUp's parent subtotal.
+
+  The parent is whichever variable the expression's LHS names — the same
+  derivation the frozen evaluator uses (``lhs_variable_names``), so both
+  paths agree even when a tenant-authored rule lists children first.
+  Falls back to ``variables[0]`` (both machine producers' parent-first
+  convention) when the expression can't be parsed, has no single-LHS
+  shape, or names a variable that isn't declared.
+  """
+  variables = rule.rule_variables or []
+  if not variables:
+    return None
+  names = [v.get("variable_name", "") for v in variables]
+  expression = rule.rule_expression if isinstance(rule.rule_expression, str) else ""
+  try:
+    parsed = parse_arithmetic_expression(expression, [n for n in names if n])
+    lhs = lhs_variable_names(parsed)
+  except InvalidRuleExpression:
+    lhs = []
+  if len(lhs) == 1 and lhs[0] in names:
+    return variables[names.index(lhs[0])]
+  return variables[0]
+
+
 def _rollup_parent_element_id(
   session: Session, rule: Rule, cache: dict[str, str | None]
 ) -> tuple[str | None, str]:
-  """Resolve a RollUp rule's parent (the LHS = first variable) to an element_id.
+  """Resolve a RollUp rule's parent (the expression LHS) to an element_id.
 
   Prefers an explicit ``variable_element_id`` (tenant CoA elements have a null
   qname); otherwise resolves the qname, cached across rules in one run.
   """
-  variables = rule.rule_variables or []
-  if not variables:
+  parent = _rollup_parent_variable(rule)
+  if parent is None:
     return None, ""
-  v0 = variables[0]
-  qname = v0.get("variable_qname", "") or ""
-  explicit = v0.get("variable_element_id")
+  qname = parent.get("variable_qname", "") or ""
+  explicit = parent.get("variable_element_id")
   if explicit:
     return explicit, qname
   if qname in cache:

--- a/robosystems/operations/information_block/rules/expressions.py
+++ b/robosystems/operations/information_block/rules/expressions.py
@@ -206,10 +206,39 @@ def evaluate_arithmetic(parsed: ParsedExpression, values: dict[str, float]) -> f
   return _eval_arith(parsed.tree.body, mapped)
 
 
+def build_rollup_expression(parent_name: str, children: list[tuple[str, float]]) -> str:
+  """``$Parent = ($childA + $childB - $childC ...)``.
+
+  Weight +1 -> ``+``, -1 -> ``-``, otherwise an explicit ``* weight``
+  term (``($child * 0.5)``) so non-unit calc weights survive into the
+  frozen expression. Shared by the seed rollup-rule generator
+  (``taxonomy/scripts/generate_rollup_rules.py``) and tenant auto-rule
+  emission (``operations/taxonomy_block/auto_rules.py``); callers pass
+  final variable names — any qname-to-name mapping happens upstream.
+  """
+  parts: list[str] = []
+  for idx, (child_name, weight) in enumerate(children):
+    var = f"${child_name}"
+    if weight == 1.0:
+      sign, term = "+", var
+    elif weight == -1.0:
+      sign, term = "-", var
+    else:
+      # Render -0.0 cleanly and keep weight literal for non-unit weights.
+      sign, term = "+", f"({var} * {weight})"
+    if idx == 0:
+      parts.append(term if sign == "+" else f"-{term}")
+    else:
+      parts.append(f"{sign} {term}")
+  rhs = " ".join(parts)
+  return f"${parent_name} = ({rhs})"
+
+
 __all__ = [
   "EQUALITY_TOLERANCE",
   "InvalidRuleExpression",
   "ParsedExpression",
+  "build_rollup_expression",
   "evaluate_arithmetic",
   "evaluate_equality",
   "lhs_variable_names",

--- a/robosystems/operations/taxonomy_block/auto_rules.py
+++ b/robosystems/operations/taxonomy_block/auto_rules.py
@@ -37,21 +37,75 @@ Rules emitted:
 
 from __future__ import annotations
 
-from sqlalchemy import select
+import re
+from collections import Counter
+
+from sqlalchemy import delete, select
 from sqlalchemy.orm import Session, aliased
 
+from robosystems.models.api.taxonomy_block import UpdateTaxonomyBlockRequest
 from robosystems.models.extensions import (
   Association,
   Element,
   Rule,
   Structure,
   Taxonomy,
+  VerificationResult,
+)
+from robosystems.operations.information_block.rules.expressions import (
+  build_rollup_expression,
 )
 
 _AUTO = "auto"
 _STRUCTURE_RULES = "ReportLevelModelStructureRule"
 _XBRL_RULES = "XBRLTechnicalSyntaxRule"
 _FAC_RULES = "FundamentalAccountingConceptRelation"
+
+
+def _identifier(token: str) -> str:
+  """Sanitize a token into a parser-safe ``$Variable`` identifier.
+
+  The expression parser rewrites ``$Name`` to ``_var_Name``, which must
+  be a valid Python identifier — so ``:``, ``-``, spaces, and any other
+  non-word characters become ``_``, and a leading digit gets a ``_``
+  prefix.
+  """
+  cleaned = re.sub(r"\W", "_", token)
+  if not cleaned or cleaned[0].isdigit():
+    cleaned = f"_{cleaned}"
+  return cleaned
+
+
+def _resolve_variable_names(
+  entries: list[tuple[str | None, str | None, str]],
+) -> list[str]:
+  """Collision-free variable names for one rule's participants.
+
+  ``entries`` is ``(qname, name, element_id)`` per participant, parent
+  first. The base name is the sanitized local part of the first non-null
+  source — stable for the common case. When two participants share a
+  local name across namespaces (``driftline:InventoryNet`` vs
+  ``rs-gaap:InventoryNet``), the full qname is qualified in; a numeric
+  suffix is the final tiebreaker for qname-less duplicates. Collided
+  names would otherwise merge in the engine's name-keyed fact bindings
+  (one child double-counted, the other dropped).
+  """
+  sources = [qname or name or element_id for qname, name, element_id in entries]
+  base_names = [_identifier(source.split(":")[-1]) for source in sources]
+  counts = Counter(base_names)
+
+  resolved: list[str] = []
+  used: set[str] = set()
+  for source, base in zip(sources, base_names, strict=False):
+    candidate = _identifier(source) if counts[base] > 1 else base
+    if candidate in used:
+      suffix = 2
+      while f"{candidate}_{suffix}" in used:
+        suffix += 1
+      candidate = f"{candidate}_{suffix}"
+    used.add(candidate)
+    resolved.append(candidate)
+  return resolved
 
 
 def emit_auto_rules(
@@ -134,6 +188,79 @@ def emit_auto_rules(
   session.flush()
 
 
+def _has_structural_deltas(payload: UpdateTaxonomyBlockRequest) -> bool:
+  """True when the update touches inputs auto-rule emission depends on.
+
+  Emission reads the structure set, each structure's
+  ``concept_arrangement``, and the calculation arcs — so structure
+  add/update/remove, association add/remove, and element removal (which
+  cascades arc deletes) all invalidate the emitted set. Element
+  add/update can't change emission output (qnames are immutable via
+  patch), and tenant ``rules_to_*`` / top-level fields are disjoint from
+  ``rule_origin='auto'`` rows.
+  """
+  return bool(
+    payload.structures_to_add
+    or payload.structures_to_update
+    or payload.structures_to_remove
+    or payload.associations_to_add
+    or payload.associations_to_remove
+    or payload.elements_to_remove
+  )
+
+
+def refresh_auto_rules(
+  session: Session,
+  taxonomy: Taxonomy,
+  payload: UpdateTaxonomyBlockRequest,
+  *,
+  updated_by: str,
+) -> None:
+  """Re-derive the taxonomy's auto rules after a structural update.
+
+  Auto rules are derived state with no natural upsert key (parentage
+  lives inside ``rule_variables`` JSON), so refresh is wholesale
+  delete-then-recreate: drop every ``rule_origin='auto'`` row the
+  taxonomy owns and re-run :func:`emit_auto_rules` over its live
+  structures. Verification results FK the deleted rules NOT NULL with
+  no cascade, so they go first — they're re-derivable diagnostics the
+  next ``evaluate-rules`` run rewrites.
+
+  Skipped entirely for updates with no structural delta (element edits,
+  tenant rule changes, metadata) to avoid rule-id churn and needless
+  verification-history loss.
+  """
+  if not _has_structural_deltas(payload):
+    return
+
+  # The extensions session runs with autoflush=False and the apply_*
+  # helpers don't all flush — push every pending delta to the DB first
+  # so re-derivation reads the fully-applied post-update state (a
+  # just-added calc arc must appear in the refreshed footing rule).
+  session.flush()
+
+  auto_rule_ids = select(Rule.id).where(
+    Rule.taxonomy_id == taxonomy.id,
+    Rule.rule_origin == _AUTO,
+  )
+  session.execute(
+    delete(VerificationResult).where(VerificationResult.rule_id.in_(auto_rule_ids))
+  )
+  session.execute(
+    delete(Rule).where(
+      Rule.taxonomy_id == taxonomy.id,
+      Rule.rule_origin == _AUTO,
+    )
+  )
+
+  structures = list(
+    session.execute(select(Structure).where(Structure.taxonomy_id == taxonomy.id))
+    .scalars()
+    .all()
+  )
+  emit_auto_rules(session, taxonomy, structures, created_by=updated_by)
+
+
 def _add_rollup_rules(
   session: Session,
   *,
@@ -183,30 +310,32 @@ def _add_rollup_rules(
 
   for parent_id, children in by_parent.items():
     first = children[0]
-    parent_label = (first.parent_qname or first.parent_name or parent_id).split(":")[-1]
+    names = _resolve_variable_names(
+      [(first.parent_qname, first.parent_name, parent_id)]
+      + [(c.child_qname, c.child_name, c.to_element_id) for c in children]
+    )
     variables: list[dict[str, str]] = [
       {
-        "variable_name": parent_label,
+        "variable_name": names[0],
         "variable_qname": first.parent_qname or "",
         "variable_element_id": parent_id,
       }
     ]
-    terms: list[str] = []
-    for child in children:
-      child_label = (
-        child.child_qname or child.child_name or child.to_element_id
-      ).split(":")[-1]
+    for i, child in enumerate(children):
       variables.append(
         {
-          "variable_name": child_label,
+          "variable_name": names[i + 1],
           "variable_qname": child.child_qname or "",
           "variable_element_id": child.to_element_id,
         }
       )
-      weight = child.weight if child.weight is not None else 1.0
-      sign = "-" if weight < 0 else "+"
-      terms.append(f"{sign} ${child_label}")
-    expression = f"${parent_label} = {' '.join(terms).lstrip('+ ')}"
+    expression = build_rollup_expression(
+      names[0],
+      [
+        (names[i + 1], c.weight if c.weight is not None else 1.0)
+        for i, c in enumerate(children)
+      ],
+    )
 
     session.add(
       Rule(
@@ -216,7 +345,7 @@ def _add_rollup_rules(
         rule_check_kind=None,
         rule_expression=expression,
         rule_message=(
-          f"Calculation rollup: {parent_label} must equal the calculation "
+          f"Calculation rollup: {names[0]} must equal the calculation "
           f"sum of its children."
         ),
         rule_severity="error",

--- a/robosystems/operations/taxonomy_block/chart_of_accounts.py
+++ b/robosystems/operations/taxonomy_block/chart_of_accounts.py
@@ -31,7 +31,10 @@ from robosystems.models.extensions import (
   Trait,
 )
 from robosystems.operations.taxonomy_block._helpers import qname_for
-from robosystems.operations.taxonomy_block.auto_rules import emit_auto_rules
+from robosystems.operations.taxonomy_block.auto_rules import (
+  emit_auto_rules,
+  refresh_auto_rules,
+)
 from robosystems.operations.taxonomy_block.cascade import (
   cascade_delete_taxonomy,
   preflight_delete,
@@ -405,6 +408,7 @@ def update(
   apply_rules_to_add(
     session, taxonomy, payload, new_elements, new_structures, updated_by
   )
+  refresh_auto_rules(session, taxonomy, payload, updated_by=updated_by)
   session.flush()
   return taxonomy.id
 

--- a/robosystems/operations/taxonomy_block/custom_ontology.py
+++ b/robosystems/operations/taxonomy_block/custom_ontology.py
@@ -38,7 +38,10 @@ from robosystems.operations.taxonomy_block._helpers import (
   qname_for,
   structure_from_request,
 )
-from robosystems.operations.taxonomy_block.auto_rules import emit_auto_rules
+from robosystems.operations.taxonomy_block.auto_rules import (
+  emit_auto_rules,
+  refresh_auto_rules,
+)
 from robosystems.operations.taxonomy_block.cascade import (
   cascade_delete_taxonomy,
   preflight_delete,
@@ -272,6 +275,7 @@ def update(
   apply_rules_to_add(
     session, taxonomy, payload, new_elements, new_structures, updated_by
   )
+  refresh_auto_rules(session, taxonomy, payload, updated_by=updated_by)
   session.flush()
   return taxonomy.id
 

--- a/robosystems/operations/taxonomy_block/reporting_extension.py
+++ b/robosystems/operations/taxonomy_block/reporting_extension.py
@@ -46,7 +46,10 @@ from robosystems.operations.taxonomy_block._helpers import (
   qname_for,
   structure_from_request,
 )
-from robosystems.operations.taxonomy_block.auto_rules import emit_auto_rules
+from robosystems.operations.taxonomy_block.auto_rules import (
+  emit_auto_rules,
+  refresh_auto_rules,
+)
 from robosystems.operations.taxonomy_block.cascade import (
   cascade_delete_taxonomy,
   preflight_delete,
@@ -357,6 +360,7 @@ def update(
   apply_rules_to_add(
     session, taxonomy, payload, new_elements, new_structures, updated_by
   )
+  refresh_auto_rules(session, taxonomy, payload, updated_by=updated_by)
   session.flush()
   return taxonomy.id
 

--- a/robosystems/operations/taxonomy_block/update_apply.py
+++ b/robosystems/operations/taxonomy_block/update_apply.py
@@ -27,6 +27,7 @@ from robosystems.models.extensions import (
   Rule,
   Structure,
   Taxonomy,
+  VerificationResult,
 )
 from robosystems.operations.taxonomy_block._helpers import structure_from_request
 from robosystems.operations.taxonomy_block.rule_persistence import (
@@ -377,7 +378,8 @@ def apply_structures_to_update(
   payload: UpdateTaxonomyBlockRequest,
   updated_by: str,
 ) -> None:
-  """Mutate existing structures — name / description / role_uri / metadata."""
+  """Mutate existing structures — name / description / role_uri /
+  concept_arrangement / metadata."""
   if not payload.structures_to_update:
     return
 
@@ -393,6 +395,8 @@ def apply_structures_to_update(
       structure.name = patch.name
     if patch.description is not None:
       structure.description = patch.description
+    if patch.concept_arrangement is not None:
+      structure.concept_arrangement = patch.concept_arrangement
     if patch.metadata is not None:
       structure.metadata_ = dict(patch.metadata)
     if patch.role_uri is not None:
@@ -408,11 +412,27 @@ def apply_structures_to_remove(
   taxonomy: Taxonomy,
   payload: UpdateTaxonomyBlockRequest,
 ) -> None:
-  """Delete structures + their rules + cascading associations."""
+  """Delete structures + their rules + cascading associations.
+
+  Verification results FK both the structures and their rules with no
+  ON DELETE, so they go first — by ``structure_id`` and by ``rule_id``
+  of the structures' rules.
+  """
   if not payload.structures_to_remove:
     return
 
   ids = list(payload.structures_to_remove)
+  structure_rule_ids = select(Rule.id).where(
+    Rule.target_kind == "structure", Rule.target_structure_id.in_(ids)
+  )
+  session.execute(
+    delete(VerificationResult).where(
+      or_(
+        VerificationResult.structure_id.in_(ids),
+        VerificationResult.rule_id.in_(structure_rule_ids),
+      )
+    )
+  )
   session.execute(
     delete(Rule).where(
       Rule.target_kind == "structure", Rule.target_structure_id.in_(ids)

--- a/robosystems/operations/taxonomy_block/update_validator.py
+++ b/robosystems/operations/taxonomy_block/update_validator.py
@@ -74,6 +74,10 @@ def validate_update_envelope(
   qname_by_element_id = {e.id: e.qname for e in current_elements}
   element_id_by_qname = {e.qname: e.id for e in current_elements if e.qname}
 
+  _resolve_foreign_element_qnames(
+    session, qname_by_element_id, current_elements, current_associations
+  )
+
   structures_to_remove = set(payload.structures_to_remove or [])
   elements_to_remove_qnames = set(payload.elements_to_remove or [])
   associations_to_remove_ids = set(payload.associations_to_remove or [])
@@ -232,6 +236,40 @@ def validate_update_envelope(
   )
 
   return issues
+
+
+def _resolve_foreign_element_qnames(
+  session: Session,
+  qname_by_element_id: dict,
+  current_elements: list[Element],
+  current_associations: list[Association],
+) -> None:
+  """Fold library-element qnames into the projection's id→qname map.
+
+  Extend-mode taxonomies arc from / parent under LIBRARY concepts, whose
+  Element rows live in the parent taxonomy — without resolving those
+  foreign ids the projection stringifies them to ``""`` and every update
+  fails reference resolution (``phantom_from_ref``), even though the
+  create validator resolves the same refs via ``_load_library_qnames``.
+  Mutates ``qname_by_element_id`` in place.
+  """
+  foreign_ids = {
+    eid
+    for a in current_associations
+    for eid in (a.from_element_id, a.to_element_id)
+    if eid and eid not in qname_by_element_id
+  } | {
+    e.parent_id
+    for e in current_elements
+    if e.parent_id and e.parent_id not in qname_by_element_id
+  }
+  if not foreign_ids:
+    return
+  for eid, qname in session.execute(
+    select(Element.id, Element.qname).where(Element.id.in_(foreign_ids))
+  ).all():
+    if qname:
+      qname_by_element_id[eid] = qname
 
 
 def _element_classification_hint(element: Element) -> str | None:

--- a/robosystems/operations/taxonomy_block/validators.py
+++ b/robosystems/operations/taxonomy_block/validators.py
@@ -44,6 +44,7 @@ from robosystems.models.api.taxonomy_block import (
 from robosystems.models.extensions import Element
 from robosystems.operations.information_block.rules.expressions import (
   InvalidRuleExpression,
+  lhs_variable_names,
   parse_arithmetic_expression,
 )
 
@@ -410,8 +411,29 @@ def _phase_rule_expression_parse(
     variable_names = [
       v.get("variable_name", "") for v in rule.variables if v.get("variable_name")
     ]
+
+    duplicates = sorted(
+      {name for name in variable_names if variable_names.count(name) > 1}
+    )
+    if duplicates:
+      # The engine binds facts in dicts keyed by variable_name, so two
+      # same-named variables silently merge — one element double-counted,
+      # the other dropped.
+      issues.append(
+        ValidationIssue(
+          phase="rule_expression_parse",
+          code="duplicate_variable_name",
+          message=(
+            f"rule {rule.name!r} declares duplicate variable name(s) "
+            f"{duplicates}; every variable must be unique within a rule."
+          ),
+          context={"rule_name": rule.name, "duplicates": duplicates},
+        )
+      )
+      continue
+
     try:
-      parse_arithmetic_expression(rule.expression, variable_names)
+      parsed = parse_arithmetic_expression(rule.expression, variable_names)
     except InvalidRuleExpression as exc:
       issues.append(
         ValidationIssue(
@@ -421,6 +443,29 @@ def _phase_rule_expression_parse(
           context={"rule_name": rule.name, "expression": rule.expression},
         )
       )
+      continue
+
+    if rule.rule_pattern == "RollUp":
+      # The arc-derived evaluator resolves the parent subtotal from the
+      # expression LHS with variables[0] as the legacy fallback — keep
+      # both producers' parent-first invariant enforced at the gate.
+      try:
+        lhs = lhs_variable_names(parsed)
+      except InvalidRuleExpression:
+        lhs = []
+      if len(lhs) == 1 and variable_names and lhs[0] != variable_names[0]:
+        issues.append(
+          ValidationIssue(
+            phase="rule_expression_parse",
+            code="rollup_parent_not_first",
+            message=(
+              f"rule {rule.name!r} is a RollUp whose expression LHS "
+              f"({lhs[0]!r}) is not variables[0] ({variable_names[0]!r}); "
+              f"list the parent subtotal first."
+            ),
+            context={"rule_name": rule.name, "lhs": lhs[0]},
+          )
+        )
   return issues
 
 

--- a/robosystems/taxonomy/scripts/generate_rollup_rules.py
+++ b/robosystems/taxonomy/scripts/generate_rollup_rules.py
@@ -29,6 +29,10 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from robosystems.operations.information_block.rules.expressions import (
+  build_rollup_expression,
+)
+
 _FRAMEWORKS = Path(__file__).resolve().parents[3] / "frameworks"
 _CALC_SOURCE = (
   _FRAMEWORKS
@@ -83,24 +87,14 @@ def _role_slug(role_uri: str) -> str:
 def _build_expression(parent: str, children: list[tuple[str, float]]) -> str:
   """``$Parent = ($childA + $childB - $childC ...)``.
 
-  Weight +1 -> ``+``, -1 -> ``-``, otherwise an explicit ``* weight`` term.
+  Thin qname-to-local-name wrapper over the shared
+  :func:`build_rollup_expression` (also used by tenant auto-rule
+  emission) — output is byte-identical to the historical inline
+  builder, so the committed seed artifact never needs regeneration.
   """
-  parts: list[str] = []
-  for idx, (child_qname, weight) in enumerate(children):
-    var = f"${_local(child_qname)}"
-    if weight == 1.0:
-      sign, term = "+", var
-    elif weight == -1.0:
-      sign, term = "-", var
-    else:
-      # Render -0.0 cleanly and keep weight literal for non-unit weights.
-      sign, term = "+", f"({var} * {weight})"
-    if idx == 0:
-      parts.append(term if sign == "+" else f"-{term}")
-    else:
-      parts.append(f"{sign} {term}")
-  rhs = " ".join(parts)
-  return f"${_local(parent)} = ({rhs})"
+  return build_rollup_expression(
+    _local(parent), [(_local(child_qname), weight) for child_qname, weight in children]
+  )
 
 
 def build_rollup_rules(graph: list[dict]) -> list[dict]:

--- a/tests/operations/information_block/rules/test_expressions.py
+++ b/tests/operations/information_block/rules/test_expressions.py
@@ -120,3 +120,53 @@ class TestEvaluateEquality:
     passed, residual = evaluate_equality(parsed, {"A": -5.0, "B": 5.0})
     assert passed is True
     assert residual == pytest.approx(0.0)
+
+
+class TestBuildRollupExpression:
+  """Shared builder used by both the seed generator and tenant auto rules."""
+
+  def test_unit_weights(self) -> None:
+    from robosystems.operations.information_block.rules.expressions import (
+      build_rollup_expression,
+    )
+
+    expr = build_rollup_expression("Assets", [("Current", 1.0), ("Noncurrent", 1.0)])
+    assert expr == "$Assets = ($Current + $Noncurrent)"
+
+  def test_first_term_negative_weight(self) -> None:
+    from robosystems.operations.information_block.rules.expressions import (
+      build_rollup_expression,
+    )
+
+    expr = build_rollup_expression("Net", [("Contra", -1.0), ("Gross", 1.0)])
+    assert expr == "$Net = (-$Contra + $Gross)"
+
+  def test_non_unit_weight_keeps_coefficient(self) -> None:
+    from robosystems.operations.information_block.rules.expressions import (
+      build_rollup_expression,
+    )
+
+    expr = build_rollup_expression("Total", [("Half", 0.5), ("Double", 2.0)])
+    assert expr == "$Total = (($Half * 0.5) + ($Double * 2.0))"
+
+  def test_single_child(self) -> None:
+    from robosystems.operations.information_block.rules.expressions import (
+      build_rollup_expression,
+    )
+
+    expr = build_rollup_expression("Total", [("Only", 1.0)])
+    assert expr == "$Total = ($Only)"
+
+  def test_output_round_trips_through_parser(self) -> None:
+    from robosystems.operations.information_block.rules.expressions import (
+      build_rollup_expression,
+      lhs_variable_names,
+      parse_arithmetic_expression,
+    )
+
+    names = ["Total", "Half", "Contra", "Plain"]
+    expr = build_rollup_expression(
+      "Total", [("Half", 0.5), ("Contra", -1.0), ("Plain", 1.0)]
+    )
+    parsed = parse_arithmetic_expression(expr, names)
+    assert lhs_variable_names(parsed) == ["Total"]

--- a/tests/operations/information_block/rules/test_rollup_arc_derived.py
+++ b/tests/operations/information_block/rules/test_rollup_arc_derived.py
@@ -450,3 +450,135 @@ class TestRollupRoutingInEngine:
     added = session.add.call_args_list[0][0][0]
     assert added.status == "pass"
     assert added.detail.get("source") == "calc-dag"
+
+
+class TestRollupParentResolution:
+  """The parent is the expression LHS, not blindly variables[0]."""
+
+  def _rule_with_expression(self, expression) -> MagicMock:
+    rule = MagicMock()
+    rule.rule_pattern = "RollUp"
+    rule.rule_expression = expression
+    rule.rule_variables = [
+      {
+        "variable_name": "Raw",
+        "variable_qname": "ext:Raw",
+        "variable_element_id": "elem_raw",
+      },
+      {
+        "variable_name": "Finished",
+        "variable_qname": "ext:Finished",
+        "variable_element_id": "elem_fg",
+      },
+      {
+        "variable_name": "Total",
+        "variable_qname": "ext:Total",
+        "variable_element_id": "elem_total",
+      },
+    ]
+    return rule
+
+  def test_lhs_resolves_parent_when_children_listed_first(self) -> None:
+    from robosystems.operations.information_block.rules.engine import (
+      _rollup_parent_element_id,
+    )
+
+    rule = self._rule_with_expression("$Total = $Raw + $Finished")
+    parent_id, parent_qname = _rollup_parent_element_id(MagicMock(), rule, {})
+    assert parent_id == "elem_total"
+    assert parent_qname == "ext:Total"
+
+  def test_unparseable_expression_falls_back_to_first_variable(self) -> None:
+    from robosystems.operations.information_block.rules.engine import (
+      _rollup_parent_element_id,
+    )
+
+    rule = self._rule_with_expression("$$$ not an expression")
+    parent_id, parent_qname = _rollup_parent_element_id(MagicMock(), rule, {})
+    assert parent_id == "elem_raw"
+    assert parent_qname == "ext:Raw"
+
+  def test_undeclared_lhs_variable_falls_back_to_first_variable(self) -> None:
+    from robosystems.operations.information_block.rules.engine import (
+      _rollup_parent_element_id,
+    )
+
+    # $Ghost is not a declared variable → parse rejects the unbound token
+    # → legacy variables[0] fallback.
+    rule = self._rule_with_expression("$Ghost = $Raw + $Finished")
+    parent_id, _ = _rollup_parent_element_id(MagicMock(), rule, {})
+    assert parent_id == "elem_raw"
+
+  def test_non_string_expression_falls_back_to_first_variable(self) -> None:
+    from robosystems.operations.information_block.rules.engine import (
+      _rollup_parent_element_id,
+    )
+
+    rule = self._rule_with_expression(None)
+    parent_id, _ = _rollup_parent_element_id(MagicMock(), rule, {})
+    assert parent_id == "elem_raw"
+
+
+class TestBinderDuplicateGuard:
+  """Name-keyed bindings must reject repeated variable names loudly."""
+
+  def _dup_rule(self) -> MagicMock:
+    rule = MagicMock()
+    rule.rule_pattern = "EqualTo"
+    rule.rule_variables = [
+      {
+        "variable_name": "InventoryNet",
+        "variable_qname": "driftline:InventoryNet",
+        "variable_element_id": "elem_a",
+      },
+      {
+        "variable_name": "InventoryNet",
+        "variable_qname": "rs-gaap:InventoryNet",
+        "variable_element_id": "elem_b",
+      },
+    ]
+    rule.metadata_ = {}
+    return rule
+
+  def test_bind_variables_raises_on_duplicate_name(self) -> None:
+    from robosystems.operations.information_block.rules.engine import _bind_variables
+
+    with pytest.raises(ValueError, match="duplicate variable_name"):
+      _bind_variables(MagicMock(), self._dup_rule(), "struct_1", None, None)
+
+  def test_bind_sum_variables_raises_on_duplicate_name(self) -> None:
+    from robosystems.operations.information_block.rules.engine import (
+      _bind_sum_variables,
+    )
+
+    with pytest.raises(ValueError, match="duplicate variable_name"):
+      _bind_sum_variables(MagicMock(), self._dup_rule(), "struct_1")
+
+  def test_engine_records_error_status_for_duplicate_name_rule(self) -> None:
+    """The per-rule handler converts the guard into status='error' —
+    visible in Verification Results instead of a silently wrong verdict."""
+    session = MagicMock()
+    session.get.return_value = MagicMock(id="struct_1", block_type="schedule")
+
+    rule_lite = MagicMock()
+    rule_lite.id = "rule_dup"
+    rule_orm = self._dup_rule()
+    rule_orm.id = "rule_dup"
+
+    assoc = MagicMock()
+    assoc.scalars.return_value.all.return_value = []
+    rules_res = MagicMock()
+    rules_res.scalars.return_value.all.return_value = [rule_orm]
+    fact_res = MagicMock()
+    session.execute.side_effect = [assoc, rules_res, fact_res]
+
+    with patch(
+      "robosystems.operations.information_block.rules.engine.load_rules_for_structure",
+      return_value=[rule_lite],
+    ):
+      results = evaluate_rules_for_structure(session, "struct_1")
+
+    assert len(results) == 1
+    added = session.add.call_args_list[0][0][0]
+    assert added.status == "error"
+    assert "duplicate variable_name" in added.message

--- a/tests/operations/taxonomy_block/test_auto_rules.py
+++ b/tests/operations/taxonomy_block/test_auto_rules.py
@@ -2,9 +2,16 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
-from robosystems.operations.taxonomy_block.auto_rules import emit_auto_rules
+from robosystems.models.api.taxonomy_block import (
+  TaxonomyBlockElementRequest,
+  UpdateTaxonomyBlockRequest,
+)
+from robosystems.operations.taxonomy_block.auto_rules import (
+  emit_auto_rules,
+  refresh_auto_rules,
+)
 
 
 def _fake_taxonomy(
@@ -239,7 +246,7 @@ class TestRollupEmission:
     child_ids = {v["variable_element_id"] for v in rule.rule_variables[1:]}
     assert child_ids == {"elem_raw", "elem_fg"}
     assert rule.rule_expression == (
-      "$InventoryNet = $InventoryRawMaterials + $InventoryFinishedGoods"
+      "$InventoryNet = ($InventoryRawMaterials + $InventoryFinishedGoods)"
     )
 
   def test_negative_weight_renders_minus_term(self) -> None:
@@ -268,7 +275,7 @@ class TestRollupEmission:
 
     added = [c.args[0] for c in session.add.call_args_list]
     rule = next(r for r in added if r.rule_pattern == "RollUp")
-    assert rule.rule_expression == "$Net = $Gross - $Allowance"
+    assert rule.rule_expression == "$Net = ($Gross - $Allowance)"
 
   def test_roll_up_without_calc_arcs_emits_no_rollup(self) -> None:
     """Presentation-only roll_up renders but has nothing to foot."""
@@ -290,3 +297,205 @@ class TestRollupEmission:
     emit_auto_rules(session, taxonomy, [plain], created_by="usr_1")
 
     session.execute.assert_not_called()
+
+
+class TestVariableNaming:
+  """Weight fidelity, cross-namespace dedupe, and parser round-trips."""
+
+  def _emit_one_rollup(self, rows: list[MagicMock]) -> MagicMock:
+    session = MagicMock()
+    taxonomy = _fake_taxonomy("reporting_extension", parent_taxonomy_id="lib_1")
+    note = _fake_structure("struct_note", concept_arrangement="roll_up")
+    session.execute.return_value.fetchall.return_value = rows
+    emit_auto_rules(session, taxonomy, [note], created_by="usr_1")
+    added = [c.args[0] for c in session.add.call_args_list]
+    return next(r for r in added if r.rule_pattern == "RollUp")
+
+  def test_non_unit_weights_survive_into_expression(self) -> None:
+    rule = self._emit_one_rollup(
+      [
+        _calc_row(
+          "elem_total",
+          "elem_half",
+          parent_qname="ext:Total",
+          child_qname="ext:Half",
+          weight=0.5,
+          order_value=1.0,
+        ),
+        _calc_row(
+          "elem_total",
+          "elem_double",
+          parent_qname="ext:Total",
+          child_qname="ext:Double",
+          weight=2.0,
+          order_value=2.0,
+        ),
+      ]
+    )
+    assert rule.rule_expression == "$Total = (($Half * 0.5) + ($Double * 2.0))"
+
+  def test_emitted_expression_round_trips_through_parser(self) -> None:
+    from robosystems.operations.information_block.rules.expressions import (
+      parse_arithmetic_expression,
+    )
+
+    rule = self._emit_one_rollup(
+      [
+        _calc_row(
+          "elem_total",
+          "elem_half",
+          parent_qname="ext:Total",
+          child_qname="ext:Half",
+          weight=0.5,
+          order_value=1.0,
+        ),
+        _calc_row(
+          "elem_total",
+          "elem_neg",
+          parent_qname="ext:Total",
+          child_qname="ext:Contra",
+          weight=-1.0,
+          order_value=2.0,
+        ),
+      ]
+    )
+    names = [v["variable_name"] for v in rule.rule_variables]
+    parsed = parse_arithmetic_expression(rule.rule_expression, names)
+    assert parsed is not None
+
+  def test_cross_namespace_local_name_collision_qualifies_names(self) -> None:
+    rule = self._emit_one_rollup(
+      [
+        _calc_row(
+          "elem_tenant_inv",
+          "elem_lib_inv",
+          parent_qname="driftline:InventoryNet",
+          child_qname="rs-gaap:InventoryNet",
+          order_value=1.0,
+        ),
+        _calc_row(
+          "elem_tenant_inv",
+          "elem_reserve",
+          parent_qname="driftline:InventoryNet",
+          child_qname="ext:Reserve",
+          weight=-1.0,
+          order_value=2.0,
+        ),
+      ]
+    )
+    names = [v["variable_name"] for v in rule.rule_variables]
+    assert names == ["driftline_InventoryNet", "rs_gaap_InventoryNet", "Reserve"]
+    assert len(set(names)) == len(names)
+    assert rule.rule_expression == (
+      "$driftline_InventoryNet = ($rs_gaap_InventoryNet - $Reserve)"
+    )
+    # Parent stays index 0 with its explicit element id intact.
+    assert rule.rule_variables[0]["variable_element_id"] == "elem_tenant_inv"
+
+  def test_no_collision_keeps_bare_local_names(self) -> None:
+    rule = self._emit_one_rollup(
+      [
+        _calc_row(
+          "elem_total",
+          "elem_raw",
+          parent_qname="rs-gaap:InventoryNet",
+          child_qname="driftline:RawMaterials",
+          order_value=1.0,
+        ),
+      ]
+    )
+    names = [v["variable_name"] for v in rule.rule_variables]
+    assert names == ["InventoryNet", "RawMaterials"]
+
+  def test_null_qname_spaced_name_sanitizes_to_identifier(self) -> None:
+    from robosystems.operations.information_block.rules.expressions import (
+      parse_arithmetic_expression,
+    )
+
+    row = _calc_row(
+      "elem_total",
+      "elem_cogs",
+      parent_qname="ext:Total",
+      child_qname="ignored",
+      order_value=1.0,
+    )
+    row.child_qname = None
+    row.child_name = "Cost of Goods"
+    rule = self._emit_one_rollup([row])
+    names = [v["variable_name"] for v in rule.rule_variables]
+    assert names == ["Total", "Cost_of_Goods"]
+    parse_arithmetic_expression(rule.rule_expression, names)
+
+
+class TestRefreshAutoRules:
+  def _payload(self, **kwargs) -> UpdateTaxonomyBlockRequest:
+    return UpdateTaxonomyBlockRequest(taxonomy_id="tax_1", **kwargs)
+
+  def test_metadata_only_update_skips_refresh(self) -> None:
+    session = MagicMock()
+    refresh_auto_rules(
+      session,
+      _fake_taxonomy(),
+      self._payload(name="Renamed", description="new"),
+      updated_by="usr_1",
+    )
+    session.execute.assert_not_called()
+
+  def test_element_add_only_update_skips_refresh(self) -> None:
+    session = MagicMock()
+    payload = self._payload(
+      elements_to_add=[
+        TaxonomyBlockElementRequest(qname="ext:NewThing", name="New Thing")
+      ]
+    )
+    refresh_auto_rules(session, _fake_taxonomy(), payload, updated_by="usr_1")
+    session.execute.assert_not_called()
+
+  def test_structural_update_deletes_vrs_before_rules_then_reemits(self) -> None:
+    session = MagicMock()
+    session.execute.return_value.scalars.return_value.all.return_value = []
+    taxonomy = _fake_taxonomy()
+    payload = self._payload(structures_to_remove=["s_gone"])
+
+    with patch(
+      "robosystems.operations.taxonomy_block.auto_rules.emit_auto_rules"
+    ) as emit:
+      refresh_auto_rules(session, taxonomy, payload, updated_by="usr_1")
+
+    deleted_tables = [
+      c.args[0].table.name
+      for c in session.execute.call_args_list
+      if hasattr(c.args[0], "table")
+    ]
+    assert deleted_tables == ["verification_results", "rules"]
+    emit.assert_called_once()
+    assert emit.call_args.args[1] is taxonomy
+    assert emit.call_args.kwargs == {"created_by": "usr_1"}
+
+  def test_flushes_pending_deltas_before_rederiving(self) -> None:
+    """The extensions session runs autoflush=False, so a just-added calc
+    arc is invisible to the refresh SELECTs unless refresh flushes first
+    — caught live by the Driftline update probe (rule kept 3 children)."""
+    session = MagicMock()
+    session.execute.return_value.scalars.return_value.all.return_value = []
+    payload = self._payload(associations_to_remove=["a_gone"])
+
+    with patch("robosystems.operations.taxonomy_block.auto_rules.emit_auto_rules"):
+      refresh_auto_rules(session, _fake_taxonomy(), payload, updated_by="usr_1")
+
+    flush_order = [
+      name for name, *_ in session.method_calls if name in ("flush", "execute")
+    ]
+    assert flush_order[0] == "flush"
+
+  def test_association_delta_triggers_refresh(self) -> None:
+    session = MagicMock()
+    session.execute.return_value.scalars.return_value.all.return_value = []
+    payload = self._payload(associations_to_remove=["a_1"])
+
+    with patch(
+      "robosystems.operations.taxonomy_block.auto_rules.emit_auto_rules"
+    ) as emit:
+      refresh_auto_rules(session, _fake_taxonomy(), payload, updated_by="usr_1")
+
+    emit.assert_called_once()

--- a/tests/operations/taxonomy_block/test_reporting_extension.py
+++ b/tests/operations/taxonomy_block/test_reporting_extension.py
@@ -60,6 +60,18 @@ def test_concept_arrangement_literal_matches_canonical_vocabulary() -> None:
   assert literal_values == set(CONCEPT_ARRANGEMENT_VALUES)
 
 
+def test_structure_update_patch_cap_matches_canonical_vocabulary() -> None:
+  """Same drift guard for the update patch — it shares the
+  ``ConceptArrangement`` alias with the create request."""
+  from robosystems.models.api.taxonomy_block import StructureUpdatePatch
+
+  annotation = StructureUpdatePatch.model_fields["concept_arrangement"].annotation
+  literal_values: set[str] = set()
+  for arg in get_args(annotation):
+    literal_values.update(get_args(arg))
+  assert literal_values == set(CONCEPT_ARRANGEMENT_VALUES)
+
+
 def test_create_request_rejects_missing_parent() -> None:
   """Pydantic-level validator enforces parent_taxonomy_id for extensions."""
   with pytest.raises(ValidationError) as exc:

--- a/tests/operations/taxonomy_block/test_update.py
+++ b/tests/operations/taxonomy_block/test_update.py
@@ -460,8 +460,16 @@ class TestApplyStructuresToRemove:
     )
     apply_structures_to_remove(session, taxonomy, payload)
 
-    # 3 DELETEs: rules, associations, structures
-    assert session.execute.call_count == 3
+    # 4 DELETEs: verification results FIRST (they FK rules and
+    # structures with no ON DELETE), then rules, associations, structures
+    assert session.execute.call_count == 4
+    deleted_tables = [c.args[0].table.name for c in session.execute.call_args_list]
+    assert deleted_tables == [
+      "verification_results",
+      "rules",
+      "associations",
+      "structures",
+    ]
     session.flush.assert_called_once()
 
   def test_noop_when_nothing_to_remove(self) -> None:
@@ -537,3 +545,149 @@ class TestApplyStructuresToUpdate:
     assert structure.description == "new desc"
     assert structure.metadata_["role_uri"] == "http://role/x"
     assert structure.metadata_["existing"] == "kept"
+
+
+class TestApplyStructuresToUpdateConceptArrangement:
+  def test_sets_concept_arrangement_when_patched(self) -> None:
+    from robosystems.operations.taxonomy_block.update_apply import (
+      apply_structures_to_update,
+    )
+
+    session = MagicMock()
+    structure = MagicMock()
+    structure.id = "s_1"
+    structure.concept_arrangement = "set"
+    session.execute.return_value = _mock_execute_result([structure])
+
+    payload = UpdateTaxonomyBlockRequest(
+      taxonomy_id="tax_42",
+      structures_to_update=[
+        StructureUpdatePatch(structure_id="s_1", concept_arrangement="roll_up")
+      ],
+    )
+    apply_structures_to_update(
+      session, _fake_taxonomy("reporting_extension"), payload, "usr_1"
+    )
+    assert structure.concept_arrangement == "roll_up"
+
+  def test_leaves_concept_arrangement_when_not_patched(self) -> None:
+    from robosystems.operations.taxonomy_block.update_apply import (
+      apply_structures_to_update,
+    )
+
+    session = MagicMock()
+    structure = MagicMock()
+    structure.id = "s_1"
+    structure.concept_arrangement = "set"
+    session.execute.return_value = _mock_execute_result([structure])
+
+    payload = UpdateTaxonomyBlockRequest(
+      taxonomy_id="tax_42",
+      structures_to_update=[StructureUpdatePatch(structure_id="s_1", name="Renamed")],
+    )
+    apply_structures_to_update(
+      session, _fake_taxonomy("reporting_extension"), payload, "usr_1"
+    )
+    assert structure.concept_arrangement == "set"
+
+  def test_patch_rejects_unknown_concept_arrangement(self) -> None:
+    with pytest.raises(Exception):
+      StructureUpdatePatch(structure_id="s_1", concept_arrangement="not_a_cap")
+
+  def test_patch_accepts_text_block(self) -> None:
+    patch_model = StructureUpdatePatch(
+      structure_id="s_1", concept_arrangement="text_block"
+    )
+    assert patch_model.concept_arrangement == "text_block"
+
+
+class TestUpdateRefreshesAutoRules:
+  """Every handler's update() re-derives auto rules after applying deltas."""
+
+  def _run_update(self, module_name: str, taxonomy_type: str) -> MagicMock:
+    import importlib
+
+    module = importlib.import_module(
+      f"robosystems.operations.taxonomy_block.{module_name}"
+    )
+    session = MagicMock()
+    tax = _fake_taxonomy(taxonomy_type)
+    session.get.return_value = tax
+    session.execute.return_value = _mock_execute_result([])
+    payload = UpdateTaxonomyBlockRequest(
+      taxonomy_id="tax_42", structures_to_remove=["s_gone"]
+    )
+    with (
+      patch(
+        f"robosystems.operations.taxonomy_block.{module_name}.validate_update_envelope",
+        return_value=[],
+      ),
+      patch(
+        f"robosystems.operations.taxonomy_block.{module_name}.refresh_auto_rules"
+      ) as refresh,
+    ):
+      module.update(session, payload, "usr_1")
+    return refresh
+
+  def test_custom_ontology_update_calls_refresh(self) -> None:
+    refresh = self._run_update("custom_ontology", "custom_ontology")
+    refresh.assert_called_once()
+    assert refresh.call_args.kwargs == {"updated_by": "usr_1"}
+
+  def test_chart_of_accounts_update_calls_refresh(self) -> None:
+    refresh = self._run_update("chart_of_accounts", "chart_of_accounts")
+    refresh.assert_called_once()
+
+  def test_reporting_extension_update_calls_refresh(self) -> None:
+    refresh = self._run_update("reporting_extension", "reporting_extension")
+    refresh.assert_called_once()
+
+
+class TestResolveForeignElementQnames:
+  """Library-element endpoints must project to their real qnames — an
+  extend-mode note arcs FROM a library concept, and before this fix every
+  update to such a taxonomy 422'd with phantom_from_ref."""
+
+  def _assoc(self, from_id: str, to_id: str) -> MagicMock:
+    a = MagicMock()
+    a.from_element_id = from_id
+    a.to_element_id = to_id
+    return a
+
+  def _element(self, eid: str, parent_id: str | None = None) -> MagicMock:
+    e = MagicMock()
+    e.id = eid
+    e.parent_id = parent_id
+    return e
+
+  def test_resolves_library_arc_endpoints_and_parents(self) -> None:
+    from robosystems.operations.taxonomy_block.update_validator import (
+      _resolve_foreign_element_qnames,
+    )
+
+    session = MagicMock()
+    session.execute.return_value.all.return_value = [
+      ("elem_lib_total", "rs-gaap:InventoryNet"),
+    ]
+    qname_by_id = {"elem_member": "driftline:RawMaterials"}
+    elements = [self._element("elem_member", parent_id="elem_lib_total")]
+    associations = [self._assoc("elem_lib_total", "elem_member")]
+
+    _resolve_foreign_element_qnames(session, qname_by_id, elements, associations)
+
+    assert qname_by_id["elem_lib_total"] == "rs-gaap:InventoryNet"
+    session.execute.assert_called_once()
+
+  def test_no_foreign_ids_skips_query(self) -> None:
+    from robosystems.operations.taxonomy_block.update_validator import (
+      _resolve_foreign_element_qnames,
+    )
+
+    session = MagicMock()
+    qname_by_id = {"elem_a": "x:A", "elem_b": "x:B"}
+    elements = [self._element("elem_a"), self._element("elem_b", parent_id="elem_a")]
+    associations = [self._assoc("elem_a", "elem_b")]
+
+    _resolve_foreign_element_qnames(session, qname_by_id, elements, associations)
+
+    session.execute.assert_not_called()

--- a/tests/operations/taxonomy_block/test_validators.py
+++ b/tests/operations/taxonomy_block/test_validators.py
@@ -282,6 +282,73 @@ class TestRuleExpressionParse:
     issues = validate_create_envelope(payload, _session_empty())
     assert any(i.code == "unparseable_expression" for i in issues)
 
+  def test_duplicate_variable_name_rejected(self) -> None:
+    """Same-named variables silently merge in the engine's name-keyed
+    fact bindings — the gate rejects them outright."""
+    payload = _basic_coa(
+      rules=[
+        TaxonomyBlockRuleRequest(
+          name="colliding",
+          rule_category="FundamentalAccountingConceptRelation",
+          rule_pattern="EqualTo",
+          expression="$Total = $InventoryNet + $InventoryNet",
+          variables=[
+            {"variable_name": "Total", "variable_qname": "ext:Total"},
+            {"variable_name": "InventoryNet", "variable_qname": "ext:InventoryNet"},
+            {
+              "variable_name": "InventoryNet",
+              "variable_qname": "rs-gaap:InventoryNet",
+            },
+          ],
+          target_taxonomy_self=True,
+        )
+      ]
+    )
+    issues = validate_create_envelope(payload, _session_empty())
+    assert any(i.code == "duplicate_variable_name" for i in issues)
+
+  def test_rollup_parent_not_first_rejected(self) -> None:
+    """RollUp rules must list the LHS parent subtotal at variables[0] —
+    the arc-derived evaluator's legacy fallback trusts that position."""
+    payload = _basic_coa(
+      rules=[
+        TaxonomyBlockRuleRequest(
+          name="children-first",
+          rule_category="FundamentalAccountingConceptRelation",
+          rule_pattern="RollUp",
+          expression="$Total = $Raw + $Finished",
+          variables=[
+            {"variable_name": "Raw", "variable_qname": "ext:Raw"},
+            {"variable_name": "Finished", "variable_qname": "ext:Finished"},
+            {"variable_name": "Total", "variable_qname": "ext:Total"},
+          ],
+          target_taxonomy_self=True,
+        )
+      ]
+    )
+    issues = validate_create_envelope(payload, _session_empty())
+    assert any(i.code == "rollup_parent_not_first" for i in issues)
+
+  def test_rollup_parent_first_accepted(self) -> None:
+    payload = _basic_coa(
+      rules=[
+        TaxonomyBlockRuleRequest(
+          name="parent-first",
+          rule_category="FundamentalAccountingConceptRelation",
+          rule_pattern="RollUp",
+          expression="$Total = $Raw + $Finished",
+          variables=[
+            {"variable_name": "Total", "variable_qname": "ext:Total"},
+            {"variable_name": "Raw", "variable_qname": "ext:Raw"},
+            {"variable_name": "Finished", "variable_qname": "ext:Finished"},
+          ],
+          target_taxonomy_self=True,
+        )
+      ]
+    )
+    issues = validate_create_envelope(payload, _session_empty())
+    assert not any(i.phase == "rule_expression_parse" for i in issues)
+
 
 class TestErrorAggregation:
   def test_all_issues_raised_together(self) -> None:

--- a/tests/taxonomy/test_rollup_rules_seed.py
+++ b/tests/taxonomy/test_rollup_rules_seed.py
@@ -168,3 +168,33 @@ class TestBuilder:
     ]
     with pytest.raises(ValueError, match="multiple parents"):
       build_rollup_rules(graph)
+
+
+class TestBuilderNonUnitWeights:
+  def test_non_unit_weight_renders_explicit_coefficient(self) -> None:
+    """Locks the shared-builder delegation: a 0.5-weighted arc keeps its
+    coefficient as ``($var * 0.5)`` (byte-identical to the historical
+    inline builder)."""
+    graph = [
+      {
+        "@id": "_:a1",
+        "arcFrom": {"@id": "rs-gaap:Total"},
+        "arcTo": {"@id": "rs-gaap:HalfShare"},
+        "arcAssociationType": "calculation",
+        "arcRoleUri": "https://x/roles/calc/BS-Total",
+        "arcWeight": 0.5,
+        "arcOrder": 100.0,
+      },
+      {
+        "@id": "_:a2",
+        "arcFrom": {"@id": "rs-gaap:Total"},
+        "arcTo": {"@id": "rs-gaap:Plain"},
+        "arcAssociationType": "calculation",
+        "arcRoleUri": "https://x/roles/calc/BS-Total",
+        "arcWeight": 1.0,
+        "arcOrder": 200.0,
+      },
+    ]
+    rules = build_rollup_rules(graph)
+    assert len(rules) == 1
+    assert rules[0]["ruleExpression"] == "$Total = (($HalfShare * 0.5) + $Plain)"


### PR DESCRIPTION
## Summary

Closes the §10.1 authoring-hardening cluster (#2/#8/#9/#10 from the v1.6.5→main review) — the last gate before inviting general tenant disclosure authoring — plus **two latent update-path bugs** the new e2e probe caught live.

### The four planned fixes

- **Auto-rule refresh on update (#2)**: `update-taxonomy-block` now re-derives the taxonomy's auto rules after any structural delta (`refresh_auto_rules`: wholesale delete-then-recreate — auto rules are derived state with no natural upsert key). Verification results FK rules/structures NOT NULL with no cascade, so they delete first; the same FK-safe ordering is applied to `apply_structures_to_remove` (latent bug). Pure element/metadata/tenant-rule updates skip the refresh to avoid rule-id churn. `StructureUpdatePatch` gains `concept_arrangement` (shared `ConceptArrangement` alias, drift-tested against `CONCEPT_ARRANGEMENT_VALUES`) so a mis-CAP'd structure is repairable; `block_type` stays immutable.
- **Weight fidelity (#8)**: non-unit calc weights (0.5, 2.0) no longer collapse to bare `+`/`-` in frozen rule expressions. The seed generator's `_build_expression` moved to `rules/expressions.py` as `build_rollup_expression`; both producers share it (seed output byte-identical — no artifact regeneration).
- **Variable-name collisions (#9)**: cross-namespace local-name collisions (`driftline:InventoryNet` vs `rs-gaap:InventoryNet`) dedupe deterministically (bare local name when unique → sanitized qname qualification on collision). Binders raise on duplicate names (per-rule handler records `status='error'` instead of a silently wrong verdict); the create/update validator rejects `duplicate_variable_name` and enforces `rollup_parent_not_first`.
- **LHS parent resolution (#10)**: `_rollup_parent_element_id` derives the RollUp parent from the expression LHS (reconciling with the frozen evaluator) with `variables[0]` as the legacy fallback.

### Probe-caught extras

The Driftline demo now grows the inventory note through `update-taxonomy-block` (adds a 4th member + arcs) and asserts the footing rule re-derives. That probe caught:

1. **Update validator projection blind to library refs**: extend-mode notes arc FROM library concepts; the projection stringified those endpoints to `from_ref=''` → every update to the canonical note shape 422'd with `phantom_from_ref`. Fixed via `_resolve_foreign_element_qnames` (mirrors create's `_load_library_qnames` awareness).
2. **autoflush=False vs re-derivation**: the extensions session doesn't autoflush and `apply_associations_to_add` doesn't flush — the refresh re-emitted a 3-child rule despite the 4th arc being applied. `refresh_auto_rules` now flushes first.

## Testing

- 687 tests green across `tests/operations/taxonomy_block`, `tests/operations/information_block`, `tests/taxonomy` (~60 new); full suite + code quality via `just test-all` (one unrelated pre-existing graph_api flake, passes in isolation)
- `git diff frameworks/` empty — seed artifact untouched
- E2E: Driftline demo end-to-end — update-path probe passes (footing rule refreshed, 4 children), report RollUp passes, Arelle valid, SHACL conforms

## Follow-up (out of scope)

- `cascade.py` taxonomy-delete has the same VR-FK delete-ordering hazard — pre-existing, deserves its own small PR
- The 3 structural check kinds (`NoCycles`/`NoOrphanArcs`/`ParentBeforeChild`) still evaluate as `skipped` (evaluators unbuilt — known)