### PR TITLE
feat(forecast): line assertions — manual statement-line overrides on scenarios

### DIFF
--- a/frameworks/rs-gaap/packages/rs-gaap-calculations/v1/taxonomy.jsonld
+++ b/frameworks/rs-gaap/packages/rs-gaap-calculations/v1/taxonomy.jsonld
@@ -1366,6 +1366,20 @@
       "@type": "rs:Association"
     },
     {
+      "@id": "_:rs-gaap-deriv-cf-ap-arc-2",
+      "from": {
+        "@id": "rs-gaap:IncreaseDecreaseInAccountsPayableAndAccruedLiabilities"
+      },
+      "to": {
+        "@id": "rs-gaap:AccountsPayableCurrent"
+      },
+      "associationType": "derivation",
+      "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-calculations/CashFlowStatement",
+      "weight": 1.0,
+      "order": 200.0,
+      "@type": "rs:Association"
+    },
+    {
       "@id": "_:rs-gaap-deriv-cf-other-op-arc-1",
       "from": {
         "@id": "rs-gaap:IncreaseDecreaseInOtherOperatingCapitalNet"

--- a/robosystems/models/api/extensions/forecasts.py
+++ b/robosystems/models/api/extensions/forecasts.py
@@ -75,6 +75,59 @@ class LeverAssertionRequest(BaseModel):
     return self
 
 
+class LineAssertionRequest(BaseModel):
+  """One statement line's directly asserted values for the scenario.
+
+  The manual-override half of the authored surface: where a lever
+  asserts a *driver* (growth %, DSO) whose rule derives the line, a
+  line assertion asserts the **line itself** — an rs-gaap (or tenant
+  extension) statement leaf pinned to typed values for the months it
+  names. Assertions win over driver rules and carry-forward for those
+  months (a displaced rule lands in ``skipped``, legibly); months the
+  assertion doesn't name keep the engine's normal derivation.
+
+  **Leaves only** — subtotals stay calc-DAG-derived, so a manually set
+  line still articulates through RollUps, RE, balancing cash, and the
+  derived CF, and stays verification-gated (the whole pitch vs a
+  spreadsheet cell). The create handler rejects calc-parent qnames.
+
+  Value/period grammar is identical to levers: ``value`` is a uniform
+  fill across the horizon, ``values_by_period`` overrides individual
+  months. The canonical uses: zero out a base-month one-off so
+  carry-forward stops replicating it, or hold a line at a known budget
+  number no driver models.
+  """
+
+  qname: str = Field(
+    ...,
+    description=(
+      "QName of the statement leaf to assert (e.g. "
+      "``rs-gaap:NonoperatingIncomeExpense``). Must be a calc-DAG leaf; "
+      "rs-driver concepts belong in ``levers``."
+    ),
+  )
+  value: float | None = Field(
+    None,
+    description="Uniform value asserted for every month of the horizon.",
+  )
+  values_by_period: dict[str, float] | None = Field(
+    None,
+    description=(
+      "Per-month overrides keyed by ``YYYY-MM``. Wins over ``value`` "
+      "for the months it names."
+    ),
+  )
+
+  @model_validator(mode="after")
+  def _require_some_value(self) -> LineAssertionRequest:
+    if self.value is None and not self.values_by_period:
+      raise ValueError(
+        f"Line assertion {self.qname!r} needs a uniform `value` and/or "
+        "`values_by_period` overrides."
+      )
+    return self
+
+
 class CreateForecastRequest(BaseModel):
   """Create a forecast block — the authored scenario container.
 
@@ -139,6 +192,14 @@ class CreateForecastRequest(BaseModel):
     min_length=1,
     description="Lever assertions — at least one.",
   )
+  line_assertions: list[LineAssertionRequest] = Field(
+    default_factory=list,
+    description=(
+      "Direct statement-line assertions (manual overrides). Each names "
+      "a calc-DAG leaf and wins over driver rules and carry-forward "
+      "for the months it asserts."
+    ),
+  )
   entity_id: str | None = Field(
     None,
     description=(
@@ -151,11 +212,13 @@ class CreateForecastRequest(BaseModel):
 class UpdateForecastRequest(BaseModel):
   """Update a forecast block in place.
 
-  Mutable: name, scenario_kind, horizon_months, base_period, levers.
-  ``levers`` is a **full replace** when provided (partial lever edits
-  would make the asserted set ambiguous). Updating does NOT recompute —
-  previously computed scenario months go stale until the next
-  ``compute-forecast`` run (the compute-metrics drift semantics).
+  Mutable: name, scenario_kind, horizon_months, base_period, levers,
+  line_assertions. ``levers`` and ``line_assertions`` are each a
+  **full replace** when provided (partial edits would make the asserted
+  set ambiguous); replacing one leaves the other as stored. Updating
+  does NOT recompute — previously computed scenario months go stale
+  until the next ``compute-forecast`` run (the compute-metrics drift
+  semantics).
   """
 
   structure_id: str = Field(..., description="Structure ID of the forecast block.")
@@ -167,6 +230,13 @@ class UpdateForecastRequest(BaseModel):
     None,
     min_length=1,
     description="Full replacement of the lever set when provided.",
+  )
+  line_assertions: list[LineAssertionRequest] | None = Field(
+    None,
+    description=(
+      "Full replacement of the line-assertion set when provided. Pass "
+      "an empty list to clear every assertion."
+    ),
   )
 
 

--- a/robosystems/models/api/information_block.py
+++ b/robosystems/models/api/information_block.py
@@ -618,6 +618,44 @@ class LeverAssertionLite(BaseModel):
   )
 
 
+class LineAssertionLite(BaseModel):
+  """One statement line's persisted direct assertion inside
+  ``ForecastMechanics``.
+
+  The manual-override sibling of :class:`LeverAssertionLite`: a lever
+  asserts a *driver* whose rule derives a line; a line assertion pins
+  the **line itself** (a calc-DAG leaf) to typed values for the months
+  it names — winning over driver rules and carry-forward for exactly
+  those months (a displaced rule surfaces in the compute response's
+  ``skipped`` list). Subtotals stay calc-DAG-derived, so a manual line
+  still articulates through RollUps, RE, balancing cash, and derived
+  CF, and stays verification-gated.
+
+  Same persistence doctrine as levers: values are duplicated as
+  authored facts in the scenario's lever FactSet (facts are what
+  ``compute-forecast`` binds); this mechanics copy is the
+  operator-legible round-trip shape.
+  """
+
+  qname: str = Field(..., description="Asserted statement-leaf qname.")
+  element_id: str = Field(..., description="Resolved tenant element id.")
+  item_type: str | None = Field(
+    None,
+    description="Format family from the element (monetary | ...).",
+  )
+  period_type: str = Field(
+    "duration",
+    description=(
+      "The element's period type — duration assertions pin IS lines; "
+      "instant assertions pin BS lines through the roll."
+    ),
+  )
+  values_by_period: dict[str, float] = Field(
+    ...,
+    description="Expanded per-month assertions keyed by ``YYYY-MM``.",
+  )
+
+
 class ForecastMechanics(BaseModel):
   """Authored scenario container for ``block_type='forecast'`` (FP&A F-1).
 
@@ -655,6 +693,14 @@ class ForecastMechanics(BaseModel):
   levers: list[LeverAssertionLite] = Field(
     ...,
     description="Expanded lever assertions (authoring order).",
+  )
+  line_assertions: list[LineAssertionLite] = Field(
+    default_factory=list,
+    description=(
+      "Direct statement-line assertions (authoring order) — manual "
+      "overrides that win over driver rules and carry-forward for the "
+      "months they name."
+    ),
   )
   computed_months: int = Field(
     default=0,
@@ -1910,6 +1956,7 @@ __all__ = [
   "InformationBlockEnvelope",
   "InformationModelResponse",
   "LeverAssertionLite",
+  "LineAssertionLite",
   "MetricMechanics",
   "RenderingLite",
   "RenderingPeriodLite",

--- a/robosystems/operations/information_block/forecast.py
+++ b/robosystems/operations/information_block/forecast.py
@@ -1,19 +1,22 @@
 """Handlers for ``block_type='forecast'`` — the authored scenario container.
 
 The forecast block is the FP&A engine's authored surface (F-1): scenario
-identity (name + ``scenario_kind``), horizon, base period, and lever
-assertions on ``rs-driver:*`` catalog elements. The block IS the
+identity (name + ``scenario_kind``), horizon, base period, lever
+assertions on ``rs-driver:*`` catalog elements, and direct **line
+assertions** on statement leaves (manual overrides that win over driver
+rules and carry-forward for the months they name). The block IS the
 scenario — its structure id is the ``scenario_id`` every derived forward
 FactSet carries (NULL = actuals), and deleting the block removes the
 whole scenario slice.
 
 Persistence follows the rules-for-mechanics / **facts-for-values**
 doctrine: lever *mechanics* are the library-seeded rs-driver Derive
-rules; lever *values* land as authored Numeric facts in ONE
-``factset_type='custom'`` FactSet whose ``scenario_id`` is the forecast
-block itself (self-referential — the levers belong to the scenario,
-cascade-delete with it, and stay invisible to actuals reads and to
-metric operand binding, which only joins ``('report', 'metric')`` sets).
+rules; lever and line-assertion *values* land as authored Numeric facts
+in ONE ``factset_type='custom'`` FactSet whose ``scenario_id`` is the
+forecast block itself (self-referential — the assertions belong to the
+scenario, cascade-delete with it, and stay invisible to actuals reads
+and to metric operand binding, which only joins ``('report', 'metric')``
+sets).
 
 ``create`` / ``update`` / ``delete`` follow the Schedule/rollforward
 declarative pattern; ``build_envelope`` renders the lever grid
@@ -37,6 +40,7 @@ from robosystems.models.api.information_block import (
   InformationBlockEnvelope,
   InformationModelResponse,
   LeverAssertionLite,
+  LineAssertionLite,
   RenderingLite,
   RenderingPeriodLite,
   RenderingRowLite,
@@ -62,6 +66,9 @@ from robosystems.operations.roboledger.fiscal_calendar.periods import (
   period_date_range,
   period_from_date,
 )
+from robosystems.operations.roboledger.reports.calc_dag import (
+  load_rs_gaap_calculations,
+)
 from robosystems.utils.ulid import generate_prefixed_ulid
 
 if TYPE_CHECKING:
@@ -71,6 +78,7 @@ if TYPE_CHECKING:
     CreateForecastRequest,
     DeleteForecastRequest,
     LeverAssertionRequest,
+    LineAssertionRequest,
     UpdateForecastRequest,
   )
 
@@ -181,6 +189,99 @@ def _expand_levers(
   return expanded
 
 
+_ASSERTION_BLOCKED_SOURCES = {
+  _LEVER_SOURCE: "rs-driver concepts are levers — assert them via `levers`",
+  "rs-metric": "rs-metric concepts are computed by compute-metrics, never asserted",
+}
+
+
+def _expand_line_assertions(
+  session: Session,
+  assertions: list[LineAssertionRequest],
+  base_period: str,
+  horizon_months: int,
+) -> list[LineAssertionLite]:
+  """Resolve + expand wire-level line assertions to explicit per-month maps.
+
+  Same grammar and expansion as levers; the validation differs: an
+  assertion names a **statement leaf** — any resolvable non-abstract
+  concept that isn't an rs-driver lever or rs-metric output, and isn't
+  a parent in the global rs-gaap calc DAG (**leaves only** — subtotals
+  stay derived so a manual line still articulates and stays
+  verification-gated).
+  """
+  if not assertions:
+    return []
+
+  months = [add_months(base_period, i) for i in range(1, horizon_months + 1)]
+  month_set = set(months)
+  calc_parent_ids = set(load_rs_gaap_calculations(session).keys())
+
+  expanded: list[LineAssertionLite] = []
+  seen: set[str] = set()
+  for assertion in assertions:
+    if assertion.qname in seen:
+      raise ValueError(
+        f"Duplicate line-assertion qname {assertion.qname!r} in the assertion set."
+      )
+    seen.add(assertion.qname)
+
+    element = session.execute(
+      select(Element).where(Element.qname == assertion.qname).limit(1)
+    ).scalar_one_or_none()
+    if element is None:
+      raise ValueError(
+        f"Line-assertion qname {assertion.qname!r} did not resolve to an "
+        "Element — assertions name rs-gaap (or tenant extension) "
+        "statement concepts."
+      )
+    blocked = _ASSERTION_BLOCKED_SOURCES.get(element.source or "")
+    if blocked is not None:
+      raise ValueError(f"Line-assertion qname {assertion.qname!r}: {blocked}.")
+    if element.is_abstract:
+      raise ValueError(
+        f"Line-assertion qname {assertion.qname!r} is abstract — assert a "
+        "concrete statement leaf."
+      )
+    if element.id in calc_parent_ids:
+      raise ValueError(
+        f"Line-assertion qname {assertion.qname!r} is a calc-DAG subtotal — "
+        "assertions are leaves-only so the manual value still articulates "
+        "(subtotals derive from their children)."
+      )
+
+    overrides = assertion.values_by_period or {}
+    outside = sorted(set(overrides) - month_set)
+    if outside:
+      raise ValueError(
+        f"Line assertion {assertion.qname!r} has values_by_period entries "
+        f"outside the horizon ({base_period} + {horizon_months} months): "
+        f"{outside}"
+      )
+
+    values: dict[str, float] = {}
+    for month in months:
+      if month in overrides:
+        values[month] = float(overrides[month])
+      elif assertion.value is not None:
+        values[month] = float(assertion.value)
+    if not values:
+      raise ValueError(
+        f"Line assertion {assertion.qname!r} asserts no months within the horizon."
+      )
+
+    expanded.append(
+      LineAssertionLite(
+        qname=assertion.qname,
+        element_id=element.id,
+        item_type=element.item_type,
+        period_type=element.period_type or "duration",
+        values_by_period=values,
+      )
+    )
+  return expanded
+
+
 def _load_lever_fact_set(session: Session, structure_id: str) -> FactSet | None:
   """The scenario's lever FactSet — ``'custom'`` + self-referential scenario."""
   return session.execute(
@@ -202,8 +303,11 @@ def _write_lever_fact_set(
   entity_id: str,
   created_by: str,
 ) -> FactSet:
-  """Persist the lever assertions as authored facts in one scenario set."""
-  asserted_months = sorted({m for lv in mechanics.levers for m in lv.values_by_period})
+  """Persist the lever + line assertions as authored facts in one scenario set."""
+  asserted_months = sorted(
+    {m for lv in mechanics.levers for m in lv.values_by_period}
+    | {m for la in mechanics.line_assertions for m in la.values_by_period}
+  )
   span_start = period_date_range(asserted_months[0])[0]
   span_end = period_date_range(asserted_months[-1])[1]
 
@@ -222,34 +326,44 @@ def _write_lever_fact_set(
   )
   session.flush()
 
+  authored_element_ids = [lv.element_id for lv in mechanics.levers] + [
+    la.element_id for la in mechanics.line_assertions
+  ]
   elements_by_id = {
     e.id: e
     for e in session.execute(
-      select(Element).where(Element.id.in_([lv.element_id for lv in mechanics.levers]))
+      select(Element).where(Element.id.in_(authored_element_ids))
     )
     .scalars()
     .all()
   }
-  for lever in mechanics.levers:
-    element = elements_by_id.get(lever.element_id)
+
+  def _add_fact(element_id: str, month: str, value: float, period_type: str) -> None:
+    element = elements_by_id.get(element_id)
     unit = _metric_unit(element) if element is not None else "pure"
-    for month, value in sorted(lever.values_by_period.items()):
-      month_start, month_end = period_date_range(month)
-      session.add(
-        Fact(
-          id=generate_prefixed_ulid("fact"),
-          element_id=lever.element_id,
-          value=value,
-          fact_type="Numeric",
-          period_start=month_start,
-          period_end=month_end,
-          period_type="duration",
-          unit=unit,
-          entity_id=entity_id,
-          structure_id=structure.id,
-          fact_set_id=fact_set.id,
-        )
+    month_start, month_end = period_date_range(month)
+    session.add(
+      Fact(
+        id=generate_prefixed_ulid("fact"),
+        element_id=element_id,
+        value=value,
+        fact_type="Numeric",
+        period_start=None if period_type == "instant" else month_start,
+        period_end=month_end,
+        period_type=period_type,
+        unit=unit,
+        entity_id=entity_id,
+        structure_id=structure.id,
+        fact_set_id=fact_set.id,
       )
+    )
+
+  for lever in mechanics.levers:
+    for month, value in sorted(lever.values_by_period.items()):
+      _add_fact(lever.element_id, month, value, "duration")
+  for assertion in mechanics.line_assertions:
+    for month, value in sorted(assertion.values_by_period.items()):
+      _add_fact(assertion.element_id, month, value, assertion.period_type)
   session.flush()
   return fact_set
 
@@ -266,12 +380,16 @@ def create(
   entity_id = payload.entity_id or _default_entity_id(session)
   base_period = _resolve_base_period(session, entity_id, payload.base_period)
   levers = _expand_levers(session, payload.levers, base_period, payload.horizon_months)
+  line_assertions = _expand_line_assertions(
+    session, payload.line_assertions, base_period, payload.horizon_months
+  )
 
   mechanics = ForecastMechanics(
     scenario_kind=payload.scenario_kind,
     horizon_months=payload.horizon_months,
     base_period=base_period,
     levers=levers,
+    line_assertions=line_assertions,
   )
 
   # The lever elements all live in the tenant's rs-driver taxonomy —
@@ -340,21 +458,33 @@ def update(
       "— the horizon window shifted, so every lever's per-month assertions "
       "must be restated."
     )
+  if window_changed and payload.line_assertions is None and current.line_assertions:
+    raise ValueError(
+      "Changing horizon_months or base_period requires re-supplying "
+      "`line_assertions` (or an empty list to clear them) — the horizon "
+      "window shifted, so every asserted month must be restated."
+    )
 
   levers = current.levers
   if payload.levers is not None:
     levers = _expand_levers(session, payload.levers, base_period, horizon_months)
+  line_assertions = current.line_assertions
+  if payload.line_assertions is not None:
+    line_assertions = _expand_line_assertions(
+      session, payload.line_assertions, base_period, horizon_months
+    )
 
   next_mechanics = ForecastMechanics(
     scenario_kind=scenario_kind,
     horizon_months=horizon_months,
     base_period=base_period,
     levers=levers,
+    line_assertions=line_assertions,
   )
   structure.artifact_mechanics = next_mechanics.model_dump(mode="json")
   structure.updated_by = updated_by
 
-  if payload.levers is not None:
+  if payload.levers is not None or payload.line_assertions is not None:
     existing = _load_lever_fact_set(session, structure.id)
     entity_id = existing.entity_id if existing is not None else None
     if existing is not None:
@@ -466,17 +596,18 @@ def build_envelope(
   )
   mechanics = mechanics.model_copy(update={"computed_months": len(computed_months)})
 
-  # Lever elements are not reachable via associations (the container is
-  # arc-less) — load them off the mechanics for the envelope's element
-  # list and the row metadata.
-  lever_elements = list(
-    session.execute(
-      select(Element).where(Element.id.in_([lv.element_id for lv in mechanics.levers]))
-    )
+  # Authored elements (levers + line assertions) are not reachable via
+  # associations (the container is arc-less) — load them off the
+  # mechanics for the envelope's element list and the row metadata.
+  authored_element_ids = [lv.element_id for lv in mechanics.levers] + [
+    la.element_id for la in mechanics.line_assertions
+  ]
+  authored_elements = list(
+    session.execute(select(Element).where(Element.id.in_(authored_element_ids)))
     .scalars()
     .all()
   )
-  elements_by_id = {e.id: e for e in lever_elements}
+  elements_by_id = {e.id: e for e in authored_elements}
 
   months = [
     add_months(mechanics.base_period, i) for i in range(1, mechanics.horizon_months + 1)
@@ -496,6 +627,27 @@ def build_envelope(
     )
     for lever in mechanics.levers
   ]
+  # Line assertions render as additional assumption rows — the manual
+  # overrides sit in the same grid the levers do, in authoring order.
+  rows.extend(
+    RenderingRowLite(
+      element_id=assertion.element_id,
+      element_qname=assertion.qname,
+      element_name=(
+        elements_by_id[assertion.element_id].name
+        if assertion.element_id in elements_by_id
+        else assertion.qname
+      ),
+      balance_type=(
+        elements_by_id[assertion.element_id].balance_type
+        if assertion.element_id in elements_by_id
+        else None
+      ),
+      item_type=assertion.item_type,
+      values=[assertion.values_by_period.get(month) for month in months],
+    )
+    for assertion in mechanics.line_assertions
+  )
   rendering = RenderingLite(
     rows=rows,
     periods=[
@@ -536,7 +688,7 @@ def build_envelope(
       template=None,
       mechanics=mechanics,
     ),
-    elements=elements_to_lites(session, lever_elements),
+    elements=elements_to_lites(session, authored_elements),
     connections=[],
     facts=[fact_to_lite(f, elements_by_id) for f in facts],
     rules=atoms.rules,

--- a/robosystems/operations/information_block/forecast_articulation.py
+++ b/robosystems/operations/information_block/forecast_articulation.py
@@ -84,11 +84,14 @@ _PPE_ROUTES: dict[str, float] = {
   "rs-gaap:AccumulatedDepreciationDepletionAndAmortizationPropertyPlantAndEquipment": -1.0,
 }
 
-# The library's AP derivation arc sources the combined
+# The library's original AP derivation arc sourced only the combined
 # AccountsPayableAndAccruedLiabilitiesCurrent anchor; tenants mapped to
 # the sibling AccountsPayableCurrent (the DPO rule's target) would land
 # their AP movement in the reconciling plug instead of the named CF
-# line. Supplement the arc in code until the library grows the arc.
+# line. The library now carries the split-anchor arc too
+# (deriv-cf-ap-arc-2), but it reaches an existing tenant only at its
+# next resync — this alias bridges that window (the guard below makes
+# it a no-op once the arc is present).
 _AP_CF_LEAF_QNAME = "rs-gaap:IncreaseDecreaseInAccountsPayableAndAccruedLiabilities"
 _AP_ALIAS_SOURCE_QNAME = "rs-gaap:AccountsPayableCurrent"
 

--- a/robosystems/operations/information_block/forecast_compute.py
+++ b/robosystems/operations/information_block/forecast_compute.py
@@ -8,6 +8,11 @@ month at a time from the block's ``base_period``:
 1. **Carry-forward** — every IS leaf that carried a fact in the base
    month's actual report and isn't rule-driven repeats its prior value
    (the engine default for unmodeled lines — no rules involved).
+   **Line assertions** override both carry and schedule projection for
+   the months they name (the manual-override half of the authored
+   surface — zero out a base-month one-off, hold a line at a budget
+   number), and displace a driver rule targeting the same element that
+   month (the rule lands in ``skipped``, legibly).
 2. **Driver rules** — the rs-driver catalog's ``Derive`` rules, in
    dependency order (``topo_sort_calculations`` over same-month operand
    edges). A rule is *active* for the scenario iff every rs-driver
@@ -258,18 +263,27 @@ def cmd_compute_forecast(
     )
   entity_id = body.entity_id or lever_set.entity_id or _default_entity_id(session)
 
-  # Lever VALUES bind from the scenario's authored facts (facts are the
-  # values; the mechanics copy is the legible round-trip shape).
+  # Lever + line-assertion VALUES bind from the scenario's authored
+  # facts (facts are the values; the mechanics copy is the legible
+  # round-trip shape). Levers key by qname (rule operands name qnames);
+  # assertions key by element id (the walk works in element-id space).
   element_qname_by_id: dict[str, str] = {
     lv.element_id: lv.qname for lv in mechanics.levers
   }
+  assertion_period_type: dict[str, str] = {
+    la.element_id: la.period_type for la in mechanics.line_assertions
+  }
   lever_values: dict[str, dict[str, float]] = {}
+  assertion_values: dict[str, dict[str, float]] = {}
   for fact in _numeric_facts(session, lever_set.id):
-    qname = element_qname_by_id.get(fact.element_id)
-    if qname is None or fact.value is None:
+    if fact.value is None:
       continue
     month = period_from_date(fact.period_end)
-    lever_values.setdefault(qname, {})[month] = float(fact.value)
+    qname = element_qname_by_id.get(fact.element_id)
+    if qname is not None:
+      lever_values.setdefault(qname, {})[month] = float(fact.value)
+    elif fact.element_id in assertion_period_type:
+      assertion_values.setdefault(fact.element_id, {})[month] = float(fact.value)
 
   # ── Resolve the actual structures + seed month ────────────────────────
   is_structure_id = _newest_actual_structure_id(session, "income_statement")
@@ -501,8 +515,31 @@ def cmd_compute_forecast(
         if delta:
           current[element_id] += delta
 
+    # (a3) Line assertions — the manual overrides win over carry and
+    # schedule projection for the months they name; a displaced driver
+    # rule is skipped legibly in (b), and dependent rules bind the
+    # asserted value through the same-month operand path.
+    asserted_this_month: set[str] = set()
+    for element_id, by_month in assertion_values.items():
+      if month in by_month:
+        current[element_id] = by_month[month]
+        asserted_this_month.add(element_id)
+    month_asserted_instants = {
+      el for el in asserted_this_month if assertion_period_type.get(el) == "instant"
+    }
+
     # (b) Driver rules in same-month dependency order.
     for ar in ordered_active:
+      if ar.target.id in asserted_this_month:
+        skipped.append(
+          SkippedForecastLite(
+            rule_id=ar.rule.id,
+            element_qname=ar.target.qname,
+            period=month,
+            reason="displaced by line assertion",
+          )
+        )
+        continue
       raw = ar.rule.rule_expression if isinstance(ar.rule.rule_expression, str) else ""
       expr, prior_operands = desugar_priors(raw)
       expr, avg_operands = desugar_aggregates(expr)
@@ -615,8 +652,11 @@ def cmd_compute_forecast(
     # parent's carried children proportionally, the workbook's implicit
     # semantics (every revenue stream grows at g). Without this the
     # statement's own RollUp verification fails: driven parent, stale
-    # children.
-    _scale_rule_target_children(current, active_target_ids, calculations)
+    # children. Asserted leaves are pinned — the remainder distributes
+    # over the unpinned children only.
+    _scale_rule_target_children(
+      current, active_target_ids, calculations, pinned=asserted_this_month
+    )
 
     # (c) Calc-DAG subtotals — derive, never carry (present = direct wins).
     resolved = resolve_calc_dag(current, set(current), calculations, calc_order)
@@ -630,11 +670,21 @@ def cmd_compute_forecast(
     )
 
     is_facts: list[tuple[Element, float]] = []
+    emitted_is: set[str] = set()
     for element_id in base_is_element_ids:
       element = _element(element_id)
       if element is None or element_id not in resolved:
         continue
       is_facts.append((element, resolved[element_id]))
+      emitted_is.add(element_id)
+    # An asserted duration line absent from the base month's report
+    # (e.g. a budget line the actuals never carried) still emits.
+    for element_id in sorted(
+      asserted_this_month - month_asserted_instants - emitted_is
+    ):
+      element = _element(element_id)
+      if element is not None and element_id in resolved:
+        is_facts.append((element, resolved[element_id]))
 
     # (d2) Balance-sheet roll + derived CF (F-2) — with an articulation
     # context the BS is the full roll (carry, rules, schedules, RE,
@@ -651,7 +701,7 @@ def cmd_compute_forecast(
         prev_end=prev_period_end,
         prior_bs=prior_bs,
         rule_values=current,
-        rule_instant_targets=active_instant_ids,
+        rule_instant_targets=active_instant_ids | month_asserted_instants,
         resolved_is=resolved,
         calculations=calculations,
         calc_order=calc_order,
@@ -683,9 +733,15 @@ def cmd_compute_forecast(
           if element is not None:
             cf_facts.append((element, cf_values[element_id]))
     else:
+      emitted_instants: set[str] = set()
       for ar in ordered_active:
         if ar.target.id in current and ar.target.period_type == "instant":
           bs_facts.append((ar.target, current[ar.target.id]))
+          emitted_instants.add(ar.target.id)
+      for element_id in sorted(month_asserted_instants - emitted_instants):
+        element = _element(element_id)
+        if element is not None and element_id in current:
+          bs_facts.append((element, current[element_id]))
 
     is_set_id = _upsert_month_set(
       session,
@@ -786,6 +842,7 @@ def _scale_rule_target_children(
   current: dict[str, float],
   active_target_ids: set[str],
   calculations: dict[str, list[tuple[str, float]]],
+  pinned: set[str] | None = None,
 ) -> None:
   """Scale a rule-driven calc parent's present children so the
   composition articulates with the driven value.
@@ -796,11 +853,18 @@ def _scale_rule_target_children(
   more honest than inventing a split. A skipped rule that fell back to
   carry scales by exactly 1.0 (children carried too), so this is a no-op
   for inactive months.
+
+  ``pinned`` elements (line-asserted leaves) are never scaled: the
+  driven parent's remainder after the pinned contributions distributes
+  proportionally over the unpinned children. A parent whose children
+  are all pinned (or whose unpinned sum is zero) is left untouched —
+  the visible RollUp failure again beats inventing a split.
   """
+  pinned = pinned or set()
 
   def _scale_subtree(parent: str, factor: float, visited: set[str]) -> None:
     for child, _weight in calculations.get(parent, ()):
-      if child in visited or child not in current:
+      if child in visited or child not in current or child in pinned:
         continue
       visited.add(child)
       current[child] *= factor
@@ -810,12 +874,19 @@ def _scale_rule_target_children(
     children = calculations.get(target)
     if not children or target not in current:
       continue
+    pinned_sum = sum(
+      current[child] * weight
+      for child, weight in children
+      if child in current and child in pinned
+    )
     children_sum = sum(
-      current[child] * weight for child, weight in children if child in current
+      current[child] * weight
+      for child, weight in children
+      if child in current and child not in pinned
     )
     if abs(children_sum) < 1e-9:
       continue
-    factor = current[target] / children_sum
+    factor = (current[target] - pinned_sum) / children_sum
     if factor == 1.0:
       continue
     _scale_subtree(target, factor, set())

--- a/robosystems/operations/information_block/registry.py
+++ b/robosystems/operations/information_block/registry.py
@@ -228,11 +228,14 @@ FORECAST_BLOCK = BlockTypeRegistryEntry(
   icon="trending-up-down",
   description=(
     "Authored scenario container (FP&A) — scenario identity, horizon, "
-    "and lever assertions on the rs-driver catalog. The block IS the "
-    "scenario: compute-forecast walks the driver cascade forward from "
-    "the last closed actuals and lands the derived months in the "
-    "existing statement/metric block types keyed by this block's "
-    "scenario_id (NULL = actuals)."
+    "lever assertions on the rs-driver catalog, and direct line "
+    "assertions on statement leaves (manual overrides that win over "
+    "driver rules and carry-forward for the months they name — zero "
+    "out a base-month one-off, hold a line at a budget number). The "
+    "block IS the scenario: compute-forecast walks the driver cascade "
+    "forward from the last closed actuals and lands the derived months "
+    "in the existing statement/metric block types keyed by this "
+    "block's scenario_id (NULL = actuals)."
   ),
   concept_arrangement_default="set",
   member_arrangement_default=None,

--- a/tests/operations/information_block/test_forecast_compute.py
+++ b/tests/operations/information_block/test_forecast_compute.py
@@ -22,6 +22,7 @@ from robosystems.models.api.information_block import (
   ComputeForecastRequest,
   ForecastMechanics,
   LeverAssertionLite,
+  LineAssertionLite,
 )
 from robosystems.operations.information_block import (
   forecast_compute as fc,
@@ -50,8 +51,22 @@ EL_COGS = _element("el_cogs", "rs-gaap:CostOfRevenue")
 EL_AR = _element("el_ar", "rs-gaap:ReceivablesNetCurrent", period_type="instant")
 EL_RENT = _element("el_rent", "rs-gaap:RentExpense")
 EL_GP = _element("el_gp", "rs-gaap:GrossProfit")
+EL_REV_A = _element("el_rev_a", "rs-gaap:RevenueStreamA")
+EL_REV_B = _element("el_rev_b", "rs-gaap:RevenueStreamB")
+EL_LOAN = _element("el_loan", "rs-gaap:NotesPayable", period_type="instant")
+EL_MKT = _element("el_mkt", "rs-gaap:MarketingExpense")
 
-ELEMENTS = [EL_REV, EL_COGS, EL_AR, EL_RENT, EL_GP]
+ELEMENTS = [
+  EL_REV,
+  EL_COGS,
+  EL_AR,
+  EL_RENT,
+  EL_GP,
+  EL_REV_A,
+  EL_REV_B,
+  EL_LOAN,
+  EL_MKT,
+]
 BY_ID = {e.id: e for e in ELEMENTS}
 BY_QNAME = {e.qname: e for e in ELEMENTS}
 
@@ -108,12 +123,17 @@ BASE_IS_FACTS = [
 CALC_DAG = {"el_gp": [("el_rev", 1.0), ("el_cogs", -1.0)]}
 
 
-def _mechanics(levers: list[LeverAssertionLite], horizon: int = 3) -> dict:
+def _mechanics(
+  levers: list[LeverAssertionLite],
+  horizon: int = 3,
+  assertions: list[LineAssertionLite] | None = None,
+) -> dict:
   return ForecastMechanics(
     scenario_kind="budget",
     horizon_months=horizon,
     base_period="2026-06",
     levers=levers,
+    line_assertions=assertions or [],
   ).model_dump(mode="json")
 
 
@@ -122,6 +142,23 @@ def _lever(qname: str, element_id: str, value: float, months: list[str]) -> Any:
     qname=qname,
     element_id=element_id,
     item_type="percent",
+    values_by_period=dict.fromkeys(months, value),
+  )
+
+
+def _assertion(
+  qname: str,
+  element_id: str,
+  value: float,
+  months: list[str],
+  *,
+  period_type: str = "duration",
+) -> LineAssertionLite:
+  return LineAssertionLite(
+    qname=qname,
+    element_id=element_id,
+    item_type=None,
+    period_type=period_type,
     values_by_period=dict.fromkeys(months, value),
   )
 
@@ -206,6 +243,9 @@ def _run(
   *,
   months: int | None = None,
   bs_structure: str | None = "struct_bs",
+  assertions: list[LineAssertionLite] | None = None,
+  calc_dag: dict | None = None,
+  base_is_facts: list[Any] | None = None,
 ):
   structure = _structure(mechanics)
   recorder = _Recorder()
@@ -215,7 +255,11 @@ def _run(
       block_type
     )
 
-  facts_by_set = {"fs_base_is": BASE_IS_FACTS, "fs_lever": _lever_facts(levers)}
+  authored_facts = _lever_facts(levers) + _lever_facts(assertions or [])
+  facts_by_set = {
+    "fs_base_is": base_is_facts if base_is_facts is not None else BASE_IS_FACTS,
+    "fs_lever": authored_facts,
+  }
 
   with (
     patch.object(fc, "_newest_actual_structure_id", side_effect=_structures),
@@ -231,7 +275,11 @@ def _run(
     ),
     patch.object(fc, "_load_driver_rules", return_value=rules),
     patch.object(fc, "_local_calc_arcs", return_value={}),
-    patch.object(fc, "load_rs_gaap_calculations", return_value=dict(CALC_DAG)),
+    patch.object(
+      fc,
+      "load_rs_gaap_calculations",
+      return_value=dict(calc_dag if calc_dag is not None else CALC_DAG),
+    ),
     patch.object(
       fc,
       "_load_lever_fact_set",
@@ -354,6 +402,122 @@ class TestCascade:
         ComputeForecastRequest(structure_id="struct_metric"),
         "usr_test",
       )
+
+
+class TestLineAssertions:
+  """The manual-override path (fpa §11 #10): assertions win over carry
+  and driver rules for the months they name, articulate through the
+  calc DAG, and pin their values against the rule-delta push-down."""
+
+  def test_assertion_overrides_carry_forward(self) -> None:
+    """The Harbinger case: zero out a base-month one-off so carry stops
+    replicating it into every forward month."""
+    assertions = [_assertion("rs-gaap:RentExpense", "el_rent", 0.0, ALL_MONTHS)]
+    _, rec = _run(
+      _mechanics(FULL_LEVERS, assertions=assertions),
+      FULL_RULES,
+      FULL_LEVERS,
+      assertions=assertions,
+    )
+    for month_end in (JUL, AUG, SEP):
+      assert rec.value("struct_is", month_end, "el_rent") == pytest.approx(0.0)
+
+  def test_assertion_displaces_rule_with_legible_skip(self) -> None:
+    """An asserted month wins over the driver rule (skip recorded);
+    unasserted months fall back to the rule."""
+    assertions = [_assertion("rs-gaap:CostOfRevenue", "el_cogs", 50.0, ["2026-07"])]
+    response, rec = _run(
+      _mechanics(FULL_LEVERS, assertions=assertions),
+      FULL_RULES,
+      FULL_LEVERS,
+      assertions=assertions,
+    )
+    assert rec.value("struct_is", JUL, "el_cogs") == pytest.approx(50.0)
+    assert rec.value("struct_is", AUG, "el_cogs") == pytest.approx(106.09 * 0.62)
+    displaced = [
+      s for s in response.skipped if s.reason == "displaced by line assertion"
+    ]
+    assert [(s.rule_id, s.period) for s in displaced] == [("rule_cogs", "2026-07")]
+
+  def test_asserted_leaf_articulates_through_subtotals(self) -> None:
+    """GrossProfit re-derives against the asserted CostOfRevenue — the
+    manual line still articulates, never breaks the calc DAG."""
+    assertions = [_assertion("rs-gaap:CostOfRevenue", "el_cogs", 50.0, ["2026-07"])]
+    _, rec = _run(
+      _mechanics(FULL_LEVERS, assertions=assertions),
+      FULL_RULES,
+      FULL_LEVERS,
+      assertions=assertions,
+    )
+    assert rec.value("struct_is", JUL, "el_gp") == pytest.approx(103.0 - 50.0)
+
+  def test_asserted_child_is_pinned_against_rule_delta_push_down(self) -> None:
+    """A driven calc parent's remainder distributes over the UNPINNED
+    children only — the asserted child never rescales."""
+    calc_dag = {
+      "el_gp": [("el_rev", 1.0), ("el_cogs", -1.0)],
+      "el_rev": [("el_rev_a", 1.0), ("el_rev_b", 1.0)],
+    }
+    base_facts = [
+      *BASE_IS_FACTS,
+      SimpleNamespace(element_id="el_rev_a", value=60.0),
+      SimpleNamespace(element_id="el_rev_b", value=40.0),
+    ]
+    levers = [_lever("rs-driver:RevenueGrowthRate", "el_growth", 0.03, ALL_MONTHS)]
+    assertions = [_assertion("rs-gaap:RevenueStreamA", "el_rev_a", 30.0, ["2026-07"])]
+    _, rec = _run(
+      _mechanics(levers, assertions=assertions),
+      [GROWTH_RULE],
+      levers,
+      assertions=assertions,
+      calc_dag=calc_dag,
+      base_is_facts=base_facts,
+    )
+    assert rec.value("struct_is", JUL, "el_rev") == pytest.approx(103.0)
+    assert rec.value("struct_is", JUL, "el_rev_a") == pytest.approx(30.0)
+    # Remainder over the unpinned child: (103 - 30) / 40 scales 40 → 73.
+    assert rec.value("struct_is", JUL, "el_rev_b") == pytest.approx(73.0)
+
+  def test_instant_assertion_lands_in_the_bs_set(self) -> None:
+    assertions = [
+      _assertion(
+        "rs-gaap:NotesPayable", "el_loan", 500.0, ALL_MONTHS, period_type="instant"
+      )
+    ]
+    _, rec = _run(
+      _mechanics(FULL_LEVERS, assertions=assertions),
+      FULL_RULES,
+      FULL_LEVERS,
+      assertions=assertions,
+    )
+    assert rec.value("struct_bs", JUL, "el_loan") == pytest.approx(500.0)
+    # Instant assertions never leak into the IS emission.
+    is_call = rec.month("struct_is", JUL)
+    assert is_call is not None
+    assert all(el.id != "el_loan" for el, _ in is_call["facts"])
+
+  def test_asserted_line_absent_from_base_still_emits(self) -> None:
+    assertions = [_assertion("rs-gaap:MarketingExpense", "el_mkt", 5.0, ["2026-07"])]
+    _, rec = _run(
+      _mechanics(FULL_LEVERS, assertions=assertions),
+      FULL_RULES,
+      FULL_LEVERS,
+      assertions=assertions,
+    )
+    assert rec.value("struct_is", JUL, "el_mkt") == pytest.approx(5.0)
+
+  def test_unasserted_months_resume_normal_derivation(self) -> None:
+    """After the asserted window ends, the line carries the last emitted
+    value (the engine's normal carry-forward, seeded by the assertion)."""
+    assertions = [_assertion("rs-gaap:RentExpense", "el_rent", 2.0, ["2026-07"])]
+    _, rec = _run(
+      _mechanics(FULL_LEVERS, assertions=assertions),
+      FULL_RULES,
+      FULL_LEVERS,
+      assertions=assertions,
+    )
+    assert rec.value("struct_is", JUL, "el_rent") == pytest.approx(2.0)
+    assert rec.value("struct_is", AUG, "el_rent") == pytest.approx(2.0)
 
 
 class TestUpsertMonthSet:

--- a/tests/operations/information_block/test_forecast_handlers.py
+++ b/tests/operations/information_block/test_forecast_handlers.py
@@ -19,11 +19,13 @@ from robosystems.models.api.extensions.forecasts import (
   CreateForecastRequest,
   DeleteForecastRequest,
   LeverAssertionRequest,
+  LineAssertionRequest,
   UpdateForecastRequest,
 )
 from robosystems.models.api.information_block import (
   ForecastMechanics,
   LeverAssertionLite,
+  LineAssertionLite,
 )
 from robosystems.operations.information_block import forecast as forecast_handlers
 
@@ -175,6 +177,124 @@ class TestExpandLevers:
       )
 
 
+RENT = _element("el_rent", "rs-gaap:RentExpense", source="rs-gaap", item_type=None)
+LOAN = _element("el_loan", "rs-gaap:NotesPayable", source="rs-gaap", item_type=None)
+LOAN.period_type = "instant"
+LOAN.is_monetary = True
+
+
+class TestExpandLineAssertions:
+  def _session(self, *elements: MagicMock) -> MagicMock:
+    session = MagicMock()
+    session.execute.return_value.scalar_one_or_none.side_effect = list(elements)
+    return session
+
+  def _expand(self, session: MagicMock, assertions, calc_parents=None):
+    with patch.object(
+      forecast_handlers,
+      "load_rs_gaap_calculations",
+      return_value={key: [] for key in calc_parents or []},
+    ):
+      return forecast_handlers._expand_line_assertions(
+        session, assertions, "2026-06", 3
+      )
+
+  def test_expands_with_element_metadata(self) -> None:
+    session = self._session(RENT)
+    expanded = self._expand(
+      session, [LineAssertionRequest(qname="rs-gaap:RentExpense", value=0.0)]
+    )
+    assert len(expanded) == 1
+    assertion = expanded[0]
+    assert assertion.element_id == "el_rent"
+    assert assertion.period_type == "duration"
+    assert assertion.values_by_period == {
+      "2026-07": 0.0,
+      "2026-08": 0.0,
+      "2026-09": 0.0,
+    }
+
+  def test_captures_instant_period_type(self) -> None:
+    session = self._session(LOAN)
+    expanded = self._expand(
+      session, [LineAssertionRequest(qname="rs-gaap:NotesPayable", value=500.0)]
+    )
+    assert expanded[0].period_type == "instant"
+
+  def test_empty_list_short_circuits(self) -> None:
+    session = MagicMock()
+    assert forecast_handlers._expand_line_assertions(session, [], "2026-06", 3) == []
+    session.execute.assert_not_called()
+
+  def test_rejects_rs_driver_source(self) -> None:
+    session = self._session(GROWTH)
+    with pytest.raises(ValueError, match="levers"):
+      self._expand(
+        session,
+        [LineAssertionRequest(qname="rs-driver:RevenueGrowthRate", value=0.03)],
+      )
+
+  def test_rejects_rs_metric_source(self) -> None:
+    metric = _element(
+      "el_wc", "rs-metric:WorkingCapital", source="rs-metric", item_type=None
+    )
+    session = self._session(metric)
+    with pytest.raises(ValueError, match="compute-metrics"):
+      self._expand(
+        session, [LineAssertionRequest(qname="rs-metric:WorkingCapital", value=1.0)]
+      )
+
+  def test_rejects_abstract_element(self) -> None:
+    abstract = _element(
+      "el_abs", "rs-gaap:OperatingExpensesAbstract", source="rs-gaap", item_type=None
+    )
+    abstract.is_abstract = True
+    session = self._session(abstract)
+    with pytest.raises(ValueError, match="abstract"):
+      self._expand(
+        session,
+        [LineAssertionRequest(qname="rs-gaap:OperatingExpensesAbstract", value=1.0)],
+      )
+
+  def test_rejects_calc_parent_leaves_only(self) -> None:
+    revenues = _element("el_rev", "rs-gaap:Revenues", source="rs-gaap", item_type=None)
+    session = self._session(revenues)
+    with pytest.raises(ValueError, match="leaves-only"):
+      self._expand(
+        session,
+        [LineAssertionRequest(qname="rs-gaap:Revenues", value=100.0)],
+        calc_parents=["el_rev"],
+      )
+
+  def test_rejects_unresolved_qname(self) -> None:
+    session = self._session(None)
+    with pytest.raises(ValueError, match="did not resolve"):
+      self._expand(session, [LineAssertionRequest(qname="rs-gaap:Nope", value=1.0)])
+
+  def test_rejects_override_outside_horizon(self) -> None:
+    session = self._session(RENT)
+    with pytest.raises(ValueError, match="outside the horizon"):
+      self._expand(
+        session,
+        [
+          LineAssertionRequest(
+            qname="rs-gaap:RentExpense", values_by_period={"2027-01": 0.0}
+          )
+        ],
+      )
+
+  def test_rejects_duplicate_assertion(self) -> None:
+    session = self._session(RENT, RENT)
+    with pytest.raises(ValueError, match="Duplicate line-assertion"):
+      self._expand(
+        session,
+        [
+          LineAssertionRequest(qname="rs-gaap:RentExpense", value=0.0),
+          LineAssertionRequest(qname="rs-gaap:RentExpense", value=1.0),
+        ],
+      )
+
+
 class TestResolveBasePeriod:
   def test_request_value_wins(self) -> None:
     session = MagicMock()
@@ -318,6 +438,55 @@ class TestWriteLeverFactSet:
     assert first.period_type == "duration"
     assert first.unit == "pure"  # percent → 'pure'
 
+  def test_line_assertions_ride_the_same_set_with_typed_periods(self) -> None:
+    structure = SimpleNamespace(id="struct_budget_01")
+    mechanics = ForecastMechanics(
+      scenario_kind="budget",
+      horizon_months=2,
+      base_period="2026-06",
+      levers=[
+        LeverAssertionLite(
+          qname="rs-driver:RevenueGrowthRate",
+          element_id="el_growth",
+          item_type="percent",
+          values_by_period={"2026-07": 0.03},
+        )
+      ],
+      line_assertions=[
+        LineAssertionLite(
+          qname="rs-gaap:NotesPayable",
+          element_id="el_loan",
+          item_type=None,
+          period_type="instant",
+          values_by_period={"2026-07": 500.0, "2026-08": 500.0},
+        )
+      ],
+    )
+    session = MagicMock()
+    session.execute.return_value.scalars.return_value.all.return_value = [GROWTH, LOAN]
+    added_facts: list[Any] = []
+    session.add.side_effect = added_facts.append
+
+    with patch.object(
+      forecast_handlers,
+      "create_fact_set",
+      return_value=SimpleNamespace(id="fs_lever"),
+    ) as create_fs:
+      forecast_handlers._write_lever_fact_set(
+        session, structure, mechanics, "ent_1", "usr_test"
+      )
+
+    # The span covers the assertion months beyond the lever's.
+    kwargs = create_fs.call_args.kwargs
+    assert kwargs["period_start"] == date(2026, 7, 1)
+    assert kwargs["period_end"] == date(2026, 8, 31)
+
+    assertion_facts = [f for f in added_facts if f.element_id == "el_loan"]
+    assert len(assertion_facts) == 2
+    assert all(f.period_type == "instant" for f in assertion_facts)
+    assert all(f.period_start is None for f in assertion_facts)
+    assert all(f.unit == "USD" for f in assertion_facts)
+
 
 class TestUpdate:
   def _structure(self) -> MagicMock:
@@ -368,6 +537,72 @@ class TestUpdate:
         "usr_test",
       )
     session.commit.assert_not_called()
+
+  def _structure_with_assertions(self) -> MagicMock:
+    structure = self._structure()
+    mechanics = ForecastMechanics.model_validate(structure.artifact_mechanics)
+    structure.artifact_mechanics = mechanics.model_copy(
+      update={
+        "line_assertions": [
+          LineAssertionLite(
+            qname="rs-gaap:RentExpense",
+            element_id="el_rent",
+            item_type=None,
+            period_type="duration",
+            values_by_period={"2026-07": 0.0},
+          )
+        ]
+      }
+    ).model_dump(mode="json")
+    return structure
+
+  def test_window_change_requires_line_assertions_when_present(self) -> None:
+    structure = self._structure_with_assertions()
+    session = MagicMock()
+    session.get.return_value = structure
+    with (
+      patch.object(forecast_handlers, "_expand_levers", return_value=[]),
+      pytest.raises(ValueError, match="`line_assertions`"),
+    ):
+      forecast_handlers.update(
+        session,
+        UpdateForecastRequest(
+          structure_id="struct_budget_01",
+          horizon_months=6,
+          levers=[
+            LeverAssertionRequest(qname="rs-driver:RevenueGrowthRate", value=0.03)
+          ],
+        ),
+        "usr_test",
+      )
+    session.commit.assert_not_called()
+
+  def test_line_assertions_only_update_rewrites_the_authored_set(self) -> None:
+    """Passing an empty list clears the assertions AND rewrites the
+    authored FactSet (full-replace semantics, levers untouched)."""
+    structure = self._structure_with_assertions()
+    session = MagicMock()
+    session.get.return_value = structure
+    existing_set = MagicMock()
+    existing_set.entity_id = "ent_1"
+
+    with (
+      patch.object(
+        forecast_handlers, "_load_lever_fact_set", return_value=existing_set
+      ),
+      patch.object(forecast_handlers, "_write_lever_fact_set") as write_set,
+    ):
+      forecast_handlers.update(
+        session,
+        UpdateForecastRequest(structure_id="struct_budget_01", line_assertions=[]),
+        "usr_test",
+      )
+
+    mech = ForecastMechanics.model_validate(structure.artifact_mechanics)
+    assert mech.line_assertions == []
+    assert mech.levers[0].qname == "rs-driver:RevenueGrowthRate"
+    session.delete.assert_called_once_with(existing_set)
+    write_set.assert_called_once()
 
   def test_missing_or_wrong_type_raises(self) -> None:
     session = MagicMock()
@@ -490,6 +725,84 @@ class TestBuildEnvelope:
       date(2026, 7, 31),
       date(2026, 8, 31),
     ]
+
+  def test_line_assertions_render_as_assumption_rows(self) -> None:
+    structure = MagicMock()
+    structure.id = "struct_budget_01"
+    structure.block_type = "forecast"
+    structure.name = "FY26 Operating Budget"
+    structure.description = None
+    structure.renderer_note = None
+    structure.taxonomy_id = "tax_rs_driver"
+    structure.concept_arrangement = "set"
+    structure.member_arrangement = None
+    structure.artifact_mechanics = ForecastMechanics(
+      scenario_kind="budget",
+      horizon_months=2,
+      base_period="2026-06",
+      levers=[
+        LeverAssertionLite(
+          qname="rs-driver:RevenueGrowthRate",
+          element_id="el_growth",
+          item_type="percent",
+          values_by_period={"2026-07": 0.03},
+        )
+      ],
+      line_assertions=[
+        LineAssertionLite(
+          qname="rs-gaap:RentExpense",
+          element_id="el_rent",
+          item_type=None,
+          period_type="duration",
+          values_by_period={"2026-07": 0.0, "2026-08": 0.0},
+        )
+      ],
+    ).model_dump(mode="json")
+
+    atoms = SimpleNamespace(
+      structure=structure,
+      taxonomy_name="rs-driver",
+      associations=[],
+      elements=[],
+      element_ids=[],
+      rules=[],
+      classifications_by_assoc={},
+      fact_set=None,
+      verification_results=[],
+      verification_summary=None,
+    )
+
+    session = MagicMock()
+    computed_result = MagicMock()
+    computed_result.scalars.return_value.all.return_value = []
+    elements_result = MagicMock()
+    elements_result.scalars.return_value.all.return_value = [GROWTH, RENT]
+    lever_set_result = MagicMock()
+    lever_set_result.scalar_one_or_none.return_value = None
+    docs_result = MagicMock()
+    docs_result.all.return_value = []
+    session.execute.side_effect = [
+      computed_result,
+      elements_result,
+      lever_set_result,
+      docs_result,
+    ]
+
+    with patch.object(
+      forecast_handlers, "load_base_envelope_atoms", return_value=atoms
+    ):
+      envelope = forecast_handlers.build_envelope(session, "struct_budget_01")
+
+    assert envelope is not None
+    rendering = envelope.view.rendering
+    assert rendering is not None
+    assert [r.element_qname for r in rendering.rows] == [
+      "rs-driver:RevenueGrowthRate",
+      "rs-gaap:RentExpense",
+    ]
+    assertion_row = rendering.rows[1]
+    assert assertion_row.values == [0.0, 0.0]
+    assert assertion_row.balance_type == "debit"
 
   def test_returns_none_for_wrong_block_type(self) -> None:
     session = MagicMock()


### PR DESCRIPTION
## Summary

Adds **line assertions** to the forecast block — the manual-override half of the authored surface. Levers assert *drivers* (growth %, DSO) whose rules derive lines; a line assertion asserts the **line itself**: a statement leaf pinned to typed values for the months it names. This closes the gap where carry-forward replicated base-month one-offs into every forward month with no way to zero or hold a line manually. Also promotes the forecast articulation's in-code AP alias into library content (`deriv-cf-ap-arc-2`).

## Changes

**Authoring** (`models/api/extensions/forecasts.py`, `operations/information_block/forecast.py`)
- `line_assertions` on the forecast create/update payloads — `qname` → uniform `value` and/or `values_by_period`, the same expansion grammar as levers (horizon-bounded, duplicates rejected).
- Validation: qname must resolve; `rs-driver` sources are redirected to `levers`; `rs-metric` sources rejected (computed, never asserted); abstract concepts rejected; **calc-DAG parents rejected** — assertions are leaves-only, so subtotals stay derived and a manual line still articulates through RollUps, RE, balancing cash, and derived CF, and stays verification-gated.
- Values persist as authored facts in the scenario's self-referential `'custom'` FactSet next to the levers (facts-for-values; the mechanics carries the legible `LineAssertionLite` copy, backward-compatible default `[]`). The element's `period_type` is captured at expansion — duration assertions pin IS lines, instant assertions pin BS lines.
- Update semantics mirror levers: full replace when provided, empty list clears, window changes require restating.

**Compute walk** (`operations/information_block/forecast_compute.py`)
- Assertions apply after carry-forward and schedule deltas, before driver rules — so they win over both, and *dependent* rules bind the asserted value through the same-month operand path.
- A driver rule targeting an asserted element that month is skipped with reason `displaced by line assertion` (surfaced in the compute response, per-month).
- The rule-delta push-down **pins asserted children**: a driven calc parent's remainder (`driven − Σ pinned·weight`) distributes proportionally over the unpinned children only.
- Instant assertions join the BS roll's instant-target set (the balancing cash absorbs them, so A = L + E holds by construction); asserted lines absent from the base month's report still emit.

**Envelope** (`forecast.py`, `registry.py`)
- Assertion rows render in the forecast block's assumption grid after the lever rows (element name, balance type, `item_type` formatting) — the `/plan` Assumptions section picks them up with no frontend change.
- Registry description updated so the MCP `create-information-block` surface documents the capability.

**Library** (`frameworks/rs-gaap/packages/rs-gaap-calculations/v1/taxonomy.jsonld`, `forecast_articulation.py`)
- New `deriv-cf-ap-arc-2` derivation arc sourcing `AccountsPayableCurrent` into `IncreaseDecreaseInAccountsPayableAndAccruedLiabilities`, so tenants mapped to the split AP anchor derive the named CF line instead of landing the movement in the reconciling plug. The in-code alias stays as the bridge for tenants that haven't resynced the arc yet (its existing guard makes it a no-op once the arc is present). No migration — the arc reaches existing tenants at their next package resync; fresh seeds carry it immediately.

## Testing

- `just test-code` — ruff, format, basedpyright, cf-lint all pass.
- `just test` — 2771 passed; the one failure is the known pre-existing order-dependent flake `test_incremental_equals_full_load` (fails under the parallel run on `main` too; passes in isolation, re-verified).
- 21 new unit tests: expansion/validation (leaves-only, source rejection, horizon bounds, duplicates), walk precedence (overrides carry, displaces rules legibly, articulates through subtotals, pinned push-down remainder, instant → BS set, absent-from-base emission, post-window resumption), update semantics (window-change restating, empty-list clear + set rewrite), fact-set persistence (typed periods, span), and envelope rows.
- Live e2e against the local Driftline showcase graph (create → compute → GraphQL reads → delete): S&M zeroed across the horizon while revenue compounds at exactly 1.03; an asserted AR instant lands on the scenario BS with verification green every month; the DSO rule displaced 3/3 months; the actuals series is untouched (14 periods, 0 forecast columns); a subtotal assertion 422s with the leaves-only message.

## Notes

- First slice of FP&A F-3 arriving by demand-pull; the lever form / Operator pre-fill / scenario management remain demand-pulled.
- The absolute revenue-level lever (restart-from-zero) is deliberately out of scope — it's a catalog gap, not an override.
- SDK regens (TS/Py) can ride the next client release; the new payload fields are optional and additive.
