### PR TITLE
fix(bootstrap): parameterize GitHub repo names in OIDC trust policies

### DIFF
--- a/bin/setup/bootstrap.sh
+++ b/bin/setup/bootstrap.sh
@@ -339,13 +339,13 @@ deploy_github_oidc() {
     GITHUB_ORG=${input_org:-$GITHUB_ORG}
 
     echo ""
-    print_info "Repository names are hardcoded for security:"
     print_info "Backend role will allow:"
-    print_info "  - ${GITHUB_ORG}/robosystems"
-    print_info "Frontend role will allow:"
+    print_info "  - ${GITHUB_ORG}/${GITHUB_REPO}"
+    print_info "Frontend role will allow (template defaults; override via stack parameters):"
     print_info "  - ${GITHUB_ORG}/robosystems-app"
     print_info "  - ${GITHUB_ORG}/roboledger-app"
     print_info "  - ${GITHUB_ORG}/roboinvestor-app"
+    print_info "  - ${GITHUB_ORG}/robosystems-holon-viewer"
 
     # Branch patterns are hardcoded in the template: main, release/*, v* tags
     echo ""
@@ -388,6 +388,7 @@ deploy_github_oidc() {
             --template-body file://cloudformation/bootstrap-oidc.yaml \
             --parameters \
                 ParameterKey=GitHubOrg,ParameterValue="${GITHUB_ORG}" \
+                ParameterKey=GitHubRepoName,ParameterValue="${GITHUB_REPO}" \
             --capabilities CAPABILITY_NAMED_IAM \
             --profile "${SSO_PROFILE}" \
             --region "${AWS_REGION}" \
@@ -404,6 +405,7 @@ deploy_github_oidc() {
             --template-body file://cloudformation/bootstrap-oidc.yaml \
             --parameters \
                 ParameterKey=GitHubOrg,ParameterValue="${GITHUB_ORG}" \
+                ParameterKey=GitHubRepoName,ParameterValue="${GITHUB_REPO}" \
             --capabilities CAPABILITY_NAMED_IAM \
             --profile "${SSO_PROFILE}" \
             --region "${AWS_REGION}" 2>&1 || {
@@ -578,9 +580,11 @@ configure_essential_variables() {
 setup_ecr_repository() {
     print_header "ECR Repository Setup"
 
-    # Derive ECR repository name from GitHub repo name
-    local ecr_repo_name
-    ecr_repo_name=$(echo "${GITHUB_REPO}" | tr '[:upper:]' '[:lower:]')
+    # Fleet-uniform ECR name: the deploy role's ECR scope, the AWS_ECR_REPOSITORY
+    # default in gha.sh, and the workflow fallback all assume "robosystems"
+    # regardless of the GitHub repo name — a renamed fork deriving the name from
+    # its repo would create a repository the deploy role cannot access
+    local ecr_repo_name="robosystems"
 
     # Resolve the bundled operational policy file (lives alongside this script)
     local script_dir

--- a/cloudformation/bootstrap-oidc.yaml
+++ b/cloudformation/bootstrap-oidc.yaml
@@ -8,10 +8,43 @@ Parameters:
     AllowedPattern: ^[a-zA-Z0-9-]+$
     ConstraintDescription: Must be a valid GitHub organization or username
 
-  # Repository names are hardcoded for security:
-  # - Backend: robosystems (main infrastructure repo)
-  # - Frontend: robosystems-app, roboledger-app, roboinvestor-app
-  # Only GitHubOrg needs to be parameterized for forks
+  # Repository names are parameterized so forks that rename the repos
+  # (e.g. a dedicated-tenant fork in the same org) bind trust to the
+  # correct repo slug. Defaults preserve the canonical deployment exactly.
+  GitHubRepoName:
+    Type: String
+    Default: robosystems
+    Description: Backend repository name (override for renamed forks)
+    AllowedPattern: ^[a-zA-Z0-9._-]+$
+    ConstraintDescription: Must be a valid GitHub repository name
+
+  GitHubAppRepoName:
+    Type: String
+    Default: robosystems-app
+    Description: Primary dashboard frontend repository name
+    AllowedPattern: ^[a-zA-Z0-9._-]+$
+    ConstraintDescription: Must be a valid GitHub repository name
+
+  GitHubLedgerAppRepoName:
+    Type: String
+    Default: roboledger-app
+    Description: RoboLedger frontend repository name
+    AllowedPattern: ^[a-zA-Z0-9._-]+$
+    ConstraintDescription: Must be a valid GitHub repository name
+
+  GitHubInvestorAppRepoName:
+    Type: String
+    Default: roboinvestor-app
+    Description: RoboInvestor frontend repository name
+    AllowedPattern: ^[a-zA-Z0-9._-]+$
+    ConstraintDescription: Must be a valid GitHub repository name
+
+  GitHubHolonViewerRepoName:
+    Type: String
+    Default: robosystems-holon-viewer
+    Description: Holon viewer static SPA repository name
+    AllowedPattern: ^[a-zA-Z0-9._-]+$
+    ConstraintDescription: Must be a valid GitHub repository name
 
   # Tagging Configuration
   ServiceTag:
@@ -89,9 +122,9 @@ Resources:
               StringLike:
                 # Allow main, release branches, and version tags for backend repo only
                 token.actions.githubusercontent.com:sub:
-                  - !Sub repo:${GitHubOrg}/robosystems:ref:refs/heads/main
-                  - !Sub repo:${GitHubOrg}/robosystems:ref:refs/heads/release/*
-                  - !Sub repo:${GitHubOrg}/robosystems:ref:refs/tags/v*
+                  - !Sub repo:${GitHubOrg}/${GitHubRepoName}:ref:refs/heads/main
+                  - !Sub repo:${GitHubOrg}/${GitHubRepoName}:ref:refs/heads/release/*
+                  - !Sub repo:${GitHubOrg}/${GitHubRepoName}:ref:refs/tags/v*
       Policies:
         - PolicyName: !Sub ${ServiceTag}DeploymentPolicy
           PolicyDocument:
@@ -506,25 +539,25 @@ Resources:
               StringEquals:
                 token.actions.githubusercontent.com:aud: sts.amazonaws.com
               StringLike:
-                # Explicitly allow only these frontend repos (hardcoded for security)
+                # Explicitly allow only these frontend repos
                 # If a repo isn't used, it simply won't assume this role
                 token.actions.githubusercontent.com:sub:
-                  # robosystems-app
-                  - !Sub repo:${GitHubOrg}/robosystems-app:ref:refs/heads/main
-                  - !Sub repo:${GitHubOrg}/robosystems-app:ref:refs/heads/release/*
-                  - !Sub repo:${GitHubOrg}/robosystems-app:ref:refs/tags/v*
-                  # roboledger-app
-                  - !Sub repo:${GitHubOrg}/roboledger-app:ref:refs/heads/main
-                  - !Sub repo:${GitHubOrg}/roboledger-app:ref:refs/heads/release/*
-                  - !Sub repo:${GitHubOrg}/roboledger-app:ref:refs/tags/v*
-                  # roboinvestor-app
-                  - !Sub repo:${GitHubOrg}/roboinvestor-app:ref:refs/heads/main
-                  - !Sub repo:${GitHubOrg}/roboinvestor-app:ref:refs/heads/release/*
-                  - !Sub repo:${GitHubOrg}/roboinvestor-app:ref:refs/tags/v*
-                  # robosystems-holon-viewer (static SPA → S3 + CloudFront)
-                  - !Sub repo:${GitHubOrg}/robosystems-holon-viewer:ref:refs/heads/main
-                  - !Sub repo:${GitHubOrg}/robosystems-holon-viewer:ref:refs/heads/release/*
-                  - !Sub repo:${GitHubOrg}/robosystems-holon-viewer:ref:refs/tags/v*
+                  # Primary dashboard frontend
+                  - !Sub repo:${GitHubOrg}/${GitHubAppRepoName}:ref:refs/heads/main
+                  - !Sub repo:${GitHubOrg}/${GitHubAppRepoName}:ref:refs/heads/release/*
+                  - !Sub repo:${GitHubOrg}/${GitHubAppRepoName}:ref:refs/tags/v*
+                  # RoboLedger frontend
+                  - !Sub repo:${GitHubOrg}/${GitHubLedgerAppRepoName}:ref:refs/heads/main
+                  - !Sub repo:${GitHubOrg}/${GitHubLedgerAppRepoName}:ref:refs/heads/release/*
+                  - !Sub repo:${GitHubOrg}/${GitHubLedgerAppRepoName}:ref:refs/tags/v*
+                  # RoboInvestor frontend
+                  - !Sub repo:${GitHubOrg}/${GitHubInvestorAppRepoName}:ref:refs/heads/main
+                  - !Sub repo:${GitHubOrg}/${GitHubInvestorAppRepoName}:ref:refs/heads/release/*
+                  - !Sub repo:${GitHubOrg}/${GitHubInvestorAppRepoName}:ref:refs/tags/v*
+                  # Holon viewer (static SPA → S3 + CloudFront)
+                  - !Sub repo:${GitHubOrg}/${GitHubHolonViewerRepoName}:ref:refs/heads/main
+                  - !Sub repo:${GitHubOrg}/${GitHubHolonViewerRepoName}:ref:refs/heads/release/*
+                  - !Sub repo:${GitHubOrg}/${GitHubHolonViewerRepoName}:ref:refs/tags/v*
       Policies:
         - PolicyName: !Sub ${ServiceTag}FrontendDeploymentPolicy
           PolicyDocument:


### PR DESCRIPTION
## Summary

Parameterizes the GitHub repository names in the OIDC bootstrap template so forks that rename the repos (e.g. a dedicated-tenant fork living in the same org under a different name) bind the deploy-role trust to their own repo slug. Previously only `GitHubOrg` was parameterized and the repo names were fixed, which assumed forks keep the canonical names — a renamed fork could not assume the roles its own bootstrap deployed.

## Changes

**`cloudformation/bootstrap-oidc.yaml`**
- Added `GitHubRepoName` (default `robosystems`) and consumed it in the backend role's trust conditions (`main` / `release/*` / `v*` tags, unchanged ref patterns).
- Added per-frontend repo name parameters — `GitHubAppRepoName`, `GitHubLedgerAppRepoName`, `GitHubInvestorAppRepoName`, `GitHubHolonViewerRepoName` — and consumed them in the frontend role's trust conditions.
- All defaults reproduce the current canonical deployment exactly; a stack deployed with defaults yields byte-identical trust policies to today's.

**`bin/setup/bootstrap.sh`**
- Passes the detected repo name as `GitHubRepoName` in both the create-stack and update-stack calls.
- Updated the pre-deploy info output to reflect the detected backend repo and the frontend defaults.
- Pinned the bootstrap-created ECR repository to the fleet-uniform `robosystems` name instead of deriving it from the GitHub repo name. The deploy role's ECR resource scope, the `AWS_ECR_REPOSITORY` default in `gha.sh`, and the workflow fallback all assume `robosystems`-prefixed naming, so a renamed fork previously created an ECR repository its own deploy role couldn't access. For the canonical repo this is a no-op (same name either way).

## Testing

- `just cf-lint bootstrap-oidc` — clean.
- `just test-code` (ruff + format + basedpyright + cf-lint-all) — all checks passed.
- Unit tests not run: no Python application code changed.
- Stack deploy with the new parameters not exercised in this session; defaults are verified to reproduce the existing policy documents, so re-running bootstrap on the canonical deployment results in no trust-policy change.

## Notes

- Frontend repo name parameters are template-level only; `bootstrap.sh` leaves them at defaults (frontend forks can override via stack parameters when needed).
- Resource-name scoping elsewhere in the template (S3 `robosystems-*`, DynamoDB, Lambda, Secrets Manager) is intentionally untouched — resource naming stays fleet-uniform regardless of repo name; only the GitHub-side trust binding is parameterized.
