### PR TITLE
Forecast-lever legibility for code-blind MCP operators

### DIFF
--- a/robosystems/models/api/extensions/forecasts.py
+++ b/robosystems/models/api/extensions/forecasts.py
@@ -28,13 +28,21 @@ class LeverAssertionRequest(BaseModel):
   """One lever's asserted values for the scenario.
 
   ``qname`` must resolve to an ``rs-driver:*`` catalog element (the
-  create handler rejects anything else). Value conventions follow the
-  catalog: percent levers are decimals per month (0.03 = 3%/month),
-  days levers are day counts.
+  create handler rejects anything else). Each lever's value semantics
+  are defined by its catalog element's documentation — surfaced as
+  ``documentation`` on the elements bundled in the forecast block's
+  envelope (``get-information-block``). Percent levers are decimals but
+  their *meaning* varies by lever: growth levers are month-over-month
+  rates (``RevenueGrowthRate`` 0.03 = +3%/month, compounding), while
+  rate-on-base levers are fractions of the same month's base
+  (``CostOfRevenueRate`` 0.62 = cost of revenue at 62% of that month's
+  revenues — not a growth rate). Days levers (``DaysSalesOutstanding``,
+  ``DaysPayableOutstanding``) are day counts.
 
   ``value`` is a uniform fill across the whole horizon;
   ``values_by_period`` overrides individual months (``"YYYY-MM"``
-  keys). At least one of the two must be provided. Months covered by
+  keys) — e.g. a margin-compression ramp asserts a different rate each
+  month. At least one of the two must be provided. Months covered by
   neither carry no assertion — the lever's rule is inactive for that
   month and its target falls to the engine's carry-forward default.
   """
