### PR TITLE
docs(taxonomy): correct resync module's account of its own callers

### DIFF
--- a/robosystems/operations/taxonomy_block/resync.py
+++ b/robosystems/operations/taxonomy_block/resync.py
@@ -9,9 +9,16 @@ inside a transaction that has executed ``SET LOCAL robosystems.library_resync =
 'on'`` — the GUC the immutability trigger (migration 0016) honors so the seeder,
 and only the seeder, may update library-origin rows in tenant scope.
 
-The admin CLI surface (``just admin … taxonomy resync``) and the
-auto-propagate-on-publish hook wrap these functions; nothing here is wired to a
-publish event yet.
+**These two wrappers currently have no callers.** No admin CLI group, no job, no
+publish hook invokes them — an earlier version of this docstring described that
+surface as if it existed. What *does* run in production is the lower-level
+``resync_library_into_tenant`` called directly from migrations (0022 rs-metric,
+0023 rs-metric grown in place, 0024 rs-driver), each fanning one **package-pinned**
+resync across ``for_each_tenant_schema``. So the propagation machinery is proven;
+what is missing is only an operator entrypoint that does not require authoring a
+migration — and, because every migration so far pinned a single package,
+**rs-gaap core has never been re-propagated to a provisioned tenant**. Keep these
+functions: they are the intended seam for that entrypoint.
 
 Propagation policy: only safe for **in-place fixes within a framework version**
 (mapping targets stay version-stable; filed reports pin their own FactSets; live


### PR DESCRIPTION
## Summary

Docstring-only correction to `robosystems/operations/taxonomy_block/resync.py`. No behavior change.

The module docstring claimed an admin CLI surface (`just admin … taxonomy resync`) and an auto-propagate-on-publish hook wrapped `resync_tenant` / `resync_all_tenants`. Neither exists — there is no `taxonomy` group under `robosystems/admin/commands/`, and both wrappers have **zero callers**.

## What actually propagates

`resync_library_into_tenant` — the lower-level function — called directly from extensions migrations:

| Migration | Package | Note |
| --- | --- | --- |
| `0022_metrics` | `rs-metric` | initial seed |
| `0023_metrics_m2` | `rs-metric` | grown **in place** — the amend path, not just additive |
| `0024_forecast` | `rs-driver` | initial seed |

Each reseeds `public` from the baked JSON-LD artifact via 0002's three seed passes, then fans a **package-pinned** resync across `for_each_tenant_schema` under the 0016 `SET LOCAL robosystems.library_resync` GUC.

## Why it's worth a commit

Both facts were mis-read straight from the docstring during a planning pass:

1. The propagation machinery is **proven in production**, not unbuilt-and-unused — so a taxonomy change ships to tenants today by authoring a migration modeled on `0023`.
2. Because every migration so far pinned a single package, **rs-gaap core has never been re-propagated to a provisioned tenant.** That is the real remaining gap, and it wasn't visible from the code's own description of itself.

The wrappers are kept deliberately — they remain the intended seam for a future operator entrypoint (a Dagster job; an admin CLI is unsuitable here because `just admin` runs on the host and the reseed reads the artifact from disk, so a prod invocation would seed the shared `public` library from the operator's local checkout).

## Test plan

- [x] `uv run ruff check` — clean
- [x] `uv run ruff format --check` — clean
- [x] No executable lines touched; diff is entirely within the module docstring

🤖 Generated with [Claude Code](https://claude.com/claude-code)