### PR TITLE
fix(billing): preview the subscription, not the customer

### DIFF
--- a/robosystems/operations/providers/payment_provider.py
+++ b/robosystems/operations/providers/payment_provider.py
@@ -112,11 +112,16 @@ class PaymentProvider(ABC):
     pass
 
   @abstractmethod
-  def get_upcoming_invoice(self, customer_id: str) -> dict[str, Any] | None:
-    """Get the upcoming invoice for a customer.
+  def get_upcoming_invoice(
+    self, customer_id: str, subscription_id: str
+  ) -> dict[str, Any] | None:
+    """Get the upcoming invoice for a customer's subscription.
 
     Args:
         customer_id: Provider customer ID
+        subscription_id: Provider subscription ID to preview. Required —
+            an upcoming invoice is a property of a subscription, not of a
+            customer, so there is nothing to preview without one.
 
     Returns:
         Upcoming invoice details or None if no upcoming invoice
@@ -602,11 +607,22 @@ class StripePaymentProvider(PaymentProvider):
       logger.error(f"Failed to list invoices: {e}", exc_info=True)
       raise
 
-  def get_upcoming_invoice(self, customer_id: str) -> dict[str, Any] | None:
-    """Get the upcoming invoice for a Stripe customer."""
+  def get_upcoming_invoice(
+    self, customer_id: str, subscription_id: str
+  ) -> dict[str, Any] | None:
+    """Get the upcoming invoice for a Stripe subscription.
+
+    `Invoice.create_preview` previews a *subscription*, not a customer.
+    Called with only `customer` it returns 400 every time — Stripe requires
+    one of subscription / schedule / subscription_details.items /
+    schedule_details.phases / invoice_items — so passing the subscription is
+    what makes this work at all, not an optimization.
+    """
     try:
       # v2026 API: Invoice.upcoming() replaced by Invoice.create_preview()
-      invoice = self.stripe.Invoice.create_preview(customer=customer_id)
+      invoice = self.stripe.Invoice.create_preview(
+        customer=customer_id, subscription=subscription_id
+      )
 
       if not invoice:
         return None
@@ -630,8 +646,14 @@ class StripePaymentProvider(PaymentProvider):
       }
 
     except self.stripe.error.InvalidRequestError as e:
-      # create_preview requires subscription/schedule params when none exist
-      logger.debug(f"No upcoming invoice for customer {customer_id}: {e}")
+      # Reachable when the subscription is in a state with nothing to bill
+      # (already canceled, fully credited). Logged at warning rather than
+      # debug: with the subscription supplied this should be rare, and the
+      # previous debug-level swallow is why a permanent 400 went unnoticed.
+      logger.warning(
+        f"No upcoming invoice for subscription {subscription_id}: {e}",
+        extra={"customer_id": customer_id, "subscription_id": subscription_id},
+      )
       return None
     except self.stripe.error.StripeError as e:
       logger.error(f"Failed to get upcoming invoice: {e}", exc_info=True)

--- a/robosystems/routers/billing/invoices.py
+++ b/robosystems/routers/billing/invoices.py
@@ -17,7 +17,11 @@ from ...models.api.billing.invoice import (
 )
 from ...models.api.common import RESOURCE_ERROR_RESPONSES
 from ...models.core import User
-from ...models.core.billing import BillingCustomer, BillingInvoice
+from ...models.core.billing import (
+  BillingCustomer,
+  BillingInvoice,
+  BillingSubscription,
+)
 from ...operations.providers.payment_provider import get_payment_provider
 
 logger = get_logger(__name__)
@@ -150,8 +154,26 @@ async def get_upcoming_invoice(
     if not customer.stripe_customer_id:
       return None
 
+    # An upcoming invoice belongs to a subscription, so resolve one locally
+    # first. Beyond correctness this keeps the no-subscription case off the
+    # network entirely — the previous customer-only call spent ~4s per
+    # billing page load before Stripe rejected it.
+    subscription_id = next(
+      (
+        sub.stripe_subscription_id
+        for sub in BillingSubscription.get_active_subscriptions_for_org(org_id, db)
+        if sub.stripe_subscription_id
+      ),
+      None,
+    )
+
+    if not subscription_id:
+      return None
+
     provider = get_payment_provider("stripe")
-    upcoming = provider.get_upcoming_invoice(customer.stripe_customer_id)
+    upcoming = provider.get_upcoming_invoice(
+      customer.stripe_customer_id, subscription_id
+    )
 
     if not upcoming:
       return None

--- a/tests/operations/providers/test_payment_provider.py
+++ b/tests/operations/providers/test_payment_provider.py
@@ -453,7 +453,7 @@ class TestStripeInvoiceOperations:
     mock_invoice.lines = mock_lines
     stripe_provider.stripe.Invoice.create_preview.return_value = mock_invoice
 
-    result = stripe_provider.get_upcoming_invoice("cus_123")
+    result = stripe_provider.get_upcoming_invoice("cus_123", "sub_123")
 
     assert result["amount_due"] == 5999
     assert result["currency"] == "usd"
@@ -461,7 +461,7 @@ class TestStripeInvoiceOperations:
     assert len(result["lines"]) == 1
     assert result["lines"][0]["description"] == "Standard Plan - Monthly"
     stripe_provider.stripe.Invoice.create_preview.assert_called_once_with(
-      customer="cus_123"
+      customer="cus_123", subscription="sub_123"
     )
 
   def test_get_upcoming_invoice_none(self, stripe_provider):
@@ -483,7 +483,7 @@ class TestStripeInvoiceOperations:
       "No upcoming invoice"
     )
 
