### PR TITLE
fix(billing): make repository subscription lifecycle recoverable

### DIFF
--- a/robosystems/models/core/billing/subscription.py
+++ b/robosystems/models/core/billing/subscription.py
@@ -4,7 +4,7 @@ from datetime import UTC, datetime, timedelta
 from enum import Enum
 from typing import Optional
 
-from sqlalchemy import Column, DateTime, ForeignKey, Index, Integer, String
+from sqlalchemy import Column, DateTime, ForeignKey, Index, Integer, String, case
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Session
 
@@ -25,8 +25,18 @@ class SubscriptionStatus(str, Enum):
   UPGRADING = "upgrading"
   PAUSED = "paused"
   CANCELED = "canceled"
+  FAILED = "failed"
   PAST_DUE = "past_due"
   UNPAID = "unpaid"
+
+
+# Statuses that no longer represent a subscription in force. Rows in these
+# states must not block a new subscription to the same resource — a canceled
+# or payment-failed subscription is history, not a conflict.
+TERMINAL_SUBSCRIPTION_STATUSES = (
+  SubscriptionStatus.CANCELED.value,
+  SubscriptionStatus.FAILED.value,
+)
 
 
 class BillingInterval(str, Enum):
@@ -163,21 +173,33 @@ class BillingSubscription(Base):
     resource_id: str,
     org_id: str,
     session: Session,
+    exclude_statuses: tuple[str, ...] = (),
   ) -> Optional["BillingSubscription"]:
     """Get subscription for a specific resource and organization.
 
     This is particularly useful for shared repositories where multiple orgs
     can have separate subscriptions to the same resource.
+
+    Pass `exclude_statuses=TERMINAL_SUBSCRIPTION_STATUSES` when checking for
+    a *conflicting* subscription: canceled/failed rows are never deleted, and
+    an unfiltered lookup would treat that history as a live duplicate.
+
+    When several rows exist for the same resource (a canceled subscription
+    followed by a resubscribe), the one still in force wins, then recency —
+    so "the subscription" always resolves to the live row when there is one,
+    and to the most recent terminal row when there is not.
     """
-    return (
-      session.query(cls)
-      .filter(
-        cls.resource_type == resource_type,
-        cls.resource_id == resource_id,
-        cls.org_id == org_id,
-      )
-      .first()
+    query = session.query(cls).filter(
+      cls.resource_type == resource_type,
+      cls.resource_id == resource_id,
+      cls.org_id == org_id,
     )
+    if exclude_statuses:
+      query = query.filter(cls.status.notin_(exclude_statuses))
+    return query.order_by(
+      case((cls.status.in_(TERMINAL_SUBSCRIPTION_STATUSES), 1), else_=0),
+      cls.created_at.desc(),
+    ).first()
 
   @classmethod
   def get_by_resource_and_user(
@@ -186,6 +208,7 @@ class BillingSubscription(Base):
     resource_id: str,
     user_id: str,
     session: Session,
+    exclude_statuses: tuple[str, ...] = (),
   ) -> Optional["BillingSubscription"]:
     """Get subscription for a specific resource and user (looks up user's org first)."""
     from robosystems.models.core.org import OrgUser
@@ -200,6 +223,7 @@ class BillingSubscription(Base):
       resource_id=resource_id,
       org_id=membership.org_id,
       session=session,
+      exclude_statuses=exclude_statuses,
     )
 
   @classmethod

--- a/robosystems/operations/providers/payment_provider.py
+++ b/robosystems/operations/providers/payment_provider.py
@@ -685,19 +685,87 @@ class StripePaymentProvider(PaymentProvider):
       raise
 
   def cancel_subscription(self, subscription_id: str) -> None:
-    """Cancel a Stripe subscription immediately."""
+    """Cancel a Stripe subscription immediately.
+
+    Idempotent: a subscription that is already canceled or no longer exists
+    on Stripe's side counts as success, so callers can safely gate local
+    cancellation on this raising — a raise always means Stripe still has a
+    live subscription that will keep billing.
+    """
     try:
       self.stripe.Subscription.cancel(subscription_id)
       logger.info(
         f"Canceled Stripe subscription {subscription_id}",
         extra={"subscription_id": subscription_id},
       )
