### PR TITLE
fix(migrations): unbreak the fresh extensions chain — item_type + rs-driver

### DIFF
--- a/migrations/extensions/versions/0002_taxonomy_library.py
+++ b/migrations/extensions/versions/0002_taxonomy_library.py
@@ -916,6 +916,19 @@ def upgrade() -> None:
   )
 
   # ──────────────────────────────────────────────────────────────────────
+  # 2a. Add item_type BEFORE the seed passes below.
+  # ──────────────────────────────────────────────────────────────────────
+  # The dynamic seed runs the CURRENT ``library_creator``, whose element
+  # upsert has written ``item_type`` since Metrics M-2 — but the column
+  # was historically added at 0021, so a FRESH database chain failed at
+  # this migration's seed with UndefinedColumn (deployed databases never
+  # noticed: they were past 0002 before M-2 shipped). Adding it here
+  # keeps the fresh chain's schema a superset of every column the seed
+  # writes; 0021's ``TenantOps.add_column`` is IF NOT EXISTS, so the
+  # later add is a safe no-op on fresh chains.
+  op.execute("ALTER TABLE elements ADD COLUMN IF NOT EXISTS item_type VARCHAR")
+
+  # ──────────────────────────────────────────────────────────────────────
   # 2b. Canonical-concept columns for cross-tenant unification.
   # ──────────────────────────────────────────────────────────────────────
   # agent_id groups elements that refer to the same cross-tenant concept;
@@ -1589,6 +1602,10 @@ def downgrade() -> None:
   # Drop substitution_group.
   op.drop_index("idx_elements_substitution_group", table_name="elements")
   op.drop_column("elements", "substitution_group")
+
+  # Drop item_type (added pre-seed in upgrade 2a). Tolerant: a chain
+  # walking down through 0021 already dropped it there.
+  op.execute("ALTER TABLE elements DROP COLUMN IF EXISTS item_type")
 
   # Re-add the old columns for 0001 compatibility. Values lost — 0001's
   # seed_reporting_taxonomy rerun repopulates them.

