### PR TITLE
Reserve library namespaces for platform authoring

### DIFF
--- a/robosystems/operations/taxonomy_block/validators.py
+++ b/robosystems/operations/taxonomy_block/validators.py
@@ -34,7 +34,7 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from typing import Any
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from robosystems.models.api.taxonomy_block import (
@@ -86,6 +86,7 @@ def validate_create_envelope(
   issues.extend(_phase_structural_integrity(payload))
   issues.extend(_phase_type_specific(payload))
   issues.extend(_phase_library_origin_respect(payload))
+  issues.extend(_phase_library_namespace_protection(payload, session))
   issues.extend(_phase_rule_expression_parse(payload))
   return issues
 
@@ -503,6 +504,59 @@ def _namespace_prefix(namespace_uri: str) -> str | None:
   if not stripped:
     return None
   return stripped.rsplit("/", 1)[-1] or None
+
+
+_LIBRARY_SEEDER = "library-seeder"
+
+
+def _phase_library_namespace_protection(
+  payload: CreateTaxonomyBlockRequest, session: Session
+) -> list[ValidationIssue]:
+  """Library namespaces are platform-owned — tenants must not declare in them.
+
+  The library evolves wholesale (rs-gaap reseeds, new packages), so a
+  tenant-minted ``rs-gaap:*`` element would fork the namespace and shadow
+  the real concept in schema-wide qname lookups. Tenants author in their
+  OWN extension namespace and *anchor* to library concepts — arcs and
+  ``parent_ref`` referencing library qnames stay legal (resolved via
+  :func:`_load_library_qnames`); only *declarations* under a
+  library-owned prefix are refused. Prefixes are derived from the seeded
+  rows themselves, so future library packages are protected automatically.
+  """
+  reserved = _load_library_prefixes(session)
+  if not reserved:
+    return []
+  issues: list[ValidationIssue] = []
+  for element in payload.elements:
+    qname = _element_qname(element, payload)
+    prefix = qname.split(":", 1)[0] if ":" in qname else ""
+    if prefix in reserved:
+      issues.append(
+        ValidationIssue(
+          phase="namespace_protection",
+          code="library_namespace_reserved",
+          message=(
+            f"element {qname!r} declares under the library-owned prefix "
+            f"{prefix!r}; author elements in your own extension namespace "
+            f"and anchor to library concepts via arcs or parent_ref."
+          ),
+          context={"element_qname": qname, "prefix": prefix},
+        )
+      )
+  return issues
+
+
+def _load_library_prefixes(session: Session) -> set[str]:
+  """Distinct qname prefixes of library-seeded elements in this schema."""
+  rows = session.execute(
+    select(func.split_part(Element.qname, ":", 1))
+    .where(
+      Element.created_by == _LIBRARY_SEEDER,
+      Element.qname.like("%:%"),
+    )
+    .distinct()
+  ).all()
+  return {row[0] for row in rows if row[0]}
 
 
 def _load_library_qnames(

--- a/tests/operations/taxonomy_block/test_validators.py
+++ b/tests/operations/taxonomy_block/test_validators.py
@@ -415,3 +415,96 @@ def test_pytest_is_wired() -> None:
   """Smoke — confirms pytest markers and module paths resolve."""
   with pytest.raises(TaxonomyBlockValidationError):
     raise TaxonomyBlockValidationError([])
+
+
+class TestLibraryNamespaceProtection:
+  """Tenants anchor to library concepts; they never declare in library
+  namespaces — rs-gaap is platform-owned and evolves wholesale."""
+
+  def _session_with_library_prefixes(self, rows_per_call: list) -> MagicMock:
+    session = MagicMock()
+    results = []
+    for rows in rows_per_call:
+      result = MagicMock()
+      result.all.return_value = rows
+      results.append(result)
+    session.execute.side_effect = results
+    return session
+
+  def test_declaring_under_library_prefix_rejected(self) -> None:
+    payload = _basic_coa(
+      elements=[
+        TaxonomyBlockElementRequest(
+          qname="rs-gaap:SneakyAssets",
+          name="Sneaky Assets",
+          trait="asset",
+          balance_type="debit",
+          period_type="instant",
+        )
+      ]
+    )
+    session = self._session_with_library_prefixes([[("rs-gaap",), ("disclosures",)]])
+    issues = validate_create_envelope(payload, session)
+    codes = {i.code for i in issues}
+    assert "library_namespace_reserved" in codes
+
+  def test_own_namespace_declaration_accepted(self) -> None:
+    payload = _basic_coa(
+      elements=[
+        TaxonomyBlockElementRequest(
+          qname="acme:Widgets",
+          name="Widgets",
+          trait="asset",
+          balance_type="debit",
+          period_type="instant",
+        )
+      ]
+    )
+    session = self._session_with_library_prefixes([[("rs-gaap",), ("disclosures",)]])
+    issues = validate_create_envelope(payload, session)
+    assert not any(i.phase == "namespace_protection" for i in issues)
+
+  def test_referencing_library_concepts_stays_legal(self) -> None:
+    """The extend-and-map shape: own-namespace member parented under and
+    arced from a library total. References resolve; only declarations
+    are namespace-guarded."""
+    payload = CreateTaxonomyBlockRequest(
+      name="Acme Extension",
+      taxonomy_type="reporting_extension",
+      parent_taxonomy_id="tax_lib",
+      elements=[
+        TaxonomyBlockElementRequest(
+          qname="acme:InventoryPackaging",
+          name="Packaging",
+          parent_ref="rs-gaap:InventoryNet",
+          balance_type="debit",
+          period_type="instant",
+        )
+      ],
+      structures=[],
+      associations=[],
+      rules=[],
+    )
+    # 1st execute: _load_library_qnames resolves the referenced parent;
+    # 2nd execute: the reserved-prefix load.
+    session = self._session_with_library_prefixes(
+      [[("rs-gaap:InventoryNet",)], [("rs-gaap",)]]
+    )
+    issues = validate_create_envelope(payload, session)
+    assert not any(i.phase == "namespace_protection" for i in issues)
+    assert not any(i.code == "phantom_parent_ref" for i in issues)
+
+  def test_no_library_rows_disables_protection(self) -> None:
+    payload = _basic_coa(
+      elements=[
+        TaxonomyBlockElementRequest(
+          qname="rs-gaap:Whatever",
+          name="Whatever",
+          trait="asset",
+          balance_type="debit",
+          period_type="instant",
+        )
+      ]
+    )
+    issues = validate_create_envelope(payload, _session_empty())
+    assert not any(i.phase == "namespace_protection" for i in issues)


### PR DESCRIPTION
## Summary

As the disclosures surface grows, rs-gaap will evolve wholesale (reseeds, new packages) — tenants must not fork it. This PR draws the authoring boundary: **tenants author in their own extension namespace and anchor to library structures; declaring elements under a library-owned prefix is refused.**

- New validation phase `namespace_protection` → issue `library_namespace_reserved`: rejects any envelope element whose qname prefix belongs to a library-seeded namespace (`rs-gaap`, `disclosures`, `styles`, `cm` today). The reserved set is derived from the seeded rows themselves (distinct prefixes of `library-seeder` elements), so future library packages are protected automatically with no config.
- **References stay legal**: arcs and `parent_ref` pointing at library qnames — the extend-and-map pattern (#886/#892) — resolve exactly as before. Only *declarations* are guarded.
- Applies to create and, via the update projection, to `update-taxonomy-block`, across all three writable block types. Existing library-row protections (`library_element_immutable`, `library_origin_smuggled`) guard the real rows; this closes the remaining gap where a tenant could mint a *new* element claiming a library qname, which would shadow the real concept nondeterministically in schema-wide qname lookups and mislabel exports.

## Testing

- 4 new validator tests (rejection, own-namespace acceptance, extend-and-map reference legality, empty-library no-op); 460 tests green across `tests/operations/taxonomy_block` + `tests/operations/information_block`; `just test-code` clean
- Live negative probe: `create-taxonomy-block` with an `rs-gaap:` element → 422 `library_namespace_reserved`
- Full Driftline demo e2e unchanged: notes author (`driftline:`/`coa:`), update-path probe passes (footing rule → 4 children), Arelle valid, SHACL conforms