### PR TITLE
docs(api): describe reopen-period's real contract

### DIFF
--- a/robosystems/models/api/extensions/fiscal_calendar.py
+++ b/robosystems/models/api/extensions/fiscal_calendar.py
@@ -151,10 +151,12 @@ class ClosePeriodRequest(BaseModel):
 
 
 class ReopenPeriodRequest(BaseModel):
-  """Decrement ``closed_through`` by one — un-locks the most recent close.
+  """Un-lock a closed period for adjustment.
 
-  Only the most recently closed period can be reopened (no
-  reach-back). The ``reason`` is required and captured in the audit
+  Reopening the current ``closed_through`` decrements it by one.
+  Reopening an earlier period is a prior-period adjustment: the
+  watermark stays put, and the re-close restores the period without
+  advancing it. The ``reason`` is required and captured in the audit
   log. Use sparingly — reopen invalidates downstream artifacts that
   trusted the closed state (reports, shared filings).
   """

--- a/robosystems/routers/extensions/roboledger/operations.py
+++ b/robosystems/routers/extensions/roboledger/operations.py
@@ -560,14 +560,17 @@ class ClosePeriodOperation(ClosePeriodRequest):
 
 
 class ReopenPeriodOperation(ReopenPeriodRequest):
-  """Reopen the most recently closed fiscal period."""
+  """Reopen a closed fiscal period."""
 
   period: str = Field(
     ...,
     pattern=r"^\d{4}-(0[1-9]|1[0-2])$",
     description=(
-      "Period to reopen, in YYYY-MM. Must equal current `closed_through` "
-      "— only the most recent close can be undone."
+      "Period to reopen, in YYYY-MM. Any closed period may be reopened. "
+      "Reopening the current `closed_through` retreats it by one month; "
+      "reopening an earlier period leaves `closed_through` where it is "
+      "(a prior-period adjustment), and its re-close restores the period "
+      "without moving the pointer."
     ),
   )
 
@@ -1890,10 +1893,13 @@ async def close_period_op(
   operation_id="reopenPeriod",
   summary="Reopen Fiscal Period",
   description=(
-    "Decrement `closed_through` by one. Only the most recently closed "
-    "period can be reopened (no reach-back). Retracts the month's "
-    "canonical statement FactSets (a reopened month is no longer a "
-    "closed assertion; re-closing restamps them). The required "
+    "Reopen a closed period for adjustment. Reopening the current "
+    "`closed_through` decrements it by one; reopening an earlier period "
+    "is a prior-period adjustment and leaves `closed_through` unchanged "
+    "— re-closing it restores the period without advancing the pointer. "
+    "Either way the period's entries become writable again. Retracts "
+    "the month's canonical statement FactSets (a reopened month is no "
+    "longer a closed assertion; re-closing restamps them). The required "
     "`reason` is captured in the audit log. Use sparingly — reopen "
     "invalidates downstream artifacts that trusted the closed state "
     "(reports, shared filings)."


### PR DESCRIPTION
## Summary

`reopen-period` advertised boundary-only reopen — *"Must equal current `closed_through`"*, *"no reach-back"* — which the implementation has never done. Interior reopen is a supported prior-period adjustment. This corrects the descriptions; there is no behavior change.

## Why the docs were the wrong half

Interior reopen is designed across three layers, not overlooked in one:

- `FiscalCalendarService.retreat_closed_through` deliberately leaves `closed_through` alone when the reopened period isn't the boundary ("you can reopen an older period without changing the pointer").
- `PeriodCloseService` routes that period's re-close through `record_reclose` on `is_latest_sequential_close`.
- `record_reclose` deliberately does not advance the pointer, because the reopen never retreated it.

Entry writes genuinely unlock too — the guard keys on `FiscalPeriod.status`, not the watermark — so the adjustment can actually be posted. Existing tests name the workflow outright (`test_reopen_older_period_preserves_pointer`, `test_older_reopen_routes_to_record_reclose`, fixtures reading `reason="prior period adj"`).

The MCP tool already documented this correctly: *"Reopening older periods (not the most recently closed) is allowed but does not decrement closed_through."* Only the REST surface disagreed.

## Changes

Three sites, all description text:

- `routers/extensions/roboledger/operations.py` — the `reopen-period` route description and the `period` field description on `ReopenPeriodOperation`
- `models/api/extensions/fiscal_calendar.py` — the `ReopenPeriodRequest` docstring

The ops-layer docstring in `commands/fiscal_calendar.py` was already accurate and is untouched.

## Context

Filed as a LIFO-guard gap in #901; re-diagnosing it showed enforcing that guard would have removed the prior-period-adjustment capability and orphaned `record_reclose`. #901 has been corrected.

## Testing

`just test-code` clean; `tests/operations/roboledger/fiscal_calendar` 119 passed, `tests/routers/extensions` 69 passed. No test changes needed — no behavior changed.