### PR TITLE
docs(frameworks): document the graph-pin vs entity-adoption split

### DIFF
--- a/frameworks/README.md
+++ b/frameworks/README.md
@@ -34,14 +34,14 @@ Every reporting domain in this library — accounting GAAP today, IFRS /
 call report / tax / energy reporting in the future — shares the same
 shape:
 
-| Layer | Role | Examples |
-| --- | --- | --- |
-| **Upstream authority** | Publishes a taxonomy nobody edits but everyone files against | FASB us-gaap, IASB IFRS, NAIC statutory, FFIEC call report, FERC Form 1, EIA-861, EPA TRI |
-| **`rs-` curation** | Our authored, edited, render-target version of the upstream | `rs-gaap` (today); future `rs-ifrs`, `rs-call-report`, `rs-irs`, `rs-ferc`, `rs-statutory`, `rs-tri` |
-| **Framework manifest** | Pins packages + bridges + Styles into one composable deliverable | `rs-gaap/v1.json` |
-| **Reporting Styles** | Vertical / filer-profile variants **within** a framework | Default, Small Private Company, Banking, Insurance, Mining, Cannabis (defined inside `rs-gaap-reporting-styles/v1/`) |
-| **Bridges** | Equivalences between namespaces (curation ↔ upstream for filing, or curation ↔ peer) | `fac-to-rs-gaap`, future `rs-gaap-to-us-gaap` (SEC export), `rs-gaap-to-ifrs` |
-| **Tenant CoA → curation mapping** | Per-graph: a customer's chart of accounts → rs-* leaves | LINE_ITEM_RELATES_TO_ELEMENT + Associations (lives in the tenant schema, not here) |
+| Layer                             | Role                                                                                 | Examples                                                                                                   |
+| --------------------------------- | ------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------- |
+| **Upstream authority**            | Publishes a taxonomy nobody edits but everyone files against                         | FASB us-gaap, IASB IFRS, NAIC statutory, FFIEC call report, FERC Form 1, EIA-861, EPA TRI                  |
+| **`rs-` curation**                | Our authored, edited, render-target version of the upstream                          | `rs-gaap` (today); future `rs-ifrs`, `rs-call-report`, `rs-irs`, `rs-ferc`, `rs-statutory`, `rs-tri`       |
+| **Framework manifest**            | Pins packages + bridges + Styles into one composable deliverable                     | `rs-gaap/v1.json`                                                                                          |
+| **Reporting Styles**              | Vertical / filer-profile variants **within** a framework                             | Default, Small Private Company, Banking, Insurance, Mining (defined inside `rs-gaap-reporting-styles/v1/`) |
+| **Bridges**                       | Equivalences between namespaces (curation ↔ upstream for filing, or curation ↔ peer) | `fac-to-rs-gaap`, future `rs-gaap-to-us-gaap` (SEC export), `rs-gaap-to-ifrs`                              |
+| **Tenant CoA → curation mapping** | Per-graph: a customer's chart of accounts → rs-\* leaves                             | LINE_ITEM_RELATES_TO_ELEMENT + Associations (lives in the tenant schema, not here)                         |
 
 The unit doesn't have to be currency. XBRL already handles non-monetary
 units (MWh, barrels, tons CO₂e, headcount), and our Fact model inherits
@@ -50,13 +50,13 @@ without special-casing.
 
 ## Framework vs. Reporting Style — don't conflate them
 
