### PR TITLE
Resize graph tier instance ladder, reprice, and fix offerings metadata

### DIFF
--- a/.github/configs/graph.yml
+++ b/.github/configs/graph.yml
@@ -8,10 +8,16 @@
 # - Supports "MotherDuck for Graphs" pattern: DuckDB staging → LadybugDB materialization
 #
 # TIER PHILOSOPHY:
-# - Standard: Dedicated m7g.large, single database + 3 subgraphs, cost-efficient entry
-# - Large: Dedicated r7g.large, subgraphs for organization, team collaboration
+# - Standard: Dedicated m7g.medium, single database + 3 subgraphs, cost-efficient entry
+# - Large: Dedicated m7g.large, subgraphs for organization, team collaboration
 # - XLarge: Dedicated r7g.xlarge, maximum subgraphs, advanced scale
 # - Shared: Public data repositories (SEC) - separate infrastructure
+#
+# MEMORY SIZING: LadybugDB buffer pools are lazily filled caps, not reservations,
+# so nominal (parent + subgraphs) may exceed max_memory_mb — subgraphs are rarely
+# all active at once. The hard ceiling is the admission-control guard, which
+# trips at 85% of *instance* RAM (graph_api/core/admission_control.py), so size
+# parent + duckdb_memory_limit to stay under that even when both are hot.
 
 production:
   writers:
@@ -19,7 +25,7 @@ production:
     # LADYBUGDB STANDARD TIER - Dedicated m7g.large
     # =========================================================================
     - name: ladybug-standard
-      description: Dedicated m7g.large LadybugDB tier for cost-efficient entry with subgraph support
+      description: Dedicated m7g.medium LadybugDB tier for cost-efficient entry with subgraph support
       backend: ladybug
       stack_suffix: LadybugStandard
       tier: ladybug-standard
@@ -47,36 +53,34 @@ production:
       # Graph content limits
       graph_limits:
         instance_storage_limit_gb: 20 # Soft storage cap for entire instance (parent + subgraphs + staging)
-        max_rows_per_copy: 2000000   # 2M rows per copy operation (hard limit, prevents OOM during materialization)
-        max_single_table_rows: 5000000 # 5M rows per staging table
-        chunk_size_rows: 500000      # 500K rows per materialization chunk (conservative for 2GB buffer pool)
+        max_rows_per_copy: 1000000   # 1M rows per copy operation (hard limit, prevents OOM during materialization)
+        max_single_table_rows: 2500000 # 2.5M rows per staging table
+        chunk_size_rows: 250000      # 250K rows per materialization chunk (conservative for 1GB parent buffer pool)
         warn_at_percentage: 80       # Warn when approaching storage limit
-
-      # Memory boost configuration
-      memory:
-        baseline_mb: 2048    # Default LadybugDB memory (m7g.large = 8GB)
-        max_boost_mb: 6144   # Max boost during materialization
-        auto_reset: true     # Reset to baseline after operation
 
       # Instance configuration
       instance:
-        type: m7g.large # 8GB RAM, 2 vCPUs, ARM64 - dedicated per customer
+        type: m7g.medium # 4GB RAM, 1 vCPU, ARM64 - dedicated per customer
         databases_per_instance: 1 # Dedicated: one customer per instance
 
         # Memory configuration
-        max_memory_mb: 6144 # 6GB available (8GB - 2GB OS overhead)
-        memory_per_db_mb: 2048 # 2GB per database
+        # Admission control trips at 85% of 4GB = ~3.4GB. Worst concurrent case
+        # is parent buffer pool (1GB) + DuckDB staging (1GB) = 2GB, leaving
+        # headroom for the OS and the API container.
+        max_memory_mb: 3072 # 3GB available (4GB - 1GB OS/container overhead)
+        memory_per_db_mb: 1024 # 1GB for the parent database
+        memory_per_subgraph_mb: 384 # 384MB per subgraph (3 max, rarely all active)
 
         # LadybugDB-specific performance settings
-        chunk_size: 1000 # Batch operation chunk size
-        query_timeout: 30 # Query timeout in seconds
+        chunk_size: 500 # Batch operation chunk size
+        query_timeout: 45 # Query timeout in seconds (raised for 1 vCPU)
         max_query_length: 10000 # Maximum query size in characters
-        ingestion_batch_size: 1000 # Batch size for data ingestion
-        connection_pool_size: 10 # Max concurrent connections per database
+        ingestion_batch_size: 500 # Batch size for data ingestion
+        connection_pool_size: 5 # Max concurrent connections per database (1 vCPU)
 
         # DuckDB staging configuration
-        duckdb_memory_limit: "2GB" # Conservative for standard tier
-        duckdb_max_threads: 2 # m7g.large = 2 vCPU
+        duckdb_memory_limit: "1GB" # Spills to disk beyond this - slower, not fatal
+        duckdb_max_threads: 2 # m7g.medium = 1 vCPU (2x oversubscription is fine for DuckDB)
 
       # Deployment configuration
       deployment:
@@ -87,7 +91,7 @@ production:
     # LADYBUGDB LARGE TIER - Dedicated r7g.large
     # =========================================================================
     - name: ladybug-large
-      description: Dedicated r7g.large with subgraph support (10 subgraphs)
+      description: Dedicated m7g.large with subgraph support (10 subgraphs)
       backend: ladybug
       stack_suffix: LadybugLarge
       tier: ladybug-large
@@ -96,7 +100,7 @@ production:
       max_subgraphs: 10 # Support up to 10 subgraphs (1 parent + 10 children = 11 databases total)
 
       # Resource limits
-      api_rate_multiplier: 1.5 # 1.5x rate limits (2x RAM, same CPU as standard)
+      api_rate_multiplier: 1.5 # 1.5x rate limits (2x RAM, 2x CPU vs standard)
 
       # Copy operation limits
       copy_operations:
@@ -115,37 +119,33 @@ production:
       # Graph content limits
       graph_limits:
         instance_storage_limit_gb: 50 # Soft storage cap for entire instance (parent + subgraphs + staging)
-        max_rows_per_copy: 10000000  # 10M rows per copy operation (hard limit, prevents OOM during materialization)
-        max_single_table_rows: 25000000 # 25M rows per staging table
-        chunk_size_rows: 1000000     # 1M rows per materialization chunk (conservative for 1.3GB buffer pool)
+        max_rows_per_copy: 5000000   # 5M rows per copy operation (hard limit, prevents OOM during materialization)
+        max_single_table_rows: 12500000 # 12.5M rows per staging table
+        chunk_size_rows: 500000      # 500K rows per materialization chunk (conservative for 2GB parent buffer pool)
         warn_at_percentage: 80       # Warn when approaching storage limit
-
-      # Memory boost configuration
-      memory:
-        baseline_mb: 4096    # Default LadybugDB memory (r7g.large = 16GB)
-        max_boost_mb: 12288  # Max boost during materialization
-        auto_reset: true     # Reset to baseline after operation
 
       # Instance configuration
       instance:
