### PR TITLE
feat(forecast): scenario + forecast MVP (F-1)

### DIFF
--- a/examples/_scenario/runner.py
+++ b/examples/_scenario/runner.py
@@ -1303,9 +1303,7 @@ def compute_custom_metrics(
     print(f"  {catalog['name']}:")
     computed_windows = 0
     for window in windows:
-      result = _post_compute_metrics(
-        graph_id, catalog["structure_id"], window, api_key
-      )
+      result = _post_compute_metrics(graph_id, catalog["structure_id"], window, api_key)
       if result is None:
         continue
       if result.get("computed"):
@@ -1322,6 +1320,237 @@ def compute_custom_metrics(
             f"    {window[1]}  (skipped) {s.get('element_qname')}: {s.get('reason')}"
           )
     print(f"    Series: {computed_windows}/{len(windows)} window(s) computed")
+
+
+# ---------------------------------------------------------------------------
+# Step 3f: Forecast scenario — author levers, walk the cascade (FP&A F-1)
+# ---------------------------------------------------------------------------
+
+
+def _graphql_rendering(
+  graph_id: str, block_id: str, headers: dict, scenario_id: str | None = None
+) -> dict:
+  """One block's ``view.rendering`` via GraphQL (scenario-aware read)."""
+  import httpx
+
+  scenario_arg = f', scenarioId: "{scenario_id}"' if scenario_id else ""
+  query = (
+    f'{{ informationBlock(id: "{block_id}"{scenario_arg}) '
+    "{ view { rendering { rows { elementQname values } "
+    "periods { end label } } } } }"
+  )
+  resp = httpx.post(
+    f"{BASE_URL}/extensions/{graph_id}/graphql",
+    json={"query": query},
+    headers=headers,
+    timeout=60.0,
+  )
+  if resp.status_code >= 400:
+    print(f"  ERROR: graphql read -> HTTP {resp.status_code}: {resp.text[:160]}")
+    return {}
+  block = ((resp.json() or {}).get("data") or {}).get("informationBlock") or {}
+  return (block.get("view") or {}).get("rendering") or {}
+
+
+def _rendering_value(rendering: dict, qname: str) -> float | None:
+  """Last-column value of one row in a rendering grid."""
+  for row in rendering.get("rows") or []:
+    if row.get("elementQname") == qname:
+      values = [v for v in (row.get("values") or []) if isinstance(v, (int, float))]
+      return float(values[-1]) if values else None
+  return None
+
+
+def _statement_block_id(graph_id: str, block_type: str) -> str | None:
+  """The tenant's reporting structure for a statement family (the one
+  whose envelope carries facts — data-driven, never by name)."""
+  client = _get_ledger_client()
+  blocks = client.list_information_blocks(graph_id, block_type=block_type)
+  for block in blocks:
+    if block.get("facts"):
+      return block.get("id")
+  return blocks[0].get("id") if blocks else None
+
+
+def run_forecast_scenario(
+  graph_id: str,
+  scenario,
+  forecast_levers: dict[str, float],
+) -> str | None:
+  """Author + compute the operating-budget scenario (the FP&A F-1 walk).
+
+  The full forecast-engine loop through the public surface: the forecast
+  block is authored via the generic ``create-information-block`` op
+  (lever values on rs-driver catalog concepts), ``compute-forecast``
+  walks the driver cascade 12 months past the close boundary, and the
+  scenario's metric series extends through ``compute-metrics`` with the
+  scenario filter. Verifications are e2e claims, not spot prints:
+
+  - month-over-month revenue growth equals the asserted lever exactly
+    (compounding through [t-1] binding),
+  - AR / (Revenues / 30) equals the asserted DSO (days-based balance),
+  - the ACTUALS metric envelope is byte-for-byte unchanged in period
+    count (the scenario never leaks into default reads — the hijack
+    check, live),
+  - the scenario metric envelope extends by the horizon with
+    "(forecast)"-labeled columns.
+  """
+  import httpx
+
+  api_key = _client_config()["token"]
+  headers = {"X-API-Key": api_key, "Content-Type": "application/json"}
+  horizon = 12
+
+  # 1. Author the scenario — lever VALUES on rs-driver concepts; the
+  #    mechanics (what each lever drives) are the library's Derive rules.
+  levers = [
+    {"qname": qname, "value": value} for qname, value in forecast_levers.items()
+  ]
+  resp = httpx.post(
+    f"{BASE_URL}/extensions/roboledger/{graph_id}/operations/create-information-block",
+    json={
+      "block_type": "forecast",
+      "payload": {
+        "name": f"FY{(scenario.report_period[1].year + 1) % 100} Operating Budget"
+        if scenario.report_period
+        else "Operating Budget",
+        "scenario_kind": "budget",
+        "horizon_months": horizon,
+        "levers": levers,
+      },
+    },
+    headers=headers,
+    timeout=60.0,
+  )
+  if resp.status_code >= 400:
+    print(f"  ERROR: create forecast -> HTTP {resp.status_code}: {resp.text[:200]}")
+    return None
+  envelope = (resp.json() or {}).get("result") or {}
+  scenario_id = envelope.get("id")
+  mechanics = ((envelope.get("artifact") or {}).get("mechanics")) or {}
+  print(f"  Scenario:     {envelope.get('name')} ({scenario_id})")
+  print(f"  Base period:  {mechanics.get('base_period')} (+{horizon} months)")
+  for qname, value in forecast_levers.items():
+    print(f"    {qname.split(':')[-1]}: {value}")
+
+  # 2. Walk the cascade — first to horizon-1 (the compounding probe's
+  #    baseline), then the full horizon (rerun replaces cleanly).
+  is_block_id = _statement_block_id(graph_id, "income_statement")
+  rev_prev = None
+  if is_block_id:
+    probe = httpx.post(
+      f"{BASE_URL}/extensions/roboledger/{graph_id}/operations/compute-forecast",
+      json={"structure_id": scenario_id, "months": horizon - 1},
+      headers=headers,
+      timeout=120.0,
+    )
+    if probe.status_code < 400:
+      rendering = _graphql_rendering(graph_id, is_block_id, headers, scenario_id)
+      rev_prev = _rendering_value(rendering, "rs-gaap:Revenues")
+
+  resp = httpx.post(
+    f"{BASE_URL}/extensions/roboledger/{graph_id}/operations/compute-forecast",
+    json={"structure_id": scenario_id},
+    headers=headers,
+    timeout=120.0,
+  )
+  if resp.status_code >= 400:
+    print(f"  ERROR: compute-forecast -> HTTP {resp.status_code}: {resp.text[:200]}")
+    return scenario_id
+  result = (resp.json() or {}).get("result") or {}
+  months_computed = result.get("months_computed") or []
+  skipped = result.get("skipped") or []
+  print(f"  Cascade:      {len(months_computed)}/{horizon} months computed")
+  for skip in skipped[:3]:
+    print(f"    (skipped) {skip.get('element_qname')}: {skip.get('reason')}")
+
+  # 3. Compounding — the last month's revenue over the prior month's
+  #    must equal (1 + growth) exactly; [t-1] binding e2e.
+  growth = forecast_levers.get("rs-driver:RevenueGrowthRate")
+  rendering = (
+    _graphql_rendering(graph_id, is_block_id, headers, scenario_id)
+    if is_block_id
+    else {}
+  )
+  rev_last = _rendering_value(rendering, "rs-gaap:Revenues")
+  if growth and rev_prev and rev_last:
+    ratio = rev_last / rev_prev
+    if abs(ratio - (1 + growth)) < 1e-6:
+      print(f"  Compounding:  {ratio:.4f} == 1 + {growth} (month {horizon})")
+    else:
+      print(f"  WARNING: growth ratio {ratio:.6f} != {1 + growth}")
+  labels = [p.get("label") for p in rendering.get("periods") or []]
+  if labels and all(label and "(forecast)" in label for label in labels):
+    print(f"  Labels:       {labels[-1]}")
+
+  # 4. Working capital — AR against the same month's revenue must
+  #    reproduce the asserted DSO (days-based balance mechanics).
+  dso = forecast_levers.get("rs-driver:DaysSalesOutstanding")
+  bs_block_id = _statement_block_id(graph_id, "balance_sheet")
+  if dso and rev_last and bs_block_id:
+    bs_rendering = _graphql_rendering(graph_id, bs_block_id, headers, scenario_id)
+    ar = _rendering_value(bs_rendering, "rs-gaap:ReceivablesNetCurrent")
+    if ar is not None:
+      implied = ar / (rev_last / 30)
+      if abs(implied - dso) < 1e-6:
+        print(f"  DSO:          AR / (Revenues/30) == {implied:.1f} days")
+      else:
+        print(f"  WARNING: implied DSO {implied:.4f} != asserted {dso}")
+
+  # 5. Extend the metric series into the scenario's forward months, then
+  #    prove the seam: actuals envelope unchanged, scenario envelope
+  #    longer by the horizon with labeled columns.
+  client = _get_ledger_client()
+  blocks = client.list_information_blocks(graph_id, block_type="metric")
+  metric_block = next(
+    (b for b in blocks if b.get("name") == "Key Financial Metrics"),
+    blocks[0] if blocks else None,
+  )
+  if metric_block is None:
+    return scenario_id
+  metric_id = metric_block.get("id")
+  actual_rendering = _graphql_rendering(graph_id, metric_id, headers)
+  actual_periods = len(actual_rendering.get("periods") or [])
+
+  computed_months = 0
+  for month in months_computed:
+    payload = {
+      "structure_id": metric_id,
+      "period_end": month["period_end"],
+      "period_start": month["period_start"],
+      "scenario_id": scenario_id,
+    }
+    resp = httpx.post(
+      f"{BASE_URL}/extensions/roboledger/{graph_id}/operations/compute-metrics",
+      json=payload,
+      headers=headers,
+      timeout=60.0,
+    )
+    if resp.status_code < 400 and (
+      ((resp.json() or {}).get("result") or {}).get("computed")
+    ):
+      computed_months += 1
+  print(f"  Metrics:      {computed_months}/{len(months_computed)} scenario months")
+
+  after_actual = _graphql_rendering(graph_id, metric_id, headers)
+  after_scenario = _graphql_rendering(graph_id, metric_id, headers, scenario_id)
+  actual_after = len(after_actual.get("periods") or [])
+  scenario_periods = after_scenario.get("periods") or []
+  forecast_cols = [
+    p for p in scenario_periods if p.get("label") and "(forecast)" in p["label"]
+  ]
+  if actual_after == actual_periods:
+    print(f"  Actuals:      unchanged ({actual_after} periods — no scenario leak)")
+  else:
+    print(
+      f"  WARNING: actuals envelope changed "
+      f"({actual_periods} -> {actual_after} periods)"
+    )
+  print(
+    f"  Series:       {len(scenario_periods)} periods with scenario "
+    f"({len(forecast_cols)} forecast columns)"
+  )
+  return scenario_id
 
 
 # ---------------------------------------------------------------------------
@@ -1703,9 +1932,7 @@ def generate_monthly_reports(
   # Recover the rolling window's start from the annual period: the annual
   # window ends at the close target, offset ``months - 2`` from the start.
   annual_end = scenario.report_period[1]
-  start = add_months(
-    date(annual_end.year, annual_end.month, 1), -(scenario.months - 2)
-  )
+  start = add_months(date(annual_end.year, annual_end.month, 1), -(scenario.months - 2))
 
   windows = month_windows(start, scenario.months)
   created = 0
@@ -1853,6 +2080,7 @@ def run_demo(
   text_blocks: list[dict] | None = None,
   custom_metrics: list[dict] | None = None,
   memories: list[dict] | None = None,
+  forecast_levers: dict[str, float] | None = None,
   argv: list[str] | None = None,
 ) -> None:
   """Provision a graph and load the full company for one showcase episode.
@@ -1868,6 +2096,9 @@ def run_demo(
   authored with the disclosures, computed after the report files.
   ``memories`` (optional) seed the graph's semantic memory through the
   MCP ``remember`` tool (see ``seed_memories``).
+  ``forecast_levers`` (optional) authors + computes an operating-budget
+  forecast scenario after the metric series lands (see
+  ``run_forecast_scenario``) — a ``{rs-driver qname: value}`` map.
   """
   argv = sys.argv if argv is None else argv
   dry_run = "--dry-run" in argv
@@ -2033,6 +2264,13 @@ def run_demo(
     print("\nComputing custom metrics...")
     compute_custom_metrics(graph_id, scenario, authored_metric_catalogs, period_windows)
 
+  # Forecast scenario — the FP&A F-1 walk: authored levers, driver
+  # cascade 12 months past the close boundary, scenario metric series.
+  forecast_scenario_id = None
+  if report_id and forecast_levers:
+    print("\nRunning forecast scenario...")
+    forecast_scenario_id = run_forecast_scenario(graph_id, scenario, forecast_levers)
+
   # Summary
   print("\n" + "=" * 60)
   print(f"  Graph ID: {graph_id}")
@@ -2049,6 +2287,8 @@ def run_demo(
   if report_id:
     print(f"  Annual report: filed ({report_id})")
     print(f"  Viewer URL:    /reports/{report_id}?graph={graph_id}")
+  if forecast_scenario_id:
+    print(f"  Forecast:      /explorer?scenario={forecast_scenario_id}")
   print("\n  Run the close (Claude Desktop / MCP):")
   print(f"    1. Switch to workspace: {graph_id}")
   print("    2. Ask: 'Search for month-end close procedures'")

--- a/examples/coffee_roaster_demo/main.py
+++ b/examples/coffee_roaster_demo/main.py
@@ -38,6 +38,17 @@ REVEAL_PROMPTS = [
   "How much cash is tied up in inventory vs. receivables?",
 ]
 
+# Operating-budget scenario (FP&A F-1) — Driftline's working-capital arc as
+# lever assertions: modest growth, roaster margins, the slow-paying wholesale
+# account baked into DSO. Values follow the rs-driver catalog conventions
+# (percent levers as decimals per month, days levers as day counts).
+FORECAST_LEVERS = {
+  "rs-driver:RevenueGrowthRate": 0.03,
+  "rs-driver:CostOfRevenueRate": 0.62,
+  "rs-driver:DaysSalesOutstanding": 45,
+  "rs-driver:DaysPayableOutstanding": 30,
+}
+
 
 def main() -> None:
   run_demo(
@@ -51,6 +62,7 @@ def main() -> None:
     text_blocks=TEXT_BLOCK_NOTES,
     custom_metrics=CUSTOM_METRICS,
     memories=MEMORIES,
+    forecast_levers=FORECAST_LEVERS,
   )
 
 

--- a/examples/saas_startup_demo/main.py
+++ b/examples/saas_startup_demo/main.py
@@ -39,6 +39,20 @@ REVEAL_PROMPTS = [
   "Net out deferred revenue — at this burn, what's our real runway?",
 ]
 
+# Operating-budget scenario (FP&A F-1) — Cadence's growth/burn arc as lever
+# assertions: SaaS growth continuing the historical ramp (~5%/month), the
+# ~22% hosting + support cost-of-revenue rate, a month of hosting bills in
+# payables. DSO is deliberately NOT asserted — an annual-prepay book has no
+# receivables story, so the DSO rule stays inactive and the working-capital
+# projection is the payables side only (the partial-lever path, on purpose:
+# each episode's scenario asserts the levers its business model actually
+# turns). Values follow the rs-driver catalog conventions.
+FORECAST_LEVERS = {
+  "rs-driver:RevenueGrowthRate": 0.05,
+  "rs-driver:CostOfRevenueRate": 0.22,
+  "rs-driver:DaysPayableOutstanding": 30,
+}
+
 
 def main() -> None:
   run_demo(
@@ -52,6 +66,7 @@ def main() -> None:
     text_blocks=TEXT_BLOCK_NOTES,
     custom_metrics=CUSTOM_METRICS,
     memories=MEMORIES,
+    forecast_levers=FORECAST_LEVERS,
   )
 
 

--- a/frameworks/rs-gaap/packages/rs-driver/v1/taxonomy.jsonld
+++ b/frameworks/rs-gaap/packages/rs-driver/v1/taxonomy.jsonld
@@ -1,0 +1,326 @@
+{
+  "@context": {
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "skos": "http://www.w3.org/2004/02/skos/core#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "xbrli": "http://www.xbrl.org/2003/instance#",
+    "link": "http://www.xbrl.org/2003/linkbase#",
+    "xlink": "http://www.w3.org/1999/xlink#",
+    "rs-gaap": "https://robosystems.ai/taxonomy/rs-gaap/v1/",
+    "rs-driver": "https://robosystems.ai/taxonomy/rs-gaap/drivers/v1/",
+    "rs": "https://robosystems.ai/vocab/",
+    "balance": {
+      "@id": "xbrli:balance"
+    },
+    "periodType": {
+      "@id": "xbrli:periodType"
+    },
+    "abstract": {
+      "@id": "https://robosystems.ai/vocab/abstract",
+      "@type": "xsd:boolean"
+    },
+    "monetary": {
+      "@id": "https://robosystems.ai/vocab/monetary",
+      "@type": "xsd:boolean"
+    },
+    "elementType": {
+      "@id": "https://robosystems.ai/vocab/elementType"
+    },
+    "itemType": {
+      "@id": "https://robosystems.ai/vocab/itemType"
+    },
+    "from": {
+      "@id": "xlink:from",
+      "@type": "@id"
+    },
+    "to": {
+      "@id": "xlink:to",
+      "@type": "@id"
+    },
+    "arcrole": {
+      "@id": "xlink:arcrole",
+      "@type": "@id"
+    },
+    "role": {
+      "@id": "xlink:role",
+      "@type": "@id"
+    },
+    "order": {
+      "@id": "link:order",
+      "@type": "xsd:decimal"
+    },
+    "associationType": {
+      "@id": "https://robosystems.ai/vocab/associationType"
+    },
+    "label": "rdfs:label",
+    "documentation": "rdfs:comment",
+    "structureName": {
+      "@id": "https://robosystems.ai/vocab/structureName"
+    },
+    "blockType": {
+      "@id": "https://robosystems.ai/vocab/blockType"
+    },
+    "roleUri": {
+      "@id": "https://robosystems.ai/vocab/roleUri"
+    },
+    "conceptArrangementPattern": {
+      "@id": "https://robosystems.ai/vocab/conceptArrangementPattern"
+    },
+    "ruleCategory": {
+      "@id": "https://robosystems.ai/vocab/ruleCategory"
+    },
+    "rulePattern": {
+      "@id": "https://robosystems.ai/vocab/rulePattern"
+    },
+    "ruleExpression": {
+      "@id": "https://robosystems.ai/vocab/ruleExpression"
+    },
+    "ruleTarget": {
+      "@id": "https://robosystems.ai/vocab/ruleTarget"
+    },
+    "targetKind": {
+      "@id": "https://robosystems.ai/vocab/targetKind"
+    },
+    "targetRef": {
+      "@id": "https://robosystems.ai/vocab/targetRef"
+    },
+    "ruleVariables": {
+      "@id": "https://robosystems.ai/vocab/ruleVariables",
+      "@container": "@list"
+    },
+    "variableName": {
+      "@id": "https://robosystems.ai/vocab/variableName"
+    },
+    "variableQname": {
+      "@id": "https://robosystems.ai/vocab/variableQname"
+    },
+    "ruleMessage": {
+      "@id": "https://robosystems.ai/vocab/ruleMessage"
+    },
+    "ruleSeverity": {
+      "@id": "https://robosystems.ai/vocab/ruleSeverity"
+    },
+    "ruleOrigin": {
+      "@id": "https://robosystems.ai/vocab/ruleOrigin"
+    }
+  },
+  "standard": "rs-driver",
+  "version": "v1",
+  "taxonomy_type": "reporting_extension",
+  "namespace_uri": "https://robosystems.ai/taxonomy/rs-gaap/drivers/v1/",
+  "default_block_type": "custom",
+  "origin": "native",
+  "description": "rs-driver — the curated forecast lever catalog (Forecast F-1). Each lever is a qname-addressable concept in the rs-driver namespace plus one Derive rule whose ruleExpression states the driven mechanics against rs-gaap anchor targets ($Anchor = f(prior anchors, lever)) — rules for mechanics, authored facts for values. Lever VALUES are asserted per scenario as facts on these elements inside a forecast block's lever FactSet; a rule activates for a scenario only when every rs-driver operand it names has asserted values, and inactive targets fall to the engine's carry-forward default. compute-forecast walks the cascade month-by-month from the last closed actuals: the $X[t-1] prior-period operand binds the previous forecast month (seeded from actuals at the base period). Value conventions: percent levers are decimals per month (0.03 = 3%/month), days levers are day counts. The Driver Catalog node is both an abstract element and a Structure (block_type='custom' — a reference catalog, not a renderable block) whose presentation arcs enumerate the levers. Hand-authored.",
+  "@graph": [
+    {
+      "@id": "rs-driver:DriverCatalog",
+      "label": "Driver Catalog",
+      "documentation": "Container for the seeded forecast lever catalog — an abstract element and a reference Structure (block_type='custom', never rendered). Forecast blocks assert lever values against the member concepts; compute-forecast reads the Derive rules for the driven mechanics.",
+      "elementType": "abstract",
+      "periodType": "duration",
+      "abstract": true,
+      "monetary": false,
+      "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/drivers/DriverCatalog",
+      "structureName": "Driver Catalog",
+      "blockType": "custom",
+      "conceptArrangementPattern": "set"
+    },
+    {
+      "@id": "rs-driver:RevenueGrowthRate",
+      "label": "Revenue Growth Rate",
+      "documentation": "Month-over-month revenue growth (compounding lever): Revenues[t] = Revenues[t-1] x (1 + rate). Decimal per month (0.03 = 3%/month). Derive-backward seam: trailing growth is computable from the actual monthly series; asserted forward per scenario.",
+      "elementType": "concept",
+      "periodType": "duration",
+      "monetary": false,
+      "itemType": "percent"
+    },
+    {
+      "@id": "rs-driver:CostOfRevenueRate",
+      "label": "Cost of Revenue Rate",
+      "documentation": "Cost of revenue as a fraction of the same month's revenues (rate-on-base lever). Decimal (0.62 = 62% of revenue).",
+      "elementType": "concept",
+      "periodType": "duration",
+      "monetary": false,
+      "itemType": "percent"
+    },
+    {
+      "@id": "rs-driver:DaysSalesOutstanding",
+      "label": "Days Sales Outstanding",
+      "documentation": "Collection-cycle lever (days-based balance): Accounts Receivable = monthly Revenues / 30 x DSO. Day count (45 = 45 days). Drives the AR working-capital balance from the revenue flow rate.",
+      "elementType": "concept",
+      "periodType": "duration",
+      "monetary": false,
+      "itemType": "days"
+    },
+    {
+      "@id": "rs-driver:DaysPayableOutstanding",
+      "label": "Days Payable Outstanding",
+      "documentation": "Payment-cycle lever (days-based balance): Accounts Payable = monthly Cost of Revenue / 30 x DPO. Day count (30 = 30 days). COGS-based (the standard DPO definition) — Cost of Revenue is itself rule-driven in the cascade, so the base is always available at eval time.",
+      "elementType": "concept",
+      "periodType": "duration",
+      "monetary": false,
+      "itemType": "days"
+    },
+    {
+      "@id": "_:rs-driver-pres-arc-1",
+      "@type": "rs:Association",
+      "from": {
+        "@id": "rs-driver:DriverCatalog"
+      },
+      "to": {
+        "@id": "rs-driver:RevenueGrowthRate"
+      },
+      "associationType": "presentation",
+      "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+      "role": "https://robosystems.ai/seattle/cm-roles/roles/drivers/DriverCatalog",
+      "order": 1.0
+    },
+    {
+      "@id": "_:rs-driver-pres-arc-2",
+      "@type": "rs:Association",
+      "from": {
+        "@id": "rs-driver:DriverCatalog"
+      },
+      "to": {
+        "@id": "rs-driver:CostOfRevenueRate"
+      },
+      "associationType": "presentation",
+      "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+      "role": "https://robosystems.ai/seattle/cm-roles/roles/drivers/DriverCatalog",
+      "order": 2.0
+    },
+    {
+      "@id": "_:rs-driver-pres-arc-3",
+      "@type": "rs:Association",
+      "from": {
+        "@id": "rs-driver:DriverCatalog"
+      },
+      "to": {
+        "@id": "rs-driver:DaysSalesOutstanding"
+      },
+      "associationType": "presentation",
+      "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+      "role": "https://robosystems.ai/seattle/cm-roles/roles/drivers/DriverCatalog",
+      "order": 3.0
+    },
+    {
+      "@id": "_:rs-driver-pres-arc-4",
+      "@type": "rs:Association",
+      "from": {
+        "@id": "rs-driver:DriverCatalog"
+      },
+      "to": {
+        "@id": "rs-driver:DaysPayableOutstanding"
+      },
+      "associationType": "presentation",
+      "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+      "role": "https://robosystems.ai/seattle/cm-roles/roles/drivers/DriverCatalog",
+      "order": 4.0
+    },
+    {
+      "@id": "_:rs-driver-derive-revenue-growth",
+      "ruleCategory": "ReportingSystemSpecificRule",
+      "rulePattern": "Derive",
+      "ruleExpression": "$Revenues = ($Revenues[t-1] * (1 + $RevenueGrowthRate))",
+      "ruleTarget": {
+        "targetKind": "element",
+        "targetRef": "rs-gaap:Revenues"
+      },
+      "ruleVariables": [
+        {
+          "variableName": "Revenues",
+          "variableQname": "rs-gaap:Revenues"
+        },
+        {
+          "variableName": "RevenueGrowthRate",
+          "variableQname": "rs-driver:RevenueGrowthRate"
+        }
+      ],
+      "ruleMessage": "Revenues[t] = Revenues[t-1] x (1 + Revenue Growth Rate)",
+      "ruleSeverity": "info",
+      "ruleOrigin": "native"
+    },
+    {
+      "@id": "_:rs-driver-derive-cost-of-revenue",
+      "ruleCategory": "ReportingSystemSpecificRule",
+      "rulePattern": "Derive",
+      "ruleExpression": "$CostOfRevenue = ($Revenues * $CostOfRevenueRate)",
+      "ruleTarget": {
+        "targetKind": "element",
+        "targetRef": "rs-gaap:CostOfRevenue"
+      },
+      "ruleVariables": [
+        {
+          "variableName": "CostOfRevenue",
+          "variableQname": "rs-gaap:CostOfRevenue"
+        },
+        {
+          "variableName": "Revenues",
+          "variableQname": "rs-gaap:Revenues"
+        },
+        {
+          "variableName": "CostOfRevenueRate",
+          "variableQname": "rs-driver:CostOfRevenueRate"
+        }
+      ],
+      "ruleMessage": "Cost of Revenue = Revenues x Cost of Revenue Rate",
+      "ruleSeverity": "info",
+      "ruleOrigin": "native"
+    },
+    {
+      "@id": "_:rs-driver-derive-accounts-receivable",
+      "ruleCategory": "ReportingSystemSpecificRule",
+      "rulePattern": "Derive",
+      "ruleExpression": "$ReceivablesNetCurrent = (($Revenues / 30) * $DaysSalesOutstanding)",
+      "ruleTarget": {
+        "targetKind": "element",
+        "targetRef": "rs-gaap:ReceivablesNetCurrent"
+      },
+      "ruleVariables": [
+        {
+          "variableName": "ReceivablesNetCurrent",
+          "variableQname": "rs-gaap:ReceivablesNetCurrent"
+        },
+        {
+          "variableName": "Revenues",
+          "variableQname": "rs-gaap:Revenues"
+        },
+        {
+          "variableName": "DaysSalesOutstanding",
+          "variableQname": "rs-driver:DaysSalesOutstanding"
+        }
+      ],
+      "ruleMessage": "Accounts Receivable = (Revenues / 30) x Days Sales Outstanding",
+      "ruleSeverity": "info",
+      "ruleOrigin": "native"
+    },
+    {
+      "@id": "_:rs-driver-derive-accounts-payable",
+      "ruleCategory": "ReportingSystemSpecificRule",
+      "rulePattern": "Derive",
+      "ruleExpression": "$AccountsPayableCurrent = (($CostOfRevenue / 30) * $DaysPayableOutstanding)",
+      "ruleTarget": {
+        "targetKind": "element",
+        "targetRef": "rs-gaap:AccountsPayableCurrent"
+      },
+      "ruleVariables": [
+        {
+          "variableName": "AccountsPayableCurrent",
+          "variableQname": "rs-gaap:AccountsPayableCurrent"
+        },
+        {
+          "variableName": "CostOfRevenue",
+          "variableQname": "rs-gaap:CostOfRevenue"
+        },
+        {
+          "variableName": "DaysPayableOutstanding",
+          "variableQname": "rs-driver:DaysPayableOutstanding"
+        }
+      ],
+      "ruleMessage": "Accounts Payable = (Cost of Revenue / 30) x Days Payable Outstanding",
+      "ruleSeverity": "info",
+      "ruleOrigin": "native"
+    }
+  ]
+}

--- a/frameworks/rs-gaap/v1.json
+++ b/frameworks/rs-gaap/v1.json
@@ -23,7 +23,8 @@
     {"standard": "rs-gaap-reporting-styles",     "version": "v1", "ordinal": 11, "is_required": true},
     {"standard": "rs-gaap-rollup-rules",         "version": "v1", "ordinal": 12, "is_required": true},
     {"standard": "rs-gaap-rules",                "version": "v1", "ordinal": 13, "is_required": true},
-    {"standard": "rs-metric",                    "version": "v1", "ordinal": 14, "is_required": true}
+    {"standard": "rs-metric",                    "version": "v1", "ordinal": 14, "is_required": true},
+    {"standard": "rs-driver",                    "version": "v1", "ordinal": 15, "is_required": true}
   ],
   "bridges": [
     {"bridge": "fac-to-rs-gaap",                            "version": "v1", "ordinal": 0, "is_required": true, "tenant_copy": false},

--- a/migrations/extensions/versions/0002_taxonomy_library.py
+++ b/migrations/extensions/versions/0002_taxonomy_library.py
@@ -132,7 +132,9 @@ _WIDENED_ELEMENT_SOURCE_CHECK = (
   # 'rs-metric' — the metric catalog package (0022's backfill for existing
   # databases; fresh seeds pick it up here because this seed reads the
   # current frameworks/ manifest, which lists rs-metric).
-  "'disclosures', 'checklist', 'styles', 'cm', 'rs-metric'"
+  # 'rs-driver' — the forecast lever catalog package (0024's backfill for
+  # existing databases; same dynamic-manifest rule as rs-metric).
+  "'disclosures', 'checklist', 'styles', 'cm', 'rs-metric', 'rs-driver'"
   ")"
 )
 _WIDENED_TAXONOMY_TYPE_CHECK = (

--- a/migrations/extensions/versions/0024_forecast.py
+++ b/migrations/extensions/versions/0024_forecast.py
@@ -1,0 +1,346 @@
+"""forecast — scenario axis on fact_sets + the rs-driver lever catalog
+
+The Forecast MVP (F-1) needs one schema change, two vocabulary widenings,
+and a new library package in deployments seeded before rs-driver existed:
+
+- ``fact_sets``: add ``scenario_id`` (nullable, NULL = actuals) — the
+  scenario axis. Non-NULL points at the owning ``forecast`` Structure
+  (the block IS the scenario) with ON DELETE CASCADE so deleting the
+  block removes its whole scenario slice. Partial index for the
+  scenario-slice reads.
+- ``structures``: widen ``check_block_type`` to admit ``'forecast'``
+  (the authored scenario container: lever assertions + scenario
+  identity; derived forward facts land in the EXISTING statement/metric
+  block types stamped with ``scenario_id``).
+- ``elements``: widen ``check_element_source`` to admit ``'rs-driver'``
+  (the lever catalog's namespace prefix, following the rs-metric
+  source-per-package convention from 0022).
+
+Then the content: seed ``frameworks/rs-gaap/packages/rs-driver/v1`` into
+the public library (0022's pass structure), mirror the manifest's new
+``framework_packages`` junction row, and fan the package into every
+existing tenant schema via ``resync_library_into_tenant`` under
+``SET LOCAL robosystems.library_resync = 'on'`` (0016).
+
+Fresh deployments get all of this from 0002 + provisioning (the manifest
+now lists rs-driver; ``_widen_library_checks`` and the models carry the
+widened vocabulary), so this migration is the backfill path for existing
+databases. Deploy-coupled with the scenario-aware reader code: a scenario
+FactSet written before readers filter on ``scenario_id`` would win the
+latest-FactSet envelope reads (they order by ``period_end DESC``).
+
+Note: the downgrade deletes every scenario FactSet and forecast block,
+deletes rs-driver content (public + tenants), and re-narrows the
+constraints. It will fail if tenant-authored content references
+rs-driver elements outside those paths — data the operator must triage.
+
+Revision ID: 0024
+Revises: 0023
+Create Date: 2026-07-23
+
+"""
+
+from __future__ import annotations
+
+from alembic import op
+from sqlalchemy import text
+
+from migrations.extensions.helpers import TenantOps, for_each_tenant_schema
+
+# revision identifiers, used by Alembic.
+revision = "0024"
+down_revision = "0023"
+branch_labels = None
+depends_on = None
+
+_PACKAGE_STANDARD = "rs-driver"
+_PACKAGE_VERSION = "v1"
+_FRAMEWORK = "rs-gaap"
+_FRAMEWORK_VERSION = "v1"
+_PACKAGE_ORDINAL = 15
+
+_BLOCK_TYPE_WIDENED = (
+  "block_type IN ("
+  "'income_statement', 'balance_sheet', "
+  "'cash_flow_statement', 'equity_statement', "
+  "'comprehensive_income', "
+  "'schedule', 'rollforward', 'reconciliation', 'policy', 'metric', "
+  "'forecast', "
+  "'chart_of_accounts', 'coa_mapping', "
+  "'validation_rules', 'regulatory_disclosure', 'taxonomy_mapping', "
+  "'reporting_style', "
+  "'custom'"
+  ")"
+)
+_BLOCK_TYPE_ORIGINAL = (
+  "block_type IN ("
+  "'income_statement', 'balance_sheet', "
+  "'cash_flow_statement', 'equity_statement', "
+  "'comprehensive_income', "
+  "'schedule', 'rollforward', 'reconciliation', 'policy', 'metric', "
+  "'chart_of_accounts', 'coa_mapping', "
+  "'validation_rules', 'regulatory_disclosure', 'taxonomy_mapping', "
+  "'reporting_style', "
+  "'custom'"
+  ")"
+)
+
+_SOURCE_WIDENED = (
+  "source IN ("
+  "'fac', 'rs-gaap', 'us-gaap', 'ifrs', "
+  "'quickbooks', 'xero', 'plaid', 'native', 'import', 'system', "
+  "'disclosures', 'checklist', 'styles', 'cm', 'rs-metric', 'rs-driver'"
+  ")"
+)
+_SOURCE_ORIGINAL = (
+  "source IN ("
+  "'fac', 'rs-gaap', 'us-gaap', 'ifrs', "
+  "'quickbooks', 'xero', 'plaid', 'native', 'import', 'system', "
+  "'disclosures', 'checklist', 'styles', 'cm', 'rs-metric'"
+  ")"
+)
+
+
+def _add_scenario_axis(conn, schema: str) -> None:
+  t = TenantOps(conn, schema)
+  t.add_column("fact_sets", "scenario_id", "TEXT")
+  t.add_foreign_key(
+    "fact_sets",
+    "fk_fact_sets_scenario",
+    ["scenario_id"],
+    "structures",
+    ["id"],
+    on_delete="CASCADE",
+  )
+  t.create_index(
+    "idx_fact_sets_scenario",
+    "fact_sets",
+    ["scenario_id"],
+    where="scenario_id IS NOT NULL",
+  )
+
+
+def _drop_scenario_axis(conn, schema: str) -> None:
+  t = TenantOps(conn, schema)
+  t.drop_index("idx_fact_sets_scenario")
+  t.drop_constraint("fact_sets", "fk_fact_sets_scenario")
+  t.drop_column("fact_sets", "scenario_id")
+
+
+def _widen(conn, schema: str) -> None:
+  t = TenantOps(conn, schema)
+  t.add_check("structures", "check_block_type", _BLOCK_TYPE_WIDENED)
+  t.add_check("elements", "check_element_source", _SOURCE_WIDENED)
+
+
+def _narrow(conn, schema: str) -> None:
+  t = TenantOps(conn, schema)
+  t.add_check("structures", "check_block_type", _BLOCK_TYPE_ORIGINAL)
+  t.add_check("elements", "check_element_source", _SOURCE_ORIGINAL)
+
+
+def _seed_path():
+  from robosystems.taxonomy.discovery import FRAMEWORKS_DIR
+
+  return (
+    FRAMEWORKS_DIR
+    / _FRAMEWORK
+    / "packages"
+    / _PACKAGE_STANDARD
+    / _PACKAGE_VERSION
+    / "taxonomy.jsonld"
+  )
+
+
+def _seed_public_library(conn) -> None:
+  """Load rs-driver into the public library — 0022's three passes, one package."""
+  from sqlalchemy.orm import Session as _Session
+
+  from robosystems.operations.taxonomy_block.library_creator import (
+    create_library_arcs,
+    create_library_rules,
+    create_library_taxonomy_elements,
+    prune_empty_default_structures,
+  )
+  from robosystems.taxonomy import load_taxonomy_package
+
+  package = load_taxonomy_package(_seed_path())
+  session = _Session(bind=conn)
+  try:
+    _, counts = create_library_taxonomy_elements(session, package)
+    session.flush()
+    print(
+      f"  [rs-driver pass 1] elements={counts['elements']} "
+      f"structures={counts['structures']}"
+    )
+    counts = create_library_arcs(session, package)
+    session.flush()
+    print(
+      f"  [rs-driver pass 2] associations={counts['associations']} "
+      f"(skipped={counts['associations_skipped']})"
+    )
+    counts = create_library_rules(session, package)
+    session.flush()
+    print(
+      f"  [rs-driver pass 3] rules={counts['rules']} "
+      f"(skipped={counts['rules_skipped']})"
+    )
+    pruned = prune_empty_default_structures(session)
+    session.flush()
+    print(f"  [rs-driver pass 4] pruned {pruned} empty default structure(s)")
+  finally:
+    session.close()
+
+
+def _upsert_framework_package_row(conn) -> None:
+  """Mirror the manifest's new packages[] entry — 0007's junction upsert."""
+  from datetime import UTC, datetime
+
+  from robosystems.utils.uuid import generate_deterministic_uuid
+
+  fid = generate_deterministic_uuid(
+    f"{_FRAMEWORK}:{_FRAMEWORK_VERSION}", namespace="framework"
+  )
+  fpid = generate_deterministic_uuid(
+    f"{fid}:{_PACKAGE_STANDARD}:{_PACKAGE_VERSION}", namespace="framework_package"
+  )
+  conn.execute(
+    text("""
+      INSERT INTO public.framework_packages (
+        id, framework_id, package_standard, package_version,
+        ordinal, is_required, metadata, created_at, created_by
+      ) VALUES (
+        :id, :fid, :std, :ver, :ordinal, true,
+        '{}'::jsonb, :now, 'library-seeder'
+      )
+      ON CONFLICT (id) DO UPDATE SET
+        ordinal     = EXCLUDED.ordinal,
+        is_required = EXCLUDED.is_required
+    """),
+    {
+      "id": fpid,
+      "fid": fid,
+      "std": _PACKAGE_STANDARD,
+      "ver": _PACKAGE_VERSION,
+      "ordinal": _PACKAGE_ORDINAL,
+      "now": datetime.now(UTC),
+    },
+  )
+
+
+def upgrade() -> None:
+  from robosystems.taxonomy.writer import SET_LIBRARY_RESYNC, resync_library_into_tenant
+
+  conn = op.get_bind()
+
+  # 1. Scenario axis + vocabulary widenings — must precede the seed so
+  #    rs-driver rows insert and forecast blocks can be authored.
+  _add_scenario_axis(conn, "public")
+  _widen(conn, "public")
+
+  def _schema_ddl(conn, schema: str) -> None:
+    _add_scenario_axis(conn, schema)
+    _widen(conn, schema)
+
+  for_each_tenant_schema(conn, _schema_ddl)
+
+  # 2. Public library seed + manifest junction row.
+  _seed_public_library(conn)
+  _upsert_framework_package_row(conn)
+
+  # 3. Fan the new package into every existing tenant schema. SET LOCAL is
+  #    transaction-scoped — it covers the whole fan-out and vanishes on
+  #    commit. Mandatory: the package's arcs INSERT into a library-seeded
+  #    structure, which the 0016 immutability triggers reject otherwise.
+  conn.execute(text(SET_LIBRARY_RESYNC))
+
+  def _copy(conn, schema: str) -> None:
+    stats = resync_library_into_tenant(
+      conn, schema, pin={_PACKAGE_STANDARD: _PACKAGE_VERSION}
+    )
+    print(
+      f"  [rs-driver → {schema}] elements={stats.elements} "
+      f"structures={stats.structures} associations={stats.associations} "
+      f"rules={stats.rules}"
+    )
+
+  for_each_tenant_schema(conn, _copy)
+
+
+def _delete_scenario_content(conn, schema: str) -> None:
+  """Delete every scenario slice + forecast block from one schema.
+
+  Scenario FactSets (facts cascade) must go before forecast Structures —
+  the lever set and every emitted month reference the forecast id via
+  ``scenario_id``, and ``fact_sets.structure_id`` has no ON DELETE.
+  """
+  s = schema
+  conn.execute(text(f"DELETE FROM {s}.fact_sets WHERE scenario_id IS NOT NULL"))
+  conn.execute(text(f"DELETE FROM {s}.structures WHERE block_type = 'forecast'"))
+
+
+def _delete_package_content(conn, schema: str) -> None:
+  """Delete rs-driver content from one schema in FK-safe order."""
+  from robosystems.utils.uuid import generate_deterministic_uuid
+
+  taxonomy_id = generate_deterministic_uuid(
+    f"{_PACKAGE_STANDARD}:{_PACKAGE_VERSION}", namespace="taxonomy"
+  )
+  s = schema
+  params = {"tid": taxonomy_id}
+  statements = [
+    f"DELETE FROM {s}.verification_results WHERE rule_id IN "
+    f"(SELECT id FROM {s}.rules WHERE taxonomy_id = :tid)",
+    f"DELETE FROM {s}.rules WHERE taxonomy_id = :tid",
+    f"DELETE FROM {s}.fact_sets WHERE structure_id IN "
+    f"(SELECT id FROM {s}.structures WHERE taxonomy_id = :tid)",
+    f"DELETE FROM {s}.associations WHERE structure_id IN "
+    f"(SELECT id FROM {s}.structures WHERE taxonomy_id = :tid)",
+    f"DELETE FROM {s}.structures WHERE taxonomy_id = :tid",
+    f"DELETE FROM {s}.element_traits WHERE element_id IN "
+    f"(SELECT id FROM {s}.elements WHERE taxonomy_id = :tid)",
+    f"DELETE FROM {s}.element_labels WHERE element_id IN "
+    f"(SELECT id FROM {s}.elements WHERE taxonomy_id = :tid)",
+    f"DELETE FROM {s}.element_references WHERE element_id IN "
+    f"(SELECT id FROM {s}.elements WHERE taxonomy_id = :tid)",
+    f"DELETE FROM {s}.elements WHERE taxonomy_id = :tid",
+    f"DELETE FROM {s}.taxonomies WHERE id = :tid",
+  ]
+  for stmt in statements:
+    conn.execute(text(stmt), params)
+
+
+def downgrade() -> None:
+  from robosystems.taxonomy.writer import SET_LIBRARY_RESYNC
+  from robosystems.utils.uuid import generate_deterministic_uuid
+
+  conn = op.get_bind()
+
+  # Library-row deletes in tenant schemas need the immutability bypass.
+  conn.execute(text(SET_LIBRARY_RESYNC))
+
+  def _delete(conn, schema: str) -> None:
+    _delete_scenario_content(conn, schema)
+    _delete_package_content(conn, schema)
+    _drop_scenario_axis(conn, schema)
+
+  for_each_tenant_schema(conn, _delete)
+  _delete_scenario_content(conn, "public")
+  _delete_package_content(conn, "public")
+  _drop_scenario_axis(conn, "public")
+
+  fid = generate_deterministic_uuid(
+    f"{_FRAMEWORK}:{_FRAMEWORK_VERSION}", namespace="framework"
+  )
+  fpid = generate_deterministic_uuid(
+    f"{fid}:{_PACKAGE_STANDARD}:{_PACKAGE_VERSION}", namespace="framework_package"
+  )
+  conn.execute(
+    text("DELETE FROM public.framework_packages WHERE id = :id"), {"id": fpid}
+  )
+
+  # Re-narrow the vocabulary — fails if 'forecast' structures or
+  # 'rs-driver' elements remain outside the deleted content
+  # (tenant-authored), which is data the operator must triage first.
+  _narrow(conn, "public")
+  for_each_tenant_schema(conn, _narrow)

--- a/robosystems/arelle/context.py
+++ b/robosystems/arelle/context.py
@@ -75,6 +75,11 @@ CANONICAL_CONTEXT: dict = {
   # Each metric is a qname-addressable concept plus a Derive rule that
   # computes it from rs-gaap anchor facts.
   "rs-metric": "https://robosystems.ai/taxonomy/rs-gaap/metrics/v1/",
+  # rs-driver — the forecast lever catalog (Driver Catalog). Each lever
+  # is a qname-addressable concept plus a Derive rule stating the driven
+  # mechanics against rs-gaap anchor targets; values are asserted per
+  # scenario as authored facts.
+  "rs-driver": "https://robosystems.ai/taxonomy/rs-gaap/drivers/v1/",
   "ifrs": "http://xbrl.ifrs.org/taxonomy/",
   "dei": "http://xbrl.sec.gov/dei/",
   # Seattle Method conceptual-model role URIs (Charlie's CM namespace)

--- a/robosystems/db/extensions.py
+++ b/robosystems/db/extensions.py
@@ -259,7 +259,7 @@ def _widen_library_checks(conn, schema: str) -> None:
     "'quickbooks', 'xero', 'plaid', 'native', 'import', 'system', "
     # rs-gaap framework extension packages anchored to
     # sibling namespaces of rs-gaap.
-    "'disclosures', 'checklist', 'styles', 'rs-metric', "
+    "'disclosures', 'checklist', 'styles', 'rs-metric', 'rs-driver', "
     # cm — Conceptual Model framework (cm:Debit/cm:Credit posting roles),
     # tenant-copied with the default pin.
     "'cm'"
@@ -290,6 +290,8 @@ def _widen_library_checks(conn, schema: str) -> None:
     "'comprehensive_income', "
     # Domain-specific working-paper / schedule patterns
     "'schedule', 'rollforward', 'reconciliation', 'policy', 'metric', "
+    # Forecast — authored scenario container (FP&A engine, 0024).
+    "'forecast', "
     # CoA + CoA→GAAP mapping
     "'chart_of_accounts', 'coa_mapping', "
     # Reference-taxonomy structure kinds (XBRL network roles distinct

--- a/robosystems/graphql/resolvers/information_block.py
+++ b/robosystems/graphql/resolvers/information_block.py
@@ -49,10 +49,18 @@ class InformationBlockQuery:
     self,
     info: Info[GraphQLContext, None],
     id: strawberry.ID,
+    scenario_id: str | None = None,
   ) -> InformationBlock | None:
-    """Fetch a single Information Block envelope by id."""
+    """Fetch a single Information Block envelope by id.
+
+    ``scenarioId`` selects the FactSet slice: omitted = actuals; a
+    forecast block's structure id = that scenario's parallel universe
+    (statement envelopes bind its latest computed month, metric
+    envelopes extend the series with its forward columns, labeled
+    "(forecast)").
+    """
     with _open_session(info) as session:
-      envelope = get_information_block(session, str(id))
+      envelope = get_information_block(session, str(id), scenario_id=scenario_id)
       return InformationBlock.from_pydantic(envelope) if envelope else None
 
   @strawberry.field
@@ -63,12 +71,15 @@ class InformationBlockQuery:
     category: str | None = None,
     limit: int | None = None,
     offset: int | None = None,
+    scenario_id: str | None = None,
   ) -> list[InformationBlock]:
     """List Information Blocks with optional block_type + category filters.
 
     ``blockType`` filters to one registered block type (e.g.
     ``'schedule'``). ``category`` filters on the registry entry's
     category label ('Close', 'Reporting', …). Both combine as AND.
+    ``scenarioId`` threads into each envelope's FactSet binding (the
+    Structure list itself is scenario-independent).
     """
     limit, offset = _resolve_pagination(limit, offset, default_limit=50)
     graph_id = require_graph_id(info)
@@ -80,6 +91,7 @@ class InformationBlockQuery:
         limit=limit,
         offset=offset,
         library_sentinel=(graph_id == LIBRARY_GRAPH_ID),
+        scenario_id=scenario_id,
       )
       return [InformationBlock.from_pydantic(r) for r in rows]
 

--- a/robosystems/middleware/mcp/tools/information_block_tools.py
+++ b/robosystems/middleware/mcp/tools/information_block_tools.py
@@ -52,6 +52,10 @@ class GetInformationBlockTool:
 
 **PARAMETERS:**
 - id (required): The Information Block's structure id
+- scenario_id (optional): A forecast block's structure id — binds that
+  scenario's FactSet slice instead of actuals (statement envelopes show
+  the latest computed forecast month; metric envelopes extend the series
+  with the scenario's forward columns, labeled "(forecast)")
 
 **RETURNS:**
 A typed envelope with:
@@ -76,6 +80,13 @@ were retired in favor of this pair.""",
             "type": "string",
             "description": "Information Block (structure) id",
           },
+          "scenario_id": {
+            "type": "string",
+            "description": (
+              "Forecast block structure id — bind that scenario's "
+              "FactSet slice instead of actuals."
+            ),
+          },
         },
         "required": ["id"],
       },
@@ -84,10 +95,11 @@ were retired in favor of this pair.""",
   async def execute(self, arguments: dict[str, Any]) -> Any:
     graph_id = self.client.graph_id
     block_id = arguments["id"]
+    scenario_id = arguments.get("scenario_id")
 
     try:
       with extensions_session(graph_id) as session:
-        envelope = ops_get_information_block(session, block_id)
+        envelope = ops_get_information_block(session, block_id, scenario_id=scenario_id)
         if envelope is None:
           return {
             "error": "not_found",
@@ -125,6 +137,9 @@ class ListInformationBlocksTool:
 - category (optional): Filter by registry category (e.g., 'Close')
 - limit (optional, default 50): Max results to return (1-1000)
 - offset (optional, default 0): Pagination offset
+- scenario_id (optional): A forecast block's structure id — each
+  envelope binds that scenario's FactSet slice instead of actuals
+  (list blocks with block_type='forecast' to discover scenarios)
 - include_atoms (optional, default false): When false, returns a lean
   summary per block (id, type, name, display_name, category, taxonomy_id,
   taxonomy_name, disclosure_id, element_count, fact_count, rule_count).
@@ -175,6 +190,13 @@ class ListInformationBlocksTool:
               "keep list calls compact."
             ),
           },
+          "scenario_id": {
+            "type": "string",
+            "description": (
+              "Forecast block structure id — bind each envelope to that "
+              "scenario's FactSet slice instead of actuals."
+            ),
+          },
         },
         "required": [],
       },
