### PR TITLE
feat(close): backfill-plan-history — compile monthly statement history behind the close boundary

### DIFF
--- a/robosystems/middleware/mcp/tools/fiscal_calendar_tools.py
+++ b/robosystems/middleware/mcp/tools/fiscal_calendar_tools.py
@@ -1,6 +1,6 @@
 """Fiscal calendar MCP tools for AI accounting close workflows.
 
-Three tools that expose the fiscal calendar state machine to Claude:
+Four tools that expose the fiscal calendar state machine to Claude:
 
 1. get-fiscal-calendar — read current state (closed_through, close_target,
    gap, closeable_now, blockers)
@@ -8,13 +8,16 @@ Three tools that expose the fiscal calendar state machine to Claude:
    the period, marks the period closed, advances closed_through, auto-advances
    close_target when reached
 3. reopen-period — undo a prior close. Requires a reason for the audit log.
+4. backfill-plan-history — compile monthly statement history behind the
+   close boundary (chunked reopen → reclose restamps, feeding the plan's
+   historical columns).
 
 Initialize and set-close-target are deliberately NOT exposed as MCP tools:
 initialize is a one-time onboarding operation done via the UI, and
 set-close-target is a configuration action that normal close workflows
 don't need (auto-advance handles it). Both are still available via REST.
 
-All three tools route through `operations/roboledger/{reads,commands}/
+All tools route through `operations/roboledger/{reads,commands}/
 fiscal_calendar.py` so MCP, GraphQL, and the REST operation surface
 share one source of truth for both behavior and wire shape.
 """
@@ -28,9 +31,16 @@ from robosystems.middleware.mcp.tools._gate import (
   MCPExtensionGateError,
   require_graph_extension_mcp,
 )
+from robosystems.models.api.extensions.fiscal_calendar import (
+  BackfillPlanHistoryRequest,
+)
 from robosystems.operations.roboledger.commands.fiscal_calendar import (
+  BackfillPreconditionError,
   PeriodNotClosedError,
   PeriodNotFoundInLedgerError,
+)
+from robosystems.operations.roboledger.commands.fiscal_calendar import (
+  backfill_plan_history as ops_backfill_plan_history,
 )
 from robosystems.operations.roboledger.commands.fiscal_calendar import (
   close_period as ops_close_period,
@@ -483,4 +493,160 @@ class ReopenPeriodTool:
       return {"error": "calendar_error", "message": str(exc)}
     except Exception as exc:
       logger.warning(f"reopen-period failed: {exc}")
+      return {"error": str(exc)}
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# backfill-plan-history
+# ────────────────────────────────────────────────────────────────────────────
+
+
+class BackfillPlanHistoryTool:
+  """Compile monthly statement history behind the close boundary."""
+
+  def __init__(self, graph_client):
+    self.client = graph_client
+
+  def get_tool_definition(self) -> dict[str, Any]:
+    return {
+      "name": "backfill-plan-history",
+      "description": """Compile monthly statement history behind the close boundary — the plan's historical columns.
+
+**WHEN TO USE:**
+- The Plan page shows only annual (or missing) columns because historical
+  months were closed before close-time statement stamping existed, or were
+  baseline-closed at calendar initialization and never really closed
+- A tenant with deep ledger history (QB sync) wants monthly statement
+  columns further back than the calendar currently covers
+- After onboarding: CoA mapping is done and the user wants their history
+  compiled into the monthly statement series
+
+**WHAT IT DOES (per call, oldest month first):**
+1. Finds the earliest month with ledger data (the hard floor — a request
+   can never reach past real data)
+2. Seeds any missing FiscalPeriod rows back to the clamped start
+   (baseline-closed)
+3. For each month in range that lacks canonical statement FactSets, runs
+   the REAL reopen → reclose cycle: balance validation, statement
+   stamping, statement rules, and audit events — identical to a manual
+   restamp
+4. Stops after max_periods months and reports the rest in
+   remaining_periods — call again to continue (chunked, resumable)
+
+**IDEMPOTENT / SAFE:**
+- Months that already have canonical statement sets are never touched
+- Months holding draft entries are SKIPPED, never posted — the backfill
+  refuses to commit ledger changes nobody reviewed (resolve via
+  list-period-drafts + close-period, then re-run)
+- A failed reclose halts the run (no holes in the series); the failure
+  rides that month's outcome
+- The open month and close_target are never touched
+
+**PARAMETERS:**
+- start_period (optional): YYYY-MM to backfill from. Defaults to the
+  earliest month with ledger data; clamped there when set earlier.
+- max_periods (optional, default 12, max 24): months to restamp this call.
+- allow_stale_sync (optional): override the sync gate on each reclose —
+  rarely needed since historical months predate the last sync.
+- note (optional): attached to each close audit event.
+
+**RETURNS:**
+- earliest_available_period / effective_start_period / closed_through:
+  the resolved range
+- period_rows_created: FiscalPeriod rows seeded for uncovered months
+- processed: per-month outcomes (stamped | skipped_drafts | failed) with
+  statement stamp + rule details
+- remaining_periods: months still needing stamps — LOOP UNTIL EMPTY
+- fiscal_calendar: refreshed calendar state
+
+**WORKFLOW:**
+1. Call with defaults (or a start_period the user chose)
+2. Report per-month outcomes to the user
+3. If remaining_periods is non-empty, call again
+4. Verify in the Plan page / statement series when done""",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "start_period": {
+            "type": "string",
+            "description": (
+              "YYYY-MM to backfill from (default: earliest month with "
+              "ledger data; clamped to it when earlier)"
+            ),
+            "pattern": r"^\d{4}-(0[1-9]|1[0-2])$",
+          },
+          "max_periods": {
+            "type": "integer",
+            "description": "Months to restamp in this call (default 12, max 24)",
+            "minimum": 1,
+            "maximum": 24,
+          },
+          "allow_stale_sync": {
+            "type": "boolean",
+            "description": (
+              "Override the sync-currency gate on each reclose (default "
+              "false). Rarely needed — historical months predate the last "
+              "sync in the normal case."
+            ),
+          },
+          "note": {
+            "type": "string",
+            "description": "Optional note attached to each close audit event",
+          },
+        },
+        "required": [],
+      },
+    }
+
+  async def execute(self, arguments: dict[str, Any]) -> Any:
+    graph_id = self.client.graph_id
+
+    try:
+      require_graph_extension_mcp("roboledger", graph_id)
+    except MCPExtensionGateError as exc:
+      return {"error": exc.code, "message": exc.message}
+
+    body = BackfillPlanHistoryRequest(
+      start_period=arguments.get("start_period"),
+      max_periods=int(arguments.get("max_periods", 12)),
+      allow_stale_sync=bool(arguments.get("allow_stale_sync", False)),
+      note=arguments.get("note"),
+    )
+    actor_id = getattr(self.client, "user_id", None) or f"mcp:{graph_id}"
+
+    svc = FiscalCalendarService()
+    close_svc = PeriodCloseService(svc)
+
+    try:
+      with extensions_session(graph_id) as session, _platform_session() as platform_db:
+        result = ops_backfill_plan_history(
+          session,
+          platform_db,
+          graph_id,
+          body,
+          actor_id=actor_id,
+          service=svc,
+          close_service=close_svc,
+          actor_type="agent",
+        )
+        fc_payload = result.fiscal_calendar.model_dump(mode="json")
+        has_sync, _ = qb_sync_state(platform_db, graph_id)
+        fc_payload["has_sync_connection"] = has_sync
+        return {
+          "earliest_available_period": result.earliest_available_period,
+          "effective_start_period": result.effective_start_period,
+          "closed_through": result.closed_through,
+          "period_rows_created": result.period_rows_created,
+          "processed": [
+            outcome.model_dump(mode="json") for outcome in result.processed
+          ],
+          "remaining_periods": result.remaining_periods,
+          "fiscal_calendar": fc_payload,
+        }
+    except BackfillPreconditionError as exc:
+      return {"error": exc.code, "message": str(exc)}
+    except FiscalCalendarError as exc:
+      return {"error": "calendar_error", "message": str(exc)}
+    except Exception as exc:
+      logger.warning(f"backfill-plan-history failed: {exc}")
       return {"error": str(exc)}

