### PR TITLE
refactor(roboledger): build-fact-grid returns facts, not a pivot

### DIFF
--- a/robosystems/middleware/mcp/tools/fact_grid_tool.py
+++ b/robosystems/middleware/mcp/tools/fact_grid_tool.py
@@ -14,6 +14,7 @@ The tool's job is:
 
 from __future__ import annotations
 
+import time
 from typing import Any
 
 from robosystems.logger import logger
@@ -21,6 +22,7 @@ from robosystems.models.api.views import ViewAxisConfig, ViewConfig
 from robosystems.operations.roboledger.views import (
   FactGridBuilder,
   query_fact_grid,
+  summarize_by_element,
 )
 
 
@@ -56,9 +58,12 @@ class BuildFactGridTool:
 - fiscal_year/fiscal_period: Filter by report fiscal context
 
 **RETURNS:**
-- Deduplicated facts with element qnames, names, values, periods, and units
-- Entity ticker and name included when entity filters are used
+- Deduplicated facts with element qnames, names, values, periods, and units — one record per fact, not a pivot table
+- Entity ticker and name ONLY when an entity filter is used
 - Only consolidated totals (dimensional breakdowns excluded)
+
+**IMPORTANT:**
+Always pass entity or entities. Without an entity filter the response carries no entity identity at all, so facts from different filers are indistinguishable — and the query degrades to a full scan of the fact table, which is slow on large repositories like SEC.
 
 **TIP:**
 For income statement items (revenue, net income), always specify period_type='annual' or 'quarterly' to avoid mixing duration types. Use canonical_concepts for cross-company comparisons where companies may use different XBRL tags for the same concept.""",
@@ -106,19 +111,14 @@ For income statement items (revenue, net income), always specify period_type='an
             "description": "Filter by period type: 'annual' (duration facts only), 'quarterly' (duration facts only), 'instant' (point-in-time facts). Default depends on statement type.",
             "enum": ["annual", "quarterly", "instant"],
           },
-          "dimensions": {
-            "type": "object",
-            "description": "Optional dimensional filters (e.g., segment, geography)",
-            "default": {},
-          },
           "rows": {
             "type": "array",
-            "description": "Optional axis configuration for rows",
+            "description": "Optional aspect scoping, e.g. [{'type': 'period', 'selected_members': ['2024-12-31']}]",
             "default": [],
           },
           "columns": {
             "type": "array",
-            "description": "Optional axis configuration for columns",
+            "description": "Optional aspect scoping; same shape as 'rows'. Rows/columns are naming conventions only — both filter.",
             "default": [],
           },
           "include_summary": {
@@ -176,6 +176,8 @@ For income statement items (revenue, net income), always specify period_type='an
           "message": f"Column {i} must be a dictionary with axis configuration",
         }
 
+    start_time = time.time()
+
     fact_data = await query_fact_grid(
       graph_id=self.client.graph_id,
       elements=elements or None,
@@ -198,14 +200,15 @@ For income statement items (revenue, net income), always specify period_type='an
       fact_data=fact_data, view_config=view_config, source="mcp_tool"
     )
 
+    # Query time dominates; timing only the in-memory build reported ~1ms
+    # regardless of how long the graph took.
+    elapsed_ms = (time.time() - start_time) * 1000
+
     logger.info(
       f"Built fact grid with {fact_grid.metadata.fact_count} facts "
-      f"across {fact_grid.metadata.dimension_count} dimensions"
+      f"across {fact_grid.metadata.dimension_count} dimensions "
+      f"in {elapsed_ms:.0f}ms"
     )
-
-    data_records: list[dict[str, Any]] = []
-    if fact_grid.facts_df is not None and not fact_grid.facts_df.empty:
-      data_records = fact_grid.facts_df.to_dict(orient="records")
 
     response: dict[str, Any] = {
       "success": True,
@@ -220,28 +223,12 @@ For income statement items (revenue, net income), always specify period_type='an
         }
         for d in fact_grid.dimensions
       ],
-      "data": data_records,
-      "construction_time_ms": fact_grid.metadata.construction_time_ms,
+      "data": fact_grid.facts,
+      "construction_time_ms": elapsed_ms,
       "message": f"Built fact grid with {fact_grid.metadata.fact_count} facts",
     }
 
-    if (
-      include_summary
-      and fact_grid.facts_df is not None
-      and not fact_grid.facts_df.empty
-    ):
-      df = fact_grid.facts_df
-      if "element_name" in df.columns and "value" in df.columns:
-        summary: dict[str, dict[str, float]] = {}
-        for element_name in df["element_name"].unique():
-          element_data = df[df["element_name"] == element_name]
-          summary[element_name] = {
-            "count": len(element_data),
-            "total": float(element_data["value"].sum()),
-            "average": float(element_data["value"].mean()),
-            "min": float(element_data["value"].min()),
-            "max": float(element_data["value"].max()),
-          }
-        response["summary"] = summary
+    if include_summary and fact_grid.facts:
+      response["summary"] = summarize_by_element(fact_grid.facts)
 
     return response

--- a/robosystems/models/api/views/__init__.py
+++ b/robosystems/models/api/views/__init__.py
@@ -10,7 +10,8 @@ from robosystems.models.api.views.view_config import (
   ViewConfig,
 )
 from robosystems.models.api.views.view_response import (
-  PivotTablePresentation,
+  ElementSummary,
+  FactRecord,
   ViewMetadata,
   ViewResponse,
 )
@@ -19,9 +20,10 @@ __all__ = [
   "CreateViewRequest",
   "Dimension",
   "DimensionType",
+  "ElementSummary",
   "FactGrid",
   "FactGridMetadata",
-  "PivotTablePresentation",
+  "FactRecord",
   "ViewAxisConfig",
   "ViewConfig",
   "ViewMetadata",

--- a/robosystems/models/api/views/fact_grid.py
+++ b/robosystems/models/api/views/fact_grid.py
@@ -1,7 +1,6 @@
 from enum import Enum
 from typing import Any
 
-import pandas as pd
 from pydantic import BaseModel, Field
 
 
@@ -9,7 +8,6 @@ class DimensionType(str, Enum):
   ELEMENT = "element"
   PERIOD = "period"
   ENTITY = "entity"
-  DIMENSION_AXIS = "dimension_axis"
 
 
 class Dimension(BaseModel):
@@ -39,22 +37,16 @@ class FactGridMetadata(BaseModel):
 
 
 class FactGrid(BaseModel):
+  """A scoped, deduplicated set of facts plus the aspects they span.
+
+  Deliberately *not* a pivot: cells are not collapsed and nothing is
+  aggregated. Arranging facts into a table is the consumer's job — see
+  ``@robosystems/report-components``, whose pivot engine keys cells on a
+  fact's full aspect signature rather than on ``(element, period)``.
+  """
+
   dimensions: list[Dimension] = Field(..., description="Dimensions in the grid")
-  facts_df: Any | None = Field(
-    None,
-    description="Pandas DataFrame with fact data (not serialized, internal use only)",
-    exclude=True,
+  facts: list[dict[str, Any]] = Field(
+    default_factory=list, description="Deduplicated fact records"
   )
   metadata: FactGridMetadata = Field(..., description="Metadata about the grid")
-
-  class Config:
-    arbitrary_types_allowed = True
-
-  def as_pivot_table(self, config: dict[str, Any] | None = None) -> pd.DataFrame:
-    if self.facts_df is None:
-      return pd.DataFrame()
-
-    if config is None:
-      return self.facts_df
-
-    return self.facts_df

--- a/robosystems/models/api/views/view_config.py
+++ b/robosystems/models/api/views/view_config.py
@@ -2,44 +2,32 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class ViewAxisConfig(BaseModel):
-  type: str = Field(
-    ..., description="Axis type: 'element', 'period', 'dimension', 'entity'"
-  )
+  """Scoping configuration for one aspect of the fact query.
 
