### PR TITLE
test: cover the customer-data plane and close the two 0% modules

### DIFF
--- a/tests/adapters/sec/pipeline/test_entity_sync.py
+++ b/tests/adapters/sec/pipeline/test_entity_sync.py
@@ -1,0 +1,548 @@
+"""Tests for the per-CIK SEC entity-sync pipeline.
+
+`sec_entity_sync` is a live Dagster job -- `SECProvider` submits it when a
+customer connects a SEC data source -- so the extract → transform → load
+chain runs against customer graphs. Covers filing discovery, the
+consolidation/dedup step, and the node-before-relationship load ordering
+that foreign-key constraints depend on.
+"""
+
+import json
+from io import BytesIO
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+from dagster import build_asset_context
+
+from robosystems.adapters.sec.pipeline.entity_sync.configs import SECEntitySyncConfig
+from robosystems.adapters.sec.pipeline.entity_sync.extract import sec_entity_extract
+from robosystems.adapters.sec.pipeline.entity_sync.load import (
+  _count_parquet_rows,
+  sec_entity_load,
+)
+from robosystems.adapters.sec.pipeline.entity_sync.transform import sec_entity_transform
+from robosystems.adapters.sec.pipeline.entity_sync.utils import get_pipeline_work_dir
+
+EXTRACT = "robosystems.adapters.sec.pipeline.entity_sync.extract"
+TRANSFORM = "robosystems.adapters.sec.pipeline.entity_sync.transform"
+LOAD = "robosystems.adapters.sec.pipeline.entity_sync.load"
+
+
+def _config(**overrides):
+  defaults = {
+    "graph_id": "kg1a2b3c4d5e6f78",
+    "connection_id": "conn_1",
+    "user_id": "usr_1",
+    "cik": "0000320193",
+  }
+  defaults.update(overrides)
+  return SECEntitySyncConfig(**defaults)
+
+
+@pytest.fixture
+def work_dir(tmp_path):
+  """Pin the shared pipeline work directory into tmp_path."""
+  d = tmp_path / "work"
+  d.mkdir()
+  with (
+    patch(f"{EXTRACT}.get_pipeline_work_dir", return_value=d),
+    patch(f"{TRANSFORM}.get_pipeline_work_dir", return_value=d),
+    patch(f"{LOAD}.get_pipeline_work_dir", return_value=d),
+  ):
+    yield d
+
+
+@pytest.fixture
+def pyarrow_local_io(tmp_path):
+  """Skip if pyarrow's local-file scheme has been claimed by another library.
+
+  Importing `networkit` (pulled in by the SEC knowledge package's PageRank
+  path, which sorts earlier in a full-suite run) registers the ``file`` URI
+  scheme that pyarrow also registers, after which every pyarrow *filesystem*
+  operation raises ``ArrowKeyError``. In-memory ops are unaffected, so only
+  the tests that reach `pq.write_table(..., path)` or `pq.read_metadata` need
+  this -- see commit a5b7baad.
+
+  Probes the capability rather than sniffing `sys.modules`: the collision is
+  platform-specific (macOS hits it, Linux/CI does not), so CI keeps full
+  coverage of these paths while a local run degrades to a skip instead of
+  tripping `-x` and halting the suite.
+  """
+  try:
+    pq.write_table(pa.table({"probe": [1]}), str(tmp_path / "_probe.parquet"))
+  except pa.ArrowKeyError as exc:  # pragma: no cover - platform-dependent
+    pytest.skip(f"pyarrow local-file I/O unavailable in this process: {exc}")
+
+
+def _parquet_bytes(rows):
+  """Serialise rows to parquet bytes as `process_single_filing_to_memory` does."""
+  buf = BytesIO()
+  pq.write_table(pa.Table.from_pylist(rows), buf)
+  return buf.getvalue()
+
+
+def _filing_result(tables=None, success=True, error=None, skipped_reason=None):
+  result = MagicMock()
+  result.success = success
+  result.error = error
+  result.skipped_reason = skipped_reason
+  result.tables = tables if tables is not None else {}
+  return result
+
+
+@pytest.mark.unit
+class TestWorkDir:
+  def test_is_deterministic_per_graph_and_created(self):
+    a = get_pipeline_work_dir("kg_alpha")
+    b = get_pipeline_work_dir("kg_alpha")
+    c = get_pipeline_work_dir("kg_beta")
+
+    assert a == b, "all three assets must land on the same directory"
+    assert a != c, "graphs must not share a work directory"
+    assert a.exists()
+
+
+@pytest.mark.unit
+class TestExtract:
+  def _s3_with(self, year_prefixes, objects_by_prefix, has_submissions=True):
+    paginator = MagicMock()
+
+    def paginate(**kwargs):
+      prefix = kwargs["Prefix"]
+      if kwargs.get("Delimiter") == "/":
+        return [{"CommonPrefixes": [{"Prefix": p} for p in year_prefixes]}]
+      return [{"Contents": objects_by_prefix.get(prefix, [])}]
+
+    paginator.paginate.side_effect = paginate
+    s3 = MagicMock()
+    s3.get_paginator.return_value = paginator
+    if not has_submissions:
+      s3.head_object.side_effect = RuntimeError("404")
+    return s3
+
+  def test_discovers_zips_across_year_partitions(self, work_dir):
+    cik = "0000320193"
+    s3 = self._s3_with(
+      year_prefixes=["sec/year=2023/", "sec/year=2024/"],
+      objects_by_prefix={
+        f"sec/year=2023/{cik}/": [
+          {"Key": f"sec/year=2023/{cik}/acc-1.zip", "Size": 100}
+        ],
+        f"sec/year=2024/{cik}/": [
+          {"Key": f"sec/year=2024/{cik}/acc-2.zip", "Size": 200}
+        ],
+      },
+    )
+
+    with patch("boto3.client", return_value=s3):
+      result = sec_entity_extract(build_asset_context(), _config(cik=cik))
+
+    assert result.metadata["filings_found"] == 2
+    assert result.metadata["years"] == ["2023", "2024"]
+
+    manifest = json.loads((work_dir / "filing_manifest.json").read_text())
+    assert [f["accession"] for f in manifest["filings"]] == ["acc-1", "acc-2"]
+    assert manifest["filings"][0]["year"] == "2023"
+    assert manifest["filings"][0]["size_bytes"] == 100
+
+  def test_ignores_non_zip_objects(self, work_dir):
+    cik = "0000320193"
+    s3 = self._s3_with(
+      year_prefixes=["sec/year=2024/"],
+      objects_by_prefix={
+        f"sec/year=2024/{cik}/": [
+          {"Key": f"sec/year=2024/{cik}/acc-1.zip", "Size": 100},
+          {"Key": f"sec/year=2024/{cik}/notes.txt", "Size": 5},
+          {"Key": f"sec/year=2024/{cik}/index.json", "Size": 5},
+        ]
+      },
+    )
+
+    with patch("boto3.client", return_value=s3):
+      result = sec_entity_extract(build_asset_context(), _config(cik=cik))
+
+    assert result.metadata["filings_found"] == 1
+
+  def test_records_missing_submissions_metadata(self, work_dir):
+    s3 = self._s3_with(year_prefixes=[], objects_by_prefix={}, has_submissions=False)
+
+    with patch("boto3.client", return_value=s3):
+      result = sec_entity_extract(build_asset_context(), _config())
+
+    assert result.metadata["has_submissions"] is False
+    manifest = json.loads((work_dir / "filing_manifest.json").read_text())
+    assert manifest["submissions_key"] is None
+
+  def test_writes_manifest_even_when_no_filings_found(self, work_dir):
+    """Transform reads this manifest unconditionally; a missing file would
+    turn an empty CIK into a hard pipeline failure."""
+    s3 = self._s3_with(year_prefixes=[], objects_by_prefix={})
+
+    with patch("boto3.client", return_value=s3):
+      result = sec_entity_extract(build_asset_context(), _config())
+
+    assert result.metadata["filings_found"] == 0
+    manifest = json.loads((work_dir / "filing_manifest.json").read_text())
+    assert manifest["filings"] == []
+    assert manifest["form_types"] == ["10-K", "10-Q", "20-F", "40-F"]
+
+
+@pytest.mark.unit
+class TestTransform:
+  def _write_manifest(self, work_dir, filings, form_types=None):
+    (work_dir / "filing_manifest.json").write_text(
+      json.dumps(
+        {
+          "cik": "0000320193",
+          "filings": filings,
+          "bucket": "raw-bucket",
+          "form_types": form_types or ["10-K"],
+        }
+      )
+    )
+
+  def test_missing_manifest_is_a_clear_error(self, work_dir):
+    with pytest.raises(ValueError, match="Run sec_entity_extract first"):
+      sec_entity_transform(build_asset_context(), _config())
+
+  def test_returns_zeroed_metadata_when_no_filings(self, work_dir):
+    self._write_manifest(work_dir, [])
+
+    result = sec_entity_transform(build_asset_context(), _config())
+
+    assert result.metadata["filings_processed"] == 0
+    assert result.metadata["tables_output"] == 0
+
+  def test_consolidates_tables_across_filings(self, work_dir, pyarrow_local_io):
+    self._write_manifest(
+      work_dir,
+      [
+        {"storage_key": "k1", "accession": "acc-1", "year": "2023"},
+        {"storage_key": "k2", "accession": "acc-2", "year": "2024"},
+      ],
+    )
+    results = [
+      _filing_result(
+        {"nodes/Fact": _parquet_bytes([{"identifier": "f1", "value": 1}])}
+      ),
+      _filing_result(
+        {"nodes/Fact": _parquet_bytes([{"identifier": "f2", "value": 2}])}
+      ),
+    ]
+
+    with (
+      patch("boto3.client"),
+      patch("robosystems.adapters.sec.processors.metadata.SECMetadataLoader"),
+      patch(
+        "robosystems.adapters.sec.processors.processing.process_single_filing_to_memory",
+        side_effect=results,
+      ),
+    ):
+      result = sec_entity_transform(build_asset_context(), _config())
+
+    assert result.metadata["filings_processed"] == 2
+    assert result.metadata["tables_output"] == 1
+
+    out = pq.read_table(str(work_dir / "output" / "sec_Fact.parquet"))
+    assert out.num_rows == 2, "facts from both filings must survive"
+
+  def test_dedups_shared_node_tables_on_identifier(self, work_dir, pyarrow_local_io):
+    """Element/Label/etc. use content-derived ids, so the same element
+    appearing in two filings must collapse to one row."""
+    self._write_manifest(
+      work_dir,
+      [
+        {"storage_key": "k1", "accession": "acc-1", "year": "2023"},
+        {"storage_key": "k2", "accession": "acc-2", "year": "2024"},
+      ],
+    )
+    shared = _parquet_bytes(
+      [
+        {"identifier": "el-1", "qname": "Revenue"},
+        {"identifier": "el-2", "qname": "Cost"},
+      ]
+    )
+    results = [
+      _filing_result({"nodes/Element": shared}),
+      _filing_result({"nodes/Element": shared}),
+    ]
+
+    with (
+      patch("boto3.client"),
+      patch("robosystems.adapters.sec.processors.metadata.SECMetadataLoader"),
+      patch(
+        "robosystems.adapters.sec.processors.processing.process_single_filing_to_memory",
+        side_effect=results,
+      ),
+    ):
+      sec_entity_transform(build_asset_context(), _config())
+
+    out = pq.read_table(str(work_dir / "output" / "sec_Element.parquet"))
+    assert out.num_rows == 2, "duplicate elements must be deduped to 2, not 4"
+    assert sorted(out.column("identifier").to_pylist()) == ["el-1", "el-2"]
+
+  def test_non_shared_tables_are_not_deduped(self, work_dir, pyarrow_local_io):
+    """Facts legitimately repeat identifiers across periods -- dedup here
+    would silently drop customer data."""
+    self._write_manifest(
+      work_dir,
+      [
+        {"storage_key": "k1", "accession": "acc-1", "year": "2023"},
+        {"storage_key": "k2", "accession": "acc-2", "year": "2024"},
+      ],
+    )
+    same = _parquet_bytes([{"identifier": "dup", "value": 1}])
+    results = [
+      _filing_result({"nodes/Fact": same}),
+      _filing_result({"nodes/Fact": same}),
+    ]
+
+    with (
+      patch("boto3.client"),
+      patch("robosystems.adapters.sec.processors.metadata.SECMetadataLoader"),
+      patch(
+        "robosystems.adapters.sec.processors.processing.process_single_filing_to_memory",
+        side_effect=results,
+      ),
+    ):
+      sec_entity_transform(build_asset_context(), _config())
+
+    out = pq.read_table(str(work_dir / "output" / "sec_Fact.parquet"))
+    assert out.num_rows == 2
+
+  def test_counts_failed_and_skipped_filings_without_aborting(
+    self, work_dir, pyarrow_local_io
+  ):
+    self._write_manifest(
+      work_dir,
+      [
+        {"storage_key": "k1", "accession": "ok", "year": "2023"},
+        {"storage_key": "k2", "accession": "failed", "year": "2023"},
+        {"storage_key": "k3", "accession": "skipped", "year": "2023"},
+        {"storage_key": "k4", "accession": "empty", "year": "2023"},
+      ],
+    )
+    results = [
+      _filing_result({"nodes/Fact": _parquet_bytes([{"identifier": "f1"}])}),
+      _filing_result(success=False, error="corrupt zip"),
+      _filing_result(skipped_reason="form type not requested"),
+      _filing_result(tables={}),
+    ]
+
+    with (
+      patch("boto3.client"),
+      patch("robosystems.adapters.sec.processors.metadata.SECMetadataLoader"),
+      patch(
+        "robosystems.adapters.sec.processors.processing.process_single_filing_to_memory",
+        side_effect=results,
+      ),
+    ):
+      result = sec_entity_transform(build_asset_context(), _config())
+
+    assert result.metadata["filings_processed"] == 1
+    assert result.metadata["filings_failed"] == 1
+    assert result.metadata["filings_skipped"] == 2
+
+  def test_raised_exception_counts_as_failure_not_crash(
+    self, work_dir, pyarrow_local_io
+  ):
+    """One bad filing must not abandon the other 40 in a backfill."""
+    self._write_manifest(
+      work_dir,
+      [
+        {"storage_key": "k1", "accession": "boom", "year": "2023"},
+        {"storage_key": "k2", "accession": "ok", "year": "2023"},
+      ],
+    )
+    results = [
+      RuntimeError("arelle exploded"),
+      _filing_result({"nodes/Fact": _parquet_bytes([{"identifier": "f1"}])}),
+    ]
+
+    with (
+      patch("boto3.client"),
+      patch("robosystems.adapters.sec.processors.metadata.SECMetadataLoader"),
+      patch(
+        "robosystems.adapters.sec.processors.processing.process_single_filing_to_memory",
+        side_effect=results,
+      ),
+    ):
+      result = sec_entity_transform(build_asset_context(), _config())
+
+    assert result.metadata["filings_failed"] == 1
+    assert result.metadata["filings_processed"] == 1
+
+  def test_writes_table_metadata_for_the_load_step(self, work_dir, pyarrow_local_io):
+    self._write_manifest(
+      work_dir, [{"storage_key": "k1", "accession": "acc-1", "year": "2023"}]
+    )
+    tables = {
+      "nodes/Fact": _parquet_bytes([{"identifier": "f1"}]),
+      "relationships/HAS_FACT": _parquet_bytes([{"from": "a", "to": "b"}]),
+    }
+
+    with (
+      patch("boto3.client"),
+      patch("robosystems.adapters.sec.processors.metadata.SECMetadataLoader"),
+      patch(
+        "robosystems.adapters.sec.processors.processing.process_single_filing_to_memory",
+        return_value=_filing_result(tables),
+      ),
+    ):
+      sec_entity_transform(build_asset_context(), _config())
+
+    meta = json.loads((work_dir / "table_metadata.json").read_text())
+    assert meta["Fact"]["entity_type"] == "nodes"
+    assert meta["HAS_FACT"]["entity_type"] == "relationships"
+
+  def test_enrichment_failure_is_non_fatal(self, work_dir):
+    """Enrichment is optional; a broken enricher must not fail the sync."""
+    self._write_manifest(work_dir, [])
+
+    with (
+      patch("boto3.client"),
+      patch("robosystems.adapters.sec.processors.metadata.SECMetadataLoader"),
+    ):
+      result = sec_entity_transform(
+        build_asset_context(), _config(skip_enrichment=False)
+      )
+
+    assert result.metadata["filings_processed"] == 0
+
+
+@pytest.mark.unit
+class TestParquetRowCount:
+  def test_counts_rows(self, tmp_path, pyarrow_local_io):
+    path = tmp_path / "t.parquet"
+    pq.write_table(pa.Table.from_pylist([{"a": 1}, {"a": 2}, {"a": 3}]), str(path))
+
+    assert _count_parquet_rows(path) == 3
+
+  def test_unreadable_file_counts_as_zero(self, tmp_path, pyarrow_local_io):
+    """Row count only feeds progress metadata -- it must never abort a load."""
+    path = tmp_path / "broken.parquet"
+    path.write_bytes(b"not a parquet file")
+
+    assert _count_parquet_rows(path) == 0
+
+
+@pytest.mark.unit
+class TestLoad:
+  def test_missing_table_metadata_is_a_clear_error(self, work_dir):
+    with pytest.raises(ValueError, match="Run sec_entity_transform first"):
+      sec_entity_load(build_asset_context(), _config())
+
+  def test_stages_nodes_before_relationships(
+    self, work_dir, tmp_path, pyarrow_local_io
+  ):
+    """Relationship rows reference node ids, so a relationship staged first
+    would violate foreign-key constraints at materialization."""
+    (work_dir / "table_metadata.json").write_text(
+      json.dumps(
+        {
+          "HAS_FACT": {"entity_type": "relationships", "table_name": "HAS_FACT"},
+          "Fact": {"entity_type": "nodes", "table_name": "Fact"},
+          "Entity": {"entity_type": "nodes", "table_name": "Entity"},
+        }
+      )
+    )
+    output = work_dir / "output"
+    output.mkdir()
+    for name in ("HAS_FACT", "Fact", "Entity"):
+      pq.write_table(
+        pa.Table.from_pylist([{"identifier": "x"}]), str(output / f"sec_{name}.parquet")
+      )
+
+    staged_order = []
+    client = MagicMock()
+
+    async def create_table(**kwargs):
+      staged_order.append(kwargs["table_name"])
+
+    client.create_table = create_table
+    client.materialize_table = AsyncMock(return_value={"rows_ingested": 1})
+
+    session = MagicMock()
+    session.__enter__ = MagicMock(return_value=session)
+    session.__exit__ = MagicMock(return_value=False)
+
+    graph_file = MagicMock(id="gf_1")
+    graph_table = MagicMock(id="gt_1", row_count=0, file_count=0, total_size_bytes=0)
+
+    with (
+      patch("robosystems.database.SessionFactory", return_value=session),
+      patch("robosystems.operations.aws.s3.S3Client"),
+      patch(
+        "robosystems.graph_api.client.factory.get_graph_client",
+        AsyncMock(return_value=client),
+      ),
+      patch(
+        "robosystems.models.core.graph.graph_table.GraphTable.get_by_name",
+        return_value=graph_table,
+      ),
+      patch(
+        "robosystems.models.core.graph.graph_file.GraphFile.create",
+        return_value=graph_file,
+      ),
+      patch(
+        "robosystems.models.core.graph.graph_file.GraphFile.get_all_for_table",
+        return_value=[],
+      ),
+      patch(
+        "robosystems.operations.connection_service.ConnectionService.update_last_sync",
+        AsyncMock(),
+      ),
+    ):
+      result = sec_entity_load(build_asset_context(), _config())
+
+    assert staged_order[-1] == "HAS_FACT", "relationships must stage last"
+    assert set(staged_order[:2]) == {"Fact", "Entity"}
+    assert result.metadata["tables_staged"] == 3
+    assert result.metadata["tables_materialized"] == 3
+
+  def test_skips_tables_with_no_parquet_on_disk(self, work_dir):
+    (work_dir / "table_metadata.json").write_text(
+      json.dumps({"Ghost": {"entity_type": "nodes", "table_name": "Ghost"}})
+    )
+    (work_dir / "output").mkdir()
+
+    session = MagicMock()
+    session.__enter__ = MagicMock(return_value=session)
+    session.__exit__ = MagicMock(return_value=False)
+
+    with (
+      patch("robosystems.database.SessionFactory", return_value=session),
+      patch("robosystems.operations.aws.s3.S3Client"),
+      patch(
+        "robosystems.graph_api.client.factory.get_graph_client",
+        AsyncMock(return_value=MagicMock()),
+      ),
+      patch(
+        "robosystems.operations.connection_service.ConnectionService.update_last_sync",
+        AsyncMock(),
+      ),
+    ):
+      result = sec_entity_load(build_asset_context(), _config())
+
+    assert result.metadata["tables_staged"] == 0
+    assert result.metadata["tables_materialized"] == 0
+
+
+@pytest.mark.unit
+class TestJobRegistration:
+  def test_job_is_named_for_the_provider_submission(self):
+    """`SECProvider` submits this job by name; a rename would break the
+    connect flow silently."""
+    from robosystems.adapters.sec.pipeline.entity_sync.jobs import (
+      sec_entity_sync_job,
+    )
+
+    assert sec_entity_sync_job.name == "sec_entity_sync"
+
+  def test_pipeline_exports_the_three_assets(self):
+    from robosystems.adapters.sec.pipeline import entity_sync
+
+    for name in ("sec_entity_extract", "sec_entity_transform", "sec_entity_load"):
+      assert hasattr(entity_sync, name), f"{name} must stay importable"

