### PR TITLE
chore(infra): patch OS packages at boot on graph and Lambda images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -369,6 +369,7 @@ jobs:
             --provenance=false \
             --cache-from type=gha,scope=lambda \
             --cache-to type=gha,scope=lambda,mode=max \
+            --build-arg CACHE_DATE=$(date -u +%Y%m%d) \
             -t "${ECR_URL}:${IMAGE_TAG}" \
             -f Dockerfile.lambda .
 

--- a/Dockerfile.lambda
+++ b/Dockerfile.lambda
@@ -5,6 +5,13 @@
 # Use AWS Lambda Python base image (ARM64 for Graviton cost savings)
 FROM public.ecr.aws/lambda/python:3.13-arm64
 
+# Apply Amazon Linux security patches. The base image lags AL2023 package
+# releases, so without this the image ships whatever AWS last baked.
+# CACHE_DATE (set per-build in build.yml) busts this layer so the upgrade
+# re-runs despite GHA layer caching — a cached layer keeps stale OS packages.
+ARG CACHE_DATE
+RUN echo "os-refresh ${CACHE_DATE}" && dnf update -y && dnf clean all && rm -rf /var/cache/dnf
+
 # Install uv for dependency export
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 

--- a/Dockerfile.lambda
+++ b/Dockerfile.lambda
@@ -7,10 +7,13 @@ FROM public.ecr.aws/lambda/python:3.13-arm64
 
 # Apply Amazon Linux security patches. The base image lags AL2023 package
 # releases, so without this the image ships whatever AWS last baked.
+# --releasever=latest is required, not optional: AL2023 pins releasever to the
+# version baked into the image, so a plain `dnf update` resolves against that
+# frozen snapshot and upgrades nothing at all.
 # CACHE_DATE (set per-build in build.yml) busts this layer so the upgrade
 # re-runs despite GHA layer caching — a cached layer keeps stale OS packages.
 ARG CACHE_DATE
-RUN echo "os-refresh ${CACHE_DATE}" && dnf update -y && dnf clean all && rm -rf /var/cache/dnf
+RUN echo "os-refresh ${CACHE_DATE}" && dnf update -y --releasever=latest && dnf clean all && rm -rf /var/cache/dnf
 
 # Install uv for dependency export
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv

--- a/cloudformation/graph-ladybug-replicas.yaml
+++ b/cloudformation/graph-ladybug-replicas.yaml
@@ -453,6 +453,22 @@ Resources:
             exec > >(tee /var/log/user-data-bootstrap.log) 2>&1
             echo "Starting shared replica bootstrap at $(date)..."
 
+            # Apply Amazon Linux security patches. The ASG launches from a pinned
+            # AMI refreshed monthly, so without this an instance runs whatever
+            # packages that AMI shipped with for up to a month after publication.
+            # --releasever=latest is required, not optional: AL2023 pins releasever
+            # to the version baked into the AMI, so a plain `dnf update` resolves
+            # against that frozen snapshot and upgrades nothing at all. For the same
+            # reason this cannot be narrowed to --security: AL2023 ships no
+            # updateinfo metadata, so security-only filtering matches nothing.
+            # Non-fatal on purpose: set -e would turn a transient repo error into
+            # a failed launch.
+            # kernel* is excluded because a kernel update needs a reboot to take
+            # effect — installing one here would have scanners report it patched
+            # while the vulnerable kernel is still running. AMI refresh covers those.
+            echo "Applying security updates..."
+            dnf update -y --releasever=latest --exclude='kernel*' || echo "WARNING: security update failed, continuing boot"
+
             # Extract bucket name from ARN (arn:aws:s3:::bucket-name -> bucket-name)
             DEPLOYMENT_BUCKET_ARN="${DeploymentBucketArn}"
             DEPLOYMENT_BUCKET=$(echo "$DEPLOYMENT_BUCKET_ARN" | sed 's|arn:aws:s3:::||')

--- a/cloudformation/graph-ladybug.yaml
+++ b/cloudformation/graph-ladybug.yaml
@@ -423,6 +423,22 @@ Resources:
             #!/bin/bash
             set -e
 
