### PR TITLE
fix(graphql): accept explicit null for defaulted resolver arguments

### DIFF
--- a/robosystems/graphql/resolvers/_common.py
+++ b/robosystems/graphql/resolvers/_common.py
@@ -36,6 +36,23 @@ _MAX_LIMIT = 1000
 _MIN_OFFSET = 0
 
 
+def resolve_pagination(
+  limit: int | None, offset: int | None, *, default_limit: int
+) -> tuple[int, int]:
+  """Default null pagination args, then bounds-check.
+
+  Generated SDK clients (graphql-codegen) pass explicit ``null`` for
+  every omitted variable, and GraphQL rejects explicit null for a
+  non-null argument even when it declares a default — so pagination
+  args are declared nullable in the schema (``Int`` rather than
+  ``Int! = N``) and defaulted here instead.
+  """
+  resolved_limit = default_limit if limit is None else limit
+  resolved_offset = 0 if offset is None else offset
+  validate_pagination(resolved_limit, resolved_offset)
+  return resolved_limit, resolved_offset
+
+
 def validate_pagination(limit: int, offset: int) -> None:
   """Reject out-of-range pagination args at the resolver boundary.
 

--- a/robosystems/graphql/resolvers/information_block.py
+++ b/robosystems/graphql/resolvers/information_block.py
@@ -23,7 +23,7 @@ from robosystems.graphql.resolvers._common import (
   open_library_session as _open_session,
 )
 from robosystems.graphql.resolvers._common import (
-  validate_pagination as _validate_pagination,
+  resolve_pagination as _resolve_pagination,
 )
 from robosystems.graphql.types.information_block import InformationBlock
 from robosystems.operations.information_block import (
@@ -61,8 +61,8 @@ class InformationBlockQuery:
     info: Info[GraphQLContext, None],
     block_type: str | None = None,
     category: str | None = None,
-    limit: int = 50,
-    offset: int = 0,
+    limit: int | None = None,
+    offset: int | None = None,
   ) -> list[InformationBlock]:
     """List Information Blocks with optional block_type + category filters.
 
@@ -70,7 +70,7 @@ class InformationBlockQuery:
     ``'schedule'``). ``category`` filters on the registry entry's
     category label ('Close', 'Reporting', …). Both combine as AND.
     """
-    _validate_pagination(limit, offset)
+    limit, offset = _resolve_pagination(limit, offset, default_limit=50)
     graph_id = require_graph_id(info)
     with _open_session(info) as session:
       rows = list_information_blocks(

--- a/robosystems/graphql/resolvers/investor.py
+++ b/robosystems/graphql/resolvers/investor.py
@@ -18,7 +18,7 @@ from robosystems.graphql.resolvers._common import (
   open_extensions_session as _open_session,
 )
 from robosystems.graphql.resolvers._common import (
-  validate_pagination as _validate_pagination,
+  resolve_pagination as _resolve_pagination,
 )
 from robosystems.graphql.types.investor import (
   HoldingsList,
@@ -79,11 +79,11 @@ class InvestorQuery:
   def portfolios(
     self,
     info: Info[GraphQLContext, None],
-    limit: int = 100,
-    offset: int = 0,
+    limit: int | None = None,
+    offset: int | None = None,
   ) -> PortfolioList | None:
     """Paginated list of portfolios."""
-    _validate_pagination(limit, offset)
+    limit, offset = _resolve_pagination(limit, offset, default_limit=100)
     try:
       with _open_session(info, "roboinvestor") as session:
         response = reads_portfolios.list_portfolios(session, limit=limit, offset=offset)
@@ -100,11 +100,11 @@ class InvestorQuery:
     entity_id: str | None = None,
     security_type: str | None = None,
     is_active: bool | None = None,
-    limit: int = 100,
-    offset: int = 0,
+    limit: int | None = None,
+    offset: int | None = None,
   ) -> SecurityList | None:
     """Paginated list of securities."""
-    _validate_pagination(limit, offset)
+    limit, offset = _resolve_pagination(limit, offset, default_limit=100)
     try:
       with _open_session(info, "roboinvestor") as session:
         response = reads_securities.list_securities(
@@ -144,11 +144,11 @@ class InvestorQuery:
     portfolio_id: str | None = None,
     security_id: str | None = None,
     status: str | None = None,
-    limit: int = 100,
-    offset: int = 0,
+    limit: int | None = None,
+    offset: int | None = None,
   ) -> PositionList | None:
     """Paginated list of positions."""
-    _validate_pagination(limit, offset)
+    limit, offset = _resolve_pagination(limit, offset, default_limit=100)
     try:
       with _open_session(info, "roboinvestor") as session:
         response = reads_positions.list_positions(

--- a/robosystems/graphql/resolvers/ledger.py
+++ b/robosystems/graphql/resolvers/ledger.py
@@ -26,7 +26,7 @@ from robosystems.graphql.resolvers._common import (
   open_extensions_session as _open_session,
 )
 from robosystems.graphql.resolvers._common import (
-  validate_pagination as _validate_pagination,
+  resolve_pagination as _resolve_pagination,
 )
 from robosystems.graphql.types.ledger import (
   AccountList,
@@ -209,11 +209,11 @@ class LedgerQuery:
     agent_type: str | None = None,
     source: str | None = None,
     is_active: bool | None = True,
-    limit: int = 50,
-    offset: int = 0,
+    limit: int | None = None,
+    offset: int | None = None,
   ) -> list[Agent]:
     """List counterparty agents with optional filters."""
-    _validate_pagination(limit, offset)
+    limit, offset = _resolve_pagination(limit, offset, default_limit=50)
     try:
       with _open_session(info, "roboledger") as session:
         responses = reads_agent.list_agents(
@@ -306,8 +306,8 @@ class LedgerQuery:
     status: str | None = None,
     agent_id: str | None = None,
     source: str | None = None,
-    limit: int = 50,
-    offset: int = 0,
+    limit: int | None = None,
+    offset: int | None = None,
   ) -> list[EventBlock]:
     """List event blocks with optional filters.
 
