### PR TITLE
Treat shared repository subgraphs as repositories everywhere

### DIFF
--- a/robosystems/middleware/graph/types.py
+++ b/robosystems/middleware/graph/types.py
@@ -213,6 +213,13 @@ class GraphTypeRegistry:
     Returns:
         GraphIdentity with category and type information
     """
+    # The registry is authoritative for what is shared. Shared-repo subgraph
+    # rows are created with is_repository=False (subgraph_service), so trusting
+    # the row alone classified sec_historical as a READ_WRITE user graph.
+    from ...config.shared_repositories import (
+      is_shared_repository_or_subgraph as _is_shared_repo_or_sub,
+    )
+
     # Try database lookup first if session provided
     if session:
       from ...models.core import Graph
@@ -220,7 +227,7 @@ class GraphTypeRegistry:
       graph = Graph.get_by_id(graph_id, session)
       if graph:
         # Found in database - use actual metadata
-        if graph.is_repository:
+        if graph.is_repository or _is_shared_repo_or_sub(graph_id):
           try:
             tier = (
               GraphTier(graph.graph_tier)
@@ -268,10 +275,6 @@ class GraphTypeRegistry:
 
     # Fallback: pattern-based detection (for cases without session)
     # Check if it's a known shared repository
-    from ...config.shared_repositories import (
-      is_shared_repository_or_subgraph as _is_shared_repo_or_sub,
-    )
-
     if _is_shared_repo_or_sub(graph_id):
       return GraphIdentity(
         graph_id=graph_id,

--- a/robosystems/operations/graph/credit_service.py
+++ b/robosystems/operations/graph/credit_service.py
@@ -22,7 +22,7 @@ from ...config.shared_repositories import (
   get_credit_costs as _get_credit_costs,
 )
 from ...config.shared_repositories import (
-  is_shared_repository as _is_shared_repository,
+  is_shared_repository_or_subgraph as _is_shared_repository_or_subgraph,
 )
 from ...middleware.graph.types import parse_graph_id
 from ...models.core import (
@@ -122,8 +122,14 @@ class CreditService:
     return parent_id
 
   def _is_shared_repository(self, graph_id: str) -> bool:
-    """Check if the graph_id represents a shared repository."""
-    return _is_shared_repository(graph_id)
+    """Check if the graph_id is a shared repository or one of its subgraphs.
+
+    Subgraphs count: `sec_historical` bills against the user's `sec`
+    repository pool, exactly as `sec` does. The exact-only check sent shared
+    subgraphs down the user-graph path, where the GraphCredits lookup for a
+    repository finds nothing and AI operations ran unbilled.
+    """
+    return _is_shared_repository_or_subgraph(graph_id)
 
   def consume_credits(
     self,
@@ -169,10 +175,11 @@ class CreditService:
           "credits_consumed": 0,
         }
 
-      # Route to shared repository credit system
+      # Route to shared repository credit system. The pool is keyed by the
+      # repository id, so a shared subgraph resolves to its parent first.
       return self.consume_shared_repository_credits(
         user_id=user_id,
-        repository_name=graph_id,
+        repository_name=self._get_parent_graph_id(graph_id),
         operation_type=operation_type,
         metadata=metadata,
         cached=cached,
@@ -313,10 +320,11 @@ class CreditService:
       if not user_id:
         return {"error": "User ID required for shared repository credit summary"}
 
-      # Get user's repository credits
+      # Get user's repository credits. The pool is keyed by the repository id,
+      # so a shared subgraph resolves to its parent first.
       user_repo_credits = UserRepositoryCredits.get_user_repository_credits(
         user_id=user_id,
-        repository_type=graph_id,  # repository_type is the graph_id for shared repos
+        repository_type=self._get_parent_graph_id(graph_id),
         session=self.session,
       )
 
@@ -507,10 +515,11 @@ class CreditService:
           "error": "User ID required for shared repository access",
         }
 
-      # Route to shared repository credit system
+      # Route to shared repository credit system. The pool is keyed by the
+      # repository id, so a shared subgraph resolves to its parent first.
       shared_check = self.check_shared_repository_access(
         user_id=user_id,
-        repository_name=graph_id,
+        repository_name=self._get_parent_graph_id(graph_id),
         operation_type=operation_type,
         required_credits=required_credits,  # Pass the required credits for AI operations
       )

--- a/robosystems/routers/graphs/backups/backup.py
+++ b/robosystems/routers/graphs/backups/backup.py
@@ -151,20 +151,27 @@ async def list_backups(
         )
       )
 
-    # Check if this is a shared repository and get download quota
-    is_shared_repo = MultiTenantUtils.is_shared_repository(graph_id)
+    # Check if this is a shared repository and get download quota.
+    # Subgraph-aware, and the quota keys on the parent repository — matching
+    # the download endpoint, which enforces against the parent's counter. The
+    # exact-only check made list and download disagree about sec_historical.
+    is_shared_repo = MultiTenantUtils.is_shared_repository_or_subgraph(graph_id)
     download_quota = None
 
     if is_shared_repo:
-      # Get user's repository subscription for quota info
+      from robosystems.config.shared_repositories import (
+        resolve_shared_repository_parent,
+      )
+
+      repository_id = resolve_shared_repository_parent(graph_id)
       user_repo = UserRepository.get_by_user_and_repository(
-        str(current_user.id), graph_id, db
+        str(current_user.id), repository_id, db
       )
       if user_repo:
         plan = user_repo.repository_plan
         quota_info = await DownloadRateLimiter.get_download_quota(
           user_id=str(current_user.id),
-          repository=graph_id,
+          repository=repository_id,
           plan=plan,
         )
         download_quota = DownloadQuota(

--- a/robosystems/routers/graphs/health.py
+++ b/robosystems/routers/graphs/health.py
@@ -49,7 +49,9 @@ def _resources_exposable(graph_id: str, graph_tier: str) -> bool:
   from robosystems.config.graph_tier import GraphTierConfig
   from robosystems.middleware.graph.utils import MultiTenantUtils
 
-  if MultiTenantUtils.is_shared_repository(graph_id):
+  # Subgraph-aware: sec_historical serves every tenant from the shared master
+  # exactly as sec does, so the exact-only check leaked its instance metrics.
+  if MultiTenantUtils.is_shared_repository_or_subgraph(graph_id):
     return False
   return GraphTierConfig.get_databases_per_instance(graph_tier) == 1
 

--- a/robosystems/routers/graphs/limits.py
+++ b/robosystems/routers/graphs/limits.py
@@ -107,12 +107,15 @@ async def get_graph_limits(
     # - Fallback: ladybug-standard (shouldn't happen in practice)
     if graph:
       graph_tier = str(graph.graph_tier)
-    elif MultiTenantUtils.is_shared_repository(graph_id):
+    elif MultiTenantUtils.is_shared_repository_or_subgraph(graph_id):
       graph_tier = "ladybug-shared"
     else:
       graph_tier = "ladybug-standard"
 
-    is_shared = MultiTenantUtils.is_shared_repository(graph_id)
+    # Subgraph-aware, matching _get_graph_client above: sec_historical must
+    # take the shared-repository path here too, or the sections below walk the
+    # shared master's storage — the exact latency hazard their comments forbid.
+    is_shared = MultiTenantUtils.is_shared_repository_or_subgraph(graph_id)
 
     # The tier whose rate-limit table the limiter enforces for requests to
     # this graph. Shared repositories are user-keyed at the fallback tier, and

--- a/robosystems/routers/graphs/mcp/tools.py
+++ b/robosystems/routers/graphs/mcp/tools.py
@@ -32,8 +32,10 @@ circuit_breaker = CircuitBreakerManager()
 
 
 def _get_mcp_operation_type(graph_id: str) -> str:
-  # Shared repos route to reader cluster; user graphs always use writer for consistency
-  if MultiTenantUtils.is_shared_repository(graph_id):
+  # Shared repos and their subgraphs route to the reader cluster; user graphs
+  # always use the writer for consistency. Matches middleware/mcp/factory.py,
+  # which already classified sec_historical as read while this returned write.
+  if MultiTenantUtils.is_shared_repository_or_subgraph(graph_id):
     return "read"
   else:
     return "write"
@@ -140,7 +142,7 @@ async def list_mcp_tools(
       event_data={
         "graph_id": graph_id,
         "tool_count": len(enhanced_tools),
-        "is_shared_repo": MultiTenantUtils.is_shared_repository(graph_id),
+        "is_shared_repo": MultiTenantUtils.is_shared_repository_or_subgraph(graph_id),
       },
       user_id=current_user.id,
     )

--- a/robosystems/routers/graphs/query/execute.py
+++ b/robosystems/routers/graphs/query/execute.py
@@ -463,11 +463,11 @@ async def execute_cypher_query(
           user_id=current_user.id,
         )
 
-        # Shared repositories have their own scaling (ALB + ASG) —
-        # queuing just delays the inevitable, so return a timeout error.
-        # User graphs benefit from the queue since they have limited
-        # connections (max 3) and no read replicas.
-        is_shared = MultiTenantUtils.is_shared_repository(graph_id)
+        # Shared repositories and their subgraphs have their own scaling
+        # (ALB + ASG) — queuing just delays the inevitable, so return a
+        # timeout error. User graphs benefit from the queue since they have
+        # limited connections (max 3) and no read replicas.
+        is_shared = MultiTenantUtils.is_shared_repository_or_subgraph(graph_id)
 
         if client_info["is_interactive"] or is_shared:
           elapsed = (datetime.now(UTC) - start_time).total_seconds()

--- a/tests/middleware/graph/test_types.py
+++ b/tests/middleware/graph/test_types.py
@@ -74,6 +74,34 @@ class TestGraphTypeRegistry:
     assert identity.graph_type == "entity"
     assert identity.graph_tier == GraphTier.LADYBUG_STANDARD
 
+  def test_shared_repo_subgraph_row_still_classifies_as_shared(
+    self, db_session, test_org
+  ):
+    """The registry is authoritative over the row's is_repository flag.
+
+    subgraph_service creates shared-repo subgraph rows (e.g. sec_historical)
+    with is_repository=False, so trusting the row alone classified them as
+    READ_WRITE user graphs whenever a session was passed — while the
+    sessionless fallback said SHARED/READ_ONLY for the same id.
+    """
+    subgraph_row = Graph.create(
+      graph_id=f"sec_h{self.unique_id}",
+      graph_name="SEC Historical Subgraph",
+      graph_type="entity",
+      org_id=test_org.id,
+      session=db_session,
+      graph_tier=GraphTier.LADYBUG_SHARED,
+    )
+    assert subgraph_row.is_repository is False
+
+    identity = GraphTypeRegistry.identify_graph(
+      subgraph_row.graph_id, session=db_session
+    )
+
+    assert identity.category == GraphCategory.SHARED
+    assert identity.access_pattern == AccessPattern.READ_ONLY
+    assert identity.graph_tier == GraphTier.LADYBUG_SHARED
+
   def test_identify_graph_named_parameter_usage(self):
     """
     Regression test: ensure graph_tier uses named parameter.

