### PR TITLE
Reconcile the instance registry against live EC2

### DIFF
--- a/bin/lambda/graph_volume_monitor.py
+++ b/bin/lambda/graph_volume_monitor.py
@@ -34,6 +34,13 @@ ENVIRONMENT = os.environ.get("ENVIRONMENT", "staging")
 VOLUME_REGISTRY_TABLE = os.environ.get("VOLUME_REGISTRY_TABLE")
 INSTANCE_REGISTRY_TABLE = os.environ.get("INSTANCE_REGISTRY_TABLE")
 ALERT_TOPIC_ARN = os.environ.get("ALERT_TOPIC_ARN")
+# An instance writes its registry row before it is `running` and fully tagged,
+# so it is briefly invisible to discovery. Rows younger than this are never
+# reaped, which keeps reconciliation from deleting an instance mid-boot. Well
+# above the ~3.5 min observed writer boot.
+INSTANCE_REGISTRY_GRACE_SECONDS = int(
+  os.environ.get("INSTANCE_REGISTRY_GRACE_SECONDS", "1800")
+)
 EXPANSION_THRESHOLD = float(os.environ.get("EXPANSION_THRESHOLD", "0.8"))  # 80%
 EXPANSION_FACTOR = float(os.environ.get("EXPANSION_FACTOR", "1.5"))  # 50% increase
 # Floor on each expansion step. Kept meaningfully large because EBS enforces
@@ -110,6 +117,10 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
       return grow_filesystem_only(event)
     elif action == "fix_stuck_volumes":
       return fix_stuck_optimizing_volumes()
+    elif action == "sync_instance_registry":
+      # On-demand path so a known-stale registry can be reconciled without
+      # waiting for the next scheduled run.
+      return {"statusCode": 200, **sync_instance_registry()}
     else:
       return {"statusCode": 400, "error": f"Unknown action: {action}"}
   else:
@@ -146,6 +157,8 @@ def monitor_all_instances(expand_immediately: bool = False) -> dict[str, Any]:
     "volumes_expanded": [],
     "errors": [],
     "registry_synced": False,
+    "instance_registry_synced": False,
+    "stale_instances_removed": 0,
   }
 
   try:
@@ -157,6 +170,18 @@ def monitor_all_instances(expand_immediately: bool = False) -> dict[str, Any]:
     except Exception as e:
       logger.warning(f"Failed to sync volume registry: {e}")
       results["errors"].append(f"Registry sync failed: {e!s}")
+
+    # Separately guarded: the instance registry has no deregistration path of
+    # its own for volume-less nodes, so a failure here must not be masked by,
+    # or mask, the volume sync above.
+    try:
+      instance_sync = sync_instance_registry()
+      results["instance_registry_synced"] = True
+      results["stale_instances_removed"] = instance_sync["removed"]
+      logger.info(f"Instance registry synchronized: {instance_sync}")
+    except Exception as e:
+      logger.warning(f"Failed to sync instance registry: {e}")
+      results["errors"].append(f"Instance registry sync failed: {e!s}")
 
     # Discover all Graph instances
     instances = discover_lbug_instances()
@@ -1403,6 +1428,85 @@ def send_stuck_volume_alert(fixed_volumes: list[dict]):
 
   except Exception as e:
     logger.error(f"Failed to send stuck volume alert: {e}")