--- a/tests/graph_api/client/test_client_operations.py
+++ b/tests/graph_api/client/test_client_operations.py
@@ -1,0 +1,288 @@
+"""Tests for the Graph API client's operation wrappers.
+
+`GraphClient` is the boundary every service crosses to reach customer data,
+so these assert the contract each wrapper puts on the wire: method, path,
+and payload. Retry/circuit-breaker behaviour lives in `test_client.py`.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from robosystems.graph_api.client.client import GraphClient
+
+
+@pytest.fixture(autouse=True)
+def mock_env():
+  with patch("robosystems.config.env") as mock:
+    mock.GRAPH_API_KEY = "test-api-key"
+    mock.ENVIRONMENT = "test"
+    yield mock
+
+
+@pytest.fixture
+def client():
+  return GraphClient(base_url="http://localhost:8001")
+
+
+@pytest.fixture
+def request_mock(client):
+  """Replace `_request` and hand back the recorded calls."""
+  response = MagicMock()
+  response.json.return_value = {"status": "ok"}
+  mock = AsyncMock(return_value=response)
+  client._request = mock
+  return mock
+
+
+def _call(mock):
+  """Normalise a recorded `_request` call to (method, path, kwargs)."""
+  args, kwargs = mock.call_args
+  return args[0], args[1], kwargs
+
+
+@pytest.mark.unit
+class TestClassifyOperation:
+  @pytest.mark.parametrize(
+    "path,expected",
+    [
+      ("/databases/kg1/query", "query"),
+      ("/databases/kg1/tables", "table_ops"),
+      ("/databases/kg1/tables/Fact/materialize", "materialize"),
+      ("/databases/kg1/schema", "schema"),
+      ("/databases/kg1/backup", "backup"),
+      ("/databases/kg1/restore", "restore"),
+      ("/databases/kg1/metrics", "metrics"),
+      ("/health", "health"),
+      ("/databases/kg1/info", "info"),
+      ("/databases", "database_ops"),
+      ("/databases/kg1/memory", "memory"),
+      ("/databases/kg1/fork", "fork"),
+      ("/databases/kg1/tasks", "task"),
+      ("/databases/kg1/something-else", "other"),
+    ],
+  )
+  def test_classifies_paths_for_metrics(self, path, expected):
+    assert GraphClient._classify_operation(path) == expected
+
+  def test_ingest_paths_are_classified_by_substring(self):
+    assert GraphClient._classify_operation("/databases/kg1/ingest/s3") == "ingest"
+
+  @pytest.mark.parametrize(
+    "path", ["/databases/kg1/memory/boost", "/databases/kg1/memory/status"]
+  )
+  def test_memory_subpaths_currently_fall_through_to_other(self, path):
+    """Characterisation, not endorsement: the memory check only inspects the
+    final path segment, so `/memory/boost` lands in `other` and memory work
+    is under-reported in the operation metrics. Harmless to correctness --
+    this label only feeds dashboards -- but the grouping is misleading.
+    """
+    assert GraphClient._classify_operation(path) == "other"
+
+
+@pytest.mark.unit
+class TestMemoryManagement:
+  @pytest.mark.asyncio
+  async def test_boost_memory_defaults_to_both_targets(self, client, request_mock):
+    await client.boost_memory("kg1")
+
+    method, path, kwargs = _call(request_mock)
+    assert (method, path) == ("POST", "/databases/kg1/memory/boost")
+    assert kwargs["json_data"] == {"target": "both"}
+
+  @pytest.mark.asyncio
+  async def test_boost_memory_forwards_explicit_target(self, client, request_mock):
+    await client.boost_memory("kg1", target="duckdb")
+
+    assert _call(request_mock)[2]["json_data"] == {"target": "duckdb"}
+
+  @pytest.mark.asyncio
+  async def test_restore_memory(self, client, request_mock):
+    await client.restore_memory("kg1")
+
+    method, path, _ = _call(request_mock)
+    assert method == "POST"
+    assert "kg1" in path and "memory" in path
+
+  @pytest.mark.asyncio
+  async def test_memory_status(self, client, request_mock):
+    await client.memory_status("kg1")
+
+    method, path, _ = _call(request_mock)
+    assert method == "GET"
+    assert "memory" in path
+
+
+@pytest.mark.unit
+class TestDatabaseLifecycle:
+  @pytest.mark.asyncio
+  async def test_database_exists_true_when_get_succeeds(self, client):
+    client.get_database = AsyncMock(return_value={"graph_id": "kg1"})
+
+    assert await client.database_exists("kg1") is True
+
+  @pytest.mark.asyncio
+  async def test_database_exists_false_on_404(self, client):
+    error = RuntimeError("not found")
+    error.status_code = 404
+    client.get_database = AsyncMock(side_effect=error)
+
+    assert await client.database_exists("kg1") is False
+
+  @pytest.mark.asyncio
+  async def test_database_exists_propagates_non_404(self, client):
+    """A 500 must not be reported as 'does not exist' -- callers create the
+    database on False, which would be destructive against a live graph."""
+    error = RuntimeError("server exploded")
+    error.status_code = 500
+    client.get_database = AsyncMock(side_effect=error)
+
+    with pytest.raises(RuntimeError):
+      await client.database_exists("kg1")
+
+  @pytest.mark.asyncio
+  async def test_ensure_database_exists_creates_when_missing(self, client):
+    client.database_exists = AsyncMock(return_value=False)
+    client.create_database = AsyncMock()
+
+    await client.ensure_database_exists("kg1", schema_type="entity")
+
+    client.create_database.assert_awaited_once_with("kg1", "entity")
+
+  @pytest.mark.asyncio
+  async def test_ensure_database_exists_is_a_noop_when_present(self, client):
+    client.database_exists = AsyncMock(return_value=True)
+    client.create_database = AsyncMock()
+
+    await client.ensure_database_exists("kg1")
+
+    client.create_database.assert_not_awaited()
+
+  @pytest.mark.asyncio
+  async def test_swap_database_without_lock_token(self, client, request_mock):
+    await client.swap_database("kg1")
+
+    method, path, kwargs = _call(request_mock)
+    assert (method, path) == ("POST", "/databases/kg1/swap")
+    assert kwargs["headers"] is None
+
+  @pytest.mark.asyncio
+  async def test_swap_database_forwards_held_lock_token(self, client, request_mock):
+    """Passing the token avoids re-acquiring a lock the caller already holds,
+    which would deadlock the swap."""
+    await client.swap_database("kg1", lock_token="tok-123")
+
+    assert _call(request_mock)[2]["headers"] == {
+      "X-Materialization-Lock-Token": "tok-123"
+    }
+
+
+@pytest.mark.unit
+class TestDDLAndExistence:
+  @pytest.mark.asyncio
+  async def test_execute_ddl_targets_explicit_graph(self, client):
+    client.query = AsyncMock(return_value={"rows": []})
+
+    await client.execute_ddl("CREATE NODE TABLE Foo(id STRING, PRIMARY KEY(id))", "kg1")
+
+    client.query.assert_awaited_once()
+    assert client.query.await_args.args[1] == "kg1"
+
+  @pytest.mark.asyncio
+  async def test_execute_ddl_falls_back_to_client_graph(self, client):
+    client.graph_id = "kg_default"
+    client.query = AsyncMock(return_value={})
+
+    await client.execute_ddl("CREATE NODE TABLE Foo(id STRING, PRIMARY KEY(id))")
+
+    assert client.query.await_args.args[1] == "kg_default"
+
+
+@pytest.mark.unit
+class TestTableOperations:
+  @pytest.mark.asyncio
+  async def test_list_tables(self, client, request_mock):
+    request_mock.return_value.json.return_value = {"tables": [{"name": "Fact"}]}
+
+    await client.list_tables("kg1")
+
+    method, path, _ = _call(request_mock)
+    assert method == "GET"
+    assert path == "/databases/kg1/tables"
+
+  @pytest.mark.asyncio
+  async def test_delete_table(self, client, request_mock):
+    await client.delete_table("kg1", "Fact")
+
+    method, path, _ = _call(request_mock)
+    assert method == "DELETE"
+    assert path.endswith("/tables/Fact")
+
+  @pytest.mark.asyncio
+  async def test_materialize_table_posts_to_table_path(self, client, request_mock):
+    await client.materialize_table(graph_id="kg1", table_name="Fact")
+
+    method, path, _ = _call(request_mock)
+    assert method == "POST"
+    assert "Fact" in path and path.endswith("materialize")
+
+  @pytest.mark.asyncio
+  async def test_query_table_sends_sql(self, client, request_mock):
+    await client.query_table("kg1", "SELECT 1")
+
+    method, path, kwargs = _call(request_mock)
+    assert method == "POST"
+    assert "tables" in path
+    assert "SELECT 1" in str(kwargs.get("json_data"))
+
+
+@pytest.mark.unit
+class TestMigrationOperations:
+  """These drive the engine-upgrade path; a wrong verb or path silently
+  skips the migration rather than failing loudly."""
+
+  @pytest.mark.asyncio
+  async def test_migration_status_is_a_read(self, client, request_mock):
+    await client.migration_status()
+
+    method, path, _ = _call(request_mock)
+    assert method == "GET"
+    assert "migration" in path
+
+  @pytest.mark.asyncio
+  async def test_migration_import_is_a_write(self, client, request_mock):
+    await client.migration_import()
+
+    method, path, _ = _call(request_mock)
+    assert method == "POST"
+    assert "migration" in path
+
+  @pytest.mark.asyncio
+  async def test_migration_cleanup_is_a_write(self, client, request_mock):
+    await client.migration_cleanup()
+
+    method, path, _ = _call(request_mock)
+    assert method == "POST"
+    assert "migration" in path
+
+
+@pytest.mark.unit
+class TestVectorOperations:
+  @pytest.mark.asyncio
+  async def test_vector_search_posts_embedding(self, client, request_mock):
+    request_mock.return_value.json.return_value = {"results": [], "total": 0}
+
+    await client.vector_search("kg1", "Fact", [0.1, 0.2], limit=5)
+
+    method, path, kwargs = _call(request_mock)
+    assert method == "POST"
+    assert "vector" in path
+    assert kwargs["json_data"]["embedding"] == [0.1, 0.2]
+
+  @pytest.mark.asyncio
+  async def test_build_vector_index_targets_the_table(self, client, request_mock):
+    await client.build_vector_index("kg1", "Fact")
+
+    method, path, _ = _call(request_mock)
+    assert method == "POST"
+    assert "Fact" in path

--- a/tests/graph_api/core/test_migration_service.py
+++ b/tests/graph_api/core/test_migration_service.py
@@ -1,0 +1,637 @@
+"""Tests for the LadybugDB version-migration service.
+
+Focus is the state machine that protects customer databases during an
+engine upgrade: the export/import mutual-exclusion guards, the disk-space
+precondition, node-count verification, and the rollback that restores
+`.pre-migration` files when an import fails partway through.
+"""
+
+import json
+import os
+import threading
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from robosystems.graph_api.core import migration_service as ms
+from robosystems.graph_api.core.migration_service import MigrationService
+
+TASK_MODULE = "robosystems.graph_api.core.migration_service"
+
+
+@pytest.fixture(autouse=True)
+def reset_migration_state():
+  """Module-level flags are process globals -- reset around every test."""
+  ms._migration_in_progress = False
+  ms._export_in_progress = False
+  ms._active_task_id = None
+  yield
+  ms._migration_in_progress = False
+  ms._export_in_progress = False
+  ms._active_task_id = None
+
+
+@pytest.fixture
+def service(tmp_path):
+  return MigrationService(base_path=tmp_path)
+
+
+@pytest.fixture
+def task_manager():
+  """Stub the redis-backed migration task manager."""
+  tm = MagicMock()
+  tm.update_task = AsyncMock()
+  tm.complete_task = AsyncMock()
+  tm.fail_task = AsyncMock()
+  with patch(f"{TASK_MODULE}.migration_task_manager", tm):
+    yield tm
+
+
+def _fake_conn(tables, counts=None, failing_tables=()):
+  """Build a stand-in LadybugDB connection.
+
+  `tables` is a list of (name, type) pairs as `show_tables()` would yield;
+  `counts` maps node-table name to its node count.
+  """
+  counts = counts or {}
+
+  def execute(query):
+    if "show_tables" in query:
+      rows = [(i, name, ttype) for i, (name, ttype) in enumerate(tables)]
+      return _FakeResult(rows)
+    for name in counts:
+      if f"(n:{name})" in query:
+        if name in failing_tables:
+          raise RuntimeError(f"table {name} unreadable")
+        return _FakeResult([(counts[name],)])
+    if any(f"(n:{t})" in query for t, _ in tables):
+      raise RuntimeError("unreadable table")
+    return _FakeResult([])
+
+  conn = MagicMock()
+  conn.execute.side_effect = execute
+  return conn
+
+
+def _importing_database():
+  """Stand-in for `lbug.Database` that materialises the file it opens.
+
+  The real IMPORT creates the `.lbug` on disk; the import path then stats it
+  for the result payload, so a bare MagicMock leaves a missing-file error.
+  """
+
+  def factory(path, *args, **kwargs):
+    Path(path).write_bytes(b"imported-database")
+    return MagicMock()
+
+  return factory
+
+
+class _FakeResult:
+  def __init__(self, rows):
+    self._rows = list(rows)
+
+  def has_next(self):
+    return bool(self._rows)
+
+  def get_next(self):
+    return self._rows.pop(0)
+
+
+class TestMigrationStateGuards:
+  """The export/import flags are the only thing preventing two migrations
+  from operating on the same database files concurrently."""
+
+  def test_export_guard_is_exclusive(self):
+    assert ms._try_start_export() is True
+    assert ms._try_start_export() is False, "second caller must not acquire"
+
+    ms._clear_export_in_progress()
+    assert ms._try_start_export() is True, "flag must be reusable after clear"
+
+  def test_import_guard_is_exclusive_and_records_task(self):
+    assert ms._try_start_import("task-1") is True
+    assert ms.is_migration_in_progress() is True
+    assert ms.get_active_task_id() == "task-1"
+
+    # A second import must not acquire, and must not steal the task id.
+    assert ms._try_start_import("task-2") is False
+    assert ms.get_active_task_id() == "task-1"
+
+  def test_clearing_import_state_drops_task_id(self):
+    ms._try_start_import("task-1")
+    ms._set_migration_in_progress(False)
+
+    assert ms.is_migration_in_progress() is False
+    assert ms.get_active_task_id() is None
+
+  def test_export_and_import_guards_are_independent(self):
+    """An in-flight export must not block an import (they run on opposite
+    sides of a container swap), and vice versa."""
+    assert ms._try_start_export() is True
+    assert ms._try_start_import("task-1") is True
+
+  def test_only_one_thread_wins_the_export_guard(self):
+    """The guard is a check-then-set under a lock; if the lock were dropped,
+    concurrent callers could both proceed and corrupt the export directory."""
+    acquired = []
+    barrier = threading.Barrier(8)
+
+    def contend():
+      barrier.wait()
+      if ms._try_start_export():
+        acquired.append(threading.current_thread().name)
+
+    threads = [threading.Thread(target=contend) for _ in range(8)]
+    for t in threads:
+      t.start()
+    for t in threads:
+      t.join()
+
+    assert len(acquired) == 1, f"expected exactly one winner, got {acquired}"
+
+  def test_only_one_thread_wins_the_import_guard(self):
+    acquired = []
+    barrier = threading.Barrier(8)
+
+    def contend(n):
+      barrier.wait()
+      if ms._try_start_import(f"task-{n}"):
+        acquired.append(n)
+
+    threads = [threading.Thread(target=contend, args=(i,)) for i in range(8)]
+    for t in threads:
+      t.start()
+    for t in threads:
+      t.join()
+
+    assert len(acquired) == 1
+    assert ms.get_active_task_id() == f"task-{acquired[0]}"
+
+
+class TestDatabaseDiscovery:
+  def test_returns_empty_when_base_path_missing(self, tmp_path):
+    service = MigrationService(base_path=tmp_path / "does-not-exist")
+    assert service._discover_databases() == []
+
+  def test_finds_only_lbug_files_sorted(self, service, tmp_path):
+    (tmp_path / "kg_b.lbug").write_bytes(b"x")
+    (tmp_path / "kg_a.lbug").write_bytes(b"x")
+    (tmp_path / "notes.txt").write_text("ignore me")
+    (tmp_path / "kg_a.lbug.wal").write_bytes(b"x")
+    (tmp_path / "subdir.lbug").mkdir()
+
+    assert service._discover_databases() == ["kg_a", "kg_b"]
+
+
+class TestDiskSpacePrecondition:
+  def test_raises_when_available_space_is_short(self, service, tmp_path):
+    (tmp_path / "kg_a.lbug").write_bytes(b"x" * 2048)
+
+    stat = MagicMock(f_bavail=1, f_frsize=512)  # 512 bytes available
+    with patch(f"{TASK_MODULE}.os.statvfs", return_value=stat):
+      with pytest.raises(RuntimeError, match="Insufficient disk space"):
+        service._check_disk_space(["kg_a"])
+
+  def test_passes_when_space_is_sufficient(self, service, tmp_path):
+    (tmp_path / "kg_a.lbug").write_bytes(b"x" * 1024)
+
+    stat = MagicMock(f_bavail=1024, f_frsize=1024)  # 1 MB available
+    with patch(f"{TASK_MODULE}.os.statvfs", return_value=stat):
+      service._check_disk_space(["kg_a"])  # must not raise
+
+  def test_ignores_databases_with_no_file_on_disk(self, service):
+    stat = MagicMock(f_bavail=1024, f_frsize=1024)
+    with patch(f"{TASK_MODULE}.os.statvfs", return_value=stat):
+      service._check_disk_space(["missing_db"])  # must not raise
+
+
+class TestCounts:
+  def test_node_count_sums_node_tables_only(self, service):
+    conn = _fake_conn(
+      tables=[("Entity", "NODE"), ("Fact", "NODE"), ("HAS_FACT", "REL")],
+      counts={"Entity": 7, "Fact": 35},
+    )
+    assert service._get_node_count(conn) == 42
+
+  def test_node_count_tolerates_an_unreadable_table(self, service):
+    """One bad table must not abort the whole count -- the export still
+    proceeds, it just verifies against a lower number."""
+    conn = _fake_conn(
+      tables=[("Entity", "NODE"), ("Broken", "NODE")],
+      counts={"Entity": 7, "Broken": 5},
+      failing_tables=("Broken",),
+    )
+    assert service._get_node_count(conn) == 7
+
+  def test_rel_table_count_counts_only_rel(self, service):
+    conn = _fake_conn(
+      tables=[("Entity", "NODE"), ("HAS_FACT", "REL"), ("IN_PERIOD", "REL")]
+    )
+    assert service._get_rel_table_count(conn) == 2
+
+
+class TestSystemBackupUpload:
+  def test_uploads_with_migration_metadata(self, service, tmp_path):
+    db_file = tmp_path / "kg_a.lbug"
+    db_file.write_bytes(b"x" * 100)
+
+    s3 = MagicMock()
+    with patch.object(service, "_get_s3_client", return_value=s3):
+      key = service._upload_system_backup(
+        db_file, "kg_a", "0.18.1", "0.19.0", "test-bucket"
+      )
+
+    s3.upload_file.assert_called_once()
+    args, kwargs = s3.upload_file.call_args
+    assert args[1] == "test-bucket"
+    assert args[2] == key
+    metadata = kwargs["ExtraArgs"]["Metadata"]
+    assert metadata["backup_type"] == "system"
+    assert metadata["source_version"] == "0.18.1"
+    assert metadata["target_version"] == "0.19.0"
+    assert metadata["original_size"] == "100"
+
+
+class TestStatusReporting:
+  def test_reports_no_pending_migration_on_clean_instance(self, service):
+    status = service.get_status()
+
+    assert status["migration_pending"] is False
+    assert status["migration_in_progress"] is False
+    assert status["manifest"] is None
+    assert status["pre_migration_files"] == []
+    assert status["active_task_id"] is None
+
+  def test_reports_pending_migration_and_active_task(self, service, tmp_path):
+    manifest = {"source_version": "0.18.1", "target_version": "0.19.0"}
+    (tmp_path / "migration.json").write_text(json.dumps(manifest))
+    (tmp_path / "kg_a.lbug.pre-migration").write_bytes(b"x")
+    ms._try_start_import("task-9")
+
+    status = service.get_status()
+
+    assert status["migration_pending"] is True
+    assert status["migration_in_progress"] is True
+    assert status["manifest"] == manifest
+    assert status["pre_migration_files"] == ["kg_a.lbug.pre-migration"]
+    assert status["active_task_id"] == "task-9"
+
+  def test_corrupt_manifest_is_reported_as_no_manifest(self, service, tmp_path):
+    """A truncated manifest must not crash the status endpoint -- operators
+    need it most when a migration has gone wrong."""
+    (tmp_path / "migration.json").write_text("{not valid json")
+
+    status = service.get_status()
+
+    assert status["manifest"] is None
+    assert status["migration_pending"] is False
+
+
+class TestPreMigrationCleanup:
+  def test_deletes_pre_migration_files_and_reports_bytes_freed(self, service, tmp_path):
+    (tmp_path / "kg_a.lbug.pre-migration").write_bytes(b"x" * 100)
+    (tmp_path / "kg_b.lbug.pre-migration").write_bytes(b"x" * 50)
+    (tmp_path / "kg_a.lbug").write_bytes(b"keep me")
+
+    result = service.cleanup_pre_migration_files()
+
+    assert sorted(result["files_deleted"]) == [
+      "kg_a.lbug.pre-migration",
+      "kg_b.lbug.pre-migration",
+    ]
+    assert result["total_freed_bytes"] == 150
+    assert (tmp_path / "kg_a.lbug").exists(), "live database must survive cleanup"
+
+  def test_noop_when_base_path_missing(self, tmp_path):
+    service = MigrationService(base_path=tmp_path / "gone")
+    assert service.cleanup_pre_migration_files() == {
+      "files_deleted": [],
+      "total_freed_bytes": 0,
+    }
+
+
+class TestExportAllDatabases:
+  @pytest.mark.asyncio
+  async def test_refuses_when_an_export_is_already_running(self, service, task_manager):
+    ms._try_start_export()
+
+    await service.export_all_databases("task-1", "0.18.1", "0.19.0", "bucket")
+
+    task_manager.fail_task.assert_awaited_once_with(
+      "task-1", "Export already in progress"
+    )
+
+  @pytest.mark.asyncio
+  async def test_completes_early_when_no_databases_present(self, service, task_manager):
+    await service.export_all_databases("task-1", "0.18.1", "0.19.0", "bucket")
+
+    task_manager.complete_task.assert_awaited_once()
+    result = task_manager.complete_task.await_args.kwargs["result"]
+    assert result["databases"] == []
+    assert ms._export_in_progress is False, "guard must be released"
+
+  @pytest.mark.asyncio
+  async def test_releases_guard_when_export_raises(
+    self, service, task_manager, tmp_path
+  ):
+    """The finally-block release is what lets a retry succeed after a failed
+    export; without it the instance is wedged until restart."""
+    (tmp_path / "kg_a.lbug").write_bytes(b"x")
+
+    with patch.object(
+      service, "_check_disk_space", side_effect=RuntimeError("disk full")
+    ):
+      await service.export_all_databases("task-1", "0.18.1", "0.19.0", "bucket")
+
+    task_manager.fail_task.assert_awaited_once_with("task-1", "disk full")
+    assert ms._export_in_progress is False
+
+
+class TestImportAllDatabases:
+  @pytest.mark.asyncio
+  async def test_refuses_when_an_import_is_already_running(self, service, task_manager):
+    ms._try_start_import("other-task")
+
+    await service.import_all_databases("task-1")
+
+    task_manager.fail_task.assert_awaited_once_with(
+      "task-1", "Import already in progress"
+    )
+
+  @pytest.mark.asyncio
+  async def test_completes_and_clears_flag_when_no_manifest(
+    self, service, task_manager
+  ):
+    await service.import_all_databases("task-1")
+
+    task_manager.complete_task.assert_awaited_once()
+    assert task_manager.complete_task.await_args.kwargs["result"] == {
+      "message": "No migration pending"
+    }
+    assert ms.is_migration_in_progress() is False, "health must not stay at 503"
+
+  @pytest.mark.asyncio
+  async def test_completes_and_clears_flag_when_manifest_has_no_databases(
+    self, service, task_manager, tmp_path
+  ):
+    (tmp_path / "migration.json").write_text(json.dumps({"databases": []}))
+
+    await service.import_all_databases("task-1")
+
+    assert task_manager.complete_task.await_args.kwargs["result"] == {
+      "message": "Manifest has no databases"
+    }
+    assert ms.is_migration_in_progress() is False
+
+  @pytest.mark.asyncio
+  async def test_missing_export_directory_fails_and_clears_flag(
+    self, service, task_manager, tmp_path
+  ):
+    (tmp_path / "migration.json").write_text(
+      json.dumps(
+        {
+          "source_version": "0.18.1",
+          "target_version": "0.19.0",
+          "databases": [
+            {"graph_id": "kg_a", "export_path": "exports/kg_a", "node_count": 1}
+          ],
+        }
+      )
+    )
+
+    await service.import_all_databases("task-1")
+
+    task_manager.fail_task.assert_awaited_once()
+    assert "Export directory missing" in task_manager.fail_task.await_args.args[1]
+    assert ms.is_migration_in_progress() is False
+
+  @pytest.mark.asyncio
+  async def test_rolls_back_renamed_database_when_import_fails(
+    self, service, task_manager, tmp_path
+  ):
+    """The rollback is the whole safety story: if IMPORT fails, the original
+    .lbug must come back or the customer's graph is gone."""
+    (tmp_path / "migration.json").write_text(
+      json.dumps(
+        {
+          "source_version": "0.18.1",
+          "target_version": "0.19.0",
+          "databases": [
+            {"graph_id": "kg_a", "export_path": "exports/kg_a", "node_count": 10}
+          ],
+        }
+      )
+    )
+    export_dir = tmp_path / "exports" / "kg_a"
+    export_dir.mkdir(parents=True)
+    db_file = tmp_path / "kg_a.lbug"
+    db_file.write_bytes(b"original-database")
+
+    with patch(f"{TASK_MODULE}.lbug.Database", side_effect=RuntimeError("bad engine")):
+      await service.import_all_databases("task-1")
+
+    task_manager.fail_task.assert_awaited_once()
+    assert db_file.exists(), "original database must be restored"
+    assert db_file.read_bytes() == b"original-database"
+    assert not Path(f"{db_file}.pre-migration").exists()
+    assert ms.is_migration_in_progress() is False
+
+  @pytest.mark.asyncio
+  async def test_node_count_mismatch_beyond_tolerance_fails_the_import(
+    self, service, task_manager, tmp_path
+  ):
+    (tmp_path / "migration.json").write_text(
+      json.dumps(
+        {
+          "source_version": "0.18.1",
+          "target_version": "0.19.0",
+          "databases": [
+            {"graph_id": "kg_a", "export_path": "exports/kg_a", "node_count": 1000}
+          ],
+        }
+      )
+    )
+    (tmp_path / "exports" / "kg_a").mkdir(parents=True)
+    (tmp_path / "kg_a.lbug").write_bytes(b"original")
+
+    with (
+      patch(f"{TASK_MODULE}.lbug.Database"),
+      patch(f"{TASK_MODULE}.lbug.Connection"),
+      patch.object(service, "_get_node_count", return_value=400),
+    ):
+      await service.import_all_databases("task-1")
+
+    task_manager.fail_task.assert_awaited_once()
+    assert "Node count mismatch" in task_manager.fail_task.await_args.args[1]
+
+  @pytest.mark.asyncio
+  async def test_small_node_count_drift_is_tolerated(
+    self, service, task_manager, tmp_path
+  ):
+    """Writes can land between export and import; a 0.1% drift is accepted
+    rather than failing the upgrade."""
+    (tmp_path / "migration.json").write_text(
+      json.dumps(
+        {
+          "source_version": "0.18.1",
+          "target_version": "0.19.0",
+          "databases": [
+            {"graph_id": "kg_a", "export_path": "exports/kg_a", "node_count": 10000}
+          ],
+        }
+      )
+    )
+    (tmp_path / "exports" / "kg_a").mkdir(parents=True)
+    (tmp_path / "kg_a.lbug").write_bytes(b"original")
+
+    with (
+      patch(f"{TASK_MODULE}.lbug.Database", side_effect=_importing_database()),
+      patch(f"{TASK_MODULE}.lbug.Connection"),
+      patch.object(service, "_get_node_count", return_value=10005),
+    ):
+      await service.import_all_databases("task-1")
+
+    task_manager.complete_task.assert_awaited_once()
+    result = task_manager.complete_task.await_args.kwargs["result"]
+    assert result["databases_imported"] == 1
+    assert result["results"][0]["verified"] is False
+    assert ms.is_migration_in_progress() is False
+
+  @pytest.mark.asyncio
+  async def test_successful_import_cleans_up_manifest_and_exports(
+    self, service, task_manager, tmp_path
+  ):
+    (tmp_path / "migration.json").write_text(
+      json.dumps(
+        {
+          "source_version": "0.18.1",
+          "target_version": "0.19.0",
+          "databases": [
+            {"graph_id": "kg_a", "export_path": "exports/kg_a", "node_count": 10}
+          ],
+        }
+      )
+    )
+    (tmp_path / "exports" / "kg_a").mkdir(parents=True)
+    (tmp_path / "kg_a.lbug").write_bytes(b"original")
+
+    with (
+      patch(f"{TASK_MODULE}.lbug.Database", side_effect=_importing_database()),
+      patch(f"{TASK_MODULE}.lbug.Connection"),
+      patch.object(service, "_get_node_count", return_value=10),
+    ):
+      await service.import_all_databases("task-1")
+
+    task_manager.complete_task.assert_awaited_once()
+    assert not (tmp_path / "migration.json").exists()
+    assert not (tmp_path / "exports").exists()
+    assert ms.is_migration_in_progress() is False
+
+  @pytest.mark.asyncio
+  async def test_parents_are_imported_before_subgraphs(
+    self, service, task_manager, tmp_path
+  ):
+    """Subgraph ids extend their parent's, so shorter ids must import first."""
+    (tmp_path / "migration.json").write_text(
+      json.dumps(
+        {
+          "source_version": "0.18.1",
+          "target_version": "0.19.0",
+          "databases": [
+            {"graph_id": "kg1a2b3c_dev", "export_path": "exports/sub", "node_count": 0},
+            {"graph_id": "kg1a2b3c", "export_path": "exports/parent", "node_count": 0},
+          ],
+        }
+      )
+    )
+    (tmp_path / "exports" / "sub").mkdir(parents=True)
+    (tmp_path / "exports" / "parent").mkdir(parents=True)
+
+    with (
+      patch(f"{TASK_MODULE}.lbug.Database", side_effect=_importing_database()),
+      patch(f"{TASK_MODULE}.lbug.Connection"),
+      patch.object(service, "_get_node_count", return_value=0),
+    ):
+      await service.import_all_databases("task-1")
+
+    result = task_manager.complete_task.await_args.kwargs["result"]
+    order = [r["graph_id"] for r in result["results"]]
+    assert order == ["kg1a2b3c", "kg1a2b3c_dev"]
+
+
+class TestServicePaths:
+  def test_derives_export_and_manifest_paths_from_base(self, tmp_path):
+    service = MigrationService(base_path=tmp_path)
+
+    assert service.exports_path == tmp_path / "exports"
+    assert service.manifest_path == tmp_path / "migration.json"
+
+  def test_defaults_base_path_to_configured_database_path(self):
+    with patch(f"{TASK_MODULE}.env") as mock_env:
+      mock_env.LBUG_DATABASE_PATH = "/data/lbug-dbs"
+      service = MigrationService()
+
+    assert service.base_path == Path("/data/lbug-dbs")
+
+
+class TestS3ClientConstruction:
+  def test_passes_endpoint_and_credentials_when_configured(self, service):
+    config = {
+      "region_name": "us-east-1",
+      "endpoint_url": "http://localstack:4566",
+      "aws_access_key_id": "key",
+      "aws_secret_access_key": "secret",
+    }
+    with (
+      patch(f"{TASK_MODULE}.env.get_s3_config", return_value=config),
+      patch(f"{TASK_MODULE}.boto3.client") as mock_client,
+    ):
+      service._get_s3_client()
+
+    kwargs = mock_client.call_args.kwargs
+    assert kwargs["endpoint_url"] == "http://localstack:4566"
+    assert kwargs["aws_access_key_id"] == "key"
+    assert kwargs["aws_secret_access_key"] == "secret"
+
+  def test_omits_endpoint_and_credentials_when_using_instance_role(self, service):
+    """On EC2 the instance profile supplies credentials; passing empty
+    strings through would break the default provider chain."""
+    with (
+      patch(
+        f"{TASK_MODULE}.env.get_s3_config", return_value={"region_name": "us-east-1"}
+      ),
+      patch(f"{TASK_MODULE}.boto3.client") as mock_client,
+    ):
+      service._get_s3_client()
+
+    kwargs = mock_client.call_args.kwargs
+    assert "endpoint_url" not in kwargs
+    assert "aws_access_key_id" not in kwargs
+    assert kwargs["region_name"] == "us-east-1"
+
+
+class TestCheckpointBeforeExport:
+  def test_checkpoint_runs_against_a_writable_connection(self, service):
+    """CHECKPOINT must not use a read-only handle, or the WAL never drains
+    and the upgraded engine hits a corrupt WAL tail."""
+    conn = MagicMock()
+    ladybug_service = MagicMock()
+    ladybug_service.db_manager.get_connection.return_value.__enter__.return_value = conn
+
+    with patch(
+      "robosystems.graph_api.core.ladybug.get_ladybug_service",
+      return_value=ladybug_service,
+    ):
+      service._checkpoint_database("kg_a")
+
+    ladybug_service.db_manager.get_connection.assert_called_once_with(
+      "kg_a", read_only=False
+    )
+    conn.execute.assert_called_once_with("CHECKPOINT")
+
+
+def test_os_import_is_module_level():
+  """Guards the patch targets used above."""
+  assert ms.os is os

