### PR TITLE
fix(replicas): make replica health alarms warmup-aware

### DIFF
--- a/cloudformation/graph-ladybug-replicas.yaml
+++ b/cloudformation/graph-ladybug-replicas.yaml
@@ -702,16 +702,52 @@ Resources:
   # ========================================
   # CLOUDWATCH ALARMS
   # ========================================
-  UnhealthyHostsAlarm:
+  # Serving-capacity alarm: fires when fewer than MinInstances replicas can take
+  # traffic. This is the real availability signal - a replica still bootstrapping
+  # does not reduce the healthy count, so scale-out never trips it. With
+  # MinInstances=0 (cost-saving mode) the threshold makes it unfirable, which is
+  # correct for a deliberately empty fleet.
+  InsufficientHealthyHostsAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmName: !Sub robosystems-shared-replicas-${Environment}-unhealthy-hosts
-      AlarmDescription: Alert when replicas are unhealthy
-      MetricName: UnHealthyHostCount
+      AlarmName: !Sub robosystems-shared-replicas-${Environment}-insufficient-healthy-hosts
+      AlarmDescription: Alert when serving replicas drop below the configured minimum
+      MetricName: HealthyHostCount
       Namespace: AWS/ApplicationELB
       Statistic: Average
       Period: 60
       EvaluationPeriods: 3
+      Threshold: !Ref MinInstances
+      ComparisonOperator: LessThanThreshold
+      Dimensions:
+        - Name: TargetGroup
+          Value: !GetAtt ReplicaTargetGroup.TargetGroupFullName
+        - Name: LoadBalancer
+          Value: !GetAtt ReplicaALB.LoadBalancerFullName
+      AlarmActions:
+        - !Ref ReplicaAlertTopic
+      TreatMissingData: notBreaching
+
+  # Stuck-host alarm: a replica that never finishes coming up (failed shared
+  # database download, crash-looping container) while healthy replicas still
+  # serve traffic - a gap InsufficientHealthyHostsAlarm cannot see.
+  #
+  # The evaluation window must clear normal bootstrap, which is dominated by the
+  # shared database download from S3 (~8 min for the ~120GB sec graph) plus the
+  # container pull and warmup - about 11 min end to end, and growing with the
+  # graph. The instance refresh already budgets 900s (InstanceWarmup) for this.
+  # 20 min clears both with margin; anything unhealthy that long is genuinely
+  # stuck, not warming.
+  UnhealthyHostsAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub robosystems-shared-replicas-${Environment}-unhealthy-hosts
+      AlarmDescription: Alert when a replica stays unhealthy well past normal bootstrap
+      MetricName: UnHealthyHostCount
+      Namespace: AWS/ApplicationELB
+      Statistic: Average
+      Period: 60
+      EvaluationPeriods: 20
       Threshold: 1
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Dimensions:


### PR DESCRIPTION
## Problem

`robosystems-shared-replicas-prod-unhealthy-hosts` fires on every memory-driven scale-out, before the new instance has any chance to come up.

A replica registers with the target group immediately on launch, but cannot serve until it downloads the shared database from S3, pulls the container, and warms up. Observed on `i-0300a33a420c5f201` today:

| Step | Duration |
| --- | --- |
| `sec.lbug` download from S3 (~120GB) | 483s |
| Container pull + open read-only + 15 warmup probes | ~2 min |
| **Launch → `Replica marked as ready`** | **~10.5 min** |

The alarm breached at 3 min (`EvaluationPeriods: 3`, `Period: 60`). Every scale-out pages, and the paging window is ~7 min of pure noise.

Worth noting the bootstrap window is understood everywhere *except* this alarm — the ASG carries `HealthCheckGracePeriod: 1800`, and the instance refresh sets `InstanceWarmup: 900`.

## Fix

The single alarm was conflating two different questions. Split them:

**`InsufficientHealthyHostsAlarm`** (new) — `HealthyHostCount < MinInstances`, 3×60s. The actual availability signal: can we serve? A bootstrapping replica doesn't reduce the healthy count, so scale-out can't trip it. Real capacity loss still pages in 3 min. The nightly refresh can't trip it either, since it runs `MinHealthyPercentage: 100` and launches before terminating (verified: healthy went 2 → 4 → 2).

**`UnhealthyHostsAlarm`** (retargeted) — same metric, but over 20 min. Now means a replica is genuinely *stuck* — failed database download, crash-looping container — while other replicas still serve. That's a real failure mode the capacity alarm can't see, so it's worth keeping rather than deleting. 20 min clears both the ~11 min bootstrap and the refresh's 900s `InstanceWarmup` with margin.

Net effect: genuine failures page on a more meaningful signal at the same 3-min latency; normal warmup pages never.

## Notes

- `Threshold` references `!Ref MinInstances` rather than hardcoding 2, so it tracks config. In cost-saving mode (`MinInstances: 0`), `< 0` is unfirable — correct for a deliberately empty fleet.
- `TreatMissingData: notBreaching` retained from the existing alarm. For a `LessThanThreshold` alarm this means a total metric outage won't page; `breaching` was the alternative, but it would page continuously in cost-saving mode when there are no targets. Flagging the tradeoff rather than changing semantics silently.
- Bootstrap time grows with the shared graph. If the SEC database roughly doubles, the 20-min window wants revisiting.
- Deploying this replaces one alarm and adds one; no instance cycling (CloudWatch alarms only).

## Context

Found while investigating a scale-out triggered by sustained query load. The scale-out itself was healthy behavior — memory target-tracking (80% avg) fired because the fixed 8GB buffer pool on a 15GB instance converges to ~85% once warm, and the rung above `OnDemandBaseCapacity: 2` is 100% spot. The nightly Dagster replica refresh recycles instances with cold caches, which lets `AlarmLow` scale back in. So the only defect was the false page.

## Testing

- `just cf-lint graph-ladybug-replicas` — clean
- `aws cloudformation validate-template` — accepts `!Ref MinInstances` in `Threshold`