### PR TITLE
fix(sec): default knowledge-artifact DuckDB budget to 16GB

### DIFF
--- a/robosystems/adapters/sec/knowledge/artifact.py
+++ b/robosystems/adapters/sec/knowledge/artifact.py
@@ -79,7 +79,7 @@ class ElementKnowledgeBuilder:
     filing_count (INT32), disclosure_type (STRING)
   """
 
-  def __init__(self, memory_limit: str = "8GB") -> None:
+  def __init__(self, memory_limit: str = "16GB") -> None:
     self._memory_limit = memory_limit
 
   def build(self, db_path: str | Path) -> Path:
@@ -398,7 +398,7 @@ class StructureKnowledgeBuilder:
   2. structure_consensus.parquet — cross-filing majority-vote for identical structures
   """
 
-  def __init__(self, memory_limit: str = "8GB") -> None:
+  def __init__(self, memory_limit: str = "16GB") -> None:
     self._memory_limit = memory_limit
 
   def build(self, db_path: str | Path) -> tuple[Path, Path]:
@@ -556,7 +556,7 @@ class DisclosureProfileBuilder:
   2. disclosure_consensus.parquet — cross-filing majority-vote using disclosure type
   """
 
-  def __init__(self, memory_limit: str = "8GB") -> None:
+  def __init__(self, memory_limit: str = "16GB") -> None:
     self._memory_limit = memory_limit
 
   def build(self, db_path: str | Path) -> tuple[Path, Path]:

--- a/robosystems/adapters/sec/pipeline/artifact.py
+++ b/robosystems/adapters/sec/pipeline/artifact.py
@@ -33,14 +33,16 @@ class SECArtifactConfig(Config):
   """Configuration for SEC artifact generation."""
 
   duckdb_source: str = "sec"
-  # DuckDB memory budget per builder connection. MUST stay well under the ECS
-  # task memory (16GB) — the extractions spill to disk beyond this, but the
-  # extracted result set is still materialized in Python on top of DuckDB's
-  # buffer, so setting this near the container size starves Python and the
-  # kernel OOM-kills the task (SIGKILL). Raising it does NOT help a corpus that
-  # outgrew memory; the spill-to-disk path (see extractors._connect) does.
+  # DuckDB memory budget per builder connection, bounded on both sides. Too
+  # low and DuckDB itself OOMs on un-spillable block pins during the
+  # structure-composition extraction (an 8GB budget died this way on the
+  # Jul 2026 ~55GB corpus, regardless of task size). Too close to the ECS
+  # task memory (24GB, see jobs.py) and the result set materialized in
+  # Python on top of DuckDB's buffer starves the kernel into OOM-killing
+  # the task (SIGKILL — a 14GB budget on the older 16GB task). 16GB leaves
+  # ~8GB of Python headroom and cleared the Jul 2026 corpus.
   memory_limit: str = Field(
-    default="8GB",
+    default="16GB",
     description="DuckDB memory budget per builder; keep well below task memory.",
   )
   publish_r2: bool = False

--- a/robosystems/adapters/sec/pipeline/jobs.py
+++ b/robosystems/adapters/sec/pipeline/jobs.py
@@ -490,12 +490,13 @@ sec_artifact_generation_job = define_asset_job(
     "phase": "artifact",
     # Downloads full DuckDB staging file from S3 then runs graph algorithms.
     # DuckDB uses threads=1 + spill-to-disk (preserve_insertion_order=false) so
-    # its buffer stays bounded (~memory_limit, 8GB) and overflows to ephemeral.
-    # Peak is DuckDB budget + the Python result materialized on top: ~14.4 GB on
-    # the Mar 2026 104 GB corpus, which outgrew the 16 GB lower-bound and started
-    # OOM-killing (SIGKILL) as the corpus grew. 4 vCPU unlocks the >16 GB Fargate
-    # memory tier; 24 GB gives the Python side headroom (DuckDB stays capped +
-    # spills, so raising DuckDB's own memory_limit is the wrong lever here).
+    # its buffer stays bounded (~memory_limit, 16GB default) and overflows to
+    # ephemeral. Spill only bounds spillable operators: the Jul 2026 corpus
+    # OOM'd inside DuckDB at an 8GB budget on un-spillable block pins, which is
+    # why the default budget is 16GB (see SECArtifactConfig). Peak task usage
+    # is the DuckDB budget + the Python result materialized on top, so 24 GB
+    # keeps ~8 GB of Python headroom (a 14GB budget on the older 16 GB task
+    # SIGKILL'd). 4 vCPU unlocks the >16 GB Fargate memory tier.
     # Ephemeral: 200GB covers the DuckDB file + spill + artifacts.
     "ecs/cpu": "4096",
     "ecs/memory": "24576",

--- a/tests/adapters/sec/pipeline/test_artifact.py
+++ b/tests/adapters/sec/pipeline/test_artifact.py
@@ -20,13 +20,13 @@ class TestSECArtifactConfig:
     """Test default configuration values."""
     config = SECArtifactConfig()
     assert config.duckdb_source == "sec"
-    assert config.memory_limit == "8GB"
+    assert config.memory_limit == "16GB"
 
   def test_custom_values(self):
     """Test custom configuration values."""
-    config = SECArtifactConfig(duckdb_source="sec_historical", memory_limit="16GB")
+    config = SECArtifactConfig(duckdb_source="sec_historical", memory_limit="12GB")
     assert config.duckdb_source == "sec_historical"
-    assert config.memory_limit == "16GB"
+    assert config.memory_limit == "12GB"
 
 
 @pytest.mark.unit
@@ -178,15 +178,15 @@ class TestSecKnowledgeArtifacts:
     )
     mock_disclosure_builder_cls.return_value = mock_disclosure_builder
 
-    config = SECArtifactConfig(memory_limit="16GB")
+    config = SECArtifactConfig(memory_limit="12GB")
     context = build_asset_context()
 
     sec_knowledge_artifacts(context, config)
 
     # Verify memory limit passed to builders
-    mock_element_builder_cls.assert_called_once_with(memory_limit="16GB")
-    mock_structure_builder_cls.assert_called_once_with(memory_limit="16GB")
-    mock_disclosure_builder_cls.assert_called_once_with(memory_limit="16GB")
+    mock_element_builder_cls.assert_called_once_with(memory_limit="12GB")
+    mock_structure_builder_cls.assert_called_once_with(memory_limit="12GB")
+    mock_disclosure_builder_cls.assert_called_once_with(memory_limit="12GB")
 
   @patch("robosystems.adapters.sec.knowledge.framework.DuckDBAnalyticsContext")
   @patch("robosystems.adapters.sec.knowledge.artifact.ElementKnowledgeBuilder")


### PR DESCRIPTION
## Summary

Prod `sec_artifact_generation` runs OOM at the current 8GB default DuckDB budget — run `d65c59c1` (2026-07-21) died with a DuckDB-internal `OutOfMemoryException` ("failed to pin block of size 256.0 KiB (7.4 GiB/7.4 GiB used)") in `extract_structure_compositions`, and run `cd5ad437` (2026-07-22) succeeded with `memory_limit: 16GB` on the same corpus in ~50 min. This makes 16GB the default so scheduled runs don't need a manual config override.

The spill-to-disk path added in a78f10c0 only bounds spillable operators; the structure-composition extraction pins blocks DuckDB can't evict, so the budget itself has to cover it. The 24GB task keeps ~8GB of Python headroom above the new default (a 14GB budget on the older 16GB task SIGKILL'd, so the ceiling is real and documented).

## Changes

- `SECArtifactConfig.memory_limit` default `8GB` → `16GB`, with the comment rewritten to document both failure modes (DuckDB-internal OOM below, kernel SIGKILL near task memory)
- `sec_artifact_generation_job` tag comment updated — the "raising DuckDB's own memory_limit is the wrong lever" claim is now disproven for the un-spillable pin failure mode
- Builder-class defaults (`ElementKnowledgeBuilder`, `StructureKnowledgeBuilder`, `DisclosureProfileBuilder`) aligned to 16GB so direct construction can't regress to the known-OOM budget
- Tests: default assertion updated; custom-value tests switched to 12GB so they stay distinct from the new default

## Testing

- `uv run pytest tests/adapters/sec/pipeline/test_artifact.py tests/adapters/sec/knowledge/` — 191 passed
- `just test-code` — clean
- Validated in prod: 16GB run `cd5ad437-0f54-4be4-9cb1-cb1001ed445f` succeeded end-to-end incl. S3 + R2 publish