### PR TITLE
feat(close): stamp canonical statement FactSets at period close

### DIFF
--- a/robosystems/middleware/mcp/tools/fiscal_calendar_tools.py
+++ b/robosystems/middleware/mcp/tools/fiscal_calendar_tools.py
@@ -52,6 +52,9 @@ from robosystems.operations.roboledger.reads.fiscal_calendar import (
   build_fiscal_calendar_response,
   qb_sync_state,
 )
+from robosystems.operations.roboledger.reports.statement_sets import (
+  StatementStampError,
+)
 
 
 def _calendar_dict(session, graph_id: str, calendar, service) -> dict[str, Any]:
@@ -169,11 +172,17 @@ class ClosePeriodTool:
 3. Validates the BS equation balances for the period
 4. Transitions the FiscalPeriod from open → closed
 5. Advances closed_through; auto-advances close_target if reached
-6. Auto-runs the rule engine for every schedule Structure with facts in
-   the closed period. Rule outcomes ride on the response as
-   `rule_summary` / `evaluated_structure_ids` so you can report which
-   schedules passed / failed to the user.
-7. Emits a period_closed audit event
+6. Pivots the posted ledger and stamps the period's canonical statement
+   FactSets (balance sheet / income statement / cash flow) — closing IS
+   the act that persists the month's statements. Re-closing replaces
+   them. Soft-skipped (statements_stamped=false with a note) when the
+   tenant has no CoA mapping yet.
+7. Auto-runs the rule engine for every schedule Structure with facts in
+   the closed period, and the statement rule corpus against the stamped
+   sets. Rule outcomes ride on the response as `rule_summary` /
+   `evaluated_structure_ids` / `statement_rule_summary` so you can
+   report which schedules and statements passed / failed to the user.
+8. Emits a period_closed audit event
 
 **PARAMETERS:**
 - period (required): YYYY-MM format (e.g., "2026-03")
@@ -191,6 +200,13 @@ class ClosePeriodTool:
   null when no schedules had facts in the period.
 - evaluated_structure_ids: ids of schedule Structures whose rules were
   evaluated. Pairs with rule_summary.
+- statements_stamped / statement_stamp_note: whether the close stamped
+  the period's canonical statement FactSets (note carries the soft-skip
+  reason, e.g. no_coa_mapping).
+- stamped_statement_sets: structure_id -> fact_set_id for the minted
+  canonical sets — use get-information-block to render them.
+- statement_rule_summary: verification tally across the stamped
+  statements (pass / fail / error / skipped); null when no rules exist.
 
 **GUARDS (422 errors):**
 - Cannot close out of sequence
@@ -276,6 +292,13 @@ class ClosePeriodTool:
           # consumers see the same surface.
           "rule_summary": result.rule_summary,
           "evaluated_structure_ids": list(result.evaluated_structure_ids),
+          # Canonical statement stamping (the close-time pivot). Shaped
+          # by hand here — without these keys agents never see that the
+          # close persisted the month's statements.
+          "statements_stamped": result.statements_stamped,
+          "statement_stamp_note": result.statement_stamp_note,
+          "stamped_statement_sets": dict(result.stamped_statement_sets),
+          "statement_rule_summary": result.statement_rule_summary,
         }
     except CloseGateFailed as exc:
       if exc.no_calendar:
@@ -314,6 +337,14 @@ class ClosePeriodTool:
           "Review the ledger before closing."
         ),
       }
+    except StatementStampError as exc:
+      return {
+        "error": "statement_stamp_failed",
+        "message": (
+          f"{exc} The close rolled back — nothing was committed. Fix the "
+          "mapping/reporting configuration and re-run close-period."
+        ),
+      }
     except FiscalCalendarError as exc:
       return {"error": "calendar_error", "message": str(exc)}
     except Exception as exc:
@@ -345,9 +376,11 @@ class ReopenPeriodTool:
 **WHAT IT DOES:**
 1. Transitions FiscalPeriod from 'closed' → 'closing' (drafts may still exist)
 2. If this was the latest closed period, decrements closed_through
-3. Does NOT modify close_target — that's a separate user decision
-4. Does NOT modify existing posted entries — they stay posted
-5. Emits a period_reopened audit event with the required reason
+3. Retracts the month's canonical statement FactSets (a reopened month is
+   no longer a closed assertion; re-closing restamps them fresh)
+4. Does NOT modify close_target — that's a separate user decision
+5. Does NOT modify existing posted entries — they stay posted
+6. Emits a period_reopened audit event with the required reason
 
 **PARAMETERS:**
 - period (required): YYYY-MM format
@@ -355,6 +388,8 @@ class ReopenPeriodTool:
 
 **RETURNS:**
 - Updated fiscal_calendar state
+- statement_sets_retracted: how many canonical statement FactSets the
+  reopen deleted (0 for months closed before close-time stamping existed)
 
 **GUARDS:**
 - Period must be in 'closed' status (422 otherwise)
@@ -412,7 +447,7 @@ class ReopenPeriodTool:
     try:
       with extensions_session(graph_id) as session, _platform_session() as platform_db:
         try:
-          fc_response = ops_reopen_period(
+          result = ops_reopen_period(
             session,
             platform_db,
             graph_id,
@@ -433,13 +468,16 @@ class ReopenPeriodTool:
             "error": "not_closed",
             "message": f"Period {period!r} is not closed (status={exc.status!r}).",
           }
-        fc_payload = fc_response.model_dump(mode="json")
+        fc_payload = result.fiscal_calendar.model_dump(mode="json")
         has_sync, _ = qb_sync_state(platform_db, graph_id)
         fc_payload["has_sync_connection"] = has_sync
         return {
           "period": period,
           "reason": reason,
           "fiscal_calendar": fc_payload,
+          # Canonical statement sets deleted by the reopen (a reopened
+          # month is no longer a closed assertion; re-closing restamps).
+          "statement_sets_retracted": result.statement_sets_retracted,
         }
     except FiscalCalendarError as exc:
       return {"error": "calendar_error", "message": str(exc)}

--- a/robosystems/models/api/extensions/fiscal_calendar.py
+++ b/robosystems/models/api/extensions/fiscal_calendar.py
@@ -319,6 +319,36 @@ class ClosePeriodResponse(BaseModel):
       "close. Pairs with rule_summary."
     ),
   )
+  statements_stamped: bool = Field(
+    False,
+    description=(
+      "Whether the close stamped the period's canonical statement "
+      "FactSets (the close-time pivot). False when the tenant hasn't "
+      "set up reporting yet — see statement_stamp_note."
+    ),
+  )
+  statement_stamp_note: str | None = Field(
+    None,
+    description=(
+      "Soft-skip reason when statements_stamped is false: "
+      "no_coa_mapping | no_entity | no_statement_structures | no_taxonomy."
+    ),
+  )
+  stamped_statement_sets: dict[str, str] = Field(
+    default_factory=dict,
+    description=(
+      "structure_id -> fact_set_id for every canonical statement FactSet "
+      "minted by this close (report_id NULL; replaced on reclose)."
+    ),
+  )
+  statement_rule_summary: dict[str, int] | None = Field(
+    None,
+    description=(
+      "Aggregated statement-rule verification outcome across the stamped "
+      "structures — keys: pass/fail/error/skipped. None when no statement "
+      "rules exist. Distinct from rule_summary (the schedule-rule pass)."
+    ),
+  )
 
 
 # ── Draft review (read-only) ──────────────────────────────────────────────

