### PR TITLE
Align backup, agent-limit, and offering claims with what runs

### DIFF
--- a/robosystems/config/deprovisioning.py
+++ b/robosystems/config/deprovisioning.py
@@ -10,11 +10,18 @@ class DeprovisioningConfig:
   retention_days: int = 7
   require_final_backup: bool = True
   backup_delay_hours: int = 24
+  # 90 days for every tier: the S3 lifecycle rule (cloudformation/s3.yaml,
+  # ExpireGraphBackups: 90) deletes the object then regardless of what is
+  # promised here, and the final backup creates no GraphBackup row, so the
+  # tier-aware cleanup job cannot extend it either. This table once promised
+  # 180/365 days to Large/XLarge — hosting the infrastructure could not
+  # deliver. Extending it for real means exempting final backups from the
+  # lifecycle rule and tracking them in GraphBackup.
   backup_hosting_days: dict[str, int] = field(
     default_factory=lambda: {
       "ladybug-standard": 90,
-      "ladybug-large": 180,
-      "ladybug-xlarge": 365,
+      "ladybug-large": 90,
+      "ladybug-xlarge": 90,
     }
   )
 

--- a/robosystems/config/graph_tier.py
+++ b/robosystems/config/graph_tier.py
@@ -505,9 +505,13 @@ class GraphTierConfig:
       elif "MEDIUM" in instance_type:
         features.append("Dedicated medium instance")
 
-      max_memory_mb = instance.get("max_memory_mb", 0)
-      if max_memory_mb and max_memory_mb > 0:
-        features.append(f"{max_memory_mb / 1024:.0f}GB RAM")
+      # Advertise the instance's physical RAM, matching /v1/offering's
+      # infrastructure line. max_memory_mb is the LadybugDB budget after OS
+      # overhead — reporting it here made the same tier claim "3GB RAM" in
+      # one response and "4 GB RAM" in another.
+      instance_ram_gb = instance.get("instance_ram_gb", 0)
+      if instance_ram_gb and instance_ram_gb > 0:
+        features.append(f"{instance_ram_gb:g} GB RAM")
 
     # Add rate limit multiplier if not standard. Derived from the enforced
     # limits — graph.yml no longer carries an api_rate_multiplier key.

--- a/robosystems/models/api/graphs/backups.py
+++ b/robosystems/models/api/graphs/backups.py
@@ -18,7 +18,16 @@ class BackupCreateRequest(BaseModel):
     description="Backup type - only 'full' is supported",
     pattern="^full$",  # Only allow full backups
   )
-  retention_days: int = Field(30, ge=1, le=2555, description="Retention period in days")
+  retention_days: int = Field(
+    30,
+    ge=1,
+    le=90,
+    description=(
+      "Retention period in days, further capped to the graph tier's maximum "
+      "(7/30/90). 90 is the hard ceiling: the storage lifecycle expires "
+      "backup objects then regardless of the requested value."
+    ),
+  )
   compression: bool = Field(
     True, description="Enable compression (always enabled for optimal storage)"
   )

--- a/robosystems/models/api/graphs/tier.py
+++ b/robosystems/models/api/graphs/tier.py
@@ -41,7 +41,13 @@ class GraphTierInstance(BaseModel):
   """Instance specifications for a tier."""
 
   type: str = Field(..., description="Instance type identifier")
-  memory_mb: int = Field(..., description="Memory allocated to your graph in megabytes")
+  memory_mb: int = Field(
+    ...,
+    description=(
+      "LadybugDB memory budget for the whole instance in megabytes (below "
+      "physical RAM after OS overhead; not a per-graph allocation)"
+    ),
+  )
   is_multitenant: bool = Field(
     ..., description="Whether this tier shares infrastructure with other graphs"
   )

--- a/robosystems/routers/graphs/operations.py
+++ b/robosystems/routers/graphs/operations.py
@@ -590,13 +590,21 @@ async def create_backup_op(
       detail="Only 'full_dump' backup format is currently supported",
     )
 
-  # Cap retention to tier max
+  # Cap retention to the tier's maximum. Unconditional: a missing graph row
+  # or tier falls back to the smallest tier's cap rather than skipping the
+  # clamp — an uncapped value would be accepted here and then destroyed by
+  # the 90-day S3 lifecycle rule, leaving a COMPLETED record pointing at a
+  # deleted object.
   graph_record = Graph.get_by_id(graph_id, db)
