### PR TITLE
fix(information-block): sum duplicate facts per cell in series statement rendering

### DIFF
--- a/robosystems/models/api/graphs/metrics.py
+++ b/robosystems/models/api/graphs/metrics.py
@@ -1,4 +1,4 @@
-"""Graph query API models."""
+"""Graph metrics and usage API models."""
 
 from typing import Any
 

--- a/robosystems/models/api/graphs/query.py
+++ b/robosystems/models/api/graphs/query.py
@@ -91,33 +91,6 @@ def translate_neo4j_to_lbug(query: str) -> str:
     return translated
 
 
-class GraphMetricsResponse(BaseModel):
-  """Response model for graph metrics."""
-
-  graph_id: str = Field(..., description="Graph database identifier")
-  graph_name: str | None = Field(None, description="Display name for the graph")
-  user_role: str | None = Field(None, description="User's role in this graph")
-  timestamp: str = Field(..., description="Metrics collection timestamp")
-  total_nodes: int = Field(..., description="Total number of nodes")
-  total_relationships: int = Field(..., description="Total number of relationships")
-  node_counts: dict[str, int] = Field(..., description="Node counts by label")
-  relationship_counts: dict[str, int] = Field(
-    ..., description="Relationship counts by type"
-  )
-  estimated_size: dict[str, Any] = Field(..., description="Database size estimates")
-  health_status: dict[str, Any] = Field(..., description="Database health information")
-
-
-class GraphUsageResponse(BaseModel):
-  """Response model for graph usage statistics."""
-
-  graph_id: str = Field(..., description="Graph database identifier")
-  storage_usage: dict[str, Any] = Field(..., description="Storage usage information")
-  query_statistics: dict[str, Any] = Field(..., description="Query statistics")
-  recent_activity: dict[str, Any] = Field(..., description="Recent activity summary")
-  timestamp: str = Field(..., description="Usage collection timestamp")
-
-
 class CypherStatementRequest(BaseModel):
   """Request model for Cypher query execution."""
 

