### PR TITLE
feat(roboledger): assert-metrics — asserted metric series write path

### DIFF
--- a/robosystems/models/api/information_block.py
+++ b/robosystems/models/api/information_block.py
@@ -1843,6 +1843,138 @@ class ComputeMetricsResponse(BaseModel):
   skipped: list[SkippedMetricLite] = Field(default_factory=list)
 
 
+class MetricObservation(BaseModel):
+  """One externally-observed value in an ``assert-metrics`` request."""
+
+  qname: str = Field(
+    ...,
+    min_length=1,
+    description=(
+      "Metric element qname (e.g. rsx:GithubStars). Must resolve to a "
+      "concept on the structure's presentation catalog."
+    ),
+  )
+  value: float = Field(..., description="Observed value.")
+
+
+class AssertedMetricLite(BaseModel):
+  """One metric written by an ``assert-metrics`` run."""
+
+  element_id: str = Field(..., description="Metric element the fact was written for.")
+  element_qname: str = Field(..., description="Metric element qname.")
+  name: str = Field(..., description="Metric display name.")
+  value: float = Field(..., description="Asserted value.")
+  unit: str = Field(
+    ..., description="Fact unit — 'USD' for monetary, 'days' for days, else 'pure'."
+  )
+  period_type: str = Field(..., description="'instant' or 'duration'.")
+  item_type: str | None = Field(
+    None,
+    description=(
+      "Format family from the metric element (monetary | ratio | percent "
+      "| multiple | days). None means untyped; fall back to unit."
+    ),
+  )
+
+
+class AssertMetricsRequest(BaseModel):
+  """Request body for the ``assert-metrics`` operation.
+
+  The observation sibling of ``compute-metrics``: writes externally-
+  observed values (usage counts, marketing numbers, hand-carried
+  figures) into the period's standing ``factset_type='metric'`` FactSet
+  with ``AssertedProvenance``. Re-asserting a period replaces its facts
+  — one standing FactSet per (structure, entity, period_end), the
+  accumulating time series.
+
+  Structures carrying ``Derive`` rules are compute-owned
+  (``compute-metrics``) and rejected — asserted and derived metric
+  series keep disjoint structures. Asserted series are actuals; there
+  is no scenario axis.
+  """
+
+  structure_id: str = Field(
+    ...,
+    description="Metric block structure (block_type='metric') to assert into.",
+  )
+  period_end: date = Field(
+    ...,
+    description=(
+      "Period end the observations are for — instant concepts (a follower "
+      "count at month end) land as of this date; duration concepts (monthly "
+      "downloads) end on it."
+    ),
+  )
+  period_start: date | None = Field(
+    None,
+    description=(
+      "Window start for duration concepts and the standing FactSet's "
+      "period_start. Instant concepts ignore it."
+    ),
+  )
+  entity_id: str | None = Field(
+    None,
+    description=(
+      "Entity to assert for. Defaults to the graph's earliest-created "
+      "entity (the primary entity for single-entity graphs)."
+    ),
+  )
+  source_system: str = Field(
+    ...,
+    min_length=1,
+    description=(
+      "Identifier of the asserting system (e.g. 'content-machine') — "
+      "recorded as the AssertedProvenance source_system."
+    ),
+  )
+  basis_note: str | None = Field(
+    None,
+    description="Free-text basis / source reference for the observations.",
+  )
+  observations: list[MetricObservation] = Field(
+    ...,
+    min_length=1,
+    description="Observed values, one per metric concept — duplicates rejected.",
+  )
+
+  model_config = ConfigDict(
+    json_schema_extra={
+      "examples": [
+        {
+          "structure_id": "str_growth_metrics",
+          "period_start": "2026-07-01",
+          "period_end": "2026-07-31",
+          "source_system": "content-machine",
+          "observations": [
+            {"qname": "rsx:GithubStars", "value": 1240},
+            {"qname": "rsx:NpmDownloads", "value": 3811},
+          ],
+        }
+      ]
+    }
+  )
+
+
+class AssertMetricsResponse(BaseModel):
+  """Response for the ``assert-metrics`` operation."""
+
+  structure_id: str
+  entity_id: str
+  period_end: date
+  fact_set_id: str = Field(
+    ...,
+    description="Standing metric FactSet the observations were written to.",
+  )
+  asserted: list[AssertedMetricLite] = Field(default_factory=list)
+  replaced: bool = Field(
+    False,
+    description=(
+      "True when a prior standing set existed for the period and its "
+      "facts were replaced."
+    ),
+  )
+
+
 class ForecastMonthLite(BaseModel):
   """One computed forward month in a ``compute-forecast`` response."""
 
