### PR TITLE
feat(blocks): server-side series windowing on statement envelopes

### DIFF
--- a/robosystems/graphql/resolvers/information_block.py
+++ b/robosystems/graphql/resolvers/information_block.py
@@ -51,6 +51,8 @@ class InformationBlockQuery:
     id: strawberry.ID,
     scenario_id: str | None = None,
     series: bool = False,
+    series_history: int | None = None,
+    series_forecast: int | None = None,
   ) -> InformationBlock | None:
     """Fetch a single Information Block envelope by id.
 
@@ -64,10 +66,20 @@ class InformationBlockQuery:
     series — one column per period, actuals-preferred at the seam when
     combined with ``scenarioId``; forecast columns carry
     ``periods[].forecast = true``. Non-statement block types ignore it.
+
+    ``seriesHistory`` / ``seriesForecast`` window the series to its
+    seam-adjacent columns — the last N actual columns and the first N
+    forecast columns; omitted = unbounded. Pass the visible window so
+    the envelope scales with the screen, not the ledger's age.
     """
     with _open_session(info) as session:
       envelope = get_information_block(
-        session, str(id), scenario_id=scenario_id, series=series
+        session,
+        str(id),
+        scenario_id=scenario_id,
+        series=series,
+        series_history=series_history,
+        series_forecast=series_forecast,
       )
       return InformationBlock.from_pydantic(envelope) if envelope else None
 

--- a/robosystems/middleware/mcp/tools/information_block_tools.py
+++ b/robosystems/middleware/mcp/tools/information_block_tools.py
@@ -60,6 +60,10 @@ class GetInformationBlockTool:
   time series — one column per period; combined with scenario_id the
   columns cross the actuals/forecast seam (forecast columns carry
   periods[].forecast = true). Non-statement block types ignore it
+- series_history / series_forecast (optional): Window the series to its
+  seam-adjacent columns — the last N actual columns and the first N
+  forecast columns. Omitted = unbounded. Prefer a window on deep-history
+  tenants: an unbounded series envelope grows with the ledger's age
 
 **RETURNS:**
 A typed envelope with:
@@ -99,6 +103,22 @@ were retired in favor of this pair.""",
               "forecast seam)."
             ),
           },
+          "series_history": {
+            "type": "integer",
+            "minimum": 0,
+            "description": (
+              "With series: keep only the last N actual columns "
+              "(nearest the close boundary). Omitted = all history."
+            ),
+          },
+          "series_forecast": {
+            "type": "integer",
+            "minimum": 0,
+            "description": (
+              "With series: keep only the first N forecast columns "
+              "(nearest the seam). Omitted = the full horizon."
+            ),
+          },
         },
         "required": ["id"],
       },
@@ -109,11 +129,18 @@ were retired in favor of this pair.""",
     block_id = arguments["id"]
     scenario_id = arguments.get("scenario_id")
     series = bool(arguments.get("series", False))