--- a/migrations/extensions/versions/0007_frameworks_bridges.py
+++ b/migrations/extensions/versions/0007_frameworks_bridges.py
@@ -261,7 +261,9 @@ _WIDENED_ELEMENT_SOURCE_CHECK = (
   # schemas (which now contain cm rows) doesn't fail constraint validation.
   # 'rs-metric' — same reason: fresh databases seed the metric catalog at
   # 0002, so the rows exist when this DROP+ADD re-validates them.
-  "'disclosures', 'checklist', 'styles', 'cm', 'rs-metric'"
+  # 'rs-driver' — same reason again: the forecast lever catalog seeds at
+  # 0002 on fresh databases (0024's backfill covers deployed ones).
+  "'disclosures', 'checklist', 'styles', 'cm', 'rs-metric', 'rs-driver'"
   ")"
 )
 _PRIOR_ELEMENT_SOURCE_CHECK = (

--- a/migrations/extensions/versions/0022_metrics.py
+++ b/migrations/extensions/versions/0022_metrics.py
@@ -79,7 +79,10 @@ _SOURCE_WIDENED = (
   "source IN ("
   "'fac', 'rs-gaap', 'us-gaap', 'ifrs', "
   "'quickbooks', 'xero', 'plaid', 'native', 'import', 'system', "
-  "'disclosures', 'checklist', 'styles', 'cm', 'rs-metric'"
+  # 'rs-driver' — fresh databases seed the forecast lever catalog at
+  # 0002 (dynamic manifest), so the rows exist when this DROP+ADD
+  # re-validates them; deployed databases get the value at 0024.
+  "'disclosures', 'checklist', 'styles', 'cm', 'rs-metric', 'rs-driver'"
   ")"
 )
 _SOURCE_ORIGINAL = (

--- a/migrations/extensions/versions/0024_forecast.py
+++ b/migrations/extensions/versions/0024_forecast.py
@@ -92,11 +92,16 @@ _SOURCE_WIDENED = (
   "'disclosures', 'checklist', 'styles', 'cm', 'rs-metric', 'rs-driver'"
   ")"
 )
+# The downgrade target mirrors 0022's _SOURCE_WIDENED as written, which
+# admits 'rs-driver' for fresh-chain correctness (fresh databases seed
+# the catalog at 0002, before this migration exists). Harmless on a
+# deployed downgrade: the package content is deleted first, so the
+# admitted-but-unused value never matches a row.
 _SOURCE_ORIGINAL = (
   "source IN ("
   "'fac', 'rs-gaap', 'us-gaap', 'ifrs', "
   "'quickbooks', 'xero', 'plaid', 'native', 'import', 'system', "
-  "'disclosures', 'checklist', 'styles', 'cm', 'rs-metric'"
+  "'disclosures', 'checklist', 'styles', 'cm', 'rs-metric', 'rs-driver'"
   ")"
 )
 

--- a/tests/taxonomy/test_forecast_migration_shape.py
+++ b/tests/taxonomy/test_forecast_migration_shape.py
@@ -44,7 +44,11 @@ class TestMigration0024Constants:
 
   def test_widened_source_admits_rs_driver(self) -> None:
     assert "'rs-driver'" in mig_0024._SOURCE_WIDENED
-    assert "'rs-driver'" not in mig_0024._SOURCE_ORIGINAL
+    # The downgrade target ALSO admits 'rs-driver' — fresh chains seed
+    # the catalog at 0002 (before this migration exists), so narrowing
+    # it out would break a fresh-chain downgrade. Deployed downgrades
+    # delete the package content first, so the value is unused there.
+    assert "'rs-driver'" in mig_0024._SOURCE_ORIGINAL
 
   def test_package_identity(self) -> None:
     assert mig_0024._PACKAGE_STANDARD == "rs-driver"
@@ -65,6 +69,30 @@ class TestFreshPathParity:
     """0002's seed is dynamic (reads the current manifest) — a fresh DB
     inserts rs-driver elements AT 0002, before 0024's widen ever runs."""
     assert "'rs-driver'" in mig_0002._WIDENED_ELEMENT_SOURCE_CHECK
+
+  def test_0002_adds_item_type_before_the_seed(self) -> None:
+    """The seed runs the CURRENT library_creator, whose element upsert
+    writes item_type (M-2) — the column historically arrived at 0021,
+    so 0002 must pre-create it or every fresh chain fails mid-seed
+    (the 2026-07-23 dagster-daemon rebuild failure)."""
+    import inspect
+
+    source = inspect.getsource(mig_0002.upgrade)
+    add = source.find("ADD COLUMN IF NOT EXISTS item_type")
+    seed = source.find("for seed_path in SEED_FILES")
+    assert add != -1, "0002.upgrade no longer pre-creates elements.item_type"
+    assert seed != -1, "0002.upgrade seed loop moved — update this anchor"
+    assert add < seed, "item_type add must precede the seed passes"
+
+  def test_every_source_check_reinstall_admits_rs_driver(self) -> None:
+    """Migrations between the 0002 seed and the 0024 widen that DROP+ADD
+    check_element_source must admit 'rs-driver' — fresh chains carry the
+    rows from 0002, so a narrower re-install CheckViolations mid-chain
+    (0007 and 0022 both bit during the fresh-chain verification)."""
+    mig_0007 = _load_migration("0007_frameworks_bridges.py", "mig_0007_forecast_shape")
+    mig_0022 = _load_migration("0022_metrics.py", "mig_0022_source_shape")
+    assert "'rs-driver'" in mig_0007._WIDENED_ELEMENT_SOURCE_CHECK
+    assert "'rs-driver'" in mig_0022._SOURCE_WIDENED
 
   def test_provisioning_widens_match(self) -> None:
     """Fresh tenant schemas get their CHECKs from _widen_library_checks,


### PR DESCRIPTION
## Summary

A full local rebuild (fresh extensions DB) tripped the dagster daemon's boot-time migration — and exposed that **every fresh-database chain has been broken since Metrics M-2**, plus a second break F-1 would have added. Deployed databases are unaffected (they were past the failing migrations before the code shipped); this only bites brand-new environments: dev rebuilds, CI fresh DBs, future fresh deploys.

## The two breaks

1. **`item_type` (latent since #915)** — 0002's seed is dynamic: it runs the *current* `library_creator`, whose element upsert has written `item_type` since M-2. The column historically arrived at **0021**, so a fresh chain died at 0002's seed with `UndefinedColumn`. Fix: 0002 pre-creates the column before its seed passes (`ADD COLUMN IF NOT EXISTS`); 0021's `TenantOps.add_column` is already `IF NOT EXISTS`, so its later add no-ops. Tolerant drop in 0002's downgrade.

2. **`rs-driver` source re-installs (would have shipped with F-1)** — 0007 and 0022 both `DROP+ADD check_element_source` with enumerated lists that predate rs-driver. On a fresh chain the catalog rows exist from 0002 (dynamic manifest), so both re-installs `CheckViolation`ed. Both lists now admit `'rs-driver'` — the exact rs-metric precedent (3c7cd8cf touched 0002 + 0007; 0022 is the additional site rs-driver needs because it sits between the seed and the 0024 widen). 0024's downgrade target mirrors 0022-as-written; harmless on deployed downgrades since the package content is deleted first.

## Verification

- Fresh chain **0001 → 0024 completes clean** against the rebuilt local DB (rs-driver seeded at 0002 — 5 elements / 4 arcs / 4 rules; idempotent re-seed at 0024; `migrate-current` = 0024).
- **Dagster daemon boots healthy** (sensors ticking).
- New shape tests pin the invariants: item_type add precedes the seed loop in 0002, and `'rs-driver'` present in every `check_element_source` re-install site (0007, 0022) — the class of drift that produced both breaks.
- `tests/taxonomy/` — 264 passed.