### PR TITLE
Metrics M-1: rs-metric catalog + compute-metrics; TAXONOMY_AUTHORING_ENABLED gate

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -217,6 +217,10 @@ SECURITY_AUDIT_ENABLED=false
 # AI semantic memory (LanceDB) — master gate (REST + ops + recall + governance);
 # MCP_SEMANTIC_MEMORY_ENABLED is the additional MCP-tool sub-gate.
 # SEMANTIC_MEMORY_ENABLED=false
+# Tenant framework authoring (reporting_extension/custom_ontology taxonomy
+# blocks, create+update). Default: on in dev/test, OFF in prod/staging
+# (fail-closed; flip via SSM features/TAXONOMY_AUTHORING_ENABLED + restart).
+# TAXONOMY_AUTHORING_ENABLED=true
 
 ## Shared Repository Operations
 # SHARED_MASTER_READS_ENABLED=true

--- a/bin/setup/aws.sh
+++ b/bin/setup/aws.sh
@@ -221,6 +221,7 @@ function create_ssm_feature_flags() {
         "SEMANTIC_SEARCH_ENABLED=false"
         "SSE_ENABLED=true"
         "SUBGRAPH_CREATION_ENABLED=true"
+        "TAXONOMY_AUTHORING_ENABLED=false"
         "USER_REGISTRATION_ENABLED=${user_reg}"
     )
 

--- a/examples/_scenario/runner.py
+++ b/examples/_scenario/runner.py
@@ -1007,6 +1007,80 @@ def verify_disclosure_notes(graph_id: str) -> None:
       print(f"    Verification: {passed}/{total} rules passed")
 
 
+def verify_metrics(graph_id: str, scenario) -> None:
+  """Compute + render the Key Financial Metrics standing time series.
+
+  The Metrics M-1 probe: the library-seeded rs-metric catalog computes
+  from the filed report's persisted facts. Two period ends (current +
+  prior comparative — ``comparative=True`` persists both windows) make
+  an honest 2-period series for the instant metrics; InterestCoverage
+  skips with a reason for a debt-free scenario, exercising the
+  soft-fail path on purpose.
+  """
+  import httpx
+
+  client = _get_ledger_client()
+  blocks = client.list_information_blocks(graph_id, block_type="metric")
+  if not blocks:
+    print("  ERROR: no metric block found — was the rs-metric package seeded?")
+    return
+  block = blocks[0]
+  structure_id = block.get("id")
+  print(f"  Metric block: {block.get('name')} ({structure_id})")
+
+  if scenario.report_period is None:
+    print("  (skipped — scenario has no report_period)")
+    return
+  period_start, period_end = scenario.report_period
+  # Mirrors the report's comparative window (_compute_prior_period):
+  # the prior period ends the day before the current window starts.
+  prior_end = period_start - timedelta(days=1)
+
+  api_key = _client_config()["token"]
+  for pe in (prior_end, period_end):
+    resp = httpx.post(
+      f"{BASE_URL}/extensions/roboledger/{graph_id}/operations/compute-metrics",
+      json={"structure_id": structure_id, "period_end": pe.isoformat()},
+      headers={"X-API-Key": api_key, "Content-Type": "application/json"},
+      timeout=60.0,
+    )
+    if resp.status_code >= 400:
+      print(f"  ERROR: compute-metrics {pe} -> HTTP {resp.status_code}: {resp.text[:200]}")
+      continue
+    result = (resp.json() or {}).get("result") or {}
+    computed = result.get("computed") or []
+    skipped = result.get("skipped") or []
+    print(f"  {pe}: {len(computed)} computed, {len(skipped)} skipped")
+    for m in computed:
+      value = m.get("value")
+      if not isinstance(value, (int, float)):
+        continue
+      shown = f"${value:,.2f}" if m.get("unit") == "USD" else f"{value:,.2f}"
+      print(f"    {m.get('name')}: {shown}")
+    for s in skipped:
+      print(f"    (skipped) {s.get('element_qname')}: {s.get('reason')}")
+
+  # Re-read the block — the standing sets are now the rendered series.
+  blocks = client.list_information_blocks(graph_id, block_type="metric")
+  rendering = ((blocks[0].get("view") or {}).get("rendering") or {}) if blocks else {}
+  periods = rendering.get("periods") or []
+  rows = rendering.get("rows") or []
+  print(f"  Time series: {len(periods)} period(s), {len(rows)} metric row(s)")
+  current_ratio = next(
+    (r for r in rows if r.get("element_qname") == "rs-metric:CurrentRatio"), None
+  )
+  if current_ratio is None:
+    print("  WARNING: Current Ratio row missing from the rendering")
+    return
+  values = current_ratio.get("values") or []
+  print(f"    Current Ratio series: {values}")
+  numeric = [v for v in values if isinstance(v, (int, float))]
+  if len(periods) >= 2 and len(numeric) >= 2:
+    print("  Two-period metric series verified")
+  elif not numeric:
+    print("  WARNING: Current Ratio has no computed values")
+
+
 # ---------------------------------------------------------------------------
 # Step 3b: AI mapping path — requires Bedrock (optional)
 # ---------------------------------------------------------------------------
