### PR TITLE
fix(sec): spill knowledge-artifact extraction to disk; size task for grown corpus

### DIFF
--- a/robosystems/adapters/sec/knowledge/extractors.py
+++ b/robosystems/adapters/sec/knowledge/extractors.py
@@ -52,6 +52,12 @@ class ArcExtractor:
     # Ensure spill-to-disk uses the same directory as the database file
     temp_dir = str(self._db_path.parent)
     conn.execute(f"SET temp_directory = '{temp_dir}'")
+    # Let the hash aggregations (LIST(DISTINCT ...) over the large STRUCTURE/
+    # ASSOCIATION joins) spill to temp_directory instead of holding the whole
+    # grouping in RAM. Without this the aggregate cannot spill and dies with an
+    # internal OutOfMemoryException on the full corpus; the extractions here are
+    # all grouped/deduplicated downstream, so result row order is irrelevant.
+    conn.execute("SET preserve_insertion_order = false")
     return conn
 
   def extract_deduplicated_edges(self) -> list[tuple[str, str, float, str]]:

--- a/robosystems/adapters/sec/pipeline/artifact.py
+++ b/robosystems/adapters/sec/pipeline/artifact.py
@@ -26,13 +26,23 @@ from dagster import (
   MaterializeResult,
   asset,
 )
+from pydantic import Field
 
 
 class SECArtifactConfig(Config):
   """Configuration for SEC artifact generation."""
 
   duckdb_source: str = "sec"
-  memory_limit: str = "8GB"
+  # DuckDB memory budget per builder connection. MUST stay well under the ECS
+  # task memory (16GB) — the extractions spill to disk beyond this, but the
+  # extracted result set is still materialized in Python on top of DuckDB's
+  # buffer, so setting this near the container size starves Python and the
+  # kernel OOM-kills the task (SIGKILL). Raising it does NOT help a corpus that
+  # outgrew memory; the spill-to-disk path (see extractors._connect) does.
+  memory_limit: str = Field(
+    default="8GB",
+    description="DuckDB memory budget per builder; keep well below task memory.",
+  )
   publish_r2: bool = False
 
 