--- a/tests/operations/graph/test_credit_service.py
+++ b/tests/operations/graph/test_credit_service.py
@@ -540,3 +540,76 @@ class TestCreditCaching:
     balance, tier = result
     assert balance == Decimal("950.0")
     assert tier == "standard"
+
+
+@pytest.mark.unit
+class TestSharedRepositorySubgraphBilling:
+  """AI operations on a shared repository's subgraph bill the parent's pool.
+
+  The exact-only shared-repository check sent sec_historical down the
+  user-graph path, where GraphCredits.get_by_graph_id("sec") finds nothing —
+  so the operation ran and was never billed. The pool is keyed by the
+  repository id, so routing must resolve the parent first.
+  """
+
+  @pytest.fixture
+  def credit_service(self):
+    with patch("robosystems.middleware.billing.cache.credit_cache"):
+      return CreditService(MagicMock())
+
+  def test_consume_credits_routes_subgraph_to_parent_repository_pool(
+    self, credit_service
+  ):
+    with patch.object(
+      credit_service,
+      "consume_shared_repository_credits",
+      return_value={"success": True, "credits_consumed": 5.0},
+    ) as mock_consume:
+      result = credit_service.consume_credits(
+        graph_id="sec_historical",
+        operation_type="agent_call",
+        base_cost=Decimal("5"),
+        user_id="user123",
+      )
+
+    assert result["success"] is True
+    assert mock_consume.call_args.kwargs["repository_name"] == "sec"
+
+  def test_consume_credits_on_the_repository_itself_is_unchanged(self, credit_service):
+    with patch.object(
+      credit_service,
+      "consume_shared_repository_credits",
+      return_value={"success": True, "credits_consumed": 1.0},
+    ) as mock_consume:
+      credit_service.consume_credits(
+        graph_id="sec",
+        operation_type="query",
+        base_cost=Decimal("1"),
+        user_id="user123",
+      )
+
+    assert mock_consume.call_args.kwargs["repository_name"] == "sec"
+
+  def test_subgraph_without_user_id_is_rejected_not_misrouted(self, credit_service):
+    """The shared path requires a user; the failure must say so rather than
+    fall through to a nonexistent GraphCredits pool."""
+    result = credit_service.consume_credits(
+      graph_id="sec_historical",
+      operation_type="query",
+      base_cost=Decimal("1"),
+    )
+
+    assert result["success"] is False
+    assert "User ID required" in result["error"]
+
+  def test_check_credit_balance_routes_subgraph_to_parent(self, credit_service):
+    with patch.object(
+      credit_service,
+      "check_shared_repository_access",
+      return_value={"has_access": True, "has_sufficient_credits": True},
+    ) as mock_check:
+      credit_service.check_credit_balance(
+        "sec_historical", Decimal("1"), user_id="user123"
+      )
+
+    assert mock_check.call_args.kwargs["repository_name"] == "sec"

