### PR TITLE
fix(infra): grant the volume monitor scan/delete on the instance registry

### DIFF
--- a/cloudformation/graph-volumes.yaml
+++ b/cloudformation/graph-volumes.yaml
@@ -317,6 +317,14 @@ Resources:
                     - UseProvidedVolumeRegistry
                     - !Sub "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${VolumeRegistryTable}/index/*"
                     - !Sub "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/robosystems-graph-${Environment}-volume-registry/index/*"
+              # Instance-registry reconciliation (sync_instance_registry, runs
+              # inside every scheduled monitor_all): scan the registry and
+              # delete rows whose EC2 instance no longer exists.
+              - Effect: Allow
+                Action:
+                  - dynamodb:Scan
+                  - dynamodb:DeleteItem
+                Resource: !Sub "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/robosystems-graph-${Environment}-instance-registry"
               - Effect: Allow
                 Action:
                   - ssm:SendCommand


### PR DESCRIPTION
## Summary

Staging is firing `LadybugDB Volume Monitoring Errors` SNS alerts every 15 minutes: the #961 reconciler runs `sync_instance_registry` inside every scheduled `monitor_all`, but the volume-monitor role's DynamoDB grant only covers the **volume**-registry table — the only instance-registry grant in the template sits on the *detachment* Lambda's role. Every scan fails with `AccessDeniedException`, so the reconciler has never actually run.

Adds a scoped statement to `VolumeMonitorPolicy`: `dynamodb:Scan` + `dynamodb:DeleteItem` on `robosystems-graph-${Environment}-instance-registry` — exactly the two calls the reconciler makes (its metric emission already has `cloudwatch:PutMetricData`).

Deploying this to staging stops the alert spam; it must ride along whenever prod picks up the reconciler (v1.6.16), or prod inherits the same failure loop.

## Testing

- `cfn-lint` clean on the template.
- Note: this is a CloudFormation-tracked role change, so the stack update applies it directly — no ASG refresh needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)