+
+
+def sync_instance_registry() -> dict[str, int]:
+  """Remove instance-registry rows whose EC2 instance no longer exists.
+
+  Writers deregister themselves twice over: the on-instance lifecycle script
+  marks `terminating` then `terminated`, and the termination lifecycle hook's
+  detachment Lambda deletes the row outright. Both of those hang off EBS volume
+  management, so an instance with no volume gets neither — shared replicas
+  register on boot (`ladybug-replica.sh`) and nothing ever removes them. They
+  also run on spot, so the rows accumulate at the reclaim rate rather than the
+  deploy rate.
+
+  Reconciling here rather than giving replicas their own lifecycle hook covers
+  every way an instance can vanish — graceful shutdown, spot reclaim, or host
+  failure — instead of only the ones that grant a shutdown window.
+
+  Rows younger than INSTANCE_REGISTRY_GRACE_SECONDS are left alone: an instance
+  registers itself before it is `running` and fully tagged, so it is briefly
+  invisible to discovery and must not be reaped during its own boot.
+  """
+  results = {"scanned": 0, "removed": 0, "skipped_recent": 0}
+
+  if not INSTANCE_REGISTRY_TABLE:
+    logger.info("No instance registry table configured, skipping sync")
+    return results
+
+  # Discovery is the same tag+state filter the monitor already trusts to
+  # enumerate live instances, so a row absent from it is absent from EC2.
+  live_instance_ids = {i["instance_id"] for i in discover_lbug_instances()}
+
+  table = dynamodb.Table(INSTANCE_REGISTRY_TABLE)
+  cutoff = (
+    datetime.now(UTC) - timedelta(seconds=INSTANCE_REGISTRY_GRACE_SECONDS)
+  ).isoformat()
+
+  rows: list[dict] = []
+  response = table.scan()
+  rows.extend(response.get("Items", []))
+  while "LastEvaluatedKey" in response:
+    response = table.scan(ExclusiveStartKey=response["LastEvaluatedKey"])
+    rows.extend(response.get("Items", []))
+
+  results["scanned"] = len(rows)
+
+  for row in rows:
+    instance_id = row.get("instance_id")
+    if not instance_id or instance_id in live_instance_ids:
+      continue
+
+    if (row.get("created_at") or "") > cutoff:
+      results["skipped_recent"] += 1
+      logger.info(f"Instance {instance_id} registered recently; leaving it alone")
+      continue
+
+    table.delete_item(Key={"instance_id": instance_id})
+    results["removed"] += 1
+    logger.warning(
+      f"Removed instance-registry row for {instance_id} "
+      f"(status={row.get('status')}, node_type={row.get('node_type')}) — "
+      "no matching live EC2 instance"
+    )
+
+  if results["removed"]:
+    try:
+      cloudwatch.put_metric_data(
+        Namespace=f"RoboSystems/Graph/{ENVIRONMENT}",
+        MetricData=[
+          {
+            "MetricName": "StaleInstanceRegistryEntries",
+            "Value": results["removed"],
+            "Unit": "Count",
+          }
+        ],
+      )
+    except Exception as e:
+      logger.warning(f"Failed to publish stale instance registry metric: {e}")
+
+  return results
 
 
 def sync_volume_registry():

--- a/tests/lambda/conftest.py
+++ b/tests/lambda/conftest.py
@@ -35,6 +35,9 @@ def aws_env(monkeypatch):
   monkeypatch.setenv("ENVIRONMENT", "test")
   monkeypatch.setenv("VOLUME_REGISTRY_TABLE", "test-volume-registry")
   monkeypatch.setenv("GRAPH_REGISTRY_TABLE", "test-graph-registry")