@@ -1573,6 +1647,13 @@ def run_demo(
   if disclosures and report_id:
     print("\nRendered disclosure notes:")
     verify_disclosure_notes(graph_id)
+
+  # Metrics probe — compute the seeded Key Financial Metrics catalog
+  # against the report's persisted facts for both comparative period
+  # ends, then render the standing time series.
+  if report_id:
+    print("\nComputing key financial metrics...")
+    verify_metrics(graph_id, scenario)
 
   # Summary
   print("\n" + "=" * 60)

--- a/frameworks/rs-gaap/packages/rs-metric/v1/taxonomy.jsonld
+++ b/frameworks/rs-gaap/packages/rs-metric/v1/taxonomy.jsonld
@@ -1,0 +1,377 @@
+{
+  "@context": {
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "skos": "http://www.w3.org/2004/02/skos/core#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "xbrli": "http://www.xbrl.org/2003/instance#",
+    "link": "http://www.xbrl.org/2003/linkbase#",
+    "xlink": "http://www.w3.org/1999/xlink#",
+    "rs-gaap": "https://robosystems.ai/taxonomy/rs-gaap/v1/",
+    "rs-metric": "https://robosystems.ai/taxonomy/rs-gaap/metrics/v1/",
+    "rs": "https://robosystems.ai/vocab/",
+    "balance": {
+      "@id": "xbrli:balance"
+    },
+    "periodType": {
+      "@id": "xbrli:periodType"
+    },
+    "abstract": {
+      "@id": "https://robosystems.ai/vocab/abstract",
+      "@type": "xsd:boolean"
+    },
+    "monetary": {
+      "@id": "https://robosystems.ai/vocab/monetary",
+      "@type": "xsd:boolean"
+    },
+    "elementType": {
+      "@id": "https://robosystems.ai/vocab/elementType"
+    },
+    "from": {
+      "@id": "xlink:from",
+      "@type": "@id"
+    },
+    "to": {
+      "@id": "xlink:to",
+      "@type": "@id"
+    },
+    "arcrole": {
+      "@id": "xlink:arcrole",
+      "@type": "@id"
+    },
+    "role": {
+      "@id": "xlink:role",
+      "@type": "@id"
+    },
+    "order": {
+      "@id": "link:order",
+      "@type": "xsd:decimal"
+    },
+    "associationType": {
+      "@id": "https://robosystems.ai/vocab/associationType"
+    },
+    "label": "rdfs:label",
+    "documentation": "rdfs:comment",
+    "structureName": {
+      "@id": "https://robosystems.ai/vocab/structureName"
+    },
+    "blockType": {
+      "@id": "https://robosystems.ai/vocab/blockType"
+    },
+    "roleUri": {
+      "@id": "https://robosystems.ai/vocab/roleUri"
+    },
+    "conceptArrangementPattern": {
+      "@id": "https://robosystems.ai/vocab/conceptArrangementPattern"
+    },
+    "ruleCategory": {
+      "@id": "https://robosystems.ai/vocab/ruleCategory"
+    },
+    "rulePattern": {
+      "@id": "https://robosystems.ai/vocab/rulePattern"
+    },
+    "ruleExpression": {
+      "@id": "https://robosystems.ai/vocab/ruleExpression"
+    },
+    "ruleTarget": {
+      "@id": "https://robosystems.ai/vocab/ruleTarget"
+    },
+    "targetKind": {
+      "@id": "https://robosystems.ai/vocab/targetKind"
+    },
+    "targetRef": {
+      "@id": "https://robosystems.ai/vocab/targetRef"
+    },
+    "ruleVariables": {
+      "@id": "https://robosystems.ai/vocab/ruleVariables",
+      "@container": "@list"
+    },
+    "variableName": {
+      "@id": "https://robosystems.ai/vocab/variableName"
+    },
+    "variableQname": {
+      "@id": "https://robosystems.ai/vocab/variableQname"
+    },
+    "ruleMessage": {
+      "@id": "https://robosystems.ai/vocab/ruleMessage"
+    },
+    "ruleSeverity": {
+      "@id": "https://robosystems.ai/vocab/ruleSeverity"
+    },
+    "ruleOrigin": {
+      "@id": "https://robosystems.ai/vocab/ruleOrigin"
+    }
+  },
+  "standard": "rs-metric",
+  "version": "v1",
+  "taxonomy_type": "reporting_extension",
+  "namespace_uri": "https://robosystems.ai/taxonomy/rs-gaap/metrics/v1/",
+  "default_block_type": "metric",
+  "origin": "native",
+  "description": "rs-metric — the library metric catalog (Metrics M-1). Each metric is a qname-addressable concept in the rs-metric namespace plus one Derive rule whose ruleExpression computes it from rs-gaap anchor facts ($Metric = f(rs-gaap operands)). The Key Financial Metrics node is both an abstract element and a Structure (block_type='metric', CAP arithmetic) whose presentation arcs enumerate the catalog — the standing metric block every tenant receives. Operand qnames are the canonical calc-DAG anchors the report pivot persists (e.g. InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings, not InventoryNet). compute-metrics binds operands to persisted report facts per period and upserts a standing factset_type='metric' FactSet. Metrics with missing operands or undefined ratios are skipped with a reason, never errored. Hand-authored; avg()/composition metrics land in M-2.",
+  "@graph": [
+    {
+      "@id": "rs-metric:KeyFinancialMetrics",
+      "label": "Key Financial Metrics",
+      "documentation": "Container for the seeded metric catalog — an abstract element and the standing metric Structure. compute-metrics fills its FactSets; the metric envelope renders the time series.",
+      "elementType": "abstract",
+      "periodType": "duration",
+      "abstract": true,
+      "monetary": false,
+      "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/metrics/KeyFinancialMetrics",
+      "structureName": "Key Financial Metrics",
+      "blockType": "metric",
+      "conceptArrangementPattern": "arithmetic"
+    },
+    {
+      "@id": "rs-metric:WorkingCapital",
+      "label": "Working Capital",
+      "documentation": "Current assets minus current liabilities — the short-term liquidity cushion.",
+      "elementType": "concept",
+      "periodType": "instant",
+      "balance": "debit",
+      "monetary": true
+    },
+    {
+      "@id": "rs-metric:CurrentRatio",
+      "label": "Current Ratio",
+      "documentation": "Current assets over current liabilities.",
+      "elementType": "concept",
+      "periodType": "instant",
+      "monetary": false
+    },
+    {
+      "@id": "rs-metric:QuickRatio",
+      "label": "Quick Ratio",
+      "documentation": "Current assets excluding inventory, over current liabilities (acid test).",
+      "elementType": "concept",
+      "periodType": "instant",
+      "monetary": false
+    },
+    {
+      "@id": "rs-metric:DebtToEquity",
+      "label": "Debt to Equity",
+      "documentation": "Total liabilities over stockholders' equity.",
+      "elementType": "concept",
+      "periodType": "instant",
+      "monetary": false
+    },
+    {
+      "@id": "rs-metric:InterestCoverage",
+      "label": "Interest Coverage",
+      "documentation": "Operating income over interest expense. Skips (rather than errors) for debt-free entities with no interest expense fact.",
+      "elementType": "concept",
+      "periodType": "duration",
+      "monetary": false
+    },
+    {
+      "@id": "_:rs-metric-pres-arc-1",
+      "@type": "rs:Association",
+      "from": {
+        "@id": "rs-metric:KeyFinancialMetrics"
+      },
+      "to": {
+        "@id": "rs-metric:WorkingCapital"
+      },
+      "associationType": "presentation",
+      "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+      "role": "https://robosystems.ai/seattle/cm-roles/roles/metrics/KeyFinancialMetrics",
+      "order": 1.0
+    },
+    {
+      "@id": "_:rs-metric-pres-arc-2",
+      "@type": "rs:Association",
+      "from": {
+        "@id": "rs-metric:KeyFinancialMetrics"
+      },
+      "to": {
+        "@id": "rs-metric:CurrentRatio"
+      },
+      "associationType": "presentation",
+      "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+      "role": "https://robosystems.ai/seattle/cm-roles/roles/metrics/KeyFinancialMetrics",
+      "order": 2.0
+    },
+    {
+      "@id": "_:rs-metric-pres-arc-3",
+      "@type": "rs:Association",
+      "from": {
+        "@id": "rs-metric:KeyFinancialMetrics"
+      },
+      "to": {
+        "@id": "rs-metric:QuickRatio"
+      },
+      "associationType": "presentation",
+      "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+      "role": "https://robosystems.ai/seattle/cm-roles/roles/metrics/KeyFinancialMetrics",
+      "order": 3.0
+    },
+    {
+      "@id": "_:rs-metric-pres-arc-4",
+      "@type": "rs:Association",
+      "from": {
+        "@id": "rs-metric:KeyFinancialMetrics"
+      },
+      "to": {
+        "@id": "rs-metric:DebtToEquity"
+      },
+      "associationType": "presentation",
+      "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+      "role": "https://robosystems.ai/seattle/cm-roles/roles/metrics/KeyFinancialMetrics",
+      "order": 4.0
+    },
+    {
+      "@id": "_:rs-metric-pres-arc-5",
+      "@type": "rs:Association",
+      "from": {
+        "@id": "rs-metric:KeyFinancialMetrics"
+      },
+      "to": {
+        "@id": "rs-metric:InterestCoverage"
+      },
+      "associationType": "presentation",
+      "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+      "role": "https://robosystems.ai/seattle/cm-roles/roles/metrics/KeyFinancialMetrics",
+      "order": 5.0
+    },
+    {
+      "@id": "_:rs-metric-derive-working-capital",
+      "ruleCategory": "ReportingSystemSpecificRule",
+      "rulePattern": "Derive",
+      "ruleExpression": "$WorkingCapital = ($AssetsCurrent - $LiabilitiesCurrent)",
+      "ruleTarget": {
+        "targetKind": "element",
+        "targetRef": "rs-metric:WorkingCapital"
+      },
+      "ruleVariables": [
+        {
+          "variableName": "WorkingCapital",
+          "variableQname": "rs-metric:WorkingCapital"
+        },
+        {
+          "variableName": "AssetsCurrent",
+          "variableQname": "rs-gaap:AssetsCurrent"
+        },
+        {
+          "variableName": "LiabilitiesCurrent",
+          "variableQname": "rs-gaap:LiabilitiesCurrent"
+        }
+      ],
+      "ruleMessage": "Working Capital = Current Assets - Current Liabilities",
+      "ruleSeverity": "info",
+      "ruleOrigin": "native"
+    },
+    {
+      "@id": "_:rs-metric-derive-current-ratio",
+      "ruleCategory": "ReportingSystemSpecificRule",
+      "rulePattern": "Derive",
+      "ruleExpression": "$CurrentRatio = ($AssetsCurrent / $LiabilitiesCurrent)",
+      "ruleTarget": {
+        "targetKind": "element",
+        "targetRef": "rs-metric:CurrentRatio"
+      },
+      "ruleVariables": [
+        {
+          "variableName": "CurrentRatio",
+          "variableQname": "rs-metric:CurrentRatio"
+        },
+        {
+          "variableName": "AssetsCurrent",
+          "variableQname": "rs-gaap:AssetsCurrent"
+        },
+        {
+          "variableName": "LiabilitiesCurrent",
+          "variableQname": "rs-gaap:LiabilitiesCurrent"
+        }
+      ],
+      "ruleMessage": "Current Ratio = Current Assets / Current Liabilities",
+      "ruleSeverity": "info",
+      "ruleOrigin": "native"
+    },
+    {
+      "@id": "_:rs-metric-derive-quick-ratio",
+      "ruleCategory": "ReportingSystemSpecificRule",
+      "rulePattern": "Derive",
+      "ruleExpression": "$QuickRatio = (($AssetsCurrent - $InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings) / $LiabilitiesCurrent)",
+      "ruleTarget": {
+        "targetKind": "element",
+        "targetRef": "rs-metric:QuickRatio"
+      },
+      "ruleVariables": [
+        {
+          "variableName": "QuickRatio",
+          "variableQname": "rs-metric:QuickRatio"
+        },
+        {
+          "variableName": "AssetsCurrent",
+          "variableQname": "rs-gaap:AssetsCurrent"
+        },
+        {
+          "variableName": "InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
+          "variableQname": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings"
+        },
+        {
+          "variableName": "LiabilitiesCurrent",
+          "variableQname": "rs-gaap:LiabilitiesCurrent"
+        }
+      ],
+      "ruleMessage": "Quick Ratio = (Current Assets - Inventory) / Current Liabilities",
+      "ruleSeverity": "info",
+      "ruleOrigin": "native"
+    },
+    {
+      "@id": "_:rs-metric-derive-debt-to-equity",
+      "ruleCategory": "ReportingSystemSpecificRule",
+      "rulePattern": "Derive",
+      "ruleExpression": "$DebtToEquity = ($Liabilities / $StockholdersEquity)",
+      "ruleTarget": {
+        "targetKind": "element",
+        "targetRef": "rs-metric:DebtToEquity"
+      },
+      "ruleVariables": [
+        {
+          "variableName": "DebtToEquity",
+          "variableQname": "rs-metric:DebtToEquity"
+        },
+        {
+          "variableName": "Liabilities",
+          "variableQname": "rs-gaap:Liabilities"
+        },
+        {
+          "variableName": "StockholdersEquity",
+          "variableQname": "rs-gaap:StockholdersEquity"
+        }
+      ],
+      "ruleMessage": "Debt to Equity = Total Liabilities / Stockholders' Equity",
+      "ruleSeverity": "info",
+      "ruleOrigin": "native"
+    },
+    {
+      "@id": "_:rs-metric-derive-interest-coverage",
+      "ruleCategory": "ReportingSystemSpecificRule",
+      "rulePattern": "Derive",
+      "ruleExpression": "$InterestCoverage = ($OperatingIncomeLoss / $InterestExpense)",
+      "ruleTarget": {
+        "targetKind": "element",
+        "targetRef": "rs-metric:InterestCoverage"
+      },
+      "ruleVariables": [
+        {
+          "variableName": "InterestCoverage",
+          "variableQname": "rs-metric:InterestCoverage"
+        },
+        {
+          "variableName": "OperatingIncomeLoss",
+          "variableQname": "rs-gaap:OperatingIncomeLoss"
+        },
+        {
+          "variableName": "InterestExpense",
+          "variableQname": "rs-gaap:InterestExpense"
+        }
+      ],
+      "ruleMessage": "Interest Coverage = Operating Income / Interest Expense",
+      "ruleSeverity": "info",
+      "ruleOrigin": "native"
+    }
+  ]
+}

--- a/frameworks/rs-gaap/v1.json
+++ b/frameworks/rs-gaap/v1.json
@@ -22,7 +22,8 @@
     {"standard": "rs-gaap-reporting-checklist",  "version": "v1", "ordinal": 10, "is_required": true, "tenant_copy": false},
     {"standard": "rs-gaap-reporting-styles",     "version": "v1", "ordinal": 11, "is_required": true},
     {"standard": "rs-gaap-rollup-rules",         "version": "v1", "ordinal": 12, "is_required": true},
-    {"standard": "rs-gaap-rules",                "version": "v1", "ordinal": 13, "is_required": true}
+    {"standard": "rs-gaap-rules",                "version": "v1", "ordinal": 13, "is_required": true},
+    {"standard": "rs-metric",                    "version": "v1", "ordinal": 14, "is_required": true}
   ],
   "bridges": [
     {"bridge": "fac-to-rs-gaap",                            "version": "v1", "ordinal": 0, "is_required": true, "tenant_copy": false},

--- a/migrations/extensions/versions/0022_metrics.py
+++ b/migrations/extensions/versions/0022_metrics.py
@@ -1,0 +1,301 @@
+"""metrics — seed the rs-metric catalog package + Derive rules + metric FactSets
+
+The Metrics MVP (M-1) needs three vocabulary widenings plus a new library
+package in deployments whose library was seeded before rs-metric existed:
+
+- ``fact_sets``: widen ``check_fact_set_type`` to admit ``'metric'``
+  (standing computed-metric time series — one FactSet per
+  (structure, entity, period_end), filled by compute-metrics).
+- ``rules``: widen ``check_rule_pattern`` to admit ``'Derive'`` (rules that
+  COMPUTE a value from bound facts rather than verify one).
+- ``elements``: widen ``check_element_source`` to admit ``'rs-metric'``
+  (the metric catalog's namespace prefix, following the disclosures /
+  checklist / styles source-per-package convention from 0007).
+
+Then the content: seed ``frameworks/rs-gaap/packages/rs-metric/v1`` into the
+public library (0002's pass structure, one package), mirror the manifest's
+new ``framework_packages`` junction row (0007's deterministic-uuid upsert),
+and fan the package into every existing tenant schema via
+``resync_library_into_tenant`` with a single-package pin. The resync runs
+under ``SET LOCAL robosystems.library_resync = 'on'`` (0016) — the new
+package's arcs INSERT into a library-seeded structure, which the
+immutability triggers reject otherwise.
+
+Fresh deployments get all of this from 0002 + provisioning (the manifest now
+lists rs-metric; ``_widen_library_checks`` and the models carry the widened
+vocabulary), so this migration is the backfill path for existing databases.
+
+Note: the downgrade deletes rs-metric content (public + tenants, including
+any computed metric FactSets) and re-narrows the constraints. It will fail
+if tenant-authored content references rs-metric elements (e.g. custom arcs
+into the catalog). Expected once the values are in use.
+
+Revision ID: 0022
+Revises: 0021
+Create Date: 2026-07-19
+
+"""
+
+from __future__ import annotations
+
+from alembic import op
+from sqlalchemy import text
+
+from migrations.extensions.helpers import TenantOps, for_each_tenant_schema
+
+# revision identifiers, used by Alembic.
+revision = "0022"
+down_revision = "0021"
+branch_labels = None
+depends_on = None
+
+_PACKAGE_STANDARD = "rs-metric"
+_PACKAGE_VERSION = "v1"
+_FRAMEWORK = "rs-gaap"
+_FRAMEWORK_VERSION = "v1"
+_PACKAGE_ORDINAL = 14
+
+_FACTSET_WIDENED = (
+  "factset_type IN ('report', 'schedule', 'custom', 'disclosure', 'metric')"
+)
+_FACTSET_ORIGINAL = "factset_type IN ('report', 'schedule', 'custom', 'disclosure')"
+
+_RULE_PATTERN_WIDENED = (
+  "rule_pattern IS NULL OR rule_pattern IN ("
+  "'Adjustment', 'CoExists', 'Derive', 'EqualTo', 'Exists', 'GreaterThan', "
+  "'GreaterThanOrEqualToZero', 'LessThan', 'RollForward', 'RollUp', "
+  "'SumEquals', 'Variance'"
+  ")"
+)
+_RULE_PATTERN_ORIGINAL = (
+  "rule_pattern IS NULL OR rule_pattern IN ("
+  "'Adjustment', 'CoExists', 'EqualTo', 'Exists', 'GreaterThan', "
+  "'GreaterThanOrEqualToZero', 'LessThan', 'RollForward', 'RollUp', "
+  "'SumEquals', 'Variance'"
+  ")"
+)
+
+_SOURCE_WIDENED = (
+  "source IN ("
+  "'fac', 'rs-gaap', 'us-gaap', 'ifrs', "
+  "'quickbooks', 'xero', 'plaid', 'native', 'import', 'system', "
+  "'disclosures', 'checklist', 'styles', 'cm', 'rs-metric'"
+  ")"
+)
+_SOURCE_ORIGINAL = (
+  "source IN ("
+  "'fac', 'rs-gaap', 'us-gaap', 'ifrs', "
+  "'quickbooks', 'xero', 'plaid', 'native', 'import', 'system', "
+  "'disclosures', 'checklist', 'styles', 'cm'"
+  ")"
+)
+
+
+def _widen(conn, schema: str) -> None:
+  t = TenantOps(conn, schema)
+  t.add_check("fact_sets", "check_fact_set_type", _FACTSET_WIDENED)
+  t.add_check("rules", "check_rule_pattern", _RULE_PATTERN_WIDENED)
+  t.add_check("elements", "check_element_source", _SOURCE_WIDENED)
+
+
+def _narrow(conn, schema: str) -> None:
+  t = TenantOps(conn, schema)
+  t.add_check("fact_sets", "check_fact_set_type", _FACTSET_ORIGINAL)
+  t.add_check("rules", "check_rule_pattern", _RULE_PATTERN_ORIGINAL)
+  t.add_check("elements", "check_element_source", _SOURCE_ORIGINAL)
+
+
+def _seed_path():
+  from robosystems.taxonomy.discovery import FRAMEWORKS_DIR
+
+  return (
+    FRAMEWORKS_DIR
+    / _FRAMEWORK
+    / "packages"
+    / _PACKAGE_STANDARD
+    / _PACKAGE_VERSION
+    / "taxonomy.jsonld"
+  )
+
+
+def _seed_public_library(conn) -> None:
+  """Load rs-metric into the public library — 0002's three passes, one package."""
+  from sqlalchemy.orm import Session as _Session
+
+  from robosystems.operations.taxonomy_block.library_creator import (
+    create_library_arcs,
+    create_library_rules,
+    create_library_taxonomy_elements,
+    prune_empty_default_structures,
+  )
+  from robosystems.taxonomy import load_taxonomy_package
+
+  package = load_taxonomy_package(_seed_path())
+  session = _Session(bind=conn)
+  try:
+    _, counts = create_library_taxonomy_elements(session, package)
+    session.flush()
+    print(
+      f"  [rs-metric pass 1] elements={counts['elements']} "
+      f"structures={counts['structures']}"
+    )
+    counts = create_library_arcs(session, package)
+    session.flush()
+    print(
+      f"  [rs-metric pass 2] associations={counts['associations']} "
+      f"(skipped={counts['associations_skipped']})"
+    )
+    counts = create_library_rules(session, package)
+    session.flush()
+    print(
+      f"  [rs-metric pass 3] rules={counts['rules']} "
+      f"(skipped={counts['rules_skipped']})"
+    )
+    # The auto-created "rs-metric — default structure" fallback ends up
+    # empty (every arc routes to the named Key Financial Metrics role);
+    # prune it so it isn't copied into every tenant. Same name-scoped
+    # helper 0002 uses — other packages' defaults are already gone.
+    pruned = prune_empty_default_structures(session)
+    session.flush()
+    print(f"  [rs-metric pass 4] pruned {pruned} empty default structure(s)")
+  finally:
+    session.close()
+
+
+def _upsert_framework_package_row(conn) -> None:
+  """Mirror the manifest's new packages[] entry — 0007's junction upsert."""
+  from datetime import UTC, datetime
+
+  from robosystems.utils.uuid import generate_deterministic_uuid
+
+  fid = generate_deterministic_uuid(
+    f"{_FRAMEWORK}:{_FRAMEWORK_VERSION}", namespace="framework"
+  )
+  fpid = generate_deterministic_uuid(
+    f"{fid}:{_PACKAGE_STANDARD}:{_PACKAGE_VERSION}", namespace="framework_package"
+  )
+  conn.execute(
+    text("""
+      INSERT INTO public.framework_packages (
+        id, framework_id, package_standard, package_version,
+        ordinal, is_required, metadata, created_at, created_by
+      ) VALUES (
+        :id, :fid, :std, :ver, :ordinal, true,
+        '{}'::jsonb, :now, 'library-seeder'
+      )
+      ON CONFLICT (id) DO UPDATE SET
+        ordinal     = EXCLUDED.ordinal,
+        is_required = EXCLUDED.is_required
+    """),
+    {
+      "id": fpid,
+      "fid": fid,
+      "std": _PACKAGE_STANDARD,
+      "ver": _PACKAGE_VERSION,
+      "ordinal": _PACKAGE_ORDINAL,
+      "now": datetime.now(UTC),
+    },
+  )
+
+
+def upgrade() -> None:
+  from robosystems.taxonomy.writer import SET_LIBRARY_RESYNC, resync_library_into_tenant
+
+  conn = op.get_bind()
+
+  # 1. Vocabulary widenings — must precede the seed so rs-metric rows insert.
+  _widen(conn, "public")
+  for_each_tenant_schema(conn, _widen)
+
+  # 2. Public library seed + manifest junction row.
+  _seed_public_library(conn)
+  _upsert_framework_package_row(conn)
+
+  # 3. Fan the new package into every existing tenant schema. SET LOCAL is
+  #    transaction-scoped — it covers the whole fan-out and vanishes on
+  #    commit. Mandatory: the package's arcs INSERT into a library-seeded
+  #    structure, which the 0016 immutability triggers reject otherwise
+  #    (resync_library_into_tenant asserts the GUC up front).
+  conn.execute(text(SET_LIBRARY_RESYNC))
+
+  def _copy(conn, schema: str) -> None:
+    stats = resync_library_into_tenant(
+      conn, schema, pin={_PACKAGE_STANDARD: _PACKAGE_VERSION}
+    )
+    print(
+      f"  [rs-metric → {schema}] elements={stats.elements} "
+      f"structures={stats.structures} associations={stats.associations} "
+      f"rules={stats.rules}"
+    )
+
+  for_each_tenant_schema(conn, _copy)
+
+
+def _delete_package_content(conn, schema: str) -> None:
+  """Delete rs-metric content from one schema in FK-safe order.
+
+  Fails (by design) if tenant-authored content still references rs-metric
+  elements in ways not covered here — that's data the operator must
+  triage, not silently drop.
+  """
+  from robosystems.utils.uuid import generate_deterministic_uuid
+
+  taxonomy_id = generate_deterministic_uuid(
+    f"{_PACKAGE_STANDARD}:{_PACKAGE_VERSION}", namespace="taxonomy"
+  )
+  s = schema
+  params = {"tid": taxonomy_id}
+  statements = [
+    # verification_results FK rules NOT NULL with no ON DELETE.
+    f"DELETE FROM {s}.verification_results WHERE rule_id IN "
+    f"(SELECT id FROM {s}.rules WHERE taxonomy_id = :tid)",
+    f"DELETE FROM {s}.rules WHERE taxonomy_id = :tid",
+    # Metric FactSets reference the catalog structure; facts cascade.
+    f"DELETE FROM {s}.fact_sets WHERE structure_id IN "
+    f"(SELECT id FROM {s}.structures WHERE taxonomy_id = :tid)",
+    f"DELETE FROM {s}.associations WHERE structure_id IN "
+    f"(SELECT id FROM {s}.structures WHERE taxonomy_id = :tid)",
+    f"DELETE FROM {s}.structures WHERE taxonomy_id = :tid",
+    f"DELETE FROM {s}.element_traits WHERE element_id IN "
+    f"(SELECT id FROM {s}.elements WHERE taxonomy_id = :tid)",
+    f"DELETE FROM {s}.element_labels WHERE element_id IN "
+    f"(SELECT id FROM {s}.elements WHERE taxonomy_id = :tid)",
+    f"DELETE FROM {s}.element_references WHERE element_id IN "
+    f"(SELECT id FROM {s}.elements WHERE taxonomy_id = :tid)",
+    f"DELETE FROM {s}.elements WHERE taxonomy_id = :tid",
+    f"DELETE FROM {s}.taxonomies WHERE id = :tid",
+  ]
+  for stmt in statements:
+    conn.execute(text(stmt), params)
+
+
+def downgrade() -> None:
+  from robosystems.taxonomy.writer import SET_LIBRARY_RESYNC
+  from robosystems.utils.uuid import generate_deterministic_uuid
+
+  conn = op.get_bind()
+
+  # Library-row deletes in tenant schemas need the immutability bypass.
+  conn.execute(text(SET_LIBRARY_RESYNC))
+
+  def _delete(conn, schema: str) -> None:
+    _delete_package_content(conn, schema)
+
+  for_each_tenant_schema(conn, _delete)
+  _delete_package_content(conn, "public")
+
+  fid = generate_deterministic_uuid(
+    f"{_FRAMEWORK}:{_FRAMEWORK_VERSION}", namespace="framework"
+  )
+  fpid = generate_deterministic_uuid(
+    f"{fid}:{_PACKAGE_STANDARD}:{_PACKAGE_VERSION}", namespace="framework_package"
+  )
+  conn.execute(
+    text("DELETE FROM public.framework_packages WHERE id = :id"), {"id": fpid}
+  )
+
+  # Re-narrow the vocabulary — fails if 'metric' FactSets or 'Derive'
+  # rules remain outside the deleted package (tenant-authored), which is
+  # data the operator must triage first.
+  _narrow(conn, "public")
+  for_each_tenant_schema(conn, _narrow)

--- a/robosystems/arelle/context.py
+++ b/robosystems/arelle/context.py
@@ -71,6 +71,10 @@ CANONICAL_CONTEXT: dict = {
   # rs-gaap-reporting-styles — declares Style entities that compose specific
   # Disclosures for a vertical / filer profile.
   "styles": "https://robosystems.ai/taxonomy/rs-gaap/reporting-styles/v1/",
+  # rs-metric — the library metric catalog (Key Financial Metrics).
+  # Each metric is a qname-addressable concept plus a Derive rule that
+  # computes it from rs-gaap anchor facts.
+  "rs-metric": "https://robosystems.ai/taxonomy/rs-gaap/metrics/v1/",
   "ifrs": "http://xbrl.ifrs.org/taxonomy/",
   "dei": "http://xbrl.sec.gov/dei/",
   # Seattle Method conceptual-model role URIs (Charlie's CM namespace)

--- a/robosystems/config/env.py
+++ b/robosystems/config/env.py
@@ -607,6 +607,21 @@ class EnvConfig:
     "SEMANTIC_MEMORY_ENABLED",
     get_parameter_value("SEMANTIC_MEMORY_ENABLED", "false").lower() == "true",
   )
+  # Gates tenant authoring of framework-shaped taxonomy blocks
+  # (reporting_extension / custom_ontology) on create + update; delete stays
+  # open so gated content can always be removed. chart_of_accounts is never
+  # gated — it is the core product path. Fail-closed in prod/staging: the
+  # default is "false" there, so a missing SSM parameter cannot open the
+  # surface. Dev/test default on (the scenario demos author
+  # reporting_extension disclosure notes).
+  TAXONOMY_AUTHORING_ENABLED = get_bool_env(
+    "TAXONOMY_AUTHORING_ENABLED",
+    get_parameter_value(
+      "TAXONOMY_AUTHORING_ENABLED",
+      "false" if ENVIRONMENT in ("prod", "staging") else "true",
+    ).lower()
+    == "true",
+  )
 
   # --- OpenSearch ---
   OPENSEARCH_URL = get_str_env("OPENSEARCH_URL", "http://localhost:9200")

--- a/robosystems/db/extensions.py
+++ b/robosystems/db/extensions.py
@@ -259,7 +259,7 @@ def _widen_library_checks(conn, schema: str) -> None:
     "'quickbooks', 'xero', 'plaid', 'native', 'import', 'system', "
     # rs-gaap framework extension packages anchored to
     # sibling namespaces of rs-gaap.
-    "'disclosures', 'checklist', 'styles', "
+    "'disclosures', 'checklist', 'styles', 'rs-metric', "
     # cm — Conceptual Model framework (cm:Debit/cm:Credit posting roles),
     # tenant-copied with the default pin.
     "'cm'"

--- a/robosystems/models/api/information_block.py
+++ b/robosystems/models/api/information_block.py
@@ -1370,10 +1370,115 @@ class EvaluateRulesResponse(BaseModel):
   )
 
 