--- a/robosystems/middleware/mcp/tools/manager.py
+++ b/robosystems/middleware/mcp/tools/manager.py
@@ -250,6 +250,7 @@ class GraphMCPTools:
     self.get_fiscal_calendar_tool = None
     self.close_period_tool = None
     self.reopen_period_tool = None
+    self.backfill_plan_history_tool = None
     # Information Block read tools (get/list-information-block) — these
     # replaced the retired schedule-specific reads (list-schedule-structures,
     # get-schedule-facts).
@@ -257,6 +258,7 @@ class GraphMCPTools:
     self.list_information_blocks_tool = None
     if self._has_extension("roboledger") and env.ROBOLEDGER_ENABLED and not read_only:
       from .fiscal_calendar_tools import (
+        BackfillPlanHistoryTool,
         ClosePeriodTool,
         GetFiscalCalendarTool,
         ReopenPeriodTool,
@@ -286,6 +288,7 @@ class GraphMCPTools:
       self.get_fiscal_calendar_tool = GetFiscalCalendarTool(graph_client)
       self.close_period_tool = ClosePeriodTool(graph_client)
       self.reopen_period_tool = ReopenPeriodTool(graph_client)
+      self.backfill_plan_history_tool = BackfillPlanHistoryTool(graph_client)
 
     # Information Block reads stay available on read-only *tenant* graphs (no
     # read_only guard) but are excluded on shared repos: they read the
@@ -664,6 +667,8 @@ class GraphMCPTools:
       tools.append(self.close_period_tool.get_tool_definition())
     if self.reopen_period_tool is not None:
       tools.append(self.reopen_period_tool.get_tool_definition())
+    if self.backfill_plan_history_tool is not None:
+      tools.append(self.backfill_plan_history_tool.get_tool_definition())
     return tools
 
   def _get_taxonomy_tool_definitions(self) -> list[dict[str, Any]]:
@@ -1239,6 +1244,15 @@ class GraphMCPTools:
             "Requires roboledger extension and ROBOLEDGER_ENABLED=true."
           )
         result = await self.reopen_period_tool.execute(arguments)
+        return result if return_raw else json.dumps(result, indent=2)
+
+      elif name == "backfill-plan-history":
+        if self.backfill_plan_history_tool is None:
+          raise ValueError(
+            "backfill-plan-history tool is not available. "
+            "Requires roboledger extension and ROBOLEDGER_ENABLED=true."
+          )
+        result = await self.backfill_plan_history_tool.execute(arguments)
         return result if return_raw else json.dumps(result, indent=2)
 
       # Taxonomy mapping tools

--- a/robosystems/middleware/mcp/tools/playbook_tools.py
+++ b/robosystems/middleware/mcp/tools/playbook_tools.py
@@ -191,6 +191,7 @@ def _build_playbook(mode: str) -> dict[str, Any]:
     "create-event-block",
     "list-period-drafts",
     "close-period",
+    "backfill-plan-history",
     "search-documents",
     "get-graph-schema",
     "get-unmapped-elements",

--- a/robosystems/models/api/extensions/fiscal_calendar.py
+++ b/robosystems/models/api/extensions/fiscal_calendar.py
@@ -167,6 +167,66 @@ class ReopenPeriodRequest(BaseModel):
   note: str | None = Field(None, description="Additional free-form note")
 
 
