### PR TITLE
feat(blocks): chart View projection — the 7th arm, server-shaped panel config

### DIFF
--- a/robosystems/graphql/types/information_block.py
+++ b/robosystems/graphql/types/information_block.py
@@ -24,6 +24,15 @@ from robosystems.models.api.information_block import (
   ArtifactResponse as PydanticArtifact,
 )
 from robosystems.models.api.information_block import (
+  ChartLite as PydanticChart,
+)
+from robosystems.models.api.information_block import (
+  ChartPanelLite as PydanticChartPanel,
+)
+from robosystems.models.api.information_block import (
+  ChartSeriesLite as PydanticChartSeries,
+)
+from robosystems.models.api.information_block import (
   ClassificationLite as PydanticClassification,
 )
 from robosystems.models.api.information_block import (
@@ -170,6 +179,21 @@ class InformationBlockRendering:
   """Pre-computed rendering projection — rows + periods + validation."""
 
 
+@pydantic_type(model=PydanticChartSeries, all_fields=True)
+class InformationBlockChartSeries:
+  """One plottable series — identity only; values join rendering.rows."""
+
+
+@pydantic_type(model=PydanticChartPanel, all_fields=True)
+class InformationBlockChartPanel:
+  """One chart panel — series sharing a y-axis format family."""
+
+
+@pydantic_type(model=PydanticChart, all_fields=True)
+class InformationBlockChart:
+  """Server-shaped chart projection — panel/series config, never values."""
+
+
 @pydantic_type(model=PydanticViewProjections, all_fields=True)
 class InformationBlockViewProjections:
   """Charlie's six type-of View arms surfaced in the envelope."""
@@ -288,6 +312,9 @@ class InformationBlock:
 __all__ = [
   "Artifact",
   "InformationBlock",
+  "InformationBlockChart",
+  "InformationBlockChartPanel",
+  "InformationBlockChartSeries",
   "InformationBlockClassification",
   "InformationBlockConnection",
   "InformationBlockElement",

--- a/robosystems/models/api/information_block.py
+++ b/robosystems/models/api/information_block.py
@@ -759,6 +759,62 @@ class RenderingLite(BaseModel):
   unmapped_count: int = 0
 
 
+class ChartSeriesLite(BaseModel):
+  """One plottable series in a chart panel.
+
+  Carries structure and identity only — the values live in the sibling
+  ``rendering.rows`` (join on ``element_id``), so the chart arm never
+  duplicates the value matrix. ``key`` is the stable series identity for
+  client state (colors, toggles); today it equals ``element_id``, and
+  future axes (the forecast scenario) arrive as new fields on this
+  model, never a new arm shape.
+  """
+
+  model_config = ConfigDict(from_attributes=True)
+
+  key: str = Field(..., description="Stable series id — element_id today.")
+  element_id: str
+  label: str = Field(..., description="Display name for legends.")
+
+
+class ChartPanelLite(BaseModel):
+  """One chart panel — series sharing a y-axis format family.
+
+  Mixed-unit catalogs are unplottable on one axis, so the server groups
+  rows into panels by ``item_type`` family (NULL falls back to
+  ``is_monetary``). The x-axis is always ``rendering.periods``.
+  """
+
+  model_config = ConfigDict(from_attributes=True)
+
+  label: str | None = Field(
+    None, description="Panel heading — e.g. 'Monetary', 'Ratios'."
+  )
+  item_type: str | None = Field(
+    None,
+    description=(
+      "Format family shared by the panel's series (monetary | ratio | "
+      "percent | multiple | days); None for the untyped fallback panel."
+    ),
+  )
+  kind: str = Field("line", description="Per-panel mark — 'line' or 'bar'.")
+  series: list[ChartSeriesLite] = Field(default_factory=list)
+
+
+class ChartLite(BaseModel):
+  """Server-shaped chart projection — panel/series CONFIG, never values.
+
+  The second real server-computed View arm (after ``rendering``). Values
+  come from ``rendering.rows`` joined by ``element_id``; the x-axis is
+  ``rendering.periods``. Renderers (report-components) turn one panel
+  into one chart.
+  """
+
+  model_config = ConfigDict(from_attributes=True)
+
+  panels: list[ChartPanelLite] = Field(default_factory=list)
+
+
 class ViewProjections(BaseModel):
   """Charlie's six ``type-of View`` arms, surfaced at the envelope boundary.
 
@@ -768,7 +824,9 @@ class ViewProjections(BaseModel):
   mode; missing projections (those still in backlog) render as empty
   states without breaking the dispatcher.
 
-  Today: ``rendering`` is computed for the statement family.
+  Today: ``rendering`` is computed for the statement family, and
+  ``chart`` (the 7th arm — panel/series config over the rendering's
+  rows and periods) for metric blocks.
   Other arms (``fact_table``, ``model_structure``, ``verification_results``,
   ``report_elements``, ``business_rules``) come online as their backend
   support lands; ``fact_table`` is trivially derivable from
@@ -779,6 +837,7 @@ class ViewProjections(BaseModel):
   model_config = ConfigDict(from_attributes=True)
 
   rendering: RenderingLite | None = None
+  chart: ChartLite | None = None
 
 
 # ── Envelope root ──────────────────────────────────────────────────────────
@@ -1499,6 +1558,9 @@ class ComputeMetricsResponse(BaseModel):
 __all__ = [
   "ArtifactMechanics",
   "ArtifactResponse",
+  "ChartLite",
+  "ChartPanelLite",
+  "ChartSeriesLite",
   "ClassificationLite",
   "ComputeMetricsRequest",
   "ComputeMetricsResponse",

--- a/robosystems/operations/information_block/chart.py
+++ b/robosystems/operations/information_block/chart.py
@@ -1,0 +1,97 @@
+"""Chart View projection — panel/series config over a rendering.
+
+The 7th ``type-of View`` arm (A-2), and the second real server-shaped
+one after ``rendering``. The server's value-add is the grouping logic:
+mixed-unit catalogs are unplottable on one y-axis, so rows group into
+one panel per ``item_type`` format family (NULL falls back to the
+``is_monetary`` binary), panel order following first appearance in
+presentation-arc order. The projection carries structure only — series
+values live in ``rendering.rows`` (joined by ``element_id``) and the
+x-axis is ``rendering.periods`` — so the chart arm never duplicates the
+value matrix.
+
+Rendering-generic by design: A-2 invokes it from the metric envelope
+builder only, but any builder whose rendering rows carry plottable
+per-period values (statements, schedules) can adopt it without
+redesign. Subtotal rows are excluded — statement charts need subtotal
+curation first, which is the adopting builder's problem, not this
+helper's.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from robosystems.models.api.information_block import (
+  ChartLite,
+  ChartPanelLite,
+  ChartSeriesLite,
+  RenderingLite,
+)
+
+if TYPE_CHECKING:
+  from robosystems.models.extensions import Element
+
+_FAMILY_LABELS = {
+  "monetary": "Monetary",
+  "ratio": "Ratios",
+  "percent": "Percentages",
+  "multiple": "Multiples",
+  "days": "Days",
+}
+
+
+def _family_for(element: Element | None) -> tuple[str | None, str | None]:
+  """(item_type family, panel label) for one row's element.
+
+  NULL ``item_type`` falls back to the ``is_monetary`` binary — the
+  same fallback the unit mapping uses — so untyped catalogs still get
+  coherent monetary/pure panels.
+  """
+  if element is None:
+    return None, None
+  if element.item_type is not None:
+    return element.item_type, _FAMILY_LABELS.get(element.item_type, element.item_type)
+  if element.is_monetary:
+    return "monetary", _FAMILY_LABELS["monetary"]
+  return None, None
+
+
+def build_chart_projection(
+  rendering: RenderingLite | None,
+  elements_by_id: dict[str, Element],
+) -> ChartLite | None:
+  """Group a rendering's plottable rows into format-family chart panels.
+
+  Returns ``None`` when there is nothing to plot (no rendering, no
+  rows) — the envelope simply omits the arm and the frontend's chart
+  mode renders its empty state.
+  """
+  if rendering is None or not rendering.rows:
+    return None
+
+  panels: dict[str | None, ChartPanelLite] = {}
+  order: list[str | None] = []
+  for row in rendering.rows:
+    if row.is_subtotal or row.text_value is not None:
+      continue
+    family, label = _family_for(elements_by_id.get(row.element_id))
+    if family not in panels:
+      panels[family] = ChartPanelLite(
+        label=label, item_type=family, kind="line", series=[]
+      )
+      order.append(family)
+    panels[family].series.append(
+      ChartSeriesLite(
+        key=row.element_id,
+        element_id=row.element_id,
+        label=row.element_name,
+      )
+    )
+
+  if not order:
+    return None
+  return ChartLite(panels=[panels[family] for family in order])
+
+
+__all__ = ["build_chart_projection"]

--- a/robosystems/operations/information_block/metric.py
+++ b/robosystems/operations/information_block/metric.py
@@ -31,6 +31,7 @@ from robosystems.models.api.information_block import (
 )
 from robosystems.models.extensions.roboledger.fact import Fact
 from robosystems.models.extensions.roboledger.fact_set import FactSet
+from robosystems.operations.information_block.chart import build_chart_projection
 from robosystems.operations.information_block.envelope import (
   association_to_connection,
   element_to_lite,
@@ -188,7 +189,10 @@ def build_envelope(
     fact_set=latest_lite,
     verification_results=atoms.verification_results,
     verification_summary=atoms.verification_summary,
-    view=ViewProjections(rendering=rendering),
+    view=ViewProjections(
+      rendering=rendering,
+      chart=build_chart_projection(rendering, elements_by_id),
+    ),
   )
 
 

--- a/tests/operations/information_block/test_chart_projection.py
+++ b/tests/operations/information_block/test_chart_projection.py
@@ -1,0 +1,143 @@
+"""Tests for the chart View projection — panel grouping over a rendering."""
+
+from __future__ import annotations
+
+from datetime import date
+from types import SimpleNamespace
+
+from robosystems.models.api.information_block import (
+  RenderingLite,
+  RenderingPeriodLite,
+  RenderingRowLite,
+)
+from robosystems.operations.information_block.chart import build_chart_projection
+
+
+def _element(
+  element_id: str,
+  *,
+  item_type: str | None = None,
+  is_monetary: bool = False,
+) -> SimpleNamespace:
+  return SimpleNamespace(id=element_id, item_type=item_type, is_monetary=is_monetary)
+
+
+def _row(
+  element_id: str,
+  name: str,
+  *,
+  values: list[float | None] | None = None,
+  is_subtotal: bool = False,
+  text_value: str | None = None,
+) -> RenderingRowLite:
+  return RenderingRowLite(
+    element_id=element_id,
+    element_name=name,
+    values=values or [1.0, 2.0],
+    is_subtotal=is_subtotal,
+    text_value=text_value,
+  )
+
+
+def _rendering(rows: list[RenderingRowLite]) -> RenderingLite:
+  return RenderingLite(
+    rows=rows,
+    periods=[
+      RenderingPeriodLite(start=date(2026, 5, 1), end=date(2026, 5, 31)),
+      RenderingPeriodLite(start=date(2026, 6, 1), end=date(2026, 6, 30)),
+    ],
+  )
+
+
+class TestBuildChartProjection:
+  def test_groups_rows_into_item_type_panels_in_arc_order(self) -> None:
+    rendering = _rendering(
+      [
+        _row("el_wc", "Working Capital"),
+        _row("el_cr", "Current Ratio"),
+        _row("el_qr", "Quick Ratio"),
+        _row("el_roe", "Return on Equity"),
+      ]
+    )
+    elements = {
+      "el_wc": _element("el_wc", item_type="monetary"),
+      "el_cr": _element("el_cr", item_type="ratio"),
+      "el_qr": _element("el_qr", item_type="ratio"),
+      "el_roe": _element("el_roe", item_type="percent"),
+    }
+
+    chart = build_chart_projection(rendering, elements)
+
+    assert chart is not None
+    assert [p.item_type for p in chart.panels] == ["monetary", "ratio", "percent"]
+    assert [p.label for p in chart.panels] == [
+      "Monetary",
+      "Ratios",
+      "Percentages",
+    ]
+    ratio_panel = chart.panels[1]
+    assert [s.label for s in ratio_panel.series] == ["Current Ratio", "Quick Ratio"]
+    for panel in chart.panels:
+      assert panel.kind == "line"
+      for series in panel.series:
+        assert series.key == series.element_id
+
+  def test_null_item_type_falls_back_to_is_monetary(self) -> None:
+    rendering = _rendering(
+      [_row("el_a", "Untyped Monetary"), _row("el_b", "Untyped Pure")]
+    )
+    elements = {
+      "el_a": _element("el_a", is_monetary=True),
+      "el_b": _element("el_b", is_monetary=False),
+    }
+
+    chart = build_chart_projection(rendering, elements)
+
+    assert chart is not None
+    assert [p.item_type for p in chart.panels] == ["monetary", None]
+    assert chart.panels[0].label == "Monetary"
+    assert chart.panels[1].label is None
+
+  def test_excludes_subtotal_and_text_rows(self) -> None:
+    rendering = _rendering(
+      [
+        _row("el_a", "Line"),
+        _row("el_sub", "Subtotal", is_subtotal=True),
+        _row("el_txt", "Policy", text_value="# markdown"),
+      ]
+    )
+    elements = {
+      "el_a": _element("el_a", item_type="ratio"),
+      "el_sub": _element("el_sub", item_type="ratio"),
+      "el_txt": _element("el_txt"),
+    }
+
+    chart = build_chart_projection(rendering, elements)
+
+    assert chart is not None
+    assert len(chart.panels) == 1
+    assert [s.element_id for s in chart.panels[0].series] == ["el_a"]
+
+  def test_none_for_empty_rendering(self) -> None:
+    assert build_chart_projection(None, {}) is None
+    assert build_chart_projection(_rendering([]), {}) is None
+
+  def test_none_when_every_row_is_excluded(self) -> None:
+    rendering = _rendering([_row("el_sub", "Subtotal", is_subtotal=True)])
+    assert build_chart_projection(rendering, {}) is None
+
+  def test_unknown_element_lands_in_untyped_panel(self) -> None:
+    rendering = _rendering([_row("el_ghost", "Ghost")])
+    chart = build_chart_projection(rendering, {})
+    assert chart is not None
+    assert chart.panels[0].item_type is None
+    assert chart.panels[0].series[0].label == "Ghost"
+
+  def test_unknown_family_uses_raw_item_type_as_label(self) -> None:
+    rendering = _rendering([_row("el_x", "Exotic")])
+    chart = build_chart_projection(
+      rendering, {"el_x": _element("el_x", item_type="shares")}
+    )
+    assert chart is not None
+    assert chart.panels[0].item_type == "shares"
+    assert chart.panels[0].label == "shares"

--- a/tests/operations/information_block/test_metric_handlers.py
+++ b/tests/operations/information_block/test_metric_handlers.py
@@ -167,6 +167,14 @@ class TestBuildEnvelope:
     assert envelope.fact_set is not None
     assert envelope.fact_set.id == "fs2"  # latest period is the envelope's set
 
+    # The chart arm rides alongside — panel per format family (both
+    # fixture elements are untyped non-monetary → one untyped panel),
+    # series joining the rendering rows by element_id.
+    chart = envelope.view.chart
+    assert chart is not None
+    assert len(chart.panels) == 1
+    assert [s.element_id for s in chart.panels[0].series] == ["el_wc", "el_cr"]
+
   def test_never_computed_block_renders_catalog_skeleton(self) -> None:
     structure = _structure()
     arcs = [_arc("el_wc", 1.0), _arc("el_cr", 2.0)]


### PR DESCRIPTION
## What

The A-2 backend increment (stacked on #915 — merge that first; this diff is chart-only). Adds `view.chart`, the **second real server-computed View arm** after `rendering`, per the settled design call: charts are a server-shaped View projection, not a client-only render mode.

### Shape — config, never values

`ChartLite { panels[] }` → `ChartPanelLite { label, item_type, kind, series[] }` → `ChartSeriesLite { key, element_id, label }`. Series join `rendering.rows` by `element_id` and the x-axis is always `rendering.periods` — the arm never duplicates the value matrix. `key` is the stable series identity for client state; future axes (the forecast scenario in F-1) arrive as new fields on `ChartSeriesLite`, never a new arm shape.

### Grouping (the server's value-add)

Mixed-unit catalogs are unplottable on one y-axis, so `build_chart_projection` (new `operations/information_block/chart.py`) groups non-subtotal, non-text rows into one panel per `item_type` format family (NULL → `is_monetary` fallback), panel order = presentation-arc first appearance. Rendering-generic by design — A-2 wires it into the metric envelope builder only; statements/schedules can adopt later (subtotal curation is the adopting builder's problem).

### Surfaces

Three `@pydantic_type(all_fields=True)` Strawberry leaves (defined before `InformationBlockViewProjections` so derivation picks the field up); GraphQL resolver, MCP `get-information-block`, and the REST envelope (via operation `result_type`) all carry the arm with **zero changes**.

## Verification

- 7 new `build_chart_projection` tests (family grouping + arc order, `is_monetary` fallback, subtotal/text exclusion, empty→None, unknown-element and unknown-family cases); metric-handler envelope test asserts the arm rides alongside rendering; GraphQL schema tests green.
- **Live**: the Driftline Key Financial Metrics envelope returns Monetary / Ratios / Percentages / Multiples panels over the 15-month series through GraphQL.
- `just test-code` green.