### PR TITLE
fix(taxonomy): clear derived FK rows in cascade and structure removal

### DIFF
--- a/robosystems/operations/taxonomy_block/cascade.py
+++ b/robosystems/operations/taxonomy_block/cascade.py
@@ -21,13 +21,16 @@ from sqlalchemy.orm import Session
 
 from robosystems.models.extensions import (
   Association,
+  AssociationClassification,
   Element,
   ElementLabel,
   ElementReference,
   ElementTrait,
+  FactSet,
   Rule,
   Structure,
   Taxonomy,
+  VerificationResult,
 )
 from robosystems.models.extensions.roboledger.fact import Fact
 from robosystems.models.extensions.roboledger.line_item import LineItem
@@ -51,18 +54,43 @@ def preflight_delete(session: Session, taxonomy_id: str) -> DeletePreflight:
       select(Element.id).where(Element.taxonomy_id == taxonomy_id)
     ).all()
   ]
+  structure_ids = [
+    row[0]
+    for row in session.execute(
+      select(Structure.id).where(Structure.taxonomy_id == taxonomy_id)
+    ).all()
+  ]
 
-  if not element_ids:
+  if not element_ids and not structure_ids:
     return DeletePreflight()
 
-  fact_count = (
-    session.execute(select(Fact.id).where(Fact.element_id.in_(element_ids)))
-    .scalars()
-    .all()
-  )
+  # Facts die two ways: by referencing this taxonomy's elements, and by
+  # membership in a FactSet attached to one of its structures (report
+  # snapshots and standing text-block/metric sets cascade with their set,
+  # including snapshot copies of other taxonomies' concepts).
+  fact_predicates = []
+  if element_ids:
+    fact_predicates.append(Fact.element_id.in_(element_ids))
+  if structure_ids:
+    fact_predicates.append(
+      Fact.fact_set_id.in_(
+        select(FactSet.id).where(FactSet.structure_id.in_(structure_ids))
+      )
+    )
+  fact_clause = fact_predicates[0]
+  for pred in fact_predicates[1:]:
+    fact_clause = fact_clause | pred
+  fact_count = session.execute(select(Fact.id).where(fact_clause)).scalars().all()
+
+  if not element_ids:
+    return DeletePreflight(fact_count=len(fact_count))
 
   line_item_count = (
-    session.execute(select(LineItem.id).where(LineItem.element_id.in_(element_ids)))
+    session.execute(
+      select(LineItem.id).where(
+        LineItem.element_id.in_(element_ids) | LineItem.flow_element_id.in_(element_ids)
+      )
+    )
     .scalars()
     .all()
   )
@@ -113,12 +141,38 @@ def cascade_delete_taxonomy(
     ).all()
   ]
 
-  facts_deleted = 0
-  if cascade_facts and element_ids:
-    result = session.execute(delete(Fact).where(Fact.element_id.in_(element_ids)))
-    facts_deleted = result.rowcount or 0
+  fact_set_ids = []
+  if structure_ids:
+    fact_set_ids = (
+      session.execute(select(FactSet.id).where(FactSet.structure_id.in_(structure_ids)))
+      .scalars()
+      .all()
+    )
 
