### PR TITLE
Omit offering tiers this environment cannot describe

### DIFF
--- a/robosystems/routers/offering.py
+++ b/robosystems/routers/offering.py
@@ -71,6 +71,19 @@ async def get_service_offerings(
       # Find the corresponding tier config for technical specs
       tier_config = next((t for t in tier_configs if t.get("tier") == tier_name), None)
 
+      # Skip a tier this environment cannot describe. Billing defines what is
+      # purchasable; graph.yml defines the specs. When the two disagree — as in
+      # local dev, which only defines ladybug-standard because it runs a single
+      # graph_api — the tier used to be advertised anyway, with max_subgraphs
+      # fabricated as 0 and the limits falling through to Standard-shaped
+      # defaults. "Zero subgraphs, 20 GB" is a confident wrong answer where the
+      # truth is "not offered here"; omitting the tier says that instead.
+      if not tier_config:
+        logger.info(
+          f"Skipping tier {tier_name} in offerings: no tier config for this environment"
+        )
+        continue
+
       # Get backup retention from graph.yml (single source of truth for infra limits)
       backup_limits = GraphTierConfig.get_backup_limits(tier_name)
       backup_retention_days = backup_limits.get("backup_retention_days", 0)
@@ -101,23 +114,17 @@ async def get_service_offerings(
         else "Standard support",
       ]
 
-      # Add subgraph support if available
-      if tier_config and tier_config.get("max_subgraphs", 0) > 0:
+      # tier_config is guaranteed non-None past the skip above.
+      if tier_config.get("max_subgraphs", 0) > 0:
         features.append(f"Up to {tier_config.get('max_subgraphs')} subgraphs")
 
-      # Add content limits if available
-      graph_limits: dict = {}
-      if tier_config:
-        graph_limits = tier_config.get("limits", {}).get("graph_limits", {})
-        if not graph_limits:
-          # Try from the writer config directly
-          from ..config.graph_tier import GraphTierConfig
-
-          graph_limits = GraphTierConfig.get_graph_limits(tier_name)
-        if graph_limits:
-          storage_limit = graph_limits.get("instance_storage_limit_gb", 0)
-          if storage_limit > 0:
-            features.append(f"{int(storage_limit)} GB instance storage")
+      graph_limits: dict = tier_config.get("limits", {}).get("graph_limits", {})
+      if not graph_limits:
+        # Try from the writer config directly
+        graph_limits = GraphTierConfig.get_graph_limits(tier_name)
+      storage_limit = graph_limits.get("instance_storage_limit_gb", 0)
+      if storage_limit > 0:
+        features.append(f"{int(storage_limit)} GB instance storage")
 
       tier_info = {
         "name": tier_name,
@@ -129,14 +136,12 @@ async def get_service_offerings(
         "features": features,
         "backup_retention_days": backup_retention_days,
         "priority_support": plan_data.get("priority_support", False),
-        "max_subgraphs": tier_config.get("max_subgraphs", 0) if tier_config else 0,
+        "max_subgraphs": tier_config.get("max_subgraphs", 0),
         "instance_storage_limit_gb": GraphTierConfig.get_instance_storage_limit_gb(
           tier_name
         ),
-        "api_rate_multiplier": tier_config.get("api_rate_multiplier", 1.0)
-        if tier_config
-        else 1.0,
-        "backend": tier_config.get("backend", "ladybug") if tier_config else "ladybug",
+        "api_rate_multiplier": tier_config.get("api_rate_multiplier", 1.0),
+        "backend": tier_config.get("backend", "ladybug"),
         "instance_type": instance_type or None,
       }
       graph_tiers.append(tier_info)

--- a/tests/config/test_graph_tier_config.py
+++ b/tests/config/test_graph_tier_config.py
@@ -219,6 +219,38 @@ def test_get_instance_storage_limit_gb(mock_graph_config):
   assert GraphTierConfig.get_instance_storage_limit_gb("ladybug-large") == 50.0
 
 
+def test_tiers_defined_in_an_environment_match_production():
+  """Where a tier IS defined, its capability and product limits match prod.
+
+  Not every environment defines every tier — development deliberately defines
+  only ladybug-standard, because it runs a single graph_api and Large/XLarge
+  cannot exist there. That absence is fine and is handled by omitting the tier
+  from /v1/offering. What is not fine is a tier that exists with *different*
+  numbers, since subgraph count and storage cap are properties of the tier
+  rather than of the deployment.
+
+  api_rate_multiplier is deliberately not asserted: staging runs Large/XLarge
+  looser than production (2.5/5.0 vs 1.5/2.5), plausibly intentional headroom.
+  """
+  GraphTierConfig.clear_cache()
+  tiers = ("ladybug-standard", "ladybug-large", "ladybug-xlarge")
+
+  for env_name in ("staging", "development"):
+    for tier in tiers:
+      config = GraphTierConfig.get_tier_config(tier, env_name)
+      if not config:
+        continue  # Not offered in this environment — see docstring.
+
+      prod = GraphTierConfig.get_tier_config(tier, "production")
+      assert config.get("max_subgraphs") == prod.get("max_subgraphs"), (
+        f"{env_name}/{tier} max_subgraphs={config.get('max_subgraphs')} does not "
+        f"match production's {prod.get('max_subgraphs')}"
+      )
+      assert GraphTierConfig.get_instance_storage_limit_gb(tier, env_name) == (
+        GraphTierConfig.get_instance_storage_limit_gb(tier, "production")
+      ), f"{env_name}/{tier} instance_storage_limit_gb does not match production"
+
+
 def test_subgraph_memory_is_configured_separately_from_parent(mock_graph_config):
   """Subgraphs get a smaller buffer pool than the parent database.
 

--- a/tests/routers/test_offering.py
+++ b/tests/routers/test_offering.py
@@ -75,6 +75,36 @@ class TestOfferingEndpoint:
     # Structure should be the same
     assert data1.keys() == data2.keys()
 
+  # Note: More detailed tests would require knowledge of the actual
+  # offering data structure which may change over time.
 
-# Note: More detailed tests would require knowledge of the actual
-# offering data structure which may change over time.
+  async def test_advertised_tiers_never_report_fabricated_specs(
+    self, async_client: AsyncClient
+  ):
+    """A listed tier must carry real specs, not defaults standing in for them.
+
+    Billing defines what is purchasable; graph.yml defines the specs. Where
+    they disagree — local dev defines only ladybug-standard, because it runs a
+    single graph_api — the tier used to be listed anyway with max_subgraphs
+    fabricated as 0 and the limits falling through to Standard-shaped defaults.
+    "Up to 0 subgraphs, 20 GB" is a confident wrong answer; the tier is now
+    omitted instead, so anything listed here is genuinely described.
+    """
+    response = await async_client.get("/v1/offering")
+    assert response.status_code == 200
+
+    tiers = response.json()["graph_subscriptions"]["tiers"]
+    assert tiers, "at least one tier must be offered"
+
+    for tier in tiers:
+      assert tier["max_subgraphs"] > 0, (
+        f"{tier['name']} advertises {tier['max_subgraphs']} subgraphs — a tier "
+        "without a config should be omitted, not listed with zeros"
+      )
+      assert tier["instance_storage_limit_gb"] > 0, (
+        f"{tier['name']} advertises no storage limit"
+      )
+      assert tier["backup_retention_days"] > 0, (
+        f"{tier['name']} advertises no backup retention"
+      )
+      assert tier["instance_type"], f"{tier['name']} has no instance type"


### PR DESCRIPTION
`/v1/offering` advertised Large and XLarge in local dev as **"Up to 0 subgraphs, 20 GB, 7-day retention"** — plausible-looking numbers that were entirely fabricated.

## Why it looked believable

Billing defines what is *purchasable*; `graph.yml` defines the *specs*. Where they disagree, the tier was listed anyway:

```python
"max_subgraphs": tier_config.get("max_subgraphs", 0) if tier_config else 0,
```

That asserts "this tier has zero subgraphs" when the truth is "I have no config for it." Storage and retention then fell through to the Standard-shaped defaults in `get_graph_limits` / `get_backup_limits`.

Price and credits were correct throughout, because those come from `billing/core.py`, which has no environment dimension. That split — price right, every spec wrong — is what made the output convincing.

## The fix is subtraction, not addition

The obvious move was to add Large/XLarge blocks to `development`. That would be fiction: dev runs a **single graph_api**, so those tiers cannot exist there, and the instance blocks would describe machines nothing will ever provision.

Instead, a tier with no config for the environment is now **skipped**. "Zero subgraphs, 20 GB" is a confident wrong answer where the truth is "not offered here" — omitting says that, and lets a client keep its own defaults rather than overwrite them with fabricated ones.

No schema change, so no SDK regen. Production is unaffected: all three tiers have configs and all three still list.

Also removes the now-dead `if tier_config` guards below the skip.

## Pre-existing drift, deliberately left alone

The parity test surfaced that **staging runs Large/XLarge at `api_rate_multiplier` 2.5/5.0 against production's 1.5/2.5**. Not touched and excluded from the assertion — looser staging limits are plausibly intentional headroom for load testing, and that's a product call rather than something to normalize silently.

The test now allows a tier to be *absent* from an environment but requires that where it is present, its subgraph count and storage cap match production.

## Testing

Full suite: **11,385 passed**, `just test-code` clean. The only failures are the two pre-existing `test_incremental_materialize` cases that reproduce on `main` and pass in isolation.

Paired with robosystems-app, which guards the client side of the same bug — `??` falls back on null/undefined but not `0`, so a fabricated zero overrode a correct fallback.