@@ -187,6 +209,7 @@ class ListInformationBlocksTool:
     limit = int(arguments.get("limit", 50))
     offset = int(arguments.get("offset", 0))
     include_atoms = bool(arguments.get("include_atoms", False))
+    scenario_id = arguments.get("scenario_id")
 
     # MCP inputSchema declares minimum/maximum bounds for limit + offset,
     # but the stdio server doesn't enforce them — some clients (and
@@ -213,6 +236,7 @@ class ListInformationBlocksTool:
           limit=limit,
           offset=offset,
           library_sentinel=(graph_id == LIBRARY_GRAPH_ID),
+          scenario_id=scenario_id,
         )
         if include_atoms:
           blocks = [e.model_dump(mode="json") for e in envelopes]

--- a/robosystems/models/api/extensions/forecasts.py
+++ b/robosystems/models/api/extensions/forecasts.py
@@ -1,0 +1,175 @@
+"""API request models for the ``forecast`` Information Block type.
+
+Mirrors the shape of ``rollforward.py`` — request bodies live here, the
+typed ``ForecastMechanics`` envelope lives in
+``robosystems.models.api.information_block`` alongside the other block-
+type mechanics shapes.
+
+The forecast block is the **authored scenario container** (FP&A F-1):
+scenario identity (name + ``scenario_kind``), horizon, base period, and
+the lever assertions — values on ``rs-driver:*`` catalog elements. The
+lever *mechanics* (what each lever drives, and how) are library-seeded
+Derive rules; the author asserts only the values. Derived forward facts
+land in the existing statement/metric block types stamped with the
+scenario, produced by the ``compute-forecast`` operation.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+# ``YYYY-MM`` period keys — same convention as the fiscal calendar.
+_PERIOD_PATTERN = r"^\d{4}-(0[1-9]|1[0-2])$"
+
+
+class LeverAssertionRequest(BaseModel):
+  """One lever's asserted values for the scenario.
+
+  ``qname`` must resolve to an ``rs-driver:*`` catalog element (the
+  create handler rejects anything else). Value conventions follow the
+  catalog: percent levers are decimals per month (0.03 = 3%/month),
+  days levers are day counts.
+
+  ``value`` is a uniform fill across the whole horizon;
+  ``values_by_period`` overrides individual months (``"YYYY-MM"``
+  keys). At least one of the two must be provided. Months covered by
+  neither carry no assertion — the lever's rule is inactive for that
+  month and its target falls to the engine's carry-forward default.
+  """
+
+  qname: str = Field(
+    ...,
+    description=(
+      "QName of the rs-driver lever element (e.g. ``rs-driver:RevenueGrowthRate``)."
+    ),
+  )
+  value: float | None = Field(
+    None,
+    description="Uniform value asserted for every month of the horizon.",
+  )
+  values_by_period: dict[str, float] | None = Field(
+    None,
+    description=(
+      "Per-month overrides keyed by ``YYYY-MM``. Wins over ``value`` "
+      "for the months it names."
+    ),
+  )
+
+  @model_validator(mode="after")
+  def _require_some_value(self) -> LeverAssertionRequest:
+    if self.value is None and not self.values_by_period:
+      raise ValueError(
+        f"Lever {self.qname!r} needs a uniform `value` and/or "
+        "`values_by_period` overrides."
+      )
+    return self
+
+
+class CreateForecastRequest(BaseModel):
+  """Create a forecast block — the authored scenario container.
+
+  ``base_period`` defaults to the fiscal calendar's
+  ``closed_through_period`` (else the newest actual report month) —
+  the walk projects forward from the last closed actuals. The resolved
+  value is stored in the mechanics so recompute is deterministic.
+  """
+
+  model_config = ConfigDict(
+    json_schema_extra={
+      "examples": [
+        {
+          "summary": "FY operating budget — growth + margins + working capital",
+          "description": (
+            "A 12-month budget scenario: 3%/month revenue growth "
+            "compounding, 62% cost-of-revenue rate, 45-day DSO, 30-day "
+            "DPO. Lever values are decimals/day-counts per the "
+            "rs-driver catalog conventions. After creating, run "
+            "`compute-forecast` to derive the forward months."
+          ),
+          "value": {
+            "name": "FY26 Operating Budget",
+            "scenario_kind": "budget",
+            "horizon_months": 12,
+            "levers": [
+              {"qname": "rs-driver:RevenueGrowthRate", "value": 0.03},
+              {"qname": "rs-driver:CostOfRevenueRate", "value": 0.62},
+              {"qname": "rs-driver:DaysSalesOutstanding", "value": 45},
+              {"qname": "rs-driver:DaysPayableOutstanding", "value": 30},
+            ],
+          },
+        }
+      ]
+    }
+  )
+
+  name: str = Field(..., description="Human-readable scenario name.")
+  scenario_kind: Literal["budget", "forecast", "projection"] = Field(
+    "forecast",
+    description=(
+      "What kind of scenario this is — metadata for display/filtering, "
+      "not machinery. All kinds compute identically."
+    ),
+  )
+  horizon_months: int = Field(
+    12,
+    ge=1,
+    le=36,
+    description="Forward months to project past the base period.",
+  )
+  base_period: str | None = Field(
+    None,
+    pattern=_PERIOD_PATTERN,
+    description=(
+      "Seed month (``YYYY-MM``) the walk projects forward from. "
+      "Defaults to the fiscal calendar's closed-through period, else "
+      "the newest actual report month. Resolved and stored at create "
+      "time."
+    ),
+  )
+  levers: list[LeverAssertionRequest] = Field(
+    ...,
+    min_length=1,
+    description="Lever assertions — at least one.",
+  )
+  entity_id: str | None = Field(
+    None,
+    description=(
+      "Entity the scenario belongs to. Defaults to the graph's "
+      "earliest-created entity (single-entity convention)."
+    ),
+  )
+
+
+class UpdateForecastRequest(BaseModel):
+  """Update a forecast block in place.
+
+  Mutable: name, scenario_kind, horizon_months, base_period, levers.
+  ``levers`` is a **full replace** when provided (partial lever edits
+  would make the asserted set ambiguous). Updating does NOT recompute —
+  previously computed scenario months go stale until the next
+  ``compute-forecast`` run (the compute-metrics drift semantics).
+  """
+
+  structure_id: str = Field(..., description="Structure ID of the forecast block.")
+  name: str | None = None
+  scenario_kind: Literal["budget", "forecast", "projection"] | None = None
+  horizon_months: int | None = Field(None, ge=1, le=36)
+  base_period: str | None = Field(None, pattern=_PERIOD_PATTERN)
+  levers: list[LeverAssertionRequest] | None = Field(
+    None,
+    min_length=1,
+    description="Full replacement of the lever set when provided.",
+  )
+
+
+class DeleteForecastRequest(BaseModel):
+  """Delete a forecast block.
+
+  Removes the scenario's entire parallel universe: the lever FactSet
+  AND every computed scenario FactSet (the forward statement/metric
+  months keyed by this scenario). Actuals are never touched.
+  """
+
+  structure_id: str = Field(..., description="Structure ID of the forecast block.")

--- a/robosystems/models/api/fact_provenance.py
+++ b/robosystems/models/api/fact_provenance.py
@@ -23,6 +23,10 @@ discipline as ``ArtifactMechanics``, which discriminates on ``kind``):
 * ``document`` — text-block fact bound from a platform Document; the
                  document is the editable source of truth and
                  ``content_hash`` is the drift signal.
+* ``forecast`` — forward facts derived by the forecast engine's driver
+                 cascade (scenario slice, ``fact_sets.scenario_id`` set);
+                 deterministic recompute from lever assertions + actual
+                 seeds, no posted event behind any forward month.
 * ``filed``    — as-filed public disclosure filed with a regulator/authority
                  (SEC EDGAR XBRL); the filing itself is the source of record,
                  citable by accession + filing date. No posted-ledger lineage
@@ -167,6 +171,36 @@ class DocumentProvenance(BaseModel):
   asserted_by: str | None = Field(None, description="Actor that bound the text.")
 
 
+class ForecastProvenance(BaseModel):
+  """Forward facts derived by the forecast engine (scenario slice).
+
+  ``compute-forecast`` walks a scenario's driver cascade month-by-month
+  from the last closed actuals and emits the results into scenario-keyed
+  standing FactSets (``fact_sets.scenario_id`` = the owning forecast
+  block). A forecast-specialized sibling of ``derived``: deterministic
+  recompute from lever assertions + actual seed values, with no posted
+  event behind any forward month. Distinct from ``schedule`` (a single
+  self-projecting template) — this is the multi-driver cascade.
+  """
+
+  origin: Literal["forecast"] = "forecast"
+  scenario_structure_id: str = Field(
+    ..., description="Forecast Structure (the scenario) that generated the facts."
+  )
+  base_period: str = Field(
+    ...,
+    description="Seed month the walk projected forward from ('YYYY-MM').",
+  )
+  month_index: int = Field(
+    ...,
+    description="1-based offset of this month past the actual/forecast seam.",
+  )
+  drivers: list[str] = Field(
+    default_factory=list,
+    description="Active lever qnames that shaped this month's cascade.",
+  )
+
+
 class FiledProvenance(BaseModel):
   """As-filed public disclosure filed with a regulator/authority.
 