+    except self.stripe.error.InvalidRequestError as e:
+      if self._subscription_already_terminal(subscription_id):
+        logger.warning(
+          f"Stripe subscription {subscription_id} already canceled or missing; "
+          "treating cancel as success",
+          extra={"subscription_id": subscription_id},
+        )
+        return
+      logger.error(
+        f"Failed to cancel Stripe subscription {subscription_id}: {e}",
+        exc_info=True,
+      )
+      raise
     except Exception as e:
       logger.error(
         f"Failed to cancel Stripe subscription {subscription_id}: {e}",
         exc_info=True,
       )
       raise
+
+  def cancel_subscription_at_period_end(self, subscription_id: str) -> None:
+    """Flag a Stripe subscription to cancel when the current period ends.
+
+    Idempotent with the same contract as `cancel_subscription`: an
+    already-canceled or missing subscription counts as success.
+    """
+    try:
+      self.stripe.Subscription.modify(subscription_id, cancel_at_period_end=True)
+      logger.info(
+        f"Set Stripe subscription {subscription_id} to cancel at period end",
+        extra={"subscription_id": subscription_id},
+      )
+    except self.stripe.error.InvalidRequestError as e:
+      if self._subscription_already_terminal(subscription_id):
+        logger.warning(
+          f"Stripe subscription {subscription_id} already canceled or missing; "
+          "treating period-end cancel as success",
+          extra={"subscription_id": subscription_id},
+        )
+        return
+      logger.error(
+        f"Failed to set period-end cancel on Stripe subscription "
+        f"{subscription_id}: {e}",
+        exc_info=True,
+      )
+      raise
+    except Exception as e:
+      logger.error(
+        f"Failed to set period-end cancel on Stripe subscription "
+        f"{subscription_id}: {e}",
+        exc_info=True,
+      )
+      raise
+
+  def _subscription_already_terminal(self, subscription_id: str) -> bool:
+    """True when Stripe no longer has a live subscription to cancel.
+
+    Retrieval is the robust check — Stripe's InvalidRequestError covers both
+    'no such subscription' and 'already canceled', and message-matching on
+    those is brittle across API versions.
+    """
+    try:
+      subscription = self.stripe.Subscription.retrieve(subscription_id)
+      return subscription.status == "canceled"
+    except self.stripe.error.InvalidRequestError:
+      return True
+    except Exception:
+      return False
 
   def create_portal_session(self, customer_id: str, return_url: str) -> str:
     """Create a Stripe Customer Portal session for payment management."""

--- a/robosystems/routers/graphs/subscriptions.py
+++ b/robosystems/routers/graphs/subscriptions.py
@@ -25,6 +25,10 @@ from ...models.api.common import RESOURCE_ERROR_RESPONSES
 from ...models.core import User, UserRepository
 from ...models.core.billing import BillingAuditLog, BillingCustomer, BillingSubscription
 from ...models.core.billing.audit_log import BillingEventType
+from ...models.core.billing.subscription import (
+  TERMINAL_SUBSCRIPTION_STATUSES,
+  SubscriptionStatus,
+)
 
 logger = get_logger(__name__)
 
@@ -181,11 +185,15 @@ async def create_repository_subscription(
       )
 
     parent_repo_id = resolve_shared_repository_parent(graph_id)
+    # Only a subscription still in force conflicts. Canceled and failed rows
+    # are kept as history and must not block resubscribing — an unfiltered
+    # check here turned one declined card into a permanent 409.
     existing = BillingSubscription.get_by_resource_and_user(
       resource_type="repository",
       resource_id=parent_repo_id,
       user_id=current_user.id,
       session=db,
+      exclude_statuses=TERMINAL_SUBSCRIPTION_STATUSES,
     )
 
     if existing:
@@ -309,7 +317,7 @@ async def create_repository_subscription(
           },
           exc_info=True,
         )