--- a/robosystems/adapters/sec/pipeline/jobs.py
+++ b/robosystems/adapters/sec/pipeline/jobs.py
@@ -489,11 +489,16 @@ sec_artifact_generation_job = define_asset_job(
     "pipeline": "sec",
     "phase": "artifact",
     # Downloads full DuckDB staging file from S3 then runs graph algorithms.
-    # DuckDB uses threads=1 + spill-to-disk for large joins.
-    # Observed peak: ~14.4 GB (Mar 2026, 104 GB corpus). 16 GB to test lower bound.
-    # Ephemeral: 200GB covers 104GB DuckDB + spill (structure membership query) + artifacts.
-    "ecs/cpu": "2048",
-    "ecs/memory": "16384",
+    # DuckDB uses threads=1 + spill-to-disk (preserve_insertion_order=false) so
+    # its buffer stays bounded (~memory_limit, 8GB) and overflows to ephemeral.
+    # Peak is DuckDB budget + the Python result materialized on top: ~14.4 GB on
+    # the Mar 2026 104 GB corpus, which outgrew the 16 GB lower-bound and started
+    # OOM-killing (SIGKILL) as the corpus grew. 4 vCPU unlocks the >16 GB Fargate
+    # memory tier; 24 GB gives the Python side headroom (DuckDB stays capped +
+    # spills, so raising DuckDB's own memory_limit is the wrong lever here).
+    # Ephemeral: 200GB covers the DuckDB file + spill + artifacts.
+    "ecs/cpu": "4096",
+    "ecs/memory": "24576",
     "ecs/ephemeral_storage": "200",
     "ecs/run_task_kwargs": {
       "capacityProviderStrategy": [

--- a/tests/adapters/sec/knowledge/test_extractors.py
+++ b/tests/adapters/sec/knowledge/test_extractors.py
@@ -69,6 +69,19 @@ class TestArcExtractorConnect:
     finally:
       conn.close()
 
+  def test_connect_disables_insertion_order(self, sec_duckdb):
+    """preserve_insertion_order is off so large hash aggregations spill to disk
+    (temp_directory) instead of dying with an internal OutOfMemoryException."""
+    extractor = ArcExtractor(sec_duckdb, memory_limit="256MB")
+    conn = extractor._connect()
+    try:
+      value = conn.execute(
+        "SELECT current_setting('preserve_insertion_order')"
+      ).fetchone()[0]
+      assert value in (False, "false")
+    finally:
+      conn.close()
+
 
 class TestExtractDeduplicatedEdges:
   """Tests for extract_deduplicated_edges."""

--- a/tests/adapters/sec/pipeline/test_jobs.py
+++ b/tests/adapters/sec/pipeline/test_jobs.py
@@ -191,9 +191,14 @@ class TestSECArtifactJob:
     assert sec_artifact_generation_job.tags.get("phase") == "artifact"
 
   def test_job_has_enhanced_ecs_profile(self):
-    """Test artifact generation job has enhanced ECS profile for compute."""
-    assert sec_artifact_generation_job.tags.get("ecs/cpu") == "2048"
-    assert sec_artifact_generation_job.tags.get("ecs/memory") == "16384"
+    """Test artifact generation job has enhanced ECS profile for compute.
+
+    4 vCPU is required to unlock the >16GB Fargate memory tier; 24GB gives the
+    Python-side result materialization headroom while DuckDB stays capped and
+    spills to disk (the 16GB profile OOM-killed as the corpus grew).
+    """
+    assert sec_artifact_generation_job.tags.get("ecs/cpu") == "4096"
+    assert sec_artifact_generation_job.tags.get("ecs/memory") == "24576"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Problem

`sec_artifact_generation` (the `sec_knowledge_artifacts` asset) OOM-killed on the grown SEC corpus, failing every retry. Two **distinct** failure signatures pinned the cause:

- **8 GB DuckDB `memory_limit`** → graceful DuckDB `OutOfMemoryException` (`7.4 / 7.4 GiB used`). DuckDB hit *its own* limit and **could not spill** the large `LIST(DISTINCT …)` hash aggregation over the `STRUCTURE_HAS_ASSOCIATION` / `ASSOCIATION_HAS_TO_ELEMENT` joins — even though 100+ GB of ephemeral disk sat free.
- **14 GB DuckDB `memory_limit`** → kernel **SIGKILL** (signal 9). DuckDB was allowed to grow toward 14 GB, and the extracted result materialized in Python on top blew past the 16 GB task cgroup.

Raising DuckDB's own `memory_limit` is the **wrong lever** — it just hogs the box and starves the Python half. The job comment already noted 16 GB was a "Mar-2026 lower-bound experiment"; the corpus outgrew it.

## Fix

- **`extractors._connect`**: `SET preserve_insertion_order = false` so the large aggregations spill to the already-configured `temp_directory` instead of dying on DuckDB's internal OOM. All extractions here are grouped/deduplicated downstream, so result row order is irrelevant (per-group `ORDER BY` inside `LIST()` is unaffected).
- **`SECArtifactConfig.memory_limit`**: documented that it must stay well below task memory, since the result is materialized in Python on top of DuckDB's buffer.
- **`sec_artifact_generation_job`**: `2 vCPU / 16 GB` → `4 vCPU / 24 GB`. DuckDB now stays capped and spills; the extra headroom is for the **Python** side as the corpus grows. (4 vCPU is required to unlock the >16 GB Fargate memory tier.)
- **Test**: assert `_connect` disables `preserve_insertion_order`.

## Testing

- `ruff check`, `ruff format --check`, `basedpyright` all clean.
- Unit tests run in CI (local run needs the full stack for the Postgres autouse fixture).

## Follow-up (not in this PR)

The deeper win is to avoid the Python materialization entirely — push the profile/consensus aggregation into DuckDB and `COPY` straight to parquet, so peak memory stops scaling with corpus size. Filed separately.