### PR TITLE
Differentiate rate limits by tier and bucket per graph

### DIFF
--- a/.github/configs/graph.yml
+++ b/.github/configs/graph.yml
@@ -22,7 +22,7 @@
 production:
   writers:
     # =========================================================================
-    # LADYBUGDB STANDARD TIER - Dedicated m7g.large
+    # LADYBUGDB STANDARD TIER - Dedicated m7g.medium
     # =========================================================================
     - name: ladybug-standard
       description: Dedicated m7g.medium LadybugDB tier for cost-efficient entry with subgraph support
@@ -32,9 +32,6 @@ production:
 
       # Subgraph configuration
       max_subgraphs: 3 # Up to 3 subgraphs (1 parent + 3 children = 4 databases total)
-
-      # Resource limits
-      api_rate_multiplier: 1.0 # Base rate limits (1x)
 
       # Copy operation limits
       copy_operations:
@@ -90,7 +87,7 @@ production:
         always_enabled: true # LadybugDB standard tier is the foundation - always available
 
     # =========================================================================
-    # LADYBUGDB LARGE TIER - Dedicated r7g.large
+    # LADYBUGDB LARGE TIER - Dedicated m7g.large
     # =========================================================================
     - name: ladybug-large
       description: Dedicated m7g.large with subgraph support (10 subgraphs)
@@ -100,9 +97,6 @@ production:
 
       # Subgraph configuration
       max_subgraphs: 10 # Support up to 10 subgraphs (1 parent + 10 children = 11 databases total)
-
-      # Resource limits
-      api_rate_multiplier: 1.5 # 1.5x rate limits (2x RAM, 2x CPU vs standard)
 
       # Copy operation limits
       copy_operations:
@@ -169,9 +163,6 @@ production:
       max_subgraphs: 25 # Practical limit of 25 subgraphs (marketed as "unlimited")
       # Note: 1 parent + 25 subgraphs = 26 databases total on xlarge instance
 
-      # Resource limits
-      api_rate_multiplier: 2.5 # 2.5x rate limits (4x RAM, 2x CPU vs standard)
-
       # Copy operation limits
       copy_operations:
         max_file_size_gb: 10.0 # Maximum file size for enterprise workloads
@@ -237,9 +228,6 @@ production:
 
       # Repository configuration
       max_subgraphs: 10 # Platform-managed subgraphs only (e.g., sec_historical)
-
-      # Resource limits
-      api_rate_multiplier: null # Separate rate limiting for public access
 
       # Copy operation limits (for platform data loading)
       copy_operations:
@@ -335,7 +323,6 @@ staging:
       tier: ladybug-standard
 
       max_subgraphs: 3
-      api_rate_multiplier: 1.0
 
       # Copy operation limits
       copy_operations:
@@ -389,7 +376,6 @@ staging:
       tier: ladybug-large
 
       max_subgraphs: 10
-      api_rate_multiplier: 2.5
 
       copy_operations:
         max_file_size_gb: 5.0
@@ -441,7 +427,6 @@ staging:
       tier: ladybug-xlarge
 
       max_subgraphs: 25
-      api_rate_multiplier: 5.0
 
       copy_operations:
         max_file_size_gb: 10.0
@@ -493,7 +478,6 @@ staging:
       tier: ladybug-shared
 
       max_subgraphs: 10 # Platform-managed subgraphs only
-      api_rate_multiplier: null
 
       copy_operations:
         max_file_size_gb: 10.0
@@ -560,7 +544,6 @@ development:
       tier: ladybug-standard
 
       max_subgraphs: 3
-      api_rate_multiplier: 1.0
 
       copy_operations:
         max_file_size_gb: 1.0

--- a/robosystems/config/graph_tier.py
+++ b/robosystems/config/graph_tier.py
@@ -315,17 +315,31 @@ class GraphTierConfig:
 
   @classmethod
   def get_api_rate_multiplier(cls, tier: str, environment: str | None = None) -> float:
-    """Get rate limit multiplier for a tier.
+    """Get this tier's rate limit relative to ladybug-standard.
+
+    Derived from the limits the limiter actually enforces, not from a
+    standalone knob. It used to read `api_rate_multiplier` out of graph.yml,
+    where it was 1.0/1.5/2.5 — read in several places, applied in none, so
+    /limits and /offering reported throughput no tier ever received. That key
+    is gone; the ratio now comes from SUBSCRIPTION_RATE_LIMITS, which means it
+    cannot drift from enforcement again.
 
     Args:
         tier: The tier name (ladybug-standard, ladybug-large, ladybug-xlarge)
-        environment: Environment (defaults to current env)
+        environment: Unused; retained for call-site compatibility.
 
     Returns:
-        Rate limit multiplier (1.0 = base limits)
+        Multiple of the standard tier's limits (1.0 = same as standard)
     """
-    tier_config = cls.get_tier_config(tier, environment)
-    return tier_config.get("api_rate_multiplier", 1.0)
+    from .rate_limits import EndpointCategory, RateLimitConfig
+
+    baseline = RateLimitConfig.get_rate_limit(
+      "ladybug-standard", EndpointCategory.GRAPH_QUERY
+    )
+    actual = RateLimitConfig.get_rate_limit(tier, EndpointCategory.GRAPH_QUERY)
+    if not baseline or not actual or not baseline[0]:
+      return 1.0
+    return actual[0] / baseline[0]
 
   @classmethod
   def get_copy_operation_limits(

--- a/robosystems/config/graph_tier.py
+++ b/robosystems/config/graph_tier.py
@@ -333,6 +333,12 @@ class GraphTierConfig:
     """
     from .rate_limits import EndpointCategory, RateLimitConfig
 
+    # A tier without its own limits table (ladybug-shared, legacy strings) is
+    # enforced at the standard-tier fallback, so its multiplier is 1.0 — not
+    # the base-table ratio get_rate_limit's fallback would imply.
+    if tier not in RateLimitConfig.SUBSCRIPTION_RATE_LIMITS:
+      return 1.0
+
     baseline = RateLimitConfig.get_rate_limit(
       "ladybug-standard", EndpointCategory.GRAPH_QUERY
     )
@@ -513,10 +519,12 @@ class GraphTierConfig:
       if max_memory_mb and max_memory_mb > 0:
         features.append(f"{max_memory_mb / 1024:.0f}GB RAM")
 
-    # Add rate limit multiplier if not standard
-    rate_multiplier = tier_config.get("api_rate_multiplier", 1.0)
-    if rate_multiplier is not None and rate_multiplier > 1:
-      features.append(f"{rate_multiplier}x API rate limits")
+    # Add rate limit multiplier if not standard. Derived from the enforced
+    # limits — graph.yml no longer carries an api_rate_multiplier key.
+    tier_name = tier_config.get("tier") or tier_config.get("name")
+    rate_multiplier = cls.get_api_rate_multiplier(tier_name) if tier_name else 1.0
+    if rate_multiplier > 1:
+      features.append(f"{rate_multiplier:g}x API rate limits")
 
     # Add backup retention
     backup_limits = tier_config.get("backup_limits", {})
@@ -597,7 +605,7 @@ class GraphTierConfig:
         "enabled": is_enabled,
         "max_subgraphs": writer.get("max_subgraphs"),
         "monthly_credits": monthly_credits,