-    result = stripe_provider.get_upcoming_invoice("cus_123")
+    result = stripe_provider.get_upcoming_invoice("cus_123", "sub_123")
 
     assert result is None
 

--- a/tests/routers/billing/test_invoices.py
+++ b/tests/routers/billing/test_invoices.py
@@ -249,8 +249,17 @@ class TestGetUpcomingInvoice:
   @patch("robosystems.models.core.OrgUser.get_by_org_and_user")
   @patch("robosystems.routers.billing.invoices.BillingCustomer.get_or_create")
   @patch("robosystems.routers.billing.invoices.get_payment_provider")
+  @patch(
+    "robosystems.routers.billing.invoices.BillingSubscription.get_active_subscriptions_for_org"
+  )
   async def test_get_upcoming_invoice_none(
-    self, mock_get_provider, mock_get_customer, mock_get_org_user, mock_user, mock_db
+    self,
+    mock_get_subs,
+    mock_get_provider,
+    mock_get_customer,
+    mock_get_org_user,
+    mock_user,
+    mock_db,
   ):
     """Test getting upcoming invoice when none exists."""
     from robosystems.models.core import OrgRole
@@ -262,6 +271,10 @@ class TestGetUpcomingInvoice:
     mock_customer = Mock(spec=BillingCustomer)
     mock_customer.stripe_customer_id = "cus_123"
     mock_get_customer.return_value = mock_customer
+
+    mock_sub = Mock()
+    mock_sub.stripe_subscription_id = "sub_123"
+    mock_get_subs.return_value = [mock_sub]
 
     mock_provider = Mock()
     mock_provider.get_upcoming_invoice.return_value = None
@@ -275,11 +288,105 @@ class TestGetUpcomingInvoice:
   @patch("robosystems.models.core.OrgUser.get_by_org_and_user")
   @patch("robosystems.routers.billing.invoices.BillingCustomer.get_or_create")
   @patch("robosystems.routers.billing.invoices.get_payment_provider")
+  @patch(
+    "robosystems.routers.billing.invoices.BillingSubscription.get_active_subscriptions_for_org"
+  )
+  async def test_no_subscription_never_calls_stripe(
+    self,
+    mock_get_subs,
+    mock_get_provider,
+    mock_get_customer,
+    mock_get_org_user,
+    mock_user,
+    mock_db,
+  ):
+    """No subscription means nothing to preview — and no network call.
+
+    Stripe rejects a preview that names only a customer, so the previous
+    behaviour spent ~4s per billing page load to be told so.
+    """
+    from robosystems.models.core import OrgRole
+
+    mock_org_user = Mock()
+    mock_org_user.role = OrgRole.OWNER
+    mock_get_org_user.return_value = mock_org_user
+
+    mock_customer = Mock(spec=BillingCustomer)
+    mock_customer.stripe_customer_id = "cus_123"
+    mock_get_customer.return_value = mock_customer
+
+    mock_get_subs.return_value = []
+
+    result = await get_upcoming_invoice("org_123", mock_user, mock_db, None)
+
+    assert result is None
+    mock_get_provider.assert_not_called()
+
+  @pytest.mark.asyncio
+  @patch("robosystems.models.core.OrgUser.get_by_org_and_user")
+  @patch("robosystems.routers.billing.invoices.BillingCustomer.get_or_create")
+  @patch("robosystems.routers.billing.invoices.get_payment_provider")
+  @patch(
+    "robosystems.routers.billing.invoices.BillingSubscription.get_active_subscriptions_for_org"
+  )
+  async def test_subscription_id_is_passed_to_the_provider(
+    self,
+    mock_get_subs,
+    mock_get_provider,
+    mock_get_customer,
+    mock_get_org_user,
+    mock_user,
+    mock_db,
+  ):
+    """The subscription is what makes the preview valid, so it must reach Stripe."""
+    from robosystems.models.core import OrgRole
+
+    mock_org_user = Mock()
+    mock_org_user.role = OrgRole.OWNER
+    mock_get_org_user.return_value = mock_org_user
+
+    mock_customer = Mock(spec=BillingCustomer)
+    mock_customer.stripe_customer_id = "cus_123"
+    mock_get_customer.return_value = mock_customer
+
+    # A subscription with no Stripe id (e.g. a local-only record) is skipped
+    # in favour of one that can actually be previewed.
+    unlinked = Mock()
+    unlinked.stripe_subscription_id = None
+    linked = Mock()
+    linked.stripe_subscription_id = "sub_abc"
+    mock_get_subs.return_value = [unlinked, linked]
+
+    mock_provider = Mock()
+    mock_provider.get_upcoming_invoice.return_value = None
+    mock_get_provider.return_value = mock_provider
+
+    await get_upcoming_invoice("org_123", mock_user, mock_db, None)
+
+    mock_provider.get_upcoming_invoice.assert_called_once_with("cus_123", "sub_abc")
+
+  @pytest.mark.asyncio
+  @patch("robosystems.models.core.OrgUser.get_by_org_and_user")
+  @patch("robosystems.routers.billing.invoices.BillingCustomer.get_or_create")
+  @patch("robosystems.routers.billing.invoices.get_payment_provider")
+  @patch(
+    "robosystems.routers.billing.invoices.BillingSubscription.get_active_subscriptions_for_org"
+  )
   async def test_get_upcoming_invoice_success(
-    self, mock_get_provider, mock_get_customer, mock_get_org_user, mock_user, mock_db
+    self,
+    mock_get_subs,
+    mock_get_provider,
+    mock_get_customer,
+    mock_get_org_user,
+    mock_user,
+    mock_db,
   ):
     """Test successful upcoming invoice retrieval."""
     from robosystems.models.core import OrgRole