-  if graph_record and graph_record.graph_tier:
-    backup_limits = GraphTierConfig.get_backup_limits(graph_record.graph_tier)
-    tier_max = backup_limits.get("backup_retention_days", 90)
-    if body.retention_days > tier_max:
-      body.retention_days = tier_max
+  backup_tier = (
+    str(graph_record.graph_tier)
+    if graph_record and graph_record.graph_tier
+    else "ladybug-standard"
+  )
+  tier_max = GraphTierConfig.get_backup_limits(backup_tier).get(
+    "backup_retention_days", 7
+  )
+  effective_retention_days = min(body.retention_days, tier_max)
 
   # Enqueue Dagster backup job
   run_config = build_graph_job_config(
@@ -605,7 +613,7 @@ async def create_backup_op(
     user_id=user_id,
     backup_type="full",
     backup_format=body.backup_format,
-    retention_days=body.retention_days,
+    retention_days=effective_retention_days,
     compression=True,
     encryption=body.encryption,
   )
@@ -623,7 +631,15 @@ async def create_backup_op(
     operation_id=operation_id,
     partial_result={
       "status": "accepted",
-      "message": "Backup creation started",
+      "message": (
+        "Backup creation started"
+        if effective_retention_days == body.retention_days
+        else (
+          f"Backup creation started (retention capped to "
+          f"{effective_retention_days} days, the {backup_tier} maximum)"
+        )
+      ),
+      "retention_days": effective_retention_days,
       "monitoring": {
         "sse_endpoint": f"/v1/operations/{operation_id}/stream",
       },

--- a/robosystems/routers/graphs/operator/execute.py
+++ b/robosystems/routers/graphs/operator/execute.py
@@ -66,6 +66,24 @@ from .strategies import (
 router = APIRouter()
 
 
+async def _enforce_shared_repository_agent_limits(
+  graph_id: str, current_user: User, db: Session
+) -> None:
+  """Apply shared-repository access + per-plan agent volume limits.
+
+  Repository plans advertise agent_calls_per_* limits; until this hook,
+  nothing ever checked them (query/mcp/search had their equivalents, the
+  operator surface did not), so the advertised numbers were unenforced.
+  """
+  from robosystems.routers.graphs.query.execute import (
+    _check_shared_repository_limits,
+  )
+
+  await _check_shared_repository_limits(
+    graph_id, current_user, db, endpoint="agent", operation="agent"
+  )
+
+
 def _check_operator_post_enabled():
   """Check if operator POST endpoints are enabled."""
   if not env.OPERATOR_POST_ENABLED:
@@ -156,6 +174,7 @@ async def auto_operator(
   _rate_limit: None = Depends(subscription_aware_rate_limit_dependency),
 ) -> OperatorResponse | JSONResponse | EventSourceResponse:
   _check_operator_post_enabled()
+  await _enforce_shared_repository_agent_limits(graph_id, current_user, db)
 
   try:
     # Detect client capabilities
@@ -318,6 +337,7 @@ async def specific_operator(
   _rate_limit: None = Depends(subscription_aware_rate_limit_dependency),
 ) -> OperatorResponse | JSONResponse | EventSourceResponse:
   _check_operator_post_enabled()
+  await _enforce_shared_repository_agent_limits(graph_id, current_user, db)
 
   try:
     # Get operator to access execution profile (operators are lightweight, no graph/user needed)
@@ -427,6 +447,7 @@ async def batch_operator(
   _rate_limit: None = Depends(subscription_aware_rate_limit_dependency),
 ) -> BatchOperatorResponse:
   _check_operator_post_enabled()
+  await _enforce_shared_repository_agent_limits(graph_id, current_user, db)
 
   import time
 

--- a/robosystems/routers/graphs/query/execute.py
+++ b/robosystems/routers/graphs/query/execute.py
@@ -710,7 +710,11 @@ async def execute_cypher_query(
 
 
 async def _check_shared_repository_limits(
-  graph_id: str, user: User, session: Session, endpoint: str = "query"
+  graph_id: str,
+  user: User,
+  session: Session,
+  endpoint: str = "query",
+  operation: str = "query",
 ) -> None:
   from robosystems.config import env
   from robosystems.config.shared_repositories import (
@@ -764,7 +768,7 @@ async def _check_shared_repository_limits(
     limit_check = await limiter.check_limits(
       user_id=user.id,
       graph_id=graph_id,
-      operation="query",  # Direct queries
+      operation=operation,
       endpoint=endpoint,
       repository_plan=repo_plan,
     )

--- a/robosystems/routers/offering.py
+++ b/robosystems/routers/offering.py
@@ -222,12 +222,15 @@ async def get_service_offerings(
         ],
       },
       repository_subscriptions={
-        "description": "Organization-level shared repository access subscriptions",
-        "pricing_model": "per_organization",
+        # Per USER, not per organization: access, credits, and volume limits
+        # all key on the subscribing user (UserRepository / UserRepositoryCredits).
+        # This copy once claimed org-level sharing the implementation never had.
+        "description": "Per-user shared repository access subscriptions",
+        "pricing_model": "per_user",
         "repositories": repositories,
         "notes": [
-          "Repository subscriptions are purchased at the organization level",
-          "All organization members share access to subscribed repositories",
+          "Repository subscriptions are purchased per user",
+          "Each subscribing user gets their own credits and rate limits",
           "Repository subscriptions are separate from graph subscriptions",
           "Can be combined with any graph infrastructure tier",
           "Repository queries do not consume AI credits",

--- a/tests/config/test_graph_tier_config.py
+++ b/tests/config/test_graph_tier_config.py
@@ -305,3 +305,16 @@ def test_subgraph_memory_is_configured_separately_from_parent(mock_graph_config)
   instance = GraphTierConfig.get_tier_config("ladybug-standard")["instance"]
   assert instance["memory_per_db_mb"] == 512
   assert instance["memory_per_subgraph_mb"] == 256
+
+
+def test_backup_hosting_days_never_exceed_the_s3_lifecycle():
+  """The S3 lifecycle rule deletes backup objects at 90 days, and the final
+  deprovisioning backup creates no GraphBackup row, so no tier can promise
+  hosting beyond 90 days. This table once promised 180/365 to Large/XLarge —
+  retention the infrastructure silently could not deliver."""
+  from robosystems.config.deprovisioning import get_deprovisioning_config
+
+  config = get_deprovisioning_config()
+  for tier, days in config.backup_hosting_days.items():
+    assert days <= 90, f"{tier} promises {days}-day backup hosting; S3 deletes at 90"
+  assert config.get_backup_hosting_days("unknown-tier") <= 90

--- a/tests/models/api/test_backup_models.py
+++ b/tests/models/api/test_backup_models.py
@@ -46,12 +46,15 @@ class TestBackupCreateRequest:
       BackupCreateRequest(retention_days=0)
 
   def test_retention_days_maximum(self):
-    model = BackupCreateRequest(retention_days=2555)
-    assert model.retention_days == 2555
+    """90 is the ceiling: the S3 lifecycle expires backup objects at 90 days,
+    so accepting more (this once allowed 2555) produced COMPLETED backup
+    records pointing at objects the lifecycle had already deleted."""
+    model = BackupCreateRequest(retention_days=90)
+    assert model.retention_days == 90
 
   def test_retention_days_above_maximum(self):
     with pytest.raises(ValidationError):
-      BackupCreateRequest(retention_days=2556)
+      BackupCreateRequest(retention_days=91)
 
   def test_compression_must_be_true(self):
     with pytest.raises(ValidationError) as exc_info:

--- a/tests/routers/graphs/test_operator_router.py
+++ b/tests/routers/graphs/test_operator_router.py
@@ -454,3 +454,33 @@ class TestOperatorEndpoints:
     components = openapi["components"]["schemas"]
     assert "OperatorRequest" in components
     assert "OperatorResponse" in components
+
+
+class TestOperatorSharedRepositoryLimits:
+  """The operator surface must enforce the manifest's agent_calls_* limits.
+
+  Repository plans have always advertised agent volume limits, but only
+  query/mcp/search called the volume limiter — nothing ever passed
+  operation="agent", so the advertised numbers were unenforced.
+  """
+
+  @pytest.mark.asyncio
+  async def test_agent_limits_delegate_with_agent_operation(self):
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from robosystems.routers.graphs.operator.execute import (
+      _enforce_shared_repository_agent_limits,
+    )
+
+    user = MagicMock()
+    db = MagicMock()
+
+    with patch(
+      "robosystems.routers.graphs.query.execute._check_shared_repository_limits",
+      new=AsyncMock(),
+    ) as mock_check:
+      await _enforce_shared_repository_agent_limits("sec", user, db)
+
+    mock_check.assert_awaited_once_with(
+      "sec", user, db, endpoint="agent", operation="agent"
+    )

--- a/tests/routers/test_offering.py
+++ b/tests/routers/test_offering.py
@@ -124,3 +124,13 @@ class TestOfferingEndpoint:
       assert tier["api_rate_multiplier"] == GraphTierConfig.get_api_rate_multiplier(
         tier["name"]
       ), f"{tier['name']} advertises a multiplier the limiter does not enforce"
+
+  async def test_repository_pricing_model_is_per_user(self, async_client: AsyncClient):
+    """Access, credits, and volume limits all key on the subscribing user
+    (UserRepository / UserRepositoryCredits); this copy once claimed
+    org-level sharing the implementation never had."""
+    response = await async_client.get("/v1/offering")
+    assert response.status_code == 200
+
+    repos = response.json()["repository_subscriptions"]
+    assert repos["pricing_model"] == "per_user"


### PR DESCRIPTION
Four claims the platform made and did not keep, each aligned to what actually runs. Based on `chore/stale-claims-cleanup` (#952); retarget-safe once that merges.

## Deprovisioning backup hosting: 90 days for everyone

The config promised 90/180/365-day post-cancellation backup hosting by tier. The S3 lifecycle rule (`ExpireGraphBackups: 90`) deletes the object at 90 days regardless, and the final deprovisioning backup creates no `GraphBackup` row, so the tier-aware cleanup job cannot see it to extend anything. Large and XLarge's extended hosting **physically never happened**. All tiers now promise the 90 days the infrastructure delivers, pinned by a test against the lifecycle ceiling. (Delivering more for real means exempting final backups from the lifecycle rule and tracking them — noted in the config for whoever builds it.)

## Backup retention: capped at 90, clamped visibly

`retention_days` accepted up to **2555 days** while the same lifecycle rule destroyed the object at 90 — producing `COMPLETED` backup records pointing at deleted objects, with restore failing opaquely. Three changes:

- The request field caps at `le=90`, with a description that says why.
- The per-tier clamp (7/30/90) now applies **unconditionally** — it previously skipped entirely when the graph row or tier was missing, which is exactly when clamping matters most.
- The clamp is **visible**: the operation envelope reports the effective `retention_days` and the message says when it was capped. The UI defaults the field to 90; a Standard customer was silently given 7 with no indication in the response or the backup list.

## `agent_calls_*` limits: enforced for the first time

Repository plans have always advertised per-plan agent volume limits (`agent_calls_per_hour` etc. in `/v1/offering`), but nothing ever passed `operation="agent"` to the volume limiter — query/mcp/search each had their enforcement hook, the operator surface had none. All three operator entry points (auto, specific, batch) now run shared-repository access + agent volume limits through the same helper the other three surfaces use.

## Offering copy: per-user repositories, one RAM number

- `/v1/offering` described repository subscriptions as `per_organization` ("all organization members share access"). Access, credits, and volume limits all key on the subscribing user (`UserRepository` / `UserRepositoryCredits`) — the copy now says `per_user`.
- The same tier claimed "4 GB RAM" in `/offering` and "3GB RAM" in `/v1/graphs/tiers` — the latter reported the LadybugDB memory budget, not the machine. Both now advertise instance RAM, and the `memory_mb` field description stops calling the instance-wide budget "memory allocated to your graph".

## Testing

Full suite: **11,426 passed**; only failures are the two pre-existing `test_incremental_materialize` cases that reproduce on `main`. New tests pin the hosting-days ceiling, the 90-day request cap (updating the test that pinned 2555), the agent-operation delegation, and the per-user pricing model.
