### PR TITLE
fix(reports): compose calc arcs cross-structure in IB statement rendering

### DIFF
--- a/robosystems/operations/information_block/statement.py
+++ b/robosystems/operations/information_block/statement.py
@@ -25,8 +25,9 @@ client-side rollup or hierarchy walk needed. The pure in-memory rollup
 helpers (``_build_rows``, ``_facts_to_balance_dict``, ``_natural_sign``)
 are imported from
 :mod:`robosystems.operations.roboledger.reports.fact_grid`; the
-hierarchy + calculations + classifications are derived from the
-already-loaded envelope atoms (no redundant SQL).
+hierarchy + classifications are derived from the already-loaded
+envelope atoms, and calculations compose cross-structure for
+``arithmetic`` blocks (see ``_build_statement_rendering``).
 """
 
 from __future__ import annotations
@@ -64,7 +65,9 @@ from robosystems.operations.roboledger.reports.fact_grid import (
   ReportFact,
   _Balance,  # type: ignore[reportPrivateUsage]
   _build_rows,  # type: ignore[reportPrivateUsage]
+  _collect_hierarchy_element_ids,  # type: ignore[reportPrivateUsage]
   _HierarchyNode,  # type: ignore[reportPrivateUsage]
+  _load_calculations,  # type: ignore[reportPrivateUsage]
 )
 from robosystems.operations.roboledger.reports.guard_rails import validate_report
 
@@ -156,6 +159,7 @@ def _build_statement_envelope(
     facts=facts,
     structure_id=structure.id,
     block_type=block_type,
+    concept_arrangement=structure.concept_arrangement,
   )
 
   # Statement-family types carry fixed display strings; block types that
@@ -211,6 +215,7 @@ def _build_statement_rendering(
   facts: list[Fact],
   structure_id: str,
   block_type: str,
+  concept_arrangement: str | None = None,
 ) -> RenderingLite:
   """Compute the Rendering view projection for a statement-family block.
 
