### PR TITLE
fix(metrics): measure graph storage instead of guessing it

### DIFF
--- a/robosystems/models/api/graphs/metrics.py
+++ b/robosystems/models/api/graphs/metrics.py
@@ -18,7 +18,15 @@ class GraphMetricsResponse(BaseModel):
   relationship_counts: dict[str, int] = Field(
     ..., description="Relationship counts by type"
   )
-  estimated_size: dict[str, Any] = Field(..., description="Database size estimates")
+  storage: dict[str, Any] = Field(
+    ...,
+    description=(
+      "Measured on-disk storage: total_bytes/kb/mb/gb plus itemized `items` "
+      "(graph, memory, subgraph, vectors, staging). Carries `error` instead "
+      "if the instance could not be reached — the fields are absent rather "
+      "than estimated."
+    ),
+  )
   health_status: dict[str, Any] = Field(..., description="Database health information")
 
 

--- a/robosystems/operations/graph/metrics_service.py
+++ b/robosystems/operations/graph/metrics_service.py
@@ -18,7 +18,6 @@ class GraphMetricsService:
 
   # Configuration constants
   DEFAULT_GRAPH_LIMIT = 5
-  DEFAULT_NODE_SIZE_ESTIMATE = 150  # bytes per node for size estimation
 
   def __init__(self):
     self.metrics_instance = get_endpoint_metrics()
@@ -47,7 +46,7 @@ class GraphMetricsService:
         "relationship_counts": await self._get_relationship_counts_by_type(repository),
         "total_nodes": 0,
         "total_relationships": 0,
-        "estimated_size": await self._estimate_database_size(repository),
+        "storage": await self._get_storage(graph_id),
         "health_status": await self._check_graph_health(repository),
       }
 
@@ -303,49 +302,39 @@ class GraphMetricsService:
         logger.warning(f"Fallback relationship count also failed: {fallback_e}")
         return {"_total": 0}  # Return 0 instead of string to avoid type issues
 
-  async def _estimate_database_size(self, repository) -> dict[str, Any]:
-    """Estimate database storage usage."""
+  async def _get_storage(self, graph_id: str) -> dict[str, Any]:
+    """Measured on-disk storage for a graph and everything it owns.
+
+    Replaces a ``node_count * 100 bytes`` heuristic that reported roughly
+    7 KB for a real 1 MB graph. The measure spans the LadybugDB databases,
+    vector indexes and staging file, so it reflects actual occupied disk
+    rather than a guess derived from node count.
+    """
+    from robosystems.graph_api.client.factory import GraphClientFactory
+
     try:
-      # Try to get database size information with fallback strategies
-      size_queries = [
-        # Try to get database size information (LadybugDB doesn't have JMX, skip this)
-        # "CALL dbms.queryJmx('...') YIELD attributes RETURN attributes",
-        # Simple fallback with estimation
-        "MATCH (n) RETURN count(n) as nodeCount, count(n) * 100 as estimatedBytes",
-      ]
-
-      for query in size_queries:
-        try:
-          result = await repository.execute_query(query)
-          records = list(result)
-          if records:
-            return {"size_info": dict(records[0]), "method": "database_query"}
-        except Exception as query_error:
-          logger.debug(f"Size query failed: {query_error}")
-          continue
-
-      # Final fallback - basic estimation
+      client = await GraphClientFactory.create_client(
+        graph_id=graph_id, operation_type="read"
+      )
       try:
-        result = await repository.execute_query("MATCH (n) RETURN count(n) as total")
-        node_count = result[0]["total"] if result else 0
-      except Exception as count_e:
-        logger.debug(f"Node count estimation failed: {count_e}")
-        node_count = 0
-      estimated_bytes = (
-        node_count * self.DEFAULT_NODE_SIZE_ESTIMATE
-      )  # Configurable estimate per node
+        breakdown = await client.get_storage_breakdown(graph_id)
+      finally:
+        await client.close()
 
+      total_bytes = breakdown.get("total_bytes", 0)
       return {
-        "estimated_bytes": estimated_bytes,
-        "estimated_kb": estimated_bytes / 1024,
-        "estimated_mb": estimated_bytes / (1024 * 1024),
-        "method": "estimation",
-        "note": "Based on node count estimation",
+        "total_bytes": total_bytes,
+        "total_kb": total_bytes / 1024,
+        "total_mb": total_bytes / (1024 * 1024),
+        "total_gb": total_bytes / (1024**3),
+        "items": breakdown.get("items", []),
       }
 
     except Exception as e:
-      logger.warning(f"Failed to estimate database size: {e}")
-      return {"error": "Unable to estimate size", "method": "failed"}
+      # Degrade to an absent measure rather than a fabricated one — a missing
+      # number is honest, a made-up number is what this replaced.
+      logger.warning(f"Failed to measure storage for {graph_id}: {e}")
+      return {"error": "Unable to measure storage"}
 
   async def _check_graph_health(self, repository) -> dict[str, Any]:
     """Check graph database health status."""
