### PR TITLE
perf(tests): cut suite wall-clock in half by removing real retry/poll sleeps

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -9,6 +9,7 @@ markers =
     unit: marks unit tests
     slow: marks tests that take longer to run
     security: marks security-related tests
+    real_retry_delay: opts out of the zeroed Graph API client backoff (see tests/graph_api/conftest.py)
 
 env =
     ENVIRONMENT=test

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,31 @@ password_module.PasswordSecurity.BCRYPT_ROUNDS = 4  # Fast for tests
 
 
 @pytest.fixture(autouse=True)
+def no_retry_backoff(monkeypatch):
+  """Elide `retrying`'s exponential backoff so retry tests don't pay real time.
+
+  Production policies like `_QB_RETRY` wait ~31s across 5 attempts. Tests
+  assert that retries *happen* (call counts, final exception wrapping),
+  never that they are slow, so the wall-clock wait is pure cost.
+
+  Rebinds only the `time` name inside the `retrying` module -- patching
+  `retrying.time.sleep` would mutate the shared `time` module and break
+  tests that depend on real sleeps (e.g. the SEC rate limiter). Retries
+  still execute; `time.time()` stays real because `retrying` uses it to
+  compute `delay_since_first_attempt_ms`.
+  """
+  import time as real_time
+
+  import retrying
+
+  class _NoSleepClock:
+    time = staticmethod(real_time.time)
+    sleep = staticmethod(lambda _seconds: None)
+
+  monkeypatch.setattr(retrying, "time", _NoSleepClock)
+
+
+@pytest.fixture(autouse=True)
 def mock_email_dagster_jobs():
   """Mock Dagster email jobs globally so registration/email-change tests don't need Dagster running.
 

--- a/tests/graph_api/client/test_base.py
+++ b/tests/graph_api/client/test_base.py
@@ -164,6 +164,7 @@ class TestBaseGraphClient:
       assert client._should_retry(server_error, 0) is True
       assert client._should_retry(server_error, 1) is True
 
+  @pytest.mark.real_retry_delay
   def test_calculate_retry_delay(self):
     """Test retry delay calculation with exponential backoff."""
     config = GraphClientConfig(

--- a/tests/graph_api/client/test_client.py
+++ b/tests/graph_api/client/test_client.py
@@ -937,6 +937,7 @@ class TestGraphClientBaseHelpers:
     error = RuntimeError("Unknown")
     assert client._should_retry(error, 0) is False
 
+  @pytest.mark.real_retry_delay
   def test_calculate_retry_delay(self, mock_env):
     """Retry delay uses exponential backoff."""
     client = GraphClient(base_url="http://localhost:8001")

--- a/tests/graph_api/conftest.py
+++ b/tests/graph_api/conftest.py
@@ -1,0 +1,52 @@
+import asyncio as real_asyncio
+
+import pytest
+
+from robosystems.graph_api.client.base import BaseGraphClient
+from robosystems.graph_api.core import task_sse
+
+
+@pytest.fixture(autouse=True)
+def no_client_retry_delay(request, monkeypatch):
+  """Collapse the Graph API client's exponential backoff to zero.
+
+  `_execute_with_retry` awaits `asyncio.sleep(_calculate_retry_delay(...))`.
+  With the shipped defaults (`retry_delay=1.0`, `retry_backoff=2.0`,
+  `max_retries=3`) an exhausted retry chain waits 1 + 2 + 4 = 7s, which is
+  what made the timeout/retry tests here the slowest in the suite.
+
+  Patching the delay -- rather than the config -- keeps `test_config.py`'s
+  assertions on the shipped defaults (`retry_delay == 1.0`) meaningful, and
+  keeps `asyncio.sleep` itself real so the retry loop's await semantics are
+  unchanged.
+
+  Tests that assert on the backoff curve itself opt out with
+  `@pytest.mark.real_retry_delay`.
+  """
+  if request.node.get_closest_marker("real_retry_delay"):
+    return
+  monkeypatch.setattr(
+    BaseGraphClient, "_calculate_retry_delay", lambda self, attempt: 0.0
+  )
+
+
+@pytest.fixture(autouse=True)
+def no_task_sse_poll_sleep(monkeypatch):
+  """Drop the SSE generator's 2s poll interval.
+
+  `generate_task_sse_events` polls task state on a hardcoded
+  `asyncio.sleep(2)`. Nothing asserts on that cadence -- the heartbeat
+  test already drives elapsed time through a mocked `time.time` -- so the
+  wait was pure wall-clock. Loop iteration counts are unchanged, which
+  keeps that test's finite `side_effect` sequence lined up.
+  """
+
+  class _NoSleepAsyncio:
+    def __getattr__(self, name):
+      return getattr(real_asyncio, name)
+
+    @staticmethod
+    async def sleep(_seconds):
+      return None
+
+  monkeypatch.setattr(task_sse, "asyncio", _NoSleepAsyncio())

--- a/tests/graph_api/test_query_timeout.py
+++ b/tests/graph_api/test_query_timeout.py
@@ -32,15 +32,17 @@ class TestQueryTimeout:
 
     def slow_operation():
       """Simulate a slow database operation."""
-      time.sleep(5)  # Sleep for 5 seconds
+      # Only needs to outlast the timeout below. The executor's __exit__
+      # joins the worker, so this duration is paid in full -- keep it small.
+      time.sleep(1.0)
       return "Should not reach here"
 
     with ThreadPoolExecutor(max_workers=1) as executor:
       future = executor.submit(slow_operation)
 
-      # Try to get result with 1 second timeout
+      # Try to get result with a timeout well under the operation's duration.
       with pytest.raises(FuturesTimeoutError):
-        future.result(timeout=1.0)
+        future.result(timeout=0.2)
 
       # Cancel the future
       future.cancel()
@@ -65,7 +67,7 @@ class TestQueryTimeout:
 
     def slow_execute(*args, **kwargs):
       """Simulate a slow query execution."""
-      time.sleep(3)  # Query takes 3 seconds
+      time.sleep(1.0)  # Comfortably exceeds the 0.5s query timeout above
       return MagicMock()
 
     mock_conn.execute = slow_execute
@@ -111,7 +113,7 @@ class TestQueryTimeout:
       """Operation that tracks execution."""
       try:
         executed.append("started")
-        time.sleep(2)
+        time.sleep(0.8)  # Outlasts the 0.5s timeout below
         executed.append("completed")
         return "success"
       except Exception as e:
@@ -144,7 +146,7 @@ class TestQueryTimeout:
       """Async operation that uses ThreadPoolExecutor for timeout."""
 
       def sync_slow_operation():
-        time.sleep(2)
+        time.sleep(0.8)  # Outlasts the 0.5s timeout below
         return "too slow"
 
       with ThreadPoolExecutor(max_workers=1) as executor:

--- a/tests/operations/graph/engine/test_backup_service.py
+++ b/tests/operations/graph/engine/test_backup_service.py
@@ -45,7 +45,24 @@ def mock_allocation_manager():
 
 
 @pytest.fixture
-def mock_s3_client():
+def _moto_env(monkeypatch):
+  """Let moto intercept instead of LocalStack.
+
+  `pytest.ini` sets `AWS_ENDPOINT_URL=http://localhost:4566`, which boto3
+  honours at client-construction time -- so clients built inside
+  `mock_aws()` were still addressing LocalStack. CloudWatch isn't among the
+  services LocalStack runs here (CI starts it with `s3,secretsmanager,iam`),
+  so `PutMetricData` returned HTTP 500 and botocore retried it five times
+  with exponential backoff, costing ~10s per test.
+  """
+  monkeypatch.delenv("AWS_ENDPOINT_URL", raising=False)
+  monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+  monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+  monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
+
+
+@pytest.fixture
+def mock_s3_client(_moto_env):
   """Mock S3 client for testing."""
   with mock_aws():
     client = boto3.client("s3", region_name="us-east-1")
@@ -55,7 +72,7 @@ def mock_s3_client():
 
 
 @pytest.fixture
-def mock_cloudwatch_client():
+def mock_cloudwatch_client(_moto_env):
   """Mock CloudWatch client for testing."""
   with mock_aws():
     client = boto3.client("cloudwatch", region_name="us-east-1")

--- a/tests/operations/graph/tasks/conftest.py
+++ b/tests/operations/graph/tasks/conftest.py
@@ -1,0 +1,34 @@
+import asyncio as real_asyncio
+
+import pytest
+
+from robosystems.operations.graph.tasks import graph_tier_upgrade
+
+
+@pytest.fixture(autouse=True)
+def no_tier_upgrade_poll_sleep(monkeypatch):
+  """Make the tier-upgrade poll loops wait no real time.
+
+  `_wait_for_reattachment` and `_drain_instance` poll DynamoDB/ASG on
+  `REATTACH_POLL_INTERVAL_SECONDS` (10s) and `DRAIN_POLL_INTERVAL_SECONDS`
+  (5s). Tests drive those loops with mocks that flip state after one
+  iteration, so each paid a full real interval.
+
+  This neuters the sleep rather than zeroing the interval constants,
+  because the loops also use the interval to advance `elapsed` against
+  `REATTACH_TIMEOUT_SECONDS`. Zeroing the constant would stop `elapsed`
+  from advancing and spin forever on any test where the volume never
+  attaches; no-oping the sleep keeps the termination arithmetic identical
+  to production. Rebinding the module's `asyncio` name (rather than
+  `asyncio.sleep`) keeps the patch scoped to this one module.
+  """
+
+  class _NoSleepAsyncio:
+    def __getattr__(self, name):
+      return getattr(real_asyncio, name)
+
+    @staticmethod
+    async def sleep(_seconds):
+      return None
+
+  monkeypatch.setattr(graph_tier_upgrade, "asyncio", _NoSleepAsyncio())


### PR DESCRIPTION
## Why

The unit suite spent **46% of its runtime idle**. Profiling the full run showed 40 tests holding **236s of the 516s total**, nearly all of it real wall-clock spent waiting on retry backoff, poll intervals, and timeouts that no assertion depends on.

That idle time is machine-independent, so it was also the one slice of CI a faster runner could never reclaim. The `Run tests` step had reached **649s against its own `timeout-minutes: 15`** — 72% of a hard ceiling, where an overrun surfaces as a timeout rather than as "we added tests."

Step breakdown before this change (`Test CI`, 13m20s total):

| Step | Time |
| --- | --- |
| **Run tests** | **649s** |
| Initialize containers | 43s |
| Type checking | 38s |
| everything else | ~70s |

## What

Each fix rebinds the sleeping name *inside* the importing module rather than patching `time`/`asyncio` themselves. `retrying.time` **is** the real `time` module — patching its `sleep` would have globally defeated tests that depend on real ones (the SEC rate limiter, verified separately).

- **`retrying`** — no-sleep clock for `_QB_RETRY`'s 5-attempt / ~31s backoff. `time.time()` stays real, since `retrying` uses it for `delay_since_first_attempt_ms`.
- **`graph_api` client** — zero `_calculate_retry_delay` (1+2+4s per exhausted chain). The two tests that assert the backoff *curve* opt out via a new registered `real_retry_delay` marker rather than being silently defeated.
- **Tier upgrade** — no-op the module's `asyncio.sleep` rather than zeroing `REATTACH_POLL_INTERVAL_SECONDS`. That constant doubles as the `elapsed` increment, so zeroing it would spin forever on the timeout test; this keeps the termination arithmetic identical to production.
- **Task SSE** — drop the hardcoded 2s poll. Iteration counts are unchanged, which keeps the heartbeat test's finite `side_effect` sequence aligned.
- **Query timeout** — shrink oversized margins. These assert real timeout mechanics, so they were reduced in the safe direction: the claim is *"the timeout fires,"* and a loaded runner only makes it fire more reliably.

## A real defect found along the way

The backup-service fixtures were **never exercising moto**. `pytest.ini` sets `AWS_ENDPOINT_URL=http://localhost:4566`, which boto3 honours at client-construction time — so clients built inside `mock_aws()` were addressing LocalStack. CloudWatch isn't among the services LocalStack runs here (CI starts it with `s3,secretsmanager,iam`), so `PutMetricData` returned HTTP 500 and botocore retried it five times with exponential backoff.

`tests/lambda/conftest.py` already documents and handles exactly this; the backup fixtures had missed it. Those three tests cost ~23s and were asserting against a service that was erroring out.

## Result

```
before:  11577 passed, 15 skipped, 101 deselected in 516.48s (0:08:36)
after:   11577 passed, 15 skipped, 101 deselected in 247.01s (0:04:07)
```

- **Suite: 516s → 247s (52%)**
- **Slowest test: 31.7s → 3.9s** — the fat tail is flat
- Identical counts; no test removed, skipped, or weakened
- Projected CI: ~13m20s → **~9m**, moving the test step from 72% to ~35% of its timeout budget

Because the reclaimed time is sleep rather than compute, it subtracts from CI rather than scaling with it.

## Verification

- Full suite green, run twice end to end
- `basedpyright`: 0 errors · `ruff check` + `ruff format`: clean
- SEC rate-limiter suite verified unaffected by the `retrying` patch (155 passed)
- `test_query_timeout.py` — the only change carrying flake risk — run 5× consecutively (4.60–5.05s, all green)

## Follow-up (not in this PR)

`pytest-xdist` is not installed and CI runs single-process on a 4-vCPU runner. With the stragglers gone, `-n 4` is now worth considering — but it needs per-worker isolation first: `tests/conftest.py:46` does `DROP SCHEMA public CASCADE` on a single shared database, the autouse cleanup truncates 21 shared tables per test, and `LBUG_DATABASE_PATH` / the LocalStack bucket are hardcoded. Separate change, with a real stabilization tail.