### PR TITLE
feat(forecast): F-2 articulation — BS roll, derived CF, verification gating

### DIFF
--- a/examples/_scenario/runner.py
+++ b/examples/_scenario/runner.py
@@ -1403,6 +1403,8 @@ def run_forecast_scenario(
 
   # 1. Author the scenario — lever VALUES on rs-driver concepts; the
   #    mechanics (what each lever drives) are the library's Derive rules.
+  #    (Provisioning idempotency is owned by ``reset_demo``, which wipes
+  #    prior demo state — including any earlier forecast block.)
   levers = [
     {"qname": qname, "value": value} for qname, value in forecast_levers.items()
   ]
@@ -1433,10 +1435,13 @@ def run_forecast_scenario(
   for qname, value in forecast_levers.items():
     print(f"    {qname.split(':')[-1]}: {value}")
 
-  # 2. Walk the cascade — first to horizon-1 (the compounding probe's
-  #    baseline), then the full horizon (rerun replaces cleanly).
+  # 2. Walk the cascade — first to horizon-1 (the compounding /
+  #    continuity probes' baseline), then the full horizon (rerun
+  #    replaces cleanly).
   is_block_id = _statement_block_id(graph_id, "income_statement")
-  rev_prev = None
+  bs_block_id = _statement_block_id(graph_id, "balance_sheet")
+  cf_block_id = _statement_block_id(graph_id, "cash_flow_statement")
+  rev_prev = cash_prev = re_prev = None
   if is_block_id:
     probe = httpx.post(
       f"{BASE_URL}/extensions/roboledger/{graph_id}/operations/compute-forecast",
@@ -1447,6 +1452,14 @@ def run_forecast_scenario(
     if probe.status_code < 400:
       rendering = _graphql_rendering(graph_id, is_block_id, headers, scenario_id)
       rev_prev = _rendering_value(rendering, "rs-gaap:Revenues")
+      if bs_block_id:
+        probe_bs = _graphql_rendering(graph_id, bs_block_id, headers, scenario_id)
+        cash_prev = _rendering_value(
+          probe_bs, "rs-gaap:CashAndCashEquivalentsAtCarryingValue"
+        )
+        re_prev = _rendering_value(
+          probe_bs, "rs-gaap:RetainedEarningsAccumulatedDeficit"
+        )
 
   resp = httpx.post(
     f"{BASE_URL}/extensions/roboledger/{graph_id}/operations/compute-forecast",
@@ -1486,9 +1499,12 @@ def run_forecast_scenario(
   # 4. Working capital — AR against the same month's revenue must
   #    reproduce the asserted DSO (days-based balance mechanics).
   dso = forecast_levers.get("rs-driver:DaysSalesOutstanding")
-  bs_block_id = _statement_block_id(graph_id, "balance_sheet")
-  if dso and rev_last and bs_block_id:
-    bs_rendering = _graphql_rendering(graph_id, bs_block_id, headers, scenario_id)
+  bs_rendering = (
+    _graphql_rendering(graph_id, bs_block_id, headers, scenario_id)
+    if bs_block_id
+    else {}
+  )
+  if dso and rev_last:
     ar = _rendering_value(bs_rendering, "rs-gaap:ReceivablesNetCurrent")
     if ar is not None:
       implied = ar / (rev_last / 30)
@@ -1496,6 +1512,53 @@ def run_forecast_scenario(
         print(f"  DSO:          AR / (Revenues/30) == {implied:.1f} days")
       else:
         print(f"  WARNING: implied DSO {implied:.4f} != asserted {dso}")
+
+  # 4b. Articulation (F-2) — the three-statement claims, live:
+  #     A = L + E by construction; RE rolls by exactly NI; cash moves by
+  #     exactly the CF net change; every month's rule corpus passes.
+  assets = _rendering_value(bs_rendering, "rs-gaap:Assets")
+  le_total = _rendering_value(bs_rendering, "rs-gaap:LiabilitiesAndStockholdersEquity")
+  if assets is not None and le_total is not None:
+    if abs(assets - le_total) < 0.01:
+      print(f"  A = L + E:    {assets:,.2f} == {le_total:,.2f}")
+    else:
+      print(f"  WARNING: balance sheet out of balance ({assets} != {le_total})")
+  cash_last = _rendering_value(
+    bs_rendering, "rs-gaap:CashAndCashEquivalentsAtCarryingValue"
+  )
+  re_last = _rendering_value(bs_rendering, "rs-gaap:RetainedEarningsAccumulatedDeficit")
+  ni_last = _rendering_value(rendering, "rs-gaap:NetIncomeLoss")
+  if re_prev is not None and re_last is not None and ni_last is not None:
+    if abs((re_last - re_prev) - ni_last) < 0.01:
+      print(f"  RE roll:      ΔRE == NI ({ni_last:,.2f})")
+    else:
+      print(f"  WARNING: ΔRE {re_last - re_prev:,.2f} != NI {ni_last:,.2f}")
+  if cf_block_id and cash_prev is not None and cash_last is not None:
+    cf_rendering = _graphql_rendering(graph_id, cf_block_id, headers, scenario_id)
+    net_change = _rendering_value(
+      cf_rendering, "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease"
+    )
+    if net_change is not None:
+      if abs((cash_last - cash_prev) - net_change) < 0.01:
+        print(f"  Cash roll:    ΔCash == CF net change ({net_change:,.2f})")
+      else:
+        print(
+          f"  WARNING: ΔCash {cash_last - cash_prev:,.2f} != "
+          f"CF net change {net_change:,.2f}"
+        )
+  verified = [m for m in months_computed if m.get("verification_passed")]
+  failed = [m for m in months_computed if m.get("verification_passed") is False]
+  if failed:
+    print(f"  WARNING: {len(failed)} months failed verification")
+    for month in failed[:2]:
+      for failure in (month.get("verification_failures") or [])[:2]:
+        print(f"    {month.get('period')}: {failure}")
+  elif verified:
+    print(f"  Verification: {len(verified)}/{len(months_computed)} months pass")
+  cf_months = [m for m in months_computed if m.get("cash_flow_fact_set_id")]
+  print(f"  Statements:   IS + BS + CF ({len(cf_months)}/{len(months_computed)} CF)")
+  for note in result.get("diagnostics") or []:
+    print(f"    (note) {note}")
 
   # 5. Extend the metric series into the scenario's forward months, then
   #    prove the seam: actuals envelope unchanged, scenario envelope

--- a/robosystems/models/api/information_block.py
+++ b/robosystems/models/api/information_block.py
@@ -1803,12 +1803,31 @@ class ForecastMonthLite(BaseModel):
   balance_sheet_fact_set_id: str | None = Field(
     None,
     description=(
-      "Scenario BS FactSet upserted for the month (working-capital "
-      "instants only in F-1 — the full BS roll is a later phase)."
+      "Scenario BS FactSet upserted for the month — the full roll: "
+      "carry-forward, rule-driven working capital, schedule movements, "
+      "RE roll, balancing cash (A = L + E by construction)."
+    ),
+  )
+  cash_flow_fact_set_id: str | None = Field(
+    None,
+    description=(
+      "Scenario CF FactSet upserted for the month — indirect-method, "
+      "derived from BS deltas + NI, reconciled to the balancing ΔCash."
     ),
   )
   computed_count: int = Field(
-    0, description="Number of facts emitted for the month across both sets."
+    0, description="Number of facts emitted for the month across all sets."
+  )
+  verification_passed: bool | None = Field(
+    None,
+    description=(
+      "Whether every rule evaluated against the month's scenario sets "
+      "passed (None = no rules ran for the month)."
+    ),
+  )
+  verification_failures: list[str] = Field(
+    default_factory=list,
+    description="Failed/errored rule messages for the month (capped).",
   )
 
 
@@ -1886,6 +1905,14 @@ class ComputeForecastResponse(BaseModel):
   months: int = Field(..., description="Forward months requested.")
   months_computed: list[ForecastMonthLite] = Field(default_factory=list)
   skipped: list[SkippedForecastLite] = Field(default_factory=list)
+  diagnostics: list[str] = Field(
+    default_factory=list,
+    description=(
+      "Articulation notes — a missing cash/earnings anchor, schedule "
+      "contributions with no base-set landing spot, an absent "
+      "cash-flow structure. Informational; the walk still computed."
+    ),
+  )
 
 
 __all__ = [

--- a/robosystems/operations/information_block/envelope.py
+++ b/robosystems/operations/information_block/envelope.py
@@ -191,18 +191,35 @@ def verification_result_to_lite(row: VerificationResult) -> VerificationResultLi
 
 
 def load_verification_results_for_structure(
-  session: Session, structure_id: str
+  session: Session, structure_id: str, scenario_id: str | None = None
 ) -> list[VerificationResultLite]:
-  """Fetch verification results scoped to a Structure.
+  """Fetch verification results scoped to a Structure and scenario slice.
 
   Returns the full history ordered by ``evaluated_at`` descending so
   the envelope exposes the most recent run first. Empty list when no
   rows — the common case until the rule engine writes results.
+
+  ``scenario_id`` scopes results the same way FactSet reads are scoped:
+  compute-forecast verifies every scenario month against the statement
+  structures, so without the filter those runs would pollute the
+  actuals envelope's verification list (the verification-bleed analog
+  of the FactSet-read hijack). ``None`` keeps structure-level results
+  (``fact_set_id IS NULL``) plus results pinned to actuals sets; a
+  scenario id swaps the pinned half for that scenario's sets.
   """
+  scenario_predicate = (
+    FactSet.scenario_id.is_(None)
+    if scenario_id is None
+    else FactSet.scenario_id == scenario_id
+  )
   rows = (
     session.execute(
       select(VerificationResult)
-      .where(VerificationResult.structure_id == structure_id)
+      .outerjoin(FactSet, VerificationResult.fact_set_id == FactSet.id)
+      .where(
+        VerificationResult.structure_id == structure_id,
+        or_(VerificationResult.fact_set_id.is_(None), scenario_predicate),
+      )
       .order_by(VerificationResult.evaluated_at.desc())
     )
     .scalars()
@@ -503,7 +520,13 @@ def load_base_envelope_atoms(
     session, [a.id for a in associations]
   )
 
-  verification_results = load_verification_results_for_structure(session, structure_id)
+  # Results scope to the slice being read: a pinned set filters by ITS
+  # scenario (a snapshot of a scenario month shows that month's runs).
+  verification_results = load_verification_results_for_structure(
+    session,
+    structure_id,
+    scenario_id=fact_set.scenario_id if fact_set is not None else scenario_id,
+  )
 
   return BaseEnvelopeAtoms(
     structure=structure,

--- a/robosystems/operations/information_block/forecast.py
+++ b/robosystems/operations/information_block/forecast.py
@@ -389,11 +389,27 @@ def delete(
   structure = _load_forecast_or_404(session, payload.structure_id)
   structure_id = structure.id
 
-  for fact_set in (
+  scenario_sets = (
     session.execute(select(FactSet).where(FactSet.scenario_id == structure_id))
     .scalars()
     .all()
-  ):
+  )
+  # Verification rows pin the scenario's month sets (compute-forecast
+  # verifies each month, F-2); no DB-level FK ties them to fact_sets,
+  # so sweep them here or they orphan invisibly.
+  set_ids = [fs.id for fs in scenario_sets]
+  if set_ids:
+    from robosystems.models.extensions import VerificationResult
+
+    for stale in (
+      session.execute(
+        select(VerificationResult).where(VerificationResult.fact_set_id.in_(set_ids))
+      )
+      .scalars()
+      .all()
+    ):
+      session.delete(stale)
+  for fact_set in scenario_sets:
     session.delete(fact_set)
   session.flush()
 

--- a/robosystems/operations/information_block/forecast_articulation.py
+++ b/robosystems/operations/information_block/forecast_articulation.py
@@ -1,0 +1,538 @@
+"""Forecast articulation — BS roll, schedule projection, derived CF (F-2).
+
+F-1 shipped a footing forecast IS plus rule-driven working-capital
+instants; this module articulates the rest of the model per forward
+month, all as composition over shipped machinery:
+
+- **Balance-sheet roll**: every base-month BS leaf that isn't rule- or
+  schedule-driven carries at its prior value (the workbook's
+  forward-rolling BS); Retained Earnings rolls ``RE[m] = RE[m-1] +
+  NI[m]`` (the auto-derived-RE doctrine, distributions not yet
+  modeled); **cash is the balancing roll** — with every other line
+  known, ``cash = LiabilitiesAndStockholdersEquity - Σ other assets``,
+  so A = L + E holds *by construction*.
+- **Schedule projection**: schedules already emit future ``in_scope``
+  facts (duration movements + running-balance instants) in their
+  ``factset_type='schedule'`` sets. Duration contributions delta-adjust
+  the IS carry (an ending schedule's expense stops instead of carrying
+  forever); instant movements roll the BS (accumulated depreciation
+  keeps growing; a prepaid keeps drawing down). Contributions route
+  through the CoA→rs-gaap mapping's primary target into the elements
+  the base sets actually carry — the PP&E gross/contra pair routes onto
+  ``PropertyPlantAndEquipmentNet`` exactly the way
+  ``fact_grid._synthesize_ppe_net_facts`` nets it for actuals.
+- **Derived cash flow**: the actuals doctrine reused — operating CF
+  leaves derive from period-over-period BS deltas via the library's
+  ``association_type='derivation'`` arcs (a leaf with a direct IS value,
+  e.g. DDA, wins over derivation); the residual against the balancing
+  ΔCash books to ``IncreaseDecreaseInOtherOperatingCapitalNet`` (the
+  ``_reconcile_operating_to_cash`` plug), so the CF foots to ΔCash
+  exactly.
+
+Instant movements are computed **per schedule FactSet**, not per
+element: two depreciation schedules feeding one anchor must each
+contribute their own month-over-month movement — an element-level
+aggregate would reverse an ended schedule's entire balance the month
+its instants stop.
+
+Everything here is pure given a loaded :class:`ArticulationContext`;
+:mod:`.forecast_compute` owns session orchestration and emission.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from sqlalchemy import text
+
+from robosystems.operations.roboledger.reports.calc_dag import (
+  resolve_calc_dag,
+)
+from robosystems.operations.roboledger.reports.fact_grid import (
+  _CASH_ANCHOR_QNAMES,
+  _CF_NET_CHANGE_QNAME,
+  _CF_OPERATING_SUBTOTAL_QNAME,
+  _CF_RECONCILING_LEAF_QNAME,
+)
+
+if TYPE_CHECKING:
+  from datetime import date
+
+  from sqlalchemy.orm import Session
+
+# Form-aware earnings homes, most→least common; the roll target is the
+# first with a fact in the base BS set (mirrors fact_grid._find_close_target).
+_RE_CANDIDATE_QNAMES = (
+  "rs-gaap:RetainedEarningsAccumulatedDeficit",
+  "rs-gaap:PartnersCapital",
+  "rs-gaap:MembersEquity",
+)
+
+_NI_QNAME = "rs-gaap:NetIncomeLoss"
+_ASSETS_QNAME = "rs-gaap:Assets"
+_LE_QNAME = "rs-gaap:LiabilitiesAndStockholdersEquity"
+_CF_INVESTING_QNAME = "rs-gaap:NetCashProvidedByUsedInInvestingActivities"
+_CF_FINANCING_QNAME = "rs-gaap:NetCashProvidedByUsedInFinancingActivities"
+
+# PP&E routing — the base BS carries the synthesized Net line, not the
+# gross/contra pair (fact_grid._synthesize_ppe_net_facts), so schedule
+# movements on either side route onto Net with the netting sign.
+_PPE_NET_QNAME = "rs-gaap:PropertyPlantAndEquipmentNet"
+_PPE_ROUTES: dict[str, float] = {
+  "rs-gaap:PropertyPlantAndEquipmentGross": 1.0,
+  "rs-gaap:AccumulatedDepreciationDepletionAndAmortizationPropertyPlantAndEquipment": -1.0,
+}
+
+# The library's AP derivation arc sources the combined
+# AccountsPayableAndAccruedLiabilitiesCurrent anchor; tenants mapped to
+# the sibling AccountsPayableCurrent (the DPO rule's target) would land
+# their AP movement in the reconciling plug instead of the named CF
+# line. Supplement the arc in code until the library grows the arc.
+_AP_CF_LEAF_QNAME = "rs-gaap:IncreaseDecreaseInAccountsPayableAndAccruedLiabilities"
+_AP_ALIAS_SOURCE_QNAME = "rs-gaap:AccountsPayableCurrent"
+
+_RECONCILE_TOLERANCE = 0.005
+
+
+@dataclass
+class ScheduleProjection:
+  """Schedule contributions routed into base-set element space.
+
+  ``duration_total``: IS element → month key (``YYYY-MM``) → Σ weighted
+  contribution (element-level aggregate is correct for durations — an
+  ended schedule's expense should stop).
+  ``instant_by_set``: (schedule FactSet id, BS element) → period_end →
+  weighted running balance (per-set so movements freeze, never reverse,
+  when a schedule ends).
+  ``unrouted``: qnames whose contributions had no base-set landing spot
+  — surfaced as compute diagnostics, never silently dropped.
+  """
+
+  duration_total: dict[str, dict[str, float]] = field(default_factory=dict)
+  instant_by_set: dict[tuple[str, str], dict[date, float]] = field(default_factory=dict)
+  unrouted: list[str] = field(default_factory=list)
+
+
+@dataclass
+class ArticulationContext:
+  """Everything the per-month BS roll + CF derivation needs, loaded once."""
+
+  bs_structure_id: str
+  cf_structure_id: str | None
+  base_bs_element_ids: list[str]
+  bs_prior: dict[str, float]
+  cash_element_id: str | None
+  re_element_id: str | None
+  ni_element_id: str | None
+  assets_element_id: str | None
+  le_element_id: str | None
+  net_change_element_id: str | None
+  recon_element_id: str | None
+  operating_element_id: str | None
+  investing_element_id: str | None
+  financing_element_id: str | None
+  derivations: dict[str, list[tuple[str, float]]]
+  schedules: ScheduleProjection
+  diagnostics: list[str] = field(default_factory=list)
+
+
+def _resolve_qnames(session: Session, qnames: list[str]) -> dict[str, str]:
+  rows = session.execute(
+    text("SELECT qname, id FROM elements WHERE qname = ANY(:q)"),
+    {"q": qnames},
+  ).fetchall()
+  return {r.qname: r.id for r in rows}
+
+
+def _load_operating_derivations(
+  session: Session,
+) -> dict[str, list[tuple[str, float]]]:
+  """Operating derivation arcs (CF leaf ← BS source, signed weight).
+
+  Same query + investing/financing exclusion as
+  ``fact_grid._derive_cash_flow_facts`` — net-delta derivation is an
+  operating-only doctrine (gross investing/financing presentation can't
+  come from balance deltas).
+  """
+  rows = session.execute(
+    text("""
+      SELECT a.from_element_id, a.to_element_id, a.weight
+      FROM associations a
+      WHERE a.association_type = 'derivation'
+        AND NOT EXISTS (
+          SELECT 1 FROM element_traits et
+          JOIN traits t ON t.id = et.trait_id
+          WHERE et.element_id = a.from_element_id
+            AND t.category = 'activityType'
+            AND t.identifier IN ('investingActivity', 'financingActivity')
+        )
+    """)
+  ).fetchall()
+  derivations: dict[str, list[tuple[str, float]]] = {}
+  for cf_id, source_id, weight in rows:
+    derivations.setdefault(cf_id, []).append((source_id, float(weight or 1.0)))
+  return derivations
+
+
+def _load_schedule_projection(
+  session: Session,
+  *,
+  mapping_id: str | None,
+  entity_id: str,
+  window_start: date,
+  window_end: date,
+  base_is_element_ids: set[str],
+  base_bs_element_ids: set[str],
+  ppe_net_element_id: str | None,
+) -> ScheduleProjection:
+  """Load schedule facts in the window, mapped + routed into base space.
+
+  Each schedule CoA element routes through its **primary** mapping
+  target (trait-classified targets outrank inferred, qname tiebreak —
+  the ``_read_mapped_balances`` close-primary designation), then into
+  the element the base set carries: direct when present, the PP&E
+  gross/contra pair onto Net, anything else → ``unrouted``.
+
+  Deliberately NOT filtered on ``fact_scope``: the base month sits left
+  of ``closed_through``, so its schedule facts are ``historical`` — and
+  they are exactly the delta/movement basis. Without them every forward
+  month re-adds the base month's expense (DDA compounding by one
+  month's depreciation per month — caught live, 2026-07-23) and the
+  first month's instant movement re-adds entire running balances.
+  """
+  projection = ScheduleProjection()
+  if mapping_id is None:
+    return projection
+
+  rows = session.execute(
+    text("""
+      SELECT f.fact_set_id, f.value, f.period_end, f.period_type,
+             f.element_id AS source_id,
+             m.to_element_id AS target_id, target.qname AS target_qname,
+             tcls.identifier AS classification
+      FROM facts f
+      JOIN fact_sets fs ON fs.id = f.fact_set_id
+        AND fs.factset_type = 'schedule'
+        AND fs.scenario_id IS NULL
+        AND fs.entity_id = :entity_id
+      JOIN associations m ON m.from_element_id = f.element_id
+        AND m.association_type = 'mapping'
+        AND m.structure_id = :mapping_id
+      JOIN elements target ON target.id = m.to_element_id
+        AND target.element_type = 'concept'
+        AND target.is_abstract = false
+      LEFT JOIN (
+        SELECT et.element_id, t.identifier
+        FROM element_traits et
+        JOIN traits t ON t.id = et.trait_id
+        WHERE et.is_primary = TRUE
+          AND t.category = 'elementsOfFinancialStatements'
+      ) tcls ON tcls.element_id = target.id
+      WHERE f.fact_type = 'Numeric'
+        AND f.value IS NOT NULL
+        AND f.period_end >= :window_start
+        AND f.period_end <= :window_end
+    """),
+    {
+      "mapping_id": mapping_id,
+      "entity_id": entity_id,
+      "window_start": window_start,
+      "window_end": window_end,
+    },
+  ).fetchall()
+  if not rows:
+    return projection
+
+  # Primary target per SOURCE element (a schedule account mapped to a
+  # statement anchor + disclosure concepts contributes once, to the
+  # anchor) — the close-primary ranking from _read_mapped_balances.
+  by_source: dict[str, list] = {}
+  for row in rows:
+    by_source.setdefault(row.source_id, []).append(row)
+  primary_target: dict[str, tuple[str, str]] = {}
+  for source_id, source_rows in by_source.items():
+    ranked = sorted(
+      source_rows, key=lambda r: (r.classification is None, r.target_qname)
+    )
+    primary_target[source_id] = (ranked[0].target_id, ranked[0].target_qname)
+
+  unrouted: set[str] = set()
+  for row in rows:
+    target_id, target_qname = primary_target[row.source_id]
+    if (row.target_id, row.target_qname) != (target_id, target_qname):
+      continue  # non-primary fan-out arc — contribution counted once
+    value = float(row.value)
+    if row.period_type == "instant":
+      routed_id: str | None = None
+      weight = 1.0
+      if target_id in base_bs_element_ids:
+        routed_id = target_id
+      elif target_qname in _PPE_ROUTES and ppe_net_element_id in base_bs_element_ids:
+        routed_id = ppe_net_element_id
+        weight = _PPE_ROUTES[target_qname]
+      if routed_id is None:
+        unrouted.add(target_qname)
+        continue
+      per_set = projection.instant_by_set.setdefault((row.fact_set_id, routed_id), {})
+      per_set[row.period_end] = per_set.get(row.period_end, 0.0) + weight * value
+    else:
+      if target_id not in base_is_element_ids:
+        unrouted.add(target_qname)
+        continue
+      month_key = f"{row.period_end.year:04d}-{row.period_end.month:02d}"
+      per_month = projection.duration_total.setdefault(target_id, {})
+      per_month[month_key] = per_month.get(month_key, 0.0) + value
+
+  projection.unrouted = sorted(unrouted)
+  return projection
+
+
+def load_articulation_context(
+  session: Session,
+  *,
+  bs_structure_id: str,
+  cf_structure_id: str | None,
+  mapping_id: str | None,
+  entity_id: str,
+  base_bs_element_ids: list[str],
+  bs_prior: dict[str, float],
+  base_is_element_ids: list[str],
+  base_start: date,
+  horizon_end: date,
+) -> ArticulationContext:
+  """Resolve the articulation anchors + arcs + schedule projection once."""
+  specials = _resolve_qnames(
+    session,
+    [
+      *_CASH_ANCHOR_QNAMES,
+      *_RE_CANDIDATE_QNAMES,
+      _NI_QNAME,
+      _ASSETS_QNAME,
+      _LE_QNAME,
+      _CF_NET_CHANGE_QNAME,
+      _CF_RECONCILING_LEAF_QNAME,
+      _CF_OPERATING_SUBTOTAL_QNAME,
+      _CF_INVESTING_QNAME,
+      _CF_FINANCING_QNAME,
+      _PPE_NET_QNAME,
+      _AP_CF_LEAF_QNAME,
+      _AP_ALIAS_SOURCE_QNAME,
+    ],
+  )
+  base_set = set(base_bs_element_ids)
+  diagnostics: list[str] = []
+
+  def _anchor_with_base_fact(
+    candidates: tuple[str, ...] | frozenset[str],
+  ) -> str | None:
+    with_fact = [
+      specials[q] for q in candidates if q in specials and specials[q] in base_set
+    ]
+    if with_fact:
+      return with_fact[0]
+    resolvable = [specials[q] for q in candidates if q in specials]
+    return resolvable[0] if resolvable else None
+
+  cash_element_id = _anchor_with_base_fact(tuple(sorted(_CASH_ANCHOR_QNAMES)))
+  if cash_element_id is not None and cash_element_id not in base_set:
+    diagnostics.append("no cash anchor in the base balance sheet — cash rolls from 0")
+  re_element_id = _anchor_with_base_fact(_RE_CANDIDATE_QNAMES)
+  if re_element_id is not None and re_element_id not in base_set:
+    diagnostics.append(
+      "no earnings-home fact in the base balance sheet — retained earnings rolls from 0"
+    )
+
+  derivations = _load_operating_derivations(session)
+  ap_leaf_id = specials.get(_AP_CF_LEAF_QNAME)
+  ap_alias_id = specials.get(_AP_ALIAS_SOURCE_QNAME)
+  if ap_leaf_id is not None and ap_alias_id is not None:
+    sources = derivations.setdefault(ap_leaf_id, [])
+    if all(src != ap_alias_id for src, _ in sources):
+      sources.append((ap_alias_id, 1.0))
+
+  schedules = _load_schedule_projection(
+    session,
+    mapping_id=mapping_id,
+    entity_id=entity_id,
+    window_start=base_start,
+    window_end=horizon_end,
+    base_is_element_ids=set(base_is_element_ids),
+    base_bs_element_ids=base_set,
+    ppe_net_element_id=specials.get(_PPE_NET_QNAME),
+  )
+  if schedules.unrouted:
+    diagnostics.append(
+      "schedule contributions with no base-set landing spot skipped: "
+      + ", ".join(schedules.unrouted)
+    )
+
+  return ArticulationContext(
+    bs_structure_id=bs_structure_id,
+    cf_structure_id=cf_structure_id,
+    base_bs_element_ids=base_bs_element_ids,
+    bs_prior=bs_prior,
+    cash_element_id=cash_element_id,
+    re_element_id=re_element_id,
+    ni_element_id=specials.get(_NI_QNAME),
+    assets_element_id=specials.get(_ASSETS_QNAME),
+    le_element_id=specials.get(_LE_QNAME),
+    net_change_element_id=specials.get(_CF_NET_CHANGE_QNAME),
+    recon_element_id=specials.get(_CF_RECONCILING_LEAF_QNAME),
+    operating_element_id=specials.get(_CF_OPERATING_SUBTOTAL_QNAME),
+    investing_element_id=specials.get(_CF_INVESTING_QNAME),
+    financing_element_id=specials.get(_CF_FINANCING_QNAME),
+    derivations=derivations,
+    schedules=schedules,
+    diagnostics=diagnostics,
+  )
+
+
+def schedule_is_delta(
+  ctx: ArticulationContext, element_id: str, month: str, base_month: str
+) -> float:
+  """IS carry adjustment: this month's schedule expense minus the base
+  month's (already inside the carried value). Element-level on purpose —
+  an ended schedule's expense must STOP, not carry."""
+  per_month = ctx.schedules.duration_total.get(element_id)
+  if not per_month:
+    return 0.0
+  return per_month.get(month, 0.0) - per_month.get(base_month, 0.0)
+
+
+def schedule_instant_movement(
+  ctx: ArticulationContext, element_id: str, month_end: date, prev_end: date
+) -> float:
+  """BS movement for the month from schedule running balances, summed
+  per schedule set. A set with no instant this month contributes 0 —
+  its balance froze at the final value (never reversed)."""
+  movement = 0.0
+  for (_, routed_id), by_date in ctx.schedules.instant_by_set.items():
+    if routed_id != element_id:
+      continue
+    current = by_date.get(month_end)
+    if current is None:
+      continue
+    movement += current - by_date.get(prev_end, 0.0)
+  return movement
+
+
+def roll_balance_sheet(
+  ctx: ArticulationContext,
+  *,
+  month_end: date,
+  prev_end: date,
+  prior_bs: dict[str, float],
+  rule_values: dict[str, float],
+  rule_instant_targets: set[str],
+  resolved_is: dict[str, float],
+  calculations: dict[str, list[tuple[str, float]]],
+  calc_order: list[str],
+) -> dict[str, float]:
+  """One month's full BS leaf values: carry + rules + schedules + RE
+  roll + balancing cash. Subtotals stay derived (resolve_calc_dag at
+  emission), never carried."""
+  calc_targets = set(calculations.keys())
+  bs: dict[str, float] = {}
+
+  for element_id in ctx.base_bs_element_ids:
+    if element_id in calc_targets:
+      continue  # subtotals derive
+    if element_id == ctx.cash_element_id or element_id == ctx.re_element_id:
+      continue  # balancing / rolled below
+    if element_id in rule_instant_targets and element_id in rule_values:
+      bs[element_id] = rule_values[element_id]
+      continue
+    bs[element_id] = prior_bs.get(element_id, 0.0)
+
+  # Rule-driven instants outside the base presentation still roll (the
+  # F-1 behavior — e.g. an AP anchor the actuals never carried).
+  for element_id in rule_instant_targets:
+    if (
+      element_id in rule_values
+      and element_id not in bs
+      and element_id not in calc_targets
+    ):
+      bs[element_id] = rule_values[element_id]
+
+  for element_id in list(bs):
+    movement = schedule_instant_movement(ctx, element_id, month_end, prev_end)
+    if movement:
+      bs[element_id] += movement
+
+  if ctx.re_element_id is not None:
+    net_income = resolved_is.get(ctx.ni_element_id, 0.0) if ctx.ni_element_id else 0.0
+    bs[ctx.re_element_id] = prior_bs.get(ctx.re_element_id, 0.0) + net_income
+
+  if ctx.cash_element_id is not None and ctx.le_element_id and ctx.assets_element_id:
+    interim = resolve_calc_dag(bs, set(bs), calculations, calc_order)
+    le_total = interim.get(ctx.le_element_id, 0.0)
+    assets_ex_cash = interim.get(ctx.assets_element_id, 0.0)
+    bs[ctx.cash_element_id] = le_total - assets_ex_cash
+
+  return bs
+
+
+def derive_cash_flow(
+  ctx: ArticulationContext,
+  *,
+  bs: dict[str, float],
+  prior_bs: dict[str, float],
+  resolved_is: dict[str, float],
+  calculations: dict[str, list[tuple[str, float]]],
+  calc_order: list[str],
+) -> tuple[dict[str, float], float]:
+  """One month's CF values (leaves + emission subtotals) and the plug.
+
+  Leaves: a derivation leaf with a direct IS value (DDA) takes it
+  (direct-fact-wins); everything else derives ``Σ weight · ΔBS``.
+  The residual against the balancing ΔCash books to the reconciling
+  leaf — the CF foots to ΔCash exactly, by the actuals plug doctrine.
+  """
+  cf: dict[str, float] = {}
+  for leaf_id, sources in ctx.derivations.items():
+    if leaf_id in resolved_is:
+      value = resolved_is[leaf_id]
+    else:
+      value = sum(
+        weight * (bs.get(src, 0.0) - prior_bs.get(src, 0.0)) for src, weight in sources
+      )
+    if value != 0.0:
+      cf[leaf_id] = value
+
+  if ctx.ni_element_id is not None and ctx.ni_element_id in resolved_is:
+    cf[ctx.ni_element_id] = resolved_is[ctx.ni_element_id]
+
+  plug = 0.0
+  if ctx.cash_element_id is not None and ctx.net_change_element_id is not None:
+    delta_cash = bs.get(ctx.cash_element_id, 0.0) - prior_bs.get(
+      ctx.cash_element_id, 0.0
+    )
+    computed = resolve_calc_dag(cf, set(cf), calculations, calc_order)
+    residual = delta_cash - computed.get(ctx.net_change_element_id, 0.0)
+    if abs(residual) > _RECONCILE_TOLERANCE and ctx.recon_element_id is not None:
+      cf[ctx.recon_element_id] = cf.get(ctx.recon_element_id, 0.0) + residual
+      plug = residual
+
+  # Emission set mirrors the actual monthly CF sets: nonzero leaves plus
+  # the Operating + net-change spine (Investing/Financing when nonzero).
+  final = resolve_calc_dag(cf, set(cf), calculations, calc_order)
+  for subtotal_id in (ctx.operating_element_id, ctx.net_change_element_id):
+    if subtotal_id is not None:
+      cf[subtotal_id] = final.get(subtotal_id, 0.0)
+  for subtotal_id in (ctx.investing_element_id, ctx.financing_element_id):
+    if subtotal_id is not None and final.get(subtotal_id, 0.0) != 0.0:
+      cf[subtotal_id] = final[subtotal_id]
+
+  return cf, plug
+
+
+__all__ = [
+  "ArticulationContext",
+  "ScheduleProjection",
+  "derive_cash_flow",
+  "load_articulation_context",
+  "roll_balance_sheet",
+  "schedule_instant_movement",
+  "schedule_is_delta",
+]

--- a/robosystems/operations/information_block/forecast_compute.py
+++ b/robosystems/operations/information_block/forecast_compute.py
@@ -63,6 +63,13 @@ from robosystems.operations.information_block.forecast import (
   FORECAST_BLOCK_TYPE,
   _load_lever_fact_set,
 )
+from robosystems.operations.information_block.forecast_articulation import (
+  ArticulationContext,
+  derive_cash_flow,
+  load_articulation_context,
+  roll_balance_sheet,
+  schedule_is_delta,
+)
 from robosystems.operations.information_block.metrics import (
   _default_entity_id,
   _metric_unit,
@@ -295,14 +302,24 @@ def cmd_compute_forecast(
       base_is_element_ids.append(fact.element_id)
     prior_values[fact.element_id] = float(fact.value)
 
-  # BS instants seed [t-1]/carry context for balance-driven rules.
+  # BS instants seed [t-1]/carry context for balance-driven rules — and,
+  # since F-2, the full roll: base_bs_element_ids preserves emission
+  # order, bs_prior is the roll's month-zero state.
+  base_bs_set = None
+  base_bs_element_ids: list[str] = []
+  bs_prior: dict[str, float] = {}
   if bs_structure_id is not None:
     base_bs_set = _actual_set_at(
       session, bs_structure_id, entity_id, base_start, base_end
     )
     if base_bs_set is not None:
       for fact in _numeric_facts(session, base_bs_set.id):
-        if fact.value is not None and fact.element_id not in prior_values:
+        if fact.value is None:
+          continue
+        if fact.element_id not in bs_prior:
+          base_bs_element_ids.append(fact.element_id)
+        bs_prior[fact.element_id] = float(fact.value)
+        if fact.element_id not in prior_values:
           prior_values[fact.element_id] = float(fact.value)
 
   # ── Activate driver rules for this scenario ───────────────────────────
@@ -387,9 +404,14 @@ def cmd_compute_forecast(
   )
 
   # ── Calc DAG + carry pool ─────────────────────────────────────────────
+  global_calcs = load_rs_gaap_calculations(session)
   calculations = merge_calculations(
-    load_rs_gaap_calculations(session), _local_calc_arcs(session, is_structure_id)
+    global_calcs, _local_calc_arcs(session, is_structure_id)
   )
+  if bs_structure_id is not None:
+    calculations = merge_calculations(
+      calculations, _local_calc_arcs(session, bs_structure_id)
+    )
   calc_order = topo_sort_calculations(calculations)
   calc_targets = set(calculations.keys())
   carry_pool = [
@@ -397,6 +419,49 @@ def cmd_compute_forecast(
     for el in base_is_element_ids
     if el not in calc_targets and el not in active_target_ids
   ]
+
+  # ── Articulation context (F-2) — BS roll + schedules + derived CF ─────
+  # The mapping id rides the base report set's PivotProvenance; without
+  # it schedule contributions can't route CoA→rs-gaap and are skipped.
+  mapping_id: str | None = None
+  for seed_set in (base_is_set, base_bs_set):
+    prov = getattr(seed_set, "provenance", None) if seed_set is not None else None
+    if isinstance(prov, dict) and prov.get("origin") == "pivot":
+      mapping_id = prov.get("mapping_id")
+      if mapping_id:
+        break
+  cf_structure_id = _newest_actual_structure_id(session, "cash_flow_statement")
+
+  ctx: ArticulationContext | None = None
+  diagnostics: list[str] = []
+  if bs_structure_id is not None and base_bs_set is not None:
+    horizon_end = period_date_range(add_months(mechanics.base_period, months_n))[1]
+    ctx = load_articulation_context(
+      session,
+      bs_structure_id=bs_structure_id,
+      cf_structure_id=cf_structure_id,
+      mapping_id=mapping_id,
+      entity_id=entity_id,
+      base_bs_element_ids=base_bs_element_ids,
+      bs_prior=bs_prior,
+      base_is_element_ids=base_is_element_ids,
+      base_start=base_start,
+      horizon_end=horizon_end,
+    )
+    diagnostics.extend(ctx.diagnostics)
+    if cf_structure_id is None:
+      diagnostics.append(
+        "no actual cash-flow statement exists — scenario CF sets skipped"
+      )
+    if mapping_id is None:
+      diagnostics.append(
+        "base report carries no mapping provenance — schedule projections skipped"
+      )
+  else:
+    diagnostics.append(
+      "no actual balance sheet at the base period — emitting the "
+      "rule-driven working-capital instants only (no BS roll / CF)"
+    )
 
   elements_by_id: dict[str, Element] = {}
 
@@ -410,6 +475,11 @@ def cmd_compute_forecast(
   # ── The walk ──────────────────────────────────────────────────────────
   months_computed: list[ForecastMonthLite] = []
   months = [add_months(mechanics.base_period, i) for i in range(1, months_n + 1)]
+  active_instant_ids = {
+    ar.target.id for ar in ordered_active if ar.target.period_type == "instant"
+  }
+  prior_bs = dict(bs_prior)
+  prev_period_end = base_end
 
   for month_index, month in enumerate(months, start=1):
     month_start, month_end = period_date_range(month)
@@ -419,6 +489,15 @@ def cmd_compute_forecast(
     for element_id in carry_pool:
       if element_id in prior_values:
         current[element_id] = prior_values[element_id]
+
+    # (a2) Schedule deltas — a schedule's own projection overrides the
+    # carry for its expense lines (an ended schedule's expense stops;
+    # the base month's contribution is already inside the carried value).
+    if ctx is not None:
+      for element_id in list(current):
+        delta = schedule_is_delta(ctx, element_id, month, mechanics.base_period)
+        if delta:
+          current[element_id] += delta
 
     # (b) Driver rules in same-month dependency order.
     for ar in ordered_active:
@@ -529,6 +608,14 @@ def cmd_compute_forecast(
       if element_id not in current and element_id in prior_values:
         current[element_id] = prior_values[element_id]
 
+    # (b2) Push rule deltas down the composition — a Derive rule that
+    # targets a calc PARENT (Revenues, CostOfRevenue) scales the
+    # parent's carried children proportionally, the workbook's implicit
+    # semantics (every revenue stream grows at g). Without this the
+    # statement's own RollUp verification fails: driven parent, stale
+    # children.
+    _scale_rule_target_children(current, active_target_ids, calculations)
+
     # (c) Calc-DAG subtotals — derive, never carry (present = direct wins).
     resolved = resolve_calc_dag(current, set(current), calculations, calc_order)
 
@@ -547,10 +634,56 @@ def cmd_compute_forecast(
         continue
       is_facts.append((element, resolved[element_id]))
 
+    # (d2) Balance-sheet roll + derived CF (F-2) — with an articulation
+    # context the BS is the full roll (carry, rules, schedules, RE,
+    # balancing cash) and the CF derives from its deltas; without one
+    # (no actual BS at the base period) the F-1 behavior stands: the
+    # rule-driven working-capital instants alone.
     bs_facts: list[tuple[Element, float]] = []
-    for ar in ordered_active:
-      if ar.target.id in current and ar.target.period_type == "instant":
-        bs_facts.append((ar.target, current[ar.target.id]))
+    cf_facts: list[tuple[Element, float]] = []
+    bs_values: dict[str, float] = {}
+    if ctx is not None:
+      bs_values = roll_balance_sheet(
+        ctx,
+        month_end=month_end,
+        prev_end=prev_period_end,
+        prior_bs=prior_bs,
+        rule_values=current,
+        rule_instant_targets=active_instant_ids,
+        resolved_is=resolved,
+        calculations=calculations,
+        calc_order=calc_order,
+      )
+      final_bs = resolve_calc_dag(bs_values, set(bs_values), calculations, calc_order)
+      emitted_bs: set[str] = set()
+      for element_id in base_bs_element_ids:
+        element = _element(element_id)
+        if element is None or element_id not in final_bs:
+          continue
+        bs_facts.append((element, final_bs[element_id]))
+        emitted_bs.add(element_id)
+      for element_id in sorted(set(bs_values) - emitted_bs):
+        element = _element(element_id)
+        if element is not None:
+          bs_facts.append((element, bs_values[element_id]))
+
+      if ctx.cf_structure_id is not None:
+        cf_values, _plug = derive_cash_flow(
+          ctx,
+          bs=bs_values,
+          prior_bs=prior_bs,
+          resolved_is=resolved,
+          calculations=calculations,
+          calc_order=calc_order,
+        )
+        for element_id in sorted(cf_values):
+          element = _element(element_id)
+          if element is not None:
+            cf_facts.append((element, cf_values[element_id]))
+    else:
+      for ar in ordered_active:
+        if ar.target.id in current and ar.target.period_type == "instant":
+          bs_facts.append((ar.target, current[ar.target.id]))
 
     is_set_id = _upsert_month_set(
       session,
@@ -576,6 +709,36 @@ def cmd_compute_forecast(
         created_by=created_by,
         facts=bs_facts,
       )
+    cf_set_id = None
+    if ctx is not None and ctx.cf_structure_id is not None and cf_facts:
+      cf_set_id = _upsert_month_set(
+        session,
+        structure_id=ctx.cf_structure_id,
+        entity_id=entity_id,
+        scenario_id=scenario_id,
+        period_start=month_start,
+        period_end=month_end,
+        provenance=provenance,
+        created_by=created_by,
+        facts=cf_facts,
+      )
+
+    # (f) Verify the month — the same rule corpus that gates actuals,
+    # pinned to each scenario set (the fact_set_id pin scopes balances
+    # and binds; no scenario threading inside the engine). Prior runs
+    # for a set are replaced, mirroring the fact upsert's drift
+    # semantics — results are per-month state, not append-only history.
+    verification_passed, verification_failures = _verify_month_sets(
+      session,
+      sets=(
+        (is_structure_id, is_set_id),
+        (bs_structure_id, bs_set_id),
+        (ctx.cf_structure_id if ctx is not None else None, cf_set_id),
+      ),
+      period_end=month_end,
+      created_by=created_by,
+      global_calculations=global_calcs,
+    )
 
     months_computed.append(
       ForecastMonthLite(
@@ -584,17 +747,25 @@ def cmd_compute_forecast(
         period_end=month_end,
         income_statement_fact_set_id=is_set_id,
         balance_sheet_fact_set_id=bs_set_id,
-        computed_count=len(is_facts) + len(bs_facts),
+        cash_flow_fact_set_id=cf_set_id,
+        computed_count=len(is_facts) + len(bs_facts) + len(cf_facts),
+        verification_passed=verification_passed,
+        verification_failures=verification_failures,
       )
     )
 
     # (e) Roll the window: next month's [t-1]/carry context is this
-    # month's resolved IS values + the balance instants.
+    # month's resolved IS values + the full balance sheet.
     prior_values.clear()
     for element, value in is_facts:
       prior_values[element.id] = value
-    for element, value in bs_facts:
-      prior_values[element.id] = value
+    if bs_values:
+      prior_values.update(bs_values)
+      prior_bs = bs_values
+    else:
+      for element, value in bs_facts:
+        prior_values[element.id] = value
+    prev_period_end = month_end
 
   session.flush()
   return ComputeForecastResponse(
@@ -605,7 +776,103 @@ def cmd_compute_forecast(
     months=months_n,
     months_computed=months_computed,
     skipped=skipped,
+    diagnostics=diagnostics,
   )
+
+
+def _scale_rule_target_children(
+  current: dict[str, float],
+  active_target_ids: set[str],
+  calculations: dict[str, list[tuple[str, float]]],
+) -> None:
+  """Scale a rule-driven calc parent's present children so the
+  composition articulates with the driven value.
+
+  Proportional: each child (and its own subtree, recursively) multiplies
+  by ``driven / Σ child·weight``. A zero children-sum is left untouched
+  — proportional scaling has no basis, and the visible RollUp failure is
+  more honest than inventing a split. A skipped rule that fell back to
+  carry scales by exactly 1.0 (children carried too), so this is a no-op
+  for inactive months.
+  """
+
+  def _scale_subtree(parent: str, factor: float, visited: set[str]) -> None:
+    for child, _weight in calculations.get(parent, ()):
+      if child in visited or child not in current:
+        continue
+      visited.add(child)
+      current[child] *= factor
+      _scale_subtree(child, factor, visited)
+
+  for target in active_target_ids:
+    children = calculations.get(target)
+    if not children or target not in current:
+      continue
+    children_sum = sum(
+      current[child] * weight for child, weight in children if child in current
+    )
+    if abs(children_sum) < 1e-9:
+      continue
+    factor = current[target] / children_sum
+    if factor == 1.0:
+      continue
+    _scale_subtree(target, factor, set())
+
+
+_MAX_FAILURES_PER_MONTH = 5
+
+
+def _verify_month_sets(
+  session: Session,
+  *,
+  sets: tuple[tuple[str | None, str | None], ...],
+  period_end: date,
+  created_by: str,
+  global_calculations: dict[str, list[tuple[str, float]]],
+) -> tuple[bool | None, list[str]]:
+  """Run the rule corpus against each emitted scenario set, pinned.
+
+  Prior results for a set are deleted first — a recompute replaces the
+  month's verification state the same way the fact upsert replaces its
+  values. Returns ``(passed, failures)``: ``passed`` is ``None`` when
+  no rules produced results, else whether nothing failed/errored;
+  ``failures`` carries the first few failed/errored messages.
+  """
+  from robosystems.models.extensions import VerificationResult
+  from robosystems.operations.information_block.rules.engine import (
+    evaluate_rules_for_structure,
+  )
+
+  any_results = False
+  failures: list[str] = []
+  for structure_id, fact_set_id in sets:
+    if structure_id is None or fact_set_id is None:
+      continue
+    for stale in (
+      session.execute(
+        select(VerificationResult).where(VerificationResult.fact_set_id == fact_set_id)
+      )
+      .scalars()
+      .all()
+    ):
+      session.delete(stale)
+    results = evaluate_rules_for_structure(
+      session,
+      structure_id,
+      fact_set_id=fact_set_id,
+      period_end=period_end,
+      created_by=created_by,
+      global_calculations=global_calculations,
+    )
+    if results:
+      any_results = True
+    for result in results:
+      if result.status in ("fail", "error") and len(failures) < _MAX_FAILURES_PER_MONTH:
+        failures.append(f"{result.status}: {result.message}")
+
+  if not any_results:
+    return None, []
+  return not failures, failures
 
 
 def _upsert_month_set(

--- a/tests/operations/information_block/test_envelope_fact_set.py
+++ b/tests/operations/information_block/test_envelope_fact_set.py
@@ -16,6 +16,7 @@ from robosystems.operations.information_block.envelope import (
   fact_set_to_lite,
   load_fact_set_by_id_for_structure,
   load_latest_fact_set_for_structure,
+  load_verification_results_for_structure,
 )
 
 
@@ -162,3 +163,37 @@ class TestLoadFactSetByIdForStructure:
     assert lite is not None
     assert lite.id == "fs_pinned"
     assert lite.structure_id == "struct_bs"
+
+
+class TestVerificationResultsScenarioScope:
+  """**The verification-bleed regression** (the F-2 analog of the FactSet
+  hijack): compute-forecast verifies every scenario month against the
+  statement structures, so the envelope's verification loader must scope
+  results by scenario or the actuals envelope grows a failed/passed row
+  per scenario month per rule."""
+
+  @staticmethod
+  def _session() -> MagicMock:
+    session = MagicMock()
+    session.execute.return_value.scalars.return_value.all.return_value = []
+    return session
+
+  def test_actuals_read_excludes_scenario_set_results(self) -> None:
+    session = self._session()
+    load_verification_results_for_structure(session, "struct_bs")
+    stmt = session.execute.call_args.args[0]
+    sql = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+    # Structure-level results (no set) stay; set-pinned results must
+    # come from actuals sets only.
+    assert "fact_set_id IS NULL" in sql
+    assert "scenario_id IS NULL" in sql
+
+  def test_scenario_read_includes_only_that_scenarios_results(self) -> None:
+    session = self._session()
+    load_verification_results_for_structure(session, "struct_bs", "struct_budget")
+    stmt = session.execute.call_args.args[0]
+    sql = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+    assert "scenario_id = 'struct_budget'" in sql
+    assert "scenario_id IS NULL" not in sql
+    # Structure-level (unpinned) results still ride along.
+    assert "fact_set_id IS NULL" in sql

--- a/tests/operations/information_block/test_forecast_articulation.py
+++ b/tests/operations/information_block/test_forecast_articulation.py
@@ -1,0 +1,302 @@
+"""Forecast articulation (F-2) — BS roll, schedule movements, derived CF.
+
+Pure-function coverage over a hand-built :class:`ArticulationContext`;
+no session involved. The identities asserted here are the articulation
+claims themselves: A = L + E by construction (balancing cash), RE roll
+exactness, per-set schedule-movement freeze semantics, CF footing to
+ΔCash via the reconciling plug.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from robosystems.operations.information_block.forecast_articulation import (
+  ArticulationContext,
+  ScheduleProjection,
+  derive_cash_flow,
+  roll_balance_sheet,
+  schedule_instant_movement,
+  schedule_is_delta,
+)
+from robosystems.operations.roboledger.reports.calc_dag import (
+  resolve_calc_dag,
+  topo_sort_calculations,
+)
+
+pytestmark = pytest.mark.unit
+
+MAY = date(2026, 5, 31)
+JUN = date(2026, 6, 30)
+JUL = date(2026, 7, 31)
+
+# A miniature but complete three-statement calc DAG.
+CALC = {
+  "Assets": [("AssetsCurrent", 1.0), ("AssetsNoncurrent", 1.0)],
+  "AssetsCurrent": [("cash", 1.0), ("ar", 1.0), ("prepaid", 1.0)],
+  "AssetsNoncurrent": [("ppe_net", 1.0)],
+  "Liabilities": [("ap", 1.0)],
+  "StockholdersEquity": [("apic", 1.0), ("re", 1.0)],
+  "LE": [("Liabilities", 1.0), ("StockholdersEquity", 1.0)],
+  "cf_op": [
+    ("ni", 1.0),
+    ("dda", 1.0),
+    ("d_ar", 1.0),
+    ("d_prepaid", 1.0),
+    ("d_ap", 1.0),
+    ("recon", 1.0),
+  ],
+  "cf_net": [("cf_op", 1.0), ("cf_inv", 1.0), ("cf_fin", 1.0)],
+}
+CALC_ORDER = topo_sort_calculations(CALC)
+
+BS_PRIOR = {
+  "cash": 50.0,
+  "ar": 100.0,
+  "prepaid": 12.0,
+  "ppe_net": 60.0,
+  "ap": 0.0,
+  "apic": 100.0,
+  "re": 122.0,
+}
+
+
+def _ctx(schedules: ScheduleProjection | None = None) -> ArticulationContext:
+  return ArticulationContext(
+    bs_structure_id="struct_bs",
+    cf_structure_id="struct_cf",
+    base_bs_element_ids=[
+      *BS_PRIOR,
+      "Assets",
+      "AssetsCurrent",
+      "AssetsNoncurrent",
+      "Liabilities",
+      "StockholdersEquity",
+      "LE",
+    ],
+    bs_prior=dict(BS_PRIOR),
+    cash_element_id="cash",
+    re_element_id="re",
+    ni_element_id="ni",
+    assets_element_id="Assets",
+    le_element_id="LE",
+    net_change_element_id="cf_net",
+    recon_element_id="recon",
+    operating_element_id="cf_op",
+    investing_element_id="cf_inv",
+    financing_element_id="cf_fin",
+    derivations={
+      "d_ar": [("ar", -1.0)],
+      "d_prepaid": [("prepaid", -1.0)],
+      "d_ap": [("ap", 1.0)],
+      "dda": [("accum_dep", 1.0)],
+    },
+    schedules=schedules or ScheduleProjection(),
+  )
+
+
+def _roll(ctx: ArticulationContext, **overrides) -> dict[str, float]:
+  kwargs = {
+    "month_end": JUN,
+    "prev_end": MAY,
+    "prior_bs": dict(BS_PRIOR),
+    "rule_values": {"ar": 150.0, "ap": 62.0},
+    "rule_instant_targets": {"ar", "ap"},
+    "resolved_is": {"ni": 10.0},
+    "calculations": CALC,
+    "calc_order": CALC_ORDER,
+  }
+  kwargs.update(overrides)
+  return roll_balance_sheet(ctx, **kwargs)
+
+
+class TestBalanceSheetRoll:
+  def test_articulated_roll_balances_by_construction(self):
+    schedules = ScheduleProjection(
+      instant_by_set={
+        ("fs_dep", "ppe_net"): {MAY: -10.0, JUN: -12.0},
+        ("fs_prepaid", "prepaid"): {MAY: 12.0, JUN: 11.0},
+      }
+    )
+    bs = _roll(_ctx(schedules))
+
+    # Carry, rules, schedules, RE roll, balancing cash — each line lands.
+    assert bs["apic"] == 100.0  # carry
+    assert bs["ar"] == 150.0  # DSO rule
+    assert bs["ap"] == 62.0  # DPO rule
+    assert bs["prepaid"] == 11.0  # schedule draw-down
+    assert bs["ppe_net"] == 58.0  # accumulated-dep movement (-2)
+    assert bs["re"] == 132.0  # RE[m] = RE[m-1] + NI
+
+    # Balancing cash: LE = 62 + (100 + 132) = 294; other assets = 219.
+    assert bs["cash"] == pytest.approx(75.0)
+
+    # The articulation claim itself: A = L + E, exactly.
+    final = resolve_calc_dag(bs, set(bs), CALC, CALC_ORDER)
+    assert final["Assets"] == pytest.approx(final["LE"])
+
+  def test_subtotals_never_carried(self):
+    bs = _roll(_ctx())
+    for subtotal in ("Assets", "AssetsCurrent", "Liabilities", "LE"):
+      assert subtotal not in bs  # leaves only; subtotals derive at emission
+
+  def test_skipped_rule_target_falls_back_to_carry(self):
+    # DSO inactive this month — AR carries instead of jumping.
+    bs = _roll(_ctx(), rule_values={"ap": 62.0})
+    assert bs["ar"] == 100.0
+
+  def test_re_rolls_from_zero_without_base_fact(self):
+    ctx = _ctx()
+    prior = {k: v for k, v in BS_PRIOR.items() if k != "re"}
+    bs = _roll(ctx, prior_bs=prior)
+    assert bs["re"] == 10.0
+
+
+class TestScheduleSemantics:
+  def test_instant_movement_freezes_when_a_schedule_ends(self):
+    # Set A still running (+2); set B ended after MAY — it contributes 0,
+    # never a reversal of its final balance.
+    schedules = ScheduleProjection(
+      instant_by_set={
+        ("fs_a", "ppe_net"): {MAY: 10.0, JUN: 12.0},
+        ("fs_b", "ppe_net"): {MAY: 8.0},
+      }
+    )
+    ctx = _ctx(schedules)
+    assert schedule_instant_movement(ctx, "ppe_net", JUN, MAY) == pytest.approx(2.0)
+
+  def test_instant_movement_new_schedule_contributes_full_balance(self):
+    schedules = ScheduleProjection(instant_by_set={("fs_new", "prepaid"): {JUN: 9.0}})
+    ctx = _ctx(schedules)
+    assert schedule_instant_movement(ctx, "prepaid", JUN, MAY) == pytest.approx(9.0)
+
+  def test_is_delta_stops_an_ended_schedules_expense(self):
+    schedules = ScheduleProjection(
+      duration_total={"dda": {"2026-05": 5.0, "2026-06": 3.0}}
+    )
+    ctx = _ctx(schedules)
+    # Base month carried 5 inside the IS value; June's schedule says 3.
+    assert schedule_is_delta(ctx, "dda", "2026-06", "2026-05") == pytest.approx(-2.0)
+    # July: no schedule fact at all — the whole base expense stops.
+    assert schedule_is_delta(ctx, "dda", "2026-07", "2026-05") == pytest.approx(-5.0)
+
+
+class TestRuleDeltaPushDown:
+  """A Derive rule that targets a calc PARENT must scale the parent's
+  carried children proportionally, or the statement's own RollUp
+  verification fails (driven parent, stale children)."""
+
+  def test_children_scale_proportionally(self):
+    from robosystems.operations.information_block.forecast_compute import (
+      _scale_rule_target_children,
+    )
+
+    calcs = {"revenues": [("stream_a", 1.0), ("stream_b", 1.0)]}
+    current = {"revenues": 206.0, "stream_a": 150.0, "stream_b": 50.0}
+    _scale_rule_target_children(current, {"revenues"}, calcs)
+    assert current["stream_a"] == pytest.approx(154.5)
+    assert current["stream_b"] == pytest.approx(51.5)
+    # The rollup identity the verification checks:
+    assert current["stream_a"] + current["stream_b"] == pytest.approx(
+      current["revenues"]
+    )
+
+  def test_scaling_recurses_down_the_subtree(self):
+    from robosystems.operations.information_block.forecast_compute import (
+      _scale_rule_target_children,
+    )
+
+    calcs = {
+      "revenues": [("product", 1.0)],
+      "product": [("sku_1", 1.0), ("sku_2", 1.0)],
+    }
+    current = {"revenues": 220.0, "product": 200.0, "sku_1": 120.0, "sku_2": 80.0}
+    _scale_rule_target_children(current, {"revenues"}, calcs)
+    assert current["product"] == pytest.approx(220.0)
+    assert current["sku_1"] == pytest.approx(132.0)
+    assert current["sku_2"] == pytest.approx(88.0)
+
+  def test_zero_children_sum_left_untouched(self):
+    from robosystems.operations.information_block.forecast_compute import (
+      _scale_rule_target_children,
+    )
+
+    calcs = {"revenues": [("stream_a", 1.0)]}
+    current = {"revenues": 206.0, "stream_a": 0.0}
+    _scale_rule_target_children(current, {"revenues"}, calcs)
+    # No proportional basis — visible RollUp failure beats an invented split.
+    assert current["stream_a"] == 0.0
+
+  def test_carried_fallback_is_a_no_op(self):
+    from robosystems.operations.information_block.forecast_compute import (
+      _scale_rule_target_children,
+    )
+
+    calcs = {"revenues": [("stream_a", 1.0)]}
+    current = {"revenues": 100.0, "stream_a": 100.0}
+    _scale_rule_target_children(current, {"revenues"}, calcs)
+    assert current["stream_a"] == 100.0
+
+
+class TestDerivedCashFlow:
+  def test_cf_derives_deltas_and_foots_without_plug(self):
+    ctx = _ctx()
+    bs = {**BS_PRIOR, "ar": 150.0, "ap": 62.0, "prepaid": 11.0, "re": 132.0}
+    bs["cash"] = 75.0  # the balancing value for these lines
+    cf, plug = derive_cash_flow(
+      ctx,
+      bs=bs,
+      prior_bs=dict(BS_PRIOR),
+      resolved_is={"ni": 10.0, "dda": 2.0},
+      calculations=CALC,
+      calc_order=CALC_ORDER,
+    )
+    assert cf["d_ar"] == pytest.approx(-50.0)  # asset up = cash use
+    assert cf["d_prepaid"] == pytest.approx(1.0)  # asset down = cash source
+    assert cf["d_ap"] == pytest.approx(62.0)  # liability up = cash source
+    assert cf["dda"] == pytest.approx(2.0)  # direct IS value wins
+    assert cf["ni"] == pytest.approx(10.0)
+    # ΔCash = 25 = 10 + 2 - 50 + 1 + 62 → no residual, no plug.
+    assert plug == 0.0
+    assert "recon" not in cf
+    assert cf["cf_op"] == pytest.approx(25.0)
+    assert cf["cf_net"] == pytest.approx(25.0)
+    # Zero investing/financing stay out of the emission (actuals mirror).
+    assert "cf_inv" not in cf
+    assert "cf_fin" not in cf
+
+  def test_residual_books_to_the_reconciling_plug(self):
+    ctx = _ctx()
+    bs = {**BS_PRIOR, "ar": 150.0, "ap": 62.0, "prepaid": 11.0, "re": 132.0}
+    bs["cash"] = 75.0
+    # No direct DDA and no accum_dep in the BS dicts → derived net change
+    # misses 2.0 vs ΔCash; the plug closes it.
+    cf, plug = derive_cash_flow(
+      ctx,
+      bs=bs,
+      prior_bs=dict(BS_PRIOR),
+      resolved_is={"ni": 10.0},
+      calculations=CALC,
+      calc_order=CALC_ORDER,
+    )
+    delta_cash = 25.0
+    assert plug == pytest.approx(delta_cash - (10.0 - 50.0 + 1.0 + 62.0))
+    assert cf["recon"] == pytest.approx(plug)
+    assert cf["cf_net"] == pytest.approx(delta_cash)  # foots exactly
+
+  def test_direct_leaf_never_double_counts_with_derivation(self):
+    # dda has BOTH a direct IS value and a derivation source that moved.
+    ctx = _ctx()
+    bs = {**BS_PRIOR, "accum_dep": -12.0, "re": 132.0}
+    prior = {**BS_PRIOR, "accum_dep": -10.0}
+    cf, _ = derive_cash_flow(
+      ctx,
+      bs=bs,
+      prior_bs=prior,
+      resolved_is={"ni": 10.0, "dda": 2.0},
+      calculations=CALC,
+      calc_order=CALC_ORDER,
+    )
+    assert cf["dda"] == pytest.approx(2.0)

--- a/tests/operations/information_block/test_forecast_compute.py
+++ b/tests/operations/information_block/test_forecast_compute.py
@@ -238,6 +238,7 @@ def _run(
       return_value=SimpleNamespace(id="fs_lever", entity_id="ent_1"),
     ),
     patch.object(fc, "_upsert_month_set", recorder),
+    patch.object(fc, "_verify_month_sets", return_value=(None, [])),
   ):
     response = fc.cmd_compute_forecast(
       _session(structure),

--- a/tests/operations/information_block/test_forecast_handlers.py
+++ b/tests/operations/information_block/test_forecast_handlers.py
@@ -390,9 +390,10 @@ class TestDelete:
 
     lever_set = SimpleNamespace(id="fs_lever")
     month_set = SimpleNamespace(id="fs_july_is")
-    session.execute.return_value.scalars.return_value.all.return_value = [
-      lever_set,
-      month_set,
+    stale_verification = SimpleNamespace(id="vr_stale")
+    session.execute.return_value.scalars.return_value.all.side_effect = [
+      [lever_set, month_set],  # the scenario's FactSets
+      [stale_verification],  # verification rows pinned to those sets
     ]
 
     result = forecast_handlers.delete(
@@ -401,9 +402,11 @@ class TestDelete:
 
     assert result == "struct_budget_01"
     deleted = [call.args[0] for call in session.delete.call_args_list]
-    # Scenario sets first (they attach to OTHER structures — the
-    # structure delete alone wouldn't reach them), then the block.
-    assert deleted == [lever_set, month_set, structure]
+    # Verification rows first (no DB-level FK ties them to fact_sets —
+    # unswept they'd orphan invisibly), then the scenario sets (they
+    # attach to OTHER structures — the structure delete alone wouldn't
+    # reach them), then the block.
+    assert deleted == [stale_verification, lever_set, month_set, structure]
     session.commit.assert_called_once()
 
 


### PR DESCRIPTION
## Summary

F-2 of the FP&A operating plan (`fpa-operating-plan.md` §10): the forecast engine's scenario months now articulate into a coherent three-statement model. F-1 produced a footing IS plus rule-driven AR/AP instants; this PR adds everything §10.3 named as the coherence gap — and it's all composition over shipped machinery, no new math surfaces.

### The cascade per forward month (new steps in bold)

carry → **schedule IS deltas** → driver rules (topo) → **rule-delta push-down** → calc-DAG subtotals → **BS roll → balancing cash → CF derive + reconcile** → emit IS/BS/CF sets → **verify**

- **Balance-sheet roll** (`forecast_articulation.py`): base BS leaves carry; rule-driven working capital overrides; schedule instant movements apply **per schedule set** (an ended schedule freezes at its final balance, never reverses); RE rolls `RE[m] = RE[m-1] + NI[m]`; **cash is the balancing roll** — A = L + E holds by construction. Subtotals always derive, never carry.
- **Schedule projection**: contributions route through the mapping's primary target into base-set element space (the PP&E gross/contra pair routes onto `PropertyPlantAndEquipmentNet`, mirroring `_synthesize_ppe_net_facts`). Duration deltas adjust the IS carry so an ending schedule's expense stops. The window includes historical-scope facts deliberately — the base month is the delta basis (caught live: without it every month re-added the base month's depreciation).
- **Derived CF**: operating leaves from period-over-period BS deltas via the library's derivation arcs (a leaf with a direct IS value — DDA — wins); residual vs the balancing ΔCash books to the reconciling leaf, the actuals plug doctrine. CF foots to ΔCash exactly. In-code supplement: `AccountsPayableCurrent` aliases into the AP CF leaf (the library arc only sources the combined AP+accrued anchor — library follow-up noted).
- **Rule-delta push-down**: a Derive rule targeting a calc parent (Revenues, CostOfRevenue) scales the parent's carried children proportionally — the workbook's implicit semantics. First live verification run caught exactly this (driven parent, stale children → rollup residuals).
- **Verification gating**: each scenario month runs the same rule corpus as actuals, pinned via the existing `fact_set_id` path (no engine threading needed); results replace on recompute; per-month outcome rides the response.
- **Verification-bleed fix** (the F-2 analog of F-1's FactSet hijack): envelope reads now scope verification results by scenario — without it, scenario-month runs pollute every actuals envelope's verification list. Regression-tested via emitted SQL. The forecast delete sweeps its months' results (no DB-level FK ties them).

### Live verification (both showcase episodes, fresh provisioning)

Driftline + Cadence: A = L + E exact every month, ΔRE == NI, ΔCash == CF net change, 12/12 months verified, 12/12 CF sets, actuals envelopes unchanged at 15 periods (hijack + bleed checks live). Cadence runs the partial-lever path (no DSO) clean, and its runway story now renders: NI negative, cash declining monthly.

### Notes

- No migration — code-only; CF sets reuse the existing FactSet shape.
- `test_incremental_equals_full_load` fails order-dependently under the parallel run on main too (pre-existing flake; passes in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)