--- a/tests/graph_api/routers/databases/tables/test_materialize_helpers.py
+++ b/tests/graph_api/routers/databases/tables/test_materialize_helpers.py
@@ -1,0 +1,393 @@
+"""Tests for the materialization helpers.
+
+These build the SQL that moves staged customer data from DuckDB into
+LadybugDB, so a mistake here is a silent data-correctness bug rather than a
+crash: a dropped column, a truncated DECIMAL, or a keyset snapshot written
+outside the staging directory.
+"""
+
+from pathlib import Path as FilePath
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from robosystems.graph_api.routers.databases.tables.materialize import (
+  CHECKPOINT_MAX_RETRIES,
+  _build_reconciled_select,
+  _build_type_safe_select,
+  _copy_result_rows,
+  _export_incremental_keyset,
+  _get_target_columns,
+  _incr_keyset_path,
+  _lbug_type_to_duck,
+  checkpoint_with_retry,
+)
+
+MODULE = "robosystems.graph_api.routers.databases.tables.materialize"
+
+
+def _arrow_result(message):
+  arrow = MagicMock()
+  arrow.num_rows = 1
+  arrow.num_columns = 1
+  cell = MagicMock()
+  cell.as_py.return_value = message
+  arrow.column.return_value = [cell]
+  result = MagicMock()
+  result.get_as_arrow.return_value = arrow
+  return result
+
+
+@pytest.mark.unit
+class TestCopyResultRows:
+  def test_parses_tuple_count_from_copy_message(self):
+    assert _copy_result_rows(_arrow_result("1500 tuples have been copied"), 0) == 1500
+
+  def test_parses_singular_tuple(self):
+    assert _copy_result_rows(_arrow_result("1 tuple has been copied"), 0) == 1
+
+  def test_falls_back_when_message_has_no_count(self):
+    assert _copy_result_rows(_arrow_result("copy finished"), 42) == 42
+
+  def test_falls_back_on_none_result(self):
+    assert _copy_result_rows(None, 42) == 42
+
+  def test_falls_back_when_arrow_access_raises(self):
+    """A count is only reported metadata -- it must never fail the load."""
+    result = MagicMock()
+    result.get_as_arrow.side_effect = RuntimeError("arrow unavailable")
+
+    assert _copy_result_rows(result, 42) == 42
+
+  def test_falls_back_on_empty_arrow_table(self):
+    arrow = MagicMock(num_rows=0, num_columns=0)
+    result = MagicMock()
+    result.get_as_arrow.return_value = arrow
+
+    assert _copy_result_rows(result, 7) == 7
+
+
+@pytest.mark.unit
+class TestKeysetPathSafety:
+  """`graph_id` and `table_name` arrive as URL path params and are used to
+  build a filesystem path -- they must not be able to escape the staging dir."""
+
+  def test_builds_path_under_staging(self):
+    with patch(f"{MODULE}.env") as mock_env:
+      mock_env.DUCKDB_STAGING_PATH = "/data/staging"
+      path = _incr_keyset_path("kg1a2b3c", "Fact")
+
+    assert path == FilePath("/data/staging/incr_keys/kg1a2b3c/Fact.parquet")
+
+  @pytest.mark.parametrize(
+    "graph_id",
+    ["../../etc", "kg/../..", "kg1;rm -rf /", "kg 1", "kg\x00", "", "kg/sub"],
+  )
+  def test_rejects_unsafe_graph_id(self, graph_id):
+    with pytest.raises(ValueError, match="Unsafe graph_id"):
+      _incr_keyset_path(graph_id, "Fact")
+
+  @pytest.mark.parametrize(
+    "table_name", ["../secrets", "Fact/../..", "Fact;DROP", "", "a b"]
+  )
+  def test_rejects_unsafe_table_name(self, table_name):
+    with pytest.raises(ValueError, match="Unsafe table_name"):
+      _incr_keyset_path("kg1a2b3c", table_name)
+
+  def test_allows_hyphens_and_underscores(self):
+    with patch(f"{MODULE}.env") as mock_env:
+      mock_env.DUCKDB_STAGING_PATH = "/data/staging"
+      path = _incr_keyset_path("kg_1a-2b", "HAS_FACT")
+
+    assert path.name == "HAS_FACT.parquet"
+
+
+@pytest.mark.unit
+class TestTypeMapping:
+  @pytest.mark.parametrize(
+    "lbug,duck",
+    [
+      ("STRING", "VARCHAR"),
+      ("INT64", "BIGINT"),
+      ("INT32", "INT"),
+      ("DOUBLE", "DOUBLE"),
+      ("BOOL", "BOOLEAN"),
+      ("DATE", "DATE"),
+      ("TIMESTAMP", "TIMESTAMP"),
+    ],
+  )
+  def test_maps_known_types(self, lbug, duck):
+    assert _lbug_type_to_duck(lbug) == duck
+
+  def test_is_case_insensitive(self):
+    assert _lbug_type_to_duck("string") == "VARCHAR"
+    assert _lbug_type_to_duck("Int64") == "BIGINT"
+
+  def test_passes_through_parameterized_types(self):
+    """Embedding columns like FLOAT[384] are DuckDB-native -- flattening them
+    to VARCHAR would corrupt vector search."""
+    assert _lbug_type_to_duck("FLOAT[384]") == "FLOAT[384]"
+    assert _lbug_type_to_duck("DOUBLE[3]") == "DOUBLE[3]"
+
+  def test_unknown_scalar_defaults_to_varchar(self):
+    assert _lbug_type_to_duck("SOMETHING_NEW") == "VARCHAR"
+
+
+@pytest.mark.unit
+class TestTypeSafeSelect:
+  def test_preserves_source_column_order(self):
+    select = _build_type_safe_select(
+      [("identifier", "VARCHAR"), ("value", "BIGINT"), ("name", "VARCHAR")]
+    )
+
+    assert select == '"identifier", "value", "name"'
+
+  def test_casts_decimal_to_double(self):
+    """LadybugDB has no DECIMAL; postgres_scan stages NUMERIC as DECIMAL, so
+    the cast has to happen at the source or Arrow types disagree."""
+    select = _build_type_safe_select([("amount", "DECIMAL(18,2)")])
+
+    assert select == 'CAST("amount" AS DOUBLE) AS "amount"'
+
+  def test_excluded_columns_are_dropped(self):
+    select = _build_type_safe_select(
+      [("identifier", "VARCHAR"), ("secret", "VARCHAR")], exclude_cols={"secret"}
+    )
+
+    assert select == '"identifier"'
+
+  def test_nullified_columns_keep_their_position_and_type(self):
+    """COPY is positional -- a nullified column must still occupy its slot."""
+    select = _build_type_safe_select(
+      [("identifier", "VARCHAR"), ("embedding", "FLOAT[384]")],
+      null_cols={"embedding"},
+    )
+
+    assert select == '"identifier", NULL::FLOAT[384] AS "embedding"'
+
+  def test_exclusion_wins_over_nullification(self):
+    select = _build_type_safe_select(
+      [("a", "VARCHAR"), ("b", "VARCHAR")],
+      exclude_cols={"b"},
+      null_cols={"b"},
+    )
+
+    assert select == '"a"'
+
+
+@pytest.mark.unit
+class TestReconciledSelect:
+  def test_casts_present_columns_to_target_type(self):
+    select = _build_reconciled_select(
+      target_columns=[("identifier", "STRING"), ("value", "INT64")],
+      source_column_names=["identifier", "value"],
+      source_table="staged",
+    )
+
+    assert "TRY_CAST(identifier AS VARCHAR) AS identifier" in select
+    assert "TRY_CAST(value AS BIGINT) AS value" in select
+
+  def test_missing_source_columns_become_typed_nulls(self):
+    """DuckDB infers all-NULL staged columns as INT32; without the typed NULL
+    the COPY would fail on a type mismatch against the target."""
+    select = _build_reconciled_select(
+      target_columns=[("identifier", "STRING"), ("added_later", "DOUBLE")],
+      source_column_names=["identifier"],
+      source_table="staged",
+    )
+
+    assert "NULL::DOUBLE AS added_later" in select
+
+  def test_relationship_key_columns_are_passed_through_first(self):
+    """TABLE_INFO omits from/to for rel tables, but COPY requires them."""
+    select = _build_reconciled_select(
+      target_columns=[("weight", "DOUBLE")],
+      source_column_names=["from", "to", "weight"],
+      source_table="staged",
+    )
+
+    assert select.startswith('"from", "to",')
+
+  def test_duckdb_src_dst_variants_are_passed_through(self):
+    select = _build_reconciled_select(
+      target_columns=[("weight", "DOUBLE")],
+      source_column_names=["src", "dst", "weight"],
+      source_table="staged",
+    )
+
+    assert select.startswith('"src", "dst",')
+
+  def test_implicit_columns_not_duplicated_when_target_declares_them(self):
+    select = _build_reconciled_select(
+      target_columns=[("from", "STRING"), ("weight", "DOUBLE")],
+      source_column_names=["from", "weight"],
+      source_table="staged",
+    )
+
+    columns = [part.strip() for part in select.split(",")]
+    from_columns = [c for c in columns if c.endswith("from") or c == '"from"']
+    assert from_columns == ["TRY_CAST(from AS VARCHAR) AS from"], (
+      "the implicit pass-through must be skipped when TABLE_INFO already "
+      f"declares the column, else COPY gets it twice: {select}"
+    )
+
+  def test_excluded_target_columns_are_dropped(self):
+    select = _build_reconciled_select(
+      target_columns=[("identifier", "STRING"), ("internal", "STRING")],
+      source_column_names=["identifier", "internal"],
+      source_table="staged",
+      exclude_cols={"internal"},
+    )
+
+    assert "internal" not in select
+
+  def test_nullified_target_columns_keep_their_slot(self):
+    select = _build_reconciled_select(
+      target_columns=[("identifier", "STRING"), ("embedding", "FLOAT[384]")],
+      source_column_names=["identifier", "embedding"],
+      source_table="staged",
+      null_cols={"embedding"},
+    )
+
+    assert "NULL::FLOAT[384] AS embedding" in select
+    assert "TRY_CAST(embedding" not in select
+
+
+@pytest.mark.unit
+class TestGetTargetColumns:
+  def _service_returning(self, rows):
+    conn = MagicMock()
+    result = MagicMock()
+    result.get_as_list.return_value = rows
+    conn.execute.return_value = result
+    service = MagicMock()
+    service.db_manager.connection_pool.get_connection.return_value.__enter__.return_value = conn
+    return service
+
+  def test_parses_table_info_rows(self):
+    service = self._service_returning(
+      [[0, "identifier", "STRING", None, True], [1, "value", "INT64", None, False]]
+    )
+
+    assert _get_target_columns(service, "kg1", "Fact") == [
+      ("identifier", "STRING"),
+      ("value", "INT64"),
+    ]
+
+  def test_returns_none_when_no_columns(self):
+    assert _get_target_columns(self._service_returning([]), "kg1", "Fact") is None
+
+  def test_returns_none_when_table_missing(self):
+    """A table that doesn't exist yet is normal on first materialization --
+    the caller falls back to the type-safe select."""
+    service = MagicMock()
+    service.db_manager.connection_pool.get_connection.side_effect = RuntimeError(
+      "Table Fact does not exist"
+    )
+
+    assert _get_target_columns(service, "kg1", "Fact") is None
+
+  def test_skips_malformed_rows(self):
+    service = self._service_returning([[0, "identifier", "STRING"], [1, "short"]])
+
+    assert _get_target_columns(service, "kg1", "Fact") == [("identifier", "STRING")]
+
+
+@pytest.mark.unit
+class TestExportIncrementalKeyset:
+  def _service(self):
+    conn = MagicMock()
+    service = MagicMock()
+    service.db_manager.connection_pool.get_connection.return_value.__enter__.return_value = conn
+    return service, conn
+
+  def test_node_keyset_selects_identifier(self, tmp_path):
+    service, conn = self._service()
+    path = tmp_path / "keys" / "Fact.parquet"
+
+    _export_incremental_keyset(service, "kg1", "Fact", is_rel=False, snapshot_path=path)
+
+    copy_sql = [c.args[0] for c in conn.execute.call_args_list if "COPY" in c.args[0]]
+    assert "MATCH (n:Fact) RETURN n.identifier AS identifier" in copy_sql[0]
+    assert path.parent.exists(), "snapshot directory must be created"
+
+  def test_relationship_keyset_selects_src_and_dst(self, tmp_path):
+    service, conn = self._service()
+
+    _export_incremental_keyset(
+      service, "kg1", "HAS_FACT", is_rel=True, snapshot_path=tmp_path / "k.parquet"
+    )
+
+    copy_sql = [c.args[0] for c in conn.execute.call_args_list if "COPY" in c.args[0]]
+    assert "MATCH (a)-[:HAS_FACT]->(b)" in copy_sql[0]
+    assert "a.identifier AS src" in copy_sql[0]
+    assert "b.identifier AS dst" in copy_sql[0]
+
+  def test_raises_timeout_for_the_traversal_then_resets_it(self, tmp_path):
+    """A 200M-edge traversal needs the long timeout, but leaving it raised
+    would let ordinary queries hang for an hour."""
+    service, conn = self._service()
+
+    _export_incremental_keyset(
+      service, "kg1", "Fact", is_rel=False, snapshot_path=tmp_path / "k.parquet"
+    )
+
+    calls = [c.args[0] for c in conn.execute.call_args_list]
+    assert calls[0] == "CALL timeout=3600000"
+    assert calls[-1] == "CALL timeout=120000"
+
+  def test_timeout_is_reset_even_when_copy_fails(self, tmp_path):
+    service, conn = self._service()
+    conn.execute.side_effect = lambda sql: (
+      (_ for _ in ()).throw(RuntimeError("copy failed"))
+      if sql.startswith("COPY")
+      else MagicMock()
+    )
+
+    with pytest.raises(RuntimeError):
+      _export_incremental_keyset(
+        service, "kg1", "Fact", is_rel=False, snapshot_path=tmp_path / "k.parquet"
+      )
+
+    assert conn.execute.call_args_list[-1].args[0] == "CALL timeout=120000"
+
+  def test_escapes_single_quotes_in_snapshot_path(self, tmp_path):
+    service, conn = self._service()
+    path = tmp_path / "o'brien.parquet"
+
+    _export_incremental_keyset(service, "kg1", "Fact", False, path)
+
+    copy_sql = [c.args[0] for c in conn.execute.call_args_list if "COPY" in c.args[0]]
+    assert "o''brien.parquet" in copy_sql[0]
+
+
+@pytest.mark.unit
+class TestCheckpointWithRetry:
+  def test_returns_on_first_success(self):
+    conn = MagicMock()
+
+    checkpoint_with_retry(conn, "kg1")
+
+    conn.execute.assert_called_once_with("CHECKPOINT")
+
+  def test_retries_then_succeeds(self):
+    conn = MagicMock()
+    conn.execute.side_effect = [RuntimeError("locked"), None]
+
+    with patch("time.sleep"):
+      checkpoint_with_retry(conn, "kg1")
+
+    assert conn.execute.call_count == 2
+
+  def test_raises_500_after_exhausting_retries(self):
+    conn = MagicMock()
+    conn.execute.side_effect = RuntimeError("still locked")
+
+    with patch("time.sleep"):
+      with pytest.raises(HTTPException) as exc:
+        checkpoint_with_retry(conn, "kg1", context="parent DuckDB")
+
+    assert exc.value.status_code == 500
+    assert "parent DuckDB" in exc.value.detail
+    assert conn.execute.call_count == CHECKPOINT_MAX_RETRIES

