### PR TITLE
chore(api): type the buildFactGrid and financialStatementAnalysis results

### DIFF
--- a/robosystems/routers/extensions/roboledger/views.py
+++ b/robosystems/routers/extensions/roboledger/views.py
@@ -82,7 +82,7 @@ _RATE_LIMIT = Depends(subscription_aware_rate_limit_dependency)
 
 @router.post(
   "/build-fact-grid",
-  response_model=OperationEnvelope,
+  response_model=OperationEnvelope[ViewResponse],
   operation_id="buildFactGrid",
   summary="Build Fact Grid",
   description="Queries LadybugDB `Fact` nodes by element qnames or canonical concepts, with filters for periods, entities, form, and fiscal context. Returns a deduplicated pivot table. Works on both roboledger tenant graphs (post-materialization) and the SEC shared repository.",
@@ -180,7 +180,7 @@ async def build_fact_grid_op(
 
 @router.post(
   "/financial-statement-analysis",
-  response_model=OperationEnvelope,
+  response_model=OperationEnvelope[FinancialStatementAnalysisResponse],
   operation_id="financialStatementAnalysis",
   summary="Financial Statement Analysis",
   description=(


### PR DESCRIPTION
## Summary

Follow-on to #955. Two more view operations had the same defect: `response_model=OperationEnvelope` without parameterising the generic, so OpenAPI described `result` as `Any` — even though both runners already return typed Pydantic models, and both models were already imported in the module.

```diff
-  response_model=OperationEnvelope,          # buildFactGrid
+  response_model=OperationEnvelope[ViewResponse],

-  response_model=OperationEnvelope,          # financialStatementAnalysis
+  response_model=OperationEnvelope[FinancialStatementAnalysisResponse],
```

## Correcting my own earlier reasoning

While reviewing the SDK facades I said these two were "correctly untyped because their backend routes aren't parameterised." That was circular — the routes aren't parameterised *because this was missed*, not because there's no type to declare. `build_fact_grid_op` returns `ViewResponse(...)` and `financial_statement_analysis_op` returns `FinancialStatementAnalysisResponse(...)`. Both types existed the whole time.

Found by auditing every `response_model=OperationEnvelope,` in the codebase rather than waiting to trip over them one at a time: **20 bare vs 19 parameterised**, so this is systemic rather than a one-off.

## The remaining bare route in this module is correct

`autoMapElements` stays bare deliberately — it dispatches to a background worker and returns a `pending` envelope whose `result` is null at return time. There's nothing to declare.

## Verification

Generated the spec from `create_app()` and checked both operations:

```
buildFactGrid              → OperationEnvelope_ViewResponse_
  result: ViewResponse | null                          (was: Any)
financialStatementAnalysis → OperationEnvelope_FinancialStatementAnalysisResponse_
  result: FinancialStatementAnalysisResponse | null    (was: Any)
```

## Testing

`pytest tests/routers/extensions/roboledger/` — 55 passed. ruff check clean, basedpyright 0 errors / 0 warnings. Behaviour unchanged: same handlers, same payloads, now declared.

## Why now

The point is to get everything typed in **one** regen + publish cycle rather than discovering the next one after the release. `liveFinancialStatement` (#955) already forced one round; these two would otherwise force a third.

Once merged, both clients regenerate and their facades can surface the real types — `buildFactGrid` and `financialStatementAnalysis` currently return `Record<string, unknown>` / `dict[str, Any]` in the TypeScript and Python facades respectively, which was *correct* until now and becomes wrong the moment this lands.