--- a/tests/routers/graphs/mcp/test_mcp_execute.py
+++ b/tests/routers/graphs/mcp/test_mcp_execute.py
@@ -729,3 +729,25 @@ class TestCachedStrategies:
       graph_id="sec_historical",
     )
     assert schema_strategy == MCPExecutionStrategy.SCHEMA_CACHED
+
+
+@pytest.mark.unit
+class TestToolsRouterOperationType:
+  """tools.py carries its own _get_mcp_operation_type; it must agree with
+  execute.py and the MCP factory that shared subgraphs are reads — it
+  returned "write" for sec_historical while both of those said "read"."""
+
+  def test_shared_repo_and_subgraph_return_read(self):
+    from robosystems.routers.graphs.mcp.tools import (
+      _get_mcp_operation_type as tools_op_type,
+    )
+
+    assert tools_op_type("sec") == "read"
+    assert tools_op_type("sec_historical") == "read"
+
+  def test_user_graph_returns_write(self):
+    from robosystems.routers.graphs.mcp.tools import (
+      _get_mcp_operation_type as tools_op_type,
+    )
+
+    assert tools_op_type("kg0123456789abcdef") == "write"

--- a/tests/routers/graphs/test_graph_limits.py
+++ b/tests/routers/graphs/test_graph_limits.py
@@ -343,3 +343,25 @@ class TestGraphLimitsEndpoint:
     assert data["graph_tier"] == "kuzu-standard"
     assert data["subscription_tier"] == "ladybug-standard"
     assert data["rate_limits"]["requests_per_minute"] == 60