--- a/tests/graph_api/routers/databases/test_vector_hnsw.py
+++ b/tests/graph_api/routers/databases/test_vector_hnsw.py
@@ -1,0 +1,271 @@
+"""Tests for the HNSW vector backend in the vector-search router.
+
+The LanceDB-backed endpoints are covered in `test_vector_search.py`; this
+file covers the LadybugDB/HNSW path, which interpolates table and column
+names straight into Cypher and therefore leans entirely on
+`_validate_identifier` to stay safe.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from robosystems.graph_api.routers.databases.vector_search import (
+  _build_hnsw_index,
+  _require_writer,
+  _search_hnsw_index,
+  _validate_identifier,
+)
+
+MODULE = "robosystems.graph_api.routers.databases.vector_search"
+
+
+def _service_with(conn):
+  service = MagicMock()
+  service.db_manager.connection_pool.get_connection.return_value.__enter__.return_value = conn
+  service.db_manager.rebuild_vector_index.return_value = True
+  return service
+
+
+def _vector_query(conn):
+  """The QUERY_VECTOR_INDEX statement the search issued."""
+  return next(
+    c.args[0] for c in conn.execute.call_args_list if "QUERY_VECTOR_INDEX" in c.args[0]
+  )
+
+
+@pytest.mark.unit
+class TestIdentifierValidation:
+  """These values are interpolated into Cypher without parameterization."""
+
+  @pytest.mark.parametrize("value", ["Fact", "_private", "Table_1", "a"])
+  def test_accepts_plain_identifiers(self, value):
+    _validate_identifier(value)  # must not raise
+
+  @pytest.mark.parametrize(
+    "value",
+    [
+      "Fact; MATCH (n) DETACH DELETE n",
+      "Fact) RETURN 1 //",
+      "1Fact",
+      "Fact-1",
+      "Fact Name",
+      "",
+      "'; DROP",
+      "Fact\nMATCH",
+      "../etc",
+    ],
+  )
+  def test_rejects_injection_shaped_values(self, value):
+    with pytest.raises(ValueError, match="Invalid"):
+      _validate_identifier(value)
+
+  def test_error_names_the_offending_label(self):
+    with pytest.raises(ValueError, match="Invalid column"):
+      _validate_identifier("bad-col", "column")
+
+
+@pytest.mark.unit
+class TestRequireWriter:
+  def test_allows_writer(self, monkeypatch):
+    monkeypatch.delenv("LBUG_ROLE", raising=False)
+    _require_writer()  # must not raise
+
+  def test_blocks_replica_with_501(self, monkeypatch):
+    """Replicas have no writable graph -- building there would corrupt the
+    read path or silently no-op."""
+    monkeypatch.setenv("LBUG_ROLE", "replica")
+
+    with pytest.raises(HTTPException) as exc:
+      _require_writer()
+
+    assert exc.value.status_code == 501
+
+
+@pytest.mark.unit
+class TestBuildHnswIndex:
+  def test_builds_and_reports_row_count(self):
+    conn = MagicMock()
+    result = MagicMock()
+    result.get_as_list.return_value = [[1500]]
+    conn.execute.return_value = result
+    service = _service_with(conn)
+
+    with patch(f"{MODULE}._get_ladybug_service", return_value=service):
+      out = _build_hnsw_index("kg1", "Fact")
+
+    assert out["row_count"] == 1500
+    assert out["table_name"] == "Fact"
+    service.db_manager.rebuild_vector_index.assert_called_once_with(
+      conn, "Fact", "embedding"
+    )
+
+  def test_checkpoints_after_building(self):
+    """Without the CHECKPOINT the index lives only in the WAL and is lost on
+    the next engine restart."""
+    conn = MagicMock()
+    conn.execute.return_value = MagicMock(get_as_list=MagicMock(return_value=[[0]]))
+    service = _service_with(conn)
+
+    with patch(f"{MODULE}._get_ladybug_service", return_value=service):
+      _build_hnsw_index("kg1", "Fact")
+
+    assert any(c.args[0] == "CHECKPOINT" for c in conn.execute.call_args_list), (
+      "index build must be checkpointed"
+    )
+
+  def test_raises_when_rebuild_reports_failure(self):
+    conn = MagicMock()
+    service = _service_with(conn)
+    service.db_manager.rebuild_vector_index.return_value = False
+
+    with patch(f"{MODULE}._get_ladybug_service", return_value=service):
+      with pytest.raises(RuntimeError, match="Failed to build HNSW index"):
+        _build_hnsw_index("kg1", "Fact")
+
+  def test_row_count_failure_degrades_to_zero(self):
+    conn = MagicMock()
+
+    def execute(sql):
+      if sql.startswith("MATCH"):
+        raise RuntimeError("count failed")
+      return MagicMock()
+
+    conn.execute.side_effect = execute
+    service = _service_with(conn)
+
+    with patch(f"{MODULE}._get_ladybug_service", return_value=service):
+      out = _build_hnsw_index("kg1", "Fact")
+
+    assert out["row_count"] == 0, "a failed count must not fail the build"
+
+  @pytest.mark.parametrize("bad", ["Fact; DELETE", "1Fact", "Fact-x"])
+  def test_rejects_unsafe_table_name_before_touching_the_graph(self, bad):
+    with patch(f"{MODULE}._get_ladybug_service") as mock_service:
+      with pytest.raises(ValueError, match="Invalid table_name"):
+        _build_hnsw_index("kg1", bad)
+
+    mock_service.assert_not_called()
+
+  def test_rejects_unsafe_column(self):
+    with patch(f"{MODULE}._get_ladybug_service") as mock_service:
+      with pytest.raises(ValueError, match="Invalid column"):
+        _build_hnsw_index("kg1", "Fact", column="embedding; DROP")
+
+    mock_service.assert_not_called()
+
+
+@pytest.mark.unit
+class TestSearchHnswIndex:
+  def _conn_returning(self, rows):
+    conn = MagicMock()
+    result = MagicMock()
+    result.get_as_list.return_value = rows
+    conn.execute.return_value = result
+    return conn
+
+  def test_maps_selected_columns_onto_results(self):
+    conn = self._conn_returning([["f1", "Revenue", 0.12], ["f2", "Cost", 0.30]])
+    service = _service_with(conn)
+
+    with patch(f"{MODULE}._get_ladybug_service", return_value=service):
+      out = _search_hnsw_index(
+        "kg1", "Fact", [0.1, 0.2], limit=2, select_columns=["identifier", "label"]
+      )
+
+    assert out["total"] == 2
+    assert out["results"][0] == {
+      "identifier": "f1",
+      "label": "Revenue",
+      "distance": 0.12,
+    }
+
+  def test_flattens_node_dicts_when_no_columns_selected(self):
+    conn = self._conn_returning([[{"identifier": "f1", "value": 10}, 0.12]])
+    service = _service_with(conn)
+
+    with patch(f"{MODULE}._get_ladybug_service", return_value=service):
+      out = _search_hnsw_index("kg1", "Fact", [0.1], limit=5)
+
+    assert out["results"][0] == {"identifier": "f1", "value": 10, "distance": 0.12}
+
+  def test_keeps_scalar_nodes_under_a_node_key(self):
+    conn = self._conn_returning([["opaque", 0.5]])
+    service = _service_with(conn)
+
+    with patch(f"{MODULE}._get_ladybug_service", return_value=service):
+      out = _search_hnsw_index("kg1", "Fact", [0.1], limit=5)
+
+    assert out["results"][0] == {"node": "opaque", "distance": 0.5}
+
+  def test_over_fetches_then_applies_the_caller_limit(self):
+    """HNSW is approximate, so the query over-fetches and re-sorts; the
+    over-fetch is capped so a large limit can't blow up the scan."""
+    conn = self._conn_returning([])
+    service = _service_with(conn)
+
+    with patch(f"{MODULE}._get_ladybug_service", return_value=service):
+      _search_hnsw_index("kg1", "Fact", [0.1], limit=10)
+
+    query = _vector_query(conn)
+    assert "20)" in query, "should over-fetch 2x"
+    assert query.rstrip().endswith("LIMIT 10")
+
+  def test_over_fetch_is_capped_at_200(self):
+    conn = self._conn_returning([])
+    service = _service_with(conn)
+
+    with patch(f"{MODULE}._get_ladybug_service", return_value=service):
+      _search_hnsw_index("kg1", "Fact", [0.1], limit=150)
+
+    query = _vector_query(conn)
+    assert "200)" in query
+
+  def test_installs_vector_extension_when_load_fails(self):
+    conn = MagicMock()
+    calls = []
+
+    def execute(sql):
+      calls.append(sql)
+      if sql == "LOAD EXTENSION vector" and calls.count("LOAD EXTENSION vector") == 1:
+        raise RuntimeError("not installed")
+      return MagicMock(get_as_list=MagicMock(return_value=[]))
+
+    conn.execute.side_effect = execute
+    service = _service_with(conn)
+
+    with patch(f"{MODULE}._get_ladybug_service", return_value=service):
+      _search_hnsw_index("kg1", "Fact", [0.1], limit=5)
+
+    assert "INSTALL vector" in calls
+    assert calls.count("LOAD EXTENSION vector") == 2
+
+  def test_derives_index_name_from_table(self):
+    conn = self._conn_returning([])
+    service = _service_with(conn)
+
+    with patch(f"{MODULE}._get_ladybug_service", return_value=service):
+      _search_hnsw_index("kg1", "FactSet", [0.1], limit=5)
+
+    query = _vector_query(conn)
+    assert "'factset_vec_index'" in query
+
+  @pytest.mark.parametrize("bad", ["Fact; DELETE", "1Fact"])
+  def test_rejects_unsafe_table_name(self, bad):
+    with patch(f"{MODULE}._get_ladybug_service") as mock_service:
+      with pytest.raises(ValueError, match="Invalid table_name"):
+        _search_hnsw_index("kg1", bad, [0.1], limit=5)
+
+    mock_service.assert_not_called()
+
+  def test_rejects_unsafe_select_column(self):
+    """select_columns land in the RETURN clause -- a crafted value would let
+    a caller project arbitrary Cypher."""
+    with patch(f"{MODULE}._get_ladybug_service") as mock_service:
+      with pytest.raises(ValueError, match="Invalid column"):
+        _search_hnsw_index(
+          "kg1", "Fact", [0.1], limit=5, select_columns=["identifier", "x) RETURN 1 //"]
+        )
+
+    mock_service.assert_not_called()

