### PR TITLE
fix(close): stamped cash flow articulates via prior-month pivot

### DIFF
--- a/robosystems/middleware/mcp/tools/fiscal_calendar_tools.py
+++ b/robosystems/middleware/mcp/tools/fiscal_calendar_tools.py
@@ -535,6 +535,7 @@ class BackfillPlanHistoryTool:
 
 **IDEMPOTENT / SAFE:**
 - Months that already have canonical statement sets are never touched
+  (unless restamp=true — the deliberate healing pass that re-derives them)
 - Months holding draft entries are SKIPPED, never posted — the backfill
   refuses to commit ledger changes nobody reviewed (resolve via
   list-period-drafts + close-period, then re-run)
@@ -548,6 +549,10 @@ class BackfillPlanHistoryTool:
 - max_periods (optional, default 12, max 24): months to restamp this call.
 - allow_stale_sync (optional): override the sync gate on each reclose —
   rarely needed since historical months predate the last sync.
+- restamp (optional, default false): also re-derive months that already
+  have canonical sets — the healing pass after an engine improvement.
+  Advance start_period between chunks (a restamp run is not
+  self-resuming).
 - note (optional): attached to each close audit event.
 
 **RETURNS:**
@@ -589,6 +594,17 @@ class BackfillPlanHistoryTool:
               "sync in the normal case."
             ),
           },
+          "restamp": {
+            "type": "boolean",
+            "description": (
+              "Also re-derive months that ALREADY have canonical statement "
+              "sets (default false). The healing pass after an engine "
+              "improvement changes what a stamp produces. NOT self-resuming "
+              "— every month in range stays a candidate, so advance "
+              "start_period between chunks instead of looping on "
+              "remaining_periods."
+            ),
+          },
           "note": {
             "type": "string",
             "description": "Optional note attached to each close audit event",
@@ -610,6 +626,7 @@ class BackfillPlanHistoryTool:
       start_period=arguments.get("start_period"),
       max_periods=int(arguments.get("max_periods", 12)),
       allow_stale_sync=bool(arguments.get("allow_stale_sync", False)),
+      restamp=bool(arguments.get("restamp", False)),
       note=arguments.get("note"),
     )
     actor_id = getattr(self.client, "user_id", None) or f"mcp:{graph_id}"

--- a/robosystems/models/api/extensions/fiscal_calendar.py
+++ b/robosystems/models/api/extensions/fiscal_calendar.py
@@ -180,7 +180,8 @@ class BackfillPlanHistoryRequest(BaseModel):
   Chunked: each call processes at most ``max_periods`` months (oldest
   first) and reports what's left in ``remaining_periods`` — loop until
   it comes back empty. Idempotent: months that already have canonical
-  sets are never touched, so re-running is safe.
+  sets are never touched, so re-running is safe (``restamp=true``
+  deliberately trades this away to re-derive existing sets).
 
   The backfill never reaches past the tenant's earliest ledger data —
   ``start_period`` is clamped to the first month with entries.
@@ -213,6 +214,17 @@ class BackfillPlanHistoryRequest(BaseModel):
       "rarely needed."
     ),
   )
+  restamp: bool = Field(
+    False,
+    description=(
+      "Also re-derive months that ALREADY have canonical statement "
+      "sets (default: skip them). Use after an engine improvement "
+      "changes what a stamp produces — each month reruns the full "
+      "reopen → reclose cycle and replaces its sets. A restamp run is "
+      "not self-resuming (every month in range stays a candidate); "
+      "advance `start_period` between chunks."
+    ),
+  )
   note: str | None = Field(
     None, description="Free-form note attached to each close audit event"
   )
@@ -222,6 +234,7 @@ class BackfillPlanHistoryRequest(BaseModel):
       "examples": [
         {},
         {"start_period": "2019-07", "max_periods": 12},
+        {"restamp": True, "start_period": "2024-08", "max_periods": 12},
       ]
     }
   )

