### PR TITLE
Anchor semantic sovereignty in the README intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 RoboSystems is an open-source, AI-native financial intelligence platform for accounting, financial reporting, and investment management. It gives AI agents and analysts a ledger-grade system of record they can both query and operate — closing the books, producing reports, and analyzing portfolios across accounting, market, and SEC data. Powers [RoboLedger](https://roboledger.ai) and [RoboInvestor](https://roboinvestor.ai).
 
+Open source top to bottom — the accounting ontology, reporting taxonomies, and calculation structures are inspectable, portable artifacts you own, not configuration trapped in a vendor platform: [semantic sovereignty](https://robosystems.ai/blog/semantic-sovereignty) for your financial data.
+
 ## Platform
 
 The platform provides the core infrastructure that all extensions build on:


### PR DESCRIPTION
## Summary

Adds one sentence to the README intro naming what the open-source posture buys: the accounting ontology, reporting taxonomies, and calculation structures are inspectable, portable artifacts the user owns — semantic sovereignty — with a link to the defining essay on the blog.

## Notes

- Copy-only change; no code touched.
- The linked essay publishes via the content pipeline; merge can precede or follow it, the URL is stable.