### PR TITLE
feat(forecast): per-line growth trajectories

### DIFF
--- a/robosystems/models/api/extensions/forecasts.py
+++ b/robosystems/models/api/extensions/forecasts.py
@@ -128,6 +128,66 @@ class LineAssertionRequest(BaseModel):
     return self
 
 
+class LineGrowthRequest(BaseModel):
+  """One statement line's asserted growth trajectory for the scenario.
+
+  The generic per-line sibling of ``rs-driver:RevenueGrowthRate``: where
+  the catalog lever grows *revenue* through its seeded rule, a line
+  growth entry grows **any income-statement leaf** at a month-over-month
+  rate — ``value`` -0.05 cuts the line 5% per month, compounding from
+  the base month's value. This is what expense trajectories ("opex +2%/mo
+  with inflation", "cut costs 5%/mo starting October") use; without it
+  every unmodeled line just carries flat.
+
+  Semantics per month: ``line[t] = line[t-1] * (1 + rate[t])``. Months
+  the entry doesn't name keep the engine's carry-forward (grow-then-hold
+  ramps fall out of ``values_by_period`` naturally). **Duration leaves
+  only**: balance-sheet lines roll from the IS and the working-capital
+  levers — grow the driving IS line instead. A line already driven by an
+  active catalog rule (e.g. Revenues with ``RevenueGrowthRate`` set) or
+  named by a ``line_assertions`` entry is rejected — one owner per line.
+  """
+
+  qname: str = Field(
+    ...,
+    description=(
+      "QName of the income-statement leaf to grow (e.g. "
+      "``rs-gaap:ResearchAndDevelopmentExpense``). Must be a calc-DAG "
+      "duration leaf."
+    ),
+  )
+  value: float | None = Field(
+    None,
+    gt=-1,
+    description=(
+      "Uniform month-over-month growth rate for every month of the "
+      "horizon (decimal: 0.02 = +2%/mo, -0.05 = -5%/mo)."
+    ),
+  )
+  values_by_period: dict[str, float] | None = Field(
+    None,
+    description=(
+      "Per-month rate overrides keyed by ``YYYY-MM``. Wins over "
+      "``value`` for the months it names; months named by neither "
+      "carry the line's prior value (rate 0)."
+    ),
+  )
+
+  @model_validator(mode="after")
+  def _require_some_value(self) -> LineGrowthRequest:
+    if self.value is None and not self.values_by_period:
+      raise ValueError(
+        f"Line growth {self.qname!r} needs a uniform `value` and/or "
+        "`values_by_period` overrides."
+      )
+    if self.values_by_period and any(v <= -1 for v in self.values_by_period.values()):
+      raise ValueError(
+        f"Line growth {self.qname!r}: rates must be greater than -1 "
+        "(-1 would zero the line — use a line assertion for that)."
+      )
+    return self
+
+
 class CreateForecastRequest(BaseModel):
   """Create a forecast block — the authored scenario container.
 
@@ -200,6 +260,15 @@ class CreateForecastRequest(BaseModel):
       "for the months it asserts."
     ),
   )
+  line_growth: list[LineGrowthRequest] = Field(
+    default_factory=list,
+    description=(
+      "Per-line growth trajectories. Each names an income-statement "
+      "leaf and grows it month-over-month at the asserted rate — the "
+      "generic form of the revenue growth lever, for lines the catalog "
+      "doesn't drive (opex trajectories, cost-cut ramps)."
+    ),
+  )
   entity_id: str | None = Field(
     None,
     description=(
@@ -236,6 +305,13 @@ class UpdateForecastRequest(BaseModel):
     description=(
       "Full replacement of the line-assertion set when provided. Pass "
       "an empty list to clear every assertion."
+    ),
+  )
+  line_growth: list[LineGrowthRequest] | None = Field(
+    None,
+    description=(
+      "Full replacement of the line-growth set when provided. Pass an "
+      "empty list to clear every growth entry."
     ),
   )
 

--- a/robosystems/models/api/information_block.py
+++ b/robosystems/models/api/information_block.py
@@ -656,6 +656,36 @@ class LineAssertionLite(BaseModel):
   )
 
 
+class LineGrowthLite(BaseModel):
+  """One statement line's persisted growth trajectory inside
+  ``ForecastMechanics``.
+
+  The generic per-line form of the revenue growth lever: grows an
+  income-statement leaf month-over-month at the asserted rate
+  (``line[t] = line[t-1] * (1 + rate[t])``), compounding from the base
+  month's value. Months without a rate keep the engine's carry-forward.
+  Duration leaves only; disjoint from ``line_assertions`` and from any
+  active catalog rule's target (one owner per line).
+
+  Persistence deviates from levers/assertions deliberately: rates are
+  NOT duplicated as facts in the scenario FactSet — a growth rate on a
+  monetary statement element would be a unit-lying fact. This mechanics
+  copy is the single authored store; ``compute-forecast`` binds rates
+  from here.
+  """
+
+  qname: str = Field(..., description="Grown statement-leaf qname.")
+  element_id: str = Field(..., description="Resolved tenant element id.")
+  item_type: str = Field(
+    "percent",
+    description="Always 'percent' — the grid row renders rates, not values.",
+  )
+  values_by_period: dict[str, float] = Field(
+    ...,
+    description="Expanded per-month growth rates keyed by ``YYYY-MM``.",
+  )
+
+
 class ForecastMechanics(BaseModel):
   """Authored scenario container for ``block_type='forecast'`` (FP&A F-1).
 
