### PR TITLE
fix(materialize): require rebuild when new uploads join ingested data

### DIFF
--- a/examples/custom_graph_demo/upload_ingest.py
+++ b/examples/custom_graph_demo/upload_ingest.py
@@ -183,9 +183,12 @@ def materialize_graph_data(clients: RoboSystemsClients, graph_id: str) -> None:
   print("=" * 70)
 
   try:
+    # The demo reuses its graph across runs and re-uploads every file, so a
+    # rebuild is the correct semantics — a non-rebuild materialize of a
+    # populated graph is rejected with a 409 (it would re-copy ingested rows).
     result = clients.graphs.materialize(
       graph_id,
-      MaterializationOptions(rebuild=False),
+      MaterializationOptions(rebuild=True),
     )
     if result.success:
       print(f"\n✅ Materialization complete: {result.message}")

--- a/robosystems/models/api/graphs/operations.py
+++ b/robosystems/models/api/graphs/operations.py
@@ -93,7 +93,13 @@ class MaterializeOp(BaseModel):
     default=False, description="Force materialization even if already up to date"
   )
   rebuild: bool = Field(
-    default=False, description="Rebuild the graph from scratch, dropping existing data"
+    default=False,
+    description=(
+      "Rebuild the graph from scratch, dropping existing data. Required "
+      "(staged source) when materializing new uploads into a graph that "
+      "already contains materialized data — staging replays all uploaded "
+      "files, so a non-rebuild pass would re-copy ingested rows (409)."
+    ),
   )
   dry_run: bool = Field(
     default=False, description="Validate tables without writing to the graph"

--- a/robosystems/operations/graph/commands/materialize.py
+++ b/robosystems/operations/graph/commands/materialize.py
@@ -177,6 +177,7 @@ async def materialize_cmd(
       }
 
     # Staged path: uploaded parquet files → DuckDB → LadybugDB
+    _require_rebuild_for_populated_graph(db, graph_id, rebuild=body.rebuild)
     use_direct = _should_use_direct_materialization(db, graph_id)
     lock_key = f"graph_materialize:{graph_id}" if lock else None
 
@@ -260,6 +261,56 @@ def _resolve_source(source: str | None, graph_type: str) -> str:
       ),
     )
   return source
+
+
+def _require_rebuild_for_populated_graph(
+  db: Session, graph_id: str, *, rebuild: bool
+) -> None:
+  """Reject a non-rebuild materialize that would re-copy ingested rows.
+
+  DuckDB staging tables rebuild from *all* uploaded files, so once any file
+  has been materialized into the graph, a later non-rebuild materialize
+  replays the whole table — duplicate node keys fail the COPY and duplicate
+  relationships load silently. Only the combination that actually re-copies
+  is rejected: prior ingested files AND new pending files. A repeat call
+  with nothing new keeps its existing not-stale skip behavior, and a first
+  materialize (nothing ingested yet) is unaffected.
+  """
+  if rebuild:
+    return
+
+  from robosystems.models.core import GraphFile, GraphTable
+
+  def _file_exists(*filters) -> bool:
+    return (
+      db.query(GraphFile.id)
+      .join(GraphTable, GraphFile.table_id == GraphTable.id)
+      .filter(GraphTable.graph_id == graph_id, *filters)
+      .first()
+      is not None
+    )
+
+  previously_ingested = _file_exists(GraphFile.graph_status == "ingested")
+  if not previously_ingested:
+    return
+
+  pending_files = _file_exists(
+    GraphFile.duckdb_status == "staged",
+    GraphFile.graph_status != "ingested",
+  )
+  if not pending_files:
+    return
+
+  raise HTTPException(
+    status_code=status.HTTP_409_CONFLICT,
+    detail={
+      "error": (
+        "This graph already contains materialized data; materializing new "
+        "uploads without a rebuild would re-copy previously ingested rows."
+      ),
+      "resolution": ("Pass rebuild=true to rebuild the graph from all uploaded files."),
+    },
+  )
 
 
 def _should_use_direct_materialization(db: Session, graph_id: str) -> bool:

--- a/tests/operations/graph/commands/test_materialize_guard.py
+++ b/tests/operations/graph/commands/test_materialize_guard.py
@@ -1,0 +1,145 @@
+"""Tests for the non-rebuild re-materialization guard (staged source).
+
+DuckDB staging tables rebuild from *all* uploaded files, so once any file
+has been materialized into the graph, a later non-rebuild materialize
+replays the whole table into a graph that already holds those rows —
+duplicate node keys hard-fail the COPY and duplicate relationships load
+silently. The guard converts that into an explicit 409 asking for
+rebuild=true, while leaving first-time materializes and no-new-data
+repeat calls untouched.
+"""
+
+import uuid
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from robosystems.models.core import GraphFile, GraphTable
+from robosystems.models.core.graph.graph import Graph
+from robosystems.operations.graph.commands.materialize import (
+  _require_rebuild_for_populated_graph,
+)
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture()
+def staged_graph(db_session: Session):
+  """A generic graph with one table and helpers to add files in a state."""
+  graph_id = f"kg{uuid.uuid4().hex[:14]}"
+  graph = Graph(graph_id=graph_id, graph_name="Guard Test", graph_type="generic")
+  db_session.add(graph)
+  db_session.flush()
+
+  table = GraphTable(
+    graph_id=graph_id,
+    table_name="Item",
+    table_type="node",
+    schema_json={"columns": []},
+  )
+  db_session.add(table)
+  db_session.flush()
+
+  def add_file(duckdb_status: str, graph_status: str) -> GraphFile:
+    file = GraphFile(
+      graph_id=graph_id,
+      table_id=table.id,
+      file_name=f"{uuid.uuid4().hex[:8]}.parquet",
+      s3_key=f"test/{graph_id}/{uuid.uuid4().hex[:8]}.parquet",
+      file_format="parquet",
+      file_size_bytes=1024,
+      upload_method="direct",
+      duckdb_status=duckdb_status,
+      graph_status=graph_status,
+    )
+    db_session.add(file)
+    db_session.flush()
+    return file
+
+  return {"graph_id": graph_id, "add_file": add_file}
+
+
+class TestRequireRebuildForPopulatedGraph:
+  def test_first_materialize_is_allowed(self, db_session, staged_graph):
+    staged_graph["add_file"]("staged", "pending")
+
+    _require_rebuild_for_populated_graph(
+      db_session, staged_graph["graph_id"], rebuild=False
+    )
+
+  def test_new_uploads_into_populated_graph_require_rebuild(
+    self, db_session, staged_graph
+  ):
+    staged_graph["add_file"]("staged", "ingested")
+    staged_graph["add_file"]("staged", "pending")
+
+    with pytest.raises(HTTPException) as exc:
+      _require_rebuild_for_populated_graph(
+        db_session, staged_graph["graph_id"], rebuild=False
+      )
+
+    assert exc.value.status_code == 409
+    assert "rebuild=true" in str(exc.value.detail)
+
+  def test_rebuild_bypasses_the_guard(self, db_session, staged_graph):
+    staged_graph["add_file"]("staged", "ingested")
+    staged_graph["add_file"]("staged", "pending")
+
+    _require_rebuild_for_populated_graph(
+      db_session, staged_graph["graph_id"], rebuild=True
+    )
+
+  def test_repeat_call_with_no_new_files_is_allowed(self, db_session, staged_graph):
+    """Nothing pending means nothing re-copies; the existing not-stale skip
+    keeps handling the benign repeat call."""
+    staged_graph["add_file"]("staged", "ingested")
+
+    _require_rebuild_for_populated_graph(
+      db_session, staged_graph["graph_id"], rebuild=False
+    )
+
+  def test_failed_previous_materialize_can_retry_without_rebuild(
+    self, db_session, staged_graph
+  ):
+    """A failed first materialize marked nothing ingested — retrying must
+    not demand a rebuild."""
+    staged_graph["add_file"]("staged", "failed")
+    staged_graph["add_file"]("staged", "pending")
+
+    _require_rebuild_for_populated_graph(
+      db_session, staged_graph["graph_id"], rebuild=False
+    )
+
+  def test_other_graphs_files_do_not_trip_the_guard(self, db_session, staged_graph):
+    other_id = f"kg{uuid.uuid4().hex[:14]}"
+    other = Graph(graph_id=other_id, graph_name="Other", graph_type="generic")
+    db_session.add(other)
+    db_session.flush()
+    other_table = GraphTable(
+      graph_id=other_id,
+      table_name="Item",
+      table_type="node",
+      schema_json={"columns": []},
+    )
+    db_session.add(other_table)
+    db_session.flush()
+    db_session.add(
+      GraphFile(
+        graph_id=other_id,
+        table_id=other_table.id,
+        file_name="x.parquet",
+        s3_key=f"test/{other_id}/x.parquet",
+        file_format="parquet",
+        file_size_bytes=1024,
+        upload_method="direct",
+        duckdb_status="staged",
+        graph_status="ingested",
+      )
+    )
+    db_session.flush()
+    staged_graph["add_file"]("staged", "pending")
+
+    _require_rebuild_for_populated_graph(
+      db_session, staged_graph["graph_id"], rebuild=False
+    )


### PR DESCRIPTION
## Summary

On the staged (generic-graph) source, DuckDB staging tables rebuild from **all** uploaded files, so once any file has been materialized into a graph, a later non-rebuild materialize replays the whole staging table into a graph that already holds those rows: duplicate node keys hard-fail the COPY (an opaque 500 since the `ignore_errors` removal in #867), and duplicate relationships load silently, double-counting data. Per discussion, we're deliberately **not** wiring an incremental ingest path for this — the guard makes the contract explicit instead.

- `materialize_cmd` (staged path only) now rejects exactly the combination that re-copies — previously ingested files **and** new pending uploads, without `rebuild=true` — with a 409 explaining the resolution.
- First-time materializes are untouched; repeat calls with nothing new keep their existing not-stale skip; a failed first attempt (nothing marked ingested) can retry without a rebuild; the extensions source is unaffected (blue-green rebuilds from scratch by design).
- `MaterializeOp.rebuild` field docs updated with the contract.
- The custom-graph demo reuses its graph across runs and re-uploads every file, so it now materializes with `rebuild=true` (supplyflow already does `rebuild = not need_provision`, which is compatible as-is).

## Testing

Six new tests against a real Postgres session covering: first materialize allowed, new-uploads-into-populated-graph → 409, rebuild bypass, no-new-files repeat allowed, failed-first-attempt retry allowed, and cross-graph isolation. Adjacent suites (`routers/graphs`, MCP graph tools): 640 passed; `just test-code` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)