@@ -201,6 +235,7 @@ FactProvenance = Annotated[
   | DerivedProvenance
   | AssertedProvenance
   | DocumentProvenance
+  | ForecastProvenance
   | FiledProvenance,
   Field(discriminator="origin"),
 ]

--- a/robosystems/models/api/information_block.py
+++ b/robosystems/models/api/information_block.py
@@ -1771,6 +1771,104 @@ class ComputeMetricsResponse(BaseModel):
   skipped: list[SkippedMetricLite] = Field(default_factory=list)
 
 
+class ForecastMonthLite(BaseModel):
+  """One computed forward month in a ``compute-forecast`` response."""
+
+  period: str = Field(..., description="Month key (``YYYY-MM``).")
+  period_start: date
+  period_end: date
+  income_statement_fact_set_id: str | None = Field(
+    None,
+    description="Scenario IS FactSet upserted for the month.",
+  )
+  balance_sheet_fact_set_id: str | None = Field(
+    None,
+    description=(
+      "Scenario BS FactSet upserted for the month (working-capital "
+      "instants only in F-1 — the full BS roll is a later phase)."
+    ),
+  )
+  computed_count: int = Field(
+    0, description="Number of facts emitted for the month across both sets."
+  )
+
+
+class SkippedForecastLite(BaseModel):
+  """One rule/month soft-skip in a ``compute-forecast`` response.
+
+  A skipped rule never aborts the walk — its target falls back to the
+  carry-forward value for that month (when a prior value exists).
+  """
+
+  rule_id: str | None = None
+  element_qname: str | None = None
+  period: str = Field(..., description="Month key (``YYYY-MM``) of the skip.")
+  reason: str
+  missing: list[str] = Field(default_factory=list)
+
+
+class ComputeForecastRequest(BaseModel):
+  """Request body for the ``compute-forecast`` operation.
+
+  Walks the scenario's driver cascade month-by-month forward from the
+  forecast block's ``base_period``: lever-driven Derive rules in
+  dependency order, carry-forward for unmodeled IS lines, calc-DAG
+  subtotals — upserting one scenario IS FactSet (+ a working-capital BS
+  set) per forward month, all keyed by the forecast block's
+  ``scenario_id``. Re-running replaces each month's values (the
+  compute-metrics drift semantics). Deterministic and non-AI — no
+  credits consumed.
+  """
+
+  structure_id: str = Field(
+    ...,
+    description="Forecast block structure (block_type='forecast') to compute.",
+  )
+  months: int | None = Field(
+    None,
+    ge=1,
+    description=(
+      "Forward months to compute — defaults to the block's full "
+      "horizon_months; must not exceed it (lever assertions don't "
+      "extend past the horizon)."
+    ),
+  )
+  entity_id: str | None = Field(
+    None,
+    description=(
+      "Entity to compute for. Defaults to the lever FactSet's entity "
+      "(the entity the scenario was authored against)."
+    ),
+  )
+
+  model_config = ConfigDict(
+    json_schema_extra={
+      "examples": [
+        {"structure_id": "struct_fy26_budget"},
+        {"structure_id": "struct_fy26_budget", "months": 6},
+      ]
+    }
+  )
+
+
+class ComputeForecastResponse(BaseModel):
+  """Response for the ``compute-forecast`` operation."""
+
+  structure_id: str
+  scenario_id: str = Field(
+    ...,
+    description=(
+      "The scenario key every emitted FactSet carries — the forecast "
+      "block's own structure id."
+    ),
+  )
+  entity_id: str
+  base_period: str = Field(..., description="Seed month the walk projected from.")
+  months: int = Field(..., description="Forward months requested.")
+  months_computed: list[ForecastMonthLite] = Field(default_factory=list)
+  skipped: list[SkippedForecastLite] = Field(default_factory=list)
+
+
 __all__ = [
   "ArtifactMechanics",
   "ArtifactResponse",
@@ -1778,6 +1876,8 @@ __all__ = [
   "ChartPanelLite",
   "ChartSeriesLite",
   "ClassificationLite",
+  "ComputeForecastRequest",
+  "ComputeForecastResponse",
   "ComputeMetricsRequest",
   "ComputeMetricsResponse",
   "ComputedMetricLite",
@@ -1791,6 +1891,7 @@ __all__ = [
   "FactLite",
   "FactSetLite",
   "ForecastMechanics",
+  "ForecastMonthLite",
   "InformationBlockEnvelope",
   "InformationModelResponse",
   "LeverAssertionLite",
@@ -1802,6 +1903,7 @@ __all__ = [
   "RuleTargetLite",
   "RuleVariableLite",
   "ScheduleMechanics",
+  "SkippedForecastLite",
   "SkippedMetricLite",
   "StatementMechanics",
   "UpdateInformationBlockRequest",

--- a/robosystems/models/api/information_block.py
+++ b/robosystems/models/api/information_block.py
@@ -16,6 +16,11 @@ from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Discriminator, Field, RootModel
 
+from robosystems.models.api.extensions.forecasts import (
+  CreateForecastRequest,
+  DeleteForecastRequest,
+  UpdateForecastRequest,
+)
 from robosystems.models.api.extensions.rollforward import (
   AttributionFilter,
   CreateRollforwardRequest,
@@ -572,6 +577,78 @@ class RollforwardMechanics(BaseModel):
   )
 
 
+class LeverAssertionLite(BaseModel):
+  """One lever's persisted assertion inside ``ForecastMechanics``.
+
+  The create handler expands the wire-level assertion (uniform ``value``
+  + per-month overrides) into the explicit ``values_by_period`` map so
+  compute never interpolates — every asserted month is stated. The
+  values are duplicated as authored facts in the scenario's lever
+  FactSet (rules for mechanics, **facts for values** — the facts are
+  what ``compute-forecast`` binds); this mechanics copy is the
+  operator-legible round-trip shape.
+  """
+
+  qname: str = Field(..., description="rs-driver lever element qname.")
+  element_id: str = Field(..., description="Resolved tenant element id.")
+  item_type: str | None = Field(
+    None,
+    description="Format family from the catalog (percent | days | ...).",
+  )
+  values_by_period: dict[str, float] = Field(
+    ...,
+    description="Expanded per-month assertions keyed by ``YYYY-MM``.",
+  )
+
+
+class ForecastMechanics(BaseModel):
+  """Authored scenario container for ``block_type='forecast'`` (FP&A F-1).
+
+  The block IS the scenario: its structure id is the ``scenario_id``
+  every derived forward FactSet carries (NULL = actuals). The authored
+  surface is exactly this — scenario identity, horizon, base period,
+  lever assertions; everything downstream is derived by
+  ``compute-forecast`` (levers → driven rs-gaap anchors via the
+  rs-driver Derive rules → carry-forward for unmodeled IS lines →
+  calc-DAG subtotals), landing in the EXISTING statement/metric block
+  types stamped with the scenario. Reads directly from the typed
+  ``structures.artifact_mechanics`` JSONB column.
+  """
+
+  kind: Literal["forecast"] = "forecast"
+  scenario_kind: Literal["budget", "forecast", "projection"] = Field(
+    "forecast",
+    description="Scenario kind — display/filter metadata, not machinery.",
+  )
+  horizon_months: int = Field(
+    ...,
+    ge=1,
+    le=36,
+    description="Forward months projected past the base period.",
+  )
+  base_period: str = Field(
+    ...,
+    description=(
+      "Seed month (``YYYY-MM``) the walk projects forward from — "
+      "resolved at create time (request → fiscal calendar "
+      "closed-through → newest actual report month) and stored so "
+      "recompute is deterministic."
+    ),
+  )
+  levers: list[LeverAssertionLite] = Field(
+    ...,
+    description="Expanded lever assertions (authoring order).",
+  )
+  computed_months: int = Field(
+    default=0,
+    description=(
+      "Number of forward months with computed scenario FactSets. "
+      "Runtime state filled at envelope-build time — 0 until the first "
+      "compute-forecast run."
+    ),
+  )
+
+
 class StatementMechanics(BaseModel):
   """Renderer mechanics for the statement family of block types.
 
@@ -617,7 +694,11 @@ class StatementMechanics(BaseModel):
 # New block-type mechanics models add a `kind` literal and extend this
 # union. Pydantic dispatches on `kind` via the discriminator tag.
 ArtifactMechanics = Annotated[
-  ScheduleMechanics | StatementMechanics | MetricMechanics | RollforwardMechanics,
+  ScheduleMechanics
+  | StatementMechanics
+  | MetricMechanics
+  | RollforwardMechanics
+  | ForecastMechanics,
   Field(discriminator="kind"),
 ]
 
@@ -1090,8 +1171,57 @@ class _CreateRollforwardArm(BaseModel):
   )
 
 
+class _CreateForecastArm(BaseModel):
+  """Create-information-block body for ``block_type="forecast"``.
+
+  Carries a typed forecast payload — the authored scenario container:
+  scenario identity, horizon, base period, lever assertions on
+  ``rs-driver:*`` catalog elements. Run ``compute-forecast`` after
+  creating to derive the forward months.
+  """
+
+  model_config = ConfigDict(
+    json_schema_extra={
+      "examples": [
+        {
+          "summary": "12-month operating budget scenario",
+          "description": (
+            "Budget scenario: 3%/month revenue growth compounding, 62% "
+            "cost-of-revenue rate, 45-day DSO, 30-day DPO. Lever values "
+            "follow the rs-driver catalog conventions (percent levers "
+            "as decimals per month, days levers as day counts)."
+          ),
+          "value": {
+            "block_type": "forecast",
+            "payload": {
+              "name": "FY26 Operating Budget",
+              "scenario_kind": "budget",
+              "horizon_months": 12,
+              "levers": [
+                {"qname": "rs-driver:RevenueGrowthRate", "value": 0.03},
+                {"qname": "rs-driver:CostOfRevenueRate", "value": 0.62},
+                {"qname": "rs-driver:DaysSalesOutstanding", "value": 45},
+                {"qname": "rs-driver:DaysPayableOutstanding", "value": 30},
+              ],
+            },
+          },
+        }
+      ]
+    }
+  )
+
+  block_type: Literal["forecast"] = Field(
+    ...,
+    description="Discriminator value selecting this arm.",
+  )
+  payload: CreateForecastRequest = Field(
+    ...,
+    description="Forecast creation payload.",
+  )
+
+
 _CreateInformationBlockArms = Annotated[
-  _CreateScheduleArm | _CreateRollforwardArm | _CreateLegacyArm,
+  _CreateScheduleArm | _CreateRollforwardArm | _CreateForecastArm | _CreateLegacyArm,
   Discriminator("block_type"),
 ]
 
@@ -1112,9 +1242,14 @@ class CreateInformationBlockRequest(RootModel[_CreateInformationBlockArms]):
   @property
   def payload(
     self,
-  ) -> CreateScheduleRequest | CreateRollforwardRequest | dict[str, Any]:
-    """Payload of the resolved arm. Typed for the schedule and
-    rollforward arms; a raw dict for the legacy arms (the dispatch
+  ) -> (
+    CreateScheduleRequest
+    | CreateRollforwardRequest
+    | CreateForecastRequest
+    | dict[str, Any]
+  ):
+    """Payload of the resolved arm. Typed for the schedule, rollforward,
+    and forecast arms; a raw dict for the legacy arms (the dispatch
     handler validates it at runtime against the registry entry's
     request model)."""
     return self.root.payload
@@ -1214,8 +1349,48 @@ class _UpdateRollforwardArm(BaseModel):
   )
 
 
+class _UpdateForecastArm(BaseModel):
+  """Update-information-block body for ``block_type="forecast"``.
+
+  Mutable: name, scenario_kind, horizon_months, base_period, levers
+  (full replace). Updating does not recompute — run ``compute-forecast``
+  to refresh the scenario's derived months.
+  """
+
+  model_config = ConfigDict(
+    json_schema_extra={
+      "examples": [
+        {
+          "summary": "Raise the growth assumption",
+          "value": {
+            "block_type": "forecast",
+            "payload": {
+              "structure_id": "struct_fy26_budget",
+              "levers": [
+                {"qname": "rs-driver:RevenueGrowthRate", "value": 0.04},
+                {"qname": "rs-driver:CostOfRevenueRate", "value": 0.62},
+                {"qname": "rs-driver:DaysSalesOutstanding", "value": 45},
+                {"qname": "rs-driver:DaysPayableOutstanding", "value": 30},
+              ],
+            },
+          },
+        }
+      ]
+    }
+  )
+
+  block_type: Literal["forecast"] = Field(
+    ...,
+    description="Discriminator value selecting this arm.",
+  )
+  payload: UpdateForecastRequest = Field(
+    ...,
+    description="Forecast update payload.",
+  )
+
+
 _UpdateInformationBlockArms = Annotated[
-  _UpdateScheduleArm | _UpdateRollforwardArm | _UpdateLegacyArm,
+  _UpdateScheduleArm | _UpdateRollforwardArm | _UpdateForecastArm | _UpdateLegacyArm,
   Discriminator("block_type"),
 ]
 
@@ -1234,7 +1409,12 @@ class UpdateInformationBlockRequest(RootModel[_UpdateInformationBlockArms]):
   @property
   def payload(
     self,
-  ) -> UpdateScheduleRequest | UpdateRollforwardRequest | dict[str, Any]:
+  ) -> (
+    UpdateScheduleRequest
+    | UpdateRollforwardRequest
+    | UpdateForecastRequest
+    | dict[str, Any]
+  ):
     return self.root.payload
 
 
@@ -1330,8 +1510,39 @@ class _DeleteRollforwardArm(BaseModel):
   )
 
 
+class _DeleteForecastArm(BaseModel):
+  """Delete-information-block body for ``block_type="forecast"``.
+
+  Removes the scenario's entire parallel universe — the lever FactSet
+  and every computed scenario FactSet. Actuals are never touched.
+  """
+
+  model_config = ConfigDict(
+    json_schema_extra={
+      "examples": [
+        {
+          "summary": "Delete a forecast scenario",
+          "value": {
+            "block_type": "forecast",
+            "payload": {"structure_id": "struct_fy26_budget"},
+          },
+        }
+      ]
+    }
+  )
+
+  block_type: Literal["forecast"] = Field(
+    ...,
+    description="Discriminator value selecting this arm.",
+  )
+  payload: DeleteForecastRequest = Field(
+    ...,
+    description="Forecast delete payload.",
+  )
+
+
 _DeleteInformationBlockArms = Annotated[
-  _DeleteScheduleArm | _DeleteRollforwardArm | _DeleteLegacyArm,
+  _DeleteScheduleArm | _DeleteRollforwardArm | _DeleteForecastArm | _DeleteLegacyArm,
   Discriminator("block_type"),
 ]
 
@@ -1349,7 +1560,12 @@ class DeleteInformationBlockRequest(RootModel[_DeleteInformationBlockArms]):
   @property
   def payload(
     self,
-  ) -> DeleteScheduleRequest | DeleteRollforwardRequest | dict[str, Any]:
+  ) -> (
+    DeleteScheduleRequest
+    | DeleteRollforwardRequest
+    | DeleteForecastRequest
+    | dict[str, Any]
+  ):
     return self.root.payload
 
 
@@ -1574,8 +1790,10 @@ __all__ = [
   "EvaluateRulesResponse",
   "FactLite",
   "FactSetLite",
+  "ForecastMechanics",
   "InformationBlockEnvelope",
   "InformationModelResponse",
+  "LeverAssertionLite",
   "MetricMechanics",
   "RenderingLite",
   "RenderingPeriodLite",

--- a/robosystems/models/api/information_block.py
+++ b/robosystems/models/api/information_block.py
@@ -207,8 +207,8 @@ class FactSetLite(BaseModel):
   factset_type: str = Field(
     ...,
     description=(
-      "'report' | 'schedule' | 'custom' | 'disclosure'. Enum closure "
-      "enforced by the ``public.fact_sets`` CHECK constraint."
+      "'report' | 'schedule' | 'custom' | 'disclosure' | 'metric'. Enum "
+      "closure enforced by the ``public.fact_sets`` CHECK constraint."
     ),
   )
   entity_id: str
@@ -217,6 +217,14 @@ class FactSetLite(BaseModel):
     description=(
       "Back-pointer to the ``reports`` table while ``report_id`` still "
       "lives on facts. Drops out once the retirement migration lands."
+    ),
+  )
+  scenario_id: str | None = Field(
+    None,
+    description=(
+      "Scenario axis (the forecast engine). NULL = actuals; non-NULL "
+      "names the owning forecast block whose parallel universe this "
+      "set belongs to."
     ),
   )
   provenance: dict | None = Field(
@@ -1737,6 +1745,17 @@ class ComputeMetricsRequest(BaseModel):
     description=(
       "Entity to compute for. Defaults to the graph's earliest-created "
       "entity (the primary entity for single-entity graphs)."
+    ),
+  )
+  scenario_id: str | None = Field(
+    None,
+    description=(
+      "Compute on a scenario slice: operands bind that scenario's facts "
+      "(actuals as the fallback across the seam) and the standing metric "
+      "set is stamped with the scenario. None (the default) computes "
+      "actuals only. Pass a forecast block's structure id after "
+      "compute-forecast to extend the metric series into its forward "
+      "months."
     ),
   )
 

--- a/robosystems/models/extensions/element.py
+++ b/robosystems/models/extensions/element.py
@@ -108,7 +108,8 @@ class Element(ExtensionsBase):
       # tenant-copied with the default pin so schedule has-part arcs resolve.
       # 'rs-metric' — the metric catalog package (seeded at 0002 on fresh
       # databases, backfilled by 0022 on existing ones).
-      "'cm', 'rs-metric')",
+      # 'rs-driver' — the forecast lever catalog package (seeded at 0024).
+      "'cm', 'rs-metric', 'rs-driver')",
       name="check_element_source",
     ),
   )

--- a/robosystems/models/extensions/roboledger/fact_set.py
+++ b/robosystems/models/extensions/roboledger/fact_set.py
@@ -25,6 +25,7 @@ from sqlalchemy import (
   Index,
   String,
   event,
+  text,
 )
 from sqlalchemy.dialects.postgresql import JSONB
 
@@ -51,6 +52,11 @@ class FactSet(ExtensionsBase):
     Index("idx_fact_sets_period", "period_start", "period_end"),
     Index("idx_fact_sets_entity", "entity_id"),
     Index("idx_fact_sets_report", "report_id"),
+    Index(
+      "idx_fact_sets_scenario",
+      "scenario_id",
+      postgresql_where=text("scenario_id IS NOT NULL"),
+    ),
     CheckConstraint(
       # 'disclosure' = a standing text-block binding set: the durable
       # Document->fact bind that report builds snapshot from.
@@ -91,6 +97,19 @@ class FactSet(ExtensionsBase):
   # Report whose id isn't known until the snapshot is copied; report
   # facts created via ``create_report`` always populate it.
   report_id = Column(String, nullable=True)
+
+  # Scenario axis (the forecast engine's parallel universes). NULL =
+  # actuals — every pre-forecast writer leaves it unset, so the entire
+  # historical corpus is the null scenario by construction. Non-NULL
+  # points at the owning ``forecast`` Structure (the block IS the
+  # scenario), and ON DELETE CASCADE removes the whole scenario slice
+  # with its block. Never SET NULL here: an orphaned scenario set
+  # demoted to NULL would masquerade as actuals.
+  scenario_id = Column(
+    String,
+    ForeignKey("structures.id", ondelete="CASCADE"),
+    nullable=True,
+  )
 
   # Free-form metadata (render config pins, template id at creation time,
   # agent prompt, etc.). NOTE: typed fact provenance lives on its own

--- a/robosystems/models/extensions/structure.py
+++ b/robosystems/models/extensions/structure.py
@@ -87,6 +87,11 @@ class Structure(ExtensionsBase):
       "'comprehensive_income', "
       # Domain-specific working-paper / schedule patterns
       "'schedule', 'rollforward', 'reconciliation', 'policy', 'metric', "
+      # Forecast — the authored scenario container (FP&A engine): lever
+      # assertions + scenario identity; derived forward facts land in
+      # the EXISTING statement/metric block types stamped with
+      # fact_sets.scenario_id, never in a parallel forecast statement.
+      "'forecast', "
       # Chart-of-accounts and CoA→GAAP mapping
       "'chart_of_accounts', 'coa_mapping', "
       # Reference-taxonomy structure kinds (XBRL network roles distinct

--- a/robosystems/operations/information_block/disclosure.py
+++ b/robosystems/operations/information_block/disclosure.py
@@ -59,6 +59,7 @@ def build_envelope(
   session: Session,
   structure_id: str,
   fact_set_id: str | None = None,
+  scenario_id: str | None = None,
 ) -> InformationBlockEnvelope | None:
   """Pack the envelope for a disclosure-note structure.
 
@@ -69,6 +70,10 @@ def build_envelope(
   Returns ``None`` when the structure doesn't exist, isn't a
   ``regulatory_disclosure``, or carries neither arcs nor content (the
   library's disclosure-identity envelopes — not renderable blocks).
+
+  ``scenario_id`` is accepted for dispatch-signature parity and ignored
+  — disclosures bind standing document/report content, not scenario
+  slices (the forecast engine never emits disclosure sets).
   """
   structure = session.get(Structure, structure_id)
   if structure is None or structure.block_type != DISCLOSURE_BLOCK_TYPE:

--- a/robosystems/operations/information_block/envelope.py
+++ b/robosystems/operations/information_block/envelope.py
@@ -169,6 +169,7 @@ def fact_set_to_lite(fact_set: FactSet) -> FactSetLite:
     factset_type=fact_set.factset_type,
     entity_id=fact_set.entity_id,
     report_id=fact_set.report_id,
+    scenario_id=fact_set.scenario_id,
     provenance=fact_set.provenance,
   )
 
