### PR TITLE
Claim volumes atomically before attaching

### DIFF
--- a/bin/lambda/graph_volume_manager.py
+++ b/bin/lambda/graph_volume_manager.py
@@ -18,6 +18,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import boto3
+from botocore.exceptions import ClientError
 
 # Configure logging
 logger = logging.getLogger()
@@ -40,6 +41,14 @@ ALERT_TOPIC = os.environ["ALERT_TOPIC_ARN"]
 # Retention for fallback cleanup of orphaned volume snapshots (tagged AutoDelete: true)
 # Note: DLM handles primary snapshot lifecycle with 3-day retention
 RETENTION_DAYS = int(os.environ.get("SNAPSHOT_RETENTION_DAYS", "7"))
+
+# How long a volume may sit in `claiming` before another launch may take it.
+# Only reached if the Lambda dies between claiming a volume and attaching it —
+# the ordinary failure path releases the claim itself. Must exceed the worst
+# case of attach_and_register_volume (instance_running waiter 5 min, plus the
+# volume_available waiter and attach retries) so a slow-but-live attach is
+# never stolen out from under itself.
+STALE_CLAIM_SECONDS = int(os.environ.get("STALE_CLAIM_SECONDS", "900"))
 
 # Volume defaults (used as fallback when tier not found in tier_config)
 DEFAULT_SIZE = 50  # GB
@@ -154,6 +163,10 @@ def handle_instance_launch(event: dict[str, Any]) -> dict[str, Any]:
       elif "sec" not in databases:
         databases.append("sec")
 
+  # Return anything stranded mid-claim to the pool before scanning, or a volume
+  # whose claimant died would stay invisible to the `available` filter forever.
+  reclaim_stale_claims(az, tier)
+
   # Check for any available volumes in the same AZ and tier
   # CRITICAL: Must match availability zone exactly to avoid attachment failures
   all_items = []
@@ -184,44 +197,33 @@ def handle_instance_launch(event: dict[str, Any]) -> dict[str, Any]:
     valid_volumes = [v for v in all_items if v.get("availability_zone") == az]
 
     if valid_volumes:
-      # Sort volumes by preference:
-      # 1. Volumes with matching databases (if databases were specified)
-      # 2. Volumes with any data
-      # 3. Empty volumes
+      # Try candidates in preference order, claiming each atomically before
+      # attaching. A lost claim means a concurrent launch took that volume, so
+      # move on rather than fail — the attach retry loop cannot help there,
+      # since it waits on a volume that is now legitimately held.
+      for volume, volume_databases in ordered_volume_candidates(
+        valid_volumes, databases
+      ):
+        volume_id = volume["volume_id"]
 
-      if databases:
-        # Look for volumes with matching databases
-        matching_db_volumes = [
-          v
-          for v in valid_volumes
-          if v.get("databases")
-          and any(db in v.get("databases", []) for db in databases)
-        ]
-        if matching_db_volumes:
-          volume = matching_db_volumes[0]
-          logger.info(
-            f"Reusing volume {volume['volume_id']} with matching databases: {volume.get('databases')} in AZ {az}"
-          )
-          return attach_and_register_volume(
-            volume["volume_id"], instance_id, volume.get("databases", databases)
-          )
+        if not claim_volume(volume_id, instance_id):
+          continue
 
-      # Prefer volumes with data
-      volumes_with_data = [v for v in valid_volumes if v.get("databases")]
-      if volumes_with_data:
-        volume = volumes_with_data[0]
         logger.info(
-          f"Reusing volume {volume['volume_id']} with databases: {volume.get('databases')} in AZ {az}"
+          f"Claimed volume {volume_id} with databases: {volume.get('databases')} in AZ {az}"
         )