-| | Framework | Reporting Style |
-| --- | --- | --- |
-| **What it is** | A self-contained taxonomy stack with its own concept namespace, presentation, calc, and rules | A vertical / filer-profile composition of named Disclosures *within* a framework |
-| **Cardinality** | A few (one per regulatory regime: GAAP, IFRS, call report, tax, FERC, …) | Many per framework (Default, Small Private, Banking, Insurance, Mining, Cannabis, …) |
-| **Lives at** | `{name}/{version}.json` (+ shared `packages/` and `bridges/` siblings) | Rows inside the `*-reporting-styles/v1/` package of a framework |
-| **Pinned by** | Graph (entity → framework via `Graph.taxonomy_pin`) | Entity within a graph (provisioning-time selection) |
-| **Example** | `rs-gaap@v1` for US GAAP filers | `Banking Style` for an entity in `rs-gaap@v1` |
+|                 | Framework                                                                                                                     | Reporting Style                                                                  |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| **What it is**  | A self-contained taxonomy stack with its own concept namespace, presentation, calc, and rules                                 | A vertical / filer-profile composition of named Disclosures _within_ a framework |
+| **Cardinality** | A few (one per regulatory regime: GAAP, IFRS, call report, tax, FERC, …)                                                      | Many per framework (Default, Small Private, Banking, Insurance, Mining, …)       |
+| **Lives at**    | `{name}/{version}.json` (+ shared `packages/` and `bridges/` siblings)                                                        | Rows inside the `*-reporting-styles/v1/` package of a framework                  |
+| **Pinned by**   | Graph for availability (`Graph.taxonomy_pin` controls the tenant copy); Entity for adoption (`EntityTaxonomy` rows per basis) | Entity within a graph (`Entity.reporting_style_id`, extensions DB)               |
+| **Example**     | `rs-gaap@v1` for US GAAP filers                                                                                               | `Banking Style` for an entity in `rs-gaap@v1`                                    |
 
 A bank that files a 10-K and a call report is pinned to **two
 frameworks** (`rs-gaap` + `rs-call-report`) and within each one picks
@@ -105,10 +105,10 @@ frameworks/
 ### `tenant-exclude/` — per-tenant copy curation (a policy, not a package)
 
 `tenant-exclude/v1.json` is **framework-level policy**, the same tier as the
-manifest — *not* a package. Packages are JSON-LD taxonomy content **seeded into
+manifest — _not_ a package. Packages are JSON-LD taxonomy content **seeded into
 the DB** and listed in the manifest's `packages[]`; this artifact is a flat
 qname list **consumed by the copy path** (`taxonomy/writer.py`) at provision
-time to decide which rs-gaap concepts a *tenant* receives. The full rs-gaap
+time to decide which rs-gaap concepts a _tenant_ receives. The full rs-gaap
 catalog (~2155 concepts) stays in the **public** library (it backs the future
 SEC us-gaap bridge); a tenant gets the keep-critical curation (~143) under the
 `tenant_exclude_keep_critical` policy (public ~2,155 → tenant ~143) — the
@@ -129,7 +129,7 @@ Framework version lives in the manifest filename (`v1.json`), not in a
 subdirectory. A future `rs-gaap@v2` ships as `rs-gaap/v2.json` alongside
 `v1.json` and reuses the shared `packages/` + `bridges/` directories
 (pinning whichever package versions it needs). The only `v1` segment in
-a leaf path identifies the *package* version.
+a leaf path identifies the _package_ version.
 
 Every future framework (`rs-ifrs`, `rs-call-report`, `rs-irs`,
 `rs-ferc`, `rs-statutory`, `rs-tri`, …) is a sibling here with the same
@@ -148,17 +148,40 @@ A framework manifest lives at `{name}/{version}.json`:
   "title": "RoboSystems rs-gaap Reporting Framework",
   "description": "...",
   "framework_type": "reporting",