+class BackfillPlanHistoryRequest(BaseModel):
+  """Compile monthly statement history behind the close boundary.
+
+  Extends the fiscal calendar backward (seeding any missing
+  `FiscalPeriod` rows as baseline-closed) and restamps each closed
+  month that lacks canonical statement FactSets by running the real
+  reopen → reclose cycle — the same path a manual restamp takes, so
+  balance validation, statement rules, and audit events all apply.
+  Feeds the plan's monthly historical columns.
+
+  Chunked: each call processes at most ``max_periods`` months (oldest
+  first) and reports what's left in ``remaining_periods`` — loop until
+  it comes back empty. Idempotent: months that already have canonical
+  sets are never touched, so re-running is safe.
+
+  The backfill never reaches past the tenant's earliest ledger data —
+  ``start_period`` is clamped to the first month with entries.
+  """
+
+  start_period: str | None = Field(
+    None,
+    pattern=PERIOD_PATTERN,
+    description=(
+      "YYYY-MM period to backfill from. Clamped to the earliest month "
+      "with ledger data; defaults to that month when omitted. Must be "
+      "on or before `closed_through`."
+    ),
+  )
+  max_periods: int = Field(
+    12,
+    ge=1,
+    le=24,
+    description=(
+      "Maximum months to restamp in this call. Each month runs a full "
+      "reopen → reclose cycle; keep chunks modest and loop on "
+      "`remaining_periods`."
+    ),
+  )
+  allow_stale_sync: bool = Field(
+    False,
+    description=(
+      "Override the sync-currency gate on each reclose. Historical "
+      "months predate the last sync in the normal case, so this is "
+      "rarely needed."
+    ),
+  )
+  note: str | None = Field(
+    None, description="Free-form note attached to each close audit event"
+  )
+
+  model_config = ConfigDict(
+    json_schema_extra={
+      "examples": [
+        {},
+        {"start_period": "2019-07", "max_periods": 12},
+      ]
+    }
+  )
+
+
 # ── Responses ──────────────────────────────────────────────────────────────
 
 
@@ -347,6 +407,77 @@ class ClosePeriodResponse(BaseModel):
       "Aggregated statement-rule verification outcome across the stamped "
       "structures — keys: pass/fail/error/skipped. None when no statement "
       "rules exist. Distinct from rule_summary (the schedule-rule pass)."
+    ),
+  )
+
+
+class BackfillPeriodOutcome(BaseModel):
+  """Per-month result of a plan-history backfill pass."""
+
+  period: str = Field(..., description="The month, in YYYY-MM")
+  status: str = Field(
+    ...,
+    description=(
+      "stamped: reopen → reclose completed. skipped_drafts: the month "
+      "holds draft entries the backfill refuses to post — review via "
+      "list-period-drafts, then close-period or re-run. failed: the "
+      "reclose raised; processing halted (see detail)."
+    ),
+  )
+  statements_stamped: bool = Field(
+    False,
+    description=(
+      "Whether the reclose stamped canonical statement FactSets. False "
+      "with a statement_stamp_note soft-skip when reporting isn't set up."
+    ),
+  )
+  statement_stamp_note: str | None = Field(
+    None, description="Soft-skip reason when statements_stamped is false"
+  )
+  statement_rule_summary: dict[str, int] | None = Field(
+    None,
+    description=(
+      "Statement-rule verification tally for the month's stamped sets "
+      "(pass/fail/error/skipped); None when no rules ran."
+    ),
+  )
+  detail: str | None = Field(
+    None, description="Human-readable detail for skipped/failed months"
+  )
+
+
+class BackfillPlanHistoryResponse(BaseModel):
+  """Response from one chunked plan-history backfill call."""
+
+  fiscal_calendar: FiscalCalendarResponse
+  earliest_available_period: str = Field(
+    ...,
+    description="First month with ledger data — the hard floor for backfill",
+  )
+  effective_start_period: str = Field(
+    ...,
+    description=("The start actually used after clamping to earliest_available_period"),
+  )
+  closed_through: str = Field(
+    ..., description="The close boundary the backfill runs up to (inclusive)"
+  )
+  period_rows_created: int = Field(
+    0,
+    description=(
+      "FiscalPeriod rows seeded (baseline-closed) for months the calendar "
+      "didn't cover yet"
+    ),
+  )
+  processed: list[BackfillPeriodOutcome] = Field(
+    default_factory=list,
+    description="Months this call attempted, oldest first",
+  )
+  remaining_periods: list[str] = Field(
+    default_factory=list,
+    description=(
+      "Months still lacking canonical statement sets that this call did "
+      "not attempt (beyond max_periods, or after a failure halt). Loop "
+      "until empty."
     ),
   )
 

--- a/robosystems/operations/roboledger/commands/fiscal_calendar.py
+++ b/robosystems/operations/roboledger/commands/fiscal_calendar.py
@@ -15,21 +15,35 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from sqlalchemy import func as sa_func
 from sqlalchemy.orm import Session
 
 from robosystems.models.api.extensions.fiscal_calendar import (
+  BackfillPeriodOutcome,
+  BackfillPlanHistoryRequest,
+  BackfillPlanHistoryResponse,
   ClosePeriodResponse,
   FiscalCalendarResponse,
   InitializeLedgerRequest,
   InitializeLedgerResponse,
 )