+
+    mock_sub = Mock()
+    mock_sub.stripe_subscription_id = "sub_123"
+    mock_get_subs.return_value = [mock_sub]
 
     mock_org_user = Mock()
     mock_org_user.role = OrgRole.OWNER
@@ -323,11 +430,24 @@ class TestGetUpcomingInvoice:
   @patch("robosystems.models.core.OrgUser.get_by_org_and_user")
   @patch("robosystems.routers.billing.invoices.BillingCustomer.get_or_create")
   @patch("robosystems.routers.billing.invoices.get_payment_provider")
+  @patch(
+    "robosystems.routers.billing.invoices.BillingSubscription.get_active_subscriptions_for_org"
+  )
   async def test_get_upcoming_invoice_with_multiple_line_items(
-    self, mock_get_provider, mock_get_customer, mock_get_org_user, mock_user, mock_db
+    self,
+    mock_get_subs,
+    mock_get_provider,
+    mock_get_customer,
+    mock_get_org_user,
+    mock_user,
+    mock_db,
   ):
     """Test upcoming invoice with multiple line items."""
     from robosystems.models.core import OrgRole
+
+    mock_sub = Mock()
+    mock_sub.stripe_subscription_id = "sub_123"
+    mock_get_subs.return_value = [mock_sub]
 
     mock_org_user = Mock()
     mock_org_user.role = OrgRole.OWNER


### PR DESCRIPTION
## Summary

The upcoming invoice has **never rendered** since the v2026 Stripe migration, and cost **~4s of every billing page load** to fail.

Surfaced from the Stripe dashboard showing a run of `POST /v1/invoices/create_preview` → `400 ERR`, one pair per page load.

## Root cause

`Invoice.create_preview` previews a **subscription**, not a customer. Per Stripe:

> The Preview Invoice API only supports previewing the upcoming invoice for a specific subscription or subscription schedule, **not for a customer as a whole**. You need to explicitly pass one of `subscription`, `schedule`, `subscription_details.items`, `schedule_details.phases`, or `invoice_items`.

We passed only `customer`, so the call could never succeed.

The 400 was caught and logged at **debug** as "no upcoming invoice" — which is how a permanent failure passed for an empty result for as long as it has.

## The latency

Measured in prod, same org, same page load:

| Endpoint | Duration |
| --- | --- |
| `/billing/invoices/{org}/upcoming` | **3982ms**, **4638ms** |
| `/billing/customer/{org}` | 245ms, 4007ms |
| `/billing/invoices/{org}` | 274ms, 65ms |
| `/billing/subscriptions/{org}` | 41–57ms |

Roughly four seconds, per load, spent being told the request was invalid.

## Changes

- `get_upcoming_invoice(customer_id, subscription_id)` — the subscription is now required and passed to `create_preview`. It is what makes the call valid at all, not an optimization, so it is a required argument rather than an optional one.
- The endpoint resolves the subscription from **our own records** (`BillingSubscription.get_active_subscriptions_for_org`, indexed) before calling Stripe. An org without one returns `None` **without touching the network** — so the no-subscription case costs nothing rather than 4s.
- A subscription row with no `stripe_subscription_id` is skipped in favour of one that can actually be previewed.
- The remaining `InvalidRequestError` path logs at **warning**, not debug. With the subscription supplied it means something real (canceled, fully credited), and debug-level swallowing is precisely what hid this.

## Testing

- New: no subscription → `get_payment_provider` is **never called**; and the resolved subscription id is asserted to reach the provider, including preferring a linked row over an unlinked one.
- Existing provider test now asserts `create_preview` is called with `customer=` **and** `subscription=` — the assertion that would have caught this originally.
- `just test-code`: all checks passed. Full unit suite: **11,362 passed** (`-p no:randomly`; one pre-existing local-env pyarrow failure excluded, reproduces on clean `origin/main`).

## Notes

- No schema or API contract change — `UpcomingInvoice` is unchanged, it just stops always being `null`.
- Independent of #939; touches different files.
- Worth a glance after deploy: the Stripe dashboard should stop logging `create_preview` 400s entirely.