### PR TITLE
fix(sec): keep networkit out of processes that use pyarrow

### DIFF
--- a/robosystems/adapters/sec/knowledge/__init__.py
+++ b/robosystems/adapters/sec/knowledge/__init__.py
@@ -4,22 +4,34 @@ Provides statement classification using graph analytics algorithms
 from icebug (networkit), a DuckDB analytics framework for running
 queries on SEC staging data, and knowledge artifact builders for
 graph-based confidence refinement.
+
+**Re-exports are lazy.** `artifact` and `graphs` import `networkit`, and
+importing networkit registers the ``file`` URI scheme in the Arrow registry
+that `pyarrow` also registers — after which *every* pyarrow local-file
+operation in that process raises ``ArrowKeyError: Attempted to register
+factory for scheme 'file'``, including ``pq.write_table`` and
+``pq.read_metadata``. Eager re-exports here meant that importing any module
+in this package — `framework`, which only needs duckdb, or `classifiers`,
+for a constant dict — pulled networkit in and poisoned pyarrow for the rest
+of the process. Resolving names on demand keeps networkit confined to the
+callers that actually run graph analytics.
 """
 
-from robosystems.adapters.sec.knowledge.artifact import (
-  DisclosureProfileBuilder,
-  ElementKnowledgeBuilder,
-  StructureKnowledgeBuilder,
-)
-from robosystems.adapters.sec.knowledge.classifiers import StatementClassifier
-from robosystems.adapters.sec.knowledge.extractors import ArcExtractor
-from robosystems.adapters.sec.knowledge.framework import DuckDBAnalyticsContext
+_LAZY_IMPORTS = {
+  "ArcExtractor": "robosystems.adapters.sec.knowledge.extractors",
+  "DisclosureProfileBuilder": "robosystems.adapters.sec.knowledge.artifact",
+  "DuckDBAnalyticsContext": "robosystems.adapters.sec.knowledge.framework",
+  "ElementKnowledgeBuilder": "robosystems.adapters.sec.knowledge.artifact",
+  "StatementClassifier": "robosystems.adapters.sec.knowledge.classifiers",
+  "StructureKnowledgeBuilder": "robosystems.adapters.sec.knowledge.artifact",
+}
 
-__all__ = [
-  "ArcExtractor",
-  "DisclosureProfileBuilder",
-  "DuckDBAnalyticsContext",
-  "ElementKnowledgeBuilder",
-  "StatementClassifier",
-  "StructureKnowledgeBuilder",
-]
+
+def __getattr__(name: str):
+  """Lazy import knowledge classes on first access."""
+  if name in _LAZY_IMPORTS:
+    import importlib
+
+    module = importlib.import_module(_LAZY_IMPORTS[name])
+    return getattr(module, name)
+  raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/robosystems/adapters/sec/knowledge/classifiers.py
+++ b/robosystems/adapters/sec/knowledge/classifiers.py
@@ -13,9 +13,9 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING
 
-import networkit as nk
-
 if TYPE_CHECKING:
+  import networkit as nk
+
   from robosystems.adapters.sec.knowledge.graphs import ElementGraph
 
 logger = logging.getLogger(__name__)

--- a/tests/graph_api/routers/databases/tables/test_incremental_materialize.py
+++ b/tests/graph_api/routers/databases/tables/test_incremental_materialize.py
@@ -19,7 +19,6 @@ from types import SimpleNamespace
 
 import duckdb
 import ladybug as lbug
-import pyarrow.parquet as pq
 import pytest
 
 from robosystems.graph_api.routers.databases.tables.materialize import (
@@ -44,9 +43,17 @@ def _ladybug_service(conn):
 
 
 def _load(conn, duck, table_name, select_sql, out_path):
-  """DuckDB SELECT -> parquet -> ladybug COPY. Returns rows COPYed."""
-  duck.execute(f"COPY ({select_sql}) TO '{out_path}' (FORMAT parquet)")
-  rows = pq.read_metadata(str(out_path)).num_rows
+  """DuckDB SELECT -> parquet -> ladybug COPY. Returns rows COPYed.
+
+  Counts with duckdb rather than ``pyarrow.parquet.read_metadata``: duckdb
+  wrote the file, and pyarrow's local-file operations raise
+  ``ArrowKeyError: Attempted to register factory for scheme 'file'`` in any
+  process that has imported networkit (see the SEC knowledge package) —
+  which, in a full-suite run, is this one.
+  """
+  esc = str(out_path).replace("'", "''")
+  duck.execute(f"COPY ({select_sql}) TO '{esc}' (FORMAT parquet)")
+  rows = duck.execute(f"SELECT count(*) FROM read_parquet('{esc}')").fetchone()[0]
   if rows:
     conn.execute(f"COPY {table_name} FROM '{out_path}'")
   return rows


### PR DESCRIPTION
## The incompatibility

Importing `networkit` registers the `file` URI scheme in the Arrow registry that `pyarrow` also registers. After that, every pyarrow local-file operation in the process fails:

```python
import networkit
pq.write_table(t, 'probe.parquet')   # ArrowKeyError: scheme 'file' already registered
pq.read_metadata('probe.parquet')    # ArrowKeyError
```

Both directions of import order fail — networkit 12.9 and pyarrow 24.0.0 share one Arrow registry and both claim the scheme.

## Why the knowledge package made it everyone's problem

`knowledge/__init__.py` eagerly imported `artifact`, which imports networkit. So importing **any** module in the package pulled it in:

- `framework` needs only duckdb
- `classifiers` is imported by `enrichment.py:613` purely to read the `DISCLOSURE_TO_STATEMENT` dict

…and `adapters/sec/processors/parquet.py` writes with pyarrow. Whether those share a process depends on Dagster job wiring I haven't traced, and SEC ingestion works in production today, so this was a latent landmine rather than an active fire — but it's the kind that surfaces as an unexplainable `ArrowKeyError` in a worker.

## The fix

**`classifiers.py`** — `import networkit as nk` moves under `TYPE_CHECKING`. `nk` appears exactly once, at line 266, as a type annotation, in a module with `from __future__ import annotations`. It was never needed at runtime. This is what defuses the enrichment path.

**`knowledge/__init__.py`** — re-exports become lazy via the `_LAZY_IMPORTS` + `__getattr__` pattern already used in `adapters/__init__.py`.

`artifact.py` and `graphs.py` keep their imports — they genuinely run PageRank and CoreDecomposition. networkit now loads only for callers doing graph analytics, and that path writes parquet through duckdb rather than pyarrow.

Verified: importing the package, `framework`, `classifiers`, or `enrichment` leaves `networkit` unloaded and pyarrow writes working; all six exports still resolve; unknown attributes still raise `AttributeError`.

## The test change, and why the source fix wasn't enough

The knowledge tests exercise `artifact` and `graphs` directly, so networkit is loaded in any full-suite process regardless. `test_incremental_materialize.py` used pyarrow in exactly one place — `pq.read_metadata(path).num_rows` — to count rows in a parquet file **duckdb had just written**. It counts with duckdb instead and drops the dependency.

This is targeted, not systemic: networkit and pyarrow remain incompatible in-process, so if another test starts doing pyarrow local-file IO after the knowledge tests, it will fail the same way. The durable protection is the laziness in the source; this just removes today's only collision.

## Why it mattered

`pytest.ini:80` sets `-x` in `addopts`, so the failure **halted the entire local suite** at `tests/graph_api` — everything sorting after it (`graphql`, `middleware`, `models`, `operations`, `routers`, `security`) never ran locally. CI on Linux is unaffected, so the gap was invisible there.

That is not hypothetical: a regression introduced earlier in this fact-grid work went undetected in a local full-suite run for exactly this reason, and was only caught by running a narrower subset.

## Verification

Full suite with nothing excluded: **11577 passed, 15 skipped**. The reproduction that failed throughout — `tests/adapters` + `test_incremental_materialize.py` — now passes (1322 passed, 9 skipped). `just test-code` clean.