+from robosystems.models.extensions.roboledger.entry import Entry
 from robosystems.models.extensions.roboledger.fiscal_period import FiscalPeriod
 from robosystems.operations.roboledger.fiscal_calendar import (
+  CloseGateFailed,
+  FiscalCalendarError,
   FiscalCalendarService,
   PeriodCloseService,
+  PeriodNotFoundError,
+  UnbalancedLedgerError,
   add_months,
   current_month_period,
+  next_period,
   period_date_range,
+  period_from_date,
+)
+from robosystems.operations.roboledger.fiscal_calendar.close_service import (
+  WritebackFailed,
 )
 from robosystems.operations.roboledger.reads.fiscal_calendar import (
   build_fiscal_calendar_response,
@@ -63,6 +77,20 @@ class PeriodNotClosedError(Exception):
     super().__init__(f"Period {period!r} is not closed (status={status!r}).")
     self.period = period
     self.status = status
+
+
+class BackfillPreconditionError(Exception):
+  """Raised when a plan-history backfill can't start.
+
+  ``code`` is machine-readable: ``nothing_closed`` (no close boundary to
+  backfill behind — run close-period first), ``no_ledger_data`` (the
+  graph has no entries to compile), or ``start_after_boundary`` (the
+  requested start is past `closed_through`).
+  """
+
+  def __init__(self, code: str, message: str) -> None:
+    super().__init__(message)
+    self.code = code
 
 
 def initialize_ledger(
@@ -282,4 +310,187 @@ def reopen_period(
       session, graph_id, calendar, has_sync, last_sync_at, service
     ),
     statement_sets_retracted=len(retracted),
+  )
+
+
+def backfill_plan_history(
+  session: Session,
+  platform_db: Session,
+  graph_id: str,
+  body: BackfillPlanHistoryRequest,
+  actor_id: str,
+  service: FiscalCalendarService,
+  close_service: PeriodCloseService,
+  actor_type: str = "user",
+) -> BackfillPlanHistoryResponse:
+  """Compile monthly statement history behind the close boundary.
+
+  Seeds missing `FiscalPeriod` rows (baseline-closed) back to the
+  clamped start, then walks every month in the range that lacks
+  canonical statement FactSets oldest-first, running the real
+  `reopen_period` → `close_period` cycle on each — identical semantics
+  to a manual restamp, so balance validation, statement rules, QB
+  writeback guards, and audit events all apply per month.
+
+  Chunked and resumable: at most ``body.max_periods`` months are
+  attempted per call; each month commits individually (via the reused
+  commands), so an interrupted run resumes where it left off — a month
+  left in status='closing' by a failed reclose skips straight to the
+  close on retry. Months with draft entries are skipped, never posted:
+  the backfill refuses to commit ledger changes nobody reviewed.
+
+  A failed reclose halts processing (continuing would hole the series);
+  the failure rides the month's outcome and everything untried lands in
+  ``remaining_periods``.
+
+  Raises `FiscalCalendarError` when the calendar isn't initialized and
+  `BackfillPreconditionError` for nothing-closed / no-data / bad-range.
+  """
+  calendar = service.require(session, graph_id)
+  closed_through = calendar.closed_through_period
+  if closed_through is None:
+    raise BackfillPreconditionError(
+      "nothing_closed",
+      "Nothing is closed yet — the backfill fills history behind the "
+      "close boundary. Close the first period with close-period, or "
+      "catch up normally.",
+    )
+
+  earliest_date = session.query(sa_func.min(Entry.posting_date)).scalar()
+  if earliest_date is None:
+    raise BackfillPreconditionError(
+      "no_ledger_data",
+      "The ledger has no entries — nothing to compile. Sync or import data first.",
+    )
+  earliest_available = period_from_date(earliest_date)
+
+  start = body.start_period or earliest_available
+  if start < earliest_available:
+    start = earliest_available
+  if start > closed_through:
+    raise BackfillPreconditionError(
+      "start_after_boundary",
+      f"start_period {body.start_period!r} is after closed_through "
+      f"{closed_through!r} — the backfill only compiles closed history.",
+    )
+
+  rows_created = service.ensure_fiscal_periods(
+    session,
+    graph_id,
+    start_period=start,
+    end_period=closed_through,
+    closed_through=closed_through,
+  )
+  if rows_created:
+    session.commit()
+
+  # Function-level import — statement_sets pulls in information-block
+  # machinery (same posture as reopen_period's imports above).
+  from robosystems.operations.roboledger.reports.statement_sets import (
+    StatementStampError,
+    has_canonical_statement_sets,
+  )
+
+  candidates: list[str] = []
+  current = start
+  while current <= closed_through:
+    ps, pe = period_date_range(current)
+    if not has_canonical_statement_sets(session, period_start=ps, period_end=pe):
+      candidates.append(current)
+    current = next_period(current)
+
+  processed: list[BackfillPeriodOutcome] = []
+  for period in candidates[: body.max_periods]:
+    ps, pe = period_date_range(period)
+    draft_count = (
+      session.query(Entry)
+      .filter(
+        Entry.posting_date >= ps,
+        Entry.posting_date <= pe,
+        Entry.status == "draft",
+      )
+      .count()
+    )
+    if draft_count:
+      processed.append(
+        BackfillPeriodOutcome(
+          period=period,
+          status="skipped_drafts",
+          detail=(
+            f"{draft_count} draft entries in the window — review via "
+            "list-period-drafts, then close-period or re-run the backfill."
+          ),
+        )
+      )
+      continue
+
+    fp = (
+      session.query(FiscalPeriod)
+      .filter(FiscalPeriod.graph_id == graph_id, FiscalPeriod.name == period)
+      .one()
+    )
+    try:
+      if fp.status == "closed":
+        reopen_period(
+          session,
+          platform_db,
+          graph_id,
+          period,
+          actor_id=actor_id,
+          reason="plan history backfill",
+          note=body.note,
+          service=service,
+          actor_type=actor_type,
+        )
+      close_result = close_period(
+        session,
+        platform_db,
+        graph_id,
+        period,
+        actor_id=actor_id,
+        allow_stale_sync=body.allow_stale_sync,
+        note=body.note,
+        service=service,
+        close_service=close_service,
+        actor_type=actor_type,
+      )
+      processed.append(
+        BackfillPeriodOutcome(
+          period=period,
+          status="stamped",
+          statements_stamped=close_result.statements_stamped,
+          statement_stamp_note=close_result.statement_stamp_note,
+          statement_rule_summary=close_result.statement_rule_summary,
+        )
+      )
+    except (
+      CloseGateFailed,
+      PeriodNotFoundError,
+      UnbalancedLedgerError,
+      WritebackFailed,
+      StatementStampError,
+      PeriodNotClosedError,
+      FiscalCalendarError,
+    ) as exc:
+      session.rollback()
+      processed.append(
+        BackfillPeriodOutcome(period=period, status="failed", detail=str(exc))
+      )
+      break
+
+  attempted = {outcome.period for outcome in processed}
+  remaining = [p for p in candidates if p not in attempted]
+
+  refreshed = service.require(session, graph_id)
+  has_sync, last_sync_at = qb_sync_state(platform_db, graph_id)
+  return BackfillPlanHistoryResponse(
+    fiscal_calendar=build_fiscal_calendar_response(
+      session, graph_id, refreshed, has_sync, last_sync_at, service
+    ),
+    earliest_available_period=earliest_available,
+    effective_start_period=start,
+    closed_through=closed_through,
+    period_rows_created=rows_created,
+    processed=processed,
+    remaining_periods=remaining,
   )

--- a/robosystems/operations/roboledger/reports/statement_sets.py
+++ b/robosystems/operations/roboledger/reports/statement_sets.py
@@ -474,6 +474,17 @@ def _canonical_set_ids_in_window(
   )
 
 
+def has_canonical_statement_sets(
+  session: Session, *, period_start: date, period_end: date
+) -> bool:
+  """Whether the window already carries close-stamped canonical sets.
+
+  The plan-history backfill's idempotency check: months that answer True
+  are already part of the statement series and are never touched again.
+  """
+  return bool(_canonical_set_ids_in_window(session, period_start, period_end))
+
+
 def retract_canonical_statement_sets(
   session: Session, *, period_start: date, period_end: date
 ) -> list[str]:

--- a/robosystems/routers/extensions/roboledger/operations.py
+++ b/robosystems/routers/extensions/roboledger/operations.py
@@ -123,6 +123,8 @@ from robosystems.models.api.extensions.entity import (
   UpdateEntityRequest,
 )
 from robosystems.models.api.extensions.fiscal_calendar import (
+  BackfillPlanHistoryRequest,
+  BackfillPlanHistoryResponse,
   ClosePeriodRequest,
   ClosePeriodResponse,
   FiscalCalendarResponse,
@@ -273,8 +275,12 @@ from robosystems.operations.roboledger.commands.event_handler import (
   update_event_handler as cmd_update_event_handler,
 )
 from robosystems.operations.roboledger.commands.fiscal_calendar import (
+  BackfillPreconditionError,
   PeriodNotClosedError,
   PeriodNotFoundInLedgerError,
+)
+from robosystems.operations.roboledger.commands.fiscal_calendar import (
+  backfill_plan_history as cmd_backfill_plan_history,
 )
 from robosystems.operations.roboledger.commands.fiscal_calendar import (
   close_period as cmd_close_period,
@@ -575,6 +581,12 @@ class ReopenPeriodOperation(ReopenPeriodRequest):
       ]
     },
   )
