### PR TITLE
fix(forecast): roll asserted leaves up through absent calc subtrees

### DIFF
--- a/robosystems/operations/information_block/forecast.py
+++ b/robosystems/operations/information_block/forecast.py
@@ -55,6 +55,9 @@ from robosystems.operations.information_block.envelope import (
   fact_to_lite,
   load_base_envelope_atoms,
 )
+from robosystems.operations.information_block.forecast_history import (
+  back_solve_lever_history,
+)
 from robosystems.operations.information_block.metrics import (
   _default_entity_id,
   _latest_report_period_end_before,
@@ -562,12 +565,22 @@ def build_envelope(
   regardless of which scenario filter the read carried.
 
   Renders the **lever grid** metric-style: one row per lever (authoring
-  order, ``item_type`` driving percent/days formatting), one period
-  column per horizon month, values from the mechanics' expanded
-  assertions. ``computed_months`` is filled from the scenario's derived
-  statement sets. No chart arm — the scenario's time-series surface is
-  the metric/statement blocks read with the scenario filter, not the
-  container itself.
+  order, ``item_type`` driving percent/days formatting), values from the
+  mechanics' expanded assertions. ``computed_months`` is filled from the
+  scenario's derived statement sets. No chart arm — the scenario's
+  time-series surface is the metric/statement blocks read with the
+  scenario filter, not the container itself.
+
+  Columns span the **closed months plus the horizon**, not the horizon
+  alone (:mod:`.forecast_history`): behind the seam each lever shows the
+  rate the book actually ran at, recovered by inverting its own Derive
+  rule against the month's actuals, so an assumption reads as one series
+  across the seam. Actual beats forecast at overlap — a horizon month
+  that has since closed renders its realized rate, never the stale
+  assertion made for it. ``periods[].forecast`` marks the forward
+  columns exactly as the statement series does; its presence anywhere in
+  this rendering is also what tells a client the envelope carries
+  history at all (pre-history envelopes never set the flag).
   """
   atoms = load_base_envelope_atoms(
     session,
@@ -609,9 +622,30 @@ def build_envelope(
   )
   elements_by_id = {e.id: e for e in authored_elements}
 
-  months = [
+  horizon_months = [
     add_months(mechanics.base_period, i) for i in range(1, mechanics.horizon_months + 1)
   ]
+  # The realized side of the grid: each lever's rule inverted against the
+  # closed months' actuals, so an assumption reads as one series across
+  # the seam instead of starting from nothing at the horizon.
+  history = back_solve_lever_history(session, mechanics)
+  actual_months = set(history.months)
+  # Actual beats forecast at overlap — a horizon month that has since
+  # closed is history now, and its cell shows the rate the book ran at,
+  # not the rate that was asserted for it.
+  months = sorted(actual_months | set(horizon_months))
+  forecast_months = {month for month in horizon_months if month not in actual_months}
+
+  def lever_value(lever: LeverAssertionLite, month: str) -> float | None:
+    if month in forecast_months:
+      return lever.values_by_period.get(month)
+    return history.lever_values.get(lever.qname, {}).get(month)
+
+  def line_value(assertion: LineAssertionLite, month: str) -> float | None:
+    if month in forecast_months:
+      return assertion.values_by_period.get(month)
+    return history.line_values.get(assertion.element_id, {}).get(month)
+
   rows = [
     RenderingRowLite(
       element_id=lever.element_id,
@@ -623,7 +657,7 @@ def build_envelope(
       ),
       balance_type=None,
       item_type=lever.item_type,
-      values=[lever.values_by_period.get(month) for month in months],
+      values=[lever_value(lever, month) for month in months],
     )
     for lever in mechanics.levers
   ]
@@ -644,7 +678,7 @@ def build_envelope(
         else None
       ),
       item_type=assertion.item_type,
-      values=[assertion.values_by_period.get(month) for month in months],
+      values=[line_value(assertion, month) for month in months],
     )
     for assertion in mechanics.line_assertions
   )
@@ -654,6 +688,11 @@ def build_envelope(
       RenderingPeriodLite(
         start=period_date_range(month)[0],
         end=period_date_range(month)[1],
+        # The seam marker, same contract as the statement series: True
+        # only where the column is the scenario's own forward month.
+        # Absent on the realized months — and its presence anywhere is
+        # what tells a client this envelope carries history at all.
+        forecast=True if month in forecast_months else None,
       )
       for month in months
     ],

--- a/robosystems/operations/information_block/forecast_compute.py
+++ b/robosystems/operations/information_block/forecast_compute.py
@@ -430,11 +430,27 @@ def cmd_compute_forecast(
     )
   calc_order = topo_sort_calculations(calculations)
   calc_targets = set(calculations.keys())
+  parents_by_child = _build_parents_by_child(calculations)
   carry_pool = [
     el
     for el in base_is_element_ids
     if el not in calc_targets and el not in active_target_ids
   ]
+  # Asserted duration lines join the carry pool: a ramp's last asserted
+  # value carries into the unasserted months (where the driver rules
+  # take over), exactly like any other leaf. Without this, a line
+  # asserted into a base month that never carried it would vanish the
+  # month after its last assertion.
+  base_id_set = set(base_is_element_ids)
+  for element_id in sorted(
+    el for el, pt in assertion_period_type.items() if pt != "instant"
+  ):
+    if (
+      element_id not in base_id_set
+      and element_id not in calc_targets
+      and element_id not in active_target_ids
+    ):
+      carry_pool.append(element_id)
 
   # ── Articulation context (F-2) — BS roll + schedules + derived CF ─────
   # The mapping id rides the base report set's PivotProvenance; without
@@ -529,14 +545,37 @@ def cmd_compute_forecast(
     }
 
     # (b) Driver rules in same-month dependency order.
+    asserted_ancestors = _ancestor_closure(
+      asserted_this_month - month_asserted_instants, parents_by_child
+    )
+    displaced_targets: set[str] = set()
     for ar in ordered_active:
       if ar.target.id in asserted_this_month:
+        displaced_targets.add(ar.target.id)
         skipped.append(
           SkippedForecastLite(
             rule_id=ar.rule.id,
             element_qname=ar.target.qname,
             period=month,
             reason="displaced by line assertion",
+          )
+        )
+        continue
+      # A rule driving a calc PARENT whose entire valued subtree is
+      # pinned by assertions this month has nothing to drive — the
+      # push-down would have no unpinned child for the remainder, and
+      # the final subtotal derivation would contradict the driven value.
+      # Displace it as legibly as a direct-target assertion.
+      if ar.target.id in asserted_ancestors and _subtree_all_pinned(
+        ar.target.id, calculations, current, asserted_this_month
+      ):
+        displaced_targets.add(ar.target.id)
+        skipped.append(
+          SkippedForecastLite(
+            rule_id=ar.rule.id,
+            element_qname=ar.target.qname,
+            period=month,
+            reason="displaced by line assertion (contributing children pinned)",
           )
         )
         continue
@@ -589,11 +628,18 @@ def cmd_compute_forecast(
         if operand_element is None:
           missing.append(qname)
           continue
-        # Same-month value first (carried or rule-computed earlier in the
-        # topo order), prior month as the fallback — a subtotal base like
-        # Revenues-as-rollup still binds even when its rule is inactive.
+        # Same-month value first (carried or rule-computed earlier in
+        # the topo order), then same-month DERIVED from valued children
+        # (a calc parent like Revenues whose only value this month is an
+        # asserted leaf), prior month last — a subtotal base still binds
+        # when its rule is inactive, and a stale prior never beats a
+        # derivable same-month value.
         if operand_element.id in current:
           values[name] = current[operand_element.id]
+          continue
+        derived = _derive_from_children(operand_element.id, calculations, current)
+        if derived is not None:
+          values[name] = derived
         elif operand_element.id in prior_values:
           values[name] = prior_values[operand_element.id]
         else:
@@ -643,8 +689,16 @@ def cmd_compute_forecast(
 
     # A skipped rule's target falls back to carry-forward for the month —
     # the honest default, and it keeps the cascade fed for dependents.
+    # Displaced targets never fall back: the assertion path owns their
+    # value (a carried stale parent would beat the freshly derived
+    # child sum at the subtotal step, breaking the very rollup the
+    # displacement protects).
     for element_id in active_target_ids:
-      if element_id not in current and element_id in prior_values:
+      if (
+        element_id not in current
+        and element_id not in displaced_targets
+        and element_id in prior_values
+      ):
         current[element_id] = prior_values[element_id]
 
     # (b2) Push rule deltas down the composition — a Derive rule that
@@ -677,14 +731,31 @@ def cmd_compute_forecast(
         continue
       is_facts.append((element, resolved[element_id]))
       emitted_is.add(element_id)
-    # An asserted duration line absent from the base month's report
-    # (e.g. a budget line the actuals never carried) still emits.
-    for element_id in sorted(
-      asserted_this_month - month_asserted_instants - emitted_is
-    ):
+    # Duration lines living OUTSIDE the base month's report still emit:
+    # the asserted (or assertion-carried) line itself AND its derived
+    # calc ancestors — without the ancestors the emitted set can't roll
+    # up (Revenues missing over an asserted revenue leaf), the month
+    # fails verification with a residual equal to the assertion, and
+    # the next month's [t-1] operands never see the derived parent.
+    extra_is: set[str] = set()
+    for element_id in current:
+      if element_id in emitted_is:
+        continue
+      element = _element(element_id)
+      if element is None or element.period_type == "instant":
+        continue
+      extra_is.add(element_id)
+    for ancestor_id in _ancestor_closure(extra_is, parents_by_child):
+      if ancestor_id in emitted_is or ancestor_id in extra_is:
+        continue
+      element = _element(ancestor_id)
+      if element is not None and element.period_type != "instant":
+        extra_is.add(ancestor_id)
+    for element_id in sorted(extra_is):
       element = _element(element_id)
       if element is not None and element_id in resolved:
         is_facts.append((element, resolved[element_id]))
+        emitted_is.add(element_id)
 
     # (d2) Balance-sheet roll + derived CF (F-2) — with an articulation
     # context the BS is the full roll (carry, rules, schedules, RE,
@@ -836,6 +907,98 @@ def cmd_compute_forecast(
     skipped=skipped,
     diagnostics=diagnostics,
   )
+
+
+def _build_parents_by_child(
+  calculations: dict[str, list[tuple[str, float]]],
+) -> dict[str, list[str]]:
+  """Reverse the calc DAG: child element id → parent element ids."""
+  parents: dict[str, list[str]] = {}
+  for parent, children in calculations.items():
+    for child_id, _weight in children:
+      parents.setdefault(child_id, []).append(parent)
+  return parents
+
+
+def _ancestor_closure(
+  seed_ids: set[str], parents_by_child: dict[str, list[str]]
+) -> set[str]:
+  """Every calc ancestor reachable upward from the seed elements."""
+  closure: set[str] = set()
+  stack = list(seed_ids)
+  while stack:
+    for parent in parents_by_child.get(stack.pop(), ()):
+      if parent not in closure:
+        closure.add(parent)
+        stack.append(parent)
+  return closure
+
+
+def _subtree_all_pinned(
+  target_id: str,
+  calculations: dict[str, list[tuple[str, float]]],
+  current: dict[str, float],
+  asserted: set[str],
+) -> bool:
+  """Whether every valued element under ``target_id`` is line-asserted.
+
+  The displacement test for rules that drive a calc PARENT (the growth
+  rule targets Revenues): when the target's entire contribution basis
+  this month is pinned by assertions, the rule has nothing left to
+  drive — push-down has no unpinned child to absorb the remainder — so
+  it must be displaced rather than fight the assertion. A partially
+  pinned subtree keeps the rule active (the existing pinned push-down
+  distributes the remainder over the unpinned children).
+  """
+  has_value = False
+  seen: set[str] = set()
+  stack = [child for child, _w in calculations.get(target_id, ())]
+  while stack:
+    node = stack.pop()
+    if node in seen:
+      continue
+    seen.add(node)
+    if node in current:
+      has_value = True
+      if node not in asserted:
+        return False
+    stack.extend(child for child, _w in calculations.get(node, ()))
+  return has_value
+
+
+def _derive_from_children(
+  element_id: str,
+  calculations: dict[str, list[tuple[str, float]]],
+  current: dict[str, float],
+  _seen: set[str] | None = None,
+) -> float | None:
+  """Σ child·weight over ``current``, recursing through subtotal children.
+
+  Same-month operand fallback: a rule operand naming a calc parent that
+  has no direct value yet (Revenues when only an asserted revenue leaf
+  exists) binds its derived value instead of falling to a stale prior.
+  Returns None when no descendant carries a value — an absent subtree
+  must stay a skip, never a fabricated zero.
+  """
+  seen = _seen or set()
+  if element_id in seen:
+    return None
+  seen.add(element_id)
+  children = calculations.get(element_id)
+  if not children:
+    return None
+  total = 0.0
+  any_value = False
+  for child_id, weight in children:
+    if child_id in current:
+      total += current[child_id] * weight
+      any_value = True
+    else:
+      sub = _derive_from_children(child_id, calculations, current, seen)
+      if sub is not None:
+        total += sub * weight
+        any_value = True
+  return total if any_value else None
 
 
 def _scale_rule_target_children(

--- a/robosystems/operations/information_block/forecast_compute.py
+++ b/robosystems/operations/information_block/forecast_compute.py
@@ -60,7 +60,6 @@ from robosystems.models.extensions import (
   Element,
   Rule,
   Structure,
-  Taxonomy,
 )
 from robosystems.models.extensions.roboledger.fact import Fact
 from robosystems.models.extensions.roboledger.fact_set import FactSet
@@ -74,6 +73,12 @@ from robosystems.operations.information_block.forecast_articulation import (
   load_articulation_context,
   roll_balance_sheet,
   schedule_is_delta,
+)
+from robosystems.operations.information_block.forecast_history import (
+  DRIVER_PREFIX,
+  driver_rules,
+  newest_actual_structure_id,
+  numeric_facts,
 )
 from robosystems.operations.information_block.metrics import (
   _default_entity_id,
@@ -106,9 +111,6 @@ if TYPE_CHECKING:
 
   from sqlalchemy.orm import Session
 
-_DRIVER_STANDARD = "rs-driver"
-_DRIVER_PREFIX = "rs-driver:"
-
 
 @dataclass
 class _ActiveRule:
@@ -118,26 +120,6 @@ class _ActiveRule:
   target: Element
   qname_by_name: dict[str, str]
   operand_names: list[str]
-
-
-def _newest_actual_structure_id(session: Session, block_type: str) -> str | None:
-  """Structure behind the entity's newest actual report set of a block type.
-
-  Data-driven (never by name) — multi-variant reporting styles mean the
-  'income_statement' structure a tenant actually reports under is
-  whichever one its newest actual ``'report'`` FactSet instantiates.
-  """
-  return session.execute(
-    select(FactSet.structure_id)
-    .join(Structure, FactSet.structure_id == Structure.id)
-    .where(
-      FactSet.factset_type == "report",
-      FactSet.scenario_id.is_(None),
-      Structure.block_type == block_type,
-    )
-    .order_by(FactSet.created_at.desc())
-    .limit(1)
-  ).scalar()
 
 
 def _actual_set_at(
@@ -167,40 +149,6 @@ def _actual_set_at(
     .order_by(FactSet.created_at.desc())
     .limit(1)
   ).scalar_one_or_none()
-
-
-def _numeric_facts(session: Session, fact_set_id: str) -> list[Fact]:
-  return list(
-    session.execute(
-      select(Fact).where(
-        Fact.fact_set_id == fact_set_id,
-        Fact.fact_scope == "in_scope",
-        Fact.value.is_not(None),
-      )
-    )
-    .scalars()
-    .all()
-  )
-
-
-def _load_driver_rules(session: Session) -> list[Rule]:
-  """Every Derive rule seeded by the rs-driver catalog (tenant copy)."""
-  taxonomy_ids = (
-    session.execute(select(Taxonomy.id).where(Taxonomy.standard == _DRIVER_STANDARD))
-    .scalars()
-    .all()
-  )
-  if not taxonomy_ids:
-    return []
-  return list(
-    session.execute(
-      select(Rule)
-      .where(Rule.taxonomy_id.in_(taxonomy_ids), Rule.rule_pattern == "Derive")
-      .order_by(Rule.id)
-    )
-    .scalars()
-    .all()
-  )
 
 
 def _local_calc_arcs(
@@ -275,7 +223,7 @@ def cmd_compute_forecast(
   }
   lever_values: dict[str, dict[str, float]] = {}
   assertion_values: dict[str, dict[str, float]] = {}
-  for fact in _numeric_facts(session, lever_set.id):
+  for fact in numeric_facts(session, lever_set.id):
     if fact.value is None:
       continue
     month = period_from_date(fact.period_end)
@@ -286,7 +234,7 @@ def cmd_compute_forecast(
       assertion_values.setdefault(fact.element_id, {})[month] = float(fact.value)
 
   # ── Resolve the actual structures + seed month ────────────────────────
-  is_structure_id = _newest_actual_structure_id(session, "income_statement")
+  is_structure_id = newest_actual_structure_id(session, "income_statement")
   if is_structure_id is None:
     raise ValueError(
       "No actual income-statement sets exist to project from — close at "
@@ -294,7 +242,7 @@ def cmd_compute_forecast(
       "sets). If months are already closed without statements, set up "
       "the CoA mapping and reporting style, then reclose."
     )
-  bs_structure_id = _newest_actual_structure_id(session, "balance_sheet")
+  bs_structure_id = newest_actual_structure_id(session, "balance_sheet")
 
   base_start, base_end = period_date_range(mechanics.base_period)
   base_is_set = _actual_set_at(
@@ -311,7 +259,7 @@ def cmd_compute_forecast(
 
   prior_values: dict[str, float] = {}
   base_is_element_ids: list[str] = []
-  for fact in _numeric_facts(session, base_is_set.id):
+  for fact in numeric_facts(session, base_is_set.id):
     if fact.value is None:
       continue
     if fact.element_id not in prior_values:
@@ -329,7 +277,7 @@ def cmd_compute_forecast(
       session, bs_structure_id, entity_id, base_start, base_end
     )
     if base_bs_set is not None:
-      for fact in _numeric_facts(session, base_bs_set.id):
+      for fact in numeric_facts(session, base_bs_set.id):
         if fact.value is None:
           continue
         if fact.element_id not in bs_prior:
@@ -350,7 +298,7 @@ def cmd_compute_forecast(
 
   skipped: list[SkippedForecastLite] = []
   active_rules: list[_ActiveRule] = []
-  for rule in _load_driver_rules(session):
+  for rule in driver_rules(session):
     variables = rule.rule_variables or []
     names = [v.get("variable_name") for v in variables if isinstance(v, dict)]
     if not all(isinstance(n, str) and n for n in names):
@@ -360,7 +308,7 @@ def cmd_compute_forecast(
       for v in variables
       if isinstance(v, dict) and isinstance(v.get("variable_qname"), str)
     }
-    lever_qnames = [q for q in qname_by_name.values() if q.startswith(_DRIVER_PREFIX)]
+    lever_qnames = [q for q in qname_by_name.values() if q.startswith(DRIVER_PREFIX)]
     # Active iff every lever operand has asserted values in this scenario.
     if not lever_qnames or any(q not in lever_values for q in lever_qnames):
       continue
@@ -415,7 +363,7 @@ def cmd_compute_forecast(
       q
       for ar in active_rules
       for q in ar.qname_by_name.values()
-      if q.startswith(_DRIVER_PREFIX)
+      if q.startswith(DRIVER_PREFIX)
     }
   )
 
@@ -462,7 +410,7 @@ def cmd_compute_forecast(
       mapping_id = prov.get("mapping_id")
       if mapping_id:
         break
-  cf_structure_id = _newest_actual_structure_id(session, "cash_flow_statement")
+  cf_structure_id = newest_actual_structure_id(session, "cash_flow_statement")
 
   ctx: ArticulationContext | None = None
   diagnostics: list[str] = []
@@ -617,7 +565,7 @@ def cmd_compute_forecast(
         if qname is None:
           missing.append(name)
           continue
-        if qname.startswith(_DRIVER_PREFIX):
+        if qname.startswith(DRIVER_PREFIX):
           lever_month_values = lever_values.get(qname, {})
           if month not in lever_month_values:
             missing.append(f"{qname} (lever not asserted for {month})")

--- a/robosystems/operations/information_block/forecast_history.py
+++ b/robosystems/operations/information_block/forecast_history.py
@@ -1,0 +1,399 @@
+"""Back-solve a scenario's levers from what actually happened.
+
+The lever grid answers *"what am I assuming?"* for the months ahead.
+Behind the seam that question has a factual answer instead: the rate the
+book actually ran at. This module inverts the ``rs-driver`` Derive rules
+against the closed months' canonical statement sets so the Assumptions
+block reads as ONE continuous series across the seam — realized rates on
+the left, asserted rates on the right.
+
+It also closes a smaller correctness gap. A scenario whose horizon
+opened before today still holds asserted lever values for months that
+have since closed; rendering them as-is presents an assumption as though
+it described history. Those months are facts now, so the realized value
+supersedes the assertion — the same actual-beats-forecast rule
+:func:`envelope.load_statement_fact_set_series` applies to statement
+columns (the moving seam).
+
+**Inversion is generic, not per-rule.** Every seeded driver rule is
+affine in its lever operand::
+
+    Revenues               = Revenues[t-1] * (1 + RevenueGrowthRate)
+    CostOfRevenue          = Revenues * CostOfRevenueRate
+    ReceivablesNetCurrent  = (Revenues / 30) * DaysSalesOutstanding
+    AccountsPayableCurrent = (CostOfRevenue / 30) * DaysPayableOutstanding
+
+so evaluating the RHS at ``lever = 0`` and ``lever = 1`` recovers the
+intercept and the slope, and the lever falls out of the month's actual
+target value::
+
+    target = a + b*lever    ⇒    lever = (target_actual - a) / b
+
+Nothing is hardcoded to the four catalog drivers: a fifth lever whose
+rule is affine in it back-solves for free, and a rule that isn't (slope
+0) blanks its historical cells rather than guessing. Every failure mode
+— unbound operand, missing prior month, no actual target, ``avg()`` in
+the expression — blanks that one cell and leaves the rest of the grid
+standing.
+
+Read-only and deterministic: nothing here writes facts. The realized
+rate is a *rendering* of actuals already stamped by close, not a new
+fact-producing path.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from sqlalchemy import select
+
+from robosystems.models.api.information_block import ForecastMechanics
+from robosystems.models.extensions import Element, Rule, Structure, Taxonomy
+from robosystems.models.extensions.roboledger.fact import Fact
+from robosystems.models.extensions.roboledger.fact_set import FactSet
+from robosystems.operations.information_block.envelope import (
+  load_statement_fact_set_series,
+)
+from robosystems.operations.information_block.rules.expressions import (
+  InvalidRuleExpression,
+  desugar_aggregates,
+  desugar_priors,
+  evaluate_derivation,
+  lhs_variable_names,
+  parse_arithmetic_expression,
+)
+from robosystems.operations.roboledger.fiscal_calendar.periods import (
+  period_from_date,
+)
+
+if TYPE_CHECKING:
+  from sqlalchemy.orm import Session
+
+DRIVER_STANDARD = "rs-driver"
+DRIVER_PREFIX = "rs-driver:"
+
+# Statement families the driver operands live in. Cash flow carries no
+# driver anchors today (the CF is derived, never driven).
+_ACTUAL_BLOCK_TYPES = ("income_statement", "balance_sheet")
+
+# A lever whose rule barely moves its target can't be recovered from the
+# target: the division blows the value up. Blank the cell instead.
+_MIN_SLOPE = 1e-9
+
+
+def driver_rules(session: Session) -> list[Rule]:
+  """Every Derive rule seeded by the rs-driver catalog (tenant copy)."""
+  taxonomy_ids = (
+    session.execute(select(Taxonomy.id).where(Taxonomy.standard == DRIVER_STANDARD))
+    .scalars()
+    .all()
+  )
+  if not taxonomy_ids:
+    return []
+  return list(
+    session.execute(
+      select(Rule)
+      .where(Rule.taxonomy_id.in_(taxonomy_ids), Rule.rule_pattern == "Derive")
+      .order_by(Rule.id)
+    )
+    .scalars()
+    .all()
+  )
+
+
+def numeric_facts(session: Session, fact_set_id: str) -> list[Fact]:
+  """In-scope valued facts of one FactSet."""
+  return list(
+    session.execute(
+      select(Fact).where(
+        Fact.fact_set_id == fact_set_id,
+        Fact.fact_scope == "in_scope",
+        Fact.value.is_not(None),
+      )
+    )
+    .scalars()
+    .all()
+  )
+
+
+def newest_actual_structure_id(session: Session, block_type: str) -> str | None:
+  """Structure behind the entity's newest actual report set of a block type.
+
+  Data-driven (never by name) — multi-variant reporting styles mean the
+  'income_statement' structure a tenant actually reports under is
+  whichever one its newest actual ``'report'`` FactSet instantiates.
+  """
+  return session.execute(
+    select(FactSet.structure_id)
+    .join(Structure, FactSet.structure_id == Structure.id)
+    .where(
+      FactSet.factset_type == "report",
+      FactSet.scenario_id.is_(None),
+      Structure.block_type == block_type,
+    )
+    .order_by(FactSet.created_at.desc())
+    .limit(1)
+  ).scalar()
+
+
+def _lookup_element(session: Session, qname: str) -> Element | None:
+  """One element by qname — the operand/target resolution seam."""
+  return session.execute(
+    select(Element).where(Element.qname == qname).limit(1)
+  ).scalar_one_or_none()
+
+
+@dataclass
+class LeverHistory:
+  """Realized lever + line values for the closed months.
+
+  ``months`` is every month the actual statement series covers, ascending
+  ``YYYY-MM`` — the same column identities the Plan grid's statement
+  sections carry, so the lever rows land in register with them.
+  """
+
+  months: list[str] = field(default_factory=list)
+  #: rs-driver qname → month → back-solved rate
+  lever_values: dict[str, dict[str, float]] = field(default_factory=dict)
+  #: asserted line element id → month → the line's actual value
+  line_values: dict[str, dict[str, float]] = field(default_factory=dict)
+
+
+@dataclass
+class _SolvableRule:
+  """A driver rule pre-parsed for repeated back-solving."""
+
+  lever_qname: str
+  target_element_id: str
+  lever_name: str
+  parsed: object
+  #: operand variable name → element id (same-month binding)
+  operand_element_ids: dict[str, str]
+  #: synthesized ``__prior_*`` name → element id (previous-month binding)
+  prior_element_ids: dict[str, str]
+
+
+def back_solve_lever_history(
+  session: Session, mechanics: ForecastMechanics
+) -> LeverHistory:
+  """Realized lever values for every closed month, by rule inversion.
+
+  Returns an empty history when the tenant has no actual statement sets,
+  no rs-driver rules, or nothing to solve — callers render the asserted
+  horizon alone in that case, exactly as before.
+  """
+  lever_qnames = {lever.qname for lever in mechanics.levers}
+  line_element_ids = {assertion.element_id for assertion in mechanics.line_assertions}
+  if not lever_qnames and not line_element_ids:
+    return LeverHistory()
+
+  element_cache: dict[str, Element | None] = {}
+
+  def element_by_qname(qname: str) -> Element | None:
+    if qname not in element_cache:
+      element_cache[qname] = _lookup_element(session, qname)
+    return element_cache[qname]
+
+  solvable = _solvable_rules(session, lever_qnames, element_by_qname)
+  if not solvable and not line_element_ids:
+    return LeverHistory()
+
+  # Only the elements the grid actually needs — the whole point of a
+  # targeted read is that the lever grid stays cheap next to the
+  # statement series envelopes it renders beside.
+  needed_element_ids = set(line_element_ids)
+  for rule in solvable:
+    needed_element_ids.add(rule.target_element_id)
+    needed_element_ids.update(rule.operand_element_ids.values())
+    needed_element_ids.update(rule.prior_element_ids.values())
+
+  months, actuals = _actual_monthly_values(session, needed_element_ids)
+  if not months:
+    return LeverHistory()
+
+  history = LeverHistory(months=months)
+  for index, month in enumerate(months):
+    current = actuals.get(month, {})
+    prior = actuals.get(months[index - 1], {}) if index > 0 else {}
+    for rule in solvable:
+      value = _back_solve(rule, current, prior)
+      if value is not None:
+        history.lever_values.setdefault(rule.lever_qname, {})[month] = value
+    # An asserted line's realized counterpart is simply the line's own
+    # actual — no inversion needed, it IS the statement value.
+    for element_id in line_element_ids:
+      actual = current.get(element_id)
+      if actual is not None:
+        history.line_values.setdefault(element_id, {})[month] = actual
+  return history
+
+
+def _solvable_rules(
+  session: Session,
+  lever_qnames: set[str],
+  element_by_qname,
+) -> list[_SolvableRule]:
+  """Parse each driver rule once, keeping those we can invert."""
+  solvable: list[_SolvableRule] = []
+  for rule in driver_rules(session):
+    variables = rule.rule_variables or []
+    qname_by_name = {
+      v["variable_name"]: v["variable_qname"]
+      for v in variables
+      if isinstance(v, dict)
+      and isinstance(v.get("variable_name"), str)
+      and isinstance(v.get("variable_qname"), str)
+    }
+    if not qname_by_name:
+      continue
+    # The lever this rule is driven by — and only levers this scenario
+    # actually asserts (an unasserted catalog rule has no row to fill).
+    lever_names = [
+      name
+      for name, qname in qname_by_name.items()
+      if qname.startswith(DRIVER_PREFIX) and qname in lever_qnames
+    ]
+    if len(lever_names) != 1:
+      continue
+    lever_name = lever_names[0]
+    target = (
+      session.get(Element, rule.target_element_id) if rule.target_element_id else None
+    )
+    if target is None:
+      continue
+
+    raw = rule.rule_expression if isinstance(rule.rule_expression, str) else ""
+    expr, prior_operands = desugar_priors(raw)
+    expr, avg_operands = desugar_aggregates(expr)
+    if avg_operands:
+      # avg() needs a begin/end pair this walk doesn't track — the same
+      # honest skip compute-forecast takes.
+      continue
+    operand_names = list(qname_by_name)
+    try:
+      parsed = parse_arithmetic_expression(
+        expr, operand_names + list(prior_operands) + list(avg_operands)
+      )
+      lhs_names = lhs_variable_names(parsed)
+    except InvalidRuleExpression:
+      continue
+    if len(lhs_names) != 1:
+      continue
+
+    operand_element_ids: dict[str, str] = {}
+    unbound = False
+    for name, qname in qname_by_name.items():
+      if name in (lhs_names[0], lever_name):
+        continue
+      element = element_by_qname(qname)
+      if element is None:
+        unbound = True
+        break
+      operand_element_ids[name] = element.id
+    if unbound:
+      continue
+
+    prior_element_ids: dict[str, str] = {}
+    for synth_name, base_name in prior_operands.items():
+      qname = qname_by_name.get(base_name)
+      element = element_by_qname(qname) if qname else None
+      if element is None:
+        unbound = True
+        break
+      prior_element_ids[synth_name] = element.id
+    if unbound:
+      continue
+
+    solvable.append(
+      _SolvableRule(
+        lever_qname=qname_by_name[lever_name],
+        target_element_id=target.id,
+        lever_name=lever_name,
+        parsed=parsed,
+        operand_element_ids=operand_element_ids,
+        prior_element_ids=prior_element_ids,
+      )
+    )
+  return solvable
+
+
+def _back_solve(
+  rule: _SolvableRule,
+  current: dict[str, float],
+  prior: dict[str, float],
+) -> float | None:
+  """Invert one rule for one month, or None when it can't be bound."""
+  target_actual = current.get(rule.target_element_id)
+  if target_actual is None:
+    return None
+
+  values: dict[str, float] = {}
+  for name, element_id in rule.operand_element_ids.items():
+    operand = current.get(element_id)
+    if operand is None:
+      return None
+    values[name] = operand
+  for name, element_id in rule.prior_element_ids.items():
+    operand = prior.get(element_id)
+    if operand is None:
+      return None
+    values[name] = operand
+
+  try:
+    values[rule.lever_name] = 0.0
+    intercept = evaluate_derivation(rule.parsed, values)
+    values[rule.lever_name] = 1.0
+    slope = evaluate_derivation(rule.parsed, values) - intercept
+  except InvalidRuleExpression:
+    return None
+  if abs(slope) < _MIN_SLOPE:
+    return None
+  return (target_actual - intercept) / slope
+
+
+def _actual_monthly_values(
+  session: Session, element_ids: set[str]
+) -> tuple[list[str], dict[str, dict[str, float]]]:
+  """Actual values per closed month for exactly the elements asked for.
+
+  Months come from the FactSet series, not from the facts — a month with
+  no binding value is still a column (it renders blank), which is how a
+  gap in the operand data reads honestly rather than silently shifting
+  the grid.
+  """
+  months: set[str] = set()
+  by_month: dict[str, dict[str, float]] = {}
+  if not element_ids:
+    return [], by_month
+
+  for block_type in _ACTUAL_BLOCK_TYPES:
+    structure_id = newest_actual_structure_id(session, block_type)
+    if structure_id is None:
+      continue
+    # scenario_id=None → actuals only. The same loader the statement
+    # series columns come from, so the months line up by construction.
+    series = load_statement_fact_set_series(session, structure_id, None)
+    if not series:
+      continue
+    month_by_set = {
+      fact_set.id: period_from_date(fact_set.period_end) for fact_set in series
+    }
+    months.update(month_by_set.values())
+    rows = (
+      session.execute(
+        select(Fact).where(
+          Fact.fact_set_id.in_(list(month_by_set)),
+          Fact.element_id.in_(list(element_ids)),
+          Fact.fact_scope == "in_scope",
+          Fact.value.is_not(None),
+        )
+      )
+      .scalars()
+      .all()
+    )
+    for fact in rows:
+      month = month_by_set[fact.fact_set_id]
+      by_month.setdefault(month, {})[fact.element_id] = float(fact.value)
+
+  return sorted(months), by_month

