### PR TITLE
fix(graph-api): gate admission on cgroup headroom, not just host memory

### DIFF
--- a/robosystems/graph_api/core/admission_control.py
+++ b/robosystems/graph_api/core/admission_control.py
@@ -7,10 +7,26 @@ preventing OOM kills and maintaining service stability.
 
 import time
 from enum import Enum
+from pathlib import Path
 
 import psutil
 
 from robosystems.logger import logger
+
+# Cgroup v2 unified hierarchy as seen from inside the container. Absent on
+# dev machines and bare-metal hosts; tests point this at a fixture directory.
+_CGROUP_DIR = Path("/sys/fs/cgroup")
+
+
+def _read_cgroup_limit_bytes() -> int | None:
+  """Read the container's cgroup v2 memory limit, or None if unlimited/absent."""
+  try:
+    raw = (_CGROUP_DIR / "memory.max").read_text().strip()
+  except (FileNotFoundError, NotADirectoryError):
+    return None
+  if raw == "max":
+    return None
+  return int(raw)
 
 
 class AdmissionDecision(str, Enum):
@@ -48,7 +64,10 @@ class LadybugAdmissionController:
             query working set. See min_available_mb.
         min_available_mb: Reject when free memory falls below this many MB.
             Absolute rather than proportional, so it stays correct when the
-            buffer pool or the instance size changes.
+            buffer pool or the instance size changes. Free memory is the
+            tighter of host-available and headroom under the container's
+            cgroup memory limit, since whichever binds first is the one
+            that kills the process.
         cpu_threshold: Max CPU usage percent before rejecting
         max_connections_per_db: Max concurrent connections per database
         check_interval: Seconds between resource checks (cached)
@@ -63,16 +82,54 @@ class LadybugAdmissionController:
     self._last_check = 0.0
     self._cached_memory = 0.0
     self._cached_available_mb = float("inf")
+    self._cached_cgroup_available_mb: float | None = None
     self._cached_cpu = 0.0
 
     # Connection tracking
     self._connections_per_db: dict[str, int] = {}
 
+    try:
+      limit_bytes = _read_cgroup_limit_bytes()
+    except Exception as e:
+      logger.warning(f"Failed to read cgroup memory limit: {e}")
+      limit_bytes = None
+    self.cgroup_limit_mb = (
+      limit_bytes / (1024 * 1024) if limit_bytes is not None else None
+    )
+
+    cgroup_desc = (
+      f"{self.cgroup_limit_mb:.0f}MB" if self.cgroup_limit_mb is not None else "none"
+    )
     logger.info(
       f"LadybugAdmissionController initialized - Min available: {min_available_mb}MB, "
+      f"Cgroup memory limit: {cgroup_desc}, "
       f"Memory report threshold: {memory_threshold}%, "
       f"CPU: {cpu_threshold}%, Max connections/DB: {max_connections_per_db}"
     )
+
+  def _cgroup_available_mb(self) -> float | None:
+    """Headroom before the container's cgroup memory limit binds.
+
+    psutil reads host /proc, but a Docker container is killed by its own
+    memory cgroup long before the host runs dry, so the gate must measure
+    distance to whichever limit is tighter. Returns None when no cgroup v2
+    memory limit applies (dev machines, unlimited containers).
+
+    File cache counts toward memory.current but the kernel reclaims it
+    before OOM-killing, so it is headroom, not pressure - without adding it
+    back a warm node would latch into rejection just like the old percent
+    gate did.
+    """
+    limit = _read_cgroup_limit_bytes()
+    if limit is None:
+      return None
+    current = int((_CGROUP_DIR / "memory.current").read_text().strip())
+    reclaimable = 0
+    for line in (_CGROUP_DIR / "memory.stat").read_text().splitlines():
+      key, _, value = line.partition(" ")
+      if key in ("inactive_file", "active_file"):
+        reclaimable += int(value)
+    return max(0.0, (limit - current + reclaimable) / (1024 * 1024))
 
   def _update_resource_cache(self) -> None:
     """Update cached resource metrics if stale."""