+
+
+class BackfillPlanHistoryOperation(BackfillPlanHistoryRequest):
+  """Compile monthly statement history behind the close boundary."""
+
+  pass  # range and chunking already in body
 
 
 class RegenerateReportOperation(RegenerateReportRequest):
@@ -1938,6 +1950,78 @@ async def reopen_period_op(
       )
     except PeriodNotClosedError as e:
       raise HTTPException(status_code=422, detail=str(e))
+    except FiscalCalendarError as e:
+      raise HTTPException(status_code=404, detail=str(e))
+    except ProgrammingError as e:
+      if _is_schema_missing(e):
+        raise _ledger_404()
+      raise
+
+  return await _dispatch(ctx, _runner, cache)
+
+
+@router.post(
+  "/backfill-plan-history",
+  response_model=OperationEnvelope[BackfillPlanHistoryResponse],
+  operation_id="backfillPlanHistory",
+  summary="Backfill Plan History",
+  description=(
+    "Compile monthly statement history behind the close boundary — the "
+    "plan's historical columns. Seeds any missing FiscalPeriod rows "
+    "(baseline-closed) back to the clamped `start_period`, then "
+    "restamps each month lacking canonical statement FactSets by "
+    "running the real reopen → reclose cycle (balance validation, "
+    "statement rules, and audit events per month). Chunked: at most "
+    "`max_periods` months per call, oldest first — loop until "
+    "`remaining_periods` comes back empty. Idempotent: already-stamped "
+    "months are never touched. Months holding draft entries are "
+    "skipped, never posted. `start_period` is clamped to the earliest "
+    "month with ledger data, so deep-history tenants only backfill "
+    "what actually exists."
+  ),
+  tags=[_OP_TAG],
+  dependencies=[_RATE_LIMIT],
+  responses={**OPERATION_ERROR_RESPONSES},
+)
+@endpoint_metrics_decorator(
+  "/extensions/roboledger/{graph_id}/operations/backfill-plan-history",
+  method="POST",
+  business_event_type="ledger_backfill_plan_history",
+)
+async def backfill_plan_history_op(
+  body: BackfillPlanHistoryOperation,
+  graph_id: str = Path(..., pattern=GRAPH_OR_SUBGRAPH_ID_PATTERN),
+  user: User = Depends(get_current_user_with_graph),
+  _ext: GraphExtensionContext = Depends(_require_roboledger),
+  idempotency_key: str | None = Header(None, alias="Idempotency-Key"),
+  cache: IdempotencyCache = Depends(get_idempotency_cache),
+  platform_db: Session = Depends(get_db_session),
+) -> OperationEnvelope:
+  ctx = _ctx(
+    graph_id=graph_id,
+    user_id=str(user.id),
+    op="backfill-plan-history",
+    idempotency_key=idempotency_key,
+    body=body,
+  )
+
+  def _runner():
+    try:
+      with extensions_session(graph_id) as session:
+        return cmd_backfill_plan_history(
+          session,
+          platform_db,
+          graph_id,
+          body,
+          actor_id=str(user.id),
+          service=_fiscal_svc,
+          close_service=_close_svc,
+        )
+    except BackfillPreconditionError as e:
+      raise HTTPException(
+        status_code=422,
+        detail={"message": str(e), "code": e.code},
+      )
     except FiscalCalendarError as e:
       raise HTTPException(status_code=404, detail=str(e))
     except ProgrammingError as e:

--- a/tests/middleware/mcp/tools/test_fiscal_calendar_tools.py
+++ b/tests/middleware/mcp/tools/test_fiscal_calendar_tools.py
@@ -23,14 +23,18 @@ import pytest
 
 from robosystems.middleware.mcp.tools._gate import MCPExtensionGateError
 from robosystems.middleware.mcp.tools.fiscal_calendar_tools import (
+  BackfillPlanHistoryTool,
   ClosePeriodTool,
   ReopenPeriodTool,
 )
 from robosystems.models.api.extensions.fiscal_calendar import (
+  BackfillPeriodOutcome,
+  BackfillPlanHistoryResponse,
   ClosePeriodResponse,
   FiscalCalendarResponse,
 )
 from robosystems.operations.roboledger.commands.fiscal_calendar import (
+  BackfillPreconditionError,
   ReopenPeriodResult,
 )
 from robosystems.operations.roboledger.fiscal_calendar import (
@@ -453,4 +457,105 @@ class TestFiscalCalendarGate:
       result = await tool.execute({"period": "2026-03", "reason": "fix"})
 
     assert result["error"] == "extension_not_provisioned"
+    ops.assert_not_called()
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# BackfillPlanHistoryTool
+# ────────────────────────────────────────────────────────────────────────────
+
+
+def _backfill_response(**overrides) -> BackfillPlanHistoryResponse:
+  defaults: dict = {
+    "fiscal_calendar": _fc_response(),
+    "earliest_available_period": "2024-07",
+    "effective_start_period": "2024-07",
+    "closed_through": "2026-05",
+    "period_rows_created": 0,
+    "processed": [
+      BackfillPeriodOutcome(
+        period="2024-07",
+        status="stamped",
+        statements_stamped=True,
+        statement_rule_summary={"pass": 3, "fail": 0, "error": 0, "skipped": 0},
+      )
+    ],
+    "remaining_periods": ["2024-08", "2024-09"],
+  }
+  defaults.update(overrides)
+  return BackfillPlanHistoryResponse(**defaults)
+
+
+class TestBackfillPlanHistoryTool:
+  @pytest.mark.asyncio
+  async def test_delegates_and_reshapes(self):
+    tool = BackfillPlanHistoryTool(_client(user_id="usr_abc"))
+    with (
+      _patch_sessions(),
+      patch(
+        f"{MODULE}.ops_backfill_plan_history", return_value=_backfill_response()
+      ) as ops,
+    ):
+      result = await tool.execute({"start_period": "2024-07", "max_periods": 1})
+
+    ops.assert_called_once()
+    body = ops.call_args.args[3]
+    assert body.start_period == "2024-07"
+    assert body.max_periods == 1
+    assert ops.call_args.kwargs["actor_type"] == "agent"
+    assert result["effective_start_period"] == "2024-07"
+    assert result["remaining_periods"] == ["2024-08", "2024-09"]
+    assert result["processed"][0]["period"] == "2024-07"
+    assert result["processed"][0]["status"] == "stamped"
+    assert result["fiscal_calendar"]["graph_id"] == GRAPH_ID
+
+  @pytest.mark.asyncio
+  async def test_defaults_apply_when_arguments_empty(self):
+    tool = BackfillPlanHistoryTool(_client(user_id="usr_abc"))
+    with (
+      _patch_sessions(),
+      patch(
+        f"{MODULE}.ops_backfill_plan_history", return_value=_backfill_response()
+      ) as ops,
+    ):
+      await tool.execute({})
+
+    body = ops.call_args.args[3]
+    assert body.start_period is None
+    assert body.max_periods == 12
+    assert body.allow_stale_sync is False
+
+  @pytest.mark.asyncio
+  async def test_precondition_error_maps_to_code(self):
+    tool = BackfillPlanHistoryTool(_client(user_id="usr_abc"))
+    with (
+      _patch_sessions(),
+      patch(
+        f"{MODULE}.ops_backfill_plan_history",
+        side_effect=BackfillPreconditionError(
+          "nothing_closed", "Nothing is closed yet."
+        ),
+      ),
+    ):
+      result = await tool.execute({})
+
+    assert result["error"] == "nothing_closed"
+    assert "closed" in result["message"]
+
+  @pytest.mark.asyncio
+  async def test_rejects_on_repo_graph_before_ops(self):
+    tool = BackfillPlanHistoryTool(_client(user_id="usr_abc"))
+    with (
+      patch(
+        f"{MODULE}.require_graph_extension_mcp",
+        side_effect=MCPExtensionGateError(
+          "repository_write_forbidden",
+          "roboledger commands are not available on repository graphs",
+        ),
+      ),
+      patch(f"{MODULE}.ops_backfill_plan_history") as ops,
+    ):
+      result = await tool.execute({})
+
+    assert result["error"] == "repository_write_forbidden"
     ops.assert_not_called()

--- a/tests/operations/roboledger/commands/test_fiscal_calendar.py
+++ b/tests/operations/roboledger/commands/test_fiscal_calendar.py
@@ -1,9 +1,10 @@
 """Unit tests for the fiscal-calendar command wrappers.
 
 Focus: the close-time statement-stamping surface — `close_period` maps
-the stamp outcome onto `ClosePeriodResponse`, and `reopen_period`
-retracts the reopened month's canonical statement sets (returning
-`ReopenPeriodResult` with the count).
+the stamp outcome onto `ClosePeriodResponse`, `reopen_period` retracts
+the reopened month's canonical statement sets (returning
+`ReopenPeriodResult` with the count), and `backfill_plan_history`
+compiles closed history through chunked reopen → reclose cycles.
 """
 
 from __future__ import annotations
@@ -13,15 +14,25 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from robosystems.models.api.extensions.fiscal_calendar import FiscalCalendarResponse
+from robosystems.models.api.extensions.fiscal_calendar import (
+  BackfillPlanHistoryRequest,
+  FiscalCalendarResponse,
+)
+from robosystems.models.extensions.roboledger.entry import Entry
+from robosystems.models.extensions.roboledger.fiscal_period import FiscalPeriod
 from robosystems.operations.roboledger.commands.fiscal_calendar import (
+  BackfillPreconditionError,
   PeriodNotClosedError,
   PeriodNotFoundInLedgerError,
   ReopenPeriodResult,
+  backfill_plan_history,
   close_period,
   reopen_period,
 )
-from robosystems.operations.roboledger.fiscal_calendar import PeriodCloseResult
+from robosystems.operations.roboledger.fiscal_calendar import (
+  PeriodCloseResult,
+  UnbalancedLedgerError,
+)
 
 GRAPH_ID = "kg01234567890abcdef"
 
@@ -178,3 +189,221 @@ class TestReopenRetractsCanonicalSets:
         note=None,
         service=MagicMock(),
       )
