### PR TITLE
fix(forecast): launch-surface correctness on the statement/forecast path

### DIFF
--- a/robosystems/graphql/resolvers/information_block.py
+++ b/robosystems/graphql/resolvers/information_block.py
@@ -50,7 +50,11 @@ class InformationBlockQuery:
     info: Info[GraphQLContext, None],
     id: strawberry.ID,
     scenario_id: str | None = None,
-    series: bool = False,
+    # Nullable rather than `bool = False`: generated SDK clients pass
+    # explicit null for omitted variables, and GraphQL rejects null for a
+    # non-null argument even with a schema default (same contract as the
+    # pagination args in _common.resolve_pagination).
+    series: bool | None = None,
     series_history: int | None = None,
     series_forecast: int | None = None,
   ) -> InformationBlock | None:
@@ -77,7 +81,7 @@ class InformationBlockQuery:
         session,
         str(id),
         scenario_id=scenario_id,
-        series=series,
+        series=bool(series),
         series_history=series_history,
         series_forecast=series_forecast,
       )

--- a/robosystems/operations/information_block/forecast_compute.py
+++ b/robosystems/operations/information_block/forecast_compute.py
@@ -135,6 +135,11 @@ def _actual_set_at(
   monthly period_end coincides with the FY end, and without the window
   guard the ANNUAL comparative set (created later) would win and seed
   ``Revenues[t-1]`` with the FY column instead of the month.
+
+  Canonical sets (report_id IS NULL — the close-time stamp) beat
+  publication snapshots, same contract as the envelope loaders: a Report
+  published later for the base month must not seed the forecast off a
+  frozen snapshot that may have been regenerated with a different style.
   """
   return session.execute(
     select(FactSet)
@@ -146,7 +151,10 @@ def _actual_set_at(
       FactSet.period_end == period_end,
       FactSet.period_start >= period_start,
     )
-    .order_by(FactSet.created_at.desc())
+    .order_by(
+      FactSet.report_id.isnot(None).asc(),
+      FactSet.created_at.desc(),
+    )
     .limit(1)
   ).scalar_one_or_none()
 
@@ -513,6 +521,7 @@ def cmd_compute_forecast(
     # Authoring rejects overlap with assertions and active catalog
     # rules, but a stale overlap (catalog rule activated after the
     # growth entry was stored) yields to the rule, legibly.
+    grown_this_month: set[str] = set()
     for element_id, rate_by_month in growth_rates.items():
       rate = rate_by_month.get(month)
       if rate is None:
@@ -528,6 +537,7 @@ def cmd_compute_forecast(
         )
         continue
       current[element_id] = prior_values.get(element_id, 0.0) * (1.0 + rate)
+      grown_this_month.add(element_id)
 
     # (a3) Line assertions — the manual overrides win over carry and
     # schedule projection for the months they name; a displaced driver
@@ -541,6 +551,10 @@ def cmd_compute_forecast(
     month_asserted_instants = {
       el for el in asserted_this_month if assertion_period_type.get(el) == "instant"
     }
+    # One owner per line: a grown value is as authored as an asserted one,
+    # so the push-down must not rescale it away — the driven parent's
+    # remainder distributes over the un-owned siblings instead.
+    pinned_this_month = asserted_this_month | grown_this_month
 
     # (b) Driver rules in same-month dependency order.
     asserted_ancestors = _ancestor_closure(
@@ -565,7 +579,7 @@ def cmd_compute_forecast(
       # the final subtotal derivation would contradict the driven value.
       # Displace it as legibly as a direct-target assertion.
       if ar.target.id in asserted_ancestors and _subtree_all_pinned(
-        ar.target.id, calculations, current, asserted_this_month
+        ar.target.id, calculations, current, pinned_this_month
       ):
         displaced_targets.add(ar.target.id)
         skipped.append(
@@ -704,10 +718,10 @@ def cmd_compute_forecast(
     # parent's carried children proportionally, the workbook's implicit
     # semantics (every revenue stream grows at g). Without this the
     # statement's own RollUp verification fails: driven parent, stale
-    # children. Asserted leaves are pinned — the remainder distributes
-    # over the unpinned children only.
+    # children. Asserted and grown leaves are pinned — the remainder
+    # distributes over the unpinned children only.
     _scale_rule_target_children(
-      current, active_target_ids, calculations, pinned=asserted_this_month
+      current, active_target_ids, calculations, pinned=pinned_this_month
     )
 
     # (c) Calc-DAG subtotals — derive, never carry (present = direct wins).
@@ -1015,9 +1029,9 @@ def _scale_rule_target_children(
   carry scales by exactly 1.0 (children carried too), so this is a no-op
   for inactive months.
 
-  ``pinned`` elements (line-asserted leaves) are never scaled: the
-  driven parent's remainder after the pinned contributions distributes
-  proportionally over the unpinned children. A parent whose children
+  ``pinned`` elements (line-asserted or line-grown leaves) are never
+  scaled: the driven parent's remainder after the pinned contributions
+  distributes proportionally over the unpinned children. A parent whose children
   are all pinned (or whose unpinned sum is zero) is left untouched —
   the visible RollUp failure again beats inventing a split.
   """

--- a/robosystems/operations/roboledger/reports/calc_dag.py
+++ b/robosystems/operations/roboledger/reports/calc_dag.py
@@ -54,7 +54,16 @@ def load_rs_gaap_calculations(
     """)
   ).fetchall()
   calculations: dict[str, list[tuple[str, float]]] = {}
+  seen: set[tuple[str, str]] = set()
   for r in rows:
+    # The merge is keyed on (parent → child) across every calc structure of
+    # the standard. The shipped package has no duplicate pairs today, but a
+    # future edit that arcs the same pair in a second structure would
+    # silently double-count the child in every subtotal — dedupe rather
+    # than trust the package forever.
+    if (r.parent, r.child) in seen:
+      continue
+    seen.add((r.parent, r.child))
     weight = float(r.weight) if r.weight is not None else 1.0
     calculations.setdefault(r.parent, []).append((r.child, weight))
   return calculations

--- a/tests/graphql/extensions/test_information_block.py
+++ b/tests/graphql/extensions/test_information_block.py
@@ -191,6 +191,33 @@ class TestInformationBlocksQuery:
     assert kwargs["limit"] == 200
     assert kwargs["offset"] == 0
 
+  def test_explicit_null_series_variables_are_accepted(self) -> None:
+    """Regression: the series args must follow the same nullable contract
+    as pagination — generated SDK clients send explicit ``null`` for every
+    omitted variable, and ``series: Boolean! = false`` rejected it
+    ("Argument 'series' of non-null type 'Boolean!' must not be null")."""
+    with (
+      _patch_session(),
+      patch(GET_PATH, return_value=None) as mock_get,
+    ):
+      result = schema.execute_sync(
+        "query Get($id: ID!, $series: Boolean, $seriesHistory: Int,"
+        " $seriesForecast: Int) {"
+        " informationBlock(id: $id, series: $series,"
+        " seriesHistory: $seriesHistory, seriesForecast: $seriesForecast)"
+        " { id } }",
+        variable_values={
+          "id": "struct_ib_01",
+          "series": None,
+          "seriesHistory": None,
+          "seriesForecast": None,
+        },
+        context_value=_ctx(),
+      )
+    assert result.errors is None
+    _, kwargs = mock_get.call_args
+    assert kwargs["series"] is False
+
   def test_returns_empty_list_on_library_sentinel(self) -> None:
     """Schedule has surfaces_in_library=False, so the sentinel returns []."""
     with (

--- a/tests/operations/information_block/test_forecast_base_binding.py
+++ b/tests/operations/information_block/test_forecast_base_binding.py
@@ -1,0 +1,159 @@
+"""Regression tests for the forecast base-month FactSet binder.
+
+``_actual_set_at`` seeds the forecast's prior values, the BS roll's
+month-zero state, and the mapping-provenance lookup. It must prefer the
+canonical close-time stamp (report_id IS NULL) over publication
+snapshots — the same contract as the statement envelope loaders — or a
+Report published later for the base month flips the forecast base onto
+a frozen snapshot that can diverge from the statement rendered beside it.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import UTC, date, datetime, timedelta
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+import robosystems.models.extensions  # noqa: F401  (register models on ExtensionsBase)
+from robosystems.db.extensions import ExtensionsBase
+from robosystems.models.extensions import FactSet, Structure, Taxonomy
+from robosystems.operations.information_block.forecast_compute import _actual_set_at
+
+pytestmark = pytest.mark.unit
+
+PERIOD_START = date(2026, 6, 1)
+PERIOD_END = date(2026, 6, 30)
+
+
+@pytest.fixture()
+def ext_session():
+  """Extensions schema in the test Postgres DB, one throwaway schema per test."""
+  database_url = os.environ.get("TEST_DATABASE_URL")
+  if not database_url:
+    pytest.skip("TEST_DATABASE_URL not configured")
+
+  schema = f"ext_fcbind_{uuid.uuid4().hex[:12]}"
+  engine = create_engine(database_url)
+  with engine.begin() as conn:
+    conn.execute(text(f'CREATE SCHEMA "{schema}"'))
+
+  session = sessionmaker(bind=engine)()
+  session.execute(text(f'SET search_path TO "{schema}"'))
+  ExtensionsBase.metadata.create_all(bind=session.connection())
+  session.commit()
+  session.execute(text(f'SET search_path TO "{schema}"'))
+
+  try:
+    yield session
+  finally:
+    session.rollback()
+    session.close()
+    with engine.begin() as conn:
+      conn.execute(text(f'DROP SCHEMA "{schema}" CASCADE'))
+    engine.dispose()
+
+
+@pytest.fixture()
+def statement_structure(ext_session):
+  taxonomy = Taxonomy(name="Style", taxonomy_type="reporting_extension")
+  ext_session.add(taxonomy)
+  ext_session.flush()
+  structure = Structure(
+    name="Income Statement", block_type="income_statement", taxonomy_id=taxonomy.id
+  )
+  ext_session.add(structure)
+  ext_session.flush()
+  return structure
+
+
+def _add_set(
+  session,
+  structure_id: str,
+  *,
+  report_id: str | None,
+  created_offset_minutes: int,
+) -> FactSet:
+  fact_set = FactSet(
+    structure_id=structure_id,
+    period_start=PERIOD_START,
+    period_end=PERIOD_END,
+    factset_type="report",
+    entity_id="ent_1",
+    report_id=report_id,
+  )
+  fact_set.provenance = {"origin": "pivot", "mapping_id": "m", "period": "2026-06"}
+  fact_set.created_at = datetime(2026, 7, 1, tzinfo=UTC) + timedelta(
+    minutes=created_offset_minutes
+  )
+  session.add(fact_set)
+  session.flush()
+  return fact_set
+
+
+class TestActualSetAt:
+  def test_canonical_beats_later_publication_snapshot(
+    self, ext_session, statement_structure
+  ):
+    canonical = _add_set(
+      ext_session, statement_structure.id, report_id=None, created_offset_minutes=0
+    )
+    _add_set(
+      ext_session,
+      statement_structure.id,
+      report_id="rep_1",
+      created_offset_minutes=60,
+    )
+    ext_session.commit()
+
+    found = _actual_set_at(
+      ext_session, statement_structure.id, "ent_1", PERIOD_START, PERIOD_END
+    )
+
+    assert found is not None
+    assert found.id == canonical.id
+
+  def test_newest_wins_among_publications_when_no_canonical(
+    self, ext_session, statement_structure
+  ):
+    _add_set(
+      ext_session,
+      statement_structure.id,
+      report_id="rep_1",
+      created_offset_minutes=0,
+    )
+    newer = _add_set(
+      ext_session,
+      statement_structure.id,
+      report_id="rep_2",
+      created_offset_minutes=60,
+    )
+    ext_session.commit()
+
+    found = _actual_set_at(
+      ext_session, statement_structure.id, "ent_1", PERIOD_START, PERIOD_END
+    )
+
+    assert found is not None
+    assert found.id == newer.id
+
+  def test_newest_canonical_wins_among_canonicals(
+    self, ext_session, statement_structure
+  ):
+    _add_set(
+      ext_session, statement_structure.id, report_id=None, created_offset_minutes=0
+    )
+    newer = _add_set(
+      ext_session, statement_structure.id, report_id=None, created_offset_minutes=60
+    )
+    ext_session.commit()
+
+    found = _actual_set_at(
+      ext_session, statement_structure.id, "ent_1", PERIOD_START, PERIOD_END
+    )
+
+    assert found is not None
+    assert found.id == newer.id

--- a/tests/operations/information_block/test_forecast_compute.py
+++ b/tests/operations/information_block/test_forecast_compute.py
@@ -691,6 +691,36 @@ class TestLineGrowth:
     )
     assert rec.value("struct_is", JUL, "el_mkt") == pytest.approx(0.0)
 
+  def test_grown_child_is_pinned_against_rule_delta_push_down(self) -> None:
+    """One owner per line: a grown leaf under a rule-driven calc parent
+    keeps its authored trajectory — the driven parent's remainder
+    distributes over the un-owned sibling only (same contract as line
+    assertions). Previously the push-down silently rescaled the grown
+    value with no skipped entry."""
+    calc_dag = {
+      "el_gp": [("el_rev", 1.0), ("el_cogs", -1.0)],
+      "el_rev": [("el_rev_a", 1.0), ("el_rev_b", 1.0)],
+    }
+    base_facts = [
+      *BASE_IS_FACTS,
+      SimpleNamespace(element_id="el_rev_a", value=60.0),
+      SimpleNamespace(element_id="el_rev_b", value=40.0),
+    ]
+    levers = [_lever("rs-driver:RevenueGrowthRate", "el_growth", 0.03, ALL_MONTHS)]
+    growth = [_growth("rs-gaap:RevenueStreamA", "el_rev_a", {"2026-07": 0.10})]
+    _, rec = _run(
+      _mechanics(levers, growth=growth),
+      [GROWTH_RULE],
+      levers,
+      calc_dag=calc_dag,
+      base_is_facts=base_facts,
+    )
+    assert rec.value("struct_is", JUL, "el_rev") == pytest.approx(103.0)
+    # 60 grown 10% — not rescaled by the parent's push-down.
+    assert rec.value("struct_is", JUL, "el_rev_a") == pytest.approx(66.0)
+    # Remainder over the un-owned sibling: (103 - 66) / 40 scales 40 -> 37.
+    assert rec.value("struct_is", JUL, "el_rev_b") == pytest.approx(37.0)
+
   def test_growth_articulates_through_subtotals(self) -> None:
     """A grown COGS re-derives GrossProfit — the grown leaf participates
     in the calc DAG exactly like a carried or rule-driven one."""


### PR DESCRIPTION
## Summary

Three verified findings from the post-v1.6.0 review, all on the FP&A launch surface, plus one cheap guard:

1. **GraphQL `series` non-null regression** — `series: bool = False` compiles to `Boolean! = false`, the exact pattern #905 removed from pagination: graphql-codegen clients send explicit `null` for omitted variables, and GraphQL rejects null for non-null args even with a schema default. Any SDK operation declaring `$series` and omitting it failed. Now nullable-with-resolver-default, matching `resolve_pagination`'s documented contract (`seriesHistory`/`seriesForecast` were already nullable).

2. **Forecast base binder canonical tiebreak** — `_actual_set_at` ordered by `created_at` alone, so the close→publish→forecast flow seeded the forecast (prior values, BS roll month-zero, mapping-provenance lookup) from the frozen publication snapshot instead of the canonical close stamp. Now applies the same `report_id IS NULL`-first ordering as `load_latest_fact_set_for_structure` / `load_statement_fact_set_series`, with newest-wins within each class.

3. **`line_growth` pinned against rule push-down** — a grown line under a rule-driven calc parent was silently rescaled by `_scale_rule_target_children` (only assertions were pinned), overriding the authored trajectory with no `skipped` entry. Grown lines are now pinned exactly like asserted lines for the months their trajectory names — the driven parent's remainder distributes over un-owned siblings — and the subtree-fully-pinned rule displacement considers them too. Rate-less (grow-then-hold) months stay unpinned, same as assertion semantics.

4. **`load_rs_gaap_calculations` arc dedupe** — the cross-structure merge would double-count a `(parent, child)` pair arced in two calc structures. Clean in the shipped package (verified), but one future package edit away from silently corrupting every subtotal; dedupe closes it.

## Testing

- New: explicit-null `series` variables accepted (mirrors the #905 regression test); grown-child-pinned push-down test (mirrors the asserted-child test: parent driven to 103, grown child holds 66, sibling takes the 37 remainder); `_actual_set_at` canonical-beats-publication + newest-wins tests against a real Postgres schema.
- `tests/operations/information_block` + `tests/operations/roboledger` + `tests/graphql`: 1280 passed; `just test-code` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)