@@ -364,15 +353,15 @@ class GraphMetricsService:
       # Record node and relationship counts as gauges
       if "error" not in metrics:
         # Record graph metrics
-        estimated_size = metrics.get("estimated_size", {}).get("estimated_bytes", 0)
-        if not isinstance(estimated_size, int):
-          estimated_size = 0
+        storage_bytes = metrics.get("storage", {}).get("total_bytes", 0)
+        if not isinstance(storage_bytes, int):
+          storage_bytes = 0
 
         self.metrics_instance.record_graph_metrics(
           graph_id=graph_id,
           node_count=metrics.get("total_nodes", 0),
           relationship_count=metrics.get("total_relationships", 0),
-          estimated_size_bytes=estimated_size,
+          estimated_size_bytes=storage_bytes,
           additional_attributes={
             "node_label_count": len(metrics.get("node_counts", {})),
             "relationship_type_count": len(metrics.get("relationship_counts", {})),

--- a/tests/operations/graph/test_metrics_service.py
+++ b/tests/operations/graph/test_metrics_service.py
@@ -59,9 +59,9 @@ class TestCollectMetricsForGraph:
       ),
       patch.object(
         metrics_service,
-        "_estimate_database_size",
+        "_get_storage",
         new_callable=AsyncMock,
-        return_value={"estimated_bytes": 2250},
+        return_value={"total_bytes": 2250},
       ),
       patch.object(
         metrics_service,
@@ -310,31 +310,78 @@ class TestGetRelationshipCountsByType:
     assert result == {"_total": 20}
 
 
-class TestEstimateDatabaseSize:
-  @pytest.mark.asyncio
-  @pytest.mark.unit
-  async def test_query_success(self, metrics_service, mock_repository):
-    mock_repository.execute_query = AsyncMock(
-      return_value=[{"nodeCount": 100, "estimatedBytes": 10000}]
-    )
+class TestGetStorage:
+  """Storage is measured, never estimated.
 
-    result = await metrics_service._estimate_database_size(mock_repository)
-    assert result["method"] == "database_query"
-    assert result["size_info"]["nodeCount"] == 100
+  Replaces TestEstimateDatabaseSize, whose subject was a node-count
+  heuristic. The tests that matter now are that the real measure is
+  reported faithfully, and that an unreachable instance yields no number
+  rather than a plausible-looking one.
+  """
 
   @pytest.mark.asyncio
   @pytest.mark.unit
-  async def test_fallback_estimation(self, metrics_service, mock_repository):
-    mock_repository.execute_query = AsyncMock(
-      side_effect=[
-        Exception("query not supported"),
-        [{"total": 100}],
-      ]
+  async def test_reports_the_measured_total(self, metrics_service):
+    client = AsyncMock()
+    client.get_storage_breakdown = AsyncMock(
+      return_value={
+        "graph_id": MOCK_GRAPH_ID,
+        "total_bytes": 3145728,
+        "items": [{"type": "graph", "id": MOCK_GRAPH_ID, "bytes": 3145728}],
+      }
     )
 
-    result = await metrics_service._estimate_database_size(mock_repository)
-    assert result["method"] == "estimation"
-    assert result["estimated_bytes"] == 100 * 150
+    with patch(
+      "robosystems.graph_api.client.factory.GraphClientFactory.create_client",
+      new_callable=AsyncMock,
+      return_value=client,
+    ):
+      result = await metrics_service._get_storage(MOCK_GRAPH_ID)
+
+    assert result["total_bytes"] == 3145728
+    assert result["total_mb"] == 3.0
+    assert result["items"][0]["type"] == "graph"
+    client.close.assert_awaited_once()
+
+  @pytest.mark.asyncio
+  @pytest.mark.unit
+  async def test_carries_the_itemized_breakdown(self, metrics_service):
+    """The dashboard can show where the bytes went, not just how many."""
+    client = AsyncMock()
+    client.get_storage_breakdown = AsyncMock(
+      return_value={
+        "total_bytes": 300,
+        "items": [
+          {"type": "graph", "id": MOCK_GRAPH_ID, "bytes": 100},
+          {"type": "vectors", "id": MOCK_GRAPH_ID, "bytes": 50},
+          {"type": "staging", "id": MOCK_GRAPH_ID, "bytes": 150},
+        ],
+      }
+    )
+
+    with patch(
+      "robosystems.graph_api.client.factory.GraphClientFactory.create_client",
+      new_callable=AsyncMock,
+      return_value=client,
+    ):
+      result = await metrics_service._get_storage(MOCK_GRAPH_ID)
+
+    assert {i["type"] for i in result["items"]} == {"graph", "vectors", "staging"}
+    assert sum(i["bytes"] for i in result["items"]) == result["total_bytes"]
+
+  @pytest.mark.asyncio
+  @pytest.mark.unit
+  async def test_unreachable_instance_reports_no_number(self, metrics_service):
+    """A missing measure is honest; a fabricated one is what this replaced."""
+    with patch(
+      "robosystems.graph_api.client.factory.GraphClientFactory.create_client",
+      new_callable=AsyncMock,
+      side_effect=RuntimeError("node unreachable"),
+    ):
+      result = await metrics_service._get_storage(MOCK_GRAPH_ID)
+
+    assert "error" in result
+    assert "total_bytes" not in result
 
 
 class TestCheckGraphHealth:
@@ -373,7 +420,7 @@ class TestRecordOtelMetrics:
       "total_relationships": 50,
       "node_counts": {"Person": 100},
       "relationship_counts": {"WORKS_AT": 50},
-      "estimated_size": {"estimated_bytes": 15000},
+      "storage": {"total_bytes": 15000},
       "health_status": {"status": "healthy"},
     }
 
@@ -391,7 +438,7 @@ class TestRecordOtelMetrics:
       "total_relationships": 50,
       "node_counts": {},
       "relationship_counts": {},
-      "estimated_size": {},
+      "storage": {},
       "health_status": {},
     }
 

--- a/tests/routers/graphs/test_usage.py
+++ b/tests/routers/graphs/test_usage.py
@@ -142,7 +142,14 @@ class TestGetGraphMetrics:
       "total_nodes": 1000,
       "total_relationships": 5000,
       "timestamp": "2024-06-15T00:00:00Z",
-      "estimated_size": {"nodes_bytes": 50000, "relationships_bytes": 100000},
+      "storage": {
+        "total_bytes": 3101581,
+        "total_mb": 2.96,
+        "items": [
+          {"type": "graph", "id": "kg01234567890abcdef", "bytes": 1159258},
+          {"type": "staging", "id": "kg01234567890abcdef", "bytes": 1847296},
+        ],
+      },
       "health_status": {"status": "healthy", "last_check": "2024-06-15T00:00:00Z"},
       "node_counts": {"Entity": 500, "Report": 300},
       "relationship_counts": {"FILED": 200},


### PR DESCRIPTION
## Summary

Removes the last fabricated number on the platform. `collect_metrics_for_graph` reported storage as `node_count * 100 bytes` — roughly **7 KB for a real 1 MB graph** — via a fallback chain that ended in a *second, differently wrong* estimate at 150 bytes per node. It now reads the itemized measure added in #937.

Closes the remaining half of P2 in the graph-capacity plan.

## Changes

- `_estimate_database_size` → `_get_storage`, reading `GraphClient.get_storage_breakdown`. The figure now spans the graph, its memory database, subgraphs, vector indexes and staging file rather than approximating one of them.
- Response field `estimated_size` → **`storage`**: nothing is estimated any more and the old name would have kept implying otherwise. Carries `total_bytes/kb/mb/gb` plus the itemized `items`.
- An unreachable instance returns `{"error": ...}` with **no total**, rather than falling back to an estimate. A missing number is honest; a plausible-looking wrong one is what this replaces.
- Drops `DEFAULT_NODE_SIZE_ESTIMATE`, now unused.

## Where the guess was actually going

Worth stating, because the spec and I both had this wrong: **it was never rendered.** `dashboard/content.tsx` displays only `total_nodes` / `total_relationships` and never read the field. The fiction went to two places instead:

1. the API response, for any SDK consumer, and
2. **OTel `record_graph_metrics`** — whose graph-size gauge has therefore been accumulating invented bytes.

That is arguably a worse destination than a UI card: nobody was looking at it, so nothing ever contradicted it. The gauge now receives measured bytes.

It also means the rename is **not a breaking change for robosystems-app** — the predicted coordinated app PR turned out to be unnecessary. The app-side work that *was* needed is unit formatting, shipped separately in RoboFinSystems/robosystems-app#224.

## Testing

- `TestEstimateDatabaseSize` replaced by `TestGetStorage`: the measured total is reported faithfully, the itemized breakdown is carried through, and an unreachable instance yields no number rather than a plausible one.
- Fixtures updated in `test_metrics_service.py` and `test_usage.py`.
- `just test-code`: all checks passed. Full unit suite: **11,360 passed** (one pre-existing local-env pyarrow failure in `test_incremental_materialize.py` excluded — reproduces on clean `origin/main`).

## Notes

- Needs an SDK regen + release; `storage` replaces `estimated_size` in `GraphMetricsResponse`.
- `models/api/graphs/query.py` still holds a **dead duplicate** `GraphMetricsResponse` with the old field name — shadowed by the `metrics.py` one the package actually exports. Left alone here to keep this focused, but it is a confusing thing to leave lying around and worth deleting separately.
- Remaining in the plan after this: P3/P4 (persistence + gb-hours, demand-pulled — no storage billing yet) and the P5 CloudWatch trend.