### PR TITLE
chore(build): re-run OS package upgrades on every image build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -203,6 +203,7 @@ jobs:
             --cache-from type=gha,scope=main \
             --cache-to type=gha,scope=main,mode=max \
             --build-arg UV_CACHE_DIR=/tmp/uv-cache \
+            --build-arg CACHE_DATE=$(date -u +%Y%m%d) \
             $TAGS \
             -f Dockerfile .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -125,8 +125,11 @@ ENV PYTHONUNBUFFERED=1 \
     DAGSTER_HOME="/app/dagster_home" \
     FASTEMBED_CACHE_PATH="/app/fastembed_cache"
 
-# Install runtime dependencies, apply security patches, and install uv
-RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
+# Install runtime dependencies, apply security patches, and install uv.
+# CACHE_DATE (set per-build in build.yml) busts this layer so the upgrade
+# re-runs despite GHA layer caching — a cached layer keeps stale OS packages.
+ARG CACHE_DATE
+RUN echo "os-refresh ${CACHE_DATE}" && apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     libpq5 \
     libatomic1 \
     postgresql-client \


### PR DESCRIPTION
## Summary

Ensures OS-level security patches actually land in every image build. The runtime stage runs `apt-get upgrade -y`, but with GHA layer caching (`--cache-from type=gha,scope=main`) that layer is reused from cache and never re-executes — upgrades only landed when the base image digest happened to move. Same treatment as the three frontend apps (robosystems-app#214, roboledger-app#218, roboinvestor-app#187).

## Changes

**Dockerfile**

- Adds an `ARG CACHE_DATE` consumed at the start of the runtime stage's `apt-get upgrade` layer, so a changed value invalidates the layer and the upgrade re-runs.

**.github/workflows/build.yml**

- Passes `--build-arg CACHE_DATE=$(date -u +%Y%m%d)` to the main-image buildx invocation — the layer re-runs on the first build of each UTC day; same-day rebuilds keep full cache benefit. `Dockerfile.lambda` is untouched (AWS-managed base, no upgrade layer).

## Testing

- Pre-commit gate green (lint, cf-lint). The behavior change itself is exercised by the next image build; the Trivy scan in build.yml verifies the result.
