### PR TITLE
feat(admin): manage org graph limits via admin API and CLI

### DIFF
--- a/robosystems/admin/commands/users_orgs.py
+++ b/robosystems/admin/commands/users_orgs.py
@@ -166,16 +166,19 @@ def list_orgs(client, limit):
   table.add_column("Type", overflow="fold")
   table.add_column("Users", justify="right")
   table.add_column("Graphs", justify="right")
+  table.add_column("Limit", justify="right")
   table.add_column("Credits", justify="right")
   table.add_column("Created", overflow="fold")
 
   for org in orgs_list:
+    max_graphs = org.get("max_graphs")
     table.add_row(
       org["org_id"],
       org["name"],
       org["org_type"],
       str(org["user_count"]),
       str(org["graph_count"]),
+      "unlimited" if max_graphs == -1 else str(max_graphs),
       f"{org['total_credits']:.2f}",
       org["created_at"][:10],
     )
@@ -203,6 +206,13 @@ def get_org(client, org_id):
   click.echo(f"  Users: {org['user_count']}")
   click.echo(f"  Graphs: {org['graph_count']}")
   click.echo(f"  Total Credits: {org['total_credits']:.2f}")
+
+  click.echo("\nLIMITS")
+  max_graphs = org.get("max_graphs")
+  if max_graphs == -1:
+    click.echo("  Max Graphs: unlimited")
+  else:
+    click.echo(f"  Max Graphs: {max_graphs}")
 
   click.echo("\nBILLING")
   click.echo(f"  Payment Method: {'Yes' if org.get('has_payment_method') else 'No'}")
@@ -240,6 +250,12 @@ def get_org(client, org_id):
 @click.option("--billing-email", help="Billing email address")
 @click.option("--billing-contact-name", help="Billing contact name")
 @click.option("--payment-terms", help="Payment terms (e.g., net_30, net_60)")
