### PR TITLE
fix(volumes): stop stale 'expanding' status from stalling the master wake

### DIFF
--- a/bin/lambda/graph_volume_monitor.py
+++ b/bin/lambda/graph_volume_monitor.py
@@ -277,6 +277,10 @@ def check_and_expand_volume(instance: dict, expand_immediately: bool = False) ->
       result["filesystem_grown"] = grow_result.get("success", False)
       result["reason"] = f"EBS ({ebs_size_gb}GB) > filesystem ({current_size}GB)"
       result["ebs_size_gb"] = ebs_size_gb
+      # EBS > filesystem means the resize already completed; clear any stale
+      # 'expanding' status left by an expansion whose grow didn't finalize.
+      if grow_result.get("success") and volume_id:
+        mark_volume_attached(volume_id)
       # Use the EBS size as the current size for expansion check since
       # filesystem growth should now match the EBS volume
       current_size = ebs_size_gb
@@ -322,6 +326,9 @@ def check_and_expand_volume(instance: dict, expand_immediately: bool = False) ->
         result["action"] = "filesystem_growth_only"
         result["filesystem_grown"] = grow_result.get("success", False)
         result["reason"] = "Volume stuck in optimizing state"
+        # Optimizing volumes are attached and usable; don't leave them 'expanding'.
+        if grow_result.get("success"):
+          mark_volume_attached(volume_id)
         return result
       elif modification_state == "modifying":
         logger.info(f"Volume {volume_id} is already being modified, skipping")
@@ -381,6 +388,9 @@ def check_and_expand_volume(instance: dict, expand_immediately: bool = False) ->
                   if cmd_status["Status"] == "Success":
                     logger.info("Filesystem growth completed successfully")
                     result["expansion_details"]["filesystem_status"] = "grown"