@@ -80,8 +137,13 @@ class LadybugAdmissionController:
     if now - self._last_check >= self.check_interval:
       try:
         memory = psutil.virtual_memory()
+        available_mb = memory.available / (1024 * 1024)
+        cgroup_available_mb = self._cgroup_available_mb()
+        if cgroup_available_mb is not None:
+          available_mb = min(available_mb, cgroup_available_mb)
         self._cached_memory = memory.percent
-        self._cached_available_mb = memory.available / (1024 * 1024)
+        self._cached_available_mb = available_mb
+        self._cached_cgroup_available_mb = cgroup_available_mb
         self._cached_cpu = psutil.cpu_percent(interval=0.1)
         self._last_check = now
       except Exception as e:
@@ -89,6 +151,7 @@ class LadybugAdmissionController:
         # Fail closed on error: assume no headroom rather than admit blindly
         self._cached_memory = 80.0
         self._cached_available_mb = 0.0
+        self._cached_cgroup_available_mb = 0.0
         self._cached_cpu = 80.0
 
   def check_admission(
@@ -110,7 +173,8 @@ class LadybugAdmissionController:
     # Check free memory headroom. Gated on absolute available memory, not
     # percent used: the buffer pool is a fixed allocation that fills by design,
     # so a warm node legitimately sits high on percent-used while still having
-    # room to serve.
+    # room to serve. Available is the tighter of host memory and the
+    # container's cgroup limit - the memcg cap binds first under Docker.
     if self._cached_available_mb < self.min_available_mb:
       reason = (
         f"Insufficient memory headroom: {self._cached_available_mb:.0f}MB available "
@@ -169,6 +233,8 @@ class LadybugAdmissionController:
     return {
       "memory_percent": self._cached_memory,
       "memory_available_mb": self._cached_available_mb,
+      "cgroup_limit_mb": self.cgroup_limit_mb,
+      "cgroup_available_mb": self._cached_cgroup_available_mb,
       "cpu_percent": self._cached_cpu,
       "memory_threshold": self.memory_threshold,
       "min_available_mb": self.min_available_mb,

--- a/tests/graph_api/test_graph_api_admission_control.py
+++ b/tests/graph_api/test_graph_api_admission_control.py
@@ -11,6 +11,19 @@ from robosystems.graph_api.core.admission_control import (
 )
 
 
+@pytest.fixture(autouse=True)
+def isolate_cgroup(monkeypatch, tmp_path):
+  """Point the cgroup probe at an empty directory.
+
+  Keeps tests hermetic: on a containerized CI runner the real
+  /sys/fs/cgroup/memory.max would otherwise feed into every decision.
+  """
+  monkeypatch.setattr(
+    "robosystems.graph_api.core.admission_control._CGROUP_DIR",
+    tmp_path / "no-cgroup",
+  )
+
+
 @pytest.fixture
 def set_resource_usage(monkeypatch):
   """Helper to patch psutil resource metrics."""
@@ -25,6 +38,32 @@ def set_resource_usage(monkeypatch):
     monkeypatch.setattr(
       "robosystems.graph_api.core.admission_control.psutil.cpu_percent",
       lambda interval=0.1: cpu_percent,
+    )
+
+  return _setter
+
+
+@pytest.fixture
+def set_cgroup_memory(monkeypatch, tmp_path):
+  """Helper to fabricate a cgroup v2 memory hierarchy."""
+
+  def _setter(
+    limit: int | str,
+    current: int = 0,
+    inactive_file: int = 0,
+    active_file: int = 0,
+  ):
+    cgroup_dir = tmp_path / "cgroup"
+    cgroup_dir.mkdir(exist_ok=True)
+    (cgroup_dir / "memory.max").write_text(f"{limit}\n")
+    (cgroup_dir / "memory.current").write_text(f"{current}\n")
+    (cgroup_dir / "memory.stat").write_text(
+      f"anon {max(0, current - inactive_file - active_file)}\n"
+      f"inactive_file {inactive_file}\n"
+      f"active_file {active_file}\n"
+    )
+    monkeypatch.setattr(
+      "robosystems.graph_api.core.admission_control._CGROUP_DIR", cgroup_dir
     )
 
   return _setter
@@ -106,6 +145,90 @@ def test_headroom_gate_is_independent_of_instance_size(set_resource_usage):
   # Large instance at a far lower percentage, but genuinely starved
   set_resource_usage(memory_percent=40.0, cpu_percent=20.0, available_mb=256.0)
   assert controller.check_admission("graph-123")[0] == AdmissionDecision.REJECT_MEMORY
+
+
+GB = 1024 * 1024 * 1024
+
+
+def test_cgroup_limit_binds_before_host_memory(set_resource_usage, set_cgroup_memory):
+  """The memcg cap kills the process while the host still has room.
+
+  Regression: a shared replica was OOM-killed at its 13GB container limit
+  (CONSTRAINT_MEMCG) while the host reported ~2.4GB available, so the
+  host-only gate stayed open right up to the kill.
+  """
+  controller = LadybugAdmissionController(min_available_mb=1024.0, check_interval=0.0)
+  set_resource_usage(memory_percent=84.0, cpu_percent=20.0, available_mb=2400.0)
+  # 13GB limit, 12.7GB anonymous (buffer pool + query working set), no cache left
+  set_cgroup_memory(limit=13 * GB, current=int(12.7 * GB))
+
+  decision, reason = controller.check_admission("sec")
+
+  assert decision == AdmissionDecision.REJECT_MEMORY
+  assert reason is not None
+  assert "Insufficient memory headroom" in reason
+
+
+def test_cgroup_file_cache_counts_as_headroom(set_resource_usage, set_cgroup_memory):
+  """Page cache inside the cgroup is reclaimed before an OOM kill.
+
+  memory.current includes file cache, so without adding it back a warm node
+  whose cgroup is full of reclaimable cache would latch into rejection just
+  like the old percent-used gate did.
+  """
+  controller = LadybugAdmissionController(min_available_mb=1024.0, check_interval=0.0)
+  set_resource_usage(memory_percent=84.0, cpu_percent=20.0, available_mb=2400.0)
+  # Near the 13GB cap on paper, but 3GB of it is reclaimable file cache
+  set_cgroup_memory(
+    limit=13 * GB,
+    current=int(12.7 * GB),
+    inactive_file=2 * GB,
+    active_file=1 * GB,
+  )
+
+  decision, reason = controller.check_admission("sec")
+
+  assert decision == AdmissionDecision.ACCEPT
+  assert reason is None
+
+
+def test_unlimited_cgroup_falls_back_to_host_gate(
+  set_resource_usage, set_cgroup_memory
+):
+  """A container without a memory limit ('max') gates on host memory alone."""
+  controller = LadybugAdmissionController(min_available_mb=1024.0, check_interval=0.0)
+  set_cgroup_memory(limit="max", current=12 * GB)
+
+  set_resource_usage(memory_percent=80.0, cpu_percent=20.0, available_mb=3000.0)
+  assert controller.check_admission("sec")[0] == AdmissionDecision.ACCEPT
+
+  set_resource_usage(memory_percent=97.0, cpu_percent=20.0, available_mb=512.0)
+  assert controller.check_admission("sec")[0] == AdmissionDecision.REJECT_MEMORY
+
+
+def test_host_gate_still_applies_under_a_loose_cgroup(
+  set_resource_usage, set_cgroup_memory
+):
+  """The tighter of the two limits wins in both directions."""
+  controller = LadybugAdmissionController(min_available_mb=1024.0, check_interval=0.0)
+  # Plenty of cgroup headroom, but the host itself is starved
+  set_cgroup_memory(limit=13 * GB, current=1 * GB)
+  set_resource_usage(memory_percent=97.0, cpu_percent=20.0, available_mb=512.0)
+
+  assert controller.check_admission("sec")[0] == AdmissionDecision.REJECT_MEMORY
+
+
+def test_get_metrics_reports_cgroup_headroom(set_resource_usage, set_cgroup_memory):
+  """Metrics expose the cgroup limit and cached headroom for observability."""
+  set_cgroup_memory(limit=13 * GB, current=9 * GB, inactive_file=1 * GB)
+  set_resource_usage(memory_percent=60.0, cpu_percent=20.0, available_mb=8192.0)
+  controller = LadybugAdmissionController(min_available_mb=1024.0, check_interval=0.0)
+
+  metrics = controller.get_metrics()
+
+  assert metrics["cgroup_limit_mb"] == pytest.approx(13 * 1024.0)
+  assert metrics["cgroup_available_mb"] == pytest.approx(5 * 1024.0)
+  assert metrics["memory_available_mb"] == pytest.approx(5 * 1024.0)
 
 
 def test_resource_probe_failure_fails_closed(monkeypatch):


### PR DESCRIPTION
## Summary

The admission controller's free-memory gate reads host memory via psutil, but the graph container runs under a Docker memory cgroup capped ~2GB below host total. A prod shared replica's process grew to its 13GB memcg cap and was OOM-killed (`CONSTRAINT_MEMCG`) while the host still reported ~2.4GB available — so admission stayed open right up to the kill and the node took a cold restart mid-traffic, dumping its warm buffer pool. This PR makes the gate measure headroom against whichever limit actually binds first.

## Changes

**`robosystems/graph_api/core/admission_control.py`**
- Effective available memory is now the tighter of host-available (psutil, unchanged) and headroom under the container's cgroup v2 memory limit (`/sys/fs/cgroup/memory.max` / `memory.current`).
- File cache inside the cgroup counts toward `memory.current` but the kernel reclaims it before OOM-killing, so `inactive_file + active_file` (from `memory.stat`) are added back as headroom. Without this, a warm node full of reclaimable cache would latch into rejection — recreating the exact failure mode the percent-gate removal (#c504943a) fixed.
- Environments without a cgroup limit (dev machines, unlimited containers, bare metal) fall back to the host-only gate unchanged; probe failures keep the existing fail-closed behavior.
- The startup log line prints the detected container limit, and `get_metrics()` now exposes `cgroup_limit_mb` and `cgroup_available_mb` (additive keys, passed through the existing `/metrics` payload).

**`tests/graph_api/test_graph_api_admission_control.py`**
- Regression test replaying the prod kill: 13GB cap, 12.7GB anonymous RSS, host showing 2.4GB free → now rejects.
- Inverse test: same numbers but the cgroup mostly reclaimable file cache → still accepts.
- Coverage for unlimited (`max`) cgroups, host-gate-binds-under-loose-cgroup, and the new metrics fields.
- Autouse fixture isolates all tests from the real `/sys/fs/cgroup` so results are hermetic on containerized CI runners.

## Testing

- `uv run pytest tests/graph_api` — 1140 passed (includes the 14 admission-control tests and metrics router tests).
- `just test-code` — ruff, format, basedpyright, cf-lint all clean.
- Full `just test-all` not run this session.

## Notes

- This narrows the window but can't fully close it: admission is checked at query start, so a single admitted query that balloons several GB mid-flight can still hit the cap. If that recurs, the next lever is the pool/cap arithmetic (8GB buffer pool under a 13GB container limit leaves ~4GB for query working set + process overhead).
- No config changes needed — `LBUG_ADMISSION_MIN_AVAILABLE_MB` now simply applies to the tighter of the two measures.