@@ -316,7 +316,7 @@ class LedgerQuery:
     inbox queue, ``committed`` for the audit-trail view), ``source``
     (``quickbooks`` / ``schedule`` / ``manual``), and ``event_type``.
     """
-    _validate_pagination(limit, offset)
+    limit, offset = _resolve_pagination(limit, offset, default_limit=50)
     try:
       with _open_session(info, "roboledger") as session:
         responses = reads_event_block.list_event_blocks(
@@ -401,11 +401,11 @@ class LedgerQuery:
     info: Info[GraphQLContext, None],
     classification: str | None = None,
     is_active: bool | None = None,
-    limit: int = 100,
-    offset: int = 0,
+    limit: int | None = None,
+    offset: int | None = None,
   ) -> AccountList | None:
     """Paginated Chart of Accounts listing."""
-    _validate_pagination(limit, offset)
+    limit, offset = _resolve_pagination(limit, offset, default_limit=100)
     try:
       with _open_session(info, "roboledger") as session:
         response = reads_accounts.list_accounts(
@@ -423,7 +423,7 @@ class LedgerQuery:
   def account_tree(
     self,
     info: Info[GraphQLContext, None],
-    include_inactive: bool = False,
+    include_inactive: bool | None = None,
   ) -> AccountTree | None:
     """Chart of Accounts as a recursive tree.
 
@@ -435,7 +435,7 @@ class LedgerQuery:
     try:
       with _open_session(info, "roboledger") as session:
         response = reads_accounts.get_account_tree(
-          session, include_inactive=include_inactive
+          session, include_inactive=bool(include_inactive)
         )
     except (ValueError, ProgrammingError):
       _raise_ledger_not_initialized()
@@ -495,11 +495,11 @@ class LedgerQuery:
     type: str | None = None,
     start_date: date | None = None,
     end_date: date | None = None,
-    limit: int = 100,
-    offset: int = 0,
+    limit: int | None = None,
+    offset: int | None = None,
   ) -> LedgerTransactionList | None:
     """Paginated list of transactions."""
