### PR TITLE
fix(graph-api): gate admission on free memory, not percent used

### DIFF
--- a/robosystems/config/defaults.py
+++ b/robosystems/config/defaults.py
@@ -89,13 +89,22 @@ class TimeoutDefaults:
 
 class AdmissionDefaults:
   """
-  Admission control thresholds (all values are percentages 0-100).
+  Admission control thresholds.
 
   These thresholds determine when to start rejecting new requests
   to protect system stability.
+
+  MEMORY_THRESHOLD is a percentage (0-100) used to *report* memory pressure.
+  It is deliberately not the gate for rejecting graph queries: a LadybugDB
+  buffer pool is a fixed pre-commitment that is supposed to fill, so percent
+  of total memory conflates that constant with the query working set that
+  actually predicts exhaustion. Rejection is gated on MIN_AVAILABLE_MB, an
+  absolute headroom figure that does not move when the pool or the instance
+  size changes.
   """
 
-  MEMORY_THRESHOLD = 85.0  # Start rejecting at 85% memory usage
+  MEMORY_THRESHOLD = 85.0  # Report memory pressure at 85% usage
+  MIN_AVAILABLE_MB = 1024.0  # Reject when free memory falls below 1GB
   CPU_THRESHOLD = 90.0  # Start rejecting at 90% CPU usage
   QUEUE_THRESHOLD = 80.0  # Start rejecting at 80% queue capacity
 

--- a/robosystems/config/env.py
+++ b/robosystems/config/env.py
@@ -885,6 +885,11 @@ class EnvConfig:
     "lbug_admission/MEMORY_THRESHOLD",
     AdmissionDefaults.MEMORY_THRESHOLD,
   )