-        subscription.status = "failed"
+        subscription.status = SubscriptionStatus.FAILED.value
         db.commit()
         raise HTTPException(
           status_code=402,
@@ -358,7 +366,7 @@ async def create_repository_subscription(
       # The subscription will be in a bad state - mark it as failed
       failed_sub = db.query(BillingSubscription).filter_by(id=subscription_id).first()
       if failed_sub:
-        failed_sub.status = "failed"
+        failed_sub.status = SubscriptionStatus.FAILED.value
         # Cancel Stripe subscription so the customer isn't charged
         if failed_sub.stripe_subscription_id:
           try:
@@ -510,7 +518,42 @@ async def _change_repository_plan(
       detail="Repository access record not found. Please contact support.",
     )
 
-  # Update DB first — if this fails, Stripe stays consistent
+  # Stripe first, DB second. The reverse order left an unrecoverable seam:
+  # update_plan commits, Stripe fails, and every retry dies on the
+  # "Already on this plan" check above — local state says the new plan while
+  # Stripe keeps billing the old price forever. This order converges instead:
+  # a Stripe failure changes nothing locally (clean 502, retry works), and a
+  # DB failure after Stripe succeeded leaves the retry path open, where
+  # re-applying the same price to the subscription is a no-op.
+  # Products/prices are keyed on the parent repository and the canonical
+  # plan name.
+  stripe_sub_id = subscription.stripe_subscription_id
+  if stripe_sub_id:
+    provider = get_payment_provider("stripe")
+    try:
+      new_stripe_price_id = provider.get_or_create_price(
+        plan_name=new_plan_tier,
+        resource_type="repository",
+        repository_id=parent_repo_id,
+      )
+      provider.change_subscription_price(
+        subscription_id=stripe_sub_id,
+        new_price_id=new_stripe_price_id,
+      )
+    except Exception as e:
+      logger.error(
+        f"Failed to change Stripe price for {graph_id} plan change: {e}",
+        extra={"subscription_id": subscription.id},
+        exc_info=True,
+      )
+      raise HTTPException(
+        status_code=502,
+        detail=(
+          "The payment provider could not apply the plan change. "
+          "No changes were made — please try again."
+        ),
+      )
+
   subscription.update_plan(new_plan_tier, new_price_cents, db)
 
   user_repo.upgrade_tier(
@@ -519,21 +562,6 @@ async def _change_repository_plan(
     new_price_cents=new_price_cents,
     new_credits=new_credits,
   )
-
-  # Update Stripe subscription if linked. Products/prices are keyed on the
-  # parent repository and the canonical plan name.
-  stripe_sub_id = subscription.stripe_subscription_id
-  if stripe_sub_id:
-    provider = get_payment_provider("stripe")
-    new_stripe_price_id = provider.get_or_create_price(
-      plan_name=new_plan_tier,
-      resource_type="repository",
-      repository_id=parent_repo_id,
-    )
-    provider.change_subscription_price(
-      subscription_id=stripe_sub_id,
-      new_price_id=new_stripe_price_id,
-    )
 
   # Audit log
   org_id = user_orgs[0].org_id
@@ -657,7 +685,11 @@ async def cancel_repository_subscription(
         ),
       )
 
-  # Stripe-side: full cancel for immediate, period-end via Subscription.modify.
+  # Stripe-side: full cancel for immediate, period-end otherwise. Both provider
+  # methods are idempotent (already-canceled/missing counts as success), so a
+  # raise here always means Stripe still has a live subscription that will
+  # keep billing — in which case the local cancel and access revocation must
+  # not proceed, or the customer pays for access they no longer have.
   # Default cancel does NOT prorate or refund.
   if subscription.stripe_subscription_id:
     try:
@@ -665,15 +697,19 @@ async def cancel_repository_subscription(
       if body.immediate:
         provider.cancel_subscription(subscription.stripe_subscription_id)
       else:
-        provider.stripe.Subscription.modify(
-          subscription.stripe_subscription_id,
-          cancel_at_period_end=True,
-        )
+        provider.cancel_subscription_at_period_end(subscription.stripe_subscription_id)
     except Exception as e:
       logger.error(
         f"Failed to cancel Stripe subscription for {graph_id}: {e}",
         extra={"subscription_id": subscription.id},
         exc_info=True,
+      )
+      raise HTTPException(
+        status_code=502,
+        detail=(
+          "The payment provider could not cancel the subscription. "
+          "No changes were made — please try again."
+        ),
       )
 
   subscription.cancel(db, immediate=body.immediate)

--- a/tests/models/core/billing/test_subscription.py
+++ b/tests/models/core/billing/test_subscription.py
@@ -720,3 +720,109 @@ class TestBillingSubscriptionIndexes:
     )
 
     assert len(active_subs) == 2
+
+
+class TestResubscribeLookups:
+  """Canceled/failed rows are kept as history and must neither block a new
+  subscription to the same resource nor shadow the live one in lookups.
+
+  An unfiltered `.first()` here is what turned one canceled repository
+  subscription (or one declined card) into a permanent 409 on resubscribe.
+  """
+
+  def _repo_sub(self, db_session, org_id, status: str | None = None):
+    sub = BillingSubscription.create_subscription(
+      org_id=org_id,
+      resource_type="repository",
+      resource_id="sec",
+      plan_name="starter",
+      base_price_cents=2900,
+      session=db_session,
+      billing_interval="monthly",
+    )
+    if status is not None:
+      sub.status = status
+      db_session.commit()
+    return sub
+
+  def test_terminal_rows_do_not_count_as_conflicts(
+    self, db_session: Session, test_user, test_org
+  ):
+    from robosystems.models.core.billing.subscription import (
+      TERMINAL_SUBSCRIPTION_STATUSES,
+    )
+
+    for status in TERMINAL_SUBSCRIPTION_STATUSES:
+      self._repo_sub(db_session, test_org.id, status=status)
+
+    conflict = BillingSubscription.get_by_resource_and_org(
+      resource_type="repository",
+      resource_id="sec",
+      org_id=test_org.id,
+      session=db_session,
+      exclude_statuses=TERMINAL_SUBSCRIPTION_STATUSES,
+    )
+
+    assert conflict is None
+
+  def test_live_row_still_counts_as_conflict(
+    self, db_session: Session, test_user, test_org
+  ):
+    from robosystems.models.core.billing.subscription import (
+      TERMINAL_SUBSCRIPTION_STATUSES,
+    )
+
+    self._repo_sub(db_session, test_org.id, status=SubscriptionStatus.ACTIVE.value)
+
+    conflict = BillingSubscription.get_by_resource_and_org(
+      resource_type="repository",
+      resource_id="sec",
+      org_id=test_org.id,
+      session=db_session,
+      exclude_statuses=TERMINAL_SUBSCRIPTION_STATUSES,
+    )
+
+    assert conflict is not None
+
+  def test_live_row_shadows_terminal_history(
+    self, db_session: Session, test_user, test_org
+  ):
+    """After a cancel-then-resubscribe, unfiltered lookups (status GET,
+    plan change, cancel) must resolve to the live subscription, not
+    whichever row the database happens to return first."""
+    self._repo_sub(db_session, test_org.id, status=SubscriptionStatus.CANCELED.value)
+    live = self._repo_sub(
+      db_session, test_org.id, status=SubscriptionStatus.ACTIVE.value
+    )
+
+    found = BillingSubscription.get_by_resource_and_org(
+      resource_type="repository",
+      resource_id="sec",
+      org_id=test_org.id,
+      session=db_session,
+    )
+
+    assert found is not None
+    assert found.id == live.id
+
+  def test_most_recent_terminal_row_when_none_live(
+    self, db_session: Session, test_user, test_org
+  ):
+    """With only history left, lookups return the most recent chapter of it —
+    so a status GET after a full cancel still reads 'canceled'."""
+    self._repo_sub(db_session, test_org.id, status=SubscriptionStatus.FAILED.value)
+    latest = self._repo_sub(
+      db_session, test_org.id, status=SubscriptionStatus.CANCELED.value
+    )
+    latest.created_at = latest.created_at + timedelta(seconds=5)
+    db_session.commit()
+
+    found = BillingSubscription.get_by_resource_and_org(
+      resource_type="repository",
+      resource_id="sec",
+      org_id=test_org.id,
+      session=db_session,
+    )
+
+    assert found is not None
+    assert found.id == latest.id

--- a/tests/operations/graph/test_subscription_edge_cases.py
+++ b/tests/operations/graph/test_subscription_edge_cases.py
@@ -39,6 +39,8 @@ class TestSubscriptionEdgeCases:
     ):
       # Mock no existing subscription
       mock_session.query.return_value.filter.return_value.first.return_value = None
+      # get_by_resource_and_org orders live-before-terminal, newest-first
+      mock_session.query.return_value.filter.return_value.order_by.return_value.first.return_value = None
 
       # Simulate unique constraint violation
       mock_session.commit.side_effect = IntegrityError(
@@ -72,6 +74,8 @@ class TestSubscriptionEdgeCases:
       return_value=plan_config,
     ):
       mock_session.query.return_value.filter.return_value.first.return_value = None
+      # get_by_resource_and_org orders live-before-terminal, newest-first
+      mock_session.query.return_value.filter.return_value.order_by.return_value.first.return_value = None
       mock_session.query.return_value.filter.return_value.count.return_value = 0
 
       result = subscription_service.create_graph_subscription(user_id, graph_id, "free")
@@ -117,6 +121,8 @@ class TestSubscriptionEdgeCases:
       return_value=plan_config,
     ):
       mock_session.query.return_value.filter.return_value.first.return_value = None