--- a/robosystems/operations/information_block/envelope.py
+++ b/robosystems/operations/information_block/envelope.py
@@ -306,6 +306,13 @@ def load_latest_fact_set_for_structure(
   computed forecast month would win this period_end-descending read and
   hijack every default envelope. A non-None value pins that scenario
   exactly — statement + scenario binds the latest forecast month.
+
+  At equal ``period_end``, canonical sets (``report_id IS NULL`` — the
+  close-time stamp) beat publication snapshots: a Report published
+  later for the same month must not flip the default envelope off the
+  canonical record. Boolean-expression tiebreak, not a raw
+  ``report_id`` ordering — the latter would order publication sets by
+  id and invert the created_at preference among them.
   """
   row = session.execute(
     select(FactSet)
@@ -315,7 +322,11 @@ def load_latest_fact_set_for_structure(
       if scenario_id is None
       else FactSet.scenario_id == scenario_id,
     )
-    .order_by(FactSet.period_end.desc(), FactSet.created_at.desc())
+    .order_by(
+      FactSet.period_end.desc(),
+      FactSet.report_id.isnot(None).asc(),
+      FactSet.created_at.desc(),
+    )
     .limit(1)
   ).scalar()
   return fact_set_to_lite(row) if row is not None else None
@@ -336,10 +347,13 @@ def load_statement_fact_set_series(
   scenario's sets, and at an overlapping ``period_end`` the actual wins
   (the moving seam — a closed month's draft supersedes its forecast).
 
-  Two collisions collapse per ``period_end``, in order:
+  Three collisions collapse per ``period_end``, in order:
 
   1. ``scenario_id ASC NULLS FIRST`` — the actual beats the forecast.
-  2. ``period_start DESC NULLS LAST`` — the NARROWER window wins, so at
+  2. canonical before publication (``report_id IS NULL`` first) — the
+     close-time stamp is the series source; a Report published later
+     for the same month must not flip the column onto its snapshot.
+  3. ``period_start DESC NULLS LAST`` — the NARROWER window wins, so at
      the FY-end month the monthly set beats the annual report set
      created later (the FY-capture lesson applied at series level;
      ``created_at DESC`` alone would pick the annual).
@@ -360,6 +374,7 @@ def load_statement_fact_set_series(
       .order_by(
         FactSet.period_end.asc(),
         FactSet.scenario_id.asc().nulls_first(),
+        FactSet.report_id.isnot(None).asc(),
         FactSet.period_start.desc().nulls_last(),
         FactSet.created_at.desc(),
       )

--- a/robosystems/operations/roboledger/commands/fiscal_calendar.py
+++ b/robosystems/operations/roboledger/commands/fiscal_calendar.py
@@ -29,6 +29,7 @@ from robosystems.operations.roboledger.fiscal_calendar import (
   PeriodCloseService,
   add_months,
   current_month_period,
+  period_date_range,
 )
 from robosystems.operations.roboledger.reads.fiscal_calendar import (
   build_fiscal_calendar_response,
@@ -38,9 +39,17 @@ from robosystems.operations.roboledger.reads.fiscal_calendar import (
 
 @dataclass
 class ReopenPeriodResult:
-  """Return value for `reopen_period` — wraps the refreshed calendar."""
+  """Return value for `reopen_period` — wraps the refreshed calendar.
+
+  ``statement_sets_retracted`` counts the reopened month's canonical
+  statement FactSets deleted by the reopen (0 when the month was closed
+  before close-time stamping existed, or was soft-skipped). The REST
+  router keeps returning only ``fiscal_calendar`` (wire shape
+  unchanged); the MCP tool surfaces the count.
+  """
 
   fiscal_calendar: FiscalCalendarResponse
+  statement_sets_retracted: int = 0
 
 
 class PeriodNotFoundInLedgerError(LookupError):
@@ -191,6 +200,10 @@ def close_period(
     target_auto_advanced=result.target_auto_advanced,
     rule_summary=result.rule_summary,
     evaluated_structure_ids=list(result.evaluated_structure_ids),
+    statements_stamped=result.statements_stamped,
+    statement_stamp_note=result.statement_stamp_note,
+    stamped_statement_sets=dict(result.stamped_statement_sets),
+    statement_rule_summary=result.statement_rule_summary,
   )
 
 
@@ -204,8 +217,13 @@ def reopen_period(
   note: str | None,
   service: FiscalCalendarService,
   actor_type: str = "user",
-) -> FiscalCalendarResponse:
+) -> ReopenPeriodResult:
   """Reopen a closed fiscal period.
+
+  Retracts the month's canonical statement FactSets (close-time
+  stamping's inverse): a reopened month is no longer a closed assertion,
+  so its persisted statements — and their verification results — go
+  with it. The re-close restamps fresh sets.
 
   Raises `PeriodNotFoundInLedgerError` if the `FiscalPeriod` row
   doesn't exist, `PeriodNotClosedError` if it's not actually closed,
@@ -245,9 +263,23 @@ def reopen_period(
   )
 
   reinstate_reopened_schedule_scopes(session)
+
+  # Retract the reopened month's canonical statement sets. Function-level
+  # import — statement_sets pulls in information-block machinery this
+  # module otherwise never loads (same posture as the schedules import
+  # above).
+  from robosystems.operations.roboledger.reports.statement_sets import (
+    retract_canonical_statement_sets,
+  )
+
+  ps, pe = period_date_range(period)
+  retracted = retract_canonical_statement_sets(session, period_start=ps, period_end=pe)
   session.commit()
 
   has_sync, last_sync_at = qb_sync_state(platform_db, graph_id)
-  return build_fiscal_calendar_response(
-    session, graph_id, calendar, has_sync, last_sync_at, service
+  return ReopenPeriodResult(
+    fiscal_calendar=build_fiscal_calendar_response(
+      session, graph_id, calendar, has_sync, last_sync_at, service
+    ),
+    statement_sets_retracted=len(retracted),
   )

--- a/robosystems/operations/roboledger/commands/reports.py
+++ b/robosystems/operations/roboledger/commands/reports.py
@@ -27,10 +27,7 @@ from robosystems.models.api.extensions.reports import (
   ShareReportResponse,
   ShareResultItem,
 )
-from robosystems.models.api.fact_provenance import (
-  AssertedProvenance,
-  PivotProvenance,
-)
+from robosystems.models.api.fact_provenance import AssertedProvenance
 from robosystems.models.extensions import (
   Fact,
   PublishList,
@@ -41,12 +38,6 @@ from robosystems.models.extensions import (
 from robosystems.models.extensions.structure import TEXT_BLOCK_CAPS
 from robosystems.operations.aws.s3 import S3Client
 from robosystems.operations.information_block.envelope import DISCLOSURE_BLOCK_TYPE
-from robosystems.operations.information_block.rules.engine import (
-  evaluate_rules_for_structure,
-)
-from robosystems.operations.roboledger.commands._guards import (
-  rule_summary as _rule_summary,
-)
 from robosystems.operations.roboledger.fact_set import create_fact_set
 from robosystems.operations.roboledger.reads.reports import (
   build_periods,
@@ -55,15 +46,25 @@ from robosystems.operations.roboledger.reads.reports import (
   report_to_response,
   resolve_entity_name,
 )
-from robosystems.operations.roboledger.reports.calc_dag import (
-  load_rs_gaap_calculations,
-)
 from robosystems.operations.roboledger.reports.fact_grid import generate_report_facts
 from robosystems.operations.roboledger.reports.network_picker import (
-  NoNetworkForStatementTypeError,
-  get_render_network,
   load_close_target_concept,
   load_entity_reporting_style,
+)
+
+# The statement-set production core was extracted to ``statement_sets``
+# so the close path can mint canonical (report_id NULL) sets through the
+# same machinery. Names are re-imported here to keep this module's
+# surface stable — tests and the router import them from this module.
+from robosystems.operations.roboledger.reports.statement_sets import (  # noqa: F401
+  _TAXONOMY_SCOPE_CTE,
+  NoEntityError,
+  _build_structure_mapping,
+  _evaluate_report_structures,
+  _get_entity_id,
+  _persist_report_facts,
+  _pick_disclosure_structures,
+  _pre_create_report_fact_sets,
 )
 from robosystems.operations.serialization import (
   RdfFlavor,
@@ -71,7 +72,6 @@ from robosystems.operations.serialization import (
   build_report_bundle,
   serialize_to_rdf,
 )
-from robosystems.utils.ulid import generate_prefixed_ulid
 
 
 class ReportNotFoundError(LookupError):
@@ -94,10 +94,6 @@ class ReportNotPublishedError(Exception):
   """Raised when trying to share a report that isn't in 'published' state."""
 
 
-class NoEntityError(Exception):
-  """Raised when `create_report` can't find an Entity to tag facts to."""
-
-
 class TaxonomyNotFoundError(LookupError):
   """Raised when `create_report` references a missing taxonomy."""
 
@@ -109,275 +105,6 @@ class BundleUploadError(RuntimeError):
   ``published`` without a bundle artifact at ``Report.bundle_url``.
   Callers (router layer) translate this to HTTP 502.
   """
-
-
-def _get_entity_id(session: Session, graph_id: str) -> str:
-  """Get the earliest-created entity ID — the primary entity for single-entity graphs."""
-  result = session.execute(
-    text("SELECT id FROM entities ORDER BY created_at ASC LIMIT 1")
-  )
-  row = result.fetchone()
-  if row is None:
-    raise NoEntityError("No entity found. Import data before creating reports.")
-  return row.id
-
-
-def _evaluate_report_structures(
-  session: Session,
-  facts,
-  element_to_structures: dict[str, list[str]],
-  structure_to_factset: dict[str, str],
-  period_start,
-  period_end,
-  created_by: str,
-) -> dict[str, int] | None:
-  """Run rule evaluation for every structure that received report facts.
-
-  Returns an aggregated rule_summary across all structures, or None if
-  no structures have rules.
-  """
-  structures_with_facts: set[str] = set()
-  for f in facts.facts:
-    for sid in element_to_structures.get(f.element_id, ()):
-      structures_with_facts.add(sid)
-  # The rs-gaap-calculations DAG is invariant across structures within this
-  # report run — load it once and share it (each structure still gets its own
-  # local-arc overlay from a copy) rather than re-querying per structure.
-  global_calculations = load_rs_gaap_calculations(session)
-  all_results = []
-  for structure_id in structures_with_facts:
-    results = evaluate_rules_for_structure(
-      session,
-      structure_id,
-      fact_set_id=structure_to_factset[structure_id],
-      period_start=period_start,
-      period_end=period_end,
-      created_by=created_by,
-      global_calculations=global_calculations,
-    )
-    all_results.extend(results)
-  return _rule_summary(all_results)
-
-
-_RENDER_TARGET_STATEMENT_TYPES: tuple[str, ...] = (
-  "balance_sheet",
-  "income_statement",
-  "cash_flow_statement",
-  "equity_statement",
-)
-
-
-# Downward-recursive taxonomy closure: the report's taxonomy plus every
-# extension descending from it (extension taxonomies point at their parent
-# via ``parent_taxonomy_id``). Scopes disclosure picking so one report
-# never pulls in another framework's (or an abandoned extension's) notes.
-_TAXONOMY_SCOPE_CTE = """
-      WITH RECURSIVE scoped AS (
-        SELECT id FROM taxonomies WHERE id = :taxonomy_id
-        UNION ALL
-        SELECT t.id FROM taxonomies t JOIN scoped sc
-          ON t.parent_taxonomy_id = sc.id
-      )
-"""
-
-
-def _pick_disclosure_structures(
-  session: Session,
-  fact_element_ids: set[str],
-  taxonomy_id: str,
-) -> list[str]:
-  """Disclosure structures whose MEMBER concepts actually received facts.
-
-  Disclosures are not composed by the Reporting Style — styles pin
-  statement layouts only. A disclosure renders because the mapped
-  ledger produced values for its concepts (the forward/Reportability
-  direction): pick every active ``regulatory_disclosure`` structure
-  owning at least one presentation arc whose MEMBER (``to``) endpoint
-  is among the generated facts' elements. The member-only condition is
-  deliberate: a note's total is typically a common library leaf that
-  almost always has a fact, so an endpoint-OR would pick the note with
-  an empty (structurally unfailable) member breakdown.
-
-  Scoped to the report's taxonomy closure (the resolved taxonomy plus
-  its descendant extensions) so a foreign framework's notes — or an
-  abandoned extension taxonomy's — never join this report's render set.
-
-  The library's disclosure-identity envelopes (``disclosures:*`` rows
-  with no arcs) never match the presentation-arc requirement, and a
-  tenant with no arc-bearing disclosure structures gets an empty list —
-  the picker is inert until a disclosure structure with content exists.
-  """
-  if not fact_element_ids:
-    return []
-  rows = session.execute(
-    text(
-      _TAXONOMY_SCOPE_CTE
-      + """
-      SELECT DISTINCT a.structure_id AS structure_id
-      FROM associations a
-      JOIN structures s ON s.id = a.structure_id
-      WHERE s.block_type = :disclosure_block_type
-        AND s.is_active IS TRUE
-        AND s.taxonomy_id IN (SELECT id FROM scoped)
-        AND a.association_type = 'presentation'
-        AND a.to_element_id = ANY(:element_ids)
-      """
-    ),
-    {
-      "disclosure_block_type": DISCLOSURE_BLOCK_TYPE,
-      "element_ids": list(fact_element_ids),
-      "taxonomy_id": taxonomy_id,
-    },
-  ).fetchall()
-  return [row.structure_id for row in rows]
-
-
-def _build_structure_mapping(
-  session: Session,
-  reporting_style_id: str,
-  fact_element_ids: set[str] | None = None,
-  taxonomy_id: str | None = None,
-) -> tuple[dict[str, list[str]], dict[str, str]]:
-  """Return (element_id→[structure_ids], structure_id→fact_set_id) for the
-  Reporting Style composed for this graph, plus fact-picked disclosures.
-
-  Walks ``reporting_style_networks`` to pick one Network per statement
-  type, then enumerates each Network's association rows to map elements →
-  structure ids. An element can appear in multiple structures (e.g.
-  ``NetIncomeLoss`` is the bottom line of the Income Statement AND the
-  first calc-child of the Cash Flow Operating rollup), and the fact must
-  be stamped onto every owning structure's FactSet so each block's
-  renderer can resolve its calc rollups locally. Pre-generates a
-  fact_set_id ULID per picked structure.
-
-  ``fact_element_ids`` (the elements the just-generated report facts
-  touch) drives the disclosure half: disclosure structures are NOT
-  style-composed — they join the render set when their concepts
-  received facts (:func:`_pick_disclosure_structures`).
-
-  Networks for statement types the Style doesn't compose are skipped
-  silently — a Style is free to omit, say, the comprehensive_income
-  Network. Statement types the renderer asks for that the Style
-  *does* try to render but lacks a composition row for surface as
-  ``NoNetworkForStatementTypeError`` at picker time (the caller wraps
-  the loop and decides whether to fail closed).
-  """
-  element_to_structures: dict[str, list[str]] = {}
-  structure_to_factset: dict[str, str] = {}
-  picked_structure_ids: list[str] = []
-
-  for statement_type in _RENDER_TARGET_STATEMENT_TYPES:
-    try:
-      network = get_render_network(session, reporting_style_id, statement_type)
-    except NoNetworkForStatementTypeError:
-      # Style doesn't compose this statement type — skip silently so a
-      # Style that ships without (say) an equity Network still renders.
-      # Safety net: the ``change-reporting-style`` command validates that
-      # every required statement_type has a composition row before setting
-      # ``entities.reporting_style_id``, so by the time this loop runs the
-      # only `NoNetworkForStatementTypeError` we should see is for
-      # genuinely optional types (e.g. a Style that deliberately omits
-      # ``comprehensive_income``).
-      continue
-    picked_structure_ids.append(network.structure_id)
-
-  if taxonomy_id is not None:
-    for disclosure_id in _pick_disclosure_structures(
-      session, fact_element_ids or set(), taxonomy_id
-    ):
-      if disclosure_id not in picked_structure_ids:
-        picked_structure_ids.append(disclosure_id)
-
-  if not picked_structure_ids:
-    return {}, {}
-
-  # Map BOTH endpoints of every arc to the structure, not just
-  # ``to_element_id``. A subtotal that sits at the top of its tree
-  # (e.g. ``rs-gaap:Assets``, ``rs-gaap:LiabilitiesAndStockholdersEquity``)
-  # appears only as a ``from_element_id`` (parent), so a to-only mapping
-  # never stamps its persisted subtotal fact into the structure's FactSet
-  # — and the balance-identity rule scoped to it can't bind. Abstract
-  # parents carry no facts, so including ``from_element_id`` is harmless
-  # for them and load-bearing for top-level subtotals.
-  rows = session.execute(
-    text(
-      """
-      SELECT DISTINCT a.structure_id AS structure_id, a.to_element_id AS element_id
-      FROM associations a
-      WHERE a.structure_id = ANY(:struct_ids) AND a.to_element_id IS NOT NULL
-      UNION
-      SELECT DISTINCT a.structure_id AS structure_id, a.from_element_id AS element_id
-      FROM associations a
-      WHERE a.structure_id = ANY(:struct_ids) AND a.from_element_id IS NOT NULL
-      """
-    ),
-    {"struct_ids": picked_structure_ids},
-  ).fetchall()
-
-  for row in rows:
-    element_to_structures.setdefault(row.element_id, []).append(row.structure_id)
-  structure_to_factset = {
-    sid: generate_prefixed_ulid("fs") for sid in picked_structure_ids
-  }
-  return element_to_structures, structure_to_factset
-
-
-def _persist_report_facts(
-  session: Session,
-  report_id: str,
-  facts,
-  entity_id: str,
-  element_to_structures: dict[str, list[str]],
-  structure_to_factset: dict[str, str],
-) -> None:
-  """Clear any existing facts for this report and persist the new set.
-
-  Every persisted Fact is stamped with ``structure_id`` and
-  ``fact_set_id`` — the FactSet is the sole parent pointer. Facts whose
-  element isn't reached by any Network in the picked Reporting Style are
-  skipped: there's no Network to render them through, so they can't be
-  stamped with a structure_id, and the fact_set_id NOT NULL constraint
-  would reject them.
-
-  An element that appears in N structures (e.g. ``NetIncomeLoss`` =
-  bottom-line of the IS AND first calc-child of CF Operating) gets one
-  Fact row per owning structure, each pinned to that structure's
-  FactSet. This is what lets the CF block's calc walker resolve
-  NetIncome locally without cross-structure fact lookup.
-  """
-  session.execute(
-    text(
-      "DELETE FROM facts WHERE fact_set_id IN "
-      "(SELECT id FROM fact_sets WHERE report_id = :report_id)"
-    ),
-    {"report_id": report_id},
-  )
-  for fact in facts.facts:
-    for structure_id in element_to_structures.get(fact.element_id, ()):
-      fact_set_id = structure_to_factset.get(structure_id)
-      if fact_set_id is None:
-        continue
-      rf = Fact(
-        element_id=fact.element_id,
-        value=fact.value,
-        period_start=fact.period_start,
-        period_end=fact.period_end,
-        period_type=fact.period_type,
-        unit="USD",
-        entity_id=entity_id,
-        structure_id=structure_id,
-        fact_set_id=fact_set_id,
-      )
-      session.add(rf)
-
-  # Flush so every fact is visible to the rule-evaluation binds that
-  # follow. The session runs ``autoflush=False``, and
-  # ``_evaluate_report_structures`` iterates structures in
-  # non-deterministic set order; without an explicit flush here the
-  # FIRST structure evaluated would bind against unflushed facts and
-  # spuriously ``skip`` every rule (the terminal flush inside the first
-  # ``evaluate_rules_for_structure`` would only rescue the later ones).
-  session.flush()
 
 
 def _snapshot_text_block_facts(
@@ -485,63 +212,6 @@ def _snapshot_text_block_facts(
       )
   session.flush()
   return len(rows)
-
-
-def _pre_create_report_fact_sets(
-  session: Session,
-  report_id: str,
-  entity_id: str,
-  created_by: str,
-  periods,
-  structure_to_factset: dict[str, str],
-  mapping_id: str,
-) -> None:
-  """Insert one FactSet row per picked Network — before facts are stamped.
-
-  ``create_report`` creates the ``fact_sets`` row first, then stamps
-  facts referencing its id. The period envelope comes from the report's
-  ``periods`` (min start, max end) rather than being derived post-hoc
-  from filtered facts. That keeps the dataflow forward and lets the FK
-  ``facts.fact_set_id`` → ``fact_sets.id`` hold without orphan risk.
-
-  Every picked Network gets a FactSet row, even one whose Network the
-  CoA hasn't reached yet (e.g., the demo's CF Network with no
-  cash-flow CoA mappings). The envelope read
-  (``ORDER BY period_end DESC LIMIT 1``) still resolves cleanly per
-  structure; consumers can detect "no facts in this period" by the
-  zero fact_count on the resulting envelope.
-  """
-  if not periods:
-    return
-
-  starts = [p.start for p in periods if getattr(p, "start", None) is not None]
-  envelope_start = min(starts) if starts else None
-  envelope_end = max(p.end for p in periods)
-
-  # Report facts are pivoted from the posted ledger via the CoA→framework
-  # mapping; one provenance descriptor per Network's FactSet. Duration
-  # envelopes use ``start/end``; an instant-only envelope (no start) carries
-  # the single end date rather than a leading-slash ``/end``.
-  period_key = (
-    f"{envelope_start}/{envelope_end}" if envelope_start else str(envelope_end)
-  )
-  for structure_id, fact_set_id in structure_to_factset.items():
-    create_fact_set(
-      session,
-      id=fact_set_id,
-      structure_id=structure_id,
-      period_start=envelope_start,
-      period_end=envelope_end,
-      factset_type="report",
-      entity_id=entity_id,
-      report_id=report_id,
-      created_by=created_by,
-      provenance=PivotProvenance(mapping_id=mapping_id, period=period_key),
-    )
-  # Explicit flush so the new fact_sets rows hit the DB before the fact
-  # INSERTs that reference them. SQLAlchemy's session-flush ordering is
-  # by INSERT statement type, not by FK dependency.
-  session.flush()
 
 
 def _record_bundle_validation(bundle: StatementBundle, report_def: Report) -> None:

--- a/robosystems/operations/roboledger/fiscal_calendar/close_service.py
+++ b/robosystems/operations/roboledger/fiscal_calendar/close_service.py
@@ -12,7 +12,9 @@ the domain exceptions defined here into their respective error formats.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from dataclasses import field as dataclass_field
 from datetime import UTC, datetime
+from typing import TYPE_CHECKING
 
 from sqlalchemy import text
 from sqlalchemy.orm import Session
@@ -27,6 +29,13 @@ from .service import (
   CloseableGateResult,
   FiscalCalendarService,
 )
+
+if TYPE_CHECKING:
+  from collections.abc import Callable
+
+  from robosystems.operations.roboledger.reports.statement_sets import (
+    StatementStampResult,
+  )
 
 # ────────────────────────────────────────────────────────────────────────────
 # Errors
@@ -119,6 +128,15 @@ class PeriodCloseResult:
   # ids of schedule Structures whose rules were evaluated. Empty when no
   # schedule structures had facts in the closed period.
   evaluated_structure_ids: tuple[str, ...] = ()
+  # Canonical statement stamping (close-time pivot). False + note when
+  # the tenant hasn't set up reporting (soft-skip); True with the minted
+  # structure_id -> fact_set_id map otherwise. A stamp failure on a
+  # reporting-configured tenant raises StatementStampError instead —
+  # the close rolls back rather than holing the statement series.
+  statements_stamped: bool = False
+  statement_stamp_note: str | None = None
+  stamped_statement_sets: dict[str, str] = dataclass_field(default_factory=dict)
+  statement_rule_summary: dict[str, int] | None = None
 
 
 # ────────────────────────────────────────────────────────────────────────────
@@ -142,13 +160,29 @@ class PeriodCloseService:
      `closed_by=actor_id`.
   5. **Calendar advance or reclose** — advance_closed_through if this is
      a first-close or latest-reopen reclose, otherwise record_reclose.
+  5b. **Canonical statement stamping** — pivot the posted ledger and
+     stamp the period's statement FactSets (`report_id NULL`), replacing
+     any prior canonical sets for the window (reclose/retry idempotency).
+     Soft-skips when the tenant hasn't set up reporting; raises
+     `StatementStampError` (rolling back the close) when reporting is
+     configured but the pivot fails. Runs after the draft→posted
+     transition because the pivot reads posted entries only.
 
   Callers commit the session. All failures raise domain exceptions that
   the REST / MCP caller translates into its native error format.
+
+  ``statement_stamper`` is injectable for tests; the default resolves
+  :func:`stamp_canonical_statement_sets` lazily so this module stays
+  free of information-block imports at module load.
   """
 
-  def __init__(self, fcs: FiscalCalendarService | None = None):
+  def __init__(
+    self,
+    fcs: FiscalCalendarService | None = None,
+    statement_stamper: Callable[..., StatementStampResult] | None = None,
+  ):
     self._fcs = fcs or FiscalCalendarService()
+    self._statement_stamper = statement_stamper
 
   def close(
     self,
@@ -268,6 +302,20 @@ class PeriodCloseService:
       and calendar.close_target_period is not None
     )
 
+    # 5b. Canonical statement stamping — the close IS the act that
+    # persists the month's statements. Replace semantics inside the
+    # stamper make this idempotent for first-close, reclose, and
+    # retry-after-failure; StatementStampError propagates so the whole
+    # close (including the transitions above) rolls back rather than
+    # leaving a closed month with no canonical sets.
+    stamp = self._stamp_statement_sets(
+      session,
+      graph_id=graph_id,
+      period_start=period_start,
+      period_end=period_end,
+      actor_id=actor_id,
+    )
+
     # 6. Auto-run rules on schedules with facts in the closing period.
     # Rule failures are isolated from the close result: the close succeeds
     # even if a rule errors, and the failure surfaces only in rule_summary
@@ -286,6 +334,8 @@ class PeriodCloseService:
       f"Period {period} closed for graph {graph_id}: "
       f"entries_posted={entries_posted} reclose={is_reclose} "
       f"target_auto_advanced={target_auto_advanced} "
+      f"statements_stamped={stamp.stamped} "
+      f"stamp_note={stamp.note} "
       f"rule_summary={rule_summary}"
     )
 
@@ -297,9 +347,44 @@ class PeriodCloseService:
       was_reclose=is_reclose,
       rule_summary=rule_summary,
       evaluated_structure_ids=evaluated_ids,
+      statements_stamped=stamp.stamped,
+      statement_stamp_note=stamp.note,
+      stamped_statement_sets=stamp.fact_set_ids,
+      statement_rule_summary=stamp.rule_summary,
     )
 
   # ── Private helpers ────────────────────────────────────────────────────
+
+  def _stamp_statement_sets(
+    self,
+    session: Session,
+    *,
+    graph_id: str,
+    period_start,
+    period_end,
+    actor_id: str,
+  ) -> StatementStampResult:
+    """Run the canonical statement stamper (injected or lazily resolved).
+
+    Lazy import mirrors `_evaluate_schedule_rules_in_period` — the close
+    service stays free of information-block/report dependencies at module
+    import time, and mocked-session tests inject a stub stamper instead
+    of exercising the pivot.
+    """
+    stamper = self._statement_stamper
+    if stamper is None:
+      from robosystems.operations.roboledger.reports.statement_sets import (
+        stamp_canonical_statement_sets,
+      )
+
+      stamper = stamp_canonical_statement_sets
+    return stamper(
+      session,
+      graph_id=graph_id,
+      period_start=period_start,
+      period_end=period_end,
+      actor_id=actor_id,
+    )
 
   def _publish_drafts_to_qb(
     self,

--- a/robosystems/operations/roboledger/reports/statement_sets.py
+++ b/robosystems/operations/roboledger/reports/statement_sets.py
@@ -1,0 +1,628 @@
+"""Canonical statement FactSet production — shared by close and publication.
+
+Statement FactSets (``factset_type='report'``) have two producers with
+different ownership semantics:
+
+- **Close (canonical).** Closing a fiscal period pivots the posted ledger
+  through the active CoA mapping and stamps the month's statement sets
+  with ``report_id NULL`` — the canonical, replaceable record of the
+  closed month. Reclose replaces them (:func:`stamp_canonical_statement_sets`
+  deletes-then-mints by period window); reopen retracts them
+  (:func:`retract_canonical_statement_sets`). The statement-envelope,
+  series, forecast, and metric readers bind these by
+  ``(structure_id, factset_type, period)`` and never touch ``report_id``.
+- **Publication (snapshot).** ``create_report`` mints its own
+  ``report_id``-owned sets, frozen at filing time: a published Report keeps
+  the numbers as generated even if the ledger is later reopened and
+  restamped. ``delete_report`` / ``regenerate_report`` delete only by
+  ``report_id`` and can never destroy canonical closed-month history.
+
+The pivot/persist helpers here were extracted from ``commands/reports.py``
+so both producers share one implementation; ``commands/reports.py``
+re-imports them, keeping its public surface unchanged.
+
+Import-cycle rule: this module must not import from
+``operations/roboledger/commands/*`` other than the leaf ``_guards``
+module (which imports nothing back). The close service and the fiscal
+calendar commands import THIS module function-level, preserving their
+lazy-import posture toward information-block machinery.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from sqlalchemy import delete, text
+
+from robosystems.logger import logger
+from robosystems.models.api.fact_provenance import PivotProvenance
+from robosystems.models.extensions import Fact, VerificationResult
+from robosystems.models.extensions.roboledger import Structure
+from robosystems.operations.information_block.envelope import DISCLOSURE_BLOCK_TYPE
+from robosystems.operations.information_block.rules.engine import (
+  evaluate_rules_for_structure,
+)
+from robosystems.operations.roboledger.commands._guards import (
+  rule_summary as _rule_summary,
+)
+from robosystems.operations.roboledger.fact_set import create_fact_set
+from robosystems.operations.roboledger.reports.calc_dag import (
+  load_rs_gaap_calculations,
+)
+from robosystems.operations.roboledger.reports.fact_grid import (
+  PeriodSpec,
+  generate_report_facts,
+)
+from robosystems.operations.roboledger.reports.network_picker import (
+  NoNetworkForStatementTypeError,
+  get_render_network,
+  load_close_target_concept,
+  load_entity_reporting_style,
+)
+from robosystems.utils.ulid import generate_prefixed_ulid
+
+if TYPE_CHECKING:
+  from datetime import date
+
+  from sqlalchemy.orm import Session
+
+
+class NoEntityError(Exception):
+  """Raised when the report path can't find an Entity to tag facts to."""
+
+
+class StatementStampError(Exception):
+  """Raised when a reporting-configured tenant's close-time stamp fails.
+
+  Distinct from the soft-skip path (tenant hasn't set up reporting —
+  close proceeds without sets): this means the mapping/style resolved
+  but the pivot or persist raised, so the close must roll back and the
+  operator can fix the cause and re-run the close.
+  """
+
+
+@dataclass
+class StatementStampResult:
+  """Outcome of :func:`stamp_canonical_statement_sets`."""
+
+  stamped: bool
+  # Soft-skip reason when ``stamped`` is False:
+  # 'no_coa_mapping' | 'no_entity' | 'no_statement_structures' | 'no_taxonomy'
+  note: str | None = None
+  # structure_id -> fact_set_id for every minted canonical set.
+  fact_set_ids: dict[str, str] = field(default_factory=dict)
+  # Aggregated statement-rule outcome across the stamped structures
+  # (pass/fail/error/skipped); None when no statement rules exist or
+  # the evaluation itself errored (non-fatal, logged).
+  rule_summary: dict[str, int] | None = None
+
+
+def _get_entity_id(session: Session, graph_id: str) -> str:
+  """Get the earliest-created entity ID — the primary entity for single-entity graphs."""
+  result = session.execute(
+    text("SELECT id FROM entities ORDER BY created_at ASC LIMIT 1")
+  )
+  row = result.fetchone()
+  if row is None:
+    raise NoEntityError("No entity found. Import data before creating reports.")
+  return row.id
+
+
+def _evaluate_report_structures(
+  session: Session,
+  facts,
+  element_to_structures: dict[str, list[str]],
+  structure_to_factset: dict[str, str],
+  period_start,
+  period_end,
+  created_by: str,
+) -> dict[str, int] | None:
+  """Run rule evaluation for every structure that received report facts.
+
+  Returns an aggregated rule_summary across all structures, or None if
+  no structures have rules.
+  """
+  structures_with_facts: set[str] = set()
+  for f in facts.facts:
+    for sid in element_to_structures.get(f.element_id, ()):
+      structures_with_facts.add(sid)
+  # The rs-gaap-calculations DAG is invariant across structures within this
+  # report run — load it once and share it (each structure still gets its own
+  # local-arc overlay from a copy) rather than re-querying per structure.
+  global_calculations = load_rs_gaap_calculations(session)
+  all_results = []
+  for structure_id in structures_with_facts:
+    results = evaluate_rules_for_structure(
+      session,
+      structure_id,
+      fact_set_id=structure_to_factset[structure_id],
+      period_start=period_start,
+      period_end=period_end,
+      created_by=created_by,
+      global_calculations=global_calculations,
+    )
+    all_results.extend(results)
+  return _rule_summary(all_results)
+
+
+_RENDER_TARGET_STATEMENT_TYPES: tuple[str, ...] = (
+  "balance_sheet",
+  "income_statement",
+  "cash_flow_statement",
+  "equity_statement",
+)
+
+
+# Downward-recursive taxonomy closure: the report's taxonomy plus every
+# extension descending from it (extension taxonomies point at their parent
+# via ``parent_taxonomy_id``). Scopes disclosure picking so one report
+# never pulls in another framework's (or an abandoned extension's) notes.
+_TAXONOMY_SCOPE_CTE = """
+      WITH RECURSIVE scoped AS (
+        SELECT id FROM taxonomies WHERE id = :taxonomy_id
+        UNION ALL
+        SELECT t.id FROM taxonomies t JOIN scoped sc
+          ON t.parent_taxonomy_id = sc.id
+      )
+"""
+
+
+def _pick_disclosure_structures(
+  session: Session,
+  fact_element_ids: set[str],
+  taxonomy_id: str,
+) -> list[str]:
+  """Disclosure structures whose MEMBER concepts actually received facts.
+
+  Disclosures are not composed by the Reporting Style — styles pin
+  statement layouts only. A disclosure renders because the mapped
+  ledger produced values for its concepts (the forward/Reportability
+  direction): pick every active ``regulatory_disclosure`` structure
+  owning at least one presentation arc whose MEMBER (``to``) endpoint
+  is among the generated facts' elements. The member-only condition is
+  deliberate: a note's total is typically a common library leaf that
+  almost always has a fact, so an endpoint-OR would pick the note with
+  an empty (structurally unfailable) member breakdown.
+
+  Scoped to the report's taxonomy closure (the resolved taxonomy plus
+  its descendant extensions) so a foreign framework's notes — or an
+  abandoned extension taxonomy's — never join this report's render set.
+
+  The library's disclosure-identity envelopes (``disclosures:*`` rows
+  with no arcs) never match the presentation-arc requirement, and a
+  tenant with no arc-bearing disclosure structures gets an empty list —
+  the picker is inert until a disclosure structure with content exists.
+  """
+  if not fact_element_ids:
+    return []
+  rows = session.execute(
+    text(
+      _TAXONOMY_SCOPE_CTE
+      + """
+      SELECT DISTINCT a.structure_id AS structure_id
+      FROM associations a
+      JOIN structures s ON s.id = a.structure_id
+      WHERE s.block_type = :disclosure_block_type
+        AND s.is_active IS TRUE
+        AND s.taxonomy_id IN (SELECT id FROM scoped)
+        AND a.association_type = 'presentation'
+        AND a.to_element_id = ANY(:element_ids)
+      """
+    ),
+    {
+      "disclosure_block_type": DISCLOSURE_BLOCK_TYPE,
+      "element_ids": list(fact_element_ids),
+      "taxonomy_id": taxonomy_id,
+    },
+  ).fetchall()
+  return [row.structure_id for row in rows]
+
+
+def _build_structure_mapping(
+  session: Session,
+  reporting_style_id: str,
+  fact_element_ids: set[str] | None = None,
+  taxonomy_id: str | None = None,
+) -> tuple[dict[str, list[str]], dict[str, str]]:
+  """Return (element_id→[structure_ids], structure_id→fact_set_id) for the
+  Reporting Style composed for this graph, plus fact-picked disclosures.
+
+  Walks ``reporting_style_networks`` to pick one Network per statement
+  type, then enumerates each Network's association rows to map elements →
+  structure ids. An element can appear in multiple structures (e.g.
+  ``NetIncomeLoss`` is the bottom line of the Income Statement AND the
+  first calc-child of the Cash Flow Operating rollup), and the fact must
+  be stamped onto every owning structure's FactSet so each block's
+  renderer can resolve its calc rollups locally. Pre-generates a
+  fact_set_id ULID per picked structure.
+
+  ``fact_element_ids`` (the elements the just-generated report facts
+  touch) drives the disclosure half: disclosure structures are NOT
+  style-composed — they join the render set when their concepts
+  received facts (:func:`_pick_disclosure_structures`).
+
+  Networks for statement types the Style doesn't compose are skipped
+  silently — a Style is free to omit, say, the comprehensive_income
+  Network. Statement types the renderer asks for that the Style
+  *does* try to render but lacks a composition row for surface as
+  ``NoNetworkForStatementTypeError`` at picker time (the caller wraps
+  the loop and decides whether to fail closed).
+  """
+  element_to_structures: dict[str, list[str]] = {}
+  structure_to_factset: dict[str, str] = {}
+  picked_structure_ids: list[str] = []
+
+  for statement_type in _RENDER_TARGET_STATEMENT_TYPES:
+    try:
+      network = get_render_network(session, reporting_style_id, statement_type)
+    except NoNetworkForStatementTypeError:
+      # Style doesn't compose this statement type — skip silently so a
+      # Style that ships without (say) an equity Network still renders.
+      # Safety net: the ``change-reporting-style`` command validates that
+      # every required statement_type has a composition row before setting
+      # ``entities.reporting_style_id``, so by the time this loop runs the
+      # only `NoNetworkForStatementTypeError` we should see is for
+      # genuinely optional types (e.g. a Style that deliberately omits
+      # ``comprehensive_income``).
+      continue
+    picked_structure_ids.append(network.structure_id)
+
+  if taxonomy_id is not None:
+    for disclosure_id in _pick_disclosure_structures(
+      session, fact_element_ids or set(), taxonomy_id
+    ):
+      if disclosure_id not in picked_structure_ids:
+        picked_structure_ids.append(disclosure_id)
+
+  if not picked_structure_ids:
+    return {}, {}
+
+  # Map BOTH endpoints of every arc to the structure, not just
+  # ``to_element_id``. A subtotal that sits at the top of its tree
+  # (e.g. ``rs-gaap:Assets``, ``rs-gaap:LiabilitiesAndStockholdersEquity``)
+  # appears only as a ``from_element_id`` (parent), so a to-only mapping
+  # never stamps its persisted subtotal fact into the structure's FactSet
+  # — and the balance-identity rule scoped to it can't bind. Abstract
+  # parents carry no facts, so including ``from_element_id`` is harmless
+  # for them and load-bearing for top-level subtotals.
+  rows = session.execute(
+    text(
+      """
+      SELECT DISTINCT a.structure_id AS structure_id, a.to_element_id AS element_id
+      FROM associations a
+      WHERE a.structure_id = ANY(:struct_ids) AND a.to_element_id IS NOT NULL
+      UNION
+      SELECT DISTINCT a.structure_id AS structure_id, a.from_element_id AS element_id
+      FROM associations a
+      WHERE a.structure_id = ANY(:struct_ids) AND a.from_element_id IS NOT NULL
+      """
+    ),
+    {"struct_ids": picked_structure_ids},
+  ).fetchall()
+
+  for row in rows:
+    element_to_structures.setdefault(row.element_id, []).append(row.structure_id)
+  structure_to_factset = {
+    sid: generate_prefixed_ulid("fs") for sid in picked_structure_ids
+  }
+  return element_to_structures, structure_to_factset
+
+
+def _pre_create_report_fact_sets(
+  session: Session,
+  report_id: str | None,
+  entity_id: str,
+  created_by: str,
+  periods,
+  structure_to_factset: dict[str, str],
+  mapping_id: str,
+) -> None:
+  """Insert one FactSet row per picked Network — before facts are stamped.
+
+  ``create_report`` creates the ``fact_sets`` row first, then stamps
+  facts referencing its id. The period envelope comes from the report's
+  ``periods`` (min start, max end) rather than being derived post-hoc
+  from filtered facts. That keeps the dataflow forward and lets the FK
+  ``facts.fact_set_id`` → ``fact_sets.id`` hold without orphan risk.
+
+  ``report_id=None`` mints CANONICAL sets — the close-time record owned
+  only by ``(structure_id, period)``; a non-None id mints a Report's
+  publication snapshot.
+
+  Every picked Network gets a FactSet row, even one whose Network the
+  CoA hasn't reached yet (e.g., the demo's CF Network with no
+  cash-flow CoA mappings). The envelope read
+  (``ORDER BY period_end DESC LIMIT 1``) still resolves cleanly per
+  structure; consumers can detect "no facts in this period" by the
+  zero fact_count on the resulting envelope.
+  """
+  if not periods:
+    return
+
+  starts = [p.start for p in periods if getattr(p, "start", None) is not None]
+  envelope_start = min(starts) if starts else None
+  envelope_end = max(p.end for p in periods)
+
+  # Report facts are pivoted from the posted ledger via the CoA→framework
+  # mapping; one provenance descriptor per Network's FactSet. Duration
+  # envelopes use ``start/end``; an instant-only envelope (no start) carries
+  # the single end date rather than a leading-slash ``/end``.
+  period_key = (
+    f"{envelope_start}/{envelope_end}" if envelope_start else str(envelope_end)
+  )
+  for structure_id, fact_set_id in structure_to_factset.items():
+    create_fact_set(
+      session,
+      id=fact_set_id,
+      structure_id=structure_id,
+      period_start=envelope_start,
+      period_end=envelope_end,
+      factset_type="report",
+      entity_id=entity_id,
+      report_id=report_id,
+      created_by=created_by,
+      provenance=PivotProvenance(mapping_id=mapping_id, period=period_key),
+    )
+  # Explicit flush so the new fact_sets rows hit the DB before the fact
+  # INSERTs that reference them. SQLAlchemy's session-flush ordering is
+  # by INSERT statement type, not by FK dependency.
+  session.flush()
+
+
+def _stamp_facts_into_sets(
+  session: Session,
+  facts,
+  entity_id: str,
+  element_to_structures: dict[str, list[str]],
+  structure_to_factset: dict[str, str],
+) -> None:
+  """Persist generated report facts into their pre-created FactSets.
+
+  Every persisted Fact is stamped with ``structure_id`` and
+  ``fact_set_id`` — the FactSet is the sole parent pointer. Facts whose
+  element isn't reached by any Network in the picked Reporting Style are
+  skipped: there's no Network to render them through, so they can't be
+  stamped with a structure_id, and the fact_set_id NOT NULL constraint
+  would reject them.
+
+  An element that appears in N structures (e.g. ``NetIncomeLoss`` =
+  bottom-line of the IS AND first calc-child of CF Operating) gets one
+  Fact row per owning structure, each pinned to that structure's
+  FactSet. This is what lets the CF block's calc walker resolve
+  NetIncome locally without cross-structure fact lookup.
+  """
+  for fact in facts.facts:
+    for structure_id in element_to_structures.get(fact.element_id, ()):
+      fact_set_id = structure_to_factset.get(structure_id)
+      if fact_set_id is None:
+        continue
+      rf = Fact(
+        element_id=fact.element_id,
+        value=fact.value,
+        period_start=fact.period_start,
+        period_end=fact.period_end,
+        period_type=fact.period_type,
+        unit="USD",
+        entity_id=entity_id,
+        structure_id=structure_id,
+        fact_set_id=fact_set_id,
+      )
+      session.add(rf)
+
+  # Flush so every fact is visible to the rule-evaluation binds that
+  # follow. The session runs ``autoflush=False``, and
+  # ``_evaluate_report_structures`` iterates structures in
+  # non-deterministic set order; without an explicit flush here the
+  # FIRST structure evaluated would bind against unflushed facts and
+  # spuriously ``skip`` every rule (the terminal flush inside the first
+  # ``evaluate_rules_for_structure`` would only rescue the later ones).
+  session.flush()
+
+
+def _persist_report_facts(
+  session: Session,
+  report_id: str,
+  facts,
+  entity_id: str,
+  element_to_structures: dict[str, list[str]],
+  structure_to_factset: dict[str, str],
+) -> None:
+  """Clear any existing facts for this report and persist the new set.
+
+  The publication path: DELETE by ``report_id`` (regeneration clears
+  prior snapshots; canonical ``report_id NULL`` sets are untouchable
+  through this path by construction), then stamp via
+  :func:`_stamp_facts_into_sets`.
+  """
+  session.execute(
+    text(
+      "DELETE FROM facts WHERE fact_set_id IN "
+      "(SELECT id FROM fact_sets WHERE report_id = :report_id)"
+    ),
+    {"report_id": report_id},
+  )
+  _stamp_facts_into_sets(
+    session, facts, entity_id, element_to_structures, structure_to_factset
+  )
+
+
+def _canonical_set_ids_in_window(
+  session: Session, period_start: date, period_end: date
+) -> list[str]:
+  """Canonical statement set ids for exactly this period window.
+
+  Window-scoped on purpose (not per-structure): a reclose after a
+  reporting-style change must retire the OLD style's sets too, and
+  reopen retraction can't know which structures a past close picked.
+  The predicates exclude every other producer: publication snapshots
+  (``report_id NOT NULL``), scenario months (``scenario_id NOT NULL``),
+  and non-'report' factset types (schedule/metric/disclosure/custom).
+  """
+  return list(
+    session.execute(
+      text(
+        "SELECT id FROM fact_sets "
+        "WHERE period_start = :ps AND period_end = :pe "
+        "  AND factset_type = 'report' "
+        "  AND report_id IS NULL AND scenario_id IS NULL"
+      ),
+      {"ps": period_start, "pe": period_end},
+    )
+    .scalars()
+    .all()
+  )
+
+
+def retract_canonical_statement_sets(
+  session: Session, *, period_start: date, period_end: date
+) -> list[str]:
+  """Delete the window's canonical statement sets (reopen / replace path).
+
+  Sweeps the sets' VerificationResults first — no DB-level FK ties
+  results to fact_sets (the forecast-delete precedent), so without the
+  sweep they'd orphan invisibly and bleed into later reads. Facts
+  cascade at the DB level (``facts.fact_set_id ON DELETE CASCADE``).
+
+  Returns the retracted fact_set ids (empty when the window had none —
+  e.g. reopening a month closed before this stamping existed, or a
+  soft-skipped close).
+  """
+  set_ids = _canonical_set_ids_in_window(session, period_start, period_end)
+  if not set_ids:
+    return []
+  session.execute(
+    delete(VerificationResult).where(VerificationResult.fact_set_id.in_(set_ids))
+  )
+  session.execute(text("DELETE FROM fact_sets WHERE id = ANY(:ids)"), {"ids": set_ids})
+  session.flush()
+  return set_ids
+
+
+def stamp_canonical_statement_sets(
+  session: Session,
+  *,
+  graph_id: str,
+  period_start: date,
+  period_end: date,
+  actor_id: str,
+) -> StatementStampResult:
+  """Pivot the posted ledger and stamp the period's canonical statement sets.
+
+  The close-time producer: statements only (``taxonomy_id=None`` keeps
+  the disclosure picker out — text-block snapshots and disclosure
+  membership are publication concerns that stay in ``create_report``).
+
+  Two-zone failure semantics:
+
+  - **Soft-skip** (returns ``stamped=False`` with a note): the tenant
+    hasn't set up reporting — no CoA mapping, no entity, no composed
+    statement structures, or no rs-gaap taxonomy. The close proceeds;
+    a later close (after mapping) stamps normally.
+  - **Hard fail** (:class:`StatementStampError`): reporting IS
+    configured but the pivot or persist raised. The close must roll
+    back — a closed month without its canonical sets would silently
+    hole the statement series — and the operator fixes and re-closes.
+
+  Replace semantics: any canonical sets already in this window are
+  retracted first (results swept, facts cascaded), making the stamp
+  idempotent across reclose and retry-after-failure.
+
+  Statement-rule verification runs after the stamp, pinned per minted
+  set, and is NON-fatal (mirrors the close's schedule-rule pass): a
+  failed identity check is a finding on the month, not a reason to
+  refuse the close. Its outcome rides ``rule_summary``.
+  """
+  mapping = (
+    session.query(Structure)
+    .filter(Structure.block_type == "coa_mapping")
+    .order_by(Structure.created_at.desc())
+    .first()
+  )
+  if mapping is None:
+    return StatementStampResult(stamped=False, note="no_coa_mapping")
+
+  try:
+    entity_id = _get_entity_id(session, graph_id)
+  except NoEntityError:
+    return StatementStampResult(stamped=False, note="no_entity")
+
+  reporting_style_id = load_entity_reporting_style(session, entity_id)
+  element_to_structures, structure_to_factset = _build_structure_mapping(
+    session, reporting_style_id, fact_element_ids=None, taxonomy_id=None
+  )
+  if not structure_to_factset:
+    return StatementStampResult(stamped=False, note="no_statement_structures")
+
+  taxonomy_row = session.execute(
+    text(
+      "SELECT id FROM taxonomies "
+      "WHERE standard = 'rs-gaap' AND taxonomy_type = 'reporting_standard' "
+      "ORDER BY version DESC LIMIT 1"
+    )
+  ).fetchone()
+  if taxonomy_row is None:
+    return StatementStampResult(stamped=False, note="no_taxonomy")
+
+  period_label = period_end.strftime("%Y-%m")
+  try:
+    close_target = load_close_target_concept(session, reporting_style_id)
+    facts = generate_report_facts(
+      session=session,
+      taxonomy_id=taxonomy_row.id,
+      mapping_id=mapping.id,
+      periods=[PeriodSpec(start=period_start, end=period_end, label=period_label)],
+      close_target_qname=close_target,
+    )
+    retract_canonical_statement_sets(
+      session, period_start=period_start, period_end=period_end
+    )
+    _pre_create_report_fact_sets(
+      session,
+      None,
+      entity_id,
+      actor_id,
+      [PeriodSpec(start=period_start, end=period_end, label=period_label)],
+      structure_to_factset,
+      mapping.id,
+    )
+    _stamp_facts_into_sets(
+      session, facts, entity_id, element_to_structures, structure_to_factset
+    )
+  except Exception as exc:
+    raise StatementStampError(
+      f"Failed to stamp canonical statement sets for {period_label} "
+      f"on graph {graph_id}: {exc}"
+    ) from exc
+
+  rule_summary: dict[str, int] | None = None
+  try:
+    rule_summary = _evaluate_report_structures(
+      session,
+      facts,
+      element_to_structures,
+      structure_to_factset,
+      period_start,
+      period_end,
+      actor_id,
+    )
+  except Exception as exc:
+    logger.warning(
+      f"Statement-rule evaluation failed after close stamp for "
+      f"{period_label} on graph {graph_id}: {exc}"
+    )
+
+  return StatementStampResult(
+    stamped=True,
+    fact_set_ids=dict(structure_to_factset),
+    rule_summary=rule_summary,
+  )
+
+
+__all__ = [
+  "NoEntityError",
+  "StatementStampError",
+  "StatementStampResult",
+  "retract_canonical_statement_sets",
+  "stamp_canonical_statement_sets",
+]

--- a/robosystems/routers/extensions/roboledger/operations.py
+++ b/robosystems/routers/extensions/roboledger/operations.py
@@ -412,6 +412,9 @@ from robosystems.operations.roboledger.fiscal_calendar.service import (
   CalendarAlreadyInitializedError,
   InvalidCloseTargetError,
 )
+from robosystems.operations.roboledger.reports.statement_sets import (
+  StatementStampError,
+)
 from robosystems.operations.taxonomy_block.commands import (
   TaxonomyAuthoringDisabledError,
 )
@@ -1737,12 +1740,15 @@ async def set_close_target_op(
   description=(
     "Lock a single fiscal period. Posts draft entries, runs the "
     "balance-sheet equation check, advances `closed_through` by one, "
-    "and auto-advances `close_target` if this close caught up to it. "
-    "Period must be exactly `closed_through + 1` — sequence violations "
-    "return 422 with structured `blockers`. Common blockers: "
-    "`sync_stale` (override with `allow_stale_sync=true` after manual "
-    "verification), `period_incomplete` (draft entries unbalanced), "
-    "`sequence_violation` (out-of-order)."
+    "auto-advances `close_target` if this close caught up to it, and "
+    "stamps the period's canonical statement FactSets from the posted "
+    "ledger (`statements_stamped` / `stamped_statement_sets` in the "
+    "response; soft-skipped with `statement_stamp_note` when reporting "
+    "isn't set up). Period must be exactly `closed_through + 1` — "
+    "sequence violations return 422 with structured `blockers`. Common "
+    "blockers: `sync_stale` (override with `allow_stale_sync=true` "
+    "after manual verification), `period_incomplete` (draft entries "
+    "unbalanced), `sequence_violation` (out-of-order)."
   ),
   tags=[_OP_TAG],
   dependencies=[_RATE_LIMIT],
@@ -1844,6 +1850,18 @@ async def close_period_op(
           "code": "WRITE_BACK_FAILED",
         },
       )
+    except StatementStampError as e:
+      # The close rolled back: reporting is configured but the pivot
+      # couldn't stamp the period's canonical statement sets. Fix the
+      # cause (mapping/style) and re-run the close — nothing was
+      # committed.
+      raise HTTPException(
+        status_code=422,
+        detail={
+          "message": str(e),
+          "code": "STATEMENT_STAMP_FAILED",
+        },
+      )
     except FiscalCalendarError as e:
       raise HTTPException(status_code=404, detail=str(e))
     except ProgrammingError as e:
@@ -1861,10 +1879,12 @@ async def close_period_op(
   summary="Reopen Fiscal Period",
   description=(
     "Decrement `closed_through` by one. Only the most recently closed "
-    "period can be reopened (no reach-back). The required `reason` is "
-    "captured in the audit log. Use sparingly — reopen invalidates "
-    "downstream artifacts that trusted the closed state (reports, "
-    "shared filings)."
+    "period can be reopened (no reach-back). Retracts the month's "
+    "canonical statement FactSets (a reopened month is no longer a "
+    "closed assertion; re-closing restamps them). The required "
+    "`reason` is captured in the audit log. Use sparingly — reopen "
+    "invalidates downstream artifacts that trusted the closed state "
+    "(reports, shared filings)."
   ),
   tags=[_OP_TAG],
   dependencies=[_RATE_LIMIT],
@@ -1900,6 +1920,8 @@ async def reopen_period_op(
   def _runner():
     try:
       with extensions_session(graph_id) as session:
+        # Wire shape unchanged: the envelope still carries the refreshed
+        # calendar; the retraction count rides the MCP surface only.
         return cmd_reopen_period(
           session,
           platform_db,
@@ -1909,7 +1931,7 @@ async def reopen_period_op(
           reason=body.reason,
           note=body.note,
           service=_fiscal_svc,
-        )
+        ).fiscal_calendar
     except PeriodNotFoundInLedgerError:
       raise HTTPException(
         status_code=404, detail=f"Fiscal period {body.period!r} not found."

--- a/tests/middleware/mcp/tools/test_fiscal_calendar_tools.py
+++ b/tests/middleware/mcp/tools/test_fiscal_calendar_tools.py
@@ -30,6 +30,9 @@ from robosystems.models.api.extensions.fiscal_calendar import (
   ClosePeriodResponse,
   FiscalCalendarResponse,
 )
+from robosystems.operations.roboledger.commands.fiscal_calendar import (
+  ReopenPeriodResult,
+)
 from robosystems.operations.roboledger.fiscal_calendar import (
   CloseGateFailed,
   PeriodNotFoundError,
@@ -37,6 +40,9 @@ from robosystems.operations.roboledger.fiscal_calendar import (
 )
 from robosystems.operations.roboledger.fiscal_calendar.service import (
   CloseableGateResult,
+)
+from robosystems.operations.roboledger.reports.statement_sets import (
+  StatementStampError,
 )
 
 MODULE = "robosystems.middleware.mcp.tools.fiscal_calendar_tools"
@@ -181,6 +187,54 @@ class TestClosePeriodToolHappyPath:
     assert result["evaluated_structure_ids"] == []
 
   @pytest.mark.asyncio
+  async def test_response_includes_statement_stamp_fields(self):
+    """The close-time stamping outcome must reach agents — the MCP dict
+    is shaped by hand, so these keys are pinned explicitly."""
+    tool = ClosePeriodTool(_client(user_id="usr_abc"))
+    response = _close_response(
+      statements_stamped=True,
+      statement_stamp_note=None,
+      stamped_statement_sets={"struct_bs": "fs_bs", "struct_is": "fs_is"},
+      statement_rule_summary={"pass": 5, "fail": 0, "error": 0, "skipped": 1},
+    )
+
+    with (
+      _patch_sessions(),
+      patch(f"{MODULE}.ops_close_period", return_value=response),
+    ):
+      result = await tool.execute({"period": "2026-01"})
+
+    assert result["statements_stamped"] is True
+    assert result["statement_stamp_note"] is None
+    assert result["stamped_statement_sets"] == {
+      "struct_bs": "fs_bs",
+      "struct_is": "fs_is",
+    }
+    assert result["statement_rule_summary"] == {
+      "pass": 5,
+      "fail": 0,
+      "error": 0,
+      "skipped": 1,
+    }
+
+  @pytest.mark.asyncio
+  async def test_response_soft_skip_note_surfaces(self):
+    tool = ClosePeriodTool(_client(user_id="usr_abc"))
+    response = _close_response(
+      statements_stamped=False, statement_stamp_note="no_coa_mapping"
+    )
+
+    with (
+      _patch_sessions(),
+      patch(f"{MODULE}.ops_close_period", return_value=response),
+    ):
+      result = await tool.execute({"period": "2026-01"})
+
+    assert result["statements_stamped"] is False
+    assert result["statement_stamp_note"] == "no_coa_mapping"
+    assert result["stamped_statement_sets"] == {}
+
+  @pytest.mark.asyncio
   async def test_actor_id_falls_back_to_graph_scoped_sentinel(self):
     """When the MCP client has no user_id, fall back to mcp:{graph_id}
     so audit logs stay traceable per tenant (matches ReopenPeriodTool)."""
@@ -291,6 +345,44 @@ class TestClosePeriodToolErrors:
     assert result["error"] == "unbalanced"
     assert "1000" in result["message"]
     assert "900" in result["message"]
+
+
+class TestStatementStampErrorTranslation:
+  @pytest.mark.asyncio
+  async def test_statement_stamp_failed_error_shape(self):
+    """A stamp hard-fail rolled the close back — the MCP error must say
+    so and encourage a retry after fixing the reporting config."""
+    tool = ClosePeriodTool(_client(user_id="usr_abc"))
+    with (
+      _patch_sessions(),
+      patch(
+        f"{MODULE}.ops_close_period",
+        side_effect=StatementStampError("pivot failed for 2026-03"),
+      ),
+    ):
+      result = await tool.execute({"period": "2026-03"})
+
+    assert result["error"] == "statement_stamp_failed"
+    assert "rolled back" in result["message"]
+    assert "pivot failed for 2026-03" in result["message"]
+
+
+class TestReopenPeriodToolResult:
+  @pytest.mark.asyncio
+  async def test_retraction_count_surfaces(self):
+    tool = ReopenPeriodTool(_client(user_id="usr_abc"))
+    result_obj = ReopenPeriodResult(
+      fiscal_calendar=_fc_response(), statement_sets_retracted=3
+    )
+    with (
+      _patch_sessions(),
+      patch(f"{MODULE}.ops_reopen_period", return_value=result_obj),
+    ):
+      result = await tool.execute({"period": "2026-01", "reason": "missed accrual"})
+
+    assert result["period"] == "2026-01"
+    assert result["statement_sets_retracted"] == 3
+    assert result["fiscal_calendar"]["graph_id"] == GRAPH_ID
 
 
 # ────────────────────────────────────────────────────────────────────────────

--- a/tests/operations/information_block/test_envelope_fact_set.py
+++ b/tests/operations/information_block/test_envelope_fact_set.py
@@ -122,6 +122,26 @@ class TestLoadLatestFactSetForStructure:
     assert "scenario_id = 'struct_budget'" in sql
     assert "scenario_id IS NULL" not in sql
 
+  def test_canonical_beats_publication_snapshot_at_equal_period_end(self) -> None:
+    """Close-time canonical sets (``report_id IS NULL``) outrank a
+    Report's publication snapshot at the same ``period_end`` — a report
+    published later for the month must not flip the default envelope
+    off the canonical record. The tiebreak is a boolean expression
+    (``report_id IS NOT NULL ASC``) sitting between the period_end and
+    created_at orderings."""
+    session = MagicMock()
+    result = MagicMock()
+    result.scalar.return_value = None
+    session.execute.return_value = result
+
+    load_latest_fact_set_for_structure(session, "struct_bs")
+    stmt = session.execute.call_args.args[0]
+    sql = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+    order_by = sql.split("ORDER BY")[1]
+    assert "report_id IS NOT NULL" in order_by
+    assert order_by.index("period_end DESC") < order_by.index("report_id IS NOT NULL")
+    assert order_by.index("report_id IS NOT NULL") < order_by.index("created_at DESC")
+
   def test_future_scenario_set_never_wins_default_read(self) -> None:
     """End-to-end shape of the regression: with a scenario row present
     the default read still projects the actual row the (filtered) query
@@ -174,8 +194,10 @@ class TestLoadStatementFactSetSeries:
   def test_ordering_encodes_seam_and_window_precedence(self) -> None:
     """The collapse is first-row-per-period_end, so the ORDER BY IS the
     semantics: actual beats forecast (scenario NULLS FIRST), then the
-    NARROWER window beats the annual set sharing the FY-end period_end
-    (period_start DESC — the FY-capture lesson at series level)."""
+    canonical close-stamped set beats a publication snapshot
+    (``report_id IS NOT NULL ASC``), then the NARROWER window beats the
+    annual set sharing the FY-end period_end (period_start DESC — the
+    FY-capture lesson at series level)."""
     from robosystems.operations.information_block.envelope import (
       load_statement_fact_set_series,
     )
@@ -187,9 +209,39 @@ class TestLoadStatementFactSetSeries:
     order_by = sql.split("ORDER BY")[1]
     assert "period_end ASC" in order_by
     assert "scenario_id ASC NULLS FIRST" in order_by
+    assert "report_id IS NOT NULL" in order_by
     assert "period_start DESC NULLS LAST" in order_by
     assert order_by.index("period_end ASC") < order_by.index("scenario_id ASC")
-    assert order_by.index("scenario_id ASC") < order_by.index("period_start DESC")
+    assert order_by.index("scenario_id ASC") < order_by.index("report_id IS NOT NULL")
+    assert order_by.index("report_id IS NOT NULL") < order_by.index("period_start DESC")
+
+  def test_canonical_column_survives_later_publication_snapshot(self) -> None:
+    """Collapse narrative for the canonical tiebreak: at one period_end
+    the close-stamped set (report_id NULL) is ordered first and keeps
+    the column; the monthly Report's snapshot minted later never flips
+    the series source."""
+    from robosystems.operations.information_block.envelope import (
+      load_statement_fact_set_series,
+    )
+
+    june = date(2026, 6, 30)
+    rows = [
+      _make_fact_set(
+        fs_id="fs_canonical",
+        period_start=date(2026, 6, 1),
+        period_end=june,
+        report_id=None,
+      ),
+      _make_fact_set(
+        fs_id="fs_snapshot",
+        period_start=date(2026, 6, 1),
+        period_end=june,
+        report_id="rep_june",
+      ),
+    ]
+    session = self._session(rows)
+    series = load_statement_fact_set_series(session, "struct_bs")
+    assert [fs.id for fs in series] == ["fs_canonical"]
 
   def test_collapse_keeps_first_row_per_period_end(self) -> None:
     from robosystems.operations.information_block.envelope import (

--- a/tests/operations/roboledger/commands/test_fiscal_calendar.py
+++ b/tests/operations/roboledger/commands/test_fiscal_calendar.py
@@ -1,0 +1,180 @@
+"""Unit tests for the fiscal-calendar command wrappers.
+
+Focus: the close-time statement-stamping surface — `close_period` maps
+the stamp outcome onto `ClosePeriodResponse`, and `reopen_period`
+retracts the reopened month's canonical statement sets (returning
+`ReopenPeriodResult` with the count).
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from robosystems.models.api.extensions.fiscal_calendar import FiscalCalendarResponse
+from robosystems.operations.roboledger.commands.fiscal_calendar import (
+  PeriodNotClosedError,
+  PeriodNotFoundInLedgerError,
+  ReopenPeriodResult,
+  close_period,
+  reopen_period,
+)
+from robosystems.operations.roboledger.fiscal_calendar import PeriodCloseResult
+
+GRAPH_ID = "kg01234567890abcdef"
+
+_MOD = "robosystems.operations.roboledger.commands.fiscal_calendar"
+
+
+def _fc_response() -> FiscalCalendarResponse:
+  return FiscalCalendarResponse(graph_id=GRAPH_ID, fiscal_year_start_month=1)
+
+
+def _close_result(**overrides) -> PeriodCloseResult:
+  defaults = {
+    "period": "2026-01",
+    "entries_posted": 3,
+    "target_auto_advanced": False,
+    "calendar": MagicMock(),
+    "was_reclose": False,
+    "rule_summary": None,
+    "evaluated_structure_ids": (),
+    "statements_stamped": True,
+    "statement_stamp_note": None,
+    "stamped_statement_sets": {"struct_bs": "fs_bs"},
+    "statement_rule_summary": {"pass": 3, "fail": 0, "error": 0, "skipped": 0},
+  }
+  defaults.update(overrides)
+  return PeriodCloseResult(**defaults)
+
+
+class TestClosePeriodResponseMapping:
+  def _run(self, result: PeriodCloseResult):
+    close_service = MagicMock()
+    close_service.close.return_value = result
+    with (
+      patch(f"{_MOD}.qb_sync_state", return_value=(False, None)),
+      patch(f"{_MOD}.build_fiscal_calendar_response", return_value=_fc_response()),
+    ):
+      return close_period(
+        MagicMock(),
+        MagicMock(),
+        GRAPH_ID,
+        "2026-01",
+        actor_id="usr_1",
+        allow_stale_sync=False,
+        note=None,
+        service=MagicMock(),
+        close_service=close_service,
+      )
+
+  def test_stamp_fields_ride_the_response(self):
+    resp = self._run(_close_result())
+    assert resp.statements_stamped is True
+    assert resp.statement_stamp_note is None
+    assert resp.stamped_statement_sets == {"struct_bs": "fs_bs"}
+    assert resp.statement_rule_summary == {
+      "pass": 3,
+      "fail": 0,
+      "error": 0,
+      "skipped": 0,
+    }
+
+  def test_soft_skip_maps_note(self):
+    resp = self._run(
+      _close_result(
+        statements_stamped=False,
+        statement_stamp_note="no_coa_mapping",
+        stamped_statement_sets={},
+        statement_rule_summary=None,
+      )
+    )
+    assert resp.statements_stamped is False
+    assert resp.statement_stamp_note == "no_coa_mapping"
+    assert resp.stamped_statement_sets == {}
+    assert resp.statement_rule_summary is None
+
+
+class TestReopenRetractsCanonicalSets:
+  def _run(self, fp_status="closed", retracted=("fs_a", "fs_b")):
+    session = MagicMock()
+    fp = MagicMock()
+    fp.status = fp_status
+    session.query.return_value.filter.return_value.one_or_none.return_value = fp
+
+    retract = MagicMock(return_value=list(retracted))
+    with (
+      patch(f"{_MOD}.qb_sync_state", return_value=(False, None)),
+      patch(f"{_MOD}.build_fiscal_calendar_response", return_value=_fc_response()),
+      patch(
+        "robosystems.operations.roboledger.commands.schedules."
+        "reinstate_reopened_schedule_scopes"
+      ),
+      patch(
+        "robosystems.operations.roboledger.reports.statement_sets."
+        "retract_canonical_statement_sets",
+        retract,
+      ),
+    ):
+      result = reopen_period(
+        session,
+        MagicMock(),
+        GRAPH_ID,
+        "2026-01",
+        actor_id="usr_1",
+        reason="missed accrual",
+        note=None,
+        service=MagicMock(),
+      )
+    return result, retract, fp
+
+  def test_returns_result_with_retraction_count(self):
+    result, retract, fp = self._run()
+    assert isinstance(result, ReopenPeriodResult)
+    assert result.statement_sets_retracted == 2
+    assert isinstance(result.fiscal_calendar, FiscalCalendarResponse)
+    assert fp.status == "closing"
+
+  def test_retraction_keyed_by_month_window(self):
+    _, retract, _ = self._run()
+    kwargs = retract.call_args.kwargs
+    assert kwargs["period_start"] == date(2026, 1, 1)
+    assert kwargs["period_end"] == date(2026, 1, 31)
+
+  def test_month_without_canonical_sets_counts_zero(self):
+    result, _, _ = self._run(retracted=())
+    assert result.statement_sets_retracted == 0
+
+  def test_period_not_found_raises(self):
+    session = MagicMock()
+    session.query.return_value.filter.return_value.one_or_none.return_value = None
+    with pytest.raises(PeriodNotFoundInLedgerError):
+      reopen_period(
+        session,
+        MagicMock(),
+        GRAPH_ID,
+        "2026-01",
+        actor_id="usr_1",
+        reason="r",
+        note=None,
+        service=MagicMock(),
+      )
+
+  def test_period_not_closed_raises(self):
+    session = MagicMock()
+    fp = MagicMock()
+    fp.status = "open"
+    session.query.return_value.filter.return_value.one_or_none.return_value = fp
+    with pytest.raises(PeriodNotClosedError):
+      reopen_period(
+        session,
+        MagicMock(),
+        GRAPH_ID,
+        "2026-01",
+        actor_id="usr_1",
+        reason="r",
+        note=None,
+        service=MagicMock(),
+      )

--- a/tests/operations/roboledger/commands/test_reports.py
+++ b/tests/operations/roboledger/commands/test_reports.py
@@ -49,7 +49,12 @@ class _FakeFacts:
     self.facts = facts
 
 
-_PICKER_PATH = "robosystems.operations.roboledger.commands.reports.get_render_network"
+# The mapping builder moved to `reports.statement_sets` (shared by the
+# close-time stamper); it resolves the picker from ITS namespace, so the
+# patch path follows the function. Assertions are unchanged.
+_PICKER_PATH = (
+  "robosystems.operations.roboledger.reports.statement_sets.get_render_network"
+)
 
 
 def test_build_structure_mapping_resolves_each_statement_type_via_picker() -> None:

--- a/tests/operations/roboledger/fiscal_calendar/test_close_service.py
+++ b/tests/operations/roboledger/fiscal_calendar/test_close_service.py
@@ -28,8 +28,23 @@ from robosystems.operations.roboledger.fiscal_calendar import (
 from robosystems.operations.roboledger.fiscal_calendar.service import (
   CloseableGateResult,
 )
+from robosystems.operations.roboledger.reports.statement_sets import (
+  StatementStampError,
+  StatementStampResult,
+)
 
 GRAPH_ID = "kg01234567890abcdef"
+
+
+def _noop_stamper(session, **kwargs):
+  """Stub statement stamper for tests exercising the close flow itself.
+
+  The real stamper resolves mapping/style/taxonomy and runs the pivot —
+  against these MagicMock sessions it would consume the ordered
+  ``session.execute.side_effect`` lists and 'find' a mapping in mock
+  truthiness. Injection keeps every pre-existing assertion exact.
+  """
+  return StatementStampResult(stamped=False, note="no_coa_mapping")
 
 
 def _fp(status: str, name: str = "2026-01"):
@@ -120,7 +135,7 @@ def _mock_session_with_fp(fp, debit: int = 0, credit: int = 0, updated: int = 0)
 class TestCloseHappyPath:
   def test_normal_close_calls_advance(self):
     fcs = _mock_fcs(gate_result=CloseableGateResult(is_closeable=True))
-    svc = PeriodCloseService(fcs)
+    svc = PeriodCloseService(fcs, statement_stamper=_noop_stamper)
     session = _mock_session_with_fp(
       _fp(status="open"), debit=5000, credit=5000, updated=3
     )
@@ -141,7 +156,7 @@ class TestCloseHappyPath:
 
   def test_close_sets_period_status_and_actor(self):
     fcs = _mock_fcs(gate_result=CloseableGateResult(is_closeable=True))
-    svc = PeriodCloseService(fcs)
+    svc = PeriodCloseService(fcs, statement_stamper=_noop_stamper)
     fp = _fp(status="open")
     session = _mock_session_with_fp(fp)
 
@@ -168,7 +183,7 @@ class TestCloseHappyPath:
       cal_before=cal_before,
       advance_return=cal_after,
     )
-    svc = PeriodCloseService(fcs)
+    svc = PeriodCloseService(fcs, statement_stamper=_noop_stamper)
     session = _mock_session_with_fp(_fp(status="open"))
 
     result = svc.close(
@@ -195,7 +210,7 @@ class TestCloseGateFailure:
         blockers=[CloseableGateResult.SEQUENCE],
       )
     )
-    svc = PeriodCloseService(fcs)
+    svc = PeriodCloseService(fcs, statement_stamper=_noop_stamper)
     session = MagicMock()
 
     with pytest.raises(CloseGateFailed) as exc_info:
@@ -217,7 +232,7 @@ class TestCloseGateFailure:
         blockers=[CloseableGateResult.NO_CALENDAR],
       )
     )
-    svc = PeriodCloseService(fcs)
+    svc = PeriodCloseService(fcs, statement_stamper=_noop_stamper)
 
     with pytest.raises(CloseGateFailed) as exc_info:
       svc.close(
@@ -241,7 +256,7 @@ class TestUnbalancedLedger:
     """The BS check runs BEFORE any state mutation, so raising it leaves
     the session unchanged (no rollback needed)."""
     fcs = _mock_fcs(gate_result=CloseableGateResult(is_closeable=True))
-    svc = PeriodCloseService(fcs)
+    svc = PeriodCloseService(fcs, statement_stamper=_noop_stamper)
     session = _mock_session_with_fp(_fp(status="open"), debit=1000, credit=900)
 
     with pytest.raises(UnbalancedLedgerError) as exc_info:
@@ -269,7 +284,7 @@ class TestUnbalancedLedger:
 class TestPeriodNotFound:
   def test_raises_when_fiscal_period_missing(self):
     fcs = _mock_fcs(gate_result=CloseableGateResult(is_closeable=True))
-    svc = PeriodCloseService(fcs)
+    svc = PeriodCloseService(fcs, statement_stamper=_noop_stamper)
     session = _mock_session_with_fp(None)
 
     with pytest.raises(PeriodNotFoundError):
@@ -295,7 +310,7 @@ class TestRecloseRouting:
       gate_result=CloseableGateResult(is_closeable=True),
       is_latest=True,
     )
-    svc = PeriodCloseService(fcs)
+    svc = PeriodCloseService(fcs, statement_stamper=_noop_stamper)
     session = _mock_session_with_fp(_fp(status="closing"))
 
     svc.close(
@@ -316,7 +331,7 @@ class TestRecloseRouting:
       gate_result=CloseableGateResult(is_closeable=True),
       is_latest=False,
     )
-    svc = PeriodCloseService(fcs)
+    svc = PeriodCloseService(fcs, statement_stamper=_noop_stamper)
     session = _mock_session_with_fp(_fp(status="closing", name="2025-06"))
 
     result = svc.close(
@@ -343,7 +358,7 @@ class TestStaleSyncAudit:
 
   def test_override_annotates_note(self):
     fcs = _mock_fcs(gate_result=CloseableGateResult(is_closeable=True))
-    svc = PeriodCloseService(fcs)
+    svc = PeriodCloseService(fcs, statement_stamper=_noop_stamper)
     session = _mock_session_with_fp(_fp(status="open"))
 
     svc.close(
@@ -365,7 +380,7 @@ class TestStaleSyncAudit:
   def test_override_without_sync_connection_is_not_annotated(self):
     """No sync connection → allow_stale_sync is a no-op, no annotation."""
     fcs = _mock_fcs(gate_result=CloseableGateResult(is_closeable=True))
-    svc = PeriodCloseService(fcs)
+    svc = PeriodCloseService(fcs, statement_stamper=_noop_stamper)
     session = _mock_session_with_fp(_fp(status="open"))
 
     svc.close(
@@ -384,7 +399,7 @@ class TestStaleSyncAudit:
 
   def test_no_override_passes_note_unchanged(self):
     fcs = _mock_fcs(gate_result=CloseableGateResult(is_closeable=True))
-    svc = PeriodCloseService(fcs)
+    svc = PeriodCloseService(fcs, statement_stamper=_noop_stamper)
     session = _mock_session_with_fp(_fp(status="open"))
 
     svc.close(
@@ -440,7 +455,7 @@ class TestCloseAutoRunsRules:
 
   def test_rule_summary_aggregates_across_schedules(self):
     fcs = _mock_fcs(gate_result=CloseableGateResult(is_closeable=True))
-    svc = PeriodCloseService(fcs)
+    svc = PeriodCloseService(fcs, statement_stamper=_noop_stamper)
 
     _r = lambda status: MagicMock(status=status)  # noqa: E731
     session, eval_patcher = self._session_with_schedules_and_rule_results(
@@ -468,7 +483,7 @@ class TestCloseAutoRunsRules:
 
   def test_no_schedules_returns_none_summary(self):
     fcs = _mock_fcs(gate_result=CloseableGateResult(is_closeable=True))
-    svc = PeriodCloseService(fcs)
+    svc = PeriodCloseService(fcs, statement_stamper=_noop_stamper)
 
     session, eval_patcher = self._session_with_schedules_and_rule_results(
       _fp(status="open"), schedule_ids=[], rule_results_per_struct={}
@@ -492,7 +507,7 @@ class TestCloseAutoRunsRules:
     """A bare exception out of the rule engine is logged and skipped — the
     close still succeeds with whatever results were tallied beforehand."""
     fcs = _mock_fcs(gate_result=CloseableGateResult(is_closeable=True))
-    svc = PeriodCloseService(fcs)
+    svc = PeriodCloseService(fcs, statement_stamper=_noop_stamper)
 
     _r = lambda status: MagicMock(status=status)  # noqa: E731
     session = _mock_session_with_fp(_fp(status="open"))
@@ -529,6 +544,162 @@ class TestCloseAutoRunsRules:
     # close succeeded — only the good schedule's results land in the summary
     assert result.rule_summary == {"pass": 1, "fail": 0, "error": 0, "skipped": 0}
     assert result.evaluated_structure_ids == ("struct_ok", "struct_bad")
+
+
+class TestCloseStampsStatementSets:
+  """Step 5b: the close stamps the period's canonical statement sets.
+
+  Contract: stamp outcome rides `PeriodCloseResult`; a soft-skip never
+  blocks the close; `StatementStampError` propagates (the command layer
+  never commits, so the whole close rolls back); stamping runs after the
+  draft→posted transition (the pivot reads posted entries only) and
+  before the schedule-rule pass; reclose stamps too (replace semantics
+  live inside the stamper).
+  """
+
+  def test_stamp_result_rides_close_result(self):
+    fcs = _mock_fcs(gate_result=CloseableGateResult(is_closeable=True))
+    sets = {"struct_bs": "fs_bs", "struct_is": "fs_is"}
+    summary = {"pass": 4, "fail": 1, "error": 0, "skipped": 0}
+
+    def _stamper(session, **kwargs):
+      return StatementStampResult(stamped=True, fact_set_ids=sets, rule_summary=summary)
+
+    svc = PeriodCloseService(fcs, statement_stamper=_stamper)
+    session = _mock_session_with_fp(_fp(status="open"))
+
+    result = svc.close(
+      session,
+      GRAPH_ID,
+      "2026-01",
+      actor_id="usr_1",
+      has_sync_connection=False,
+      last_sync_at=None,
+    )
+
+    assert result.statements_stamped is True
+    assert result.statement_stamp_note is None
+    assert result.stamped_statement_sets == sets
+    assert result.statement_rule_summary == summary
+
+  def test_soft_skip_keeps_close_succeeding(self):
+    fcs = _mock_fcs(gate_result=CloseableGateResult(is_closeable=True))
+    svc = PeriodCloseService(fcs, statement_stamper=_noop_stamper)
+    fp = _fp(status="open")
+    session = _mock_session_with_fp(fp)
+
+    result = svc.close(
+      session,
+      GRAPH_ID,
+      "2026-01",
+      actor_id="usr_1",
+      has_sync_connection=False,
+      last_sync_at=None,
+    )
+
+    assert fp.status == "closed"
+    assert result.statements_stamped is False
+    assert result.statement_stamp_note == "no_coa_mapping"
+    assert result.stamped_statement_sets == {}
+
+  def test_stamp_error_propagates(self):
+    """Reporting is configured but the pivot failed — the exception must
+    reach the command layer so nothing commits (full close rollback)."""
+    fcs = _mock_fcs(gate_result=CloseableGateResult(is_closeable=True))
+
+    def _stamper(session, **kwargs):
+      raise StatementStampError("pivot exploded")
+
+    svc = PeriodCloseService(fcs, statement_stamper=_stamper)
+    session = _mock_session_with_fp(_fp(status="open"))
+
+    with pytest.raises(StatementStampError):
+      svc.close(
+        session,
+        GRAPH_ID,
+        "2026-01",
+        actor_id="usr_1",
+        has_sync_connection=False,
+        last_sync_at=None,
+      )
+
+  def test_stamp_runs_after_post_and_before_schedule_rules(self):
+    """At stamp time the FiscalPeriod is already closed (drafts posted)
+    and only the BS-preflight execute has run — the schedule-rule query
+    (the second session.execute) hasn't happened yet."""
+    fcs = _mock_fcs(gate_result=CloseableGateResult(is_closeable=True))
+    fp = _fp(status="open")
+    observed = {}
+
+    def _stamper(session, **kwargs):
+      observed["fp_status"] = fp.status
+      observed["execute_calls"] = session.execute.call_count
+      return StatementStampResult(stamped=True)
+
+    svc = PeriodCloseService(fcs, statement_stamper=_stamper)
+    session = _mock_session_with_fp(fp)
+
+    svc.close(
+      session,
+      GRAPH_ID,
+      "2026-01",
+      actor_id="usr_1",
+      has_sync_connection=False,
+      last_sync_at=None,
+    )
+
+    assert observed["fp_status"] == "closed"
+    assert observed["execute_calls"] == 1
+
+  def test_stamper_receives_period_window_and_actor(self):
+    fcs = _mock_fcs(gate_result=CloseableGateResult(is_closeable=True))
+    captured = {}
+
+    def _stamper(session, **kwargs):
+      captured.update(kwargs)
+      return StatementStampResult(stamped=True)
+
+    svc = PeriodCloseService(fcs, statement_stamper=_stamper)
+    session = _mock_session_with_fp(_fp(status="open"))
+
+    svc.close(
+      session,
+      GRAPH_ID,
+      "2026-01",
+      actor_id="usr_close",
+      has_sync_connection=False,
+      last_sync_at=None,
+    )
+
+    assert captured["graph_id"] == GRAPH_ID
+    assert captured["actor_id"] == "usr_close"
+    assert captured["period_start"] == datetime(2026, 1, 1).date()
+    assert captured["period_end"] == datetime(2026, 1, 31).date()
+
+  def test_reclose_also_stamps(self):
+    """A reclose (status='closing') replaces the month's canonical sets —
+    the stamper must run on that path too."""
+    fcs = _mock_fcs(gate_result=CloseableGateResult(is_closeable=True), is_latest=True)
+    calls = []
+
+    def _stamper(session, **kwargs):
+      calls.append(kwargs["period_end"])
+      return StatementStampResult(stamped=True)
+
+    svc = PeriodCloseService(fcs, statement_stamper=_stamper)
+    session = _mock_session_with_fp(_fp(status="closing"))
+
+    result = svc.close(
+      session,
+      GRAPH_ID,
+      "2026-01",
+      actor_id="usr_1",
+      has_sync_connection=False,
+      last_sync_at=None,
+    )
+
+    assert result.was_reclose is True
+    assert len(calls) == 1
 
 
 class TestClosePrePublishWriteback:

--- a/tests/operations/roboledger/reports/test_statement_sets.py
+++ b/tests/operations/roboledger/reports/test_statement_sets.py
@@ -1,0 +1,308 @@
+"""Unit tests for canonical statement-set stamping (the close-time pivot).
+
+Covers the two-zone failure contract of ``stamp_canonical_statement_sets``
+(soft-skip when reporting isn't set up; ``StatementStampError`` when the
+pivot fails on a configured tenant), the replace-delete + minted-set
+shape, non-fatal verification, and ``retract_canonical_statement_sets``
+(the reopen path: VerificationResult sweep + window-scoped delete).
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from robosystems.models.extensions.roboledger.fact_set import FactSet
+from robosystems.operations.roboledger.reports.statement_sets import (
+  StatementStampError,
+  retract_canonical_statement_sets,
+  stamp_canonical_statement_sets,
+)
+
+GRAPH_ID = "kg01234567890abcdef"
+PS = date(2026, 1, 1)
+PE = date(2026, 1, 31)
+
+_MOD = "robosystems.operations.roboledger.reports.statement_sets"
+
+
+def _row(**attrs):
+  row = MagicMock()
+  for k, v in attrs.items():
+    setattr(row, k, v)
+  return row
+
+
+def _exec_fetchone(row):
+  m = MagicMock()
+  m.fetchone.return_value = row
+  return m
+
+
+def _exec_scalars(values):
+  m = MagicMock()
+  m.scalars.return_value.all.return_value = values
+  return m
+
+
+def _session(mapping, execute_side_effects):
+  """MagicMock session: mapping query via ``session.query``; ordered SQL
+  results via ``session.execute.side_effect``."""
+  session = MagicMock()
+  session.query.return_value.filter.return_value.order_by.return_value.first.return_value = mapping
+  session.execute.side_effect = execute_side_effects
+  return session
+
+
+def _fake_facts():
+  return SimpleNamespace(
+    facts=[
+      SimpleNamespace(
+        element_id="el_cash",
+        value=100.0,
+        period_start=None,
+        period_end=PE,
+        period_type="instant",
+      ),
+      SimpleNamespace(
+        element_id="el_rev",
+        value=50.0,
+        period_start=PS,
+        period_end=PE,
+        period_type="duration",
+      ),
+    ]
+  )
+
+
+def _stamp(session, **patches):
+  """Run the stamper with the pivot collaborators patched."""
+  defaults = {
+    "load_entity_reporting_style": MagicMock(return_value="style_1"),
+    "_build_structure_mapping": MagicMock(
+      return_value=(
+        {"el_cash": ["struct_bs"], "el_rev": ["struct_is"]},
+        {"struct_bs": "fs_bs", "struct_is": "fs_is"},
+      )
+    ),
+    "load_close_target_concept": MagicMock(return_value="rs-gaap:RE"),
+    "generate_report_facts": MagicMock(return_value=_fake_facts()),
+    "_evaluate_report_structures": MagicMock(
+      return_value={"pass": 2, "fail": 0, "error": 0, "skipped": 0}
+    ),
+  }
+  defaults.update(patches)
+  with (
+    patch(
+      f"{_MOD}.load_entity_reporting_style", defaults["load_entity_reporting_style"]
+    ),
+    patch(f"{_MOD}._build_structure_mapping", defaults["_build_structure_mapping"]),
+    patch(f"{_MOD}.load_close_target_concept", defaults["load_close_target_concept"]),
+    patch(f"{_MOD}.generate_report_facts", defaults["generate_report_facts"]),
+    patch(
+      f"{_MOD}._evaluate_report_structures", defaults["_evaluate_report_structures"]
+    ),
+  ):
+    return stamp_canonical_statement_sets(
+      session,
+      graph_id=GRAPH_ID,
+      period_start=PS,
+      period_end=PE,
+      actor_id="usr_close",
+    )
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Soft-skips — reporting not set up, close proceeds without sets
+# ────────────────────────────────────────────────────────────────────────────
+
+
+class TestSoftSkips:
+  def test_no_coa_mapping(self):
+    session = _session(mapping=None, execute_side_effects=[])
+    result = _stamp(session)
+    assert result.stamped is False
+    assert result.note == "no_coa_mapping"
+    assert result.fact_set_ids == {}
+    session.add.assert_not_called()
+
+  def test_no_entity(self):
+    session = _session(
+      mapping=_row(id="map_1"),
+      execute_side_effects=[_exec_fetchone(None)],  # _get_entity_id
+    )
+    result = _stamp(session)
+    assert result.stamped is False
+    assert result.note == "no_entity"
+
+  def test_no_statement_structures(self):
+    session = _session(
+      mapping=_row(id="map_1"),
+      execute_side_effects=[_exec_fetchone(_row(id="ent_1"))],
+    )
+    result = _stamp(session, _build_structure_mapping=MagicMock(return_value=({}, {})))
+    assert result.stamped is False
+    assert result.note == "no_statement_structures"
+
+  def test_no_taxonomy(self):
+    session = _session(
+      mapping=_row(id="map_1"),
+      execute_side_effects=[
+        _exec_fetchone(_row(id="ent_1")),  # _get_entity_id
+        _exec_fetchone(None),  # rs-gaap taxonomy lookup
+      ],
+    )
+    result = _stamp(session)
+    assert result.stamped is False
+    assert result.note == "no_taxonomy"
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Happy path — minted-set shape + verification riding the result
+# ────────────────────────────────────────────────────────────────────────────
+
+
+class TestStampHappyPath:
+  def _happy_session(self, existing_canonical_ids=()):
+    effects = [
+      _exec_fetchone(_row(id="ent_1")),  # _get_entity_id
+      _exec_fetchone(_row(id="tax_1")),  # rs-gaap taxonomy
+      _exec_scalars(list(existing_canonical_ids)),  # retract: window select
+    ]
+    if existing_canonical_ids:
+      effects.append(MagicMock())  # VerificationResult sweep
+      effects.append(MagicMock())  # fact_sets delete
+    return _session(mapping=_row(id="map_1"), execute_side_effects=effects)
+
+  def _added_fact_sets(self, session) -> list[FactSet]:
+    return [
+      call.args[0]
+      for call in session.add.call_args_list
+      if isinstance(call.args[0], FactSet)
+    ]
+
+  def test_mints_canonical_sets_with_pivot_provenance(self):
+    session = self._happy_session()
+    result = _stamp(session)
+
+    assert result.stamped is True
+    assert result.note is None
+    assert result.fact_set_ids == {"struct_bs": "fs_bs", "struct_is": "fs_is"}
+    assert result.rule_summary == {"pass": 2, "fail": 0, "error": 0, "skipped": 0}
+
+    fact_sets = self._added_fact_sets(session)
+    assert len(fact_sets) == 2
+    for fs in fact_sets:
+      assert fs.report_id is None
+      assert fs.scenario_id is None
+      assert fs.factset_type == "report"
+      assert fs.period_start == PS
+      assert fs.period_end == PE
+      assert fs.provenance["origin"] == "pivot"
+      assert fs.provenance["mapping_id"] == "map_1"
+      assert fs.provenance["period"] == f"{PS}/{PE}"
+
+  def test_replace_deletes_prior_canonical_sets_and_sweeps_results(self):
+    session = self._happy_session(existing_canonical_ids=["fs_old_bs", "fs_old_is"])
+    result = _stamp(session)
+    assert result.stamped is True
+
+    calls = session.execute.call_args_list
+    # 3rd call selected the window's canonical ids; its SQL carries the
+    # ownership predicates that protect every other producer's sets.
+    window_sql = str(calls[2].args[0])
+    assert "factset_type = 'report'" in window_sql
+    assert "report_id IS NULL" in window_sql
+    assert "scenario_id IS NULL" in window_sql
+    assert "period_start = :ps" in window_sql
+    assert "period_end = :pe" in window_sql
+    # 4th: VerificationResult sweep (no DB FK ties results to sets).
+    sweep_sql = str(calls[3].args[0])
+    assert "verification_results" in sweep_sql.lower()
+    # 5th: the canonical sets themselves.
+    delete_sql = str(calls[4].args[0])
+    assert "DELETE FROM fact_sets" in delete_sql
+    assert calls[4].args[1] == {"ids": ["fs_old_bs", "fs_old_is"]}
+
+  def test_verification_failure_is_non_fatal(self):
+    session = self._happy_session()
+    result = _stamp(
+      session,
+      _evaluate_report_structures=MagicMock(side_effect=RuntimeError("engine down")),
+    )
+    assert result.stamped is True
+    assert result.rule_summary is None
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Hard fail — reporting configured, pivot raised
+# ────────────────────────────────────────────────────────────────────────────
+
+
+class TestStampHardFail:
+  def test_pivot_exception_wraps_in_statement_stamp_error(self):
+    session = _session(
+      mapping=_row(id="map_1"),
+      execute_side_effects=[
+        _exec_fetchone(_row(id="ent_1")),
+        _exec_fetchone(_row(id="tax_1")),
+      ],
+    )
+    with pytest.raises(StatementStampError) as exc_info:
+      _stamp(
+        session,
+        generate_report_facts=MagicMock(side_effect=ValueError("bad mapping arc")),
+      )
+    assert "2026-01" in str(exc_info.value)
+    assert isinstance(exc_info.value.__cause__, ValueError)
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Retraction — the reopen path
+# ────────────────────────────────────────────────────────────────────────────
+
+
+class TestRetractCanonicalSets:
+  def test_empty_window_is_a_noop(self):
+    session = MagicMock()
+    session.execute.side_effect = [_exec_scalars([])]
+    retracted = retract_canonical_statement_sets(
+      session, period_start=PS, period_end=PE
+    )
+    assert retracted == []
+    assert session.execute.call_count == 1
+    session.flush.assert_not_called()
+
+  def test_sweeps_results_then_deletes_sets(self):
+    session = MagicMock()
+    session.execute.side_effect = [
+      _exec_scalars(["fs_a", "fs_b"]),
+      MagicMock(),  # VerificationResult sweep
+      MagicMock(),  # fact_sets delete
+    ]
+    retracted = retract_canonical_statement_sets(
+      session, period_start=PS, period_end=PE
+    )
+    assert retracted == ["fs_a", "fs_b"]
+
+    calls = session.execute.call_args_list
+    sweep_sql = str(calls[1].args[0])
+    assert "verification_results" in sweep_sql.lower()
+    delete_sql = str(calls[2].args[0])
+    assert "DELETE FROM fact_sets" in delete_sql
+    assert calls[2].args[1] == {"ids": ["fs_a", "fs_b"]}
+    session.flush.assert_called_once()
+
+  def test_window_predicates_protect_other_producers(self):
+    """The window select must exclude publication snapshots
+    (report_id NOT NULL), scenario months, and non-'report' set types."""
+    session = MagicMock()
+    session.execute.side_effect = [_exec_scalars([])]
+    retract_canonical_statement_sets(session, period_start=PS, period_end=PE)
+    sql = str(session.execute.call_args_list[0].args[0])
+    assert "factset_type = 'report'" in sql
+    assert "report_id IS NULL" in sql
+    assert "scenario_id IS NULL" in sql


### PR DESCRIPTION
## Summary

Moves statement-FactSet production to the close boundary — **closing a month is now the deliberate act that persists its statements**, and reports become pure publication (spec §11 #5's settled trichotomy, minus the deferred live mode).

- **`close-period` stamps canonical sets**: after the draft→posted transition, the close pivots the posted ledger through the active CoA mapping and mints the period's statement FactSets with `report_id NULL`, then evaluates the statement rule corpus pinned per set (non-fatal, outcome rides the response). Replace semantics make it idempotent across reclose and retry.
- **`reopen-period` retracts them** (a reopened month is no longer a closed assertion) and sweeps their VerificationResults; re-closing restamps fresh.
- **Failure semantics**: tenant without reporting set up → soft-skip with a note (close proceeds); reporting configured but pivot fails → `StatementStampError`, whole close rolls back (422 `STATEMENT_STAMP_FAILED`).
- **`create-report` unchanged**: publication keeps minting its own `report_id`-owned snapshot sets, frozen at filing; delete/regenerate delete only by `report_id` and can never destroy canonical closed-month history. The shared production core is extracted to `operations/roboledger/reports/statement_sets.py`.
- **Reader tiebreak**: `load_statement_fact_set_series` / `load_latest_fact_set_for_structure` prefer canonical sets at equal `period_end`, so a later publication snapshot can't flip a series column off the close-stamped record.
- **Response surfaces** (REST + MCP, additive only): `statements_stamped`, `statement_stamp_note`, `stamped_statement_sets`, `statement_rule_summary` on close; `statement_sets_retracted` on MCP reopen. Wire shape of the reopen REST envelope is unchanged.

Zero reader migration: statement/forecast/metric readers already bind sets by `(structure_id, factset_type='report', period)` and never touch `report_id`. No DB migration — `fact_sets.report_id` was already nullable.

Follow-up PR switches the showcase runner from minting monthly draft reports to closing each historical month.

## Testing

- `just test-all`: full suite green (2768 passed; the one failure is the known pre-existing `test_incremental_equals_full_load` parallel flake, passes in isolation) + code quality clean.
- New: `test_statement_sets.py` (soft-skips, replace-delete scoping + result sweep, minted-set shape/provenance, hard-fail wrap, non-fatal verification), `test_fiscal_calendar.py` (close response mapping, reopen retraction window + count), `TestCloseStampsStatementSets` (ordering, reclose, error propagation), MCP dict keys + error shape, envelope ordering/collapse pins.
- `tests/operations/roboledger/commands/test_reports.py` assertions untouched (the extraction gate); only the picker patch path follows the moved function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)