### PR TITLE
Give writer rollouts a boot-sized signal budget

### DIFF
--- a/.github/workflows/deploy-graph-ladybug.yml
+++ b/.github/workflows/deploy-graph-ladybug.yml
@@ -134,7 +134,11 @@ on:
 jobs:
   deploy:
     runs-on: ${{ fromJSON(inputs.runner_config) }}
-    timeout-minutes: 30
+    # A rolling update replaces one instance at a time, so the ceiling is
+    # min_instances x the stack's PauseTime — 3 x PT15M = 45 min for the
+    # standard tier. Must stay above the monitor step's own timeout below, or
+    # the job is killed before the monitor can report why the stack is stuck.
+    timeout-minutes: 65
     permissions:
       id-token: write
       contents: read
@@ -339,7 +343,10 @@ jobs:
         uses: ./.github/actions/monitor-stack-deployment
         with:
           stack-name: ${{ inputs.stack_name }}
-          timeout: "1800"
+          # 55 min: clears the 45-min worst case (3 standard writers x PT15M)
+          # with headroom, and stays under the job's timeout-minutes so a stuck
+          # rollout surfaces here as a reported failure rather than a killed job.
+          timeout: "3300"
           interval: "10"
 
       - name: Get Stack Outputs

--- a/cloudformation/graph-ladybug.yaml
+++ b/cloudformation/graph-ladybug.yaml
@@ -650,7 +650,15 @@ Resources:
       AutoScalingRollingUpdate:
         MinInstancesInService: 0 # Allow full flexibility since instances are protected
         MaxBatchSize: 1
-        PauseTime: PT5M
+        # Conditional because PauseTime means opposite things either side of
+        # WaitOnResourceSignals below. With signals it is a ceiling — a booted
+        # instance signals and the rollout moves on — so it must cover a full
+        # cold boot, and PT15M matches the CreationPolicy budget above for the
+        # identical work. Without signals it is a floor: CloudFormation sleeps
+        # the whole duration per batch regardless, so the tiers that run at
+        # min=0 keep the short pause rather than paying 15 idle minutes an
+        # instance.
+        PauseTime: !If [HasMinInstances, PT15M, PT5M]
         WaitOnResourceSignals: !If [HasMinInstances, true, false]
         SuspendProcesses:
           - AlarmNotification


### PR DESCRIPTION
## Summary

The OS-patching commit (#958) adds a `dnf update` to writer userdata. That changes the launch template, so CloudFormation rolls the writer fleet — the first real exercise of that path since the graph AMI became SSM-pinned, which is why the existing budget hasn't been tested lately.

Prep for the v1.6.15 rollout; no behavioural change to anything but deploy timing.

## PauseTime PT5M → PT15M, conditionally

`PauseTime` has to cover the entire boot — patching, env setup, DynamoDB registration, the S3 setup script download, container start, and `cfn-signal`. PT5M is thin for that even before `dnf update` is prepended to it, and the `dnf update` runs *first* in userdata. PT15M matches the `CreationPolicy` budget directly above it, which covers identical work.

The bump is conditional (`!If [HasMinInstances, PT15M, PT5M]`) because `PauseTime` means opposite things either side of the `WaitOnResourceSignals` line below it:

| | `WaitOnResourceSignals` | `PauseTime` acts as |
|---|---|---|
| `min > 0` (standard) | `true` | a **ceiling** — a booted instance signals and the rollout moves on |
| `min = 0` (large, xlarge, shared) | `false` | a **floor** — CloudFormation sleeps the full duration per batch regardless |

A blanket PT15M would therefore impose a mandatory 15-minute sleep per instance on the tiers that don't signal, including the shared SEC master. The conditional mirrors the existing one on the next line, and intrinsics in these blocks are already proven in this stack (`WaitOnResourceSignals` and the `CreationPolicy` `Count` both use `!If` today).

## The two surrounding caps had to move with it

`LBUG_STANDARD_MIN_INSTANCES_PROD=3` with `MaxBatchSize: 1`, so the worst case is **3 × PT15M = 45 min**. Both caps around it were sized for PT5M and would have killed the job before CloudFormation finished — the same three-cap mismatch documented for the replica fleet, where the CFN timeout, the job `timeout-minutes`, and the monitor action `timeout` all had to clear the real boot time:

- job `timeout-minutes`: 30 → **65**
- monitor step `timeout`: 1800 → **3300** (55 min)

Monitor stays under the job deliberately, so a stuck rollout surfaces as a reported failure rather than a truncated one. Replicas already carry the equivalent shape (PT30M / 70 min / 3600s).

## Testing

`cfn-lint` clean on the modified template; workflow YAML parses. No test pins these values — the pre-commit hook (ruff, format, cfn-lint) passed.

Worth noting this cannot be validated on staging: `LBUG_STANDARD_MIN_INSTANCES_STAGING=0`, so staging takes the no-signal branch and never exercises the path this changes.