-    _validate_pagination(limit, offset)
+    limit, offset = _resolve_pagination(limit, offset, default_limit=100)
     try:
       with _open_session(info, "roboledger") as session:
         response = reads_transactions.list_transactions(
@@ -570,11 +570,11 @@ class LedgerQuery:
     source: str | None = None,
     classification: str | None = None,
     is_abstract: bool | None = None,
-    limit: int = 100,
-    offset: int = 0,
+    limit: int | None = None,
+    offset: int | None = None,
   ) -> ElementList | None:
     """Paginated list of taxonomy elements."""
-    _validate_pagination(limit, offset)
+    limit, offset = _resolve_pagination(limit, offset, default_limit=100)
     try:
       with _open_session(info, "roboledger") as session:
         response = reads_taxonomies.list_elements(
@@ -865,8 +865,8 @@ class LedgerQuery:
     self,
     info: Info[GraphQLContext, None],
     report_id: str,
-    format: ReportDownloadFormat = ReportDownloadFormat.JSONLD,
-    expires_in: int = reads_reports.PRESIGN_DEFAULT_SECONDS,
+    format: ReportDownloadFormat | None = None,
+    expires_in: int | None = None,
   ) -> ReportBundleDownload | None:
     """Presigned download URL for a published Report's serialization bundle.
 
@@ -878,6 +878,10 @@ class LedgerQuery:
     doesn't exist; raises a typed error when it exists but has no
     published bundle yet.
     """