@@ -218,9 +223,13 @@ def _build_statement_rendering(
   :mod:`robosystems.operations.roboledger.reports.fact_grid` (``_build_rows``)
   and the guard-rail checks from
   :mod:`robosystems.operations.roboledger.reports.guard_rails`
-  (``validate_report``). Hierarchy and calculations are derived from the
-  already-loaded ``associations`` (no redundant SQL); classifications are
-  fetched in a single trait-axis query.
+  (``validate_report``). The hierarchy is derived from the already-loaded
+  ``associations``; classifications are fetched in a single trait-axis
+  query. Calculations follow the block's concept arrangement:
+  ``arithmetic`` composes the calc DAG cross-structure in one query
+  (calc arcs live in sibling calculation structures, not in the
+  presentation block's own associations); other CAPs derive them from
+  the in-envelope associations with no extra SQL.
 
   Empty-fact case: returns ``RenderingLite`` with an empty ``rows`` list
   and an empty ``periods`` list — the envelope still validates and the
@@ -280,14 +289,27 @@ def _build_statement_rendering(
       )
     )
 
-  # 4) Build hierarchy + calculations from already-loaded associations.
+  # 4) Build hierarchy from already-loaded associations.
   hierarchy = _build_hierarchy_from_atoms(
     structure_id, elements_by_id, classification_by_id, associations
   )
   if not hierarchy:
     return RenderingLite(rows=[], periods=[], validation=None, unmapped_count=0)
 
-  calculations = _calculations_from_associations(associations)
+  # Calculation arcs — mirrors ``render_structure_view``. ``arithmetic``
+  # Disclosures keep presentation and calculation in SEPARATE structures
+  # (e.g. the rs-gaap Multi-step presentation block carries only
+  # presentation arcs; its calc DAG lives in the sibling "… calculation"
+  # structure), so the block's own associations can't identify Gross
+  # Profit / Operating Income as calc-target subtotals. Compose the calc
+  # DAG cross-structure in that case; other CAPs keep the in-envelope
+  # associations (single-structure convention, no extra SQL).
+  if concept_arrangement == "arithmetic":
+    calculations = _load_calculations(
+      session, element_ids=_collect_hierarchy_element_ids(hierarchy)
+    )
+  else:
+    calculations = _calculations_from_associations(associations)
 
   # 5) Per-period balance dicts (one per column).
   period_balances = [

--- a/robosystems/operations/roboledger/reports/guard_rails.py
+++ b/robosystems/operations/roboledger/reports/guard_rails.py
@@ -331,25 +331,36 @@ def _validate_cash_flow(rows: list[FactRow]) -> ValidationResult:
 def _check_totals_foot(rows: list[FactRow], result: ValidationResult) -> None:
   """Verify that subtotal rows equal the sum of their children.
 
-  Uses the row ordering: a subtotal row is followed by its children
-  (which have depth = subtotal.depth + 1) until the next row at the
-  same or lower depth.
+  ``_build_rows`` emits post-order — children first, then their parent
+  subtotal — so a subtotal's children are the rows immediately BEFORE it
+  with depth = subtotal.depth + 1, scanning back until a row at the same
+  or lower depth. (An earlier version scanned forward, which footed each
+  subtotal against the NEXT section's children — e.g. 'Revenues' against
+  Cost of Revenue's leaves — producing spurious warnings and silently
+  skipping the real check.)
+
+  Calc-target subtotals with no presentation children (Gross Profit,
+  Operating Income) have no preceding deeper rows and fall out via the
+  zero child_sum guard; their arithmetic is covered by the calc DAG and
+  the net-income equation. Value-less structural headers (abstract rows
+  rendered with all-None values) are skipped outright.
   """
   result.checks.append("totals_foot")
 
-  subtotal_indices = [i for i, r in enumerate(rows) if r.is_subtotal]
-
-  for idx in subtotal_indices:
-    subtotal = rows[idx]
+  for idx, subtotal in enumerate(rows):
+    if not subtotal.is_subtotal:
+      continue
+    if not any(v is not None for v in subtotal.values):
+      continue
     child_sum = 0.0
 
-    # Children follow the subtotal and have depth = subtotal.depth + 1
-    for j in range(idx + 1, len(rows)):
+    # Children precede the subtotal (post-order) at depth = subtotal.depth + 1.
+    # Only sum direct children, not grandchildren — grandchildren are
+    # already rolled into their parent subtotals.
+    for j in range(idx - 1, -1, -1):
       child = rows[j]
       if child.depth <= subtotal.depth:
         break
-      # Only sum direct children (depth = subtotal.depth + 1),
-      # not grandchildren — grandchildren are already rolled into their parent subtotals
       if child.depth == subtotal.depth + 1:
         child_sum += (child.values[0] or 0.0) if child.values else 0.0
 

--- a/tests/operations/information_block/test_statement_handlers.py
+++ b/tests/operations/information_block/test_statement_handlers.py
@@ -499,3 +499,127 @@ class TestRenderingSkipsNonnumericFacts:
     )
 
     assert rendering.rows == []
+
+
+class TestRenderingComposesCalcsCrossStructure:
+  """Regression: rs-gaap ``arithmetic`` statement blocks carry only
+  presentation arcs — their calc DAG lives in a sibling calculation
+  structure. The rendering must compose calcs cross-structure so
+  calc-target lines (Gross Profit, Net Income) are flagged
+  ``is_subtotal`` and the guard-rail Net Income reconciliation doesn't
+  double-count them as credit-nature leaves (Driftline FY2026:
+  reported 8,785.70 vs implied 131,957.06)."""
+
+  @staticmethod
+  def _elem(element_id: str, qname: str, balance_type: str) -> Any:
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+      id=element_id,
+      qname=qname,
+      name=element_id,
+      balance_type=balance_type,
+      is_abstract=False,
+    )
+
+  @staticmethod
+  def _fact(element_id: str, value: float) -> Any:
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+      element_id=element_id,
+      value=value,
+      period_start=date(2025, 7, 1),
+      period_end=date(2026, 6, 30),
+      period_type="duration",
+    )
+
+  @staticmethod
+  def _presentation_arc(from_id: str, to_id: str, order: float) -> MagicMock:
+    a = MagicMock()
+    a.association_type = "presentation"
+    a.from_element_id = from_id
+    a.to_element_id = to_id
+    a.order_value = order
+    return a
+
+  def _rendering(self, concept_arrangement: str | None) -> Any:
+    from types import SimpleNamespace
+
+    structure_id = "struct_is_multistep"
+    elements = [
+      self._elem("e_rev", "rs-gaap:Revenues", "credit"),
+      self._elem("e_cogs", "rs-gaap:CostOfRevenue", "debit"),
+      self._elem("e_gp", "rs-gaap:GrossProfit", "credit"),
+      self._elem("e_ni", "rs-gaap:NetIncomeLoss", "credit"),
+    ]
+    # Presentation-only block: flat lines anchored at the structure_id,
+    # no calculation associations in the envelope atoms.
+    associations = [
+      self._presentation_arc(structure_id, "e_rev", 0.0),
+      self._presentation_arc(structure_id, "e_cogs", 1.0),
+      self._presentation_arc(structure_id, "e_gp", 2.0),
+      self._presentation_arc(structure_id, "e_ni", 3.0),
+    ]
+    # The report FactSet stamps a fact on EVERY line, subtotals included.
+    facts = [
+      self._fact("e_rev", 300.0),
+      self._fact("e_cogs", 100.0),
+      self._fact("e_gp", 200.0),
+      self._fact("e_ni", 200.0),
+    ]
+
+    # session.execute #1: classification lookup (none mapped);
+    # session.execute #2 (arithmetic only): cross-structure calc arcs —
+    # GP = Revenues - CostOfRevenue; NI = GP.
+    calc_rows = [
+      SimpleNamespace(
+        structure_id="struct_is_calc",
+        from_element_id="e_gp",
+        to_element_id="e_rev",
+        weight=1.0,
+      ),
+      SimpleNamespace(
+        structure_id="struct_is_calc",
+        from_element_id="e_gp",
+        to_element_id="e_cogs",
+        weight=-1.0,
+      ),
+      SimpleNamespace(
+        structure_id="struct_is_calc",
+        from_element_id="e_ni",
+        to_element_id="e_gp",
+        weight=1.0,
+      ),
+    ]
+    session = MagicMock()
+    session.execute.side_effect = [_exec_result(all_rows=[]), calc_rows]
+
+    return statement_handlers._build_statement_rendering(
+      session,
+      elements=elements,  # type: ignore[arg-type]
+      associations=associations,  # type: ignore[arg-type]
+      facts=facts,  # type: ignore[arg-type]
+      structure_id=structure_id,
+      block_type="income_statement",
+      concept_arrangement=concept_arrangement,
+    )
+
+  def test_arithmetic_block_flags_calc_targets_and_validates(self) -> None:
+    rendering = self._rendering("arithmetic")
+
+    flags = {r.element_qname: r.is_subtotal for r in rendering.rows}
+    assert flags["rs-gaap:GrossProfit"] is True
+    assert flags["rs-gaap:NetIncomeLoss"] is True
+
+    assert rendering.validation is not None
+    assert rendering.validation.passed is True
+    assert not any("Net Income mismatch" in f for f in rendering.validation.failures)
+
+  def test_non_arithmetic_block_keeps_envelope_associations(self) -> None:
+    """roll_up blocks keep the single-structure convention: calcs come
+    from the envelope's own associations (none here), no calc SQL."""
+    rendering = self._rendering("roll_up")
+
+    flags = {r.element_qname: r.is_subtotal for r in rendering.rows}
+    assert flags["rs-gaap:GrossProfit"] is False

