### PR TITLE
chore(docker): add `just upgrade` to refresh stale local images

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,8 @@ LOG_LEVEL=INFO
 ## Docker Image Configuration
 ## - New users: Keep these to pull pre-built images (~10s download)
 ## - Developers: Comment out to build locally from Dockerfile (~3 min build)
+## Images are cached after the first pull — run `just upgrade` to fetch newer ones
+## (works in both modes; a plain `just start` will keep running the cached image)
 ROBOSYSTEMS_IMAGE=robofinsystems/robosystems:latest
 ROBOSYSTEMS_PULL_POLICY=if_not_present
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,7 @@ curl -X POST "http://localhost:8000/v1/graphs/$GRAPH_ID/operations/materialize" 
 
 ```bash
 just start                 # Start full Docker stack
+just upgrade               # Fetch latest images (or rebuild) and recreate what changed
 just restart               # Quick restart (Python code changes only)
 just rebuild               # Full rebuild (dependency/Dockerfile changes)
 just test                  # Run tests (excludes slow/integration)

--- a/README.md
+++ b/README.md
@@ -62,14 +62,17 @@ Dedicated frontend app: [`roboinvestor-app`](https://github.com/RoboFinSystems/r
 ### Docker Development Environment
 
 ```bash
-# Install uv and just
-brew install uv just
+# Install uv and just (jq ships with macOS 15+; install it on older macOS or Linux)
+brew install uv just jq
 
 # Start robosystems backend api
 just start
 
 # Start frontend apps - robosystems-app, roboledger-app, roboinvestor-app
 just start apps