-        "api_rate_multiplier": writer.get("api_rate_multiplier", 1.0),
+        "api_rate_multiplier": cls.get_api_rate_multiplier(tier_name),
         "features": cls._generate_tier_features(writer),
         "instance": {
           "type": instance_config.get("type"),

--- a/robosystems/config/rate_limits.py
+++ b/robosystems/config/rate_limits.py
@@ -92,15 +92,53 @@ class RateLimitConfig:
   # BURST-FOCUSED CONFIGURATION: Short windows for burst protection
   # Volume control is handled by the credit system
   # Format: {tier: {category: (limit, period)}}
+  # Categories served by the customer's own dedicated LadybugDB instance.
+  # These scale by tier and bucket per graph; everything else is shared
+  # infrastructure, stays flat, and buckets per user. See the comment on
+  # SUBSCRIPTION_RATE_LIMITS below for why the distinction matters.
+  #
+  # GRAPH_SEARCH is deliberately absent: it hits the shared OpenSearch cluster,
+  # not the tenant's instance. GRAPH_IMPORT is absent because LadybugDB ingests
+  # sequentially regardless of tier, so extra cores buy nothing there.
+  DEDICATED_RESOURCE_CATEGORIES: frozenset[EndpointCategory] = frozenset(
+    {
+      EndpointCategory.GRAPH_QUERY,
+      EndpointCategory.GRAPH_READ,
+      EndpointCategory.GRAPH_WRITE,
+      EndpointCategory.GRAPH_MCP,
+      EndpointCategory.GRAPH_OPERATOR,
+      EndpointCategory.GRAPH_ANALYTICS,
+    }
+  )
+
   SUBSCRIPTION_RATE_LIMITS: dict[
     str, dict[EndpointCategory, tuple[int, RateLimitPeriod]]
   ] = {
     # -----------------------------------------------------------------------
     # MANAGED SERVICE RATE LIMITS
-    # All tiers share managed infrastructure. Limits are conservative to
-    # protect shared resources (OpenSearch t3.medium, LadybugDB on m7g/r7g).
-    # For self-hosted scale, customers deploy their own infrastructure.
-    # Loosen these as infra scales up.
+    #
+    # Two kinds of limit live in this table, and they differ by what they
+    # protect:
+    #
+    #   Dedicated  — categories in DEDICATED_RESOURCE_CATEGORIES hit the
+    #                customer's own LadybugDB instance. Every customer tier is
+    #                databases_per_instance: 1, so a heavy tenant harms only
+    #                themselves. These scale with the tier's vCPU count
+    #                (m7g.medium 1 → m7g.large 2 → r7g.xlarge 4), because read
+    #                throughput is what the extra cores actually buy.
+    #
+    #   Shared     — everything else lands on infrastructure every tenant
+    #                shares: OpenSearch (t3.medium), the extensions RDS, the
+    #                API tier itself. These stay flat across tiers and bucket
+    #                per user, so buying more graphs cannot multiply one
+    #                customer's load on a resource others depend on.
+    #
+    # An earlier version of this comment described LadybugDB as shared, which
+    # is what kept every tier on identical limits. It is not shared, and that
+    # is the whole reason the dedicated half can differentiate at all.
+    #
+    # Admission control (85% of instance CPU/memory) remains the real overload
+    # backstop; these numbers are a product lever, not the safety mechanism.
     # -----------------------------------------------------------------------
     "base": {
       # Anonymous / unrecognized tier — tightest limits
@@ -130,7 +168,12 @@ class RateLimitConfig:
       EndpointCategory.TABLE_UPLOAD: (5, RateLimitPeriod.MINUTE),
       EndpointCategory.TABLE_MANAGEMENT: (5, RateLimitPeriod.MINUTE),
     },
-    # ladybug-standard: m7g.large (8GB, 2 vCPU) — anchor tier
+    # ladybug-standard: m7g.medium (4GB, 1 vCPU) — the anchor the other tiers
+    # multiply from. These values were originally sized for m7g.large and are
+    # deliberately left as-is after the resize rather than halved: observed
+    # production load is ~1% CPU, nowhere near binding, and cutting limits on
+    # existing customers to match a smaller box would be a service regression
+    # in exchange for protection admission control already provides.
     "ladybug-standard": {
       EndpointCategory.AUTH: (20, RateLimitPeriod.MINUTE),
       EndpointCategory.USER_MANAGEMENT: (60, RateLimitPeriod.MINUTE),
@@ -161,11 +204,8 @@ class RateLimitConfig:
       EndpointCategory.TABLE_UPLOAD: (10, RateLimitPeriod.MINUTE),
       EndpointCategory.TABLE_MANAGEMENT: (15, RateLimitPeriod.MINUTE),
     },
-    # ladybug-large: r7g.large (16GB, 2 vCPU)
-    # Identical enforcement to standard: the API limiter classifies all
-    # authenticated users as ladybug-standard, so these per-tier tables are
-    # reference/parity only. Burst protection is deliberately tier-flat;
-    # per-tier volume is governed by credits, not by a rate-limit multiplier.
+    # ladybug-large: m7g.large (8GB, 2 vCPU) — 2x Standard's vCPU, so the
+    # dedicated-resource categories double. Shared categories match Standard.
     "ladybug-large": {
       EndpointCategory.AUTH: (20, RateLimitPeriod.MINUTE),
       EndpointCategory.USER_MANAGEMENT: (60, RateLimitPeriod.MINUTE),
@@ -173,20 +213,20 @@ class RateLimitConfig:
       EndpointCategory.STATUS: (120, RateLimitPeriod.MINUTE),
       EndpointCategory.SSE: (5, RateLimitPeriod.MINUTE),
       EndpointCategory.BILLING: (60, RateLimitPeriod.MINUTE),  # Never block payments
-      # Graph-scoped — same base, multiplied by 1.5x from graph.yml
-      EndpointCategory.GRAPH_READ: (120, RateLimitPeriod.MINUTE),
-      EndpointCategory.GRAPH_WRITE: (30, RateLimitPeriod.MINUTE),
-      EndpointCategory.GRAPH_ANALYTICS: (15, RateLimitPeriod.MINUTE),
+      # Dedicated instance — 2x Standard (2 vCPU vs 1)
+      EndpointCategory.GRAPH_READ: (240, RateLimitPeriod.MINUTE),
+      EndpointCategory.GRAPH_WRITE: (60, RateLimitPeriod.MINUTE),
+      EndpointCategory.GRAPH_ANALYTICS: (30, RateLimitPeriod.MINUTE),
       EndpointCategory.GRAPH_BACKUP: (5, RateLimitPeriod.MINUTE),
       EndpointCategory.GRAPH_MANAGEMENT: (10, RateLimitPeriod.MINUTE),
       EndpointCategory.GRAPH_SYNC: (10, RateLimitPeriod.MINUTE),
-      EndpointCategory.GRAPH_MCP: (30, RateLimitPeriod.MINUTE),
-      EndpointCategory.GRAPH_OPERATOR: (15, RateLimitPeriod.MINUTE),
+      EndpointCategory.GRAPH_MCP: (60, RateLimitPeriod.MINUTE),
+      EndpointCategory.GRAPH_OPERATOR: (30, RateLimitPeriod.MINUTE),
       EndpointCategory.GRAPH_SEARCH: (
         10,
         RateLimitPeriod.MINUTE,
       ),  # Shared OpenSearch t3.medium
-      EndpointCategory.GRAPH_QUERY: (60, RateLimitPeriod.MINUTE),
+      EndpointCategory.GRAPH_QUERY: (120, RateLimitPeriod.MINUTE),
       EndpointCategory.GRAPH_IMPORT: (10, RateLimitPeriod.MINUTE),
       # Extensions surface (OLTP on shared RDS)
       EndpointCategory.EXTENSIONS_GRAPHQL: (600, RateLimitPeriod.MINUTE),
@@ -207,19 +247,19 @@ class RateLimitConfig:
       EndpointCategory.SSE: (5, RateLimitPeriod.MINUTE),
       EndpointCategory.BILLING: (60, RateLimitPeriod.MINUTE),  # Never block payments
       # Graph-scoped — same base, multiplied by 2.5x from graph.yml
-      EndpointCategory.GRAPH_READ: (120, RateLimitPeriod.MINUTE),
-      EndpointCategory.GRAPH_WRITE: (30, RateLimitPeriod.MINUTE),
-      EndpointCategory.GRAPH_ANALYTICS: (15, RateLimitPeriod.MINUTE),
+      EndpointCategory.GRAPH_READ: (480, RateLimitPeriod.MINUTE),
+      EndpointCategory.GRAPH_WRITE: (120, RateLimitPeriod.MINUTE),
+      EndpointCategory.GRAPH_ANALYTICS: (60, RateLimitPeriod.MINUTE),
       EndpointCategory.GRAPH_BACKUP: (5, RateLimitPeriod.MINUTE),
       EndpointCategory.GRAPH_MANAGEMENT: (10, RateLimitPeriod.MINUTE),
       EndpointCategory.GRAPH_SYNC: (10, RateLimitPeriod.MINUTE),
-      EndpointCategory.GRAPH_MCP: (30, RateLimitPeriod.MINUTE),
-      EndpointCategory.GRAPH_OPERATOR: (15, RateLimitPeriod.MINUTE),
+      EndpointCategory.GRAPH_MCP: (120, RateLimitPeriod.MINUTE),
+      EndpointCategory.GRAPH_OPERATOR: (60, RateLimitPeriod.MINUTE),
       EndpointCategory.GRAPH_SEARCH: (
         10,
         RateLimitPeriod.MINUTE,
       ),  # Shared OpenSearch t3.medium
-      EndpointCategory.GRAPH_QUERY: (60, RateLimitPeriod.MINUTE),
+      EndpointCategory.GRAPH_QUERY: (240, RateLimitPeriod.MINUTE),
       EndpointCategory.GRAPH_IMPORT: (10, RateLimitPeriod.MINUTE),
       # Extensions surface (OLTP on shared RDS)
       EndpointCategory.EXTENSIONS_GRAPHQL: (600, RateLimitPeriod.MINUTE),

--- a/robosystems/config/rate_limits.py
+++ b/robosystems/config/rate_limits.py
@@ -236,9 +236,8 @@ class RateLimitConfig:
       EndpointCategory.TABLE_UPLOAD: (10, RateLimitPeriod.MINUTE),
       EndpointCategory.TABLE_MANAGEMENT: (15, RateLimitPeriod.MINUTE),
     },
-    # ladybug-xlarge: r7g.xlarge (32GB, 4 vCPU)
-    # Identical enforcement to standard (see ladybug-large note): reference/
-    # parity only; the limiter treats all authenticated users as standard.
+    # ladybug-xlarge: r7g.xlarge (32GB, 4 vCPU) — 4x Standard's vCPU, so the
+    # dedicated-resource categories quadruple. Shared categories match Standard.
     "ladybug-xlarge": {
       EndpointCategory.AUTH: (20, RateLimitPeriod.MINUTE),
       EndpointCategory.USER_MANAGEMENT: (60, RateLimitPeriod.MINUTE),
@@ -246,7 +245,7 @@ class RateLimitConfig:
       EndpointCategory.STATUS: (120, RateLimitPeriod.MINUTE),
       EndpointCategory.SSE: (5, RateLimitPeriod.MINUTE),
       EndpointCategory.BILLING: (60, RateLimitPeriod.MINUTE),  # Never block payments
-      # Graph-scoped — same base, multiplied by 2.5x from graph.yml
+      # Dedicated instance — 4x Standard (4 vCPU vs 1)
       EndpointCategory.GRAPH_READ: (480, RateLimitPeriod.MINUTE),
       EndpointCategory.GRAPH_WRITE: (120, RateLimitPeriod.MINUTE),
       EndpointCategory.GRAPH_ANALYTICS: (60, RateLimitPeriod.MINUTE),

--- a/robosystems/config/rate_limits.py
+++ b/robosystems/config/rate_limits.py
@@ -100,6 +100,12 @@ class RateLimitConfig:
   # GRAPH_SEARCH is deliberately absent: it hits the shared OpenSearch cluster,
   # not the tenant's instance. GRAPH_IMPORT is absent because LadybugDB ingests
   # sequentially regardless of tier, so extra cores buy nothing there.
+  # GRAPH_BACKUP, GRAPH_MANAGEMENT, and GRAPH_SYNC are also deliberately
+  # absent: they are low-frequency control-plane operations whose cost lands
+  # on shared infrastructure — S3 for backups, the platform database and
+  # orchestration for management, external providers via the shared worker
+  # pool for sync — not on the tenant's own cores, so tier vCPU is not the
+  # scaling axis for any of them.
   DEDICATED_RESOURCE_CATEGORIES: frozenset[EndpointCategory] = frozenset(
     {
       EndpointCategory.GRAPH_QUERY,

--- a/robosystems/middleware/rate_limits/graph_tier_resolver.py
+++ b/robosystems/middleware/rate_limits/graph_tier_resolver.py
@@ -1,0 +1,106 @@
+"""Resolve a request's graph and its tier for rate limiting.
+
+The limiter runs on the hottest path in the API and historically did no
+database work at all — every decision came from Valkey. Resolving a tier means
+a `graphs` lookup, so it is cached with a short TTL and every failure mode
+falls back to the *tightest* tier rather than the loosest: a cache outage or a
+deleted graph must not hand out XLarge throughput.
+"""
+
+from ...config.graph_tier import GraphTier
+from ...config.valkey_registry import ValkeyDatabase, create_redis_client
+from ...logger import logger
+
+# Tightest customer tier. Used whenever the real tier cannot be established,
+# so degradation is always toward less throughput, never more.
+FALLBACK_TIER = GraphTier.LADYBUG_STANDARD.value
+
+# Short enough that a tier change takes effect promptly, long enough that the
+# lookup does not run on every request in a burst.
+_TIER_CACHE_TTL_SECONDS = 300
+
+_CACHE_PREFIX = "ratelimit:graph_tier:"
+
+# Sentinel stored for graph ids that resolve to nothing, so a stream of requests
+# for a non-existent graph does not re-query the database each time.
+_UNKNOWN = "-"
+
+
+def extract_graph_id(path: str) -> str | None:
+  """Pull the graph id out of a request path, or None if it is not graph-scoped.
+
+  Three shapes carry a graph id:
+      /v1/graphs/{graph_id}/...
+      /extensions/{graph_id}/graphql
+      /extensions/{domain}/{graph_id}/operations/...
+
+  The middle form is distinguished from the last by its second segment: a
+  domain is a known product name, anything else is a graph id.
+  """
+  parts = [segment for segment in path.split("/") if segment]
+
+  if len(parts) >= 3 and parts[0] == "v1" and parts[1] == "graphs":
+    candidate = parts[2]
+    # /v1/graphs/schema/validate carries no graph id.
+    return None if candidate == "schema" else candidate
+
+  if len(parts) >= 2 and parts[0] == "extensions":
+    if parts[1] in ("roboledger", "roboinvestor"):
+      return parts[2] if len(parts) >= 3 else None
+    return parts[1]
+
+  return None
+
+
+def _cached_tier(graph_id: str) -> str | None:
+  try:
+    client = create_redis_client(ValkeyDatabase.GRAPH_ROUTING)
+    value = client.get(f"{_CACHE_PREFIX}{graph_id}")
+  except Exception as e:
+    # A cache outage must not fail the request; fall through to the database.
+    logger.debug(f"Rate limit tier cache unavailable for {graph_id}: {e}")
+    return None
+  return value if isinstance(value, str) else None
+
+
+def _store_tier(graph_id: str, tier: str) -> None:
+  try:
+    client = create_redis_client(ValkeyDatabase.GRAPH_ROUTING)
+    client.setex(f"{_CACHE_PREFIX}{graph_id}", _TIER_CACHE_TTL_SECONDS, tier)
+  except Exception as e:
+    logger.debug(f"Could not cache tier for {graph_id}: {e}")
+
+
+def resolve_graph_tier(graph_id: str) -> str:
+  """Return the graph's tier, or the tightest tier if it cannot be determined.
+
+  Never raises: rate limiting is not the place to surface a lookup failure, and
+  failing open would let an error hand out more throughput than the customer
+  bought.
+  """
+  cached = _cached_tier(graph_id)
+  if cached == _UNKNOWN:
+    return FALLBACK_TIER
+  if cached:
+    return cached
+
+  try:
+    from ...database import session as session_factory
+    from ...models.core.graph import Graph
+
+    db = session_factory()
+    try:
+      graph = Graph.get_by_id(graph_id, db)
+      tier = str(graph.graph_tier) if graph and graph.graph_tier else None
+    finally:
+      db.close()
+  except Exception as e:
+    logger.warning(f"Could not resolve tier for {graph_id}, using {FALLBACK_TIER}: {e}")
+    return FALLBACK_TIER
+
+  if not tier:
+    _store_tier(graph_id, _UNKNOWN)
+    return FALLBACK_TIER
+
+  _store_tier(graph_id, tier)
+  return tier

--- a/robosystems/middleware/rate_limits/graph_tier_resolver.py
+++ b/robosystems/middleware/rate_limits/graph_tier_resolver.py
@@ -8,6 +8,7 @@ deleted graph must not hand out XLarge throughput.
 """
 
 from ...config.graph_tier import GraphTier
+from ...config.rate_limits import RateLimitConfig
 from ...config.valkey_registry import ValkeyDatabase, create_redis_client
 from ...logger import logger
 
@@ -25,6 +26,26 @@ _CACHE_PREFIX = "ratelimit:graph_tier:"
 # for a non-existent graph does not re-query the database each time.
 _UNKNOWN = "-"
 
+# Static path segments that occupy the graph-id position under /v1/graphs.
+# Treating one as a graph id would collapse every caller of that route into a
+# single shared bucket — the cross-tenant failure the shared-repository
+# exclusion exists to prevent. Those routes use the general limiter today, so
+# this guard is defense in depth against one of them adopting the
+# subscription-aware dependency.
+_STATIC_GRAPH_SEGMENTS = frozenset({"schema", "tiers", "capacity", "extensions"})
+
+# One client for the process, created lazily. The limiter runs per request on
+# the hottest path in the API; creating a client (and its connection pool) per
+# call would mean a TCP/TLS handshake per request in production.
+_redis_client = None
+
+
+def _redis():
+  global _redis_client
+  if _redis_client is None:
+    _redis_client = create_redis_client(ValkeyDatabase.GRAPH_ROUTING)
+  return _redis_client
+
 
 def extract_graph_id(path: str) -> str | None:
   """Pull the graph id out of a request path, or None if it is not graph-scoped.
@@ -41,8 +62,7 @@ def extract_graph_id(path: str) -> str | None:
 
   if len(parts) >= 3 and parts[0] == "v1" and parts[1] == "graphs":
     candidate = parts[2]
-    # /v1/graphs/schema/validate carries no graph id.
-    return None if candidate == "schema" else candidate
+    return None if candidate in _STATIC_GRAPH_SEGMENTS else candidate
 
   if len(parts) >= 2 and parts[0] == "extensions":
     if parts[1] in ("roboledger", "roboinvestor"):
@@ -54,8 +74,7 @@ def extract_graph_id(path: str) -> str | None:
 
 def _cached_tier(graph_id: str) -> str | None:
   try:
-    client = create_redis_client(ValkeyDatabase.GRAPH_ROUTING)
-    value = client.get(f"{_CACHE_PREFIX}{graph_id}")
+    value = _redis().get(f"{_CACHE_PREFIX}{graph_id}")
   except Exception as e:
     # A cache outage must not fail the request; fall through to the database.
     logger.debug(f"Rate limit tier cache unavailable for {graph_id}: {e}")
@@ -65,8 +84,7 @@ def _cached_tier(graph_id: str) -> str | None:
 
 def _store_tier(graph_id: str, tier: str) -> None:
   try:
-    client = create_redis_client(ValkeyDatabase.GRAPH_ROUTING)
-    client.setex(f"{_CACHE_PREFIX}{graph_id}", _TIER_CACHE_TTL_SECONDS, tier)
+    _redis().setex(f"{_CACHE_PREFIX}{graph_id}", _TIER_CACHE_TTL_SECONDS, tier)
   except Exception as e:
     logger.debug(f"Could not cache tier for {graph_id}: {e}")
 
@@ -77,12 +95,20 @@ def resolve_graph_tier(graph_id: str) -> str:
   Never raises: rate limiting is not the place to surface a lookup failure, and
   failing open would let an error hand out more throughput than the customer
   bought.
+
+  A tier string with no entry in SUBSCRIPTION_RATE_LIMITS (ladybug-shared on a
+  repository row, or a legacy value predating a rename) also resolves to
+  FALLBACK_TIER: without this guard the limits lookup would fall through to the
+  anonymous "base" table, dropping a paying customer below the floor this
+  module promises.
   """
   cached = _cached_tier(graph_id)
   if cached == _UNKNOWN:
     return FALLBACK_TIER
   if cached:
-    return cached
+    return (
+      cached if cached in RateLimitConfig.SUBSCRIPTION_RATE_LIMITS else FALLBACK_TIER
+    )
 
   try:
     from ...database import session as session_factory
@@ -103,4 +129,4 @@ def resolve_graph_tier(graph_id: str) -> str:
     return FALLBACK_TIER
 
   _store_tier(graph_id, tier)
-  return tier
+  return tier if tier in RateLimitConfig.SUBSCRIPTION_RATE_LIMITS else FALLBACK_TIER

--- a/robosystems/middleware/rate_limits/rate_limiting.py
+++ b/robosystems/middleware/rate_limits/rate_limiting.py
@@ -484,6 +484,14 @@ def subscription_aware_rate_limit_dependency(request: Request):
     # Fall back to general rate limiting for non-subscription endpoints
     return rate_limit_dependency(request)
 
+  from ...config.rate_limits import RateLimitConfig
+  from ...config.shared_repositories import is_shared_repository_or_subgraph
+  from .graph_tier_resolver import (
+    FALLBACK_TIER,
+    extract_graph_id,
+    resolve_graph_tier,
+  )
+
   # Get user identification
   user_id = get_user_from_request(request)
   if not user_id:
@@ -491,9 +499,7 @@ def subscription_aware_rate_limit_dependency(request: Request):
     subscription_tier = "base"
     identifier = f"anon_sub:{request.client.host if request.client else 'unknown'}"
   else:
-    # All authenticated users get ladybug-standard tier rate limits
-    # Graph-specific subscriptions are handled at the graph level
-    subscription_tier = "ladybug-standard"
+    subscription_tier = FALLBACK_TIER
     identifier = f"user_sub:{user_id}"
 
   # Determine endpoint category
@@ -501,6 +507,34 @@ def subscription_aware_rate_limit_dependency(request: Request):
   if not category:
     # Fall back to general rate limiting if category not found
     return rate_limit_dependency(request)
+
+  # Resolve the graph's own tier for graph-scoped requests. Previously every
+  # authenticated user was pinned to ladybug-standard, which made the large and
+  # xlarge tables unreachable, and the bucket was keyed by user, so a customer
+  # with ten graphs shared one budget across all of them — per-graph pricing
+  # that delivered no per-graph throughput.
+  #
+  # Three conditions, and each excludes a case where per-graph bucketing is
+  # actively wrong:
+  #
+  #   1. The request is graph-scoped at all.
+  #   2. The graph is NOT a shared repository. `sec` is one graph that every
+  #      tenant queries, so keying the bucket by graph id would put all of them
+  #      in a single budget and let one heavy user rate-limit everyone else off
+  #      it. Shared repositories stay user-keyed, which is also what isolates
+  #      tenants from each other. Subgraphs count too — `sec_historical` is as
+  #      shared as `sec`.
+  #   3. The category hits the tenant's own instance. Shared-infrastructure
+  #      categories stay user-keyed and tier-flat, or a customer could multiply
+  #      their load on OpenSearch or the extensions RDS by creating graphs.
+  graph_id = extract_graph_id(request.url.path) if user_id else None
+  if (
+    graph_id
+    and not is_shared_repository_or_subgraph(graph_id)
+    and category in RateLimitConfig.DEDICATED_RESOURCE_CATEGORIES
+  ):
+    subscription_tier = resolve_graph_tier(graph_id)
+    identifier = f"graph_sub:{graph_id}"
 
   # Get subscription-based limits
   limit_config = get_subscription_rate_limit(subscription_tier, category)

--- a/robosystems/middleware/rate_limits/rate_limiting.py
+++ b/robosystems/middleware/rate_limits/rate_limiting.py
@@ -486,6 +486,7 @@ def subscription_aware_rate_limit_dependency(request: Request):
 
   from ...config.rate_limits import RateLimitConfig
   from ...config.shared_repositories import is_shared_repository_or_subgraph
+  from ..graph.types import parse_graph_id
   from .graph_tier_resolver import (
     FALLBACK_TIER,
     extract_graph_id,
@@ -533,8 +534,14 @@ def subscription_aware_rate_limit_dependency(request: Request):
     and not is_shared_repository_or_subgraph(graph_id)
     and category in RateLimitConfig.DEDICATED_RESOURCE_CATEGORIES
   ):
-    subscription_tier = resolve_graph_tier(graph_id)
-    identifier = f"graph_sub:{graph_id}"
+    # A subgraph lives on its parent's instance and is not separately priced,
+    # so it draws from the parent's budget: kg123_dev buckets as kg123. Without
+    # this, an XLarge tenant with 25 subgraphs would hold 26 independent
+    # budgets against one machine. Resolving the parent also spares the
+    # resolver a per-subgraph cache entry and database row dependency.
+    parent_graph_id, _subgraph_name = parse_graph_id(graph_id)
+    subscription_tier = resolve_graph_tier(parent_graph_id)
+    identifier = f"graph_sub:{parent_graph_id}"
 
   # Get subscription-based limits
   limit_config = get_subscription_rate_limit(subscription_tier, category)

--- a/robosystems/models/api/graphs/limits.py
+++ b/robosystems/models/api/graphs/limits.py
@@ -222,7 +222,9 @@ class GraphLimitsResponse(BaseModel):
   )
 
   graph_id: str = Field(..., description="Graph database identifier")
-  subscription_tier: str = Field(..., description="User's subscription tier")
+  subscription_tier: str = Field(
+    ..., description="Rate-limit tier enforced for requests to this graph"
+  )
   graph_tier: str = Field(..., description="Graph's database tier")
   is_shared_repository: bool = Field(
     ..., description="Whether this is a shared repository"

--- a/robosystems/routers/graphs/limits.py
+++ b/robosystems/routers/graphs/limits.py
@@ -173,23 +173,25 @@ async def get_graph_limits(
     # Get backup limits from tier configuration (based on graph tier)
     backup_limits = get_tier_backup_limits(graph_tier)
 
-    # Define rate limits based on graph tier (using api_rate_multiplier from config)
-    base_requests_per_minute = 60
-    base_requests_per_hour = 1000
-    base_burst_capacity = 10
+    # Report what the limiter actually enforces, read from the same table the
+    # limiter reads. This previously computed 60 x api_rate_multiplier, which
+    # told Large 90/min and XLarge 150/min while enforcement gave every tier
+    # 60 — the multiplier is read in several places and applied in none.
+    # Reporting a limit we do not honour is worse than reporting a lower one.
+    from ...config.rate_limits import EndpointCategory, RateLimitConfig
 
-    multiplier = GraphTierConfig.get_api_rate_multiplier(graph_tier)
+    query_limit = RateLimitConfig.get_rate_limit(
+      graph_tier, EndpointCategory.GRAPH_QUERY
+    )
+    requests_per_minute = query_limit[0] if query_limit else 60
 
     rate_limits = {
-      "requests_per_minute": int(base_requests_per_minute * multiplier)
-      if multiplier
-      else base_requests_per_minute,
-      "requests_per_hour": int(base_requests_per_hour * multiplier)
-      if multiplier
-      else base_requests_per_hour,
-      "burst_capacity": int(base_burst_capacity * multiplier)
-      if multiplier
-      else base_burst_capacity,
+      "requests_per_minute": requests_per_minute,
+      # Derived, not separately enforced: the limiter uses fixed-window
+      # per-minute buckets, so these describe the same budget over a longer
+      # span rather than independent ceilings.
+      "requests_per_hour": requests_per_minute * 60,
+      "burst_capacity": requests_per_minute,
     }
 
     # Get credit limits if applicable

--- a/robosystems/routers/graphs/limits.py
+++ b/robosystems/routers/graphs/limits.py
@@ -98,9 +98,6 @@ async def get_graph_limits(
     from robosystems.models.core.graph import Graph
     from robosystems.models.core.graph.graph_credits import GraphCredits
 
-    # Get user's subscription tier
-    user_tier = getattr(current_user, "subscription_tier", "ladybug-standard")
-
     # Get graph information if it exists
     graph = session.query(Graph).filter(Graph.graph_id == graph_id).first()
 
@@ -116,6 +113,20 @@ async def get_graph_limits(
       graph_tier = "ladybug-standard"
 
     is_shared = MultiTenantUtils.is_shared_repository(graph_id)
+
+    # The tier whose rate-limit table the limiter enforces for requests to
+    # this graph. Shared repositories are user-keyed at the fallback tier, and
+    # a tier string without a limits table (ladybug-shared, legacy values)
+    # also floors there — without this, the lookup below would fall through to
+    # the anonymous "base" table and report 20/min for a graph served 60.
+    from ...config.rate_limits import EndpointCategory, RateLimitConfig
+    from ...middleware.rate_limits.graph_tier_resolver import FALLBACK_TIER
+
+    enforced_tier = (
+      graph_tier
+      if not is_shared and graph_tier in RateLimitConfig.SUBSCRIPTION_RATE_LIMITS
+      else FALLBACK_TIER
+    )
 
     # Get storage information (instance storage limit from graph.yml).
     # Reads the itemized breakdown so this agrees with `instance_usage` below
@@ -178,10 +189,8 @@ async def get_graph_limits(
     # told Large 90/min and XLarge 150/min while enforcement gave every tier
     # 60 — the multiplier is read in several places and applied in none.
     # Reporting a limit we do not honour is worse than reporting a lower one.
-    from ...config.rate_limits import EndpointCategory, RateLimitConfig
-
     query_limit = RateLimitConfig.get_rate_limit(
-      graph_tier, EndpointCategory.GRAPH_QUERY
+      enforced_tier, EndpointCategory.GRAPH_QUERY
     )
     requests_per_minute = query_limit[0] if query_limit else 60
 
@@ -203,11 +212,14 @@ async def get_graph_limits(
         )
         if graph_credits:
           credit_limits = {
-            "monthly_ai_credits": graph_credits.monthly_credit_limit,
-            "current_balance": graph_credits.current_balance,
+            "monthly_ai_credits": int(graph_credits.monthly_allocation),
+            "current_balance": int(graph_credits.current_balance),
           }
-      except Exception:
-        pass
+      except Exception as e:
+        # A bare pass here once hid a nonexistent-column read for the life of
+        # the endpoint; credits are optional in the response, but the failure
+        # must be visible.
+        logger.warning(f"Could not get credit limits for {graph_id}: {e}")
 
     # Get content limits and instance usage for non-shared graphs.
     # check_instance_storage is a single Graph API call covering the whole
@@ -268,7 +280,10 @@ async def get_graph_limits(
     # Build comprehensive response using typed models
     response = GraphLimitsResponse(
       graph_id=graph_id,
-      subscription_tier=user_tier,
+      # Graph subscriptions are per graph, not per user (User has no tier
+      # column): report the tier whose limits this graph's requests are
+      # actually held to.
+      subscription_tier=enforced_tier,
       graph_tier=graph_tier,
       is_shared_repository=is_shared,
       storage=StorageLimits(**storage_limits),

--- a/robosystems/routers/graphs/main.py
+++ b/robosystems/routers/graphs/main.py
@@ -492,8 +492,14 @@ async def get_available_graph_tiers(
     from robosystems.config import BillingConfig
     from robosystems.config.graph_tier import GraphTierConfig
 
-    # Get tier configurations from graph.yml
-    tiers = GraphTierConfig.get_available_tiers(include_disabled=include_disabled)
+    # include_disabled=True is deliberate, same reasoning as /v1/offering:
+    # get_available_tiers gates on deployment.always_enabled/enabled_default,
+    # which answers "is the CloudFormation stack deployed by default" — not
+    # "can a customer buy this". Large and XLarge carry enabled_default: false
+    # plus an enable_var only the deploy workflow reads, so honouring the flag
+    # here made both tiers invisible in production. What is sellable is
+    # decided by the billing catalog below.
+    tiers = GraphTierConfig.get_available_tiers(include_disabled=True)
 
     # Filter out internal-only and not-yet-available tiers
     excluded_tiers = [
@@ -501,34 +507,28 @@ async def get_available_graph_tiers(
     ]
     tiers = [tier for tier in tiers if tier.get("tier") not in excluded_tiers]
 
-    # Try to add pricing information from billing config
+    # Attach pricing from the billing catalog, which also decides what is
+    # offered: a tier billing cannot price is not purchasable here and is
+    # omitted unless the caller asked for disabled tiers. No hardcoded price
+    # fallback — a fabricated number that matches neither billing nor Stripe
+    # is worse than omission.
     try:
-      pricing_info = BillingConfig.get_all_pricing_info()
-      tier_pricing = pricing_info.get("subscription_tiers", {})
-
-      for tier in tiers:
-        tier_key = tier.get("tier", "")
-
-        # tier_pricing uses the same keys as tier names (e.g., "ladybug-standard")
-        if tier_pricing.get(tier_key):
-          # Convert cents to dollars for monthly_price
-          base_price_cents = tier_pricing[tier_key].get("base_price_cents", 0)
-          tier["monthly_price"] = base_price_cents / 100.0
-          tier["monthly_credits"] = tier_pricing[tier_key].get(
-            "monthly_credit_allocation", 0
-          )
-        else:
-          # Default pricing if not found (matching current billing config)
-          default_prices = {
-            "ladybug-standard": 100.0,
-            "ladybug-large": 300.0,
-            "ladybug-xlarge": 700.0,
-          }
-          tier["monthly_price"] = default_prices.get(tier_key)
-
+      tier_pricing = BillingConfig.get_all_pricing_info().get("subscription_tiers", {})
     except Exception as pricing_error:
       logger.warning(f"Could not load pricing information: {pricing_error}")
-      # Pricing remains None if we can't load it
+      tier_pricing = None
+
+    if tier_pricing is not None:
+      priced_tiers = []
+      for tier in tiers:
+        plan_data = tier_pricing.get(tier.get("tier", ""))
+        if plan_data:
+          tier["monthly_price"] = plan_data.get("base_price_cents", 0) / 100.0
+          tier["monthly_credits"] = plan_data.get("monthly_credit_allocation", 0)
+          priced_tiers.append(tier)
+        elif include_disabled:
+          priced_tiers.append(tier)
+      tiers = priced_tiers
 
     return AvailableGraphTiersResponse(tiers=tiers)
 

--- a/robosystems/routers/offering.py
+++ b/robosystems/routers/offering.py
@@ -140,7 +140,7 @@ async def get_service_offerings(
         "instance_storage_limit_gb": GraphTierConfig.get_instance_storage_limit_gb(
           tier_name
         ),
-        "api_rate_multiplier": tier_config.get("api_rate_multiplier", 1.0),
+        "api_rate_multiplier": GraphTierConfig.get_api_rate_multiplier(tier_name),
         "backend": tier_config.get("backend", "ladybug"),
         "instance_type": instance_type or None,
       }

--- a/tests/config/test_graph_tier_config.py
+++ b/tests/config/test_graph_tier_config.py
@@ -232,8 +232,8 @@ def test_tiers_defined_in_an_environment_match_production():
   numbers, since subgraph count and storage cap are properties of the tier
   rather than of the deployment.
 
-  api_rate_multiplier is deliberately not asserted: staging runs Large/XLarge
-  looser than production (2.5/5.0 vs 1.5/2.5), plausibly intentional headroom.
+  api_rate_multiplier needs no assertion here: it is derived from
+  SUBSCRIPTION_RATE_LIMITS, which does not vary by environment.
   """
   GraphTierConfig.clear_cache()
   tiers = ("ladybug-standard", "ladybug-large", "ladybug-xlarge")
@@ -252,6 +252,37 @@ def test_tiers_defined_in_an_environment_match_production():
       assert GraphTierConfig.get_instance_storage_limit_gb(tier, env_name) == (
         GraphTierConfig.get_instance_storage_limit_gb(tier, "production")
       ), f"{env_name}/{tier} instance_storage_limit_gb does not match production"
+
+
+def test_available_tiers_report_the_derived_rate_multiplier():
+  """The multiplier surfaced by /v1/offering and /v1/graphs/tiers is derived.
+
+  graph.yml no longer carries an api_rate_multiplier key, so any surface that
+  reads it off the writer dict with .get() silently flattens every tier to the
+  1.0 default — telling Large and XLarge customers they get standard limits
+  while enforcement gives them 2x/4x. Pin the reported value to the derived
+  one for every tier the catalog can list.
+  """
+  GraphTierConfig.clear_cache()
+  expected = {
+    "ladybug-standard": 1.0,
+    "ladybug-large": 2.0,
+    "ladybug-xlarge": 4.0,
+  }
+
+  for env_name in ("production", "staging"):
+    tiers = GraphTierConfig.get_available_tiers(env_name, include_disabled=True)
+    by_name = {t["tier"]: t for t in tiers if t["tier"] in expected}
+    assert set(by_name) == set(expected), (
+      f"{env_name} does not define all customer tiers: {sorted(by_name)}"
+    )
+    for tier_name, multiplier in expected.items():
+      assert by_name[tier_name]["api_rate_multiplier"] == multiplier, (
+        f"{env_name}/{tier_name} reports "
+        f"{by_name[tier_name]['api_rate_multiplier']}, expected {multiplier}"
+      )
+    assert "2x API rate limits" in by_name["ladybug-large"]["features"]
+    assert "4x API rate limits" in by_name["ladybug-xlarge"]["features"]
 
 
 def test_subgraph_memory_is_configured_separately_from_parent(mock_graph_config):

--- a/tests/config/test_graph_tier_config.py
+++ b/tests/config/test_graph_tier_config.py
@@ -129,7 +129,10 @@ def test_tier_config_loads_once_when_cached(mock_graph_config):
 
 def test_accessors_return_configured_values(mock_graph_config):
   assert get_tier_max_subgraphs("ladybug-standard") == 5
-  assert get_tier_api_rate_multiplier("ladybug-standard") == 1.5
+  # No longer read from graph.yml: the multiplier is derived from the limits
+  # SUBSCRIPTION_RATE_LIMITS actually enforces, so it cannot drift from them.
+  # The mocked YAML's api_rate_multiplier is therefore ignored by design.
+  assert get_tier_api_rate_multiplier("ladybug-standard") == 1.0
 
   copy_limits = get_tier_copy_operation_limits("ladybug-standard")
   assert copy_limits["max_file_size_gb"] == 3
@@ -150,7 +153,7 @@ def test_accessors_return_configured_values(mock_graph_config):
 def test_accessors_fall_back_to_defaults_when_missing(mock_graph_config):
   # ladybug-large is missing multiplier/copy settings so defaults apply
   assert GraphTierConfig.get_tier_config("unknown-tier") == {}
-  assert get_tier_api_rate_multiplier("ladybug-large") == 1.0
+  assert get_tier_api_rate_multiplier("ladybug-large") == 2.0  # derived, 2 vCPU
 
   default_copy = get_tier_copy_operation_limits("ladybug-large")
   assert default_copy["max_file_size_gb"] == 1.0

--- a/tests/middleware/rate_limits/test_graph_tier_resolver.py
+++ b/tests/middleware/rate_limits/test_graph_tier_resolver.py
@@ -33,6 +33,11 @@ class TestExtractGraphId:
       ("/v1/auth/login", None),
       # Carries no graph id despite sitting under /graphs
       ("/v1/graphs/schema/validate", None),
+      # Static routes whose second segment is not a graph id. Treating one as
+      # a graph id would collapse every caller into a single shared bucket.
+      ("/v1/graphs/tiers", None),
+      ("/v1/graphs/capacity", None),
+      ("/v1/graphs/extensions", None),
     ],
   )
   def test_extraction(self, path, expected):
@@ -77,6 +82,28 @@ class TestResolveGraphTier:
 
     with patch("robosystems.database.session", side_effect=RuntimeError("db is down")):
       assert resolve_graph_tier("kg1abc") == FALLBACK_TIER
+
+  @patch("robosystems.middleware.rate_limits.graph_tier_resolver._store_tier")
+  @patch("robosystems.middleware.rate_limits.graph_tier_resolver._cached_tier")
+  def test_tier_without_a_limits_table_falls_back(self, mock_cached, _mock_store):
+    """A stored tier string with no SUBSCRIPTION_RATE_LIMITS entry — a legacy
+    value or ladybug-shared — must floor at FALLBACK_TIER, not fall through to
+    the anonymous base table."""
+    mock_cached.return_value = None
+    graph = MagicMock()
+    graph.graph_tier = "kuzu-standard"
+
+    with patch("robosystems.models.core.graph.Graph.get_by_id", return_value=graph):
+      with patch("robosystems.database.session", return_value=MagicMock()):
+        assert resolve_graph_tier("kg1legacy") == FALLBACK_TIER
+
+  @patch("robosystems.middleware.rate_limits.graph_tier_resolver._cached_tier")
+  def test_cached_tier_without_a_limits_table_falls_back(self, mock_cached):
+    mock_cached.return_value = "ladybug-shared"
+
+    with patch("robosystems.models.core.graph.Graph.get_by_id") as mock_get:
+      assert resolve_graph_tier("kg1abc") == FALLBACK_TIER
+      mock_get.assert_not_called()
 
   def test_fallback_is_the_tightest_customer_tier(self):
     """Degrading must never hand out more than the cheapest tier allows."""
@@ -183,6 +210,47 @@ class TestSharedRepositoryIsolation:
       "graph_sub:kg1bbb:graph_query",
     ], seen
 
+  def test_subgraph_queries_draw_from_the_parents_budget(self):
+    """kg…_dev lives on its parent's instance and is not separately priced,
+    so it must share the parent's bucket — not mint its own."""
+    from robosystems.middleware.rate_limits.rate_limiting import (
+      subscription_aware_rate_limit_dependency,
+    )
+
+    seen = []
+
+    def record(identifier, limit, window):
+      seen.append(identifier)
+      return (True, 100)
+
+    request = MagicMock()
+    request.method = "POST"
+    request.client.host = "1.2.3.4"
+    request.state = MagicMock()
+    request.headers = {}
+
+    parent = "kg0123456789abcdef"
+
+    with patch(
+      "robosystems.middleware.rate_limits.rate_limiting.rate_limit_cache.check_rate_limit",
+      side_effect=record,
+    ):
+      with patch(
+        "robosystems.middleware.rate_limits.rate_limiting.get_user_from_request",
+        return_value="user_a",
+      ):
+        with patch(
+          "robosystems.middleware.rate_limits.graph_tier_resolver.resolve_graph_tier",
+          return_value="ladybug-standard",
+        ) as mock_resolve:
+          for gid in (parent, f"{parent}_dev"):
+            request.url.path = f"/v1/graphs/{gid}/query/cypher"
+            subscription_aware_rate_limit_dependency(request)
+
+    assert seen == [f"graph_sub:{parent}:graph_query"] * 2, seen
+    for call in mock_resolve.call_args_list:
+      assert call.args[0] == parent
+
 
 class TestTierDifferentiation:
   def test_dedicated_categories_scale_with_vcpu(self):
@@ -222,5 +290,8 @@ class TestTierDifferentiation:
       ("ladybug-standard", 1.0),
       ("ladybug-large", 2.0),
       ("ladybug-xlarge", 4.0),
+      # No limits table of their own — enforced at the standard fallback.
+      ("ladybug-shared", 1.0),
+      ("kuzu-standard", 1.0),
     ):
       assert GraphTierConfig.get_api_rate_multiplier(tier) == expected

--- a/tests/middleware/rate_limits/test_graph_tier_resolver.py
+++ b/tests/middleware/rate_limits/test_graph_tier_resolver.py
@@ -1,0 +1,226 @@
+"""Tests for graph-scoped rate limit tier resolution.
+
+The limiter previously pinned every authenticated user to ladybug-standard and
+bucketed by user, so the large/xlarge tables were unreachable and a customer
+with ten graphs shared one budget. These cover the resolution that replaced it,
+weighted toward the failure modes — resolution must never fail *open*.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from robosystems.config.rate_limits import EndpointCategory, RateLimitConfig
+from robosystems.middleware.rate_limits.graph_tier_resolver import (
+  FALLBACK_TIER,
+  extract_graph_id,
+  resolve_graph_tier,
+)
+
+
+class TestExtractGraphId:
+  @pytest.mark.parametrize(
+    "path,expected",
+    [
+      ("/v1/graphs/kg1abc/query/cypher", "kg1abc"),
+      ("/v1/graphs/kg1abc/mcp/call-tool", "kg1abc"),
+      ("/extensions/kg1abc/graphql", "kg1abc"),
+      ("/extensions/roboledger/kg1abc/operations/close-period", "kg1abc"),
+      ("/extensions/roboinvestor/kg1abc/operations/create-security", "kg1abc"),
+      # Not graph-scoped
+      ("/v1/user/subscription", None),
+      ("/v1/status", None),
+      ("/v1/auth/login", None),
+      # Carries no graph id despite sitting under /graphs
+      ("/v1/graphs/schema/validate", None),
+    ],
+  )
+  def test_extraction(self, path, expected):
+    assert extract_graph_id(path) == expected
+
+
+class TestResolveGraphTier:
+  """Every failure path must land on the tightest tier, never the loosest."""
+
+  @patch("robosystems.middleware.rate_limits.graph_tier_resolver._store_tier")
+  @patch("robosystems.middleware.rate_limits.graph_tier_resolver._cached_tier")
+  def test_returns_the_graphs_tier(self, mock_cached, _mock_store):
+    mock_cached.return_value = None
+    graph = MagicMock()
+    graph.graph_tier = "ladybug-xlarge"
+
+    with patch("robosystems.models.core.graph.Graph.get_by_id", return_value=graph):
+      with patch("robosystems.database.session", return_value=MagicMock()):
+        assert resolve_graph_tier("kg1abc") == "ladybug-xlarge"
+
+  @patch("robosystems.middleware.rate_limits.graph_tier_resolver._cached_tier")
+  def test_cache_hit_skips_the_database(self, mock_cached):
+    mock_cached.return_value = "ladybug-large"
+
+    with patch("robosystems.models.core.graph.Graph.get_by_id") as mock_get:
+      assert resolve_graph_tier("kg1abc") == "ladybug-large"
+      mock_get.assert_not_called()
+
+  @patch("robosystems.middleware.rate_limits.graph_tier_resolver._store_tier")
+  @patch("robosystems.middleware.rate_limits.graph_tier_resolver._cached_tier")
+  def test_unknown_graph_falls_back(self, mock_cached, _mock_store):
+    mock_cached.return_value = None
+
+    with patch("robosystems.models.core.graph.Graph.get_by_id", return_value=None):
+      with patch("robosystems.database.session", return_value=MagicMock()):
+        assert resolve_graph_tier("kg1missing") == FALLBACK_TIER
+
+  @patch("robosystems.middleware.rate_limits.graph_tier_resolver._cached_tier")
+  def test_database_failure_falls_back_rather_than_raising(self, mock_cached):
+    """A lookup error must not 500 the request, nor grant more throughput."""
+    mock_cached.return_value = None
+
+    with patch("robosystems.database.session", side_effect=RuntimeError("db is down")):
+      assert resolve_graph_tier("kg1abc") == FALLBACK_TIER
+
+  def test_fallback_is_the_tightest_customer_tier(self):
+    """Degrading must never hand out more than the cheapest tier allows."""
+    fallback_limit = RateLimitConfig.get_rate_limit(
+      FALLBACK_TIER, EndpointCategory.GRAPH_QUERY
+    )
+    for tier in ("ladybug-standard", "ladybug-large", "ladybug-xlarge"):
+      tier_limit = RateLimitConfig.get_rate_limit(tier, EndpointCategory.GRAPH_QUERY)
+      assert fallback_limit and tier_limit
+      assert fallback_limit[0] <= tier_limit[0], (
+        f"{FALLBACK_TIER} is not the tightest tier — {tier} allows less"
+      )
+
+
+class TestSharedRepositoryIsolation:
+  """Shared repositories must stay user-bucketed, never graph-bucketed.
+
+  `sec` is a single graph every tenant queries. Keying its bucket by graph id
+  would put every customer in one budget, letting a single heavy user exhaust
+  the limit for everyone — the opposite of what rate limiting is for. Per-graph
+  bucketing is only safe when the graph belongs to one tenant.
+  """
+
+  def test_shared_repositories_and_their_subgraphs_are_recognised(self):
+    from robosystems.config.shared_repositories import (
+      is_shared_repository_or_subgraph,
+    )
+
+    assert is_shared_repository_or_subgraph("sec")
+    assert is_shared_repository_or_subgraph("sec_historical")
+    assert not is_shared_repository_or_subgraph("kg1a2b3c")
+
+  def test_shared_repository_query_buckets_by_user(self):
+    """Two users on `sec` must not share a bucket."""
+    from robosystems.middleware.rate_limits.rate_limiting import (
+      subscription_aware_rate_limit_dependency,
+    )
+
+    seen = []
+
+    def record(identifier, limit, window):
+      seen.append(identifier)
+      return (True, 100)
+
+    request = MagicMock()
+    request.url.path = "/v1/graphs/sec/query/cypher"
+    request.method = "POST"
+    request.client.host = "1.2.3.4"
+    request.state = MagicMock()
+    request.headers = {}
+
+    with patch(
+      "robosystems.middleware.rate_limits.rate_limiting.rate_limit_cache.check_rate_limit",
+      side_effect=record,
+    ):
+      with patch(
+        "robosystems.middleware.rate_limits.rate_limiting.get_user_from_request",
+        side_effect=["user_a", "user_b"],
+      ):
+        subscription_aware_rate_limit_dependency(request)
+        subscription_aware_rate_limit_dependency(request)
+
+    assert seen == [
+      "user_sub:user_a:graph_query",
+      "user_sub:user_b:graph_query",
+    ], seen
+
+  def test_tenant_graph_query_buckets_by_graph(self):
+    """A tenant's own graphs each get their own budget."""
+    from robosystems.middleware.rate_limits.rate_limiting import (
+      subscription_aware_rate_limit_dependency,
+    )
+
+    seen = []
+
+    def record(identifier, limit, window):
+      seen.append(identifier)
+      return (True, 100)
+
+    request = MagicMock()
+    request.method = "POST"
+    request.client.host = "1.2.3.4"
+    request.state = MagicMock()
+    request.headers = {}
+
+    with patch(
+      "robosystems.middleware.rate_limits.rate_limiting.rate_limit_cache.check_rate_limit",
+      side_effect=record,
+    ):
+      with patch(
+        "robosystems.middleware.rate_limits.rate_limiting.get_user_from_request",
+        return_value="user_a",
+      ):
+        with patch(
+          "robosystems.middleware.rate_limits.graph_tier_resolver.resolve_graph_tier",
+          return_value="ladybug-standard",
+        ):
+          for gid in ("kg1aaa", "kg1bbb"):
+            request.url.path = f"/v1/graphs/{gid}/query/cypher"
+            subscription_aware_rate_limit_dependency(request)
+
+    assert seen == [
+      "graph_sub:kg1aaa:graph_query",
+      "graph_sub:kg1bbb:graph_query",
+    ], seen
+
+
+class TestTierDifferentiation:
+  def test_dedicated_categories_scale_with_vcpu(self):
+    """1x / 2x / 4x, matching m7g.medium -> m7g.large -> r7g.xlarge."""
+    for category in RateLimitConfig.DEDICATED_RESOURCE_CATEGORIES:
+      standard = RateLimitConfig.get_rate_limit("ladybug-standard", category)
+      assert standard, category
+      for tier, factor in (("ladybug-large", 2), ("ladybug-xlarge", 4)):
+        actual = RateLimitConfig.get_rate_limit(tier, category)
+        assert actual and actual[0] == standard[0] * factor, (
+          f"{tier}/{category.value} is {actual[0] if actual else None}, "
+          f"expected {standard[0] * factor}"
+        )
+
+  def test_shared_resource_categories_stay_flat(self):
+    """Shared infra must not scale, or one tenant can starve the rest."""
+    shared = {
+      EndpointCategory.GRAPH_SEARCH,  # OpenSearch t3.medium
+      EndpointCategory.GRAPH_IMPORT,  # sequential in LadybugDB regardless
+      EndpointCategory.EXTENSIONS_GRAPHQL,  # shared RDS
+      EndpointCategory.EXTENSIONS_WRITE,
+    }
+    assert not (shared & RateLimitConfig.DEDICATED_RESOURCE_CATEGORIES)
+
+    for category in shared:
+      limits = {
+        RateLimitConfig.get_rate_limit(t, category)[0]  # type: ignore[index]
+        for t in ("ladybug-standard", "ladybug-large", "ladybug-xlarge")
+      }
+      assert len(limits) == 1, f"{category.value} differs across tiers: {limits}"
+
+  def test_reported_multiplier_matches_enforcement(self):
+    """The multiplier is derived, so it cannot drift from what is enforced."""
+    from robosystems.config.graph_tier import GraphTierConfig
+
+    for tier, expected in (
+      ("ladybug-standard", 1.0),
+      ("ladybug-large", 2.0),
+      ("ladybug-xlarge", 4.0),
+    ):
+      assert GraphTierConfig.get_api_rate_multiplier(tier) == expected

--- a/tests/middleware/rate_limits/test_subscription_rate_limiting.py
+++ b/tests/middleware/rate_limits/test_subscription_rate_limiting.py
@@ -168,11 +168,14 @@ class TestSubscriptionRateLimits:
     assert limit == 30
     assert window == 60
 
-    # LadybugDB Large tier — same base as standard, multiplied by graph.yml
+    # LadybugDB Large tier — 2x Standard on dedicated-resource categories,
+    # matching its 2 vCPU against Standard's 1. This previously asserted 60
+    # with the note "1.5x multiplier applied separately"; nothing applied it,
+    # so the tables were identical and the comment documented a bug.
     limit, window = get_subscription_rate_limit(
       "ladybug-large", EndpointCategory.GRAPH_QUERY
     )
-    assert limit == 60  # Same base; 1.5x multiplier applied separately
+    assert limit == 120
     assert window == 60
 
   def test_standard_tier_has_appropriate_limits(self):
@@ -242,9 +245,12 @@ class TestSubscriptionAwareRateLimiting:
     # Call the dependency
     subscription_aware_rate_limit_dependency(mock_request)
 
-    # Verify correct limit was checked (120/minute for standard tier graph reads)
+    # Graph-scoped reads bucket per graph, not per user: graph_read is a
+    # dedicated-resource category, so each graph gets its own budget on its own
+    # instance. Buckets were keyed "user_sub:{user_id}" until per-graph pricing
+    # made that wrong — ten graphs shared one budget.
     mock_check_rate_limit.assert_called_once_with(
-      "user_sub:user_456:graph_read", 120, 60
+      "graph_sub:kg1a2b3c:graph_read", 120, 60
     )
 
     # Verify request state was updated

--- a/tests/routers/graphs/test_graph_limits.py
+++ b/tests/routers/graphs/test_graph_limits.py
@@ -194,3 +194,152 @@ class TestGraphCreationLimits:
   #   """Test that users without limits get defaults from environment."""
   #   # This test needs to be rewritten to handle the new SSE response format
   #   pass
+
+
+@pytest.mark.asyncio
+class TestGraphLimitsEndpoint:
+  """GET /v1/graphs/{graph_id}/limits must report what is enforced.
+
+  Three bugs lived in this one handler: `credits` was permanently null (it
+  read a column that does not exist, behind a bare except), `subscription_tier`
+  came from a User attribute that does not exist, and shared repositories
+  reported the anonymous base table while enforcement grants the user-keyed
+  standard tier. These pin the endpoint end to end.
+  """
+
+  def _use_test_db(self, test_db):
+    """Route the endpoint's async session dependency at the test database.
+
+    async_client does not override get_async_db_session; its teardown clears
+    all overrides, so adding one here is safe.
+    """
+    from main import app
+    from robosystems.database import get_async_db_session
+
+    async def override():
+      yield test_db
+
+    app.dependency_overrides[get_async_db_session] = override
+
+  def _make_graph(self, test_db, test_org, test_user, tier, with_credits=True):
+    import uuid
+    from datetime import UTC, datetime
+    from decimal import Decimal
+
+    from robosystems.models.core import Graph, GraphCredits, GraphUser
+
+    graph = Graph.create(
+      graph_id=f"kg{uuid.uuid4().hex[:16]}",
+      graph_name="Limits Endpoint Graph",
+      graph_type="entity",
+      org_id=test_org.id,
+      session=test_db,
+      base_schema="base",
+      schema_extensions=[],
+      graph_tier=tier,
+      graph_instance_id="test-instance",
+    )
+    GraphUser.create(
+      user_id=test_user.id,
+      graph_id=graph.graph_id,
+      role="admin",
+      is_selected=False,
+      session=test_db,
+    )
+    if with_credits:
+      test_db.add(
+        GraphCredits(
+          id=f"gc_{graph.graph_id}",
+          graph_id=graph.graph_id,
+          user_id=test_user.id,
+          billing_admin_id=test_user.id,
+          current_balance=Decimal("31999.50"),
+          monthly_allocation=Decimal("32000"),
+          last_allocation_date=datetime.now(UTC),
+        )
+      )
+    test_db.commit()
+    return graph
+
+  def _no_graph_api(self):
+    """The handler tolerates an unreachable Graph API; keep tests hermetic."""
+    from unittest.mock import AsyncMock
+
+    return (
+      patch(
+        "robosystems.routers.graphs.limits.get_universal_repository",
+        new=AsyncMock(),
+      ),
+      patch(
+        "robosystems.routers.graphs.limits._get_graph_client",
+        new=AsyncMock(side_effect=RuntimeError("no graph api in tests")),
+      ),
+      patch(
+        "robosystems.middleware.graph.ingestion_limits.IngestionLimitChecker.check_instance_storage",
+        new=AsyncMock(side_effect=RuntimeError("no graph api in tests")),
+      ),
+    )
+
+  async def test_reports_enforced_tier_rate_and_credits(
+    self, async_client: AsyncClient, test_db, test_org, test_user
+  ):
+    from robosystems.config.graph_tier import GraphTier
+
+    graph = self._make_graph(test_db, test_org, test_user, GraphTier.LADYBUG_LARGE)
+    self._use_test_db(test_db)
+
+    repo, client, storage = self._no_graph_api()
+    with repo, client, storage:
+      response = await async_client.get(f"/v1/graphs/{graph.graph_id}/limits")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["graph_tier"] == "ladybug-large"
+    assert data["subscription_tier"] == "ladybug-large"
+    # The enforced GRAPH_QUERY limit for ladybug-large, not 60 x multiplier
+    assert data["rate_limits"]["requests_per_minute"] == 120
+    # Was permanently null: the handler read monthly_credit_limit, a column
+    # that does not exist, and a bare except swallowed the AttributeError.
+    assert data["credits"] == {
+      "monthly_ai_credits": 32000,
+      "current_balance": 31999,
+    }
+
+  async def test_shared_repository_reports_the_enforced_fallback_tier(
+    self, async_client: AsyncClient, test_db
+  ):
+    """ladybug-shared has no limits table; enforcement grants the user-keyed
+    standard tier, and the report must not fall to the base table (20/min)."""
+    self._use_test_db(test_db)
+
+    repo, client, storage = self._no_graph_api()
+    with repo, client, storage:
+      response = await async_client.get("/v1/graphs/sec/limits")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["is_shared_repository"] is True
+    assert data["graph_tier"] == "ladybug-shared"
+    assert data["subscription_tier"] == "ladybug-standard"
+    assert data["rate_limits"]["requests_per_minute"] == 60
+    assert data["credits"] is None
+
+  async def test_legacy_tier_string_floors_at_standard_not_base(
+    self, async_client: AsyncClient, test_db, test_org, test_user
+  ):
+    """A graphs.graph_tier value predating a tier rename must report the
+    fallback tier's limits, mirroring what the limiter enforces."""
+    graph = self._make_graph(
+      test_db, test_org, test_user, "kuzu-standard", with_credits=False
+    )
+    self._use_test_db(test_db)
+
+    repo, client, storage = self._no_graph_api()
+    with repo, client, storage:
+      response = await async_client.get(f"/v1/graphs/{graph.graph_id}/limits")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["graph_tier"] == "kuzu-standard"
+    assert data["subscription_tier"] == "ladybug-standard"
+    assert data["rate_limits"]["requests_per_minute"] == 60

--- a/tests/routers/test_offering.py
+++ b/tests/routers/test_offering.py
@@ -108,3 +108,19 @@ class TestOfferingEndpoint:
         f"{tier['name']} advertises no backup retention"
       )
       assert tier["instance_type"], f"{tier['name']} has no instance type"
