### PR TITLE
fix(shared): stop scanning shared repositories on read paths

### DIFF
--- a/robosystems/graph_api/client/client.py
+++ b/robosystems/graph_api/client/client.py
@@ -1322,17 +1322,26 @@ class GraphClient(BaseGraphClient):
     response = await self._request("GET", f"/databases/{graph_id}")
     return response.json()
 
-  async def get_database_metrics(self, graph_id: str) -> dict[str, Any]:
+  async def get_database_metrics(
+    self, graph_id: str, include_counts: bool = False
+  ) -> dict[str, Any]:
     """
-    Get metrics for a specific database (optimized for billing).
+    Get size and modification metrics for a specific database.
 
     Args:
         graph_id: Database to get metrics for
+        include_counts: Also compute node/relationship counts. These are full
+            graph scans — tens of seconds on a large database — so they are
+            off by default and come back as None. Only pass True off a
+            latency path.
 
     Returns:
-        Database metrics including size, counts, and timestamps
+        Database metrics including size and timestamps
     """
-    response = await self._request("GET", f"/databases/{graph_id}/metrics")
+    params = {"include_counts": "true"} if include_counts else None
+    response = await self._request(
+      "GET", f"/databases/{graph_id}/metrics", params=params
+    )
     return response.json()
 
   async def get_metrics(self) -> dict[str, Any]:

--- a/robosystems/graph_api/routers/databases/metrics.py
+++ b/robosystems/graph_api/routers/databases/metrics.py
@@ -10,7 +10,7 @@ import os
 from pathlib import Path
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi import Path as PathParam
 from fastapi import status as http_status
 
@@ -25,18 +25,26 @@ router = APIRouter(prefix="/databases", tags=["Metrics"])
 @router.get("/{graph_id}/metrics")
 async def get_database_metrics(
   graph_id: str = PathParam(..., description="Graph database identifier"),
+  include_counts: bool = Query(
+    False,
+    description=(
+      "Compute node and relationship counts. Off by default: these are full "
+      "graph scans, and on a large database they take tens of seconds."
+    ),
+  ),
   service=Depends(get_ladybug_service),
 ) -> dict[str, Any]:
   """
   Get metrics for a specific database.
 
-  Returns metrics specifically for billing and monitoring:
-  - Database size in bytes
-  - Node and relationship counts
-  - Last modified timestamp
-  - Database tier information
+  Returns size and modification metadata, which is what callers on a latency
+  path need. `node_count` / `relationship_count` are **opt-in** via
+  `include_counts` and are `None` otherwise.
 
-  This endpoint is optimized for per-database billing collection.
+  The counts are `MATCH (n) RETURN count(n)` and its relationship equivalent —
+  full scans with no index to lean on. On the SEC repository (~110 GB) that
+  exceeded 30s and timed out the caller, so the cost is explicit rather than
+  a default anyone can wander into.
   """
   try:
     validated_graph_id = validate_database_name(graph_id)
