### PR TITLE
fix(extensions): surface partial materialization and block the swap

### DIFF
--- a/robosystems/dagster/jobs/extensions.py
+++ b/robosystems/dagster/jobs/extensions.py
@@ -116,12 +116,16 @@ def materialize_extensions_to_graph(
   finally:
     loop.close()
 
-  if result.status == "error":
-    context.log.error(f"Extensions materialization failed: {result.errors}")
+  if result.status != "success":
+    # 'partial' matters as much as 'error': a graph missing a relationship
+    # table renders empty statements. Failing here leaves graph_stale set,
+    # so the next OLTP write triggers another rebuild attempt.
+    context.log.error(f"Extensions materialization {result.status}: {result.errors}")
     raise Failure(
-      description=f"Extensions materialization failed for {graph_id}",
+      description=(f"Extensions materialization {result.status} for {graph_id}"),
       metadata={
         "graph_id": MetadataValue.text(graph_id),
+        "status": MetadataValue.text(result.status),
         "errors": MetadataValue.text("; ".join(result.errors)),
         "duration_ms": MetadataValue.float(result.duration_ms),
       },

--- a/robosystems/operations/extensions/materialize.py
+++ b/robosystems/operations/extensions/materialize.py
@@ -1483,16 +1483,20 @@ class ExtensionsMaterializer:
       # Use source_graph_id so the WIP reads from the original graph's DuckDB
       await self._materialize_tables(client, wip_id, result, source_graph_id=graph_id)
 
-      # Step 6: Swap WIP → active (milliseconds of downtime)
-      if result.status != "error":
+      # Step 6: Swap WIP → active (milliseconds of downtime). Only a fully
+      # clean build ships: a 'partial' WIP (an edge table failed to COPY)
+      # would swap in a ledger whose statements silently render empty, so
+      # the last good graph stays active instead and staleness is left set
+      # for a retry.
+      if result.status == "success":
         logger.info(f"Swapping WIP {wip_id} → active {graph_id}")
         await client.swap_database(graph_id, lock_token=lock.token if lock else None)
         logger.info(f"Blue-green swap complete for {graph_id}")
       else:
         # Materialization had errors — abandon WIP, active is untouched
         logger.warning(
-          f"Blue-green materialization had errors for {graph_id}, "
-          f"abandoning WIP (active graph untouched)"
+          f"Blue-green materialization {result.status} for {graph_id} "
+          f"({len(result.errors)} errors), abandoning WIP (active graph untouched)"
         )
         try:
           await client.delete_database(wip_id, preserve_duckdb=True)
@@ -1681,3 +1685,9 @@ class ExtensionsMaterializer:
             f"so edge tables don't silently load with broken FK targets. "
             f"Original error: {e!s}"
           ) from e
+        # Edge failure: keep going (an isolated edge problem isn't
+        # graph-invalidating for the remaining tables), but the run is no
+        # longer a clean build — callers gating on status must not treat a
+        # graph missing a relationship table as success.
+        if result.status == "success":
+          result.status = "partial"

--- a/tests/operations/extensions/test_materialize.py
+++ b/tests/operations/extensions/test_materialize.py
@@ -643,3 +643,112 @@ class TestExtensionsMaterializer:
     # -wip stripped before the lookup, so the source graph's extensions resolve
     assert captured["id"] == base_id
     assert exts == ["roboledger", "roboinvestor"]
+
+
+class TestPartialStatusAndSwapGate:
+  """A failed edge COPY must not ship as success.
+
+  Edge failures are deliberately non-fatal for the remaining tables, but a
+  graph missing a whole relationship table (ENTRY_HAS_LINE_ITEM,
+  TRANSACTION_HAS_ENTRY) renders empty statements — the blue-green swap and
+  the Dagster consumer both gate on status, so 'partial' has to be a status
+  they can see, not a note buried in result.errors.
+  """
+
+  def _materializer(self):
+    from robosystems.operations.extensions.materialize import (
+      ExtensionsMaterializer,
+    )
+
+    return ExtensionsMaterializer()
+
+  @pytest.mark.asyncio
+  async def test_edge_failure_marks_result_partial(self):
+    materializer = self._materializer()
+    result = MaterializeResult(graph_id=GRAPH_ID)
+    result.tables_staged = ["Entity", "ENTRY_HAS_LINE_ITEM", "TRANSACTION_HAS_ENTRY"]
+
+    async def materialize_table(graph_id, table_name, timeout, source_graph_id=None):
+      if table_name == "ENTRY_HAS_LINE_ITEM":
+        raise RuntimeError("COPY exploded")
+      return {"rows_ingested": 10}
+
+    client = AsyncMock()
+    client.materialize_table.side_effect = materialize_table
+
+    await materializer._materialize_tables(client, GRAPH_ID, result)
+
+    assert result.status == "partial"
+    assert len(result.errors) == 1
+    # The failure is non-fatal: the remaining edge table still materialized.
+    assert result.tables_materialized == ["Entity", "TRANSACTION_HAS_ENTRY"]
+
+  @pytest.mark.asyncio
+  async def test_node_failure_still_fatal(self):
+    materializer = self._materializer()
+    result = MaterializeResult(graph_id=GRAPH_ID)
+    result.tables_staged = ["Entity", "ENTRY_HAS_LINE_ITEM"]
+
+    client = AsyncMock()
+    client.materialize_table.side_effect = RuntimeError("COPY exploded")
+
+    with pytest.raises(RuntimeError):
+      await materializer._materialize_tables(client, GRAPH_ID, result)
+
+    assert result.status == "failed"
+
+  async def _run_blue_green(self, final_status: str):
+    """Drive _materialize_blue_green with a stubbed pipeline."""
+    materializer = self._materializer()
+    result = MaterializeResult(graph_id=GRAPH_ID)
+
+    async def fake_materialize_tables(client, graph_id, res, source_graph_id=None):
+      res.status = final_status
+
+    client = AsyncMock()
+    client.database_exists.return_value = False
+
+    lock = AsyncMock()
+    lock.acquire.return_value = True
+    lock.acquired = True
+
+    with (
+      patch.object(materializer, "_ensure_database", new=AsyncMock()),
+      patch.object(
+        materializer, "_get_graph_extensions", new=AsyncMock(return_value=[])
+      ),
+      patch.object(materializer, "_stage_tables", new=AsyncMock()),
+      patch.object(materializer, "_materialize_tables", new=fake_materialize_tables),
+      patch(
+        "robosystems.operations.extensions.materialize.build_postgres_connstr",
+        return_value=CONNSTR,
+      ),
+      patch(
+        "robosystems.graph_api.core.ladybug.materialization_lock.MaterializationLock",
+        return_value=lock,
+      ),
+      patch(
+        "robosystems.config.valkey_registry.create_async_redis_client",
+        return_value=AsyncMock(),
+      ),
+    ):
+      await materializer._materialize_blue_green(client, GRAPH_ID, ENTITY_ID, result)
+
+    return client
+
+  @pytest.mark.asyncio
+  async def test_clean_build_swaps(self):
+    client = await self._run_blue_green("success")
+    client.swap_database.assert_called_once()
+
+  @pytest.mark.asyncio
+  async def test_partial_build_does_not_swap(self):
+    client = await self._run_blue_green("partial")
+    client.swap_database.assert_not_called()
+    # WIP is abandoned so the last good graph stays active.
+    client.delete_database.assert_called_once()
+
+  @pytest.mark.asyncio
+  async def test_error_build_does_not_swap(self):
+    client = await self._run_blue_green("error")
+    client.swap_database.assert_not_called()


### PR DESCRIPTION
## Summary

A failed relationship-table COPY during blue-green extensions materialization was invisible to every caller gating on status: the error was appended to `result.errors` but `status` stayed `"success"`, so the WIP swapped into active with an entire edge table missing (e.g. `ENTRY_HAS_LINE_ITEM` — a ledger graph that renders empty statements), and the Dagster run logged as complete and cleared staleness, silencing any retry.

Changes:

- **Edge-table failures mark the result `partial`** (node-table failures remain fatal, unchanged — they abort so edges don't load against broken FK targets). The continue-on-edge-failure behavior is preserved for the remaining tables; only the reported status changes.
- **The blue-green swap gate only ships a clean build** — a `partial` WIP is abandoned and the last good graph stays active.
- **The Dagster consumer fails the run on any non-success status.** Failing leaves `graph_stale` set, so the next OLTP write triggers another rebuild attempt (the sensor's `run_key` is keyed on the staleness event) — transient failures self-heal, persistent ones produce visible failed runs instead of silently corrupt graphs.

## Testing

New tests: edge failure → `partial` with remaining tables still materialized; node failure still fatal; swap called on `success` only; partial/error builds abandon the WIP. Full extensions materialize suite: 52 passed; `just test-code` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)