-  "depends_on": [
-    {"framework": "fac", "version": "v1"}
-  ],
+  "depends_on": [{ "framework": "fac", "version": "v1" }],
   "packages": [
-    {"standard": "rs-gaap",                  "version": "v1", "ordinal": 0, "is_required": true},
-    {"standard": "rs-gaap-traits",           "version": "v1", "ordinal": 1, "is_required": true},
-    {"standard": "rs-gaap-presentation",     "version": "v1", "ordinal": 3, "is_required": true},
-    {"standard": "rs-gaap-reporting-styles", "version": "v1", "ordinal": 9, "is_required": true}
+    {
+      "standard": "rs-gaap",
+      "version": "v1",
+      "ordinal": 0,
+      "is_required": true
+    },
+    {
+      "standard": "rs-gaap-traits",
+      "version": "v1",
+      "ordinal": 1,
+      "is_required": true
+    },
+    {
+      "standard": "rs-gaap-presentation",
+      "version": "v1",
+      "ordinal": 3,
+      "is_required": true
+    },
+    {
+      "standard": "rs-gaap-reporting-styles",
+      "version": "v1",
+      "ordinal": 9,
+      "is_required": true
+    }
   ],
   "bridges": [
-    {"bridge": "fac-to-rs-gaap", "version": "v1", "ordinal": 0, "is_required": true}
+    {
+      "bridge": "fac-to-rs-gaap",
+      "version": "v1",
+      "ordinal": 0,
+      "is_required": true
+    }
   ]
 }
 ```
@@ -185,7 +208,7 @@ Fields:
   - `is_required: false` lets the migration skip an entry whose
     `taxonomy.jsonld` doesn't exist on disk yet.
   - `tenant_copy` (default `true`) is an **orthogonal** axis to
-    `is_required`. It governs the *per-tenant copy*, not the public seed:
+    `is_required`. It governs the _per-tenant copy_, not the public seed:
     a present `taxonomy.jsonld` is always seeded into the public library
     (the seeder keys off file presence + `is_required`, not this flag),
     but `tenant_copy: false` omits the package from
@@ -199,7 +222,7 @@ Fields:
     a cross-package arc into a `tenant_copy: false` package self-skips
     rather than dangling a NOT NULL FK).
 - **`bridges[]`** — equivalence taxonomies owned by this framework
-  (typically bridges *out of* a dependency framework's namespace into
+  (typically bridges _out of_ a dependency framework's namespace into
   this one's). Same tuple shape as packages.
 
 ## Framework resolution
@@ -224,30 +247,46 @@ null
 Cases 1–3 expand the framework manifest (and walk `depends_on`) into a
 flat `{standard: version}` dict. Case 4 is returned as-is.
 
+The pin is the **availability** layer only — it decides which library
+content gets copied into the tenant schema at provision time. Which
+taxonomies an _entity_ actually uses is the separate **adoption**
+layer: the `EntityTaxonomy` join table (extensions DB,
+`models/extensions/entity_taxonomy.py`) links an entity to any number
+of taxonomies across bases (`reporting`, `chart_of_accounts`,
+`mapping`, `schedule`), with at most one `is_primary` row per
+(entity, basis). The pin stays on the Graph; adoption lives on the
+Entity — so heterogeneous entities in one graph can each adopt
+different reporting taxonomies, provided the pin made them available.
+
 ## One ledger, many filings — the load-bearing premise
 
 Every U.S. business has multiple simultaneous reporting frameworks
 projecting from one ledger:
 
-| Entity profile | Active frameworks |
-| --- | --- |
-| Public bank | `rs-gaap` (10-K) + `rs-call-report` (FFIEC 031/041) + `rs-irs` (1120) |
-| Public insurer | `rs-gaap` (10-K) + `rs-statutory` (NAIC) + `rs-irs` (1120) |
-| Regulated utility | `rs-gaap` (10-K) + `rs-ferc` (Form 1) + `rs-irs` |
-| Private LLC | `rs-gaap` (book) + `rs-irs` (1065/1120) |
-| Non-public corp | `rs-gaap` (book) + `rs-irs` (1120) |
+| Entity profile    | Active frameworks                                                     |
+| ----------------- | --------------------------------------------------------------------- |
+| Public bank       | `rs-gaap` (10-K) + `rs-call-report` (FFIEC 031/041) + `rs-irs` (1120) |
+| Public insurer    | `rs-gaap` (10-K) + `rs-statutory` (NAIC) + `rs-irs` (1120)            |
+| Regulated utility | `rs-gaap` (10-K) + `rs-ferc` (Form 1) + `rs-irs`                      |
+| Private LLC       | `rs-gaap` (book) + `rs-irs` (1065/1120)                               |
+| Non-public corp   | `rs-gaap` (book) + `rs-irs` (1120)                                    |
 
 Schedule M-1 / M-3 is the federally-mandated, line-by-line
-reconciliation between book and tax — it exists *because* book and tax
+reconciliation between book and tax — it exists _because_ book and tax
 are intentionally different frameworks projecting from the same ledger.
 The same dynamic applies to call-report-to-GAAP, stat-to-GAAP,
 FERC-to-GAAP.
 
 Today the library ships two frameworks (fac + rs-gaap). The directory
 structure and `depends_on` machinery support adding peer frameworks
-without restructure. The mature `Graph.taxonomy_pin` shape (plural,
-role-tagged: `[{framework, role: "book"|"regulatory"|"tax"}, ...]`) is a
-model-layer evolution, not a library-layer one.
+without restructure. Multiple frameworks per graph is already
+mechanically possible at the copy layer — a legacy flat pin can list
+packages from more than one framework, and a framework can
+`depends_on` another — and the adoption half is built: `EntityTaxonomy`
+lets each entity adopt multiple taxonomies with one primary per basis.
+What remains future is the first-class plural, role-tagged pin shape
+(`[{framework, role: "book"|"regulatory"|"tax"}, ...]`) — a model-layer
+evolution, not a library-layer one.
 
 ## Adding a new framework
 
@@ -255,7 +294,7 @@ model-layer evolution, not a library-layer one.
    `depends_on` for any prior frameworks whose atoms you reuse.
 2. Add the framework's own packages under
    `<name>/packages/<standard>/<version>/taxonomy.jsonld`.
-3. Add bridges owned by this framework (typically bridging *into* one of
+3. Add bridges owned by this framework (typically bridging _into_ one of
    your dependencies' namespaces) under
    `<name>/bridges/<bridge>/<version>/taxonomy.jsonld`.
 4. Run a fresh `just reset-local` — migration 0007 walks every
@@ -288,5 +327,5 @@ The Python runtime stays at `robosystems/taxonomy/` as a flat module
 - `loader.py` — JSON-LD parser via rdflib → `TaxonomyPackage`
 - `writer.py` — copies the pinned library subset into a tenant schema
 - `pins.py` — resolves `Graph.taxonomy_pin` to a flat `{standard:
-  version}` dict (walks `depends_on`)
+version}` dict (walks `depends_on`)
 - `seed.py` — legacy Python-dict seeder (kept for migration 0001)