+      # get_by_resource_and_org orders live-before-terminal, newest-first
+      mock_session.query.return_value.filter.return_value.order_by.return_value.first.return_value = None
       mock_session.query.return_value.filter.return_value.count.return_value = 0
 
       result = subscription_service.create_graph_subscription(

--- a/tests/operations/graph/test_subscription_service.py
+++ b/tests/operations/graph/test_subscription_service.py
@@ -89,6 +89,8 @@ class TestGraphSubscriptionService:
     ):
       # Mock no existing subscription
       mock_session.query.return_value.filter.return_value.first.return_value = None
+      # get_by_resource_and_org orders live-before-terminal, newest-first
+      mock_session.query.return_value.filter.return_value.order_by.return_value.first.return_value = None
       mock_session.query.return_value.filter.return_value.count.return_value = 0
 
       result = subscription_service.create_graph_subscription(
@@ -120,6 +122,8 @@ class TestGraphSubscriptionService:
     ):
       # Mock existing subscription check (none exists)
       mock_session.query.return_value.filter.return_value.first.return_value = None
+      # get_by_resource_and_org orders live-before-terminal, newest-first
+      mock_session.query.return_value.filter.return_value.order_by.return_value.first.return_value = None
       mock_session.query.return_value.filter.return_value.count.return_value = 0
 
       # Call the method