--- a/robosystems/operations/information_block/statement.py
+++ b/robosystems/operations/information_block/statement.py
@@ -479,20 +479,31 @@ def _facts_to_balance_dict_for_period(
   set to "debit" to keep ``_build_rows`` from re-applying sign
   conversion (it dispatches on balance_type when ``pre_signed=False``;
   with ``pre_signed=True`` the balance is returned as-is).
+
+  Multiple facts on the same ``element_id`` for the same period sum —
+  the fact-generation contract (see ``_derive_cash_flow_facts``) allows
+  it, and the stamped CF carries a derived ΔWC fact plus the
+  cash-reconciliation plug on the same operating leaf. Overwriting here
+  would drop the plug from the rendered cell while the stamped subtotal
+  still includes it, so the section stops footing.
   """
   balances: dict[str, _Balance] = {}
   for fact in facts:
     if fact.period_start == period_start and fact.period_end == period_end:
-      balances[fact.element_id] = _Balance(
-        element_id=fact.element_id,
-        qname=fact.element_qname,
-        name=fact.element_name,
-        classification=fact.classification,
-        balance_type="debit",
-        total_debits=0.0,
-        total_credits=0.0,
-        net_balance=fact.value,
-      )
+      existing = balances.get(fact.element_id)
+      if existing is None:
+        balances[fact.element_id] = _Balance(
+          element_id=fact.element_id,
+          qname=fact.element_qname,
+          name=fact.element_name,
+          classification=fact.classification,
+          balance_type="debit",
+          total_debits=0.0,
+          total_credits=0.0,
+          net_balance=fact.value,
+        )
+      else:
+        existing.net_balance += fact.value
   return balances
 
 

--- a/tests/operations/information_block/test_statement_handlers.py
+++ b/tests/operations/information_block/test_statement_handlers.py
@@ -508,6 +508,55 @@ class TestRenderingSkipsNonnumericFacts:
     assert rendering.rows == []
 
 
+class TestRenderingSumsDuplicateFacts:
+  def test_two_facts_on_same_element_and_period_sum_into_one_cell(self) -> None:
+    """The stamped CF can carry two facts on one operating leaf for the
+    same month — the derived ΔWC value plus the cash-reconciliation plug
+    from ``_reconcile_operating_to_cash``. The balance dict must sum them
+    (mirroring ``fact_grid._facts_to_balance_dict``); overwriting drops
+    the plug from the rendered cell while the stamped subtotal still
+    includes it, so the operating section stops footing."""
+    from types import SimpleNamespace
+
+    session = MagicMock()
+    session.execute.return_value = _exec_result(all_rows=[])
+
+    structure_id = "struct_cf_indirect"
+    element = SimpleNamespace(
+      id="elem_other_wc",
+      qname="rs-gaap:IncreaseDecreaseInOtherOperatingCapitalNet",
+      name="Other operating capital, net",
+      balance_type="debit",
+      is_abstract=False,
+    )
+    association = MagicMock()
+    association.association_type = "presentation"
+    association.from_element_id = structure_id
+    association.to_element_id = "elem_other_wc"
+    association.order_value = 0.0
+
+    def _fact(value: float) -> SimpleNamespace:
+      return SimpleNamespace(
+        element_id="elem_other_wc",
+        value=value,
+        period_start=date(2026, 3, 1),
+        period_end=date(2026, 3, 31),
+        period_type="duration",
+      )
+
+    rendering = statement_handlers._build_statement_rendering(
+      session,
+      elements=[element],  # type: ignore[list-item]
+      associations=[association],
+      facts=[_fact(-1000.00), _fact(-1819.25)],  # type: ignore[list-item]
+      structure_id=structure_id,
+      block_type="cash_flow_statement",
+    )
+
+    assert len(rendering.rows) == 1
+    assert rendering.rows[0].values == [pytest.approx(-2819.25)]
+
+
 class TestRenderingComposesCalcsCrossStructure:
   """Regression: rs-gaap ``arithmetic`` statement blocks carry only
   presentation arcs — their calc DAG lives in a sibling calculation


### PR DESCRIPTION
## Summary

Post-deploy validation of the v1.6.12 restamp heal surfaced a rendering defect: the series statement renderer's per-period balance dict (`_facts_to_balance_dict_for_period` in `operations/information_block/statement.py`) overwrote on duplicate (element, period) instead of summing — unlike `fact_grid._facts_to_balance_dict`, which it documents itself as mirroring and which sums by contract.

The two-period CF stamper legitimately produces two facts on one operating leaf for a month: the derived ΔWC value on `IncreaseDecreaseInOtherOperatingCapitalNet` plus the cash-reconciliation plug from `_reconcile_operating_to_cash`. The stored data is correct (subtotals include both; net change ties ΔCash exactly), but the rendered cell kept only one fact, so the operating section stopped footing against its own subtotal in the Plan-page series view (e.g. children summing to −2,829.72 under a −4,648.97 subtotal — a gap of exactly the dropped plug).

## Changes

- `operations/information_block/statement.py` — `_facts_to_balance_dict_for_period` now sums on collision (`existing.net_balance += fact.value`), matching the fact_grid reference implementation; docstring documents why duplicates are legitimate on the stamped CF.
- `tests/operations/information_block/test_statement_handlers.py` — regression test rendering two facts on the same (element, period) into one summed cell; verified red without the fix.

## Testing

- `tests/operations/information_block` + `tests/operations/roboledger`: 1,176 passed.
- `just test-code`: all checks passed (ruff, format, basedpyright, cf-lint).
- Negative check: the new test fails against the unfixed renderer.

## Notes

- No restamp needed after deploy — the canonical stamped FactSets already hold both fact rows; only the rendering collapsed them.
- `forecast_history`/`forecast_compute` actuals loaders have the same last-wins shape but only read IS/BS sets, where the fact generator emits at most one fact per (element, period) today — left untouched to keep this scoped; noted here for the record.

- Carries one unrelated ride-along commit (`867ea266`): removal of the duplicate `GraphMetricsResponse` / `GraphUsageResponse` left in `models/api/graphs/query.py` by the metrics/usage move. Pure deletion, no behavior change, reviews independently of the rendering fix. Closes #941.