+
+
+class TestBackfillPlanHistory:
+  """Chunked reopen → reclose compilation of closed monthly history.
+
+  The calendar boundary is 2026-02 and ledger data starts 2025-11-03,
+  so the full candidate range is 2025-11 .. 2026-02 (4 months).
+  """
+
+  CLOSED_THROUGH = "2026-02"
+  EARLIEST = date(2025, 11, 3)
+
+  def _service(self, closed_through=CLOSED_THROUGH, rows_created=0):
+    service = MagicMock()
+    calendar = MagicMock()
+    calendar.closed_through_period = closed_through
+    service.require.return_value = calendar
+    service.ensure_fiscal_periods.return_value = rows_created
+    return service
+
+  def _session(self, earliest=EARLIEST, draft_counts=(), fp_statuses=()):
+    """Session mock that routes by query target.
+
+    ``draft_counts`` / ``fp_statuses`` are consumed one per attempted
+    month, in order.
+    """
+    session = MagicMock()
+    draft_iter = iter(draft_counts)
+    fp_iter = iter(fp_statuses)
+
+    def _query(arg):
+      q = MagicMock()
+      if arg is Entry:
+        q.filter.return_value.count.side_effect = lambda: next(draft_iter)
+      elif arg is FiscalPeriod:
+        fp = MagicMock()
+        fp.status = next(fp_iter)
+        q.filter.return_value.one.return_value = fp
+      else:  # the min(posting_date) expression
+        q.scalar.return_value = earliest
+      return q
+
+    session.query.side_effect = _query
+    return session
+
+  def _run(
+    self,
+    session,
+    service,
+    body=None,
+    stamped_windows=frozenset(),
+    close_side_effect=None,
+  ):
+    """Run the backfill with the reopen/close commands patched out.
+
+    ``stamped_windows`` holds YYYY-MM months that already have canonical
+    sets (the idempotency skip).
+    """
+    body = body or BackfillPlanHistoryRequest()
+
+    def _has_sets(_session, *, period_start, period_end):
+      return period_start.strftime("%Y-%m") in stamped_windows
+
+    close_result = MagicMock()
+    close_result.statements_stamped = True
+    close_result.statement_stamp_note = None
+    close_result.statement_rule_summary = {
+      "pass": 3,
+      "fail": 0,
+      "error": 0,
+      "skipped": 0,
+    }
+    close_mock = MagicMock(return_value=close_result, side_effect=close_side_effect)
+    reopen_mock = MagicMock()
+    with (
+      patch(f"{_MOD}.reopen_period", reopen_mock),
+      patch(f"{_MOD}.close_period", close_mock),
+      patch(f"{_MOD}.qb_sync_state", return_value=(False, None)),
+      patch(f"{_MOD}.build_fiscal_calendar_response", return_value=_fc_response()),
+      patch(
+        "robosystems.operations.roboledger.reports.statement_sets."
+        "has_canonical_statement_sets",
+        side_effect=_has_sets,
+      ),
+    ):
+      response = backfill_plan_history(
+        session,
+        MagicMock(),
+        GRAPH_ID,
+        body,
+        actor_id="usr_1",
+        service=service,
+        close_service=MagicMock(),
+      )
+    return response, reopen_mock, close_mock
+
+  def test_nothing_closed_raises(self):
+    with pytest.raises(BackfillPreconditionError) as exc_info:
+      self._run(self._session(), self._service(closed_through=None))
+    assert exc_info.value.code == "nothing_closed"
+
+  def test_no_ledger_data_raises(self):
+    with pytest.raises(BackfillPreconditionError) as exc_info:
+      self._run(self._session(earliest=None), self._service())
+    assert exc_info.value.code == "no_ledger_data"
+
+  def test_start_after_boundary_raises(self):
+    with pytest.raises(BackfillPreconditionError) as exc_info:
+      self._run(
+        self._session(),
+        self._service(),
+        body=BackfillPlanHistoryRequest(start_period="2026-03"),
+      )
+    assert exc_info.value.code == "start_after_boundary"
+
+  def test_clamps_start_to_earliest_data(self):
+    service = self._service(rows_created=4)
+    session = self._session(draft_counts=[0] * 4, fp_statuses=["closed"] * 4)
+    response, _, _ = self._run(
+      session,
+      service,
+      body=BackfillPlanHistoryRequest(start_period="2019-01"),
+    )
+    assert response.earliest_available_period == "2025-11"
+    assert response.effective_start_period == "2025-11"
+    assert response.period_rows_created == 4
+    service.ensure_fiscal_periods.assert_called_once_with(
+      session,
+      GRAPH_ID,
+      start_period="2025-11",
+      end_period=self.CLOSED_THROUGH,
+      closed_through=self.CLOSED_THROUGH,
+    )
+
+  def test_already_stamped_months_untouched(self):
+    session = self._session(draft_counts=[0, 0], fp_statuses=["closed", "closed"])
+    response, reopen_mock, close_mock = self._run(
+      session,
+      self._service(),
+      stamped_windows={"2025-11", "2025-12"},
+    )
+    attempted = [outcome.period for outcome in response.processed]
+    assert attempted == ["2026-01", "2026-02"]
+    assert all(o.status == "stamped" for o in response.processed)
+    assert response.remaining_periods == []
+    assert reopen_mock.call_count == 2
+    assert close_mock.call_count == 2
+
+  def test_chunking_respects_max_periods(self):
+    session = self._session(draft_counts=[0, 0], fp_statuses=["closed", "closed"])
+    response, _, close_mock = self._run(
+      session,
+      self._service(),
+      body=BackfillPlanHistoryRequest(max_periods=2),
+    )
+    attempted = [outcome.period for outcome in response.processed]
+    assert attempted == ["2025-11", "2025-12"]
+    assert response.remaining_periods == ["2026-01", "2026-02"]
+    assert close_mock.call_count == 2
+
+  def test_draft_months_skipped_never_posted(self):
+    session = self._session(
+      draft_counts=[2, 0, 0, 0],
+      fp_statuses=["closed", "closed", "closed"],
+    )
+    response, _, close_mock = self._run(session, self._service())
+    assert response.processed[0].period == "2025-11"
+    assert response.processed[0].status == "skipped_drafts"
+    assert [o.period for o in response.processed if o.status == "stamped"] == [
+      "2025-12",
+      "2026-01",
+      "2026-02",
+    ]
+    assert close_mock.call_count == 3
+    assert response.remaining_periods == []
+
+  def test_failure_halts_and_reports_remaining(self):
+    session = self._session(draft_counts=[0], fp_statuses=["closed"])
+    response, _, _ = self._run(
+      session,
+      self._service(),
+      close_side_effect=UnbalancedLedgerError(100, 90),
+    )
+    assert len(response.processed) == 1
+    assert response.processed[0].status == "failed"
+    assert "debits=100" in (response.processed[0].detail or "")
+    assert response.remaining_periods == ["2025-12", "2026-01", "2026-02"]
+    session.rollback.assert_called_once()
+
+  def test_resume_skips_reopen_for_closing_period(self):
+    session = self._session(
+      draft_counts=[0],
+      fp_statuses=["closing"],
+    )
+    response, reopen_mock, close_mock = self._run(
+      session,
+      self._service(),
+      body=BackfillPlanHistoryRequest(max_periods=1),
+    )
+    assert response.processed[0].status == "stamped"
+    reopen_mock.assert_not_called()
+    close_mock.assert_called_once()
+
+  def test_stamp_outcome_fields_ride_through(self):
+    session = self._session(draft_counts=[0], fp_statuses=["closed"])
+    response, _, _ = self._run(
+      session,
+      self._service(),
+      body=BackfillPlanHistoryRequest(max_periods=1),
+    )
+    outcome = response.processed[0]
+    assert outcome.statements_stamped is True
+    assert outcome.statement_rule_summary == {
+      "pass": 3,
+      "fail": 0,
+      "error": 0,
+      "skipped": 0,
+    }

