### PR TITLE
feat(capacity): graph /metrics + /usage rename, instance resources, real storage measurement

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -54,6 +54,13 @@
       "problemMatcher": []
     },
     {
+      "label": "RoboSystems Upgrade",
+      "type": "shell",
+      "command": "just",
+      "args": ["upgrade", "${input:profileDocker}"],
+      "problemMatcher": []
+    },
+    {
       "label": "RoboSystems Clone Apps",
       "type": "shell",
       "command": "just",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     # RoboSystems client for demo and testing
-    "robosystems-client==0.5.3",
+    "robosystems-client==0.5.8",
 
     # Testing framework
     "pytest>=9.0.0,<10.0",

--- a/robosystems/config/graph_tier.py
+++ b/robosystems/config/graph_tier.py
@@ -174,6 +174,25 @@ class GraphTierConfig:
     return instance_config.get("memory_per_db_mb", 2048)
 
   @classmethod
+  def get_databases_per_instance(cls, tier: str, environment: str | None = None) -> int:
+    """Get how many graph databases share one instance for a tier.
+
+    1 means the tier is dedicated (single-tenant per box); >1 means packed.
+    This is the packing property of the *product tier*, distinct from the
+    dev-only ``LBUG_DATABASES_PER_INSTANCE`` allocation override.
+
+    Args:
+        tier: The tier name (ladybug-standard, ladybug-large, ladybug-xlarge, ladybug-shared)
+        environment: Environment (defaults to current env)
+
+    Returns:
+        Databases co-located on one instance (defaults to 1 = dedicated)
+    """
+    tier_config = cls.get_tier_config(tier, environment)
+    instance_config = tier_config.get("instance", {})
+    return instance_config.get("databases_per_instance", 1)
+
+  @classmethod
   def get_max_memory_mb(cls, tier: str, environment: str | None = None) -> int:
     """Get total memory allocation for a tier.
 

--- a/robosystems/config/rate_limits.py
+++ b/robosystems/config/rate_limits.py
@@ -362,10 +362,12 @@ class RateLimitConfig:
           return EndpointCategory.TABLE_QUERY
         return EndpointCategory.GRAPH_QUERY
 
-      # Usage analytics — aggregation-heavy reads get a dedicated bucket
-      # (the endpoint segment is "analytics"; this previously checked
-      # `endpoint_type == "graph"` and never matched).
-      elif endpoint_type == "analytics":
+      # Content metrics + consumption usage — aggregation-heavy reads get a
+      # dedicated bucket. Match the endpoint segment, which is what actually
+      # appears in the path: this checked `endpoint_type == "graph"` once and
+      # never matched, then "analytics" until those routes were renamed to
+      # /metrics and /usage. Keep this in step with routers/graphs/usage.py.
+      elif endpoint_type in ("metrics", "usage"):
         return EndpointCategory.GRAPH_ANALYTICS
 
       # Graph lifecycle operations — POST /operations/{op_name}. Dedicated

--- a/robosystems/graph_api/client/client.py
+++ b/robosystems/graph_api/client/client.py
@@ -1292,6 +1292,23 @@ class GraphClient(BaseGraphClient):
     response = await self._request("GET", f"/databases/{graph_id}/backup")
     return response.content
 
+  async def get_storage_breakdown(self, graph_id: str) -> dict[str, Any]:
+    """
+    Get itemized disk usage for a graph and everything it owns.
+
+    Covers the LadybugDB databases (graph, memory, subgraphs, WALs), the
+    LanceDB vector indexes and the DuckDB staging file — so the total is
+    real occupied disk, not just the primary database.
+
+    Args:
+        graph_id: Parent graph to measure
+
+    Returns:
+        ``{graph_id, total_bytes, items: [{type, id, bytes}]}``
+    """
+    response = await self._request("GET", f"/databases/{graph_id}/storage")
+    return response.json()
+
   async def get_database_info(self, graph_id: str) -> dict[str, Any]:
     """
     Get comprehensive database information and statistics.

--- a/robosystems/graph_api/core/ladybug/manager.py
+++ b/robosystems/graph_api/core/ladybug/manager.py
@@ -23,6 +23,7 @@ import ladybug as lbug
 from fastapi import HTTPException, status
 
 from robosystems.config import env
+from robosystems.graph_api.core.storage_breakdown import path_size_bytes
 from robosystems.graph_api.models.database import (
   DatabaseCreateRequest,
   DatabaseCreateResponse,
@@ -545,7 +546,10 @@ class LadybugDatabaseManager:
       )
 
     try:
-      size_bytes = db_path.stat().st_size if db_path.is_file() else 0
+      # A LadybugDB database is a single file in some engine versions and a
+      # directory in others. Sizing only the file case reported 0 for every
+      # directory-shaped database, which is why storage read as empty.
+      size_bytes = path_size_bytes(db_path)
       created_at = datetime.fromtimestamp(db_path.stat().st_ctime).isoformat()
       database_path = str(db_path)
 

--- a/robosystems/graph_api/core/storage_breakdown.py
+++ b/robosystems/graph_api/core/storage_breakdown.py
@@ -1,0 +1,160 @@
+"""Itemized, instance-scoped storage measurement for a graph.
+
+The single source of truth for "how much disk does this graph occupy". Every
+consumer — live display, cap enforcement, historical metering — reads this
+rather than measuring its own way, because measuring it several ways is
+exactly how the number came to be wrong several different ways.
+
+A graph's footprint is not just its ``.lbug`` file. It spans three
+instance-local roots, and the pieces outside the primary database routinely
+outweigh it — staging alone is frequently larger than the graph. Counting only
+the primary file undercounts real COGS by a wide margin.
+
+Backups live in S3, off-instance, and are deliberately out of scope.
+"""
+
+from pathlib import Path
+from typing import Any
+
+from robosystems.config import env
+from robosystems.graph_api.core.utils import validate_database_name
+from robosystems.logger import logger
+
+# Storage item types, in the order they are reported.
+TYPE_GRAPH = "graph"
+TYPE_MEMORY = "memory"
+TYPE_SUBGRAPH = "subgraph"
+TYPE_VECTORS = "vectors"
+TYPE_STAGING = "staging"
+
+
+def path_size_bytes(path: Path) -> int:
+  """Size of a file or directory, recursing into directories.
+
+  A LadybugDB database may be either a single file or a directory depending on
+  the engine version, so both shapes have to be handled. Treating the directory
+  case as unmeasurable is what previously made this report zero.
+  """
+  total = 0
+  try:
+    if path.is_file():
+      return path.stat().st_size
+    if path.is_dir():
+      for item in path.rglob("*"):
+        try:
+          if item.is_file():
+            total += item.stat().st_size
+        except OSError:
+          # A file vanishing mid-walk (compaction, WAL rotation) is normal;
+          # skip it rather than failing the whole measurement.
+          continue
+  except OSError as e:
+    logger.debug(f"Could not size {path}: {e}")
+  return total
+
+
+def _owns(name: str, graph_id: str) -> bool:
+  """Whether an on-disk name belongs to this graph.
+
+  Exact match is the graph itself; the ``_`` boundary covers its memory
+  database and subgraphs. Top-level ids are fixed-length ``kg`` + hex, so the
+  prefix cannot collide with a different tenant's graph.
+  """
+  return name == graph_id or name.startswith(f"{graph_id}_")
+
+
+def _classify_lbug(stem: str, graph_id: str) -> str:
+  """Classify a `.lbug` database by its name."""
+  if stem == graph_id:
+    return TYPE_GRAPH
+  if stem == f"{graph_id}_memory":
+    return TYPE_MEMORY
+  return TYPE_SUBGRAPH
+
+
+def _collect_lbug(root: Path, graph_id: str) -> list[dict[str, Any]]:
+  """Databases and their write-ahead logs under the LadybugDB root.
+
+  WAL bytes are folded into the database they belong to rather than itemized
+  separately — they are the same logical object to anyone reading a quota.
+  """
+  sizes: dict[str, int] = {}
+  if not root.is_dir():
+    return []
+
+  for item in root.iterdir():
+    name = item.name
+    if name.endswith(".lbug"):
+      stem = name[: -len(".lbug")]
+    elif name.endswith(".lbug.wal"):
+      stem = name[: -len(".lbug.wal")]
+    else:
+      continue
+
+    if not _owns(stem, graph_id):
+      continue
+    sizes[stem] = sizes.get(stem, 0) + path_size_bytes(item)
+
+  return [
+    {"type": _classify_lbug(stem, graph_id), "id": stem, "bytes": size}
+    for stem, size in sorted(sizes.items())
+  ]
+
+
+def _collect_vectors(root: Path, graph_id: str) -> list[dict[str, Any]]:
+  """LanceDB index directories, one per graph / memory / subgraph."""
+  if not root.is_dir():
+    return []
+  return [
+    {"type": TYPE_VECTORS, "id": item.name, "bytes": path_size_bytes(item)}
+    for item in sorted(root.iterdir(), key=lambda p: p.name)
+    if _owns(item.name, graph_id)
+  ]
+
+
+def _collect_staging(root: Path, graph_id: str) -> list[dict[str, Any]]:
+  """DuckDB staging file — the Data Lake's physical footprint.
+
+  Surfaced elsewhere as logical table bytes, which is a much smaller number
+  than the file on disk. This counts the file, because that is what occupies
+  the volume.
+  """
+  if not root.is_dir():
+    return []
+  return [
+    {
+      "type": TYPE_STAGING,
+      "id": item.name[: -len(".duckdb")],
+      "bytes": path_size_bytes(item),
+    }
+    for item in sorted(root.iterdir(), key=lambda p: p.name)
+    if item.name.endswith(".duckdb") and _owns(item.name[: -len(".duckdb")], graph_id)
+  ]
+
+
+def compute_storage_breakdown(graph_id: str) -> dict[str, Any]:
+  """Total and per-item disk usage for a graph and everything it owns.
+
+  Args:
+      graph_id: Parent graph identifier. Its memory database, subgraphs,
+          vector indexes and staging file are all attributed to it.
+
+  Returns:
+      ``{graph_id, total_bytes, items: [{type, id, bytes}]}`` where ``type``
+      is one of graph, memory, subgraph, vectors, staging.
+
+  Raises:
+      HTTPException: If ``graph_id`` fails name validation.
+  """
+  validated = validate_database_name(graph_id)
+
+  items: list[dict[str, Any]] = []
+  items.extend(_collect_lbug(Path(env.LBUG_DATABASE_PATH), validated))
+  items.extend(_collect_vectors(Path(env.LANCE_INDEX_PATH), validated))
+  items.extend(_collect_staging(Path(env.DUCKDB_STAGING_PATH), validated))
+
+  return {
+    "graph_id": validated,
+    "total_bytes": sum(item["bytes"] for item in items),
+    "items": items,
+  }

--- a/robosystems/graph_api/routers/databases/metrics.py
+++ b/robosystems/graph_api/routers/databases/metrics.py
@@ -15,6 +15,7 @@ from fastapi import Path as PathParam
 from fastapi import status as http_status
 
 from robosystems.graph_api.core.ladybug import get_ladybug_service
+from robosystems.graph_api.core.storage_breakdown import compute_storage_breakdown
 from robosystems.graph_api.core.utils import validate_database_name
 from robosystems.logger import logger
 
@@ -101,4 +102,32 @@ async def get_database_metrics(
     raise HTTPException(
       status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
       detail="Failed to retrieve database metrics",
+    )
+
+
+@router.get("/{graph_id}/storage")
+async def get_database_storage(
+  graph_id: str = PathParam(..., description="Graph database identifier"),
+) -> dict[str, Any]:
+  """
+  Get itemized disk usage for a graph and everything it owns.
+
+  Spans all three instance-local roots — the LadybugDB databases (graph,
+  memory, subgraphs, and their write-ahead logs), the LanceDB vector indexes,
+  and the DuckDB staging file — so the total reflects real occupied disk
+  rather than the primary database alone.
+
+  Returns `total_bytes` plus per-item `{type, id, bytes}`, where type is one
+  of graph, memory, subgraph, vectors, staging. S3 backups are off-instance
+  and excluded.
+  """
+  try:
+    return compute_storage_breakdown(graph_id)
+  except HTTPException:
+    raise
+  except Exception as e:
+    logger.error(f"Failed to compute storage breakdown for {graph_id}: {e!s}")
+    raise HTTPException(
+      status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
+      detail="Failed to retrieve storage breakdown",
     )

--- a/robosystems/middleware/graph/ingestion_limits.py
+++ b/robosystems/middleware/graph/ingestion_limits.py
@@ -133,39 +133,39 @@ class IngestionLimitChecker:
         Dict with: allowed, errors, total_storage_gb, limit_gb,
         usage_percentage, status, databases
     """
-    from robosystems.models.core.graph import Graph
-
     limit_gb = GraphTierConfig.get_instance_storage_limit_gb(tier)
     warn_pct = (
       GraphTierConfig.get_graph_limits(tier).get("warn_at_percentage", 80) / 100
     )
 
-    # Collect all database IDs on this instance (parent + subgraphs)
-    database_ids = [(graph_id, True)]
-    subgraphs = Graph.get_subgraphs(graph_id, db)
-    for sg in subgraphs:
-      database_ids.append((sg.graph_id, False))
+    # One call covers the whole instance. Subgraphs always live on their
+    # parent's instance, so the breakdown's `{id}_*` scan already includes
+    # them — plus the memory database, vector indexes and staging file. This
+    # also replaces the previous N+1 (one Graph API call per subgraph), and
+    # catches on-disk leftovers the graph registry has lost track of.
+    breakdown = await cls._get_storage_breakdown(graph_id)
+    items: list[dict[str, Any]] = breakdown.get("items", []) if breakdown else []
+    total_bytes = breakdown.get("total_bytes", 0) if breakdown else None
 
-    # Fetch storage for all databases in parallel
-    size_tasks = [cls._get_database_size_bytes(gid) for gid, _ in database_ids]
-    sizes = await asyncio.gather(*size_tasks)
-
-    # Build breakdown and total
-    databases: list[dict[str, Any]] = []
-    total_bytes = 0
-    for (gid, is_parent), size_bytes in zip(database_ids, sizes, strict=True):
-      size_mb = round(size_bytes / (1024**2), 2) if size_bytes is not None else None
-      databases.append(
-        {
-          "graph_id": gid,
-          "is_parent": is_parent,
-          "size_mb": size_mb,
-        }
+    # Roll the itemized view up per database for the summary shape, so a
+    # database's graph/vector/staging bytes appear as one line.
+    bytes_by_database: dict[str, int] = {}
+    for item in items:
+      item_id = item.get("id") or graph_id
+      bytes_by_database[item_id] = bytes_by_database.get(item_id, 0) + item.get(
+        "bytes", 0
       )
-      if size_bytes is not None:
-        total_bytes += size_bytes
 
-    total_storage_gb = round(total_bytes / (1024**3), 2)
+    databases: list[dict[str, Any]] = [
+      {
+        "graph_id": gid,
+        "is_parent": gid == graph_id,
+        "size_mb": round(size / (1024**2), 2),
+      }
+      for gid, size in sorted(bytes_by_database.items())
+    ]
+
+    total_storage_gb = round((total_bytes or 0) / (1024**3), 2)
     usage_percentage = (
       round((total_storage_gb / limit_gb) * 100, 1) if limit_gb > 0 else 0
     )
@@ -194,6 +194,7 @@ class IngestionLimitChecker:
       "usage_percentage": usage_percentage,
       "status": instance_status,
       "databases": databases,
+      "items": items,
     }
 
   @classmethod
@@ -220,11 +221,17 @@ class IngestionLimitChecker:
     return {r.table_name: int(r.total_rows) for r in results if r.table_name}
 
   @classmethod
-  async def _get_database_size_bytes(cls, graph_id: str) -> int | None:
-    """Get database size in bytes from Graph API (file stat, instant).
+  async def _get_storage_breakdown(cls, graph_id: str) -> dict[str, Any] | None:
+    """Get itemized disk usage for a graph, from the Graph API.
+
+    Covers the graph's own database plus its memory database, subgraph
+    databases, vector indexes and staging file — all real disk on the same
+    instance. The pieces outside the primary ``.lbug`` frequently outweigh
+    it, so measuring only that file undercounts the cap denominator and
+    therefore real COGS.
 
     Returns:
-        Size in bytes, or None if unavailable
+        ``{graph_id, total_bytes, items}``, or None if unavailable
     """
     from robosystems.graph_api.client.factory import GraphClientFactory
 
@@ -232,9 +239,11 @@ class IngestionLimitChecker:
       client = await GraphClientFactory.create_client(
         graph_id=graph_id, operation_type="read"
       )
-      db_info = await asyncio.wait_for(client.get_database_info(graph_id), timeout=10)
+      breakdown = await asyncio.wait_for(
+        client.get_storage_breakdown(graph_id), timeout=10
+      )
       await client.close()
-      return db_info.get("size_bytes")
+      return breakdown
     except Exception as e:
       logger.debug(f"Could not get database size for {graph_id}: {e}")
       return None

--- a/robosystems/middleware/robustness/README.md
+++ b/robosystems/middleware/robustness/README.md
@@ -173,7 +173,7 @@ operation_logger = get_operation_logger()
 # Explicit start/finish
 op_id = operation_logger.log_operation_start(
     operation="analytics_query",
-    endpoint="/v1/graphs/{graph_id}/analytics",
+    endpoint="/v1/graphs/{graph_id}/metrics",
     graph_id=graph_id,
     user_id=user_id,
 )
@@ -223,7 +223,7 @@ record_operation_metric(
     operation_type=OperationType.ANALYTICS_QUERY,
     status=OperationStatus.SUCCESS,
     duration_ms=operation_duration_ms,
-    endpoint="/v1/graphs/{graph_id}/analytics",
+    endpoint="/v1/graphs/{graph_id}/metrics",
     graph_id=graph_id,
     user_id=user_id,
     operation_name="get_graph_metrics",
@@ -254,7 +254,7 @@ async def handler(graph_id, user_id):
             operation_type=OperationType.ANALYTICS_QUERY,
             status=OperationStatus.SUCCESS,
             duration_ms=(time.time() - start) * 1000,
-            endpoint="/v1/graphs/{graph_id}/analytics",
+            endpoint="/v1/graphs/{graph_id}/metrics",
             graph_id=graph_id,
             user_id=user_id,
         )

--- a/robosystems/models/api/graphs/health.py
+++ b/robosystems/models/api/graphs/health.py
@@ -31,7 +31,38 @@ class DatabaseHealthResponse(BaseModel):
     ..., description="Error rate in last 24 hours (percentage)", examples=[0.5]
   )
   memory_usage_mb: float | None = Field(
-    None, description="Memory usage in MB", examples=[512.3]
+    None,
+    description=(
+      "Instance memory in use, MB. Only populated for dedicated "
+      "single-tenant instances; null on shared repositories and packed tiers."
+    ),
+    examples=[512.3],
+  )
+  memory_usage_percent: float | None = Field(
+    None,
+    description=(
+      "Instance memory in use, percent. Expect high values during "
+      "materialization — the engine deliberately boosts to near the whole "
+      "instance while rebuilding. Read `resource_status` rather than this "
+      "number alone. Dedicated instances only."
+    ),
+    examples=[41.8],
+  )
+  cpu_usage_percent: float | None = Field(
+    None,
+    description=(
+      "Instance CPU in use, percent. Dedicated single-tenant instances only."
+    ),
+    examples=[12.4],
+  )
+  resource_status: str | None = Field(
+    None,
+    description=(
+      "Interpreted instance load: 'idle' (headroom), 'busy' (working "
+      "normally — typical while materializing), 'constrained' (sustained "
+      "pressure worth acting on). Null when resource metrics are not exposed."
+    ),
+    examples=["idle"],
   )
   storage_usage_mb: float | None = Field(
     None, description="Storage usage in MB", examples=[1024.7]

--- a/robosystems/models/api/graphs/limits.py
+++ b/robosystems/models/api/graphs/limits.py
@@ -76,6 +76,17 @@ class DatabaseStorageEntry(BaseModel):
   size_mb: float | None = Field(None, description="Database size in MB")
 
 
+class StorageItem(BaseModel):
+  """One itemized piece of a graph's on-disk footprint."""
+
+  type: str = Field(
+    ...,
+    description="One of: graph, memory, subgraph, vectors, staging",
+  )
+  id: str = Field(..., description="Database or index identifier")
+  bytes: int = Field(..., description="Size in bytes")
+
+
 class InstanceUsage(BaseModel):
   """Aggregate storage usage across the dedicated instance.
 
@@ -100,6 +111,13 @@ class InstanceUsage(BaseModel):
   databases: list[DatabaseStorageEntry] = Field(
     default_factory=list,
     description="Per-database storage breakdown",
+  )
+  items: list[StorageItem] = Field(
+    default_factory=list,
+    description=(
+      "Itemized storage by type — graph, memory, subgraph, vectors, staging. "
+      "Sums to total_storage_gb."
+    ),
   )
 
 

--- a/robosystems/routers/__init__.py
+++ b/robosystems/routers/__init__.py
@@ -87,7 +87,9 @@ router.include_router(
 )  # No prefix - handled in the operator module itself
 router.include_router(mcp_router, prefix="/mcp")
 router.include_router(backups_router, prefix="/backups")
-router.include_router(usage_router, prefix="/analytics")
+router.include_router(
+  usage_router
+)  # No prefix - handles /metrics and /usage internally
 router.include_router(query_router)  # No prefix - handled in the query module itself
 router.include_router(schema_router)  # No prefix - handled in the schema module itself
 router.include_router(credits_router)  # Already has /credits prefix

--- a/robosystems/routers/graphs/health.py
+++ b/robosystems/routers/graphs/health.py
@@ -29,6 +29,61 @@ router = APIRouter(tags=["Graph Health"])
 circuit_breaker = CircuitBreakerManager()
 timeout_coordinator = TimeoutCoordinator()
 
+# Below this on both axes the instance has obvious headroom.
+_IDLE_CEILING_PERCENT = 50.0
+
+
+def _resources_exposable(graph_id: str, graph_tier: str) -> bool:
+  """Whether instance CPU/memory may be shown to this graph's owner.
+
+  Safe only when the instance is genuinely single-tenant, so both checks are
+  required and neither is redundant:
+
+  - Shared repositories (e.g. sec) run one database per box but are read by
+    every tenant, so instance load leaks cross-tenant activity.
+  - A packed tier co-locates unrelated tenants by construction.
+
+  Driving the second check off the tier's ``databases_per_instance`` rather
+  than a tier allowlist means a future packed tier closes this automatically.
+  """
+  from robosystems.config.graph_tier import GraphTierConfig
+  from robosystems.middleware.graph.utils import MultiTenantUtils
+
+  if MultiTenantUtils.is_shared_repository(graph_id):
+    return False
+  return GraphTierConfig.get_databases_per_instance(graph_tier) == 1
+
+
+def _derive_resource_status(
+  cpu_percent: float | None,
+  memory_percent: float | None,
+  admission_control: dict,
+) -> str | None:
+  """Interpret raw load, so a normal workload doesn't read as a fault.
+
+  Materialization deliberately boosts to near the whole instance, so a high
+  memory reading is usually the engine working as designed. ``constrained``
+  is therefore anchored to the admission controller's own thresholds — the
+  point at which the node starts shedding work — rather than an arbitrary
+  number, so it means "actually worth acting on".
+  """
+  if cpu_percent is None and memory_percent is None:
+    return None
+
+  cpu = cpu_percent or 0.0
+  memory = memory_percent or 0.0
+
+  cpu_threshold = admission_control.get("cpu_threshold")
+  memory_threshold = admission_control.get("memory_threshold")
+  if (cpu_threshold and cpu >= cpu_threshold) or (
+    memory_threshold and memory >= memory_threshold
+  ):
+    return "constrained"
+
+  if cpu < _IDLE_CEILING_PERCENT and memory < _IDLE_CEILING_PERCENT:
+    return "idle"
+  return "busy"
+
 
 async def _get_graph_client(graph_id: str) -> GraphClient:
   from robosystems.config.shared_repositories import is_shared_repository_or_subgraph
@@ -136,6 +191,34 @@ async def get_database_health(
         if is_stale:
           staleness_alert = ["Graph is stale — materialization recommended"]
 
+      # Instance CPU/memory, dedicated single-tenant instances only.
+      # Best-effort: a failure here must not fail the health check.
+      cpu_usage_percent = None
+      memory_usage_percent = None
+      memory_usage_mb = None
+      resource_status = None
+      if graph_record and _resources_exposable(graph_id, str(graph_record.graph_tier)):
+        try:
+          node_metrics = await asyncio.wait_for(
+            graph_client.get_metrics(), timeout=health_timeout
+          )
+          system = node_metrics.get("system", {})
+          memory = system.get("memory", {})
+          cpu = system.get("cpu", {})
+
+          memory_usage_percent = memory.get("usage_percent")
+          used_gb = memory.get("used_gb")
+          if used_gb is not None:
+            memory_usage_mb = round(used_gb * 1024, 1)
+          cpu_usage_percent = cpu.get("usage_percent")
+          resource_status = _derive_resource_status(
+            cpu_usage_percent,
+            memory_usage_percent,
+            node_metrics.get("admission_control", {}),
+          )
+        except Exception as e:
+          logger.debug(f"Could not fetch instance resources for {graph_id}: {e}")
+
       return DatabaseHealthResponse(
         graph_id=graph_id,
         status="degraded" if is_stale else ("healthy" if db_metrics else "unknown"),
@@ -145,7 +228,10 @@ async def get_database_health(
         query_count_24h=0,
         avg_query_time_ms=0.0,
         error_rate_24h=0.0,
-        memory_usage_mb=None,
+        memory_usage_mb=memory_usage_mb,
+        memory_usage_percent=memory_usage_percent,
+        cpu_usage_percent=cpu_usage_percent,
+        resource_status=resource_status,
         storage_usage_mb=db_metrics.get("size_mb"),
         alerts=staleness_alert,
         is_stale=is_stale,

--- a/robosystems/routers/graphs/info.py
+++ b/robosystems/routers/graphs/info.py
@@ -95,8 +95,11 @@ async def get_database_info(
 
       logger.debug(f"Database info retrieved for graph {graph_id}")
 
-      # Calculate derived fields
-      database_size_bytes = info_result.get("database_size_bytes", 0)
+      # Calculate derived fields. The Graph API emits `size_bytes`; reading
+      # `database_size_bytes` here meant this always reported 0. This stays a
+      # lightweight single-database summary — see /limits for the itemized,
+      # instance-wide total that includes memory, vectors and staging.
+      database_size_bytes = info_result.get("size_bytes", 0)
       database_size_mb = round(database_size_bytes / (1024 * 1024), 2)
 
       return DatabaseInfoResponse(

--- a/robosystems/routers/graphs/limits.py
+++ b/robosystems/routers/graphs/limits.py
@@ -30,6 +30,7 @@ from robosystems.models.api.graphs.limits import (
   InstanceUsage,
   QueryLimits,
   RateLimits,
+  StorageItem,
   StorageLimits,
 )
 from robosystems.models.core import User
@@ -116,17 +117,20 @@ async def get_graph_limits(
 
     is_shared = MultiTenantUtils.is_shared_repository(graph_id)
 
-    # Get storage information (instance storage limit from graph.yml)
+    # Get storage information (instance storage limit from graph.yml).
+    # Reads the itemized breakdown so this agrees with `instance_usage` below
+    # and with cap enforcement — all three previously disagreed, and this one
+    # read a field name the Graph API never emitted, so it was always 0.
     max_storage_gb = GraphTierConfig.get_instance_storage_limit_gb(graph_tier)
     storage_limits = {}
     try:
       graph_client = await _get_graph_client(graph_id)
-      db_info = await asyncio.wait_for(
-        graph_client.get_database_info(graph_id), timeout=10
+      breakdown = await asyncio.wait_for(
+        graph_client.get_storage_breakdown(graph_id), timeout=10
       )
       await graph_client.close()
 
-      current_storage_gb = db_info.get("database_size_bytes", 0) / (1024**3)
+      current_storage_gb = breakdown.get("total_bytes", 0) / (1024**3)
 
       storage_limits = {
         "current_usage_gb": round(current_storage_gb, 2),
@@ -191,9 +195,9 @@ async def get_graph_limits(
         pass
 
     # Get content limits and instance usage for non-shared graphs.
-    # Note: check_instance_storage issues parallel Graph API calls for the parent
-    # + each subgraph (N+1 calls). For graphs with many subgraphs this adds
-    # latency. Consider adding a short-TTL Valkey cache if this becomes an issue.
+    # check_instance_storage is a single Graph API call covering the whole
+    # instance — subgraphs live on the parent's box, so one breakdown itemizes
+    # them all.
     content_limits = None
     instance_usage = None
     if not is_shared:
@@ -241,6 +245,7 @@ async def get_graph_limits(
           databases=[
             DatabaseStorageEntry(**db_entry) for db_entry in storage_check["databases"]
           ],
+          items=[StorageItem(**item) for item in storage_check.get("items", [])],
         )
       except Exception as e:
         logger.warning(f"Could not get instance usage for {graph_id}: {e}")

--- a/robosystems/routers/graphs/usage.py
+++ b/robosystems/routers/graphs/usage.py
@@ -1,4 +1,13 @@
-"""Graph usage analytics and monitoring API endpoints."""
+"""Graph content metrics and consumption usage API endpoints.
+
+Two distinct questions, two routes:
+
+- ``GET /metrics`` — what is *in* the graph (node/relationship counts, size, health)
+- ``GET /usage`` — what the graph *consumed* (storage, credits, performance, events)
+
+Neither is analytics. "Analytics" is reserved for the BI surface; these routes were
+renamed off ``/analytics`` so they stop squatting on it.
+"""
 
 import asyncio
 import time
@@ -39,18 +48,21 @@ from robosystems.operations.graph.metrics_service import GraphMetricsService
 
 router = APIRouter(tags=["Usage"])
 
+_METRICS_ENDPOINT = "/v1/graphs/{graph_id}/metrics"
+_USAGE_ENDPOINT = "/v1/graphs/{graph_id}/usage"
+
 graph_metrics_service = GraphMetricsService()
 
 
 @router.get(
-  "",
+  "/metrics",
   response_model=GraphMetricsResponse,
   summary="Get Graph Metrics",
   operation_id="getGraphMetrics",
   responses={**RESOURCE_ERROR_RESPONSES},
 )
 @endpoint_metrics_decorator(
-  endpoint_name="/v1/graphs/{graph_id}/analytics",
+  endpoint_name=_METRICS_ENDPOINT,
   business_event_type="graph_metrics_accessed",
 )
 async def get_graph_metrics(
@@ -74,7 +86,7 @@ async def get_graph_metrics(
     operation_type=OperationType.ANALYTICS_QUERY,
     status=OperationStatus.SUCCESS,
     duration_ms=0.0,
-    endpoint="/v1/graphs/{graph_id}/analytics",
+    endpoint=_METRICS_ENDPOINT,
     graph_id=graph_id,
     user_id=current_user.id,
     operation_name="get_graph_metrics",
@@ -98,7 +110,7 @@ async def get_graph_metrics(
     )
 
     operation_logger.log_external_service_call(
-      endpoint="/v1/graphs/{graph_id}/analytics",
+      endpoint=_METRICS_ENDPOINT,
       service_name="graph_metrics_service",
       operation="collect_comprehensive_metrics",
       duration_ms=0.0,
@@ -123,7 +135,7 @@ async def get_graph_metrics(
 
     metrics_instance = get_endpoint_metrics()
     metrics_instance.record_business_event(
-      endpoint="/v1/graphs/{graph_id}/analytics",
+      endpoint=_METRICS_ENDPOINT,
       method="GET",
       event_type="graph_metrics_accessed",
       event_data={
@@ -142,7 +154,7 @@ async def get_graph_metrics(
       operation_type=OperationType.ANALYTICS_QUERY,
       status=OperationStatus.SUCCESS,
       duration_ms=operation_duration_ms,
-      endpoint="/v1/graphs/{graph_id}/analytics",
+      endpoint=_METRICS_ENDPOINT,
       graph_id=graph_id,
       user_id=current_user.id,
       operation_name="get_graph_metrics",
@@ -165,7 +177,7 @@ async def get_graph_metrics(
       operation_type=OperationType.ANALYTICS_QUERY,
       status=OperationStatus.FAILURE,
       duration_ms=operation_duration_ms,
-      endpoint="/v1/graphs/{graph_id}/analytics",
+      endpoint=_METRICS_ENDPOINT,
       graph_id=graph_id,
       user_id=current_user.id,
       operation_name="get_graph_metrics",
@@ -190,7 +202,7 @@ async def get_graph_metrics(
       operation_type=OperationType.ANALYTICS_QUERY,
       status=OperationStatus.FAILURE,
       duration_ms=operation_duration_ms,
-      endpoint="/v1/graphs/{graph_id}/analytics",
+      endpoint=_METRICS_ENDPOINT,
       graph_id=graph_id,
       user_id=current_user.id,
       operation_name="get_graph_metrics",
@@ -208,7 +220,7 @@ async def get_graph_metrics(
       operation_type=OperationType.ANALYTICS_QUERY,
       status=OperationStatus.FAILURE,
       duration_ms=operation_duration_ms,
-      endpoint="/v1/graphs/{graph_id}/analytics",
+      endpoint=_METRICS_ENDPOINT,
       graph_id=graph_id,
       user_id=current_user.id,
       operation_name="get_graph_metrics",
@@ -231,16 +243,16 @@ async def get_graph_metrics(
 @router.get(
   "/usage",
   response_model=GraphUsageResponse,
-  summary="Get Graph Usage Analytics",
+  summary="Get Graph Usage",
   description="Time ranges: 24h, 7d, 30d, current_month, last_month. Toggle storage, credits, performance, and events sections via query params.",
-  operation_id="getGraphUsageAnalytics",
+  operation_id="getGraphUsage",
   responses={**RESOURCE_ERROR_RESPONSES},
 )
 @endpoint_metrics_decorator(
-  endpoint_name="/v1/graphs/{graph_id}/usage",
+  endpoint_name=_USAGE_ENDPOINT,
   business_event_type="graph_usage_accessed",
 )
-async def get_graph_usage_analytics(
+async def get_graph_usage(
   graph_id: str = Path(
     ...,
     description="The graph ID to get usage analytics for",
@@ -272,7 +284,7 @@ async def get_graph_usage_analytics(
     operation_type=OperationType.ANALYTICS_QUERY,
     status=OperationStatus.SUCCESS,
     duration_ms=0.0,
-    endpoint="/v1/graphs/{graph_id}/usage",
+    endpoint=_USAGE_ENDPOINT,
     graph_id=graph_id,
     user_id=current_user.id,
     operation_name="get_usage_analytics",
@@ -301,7 +313,7 @@ async def get_graph_usage_analytics(
     )
 
     operation_logger.log_external_service_call(
-      endpoint="/v1/graphs/{graph_id}/usage",
+      endpoint=_USAGE_ENDPOINT,
       service_name="graph_usage",
       operation="query_usage_analytics",
       duration_ms=0.0,
@@ -397,7 +409,7 @@ async def get_graph_usage_analytics(
 
     metrics_instance = get_endpoint_metrics()
     metrics_instance.record_business_event(
-      endpoint="/v1/graphs/{graph_id}/usage",
+      endpoint=_USAGE_ENDPOINT,
       method="GET",
       event_type="graph_usage_accessed",
       event_data={
@@ -418,7 +430,7 @@ async def get_graph_usage_analytics(
       operation_type=OperationType.ANALYTICS_QUERY,
       status=OperationStatus.SUCCESS,
       duration_ms=operation_duration_ms,
-      endpoint="/v1/graphs/{graph_id}/usage",
+      endpoint=_USAGE_ENDPOINT,
       graph_id=graph_id,
       user_id=current_user.id,
       operation_name="get_usage_analytics",
@@ -446,7 +458,7 @@ async def get_graph_usage_analytics(
       operation_type=OperationType.ANALYTICS_QUERY,
       status=OperationStatus.FAILURE,
       duration_ms=operation_duration_ms,
-      endpoint="/v1/graphs/{graph_id}/usage",
+      endpoint=_USAGE_ENDPOINT,
       graph_id=graph_id,
       user_id=current_user.id,
       operation_name="get_usage_analytics",
@@ -472,7 +484,7 @@ async def get_graph_usage_analytics(
       operation_type=OperationType.ANALYTICS_QUERY,
       status=OperationStatus.FAILURE,
       duration_ms=operation_duration_ms,
-      endpoint="/v1/graphs/{graph_id}/usage",
+      endpoint=_USAGE_ENDPOINT,
       graph_id=graph_id,
       user_id=current_user.id,
       operation_name="get_usage_analytics",
@@ -491,7 +503,7 @@ async def get_graph_usage_analytics(
       operation_type=OperationType.ANALYTICS_QUERY,
       status=OperationStatus.FAILURE,
       duration_ms=operation_duration_ms,
-      endpoint="/v1/graphs/{graph_id}/usage",
+      endpoint=_USAGE_ENDPOINT,
       graph_id=graph_id,
       user_id=current_user.id,
       operation_name="get_usage_analytics",

--- a/tests/config/test_rate_limits.py
+++ b/tests/config/test_rate_limits.py
@@ -52,9 +52,9 @@ def test_unknown_tier_falls_back_to_base_limits():
     # graph-independent (no graph_id) but still read-like.
     ("/v1/graphs/abc/schema", "GET", EndpointCategory.GRAPH_READ),
     ("/v1/graphs/schema/validate", "POST", EndpointCategory.GRAPH_READ),
-    # Usage analytics — dedicated bucket
-    ("/v1/graphs/abc/analytics", "GET", EndpointCategory.GRAPH_ANALYTICS),
-    ("/v1/graphs/abc/analytics/usage", "GET", EndpointCategory.GRAPH_ANALYTICS),
+    # Content metrics + consumption usage — dedicated bucket
+    ("/v1/graphs/abc/metrics", "GET", EndpointCategory.GRAPH_ANALYTICS),
+    ("/v1/graphs/abc/usage", "GET", EndpointCategory.GRAPH_ANALYTICS),
     # Backup list is a read; download too
     ("/v1/graphs/abc/backups", "GET", EndpointCategory.GRAPH_READ),
     # Graph lifecycle operations get dedicated buckets

--- a/tests/graph_api/core/test_storage_breakdown.py
+++ b/tests/graph_api/core/test_storage_breakdown.py
@@ -1,0 +1,180 @@
+"""Tests for itemized graph storage measurement.
+
+The bugs this replaces both produced a confident zero, so these tests care
+most about two things: that a directory-shaped database is actually measured,
+and that the total spans all three roots rather than the primary file alone.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from robosystems.graph_api.core.storage_breakdown import (
+  compute_storage_breakdown,
+  path_size_bytes,
+)
+
+GRAPH_ID = "kg19f54bda80f39fbbac0f"
+OTHER_ID = "kg00000000000000000000"
+
+
+@pytest.fixture
+def roots(tmp_path, monkeypatch):
+  """Three instance-local storage roots, patched into env."""
+  lbug = tmp_path / "lbug-dbs"
+  lance = tmp_path / "lance"
+  staging = tmp_path / "staging"
+  for root in (lbug, lance, staging):
+    root.mkdir()
+
+  monkeypatch.setattr(
+    "robosystems.graph_api.core.storage_breakdown.env.LBUG_DATABASE_PATH", str(lbug)
+  )
+  monkeypatch.setattr(
+    "robosystems.graph_api.core.storage_breakdown.env.LANCE_INDEX_PATH", str(lance)
+  )
+  monkeypatch.setattr(
+    "robosystems.graph_api.core.storage_breakdown.env.DUCKDB_STAGING_PATH",
+    str(staging),
+  )
+  return {"lbug": lbug, "lance": lance, "staging": staging}
+
+
+def _write(path: Path, size: int) -> None:
+  path.parent.mkdir(parents=True, exist_ok=True)
+  path.write_bytes(b"x" * size)
+
+
+class TestPathSizeBytes:
+  def test_sizes_a_file(self, tmp_path):
+    _write(tmp_path / "db.lbug", 512)
+    assert path_size_bytes(tmp_path / "db.lbug") == 512
+
+  def test_sizes_a_directory_recursively(self, tmp_path):
+    """The regression that mattered: directory-shaped databases read as 0."""
+    _write(tmp_path / "db.lbug" / "data" / "a.bin", 300)
+    _write(tmp_path / "db.lbug" / "b.bin", 200)
+    assert path_size_bytes(tmp_path / "db.lbug") == 500
+
+  def test_missing_path_is_zero_not_an_error(self, tmp_path):
+    assert path_size_bytes(tmp_path / "nope.lbug") == 0
+
+
+class TestComputeStorageBreakdown:
+  def test_counts_all_three_roots(self, roots):
+    """Total must span lbug + vectors + staging, not the graph file alone."""
+    _write(roots["lbug"] / f"{GRAPH_ID}.lbug", 1000)
+    _write(roots["lance"] / GRAPH_ID / "index.bin", 70)
+    _write(roots["staging"] / f"{GRAPH_ID}.duckdb", 1800)
+
+    result = compute_storage_breakdown(GRAPH_ID)
+
+    assert result["total_bytes"] == 2870
+    assert {i["type"] for i in result["items"]} == {"graph", "vectors", "staging"}
+
+  def test_staging_can_exceed_the_graph_itself(self, roots):
+    """Guards the undercount: the primary file is a minority of the footprint."""
+    _write(roots["lbug"] / f"{GRAPH_ID}.lbug", 100)
+    _write(roots["staging"] / f"{GRAPH_ID}.duckdb", 900)
+
+    result = compute_storage_breakdown(GRAPH_ID)
+    graph_bytes = next(i["bytes"] for i in result["items"] if i["type"] == "graph")
+
+    assert graph_bytes == 100
+    assert result["total_bytes"] == 1000
+
+  def test_classifies_memory_and_subgraphs(self, roots):
+    _write(roots["lbug"] / f"{GRAPH_ID}.lbug", 10)
+    _write(roots["lbug"] / f"{GRAPH_ID}_memory.lbug", 20)
+    _write(roots["lbug"] / f"{GRAPH_ID}_dev.lbug", 30)
+
+    items = {i["id"]: i["type"] for i in compute_storage_breakdown(GRAPH_ID)["items"]}
+
+    assert items[GRAPH_ID] == "graph"
+    assert items[f"{GRAPH_ID}_memory"] == "memory"
+    assert items[f"{GRAPH_ID}_dev"] == "subgraph"
+
+  def test_folds_wal_into_its_database(self, roots):
+    """A WAL is the same logical object as its database to a quota reader."""
+    _write(roots["lbug"] / f"{GRAPH_ID}.lbug", 100)
+    _write(roots["lbug"] / f"{GRAPH_ID}.lbug.wal", 50)
+
+    items = compute_storage_breakdown(GRAPH_ID)["items"]
+    graph_items = [i for i in items if i["type"] == "graph"]
+
+    assert len(graph_items) == 1
+    assert graph_items[0]["bytes"] == 150
+
+  def test_measures_directory_shaped_databases(self, roots):
+    _write(roots["lbug"] / f"{GRAPH_ID}.lbug" / "chunk.bin", 4096)
+
+    result = compute_storage_breakdown(GRAPH_ID)
+
+    assert result["total_bytes"] == 4096
+
+  def test_excludes_other_tenants(self, roots):
+    """The cap denominator must not absorb a neighbour's disk."""
+    _write(roots["lbug"] / f"{GRAPH_ID}.lbug", 100)
+    _write(roots["lbug"] / f"{OTHER_ID}.lbug", 999)
+    _write(roots["lance"] / OTHER_ID / "index.bin", 999)
+    _write(roots["staging"] / f"{OTHER_ID}.duckdb", 999)
+
+    result = compute_storage_breakdown(GRAPH_ID)
+
+    assert result["total_bytes"] == 100
+    assert all(i["id"].startswith(GRAPH_ID) for i in result["items"])
+
+  def test_prefix_match_requires_the_underscore_boundary(self, roots):
+    """`kg1abc` must not swallow `kg1abcdef`."""
+    _write(roots["lbug"] / f"{GRAPH_ID}.lbug", 100)
+    _write(roots["lbug"] / f"{GRAPH_ID}extra.lbug", 500)
+
+    result = compute_storage_breakdown(GRAPH_ID)
+
+    assert result["total_bytes"] == 100
+
+  def test_empty_instance_reports_zero_cleanly(self, roots):
+    result = compute_storage_breakdown(GRAPH_ID)
+
+    assert result["total_bytes"] == 0
+    assert result["items"] == []
+    assert result["graph_id"] == GRAPH_ID
+
+  def test_missing_roots_do_not_raise(self, tmp_path, monkeypatch):
+    """A node without vectors or staging configured still reports its graph."""
+    lbug = tmp_path / "lbug-dbs"
+    lbug.mkdir()
+    _write(lbug / f"{GRAPH_ID}.lbug", 42)
+
+    monkeypatch.setattr(
+      "robosystems.graph_api.core.storage_breakdown.env.LBUG_DATABASE_PATH", str(lbug)
+    )
+    monkeypatch.setattr(
+      "robosystems.graph_api.core.storage_breakdown.env.LANCE_INDEX_PATH",
+      str(tmp_path / "absent-lance"),
+    )
+    monkeypatch.setattr(
+      "robosystems.graph_api.core.storage_breakdown.env.DUCKDB_STAGING_PATH",
+      str(tmp_path / "absent-staging"),
+    )
+
+    assert compute_storage_breakdown(GRAPH_ID)["total_bytes"] == 42
+
+  def test_total_always_equals_the_sum_of_items(self, roots):
+    _write(roots["lbug"] / f"{GRAPH_ID}.lbug", 11)
+    _write(roots["lbug"] / f"{GRAPH_ID}_memory.lbug", 22)
+    _write(roots["lbug"] / f"{GRAPH_ID}_sub.lbug", 33)
+    _write(roots["lance"] / GRAPH_ID / "i.bin", 44)
+    _write(roots["lance"] / f"{GRAPH_ID}_memory" / "i.bin", 55)
+    _write(roots["staging"] / f"{GRAPH_ID}.duckdb", 66)
+
+    result = compute_storage_breakdown(GRAPH_ID)
+
+    assert result["total_bytes"] == sum(i["bytes"] for i in result["items"])
+    assert result["total_bytes"] == 231
+
+  def test_rejects_an_unsafe_graph_id(self, roots):
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException):
+      compute_storage_breakdown("../../etc/passwd")

--- a/tests/middleware/graph/test_ingestion_limits.py
+++ b/tests/middleware/graph/test_ingestion_limits.py
@@ -102,9 +102,12 @@ class TestCheckMaterializationLimits:
       ),
       patch.object(
         IngestionLimitChecker,
-        "_get_database_size_bytes",
+        "_get_storage_breakdown",
         new_callable=AsyncMock,
-        return_value=25 * 1024**3,  # 25 GB on a 20 GB tier
+        return_value={
+          "total_bytes": 25 * 1024**3,
+          "items": [{"type": "graph", "id": "kg_test", "bytes": 25 * 1024**3}],
+        },  # 25 GB on a 20 GB tier
       ),
       patch(
         "robosystems.models.core.graph.Graph.get_subgraphs",
@@ -173,9 +176,12 @@ class TestCheckInstanceStorage:
     with (
       patch.object(
         IngestionLimitChecker,
-        "_get_database_size_bytes",
+        "_get_storage_breakdown",
         new_callable=AsyncMock,
-        return_value=5 * 1024**3,  # 5 GB
+        return_value={
+          "total_bytes": 5 * 1024**3,
+          "items": [{"type": "graph", "id": "kg_test", "bytes": 5 * 1024**3}],
+        },  # 5 GB
       ),
       patch(
         "robosystems.models.core.graph.Graph.get_subgraphs",
@@ -210,9 +216,12 @@ class TestCheckInstanceStorage:
     with (
       patch.object(
         IngestionLimitChecker,
-        "_get_database_size_bytes",
+        "_get_storage_breakdown",
         new_callable=AsyncMock,
-        return_value=17 * 1024**3,  # 17 GB
+        return_value={
+          "total_bytes": 17 * 1024**3,
+          "items": [{"type": "graph", "id": "kg_test", "bytes": 17 * 1024**3}],
+        },  # 17 GB
       ),
       patch(
         "robosystems.models.core.graph.Graph.get_subgraphs",
@@ -243,9 +252,12 @@ class TestCheckInstanceStorage:
     with (
       patch.object(
         IngestionLimitChecker,
-        "_get_database_size_bytes",
+        "_get_storage_breakdown",
         new_callable=AsyncMock,
-        return_value=21 * 1024**3,  # 21 GB
+        return_value={
+          "total_bytes": 21 * 1024**3,
+          "items": [{"type": "graph", "id": "kg_test", "bytes": 21 * 1024**3}],
+        },  # 21 GB
       ),
       patch(
         "robosystems.models.core.graph.Graph.get_subgraphs",
@@ -280,9 +292,12 @@ class TestCheckInstanceStorage:
     with (
       patch.object(
         IngestionLimitChecker,
-        "_get_database_size_bytes",
+        "_get_storage_breakdown",
         new_callable=AsyncMock,
-        return_value=5 * 1024**3,
+        return_value={
+          "total_bytes": 5 * 1024**3,
+          "items": [{"type": "graph", "id": "kg_test", "bytes": 5 * 1024**3}],
+        },
       ),
       patch(
         "robosystems.models.core.graph.Graph.get_subgraphs",
@@ -308,29 +323,30 @@ class TestCheckInstanceStorage:
 
   @pytest.mark.asyncio
   async def test_aggregates_subgraphs(self):
-    """Test that storage is summed across parent and subgraphs."""
+    """Storage covers parent and subgraphs from one instance-wide read.
+
+    Subgraphs always live on their parent's instance, so a single breakdown
+    already itemizes them — no per-subgraph call, and no dependence on the
+    graph registry being in step with what is actually on disk.
+    """
     mock_db = MagicMock()
 
-    # Create mock subgraph
-    mock_subgraph = MagicMock()
-    mock_subgraph.graph_id = "kg_test_dev"
-
-    # Return different sizes for parent vs subgraph
-    async def mock_get_size(graph_id):
-      if graph_id == "kg_test":
-        return 10 * 1024**3  # 10 GB parent
-      return 5 * 1024**3  # 5 GB subgraph
+    breakdown = {
+      "graph_id": "kg_test",
+      "total_bytes": 15 * 1024**3,
+      "items": [
+        {"type": "graph", "id": "kg_test", "bytes": 10 * 1024**3},
+        {"type": "subgraph", "id": "kg_test_dev", "bytes": 5 * 1024**3},
+      ],
+    }
 
     with (
       patch.object(
         IngestionLimitChecker,
-        "_get_database_size_bytes",
-        side_effect=mock_get_size,
-      ),
-      patch(
-        "robosystems.models.core.graph.Graph.get_subgraphs",
-        return_value=[mock_subgraph],
-      ),
+        "_get_storage_breakdown",
+        new_callable=AsyncMock,
+        return_value=breakdown,
+      ) as mock_breakdown,
       patch(
         "robosystems.middleware.graph.ingestion_limits.GraphTierConfig.get_instance_storage_limit_gb",
         return_value=20.0,
@@ -353,29 +369,32 @@ class TestCheckInstanceStorage:
     assert result["databases"][0]["is_parent"] is True
     assert result["databases"][1]["is_parent"] is False
     assert result["databases"][1]["graph_id"] == "kg_test_dev"
+    assert result["items"] == breakdown["items"]
+
+    # One call for the whole instance, not one per database.
+    mock_breakdown.assert_awaited_once_with("kg_test")
 
   @pytest.mark.asyncio
-  async def test_handles_unavailable_subgraph(self):
-    """Test graceful degradation when a subgraph's size can't be fetched."""
+  async def test_rolls_types_up_per_database(self):
+    """A database's graph, vector and staging bytes report as one line."""
     mock_db = MagicMock()
 
-    mock_subgraph = MagicMock()
-    mock_subgraph.graph_id = "kg_test_dev"
-
-    async def mock_get_size(graph_id):
-      if graph_id == "kg_test":
-        return 10 * 1024**3
-      return None  # Subgraph unavailable
+    breakdown = {
+      "graph_id": "kg_test",
+      "total_bytes": 6 * 1024**3,
+      "items": [
+        {"type": "graph", "id": "kg_test", "bytes": 3 * 1024**3},
+        {"type": "vectors", "id": "kg_test", "bytes": 1 * 1024**3},
+        {"type": "staging", "id": "kg_test", "bytes": 2 * 1024**3},
+      ],
+    }
 
     with (
       patch.object(
         IngestionLimitChecker,
-        "_get_database_size_bytes",
-        side_effect=mock_get_size,
-      ),
-      patch(
-        "robosystems.models.core.graph.Graph.get_subgraphs",
-        return_value=[mock_subgraph],
+        "_get_storage_breakdown",
+        new_callable=AsyncMock,
+        return_value=breakdown,
       ),
       patch(
         "robosystems.middleware.graph.ingestion_limits.GraphTierConfig.get_instance_storage_limit_gb",
@@ -392,7 +411,38 @@ class TestCheckInstanceStorage:
         tier="ladybug-standard",
       )
 
-    # Only parent size counted
-    assert result["total_storage_gb"] == 10.0
-    assert len(result["databases"]) == 2
-    assert result["databases"][1]["size_mb"] is None
+    assert len(result["databases"]) == 1
+    assert result["databases"][0]["size_mb"] == 6 * 1024
+    assert result["total_storage_gb"] == 6.0
+
+  @pytest.mark.asyncio
+  async def test_unavailable_breakdown_degrades_to_zero(self):
+    """An unreachable node must not fabricate usage or block on nothing."""
+    mock_db = MagicMock()
+
+    with (
+      patch.object(
+        IngestionLimitChecker,
+        "_get_storage_breakdown",
+        new_callable=AsyncMock,
+        return_value=None,
+      ),
+      patch(
+        "robosystems.middleware.graph.ingestion_limits.GraphTierConfig.get_instance_storage_limit_gb",
+        return_value=20.0,
+      ),
+      patch(
+        "robosystems.middleware.graph.ingestion_limits.GraphTierConfig.get_graph_limits",
+        return_value={"warn_at_percentage": 80},
+      ),
+    ):
+      result = await IngestionLimitChecker.check_instance_storage(
+        db=mock_db,
+        graph_id="kg_test",
+        tier="ladybug-standard",
+      )
+
+    assert result["allowed"] is True
+    assert result["total_storage_gb"] == 0.0
+    assert result["databases"] == []
+    assert result["items"] == []

--- a/tests/middleware/otel/test_endpoint_metrics.py
+++ b/tests/middleware/otel/test_endpoint_metrics.py
@@ -254,8 +254,8 @@ class TestSanitizeEndpoint:
 
   def test_collapses_raw_graph_id(self):
     assert (
-      _sanitize_endpoint("/v1/graphs/kg19ea0c7f61d75b25f1c1/analytics")
-      == "/v1/graphs/{graph_id}/analytics"
+      _sanitize_endpoint("/v1/graphs/kg19ea0c7f61d75b25f1c1/metrics")
+      == "/v1/graphs/{graph_id}/metrics"
     )
 
   def test_collapses_subgraph_id(self):
@@ -265,7 +265,7 @@ class TestSanitizeEndpoint:
     )
 
   def test_leaves_templated_placeholder_untouched(self):
-    templated = "/v1/graphs/{graph_id}/analytics"
+    templated = "/v1/graphs/{graph_id}/metrics"
     assert _sanitize_endpoint(templated) == templated
 
   def test_leaves_non_graph_paths_untouched(self):
@@ -283,7 +283,7 @@ class TestSanitizeEndpoint:
   def test_record_business_event_sanitizes_label(self, metrics):
     # Even if a caller leaks a raw graph_id, the recorded label is collapsed.
     metrics.record_business_event(
-      endpoint="/v1/graphs/kg19ea0c7f61d75b25f1c1/analytics",
+      endpoint="/v1/graphs/kg19ea0c7f61d75b25f1c1/metrics",
       method="GET",
       event_type="graph_metrics_accessed",
     )

--- a/tests/routers/graphs/test_health_resources.py
+++ b/tests/routers/graphs/test_health_resources.py
@@ -1,0 +1,199 @@
+"""Tests for instance CPU/memory exposure on the graph health endpoint.
+
+The exposure guard is a tenant-isolation boundary: instance load must only be
+visible to the owner of a genuinely single-tenant instance. These tests pin
+both halves of that guard, plus the status derivation that keeps a normal
+materialization from reading as a fault.
+"""
+
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from robosystems.routers.graphs.health import (
+  _derive_resource_status,
+  _resources_exposable,
+  get_database_health,
+)
+
+
+class TestResourcesExposable:
+  """Both halves of the guard are required; neither is redundant."""
+
+  def test_dedicated_tier_is_exposable(self):
+    assert _resources_exposable("kg01234567890abcdef", "ladybug-standard") is True
+
+  @pytest.mark.parametrize(
+    "tier", ["ladybug-standard", "ladybug-large", "ladybug-xlarge"]
+  )
+  def test_all_dedicated_product_tiers_are_exposable(self, tier):
+    assert _resources_exposable("kg01234567890abcdef", tier) is True
+
+  def test_shared_repository_is_not_exposable(self):
+    """sec runs one database per box but is read by every tenant."""
+    assert _resources_exposable("sec", "ladybug-shared") is False
+
+  def test_packed_tier_is_not_exposable(self):
+    """A tier that co-locates tenants closes the guard automatically.
+
+    This is the property that makes a future packed tier safe by
+    construction rather than by remembering to revoke exposure.
+    """
+    with patch(
+      "robosystems.config.graph_tier.GraphTierConfig.get_databases_per_instance",
+      return_value=8,
+    ):
+      assert _resources_exposable("kg01234567890abcdef", "ladybug-community") is False
+
+  def test_shared_repo_check_is_independent_of_packing(self):
+    """A shared repo stays hidden even when its tier reports dedicated."""
+    with patch(
+      "robosystems.config.graph_tier.GraphTierConfig.get_databases_per_instance",
+      return_value=1,
+    ):
+      assert _resources_exposable("sec", "ladybug-shared") is False
+
+
+class TestDeriveResourceStatus:
+  """`constrained` is anchored to the admission controller's own thresholds."""
+
+  ADMISSION = {"cpu_threshold": 90.0, "memory_threshold": 85.0}
+
+  def test_low_load_is_idle(self):
+    assert _derive_resource_status(5.0, 30.0, self.ADMISSION) == "idle"
+
+  def test_moderate_load_is_busy(self):
+    assert _derive_resource_status(55.0, 60.0, self.ADMISSION) == "busy"
+
+  def test_materialization_boost_reads_as_busy_not_constrained(self):
+    """Materialization deliberately boosts toward the whole instance.
+
+    Below the admission threshold that is the engine working as designed,
+    so it must not surface as a fault the tenant would file a ticket about.
+    """
+    assert _derive_resource_status(45.0, 80.0, self.ADMISSION) == "busy"
+
+  def test_memory_at_admission_threshold_is_constrained(self):
+    assert _derive_resource_status(10.0, 85.0, self.ADMISSION) == "constrained"
+
+  def test_cpu_at_admission_threshold_is_constrained(self):
+    assert _derive_resource_status(90.0, 10.0, self.ADMISSION) == "constrained"
+
+  def test_missing_thresholds_never_report_constrained(self):
+    """A node that reports no thresholds should degrade, not cry wolf."""
+    assert _derive_resource_status(99.0, 99.0, {}) == "busy"
+
+  def test_no_readings_yields_no_status(self):
+    assert _derive_resource_status(None, None, self.ADMISSION) is None
+
+  def test_partial_reading_still_classifies(self):
+    assert _derive_resource_status(None, 95.0, self.ADMISSION) == "constrained"
+
+
+def _make_user():
+  user = Mock()
+  user.id = "user-123"
+  return user
+
+
+def _make_graph_client(system=None, admission=None):
+  client = AsyncMock()
+  client.get_database_metrics = AsyncMock(return_value={"size_mb": 12.5})
+  client.health_check = AsyncMock(return_value={"uptime_seconds": 3600.0})
+  client.get_metrics = AsyncMock(
+    return_value={
+      "system": system
+      or {
+        "cpu": {"usage_percent": 7.5},
+        "memory": {"usage_percent": 22.0, "used_gb": 1.5},
+      },
+      "admission_control": admission
+      or {"cpu_threshold": 90.0, "memory_threshold": 85.0},
+    }
+  )
+  client.close = AsyncMock()
+  return client
+
+
+def _make_graph_record(tier="ladybug-standard"):
+  record = Mock()
+  record.graph_tier = tier
+  record.graph_stale = False
+  record.graph_stale_reason = None
+  record.graph_stale_at = None
+  record.graph_metadata = {}
+  return record
+
+
+async def _call_health(graph_id, client, graph_record):
+  with patch("robosystems.routers.graphs.health.get_universal_repository", AsyncMock()):
+    with patch(
+      "robosystems.routers.graphs.health._get_graph_client",
+      AsyncMock(return_value=client),
+    ):
+      with patch("robosystems.models.core.Graph.get_by_id", return_value=graph_record):
+        return await get_database_health(
+          graph_id=graph_id,
+          current_user=_make_user(),
+          session=Mock(),
+          _=None,
+        )
+
+
+@pytest.mark.asyncio
+class TestHealthEndpointResourceExposure:
+  """End-to-end through the handler, since the guard is what matters."""
+
+  async def test_dedicated_graph_reports_resources(self):
+    client = _make_graph_client()
+    result = await _call_health(
+      "kg01234567890abcdef", client, _make_graph_record("ladybug-standard")
+    )
+
+    assert result.cpu_usage_percent == 7.5
+    assert result.memory_usage_percent == 22.0
+    assert result.memory_usage_mb == pytest.approx(1536.0)
+    assert result.resource_status == "idle"
+    client.get_metrics.assert_awaited_once()
+
+  async def test_shared_repository_reports_no_resources(self):
+    client = _make_graph_client()
+    result = await _call_health("sec", client, _make_graph_record("ladybug-shared"))
+
+    assert result.cpu_usage_percent is None
+    assert result.memory_usage_percent is None
+    assert result.memory_usage_mb is None
+    assert result.resource_status is None
+
+  async def test_shared_repository_never_queries_the_instance(self):
+    """The guard short-circuits before the call, not after."""
+    client = _make_graph_client()
+    await _call_health("sec", client, _make_graph_record("ladybug-shared"))
+
+    client.get_metrics.assert_not_awaited()
+
+  async def test_resource_failure_does_not_fail_health_check(self):
+    """Resource collection is best-effort decoration on a health check."""
+    client = _make_graph_client()
+    client.get_metrics = AsyncMock(side_effect=RuntimeError("node unreachable"))
+
+    result = await _call_health(
+      "kg01234567890abcdef", client, _make_graph_record("ladybug-standard")
+    )
+
+    assert result.status == "healthy"
+    assert result.cpu_usage_percent is None
+    assert result.resource_status is None
+
+  async def test_constrained_instance_surfaces_status(self):
+    client = _make_graph_client(
+      system={
+        "cpu": {"usage_percent": 12.0},
+        "memory": {"usage_percent": 97.0, "used_gb": 7.6},
+      }
+    )
+    result = await _call_health(
+      "kg01234567890abcdef", client, _make_graph_record("ladybug-standard")
+    )
+
+    assert result.resource_status == "constrained"

--- a/tests/routers/graphs/test_usage.py
+++ b/tests/routers/graphs/test_usage.py
@@ -1,4 +1,4 @@
-"""Comprehensive unit tests for the usage analytics router."""
+"""Comprehensive unit tests for the graph metrics + usage router."""
 
 import asyncio
 from datetime import UTC, datetime
@@ -11,7 +11,7 @@ from robosystems.routers.graphs.usage import (
   _get_days_from_time_range,
   _parse_time_range,
   get_graph_metrics,
-  get_graph_usage_analytics,
+  get_graph_usage,
 )
 
 
@@ -268,7 +268,7 @@ class TestGetGraphMetrics:
 
 @pytest.mark.unit
 class TestGetGraphUsageAnalytics:
-  """Test the get_graph_usage_analytics endpoint."""
+  """Test the get_graph_usage endpoint."""
 
   @pytest.mark.asyncio
   async def test_basic_usage_analytics_no_data(self):
@@ -294,7 +294,7 @@ class TestGetGraphUsageAnalytics:
           return_value={},
         ),
       ):
-        result = await get_graph_usage_analytics(
+        result = await get_graph_usage(
           graph_id="kg01234567890abcdef",
           time_range="30d",
           include_storage=True,
@@ -341,7 +341,7 @@ class TestGetGraphUsageAnalytics:
           return_value={},
         ),
       ):
-        result = await get_graph_usage_analytics(
+        result = await get_graph_usage(
           graph_id=graph_id,
           time_range="30d",
           include_storage=True,
@@ -365,7 +365,7 @@ class TestGetGraphUsageAnalytics:
     cb_patch, tc_patch, ol_patch, rm_patch = _patch_robustness()
 
     with cb_patch, tc_patch, ol_patch, rm_patch:
-      result = await get_graph_usage_analytics(
+      result = await get_graph_usage(
         graph_id="kg01234567890abcdef",
         time_range="24h",
         include_storage=False,
@@ -402,7 +402,7 @@ class TestGetGraphUsageAnalytics:
       rm_patch,
     ):
       with pytest.raises(HTTPException) as exc_info:
-        await get_graph_usage_analytics(
+        await get_graph_usage(
           graph_id="kg01234567890abcdef",
           time_range="30d",
           include_storage=False,

--- a/uv.lock
+++ b/uv.lock
@@ -3699,7 +3699,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.34.2,<3.0" },
     { name = "retrying", specifier = ">=1.4.0,<2.0" },
     { name = "rich", marker = "extra == 'dev'", specifier = ">=15.0.0,<16.0" },
-    { name = "robosystems-client", marker = "extra == 'dev'", specifier = "==0.5.3" },
+    { name = "robosystems-client", marker = "extra == 'dev'", specifier = "==0.5.8" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0,<1.0" },
     { name = "sqlalchemy", specifier = ">=2.0.0,<3.0" },
     { name = "sse-starlette", specifier = ">=3.3.0,<4.0" },
@@ -3722,7 +3722,7 @@ lambda = [
 
 [[package]]
 name = "robosystems-client"
-version = "0.5.3"
+version = "0.5.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -3730,9 +3730,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b2/c6/42f874018af79d5f98095f27ad9bdf6579e8b4b3cd24feedb9be0dcfa9f3/robosystems_client-0.5.3.tar.gz", hash = "sha256:1ce8eb8824f6d4b233c45085bcf45925fac5ca5ab12c14faf65b5094022cf32d", size = 411720, upload-time = "2026-07-19T06:56:48.499Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a7/4c/4ce4c66d459a7e505bb1affa582b3ba0dd4d2e8227e60a8bf02831741fc2/robosystems_client-0.5.8.tar.gz", hash = "sha256:c0d8266db43f5791e40b302e74fc936da4a57565a91850f5fb18f1927bf75e70", size = 438327, upload-time = "2026-07-26T06:42:01.446Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/68/cd/97962742e6dbddf045fec89a609649eb8e4c53800d42d13aed59784c64fb/robosystems_client-0.5.3-py3-none-any.whl", hash = "sha256:6206c05cbb070654dfc489c9e5bd0f4de8cb43dbccfcb3d169d1f8fb2dc2708f", size = 963972, upload-time = "2026-07-19T06:56:47.009Z" },
+    { url = "https://files.pythonhosted.org/packages/96/b8/3bb2d09661408595b62ca9a8a8bed9062791de64704b3f68fa1740041087/robosystems_client-0.5.8-py3-none-any.whl", hash = "sha256:8e11546d3d624998522f3aad53b73639f8ef702a46695e66a1d10ac8a8c9f340", size = 1032056, upload-time = "2026-07-26T06:41:59.671Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Three related pieces of the graph capacity surface — **name it, measure it, surface it.**

1. The two routes under `/v1/graphs/{graph_id}/analytics` answer different questions and neither is analytics, so they move to `/metrics` (what is *in* the graph) and `/usage` (what it *consumed*).
2. Instance CPU and memory become visible to the owner of a dedicated graph — filling a `memory_usage_mb` field that had been declared and hardcoded `None` since the health endpoint was written.
3. **Storage stops reporting `0.00 GB`**, and starts counting what a graph actually occupies.

## 1. Endpoint rename

| Before | After | operation_id |
| --- | --- | --- |
| `/v1/graphs/{graph_id}/analytics` | `/v1/graphs/{graph_id}/metrics` | `getGraphMetrics` — unchanged |
| `/v1/graphs/{graph_id}/analytics/usage` | `/v1/graphs/{graph_id}/usage` | `getGraphUsageAnalytics` → `getGraphUsage` |

- `getGraphMetrics` keeps its `operation_id` on purpose: robosystems-app consumes the raw generated client by method name, so the dashboard call site needs no change — only an SDK regen. `getGraphUsageAnalytics` is renamed because it has no consumers.
- The file was already `usage.py` and the router already tagged `Usage`; only the URL prefix was stale.
- **The telemetry already claimed the new name** across eight call sites — a path that did not exist, so anything keyed on it recorded against a phantom route. Those labels are now true and pulled into module constants so they cannot drift again.
- `config/rate_limits.py` matched the literal `"analytics"` segment to assign `GRAPH_ANALYTICS`. Left alone, both endpoints would have silently dropped into the generic bucket — the same class of bug the comment above that branch already records happening once before.

## 2. Instance resources

- `DatabaseHealthResponse` gains `cpu_usage_percent`, `memory_usage_percent`, `resource_status`; `memory_usage_mb` is now populated. Source is the live psutil reading the node already serves at `/metrics` — no new IAM, no CloudWatch call, works in local dev.
- Guarded by `NOT is_shared_repository(graph_id) AND databases_per_instance == 1`. Both halves are required: shared repositories run one database per box but are read by every tenant, and a packed tier co-locates tenants by construction. Driving the second half off the tier’s `databases_per_instance` rather than a tier allowlist means any future packed tier closes this automatically.
- `resource_status` exists because raw numbers invite false alarms: materialization deliberately boosts toward the whole instance, so every sync and close would show memory in the 90s. `constrained` is anchored to the **admission controller’s own thresholds** — where the node starts shedding work — so it means something actionable. A boost below that reads as `busy`.
- Best-effort: the health check still succeeds, fields null, if the node is unreachable.

## 3. Storage — two stacked bugs, then an undercount

Storage read `0.00 GB` everywhere, and it took **two independent bugs** to get there. Fixing either alone still reports zero:

- **Producer**: `get_database_info` sized a database with `st_size if db_path.is_file() else 0`, so a **directory-shaped** LadybugDB database measured 0 by construction. Both shapes exist — the metrics collector already handled each.
- **Reader**: `/info` and `/limits` read `database_size_bytes` from a Graph API that emits `size_bytes`.

Fixing only those would trade a zero for an undercount, because a graph’s footprint was never just its `.lbug` file. It spans three instance-local roots, and the pieces outside the primary database routinely outweigh it — **staging alone is frequently larger than the graph**. So this adds one itemized measure every consumer reads:

```
GET /databases/{graph_id}/storage
-> {total_bytes, items: [{type, id, bytes}]}
```

covering the graph, its memory database, subgraphs and their WALs, the LanceDB vector indexes, and the DuckDB staging file. S3 backups are off-instance and excluded.

**Three surfaces that disagreed now read the same number**: `/limits` `storage`, `/limits` `instance_usage`, and cap enforcement. `instance_usage` also gains itemized `items` — which its docstring already claimed to cover.

Enforcement gets more accurate as a side effect: the cap denominator now includes memory, vectors and staging, so it reflects real COGS.

Also removes an **N+1** — `check_instance_storage` made one Graph API call per subgraph. Subgraphs live on their parent’s instance, so one breakdown itemizes them all, and it catches on-disk leftovers the graph registry has lost track of.

## Housekeeping

- `robosystems-client` 0.5.3 → 0.5.8 (dev-only, used by `examples/`; no demo calls the renamed function).
- A `.vscode` upgrade task.

## Testing

- **Storage**: 14 tests — directory-shaped sizing (the regression that mattered), the total spanning all three roots, staging exceeding the graph, WAL folding, tenant isolation, the `_` prefix boundary (`kg1abc` must not swallow `kg1abcdef`), missing roots, and path-traversal rejection.
- **Instance resources**: 20 tests — both halves of the exposure guard, the status derivation (including that a materialization boost reads `busy`, not `constrained`), and the handler asserting a shared repository **never issues the call** rather than filtering after.
- **Enforcement**: `check_instance_storage` tests rebased on the single-call shape, plus per-database type roll-up and graceful degradation when the node is unreachable.
- `just test-code`: all checks passed. Full unit suite: **11,359 passed** (one pre-existing local-env pyarrow failure in `test_incremental_materialize.py` excluded — verified to reproduce on a clean tree at `origin/main`).

## Notes

- No migration, no config change. The rename itself is behaviour-neutral; storage is the one behaviour change, and it changes a number from wrong to right.
- SDKs are already published against this: `robosystems-client` 0.5.8 (PyPI), `@robosystems/client` 0.5.10 (npm). **Both point at the renamed routes, so this should merge and deploy before anything adopts them.**
- Frontend companion: RoboFinSystems/robosystems-app#223 (instance resources card + client bump). It should land after this deploys.
- Remaining from the metering plan: persisting snapshots for historical gb-hours, and the CloudWatch-backed resource *trend*. Both are additive on top of this measure.