@@ -147,11 +151,14 @@ class TestGraphSubscriptionService:
       "robosystems.operations.graph.subscription_service.BillingConfig.get_subscription_plan",
       return_value=plan_config,
     ):
-      # Mock existing subscription
+      # Mock existing subscription — get_by_resource_and_org orders
+      # live-before-terminal, newest-first, so the lookup chain includes
+      # order_by
       existing_sub = Mock(spec=BillingSubscription)
       mock_session.query.return_value.filter.return_value.first.return_value = (
         existing_sub
       )
+      mock_session.query.return_value.filter.return_value.order_by.return_value.first.return_value = existing_sub
 
       result = subscription_service.create_graph_subscription(user_id, graph_id)
 
@@ -183,6 +190,8 @@ class TestGraphSubscriptionService:
     ):
       # Mock no existing subscription
       mock_session.query.return_value.filter.return_value.first.return_value = None
+      # get_by_resource_and_org orders live-before-terminal, newest-first
+      mock_session.query.return_value.filter.return_value.order_by.return_value.first.return_value = None
       mock_session.commit.side_effect = SQLAlchemyError("Database error")
 
       with pytest.raises(SQLAlchemyError):

--- a/tests/operations/providers/test_payment_provider.py
+++ b/tests/operations/providers/test_payment_provider.py
@@ -160,11 +160,17 @@ class TestStripeSubscriptionOperations:
   @pytest.fixture
   def stripe_provider(self):
     """Create Stripe provider with mocked Stripe."""
+    import stripe as stripe_module
+
     with patch("robosystems.operations.providers.payment_provider.env"):
       with patch.object(StripePaymentProvider, "__init__", lambda self: None):
         provider = StripePaymentProvider()
         provider.stripe = Mock()
         provider.stripe.Subscription = Mock()
+        # cancel_subscription's idempotency check catches
+        # stripe.error.InvalidRequestError; except-clauses need the real
+        # exception classes, not Mock attributes.
+        provider.stripe.error = stripe_module.error
         return provider
 
   def test_create_subscription_success(self, stripe_provider):
@@ -565,3 +571,76 @@ class TestGraphPriceResolution:
 
     assert result == "price_99"
     stripe_provider.stripe.Price.create.assert_not_called()
