### PR TITLE
fix(roboledger): scope CoA reads to chart-of-accounts taxonomies

### DIFF
--- a/robosystems/operations/roboledger/reads/account_rollups.py
+++ b/robosystems/operations/roboledger/reads/account_rollups.py
@@ -79,6 +79,9 @@ _UNMAPPED_SQL = text("""
   SELECT COUNT(*) AS cnt
   FROM elements e
   WHERE e.source = ANY(:sources)
+    AND (e.taxonomy_id IS NULL OR e.taxonomy_id IN (
+      SELECT id FROM taxonomies WHERE taxonomy_type = 'chart_of_accounts'
+    ))
     AND e.is_active = true
     AND e.is_abstract = false
     AND NOT EXISTS (

--- a/robosystems/operations/roboledger/reads/accounts.py
+++ b/robosystems/operations/roboledger/reads/accounts.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from sqlalchemy import func, select
+from sqlalchemy import and_, func, or_, select
 from sqlalchemy.orm import Session
 
 from robosystems.models.api.common import create_pagination_info
@@ -18,10 +18,32 @@ from robosystems.models.api.extensions.accounts import (
 from robosystems.models.extensions import (
   Element,
   ElementTrait,
+  Taxonomy,
   Trait,
 )
 from robosystems.models.extensions.roboledger import COA_SOURCES
 from robosystems.operations.library.reads import efs_trait_by_element
+
+
+def coa_element_clause():
+  """Predicate for "this elements row is a Chart-of-Accounts account".
+
+  ``source`` alone cannot discriminate: envelope-authored framework
+  concepts (``reporting_extension`` / ``custom_ontology`` / ``schedule``
+  taxonomies) share ``source='native'`` with natively-authored CoA
+  accounts, and would otherwise leak into every CoA-scoped read.
+  Adapter-imported accounts (QuickBooks, …) carry no ``taxonomy_id``,
+  so NULL-taxonomy rows stay in.
+  """
+  return and_(
+    Element.source.in_(COA_SOURCES),
+    or_(
+      Element.taxonomy_id.is_(None),
+      Element.taxonomy_id.in_(
+        select(Taxonomy.id).where(Taxonomy.taxonomy_type == "chart_of_accounts")
+      ),
+    ),
+  )
 
 
 def _parse_meta(raw: Any) -> dict[str, Any]:
@@ -78,10 +100,8 @@ def list_accounts(
   ``trait`` filters on the FASB elementsOfFinancialStatements
   trait via the element_traits junction table.
   """
-  query = select(Element).where(Element.source.in_(COA_SOURCES))
-  count_query = (
-    select(func.count()).select_from(Element).where(Element.source.in_(COA_SOURCES))
-  )
+  query = select(Element).where(coa_element_clause())
+  count_query = select(func.count()).select_from(Element).where(coa_element_clause())
 
   if trait is not None:
     subquery = (
@@ -124,7 +144,7 @@ def get_account_tree(
   every CoA-facing view. Pass ``include_inactive=True`` to surface them
   (admin / cleanup contexts only).
   """
-  query = select(Element).where(Element.source.in_(COA_SOURCES))
+  query = select(Element).where(coa_element_clause())
   if not include_inactive:
     query = query.where(Element.is_active.is_(True))
   rows = session.execute(query.order_by(Element.code)).scalars().all()

--- a/robosystems/operations/roboledger/reads/taxonomies.py
+++ b/robosystems/operations/roboledger/reads/taxonomies.py
@@ -35,8 +35,7 @@ from robosystems.operations.library.reads import (
   efs_trait_by_element,
   liquidity_by_element,
 )
-
-_COA_SOURCES = ("quickbooks", "xero", "plaid", "native", "import")
+from robosystems.operations.roboledger.reads.accounts import coa_element_clause
 
 
 class MappingNotFoundError(LookupError):
@@ -192,7 +191,7 @@ def count_coa_elements(session: Session) -> int:
       select(func.count())
       .select_from(Element)
       .where(
-        Element.source.in_(_COA_SOURCES),
+        coa_element_clause(),
         Element.is_active.is_(True),
         Element.is_abstract.is_(False),
       )
@@ -328,7 +327,7 @@ def list_unmapped_elements(
 ) -> list[UnmappedElementResponse]:
   """List CoA elements not yet mapped to the reporting taxonomy."""
   coa_query = select(Element).where(
-    Element.source.in_(_COA_SOURCES),
+    coa_element_clause(),
     Element.is_active.is_(True),
     Element.is_abstract.is_(False),
   )
@@ -878,7 +877,7 @@ def get_mapping_coverage(session: Session, mapping_id: str) -> MappingCoverageRe
       select(func.count())
       .select_from(Element)
       .where(
-        Element.source.in_(_COA_SOURCES),
+        coa_element_clause(),
         Element.is_active.is_(True),
         Element.is_abstract.is_(False),
       )

--- a/robosystems/operations/roboledger/reports/fact_grid.py
+++ b/robosystems/operations/roboledger/reports/fact_grid.py
@@ -1788,6 +1788,9 @@ def _count_unmapped(
       SELECT COUNT(*) AS cnt
       FROM elements e
       WHERE e.source = ANY(:sources)
+        AND (e.taxonomy_id IS NULL OR e.taxonomy_id IN (
+          SELECT id FROM taxonomies WHERE taxonomy_type = 'chart_of_accounts'
+        ))
         AND e.is_active = true
         AND NOT EXISTS (
           SELECT 1 FROM associations ea

--- a/robosystems/scripts/framework_validate.py
+++ b/robosystems/scripts/framework_validate.py
@@ -59,7 +59,7 @@ from robosystems.config.constants import ReportingStyleConstants
 
 # NOTE — accepted coupling: this validator deliberately reuses several
 # underscore-prefixed internals from the operations/reporting layer
-# (_load_calc_parents, _resolve_root_ids, _COA_SOURCES, _load_reporting_structure,
+# (_load_calc_parents, _resolve_root_ids, _load_reporting_structure,
 # _HierarchyNode, _get_engine, _sanitize_schema). It has to, to see the framework
 # *exactly* as the renderer does. The cost is that a refactor of those modules can
 # break this script with no import-time signal — so the pure-logic helpers are
@@ -71,11 +71,11 @@ from robosystems.db.extensions import (
   extensions_session,
   provision_tenant_schema,
 )
+from robosystems.models.extensions.roboledger import COA_SOURCES as _COA_SOURCES
 from robosystems.operations.operators.implementations.mapping.constants import (
   FAC_TO_RS_GAAP_FALLBACK,
 )
 from robosystems.operations.roboledger.reads.taxonomies import (
-  _COA_SOURCES,
   _load_calc_parents,
   _resolve_root_ids,
   is_target_reachable,

--- a/tests/operations/roboledger/reads/test_accounts_taxonomy_scope.py
+++ b/tests/operations/roboledger/reads/test_accounts_taxonomy_scope.py
@@ -1,0 +1,104 @@
+"""Taxonomy scoping of the CoA-facing reads.
+
+``Element.source`` alone cannot discriminate a Chart-of-Accounts
+account: envelope-authored framework concepts (``reporting_extension``
+/ ``custom_ontology`` taxonomy blocks) share ``source='native'`` with
+natively-authored CoA accounts, so a source-only filter leaks tenant
+framework concepts (disclosure members, policy text blocks) into every
+CoA surface — the accounts page, the mapping-coverage denominator, and
+the unmapped-elements feed that drives auto-mapping.
+
+``coa_element_clause`` adds the taxonomy discriminator: an element is
+CoA if its source matches AND it either has no taxonomy (adapter
+imports set ``taxonomy_id=NULL``) or belongs to a
+``taxonomy_type='chart_of_accounts'`` taxonomy.
+
+These tests verify the discriminator is present in the compiled SQL of
+each CoA-scoped read. End-to-end correctness is exercised by the
+integration tests.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from sqlalchemy.dialects import postgresql
+
+from robosystems.operations.roboledger.reads import accounts as reads_accounts
+from robosystems.operations.roboledger.reads import taxonomies as reads_taxonomies
+
+
+def _compiled_sql(call_args) -> str:
+  stmt = call_args[0][0]
+  return str(stmt.compile(dialect=postgresql.dialect()))
+
+
+def _assert_taxonomy_guard(sql: str) -> None:
+  """The guard: taxonomy_id IS NULL OR taxonomy_id IN (CoA taxonomies)."""
+  assert "elements.taxonomy_id IS NULL" in sql, (
+    f"Expected NULL-taxonomy arm (adapter-imported accounts) in SQL, got:\n{sql}"
+  )
+  assert "taxonomies.taxonomy_type" in sql, (
+    f"Expected taxonomy_type subquery arm in SQL, got:\n{sql}"
+  )
+
+
+def _session_with_no_rows() -> MagicMock:
+  session = MagicMock()
+  session.execute.return_value.scalars.return_value.all.return_value = []
+  return session
+
+
+class TestCoaElementClause:
+  def test_clause_carries_source_and_taxonomy_discriminator(self):
+    clause = reads_accounts.coa_element_clause()
+    sql = str(clause.compile(dialect=postgresql.dialect()))
+    assert "elements.source IN" in sql
+    _assert_taxonomy_guard(sql)
+
+
+class TestAccountReadsScoped:
+  def test_get_account_tree_excludes_framework_concepts(self):
+    session = _session_with_no_rows()
+    reads_accounts.get_account_tree(session)
+    _assert_taxonomy_guard(_compiled_sql(session.execute.call_args))
+
+  def test_list_accounts_excludes_framework_concepts(self):
+    session = _session_with_no_rows()
+    session.execute.return_value.scalar.return_value = 0
+    reads_accounts.list_accounts(session)
+    # Both the count query and the row query must carry the guard.
+    for call in session.execute.call_args_list:
+      _assert_taxonomy_guard(_compiled_sql(call))
+
+
+class TestTaxonomyReadsScoped:
+  def test_count_coa_elements_excludes_framework_concepts(self):
+    session = MagicMock()
+    session.execute.return_value.scalar.return_value = 0
+    reads_taxonomies.count_coa_elements(session)
+    _assert_taxonomy_guard(_compiled_sql(session.execute.call_args))
+
+  def test_list_unmapped_elements_excludes_framework_concepts(self):
+    session = _session_with_no_rows()
+    reads_taxonomies.list_unmapped_elements(session)
+    # First execute is the CoA-element query; the second loads mapped ids.
+    _assert_taxonomy_guard(_compiled_sql(session.execute.call_args_list[0]))
+
+
+class TestRawSqlCountsScoped:
+  def test_account_rollups_unmapped_sql_has_guard(self):
+    from robosystems.operations.roboledger.reads import account_rollups
+
+    sql = account_rollups._UNMAPPED_SQL.text
+    assert "taxonomy_id IS NULL" in sql
+    assert "taxonomy_type = 'chart_of_accounts'" in sql
+
+  def test_fact_grid_count_unmapped_has_guard(self):
+    import inspect
+
+    from robosystems.operations.roboledger.reports import fact_grid
+
+    src = inspect.getsource(fact_grid._count_unmapped)
+    assert "taxonomy_id IS NULL" in src
+    assert "taxonomy_type = 'chart_of_accounts'" in src


### PR DESCRIPTION
## Problem

Envelope-authored framework concepts (reporting_extension / custom_ontology taxonomy blocks) share `source='native'` with natively-authored CoA accounts, and the CoA-facing reads keyed "is this a Chart-of-Accounts account?" on `Element.source` alone. Tenant-authored disclosure members and policy text blocks therefore leaked into every CoA surface:

- The Chart of Accounts page listed policy text blocks and disclosure members as accounts (with a defaulted Debit balance and no classification)
- The mapping-coverage denominator was inflated (27/35 instead of 27/27)
- `get-unmapped-elements` fed them to suggest-mapping / Auto-Map, so the MappingOperator would try to map policy notes to GAAP concepts

## Fix

New `coa_element_clause()` predicate: `source IN COA_SOURCES AND (taxonomy_id IS NULL OR taxonomy_type = 'chart_of_accounts')`. The NULL arm keeps adapter-imported accounts (QuickBooks sets no `taxonomy_id`); the taxonomy arm excludes framework concepts, which always belong to their authoring taxonomy.

Applied to:
- `reads/accounts.py` — `list_accounts`, `get_account_tree` (+ the new shared clause)
- `reads/taxonomies.py` — `count_coa_elements`, `list_unmapped_elements`, mapping-summary denominator (local `_COA_SOURCES` tuple removed)
- `reads/account_rollups.py` — `_UNMAPPED_SQL`
- `reports/fact_grid.py` — `_count_unmapped`
- `scripts/framework_validate.py` — repoints its `_COA_SOURCES` import at the canonical `COA_SOURCES` (diagnostic behavior unchanged)

## Verification

- New compiled-SQL tests (`test_accounts_taxonomy_scope.py`) assert the discriminator on every scoped read
- Verified live against the Driftline demo graph: `accountTree.totalAccounts` 35 → 27, with exactly the real accounts returned

Companion frontend PR (roboledger-app): surfaces the tenant-authored reporting-extension taxonomies in the Taxonomy Library picker.