+
+# Fetch the latest images and recreate anything that changed (after a git pull)
+just upgrade
 ```
 
 This initializes the `.env` file and starts the complete RoboSystems stack with:

--- a/bin/tools/upgrade.sh
+++ b/bin/tools/upgrade.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+set -e
+
+# Upgrade the local Docker stack, brew-style.
+#
+# Compose caches images with pull_policy=if_not_present, so a published image
+# is never re-fetched once it is on disk — pulling the repo does not update
+# the containers. This refreshes them:
+#
+#   image mode (ROBOSYSTEMS_IMAGE points at a registry)  -> pull --policy always
+#   build mode (image is a bare local tag)               -> build --pull
+#
+# Then recreates only the containers whose image actually changed.
+#
+# Usage: ./bin/tools/upgrade.sh [profile] [scope]
+#   profile  compose profile to upgrade (default: robosystems)
+#   scope    "all" also refreshes upstream images (postgres, valkey, opensearch, ...)
+
+PROFILE=${1:-robosystems}
+SCOPE=${2:-}
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "❌ jq is required by this command (brew install jq)"
+  exit 1
+fi
+
+test -f .env || cp .env.example .env
+
+COMPOSE="docker compose -f compose.yaml --env-file .env --profile ${PROFILE}"
+
+echo "🔍 Resolving images for profile '${PROFILE}'..."
+
+# Services with a build: section are ours; everything else is an upstream image.
+SERVICES=$(${COMPOSE} config --format json |
+  jq -r '.services | to_entries[] | select(.value.build != null) | "\(.key) \(.value.image)"')
+
+if [ -z "$SERVICES" ]; then
+  echo "❌ No RoboSystems services found in profile '${PROFILE}'"
+  exit 1
+fi
+
+# A registry reference contains a slash (robofinsystems/robosystems:latest);
+# a bare tag (robosystems-local) means the service is built from source here.
+PULL_SVCS=""
+BUILD_SVCS=""
+PULL_IMAGES=""
+while read -r SVC IMAGE; do
+  [ -z "$SVC" ] && continue
+  case "$IMAGE" in
+  */*)
+    PULL_SVCS="$PULL_SVCS $SVC"
+    case " $PULL_IMAGES " in
+    *" $IMAGE "*) ;;
+    *) PULL_IMAGES="$PULL_IMAGES $IMAGE" ;;
+    esac
+    ;;
+  *) BUILD_SVCS="$BUILD_SVCS $SVC" ;;
+  esac
+done <<EOF
+$SERVICES
+EOF
+
+# Snapshot image IDs so we can report what actually moved.
+BEFORE=""
+for IMAGE in $PULL_IMAGES; do
+  BEFORE="$BEFORE$IMAGE $(docker image inspect --format '{{.Id}}' "$IMAGE" 2>/dev/null || echo absent)
+"
+done
+
+if [ -n "$PULL_SVCS" ]; then
+  echo "📥 Pulling published images:$PULL_SVCS"
+  ${COMPOSE} pull --policy always $PULL_SVCS
+fi
+
+if [ "$SCOPE" = "all" ]; then
+  echo "📥 Refreshing upstream images (postgres, valkey, opensearch, ...)"
+  ${COMPOSE} pull --policy always --ignore-buildable --ignore-pull-failures
+fi
+
+if [ -n "$BUILD_SVCS" ]; then
+  echo "🔨 Rebuilding from source:$BUILD_SVCS"
+  ${COMPOSE} build --pull $BUILD_SVCS
+fi
+
+echo "🚀 Recreating containers whose image changed..."
+${COMPOSE} up --detach
+
+short_id() {
+  case "$1" in
+  sha256:*) echo "${1:7:12}" ;;
+  *) echo "$1" ;;
+  esac
+}
+
+echo ""
+echo "📋 Result:"
+for IMAGE in $PULL_IMAGES; do
+  OLD=$(echo "$BEFORE" | awk -v i="$IMAGE" '$1 == i {print $2}')
+  NEW=$(docker image inspect --format '{{.Id}}' "$IMAGE" 2>/dev/null || echo absent)
+  if [ "$OLD" = "$NEW" ]; then
+    echo "  ✅ ${IMAGE} already up to date"
+  else
+    echo "  ⬆️  ${IMAGE} updated ($(short_id "$OLD") → $(short_id "$NEW"))"
+  fi
+done
+
+if [ -n "$BUILD_SVCS" ]; then
+  echo "  🔨 rebuilt from source:$BUILD_SVCS"
+fi
+
+if [ "$SCOPE" != "all" ]; then
+  echo ""
+  echo "💡 Upstream images (postgres, valkey, ...) were left alone — 'just upgrade ${PROFILE} all' refreshes those too"
+fi

--- a/justfile
+++ b/justfile
@@ -8,6 +8,7 @@
 #
 # QUICK START:
 #   just start             # Full Docker setup (creates .env files automatically)
+#   just upgrade           # Fetch the latest images / rebuild, recreate what changed
 #   just restart           # After code changes (no rebuild)
 #   just test              # Run tests
 #   just logs api          # View API logs
@@ -39,6 +40,10 @@ stop profile="robosystems":
 # Tear down and remove containers entirely
 teardown profile="robosystems":
     docker compose -f compose.yaml --profile {{profile}} down
+
+# Upgrade to the latest images - pulls published images, or rebuilds in build mode (scope="all" also refreshes postgres/valkey/opensearch)
+upgrade profile="robosystems" scope="":
+    @bin/tools/upgrade.sh {{profile}} {{scope}}
 
 # Rebuild containers (rebuilds images and force recreates - for package/env changes)
 rebuild profile="robosystems":


### PR DESCRIPTION
## Problem

`compose.yaml` sets `pull_policy: ${ROBOSYSTEMS_PULL_POLICY:-never}`, and `.env.example` ships image mode with `if_not_present`. Once a published image is on disk it is never re-fetched — so pulling the repo leaves containers running an old image, and `just start` will happily keep doing so forever.

Because only `./robosystems` is bind-mounted, the source always looks current while the drift sits in dependencies, `bin/entrypoint.sh` (which runs migrations), `alembic/`, and the baked `frameworks/`. That makes it a confusing class of failure to debug.

## What this adds

`just upgrade [profile] [scope]` → `bin/tools/upgrade.sh`, the `brew upgrade` analogue for the local stack.

It asks compose for the resolved image of every service with a `build:` section (those are ours; the rest are upstream) and picks a path **per service**, so a mixed `.env` — backend built locally, apps from Docker Hub — does the right thing on each half:

| Resolved image | Action |
| --- | --- |
| registry ref (`robofinsystems/robosystems:latest`) | `pull --policy always` (overrides the cached `if_not_present`) |
| bare local tag (`robosystems-local`) | `build --pull` |

It then runs a plain `up --detach` — no `--force-recreate` — so only containers whose image ID actually moved get recreated.

Two notes on the build-mode path:

- `--pull` re-resolves the Dockerfile `FROM` tags (`ghcr.io/ladybugdb/extension-repo:latest`, `python:3.13-slim`). Both are moving tags that a plain `just rebuild` silently keeps cached, so build-mode users were quietly running stale bases.
- `scope="all"` also refreshes upstream images (postgres, valkey, opensearch, localstack). Left out of the default because those tags move too and a surprise Postgres minor bump on a routine upgrade is not what anyone wants.

## Verification

Real run in build mode (the current `.env` here):

```
📋 Result:
  🔨 rebuilt from source: api dagster-daemon dagster-webserver graph-api worker
```

`docker ps` afterwards showed the five rebuilt services at `Up 5 seconds` while `pg`, `valkey`, `opensearch` and `localstack` stayed `Up 14 hours` untouched — as did the `apps`-profile containers. The `--pull` re-pulled a moved `ghcr.io/ladybugdb/extension-repo:latest` (1.97 GB), confirming the stale-base problem was real. API came back green (`GET /v1/status → 200`, graph-api `/health → 200`).

Image mode verified via `docker compose pull --dry-run` in both scopes, including that `--ignore-buildable` correctly limits the upstream refresh to the four third-party services.

## Notes

- `jq` is now a hard requirement of this command, with a clear error message. It ships with macOS 15+ at `/usr/bin/jq` and the wiki already lists it as a prereq (`Bootstrap-Guide`, `Quick-Start`); the README brew line is updated to match for older macOS and Linux.
- Docs updated where these commands are enumerated: README quick start, `CLAUDE.md` daily development, and the `.env.example` image block — the place someone reads when wondering why their containers are stale.