### PR TITLE
feat(roboledger): entity identity, element anchoring, and payload bounds on fact-grid

### DIFF
--- a/robosystems/middleware/mcp/tools/fact_grid_tool.py
+++ b/robosystems/middleware/mcp/tools/fact_grid_tool.py
@@ -17,8 +17,13 @@ from __future__ import annotations
 import time
 from typing import Any
 
+from robosystems.config.shared_repositories import is_shared_repository_or_subgraph
 from robosystems.logger import logger
 from robosystems.models.api.views import ViewAxisConfig, ViewConfig
+from robosystems.models.api.views.view_config import (
+  DEFAULT_FACT_LIMIT,
+  MAX_FACT_LIMIT,
+)
 from robosystems.operations.roboledger.views import (
   FactGridBuilder,
   query_fact_grid,
@@ -58,12 +63,12 @@ class BuildFactGridTool:
 - fiscal_year/fiscal_period: Filter by report fiscal context
 
 **RETURNS:**
-- Deduplicated facts with element qnames, names, values, periods, and units — one record per fact, not a pivot table
-- Entity ticker and name ONLY when an entity filter is used
+- Deduplicated facts with element qnames, names, values, periods, units, and entity ticker/name — one record per fact, not a pivot table
 - Only consolidated totals (dimensional breakdowns excluded)
+- `truncated: true` when more facts matched than `limit` allowed; the ones returned are the most recent by period
 
 **IMPORTANT:**
-Always pass entity or entities. Without an entity filter the response carries no entity identity at all, so facts from different filers are indistinguishable — and the query degrades to a full scan of the fact table, which is slow on large repositories like SEC.
+On shared repositories (e.g. SEC) entity or entities is REQUIRED — those graphs host thousands of filers, so an unscoped query returns an arbitrary slice of arbitrary companies. On a tenant graph the URL already scopes to one entity, so the filter is optional there.
 
 **TIP:**
 For income statement items (revenue, net income), always specify period_type='annual' or 'quarterly' to avoid mixing duration types. Use canonical_concepts for cross-company comparisons where companies may use different XBRL tags for the same concept.""",
@@ -126,6 +131,11 @@ For income statement items (revenue, net income), always specify period_type='an
             "description": "Include summary statistics (count, total, avg, min, max) by element",
             "default": False,
           },
+          "limit": {
+            "type": "integer",
+            "description": f"Maximum facts to return (default {DEFAULT_FACT_LIMIT}, max {MAX_FACT_LIMIT}). Applied after dedup and sort, so truncation keeps the most recent periods.",
+            "default": DEFAULT_FACT_LIMIT,
+          },
         },
         "required": [],
       },
@@ -145,6 +155,7 @@ For income statement items (revenue, net income), always specify period_type='an
     rows = arguments.get("rows", [])
     columns = arguments.get("columns", [])
     include_summary = arguments.get("include_summary", False)
+    limit = arguments.get("limit", DEFAULT_FACT_LIMIT)
 
     if not elements and not canonical_concepts:
       return {
@@ -156,6 +167,28 @@ For income statement items (revenue, net income), always specify period_type='an
       return {
         "error": "missing_period_filter",
         "message": "Provide periods, period_type, or fiscal_year to scope the query",
+      }
+
+    # Shared repos host thousands of filers; an entity-less query there
+    # returns an arbitrary slice of arbitrary companies. Tenant graphs are
+    # already entity-scoped by the graph itself. Mirrors the REST route.
+    if (
+      is_shared_repository_or_subgraph(self.client.graph_id)
+      and not entity
+      and not entities
+    ):
+      return {
+        "error": "missing_entity_filter",
+        "message": (
+          "entity or entities is required on shared-repository graphs "
+          "(e.g. SEC). Pass a ticker, CIK, or company name."
+        ),
+      }
+
+    if not isinstance(limit, int) or limit < 1 or limit > MAX_FACT_LIMIT:
+      return {
+        "error": "invalid_limit",
+        "message": f"limit must be an integer between 1 and {MAX_FACT_LIMIT}",
       }
 
     if rows and not isinstance(rows, list):
@@ -178,7 +211,7 @@ For income statement items (revenue, net income), always specify period_type='an
 
     start_time = time.time()
 
-    fact_data = await query_fact_grid(
+    fact_data, truncated = await query_fact_grid(
       graph_id=self.client.graph_id,
       elements=elements or None,
       canonical_concepts=canonical_concepts or None,
@@ -189,6 +222,7 @@ For income statement items (revenue, net income), always specify period_type='an
       fiscal_year=fiscal_year,
       fiscal_period=fiscal_period,
       period_type=period_type,
+      limit=limit,
     )
 
     row_configs = [ViewAxisConfig(**r) for r in rows] if rows else []
@@ -224,8 +258,16 @@ For income statement items (revenue, net income), always specify period_type='an
         for d in fact_grid.dimensions
       ],
       "data": fact_grid.facts,
+      "truncated": truncated,
       "construction_time_ms": elapsed_ms,
-      "message": f"Built fact grid with {fact_grid.metadata.fact_count} facts",
+      "message": (
+        f"Built fact grid with {fact_grid.metadata.fact_count} facts"
+        + (
+          f" (truncated at limit={limit}; narrow the filters or raise limit)"
+          if truncated
+          else ""
+        )
+      ),
     }
 
     if include_summary and fact_grid.facts:

--- a/robosystems/models/api/views/view_config.py
+++ b/robosystems/models/api/views/view_config.py
@@ -1,5 +1,12 @@
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+# Payload bounds, shared with the ops-layer query and the MCP tool. A single
+# common element spans hundreds of thousands of facts on the SEC repository,
+# so an unbounded response is never useful and routinely exceeds an MCP
+# caller's token budget.
+DEFAULT_FACT_LIMIT = 250
+MAX_FACT_LIMIT = 5000
+
 
 class ViewAxisConfig(BaseModel):
   """Scoping configuration for one aspect of the fact query.
@@ -122,6 +129,16 @@ class CreateViewRequest(BaseModel):
   include_summary: bool = Field(
     default=False,
     description="Include summary statistics per element",
+  )
+  limit: int = Field(
+    default=DEFAULT_FACT_LIMIT,
+    ge=1,
+    le=MAX_FACT_LIMIT,
+    description=(
+      "Maximum facts to return. Applied after deduplication and sorting, so "
+      "truncation keeps the most recent periods. Check `metadata.truncated` "
+      "to see whether more facts matched."
+    ),
   )
   view_config: ViewConfig = Field(
     default_factory=ViewConfig, description="Aspect scoping configuration"

--- a/robosystems/models/api/views/view_response.py
+++ b/robosystems/models/api/views/view_response.py
@@ -34,6 +34,14 @@ class ViewMetadata(BaseModel):
   source: str = Field(..., description="Data source type")
   period_start: str | None = Field(None, description="Period start date")
   period_end: str | None = Field(None, description="Period end date")
+  truncated: bool = Field(
+    default=False,
+    description=(
+      "True when more facts matched than `limit` allowed. The returned facts "
+      "are the most recent by period; narrow the filters or raise `limit` to "
+      "see the rest."
+    ),
+  )
 
 
 class ViewResponse(BaseModel):

--- a/robosystems/operations/roboledger/views/fact_query.py
+++ b/robosystems/operations/roboledger/views/fact_query.py
@@ -14,6 +14,13 @@ the same LadybugDB-specific optimizations:
   so ``f.has_dimensions = false`` stays in WHERE.
 - **``DISTINCT`` + ``ORDER BY`` together returns empty results**, so
   we run without either clause in Cypher and do dedup + sort in Python.
+- **``ORDER BY`` + ``LIMIT`` is not a cheap top-N.** Ordering forces a
+  full materialize-then-sort: over the ~269k ``us-gaap:Assets`` facts on
+  the SEC repository, ``ORDER BY p.end_date DESC LIMIT 5`` times out at
+  25s while a bare ``count(f)`` on the same anchored pattern returns
+  promptly. ``limit`` is therefore applied in Python after dedup + sort,
+  where it bounds the *payload* deterministically (most recent first).
+  Bounding the *query* is the job of anchoring and the caller's filters.
 """
 
 from __future__ import annotations
@@ -22,6 +29,7 @@ import re
 from typing import Any
 
 from robosystems.middleware.graph import get_graph_repository
+from robosystems.models.api.views.view_config import DEFAULT_FACT_LIMIT
 
 # Pre-compiled patterns for inline Cypher node filter sanitization.
 _SAFE_STR_RE = re.compile(r"[\w:\-]+")
@@ -113,26 +121,23 @@ def _build_entity_match(
   )
 
 
-def _deduplicate_fact_rows(
-  rows: list[dict[str, Any]], *, has_entity: bool
-) -> list[dict[str, Any]]:
-  """Dedup by ``(element, period, [entity])`` keeping the first occurrence,
+def _deduplicate_fact_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+  """Dedup by ``(element, period, entity)`` keeping the first occurrence,
   then sort by ``period_end`` DESC.
 
   DISTINCT + ORDER BY returns empty results in LadybugDB, so the query
-  omits both and we handle dedup + sort here.
+  omits both and we handle dedup + sort here. Entity is always part of the
+  key — without it two filers reporting the same element for the same
+  period collapse into one row.
   """
   seen: set[tuple] = set()
   deduped: list[dict[str, Any]] = []
   for row in rows:
-    if has_entity:
-      key = (
-        row.get("element_id", ""),
-        row.get("period_end", ""),
-        row.get("entity_ticker") or row.get("entity_name", ""),
-      )
-    else:
-      key = (row.get("element_id", ""), row.get("period_end", ""))
+    key = (
+      row.get("element_id", ""),
+      row.get("period_end", ""),
+      row.get("entity_ticker") or row.get("entity_name", ""),
+    )
     if key not in seen:
       seen.add(key)
       deduped.append(row)
@@ -151,7 +156,8 @@ async def query_fact_grid(
   fiscal_year: int | None = None,
   fiscal_period: str | None = None,
   period_type: str | None = None,
-) -> list[dict[str, Any]]:
+  limit: int = DEFAULT_FACT_LIMIT,
+) -> tuple[list[dict[str, Any]], bool]:
   """Query deduplicated facts for the roboledger XBRL hypercube.
 
   Shared by REST (`build-fact-grid`) and MCP (`BuildFactGridTool`). See
@@ -168,12 +174,16 @@ async def query_fact_grid(
       fiscal_year: Fiscal year filter.
       fiscal_period: Fiscal period filter (e.g., ``'FY'``, ``'Q1'``).
       period_type: ``'annual'``, ``'quarterly'``, or ``'instant'``.
+      limit: Maximum fact records to return, applied after dedup + sort so
+          truncation keeps the most recent periods.
 
   Returns:
-      Fact records with keys ``element_id``, ``element_name``, ``period_end``,
-      ``value``, ``unit``, and — only when entity filters are used —
-      ``entity_ticker`` and ``entity_name``. Deduplicated and sorted by
-      ``period_end`` descending.
+      ``(facts, truncated)``. Each fact carries ``element_id``,
+      ``element_name``, ``period_end``, ``value``, ``unit``,
+      ``entity_ticker`` and ``entity_name`` — entity identity is always
+      returned, since without it facts from different filers are
+      indistinguishable. Deduplicated and sorted by ``period_end``
+      descending. ``truncated`` is True when ``limit`` dropped rows.
   """
   parameters: dict[str, Any] = {}
 
@@ -181,26 +191,26 @@ async def query_fact_grid(
     elements, canonical_concepts, parameters
   )
   entity_list = entities if entities else ([entity] if entity else None)
-  entity_pattern, entity_where = _build_entity_match(entity_list, parameters)
+  entity_filter, entity_where = _build_entity_match(entity_list, parameters)
+  entity_pattern = entity_filter or "(ent:Entity)"
 
-  # Anchor the traversal on the Entity when an entity filter is present so the
-  # planner seeds from the ~thousands of Entity nodes (single tickers are
-  # inline-anchored to one) and never full-scans the 100M+ Fact nodes that
-  # leading with (f:Fact) forces. Multi-entity / CIK / name comparisons lost
-  # the single-ticker inline anchor and degraded to a full Fact scan (25s+
-  # timeout) before this; leading with Entity keeps them sub-second.
-  if entity_pattern:
-    match_parts = [
-      f"{entity_pattern}<-[:FACT_HAS_ENTITY]-(f:Fact)-[:FACT_HAS_ELEMENT]->{element_pattern}",
-      "(f)-[:FACT_HAS_PERIOD]->(p:Period)",
-      "(f)-[:FACT_HAS_UNIT]->(u:Unit)",
-    ]
+  # Lead the MATCH with whichever pattern is selective, never with (f:Fact) —
+  # that forces a full scan of the 100M+ Fact nodes. With an entity filter the
+  # planner seeds from the ~thousands of Entity nodes (a single ticker is
+  # inline-anchored to one); without one it seeds from the Element, which for
+  # a specific qname is a single node. Multi-entity / CIK / name comparisons
+  # lost the single-ticker inline anchor and degraded to a full Fact scan
+  # (25s+ timeout) before this.
+  if entity_filter:
+    lead = f"{entity_pattern}<-[:FACT_HAS_ENTITY]-(f:Fact)-[:FACT_HAS_ELEMENT]->{element_pattern}"
   else:
-    match_parts = [
-      f"(f:Fact)-[:FACT_HAS_ELEMENT]->{element_pattern}",
-      "(f)-[:FACT_HAS_PERIOD]->(p:Period)",
-      "(f)-[:FACT_HAS_UNIT]->(u:Unit)",
-    ]
+    lead = f"{element_pattern}<-[:FACT_HAS_ELEMENT]-(f:Fact)-[:FACT_HAS_ENTITY]->{entity_pattern}"
+
+  match_parts = [
+    lead,
+    "(f)-[:FACT_HAS_PERIOD]->(p:Period)",
+    "(f)-[:FACT_HAS_UNIT]->(u:Unit)",
+  ]
 
   where_clauses = ["f.has_dimensions = false", *element_where, *entity_where]
 
@@ -228,27 +238,21 @@ async def query_fact_grid(
       parameters["fiscal_period"] = fiscal_period
 
   # Omit DISTINCT + ORDER BY — both broken together in LadybugDB; dedup
-  # and sort happen in Python below.
-  if entity_pattern:
-    return_clause = (
-      "\n      RETURN\n"
-      "        el.qname as element_id,\n"
-      "        el.name as element_name,\n"
-      "        p.end_date as period_end,\n"
-      "        f.numeric_value as value,\n"
-      "        u.value as unit,\n"
-      "        ent.ticker as entity_ticker,\n"
-      "        ent.name as entity_name\n      "
-    )
-  else:
-    return_clause = (
-      "\n      RETURN\n"
-      "        el.qname as element_id,\n"
-      "        el.name as element_name,\n"
-      "        p.end_date as period_end,\n"
-      "        f.numeric_value as value,\n"
-      "        u.value as unit\n      "
-    )
+  # and sort happen in Python below. Entity columns are always returned:
+  # every Fact carries a FACT_HAS_ENTITY edge (verified on SEC — the
+  # us-gaap:Assets fact count is identical with and without the traversal,
+  # and materialize.py builds the edge for native and shared facts alike),
+  # so the join drops nothing and the caller can always tell filers apart.
+  return_clause = (
+    "\n      RETURN\n"
+    "        el.qname as element_id,\n"
+    "        el.name as element_name,\n"
+    "        p.end_date as period_end,\n"
+    "        f.numeric_value as value,\n"
+    "        u.value as unit,\n"
+    "        ent.ticker as entity_ticker,\n"
+    "        ent.name as entity_name\n      "
+  )
 
   query = "MATCH " + ", ".join(match_parts)
   query += "\nWHERE " + "\n  AND ".join(where_clauses)
@@ -261,6 +265,9 @@ async def query_fact_grid(
   results = await repository.execute_query(query, parameters)
 
   if not results:
-    return []
+    return [], False
 
-  return _deduplicate_fact_rows(results, has_entity=bool(entity_pattern))
+  deduped = _deduplicate_fact_rows(results)
+  if len(deduped) > limit:
+    return deduped[:limit], True
+  return deduped, False

--- a/robosystems/routers/extensions/roboledger/views.py
+++ b/robosystems/routers/extensions/roboledger/views.py
@@ -17,9 +17,10 @@ that gated only on `FACT_GRID_ENABLED`.
 **Why still under `/extensions/roboledger/`?**
 Because the fact-grid is roboledger-schema-specific. It doesn't fit on
 the platform graph surface (which is schema-agnostic) and it doesn't
-fit on GraphQL (which can't represent multi-dimensional pivot tables
-naturally). The operations dispatcher is the right home — we just
-gate the mount on `FACT_GRID_ENABLED` independently.
+fit on GraphQL (whose typed field selection can't express an arbitrary
+slice across element, period, and entity). The operations dispatcher is
+the right home — we just gate the mount on `FACT_GRID_ENABLED`
+independently.
 
 **Idempotency + audit:**
 Because this is a real operation in the dispatcher, it gets the
@@ -125,9 +126,23 @@ async def build_fact_grid_op(
       detail="Provide periods, period_type, or fiscal_year to scope the query",
     )
 
+  # Shared repositories host thousands of filers, so an entity-less query
+  # returns an arbitrary slice of facts from arbitrary companies. A tenant
+  # graph is already scoped to its entity by the URL — and that entity is
+  # often a private company with no ticker or CIK to filter on — so the
+  # requirement applies only to shared repos. Mirrors the asymmetry in
+  # financial-statement-analysis below.
+  if (
+    is_shared_repository_or_subgraph(graph_id) and not body.entity and not body.entities
+  ):
+    raise HTTPException(
+      status_code=400,
+      detail=("entity or entities is required on shared-repository graphs (e.g. SEC)."),
+    )
+
   async def _runner():
     start_time = time.time()
-    fact_data = await query_fact_grid(
+    fact_data, truncated = await query_fact_grid(
       graph_id=graph_id,
       elements=body.elements or None,
       canonical_concepts=body.canonical_concepts or None,
@@ -138,6 +153,7 @@ async def build_fact_grid_op(
       fiscal_year=body.fiscal_year,
       fiscal_period=body.fiscal_period,
       period_type=body.period_type,
+      limit=body.limit,
     )
 
     builder = FactGridBuilder()
@@ -151,6 +167,7 @@ async def build_fact_grid_op(
       facts_processed=fact_grid.metadata.fact_count,
       construction_time_ms=construction_time_ms,
       source="fact_grid",
+      truncated=truncated,
     )
 
     summary = None

--- a/tests/middleware/mcp/test_client.py
+++ b/tests/middleware/mcp/test_client.py
@@ -480,7 +480,7 @@ class TestGraphMCPTools:
     with patch(
       "robosystems.middleware.mcp.tools.fact_grid_tool.query_fact_grid",
       new_callable=AsyncMock,
-      return_value=facts,
+      return_value=(facts, False),
     ):
       result = await tools.call_tool(
         "build-fact-grid",

--- a/tests/middleware/mcp/test_tools.py
+++ b/tests/middleware/mcp/test_tools.py
@@ -51,7 +51,7 @@ class TestBuildFactGridTool:
     with patch(
       "robosystems.middleware.mcp.tools.fact_grid_tool.query_fact_grid",
       new_callable=AsyncMock,
-      return_value=facts,
+      return_value=(facts, False),
     ):
       result = await tool.execute(
         {"elements": ["us-gaap:Assets"], "periods": ["2023-12-31"]}
@@ -61,6 +61,99 @@ class TestBuildFactGridTool:
     assert result["fact_count"] == 1
     assert result["dimension_count"] == 2
     assert result["data"] == facts
+    assert result["truncated"] is False
+
+  @pytest.mark.asyncio
+  @pytest.mark.unit
+  async def test_shared_repo_requires_entity(self, mock_graph_client):
+    """SEC hosts thousands of filers; an unscoped query returns an arbitrary
+    slice of arbitrary companies."""
+    mock_graph_client.graph_id = "sec"
+    tool = BuildFactGridTool(mock_graph_client)
+
+    result = await tool.execute(
+      {"elements": ["us-gaap:Assets"], "periods": ["2023-12-31"]}
+    )
+
+    assert result["error"] == "missing_entity_filter"
+
+  @pytest.mark.asyncio
+  @pytest.mark.unit
+  async def test_shared_repo_with_entity_proceeds(self, mock_graph_client):
+    mock_graph_client.graph_id = "sec"
+    tool = BuildFactGridTool(mock_graph_client)
+
+    with patch(
+      "robosystems.middleware.mcp.tools.fact_grid_tool.query_fact_grid",
+      new_callable=AsyncMock,
+      return_value=([], False),
+    ):
+      result = await tool.execute(
+        {
+          "elements": ["us-gaap:Assets"],
+          "periods": ["2023-12-31"],
+          "entity": "NVDA",
+        }
+      )
+
+    assert result["success"] is True
+
+  @pytest.mark.asyncio
+  @pytest.mark.unit
+  async def test_tenant_graph_does_not_require_entity(self, mock_graph_client):
+    tool = BuildFactGridTool(mock_graph_client)
+
+    with patch(
+      "robosystems.middleware.mcp.tools.fact_grid_tool.query_fact_grid",
+      new_callable=AsyncMock,
+      return_value=([], False),
+    ):
+      result = await tool.execute(
+        {"elements": ["us-gaap:Assets"], "periods": ["2023-12-31"]}
+      )
+
+    assert result["success"] is True
+
+  @pytest.mark.asyncio
+  @pytest.mark.unit
+  async def test_limit_out_of_range_rejected(self, mock_graph_client):
+    tool = BuildFactGridTool(mock_graph_client)
+
+    result = await tool.execute(
+      {
+        "elements": ["us-gaap:Assets"],
+        "periods": ["2023-12-31"],
+        "limit": 999999,
+      }
+    )
+
+    assert result["error"] == "invalid_limit"
+
+  @pytest.mark.asyncio
+  @pytest.mark.unit
+  async def test_truncation_is_surfaced_in_message(self, mock_graph_client):
+    tool = BuildFactGridTool(mock_graph_client)
+    facts = [
+      {
+        "element_id": "us-gaap:Assets",
+        "element_name": "Assets",
+        "period_end": "2023-12-31",
+        "value": 1000.0,
+        "unit": "USD",
+      }
+    ]
+
+    with patch(
+      "robosystems.middleware.mcp.tools.fact_grid_tool.query_fact_grid",
+      new_callable=AsyncMock,
+      return_value=(facts, True),
+    ):
+      result = await tool.execute(
+        {"elements": ["us-gaap:Assets"], "periods": ["2023-12-31"], "limit": 1}
+      )
+
+    assert result["truncated"] is True
+    assert "truncated" in result["message"]
 
   @pytest.mark.asyncio
   @pytest.mark.unit
@@ -153,7 +246,7 @@ class TestBuildFactGridTool:
     with patch(
       "robosystems.middleware.mcp.tools.fact_grid_tool.query_fact_grid",
       new_callable=AsyncMock,
-      return_value=facts,
+      return_value=(facts, False),
     ):
       result = await tool.execute(
         {

--- a/tests/models/api/test_view_models.py
+++ b/tests/models/api/test_view_models.py
@@ -4,6 +4,8 @@ import pytest
 from pydantic import ValidationError
 
 from robosystems.models.api.views.view_config import (
+  DEFAULT_FACT_LIMIT,
+  MAX_FACT_LIMIT,
   CreateViewRequest,
   ViewAxisConfig,
   ViewConfig,
@@ -127,6 +129,26 @@ class TestCreateViewRequest:
     assert model.form == "10-K"
     assert model.fiscal_year == 2024
     assert model.fiscal_period == "FY"
+
+  def test_limit_defaults(self):
+    model = CreateViewRequest(elements=["us-gaap:Assets"], period_type="instant")
+    assert model.limit == DEFAULT_FACT_LIMIT
+
+  def test_limit_above_max_rejected(self):
+    with pytest.raises(ValidationError):
+      CreateViewRequest(
+        elements=["us-gaap:Assets"],
+        period_type="instant",
+        limit=MAX_FACT_LIMIT + 1,
+      )
+
+  def test_limit_below_one_rejected(self):
+    with pytest.raises(ValidationError):
+      CreateViewRequest(
+        elements=["us-gaap:Assets"],
+        period_type="instant",
+        limit=0,
+      )
 
   def test_invalid_period_type(self):
     with pytest.raises(ValidationError):

--- a/tests/operations/roboledger/views/test_fact_query.py
+++ b/tests/operations/roboledger/views/test_fact_query.py
@@ -259,20 +259,44 @@ class TestQueryFactGrid:
 
   @pytest.mark.asyncio
   @pytest.mark.unit
-  async def test_entity_columns_excluded_when_no_filter(self, mock_repository):
+  async def test_entity_columns_included_without_filter(self, mock_repository):
+    """Entity identity is always returned — without it facts from different
+    filers are indistinguishable."""
     with patch(PATCH_REPO, return_value=mock_repository):
       await query_fact_grid(MOCK_GRAPH_ID, elements=["us-gaap:Assets"])
     query = mock_repository.execute_query.call_args[0][0]
-    assert "entity_ticker" not in query
+    assert "entity_ticker" in query
+    assert "entity_name" in query
+
+  @pytest.mark.asyncio
+  @pytest.mark.unit
+  async def test_leads_with_element_anchor_without_entity_filter(self, mock_repository):
+    """Never lead with (f:Fact) — that full-scans the fact table."""
+    with patch(PATCH_REPO, return_value=mock_repository):
+      await query_fact_grid(MOCK_GRAPH_ID, elements=["us-gaap:Assets"])
+    query = mock_repository.execute_query.call_args[0][0]
+    assert query.startswith("MATCH (el:Element {qname: 'us-gaap:Assets'})")
+    assert "MATCH (f:Fact)" not in query
+
+  @pytest.mark.asyncio
+  @pytest.mark.unit
+  async def test_leads_with_entity_anchor_when_filtered(self, mock_repository):
+    with patch(PATCH_REPO, return_value=mock_repository):
+      await query_fact_grid(MOCK_GRAPH_ID, elements=["us-gaap:Assets"], entity="NVDA")
+    query = mock_repository.execute_query.call_args[0][0]
+    assert query.startswith("MATCH (ent:Entity {ticker: 'NVDA'})")
 
   @pytest.mark.asyncio
   @pytest.mark.unit
   async def test_empty_results_returns_empty_list(self, mock_repository):
     mock_repository.execute_query.return_value = []
     with patch(PATCH_REPO, return_value=mock_repository):
-      result = await query_fact_grid(MOCK_GRAPH_ID, elements=["us-gaap:Assets"])
+      result, truncated = await query_fact_grid(
+        MOCK_GRAPH_ID, elements=["us-gaap:Assets"]
+      )
 
     assert result == []
+    assert truncated is False
 
   @pytest.mark.asyncio
   @pytest.mark.unit
@@ -316,12 +340,48 @@ class TestQueryFactGrid:
       },
     ]
     with patch(PATCH_REPO, return_value=mock_repository):
-      result = await query_fact_grid(MOCK_GRAPH_ID, elements=["us-gaap:Assets"])
+      result, truncated = await query_fact_grid(
+        MOCK_GRAPH_ID, elements=["us-gaap:Assets"]
+      )
     assert len(result) == 2
     # Sorted DESC by period_end
     assert result[0]["period_end"] == "2025-12-31"
     assert result[0]["value"] == 100.0
     assert result[1]["period_end"] == "2024-12-31"
+    assert truncated is False
+
+  @pytest.mark.asyncio
+  @pytest.mark.unit
+  async def test_limit_truncates_after_sort(self, mock_repository):
+    """Truncation keeps the most recent periods, not an arbitrary slice."""
+    mock_repository.execute_query.return_value = [
+      {
+        "element_id": "us-gaap:Assets",
+        "element_name": "Assets",
+        "period_end": end,
+        "value": 1.0,
+        "unit": "USD",
+        "entity_ticker": "NVDA",
+      }
+      for end in ["2023-12-31", "2025-12-31", "2024-12-31"]
+    ]
+    with patch(PATCH_REPO, return_value=mock_repository):
+      result, truncated = await query_fact_grid(
+        MOCK_GRAPH_ID, elements=["us-gaap:Assets"], limit=2
+      )
+
+    assert truncated is True
+    assert [r["period_end"] for r in result] == ["2025-12-31", "2024-12-31"]
+
+  @pytest.mark.asyncio
+  @pytest.mark.unit
+  async def test_limit_not_applied_in_cypher(self, mock_repository):
+    """ORDER BY + LIMIT forces a full materialize-then-sort in LadybugDB
+    (25s timeout over 269k facts), so the limit is a Python-side bound."""
+    with patch(PATCH_REPO, return_value=mock_repository):
+      await query_fact_grid(MOCK_GRAPH_ID, elements=["us-gaap:Assets"], limit=10)
+    query = mock_repository.execute_query.call_args[0][0]
+    assert "LIMIT" not in query.upper()
 
 
 class TestDeduplicateFactRows:
@@ -332,11 +392,11 @@ class TestDeduplicateFactRows:
       {"element_id": "us-gaap:Assets", "period_end": "2025-12-31", "value": 999},
       {"element_id": "us-gaap:Revenue", "period_end": "2025-12-31", "value": 50},
     ]
-    deduped = _deduplicate_fact_rows(rows, has_entity=False)
+    deduped = _deduplicate_fact_rows(rows)
     assert len(deduped) == 2
 
   @pytest.mark.unit
-  def test_has_entity_key_includes_ticker(self):
+  def test_entity_is_part_of_the_key(self):
     """Same (qname, period) but different tickers should NOT dedup."""
     rows = [
       {
@@ -352,7 +412,7 @@ class TestDeduplicateFactRows:
         "value": 200,
       },
     ]
-    deduped = _deduplicate_fact_rows(rows, has_entity=True)
+    deduped = _deduplicate_fact_rows(rows)
     assert len(deduped) == 2
 
   @pytest.mark.unit
@@ -362,7 +422,7 @@ class TestDeduplicateFactRows:
       {"element_id": "b", "period_end": "2025-06-30", "value": 2},
       {"element_id": "c", "period_end": "2023-12-31", "value": 3},
     ]
-    deduped = _deduplicate_fact_rows(rows, has_entity=False)
+    deduped = _deduplicate_fact_rows(rows)
     assert [r["period_end"] for r in deduped] == [
       "2025-06-30",
       "2024-12-31",

--- a/tests/routers/extensions/roboledger/test_views.py
+++ b/tests/routers/extensions/roboledger/test_views.py
@@ -27,6 +27,7 @@ from robosystems.models.api.extensions.reports import (
   FinancialStatementAnalysisRequest,
 )
 from robosystems.models.api.views import CreateViewRequest
+from robosystems.models.api.views.view_config import DEFAULT_FACT_LIMIT
 from robosystems.routers.extensions.roboledger.views import (
   build_fact_grid_op,
   financial_statement_analysis_op,
@@ -44,6 +45,7 @@ def _make_create_view_request(
   entity=None,
   entities=None,
   include_summary=False,
+  limit=DEFAULT_FACT_LIMIT,
 ):
   """Build a real CreateViewRequest matching the route signature."""
   return CreateViewRequest(
@@ -54,6 +56,7 @@ def _make_create_view_request(
     entity=entity,
     entities=entities or [],
     include_summary=include_summary,
+    limit=limit,
   )
 
 
@@ -100,7 +103,7 @@ class TestBuildFactGridOperation:
     with patch(
       f"{MODULE}.query_fact_grid",
       new_callable=AsyncMock,
-      return_value=facts,
+      return_value=(facts, False),
     ) as mock_query:
       envelope = await build_fact_grid_op(
         body=body,
@@ -153,7 +156,7 @@ class TestBuildFactGridOperation:
     with patch(
       f"{MODULE}.query_fact_grid",
       new_callable=AsyncMock,
-      return_value=facts,
+      return_value=(facts, False),
     ):
       envelope = await build_fact_grid_op(
         body=body,
@@ -178,7 +181,7 @@ class TestBuildFactGridOperation:
     with patch(
       f"{MODULE}.query_fact_grid",
       new_callable=AsyncMock,
-      return_value=_make_facts(),
+      return_value=(_make_facts(), False),
     ) as mock_query:
       await build_fact_grid_op(
         body=body,
@@ -256,7 +259,7 @@ class TestBuildFactGridOperation:
     with patch(
       f"{MODULE}.query_fact_grid",
       new_callable=AsyncMock,
-      return_value=facts,
+      return_value=(facts, False),
     ):
       envelope = await build_fact_grid_op(
         body=body,
@@ -270,6 +273,91 @@ class TestBuildFactGridOperation:
     assert summary["us-gaap:Revenues"]["count"] == 2
     assert summary["us-gaap:Revenues"]["total"] == 3000.0
     assert summary["us-gaap:CostOfRevenue"]["total"] == 500.0
+
+  @pytest.mark.unit
+  async def test_shared_repo_without_entity_raises_400(self):
+    """Shared repos host thousands of filers; an unscoped query there returns
+    an arbitrary slice of arbitrary companies."""
+    body = _make_create_view_request()
+
+    with patch(f"{MODULE}.is_shared_repository_or_subgraph", return_value=True):
+      with pytest.raises(HTTPException) as exc_info:
+        await build_fact_grid_op(
+          body=body,
+          graph_id="sec",
+          user=_make_user(),
+          idempotency_key=None,
+          cache=_FakeCache(),
+        )
+
+    assert exc_info.value.status_code == 400
+    assert "entity" in exc_info.value.detail.lower()
+
+  @pytest.mark.unit
+  async def test_shared_repo_with_entity_allowed(self):
+    body = _make_create_view_request(entity="NVDA")
+
+    with (
+      patch(f"{MODULE}.is_shared_repository_or_subgraph", return_value=True),
+      patch(
+        f"{MODULE}.query_fact_grid",
+        new_callable=AsyncMock,
+        return_value=(_make_facts(), False),
+      ),
+    ):
+      envelope = await build_fact_grid_op(
+        body=body,
+        graph_id="sec",
+        user=_make_user(),
+        idempotency_key=None,
+        cache=_FakeCache(),
+      )
+
+    assert envelope.status == "completed"
+
+  @pytest.mark.unit
+  async def test_tenant_graph_without_entity_allowed(self):
+    """A tenant graph is already entity-scoped by its URL, and its entity is
+    often a private company with no ticker or CIK to filter on."""
+    body = _make_create_view_request()
+
+    with (
+      patch(f"{MODULE}.is_shared_repository_or_subgraph", return_value=False),
+      patch(
+        f"{MODULE}.query_fact_grid",
+        new_callable=AsyncMock,
+        return_value=(_make_facts(), False),
+      ),
+    ):
+      envelope = await build_fact_grid_op(
+        body=body,
+        graph_id=GRAPH_ID,
+        user=_make_user(),
+        idempotency_key=None,
+        cache=_FakeCache(),
+      )
+
+    assert envelope.status == "completed"
+
+  @pytest.mark.unit
+  async def test_limit_threads_through_and_truncation_surfaces(self):
+    body = _make_create_view_request(limit=2)
+
+    with patch(
+      f"{MODULE}.query_fact_grid",
+      new_callable=AsyncMock,
+      return_value=(_make_facts(count=2), True),
+    ) as mock_query:
+      envelope = await build_fact_grid_op(
+        body=body,
+        graph_id=GRAPH_ID,
+        user=_make_user(),
+        idempotency_key=None,
+        cache=_FakeCache(),
+      )
+
+    assert mock_query.call_args.kwargs["limit"] == 2
+    assert envelope.result["metadata"]["truncated"] is True  # type: ignore[index]
 
   @pytest.mark.unit
   async def test_internal_error_audited_and_propagated(self):


### PR DESCRIPTION
Follow-up to #976, closing the two gaps that PR flagged and fixing the anchoring defect behind them. Three problems, one symptom: `build-fact-grid` being slow and hard to trust on the SEC repository.

## Entity identity is now always returned

The `RETURN` clause only carried `ent.ticker` / `ent.name` when an entity filter was present. Without one, the response was facts from many filers with no way to tell them apart — a `revenue` / FY2024 query came back with **364 anonymous facts across 176 periods**.

Safe to always join, verified against production SEC:

```
MATCH (el:Element {qname:'us-gaap:Assets'})<-[:FACT_HAS_ELEMENT]-(f:Fact)                        → 269,054
MATCH (el:Element {qname:'us-gaap:Assets'})<-[:FACT_HAS_ELEMENT]-(f:Fact)-[:FACT_HAS_ENTITY]->() → 269,054
```

Identical counts, and `materialize.py:1146` builds `FACT_HAS_ENTITY` for both the native and shared-fact paths, so tenant graphs are covered too.

Dedup now always keys on entity as well. Previously the key dropped entity whenever no filter was passed, so two filers reporting the same element for the same period collapsed into one row.

## The query no longer leads with `(f:Fact)`

Without an entity filter the MATCH led with `(f:Fact)`, forcing a full scan of the fact table — the actual source of the timeouts. It now leads with the Element pattern, which for a specific qname is a single node, using the same inline-anchor trick already applied to single tickers. With an entity filter the Entity anchor still wins.

## `limit` (default 250, max 5000) and a `truncated` flag

A single common element spans hundreds of thousands of facts, and the unbounded response routinely blew past an MCP caller's token budget — the 364-fact query above was 83KB.

The limit is applied in Python **after** dedup and sort, so truncation deterministically keeps the most recent periods. It is deliberately *not* pushed into Cypher: `ORDER BY` forces a full materialize-then-sort in LadybugDB, and `ORDER BY p.end_date DESC LIMIT 5` over those 269k facts **times out at 25s**, while a bare `count(f)` on the same anchored pattern returns promptly. That measurement is recorded in the module docstring, because pushing the limit down is the natural instinct on reading this code.

So the two mechanisms have separate jobs: anchoring and the caller's filters bound the *query*; `limit` bounds the *payload*.

## `entity` required on shared repositories only

Shared repos host thousands of filers, so an unscoped query there returns an arbitrary slice of arbitrary companies. A tenant graph is already scoped to its entity by the URL — and that entity is often a private company with **no ticker and no CIK** to filter on (`schemas/base.py:46-47`), so requiring the filter there would mean exact-matching a company `name` string for no gain.

This mirrors the asymmetry `financial_statement_analysis_op` already uses in the same router: `ticker` required on shared repos, `report_id` on tenant graphs. Enforced on both the REST route (400) and the MCP tool (error result).

## Note on constant placement

`DEFAULT_FACT_LIMIT` / `MAX_FACT_LIMIT` live in `models/api/views/view_config.py` rather than the ops layer. Defining them in `fact_query.py` and importing them from the request model creates a genuine cycle — `models.api.views` pulls in the `operations.roboledger.views` package init, which imports `fact_grid_builder`, which imports `models.api.views`. Ops importing the constant from models matches how `fact_grid_builder` already depends on that package.

## API changes

- `metadata.truncated` added to the response
- `limit` added to the request (validated 1..5000)
- `entity` / `entities` required on shared-repo graphs — a 400 where an unscoped query previously succeeded
- MCP: `limit` argument added, `truncated` at the top level and noted in `message`

SDK regeneration needed, as with #976.

## Verification

Behavior confirmed against production SEC before implementing — both the entity-edge counts and the `ORDER BY` timeout above are measurements, not assumptions.

`just test-code` clean. Full suite green (11570 passed, 15 skipped), excluding `test_incremental_materialize.py` for the unrelated pre-existing pyarrow `file`-scheme double-registration documented in #976.

New coverage: element-vs-entity anchoring, entity columns present without a filter, limit truncating after sort, limit absent from the emitted Cypher, shared-repo-requires-entity and tenant-graph-does-not on both surfaces, and limit bounds validation.
