### PR TITLE
feat(blocks): statement-series projection — statements as time series (F-4)

### DIFF
--- a/robosystems/graphql/resolvers/information_block.py
+++ b/robosystems/graphql/resolvers/information_block.py
@@ -50,6 +50,7 @@ class InformationBlockQuery:
     info: Info[GraphQLContext, None],
     id: strawberry.ID,
     scenario_id: str | None = None,
+    series: bool = False,
   ) -> InformationBlock | None:
     """Fetch a single Information Block envelope by id.
 
@@ -58,9 +59,16 @@ class InformationBlockQuery:
     (statement envelopes bind its latest computed month, metric
     envelopes extend the series with its forward columns, labeled
     "(forecast)").
+
+    ``series`` renders a statement block as its whole report-set time
+    series — one column per period, actuals-preferred at the seam when
+    combined with ``scenarioId``; forecast columns carry
+    ``periods[].forecast = true``. Non-statement block types ignore it.
     """
     with _open_session(info) as session:
-      envelope = get_information_block(session, str(id), scenario_id=scenario_id)
+      envelope = get_information_block(
+        session, str(id), scenario_id=scenario_id, series=series
+      )
       return InformationBlock.from_pydantic(envelope) if envelope else None
 
   @strawberry.field

--- a/robosystems/middleware/mcp/tools/information_block_tools.py
+++ b/robosystems/middleware/mcp/tools/information_block_tools.py
@@ -56,6 +56,10 @@ class GetInformationBlockTool:
   scenario's FactSet slice instead of actuals (statement envelopes show
   the latest computed forecast month; metric envelopes extend the series
   with the scenario's forward columns, labeled "(forecast)")
+- series (optional): Render a statement block as its whole report-set
+  time series — one column per period; combined with scenario_id the
+  columns cross the actuals/forecast seam (forecast columns carry
+  periods[].forecast = true). Non-statement block types ignore it
 
 **RETURNS:**
 A typed envelope with:
@@ -87,6 +91,14 @@ were retired in favor of this pair.""",
               "FactSet slice instead of actuals."
             ),
           },
+          "series": {
+            "type": "boolean",
+            "description": (
+              "Statement blocks only: render the whole report-set time "
+              "series (one column per period, actuals-preferred at the "
+              "forecast seam)."
+            ),
+          },
         },
         "required": ["id"],
       },
@@ -96,10 +108,13 @@ were retired in favor of this pair.""",
     graph_id = self.client.graph_id
     block_id = arguments["id"]
     scenario_id = arguments.get("scenario_id")
+    series = bool(arguments.get("series", False))
 
     try:
       with extensions_session(graph_id) as session:
-        envelope = ops_get_information_block(session, block_id, scenario_id=scenario_id)
+        envelope = ops_get_information_block(
+          session, block_id, scenario_id=scenario_id, series=series
+        )
         if envelope is None:
           return {
             "error": "not_found",

--- a/robosystems/models/api/information_block.py
+++ b/robosystems/models/api/information_block.py
@@ -811,6 +811,15 @@ class RenderingPeriodLite(BaseModel):
   start: date
   end: date
   label: str | None = None
+  forecast: bool | None = Field(
+    None,
+    description=(
+      "True when this column comes from a forecast scenario's FactSet "
+      "— the machine-readable seam marker (labels also carry a "
+      "'(forecast)' suffix, but consumers should key styling off this "
+      "flag, not label parsing). None/absent = an actuals column."
+    ),
+  )
 
 
 class ValidationLite(BaseModel):

--- a/robosystems/operations/information_block/disclosure.py
+++ b/robosystems/operations/information_block/disclosure.py
@@ -60,6 +60,7 @@ def build_envelope(
   structure_id: str,
   fact_set_id: str | None = None,
   scenario_id: str | None = None,
+  series: bool = False,
 ) -> InformationBlockEnvelope | None:
   """Pack the envelope for a disclosure-note structure.
 

--- a/robosystems/operations/information_block/envelope.py
+++ b/robosystems/operations/information_block/envelope.py
@@ -10,6 +10,7 @@ diverge.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import date
 
 from sqlalchemy import or_, select
 from sqlalchemy.orm import Session
@@ -301,6 +302,58 @@ def load_latest_fact_set_for_structure(
     .limit(1)
   ).scalar()
   return fact_set_to_lite(row) if row is not None else None
+
+
+def load_statement_fact_set_series(
+  session: Session, structure_id: str, scenario_id: str | None = None
+) -> list[FactSetLite]:
+  """The full report-set series for a statement structure, one per period.
+
+  The statement analog of the metric series loader
+  (:func:`metric._load_metric_fact_sets` is hard-scoped to
+  ``factset_type='metric'``): every ``'report'`` set for the structure,
+  ascending ``period_end`` — the monthly columns of the F-4 Plan grid.
+
+  Scenario semantics mirror the metric series: ``scenario_id=None``
+  loads actuals only; a scenario id loads actuals **plus** that
+  scenario's sets, and at an overlapping ``period_end`` the actual wins
+  (the moving seam — a closed month's draft supersedes its forecast).
+
+  Two collisions collapse per ``period_end``, in order:
+
+  1. ``scenario_id ASC NULLS FIRST`` — the actual beats the forecast.
+  2. ``period_start DESC NULLS LAST`` — the NARROWER window wins, so at
+     the FY-end month the monthly set beats the annual report set
+     created later (the FY-capture lesson applied at series level;
+     ``created_at DESC`` alone would pick the annual).
+  """
+  scenario_predicate = (
+    FactSet.scenario_id.is_(None)
+    if scenario_id is None
+    else or_(FactSet.scenario_id.is_(None), FactSet.scenario_id == scenario_id)
+  )
+  rows = (
+    session.execute(
+      select(FactSet)
+      .where(
+        FactSet.structure_id == structure_id,
+        FactSet.factset_type == "report",
+        scenario_predicate,
+      )
+      .order_by(
+        FactSet.period_end.asc(),
+        FactSet.scenario_id.asc().nulls_first(),
+        FactSet.period_start.desc().nulls_last(),
+        FactSet.created_at.desc(),
+      )
+    )
+    .scalars()
+    .all()
+  )
+  by_period_end: dict[date, FactSet] = {}
+  for row in rows:
+    by_period_end.setdefault(row.period_end, row)
+  return [fact_set_to_lite(row) for row in by_period_end.values()]
 
 
 def load_fact_set_by_id_for_structure(

--- a/robosystems/operations/information_block/forecast.py
+++ b/robosystems/operations/information_block/forecast.py
@@ -407,6 +407,7 @@ def build_envelope(
   structure_id: str,
   fact_set_id: str | None = None,
   scenario_id: str | None = None,
+  series: bool = False,
 ) -> InformationBlockEnvelope | None:
   """Reload a forecast Structure and pack its envelope.
 

--- a/robosystems/operations/information_block/metric.py
+++ b/robosystems/operations/information_block/metric.py
@@ -178,13 +178,15 @@ def build_envelope(
       RenderingPeriodLite(
         start=fs.period_start if fs.period_start is not None else fs.period_end,
         end=fs.period_end,
-        # Scenario-sourced columns are labeled honestly; actual columns
-        # keep label=None and the frontend formats dates as today.
+        # Scenario-sourced columns are labeled honestly AND flagged
+        # machine-readably; actual columns keep label=None (the
+        # frontend formats dates) and no flag.
         label=(
           f"{fs.period_end.strftime('%b %Y')} (forecast)"
           if fs.scenario_id is not None
           else None
         ),
+        forecast=True if fs.scenario_id is not None else None,
       )
       for fs in fact_sets
     ],

--- a/robosystems/operations/information_block/metric.py
+++ b/robosystems/operations/information_block/metric.py
@@ -103,8 +103,13 @@ def build_envelope(
   structure_id: str,
   fact_set_id: str | None = None,
   scenario_id: str | None = None,
+  series: bool = False,
 ) -> InformationBlockEnvelope | None:
   """Pack a metric Structure + its standing time series into the envelope.
+
+  ``series`` is accepted for dispatch-signature parity and ignored — a
+  metric envelope IS the full series already; the flag exists for the
+  statement family, whose default read binds a single set.
 
   Rendering: one period column per metric FactSet (ascending
   ``period_end``), one row per catalog concept in presentation-arc

--- a/robosystems/operations/information_block/reads.py
+++ b/robosystems/operations/information_block/reads.py
@@ -28,6 +28,7 @@ def get_information_block(
   structure_id: str,
   fact_set_id: str | None = None,
   scenario_id: str | None = None,
+  series: bool = False,
 ) -> InformationBlockEnvelope | None:
   """Fetch one block by id, dispatching via the structure's block_type.
 
@@ -35,8 +36,8 @@ def get_information_block(
   registered — callers map that to a GraphQL null / REST 404. When
   ``fact_set_id`` is provided the envelope is rehydrated from that
   specific FactSet instead of the latest one (used by Report Block
-  rehydration to surface a frozen snapshot) and ``scenario_id`` is
-  ignored — an explicit pin bypasses scenario selection.
+  rehydration to surface a frozen snapshot) and ``scenario_id`` /
+  ``series`` are ignored — an explicit pin bypasses both.
 
   ``scenario_id`` selects the FactSet slice the envelope binds:
   ``None`` = actuals; a forecast block's structure id = that scenario
@@ -44,6 +45,12 @@ def get_information_block(
   extend the series with its forward columns). Block types without
   scenario slices (schedule, rollforward, disclosure) accept and
   ignore it.
+
+  ``series=True`` renders a statement block as its whole report-set
+  time series — one column per period, actuals-preferred at the seam
+  when combined with ``scenario_id`` (the F-4 statement-series
+  projection). Non-statement block types accept and ignore it (metric
+  envelopes are always the full series).
   """
   structure = session.get(Structure, structure_id)
   if structure is None:
@@ -56,7 +63,7 @@ def get_information_block(
     # be built.
     return None
   return entry.dispatch_build_envelope(
-    session, structure_id, fact_set_id, scenario_id=scenario_id
+    session, structure_id, fact_set_id, scenario_id=scenario_id, series=series
   )
 
 

--- a/robosystems/operations/information_block/rollforward.py
+++ b/robosystems/operations/information_block/rollforward.py
@@ -237,6 +237,7 @@ def build_envelope(
   structure_id: str,
   fact_set_id: str | None = None,
   scenario_id: str | None = None,
+  series: bool = False,
 ) -> InformationBlockEnvelope | None:
   """Reload a rollforward Structure and pack its envelope.
 

--- a/robosystems/operations/information_block/schedule.py
+++ b/robosystems/operations/information_block/schedule.py
@@ -168,6 +168,7 @@ def build_envelope(
   structure_id: str,
   fact_set_id: str | None = None,
   scenario_id: str | None = None,
+  series: bool = False,
 ) -> InformationBlockEnvelope | None:
   """Reload a schedule Structure and pack its Information Block envelope.
 

--- a/robosystems/operations/information_block/statement.py
+++ b/robosystems/operations/information_block/statement.py
@@ -58,6 +58,7 @@ from robosystems.operations.information_block.envelope import (
   fact_to_lite,
   load_base_envelope_atoms,
   load_disclosure_id_for_structure,
+  load_statement_fact_set_series,
 )
 from robosystems.operations.roboledger.reports.fact_grid import (
   FactRow,
@@ -96,6 +97,7 @@ def _build_statement_envelope(
   structure_id: str,
   fact_set_id: str | None = None,
   scenario_id: str | None = None,
+  series: bool = False,
   *,
   block_type: str,
 ) -> InformationBlockEnvelope | None:
@@ -122,6 +124,16 @@ def _build_statement_envelope(
   scenario's latest computed forecast month and every rendered period
   column carries a ``"... (forecast)"`` label so the surface is honest
   about what it shows.
+
+  **Series mode (F-4).** ``series=True`` binds the structure's WHOLE
+  report-set series instead of one set — one rendered column per
+  period, actuals-preferred at the seam when a scenario is selected
+  (:func:`envelope.load_statement_fact_set_series`). This is the
+  statement analog of the metric time series and the data spine of the
+  Plan grid. Facts are windowed per set to the set's own period so an
+  annual report's comparative facts can't leak into a monthly column.
+  An explicit ``fact_set_id`` pin bypasses series mode (a snapshot is
+  a single set by definition).
   """
   atoms = load_base_envelope_atoms(
     session,
@@ -136,8 +148,44 @@ def _build_statement_envelope(
   structure = atoms.structure
   element_ids = atoms.element_ids
 
+  series_mode = series and fact_set_id is None
+  forecast_period_ends: set[date] = set()
   facts: list[Fact] = []
-  if element_ids and atoms.fact_set is not None:
+  if element_ids and series_mode:
+    series_sets = load_statement_fact_set_series(session, structure_id, scenario_id)
+    forecast_period_ends = {
+      fs.period_end for fs in series_sets if fs.scenario_id is not None
+    }
+    if series_sets:
+      all_facts = (
+        session.execute(
+          select(Fact).where(
+            Fact.fact_set_id.in_([fs.id for fs in series_sets]),
+            Fact.element_id.in_(element_ids),
+          )
+        )
+        .scalars()
+        .all()
+      )
+      # Window each fact to its OWN set's period — a set may carry
+      # comparative-period facts (annual reports do) and those belong
+      # to another column, not this one.
+      window_by_set = {fs.id: (fs.period_start, fs.period_end) for fs in series_sets}
+      for f in all_facts:
+        window = window_by_set.get(f.fact_set_id or "")
+        if window is None:
+          continue
+        set_start, set_end = window
+        if f.period_end != set_end:
+          continue
+        if (
+          f.period_start is not None
+          and set_start is not None
+          and f.period_start < set_start
+        ):
+          continue
+        facts.append(f)
+  elif element_ids and atoms.fact_set is not None:
     facts = list(
       session.execute(
         select(Fact).where(
@@ -170,10 +218,25 @@ def _build_statement_envelope(
     concept_arrangement=structure.concept_arrangement,
   )
 
-  # Scenario mode bound a forecast set — every rendered column is a
-  # forward month; stamp the labels so tables and chart axes read
-  # honestly.
-  if (
+  # Stamp forecast columns — label + machine-readable flag — so tables
+  # and chart axes read honestly. Series mode marks exactly the columns
+  # whose winning set is a scenario set (the seam falls out of the
+  # actuals-preferred collapse); single-set scenario mode marks every
+  # column of the bound forecast month.
+  if series_mode and forecast_period_ends:
+    rendering = rendering.model_copy(
+      update={
+        "periods": [
+          p.model_copy(
+            update={"label": _forecast_period_label(p.end), "forecast": True}
+          )
+          if p.end in forecast_period_ends
+          else p
+          for p in rendering.periods
+        ]
+      }
+    )
+  elif (
     scenario_id is not None
     and atoms.fact_set is not None
     and atoms.fact_set.scenario_id == scenario_id
@@ -181,7 +244,9 @@ def _build_statement_envelope(
     rendering = rendering.model_copy(
       update={
         "periods": [
-          p.model_copy(update={"label": _forecast_period_label(p.end)})
+          p.model_copy(
+            update={"label": _forecast_period_label(p.end), "forecast": True}
+          )
           for p in rendering.periods
         ]
       }

--- a/tests/operations/information_block/test_envelope_fact_set.py
+++ b/tests/operations/information_block/test_envelope_fact_set.py
@@ -136,6 +136,88 @@ class TestLoadLatestFactSetForStructure:
     assert lite.scenario_id is None
 
 
+class TestLoadStatementFactSetSeries:
+  """The F-4 series loader — every report set as one column, with the
+  actuals-preferred seam and the narrower-window-wins collapse."""
+
+  @staticmethod
+  def _session(rows: list) -> MagicMock:
+    session = MagicMock()
+    session.execute.return_value.scalars.return_value.all.return_value = rows
+    return session
+
+  def test_actuals_read_excludes_scenario_sets(self) -> None:
+    from robosystems.operations.information_block.envelope import (
+      load_statement_fact_set_series,
+    )
+
+    session = self._session([])
+    load_statement_fact_set_series(session, "struct_bs")
+    stmt = session.execute.call_args.args[0]
+    sql = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+    assert "scenario_id IS NULL" in sql
+    assert "scenario_id =" not in sql  # no scenario arm in actuals mode
+
+  def test_scenario_read_merges_actuals_plus_that_scenario(self) -> None:
+    from robosystems.operations.information_block.envelope import (
+      load_statement_fact_set_series,
+    )
+
+    session = self._session([])
+    load_statement_fact_set_series(session, "struct_bs", "struct_budget")
+    stmt = session.execute.call_args.args[0]
+    sql = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+    assert "scenario_id IS NULL" in sql
+    assert "scenario_id = 'struct_budget'" in sql
+
+  def test_ordering_encodes_seam_and_window_precedence(self) -> None:
+    """The collapse is first-row-per-period_end, so the ORDER BY IS the
+    semantics: actual beats forecast (scenario NULLS FIRST), then the
+    NARROWER window beats the annual set sharing the FY-end period_end
+    (period_start DESC — the FY-capture lesson at series level)."""
+    from robosystems.operations.information_block.envelope import (
+      load_statement_fact_set_series,
+    )
+
+    session = self._session([])
+    load_statement_fact_set_series(session, "struct_bs", "struct_budget")
+    stmt = session.execute.call_args.args[0]
+    sql = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+    order_by = sql.split("ORDER BY")[1]
+    assert "period_end ASC" in order_by
+    assert "scenario_id ASC NULLS FIRST" in order_by
+    assert "period_start DESC NULLS LAST" in order_by
+    assert order_by.index("period_end ASC") < order_by.index("scenario_id ASC")
+    assert order_by.index("scenario_id ASC") < order_by.index("period_start DESC")
+
+  def test_collapse_keeps_first_row_per_period_end(self) -> None:
+    from robosystems.operations.information_block.envelope import (
+      load_statement_fact_set_series,
+    )
+
+    may = date(2026, 5, 31)
+    june = date(2026, 6, 30)
+    # Pre-ordered as the SQL would return them: May actual, June actual
+    # (draft), June forecast (loses the seam), then a second May row
+    # (an annual set at the same period_end — loses the window rule).
+    rows = [
+      _make_fact_set(fs_id="fs_may", period_start=date(2026, 5, 1), period_end=may),
+      _make_fact_set(
+        fs_id="fs_june_draft", period_start=date(2026, 6, 1), period_end=june
+      ),
+      _make_fact_set(
+        fs_id="fs_june_forecast",
+        period_start=date(2026, 6, 1),
+        period_end=june,
+        scenario_id="struct_budget",
+      ),
+      _make_fact_set(fs_id="fs_fy", period_start=date(2025, 6, 1), period_end=may),
+    ]
+    session = self._session(rows)
+    series = load_statement_fact_set_series(session, "struct_bs", "struct_budget")
+    assert [fs.id for fs in series] == ["fs_may", "fs_june_draft"]
+
+
 class TestLoadFactSetByIdForStructure:
   """Pin lookup for the Report-Block read path — match Structure + id, or None."""
 

--- a/tests/operations/information_block/test_reads.py
+++ b/tests/operations/information_block/test_reads.py
@@ -77,7 +77,26 @@ class TestGetInformationBlock:
     with patch.dict(REGISTRY_PATH, {"schedule": patched}):
       result = get_information_block(session, "struct_1")
     assert result is expected
-    mock_build.assert_called_once_with(session, "struct_1", None, scenario_id=None)
+    mock_build.assert_called_once_with(
+      session, "struct_1", None, scenario_id=None, series=False
+    )
+
+  def test_series_threads_through_dispatch(self) -> None:
+    """The F-4 series flag reaches the handler as a keyword — statement
+    handlers render the whole report-set series; others ignore it."""
+    session = MagicMock()
+    structure = MagicMock()
+    structure.block_type = "schedule"
+    session.get.return_value = structure
+    mock_build = MagicMock(return_value=_envelope("struct_1"))
+    patched = _schedule_entry_with_build(mock_build)
+    with patch.dict(REGISTRY_PATH, {"schedule": patched}):
+      get_information_block(
+        session, "struct_1", scenario_id="struct_budget", series=True
+      )
+    mock_build.assert_called_once_with(
+      session, "struct_1", None, scenario_id="struct_budget", series=True
+    )
 
 
 # ── list_information_blocks ────────────────────────────────────────────────
@@ -303,4 +322,6 @@ class TestGetInformationBlockForFactSet:
       result = get_information_block_for_fact_set(session, "fs_01")
 
     assert result is expected
-    mock_build.assert_called_once_with(session, "struct_1", "fs_01", scenario_id=None)
+    mock_build.assert_called_once_with(
+      session, "struct_1", "fs_01", scenario_id=None, series=False
+    )

--- a/tests/operations/information_block/test_statement_handlers.py
+++ b/tests/operations/information_block/test_statement_handlers.py
@@ -627,3 +627,190 @@ class TestRenderingComposesCalcsCrossStructure:
 
     flags = {r.element_qname: r.is_subtotal for r in rendering.rows}
     assert flags["rs-gaap:GrossProfit"] is False
+
+
+class TestSeriesMode:
+  """F-4 statement-series projection — one column per report set,
+  actuals-preferred at the seam, facts windowed to their own set."""
+
+  @staticmethod
+  def _element(element_id: str, qname: str, period_type: str = "instant") -> MagicMock:
+    element = MagicMock()
+    element.id = element_id
+    element.qname = qname
+    element.name = qname.split(":")[-1]
+    element.code = None
+    element.element_type = "concept"
+    element.is_abstract = False
+    element.is_monetary = True
+    element.balance_type = "debit"
+    element.period_type = period_type
+    element.item_type = None
+    return element
+
+  @staticmethod
+  def _assoc() -> MagicMock:
+    assoc = MagicMock()
+    assoc.id = "assoc_1"
+    assoc.from_element_id = "elem_assets"
+    assoc.to_element_id = "elem_cash"
+    assoc.association_type = "presentation"
+    assoc.arcrole = None
+    assoc.order_value = None
+    assoc.weight = None
+    return assoc
+
+  @staticmethod
+  def _fact_set(
+    fs_id: str,
+    period_start: date,
+    period_end: date,
+    scenario_id: str | None = None,
+  ) -> MagicMock:
+    fs = MagicMock()
+    fs.id = fs_id
+    fs.structure_id = "struct_balance_sheet"
+    fs.period_start = period_start
+    fs.period_end = period_end
+    fs.factset_type = "report"
+    fs.entity_id = "ent_demo"
+    fs.report_id = None
+    fs.scenario_id = scenario_id
+    fs.provenance = None
+    return fs
+
+  @staticmethod
+  def _fact(
+    fact_id: str,
+    fact_set_id: str,
+    period_end: date,
+    value: float,
+    period_start: date | None = None,
+  ) -> MagicMock:
+    fact = MagicMock()
+    fact.id = fact_id
+    fact.element_id = "elem_cash"
+    fact.value = value
+    fact.string_value = None
+    fact.fact_type = "Numeric"
+    fact.content_type = None
+    fact.period_start = period_start
+    fact.period_end = period_end
+    fact.period_type = "instant"
+    fact.unit = "USD"
+    fact.fact_scope = "in_scope"
+    fact.fact_set_id = fact_set_id
+    return fact
+
+  def _run_series(
+    self,
+    series_sets: list[MagicMock],
+    facts: list[MagicMock],
+    scenario_id: str | None,
+  ):
+    session = MagicMock()
+    structure = _make_statement_structure(
+      structure_id="struct_balance_sheet",
+      block_type="balance_sheet",
+      name="Balance Sheet",
+    )
+    session.get.return_value = structure
+    latest = series_sets[-1] if series_sets else None
+    session.execute.side_effect = [
+      _exec_result(scalar=latest),  # latest set (atoms.fact_set)
+      _exec_result(scalar="US GAAP"),  # taxonomy name
+      _exec_result(scalars_all=[self._assoc()]),  # associations
+      _exec_result(
+        scalars_all=[self._element("elem_cash", "rs-gaap:Cash")]
+      ),  # elements
+      _exec_result(scalars_all=[]),  # rules
+      _exec_result(all_rows=[]),  # association classifications
+      _exec_result(scalars_all=[]),  # verification results
+      _exec_result(scalars_all=series_sets),  # the series (F-4)
+      _exec_result(scalars_all=facts),  # facts across the series sets
+      _exec_result(all_rows=[]),  # element classifications
+    ]
+    build = statement_handlers.make_statement_handlers("balance_sheet")
+    return build(session, "struct_balance_sheet", scenario_id=scenario_id, series=True)
+
+  def test_one_column_per_set_with_seam_flags(self) -> None:
+    may, june = date(2026, 5, 31), date(2026, 6, 30)
+    sets = [
+      self._fact_set("fs_may", date(2026, 5, 1), may),
+      self._fact_set("fs_june", date(2026, 6, 1), june, scenario_id="struct_budget"),
+    ]
+    facts = [
+      self._fact("f_may", "fs_may", may, 100_000.0),
+      self._fact("f_june", "fs_june", june, 110_000.0),
+    ]
+    envelope = self._run_series(sets, facts, "struct_budget")
+
+    assert envelope is not None
+    rendering = envelope.view.rendering
+    assert rendering is not None
+    assert [p.end for p in rendering.periods] == [may, june]
+    # The seam: actual column unmarked, forecast column labeled + flagged.
+    assert rendering.periods[0].label is None
+    assert rendering.periods[0].forecast is None
+    assert rendering.periods[1].label == "Jun 2026 (forecast)"
+    assert rendering.periods[1].forecast is True
+    cash_row = next(r for r in rendering.rows if r.element_qname == "rs-gaap:Cash")
+    assert cash_row.values == [100_000.0, 110_000.0]
+
+  def test_facts_window_to_their_own_set(self) -> None:
+    """An annual set carries comparative-period facts; they must not
+    leak into other columns (nor mint phantom columns)."""
+    may, june = date(2026, 5, 31), date(2026, 6, 30)
+    sets = [
+      self._fact_set("fs_may", date(2026, 5, 1), may),
+      self._fact_set("fs_june", date(2026, 6, 1), june),
+    ]
+    facts = [
+      self._fact("f_may", "fs_may", may, 100_000.0),
+      self._fact("f_june", "fs_june", june, 110_000.0),
+      # Comparative fact inside fs_june pointing at MAY — windowed out.
+      self._fact("f_comparative", "fs_june", may, 999_999.0),
+    ]
+    envelope = self._run_series(sets, facts, None)
+
+    assert envelope is not None
+    rendering = envelope.view.rendering
+    assert rendering is not None
+    cash_row = next(r for r in rendering.rows if r.element_qname == "rs-gaap:Cash")
+    assert cash_row.values == [100_000.0, 110_000.0]  # not 999_999
+
+  def test_fact_set_pin_bypasses_series(self) -> None:
+    """A snapshot pin is a single set by definition — series is ignored."""
+    may = date(2026, 5, 31)
+    pinned = self._fact_set("fs_pinned", date(2026, 5, 1), may)
+    session = MagicMock()
+    structure = _make_statement_structure(
+      structure_id="struct_balance_sheet",
+      block_type="balance_sheet",
+      name="Balance Sheet",
+    )
+    session.get.return_value = structure
+    session.execute.side_effect = [
+      _exec_result(scalar=pinned),  # fact set by id (pin validation)
+      _exec_result(scalar="US GAAP"),  # taxonomy name
+      _exec_result(scalars_all=[self._assoc()]),  # associations
+      _exec_result(
+        scalars_all=[self._element("elem_cash", "rs-gaap:Cash")]
+      ),  # elements
+      _exec_result(scalars_all=[]),  # rules
+      _exec_result(all_rows=[]),  # association classifications
+      _exec_result(scalars_all=[]),  # verification results
+      _exec_result(
+        scalars_all=[self._fact("f_may", "fs_pinned", may, 100_000.0)]
+      ),  # facts by pinned set — NO series query in between
+      _exec_result(all_rows=[]),  # element classifications
+    ]
+    build = statement_handlers.make_statement_handlers("balance_sheet")
+    envelope = build(
+      session, "struct_balance_sheet", "fs_pinned", scenario_id=None, series=True
+    )
+
+    assert envelope is not None
+    rendering = envelope.view.rendering
+    assert rendering is not None
+    assert len(rendering.periods) == 1


### PR DESCRIPTION
## Summary

The F-4 statement-series projection (`fpa-operating-plan.md` §10.3 #2): statement envelopes gain a **series mode** — `series=true` renders the structure's whole report-set series as one column per period, the statement analog of the metric time series. This is the one genuinely new backend piece the Plan surface needs; the roboledger-app `/plan` grid composes on top of it.

### What's here

- **`load_statement_fact_set_series`** (`envelope.py`): every `'report'` set for the structure ascending `period_end`. With a scenario: actuals + that scenario merged, **actuals-preferred at overlapping period_ends** (the moving seam). Collapse precedence is encoded in the ORDER BY and tested as such: actual beats forecast, then the **narrower window wins** — the monthly set beats the annual report sharing the FY-end period_end (the FY-capture lesson applied at series level; `created_at` alone would pick the annual).
- **Statement series rendering** (`statement.py`): facts load across all series sets, **windowed per set to the set's own period** so an annual report's comparative facts can't leak into a monthly column or mint phantom columns. The existing multi-column rendering path does the rest.
- **`RenderingPeriodLite.forecast`** — machine-readable seam marker on forecast columns (alongside the `"(forecast)"` label), stamped by both statement modes; frontends stop parsing label strings.
- **Threading**: `reads.get_information_block(series=...)` → registry dispatch → GraphQL `informationBlock(series:)` → MCP `get-information-block`. Non-statement handlers accept-and-ignore (a metric envelope is always the full series); a `fact_set_id` pin bypasses series (a snapshot is one set by definition). Default reads are byte-identical — regression-covered.

### Live verification (Driftline, local)

- `series=true` + scenario: **26 columns** — 15 actual + 11 forecast (June's forecast superseded by the open-month draft = the seam), forecast flags from Jul 2026, cash row populated across all 26.
- `series=true` actuals-only: 15 clean monthly columns (annual set correctly collapsed).
- Default read: unchanged (June draft, 2 columns, no flags).

### Notes

- No migration; read-side only. Composes with #920 (F-2 articulation) but does not depend on it — no overlapping hunks.
- SDK follow-ups: TS `$series` arg + `forecast` period field, Python regen (separate PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)