+
+  async def test_rate_multiplier_is_the_derived_value(self, async_client: AsyncClient):
+    """The advertised multiplier must come from the enforced limits table.
+
+    graph.yml no longer defines api_rate_multiplier, so reading it off the
+    tier config dict silently reports 1.0 for every tier.
+    """
+    from robosystems.config.graph_tier import GraphTierConfig
+
+    response = await async_client.get("/v1/offering")
+    assert response.status_code == 200
+
+    for tier in response.json()["graph_subscriptions"]["tiers"]:
+      assert tier["api_rate_multiplier"] == GraphTierConfig.get_api_rate_multiplier(
+        tier["name"]
+      ), f"{tier['name']} advertises a multiplier the limiter does not enforce"


### PR DESCRIPTION
Rate limiting worked as burst protection but was **undifferentiated by tier** — in four independent ways, each of which hid the others. A follow-up commit then makes every surface that *describes* the limits agree with what the first commit enforces.

## What was broken

| | |
|---|---|
| `rate_limiting.py:496` | pinned every authenticated user to `"ladybug-standard"`, making the `ladybug-large` and `ladybug-xlarge` tables **unreachable code** |
| the tables themselves | held **identical values**, so fixing the lookup alone would have changed nothing |
| `api_rate_multiplier` | read in four places, applied in **none** — `/v1/graphs/{id}/limits` reported 90/min to Large and 150/min to XLarge, who were served 60 |
| bucket key | keyed by **user**, so a customer with ten graphs shared one budget — per-graph pricing delivering no per-graph throughput |