@@ -80,13 +88,16 @@ class CreateForecastRequest(BaseModel):
     json_schema_extra={
       "examples": [
         {
-          "summary": "FY operating budget — growth + margins + working capital",
+          "summary": "FY operating budget — growth + margin ramp + working capital",
           "description": (
             "A 12-month budget scenario: 3%/month revenue growth "
-            "compounding, 62% cost-of-revenue rate, 45-day DSO, 30-day "
-            "DPO. Lever values are decimals/day-counts per the "
-            "rs-driver catalog conventions. After creating, run "
-            "`compute-forecast` to derive the forward months."
+            "compounding, cost-of-revenue rate ramping from 44% toward "
+            "62% via per-month overrides (rate-on-base: each value is "
+            "that month's cost as a fraction of revenues), 45-day DSO, "
+            "30-day DPO. Each lever's semantics come from its catalog "
+            "documentation (on the envelope's elements). After "
+            "creating, run `compute-forecast` to derive the forward "
+            "months."
           ),
           "value": {
             "name": "FY26 Operating Budget",
@@ -94,7 +105,15 @@ class CreateForecastRequest(BaseModel):
             "horizon_months": 12,
             "levers": [
               {"qname": "rs-driver:RevenueGrowthRate", "value": 0.03},
-              {"qname": "rs-driver:CostOfRevenueRate", "value": 0.62},
+              {
+                "qname": "rs-driver:CostOfRevenueRate",
+                "value": 0.62,
+                "values_by_period": {
+                  "2026-06": 0.44,
+                  "2026-07": 0.47,
+                  "2026-08": 0.5,
+                },
+              },
               {"qname": "rs-driver:DaysSalesOutstanding", "value": 45},
               {"qname": "rs-driver:DaysPayableOutstanding", "value": 30},
             ],

--- a/robosystems/models/api/information_block.py
+++ b/robosystems/models/api/information_block.py
@@ -67,6 +67,15 @@ class ElementLite(BaseModel):
       "days | string | …). None means untyped; fall back to is_monetary."
     ),
   )
+  documentation: str | None = Field(
+    None,
+    description=(
+      "The element's documentation-role label — the catalog's "
+      "authoritative value semantics (e.g. whether a percent driver is "
+      "a growth rate or a rate-on-base fraction). None when the "
+      "element carries no documentation label."
+    ),
+  )
 
 
 class ClassificationLite(BaseModel):
@@ -1402,7 +1411,11 @@ class _UpdateForecastArm(BaseModel):
   )
   payload: UpdateForecastRequest = Field(
     ...,
-    description="Forecast update payload.",
+    description=(
+      "Forecast update payload. Updating does NOT recompute — lever, "
+      "horizon, or base-period changes leave the scenario's computed "
+      "months stale until the next `compute-forecast` run."
+    ),
   )
 
 

--- a/robosystems/operations/information_block/envelope.py
+++ b/robosystems/operations/information_block/envelope.py
@@ -33,6 +33,7 @@ from robosystems.models.extensions import (
   AssociationClassification,
   Classification,
   Element,
+  ElementLabel,
   Rule,
   Structure,
   VerificationResult,
@@ -45,7 +46,7 @@ from robosystems.models.extensions.roboledger import Fact, FactSet
 DISCLOSURE_BLOCK_TYPE = "regulatory_disclosure"
 
 
-def element_to_lite(element: Element) -> ElementLite:
+def element_to_lite(element: Element, documentation: str | None = None) -> ElementLite:
   """Project an :class:`Element` ORM row onto :class:`ElementLite`."""
   return ElementLite(
     id=element.id,
@@ -58,7 +59,40 @@ def element_to_lite(element: Element) -> ElementLite:
     balance_type=element.balance_type,
     period_type=element.period_type,
     item_type=element.item_type,
+    documentation=documentation,
   )
+
+
+def load_documentation_for_elements(
+  session: Session, element_ids: list[str]
+) -> dict[str, str]:
+  """Documentation-role label text keyed by element id, one batched query.
+
+  The taxonomy loader lands each catalog element's ``documentation``
+  field as an :class:`ElementLabel` row with ``role='documentation'`` —
+  the authoritative value semantics for driver/metric concepts. Elements
+  without one (CoA entries, most tenant-native elements) simply have no
+  entry in the returned map.
+  """
+  if not element_ids:
+    return {}
+  rows = session.execute(
+    select(ElementLabel.element_id, ElementLabel.text).where(
+      ElementLabel.element_id.in_(element_ids),
+      ElementLabel.role == "documentation",
+    )
+  ).all()
+  return dict(rows)
+
+
+def elements_to_lites(session: Session, elements: list[Element]) -> list[ElementLite]:
+  """Project elements with their documentation labels attached.
+
+  The shared path every envelope builder uses — one batched label query
+  per envelope, never per element.
+  """
+  docs = load_documentation_for_elements(session, [e.id for e in elements])
+  return [element_to_lite(e, documentation=docs.get(e.id)) for e in elements]
 
 
 def association_to_connection(
@@ -761,11 +795,13 @@ __all__ = [
   "association_to_connection",
   "build_verification_summary",
   "element_to_lite",
+  "elements_to_lites",
   "fact_set_to_lite",
   "fact_to_lite",
   "load_base_envelope_atoms",
   "load_classifications_for_associations",
   "load_disclosure_id_for_structure",
+  "load_documentation_for_elements",
   "load_fact_set_by_id_for_structure",
   "load_latest_fact_set_for_structure",
   "load_rules_for_structure",

--- a/robosystems/operations/information_block/forecast.py
+++ b/robosystems/operations/information_block/forecast.py
@@ -46,7 +46,7 @@ from robosystems.models.extensions import Element, Structure
 from robosystems.models.extensions.roboledger.fact import Fact
 from robosystems.models.extensions.roboledger.fact_set import FactSet
 from robosystems.operations.information_block.envelope import (
-  element_to_lite,
+  elements_to_lites,
   fact_set_to_lite,
   fact_to_lite,
   load_base_envelope_atoms,
@@ -536,7 +536,7 @@ def build_envelope(
       template=None,
       mechanics=mechanics,
     ),
-    elements=[element_to_lite(e) for e in lever_elements],
+    elements=elements_to_lites(session, lever_elements),
     connections=[],
     facts=[fact_to_lite(f, elements_by_id) for f in facts],
     rules=atoms.rules,

--- a/robosystems/operations/information_block/forecast_compute.py
+++ b/robosystems/operations/information_block/forecast_compute.py
@@ -275,8 +275,10 @@ def cmd_compute_forecast(
   is_structure_id = _newest_actual_structure_id(session, "income_statement")
   if is_structure_id is None:
     raise ValueError(
-      "No actual income-statement report FactSet exists — generate at "
-      "least one report before computing a forecast."
+      "No actual income-statement sets exist to project from — close at "
+      "least one month first (closing a period stamps its statement "
+      "sets). If months are already closed without statements, set up "
+      "the CoA mapping and reporting style, then reclose."
     )
   bs_structure_id = _newest_actual_structure_id(session, "balance_sheet")
 
@@ -286,11 +288,11 @@ def cmd_compute_forecast(
   )
   if base_is_set is None:
     raise ValueError(
-      f"No actual income-statement report at the base period "
-      f"{mechanics.base_period} (a monthly report whose window starts "
-      f"{base_start} and ends {base_end}). Generate monthly reports "
-      "through the base period, or set base_period to a month that has "
-      "one."
+      f"No actual income statement at the base period "
+      f"{mechanics.base_period} (a monthly set whose window starts "
+      f"{base_start} and ends {base_end}). Close the months through the "
+      "base period (closing stamps each month's statement sets), or set "
+      "base_period to a month that has one."
     )
 
   prior_values: dict[str, float] = {}

--- a/robosystems/operations/information_block/metric.py
+++ b/robosystems/operations/information_block/metric.py
@@ -34,7 +34,7 @@ from robosystems.models.extensions.roboledger.fact_set import FactSet
 from robosystems.operations.information_block.chart import build_chart_projection
 from robosystems.operations.information_block.envelope import (
   association_to_connection,
-  element_to_lite,
+  elements_to_lites,
   fact_set_to_lite,
   fact_to_lite,
   load_base_envelope_atoms,
@@ -219,7 +219,7 @@ def build_envelope(
       template=None,
       mechanics=mechanics,
     ),
-    elements=[element_to_lite(e) for e in atoms.elements],
+    elements=elements_to_lites(session, atoms.elements),
     connections=[
       association_to_connection(a, atoms.classifications_by_assoc.get(a.id, []))
       for a in atoms.associations

--- a/robosystems/operations/information_block/rollforward.py
+++ b/robosystems/operations/information_block/rollforward.py
@@ -45,7 +45,7 @@ from robosystems.models.api.information_block import (
 from robosystems.models.extensions import Element, Structure
 from robosystems.operations.information_block.envelope import (
   association_to_connection,
-  element_to_lite,
+  elements_to_lites,
   load_base_envelope_atoms,
 )
 
@@ -281,7 +281,7 @@ def build_envelope(
       template=None,
       mechanics=mechanics,
     ),
-    elements=[element_to_lite(e) for e in atoms.elements],
+    elements=elements_to_lites(session, atoms.elements),
     connections=[
       association_to_connection(a, atoms.classifications_by_assoc.get(a.id, []))
       for a in atoms.associations

--- a/robosystems/operations/information_block/schedule.py
+++ b/robosystems/operations/information_block/schedule.py
@@ -40,7 +40,7 @@ from robosystems.models.extensions import Structure
 from robosystems.models.extensions.roboledger import Entry, Fact
 from robosystems.operations.information_block.envelope import (
   association_to_connection,
-  element_to_lite,
+  elements_to_lites,
   fact_to_lite,
   load_base_envelope_atoms,
 )
@@ -279,7 +279,7 @@ def build_envelope(
       template=None,
       mechanics=mechanics,
     ),
-    elements=[element_to_lite(e) for e in atoms.elements],
+    elements=elements_to_lites(session, atoms.elements),
     connections=[
       association_to_connection(a, atoms.classifications_by_assoc.get(a.id, []))
       for a in atoms.associations

--- a/robosystems/operations/information_block/statement.py
+++ b/robosystems/operations/information_block/statement.py
@@ -54,7 +54,7 @@ from robosystems.models.extensions import Association, Element
 from robosystems.models.extensions.roboledger import Fact
 from robosystems.operations.information_block.envelope import (
   association_to_connection,
-  element_to_lite,
+  elements_to_lites,
   fact_to_lite,
   load_base_envelope_atoms,
   load_disclosure_id_for_structure,
@@ -280,7 +280,7 @@ def _build_statement_envelope(
       template=None,
       mechanics=mechanics,
     ),
-    elements=[element_to_lite(e) for e in atoms.elements],
+    elements=elements_to_lites(session, atoms.elements),
     connections=[
       association_to_connection(a, atoms.classifications_by_assoc.get(a.id, []))
       for a in atoms.associations

--- a/robosystems/operations/information_block/text_block.py
+++ b/robosystems/operations/information_block/text_block.py
@@ -34,7 +34,7 @@ from robosystems.models.extensions.roboledger import Fact
 from robosystems.operations.information_block.envelope import (
   DISCLOSURE_BLOCK_TYPE,
   association_to_connection,
-  element_to_lite,
+  elements_to_lites,
   fact_to_lite,
   load_base_envelope_atoms,
   load_disclosure_id_for_structure,
@@ -138,7 +138,7 @@ def build_text_block_envelope(
       template=None,
       mechanics=mechanics,
     ),
-    elements=[element_to_lite(e) for e in atoms.elements],
+    elements=elements_to_lites(session, atoms.elements),
     connections=[
       association_to_connection(a, atoms.classifications_by_assoc.get(a.id, []))
       for a in atoms.associations

--- a/tests/operations/information_block/test_disclosure_handlers.py
+++ b/tests/operations/information_block/test_disclosure_handlers.py
@@ -161,7 +161,7 @@ class TestBuildEnvelope:
 
     # Query order with associations: fact_set → taxonomy name →
     # associations → elements → rules → association classifications →
-    # verification_results.
+    # verification_results → documentation labels.
     session.execute.side_effect = [
       _exec_result(scalar=None),
       _exec_result(scalar="Driftline Extension"),
@@ -170,6 +170,7 @@ class TestBuildEnvelope:
       _exec_result(scalars_all=[]),
       _exec_result(all_rows=[]),
       _exec_result(scalars_all=[]),
+      _exec_result(all_rows=[]),
     ]
 
     envelope = disclosure_handlers.build_envelope(session, "struct_inventory_note")

--- a/tests/operations/information_block/test_envelope_elements.py
+++ b/tests/operations/information_block/test_envelope_elements.py
@@ -1,0 +1,108 @@
+"""Tests for element projection with documentation labels.
+
+Exercises :func:`element_to_lite`, :func:`load_documentation_for_elements`,
+and :func:`elements_to_lites` from
+:mod:`robosystems.operations.information_block.envelope` with a mocked
+SQLAlchemy session — no database required.
+
+The documentation-role label carries the catalog's authoritative value
+semantics (e.g. whether a percent driver is a growth rate or a
+rate-on-base fraction). Surfacing it on the envelope is what lets a
+code-blind MCP operator author lever values correctly.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from robosystems.operations.information_block.envelope import (
+  element_to_lite,
+  elements_to_lites,
+  load_documentation_for_elements,
+)
+
+
+def _make_element(elem_id: str = "elem_1", qname: str | None = None) -> MagicMock:
+  element = MagicMock()
+  element.id = elem_id
+  element.qname = qname
+  element.name = "Cost of Revenue Rate"
+  element.code = qname
+  element.element_type = "concept"
+  element.is_abstract = False
+  element.is_monetary = False
+  element.balance_type = "debit"
+  element.period_type = "duration"
+  element.item_type = "percent"
+  return element
+
+
+def _session_returning(rows: list[tuple[str, str]]) -> MagicMock:
+  session = MagicMock()
+  result = MagicMock()
+  result.all.return_value = rows
+  session.execute.return_value = result
+  return session
+
+
+class TestElementToLite:
+  def test_documentation_defaults_to_none(self) -> None:
+    lite = element_to_lite(_make_element())
+    assert lite.documentation is None
+
+  def test_documentation_attached_when_passed(self) -> None:
+    lite = element_to_lite(
+      _make_element(qname="rs-driver:CostOfRevenueRate"),
+      documentation="Cost of revenue as a fraction of the same month's revenues.",
+    )
+    assert lite.documentation is not None
+    assert "fraction" in lite.documentation
+
+
+class TestLoadDocumentationForElements:
+  def test_empty_ids_short_circuits_without_querying(self) -> None:
+    session = MagicMock()
+    assert load_documentation_for_elements(session, []) == {}
+    session.execute.assert_not_called()
+
+  def test_maps_element_id_to_label_text(self) -> None:
+    session = _session_returning(
+      [
+        ("elem_a", "Month-over-month revenue growth (compounding lever)."),
+        ("elem_b", "Rate-on-base lever: fraction of same-month revenues."),
+      ]
+    )
+    docs = load_documentation_for_elements(session, ["elem_a", "elem_b", "elem_c"])
+    assert docs == {
+      "elem_a": "Month-over-month revenue growth (compounding lever).",
+      "elem_b": "Rate-on-base lever: fraction of same-month revenues.",
+    }
+    session.execute.assert_called_once()
+
+
+class TestElementsToLites:
+  def test_attaches_documentation_by_id_with_one_query(self) -> None:
+    elements = [
+      _make_element("elem_growth", "rs-driver:RevenueGrowthRate"),
+      _make_element("elem_cogs", "rs-driver:CostOfRevenueRate"),
+      _make_element("elem_coa", None),
+    ]
+    session = _session_returning(
+      [
+        ("elem_growth", "Month-over-month revenue growth."),
+        ("elem_cogs", "Fraction of the same month's revenues."),
+      ]
+    )
+    lites = elements_to_lites(session, elements)
+    assert [lite.documentation for lite in lites] == [
+      "Month-over-month revenue growth.",
+      "Fraction of the same month's revenues.",
+      None,
+    ]
+    # Batched — one label query per envelope, never per element.
+    session.execute.assert_called_once()
+
+  def test_empty_element_list(self) -> None:
+    session = MagicMock()
+    assert elements_to_lites(session, []) == []
+    session.execute.assert_not_called()

--- a/tests/operations/information_block/test_forecast_handlers.py
+++ b/tests/operations/information_block/test_forecast_handlers.py
@@ -455,7 +455,14 @@ class TestBuildEnvelope:
     elements_result.scalars.return_value.all.return_value = [GROWTH]
     lever_set_result = MagicMock()
     lever_set_result.scalar_one_or_none.return_value = None
-    session.execute.side_effect = [computed_result, elements_result, lever_set_result]
+    docs_result = MagicMock()
+    docs_result.all.return_value = []
+    session.execute.side_effect = [
+      computed_result,
+      elements_result,
+      lever_set_result,
+      docs_result,
+    ]
 
     with patch.object(
       forecast_handlers, "load_base_envelope_atoms", return_value=atoms

--- a/tests/operations/information_block/test_metric_handlers.py
+++ b/tests/operations/information_block/test_metric_handlers.py
@@ -18,6 +18,13 @@ def _scalars(items: list[Any]) -> MagicMock:
   return result
 
 
+def _docs() -> MagicMock:
+  """The envelope's batched documentation-label query — empty result."""
+  result = MagicMock()
+  result.all.return_value = []
+  return result
+
+
 def _structure(*, mechanics: dict | None = None) -> MagicMock:
   s = MagicMock()
   s.id = "str_metrics"
@@ -148,6 +155,7 @@ class TestBuildEnvelope:
     session.execute.side_effect = [
       _scalars([fs1, fs2]),  # metric FactSets, period asc
       _scalars(facts),
+      _docs(),
     ]
 
     with patch.object(
@@ -182,7 +190,7 @@ class TestBuildEnvelope:
     structure = _structure()
     arcs = [_arc("el_wc", 1.0), _arc("el_cr", 2.0)]
     session = MagicMock()
-    session.execute.side_effect = [_scalars([])]  # no metric FactSets
+    session.execute.side_effect = [_scalars([]), _docs()]  # no metric FactSets
 
     with patch.object(
       metric_handlers,
@@ -210,6 +218,7 @@ class TestBuildEnvelope:
     session.get.return_value = fs2  # _load_metric_fact_sets pin path
     session.execute.side_effect = [
       _scalars([_fact("f2", "el_wc", 60.0, "fs2", P2)]),
+      _docs(),
     ]
     pinned_atoms = BaseEnvelopeAtoms(
       structure=structure,
@@ -252,7 +261,7 @@ class TestBuildEnvelope:
       }
     )
     session = MagicMock()
-    session.execute.side_effect = [_scalars([])]
+    session.execute.side_effect = [_scalars([]), _docs()]
 
     with patch.object(
       metric_handlers, "load_base_envelope_atoms", return_value=_atoms(structure)
@@ -271,7 +280,7 @@ class TestBuildEnvelope:
   def test_mechanics_default_when_column_null(self) -> None:
     structure = _structure(mechanics=None)
     session = MagicMock()
-    session.execute.side_effect = [_scalars([])]
+    session.execute.side_effect = [_scalars([]), _docs()]
 
     with patch.object(
       metric_handlers, "load_base_envelope_atoms", return_value=_atoms(structure)

--- a/tests/operations/information_block/test_statement_handlers.py
+++ b/tests/operations/information_block/test_statement_handlers.py
@@ -238,7 +238,7 @@ class TestBuildEnvelope:
 
     # Query order (1 association → elements + classifications queries run):
     # fact_set → taxonomy → associations → elements → rules → classifications →
-    # verification_results
+    # verification_results → documentation labels
     session.execute.side_effect = [
       _exec_result(scalar=None),  # latest fact set → None
       _exec_result(scalar="US GAAP"),  # taxonomy name
@@ -247,6 +247,7 @@ class TestBuildEnvelope:
       _exec_result(scalars_all=[]),  # rules
       _exec_result(all_rows=[]),  # association classifications
       _exec_result(scalars_all=[]),  # verification results
+      _exec_result(all_rows=[]),  # documentation labels
     ]
 
     build = statement_handlers.make_statement_handlers("income_statement")
@@ -333,7 +334,8 @@ class TestBuildEnvelope:
     # fact_set → taxonomy → associations → elements → rules →
     # assoc-classifications → verification_results →
     # facts (filtered by fact_set.id) →
-    # element-classifications (rendering projection trait lookup)
+    # element-classifications (rendering projection trait lookup) →
+    # documentation labels
     session.execute.side_effect = [
       _exec_result(scalar=fact_set),  # latest fact set
       _exec_result(scalar="US GAAP"),  # taxonomy name
@@ -344,6 +346,7 @@ class TestBuildEnvelope:
       _exec_result(scalars_all=[]),  # verification results
       _exec_result(scalars_all=[fact]),  # facts (filtered by fact_set.id)
       _exec_result(all_rows=[]),  # element classifications (Plan B)
+      _exec_result(all_rows=[]),  # documentation labels
     ]
 
     build = statement_handlers.make_statement_handlers("balance_sheet")
@@ -729,6 +732,7 @@ class TestSeriesMode:
       _exec_result(scalars_all=series_sets),  # the series (F-4)
       _exec_result(scalars_all=facts),  # facts across the series sets
       _exec_result(all_rows=[]),  # element classifications
+      _exec_result(all_rows=[]),  # documentation labels
     ]
     build = statement_handlers.make_statement_handlers("balance_sheet")
     return build(session, "struct_balance_sheet", scenario_id=scenario_id, series=True)
@@ -804,6 +808,7 @@ class TestSeriesMode:
         scalars_all=[self._fact("f_may", "fs_pinned", may, 100_000.0)]
       ),  # facts by pinned set — NO series query in between
       _exec_result(all_rows=[]),  # element classifications
+      _exec_result(all_rows=[]),  # documentation labels
     ]
     build = statement_handlers.make_statement_handlers("balance_sheet")
     envelope = build(


### PR DESCRIPTION
## Summary

Fixing Driftline's inverted cost-of-revenue lever surfaced three gaps a code-blind MCP operator (a customer's agent, Cowork) could not have recovered from the tool surface alone. This PR closes them server-side — the same doctrine as `get-close-playbook`: legibility is a property of the MCP surface, not a client-side skill.

## Changes

**1. Envelope elements carry catalog documentation.** `ElementLite` gains a `documentation` field populated from the documentation-role `ElementLabel` rows the taxonomy loader already lands in every tenant — the authoritative value semantics for driver/metric concepts (e.g. `CostOfRevenueRate` = *fraction of the same month's revenues*, not a growth rate). One batched label query per envelope via the new `elements_to_lites` helper, shared by all six builders. Flows to GraphQL (`all_fields` derivation) and MCP (`model_dump`) with no further wiring; additive on the wire.

**2. Corrected lever conventions.** `LeverAssertionRequest` claimed all percent levers are "decimals per month (0.03 = 3%/month)" — true for `RevenueGrowthRate`, wrong for rate-on-base levers. The description now distinguishes growth-rate vs rate-on-base semantics and points at the envelope's `documentation`; the create example demonstrates a `values_by_period` margin ramp. The `update-information-block` forecast arm now states the update→compute two-step (lever edits leave computed months stale until `compute-forecast`).

**3. Close-doctrine error copy.** `compute-forecast`'s no-actuals guardrails told operators to "generate monthly reports" — stale since #922 moved monthly statement sets to the close. They now say to close months (closing stamps statement sets), or fix CoA mapping and reclose.

## Testing

- New `test_envelope_elements.py` (batched documentation load, attach-by-id, back-compat default).
- Handler test mocks updated for the one extra label query per envelope build.
- `just test-all`: 2768 passed; the one failure is the known pre-existing `test_incremental_equals_full_load` parallel flake (passes in isolation, untouched by this change).
- Live smoke test: GraphQL `informationBlock.elements.documentation` on the Driftline forecast block returns all four lever docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)