+  LBUG_ADMISSION_MIN_AVAILABLE_MB = get_tuning_float(
+    "LBUG_ADMISSION_MIN_AVAILABLE_MB",
+    "lbug_admission/MIN_AVAILABLE_MB",
+    AdmissionDefaults.MIN_AVAILABLE_MB,
+  )
   LBUG_ADMISSION_CPU_THRESHOLD = get_tuning_float(
     "LBUG_ADMISSION_CPU_THRESHOLD",
     "lbug_admission/CPU_THRESHOLD",

--- a/robosystems/graph_api/core/admission_control.py
+++ b/robosystems/graph_api/core/admission_control.py
@@ -32,7 +32,8 @@ class LadybugAdmissionController:
 
   def __init__(
     self,
-    memory_threshold: float = 85.0,  # Conservative threshold for production safety (% of total instance memory)
+    memory_threshold: float = 85.0,  # Reporting only - see min_available_mb for the gate
+    min_available_mb: float = 1024.0,
     cpu_threshold: float = 95.0,
     max_connections_per_db: int = 10,
     check_interval: float = 1.0,
@@ -41,12 +42,19 @@ class LadybugAdmissionController:
     Initialize LadybugDB admission controller.
 
     Args:
-        memory_threshold: Max memory usage percent before rejecting
+        memory_threshold: Memory usage percent at which the node reports
+            pressure. Not a rejection gate - a buffer pool is meant to fill,
+            so percent of total conflates that fixed allocation with the
+            query working set. See min_available_mb.
+        min_available_mb: Reject when free memory falls below this many MB.
+            Absolute rather than proportional, so it stays correct when the
+            buffer pool or the instance size changes.
         cpu_threshold: Max CPU usage percent before rejecting
         max_connections_per_db: Max concurrent connections per database
         check_interval: Seconds between resource checks (cached)
     """
     self.memory_threshold = memory_threshold
+    self.min_available_mb = min_available_mb
     self.cpu_threshold = cpu_threshold
     self.max_connections_per_db = max_connections_per_db
     self.check_interval = check_interval
@@ -54,13 +62,15 @@ class LadybugAdmissionController:
     # Cached resource data to avoid frequent psutil calls
     self._last_check = 0.0
     self._cached_memory = 0.0
+    self._cached_available_mb = float("inf")
     self._cached_cpu = 0.0
 
     # Connection tracking
     self._connections_per_db: dict[str, int] = {}
 
     logger.info(
-      f"LadybugAdmissionController initialized - Memory: {memory_threshold}%, "
+      f"LadybugAdmissionController initialized - Min available: {min_available_mb}MB, "
+      f"Memory report threshold: {memory_threshold}%, "
       f"CPU: {cpu_threshold}%, Max connections/DB: {max_connections_per_db}"
     )
 
@@ -69,13 +79,16 @@ class LadybugAdmissionController:
     now = time.time()
     if now - self._last_check >= self.check_interval:
       try:
-        self._cached_memory = psutil.virtual_memory().percent
+        memory = psutil.virtual_memory()
+        self._cached_memory = memory.percent
+        self._cached_available_mb = memory.available / (1024 * 1024)
         self._cached_cpu = psutil.cpu_percent(interval=0.1)
         self._last_check = now
       except Exception as e:
         logger.error(f"Failed to get system resources: {e}")
-        # Use conservative defaults on error
+        # Fail closed on error: assume no headroom rather than admit blindly
         self._cached_memory = 80.0
+        self._cached_available_mb = 0.0
         self._cached_cpu = 80.0
 
   def check_admission(
@@ -94,11 +107,14 @@ class LadybugAdmissionController:
     # Update cached metrics
     self._update_resource_cache()
 
-    # Check memory threshold
-    if self._cached_memory > self.memory_threshold:
+    # Check free memory headroom. Gated on absolute available memory, not
+    # percent used: the buffer pool is a fixed allocation that fills by design,
+    # so a warm node legitimately sits high on percent-used while still having
+    # room to serve.
+    if self._cached_available_mb < self.min_available_mb:
       reason = (
-        f"Memory usage too high: {self._cached_memory:.1f}% "
-        f"(threshold: {self.memory_threshold}%)"
+        f"Insufficient memory headroom: {self._cached_available_mb:.0f}MB available "
+        f"(minimum: {self.min_available_mb:.0f}MB)"
       )
       logger.warning(f"Rejecting request for {database_name}: {reason}")
       return AdmissionDecision.REJECT_MEMORY, reason
@@ -152,8 +168,10 @@ class LadybugAdmissionController:
     self._update_resource_cache()
     return {
       "memory_percent": self._cached_memory,
+      "memory_available_mb": self._cached_available_mb,
       "cpu_percent": self._cached_cpu,
       "memory_threshold": self.memory_threshold,
+      "min_available_mb": self.min_available_mb,
       "cpu_threshold": self.cpu_threshold,
       "connections_per_db": dict(self._connections_per_db),
       "total_connections": sum(self._connections_per_db.values()),
@@ -174,6 +192,7 @@ def get_admission_controller() -> LadybugAdmissionController:
     # Use centralized config (which handles env vars and defaults properly)
     _admission_controller = LadybugAdmissionController(
       memory_threshold=env.LBUG_ADMISSION_MEMORY_THRESHOLD,
+      min_available_mb=env.LBUG_ADMISSION_MIN_AVAILABLE_MB,
       cpu_threshold=env.LBUG_ADMISSION_CPU_THRESHOLD,
       max_connections_per_db=LBUG_MAX_CONNECTIONS_PER_DB,
     )

--- a/tests/graph_api/test_graph_api_admission_control.py
+++ b/tests/graph_api/test_graph_api_admission_control.py
@@ -15,10 +15,12 @@ from robosystems.graph_api.core.admission_control import (
 def set_resource_usage(monkeypatch):
   """Helper to patch psutil resource metrics."""
 
-  def _setter(memory_percent: float, cpu_percent: float):
+  def _setter(memory_percent: float, cpu_percent: float, available_mb: float = 8192.0):
     monkeypatch.setattr(
       "robosystems.graph_api.core.admission_control.psutil.virtual_memory",
-      lambda: SimpleNamespace(percent=memory_percent),
+      lambda: SimpleNamespace(
+        percent=memory_percent, available=int(available_mb * 1024 * 1024)
+      ),
     )
     monkeypatch.setattr(
       "robosystems.graph_api.core.admission_control.psutil.cpu_percent",
@@ -44,21 +46,83 @@ def test_check_admission_accepts_when_under_thresholds(set_resource_usage):
   assert reason is None
 
 
-def test_check_admission_rejects_on_memory_pressure(set_resource_usage):
-  """Ensure high memory usage triggers load shedding."""
+def test_check_admission_rejects_when_headroom_exhausted(set_resource_usage):
+  """Ensure genuinely low free memory triggers load shedding."""
   controller = LadybugAdmissionController(
-    memory_threshold=70.0,
+    min_available_mb=1024.0,
     cpu_threshold=95.0,
     max_connections_per_db=2,
     check_interval=0.0,
   )
-  set_resource_usage(memory_percent=85.0, cpu_percent=30.0)
+  set_resource_usage(memory_percent=99.0, cpu_percent=30.0, available_mb=512.0)
 
   decision, reason = controller.check_admission("graph-123")
 
   assert decision == AdmissionDecision.REJECT_MEMORY
   assert reason is not None
-  assert "Memory usage too high" in reason
+  assert "Insufficient memory headroom" in reason
+
+
+def test_warm_buffer_pool_does_not_reject(set_resource_usage):
+  """A full buffer pool reads as high percent-used but must still serve.
+
+  Regression: replicas ran an 8GB pool on a 15.7GB instance, so warm nodes sat
+  at ~87% used and the old percent gate rejected every query even though ~2GB
+  was free.
+  """
+  controller = LadybugAdmissionController(
+    memory_threshold=85.0,
+    min_available_mb=1024.0,
+    cpu_threshold=95.0,
+    max_connections_per_db=2,
+    check_interval=0.0,
+  )
+  set_resource_usage(memory_percent=87.4, cpu_percent=30.0, available_mb=1974.0)
+
+  decision, reason = controller.check_admission("graph-123")
+
+  assert decision == AdmissionDecision.ACCEPT
+  assert reason is None
+
+
+def test_headroom_gate_is_independent_of_instance_size(set_resource_usage):
+  """The gate must not move when total memory changes.
+
+  Same absolute headroom on a small and a large instance yields the same
+  decision, which is what stops the guard needing a re-tune every time the
+  pool or instance type changes.
+  """
+  controller = LadybugAdmissionController(
+    min_available_mb=1024.0,
+    cpu_threshold=95.0,
+    max_connections_per_db=5,
+    check_interval=0.0,
+  )
+
+  # Small instance, mostly consumed by the pool
+  set_resource_usage(memory_percent=88.0, cpu_percent=20.0, available_mb=1800.0)
+  assert controller.check_admission("graph-123")[0] == AdmissionDecision.ACCEPT
+
+  # Large instance at a far lower percentage, but genuinely starved
+  set_resource_usage(memory_percent=40.0, cpu_percent=20.0, available_mb=256.0)
+  assert controller.check_admission("graph-123")[0] == AdmissionDecision.REJECT_MEMORY
+
+
+def test_resource_probe_failure_fails_closed(monkeypatch):
+  """If psutil raises, assume no headroom rather than admitting blindly."""
+
+  def _boom():
+    raise RuntimeError("psutil unavailable")
+
+  monkeypatch.setattr(
+    "robosystems.graph_api.core.admission_control.psutil.virtual_memory", _boom
+  )
+  controller = LadybugAdmissionController(min_available_mb=1024.0, check_interval=0.0)
+
+  decision, reason = controller.check_admission("graph-123")
+
+  assert decision == AdmissionDecision.REJECT_MEMORY
+  assert reason is not None
 
 
 def test_check_admission_rejects_on_cpu_for_ingestion(set_resource_usage):
@@ -113,6 +177,7 @@ def test_get_metrics_includes_live_counters(set_resource_usage):
   metrics = controller.get_metrics()
 
   assert metrics["memory_percent"] == pytest.approx(60.0)
+  assert metrics["memory_available_mb"] == pytest.approx(8192.0)
   assert metrics["cpu_percent"] == pytest.approx(40.0)
   assert metrics["connections_per_db"]["graph-123"] == 1
   assert metrics["total_connections"] == 1
@@ -133,6 +198,9 @@ def test_get_admission_controller_uses_env_configuration(monkeypatch):
   monkeypatch.setattr(
     "robosystems.config.env.LBUG_ADMISSION_CPU_THRESHOLD", 88.0, raising=False
   )
+  monkeypatch.setattr(
+    "robosystems.config.env.LBUG_ADMISSION_MIN_AVAILABLE_MB", 2048.0, raising=False
+  )
   # Patch the constant at its source module before the function imports it
   monkeypatch.setattr(
     "robosystems.config.constants.LBUG_MAX_CONNECTIONS_PER_DB",
@@ -145,5 +213,6 @@ def test_get_admission_controller_uses_env_configuration(monkeypatch):
 
   assert controller_one is controller_two  # Singleton
   assert controller_one.memory_threshold == 77.0
+  assert controller_one.min_available_mb == 2048.0
   assert controller_one.cpu_threshold == 88.0
   assert controller_one.max_connections_per_db == 5


### PR DESCRIPTION
## Problem

Shared SEC replicas rejected **331 of 611 requests (54%)** over a two-hour window, with ~684 admission rejections in the logs:

```
Query rejected for sec: Memory usage too high: 87.4% (threshold: 85.0%)
```

The guard compared `psutil.virtual_memory().percent` against 85%. But a LadybugDB buffer pool is a fixed pre-commitment that is *meant* to fill. Live readout from a warm replica:

```
total 15678 MB   used 13450   available 1974     → percent = 87.4%
```

An 8GB pool on a 15.7GB instance parks a warm node at ~87% used with **~2GB still free**, so the gate latched on and stayed on. `/health` never reflected it, so the ALB kept routing to nodes refusing all work — all three targets read `healthy` throughout.

## Why percent-used is the wrong signal

It folds a **constant** (the pool) into a reading meant to track the **variable** that predicts exhaustion (query working set). Consequences:

- The threshold must be re-tuned whenever the pool or instance type changes.
- It has silently broken **twice, identically** — first on m7g.large, then again on r7g.large after `63222ffd` grew the pool 3.5GB → 8GB. The `graph.yml` comment documents the first occurrence in the same words: *"latched into 503s that /health never reflected, so the ALB kept routing."*
- Sizing up doesn't fix it. Last time the pool grew *with* the instance, so the percentage stayed pinned.

The guard has also never been load-bearing. cgroup counters from a warm replica:

```
max        20130     ← hit the 13GB ceiling 20,130 times
oom            0
oom_kill       0
RestartCount=0  OOMKilled=false   (kernel OOM messages: 0)
```

Never OOM-killed. The container sits at its ceiling because cgroup `memory.current` includes reclaimable page cache from streaming the 122GB `.lbug`, and the kernel reclaims every time. Both prior incidents were the *guard* failing, not an OOM.

## Change

Reject on **absolute free memory**, which doesn't move when the pool or instance size changes:

| | Signal | Role |
|---|---|---|
| `min_available_mb` (new) | `virtual_memory().available` | **Rejection gate.** Default 1024MB |
| `memory_threshold` | percent used | **Reporting only.** `routers/graphs/health.py:78` uses it to classify a node `constrained`, which stays accurate |

The engine's own `max_memory_mb: 10240` cap remains the backstop against a single query overcommitting — it's precise and allocation-aware, and was never the binding constraint.

Resource probe failures now **fail closed** (assume no headroom) rather than defaulting to 80% and admitting blindly.

## Notes

- **No SSM change needed.** The stale `lbug_admission/MEMORY_THRESHOLD=85` keeps its reporting meaning and no longer gates queries, so the fix lands without touching prod config. Optionally tune via `lbug_admission/MIN_AVAILABLE_MB`.
- **The 1024MB default wants revisiting** once peak query working set is instrumented. Measured warm headroom was ~2GB, so this leaves ~950MB of margin — reasoned, not measured. It's SSM-tunable.
- `AdmissionControlConfig` in `models/cluster.py` is descriptive metadata only, not a gate — deliberately unchanged.
- The API-tier controller in `middleware/graph/admission_control.py` has the same percent-based shape but sits at 90% and did not fire here. Left alone to keep this reviewable; worth a follow-up.

## Immediate mitigation already applied

Rolled `docker restart graph-api-shared` across all three replicas (read-only nodes, DB already on local disk, ~20s each, no 122GB re-download). Memory went 87.4% → ~37%, available 1974MB → ~9.8GB, all targets healthy, and live SEC queries confirmed working. That buys ~3.5–4.5h under sustained load — the measured time from launch to first rejection — so this fix is what makes it durable.

## Testing

- `uv run pytest tests/graph_api/test_graph_api_admission_control.py tests/middleware/graph/test_query_queue.py` — 44 passed
- `uv run pytest tests/config` — 487 passed; health/metrics surface — 112 passed
- `just test-code` — clean
- New regression tests: warm pool at 87.4%/1974MB free is admitted; the gate returns the same verdict regardless of instance size; probe failure fails closed