### PR TITLE
fix(graph): give shared-replica boot headroom over the PT20M signal deadline

### DIFF
--- a/.github/workflows/deploy-graph-replicas.yml
+++ b/.github/workflows/deploy-graph-replicas.yml
@@ -183,7 +183,10 @@ on:
 jobs:
   deploy:
     runs-on: ${{ fromJSON(inputs.runner_config) }}
-    timeout-minutes: 30
+    # Rolling update replaces replicas one at a time (MaxBatchSize 1), each with
+    # a PT30M signal budget; two instances back-to-back can run ~60 min. Cover
+    # that plus the monitor action's own 3600s window and setup overhead.
+    timeout-minutes: 70
     permissions:
       id-token: write
       contents: read
@@ -405,7 +408,9 @@ jobs:
         uses: ./.github/actions/monitor-stack-deployment
         with:
           stack-name: ${{ inputs.stack_name }}
-          timeout: "1800"
+          # Cover a full rolling replica cycle (~120GB download + warmup per
+          # instance, two instances sequential). PT30M x2 → 60 min.
+          timeout: "3600"
           interval: "10"
 
       - name: Get Stack Outputs

--- a/cloudformation/graph-ladybug-replicas.yaml
+++ b/cloudformation/graph-ladybug-replicas.yaml
@@ -556,14 +556,18 @@ Resources:
     CreationPolicy:
       ResourceSignal:
         Count: !If [HasMinInstances, !Ref MinInstances, 0]
-        # S3 download (~7 min) + system setup (~2 min) + container warmup (~1 min)
-        Timeout: PT20M
+        # Measured cold boot is ~15-20 min: ~8 min S3 download (sec.lbug is
+        # ~120GB and growing) + OS/container setup + read-only DB open + warmup.
+        # PT30M keeps a fleet cycle from racing the signal deadline (PT20M was
+        # marginal and lost the race once the deploy stopped pinning the tag).
+        Timeout: PT30M
     UpdatePolicy:
       AutoScalingRollingUpdate:
         MinInstancesInService: !If [HasMinInstances, 1, 0]
         MaxBatchSize: 1
-        # Rolling updates also need time for download + warmup
-        PauseTime: PT20M
+        # Rolling updates re-download + warm up per instance; match the
+        # CreationPolicy signal budget above (was PT20M — too tight).
+        PauseTime: PT30M
         WaitOnResourceSignals: !If [HasMinInstances, true, false]
 
   # CPU-based Auto Scaling


### PR DESCRIPTION
## Problem

The prod deploy on 2026-07-21 failed at `deploy-graph / deploy-shared-replicas` — CloudFormation reported `ReplicaAutoScalingGroup UPDATE_FAILED: Received 0 SUCCESS signal(s) out of 2` and auto-rolled-back. Prod stayed healthy (the rollback restored a working replica fleet); only the replica *update* failed.

## Root cause

Cycling the SEC shared-replica fleet makes each new instance download the ~120GB `sec.lbug` from S3 (~8 min), open it read-only, and warm up before it can `cfn-signal`. That cold boot is **~15–20 min**, which was racing the stack's **`PT20M`** CreationPolicy / UpdatePolicy signal deadline.

It went unnoticed because most deploys don't cycle the fleet at all (no LaunchTemplate change → 30-second no-op). The move to the moving `prod` replica image tag changed `ECRImageTag`, which forced a one-time fleet cycle — and the boot lost the race.

Two GitHub caps also sat at 30 min and killed the run mid-cycle: the reusable job's `timeout-minutes` and the `monitor-stack-deployment` action's `timeout`.

## Change (config only — no engine/app change)

- `graph-ladybug-replicas.yaml`: CreationPolicy `Timeout` and UpdatePolicy `PauseTime` **PT20M → PT30M** (per-instance signal budget).
- `deploy-graph-replicas.yml`: job `timeout-minutes` **30 → 70**, monitor action `timeout` **1800 → 3600s** (a rolling cycle of two instances at MaxBatchSize 1 can run ~60 min).

Boot budget is now ~10 min over the observed cold-boot time, and the pipeline waits long enough to see a full cycle complete.

## Validation

`just cf-lint graph-ladybug-replicas` passes. Applies itself on the next prod deploy (the new UpdatePolicy governs that very rollout).