+            # Apply Amazon Linux security patches. The ASG launches from a pinned
+            # AMI refreshed monthly, so without this an instance runs whatever
+            # packages that AMI shipped with for up to a month after publication.
+            # --releasever=latest is required, not optional: AL2023 pins releasever
+            # to the version baked into the AMI, so a plain `dnf update` resolves
+            # against that frozen snapshot and upgrades nothing at all. For the same
+            # reason this cannot be narrowed to --security: AL2023 ships no
+            # updateinfo metadata, so security-only filtering matches nothing.
+            # Non-fatal on purpose: set -e plus the cfn-signal ERR trap below would
+            # turn a transient repo error into a failed launch.
+            # kernel* is excluded because a kernel update needs a reboot to take
+            # effect — installing one here would have scanners report it patched
+            # while the vulnerable kernel is still running. AMI refresh covers those.
+            echo "Applying security updates..."
+            dnf update -y --releasever=latest --exclude='kernel*' || echo "WARNING: security update failed, continuing boot"
+
             # Set environment variables
             echo "Setting environment variables..."
 


### PR DESCRIPTION
## Summary

OS packages on the graph EC2 instances and in the Lambda container image were only ever as current as the image they launched from — the graph ASGs boot from an AMI refreshed on a monthly cadence, and `Dockerfile.lambda` never patched at all. The API image has always run an `apt-get upgrade` under a `CACHE_DATE` bust; this brings the other two surfaces up to the same standard.

## Changes

**`Dockerfile.lambda`**
- Added an `ARG CACHE_DATE` + `dnf update -y --releasever=latest` layer after the `FROM`, mirroring the existing pattern at `Dockerfile:131-132`.

**`.github/workflows/build.yml`**
- Pass `--build-arg CACHE_DATE=$(date -u +%Y%m%d)` to the lambda `buildx build`. Without this the update layer is restored from `--cache-from type=gha,scope=lambda` and never re-runs, pinning whatever packages were current when the layer was first built.

**`cloudformation/graph-ladybug.yaml`, `cloudformation/graph-ladybug-replicas.yaml`**
- Added a boot-time `dnf update` step to both launch-template UserData scripts so instances patch on launch instead of carrying the AMI's package set until the next AMI refresh.

## Notes on the implementation

Three non-obvious constraints drove the final form of the command, all verified rather than assumed:

- **`--releasever=latest` is load-bearing.** AL2023 pins `releasever` to the version baked into the image, so a plain `dnf update` resolves against that frozen snapshot and upgrades *nothing*. An earlier revision of this branch omitted it and was inert; the no-op is silent and reports `Nothing to do`, which reads exactly like "already current."
- **`--security` cannot be used.** AL2023 ships no `updateinfo` metadata (`dnf updateinfo list` returns empty), so security-only filtering matches nothing and silently no-ops. Moving the whole release snapshot forward is the only functional path on AL2023.
- **`kernel*` is excluded on the EC2 path.** A kernel update needs a reboot to take effect; installing one at boot without rebooting would make scanners report it patched while the vulnerable kernel is still running. AMI refresh remains the path for kernel packages.

The UserData step is deliberately non-fatal (`|| echo "WARNING: ..."`). Both scripts run under `set -e`, and the writer template installs a `cfn-signal -e 1` ERR trap — without the guard, a transient package-repo error would fail the instance launch and have the ASG replace it.

## Testing

- `just cf-lint graph-ladybug` and `just cf-lint graph-ladybug-replicas` — both exit 0.
- Pre-commit hooks (ruff, format, basedpyright) passed on both commits: `0 errors, 0 warnings, 0 notes`.
- Built `Dockerfile.lambda` for `linux/arm64` and scanned the result with Trivy (`--ignore-unfixed --severity CRITICAL,HIGH`): **0 findings**, down from 10 on the current image.
- Verified the UserData command against `amazonlinux:2023.12.20260611.0`, matching the package baseline of the AMI currently in the launch templates: 23 packages upgraded, and `glib2`, `libacl`, `expat`, `sqlite-libs` and `python3` all land on the versions the scanners ask for. The same command against the pre-fix form upgraded 0 packages, which is how the `--releasever` requirement was found.
- `just test-all` unit tests: **not run.** No Python source changed on this branch — the diff is one Dockerfile, one workflow, and two CloudFormation templates.

## Follow-ups

- Closes the *drift* between AMI refreshes and applies to instances as they relaunch. It does not patch currently-running instances, and by design does not address kernel packages on them — both are covered by an ASG refresh via `graph-maintenance.yml` (`update-ami` + `trigger_asg_refresh`), which is a separate operational decision on stateful writers.
- `cloudformation/bastion.yaml` launches from an AMI and has the same gap; intentionally left out of scope here.
- The Lambda image findings only re-scan on a tagged release, since `scan-lambda` runs from `build.yml` on release rather than on PR merge.