+    series_history = arguments.get("series_history")
+    series_forecast = arguments.get("series_forecast")
 
     try:
       with extensions_session(graph_id) as session:
         envelope = ops_get_information_block(
-          session, block_id, scenario_id=scenario_id, series=series
+          session,
+          block_id,
+          scenario_id=scenario_id,
+          series=series,
+          series_history=int(series_history) if series_history is not None else None,
+          series_forecast=int(series_forecast) if series_forecast is not None else None,
         )
         if envelope is None:
           return {

--- a/robosystems/operations/information_block/disclosure.py
+++ b/robosystems/operations/information_block/disclosure.py
@@ -61,6 +61,8 @@ def build_envelope(
   fact_set_id: str | None = None,
   scenario_id: str | None = None,
   series: bool = False,
+  series_history: int | None = None,
+  series_forecast: int | None = None,
 ) -> InformationBlockEnvelope | None:
   """Pack the envelope for a disclosure-note structure.
 

--- a/robosystems/operations/information_block/envelope.py
+++ b/robosystems/operations/information_block/envelope.py
@@ -432,6 +432,39 @@ def load_statement_fact_set_series(
   return [fact_set_to_lite(row) for row in by_period_end.values()]
 
 
+def window_series_sets(
+  series_sets: list[FactSetLite],
+  history: int | None,
+  forecast: int | None,
+) -> list[FactSetLite]:
+  """Trim a collapsed statement series to its seam-adjacent window.
+
+  ``history`` keeps the LAST N actual columns (``scenario_id`` None —
+  the months nearest the close boundary); ``forecast`` keeps the FIRST
+  N forecast columns (the months nearest the seam). ``None`` leaves
+  that side unbounded, so ``(None, None)`` is the identity — existing
+  callers see the full series unchanged. Column order (ascending
+  ``period_end``, the :func:`load_statement_fact_set_series` contract)
+  is preserved.
+
+  Counts are COLUMNS, not calendar months: post-backfill the actual
+  series is monthly so they coincide, but an annual-only tenant's
+  ``history=12`` keeps twelve annual columns rather than one year.
+  """
+  if history is None and forecast is None:
+    return series_sets
+  if (history is not None and history < 0) or (forecast is not None and forecast < 0):
+    raise ValueError("series window counts must be >= 0")
+  actuals = [fs for fs in series_sets if fs.scenario_id is None]
+  forecasts = [fs for fs in series_sets if fs.scenario_id is not None]
+  if history is not None:
+    actuals = actuals[-history:] if history > 0 else []
+  if forecast is not None:
+    forecasts = forecasts[:forecast]
+  keep = {fs.id for fs in actuals} | {fs.id for fs in forecasts}
+  return [fs for fs in series_sets if fs.id in keep]
+
+
 def _drop_covering_windows(rows: list) -> list:
   """Drop sets whose window strictly contains another loaded set's window.
 

--- a/robosystems/operations/information_block/forecast.py
+++ b/robosystems/operations/information_block/forecast.py
@@ -557,6 +557,8 @@ def build_envelope(
   fact_set_id: str | None = None,
   scenario_id: str | None = None,
   series: bool = False,
+  series_history: int | None = None,
+  series_forecast: int | None = None,
 ) -> InformationBlockEnvelope | None:
   """Reload a forecast Structure and pack its envelope.
 

--- a/robosystems/operations/information_block/metric.py
+++ b/robosystems/operations/information_block/metric.py
@@ -104,6 +104,8 @@ def build_envelope(
   fact_set_id: str | None = None,
   scenario_id: str | None = None,
   series: bool = False,
+  series_history: int | None = None,
+  series_forecast: int | None = None,
 ) -> InformationBlockEnvelope | None:
   """Pack a metric Structure + its standing time series into the envelope.
 

--- a/robosystems/operations/information_block/reads.py
+++ b/robosystems/operations/information_block/reads.py
@@ -29,6 +29,8 @@ def get_information_block(
   fact_set_id: str | None = None,
   scenario_id: str | None = None,
   series: bool = False,
+  series_history: int | None = None,
+  series_forecast: int | None = None,
 ) -> InformationBlockEnvelope | None:
   """Fetch one block by id, dispatching via the structure's block_type.
 
@@ -51,6 +53,12 @@ def get_information_block(
   when combined with ``scenario_id`` (the F-4 statement-series
   projection). Non-statement block types accept and ignore it (metric
   envelopes are always the full series).
+
+  ``series_history`` / ``series_forecast`` window the series to its
+  seam-adjacent columns — the last N actual columns and the first N
+  forecast columns; ``None`` = unbounded. Only meaningful with
+  ``series=True`` on statement-family blocks; other block types accept
+  and ignore them (signature parity).
   """
   structure = session.get(Structure, structure_id)
   if structure is None:
@@ -63,7 +71,13 @@ def get_information_block(
     # be built.
     return None
   return entry.dispatch_build_envelope(
-    session, structure_id, fact_set_id, scenario_id=scenario_id, series=series
+    session,
+    structure_id,
+    fact_set_id,
+    scenario_id=scenario_id,
+    series=series,
+    series_history=series_history,
+    series_forecast=series_forecast,
   )
 
 

--- a/robosystems/operations/information_block/rollforward.py
+++ b/robosystems/operations/information_block/rollforward.py
@@ -238,6 +238,8 @@ def build_envelope(
   fact_set_id: str | None = None,
   scenario_id: str | None = None,
   series: bool = False,
+  series_history: int | None = None,
+  series_forecast: int | None = None,
 ) -> InformationBlockEnvelope | None:
   """Reload a rollforward Structure and pack its envelope.
 

--- a/robosystems/operations/information_block/schedule.py
+++ b/robosystems/operations/information_block/schedule.py
@@ -169,6 +169,8 @@ def build_envelope(
   fact_set_id: str | None = None,
   scenario_id: str | None = None,
   series: bool = False,
+  series_history: int | None = None,
+  series_forecast: int | None = None,
 ) -> InformationBlockEnvelope | None:
   """Reload a schedule Structure and pack its Information Block envelope.
 

--- a/robosystems/operations/information_block/statement.py
+++ b/robosystems/operations/information_block/statement.py
@@ -59,6 +59,7 @@ from robosystems.operations.information_block.envelope import (
   load_base_envelope_atoms,
   load_disclosure_id_for_structure,
   load_statement_fact_set_series,
+  window_series_sets,
 )
 from robosystems.operations.roboledger.reports.fact_grid import (
   FactRow,
@@ -98,6 +99,8 @@ def _build_statement_envelope(
   fact_set_id: str | None = None,
   scenario_id: str | None = None,
   series: bool = False,
+  series_history: int | None = None,
+  series_forecast: int | None = None,
   *,
   block_type: str,
 ) -> InformationBlockEnvelope | None:
@@ -134,6 +137,15 @@ def _build_statement_envelope(
   annual report's comparative facts can't leak into a monthly column.
   An explicit ``fact_set_id`` pin bypasses series mode (a snapshot is
   a single set by definition).
+
+  **Series window.** ``series_history`` / ``series_forecast`` trim the
+  series to its seam-adjacent columns BEFORE facts load — the last N
+  actual columns and the first N forecast columns
+  (:func:`envelope.window_series_sets`). ``None`` = unbounded (the
+  pre-window behavior), so existing callers are untouched; the Plan
+  page passes its visible window so a deep-history tenant's envelope
+  stays proportional to what's on screen rather than to the ledger's
+  age.
   """
   atoms = load_base_envelope_atoms(
     session,
@@ -153,6 +165,7 @@ def _build_statement_envelope(
   facts: list[Fact] = []
   if element_ids and series_mode:
     series_sets = load_statement_fact_set_series(session, structure_id, scenario_id)
+    series_sets = window_series_sets(series_sets, series_history, series_forecast)
     forecast_period_ends = {
       fs.period_end for fs in series_sets if fs.scenario_id is not None
     }

--- a/tests/operations/information_block/test_envelope_fact_set.py
+++ b/tests/operations/information_block/test_envelope_fact_set.py
@@ -157,6 +157,97 @@ class TestLoadLatestFactSetForStructure:
     assert lite.scenario_id is None
 
 
+class TestWindowSeriesSets:
+  """Seam-adjacent series windowing — the §11 #11 server-side trim.
+
+  ``history`` keeps the LAST N actual columns; ``forecast`` keeps the
+  FIRST N forecast columns; ``None`` = unbounded on that side.
+  """
+
+  @staticmethod
+  def _series() -> list:
+    """5 actual months (Jan..May) + 3 forecast months (Jun..Aug), ascending."""
+    from robosystems.operations.information_block.envelope import fact_set_to_lite
+
+    sets = []
+    for month in range(1, 6):
+      sets.append(
+        fact_set_to_lite(
+          _make_fact_set(
+            fs_id=f"fs_a{month}",
+            period_start=date(2026, month, 1),
+            period_end=date(2026, month, 28),
+          )
+        )
+      )
+    for month in range(6, 9):
+      sets.append(
+        fact_set_to_lite(
+          _make_fact_set(
+            fs_id=f"fs_f{month}",
+            period_start=date(2026, month, 1),
+            period_end=date(2026, month, 28),
+            scenario_id="struct_budget",
+          )
+        )
+      )
+    return sets
+
+  def test_unbounded_is_identity(self) -> None:
+    from robosystems.operations.information_block.envelope import window_series_sets
+
+    series = self._series()
+    assert window_series_sets(series, None, None) is series
+
+  def test_history_keeps_last_n_actuals(self) -> None:
+    from robosystems.operations.information_block.envelope import window_series_sets
+
+    kept = window_series_sets(self._series(), 2, None)
+    assert [fs.id for fs in kept] == ["fs_a4", "fs_a5", "fs_f6", "fs_f7", "fs_f8"]
+
+  def test_forecast_keeps_first_n_forecasts(self) -> None:
+    from robosystems.operations.information_block.envelope import window_series_sets
+
+    kept = window_series_sets(self._series(), None, 1)
+    assert [fs.id for fs in kept] == [
+      "fs_a1",
+      "fs_a2",
+      "fs_a3",
+      "fs_a4",
+      "fs_a5",
+      "fs_f6",
+    ]
+
+  def test_combined_window_preserves_ascending_order(self) -> None:
+    from robosystems.operations.information_block.envelope import window_series_sets
+
+    kept = window_series_sets(self._series(), 3, 2)
+    assert [fs.id for fs in kept] == ["fs_a3", "fs_a4", "fs_a5", "fs_f6", "fs_f7"]
+
+  def test_zero_history_is_forecast_only(self) -> None:
+    from robosystems.operations.information_block.envelope import window_series_sets
+
+    kept = window_series_sets(self._series(), 0, None)
+    assert [fs.id for fs in kept] == ["fs_f6", "fs_f7", "fs_f8"]
+
+  def test_oversized_windows_keep_everything(self) -> None:
+    from robosystems.operations.information_block.envelope import window_series_sets
+
+    series = self._series()
+    kept = window_series_sets(series, 100, 100)
+    assert [fs.id for fs in kept] == [fs.id for fs in series]
+
+  def test_negative_counts_raise(self) -> None:
+    import pytest
+
+    from robosystems.operations.information_block.envelope import window_series_sets
+
+    with pytest.raises(ValueError):
+      window_series_sets(self._series(), -1, None)
+    with pytest.raises(ValueError):
+      window_series_sets(self._series(), None, -1)
+
+
 class TestLoadStatementFactSetSeries:
   """The F-4 series loader — every report set as one column, with the
   actuals-preferred seam and the narrower-window-wins collapse."""

--- a/tests/operations/information_block/test_reads.py
+++ b/tests/operations/information_block/test_reads.py
@@ -78,7 +78,13 @@ class TestGetInformationBlock:
       result = get_information_block(session, "struct_1")
     assert result is expected
     mock_build.assert_called_once_with(
-      session, "struct_1", None, scenario_id=None, series=False
+      session,
+      "struct_1",
+      None,
+      scenario_id=None,
+      series=False,
+      series_history=None,
+      series_forecast=None,
     )
 
   def test_series_threads_through_dispatch(self) -> None:
@@ -92,10 +98,21 @@ class TestGetInformationBlock:
     patched = _schedule_entry_with_build(mock_build)
     with patch.dict(REGISTRY_PATH, {"schedule": patched}):
       get_information_block(
-        session, "struct_1", scenario_id="struct_budget", series=True
+        session,
+        "struct_1",
+        scenario_id="struct_budget",
+        series=True,
+        series_history=12,
+        series_forecast=6,
       )
     mock_build.assert_called_once_with(
-      session, "struct_1", None, scenario_id="struct_budget", series=True
+      session,
+      "struct_1",
+      None,
+      scenario_id="struct_budget",
+      series=True,
+      series_history=12,
+      series_forecast=6,
     )
 
 
@@ -323,5 +340,11 @@ class TestGetInformationBlockForFactSet:
 
     assert result is expected
     mock_build.assert_called_once_with(
-      session, "struct_1", "fs_01", scenario_id=None, series=False
+      session,
+      "struct_1",
+      "fs_01",
+      scenario_id=None,
+      series=False,
+      series_history=None,
+      series_forecast=None,
     )

--- a/tests/operations/information_block/test_statement_handlers.py
+++ b/tests/operations/information_block/test_statement_handlers.py
@@ -710,6 +710,8 @@ class TestSeriesMode:
     series_sets: list[MagicMock],
     facts: list[MagicMock],
     scenario_id: str | None,
+    series_history: int | None = None,
+    series_forecast: int | None = None,
   ):
     session = MagicMock()
     structure = _make_statement_structure(
@@ -735,7 +737,14 @@ class TestSeriesMode:
       _exec_result(all_rows=[]),  # documentation labels
     ]
     build = statement_handlers.make_statement_handlers("balance_sheet")
-    return build(session, "struct_balance_sheet", scenario_id=scenario_id, series=True)
+    return build(
+      session,
+      "struct_balance_sheet",
+      scenario_id=scenario_id,
+      series=True,
+      series_history=series_history,
+      series_forecast=series_forecast,
+    )
 
   def test_one_column_per_set_with_seam_flags(self) -> None:
     may, june = date(2026, 5, 31), date(2026, 6, 30)
@@ -782,6 +791,34 @@ class TestSeriesMode:
     assert rendering is not None
     cash_row = next(r for r in rendering.rows if r.element_qname == "rs-gaap:Cash")
     assert cash_row.values == [100_000.0, 110_000.0]  # not 999_999
+
+  def test_series_window_trims_to_seam_adjacent_columns(self) -> None:
+    """series_history/series_forecast keep the last N actual + first N
+    forecast columns — the §11 #11 server-side window. Facts for the
+    trimmed sets never render."""
+    ends = [date(2026, m, 28) for m in (3, 4, 5, 6, 7)]
+    sets = [
+      self._fact_set("fs_mar", date(2026, 3, 1), ends[0]),
+      self._fact_set("fs_apr", date(2026, 4, 1), ends[1]),
+      self._fact_set("fs_may", date(2026, 5, 1), ends[2]),
+      self._fact_set("fs_jun", date(2026, 6, 1), ends[3], scenario_id="struct_budget"),
+      self._fact_set("fs_jul", date(2026, 7, 1), ends[4], scenario_id="struct_budget"),
+    ]
+    facts = [
+      self._fact(f"f_{fs.id}", fs.id, fs.period_end, 1_000.0 * (i + 1))
+      for i, fs in enumerate(sets)
+    ]
+    envelope = self._run_series(
+      sets, facts, "struct_budget", series_history=1, series_forecast=1
+    )
+
+    assert envelope is not None
+    rendering = envelope.view.rendering
+    assert rendering is not None
+    assert [p.end for p in rendering.periods] == [ends[2], ends[3]]
+    assert rendering.periods[1].forecast is True
+    cash_row = next(r for r in rendering.rows if r.element_qname == "rs-gaap:Cash")
+    assert cash_row.values == [3_000.0, 4_000.0]
 
   def test_fact_set_pin_bypasses_series(self) -> None:
     """A snapshot pin is a single set by definition — series is ignored."""


### PR DESCRIPTION
## Summary

Statement series reads (`series: true` — the Plan page's data spine) rendered every column the tenant has ever stamped: ~350–460KB per envelope at the current 35 columns, growing linearly with ledger age. This was the gate blocking deep-history backfills (spec §11 #11). The series can now be windowed server-side to its seam-adjacent columns — `series_history` keeps the last N actual columns, `series_forecast` the first N forecast columns — and the trim happens **before** facts load, so the whole envelope build (facts query, per-set windowing, rendering) scales with the requested window rather than the ledger's age. Both parameters omitted = unbounded, so every existing caller is untouched.

## Changes

**`operations/information_block/envelope.py`**
- New `window_series_sets(series_sets, history, forecast)`: trims the collapsed series (ascending `period_end`, actual-beats-forecast at the seam) to the last N actual + first N forecast columns. `None` = unbounded per side; `0` = drop that side (forecast-only view is legal); negative raises `ValueError`. Counts are columns, not calendar months (documented — an annual-only tenant's `history=12` keeps twelve annual columns).

**`operations/information_block/statement.py`**
- `_build_statement_envelope` accepts `series_history` / `series_forecast` and applies the window right after `load_statement_fact_set_series`, before the facts query. `forecast_period_ends` (the seam flags) derive from the windowed set list.

**`operations/information_block/reads.py` + five sibling builders**
- `get_information_block` threads the two parameters to the registry dispatch. `schedule` / `metric` / `forecast` / `rollforward` / `disclosure` builders accept them for dispatch-signature parity and ignore them (the established `series` pattern).

**Surfaces**
- GraphQL: `informationBlock(id, scenarioId, series, seriesHistory, seriesForecast)`.
- MCP: `get-information-block` gains `series_history` / `series_forecast` (schema `minimum: 0`), with agent-facing guidance to prefer a window on deep-history tenants.

## Testing

- New unit tests: `TestWindowSeriesSets` (identity, last-N/first-N, combined window order, zero-history forecast-only, oversized windows, negative raises) and a statement-handler test proving the window trims rendered columns through the real builder.
- `just test-code` (ruff + format + basedpyright + cf-lint): all checks passed.
- Affected trees (`tests/operations/information_block/`, `tests/graphql/`, `tests/middleware/mcp/`): 1,143 passed.

## Notes / Follow-ups

- App side: roboledger-app's Plan page (#232 dual window control) still slices client-side; a follow-up wires its History × Forecast selections into `seriesHistory` / `seriesForecast` so the payload shrinks to the visible window. Client slicing can stay as a belt.
- This unblocks the deep-history backfill (2019–2024) for the Harbinger tenant — the payload no longer grows with backfilled depth once the app passes a window.