The comment justifying the hardcode said *"graph-specific subscriptions are handled at the graph level."* The only graph-tier-aware limiter is `download_limits.py`, which governs monthly backup downloads. `graph_scoped_rate_limit_dependency` turns out to be a pure alias for the same function.

## What unlocked it

**LadybugDB writers are not shared.** Every customer tier is `databases_per_instance: 1`, so query load lands on the tenant's own box. The config comment asserted the opposite — *"protect shared resources (OpenSearch t3.medium, LadybugDB on m7g/r7g)"* — and that false premise is what justified flat limits.

Categories now split by what they actually touch:

| Resource | Categories | Treatment |
|---|---|---|
| Tenant's **own** instance | `graph_query`, `graph_read`, `graph_write`, `graph_mcp`, `graph_operator`, `graph_analytics` | scale **1×/2×/4×** by vCPU, bucketed **per graph** |
| **Shared** OpenSearch / RDS / API | `graph_search`, `graph_import`, `extensions_*`, auth, billing | **flat**, bucketed **per user** |

`graph_import` stays flat deliberately: LadybugDB ingests sequentially regardless of tier, so extra cores buy nothing.

## Shared repositories are excluded from per-graph bucketing

`sec` is **one graph every tenant queries**. Keying its bucket by graph id would put all of them in a single budget and let one heavy user exhaust it for everyone — worse than the bug being fixed. Those stay user-keyed, which is also what isolates tenants from each other. Subgraphs count too: `sec_historical` is as shared as `sec`, so the check uses `is_shared_repository_or_subgraph`.