+
+  async def test_shared_repository_subgraph_takes_the_shared_path(
+    self, async_client: AsyncClient, test_db
+  ):
+    """sec_historical must be treated exactly like sec: shared tier report,
+    no storage walk against the shared master, no credits block. The
+    exact-only check ran it through the user-graph sections."""
+    self._use_test_db(test_db)
+
+    repo, client, storage = self._no_graph_api()
+    with repo, client, storage:
+      response = await async_client.get("/v1/graphs/sec_historical/limits")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["is_shared_repository"] is True
+    assert data["graph_tier"] == "ladybug-shared"
+    assert data["subscription_tier"] == "ladybug-standard"
+    assert data["rate_limits"]["requests_per_minute"] == 60
+    assert data["credits"] is None
+    assert data["content"] is None
+    assert data["instance"] is None

--- a/tests/routers/graphs/test_health_resources.py
+++ b/tests/routers/graphs/test_health_resources.py
@@ -33,6 +33,14 @@ class TestResourcesExposable:
     """sec runs one database per box but is read by every tenant."""
     assert _resources_exposable("sec", "ladybug-shared") is False
 
+  def test_shared_repository_subgraph_is_not_exposable(self):
+    """sec_historical serves every tenant from the shared master, like sec.
+
+    The exact-only check let it through to the databases_per_instance branch,
+    which is 1 for ladybug-shared — leaking shared-master metrics.
+    """
+    assert _resources_exposable("sec_historical", "ladybug-shared") is False
+
   def test_packed_tier_is_not_exposable(self):
     """A tier that co-locates tenants closes the guard automatically.
 


### PR DESCRIPTION
Two helpers answer "is this graph shared": the exact-only registry check (`is_shared_repository`) and the subgraph-aware `is_shared_repository_or_subgraph`. About half the call sites used the exact form, so **`sec_historical` — as shared as `sec`, served from the same master — leaked into user-graph code paths**. Each escape produced a different bug; this PR converges on one convention: subgraph-aware wherever the question is "should this request take the shared path", with the parent repository resolved wherever a per-user pool or quota is keyed.

## The one that matters most: billing

AI operations on a shared repository's subgraph **billed nothing**. The credit service's exact-only check sent `sec_historical` down the user-graph path, which resolves the parent and looks up a `GraphCredits` pool — a pool repositories do not have, because their credits are per-user (`UserRepositoryCredits`). The lookup failed, the operator layer only logs consumption failures, and the operation ran unbilled.

Consumption, balance checks, and summaries now recognize shared subgraphs and resolve the parent before touching the per-user pool, so `sec_historical` bills against the user's `sec` repository credits exactly as `sec` does. A subgraph request without a user id is rejected with the same "User ID required" error the repository itself produces, rather than misrouting.

## Classification

`GraphTypeRegistry.identify_graph` trusted the row's `is_repository` flag when a session was supplied — but `subgraph_service` creates shared-repo subgraph rows with `is_repository=False`, so the same id classified as a **READ_WRITE user graph** with a session and SHARED/READ_ONLY without one. The registry is now authoritative over the row flag.

## The rest of the sweep

| Surface | Before | After |
|---|---|---|
| `/v1/graphs/{id}/limits` | shared subgraphs took the user-graph path, including the recursive storage walk on shared infrastructure the file's own comments forbid | report like their repository |
| `/health` resource exposure | gate checked the exact id only | recognizes shared subgraphs |
| Backups list | download quota looked up and keyed on the raw subgraph id, disagreeing with the download endpoint's enforcement keys | resolves and keys on the parent |
| MCP tools router | returned `write` for shared subgraphs while `execute.py` and the MCP factory said `read` | agrees: `read` |
| Query timeout | shared subgraphs fell into the user-graph connection queue | 408 like their repository |

## Testing

Full suite: **11,425 passed**; only failures are the two pre-existing `test_incremental_materialize` cases that reproduce on `main`. Twelve new tests pin the corrected routing: subgraph consumption reaches the parent's repository pool (and the repository itself is unchanged), missing-user rejection, session-backed classification of a shared subgraph row, the limits endpoint's shared path for `sec_historical`, resource-exposure gating, and tools/execute operation-type agreement.
