### PR TITLE
fix(information-block): window the forecast envelope month axis in register with statements

### DIFF
--- a/robosystems/operations/information_block/envelope.py
+++ b/robosystems/operations/information_block/envelope.py
@@ -465,6 +465,38 @@ def window_series_sets(
   return [fs for fs in series_sets if fs.id in keep]
 
 
+def window_month_axis(
+  months: list[str],
+  forecast_months: set[str],
+  history: int | None,
+  forecast: int | None,
+) -> list[str]:
+  """Trim a chronological ``YYYY-MM`` axis to its seam-adjacent window.
+
+  The month-keyed counterpart of :func:`window_series_sets` for
+  envelopes whose column axis is a month list rather than FactSet
+  columns (the forecast block's assumptions grid). Same semantics:
+  ``history`` keeps the LAST N non-forecast months, ``forecast`` keeps
+  the FIRST N forecast months, ``None`` leaves that side unbounded.
+  Keeping the two in register matters — the Plan grid unions the
+  assumptions axis with the windowed statement series, and any month
+  this axis carries beyond the statements' window surfaces as a
+  phantom column with no statement values behind it.
+  """
+  if history is None and forecast is None:
+    return months
+  if (history is not None and history < 0) or (forecast is not None and forecast < 0):
+    raise ValueError("series window counts must be >= 0")
+  actuals = [m for m in months if m not in forecast_months]
+  forwards = [m for m in months if m in forecast_months]
+  if history is not None:
+    actuals = actuals[-history:] if history > 0 else []
+  if forecast is not None:
+    forwards = forwards[:forecast]
+  keep = set(actuals) | set(forwards)
+  return [m for m in months if m in keep]
+
+
 def _drop_covering_windows(rows: list) -> list:
   """Drop sets whose window strictly contains another loaded set's window.
 

--- a/robosystems/operations/information_block/forecast.py
+++ b/robosystems/operations/information_block/forecast.py
@@ -57,6 +57,7 @@ from robosystems.operations.information_block.envelope import (
   fact_set_to_lite,
   fact_to_lite,
   load_base_envelope_atoms,
+  window_month_axis,
 )
 from robosystems.operations.information_block.forecast_history import (
   back_solve_lever_history,
@@ -759,6 +760,11 @@ def build_envelope(
   columns exactly as the statement series does; its presence anywhere in
   this rendering is also what tells a client the envelope carries
   history at all (pre-history envelopes never set the flag).
+
+  ``series_history`` / ``series_forecast`` window the month axis with
+  statement-series semantics (last N actual months, first N forecast
+  months; ``None`` = unbounded) so the assumptions grid stays in
+  register with windowed statement reads on the Plan page.
   """
   atoms = load_base_envelope_atoms(
     session,
@@ -815,6 +821,11 @@ def build_envelope(
   # not the rate that was asserted for it.
   months = sorted(actual_months | set(horizon_months))
   forecast_months = {month for month in horizon_months if month not in actual_months}
+  # Seam-adjacent windowing, in register with the statement series: the
+  # Plan grid unions this axis with the windowed statement columns, so
+  # an unwindowed assumptions axis would resurface every trimmed month
+  # as a phantom column (statement rows blank, mis-read as forecast).
+  months = window_month_axis(months, forecast_months, series_history, series_forecast)
 
   def lever_value(lever: LeverAssertionLite, month: str) -> float | None:
     if month in forecast_months:

--- a/tests/operations/information_block/test_envelope_fact_set.py
+++ b/tests/operations/information_block/test_envelope_fact_set.py
@@ -248,6 +248,55 @@ class TestWindowSeriesSets:
       window_series_sets(self._series(), None, -1)
 
 
+class TestWindowMonthAxis:
+  """Month-keyed counterpart of window_series_sets — the forecast
+  block's assumptions axis must window in register with the statement
+  series, or the Plan grid's axis union resurfaces trimmed months as
+  phantom columns."""
+
+  MONTHS = ["2026-01", "2026-02", "2026-03", "2026-04", "2026-05", "2026-06"]
+  FORECAST = {"2026-05", "2026-06"}
+
+  def test_unbounded_is_identity(self) -> None:
+    from robosystems.operations.information_block.envelope import window_month_axis
+
+    assert window_month_axis(self.MONTHS, self.FORECAST, None, None) is self.MONTHS
+
+  def test_history_keeps_last_n_actuals(self) -> None:
+    from robosystems.operations.information_block.envelope import window_month_axis
+
+    kept = window_month_axis(self.MONTHS, self.FORECAST, 2, None)
+    assert kept == ["2026-03", "2026-04", "2026-05", "2026-06"]
+
+  def test_forecast_keeps_first_n_forwards(self) -> None:
+    from robosystems.operations.information_block.envelope import window_month_axis
+
+    kept = window_month_axis(self.MONTHS, self.FORECAST, None, 1)
+    assert kept == ["2026-01", "2026-02", "2026-03", "2026-04", "2026-05"]
+
+  def test_combined_window_stays_chronological(self) -> None:
+    from robosystems.operations.information_block.envelope import window_month_axis
+
+    kept = window_month_axis(self.MONTHS, self.FORECAST, 1, 1)
+    assert kept == ["2026-04", "2026-05"]
+
+  def test_zero_history_is_forecast_only(self) -> None:
+    from robosystems.operations.information_block.envelope import window_month_axis
+
+    kept = window_month_axis(self.MONTHS, self.FORECAST, 0, None)
+    assert kept == ["2026-05", "2026-06"]
+
+  def test_negative_counts_raise(self) -> None:
+    import pytest
+
+    from robosystems.operations.information_block.envelope import window_month_axis
+
+    with pytest.raises(ValueError):
+      window_month_axis(self.MONTHS, self.FORECAST, -1, None)
+    with pytest.raises(ValueError):
+      window_month_axis(self.MONTHS, self.FORECAST, None, -1)
+
+
 class TestLoadStatementFactSetSeries:
   """The F-4 series loader — every report set as one column, with the
   actuals-preferred seam and the narrower-window-wins collapse."""

--- a/tests/operations/information_block/test_forecast_handlers.py
+++ b/tests/operations/information_block/test_forecast_handlers.py
@@ -973,7 +973,13 @@ class TestBuildEnvelope:
     assert assertion_row.values == [0.0, 0.0]
     assert assertion_row.balance_type == "debit"
 
-  def _history_envelope(self, history: LeverHistory, horizon: int = 2):
+  def _history_envelope(
+    self,
+    history: LeverHistory,
+    horizon: int = 2,
+    series_history: int | None = None,
+    series_forecast: int | None = None,
+  ):
     """Build the standard one-lever envelope against a given history."""
     structure = MagicMock()
     structure.id = "struct_budget_01"
@@ -1031,7 +1037,12 @@ class TestBuildEnvelope:
       patch.object(forecast_handlers, "load_base_envelope_atoms", return_value=atoms),
       patch.object(forecast_handlers, "back_solve_lever_history", return_value=history),
     ):
-      return forecast_handlers.build_envelope(session, "struct_budget_01")
+      return forecast_handlers.build_envelope(
+        session,
+        "struct_budget_01",
+        series_history=series_history,
+        series_forecast=series_forecast,
+      )
 
   def test_realized_months_extend_the_grid_behind_the_seam(self) -> None:
     envelope = self._history_envelope(
@@ -1087,6 +1098,51 @@ class TestBuildEnvelope:
     rendering = envelope.view.rendering
     assert rendering is not None
     assert rendering.rows[0].values == [None, None, 0.03, 0.03]
+
+  def test_series_windows_trim_the_axis_in_register_with_statements(self) -> None:
+    """The Plan grid unions this axis with the windowed statement series;
+    an unwindowed assumptions axis resurfaces every trimmed month as a
+    phantom column (statement rows blank, mis-read as forecast)."""
+    envelope = self._history_envelope(
+      LeverHistory(
+        months=["2026-04", "2026-05", "2026-06"],
+        lever_values={
+          "rs-driver:RevenueGrowthRate": {
+            "2026-04": 0.011,
+            "2026-05": 0.021,
+            "2026-06": 0.038,
+          }
+        },
+      ),
+      series_history=1,
+      series_forecast=1,
+    )
+    assert envelope is not None
+    rendering = envelope.view.rendering
+    assert rendering is not None
+    # Last 1 actual month + first 1 forecast month — seam-adjacent.
+    assert [p.end for p in rendering.periods] == [
+      date(2026, 6, 30),
+      date(2026, 7, 31),
+    ]
+    assert [p.forecast for p in rendering.periods] == [None, True]
+    assert rendering.rows[0].values == [0.038, 0.03]
+
+  def test_series_windows_none_keep_the_full_axis(self) -> None:
+    envelope = self._history_envelope(
+      LeverHistory(
+        months=["2026-05", "2026-06"],
+        lever_values={
+          "rs-driver:RevenueGrowthRate": {"2026-05": 0.021, "2026-06": 0.038}
+        },
+      ),
+      series_history=None,
+      series_forecast=None,
+    )
+    assert envelope is not None
+    rendering = envelope.view.rendering
+    assert rendering is not None
+    assert len(rendering.periods) == 4
 
   def test_returns_none_for_wrong_block_type(self) -> None:
     session = MagicMock()


### PR DESCRIPTION
## Summary

Server half of the Plan-page windowing regression Joey screenshotted (phantom `F`-flagged 2024 columns when a shorter History window is selected with a scenario). The forecast (assumptions) envelope builder accepted `series_history`/`series_forecast` for dispatch-signature parity but never applied them — so a windowed Plan read got trimmed statement series (e.g. 6 columns) next to the full 37-column assumptions axis. The app's master-column union then resurfaced every trimmed month as a phantom column with no statement values behind it, and its "no actual behind it ⇒ forecast" fallback flagged them `F`; the seam slicer's "first N forecast columns" landed on Jul–Sep 2024.

Verified against prod before the fix: statement reads window correctly for the same scenario (`Mar/Apr/May 26 + Jun/Jul/Aug 26 F`), while the forecast block returns all 37 columns regardless of the args.

## Changes

- `operations/information_block/envelope.py` — new `window_month_axis(months, forecast_months, history, forecast)`: the month-keyed counterpart of `window_series_sets` (last N actual months, first N forecast months, `None` unbounded, negatives rejected), for envelopes whose axis is a `YYYY-MM` list rather than FactSet columns.
- `operations/information_block/forecast.py` — `build_envelope` applies it to the assumptions axis after the actual/horizon merge; docstring documents the in-register contract with windowed statement reads.

## Testing

- `tests/operations/information_block/test_envelope_fact_set.py` — `TestWindowMonthAxis` (identity, last-N actuals, first-N forwards, combined, zero, negatives).
- `tests/operations/information_block/test_forecast_handlers.py` — envelope-level: `series_history=1, series_forecast=1` trims the grid to the seam-adjacent pair with flags intact; `None/None` keeps the full axis.
- `tests/operations/information_block`: 457 passed. `just test-code`: all checks passed.

## Notes

- The app half lands separately in roboledger-app: pass the window options on the assumptions fetch, and scope the `composePlan` no-actual-behind-it fallback to columns after the last actual (order-free hardening — that alone fixes the live page against a backend without this PR).
- `schedule`/`rollforward`/`disclosure`/`metric` builders keep the accept-and-ignore parity signature; none of their axes joins the Plan grid union. Metric series windowing can follow if a consumer ever sends windows there.