@@ -1971,6 +2103,9 @@ class ComputeForecastResponse(BaseModel):
 __all__ = [
   "ArtifactMechanics",
   "ArtifactResponse",
+  "AssertMetricsRequest",
+  "AssertMetricsResponse",
+  "AssertedMetricLite",
   "ChartLite",
   "ChartPanelLite",
   "ChartSeriesLite",
@@ -1996,6 +2131,7 @@ __all__ = [
   "LeverAssertionLite",
   "LineAssertionLite",
   "MetricMechanics",
+  "MetricObservation",
   "RenderingLite",
   "RenderingPeriodLite",
   "RenderingRowLite",

--- a/robosystems/operations/information_block/metrics.py
+++ b/robosystems/operations/information_block/metrics.py
@@ -1,13 +1,18 @@
-"""compute-metrics — evaluate Derive rules into a standing metric FactSet.
+"""compute-metrics / assert-metrics — write a standing metric FactSet.
 
-The metric block's compute path (Metrics M-1 + the M-2 grammar).
-``Derive`` rules carry the same ``$Var`` expression grammar as
-verification rules, but are evaluated for a VALUE: the LHS names the
-metric element being computed, the RHS operands bind to the entity's
-persisted facts at the requested ``period_end``, and the result is
-written as a Numeric fact in a standing ``factset_type='metric'``
-FactSet — one per (structure, entity, period_end), so successive runs
-accumulate the time series and re-running a period replaces its values.
+The metric block's two write paths. ``compute-metrics`` (Metrics M-1 +
+the M-2 grammar) evaluates ``Derive`` rules: the same ``$Var``
+expression grammar as verification rules, but evaluated for a VALUE —
+the LHS names the metric element being computed, the RHS operands bind
+to the entity's persisted facts at the requested ``period_end``, and
+the result is written as a Numeric fact in a standing
+``factset_type='metric'`` FactSet — one per (structure, entity,
+period_end), so successive runs accumulate the time series and
+re-running a period replaces its values. ``assert-metrics`` is the
+observation sibling: externally-observed values arrive in the request
+and land on the same standing-set shape with ``AssertedProvenance``;
+structures carrying Derive rules are compute-owned and rejected, so
+asserted and derived series keep disjoint structures.
 
 M-2 grammar:
 
@@ -45,11 +50,18 @@ from datetime import date, timedelta
 from sqlalchemy import func, or_, select, text
 from sqlalchemy.orm import Session
 
-from robosystems.models.api.fact_provenance import DerivedProvenance
+from robosystems.models.api.fact_provenance import (
+  AssertedProvenance,
+  DerivedProvenance,
+)
 from robosystems.models.api.information_block import (
+  AssertedMetricLite,
+  AssertMetricsRequest,
+  AssertMetricsResponse,
   ComputedMetricLite,
   ComputeMetricsRequest,
   ComputeMetricsResponse,
+  MetricObservation,
   SkippedMetricLite,
 )
 from robosystems.models.extensions import (
@@ -562,4 +574,228 @@ def cmd_compute_metrics(
   )
 
 
-__all__ = ["cmd_compute_metrics"]
+# Mirrors forecast.py's _ASSERTION_BLOCKED_SOURCES — duplicated rather than
+# imported because forecast imports this module, so the reverse import would
+# be circular. Library-computed and lever concepts are never asserted here.
+_ASSERTION_BLOCKED_ELEMENT_SOURCES = {
+  "rs-metric": "rs-metric concepts are computed by compute-metrics, never asserted",
+  "rs-driver": "rs-driver concepts are forecast levers — assert them via `levers`",
+}
+
+
+def cmd_assert_metrics(
+  session: Session,
+  body: AssertMetricsRequest,
+  created_by: str,
+) -> AssertMetricsResponse:
+  """Write externally-observed metric values for one period.
+
+  The observation sibling of ``cmd_compute_metrics``: same standing
+  FactSet upsert (found → all its facts are deleted and provenance is
+  re-stamped; absent → created via the blessed ``create_fact_set``
+  path), but the values arrive in the request and the set is stamped
+  with ``AssertedProvenance``. Structures carrying Derive rules are
+  compute-owned and rejected — asserted and derived metric series keep
+  disjoint structures, which is also what keeps the two writers' full-
+  replace semantics from clobbering each other. ``session.flush()``
+  before returning; the OperationSpec wrapper owns the commit.
+  """
+  structure = session.get(Structure, body.structure_id)
+  if structure is None:
+    raise ValueError(f"Structure not found: {body.structure_id}")
+  if structure.block_type != METRIC_BLOCK_TYPE:
+    raise ValueError(
+      f"assert-metrics targets a block_type='metric' structure; "
+      f"{body.structure_id!r} is {structure.block_type!r}"
+    )
+
+  entity_id = body.entity_id or _default_entity_id(session)
+
+  associations = (
+    session.execute(
+      select(Association).where(Association.structure_id == body.structure_id)
+    )
+    .scalars()
+    .all()
+  )
+  element_ids = {
+    x
+    for x in (
+      {a.from_element_id for a in associations}
+      | {a.to_element_id for a in associations}
+    )
+    if x is not None
+  }
+  order_by_element: dict[str, float] = {}
+  for a in associations:
+    if a.to_element_id is not None and a.order_value is not None:
+      order_by_element.setdefault(a.to_element_id, float(a.order_value))
+
+  rules = _load_derive_rules(session, body.structure_id, list(element_ids))
+  if rules:
+    raise ValueError(
+      f"Structure {body.structure_id!r} carries {len(rules)} Derive rule(s) "
+      "and is compute-owned (compute-metrics); asserted and derived metric "
+      "series keep disjoint structures"
+    )
+
+  seen: set[str] = set()
+  duplicates: set[str] = set()
+  for obs in body.observations:
+    if obs.qname in seen:
+      duplicates.add(obs.qname)
+    seen.add(obs.qname)
+  if duplicates:
+    raise ValueError(
+      f"Duplicate observation qname(s): {sorted(duplicates)!r} — one "
+      "observation per concept per period"
+    )
+
+  qname_cache: dict[str, Element | None] = {}
+
+  def _element_by_qname(qname: str) -> Element | None:
+    if qname not in qname_cache:
+      qname_cache[qname] = session.execute(
+        select(Element).where(Element.qname == qname).limit(1)
+      ).scalar_one_or_none()
+    return qname_cache[qname]
+
+  unknown: list[str] = []
+  abstract: list[str] = []
+  blocked: list[str] = []
+  outside: list[str] = []
+  resolved: list[tuple[MetricObservation, Element]] = []
+  for obs in body.observations:
+    element = _element_by_qname(obs.qname)
+    if element is None:
+      unknown.append(obs.qname)
+      continue
+    if element.is_abstract:
+      abstract.append(obs.qname)
+      continue
+    doctrine = _ASSERTION_BLOCKED_ELEMENT_SOURCES.get(element.source or "")
+    if doctrine is not None:
+      blocked.append(f"{obs.qname} ({doctrine})")
+      continue
+    if element_ids and element.id not in element_ids:
+      # Facts for concepts outside the presentation catalog would persist
+      # but never render in the envelope — reject rather than no-op.
+      outside.append(obs.qname)
+      continue
+    resolved.append((obs, element))
+
+  problems: list[str] = []
+  if unknown:
+    problems.append(f"unknown qname(s): {unknown!r}")
+  if abstract:
+    problems.append(f"abstract concept(s) cannot carry facts: {abstract!r}")
+  if blocked:
+    problems.append(f"blocked concept(s): {blocked!r}")
+  if outside:
+    problems.append(
+      f"concept(s) not on the structure's presentation catalog: {outside!r}"
+    )
+  if problems:
+    raise ValueError("assert-metrics rejected: " + "; ".join(problems))
+
+  resolved.sort(key=lambda pair: order_by_element.get(pair[1].id, float("inf")))
+
+  asserted: list[AssertedMetricLite] = []
+  pending_facts: list[dict] = []
+  for obs, element in resolved:
+    unit = _metric_unit(element)
+    period_type = element.period_type or "instant"
+    fact_period_start = body.period_start if period_type == "duration" else None
+    pending_facts.append(
+      {
+        "element_id": element.id,
+        "value": obs.value,
+        "period_start": fact_period_start,
+        "period_type": period_type,
+        "unit": unit,
+      }
+    )
+    asserted.append(
+      AssertedMetricLite(
+        element_id=element.id,
+        element_qname=obs.qname,
+        name=element.name,
+        value=obs.value,
+        unit=unit,
+        period_type=period_type,
+        item_type=element.item_type,
+      )
+    )
+
+  provenance = AssertedProvenance(
+    source_system=body.source_system,
+    asserted_by=created_by,
+    basis_note=body.basis_note,
+  )
+
+  standing = session.execute(
+    select(FactSet)
+    .where(
+      FactSet.structure_id == body.structure_id,
+      FactSet.factset_type == "metric",
+      FactSet.entity_id == entity_id,
+      FactSet.period_end == body.period_end,
+      # Asserted series are actuals — the scenario axis never applies.
+      FactSet.scenario_id.is_(None),
+    )
+    .order_by(FactSet.created_at.desc())
+    .limit(1)
+  ).scalar_one_or_none()
+
+  replaced = standing is not None
+  if standing is None:
+    standing = create_fact_set(
+      session,
+      structure_id=body.structure_id,
+      period_start=body.period_start,
+      period_end=body.period_end,
+      factset_type="metric",
+      entity_id=entity_id,
+      provenance=provenance,
+      created_by=created_by,
+    )
+    session.flush()
+  else:
+    # Full replace — the period's values are re-asserted state.
+    for fact in (
+      session.execute(select(Fact).where(Fact.fact_set_id == standing.id))
+      .scalars()
+      .all()
+    ):
+      session.delete(fact)
+    standing.provenance = provenance.model_dump(mode="json")
+
+  for pf in pending_facts:
+    session.add(
+      Fact(
+        id=generate_prefixed_ulid("fact"),
+        element_id=pf["element_id"],
+        value=pf["value"],
+        fact_type="Numeric",
+        period_start=pf["period_start"],
+        period_end=body.period_end,
+        period_type=pf["period_type"],
+        unit=pf["unit"],
+        entity_id=entity_id,
+        structure_id=body.structure_id,
+        fact_set_id=standing.id,
+      )
+    )
+  session.flush()
+
+  return AssertMetricsResponse(
+    structure_id=body.structure_id,
+    entity_id=entity_id,
+    period_end=body.period_end,
+    fact_set_id=standing.id,
+    asserted=asserted,
+    replaced=replaced,
+  )
+
+
+__all__ = ["cmd_assert_metrics", "cmd_compute_metrics"]

--- a/robosystems/operations/information_block/registry.py
+++ b/robosystems/operations/information_block/registry.py
@@ -326,10 +326,11 @@ METRIC_BLOCK = BlockTypeRegistryEntry(
   category=METRIC_CATEGORY,
   icon="gauge",
   description=(
-    "Derivative block — computes its facts from one or more source "
-    "blocks at read time. Covenant tests, ratios, KPI trend views. "
-    "Typed mechanics ship today; the derivation evaluator that "
-    "computes facts from source-block FactSets is not yet implemented."
+    "Derivative block — a standing per-period fact series. Covenant "
+    "tests, ratios, KPI trend views. Facts are written by the "
+    "`compute-metrics` operation (Derive-rule evaluation) or the "
+    "`assert-metrics` operation (externally-observed values); metric "
+    "structures are authored via `create-taxonomy-block`."
   ),
   concept_arrangement_default="arithmetic",
   member_arrangement_default=None,
@@ -340,22 +341,24 @@ METRIC_BLOCK = BlockTypeRegistryEntry(
   construction_mode="derivative",
   dispatch_create=make_not_implemented_handler(
     "create-metric-block",
-    "Metric block construction is not yet available — the typed "
-    "`MetricMechanics` arm ships today (so callers can already query "
-    'metric envelopes via `informationBlocks(blockType="metric")`), '
-    "but the derivation evaluator that computes facts from source-block "
-    "FactSets is not yet implemented; no caller-side workaround is "
-    "available.",
+    "Metric blocks are not constructed through this operation — author "
+    "the metric structure (elements, presentation arcs, optional Derive "
+    "rules) via `create-taxonomy-block`, then write facts with "
+    "`compute-metrics` (rule evaluation) or `assert-metrics` "
+    "(externally-observed values). Envelopes are queryable via "
+    '`informationBlocks(blockType="metric")`.',
   ),
   dispatch_update=make_not_implemented_handler(
     "update-metric-block",
-    "Metric block updates are not yet available — pending the "
-    "derivation evaluator. See `create-metric-block` for context.",
+    "Metric block updates are not available through this operation — "
+    "author structure changes via the taxonomy-block operations. See "
+    "`create-metric-block` for context.",
   ),
   dispatch_delete=make_not_implemented_handler(
     "delete-metric-block",
-    "Metric block deletion is not yet available — pending the "
-    "derivation evaluator. See `create-metric-block` for context.",
+    "Metric block deletion is not available through this operation — "
+    "manage the structure via the taxonomy-block operations. See "
+    "`create-metric-block` for context.",
   ),
   dispatch_build_envelope=metric_handlers.build_envelope,
   surfaces_in_library=False,

--- a/robosystems/routers/extensions/roboledger/operations.py
+++ b/robosystems/routers/extensions/roboledger/operations.py
@@ -175,6 +175,8 @@ from robosystems.models.api.extensions.text_blocks import (
   BindTextBlockResponse,
 )
 from robosystems.models.api.information_block import (
+  AssertMetricsRequest,
+  AssertMetricsResponse,
   ComputeForecastRequest,
   ComputeForecastResponse,
   ComputeMetricsRequest,
@@ -244,6 +246,7 @@ from robosystems.operations.information_block.forecast_compute import (
   cmd_compute_forecast,
 )
 from robosystems.operations.information_block.metrics import (
+  cmd_assert_metrics,
   cmd_compute_metrics,
 )
 from robosystems.operations.information_block.rules.commands import (
@@ -1230,6 +1233,31 @@ compute_metrics_op = _registrar.register(
     result_type=ComputeMetricsResponse,
     error_map={ValueError: 422},
     mark_stale_reason="metrics_computed",
+    requires_created_by=True,
+  )
+)
+
+assert_metrics_op = _registrar.register(
+  OperationSpec(
+    name="assert-metrics",
+    summary="Assert Metrics for a Metric Block",
+    description=(
+      "Writes externally-observed metric values (usage counts, marketing "
+      "numbers, hand-carried figures) into the period's standing "
+      "factset_type='metric' FactSet with AssertedProvenance — the "
+      "observation sibling of compute-metrics. One standing FactSet per "
+      "(structure, entity, period_end); re-asserting a period replaces "
+      "its facts. Structures carrying Derive rules are compute-owned and "
+      "rejected: asserted and derived metric series keep disjoint "
+      "structures. Observations must resolve to concepts on the "
+      "structure's presentation catalog. Deterministic and non-AI — no "
+      "credits consumed."
+    ),
+    command=cmd_assert_metrics,
+    request_model=AssertMetricsRequest,
+    result_type=AssertMetricsResponse,
+    error_map={ValueError: 422},
+    mark_stale_reason="metrics_asserted",
     requires_created_by=True,
   )
 )

--- a/tests/operations/information_block/test_metrics_assert.py
+++ b/tests/operations/information_block/test_metrics_assert.py
@@ -1,0 +1,371 @@
+"""Tests for ``cmd_assert_metrics`` — observed values → standing metric FactSet."""
+
+from __future__ import annotations
+
+from datetime import date
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from robosystems.models.api.information_block import AssertMetricsRequest
+from robosystems.operations.information_block import metrics as metrics_mod
+
+PERIOD_START = date(2026, 7, 1)
+PERIOD_END = date(2026, 7, 31)
+
+
+def _scalars(items: list[Any]) -> MagicMock:
+  result = MagicMock()
+  result.scalars.return_value.all.return_value = items
+  return result
+
+
+def _scalar_one(value: Any) -> MagicMock:
+  result = MagicMock()
+  result.scalar_one_or_none.return_value = value
+  return result
+
+
+def _fetchone(row: Any) -> MagicMock:
+  result = MagicMock()
+  result.fetchone.return_value = row
+  return result
+
+
+def _structure(block_type: str = "metric") -> MagicMock:
+  s = MagicMock()
+  s.id = "str_growth"
+  s.block_type = block_type
+  return s
+
+
+def _element(
+  element_id: str,
+  qname: str,
+  name: str,
+  *,
+  monetary: bool = False,
+  period_type: str = "instant",
+  item_type: str | None = None,
+  source: str = "native",
+  is_abstract: bool = False,
+) -> SimpleNamespace:
+  return SimpleNamespace(
+    id=element_id,
+    qname=qname,
+    name=name,
+    is_monetary=monetary,
+    period_type=period_type,
+    item_type=item_type,
+    source=source,
+    is_abstract=is_abstract,
+  )
+
+
+EL_STARS = _element("el_stars", "rsx:GithubStars", "GitHub Stars")
+EL_DOWNLOADS = _element(
+  "el_dl", "rsx:NpmDownloads", "npm Downloads", period_type="duration"
+)
+EL_ABSTRACT = _element(
+  "el_root", "rsx:GrowthMetricsAbstract", "Growth Metrics", is_abstract=True
+)
+EL_LIBRARY = _element(
+  "el_cr", "rs-metric:CurrentRatio", "Current Ratio", source="rs-metric"
+)
+EL_LEVER = _element(
+  "el_lev", "rs-driver:RevenueGrowth", "Revenue Growth", source="rs-driver"
+)
+EL_STRAY = _element("el_stray", "rsx:Unarced", "Not On Structure")
+
+
+def _arc(to_element_id: str, order: float) -> SimpleNamespace:
+  return SimpleNamespace(
+    from_element_id="el_root", to_element_id=to_element_id, order_value=order
+  )
+
+
+ARCS = [_arc("el_stars", 1.0), _arc("el_dl", 2.0)]
+
+
+def _rule() -> SimpleNamespace:
+  return SimpleNamespace(id="rule_1", target_element_id="el_stars")
+
+
+def _session(structure: MagicMock) -> MagicMock:
+  session = MagicMock()
+  session.get.side_effect = lambda model, pk: structure if pk == structure.id else None
+  return session
+
+
+def _body(**overrides: Any) -> AssertMetricsRequest:
+  kwargs: dict[str, Any] = {
+    "structure_id": "str_growth",
+    "period_start": PERIOD_START,
+    "period_end": PERIOD_END,
+    "entity_id": "ent_1",
+    "source_system": "content-machine",
+    "observations": [{"qname": "rsx:GithubStars", "value": 1240}],
+  }
+  kwargs.update(overrides)
+  return AssertMetricsRequest(**kwargs)
+
+
+def _added_facts(session: MagicMock) -> list[Any]:
+  return [call.args[0] for call in session.add.call_args_list]
+
+
+class TestAssertMetrics:
+  def test_asserts_into_new_standing_set_in_arc_order(self) -> None:
+    structure = _structure()
+    session = _session(structure)
+    session.execute.side_effect = [
+      _scalars(ARCS),
+      _scalars([]),  # no Derive rules
+      _scalar_one(EL_DOWNLOADS),  # qname lookup (observation order)
+      _scalar_one(EL_STARS),
+      _scalar_one(None),  # standing FactSet lookup
+    ]
+    fact_set = MagicMock()
+    fact_set.id = "fs_new"
+
+    with patch.object(
+      metrics_mod, "create_fact_set", return_value=fact_set
+    ) as create_fs:
+      result = metrics_mod.cmd_assert_metrics(
+        session,
+        _body(
+          basis_note="July batch",
+          observations=[
+            {"qname": "rsx:NpmDownloads", "value": 3811},
+            {"qname": "rsx:GithubStars", "value": 1240},
+          ],
+        ),
+        created_by="user_1",
+      )
+
+    create_fs.assert_called_once()
+    fs_kwargs = create_fs.call_args.kwargs
+    assert fs_kwargs["factset_type"] == "metric"
+    assert fs_kwargs["entity_id"] == "ent_1"
+    assert fs_kwargs["period_end"] == PERIOD_END
+    provenance = fs_kwargs["provenance"]
+    assert provenance.origin == "asserted"
+    assert provenance.source_system == "content-machine"
+    assert provenance.asserted_by == "user_1"
+    assert provenance.basis_note == "July batch"
+
+    assert result.replaced is False
+    assert result.fact_set_id == "fs_new"
+    # Observations were given in reverse arc order — response re-sorts.
+    assert [m.element_qname for m in result.asserted] == [
+      "rsx:GithubStars",
+      "rsx:NpmDownloads",
+    ]
+    facts = _added_facts(session)
+    assert len(facts) == 2
+    assert {f.fact_set_id for f in facts} == {"fs_new"}
+    assert all(f.fact_type == "Numeric" for f in facts)
+
+  def test_reassert_replaces_prior_facts_and_restamps_provenance(self) -> None:
+    structure = _structure()
+    session = _session(structure)
+    standing = MagicMock()
+    standing.id = "fs_standing"
+    old_facts = [MagicMock(), MagicMock()]
+    session.execute.side_effect = [
+      _scalars(ARCS),
+      _scalars([]),
+      _scalar_one(EL_STARS),
+      _scalar_one(standing),
+      _scalars(old_facts),  # prior facts on the standing set
+    ]
+
+    with patch.object(metrics_mod, "create_fact_set") as create_fs:
+      result = metrics_mod.cmd_assert_metrics(session, _body(), created_by="user_1")
+
+    create_fs.assert_not_called()
+    for fact in old_facts:
+      session.delete.assert_any_call(fact)
+    assert standing.provenance["origin"] == "asserted"
+    assert standing.provenance["source_system"] == "content-machine"
+    assert result.replaced is True
+    assert result.fact_set_id == "fs_standing"
+
+  def test_missing_structure_rejected(self) -> None:
+    session = MagicMock()
+    session.get.return_value = None
+    session.get.side_effect = None
+
+    with pytest.raises(ValueError, match="Structure not found"):
+      metrics_mod.cmd_assert_metrics(session, _body(), created_by="user_1")
+
+  def test_wrong_block_type_rejected(self) -> None:
+    session = _session(_structure(block_type="schedule"))
+
+    with pytest.raises(ValueError, match="block_type='metric'"):
+      metrics_mod.cmd_assert_metrics(session, _body(), created_by="user_1")
+
+  def test_structure_with_derive_rules_is_compute_owned(self) -> None:
+    session = _session(_structure())
+    session.execute.side_effect = [
+      _scalars(ARCS),
+      _scalars([_rule()]),
+    ]
+
+    with pytest.raises(ValueError, match="compute-owned"):
+      metrics_mod.cmd_assert_metrics(session, _body(), created_by="user_1")
+    assert session.execute.call_count == 2
+
+  def test_duplicate_qnames_rejected_before_lookups(self) -> None:
+    session = _session(_structure())
+    session.execute.side_effect = [
+      _scalars(ARCS),
+      _scalars([]),
+    ]
+
+    with pytest.raises(ValueError, match="Duplicate observation qname"):
+      metrics_mod.cmd_assert_metrics(
+        session,
+        _body(
+          observations=[
+            {"qname": "rsx:GithubStars", "value": 1.0},
+            {"qname": "rsx:GithubStars", "value": 2.0},
+          ]
+        ),
+        created_by="user_1",
+      )
+    assert session.execute.call_count == 2
+
+  def test_unknown_qnames_aggregated_into_one_error(self) -> None:
+    session = _session(_structure())
+    session.execute.side_effect = [
+      _scalars(ARCS),
+      _scalars([]),
+      _scalar_one(None),
+      _scalar_one(None),
+    ]
+
+    with pytest.raises(ValueError) as exc:
+      metrics_mod.cmd_assert_metrics(
+        session,
+        _body(
+          observations=[
+            {"qname": "rsx:Nope", "value": 1.0},
+            {"qname": "rsx:AlsoNope", "value": 2.0},
+          ]
+        ),
+        created_by="user_1",
+      )
+    assert "rsx:Nope" in str(exc.value)
+    assert "rsx:AlsoNope" in str(exc.value)
+
+  def test_abstract_element_rejected(self) -> None:
+    session = _session(_structure())
+    session.execute.side_effect = [
+      _scalars(ARCS),
+      _scalars([]),
+      _scalar_one(EL_ABSTRACT),
+    ]
+
+    with pytest.raises(ValueError, match="abstract"):
+      metrics_mod.cmd_assert_metrics(
+        session,
+        _body(observations=[{"qname": "rsx:GrowthMetricsAbstract", "value": 1.0}]),
+        created_by="user_1",
+      )
+
+  @pytest.mark.parametrize(
+    ("element", "doctrine"),
+    [
+      (EL_LIBRARY, "computed by compute-metrics"),
+      (EL_LEVER, "forecast levers"),
+    ],
+  )
+  def test_blocked_element_sources_rejected(
+    self, element: SimpleNamespace, doctrine: str
+  ) -> None:
+    session = _session(_structure())
+    session.execute.side_effect = [
+      _scalars(ARCS),
+      _scalars([]),
+      _scalar_one(element),
+    ]
+
+    with pytest.raises(ValueError, match=doctrine):
+      metrics_mod.cmd_assert_metrics(
+        session,
+        _body(observations=[{"qname": element.qname, "value": 1.0}]),
+        created_by="user_1",
+      )
+
+  def test_element_outside_structure_catalog_rejected(self) -> None:
+    session = _session(_structure())
+    session.execute.side_effect = [
+      _scalars(ARCS),
+      _scalars([]),
+      _scalar_one(EL_STRAY),
+    ]
+
+    with pytest.raises(ValueError, match="presentation catalog"):
+      metrics_mod.cmd_assert_metrics(
+        session,
+        _body(observations=[{"qname": "rsx:Unarced", "value": 1.0}]),
+        created_by="user_1",
+      )
+
+  def test_duration_and_instant_period_shapes(self) -> None:
+    structure = _structure()
+    session = _session(structure)
+    session.execute.side_effect = [
+      _scalars(ARCS),
+      _scalars([]),
+      _scalar_one(EL_STARS),
+      _scalar_one(EL_DOWNLOADS),
+      _scalar_one(None),
+    ]
+    fact_set = MagicMock()
+    fact_set.id = "fs_new"
+
+    with patch.object(metrics_mod, "create_fact_set", return_value=fact_set):
+      metrics_mod.cmd_assert_metrics(
+        session,
+        _body(
+          observations=[
+            {"qname": "rsx:GithubStars", "value": 1240},
+            {"qname": "rsx:NpmDownloads", "value": 3811},
+          ]
+        ),
+        created_by="user_1",
+      )
+
+    by_element = {f.element_id: f for f in _added_facts(session)}
+    assert by_element["el_stars"].period_type == "instant"
+    assert by_element["el_stars"].period_start is None
+    assert by_element["el_dl"].period_type == "duration"
+    assert by_element["el_dl"].period_start == PERIOD_START
+    assert by_element["el_dl"].period_end == PERIOD_END
+
+  def test_default_entity_resolved_when_omitted(self) -> None:
+    structure = _structure()
+    session = _session(structure)
+    session.execute.side_effect = [
+      _fetchone(SimpleNamespace(id="ent_first")),
+      _scalars(ARCS),
+      _scalars([]),
+      _scalar_one(EL_STARS),
+      _scalar_one(None),
+    ]
+    fact_set = MagicMock()
+    fact_set.id = "fs_new"
+
+    with patch.object(
+      metrics_mod, "create_fact_set", return_value=fact_set
+    ) as create_fs:
+      result = metrics_mod.cmd_assert_metrics(
+        session, _body(entity_id=None), created_by="user_1"
+      )
+
+    assert result.entity_id == "ent_first"
+    assert create_fs.call_args.kwargs["entity_id"] == "ent_first"


### PR DESCRIPTION
## Summary

Adds `assert-metrics` — the observation sibling of `compute-metrics`. Externally-observed metric values (usage counts, marketing numbers, hand-carried figures) can now be written into a metric block's standing per-period FactSet with `AssertedProvenance`, making the metric surface usable for series the platform doesn't compute itself. External integrations author their vocabulary once via `create-taxonomy-block`, then assert observed values per period; the read side (metric envelope, chart projection, GraphQL, MCP) renders asserted periods exactly like computed ones with zero changes.

## Changes

- **`robosystems/operations/information_block/metrics.py`** — new `cmd_assert_metrics`: resolves the same standing FactSet key as `compute-metrics` (`structure, factset_type='metric', entity, period_end`, actuals only), creates it via `create_fact_set` or full-replaces its facts on re-assert (replace-per-period — re-asserting never duplicates), and stamps `AssertedProvenance(source_system, asserted_by, basis_note)`. Guards (all 422): structure must be `block_type='metric'`; structures carrying Derive rules are compute-owned and rejected, keeping asserted and derived series in disjoint structures so the two writers' full-replace semantics can't clobber each other; observations must resolve to known, non-abstract concepts on the structure's presentation catalog; duplicate qnames rejected; `rs-metric` / `rs-driver` concepts stay un-assertable (mirrors the forecast-lever doctrine). Facts inherit unit/period shape from the element (`instant` values land on `period_end`; `duration` values carry the request window).
- **`robosystems/models/api/information_block.py`** — `AssertMetricsRequest` / `AssertMetricsResponse` / `MetricObservation` / `AssertedMetricLite` (no scenario axis — asserted series are actuals).
- **`robosystems/routers/extensions/roboledger/operations.py`** — registers the op at `POST /extensions/roboledger/{graph_id}/operations/assert-metrics` with the standard envelope, `Idempotency-Key` support, and `mark_stale_reason="metrics_asserted"`. The MCP tool mounts automatically via the registrar.
- **`robosystems/operations/information_block/registry.py`** — refreshes the metric-arm copy (description + the three 501 handler messages), which still described the pre-`compute-metrics` state; the 501 behavior itself is unchanged.
- **`tests/operations/information_block/test_metrics_assert.py`** — 13 unit tests covering the create path (provenance fields, arc-order response), re-assert replace (fact deletion + provenance restamp), and every rejection path, in the same style as `test_metrics_compute.py`.

## Testing

- `uv run pytest tests/operations/information_block/ tests/routers/extensions/roboledger/` — 529 passed.
- `just test-code` (ruff + format + basedpyright + cf-lint) — clean; pre-commit hooks green.
- Full `just test` locally: 2789 passed with one failure in `tests/graph_api/.../test_incremental_materialize.py` that is unrelated and pre-existing — it reproduces on this machine without this branch's code (a pyarrow 24.0.0 filesystem-registration collision triggered by `tests/adapters/sec` ordering; passes in isolation; CI on main is green).
- Manual verification against the local stack: authored a rule-less "Growth Metrics" structure via `create-taxonomy-block`, asserted two periods, re-asserted one (`replaced: true`, same FactSet), confirmed the 422 on unknown qnames, and read the accumulated two-period series back through GraphQL `informationBlocks(blockType: "metric")` — rows in arc order, replaced values reflected.

## Notes

- A metric structure that later gains a Derive rule strands prior asserted sets as compute-replaceable — accepted; the disjoint-structures guard makes the states mutually exclusive at any point in time.
- SDK regeneration (Python/TypeScript clients) picks the new op up from OpenAPI after merge.