-  dimension_axis: str | None = Field(
-    default=None, description="Dimension axis name for dimension-type axes"
-  )
+  Filtering only. Ordering and labelling are presentation concerns and
+  belong to the consumer that arranges the facts into a table.
+  """
+
+  type: str = Field(..., description="Axis type: 'element', 'period', 'entity'")
+
   include_null_dimension: bool = Field(
     default=False,
-    description="Include facts where this dimension is NULL (default: false)",
+    description="Include facts where this aspect is absent (default: false)",
   )
 
   selected_members: list[str] | None = Field(
     default=None,
     description="Specific members to include (e.g., ['2024-12-31', '2023-12-31'])",
   )
-  member_order: list[str] | None = Field(
-    default=None, description="Explicit ordering of members (overrides default sort)"
-  )
-  member_labels: dict[str, str] | None = Field(
-    default=None,
-    description="Custom labels for members (e.g., {'2024-12-31': 'Current Year'})",
-  )
-
-  element_order: list[str] | None = Field(
-    default=None,
-    description="Element ordering for hierarchy display (e.g., ['us-gaap:Assets', 'us-gaap:Cash', ...])",
-  )
-  element_labels: dict[str, str] | None = Field(
-    default=None,
-    description="Custom labels for elements (e.g., {'us-gaap:Cash': 'Cash and Cash Equivalents'})",
-  )
 
   @field_validator("type")
   @classmethod
   def validate_axis_type(cls, v: str) -> str:
-    allowed = ["element", "period", "dimension", "entity"]
+    allowed = ["element", "period", "entity"]
     if v not in allowed:
+      # 'dimension' is deliberately absent: the fact query filters on
+      # `has_dimensions = false`, so dimensional facts never reach the
+      # response and a dimension axis could only ever be a silent no-op.
       raise ValueError(f"Axis type must be one of {allowed}, got: {v}")
     return v
 
@@ -51,14 +39,6 @@ class ViewConfig(BaseModel):
   columns: list[ViewAxisConfig] = Field(
     default_factory=list, description="Column axis configuration"
   )
-  values: str = Field(
-    default="numeric_value",
-    description="Field to use for values (default: numeric_value)",
-  )
-  aggregation_function: str = Field(
-    default="sum", description="Aggregation function: sum, average, count"
-  )
-  fill_value: float = Field(default=0.0, description="Value to use for missing data")
 
 
 class CreateViewRequest(BaseModel):
@@ -77,7 +57,6 @@ class CreateViewRequest(BaseModel):
           "form": "10-K",
           "fiscal_period": "FY",
           "view_config": {
-            "rows": [{"type": "entity"}],
             "columns": [
               {
                 "type": "period",
@@ -86,15 +65,8 @@ class CreateViewRequest(BaseModel):
                   "2023-12-31",
                   "2024-12-31",
                 ],
-                "member_labels": {
-                  "2022-12-31": "FY22",
-                  "2023-12-31": "FY23",
-                  "2024-12-31": "FY24",
-                },
               }
             ],
-            "values": "numeric_value",
-            "aggregation_function": "sum",
           },
         },
         {
@@ -106,25 +78,6 @@ class CreateViewRequest(BaseModel):
           "periods": ["2026-03-31"],
           "period_type": "instant",
           "include_summary": True,
-        },
-        {
-          "canonical_concepts": ["revenue"],
-          "entity": "NVDA",
-          "fiscal_year": 2024,
-          "fiscal_period": "FY",
-          "view_config": {
-            "rows": [{"type": "element"}],
-            "columns": [
-              {
-                "type": "dimension",
-                "dimension_axis": "us-gaap:StatementBusinessSegmentsAxis",
-                "include_null_dimension": True,
-              }
-            ],
-            "values": "numeric_value",
-            "aggregation_function": "sum",
-            "fill_value": 0.0,
-          },
         },
       ]
     }
@@ -171,7 +124,7 @@ class CreateViewRequest(BaseModel):
     description="Include summary statistics per element",
   )
   view_config: ViewConfig = Field(
-    default_factory=ViewConfig, description="View/pivot configuration"
+    default_factory=ViewConfig, description="Aspect scoping configuration"
   )
 
   @field_validator("period_type")

--- a/robosystems/models/api/views/view_response.py
+++ b/robosystems/models/api/views/view_response.py
@@ -1,15 +1,28 @@
-from typing import Any
-
 from pydantic import BaseModel, Field
 
+from robosystems.models.api.views.fact_grid import Dimension
 
-class PivotTablePresentation(BaseModel):
-  index: list[list[Any]] = Field(..., description="Row index (hierarchical)")
-  columns: list[list[Any]] = Field(..., description="Column headers (hierarchical)")
-  data: list[list[Any]] = Field(..., description="Data values")
-  metadata: dict[str, Any] = Field(
-    default_factory=dict, description="Additional metadata"
+
+class FactRecord(BaseModel):
+  element_id: str = Field(..., description="Element qname (e.g., 'us-gaap:Assets')")
+  element_name: str | None = Field(None, description="Element local name")
+  period_end: str | None = Field(None, description="Period end date (YYYY-MM-DD)")
+  value: float | None = Field(None, description="Numeric fact value")
+  unit: str | None = Field(None, description="Unit of measure (e.g., 'USD')")
+  entity_ticker: str | None = Field(
+    None, description="Entity ticker; present only when an entity filter was applied"
   )
+  entity_name: str | None = Field(
+    None, description="Entity name; present only when an entity filter was applied"
+  )
+
+
+class ElementSummary(BaseModel):
+  count: int = Field(..., description="Number of facts for this element")
+  total: float = Field(..., description="Sum of values across the returned facts")
+  average: float = Field(..., description="Mean value across the returned facts")
+  min: float = Field(..., description="Minimum value across the returned facts")
+  max: float = Field(..., description="Maximum value across the returned facts")
 
 
 class ViewMetadata(BaseModel):
@@ -24,7 +37,26 @@ class ViewMetadata(BaseModel):
 
 
 class ViewResponse(BaseModel):
+  """Flat, deduplicated facts plus the aspects they span.
+
+  No server-side pivot: each fact is returned as its own record so the
+  consumer can arrange cells on the full aspect signature. Summing across
+  entities, units, or elements that merely share a local name is a
+  presentation decision this endpoint refuses to make on the caller's behalf.
+  """
+
   metadata: ViewMetadata = Field(..., description="View metadata")
-  presentations: dict[str, Any] = Field(
-    ..., description="Presentation formats (pivot_table, narrative, etc.)"
+  dimensions: list[Dimension] = Field(
+    default_factory=list, description="Aspects spanned by the returned facts"
+  )
+  facts: list[FactRecord] = Field(
+    default_factory=list, description="Deduplicated fact records"
+  )
+  summary: dict[str, ElementSummary] | None = Field(
+    None,
+    description=(
+      "Per-element aggregates, only when include_summary=true. Note that "
+      "`total` sums across every returned period, which is meaningful for "
+      "duration facts and not for instants."
+    ),
   )

--- a/robosystems/operations/roboledger/views/__init__.py
+++ b/robosystems/operations/roboledger/views/__init__.py
@@ -16,15 +16,19 @@ extensions OLTP code, and lives under roboledger because the schema is
 roboledger's even when the data inside is SEC's.
 
 **Use this for:** cross-period and cross-entity analytical queries
-(fact grids, multi-period pivot tables, hypercube slices). Reads return
-pandas DataFrames or `FactGrid` Pydantic models.
+(fact grids, hypercube slices). Reads return fact records or `FactGrid`
+Pydantic models — scoped and deduplicated, never pivoted; arranging facts
+into cells is the consumer's job.
 
 **Don't use this for:** transactional lookups against tenant ledgers
 (account balances, draft entries, period close gates) — those live in
 `reads/` against the extensions OLTP database.
 """
 