-  # Rules — those hosted by this taxonomy or targeting any of its atoms.
+  facts_deleted = 0
+  if cascade_facts:
+    if element_ids:
+      result = session.execute(delete(Fact).where(Fact.element_id.in_(element_ids)))
+      facts_deleted += result.rowcount or 0
+    if fact_set_ids:
+      # Snapshot copies of other taxonomies' concepts inside this taxonomy's
+      # FactSets — the element-keyed delete above can't see them.
+      result = session.execute(delete(Fact).where(Fact.fact_set_id.in_(fact_set_ids)))
+      facts_deleted += result.rowcount or 0
+
+  association_ids = []
+  if structure_ids:
+    association_ids = (
+      session.execute(
+        select(Association.id).where(Association.structure_id.in_(structure_ids))
+      )
+      .scalars()
+      .all()
+    )
+
+  # Rules — those hosted by this taxonomy or targeting any of its atoms
+  # (including rules hosted elsewhere that target this taxonomy's
+  # associations, whose FK would otherwise block the association delete).
   rule_predicates = [
     Rule.taxonomy_id == taxonomy_id,
     Rule.target_taxonomy_id == taxonomy_id,
@@ -127,12 +181,45 @@ def cascade_delete_taxonomy(
     rule_predicates.append(Rule.target_structure_id.in_(structure_ids))
   if element_ids:
     rule_predicates.append(Rule.target_element_id.in_(element_ids))
+  if association_ids:
+    rule_predicates.append(Rule.target_association_id.in_(association_ids))
   rule_clause = rule_predicates[0]
   for pred in rule_predicates[1:]:
     rule_clause = rule_clause | pred
-  session.execute(delete(Rule).where(rule_clause))
+  rule_ids = session.execute(select(Rule.id).where(rule_clause)).scalars().all()
 
-  # Associations inside this taxonomy's structures.
+  # Verification results FK the rules and structures with no ON DELETE —
+  # they're derived evaluation records and always cascade, or the Rule and
+  # Structure deletes below die on the constraint.
+  vr_predicates = []
+  if rule_ids:
+    vr_predicates.append(VerificationResult.rule_id.in_(rule_ids))
+  if structure_ids:
+    vr_predicates.append(VerificationResult.structure_id.in_(structure_ids))
+  if vr_predicates:
+    vr_clause = vr_predicates[0]
+    for pred in vr_predicates[1:]:
+      vr_clause = vr_clause | pred
+    session.execute(delete(VerificationResult).where(vr_clause))
+
+  if rule_ids:
+    session.execute(delete(Rule).where(Rule.id.in_(rule_ids)))
+
+  # FactSets attached to this taxonomy's structures — standing disclosure/
+  # metric sets and report snapshots. Any facts still inside them cascade at
+  # the DB level (facts.fact_set_id is ON DELETE CASCADE); when
+  # cascade_facts=False the preflight already guaranteed there are none.
+  if fact_set_ids:
+    session.execute(delete(FactSet).where(FactSet.id.in_(fact_set_ids)))
+
+  # Associations inside this taxonomy's structures — classification rows FK
+  # the associations with no ON DELETE, so they go first.
+  if association_ids:
+    session.execute(
+      delete(AssociationClassification).where(
+        AssociationClassification.association_id.in_(association_ids)
+      )
+    )
   if structure_ids:
     session.execute(
       delete(Association).where(Association.structure_id.in_(structure_ids))

--- a/robosystems/operations/taxonomy_block/update_apply.py
+++ b/robosystems/operations/taxonomy_block/update_apply.py
@@ -20,15 +20,18 @@ from sqlalchemy.orm import Session
 from robosystems.models.api.taxonomy_block import UpdateTaxonomyBlockRequest
 from robosystems.models.extensions import (
   Association,
+  AssociationClassification,
   Element,
   ElementLabel,
   ElementReference,
   ElementTrait,
+  FactSet,
   Rule,
   Structure,
   Taxonomy,
   VerificationResult,
 )
+from robosystems.models.extensions.roboledger.fact import Fact
 from robosystems.operations.taxonomy_block._helpers import structure_from_request
 from robosystems.operations.taxonomy_block.rule_persistence import (
   persist_tenant_rules,
@@ -412,32 +415,47 @@ def apply_structures_to_remove(
   taxonomy: Taxonomy,
   payload: UpdateTaxonomyBlockRequest,
 ) -> None:
-  """Delete structures + their rules + cascading associations.
+  """Delete structures + their derived rows, in FK-dependency order.
 
-  Verification results FK both the structures and their rules with no
-  ON DELETE, so they go first — by ``structure_id`` and by ``rule_id``
-  of the structures' rules.
+  Verification results FK the structures and their rules, fact sets FK
+  the structures, classification rows FK the associations — all with no
+  ON DELETE — so each goes before its referent (same order as
+  ``delete_schedule``, the sibling structure-removal surface). Facts
+  stamped to the structure and facts inside its fact sets are derived
+  artifacts of the structure and are removed with it.
   """
   if not payload.structures_to_remove:
     return
 
   ids = list(payload.structures_to_remove)
-  structure_rule_ids = select(Rule.id).where(
-    Rule.target_kind == "structure", Rule.target_structure_id.in_(ids)
+  association_ids = (
+    session.execute(select(Association.id).where(Association.structure_id.in_(ids)))
+    .scalars()
+    .all()
   )
-  session.execute(
-    delete(VerificationResult).where(
-      or_(
-        VerificationResult.structure_id.in_(ids),
-        VerificationResult.rule_id.in_(structure_rule_ids),
+  rule_filters = [(Rule.target_kind == "structure") & Rule.target_structure_id.in_(ids)]
+  if association_ids:
+    rule_filters.append(Rule.target_association_id.in_(association_ids))
+  rule_ids = session.execute(select(Rule.id).where(or_(*rule_filters))).scalars().all()
+
+  vr_filters = [VerificationResult.structure_id.in_(ids)]
+  if rule_ids:
+    vr_filters.append(VerificationResult.rule_id.in_(rule_ids))
+  session.execute(delete(VerificationResult).where(or_(*vr_filters)))
+
+  session.execute(delete(Fact).where(Fact.structure_id.in_(ids)))
+  # Facts still inside these sets cascade at the DB level
+  # (facts.fact_set_id is ON DELETE CASCADE).
+  session.execute(delete(FactSet).where(FactSet.structure_id.in_(ids)))
+
+  if rule_ids:
+    session.execute(delete(Rule).where(Rule.id.in_(rule_ids)))
+  if association_ids:
+    session.execute(
+      delete(AssociationClassification).where(
+        AssociationClassification.association_id.in_(association_ids)
       )
     )
-  )
-  session.execute(
-    delete(Rule).where(
-      Rule.target_kind == "structure", Rule.target_structure_id.in_(ids)
-    )
-  )
   session.execute(delete(Association).where(Association.structure_id.in_(ids)))
   session.execute(delete(Structure).where(Structure.id.in_(ids)))
   session.flush()

--- a/tests/operations/taxonomy_block/test_cascade_fk_integrity.py
+++ b/tests/operations/taxonomy_block/test_cascade_fk_integrity.py
@@ -1,0 +1,259 @@
+"""FK-integrity regression tests for taxonomy cascade deletion.
+
+The disclosure substrate (#885/#889) attaches derived rows to tenant
+taxonomy structures — VerificationResults FK the rules and structures,
+FactSets FK the structures, AssociationClassifications FK the
+associations, all with no ON DELETE. ``cascade_delete_taxonomy``
+predates those tables, so deleting a taxonomy that had been used for a
+disclosure note (bound text block or published report) died on the
+first constraint with no API path to clear the blockers. Same hole in
+``apply_structures_to_remove`` for update-driven structure removal.
+
+These tests run against a real PostgreSQL schema (mocked sessions
+can't violate constraints, which is how the bug survived the existing
+delete tests).
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import date
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import Session, sessionmaker
+
+import robosystems.models.extensions  # noqa: F401  (register models on ExtensionsBase)
+from robosystems.db.extensions import ExtensionsBase
+from robosystems.models.api.taxonomy_block import UpdateTaxonomyBlockRequest
+from robosystems.models.extensions import (
+  Association,
+  AssociationClassification,
+  Classification,
+  Element,
+  FactSet,
+  Rule,
+  Structure,
+  Taxonomy,
+  VerificationResult,
+)
+from robosystems.models.extensions.roboledger.fact import Fact
+from robosystems.operations.taxonomy_block.cascade import (
+  cascade_delete_taxonomy,
+  preflight_delete,
+)
+from robosystems.operations.taxonomy_block.update_apply import (
+  apply_structures_to_remove,
+)
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture()
+def ext_session():
+  """Extensions schema in the test Postgres DB, one throwaway schema per test.
+
+  FK constraints only exist (and only bite) on a real database; the schema
+  name is unique so parallel workers can't collide.
+  """
+  database_url = os.environ.get("TEST_DATABASE_URL")
+  if not database_url:
+    pytest.skip("TEST_DATABASE_URL not configured")
+
+  schema = f"ext_cascade_{uuid.uuid4().hex[:12]}"
+  engine = create_engine(database_url)
+  with engine.begin() as conn:
+    conn.execute(text(f'CREATE SCHEMA "{schema}"'))
+
+  session_factory = sessionmaker(bind=engine)
+  session = session_factory()
+  session.execute(text(f'SET search_path TO "{schema}"'))
+  ExtensionsBase.metadata.create_all(bind=session.connection())
+  session.commit()
+  session.execute(text(f'SET search_path TO "{schema}"'))
+
+  try:
+    yield session
+  finally:
+    session.rollback()
+    session.close()
+    with engine.begin() as conn:
+      conn.execute(text(f'DROP SCHEMA "{schema}" CASCADE'))
+    engine.dispose()
+
+
+def _build_disclosure_taxonomy(session: Session) -> dict:
+  """A tenant taxonomy exercising every FK the cascade must clear."""
+  taxonomy = Taxonomy(name="Notes", taxonomy_type="reporting_extension")
+  session.add(taxonomy)
+  session.flush()
+
+  structure = Structure(name="Note 1", block_type="policy", taxonomy_id=taxonomy.id)
+  session.add(structure)
+  session.flush()
+
+  parent = Element(name="NotePolicy", taxonomy_id=taxonomy.id)
+  child = Element(name="NoteDetail", taxonomy_id=taxonomy.id)
+  session.add_all([parent, child])
+  session.flush()
+
+  association = Association(
+    structure_id=structure.id,
+    from_element_id=parent.id,
+    to_element_id=child.id,
+  )
+  session.add(association)
+  session.flush()
+
+  classification = Classification(
+    category="concept_arrangement", identifier=f"cap-{uuid.uuid4().hex[:8]}"
+  )
+  session.add(classification)
+  session.flush()
+  session.add(
+    AssociationClassification(
+      association_id=association.id, classification_id=classification.id
+    )
+  )
+
+  rule = Rule(
+    taxonomy_id=taxonomy.id,
+    rule_category="AutomatedAccountingAndReportingChecks",
+    rule_pattern="RollUp",
+    rule_expression="parent == sum(children)",
+    target_kind="structure",
+    target_structure_id=structure.id,
+  )
+  session.add(rule)
+  session.flush()
+
+  session.add(
+    VerificationResult(rule_id=rule.id, structure_id=structure.id, status="pass")
+  )
+
+  fact_set = FactSet(
+    structure_id=structure.id,
+    period_end=date(2026, 6, 30),
+    factset_type="disclosure",
+    entity_id="ent_1",
+  )
+  fact_set.provenance = {"origin": "text_block", "document_id": "doc_1"}
+  session.add(fact_set)
+  session.flush()
+
+  fact = Fact(
+    element_id=child.id,
+    string_value="Accounting policy text",
+    fact_type="Nonnumeric",
+    value_type="inline",
+    period_end=date(2026, 6, 30),
+    period_type="duration",
+    entity_id="ent_1",
+    structure_id=structure.id,
+    fact_set_id=fact_set.id,
+  )
+  session.add(fact)
+  session.commit()
+
+  return {
+    "taxonomy": taxonomy,
+    "structure": structure,
+    "elements": [parent, child],
+    "fact_set": fact_set,
+    "fact": fact,
+  }
+
+
+class TestCascadeDeleteTaxonomy:
+  def test_deletes_taxonomy_with_full_disclosure_substrate(self, ext_session):
+    built = _build_disclosure_taxonomy(ext_session)
+    taxonomy_id = built["taxonomy"].id
+
+    facts_deleted = cascade_delete_taxonomy(
+      ext_session, taxonomy_id, cascade_facts=True
+    )
+    ext_session.commit()
+
+    assert facts_deleted == 1
+    assert ext_session.get(Taxonomy, taxonomy_id) is None
+    assert ext_session.query(Structure).count() == 0
+    assert ext_session.query(VerificationResult).count() == 0
+    assert ext_session.query(FactSet).count() == 0
+    assert ext_session.query(Fact).count() == 0
+    assert ext_session.query(AssociationClassification).count() == 0
+    assert ext_session.query(Rule).count() == 0
+
+  def test_derived_rows_never_block_when_no_facts(self, ext_session):
+    """VerificationResults and an empty standing FactSet are derived records;
+    they cascade even with cascade_facts=False."""
+    built = _build_disclosure_taxonomy(ext_session)
+    ext_session.delete(built["fact"])
+    ext_session.commit()
+
+    facts_deleted = cascade_delete_taxonomy(
+      ext_session, built["taxonomy"].id, cascade_facts=False
+    )
+    ext_session.commit()
+
+    assert facts_deleted == 0
+    assert ext_session.query(FactSet).count() == 0
+    assert ext_session.query(VerificationResult).count() == 0
+
+  def test_preflight_counts_snapshot_facts_of_foreign_elements(self, ext_session):
+    """A report snapshot inside this taxonomy's set can copy another
+    taxonomy's concepts; those facts die with the set, so preflight must
+    count them toward the cascade_facts consent gate."""
+    built = _build_disclosure_taxonomy(ext_session)
+
+    other_tax = Taxonomy(name="Other", taxonomy_type="chart_of_accounts")
+    ext_session.add(other_tax)
+    ext_session.flush()
+    foreign_element = Element(name="ForeignConcept", taxonomy_id=other_tax.id)
+    ext_session.add(foreign_element)
+    ext_session.flush()
+
+    ext_session.add(
+      Fact(
+        element_id=foreign_element.id,
+        value=100,
+        period_end=date(2026, 6, 30),
+        period_type="duration",
+        entity_id="ent_1",
+        fact_set_id=built["fact_set"].id,
+      )
+    )
+    ext_session.commit()
+
+    preflight = preflight_delete(ext_session, built["taxonomy"].id)
+    assert preflight.fact_count == 2
+
+    facts_deleted = cascade_delete_taxonomy(
+      ext_session, built["taxonomy"].id, cascade_facts=True
+    )
+    ext_session.commit()
+
+    assert facts_deleted == 2
+    assert ext_session.get(Element, foreign_element.id) is not None
+    assert ext_session.get(Taxonomy, other_tax.id) is not None
+
+
+class TestApplyStructuresToRemove:
+  def test_removes_structure_with_disclosure_substrate(self, ext_session):
+    built = _build_disclosure_taxonomy(ext_session)
+    structure_id = built["structure"].id
+
+    payload = UpdateTaxonomyBlockRequest(
+      taxonomy_id=built["taxonomy"].id,
+      structures_to_remove=[structure_id],
+    )
+    apply_structures_to_remove(ext_session, built["taxonomy"], payload)
+    ext_session.commit()
+
+    assert ext_session.get(Structure, structure_id) is None
+    assert ext_session.query(FactSet).count() == 0
+    assert ext_session.query(Fact).count() == 0
+    assert ext_session.query(VerificationResult).count() == 0
+    assert ext_session.query(AssociationClassification).count() == 0
+    assert ext_session.get(Taxonomy, built["taxonomy"].id) is not None
+    assert ext_session.get(Element, built["elements"][0].id) is not None

--- a/tests/operations/taxonomy_block/test_update.py
+++ b/tests/operations/taxonomy_block/test_update.py
@@ -460,13 +460,21 @@ class TestApplyStructuresToRemove:
     )
     apply_structures_to_remove(session, taxonomy, payload)
 
-    # 4 DELETEs: verification results FIRST (they FK rules and
-    # structures with no ON DELETE), then rules, associations, structures
-    assert session.execute.call_count == 4
-    deleted_tables = [c.args[0].table.name for c in session.execute.call_args_list]
+    # FK-dependency order: verification results FIRST (they FK rules and
+    # structures with no ON DELETE), then facts + fact_sets (fact_sets FK
+    # structures), rules, association classifications (FK associations),
+    # associations, structures.
+    deleted_tables = [
+      c.args[0].table.name
+      for c in session.execute.call_args_list
+      if getattr(c.args[0], "is_dml", False)
+    ]
     assert deleted_tables == [
       "verification_results",
+      "facts",
+      "fact_sets",
       "rules",
+      "association_classifications",
       "associations",
       "structures",
     ]


### PR DESCRIPTION
## Summary

`delete-taxonomy-block` and `update-taxonomy-block` (`structures_to_remove`) both die on FK constraints once the disclosure substrate has been exercised: `verification_results` FK the rules and structures, `fact_sets` FK the structures, and `association_classifications` FK the associations — all with no ON DELETE. `cascade_delete_taxonomy` predates those tables, so a taxonomy whose disclosure note had a bound text block or a published report could never be deleted (raw IntegrityError, no API path to clear the blockers).

Both paths now delete in FK-dependency order, mirroring `delete_schedule` (the sibling structure-removal surface):

- verification results → facts + fact sets → rules → classification rows → associations → element side-tables → elements → structures → taxonomy
- rules hosted by *other* taxonomies that target this taxonomy's associations are included (their `target_association_id` FK would otherwise block the association delete)
- `preflight_delete` now counts snapshot facts living inside the taxonomy's fact sets — including copies of other taxonomies' concepts, which die with the set via the `facts.fact_set_id` ON DELETE CASCADE — so the `cascade_facts` consent gate covers everything the delete actually removes; line-item blocking also considers `flow_element_id` references
- derived rows (verification results, empty standing fact sets) never block: they cascade even with `cascade_facts=false`

## Testing

New regression tests run against a real PostgreSQL schema (throwaway schema per test) — the existing mock-based delete tests cannot violate a constraint, which is how this survived. Verified the new tests fail on the pre-fix code with the exact `verification_results_rule_id_fkey` violation. Full taxonomy_block suite: 221 passed; `just test-code` clean.

Related: #900 tracks the `bind-text-block` hardening on the same substrate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)