## Subgraphs draw from the parent's budget

A subgraph of a *user* graph is the mirror-image case: `kg…_dev` lives on `kg…`'s instance and is not separately priced, so it buckets as `kg…`. Without this, an XLarge tenant with 25 subgraphs would hold 26 independent budgets against one machine.

## Failing closed

Tier resolution is Valkey-cached (5 min TTL, one lazily-created client per process) to preserve the limiter's zero-database-access property on the hot path. Cache miss, unknown graph, or lookup error all fall back to the **tightest** tier. A resolved tier string with no `SUBSCRIPTION_RATE_LIMITS` entry — `ladybug-shared`, or a value predating a tier rename — also floors at the fallback tier rather than falling through to the anonymous `base` table: degradation lands a paying customer on the cheapest paid tier, never below it. Failing open would hand out throughput nobody bought.

The static segments under `/v1/graphs` (`tiers`, `capacity`, `extensions`) are excluded from graph-id extraction. Latent — those routes use the general limiter — but defense in depth against one of them adopting the subscription-aware dependency and collapsing every caller into a single shared bucket.

## `api_rate_multiplier`

Removed from `graph.yml`. The API field remains — it's required on two public response models — but is now **derived** from the limits actually enforced. The follow-up commit finishes the job the first started: `/v1/offering` and `/v1/graphs/tiers` were still reading the deleted YAML key and advertising **1.0 for every tier** — the inverse of the original drift. Both now call the derived function, and tests pin the derived value at both the catalog level (`get_available_tiers` for production and staging) and the endpoint level, so neither surface can flatten again. **No SDK regen needed.**