+    if format is None:
+      format = ReportDownloadFormat.JSONLD
+    if expires_in is None:
+      expires_in = reads_reports.PRESIGN_DEFAULT_SECONDS
     if not (60 <= expires_in <= reads_reports.PRESIGN_MAX_SECONDS):
       raise strawberry.exceptions.StrawberryGraphQLError(
         message=(
@@ -945,11 +949,11 @@ class LedgerQuery:
   def publish_lists(
     self,
     info: Info[GraphQLContext, None],
-    limit: int = 100,
-    offset: int = 0,
+    limit: int | None = None,
+    offset: int | None = None,
   ) -> PublishListList | None:
     """Paginated list of publish lists for this graph."""
-    _validate_pagination(limit, offset)
+    limit, offset = _resolve_pagination(limit, offset, default_limit=100)
     try:
       with _open_session(info, "roboledger") as session:
         response = reads_publish_lists.list_publish_lists(

--- a/robosystems/graphql/resolvers/library.py
+++ b/robosystems/graphql/resolvers/library.py
@@ -41,7 +41,7 @@ from robosystems.graphql.resolvers._common import (
   open_library_session as _open_session,
 )
 from robosystems.graphql.resolvers._common import (
-  validate_pagination as _validate_pagination,
+  resolve_pagination as _resolve_pagination,
 )
 from robosystems.graphql.types.library import (
   LibraryAssociation,
@@ -87,7 +87,7 @@ class LibraryQuery:
     self,
     info: Info[GraphQLContext, None],
     standard: str | None = None,
-    include_element_count: bool = False,
+    include_element_count: bool | None = None,
   ) -> list[LibraryTaxonomy]:
     """List taxonomies visible to this graph.
 
@@ -99,7 +99,7 @@ class LibraryQuery:
       rows = list_taxonomies(
         session,
         standard=standard,
-        include_element_count=include_element_count,
+        include_element_count=bool(include_element_count),
         shared_only=is_sentinel,
       )
       return [LibraryTaxonomy.from_pydantic(r) for r in rows]
@@ -111,7 +111,7 @@ class LibraryQuery:
     id: strawberry.ID | None = None,
     standard: str | None = None,
     version: str | None = None,
-    include_element_count: bool = False,
+    include_element_count: bool | None = None,
   ) -> LibraryTaxonomy | None:
     """Get a taxonomy by id or (standard, version)."""
     with _open_session(info) as session:
@@ -120,7 +120,7 @@ class LibraryQuery:
         taxonomy_id=str(id) if id else None,
         standard=standard,
         version=version,
-        include_element_count=include_element_count,
+        include_element_count=bool(include_element_count),
       )
       return LibraryTaxonomy.from_pydantic(row) if row else None
 
@@ -131,8 +131,8 @@ class LibraryQuery:
     taxonomy_id: strawberry.ID,
     association_type: str | None = None,
     structure_id: strawberry.ID | None = None,
-    limit: int = 200,
-    offset: int = 0,
+    limit: int | None = None,
+    offset: int | None = None,
   ) -> list[LibraryAssociation]:
     """List every arc contributed by a taxonomy (via its structures).
 
@@ -144,7 +144,7 @@ class LibraryQuery:
     Pass ``structure_id`` to scope to a single structure (one
     presentation/calculation hierarchy).
     """
-    _validate_pagination(limit, offset)
+    limit, offset = _resolve_pagination(limit, offset, default_limit=200)
     with _open_session(info) as session:
       rows = list_taxonomy_arcs(
         session,
@@ -185,10 +185,10 @@ class LibraryQuery:
     activity_type: str | None = None,
     element_type: str | None = None,
     is_abstract: bool | None = None,
-    limit: int = 50,
-    offset: int = 0,
-    include_labels: bool = False,
-    include_references: bool = False,
+    limit: int | None = None,
+    offset: int | None = None,
+    include_labels: bool | None = None,
+    include_references: bool | None = None,
   ) -> list[LibraryElement]:
     """List library elements with filters + pagination.
 
@@ -198,7 +198,7 @@ class LibraryQuery:
     be combined.
     `isAbstract=true` → abstract only; `false` → concrete only; omit for both.
     """
-    _validate_pagination(limit, offset)
+    limit, offset = _resolve_pagination(limit, offset, default_limit=50)
     with _open_session(info) as session:
       rows = list_elements(
         session,
@@ -210,8 +210,8 @@ class LibraryQuery:
         is_abstract=is_abstract,
         limit=limit,
         offset=offset,
-        include_labels=include_labels,
-        include_references=include_references,
+        include_labels=bool(include_labels),
+        include_references=bool(include_references),
       )
       return [LibraryElement.from_pydantic(r) for r in rows]
 
@@ -238,10 +238,10 @@ class LibraryQuery:
     info: Info[GraphQLContext, None],
     query: str,
     source: str | None = None,
-    limit: int = 50,
+    limit: int | None = None,
   ) -> list[LibraryElement]:
     """Substring search across qname, name, and standard label text."""
-    _validate_pagination(limit, 0)
+    limit, _ = _resolve_pagination(limit, None, default_limit=50)
     with _open_session(info) as session:
       rows = search_elements(session, query_text=query, limit=limit, source=source)
       return [LibraryElement.from_pydantic(r) for r in rows]
@@ -251,7 +251,7 @@ class LibraryQuery:
     self,
     info: Info[GraphQLContext, None],
     id: strawberry.ID,
-    max_depth: int = 5,
+    max_depth: int | None = None,
     structure_id: strawberry.ID | None = None,
   ) -> LibraryElementTreeNode | None:
     """Walk presentation arcs down from an element.
@@ -261,6 +261,7 @@ class LibraryQuery:
     statement variants (e.g. classified vs unclassified balance sheet)
     and a blended tree would misrepresent any single layout.
     """
+    max_depth = 5 if max_depth is None else max_depth
     if max_depth < 1 or max_depth > 10:
       raise strawberry.exceptions.StrawberryGraphQLError(
         message="max_depth must be between 1 and 10",

--- a/robosystems/graphql/resolvers/taxonomy_block.py
+++ b/robosystems/graphql/resolvers/taxonomy_block.py
@@ -23,7 +23,7 @@ from robosystems.graphql.resolvers._common import (
   open_library_session as _open_session,
 )
 from robosystems.graphql.resolvers._common import (
-  validate_pagination as _validate_pagination,
+  resolve_pagination as _resolve_pagination,
 )
 from robosystems.graphql.types.taxonomy_block import TaxonomyBlock
 from robosystems.operations.taxonomy_block.reads import (
@@ -62,8 +62,8 @@ class TaxonomyBlockQuery:
     taxonomy_type: str | None = None,
     parent_taxonomy_id: strawberry.ID | None = None,
     category: str | None = None,
-    limit: int = 50,
-    offset: int = 0,
+    limit: int | None = None,
+    offset: int | None = None,
   ) -> list[TaxonomyBlock]:
     """List Taxonomy Blocks with optional filters.
 
@@ -73,7 +73,7 @@ class TaxonomyBlockQuery:
     entry's category label (``'Chart'``, ``'Reporting'``, ``'Library'``,
     ``'Custom'``, ``'Close'``). Filters combine as AND.
     """
-    _validate_pagination(limit, offset)
+    limit, offset = _resolve_pagination(limit, offset, default_limit=50)
     graph_id = require_graph_id(info)
     with _open_session(info) as session:
       rows = list_taxonomy_blocks(

--- a/tests/graphql/extensions/test_information_block.py
+++ b/tests/graphql/extensions/test_information_block.py
@@ -162,6 +162,35 @@ class TestInformationBlocksQuery:
     assert items[0]["id"] == "struct_ib_01"
     assert items[1]["id"] == "struct_ib_02"
 
+  def test_explicit_null_pagination_variables_are_accepted(self) -> None:
+    """Regression: generated SDK clients (graphql-codegen) send explicit
+    ``null`` for every omitted variable. GraphQL rejects explicit null
+    for ``Int!`` args even with a server default, which broke the
+    roboledger-app Analytics list ("Argument 'offset' of non-null type
+    'Int!' must not be null"). Pagination args must be nullable and
+    defaulted server-side."""
+    with (
+      _patch_session(),
+      patch(LIST_PATH, return_value=[]) as mock_list,
+    ):
+      result = schema.execute_sync(
+        "query List($blockType: String, $category: String, $limit: Int, $offset: Int) {"
+        " informationBlocks(blockType: $blockType, category: $category,"
+        " limit: $limit, offset: $offset) { id } }",
+        variable_values={
+          "blockType": None,
+          "category": None,
+          "limit": 200,
+          "offset": None,
+        },
+        context_value=_ctx(),
+      )
+    assert result.errors is None
+    assert result.data["informationBlocks"] == []
+    _, kwargs = mock_list.call_args
+    assert kwargs["limit"] == 200
+    assert kwargs["offset"] == 0
+
   def test_returns_empty_list_on_library_sentinel(self) -> None:
     """Schedule has surfaces_in_library=False, so the sentinel returns []."""
     with (


### PR DESCRIPTION
## Summary

Generated SDK clients (graphql-codegen) pass explicit `null` for every omitted variable, but GraphQL rejects explicit `null` for a non-null argument even when it declares a default. Every list resolver declared pagination as `limit: Int! = N, offset: Int! = 0`, so any SDK call that omitted an option failed with `Argument 'offset' of non-null type 'Int!' must not be null`. First user-visible hit: the roboledger-app Analytics page could not list information blocks at all.

## Changes

- **`graphql/resolvers/_common.py`** — new `resolve_pagination(limit, offset, *, default_limit)` helper: defaults null pagination args server-side, then runs the existing `validate_pagination` bounds check.
- **All 14 paginated list resolvers** (`information_block`, `taxonomy_block`, `investor` ×3, `ledger` ×6, `library` ×3) — `limit`/`offset` declared nullable (`int | None = None`) and resolved through the helper, preserving each resolver's original default (50/100/200).
- **Other defaulted scalars the SDK can null out** — same nullable-with-server-default treatment: `include_element_count` (×2), `include_labels`, `include_references`, `max_depth` (library); `include_inactive`, `expires_in`, and the `ReportDownloadFormat` enum default (ledger).
- **`tests/graphql/extensions/test_information_block.py`** — regression test executing the list query through the real schema with explicit-null variables, asserting no errors and server-side defaulting.

Relaxing input nullability is backward-compatible — no SDK regeneration required; existing clients that send explicit nulls simply start working.

## Testing

- `tests/graphql`: 91 passed (including the new regression test).
- `just test-code` (ruff + format + basedpyright + cf-lint): clean.
- Verified against the local stack: the exact SDK request shape (explicit `null` for `blockType`/`category`/`offset`) now returns all 28 blocks; the Analytics page loads.
