### PR TITLE
fix(graph): stop capacity drift from double-booking dedicated writers

### DIFF
--- a/bin/userdata/common/register-graph-instance.sh
+++ b/bin/userdata/common/register-graph-instance.sh
@@ -48,6 +48,23 @@ TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 if [ "${NODE_TYPE}" = "writer" ]; then
   # User database writer registration
   echo "Registering user writer instance..."
+
+  # A replacement instance adopts the databases already on its reattached
+  # volume, so registering with a hardcoded count of 0 makes the allocator
+  # believe an occupied dedicated writer has free capacity and double-book
+  # it. The volume-manager Lambda response written during storage setup
+  # carries the authoritative database list; count parent graphs from it
+  # (subgraph IDs contain "_" and share the parent's capacity slot).
+  DB_COUNT=0
+  if [ -f /tmp/volume-response.json ]; then
+    DB_COUNT=$(jq -r '[.databases[]? | select(contains("_") | not)] | length' \
+      /tmp/volume-response.json 2>/dev/null || echo "0")
+    case "${DB_COUNT}" in
+      ''|*[!0-9]*) DB_COUNT=0 ;;
+    esac
+  fi
+  echo "Registering with database_count=${DB_COUNT} (from volume-manager response)"
+
   aws dynamodb put-item \
     --table-name "$REGISTRY_TABLE" \
     --item "{
@@ -60,7 +77,7 @@ if [ "${NODE_TYPE}" = "writer" ]; then
       \"status\": {\"S\": \"initializing\"},
       \"created_at\": {\"S\": \"${TIMESTAMP}\"},
       \"last_health_check\": {\"S\": \"${TIMESTAMP}\"},
-      \"database_count\": {\"N\": \"0\"},
+      \"database_count\": {\"N\": \"${DB_COUNT}\"},
       \"max_databases\": {\"N\": \"${MAX_DATABASES}\"},
       \"tier\": {\"S\": \"${CLUSTER_TIER}\"},
       \"region\": {\"S\": \"${AWS_REGION}\"},

--- a/robosystems/middleware/graph/allocation_manager.py
+++ b/robosystems/middleware/graph/allocation_manager.py
@@ -1010,6 +1010,42 @@ class LadybugAllocationManager:
       logger.error(f"Error checking ASG headroom for {tier.value}: {e}")
       return False
 
+  def _count_allocated_graphs(self, instance_id: str) -> int:
+    """Count graphs allocated to an instance according to the graph registry.
+
+    The graph registry is the authoritative allocation record — rows are
+    created with conditional writes at allocation time and re-pointed by the
+    volume-manager Lambda when instances cycle. The instance registry's
+    denormalized database_count is reset when a replacement instance
+    re-registers after ASG cycling, so capacity decisions must not trust it
+    (a drifted zero makes an occupied dedicated writer look empty and gets
+    it double-booked).
+    """
+    from boto3.dynamodb.conditions import Key
+
+    occupying_statuses = {
+      DatabaseStatus.ACTIVE.value,
+      DatabaseStatus.CREATING.value,
+      DatabaseStatus.MIGRATING.value,
+    }
+    count = 0
+    query_kwargs: dict[str, Any] = {
+      "IndexName": "instance-index",
+      "KeyConditionExpression": Key("instance_id").eq(instance_id),
+    }
+    while True:
+      response = self.graph_table.query(**query_kwargs)
+      count += sum(
+        1
+        for item in response.get("Items", [])
+        if item.get("status") in occupying_statuses
+      )
+      last_key = response.get("LastEvaluatedKey")
+      if not last_key:
+        break
+      query_kwargs["ExclusiveStartKey"] = last_key
+    return count
+
   async def _find_best_instance(
     self,
     instance_tier: GraphTier | None = None,
@@ -1072,7 +1108,12 @@ class LadybugAllocationManager:
         if exclude_instance and instance_id == exclude_instance:
           continue
 
-        database_count = int(item.get("database_count", 0))
+        # Occupancy comes from the graph registry, not the instance
+        # registry's database_count — that counter resets to a stale value
+        # when a replacement instance re-registers after ASG cycling, which
+        # would make an occupied dedicated writer look empty. The counter is
+        # still used as the atomic race guard during allocation (STEP 2).
+        database_count = self._count_allocated_graphs(instance_id)
         max_databases = int(item.get("max_databases", self.max_databases_per_instance))
 
         # Only include instances with available capacity

--- a/tests/middleware/graph/test_allocation_manager.py
+++ b/tests/middleware/graph/test_allocation_manager.py
@@ -213,6 +213,9 @@ def _make_manager(**overrides):
     manager = LadybugAllocationManager(environment="test")
     manager.environment = overrides.get("environment", "test")
     manager.graph_table = overrides.get("graph_table", MagicMock())
+    if not overrides.get("graph_table"):
+      # Occupancy is derived from graph-registry queries; default to empty
+      manager.graph_table.query.return_value = {"Items": []}
     manager.instance_table = overrides.get("instance_table", MagicMock())
     manager.volume_table = overrides.get("volume_table", MagicMock())
     manager.autoscaling = overrides.get("autoscaling", MagicMock())
@@ -858,6 +861,21 @@ class TestCheckTierCapacity:
 # ===========================================================================
 
 
+def _stub_graph_occupancy(manager, occupancy: dict[str, int]) -> None:
+  """Stub graph-registry queries to report N active graphs per instance."""
+
+  def _query(**kwargs):
+    instance_id = kwargs["KeyConditionExpression"]._values[1]
+    count = occupancy.get(instance_id, 0)
+    return {
+      "Items": [
+        {"graph_id": f"kg{instance_id}{i}", "status": "active"} for i in range(count)
+      ]
+    }
+
+  manager.graph_table.query.side_effect = _query
+
+
 class TestFindBestInstance:
   """Tests for LadybugAllocationManager._find_best_instance."""
 
@@ -891,6 +909,8 @@ class TestFindBestInstance:
         },
       ]
     }
