### PR TITLE
Storage enforcement: fail closed, gate the sensor path, cap volume growth by tier

### DIFF
--- a/bin/lambda/graph_volume_monitor.py
+++ b/bin/lambda/graph_volume_monitor.py
@@ -42,6 +42,22 @@ EXPANSION_FACTOR = float(os.environ.get("EXPANSION_FACTOR", "1.5"))  # 50% incre
 # Standard starting size this yields 20 -> 40GB, a doubling.
 MIN_EXPANSION_GB = int(os.environ.get("MIN_EXPANSION_GB", "20"))
 MAX_VOLUME_SIZE_GB = int(os.environ.get("MAX_VOLUME_SIZE_GB", "16384"))  # EBS limit
+
+# Product storage caps per tier in GB. Must match graph.yml's
+# instance_storage_limit_gb (this Lambda is standalone and cannot import the
+# app config; a repo test pins the two against each other). Tiers not listed
+# (ladybug-shared, replicas) have no product cap and grow to the EBS limit.
+TIER_STORAGE_LIMITS_GB = {
+  "ladybug-standard": 20,
+  "ladybug-large": 50,
+  "ladybug-xlarge": 100,
+}
+# Volume ceiling = product cap x this multiplier. Above 1.0 because DuckDB
+# staging, temp files, and vector indexes legitimately live on the volume
+# beyond the graph data the product cap governs. Without any ceiling this
+# Lambda kept expanding a 20 GB-cap tenant's volume toward the EBS maximum —
+# unbounded EBS spend for data the app-side cap should have stopped.
+TIER_CEILING_MULTIPLIER = float(os.environ.get("TIER_CEILING_MULTIPLIER", "2.0"))
 GRAPH_API_PORT = os.environ.get("GRAPH_API_PORT", "8001")
 GRAPH_API_SECRET_ARN = os.environ.get("GRAPH_API_SECRET_ARN", "")
 
@@ -341,7 +357,9 @@ def check_and_expand_volume(instance: dict, expand_immediately: bool = False) ->
         return result
 
       # Calculate new size
-      new_size = calculate_new_volume_size(current_size, usage_percent)
+      new_size = calculate_new_volume_size(
+        current_size, usage_percent, tier=instance.get("tier", "unknown")
+      )
 
       if new_size > current_size:
         # Perform expansion
@@ -1018,8 +1036,14 @@ def trigger_filesystem_growth(instance: dict) -> dict:
     return {"success": False, "error": str(e)}
 
 
-def calculate_new_volume_size(current_size: int, usage_percent: float) -> int:
-  """Calculate the new volume size based on current usage"""
+def calculate_new_volume_size(
+  current_size: int, usage_percent: float, tier: str = "unknown"
+) -> int:
+  """Calculate the new volume size based on current usage.
+
+  Returns current_size unchanged when the tier's volume ceiling has been
+  reached — the caller treats no-growth as no-expansion.
+  """
 
   # Calculate size needed to get back to 60% usage
   target_usage = 0.6
