### PR TITLE
fix(migrations): admit rs-metric source and Derive pattern in fresh-database seeds

### DIFF
--- a/migrations/extensions/versions/0002_taxonomy_library.py
+++ b/migrations/extensions/versions/0002_taxonomy_library.py
@@ -129,7 +129,10 @@ _WIDENED_ELEMENT_SOURCE_CHECK = (
   # for the same widen applied to already-deployed tenant schemas.
   # 'cm' — Conceptual Model framework (cm:Debit/cm:Credit posting roles),
   # seeded here via rs-gaap depends_on cm and tenant-copied with the pin.
-  "'disclosures', 'checklist', 'styles', 'cm'"
+  # 'rs-metric' — the metric catalog package (0022's backfill for existing
+  # databases; fresh seeds pick it up here because this seed reads the
+  # current frameworks/ manifest, which lists rs-metric).
+  "'disclosures', 'checklist', 'styles', 'cm', 'rs-metric'"
   ")"
 )
 _WIDENED_TAXONOMY_TYPE_CHECK = (
@@ -210,7 +213,9 @@ _RULE_CATEGORY_CHECK = (
 )
 _RULE_PATTERN_CHECK = (
   "rule_pattern IS NULL OR rule_pattern IN ("
-  "'Adjustment', 'CoExists', 'EqualTo', 'Exists', 'GreaterThan', "
+  # 'Derive' — compute-a-value rules (the rs-metric catalog seeds them;
+  # 0022 widens already-deployed databases the same way).
+  "'Adjustment', 'CoExists', 'Derive', 'EqualTo', 'Exists', 'GreaterThan', "
   "'GreaterThanOrEqualToZero', 'LessThan', 'RollForward', 'RollUp', "
   "'SumEquals', 'Variance'"
   ")"

--- a/migrations/extensions/versions/0007_frameworks_bridges.py
+++ b/migrations/extensions/versions/0007_frameworks_bridges.py
@@ -259,7 +259,9 @@ _WIDENED_ELEMENT_SOURCE_CHECK = (
   # 'cm' — Conceptual Model framework (cm:Debit/cm:Credit posting roles).
   # Re-applied here so the DROP+ADD over already-seeded public + tenant
   # schemas (which now contain cm rows) doesn't fail constraint validation.
-  "'disclosures', 'checklist', 'styles', 'cm'"
+  # 'rs-metric' — same reason: fresh databases seed the metric catalog at
+  # 0002, so the rows exist when this DROP+ADD re-validates them.
+  "'disclosures', 'checklist', 'styles', 'cm', 'rs-metric'"
   ")"
 )
 _PRIOR_ELEMENT_SOURCE_CHECK = (

--- a/robosystems/models/extensions/element.py
+++ b/robosystems/models/extensions/element.py
@@ -106,7 +106,9 @@ class Element(ExtensionsBase):
       "'quickbooks', 'xero', 'plaid', 'native', 'import', 'system', "
       # 'cm' — Conceptual Model posting-role concepts (cm:Debit/cm:Credit),
       # tenant-copied with the default pin so schedule has-part arcs resolve.
-      "'cm')",
+      # 'rs-metric' — the metric catalog package (seeded at 0002 on fresh
+      # databases, backfilled by 0022 on existing ones).
+      "'cm', 'rs-metric')",
       name="check_element_source",
     ),
   )

--- a/tests/taxonomy/test_rules_migration_shape.py
+++ b/tests/taxonomy/test_rules_migration_shape.py
@@ -135,7 +135,10 @@ class TestPhaseCCheckWidens:
   most common authoring footgun when adding a new package."""
 
   def test_element_source_check_admits_phase_c_namespaces(self) -> None:
-    for prefix in ("disclosures", "checklist", "styles"):
+    # 'rs-metric' rides the same rule: 0002's dynamic seed picks the
+    # package up from the current manifest, so fresh DBs insert its
+    # elements before 0022's backfill widening ever runs.
+    for prefix in ("disclosures", "checklist", "styles", "rs-metric"):
       assert f"'{prefix}'" in mig_0002._WIDENED_ELEMENT_SOURCE_CHECK, (
         f"namespace prefix {prefix!r} missing from element source CHECK"
       )
@@ -154,16 +157,20 @@ class TestRuleCheckConstraints:
       )
 
   def test_pattern_check_lists_every_enum_value(self) -> None:
-    """The effective CHECK for any DB is 0002's re-added by 0022's
-    widening ('Derive'), so the loader enum asserts against 0022's
-    final constant."""
+    """0002's seed is dynamic (it reads the current frameworks/ manifest,
+    which lists rs-metric), so a fresh DB inserts Derive rules AT 0002 —
+    its CHECK must admit every loader-enum pattern, same as 0022's final
+    constant for already-deployed DBs. Drift here is exactly the
+    fresh-database CheckViolation this test exists to prevent."""
     for pattern in RULE_PATTERN_VALUES:
       assert f"'{pattern}'" in mig_0022._RULE_PATTERN_WIDENED, (
         f"pattern {pattern!r} missing from 0022 _RULE_PATTERN_WIDENED"
       )
-    # 0022's widening must be a strict superset of 0002's original.
+      assert f"'{pattern}'" in mig_0002._RULE_PATTERN_CHECK, (
+        f"pattern {pattern!r} missing from 0002 _RULE_PATTERN_CHECK"
+      )
     assert "'Derive'" in mig_0022._RULE_PATTERN_WIDENED
-    assert "'Derive'" not in mig_0002._RULE_PATTERN_CHECK
+    assert "'Derive'" in mig_0002._RULE_PATTERN_CHECK
 
   def test_severity_check_enumerates_info_warning_error(self) -> None:
     for severity in ("info", "warning", "error"):


### PR DESCRIPTION
## Problem

A from-scratch environment (`just reset-local`, new deployment, BYOC install) fails during `migrate-up extensions`: migration 0002's library seed is **dynamic** — it reads the current `frameworks/` manifest, which now lists the rs-metric package (shipped in #894) — but 0002's frozen `check_element_source` list predates rs-metric, so the seed dies on `CheckViolation` inserting `rs-metric:*` elements before 0022 (which widens the constraint for existing databases) ever runs.

0022's own docstring states fresh deployments get the widened vocabulary from 0002 and the models — that edit was missed in #894. Same drift for the `Derive` rule pattern (rs-metric seeds Derive rules at 0002).

**Deployed environments are unaffected**: they ran 0002 before rs-metric existed and were widened by 0022; Alembic never re-runs applied revisions. This edit only changes what fresh databases do, converging them to the same end state deployed environments already have — the same in-place pattern used for `'cm'` and the `'metric'` block type.

## Fix

- `0002_taxonomy_library.py`: `_WIDENED_ELEMENT_SOURCE_CHECK` += `'rs-metric'`; `_RULE_PATTERN_CHECK` += `'Derive'`
- `0007_frameworks_bridges.py`: `_WIDENED_ELEMENT_SOURCE_CHECK` += `'rs-metric'` (its DROP+ADD re-validates the rs-metric rows 0002 now seeds)
- `models/extensions/element.py`: model CHECK += `'rs-metric'` (0022 claimed the models carried it; they didn't)

## Verification

- Reproduced the failure on a fresh local DB, applied the fix, and `migrate-up extensions` now completes 0001→0022 from scratch: 22 library taxonomies seeded, 6 rs-metric elements land at 0002, 0022's upserts are cleanly idempotent over them
- `test_rs_metric_seed.py` + migration-shape tests pass; full `just test-code` clean

## Follow-up (not in this PR)

The drift will recur with every future package: 0002's dynamic seed always tracks current `frameworks/` while its CHECK lists are frozen. Longer-term options: pin 0002 to its original package set (frozen migrations, frozen behavior) and let each package migration seed itself idempotently, or derive the CHECK list from the manifest at seed time.