+
+    _stub_graph_occupancy(manager, {"i-0000000000000aaaa": 8, "i-0000000000000bbbb": 2})
 
     best = await manager._find_best_instance(GraphTier.LADYBUG_STANDARD)
     assert best is not None
@@ -954,6 +974,7 @@ class TestFindBestInstance:
         },
       ]
     }
+    _stub_graph_occupancy(manager, {"i-0000000000000aaaa": 10})
 
     best = await manager._find_best_instance(GraphTier.LADYBUG_STANDARD)
     assert best is None

--- a/tests/middleware/graph/test_allocation_manager_extended.py
+++ b/tests/middleware/graph/test_allocation_manager_extended.py
@@ -58,7 +58,24 @@ def _create_manager(environment="test", max_dbs=10, asg_name="test-asg"):
     manager.volume_table = MagicMock()
     manager.autoscaling = MagicMock()
     manager.cloudwatch = MagicMock()
+    # Occupancy is derived from graph-registry queries; default to empty
+    manager.graph_table.query.return_value = {"Items": []}
     return manager
+
+
+def _stub_graph_occupancy(manager, occupancy: dict[str, int]) -> None:
+  """Stub graph-registry queries to report N active graphs per instance."""
+
+  def _query(**kwargs):
+    instance_id = kwargs["KeyConditionExpression"]._values[1]
+    count = occupancy.get(instance_id, 0)
+    return {
+      "Items": [
+        {"graph_id": f"kg{instance_id}{i}", "status": "active"} for i in range(count)
+      ]
+    }
+
+  manager.graph_table.query.side_effect = _query
 
 
 @pytest.mark.unit
@@ -747,6 +764,7 @@ class TestFindBestInstance:
         },
       ]
     }
+    _stub_graph_occupancy(manager, {"i-11111111": 8, "i-22222222": 2})
 
     result = await manager._find_best_instance(GraphTier.LADYBUG_STANDARD)
     assert result is not None
@@ -783,6 +801,8 @@ class TestFindBestInstance:
       ]
     }
 
+    _stub_graph_occupancy(manager, {"i-11111111": 2, "i-22222222": 5})
+
     result = await manager._find_best_instance(
       GraphTier.LADYBUG_STANDARD, exclude_instance="i-11111111"
     )
@@ -808,9 +828,73 @@ class TestFindBestInstance:
         },
       ]
     }
+    _stub_graph_occupancy(manager, {"i-11111111": 10})
 
     result = await manager._find_best_instance(GraphTier.LADYBUG_STANDARD)
     assert result is None
+
+  @pytest.mark.asyncio
+  async def test_find_best_instance_ignores_drifted_instance_counter(self):
+    """A full instance whose registry counter reset to 0 must not be selected.
+
+    Replacement instances re-register with database_count=0 after ASG
+    cycling even when their reattached volume holds a customer graph. The
+    graph registry is authoritative, so a dedicated instance with an active
+    graph is full regardless of the drifted counter.
+    """
+    manager = _create_manager()
+    now_iso = datetime.now(UTC).isoformat()
+
+    manager.instance_table.scan.return_value = {
+      "Items": [
+        {
+          "instance_id": "i-drifted",
+          "private_ip": "10.0.0.1",
+          "availability_zone": "us-east-1a",
+          "database_count": 0,
+          "max_databases": 1,
+          "created_at": now_iso,
+          "status": "healthy",
+          "cluster_tier": "ladybug-standard",
+        },
+      ]
+    }
+    _stub_graph_occupancy(manager, {"i-drifted": 1})
+
+    result = await manager._find_best_instance(GraphTier.LADYBUG_STANDARD)
+    assert result is None
+
+  @pytest.mark.asyncio
+  async def test_find_best_instance_ignores_deleted_graphs(self):
+    """Deleted and failed graph rows do not consume capacity."""
+    manager = _create_manager()
+    now_iso = datetime.now(UTC).isoformat()
+
+    manager.instance_table.scan.return_value = {
+      "Items": [
+        {
+          "instance_id": "i-11111111",
+          "private_ip": "10.0.0.1",
+          "availability_zone": "us-east-1a",
+          "database_count": 1,
+          "max_databases": 1,
+          "created_at": now_iso,
+          "status": "healthy",
+          "cluster_tier": "ladybug-standard",
+        },
+      ]
+    }
+    manager.graph_table.query.return_value = {
+      "Items": [
+        {"graph_id": "kg-old", "status": "deleted"},
+        {"graph_id": "kg-broken", "status": "failed"},
+      ]
+    }
+
+    result = await manager._find_best_instance(GraphTier.LADYBUG_STANDARD)
+    assert result is not None
+    assert result.instance_id == "i-11111111"
+    assert result.database_count == 0
 
   @pytest.mark.asyncio
   async def test_find_best_instance_empty_scan(self):

