### PR TITLE
fix(roboledger): stop forecast schedule run-off compounding past the base

### DIFF
--- a/robosystems/operations/information_block/forecast_articulation.py
+++ b/robosystems/operations/information_block/forecast_articulation.py
@@ -392,15 +392,23 @@ def load_articulation_context(
 
 
 def schedule_is_delta(
-  ctx: ArticulationContext, element_id: str, month: str, base_month: str
+  ctx: ArticulationContext, element_id: str, month: str, reference_month: str
 ) -> float:
-  """IS carry adjustment: this month's schedule expense minus the base
-  month's (already inside the carried value). Element-level on purpose —
-  an ended schedule's expense must STOP, not carry."""
+  """IS carry adjustment: this month's schedule expense minus the
+  reference month's. Element-level on purpose — an ended schedule's
+  expense must STOP, not carry.
+
+  The walk passes the PREVIOUS walk month as the reference (the carried
+  value contains that month's schedule contribution, since prior values
+  roll), so successive deltas telescope to ``sched[m] - sched[base]``.
+  Anchoring every month at the base instead re-subtracts the gap
+  cumulatively — the compounding that marched an expense line negative
+  on coherent books (caught live, 2026-07-30). Mirrors
+  ``schedule_instant_movement``'s ``prev_end`` reference."""
   per_month = ctx.schedules.duration_total.get(element_id)
   if not per_month:
     return 0.0
-  return per_month.get(month, 0.0) - per_month.get(base_month, 0.0)
+  return per_month.get(month, 0.0) - per_month.get(reference_month, 0.0)
 
 
 def schedule_instant_movement(

--- a/robosystems/operations/information_block/forecast_compute.py
+++ b/robosystems/operations/information_block/forecast_compute.py
@@ -495,6 +495,7 @@ def cmd_compute_forecast(
   }
   prior_bs = dict(bs_prior)
   prev_period_end = base_end
+  prev_month = mechanics.base_period
 
   for month_index, month in enumerate(months, start=1):
     month_start, month_end = period_date_range(month)
@@ -506,13 +507,44 @@ def cmd_compute_forecast(
         current[element_id] = prior_values[element_id]
 
     # (a2) Schedule deltas — a schedule's own projection overrides the
-    # carry for its expense lines (an ended schedule's expense stops;
-    # the base month's contribution is already inside the carried value).
+    # carry for its expense lines (an ended schedule's expense stops).
+    # The reference month is the PREVIOUS walk month, not the base: the
+    # carried value already contains the previous month's schedule
+    # contribution (prior_values rolls at (e)), so a base-anchored delta
+    # re-subtracts the base-vs-current gap every month — cumulative
+    # run-off that marches a line negative even on coherent books
+    # (caught live on the first production tenant, 2026-07-30). Mirrors
+    # schedule_instant_movement's prev_end reference on the BS side;
+    # deltas telescope to base + sched[m] - sched[base].
     if ctx is not None:
       for element_id in list(current):
-        delta = schedule_is_delta(ctx, element_id, month, mechanics.base_period)
-        if delta:
-          current[element_id] += delta
+        delta = schedule_is_delta(ctx, element_id, month, prev_month)
+        if not delta:
+          continue
+        before = current[element_id]
+        after = before + delta
+        # Schedule run-off can't take a line below zero. When the base
+        # month's actuals carry less than its schedule facts claim
+        # (stale overlapping vintages; prior-period corrections that
+        # can only land in the GL, never in schedule facts), the full
+        # run-off overshoots the base. Verification can't catch it —
+        # the incoherence is economic, not arithmetic — so clamp at
+        # zero and say so legibly.
+        if delta < 0 and before >= 0 and after < 0:
+          after = 0.0
+          clamped_el = _element(element_id)
+          skipped.append(
+            SkippedForecastLite(
+              rule_id=None,
+              element_qname=clamped_el.qname if clamped_el else element_id,
+              period=month,
+              reason=(
+                "schedule run-off clamped at zero: the schedule projection "
+                "exceeds what the line's base actuals carry"
+              ),
+            )
+          )
+        current[element_id] = after
 
     # (a2b) Line growth — the generic per-line trajectory:
     # line[t] = line[t-1] * (1 + rate[t]), compounding through the
@@ -907,6 +939,7 @@ def cmd_compute_forecast(
       for element, value in bs_facts:
         prior_values[element.id] = value
     prev_period_end = month_end
+    prev_month = month
 
   session.flush()
   return ComputeForecastResponse(

--- a/robosystems/operations/roboledger/commands/schedules.py
+++ b/robosystems/operations/roboledger/commands/schedules.py
@@ -717,7 +717,9 @@ def rebuild_schedule(
   if posted_row and posted_row.c:
     raise ValueError(
       f"Cannot rebuild schedule {structure.id!r}: {posted_row.c} posted "
-      "closing entries exist. Reopen those periods first."
+      "closing entries exist. Reopen the affected periods and void those "
+      "entries first — reopening alone leaves entries posted, so it does "
+      "not clear this guard."
     )
 
   # Capture the old originator event id so we can supersede it after the

--- a/robosystems/operations/roboledger/schedules/service.py
+++ b/robosystems/operations/roboledger/schedules/service.py
@@ -1627,7 +1627,9 @@ class ScheduleService:
     if overlap and overlap.c:
       raise ValueError(
         f"Cannot truncate: {overlap.c} posted entries exist for periods "
-        f"after {new_end_date}. Reopen those periods first."
+        f"after {new_end_date}. Reopen the affected periods and void those "
+        "entries first — reopening alone leaves entries posted, so it does "
+        "not clear this guard."
       )
 
     # Delete any draft entries that fall past the new end date (they're now stale)

--- a/tests/operations/information_block/test_forecast_articulation.py
+++ b/tests/operations/information_block/test_forecast_articulation.py
@@ -177,10 +177,27 @@ class TestScheduleSemantics:
       duration_total={"dda": {"2026-05": 5.0, "2026-06": 3.0}}
     )
     ctx = _ctx(schedules)
-    # Base month carried 5 inside the IS value; June's schedule says 3.
+    # Reference month carried 5 inside the IS value; June's schedule says 3.
     assert schedule_is_delta(ctx, "dda", "2026-06", "2026-05") == pytest.approx(-2.0)
-    # July: no schedule fact at all — the whole base expense stops.
+    # July vs a May reference: no schedule fact at all — the whole
+    # scheduled expense stops.
     assert schedule_is_delta(ctx, "dda", "2026-07", "2026-05") == pytest.approx(-5.0)
+
+  def test_is_delta_telescopes_through_successive_prev_months(self):
+    # The walk passes the PREVIOUS month as the reference (the carried
+    # value rolls), so successive deltas must telescope to the
+    # base-anchored total — the property that keeps an ended schedule a
+    # one-time step down instead of a cumulative march.
+    schedules = ScheduleProjection(
+      duration_total={"dda": {"2026-05": 5.0, "2026-06": 3.0}}
+    )
+    ctx = _ctx(schedules)
+    jun = schedule_is_delta(ctx, "dda", "2026-06", "2026-05")
+    jul = schedule_is_delta(ctx, "dda", "2026-07", "2026-06")
+    aug = schedule_is_delta(ctx, "dda", "2026-08", "2026-07")
+    assert jun + jul + aug == pytest.approx(
+      schedule_is_delta(ctx, "dda", "2026-08", "2026-05")
+    )
 
 
 class TestRuleDeltaPushDown:

--- a/tests/operations/information_block/test_forecast_compute.py
+++ b/tests/operations/information_block/test_forecast_compute.py
@@ -28,6 +28,10 @@ from robosystems.models.api.information_block import (
 from robosystems.operations.information_block import (
   forecast_compute as fc,
 )
+from robosystems.operations.information_block.forecast_articulation import (
+  ArticulationContext,
+  ScheduleProjection,
+)
 
 
 def _element(
@@ -251,6 +255,30 @@ def _structure(mechanics: dict) -> SimpleNamespace:
   )
 
 
+def _bare_ctx(schedules: ScheduleProjection) -> ArticulationContext:
+  """Minimal articulation context: schedule projection only, no BS/CF
+  machinery — every anchor None, so the roll and derivation no-op and
+  the walk's (a2) schedule-delta seam is the only ctx consumer."""
+  return ArticulationContext(
+    bs_structure_id="struct_bs",
+    cf_structure_id=None,
+    base_bs_element_ids=[],
+    bs_prior={},
+    cash_element_id=None,
+    re_element_id=None,
+    ni_element_id=None,
+    assets_element_id=None,
+    le_element_id=None,
+    net_change_element_id=None,
+    recon_element_id=None,
+    operating_element_id=None,
+    investing_element_id=None,
+    financing_element_id=None,
+    derivations={},
+    schedules=schedules,
+  )
+
+
 def _run(
   mechanics: dict,
   rules: list[Any],
@@ -261,6 +289,7 @@ def _run(
   assertions: list[LineAssertionLite] | None = None,
   calc_dag: dict | None = None,
   base_is_facts: list[Any] | None = None,
+  schedule_projection: ScheduleProjection | None = None,
 ):
   structure = _structure(mechanics)
   recorder = _Recorder()
@@ -273,16 +302,27 @@ def _run(
   authored_facts = _lever_facts(levers) + _lever_facts(assertions or [])
   facts_by_set = {
     "fs_base_is": base_is_facts if base_is_facts is not None else BASE_IS_FACTS,
+    "fs_base_bs": [],
     "fs_lever": authored_facts,
   }
 
+  def _base_set(session: Any, sid: str, *a: Any, **k: Any) -> Any:
+    if sid == "struct_is":
+      return SimpleNamespace(id="fs_base_is")
+    if sid == "struct_bs" and schedule_projection is not None:
+      # A BS base set exists so the walk builds an articulation context
+      # (patched below to the bare schedule-only shape).
+      return SimpleNamespace(id="fs_base_bs")
+    return None
+
   with (
     patch.object(fc, "newest_actual_structure_id", side_effect=_structures),
+    patch.object(fc, "_actual_set_at", side_effect=_base_set),
     patch.object(
       fc,
-      "_actual_set_at",
-      side_effect=lambda session, sid, *a, **k: (
-        SimpleNamespace(id="fs_base_is") if sid == "struct_is" else None
+      "load_articulation_context",
+      side_effect=lambda *a, **k: _bare_ctx(
+        schedule_projection or ScheduleProjection()
       ),
     ),
     patch.object(
@@ -731,6 +771,77 @@ class TestLineGrowth:
     assert rec.value("struct_is", JUL, "el_cogs") == pytest.approx(68.2)
     # GP = carried revenue 100 - grown COGS 68.2.
     assert rec.value("struct_is", JUL, "el_gp") == pytest.approx(31.8)
+
+
+class TestScheduleDeltaComposition:
+  """(a2) schedule deltas compose with the ROLLED prior: the reference
+  month is the previous walk month, so successive deltas telescope to
+  ``sched[m] - sched[base]``. Anchoring at the base re-subtracted the
+  gap every month — cumulative run-off that marched a line negative on
+  coherent books (the 2026-07-30 production finding)."""
+
+  def test_ended_schedule_steps_down_once_and_holds(self) -> None:
+    # June base: rent 10, of which 5 is scheduled. The schedule runs
+    # July at 5, steps to 3 in August, gone by September. The line must
+    # land at the unscheduled remainder (10 - 5 = 5) and HOLD — the
+    # base-anchored delta gave Sep = 8 + (0 - 5) = 3 and kept marching.
+    projection = ScheduleProjection(
+      duration_total={"el_rent": {"2026-06": 5.0, "2026-07": 5.0, "2026-08": 3.0}}
+    )
+    _, rec = _run(_mechanics([]), [], [], schedule_projection=projection)
+    assert rec.value("struct_is", JUL, "el_rent") == pytest.approx(10.0)
+    assert rec.value("struct_is", AUG, "el_rent") == pytest.approx(8.0)
+    assert rec.value("struct_is", SEP, "el_rent") == pytest.approx(5.0)
+
+  def test_run_off_clamps_at_zero_with_legible_skip(self) -> None:
+    # Base rent actual is 4 but the base month's schedule facts claim 5
+    # (stale overlapping vintage, or a prior-period correction that
+    # could only land in the GL). The schedule ends after June, so the
+    # full run-off overshoots the base: 4 - 5 = -1. Clamp at zero with
+    # one legible skip; later months hold at zero without re-firing.
+    projection = ScheduleProjection(duration_total={"el_rent": {"2026-06": 5.0}})
+    base = [
+      SimpleNamespace(element_id="el_rev", value=100.0),
+      SimpleNamespace(element_id="el_cogs", value=62.0),
+      SimpleNamespace(element_id="el_rent", value=4.0),
+      SimpleNamespace(element_id="el_gp", value=38.0),
+    ]
+    resp, rec = _run(
+      _mechanics([]),
+      [],
+      [],
+      base_is_facts=base,
+      schedule_projection=projection,
+    )
+    assert rec.value("struct_is", JUL, "el_rent") == pytest.approx(0.0)
+    assert rec.value("struct_is", AUG, "el_rent") == pytest.approx(0.0)
+    assert rec.value("struct_is", SEP, "el_rent") == pytest.approx(0.0)
+    clamps = [s for s in resp.skipped if "clamped" in s.reason]
+    assert len(clamps) == 1
+    assert clamps[0].element_qname == "rs-gaap:RentExpense"
+    assert clamps[0].period == "2026-07"
+    assert clamps[0].rule_id is None
+
+  def test_negative_carry_is_not_clamped(self) -> None:
+    # A line already negative at the base (a contra) keeps its
+    # arithmetic — the clamp only guards positive lines driven through
+    # zero by schedule run-off.
+    projection = ScheduleProjection(duration_total={"el_rent": {"2026-06": 1.0}})
+    base = [
+      SimpleNamespace(element_id="el_rev", value=100.0),
+      SimpleNamespace(element_id="el_cogs", value=62.0),
+      SimpleNamespace(element_id="el_rent", value=-2.0),
+      SimpleNamespace(element_id="el_gp", value=38.0),
+    ]
+    resp, rec = _run(
+      _mechanics([]),
+      [],
+      [],
+      base_is_facts=base,
+      schedule_projection=projection,
+    )
+    assert rec.value("struct_is", JUL, "el_rent") == pytest.approx(-3.0)
+    assert not [s for s in resp.skipped if "clamped" in s.reason]
 
 
 class TestUpsertMonthSet:


### PR DESCRIPTION
## Summary

Fixes the forecast walk's schedule projection compounding run-off past the base month: the IS carry adjustment deltaed every month against the **base** month while the carried value **rolls** month-over-month, so any schedule ending inside the horizon re-subtracted its base gap every subsequent month — marching the line linearly negative even on coherent books. Observed live as an expense line walking negative across the horizon in every scenario on a production tenant.

## Changes

**`operations/information_block/forecast_compute.py`** — the (a2) schedule-delta seam now references the **previous walk month** (tracked alongside `prev_period_end`) instead of `mechanics.base_period`, so successive deltas telescope to the intended `base + sched[m] - sched[base]` and an ended schedule steps its line down once and holds. Mirrors `schedule_instant_movement`'s `prev_end` reference on the BS side, which was already correct.

Also adds a **clamp-at-zero guard with a legible diagnostic**: when the base month's actuals carry less than its schedule facts claim (stale overlapping schedule vintages; prior-period corrections that can only land in the GL), the full run-off overshoots the base. The line now clamps at zero and emits a `skipped` entry ("schedule run-off clamped at zero…") instead of going negative — verification can't catch this case because the incoherence is economic, not arithmetic (subtotals still articulate). Lines negative at the base (contra) are untouched; lines with a growth/assertion owner remain immune by precedence, unchanged.

**`operations/information_block/forecast_articulation.py`** — `schedule_is_delta`'s parameter renamed `base_month` → `reference_month` with a docstring documenting the telescoping contract.

**`operations/roboledger/commands/schedules.py`, `operations/roboledger/schedules/service.py`** — corrected the `rebuild_schedule` / `truncate_schedule` guard messages: "reopen those periods first" implied reopening clears the posted-entry guard, but reopening never changes entry status — the entries must also be voided. Messages now say so. (No behavior change.)

**Tests** —
- `test_forecast_compute.py`: new `TestScheduleDeltaComposition` class covering the walk-level composition the existing suite never exercised (the harness always resolved `ctx` to `None`, so the schedule seam was untested): ended-schedule steps down once and holds; run-off clamps at zero with exactly one legible skip and holds; negative-at-base lines are not clamped. Harness gains a `schedule_projection` parameter and a `_bare_ctx` helper (schedule-only articulation context, all anchors `None`).
- `test_forecast_articulation.py`: telescoping property test (successive prev-month deltas sum to the base-anchored total).

## Testing

- `uv run pytest tests/operations/information_block/ tests/operations/roboledger/` — **1215 passed**.
- `just test-code` (ruff + format + basedpyright + cf-lint) — all checks passed.
- Full `just test-all` not run this session.

## Notes / Follow-ups

- Existing scenarios re-render correctly on their next `compute-forecast` run after deploy (re-runs replace each month's values in place); no migration.
- The data-side remediation — identifying and retiring stale overlapping schedule vintages on affected books — is an operator action, separate from this fix. The clamp bounds the symptom until then and names the affected lines in the response.