+@click.option(
+  "--max-graphs",
+  type=int,
+  default=None,
+  help="Maximum graphs the org may create (-1 for unlimited)",
+)
 @click.pass_obj
 def update_org(
   client,
@@ -248,8 +264,9 @@ def update_org(
   billing_email,
   billing_contact_name,
   payment_terms,
+  max_graphs,
 ):
-  """Update organization billing settings."""
+  """Update organization billing settings and limits."""
   params = {}
 
   if invoice_billing is not None:
@@ -260,6 +277,10 @@ def update_org(
     params["billing_contact_name"] = billing_contact_name
   if payment_terms:
     params["payment_terms"] = payment_terms
+  if max_graphs is not None:
+    if max_graphs < -1:
+      raise click.BadParameter("must be >= -1 (-1 means unlimited)")
+    params["max_graphs"] = max_graphs
 
   if not params:
     click.echo("❌ No updates specified")
@@ -275,3 +296,8 @@ def update_org(
   click.echo(f"   Payment Terms: {org.get('payment_terms', 'N/A')}")
   if billing_email:
     click.echo(f"   Billing Email: {org.get('billing_email', 'N/A')}")
+  if max_graphs is not None:
+    updated_limit = org.get("max_graphs")
+    click.echo(
+      f"   Max Graphs: {'unlimited' if updated_limit == -1 else updated_limit}"
+    )

--- a/robosystems/models/api/admin/__init__.py
+++ b/robosystems/models/api/admin/__init__.py
@@ -25,7 +25,7 @@ from .graphs import (
   GraphStorageResponse,
 )
 from .invoice import InvoiceLineItemResponse, InvoiceResponse
-from .orgs import OrgGraphInfo, OrgResponse, OrgUserInfo
+from .orgs import OrgGraphInfo, OrgResponse, OrgUpdateRequest, OrgUserInfo
 from .subscription import (
   SubscriptionCreateRequest,
   SubscriptionResponse,
@@ -61,6 +61,7 @@ __all__ = [
   "InvoiceResponse",
   "OrgGraphInfo",
   "OrgResponse",
+  "OrgUpdateRequest",
   "OrgUserInfo",
   "RepositoryCreditPoolResponse",
   "SubscriptionCreateRequest",

--- a/robosystems/models/api/admin/orgs.py
+++ b/robosystems/models/api/admin/orgs.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class OrgUserInfo(BaseModel):
@@ -32,6 +32,7 @@ class OrgResponse(BaseModel):
   org_type: str
   user_count: int
   graph_count: int
+  max_graphs: int
   total_credits: float
   stripe_customer_id: str | None
   has_payment_method: bool
@@ -44,3 +45,17 @@ class OrgResponse(BaseModel):
   updated_at: datetime
   users: list[OrgUserInfo]
   graphs: list[OrgGraphInfo]
+
+
+class OrgUpdateRequest(BaseModel):
+  """Request to update organization billing settings and limits."""
+
+  invoice_billing_enabled: bool | None = None
+  billing_email: str | None = None
+  billing_contact_name: str | None = None
+  payment_terms: str | None = None
+  max_graphs: int | None = Field(
+    default=None,
+    ge=-1,
+    description="Maximum graphs the org may create (-1 for unlimited)",
+  )

--- a/robosystems/routers/admin/orgs.py
+++ b/robosystems/routers/admin/orgs.py
@@ -5,11 +5,12 @@ from datetime import UTC, datetime
 from fastapi import APIRouter, HTTPException, Query, Request, status
 from sqlalchemy import func
 
+from ...config.tuning import TuningConfig
 from ...database import get_db_session
 from ...logger import get_logger
 from ...middleware.auth.admin import require_admin
-from ...models.api.admin import OrgGraphInfo, OrgResponse, OrgUserInfo
-from ...models.core import Graph, Org, OrgUser, User
+from ...models.api.admin import OrgGraphInfo, OrgResponse, OrgUpdateRequest, OrgUserInfo
+from ...models.core import Graph, Org, OrgLimits, OrgUser, User
 from ...models.core.billing import BillingAuditLog, BillingCustomer
 from ...models.core.graph.graph_credits import GraphCredits
 
@@ -35,6 +36,18 @@ def _get_org_total_credits(org_id: str, session) -> float:
     .scalar()
   ) or 0.0
   return float(total)
+
+
+def _get_org_max_graphs(org_id: str, session) -> int:
+  """Get the effective graph limit for an organization.
+
+  Falls back to the environment default when no OrgLimits row exists yet
+  (rows are created lazily on registration or first limit check).
+  """
+  limits = OrgLimits.get_by_org_id(org_id, session)
+  if limits:
+    return limits.max_graphs
+  return TuningConfig.get_org_graphs_default_limit()
 
 
 def _get_org_customer(org_id: str, session) -> BillingCustomer | None:
@@ -131,6 +144,7 @@ async def list_orgs(
           org_type=org.org_type.value,
           user_count=user_count,
           graph_count=graph_count,
+          max_graphs=_get_org_max_graphs(org.id, session),
           total_credits=total_credits_sum,
           stripe_customer_id=customer.stripe_customer_id if customer else None,
           has_payment_method=customer.has_payment_method if customer else False,
@@ -196,6 +210,7 @@ async def get_org(request: Request, org_id: str):
       org_type=org.org_type.value,
       user_count=len(users),
       graph_count=len(graph_infos),
+      max_graphs=_get_org_max_graphs(org_id, session),
       total_credits=total_credits_sum,
       stripe_customer_id=customer.stripe_customer_id if customer else None,
       has_payment_method=customer.has_payment_method if customer else False,
@@ -220,12 +235,9 @@ async def get_org(request: Request, org_id: str):
 async def update_org(
   request: Request,
   org_id: str,
-  invoice_billing_enabled: bool | None = None,
-  billing_email: str | None = None,
-  billing_contact_name: str | None = None,
-  payment_terms: str | None = None,
+  data: OrgUpdateRequest,
 ):
-  """Update organization billing settings."""
+  """Update organization billing settings and limits."""
   session = next(get_db_session())
   try:
     org = Org.get_by_id(org_id, session)
@@ -241,30 +253,37 @@ async def update_org(
     new_values = {}
 
     if (
-      invoice_billing_enabled is not None
-      and invoice_billing_enabled != customer.invoice_billing_enabled
+      data.invoice_billing_enabled is not None
+      and data.invoice_billing_enabled != customer.invoice_billing_enabled
     ):
       old_values["invoice_billing_enabled"] = customer.invoice_billing_enabled
-      new_values["invoice_billing_enabled"] = invoice_billing_enabled
-      customer.invoice_billing_enabled = invoice_billing_enabled
+      new_values["invoice_billing_enabled"] = data.invoice_billing_enabled
+      customer.invoice_billing_enabled = data.invoice_billing_enabled
 
-    if billing_email is not None and billing_email != customer.billing_email:
+    if data.billing_email is not None and data.billing_email != customer.billing_email:
       old_values["billing_email"] = customer.billing_email
-      new_values["billing_email"] = billing_email
-      customer.billing_email = billing_email
+      new_values["billing_email"] = data.billing_email
+      customer.billing_email = data.billing_email
 
     if (
-      billing_contact_name is not None
-      and billing_contact_name != customer.billing_contact_name
+      data.billing_contact_name is not None
+      and data.billing_contact_name != customer.billing_contact_name
     ):
       old_values["billing_contact_name"] = customer.billing_contact_name
-      new_values["billing_contact_name"] = billing_contact_name
-      customer.billing_contact_name = billing_contact_name
+      new_values["billing_contact_name"] = data.billing_contact_name
+      customer.billing_contact_name = data.billing_contact_name
 
-    if payment_terms is not None and payment_terms != customer.payment_terms:
+    if data.payment_terms is not None and data.payment_terms != customer.payment_terms:
       old_values["payment_terms"] = customer.payment_terms
-      new_values["payment_terms"] = payment_terms
-      customer.payment_terms = payment_terms
+      new_values["payment_terms"] = data.payment_terms
+      customer.payment_terms = data.payment_terms
+
+    if data.max_graphs is not None:
+      limits = OrgLimits.get_or_create_for_org(org_id, session)
+      if data.max_graphs != limits.max_graphs:
+        old_values["max_graphs"] = limits.max_graphs
+        new_values["max_graphs"] = data.max_graphs
+        limits.update_limit(data.max_graphs, session)
 
     customer.updated_at = datetime.now(UTC)
     session.commit()
@@ -287,7 +306,7 @@ async def update_org(
         event_type="customer.updated",
         org_id=customer.org_id,
         actor_type="admin",
-        description=f"Org billing updated by admin {request.state.admin.get('name', 'unknown')}",
+        description=f"Org settings updated by admin {request.state.admin.get('name', 'unknown')}",
         event_data={
           "admin_key_id": request.state.admin_key_id,
           "admin_name": request.state.admin.get("name"),
@@ -306,7 +325,7 @@ async def update_org(
       log_changes["payment_terms"] = "[REDACTED]"
 
     logger.info(
-      f"Admin updated org {org_id} billing",
+      f"Admin updated org {org_id}",
       extra={
         "admin_key_id": request.state.admin_key_id,
         "org_id": org_id,
@@ -320,6 +339,7 @@ async def update_org(
       org_type=org.org_type.value,
       user_count=len(user_infos),
       graph_count=len(graph_infos),
+      max_graphs=_get_org_max_graphs(org_id, session),
       total_credits=total_credits_sum,
       stripe_customer_id=customer.stripe_customer_id,
       has_payment_method=customer.has_payment_method,

--- a/tests/admin/test_cli.py
+++ b/tests/admin/test_cli.py
@@ -662,6 +662,7 @@ class TestOrgsCommands:
         "org_type": "team",
         "user_count": 5,
         "graph_count": 2,
+        "max_graphs": 2,
         "total_credits": 16000.0,
         "created_at": "2025-01-01T00:00:00Z",
       }
@@ -671,6 +672,7 @@ class TestOrgsCommands:
     assert result.exit_code == 0
     assert "Acme Corp" in result.output
     assert "org-1" in result.output
+    assert "Limit" in result.output
 
   def test_get(self, runner, mock_make_request):
     mock_make_request.return_value = {
@@ -679,6 +681,7 @@ class TestOrgsCommands:
       "org_type": "team",
       "user_count": 5,
       "graph_count": 2,
+      "max_graphs": 2,
       "total_credits": 16000.0,
       "has_payment_method": True,
       "invoice_billing_enabled": True,
@@ -695,6 +698,7 @@ class TestOrgsCommands:
     assert "Acme Corp" in result.output
     assert "Invoice Billing: Yes" in result.output
     assert "billing@acme.com" in result.output
+    assert "Max Graphs: 2" in result.output
 
   def test_update(self, runner, mock_make_request):
     mock_make_request.return_value = {
@@ -731,6 +735,56 @@ class TestOrgsCommands:
       },
     )
     assert "Updated org org-1" in result.output
+
+  def test_update_max_graphs(self, runner, mock_make_request):
+    mock_make_request.return_value = {
+      "org_id": "org-1",
+      "name": "Acme Corp",
+      "invoice_billing_enabled": False,
+      "payment_terms": "net_30",
+      "max_graphs": 2,
+    }
+
+    result = runner.invoke(
+      cli,
+      ["-e", "dev", "orgs", "update", "org-1", "--max-graphs", "2"],
+    )
+    assert result.exit_code == 0
+    mock_make_request.assert_called_once_with(
+      "PATCH",
+      "/admin/v1/orgs/org-1",
+      data={"max_graphs": 2},
+    )
+    assert "Max Graphs: 2" in result.output
+
+  def test_update_max_graphs_unlimited(self, runner, mock_make_request):
+    mock_make_request.return_value = {
+      "org_id": "org-1",
+      "name": "Acme Corp",
+      "invoice_billing_enabled": False,
+      "payment_terms": "net_30",
+      "max_graphs": -1,
+    }
+
+    result = runner.invoke(
+      cli,
+      ["-e", "dev", "orgs", "update", "org-1", "--max-graphs", "-1"],
+    )
+    assert result.exit_code == 0
+    mock_make_request.assert_called_once_with(
+      "PATCH",
+      "/admin/v1/orgs/org-1",
+      data={"max_graphs": -1},
+    )
+    assert "Max Graphs: unlimited" in result.output
+
+  def test_update_max_graphs_below_minimum_rejected(self, runner, mock_make_request):
+    result = runner.invoke(
+      cli,
+      ["-e", "dev", "orgs", "update", "org-1", "--max-graphs", "-2"],
+    )
+    assert result.exit_code != 0
+    mock_make_request.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/routers/admin/test_orgs.py
+++ b/tests/routers/admin/test_orgs.py
@@ -1,0 +1,217 @@
+"""Tests for admin orgs router."""
+
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from main import app
+from robosystems.models.core import Org, OrgLimits, OrgType, OrgUser, User
+
+
+@pytest.fixture
+def mock_admin_auth(monkeypatch):
+  """Mock admin authentication to bypass AWS Secrets Manager."""
+
+  def mock_verify_admin_key(self, api_key):
+    """Mock verify_admin_key to always return valid admin metadata."""
+    return {
+      "key_id": "admin",
+      "name": "Test Admin",
+      "permissions": ["*"],
+      "created_by": "system",
+    }
+
+  monkeypatch.setattr(
+    "robosystems.middleware.auth.admin.AdminAuthMiddleware.verify_admin_key",
+    mock_verify_admin_key,
+  )
+  yield
+
+
+@pytest.fixture
+def test_user(db_session: Session):
+  """Create a test user."""
+  unique_id = str(uuid.uuid4())[:8]
+  user = User(
+    id=f"test_user_{unique_id}",
+    email=f"test+{unique_id}@example.com",
+    name="Test User",
+    password_hash="test_hash",
+  )
+  db_session.add(user)
+  db_session.commit()
+  db_session.refresh(user)
+  return user
+
+
+@pytest.fixture
+def test_org(db_session: Session, test_user):
+  """Create a test organization."""
+  org = Org.create(
+    name="Test Organization",
+    org_type=OrgType.PERSONAL,
+    session=db_session,
+  )
+  OrgUser.create(
+    org_id=org.id,
+    user_id=test_user.id,
+    role="OWNER",
+    session=db_session,
+  )
+  return org
+
+
+@pytest.fixture
+def client():
+  """Create a test client."""
+  return TestClient(app)
+
+
+ADMIN_HEADERS = {"Authorization": "Bearer test-admin-key"}
+
+
+class TestGetOrg:
+  """Tests for the get org endpoint."""
+
+  def test_get_org_includes_max_graphs(
+    self, client, db_session, test_org, mock_admin_auth
+  ):
+    """Org details expose the effective graph limit."""
+    limits = OrgLimits.get_or_create_for_org(test_org.id, db_session)
+    limits.update_limit(3, db_session)
+
+    response = client.get(f"/admin/v1/orgs/{test_org.id}", headers=ADMIN_HEADERS)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["org_id"] == test_org.id
+    assert data["max_graphs"] == 3
+
+  def test_get_org_without_limits_row_uses_default(
+    self, client, db_session, test_org, mock_admin_auth
+  ):
+    """Orgs with no OrgLimits row report the environment default without creating one."""
+    response = client.get(f"/admin/v1/orgs/{test_org.id}", headers=ADMIN_HEADERS)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data["max_graphs"], int)
+    assert OrgLimits.get_by_org_id(test_org.id, db_session) is None
+
+  def test_get_org_not_found(self, client, mock_admin_auth):
+    """Unknown org returns 404."""
+    response = client.get("/admin/v1/orgs/org_missing", headers=ADMIN_HEADERS)
+
+    assert response.status_code == 404
+
+
+class TestListOrgs:
+  """Tests for the list orgs endpoint."""
+
+  def test_list_orgs_includes_max_graphs(
+    self, client, db_session, test_org, mock_admin_auth
+  ):
+    """Org list rows expose the effective graph limit."""
+    limits = OrgLimits.get_or_create_for_org(test_org.id, db_session)
+    limits.update_limit(1, db_session)
+
+    response = client.get("/admin/v1/orgs", headers=ADMIN_HEADERS)
+
+    assert response.status_code == 200
+    rows = {org["org_id"]: org for org in response.json()}
+    assert rows[test_org.id]["max_graphs"] == 1
+
+
+class TestUpdateOrg:
+  """Tests for the update org endpoint."""
+
+  def test_update_max_graphs(self, client, db_session, test_org, mock_admin_auth):
+    """max_graphs updates the OrgLimits row and is reflected in the response."""
+    limits = OrgLimits.get_or_create_for_org(test_org.id, db_session)
+    limits.update_limit(1, db_session)
+
+    response = client.patch(
+      f"/admin/v1/orgs/{test_org.id}",
+      json={"max_graphs": 2},
+      headers=ADMIN_HEADERS,
+    )
+
+    assert response.status_code == 200
+    assert response.json()["max_graphs"] == 2
+
+    db_session.expire_all()
+    updated = OrgLimits.get_by_org_id(test_org.id, db_session)
+    assert updated is not None
+    assert updated.max_graphs == 2
+
+  def test_update_max_graphs_creates_limits_row(
+    self, client, db_session, test_org, mock_admin_auth
+  ):
+    """Setting max_graphs on an org without a limits row creates one."""
+    assert OrgLimits.get_by_org_id(test_org.id, db_session) is None
+
+    response = client.patch(
+      f"/admin/v1/orgs/{test_org.id}",
+      json={"max_graphs": 5},
+      headers=ADMIN_HEADERS,
+    )
+
+    assert response.status_code == 200
+    assert response.json()["max_graphs"] == 5
+
+    db_session.expire_all()
+    created = OrgLimits.get_by_org_id(test_org.id, db_session)
+    assert created is not None
+    assert created.max_graphs == 5
+
+  def test_update_max_graphs_unlimited(
+    self, client, db_session, test_org, mock_admin_auth
+  ):
+    """-1 is accepted and means unlimited."""
+    response = client.patch(
+      f"/admin/v1/orgs/{test_org.id}",
+      json={"max_graphs": -1},
+      headers=ADMIN_HEADERS,
+    )
+
+    assert response.status_code == 200
+    assert response.json()["max_graphs"] == -1
+
+  def test_update_max_graphs_below_minimum_rejected(
+    self, client, test_org, mock_admin_auth
+  ):
+    """Values below -1 are rejected by validation."""
+    response = client.patch(
+      f"/admin/v1/orgs/{test_org.id}",
+      json={"max_graphs": -2},
+      headers=ADMIN_HEADERS,
+    )
+
+    assert response.status_code == 422
+
+  def test_update_billing_fields_via_body(
+    self, client, db_session, test_org, mock_admin_auth
+  ):
+    """Billing settings are read from the JSON body (the admin CLI's contract)."""
+    response = client.patch(
+      f"/admin/v1/orgs/{test_org.id}",
+      json={"billing_email": "billing@example.com", "invoice_billing_enabled": True},
+      headers=ADMIN_HEADERS,
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["billing_email"] == "billing@example.com"
+    assert data["invoice_billing_enabled"] is True
+
+  def test_update_org_not_found(self, client, mock_admin_auth):
+    """Unknown org returns 404."""
+    response = client.patch(
+      "/admin/v1/orgs/org_missing",
+      json={"max_graphs": 2},
+      headers=ADMIN_HEADERS,
+    )
+
+    assert response.status_code == 404

--- a/tests/routers/admin/test_subscription.py
+++ b/tests/routers/admin/test_subscription.py
@@ -766,7 +766,7 @@ class TestUpdateOrg:
 
     response = client.patch(
       f"/admin/v1/orgs/{test_org.id}",
-      params=payload,
+      json=payload,
       headers={"Authorization": "Bearer test-admin-key"},
     )
 
@@ -784,7 +784,7 @@ class TestUpdateOrg:
 
     response = client.patch(
       f"/admin/v1/orgs/{test_org.id}",
-      params=payload,
+      json=payload,
       headers={"Authorization": "Bearer test-admin-key"},
     )
 
@@ -805,7 +805,7 @@ class TestUpdateOrg:
 
     response = client.patch(
       f"/admin/v1/orgs/{test_org.id}",
-      params=payload,
+      json=payload,
       headers={"Authorization": "Bearer test-admin-key"},
     )
 
@@ -822,7 +822,7 @@ class TestUpdateOrg:
 
     response = client.patch(
       f"/admin/v1/orgs/{test_org.id}",
-      params=payload,
+      json=payload,
       headers={"Authorization": "Bearer test-admin-key"},
     )
 
@@ -845,6 +845,6 @@ class TestUpdateOrg:
 
     response = client.patch(
       f"/admin/v1/orgs/{test_org.id}",
-      params=payload,
+      json=payload,
     )
     assert response.status_code == 401


### PR DESCRIPTION
## Summary

Org graph limits (`OrgLimits.max_graphs`) had no admin surface — raising a customer's limit required direct database access. Since the production default is 0 (every customer is manually opted in), this is a routine support operation and needs to be a one-liner. This PR makes the limit manageable through the admin API and CLI.

## Changes

**Admin API (`routers/admin/orgs.py`, `models/api/admin/orgs.py`)**

- `PATCH /admin/v1/orgs/{org_id}` now accepts `max_graphs` (validated `>= -1`, where `-1` means unlimited) and applies it via `OrgLimits.get_or_create_for_org` + `update_limit`, included in the existing billing audit-log event
- `OrgResponse` exposes `max_graphs` on get/list/update responses, falling back to the tuning default when the org has no `OrgLimits` row yet (no row is created on reads)
- The update endpoint now takes a Pydantic `OrgUpdateRequest` body, matching the subscription update pattern. Previously it declared bare scalar params (query string) while the admin CLI sent a JSON body — so CLI billing updates were silently ignored. This fixes that contract mismatch.

**Admin CLI (`admin/commands/users_orgs.py`)**

- `orgs update --max-graphs N` (with `-1` for unlimited, values below `-1` rejected client-side)
- `orgs get` prints a LIMITS section with the current max graphs
- `orgs list` adds a Limit column so opt-in status is scannable across orgs

## Testing

- `just test routers/admin/test_orgs.py` — 10 passed (new router tests: get/list/update including limit creation, unlimited, validation rejection, body-contract regression test for billing fields)
- `just test admin` — 70 passed (includes new CLI tests for `--max-graphs`)
- `just test-code` — ruff, format, basedpyright, cf-lint all clean
- Verified end-to-end against the local dev stack: `orgs get` shows the limit, `orgs update --max-graphs 2` applies and reverts correctly
