### PR TITLE
Report enforced storage limits in admin graph endpoints

### DIFF
--- a/robosystems/config/billing/core.py
+++ b/robosystems/config/billing/core.py
@@ -187,9 +187,14 @@ class BillingConfig:
     plan_display = plan_details.get("name", plan_tier.title())
     display_name = f"{repo_display} - {plan_display}"
 
-    # Return in a consistent format with subscription plans
+    # Return in a consistent format with subscription plans. `name` is the
+    # canonical manifest plan key, not the caller's raw string: a prefixed
+    # input like 'sec-advanced' is accepted for lookup, but persisting it
+    # verbatim broke every downstream lookup keyed on the plan (rate limits
+    # returned {}, which reads as "no access", and credit/price config
+    # zeroed out).
     return {
-      "name": plan_name,
+      "name": plan_tier,
       "display_name": display_name,
       "price_cents": plan_details["price_cents"],
       "monthly_credits": plan_details["monthly_credits"],

--- a/robosystems/middleware/rate_limits/repository_rate_limits.py
+++ b/robosystems/middleware/rate_limits/repository_rate_limits.py
@@ -67,8 +67,13 @@ class SharedRepositoryRateLimits:
 
   @classmethod
   def is_endpoint_allowed(cls, repository: str, endpoint: str) -> bool:
-    """Check if an endpoint is allowed for a shared repository."""
-    return _is_endpoint_allowed(endpoint)
+    """Check if an endpoint is allowed for a shared repository.
+
+    The repository must be forwarded: dropping it skipped every per-repo
+    allowed/blocked list and always ran the cross-manifest fallback —
+    invisible with one registered manifest, wrong the moment there are two.
+    """
+    return _is_endpoint_allowed(endpoint, repo_id=repository)
 
 
 class DualLayerRateLimiter:

--- a/robosystems/routers/admin/graphs.py
+++ b/robosystems/routers/admin/graphs.py
@@ -142,7 +142,9 @@ async def list_graphs(
           storage_gb=float(latest_usage.storage_gb)
           if latest_usage and latest_usage.storage_gb
           else None,
-          storage_limit_gb=tier_config.get("storage_limit_gb"),
+          storage_limit_gb=GraphTierConfig.get_instance_storage_limit_gb(
+            graph.graph_tier
+          ),
           subgraph_count=subgraph_count or 0,
           subgraph_limit=tier_config.get("max_subgraphs"),
           created_at=graph.created_at,
@@ -221,7 +223,7 @@ async def get_graph(request: Request, graph_id: str):
       storage_gb=float(latest_usage.storage_gb)
       if latest_usage and latest_usage.storage_gb
       else None,
-      storage_limit_gb=tier_config.get("storage_limit_gb"),
+      storage_limit_gb=GraphTierConfig.get_instance_storage_limit_gb(graph.graph_tier),
       subgraph_count=subgraph_count or 0,
       subgraph_limit=tier_config.get("max_subgraphs"),
       created_at=graph.created_at,
@@ -341,14 +343,17 @@ async def get_graph_storage(request: Request, graph_id: str):
       else 0.0
     )
 
+    # Default to the tier limit ingestion actually enforces
+    # (instance_storage_limit_gb: 20/50/100). This used to read a
+    # storage_limit_gb key that exists in no billing plan, so every graph
+    # reported a fabricated 500 GB limit — and the override read a column
+    # name that does not exist (storage_limit_override_gb), turning this
+    # endpoint into a 500 for any graph with a credit pool.
     credits = GraphCredits.get_by_graph_id(graph_id, session)
-    from ...config.billing import BillingConfig
-
-    tier_config = BillingConfig.get_subscription_plan(graph.graph_tier)
     storage_limit = (
-      float(credits.storage_limit_override_gb)
-      if credits and credits.storage_limit_override_gb
-      else float(tier_config.get("storage_limit_gb", 500))
+      float(credits.storage_override_gb)
+      if credits and credits.storage_override_gb
+      else GraphTierConfig.get_instance_storage_limit_gb(graph.graph_tier)
     )
 
     usage_percentage = (

--- a/robosystems/routers/graphs/subscriptions.py
+++ b/robosystems/routers/graphs/subscriptions.py
@@ -225,12 +225,15 @@ async def create_repository_subscription(
         or "Valid payment method required to subscribe to repositories.",
       )
 
-    # Create subscription in "provisioning" state
+    # Create subscription in "provisioning" state. plan_name is the canonical
+    # plan key from config, not the request's raw string — everything keyed on
+    # the plan (rate limits, credits, price lookups) expects the canonical form.
+    plan_name = plan_config["name"]
     subscription = BillingSubscription.create_subscription(
       org_id=org_id,
       resource_type="repository",
       resource_id=parent_repo_id,
-      plan_name=request.plan_name,
+      plan_name=plan_name,
       base_price_cents=plan_config["price_cents"],
       session=db,
       billing_interval="monthly",
@@ -241,13 +244,13 @@ async def create_repository_subscription(
       event_type=BillingEventType.SUBSCRIPTION_CREATED,
       org_id=org_id,
       subscription_id=subscription.id,
-      description=f"Created {request.plan_name} subscription for {graph_id} repository",
+      description=f"Created {plan_name} subscription for {graph_id} repository",
       actor_type="user",
       actor_user_id=current_user.id,
       event_data={
         "resource_type": "repository",
-        "resource_id": graph_id,
-        "plan_name": request.plan_name,
+        "resource_id": parent_repo_id,
+        "plan_name": plan_name,
         "base_price_cents": plan_config["price_cents"],
       },
     )
@@ -262,10 +265,13 @@ async def create_repository_subscription(
         from ...operations.providers.payment_provider import get_payment_provider
 
         provider = get_payment_provider("stripe")
+        # Stripe products/prices are keyed on the parent repository and the
+        # canonical plan name; a subgraph URL or raw plan string here misses
+        # the product and errors out of the billing path.
         stripe_price_id = provider.get_or_create_price(
-          plan_name=request.plan_name,
+          plan_name=plan_name,
           resource_type="repository",
-          repository_id=graph_id,
+          repository_id=parent_repo_id,
         )
 
         stripe_subscription_id = provider.create_subscription(
@@ -275,7 +281,7 @@ async def create_repository_subscription(
             "subscription_id": str(subscription.id),
             "user_id": current_user.id,
             "resource_type": "repository",
-            "resource_id": graph_id,
+            "resource_id": parent_repo_id,
           },
         )
 
@@ -299,7 +305,7 @@ async def create_repository_subscription(
           extra={
             "user_id": current_user.id,
             "subscription_id": subscription.id,
-            "plan_name": request.plan_name,
+            "plan_name": plan_name,
           },
           exc_info=True,
         )
@@ -328,18 +334,20 @@ async def create_repository_subscription(
     )
 
     try:
+      # Provisioning is keyed on the parent repository (RepositoryType,
+      # UserRepository rows); a subgraph URL here would fail the enum lookup.
       result = await run_user_repository_provisioning(
         operation_id=None,  # No SSE tracking for sync API calls
         subscription_id=subscription_id,
         user_id=user_id,
-        repository_name=graph_id,
+        repository_name=parent_repo_id,
       )
       logger.info(
-        f"Repository provisioning completed for user {user_id} to {graph_id}",
+        f"Repository provisioning completed for user {user_id} to {parent_repo_id}",
         extra={
           "user_id": user_id,
-          "repository": graph_id,
-          "plan_name": request.plan_name,
+          "repository": parent_repo_id,
+          "plan_name": plan_name,
           "subscription_id": subscription_id,
           "credits_allocated": result.get("credits_allocated", 0),
         },
@@ -484,21 +492,26 @@ async def _change_repository_plan(
   old_plan = subscription.plan_name
   is_upgrade = new_price_cents > subscription.base_price_cents
 
-  # Update DB first — if this fails, Stripe stays consistent
-  subscription.update_plan(new_plan_tier, new_price_cents, db)
-
-  # Update UserRepository access (credits, rate limits)
-  user_repo = UserRepository.get_by_user_and_repository(current_user.id, graph_id, db)
+  # Fetch the access record BEFORE any write. It is keyed on the parent
+  # repository, and looking it up after update_plan committed left the
+  # subscription mutated with credits and rate limits untouched whenever the
+  # record was missing — the partial write this order exists to prevent.
+  user_repo = UserRepository.get_by_user_and_repository(
+    current_user.id, parent_repo_id, db
+  )
   if not user_repo:
     logger.error(
-      f"No UserRepository record for user {current_user.id} on {graph_id} "
-      f"during plan change — credits and rate limits were NOT updated",
-      extra={"user_id": current_user.id, "repository_id": graph_id},
+      f"No UserRepository record for user {current_user.id} on {parent_repo_id} "
+      f"during plan change — no changes were made",
+      extra={"user_id": current_user.id, "repository_id": parent_repo_id},
     )
     raise HTTPException(
       status_code=500,
       detail="Repository access record not found. Please contact support.",
     )
+
+  # Update DB first — if this fails, Stripe stays consistent
+  subscription.update_plan(new_plan_tier, new_price_cents, db)
 
   user_repo.upgrade_tier(
     new_plan=new_plan_tier,
@@ -507,14 +520,15 @@ async def _change_repository_plan(
     new_credits=new_credits,
   )
 
-  # Update Stripe subscription if linked
+  # Update Stripe subscription if linked. Products/prices are keyed on the
+  # parent repository and the canonical plan name.
   stripe_sub_id = subscription.stripe_subscription_id
   if stripe_sub_id:
     provider = get_payment_provider("stripe")
     new_stripe_price_id = provider.get_or_create_price(
-      plan_name=new_plan_name,
+      plan_name=new_plan_tier,
       resource_type="repository",
-      repository_id=graph_id,
+      repository_id=parent_repo_id,
     )
     provider.change_subscription_price(
       subscription_id=stripe_sub_id,
@@ -538,7 +552,7 @@ async def _change_repository_plan(
     actor_user_id=current_user.id,
     event_data={
       "resource_type": "repository",
-      "resource_id": graph_id,
+      "resource_id": parent_repo_id,
       "old_plan": old_plan,
       "new_plan": new_plan_tier,
       "old_price_cents": subscription.base_price_cents,

--- a/tests/config/billing/test_repositories.py
+++ b/tests/config/billing/test_repositories.py
@@ -94,3 +94,21 @@ def test_get_all_repository_pricing_contains_repos():
   assert pricing["plans"]["starter"]["price_display"] == "$29/month"
   assert pricing["repositories"]["sec"]["status"] == "available"
   assert pricing["billing_model"].startswith("No credit consumption")
+
+
+def test_get_repository_plan_returns_the_canonical_plan_key():
+  """The returned name is the manifest plan key, never the caller's raw string.
+
+  'sec-advanced' is accepted for lookup, but persisting it verbatim broke
+  every downstream lookup keyed on the plan: rate limits returned {} (read as
+  "no access"), and credit/price config zeroed out.
+  """
+  from robosystems.config import BillingConfig
+
+  prefixed = BillingConfig.get_repository_plan("sec", "sec-advanced")
+  plain = BillingConfig.get_repository_plan("sec", "advanced")
+
+  assert prefixed is not None and plain is not None
+  assert prefixed["name"] == "advanced"
+  assert plain["name"] == "advanced"
+  assert prefixed["price_cents"] == plain["price_cents"]

--- a/tests/middleware/rate_limits/test_repository_rate_limits.py
+++ b/tests/middleware/rate_limits/test_repository_rate_limits.py
@@ -1,6 +1,6 @@
 """Repository-specific rate limiting tests."""
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -131,3 +131,29 @@ class TestDualLayerRateLimiter:
     result = await limiter.get_usage_stats("u1", "sec", "sec-starter")
     if result:  # Only check if sec-starter has limits configured
       assert "usage" in result or result == {}
+
+
+class TestPlanKeying:
+  """The manifest keys rate limits by canonical plan name only."""
+
+  def test_canonical_plan_returns_real_limits(self):
+    result = SharedRepositoryRateLimits.get_limits("sec", "starter")
+    assert result, "canonical plan must resolve to non-empty limits"
+    assert "queries_per_minute" in result
+
+  def test_prefixed_plan_returns_empty(self):
+    """Prefixed forms are not valid manifest keys. Normalization is the
+    billing config's job (get_repository_plan returns the canonical key);
+    anything persisting a prefixed plan string bricks the user's access."""
+    assert SharedRepositoryRateLimits.get_limits("sec", "sec-starter") == {}
+
+  def test_is_endpoint_allowed_forwards_the_repository(self):
+    """Dropping the repository argument skipped every per-repo endpoint list
+    and always ran the cross-manifest fallback."""
+    with patch(
+      "robosystems.middleware.rate_limits.repository_rate_limits._is_endpoint_allowed",
+      return_value=True,
+    ) as mock_check:
+      SharedRepositoryRateLimits.is_endpoint_allowed("sec", "query")
+
+    mock_check.assert_called_once_with("query", repo_id="sec")

--- a/tests/routers/admin/test_graphs.py
+++ b/tests/routers/admin/test_graphs.py
@@ -224,3 +224,83 @@ class TestDeprovisionGraph:
       assert response.status_code == 200
       data = response.json()
       assert data["backup_created"] is False
+
+
+class TestGraphStorageReporting:
+  """Admin storage numbers must be the limits ingestion actually enforces.
+
+  The list/detail endpoints read a storage_limit_gb key that exists in no
+  tier or billing config (reporting null / a fabricated 500 GB), and the
+  storage detail read an override column that does not exist — an
+  AttributeError 500 for any graph with a credit pool.
+  """
+
+  def _add_credit_pool(self, db_session, test_graph, test_user, override=None):
+    from datetime import UTC, datetime
+    from decimal import Decimal
+
+    from robosystems.models.core import GraphCredits
+
+    credits = GraphCredits(
+      id=f"gc_{test_graph.graph_id}",
+      graph_id=test_graph.graph_id,
+      user_id=test_user.id,
+      billing_admin_id=test_user.id,
+      current_balance=Decimal("1000"),
+      monthly_allocation=Decimal("1000"),
+      last_allocation_date=datetime.now(UTC),
+      storage_override_gb=override,
+    )
+    db_session.add(credits)
+    db_session.commit()
+
+  def test_storage_detail_reports_the_enforced_tier_limit(
+    self, client, test_graph, mock_admin_auth
+  ):
+    response = client.get(
+      f"/admin/v1/graphs/{test_graph.graph_id}/storage",
+      headers={"Authorization": "Bearer test-admin-key"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["storage_limit_gb"] == 20.0
+
+  def test_graph_with_credit_pool_does_not_500(
+    self, client, db_session, test_graph, test_user, mock_admin_auth
+  ):
+    self._add_credit_pool(db_session, test_graph, test_user)
+
+    response = client.get(
+      f"/admin/v1/graphs/{test_graph.graph_id}/storage",
+      headers={"Authorization": "Bearer test-admin-key"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["storage_limit_gb"] == 20.0
+
+  def test_admin_storage_override_wins(
+    self, client, db_session, test_graph, test_user, mock_admin_auth
+  ):
+    from decimal import Decimal
+
+    self._add_credit_pool(db_session, test_graph, test_user, override=Decimal("75"))
+
+    response = client.get(
+      f"/admin/v1/graphs/{test_graph.graph_id}/storage",
+      headers={"Authorization": "Bearer test-admin-key"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["storage_limit_gb"] == 75.0
+
+  def test_graph_list_reports_the_enforced_tier_limit(
+    self, client, test_graph, mock_admin_auth
+  ):
+    response = client.get(
+      "/admin/v1/graphs",
+      headers={"Authorization": "Bearer test-admin-key"},
+    )
+
+    assert response.status_code == 200
+    row = next(r for r in response.json() if r["graph_id"] == test_graph.graph_id)
+    assert row["storage_limit_gb"] == 20.0

--- a/tests/routers/graphs/test_subscriptions_router.py
+++ b/tests/routers/graphs/test_subscriptions_router.py
@@ -401,3 +401,110 @@ class TestCancelRepositorySubscription:
         )
     assert exc.value.status_code == 403
     assert "owner" in exc.value.detail.lower()
+
+
+class TestChangeRepositoryPlan:
+  """Plan changes must persist the canonical plan key and never write partially."""
+
+  def _active_subscription(self) -> Mock:
+    sub = Mock(spec=BillingSubscription)
+    sub.id = "sub_123"
+    sub.resource_type = "repository"
+    sub.resource_id = "sec"
+    sub.plan_name = "starter"
+    sub.billing_interval = "monthly"
+    sub.status = "active"
+    sub.base_price_cents = 2900
+    sub.current_period_start = datetime(2026, 1, 1, tzinfo=UTC)
+    sub.current_period_end = datetime(2026, 2, 1, tzinfo=UTC)
+    sub.started_at = datetime(2026, 1, 1, tzinfo=UTC)
+    sub.canceled_at = None
+    sub.ends_at = None
+    sub.stripe_subscription_id = None
+    sub.created_at = datetime(2026, 1, 1, tzinfo=UTC)
+    return sub
+
+  def _owner_org(self):
+    from robosystems.models.core import OrgRole
+
+    org = Mock()
+    org.org_id = "org_1"
+    org.role = OrgRole.OWNER
+    return org
+
+  @pytest.mark.asyncio
+  @patch(f"{MODULE}.BillingAuditLog")
+  @patch(f"{MODULE}.UserRepository.get_by_user_and_repository")
+  @patch(f"{MODULE}.BillingSubscription.get_by_resource_and_user")
+  async def test_prefixed_plan_name_persists_the_canonical_form(
+    self, mock_get_sub, mock_get_repo, _mock_audit
+  ):
+    """new_plan_name='sec-advanced' must persist 'advanced' everywhere.
+
+    The raw string used to be written to both records; every lookup keyed on
+    the plan (rate limits, credits, price) then returned empty, which reads
+    as "no access" — a 429 on every query until the row was hand-fixed.
+    """
+    from robosystems.models.api.billing.subscription import (
+      UpgradeSubscriptionRequest,
+    )
+    from robosystems.routers.graphs.subscriptions import _change_repository_plan
+
+    db = MagicMock()
+    user = MagicMock()
+    user.id = "user_123"
+    sub = self._active_subscription()
+    mock_get_sub.return_value = sub
+    user_repo = Mock()
+    mock_get_repo.return_value = user_repo
+
+    with patch(
+      "robosystems.models.core.OrgUser.get_user_orgs",
+      return_value=[self._owner_org()],
+    ):
+      await _change_repository_plan(
+        "sec",
+        UpgradeSubscriptionRequest(new_plan_name="sec-advanced"),
+        user,
+        db,
+      )
+
+    sub.update_plan.assert_called_once_with("advanced", 9900, db)
+    assert mock_get_repo.call_args.args[1] == "sec"
+    assert user_repo.upgrade_tier.call_args.kwargs["new_plan"] == "advanced"
+
+  @pytest.mark.asyncio
+  @patch(f"{MODULE}.BillingAuditLog")
+  @patch(f"{MODULE}.UserRepository.get_by_user_and_repository")
+  @patch(f"{MODULE}.BillingSubscription.get_by_resource_and_user")
+  async def test_missing_access_record_makes_no_changes(
+    self, mock_get_sub, mock_get_repo, _mock_audit
+  ):
+    """The access record is checked before any write: a missing record must
+    error out with the subscription untouched, not after mutating it."""
+    from robosystems.models.api.billing.subscription import (
+      UpgradeSubscriptionRequest,
+    )
+    from robosystems.routers.graphs.subscriptions import _change_repository_plan
+
+    db = MagicMock()
+    user = MagicMock()
+    user.id = "user_123"
+    sub = self._active_subscription()
+    mock_get_sub.return_value = sub
+    mock_get_repo.return_value = None
+
+    with patch(
+      "robosystems.models.core.OrgUser.get_user_orgs",
+      return_value=[self._owner_org()],
+    ):
+      with pytest.raises(HTTPException) as exc:
+        await _change_repository_plan(
+          "sec",
+          UpgradeSubscriptionRequest(new_plan_name="advanced"),
+          user,
+          db,
+        )
+
+    assert exc.value.status_code == 500
+    sub.update_plan.assert_not_called()


### PR DESCRIPTION
Admin storage reporting disagreed with what ingestion actually enforces, three ways in one file (`routers/admin/graphs.py`):

- **List and detail endpoints** read `tier_config.get("storage_limit_gb")` — a key that exists in no tier config — so `storage_limit_gb` was always `null`.
- **The storage detail endpoint** fell back to `BillingConfig.get_subscription_plan(...).get("storage_limit_gb", 500)` — billing plans carry no such key either — so every graph reported a fabricated **500 GB** limit, and `usage_percentage` / `within_limit` / `estimated_days_to_limit` were computed against it.
- **The admin override read a column that does not exist** (`storage_limit_override_gb`; the column is `storage_override_gb`), so `GET /admin/v1/graphs/{id}/storage` was an `AttributeError` 500 for any graph with a credit pool.

All three now resolve through `GraphTierConfig.get_instance_storage_limit_gb` — the same 20/50/100 GB the ingestion gates enforce — with the (correctly-named) admin override taking precedence when set.

## Testing

Four new endpoint tests: the detail and list endpoints report the enforced tier limit, a graph **with** a credit pool returns 200 (the previous 500), and a set `storage_override_gb` wins. Full suite green apart from the two pre-existing `test_incremental_materialize` failures that reproduce on `main`.