+                    # Resize + grow done: clear the 'expanding' status the
+                    # expansion stamped, so it doesn't strand a still-awake master.
+                    mark_volume_attached(volume_id)
                   else:
                     logger.warning(f"Filesystem growth status: {cmd_status['Status']}")
                     result["expansion_details"]["filesystem_status"] = cmd_status[
@@ -673,6 +683,41 @@ def get_volume_metrics_from_cloudwatch(instance: dict) -> dict | None:
   except Exception as e:
     logger.error(f"CloudWatch fallback failed for {instance_id}: {e}")
     return None
+
+
+def mark_volume_attached(volume_id: str) -> None:
+  """Reset a volume's registry status from ``expanding`` back to ``attached``.
+
+  ``perform_volume_expansion`` stamps ``expanding`` while the online EBS resize
+  runs, but nothing else clears it until the next detach/reattach cycle. Callers
+  invoke this once a filesystem grow has succeeded so ``expanding`` stays a
+  transient state — otherwise a master kept awake across an auto-expansion is
+  left with a stale ``expanding`` row, which stalls the wake health-gate and
+  can misfire status-filtered volume lookups.
+
+  The conditional write only flips ``expanding`` → ``attached``; if a detach has
+  already moved the row to ``available`` the condition fails and we leave it be.
+  """
+  if not VOLUME_REGISTRY_TABLE:
+    return
+  try:
+    table = dynamodb.Table(VOLUME_REGISTRY_TABLE)
+    table.update_item(
+      Key={"volume_id": volume_id},
+      UpdateExpression="SET #status = :attached, last_modified = :timestamp",
+      ConditionExpression="#status = :expanding",
+      ExpressionAttributeNames={"#status": "status"},
+      ExpressionAttributeValues={
+        ":attached": "attached",
+        ":expanding": "expanding",
+        ":timestamp": datetime.now(UTC).isoformat(),
+      },
+    )
+    logger.info(f"Volume {volume_id} status reset to attached after expansion")
+  except Exception as e:
+    # ConditionalCheckFailed (status wasn't 'expanding' — e.g. already detached
+    # to 'available') is expected and harmless; other errors are non-fatal.
+    logger.info(f"Volume {volume_id} status not reset to attached: {e}")
 
 
 def perform_volume_expansion(

--- a/robosystems/dagster/assets/shared_repositories/master_parking.py
+++ b/robosystems/dagster/assets/shared_repositories/master_parking.py
@@ -100,17 +100,25 @@ def _instance_is_running(instance_id: str) -> bool:
 
 
 def _volume_attached_to(instance_id: str, database: str) -> bool:
-  """True if ``database``'s data volume is ``attached`` to ``instance_id``.
+  """True if ``database``'s data volume is attached to ``instance_id``.
 
-  Scans all rows tagged with ``database`` and matches only an actually-attached
-  one — a transient stale row (e.g. an old row mid-reattach) must not shadow the
-  real match, since that reattach race is exactly what this gate guards against.
+  Scans all rows tagged with ``database`` and matches only a row bound to THIS
+  instance — a transient stale row (e.g. an old row mid-reattach) must not shadow
+  the real match, since that reattach race is exactly what this gate guards
+  against.
+
+  ``expanding`` counts as attached: the volume monitor stamps that status while
+  an online EBS resize runs, and the volume stays attached and usable throughout
+  (the resize never takes it offline). The monitor does not reset the status
+  until the next detach/reattach, so if the master is kept awake across an
+  auto-expansion, requiring exactly ``attached`` here would hang the wake on a
+  volume that is in fact ready.
   """
   table = _dynamodb_resource().Table(env.VOLUME_REGISTRY_TABLE)
   for item in table.scan().get("Items", []):
     if (
       database in (item.get("databases") or [])
-      and item.get("status") == "attached"
+      and item.get("status") in ("attached", "expanding")
       and item.get("instance_id") == instance_id
     ):
       return True

--- a/tests/dagster/test_master_parking.py
+++ b/tests/dagster/test_master_parking.py
@@ -182,6 +182,47 @@ class TestVolumeGate:
 
     assert _volume_attached_to("i-123", "sec") is True
 
+  @patch.object(master_parking, "_dynamodb_resource")
+  def test_expanding_status_counts_as_attached(self, m_ddb):
+    # A volume mid online-resize is stamped 'expanding' but stays attached and
+    # usable; the gate must not hang the wake on it (the monitor doesn't reset
+    # the status until the next detach/reattach).
+    from robosystems.dagster.assets.shared_repositories.master_parking import (
+      _volume_attached_to,
+    )
+
+    volume_table = MagicMock()
+    volume_table.scan.return_value = {
+      "Items": [
+        {"databases": ["sec"], "status": "expanding", "instance_id": "i-123"},
+      ]
+    }
+    resource = MagicMock()
+    resource.Table.return_value = volume_table
+    m_ddb.return_value = resource
+
+    assert _volume_attached_to("i-123", "sec") is True
+
+  @patch.object(master_parking, "_dynamodb_resource")
+  def test_expanding_row_for_other_instance_is_ignored(self, m_ddb):
+    # 'expanding' still only matches THIS instance — a row bound to a different
+    # instance must not green-light the wake.
+    from robosystems.dagster.assets.shared_repositories.master_parking import (
+      _volume_attached_to,
+    )
+
+    volume_table = MagicMock()
+    volume_table.scan.return_value = {
+      "Items": [
+        {"databases": ["sec"], "status": "expanding", "instance_id": "i-other"},
+      ]
+    }
+    resource = MagicMock()
+    resource.Table.return_value = volume_table
+    m_ddb.return_value = resource
+
+    assert _volume_attached_to("i-123", "sec") is False
+
 
 @pytest.mark.unit
 def test_asg_name_from_config():

--- a/tests/lambda/conftest.py
+++ b/tests/lambda/conftest.py
@@ -88,3 +88,9 @@ def gvm(aws):
 def gvd(aws):
   """graph_volume_detachment module under mock_aws."""
   yield _import_lambda("graph_volume_detachment")
+
+
+@pytest.fixture
+def gvmon(aws):
+  """graph_volume_monitor module under mock_aws."""
+  yield _import_lambda("graph_volume_monitor")

--- a/tests/lambda/test_graph_volume_monitor.py
+++ b/tests/lambda/test_graph_volume_monitor.py
@@ -1,0 +1,57 @@
+"""Tests for the graph volume monitor Lambda's expanding-status reset.
+
+`perform_volume_expansion` stamps a volume 'expanding' during an online resize
+but nothing cleared it until the next detach/reattach, which stranded a
+still-awake shared master's wake health-gate. `mark_volume_attached` resets
+'expanding' -> 'attached' after a filesystem grow, guarded so it never clobbers
+a row a detach has already moved to 'available'.
+"""
+
+import boto3
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _put_volume(status: str, volume_id: str = "vol-abc") -> None:
+  table = boto3.resource("dynamodb", region_name="us-east-1").Table(
+    "test-volume-registry"
+  )
+  table.put_item(
+    Item={
+      "volume_id": volume_id,
+      "status": status,
+      "databases": ["sec"],
+      "instance_id": "i-123",
+    }
+  )
+
+
+def _status(volume_id: str = "vol-abc") -> str:
+  table = boto3.resource("dynamodb", region_name="us-east-1").Table(
+    "test-volume-registry"
+  )
+  return table.get_item(Key={"volume_id": volume_id})["Item"]["status"]
+
+
+class TestMarkVolumeAttached:
+  def test_resets_expanding_to_attached(self, gvmon):
+    _put_volume("expanding")
+    gvmon.mark_volume_attached("vol-abc")
+    assert _status() == "attached"
+
+  def test_leaves_available_untouched(self, gvmon):
+    # A detach already moved the row to 'available'; the conditional write must
+    # not resurrect it to 'attached'.
+    _put_volume("available")
+    gvmon.mark_volume_attached("vol-abc")
+    assert _status() == "available"
+
+  def test_noop_when_already_attached(self, gvmon):
+    _put_volume("attached")
+    gvmon.mark_volume_attached("vol-abc")
+    assert _status() == "attached"
+
+  def test_missing_row_is_non_fatal(self, gvmon):
+    # No row for the volume — the conditional write fails and is swallowed.
+    gvmon.mark_volume_attached("vol-does-not-exist")


### PR DESCRIPTION
## Problem

When the shared-master data volume auto-expands (disk crosses the 80% threshold), the volume monitor Lambda stamps the registry `status = "expanding"` — but **nothing resets it back to `attached`**. The status only returns to `attached` implicitly via a detach → reattach cycle (park → `available`, next wake → `attached`).

In steady state this is masked: the master parks every night, so any mid-run expansion's `expanding` is cleared by the next park/wake. But if the master is kept **awake across an expansion** (e.g. a long operational session, or the Friday full-rebuild), the next `shared_master_wake_job` runs its health-gate against the still-running instance with no intervening reattach. The gate (`_volume_attached_to`) required exactly `attached`, saw the stale `expanding`, and hung until timeout — stalling the nightly chain.

Observed live: a rebuild kept the master awake, the volume auto-expanded 200→300 GB (registry stuck at `expanding` even though the resize + filesystem grow completed), and the next wake hung.

## Fix

- **`master_parking._volume_attached_to`** — accept `expanding` as attached for the **same instance**. An online EBS resize keeps the volume attached and usable throughout, so a resize-in-progress must never be able to hang a wake. (Still only matches THIS instance, preserving the stale-row / reattach-race guard.)
- **`graph_volume_monitor.mark_volume_attached`** — new helper called after every filesystem grow succeeds (main expansion path + both recovery paths). A **conditional** write flips `expanding` → `attached` only, so a row a detach already moved to `available` is never clobbered. This keeps the status accurate for the wake-gate *and* the status-filtered volume lookups (`get_data_volume_id` / `get_data_volume_info`).

Belt-and-suspenders: the app-side gate change alone prevents the hang; the Lambda change removes the stale state at the source.

## Tests

- `test_master_parking`: wake-gate accepts `expanding` for the same instance, still rejects an `expanding` row bound to a different instance.
- `test_graph_volume_monitor` (new, moto): `mark_volume_attached` resets `expanding`→`attached`, leaves `available`/`attached` untouched, and is non-fatal on a missing row.
- `ruff` + `basedpyright` clean.

## Note

The `graph_volume_monitor` Lambda deploys via `cloudformation/graph-volumes.yaml`, so it takes effect on the next infra deploy of that stack (separate from the app image).