--- a/robosystems/operations/roboledger/commands/fiscal_calendar.py
+++ b/robosystems/operations/roboledger/commands/fiscal_calendar.py
@@ -327,7 +327,9 @@ def backfill_plan_history(
 
   Seeds missing `FiscalPeriod` rows (baseline-closed) back to the
   clamped start, then walks every month in the range that lacks
-  canonical statement FactSets oldest-first, running the real
+  canonical statement FactSets oldest-first (``body.restamp`` widens
+  the walk to every month in range — the healing pass after an engine
+  improvement changes what a stamp produces), running the real
   `reopen_period` → `close_period` cycle on each — identical semantics
   to a manual restamp, so balance validation, statement rules, QB
   writeback guards, and audit events all apply per month.
@@ -395,7 +397,9 @@ def backfill_plan_history(
   current = start
   while current <= closed_through:
     ps, pe = period_date_range(current)
-    if not has_canonical_statement_sets(session, period_start=ps, period_end=pe):
+    if body.restamp or not has_canonical_statement_sets(
+      session, period_start=ps, period_end=pe
+    ):
       candidates.append(current)
     current = next_period(current)
 

--- a/robosystems/operations/roboledger/reports/statement_sets.py
+++ b/robosystems/operations/roboledger/reports/statement_sets.py
@@ -31,6 +31,7 @@ lazy-import posture toward information-block machinery.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from datetime import timedelta
 from typing import TYPE_CHECKING
 
 from sqlalchemy import delete, text
@@ -524,6 +525,16 @@ def stamp_canonical_statement_sets(
   the disclosure picker out — text-block snapshots and disclosure
   membership are publication concerns that stay in ``create_report``).
 
+  The pivot runs over TWO periods — the prior calendar month plus the
+  close month — so the indirect cash flow articulates: operating CF
+  leaves derive from month-over-month BS deltas and the statement foots
+  to the actual ΔCash via the reconciling plug, exactly the
+  ``create_report`` / forecast doctrine. Only the close month's facts
+  are stamped. A close month with no prior ledger activity deltas
+  against zero balances — correct for a book's genuinely first month —
+  and a backfill's clamped seed month deltas against the ledger's true
+  prior-month balances even when that month was never itself stamped.
+
   Two-zone failure semantics:
 
   - **Soft-skip** (returns ``stamped=False`` with a note): the tenant
@@ -576,15 +587,28 @@ def stamp_canonical_statement_sets(
     return StatementStampResult(stamped=False, note="no_taxonomy")
 
   period_label = period_end.strftime("%Y-%m")
+  # The prior month rides the pivot as the indirect-CF delta basis: the
+  # working-capital derivation (``_derive_cash_flow_facts``) and the
+  # cash foot (``_reconcile_operating_to_cash``) both no-op below two
+  # periods, which is why single-period stamps used to mint a CF of
+  # NetIncome + DDA that never tied to the actual cash movement. Only
+  # the close month's facts are stamped — the prior month's are dropped
+  # after derivation (its own canonical sets, if any, are untouched).
+  prior_end = period_start - timedelta(days=1)
+  prior_start = prior_end.replace(day=1)
   try:
     close_target = load_close_target_concept(session, reporting_style_id)
     facts = generate_report_facts(
       session=session,
       taxonomy_id=taxonomy_row.id,
       mapping_id=mapping.id,
-      periods=[PeriodSpec(start=period_start, end=period_end, label=period_label)],
+      periods=[
+        PeriodSpec(start=prior_start, end=prior_end, label=prior_end.strftime("%Y-%m")),
+        PeriodSpec(start=period_start, end=period_end, label=period_label),
+      ],
       close_target_qname=close_target,
     )
+    facts.facts = [f for f in facts.facts if f.period_end == period_end]
     retract_canonical_statement_sets(
       session, period_start=period_start, period_end=period_end
     )

--- a/tests/operations/roboledger/commands/test_fiscal_calendar.py
+++ b/tests/operations/roboledger/commands/test_fiscal_calendar.py
@@ -337,6 +337,23 @@ class TestBackfillPlanHistory:
     assert reopen_mock.call_count == 2
     assert close_mock.call_count == 2
 
+  def test_restamp_re_derives_already_stamped_months(self):
+    """restamp=true widens the walk to every month in range — the
+    healing pass after an engine improvement changes what a stamp
+    produces (e.g. the two-period CF derivation)."""
+    session = self._session(draft_counts=[0] * 4, fp_statuses=["closed"] * 4)
+    response, reopen_mock, close_mock = self._run(
+      session,
+      self._service(),
+      body=BackfillPlanHistoryRequest(restamp=True),
+      stamped_windows={"2025-11", "2025-12"},
+    )
+    attempted = [outcome.period for outcome in response.processed]
+    assert attempted == ["2025-11", "2025-12", "2026-01", "2026-02"]
+    assert all(o.status == "stamped" for o in response.processed)
+    assert reopen_mock.call_count == 4
+    assert close_mock.call_count == 4
+
   def test_chunking_respects_max_periods(self):
     session = self._session(draft_counts=[0, 0], fp_statuses=["closed", "closed"])
     response, _, close_mock = self._run(

--- a/tests/operations/roboledger/reports/test_statement_sets.py
+++ b/tests/operations/roboledger/reports/test_statement_sets.py
@@ -15,6 +15,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from robosystems.models.extensions import Fact
 from robosystems.models.extensions.roboledger.fact_set import FactSet
 from robosystems.operations.roboledger.reports.statement_sets import (
   StatementStampError,
@@ -25,6 +26,8 @@ from robosystems.operations.roboledger.reports.statement_sets import (
 GRAPH_ID = "kg01234567890abcdef"
 PS = date(2026, 1, 1)
 PE = date(2026, 1, 31)
+PRIOR_PS = date(2025, 12, 1)
+PRIOR_PE = date(2025, 12, 31)
 
 _MOD = "robosystems.operations.roboledger.reports.statement_sets"
 
@@ -73,6 +76,15 @@ def _fake_facts():
         period_start=PS,
         period_end=PE,
         period_type="duration",
+      ),
+      # Prior-month pivot output — the indirect-CF delta basis. Must be
+      # consumed by the derivation, never stamped into the close month.
+      SimpleNamespace(
+        element_id="el_cash",
+        value=40.0,
+        period_start=None,
+        period_end=PRIOR_PE,
+        period_type="instant",
       ),
     ]
   )
@@ -235,6 +247,34 @@ class TestStampHappyPath:
     )
     assert result.stamped is True
     assert result.rule_summary is None
+
+  def test_pivot_receives_prior_month_delta_basis(self):
+    """The pivot must get [prior month, close month] — the indirect-CF
+    derivation and the cash foot both no-op below two periods, which is
+    the bug that stamped CF = NetIncome + DDA with zero WC deltas."""
+    session = self._happy_session()
+    gen = MagicMock(return_value=_fake_facts())
+    _stamp(session, generate_report_facts=gen)
+    periods = gen.call_args.kwargs["periods"]
+    assert [(p.start, p.end) for p in periods] == [
+      (PRIOR_PS, PRIOR_PE),
+      (PS, PE),
+    ]
+    assert [p.label for p in periods] == ["2025-12", "2026-01"]
+
+  def test_prior_month_facts_derive_but_never_stamp(self):
+    """Prior-month pivot output is the delta basis only — every stamped
+    Fact must carry the close month's period_end."""
+    session = self._happy_session()
+    result = _stamp(session)
+    assert result.stamped is True
+    stamped = [
+      call.args[0]
+      for call in session.add.call_args_list
+      if isinstance(call.args[0], Fact)
+    ]
+    assert len(stamped) == 2  # el_cash + el_rev for the close month
+    assert all(f.period_end == PE for f in stamped)
 
 
 # ────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Close-stamped monthly cash-flow statements never tied to the actual cash movement: the close-time stamper ran the report pivot over the single close month, and both indirect-CF derivers (`_derive_cash_flow_facts`, `_reconcile_operating_to_cash`) no-op below two periods — so canonical CF sets degenerated to NetIncome + DDA with zero working-capital deltas. Forecast CF columns foot to the penny (F-2 derives them from BS deltas) while the actuals beside them didn't. This PR feeds the existing derivation its missing delta basis, and adds a `restamp` mode to `backfill-plan-history` so already-stamped history can be re-derived after deploy.

## Changes

**`operations/roboledger/reports/statement_sets.py`**
- `stamp_canonical_statement_sets` now pivots two periods — the prior calendar month plus the close month — so the indirect-CF derivation and the ΔCash reconciling foot both run, exactly the `create_report` / forecast doctrine.
- Only the close month's facts are stamped; the prior month's pivot output is consumed as the delta basis and dropped (its own canonical sets are untouched).
- A close month with no prior ledger activity deltas against zero balances (correct for a book's first month); a backfill's clamped seed month deltas against the ledger's true prior-month balances even when that month was never stamped.

**`operations/roboledger/commands/fiscal_calendar.py` + `models/api/extensions/fiscal_calendar.py` + `middleware/mcp/tools/fiscal_calendar_tools.py`**
- `restamp: bool = false` on `BackfillPlanHistoryRequest`: widens the backfill's candidate walk to months that already carry canonical sets — each reruns the full reopen → reclose cycle and replaces its sets. The healing pass for history stamped before this fix. Not self-resuming by design (callers advance `start_period` between chunks); documented on the field, the command docstring, and the MCP tool schema.

**Tests**
- Stamper: the pivot receives `[prior month, close month]` chronologically; prior-month facts derive but never stamp (every stamped Fact carries the close month's period_end).
- Backfill: `restamp=true` re-derives already-stamped months (4/4 candidates vs the 2/4 idempotent default).

## Testing

- `just test-code` (ruff + format + basedpyright + cf-lint): all checks passed.
- Full unit suite (`pytest -m "not slow"`): 11,302 passed. One pre-existing local-environment failure in `tests/graph_api/routers/databases/tables/test_incremental_materialize.py` (pyarrow `ArrowKeyError`) reproduces on clean `origin/main` and is unrelated to this change — CI is the arbiter there.

## Notes

- No migration; no API-breaking change (`restamp` is additive, default false).
- Post-deploy healing: `backfill-plan-history {restamp: true}` restamps existing monthly history with articulating CF; recloses of individual months heal them the same way.