--- a/tests/operations/roboledger/reports/test_guard_rails.py
+++ b/tests/operations/roboledger/reports/test_guard_rails.py
@@ -387,11 +387,14 @@ class TestBalanceSheetValidation:
 
 
 class TestTotalsFoot:
+  # ``_build_rows`` emits post-order (children BEFORE their parent
+  # subtotal), so fixtures list leaves first.
+
   def test_matching_subtotals(self):
     rows = [
-      _row("Total", 300.0, is_subtotal=True, depth=0),
       _row("A", 100.0, depth=1),
       _row("B", 200.0, depth=1),
+      _row("Total", 300.0, is_subtotal=True, depth=0),
     ]
     result = validate_report("income_statement", rows)
     # totals_foot check should pass
@@ -402,13 +405,63 @@ class TestTotalsFoot:
 
   def test_mismatched_subtotals(self):
     rows = [
-      _row("Total", 999.0, is_subtotal=True, depth=0),
       _row("A", 100.0, depth=1),
       _row("B", 200.0, depth=1),
+      _row("Total", 999.0, is_subtotal=True, depth=0),
     ]
     result = validate_report("income_statement", rows)
     foot_warnings = [w for w in result.warnings if "does not match" in w]
     assert len(foot_warnings) == 1
+
+  def test_subtotal_not_footed_against_next_sections_children(self):
+    """Post-order regression: 'Revenues' must foot against its OWN leaf,
+    not the Cost of Revenue leaves that FOLLOW it in row order (the old
+    forward scan warned 'Revenues (189599.96) ≠ children (84000.00)')."""
+    rows = [
+      _row("Contract Revenue", 189599.96, depth=2),
+      _row("Revenues", 189599.96, is_subtotal=True, depth=1),
+      _row("COGS", 84000.0, classification="expense", depth=2),
+      _row(
+        "Cost of Revenue", 84000.0, classification="expense", is_subtotal=True, depth=1
+      ),
+    ]
+    result = validate_report("income_statement", rows)
+    foot_warnings = [w for w in result.warnings if "does not match" in w]
+    assert foot_warnings == []
+
+  def test_calc_target_subtotal_without_children_is_skipped(self):
+    """A calc-DAG subtotal (Gross Profit) has no presentation children —
+    no preceding deeper rows — and must not be footed against siblings."""
+    rows = [
+      _row("Revenues", 300.0, depth=1),
+      _row("Cost of Revenue", 100.0, classification="expense", depth=1),
+      _row(
+        "Gross Profit",
+        200.0,
+        classification="",
+        is_subtotal=True,
+        depth=1,
+        balance_type="credit",
+      ),
+    ]
+    result = validate_report("income_statement", rows)
+    foot_warnings = [w for w in result.warnings if "does not match" in w]
+    assert foot_warnings == []
+
+  def test_valueless_abstract_header_is_skipped(self):
+    """A multi-subtotal abstract header renders value-less (all None) and
+    must not warn when the backward scan reaches its depth-1 children."""
+    abstract = _row("Income Statement Abstract", 0.0, is_subtotal=True, depth=0)
+    abstract.values = [None]
+    abstract.is_abstract = True
+    rows = [
+      _row("A", 100.0, depth=1),
+      _row("B", 200.0, depth=1),
+      abstract,
+    ]
+    result = validate_report("income_statement", rows)
+    foot_warnings = [w for w in result.warnings if "does not match" in w]
+    assert foot_warnings == []
 
 
 class TestSemanticChecks:


### PR DESCRIPTION
## Summary

Filed-report statements rendered through the Information Block envelope failed guard-rail validation on correct data ("Net Income mismatch: reported 8,785.70 ≠ Σ(income − expense) 131,957.06" on the Driftline FY 2026 annual report). The envelope path derived its calc DAG from the block's own associations only — but `arithmetic` Disclosures keep presentation and calculation arcs in separate sibling structures, so the calc DAG came back empty, derived lines (Gross Profit, Operating Income, Income before Taxes, Net Income) lost their `is_subtotal` flag, and the validator double-counted them as credit-nature leaves. The live-statement path (`render_structure_view`) already composed calcs cross-structure and validated fine over the same books.

## Changes

- **`operations/information_block/statement.py`** — `_build_statement_rendering` now takes the block's `concept_arrangement`; for `arithmetic` it composes the calc DAG cross-structure in one query (`fact_grid._load_calculations(element_ids=…)` over the hierarchy's element set), mirroring `render_structure_view`. Other CAPs keep the in-envelope associations (single-structure convention, no extra SQL). Module/function docstrings updated to match.
- **`operations/roboledger/reports/guard_rails.py`** — `_check_totals_foot` now scans backwards: `_build_rows` emits post-order (children before their parent subtotal), so the old forward scan footed each subtotal against the *next* section's children — emitting spurious warnings (e.g. "Subtotal 'Revenues' (189,599.96) does not match sum of children (84,000.00)") while silently skipping the real footing check, including the load-bearing cash-flow one. Value-less abstract headers (all-`None` rows) are skipped explicitly.
- **Tests** — regression tests for the exact double-count scenario (presentation-only associations + facts stamped on derived lines) in `test_statement_handlers.py`, including the roll_up contrast case; `TestTotalsFoot` fixtures flipped to post-order plus new cases for the next-section false warning, childless calc-target subtotals, and value-less abstract headers.

## Testing

- `tests/operations/roboledger` + `tests/operations/information_block`: 953 passed.
- `just test-code` (ruff + format + basedpyright + cf-lint): clean.
- Verified end-to-end against the local stack: the Driftline multi-step income-statement envelope now returns `validation.passed: true` with zero failures/warnings, and all four derived lines carry `is_subtotal: true`, matching the live-statement path.