--- a/frameworks/rs-gaap/packages/README.md
+++ b/frameworks/rs-gaap/packages/README.md
@@ -11,8 +11,8 @@ universal accounting-concept substrate) live next door at
 `depends_on: [{framework: fac, version: v1}]` and load first.
 
 Each package here is a versioned, self-contained JSON-LD unit;
-migration 0002 walks the framework manifest to load them in dependency
-+ ordinal order at extensions DB provisioning time.
+migration 0002 walks the framework manifest to load them in
+dependency-then-ordinal order at extensions DB provisioning time.
 
 For cross-namespace equivalence taxonomies (bridges) see `../bridges/`.
 For framework composition rules and manifest schema see
@@ -77,8 +77,7 @@ packages/
 ├── rs-gaap-disclosure-mechanics/v1/  native  — DM rules per Disclosure
 ├── rs-gaap-reporting-checklist/v1/   native  — DR rules per report type
 └── rs-gaap-reporting-styles/v1/      native  — vertical / filer-profile composition surface
-                                                (Default, Small Private, Banking, Insurance,
-                                                Mining, Cannabis, …)
+                                                (Default, Small Private, Banking, Insurance, Mining, …)
 ```
 
 The trait vocabulary (`fac-traits/v1`, 99 traits across 26 categories)
@@ -97,8 +96,8 @@ currently scoped to rs-gaap; if/when another framework needs the same
 pattern, promote to `fac@v1` or extract to its own framework.
 
 **`rs-gaap-references`** and **`rs-gaap-labels`** are pure linkbases split
-out of `rs-gaap-type-subtype` (which originally clumped arcs + ASC citations
-+ labels + a redundant re-definition of every concept). They define **no
+out of `rs-gaap-type-subtype` (which originally clumped arcs, ASC citations,
+labels, and a redundant re-definition of every concept). They define **no
 concepts** — each node references a concept defined in the `rs-gaap` base
 **by qname** (the XBRL reference/label-linkbase pattern). The loader emits
 them as `reference_assignments` / `label_assignments`; the seeder attaches
@@ -113,7 +112,7 @@ are now the source of truth, edit them directly. Both are `tenant_copy: true` �
 tenants get the citations and labels for the concepts they keep.
 
 **`rs-gaap-reporting-styles`** is THE vertical-flavor surface. New
-industries (Mining, Cannabis, Cooperative, B-Corp, etc.) are added
+industries (Mining, Cooperative, B-Corp, etc.) are added
 here as new Reporting Style rows, **not** as new frameworks. The
 framework boundary is regulatory regime (GAAP, IFRS, call report,
 statutory, tax); the Reporting Style boundary is filer profile
@@ -125,7 +124,7 @@ Liabilities, Equity, Revenues, Expenses, etc.) is encoded as the
 `fac-traits/v1` (in the `fac` framework) and attached to rs-gaap
 concepts via `rs-gaap-traits/v1`'s trait-assignment arcs.
 This keeps SFAC 6 categorization queryable per-element without giving
-it a separate concept namespace, and lets every rs-* framework
+it a separate concept namespace, and lets every rs-\* framework
 inherit the same axes.
 
 ## Adding a Reporting Style preset
@@ -148,7 +147,7 @@ composition.
    mirrors `_:rs-gaap-pres-is-multistep`): a role node with `roleUri`,
    `structureName`, `blockType`, `conceptArrangementPattern`, then its
    `presentation` arcs. The calc-DAG (`rs-gaap-calculations`) is global,
-   so a presentation Structure only selects *which* rows render —
+   so a presentation Structure only selects _which_ rows render —
    subtotals like `GrossProfit` are still computed even if not presented.
 2. **Declare the Style** in `rs-gaap-reporting-styles/v1` by adding two
    fields to the Style's Structure node (the one carrying `roleUri`):
@@ -158,22 +157,22 @@ composition.
      (`balance_sheet`, `income_statement`, `cash_flow_statement`,
      `equity_statement`). Each `networkRoleUri` is a presentation
      Structure's `roleUri`.
-   A Style with no `reportingStyleNetworks` (e.g. `Banking`) stays a
-   non-selectable placeholder.
+     A Style with no `reportingStyleNetworks` (e.g. `Banking`) stays a
+     non-selectable placeholder.
 3. `just reset-local`, then `change-reporting-style` to the preset's
    Structure id (`uuid5(roleUri, "structure")`) and re-render.
 
 ### The equity-form axis (worked example)
 
 The second segment of the code is the entity's legal form
-(`CORP`/`PART`/`LLC`/…). Because composition is per-*statement*, an
+(`CORP`/`PART`/`LLC`/…). Because composition is per-_statement_, an
 equity-form variant is a **full balance-sheet Structure** that clones the
 corporate asset/liability arcs and swaps only the equity section, plus a
 form-specific Statement-of-Changes rollforward:
 
 - `BS-classified-PART` / `BS-classified-LLC` keep `rs-gaap:StockholdersEquity`
-  as the equity *total* (the calc-DAG plug: `StockholdersEquity = Σ equity
-  leaves`, which already sums `PartnersCapital`/`MembersEquity`), so the
+  as the equity _total_ (the calc-DAG plug: `StockholdersEquity = Σ equity
+leaves`, which already sums `PartnersCapital`/`MembersEquity`), so the
   balance sheet still foots. They differ from `BS-classified` only in which
   child the equity section presents — `PartnersCapital` / `MembersEquity`
   instead of the corporate stack.


### PR DESCRIPTION
## Summary

Documentation-only update to the frameworks library READMEs. The main README previously described framework pinning as a single graph-level concern; it now documents the two-layer reality that shipped with the extensions OLTP model: `Graph.taxonomy_pin` controls **availability** (which library content is copied into the tenant schema at provision time), while `EntityTaxonomy` rows carry per-entity **adoption** (which taxonomies an entity actually uses, per basis). Also folds in a formatting pass and repairs two sentences the formatter mangled.

## Changes

**`frameworks/README.md`**
- "Framework vs. Reporting Style" table: the *Pinned by* row now distinguishes graph-level availability (`Graph.taxonomy_pin`) from entity-level adoption (`EntityTaxonomy` rows per basis), and corrects the Reporting Style column to `Entity.reporting_style_id` (extensions DB) — the style lives on the entity, not the graph.
- "Framework resolution" section: new paragraph explaining the pin/adoption split — the pin decides what content exists in the tenant schema; `EntityTaxonomy` (bases `reporting` / `chart_of_accounts` / `mapping` / `schedule`, one primary per basis) decides what each entity uses, so heterogeneous entities in one graph can adopt different reporting taxonomies.
- "One ledger, many filings" closer: now states that multi-framework content per graph is already mechanically possible at the copy layer (legacy flat pin, `depends_on`) and that the adoption half exists; the plural role-tagged pin shape remains the future model-layer evolution.
- Markdown table reformatting; dropped one vertical from the Reporting Style example lists.

**`frameworks/rs-gaap/packages/README.md`**
- Same formatting pass and example-list cleanup.
- Repaired two sentences the markdown formatter had corrupted: lines beginning with `+` ("dependency + ordinal order", "arcs + ASC citations + labels …") were reinterpreted as list items, splitting the sentences mid-clause. Rephrased both so the meaning is restored and no line starts with a `+`.

## Testing

Docs-only change — no code touched. Pre-commit hooks ran on commit: format check (all files already formatted) and lint passed. Unit tests not run (not applicable to README edits).