## Reporting surfaces now match enforcement

- **`/v1/graphs/{id}/limits`** reports the enforced tier for shared repositories — it was reporting the `base` table (20/min) while enforcement grants the user-keyed standard tier (60/min), the exact "reporting a limit we do not honour" this PR exists to end. The same path covers legacy tier strings. Also in that response: `credits` was permanently `null` (the block read `monthly_credit_limit`, a column that does not exist, behind a bare `except: pass`), and `subscription_tier` came from a `User` attribute that also does not exist, reporting `ladybug-standard` to everyone. It now reports the enforced tier.
- **`/v1/graphs/tiers`** hid Large and XLarge in production by honouring `deployment.enabled_default`, which answers "is the CloudFormation stack deployed by default" rather than "can a customer buy this" — the same bug #946's sibling fix (1c25fbba) closed in `/v1/offering` — and fabricated $100/$300/$700 fallback prices matching neither billing nor Stripe. It now mirrors `/offering`: the billing catalog decides what is listed, and a tier it cannot price is omitted rather than invented.

## Deliberately not changed

Standard's numbers are **not** halved after its `m7g.large → m7g.medium` resize. Observed production load is ~1% CPU, and cutting existing customers' limits to match a smaller box trades real service for protection admission control (85% of instance CPU/memory) already provides.

## Caveat worth stating plainly

The 1×/2×/4× ratios are anchored to vCPU, **not measured**. The only load data is 27–42% peak CPU on a near-idle three-graph fleet. Admission control remains the real overload backstop; these are a product lever.

## Testing

Full suite: **11,413 passed**, `just test-code` clean. The only failures are the two pre-existing `test_incremental_materialize` cases that reproduce on `main`.

Tests are weighted toward the failure modes: fail-closed resolution, that the fallback really is the tightest tier — including for tier strings with no limits table, on both the cache and database paths — the 1×/2×/4× and flat-shared invariants, static-segment extraction, and bucketing pinned directly: two users on `sec` get **distinct** buckets, one user on two owned graphs gets distinct buckets, and a subgraph shares its parent's bucket. The derived multiplier is pinned at catalog and endpoint level.

Two existing tests were updated rather than fixed: one asserted `limit == 60` for Large with the note *"1.5x multiplier applied separately"*, and one pinned the user-keyed bucket. Both encoded the behaviour being corrected.
