### PR TITLE
feat(metrics): M-2 grammar — avg() aggregate, DuPont composition, unit/format families

### DIFF
--- a/frameworks/rs-gaap/packages/rs-metric/v1/taxonomy.jsonld
+++ b/frameworks/rs-gaap/packages/rs-metric/v1/taxonomy.jsonld
@@ -27,6 +27,9 @@
     "elementType": {
       "@id": "https://robosystems.ai/vocab/elementType"
     },
+    "itemType": {
+      "@id": "https://robosystems.ai/vocab/itemType"
+    },
     "from": {
       "@id": "xlink:from",
       "@type": "@id"
@@ -108,7 +111,7 @@
   "namespace_uri": "https://robosystems.ai/taxonomy/rs-gaap/metrics/v1/",
   "default_block_type": "metric",
   "origin": "native",
-  "description": "rs-metric — the library metric catalog (Metrics M-1). Each metric is a qname-addressable concept in the rs-metric namespace plus one Derive rule whose ruleExpression computes it from rs-gaap anchor facts ($Metric = f(rs-gaap operands)). The Key Financial Metrics node is both an abstract element and a Structure (block_type='metric', CAP arithmetic) whose presentation arcs enumerate the catalog — the standing metric block every tenant receives. Operand qnames are the canonical calc-DAG anchors the report pivot persists (e.g. InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings, not InventoryNet). compute-metrics binds operands to persisted report facts per period and upserts a standing factset_type='metric' FactSet. Metrics with missing operands or undefined ratios are skipped with a reason, never errored. Hand-authored; avg()/composition metrics land in M-2.",
+  "description": "rs-metric — the library metric catalog (Metrics M-1 + M-2). Each metric is a qname-addressable concept in the rs-metric namespace plus one Derive rule whose ruleExpression computes it from rs-gaap anchor facts ($Metric = f(rs-gaap operands)). The Key Financial Metrics node is both an abstract element and a Structure (block_type='metric', CAP arithmetic) whose presentation arcs enumerate the catalog — the standing metric block every tenant receives. Operand qnames are the canonical calc-DAG anchors the report pivot persists (e.g. InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings, not InventoryNet). compute-metrics binds operands to persisted report facts per period and upserts a standing factset_type='metric' FactSet. Metrics with missing operands or undefined ratios are skipped with a reason, never errored. M-2 adds the avg($Var) period-average aggregate (ReturnOnEquity), metric-on-metric composition in dependency order (the DuPont identity), and itemType format families (monetary | ratio | percent | multiple | days) that drive unit and display formatting. Hand-authored.",
   "@graph": [
     {
       "@id": "rs-metric:KeyFinancialMetrics",
@@ -130,7 +133,8 @@
       "elementType": "concept",
       "periodType": "instant",
       "balance": "debit",
-      "monetary": true
+      "monetary": true,
+      "itemType": "monetary"
     },
     {
       "@id": "rs-metric:CurrentRatio",
@@ -138,7 +142,8 @@
       "documentation": "Current assets over current liabilities.",
       "elementType": "concept",
       "periodType": "instant",
-      "monetary": false
+      "monetary": false,
+      "itemType": "ratio"
     },
     {
       "@id": "rs-metric:QuickRatio",
@@ -146,7 +151,8 @@
       "documentation": "Current assets excluding inventory, over current liabilities (acid test).",
       "elementType": "concept",
       "periodType": "instant",
-      "monetary": false
+      "monetary": false,
+      "itemType": "ratio"
     },
     {
       "@id": "rs-metric:DebtToEquity",
@@ -154,7 +160,8 @@
       "documentation": "Total liabilities over stockholders' equity.",
       "elementType": "concept",
       "periodType": "instant",
-      "monetary": false
+      "monetary": false,
+      "itemType": "ratio"
     },
     {
       "@id": "rs-metric:InterestCoverage",
@@ -162,7 +169,53 @@
       "documentation": "Operating income over interest expense. Skips (rather than errors) for debt-free entities with no interest expense fact.",
       "elementType": "concept",
       "periodType": "duration",
-      "monetary": false
+      "monetary": false,
+      "itemType": "multiple"
+    },
+    {
+      "@id": "rs-metric:ReturnOnEquity",
+      "label": "Return on Equity",
+      "documentation": "Net income over average stockholders' equity — avg($StockholdersEquity) is the period average (begin + end over 2), so the first period of a series skips with a reason (no prior period).",
+      "elementType": "concept",
+      "periodType": "duration",
+      "monetary": false,
+      "itemType": "percent"
+    },
+    {
+      "@id": "rs-metric:NetProfitMargin",
+      "label": "Net Profit Margin",
+      "documentation": "Net income over revenues — the profitability leg of the DuPont identity.",
+      "elementType": "concept",
+      "periodType": "duration",
+      "monetary": false,
+      "itemType": "percent"
+    },
+    {
+      "@id": "rs-metric:AssetTurnover",
+      "label": "Asset Turnover",
+      "documentation": "Revenues over average total assets — the efficiency leg of the DuPont identity.",
+      "elementType": "concept",
+      "periodType": "duration",
+      "monetary": false,
+      "itemType": "multiple"
+    },
+    {
+      "@id": "rs-metric:EquityMultiplier",
+      "label": "Equity Multiplier",
+      "documentation": "Average total assets over average stockholders' equity — the leverage leg of the DuPont identity.",
+      "elementType": "concept",
+      "periodType": "duration",
+      "monetary": false,
+      "itemType": "multiple"
+    },
+    {
+      "@id": "rs-metric:ReturnOnEquityDuPont",
+      "label": "Return on Equity (DuPont)",
+      "documentation": "Net Profit Margin × Asset Turnover × Equity Multiplier — metric-on-metric composition; agrees with Return on Equity by construction, so a divergence flags an operand inconsistency.",
+      "elementType": "concept",
+      "periodType": "duration",
+      "monetary": false,
+      "itemType": "percent"
     },
     {
       "@id": "_:rs-metric-pres-arc-1",
@@ -233,6 +286,76 @@
       "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
       "role": "https://robosystems.ai/seattle/cm-roles/roles/metrics/KeyFinancialMetrics",
       "order": 5.0
+    },
+    {
+      "@id": "_:rs-metric-pres-arc-6",
+      "@type": "rs:Association",
+      "from": {
+        "@id": "rs-metric:KeyFinancialMetrics"
+      },
+      "to": {
+        "@id": "rs-metric:ReturnOnEquity"
+      },
+      "associationType": "presentation",
+      "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+      "role": "https://robosystems.ai/seattle/cm-roles/roles/metrics/KeyFinancialMetrics",
+      "order": 6.0
+    },
+    {
+      "@id": "_:rs-metric-pres-arc-7",
+      "@type": "rs:Association",
+      "from": {
+        "@id": "rs-metric:KeyFinancialMetrics"
+      },
+      "to": {
+        "@id": "rs-metric:NetProfitMargin"
+      },
+      "associationType": "presentation",
+      "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+      "role": "https://robosystems.ai/seattle/cm-roles/roles/metrics/KeyFinancialMetrics",
+      "order": 7.0
+    },
+    {
+      "@id": "_:rs-metric-pres-arc-8",
+      "@type": "rs:Association",
+      "from": {
+        "@id": "rs-metric:KeyFinancialMetrics"
+      },
+      "to": {
+        "@id": "rs-metric:AssetTurnover"
+      },
+      "associationType": "presentation",
+      "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+      "role": "https://robosystems.ai/seattle/cm-roles/roles/metrics/KeyFinancialMetrics",
+      "order": 8.0
+    },
+    {
+      "@id": "_:rs-metric-pres-arc-9",
+      "@type": "rs:Association",
+      "from": {
+        "@id": "rs-metric:KeyFinancialMetrics"
+      },
+      "to": {
+        "@id": "rs-metric:EquityMultiplier"
+      },
+      "associationType": "presentation",
+      "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+      "role": "https://robosystems.ai/seattle/cm-roles/roles/metrics/KeyFinancialMetrics",
+      "order": 9.0
+    },
+    {
+      "@id": "_:rs-metric-pres-arc-10",
+      "@type": "rs:Association",
+      "from": {
+        "@id": "rs-metric:KeyFinancialMetrics"
+      },
+      "to": {
+        "@id": "rs-metric:ReturnOnEquityDuPont"
+      },
+      "associationType": "presentation",
+      "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+      "role": "https://robosystems.ai/seattle/cm-roles/roles/metrics/KeyFinancialMetrics",
+      "order": 10.0
     },
     {
       "@id": "_:rs-metric-derive-working-capital",
@@ -370,6 +493,145 @@
         }
       ],
       "ruleMessage": "Interest Coverage = Operating Income / Interest Expense",
+      "ruleSeverity": "info",
+      "ruleOrigin": "native"
+    },
+    {
+      "@id": "_:rs-metric-derive-return-on-equity",
+      "ruleCategory": "ReportingSystemSpecificRule",
+      "rulePattern": "Derive",
+      "ruleExpression": "$ReturnOnEquity = ($NetIncomeLoss / avg($StockholdersEquity))",
+      "ruleTarget": {
+        "targetKind": "element",
+        "targetRef": "rs-metric:ReturnOnEquity"
+      },
+      "ruleVariables": [
+        {
+          "variableName": "ReturnOnEquity",
+          "variableQname": "rs-metric:ReturnOnEquity"
+        },
+        {
+          "variableName": "NetIncomeLoss",
+          "variableQname": "rs-gaap:NetIncomeLoss"
+        },
+        {
+          "variableName": "StockholdersEquity",
+          "variableQname": "rs-gaap:StockholdersEquity"
+        }
+      ],
+      "ruleMessage": "Return on Equity = Net Income / Average Stockholders' Equity",
+      "ruleSeverity": "info",
+      "ruleOrigin": "native"
+    },
+    {
+      "@id": "_:rs-metric-derive-net-profit-margin",
+      "ruleCategory": "ReportingSystemSpecificRule",
+      "rulePattern": "Derive",
+      "ruleExpression": "$NetProfitMargin = ($NetIncomeLoss / $Revenues)",
+      "ruleTarget": {
+        "targetKind": "element",
+        "targetRef": "rs-metric:NetProfitMargin"
+      },
+      "ruleVariables": [
+        {
+          "variableName": "NetProfitMargin",
+          "variableQname": "rs-metric:NetProfitMargin"
+        },
+        {
+          "variableName": "NetIncomeLoss",
+          "variableQname": "rs-gaap:NetIncomeLoss"
+        },
+        {
+          "variableName": "Revenues",
+          "variableQname": "rs-gaap:Revenues"
+        }
+      ],
+      "ruleMessage": "Net Profit Margin = Net Income / Revenues",
+      "ruleSeverity": "info",
+      "ruleOrigin": "native"
+    },
+    {
+      "@id": "_:rs-metric-derive-asset-turnover",
+      "ruleCategory": "ReportingSystemSpecificRule",
+      "rulePattern": "Derive",
+      "ruleExpression": "$AssetTurnover = ($Revenues / avg($Assets))",
+      "ruleTarget": {
+        "targetKind": "element",
+        "targetRef": "rs-metric:AssetTurnover"
+      },
+      "ruleVariables": [
+        {
+          "variableName": "AssetTurnover",
+          "variableQname": "rs-metric:AssetTurnover"
+        },
+        {
+          "variableName": "Revenues",
+          "variableQname": "rs-gaap:Revenues"
+        },
+        {
+          "variableName": "Assets",
+          "variableQname": "rs-gaap:Assets"
+        }
+      ],
+      "ruleMessage": "Asset Turnover = Revenues / Average Total Assets",
+      "ruleSeverity": "info",
+      "ruleOrigin": "native"
+    },
+    {
+      "@id": "_:rs-metric-derive-equity-multiplier",
+      "ruleCategory": "ReportingSystemSpecificRule",
+      "rulePattern": "Derive",
+      "ruleExpression": "$EquityMultiplier = (avg($Assets) / avg($StockholdersEquity))",
+      "ruleTarget": {
+        "targetKind": "element",
+        "targetRef": "rs-metric:EquityMultiplier"
+      },
+      "ruleVariables": [
+        {
+          "variableName": "EquityMultiplier",
+          "variableQname": "rs-metric:EquityMultiplier"
+        },
+        {
+          "variableName": "Assets",
+          "variableQname": "rs-gaap:Assets"
+        },
+        {
+          "variableName": "StockholdersEquity",
+          "variableQname": "rs-gaap:StockholdersEquity"
+        }
+      ],
+      "ruleMessage": "Equity Multiplier = Average Total Assets / Average Stockholders' Equity",
+      "ruleSeverity": "info",
+      "ruleOrigin": "native"
+    },
+    {
+      "@id": "_:rs-metric-derive-return-on-equity-dupont",
+      "ruleCategory": "ReportingSystemSpecificRule",
+      "rulePattern": "Derive",
+      "ruleExpression": "$ReturnOnEquityDuPont = ($NetProfitMargin * $AssetTurnover * $EquityMultiplier)",
+      "ruleTarget": {
+        "targetKind": "element",
+        "targetRef": "rs-metric:ReturnOnEquityDuPont"
+      },
+      "ruleVariables": [
+        {
+          "variableName": "ReturnOnEquityDuPont",
+          "variableQname": "rs-metric:ReturnOnEquityDuPont"
+        },
+        {
+          "variableName": "NetProfitMargin",
+          "variableQname": "rs-metric:NetProfitMargin"
+        },
+        {
+          "variableName": "AssetTurnover",
+          "variableQname": "rs-metric:AssetTurnover"
+        },
+        {
+          "variableName": "EquityMultiplier",
+          "variableQname": "rs-metric:EquityMultiplier"
+        }
+      ],
+      "ruleMessage": "Return on Equity (DuPont) = Net Profit Margin × Asset Turnover × Equity Multiplier",
       "ruleSeverity": "info",
       "ruleOrigin": "native"
     }