+
+
+class TestStripeCancelIdempotency:
+  """Cancel must be idempotent so callers can gate local cancellation on it.
+
+  The contract: a raise always means Stripe still has a live subscription
+  that will keep billing. Already-canceled and missing subscriptions count
+  as success — failing those cases would permanently block a local cancel
+  that Stripe-side state has already satisfied.
+  """
+
+  @pytest.fixture
+  def stripe_provider(self):
+    import stripe as stripe_module
+
+    with patch("robosystems.operations.providers.payment_provider.env"):
+      with patch.object(StripePaymentProvider, "__init__", lambda self: None):
+        provider = StripePaymentProvider()
+        provider.stripe = Mock()
+        # Except-clauses need the real exception classes, not Mock attributes.
+        provider.stripe.error = stripe_module.error
+        return provider
+
+  def _invalid_request(self):
+    from stripe.error import InvalidRequestError
+
+    return InvalidRequestError("No such subscription", "id")
+
+  def test_cancel_success(self, stripe_provider):
+    stripe_provider.cancel_subscription("sub_1")
+    stripe_provider.stripe.Subscription.cancel.assert_called_once_with("sub_1")
+
+  def test_cancel_missing_subscription_counts_as_success(self, stripe_provider):
+    stripe_provider.stripe.Subscription.cancel.side_effect = self._invalid_request()
+    stripe_provider.stripe.Subscription.retrieve.side_effect = self._invalid_request()
+
+    stripe_provider.cancel_subscription("sub_gone")
+
+  def test_cancel_already_canceled_counts_as_success(self, stripe_provider):
+    stripe_provider.stripe.Subscription.cancel.side_effect = self._invalid_request()
+    stripe_provider.stripe.Subscription.retrieve.return_value = Mock(status="canceled")
+
+    stripe_provider.cancel_subscription("sub_already")
+
+  def test_cancel_failure_on_live_subscription_reraises(self, stripe_provider):
+    from stripe.error import InvalidRequestError
+
+    stripe_provider.stripe.Subscription.cancel.side_effect = self._invalid_request()
+    stripe_provider.stripe.Subscription.retrieve.return_value = Mock(status="active")
+
+    with pytest.raises(InvalidRequestError):
+      stripe_provider.cancel_subscription("sub_live")
+
+  def test_period_end_sets_flag(self, stripe_provider):
+    stripe_provider.cancel_subscription_at_period_end("sub_1")
+    stripe_provider.stripe.Subscription.modify.assert_called_once_with(
+      "sub_1", cancel_at_period_end=True
+    )
+
+  def test_period_end_missing_subscription_counts_as_success(self, stripe_provider):
+    stripe_provider.stripe.Subscription.modify.side_effect = self._invalid_request()
+    stripe_provider.stripe.Subscription.retrieve.side_effect = self._invalid_request()
+
+    stripe_provider.cancel_subscription_at_period_end("sub_gone")
+
+  def test_period_end_failure_on_live_subscription_reraises(self, stripe_provider):
+    from stripe.error import InvalidRequestError
+
+    stripe_provider.stripe.Subscription.modify.side_effect = self._invalid_request()
+    stripe_provider.stripe.Subscription.retrieve.return_value = Mock(status="active")
+
+    with pytest.raises(InvalidRequestError):
+      stripe_provider.cancel_subscription_at_period_end("sub_live")

--- a/tests/routers/graphs/test_subscriptions_router.py
+++ b/tests/routers/graphs/test_subscriptions_router.py
@@ -508,3 +508,180 @@ class TestChangeRepositoryPlan:
 
     assert exc.value.status_code == 500
     sub.update_plan.assert_not_called()