--- a/tests/middleware/graph/test_ladybug_allocation_manager.py
+++ b/tests/middleware/graph/test_ladybug_allocation_manager.py
@@ -20,6 +20,8 @@ class TestLadybugAllocationManager:
     self.mock_dynamodb = MagicMock()
     self.mock_graph_table = MagicMock()
     self.mock_instance_table = MagicMock()
+    # Occupancy is derived from graph-registry queries; default to empty
+    self.mock_graph_table.query.return_value = {"Items": []}
 
     # Patch the get_dynamodb_resource function
     self.patcher = patch(
@@ -266,6 +268,8 @@ class TestLadybugAllocationManagerSubgraphs:
     self.mock_dynamodb = MagicMock()
     self.mock_graph_table = MagicMock()
     self.mock_instance_table = MagicMock()
+    # Occupancy is derived from graph-registry queries; default to empty
+    self.mock_graph_table.query.return_value = {"Items": []}
 
     # Patch the get_dynamodb_resource function
     self.patcher = patch(


### PR DESCRIPTION
## Summary

When a LadybugDB writer cycles (spot reclaim, host failure, ASG refresh), the replacement instance re-registers in the instance registry with a hardcoded `database_count: 0` — even though its reattached volume still holds customer graphs. The allocator trusts that counter, so an occupied dedicated writer looks empty and the next graph creation would double-book it. Both prod ladybug-standard writers are currently in this drifted state following the 2026-07-03 cycle (each hosts an active graph while registered as `database_count: 0`). This is the capacity-side sibling of the 2026-05-08 routing-drift incident, whose fix taught the volume-manager Lambda to heal graph-registry routing but left the capacity counter unhealed.

## Changes

**Registration heals the counter at boot** (`bin/userdata/common/register-graph-instance.sh`)

- The writer branch derives `database_count` from the volume-manager Lambda response (`/tmp/volume-response.json`, written synchronously during storage setup before registration runs), counting parent graphs only — subgraph IDs (containing `_`) share their parent's capacity slot
- Falls back to 0 when the response is missing or malformed (fresh instance with a new volume)

**Allocation stops trusting the counter** (`robosystems/middleware/graph/allocation_manager.py`)

- `_find_best_instance` now derives per-instance occupancy from the graph registry (`instance-index` GSI, paginated), counting rows in `active`/`creating`/`migrating` status — the graph registry is the authoritative allocation record and is re-pointed by the volume-manager Lambda on instance replacement
- The denormalized `database_count` remains in place as the atomic conditional-write race guard during allocation (STEP 2), which fails closed: if the counter over-reports, allocation retries on another instance

Either fix alone closes the double-booking hazard; together the counter also stays truthful for capacity metrics and the `instances` admin CLI.

## Testing

- New regression test: a dedicated writer with drifted `database_count: 0` but an active graph in the graph registry is not selected (`test_find_best_instance_ignores_drifted_instance_counter`), plus a test that `deleted`/`failed` rows don't consume capacity
- Existing `_find_best_instance` and allocation tests updated to stub the new graph-registry query path (occupancy-by-instance helper) across all three allocation test files
- `just test middleware/graph` — 625 passed; full unit suite 2771 passed with 1 pre-existing order-dependent failure in `tests/graph_api/.../test_incremental_materialize.py` (passes in isolation, unrelated to this diff, and present on runs before these changes)
- `just test-code` — ruff, format, basedpyright, cf-lint clean

## Notes

- No ASG refresh needed: the allocation fix ships with the normal API deploy; the registration fix is boot-time-only and is pulled fresh from S3 at each future instance launch
- The two currently-drifted prod rows can be healed manually (two DynamoDB updates) or left to self-correct at the next instance cycle — allocation is safe either way once this deploys