--- a/tests/operations/information_block/test_forecast_compute.py
+++ b/tests/operations/information_block/test_forecast_compute.py
@@ -55,6 +55,9 @@ EL_REV_A = _element("el_rev_a", "rs-gaap:RevenueStreamA")
 EL_REV_B = _element("el_rev_b", "rs-gaap:RevenueStreamB")
 EL_LOAN = _element("el_loan", "rs-gaap:NotesPayable", period_type="instant")
 EL_MKT = _element("el_mkt", "rs-gaap:MarketingExpense")
+EL_REVC = _element(
+  "el_revc", "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax"
+)
 
 ELEMENTS = [
   EL_REV,
@@ -66,6 +69,7 @@ ELEMENTS = [
   EL_REV_B,
   EL_LOAN,
   EL_MKT,
+  EL_REVC,
 ]
 BY_ID = {e.id: e for e in ELEMENTS}
 BY_QNAME = {e.qname: e for e in ELEMENTS}
@@ -518,6 +522,111 @@ class TestLineAssertions:
     )
     assert rec.value("struct_is", JUL, "el_rent") == pytest.approx(2.0)
     assert rec.value("struct_is", AUG, "el_rent") == pytest.approx(2.0)
+
+
+class TestAssertionRollupIntoEmptySubtree:
+  """The Harbinger restart-ramp repro (prod, 2026-07-25): a leaf asserted
+  into a month whose BASE has no revenue subtree at all. The derived
+  ancestors must emit (else the set can't roll up and verification fails
+  with a residual equal to the assertion), same-month operands must bind
+  the derived parent (DSO), the parent-driving growth rule must be
+  displaced while the subtree is fully pinned, and after the ramp the
+  rule takes over from the carried assertion with the child scaling in
+  register."""
+
+  # Revenues is a PARENT of the asserted contract-revenue leaf; the base
+  # month carries only rent — no revenue subtree anywhere.
+  CALC_DAG_CHAIN = {
+    "el_rev": [("el_revc", 1.0)],
+    "el_gp": [("el_rev", 1.0), ("el_cogs", -1.0)],
+  }
+  BASE_RENT_ONLY = [SimpleNamespace(element_id="el_rent", value=10.0)]
+
+  def _ramp_run(self):
+    levers = [
+      _lever("rs-driver:RevenueGrowthRate", "el_growth", 0.03, ALL_MONTHS),
+      _lever("rs-driver:DaysSalesOutstanding", "el_dso", 45.0, ALL_MONTHS),
+    ]
+    assertion = LineAssertionLite(
+      qname="rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax",
+      element_id="el_revc",
+      item_type=None,
+      period_type="duration",
+      values_by_period={"2026-07": 4000.0, "2026-08": 6000.0},
+    )
+    return _run(
+      _mechanics(levers, assertions=[assertion]),
+      [GROWTH_RULE, DSO_RULE],
+      levers,
+      assertions=[assertion],
+      calc_dag=dict(self.CALC_DAG_CHAIN),
+      base_is_facts=list(self.BASE_RENT_ONLY),
+    )
+
+  def test_derived_ancestors_emit_with_the_asserted_leaf(self) -> None:
+    _, rec = self._ramp_run()
+    assert rec.value("struct_is", JUL, "el_revc") == pytest.approx(4000.0)
+    assert rec.value("struct_is", JUL, "el_rev") == pytest.approx(4000.0)
+    assert rec.value("struct_is", JUL, "el_gp") == pytest.approx(4000.0)
+    assert rec.value("struct_is", AUG, "el_rev") == pytest.approx(6000.0)
+
+  def test_parent_driving_rule_displaced_while_subtree_fully_pinned(self) -> None:
+    response, _ = self._ramp_run()
+    pinned_skips = [
+      (s.rule_id, s.period)
+      for s in response.skipped
+      if s.reason == "displaced by line assertion (contributing children pinned)"
+    ]
+    assert ("rule_growth", "2026-07") in pinned_skips
+    assert ("rule_growth", "2026-08") in pinned_skips
+    assert all(period != "2026-09" for _, period in pinned_skips)
+
+  def test_same_month_operand_derives_from_asserted_child(self) -> None:
+    """DSO binds $Revenues from the asserted leaf the same month — no
+    skip, no stale prior."""
+    _, rec = self._ramp_run()
+    assert rec.value("struct_bs", JUL, "el_ar") == pytest.approx(4000.0 / 30 * 45)
+    assert rec.value("struct_bs", AUG, "el_ar") == pytest.approx(6000.0 / 30 * 45)
+
+  def test_rule_takes_over_after_the_ramp_and_scales_the_child(self) -> None:
+    """September (unasserted): the carried assertion seeds [t-1], the
+    growth rule drives the parent, and the push-down keeps the child in
+    register — the rollup stays exact past the ramp."""
+    _, rec = self._ramp_run()
+    assert rec.value("struct_is", SEP, "el_rev") == pytest.approx(6000.0 * 1.03)
+    assert rec.value("struct_is", SEP, "el_revc") == pytest.approx(6000.0 * 1.03)
+    assert rec.value("struct_bs", SEP, "el_ar") == pytest.approx(
+      6000.0 * 1.03 / 30 * 45
+    )
+
+  def test_partially_pinned_subtree_keeps_the_rule_active(self) -> None:
+    """Two revenue streams, one asserted: the growth rule still drives
+    the parent and the remainder lands on the unpinned stream — the
+    displacement only fires when the WHOLE valued subtree is pinned."""
+    calc_dag = {
+      "el_gp": [("el_rev", 1.0), ("el_cogs", -1.0)],
+      "el_rev": [("el_rev_a", 1.0), ("el_rev_b", 1.0)],
+    }
+    base_facts = [
+      *BASE_IS_FACTS,
+      SimpleNamespace(element_id="el_rev_a", value=60.0),
+      SimpleNamespace(element_id="el_rev_b", value=40.0),
+    ]
+    levers = [_lever("rs-driver:RevenueGrowthRate", "el_growth", 0.03, ALL_MONTHS)]
+    assertions = [_assertion("rs-gaap:RevenueStreamA", "el_rev_a", 30.0, ["2026-07"])]
+    response, rec = _run(
+      _mechanics(levers, assertions=assertions),
+      [GROWTH_RULE],
+      levers,
+      assertions=assertions,
+      calc_dag=calc_dag,
+      base_is_facts=base_facts,
+    )
+    assert rec.value("struct_is", JUL, "el_rev") == pytest.approx(103.0)
+    assert not any(
+      s.reason == "displaced by line assertion (contributing children pinned)"
+      for s in response.skipped
+    )
 
 
 class TestUpsertMonthSet:

