### PR TITLE
fix(registry): discover shared replicas by NodeType during reconciliation

### DIFF
--- a/bin/lambda/graph_volume_monitor.py
+++ b/bin/lambda/graph_volume_monitor.py
@@ -264,6 +264,34 @@ def discover_lbug_instances() -> list[dict]:
   return instances
 
 
+def discover_replica_instance_ids() -> set[str]:
+  """Enumerate running shared replicas for registry reconciliation.
+
+  Replica launch templates tag instances with `NodeType: shared_replica` and no
+  `LadybugRole` tag, so `discover_lbug_instances` cannot see them. They are
+  enumerated separately (rather than folded into that filter) so they stay out
+  of the volume-expansion loop — replicas carry no data volume to manage.
+  """
+  try:
+    response = ec2.describe_instances(
+      Filters=[
+        {"Name": "tag:Service", "Values": ["RoboSystems"]},
+        {"Name": "tag:NodeType", "Values": ["shared_replica"]},
+        {"Name": "instance-state-name", "Values": ["running"]},
+        {"Name": "tag:Environment", "Values": [ENVIRONMENT]},
+      ]
+    )
+  except Exception as e:
+    logger.error(f"Failed to discover shared replicas: {e}")
+    raise
+
+  return {
+    instance["InstanceId"]
+    for reservation in response["Reservations"]
+    for instance in reservation["Instances"]
+  }
+
+
 def check_and_expand_volume(instance: dict, expand_immediately: bool = False) -> dict:
   """Check a single instance and expand if needed"""
 
@@ -1455,9 +1483,11 @@ def sync_instance_registry() -> dict[str, int]:
     logger.info("No instance registry table configured, skipping sync")
     return results
 
-  # Discovery is the same tag+state filter the monitor already trusts to
-  # enumerate live instances, so a row absent from it is absent from EC2.
+  # Writers come from the same tag+state filter the monitor already trusts;
+  # shared replicas are tagged differently and need their own discovery. A row
+  # absent from the union is absent from EC2.
   live_instance_ids = {i["instance_id"] for i in discover_lbug_instances()}
+  live_instance_ids |= discover_replica_instance_ids()
 
   table = dynamodb.Table(INSTANCE_REGISTRY_TABLE)
   cutoff = (

--- a/tests/lambda/test_graph_volume_monitor.py
+++ b/tests/lambda/test_graph_volume_monitor.py
@@ -130,7 +130,18 @@ def _instance_rows() -> set[str]:
 
 
 def _launch_tagged_instance(role: str = "shared_replica") -> str:
-  """A running instance carrying the tags discover_lbug_instances filters on."""
+  """A running instance tagged the way the launch templates actually tag it.
+
+  Writers carry `LadybugRole` (graph-ladybug.yaml); shared replicas carry only
+  `NodeType: shared_replica` (graph-ladybug-replicas.yaml) — no `LadybugRole`.
+  Keeping the fake fleet faithful to the real tag scheme is what lets these
+  tests catch a discovery filter that can't see one of the node types.
+  """
+  role_tag = (
+    {"Key": "NodeType", "Value": "shared_replica"}
+    if role == "shared_replica"
+    else {"Key": "LadybugRole", "Value": role}
+  )
   ec2 = boto3.client("ec2", region_name="us-east-1")
   ami_id = ec2.describe_images(Owners=["amazon"])["Images"][0]["ImageId"]
   resp = ec2.run_instances(
@@ -143,7 +154,7 @@ def _launch_tagged_instance(role: str = "shared_replica") -> str:
         "ResourceType": "instance",
         "Tags": [
           {"Key": "Service", "Value": "RoboSystems"},
-          {"Key": "LadybugRole", "Value": role},
+          role_tag,
           {"Key": "Environment", "Value": "test"},
         ],
       }
@@ -192,16 +203,23 @@ def test_sync_spares_a_recently_registered_instance(gvmon):
 
 
 def test_sync_removes_terminated_writers_and_stale_replicas_together(gvmon):
-  """Mixed fleet: only rows without a live EC2 instance are removed."""
-  live = _launch_tagged_instance(role="writer")
-  _put_instance(live, status="healthy", node_type="writer")
+  """Mixed fleet: only rows without a live EC2 instance are removed.
+
+  The live replica is the regression case: it is visible only via its
+  `NodeType` tag, so a reconciler that discovers solely by `LadybugRole`
+  would reap it alongside the genuinely dead rows.
+  """
+  live_writer = _launch_tagged_instance(role="writer")
+  live_replica = _launch_tagged_instance(role="shared_replica")
+  _put_instance(live_writer, status="healthy", node_type="writer")
+  _put_instance(live_replica, status="healthy", node_type="shared_replica")
   _put_instance("i-deadwriter", status="terminated", node_type="writer")
   _put_instance("i-deadreplica", status="healthy", node_type="shared_replica")
 
   result = gvmon.sync_instance_registry()
 
   assert result["removed"] == 2
-  assert _instance_rows() == {live}
+  assert _instance_rows() == {live_writer, live_replica}
 
 
 def test_sync_is_a_noop_without_a_configured_table(gvmon, monkeypatch):


### PR DESCRIPTION
## Summary

The #961 instance-registry reconciler enumerates live EC2 instances by the `LadybugRole` tag, but replica launch templates tag instances with `NodeType: shared_replica` and never set `LadybugRole`. Live replicas are therefore invisible to discovery: once past the 30-minute boot grace, their registry rows are deleted on every 15-minute run, then partially recreated by the 5-minute health-check cron (`status` + `last_health_check` only — no `created_at`, so the grace check never spares them again). The result is a permanent delete/recreate loop, ghost partial rows in the admin instances view, and `StaleInstanceRegistryEntries` firing on every run.

Not yet live: #961 merged after v1.6.15 was cut, so the deployed Lambda predates the reconciler. This should land before the next release so the reconciler goes live correct. Verified against prod: both running replicas carry only `NodeType: shared_replica`, and the current registry rows are intact.

## Changes

- `sync_instance_registry` unions a `NodeType: shared_replica`-filtered discovery into its live set, kept separate from `discover_lbug_instances` so replicas stay out of the volume-expansion loop (they carry no data volume).
- Test fleet now tags fake instances the way the real launch templates do (writers → `LadybugRole`, replicas → `NodeType`); the prior helper tagged replicas with `LadybugRole: shared_replica`, mirroring the Lambda's assumption instead of CloudFormation reality, which is why the #961 tests passed.
- Mixed-fleet test now asserts a live replica survives reconciliation alongside a live writer while dead rows of both kinds are removed. Confirmed the updated tests fail against the pre-fix Lambda.

## Testing

- `uv run pytest tests/lambda/test_graph_volume_monitor.py` — 15 passed
- `just test-code` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)