+
+
+class TestCancelStripeFailureHandling:
+  """A Stripe-side cancel failure must abort before any local mutation.
+
+  The old path logged the Stripe error and proceeded: the customer lost
+  access (and could never resubscribe) while Stripe kept billing them.
+  """
+
+  def _stripe_linked_subscription(self) -> Mock:
+    sub = Mock(spec=BillingSubscription)
+    sub.id = "sub_123"
+    sub.resource_type = "repository"
+    sub.resource_id = "sec"
+    sub.plan_name = "starter"
+    sub.billing_interval = "monthly"
+    sub.status = "active"
+    sub.base_price_cents = 999
+    sub.current_period_start = datetime(2026, 1, 1, tzinfo=UTC)
+    sub.current_period_end = datetime(2026, 2, 1, tzinfo=UTC)
+    sub.started_at = datetime(2026, 1, 1, tzinfo=UTC)
+    sub.canceled_at = None
+    sub.ends_at = None
+    sub.stripe_subscription_id = "sub_stripe_xyz"
+    sub.created_at = datetime(2026, 1, 1, tzinfo=UTC)
+    return sub
+
+  def _owner_org(self):
+    from robosystems.models.core import OrgRole
+
+    org = Mock()
+    org.org_id = "org_1"
+    org.role = OrgRole.OWNER
+    return org
+
+  @pytest.mark.asyncio
+  @patch("robosystems.operations.providers.payment_provider.get_payment_provider")
+  @patch(f"{MODULE}.UserRepository.get_by_user_and_repository")
+  @patch(f"{MODULE}.BillingAuditLog")
+  @patch(f"{MODULE}.BillingSubscription.get_by_resource_and_user")
+  async def test_stripe_cancel_failure_aborts_local_cancel(
+    self, mock_get_sub, _mock_audit, mock_get_repo, mock_get_provider
+  ):
+    user = MagicMock()
+    user.id = "user_123"
+    db = MagicMock()
+    sub = self._stripe_linked_subscription()
+    mock_get_sub.return_value = sub
+
+    provider = MagicMock()
+    provider.cancel_subscription.side_effect = Exception("stripe is down")
+    mock_get_provider.return_value = provider
+
+    with (
+      patch(f"{MODULE}.is_shared_repository", return_value=True),
+      patch(f"{MODULE}.resolve_shared_repository_parent", return_value="sec"),
+      patch(
+        "robosystems.models.core.OrgUser.get_user_orgs",
+        return_value=[self._owner_org()],
+      ),
+    ):
+      with pytest.raises(HTTPException) as exc:
+        await cancel_repository_subscription(
+          graph_id="sec",
+          body=CancelSubscriptionRequest(immediate=True, confirm="sec"),
+          current_user=user,
+          db=db,
+          _rate_limit=None,
+        )
+
+    assert exc.value.status_code == 502
+    sub.cancel.assert_not_called()
+    mock_get_repo.assert_not_called()
+
+  @pytest.mark.asyncio
+  @patch("robosystems.operations.providers.payment_provider.get_payment_provider")
+  @patch(f"{MODULE}.UserRepository.get_by_user_and_repository")
+  @patch(f"{MODULE}.BillingAuditLog")
+  @patch(f"{MODULE}.BillingSubscription.get_by_resource_and_user")
+  async def test_period_end_cancel_uses_idempotent_provider_method(
+    self, mock_get_sub, _mock_audit, mock_get_repo, mock_get_provider
+  ):
+    """Period-end cancel goes through the provider's idempotent method, not a
+    raw Subscription.modify the failure contract can't see through."""
+    user = MagicMock()
+    user.id = "user_123"
+    db = MagicMock()
+    sub = self._stripe_linked_subscription()
+    mock_get_sub.return_value = sub
+    mock_get_repo.return_value = None
+
+    provider = MagicMock()
+    mock_get_provider.return_value = provider
+
+    with (
+      patch(f"{MODULE}.is_shared_repository", return_value=True),
+      patch(f"{MODULE}.resolve_shared_repository_parent", return_value="sec"),
+      patch(
+        "robosystems.models.core.OrgUser.get_user_orgs",
+        return_value=[self._owner_org()],
+      ),
+    ):
+      await cancel_repository_subscription(
+        graph_id="sec",
+        body=CancelSubscriptionRequest(),
+        current_user=user,
+        db=db,
+        _rate_limit=None,
+      )
+
+    provider.cancel_subscription_at_period_end.assert_called_once_with("sub_stripe_xyz")
+    provider.cancel_subscription.assert_not_called()
+    sub.cancel.assert_called_once_with(db, immediate=False)
+
+
+class TestChangePlanStripeFirst:
+  """The plan change applies Stripe first: a payment-provider failure must
+  leave local state untouched so the retry path stays open.
+
+  DB-first left an unrecoverable seam — local rows on the new plan, Stripe
+  billing the old price, and every retry rejected by 'Already on this plan'.
+  """
+
+  @pytest.mark.asyncio
+  @patch("robosystems.operations.providers.payment_provider.get_payment_provider")
+  @patch(f"{MODULE}.BillingAuditLog")
+  @patch(f"{MODULE}.UserRepository.get_by_user_and_repository")
+  @patch(f"{MODULE}.BillingSubscription.get_by_resource_and_user")
+  async def test_stripe_price_change_failure_makes_no_local_changes(
+    self, mock_get_sub, mock_get_repo, _mock_audit, mock_get_provider
+  ):
+    from robosystems.models.api.billing.subscription import (
+      UpgradeSubscriptionRequest,
+    )
+    from robosystems.models.core import OrgRole
+    from robosystems.routers.graphs.subscriptions import _change_repository_plan
+
+    org = Mock()
+    org.org_id = "org_1"
+    org.role = OrgRole.OWNER
+
+    db = MagicMock()
+    user = MagicMock()
+    user.id = "user_123"
+
+    sub = Mock(spec=BillingSubscription)
+    sub.id = "sub_123"
+    sub.resource_type = "repository"
+    sub.resource_id = "sec"
+    sub.plan_name = "starter"
+    sub.status = "active"
+    sub.base_price_cents = 2900
+    sub.stripe_subscription_id = "sub_stripe_xyz"
+    mock_get_sub.return_value = sub
+
+    user_repo = Mock()
+    mock_get_repo.return_value = user_repo
+
+    provider = MagicMock()
+    provider.change_subscription_price.side_effect = Exception("stripe is down")
+    mock_get_provider.return_value = provider
+
+    with patch(
+      "robosystems.models.core.OrgUser.get_user_orgs",
+      return_value=[org],
+    ):
+      with pytest.raises(HTTPException) as exc:
+        await _change_repository_plan(
+          "sec",
+          UpgradeSubscriptionRequest(new_plan_name="advanced"),
+          user,
+          db,
+        )
+
+    assert exc.value.status_code == 502
+    sub.update_plan.assert_not_called()
+    user_repo.upgrade_tier.assert_not_called()


