### PR TITLE
fix(usage): key the storage summary by graph, not requesting user

### DIFF
--- a/robosystems/models/core/graph/graph_usage.py
+++ b/robosystems/models/core/graph/graph_usage.py
@@ -364,17 +364,23 @@ class GraphUsage(Model):
   @classmethod
   def get_monthly_storage_summary(
     cls,
-    user_id: str,
+    graph_id: str,
     year: int,
     month: int,
     session: Session,
   ) -> dict[str, dict]:
-    """Get monthly storage summary for billing."""
-    # Get storage snapshots for the month
+    """Get a graph's monthly storage summary.
+
+    Keyed by graph, not user: snapshots are written by the usage monitor
+    sensor under one arbitrary admin's user_id, so a user-keyed read
+    rendered the storage section empty for every other org member (and
+    fractured history whenever graph admins changed). Storage is a
+    property of the graph; per-graph access is enforced at the route.
+    """
     records = (
       session.query(cls)
       .filter(
-        cls.user_id == user_id,
+        cls.graph_id == graph_id,
         cls.event_type == UsageEventType.STORAGE_SNAPSHOT.value,
         cls.billing_year == year,
         cls.billing_month == month,

--- a/robosystems/routers/graphs/usage.py
+++ b/robosystems/routers/graphs/usage.py
@@ -336,7 +336,7 @@ async def get_graph_usage(
 
     if include_storage:
       storage_data = GraphUsage.get_monthly_storage_summary(
-        user_id=current_user.id,
+        graph_id=graph_id,
         year=year,
         month=month,
         session=db,

--- a/tests/models/core/graph/test_graph_usage.py
+++ b/tests/models/core/graph/test_graph_usage.py
@@ -265,9 +265,11 @@ class TestGraphUsage:
 
     self.session.commit()
 
-    # Get summary
+    # Graph-keyed: the reader must not care which user's id the sensor
+    # happened to stamp on the snapshot rows (it picks one arbitrary
+    # admin) — any member of the graph reads the same summary.
     summary = GraphUsage.get_monthly_storage_summary(
-      user_id=self.test_user_id, year=2024, month=1, session=self.session
+      graph_id=self.test_graph_id, year=2024, month=1, session=self.session
     )
 
     assert self.test_graph_id in summary
@@ -282,11 +284,8 @@ class TestGraphUsage:
 
   def test_get_monthly_storage_summary_no_data(self):
     """Test getting monthly storage summary with no data."""
-    # Use a different user ID to avoid conflicts with other tests
-    different_user = "no_data_user_999"
-
     summary = GraphUsage.get_monthly_storage_summary(
-      user_id=different_user, year=2024, month=1, session=self.session
+      graph_id="kg_no_snapshots_999", year=2024, month=1, session=self.session
     )
 
     assert summary == {}


### PR DESCRIPTION
## Summary

The dashboard's storage section (`GET /v1/graphs/{g}/usage`) rendered empty for every org member except one: storage snapshots are written by the usage monitor sensor under one arbitrary admin's `user_id` (`db.query(GraphUser).filter(role == 'admin').first()`), but `get_monthly_storage_summary` filtered on the *requesting* user's id. Only the coincidentally-attributed admin ever saw data, and history fractured across user_ids whenever graph admins changed.

Storage is a property of the graph, not of whoever is asking. The summary now filters on the route's access-checked `graph_id` — every member sees the same measurements. The sensor's write-side attribution is unchanged (the user_id column becomes provenance only; no read depends on it).

## Testing

Model tests updated to the graph-keyed contract (including the regression semantics: the reader must not care which user's id the sensor stamped). `tests/models/core/graph` + `tests/routers/graphs/test_usage.py`: 52 passed; `just test-code` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)