### PR TITLE
chore(deps): bump the robosystems-client dev pin to 0.6.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     # RoboSystems client for demo and testing
-    "robosystems-client==0.5.8",
+    "robosystems-client==0.6.1",
 
     # Testing framework
     "pytest>=9.0.0,<10.0",

--- a/uv.lock
+++ b/uv.lock
@@ -3699,7 +3699,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.34.2,<3.0" },
     { name = "retrying", specifier = ">=1.4.0,<2.0" },
     { name = "rich", marker = "extra == 'dev'", specifier = ">=15.0.0,<16.0" },
-    { name = "robosystems-client", marker = "extra == 'dev'", specifier = "==0.5.8" },
+    { name = "robosystems-client", marker = "extra == 'dev'", specifier = "==0.6.1" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0,<1.0" },
     { name = "sqlalchemy", specifier = ">=2.0.0,<3.0" },
     { name = "sse-starlette", specifier = ">=3.3.0,<4.0" },
@@ -3722,7 +3722,7 @@ lambda = [
 
 [[package]]
 name = "robosystems-client"
-version = "0.5.8"
+version = "0.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -3730,9 +3730,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a7/4c/4ce4c66d459a7e505bb1affa582b3ba0dd4d2e8227e60a8bf02831741fc2/robosystems_client-0.5.8.tar.gz", hash = "sha256:c0d8266db43f5791e40b302e74fc936da4a57565a91850f5fb18f1927bf75e70", size = 438327, upload-time = "2026-07-26T06:42:01.446Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/d7/9bc5a9b8c3b903520b56f7d415685a02ce1acdcbd1ea15c777ad77dfaca0/robosystems_client-0.6.1.tar.gz", hash = "sha256:07102642f9c4a6dcc455caac18cb061d70f74236d3870c4de358fa7652d81e50", size = 465083, upload-time = "2026-07-29T04:13:35.202Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/96/b8/3bb2d09661408595b62ca9a8a8bed9062791de64704b3f68fa1740041087/robosystems_client-0.5.8-py3-none-any.whl", hash = "sha256:8e11546d3d624998522f3aad53b73639f8ef702a46695e66a1d10ac8a8c9f340", size = 1032056, upload-time = "2026-07-26T06:41:59.671Z" },
+    { url = "https://files.pythonhosted.org/packages/63/22/bf32aa8d4152f5298a14c429da64d01d439c60295b35f223cd8d4b55cb40/robosystems_client-0.6.1-py3-none-any.whl", hash = "sha256:c146f8ee26ea38699451d321efa3bbf06c0e38a891d279d647d801e0c0ecca9a", size = 1071438, upload-time = "2026-07-29T04:13:33.393Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

The `dev` extra pinned `robosystems-client==0.5.8` — three releases behind, predating every fix in the 0.6.x line. Anything running against that pin had:

- five library queries the server **rejects outright** (`GraphQLError` on every call)
- `get_operation_status` / `cancel_operation` **always failing** when a token is set
- queued queries **401ing** (SSE config built without auth headers)
- `close_period` able to return `{"deleted": True}` while declaring `ClosePeriodResponse`

Because it's an exact pin, nothing moved it automatically. `just sdk-local` installs the local checkout editable, which masks the stale pin during local development — plausibly why the demos were exercising broken surfaces unnoticed.

## Verified before bumping

The demos **do** call `close_period`, `create_report` and `evaluate_rules`, whose empty-envelope behaviour now raises instead of returning the delete sentinel. That only fires on an already-malformed response where the old return value was never meaningful, so it converts a silent wrong value into a clear error.

They call **none** of `live_financial_statement` / `financial_statement_analysis` / `build_fact_grid`, whose returns narrowed from `dict` to typed models — so no dict-subscript access breaks. They use none of the library element queries either.

## Testing

Full suite: **2797 passed**, 9 skipped. One failure in `tests/graph_api/.../test_incremental_materialize.py::test_incremental_equals_full_load`, which **passes in isolation** and contains zero references to `robosystems_client` — an order-dependent flake, unrelated to this change and pre-existing.

## Note

Two commits: the second adds `uv.lock`, which is tracked in this repo and records the resolved bump. Without it a fresh `uv sync` would resolve from a lockfile still pinning 0.5.8 and silently undo the change. (`uv.lock` is gitignored in robosystems-python-client and tracked here — the habit doesn't transfer between the two.)