-        type: r7g.large # 16GB RAM, 2 vCPUs, ARM64 - dedicated per customer
+        type: m7g.large # 8GB RAM, 2 vCPUs, ARM64 - dedicated per customer
         databases_per_instance: 1 # One parent database per instance (subgraphs on same instance)
 
         # Memory configuration
-        max_memory_mb: 14336 # 14GB total available for parent + subgraphs
-        memory_per_db_mb: 1300 # ~1.3GB average per database (14GB / 11 databases)
-        # Note: Memory is dynamically shared among parent and subgraphs
+        # Parent gets a full 2GB pool; subgraphs are intentionally oversubscribed
+        # (2048 + 10x384 = 5.9GB nominal) since they are rarely all active.
+        max_memory_mb: 6144 # 6GB available (8GB - 2GB OS/container overhead)
+        memory_per_db_mb: 2048 # 2GB for the parent database
+        memory_per_subgraph_mb: 384 # 384MB per subgraph (10 max)
 
         # LadybugDB-specific performance settings
-        chunk_size: 1500 # Larger chunks for better performance
+        chunk_size: 1000 # Larger chunks for better performance
         query_timeout: 60 # 60 second timeout for complex queries
         max_query_length: 25000 # Support more complex queries
-        ingestion_batch_size: 2500 # Faster ingestion with dedicated resources
-        connection_pool_size: 25 # Higher concurrency for team usage
+        ingestion_batch_size: 1500 # Faster ingestion with dedicated resources
+        connection_pool_size: 15 # Higher concurrency for team usage
 
         # DuckDB staging configuration
-        duckdb_memory_limit: "4GB" # More memory for dedicated instance staging
-        duckdb_max_threads: 2 # Match vCPU count (r7g.large = 2 vCPU)
+        duckdb_memory_limit: "2GB" # More memory for dedicated instance staging
+        duckdb_max_threads: 2 # Match vCPU count (m7g.large = 2 vCPU)
 
       # Deployment configuration
       deployment:
@@ -190,21 +190,19 @@ production:
         chunk_size_rows: 5000000     # 5M rows per materialization chunk
         warn_at_percentage: 80       # Warn when approaching storage limit
 
-      # Memory boost configuration
-      memory:
-        baseline_mb: 8192    # Default LadybugDB memory (r7g.xlarge = 32GB)
-        max_boost_mb: 28672  # Max boost during materialization
-        auto_reset: true     # Reset to baseline after operation
-
       # Instance configuration
       instance:
         type: r7g.xlarge # 32GB RAM, 4 vCPUs, ARM64 - large dedicated per customer
         databases_per_instance: 1 # One parent database per instance (many subgraphs on same instance)
 
         # Memory configuration
+        # Parent gets a full 8GB pool; subgraphs are intentionally oversubscribed
+        # (8192 + 25x1024 = 33.8GB nominal) since they are rarely all active.
+        # Previously the parent was capped at 1180MB - below Standard's - because
+        # a single flat average was divided across all 26 databases.
         max_memory_mb: 30720 # 30GB available (32GB - 2GB OS overhead)
-        memory_per_db_mb: 1180 # ~1.2GB average per database (30GB / 26 databases)
-        # Note: Memory is dynamically shared, some databases can use more when needed
+        memory_per_db_mb: 8192 # 8GB for the parent database
+        memory_per_subgraph_mb: 1024 # 1GB per subgraph (25 max)
 
         # LadybugDB-specific performance settings
         chunk_size: 2000 # Maximum chunk size for best performance
@@ -325,7 +323,7 @@ staging:
     # LADYBUGDB STANDARD TIER - Staging
     # =========================================================================
     - name: ladybug-standard
-      description: Dedicated m7g.large LadybugDB tier with subgraph support
+      description: Dedicated m7g.medium LadybugDB tier with subgraph support
       backend: ladybug
       stack_suffix: LadybugStandard
       tier: ladybug-standard
@@ -349,30 +347,24 @@ staging:
 
       # Graph content limits (same as production)
       graph_limits:
-        max_nodes: 5000000
-        max_relationships: 10000000
-        max_rows_per_copy: 2000000
-        max_single_table_rows: 5000000
-        chunk_size_rows: 500000
+        instance_storage_limit_gb: 20
+        max_rows_per_copy: 1000000
+        max_single_table_rows: 2500000
+        chunk_size_rows: 250000
         warn_at_percentage: 80
 
-      # Memory boost configuration
-      memory:
-        baseline_mb: 2048
-        max_boost_mb: 6144
-        auto_reset: true
-
       instance:
-        type: m7g.large # 8GB RAM, 2 vCPUs, ARM64 - aligned with production
+        type: m7g.medium # 4GB RAM, 1 vCPU, ARM64 - aligned with production
         databases_per_instance: 1 # Dedicated
-        max_memory_mb: 6144 # 6GB available (8GB - 2GB OS overhead)
-        memory_per_db_mb: 2048 # 2GB per database
-        chunk_size: 1000
-        query_timeout: 30
+        max_memory_mb: 3072 # 3GB available (4GB - 1GB OS/container overhead)
+        memory_per_db_mb: 1024 # 1GB for the parent database
+        memory_per_subgraph_mb: 384 # 384MB per subgraph (3 max)
+        chunk_size: 500
+        query_timeout: 45
         max_query_length: 10000
-        ingestion_batch_size: 1000
-        connection_pool_size: 10
-        duckdb_memory_limit: "2GB" # Aligned with production
+        ingestion_batch_size: 500
+        connection_pool_size: 5
+        duckdb_memory_limit: "1GB" # Aligned with production
         duckdb_max_threads: 2
 
       deployment:
@@ -383,7 +375,7 @@ staging:
     # LADYBUGDB LARGE TIER - Staging
     # =========================================================================
     - name: ladybug-large
-      description: Dedicated r7g.large with subgraph support (10 subgraphs)
+      description: Dedicated m7g.large with subgraph support (10 subgraphs)
       backend: ladybug
       stack_suffix: LadybugLarge
       tier: ladybug-large
@@ -405,31 +397,25 @@ staging:
 
       # Graph content limits (same as production)
       graph_limits:
-        max_nodes: 50000000
-        max_relationships: 100000000
-        max_rows_per_copy: 10000000
-        max_single_table_rows: 25000000
-        chunk_size_rows: 1000000
+        instance_storage_limit_gb: 50
+        max_rows_per_copy: 5000000
+        max_single_table_rows: 12500000
+        chunk_size_rows: 500000
         warn_at_percentage: 80
 
-      # Memory boost configuration
-      memory:
-        baseline_mb: 4096
-        max_boost_mb: 12288
-        auto_reset: true
-
       instance:
-        type: r7g.large # 16GB RAM, 2 vCPUs, ARM64 - aligned with production
+        type: m7g.large # 8GB RAM, 2 vCPUs, ARM64 - aligned with production
         databases_per_instance: 1
-        max_memory_mb: 14336 # 14GB total available for parent + subgraphs
-        memory_per_db_mb: 1300 # ~1.3GB average per database (14GB / 11 databases)
-        chunk_size: 1500
+        max_memory_mb: 6144 # 6GB available (8GB - 2GB OS/container overhead)
+        memory_per_db_mb: 2048 # 2GB for the parent database
+        memory_per_subgraph_mb: 384 # 384MB per subgraph (10 max)
+        chunk_size: 1000
         query_timeout: 60
         max_query_length: 25000
-        ingestion_batch_size: 2500
-        connection_pool_size: 25
-        duckdb_memory_limit: "4GB" # Aligned with production
-        duckdb_max_threads: 2 # r7g.large = 2 vCPU
+        ingestion_batch_size: 1500
+        connection_pool_size: 15
+        duckdb_memory_limit: "2GB" # Aligned with production
+        duckdb_max_threads: 2 # m7g.large = 2 vCPU
 
       deployment:
         enable_var: LBUG_LARGE_ENABLED_STAGING
@@ -461,24 +447,18 @@ staging:
 
       # Graph content limits (same as production)
       graph_limits:
-        max_nodes: 200000000
-        max_relationships: 500000000
+        instance_storage_limit_gb: 100
         max_rows_per_copy: 50000000
         max_single_table_rows: 100000000
         chunk_size_rows: 5000000
         warn_at_percentage: 80
 
-      # Memory boost configuration
-      memory:
-        baseline_mb: 8192
-        max_boost_mb: 28672
-        auto_reset: true
-
       instance:
         type: r7g.xlarge # 32GB RAM, 4 vCPUs, ARM64 - aligned with production
         databases_per_instance: 1
         max_memory_mb: 30720 # 30GB available (32GB - 2GB OS overhead)
-        memory_per_db_mb: 1180 # ~1.2GB average per database (30GB / 26 databases)
+        memory_per_db_mb: 8192 # 8GB for the parent database
+        memory_per_subgraph_mb: 1024 # 1GB per subgraph (25 max)
         chunk_size: 2000
         query_timeout: 120
         max_query_length: 50000
@@ -584,30 +564,24 @@ development:
 
       # Graph content limits (same as production)
       graph_limits:
-        max_nodes: 5000000
-        max_relationships: 10000000
-        max_rows_per_copy: 2000000
-        max_single_table_rows: 5000000
-        chunk_size_rows: 500000
+        instance_storage_limit_gb: 20
+        max_rows_per_copy: 1000000
+        max_single_table_rows: 2500000
+        chunk_size_rows: 250000
         warn_at_percentage: 80
 
-      # Memory boost configuration
-      memory:
-        baseline_mb: 2048
-        max_boost_mb: 6144
-        auto_reset: true
-
       instance:
-        type: m7g.large
+        type: m7g.medium
         databases_per_instance: 1 # Dedicated
-        max_memory_mb: 6144
-        memory_per_db_mb: 2048
-        chunk_size: 750
-        query_timeout: 30
+        max_memory_mb: 3072
+        memory_per_db_mb: 1024
+        memory_per_subgraph_mb: 384
+        chunk_size: 500
+        query_timeout: 45
         max_query_length: 10000
-        ingestion_batch_size: 750
-        connection_pool_size: 10
-        duckdb_memory_limit: "2GB" # Default for local development
+        ingestion_batch_size: 500
+        connection_pool_size: 5
+        duckdb_memory_limit: "1GB" # Matches production so local dev hits the same limits
         duckdb_max_threads: 4 # Local dev can use more threads
 
       deployment:

--- a/.github/configs/graph.yml
+++ b/.github/configs/graph.yml
@@ -62,6 +62,8 @@ production:
       instance:
         type: m7g.medium # 4GB RAM, 1 vCPU, ARM64 - dedicated per customer
         databases_per_instance: 1 # Dedicated: one customer per instance
+        vcpus: 1 # Physical vCPU count (customer-facing; do not derive from duckdb_max_threads)
+        instance_ram_gb: 4 # Physical instance RAM (customer-facing; max_memory_mb is the LadybugDB budget)
 
         # Memory configuration
         # Admission control trips at 85% of 4GB = ~3.4GB. Worst concurrent case
@@ -128,6 +130,8 @@ production:
       instance:
         type: m7g.large # 8GB RAM, 2 vCPUs, ARM64 - dedicated per customer
         databases_per_instance: 1 # One parent database per instance (subgraphs on same instance)
+        vcpus: 2
+        instance_ram_gb: 8
 
         # Memory configuration
         # Parent gets a full 2GB pool; subgraphs are intentionally oversubscribed
@@ -194,6 +198,8 @@ production:
       instance:
         type: r7g.xlarge # 32GB RAM, 4 vCPUs, ARM64 - large dedicated per customer
         databases_per_instance: 1 # One parent database per instance (many subgraphs on same instance)
+        vcpus: 4
+        instance_ram_gb: 32
 
         # Memory configuration
         # Parent gets a full 8GB pool; subgraphs are intentionally oversubscribed
@@ -356,6 +362,8 @@ staging:
       instance:
         type: m7g.medium # 4GB RAM, 1 vCPU, ARM64 - aligned with production
         databases_per_instance: 1 # Dedicated
+        vcpus: 1
+        instance_ram_gb: 4
         max_memory_mb: 3072 # 3GB available (4GB - 1GB OS/container overhead)
         memory_per_db_mb: 1024 # 1GB for the parent database
         memory_per_subgraph_mb: 384 # 384MB per subgraph (3 max)
@@ -406,6 +414,8 @@ staging:
       instance:
         type: m7g.large # 8GB RAM, 2 vCPUs, ARM64 - aligned with production
         databases_per_instance: 1
+        vcpus: 2
+        instance_ram_gb: 8
         max_memory_mb: 6144 # 6GB available (8GB - 2GB OS/container overhead)
         memory_per_db_mb: 2048 # 2GB for the parent database
         memory_per_subgraph_mb: 384 # 384MB per subgraph (10 max)
@@ -456,6 +466,8 @@ staging:
       instance:
         type: r7g.xlarge # 32GB RAM, 4 vCPUs, ARM64 - aligned with production
         databases_per_instance: 1
+        vcpus: 4
+        instance_ram_gb: 32
         max_memory_mb: 30720 # 30GB available (32GB - 2GB OS overhead)
         memory_per_db_mb: 8192 # 8GB for the parent database
         memory_per_subgraph_mb: 1024 # 1GB per subgraph (25 max)
@@ -573,6 +585,8 @@ development:
       instance:
         type: m7g.medium
         databases_per_instance: 1 # Dedicated