-        # Preserve existing databases on the volume
-        existing_databases = volume.get("databases", [])
-        return attach_and_register_volume(
-          volume["volume_id"], instance_id, existing_databases
-        )
-      else:
-        volume = valid_volumes[0]
-        logger.info(f"Reusing empty volume {volume['volume_id']} in AZ {az}")
-        return attach_and_register_volume(volume["volume_id"], instance_id, databases)
+        try:
+          return attach_and_register_volume(volume_id, instance_id, volume_databases)
+        except Exception:
+          # Put it back so the next launch can use it; the instance still fails,
+          # which is the pre-existing behaviour for a genuine attach failure.
+          release_claim(volume_id, instance_id)
+          raise
+
+      logger.info(
+        f"All {len(valid_volumes)} candidate volumes in AZ {az} were claimed by "
+        "other instances; creating a new volume"
+      )
     else:
       logger.warning(
         f"Found {len(all_items)} volumes but none in AZ {az}, creating new volume"
@@ -345,6 +347,174 @@ def update_graph_registry_for_instance(
     )
 
   return results
+
+
+def claim_volume(volume_id: str, instance_id: str) -> bool:
+  """Atomically take a volume out of the `available` pool.
+
+  Returns True when this caller won the volume, False when another instance
+  claimed it first.
+
+  Selection above is a scan followed by a deterministic sort, so two instances
+  launching concurrently in the same AZ and tier see the same list and pick the
+  same candidate. Without this conditional write both proceed to attach; EC2
+  makes one of them lose with VolumeInUse, and the attach retry loop then waits
+  out a volume that will never free before failing the instance. That is
+  survivable while instances cycle one at a time, but it becomes the normal case
+  under any concurrent replacement — a batched rolling update, an ASG instance
+  refresh, a spot reclaim during a deploy, or two graphs provisioned together.
+  """
+  try:
+    table.update_item(
+      Key={"volume_id": volume_id},
+      UpdateExpression=(
+        "SET #status = :claiming, instance_id = :instance_id, claimed_at = :timestamp"
+      ),
+      ConditionExpression="#status = :available",
+      ExpressionAttributeNames={"#status": "status"},
+      ExpressionAttributeValues={
+        ":claiming": "claiming",
+        ":available": "available",
+        ":instance_id": instance_id,
+        ":timestamp": datetime.now(UTC).isoformat(),
+      },
+    )
+    return True
+  except ClientError as e:
+    if e.response["Error"]["Code"] != "ConditionalCheckFailedException":
+      raise
+    logger.info(
+      f"Volume {volume_id} was claimed by another instance before {instance_id} "
+      "could take it; trying the next candidate"
+    )
+    # Emitted so the contention rate is observable before concurrency is raised.
+    # At MaxBatchSize 1 this should stay at zero outside of scale-out overlap; a
+    # non-zero baseline means the race is already live at the current fleet size.
+    try:
+      cloudwatch.put_metric_data(
+        Namespace=f"RoboSystems/Graph/{ENVIRONMENT}",
+        MetricData=[
+          {"MetricName": "VolumeClaimContention", "Value": 1, "Unit": "Count"}
+        ],
+      )
+    except Exception as metric_error:
+      logger.warning(f"Failed to publish claim contention metric: {metric_error}")
+    return False
+
+
+def release_claim(volume_id: str, instance_id: str) -> None:
+  """Return a claimed-but-unattached volume to the pool.
+
+  Guarded on this instance still holding the claim so a release can never undo
+  a later claim by someone else.
+  """
+  try:
+    table.update_item(
+      Key={"volume_id": volume_id},
+      UpdateExpression="SET #status = :available REMOVE claimed_at",
+      ConditionExpression="#status = :claiming AND instance_id = :instance_id",
+      ExpressionAttributeNames={"#status": "status"},
+      ExpressionAttributeValues={
+        ":available": "available",
+        ":claiming": "claiming",
+        ":instance_id": instance_id,
+      },
+    )
+    logger.info(f"Released claim on volume {volume_id} held by {instance_id}")
+  except ClientError as e:
+    if e.response["Error"]["Code"] != "ConditionalCheckFailedException":
+      raise
+    logger.warning(
+      f"Claim on {volume_id} was no longer held by {instance_id}; nothing released"
+    )
+
+
+def reclaim_stale_claims(az: str, tier: str) -> int:
+  """Return volumes stranded in `claiming` to the pool.
+
+  A claim is only stranded when the Lambda died between claiming and attaching,
+  since every handled failure releases its own claim. Without this sweep such a
+  volume is invisible to future scans forever, because they filter on
+  `available` — the graph it holds would be stranded with it.
+  """
+  cutoff = (datetime.now(UTC) - timedelta(seconds=STALE_CLAIM_SECONDS)).isoformat()
+  reclaimed = 0
+
+  last_evaluated_key = None
+  while True:
+    scan_params: dict[str, Any] = {
+      "FilterExpression": (
+        "availability_zone = :az AND tier = :tier AND #status = :claiming "
+        "AND claimed_at < :cutoff"
+      ),
+      "ExpressionAttributeNames": {"#status": "status"},
+      "ExpressionAttributeValues": {
+        ":az": az,
+        ":tier": tier,
+        ":claiming": "claiming",
+        ":cutoff": cutoff,
+      },
+    }
+    if last_evaluated_key:
+      scan_params["ExclusiveStartKey"] = last_evaluated_key
+
+    response = table.scan(**scan_params)
+    for item in response.get("Items", []):
+      volume_id = item["volume_id"]
+      try:
+        table.update_item(
+          Key={"volume_id": volume_id},
+          UpdateExpression="SET #status = :available REMOVE claimed_at",
+          # Re-check staleness at write time: a concurrent launch may have
+          # legitimately re-claimed it between the scan and here.
+          ConditionExpression="#status = :claiming AND claimed_at < :cutoff",
+          ExpressionAttributeNames={"#status": "status"},
+          ExpressionAttributeValues={
+            ":available": "available",
+            ":claiming": "claiming",
+            ":cutoff": cutoff,
+          },
+        )
+        reclaimed += 1
+        logger.warning(
+          f"Reclaimed volume {volume_id} stranded in `claiming` since "
+          f"{item.get('claimed_at')}"
+        )
+      except ClientError as e:
+        if e.response["Error"]["Code"] != "ConditionalCheckFailedException":
+          raise
+
+    last_evaluated_key = response.get("LastEvaluatedKey")
+    if not last_evaluated_key:
+      break
+
+  return reclaimed
+
+
+def ordered_volume_candidates(
+  valid_volumes: list[dict], databases: Any
+) -> list[tuple[dict, Any]]:
+  """Volumes to try in preference order, each paired with the databases to register.
+
+  Order is unchanged: a volume already holding one of this instance's databases,
+  then any volume carrying data, then an empty one. What changed is that every
+  candidate is returned rather than only the best, so a caller that loses a
+  claim race falls through to the next instead of failing.
+  """
+  matching: list[tuple[dict, Any]] = []
+  with_data: list[tuple[dict, Any]] = []
+  empty: list[tuple[dict, Any]] = []
+
+  for volume in valid_volumes:
+    volume_dbs = volume.get("databases") or []
+    if databases and any(db in volume_dbs for db in databases):
+      matching.append((volume, volume_dbs))
+    elif volume_dbs:
+      with_data.append((volume, volume_dbs))
+    else:
+      empty.append((volume, databases))
+
+  return matching + with_data + empty
 
 
 def attach_and_register_volume(

--- a/tests/lambda/test_graph_volume_manager.py
+++ b/tests/lambda/test_graph_volume_manager.py
@@ -584,3 +584,176 @@ def test_cleanup_snapshots_honors_retention_days_tag(gvm):
   # The 7-day default snapshot is within retention (5 < 7) → kept.
   assert s3["SnapshotId"] in deleted
   assert s7["SnapshotId"] not in deleted
+
+
+# ---------------------------------------------------------------------------
+# Atomic volume claiming
+#
+# Selection is a scan plus a deterministic sort, so concurrent launches in the
+# same AZ and tier converge on the same candidate. EC2 stops the double-attach,
+# but the loser's retry loop then waits out a volume that will never free and
+# fails the instance — which is why the claim has to be atomic before any
+# concurrency (batched rolling update, ASG instance refresh, spot reclaim).
+# ---------------------------------------------------------------------------
+
+
+def _registry_item(volume_id: str) -> dict:
+  ddb = boto3.resource("dynamodb", region_name="us-east-1")
+  return ddb.Table("test-volume-registry").get_item(Key={"volume_id": volume_id})[
+    "Item"
+  ]
+
+
+def test_claim_volume_takes_an_available_volume(gvm):
+  volume_id = _create_test_volume()
+  _seed_registry("test-volume-registry", volume_id, [])
+
+  assert gvm.claim_volume(volume_id, "i-winner") is True
+
+  item = _registry_item(volume_id)
+  assert item["status"] == "claiming"
+  assert item["instance_id"] == "i-winner"
+  assert "claimed_at" in item
+
+
+def test_claim_volume_loses_to_an_earlier_claim(gvm):
+  """The second caller must lose rather than both proceeding to attach."""
+  volume_id = _create_test_volume()
+  _seed_registry("test-volume-registry", volume_id, [])
+
+  assert gvm.claim_volume(volume_id, "i-first") is True
+  assert gvm.claim_volume(volume_id, "i-second") is False
+
+  # The winner keeps it; the loser must not have overwritten the owner.
+  assert _registry_item(volume_id)["instance_id"] == "i-first"
+
+
+def test_claim_volume_loses_to_an_attached_volume(gvm):
+  volume_id = _create_test_volume()
+  _seed_registry("test-volume-registry", volume_id, [], status="attached")
+
+  assert gvm.claim_volume(volume_id, "i-late") is False
+
+
+def test_launch_falls_through_when_a_candidate_is_claimed_concurrently(gvm):
+  """A lost claim must advance to the next candidate, not fail the instance.
+
+  This is the regression that makes concurrent replacement safe: previously the
+  loser called attach_and_register_volume on a volume another instance held,
+  burned its retry budget on VolumeInUse, and raised.
+  """
+  instance_id = _create_test_instance()
+  taken = _create_test_volume()
+  free = _create_test_volume()
+  # Both carry data so they sort into the same preference bucket.
+  _seed_registry("test-volume-registry", taken, ["kg_taken"])
+  _seed_registry("test-volume-registry", free, ["kg_free"])
+
+  real_claim = gvm.claim_volume
+  first = {"seen": False}
+
+  def claim_but_lose_the_first(volume_id, iid):
+    """Simulate a concurrent winner taking whichever volume we try first."""
+    if not first["seen"]:
+      first["seen"] = True
+      real_claim(volume_id, "i-someone-else")
+      return False
+    return real_claim(volume_id, iid)
+
+  with patch.object(gvm, "claim_volume", side_effect=claim_but_lose_the_first):
+    result = gvm.handle_instance_launch(
+      {"instance_id": instance_id, "node_type": "writer", "tier": "ladybug-standard"}
+    )
+
+  assert result["statusCode"] == 200
+  # It attached the volume it could actually get, not the contested one.
+  assert result["volume_id"] in {taken, free}
+  assert _registry_item(result["volume_id"])["instance_id"] == instance_id
+  assert _registry_item(result["volume_id"])["status"] == "attached"
+
+
+def test_attach_failure_releases_the_claim(gvm):
+  """A failed attach must return the volume to the pool, not strand it."""
+  instance_id = _create_test_instance()
+  volume_id = _create_test_volume()
+  _seed_registry("test-volume-registry", volume_id, ["kg_a"])
+
+  with patch.object(
+    gvm, "attach_and_register_volume", side_effect=RuntimeError("attach exploded")
+  ):
+    with pytest.raises(RuntimeError):
+      gvm.handle_instance_launch(
+        {"instance_id": instance_id, "node_type": "writer", "tier": "ladybug-standard"}
+      )
+
+  item = _registry_item(volume_id)
+  assert item["status"] == "available"
+  assert "claimed_at" not in item
+
+
+def test_release_claim_will_not_undo_someone_elses_claim(gvm):
+  volume_id = _create_test_volume()
+  _seed_registry("test-volume-registry", volume_id, [])
+
+  gvm.claim_volume(volume_id, "i-owner")
+  gvm.release_claim(volume_id, "i-not-the-owner")
+
+  item = _registry_item(volume_id)
+  assert item["status"] == "claiming"
+  assert item["instance_id"] == "i-owner"
+
+
+def test_reclaim_stale_claims_frees_a_stranded_volume(gvm):
+  """A claim whose Lambda died must not hide the volume forever.
+
+  Scans filter on `available`, so without this sweep a stranded claim takes the
+  volume — and the graph it holds — out of circulation permanently.
+  """
+  volume_id = _create_test_volume()
+  _seed_registry("test-volume-registry", volume_id, ["kg_stranded"])
+  gvm.claim_volume(volume_id, "i-died")
+
+  stale = (
+    datetime.now(UTC) - timedelta(seconds=gvm.STALE_CLAIM_SECONDS + 60)
+  ).isoformat()
+  ddb = boto3.resource("dynamodb", region_name="us-east-1")
+  ddb.Table("test-volume-registry").update_item(
+    Key={"volume_id": volume_id},
+    UpdateExpression="SET claimed_at = :t",
+    ExpressionAttributeValues={":t": stale},
+  )
+
+  assert gvm.reclaim_stale_claims("us-east-1c", "ladybug-standard") == 1
+
+  item = _registry_item(volume_id)
+  assert item["status"] == "available"
+  assert item["databases"] == ["kg_stranded"]
+
+
+def test_reclaim_leaves_a_fresh_claim_alone(gvm):
+  """An in-flight attach must never be stolen out from under itself."""
+  volume_id = _create_test_volume()
+  _seed_registry("test-volume-registry", volume_id, [])
+  gvm.claim_volume(volume_id, "i-still-working")
+
+  assert gvm.reclaim_stale_claims("us-east-1c", "ladybug-standard") == 0
+  assert _registry_item(volume_id)["status"] == "claiming"
+
+
+def test_ordered_candidates_preserves_preference_order(gvm):
+  """Matching databases first, then any data, then empty — unchanged from before."""
+  empty = {"volume_id": "vol-empty", "databases": []}
+  other_data = {"volume_id": "vol-other", "databases": ["kg_other"]}
+  matching = {"volume_id": "vol-match", "databases": ["kg_mine"]}
+
+  ordered = gvm.ordered_volume_candidates([empty, other_data, matching], ["kg_mine"])
+
+  assert [v["volume_id"] for v, _ in ordered] == [
+    "vol-match",
+    "vol-other",
+    "vol-empty",
+  ]
+  # The empty volume registers the caller's databases; the others keep their own.
+  assert ordered[0][1] == ["kg_mine"]
+  assert ordered[1][1] == ["kg_other"]
+  assert ordered[2][1] == ["kg_mine"]


### PR DESCRIPTION
## Summary

Volume selection on instance launch is a DynamoDB scan for `available` volumes, a deterministic sort, then `[0]`:

```python
volumes_with_data = [v for v in valid_volumes if v.get("databases")]
volume = volumes_with_data[0]
return attach_and_register_volume(volume["volume_id"], instance_id, ...)
```

No conditional write. Two instances launching concurrently in the same AZ and tier see the same list, sort it identically, and pick the **same volume** — the determinism makes collision near-certain rather than occasional.

## What actually breaks

**Not data integrity.** `AttachVolume` is atomic server-side, so two instances never share a volume.

**The loser's boot.** It gets `VolumeInUse`, and the attach retry loop treats that as "the previous instance is still detaching" — retrying the *same* volume three times with a 30s sleep, never re-scanning. Under contention that volume is legitimately held and will never free, so the instance burns ~60s and raises.

That retry is correct for the race it was written for (the 2026-05-08 incident: a replacement instance racing its own volume's detach). It's simply the wrong remedy for claim contention.

## The fix

Volumes are claimed with a conditional update gated on `status = available`, moving to `claiming` before any attach. A caller that loses advances to the next candidate rather than failing — `ordered_volume_candidates` now returns the full preference list (matching databases → any data → empty, **ordering unchanged**) instead of only the best, so there is something to advance to. Exhausting the list falls through to creating a new volume, as before.

Failure paths return the volume to the pool:

- A raised attach releases its own claim.
- `reclaim_stale_claims` sweeps anything stranded in `claiming` past `STALE_CLAIM_SECONDS` (default 900 — comfortably above the attach path's `instance_running` waiter, `volume_available` waiter, and retries) before each scan. Without it, a claim whose Lambda died would hide its volume from every future scan permanently, since they filter on `available` — stranding the graph with it.

`VolumeClaimContention` is published on each lost claim. At `MaxBatchSize: 1` this should sit at zero outside scale-out overlap; a non-zero baseline would say the race is already live at the current fleet size, which is worth knowing before concurrency is raised.

## Compatibility of the new state

`claiming` is inert to other consumers. `graph_volume_monitor`'s reconciliation branches all gate on `status = attached`, so a claiming volume falls through them untouched — and the table already carries a comparable intermediate state (`expanding`) using the same conditional-write pattern.

## Why now, and why alone

This is a **prerequisite, not a feature**. Raising `MaxBatchSize` above 1, or moving the fleet roll to an ASG instance refresh with `MinHealthyPercentage`, both replace instances concurrently and would have turned this race from rare into routine.

Batch size is deliberately **left at 1**. The claim path soaks in production first — exercised only by scale-out and spot-reclaim overlap — so its first real test isn't a ten-instance roll across ten customers' graphs. Parallelism becomes a separate decision, and by then the contention metric will have said how often this fires today.

It also earns its place independently: the race is live now, just rare at six instances.

## Testing

`uv run pytest tests/lambda/` — **37 passed**. `just test-code` clean.

Nine new tests: claim wins and marks `claiming`; loses to an earlier claim; loses to an attached volume; launch falls through to the next candidate when a claim is lost; attach failure releases the claim; release cannot undo another instance's claim; stale claims are reclaimed; fresh claims are left alone; candidate ordering is unchanged.