@@ -52,25 +60,26 @@ async def get_database_metrics(
     # Get database info from manager
     db_info = service.db_manager.get_database_info(validated_graph_id)
 
-    # Get node and relationship counts via Cypher
-    node_count = 0
-    relationship_count = 0
-    try:
-      from robosystems.graph_api.core.ladybug import get_connection_pool
+    # Node and relationship counts are full scans — opt-in only.
+    node_count = None
+    relationship_count = None
+    if include_counts:
+      try:
+        from robosystems.graph_api.core.ladybug import get_connection_pool
 
-      pool = get_connection_pool()
-      with pool.get_connection(validated_graph_id, read_only=True) as conn:
-        result = conn.execute("MATCH (n) RETURN count(n) as count")
-        if result.has_next():
-          node_count = result.get_next()[0]
-        result.close()
+        pool = get_connection_pool()
+        with pool.get_connection(validated_graph_id, read_only=True) as conn:
+          result = conn.execute("MATCH (n) RETURN count(n) as count")
+          if result.has_next():
+            node_count = result.get_next()[0]
+          result.close()
 
-        result = conn.execute("MATCH ()-[r]->() RETURN count(r) as count")
-        if result.has_next():
-          relationship_count = result.get_next()[0]
-        result.close()
-    except Exception as e:
-      logger.warning(f"Failed to get graph counts for {validated_graph_id}: {e}")
+          result = conn.execute("MATCH ()-[r]->() RETURN count(r) as count")
+          if result.has_next():
+            relationship_count = result.get_next()[0]
+          result.close()
+      except Exception as e:
+        logger.warning(f"Failed to get graph counts for {validated_graph_id}: {e}")
 
     # Get modification time
     last_modified = None

--- a/robosystems/routers/graphs/limits.py
+++ b/robosystems/routers/graphs/limits.py
@@ -122,28 +122,41 @@ async def get_graph_limits(
     # and with cap enforcement — all three previously disagreed, and this one
     # read a field name the Graph API never emitted, so it was always 0.
     max_storage_gb = GraphTierConfig.get_instance_storage_limit_gb(graph_tier)
-    storage_limits = {}
-    try:
-      graph_client = await _get_graph_client(graph_id)
-      breakdown = await asyncio.wait_for(
-        graph_client.get_storage_breakdown(graph_id), timeout=10
-      )
-      await graph_client.close()
+    storage_limits = {
+      "current_usage_gb": None,
+      "max_storage_gb": max_storage_gb,
+      "approaching_limit": False,
+    }
 
-      current_storage_gb = breakdown.get("total_bytes", 0) / (1024**3)
+    # Shared repositories are measured for their tier limit only. Three
+    # reasons not to compute their live footprint:
+    #
+    # - There is nothing to enforce. The tenant does not own a shared
+    #   repository's size and cannot act on it, which is why `instance_usage`
+    #   below is already skipped for them.
+    # - It would be measured on a read replica, which serves the repository
+    #   over S3 ATTACH with no data volume — so local disk is a cache, not the
+    #   repository. The number would be wrong as well as expensive.
+    # - It is expensive in a place that hurts. A shared repository is large
+    #   (SEC is ~110 GB) and its replicas serve every tenant, so a recursive
+    #   walk per request is a latency hazard on shared infrastructure.
+    if not is_shared:
+      try:
+        graph_client = await _get_graph_client(graph_id)
+        breakdown = await asyncio.wait_for(
+          graph_client.get_storage_breakdown(graph_id), timeout=10
+        )
+        await graph_client.close()
 
-      storage_limits = {
-        "current_usage_gb": round(current_storage_gb, 2),
-        "max_storage_gb": max_storage_gb,
-        "approaching_limit": current_storage_gb > (max_storage_gb * 0.8),
-      }
-    except Exception as e:
-      logger.warning(f"Could not get storage info for {graph_id}: {e}")
-      storage_limits = {
-        "current_usage_gb": None,
-        "max_storage_gb": max_storage_gb,
-        "approaching_limit": False,
-      }
+        current_storage_gb = breakdown.get("total_bytes", 0) / (1024**3)
+
+        storage_limits = {
+          "current_usage_gb": round(current_storage_gb, 2),
+          "max_storage_gb": max_storage_gb,
+          "approaching_limit": current_storage_gb > (max_storage_gb * 0.8),
+        }
+      except Exception as e:
+        logger.warning(f"Could not get storage info for {graph_id}: {e}")
 
     # Get copy/ingestion limits from tier configuration (based on graph tier)
     copy_limits = get_tier_copy_operation_limits(graph_tier)

--- a/tests/graph_api/test_databases_metrics.py
+++ b/tests/graph_api/test_databases_metrics.py
@@ -65,7 +65,7 @@ class TestDatabaseMetricsRouter:
         "robosystems.graph_api.core.ladybug.get_connection_pool",
         return_value=mock_pool,
       ):
-        result = await get_database_metrics("test-db", mock_service)
+        result = await get_database_metrics("test-db", service=mock_service)
 
       assert result["graph_id"] == "test-db"
       assert result["database_name"] == "test-db"
@@ -78,13 +78,93 @@ class TestDatabaseMetricsRouter:
       assert result["instance_id"] == "test-instance-01"
       assert result["node_type"] == "writer"
 
+  def _stub_counts(self, tmpdir, mock_service, size=3072):
+    """Wire a service whose count queries would succeed if they were run."""
+    db_path = Path(tmpdir) / "test-db.lbug"
+    db_path.write_bytes(b"x" * size)
+    mock_service.db_manager.base_path = Path(tmpdir)
+    mock_service.db_manager.list_databases.return_value = ["test-db"]
+    mock_service.db_manager.get_database_info.return_value = DatabaseInfo(
+      graph_id="test-db",
+      database_path=str(db_path),
+      created_at="2024-01-01T00:00:00",
+      size_bytes=size,
+      read_only=False,
+      is_healthy=True,
+    )
+
+    mock_conn = MagicMock()
+    node_result = MagicMock()
+    node_result.has_next.return_value = True
+    node_result.get_next.return_value = [100]
+    rel_result = MagicMock()
+    rel_result.has_next.return_value = True
+    rel_result.get_next.return_value = [250]
+    mock_conn.execute.side_effect = [node_result, rel_result]
+
+    pool = MagicMock()
+    pool.get_connection.return_value.__enter__ = MagicMock(return_value=mock_conn)
+    pool.get_connection.return_value.__exit__ = MagicMock(return_value=False)
+    return pool, mock_conn
+
+  @pytest.mark.asyncio
+  async def test_counts_are_skipped_unless_requested(self, mock_service):
+    """The scans must not run by default.
+
+    `MATCH (n) RETURN count(n)` has no index to lean on; on the SEC
+    repository it exceeded 30s and timed out `/health`, which is why the
+    cost is opt-in.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+      pool, mock_conn = self._stub_counts(tmpdir, mock_service)
+
+      with patch(
+        "robosystems.graph_api.core.ladybug.get_connection_pool", return_value=pool
+      ):
+        result = await get_database_metrics(
+          "test-db", include_counts=False, service=mock_service
+        )
+
+      assert result["node_count"] is None
+      assert result["relationship_count"] is None
+      assert result["size_bytes"] == 3072
+      # The expensive part is not merely discarded — it never runs.
+      mock_conn.execute.assert_not_called()
+
+  @pytest.mark.asyncio
+  async def test_counts_computed_when_requested(self, mock_service):
+    with tempfile.TemporaryDirectory() as tmpdir:
+      pool, _ = self._stub_counts(tmpdir, mock_service)
+
+      with patch(
+        "robosystems.graph_api.core.ladybug.get_connection_pool", return_value=pool
+      ):
+        result = await get_database_metrics(
+          "test-db", include_counts=True, service=mock_service
+        )
+
+      assert result["node_count"] == 100
+      assert result["relationship_count"] == 250
+
+  def test_openapi_default_is_off(self):
+    """Guard the default through FastAPI, not just the Python signature."""
+    from robosystems.graph_api.routers.databases.metrics import router
+
+    route = next(
+      r
+      for r in router.routes
+      if getattr(r, "path", "") == "/databases/{graph_id}/metrics"
+    )
+    param = next(p for p in route.dependant.query_params if p.name == "include_counts")
+    assert param.default is False
+
   @pytest.mark.asyncio
   async def test_get_database_metrics_not_found(self, mock_service):
     """Test metrics retrieval for non-existent database."""
     mock_service.db_manager.list_databases.return_value = ["other-db"]
 
     with pytest.raises(HTTPException) as exc_info:
-      await get_database_metrics("non-existent-db", mock_service)
+      await get_database_metrics("non-existent-db", service=mock_service)
 
     assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
     assert "not found" in exc_info.value.detail
@@ -93,7 +173,7 @@ class TestDatabaseMetricsRouter:
   async def test_get_database_metrics_invalid_name(self, mock_service):
     """Test metrics retrieval with invalid database name."""
     with pytest.raises(HTTPException) as exc_info:
-      await get_database_metrics("test/db", mock_service)
+      await get_database_metrics("test/db", service=mock_service)
 
     assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
 
@@ -103,7 +183,7 @@ class TestDatabaseMetricsRouter:
     mock_service.db_manager.list_databases.side_effect = Exception("Unexpected error")
 
     with pytest.raises(HTTPException) as exc_info:
-      await get_database_metrics("test-db", mock_service)
+      await get_database_metrics("test-db", service=mock_service)
 
     assert exc_info.value.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
     assert "Failed to retrieve database metrics" in exc_info.value.detail
@@ -145,6 +225,6 @@ class TestDatabaseMetricsRouter:
           return_value=False
         )
 
-        result = await get_database_metrics("shared-db", mock_service)
+        result = await get_database_metrics("shared-db", service=mock_service)
 
       assert result["node_type"] == "shared_master"


### PR DESCRIPTION
## Summary

Two production faults on the SEC repository, both the same shape: asking a very large graph an expensive question on a latency path.

Observed in prod after `v1.6.12`:

```
GET /v1/graphs/sec/credits  - 200 (77.94ms)
GET /v1/graphs/sec/limits   - 200 (182.25ms)
GET /v1/graphs/sec/health   - 408 (30095.16ms)   <- 30s page load
```

## 1. `/health` timing out at 30s

`/health` calls `get_database_metrics`, which ran `MATCH (n) RETURN count(n)` and its relationship equivalent — **full scans with no index to lean on** — against a ~110 GB graph.

**Neither caller ever used the counts.** `health.py` reads `last_modified` + `size_mb`; `subgraphs/main.py` reads `size_mb`. Both paid for two full scans and discarded them.

Counts are now **opt-in** via `include_counts` (default off, `None` when not computed), so the cost is explicit rather than something the next caller wanders into.

## 2. `/limits` logging `Could not get storage info for sec: Not Found`

The storage breakdown is measured per graph, and shared repositories were not excluded. They are now, for three reasons — only the first of which is the reported symptom:

- **Nothing to enforce.** There is no tier cap against a repository the tenant does not own. This is already why `instance_usage` is skipped for them; the sibling block was simply inconsistent.
- **It would measure the wrong thing.** Replicas serve via **S3 ATTACH with no data volume**, so local disk is a cache, not the repository.
- **It would hurt.** A recursive walk of a 110 GB graph, on a replica serving every tenant, is a latency hazard on shared infrastructure.

### The 404 was not a code fault

The shared replica is running an image that predates the `/storage` route — its graph-api started `2026-07-25T07:16`, over a day before the `v1.6.12` deploy. Routers are not node-type gated, so a refreshed replica would have the route.

> [!NOTE]
> **An ASG refresh would have "resolved" the 404 by replacing it with the recursive walk above.** Excluding shared repositories removes the need for the refresh either way — worth knowing before anyone reaches for `graph-asg-refresh.yml` on the strength of the 404 alone.

## Testing

- New: counts are skipped unless requested — asserting `mock_conn.execute` is **never called**, so the expensive part does not merely get discarded; counts still computed when requested; and the FastAPI default is guarded via `route.dependant`, not just the Python signature (calling the handler directly leaves `include_counts` as a truthy `Query` object, which would have hidden a regression).
- Existing metrics tests moved to keyword args — they bound `mock_service` positionally, which the new parameter would have silently swallowed.
- `just test-code`: all checks passed. Full unit suite: **11,363 passed** run with `-p no:randomly` (two earlier runs each failed a *different* unrelated module — `test_graph_table`, `test_customer` — both passing in isolation; random-order flakes, not this change).

## Notes

- No API contract change for existing consumers on the platform side; `include_counts` is additive on the internal graph API.
- **Optional follow-up, not included**: the usage page still calls `getDatabaseHealth` for repositories. Now cheap, so harmless, but it fetches something `!isRepository` guarantees will not render — a one-line guard in robosystems-app.
- **Unrelated pre-existing bug found while verifying**: `limits.py:227` reads `db_info.get("node_count")` from `get_database_info`, but `DatabaseInfo` has no `node_count` field — so `InstanceUsage.node_count` has always been `null`. Untouched here; flagging rather than folding in.