@@ -1039,6 +1063,19 @@ def calculate_new_volume_size(current_size: int, usage_percent: float) -> int:
 
   # Round up to nearest 10GB for cleaner sizes
   new_size = ((new_size + 9) // 10) * 10
+
+  # Product-tier ceiling. Applied after rounding so rounding cannot step
+  # over it; never shrinks an existing volume.
+  tier_limit = TIER_STORAGE_LIMITS_GB.get(tier)
+  if tier_limit:
+    ceiling = int(tier_limit * TIER_CEILING_MULTIPLIER)
+    if current_size >= ceiling:
+      logger.error(
+        f"Volume at tier ceiling ({current_size} GB >= {ceiling} GB for "
+        f"{tier}); not expanding. Tenant is far over the product storage cap."
+      )
+      return current_size
+    new_size = min(new_size, ceiling)
 
   return new_size
 

--- a/robosystems/dagster/jobs/extensions.py
+++ b/robosystems/dagster/jobs/extensions.py
@@ -63,6 +63,48 @@ def materialize_extensions_to_graph(
   asyncio.set_event_loop(loop)
 
   try:
+    # Enforce the tier storage cap on this path too. The HTTP materialize
+    # command runs the same check, but this op is also reached directly by
+    # the staleness sensor, which otherwise rebuilds over-cap graphs on
+    # every sync — the cap only ever bound manual calls. Unknown usage
+    # (Graph API unreachable) fails the run rather than proceeding
+    # unverified; the sensor resubmits after its cursor expiry.
+    from robosystems.database import get_db_session
+    from robosystems.middleware.graph.ingestion_limits import IngestionLimitChecker
+    from robosystems.models.core.graph.graph import Graph
+
+    db_gen = get_db_session()
+    db_session = next(db_gen)
+    try:
+      graph_row = db_session.query(Graph).filter(Graph.graph_id == graph_id).first()
+      graph_tier = (
+        str(graph_row.graph_tier)
+        if graph_row and graph_row.graph_tier
+        else "ladybug-standard"
+      )
+      storage_check = loop.run_until_complete(
+        IngestionLimitChecker.check_instance_storage(db_session, graph_id, graph_tier)
+      )
+    finally:
+      try:
+        next(db_gen)
+      except StopIteration:
+        pass
+
+    if not storage_check["allowed"]:
+      context.log.error(
+        f"Storage cap blocked materialization for {graph_id}: "
+        f"{'; '.join(storage_check['errors'])}"
+      )
+      raise Failure(
+        description=f"Storage cap blocked materialization for {graph_id}",
+        metadata={
+          "graph_id": MetadataValue.text(graph_id),
+          "errors": MetadataValue.text("; ".join(storage_check["errors"])),
+          "storage_status": MetadataValue.text(storage_check["status"]),
+        },
+      )
+
     materializer = ExtensionsMaterializer()
     result = loop.run_until_complete(
       materializer.materialize(

--- a/robosystems/dagster/sensors/usage_monitor.py
+++ b/robosystems/dagster/sensors/usage_monitor.py
@@ -123,6 +123,37 @@ def graph_usage_monitor_sensor(context: SensorEvaluationContext):
 
       instance_status = storage_check["status"]
 
+      # One admin lookup serves both the snapshot row and any alert below.
+      graph_user = (
+        db.query(GraphUser)
+        .filter(
+          GraphUser.graph_id == graph.graph_id,
+          GraphUser.role == "admin",
+        )
+        .first()
+      )
+
+      # Persist the measurement as a STORAGE_SNAPSHOT row. The admin and org
+      # usage surfaces read these rows, and until this write nothing ever
+      # created one — every consumer was permanently empty. Recorded for
+      # every measured status, not just alert-worthy ones; skipped when the
+      # check returned "unknown" (nothing was measured).
+      if storage_check.get("total_storage_gb") is not None and graph_user:
+        try:
+          from robosystems.models.core.graph.graph_usage import GraphUsage
+
+          GraphUsage.record_storage_usage(
+            user_id=graph_user.user_id,
+            graph_id=graph.graph_id,
+            graph_tier=graph_tier,
+            storage_bytes=storage_check["total_storage_gb"] * (1024**3),
+            session=db,
+          )
+        except Exception as e:
+          context.log.warning(
+            f"Could not record storage snapshot for {graph.graph_id}: {e}"
+          )
+
       # Only alert for approaching or over_limit
       if instance_status not in _ALERT_STATUSES:
         continue
@@ -135,15 +166,7 @@ def graph_usage_monitor_sensor(context: SensorEvaluationContext):
         )
         continue
 
-      # Look up graph owner
-      graph_user = (
-        db.query(GraphUser)
-        .filter(
-          GraphUser.graph_id == graph.graph_id,
-          GraphUser.role == "admin",
-        )
-        .first()
-      )
+      # Owner already looked up above for the snapshot row
       if not graph_user:
         continue
 

--- a/robosystems/middleware/graph/ingestion_limits.py
+++ b/robosystems/middleware/graph/ingestion_limits.py
@@ -96,6 +96,9 @@ class IngestionLimitChecker:
 
     return {
       "allowed": len(errors) == 0,
+      # Unverifiable storage is a transient condition, not a limit violation;
+      # callers surface it as retryable (503) rather than over-limit (413).
+      "retryable": storage_check.get("retryable", False),
       "errors": errors,
       "warnings": warnings,
       "current_usage": {
@@ -147,8 +150,29 @@ class IngestionLimitChecker:
     # also replaces the previous N+1 (one Graph API call per subgraph), and
     # catches on-disk leftovers the graph registry has lost track of.
     breakdown = await cls._get_storage_breakdown(graph_id)
-    items: list[dict[str, Any]] = breakdown.get("items", []) if breakdown else []
-    total_bytes = breakdown.get("total_bytes", 0) if breakdown else None
+    if breakdown is None:
+      # Usage could not be measured. This used to fall through as 0.0 GB /
+      # healthy / allowed, which silently disabled the cap exactly when the
+      # instance was struggling. "Cannot verify" is not "empty": the write
+      # path fails closed, and `retryable` tells callers to surface it as a
+      # transient condition rather than a limit violation.
+      return {
+        "allowed": False,
+        "retryable": True,
+        "errors": [
+          f"Instance storage usage for {graph_id} could not be verified "
+          "(Graph API unavailable). Retry shortly."
+        ],
+        "total_storage_gb": None,
+        "limit_gb": limit_gb,
+        "usage_percentage": None,
+        "status": "unknown",
+        "databases": [],
+        "items": [],
+      }
+
+    items: list[dict[str, Any]] = breakdown.get("items", [])
+    total_bytes = breakdown.get("total_bytes", 0)
 
     # Roll the itemized view up per database for the summary shape, so a
     # database's graph/vector/staging bytes appear as one line.
@@ -191,6 +215,7 @@ class IngestionLimitChecker:
 
     return {
       "allowed": len(errors) == 0,
+      "retryable": False,
       "errors": errors,
       "total_storage_gb": total_storage_gb,
       "limit_gb": limit_gb,

--- a/robosystems/operations/graph/commands/materialize.py
+++ b/robosystems/operations/graph/commands/materialize.py
@@ -120,6 +120,18 @@ async def materialize_cmd(
     )
 
     if not limit_check["allowed"]:
+      # Unverifiable storage (Graph API unreachable) is transient — 503 so
+      # clients retry, not 413 which reads as "you are over your cap".
+      if limit_check.get("retryable"):
+        raise HTTPException(
+          status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+          detail={
+            "error": "Storage usage could not be verified; retry shortly",
+            "errors": limit_check["errors"],
+            "tier": graph_tier,
+          },
+          headers={"Retry-After": "30"},
+        )
       raise HTTPException(
         status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
         detail={

--- a/robosystems/operations/graph/tier_validation.py
+++ b/robosystems/operations/graph/tier_validation.py
@@ -73,7 +73,17 @@ async def validate_storage_capacity(
   storage_info = await IngestionLimitChecker.check_instance_storage(
     db, graph_id, current_tier
   )
-  total_gb = storage_info.get("total_storage_gb", 0)
+  total_gb = storage_info.get("total_storage_gb")
+
+  # Fail closed: approving a downgrade without knowing the usage could land
+  # a graph over its new, smaller cap the moment the change completes.
+  if total_gb is None:
+    raise HTTPException(
+      status_code=503,
+      detail=(
+        "Storage usage could not be verified for downgrade validation; retry shortly."
+      ),
+    )
 
   if total_gb > new_limit_gb:
     raise HTTPException(

--- a/tests/lambda/test_graph_volume_monitor.py
+++ b/tests/lambda/test_graph_volume_monitor.py
@@ -55,3 +55,38 @@ class TestMarkVolumeAttached:
   def test_missing_row_is_non_fatal(self, gvmon):
     # No row for the volume — the conditional write fails and is swallowed.
     gvmon.mark_volume_attached("vol-does-not-exist")
+
+
+class TestTierVolumeCeiling:
+  """Expansion must stop at the product-tier ceiling.
+
+  Without one, this Lambda grew a 20 GB-cap tenant's volume toward the
+  16 TB EBS maximum — unbounded EBS spend for data the application-side
+  storage cap should have stopped.
+  """
+
+  def test_growth_is_capped_at_the_tier_ceiling(self, gvmon):
+    # Standard: 20 GB cap x 2.0 multiplier = 40 GB ceiling. 35 GB at 90%
+    # wants 60 GB after expansion factor, minimum step, and rounding.
+    assert gvmon.calculate_new_volume_size(35, 0.9, tier="ladybug-standard") == 40
+
+  def test_at_ceiling_returns_current_size(self, gvmon):
+    """No growth at the ceiling; the caller treats no-growth as no-expansion."""
+    assert gvmon.calculate_new_volume_size(40, 0.95, tier="ladybug-standard") == 40
+
+  def test_tiers_without_a_product_cap_grow_freely(self, gvmon):
+    # Shared repositories are platform-managed and have no product cap.
+    assert gvmon.calculate_new_volume_size(200, 0.9, tier="ladybug-shared") == 300
+    assert gvmon.calculate_new_volume_size(200, 0.9, tier="unknown") == 300
+
+  def test_lambda_tier_limits_match_graph_yml(self, gvmon):
+    """The Lambda is standalone and cannot import app config, so its copy of
+    the per-tier caps is pinned against graph.yml here."""
+    from robosystems.config.graph_tier import GraphTierConfig
+
+    GraphTierConfig.clear_cache()
+    assert gvmon.TIER_STORAGE_LIMITS_GB, "tier limits table must not be empty"
+    for tier, limit in gvmon.TIER_STORAGE_LIMITS_GB.items():
+      assert limit == GraphTierConfig.get_instance_storage_limit_gb(
+        tier, "production"
+      ), f"{tier}: Lambda says {limit}, graph.yml disagrees"

--- a/tests/middleware/graph/test_ingestion_limits.py
+++ b/tests/middleware/graph/test_ingestion_limits.py
@@ -14,10 +14,20 @@ class TestCheckMaterializationLimits:
   async def test_within_limits_allowed(self):
     """Test that materialization is allowed when within row limits."""
     mock_db = MagicMock()
-    with patch.object(
-      IngestionLimitChecker,
-      "_get_pending_row_counts",
-      return_value={"Entity": 1000, "Fact": 2000, "ENTITY_HAS_FACT": 500},
+    with (
+      patch.object(
+        IngestionLimitChecker,
+        "_get_pending_row_counts",
+        return_value={"Entity": 1000, "Fact": 2000, "ENTITY_HAS_FACT": 500},
+      ),
+      # A measured, in-bounds breakdown. Without this mock the test only
+      # passed via the old fail-open path (unmeasured -> 0 GB -> allowed).
+      patch.object(
+        IngestionLimitChecker,
+        "_get_storage_breakdown",
+        new_callable=AsyncMock,
+        return_value={"total_bytes": 1024**3, "items": []},
+      ),
     ):
       result = await IngestionLimitChecker.check_materialization_limits(
         db=mock_db,
@@ -149,10 +159,18 @@ class TestCheckMaterializationLimits:
     """
     mock_db = MagicMock()
     # Even with large row counts, as long as they're within per-operation limits
-    with patch.object(
-      IngestionLimitChecker,
-      "_get_pending_row_counts",
-      return_value={"Entity": 500_000, "ENTITY_HAS_FACT": 250_000},
+    with (
+      patch.object(
+        IngestionLimitChecker,
+        "_get_pending_row_counts",
+        return_value={"Entity": 500_000, "ENTITY_HAS_FACT": 250_000},
+      ),
+      patch.object(
+        IngestionLimitChecker,
+        "_get_storage_breakdown",
+        new_callable=AsyncMock,
+        return_value={"total_bytes": 1024**3, "items": []},
+      ),
     ):
       result = await IngestionLimitChecker.check_materialization_limits(
         db=mock_db,
@@ -415,11 +433,15 @@ class TestCheckInstanceStorage:
     assert result["databases"][0]["size_mb"] == 6 * 1024
     assert result["total_storage_gb"] == 6.0
 
-  @pytest.mark.asyncio
-  async def test_unavailable_breakdown_degrades_to_zero(self):
-    """An unreachable node must not fabricate usage or block on nothing."""
-    mock_db = MagicMock()
 
+class TestUnmeasurableStorageFailsClosed:
+  """A Graph API failure used to read as 0 GB / healthy / allowed —
+  silently disabling the storage cap exactly when the instance was
+  struggling, which is when it matters most."""
+
+  @pytest.mark.asyncio
+  async def test_check_instance_storage_returns_unknown_and_blocks(self):
+    mock_db = MagicMock()
     with (
       patch.object(
         IngestionLimitChecker,
@@ -437,12 +459,82 @@ class TestCheckInstanceStorage:
       ),
     ):
       result = await IngestionLimitChecker.check_instance_storage(
-        db=mock_db,
-        graph_id="kg_test",
-        tier="ladybug-standard",
+        db=mock_db, graph_id="kg_test", tier="ladybug-standard"
       )
 
-    assert result["allowed"] is True
-    assert result["total_storage_gb"] == 0.0
-    assert result["databases"] == []
-    assert result["items"] == []
+    assert result["allowed"] is False
+    assert result["retryable"] is True
+    assert result["status"] == "unknown"
+    assert result["total_storage_gb"] is None
+    assert result["usage_percentage"] is None
+
+  @pytest.mark.asyncio
+  async def test_materialization_check_marks_the_block_retryable(self):
+    """Callers must be able to distinguish 'cannot verify, retry' from
+    'over your cap' — a 503 versus a 413."""
+    mock_db = MagicMock()
+    with (
+      patch.object(
+        IngestionLimitChecker,
+        "_get_pending_row_counts",
+        return_value={"Entity": 1000},
+      ),
+      patch.object(
+        IngestionLimitChecker,
+        "_get_storage_breakdown",
+        new_callable=AsyncMock,
+        return_value=None,
+      ),
+      patch(
+        "robosystems.middleware.graph.ingestion_limits.GraphTierConfig.get_instance_storage_limit_gb",
+        return_value=20.0,
+      ),
+      patch(
+        "robosystems.middleware.graph.ingestion_limits.GraphTierConfig.get_graph_limits",
+        return_value={
+          "instance_storage_limit_gb": 20,
+          "max_rows_per_copy": 1_000_000,
+          "max_single_table_rows": 2_500_000,
+          "chunk_size_rows": 250_000,
+          "warn_at_percentage": 80,
+        },
+      ),
+    ):
+      result = await IngestionLimitChecker.check_materialization_limits(
+        db=mock_db, graph_id="kg_test", tier="ladybug-standard"
+      )
+
+    assert result["allowed"] is False
+    assert result["retryable"] is True
+    assert any("could not be verified" in e for e in result["errors"])
+
+  @pytest.mark.asyncio
+  async def test_measured_over_limit_is_not_retryable(self):
+    """A genuine over-cap block must stay a hard 413, not a retry hint."""
+    mock_db = MagicMock()
+    with (
+      patch.object(
+        IngestionLimitChecker,
+        "_get_storage_breakdown",
+        new_callable=AsyncMock,
+        return_value={
+          "total_bytes": 25 * 1024**3,
+          "items": [{"type": "graph", "id": "kg_test", "bytes": 25 * 1024**3}],
+        },
+      ),
+      patch(
+        "robosystems.middleware.graph.ingestion_limits.GraphTierConfig.get_instance_storage_limit_gb",
+        return_value=20.0,
+      ),
+      patch(
+        "robosystems.middleware.graph.ingestion_limits.GraphTierConfig.get_graph_limits",
+        return_value={"warn_at_percentage": 80},
+      ),
+    ):
+      result = await IngestionLimitChecker.check_instance_storage(
+        db=mock_db, graph_id="kg_test", tier="ladybug-standard"
+      )
+
+    assert result["allowed"] is False
+    assert result["retryable"] is False
+    assert result["status"] == "over_limit"


### PR DESCRIPTION
The tier storage cap (20/50/100 GB) only bound one narrow path — the HTTP materialize command — and everything around it either bypassed it or actively undermined it. This PR closes the three holes and wires up the dead reporting path.

## Fail closed, with honest semantics

A Graph API error or timeout during the storage-breakdown call read as **0 GB used / healthy / allowed** (swallowed at debug level), silently disabling the cap exactly when the instance was struggling. Unmeasured usage is now an explicit `unknown` state with a `retryable` flag, and each consumer handles it for what it is:

| Consumer | Behavior on unknown |
|---|---|
| Materialize command | **503 + Retry-After** — distinct from the over-cap 413, so clients retry instead of thinking they're over their limit |
| Tier downgrade validation | refuses to validate (503) — approving a downgrade blind could land the graph over its new cap instantly |
| `/limits` instance usage | shows nothing rather than a fabricated healthy 0.0 |
| Usage-alert sensor | skips (nothing was measured) |

## The sensor path now enforces the cap

The 413 gate lived in the HTTP command, but sensor-driven rebuilds (`stale_graph_materialization_sensor` → `extensions_materialize_job`) — which is how routine OLAP materialization actually happens — never ran it. An over-cap graph was fully rebuilt on every sync; the cap only ever bound manual API calls. The materialize op now runs the same check first; blocked runs fail visibly in Dagster with the storage status in run metadata, and resubmit on the sensor's cursor expiry.

## Volume growth stops at a tier ceiling

The volume-expansion Lambda grew any volume at 80% usage toward the **16 TB EBS maximum** with no tier awareness — unbounded EBS spend under tenants whose product cap is 20 GB, for writes the app-side gate doesn't cover. Growth now stops at **cap × 2** (headroom because DuckDB staging, temp files, and vector indexes legitimately live on the volume beyond the graph data the cap governs; tunable via `TIER_CEILING_MULTIPLIER`). At the ceiling the Lambda logs an error and declines to expand. Shared repositories and replicas carry no product cap and grow exactly as before.

The Lambda is standalone and cannot import app config, so its copy of the per-tier caps is **pinned against graph.yml by a test** — a resize that forgets the Lambda now fails CI instead of silently splitting the two.

## Storage snapshots actually get written

The 6-hour usage sensor computed each graph's storage for alerting and threw the number away. It now persists a `STORAGE_SNAPSHOT` row per measured check — the rows the admin and org usage surfaces have been reading all along while nothing ever wrote one.

## Testing

Full suite: **11,441 passed**; only failures are the two pre-existing `test_incremental_materialize` cases that reproduce on `main`.

Two tests updated and one removed rather than fixed: two passed only *via* the fail-open path (no breakdown mock → 0 GB → allowed), and one — `test_unavailable_breakdown_degrades_to_zero` — pinned the fail-open behavior itself as desirable. New tests cover the unknown state end to end (blocks, marks retryable, measured-over-cap stays non-retryable), the Lambda ceiling (capped growth, no-growth at ceiling, capless tiers unaffected), and the Lambda↔graph.yml sync pin.

Deploy note: the Lambda changes ride the normal deploy pipeline (userdata/Lambda uploads are automated); `TIER_CEILING_MULTIPLIER` is optional with a code default of 2.0.
