### PR TITLE
chore(api): type the oauthCallback and liveFinancialStatement responses

### DIFF
--- a/robosystems/models/api/oauth.py
+++ b/robosystems/models/api/oauth.py
@@ -46,6 +46,20 @@ class OAuthCallbackRequest(BaseModel):
   error_description: str | None = Field(None, description="OAuth error details")
 
 
+class OAuthCallbackResponse(BaseModel):
+  """Result of completing an OAuth authorization flow."""
+
+  success: bool = Field(..., description="Whether the connection was established")
+  message: str = Field(..., description="Human-readable outcome of the exchange")
+  connection_id: str = Field(
+    ..., description="Connection the authorization was linked to"
+  )
+  auto_sync_task_id: str | None = Field(
+    None,
+    description="Task id of the initial sync started after connecting, or null when no sync was kicked off",
+  )
+
+
 class OAuthTokens(BaseModel):
   """OAuth tokens from provider."""
 

--- a/robosystems/routers/extensions/roboledger/reads.py
+++ b/robosystems/routers/extensions/roboledger/reads.py
@@ -33,6 +33,7 @@ from robosystems.middleware.rate_limits import subscription_aware_rate_limit_dep
 from robosystems.models.api.common import OPERATION_ERROR_RESPONSES
 from robosystems.models.api.extensions.reports import (
   LiveFinancialStatementRequest,
+  LiveFinancialStatementResponse,
 )
 from robosystems.models.core import User
 from robosystems.operations.roboledger.reads.reports import (
@@ -57,7 +58,7 @@ _require_roboledger = require_graph_extension("roboledger")
 
 @router.post(
   "/live-financial-statement",
-  response_model=OperationEnvelope,
+  response_model=OperationEnvelope[LiveFinancialStatementResponse],
   operation_id="liveFinancialStatement",
   summary="Live Financial Statement",
   description=(

--- a/robosystems/routers/graphs/connections/oauth.py
+++ b/robosystems/routers/graphs/connections/oauth.py
@@ -19,6 +19,7 @@ from robosystems.models.api.common import (
 )
 from robosystems.models.api.oauth import (
   OAuthCallbackRequest,
+  OAuthCallbackResponse,
   OAuthInitRequest,
   OAuthInitResponse,
 )
@@ -104,6 +105,7 @@ async def init_oauth(
   summary="OAuth Callback",
   description="Completes the OAuth authorization flow after provider redirect. Exchanges the authorization code for tokens, stores them, and triggers an initial sync. This is a redirect target — not typically called directly.",
   operation_id="oauthCallback",
+  response_model=OAuthCallbackResponse,
   responses={**RESOURCE_ERROR_RESPONSES},
 )
 async def oauth_callback(

--- a/tests/models/api/test_oauth_models.py
+++ b/tests/models/api/test_oauth_models.py
@@ -7,6 +7,7 @@ from pydantic import ValidationError
 
 from robosystems.models.api.oauth import (
   OAuthCallbackRequest,
+  OAuthCallbackResponse,
   OAuthConnectionUpdate,
   OAuthInitRequest,
   OAuthInitResponse,
@@ -161,3 +162,45 @@ class TestOAuthConnectionUpdate:
         provider_data={},
         status="connected",
       )  # type: ignore[call-arg]
+
+
+@pytest.mark.unit
+class TestOAuthCallbackResponse:
+  """The callback's success payload is a published contract: the OpenAPI 200
+  for oauthCallback is generated from this model, and the TypeScript client
+  casts against it."""
+
+  def test_valid_response(self):
+    model = OAuthCallbackResponse(
+      success=True,
+      message="QuickBooks connection established successfully",
+      connection_id="conn_123",
+      auto_sync_task_id="task_456",
+    )
+    assert model.success is True
+    assert model.connection_id == "conn_123"
+    assert model.auto_sync_task_id == "task_456"
+
+  def test_auto_sync_task_id_is_optional(self):
+    # No sync is started when the connection is revived rather than created.
+    model = OAuthCallbackResponse(
+      success=True,
+      message="QuickBooks connection established successfully",
+      connection_id="conn_123",
+    )
+    assert model.auto_sync_task_id is None
+
+  def test_requires_connection_id(self):
+    with pytest.raises(ValidationError):
+      OAuthCallbackResponse(success=True, message="ok")  # type: ignore[call-arg]
+
+  def test_serializes_the_shape_the_router_returns(self):
+    # Mirrors the literal dict returned by oauth_callback so a drift between
+    # the two shows up here rather than as an `unknown` in the clients.
+    payload = {
+      "success": True,
+      "message": "QuickBooks connection established successfully",
+      "connection_id": "conn_123",
+      "auto_sync_task_id": None,
+    }
+    assert OAuthCallbackResponse(**payload).model_dump() == payload


### PR DESCRIPTION
## Summary

Two routes return well-defined payloads but don't declare them, so the generated OpenAPI describes them as `unknown` / `Any`. That propagates into both SDKs and forces roboledger to hand-maintain types and cast.

Both are zero-behaviour changes — the handlers already returned exactly these shapes; FastAPI now validates and publishes them.

## 1. `oauthCallback` — no `response_model` at all

The OAuth callback route declared no `response_model`, unlike `oauth_init` directly above it, so FastAPI emitted **`200: unknown`** while the handler returns `{success, message, connection_id, auto_sync_task_id}`.

- **`models/api/oauth.py`** — adds `OAuthCallbackResponse`. `auto_sync_task_id` is nullable because the handler initialises `task_id = None` and only assigns it when an initial sync is actually kicked off (a revived connection doesn't start one).
- **`routers/graphs/connections/oauth.py`** — wires `response_model=OAuthCallbackResponse`.

**Downstream:** the TypeScript client types this as `unknown`, so roboledger's QuickBooks callback casts it to read `.success` — one of the reasons that page shipped under a whole-file `@ts-nocheck` (removed in roboledger-app#242, which kept a narrow documented cast solely because of this).

## 2. `liveFinancialStatement` — generic left unparameterised

The route declared `response_model=OperationEnvelope` without parameterising it, so `result` was `Any` — even though `get_live_financial_statement` already returns a typed `LiveFinancialStatementResponse`.

`OperationEnvelope` has been `Generic[TResult]` for exactly this purpose. Its own docstring says ops pin `OperationEnvelope[YourEnvelope]` as their response model, and five routes in `operations.py` already do. This one was simply missed.

- **`routers/extensions/roboledger/reads.py`** — `response_model=OperationEnvelope[LiveFinancialStatementResponse]`. Return annotation stays plain `-> OperationEnvelope`, matching the existing parameterised routes.

**Downstream:** the TypeScript client types this as `Promise<Record<string, unknown>>`, so roboledger's statements page hand-maintains `LiveStatement`, `LiveFactRow` and `LivePeriod` interfaces and casts through `as unknown as LiveStatement`. All of that can go after a regen.

## Verification

Generated the spec from `create_app()` and checked both operations directly rather than assuming:

```
oauthCallback → 200 → $ref: OAuthCallbackResponse          (was: unknown)
liveFinancialStatement → 200 → OperationEnvelope_LiveFinancialStatementResponse_
    result: LiveFinancialStatementResponse | null           (was: Any)
```

## Testing

- `pytest -k oauth`: **66 passed** (62 existing + 4 new).
- `pytest tests/routers/extensions/roboledger/`: **55 passed**.
- ruff check + format clean, basedpyright 0 errors / 0 warnings.
- 4 new tests in `tests/models/api/test_oauth_models.py`, including one asserting the model round-trips the **literal dict the router returns**, so handler/model drift surfaces there rather than as an `unknown` in the clients.

## Follow-up

Both clients need a regen once this merges — TypeScript first (roboledger consumes it), Python for parity. The regen must run against a backend on `main` or this branch, not `api.robosystems.ai`; prod is behind on several merged commits and regenerating against it would revert unrelated description updates. That's a regen-source concern, not a deploy prerequisite — clients are pinned by version in the Docker build, so a new client version can be cut before this reaches prod.

After the TS regen, roboledger can drop the `as { success?: boolean }` cast in `connections/qb-callback/page.tsx` and the entire hand-written statement type block in `ledger/statements/content.tsx`.