+class ComputedMetricLite(BaseModel):
+  """One metric computed by a ``compute-metrics`` run."""
+
+  rule_id: str = Field(..., description="Derive rule that produced the value.")
+  element_id: str = Field(..., description="Metric element the fact was written for.")
+  element_qname: str | None = Field(
+    None, description="Metric element qname (e.g. rs-metric:CurrentRatio)."
+  )
+  name: str = Field(..., description="Metric display name.")
+  value: float = Field(..., description="Computed value.")
+  unit: str = Field(..., description="Fact unit — 'USD' for monetary, else 'pure'.")
+  period_type: str = Field(..., description="'instant' or 'duration'.")
+
+
+class SkippedMetricLite(BaseModel):
+  """One metric a ``compute-metrics`` run could not compute.
+
+  Soft-fail by design: a missing operand fact (e.g. InterestExpense for a
+  debt-free entity) or an undefined ratio (division by zero) skips the
+  metric with a reason — it never errors the run.
+  """
+
+  rule_id: str = Field(..., description="Derive rule that was skipped.")
+  element_qname: str | None = Field(
+    None, description="Metric element qname the rule targets."
+  )
+  reason: str = Field(..., description="Why the metric was skipped.")
+  missing: list[str] = Field(
+    default_factory=list,
+    description="Operand qnames with no bound fact at the period, when applicable.",
+  )
+
+
+class ComputeMetricsRequest(BaseModel):
+  """Request body for the ``compute-metrics`` operation.
+
+  Resolves the ``Derive`` rules scoped to the metric block, binds each
+  rule's operands to the entity's most recent persisted report facts at
+  ``period_end``, evaluates, and upserts the period's standing
+  ``factset_type='metric'`` FactSet (re-running a period replaces its
+  facts). One standing FactSet per (structure, entity, period_end) — the
+  accumulating time series.
+  """
+
+  structure_id: str = Field(
+    ...,
+    description="Metric block structure (block_type='metric') to compute.",
+  )
+  period_end: date = Field(
+    ...,
+    description=(
+      "Period end to compute at. Operands bind to report facts whose "
+      "period_end matches exactly (instant balances as of this date; "
+      "durations ending on it)."
+    ),
+  )
+  period_start: date | None = Field(
+    None,
+    description=(
+      "Optional lower bound for duration-operand binding and the "
+      "standing FactSet's period_start."
+    ),
+  )
+  entity_id: str | None = Field(
+    None,
+    description=(
+      "Entity to compute for. Defaults to the graph's earliest-created "
+      "entity (the primary entity for single-entity graphs)."
+    ),
+  )
+
+  model_config = ConfigDict(
+    json_schema_extra={
+      "examples": [
+        {"structure_id": "str_key_financial_metrics", "period_end": "2026-03-31"},
+        {
+          "structure_id": "str_key_financial_metrics",
+          "period_end": "2026-03-31",
+          "period_start": "2025-04-01",
+        },
+      ]
+    }
+  )
+
+
+class ComputeMetricsResponse(BaseModel):
+  """Response for the ``compute-metrics`` operation."""
+
+  structure_id: str
+  entity_id: str
+  period_end: date
+  fact_set_id: str | None = Field(
+    None,
+    description=(
+      "Standing metric FactSet for the period — None when every metric "
+      "was skipped and no prior set existed."
+    ),
+  )
+  computed: list[ComputedMetricLite] = Field(default_factory=list)
+  skipped: list[SkippedMetricLite] = Field(default_factory=list)
+
+
 __all__ = [
   "ArtifactMechanics",
   "ArtifactResponse",
   "ClassificationLite",
+  "ComputeMetricsRequest",
+  "ComputeMetricsResponse",
+  "ComputedMetricLite",
   "ConnectionLite",
   "CreateInformationBlockRequest",
   "DeleteInformationBlockRequest",
@@ -1393,6 +1498,7 @@ __all__ = [
   "RuleTargetLite",
   "RuleVariableLite",
   "ScheduleMechanics",
+  "SkippedMetricLite",
   "StatementMechanics",
   "UpdateInformationBlockRequest",
   "ValidationLite",

--- a/robosystems/models/extensions/roboledger/fact_set.py
+++ b/robosystems/models/extensions/roboledger/fact_set.py
@@ -54,7 +54,9 @@ class FactSet(ExtensionsBase):
     CheckConstraint(
       # 'disclosure' = a standing text-block binding set: the durable
       # Document->fact bind that report builds snapshot from.
-      "factset_type IN ('report', 'schedule', 'custom', 'disclosure')",
+      # 'metric' = a standing computed-metric set: one per
+      # (structure, entity, period_end), filled by compute-metrics.
+      "factset_type IN ('report', 'schedule', 'custom', 'disclosure', 'metric')",
       name="check_fact_set_type",
     ),
   )
@@ -74,7 +76,9 @@ class FactSet(ExtensionsBase):
 
   # Kind of FactSet — 'report' for statement renderers, 'schedule' for
   # closing-entry generators, 'custom' for agent-authored derivative
-  # blocks. Enum closure enforced by the CHECK constraint above.
+  # blocks, 'disclosure' for standing text-block binds, 'metric' for
+  # standing computed-metric time series. Enum closure enforced by the
+  # CHECK constraint above.
   factset_type = Column(String, nullable=False, default="report")
 
   # Multi-tenant + cross-link fields. ``entity_id`` matches

--- a/robosystems/models/extensions/rule.py
+++ b/robosystems/models/extensions/rule.py
@@ -77,8 +77,10 @@ class Rule(ExtensionsBase):
     # over fact values. Exactly one of rule_pattern / rule_check_kind is
     # populated (see check_rule_pattern_kind_xor below).
     CheckConstraint(
+      # 'Derive' rules compute a value (compute-metrics) rather than
+      # verify one — same $Var expression grammar, evaluated for the LHS.
       "rule_pattern IS NULL OR rule_pattern IN ("
-      "'Adjustment', 'CoExists', 'EqualTo', 'Exists', 'GreaterThan', "
+      "'Adjustment', 'CoExists', 'Derive', 'EqualTo', 'Exists', 'GreaterThan', "
       "'GreaterThanOrEqualToZero', 'LessThan', 'RollForward', 'RollUp', "
       "'SumEquals', 'Variance'"
       ")",

--- a/robosystems/operations/information_block/metric.py
+++ b/robosystems/operations/information_block/metric.py
@@ -2,29 +2,41 @@
 
 Typed :class:`MetricMechanics` ships as one arm of the
 ``ArtifactMechanics`` discriminated union, and ``metric`` is registered
-as a known block type. The envelope builder reads mechanics from the
-typed ``artifact_mechanics`` column and surfaces the block as a
-placeholder with ``facts=[]``; the derivation evaluator that computes
-metric values from source-block FactSets is not yet implemented. The
-create/update/delete handlers raise :class:`NotImplementedError` via
-the registry's ``make_not_implemented_handler`` factory.
+as a known block type. The envelope builder renders the standing metric
+time series: every ``factset_type='metric'`` FactSet for the structure
+becomes one period column (they accumulate one per (entity, period_end)
+via ``compute-metrics``), and each catalog concept becomes one row with
+values aligned across the period columns. The create/update/delete
+handlers still raise :class:`NotImplementedError` via the registry's
+``make_not_implemented_handler`` factory — custom metric authoring is a
+later phase; the seeded catalog plus ``compute-metrics`` is the M-1
+surface.
 """
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from sqlalchemy import select
+
 from robosystems.models.api.information_block import (
   ArtifactResponse,
   InformationBlockEnvelope,
   InformationModelResponse,
   MetricMechanics,
+  RenderingLite,
+  RenderingPeriodLite,
+  RenderingRowLite,
+  ViewProjections,
 )
-from robosystems.models.extensions import Structure, Taxonomy
+from robosystems.models.extensions.roboledger.fact import Fact
+from robosystems.models.extensions.roboledger.fact_set import FactSet
 from robosystems.operations.information_block.envelope import (
-  build_verification_summary,
-  load_latest_fact_set_for_structure,
-  load_verification_results_for_structure,
+  association_to_connection,
+  element_to_lite,
+  fact_set_to_lite,
+  fact_to_lite,
+  load_base_envelope_atoms,
 )
 
 if TYPE_CHECKING:
@@ -35,42 +47,117 @@ METRIC_DISPLAY_NAME = "Metric"
 METRIC_CATEGORY = "Reporting"
 
 
+def _load_metric_fact_sets(
+  session: Session, structure_id: str, fact_set_id: str | None
+) -> list[FactSet]:
+  """The structure's standing metric FactSets, oldest period first.
+
+  ``fact_set_id`` pins the series to one set (the Report Block snapshot
+  path). Without a pin, every ``factset_type='metric'`` set for the
+  structure is a period column; when several sets share a period_end
+  (defensive — the compute op upserts one per (entity, period_end)),
+  the newest wins.
+  """
+  if fact_set_id is not None:
+    row = session.get(FactSet, fact_set_id)
+    return [row] if row is not None else []
+  rows = (
+    session.execute(
+      select(FactSet)
+      .where(
+        FactSet.structure_id == structure_id,
+        FactSet.factset_type == "metric",
+      )
+      .order_by(FactSet.period_end.asc(), FactSet.created_at.desc())
+    )
+    .scalars()
+    .all()
+  )
+  by_period: dict = {}
+  for fs in rows:
+    by_period.setdefault(fs.period_end, fs)
+  return list(by_period.values())
+
+
 def build_envelope(
   session: Session, structure_id: str, fact_set_id: str | None = None
 ) -> InformationBlockEnvelope | None:
-  """Reload a metric Structure and pack it into the Information Block envelope.
+  """Pack a metric Structure + its standing time series into the envelope.
 
-  Mechanics are read off the typed ``artifact_mechanics`` column;
-  ``facts`` stays empty until the derivation evaluator is implemented.
-  The envelope shape is stable so callers and UI can already render a
-  metric block as a placeholder. ``fact_set_id`` is accepted for
-  signature parity with the registry contract; metric blocks have no
-  FactSet today so the pin is a no-op.
-
-  TODO: honor ``fact_set_id`` once metric FactSets land — without the
-  pin a metric block surfaced inside a *filed* Report Block would
-  render today's evaluation rather than the snapshot reviewed at file
-  time.
+  Rendering: one period column per metric FactSet (ascending
+  ``period_end``), one row per catalog concept in presentation-arc
+  order, ``values`` aligned per column (None where a period lacks the
+  metric — e.g. InterestCoverage skipped for a debt-free year). A
+  never-computed block renders the catalog skeleton: rows with no
+  period columns.
   """
-  from sqlalchemy import select
-
-  del fact_set_id  # see TODO above; metric FactSet wiring lands later
-
-  structure = session.get(Structure, structure_id)
-  if structure is None or structure.block_type != METRIC_BLOCK_TYPE:
+  atoms = load_base_envelope_atoms(
+    session,
+    structure_id,
+    expected_block_type=METRIC_BLOCK_TYPE,
+    fact_set_id=fact_set_id,
+  )
+  if atoms is None:
     return None
+  structure = atoms.structure
+
+  fact_sets = _load_metric_fact_sets(session, structure_id, fact_set_id)
+
+  facts: list[Fact] = []
+  if fact_sets:
+    facts = list(
+      session.execute(
+        select(Fact).where(Fact.fact_set_id.in_([fs.id for fs in fact_sets]))
+      )
+      .scalars()
+      .all()
+    )
+  value_by_set_element = {(f.fact_set_id, f.element_id): f.value for f in facts}
+
+  elements_by_id = {e.id: e for e in atoms.elements}
+
+  # Catalog rows in presentation-arc order (dedupe preserving order).
+  ordered_arcs = sorted(
+    (a for a in atoms.associations if a.to_element_id is not None),
+    key=lambda a: a.order_value if a.order_value is not None else float("inf"),
+  )
+  concept_ids: list[str] = []
+  for arc in ordered_arcs:
+    if arc.to_element_id not in concept_ids:
+      concept_ids.append(arc.to_element_id)
+
+  rows: list[RenderingRowLite] = []
+  for element_id in concept_ids:
+    element = elements_by_id.get(element_id)
+    rows.append(
+      RenderingRowLite(
+        element_id=element_id,
+        element_qname=element.qname if element else None,
+        element_name=element.name if element else element_id,
+        balance_type=element.balance_type if element else None,
+        values=[value_by_set_element.get((fs.id, element_id)) for fs in fact_sets],
+      )
+    )
+
+  rendering = RenderingLite(
+    rows=rows,
+    periods=[
+      RenderingPeriodLite(
+        start=fs.period_start if fs.period_start is not None else fs.period_end,
+        end=fs.period_end,
+      )
+      for fs in fact_sets
+    ],
+    validation=None,
+    unmapped_count=0,
+  )
 
   if structure.artifact_mechanics:
     mechanics = MetricMechanics.model_validate(structure.artifact_mechanics)
   else:
     mechanics = MetricMechanics(kind="metric")
 
-  taxonomy_name = session.execute(
-    select(Taxonomy.name).where(Taxonomy.id == structure.taxonomy_id)
-  ).scalar()
-
-  fact_set = load_latest_fact_set_for_structure(session, structure_id)
-  verification_results = load_verification_results_for_structure(session, structure_id)
+  latest_lite = fact_set_to_lite(fact_sets[-1]) if fact_sets else atoms.fact_set
 
   return InformationBlockEnvelope(
     id=structure.id,
@@ -79,7 +166,7 @@ def build_envelope(
     display_name=METRIC_DISPLAY_NAME,
     category=METRIC_CATEGORY,
     taxonomy_id=structure.taxonomy_id,
-    taxonomy_name=taxonomy_name,
+    taxonomy_name=atoms.taxonomy_name,
     information_model=InformationModelResponse(
       concept_arrangement=structure.concept_arrangement or "arithmetic",
       member_arrangement=structure.member_arrangement,
@@ -90,14 +177,17 @@ def build_envelope(
       template=None,
       mechanics=mechanics,
     ),
-    fact_set=fact_set,
-    verification_results=verification_results,
-    # Metric blocks don't load rules (no rules on the envelope yet) and have
-    # no verification results until the derivation evaluator lands, so this
-    # resolves to None today; pass [] rather than skip for shape parity. If
-    # results ever appear before rules are wired here, they'd bucket under
-    # "Uncategorized" (the rule-join fallback) — correct, not a bug.
-    verification_summary=build_verification_summary(verification_results, []),
+    elements=[element_to_lite(e) for e in atoms.elements],
+    connections=[
+      association_to_connection(a, atoms.classifications_by_assoc.get(a.id, []))
+      for a in atoms.associations
+    ],
+    facts=[fact_to_lite(f, elements_by_id) for f in facts],
+    rules=atoms.rules,
+    fact_set=latest_lite,
+    verification_results=atoms.verification_results,
+    verification_summary=atoms.verification_summary,
+    view=ViewProjections(rendering=rendering),
   )
 
 

--- a/robosystems/operations/information_block/metrics.py
+++ b/robosystems/operations/information_block/metrics.py
@@ -1,0 +1,365 @@
+"""compute-metrics — evaluate Derive rules into a standing metric FactSet.
+
+The metric block's compute path (Metrics M-1). ``Derive`` rules carry the
+same ``$Var`` expression grammar as verification rules, but are evaluated
+for a VALUE: the LHS names the metric element being computed, the RHS
+operands bind to the entity's persisted report facts at the requested
+``period_end``, and the result is written as a Numeric fact in a standing
+``factset_type='metric'`` FactSet — one per (structure, entity,
+period_end), so successive runs accumulate the time series and re-running
+a period replaces its values.
+
+Soft-fail per metric: a missing operand fact (InterestExpense for a
+debt-free entity), an unresolvable qname, or an undefined ratio
+(division by zero) skips that metric with a reason — one broken metric
+never aborts the run.
+
+Operands bind against ``factset_type='report'`` facts only, so a metric
+referencing another metric simply skips in M-1 — composition (DuPont)
+is the M-2 DAG feature.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+
+from sqlalchemy import or_, select, text
+from sqlalchemy.orm import Session
+
+from robosystems.models.api.fact_provenance import DerivedProvenance
+from robosystems.models.api.information_block import (
+  ComputedMetricLite,
+  ComputeMetricsRequest,
+  ComputeMetricsResponse,
+  SkippedMetricLite,
+)
+from robosystems.models.extensions import (
+  Association,
+  Element,
+  Rule,
+  Structure,
+)
+from robosystems.models.extensions.roboledger.fact import Fact
+from robosystems.models.extensions.roboledger.fact_set import FactSet
+from robosystems.operations.information_block.registry import METRIC_BLOCK_TYPE
+from robosystems.operations.information_block.rules.expressions import (
+  InvalidRuleExpression,
+  evaluate_derivation,
+  lhs_variable_names,
+  parse_arithmetic_expression,
+)
+from robosystems.operations.roboledger.fact_set import create_fact_set
+from robosystems.utils.ulid import generate_prefixed_ulid
+
+
+@dataclass(frozen=True)
+class _BoundOperand:
+  value: float
+  period_start: date | None
+
+
+def _default_entity_id(session: Session) -> str:
+  """Earliest-created entity — the primary entity for single-entity graphs.
+
+  Same convention as ``reports._get_entity_id`` / the text-block bind.
+  """
+  row = session.execute(
+    text("SELECT id FROM entities ORDER BY created_at ASC LIMIT 1")
+  ).fetchone()
+  if row is None:
+    raise ValueError("No entity found. Import data before computing metrics.")
+  return row.id
+
+
+def _bind_operand(
+  session: Session,
+  *,
+  element_id: str,
+  entity_id: str,
+  period_end: date,
+  period_start: date | None,
+) -> _BoundOperand | None:
+  """Most recent persisted report fact for one operand at ``period_end``.
+
+  Joins Fact → FactSet on ``factset_type='report'`` (the persisted
+  statement facts, including calc-DAG subtotals) scoped to the entity.
+  ``period_end`` must match exactly — instant balances as of that date,
+  durations ending on it. Newest report wins when several cover the
+  period; among same-set candidates the longest window wins (FY over Q4
+  when both end on the date).
+  """
+  stmt = (
+    select(Fact.value, Fact.period_start)
+    .join(FactSet, Fact.fact_set_id == FactSet.id)
+    .where(
+      FactSet.factset_type == "report",
+      Fact.entity_id == entity_id,
+      Fact.element_id == element_id,
+      Fact.period_end == period_end,
+      Fact.fact_scope == "in_scope",
+      Fact.value.is_not(None),
+    )
+    .order_by(
+      FactSet.created_at.desc(),
+      Fact.period_start.asc().nulls_first(),
+    )
+    .limit(1)
+  )
+  if period_start is not None:
+    stmt = stmt.where(
+      or_(Fact.period_start.is_(None), Fact.period_start >= period_start)
+    )
+  row = session.execute(stmt).first()
+  if row is None:
+    return None
+  return _BoundOperand(value=float(row[0]), period_start=row[1])
+
+
+def _load_derive_rules(
+  session: Session, structure_id: str, element_ids: list[str]
+) -> list[Rule]:
+  """Derive rules scoped to the structure or its elements."""
+  conditions = [Rule.target_structure_id == structure_id]
+  if element_ids:
+    conditions.append(Rule.target_element_id.in_(element_ids))
+  return list(
+    session.execute(
+      select(Rule)
+      .where(or_(*conditions), Rule.rule_pattern == "Derive")
+      .order_by(Rule.id)
+    )
+    .scalars()
+    .all()
+  )
+
+
+def cmd_compute_metrics(
+  session: Session,
+  body: ComputeMetricsRequest,
+  created_by: str,
+) -> ComputeMetricsResponse:
+  """Compute every Derive rule on a metric block for one period.
+
+  Upserts the period's standing metric FactSet: found → all its facts are
+  deleted and provenance is re-stamped (re-bind drift semantics); absent →
+  created via the blessed ``create_fact_set`` path with
+  ``DerivedProvenance``. ``session.flush()`` before returning; the
+  OperationSpec wrapper owns the commit.
+  """
+  structure = session.get(Structure, body.structure_id)
+  if structure is None:
+    raise ValueError(f"Structure not found: {body.structure_id}")
+  if structure.block_type != METRIC_BLOCK_TYPE:
+    raise ValueError(
+      f"compute-metrics targets a block_type='metric' structure; "
+      f"{body.structure_id!r} is {structure.block_type!r}"
+    )
+
+  entity_id = body.entity_id or _default_entity_id(session)
+
+  associations = (
+    session.execute(
+      select(Association).where(Association.structure_id == body.structure_id)
+    )
+    .scalars()
+    .all()
+  )
+  element_ids = {
+    x
+    for x in (
+      {a.from_element_id for a in associations}
+      | {a.to_element_id for a in associations}
+    )
+    if x is not None
+  }
+  # Presentation order of the catalog — computed facts and response rows
+  # follow it so the envelope renders in arc order.
+  order_by_element: dict[str, float] = {}
+  for a in associations:
+    if a.to_element_id is not None and a.order_value is not None:
+      order_by_element.setdefault(a.to_element_id, float(a.order_value))
+
+  rules = _load_derive_rules(session, body.structure_id, list(element_ids))
+  rules.sort(
+    key=lambda r: order_by_element.get(r.target_element_id or "", float("inf"))
+  )
+
+  computed: list[ComputedMetricLite] = []
+  skipped: list[SkippedMetricLite] = []
+  pending_facts: list[dict] = []
+
+  qname_cache: dict[str, Element | None] = {}
+
+  def _element_by_qname(qname: str) -> Element | None:
+    if qname not in qname_cache:
+      qname_cache[qname] = session.execute(
+        select(Element).where(Element.qname == qname).limit(1)
+      ).scalar_one_or_none()
+    return qname_cache[qname]
+
+  for rule in rules:
+    target = (
+      session.get(Element, rule.target_element_id) if rule.target_element_id else None
+    )
+    target_qname = target.qname if target is not None else None
+
+    def _skip(reason: str, missing: list[str] | None = None) -> None:
+      skipped.append(
+        SkippedMetricLite(
+          rule_id=rule.id,
+          element_qname=target_qname,
+          reason=reason,
+          missing=missing or [],
+        )
+      )
+
+    if target is None:
+      _skip("rule has no resolvable target element")
+      continue
+
+    variables = rule.rule_variables or []
+    names = [v.get("variable_name") for v in variables]
+    if not all(isinstance(n, str) and n for n in names):
+      _skip("rule variables are missing variable_name entries")
+      continue
+    qname_by_name = {v["variable_name"]: v.get("variable_qname") for v in variables}
+
+    expression = rule.rule_expression if isinstance(rule.rule_expression, str) else ""
+    try:
+      parsed = parse_arithmetic_expression(expression, names)
+      lhs_names = lhs_variable_names(parsed)
+    except InvalidRuleExpression as exc:
+      _skip(f"expression error: {exc}")
+      continue
+    if len(lhs_names) != 1:
+      _skip(f"expected a single LHS metric variable, got {lhs_names!r}")
+      continue
+
+    operand_names = [n for n in names if n != lhs_names[0]]
+    values: dict[str, float] = {}
+    missing: list[str] = []
+    duration_start: date | None = None
+    for name in operand_names:
+      qname = qname_by_name.get(name)
+      operand_element = _element_by_qname(qname) if qname else None
+      if operand_element is None:
+        missing.append(qname or name)
+        continue
+      bound = _bind_operand(
+        session,
+        element_id=operand_element.id,
+        entity_id=entity_id,
+        period_end=body.period_end,
+        period_start=body.period_start,
+      )
+      if bound is None:
+        missing.append(qname or name)
+        continue
+      values[name] = bound.value
+      if bound.period_start is not None and duration_start is None:
+        duration_start = bound.period_start
+
+    if missing:
+      _skip("no report fact bound for operand(s)", missing=missing)
+      continue
+
+    try:
+      value = evaluate_derivation(parsed, values)
+    except InvalidRuleExpression as exc:
+      _skip(f"evaluation error: {exc}")
+      continue
+
+    unit = "USD" if target.is_monetary else "pure"
+    period_type = target.period_type or "instant"
+    fact_period_start = None
+    if period_type == "duration":
+      fact_period_start = body.period_start or duration_start
+
+    pending_facts.append(
+      {
+        "element_id": target.id,
+        "value": value,
+        "period_start": fact_period_start,
+        "period_type": period_type,
+        "unit": unit,
+      }
+    )
+    computed.append(
+      ComputedMetricLite(
+        rule_id=rule.id,
+        element_id=target.id,
+        element_qname=target_qname,
+        name=target.name,
+        value=value,
+        unit=unit,
+        period_type=period_type,
+      )
+    )
+
+  provenance = DerivedProvenance(computation="compute-metrics", source_fact_ids=[])
+
+  standing = session.execute(
+    select(FactSet)
+    .where(
+      FactSet.structure_id == body.structure_id,
+      FactSet.factset_type == "metric",
+      FactSet.entity_id == entity_id,
+      FactSet.period_end == body.period_end,
+    )
+    .order_by(FactSet.created_at.desc())
+    .limit(1)
+  ).scalar_one_or_none()
+
+  if standing is None and pending_facts:
+    standing = create_fact_set(
+      session,
+      structure_id=body.structure_id,
+      period_start=body.period_start,
+      period_end=body.period_end,
+      factset_type="metric",
+      entity_id=entity_id,
+      provenance=provenance,
+      created_by=created_by,
+    )
+    session.flush()
+  elif standing is not None:
+    # Full replace — the period's values are re-derived state.
+    for fact in (
+      session.execute(select(Fact).where(Fact.fact_set_id == standing.id))
+      .scalars()
+      .all()
+    ):
+      session.delete(fact)
+    standing.provenance = provenance.model_dump(mode="json")
+
+  if standing is not None:
+    for pf in pending_facts:
+      session.add(
+        Fact(
+          id=generate_prefixed_ulid("fact"),
+          element_id=pf["element_id"],
+          value=pf["value"],
+          fact_type="Numeric",
+          period_start=pf["period_start"],
+          period_end=body.period_end,
+          period_type=pf["period_type"],
+          unit=pf["unit"],
+          entity_id=entity_id,
+          structure_id=body.structure_id,
+          fact_set_id=standing.id,
+        )
+      )
+    session.flush()
+
+  return ComputeMetricsResponse(
+    structure_id=body.structure_id,
+    entity_id=entity_id,
+    period_end=body.period_end,
+    fact_set_id=standing.id if standing is not None else None,
+    computed=computed,
+    skipped=skipped,
+  )
+
+
+__all__ = ["cmd_compute_metrics"]

--- a/robosystems/operations/information_block/rules/expressions.py
+++ b/robosystems/operations/information_block/rules/expressions.py
@@ -206,6 +206,28 @@ def evaluate_arithmetic(parsed: ParsedExpression, values: dict[str, float]) -> f
   return _eval_arith(parsed.tree.body, mapped)
 
 
+def evaluate_derivation(parsed: ParsedExpression, values: dict[str, float]) -> float:
+  """Evaluate the RHS of a ``$Target = (expression)`` rule to a float.
+
+  The compute path for ``Derive`` rules (compute-metrics): the LHS names
+  the element being computed, so only the RHS operands need bound values
+  — pass ``values`` keyed by RHS variable name. Raises
+  :class:`InvalidRuleExpression` for a non-equality expression, a missing
+  or null operand, or division by zero.
+  """
+  compare = parsed.tree.body
+  if (
+    not isinstance(compare, ast.Compare)
+    or len(compare.ops) != 1
+    or not isinstance(compare.ops[0], ast.Eq)
+  ):
+    raise InvalidRuleExpression(
+      f"derivation expects a single LHS = RHS expression, got: {ast.dump(compare)}"
+    )
+  mapped = {f"_var_{name}": value for name, value in values.items()}
+  return _eval_arith(compare.comparators[0], mapped)
+
+
 def build_rollup_expression(parent_name: str, children: list[tuple[str, float]]) -> str:
   """``$Parent = ($childA + $childB - $childC ...)``.
 
@@ -240,6 +262,7 @@ __all__ = [
   "ParsedExpression",
   "build_rollup_expression",
   "evaluate_arithmetic",
+  "evaluate_derivation",
   "evaluate_equality",
   "lhs_variable_names",
   "parse_arithmetic_expression",

--- a/robosystems/operations/taxonomy_block/commands.py
+++ b/robosystems/operations/taxonomy_block/commands.py
@@ -10,13 +10,20 @@ sub-phases add reporting_extension / custom_ontology / reporting_standard).
 These are mounted as the ``create-taxonomy-block`` /
 ``update-taxonomy-block`` / ``delete-taxonomy-block`` CQRS operations
 in ``routers/extensions/roboledger/operations.py``. The REST registrar's
-error_map routes ``ValueError → 422`` and ``NotImplementedError → 501``.
+error_map routes ``ValueError → 422``, ``NotImplementedError → 501``,
+and ``TaxonomyAuthoringDisabledError → 403``.
+
+The one policy check that lives here (rather than in a handler) is the
+``TAXONOMY_AUTHORING_ENABLED`` environment gate: it must sit at the
+dispatch chokepoint so a single check covers both the REST operations
+and the auto-generated MCP tools, which call these same functions.
 """
 
 from __future__ import annotations
 
 from sqlalchemy.orm import Session
 
+from robosystems.config import env
 from robosystems.models.api.taxonomy_block import (
   CreateTaxonomyBlockRequest,
   DeleteTaxonomyBlockRequest,
@@ -25,6 +32,29 @@ from robosystems.models.api.taxonomy_block import (
   UpdateTaxonomyBlockRequest,
 )
 from robosystems.operations.taxonomy_block import registry as registry_module
+
+# Framework-shaped block types: authoring these creates tenant-owned taxonomy
+# content that anchors into the library and must survive future library
+# evolution. chart_of_accounts is the core product path and is never gated;
+# schedule is closing-book machinery; reporting_standard is read-only.
+GATED_TAXONOMY_TYPES = frozenset({"reporting_extension", "custom_ontology"})
+
+
+class TaxonomyAuthoringDisabledError(PermissionError):
+  """Framework authoring is disabled in this environment.
+
+  Raised on create/update of a gated taxonomy type when
+  ``TAXONOMY_AUTHORING_ENABLED`` is off. Delete is deliberately not
+  gated — removing gated content must always be possible.
+  """
+
+
+def _check_authoring_enabled(taxonomy_type: str) -> None:
+  if taxonomy_type in GATED_TAXONOMY_TYPES and not env.TAXONOMY_AUTHORING_ENABLED:
+    raise TaxonomyAuthoringDisabledError(
+      f"authoring {taxonomy_type!r} taxonomy blocks is disabled in this "
+      f"environment (TAXONOMY_AUTHORING_ENABLED is off)"
+    )
 
 
 def _get_entry_or_422(taxonomy_type: str):
@@ -48,6 +78,7 @@ def create_taxonomy_block(
   for reporting_extension) has already run by the time we get here.
   """
   entry = _get_entry_or_422(body.taxonomy_type)
+  _check_authoring_enabled(body.taxonomy_type)
   taxonomy_id = entry.dispatch_create(session, body, created_by)
 
   envelope = entry.dispatch_build_envelope(session, taxonomy_id)
@@ -78,6 +109,7 @@ def update_taxonomy_block(
     raise ValueError(f"taxonomy_id {body.taxonomy_id!r} not found")
 
   entry = _get_entry_or_422(taxonomy.taxonomy_type)
+  _check_authoring_enabled(taxonomy.taxonomy_type)
   taxonomy_id = entry.dispatch_update(session, body, created_by)
 
   envelope = entry.dispatch_build_envelope(session, taxonomy_id)
@@ -115,6 +147,8 @@ def delete_taxonomy_block(
 
 
 __all__ = [
+  "GATED_TAXONOMY_TYPES",
+  "TaxonomyAuthoringDisabledError",
   "create_taxonomy_block",
   "delete_taxonomy_block",
   "update_taxonomy_block",

--- a/robosystems/operations/taxonomy_block/library_creator.py
+++ b/robosystems/operations/taxonomy_block/library_creator.py
@@ -73,6 +73,7 @@ _ALLOWED_SOURCES = frozenset(
     "disclosures",
     "checklist",
     "styles",
+    "rs-metric",
     # cm — Conceptual Model framework (cm:Debit/cm:Credit posting roles).
     "cm",
   }

--- a/robosystems/routers/extensions/roboledger/operations.py
+++ b/robosystems/routers/extensions/roboledger/operations.py
@@ -173,6 +173,8 @@ from robosystems.models.api.extensions.text_blocks import (
   BindTextBlockResponse,
 )
 from robosystems.models.api.information_block import (
+  ComputeMetricsRequest,
+  ComputeMetricsResponse,
   CreateInformationBlockRequest,
   DeleteInformationBlockRequest,
   DeleteInformationBlockResponse,
@@ -233,6 +235,9 @@ from robosystems.operations.information_block.commands import (
 )
 from robosystems.operations.information_block.commands import (
   update_information_block as cmd_update_information_block,
+)
+from robosystems.operations.information_block.metrics import (
+  cmd_compute_metrics,
 )
 from robosystems.operations.information_block.rules.commands import (
   cmd_evaluate_rules,
@@ -401,6 +406,9 @@ from robosystems.operations.roboledger.fiscal_calendar.close_service import (
 from robosystems.operations.roboledger.fiscal_calendar.service import (
   CalendarAlreadyInitializedError,
   InvalidCloseTargetError,
+)
+from robosystems.operations.taxonomy_block.commands import (
+  TaxonomyAuthoringDisabledError,
 )
 from robosystems.operations.taxonomy_block.commands import (
   create_taxonomy_block as cmd_create_taxonomy_block,
@@ -836,8 +844,11 @@ create_taxonomy_block_op = _registrar.register(
       "Create a taxonomy block atomically: one envelope carrying the "
       "taxonomy row plus its structures, elements, associations, and "
       "rules. Dispatches by `taxonomy_type` — `chart_of_accounts` "
-      "(declarative tenant CoA) is supported; `reporting_extension` / "
-      "`custom_ontology` / `reporting_standard` are not yet implemented. "
+      "(declarative tenant CoA), `reporting_extension`, and "
+      "`custom_ontology` are supported; `reporting_standard` is "
+      "library-origin (501). `reporting_extension` / `custom_ontology` "
+      "authoring may be disabled per environment "
+      "(TAXONOMY_AUTHORING_ENABLED) — disabled surfaces 403. "
       "NOT the path for a functional close schedule: a structure with "
       "block_type='schedule' here is a bare ontology row with none of the "
       "schedule machinery (per-period facts, schedule_entry_due "
@@ -848,6 +859,7 @@ create_taxonomy_block_op = _registrar.register(
     request_model=CreateTaxonomyBlockRequest,
     result_type=TaxonomyBlockEnvelope,
     error_map={
+      TaxonomyAuthoringDisabledError: 403,
       ValueError: 422,
       NotImplementedError: 501,
     },
@@ -863,12 +875,16 @@ update_taxonomy_block_op = _registrar.register(
       "Incrementally mutate a taxonomy block via typed delta lists "
       "(elements/structures/associations/rules to add, update, remove). "
       "Dispatches by the target taxonomy's stored `taxonomy_type`. "
-      "Library-origin block types (`reporting_standard`) surface 501."
+      "Library-origin block types (`reporting_standard`) surface 501. "
+      "`reporting_extension` / `custom_ontology` authoring may be "
+      "disabled per environment (TAXONOMY_AUTHORING_ENABLED) — "
+      "disabled surfaces 403."
     ),
     command=cmd_update_taxonomy_block,
     request_model=UpdateTaxonomyBlockRequest,
     result_type=TaxonomyBlockEnvelope,
     error_map={
+      TaxonomyAuthoringDisabledError: 403,
       ValueError: 422,
       NotImplementedError: 501,
     },
@@ -1168,6 +1184,29 @@ evaluate_rules_op = _registrar.register(
     request_model=EvaluateRulesRequest,
     result_type=EvaluateRulesResponse,
     error_map={ValueError: 422},
+    requires_created_by=True,
+  )
+)
+
+compute_metrics_op = _registrar.register(
+  OperationSpec(
+    name="compute-metrics",
+    summary="Compute Metrics for a Metric Block",
+    description=(
+      "Resolves the Derive rules scoped to a metric block "
+      "(block_type='metric'), binds each rule's operands to the entity's "
+      "most recent persisted report facts at period_end, evaluates, and "
+      "upserts the period's standing factset_type='metric' FactSet — one "
+      "per (structure, entity, period_end), so successive runs accumulate "
+      "the time series and re-running a period replaces its values. "
+      "Metrics with missing operands or undefined ratios are skipped "
+      "with a reason, never errored."
+    ),
+    command=cmd_compute_metrics,
+    request_model=ComputeMetricsRequest,
+    result_type=ComputeMetricsResponse,
+    error_map={ValueError: 422},
+    mark_stale_reason="metrics_computed",
     requires_created_by=True,
   )
 )

--- a/robosystems/taxonomy/loader.py
+++ b/robosystems/taxonomy/loader.py
@@ -65,6 +65,7 @@ RULE_PATTERN_VALUES: frozenset[str] = frozenset(
   {
     "Adjustment",
     "CoExists",
+    "Derive",
     "EqualTo",
     "Exists",
     "GreaterThan",

--- a/tests/operations/information_block/rules/test_expressions.py
+++ b/tests/operations/information_block/rules/test_expressions.py
@@ -7,6 +7,7 @@ import pytest
 from robosystems.operations.information_block.rules.expressions import (
   EQUALITY_TOLERANCE,
   InvalidRuleExpression,
+  evaluate_derivation,
   evaluate_equality,
   lhs_variable_names,
   parse_arithmetic_expression,
@@ -170,3 +171,43 @@ class TestBuildRollupExpression:
     )
     parsed = parse_arithmetic_expression(expr, names)
     assert lhs_variable_names(parsed) == ["Total"]
+
+
+class TestEvaluateDerivation:
+  """The compute path for Derive rules — RHS evaluated to a value."""
+
+  def test_evaluates_rhs_with_operand_values_only(self) -> None:
+    parsed = parse_arithmetic_expression(
+      "$CurrentRatio = ($AssetsCurrent / $LiabilitiesCurrent)",
+      ["CurrentRatio", "AssetsCurrent", "LiabilitiesCurrent"],
+    )
+    value = evaluate_derivation(
+      parsed, {"AssetsCurrent": 100.0, "LiabilitiesCurrent": 40.0}
+    )
+    assert value == pytest.approx(2.5)
+
+  def test_nested_subtraction_and_division(self) -> None:
+    parsed = parse_arithmetic_expression(
+      "$QuickRatio = (($AssetsCurrent - $Inventory) / $LiabilitiesCurrent)",
+      ["QuickRatio", "AssetsCurrent", "Inventory", "LiabilitiesCurrent"],
+    )
+    value = evaluate_derivation(
+      parsed,
+      {"AssetsCurrent": 100.0, "Inventory": 20.0, "LiabilitiesCurrent": 40.0},
+    )
+    assert value == pytest.approx(2.0)
+
+  def test_division_by_zero_raises(self) -> None:
+    parsed = parse_arithmetic_expression("$Ratio = ($A / $B)", ["Ratio", "A", "B"])
+    with pytest.raises(InvalidRuleExpression, match="division by zero"):
+      evaluate_derivation(parsed, {"A": 1.0, "B": 0.0})
+
+  def test_missing_operand_raises(self) -> None:
+    parsed = parse_arithmetic_expression("$Ratio = ($A / $B)", ["Ratio", "A", "B"])
+    with pytest.raises(InvalidRuleExpression, match="unbound name"):
+      evaluate_derivation(parsed, {"A": 1.0})
+
+  def test_non_equality_expression_raises(self) -> None:
+    parsed = parse_arithmetic_expression("$A + $B", ["A", "B"])
+    with pytest.raises(InvalidRuleExpression, match="derivation expects"):
+      evaluate_derivation(parsed, {"A": 1.0, "B": 2.0})

--- a/tests/operations/information_block/test_metric_handlers.py
+++ b/tests/operations/information_block/test_metric_handlers.py
@@ -1,21 +1,118 @@
-"""Tests for metric block handler — build_envelope distinct paths."""
+"""Tests for the metric block envelope builder — the standing time series."""
 
 from __future__ import annotations
 
+from datetime import date
+from types import SimpleNamespace
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
+from robosystems.models.api.information_block import FactSetLite
 from robosystems.operations.information_block import metric as metric_handlers
+from robosystems.operations.information_block.envelope import BaseEnvelopeAtoms
 
 
-def _exec_result(
-  *, scalars_all: list[Any] | None = None, scalar: Any = None
-) -> MagicMock:
+def _scalars(items: list[Any]) -> MagicMock:
   result = MagicMock()
-  if scalars_all is not None:
-    result.scalars.return_value.all.return_value = scalars_all
-  result.scalar.return_value = scalar
+  result.scalars.return_value.all.return_value = items
   return result
+
+
+def _structure(*, mechanics: dict | None = None) -> MagicMock:
+  s = MagicMock()
+  s.id = "str_metrics"
+  s.block_type = "metric"
+  s.name = "Key Financial Metrics"
+  s.description = None
+  s.taxonomy_id = "tax_lib"
+  s.artifact_mechanics = mechanics
+  s.concept_arrangement = "arithmetic"
+  s.member_arrangement = None
+  s.renderer_note = None
+  return s
+
+
+def _element(element_id: str, qname: str, name: str) -> SimpleNamespace:
+  return SimpleNamespace(
+    id=element_id,
+    qname=qname,
+    name=name,
+    code=None,
+    element_type="concept",
+    is_abstract=False,
+    is_monetary=False,
+    balance_type="debit",
+    period_type="instant",
+  )
+
+
+EL_WC = _element("el_wc", "rs-metric:WorkingCapital", "Working Capital")
+EL_CR = _element("el_cr", "rs-metric:CurrentRatio", "Current Ratio")
+
+
+def _arc(to_element_id: str, order: float) -> SimpleNamespace:
+  return SimpleNamespace(
+    id=f"arc_{to_element_id}",
+    from_element_id="el_kfm",
+    to_element_id=to_element_id,
+    order_value=order,
+    association_type="presentation",
+    arcrole="http://www.xbrl.org/2003/arcrole/parent-child",
+    weight=None,
+  )
+
+
+def _fact_set(fs_id: str, period_end: date) -> SimpleNamespace:
+  return SimpleNamespace(
+    id=fs_id,
+    structure_id="str_metrics",
+    period_start=None,
+    period_end=period_end,
+    factset_type="metric",
+    entity_id="ent_1",
+    report_id=None,
+    provenance={"origin": "derived", "computation": "compute-metrics"},
+  )
+
+
+def _fact(
+  fact_id: str, element_id: str, value: float, fs_id: str, period_end: date
+) -> SimpleNamespace:
+  return SimpleNamespace(
+    id=fact_id,
+    element_id=element_id,
+    value=value,
+    string_value=None,
+    fact_type="Numeric",
+    content_type=None,
+    period_start=None,
+    period_end=period_end,
+    period_type="instant",
+    unit="pure",
+    fact_scope="in_scope",
+    fact_set_id=fs_id,
+  )
+
+
+def _atoms(
+  structure: MagicMock, *, associations: list | None = None
+) -> BaseEnvelopeAtoms:
+  return BaseEnvelopeAtoms(
+    structure=structure,
+    taxonomy_name="rs-metric",
+    associations=associations if associations is not None else [],
+    elements=[EL_WC, EL_CR],  # type: ignore[list-item]
+    element_ids=["el_wc", "el_cr"],
+    rules=[],
+    classifications_by_assoc={},
+    fact_set=None,
+    verification_results=[],
+    verification_summary=None,
+  )
+
+
+P1 = date(2025, 12, 31)
+P2 = date(2026, 12, 31)
 
 
 class TestBuildEnvelope:
@@ -31,65 +128,142 @@ class TestBuildEnvelope:
     session.get.return_value = structure
     assert metric_handlers.build_envelope(session, "struct_other") is None
 
-  def test_packs_mechanics_from_artifact_mechanics_column(self) -> None:
+  def test_multi_period_rendering_aligns_values_per_column(self) -> None:
+    structure = _structure()
+    arcs = [_arc("el_wc", 1.0), _arc("el_cr", 2.0)]
+    fs1, fs2 = _fact_set("fs1", P1), _fact_set("fs2", P2)
+    facts = [
+      _fact("f1", "el_wc", 55.0, "fs1", P1),
+      _fact("f2", "el_wc", 60.0, "fs2", P2),
+      # CurrentRatio only computed for the second period.
+      _fact("f3", "el_cr", 2.5, "fs2", P2),
+    ]
     session = MagicMock()
-    structure = MagicMock()
-    structure.id = "struct_metric_1"
-    structure.block_type = "metric"
-    structure.name = "Debt-to-Equity Ratio"
-    structure.description = "D/E covenant test"
-    structure.taxonomy_id = "tax_01"
-    structure.concept_arrangement = "arithmetic"
-    structure.member_arrangement = None
-    structure.renderer_note = None
-    structure.artifact_mechanics = {
-      "kind": "metric",
-      "source_block_ids": ["struct_bs"],
-      "derivation_type": "ratio",
-      "expression": "$TotalDebt / $TotalEquity",
-    }
-    session.get.return_value = structure
     session.execute.side_effect = [
-      _exec_result(scalar="US GAAP"),  # taxonomy name
-      _exec_result(scalar=None),  # latest fact set → None
-      _exec_result(scalars_all=[]),  # verification results
+      _scalars([fs1, fs2]),  # metric FactSets, period asc
+      _scalars(facts),
     ]
 
-    envelope = metric_handlers.build_envelope(session, "struct_metric_1")
+    with patch.object(
+      metric_handlers,
+      "load_base_envelope_atoms",
+      return_value=_atoms(structure, associations=arcs),
+    ):
+      envelope = metric_handlers.build_envelope(session, "str_metrics")
+
     assert envelope is not None
-    assert envelope.id == "struct_metric_1"
-    assert envelope.block_type == "metric"
-    assert envelope.name == "Debt-to-Equity Ratio"
+    rendering = envelope.view.rendering
+    assert [p.end for p in rendering.periods] == [P1, P2]
+    assert [r.element_qname for r in rendering.rows] == [
+      "rs-metric:WorkingCapital",
+      "rs-metric:CurrentRatio",
+    ]
+    assert rendering.rows[0].values == [55.0, 60.0]
+    assert rendering.rows[1].values == [None, 2.5]
+    assert len(envelope.facts) == 3
+    assert envelope.fact_set is not None
+    assert envelope.fact_set.id == "fs2"  # latest period is the envelope's set
+
+  def test_never_computed_block_renders_catalog_skeleton(self) -> None:
+    structure = _structure()
+    arcs = [_arc("el_wc", 1.0), _arc("el_cr", 2.0)]
+    session = MagicMock()
+    session.execute.side_effect = [_scalars([])]  # no metric FactSets
+
+    with patch.object(
+      metric_handlers,
+      "load_base_envelope_atoms",
+      return_value=_atoms(structure, associations=arcs),
+    ):
+      envelope = metric_handlers.build_envelope(session, "str_metrics")
+
+    assert envelope is not None
+    rendering = envelope.view.rendering
+    assert rendering.periods == []
+    assert [r.element_name for r in rendering.rows] == [
+      "Working Capital",
+      "Current Ratio",
+    ]
+    assert all(r.values == [] for r in rendering.rows)
+    assert envelope.facts == []
+    assert envelope.fact_set is None
+
+  def test_fact_set_pin_restricts_to_one_period(self) -> None:
+    structure = _structure()
+    arcs = [_arc("el_wc", 1.0)]
+    fs2 = _fact_set("fs2", P2)
+    session = MagicMock()
+    session.get.return_value = fs2  # _load_metric_fact_sets pin path
+    session.execute.side_effect = [
+      _scalars([_fact("f2", "el_wc", 60.0, "fs2", P2)]),
+    ]
+    pinned_atoms = BaseEnvelopeAtoms(
+      structure=structure,
+      taxonomy_name="rs-metric",
+      associations=arcs,
+      elements=[EL_WC, EL_CR],  # type: ignore[list-item]
+      element_ids=["el_wc", "el_cr"],
+      rules=[],
+      classifications_by_assoc={},
+      fact_set=FactSetLite(
+        id="fs2",
+        structure_id="str_metrics",
+        period_end=P2,
+        factset_type="metric",
+        entity_id="ent_1",
+      ),
+      verification_results=[],
+      verification_summary=None,
+    )
+
+    with patch.object(
+      metric_handlers, "load_base_envelope_atoms", return_value=pinned_atoms
+    ):
+      envelope = metric_handlers.build_envelope(
+        session, "str_metrics", fact_set_id="fs2"
+      )
+
+    assert envelope is not None
+    rendering = envelope.view.rendering
+    assert [p.end for p in rendering.periods] == [P2]
+    assert rendering.rows[0].values == [60.0]
+
+  def test_mechanics_from_artifact_mechanics_column(self) -> None:
+    structure = _structure(
+      mechanics={
+        "kind": "metric",
+        "source_block_ids": ["struct_bs"],
+        "derivation_type": "ratio",
+        "expression": "$TotalDebt / $TotalEquity",
+      }
+    )
+    session = MagicMock()
+    session.execute.side_effect = [_scalars([])]
+
+    with patch.object(
+      metric_handlers, "load_base_envelope_atoms", return_value=_atoms(structure)
+    ):
+      envelope = metric_handlers.build_envelope(session, "str_metrics")
+
+    assert envelope is not None
     assert envelope.display_name == "Metric"
     assert envelope.category == "Reporting"
-    assert envelope.taxonomy_name == "US GAAP"
+    assert envelope.taxonomy_name == "rs-metric"
     mechanics = envelope.artifact.mechanics
     assert mechanics.kind == "metric"
     assert mechanics.source_block_ids == ["struct_bs"]
     assert mechanics.derivation_type == "ratio"
-    assert envelope.fact_set is None
-    assert envelope.verification_results == []
 
-  def test_defaults_mechanics_when_artifact_mechanics_null(self) -> None:
+  def test_mechanics_default_when_column_null(self) -> None:
+    structure = _structure(mechanics=None)
     session = MagicMock()
-    structure = MagicMock()
-    structure.id = "struct_metric_2"
-    structure.block_type = "metric"
-    structure.name = "Gross Margin"
-    structure.description = None
-    structure.taxonomy_id = "tax_02"
-    structure.concept_arrangement = None
-    structure.member_arrangement = None
-    structure.renderer_note = None
-    structure.artifact_mechanics = None
-    session.get.return_value = structure
-    session.execute.side_effect = [
-      _exec_result(scalar=None),  # taxonomy name
-      _exec_result(scalar=None),  # latest fact set → None
-      _exec_result(scalars_all=[]),  # verification results
-    ]
+    session.execute.side_effect = [_scalars([])]
 
-    envelope = metric_handlers.build_envelope(session, "struct_metric_2")
+    with patch.object(
+      metric_handlers, "load_base_envelope_atoms", return_value=_atoms(structure)
+    ):
+      envelope = metric_handlers.build_envelope(session, "str_metrics")
+
     assert envelope is not None
     mechanics = envelope.artifact.mechanics
     assert mechanics.kind == "metric"

--- a/tests/operations/information_block/test_metrics_compute.py
+++ b/tests/operations/information_block/test_metrics_compute.py
@@ -1,0 +1,322 @@
+"""Tests for ``cmd_compute_metrics`` — Derive rules → standing metric FactSet."""
+
+from __future__ import annotations
+
+from datetime import date
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from robosystems.models.api.information_block import ComputeMetricsRequest
+from robosystems.models.extensions.roboledger.fact import Fact
+from robosystems.operations.information_block import metrics as metrics_mod
+
+PERIOD_END = date(2026, 3, 31)
+
+
+def _scalars(items: list[Any]) -> MagicMock:
+  result = MagicMock()
+  result.scalars.return_value.all.return_value = items
+  return result
+
+
+def _scalar_one(value: Any) -> MagicMock:
+  result = MagicMock()
+  result.scalar_one_or_none.return_value = value
+  return result
+
+
+def _first(row: Any) -> MagicMock:
+  result = MagicMock()
+  result.first.return_value = row
+  return result
+
+
+def _fetchone(row: Any) -> MagicMock:
+  result = MagicMock()
+  result.fetchone.return_value = row
+  return result
+
+
+def _structure(block_type: str = "metric") -> MagicMock:
+  s = MagicMock()
+  s.id = "str_metrics"
+  s.block_type = block_type
+  return s
+
+
+def _element(
+  element_id: str,
+  qname: str,
+  name: str,
+  *,
+  monetary: bool = False,
+  period_type: str = "instant",
+) -> SimpleNamespace:
+  return SimpleNamespace(
+    id=element_id,
+    qname=qname,
+    name=name,
+    is_monetary=monetary,
+    period_type=period_type,
+  )
+
+
+EL_WC = _element("el_wc", "rs-metric:WorkingCapital", "Working Capital", monetary=True)
+EL_CR = _element("el_cr", "rs-metric:CurrentRatio", "Current Ratio")
+EL_IC = _element(
+  "el_ic", "rs-metric:InterestCoverage", "Interest Coverage", period_type="duration"
+)
+EL_AC = _element("el_ac", "rs-gaap:AssetsCurrent", "Current Assets")
+EL_LC = _element("el_lc", "rs-gaap:LiabilitiesCurrent", "Current Liabilities")
+EL_OIL = _element("el_oil", "rs-gaap:OperatingIncomeLoss", "Operating Income")
+EL_IE = _element("el_ie", "rs-gaap:InterestExpense", "Interest Expense")
+
+
+def _arc(to_element_id: str, order: float) -> SimpleNamespace:
+  return SimpleNamespace(
+    from_element_id="el_kfm", to_element_id=to_element_id, order_value=order
+  )
+
+
+def _rule(
+  rule_id: str,
+  target_element_id: str,
+  expression: str,
+  variables: list[tuple[str, str]],
+) -> SimpleNamespace:
+  return SimpleNamespace(
+    id=rule_id,
+    target_element_id=target_element_id,
+    rule_pattern="Derive",
+    rule_expression=expression,
+    rule_variables=[{"variable_name": n, "variable_qname": q} for n, q in variables],
+  )
+
+
+RULE_WC = _rule(
+  "rule_wc",
+  "el_wc",
+  "$WorkingCapital = ($AssetsCurrent - $LiabilitiesCurrent)",
+  [
+    ("WorkingCapital", "rs-metric:WorkingCapital"),
+    ("AssetsCurrent", "rs-gaap:AssetsCurrent"),
+    ("LiabilitiesCurrent", "rs-gaap:LiabilitiesCurrent"),
+  ],
+)
+RULE_CR = _rule(
+  "rule_cr",
+  "el_cr",
+  "$CurrentRatio = ($AssetsCurrent / $LiabilitiesCurrent)",
+  [
+    ("CurrentRatio", "rs-metric:CurrentRatio"),
+    ("AssetsCurrent", "rs-gaap:AssetsCurrent"),
+    ("LiabilitiesCurrent", "rs-gaap:LiabilitiesCurrent"),
+  ],
+)
+RULE_IC = _rule(
+  "rule_ic",
+  "el_ic",
+  "$InterestCoverage = ($OperatingIncomeLoss / $InterestExpense)",
+  [
+    ("InterestCoverage", "rs-metric:InterestCoverage"),
+    ("OperatingIncomeLoss", "rs-gaap:OperatingIncomeLoss"),
+    ("InterestExpense", "rs-gaap:InterestExpense"),
+  ],
+)
+
+
+def _session(structure: MagicMock, elements: dict[str, Any]) -> MagicMock:
+  session = MagicMock()
+
+  def _get(model, pk):
+    if pk == structure.id:
+      return structure
+    return elements.get(pk)
+
+  session.get.side_effect = _get
+  return session
+
+
+def _body(**overrides: Any) -> ComputeMetricsRequest:
+  kwargs: dict[str, Any] = {
+    "structure_id": "str_metrics",
+    "period_end": PERIOD_END,
+    "entity_id": "ent_1",
+  }
+  kwargs.update(overrides)
+  return ComputeMetricsRequest(**kwargs)
+
+
+class TestComputeMetrics:
+  def test_computes_all_metrics_in_arc_order(self) -> None:
+    structure = _structure()
+    session = _session(
+      structure, {"el_wc": EL_WC, "el_cr": EL_CR, "el_ac": EL_AC, "el_lc": EL_LC}
+    )
+    session.execute.side_effect = [
+      _scalars([_arc("el_wc", 1.0), _arc("el_cr", 2.0)]),
+      # Reversed order from the DB — the arc order must re-sort them.
+      _scalars([RULE_CR, RULE_WC]),
+      _scalar_one(EL_AC),  # qname lookup AssetsCurrent
+      _first((100.0, None)),  # bind AssetsCurrent (rule_wc)
+      _scalar_one(EL_LC),  # qname lookup LiabilitiesCurrent
+      _first((40.0, None)),  # bind LiabilitiesCurrent (rule_wc)
+      _first((100.0, None)),  # bind AssetsCurrent (rule_cr, qname cached)
+      _first((40.0, None)),  # bind LiabilitiesCurrent (rule_cr)
+      _scalar_one(None),  # standing FactSet lookup
+    ]
+
+    with patch.object(
+      metrics_mod,
+      "create_fact_set",
+      return_value=SimpleNamespace(id="fs_new", provenance=None),
+    ) as create_fs:
+      response = metrics_mod.cmd_compute_metrics(session, _body(), "usr_1")
+
+    assert [m.element_qname for m in response.computed] == [
+      "rs-metric:WorkingCapital",
+      "rs-metric:CurrentRatio",
+    ]
+    wc, cr = response.computed
+    assert wc.value == pytest.approx(60.0)
+    assert wc.unit == "USD"
+    assert cr.value == pytest.approx(2.5)
+    assert cr.unit == "pure"
+    assert response.skipped == []
+    assert response.fact_set_id == "fs_new"
+    create_fs.assert_called_once()
+    assert create_fs.call_args.kwargs["factset_type"] == "metric"
+
+    added_facts = [
+      c.args[0] for c in session.add.call_args_list if isinstance(c.args[0], Fact)
+    ]
+    assert len(added_facts) == 2
+    for fact in added_facts:
+      assert fact.fact_set_id == "fs_new"
+      assert fact.fact_type == "Numeric"
+      assert fact.period_end == PERIOD_END
+      assert fact.period_start is None  # instant metrics
+      assert fact.entity_id == "ent_1"
+
+  def test_missing_operand_skips_with_missing_list(self) -> None:
+    structure = _structure()
+    session = _session(structure, {"el_ic": EL_IC, "el_oil": EL_OIL, "el_ie": EL_IE})
+    session.execute.side_effect = [
+      _scalars([_arc("el_ic", 1.0)]),
+      _scalars([RULE_IC]),
+      _scalar_one(EL_OIL),
+      _first((50.0, date(2025, 4, 1))),
+      _scalar_one(EL_IE),
+      _first(None),  # no InterestExpense fact — debt-free entity
+      _scalar_one(None),  # standing lookup
+    ]
+
+    with patch.object(metrics_mod, "create_fact_set") as create_fs:
+      response = metrics_mod.cmd_compute_metrics(session, _body(), "usr_1")
+
+    assert response.computed == []
+    assert len(response.skipped) == 1
+    skip = response.skipped[0]
+    assert skip.element_qname == "rs-metric:InterestCoverage"
+    assert skip.missing == ["rs-gaap:InterestExpense"]
+    assert response.fact_set_id is None
+    create_fs.assert_not_called()
+
+  def test_division_by_zero_skips_with_reason(self) -> None:
+    structure = _structure()
+    session = _session(structure, {"el_cr": EL_CR, "el_ac": EL_AC, "el_lc": EL_LC})
+    session.execute.side_effect = [
+      _scalars([_arc("el_cr", 1.0)]),
+      _scalars([RULE_CR]),
+      _scalar_one(EL_AC),
+      _first((100.0, None)),
+      _scalar_one(EL_LC),
+      _first((0.0, None)),
+      _scalar_one(None),
+    ]
+
+    response = metrics_mod.cmd_compute_metrics(session, _body(), "usr_1")
+
+    assert response.computed == []
+    assert len(response.skipped) == 1
+    assert "division by zero" in response.skipped[0].reason
+
+  def test_rerun_replaces_prior_facts_in_same_standing_set(self) -> None:
+    structure = _structure()
+    session = _session(structure, {"el_wc": EL_WC, "el_ac": EL_AC, "el_lc": EL_LC})
+    standing = MagicMock()
+    standing.id = "fs_old"
+    old_facts = [MagicMock(), MagicMock()]
+    session.execute.side_effect = [
+      _scalars([_arc("el_wc", 1.0)]),
+      _scalars([RULE_WC]),
+      _scalar_one(EL_AC),
+      _first((120.0, None)),
+      _scalar_one(EL_LC),
+      _first((70.0, None)),
+      _scalar_one(standing),
+      _scalars(old_facts),  # prior facts of the standing set
+    ]
+
+    response = metrics_mod.cmd_compute_metrics(session, _body(), "usr_1")
+
+    assert response.fact_set_id == "fs_old"
+    assert [c.args[0] for c in session.delete.call_args_list] == old_facts
+    assert standing.provenance["origin"] == "derived"
+    added_facts = [
+      c.args[0] for c in session.add.call_args_list if isinstance(c.args[0], Fact)
+    ]
+    assert len(added_facts) == 1
+    assert added_facts[0].fact_set_id == "fs_old"
+    assert added_facts[0].value == pytest.approx(50.0)
+
+  def test_duration_metric_carries_operand_period_start(self) -> None:
+    structure = _structure()
+    session = _session(structure, {"el_ic": EL_IC, "el_oil": EL_OIL, "el_ie": EL_IE})
+    fy_start = date(2025, 4, 1)
+    session.execute.side_effect = [
+      _scalars([_arc("el_ic", 1.0)]),
+      _scalars([RULE_IC]),
+      _scalar_one(EL_OIL),
+      _first((50.0, fy_start)),
+      _scalar_one(EL_IE),
+      _first((10.0, fy_start)),
+      _scalar_one(None),
+    ]
+
+    with patch.object(
+      metrics_mod,
+      "create_fact_set",
+      return_value=SimpleNamespace(id="fs_new", provenance=None),
+    ):
+      response = metrics_mod.cmd_compute_metrics(session, _body(), "usr_1")
+
+    assert response.computed[0].value == pytest.approx(5.0)
+    assert response.computed[0].period_type == "duration"
+    added_facts = [
+      c.args[0] for c in session.add.call_args_list if isinstance(c.args[0], Fact)
+    ]
+    assert added_facts[0].period_start == fy_start
+    assert added_facts[0].period_type == "duration"
+
+  def test_wrong_block_type_raises(self) -> None:
+    structure = _structure(block_type="schedule")
+    session = _session(structure, {})
+    with pytest.raises(ValueError, match="block_type='metric'"):
+      metrics_mod.cmd_compute_metrics(session, _body(), "usr_1")
+
+  def test_structure_missing_raises(self) -> None:
+    session = MagicMock()
+    session.get.return_value = None
+    with pytest.raises(ValueError, match="Structure not found"):
+      metrics_mod.cmd_compute_metrics(session, _body(), "usr_1")
+
+  def test_no_entity_raises(self) -> None:
+    structure = _structure()
+    session = _session(structure, {})
+    session.execute.side_effect = [_fetchone(None)]
+    with pytest.raises(ValueError, match="No entity found"):
+      metrics_mod.cmd_compute_metrics(session, _body(entity_id=None), "usr_1")

--- a/tests/operations/taxonomy_block/test_authoring_flag.py
+++ b/tests/operations/taxonomy_block/test_authoring_flag.py
@@ -1,0 +1,134 @@
+"""Tests for the TAXONOMY_AUTHORING_ENABLED environment gate.
+
+The gate lives at the taxonomy-block command dispatch chokepoint so one
+check covers both the REST operations and the auto-generated MCP tools.
+Gated types: ``reporting_extension`` + ``custom_ontology`` (framework
+authoring). ``chart_of_accounts`` is never gated (core product path) and
+delete stays open (content removal reduces liability).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from robosystems.operations.taxonomy_block import commands as commands_mod
+from robosystems.operations.taxonomy_block.commands import (
+  GATED_TAXONOMY_TYPES,
+  TaxonomyAuthoringDisabledError,
+  create_taxonomy_block,
+  delete_taxonomy_block,
+  update_taxonomy_block,
+)
+
+FLAG = "robosystems.config.env.TAXONOMY_AUTHORING_ENABLED"
+
+
+def _entry() -> MagicMock:
+  entry = MagicMock()
+  entry.dispatch_create.return_value = "tax_new"
+  entry.dispatch_update.return_value = "tax_upd"
+  entry.dispatch_delete.return_value = 0
+  entry.dispatch_build_envelope.return_value = MagicMock()
+  return entry
+
+
+def _create_body(taxonomy_type: str) -> MagicMock:
+  body = MagicMock()
+  body.taxonomy_type = taxonomy_type
+  return body
+
+
+def _taxonomy(taxonomy_type: str) -> MagicMock:
+  taxonomy = MagicMock()
+  taxonomy.taxonomy_type = taxonomy_type
+  taxonomy.name = "Tenant Framework"
+  return taxonomy
+
+
+class TestGateScope:
+  def test_gated_set_is_exactly_the_framework_types(self) -> None:
+    assert {"reporting_extension", "custom_ontology"} == GATED_TAXONOMY_TYPES
+
+
+class TestFlagOff:
+  @pytest.mark.parametrize("taxonomy_type", sorted(GATED_TAXONOMY_TYPES))
+  def test_create_gated_type_raises_before_dispatch(
+    self, monkeypatch: pytest.MonkeyPatch, taxonomy_type: str
+  ) -> None:
+    monkeypatch.setattr(FLAG, False)
+    entry = _entry()
+    with patch.object(commands_mod.registry_module, "get", return_value=entry):
+      with pytest.raises(TaxonomyAuthoringDisabledError, match=taxonomy_type):
+        create_taxonomy_block(MagicMock(), _create_body(taxonomy_type), "usr_1")
+    entry.dispatch_create.assert_not_called()
+
+  @pytest.mark.parametrize("taxonomy_type", sorted(GATED_TAXONOMY_TYPES))
+  def test_update_gated_type_raises_before_dispatch(
+    self, monkeypatch: pytest.MonkeyPatch, taxonomy_type: str
+  ) -> None:
+    monkeypatch.setattr(FLAG, False)
+    entry = _entry()
+    session = MagicMock()
+    session.get.return_value = _taxonomy(taxonomy_type)
+    body = MagicMock()
+    body.taxonomy_id = "tax_1"
+    with patch.object(commands_mod.registry_module, "get", return_value=entry):
+      with pytest.raises(TaxonomyAuthoringDisabledError):
+        update_taxonomy_block(session, body, "usr_1")
+    entry.dispatch_update.assert_not_called()
+
+  def test_create_chart_of_accounts_still_dispatches(
+    self, monkeypatch: pytest.MonkeyPatch
+  ) -> None:
+    monkeypatch.setattr(FLAG, False)
+    entry = _entry()
+    with patch.object(commands_mod.registry_module, "get", return_value=entry):
+      envelope = create_taxonomy_block(
+        MagicMock(), _create_body("chart_of_accounts"), "usr_1"
+      )
+    entry.dispatch_create.assert_called_once()
+    assert envelope is entry.dispatch_build_envelope.return_value
+
+  def test_delete_gated_type_still_dispatches(
+    self, monkeypatch: pytest.MonkeyPatch
+  ) -> None:
+    monkeypatch.setattr(FLAG, False)
+    entry = _entry()
+    session = MagicMock()
+    session.get.return_value = _taxonomy("reporting_extension")
+    body = MagicMock()
+    body.taxonomy_id = "tax_1"
+    body.cascade_facts = False
+    with patch.object(commands_mod.registry_module, "get", return_value=entry):
+      response = delete_taxonomy_block(session, body, "usr_1")
+    entry.dispatch_delete.assert_called_once()
+    assert response.taxonomy_id == "tax_1"
+
+
+class TestFlagOn:
+  @pytest.mark.parametrize("taxonomy_type", sorted(GATED_TAXONOMY_TYPES))
+  def test_create_gated_type_dispatches(
+    self, monkeypatch: pytest.MonkeyPatch, taxonomy_type: str
+  ) -> None:
+    monkeypatch.setattr(FLAG, True)
+    entry = _entry()
+    with patch.object(commands_mod.registry_module, "get", return_value=entry):
+      envelope = create_taxonomy_block(
+        MagicMock(), _create_body(taxonomy_type), "usr_1"
+      )
+    entry.dispatch_create.assert_called_once()
+    assert envelope is entry.dispatch_build_envelope.return_value
+
+
+class TestErrorMapWiring:
+  def test_create_and_update_specs_map_disabled_to_403(self) -> None:
+    from robosystems.routers.extensions.roboledger import operations as ops
+
+    specs = {s.name: s for s in ops._registrar.registered_specs}
+    for name in ("create-taxonomy-block", "update-taxonomy-block"):
+      assert specs[name].error_map.get(TaxonomyAuthoringDisabledError) == 403
+    assert (
+      TaxonomyAuthoringDisabledError not in specs["delete-taxonomy-block"].error_map
+    )

--- a/tests/taxonomy/test_rs_metric_seed.py
+++ b/tests/taxonomy/test_rs_metric_seed.py
@@ -1,0 +1,143 @@
+"""Tests for the rs-metric/v1 catalog package (Metrics M-1).
+
+Pins the hand-authored artifact's shape: the Key Financial Metrics
+container (element + structure), five metric concepts, five role-bound
+presentation arcs, and five ``Derive`` rules whose expressions parse and
+whose operands reference rs-gaap anchors that exist in the rs-gaap
+package (the calc-DAG anchors the report pivot persists).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from robosystems.operations.information_block.rules.expressions import (
+  lhs_variable_names,
+  parse_arithmetic_expression,
+)
+from robosystems.taxonomy.discovery import framework_root
+from robosystems.taxonomy.loader import (
+  RULE_CATEGORY_VALUES,
+  RULE_PATTERN_VALUES,
+  load_taxonomy_package,
+)
+from robosystems.taxonomy.model import RuleSpec, TaxonomyPackage
+
+SEED_PATH = framework_root("rs-gaap") / "packages" / "rs-metric" / "v1"
+ROLE_URI = "https://robosystems.ai/seattle/cm-roles/roles/metrics/KeyFinancialMetrics"
+
+EXPECTED_CONCEPTS = {
+  "rs-metric:WorkingCapital",
+  "rs-metric:CurrentRatio",
+  "rs-metric:QuickRatio",
+  "rs-metric:DebtToEquity",
+  "rs-metric:InterestCoverage",
+}
+
+
+@pytest.fixture(scope="module")
+def package() -> TaxonomyPackage:
+  return load_taxonomy_package(SEED_PATH / "taxonomy.jsonld")
+
+
+@pytest.fixture(scope="module")
+def rules(package: TaxonomyPackage) -> list[RuleSpec]:
+  return package.rules
+
+
+class TestPackageShape:
+  def test_metadata(self, package: TaxonomyPackage) -> None:
+    assert package.standard == "rs-metric"
+    assert package.version == "v1"
+    assert package.taxonomy_type == "reporting_extension"
+    assert package.default_block_type == "metric"
+
+  def test_elements(self, package: TaxonomyPackage) -> None:
+    by_qname = {e.qname: e for e in package.elements}
+    assert set(by_qname) == EXPECTED_CONCEPTS | {"rs-metric:KeyFinancialMetrics"}
+    container = by_qname["rs-metric:KeyFinancialMetrics"]
+    assert container.is_abstract
+    for qname in EXPECTED_CONCEPTS:
+      assert by_qname[qname].element_type == "concept"
+    # Every element carries the namespace prefix as its source — the
+    # value the check_element_source widening (0022 / provisioning)
+    # admits and the #893 namespace protection reserves.
+    assert {e.source for e in package.elements} == {"rs-metric"}
+
+  def test_monetary_and_period_shape(self, package: TaxonomyPackage) -> None:
+    by_qname = {e.qname: e for e in package.elements}
+    assert by_qname["rs-metric:WorkingCapital"].is_monetary
+    for ratio in ("CurrentRatio", "QuickRatio", "DebtToEquity", "InterestCoverage"):
+      assert not by_qname[f"rs-metric:{ratio}"].is_monetary
+    assert by_qname["rs-metric:InterestCoverage"].period_type == "duration"
+    for instant in ("WorkingCapital", "CurrentRatio", "QuickRatio", "DebtToEquity"):
+      assert by_qname[f"rs-metric:{instant}"].period_type == "instant"
+
+  def test_structure(self, package: TaxonomyPackage) -> None:
+    assert len(package.structures) == 1
+    structure = package.structures[0]
+    assert structure.block_type == "metric"
+    assert structure.concept_arrangement == "arithmetic"
+    assert structure.role_uri == ROLE_URI
+
+  def test_presentation_arcs_bind_catalog_to_role(
+    self, package: TaxonomyPackage
+  ) -> None:
+    arcs = package.associations
+    assert len(arcs) == 5
+    assert {a.to_qname for a in arcs} == EXPECTED_CONCEPTS
+    for arc in arcs:
+      assert arc.from_qname == "rs-metric:KeyFinancialMetrics"
+      assert arc.association_type == "presentation"
+      assert arc.role == ROLE_URI
+    orders = sorted(a.order for a in arcs)
+    assert orders == [1.0, 2.0, 3.0, 4.0, 5.0]
+
+
+class TestDeriveRules:
+  def test_five_derive_rules(self, rules: list[RuleSpec]) -> None:
+    """Regression against the RULE_PATTERN_VALUES gate: an unknown
+    pattern is silently skipped at load, so a missing 'Derive' entry
+    would collapse this to zero."""
+    assert len(rules) == 5
+    for rule in rules:
+      assert rule.rule_pattern == "Derive"
+      assert rule.rule_pattern in RULE_PATTERN_VALUES
+      assert rule.rule_category in RULE_CATEGORY_VALUES
+      assert rule.rule_severity == "info"
+
+  def test_element_scoped_to_metric_concepts(self, rules: list[RuleSpec]) -> None:
+    targets = set()
+    for rule in rules:
+      assert rule.rule_target is not None
+      assert rule.rule_target.target_kind == "element"
+      targets.add(rule.rule_target.target_ref)
+    assert targets == EXPECTED_CONCEPTS
+
+  def test_expressions_parse_with_lhs_metric_first(self, rules: list[RuleSpec]) -> None:
+    for rule in rules:
+      names = [v.variable_name for v in rule.rule_variables]
+      parsed = parse_arithmetic_expression(rule.rule_expression, names)
+      lhs = lhs_variable_names(parsed)
+      assert len(lhs) == 1
+      # LHS variable is the target metric and sits first in the list.
+      assert lhs[0] == names[0]
+      assert rule.rule_variables[0].variable_qname == rule.rule_target.target_ref
+
+  def test_operand_qnames_exist_in_rs_gaap_package(self, rules: list[RuleSpec]) -> None:
+    """Operands must be anchors the report pivot actually persists —
+    a typo'd qname soft-fails to 'skipped' at compute time, so catch it
+    here instead."""
+    rs_gaap_path = framework_root("rs-gaap") / "packages" / "rs-gaap" / "v1"
+    raw = json.loads((rs_gaap_path / "taxonomy.jsonld").read_text())
+    rs_gaap_ids = {
+      node.get("@id") for node in raw.get("@graph", []) if isinstance(node, dict)
+    }
+    for rule in rules:
+      for var in rule.rule_variables[1:]:
+        assert var.variable_qname.startswith("rs-gaap:")
+        assert var.variable_qname in rs_gaap_ids, (
+          f"{rule.id}: operand {var.variable_qname} not found in rs-gaap/v1"
+        )

--- a/tests/taxonomy/test_rules_migration_shape.py
+++ b/tests/taxonomy/test_rules_migration_shape.py
@@ -43,6 +43,15 @@ assert _spec is not None and _spec.loader is not None
 mig_0002 = _util.module_from_spec(_spec)
 _spec.loader.exec_module(mig_0002)
 
+# Later widenings layer on top of 0002 for fresh AND deployed DBs alike
+# (0022 re-adds the constraint after 0002 in the migration sequence), so
+# the loader-enum ⊆ DB-CHECK invariant holds over the union.
+_MIGRATION_0022_PATH = _MIGRATION_PATH.parent / "0022_metrics.py"
+_spec_0022 = _util.spec_from_file_location("mig_0022", _MIGRATION_0022_PATH)
+assert _spec_0022 is not None and _spec_0022.loader is not None
+mig_0022 = _util.module_from_spec(_spec_0022)
+_spec_0022.loader.exec_module(mig_0022)
+
 
 class TestImmutableTables:
   def test_rules_is_immutable_in_tenant_schemas(self) -> None:
@@ -145,10 +154,16 @@ class TestRuleCheckConstraints:
       )
 
   def test_pattern_check_lists_every_enum_value(self) -> None:
+    """The effective CHECK for any DB is 0002's re-added by 0022's
+    widening ('Derive'), so the loader enum asserts against 0022's
+    final constant."""
     for pattern in RULE_PATTERN_VALUES:
-      assert f"'{pattern}'" in mig_0002._RULE_PATTERN_CHECK, (
-        f"pattern {pattern!r} missing from _RULE_PATTERN_CHECK"
+      assert f"'{pattern}'" in mig_0022._RULE_PATTERN_WIDENED, (
+        f"pattern {pattern!r} missing from 0022 _RULE_PATTERN_WIDENED"
       )
+    # 0022's widening must be a strict superset of 0002's original.
+    assert "'Derive'" in mig_0022._RULE_PATTERN_WIDENED
+    assert "'Derive'" not in mig_0002._RULE_PATTERN_CHECK
 
   def test_severity_check_enumerates_info_warning_error(self) -> None:
     for severity in ("info", "warning", "error"):


### PR DESCRIPTION
## Summary

Two workstreams in one PR (deploy-coupled by design):

### Metrics backend MVP (M-1)

- **`rs-metric` library package** (`frameworks/rs-gaap/packages/rs-metric/v1`, ordinal 14): the Key Financial Metrics catalog — Working Capital, Current Ratio, Quick Ratio, Debt-to-Equity, Interest Coverage. Each metric is a qname-addressable concept plus one **`Derive` rule** (`$Metric = f(rs-gaap operands)`, same `ruleVariables` shape as the rollup rules), and the container node is both an abstract element and the seeded `block_type='metric'` Structure every tenant receives.
- **`compute-metrics` operation** (REST + auto-generated MCP tool): binds each Derive rule's operands to the entity's most recent persisted report facts at `period_end`, evaluates via the existing safe AST evaluator (`evaluate_derivation`), and upserts a standing `factset_type='metric'` FactSet per (structure, entity, period_end) — the accumulating time series. Re-running a period replaces its values. Missing operands / undefined ratios **skip with a reason**, never error the run.
- **Metric envelope** renders the standing series: one period column per FactSet, one row per catalog concept in presentation-arc order; `fact_set_id` pin honored.
- **Migration 0022** — the first package-adding migration: widens three vocabulary CHECKs (`factset_type` +`'metric'`, `rule_pattern` +`'Derive'`, element `source` +`'rs-metric'`) across public + every tenant schema, seeds the package into the public library, mirrors the `framework_packages` junction row, and resyncs into existing tenants under the 0016 bypass GUC. Fresh deployments get everything from 0002 + provisioning (manifest + `_widen_library_checks` + models updated in lockstep).

### `TAXONOMY_AUTHORING_ENABLED` (environment gate)

Walls tenant **framework authoring** (`reporting_extension` / `custom_ontology` taxonomy blocks) behind an environment-level flag while the surface seasons:

- Gate sits at the taxonomy-block command dispatch chokepoint — one check covers REST and the auto-generated MCP tools (tool-listing gating is impossible: the tools are block_type-blind and must stay listed for `chart_of_accounts`).
- Create + update → 403 when off; **delete stays open** (content removal reduces liability); `chart_of_accounts` is never gated.
- **Fail-closed in prod/staging**: the code default is `false` there, so a missing SSM parameter cannot open the surface. Dev/test default on (the scenario demos author disclosure notes). Enable later with `just ssm-set <env> features/TAXONOMY_AUTHORING_ENABLED true` + API restart (flags read once at process start).

## Verification

- Full unit suite + ruff + basedpyright green (one known pre-existing order-dependent flake in `test_incremental_materialize`, passes isolated).
- **Migration 0022 ran against a dev DB with two provisioned tenant schemas** — public seed, junction row, and per-tenant resync all clean.
- **Full Driftline demo e2e**: catalog computes at both comparative period ends (Working Capital \$88.0k → \$238.5k, Current Ratio 3.27 → 5.59, Quick Ratio 2.70 → 3.74, D/E 0.27 → 0.17), Interest Coverage skips with a reason for the debt-free company, and the envelope renders the two-period series.

## Deploy notes

- Extensions migration **0022** must ship in the same window as this code (deploy-coupled with 0021 from the M3 arc).
- Nit (not fixed here): `unit='pure'` facts mint a cosmetically-wrong `iso4217:pure` unit node on materialize.
- `bin/setup/aws.sh` feature-flag seed array has pre-existing stale entries (`LEDGER_ENABLED`) — left as-is, only the new flag added.