--- a/migrations/extensions/versions/0023_metrics_m2.py
+++ b/migrations/extensions/versions/0023_metrics_m2.py
@@ -1,0 +1,196 @@
+"""metrics M-2 — reseed the grown rs-metric catalog + element item_type
+
+The M-2 grammar (avg() + DuPont composition + unit/format families) grows
+the rs-metric/v1 package in place: five new concepts (ReturnOnEquity,
+NetProfitMargin, AssetTurnover, EquityMultiplier, ReturnOnEquityDuPont),
+five presentation arcs (orders 6-10), five Derive rules, and an
+``itemType`` format family on every catalog concept (monetary | ratio |
+percent | multiple | days) that ``compute-metrics`` maps to fact units
+and viewers map to display formats.
+
+No CHECK changes: 0022 already admits ``'metric'`` FactSets, ``'Derive'``
+rules, and the ``'rs-metric'`` element source, and ``elements.item_type``
+is an existing untyped column (open vocabulary by design). The work is
+pure content: re-run the 0022 seed passes against the updated artifact —
+``create_library_taxonomy_elements`` upserts carry ``item_type`` onto the
+original five concepts and insert the new five; arcs and rules follow —
+then fan the deltas into every tenant via ``resync_library_into_tenant``
+(elements and rules update in place, new rows insert additively) under
+the 0016 ``SET LOCAL robosystems.library_resync`` GUC.
+
+Fresh deployments get all of this from 0002 + provisioning against the
+updated artifact; this migration is the backfill path for existing
+databases. Deploy-coupled with the loader/writer code that reads and
+copies ``item_type`` — it executes that code at migrate time.
+
+The downgrade deletes the five new concepts' content (facts, rules,
+arcs, labels/references/traits, elements) per schema and nulls
+``item_type`` on the remaining rs-metric elements. It fails if
+tenant-authored content references the new concepts — data the operator
+must triage, not silently drop.
+
+Revision ID: 0023
+Revises: 0022
+Create Date: 2026-07-23
+
+"""
+
+from __future__ import annotations
+
+from alembic import op
+from sqlalchemy import text
+
+from migrations.extensions.helpers import for_each_tenant_schema
+
+# revision identifiers, used by Alembic.
+revision = "0023"
+down_revision = "0022"
+branch_labels = None
+depends_on = None
+
+_PACKAGE_STANDARD = "rs-metric"
+_PACKAGE_VERSION = "v1"
+
+_NEW_QNAMES = (
+  "rs-metric:ReturnOnEquity",
+  "rs-metric:NetProfitMargin",
+  "rs-metric:AssetTurnover",
+  "rs-metric:EquityMultiplier",
+  "rs-metric:ReturnOnEquityDuPont",
+)
+
+
+def _seed_path():
+  from robosystems.taxonomy.discovery import FRAMEWORKS_DIR
+
+  return (
+    FRAMEWORKS_DIR
+    / "rs-gaap"
+    / "packages"
+    / _PACKAGE_STANDARD
+    / _PACKAGE_VERSION
+    / "taxonomy.jsonld"
+  )
+
+
+def _reseed_public_library(conn) -> None:
+  """Re-run the 0022 seed passes — upserts grow the catalog in place."""
+  from sqlalchemy.orm import Session as _Session
+
+  from robosystems.operations.taxonomy_block.library_creator import (
+    create_library_arcs,
+    create_library_rules,
+    create_library_taxonomy_elements,
+    prune_empty_default_structures,
+  )
+  from robosystems.taxonomy import load_taxonomy_package
+
+  package = load_taxonomy_package(_seed_path())
+  session = _Session(bind=conn)
+  try:
+    _, counts = create_library_taxonomy_elements(session, package)
+    session.flush()
+    print(
+      f"  [rs-metric M-2 pass 1] elements={counts['elements']} "
+      f"structures={counts['structures']}"
+    )
+    counts = create_library_arcs(session, package)
+    session.flush()
+    print(
+      f"  [rs-metric M-2 pass 2] associations={counts['associations']} "
+      f"(skipped={counts['associations_skipped']})"
+    )
+    counts = create_library_rules(session, package)
+    session.flush()
+    print(
+      f"  [rs-metric M-2 pass 3] rules={counts['rules']} "
+      f"(skipped={counts['rules_skipped']})"
+    )
+    pruned = prune_empty_default_structures(session)
+    session.flush()
+    if pruned:
+      print(f"  [rs-metric M-2 pass 4] pruned {pruned} empty default structure(s)")
+  finally:
+    session.close()
+
+
+def upgrade() -> None:
+  from robosystems.taxonomy.writer import SET_LIBRARY_RESYNC, resync_library_into_tenant
+
+  conn = op.get_bind()
+
+  # 1. Grow the public catalog (upserts: item_type onto the original five,
+  #    the new five concepts/arcs/rules inserted).
+  _reseed_public_library(conn)
+
+  # 2. Fan the deltas into every existing tenant schema. SET LOCAL is
+  #    transaction-scoped — it covers the whole fan-out and vanishes on
+  #    commit. Mandatory: the new arcs INSERT into a library-seeded
+  #    structure, which the 0016 immutability triggers reject otherwise.
+  conn.execute(text(SET_LIBRARY_RESYNC))
+
+  def _copy(conn, schema: str) -> None:
+    stats = resync_library_into_tenant(
+      conn, schema, pin={_PACKAGE_STANDARD: _PACKAGE_VERSION}
+    )
+    print(
+      f"  [rs-metric M-2 → {schema}] elements={stats.elements} "
+      f"associations={stats.associations} rules={stats.rules}"
+    )
+
+  for_each_tenant_schema(conn, _copy)
+
+
+def _delete_new_concept_content(conn, schema: str) -> None:
+  """Delete the five M-2 concepts' content from one schema, FK-safe."""
+  from robosystems.utils.uuid import generate_deterministic_uuid
+
+  taxonomy_id = generate_deterministic_uuid(
+    f"{_PACKAGE_STANDARD}:{_PACKAGE_VERSION}", namespace="taxonomy"
+  )
+  s = schema
+  params = {"tid": taxonomy_id, "qnames": list(_NEW_QNAMES)}
+  statements = [
+    # verification_results FK rules NOT NULL with no ON DELETE.
+    f"DELETE FROM {s}.verification_results WHERE rule_id IN "
+    f"(SELECT r.id FROM {s}.rules r JOIN {s}.elements e "
+    f"ON r.target_element_id = e.id "
+    f"WHERE e.taxonomy_id = :tid AND e.qname = ANY(:qnames))",
+    f"DELETE FROM {s}.facts WHERE element_id IN "
+    f"(SELECT id FROM {s}.elements WHERE taxonomy_id = :tid "
+    f"AND qname = ANY(:qnames))",
+    f"DELETE FROM {s}.rules WHERE target_element_id IN "
+    f"(SELECT id FROM {s}.elements WHERE taxonomy_id = :tid "
+    f"AND qname = ANY(:qnames))",
+    f"DELETE FROM {s}.associations WHERE to_element_id IN "
+    f"(SELECT id FROM {s}.elements WHERE taxonomy_id = :tid "
+    f"AND qname = ANY(:qnames))",
+    f"DELETE FROM {s}.element_traits WHERE element_id IN "
+    f"(SELECT id FROM {s}.elements WHERE taxonomy_id = :tid "
+    f"AND qname = ANY(:qnames))",
+    f"DELETE FROM {s}.element_labels WHERE element_id IN "
+    f"(SELECT id FROM {s}.elements WHERE taxonomy_id = :tid "
+    f"AND qname = ANY(:qnames))",
+    f"DELETE FROM {s}.element_references WHERE element_id IN "
+    f"(SELECT id FROM {s}.elements WHERE taxonomy_id = :tid "
+    f"AND qname = ANY(:qnames))",
+    f"DELETE FROM {s}.elements WHERE taxonomy_id = :tid AND qname = ANY(:qnames)",
+    f"UPDATE {s}.elements SET item_type = NULL WHERE taxonomy_id = :tid",
+  ]
+  for stmt in statements:
+    conn.execute(text(stmt), params)
+
+
+def downgrade() -> None:
+  from robosystems.taxonomy.writer import SET_LIBRARY_RESYNC
+
+  conn = op.get_bind()
+
+  # Library-row deletes in tenant schemas need the immutability bypass.
+  conn.execute(text(SET_LIBRARY_RESYNC))
+
+  def _delete(conn, schema: str) -> None:
+    _delete_new_concept_content(conn, schema)
+
+  for_each_tenant_schema(conn, _delete)
+  _delete_new_concept_content(conn, "public")