### PR DESCRIPTION
## Summary

Fixes three seams in the repository-subscription lifecycle where local state and Stripe could permanently diverge:

1. **Resubscribe deadlock** — the conflict check on `POST /v1/graphs/{repo}/subscription` matched subscription rows in any status. Canceled and payment-failed rows are kept as history, so one cancel (or one declined card) produced a permanent 409 on every subsequent attempt. Conflict checks now exclude terminal statuses (`canceled`, `failed`), and `get_by_resource_and_org` deterministically prefers the live row over history — so once a canceled row and a resubscribed row coexist, status reads, plan changes, and cancels all resolve to the subscription actually in force instead of whichever row the database returned first.

2. **Swallowed Stripe cancel** — a Stripe-side failure during cancel was logged and execution continued into the local cancel and access revocation: the customer lost access while Stripe kept billing, and since Stripe-side state never changed, no webhook would ever arrive to reconcile. The route now aborts with a 502 ("no changes were made") unless Stripe-side cancellation succeeded. The provider's cancel methods are idempotent — already-canceled or missing subscriptions count as success — so a raise always means Stripe still has a live subscription, which is exactly the case where proceeding locally is wrong. Period-end cancel moves off the raw `Subscription.modify` call onto the same contract.

3. **Plan-change ordering** — the plan change committed `update_plan`/`upgrade_tier` locally before calling Stripe, and a Stripe failure left every retry rejected by the "Already on this plan" check: local rows on the new plan, Stripe billing the old price, forever. The Stripe price change now runs first — a provider failure changes nothing locally (clean 502, retry works), and a local failure after Stripe succeeded leaves the retry path open, where re-applying the same price is a no-op.

Also adds `failed` (written by the provisioning failure paths since they landed) to the `SubscriptionStatus` enum.

## Testing

- New model tests: terminal rows don't block resubscribe, live row shadows history, most-recent-terminal fallback
- New provider tests: cancel idempotency contract (missing/already-canceled = success, live-subscription failure re-raises), period-end variant
- New router tests: Stripe cancel failure → 502 with no local mutation; period-end uses the idempotent provider method; Stripe price-change failure → 502 with `update_plan`/`upgrade_tier` untouched
- `just test-all`: 2789 passed (one unrelated flake in `test_incremental_materialize` passes in isolation); `just test-code` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)