--- a/tests/routers/graphs/test_memory.py
+++ b/tests/routers/graphs/test_memory.py
@@ -1,0 +1,303 @@
+"""Tests for the semantic-memory read router.
+
+Covers list / get / recall plus the three gates each handler runs before
+touching a graph: the `SEMANTIC_MEMORY_ENABLED` flag, the shared-repository
+block, and per-graph access enforcement. Also pins the writer-client
+lifecycle -- every handler must close its client even when the body raises.
+"""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from robosystems.config import env as env_config
+from robosystems.models.api.memory import (
+  MemoryListResponse,
+  MemoryRecallRequest,
+  MemoryRecord,
+)
+from robosystems.routers.graphs.memory import (
+  get_memory,
+  list_memories,
+  recall_memory,
+)
+
+MODULE = "robosystems.routers.graphs.memory"
+
+NOW = datetime(2026, 4, 1, tzinfo=UTC)
+
+
+def _mock_user():
+  user = MagicMock()
+  user.id = "usr_1"
+  return user
+
+
+def _record(**overrides):
+  defaults = {
+    "id": "mem_abc123",
+    "text": "Q2 close ran two days late",
+    "source": "api",
+    "memory_type": "note",
+    "tags": ["close"],
+    "created_at": NOW,
+    "updated_at": NOW,
+  }
+  defaults.update(overrides)
+  return MemoryRecord(**defaults)
+
+
+@pytest.fixture
+def gates():
+  """Open all three gates; individual tests re-close the one under test."""
+  with (
+    patch(f"{MODULE}._require_memory_enabled"),
+    patch(f"{MODULE}._block_shared_repository"),
+    patch(f"{MODULE}._enforce_graph_access"),
+  ):
+    yield
+
+
+@pytest.fixture
+def writer_client():
+  """Stub the writer-only graph client and assert it gets closed."""
+  client = MagicMock()
+  client.close = AsyncMock()
+  with patch(f"{MODULE}._get_writer_client", AsyncMock(return_value=client)):
+    yield client
+
+
+@pytest.fixture
+def service():
+  svc = MagicMock()
+  svc.list_memories = AsyncMock()
+  svc.get_memory = AsyncMock()
+  svc.recall = AsyncMock()
+  with patch(f"{MODULE}._require_service", return_value=svc):
+    yield svc
+
+
+@pytest.mark.unit
+class TestListMemories:
+  @pytest.mark.asyncio
+  async def test_returns_memories_and_closes_client(
+    self, gates, writer_client, service
+  ):
+    service.list_memories.return_value = MemoryListResponse(
+      total=2, memories=[_record(), _record(id="mem_def456")], graph_id="kg_test"
+    )
+
+    result = await list_memories(graph_id="kg_test", current_user=_mock_user())
+
+    assert result.total == 2
+    assert result.graph_id == "kg_test"
+    writer_client.close.assert_awaited_once()
+
+  @pytest.mark.asyncio
+  async def test_forwards_filters_and_pagination(self, gates, writer_client, service):
+    service.list_memories.return_value = MemoryListResponse(
+      total=0, memories=[], graph_id="kg_test"
+    )
+
+    await list_memories(
+      graph_id="kg_test",
+      memory_type="decision",
+      source="operator",
+      limit=25,
+      offset=50,
+      current_user=_mock_user(),
+    )
+
+    service.list_memories.assert_awaited_once_with(
+      "kg_test",
+      memory_type="decision",
+      source="operator",
+      limit=25,
+      offset=50,
+    )
+
+  @pytest.mark.asyncio
+  async def test_closes_client_when_service_raises(self, gates, writer_client, service):
+    """A leaked writer client holds a connection against the master node."""
+    service.list_memories.side_effect = RuntimeError("store unavailable")
+
+    with pytest.raises(RuntimeError):
+      await list_memories(graph_id="kg_test", current_user=_mock_user())
+
+    writer_client.close.assert_awaited_once()
+
+
+@pytest.mark.unit
+class TestGetMemory:
+  @pytest.mark.asyncio
+  async def test_returns_record(self, gates, writer_client, service):
+    service.get_memory.return_value = _record()
+
+    result = await get_memory(
+      graph_id="kg_test", memory_id="mem_abc123", current_user=_mock_user()
+    )
+
+    assert result.id == "mem_abc123"
+    service.get_memory.assert_awaited_once_with("kg_test", "mem_abc123")
+    writer_client.close.assert_awaited_once()
+
+  @pytest.mark.asyncio
+  async def test_missing_memory_is_404_not_null(self, gates, writer_client, service):
+    service.get_memory.return_value = None
+
+    with pytest.raises(HTTPException) as exc:
+      await get_memory(
+        graph_id="kg_test", memory_id="mem_missing", current_user=_mock_user()
+      )
+
+    assert exc.value.status_code == 404
+    writer_client.close.assert_awaited_once(), "client must close on the 404 path"
+
+
+@pytest.mark.unit
+class TestRecallMemory:
+  @pytest.mark.asyncio
+  async def test_forwards_request_and_returns_hits(self, gates, writer_client, service):
+    expected = MagicMock()
+    service.recall.return_value = expected
+    request = MemoryRecallRequest(query="why did close slip", k=5)
+
+    result = await recall_memory(
+      graph_id="kg_test", request=request, current_user=_mock_user()
+    )
+
+    assert result is expected
+    service.recall.assert_awaited_once_with("kg_test", request)
+    writer_client.close.assert_awaited_once()
+
+  @pytest.mark.asyncio
+  async def test_closes_client_when_recall_raises(self, gates, writer_client, service):
+    service.recall.side_effect = RuntimeError("index missing")
+
+    with pytest.raises(RuntimeError):
+      await recall_memory(
+        graph_id="kg_test",
+        request=MemoryRecallRequest(query="anything"),
+        current_user=_mock_user(),
+      )
+
+    writer_client.close.assert_awaited_once()
+
+
+@pytest.mark.unit
+class TestGates:
+  """Each gate must fire before any graph work happens -- a handler that
+  reached `_get_writer_client` would have already opened a connection to a
+  graph the caller may not be entitled to."""
+
+  @pytest.mark.asyncio
+  @pytest.mark.parametrize(
+    "handler,kwargs",
+    [
+      (list_memories, {}),
+      (get_memory, {"memory_id": "mem_1"}),
+      (recall_memory, {"request": MemoryRecallRequest(query="q")}),
+    ],
+  )
+  async def test_disabled_flag_returns_503(self, handler, kwargs):
+    with (
+      patch.object(env_config, "SEMANTIC_MEMORY_ENABLED", False),
+      patch(f"{MODULE}._get_writer_client", AsyncMock()) as mock_client,
+    ):
+      with pytest.raises(HTTPException) as exc:
+        await handler(graph_id="kg_test", current_user=_mock_user(), **kwargs)
+
+    assert exc.value.status_code == 503
+    mock_client.assert_not_awaited()
+
+  @pytest.mark.asyncio
+  @pytest.mark.parametrize(
+    "handler,kwargs",
+    [
+      (list_memories, {}),
+      (get_memory, {"memory_id": "mem_1"}),
+      (recall_memory, {"request": MemoryRecallRequest(query="q")}),
+    ],
+  )
+  async def test_shared_repository_is_forbidden(self, handler, kwargs):
+    with (
+      patch(f"{MODULE}._require_memory_enabled"),
+      patch(f"{MODULE}._get_writer_client", AsyncMock()) as mock_client,
+    ):
+      with pytest.raises(HTTPException) as exc:
+        await handler(graph_id="sec", current_user=_mock_user(), **kwargs)
+
+    assert exc.value.status_code == 403
+    mock_client.assert_not_awaited()
+
+  @pytest.mark.asyncio
+  @pytest.mark.parametrize(
+    "handler,kwargs",
+    [
+      (list_memories, {}),
+      (get_memory, {"memory_id": "mem_1"}),
+      (recall_memory, {"request": MemoryRecallRequest(query="q")}),
+    ],
+  )
+  async def test_graph_access_is_enforced(self, handler, kwargs):
+    denied = HTTPException(status_code=403, detail="No access to graph")
+    with (
+      patch(f"{MODULE}._require_memory_enabled"),
+      patch(f"{MODULE}._block_shared_repository"),
+      patch(f"{MODULE}._enforce_graph_access", side_effect=denied),
+      patch(f"{MODULE}._get_writer_client", AsyncMock()) as mock_client,
+    ):
+      with pytest.raises(HTTPException) as exc:
+        await handler(graph_id="kg_other", current_user=_mock_user(), **kwargs)
+
+    assert exc.value.status_code == 403
+    mock_client.assert_not_awaited()
+
+
+@pytest.mark.unit
+class TestGateHelpers:
+  def test_require_memory_enabled_passes_when_flag_set(self):
+    from robosystems.routers.graphs.memory import _require_memory_enabled
+
+    with patch.object(env_config, "SEMANTIC_MEMORY_ENABLED", True):
+      _require_memory_enabled()  # must not raise
+
+  def test_block_shared_repository_allows_customer_graph(self):
+    from robosystems.routers.graphs.memory import _block_shared_repository
+
+    _block_shared_repository("kg1a2b3c4d5e6f78")  # must not raise
+
+  def test_enforce_graph_access_closes_its_session(self):
+    """The helper opens a SessionFactory directly; a leak here exhausts the
+    platform-DB pool under load."""
+    from robosystems.routers.graphs.memory import _enforce_graph_access
+
+    session = MagicMock()
+    with (
+      patch(f"{MODULE}.SessionFactory", return_value=session),
+      patch(
+        "robosystems.middleware.billing.enforcement.require_graph_access"
+      ) as mock_require,
+    ):
+      _enforce_graph_access("kg_test", require_write=True)
+
+    mock_require.assert_called_once_with("kg_test", session, require_write=True)
+    session.close.assert_called_once()
+
+  def test_enforce_graph_access_closes_session_on_denial(self):
+    from robosystems.routers.graphs.memory import _enforce_graph_access
+
+    session = MagicMock()
+    with (
+      patch(f"{MODULE}.SessionFactory", return_value=session),
+      patch(
+        "robosystems.middleware.billing.enforcement.require_graph_access",
+        side_effect=HTTPException(status_code=403, detail="denied"),
+      ),
+    ):
+      with pytest.raises(HTTPException):
+        _enforce_graph_access("kg_test")
+
+    session.close.assert_called_once()