--- a/robosystems/models/api/information_block.py
+++ b/robosystems/models/api/information_block.py
@@ -55,6 +55,13 @@ class ElementLite(BaseModel):
   is_monetary: bool = True
   balance_type: str | None = None
   period_type: str | None = None
+  item_type: str | None = Field(
+    None,
+    description=(
+      "Value-domain vocabulary (monetary | ratio | percent | multiple | "
+      "days | string | …). None means untyped; fall back to is_monetary."
+    ),
+  )
 
 
 class ClassificationLite(BaseModel):
@@ -687,6 +694,14 @@ class RenderingRowLite(BaseModel):
     ),
   )
   balance_type: str | None = None
+  item_type: str | None = Field(
+    None,
+    description=(
+      "Value-domain format family from the element (monetary | ratio | "
+      "percent | multiple | days | …). Drives per-row value formatting; "
+      "None falls back to is_monetary on the element."
+    ),
+  )
   values: list[float | None] = Field(default_factory=list)
   text_value: str | None = Field(
     None,
@@ -1380,8 +1395,17 @@ class ComputedMetricLite(BaseModel):
   )
   name: str = Field(..., description="Metric display name.")
   value: float = Field(..., description="Computed value.")
-  unit: str = Field(..., description="Fact unit — 'USD' for monetary, else 'pure'.")
+  unit: str = Field(
+    ..., description="Fact unit — 'USD' for monetary, 'days' for days, else 'pure'."
+  )
   period_type: str = Field(..., description="'instant' or 'duration'.")
+  item_type: str | None = Field(
+    None,
+    description=(
+      "Format family from the metric element (monetary | ratio | percent "
+      "| multiple | days). None means untyped; fall back to unit."
+    ),
+  )
 
 
 class SkippedMetricLite(BaseModel):

--- a/robosystems/models/extensions/element.py
+++ b/robosystems/models/extensions/element.py
@@ -133,7 +133,8 @@ class Element(ExtensionsBase):
   element_type = Column(String, nullable=False, default="concept")
   # Value domain (orthogonal to element_type, which is the structural role).
   # Open XBRL item-type vocabulary — intended values: monetary | string |
-  # date | boolean | shares | decimal | integer | text_block. NULL means
+  # date | boolean | shares | decimal | integer | text_block, plus the
+  # metric format families ratio | percent | multiple | days. NULL means
   # untyped; consumers fall back to is_monetary.
   item_type = Column(String, nullable=True)
 

--- a/robosystems/operations/information_block/envelope.py
+++ b/robosystems/operations/information_block/envelope.py
@@ -56,6 +56,7 @@ def element_to_lite(element: Element) -> ElementLite:
     is_monetary=element.is_monetary,
     balance_type=element.balance_type,
     period_type=element.period_type,
+    item_type=element.item_type,
   )
 
 

--- a/robosystems/operations/information_block/metric.py
+++ b/robosystems/operations/information_block/metric.py
@@ -135,6 +135,7 @@ def build_envelope(
         element_qname=element.qname if element else None,
         element_name=element.name if element else element_id,
         balance_type=element.balance_type if element else None,
+        item_type=element.item_type if element else None,
         values=[value_by_set_element.get((fs.id, element_id)) for fs in fact_sets],
       )
     )