--- a/tests/operations/information_block/test_forecast_compute.py
+++ b/tests/operations/information_block/test_forecast_compute.py
@@ -266,7 +266,7 @@ def _run(
   }
 
   with (
-    patch.object(fc, "_newest_actual_structure_id", side_effect=_structures),
+    patch.object(fc, "newest_actual_structure_id", side_effect=_structures),
     patch.object(
       fc,
       "_actual_set_at",
@@ -275,9 +275,9 @@ def _run(
       ),
     ),
     patch.object(
-      fc, "_numeric_facts", side_effect=lambda session, fs_id: facts_by_set[fs_id]
+      fc, "numeric_facts", side_effect=lambda session, fs_id: facts_by_set[fs_id]
     ),
-    patch.object(fc, "_load_driver_rules", return_value=rules),
+    patch.object(fc, "driver_rules", return_value=rules),
     patch.object(fc, "_local_calc_arcs", return_value={}),
     patch.object(
       fc,

--- a/tests/operations/information_block/test_forecast_handlers.py
+++ b/tests/operations/information_block/test_forecast_handlers.py
@@ -28,6 +28,7 @@ from robosystems.models.api.information_block import (
   LineAssertionLite,
 )
 from robosystems.operations.information_block import forecast as forecast_handlers
+from robosystems.operations.information_block.forecast_history import LeverHistory
 
 
 def _element(
@@ -699,8 +700,13 @@ class TestBuildEnvelope:
       docs_result,
     ]
 
-    with patch.object(
-      forecast_handlers, "load_base_envelope_atoms", return_value=atoms
+    with (
+      patch.object(forecast_handlers, "load_base_envelope_atoms", return_value=atoms),
+      # The realized side has its own tests (``test_forecast_history``);
+      # a tenant with no closed months renders the horizon alone.
+      patch.object(
+        forecast_handlers, "back_solve_lever_history", return_value=LeverHistory()
+      ),
     ):
       envelope = forecast_handlers.build_envelope(session, "struct_budget_01")
 
@@ -788,8 +794,13 @@ class TestBuildEnvelope:
       docs_result,
     ]
 
-    with patch.object(
-      forecast_handlers, "load_base_envelope_atoms", return_value=atoms
+    with (
+      patch.object(forecast_handlers, "load_base_envelope_atoms", return_value=atoms),
+      # The realized side has its own tests (``test_forecast_history``);
+      # a tenant with no closed months renders the horizon alone.
+      patch.object(
+        forecast_handlers, "back_solve_lever_history", return_value=LeverHistory()
+      ),
     ):
       envelope = forecast_handlers.build_envelope(session, "struct_budget_01")
 
@@ -803,6 +814,121 @@ class TestBuildEnvelope:
     assertion_row = rendering.rows[1]
     assert assertion_row.values == [0.0, 0.0]
     assert assertion_row.balance_type == "debit"
+
+  def _history_envelope(self, history: LeverHistory, horizon: int = 2):
+    """Build the standard one-lever envelope against a given history."""
+    structure = MagicMock()
+    structure.id = "struct_budget_01"
+    structure.block_type = "forecast"
+    structure.name = "FY26 Operating Budget"
+    structure.description = None
+    structure.renderer_note = None
+    structure.taxonomy_id = "tax_rs_driver"
+    structure.concept_arrangement = "set"
+    structure.member_arrangement = None
+    structure.artifact_mechanics = ForecastMechanics(
+      scenario_kind="budget",
+      horizon_months=horizon,
+      base_period="2026-06",
+      levers=[
+        LeverAssertionLite(
+          qname="rs-driver:RevenueGrowthRate",
+          element_id="el_growth",
+          item_type="percent",
+          values_by_period={"2026-07": 0.03, "2026-08": 0.03},
+        )
+      ],
+    ).model_dump(mode="json")
+
+    atoms = SimpleNamespace(
+      structure=structure,
+      taxonomy_name="rs-driver",
+      associations=[],
+      elements=[],
+      element_ids=[],
+      rules=[],
+      classifications_by_assoc={},
+      fact_set=None,
+      verification_results=[],
+      verification_summary=None,
+    )
+
+    session = MagicMock()
+    computed_result = MagicMock()
+    computed_result.scalars.return_value.all.return_value = []
+    elements_result = MagicMock()
+    elements_result.scalars.return_value.all.return_value = [GROWTH]
+    lever_set_result = MagicMock()
+    lever_set_result.scalar_one_or_none.return_value = None
+    docs_result = MagicMock()
+    docs_result.all.return_value = []
+    session.execute.side_effect = [
+      computed_result,
+      elements_result,
+      lever_set_result,
+      docs_result,
+    ]
+
+    with (
+      patch.object(forecast_handlers, "load_base_envelope_atoms", return_value=atoms),
+      patch.object(forecast_handlers, "back_solve_lever_history", return_value=history),
+    ):
+      return forecast_handlers.build_envelope(session, "struct_budget_01")
+
+  def test_realized_months_extend_the_grid_behind_the_seam(self) -> None:
+    envelope = self._history_envelope(
+      LeverHistory(
+        months=["2026-05", "2026-06"],
+        lever_values={
+          "rs-driver:RevenueGrowthRate": {"2026-05": 0.021, "2026-06": 0.038}
+        },
+      )
+    )
+    assert envelope is not None
+    rendering = envelope.view.rendering
+    assert rendering is not None
+    assert [p.end for p in rendering.periods] == [
+      date(2026, 5, 31),
+      date(2026, 6, 30),
+      date(2026, 7, 31),
+      date(2026, 8, 31),
+    ]
+    # Realized rates, then the asserted horizon — one continuous series.
+    assert rendering.rows[0].values == [0.021, 0.038, 0.03, 0.03]
+    # The seam marker rides the forward columns only.
+    assert [p.forecast for p in rendering.periods] == [None, None, True, True]
+
+  def test_a_closed_horizon_month_shows_the_realized_rate_not_the_assertion(
+    self,
+  ) -> None:
+    # The scenario asserted 3% for July; July has since closed at 1.2%.
+    envelope = self._history_envelope(
+      LeverHistory(
+        months=["2026-06", "2026-07"],
+        lever_values={
+          "rs-driver:RevenueGrowthRate": {"2026-06": 0.038, "2026-07": 0.012}
+        },
+      )
+    )
+    assert envelope is not None
+    rendering = envelope.view.rendering
+    assert rendering is not None
+    assert [p.end for p in rendering.periods] == [
+      date(2026, 6, 30),
+      date(2026, 7, 31),
+      date(2026, 8, 31),
+    ]
+    assert rendering.rows[0].values == [0.038, 0.012, 0.03]
+    assert [p.forecast for p in rendering.periods] == [None, None, True]
+
+  def test_a_blank_realized_cell_stays_blank(self) -> None:
+    envelope = self._history_envelope(
+      LeverHistory(months=["2026-05", "2026-06"], lever_values={})
+    )
+    assert envelope is not None
+    rendering = envelope.view.rendering
+    assert rendering is not None
+    assert rendering.rows[0].values == [None, None, 0.03, 0.03]
 
   def test_returns_none_for_wrong_block_type(self) -> None:
     session = MagicMock()

--- a/tests/operations/information_block/test_forecast_history.py
+++ b/tests/operations/information_block/test_forecast_history.py
@@ -1,0 +1,307 @@
+"""Lever back-solve tests — the realized side of the Assumptions grid.
+
+Exercises the rule inversion against the REAL seeded driver expressions
+(growth via ``[t-1]``, rate-on-base, days-on-flow) with the data loads
+patched, so the assertions target the math and the binding rules rather
+than the queries: which months solve, which blank, and that an
+unsolvable rule never takes the grid down with it.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from robosystems.models.api.information_block import (
+  ForecastMechanics,
+  LeverAssertionLite,
+  LineAssertionLite,
+)
+from robosystems.operations.information_block import forecast_history as fh
+
+
+def _element(element_id: str, qname: str) -> SimpleNamespace:
+  return SimpleNamespace(id=element_id, qname=qname)
+
+
+EL_REV = _element("el_rev", "rs-gaap:Revenues")
+EL_COGS = _element("el_cogs", "rs-gaap:CostOfRevenue")
+EL_AR = _element("el_ar", "rs-gaap:ReceivablesNetCurrent")
+EL_RENT = _element("el_rent", "rs-gaap:RentExpense")
+EL_GROWTH = _element("el_growth", "rs-driver:RevenueGrowthRate")
+EL_RATE = _element("el_rate", "rs-driver:CostOfRevenueRate")
+EL_DSO = _element("el_dso", "rs-driver:DaysSalesOutstanding")
+
+BY_QNAME = {
+  el.qname: el for el in (EL_REV, EL_COGS, EL_AR, EL_RENT, EL_GROWTH, EL_RATE, EL_DSO)
+}
+BY_ID = {el.id: el for el in BY_QNAME.values()}
+
+
+def _rule(rule_id: str, target: SimpleNamespace, expression: str, variables) -> Any:
+  return SimpleNamespace(
+    id=rule_id,
+    rule_expression=expression,
+    rule_variables=[
+      {"variable_name": name, "variable_qname": qname} for name, qname in variables
+    ],
+    target_element_id=target.id,
+  )
+
+
+# The rs-driver/v1 expressions, verbatim.
+GROWTH_RULE = _rule(
+  "rule_growth",
+  EL_REV,
+  "$Revenues = ($Revenues[t-1] * (1 + $RevenueGrowthRate))",
+  [
+    ("Revenues", "rs-gaap:Revenues"),
+    ("RevenueGrowthRate", "rs-driver:RevenueGrowthRate"),
+  ],
+)
+COGS_RULE = _rule(
+  "rule_cogs",
+  EL_COGS,
+  "$CostOfRevenue = ($Revenues * $CostOfRevenueRate)",
+  [
+    ("CostOfRevenue", "rs-gaap:CostOfRevenue"),
+    ("Revenues", "rs-gaap:Revenues"),
+    ("CostOfRevenueRate", "rs-driver:CostOfRevenueRate"),
+  ],
+)
+DSO_RULE = _rule(
+  "rule_dso",
+  EL_AR,
+  "$ReceivablesNetCurrent = (($Revenues / 30) * $DaysSalesOutstanding)",
+  [
+    ("ReceivablesNetCurrent", "rs-gaap:ReceivablesNetCurrent"),
+    ("Revenues", "rs-gaap:Revenues"),
+    ("DaysSalesOutstanding", "rs-driver:DaysSalesOutstanding"),
+  ],
+)
+
+
+def _mechanics(
+  levers: list[LeverAssertionLite],
+  assertions: list[LineAssertionLite] | None = None,
+) -> ForecastMechanics:
+  return ForecastMechanics(
+    scenario_kind="budget",
+    horizon_months=3,
+    base_period="2026-06",
+    levers=levers,
+    line_assertions=assertions or [],
+  )
+
+
+def _lever(qname: str, element_id: str) -> LeverAssertionLite:
+  return LeverAssertionLite(
+    qname=qname,
+    element_id=element_id,
+    item_type="percent",
+    values_by_period={"2026-07": 0.03},
+  )
+
+
+GROWTH_LEVER = _lever("rs-driver:RevenueGrowthRate", "el_growth")
+RATE_LEVER = _lever("rs-driver:CostOfRevenueRate", "el_rate")
+DSO_LEVER = _lever("rs-driver:DaysSalesOutstanding", "el_dso")
+
+
+def _session() -> MagicMock:
+  session = MagicMock()
+  session.get.side_effect = lambda _model, element_id: BY_ID.get(element_id)
+  return session
+
+
+def _run(
+  mechanics: ForecastMechanics,
+  rules: list[Any],
+  months: list[str],
+  actuals: dict[str, dict[str, float]],
+) -> fh.LeverHistory:
+  with (
+    patch.object(fh, "driver_rules", return_value=rules),
+    patch.object(fh, "_lookup_element", lambda _s, qname: BY_QNAME.get(qname)),
+    patch.object(fh, "_actual_monthly_values", return_value=(months, actuals)),
+  ):
+    return fh.back_solve_lever_history(_session(), mechanics)
+
+
+class TestBackSolve:
+  def test_growth_inverts_against_the_prior_month(self) -> None:
+    history = _run(
+      _mechanics([GROWTH_LEVER]),
+      [GROWTH_RULE],
+      ["2026-04", "2026-05"],
+      {
+        "2026-04": {"el_rev": 100.0},
+        "2026-05": {"el_rev": 104.0},
+      },
+    )
+    solved = history.lever_values["rs-driver:RevenueGrowthRate"]
+    # April has no prior month in the series → nothing to solve against.
+    assert "2026-04" not in solved
+    assert solved["2026-05"] == pytest.approx(0.04)
+
+  def test_rate_and_days_levers_invert_from_the_same_month(self) -> None:
+    history = _run(
+      _mechanics([RATE_LEVER, DSO_LEVER]),
+      [COGS_RULE, DSO_RULE],
+      ["2026-05"],
+      {"2026-05": {"el_rev": 300.0, "el_cogs": 186.0, "el_ar": 310.0}},
+    )
+    assert history.lever_values["rs-driver:CostOfRevenueRate"][
+      "2026-05"
+    ] == pytest.approx(0.62)
+    # AR / (Revenues / 30) = 310 / 10 = 31 days.
+    assert history.lever_values["rs-driver:DaysSalesOutstanding"][
+      "2026-05"
+    ] == pytest.approx(31.0)
+
+  def test_a_month_missing_an_operand_blanks_only_that_cell(self) -> None:
+    history = _run(
+      _mechanics([RATE_LEVER]),
+      [COGS_RULE],
+      ["2026-04", "2026-05", "2026-06"],
+      {
+        "2026-04": {"el_rev": 100.0, "el_cogs": 62.0},
+        # May never closed its cost line — no rate to recover.
+        "2026-05": {"el_rev": 110.0},
+        "2026-06": {"el_rev": 200.0, "el_cogs": 130.0},
+      },
+    )
+    solved = history.lever_values["rs-driver:CostOfRevenueRate"]
+    assert sorted(solved) == ["2026-04", "2026-06"]
+    assert solved["2026-06"] == pytest.approx(0.65)
+
+  def test_a_zero_base_leaves_the_cell_blank_rather_than_dividing(self) -> None:
+    # Revenues[t-1] = 0 ⇒ the growth rule's slope is 0: no rate explains
+    # a jump off a zero base (the §11 #9 restart case).
+    history = _run(
+      _mechanics([GROWTH_LEVER]),
+      [GROWTH_RULE],
+      ["2026-04", "2026-05"],
+      {"2026-04": {"el_rev": 0.0}, "2026-05": {"el_rev": 5000.0}},
+    )
+    assert history.lever_values.get("rs-driver:RevenueGrowthRate", {}) == {}
+    assert history.months == ["2026-04", "2026-05"]
+
+  def test_only_levers_this_scenario_asserts_are_solved(self) -> None:
+    history = _run(
+      _mechanics([RATE_LEVER]),
+      [GROWTH_RULE, COGS_RULE, DSO_RULE],
+      ["2026-05"],
+      {"2026-05": {"el_rev": 300.0, "el_cogs": 186.0, "el_ar": 310.0}},
+    )
+    assert list(history.lever_values) == ["rs-driver:CostOfRevenueRate"]
+
+  def test_line_assertions_take_the_actual_line_itself(self) -> None:
+    mechanics = _mechanics(
+      [RATE_LEVER],
+      [
+        LineAssertionLite(
+          qname="rs-gaap:RentExpense",
+          element_id="el_rent",
+          item_type=None,
+          period_type="duration",
+          values_by_period={"2026-07": 0.0},
+        )
+      ],
+    )
+    history = _run(
+      mechanics,
+      [COGS_RULE],
+      ["2026-04", "2026-05"],
+      {
+        "2026-04": {"el_rev": 100.0, "el_cogs": 62.0, "el_rent": 900.0},
+        "2026-05": {"el_rev": 110.0, "el_cogs": 68.2},
+      },
+    )
+    # No inversion for a line assertion — its realized value IS the line.
+    assert history.line_values["el_rent"] == {"2026-04": 900.0}
+
+  def test_no_closed_months_yields_an_empty_history(self) -> None:
+    history = _run(_mechanics([GROWTH_LEVER]), [GROWTH_RULE], [], {})
+    assert history.months == []
+    assert history.lever_values == {}
+
+  def test_no_driver_rules_yields_an_empty_history(self) -> None:
+    history = _run(_mechanics([GROWTH_LEVER]), [], ["2026-05"], {})
+    assert history.months == []
+
+  def test_an_unparseable_rule_is_skipped_not_raised(self) -> None:
+    broken = _rule(
+      "rule_broken",
+      EL_REV,
+      "$Revenues = ($Revenues[t-1] * ",
+      [
+        ("Revenues", "rs-gaap:Revenues"),
+        ("RevenueGrowthRate", "rs-driver:RevenueGrowthRate"),
+      ],
+    )
+    history = _run(
+      _mechanics([GROWTH_LEVER, RATE_LEVER]),
+      [broken, COGS_RULE],
+      ["2026-05"],
+      {"2026-05": {"el_rev": 300.0, "el_cogs": 186.0}},
+    )
+    assert list(history.lever_values) == ["rs-driver:CostOfRevenueRate"]
+
+
+class TestActualMonthlyValues:
+  def test_reads_only_the_elements_asked_for_across_the_series(self) -> None:
+    session = MagicMock()
+    series = [
+      SimpleNamespace(id="fs_apr", period_end=date(2026, 4, 30)),
+      SimpleNamespace(id="fs_may", period_end=date(2026, 5, 31)),
+    ]
+    facts = [
+      SimpleNamespace(fact_set_id="fs_apr", element_id="el_rev", value=100.0),
+      SimpleNamespace(fact_set_id="fs_may", element_id="el_rev", value=104.0),
+    ]
+    facts_result = MagicMock()
+    facts_result.scalars.return_value.all.return_value = facts
+    empty_result = MagicMock()
+    empty_result.scalars.return_value.all.return_value = []
+    session.execute.side_effect = [facts_result, empty_result]
+
+    with (
+      patch.object(fh, "newest_actual_structure_id", side_effect=["struct_is", None]),
+      patch.object(fh, "load_statement_fact_set_series", return_value=series),
+    ):
+      months, actuals = fh._actual_monthly_values(session, {"el_rev"})
+
+    assert months == ["2026-04", "2026-05"]
+    assert actuals == {"2026-04": {"el_rev": 100.0}, "2026-05": {"el_rev": 104.0}}
+
+  def test_a_month_with_no_binding_fact_is_still_a_column(self) -> None:
+    session = MagicMock()
+    series = [
+      SimpleNamespace(id="fs_apr", period_end=date(2026, 4, 30)),
+      SimpleNamespace(id="fs_may", period_end=date(2026, 5, 31)),
+    ]
+    facts_result = MagicMock()
+    facts_result.scalars.return_value.all.return_value = [
+      SimpleNamespace(fact_set_id="fs_apr", element_id="el_rev", value=100.0)
+    ]
+    session.execute.return_value = facts_result
+
+    with (
+      patch.object(fh, "newest_actual_structure_id", side_effect=["struct_is", None]),
+      patch.object(fh, "load_statement_fact_set_series", return_value=series),
+    ):
+      months, actuals = fh._actual_monthly_values(session, {"el_rev"})
+
+    assert months == ["2026-04", "2026-05"]
+    assert "2026-05" not in actuals
+
+  def test_no_actual_structures_means_no_months(self) -> None:
+    with patch.object(fh, "newest_actual_structure_id", return_value=None):
+      months, actuals = fh._actual_monthly_values(MagicMock(), {"el_rev"})
+    assert months == []
+    assert actuals == {}


### PR DESCRIPTION
## What

Fixes the line-assertion articulation gap found in production by the first real restart-ramp scenario: a leaf asserted into a month whose calc subtree is absent from the base month (revenue asserted onto a wound-down book) emitted the leaf but never its derived ancestors — the month failed RollUp verification with a residual exactly equal to the assertion, next-month `[t-1]` operands never saw the parent, and same-month operands (DSO's `$Revenues`) skipped as unbound.

The verification gate caught this precisely in prod (three failed months, residuals naming the missing rollup) — gating working as designed; this PR closes the gap it flagged.

## How — five coordinated changes in the monthly walk

1. **Emission** now includes every out-of-base duration line in the working set and its derived calc ancestors (values from the resolved DAG) — the scenario set rolls up, and `prior_values` feeds the next month's operands.
2. **Carry pool** gains asserted duration lines — a ramp's last asserted value carries into unasserted months where the rules take over.
3. **Operand binding** gains a derive-from-children fallback between same-month-direct and prior — a calc parent whose only same-month value is an asserted leaf binds its derived sum; an absent subtree still skips (no fabricated zeros).
4. **Displacement**: a rule driving a calc parent whose entire valued subtree is pinned by assertions is displaced legibly (`contributing children pinned`); partially pinned subtrees keep the rule active with the existing pinned push-down.
5. **Skipped-rule carry fallback** excludes displaced targets — a carried stale parent must not beat the freshly derived child sum at the subtotal step (found live: month 2 of the ramp emitted month 1's parent).

## Tests

New `TestAssertionRollupIntoEmptySubtree` (the prod repro in miniature): ancestors emit with the asserted leaf; growth displaced during the ramp, takes over after it with the child scaling in register (rollup exact past the seam); DSO binds the derived parent same-month; partial pinning keeps rules active. All 411 information-block tests pass; `just test-code` green. No migration.

## Post-deploy

The live "Restart Ramp — Oct 2026" scenario on the Harbinger tenant is the standing repro — a plain `compute-forecast` re-run after deploy should flip its three failed months to verified with revenue articulating end-to-end.