### PR DESCRIPTION
## Why these files

Rather than chase a repo-wide percentage, this targets the code where thin coverage carries real risk: the **graph API** — the service that actually holds customer data — plus the two modules sitting at **0% while serving live traffic**.

206 tests, **no production changes**.

| | Before | After |
| --- | --- | --- |
| `graph_api` | 70.4% | **75.1%** |
| Repo total | 76% | **77%** |

Per module:

| Module | Before | After |
| --- | --- | --- |
| `graph_api/core/migration_service.py` | 15% | **85%** |
| `routers/graphs/memory.py` | **0%** | **92%** |
| `entity_sync/extract.py` | **0%** | **100%** |
| `entity_sync/{utils,configs,jobs}.py` | **0%** | **100%** |
| `graph_api/routers/databases/vector_search.py` | 48% | **70%** |
| `graph_api/client/client.py` | 50% | **60%** |
| `.../tables/materialize.py` | 29% | **42%** |
| `entity_sync/load.py` | **0%** | **52%** |
| `entity_sync/transform.py` | **0%** | 24% ¹ |

¹ macOS-capped by the skip guard below; runs fully on Linux/CI.

## What the tests pin, rather than just executing lines

- **`migration_service`** — the export/import mutual-exclusion guards, including 8-thread contention proving exactly one caller acquires. These are the only thing preventing two migrations from operating on the same customer database concurrently, and they had **no tests at all**. Also the rollback that restores `.pre-migration` files when an import fails partway (without it the customer's graph is simply gone) and the 0.1% node-count drift tolerance.
- **memory router** — all three gates (feature flag, shared-repo block, graph access) fire *before* any writer client is opened, and the client is closed on every path including the 404 and the raising ones.
- **materialize helpers** — the `DECIMAL`→`DOUBLE` cast, positional-NULL handling that keeps `COPY` column counts aligned, the `from`/`to` pass-through for relationship tables, and the path-traversal guard on the keyset snapshot path.
- **vector_search HNSW** — `_validate_identifier` against injection-shaped table and column names. It's the only thing between URL input and interpolated Cypher.
- **`entity_sync`** — shared-node dedup collapsing repeated `Element` rows while leaving `Fact` rows alone (deduping those would silently drop customer data), and nodes staging before relationships so FK constraints hold.

## One skip guard, and why it probes

Importing `networkit` claims pyarrow's `file` URI scheme (commit `a5b7baad`), which breaks pyarrow **filesystem** operations — in-memory ones are fine. The SEC knowledge tests load networkit and sort earlier in a full run, so the transform tests that reach `pq.write_table(..., path)` inherit a poisoned process. Since `pytest.ini` sets `-x`, that would halt the entire suite.

The fixture **probes whether local-file I/O works** rather than sniffing `sys.modules`. The collision is macOS-only, so Linux/CI still executes these tests and keeps full coverage of the path, while a local run degrades to a clean skip.

Verified the production job is unaffected: `entity_sync` does not pull networkit even with enrichment enabled, so the `a5b7baad` fix holds and this is purely a test-suite concern.

## One characterisation finding

`_classify_operation` only inspects the final path segment, so `/databases/{id}/memory/boost` is labelled `other` and memory work is under-reported in the operation metrics. Dashboards only — no correctness impact. Left as-is and documented in the test rather than changed silently.

## Verification

- Full suite: **11,884 passed, 24 skipped** (was 11,677 / 15)
- CI (Linux): **11,788 passed, 19 skipped**, `Run tests` 410s — none of the new tests skip there, confirming the probe keeps CI coverage intact
- `basedpyright`: 0 errors · `ruff check` + `ruff format`: clean
- Every new file also run in isolation, to confirm the guarded tests genuinely pass when the process is clean

## Not in this PR

Coverage on the SEC ETL, Dagster wiring, and CLI tooling is left where it is. Those are the pools that would move a repo-wide number most, and they're also where unit tests simulate infrastructure rather than verify it — which is the failure mode that produced the LocalStack/moto bug fixed in #980.