--- a/robosystems/operations/information_block/metrics.py
+++ b/robosystems/operations/information_block/metrics.py
@@ -1,30 +1,48 @@
 """compute-metrics — evaluate Derive rules into a standing metric FactSet.
 
-The metric block's compute path (Metrics M-1). ``Derive`` rules carry the
-same ``$Var`` expression grammar as verification rules, but are evaluated
-for a VALUE: the LHS names the metric element being computed, the RHS
-operands bind to the entity's persisted report facts at the requested
-``period_end``, and the result is written as a Numeric fact in a standing
-``factset_type='metric'`` FactSet — one per (structure, entity,
-period_end), so successive runs accumulate the time series and re-running
-a period replaces its values.
+The metric block's compute path (Metrics M-1 + the M-2 grammar).
+``Derive`` rules carry the same ``$Var`` expression grammar as
+verification rules, but are evaluated for a VALUE: the LHS names the
+metric element being computed, the RHS operands bind to the entity's
+persisted facts at the requested ``period_end``, and the result is
+written as a Numeric fact in a standing ``factset_type='metric'``
+FactSet — one per (structure, entity, period_end), so successive runs
+accumulate the time series and re-running a period replaces its values.
+
+M-2 grammar:
+
+- ``avg($X)`` — the period average of an instant operand,
+  (begin + end) / 2. Desugared pre-parse to a synthesized ``$__avg_X``
+  operand (``expressions.desugar_aggregates``); the begin fact binds at
+  a resolved prior period end — ``body.period_start - 1 day`` when the
+  request carries a window, else a bound duration operand's start - 1
+  day, else the entity's newest report ``period_end`` strictly before
+  the requested one (run-cached; never the fiscal calendar, which
+  annual-comparative tenants don't populate at month ends).
+- **Composition** (DuPont) — an operand naming another rule's target is
+  an in-run metric dependency: rules evaluate in Kahn topological order
+  (``calc_dag.topo_sort_calculations``), in-run values resolve first,
+  and persisted-fact binding is widened to ``('report', 'metric')`` so
+  cross-structure metrics resolve when already computed for the period.
+  A cyclic or skipped dependency leaves the operand unbound → the
+  dependent metric soft-skips.
+
+The future ``$X[t-1]`` prior-period operand (the forecast grammar's
+general form) rides the same two seams: a pre-parse rewrite to a
+synthesized operand, bound through the same prior-period resolver.
 
 Soft-fail per metric: a missing operand fact (InterestExpense for a
-debt-free entity), an unresolvable qname, or an undefined ratio
-(division by zero) skips that metric with a reason — one broken metric
-never aborts the run.
-
-Operands bind against ``factset_type='report'`` facts only, so a metric
-referencing another metric simply skips in M-1 — composition (DuPont)
-is the M-2 DAG feature.
+debt-free entity), an unresolvable qname, a missing prior period for
+``avg()``, or an undefined ratio (division by zero) skips that metric
+with a reason — one broken metric never aborts the run.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import date
+from datetime import date, timedelta
 
-from sqlalchemy import or_, select, text
+from sqlalchemy import func, or_, select, text
 from sqlalchemy.orm import Session
 
 from robosystems.models.api.fact_provenance import DerivedProvenance
@@ -45,11 +63,13 @@ from robosystems.models.extensions.roboledger.fact_set import FactSet
 from robosystems.operations.information_block.registry import METRIC_BLOCK_TYPE
 from robosystems.operations.information_block.rules.expressions import (
   InvalidRuleExpression,
+  desugar_aggregates,
   evaluate_derivation,
   lhs_variable_names,
   parse_arithmetic_expression,
 )
 from robosystems.operations.roboledger.fact_set import create_fact_set
+from robosystems.operations.roboledger.reports.calc_dag import topo_sort_calculations
 from robosystems.utils.ulid import generate_prefixed_ulid
 
 
@@ -80,20 +100,23 @@ def _bind_operand(
   period_end: date,
   period_start: date | None,
 ) -> _BoundOperand | None:
-  """Most recent persisted report fact for one operand at ``period_end``.
+  """Most recent persisted fact for one operand at ``period_end``.
 
-  Joins Fact → FactSet on ``factset_type='report'`` (the persisted
-  statement facts, including calc-DAG subtotals) scoped to the entity.
+  Joins Fact → FactSet on ``factset_type IN ('report', 'metric')`` —
+  the persisted statement facts (including calc-DAG subtotals) plus
+  standing metric facts, so a metric operand resolves across structures
+  once its own compute has run for the period. Scoped to the entity;
   ``period_end`` must match exactly — instant balances as of that date,
-  durations ending on it. Newest report wins when several cover the
+  durations ending on it. Newest set wins when several cover the
   period; among same-set candidates the longest window wins (FY over Q4
-  when both end on the date).
+  when both end on the date). No qname can collide across the two set
+  types: metric facts land only on metric-namespace elements.
   """
   stmt = (
     select(Fact.value, Fact.period_start)
     .join(FactSet, Fact.fact_set_id == FactSet.id)
     .where(
-      FactSet.factset_type == "report",
+      FactSet.factset_type.in_(("report", "metric")),
       Fact.entity_id == entity_id,
       Fact.element_id == element_id,
       Fact.period_end == period_end,
@@ -114,6 +137,38 @@ def _bind_operand(
   if row is None:
     return None
   return _BoundOperand(value=float(row[0]), period_start=row[1])
+
+
+def _latest_report_period_end_before(
+  session: Session, entity_id: str, before: date
+) -> date | None:
+  """The entity's newest report-fact ``period_end`` strictly before a date.
+
+  The data-driven prior-period fallback for ``avg()`` when neither the
+  request nor a bound duration operand supplies a window: annual
+  comparatives resolve to the prior FY end, monthly series to the prior
+  month end. Report facts only — the canonical period spine.
+  """
+  return session.execute(
+    select(func.max(Fact.period_end))
+    .select_from(Fact)
+    .join(FactSet, Fact.fact_set_id == FactSet.id)
+    .where(
+      FactSet.factset_type == "report",
+      Fact.entity_id == entity_id,
+      Fact.period_end < before,
+      Fact.fact_scope == "in_scope",
+      Fact.value.is_not(None),
+    )
+  ).scalar()
+
+
+def _metric_unit(target: Element) -> str:
+  """Fact unit for a computed metric — from ``item_type``, else the
+  ``is_monetary`` binary (NULL ``item_type`` keeps the M-1 behavior)."""
+  if target.item_type is not None:
+    return {"monetary": "USD", "days": "days"}.get(target.item_type, "pure")
+  return "USD" if target.is_monetary else "pure"
 
 
 def _load_derive_rules(
@@ -185,9 +240,55 @@ def cmd_compute_metrics(
     key=lambda r: order_by_element.get(r.target_element_id or "", float("inf"))
   )
 
+  # Dependency-ordered evaluation (M-2 composition): an operand qname
+  # naming another rule's target is an in-run metric dependency, so the
+  # run evaluates dependencies first. Rules sort by dependency DEPTH
+  # (longest in-run chain below the target), arc order as the tiebreak —
+  # depth is deterministic where Kahn's emission order among independents
+  # is not, so independent metrics keep presentation order. Cycle
+  # remnants get a finite depth and soft-skip when their operands stay
+  # unbound.
+  targets_by_rule = {
+    rule.id: (
+      session.get(Element, rule.target_element_id) if rule.target_element_id else None
+    )
+    for rule in rules
+  }
+  run_target_qnames = {
+    t.qname for t in targets_by_rule.values() if t is not None and t.qname
+  }
+  dependency_map: dict[str, list[tuple[str, float]]] = {}
+  for rule in rules:
+    target = targets_by_rule.get(rule.id)
+    if target is None or not target.qname:
+      continue
+    operand_qnames = {
+      v.get("variable_qname")
+      for v in (rule.rule_variables or [])
+      if isinstance(v, dict)
+    }
+    dependency_map[target.qname] = [
+      (q, 1.0)
+      for q in operand_qnames
+      if q and q != target.qname and q in run_target_qnames
+    ]
+  depth_by_qname: dict[str, int] = {}
+  for qname in topo_sort_calculations(dependency_map):
+    depth_by_qname[qname] = 1 + max(
+      (depth_by_qname.get(d, 0) for d, _ in dependency_map.get(qname, [])),
+      default=-1,
+    )
+  rules.sort(
+    key=lambda r: (
+      depth_by_qname.get(getattr(targets_by_rule.get(r.id), "qname", None) or "", 0),
+      order_by_element.get(r.target_element_id or "", float("inf")),
+    )
+  )
+
   computed: list[ComputedMetricLite] = []
   skipped: list[SkippedMetricLite] = []
   pending_facts: list[dict] = []
+  computed_by_qname: dict[str, float] = {}
 
   qname_cache: dict[str, Element | None] = {}
 
@@ -198,10 +299,26 @@ def cmd_compute_metrics(
       ).scalar_one_or_none()
     return qname_cache[qname]
 
+  # Data-driven prior period for avg() — resolved at most once per run
+  # so every parameterless avg in the run shares one begin date.
+  _prior_cache: list[date | None] = []
+
+  def _data_driven_prior() -> date | None:
+    if not _prior_cache:
+      _prior_cache.append(
+        _latest_report_period_end_before(session, entity_id, body.period_end)
+      )
+    return _prior_cache[0]
+
+  def _begin_date(duration_start: date | None) -> date | None:
+    if body.period_start is not None:
+      return body.period_start - timedelta(days=1)
+    if duration_start is not None:
+      return duration_start - timedelta(days=1)
+    return _data_driven_prior()
+
   for rule in rules:
-    target = (
-      session.get(Element, rule.target_element_id) if rule.target_element_id else None
-    )
+    target = targets_by_rule.get(rule.id)
     target_qname = target.qname if target is not None else None
 
     def _skip(reason: str, missing: list[str] | None = None) -> None:
@@ -225,9 +342,12 @@ def cmd_compute_metrics(
       continue
     qname_by_name = {v["variable_name"]: v.get("variable_qname") for v in variables}
 
-    expression = rule.rule_expression if isinstance(rule.rule_expression, str) else ""
+    raw_expression = (
+      rule.rule_expression if isinstance(rule.rule_expression, str) else ""
+    )
+    expression, avg_operands = desugar_aggregates(raw_expression)
     try:
-      parsed = parse_arithmetic_expression(expression, names)
+      parsed = parse_arithmetic_expression(expression, names + list(avg_operands))
       lhs_names = lhs_variable_names(parsed)
     except InvalidRuleExpression as exc:
       _skip(f"expression error: {exc}")
@@ -242,6 +362,10 @@ def cmd_compute_metrics(
     duration_start: date | None = None
     for name in operand_names:
       qname = qname_by_name.get(name)
+      if qname and qname in computed_by_qname:
+        # In-run metric dependency — topo order guarantees it ran first.
+        values[name] = computed_by_qname[qname]
+        continue
       operand_element = _element_by_qname(qname) if qname else None
       if operand_element is None:
         missing.append(qname or name)
@@ -254,11 +378,43 @@ def cmd_compute_metrics(
         period_start=body.period_start,
       )
       if bound is None:
-        missing.append(qname or name)
+        if qname and qname in run_target_qnames:
+          missing.append(f"{qname} (metric not computed)")
+        else:
+          missing.append(qname or name)
         continue
       values[name] = bound.value
       if bound.period_start is not None and duration_start is None:
         duration_start = bound.period_start
+
+    # Second pass — avg() operands. The end value is the base operand's
+    # bound value (declared operands always bind above); the begin fact
+    # binds at the resolved prior period end.
+    for synth_name, base_name in avg_operands.items():
+      if base_name not in values:
+        if base_name not in names:
+          missing.append(f"{base_name} (avg operand not declared)")
+        continue  # base already recorded as missing above
+      begin_date = _begin_date(duration_start)
+      qname = qname_by_name.get(base_name)
+      if begin_date is None:
+        missing.append(f"{qname or base_name} (no prior period for avg)")
+        continue
+      operand_element = _element_by_qname(qname) if qname else None
+      if operand_element is None:
+        missing.append(qname or base_name)
+        continue
+      begin_bound = _bind_operand(
+        session,
+        element_id=operand_element.id,
+        entity_id=entity_id,
+        period_end=begin_date,
+        period_start=None,
+      )
+      if begin_bound is None:
+        missing.append(f"{qname} (prior @ {begin_date})")
+        continue
+      values[synth_name] = (begin_bound.value + values[base_name]) / 2.0
 
     if missing:
       _skip("no report fact bound for operand(s)", missing=missing)
@@ -270,7 +426,7 @@ def cmd_compute_metrics(
       _skip(f"evaluation error: {exc}")
       continue
 
-    unit = "USD" if target.is_monetary else "pure"
+    unit = _metric_unit(target)
     period_type = target.period_type or "instant"
     fact_period_start = None
     if period_type == "duration":
@@ -294,8 +450,17 @@ def cmd_compute_metrics(
         value=value,
         unit=unit,
         period_type=period_type,
+        item_type=target.item_type,
       )
     )
+    if target_qname:
+      computed_by_qname[target_qname] = value
+
+  # Evaluation ran in dependency order; present in arc order.
+  computed.sort(key=lambda m: order_by_element.get(m.element_id, float("inf")))
+  pending_facts.sort(
+    key=lambda pf: order_by_element.get(pf["element_id"], float("inf"))
+  )
 
   provenance = DerivedProvenance(computation="compute-metrics", source_fact_ids=[])
 

--- a/robosystems/operations/information_block/rules/expressions.py
+++ b/robosystems/operations/information_block/rules/expressions.py
@@ -11,6 +11,15 @@ constructs that could be exploited.
 
 ``eval()`` is never called. The AST walker evaluates the tree directly
 by recursing over :class:`ast.BinOp` / :class:`ast.UnaryOp` nodes.
+
+Aggregates are desugared, never evaluated: ``avg($X)`` rewrites to a
+synthesized ``$__avg_X`` operand *before* parsing
+(:func:`desugar_aggregates`), so the whitelist keeps rejecting every
+``ast.Call`` and the evaluator stays pure arithmetic — averaging happens
+at bind time in the caller, where the begin + end facts live. A future
+``$X[t-1]`` prior-period operand rides the same mechanism (rewrite to a
+synthesized operand, bind at a resolved prior period) — see
+``compute-metrics``.
 """
 
 from __future__ import annotations
@@ -43,6 +52,35 @@ class InvalidRuleExpression(ValueError):
   """Raised when a rule expression cannot be parsed or evaluated safely."""
 
 
+AVG_OPERAND_PREFIX = "__avg_"
+
+_AVG_CALL_RE = re.compile(r"\bavg\(\s*\$([A-Za-z_]\w*)\s*\)")
+
+
+def desugar_aggregates(expr: str) -> tuple[str, dict[str, str]]:
+  """Rewrite ``avg($X)`` calls to synthesized ``$__avg_X`` operands.
+
+  Returns the rewritten expression plus a map of synthesized variable
+  name → base variable name. Callers append the synthesized names to
+  the parse variable list and bind each one at evaluation time (the
+  period-average of the base operand: begin + end over 2).
+
+  Only the exact single-variable form matches; anything else —
+  ``avg($A + $B)``, ``median($X)`` — survives as a genuine
+  :class:`ast.Call` and is rejected by the whitelist walker, so the
+  no-function-calls security posture is unchanged.
+  """
+  synthesized: dict[str, str] = {}
+
+  def _sub(match: re.Match[str]) -> str:
+    base = match.group(1)
+    name = f"{AVG_OPERAND_PREFIX}{base}"
+    synthesized[name] = base
+    return f"${name}"
+
+  return _AVG_CALL_RE.sub(_sub, expr), synthesized
+
+
 @dataclass
 class ParsedExpression:
   tree: ast.Expression
@@ -52,6 +90,11 @@ class ParsedExpression:
 def _validate(node: ast.AST) -> None:
   for child in ast.walk(node):
     if not isinstance(child, _ALLOWED_NODES):
+      if isinstance(child, ast.Call):
+        raise InvalidRuleExpression(
+          "disallowed AST node: Call — function calls are not allowed; "
+          "the only aggregate form is avg($Var) in Derive expressions"
+        )
       raise InvalidRuleExpression(f"disallowed AST node: {type(child).__name__}")
 
 
@@ -257,10 +300,12 @@ def build_rollup_expression(parent_name: str, children: list[tuple[str, float]])
 
 
 __all__ = [
+  "AVG_OPERAND_PREFIX",
   "EQUALITY_TOLERANCE",
   "InvalidRuleExpression",
   "ParsedExpression",
   "build_rollup_expression",
+  "desugar_aggregates",
   "evaluate_arithmetic",
   "evaluate_derivation",
   "evaluate_equality",

--- a/robosystems/operations/taxonomy_block/library_creator.py
+++ b/robosystems/operations/taxonomy_block/library_creator.py
@@ -224,6 +224,7 @@ def create_library_taxonomy_elements(
         is_abstract=element.is_abstract,
         is_monetary=element.is_monetary,
         element_type=element.element_type,
+        item_type=element.item_type,
         parent_id=None,
         depth=0,
         path="",
@@ -247,6 +248,7 @@ def create_library_taxonomy_elements(
           "is_abstract": pg_insert(Element.__table__).excluded.is_abstract,
           "is_monetary": pg_insert(Element.__table__).excluded.is_monetary,
           "element_type": pg_insert(Element.__table__).excluded.element_type,
+          "item_type": pg_insert(Element.__table__).excluded.item_type,
         },
       )
     )

--- a/robosystems/operations/taxonomy_block/validators.py
+++ b/robosystems/operations/taxonomy_block/validators.py
@@ -44,6 +44,7 @@ from robosystems.models.api.taxonomy_block import (
 from robosystems.models.extensions import Element
 from robosystems.operations.information_block.rules.expressions import (
   InvalidRuleExpression,
+  desugar_aggregates,
   lhs_variable_names,
   parse_arithmetic_expression,
 )
@@ -433,8 +434,36 @@ def _phase_rule_expression_parse(
       )
       continue
 
+    # Derive rules may use the avg($Var) aggregate — desugar to the
+    # synthesized operand form the compute path evaluates, so authored
+    # avg expressions validate the same way they run. Other patterns
+    # keep the raw expression: a stray avg() there is a genuine
+    # ast.Call and fails the whitelist below, as it should.
+    expression = rule.expression
+    parse_names = variable_names
+    if rule.rule_pattern == "Derive":
+      expression, synthesized = desugar_aggregates(expression)
+      undeclared = sorted(
+        base for base in synthesized.values() if base not in variable_names
+      )
+      if undeclared:
+        issues.append(
+          ValidationIssue(
+            phase="rule_expression_parse",
+            code="unknown_aggregate_operand",
+            message=(
+              f"rule {rule.name!r} averages undeclared variable(s) "
+              f"{undeclared}; every avg($Var) base must appear in the "
+              f"rule's variables with a qname binding."
+            ),
+            context={"rule_name": rule.name, "undeclared": undeclared},
+          )
+        )
+        continue
+      parse_names = variable_names + list(synthesized)
+
     try:
-      parsed = parse_arithmetic_expression(rule.expression, variable_names)
+      parsed = parse_arithmetic_expression(expression, parse_names)
     except InvalidRuleExpression as exc:
       issues.append(
         ValidationIssue(

--- a/robosystems/taxonomy/loader.py
+++ b/robosystems/taxonomy/loader.py
@@ -285,6 +285,7 @@ def _extract_element(graph: Graph, subject: URIRef) -> ElementSpec | None:
   balance = _single(URIRef(f"{XBRLI_NS}balance"), "debit") or "debit"
   period_type = _single(URIRef(f"{XBRLI_NS}periodType"), "duration") or "duration"
   element_type = _single(URIRef(f"{RS_NS}elementType"), "concept") or "concept"
+  item_type = _single(URIRef(f"{RS_NS}itemType"), None)
   source = _single(URIRef(f"{RS_NS}source"), prefix) or prefix or "native"
 
   is_abstract = _bool(URIRef(f"{RS_NS}abstract"), False)
@@ -325,6 +326,7 @@ def _extract_element(graph: Graph, subject: URIRef) -> ElementSpec | None:
     is_abstract=is_abstract,
     is_monetary=is_monetary,
     element_type=element_type,
+    item_type=item_type,
     substitution_group=sub_group,
     source=source,
     parent_qname=parent_qname,

--- a/robosystems/taxonomy/model.py
+++ b/robosystems/taxonomy/model.py
@@ -107,6 +107,14 @@ class ElementSpec(BaseModel):
   element_type: str = Field(
     "concept", description="concept | abstract | axis | member | hypercube"
   )
+  item_type: str | None = Field(
+    None,
+    description=(
+      "Value-domain vocabulary (rs:itemType) — monetary | ratio | percent "
+      "| multiple | days | string | …; None means untyped (consumers fall "
+      "back to is_monetary)"
+    ),
+  )
   substitution_group: str | None = Field(
     None, description="XBRL substitution group qname, e.g. 'xbrli:item'"
   )

--- a/robosystems/taxonomy/writer.py
+++ b/robosystems/taxonomy/writer.py
@@ -54,7 +54,7 @@ _TAXONOMY_COLS = (
 _ELEMENT_COLS = (
   "id, code, name, description, qname, namespace, uri, "
   "balance_type, period_type, substitution_group, is_abstract, is_monetary, "
-  "element_type, parent_id, depth, path, taxonomy_id, source, currency, "
+  "element_type, item_type, parent_id, depth, path, taxonomy_id, source, currency, "
   "is_active, is_placeholder, external_id, external_source, "
   "agent_id, aliases, embedding, "
   "metadata, version, created_at, updated_at, created_by"
@@ -420,7 +420,7 @@ _RESYNC_ELEMENT_CONFLICT = (
   "balance_type = EXCLUDED.balance_type, period_type = EXCLUDED.period_type, "
   "substitution_group = EXCLUDED.substitution_group, "
   "is_abstract = EXCLUDED.is_abstract, is_monetary = EXCLUDED.is_monetary, "
-  "element_type = EXCLUDED.element_type"
+  "element_type = EXCLUDED.element_type, item_type = EXCLUDED.item_type"
 )
 _RESYNC_TRAIT_CONFLICT = (
   "ON CONFLICT (id) DO UPDATE SET "

--- a/tests/operations/information_block/rules/test_expressions.py
+++ b/tests/operations/information_block/rules/test_expressions.py
@@ -7,6 +7,7 @@ import pytest
 from robosystems.operations.information_block.rules.expressions import (
   EQUALITY_TOLERANCE,
   InvalidRuleExpression,
+  desugar_aggregates,
   evaluate_derivation,
   evaluate_equality,
   lhs_variable_names,
@@ -211,3 +212,51 @@ class TestEvaluateDerivation:
     parsed = parse_arithmetic_expression("$A + $B", ["A", "B"])
     with pytest.raises(InvalidRuleExpression, match="derivation expects"):
       evaluate_derivation(parsed, {"A": 1.0, "B": 2.0})
+
+
+class TestDesugarAggregates:
+  """avg($X) → synthesized $__avg_X — the pre-parse rewrite that keeps
+  the AST whitelist call-free."""
+
+  def test_rewrites_avg_to_synthesized_operand(self) -> None:
+    expr, synth = desugar_aggregates(
+      "$ReturnOnEquity = ($NetIncomeLoss / avg($StockholdersEquity))"
+    )
+    assert expr == "$ReturnOnEquity = ($NetIncomeLoss / $__avg_StockholdersEquity)"
+    assert synth == {"__avg_StockholdersEquity": "StockholdersEquity"}
+
+  def test_multiple_avg_calls_each_synthesize(self) -> None:
+    expr, synth = desugar_aggregates("$EM = (avg($Assets) / avg($Equity))")
+    assert expr == "$EM = ($__avg_Assets / $__avg_Equity)"
+    assert synth == {"__avg_Assets": "Assets", "__avg_Equity": "Equity"}
+
+  def test_plain_expression_is_untouched(self) -> None:
+    original = "$WorkingCapital = ($AssetsCurrent - $LiabilitiesCurrent)"
+    expr, synth = desugar_aggregates(original)
+    assert expr == original
+    assert synth == {}
+
+  def test_whitespace_inside_call_is_tolerated(self) -> None:
+    expr, synth = desugar_aggregates("$X = avg( $Y )")
+    assert expr == "$X = $__avg_Y"
+    assert synth == {"__avg_Y": "Y"}
+
+  def test_desugared_expression_parses_and_evaluates(self) -> None:
+    expr, synth = desugar_aggregates("$ROE = ($NI / avg($SE))")
+    parsed = parse_arithmetic_expression(expr, ["ROE", "NI", "SE", *list(synth)])
+    value = evaluate_derivation(parsed, {"NI": 30.0, "__avg_SE": 100.0})
+    assert value == pytest.approx(0.3)
+
+  def test_non_variable_argument_survives_and_is_rejected_downstream(self) -> None:
+    """avg($A + $B) is not the aggregate form — it stays a genuine
+    ast.Call and the whitelist rejects it."""
+    expr, synth = desugar_aggregates("$X = avg($A + $B)")
+    assert synth == {}
+    with pytest.raises(InvalidRuleExpression, match="disallowed"):
+      parse_arithmetic_expression(expr, ["X", "A", "B"])
+
+  def test_other_function_names_are_not_desugared(self) -> None:
+    expr, synth = desugar_aggregates("$X = median($A)")
+    assert synth == {}
+    with pytest.raises(InvalidRuleExpression, match="disallowed"):
+      parse_arithmetic_expression(expr, ["X", "A"])

--- a/tests/operations/information_block/test_disclosure_handlers.py
+++ b/tests/operations/information_block/test_disclosure_handlers.py
@@ -145,6 +145,7 @@ class TestBuildEnvelope:
     elem_total.is_monetary = True
     elem_total.balance_type = "debit"
     elem_total.period_type = "instant"
+    elem_total.item_type = None
 
     elem_raw = MagicMock()
     elem_raw.id = "elem_raw_materials"
@@ -156,6 +157,7 @@ class TestBuildEnvelope:
     elem_raw.is_monetary = True
     elem_raw.balance_type = "debit"
     elem_raw.period_type = "instant"
+    elem_raw.item_type = None
 
     # Query order with associations: fact_set → taxonomy name →
     # associations → elements → rules → association classifications →

--- a/tests/operations/information_block/test_metric_handlers.py
+++ b/tests/operations/information_block/test_metric_handlers.py
@@ -32,7 +32,9 @@ def _structure(*, mechanics: dict | None = None) -> MagicMock:
   return s
 
 
-def _element(element_id: str, qname: str, name: str) -> SimpleNamespace:
+def _element(
+  element_id: str, qname: str, name: str, *, item_type: str | None = None
+) -> SimpleNamespace:
   return SimpleNamespace(
     id=element_id,
     qname=qname,
@@ -43,6 +45,7 @@ def _element(element_id: str, qname: str, name: str) -> SimpleNamespace:
     is_monetary=False,
     balance_type="debit",
     period_type="instant",
+    item_type=item_type,
   )
 
 

--- a/tests/operations/information_block/test_metrics_compute.py
+++ b/tests/operations/information_block/test_metrics_compute.py
@@ -34,6 +34,12 @@ def _first(row: Any) -> MagicMock:
   return result
 
 
+def _scalar(value: Any) -> MagicMock:
+  result = MagicMock()
+  result.scalar.return_value = value
+  return result
+
+
 def _fetchone(row: Any) -> MagicMock:
   result = MagicMock()
   result.fetchone.return_value = row
@@ -54,6 +60,7 @@ def _element(
   *,
   monetary: bool = False,
   period_type: str = "instant",
+  item_type: str | None = None,
 ) -> SimpleNamespace:
   return SimpleNamespace(
     id=element_id,
@@ -61,6 +68,7 @@ def _element(
     name=name,
     is_monetary=monetary,
     period_type=period_type,
+    item_type=item_type,
   )
 
 
@@ -320,3 +328,399 @@ class TestComputeMetrics:
     session.execute.side_effect = [_fetchone(None)]
     with pytest.raises(ValueError, match="No entity found"):
       metrics_mod.cmd_compute_metrics(session, _body(entity_id=None), "usr_1")
+
+
+EL_NI = _element("el_ni", "rs-gaap:NetIncomeLoss", "Net Income", period_type="duration")
+EL_REV = _element("el_rev", "rs-gaap:Revenues", "Revenues", period_type="duration")
+EL_SE = _element("el_se", "rs-gaap:StockholdersEquity", "Stockholders' Equity")
+EL_A = _element("el_a", "rs-gaap:Assets", "Assets")
+EL_ROE = _element(
+  "el_roe",
+  "rs-metric:ReturnOnEquity",
+  "Return on Equity",
+  period_type="duration",
+  item_type="percent",
+)
+EL_NPM = _element(
+  "el_npm",
+  "rs-metric:NetProfitMargin",
+  "Net Profit Margin",
+  period_type="duration",
+  item_type="percent",
+)
+EL_EM = _element(
+  "el_em",
+  "rs-metric:EquityMultiplier",
+  "Equity Multiplier",
+  period_type="duration",
+  item_type="multiple",
+)
+
+RULE_ROE = _rule(
+  "rule_roe",
+  "el_roe",
+  "$ReturnOnEquity = ($NetIncomeLoss / avg($StockholdersEquity))",
+  [
+    ("ReturnOnEquity", "rs-metric:ReturnOnEquity"),
+    ("NetIncomeLoss", "rs-gaap:NetIncomeLoss"),
+    ("StockholdersEquity", "rs-gaap:StockholdersEquity"),
+  ],
+)
+RULE_EM = _rule(
+  "rule_em",
+  "el_em",
+  "$EquityMultiplier = (avg($Assets) / avg($StockholdersEquity))",
+  [
+    ("EquityMultiplier", "rs-metric:EquityMultiplier"),
+    ("Assets", "rs-gaap:Assets"),
+    ("StockholdersEquity", "rs-gaap:StockholdersEquity"),
+  ],
+)
+RULE_NPM = _rule(
+  "rule_npm",
+  "el_npm",
+  "$NetProfitMargin = ($NetIncomeLoss / $Revenues)",
+  [
+    ("NetProfitMargin", "rs-metric:NetProfitMargin"),
+    ("NetIncomeLoss", "rs-gaap:NetIncomeLoss"),
+    ("Revenues", "rs-gaap:Revenues"),
+  ],
+)
+RULE_DOUBLE_NPM = _rule(
+  "rule_double_npm",
+  "el_em",
+  "$EquityMultiplier = ($NetProfitMargin * 2)",
+  [
+    ("EquityMultiplier", "rs-metric:EquityMultiplier"),
+    ("NetProfitMargin", "rs-metric:NetProfitMargin"),
+  ],
+)
+
+
+class TestAvgOperand:
+  """avg($X) — the M-2 period-average aggregate."""
+
+  def test_avg_via_request_window(self) -> None:
+    """body.period_start present → begin fact binds at period_start - 1d."""
+    structure = _structure()
+    session = _session(structure, {"el_roe": EL_ROE, "el_ni": EL_NI, "el_se": EL_SE})
+    session.execute.side_effect = [
+      _scalars([_arc("el_roe", 1.0)]),
+      _scalars([RULE_ROE]),
+      _scalar_one(EL_NI),
+      _first((30.0, date(2026, 3, 1))),  # NetIncomeLoss for the month
+      _scalar_one(EL_SE),
+      _first((120.0, None)),  # StockholdersEquity end instant
+      _first((80.0, None)),  # StockholdersEquity begin instant (@ 2026-02-28)
+      _scalar_one(None),  # standing lookup
+    ]
+
+    with patch.object(
+      metrics_mod,
+      "create_fact_set",
+      return_value=SimpleNamespace(id="fs_new", provenance=None),
+    ):
+      response = metrics_mod.cmd_compute_metrics(
+        session, _body(period_start=date(2026, 3, 1)), "usr_1"
+      )
+
+    assert len(response.computed) == 1
+    roe = response.computed[0]
+    # 30 / ((80 + 120) / 2) = 0.3
+    assert roe.value == pytest.approx(0.3)
+    assert roe.item_type == "percent"
+    assert roe.unit == "pure"
+    # Exactly the choreographed queries ran — in particular, NO
+    # data-driven prior lookup (the request window supplied the begin).
+    assert len(session.execute.call_args_list) == 8
+
+  def test_avg_via_duration_operand_window(self) -> None:
+    """No request window — a bound duration operand's start supplies it."""
+    structure = _structure()
+    session = _session(structure, {"el_roe": EL_ROE, "el_ni": EL_NI, "el_se": EL_SE})
+    fy_start = date(2025, 4, 1)
+    session.execute.side_effect = [
+      _scalars([_arc("el_roe", 1.0)]),
+      _scalars([RULE_ROE]),
+      _scalar_one(EL_NI),
+      _first((50.0, fy_start)),  # duration operand carries the window
+      _scalar_one(EL_SE),
+      _first((150.0, None)),
+      _first((100.0, None)),  # begin @ fy_start - 1d — no prior-lookup query
+      _scalar_one(None),
+    ]
+
+    with patch.object(
+      metrics_mod,
+      "create_fact_set",
+      return_value=SimpleNamespace(id="fs_new", provenance=None),
+    ):
+      response = metrics_mod.cmd_compute_metrics(session, _body(), "usr_1")
+
+    assert response.computed[0].value == pytest.approx(50.0 / 125.0)
+    assert response.skipped == []
+
+  def test_avg_data_driven_prior_fallback_shared_across_operands(self) -> None:
+    """All-instant rule with no window — one cached prior-period lookup."""
+    structure = _structure()
+    session = _session(structure, {"el_em": EL_EM, "el_a": EL_A, "el_se": EL_SE})
+    session.execute.side_effect = [
+      _scalars([_arc("el_em", 1.0)]),
+      _scalars([RULE_EM]),
+      _scalar_one(EL_A),
+      _first((400.0, None)),  # Assets end
+      _scalar_one(EL_SE),
+      _first((200.0, None)),  # Equity end
+      _scalar(date(2026, 2, 28)),  # data-driven prior period (ONE query)
+      _first((300.0, None)),  # Assets begin
+      _first((100.0, None)),  # Equity begin — prior cached, no second lookup
+      _scalar_one(None),
+    ]
+
+    with patch.object(
+      metrics_mod,
+      "create_fact_set",
+      return_value=SimpleNamespace(id="fs_new", provenance=None),
+    ):
+      response = metrics_mod.cmd_compute_metrics(session, _body(), "usr_1")
+
+    # avg(A)=350, avg(SE)=150 → 2.333…
+    assert response.computed[0].value == pytest.approx(350.0 / 150.0)
+    assert response.computed[0].unit == "pure"
+    assert response.computed[0].item_type == "multiple"
+
+  def test_avg_with_no_prior_period_skips_with_reason(self) -> None:
+    """First period of a series — the data-driven fallback finds nothing."""
+    structure = _structure()
+    session = _session(structure, {"el_em": EL_EM, "el_a": EL_A, "el_se": EL_SE})
+    session.execute.side_effect = [
+      _scalars([_arc("el_em", 1.0)]),
+      _scalars([RULE_EM]),
+      _scalar_one(EL_A),
+      _first((400.0, None)),
+      _scalar_one(EL_SE),
+      _first((200.0, None)),
+      _scalar(None),  # no prior report period exists
+      _scalar_one(None),
+    ]
+
+    with patch.object(metrics_mod, "create_fact_set") as create_fs:
+      response = metrics_mod.cmd_compute_metrics(session, _body(), "usr_1")
+
+    assert response.computed == []
+    skip = response.skipped[0]
+    assert skip.element_qname == "rs-metric:EquityMultiplier"
+    assert any("no prior period for avg" in m for m in skip.missing)
+    create_fs.assert_not_called()
+
+  def test_avg_missing_begin_fact_skips_with_prior_annotation(self) -> None:
+    structure = _structure()
+    session = _session(structure, {"el_roe": EL_ROE, "el_ni": EL_NI, "el_se": EL_SE})
+    session.execute.side_effect = [
+      _scalars([_arc("el_roe", 1.0)]),
+      _scalars([RULE_ROE]),
+      _scalar_one(EL_NI),
+      _first((30.0, date(2026, 3, 1))),
+      _scalar_one(EL_SE),
+      _first((120.0, None)),
+      _first(None),  # begin instant absent at the prior period end
+      _scalar_one(None),
+    ]
+
+    response = metrics_mod.cmd_compute_metrics(
+      session, _body(period_start=date(2026, 3, 1)), "usr_1"
+    )
+
+    assert response.computed == []
+    skip = response.skipped[0]
+    assert any("prior @ 2026-02-28" in m for m in skip.missing)
+
+
+class TestComposition:
+  """Metric-on-metric operands — the M-2 DuPont dependency feature."""
+
+  def test_in_run_dependency_evaluates_first_and_reuses_value(self) -> None:
+    """The composite's operand resolves from the in-run value (no bind
+    query), evaluation runs dependency-first, and the response re-sorts
+    to presentation-arc order (composite first here)."""
+    structure = _structure()
+    session = _session(
+      structure,
+      {"el_em": EL_EM, "el_npm": EL_NPM, "el_ni": EL_NI, "el_rev": EL_REV},
+    )
+    session.execute.side_effect = [
+      # Composite is arc-FIRST — topo must still evaluate NPM before it.
+      _scalars([_arc("el_em", 1.0), _arc("el_npm", 2.0)]),
+      _scalars([RULE_DOUBLE_NPM, RULE_NPM]),
+      _scalar_one(EL_NI),
+      _first((20.0, date(2026, 3, 1))),
+      _scalar_one(EL_REV),
+      _first((100.0, date(2026, 3, 1))),
+      # NO bind for the composite's NPM operand — in-run value reused.
+      _scalar_one(None),
+    ]
+
+    with patch.object(
+      metrics_mod,
+      "create_fact_set",
+      return_value=SimpleNamespace(id="fs_new", provenance=None),
+    ):
+      response = metrics_mod.cmd_compute_metrics(session, _body(), "usr_1")
+
+    assert [m.element_qname for m in response.computed] == [
+      "rs-metric:EquityMultiplier",  # arc order 1.0
+      "rs-metric:NetProfitMargin",  # arc order 2.0
+    ]
+    composite, npm = response.computed
+    assert npm.value == pytest.approx(0.2)
+    assert composite.value == pytest.approx(0.4)
+    assert response.skipped == []
+
+  def test_skipped_dependency_cascades_with_reason(self) -> None:
+    structure = _structure()
+    session = _session(
+      structure,
+      {"el_em": EL_EM, "el_npm": EL_NPM, "el_ni": EL_NI, "el_rev": EL_REV},
+    )
+    session.execute.side_effect = [
+      _scalars([_arc("el_em", 1.0), _arc("el_npm", 2.0)]),
+      _scalars([RULE_DOUBLE_NPM, RULE_NPM]),
+      _scalar_one(EL_NI),
+      _first(None),  # NetIncomeLoss missing → NPM skips
+      _scalar_one(EL_REV),
+      _first((100.0, date(2026, 3, 1))),
+      # Composite falls back to a persisted-metric bind, which also misses.
+      _scalar_one(EL_NPM),
+      _first(None),
+      _scalar_one(None),
+    ]
+
+    with patch.object(metrics_mod, "create_fact_set") as create_fs:
+      response = metrics_mod.cmd_compute_metrics(session, _body(), "usr_1")
+
+    assert response.computed == []
+    reasons = {s.element_qname: s.missing for s in response.skipped}
+    assert reasons["rs-metric:NetProfitMargin"] == ["rs-gaap:NetIncomeLoss"]
+    assert reasons["rs-metric:EquityMultiplier"] == [
+      "rs-metric:NetProfitMargin (metric not computed)"
+    ]
+    create_fs.assert_not_called()
+
+  def test_cyclic_rules_degrade_to_skips(self) -> None:
+    el_a = _element("el_ma", "rs-metric:MetricA", "Metric A")
+    el_b = _element("el_mb", "rs-metric:MetricB", "Metric B")
+    rule_a = _rule(
+      "rule_ma",
+      "el_ma",
+      "$MetricA = ($MetricB * 1)",
+      [("MetricA", "rs-metric:MetricA"), ("MetricB", "rs-metric:MetricB")],
+    )
+    rule_b = _rule(
+      "rule_mb",
+      "el_mb",
+      "$MetricB = ($MetricA * 1)",
+      [("MetricB", "rs-metric:MetricB"), ("MetricA", "rs-metric:MetricA")],
+    )
+    structure = _structure()
+    session = _session(structure, {"el_ma": el_a, "el_mb": el_b})
+    session.execute.side_effect = [
+      _scalars([_arc("el_ma", 1.0), _arc("el_mb", 2.0)]),
+      _scalars([rule_a, rule_b]),
+      _scalar_one(el_b),  # A's operand B — no in-run value yet
+      _first(None),  # no persisted metric fact either
+      _scalar_one(el_a),  # B's operand A
+      _first(None),
+      _scalar_one(None),
+    ]
+
+    with patch.object(metrics_mod, "create_fact_set") as create_fs:
+      response = metrics_mod.cmd_compute_metrics(session, _body(), "usr_1")
+
+    assert response.computed == []
+    assert len(response.skipped) == 2
+    for skip in response.skipped:
+      assert any("(metric not computed)" in m for m in skip.missing)
+    create_fs.assert_not_called()
+
+
+class TestUnitFamilies:
+  """item_type → fact unit mapping (M-2 unit/format)."""
+
+  def test_days_item_type_maps_to_days_unit(self) -> None:
+    el_dso = _element(
+      "el_dso",
+      "rs-metric:DaysSalesOutstanding",
+      "Days Sales Outstanding",
+      period_type="duration",
+      item_type="days",
+    )
+    rule_dso = _rule(
+      "rule_dso",
+      "el_dso",
+      "$DaysSalesOutstanding = ($Assets / $Revenues)",
+      [
+        ("DaysSalesOutstanding", "rs-metric:DaysSalesOutstanding"),
+        ("Assets", "rs-gaap:Assets"),
+        ("Revenues", "rs-gaap:Revenues"),
+      ],
+    )
+    structure = _structure()
+    session = _session(structure, {"el_dso": el_dso, "el_a": EL_A, "el_rev": EL_REV})
+    session.execute.side_effect = [
+      _scalars([_arc("el_dso", 1.0)]),
+      _scalars([rule_dso]),
+      _scalar_one(EL_A),
+      _first((300.0, None)),
+      _scalar_one(EL_REV),
+      _first((10.0, date(2026, 3, 1))),
+      _scalar_one(None),
+    ]
+
+    with patch.object(
+      metrics_mod,
+      "create_fact_set",
+      return_value=SimpleNamespace(id="fs_new", provenance=None),
+    ):
+      response = metrics_mod.cmd_compute_metrics(session, _body(), "usr_1")
+
+    assert response.computed[0].unit == "days"
+    assert response.computed[0].item_type == "days"
+
+  def test_monetary_item_type_maps_to_usd(self) -> None:
+    el = _element(
+      "el_wc2",
+      "rs-metric:WorkingCapital",
+      "Working Capital",
+      monetary=True,
+      item_type="monetary",
+    )
+    structure = _structure()
+    session = _session(structure, {"el_wc2": el, "el_ac": EL_AC, "el_lc": EL_LC})
+    rule = _rule(
+      "rule_wc2",
+      "el_wc2",
+      "$WorkingCapital = ($AssetsCurrent - $LiabilitiesCurrent)",
+      [
+        ("WorkingCapital", "rs-metric:WorkingCapital"),
+        ("AssetsCurrent", "rs-gaap:AssetsCurrent"),
+        ("LiabilitiesCurrent", "rs-gaap:LiabilitiesCurrent"),
+      ],
+    )
+    session.execute.side_effect = [
+      _scalars([_arc("el_wc2", 1.0)]),
+      _scalars([rule]),
+      _scalar_one(EL_AC),
+      _first((100.0, None)),
+      _scalar_one(EL_LC),
+      _first((40.0, None)),
+      _scalar_one(None),
+    ]
+
+    with patch.object(
+      metrics_mod,
+      "create_fact_set",
+      return_value=SimpleNamespace(id="fs_new", provenance=None),
+    ):
+      response = metrics_mod.cmd_compute_metrics(session, _body(), "usr_1")
+
+    assert response.computed[0].unit == "USD"

--- a/tests/operations/information_block/test_rollforward_handlers.py
+++ b/tests/operations/information_block/test_rollforward_handlers.py
@@ -31,6 +31,7 @@ def _element(element_id: str, qname: str, taxonomy_id: str = "tax_mini") -> Magi
   el.id = element_id
   el.qname = qname
   el.taxonomy_id = taxonomy_id
+  el.item_type = None
   return el
 
 

--- a/tests/operations/information_block/test_statement_handlers.py
+++ b/tests/operations/information_block/test_statement_handlers.py
@@ -222,6 +222,7 @@ class TestBuildEnvelope:
     element_revenue.is_monetary = True
     element_revenue.balance_type = "credit"
     element_revenue.period_type = "duration"
+    element_revenue.item_type = None
 
     element_sales = MagicMock()
     element_sales.id = "elem_sales"
@@ -233,6 +234,7 @@ class TestBuildEnvelope:
     element_sales.is_monetary = True
     element_sales.balance_type = "credit"
     element_sales.period_type = "duration"
+    element_sales.item_type = None
 
     # Query order (1 association → elements + classifications queries run):
     # fact_set → taxonomy → associations → elements → rules → classifications →
@@ -295,6 +297,7 @@ class TestBuildEnvelope:
     element.is_monetary = True
     element.balance_type = "debit"
     element.period_type = "instant"
+    element.item_type = None
 
     fact_set = MagicMock()
     fact_set.id = "fset_balance_sheet_2026q1"

--- a/tests/operations/information_block/test_text_block_handlers.py
+++ b/tests/operations/information_block/test_text_block_handlers.py
@@ -38,6 +38,7 @@ def _element() -> SimpleNamespace:
     is_monetary=False,
     balance_type="debit",
     period_type="duration",
+    item_type=None,
   )
 
 

--- a/tests/operations/taxonomy_block/test_validators.py
+++ b/tests/operations/taxonomy_block/test_validators.py
@@ -282,6 +282,71 @@ class TestRuleExpressionParse:
     issues = validate_create_envelope(payload, _session_empty())
     assert any(i.code == "unparseable_expression" for i in issues)
 
+  def test_derive_avg_expression_accepted(self) -> None:
+    """Derive rules validate through the same avg() desugar the compute
+    path runs, so authored avg expressions pass the gate."""
+    payload = _basic_coa(
+      rules=[
+        TaxonomyBlockRuleRequest(
+          name="derive-roe",
+          rule_category="ReportingSystemSpecificRule",
+          rule_pattern="Derive",
+          expression="$ROE = ($NetIncome / avg($Equity))",
+          variables=[
+            {"variable_name": "ROE", "variable_qname": "ext:ROE"},
+            {"variable_name": "NetIncome", "variable_qname": "rs-gaap:NetIncomeLoss"},
+            {
+              "variable_name": "Equity",
+              "variable_qname": "rs-gaap:StockholdersEquity",
+            },
+          ],
+          target_taxonomy_self=True,
+        )
+      ]
+    )
+    issues = validate_create_envelope(payload, _session_empty())
+    assert not any(i.phase == "rule_expression_parse" for i in issues)
+
+  def test_derive_avg_of_undeclared_variable_rejected(self) -> None:
+    payload = _basic_coa(
+      rules=[
+        TaxonomyBlockRuleRequest(
+          name="derive-roe-bad",
+          rule_category="ReportingSystemSpecificRule",
+          rule_pattern="Derive",
+          expression="$ROE = ($NetIncome / avg($Mystery))",
+          variables=[
+            {"variable_name": "ROE", "variable_qname": "ext:ROE"},
+            {"variable_name": "NetIncome", "variable_qname": "rs-gaap:NetIncomeLoss"},
+          ],
+          target_taxonomy_self=True,
+        )
+      ]
+    )
+    issues = validate_create_envelope(payload, _session_empty())
+    assert any(i.code == "unknown_aggregate_operand" for i in issues)
+
+  def test_avg_outside_derive_still_rejected(self) -> None:
+    """Verification patterns get no desugar — avg() there is a genuine
+    function call and fails the whitelist."""
+    payload = _basic_coa(
+      rules=[
+        TaxonomyBlockRuleRequest(
+          name="equalto-with-avg",
+          rule_category="FundamentalAccountingConceptRelation",
+          rule_pattern="EqualTo",
+          expression="$Assets = avg($Equity)",
+          variables=[
+            {"variable_name": "Assets", "variable_qname": "us-gaap:Assets"},
+            {"variable_name": "Equity", "variable_qname": "us-gaap:StockholdersEquity"},
+          ],
+          target_taxonomy_self=True,
+        )
+      ]
+    )
+    issues = validate_create_envelope(payload, _session_empty())
+    assert any(i.code == "unparseable_expression" for i in issues)
+
   def test_duplicate_variable_name_rejected(self) -> None:
     """Same-named variables silently merge in the engine's name-keyed
     fact bindings — the gate rejects them outright."""

--- a/tests/taxonomy/test_rs_metric_seed.py
+++ b/tests/taxonomy/test_rs_metric_seed.py
@@ -1,10 +1,12 @@
-"""Tests for the rs-metric/v1 catalog package (Metrics M-1).
+"""Tests for the rs-metric/v1 catalog package (Metrics M-1 + M-2).
 
 Pins the hand-authored artifact's shape: the Key Financial Metrics
-container (element + structure), five metric concepts, five role-bound
-presentation arcs, and five ``Derive`` rules whose expressions parse and
-whose operands reference rs-gaap anchors that exist in the rs-gaap
-package (the calc-DAG anchors the report pivot persists).
+container (element + structure), ten metric concepts, ten role-bound
+presentation arcs, and ten ``Derive`` rules whose expressions parse
+(through the avg() desugar) and whose operands reference either rs-gaap
+anchors that exist in the rs-gaap package (the calc-DAG anchors the
+report pivot persists) or rs-metric concepts defined in this package
+(the M-2 composition operands).
 """
 
 from __future__ import annotations
@@ -14,6 +16,7 @@ import json
 import pytest
 
 from robosystems.operations.information_block.rules.expressions import (
+  desugar_aggregates,
   lhs_variable_names,
   parse_arithmetic_expression,
 )
@@ -28,12 +31,33 @@ from robosystems.taxonomy.model import RuleSpec, TaxonomyPackage
 SEED_PATH = framework_root("rs-gaap") / "packages" / "rs-metric" / "v1"
 ROLE_URI = "https://robosystems.ai/seattle/cm-roles/roles/metrics/KeyFinancialMetrics"
 
-EXPECTED_CONCEPTS = {
+M1_CONCEPTS = {
   "rs-metric:WorkingCapital",
   "rs-metric:CurrentRatio",
   "rs-metric:QuickRatio",
   "rs-metric:DebtToEquity",
   "rs-metric:InterestCoverage",
+}
+M2_CONCEPTS = {
+  "rs-metric:ReturnOnEquity",
+  "rs-metric:NetProfitMargin",
+  "rs-metric:AssetTurnover",
+  "rs-metric:EquityMultiplier",
+  "rs-metric:ReturnOnEquityDuPont",
+}
+EXPECTED_CONCEPTS = M1_CONCEPTS | M2_CONCEPTS
+
+EXPECTED_ITEM_TYPES = {
+  "rs-metric:WorkingCapital": "monetary",
+  "rs-metric:CurrentRatio": "ratio",
+  "rs-metric:QuickRatio": "ratio",
+  "rs-metric:DebtToEquity": "ratio",
+  "rs-metric:InterestCoverage": "multiple",
+  "rs-metric:ReturnOnEquity": "percent",
+  "rs-metric:NetProfitMargin": "percent",
+  "rs-metric:AssetTurnover": "multiple",
+  "rs-metric:EquityMultiplier": "multiple",
+  "rs-metric:ReturnOnEquityDuPont": "percent",
 }
 
 
@@ -69,11 +93,22 @@ class TestPackageShape:
   def test_monetary_and_period_shape(self, package: TaxonomyPackage) -> None:
     by_qname = {e.qname: e for e in package.elements}
     assert by_qname["rs-metric:WorkingCapital"].is_monetary
-    for ratio in ("CurrentRatio", "QuickRatio", "DebtToEquity", "InterestCoverage"):
-      assert not by_qname[f"rs-metric:{ratio}"].is_monetary
-    assert by_qname["rs-metric:InterestCoverage"].period_type == "duration"
+    for qname in EXPECTED_CONCEPTS - {"rs-metric:WorkingCapital"}:
+      assert not by_qname[qname].is_monetary
     for instant in ("WorkingCapital", "CurrentRatio", "QuickRatio", "DebtToEquity"):
       assert by_qname[f"rs-metric:{instant}"].period_type == "instant"
+    # The M-2 concepts measure over the window (flows or period
+    # averages), so they are all durations — like InterestCoverage.
+    for duration in {"rs-metric:InterestCoverage"} | M2_CONCEPTS:
+      assert by_qname[duration].period_type == "duration"
+
+  def test_item_types(self, package: TaxonomyPackage) -> None:
+    """Every catalog concept carries its format family — the M-2
+    unit/format plumbing seeds from here."""
+    by_qname = {e.qname: e for e in package.elements}
+    for qname, expected in EXPECTED_ITEM_TYPES.items():
+      assert by_qname[qname].item_type == expected, qname
+    assert by_qname["rs-metric:KeyFinancialMetrics"].item_type is None
 
   def test_structure(self, package: TaxonomyPackage) -> None:
     assert len(package.structures) == 1
@@ -86,22 +121,22 @@ class TestPackageShape:
     self, package: TaxonomyPackage
   ) -> None:
     arcs = package.associations
-    assert len(arcs) == 5
+    assert len(arcs) == 10
     assert {a.to_qname for a in arcs} == EXPECTED_CONCEPTS
     for arc in arcs:
       assert arc.from_qname == "rs-metric:KeyFinancialMetrics"
       assert arc.association_type == "presentation"
       assert arc.role == ROLE_URI
     orders = sorted(a.order for a in arcs)
-    assert orders == [1.0, 2.0, 3.0, 4.0, 5.0]
+    assert orders == [float(i) for i in range(1, 11)]
 
 
 class TestDeriveRules:
-  def test_five_derive_rules(self, rules: list[RuleSpec]) -> None:
+  def test_ten_derive_rules(self, rules: list[RuleSpec]) -> None:
     """Regression against the RULE_PATTERN_VALUES gate: an unknown
     pattern is silently skipped at load, so a missing 'Derive' entry
     would collapse this to zero."""
-    assert len(rules) == 5
+    assert len(rules) == 10
     for rule in rules:
       assert rule.rule_pattern == "Derive"
       assert rule.rule_pattern in RULE_PATTERN_VALUES
@@ -117,27 +152,61 @@ class TestDeriveRules:
     assert targets == EXPECTED_CONCEPTS
 
   def test_expressions_parse_with_lhs_metric_first(self, rules: list[RuleSpec]) -> None:
+    """Every expression parses through the avg() desugar (the compute
+    path's exact preprocessing) with the target metric as the sole LHS
+    variable, listed first."""
     for rule in rules:
       names = [v.variable_name for v in rule.rule_variables]
-      parsed = parse_arithmetic_expression(rule.rule_expression, names)
+      expression, synthesized = desugar_aggregates(rule.rule_expression)
+      # Every avg() base must be a declared variable with a qname binding.
+      for base in synthesized.values():
+        assert base in names, f"{rule.id}: avg base {base!r} not declared"
+      parsed = parse_arithmetic_expression(expression, names + list(synthesized))
       lhs = lhs_variable_names(parsed)
       assert len(lhs) == 1
       # LHS variable is the target metric and sits first in the list.
       assert lhs[0] == names[0]
       assert rule.rule_variables[0].variable_qname == rule.rule_target.target_ref
 
-  def test_operand_qnames_exist_in_rs_gaap_package(self, rules: list[RuleSpec]) -> None:
-    """Operands must be anchors the report pivot actually persists —
-    a typo'd qname soft-fails to 'skipped' at compute time, so catch it
-    here instead."""
+  def test_avg_and_composition_are_present(self, rules: list[RuleSpec]) -> None:
+    """The M-2 grammar is exercised by the shipped catalog: at least one
+    avg() rule and one metric-on-metric rule, and the DuPont composite's
+    operands are exactly the three legs."""
+    by_target = {r.rule_target.target_ref: r for r in rules if r.rule_target}
+    _, roe_synth = desugar_aggregates(
+      by_target["rs-metric:ReturnOnEquity"].rule_expression
+    )
+    assert roe_synth == {"__avg_StockholdersEquity": "StockholdersEquity"}
+    dupont = by_target["rs-metric:ReturnOnEquityDuPont"]
+    operand_qnames = {v.variable_qname for v in dupont.rule_variables[1:]}
+    assert operand_qnames == {
+      "rs-metric:NetProfitMargin",
+      "rs-metric:AssetTurnover",
+      "rs-metric:EquityMultiplier",
+    }
+
+  def test_operand_qnames_resolve_in_package_universe(
+    self, rules: list[RuleSpec], package: TaxonomyPackage
+  ) -> None:
+    """Operands must be anchors the report pivot actually persists (a
+    typo'd qname soft-fails to 'skipped' at compute time, so catch it
+    here) — or, for M-2 composition, rs-metric concepts defined in this
+    very package."""
     rs_gaap_path = framework_root("rs-gaap") / "packages" / "rs-gaap" / "v1"
     raw = json.loads((rs_gaap_path / "taxonomy.jsonld").read_text())
     rs_gaap_ids = {
       node.get("@id") for node in raw.get("@graph", []) if isinstance(node, dict)
     }
+    own_qnames = {e.qname for e in package.elements}
     for rule in rules:
       for var in rule.rule_variables[1:]:
-        assert var.variable_qname.startswith("rs-gaap:")
-        assert var.variable_qname in rs_gaap_ids, (
-          f"{rule.id}: operand {var.variable_qname} not found in rs-gaap/v1"
-        )
+        qname = var.variable_qname
+        if qname.startswith("rs-metric:"):
+          assert qname in own_qnames, (
+            f"{rule.id}: composition operand {qname} not defined in rs-metric/v1"
+          )
+        else:
+          assert qname.startswith("rs-gaap:")
+          assert qname in rs_gaap_ids, (
+            f"{rule.id}: operand {qname} not found in rs-gaap/v1"
+          )


### PR DESCRIPTION
## What

The Metrics M-2 increment (per `metrics-analytics.md` / `fpa-operating-plan.md` in the vault) — and by the fpa spec's re-scoping, **the forecast grammar's first commit**: `avg()` is the first cross-period operand, and the same desugar+resolver seams carry the future `[t-1]` prior-period operand.

### Grammar — `avg($X)` (`rules/expressions.py`, `metrics.py`)

- **Pre-parse desugar, not `ast.Call`**: `avg($X)` rewrites to a synthesized `$__avg_X` operand before parsing, so the AST whitelist keeps rejecting every function call (the security posture and its regression tests are untouched — `avg($A + $B)` / `median($X)` survive as genuine Calls and fail the walker, now with a clearer message).
- **Bind-time averaging**: the end value reuses the base operand's bound fact; the begin fact binds at a resolved prior period end — `period_start − 1d` when the request carries a window, else a bound duration operand's window start − 1d, else a **run-cached data-driven prior** (the entity's newest report period_end strictly before the requested one). Never the fiscal calendar — annual-comparative tenants don't populate month ends.
- **Honest skips**: no prior period → `(no prior period for avg)`; missing begin fact → `(prior @ <date>)` annotation. First column of a fresh series skips by design.

### Composition — DuPont (`metrics.py`)

- An operand naming another rule's target is an in-run dependency: rules evaluate **dependency-first** (dependency depth via `calc_dag.topo_sort_calculations`, arc order among independents; responses re-sort to presentation order), in-run values resolve before fact binds, and `_bind_operand` widens to `factset_type IN ('report','metric')` so cross-structure metrics resolve once computed for the period.
- Cycles and skipped dependencies cascade to soft-skips with `(metric not computed)` — never an error.

### Unit/format — `Element.item_type` (no schema change)

The existing open value-domain column carries `monetary | ratio | percent | multiple | days`, threaded through the taxonomy pipeline lockstep (`ElementSpec` → loader `rs:itemType` → `library_creator` upsert → writer `_ELEMENT_COLS` + `_RESYNC_ELEMENT_CONFLICT`) and surfaced on `ElementLite` / `RenderingRowLite` / `ComputedMetricLite`. Fact units map `monetary→USD`, `days→days`, else `pure` (NULL keeps the M-1 `is_monetary` binary). GraphQL picks the field up via the existing `all_fields` derivation — zero resolver changes.

### Catalog + migration

- `rs-metric/v1` grows **in place** (resync updates elements/rules, inserts new rows — a v2 would duplicate the catalog): +5 concepts/arcs/rules — ReturnOnEquity (`avg`), NetProfitMargin, AssetTurnover (`avg`), EquityMultiplier (double-`avg`), and ReturnOnEquityDuPont (pure composition), each with `itemType`.
- **Migration 0023**: no CHECK changes (0022 already admits the vocabulary) — reseed public + tenant fan-out under the resync GUC. Deploy-coupled with the loader/writer code by design.
- Tenant authoring: `Derive` rules validate through the same desugar (avg of an undeclared variable → new `unknown_aggregate_operand` issue); verification patterns get no desugar — `avg()` there still fails the whitelist.

## Verification

- **Live e2e** on the Driftline monthly series (15 monthly report FactSets from #914's runner): 0023 applied against the existing dev DB (public reseed + tenant resync — the prod backfill path), then all 15 windows recomputed: month 1 skips avg metrics with prior-date annotations + the composite cascades; months 2–15 compute 9/10 (InterestCoverage soft-skips, debt-free co); **DuPont identity holds to 1e-9 and agrees with direct ROE to 1e-6**; every rendering row carries its `itemType` through GraphQL.
- 46 expressions/seed tests + 18 compute tests (7 pre-existing choreographies unchanged — the new queries are lazy) + 30 validator tests; full unit suite 2768 passed (one pre-existing graph_api flake passes in isolation); `just test-code` green.