-from robosystems.operations.roboledger.views.fact_grid_builder import FactGridBuilder
+from robosystems.operations.roboledger.views.fact_grid_builder import (
+  FactGridBuilder,
+  summarize_by_element,
+)
 from robosystems.operations.roboledger.views.fact_query import query_fact_grid
 from robosystems.operations.roboledger.views.financial_statement_query import (
   deduplicate_facts,
@@ -36,4 +40,5 @@ __all__ = [
   "deduplicate_facts",
   "query_fact_grid",
   "query_financial_statement",
+  "summarize_by_element",
 ]

--- a/robosystems/operations/roboledger/views/fact_grid_builder.py
+++ b/robosystems/operations/roboledger/views/fact_grid_builder.py
@@ -1,7 +1,16 @@
+"""Assemble queried facts into a `FactGrid`.
+
+Scoping and aspect extraction only — **no pivoting**. Collapsing facts into
+cells is a rendering decision that depends on the full aspect signature
+(element · period · entity · unit), and getting it wrong is silent: summing
+across entities or across two taxonomies whose elements share a local name
+produces a number that looks authoritative and is meaningless. That
+arrangement belongs to the consumer — `@robosystems/report-components` keys
+cells on the whole signature — so this layer hands back the facts as queried.
+"""
+
 import time
 from typing import Any
-
-import pandas as pd
 
 from robosystems.models.api.views import (
   Dimension,
@@ -11,157 +20,173 @@ from robosystems.models.api.views import (
   ViewConfig,
 )
 
+# Aspect name (ViewAxisConfig.type) → the key `query_fact_grid` returns it under.
+_AXIS_COLUMNS = {
+  "element": "element_id",
+  "period": "period_end",
+  "entity": "entity_ticker",
+}
+
+
+def summarize_by_element(facts: list[dict[str, Any]]) -> dict[str, dict[str, float]]:
+  """Per-element aggregates over the returned facts.
+
+  Shared by the REST and MCP surfaces so both report the same numbers.
+  `total` sums across every returned period — meaningful for duration facts,
+  not for instants (summing a balance across time is not a balance).
+  """
+  summary: dict[str, dict[str, float]] = {}
+
+  by_element: dict[str, list[float]] = {}
+  for fact in facts:
+    element = fact.get("element_id")
+    value = fact.get("value")
+    if element is None or value is None:
+      continue
+    by_element.setdefault(str(element), []).append(float(value))
+
+  for element, values in by_element.items():
+    summary[element] = {
+      "count": len(values),
+      "total": sum(values),
+      "average": sum(values) / len(values),
+      "min": min(values),
+      "max": max(values),
+    }
+
+  return summary
+
 
 class FactGridBuilder:
-  """
-  Build FactGrid from fact data (unified for both modes).
-
-  Works with:
-  - Mode 1: Trial balance data from transaction aggregation
-  - Mode 2: Existing facts queried from graph
-  """
+  """Build a FactGrid from queried fact records."""
 
   def build(
     self,
-    fact_data: pd.DataFrame,
+    fact_data: list[dict[str, Any]],
     view_config: ViewConfig,
     source: str,
   ) -> FactGrid:
-    """
-    Build FactGrid from fact data.
+    """Build FactGrid from fact records.
 
     Args:
-        fact_data: DataFrame with fact data (from either mode)
-        view_config: User-specified view configuration
-        source: Source identifier for metadata
+        fact_data: Fact records from `query_fact_grid`.
+        view_config: Caller-specified aspect scoping.
+        source: Source identifier for metadata.
 
     Returns:
-        FactGrid ready for presentation generation
+        FactGrid carrying the scoped facts and the aspects they span.
     """
     start_time = time.time()
 
-    if fact_data.empty:
+    if not fact_data:
       return self._build_empty_grid(source)
 
-    df = fact_data.copy()
-
+    facts = fact_data
     if view_config.rows or view_config.columns:
-      df = self._apply_aspect_filtering(df, view_config)
+      facts = self._apply_aspect_filtering(facts, view_config)
 
-    dimensions = self._extract_dimensions(df)
+    dimensions = self._extract_dimensions(facts)
 
     metadata = FactGridMetadata(
-      fact_count=len(df),
+      fact_count=len(facts),
       dimension_count=len(dimensions),
       construction_time_ms=(time.time() - start_time) * 1000,
       source=source,
       lineage={
         "original_fact_count": len(fact_data),
-        "filtered_fact_count": len(df),
-        "columns": list(df.columns),
+        "filtered_fact_count": len(facts),
       },
     )
 
     return FactGrid(
       dimensions=dimensions,
-      facts_df=df,
+      facts=facts,
       metadata=metadata,
     )
 
   def _apply_aspect_filtering(
-    self, df: pd.DataFrame, view_config: ViewConfig
-  ) -> pd.DataFrame:
+    self, facts: list[dict[str, Any]], view_config: ViewConfig
+  ) -> list[dict[str, Any]]:
+    """Restrict facts to each axis's `selected_members`.
+
+    A fact whose aspect value is absent is dropped unless the axis sets
+    `include_null_dimension`.
     """
-    Apply aspect filtering based on ViewAxisConfig.selected_members.
+    result = facts
 
-    Filters DataFrame to only include rows where axis values match selected members.
-    """
-    result = df.copy()
-
-    all_axes = (view_config.rows or []) + (view_config.columns or [])
-
-    for axis in all_axes:
+    for axis in (view_config.rows or []) + (view_config.columns or []):
       if not axis.selected_members:
         continue
 
-      column_map = {
-        "element": "element_id",
-        "period": "period_end",
-        "entity": "entity_id",
-        "dimension": "dimension_member",
-      }
-
-      column_name = column_map.get(axis.type)
-      if not column_name or column_name not in result.columns:
+      key = _AXIS_COLUMNS.get(axis.type)
+      if not key:
         continue
 
-      mask = result[column_name].isin(axis.selected_members)
-      if not axis.include_null_dimension:
-        mask = mask | result[column_name].isna()
-
-      result = result[mask]
+      selected = set(axis.selected_members)
+      keep_null = axis.include_null_dimension
+      result = [
+        fact
+        for fact in result
+        if (fact.get(key) in selected) or (keep_null and fact.get(key) in (None, ""))
+      ]
 
     return result
 
-  def _extract_dimensions(self, fact_data: pd.DataFrame) -> list[Dimension]:
-    """Extract dimensions from fact data."""
+  def _extract_dimensions(self, facts: list[dict[str, Any]]) -> list[Dimension]:
+    """Extract the aspects the facts span, in a stable order."""
     dimensions = []
 
-    if "element_name" in fact_data.columns:
-      unique_elements = fact_data["element_name"].dropna().unique().tolist()
+    elements = self._unique(facts, "element_id")
+    if elements:
       dimensions.append(
         Dimension(
           name="Element",
           type=DimensionType.ELEMENT,
-          members=unique_elements,
+          members=elements,
         )
       )
 
-    if "period_start" in fact_data.columns or "period_end" in fact_data.columns:
-      period_members = []
-      if "period_start" in fact_data.columns:
-        period_members.extend(fact_data["period_start"].dropna().unique().tolist())
-      if "period_end" in fact_data.columns:
-        period_members.extend(fact_data["period_end"].dropna().unique().tolist())
-      unique_periods = sorted(set(period_members))
-
+    periods = self._unique(facts, "period_end")
+    if periods:
       dimensions.append(
         Dimension(
           name="Period",
           type=DimensionType.PERIOD,
-          members=unique_periods,
+          members=sorted(periods),
         )
       )
 
-    if "entity_id" in fact_data.columns:
-      unique_entities = fact_data["entity_id"].dropna().unique().tolist()
-      if unique_entities:
-        dimensions.append(
-          Dimension(
-            name="Entity",
-            type=DimensionType.ENTITY,
-            members=unique_entities,
-          )
+    # entity_ticker/entity_name are only returned when an entity filter was
+    # applied; a ticker can be null for CIK- or name-matched entities.
+    entities = self._unique(facts, "entity_ticker") or self._unique(
+      facts, "entity_name"
+    )
+    if entities:
+      dimensions.append(
+        Dimension(
+          name="Entity",
+          type=DimensionType.ENTITY,
+          members=entities,
         )
-
-    if "dimension_axis" in fact_data.columns:
-      unique_axes = fact_data["dimension_axis"].dropna().unique().tolist()
-      if unique_axes:
-        dimensions.append(
-          Dimension(
-            name="DimensionAxis",
-            type=DimensionType.DIMENSION_AXIS,
-            members=unique_axes,
-          )
-        )
+      )
 
     return dimensions
+
+  @staticmethod
+  def _unique(facts: list[dict[str, Any]], key: str) -> list[str]:
+    """Distinct non-null values for `key`, in first-seen order."""
+    seen: dict[str, None] = {}
+    for fact in facts:
+      value = fact.get(key)
+      if value is not None and value != "":
+        seen.setdefault(str(value), None)
+    return list(seen)
 
   def _build_empty_grid(self, source: str) -> FactGrid:
     """Build empty FactGrid when no facts found."""
     return FactGrid(
       dimensions=[],
-      facts_df=pd.DataFrame(),
+      facts=[],
       metadata=FactGridMetadata(
         fact_count=0,
         dimension_count=0,
@@ -170,138 +195,3 @@ class FactGridBuilder:
         lineage=None,
       ),
     )
-
-  def generate_pivot_table(
-    self, fact_grid: FactGrid, view_config: ViewConfig | None = None
-  ) -> dict[str, Any]:
-    """
-    Generate pivot table presentation from FactGrid.
-
-    Supports:
-    - Element hierarchies with subtotals
-    - Custom member ordering and labels
-    - ViewConfig-driven axis configuration
-
-    Memory Warning:
-    Creates DataFrame copies for pivot operations. For datasets > 100k rows,
-    consider streaming or batching approaches to avoid memory pressure.
-    Memory usage scales approximately O(rows * columns) for the pivot table.
-    """
-    if fact_grid.facts_df is None or fact_grid.facts_df.empty:
-      return {
-        "index": [],
-        "columns": [],
-        "data": [],
-        "metadata": {"row_count": 0, "column_count": 0},
-      }
-
-    df = fact_grid.facts_df.copy()
-
-    element_col = "element_label" if "element_label" in df.columns else "element_name"
-    if element_col not in df.columns:
-      element_col = None
-
-    value_col = "numeric_value" if "numeric_value" in df.columns else "net_balance"
-
-    if not element_col or value_col not in df.columns:
-      return {
-        "index": list(df.index),
-        "columns": list(df.columns),
-        "data": df.values.tolist(),
-        "metadata": {
-          "row_count": len(df),
-          "column_count": len(df.columns),
-        },
-      }
-
-    period_col = None
-    for col in ["period_end", "period_start"]:
-      if col in df.columns and not df[col].isna().all():
-        period_col = col
-        break
-
-    period_axis = None
-    if view_config:
-      for axis in (view_config.rows or []) + (view_config.columns or []):
-        if axis.type == "period":
-          period_axis = axis
-          break
-
-    if period_col:
-      pivot = df.pivot_table(
-        index=[element_col],
-        columns=[period_col],
-        values=value_col,
-        aggfunc="sum",
-        fill_value=0.0,
-      )
-
-      if period_axis and period_axis.member_order:
-        available_cols = [c for c in period_axis.member_order if c in pivot.columns]
-        pivot = pivot[available_cols]
-
-      if period_axis and period_axis.member_labels:
-        pivot = pivot.rename(columns=period_axis.member_labels)
-    else:
-      pivot = df[[element_col, value_col]].copy()
-      pivot = pivot.groupby(element_col)[value_col].sum()
-
-    element_axis = None
-    if view_config:
-      for axis in (view_config.rows or []) + (view_config.columns or []):
-        if axis.type == "element":
-          element_axis = axis
-          break
-
-    if element_axis and element_axis.element_order and isinstance(pivot, pd.DataFrame):
-      element_id_to_name = {}
-      if "element_id" in df.columns and element_col in df.columns:
-        mapping_df = df[["element_id", element_col]].drop_duplicates()
-        element_id_to_name = dict(
-          zip(mapping_df["element_id"], mapping_df[element_col], strict=False)
-        )
-
-      if element_id_to_name:
-        ordered_names = [
-          element_id_to_name.get(eid, eid)
-          for eid in element_axis.element_order
-          if element_id_to_name.get(eid, eid) in pivot.index
-        ]
-        if ordered_names:
-          pivot = pivot.reindex(ordered_names)
-      else:
-        available_elements = [e for e in element_axis.element_order if e in pivot.index]
-        if available_elements:
-          pivot = pivot.reindex(available_elements)
-
-    if element_axis and element_axis.element_labels and isinstance(pivot, pd.DataFrame):
-      pivot = pivot.rename(index=element_axis.element_labels)
-
-    index_values = (
-      [[idx] for idx in pivot.index]
-      if isinstance(pivot.index, pd.Index)
-      else pivot.index.tolist()
-    )
-
-    if isinstance(pivot, pd.DataFrame):
-      column_values = (
-        [[col] for col in pivot.columns]
-        if isinstance(pivot.columns, pd.Index)
-        else pivot.columns.tolist()
-      )
-      data_values = pivot.values.tolist()
-    else:
-      column_values = [["Total"]]
-      data_values = [[val] for val in pivot.values.tolist()]
-
-    return {
-      "index": index_values,
-      "columns": column_values,
-      "data": data_values,
-      "metadata": {
-        "row_count": len(index_values),
-        "column_count": len(column_values),
-        "has_periods": period_col is not None,
-        "has_hierarchy": "element_depth" in df.columns,
-      },
-    }

--- a/robosystems/operations/roboledger/views/fact_query.py
+++ b/robosystems/operations/roboledger/views/fact_query.py
@@ -21,8 +21,6 @@ from __future__ import annotations
 import re
 from typing import Any
 
-import pandas as pd
-
 from robosystems.middleware.graph import get_graph_repository
 
 # Pre-compiled patterns for inline Cypher node filter sanitization.
@@ -153,7 +151,7 @@ async def query_fact_grid(
   fiscal_year: int | None = None,
   fiscal_period: str | None = None,
   period_type: str | None = None,
-) -> pd.DataFrame:
+) -> list[dict[str, Any]]:
   """Query deduplicated facts for the roboledger XBRL hypercube.
 
   Shared by REST (`build-fact-grid`) and MCP (`BuildFactGridTool`). See
@@ -172,10 +170,10 @@ async def query_fact_grid(
       period_type: ``'annual'``, ``'quarterly'``, or ``'instant'``.
 
   Returns:
-      DataFrame with columns: ``element_id``, ``element_name``, ``period_end``,
-      ``value``, ``unit``, and optionally ``entity_ticker``, ``entity_name``
-      when entity filters are used. Deduplicated and sorted by ``period_end``
-      descending.
+      Fact records with keys ``element_id``, ``element_name``, ``period_end``,
+      ``value``, ``unit``, and — only when entity filters are used —
+      ``entity_ticker`` and ``entity_name``. Deduplicated and sorted by
+      ``period_end`` descending.
   """
   parameters: dict[str, Any] = {}
 
@@ -262,12 +260,7 @@ async def query_fact_grid(
   repository = await get_graph_repository(graph_id, operation_type="read")
   results = await repository.execute_query(query, parameters)
 
-  base_columns = ["element_id", "element_name", "period_end", "value", "unit"]
-  if entity_list:
-    base_columns.extend(["entity_ticker", "entity_name"])
-
   if not results:
-    return pd.DataFrame(columns=base_columns)
+    return []
 
-  deduped = _deduplicate_fact_rows(results, has_entity=bool(entity_pattern))
-  return pd.DataFrame(deduped)
+  return _deduplicate_fact_rows(results, has_entity=bool(entity_pattern))

--- a/robosystems/routers/extensions/roboledger/views.py
+++ b/robosystems/routers/extensions/roboledger/views.py
@@ -56,6 +56,8 @@ from robosystems.models.api.extensions.reports import (
 )
 from robosystems.models.api.views import (
   CreateViewRequest,
+  ElementSummary,
+  FactRecord,
   ViewMetadata,
   ViewResponse,
 )
@@ -68,6 +70,7 @@ from robosystems.operations.roboledger.views import (
   deduplicate_facts,
   query_fact_grid,
   query_financial_statement,
+  summarize_by_element,
 )
 
 # Import _dispatch from the sibling operations module so error
@@ -85,7 +88,7 @@ _RATE_LIMIT = Depends(subscription_aware_rate_limit_dependency)
   response_model=OperationEnvelope[ViewResponse],
   operation_id="buildFactGrid",
   summary="Build Fact Grid",
-  description="Queries LadybugDB `Fact` nodes by element qnames or canonical concepts, with filters for periods, entities, form, and fiscal context. Returns a deduplicated pivot table. Works on both roboledger tenant graphs (post-materialization) and the SEC shared repository.",
+  description="Queries LadybugDB `Fact` nodes by element qnames or canonical concepts, with filters for periods, entities, form, and fiscal context. Returns deduplicated facts plus the aspects they span — arranging them into a table is the consumer's job, since collapsing cells safely requires the full aspect signature. Works on both roboledger tenant graphs (post-materialization) and the SEC shared repository.",
   tags=[_OP_TAG],
   dependencies=[_RATE_LIMIT],
   responses={**OPERATION_ERROR_RESPONSES},
@@ -141,7 +144,6 @@ async def build_fact_grid_op(
     fact_grid = builder.build(
       fact_data=fact_data, view_config=body.view_config, source="fact_grid"
     )
-    pivot_table = builder.generate_pivot_table(fact_grid, body.view_config)
 
     construction_time_ms = (time.time() - start_time) * 1000
     metadata = ViewMetadata(
@@ -151,29 +153,19 @@ async def build_fact_grid_op(
       source="fact_grid",
     )
 
-    presentations: dict[str, object] = {"pivot_table": pivot_table}
+    summary = None
+    if body.include_summary and fact_grid.facts:
+      summary = {
+        element: ElementSummary(**stats)
+        for element, stats in summarize_by_element(fact_grid.facts).items()
+      }
 
-    # Optional inline summary stats — element-keyed aggregates, only
-    # computed when the caller asks for them.
-    if (
-      body.include_summary
-      and fact_grid.facts_df is not None
-      and not fact_grid.facts_df.empty
-    ):
-      df = fact_grid.facts_df
-      if "element_name" in df.columns and "value" in df.columns:
-        summary: dict[str, dict[str, float]] = {}
-        for element_name in df["element_name"].unique():
-          element_data = df[df["element_name"] == element_name]
-          summary[element_name] = {
-            "count": len(element_data),
-            "total": float(element_data["value"].sum()),
-            "average": float(element_data["value"].mean()),
-            "min": float(element_data["value"].min()),
-            "max": float(element_data["value"].max()),
-          }
-        presentations["summary"] = summary
-    return ViewResponse(metadata=metadata, presentations=presentations)
+    return ViewResponse(
+      metadata=metadata,
+      dimensions=fact_grid.dimensions,
+      facts=[FactRecord(**fact) for fact in fact_grid.facts],
+      summary=summary,
+    )
 
   return await _dispatch(ctx, _runner, cache)
 

--- a/tests/middleware/mcp/test_client.py
+++ b/tests/middleware/mcp/test_client.py
@@ -467,24 +467,20 @@ class TestGraphMCPTools:
 
     tools = GraphMCPTools(mock_graph_client)
 
-    import pandas as pd
-
-    fact_df = pd.DataFrame(
-      [
-        {
-          "element_id": "test:Element",
-          "element_name": "Cash",
-          "period_end": "2025-01-01",
-          "value": 1000.0,
-          "unit": "USD",
-        }
-      ]
-    )
+    facts = [
+      {
+        "element_id": "test:Element",
+        "element_name": "Cash",
+        "period_end": "2025-01-01",
+        "value": 1000.0,
+        "unit": "USD",
+      }
+    ]
 
     with patch(
       "robosystems.middleware.mcp.tools.fact_grid_tool.query_fact_grid",
       new_callable=AsyncMock,
-      return_value=fact_df,
+      return_value=facts,
     ):
       result = await tools.call_tool(
         "build-fact-grid",

--- a/tests/middleware/mcp/test_tools.py
+++ b/tests/middleware/mcp/test_tools.py
@@ -14,7 +14,6 @@ response shape.
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pandas as pd
 import pytest
 
 from robosystems.middleware.mcp.tools.fact_grid_tool import BuildFactGridTool
@@ -39,26 +38,20 @@ class TestBuildFactGridTool:
     """Happy path: delegates to query_fact_grid + FactGridBuilder."""
     tool = BuildFactGridTool(mock_graph_client)
 
-    mock_grid = MagicMock()
-    mock_grid.metadata.fact_count = 1
-    mock_grid.metadata.dimension_count = 2
-    mock_grid.metadata.construction_time_ms = 50
-    mock_grid.dimensions = []
-    mock_grid.facts_df = None
+    facts = [
+      {
+        "element_id": "us-gaap:Assets",
+        "element_name": "Assets",
+        "period_end": "2023-12-31",
+        "value": 1000.0,
+        "unit": "USD",
+      }
+    ]
 
-    mock_builder = MagicMock()
-    mock_builder.build.return_value = mock_grid
-
-    with (
-      patch(
-        "robosystems.middleware.mcp.tools.fact_grid_tool.query_fact_grid",
-        new_callable=AsyncMock,
-        return_value=pd.DataFrame(),
-      ),
-      patch(
-        "robosystems.middleware.mcp.tools.fact_grid_tool.FactGridBuilder",
-        return_value=mock_builder,
-      ),
+    with patch(
+      "robosystems.middleware.mcp.tools.fact_grid_tool.query_fact_grid",
+      new_callable=AsyncMock,
+      return_value=facts,
     ):
       result = await tool.execute(
         {"elements": ["us-gaap:Assets"], "periods": ["2023-12-31"]}
@@ -67,6 +60,7 @@ class TestBuildFactGridTool:
     assert result["success"] is True
     assert result["fact_count"] == 1
     assert result["dimension_count"] == 2
+    assert result["data"] == facts
 
   @pytest.mark.asyncio
   @pytest.mark.unit
@@ -132,31 +126,34 @@ class TestBuildFactGridTool:
     """include_summary=true emits per-element stats."""
     tool = BuildFactGridTool(mock_graph_client)
 
-    mock_grid = MagicMock()
-    mock_grid.metadata.fact_count = 3
-    mock_grid.metadata.dimension_count = 1
-    mock_grid.metadata.construction_time_ms = 10
-    mock_grid.dimensions = []
-    mock_grid.facts_df = pd.DataFrame(
+    facts = [
       {
-        "element_name": ["Revenue", "Revenue", "Cost"],
-        "value": [1000.0, 2000.0, 500.0],
-      }
-    )
+        "element_id": "us-gaap:Revenues",
+        "element_name": "Revenues",
+        "period_end": "2024-12-31",
+        "value": 1000.0,
+        "unit": "USD",
+      },
+      {
+        "element_id": "us-gaap:Revenues",
+        "element_name": "Revenues",
+        "period_end": "2023-12-31",
+        "value": 2000.0,
+        "unit": "USD",
+      },
+      {
+        "element_id": "us-gaap:CostOfRevenue",
+        "element_name": "CostOfRevenue",
+        "period_end": "2024-12-31",
+        "value": 500.0,
+        "unit": "USD",
+      },
+    ]
 
-    mock_builder = MagicMock()
-    mock_builder.build.return_value = mock_grid
-
-    with (
-      patch(
-        "robosystems.middleware.mcp.tools.fact_grid_tool.query_fact_grid",
-        new_callable=AsyncMock,
-        return_value=pd.DataFrame(),
-      ),
-      patch(
-        "robosystems.middleware.mcp.tools.fact_grid_tool.FactGridBuilder",
-        return_value=mock_builder,
-      ),
+    with patch(
+      "robosystems.middleware.mcp.tools.fact_grid_tool.query_fact_grid",
+      new_callable=AsyncMock,
+      return_value=facts,
     ):
       result = await tool.execute(
         {
@@ -167,6 +164,6 @@ class TestBuildFactGridTool:
       )
 
     assert "summary" in result
-    assert result["summary"]["Revenue"]["count"] == 2
-    assert result["summary"]["Revenue"]["total"] == 3000.0
-    assert result["summary"]["Cost"]["total"] == 500.0
+    assert result["summary"]["us-gaap:Revenues"]["count"] == 2
+    assert result["summary"]["us-gaap:Revenues"]["total"] == 3000.0
+    assert result["summary"]["us-gaap:CostOfRevenue"]["total"] == 500.0

--- a/tests/models/api/test_view_models.py
+++ b/tests/models/api/test_view_models.py
@@ -20,9 +20,11 @@ class TestViewAxisConfig:
     model = ViewAxisConfig(type="period")
     assert model.type == "period"
 
-  def test_valid_dimension_axis(self):
-    model = ViewAxisConfig(type="dimension", dimension_axis="Segment")
-    assert model.dimension_axis == "Segment"
+  def test_dimension_axis_rejected(self):
+    """The fact query filters on `has_dimensions = false`, so a dimension
+    axis could only ever be a silent no-op."""
+    with pytest.raises(ValidationError):
+      ViewAxisConfig(type="dimension")
 
   def test_valid_entity_axis(self):
     model = ViewAxisConfig(type="entity")
@@ -45,19 +47,16 @@ class TestViewAxisConfig:
     )
     assert len(model.selected_members) == 2
 
-  def test_member_labels(self):
+  def test_presentation_fields_are_not_accepted(self):
+    """Ordering and labelling belong to whatever renders the facts; the
+    request model carries scoping only."""
     model = ViewAxisConfig(
       type="period",
       member_labels={"2024-12-31": "Current Year"},
+      element_order=["us-gaap:Assets"],
     )
-    assert model.member_labels["2024-12-31"] == "Current Year"
-
-  def test_element_order(self):
-    model = ViewAxisConfig(
-      type="element",
-      element_order=["us-gaap:Assets", "us-gaap:Cash"],
-    )
-    assert len(model.element_order) == 2
+    assert not hasattr(model, "member_labels")
+    assert not hasattr(model, "element_order")
 
 
 @pytest.mark.unit
@@ -66,20 +65,20 @@ class TestViewConfig:
     model = ViewConfig()
     assert model.rows == []
     assert model.columns == []
-    assert model.values == "numeric_value"
-    assert model.aggregation_function == "sum"
-    assert model.fill_value == 0.0
 
   def test_custom_config(self):
     model = ViewConfig(
       rows=[ViewAxisConfig(type="element")],
       columns=[ViewAxisConfig(type="period")],
-      values="numeric_value",
-      aggregation_function="average",
-      fill_value=-1.0,
     )
     assert len(model.rows) == 1
-    assert model.aggregation_function == "average"
+    assert len(model.columns) == 1
+
+  def test_pivot_knobs_are_not_accepted(self):
+    """No server-side pivot means no aggregation function to configure."""
+    model = ViewConfig(values="numeric_value", aggregation_function="average")
+    assert not hasattr(model, "aggregation_function")
+    assert not hasattr(model, "fill_value")
 
 
 @pytest.mark.unit

--- a/tests/operations/roboledger/views/test_fact_grid_builder.py
+++ b/tests/operations/roboledger/views/test_fact_grid_builder.py
@@ -1,229 +1,238 @@
-import pandas as pd
 import pytest
 
 from robosystems.models.api.views import ViewAxisConfig, ViewConfig
-from robosystems.operations.roboledger.views.fact_grid_builder import FactGridBuilder
+from robosystems.operations.roboledger.views.fact_grid_builder import (
+  FactGridBuilder,
+  summarize_by_element,
+)
+
+
+def _fact(element_id, element_name, value, period_end, ticker="AAPL", unit="USD"):
+  """A fact record shaped exactly as `query_fact_grid` returns one."""
+  return {
+    "element_id": element_id,
+    "element_name": element_name,
+    "period_end": period_end,
+    "value": value,
+    "unit": unit,
+    "entity_ticker": ticker,
+    "entity_name": "Apple Inc.",
+  }
 
 
 class TestFactGridBuilder:
   @pytest.fixture
   def sample_fact_data(self):
-    return pd.DataFrame(
-      {
-        "element_id": [
-          "us-gaap:Assets",
-          "us-gaap:Cash",
-          "us-gaap:AccountsReceivableNetCurrent",
-          "us-gaap:Assets",
-          "us-gaap:Cash",
-        ],
-        "element_name": [
-          "Assets",
-          "Cash",
-          "Accounts Receivable",
-          "Assets",
-          "Cash",
-        ],
-        "numeric_value": [1000000, 100000, 200000, 1500000, 150000],
-        "period_end": [
-          "2024-12-31",
-          "2024-12-31",
-          "2024-12-31",
-          "2023-12-31",
-          "2023-12-31",
-        ],
-        "entity_id": ["AAPL", "AAPL", "AAPL", "AAPL", "AAPL"],
-        "dimension_axis": [None, None, None, None, None],
-        "dimension_member": [None, None, None, None, None],
-      }
-    )
+    return [
+      _fact("us-gaap:Assets", "Assets", 1000000, "2024-12-31"),
+      _fact("us-gaap:Cash", "Cash", 100000, "2024-12-31"),
+      _fact(
+        "us-gaap:AccountsReceivableNetCurrent",
+        "AccountsReceivableNetCurrent",
+        200000,
+        "2024-12-31",
+      ),
+      _fact("us-gaap:Assets", "Assets", 1500000, "2023-12-31"),
+      _fact("us-gaap:Cash", "Cash", 150000, "2023-12-31"),
+    ]
 
   @pytest.fixture
-  def dimensional_fact_data(self):
-    return pd.DataFrame(
-      {
-        "element_id": [
-          "us-gaap:Revenue",
-          "us-gaap:Revenue",
-          "us-gaap:Revenue",
-        ],
-        "element_name": ["Revenue", "Revenue", "Revenue"],
-        "numeric_value": [100000, 60000, 40000],
-        "period_end": ["2024-12-31", "2024-12-31", "2024-12-31"],
-        "entity_id": ["AAPL", "AAPL", "AAPL"],
-        "dimension_axis": [None, "Geography", "Geography"],
-        "dimension_member": [None, "US", "EU"],
-      }
-    )
+  def multi_entity_fact_data(self):
+    return [
+      _fact("us-gaap:Assets", "Assets", 1000000, "2024-12-31", ticker="AAPL"),
+      _fact("us-gaap:Assets", "Assets", 2000000, "2024-12-31", ticker="MSFT"),
+    ]
 
   def test_build_empty_grid(self):
     builder = FactGridBuilder()
-    empty_df = pd.DataFrame()
-    view_config = ViewConfig()
 
-    fact_grid = builder.build(empty_df, view_config, "test_source")
+    fact_grid = builder.build([], ViewConfig(), "test_source")
 
     assert fact_grid.metadata.fact_count == 0
     assert fact_grid.metadata.dimension_count == 0
-    assert fact_grid.facts_df.empty
+    assert fact_grid.facts == []
 
   def test_build_basic_grid(self, sample_fact_data):
     builder = FactGridBuilder()
-    view_config = ViewConfig()
 
-    fact_grid = builder.build(sample_fact_data, view_config, "test_source")
+    fact_grid = builder.build(sample_fact_data, ViewConfig(), "test_source")
 
     assert fact_grid.metadata.fact_count == 5
     assert fact_grid.metadata.dimension_count > 0
-    assert len(fact_grid.facts_df) == 5
+    assert len(fact_grid.facts) == 5
+
+  def test_facts_are_not_collapsed_across_entities(self, multi_entity_fact_data):
+    """Same element, same period, two filers stay two facts.
+
+    The whole reason there is no server-side pivot: collapsing this pair
+    would silently report AAPL + MSFT assets as one number.
+    """
+    builder = FactGridBuilder()
+
+    fact_grid = builder.build(multi_entity_fact_data, ViewConfig(), "test_source")
+
+    assert len(fact_grid.facts) == 2
+    assert {f["value"] for f in fact_grid.facts} == {1000000, 2000000}
 
   def test_aspect_filtering_periods(self, sample_fact_data):
     builder = FactGridBuilder()
     view_config = ViewConfig(
-      columns=[
-        ViewAxisConfig(
-          type="period",
-          selected_members=["2024-12-31"],
-        )
-      ]
+      columns=[ViewAxisConfig(type="period", selected_members=["2024-12-31"])]
     )
 
     fact_grid = builder.build(sample_fact_data, view_config, "test_source")
 
-    assert fact_grid.facts_df is not None
-    assert len(fact_grid.facts_df) == 3
-    assert all(fact_grid.facts_df["period_end"] == "2024-12-31")
+    assert len(fact_grid.facts) == 3
+    assert all(f["period_end"] == "2024-12-31" for f in fact_grid.facts)
 
   def test_aspect_filtering_elements(self, sample_fact_data):
     builder = FactGridBuilder()
     view_config = ViewConfig(
-      rows=[
-        ViewAxisConfig(
-          type="element",
-          selected_members=["us-gaap:Cash"],
-        )
-      ]
+      rows=[ViewAxisConfig(type="element", selected_members=["us-gaap:Cash"])]
     )
 
     fact_grid = builder.build(sample_fact_data, view_config, "test_source")
 
-    assert fact_grid.facts_df is not None
-    assert len(fact_grid.facts_df) == 2
-    assert all(fact_grid.facts_df["element_id"] == "us-gaap:Cash")
+    assert len(fact_grid.facts) == 2
+    assert all(f["element_id"] == "us-gaap:Cash" for f in fact_grid.facts)
 
-  def test_generate_pivot_table_basic(self, sample_fact_data):
-    builder = FactGridBuilder()
-    view_config = ViewConfig()
-
-    fact_grid = builder.build(sample_fact_data, view_config, "test_source")
-    pivot_table = builder.generate_pivot_table(fact_grid, view_config)
-
-    assert "index" in pivot_table
-    assert "columns" in pivot_table
-    assert "data" in pivot_table
-    assert "metadata" in pivot_table
-    assert pivot_table["metadata"]["row_count"] > 0
-
-  def test_generate_pivot_table_with_custom_labels(self, sample_fact_data):
+  def test_aspect_filtering_entities(self, multi_entity_fact_data):
     builder = FactGridBuilder()
     view_config = ViewConfig(
-      columns=[
+      rows=[ViewAxisConfig(type="entity", selected_members=["MSFT"])]
+    )
+
+    fact_grid = builder.build(multi_entity_fact_data, view_config, "test_source")
+
+    assert len(fact_grid.facts) == 1
+    assert fact_grid.facts[0]["entity_ticker"] == "MSFT"
+
+  def test_apply_aspect_filtering_multiple_axes(self, sample_fact_data):
+    builder = FactGridBuilder()
+    view_config = ViewConfig(
+      rows=[ViewAxisConfig(type="element", selected_members=["us-gaap:Cash"])],
+      columns=[ViewAxisConfig(type="period", selected_members=["2024-12-31"])],
+    )
+
+    filtered = builder._apply_aspect_filtering(sample_fact_data, view_config)
+
+    assert len(filtered) == 1
+    assert filtered[0]["element_id"] == "us-gaap:Cash"
+    assert filtered[0]["period_end"] == "2024-12-31"
+
+  def test_null_aspect_excluded_by_default(self):
+    """A fact missing the filtered aspect drops unless explicitly included."""
+    builder = FactGridBuilder()
+    facts = [
+      _fact("us-gaap:Assets", "Assets", 1000000, "2024-12-31"),
+      {**_fact("us-gaap:Assets", "Assets", 5, "2024-12-31"), "entity_ticker": None},
+    ]
+    view_config = ViewConfig(
+      rows=[ViewAxisConfig(type="entity", selected_members=["AAPL"])]
+    )
+
+    filtered = builder._apply_aspect_filtering(facts, view_config)
+
+    assert len(filtered) == 1
+    assert filtered[0]["entity_ticker"] == "AAPL"
+
+  def test_null_aspect_included_when_requested(self):
+    builder = FactGridBuilder()
+    facts = [
+      _fact("us-gaap:Assets", "Assets", 1000000, "2024-12-31"),
+      {**_fact("us-gaap:Assets", "Assets", 5, "2024-12-31"), "entity_ticker": None},
+    ]
+    view_config = ViewConfig(
+      rows=[
         ViewAxisConfig(
-          type="period",
-          member_order=["2024-12-31", "2023-12-31"],
-          member_labels={"2024-12-31": "Current", "2023-12-31": "Prior"},
+          type="entity",
+          selected_members=["AAPL"],
+          include_null_dimension=True,
         )
       ]
     )
 
-    fact_grid = builder.build(sample_fact_data, view_config, "test_source")
-    pivot_table = builder.generate_pivot_table(fact_grid, view_config)
+    filtered = builder._apply_aspect_filtering(facts, view_config)
 
-    if pivot_table["metadata"]["has_periods"]:
-      columns = [col[0] for col in pivot_table["columns"]]
-      if "Current" in columns or "Prior" in columns:
-        assert "Current" in columns or "2024-12-31" in columns
+    assert len(filtered) == 2
 
   def test_extract_dimensions(self, sample_fact_data):
     builder = FactGridBuilder()
 
     dimensions = builder._extract_dimensions(sample_fact_data)
 
-    assert len(dimensions) > 0
-
     dimension_types = {d.type for d in dimensions}
     assert "element" in dimension_types
     assert "period" in dimension_types
     assert "entity" in dimension_types
 
-  def test_apply_aspect_filtering_multiple_axes(self, sample_fact_data):
+    element_dim = next(d for d in dimensions if d.type == "element")
+    assert "us-gaap:Assets" in element_dim.members
+    assert len(element_dim.members) == 3
+
+    period_dim = next(d for d in dimensions if d.type == "period")
+    assert period_dim.members == ["2023-12-31", "2024-12-31"]
+
+  def test_entity_dimension_absent_without_entity_filter(self):
+    """No entity filter means the query returns no entity keys at all."""
     builder = FactGridBuilder()
+    facts = [
+      {
+        "element_id": "us-gaap:Assets",
+        "element_name": "Assets",
+        "period_end": "2024-12-31",
+        "value": 1000000,
+        "unit": "USD",
+      }
+    ]
 
-    view_config = ViewConfig(
-      rows=[
-        ViewAxisConfig(
-          type="element",
-          selected_members=["us-gaap:Cash"],
-        )
-      ],
-      columns=[
-        ViewAxisConfig(
-          type="period",
-          selected_members=["2024-12-31"],
-        )
-      ],
-    )
+    dimensions = builder._extract_dimensions(facts)
 
-    filtered_df = builder._apply_aspect_filtering(sample_fact_data, view_config)
+    assert "entity" not in {d.type for d in dimensions}
 
-    assert len(filtered_df) == 1
-    assert filtered_df.iloc[0]["element_id"] == "us-gaap:Cash"
-    assert filtered_df.iloc[0]["period_end"] == "2024-12-31"
+  def test_dimension_axis_type_rejected(self):
+    """Dimensional facts are filtered out by the query, so the axis can't work."""
+    with pytest.raises(ValueError, match="Axis type must be one of"):
+      ViewAxisConfig(type="dimension", selected_members=["Geography"])
 
-  def test_element_ordering_in_pivot_table(self, sample_fact_data):
-    builder = FactGridBuilder()
 
-    view_config = ViewConfig(
-      rows=[
-        ViewAxisConfig(
-          type="element",
-          element_order=[
-            "us-gaap:AccountsReceivableNetCurrent",
-            "us-gaap:Cash",
-            "us-gaap:Assets",
-          ],
-        )
-      ],
-      columns=[ViewAxisConfig(type="period")],
-    )
+class TestSummarizeByElement:
+  def test_aggregates_per_element(self):
+    facts = [
+      _fact("us-gaap:Assets", "Assets", 1000000, "2024-12-31"),
+      _fact("us-gaap:Assets", "Assets", 1500000, "2023-12-31"),
+      _fact("us-gaap:Cash", "Cash", 100000, "2024-12-31"),
+    ]
 
-    fact_grid = builder.build(sample_fact_data, view_config, "test_source")
-    pivot_table = builder.generate_pivot_table(fact_grid, view_config)
+    summary = summarize_by_element(facts)
 
-    row_elements = [row[0] for row in pivot_table["index"]]
-    assert row_elements[0] == "Accounts Receivable"
-    assert row_elements[1] == "Cash"
-    assert row_elements[2] == "Assets"
+    assert summary["us-gaap:Assets"]["count"] == 2
+    assert summary["us-gaap:Assets"]["total"] == 2500000
+    assert summary["us-gaap:Assets"]["average"] == 1250000
+    assert summary["us-gaap:Assets"]["min"] == 1000000
+    assert summary["us-gaap:Assets"]["max"] == 1500000
+    assert summary["us-gaap:Cash"]["count"] == 1
 
-  def test_element_labels_in_pivot_table(self, sample_fact_data):
-    builder = FactGridBuilder()
+  def test_keyed_on_qname_not_local_name(self):
+    """Two taxonomies can share a local name; qnames keep them apart."""
+    facts = [
+      _fact("us-gaap:Assets", "Assets", 100, "2024-12-31"),
+      _fact("ifrs-full:Assets", "Assets", 200, "2024-12-31"),
+    ]
 
-    view_config = ViewConfig(
-      rows=[
-        ViewAxisConfig(
-          type="element",
-          element_labels={
-            "Cash": "Cash and Cash Equivalents",
-            "Assets": "Total Assets",
-          },
-        )
-      ],
-      columns=[ViewAxisConfig(type="period")],
-    )
+    summary = summarize_by_element(facts)
 
-    fact_grid = builder.build(sample_fact_data, view_config, "test_source")
-    pivot_table = builder.generate_pivot_table(fact_grid, view_config)
+    assert set(summary) == {"us-gaap:Assets", "ifrs-full:Assets"}
 
-    row_labels = [row[0] for row in pivot_table["index"]]
-    assert "Cash and Cash Equivalents" in row_labels
-    assert "Total Assets" in row_labels
+  def test_skips_null_values(self):
+    facts = [
+      _fact("us-gaap:Assets", "Assets", 100, "2024-12-31"),
+      {**_fact("us-gaap:Assets", "Assets", 0, "2023-12-31"), "value": None},
+    ]
+
+    summary = summarize_by_element(facts)
+
+    assert summary["us-gaap:Assets"]["count"] == 1
+
+  def test_empty_input(self):
+    assert summarize_by_element([]) == {}

--- a/tests/operations/roboledger/views/test_fact_query.py
+++ b/tests/operations/roboledger/views/test_fact_query.py
@@ -14,7 +14,6 @@ Covers LadybugDB-specific behaviors:
 
 from unittest.mock import AsyncMock, patch
 
-import pandas as pd
 import pytest
 
 from robosystems.operations.roboledger.views.fact_query import (
@@ -268,15 +267,12 @@ class TestQueryFactGrid:
 
   @pytest.mark.asyncio
   @pytest.mark.unit
-  async def test_empty_results_returns_empty_dataframe(self, mock_repository):
+  async def test_empty_results_returns_empty_list(self, mock_repository):
     mock_repository.execute_query.return_value = []
     with patch(PATCH_REPO, return_value=mock_repository):
       result = await query_fact_grid(MOCK_GRAPH_ID, elements=["us-gaap:Assets"])
 
-    assert isinstance(result, pd.DataFrame)
-    assert len(result) == 0
-    assert "element_id" in result.columns
-    assert "value" in result.columns
+    assert result == []
 
   @pytest.mark.asyncio
   @pytest.mark.unit
@@ -323,9 +319,9 @@ class TestQueryFactGrid:
       result = await query_fact_grid(MOCK_GRAPH_ID, elements=["us-gaap:Assets"])
     assert len(result) == 2
     # Sorted DESC by period_end
-    assert result.iloc[0]["period_end"] == "2025-12-31"
-    assert result.iloc[0]["value"] == 100.0
-    assert result.iloc[1]["period_end"] == "2024-12-31"
+    assert result[0]["period_end"] == "2025-12-31"
+    assert result[0]["value"] == 100.0
+    assert result[1]["period_end"] == "2024-12-31"
 
 
 class TestDeduplicateFactRows:

--- a/tests/routers/extensions/roboledger/test_views.py
+++ b/tests/routers/extensions/roboledger/test_views.py
@@ -3,30 +3,30 @@
 Covers the analytical view operation registered in
 `routers/extensions/roboledger/views.py`. This is the only
 read-shaped operation in the dispatcher — it queries the LadybugDB
-graph (XBRL hypercube schema) and returns a multi-dimensional pivot
-table wrapped in an `OperationEnvelope`.
+graph (XBRL hypercube schema) and returns deduplicated facts plus the
+aspects they span, wrapped in an `OperationEnvelope`.
 
 The route lives in its own module (separate from `operations.py`) so
 it can be mounted independently of `ROBOLEDGER_ENABLED` — SEC-only
 deployments need fact-grid without enabling roboledger tenants. The
 `TestFactGridFlagDecoupling` class below pins that behavior.
 
-Mocks the underlying graph query (`query_fact_grid`) and the
-`FactGridBuilder` so the tests stay focused on the operation route's
-contract: arg threading, validation, envelope wrapping, and error
-translation. The Cypher and pandas pivot logic have their own unit
-coverage in the ops layer.
+Mocks the underlying graph query (`query_fact_grid`) but runs the real
+`FactGridBuilder` over fact records shaped exactly as the query returns
+them — the response shape is the contract under test, and mocking the
+builder is what previously let a column-name mismatch between query and
+builder go unnoticed. The Cypher has its own coverage in the ops layer.
 """
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pandas as pd
 import pytest
 from fastapi import HTTPException
 
 from robosystems.models.api.extensions.reports import (
   FinancialStatementAnalysisRequest,
 )
+from robosystems.models.api.views import CreateViewRequest
 from robosystems.routers.extensions.roboledger.views import (
   build_fact_grid_op,
   financial_statement_analysis_op,
@@ -45,22 +45,16 @@ def _make_create_view_request(
   entities=None,
   include_summary=False,
 ):
-  """Build a duck-typed CreateViewRequest matching the route signature."""
-  mock_request = MagicMock()
-  mock_request.elements = elements if elements is not None else ["us-gaap:Assets"]
-  mock_request.canonical_concepts = (
-    canonical_concepts if canonical_concepts is not None else []
+  """Build a real CreateViewRequest matching the route signature."""
+  return CreateViewRequest(
+    elements=elements if elements is not None else ["us-gaap:Assets"],
+    canonical_concepts=canonical_concepts if canonical_concepts is not None else [],
+    periods=periods or [],
+    period_type=period_type,
+    entity=entity,
+    entities=entities or [],
+    include_summary=include_summary,
   )
-  mock_request.periods = periods or []
-  mock_request.period_type = period_type
-  mock_request.entity = entity
-  mock_request.entities = entities or []
-  mock_request.form = None
-  mock_request.fiscal_year = None
-  mock_request.fiscal_period = None
-  mock_request.include_summary = include_summary
-  mock_request.view_config = MagicMock()
-  return mock_request
 
 
 def _make_user(user_id: str = "usr_test"):
@@ -69,11 +63,18 @@ def _make_user(user_id: str = "usr_test"):
   return user
 
 
-def _make_mock_grid(fact_count: int = 5):
-  grid = MagicMock()
-  grid.metadata.fact_count = fact_count
-  grid.facts_df = None
-  return grid
+def _make_facts(count: int = 5):
+  """Fact records shaped exactly as `query_fact_grid` returns them."""
+  return [
+    {
+      "element_id": "us-gaap:Assets",
+      "element_name": "Assets",
+      "period_end": f"202{i}-12-31",
+      "value": 1000.0 * (i + 1),
+      "unit": "USD",
+    }
+    for i in range(count)
+  ]
 
 
 class _FakeCache:
@@ -93,26 +94,14 @@ class TestBuildFactGridOperation:
   @pytest.mark.unit
   async def test_happy_path_wraps_in_envelope(self):
     """The operation runs query_fact_grid + FactGridBuilder and wraps result."""
-    mock_grid = _make_mock_grid(fact_count=42)
-    mock_builder = MagicMock()
-    mock_builder.build.return_value = mock_grid
-    mock_builder.generate_pivot_table.return_value = {
-      "index": [["Assets"]],
-      "columns": [["2026-01-31"]],
-      "data": [[1000.0]],
-      "metadata": {"row_count": 1, "column_count": 1},
-    }
-
+    facts = _make_facts(count=3)
     body = _make_create_view_request(elements=["us-gaap:Assets"], period_type="instant")
 
-    with (
-      patch(
-        f"{MODULE}.query_fact_grid",
-        new_callable=AsyncMock,
-        return_value=MagicMock(),
-      ) as mock_query,
-      patch(f"{MODULE}.FactGridBuilder", return_value=mock_builder),
-    ):
+    with patch(
+      f"{MODULE}.query_fact_grid",
+      new_callable=AsyncMock,
+      return_value=facts,
+    ) as mock_query:
       envelope = await build_fact_grid_op(
         body=body,
         graph_id=GRAPH_ID,
@@ -125,11 +114,11 @@ class TestBuildFactGridOperation:
     assert envelope.operation_id.startswith("op_")
     assert envelope.status == "completed"
     assert envelope.result is not None
-    # ViewResponse wraps {metadata, presentations}
-    assert "metadata" in envelope.result
-    assert "presentations" in envelope.result
-    assert envelope.result["metadata"]["facts_processed"] == 42
-    assert "pivot_table" in envelope.result["presentations"]
+    assert envelope.result["metadata"]["facts_processed"] == 3
+    assert len(envelope.result["facts"]) == 3
+    assert envelope.result["facts"][0]["element_id"] == "us-gaap:Assets"
+    assert envelope.result["facts"][0]["value"] == 1000.0
+    assert envelope.result["summary"] is None
     mock_query.assert_called_once()
     call_kwargs = mock_query.call_args.kwargs
     assert call_kwargs["graph_id"] == GRAPH_ID
@@ -137,27 +126,60 @@ class TestBuildFactGridOperation:
     assert call_kwargs["period_type"] == "instant"
 
   @pytest.mark.unit
+  async def test_facts_are_returned_unaggregated(self):
+    """Two filers reporting the same element+period stay two records."""
+    facts = [
+      {
+        "element_id": "us-gaap:Assets",
+        "element_name": "Assets",
+        "period_end": "2024-12-31",
+        "value": 1000.0,
+        "unit": "USD",
+        "entity_ticker": "AAPL",
+        "entity_name": "Apple Inc.",
+      },
+      {
+        "element_id": "us-gaap:Assets",
+        "element_name": "Assets",
+        "period_end": "2024-12-31",
+        "value": 2000.0,
+        "unit": "USD",
+        "entity_ticker": "MSFT",
+        "entity_name": "MICROSOFT CORP",
+      },
+    ]
+    body = _make_create_view_request(entities=["AAPL", "MSFT"])
+
+    with patch(
+      f"{MODULE}.query_fact_grid",
+      new_callable=AsyncMock,
+      return_value=facts,
+    ):
+      envelope = await build_fact_grid_op(
+        body=body,
+        graph_id=GRAPH_ID,
+        user=_make_user(),
+        idempotency_key=None,
+        cache=_FakeCache(),
+      )
+
+    result = envelope.result
+    assert result is not None
+    assert len(result["facts"]) == 2
+    assert {f["value"] for f in result["facts"]} == {1000.0, 2000.0}
+    entity_dim = next(d for d in result["dimensions"] if d["type"] == "entity")
+    assert entity_dim["members"] == ["AAPL", "MSFT"]
+
+  @pytest.mark.unit
   async def test_entity_filter_passed_through(self):
     """Single-entity ticker filter threads through to query_fact_grid."""
-    mock_builder = MagicMock()
-    mock_builder.build.return_value = _make_mock_grid()
-    mock_builder.generate_pivot_table.return_value = {
-      "index": [],
-      "columns": [],
-      "data": [],
-      "metadata": {},
-    }
-
     body = _make_create_view_request(entity="NVDA")
 
-    with (
-      patch(
-        f"{MODULE}.query_fact_grid",
-        new_callable=AsyncMock,
-        return_value=MagicMock(),
-      ) as mock_query,
-      patch(f"{MODULE}.FactGridBuilder", return_value=mock_builder),
-    ):
+    with patch(
+      f"{MODULE}.query_fact_grid",
+      new_callable=AsyncMock,
+      return_value=_make_facts(),
+    ) as mock_query:
       await build_fact_grid_op(
         body=body,
         graph_id=GRAPH_ID,
@@ -205,33 +227,36 @@ class TestBuildFactGridOperation:
 
   @pytest.mark.unit
   async def test_include_summary_adds_per_element_stats(self):
-    """include_summary=True adds element-keyed aggregates to presentations."""
-    mock_grid = _make_mock_grid(fact_count=3)
-    mock_grid.facts_df = pd.DataFrame(
+    """include_summary=True adds element-keyed aggregates, keyed on qname."""
+    facts = [
       {
-        "element_name": ["Revenue", "Revenue", "Cost of Revenue"],
-        "value": [1000.0, 2000.0, 500.0],
-      }
-    )
-
-    mock_builder = MagicMock()
-    mock_builder.build.return_value = mock_grid
-    mock_builder.generate_pivot_table.return_value = {
-      "index": [],
-      "columns": [],
-      "data": [],
-      "metadata": {},
-    }
-
+        "element_id": "us-gaap:Revenues",
+        "element_name": "Revenues",
+        "period_end": "2024-12-31",
+        "value": 1000.0,
+        "unit": "USD",
+      },
+      {
+        "element_id": "us-gaap:Revenues",
+        "element_name": "Revenues",
+        "period_end": "2023-12-31",
+        "value": 2000.0,
+        "unit": "USD",
+      },
+      {
+        "element_id": "us-gaap:CostOfRevenue",
+        "element_name": "CostOfRevenue",
+        "period_end": "2024-12-31",
+        "value": 500.0,
+        "unit": "USD",
+      },
+    ]
     body = _make_create_view_request(include_summary=True)
 
-    with (
-      patch(
-        f"{MODULE}.query_fact_grid",
-        new_callable=AsyncMock,
-        return_value=MagicMock(),
-      ),
-      patch(f"{MODULE}.FactGridBuilder", return_value=mock_builder),
+    with patch(
+      f"{MODULE}.query_fact_grid",
+      new_callable=AsyncMock,
+      return_value=facts,
     ):
       envelope = await build_fact_grid_op(
         body=body,
@@ -241,24 +266,20 @@ class TestBuildFactGridOperation:
         cache=_FakeCache(),
       )
 
-    presentations = envelope.result["presentations"]  # type: ignore[index]
-    assert "summary" in presentations
-    assert presentations["summary"]["Revenue"]["count"] == 2
-    assert presentations["summary"]["Revenue"]["total"] == 3000.0
-    assert presentations["summary"]["Cost of Revenue"]["total"] == 500.0
+    summary = envelope.result["summary"]  # type: ignore[index]
+    assert summary["us-gaap:Revenues"]["count"] == 2
+    assert summary["us-gaap:Revenues"]["total"] == 3000.0
+    assert summary["us-gaap:CostOfRevenue"]["total"] == 500.0
 
   @pytest.mark.unit
   async def test_internal_error_audited_and_propagated(self):
     """Any error from the underlying query bubbles up through the dispatcher."""
     body = _make_create_view_request()
 
-    with (
-      patch(
-        f"{MODULE}.query_fact_grid",
-        new_callable=AsyncMock,
-        side_effect=RuntimeError("connection lost"),
-      ),
-      patch(f"{MODULE}.FactGridBuilder"),
+    with patch(
+      f"{MODULE}.query_fact_grid",
+      new_callable=AsyncMock,
+      side_effect=RuntimeError("connection lost"),
     ):
       with pytest.raises(RuntimeError):
         await build_fact_grid_op(


### PR DESCRIPTION
## The bug

`build-fact-grid`'s REST pivot arm never pivoted. `generate_pivot_table` resolved its value column to `numeric_value` or `net_balance`, but `query_fact_grid` returns `value` — so every call fell through to the raw-frame branch and `presentations.pivot_table` was a flat dump of the DataFrame.

It went unnoticed because the builder's unit-test fixtures used `numeric_value`, a column the real query never emits, and the router tests mocked the builder wholesale.

## Why fixing the column name would have been worse

`pivot_table(index=element_name, columns=period_end, aggfunc="sum", fill_value=0.0)`:

- **Entity isn't in the key.** Multi-company comparison is the advertised use case (`entities: ['NVDA','AAPL']`) and entity appears only as metadata — a cell would become NVDA assets *plus* AAPL assets.
- **The index is the element local name.** `us-gaap:Assets` and `ifrs-full:Assets` are both "Assets" and would be summed.
- **Unit isn't in the key.** USD and shares are summable within a column.
- **`fill_value=0.0` erases blank-vs-zero** — a statement showing `0` where there was no fact is wrong in a way that reads as authoritative.

The fallback was honest; the "fixed" version would have lied. Collapsing facts into cells needs the full aspect signature, which `@robosystems/report-components` already keys on — so the server hands back facts and the consumer arranges them.

## What changed

`ViewResponse` is now typed `{metadata, dimensions, facts, summary}` rather than an untyped `presentations` dict. `generate_pivot_table` and `PivotTablePresentation` are gone. REST and MCP serve the same records from the same path, and pandas leaves this path entirely — `query_fact_grid` returns `list[dict]`, since dedup and sort were already plain Python.

Three more mismatches between the builder and the query it consumes:

- **Entity dimension could never appear.** It was extracted from `entity_id`, dimensions from `dimension_axis`; the query returns neither. This is why entity-scoped queries came back with `dimension_count: 2` in production. Now keyed on `entity_ticker`, with qnames as Element members so two taxonomies sharing a local name stay distinct.
- **`include_null_dimension` was inverted** — `if not axis.include_null_dimension` *added* null-aspect rows to the mask, so asking to exclude nulls included them.
- **Summaries keyed on local name**, collapsing distinct qnames. Now shared between both surfaces via `summarize_by_element` and keyed on qname.

## API surface

Pivot-only request knobs removed, since nothing consumed them: `member_order`, `member_labels`, `element_order`, `element_labels`, `ViewConfig.values`, `aggregation_function`, `fill_value`. `ViewAxisConfig` keeps the filtering half — `type`, `selected_members`, `include_null_dimension`.

Axis type `"dimension"` now raises instead of silently no-op'ing: the query filters on `has_dimensions = false`, so dimensional facts never reach the response.

MCP: the accepted-and-ignored `dimensions` argument is gone; `construction_time_ms` now covers the query rather than only the in-memory build (it reported ~1ms regardless of graph latency); the description warns that omitting the entity filter returns facts with no entity identity.

**Breaking OpenAPI change — the TS and Python clients need regenerating.**

## Verification

Exercised against the production SEC repository before and after. Verified the new response shape against the verbatim records prod returned for a NVDA/MSFT/AAPL revenue comparison: three facts, three entities in the Entity dimension, nothing summed.

Tests now run the real builder over records shaped as `query_fact_grid` returns them, and pin the pruned fields as absent. Five test files were updated — every one had a mock or fixture describing a shape the query doesn't produce, which is the same root cause as the bug itself.

`just test-code` clean. Full suite green (11554 passed, 15 skipped) with one exclusion noted below.

## Known gaps, not addressed here

- **No entity identity without an entity filter.** `query_fact_grid` only adds the entity columns to the `RETURN` when a filter is present, so an unfiltered query returns anonymous facts from many filers. It's also the shape that leads with `(f:Fact)` and full-scans. Mitigated for now by a warning in the tool description.
- **No result cap.** A `revenue`/FY2024 query returns 364 facts and 83KB with nothing bounding it.

## Unrelated pre-existing failure

`tests/graph_api/routers/databases/tables/test_incremental_materialize.py` fails locally on the full suite with `pyarrow.lib.ArrowKeyError: Attempted to register factory for scheme 'file' but that scheme is already registered`. It reproduces with `tests/adapters` + that file alone, is file-level rather than test-level (deselecting one test moves the failure to its neighbour), and is independent of this diff — neither `robosystems/adapters`, `tests/adapters`, `robosystems/graph_api`, nor `tests/graph_api` references any module changed here.