@@ -271,7 +272,7 @@ def build_verification_summary(
 
 
 def load_latest_fact_set_for_structure(
-  session: Session, structure_id: str
+  session: Session, structure_id: str, scenario_id: str | None = None
 ) -> FactSetLite | None:
   """Fetch the most recent FactSet for a Structure, if any.
 
@@ -280,10 +281,22 @@ def load_latest_fact_set_for_structure(
   period runs) surfaces the latest slice. Returns ``None`` when no
   FactSet row exists — typically library-seeded Structures whose
   tenant has not yet generated facts.
+
+  ``scenario_id`` selects the slice: ``None`` (the default) pins
+  **actuals** (``scenario_id IS NULL``) — load-bearing, not cosmetic:
+  scenario sets live at FUTURE period_ends, so without the pin one
+  computed forecast month would win this period_end-descending read and
+  hijack every default envelope. A non-None value pins that scenario
+  exactly — statement + scenario binds the latest forecast month.
   """
   row = session.execute(
     select(FactSet)
-    .where(FactSet.structure_id == structure_id)
+    .where(
+      FactSet.structure_id == structure_id,
+      FactSet.scenario_id.is_(None)
+      if scenario_id is None
+      else FactSet.scenario_id == scenario_id,
+    )
     .order_by(FactSet.period_end.desc(), FactSet.created_at.desc())
     .limit(1)
   ).scalar()
@@ -421,6 +434,7 @@ def load_base_envelope_atoms(
   *,
   expected_block_type: str,
   fact_set_id: str | None = None,
+  scenario_id: str | None = None,
 ) -> BaseEnvelopeAtoms | None:
   """Load every atom shared by Information Block envelope builders.
 
@@ -432,9 +446,12 @@ def load_base_envelope_atoms(
   order each individual handler used to inline.
 
   When ``fact_set_id`` is provided the atoms are pinned to that specific
-  FactSet (used by Report Block rehydration). Returns ``None`` if the
-  named FactSet doesn't belong to this Structure — callers treat the
-  pin mismatch as a clean miss.
+  FactSet (used by Report Block rehydration) and ``scenario_id`` is
+  ignored — an explicit pin bypasses scenario selection. Returns
+  ``None`` if the named FactSet doesn't belong to this Structure —
+  callers treat the pin mismatch as a clean miss. Without a pin,
+  ``scenario_id`` selects the FactSet slice (``None`` = actuals; see
+  :func:`load_latest_fact_set_for_structure`).
   """
   from robosystems.models.extensions import Taxonomy
 
@@ -450,7 +467,7 @@ def load_base_envelope_atoms(
     if fact_set is None:
       return None
   else:
-    fact_set = load_latest_fact_set_for_structure(session, structure_id)
+    fact_set = load_latest_fact_set_for_structure(session, structure_id, scenario_id)
 
   taxonomy_name = session.execute(
     select(Taxonomy.name).where(Taxonomy.id == structure.taxonomy_id)

--- a/robosystems/operations/information_block/forecast.py
+++ b/robosystems/operations/information_block/forecast.py
@@ -403,9 +403,16 @@ def delete(
 
 
 def build_envelope(
-  session: Session, structure_id: str, fact_set_id: str | None = None
+  session: Session,
+  structure_id: str,
+  fact_set_id: str | None = None,
+  scenario_id: str | None = None,
 ) -> InformationBlockEnvelope | None:
   """Reload a forecast Structure and pack its envelope.
+
+  ``scenario_id`` is accepted for dispatch-signature parity and ignored
+  — the forecast block IS the scenario; its envelope is the lever grid
+  regardless of which scenario filter the read carried.
 
   Renders the **lever grid** metric-style: one row per lever (authoring
   order, ``item_type`` driving percent/days formatting), one period

--- a/robosystems/operations/information_block/forecast.py
+++ b/robosystems/operations/information_block/forecast.py
@@ -1,0 +1,534 @@
+"""Handlers for ``block_type='forecast'`` — the authored scenario container.
+
+The forecast block is the FP&A engine's authored surface (F-1): scenario
+identity (name + ``scenario_kind``), horizon, base period, and lever
+assertions on ``rs-driver:*`` catalog elements. The block IS the
+scenario — its structure id is the ``scenario_id`` every derived forward
+FactSet carries (NULL = actuals), and deleting the block removes the
+whole scenario slice.
+
+Persistence follows the rules-for-mechanics / **facts-for-values**
+doctrine: lever *mechanics* are the library-seeded rs-driver Derive
+rules; lever *values* land as authored Numeric facts in ONE
+``factset_type='custom'`` FactSet whose ``scenario_id`` is the forecast
+block itself (self-referential — the levers belong to the scenario,
+cascade-delete with it, and stay invisible to actuals reads and to
+metric operand binding, which only joins ``('report', 'metric')`` sets).
+
+``create`` / ``update`` / ``delete`` follow the Schedule/rollforward
+declarative pattern; ``build_envelope`` renders the lever grid
+metric-style (one row per lever, one column per horizon month) so the
+frontend reuses the metric rendering path unchanged. The derivation
+itself is ``compute-forecast`` (:mod:`.forecast_compute`) — authoring
+never computes.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import TYPE_CHECKING
+
+from sqlalchemy import select
+
+from robosystems.models.api.fact_provenance import AssertedProvenance
+from robosystems.models.api.information_block import (
+  ArtifactResponse,
+  ForecastMechanics,
+  InformationBlockEnvelope,
+  InformationModelResponse,
+  LeverAssertionLite,
+  RenderingLite,
+  RenderingPeriodLite,
+  RenderingRowLite,
+  ViewProjections,
+)
+from robosystems.models.extensions import Element, Structure
+from robosystems.models.extensions.roboledger.fact import Fact
+from robosystems.models.extensions.roboledger.fact_set import FactSet
+from robosystems.operations.information_block.envelope import (
+  element_to_lite,
+  fact_set_to_lite,
+  fact_to_lite,
+  load_base_envelope_atoms,
+)
+from robosystems.operations.information_block.metrics import (
+  _default_entity_id,
+  _latest_report_period_end_before,
+  _metric_unit,
+)
+from robosystems.operations.roboledger.fact_set import create_fact_set
+from robosystems.operations.roboledger.fiscal_calendar.periods import (
+  add_months,
+  period_date_range,
+  period_from_date,
+)
+from robosystems.utils.ulid import generate_prefixed_ulid
+
+if TYPE_CHECKING:
+  from sqlalchemy.orm import Session
+
+  from robosystems.models.api.extensions.forecasts import (
+    CreateForecastRequest,
+    DeleteForecastRequest,
+    LeverAssertionRequest,
+    UpdateForecastRequest,
+  )
+
+FORECAST_BLOCK_TYPE = "forecast"
+FORECAST_DISPLAY_NAME = "Forecast"
+FORECAST_CATEGORY = "Planning"
+
+_LEVER_SOURCE = "rs-driver"
+
+
+def _resolve_base_period(
+  session: Session, entity_id: str, requested: str | None
+) -> str:
+  """Resolve the seed month the walk projects forward from.
+
+  Request value → fiscal calendar ``closed_through_period`` → the
+  entity's newest actual report month (the data-driven fallback the
+  M-2 prior-period resolver established — the calendar is not the
+  period spine for annual-comparative tenants). Stored resolved in the
+  mechanics so recompute is deterministic.
+  """
+  if requested is not None:
+    return requested
+
+  from robosystems.models.extensions.roboledger.fiscal_calendar import FiscalCalendar
+
+  calendar = (
+    session.query(FiscalCalendar).order_by(FiscalCalendar.created_at.asc()).first()
+  )
+  if calendar is not None and calendar.closed_through_period:
+    return calendar.closed_through_period
+
+  newest = _latest_report_period_end_before(session, entity_id, date(9999, 12, 31))
+  if newest is not None:
+    return period_from_date(newest)
+
+  raise ValueError(
+    "Cannot resolve a base period: the fiscal calendar has no closed-through "
+    "period and no actual report facts exist to project from. Pass "
+    "base_period explicitly."
+  )
+
+
+def _expand_levers(
+  session: Session,
+  levers: list[LeverAssertionRequest],
+  base_period: str,
+  horizon_months: int,
+) -> list[LeverAssertionLite]:
+  """Resolve + expand wire-level lever assertions to explicit per-month maps.
+
+  Every qname must resolve to an ``rs-driver``-source element; the
+  expansion applies the uniform ``value`` fill then the per-month
+  overrides, so compute never interpolates. Overrides naming months
+  outside the horizon are rejected (silent drops would make the
+  asserted set lie).
+  """
+  months = [add_months(base_period, i) for i in range(1, horizon_months + 1)]
+  month_set = set(months)
+
+  expanded: list[LeverAssertionLite] = []
+  seen: set[str] = set()
+  for lever in levers:
+    if lever.qname in seen:
+      raise ValueError(f"Duplicate lever qname {lever.qname!r} in the assertion set.")
+    seen.add(lever.qname)
+
+    element = session.execute(
+      select(Element).where(Element.qname == lever.qname).limit(1)
+    ).scalar_one_or_none()
+    if element is None:
+      raise ValueError(
+        f"Lever qname {lever.qname!r} did not resolve to an Element. "
+        "Levers must name rs-driver catalog concepts (see the Driver "
+        "Catalog structure)."
+      )
+    if element.source != _LEVER_SOURCE:
+      raise ValueError(
+        f"Lever qname {lever.qname!r} resolves to a source={element.source!r} "
+        f"element — levers must be {_LEVER_SOURCE!r} catalog concepts."
+      )
+
+    overrides = lever.values_by_period or {}
+    outside = sorted(set(overrides) - month_set)
+    if outside:
+      raise ValueError(
+        f"Lever {lever.qname!r} has values_by_period entries outside the "
+        f"horizon ({base_period} + {horizon_months} months): {outside}"
+      )
+
+    values: dict[str, float] = {}
+    for month in months:
+      if month in overrides:
+        values[month] = float(overrides[month])
+      elif lever.value is not None:
+        values[month] = float(lever.value)
+    if not values:
+      raise ValueError(f"Lever {lever.qname!r} asserts no months within the horizon.")
+
+    expanded.append(
+      LeverAssertionLite(
+        qname=lever.qname,
+        element_id=element.id,
+        item_type=element.item_type,
+        values_by_period=values,
+      )
+    )
+  return expanded
+
+
+def _load_lever_fact_set(session: Session, structure_id: str) -> FactSet | None:
+  """The scenario's lever FactSet — ``'custom'`` + self-referential scenario."""
+  return session.execute(
+    select(FactSet)
+    .where(
+      FactSet.structure_id == structure_id,
+      FactSet.factset_type == "custom",
+      FactSet.scenario_id == structure_id,
+    )
+    .order_by(FactSet.created_at.desc())
+    .limit(1)
+  ).scalar_one_or_none()
+
+
+def _write_lever_fact_set(
+  session: Session,
+  structure: Structure,
+  mechanics: ForecastMechanics,
+  entity_id: str,
+  created_by: str,
+) -> FactSet:
+  """Persist the lever assertions as authored facts in one scenario set."""
+  asserted_months = sorted({m for lv in mechanics.levers for m in lv.values_by_period})
+  span_start = period_date_range(asserted_months[0])[0]
+  span_end = period_date_range(asserted_months[-1])[1]
+
+  fact_set = create_fact_set(
+    session,
+    structure_id=structure.id,
+    scenario_id=structure.id,
+    period_start=span_start,
+    period_end=span_end,
+    factset_type="custom",
+    entity_id=entity_id,
+    provenance=AssertedProvenance(
+      source_system="forecast-levers", asserted_by=created_by
+    ),
+    created_by=created_by,
+  )
+  session.flush()
+
+  elements_by_id = {
+    e.id: e
+    for e in session.execute(
+      select(Element).where(Element.id.in_([lv.element_id for lv in mechanics.levers]))
+    )
+    .scalars()
+    .all()
+  }
+  for lever in mechanics.levers:
+    element = elements_by_id.get(lever.element_id)
+    unit = _metric_unit(element) if element is not None else "pure"
+    for month, value in sorted(lever.values_by_period.items()):
+      month_start, month_end = period_date_range(month)
+      session.add(
+        Fact(
+          id=generate_prefixed_ulid("fact"),
+          element_id=lever.element_id,
+          value=value,
+          fact_type="Numeric",
+          period_start=month_start,
+          period_end=month_end,
+          period_type="duration",
+          unit=unit,
+          entity_id=entity_id,
+          structure_id=structure.id,
+          fact_set_id=fact_set.id,
+        )
+      )
+  session.flush()
+  return fact_set
+
+
+def create(
+  session: Session,
+  payload: CreateForecastRequest,
+  created_by: str,
+) -> str:
+  """Create a forecast block. Persists the Structure + typed mechanics +
+  the lever FactSet; returns the new structure_id. Never computes —
+  run ``compute-forecast`` to derive the forward months.
+  """
+  entity_id = payload.entity_id or _default_entity_id(session)
+  base_period = _resolve_base_period(session, entity_id, payload.base_period)
+  levers = _expand_levers(session, payload.levers, base_period, payload.horizon_months)
+
+  mechanics = ForecastMechanics(
+    scenario_kind=payload.scenario_kind,
+    horizon_months=payload.horizon_months,
+    base_period=base_period,
+    levers=levers,
+  )
+
+  # The lever elements all live in the tenant's rs-driver taxonomy —
+  # the natural owner for the scenario container (rollforward precedent:
+  # owning taxonomy of the anchor element).
+  lever_element = session.get(Element, levers[0].element_id)
+  assert lever_element is not None  # resolved in _expand_levers
+  structure = Structure(
+    name=payload.name,
+    block_type=FORECAST_BLOCK_TYPE,
+    taxonomy_id=lever_element.taxonomy_id,
+    concept_arrangement="set",
+    member_arrangement=None,
+    artifact_mechanics=mechanics.model_dump(mode="json"),
+    metadata_={},
+    created_by=created_by,
+  )
+  session.add(structure)
+  session.flush()
+
+  _write_lever_fact_set(session, structure, mechanics, entity_id, created_by)
+  session.commit()
+  return structure.id
+
+
+def _load_forecast_or_404(session: Session, structure_id: str) -> Structure:
+  structure = session.get(Structure, structure_id)
+  if structure is None or structure.block_type != FORECAST_BLOCK_TYPE:
+    raise ValueError(
+      f"Forecast structure_id={structure_id!r} not found (or wrong block_type)."
+    )
+  return structure
+
+
+def update(
+  session: Session,
+  payload: UpdateForecastRequest,
+  updated_by: str,
+) -> str:
+  """Update a forecast block in place.
+
+  Mutable: name, scenario_kind, horizon_months, base_period, levers.
+  Changing ``horizon_months`` or ``base_period`` requires re-supplying
+  ``levers`` — the persisted expansion can't be re-derived (the
+  uniform-vs-override distinction is gone), so re-expansion needs the
+  wire-level assertions. A lever replacement rewrites the lever FactSet
+  wholesale. Previously computed scenario months are NOT recomputed —
+  they go stale until the next ``compute-forecast`` run.
+  """
+  structure = _load_forecast_or_404(session, payload.structure_id)
+  current = ForecastMechanics.model_validate(structure.artifact_mechanics or {})
+
+  if payload.name is not None:
+    structure.name = payload.name
+
+  scenario_kind = payload.scenario_kind or current.scenario_kind
+  horizon_months = payload.horizon_months or current.horizon_months
+  base_period = payload.base_period or current.base_period
+
+  window_changed = (
+    horizon_months != current.horizon_months or base_period != current.base_period
+  )
+  if window_changed and payload.levers is None:
+    raise ValueError(
+      "Changing horizon_months or base_period requires re-supplying `levers` "
+      "— the horizon window shifted, so every lever's per-month assertions "
+      "must be restated."
+    )
+
+  levers = current.levers
+  if payload.levers is not None:
+    levers = _expand_levers(session, payload.levers, base_period, horizon_months)
+
+  next_mechanics = ForecastMechanics(
+    scenario_kind=scenario_kind,
+    horizon_months=horizon_months,
+    base_period=base_period,
+    levers=levers,
+  )
+  structure.artifact_mechanics = next_mechanics.model_dump(mode="json")
+  structure.updated_by = updated_by
+
+  if payload.levers is not None:
+    existing = _load_lever_fact_set(session, structure.id)
+    entity_id = existing.entity_id if existing is not None else None
+    if existing is not None:
+      session.delete(existing)  # facts cascade via the DB FK
+      session.flush()
+    _write_lever_fact_set(
+      session,
+      structure,
+      next_mechanics,
+      entity_id or _default_entity_id(session),
+      updated_by,
+    )
+
+  session.flush()
+  session.commit()
+  return structure.id
+
+
+def delete(
+  session: Session,
+  payload: DeleteForecastRequest,
+  deleted_by: str,
+) -> str:
+  """Hard-delete a forecast block and its entire scenario slice.
+
+  Explicitly deletes every FactSet keyed to this scenario (the lever
+  set AND the computed forward statement/metric months — they attach to
+  OTHER structures, so the structure delete alone wouldn't reach them;
+  the DB-level ``scenario_id ... ON DELETE CASCADE`` is the backstop).
+  Actuals are never touched.
+  """
+  structure = _load_forecast_or_404(session, payload.structure_id)
+  structure_id = structure.id
+
+  for fact_set in (
+    session.execute(select(FactSet).where(FactSet.scenario_id == structure_id))
+    .scalars()
+    .all()
+  ):
+    session.delete(fact_set)
+  session.flush()
+
+  session.delete(structure)
+  session.commit()
+  return structure_id
+
+
+def build_envelope(
+  session: Session, structure_id: str, fact_set_id: str | None = None
+) -> InformationBlockEnvelope | None:
+  """Reload a forecast Structure and pack its envelope.
+
+  Renders the **lever grid** metric-style: one row per lever (authoring
+  order, ``item_type`` driving percent/days formatting), one period
+  column per horizon month, values from the mechanics' expanded
+  assertions. ``computed_months`` is filled from the scenario's derived
+  statement sets. No chart arm — the scenario's time-series surface is
+  the metric/statement blocks read with the scenario filter, not the
+  container itself.
+  """
+  atoms = load_base_envelope_atoms(
+    session,
+    structure_id,
+    expected_block_type=FORECAST_BLOCK_TYPE,
+    fact_set_id=fact_set_id,
+  )
+  if atoms is None:
+    return None
+  structure = atoms.structure
+
+  mechanics = ForecastMechanics.model_validate(structure.artifact_mechanics or {})
+
+  # Runtime state: how many forward months have computed scenario sets.
+  computed_months = (
+    session.execute(
+      select(FactSet.period_end)
+      .where(
+        FactSet.scenario_id == structure_id,
+        FactSet.factset_type == "report",
+      )
+      .distinct()
+    )
+    .scalars()
+    .all()
+  )
+  mechanics = mechanics.model_copy(update={"computed_months": len(computed_months)})
+
+  # Lever elements are not reachable via associations (the container is
+  # arc-less) — load them off the mechanics for the envelope's element
+  # list and the row metadata.
+  lever_elements = list(
+    session.execute(
+      select(Element).where(Element.id.in_([lv.element_id for lv in mechanics.levers]))
+    )
+    .scalars()
+    .all()
+  )
+  elements_by_id = {e.id: e for e in lever_elements}
+
+  months = [
+    add_months(mechanics.base_period, i) for i in range(1, mechanics.horizon_months + 1)
+  ]
+  rows = [
+    RenderingRowLite(
+      element_id=lever.element_id,
+      element_qname=lever.qname,
+      element_name=(
+        elements_by_id[lever.element_id].name
+        if lever.element_id in elements_by_id
+        else lever.qname
+      ),
+      balance_type=None,
+      item_type=lever.item_type,
+      values=[lever.values_by_period.get(month) for month in months],
+    )
+    for lever in mechanics.levers
+  ]
+  rendering = RenderingLite(
+    rows=rows,
+    periods=[
+      RenderingPeriodLite(
+        start=period_date_range(month)[0],
+        end=period_date_range(month)[1],
+      )
+      for month in months
+    ],
+    validation=None,
+    unmapped_count=0,
+  )
+
+  lever_set = _load_lever_fact_set(session, structure_id)
+  facts: list[Fact] = []
+  if lever_set is not None:
+    facts = list(
+      session.execute(select(Fact).where(Fact.fact_set_id == lever_set.id))
+      .scalars()
+      .all()
+    )
+
+  return InformationBlockEnvelope(
+    id=structure.id,
+    block_type=FORECAST_BLOCK_TYPE,
+    name=structure.name,
+    display_name=FORECAST_DISPLAY_NAME,
+    category=FORECAST_CATEGORY,
+    taxonomy_id=structure.taxonomy_id,
+    taxonomy_name=atoms.taxonomy_name,
+    information_model=InformationModelResponse(
+      concept_arrangement=structure.concept_arrangement or "set",
+      member_arrangement=structure.member_arrangement,
+    ),
+    artifact=ArtifactResponse(
+      topic=structure.description,
+      renderer_note=structure.renderer_note,
+      template=None,
+      mechanics=mechanics,
+    ),
+    elements=[element_to_lite(e) for e in lever_elements],
+    connections=[],
+    facts=[fact_to_lite(f, elements_by_id) for f in facts],
+    rules=atoms.rules,
+    fact_set=fact_set_to_lite(lever_set) if lever_set is not None else None,
+    verification_results=atoms.verification_results,
+    verification_summary=atoms.verification_summary,
+    view=ViewProjections(rendering=rendering, chart=None),
+  )
+
+
+__all__ = [
+  "FORECAST_BLOCK_TYPE",
+  "FORECAST_CATEGORY",
+  "FORECAST_DISPLAY_NAME",
+  "build_envelope",
+  "create",
+  "delete",
+  "update",
+]

--- a/robosystems/operations/information_block/forecast_compute.py
+++ b/robosystems/operations/information_block/forecast_compute.py
@@ -1,0 +1,684 @@
+"""compute-forecast — walk a scenario's driver cascade into forward FactSets.
+
+The forecast engine's derivation path (FP&A F-1). The forecast block
+(:mod:`.forecast`) holds the authored surface — scenario identity +
+lever assertions; this module derives everything downstream, one forward
+month at a time from the block's ``base_period``:
+
+1. **Carry-forward** — every IS leaf that carried a fact in the base
+   month's actual report and isn't rule-driven repeats its prior value
+   (the engine default for unmodeled lines — no rules involved).
+2. **Driver rules** — the rs-driver catalog's ``Derive`` rules, in
+   dependency order (``topo_sort_calculations`` over same-month operand
+   edges). A rule is *active* for the scenario iff every rs-driver
+   operand it names has asserted lever values; lever values bind from
+   the scenario's lever FactSet, ``$X[t-1]`` operands bind the previous
+   month's value (:func:`expressions.desugar_priors` — the documented
+   avg() sibling seam), and same-month rs-gaap operands bind the
+   current month's computed values (prior month as fallback).
+3. **Calc-DAG subtotals** — ``resolve_calc_dag`` over the merged
+   rs-gaap-calculations + local IS arcs derives GrossProfit →
+   OperatingIncome → NetIncome exactly the way the report pivot does
+   (articulation is reuse, not new math).
+
+Each month upserts one scenario IS FactSet (``factset_type='report'``,
+congruent with the actual monthly sets so statement envelopes render
+scenario columns unchanged) plus a working-capital BS set (AR/AP
+instants only — the full BS roll is F-2), all keyed by
+``fact_sets.scenario_id`` = the forecast block. Re-running a month
+replaces its values (the compute-metrics drift semantics). Soft-fail
+per rule per month: a missing lever month or unbound operand skips that
+rule with a reason and its target falls back to carry-forward — one
+broken rule never aborts the walk.
+
+Deterministic and non-AI — free under the credit model. The Operator
+that *proposes* lever values is the credit-consuming layer on top.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from sqlalchemy import select
+
+from robosystems.models.api.fact_provenance import ForecastProvenance
+from robosystems.models.api.information_block import (
+  ComputeForecastRequest,
+  ComputeForecastResponse,
+  ForecastMechanics,
+  ForecastMonthLite,
+  SkippedForecastLite,
+)
+from robosystems.models.extensions import (
+  Association,
+  Element,
+  Rule,
+  Structure,
+  Taxonomy,
+)
+from robosystems.models.extensions.roboledger.fact import Fact
+from robosystems.models.extensions.roboledger.fact_set import FactSet
+from robosystems.operations.information_block.forecast import (
+  FORECAST_BLOCK_TYPE,
+  _load_lever_fact_set,
+)
+from robosystems.operations.information_block.metrics import (
+  _default_entity_id,
+  _metric_unit,
+)
+from robosystems.operations.information_block.rules.expressions import (
+  InvalidRuleExpression,
+  desugar_aggregates,
+  desugar_priors,
+  evaluate_derivation,
+  lhs_variable_names,
+  parse_arithmetic_expression,
+)
+from robosystems.operations.roboledger.fact_set import create_fact_set
+from robosystems.operations.roboledger.fiscal_calendar.periods import (
+  add_months,
+  period_date_range,
+  period_from_date,
+)
+from robosystems.operations.roboledger.reports.calc_dag import (
+  load_rs_gaap_calculations,
+  merge_calculations,
+  resolve_calc_dag,
+  topo_sort_calculations,
+)
+from robosystems.utils.ulid import generate_prefixed_ulid
+
+if TYPE_CHECKING:
+  from datetime import date
+
+  from sqlalchemy.orm import Session
+
+_DRIVER_STANDARD = "rs-driver"
+_DRIVER_PREFIX = "rs-driver:"
+
+
+@dataclass
+class _ActiveRule:
+  """A driver rule resolved + activated for this scenario run."""
+
+  rule: Rule
+  target: Element
+  qname_by_name: dict[str, str]
+  operand_names: list[str]
+
+
+def _newest_actual_structure_id(session: Session, block_type: str) -> str | None:
+  """Structure behind the entity's newest actual report set of a block type.
+
+  Data-driven (never by name) — multi-variant reporting styles mean the
+  'income_statement' structure a tenant actually reports under is
+  whichever one its newest actual ``'report'`` FactSet instantiates.
+  """
+  return session.execute(
+    select(FactSet.structure_id)
+    .join(Structure, FactSet.structure_id == Structure.id)
+    .where(
+      FactSet.factset_type == "report",
+      FactSet.scenario_id.is_(None),
+      Structure.block_type == block_type,
+    )
+    .order_by(FactSet.created_at.desc())
+    .limit(1)
+  ).scalar()
+
+
+def _actual_set_at(
+  session: Session,
+  structure_id: str,
+  entity_id: str,
+  period_start: date,
+  period_end: date,
+) -> FactSet | None:
+  """The newest actual report set for a structure at exactly one month.
+
+  The ``period_start >= period_start`` bound is load-bearing: the final
+  monthly period_end coincides with the FY end, and without the window
+  guard the ANNUAL comparative set (created later) would win and seed
+  ``Revenues[t-1]`` with the FY column instead of the month.
+  """
+  return session.execute(
+    select(FactSet)
+    .where(
+      FactSet.structure_id == structure_id,
+      FactSet.factset_type == "report",
+      FactSet.scenario_id.is_(None),
+      FactSet.entity_id == entity_id,
+      FactSet.period_end == period_end,
+      FactSet.period_start >= period_start,
+    )
+    .order_by(FactSet.created_at.desc())
+    .limit(1)
+  ).scalar_one_or_none()
+
+
+def _numeric_facts(session: Session, fact_set_id: str) -> list[Fact]:
+  return list(
+    session.execute(
+      select(Fact).where(
+        Fact.fact_set_id == fact_set_id,
+        Fact.fact_scope == "in_scope",
+        Fact.value.is_not(None),
+      )
+    )
+    .scalars()
+    .all()
+  )
+
+
+def _load_driver_rules(session: Session) -> list[Rule]:
+  """Every Derive rule seeded by the rs-driver catalog (tenant copy)."""
+  taxonomy_ids = (
+    session.execute(select(Taxonomy.id).where(Taxonomy.standard == _DRIVER_STANDARD))
+    .scalars()
+    .all()
+  )
+  if not taxonomy_ids:
+    return []
+  return list(
+    session.execute(
+      select(Rule)
+      .where(Rule.taxonomy_id.in_(taxonomy_ids), Rule.rule_pattern == "Derive")
+      .order_by(Rule.id)
+    )
+    .scalars()
+    .all()
+  )
+
+
+def _local_calc_arcs(
+  session: Session, structure_id: str
+) -> dict[str, list[tuple[str, float]]]:
+  """A structure's own calculation arcs as a parent → children map."""
+  rows = (
+    session.execute(
+      select(Association).where(
+        Association.structure_id == structure_id,
+        Association.association_type == "calculation",
+      )
+    )
+    .scalars()
+    .all()
+  )
+  local: dict[str, list[tuple[str, float]]] = {}
+  for a in rows:
+    if a.from_element_id is None or a.to_element_id is None:
+      continue
+    weight = float(a.weight) if a.weight is not None else 1.0
+    local.setdefault(a.from_element_id, []).append((a.to_element_id, weight))
+  return local
+
+
+def cmd_compute_forecast(
+  session: Session,
+  body: ComputeForecastRequest,
+  created_by: str,
+) -> ComputeForecastResponse:
+  """Walk the scenario's driver cascade and upsert its forward FactSets.
+
+  ``session.flush()`` before returning; the OperationSpec wrapper owns
+  the commit.
+  """
+  structure = session.get(Structure, body.structure_id)
+  if structure is None:
+    raise ValueError(f"Structure not found: {body.structure_id}")
+  if structure.block_type != FORECAST_BLOCK_TYPE:
+    raise ValueError(
+      f"compute-forecast targets a block_type='forecast' structure; "
+      f"{body.structure_id!r} is {structure.block_type!r}"
+    )
+  scenario_id = structure.id
+  mechanics = ForecastMechanics.model_validate(structure.artifact_mechanics or {})
+
+  months_n = body.months or mechanics.horizon_months
+  if months_n > mechanics.horizon_months:
+    raise ValueError(
+      f"months={months_n} exceeds the block's horizon_months="
+      f"{mechanics.horizon_months} — lever assertions don't extend past "
+      "the horizon."
+    )
+
+  lever_set = _load_lever_fact_set(session, scenario_id)
+  if lever_set is None:
+    raise ValueError(
+      f"Forecast {scenario_id!r} has no lever FactSet — the block is "
+      "corrupt; re-create it via update-information-block."
+    )
+  entity_id = body.entity_id or lever_set.entity_id or _default_entity_id(session)
+
+  # Lever VALUES bind from the scenario's authored facts (facts are the
+  # values; the mechanics copy is the legible round-trip shape).
+  element_qname_by_id: dict[str, str] = {
+    lv.element_id: lv.qname for lv in mechanics.levers
+  }
+  lever_values: dict[str, dict[str, float]] = {}
+  for fact in _numeric_facts(session, lever_set.id):
+    qname = element_qname_by_id.get(fact.element_id)
+    if qname is None or fact.value is None:
+      continue
+    month = period_from_date(fact.period_end)
+    lever_values.setdefault(qname, {})[month] = float(fact.value)
+
+  # ── Resolve the actual structures + seed month ────────────────────────
+  is_structure_id = _newest_actual_structure_id(session, "income_statement")
+  if is_structure_id is None:
+    raise ValueError(
+      "No actual income-statement report FactSet exists — generate at "
+      "least one report before computing a forecast."
+    )
+  bs_structure_id = _newest_actual_structure_id(session, "balance_sheet")
+
+  base_start, base_end = period_date_range(mechanics.base_period)
+  base_is_set = _actual_set_at(
+    session, is_structure_id, entity_id, base_start, base_end
+  )
+  if base_is_set is None:
+    raise ValueError(
+      f"No actual income-statement report at the base period "
+      f"{mechanics.base_period} (a monthly report whose window starts "
+      f"{base_start} and ends {base_end}). Generate monthly reports "
+      "through the base period, or set base_period to a month that has "
+      "one."
+    )
+
+  prior_values: dict[str, float] = {}
+  base_is_element_ids: list[str] = []
+  for fact in _numeric_facts(session, base_is_set.id):
+    if fact.value is None:
+      continue
+    if fact.element_id not in prior_values:
+      base_is_element_ids.append(fact.element_id)
+    prior_values[fact.element_id] = float(fact.value)
+
+  # BS instants seed [t-1]/carry context for balance-driven rules.
+  if bs_structure_id is not None:
+    base_bs_set = _actual_set_at(
+      session, bs_structure_id, entity_id, base_start, base_end
+    )
+    if base_bs_set is not None:
+      for fact in _numeric_facts(session, base_bs_set.id):
+        if fact.value is not None and fact.element_id not in prior_values:
+          prior_values[fact.element_id] = float(fact.value)
+
+  # ── Activate driver rules for this scenario ───────────────────────────
+  qname_cache: dict[str, Element | None] = {}
+
+  def _element_by_qname(qname: str) -> Element | None:
+    if qname not in qname_cache:
+      qname_cache[qname] = session.execute(
+        select(Element).where(Element.qname == qname).limit(1)
+      ).scalar_one_or_none()
+    return qname_cache[qname]
+
+  skipped: list[SkippedForecastLite] = []
+  active_rules: list[_ActiveRule] = []
+  for rule in _load_driver_rules(session):
+    variables = rule.rule_variables or []
+    names = [v.get("variable_name") for v in variables if isinstance(v, dict)]
+    if not all(isinstance(n, str) and n for n in names):
+      continue
+    qname_by_name: dict[str, str] = {
+      v["variable_name"]: v["variable_qname"]
+      for v in variables
+      if isinstance(v, dict) and isinstance(v.get("variable_qname"), str)
+    }
+    lever_qnames = [q for q in qname_by_name.values() if q.startswith(_DRIVER_PREFIX)]
+    # Active iff every lever operand has asserted values in this scenario.
+    if not lever_qnames or any(q not in lever_values for q in lever_qnames):
+      continue
+    target_element = (
+      session.get(Element, rule.target_element_id) if rule.target_element_id else None
+    )
+    if target_element is None:
+      skipped.append(
+        SkippedForecastLite(
+          rule_id=rule.id,
+          element_qname=None,
+          period=mechanics.base_period,
+          reason="rule has no resolvable target element",
+        )
+      )
+      continue
+    active_rules.append(
+      _ActiveRule(
+        rule=rule,
+        target=target_element,
+        qname_by_name=qname_by_name,
+        operand_names=[n for n in names if isinstance(n, str)],
+      )
+    )
+
+  # Same-month dependency order: an operand qname naming another active
+  # rule's target is a same-period edge. Synthesized __prior_* operands
+  # are excluded by construction (they bind the PREVIOUS month), so
+  # compounding self-reference cannot create a cycle.
+  active_by_target_qname = {
+    ar.target.qname: ar for ar in active_rules if ar.target.qname
+  }
+  dependency_map: dict[str, list[tuple[str, float]]] = {}
+  for ar in active_rules:
+    if not ar.target.qname:
+      continue
+    same_month_deps = {
+      q
+      for q in ar.qname_by_name.values()
+      if q != ar.target.qname and q in active_by_target_qname
+    }
+    dependency_map[ar.target.qname] = [(q, 1.0) for q in same_month_deps]
+  ordered_active = [
+    active_by_target_qname[q]
+    for q in topo_sort_calculations(dependency_map)
+    if q in active_by_target_qname
+  ]
+
+  active_target_ids = {ar.target.id for ar in active_rules}
+  active_driver_qnames = sorted(
+    {
+      q
+      for ar in active_rules
+      for q in ar.qname_by_name.values()
+      if q.startswith(_DRIVER_PREFIX)
+    }
+  )
+
+  # ── Calc DAG + carry pool ─────────────────────────────────────────────
+  calculations = merge_calculations(
+    load_rs_gaap_calculations(session), _local_calc_arcs(session, is_structure_id)
+  )
+  calc_order = topo_sort_calculations(calculations)
+  calc_targets = set(calculations.keys())
+  carry_pool = [
+    el
+    for el in base_is_element_ids
+    if el not in calc_targets and el not in active_target_ids
+  ]
+
+  elements_by_id: dict[str, Element] = {}
+
+  def _element(element_id: str) -> Element | None:
+    if element_id not in elements_by_id:
+      loaded = session.get(Element, element_id)
+      if loaded is not None:
+        elements_by_id[element_id] = loaded
+    return elements_by_id.get(element_id)
+
+  # ── The walk ──────────────────────────────────────────────────────────
+  months_computed: list[ForecastMonthLite] = []
+  months = [add_months(mechanics.base_period, i) for i in range(1, months_n + 1)]
+
+  for month_index, month in enumerate(months, start=1):
+    month_start, month_end = period_date_range(month)
+    current: dict[str, float] = {}
+
+    # (a) Carry-forward — unmodeled IS leaves repeat their prior value.
+    for element_id in carry_pool:
+      if element_id in prior_values:
+        current[element_id] = prior_values[element_id]
+
+    # (b) Driver rules in same-month dependency order.
+    for ar in ordered_active:
+      raw = ar.rule.rule_expression if isinstance(ar.rule.rule_expression, str) else ""
+      expr, prior_operands = desugar_priors(raw)
+      expr, avg_operands = desugar_aggregates(expr)
+      try:
+        parsed = parse_arithmetic_expression(
+          expr, ar.operand_names + list(prior_operands) + list(avg_operands)
+        )
+        lhs_names = lhs_variable_names(parsed)
+      except InvalidRuleExpression as exc:
+        skipped.append(
+          SkippedForecastLite(
+            rule_id=ar.rule.id,
+            element_qname=ar.target.qname,
+            period=month,
+            reason=f"expression error: {exc}",
+          )
+        )
+        continue
+      if len(lhs_names) != 1:
+        skipped.append(
+          SkippedForecastLite(
+            rule_id=ar.rule.id,
+            element_qname=ar.target.qname,
+            period=month,
+            reason=f"expected a single LHS variable, got {lhs_names!r}",
+          )
+        )
+        continue
+
+      values: dict[str, float] = {}
+      missing: list[str] = []
+      for name in ar.operand_names:
+        if name == lhs_names[0]:
+          continue
+        qname = ar.qname_by_name.get(name)
+        if qname is None:
+          missing.append(name)
+          continue
+        if qname.startswith(_DRIVER_PREFIX):
+          lever_month_values = lever_values.get(qname, {})
+          if month not in lever_month_values:
+            missing.append(f"{qname} (lever not asserted for {month})")
+            continue
+          values[name] = lever_month_values[month]
+          continue
+        operand_element = _element_by_qname(qname)
+        if operand_element is None:
+          missing.append(qname)
+          continue
+        # Same-month value first (carried or rule-computed earlier in the
+        # topo order), prior month as the fallback — a subtotal base like
+        # Revenues-as-rollup still binds even when its rule is inactive.
+        if operand_element.id in current:
+          values[name] = current[operand_element.id]
+        elif operand_element.id in prior_values:
+          values[name] = prior_values[operand_element.id]
+        else:
+          missing.append(qname)
+
+      for synth_name, base_name in prior_operands.items():
+        qname = ar.qname_by_name.get(base_name)
+        operand_element = _element_by_qname(qname) if qname else None
+        if operand_element is None:
+          missing.append(qname or base_name)
+          continue
+        if operand_element.id in prior_values:
+          values[synth_name] = prior_values[operand_element.id]
+        else:
+          missing.append(f"{qname}[t-1] (no prior value)")
+
+      for synth_name in avg_operands:
+        # No driver rule uses avg() today; binding it would need a
+        # begin/end pair the walk doesn't track. Honest skip.
+        missing.append(f"{synth_name} (avg() unsupported in compute-forecast)")
+
+      if missing:
+        skipped.append(
+          SkippedForecastLite(
+            rule_id=ar.rule.id,
+            element_qname=ar.target.qname,
+            period=month,
+            reason="unbound operand(s)",
+            missing=missing,
+          )
+        )
+        continue
+
+      try:
+        value = evaluate_derivation(parsed, values)
+      except InvalidRuleExpression as exc:
+        skipped.append(
+          SkippedForecastLite(
+            rule_id=ar.rule.id,
+            element_qname=ar.target.qname,
+            period=month,
+            reason=f"evaluation error: {exc}",
+          )
+        )
+        continue
+      current[ar.target.id] = value
+
+    # A skipped rule's target falls back to carry-forward for the month —
+    # the honest default, and it keeps the cascade fed for dependents.
+    for element_id in active_target_ids:
+      if element_id not in current and element_id in prior_values:
+        current[element_id] = prior_values[element_id]
+
+    # (c) Calc-DAG subtotals — derive, never carry (present = direct wins).
+    resolved = resolve_calc_dag(current, set(current), calculations, calc_order)
+
+    # (d) Upsert the month's scenario sets.
+    provenance = ForecastProvenance(
+      scenario_structure_id=scenario_id,
+      base_period=mechanics.base_period,
+      month_index=month_index,
+      drivers=active_driver_qnames,
+    )
+
+    is_facts: list[tuple[Element, float]] = []
+    for element_id in base_is_element_ids:
+      element = _element(element_id)
+      if element is None or element_id not in resolved:
+        continue
+      is_facts.append((element, resolved[element_id]))
+
+    bs_facts: list[tuple[Element, float]] = []
+    for ar in ordered_active:
+      if ar.target.id in current and ar.target.period_type == "instant":
+        bs_facts.append((ar.target, current[ar.target.id]))
+
+    is_set_id = _upsert_month_set(
+      session,
+      structure_id=is_structure_id,
+      entity_id=entity_id,
+      scenario_id=scenario_id,
+      period_start=month_start,
+      period_end=month_end,
+      provenance=provenance,
+      created_by=created_by,
+      facts=is_facts,
+    )
+    bs_set_id = None
+    if bs_structure_id is not None and bs_facts:
+      bs_set_id = _upsert_month_set(
+        session,
+        structure_id=bs_structure_id,
+        entity_id=entity_id,
+        scenario_id=scenario_id,
+        period_start=month_start,
+        period_end=month_end,
+        provenance=provenance,
+        created_by=created_by,
+        facts=bs_facts,
+      )
+
+    months_computed.append(
+      ForecastMonthLite(
+        period=month,
+        period_start=month_start,
+        period_end=month_end,
+        income_statement_fact_set_id=is_set_id,
+        balance_sheet_fact_set_id=bs_set_id,
+        computed_count=len(is_facts) + len(bs_facts),
+      )
+    )
+
+    # (e) Roll the window: next month's [t-1]/carry context is this
+    # month's resolved IS values + the balance instants.
+    prior_values.clear()
+    for element, value in is_facts:
+      prior_values[element.id] = value
+    for element, value in bs_facts:
+      prior_values[element.id] = value
+
+  session.flush()
+  return ComputeForecastResponse(
+    structure_id=structure.id,
+    scenario_id=scenario_id,
+    entity_id=entity_id,
+    base_period=mechanics.base_period,
+    months=months_n,
+    months_computed=months_computed,
+    skipped=skipped,
+  )
+
+
+def _upsert_month_set(
+  session: Session,
+  *,
+  structure_id: str,
+  entity_id: str,
+  scenario_id: str,
+  period_start: date,
+  period_end: date,
+  provenance: ForecastProvenance,
+  created_by: str,
+  facts: list[tuple[Element, float]],
+) -> str | None:
+  """Upsert one scenario standing set — the metrics full-replace pattern,
+  keyed by (structure, entity, factset_type, period_end, **scenario**)."""
+  if not facts:
+    return None
+  standing = session.execute(
+    select(FactSet)
+    .where(
+      FactSet.structure_id == structure_id,
+      FactSet.factset_type == "report",
+      FactSet.entity_id == entity_id,
+      FactSet.period_end == period_end,
+      FactSet.scenario_id == scenario_id,
+    )
+    .order_by(FactSet.created_at.desc())
+    .limit(1)
+  ).scalar_one_or_none()
+
+  if standing is None:
+    standing = create_fact_set(
+      session,
+      structure_id=structure_id,
+      period_start=period_start,
+      period_end=period_end,
+      factset_type="report",
+      entity_id=entity_id,
+      scenario_id=scenario_id,
+      provenance=provenance,
+      created_by=created_by,
+    )
+    session.flush()
+  else:
+    # Full replace — the month's values are re-derived state.
+    for fact in (
+      session.execute(select(Fact).where(Fact.fact_set_id == standing.id))
+      .scalars()
+      .all()
+    ):
+      session.delete(fact)
+    standing.provenance = provenance.model_dump(mode="json")
+
+  for element, value in facts:
+    period_type = element.period_type or "duration"
+    session.add(
+      Fact(
+        id=generate_prefixed_ulid("fact"),
+        element_id=element.id,
+        value=value,
+        fact_type="Numeric",
+        period_start=None if period_type == "instant" else period_start,
+        period_end=period_end,
+        period_type=period_type,
+        unit=_metric_unit(element),
+        entity_id=entity_id,
+        structure_id=structure_id,
+        fact_set_id=standing.id,
+      )
+    )
+  session.flush()
+  return standing.id
+
+
+__all__ = ["cmd_compute_forecast"]

--- a/robosystems/operations/information_block/metric.py
+++ b/robosystems/operations/information_block/metric.py
@@ -49,7 +49,10 @@ METRIC_CATEGORY = "Reporting"
 
 
 def _load_metric_fact_sets(
-  session: Session, structure_id: str, fact_set_id: str | None
+  session: Session,
+  structure_id: str,
+  fact_set_id: str | None,
+  scenario_id: str | None = None,
 ) -> list[FactSet]:
   """The structure's standing metric FactSets, oldest period first.
 
@@ -58,6 +61,12 @@ def _load_metric_fact_sets(
   structure is a period column; when several sets share a period_end
   (defensive — the compute op upserts one per (entity, period_end)),
   the newest wins.
+
+  ``scenario_id=None`` loads the actual series only. A non-None value
+  loads actuals AND that scenario's sets merged into one continuous
+  series — with **actuals preferred** where both cover a period_end
+  (the moving seam: a month that closes after the forecast was computed
+  reads as actual, never as the stale projection).
   """
   if fact_set_id is not None:
     row = session.get(FactSet, fact_set_id)
@@ -68,8 +77,17 @@ def _load_metric_fact_sets(
       .where(
         FactSet.structure_id == structure_id,
         FactSet.factset_type == "metric",
+        FactSet.scenario_id.is_(None)
+        if scenario_id is None
+        else FactSet.scenario_id.is_(None) | (FactSet.scenario_id == scenario_id),
       )
-      .order_by(FactSet.period_end.asc(), FactSet.created_at.desc())
+      # Actuals (NULL scenario) sort before scenario sets per period so
+      # the seam prefers them; newest-first within each slice.
+      .order_by(
+        FactSet.period_end.asc(),
+        FactSet.scenario_id.asc().nulls_first(),
+        FactSet.created_at.desc(),
+      )
     )
     .scalars()
     .all()
@@ -81,7 +99,10 @@ def _load_metric_fact_sets(
 
 
 def build_envelope(
-  session: Session, structure_id: str, fact_set_id: str | None = None
+  session: Session,
+  structure_id: str,
+  fact_set_id: str | None = None,
+  scenario_id: str | None = None,
 ) -> InformationBlockEnvelope | None:
   """Pack a metric Structure + its standing time series into the envelope.
 
@@ -91,18 +112,23 @@ def build_envelope(
   metric — e.g. InterestCoverage skipped for a debt-free year). A
   never-computed block renders the catalog skeleton: rows with no
   period columns.
+
+  ``scenario_id`` extends the series with that scenario's forward
+  columns (actuals preferred at any overlap — the moving seam); the
+  scenario-sourced columns carry ``"... (forecast)"`` period labels.
   """
   atoms = load_base_envelope_atoms(
     session,
     structure_id,
     expected_block_type=METRIC_BLOCK_TYPE,
     fact_set_id=fact_set_id,
+    scenario_id=scenario_id,
   )
   if atoms is None:
     return None
   structure = atoms.structure
 
-  fact_sets = _load_metric_fact_sets(session, structure_id, fact_set_id)
+  fact_sets = _load_metric_fact_sets(session, structure_id, fact_set_id, scenario_id)
 
   facts: list[Fact] = []
   if fact_sets:
@@ -147,6 +173,13 @@ def build_envelope(
       RenderingPeriodLite(
         start=fs.period_start if fs.period_start is not None else fs.period_end,
         end=fs.period_end,
+        # Scenario-sourced columns are labeled honestly; actual columns
+        # keep label=None and the frontend formats dates as today.
+        label=(
+          f"{fs.period_end.strftime('%b %Y')} (forecast)"
+          if fs.scenario_id is not None
+          else None
+        ),
       )
       for fs in fact_sets
     ],

--- a/robosystems/operations/information_block/metrics.py
+++ b/robosystems/operations/information_block/metrics.py
@@ -103,6 +103,7 @@ def _bind_operand(
   entity_id: str,
   period_end: date,
   period_start: date | None,
+  scenario_id: str | None = None,
 ) -> _BoundOperand | None:
   """Most recent persisted fact for one operand at ``period_end``.
 
@@ -115,12 +116,22 @@ def _bind_operand(
   period; among same-set candidates the longest window wins (FY over Q4
   when both end on the date). No qname can collide across the two set
   types: metric facts land only on metric-namespace elements.
+
+  ``scenario_id=None`` binds actuals only (``scenario_id IS NULL`` —
+  the pin that keeps forward scenario facts out of every actual
+  compute). Non-None binds the scenario's facts WITH actuals as the
+  fallback, scenario preferred — the moving seam: a forward month's
+  operands resolve from the scenario slice while an ``avg()`` begin
+  bind at the seam still reaches the actual base month.
   """
   stmt = (
     select(Fact.value, Fact.period_start)
     .join(FactSet, Fact.fact_set_id == FactSet.id)
     .where(
       FactSet.factset_type.in_(("report", "metric")),
+      FactSet.scenario_id.is_(None)
+      if scenario_id is None
+      else or_(FactSet.scenario_id.is_(None), FactSet.scenario_id == scenario_id),
       Fact.entity_id == entity_id,
       Fact.element_id == element_id,
       Fact.period_end == period_end,
@@ -128,6 +139,7 @@ def _bind_operand(
       Fact.value.is_not(None),
     )
     .order_by(
+      FactSet.scenario_id.asc().nulls_last(),
       FactSet.created_at.desc(),
       Fact.period_start.asc().nulls_first(),
     )
@@ -144,7 +156,10 @@ def _bind_operand(
 
 
 def _latest_report_period_end_before(
-  session: Session, entity_id: str, before: date
+  session: Session,
+  entity_id: str,
+  before: date,
+  scenario_id: str | None = None,
 ) -> date | None:
   """The entity's newest report-fact ``period_end`` strictly before a date.
 
@@ -152,6 +167,9 @@ def _latest_report_period_end_before(
   request nor a bound duration operand supplies a window: annual
   comparatives resolve to the prior FY end, monthly series to the prior
   month end. Report facts only — the canonical period spine.
+  ``scenario_id`` widens the spine to include the scenario's forward
+  months (a forward month's prior is usually the previous forward
+  month); ``None`` pins actuals.
   """
   return session.execute(
     select(func.max(Fact.period_end))
@@ -159,6 +177,9 @@ def _latest_report_period_end_before(
     .join(FactSet, Fact.fact_set_id == FactSet.id)
     .where(
       FactSet.factset_type == "report",
+      FactSet.scenario_id.is_(None)
+      if scenario_id is None
+      else or_(FactSet.scenario_id.is_(None), FactSet.scenario_id == scenario_id),
       Fact.entity_id == entity_id,
       Fact.period_end < before,
       Fact.fact_scope == "in_scope",
@@ -310,7 +331,9 @@ def cmd_compute_metrics(
   def _data_driven_prior() -> date | None:
     if not _prior_cache:
       _prior_cache.append(
-        _latest_report_period_end_before(session, entity_id, body.period_end)
+        _latest_report_period_end_before(
+          session, entity_id, body.period_end, body.scenario_id
+        )
       )
     return _prior_cache[0]
 
@@ -380,6 +403,7 @@ def cmd_compute_metrics(
         entity_id=entity_id,
         period_end=body.period_end,
         period_start=body.period_start,
+        scenario_id=body.scenario_id,
       )
       if bound is None:
         if qname and qname in run_target_qnames:
@@ -414,6 +438,7 @@ def cmd_compute_metrics(
         entity_id=entity_id,
         period_end=begin_date,
         period_start=None,
+        scenario_id=body.scenario_id,
       )
       if begin_bound is None:
         missing.append(f"{qname} (prior @ {begin_date})")
@@ -475,6 +500,11 @@ def cmd_compute_metrics(
       FactSet.factset_type == "metric",
       FactSet.entity_id == entity_id,
       FactSet.period_end == body.period_end,
+      # Scenario slices keep their own standing sets — an actual compute
+      # never replaces a scenario month and vice versa.
+      FactSet.scenario_id.is_(None)
+      if body.scenario_id is None
+      else FactSet.scenario_id == body.scenario_id,
     )
     .order_by(FactSet.created_at.desc())
     .limit(1)
@@ -488,6 +518,7 @@ def cmd_compute_metrics(
       period_end=body.period_end,
       factset_type="metric",
       entity_id=entity_id,
+      scenario_id=body.scenario_id,
       provenance=provenance,
       created_by=created_by,
     )

--- a/robosystems/operations/information_block/metrics.py
+++ b/robosystems/operations/information_block/metrics.py
@@ -60,7 +60,11 @@ from robosystems.models.extensions import (
 )
 from robosystems.models.extensions.roboledger.fact import Fact
 from robosystems.models.extensions.roboledger.fact_set import FactSet
-from robosystems.operations.information_block.registry import METRIC_BLOCK_TYPE
+
+# From the envelope module (which owns the constant), NOT the registry —
+# the registry imports every handler module, so a registry import from a
+# module the handlers reach (forecast → metrics) would be circular.
+from robosystems.operations.information_block.metric import METRIC_BLOCK_TYPE
 from robosystems.operations.information_block.rules.expressions import (
   InvalidRuleExpression,
   desugar_aggregates,

--- a/robosystems/operations/information_block/reads.py
+++ b/robosystems/operations/information_block/reads.py
@@ -27,6 +27,7 @@ def get_information_block(
   session: Session,
   structure_id: str,
   fact_set_id: str | None = None,
+  scenario_id: str | None = None,
 ) -> InformationBlockEnvelope | None:
   """Fetch one block by id, dispatching via the structure's block_type.
 
@@ -34,7 +35,15 @@ def get_information_block(
   registered — callers map that to a GraphQL null / REST 404. When
   ``fact_set_id`` is provided the envelope is rehydrated from that
   specific FactSet instead of the latest one (used by Report Block
-  rehydration to surface a frozen snapshot).
+  rehydration to surface a frozen snapshot) and ``scenario_id`` is
+  ignored — an explicit pin bypasses scenario selection.
+
+  ``scenario_id`` selects the FactSet slice the envelope binds:
+  ``None`` = actuals; a forecast block's structure id = that scenario
+  (statement envelopes bind its latest computed month, metric envelopes
+  extend the series with its forward columns). Block types without
+  scenario slices (schedule, rollforward, disclosure) accept and
+  ignore it.
   """
   structure = session.get(Structure, structure_id)
   if structure is None:
@@ -46,7 +55,9 @@ def get_information_block(
     # surface as ``None`` rather than raising — the envelope just can't
     # be built.
     return None
-  return entry.dispatch_build_envelope(session, structure_id, fact_set_id)
+  return entry.dispatch_build_envelope(
+    session, structure_id, fact_set_id, scenario_id=scenario_id
+  )
 
 
 def get_information_block_for_fact_set(
@@ -77,6 +88,7 @@ def list_information_blocks(
   limit: int = 50,
   offset: int = 0,
   library_sentinel: bool = False,
+  scenario_id: str | None = None,
 ) -> list[InformationBlockEnvelope]:
   """List blocks with optional block_type + category filters.
 
@@ -88,6 +100,10 @@ def list_information_blocks(
 
   On a tenant graph_id (``library_sentinel=False``), no such filter
   applies.
+
+  ``scenario_id`` threads into each envelope's FactSet binding (see
+  :func:`get_information_block`) — the Structure selection itself is
+  scenario-independent.
   """
   # Resolve the candidate block_type id set based on the sentinel flag
   # and any explicit caller-supplied filter.
@@ -148,7 +164,9 @@ def list_information_blocks(
       entry = registry_module.get(structure.block_type)
     except KeyError:
       continue
-    envelope = entry.dispatch_build_envelope(session, structure.id)
+    envelope = entry.dispatch_build_envelope(
+      session, structure.id, None, scenario_id=scenario_id
+    )
     if envelope is not None:
       envelopes.append(envelope)
   return envelopes

--- a/robosystems/operations/information_block/registry.py
+++ b/robosystems/operations/information_block/registry.py
@@ -17,6 +17,11 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict
 
+from robosystems.models.api.extensions.forecasts import (
+  CreateForecastRequest,
+  DeleteForecastRequest,
+  UpdateForecastRequest,
+)
 from robosystems.models.api.extensions.rollforward import (
   CreateRollforwardRequest,
   DeleteRollforwardRequest,
@@ -28,12 +33,14 @@ from robosystems.models.api.extensions.schedules import (
   UpdateScheduleRequest,
 )
 from robosystems.models.api.information_block import (
+  ForecastMechanics,
   MetricMechanics,
   RollforwardMechanics,
   ScheduleMechanics,
   StatementMechanics,
 )
 from robosystems.operations.information_block import disclosure as disclosure_handlers
+from robosystems.operations.information_block import forecast as forecast_handlers
 from robosystems.operations.information_block import metric as metric_handlers
 from robosystems.operations.information_block import rollforward as rollforward_handlers
 from robosystems.operations.information_block import schedule as schedule_handlers
@@ -211,6 +218,39 @@ ROLLFORWARD_BLOCK = BlockTypeRegistryEntry(
 )
 
 
+# ── Forecast (declarative) ─────────────────────────────────────────────────
+
+FORECAST_BLOCK = BlockTypeRegistryEntry(
+  id=forecast_handlers.FORECAST_BLOCK_TYPE,
+  display_name=forecast_handlers.FORECAST_DISPLAY_NAME,
+  display_plural="Forecasts",
+  category=forecast_handlers.FORECAST_CATEGORY,
+  icon="trending-up-down",
+  description=(
+    "Authored scenario container (FP&A) — scenario identity, horizon, "
+    "and lever assertions on the rs-driver catalog. The block IS the "
+    "scenario: compute-forecast walks the driver cascade forward from "
+    "the last closed actuals and lands the derived months in the "
+    "existing statement/metric block types keyed by this block's "
+    "scenario_id (NULL = actuals)."
+  ),
+  concept_arrangement_default="set",
+  member_arrangement_default=None,
+  mechanics_schema=ForecastMechanics,
+  create_request_model=CreateForecastRequest,
+  update_request_model=UpdateForecastRequest,
+  delete_request_model=DeleteForecastRequest,
+  construction_mode="declarative",
+  dispatch_create=forecast_handlers.create,
+  dispatch_update=forecast_handlers.update,
+  dispatch_delete=forecast_handlers.delete,
+  dispatch_build_envelope=forecast_handlers.build_envelope,
+  # Forecasts are tenant-authored scenarios against live ledger data —
+  # never on the library sentinel.
+  surfaces_in_library=False,
+)
+
+
 # ── Statements (compositional) ─────────────────────────────────────────────
 
 
@@ -324,6 +364,7 @@ METRIC_BLOCK = BlockTypeRegistryEntry(
 REGISTRY: dict[str, BlockTypeRegistryEntry] = {
   SCHEDULE_BLOCK.id: SCHEDULE_BLOCK,
   ROLLFORWARD_BLOCK.id: ROLLFORWARD_BLOCK,
+  FORECAST_BLOCK.id: FORECAST_BLOCK,
   BALANCE_SHEET_BLOCK.id: BALANCE_SHEET_BLOCK,
   INCOME_STATEMENT_BLOCK.id: INCOME_STATEMENT_BLOCK,
   CASH_FLOW_STATEMENT_BLOCK.id: CASH_FLOW_STATEMENT_BLOCK,
@@ -358,6 +399,7 @@ __all__ = [
   "COMPREHENSIVE_INCOME_BLOCK",
   "DISCLOSURE_BLOCK",
   "EQUITY_STATEMENT_BLOCK",
+  "FORECAST_BLOCK",
   "INCOME_STATEMENT_BLOCK",
   "METRIC_BLOCK",
   "REGISTRY",

--- a/robosystems/operations/information_block/rollforward.py
+++ b/robosystems/operations/information_block/rollforward.py
@@ -233,14 +233,18 @@ def delete(
 
 
 def build_envelope(
-  session: Session, structure_id: str, fact_set_id: str | None = None
+  session: Session,
+  structure_id: str,
+  fact_set_id: str | None = None,
+  scenario_id: str | None = None,
 ) -> InformationBlockEnvelope | None:
   """Reload a rollforward Structure and pack its envelope.
 
   ``fact_set_id`` is accepted for signature parity but unused —
   rollforward facts are not persisted (the filter engine is called
   directly from the reconciliation harness; the renderer wiring is not
-  yet in place). The envelope's ``facts`` list is empty.
+  yet in place). The envelope's ``facts`` list is empty. ``scenario_id``
+  is likewise parity-only — rollforwards attribute posted ledger lines.
 
   Returns ``None`` when the structure doesn't exist or isn't a
   rollforward.

--- a/robosystems/operations/information_block/rules/engine.py
+++ b/robosystems/operations/information_block/rules/engine.py
@@ -181,14 +181,20 @@ def _load_period_balances(
   reconciling plug), within the period window.
 
   Scoped to a single FactSet: pinned when ``fact_set_id`` is given, else the
-  LATEST FactSet for the structure. The FactSet is the summing unit on purpose
-  — two coexisting reports over the same period both stamp this structure, so a
-  bare ``structure_id`` scope would sum across reports and double every balance.
+  LATEST **actual** FactSet for the structure (``scenario_id IS NULL`` —
+  scenario verification is a later phase, and without the pin a computed
+  forecast month would silently become the summing unit for every rule
+  run). The FactSet is the summing unit on purpose — two coexisting
+  reports over the same period both stamp this structure, so a bare
+  ``structure_id`` scope would sum across reports and double every balance.
   """
   if fact_set_id is None:
     fact_set_id = session.execute(
       select(FactSet.id)
-      .where(FactSet.structure_id == structure_id)
+      .where(
+        FactSet.structure_id == structure_id,
+        FactSet.scenario_id.is_(None),
+      )
       .order_by(FactSet.created_at.desc(), FactSet.id.desc())
       .limit(1)
     ).scalar()
@@ -470,6 +476,13 @@ def evaluate_rules_for_structure(
   for rule_lite in rule_lites:
     rule = rule_map.get(rule_lite.id)
     if rule is None:
+      continue
+    # Derive rules COMPUTE values (compute-metrics / compute-forecast) —
+    # they are not checks and must not emit VerificationResults. Without
+    # this, the rs-driver catalog's rules (whose targets are rs-gaap
+    # statement elements) would add a "skipped" row to every statement
+    # verification run.
+    if rule.rule_pattern == "Derive":
       continue
     try:
       outcome: EvaluationOutcome | None = None

--- a/robosystems/operations/information_block/rules/expressions.py
+++ b/robosystems/operations/information_block/rules/expressions.py
@@ -16,10 +16,14 @@ Aggregates are desugared, never evaluated: ``avg($X)`` rewrites to a
 synthesized ``$__avg_X`` operand *before* parsing
 (:func:`desugar_aggregates`), so the whitelist keeps rejecting every
 ``ast.Call`` and the evaluator stays pure arithmetic — averaging happens
-at bind time in the caller, where the begin + end facts live. A future
-``$X[t-1]`` prior-period operand rides the same mechanism (rewrite to a
-synthesized operand, bind at a resolved prior period) — see
-``compute-metrics``.
+at bind time in the caller, where the begin + end facts live. The
+``$X[t-1]`` prior-period reference (the forecast grammar's compounding
+form) rides the same mechanism: :func:`desugar_priors` rewrites it to a
+synthesized ``$__prior_X`` operand pre-parse, and the caller binds it at
+the resolved prior period — ``compute-forecast`` binds the previous
+forward month's value in its walk. ``ast.Subscript`` stays outside the
+whitelist, so any other bracket form (``$X[t-2]``, ``$X[0]``) is
+structurally rejected — the grammar ceiling is ``[t-1]`` + ``avg()``.
 """
 
 from __future__ import annotations
@@ -79,6 +83,38 @@ def desugar_aggregates(expr: str) -> tuple[str, dict[str, str]]:
     return f"${name}"
 
   return _AVG_CALL_RE.sub(_sub, expr), synthesized
+
+
+PRIOR_OPERAND_PREFIX = "__prior_"
+
+_PRIOR_REF_RE = re.compile(r"\$([A-Za-z_]\w*)\[t-1\]")
+
+
+def desugar_priors(expr: str) -> tuple[str, dict[str, str]]:
+  """Rewrite ``$X[t-1]`` references to synthesized ``$__prior_X`` operands.
+
+  The prior-period half of the forecast grammar (``avg()``'s documented
+  sibling seam). Returns the rewritten expression plus a map of
+  synthesized variable name → base variable name; callers append the
+  synthesized names to the parse variable list and bind each one at the
+  resolved prior period — the forecast walk binds the previous forward
+  month's value (seeded from actuals at the base period).
+
+  Only the exact ``[t-1]`` form matches. Any other bracket construct —
+  ``$X[t-2]``, ``$X[0]``, ``$X[t]`` — survives as a genuine
+  :class:`ast.Subscript`, which is outside the whitelist and rejected:
+  the grammar ceiling stays enforced structurally, same as the
+  no-function-calls posture for aggregates.
+  """
+  synthesized: dict[str, str] = {}
+
+  def _sub(match: re.Match[str]) -> str:
+    base = match.group(1)
+    name = f"{PRIOR_OPERAND_PREFIX}{base}"
+    synthesized[name] = base
+    return f"${name}"
+
+  return _PRIOR_REF_RE.sub(_sub, expr), synthesized
 
 
 @dataclass
@@ -302,10 +338,12 @@ def build_rollup_expression(parent_name: str, children: list[tuple[str, float]])
 __all__ = [
   "AVG_OPERAND_PREFIX",
   "EQUALITY_TOLERANCE",
+  "PRIOR_OPERAND_PREFIX",
   "InvalidRuleExpression",
   "ParsedExpression",
   "build_rollup_expression",
   "desugar_aggregates",
+  "desugar_priors",
   "evaluate_arithmetic",
   "evaluate_derivation",
   "evaluate_equality",

--- a/robosystems/operations/information_block/schedule.py
+++ b/robosystems/operations/information_block/schedule.py
@@ -164,7 +164,10 @@ def _latest_instant_per_element(facts: Sequence[Fact]) -> list[Fact]:
 
 
 def build_envelope(
-  session: Session, structure_id: str, fact_set_id: str | None = None
+  session: Session,
+  structure_id: str,
+  fact_set_id: str | None = None,
+  scenario_id: str | None = None,
 ) -> InformationBlockEnvelope | None:
   """Reload a schedule Structure and pack its Information Block envelope.
 
@@ -172,6 +175,9 @@ def build_envelope(
   so the generic reader can cleanly distinguish misses from errors.
   Mechanics are read from the typed ``artifact_mechanics`` column with
   fallback to legacy ``metadata_`` JSONB.
+
+  ``scenario_id`` is accepted for dispatch-signature parity and ignored
+  — schedules are physical-ledger projections with no scenario slices.
 
   ``fact_set_id`` pins the envelope to a specific FactSet snapshot —
   the Report-Block rehydration path uses this to surface the frozen

--- a/robosystems/operations/information_block/statement.py
+++ b/robosystems/operations/information_block/statement.py
@@ -95,6 +95,7 @@ def _build_statement_envelope(
   session: Session,
   structure_id: str,
   fact_set_id: str | None = None,
+  scenario_id: str | None = None,
   *,
   block_type: str,
 ) -> InformationBlockEnvelope | None:
@@ -115,12 +116,19 @@ def _build_statement_envelope(
   "latest Report touching these elements" heuristic; writes have
   stamped both ``report_id`` and ``fact_set_id`` since Phase gamma.1 so
   the switch is a strict simplification (one less query per envelope).
+
+  **Scenario slice.** ``scenario_id=None`` binds actuals (the
+  scenario-pinned latest-set read); a non-None value binds the
+  scenario's latest computed forecast month and every rendered period
+  column carries a ``"... (forecast)"`` label so the surface is honest
+  about what it shows.
   """
   atoms = load_base_envelope_atoms(
     session,
     structure_id,
     expected_block_type=block_type,
     fact_set_id=fact_set_id,
+    scenario_id=scenario_id,
   )
   if atoms is None:
     return None
@@ -161,6 +169,23 @@ def _build_statement_envelope(
     block_type=block_type,
     concept_arrangement=structure.concept_arrangement,
   )
+
+  # Scenario mode bound a forecast set — every rendered column is a
+  # forward month; stamp the labels so tables and chart axes read
+  # honestly.
+  if (
+    scenario_id is not None
+    and atoms.fact_set is not None
+    and atoms.fact_set.scenario_id == scenario_id
+  ):
+    rendering = rendering.model_copy(
+      update={
+        "periods": [
+          p.model_copy(update={"label": _forecast_period_label(p.end)})
+          for p in rendering.periods
+        ]
+      }
+    )
 
   # Statement-family types carry fixed display strings; block types that
   # share this builder without an entry (regulatory_disclosure) display
@@ -205,6 +230,16 @@ def _build_statement_envelope(
 
 
 # ── Rendering projection — server-side computed at envelope build ─────────
+
+
+def _forecast_period_label(period_end: date) -> str:
+  """Display-ready column label for a forecast period — ``"Mar 2027 (forecast)"``.
+
+  The full label (month + marker), not a bare suffix, so any consumer —
+  table header, chart axis — can use it verbatim without composing.
+  Actual columns keep ``label=None`` and format their own dates as today.
+  """
+  return f"{period_end.strftime('%b %Y')} (forecast)"
 
 
 def _build_statement_rendering(

--- a/robosystems/operations/information_block/types.py
+++ b/robosystems/operations/information_block/types.py
@@ -117,11 +117,15 @@ class BlockTypeRegistryEntry:
 
   dispatch_build_envelope: Callable[..., InformationBlockEnvelope | None]
   """Handler that reads the block and packs its envelope. Signature:
-  ``(session, structure_id, fact_set_id=None) -> InformationBlockEnvelope | None``.
+  ``(session, structure_id, fact_set_id=None, scenario_id=None) ->
+  InformationBlockEnvelope | None``.
   Returns None when the structure_id doesn't exist or its row doesn't
   belong to this block type. ``fact_set_id`` pins the envelope to a
   specific FactSet snapshot (used by Report Block rehydration); when
-  omitted the latest FactSet is used."""
+  omitted the latest FactSet is used. ``scenario_id`` selects the
+  FactSet slice (None = actuals; a forecast block's id = that
+  scenario) — block types without scenario slices accept and ignore
+  it, so every handler carries the parameter."""
 
   surfaces_in_library: bool = False
   """When True, ``list_information_blocks`` surfaces this block type on

--- a/robosystems/operations/roboledger/commands/text_blocks.py
+++ b/robosystems/operations/roboledger/commands/text_blocks.py
@@ -167,6 +167,9 @@ def bind_text_block(
     .where(
       FactSet.structure_id == body.structure_id,
       FactSet.factset_type == "disclosure",
+      # Actuals pin — disclosures have no scenario slices; defensive so a
+      # future scenario producer can never alias the standing bind.
+      FactSet.scenario_id.is_(None),
       FactSet.entity_id == entity_id,
       FactSet.period_start == body.period_start,
       FactSet.period_end == body.period_end,

--- a/robosystems/operations/roboledger/fact_set.py
+++ b/robosystems/operations/roboledger/fact_set.py
@@ -35,6 +35,7 @@ def create_fact_set(
   structure_id: str | None = None,
   period_start: date | None = None,
   report_id: str | None = None,
+  scenario_id: str | None = None,
   metadata: dict | None = None,
   id: str | None = None,
 ) -> FactSet:
@@ -43,6 +44,11 @@ def create_fact_set(
   ``provenance`` is validated through the discriminated union and stored
   as JSON on the dedicated ``provenance`` column. Pass an arm instance
   (``PivotProvenance(...)`` etc.); a raw dict is accepted and validated.
+
+  ``scenario_id`` is the scenario axis (the forecast engine): NULL —
+  the default every existing producer keeps — means actuals; non-NULL
+  points at the owning forecast Structure and keys the set into that
+  scenario's parallel universe.
   """
   validated = _PROVENANCE.validate_python(provenance)
   fact_set = FactSet(
@@ -52,6 +58,7 @@ def create_fact_set(
     factset_type=factset_type,
     entity_id=entity_id,
     report_id=report_id,
+    scenario_id=scenario_id,
     provenance=validated.model_dump(mode="json"),
   )
   if id is not None:

--- a/robosystems/operations/taxonomy_block/library_creator.py
+++ b/robosystems/operations/taxonomy_block/library_creator.py
@@ -74,6 +74,7 @@ _ALLOWED_SOURCES = frozenset(
     "checklist",
     "styles",
     "rs-metric",
+    "rs-driver",
     # cm — Conceptual Model framework (cm:Debit/cm:Credit posting roles).
     "cm",
   }

--- a/robosystems/routers/extensions/roboledger/operations.py
+++ b/robosystems/routers/extensions/roboledger/operations.py
@@ -173,6 +173,8 @@ from robosystems.models.api.extensions.text_blocks import (
   BindTextBlockResponse,
 )
 from robosystems.models.api.information_block import (
+  ComputeForecastRequest,
+  ComputeForecastResponse,
   ComputeMetricsRequest,
   ComputeMetricsResponse,
   CreateInformationBlockRequest,
@@ -235,6 +237,9 @@ from robosystems.operations.information_block.commands import (
 )
 from robosystems.operations.information_block.commands import (
   update_information_block as cmd_update_information_block,
+)
+from robosystems.operations.information_block.forecast_compute import (
+  cmd_compute_forecast,
 )
 from robosystems.operations.information_block.metrics import (
   cmd_compute_metrics,
@@ -1207,6 +1212,32 @@ compute_metrics_op = _registrar.register(
     result_type=ComputeMetricsResponse,
     error_map={ValueError: 422},
     mark_stale_reason="metrics_computed",
+    requires_created_by=True,
+  )
+)
+
+compute_forecast_op = _registrar.register(
+  OperationSpec(
+    name="compute-forecast",
+    summary="Compute Forecast for a Forecast Block",
+    description=(
+      "Walks a forecast block's driver cascade month-by-month forward "
+      "from its base period: lever-driven rs-driver Derive rules in "
+      "dependency order, carry-forward for unmodeled income-statement "
+      "lines, calc-DAG subtotals — upserting one scenario "
+      "income-statement FactSet (plus a working-capital balance-sheet "
+      "set) per forward month, all keyed by the block's scenario_id "
+      "(NULL = actuals; scenario reads pass it as a filter). Re-running "
+      "replaces each month's values. Rules with missing lever months or "
+      "unbound operands are skipped with a reason (their targets fall "
+      "back to carry-forward), never errored. Deterministic and non-AI "
+      "— no credits consumed."
+    ),
+    command=cmd_compute_forecast,
+    request_model=ComputeForecastRequest,
+    result_type=ComputeForecastResponse,
+    error_map={ValueError: 422},
+    mark_stale_reason="forecast_computed",
     requires_created_by=True,
   )
 )

--- a/tests/middleware/mcp/tools/test_information_block_tools.py
+++ b/tests/middleware/mcp/tools/test_information_block_tools.py
@@ -179,6 +179,7 @@ class TestListInformationBlocksTool:
       limit=10,
       offset=5,
       library_sentinel=False,
+      scenario_id=None,
     )
 
   @pytest.mark.asyncio
@@ -198,4 +199,5 @@ class TestListInformationBlocksTool:
       limit=50,
       offset=0,
       library_sentinel=True,
+      scenario_id=None,
     )

--- a/tests/operations/information_block/rules/test_engine.py
+++ b/tests/operations/information_block/rules/test_engine.py
@@ -358,6 +358,43 @@ class TestEvaluateRulesForStructure:
       )
     assert results == []
 
+  def test_derive_rules_emit_no_verification_results(self) -> None:
+    """Derive rules COMPUTE values (compute-metrics / compute-forecast) —
+    they are not checks. Without the exclusion, the rs-driver catalog's
+    rules (whose targets are rs-gaap statement elements) would add a
+    'skipped' VerificationResult to every statement rule run."""
+    from robosystems.operations.information_block.rules.engine import (
+      evaluate_rules_for_structure,
+    )
+
+    session = MagicMock()
+    session.get.return_value = MagicMock(id="struct_is", block_type="income_statement")
+
+    rule_lite = MagicMock()
+    rule_lite.id = "rule_driver_growth"
+    derive_rule = _make_rule_orm(
+      rule_id="rule_driver_growth",
+      pattern="Derive",
+      expression="$Revenues = ($Revenues[t-1] * (1 + $RevenueGrowthRate))",
+      variables=[
+        {"variable_name": "Revenues", "variable_qname": "rs-gaap:Revenues"},
+        {
+          "variable_name": "RevenueGrowthRate",
+          "variable_qname": "rs-driver:RevenueGrowthRate",
+        },
+      ],
+    )
+
+    with patch(
+      "robosystems.operations.information_block.rules.engine.load_rules_for_structure",
+      return_value=[rule_lite],
+    ):
+      session.execute.side_effect = [_scalars(), _scalars(derive_rule)]
+      results = evaluate_rules_for_structure(session, "struct_is")
+
+    assert results == []
+    session.add.assert_not_called()
+
 
 class TestNumericGuards:
   """Nonnumeric (text-block) facts are invisible to the numeric rule

--- a/tests/operations/information_block/rules/test_expressions.py
+++ b/tests/operations/information_block/rules/test_expressions.py
@@ -8,6 +8,7 @@ from robosystems.operations.information_block.rules.expressions import (
   EQUALITY_TOLERANCE,
   InvalidRuleExpression,
   desugar_aggregates,
+  desugar_priors,
   evaluate_derivation,
   evaluate_equality,
   lhs_variable_names,
@@ -260,3 +261,45 @@ class TestDesugarAggregates:
     assert synth == {}
     with pytest.raises(InvalidRuleExpression, match="disallowed"):
       parse_arithmetic_expression(expr, ["X", "A"])
+
+
+class TestDesugarPriors:
+  """$X[t-1] → synthesized $__prior_X — the forecast grammar's
+  prior-period reference, riding the same pre-parse rewrite as avg()."""
+
+  def test_rewrites_prior_reference_to_synthesized_operand(self) -> None:
+    expr, synth = desugar_priors(
+      "$Revenues = ($Revenues[t-1] * (1 + $RevenueGrowthRate))"
+    )
+    assert expr == "$Revenues = ($__prior_Revenues * (1 + $RevenueGrowthRate))"
+    assert synth == {"__prior_Revenues": "Revenues"}
+
+  def test_plain_expression_is_untouched(self) -> None:
+    original = "$CostOfRevenue = ($Revenues * $CostOfRevenueRate)"
+    expr, synth = desugar_priors(original)
+    assert expr == original
+    assert synth == {}
+
+  def test_desugared_compounding_parses_and_evaluates(self) -> None:
+    expr, synth = desugar_priors("$Rev = ($Rev[t-1] * (1 + $g))")
+    parsed = parse_arithmetic_expression(expr, ["Rev", "g", *list(synth)])
+    value = evaluate_derivation(parsed, {"__prior_Rev": 100.0, "g": 0.03})
+    assert value == pytest.approx(103.0)
+
+  def test_combines_with_avg_desugar(self) -> None:
+    expr, priors = desugar_priors("$X = ($Y[t-1] + avg($Z))")
+    expr, avgs = desugar_aggregates(expr)
+    assert expr == "$X = ($__prior_Y + $__avg_Z)"
+    assert priors == {"__prior_Y": "Y"}
+    assert avgs == {"__avg_Z": "Z"}
+    parsed = parse_arithmetic_expression(expr, ["X", "Y", "Z", *priors, *avgs])
+    assert evaluate_derivation(parsed, {"__prior_Y": 1.0, "__avg_Z": 2.0}) == 3.0
+
+  def test_other_lags_survive_and_are_rejected_structurally(self) -> None:
+    """The grammar ceiling is [t-1]: any other bracket form stays a
+    genuine ast.Subscript, which is outside the whitelist."""
+    for bad in ("$X = $Y[t-2]", "$X = $Y[0]", "$X = $Y[t]"):
+      expr, synth = desugar_priors(bad)
+      assert synth == {}
+      with pytest.raises(InvalidRuleExpression, match="disallowed"):
+        parse_arithmetic_expression(expr, ["X", "Y"])

--- a/tests/operations/information_block/test_envelope_fact_set.py
+++ b/tests/operations/information_block/test_envelope_fact_set.py
@@ -28,6 +28,7 @@ def _make_fact_set(
   factset_type: str = "report",
   entity_id: str = "ent_demo",
   report_id: str | None = None,
+  scenario_id: str | None = None,
   provenance: dict | None = None,
 ) -> MagicMock:
   row = MagicMock()
@@ -38,6 +39,7 @@ def _make_fact_set(
   row.factset_type = factset_type
   row.entity_id = entity_id
   row.report_id = report_id
+  row.scenario_id = scenario_id
   row.provenance = provenance
   return row
 

--- a/tests/operations/information_block/test_envelope_fact_set.py
+++ b/tests/operations/information_block/test_envelope_fact_set.py
@@ -92,6 +92,49 @@ class TestLoadLatestFactSetForStructure:
     assert lite.id == "fs_2026Q1"
     assert lite.factset_type == "report"
 
+  def test_default_read_pins_actuals(self) -> None:
+    """**The hijack regression.** Scenario sets live at FUTURE
+    period_ends, so without the ``scenario_id IS NULL`` pin one computed
+    forecast month would win this period_end-descending read and hijack
+    every default envelope. Assert the pin is in the emitted SQL."""
+    session = MagicMock()
+    result = MagicMock()
+    result.scalar.return_value = None
+    session.execute.return_value = result
+
+    load_latest_fact_set_for_structure(session, "struct_bs")
+    stmt = session.execute.call_args.args[0]
+    sql = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+    assert "scenario_id IS NULL" in sql
+
+  def test_scenario_read_pins_that_scenario_exactly(self) -> None:
+    """A scenario read binds ONLY that scenario's sets — never a mix
+    with actuals (statement + scenario = the latest forecast month)."""
+    session = MagicMock()
+    result = MagicMock()
+    result.scalar.return_value = None
+    session.execute.return_value = result
+
+    load_latest_fact_set_for_structure(session, "struct_bs", "struct_budget")
+    stmt = session.execute.call_args.args[0]
+    sql = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+    assert "scenario_id = 'struct_budget'" in sql
+    assert "scenario_id IS NULL" not in sql
+
+  def test_future_scenario_set_never_wins_default_read(self) -> None:
+    """End-to-end shape of the regression: with a scenario row present
+    the default read still projects the actual row the (filtered) query
+    returned — the filter is what excludes the scenario set."""
+    session = MagicMock()
+    result = MagicMock()
+    result.scalar.return_value = _make_fact_set(fs_id="fs_actual", scenario_id=None)
+    session.execute.return_value = result
+
+    lite = load_latest_fact_set_for_structure(session, "struct_bs")
+    assert lite is not None
+    assert lite.id == "fs_actual"
+    assert lite.scenario_id is None
+
 
 class TestLoadFactSetByIdForStructure:
   """Pin lookup for the Report-Block read path — match Structure + id, or None."""

--- a/tests/operations/information_block/test_forecast_compute.py
+++ b/tests/operations/information_block/test_forecast_compute.py
@@ -1,0 +1,460 @@
+"""compute-forecast cascade tests.
+
+Exercises the month-by-month walk with the persistence seams patched
+(``_upsert_month_set`` recorded, data loads stubbed) so the assertions
+target the cascade math itself: compounding via ``[t-1]``, rate-on-base
+same-month ordering, days-based instants, carry-forward, calc-DAG
+subtotal derivation, skip-and-fall-back semantics. ``_upsert_month_set``
+has its own persistence tests at the bottom; the full end-to-end path
+runs in the Driftline showcase harness.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from robosystems.models.api.information_block import (
+  ComputeForecastRequest,
+  ForecastMechanics,
+  LeverAssertionLite,
+)
+from robosystems.operations.information_block import (
+  forecast_compute as fc,
+)
+
+
+def _element(
+  element_id: str,
+  qname: str,
+  *,
+  period_type: str = "duration",
+  is_monetary: bool = True,
+  item_type: str | None = None,
+) -> SimpleNamespace:
+  return SimpleNamespace(
+    id=element_id,
+    qname=qname,
+    period_type=period_type,
+    is_monetary=is_monetary,
+    item_type=item_type,
+  )
+
+
+EL_REV = _element("el_rev", "rs-gaap:Revenues")
+EL_COGS = _element("el_cogs", "rs-gaap:CostOfRevenue")
+EL_AR = _element("el_ar", "rs-gaap:ReceivablesNetCurrent", period_type="instant")
+EL_RENT = _element("el_rent", "rs-gaap:RentExpense")
+EL_GP = _element("el_gp", "rs-gaap:GrossProfit")
+
+ELEMENTS = [EL_REV, EL_COGS, EL_AR, EL_RENT, EL_GP]
+BY_ID = {e.id: e for e in ELEMENTS}
+BY_QNAME = {e.qname: e for e in ELEMENTS}
+
+
+def _rule(rule_id: str, target: SimpleNamespace, expression: str, variables) -> Any:
+  return SimpleNamespace(
+    id=rule_id,
+    rule_expression=expression,
+    rule_variables=[
+      {"variable_name": name, "variable_qname": qname} for name, qname in variables
+    ],
+    target_element_id=target.id,
+  )
+
+
+GROWTH_RULE = _rule(
+  "rule_growth",
+  EL_REV,
+  "$Revenues = ($Revenues[t-1] * (1 + $RevenueGrowthRate))",
+  [
+    ("Revenues", "rs-gaap:Revenues"),
+    ("RevenueGrowthRate", "rs-driver:RevenueGrowthRate"),
+  ],
+)
+COGS_RULE = _rule(
+  "rule_cogs",
+  EL_COGS,
+  "$CostOfRevenue = ($Revenues * $CostOfRevenueRate)",
+  [
+    ("CostOfRevenue", "rs-gaap:CostOfRevenue"),
+    ("Revenues", "rs-gaap:Revenues"),
+    ("CostOfRevenueRate", "rs-driver:CostOfRevenueRate"),
+  ],
+)
+DSO_RULE = _rule(
+  "rule_dso",
+  EL_AR,
+  "$ReceivablesNetCurrent = (($Revenues / 30) * $DaysSalesOutstanding)",
+  [
+    ("ReceivablesNetCurrent", "rs-gaap:ReceivablesNetCurrent"),
+    ("Revenues", "rs-gaap:Revenues"),
+    ("DaysSalesOutstanding", "rs-driver:DaysSalesOutstanding"),
+  ],
+)
+
+# Base month actuals: the June IS monthly set (subtotal included).
+BASE_IS_FACTS = [
+  SimpleNamespace(element_id="el_rev", value=100.0),
+  SimpleNamespace(element_id="el_cogs", value=62.0),
+  SimpleNamespace(element_id="el_rent", value=10.0),
+  SimpleNamespace(element_id="el_gp", value=38.0),
+]
+
+CALC_DAG = {"el_gp": [("el_rev", 1.0), ("el_cogs", -1.0)]}
+
+
+def _mechanics(levers: list[LeverAssertionLite], horizon: int = 3) -> dict:
+  return ForecastMechanics(
+    scenario_kind="budget",
+    horizon_months=horizon,
+    base_period="2026-06",
+    levers=levers,
+  ).model_dump(mode="json")
+
+
+def _lever(qname: str, element_id: str, value: float, months: list[str]) -> Any:
+  return LeverAssertionLite(
+    qname=qname,
+    element_id=element_id,
+    item_type="percent",
+    values_by_period=dict.fromkeys(months, value),
+  )
+
+
+ALL_MONTHS = ["2026-07", "2026-08", "2026-09"]
+
+
+def _lever_facts(levers: list[LeverAssertionLite]) -> list[SimpleNamespace]:
+  facts = []
+  for lever in levers:
+    for month, value in lever.values_by_period.items():
+      year, mm = int(month[:4]), int(month[5:7])
+      end = date(year, mm, 28)  # any day in the month works for period_from_date
+      facts.append(
+        SimpleNamespace(element_id=lever.element_id, value=value, period_end=end)
+      )
+  return facts
+
+
+class _Recorder:
+  """Captures _upsert_month_set calls; returns deterministic set ids."""
+
+  def __init__(self) -> None:
+    self.calls: list[dict] = []
+
+  def __call__(self, session: Any, **kwargs: Any) -> str | None:
+    if not kwargs["facts"]:
+      return None
+    self.calls.append(kwargs)
+    return f"fs_{kwargs['structure_id']}_{kwargs['period_end']}"
+
+  def month(self, structure_id: str, period_end: date) -> dict | None:
+    for call in self.calls:
+      if call["structure_id"] == structure_id and call["period_end"] == period_end:
+        return call
+    return None
+
+  def value(self, structure_id: str, period_end: date, element_id: str) -> float:
+    call = self.month(structure_id, period_end)
+    assert call is not None, f"no emission for {structure_id} @ {period_end}"
+    for element, value in call["facts"]:
+      if element.id == element_id:
+        return value
+    raise AssertionError(f"{element_id} not emitted @ {period_end}")
+
+
+def _session(structure: Any) -> MagicMock:
+  session = MagicMock()
+
+  def _get(model: Any, obj_id: str) -> Any:
+    if obj_id == structure.id:
+      return structure
+    return BY_ID.get(obj_id)
+
+  session.get.side_effect = _get
+
+  def _execute(stmt: Any) -> Any:
+    # Only _element_by_qname reaches session.execute with the load
+    # seams patched — resolve the qname from the compiled params.
+    params = stmt.compile().params
+    qname = next((v for v in params.values() if isinstance(v, str)), None)
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = BY_QNAME.get(qname)
+    return result
+
+  session.execute.side_effect = _execute
+  return session
+
+
+def _structure(mechanics: dict) -> SimpleNamespace:
+  return SimpleNamespace(
+    id="struct_budget",
+    block_type="forecast",
+    artifact_mechanics=mechanics,
+  )
+
+
+def _run(
+  mechanics: dict,
+  rules: list[Any],
+  levers: list[LeverAssertionLite],
+  *,
+  months: int | None = None,
+  bs_structure: str | None = "struct_bs",
+):
+  structure = _structure(mechanics)
+  recorder = _Recorder()
+
+  def _structures(session: Any, block_type: str) -> str | None:
+    return {"income_statement": "struct_is", "balance_sheet": bs_structure}.get(
+      block_type
+    )
+
+  facts_by_set = {"fs_base_is": BASE_IS_FACTS, "fs_lever": _lever_facts(levers)}
+
+  with (
+    patch.object(fc, "_newest_actual_structure_id", side_effect=_structures),
+    patch.object(
+      fc,
+      "_actual_set_at",
+      side_effect=lambda session, sid, *a, **k: (
+        SimpleNamespace(id="fs_base_is") if sid == "struct_is" else None
+      ),
+    ),
+    patch.object(
+      fc, "_numeric_facts", side_effect=lambda session, fs_id: facts_by_set[fs_id]
+    ),
+    patch.object(fc, "_load_driver_rules", return_value=rules),
+    patch.object(fc, "_local_calc_arcs", return_value={}),
+    patch.object(fc, "load_rs_gaap_calculations", return_value=dict(CALC_DAG)),
+    patch.object(
+      fc,
+      "_load_lever_fact_set",
+      return_value=SimpleNamespace(id="fs_lever", entity_id="ent_1"),
+    ),
+    patch.object(fc, "_upsert_month_set", recorder),
+  ):
+    response = fc.cmd_compute_forecast(
+      _session(structure),
+      ComputeForecastRequest(structure_id="struct_budget", months=months),
+      "usr_test",
+    )
+  return response, recorder
+
+
+FULL_LEVERS = [
+  _lever("rs-driver:RevenueGrowthRate", "el_growth", 0.03, ALL_MONTHS),
+  _lever("rs-driver:CostOfRevenueRate", "el_rate", 0.62, ALL_MONTHS),
+  _lever("rs-driver:DaysSalesOutstanding", "el_dso", 45.0, ALL_MONTHS),
+]
+FULL_RULES = [GROWTH_RULE, COGS_RULE, DSO_RULE]
+
+JUL = date(2026, 7, 31)
+AUG = date(2026, 8, 31)
+SEP = date(2026, 9, 30)
+
+
+class TestCascade:
+  def test_growth_compounds_month_over_month(self) -> None:
+    _, rec = _run(_mechanics(FULL_LEVERS), FULL_RULES, FULL_LEVERS)
+    assert rec.value("struct_is", JUL, "el_rev") == pytest.approx(103.0)
+    assert rec.value("struct_is", AUG, "el_rev") == pytest.approx(106.09)
+    assert rec.value("struct_is", SEP, "el_rev") == pytest.approx(100 * 1.03**3)
+
+  def test_rate_on_base_binds_the_same_months_grown_revenue(self) -> None:
+    """Topo order: Revenues resolves before CostOfRevenue, so the rate
+    applies to THIS month's grown revenue, not the prior month's."""
+    _, rec = _run(_mechanics(FULL_LEVERS), FULL_RULES, FULL_LEVERS)
+    assert rec.value("struct_is", JUL, "el_cogs") == pytest.approx(103.0 * 0.62)
+
+  def test_days_based_instant_lands_in_the_bs_set(self) -> None:
+    _, rec = _run(_mechanics(FULL_LEVERS), FULL_RULES, FULL_LEVERS)
+    assert rec.value("struct_bs", JUL, "el_ar") == pytest.approx(103.0 / 30 * 45)
+    # Instants never leak into the IS emission.
+    is_call = rec.month("struct_is", JUL)
+    assert is_call is not None
+    assert all(el.id != "el_ar" for el, _ in is_call["facts"])
+
+  def test_unmodeled_leaf_carries_forward(self) -> None:
+    _, rec = _run(_mechanics(FULL_LEVERS), FULL_RULES, FULL_LEVERS)
+    for month_end in (JUL, AUG, SEP):
+      assert rec.value("struct_is", month_end, "el_rent") == pytest.approx(10.0)
+
+  def test_subtotal_is_derived_never_carried(self) -> None:
+    """GrossProfit re-derives from the month's Revenues - CostOfRevenue
+    — carrying the base month's 38.0 would silently break articulation."""
+    _, rec = _run(_mechanics(FULL_LEVERS), FULL_RULES, FULL_LEVERS)
+    expected = 103.0 - (103.0 * 0.62)
+    assert rec.value("struct_is", JUL, "el_gp") == pytest.approx(expected)
+    assert rec.value("struct_is", JUL, "el_gp") != pytest.approx(38.0)
+
+  def test_inactive_rule_falls_to_carry_forward(self) -> None:
+    """No growth lever asserted → the GROWTH rule never activates and
+    Revenues carries; no DSO lever → no BS emission at all."""
+    levers = [_lever("rs-driver:CostOfRevenueRate", "el_rate", 0.62, ALL_MONTHS)]
+    _, rec = _run(_mechanics(levers), FULL_RULES, levers)
+    assert rec.value("struct_is", JUL, "el_rev") == pytest.approx(100.0)
+    # Rate-on-base still runs against the carried revenue.
+    assert rec.value("struct_is", JUL, "el_cogs") == pytest.approx(62.0)
+    assert rec.month("struct_bs", JUL) is None
+
+  def test_lever_month_gap_skips_and_falls_back(self) -> None:
+    """Growth asserted only for July: August/September record a skip and
+    Revenues holds at the last computed value (carry fallback)."""
+    levers = [_lever("rs-driver:RevenueGrowthRate", "el_growth", 0.03, ["2026-07"])]
+    response, rec = _run(_mechanics(levers), [GROWTH_RULE], levers)
+    assert rec.value("struct_is", JUL, "el_rev") == pytest.approx(103.0)
+    assert rec.value("struct_is", AUG, "el_rev") == pytest.approx(103.0)
+    assert rec.value("struct_is", SEP, "el_rev") == pytest.approx(103.0)
+    skip_periods = {s.period for s in response.skipped}
+    assert skip_periods == {"2026-08", "2026-09"}
+    assert all("lever not asserted" in s.missing[0] for s in response.skipped)
+
+  def test_response_shape(self) -> None:
+    response, _ = _run(_mechanics(FULL_LEVERS), FULL_RULES, FULL_LEVERS)
+    assert response.scenario_id == "struct_budget"
+    assert response.base_period == "2026-06"
+    assert response.months == 3
+    assert [m.period for m in response.months_computed] == ALL_MONTHS
+    july = response.months_computed[0]
+    assert july.period_start == date(2026, 7, 1)
+    assert july.period_end == JUL
+    assert july.income_statement_fact_set_id is not None
+    assert july.balance_sheet_fact_set_id is not None
+    assert july.computed_count == 5  # 4 IS facts + 1 BS instant
+
+  def test_provenance_carries_month_index_and_drivers(self) -> None:
+    _, rec = _run(_mechanics(FULL_LEVERS), FULL_RULES, FULL_LEVERS)
+    call = rec.month("struct_is", AUG)
+    assert call is not None
+    provenance = call["provenance"]
+    assert provenance.origin == "forecast"
+    assert provenance.scenario_structure_id == "struct_budget"
+    assert provenance.month_index == 2
+    assert "rs-driver:RevenueGrowthRate" in provenance.drivers
+    assert call["scenario_id"] == "struct_budget"
+
+  def test_months_capped_at_horizon(self) -> None:
+    with pytest.raises(ValueError, match="exceeds the block's horizon"):
+      _run(_mechanics(FULL_LEVERS), FULL_RULES, FULL_LEVERS, months=12)
+
+  def test_wrong_block_type_rejected(self) -> None:
+    structure = SimpleNamespace(id="struct_metric", block_type="metric")
+    session = MagicMock()
+    session.get.return_value = structure
+    with pytest.raises(ValueError, match="block_type='forecast'"):
+      fc.cmd_compute_forecast(
+        session,
+        ComputeForecastRequest(structure_id="struct_metric"),
+        "usr_test",
+      )
+
+
+class TestUpsertMonthSet:
+  def test_creates_scenario_keyed_set_with_typed_facts(self) -> None:
+    session = MagicMock()
+    session.execute.return_value.scalar_one_or_none.return_value = None
+    added: list[Any] = []
+    session.add.side_effect = added.append
+
+    from robosystems.models.api.fact_provenance import ForecastProvenance
+
+    provenance = ForecastProvenance(
+      scenario_structure_id="struct_budget",
+      base_period="2026-06",
+      month_index=1,
+      drivers=[],
+    )
+    with patch.object(
+      fc, "create_fact_set", return_value=SimpleNamespace(id="fs_new")
+    ) as create_fs:
+      set_id = fc._upsert_month_set(
+        session,
+        structure_id="struct_is",
+        entity_id="ent_1",
+        scenario_id="struct_budget",
+        period_start=date(2026, 7, 1),
+        period_end=JUL,
+        provenance=provenance,
+        created_by="usr_test",
+        facts=[(EL_REV, 103.0), (EL_AR, 154.5)],
+      )
+
+    assert set_id == "fs_new"
+    kwargs = create_fs.call_args.kwargs
+    assert kwargs["scenario_id"] == "struct_budget"
+    assert kwargs["factset_type"] == "report"
+    assert kwargs["provenance"] is provenance
+
+    by_element = {f.element_id: f for f in added}
+    duration = by_element["el_rev"]
+    assert duration.period_type == "duration"
+    assert duration.period_start == date(2026, 7, 1)
+    instant = by_element["el_ar"]
+    assert instant.period_type == "instant"
+    assert instant.period_start is None
+
+  def test_rerun_replaces_facts_and_restamps_provenance(self) -> None:
+    standing = MagicMock()
+    standing.id = "fs_existing"
+    old_facts = [MagicMock(), MagicMock()]
+
+    session = MagicMock()
+    first = MagicMock()
+    first.scalar_one_or_none.return_value = standing
+    second = MagicMock()
+    second.scalars.return_value.all.return_value = old_facts
+    session.execute.side_effect = [first, second]
+
+    from robosystems.models.api.fact_provenance import ForecastProvenance
+
+    provenance = ForecastProvenance(
+      scenario_structure_id="struct_budget",
+      base_period="2026-06",
+      month_index=1,
+      drivers=["rs-driver:RevenueGrowthRate"],
+    )
+    set_id = fc._upsert_month_set(
+      session,
+      structure_id="struct_is",
+      entity_id="ent_1",
+      scenario_id="struct_budget",
+      period_start=date(2026, 7, 1),
+      period_end=JUL,
+      provenance=provenance,
+      created_by="usr_test",
+      facts=[(EL_REV, 104.0)],
+    )
+
+    assert set_id == "fs_existing"
+    deleted = [call.args[0] for call in session.delete.call_args_list]
+    assert deleted == old_facts
+    assert standing.provenance == provenance.model_dump(mode="json")
+
+  def test_empty_facts_emit_nothing(self) -> None:
+    session = MagicMock()
+
+    from robosystems.models.api.fact_provenance import ForecastProvenance
+
+    result = fc._upsert_month_set(
+      session,
+      structure_id="struct_bs",
+      entity_id="ent_1",
+      scenario_id="struct_budget",
+      period_start=date(2026, 7, 1),
+      period_end=JUL,
+      provenance=ForecastProvenance(
+        scenario_structure_id="struct_budget",
+        base_period="2026-06",
+        month_index=1,
+      ),
+      created_by="usr_test",
+      facts=[],
+    )
+    assert result is None
+    session.execute.assert_not_called()

--- a/tests/operations/information_block/test_forecast_handlers.py
+++ b/tests/operations/information_block/test_forecast_handlers.py
@@ -1,0 +1,487 @@
+"""Forecast handler tests — the authored scenario container.
+
+Exercises create / update / delete / build_envelope plus the base-period
+resolution and lever-expansion helpers for the ``forecast`` block type.
+The derivation walk is tested separately in ``test_forecast_compute.py``
+— this file only covers authoring + envelope shape.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from robosystems.models.api.extensions.forecasts import (
+  CreateForecastRequest,
+  DeleteForecastRequest,
+  LeverAssertionRequest,
+  UpdateForecastRequest,
+)
+from robosystems.models.api.information_block import (
+  ForecastMechanics,
+  LeverAssertionLite,
+)
+from robosystems.operations.information_block import forecast as forecast_handlers
+
+
+def _element(
+  element_id: str,
+  qname: str,
+  *,
+  source: str = "rs-driver",
+  item_type: str | None = "percent",
+  taxonomy_id: str = "tax_rs_driver",
+) -> MagicMock:
+  el = MagicMock()
+  el.id = element_id
+  el.qname = qname
+  el.source = source
+  el.item_type = item_type
+  el.taxonomy_id = taxonomy_id
+  el.is_monetary = False
+  el.name = qname.split(":")[-1]
+  el.code = None
+  el.element_type = "concept"
+  el.is_abstract = False
+  el.balance_type = "debit"
+  el.period_type = "duration"
+  return el
+
+
+GROWTH = _element("el_growth", "rs-driver:RevenueGrowthRate")
+DSO = _element("el_dso", "rs-driver:DaysSalesOutstanding", item_type="days")
+
+
+def _body(**overrides: Any) -> CreateForecastRequest:
+  payload: dict[str, Any] = {
+    "name": "FY26 Operating Budget",
+    "scenario_kind": "budget",
+    "horizon_months": 3,
+    "levers": [
+      LeverAssertionRequest(qname="rs-driver:RevenueGrowthRate", value=0.03),
+    ],
+  }
+  payload.update(overrides)
+  return CreateForecastRequest(**payload)
+
+
+class TestExpandLevers:
+  def _session(self, *elements: MagicMock) -> MagicMock:
+    session = MagicMock()
+    session.execute.return_value.scalar_one_or_none.side_effect = list(elements)
+    return session
+
+  def test_uniform_fill_covers_every_horizon_month(self) -> None:
+    session = self._session(GROWTH)
+    expanded = forecast_handlers._expand_levers(
+      session,
+      [LeverAssertionRequest(qname="rs-driver:RevenueGrowthRate", value=0.03)],
+      "2026-06",
+      3,
+    )
+    assert len(expanded) == 1
+    lever = expanded[0]
+    assert lever.element_id == "el_growth"
+    assert lever.item_type == "percent"
+    assert lever.values_by_period == {
+      "2026-07": 0.03,
+      "2026-08": 0.03,
+      "2026-09": 0.03,
+    }
+
+  def test_overrides_win_over_uniform_fill(self) -> None:
+    session = self._session(GROWTH)
+    expanded = forecast_handlers._expand_levers(
+      session,
+      [
+        LeverAssertionRequest(
+          qname="rs-driver:RevenueGrowthRate",
+          value=0.03,
+          values_by_period={"2026-08": 0.05},
+        )
+      ],
+      "2026-06",
+      3,
+    )
+    assert expanded[0].values_by_period["2026-08"] == 0.05
+    assert expanded[0].values_by_period["2026-07"] == 0.03
+
+  def test_override_only_leaves_uncovered_months_unasserted(self) -> None:
+    session = self._session(DSO)
+    expanded = forecast_handlers._expand_levers(
+      session,
+      [
+        LeverAssertionRequest(
+          qname="rs-driver:DaysSalesOutstanding",
+          values_by_period={"2026-07": 45.0},
+        )
+      ],
+      "2026-06",
+      3,
+    )
+    assert expanded[0].values_by_period == {"2026-07": 45.0}
+
+  def test_rejects_unresolved_qname(self) -> None:
+    session = self._session(None)
+    with pytest.raises(ValueError, match="did not resolve"):
+      forecast_handlers._expand_levers(
+        session,
+        [LeverAssertionRequest(qname="rs-driver:Nope", value=1.0)],
+        "2026-06",
+        3,
+      )
+
+  def test_rejects_non_rs_driver_source(self) -> None:
+    imposter = _element("el_rev", "rs-gaap:Revenues", source="rs-gaap")
+    session = self._session(imposter)
+    with pytest.raises(ValueError, match="rs-driver"):
+      forecast_handlers._expand_levers(
+        session,
+        [LeverAssertionRequest(qname="rs-gaap:Revenues", value=1.0)],
+        "2026-06",
+        3,
+      )
+
+  def test_rejects_duplicate_lever(self) -> None:
+    session = self._session(GROWTH, GROWTH)
+    with pytest.raises(ValueError, match="Duplicate lever"):
+      forecast_handlers._expand_levers(
+        session,
+        [
+          LeverAssertionRequest(qname="rs-driver:RevenueGrowthRate", value=0.03),
+          LeverAssertionRequest(qname="rs-driver:RevenueGrowthRate", value=0.04),
+        ],
+        "2026-06",
+        3,
+      )
+
+  def test_rejects_override_outside_horizon(self) -> None:
+    session = self._session(GROWTH)
+    with pytest.raises(ValueError, match="outside the horizon"):
+      forecast_handlers._expand_levers(
+        session,
+        [
+          LeverAssertionRequest(
+            qname="rs-driver:RevenueGrowthRate",
+            values_by_period={"2027-01": 0.03},
+          )
+        ],
+        "2026-06",
+        3,
+      )
+
+
+class TestResolveBasePeriod:
+  def test_request_value_wins(self) -> None:
+    session = MagicMock()
+    assert (
+      forecast_handlers._resolve_base_period(session, "ent_1", "2026-03") == "2026-03"
+    )
+    session.query.assert_not_called()
+
+  def test_fiscal_calendar_closed_through(self) -> None:
+    session = MagicMock()
+    calendar = SimpleNamespace(closed_through_period="2026-05")
+    session.query.return_value.order_by.return_value.first.return_value = calendar
+    assert forecast_handlers._resolve_base_period(session, "ent_1", None) == "2026-05"
+
+  def test_data_driven_fallback_from_newest_report_month(self) -> None:
+    session = MagicMock()
+    session.query.return_value.order_by.return_value.first.return_value = None
+    with patch.object(
+      forecast_handlers,
+      "_latest_report_period_end_before",
+      return_value=date(2026, 4, 30),
+    ):
+      assert forecast_handlers._resolve_base_period(session, "ent_1", None) == "2026-04"
+
+  def test_raises_when_nothing_to_project_from(self) -> None:
+    session = MagicMock()
+    session.query.return_value.order_by.return_value.first.return_value = None
+    with (
+      patch.object(
+        forecast_handlers, "_latest_report_period_end_before", return_value=None
+      ),
+      pytest.raises(ValueError, match="Cannot resolve a base period"),
+    ):
+      forecast_handlers._resolve_base_period(session, "ent_1", None)
+
+
+class TestCreate:
+  def test_persists_structure_with_mechanics_and_lever_set(self) -> None:
+    session = MagicMock()
+    # _expand_levers element lookup, then session.get for the taxonomy owner.
+    session.execute.return_value.scalar_one_or_none.side_effect = [GROWTH]
+    session.get.return_value = GROWTH
+
+    added: list[Any] = []
+    session.add.side_effect = added.append
+
+    def _flush() -> None:
+      if added:
+        added[0].id = "struct_budget_01"
+
+    session.flush.side_effect = _flush
+
+    with (
+      patch.object(forecast_handlers, "_default_entity_id", return_value="ent_1"),
+      patch.object(forecast_handlers, "_resolve_base_period", return_value="2026-06"),
+      patch.object(forecast_handlers, "_write_lever_fact_set") as write_levers,
+    ):
+      structure_id = forecast_handlers.create(session, _body(), "usr_test")
+
+    assert structure_id == "struct_budget_01"
+    persisted = added[0]
+    assert persisted.block_type == "forecast"
+    assert persisted.taxonomy_id == "tax_rs_driver"
+    assert persisted.concept_arrangement == "set"
+
+    mech = ForecastMechanics.model_validate(persisted.artifact_mechanics)
+    assert mech.scenario_kind == "budget"
+    assert mech.horizon_months == 3
+    assert mech.base_period == "2026-06"
+    assert mech.levers[0].qname == "rs-driver:RevenueGrowthRate"
+    assert mech.computed_months == 0
+
+    write_levers.assert_called_once()
+    session.commit.assert_called_once()
+
+  def test_rejects_wrong_source_before_persisting(self) -> None:
+    imposter = _element("el_rev", "rs-gaap:Revenues", source="rs-gaap")
+    session = MagicMock()
+    session.execute.return_value.scalar_one_or_none.side_effect = [imposter]
+    with (
+      patch.object(forecast_handlers, "_default_entity_id", return_value="ent_1"),
+      patch.object(forecast_handlers, "_resolve_base_period", return_value="2026-06"),
+      pytest.raises(ValueError, match="rs-driver"),
+    ):
+      forecast_handlers.create(
+        session,
+        _body(levers=[LeverAssertionRequest(qname="rs-gaap:Revenues", value=1.0)]),
+        "usr_test",
+      )
+    session.commit.assert_not_called()
+
+
+class TestWriteLeverFactSet:
+  def test_self_referential_scenario_set_with_asserted_provenance(self) -> None:
+    structure = SimpleNamespace(id="struct_budget_01")
+    mechanics = ForecastMechanics(
+      scenario_kind="budget",
+      horizon_months=2,
+      base_period="2026-06",
+      levers=[
+        LeverAssertionLite(
+          qname="rs-driver:RevenueGrowthRate",
+          element_id="el_growth",
+          item_type="percent",
+          values_by_period={"2026-07": 0.03, "2026-08": 0.03},
+        )
+      ],
+    )
+    session = MagicMock()
+    session.execute.return_value.scalars.return_value.all.return_value = [GROWTH]
+    added_facts: list[Any] = []
+    session.add.side_effect = added_facts.append
+
+    with patch.object(
+      forecast_handlers,
+      "create_fact_set",
+      return_value=SimpleNamespace(id="fs_lever"),
+    ) as create_fs:
+      fact_set = forecast_handlers._write_lever_fact_set(
+        session, structure, mechanics, "ent_1", "usr_test"
+      )
+
+    assert fact_set.id == "fs_lever"
+    kwargs = create_fs.call_args.kwargs
+    # The block IS the scenario — levers key into its own slice, so they
+    # cascade-delete with it and never surface on actuals reads.
+    assert kwargs["structure_id"] == "struct_budget_01"
+    assert kwargs["scenario_id"] == "struct_budget_01"
+    assert kwargs["factset_type"] == "custom"
+    assert kwargs["period_start"] == date(2026, 7, 1)
+    assert kwargs["period_end"] == date(2026, 8, 31)
+    assert kwargs["provenance"].origin == "asserted"
+    assert kwargs["provenance"].source_system == "forecast-levers"
+
+    assert len(added_facts) == 2
+    first = added_facts[0]
+    assert first.element_id == "el_growth"
+    assert first.value == 0.03
+    assert first.period_start == date(2026, 7, 1)
+    assert first.period_end == date(2026, 7, 31)
+    assert first.period_type == "duration"
+    assert first.unit == "pure"  # percent → 'pure'
+
+
+class TestUpdate:
+  def _structure(self) -> MagicMock:
+    structure = MagicMock()
+    structure.id = "struct_budget_01"
+    structure.block_type = "forecast"
+    structure.artifact_mechanics = ForecastMechanics(
+      scenario_kind="budget",
+      horizon_months=3,
+      base_period="2026-06",
+      levers=[
+        LeverAssertionLite(
+          qname="rs-driver:RevenueGrowthRate",
+          element_id="el_growth",
+          item_type="percent",
+          values_by_period={"2026-07": 0.03, "2026-08": 0.03, "2026-09": 0.03},
+        )
+      ],
+    ).model_dump(mode="json")
+    return structure
+
+  def test_name_only_update_preserves_mechanics_and_levers(self) -> None:
+    structure = self._structure()
+    session = MagicMock()
+    session.get.return_value = structure
+
+    forecast_handlers.update(
+      session,
+      UpdateForecastRequest(structure_id="struct_budget_01", name="Renamed"),
+      "usr_test",
+    )
+
+    assert structure.name == "Renamed"
+    mech = ForecastMechanics.model_validate(structure.artifact_mechanics)
+    assert mech.horizon_months == 3
+    assert mech.levers[0].values_by_period["2026-07"] == 0.03
+    # No lever replacement → the lever FactSet is untouched.
+    session.delete.assert_not_called()
+
+  def test_window_change_requires_levers(self) -> None:
+    structure = self._structure()
+    session = MagicMock()
+    session.get.return_value = structure
+    with pytest.raises(ValueError, match="re-supplying `levers`"):
+      forecast_handlers.update(
+        session,
+        UpdateForecastRequest(structure_id="struct_budget_01", horizon_months=6),
+        "usr_test",
+      )
+    session.commit.assert_not_called()
+
+  def test_missing_or_wrong_type_raises(self) -> None:
+    session = MagicMock()
+    session.get.return_value = None
+    with pytest.raises(ValueError, match="not found"):
+      forecast_handlers.update(
+        session,
+        UpdateForecastRequest(structure_id="struct_gone", name="x"),
+        "usr_test",
+      )
+
+
+class TestDelete:
+  def test_deletes_every_scenario_set_then_the_structure(self) -> None:
+    structure = MagicMock()
+    structure.id = "struct_budget_01"
+    structure.block_type = "forecast"
+    session = MagicMock()
+    session.get.return_value = structure
+
+    lever_set = SimpleNamespace(id="fs_lever")
+    month_set = SimpleNamespace(id="fs_july_is")
+    session.execute.return_value.scalars.return_value.all.return_value = [
+      lever_set,
+      month_set,
+    ]
+
+    result = forecast_handlers.delete(
+      session, DeleteForecastRequest(structure_id="struct_budget_01"), "usr_test"
+    )
+
+    assert result == "struct_budget_01"
+    deleted = [call.args[0] for call in session.delete.call_args_list]
+    # Scenario sets first (they attach to OTHER structures — the
+    # structure delete alone wouldn't reach them), then the block.
+    assert deleted == [lever_set, month_set, structure]
+    session.commit.assert_called_once()
+
+
+class TestBuildEnvelope:
+  def test_renders_lever_grid_with_computed_months(self) -> None:
+    structure = MagicMock()
+    structure.id = "struct_budget_01"
+    structure.block_type = "forecast"
+    structure.name = "FY26 Operating Budget"
+    structure.description = None
+    structure.renderer_note = None
+    structure.taxonomy_id = "tax_rs_driver"
+    structure.concept_arrangement = "set"
+    structure.member_arrangement = None
+    structure.artifact_mechanics = ForecastMechanics(
+      scenario_kind="budget",
+      horizon_months=2,
+      base_period="2026-06",
+      levers=[
+        LeverAssertionLite(
+          qname="rs-driver:RevenueGrowthRate",
+          element_id="el_growth",
+          item_type="percent",
+          values_by_period={"2026-07": 0.03},
+        )
+      ],
+    ).model_dump(mode="json")
+
+    atoms = SimpleNamespace(
+      structure=structure,
+      taxonomy_name="rs-driver",
+      associations=[],
+      elements=[],
+      element_ids=[],
+      rules=[],
+      classifications_by_assoc={},
+      fact_set=None,
+      verification_results=[],
+      verification_summary=None,
+    )
+
+    session = MagicMock()
+    computed_result = MagicMock()
+    computed_result.scalars.return_value.all.return_value = [date(2026, 7, 31)]
+    elements_result = MagicMock()
+    elements_result.scalars.return_value.all.return_value = [GROWTH]
+    lever_set_result = MagicMock()
+    lever_set_result.scalar_one_or_none.return_value = None
+    session.execute.side_effect = [computed_result, elements_result, lever_set_result]
+
+    with patch.object(
+      forecast_handlers, "load_base_envelope_atoms", return_value=atoms
+    ):
+      envelope = forecast_handlers.build_envelope(session, "struct_budget_01")
+
+    assert envelope is not None
+    assert envelope.block_type == "forecast"
+    assert envelope.display_name == "Forecast"
+    assert envelope.category == "Planning"
+
+    mechanics = envelope.artifact.mechanics
+    assert mechanics.kind == "forecast"
+    assert mechanics.computed_months == 1
+
+    rendering = envelope.view.rendering
+    assert rendering is not None
+    assert len(rendering.rows) == 1
+    row = rendering.rows[0]
+    assert row.element_qname == "rs-driver:RevenueGrowthRate"
+    assert row.item_type == "percent"
+    # Horizon columns: 2026-07 asserted, 2026-08 unasserted → None.
+    assert row.values == [0.03, None]
+    assert [p.end for p in rendering.periods] == [
+      date(2026, 7, 31),
+      date(2026, 8, 31),
+    ]
+
+  def test_returns_none_for_wrong_block_type(self) -> None:
+    session = MagicMock()
+    with patch.object(forecast_handlers, "load_base_envelope_atoms", return_value=None):
+      assert forecast_handlers.build_envelope(session, "struct_schedule") is None

--- a/tests/operations/information_block/test_metric_handlers.py
+++ b/tests/operations/information_block/test_metric_handlers.py
@@ -65,7 +65,9 @@ def _arc(to_element_id: str, order: float) -> SimpleNamespace:
   )
 
 
-def _fact_set(fs_id: str, period_end: date) -> SimpleNamespace:
+def _fact_set(
+  fs_id: str, period_end: date, scenario_id: str | None = None
+) -> SimpleNamespace:
   return SimpleNamespace(
     id=fs_id,
     structure_id="str_metrics",
@@ -74,6 +76,7 @@ def _fact_set(fs_id: str, period_end: date) -> SimpleNamespace:
     factset_type="metric",
     entity_id="ent_1",
     report_id=None,
+    scenario_id=scenario_id,
     provenance={"origin": "derived", "computation": "compute-metrics"},
   )
 

--- a/tests/operations/information_block/test_metric_handlers.py
+++ b/tests/operations/information_block/test_metric_handlers.py
@@ -284,3 +284,44 @@ class TestBuildEnvelope:
     assert mechanics.source_block_ids == []
     assert mechanics.derivation_type is None
     assert mechanics.expression is None
+
+
+class TestScenarioSeriesMerge:
+  """The moving seam: scenario mode merges actual + scenario standing
+  sets into one continuous series, actuals preferred at any overlap."""
+
+  P_MAR = date(2026, 3, 31)
+  P_APR = date(2026, 4, 30)
+
+  def test_default_query_pins_actuals(self) -> None:
+    session = MagicMock()
+    session.execute.return_value = _scalars([])
+    metric_handlers._load_metric_fact_sets(session, "str_metrics", None)
+    stmt = session.execute.call_args.args[0]
+    sql = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+    assert "scenario_id IS NULL" in sql
+
+  def test_scenario_query_widens_to_both_slices(self) -> None:
+    session = MagicMock()
+    session.execute.return_value = _scalars([])
+    metric_handlers._load_metric_fact_sets(
+      session, "str_metrics", None, "struct_budget"
+    )
+    stmt = session.execute.call_args.args[0]
+    sql = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+    assert "scenario_id IS NULL" in sql
+    assert "scenario_id = 'struct_budget'" in sql
+
+  def test_seam_prefers_actual_at_overlapping_period_end(self) -> None:
+    """The query orders actuals (NULL scenario) before scenario rows per
+    period_end; the per-period dedupe keeps the first — so a month that
+    closed after the forecast was computed reads as actual."""
+    actual_mar = _fact_set("fs_actual_mar", self.P_MAR, scenario_id=None)
+    scenario_mar = _fact_set("fs_scn_mar", self.P_MAR, scenario_id="struct_budget")
+    scenario_apr = _fact_set("fs_scn_apr", self.P_APR, scenario_id="struct_budget")
+    session = MagicMock()
+    session.execute.return_value = _scalars([actual_mar, scenario_mar, scenario_apr])
+    merged = metric_handlers._load_metric_fact_sets(
+      session, "str_metrics", None, "struct_budget"
+    )
+    assert [fs.id for fs in merged] == ["fs_actual_mar", "fs_scn_apr"]

--- a/tests/operations/information_block/test_metrics_compute.py
+++ b/tests/operations/information_block/test_metrics_compute.py
@@ -724,3 +724,60 @@ class TestUnitFamilies:
       response = metrics_mod.cmd_compute_metrics(session, _body(), "usr_1")
 
     assert response.computed[0].unit == "USD"
+
+
+class TestScenarioBinding:
+  """The scenario pins on operand binding — the compute-side half of the
+  hijack fix. Asserted on the emitted SQL (the predicates ARE the
+  behavior; full-cascade coverage lives in the forecast compute tests
+  and the showcase e2e)."""
+
+  def _captured_sql(self, session: MagicMock) -> str:
+    stmt = session.execute.call_args.args[0]
+    return str(stmt.compile(compile_kwargs={"literal_binds": True}))
+
+  def test_bind_operand_default_pins_actuals(self) -> None:
+    session = MagicMock()
+    session.execute.return_value.first.return_value = None
+    metrics_mod._bind_operand(
+      session,
+      element_id="el_1",
+      entity_id="ent_1",
+      period_end=date(2026, 3, 31),
+      period_start=None,
+    )
+    sql = self._captured_sql(session)
+    assert "scenario_id IS NULL" in sql
+
+  def test_bind_operand_scenario_widens_with_actual_fallback(self) -> None:
+    """Scenario binds reach the scenario slice AND actuals — the seam
+    fallback that lets an avg() begin bind at the actual base month."""
+    session = MagicMock()
+    session.execute.return_value.first.return_value = None
+    metrics_mod._bind_operand(
+      session,
+      element_id="el_1",
+      entity_id="ent_1",
+      period_end=date(2026, 4, 30),
+      period_start=None,
+      scenario_id="struct_budget",
+    )
+    sql = self._captured_sql(session)
+    assert "scenario_id IS NULL" in sql
+    assert "scenario_id = 'struct_budget'" in sql
+
+  def test_prior_period_spine_default_pins_actuals(self) -> None:
+    session = MagicMock()
+    session.execute.return_value.scalar.return_value = None
+    metrics_mod._latest_report_period_end_before(session, "ent_1", date(2026, 3, 31))
+    sql = self._captured_sql(session)
+    assert "scenario_id IS NULL" in sql
+
+  def test_prior_period_spine_scenario_widens(self) -> None:
+    session = MagicMock()
+    session.execute.return_value.scalar.return_value = None
+    metrics_mod._latest_report_period_end_before(
+      session, "ent_1", date(2026, 4, 30), "struct_budget"
+    )
+    sql = self._captured_sql(session)
+    assert "scenario_id = 'struct_budget'" in sql

--- a/tests/operations/information_block/test_reads.py
+++ b/tests/operations/information_block/test_reads.py
@@ -77,7 +77,7 @@ class TestGetInformationBlock:
     with patch.dict(REGISTRY_PATH, {"schedule": patched}):
       result = get_information_block(session, "struct_1")
     assert result is expected
-    mock_build.assert_called_once_with(session, "struct_1", None)
+    mock_build.assert_called_once_with(session, "struct_1", None, scenario_id=None)
 
 
 # ── list_information_blocks ────────────────────────────────────────────────
@@ -303,4 +303,4 @@ class TestGetInformationBlockForFactSet:
       result = get_information_block_for_fact_set(session, "fs_01")
 
     assert result is expected
-    mock_build.assert_called_once_with(session, "struct_1", "fs_01")
+    mock_build.assert_called_once_with(session, "struct_1", "fs_01", scenario_id=None)

--- a/tests/operations/information_block/test_registry.py
+++ b/tests/operations/information_block/test_registry.py
@@ -59,10 +59,12 @@ class TestRegistry:
 
   def test_list_registered_returns_all_entries(self) -> None:
     entries = list_registered()
-    # Schedule + rollforward + 5 statement block types + disclosure + metric.
+    # Schedule + rollforward + forecast + 5 statement block types +
+    # disclosure + metric.
     assert [e.id for e in entries] == [
       "schedule",
       "rollforward",
+      "forecast",
       *STATEMENT_BLOCK_IDS,
       "regulatory_disclosure",
       "metric",

--- a/tests/operations/information_block/test_schedule_handlers.py
+++ b/tests/operations/information_block/test_schedule_handlers.py
@@ -327,6 +327,7 @@ class TestBuildEnvelope:
     fact_set.factset_type = "schedule"
     fact_set.entity_id = "ent_demo"
     fact_set.report_id = None
+    fact_set.scenario_id = None
     fact_set.provenance = {
       "origin": "schedule",
       "structure_id": "struct_dep",

--- a/tests/operations/information_block/test_statement_handlers.py
+++ b/tests/operations/information_block/test_statement_handlers.py
@@ -307,6 +307,7 @@ class TestBuildEnvelope:
     fact_set.factset_type = "report"
     fact_set.entity_id = "ent_demo"
     fact_set.report_id = "rep_latest"
+    fact_set.scenario_id = None
     fact_set.provenance = {
       "origin": "pivot",
       "mapping_id": "map_1",

--- a/tests/taxonomy/test_forecast_migration_shape.py
+++ b/tests/taxonomy/test_forecast_migration_shape.py
@@ -1,0 +1,125 @@
+"""Shape tests for the forecast/scenario plumbing across the migration surface.
+
+Static checks — no DB round-trip (the extensions-DB migration harness
+lives in the dev loop). Locks down the six-way CHECK/vocabulary sync
+that a typo in any one file would silently drift:
+
+- Migration 0024's widened constants admit ``'forecast'`` (block_type)
+  and ``'rs-driver'`` (element source), and its narrow constants don't.
+- Migration 0002's fresh-path source CHECK admits ``'rs-driver'`` (its
+  seed reads the current frameworks/ manifest, which now lists
+  rs-driver — without the widen a fresh DB CheckViolations at 0002).
+- ``_widen_library_checks`` (fresh tenant provisioning) carries both.
+- The SQLAlchemy models carry both.
+- The rs-gaap@v1 manifest lists rs-driver at ordinal 15.
+"""
+
+from __future__ import annotations
+
+import importlib.util as _util
+import json
+from pathlib import Path
+
+_VERSIONS = (
+  Path(__file__).resolve().parents[2] / "migrations" / "extensions" / "versions"
+)
+
+
+def _load_migration(filename: str, name: str):
+  spec = _util.spec_from_file_location(name, _VERSIONS / filename)
+  assert spec is not None and spec.loader is not None
+  module = _util.module_from_spec(spec)
+  spec.loader.exec_module(module)
+  return module
+
+
+mig_0002 = _load_migration("0002_taxonomy_library.py", "mig_0002_forecast_shape")
+mig_0024 = _load_migration("0024_forecast.py", "mig_0024")
+
+
+class TestMigration0024Constants:
+  def test_widened_block_type_admits_forecast(self) -> None:
+    assert "'forecast'" in mig_0024._BLOCK_TYPE_WIDENED
+    assert "'forecast'" not in mig_0024._BLOCK_TYPE_ORIGINAL
+
+  def test_widened_source_admits_rs_driver(self) -> None:
+    assert "'rs-driver'" in mig_0024._SOURCE_WIDENED
+    assert "'rs-driver'" not in mig_0024._SOURCE_ORIGINAL
+
+  def test_package_identity(self) -> None:
+    assert mig_0024._PACKAGE_STANDARD == "rs-driver"
+    assert mig_0024._PACKAGE_VERSION == "v1"
+    assert mig_0024._PACKAGE_ORDINAL == 15
+
+  def test_original_source_matches_0022_widened(self) -> None:
+    """0024's narrow target IS 0022's widened state — the downgrade
+    restores exactly the pre-0024 vocabulary."""
+    mig_0022 = _load_migration("0022_metrics.py", "mig_0022_forecast_shape")
+    assert mig_0024._SOURCE_ORIGINAL.replace(" ", "").replace(
+      "\n", ""
+    ) == mig_0022._SOURCE_WIDENED.replace(" ", "").replace("\n", "")
+
+
+class TestFreshPathParity:
+  def test_0002_source_check_admits_rs_driver(self) -> None:
+    """0002's seed is dynamic (reads the current manifest) — a fresh DB
+    inserts rs-driver elements AT 0002, before 0024's widen ever runs."""
+    assert "'rs-driver'" in mig_0002._WIDENED_ELEMENT_SOURCE_CHECK
+
+  def test_provisioning_widens_match(self) -> None:
+    """Fresh tenant schemas get their CHECKs from _widen_library_checks,
+    not from the migration chain — it must carry both new values."""
+    import inspect
+
+    from robosystems.db import extensions as extensions_db
+
+    source = inspect.getsource(extensions_db._widen_library_checks)
+    assert "'forecast'" in source
+    assert "'rs-driver'" in source
+
+  def test_models_match(self) -> None:
+    import inspect
+
+    from robosystems.models.extensions import element as element_module
+    from robosystems.models.extensions import structure as structure_module
+
+    assert "'forecast'" in inspect.getsource(structure_module)
+    assert "'rs-driver'" in inspect.getsource(element_module)
+
+  def test_manifest_lists_rs_driver_at_ordinal_15(self) -> None:
+    manifest_path = (
+      Path(__file__).resolve().parents[2] / "frameworks" / "rs-gaap" / "v1.json"
+    )
+    manifest = json.loads(manifest_path.read_text())
+    by_standard = {p["standard"]: p for p in manifest["packages"]}
+    assert "rs-driver" in by_standard
+    assert by_standard["rs-driver"]["ordinal"] == 15
+    assert by_standard["rs-driver"]["version"] == "v1"
+
+
+class TestScenarioAxisDDL:
+  def test_scenario_axis_helpers_cover_column_fk_index(self) -> None:
+    """The 0024 scenario-axis DDL adds the column, the CASCADE FK, and
+    the partial index — and the downgrade drops all three."""
+    import inspect
+
+    add = inspect.getsource(mig_0024._add_scenario_axis)
+    assert "scenario_id" in add
+    assert "fk_fact_sets_scenario" in add
+    assert "idx_fact_sets_scenario" in add
+    assert "CASCADE" in add
+    drop = inspect.getsource(mig_0024._drop_scenario_axis)
+    assert "scenario_id" in drop
+    assert "fk_fact_sets_scenario" in drop
+    assert "idx_fact_sets_scenario" in drop
+
+  def test_model_carries_scenario_column_and_cascade(self) -> None:
+    from robosystems.models.extensions.roboledger.fact_set import FactSet
+
+    column = FactSet.__table__.columns["scenario_id"]
+    assert column.nullable is True
+    fks = list(column.foreign_keys)
+    assert len(fks) == 1
+    assert fks[0].ondelete == "CASCADE"
+    index_names = {idx.name for idx in FactSet.__table__.indexes}
+    assert "idx_fact_sets_scenario" in index_names

--- a/tests/taxonomy/test_rs_driver_seed.py
+++ b/tests/taxonomy/test_rs_driver_seed.py
@@ -1,0 +1,203 @@
+"""Tests for the rs-driver/v1 lever catalog package (Forecast F-1).
+
+Pins the hand-authored artifact's shape: the Driver Catalog container
+(element + reference structure, ``block_type='custom'`` so it never
+renders), four lever concepts with format families, four role-bound
+presentation arcs, and four ``Derive`` rules whose expressions parse
+through the FULL forecast preprocessing (``desugar_priors`` then
+``desugar_aggregates`` — the compute path's exact order) and whose
+targets/operands are rs-gaap anchors present in the core rs-gaap
+package (which the tenant keep-critical curation carries — the DSO
+target is ``ReceivablesNetCurrent``, NOT the tenant-excluded
+``AccountsReceivableNetCurrent``).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from robosystems.operations.information_block.rules.expressions import (
+  desugar_aggregates,
+  desugar_priors,
+  lhs_variable_names,
+  parse_arithmetic_expression,
+)
+from robosystems.taxonomy.discovery import framework_root
+from robosystems.taxonomy.loader import (
+  RULE_CATEGORY_VALUES,
+  RULE_PATTERN_VALUES,
+  load_taxonomy_package,
+)
+from robosystems.taxonomy.model import RuleSpec, TaxonomyPackage
+
+SEED_PATH = framework_root("rs-gaap") / "packages" / "rs-driver" / "v1"
+ROLE_URI = "https://robosystems.ai/seattle/cm-roles/roles/drivers/DriverCatalog"
+
+EXPECTED_CONCEPTS = {
+  "rs-driver:RevenueGrowthRate",
+  "rs-driver:CostOfRevenueRate",
+  "rs-driver:DaysSalesOutstanding",
+  "rs-driver:DaysPayableOutstanding",
+}
+
+EXPECTED_ITEM_TYPES = {
+  "rs-driver:RevenueGrowthRate": "percent",
+  "rs-driver:CostOfRevenueRate": "percent",
+  "rs-driver:DaysSalesOutstanding": "days",
+  "rs-driver:DaysPayableOutstanding": "days",
+}
+
+# target rs-gaap anchor → the lever operand that activates the rule
+EXPECTED_RULE_TARGETS = {
+  "rs-gaap:Revenues": "rs-driver:RevenueGrowthRate",
+  "rs-gaap:CostOfRevenue": "rs-driver:CostOfRevenueRate",
+  "rs-gaap:ReceivablesNetCurrent": "rs-driver:DaysSalesOutstanding",
+  "rs-gaap:AccountsPayableCurrent": "rs-driver:DaysPayableOutstanding",
+}
+
+
+@pytest.fixture(scope="module")
+def package() -> TaxonomyPackage:
+  return load_taxonomy_package(SEED_PATH / "taxonomy.jsonld")
+
+
+@pytest.fixture(scope="module")
+def rules(package: TaxonomyPackage) -> list[RuleSpec]:
+  return package.rules
+
+
+class TestPackageShape:
+  def test_metadata(self, package: TaxonomyPackage) -> None:
+    assert package.standard == "rs-driver"
+    assert package.version == "v1"
+    assert package.taxonomy_type == "reporting_extension"
+    # 'custom' keeps the reference catalog out of the renderable block
+    # surface — it is vocabulary + rules, not an Information Block.
+    assert package.default_block_type == "custom"
+
+  def test_elements(self, package: TaxonomyPackage) -> None:
+    by_qname = {e.qname: e for e in package.elements}
+    assert set(by_qname) == EXPECTED_CONCEPTS | {"rs-driver:DriverCatalog"}
+    assert by_qname["rs-driver:DriverCatalog"].is_abstract
+    for qname in EXPECTED_CONCEPTS:
+      element = by_qname[qname]
+      assert element.element_type == "concept"
+      assert not element.is_monetary
+      # Levers are per-month assertions — durations, never instants.
+      assert element.period_type == "duration"
+    # Namespace prefix as source — the value the 0024 / 0002 /
+    # provisioning check_element_source widening admits and the #893
+    # namespace protection auto-reserves.
+    assert {e.source for e in package.elements} == {"rs-driver"}
+
+  def test_item_types(self, package: TaxonomyPackage) -> None:
+    by_qname = {e.qname: e for e in package.elements}
+    for qname, expected in EXPECTED_ITEM_TYPES.items():
+      assert by_qname[qname].item_type == expected, qname
+
+  def test_structure(self, package: TaxonomyPackage) -> None:
+    assert len(package.structures) == 1
+    structure = package.structures[0]
+    assert structure.block_type == "custom"
+    assert structure.concept_arrangement == "set"
+    assert structure.role_uri == ROLE_URI
+
+  def test_presentation_arcs_bind_catalog_to_role(
+    self, package: TaxonomyPackage
+  ) -> None:
+    arcs = package.associations
+    assert len(arcs) == 4
+    assert {a.to_qname for a in arcs} == EXPECTED_CONCEPTS
+    for arc in arcs:
+      assert arc.from_qname == "rs-driver:DriverCatalog"
+      assert arc.association_type == "presentation"
+      assert arc.role == ROLE_URI
+    assert sorted(a.order for a in arcs) == [1.0, 2.0, 3.0, 4.0]
+
+
+class TestDriverRules:
+  def test_four_derive_rules(self, rules: list[RuleSpec]) -> None:
+    """Regression against the RULE_PATTERN_VALUES gate: an unknown
+    pattern is silently skipped at load."""
+    assert len(rules) == 4
+    for rule in rules:
+      assert rule.rule_pattern == "Derive"
+      assert rule.rule_pattern in RULE_PATTERN_VALUES
+      assert rule.rule_category in RULE_CATEGORY_VALUES
+      assert rule.rule_severity == "info"
+
+  def test_targets_are_rs_gaap_anchors(self, rules: list[RuleSpec]) -> None:
+    """Driver rules target the DRIVEN rs-gaap elements (cross-package,
+    like rs-gaap-rollup-rules) — never the lever concepts themselves."""
+    targets = {}
+    for rule in rules:
+      assert rule.rule_target is not None
+      assert rule.rule_target.target_kind == "element"
+      lever_operands = [
+        v.variable_qname
+        for v in rule.rule_variables
+        if v.variable_qname.startswith("rs-driver:")
+      ]
+      assert len(lever_operands) == 1, rule.id
+      targets[rule.rule_target.target_ref] = lever_operands[0]
+    assert targets == EXPECTED_RULE_TARGETS
+
+  def test_expressions_parse_with_lhs_target_first(self, rules: list[RuleSpec]) -> None:
+    """Every expression parses through desugar_priors + desugar_aggregates
+    (the compute-forecast preprocessing, in order) with the driven anchor
+    as the sole LHS variable, listed first in ruleVariables."""
+    for rule in rules:
+      names = [v.variable_name for v in rule.rule_variables]
+      expression, priors = desugar_priors(rule.rule_expression)
+      expression, avgs = desugar_aggregates(expression)
+      for base in list(priors.values()) + list(avgs.values()):
+        assert base in names, f"{rule.id}: synthesized base {base!r} not declared"
+      parsed = parse_arithmetic_expression(
+        expression, names + list(priors) + list(avgs)
+      )
+      lhs = lhs_variable_names(parsed)
+      assert len(lhs) == 1
+      assert lhs[0] == names[0]
+      assert rule.rule_variables[0].variable_qname == rule.rule_target.target_ref
+
+  def test_compounding_rule_uses_prior_reference(self, rules: list[RuleSpec]) -> None:
+    """GROWTH is the [t-1] consumer: Revenues[t] = Revenues[t-1] x (1+g)."""
+    by_target = {r.rule_target.target_ref: r for r in rules if r.rule_target}
+    _, priors = desugar_priors(by_target["rs-gaap:Revenues"].rule_expression)
+    assert priors == {"__prior_Revenues": "Revenues"}
+    # The other three rules are same-month mechanics — no prior refs.
+    for target in ("rs-gaap:CostOfRevenue", "rs-gaap:ReceivablesNetCurrent"):
+      _, other_priors = desugar_priors(by_target[target].rule_expression)
+      assert other_priors == {}
+
+  def test_qnames_resolve_in_core_rs_gaap_package(
+    self, rules: list[RuleSpec], package: TaxonomyPackage
+  ) -> None:
+    """Targets AND rs-gaap operands must exist in the core rs-gaap
+    package (the keep-critical tenant curation carries them — this is
+    the guard that caught AccountsReceivableNetCurrent, which lives in
+    the tenant-exclude list)."""
+    rs_gaap_path = framework_root("rs-gaap") / "packages" / "rs-gaap" / "v1"
+    raw = json.loads((rs_gaap_path / "taxonomy.jsonld").read_text())
+    rs_gaap_ids = {
+      node.get("@id") for node in raw.get("@graph", []) if isinstance(node, dict)
+    }
+    own_qnames = {e.qname for e in package.elements}
+    for rule in rules:
+      assert rule.rule_target is not None
+      assert rule.rule_target.target_ref in rs_gaap_ids, (
+        f"{rule.id}: target {rule.rule_target.target_ref} not in core rs-gaap/v1"
+      )
+      for var in rule.rule_variables:
+        qname = var.variable_qname
+        if qname.startswith("rs-driver:"):
+          assert qname in own_qnames, (
+            f"{rule.id}: lever operand {qname} not defined in rs-driver/v1"
+          )
+        else:
+          assert qname.startswith("rs-gaap:")
+          assert qname in rs_gaap_ids, (
+            f"{rule.id}: operand {qname} not found in core rs-gaap/v1"
+          )


### PR DESCRIPTION
## Summary

The forecast engine's first commit (FP&A F-1): a **forecast block** is the authored scenario container — scenario identity + lever assertions on the new `rs-driver:*` catalog — and everything downstream is derived. `compute-forecast` walks the driver cascade month-by-month forward from the last closed actuals and lands the results in the **existing** statement/metric block types, keyed by the new `fact_sets.scenario_id` (NULL = actuals). Scope: IS + working capital only; full BS roll/CF articulation and verification gating are F-2.

## What's in it

- **Scenario axis** — `fact_sets.scenario_id` (nullable FK to the owning forecast Structure, `ON DELETE CASCADE`, partial index). The block IS the scenario; deleting it removes its whole parallel universe. Migration `0024_forecast.py` (0022 template: column + CHECK widens + seed + tenant fan-out under `SET_LIBRARY_RESYNC`; up/down verified against a live tenant).
- **rs-driver/v1 lever catalog** (ordinal 15) — GROWTH (compounding via `[t-1]`), rate-on-base, DSO/DPO days-based balances. Derive rules state the mechanics against rs-gaap anchor targets; lever **values** are authored facts. DSO targets `ReceivablesNetCurrent` (the keep-critical anchor tenants carry); DPO bases on `CostOfRevenue` (standard definition, rule-driven so the base exists at eval time).
- **`[t-1]` grammar seam** — `desugar_priors` rewrites `$X[t-1]` to a synthesized operand pre-parse; `ast.Subscript` stays un-whitelisted so any other lag rejects structurally. The grammar ceiling (`[t-1]` + `avg()`) is parser-enforced.
- **`compute-forecast`** (one OperationSpec → REST + MCP; deterministic/non-AI → free): carry-forward for unmodeled IS leaves → active rules in same-month topo order → calc-DAG subtotals (articulation is reuse). Full-replace upserts, soft-skip with carry fallback, `ForecastProvenance`-stamped.
- **Scenario read threading** — every latest-set/operand read now pins `scenario_id IS NULL` by default. This is load-bearing, not cosmetic: scenario sets live at future period_ends, so without the pin one computed forecast month would win the period_end-descending reads. Regression tests assert the emitted SQL. Scenario reads (`scenarioId` on GraphQL/MCP) bind the slice exactly; metric envelopes merge actual + scenario series with **actuals preferred at overlaps** (the moving seam) and "(forecast)" period labels; `compute-metrics` gains `scenario_id` to extend the metric series into forward months. Derive rules are excluded from VerificationResult emission (they compute, they don't check).
- **Forecast authoring** rides the existing generic `create/update/delete-information-block` ops (declarative registry entry) — zero new endpoints; MCP tool auto-generated.

## Verification

- `just test-all` — full suite green (the `test_incremental_equals_full_load` order-dependent failure reproduces identically on `main` and is unrelated; it passes in isolation and in the sequential full run).
- Migration 0024 up/down cycled against the dev DB with a live tenant schema; fresh-path parity pinned by tests (0002 CHECK, `_widen_library_checks`, `CANONICAL_CONTEXT`, `library_creator` sources, manifest ordinal).
- **Driftline e2e** (now a standing step in the showcase runner): scenario authored via the public surface, cascade 12/12 months, month-over-month revenue ratio **1.0300 exact**, AR/(Rev/30) **== 45.0**, actuals metric envelope **unchanged at 15 periods** (the hijack check, live), 26-period scenario series with "(forecast)" columns — the June forecast month is superseded by the open month's draft actuals on read, the moving seam working as designed.

## Deploy notes

**Migration 0024 is deploy-coupled with the reader-threading code** — a scenario FactSet written before readers filter on it would hijack the default actuals envelopes, so backend deploy happens in one window (backfills existing tenants via the resync fan-out). Downstream: typescript-client `feature/scenario-reads` (publish after this deploys), python-client `feature/scenario-reads`, roboledger-app `feature/scenario-explorer` (client bump pending that publish).