+        vcpus: 1
+        instance_ram_gb: 4
         max_memory_mb: 3072
         memory_per_db_mb: 1024
         memory_per_subgraph_mb: 384

--- a/bin/lambda/graph_volume_manager.py
+++ b/bin/lambda/graph_volume_manager.py
@@ -473,9 +473,17 @@ def create_and_attach_volume(
   instance_id: str, tier: str, az: str, databases: list[str], node_type: str
 ) -> dict[str, Any]:
   """Create a new volume and attach it to the instance"""
-  # Tier configurations (updated to match .github/configs/graph.yml)
+  # Initial volume sizes. These are starting points, not caps: the volume
+  # monitor expands at 80% usage every 15 minutes, and EBS volumes can grow
+  # but never shrink - so provisioning small and growing on demand costs
+  # strictly less than provisioning for a ceiling most graphs never reach.
+  # The product cap is enforced separately by instance_storage_limit_gb in
+  # .github/configs/graph.yml (20/50/100 GB); these do not need to match it,
+  # since expansion at 80% fires before the write-path cap is reached.
+  # gp3's 3000 IOPS / 125 MBps baseline is size-independent, so a smaller
+  # volume carries no performance penalty.
   tier_config = {
-    "ladybug-standard": {"size": 50, "iops": 3000},
+    "ladybug-standard": {"size": 20, "iops": 3000},
     "ladybug-large": {"size": 50, "iops": 3000},
     "ladybug-xlarge": {"size": 50, "iops": 3000},
     "ladybug-shared": {"size": 200, "iops": 3000},

--- a/bin/lambda/graph_volume_monitor.py
+++ b/bin/lambda/graph_volume_monitor.py
@@ -36,7 +36,11 @@ INSTANCE_REGISTRY_TABLE = os.environ.get("INSTANCE_REGISTRY_TABLE")
 ALERT_TOPIC_ARN = os.environ.get("ALERT_TOPIC_ARN")
 EXPANSION_THRESHOLD = float(os.environ.get("EXPANSION_THRESHOLD", "0.8"))  # 80%
 EXPANSION_FACTOR = float(os.environ.get("EXPANSION_FACTOR", "1.5"))  # 50% increase
-MIN_EXPANSION_GB = int(os.environ.get("MIN_EXPANSION_GB", "50"))
+# Floor on each expansion step. Kept meaningfully large because EBS enforces
+# a ~6 hour cooldown between volume modifications - too small a step risks
+# needing another expansion before the next one is allowed. At the 20GB
+# Standard starting size this yields 20 -> 40GB, a doubling.
+MIN_EXPANSION_GB = int(os.environ.get("MIN_EXPANSION_GB", "20"))
 MAX_VOLUME_SIZE_GB = int(os.environ.get("MAX_VOLUME_SIZE_GB", "16384"))  # EBS limit
 GRAPH_API_PORT = os.environ.get("GRAPH_API_PORT", "8001")
 GRAPH_API_SECRET_ARN = os.environ.get("GRAPH_API_SECRET_ARN", "")

--- a/bin/setup/aws.sh
+++ b/bin/setup/aws.sh
@@ -206,6 +206,10 @@ function create_ssm_feature_flags() {
         "EMAIL_VERIFICATION_ENABLED=false"
         "FACT_GRID_ENABLED=false"
         "EXTENSIONS_ENABLED=false"
+        # Kill switch for graph_usage_monitor_sensor's 80%/100% storage emails.
+        # Seeded at its code default purely so it is discoverable in
+        # `just ssm-list <env> features` — a kill switch you cannot find is not one.
+        "GRAPH_USAGE_ALERTS_ENABLED=true"
         "LEDGER_ENABLED=false"
         "LOAD_SHEDDING_ENABLED=true"
         "MCP_AUTO_LIMIT_ENABLED=true"

--- a/robosystems/config/billing/core.py
+++ b/robosystems/config/billing/core.py
@@ -32,8 +32,8 @@ DEFAULT_GRAPH_BILLING_PLANS: list[dict[str, Any]] = [
   {
     "name": "ladybug-standard",
     "display_name": "Standard",
-    "description": "Dedicated m7g.large infrastructure with subgraph support",
-    "base_price_cents": 14900,  # $149/month
+    "description": "Dedicated infrastructure with subgraph support - AI controller layer for a single set of books",
+    "base_price_cents": 9900,  # $99/month
     "monthly_credit_allocation": 8000,  # ~200 agent calls/month
     "backup_downloads_per_month": 10,
     "max_documents": 100,
@@ -42,8 +42,8 @@ DEFAULT_GRAPH_BILLING_PLANS: list[dict[str, Any]] = [
   {
     "name": "ladybug-large",
     "display_name": "Large",
-    "description": "Dedicated r7g.large instance - enhanced performance with subgraph support",
-    "base_price_cents": 29900,  # $299/month
+    "description": "Enhanced performance and expanded subgraph capacity for growing teams",
+    "base_price_cents": 24900,  # $249/month
     "monthly_credit_allocation": 32000,  # ~800 agent calls/month
     "backup_downloads_per_month": 20,
     "max_documents": 1000,
@@ -52,8 +52,8 @@ DEFAULT_GRAPH_BILLING_PLANS: list[dict[str, Any]] = [
   {
     "name": "ladybug-xlarge",
     "display_name": "XLarge",
-    "description": "Dedicated r7g.xlarge instance - maximum performance and scale",
-    "base_price_cents": 69900,  # $699/month
+    "description": "Maximum performance and scale with the highest subgraph capacity",
+    "base_price_cents": 59900,  # $599/month
     "monthly_credit_allocation": 100000,  # ~2,600 agent calls/month
     "backup_downloads_per_month": 40,
     "max_documents": 10000,

--- a/robosystems/config/graph_tier.py
+++ b/robosystems/config/graph_tier.py
@@ -385,11 +385,17 @@ class GraphTierConfig:
         Graph limits dictionary with instance_storage_limit_gb, row limits, etc.
     """
     tier_config = cls.get_tier_config(tier, environment)
+    # These fire only when a tier resolves without a graph_limits block (unknown
+    # tier, malformed config). They MUST track the smallest tier — the row caps
+    # are OOM guardrails sized to instance RAM, so falling back to a larger
+    # tier's values would apply an 8GB-sized copy limit to a 4GB box and cause
+    # the exact OOM the guardrail exists to prevent. Keep in sync with
+    # ladybug-standard in .github/configs/graph.yml on every tier resize.
     defaults: dict[str, Any] = {
       "instance_storage_limit_gb": 20,
-      "max_rows_per_copy": 2_000_000,
-      "max_single_table_rows": 5_000_000,
-      "chunk_size_rows": 1_000_000,
+      "max_rows_per_copy": 1_000_000,
+      "max_single_table_rows": 2_500_000,
+      "chunk_size_rows": 250_000,
       "warn_at_percentage": 80,
     }
     return tier_config.get("graph_limits", defaults)

--- a/robosystems/config/graph_tier.py
+++ b/robosystems/config/graph_tier.py
@@ -415,27 +415,6 @@ class GraphTierConfig:
     return float(graph_limits.get("instance_storage_limit_gb", 20))
 
   @classmethod
-  def get_memory_config(
-    cls, tier: str, environment: str | None = None
-  ) -> dict[str, Any]:
-    """Get memory boost configuration for a tier.
-
-    Args:
-        tier: The tier name (ladybug-standard, ladybug-large, ladybug-xlarge)
-        environment: Environment (defaults to current env)
-
-    Returns:
-        Memory config dictionary with baseline_mb, max_boost_mb, auto_reset
-    """
-    tier_config = cls.get_tier_config(tier, environment)
-    defaults: dict[str, Any] = {
-      "baseline_mb": 2048,
-      "max_boost_mb": 6144,
-      "auto_reset": True,
-    }
-    return tier_config.get("memory", defaults)
-
-  @classmethod
   def get_storage_cap_gb(cls, tier: str, environment: str | None = None) -> float:
     """Get storage safety cap in GB (from backup limits, not billed).
 

--- a/robosystems/dagster/sensors/usage_monitor.py
+++ b/robosystems/dagster/sensors/usage_monitor.py
@@ -24,10 +24,32 @@ _ALERT_DEDUP_TTL_SECONDS = 7 * 24 * 3600
 # Thresholds that trigger alerts
 _ALERT_STATUSES = ("approaching", "over_limit")
 
+# RUNNING since 2026-07-27. This sensor shipped STOPPED on 2026-04-04 alongside
+# a *soft* storage cap, where "nothing enforces, nothing alerts" was coherent.
+# The cap was promoted soft -> hard on 2026-05-13 (materialize now 413s at >100%)
+# but the sensor was never started, so the hard block lost the 80% warning that
+# was supposed to give customers runway. Nobody noticed because the underlying
+# measure returned 0 for directory-shaped databases until #937 (2026-07-26) —
+# every graph read as 0% healthy, so neither the alert nor the block ever fired.
+# With the measure real, a live hard cap without its warning is not a state
+# anyone chose.
+#
+# NOTE: this is only the status applied when the Dagster instance first sees the
+# sensor. On/off state then persists in Dagster's Postgres storage, so a UI
+# toggle outlives this value — which is why the runtime kill switch below is an
+# SSM flag rather than a redeploy of this constant.
+_SENSOR_STATUS = DefaultSensorStatus.RUNNING
+
+# Runtime kill switch, read per tick (SSM, 5-min TTL cache) so alerting can be
+# stopped immediately without a deploy or a Dagster UI login:
+#   just ssm-set prod features/GRAPH_USAGE_ALERTS_ENABLED false
+# Defaults on — an alerting sensor should fail toward telling you.
+_ALERTS_ENABLED_FLAG = "GRAPH_USAGE_ALERTS_ENABLED"
+
 
 @sensor(
   minimum_interval_seconds=21600,  # 6 hours
-  default_status=DefaultSensorStatus.STOPPED,
+  default_status=_SENSOR_STATUS,
   description="Monitors graph instance storage and sends email alerts at 80%/100% thresholds",
 )
 def graph_usage_monitor_sensor(context: SensorEvaluationContext):
@@ -48,12 +70,18 @@ def graph_usage_monitor_sensor(context: SensorEvaluationContext):
   With many active graphs, consider the cumulative latency. The 6-hour
   interval keeps this manageable.
   """
+  from robosystems.config.parameter_store import get_parameter_value
   from robosystems.config.valkey_registry import ValkeyDatabase, create_redis_client
   from robosystems.database import session as db_session_factory
   from robosystems.middleware.graph.ingestion_limits import IngestionLimitChecker
   from robosystems.models.core.graph import Graph
   from robosystems.models.core.graph.graph_user import GraphUser
   from robosystems.models.core.user import User
+
+  # Read per tick rather than at import, so flipping the flag takes effect on the
+  # next evaluation instead of the next deploy.
+  if get_parameter_value(_ALERTS_ENABLED_FLAG, "true").lower() != "true":
+    return SkipReason(f"Storage alerts disabled via {_ALERTS_ENABLED_FLAG}")
 
   db = db_session_factory()
   try:

--- a/robosystems/middleware/graph/ingestion_limits.py
+++ b/robosystems/middleware/graph/ingestion_limits.py
@@ -71,15 +71,18 @@ class IngestionLimitChecker:
     pending_rows = cls._get_pending_row_counts(db, graph_id)
     total_pending_rows = sum(pending_rows.values())
 
-    # Check max_rows_per_copy (hard limit — prevents OOM during materialization)
-    max_rows_per_copy = limits.get("max_rows_per_copy", 2_000_000)
+    # Check max_rows_per_copy (hard limit — prevents OOM during materialization).
+    # Fallbacks here and below track ladybug-standard, the smallest tier, for the
+    # reason given in GraphTierConfig.get_graph_limits: a fallback larger than the
+    # actual box defeats the guardrail.
+    max_rows_per_copy = limits.get("max_rows_per_copy", 1_000_000)
     if total_pending_rows > max_rows_per_copy:
       errors.append(
         f"Total rows ({total_pending_rows:,}) exceeds max_rows_per_copy limit ({max_rows_per_copy:,})"
       )
 
     # Check individual table row limits (hard limit)
-    max_single_table = limits.get("max_single_table_rows", 5_000_000)
+    max_single_table = limits.get("max_single_table_rows", 2_500_000)
     for tbl_name, row_count in pending_rows.items():
       if row_count > max_single_table:
         errors.append(
@@ -103,7 +106,7 @@ class IngestionLimitChecker:
       "limits": {
         "max_rows_per_copy": max_rows_per_copy,
         "max_single_table_rows": max_single_table,
-        "chunk_size_rows": limits.get("chunk_size_rows", 1_000_000),
+        "chunk_size_rows": limits.get("chunk_size_rows", 250_000),
         "instance_storage_limit_gb": storage_check["limit_gb"],
       },
       "tier": tier,

--- a/robosystems/models/api/billing/offering.py
+++ b/robosystems/models/api/billing/offering.py
@@ -35,6 +35,9 @@ class GraphSubscriptionTier(BaseModel):
   api_rate_multiplier: float = Field(..., description="API rate multiplier")
   backend: str = Field(..., description="Database backend identifier")
   instance_type: str | None = Field(None, description="Instance type")
+  instance_storage_limit_gb: float = Field(
+    0, description="Soft storage cap for the instance in GB"
+  )
 
 
 class GraphSubscriptions(BaseModel):

--- a/robosystems/operations/providers/payment_provider.py
+++ b/robosystems/operations/providers/payment_provider.py
@@ -440,16 +440,38 @@ class StripePaymentProvider(PaymentProvider):
       product = products.data[0]
       logger.info(f"Found existing Stripe product for {plan_name}: {product.id}")
 
-      prices = self.stripe.Price.list(product=product.id, active=True, limit=1)
-      if prices.data:
-        return prices.data[0].id
+      # Match on unit_amount, as the repository path does. Returning the first
+      # active price regardless of amount meant a base_price_cents change never
+      # reached Stripe: the old price stayed active on the product and kept
+      # being handed back, so checkout quoted the new price from config and
+      # billed the old one. Prices are immutable in Stripe, so a repricing is
+      # always "find the one at this amount, else create it" — never a mutation.
+      prices = self.stripe.Price.list(product=product.id, active=True, limit=100)
+      for price in prices.data:
+        if price.unit_amount == target_amount and price.recurring:
+          logger.info(
+            f"Found existing price {price.id} ({target_amount} cents) for {plan_name}"
+          )
+          return price.id
 
-      logger.warning(f"No active price for product {product.id}, creating new price")
+      logger.info(
+        f"No active price at {target_amount} cents for {plan_name}, creating one",
+        extra={"product_id": product.id, "amount": target_amount},
+      )
       price = self.stripe.Price.create(
         product=product.id,
         unit_amount=target_amount,
         currency="usd",
         recurring={"interval": "month"},
+        metadata={
+          "plan_name": plan_name,
+          "resource_type": "graph",
+          "environment": env.ENVIRONMENT,
+        },
+      )
+      logger.info(
+        f"Created price {price.id} ({target_amount} cents) for {plan_name}",
+        extra={"product_id": product.id, "price_id": price.id, "amount": target_amount},
       )
       return price.id
 

--- a/robosystems/routers/offering.py
+++ b/robosystems/routers/offering.py
@@ -47,7 +47,16 @@ async def get_service_offerings(
     # Get tier configurations from graph.yml for technical specs
     from ..config.graph_tier import GraphTierConfig
 
-    tier_configs = GraphTierConfig.get_available_tiers(include_disabled=False)
+    # include_disabled=True is deliberate. get_available_tiers() gates on
+    # deployment.always_enabled / enabled_default, which answers "is the
+    # CloudFormation stack deployed by default" — not "can a customer buy
+    # this". Large and XLarge carry enabled_default: false plus an enable_var
+    # (LBUG_LARGE_ENABLED_PROD) that only the deploy workflow reads, so the
+    # running API cannot see that they are in fact enabled. Filtering here
+    # dropped their tier_config and silently zeroed max_subgraphs and
+    # api_rate_multiplier. The customer_tiers list below plus the billing
+    # plans are the real gate on what gets listed.
+    tier_configs = GraphTierConfig.get_available_tiers(include_disabled=True)
 
     # Filter to only customer-facing tiers (exclude internal/shared infrastructure)
     customer_tiers = ["ladybug-standard", "ladybug-large", "ladybug-xlarge"]
@@ -66,13 +75,18 @@ async def get_service_offerings(
       backup_limits = GraphTierConfig.get_backup_limits(tier_name)
       backup_retention_days = backup_limits.get("backup_retention_days", 0)
 
-      # Get instance type from graph.yml
+      # Get instance type from graph.yml. vcpus and instance_ram_gb are the
+      # physical instance specs; duckdb_max_threads and max_memory_mb are
+      # tuning knobs (threads can oversubscribe the CPU, and max_memory_mb is
+      # the LadybugDB budget after OS overhead) and must not be reported here.
       instance_config = GraphTierConfig.get_instance_config(tier_name)
       instance_type = instance_config.get("type", "")
-      max_memory_mb = instance_config.get("max_memory_mb", 0)
-      vcpus = instance_config.get("duckdb_max_threads", 0)
+      vcpus = instance_config.get("vcpus", 0)
+      instance_ram_gb = instance_config.get("instance_ram_gb", 0)
       infrastructure = (
-        f"Dedicated {instance_type} ({vcpus} vCPU, {max_memory_mb // 1024} GB RAM)"
+        f"Dedicated {instance_type} ({vcpus} vCPU, {instance_ram_gb} GB RAM)"
+        if instance_type and vcpus and instance_ram_gb
+        else "Dedicated instance"
         if instance_type
         else "Managed infrastructure"
       )

--- a/tests/config/billing/test_core.py
+++ b/tests/config/billing/test_core.py
@@ -19,7 +19,7 @@ def test_get_subscription_plan_returns_plan_with_credit_allocation():
   assert plan is not None
   assert plan["name"] == "ladybug-standard"
   assert plan["monthly_credit_allocation"] == 8000  # ~200 agent calls/month
-  assert plan["base_price_cents"] == 14900  # $149/month
+  assert plan["base_price_cents"] == 9900  # $99/month
 
 
 def test_get_subscription_plan_returns_none_for_unknown_tier():

--- a/tests/config/test_graph_tier_config.py
+++ b/tests/config/test_graph_tier_config.py
@@ -189,8 +189,29 @@ def test_get_graph_limits_returns_large_tier_values(mock_graph_config):
 def test_get_graph_limits_falls_back_to_defaults(mock_graph_config):
   limits = GraphTierConfig.get_graph_limits("unknown-tier")
   assert limits["instance_storage_limit_gb"] == 20
-  assert limits["max_rows_per_copy"] == 2_000_000
-  assert limits["chunk_size_rows"] == 1_000_000
+  assert limits["max_rows_per_copy"] == 1_000_000
+  assert limits["chunk_size_rows"] == 250_000
+
+
+def test_graph_limit_defaults_do_not_exceed_the_smallest_tier():
+  """Fallback row caps must never be larger than the smallest tier's.
+
+  The row caps are OOM guardrails sized to instance RAM. A fallback larger
+  than the actual box would apply a bigger tier's copy limit to a smaller
+  instance — the exact OOM the guardrail exists to prevent. This drifted
+  once already: the defaults kept m7g.large's 2M/5M after ladybug-standard
+  moved to m7g.medium, so they are pinned against real config here rather
+  than against literals in the mocked fixture.
+  """
+  GraphTierConfig.clear_cache()
+  standard = GraphTierConfig.get_graph_limits("ladybug-standard", "production")
+  defaults = GraphTierConfig.get_graph_limits("does-not-exist", "production")
+
+  for key in ("max_rows_per_copy", "max_single_table_rows", "chunk_size_rows"):
+    assert defaults[key] <= standard[key], (
+      f"default {key}={defaults[key]:,} exceeds ladybug-standard's "
+      f"{standard[key]:,} — a fallback must never be larger than the smallest tier"
+    )
 
 
 def test_get_instance_storage_limit_gb(mock_graph_config):

--- a/tests/config/test_graph_tier_config.py
+++ b/tests/config/test_graph_tier_config.py
@@ -35,12 +35,9 @@ production:
         max_single_table_rows: 5000000
         chunk_size_rows: 1000000
         warn_at_percentage: 80
-      memory:
-        baseline_mb: 2048
-        max_boost_mb: 6144
-        auto_reset: true
       instance:
         memory_per_db_mb: 512
+        memory_per_subgraph_mb: 256
         max_memory_mb: 4096
         chunk_size: 256
         query_timeout: 120
@@ -52,10 +49,6 @@ production:
         max_single_table_rows: 25000000
         chunk_size_rows: 2000000
         warn_at_percentage: 80
-      memory:
-        baseline_mb: 4096
-        max_boost_mb: 12288
-        auto_reset: true
       instance:
         memory_per_db_mb: 2048
 staging:
@@ -205,24 +198,15 @@ def test_get_instance_storage_limit_gb(mock_graph_config):
   assert GraphTierConfig.get_instance_storage_limit_gb("ladybug-large") == 50.0
 
 
-def test_get_memory_config_returns_configured_values(mock_graph_config):
-  memory = GraphTierConfig.get_memory_config("ladybug-standard")
-  assert memory["baseline_mb"] == 2048
-  assert memory["max_boost_mb"] == 6144
-  assert memory["auto_reset"] is True
+def test_subgraph_memory_is_configured_separately_from_parent(mock_graph_config):
+  """Subgraphs get a smaller buffer pool than the parent database.
 
-
-def test_get_memory_config_large_tier(mock_graph_config):
-  memory = GraphTierConfig.get_memory_config("ladybug-large")
-  assert memory["baseline_mb"] == 4096
-  assert memory["max_boost_mb"] == 12288
-
-
-def test_get_memory_config_falls_back_to_defaults(mock_graph_config):
-  memory = GraphTierConfig.get_memory_config("unknown-tier")
-  assert memory["baseline_mb"] == 2048
-  assert memory["max_boost_mb"] == 6144
-  assert memory["auto_reset"] is True
+  get_database_memory_config() reads memory_per_subgraph_mb for names
+  containing an underscore, falling back to memory_per_db_mb otherwise.
+  """
+  instance = GraphTierConfig.get_tier_config("ladybug-standard")["instance"]
+  assert instance["memory_per_db_mb"] == 512
+  assert instance["memory_per_subgraph_mb"] == 256
 
 
 def test_get_storage_cap_gb_from_backup_limits(mock_graph_config):

--- a/tests/dagster/test_usage_monitor.py
+++ b/tests/dagster/test_usage_monitor.py
@@ -6,6 +6,7 @@ from dagster import build_sensor_context
 
 from robosystems.dagster.sensors.usage_monitor import (
   _ALERT_DEDUP_TTL_SECONDS,
+  _ALERTS_ENABLED_FLAG,
   graph_usage_monitor_sensor,
 )
 
@@ -19,6 +20,53 @@ def _make_graph(graph_id="kg_test123", tier="ladybug-standard"):
   graph.parent_graph_id = None
   graph.status = "active"
   return graph
+
+
+class TestSensorEnablement:
+  """The sensor must be on, and must stay switchable off without a deploy.
+
+  It shipped STOPPED on 2026-04-04 next to a soft cap, the cap went hard on
+  2026-05-13, and nobody restarted the sensor — so the hard 413 lost the 80%
+  warning meant to precede it. Pinned here so that cannot recur silently.
+  """
+
+  def test_sensor_default_status_is_running(self):
+    from dagster import DefaultSensorStatus
+
+    from robosystems.dagster.sensors.usage_monitor import _SENSOR_STATUS
+
+    assert _SENSOR_STATUS is DefaultSensorStatus.RUNNING
+
+  @patch("robosystems.config.parameter_store.get_parameter_value")
+  @patch("robosystems.database.session")
+  def test_ssm_flag_false_skips_before_touching_the_database(
+    self, mock_session_factory, mock_get_param
+  ):
+    """The kill switch short-circuits before any DB or Graph API work."""
+    mock_get_param.return_value = "false"
+    mock_db = MagicMock()
+    mock_session_factory.return_value = mock_db
+
+    result = graph_usage_monitor_sensor(build_sensor_context())
+
+    assert result is not None
+    assert _ALERTS_ENABLED_FLAG in str(result)
+    mock_db.query.assert_not_called()
+
+  @patch("robosystems.config.parameter_store.get_parameter_value")
+  @patch("robosystems.database.session")
+  def test_defaults_to_enabled_when_flag_unset(
+    self, mock_session_factory, mock_get_param
+  ):
+    """Absent config, alerting runs — it should fail toward telling you."""
+    mock_get_param.side_effect = lambda _key, default="": default
+    mock_db = MagicMock()
+    mock_session_factory.return_value = mock_db
+    mock_db.query.return_value.filter.return_value.all.return_value = []
+
+    graph_usage_monitor_sensor(build_sensor_context())
+
+    mock_db.query.assert_called_once()
 
 
 class TestGraphUsageMonitorSensor:

--- a/tests/middleware/graph/test_ingestion_limits.py
+++ b/tests/middleware/graph/test_ingestion_limits.py
@@ -152,7 +152,7 @@ class TestCheckMaterializationLimits:
     with patch.object(
       IngestionLimitChecker,
       "_get_pending_row_counts",
-      return_value={"Entity": 1_000_000, "ENTITY_HAS_FACT": 500_000},
+      return_value={"Entity": 500_000, "ENTITY_HAS_FACT": 250_000},
     ):
       result = await IngestionLimitChecker.check_materialization_limits(
         db=mock_db,

--- a/tests/operations/providers/test_payment_provider.py
+++ b/tests/operations/providers/test_payment_provider.py
@@ -504,3 +504,64 @@ class TestStripeCaching:
     """Test that in-memory price cache is available."""
     assert hasattr(StripePaymentProvider, "_price_cache")
     assert hasattr(StripePaymentProvider, "_price_lock")
+
+
+class TestGraphPriceResolution:
+  """Graph prices must be matched by amount, not by 'first active price'.
+
+  Regression guard for a repricing that could not reach Stripe: the graph path
+  returned prices.data[0] without checking unit_amount, so changing
+  base_price_cents left the old price active and still being handed out —
+  checkout quoted the new amount from config and billed the old one. The
+  repository path had always matched on amount; only the graph path did not.
+  """
+
+  @pytest.fixture
+  def stripe_provider(self):
+    with patch("robosystems.operations.providers.payment_provider.env") as mock_env:
+      mock_env.ENVIRONMENT = "prod"
+      with patch.object(StripePaymentProvider, "__init__", lambda self: None):
+        provider = StripePaymentProvider()
+        provider.stripe = Mock()
+        yield provider
+
+  @staticmethod
+  def _price(price_id, unit_amount):
+    price = Mock()
+    price.id = price_id
+    price.unit_amount = unit_amount
+    price.recurring = {"interval": "month"}
+    return price
+
+  def _with_existing_prices(self, provider, prices):
+    product = Mock()
+    product.id = "prod_existing"
+    provider.stripe.Product.search.return_value = Mock(data=[product])
+    provider.stripe.Price.list.return_value = Mock(data=prices)
+    return product
+
+  def test_ignores_active_price_at_a_different_amount(self, stripe_provider):
+    """A stale $149 price must not satisfy a request for $99."""
+    self._with_existing_prices(stripe_provider, [self._price("price_old_149", 14900)])
+    stripe_provider.stripe.Price.create.return_value = self._price("price_new_99", 9900)
+
+    result = stripe_provider._get_or_create_graph_price(
+      "ladybug-standard", {"display_name": "Standard"}, 9900
+    )
+
+    assert result == "price_new_99"
+    assert stripe_provider.stripe.Price.create.call_args.kwargs["unit_amount"] == 9900
+
+  def test_reuses_the_price_that_matches_the_target_amount(self, stripe_provider):
+    """Matching price is reused, so repeated calls don't litter duplicates."""
+    self._with_existing_prices(
+      stripe_provider,
+      [self._price("price_old_149", 14900), self._price("price_99", 9900)],
+    )
+
+    result = stripe_provider._get_or_create_graph_price(
+      "ladybug-standard", {"display_name": "Standard"}, 9900
+    )
+
+    assert result == "price_99"
+    stripe_provider.stripe.Price.create.assert_not_called()


### PR DESCRIPTION
Downsizes the dedicated graph tiers to match observed load, reprices to follow the new cost base, and fixes three bugs in the public offerings catalog found along the way.

## Why

A month of prod telemetry across the three `ladybug-standard` m7g.large instances:

| Metric | Config allows | Actual |
|---|---|---|
| Memory | 6,144 MB cap, 2,048 MB/db | **~10% of 8 GiB (~800 MB)**, flat for a month |
| CPU (2 vCPU) | — | avg 0.6–1.2%, peak 27–42% |
| Disk IO | 630 Mbps EBS baseline | peaks 15–35 MB/interval (~1–2%) |
| Disk used | 50 GB volume | ~0% |

The 07/25 CPU and disk spikes correspond to the FP&A restamp — the heaviest recent materialization run — and it did not move memory off 10%.

## Instance ladder

| Tier | Was | Now |
|---|---|---|
| Standard | m7g.large (2 vCPU / 8 GiB) | **m7g.medium (1 vCPU / 4 GiB)** |
| Large | r7g.large (2 vCPU / 16 GiB) | **m7g.large (2 vCPU / 8 GiB)** |
| XLarge | r7g.xlarge (4 vCPU / 32 GiB) | unchanged |

## Pricing

$149 / $299 / $699 → **$99 / $249 / $599**.

At the effective SP/RI rates the fleet actually pays (~50% off on-demand, confirmed against June amortized Cost Explorer data — m7g.large ran $0.0384/hr vs $0.0816 list), $99 on m7g.medium earns the same margin that $149 on m7g.large earns today. The entry cut is margin-neutral. Existing m7g convertible RIs (8 normalization units) now cover 4 Standard graphs instead of 2.

## Memory model

Memory is re-expressed as parent + subgraph rather than one flat average divided across every database. XLarge's parent was previously capped at 1,180 MB — below Standard's 2,048 MB — because 30 GB was divided across all 26 databases. It now gets a full 8 GB pool with subgraphs at 1 GB.

Buffer pools are lazily-filled caps, not reservations, so nominal totals may exceed `max_memory_mb`; the hard ceiling is the admission-control guard at 85% of instance RAM. Sizing keeps parent + DuckDB under that even when both are hot.

## Dead config removed

The `memory: {baseline_mb, max_boost_mb, auto_reset}` blocks were read only by `GraphTierConfig.get_memory_config()`, which had no production caller. The real boost path reads `instance.ladybug_memory_boost_mb`, set only on the shared tier — so customer tiers never boosted at all. Also drops the unused `max_nodes` / `max_relationships` keys that staging and development carried.

Staging and development Standard are now value-identical to production.

## Offerings fixes

The catalog listed Large and XLarge with `max_subgraphs: 0` and `api_rate_multiplier: 1.0`, and omitted their storage line.

- `get_available_tiers(include_disabled=False)` gates on `deployment.always_enabled` / `enabled_default`. Large and XLarge set `enabled_default: false` and rely on `enable_var` (`LBUG_LARGE_ENABLED_PROD`), which only the deploy workflow reads — it appears nowhere in application or CloudFormation runtime config. The tiers were filtered out, `tier_config` resolved to `None`, and specs silently fell back to zeros while the tier was still listed and priced. Now passes `include_disabled=True`; the `customer_tiers` list and billing plans are the real gate.
- `GraphSubscriptionTier` now declares `instance_storage_limit_gb`. The router had been computing it, but the field was absent from the response model, so Pydantic dropped it for every tier including Standard.
- The infrastructure string reads new `vcpus` / `instance_ram_gb` keys instead of deriving from `duckdb_max_threads` and `max_memory_mb`. Those are tuning knobs — threads intentionally oversubscribe the CPU, and `max_memory_mb` is the LadybugDB budget after OS overhead. The old derivation already misreported Standard as 6 GB on an 8 GB box, and would have printed "2 vCPU, 3 GB RAM" for a 1 vCPU / 4 GB m7g.medium.

## Testing

`just test-all`: 2,783 passed. One pre-existing ordering-dependent failure (`test_incremental_equals_full_load`) reproduces identically on `main` and passes both in isolation and in a full `tests/graph_api` run — unrelated to this branch.

Verified against production config:

```
ladybug-standard   subgraphs=3    rate=1.0   m7g.medium (1 vCPU, 4 GB RAM)   storage=20.0
ladybug-large      subgraphs=10   rate=1.5   m7g.large  (2 vCPU, 8 GB RAM)   storage=50.0
ladybug-xlarge     subgraphs=25   rate=2.5   r7g.xlarge (4 vCPU, 32 GB RAM)  storage=100.0
```

No downstream changes needed — the frontends read prices from `/v1/offering` at runtime.

## Deployment notes

- The instance type is a CloudFormation parameter, so this **auto-cycles the three live prod Standard instances**. No ASG refresh needed, but it is a fleet replacement on customer graphs.
- Recommend deploying staging first and pushing a real book through it. The 4 GiB sizing is backed by telemetry from a near-idle three-instance fleet; it survived the FP&A restamp without denting memory, but has not been exercised by a busy multi-graph fleet.
- `LBUG_STANDARD_MAX_INSTANCES_PROD` was raised 5 → 20 separately (GitHub variable, takes effect on next deploy). RI coverage ends at 4 graphs; beyond that, graphs land on the Compute SP or on-demand.