@@ -700,6 +730,14 @@ class ForecastMechanics(BaseModel):
       "Direct statement-line assertions (authoring order) — manual "
       "overrides that win over driver rules and carry-forward for the "
       "months they name."
+    ),
+  )
+  line_growth: list[LineGrowthLite] = Field(
+    default_factory=list,
+    description=(
+      "Per-line growth trajectories (authoring order) — each grows an "
+      "income-statement leaf month-over-month at the asserted rate, "
+      "compounding from the base month."
     ),
   )
   computed_months: int = Field(

--- a/robosystems/operations/information_block/forecast.py
+++ b/robosystems/operations/information_block/forecast.py
@@ -2,12 +2,14 @@
 
 The forecast block is the FP&A engine's authored surface (F-1): scenario
 identity (name + ``scenario_kind``), horizon, base period, lever
-assertions on ``rs-driver:*`` catalog elements, and direct **line
+assertions on ``rs-driver:*`` catalog elements, direct **line
 assertions** on statement leaves (manual overrides that win over driver
-rules and carry-forward for the months they name). The block IS the
-scenario — its structure id is the ``scenario_id`` every derived forward
-FactSet carries (NULL = actuals), and deleting the block removes the
-whole scenario slice.
+rules and carry-forward for the months they name), and **line growth**
+entries (per-line month-over-month trajectories — the generic form of
+the revenue growth lever, for lines the catalog doesn't drive). The
+block IS the scenario — its structure id is the ``scenario_id`` every
+derived forward FactSet carries (NULL = actuals), and deleting the block
+removes the whole scenario slice.
 
 Persistence follows the rules-for-mechanics / **facts-for-values**
 doctrine: lever *mechanics* are the library-seeded rs-driver Derive
@@ -41,6 +43,7 @@ from robosystems.models.api.information_block import (
   InformationModelResponse,
   LeverAssertionLite,
   LineAssertionLite,
+  LineGrowthLite,
   RenderingLite,
   RenderingPeriodLite,
   RenderingRowLite,
@@ -82,6 +85,7 @@ if TYPE_CHECKING:
     DeleteForecastRequest,
     LeverAssertionRequest,
     LineAssertionRequest,
+    LineGrowthRequest,
     UpdateForecastRequest,
   )
 
@@ -285,6 +289,151 @@ def _expand_line_assertions(
   return expanded
 
 
+def _expand_line_growth(
+  session: Session,
+  entries: list[LineGrowthRequest],
+  base_period: str,
+  horizon_months: int,
+) -> list[LineGrowthLite]:
+  """Resolve + expand wire-level line-growth entries to per-month rate maps.
+
+  Same grammar and expansion as levers/assertions; the validation is the
+  line-assertion set plus **duration leaves only** — a balance-sheet
+  line rolls from the IS and the working-capital levers, so growing it
+  directly would fight the roll. Cross-list conflicts (a grown line
+  that's also asserted, or already driven by an active catalog rule)
+  are checked by :func:`_check_line_growth_conflicts` against the FINAL
+  lists, because an update can change one list without the other.
+  """
+  if not entries:
+    return []
+
+  months = [add_months(base_period, i) for i in range(1, horizon_months + 1)]
+  month_set = set(months)
+  calc_parent_ids = set(load_rs_gaap_calculations(session).keys())
+
+  expanded: list[LineGrowthLite] = []
+  seen: set[str] = set()
+  for entry in entries:
+    if entry.qname in seen:
+      raise ValueError(
+        f"Duplicate line-growth qname {entry.qname!r} in the growth set."
+      )
+    seen.add(entry.qname)
+
+    element = session.execute(
+      select(Element).where(Element.qname == entry.qname).limit(1)
+    ).scalar_one_or_none()
+    if element is None:
+      raise ValueError(
+        f"Line-growth qname {entry.qname!r} did not resolve to an Element "
+        "— growth entries name rs-gaap (or tenant extension) statement "
+        "concepts."
+      )
+    blocked = _ASSERTION_BLOCKED_SOURCES.get(element.source or "")
+    if blocked is not None:
+      raise ValueError(f"Line-growth qname {entry.qname!r}: {blocked}.")
+    if element.is_abstract:
+      raise ValueError(
+        f"Line-growth qname {entry.qname!r} is abstract — grow a concrete "
+        "statement leaf."
+      )
+    if element.id in calc_parent_ids:
+      raise ValueError(
+        f"Line-growth qname {entry.qname!r} is a calc-DAG subtotal — "
+        "growth is leaves-only so the grown line still articulates "
+        "(subtotals derive from their children)."
+      )
+    if element.period_type == "instant":
+      raise ValueError(
+        f"Line-growth qname {entry.qname!r} is a balance-sheet (instant) "
+        "line — the BS rolls from the IS and the working-capital levers; "
+        "grow the driving income-statement line instead."
+      )
+
+    overrides = entry.values_by_period or {}
+    outside = sorted(set(overrides) - month_set)
+    if outside:
+      raise ValueError(
+        f"Line growth {entry.qname!r} has values_by_period entries "
+        f"outside the horizon ({base_period} + {horizon_months} months): "
+        f"{outside}"
+      )
+
+    values: dict[str, float] = {}
+    for month in months:
+      if month in overrides:
+        values[month] = float(overrides[month])
+      elif entry.value is not None:
+        values[month] = float(entry.value)
+    if not values:
+      raise ValueError(
+        f"Line growth {entry.qname!r} asserts no months within the horizon."
+      )
+
+    expanded.append(
+      LineGrowthLite(
+        qname=entry.qname,
+        element_id=element.id,
+        values_by_period=values,
+      )
+    )
+  return expanded
+
+
+def _check_line_growth_conflicts(
+  session: Session,
+  levers: list[LeverAssertionLite],
+  line_assertions: list[LineAssertionLite],
+  line_growth: list[LineGrowthLite],
+) -> None:
+  """One owner per line — validated against the FINAL authored lists.
+
+  A grown line that's also line-asserted, or already driven by a catalog
+  rule whose levers this scenario sets, would have two writers with
+  order-dependent outcomes. Runs on both create and update (an update
+  can replace ``levers`` alone and silently activate a rule over a
+  stored growth entry).
+  """
+  if not line_growth:
+    return
+  growth_qnames = {g.qname for g in line_growth}
+  overlap = growth_qnames & {a.qname for a in line_assertions}
+  if overlap:
+    raise ValueError(
+      f"Line(s) named by both line_growth and line_assertions: "
+      f"{sorted(overlap)} — an assertion pins the value, growth derives "
+      "it; pick one per line."
+    )
+
+  from robosystems.operations.information_block.forecast_history import (
+    DRIVER_PREFIX,
+    driver_rules,
+  )
+
+  lever_qnames = {lv.qname for lv in levers}
+  for rule in driver_rules(session):
+    variables = rule.rule_variables or []
+    rule_levers = {
+      v["variable_qname"]
+      for v in variables
+      if isinstance(v, dict)
+      and isinstance(v.get("variable_qname"), str)
+      and v["variable_qname"].startswith(DRIVER_PREFIX)
+    }
+    if not rule_levers or not rule_levers <= lever_qnames:
+      continue  # rule inactive in this scenario
+    target = (
+      session.get(Element, rule.target_element_id) if rule.target_element_id else None
+    )
+    if target is not None and target.qname in growth_qnames:
+      raise ValueError(
+        f"Line growth {target.qname!r} is already driven by "
+        f"{', '.join(sorted(rule_levers))} in this scenario — set that "
+        "lever instead of a growth entry."
+      )
+
+
 def _load_lever_fact_set(session: Session, structure_id: str) -> FactSet | None:
   """The scenario's lever FactSet — ``'custom'`` + self-referential scenario."""
   return session.execute(
@@ -306,10 +455,17 @@ def _write_lever_fact_set(
   entity_id: str,
   created_by: str,
 ) -> FactSet:
-  """Persist the lever + line assertions as authored facts in one scenario set."""
+  """Persist the lever + line assertions as authored facts in one scenario set.
+
+  Line-growth rates are deliberately NOT written as facts (a rate on a
+  monetary statement element would be a unit-lying fact — the mechanics
+  copy is their single authored store), but their months still widen
+  the set's period envelope so it spans everything the scenario asserts.
+  """
   asserted_months = sorted(
     {m for lv in mechanics.levers for m in lv.values_by_period}
     | {m for la in mechanics.line_assertions for m in la.values_by_period}
+    | {m for lg in mechanics.line_growth for m in lg.values_by_period}
   )
   span_start = period_date_range(asserted_months[0])[0]
   span_end = period_date_range(asserted_months[-1])[1]
@@ -386,6 +542,10 @@ def create(
   line_assertions = _expand_line_assertions(
     session, payload.line_assertions, base_period, payload.horizon_months
   )
+  line_growth = _expand_line_growth(
+    session, payload.line_growth, base_period, payload.horizon_months
+  )
+  _check_line_growth_conflicts(session, levers, line_assertions, line_growth)
 
   mechanics = ForecastMechanics(
     scenario_kind=payload.scenario_kind,
@@ -393,6 +553,7 @@ def create(
     base_period=base_period,
     levers=levers,
     line_assertions=line_assertions,
+    line_growth=line_growth,
   )
 
   # The lever elements all live in the tenant's rs-driver taxonomy —
@@ -467,6 +628,12 @@ def update(
       "`line_assertions` (or an empty list to clear them) — the horizon "
       "window shifted, so every asserted month must be restated."
     )
+  if window_changed and payload.line_growth is None and current.line_growth:
+    raise ValueError(
+      "Changing horizon_months or base_period requires re-supplying "
+      "`line_growth` (or an empty list to clear it) — the horizon window "
+      "shifted, so every growth month must be restated."
+    )
 
   levers = current.levers
   if payload.levers is not None:
@@ -476,6 +643,14 @@ def update(
     line_assertions = _expand_line_assertions(
       session, payload.line_assertions, base_period, horizon_months
     )
+  line_growth = current.line_growth
+  if payload.line_growth is not None:
+    line_growth = _expand_line_growth(
+      session, payload.line_growth, base_period, horizon_months
+    )
+  # Against the FINAL lists — replacing `levers` alone can activate a
+  # catalog rule over a STORED growth entry.
+  _check_line_growth_conflicts(session, levers, line_assertions, line_growth)
 
   next_mechanics = ForecastMechanics(
     scenario_kind=scenario_kind,
@@ -483,6 +658,7 @@ def update(
     base_period=base_period,
     levers=levers,
     line_assertions=line_assertions,
+    line_growth=line_growth,
   )
   structure.artifact_mechanics = next_mechanics.model_dump(mode="json")
   structure.updated_by = updated_by
@@ -612,9 +788,11 @@ def build_envelope(
   # Authored elements (levers + line assertions) are not reachable via
   # associations (the container is arc-less) — load them off the
   # mechanics for the envelope's element list and the row metadata.
-  authored_element_ids = [lv.element_id for lv in mechanics.levers] + [
-    la.element_id for la in mechanics.line_assertions
-  ]
+  authored_element_ids = (
+    [lv.element_id for lv in mechanics.levers]
+    + [la.element_id for la in mechanics.line_assertions]
+    + [lg.element_id for lg in mechanics.line_growth]
+  )
   authored_elements = list(
     session.execute(select(Element).where(Element.id.in_(authored_element_ids)))
     .scalars()
@@ -645,6 +823,19 @@ def build_envelope(
     if month in forecast_months:
       return assertion.values_by_period.get(month)
     return history.line_values.get(assertion.element_id, {}).get(month)
+
+  def growth_value(entry: LineGrowthLite, month: str) -> float | None:
+    """Asserted rate ahead of the seam; the rate the line actually ran
+    at behind it (``v[t]/v[t-1] - 1`` — the trivial inversion), blanked
+    when either month's actual is missing or the prior is zero."""
+    if month in forecast_months:
+      return entry.values_by_period.get(month)
+    values = history.line_values.get(entry.element_id, {})
+    current_v = values.get(month)
+    prior_v = values.get(add_months(month, -1))
+    if current_v is None or prior_v is None or prior_v == 0:
+      return None
+    return current_v / prior_v - 1.0
 
   rows = [
     RenderingRowLite(
@@ -681,6 +872,23 @@ def build_envelope(
       values=[line_value(assertion, month) for month in months],
     )
     for assertion in mechanics.line_assertions
+  )
+  # Line-growth entries render as rate rows — asserted rates ahead of
+  # the seam, realized month-over-month rates behind it.
+  rows.extend(
+    RenderingRowLite(
+      element_id=entry.element_id,
+      element_qname=entry.qname,
+      element_name=(
+        elements_by_id[entry.element_id].name
+        if entry.element_id in elements_by_id
+        else entry.qname
+      ),
+      balance_type=None,
+      item_type=entry.item_type,
+      values=[growth_value(entry, month) for month in months],
+    )
+    for entry in mechanics.line_growth
   )
   rendering = RenderingLite(
     rows=rows,

--- a/robosystems/operations/information_block/forecast_compute.py
+++ b/robosystems/operations/information_block/forecast_compute.py
@@ -221,6 +221,15 @@ def cmd_compute_forecast(
   assertion_period_type: dict[str, str] = {
     la.element_id: la.period_type for la in mechanics.line_assertions
   }
+  # Line-growth rates bind from the mechanics directly — rates aren't
+  # facts (a rate on a monetary statement element would lie about its
+  # unit), so the mechanics copy is their single authored store.
+  growth_rates: dict[str, dict[str, float]] = {
+    lg.element_id: lg.values_by_period for lg in mechanics.line_growth
+  }
+  growth_qname_by_id: dict[str, str] = {
+    lg.element_id: lg.qname for lg in mechanics.line_growth
+  }
   lever_values: dict[str, dict[str, float]] = {}
   assertion_values: dict[str, dict[str, float]] = {}
   for fact in numeric_facts(session, lever_set.id):
@@ -399,6 +408,17 @@ def cmd_compute_forecast(
       and element_id not in active_target_ids
     ):
       carry_pool.append(element_id)
+  # Grown lines join the carry pool too: a month without a rate holds
+  # the line's last grown value instead of vanishing (grow-then-hold
+  # ramps come out of a sparse values_by_period naturally).
+  for element_id in sorted(growth_rates):
+    if (
+      element_id not in base_id_set
+      and element_id not in calc_targets
+      and element_id not in active_target_ids
+      and element_id not in carry_pool
+    ):
+      carry_pool.append(element_id)
 
   # ── Articulation context (F-2) — BS roll + schedules + derived CF ─────
   # The mapping id rides the base report set's PivotProvenance; without
@@ -443,6 +463,13 @@ def cmd_compute_forecast(
       "rule-driven working-capital instants only (no BS roll / CF)"
     )
 
+  for element_id in sorted(growth_rates):
+    if element_id not in prior_values:
+      diagnostics.append(
+        f"line growth on {growth_qname_by_id.get(element_id, element_id)}: "
+        "no base-month value — grows from 0"
+      )
+
   elements_by_id: dict[str, Element] = {}
 
   def _element(element_id: str) -> Element | None:
@@ -478,6 +505,29 @@ def cmd_compute_forecast(
         delta = schedule_is_delta(ctx, element_id, month, mechanics.base_period)
         if delta:
           current[element_id] += delta
+
+    # (a2b) Line growth — the generic per-line trajectory:
+    # line[t] = line[t-1] * (1 + rate[t]), compounding through the
+    # prior-values roll. Overrides the carry and schedule projection
+    # for the months it names; rate-less months keep the carry (a).
+    # Authoring rejects overlap with assertions and active catalog
+    # rules, but a stale overlap (catalog rule activated after the
+    # growth entry was stored) yields to the rule, legibly.
+    for element_id, rate_by_month in growth_rates.items():
+      rate = rate_by_month.get(month)
+      if rate is None:
+        continue
+      if element_id in active_target_ids:
+        skipped.append(
+          SkippedForecastLite(
+            rule_id=None,
+            element_qname=growth_qname_by_id.get(element_id),
+            period=month,
+            reason="line growth displaced by catalog driver rule",
+          )
+        )
+        continue
+      current[element_id] = prior_values.get(element_id, 0.0) * (1.0 + rate)
 
     # (a3) Line assertions — the manual overrides win over carry and
     # schedule projection for the months they name; a displaced driver

--- a/robosystems/operations/information_block/forecast_history.py
+++ b/robosystems/operations/information_block/forecast_history.py
@@ -184,7 +184,12 @@ def back_solve_lever_history(
   horizon alone in that case, exactly as before.
   """
   lever_qnames = {lever.qname for lever in mechanics.levers}
-  line_element_ids = {assertion.element_id for assertion in mechanics.line_assertions}
+  # Line assertions AND line-growth targets: both grid families render
+  # the line's own actuals behind the seam (growth rows derive the
+  # realized rate from consecutive actuals at render time).
+  line_element_ids = {
+    assertion.element_id for assertion in mechanics.line_assertions
+  } | {entry.element_id for entry in mechanics.line_growth}
   if not lever_qnames and not line_element_ids:
     return LeverHistory()
 

--- a/tests/operations/information_block/test_forecast_compute.py
+++ b/tests/operations/information_block/test_forecast_compute.py
@@ -23,6 +23,7 @@ from robosystems.models.api.information_block import (
   ForecastMechanics,
   LeverAssertionLite,
   LineAssertionLite,
+  LineGrowthLite,
 )
 from robosystems.operations.information_block import (
   forecast_compute as fc,
@@ -131,6 +132,7 @@ def _mechanics(
   levers: list[LeverAssertionLite],
   horizon: int = 3,
   assertions: list[LineAssertionLite] | None = None,
+  growth: list[LineGrowthLite] | None = None,
 ) -> dict:
   return ForecastMechanics(
     scenario_kind="budget",
@@ -138,7 +140,16 @@ def _mechanics(
     base_period="2026-06",
     levers=levers,
     line_assertions=assertions or [],
+    line_growth=growth or [],
   ).model_dump(mode="json")
+
+
+def _growth(
+  qname: str, element_id: str, values_by_period: dict[str, float]
+) -> LineGrowthLite:
+  return LineGrowthLite(
+    qname=qname, element_id=element_id, values_by_period=values_by_period
+  )
 
 
 def _lever(qname: str, element_id: str, value: float, months: list[str]) -> Any:
@@ -627,6 +638,69 @@ class TestAssertionRollupIntoEmptySubtree:
       s.reason == "displaced by line assertion (contributing children pinned)"
       for s in response.skipped
     )
+
+
+class TestLineGrowth:
+  """The generic per-line trajectory: line[t] = line[t-1] * (1 + rate[t]),
+  binding rates from the mechanics (never facts), compounding through
+  the prior-values roll, yielding to catalog rules and to the carry on
+  rate-less months."""
+
+  def test_growth_compounds_from_the_base_value(self) -> None:
+    growth = [_growth("rs-gaap:RentExpense", "el_rent", dict.fromkeys(ALL_MONTHS, 0.1))]
+    _, rec = _run(_mechanics([], growth=growth), [], [])
+    assert rec.value("struct_is", JUL, "el_rent") == pytest.approx(11.0)
+    assert rec.value("struct_is", AUG, "el_rent") == pytest.approx(12.1)
+    assert rec.value("struct_is", SEP, "el_rent") == pytest.approx(13.31)
+
+  def test_rateless_months_keep_the_carry(self) -> None:
+    """Grow-then-hold: a sparse values_by_period grows July only; the
+    later months carry the grown value instead of reverting or vanishing."""
+    growth = [_growth("rs-gaap:RentExpense", "el_rent", {"2026-07": 0.1})]
+    _, rec = _run(_mechanics([], growth=growth), [], [])
+    assert rec.value("struct_is", JUL, "el_rent") == pytest.approx(11.0)
+    assert rec.value("struct_is", AUG, "el_rent") == pytest.approx(11.0)
+    assert rec.value("struct_is", SEP, "el_rent") == pytest.approx(11.0)
+
+  def test_catalog_rule_wins_over_stale_growth_overlap(self) -> None:
+    """Authoring rejects the overlap, but a stored growth entry can be
+    overtaken when levers change — the rule owns the line and the growth
+    skip is legible."""
+    growth = [_growth("rs-gaap:Revenues", "el_rev", dict.fromkeys(ALL_MONTHS, 0.5))]
+    response, rec = _run(
+      _mechanics(FULL_LEVERS, growth=growth), FULL_RULES, FULL_LEVERS
+    )
+    # The rule's 3% — not the growth entry's 50%.
+    assert rec.value("struct_is", JUL, "el_rev") == pytest.approx(103.0)
+    displaced = [
+      s
+      for s in response.skipped
+      if s.reason == "line growth displaced by catalog driver rule"
+    ]
+    assert [s.period for s in displaced] == ALL_MONTHS
+    assert all(s.element_qname == "rs-gaap:Revenues" for s in displaced)
+
+  def test_out_of_base_growth_grows_from_zero_with_diagnostic(self) -> None:
+    growth = [
+      _growth("rs-gaap:MarketingExpense", "el_mkt", dict.fromkeys(ALL_MONTHS, 0.2))
+    ]
+    response, rec = _run(_mechanics([], growth=growth), [], [])
+    assert any(
+      "line growth on rs-gaap:MarketingExpense" in d and "grows from 0" in d
+      for d in response.diagnostics
+    )
+    assert rec.value("struct_is", JUL, "el_mkt") == pytest.approx(0.0)
+
+  def test_growth_articulates_through_subtotals(self) -> None:
+    """A grown COGS re-derives GrossProfit — the grown leaf participates
+    in the calc DAG exactly like a carried or rule-driven one."""
+    growth = [
+      _growth("rs-gaap:CostOfRevenue", "el_cogs", dict.fromkeys(ALL_MONTHS, 0.1))
+    ]
+    _, rec = _run(_mechanics([], growth=growth), [], [])
+    assert rec.value("struct_is", JUL, "el_cogs") == pytest.approx(68.2)
+    # GP = carried revenue 100 - grown COGS 68.2.
+    assert rec.value("struct_is", JUL, "el_gp") == pytest.approx(31.8)
 
 
 class TestUpsertMonthSet:

--- a/tests/operations/information_block/test_forecast_handlers.py
+++ b/tests/operations/information_block/test_forecast_handlers.py
@@ -20,6 +20,7 @@ from robosystems.models.api.extensions.forecasts import (
   DeleteForecastRequest,
   LeverAssertionRequest,
   LineAssertionRequest,
+  LineGrowthRequest,
   UpdateForecastRequest,
 )
 from robosystems.models.api.information_block import (
@@ -293,6 +294,163 @@ class TestExpandLineAssertions:
           LineAssertionRequest(qname="rs-gaap:RentExpense", value=0.0),
           LineAssertionRequest(qname="rs-gaap:RentExpense", value=1.0),
         ],
+      )
+
+
+class TestExpandLineGrowth:
+  def _session(self, *elements: MagicMock) -> MagicMock:
+    session = MagicMock()
+    session.execute.return_value.scalar_one_or_none.side_effect = list(elements)
+    return session
+
+  def _expand(self, session: MagicMock, entries, calc_parents=None):
+    with patch.object(
+      forecast_handlers,
+      "load_rs_gaap_calculations",
+      return_value={key: [] for key in calc_parents or []},
+    ):
+      return forecast_handlers._expand_line_growth(session, entries, "2026-06", 3)
+
+  def test_expands_rates_with_percent_item_type(self) -> None:
+    session = self._session(RENT)
+    expanded = self._expand(
+      session, [LineGrowthRequest(qname="rs-gaap:RentExpense", value=0.02)]
+    )
+    assert len(expanded) == 1
+    entry = expanded[0]
+    assert entry.element_id == "el_rent"
+    assert entry.item_type == "percent"
+    assert entry.values_by_period == {
+      "2026-07": 0.02,
+      "2026-08": 0.02,
+      "2026-09": 0.02,
+    }
+
+  def test_sparse_overrides_leave_uncovered_months_to_the_carry(self) -> None:
+    session = self._session(RENT)
+    expanded = self._expand(
+      session,
+      [
+        LineGrowthRequest(
+          qname="rs-gaap:RentExpense", values_by_period={"2026-07": -0.05}
+        )
+      ],
+    )
+    assert expanded[0].values_by_period == {"2026-07": -0.05}
+
+  def test_rejects_instant_element(self) -> None:
+    session = self._session(LOAN)
+    with pytest.raises(ValueError, match="balance-sheet"):
+      self._expand(
+        session, [LineGrowthRequest(qname="rs-gaap:NotesPayable", value=0.1)]
+      )
+
+  def test_rejects_calc_parent_leaves_only(self) -> None:
+    revenues = _element("el_rev", "rs-gaap:Revenues", source="rs-gaap", item_type=None)
+    session = self._session(revenues)
+    with pytest.raises(ValueError, match="leaves-only"):
+      self._expand(
+        session,
+        [LineGrowthRequest(qname="rs-gaap:Revenues", value=0.03)],
+        calc_parents=["el_rev"],
+      )
+
+  def test_rejects_rs_driver_source(self) -> None:
+    session = self._session(GROWTH)
+    with pytest.raises(ValueError, match="levers"):
+      self._expand(
+        session,
+        [LineGrowthRequest(qname="rs-driver:RevenueGrowthRate", value=0.03)],
+      )
+
+  def test_empty_list_short_circuits(self) -> None:
+    session = MagicMock()
+    assert forecast_handlers._expand_line_growth(session, [], "2026-06", 3) == []
+    session.execute.assert_not_called()
+
+
+class TestLineGrowthConflicts:
+  """One owner per line — the FINAL-lists cross-check."""
+
+  def _lite_growth(self, qname: str = "rs-gaap:RentExpense"):
+    from robosystems.models.api.information_block import LineGrowthLite
+
+    return LineGrowthLite(
+      qname=qname, element_id="el_x", values_by_period={"2026-07": 0.02}
+    )
+
+  def _lite_assertion(self, qname: str):
+    return LineAssertionLite(
+      qname=qname,
+      element_id="el_x",
+      item_type=None,
+      period_type="duration",
+      values_by_period={"2026-07": 0.0},
+    )
+
+  def test_overlap_with_assertions_rejected(self) -> None:
+    with pytest.raises(ValueError, match="both line_growth and line_assertions"):
+      forecast_handlers._check_line_growth_conflicts(
+        MagicMock(),
+        [],
+        [self._lite_assertion("rs-gaap:RentExpense")],
+        [self._lite_growth("rs-gaap:RentExpense")],
+      )
+
+  def test_active_catalog_rule_target_rejected(self) -> None:
+    """Growth on Revenues while RevenueGrowthRate is set — the catalog
+    rule owns the line; the lever is the right knob."""
+    rule = SimpleNamespace(
+      rule_variables=[
+        {"variable_name": "Revenues", "variable_qname": "rs-gaap:Revenues"},
+        {
+          "variable_name": "RevenueGrowthRate",
+          "variable_qname": "rs-driver:RevenueGrowthRate",
+        },
+      ],
+      target_element_id="el_rev",
+    )
+    session = MagicMock()
+    session.get.return_value = _element(
+      "el_rev", "rs-gaap:Revenues", source="rs-gaap", item_type=None
+    )
+    lever = LeverAssertionLite(
+      qname="rs-driver:RevenueGrowthRate",
+      element_id="el_growth",
+      item_type="percent",
+      values_by_period={"2026-07": 0.03},
+    )
+    with (
+      patch(
+        "robosystems.operations.information_block.forecast_history.driver_rules",
+        return_value=[rule],
+      ),
+      pytest.raises(ValueError, match="already driven by"),
+    ):
+      forecast_handlers._check_line_growth_conflicts(
+        session, [lever], [], [self._lite_growth("rs-gaap:Revenues")]
+      )
+
+  def test_inactive_rule_is_no_conflict(self) -> None:
+    """Same rule, but the scenario never sets its lever — growth owns
+    the line freely."""
+    rule = SimpleNamespace(
+      rule_variables=[
+        {"variable_name": "Revenues", "variable_qname": "rs-gaap:Revenues"},
+        {
+          "variable_name": "RevenueGrowthRate",
+          "variable_qname": "rs-driver:RevenueGrowthRate",
+        },
+      ],
+      target_element_id="el_rev",
+    )
+    session = MagicMock()
+    with patch(
+      "robosystems.operations.information_block.forecast_history.driver_rules",
+      return_value=[rule],
+    ):
+      forecast_handlers._check_line_growth_conflicts(
+        session, [], [], [self._lite_growth("rs-gaap:Revenues")]
       )
 
 


### PR DESCRIPTION
## Summary

The rs-driver catalog grows exactly one line (Revenues); every other income-statement line either carries flat or needs per-month line assertions — 12 months × N leaves of manual entry for any expense-trajectory scenario ("opex +2%/mo with inflation", "cut costs 5%/mo starting October"). This PR generalizes the growth mechanic to take a target line: `line_growth` entries on the forecast payload grow any IS leaf at `line[t] = line[t-1] × (1 + rate[t])`, compounding from the base month, with the established lever grammar (uniform `value` + `values_by_period` overrides). One grammar extension subsumes the would-be catalog of named expense levers.

## Changes

**Payload** (`models/api/extensions/forecasts.py`, `models/api/information_block.py`)
- `LineGrowthRequest` on create/update-forecast (full-replace semantics, empty list clears — same contract as `line_assertions`); rates must be > −1.
- `LineGrowthLite` + `ForecastMechanics.line_growth`. Rates are deliberately NOT duplicated as facts in the scenario FactSet — a growth rate on a monetary statement element would lie about its unit; the mechanics copy is the single authored store, and the growth months still widen the set's period envelope.
- The auto-generated `create-information-block` / `update-information-block` write surfaces (REST + MCP) pick the field up from the models.

**Authoring** (`operations/information_block/forecast.py`)
- `_expand_line_growth`: same validation family as assertions (resolve, blocked sources, non-abstract, leaves-only) plus **duration-only** — a BS line rolls from the IS and the WC levers; grow the driving IS line instead.
- `_check_line_growth_conflicts`, run against the FINAL lists on both create and update: one owner per line. Overlap with `line_assertions` is rejected, and so is a growth entry on a line already driven by a catalog rule whose levers this scenario sets (the error names the lever to use). Checked at update even when only `levers` changed, since a lever change can activate a rule over a stored growth entry.
- Horizon/base changes require re-supplying `line_growth` (the existing assertion rule, extended).
- Assumptions grid: growth entries render as rate rows — asserted rates ahead of the seam, **realized** month-over-month rates behind it (`v[t]/v[t-1] − 1` from consecutive canonical actuals, blanked when the prior month is missing or zero). `forecast_history` collects actuals for growth targets alongside asserted lines.

**Compute** (`operations/information_block/forecast_compute.py`)
- New walk step (a2b) between schedule deltas and line assertions: grown lines overwrite the carry for months with a rate; rate-less months keep the carry, so grow-then-hold ramps fall out of a sparse rate map naturally. Compounding rides the existing prior-values roll; subtotals re-derive through the calc DAG so verification stays gated.
- Out-of-base growth targets join the carry pool and surface a `grows from 0` diagnostic.
- A stale rule/growth overlap (possible only via update) yields to the catalog rule with a legible `skipped` entry.

## Testing

- Compute: compounding from base, sparse-rate carry, catalog-rule displacement, out-of-base diagnostic, subtotal articulation (grown COGS re-derives GrossProfit).
- Authoring: expansion + percent item_type, duration-only and leaves-only rejections, assertion-overlap and active-rule-conflict rejections, inactive-rule non-conflict.
- `just test-code`: all checks passed. Full unit suite (`pytest -m "not slow"`): 11,321 passed (one pre-existing local-env pyarrow failure in `test_incremental_materialize.py` excluded — reproduces on clean `origin/main`).

## Notes

- No migration; `line_growth` defaults empty everywhere, so existing scenarios are untouched and recompute identically.
- First increment of F-3's custom drivers: relationships beyond growth-on-self (e.g. "payroll = 20% of revenue") remain future work on the same one-owner-per-line doctrine.