+  monkeypatch.setenv(
+    "INSTANCE_REGISTRY_TABLE", "robosystems-graph-test-instance-registry"
+  )
   monkeypatch.setenv("ALERT_TOPIC_ARN", "arn:aws:sns:us-east-1:123456789012:test-topic")
   monkeypatch.setenv(
     "VOLUME_MANAGER_FUNCTION_ARN",

--- a/tests/lambda/test_graph_volume_monitor.py
+++ b/tests/lambda/test_graph_volume_monitor.py
@@ -7,6 +7,8 @@ still-awake shared master's wake health-gate. `mark_volume_attached` resets
 a row a detach has already moved to 'available'.
 """
 
+from datetime import UTC, datetime, timedelta
+
 import boto3
 import pytest
 
@@ -90,3 +92,142 @@ class TestTierVolumeCeiling:
       assert limit == GraphTierConfig.get_instance_storage_limit_gb(
         tier, "production"
       ), f"{tier}: Lambda says {limit}, graph.yml disagrees"
+
+
+# ---------------------------------------------------------------------------
+# Instance registry reconciliation
+#
+# Writers deregister twice over (on-instance lifecycle script + the termination
+# hook's detachment Lambda), but both hang off EBS volume management — so
+# volume-less nodes get neither. Shared replicas register on boot and nothing
+# ever removes them, and they run on spot, so rows accumulate at the reclaim
+# rate. Reconciling from EC2 covers every termination path, graceful or not.
+# ---------------------------------------------------------------------------
+
+INSTANCE_TABLE = "robosystems-graph-test-instance-registry"
+
+
+def _put_instance(
+  instance_id: str,
+  status: str = "healthy",
+  node_type: str = "shared_replica",
+  created_at: str | None = None,
+) -> None:
+  ddb = boto3.resource("dynamodb", region_name="us-east-1")
+  ddb.Table(INSTANCE_TABLE).put_item(
+    Item={
+      "instance_id": instance_id,
+      "status": status,
+      "node_type": node_type,
+      "created_at": created_at or (datetime.now(UTC) - timedelta(days=1)).isoformat(),
+    }
+  )
+
+
+def _instance_rows() -> set[str]:
+  ddb = boto3.resource("dynamodb", region_name="us-east-1")
+  return {i["instance_id"] for i in ddb.Table(INSTANCE_TABLE).scan().get("Items", [])}
+
+
+def _launch_tagged_instance(role: str = "shared_replica") -> str:
+  """A running instance carrying the tags discover_lbug_instances filters on."""
+  ec2 = boto3.client("ec2", region_name="us-east-1")
+  ami_id = ec2.describe_images(Owners=["amazon"])["Images"][0]["ImageId"]
+  resp = ec2.run_instances(
+    ImageId=ami_id,
+    MinCount=1,
+    MaxCount=1,
+    InstanceType="r7g.large",
+    TagSpecifications=[
+      {
+        "ResourceType": "instance",
+        "Tags": [
+          {"Key": "Service", "Value": "RoboSystems"},
+          {"Key": "LadybugRole", "Value": role},
+          {"Key": "Environment", "Value": "test"},
+        ],
+      }
+    ],
+  )
+  return resp["Instances"][0]["InstanceId"]
+
+
+def test_sync_removes_row_for_an_instance_that_no_longer_exists(gvmon):
+  """The replica case: registered on boot, never deregistered, EC2 gone."""
+  _put_instance("i-longgone", status="healthy", node_type="shared_replica")
+
+  result = gvmon.sync_instance_registry()
+
+  assert result["removed"] == 1
+  assert "i-longgone" not in _instance_rows()
+
+
+def test_sync_keeps_a_live_instance(gvmon):
+  instance_id = _launch_tagged_instance()
+  _put_instance(instance_id, status="healthy")
+
+  result = gvmon.sync_instance_registry()
+
+  assert result["removed"] == 0
+  assert instance_id in _instance_rows()
+
+
+def test_sync_spares_a_recently_registered_instance(gvmon):
+  """An instance writes its row before it is running and tagged.
+
+  Without the grace window, reconciliation would delete a row out from under an
+  instance that is still booting.
+  """
+  _put_instance(
+    "i-stillbooting",
+    status="initializing",
+    created_at=datetime.now(UTC).isoformat(),
+  )
+
+  result = gvmon.sync_instance_registry()
+
+  assert result["removed"] == 0
+  assert result["skipped_recent"] == 1
+  assert "i-stillbooting" in _instance_rows()
+
+
+def test_sync_removes_terminated_writers_and_stale_replicas_together(gvmon):
+  """Mixed fleet: only rows without a live EC2 instance are removed."""
+  live = _launch_tagged_instance(role="writer")
+  _put_instance(live, status="healthy", node_type="writer")
+  _put_instance("i-deadwriter", status="terminated", node_type="writer")
+  _put_instance("i-deadreplica", status="healthy", node_type="shared_replica")
+
+  result = gvmon.sync_instance_registry()
+
+  assert result["removed"] == 2
+  assert _instance_rows() == {live}
+
+
+def test_sync_is_a_noop_without_a_configured_table(gvmon, monkeypatch):
+  monkeypatch.setattr(gvmon, "INSTANCE_REGISTRY_TABLE", None)
+  assert gvmon.sync_instance_registry() == {
+    "scanned": 0,
+    "removed": 0,
+    "skipped_recent": 0,
+  }
+
+
+def test_handler_exposes_sync_on_demand(gvmon):
+  """Reconciling a known-stale registry shouldn't require waiting for the schedule."""
+  _put_instance("i-longgone")
+
+  result = gvmon.handler({"action": "sync_instance_registry"}, None)
+
+  assert result["statusCode"] == 200
+  assert result["removed"] == 1
+
+
+def test_monitor_all_reports_the_instance_sync(gvmon):
+  """A failure in one registry sync must not mask or be masked by the other."""
+  _put_instance("i-longgone")
+
+  result = gvmon.monitor_all_instances()
+
+  assert result["instance_registry_synced"] is True
+  assert result["stale_instances_removed"] == 1


### PR DESCRIPTION
## Summary

Two shared replicas terminated during the v1.6.15 rollout still read `status: healthy` in `robosystems-graph-prod-instance-registry`, pointing at instances that no longer exist:

```
i-07c987d513c480afc  → EC2: terminated   registry: healthy
i-0b1c755fe263e76aa  → EC2: terminated   registry: healthy
```

Nothing was going to clean them up.

## Why writers heal and replicas don't

Writers deregister **twice over**; replicas have **no** path at all.

| | Writers | Replicas |
|---|---|---|
| `graph-lifecycle.sh` marks `terminating` → `terminated` | installed by `ladybug-writer.sh:277-325` | **not installed** |
| `TerminationLifecycleHook` → detachment Lambda `delete_item` | `graph-ladybug.yaml:676` | **no hook in the template** |
| Registers on boot | yes | yes — `ladybug-replica.sh:193` |

Both writer paths hang off **EBS volume management**. The lifecycle script ships with the writer userdata; the hook exists to detach volumes safely, and registry cleanup was bolted onto it after the 2026-05-08 recovery (see the comment at `graph_volume_detachment.py:166`).

Replicas have no volume to detach, so they never needed a hook — and therefore never got the cleanup that rides on one. There's no safety net either: `graph_volume_monitor` reads `INSTANCE_REGISTRY_TABLE` but has never written to it.

**The root cause is the seam:** registry cleanup is a side effect of volume management rather than a first-class lifecycle concern, so anything volume-less is invisible to it.

## Impact, stated accurately

Narrow. Replica reads route through the **replica ALB** (`factory.py:426`), not the registry, and the only registry lookup that drives routing is `shared_master` discovery (`factory.py:502`) — which writers do maintain correctly. So this is capacity-reading and observability noise, **not** a dead-IP routing hazard.

But it grows without bound, and replicas run on spot (`SHARED_REPLICAS_SPOT_ENABLED_PROD=true`, weight 100), so rows accumulate at the **reclaim** rate rather than the deploy rate.

## The approach

Rather than giving replicas their own lifecycle hook, `sync_instance_registry` reconciles rows against the same tag+state discovery the monitor already trusts, removing any without a live instance.

That's deliberate: a hook binds cleanup to a *graceful* termination, which spot reclaim and host failure don't grant. Reconciling from EC2 covers every path an instance can take out of the fleet, and fixes the class rather than the one node type that exposed it.

**Grace window.** Rows younger than `INSTANCE_REGISTRY_GRACE_SECONDS` (default 1800, well above the ~3.5 min writer boot measured during the v1.6.15 roll) are never reaped — an instance writes its row *before* it is `running` and fully tagged, so it is briefly invisible to discovery and must not be deleted mid-boot.

**Wiring.** Runs in `monitor_all_instances` beside the existing volume sync, under its own `try/except` so neither sync masks the other's failure. Also exposed as a `sync_instance_registry` action, so a known-stale registry can be reconciled on demand rather than waiting for the schedule — which clears the two live rows on first invocation. Publishes `StaleInstanceRegistryEntries` when it removes anything.

## Testing

`uv run pytest tests/lambda/` — **44 passed**. `just test-code` clean.

Seven new tests: a vanished instance's row is removed; a live instance's is kept; a recently-registered row is spared; a mixed fleet removes only the dead; an unconfigured table is a no-op; the on-demand action works; and `monitor_all_instances` reports the result.

`INSTANCE_REGISTRY_TABLE` is now set in the lambda test conftest — the table was already created there, but the env var wasn't, so the module read `None`.