--- a/tests/routers/graphs/mcp/test_mcp_execute.py
+++ b/tests/routers/graphs/mcp/test_mcp_execute.py
@@ -30,6 +30,7 @@ class TestWriteClassificationFailClosed:
       "delete-journal-entry",
       "close-period",
       "reopen-period",
+      "backfill-plan-history",
       "execute-event-block",
       "create-information-block",
       "delete-information-block",


### PR DESCRIPTION
## What

New `backfill-plan-history` operation — `POST /extensions/roboledger/{graph_id}/operations/backfill-plan-history` + the matching MCP tool — that compiles a tenant's closed monthly history into canonical statement FactSets, feeding the plan's monthly historical columns.

## Why

Close-time statement stamping (#922) only mints canonical sets going forward. Tenants whose history was baseline-closed at calendar initialization (the QB auto-init path), or closed before stamping existed, have no monthly statement series — the plan falls back to whatever publication reports exist (typically annual columns). Deep-QB-history tenants also had no way to extend the calendar past the fixed 24-month init window.

## How

Per call, the operation:
1. Derives the earliest month with ledger data and clamps `start_period` to it — a request can never reach past real data
2. Seeds any missing `FiscalPeriod` rows back to the clamped start (baseline-closed) via the existing idempotent `ensure_fiscal_periods`
3. Walks each month in range lacking canonical statement sets, oldest first, running the real `reopen_period` → `close_period` command cycle — identical semantics to a manual restamp (balance validation, statement rules, verification results, audit events)
4. Stops after `max_periods` (default 12, max 24) and reports `remaining_periods` — callers loop until empty

Safety properties:
- **Idempotent** — months that already have canonical sets are never touched
- **Draft-safe** — months holding draft entries are skipped with a per-month outcome, never posted
- **Halt-on-failure** — a failed reclose stops the run (no holes in the series); each month commits individually so interrupted runs resume where they left off, including months left in `status='closing'`
- The open month and `close_target` are never touched

## Surfaces

- Ops kernel: `backfill_plan_history` in `operations/roboledger/commands/fiscal_calendar.py` (single source of truth)
- REST: `OperationEnvelope` + `Idempotency-Key`, registered alongside the other close-family operations
- MCP: `backfill-plan-history` tool (write-classified by the fail-closed allowlist), listed in the close playbook's related tools
- `has_canonical_statement_sets` public helper on `statement_sets.py`

## Tests

- Command: preconditions (nothing closed / no data / bad range), clamping + row seeding, idempotent skip, chunking, draft-skip, failure halt + rollback, resume path, outcome field mapping
- MCP tool: delegation/reshaping, defaults, precondition error codes, extension gate
- Write-classification invariant extended in `test_mcp_execute.py`
- `just test-code` green; 1,459 adjacent tests pass

No migrations. SDK regen can ride a later batch — the MCP surface is the driving consumer.