### PR TITLE
chore(ci): bump setup-uv to v8.3.2, the seasoned prior-major line

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -55,7 +55,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
 
       - name: Get current version
         id: current-version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -145,7 +145,7 @@ jobs:
 
       - name: Install uv (GitHub-hosted runners only)
         if: runner.os == 'Linux' && !contains(runner.name, 'robosystems')
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"


### PR DESCRIPTION
## Summary

Manual alternative to dependabot's #995 (setup-uv 7.6.0 → 9.0.0), per our dependency policy: dot-zero majors season before adoption.

- **v9.0.0 is ~2 weeks old** (its headline change — `prune-cache` defaulting off — trades PyPI load for higher Actions cache usage)
- **v8.3.2 is the mature line**: five releases over ~3.5 months
- **v8's breaking changes don't apply to us**: we pin by commit SHA (so the end of `@v8`-style tag publishing is moot) and don't use the removed custom manifest format
- Our only inputs (`enable-cache`, `cache-dependency-glob`) are unchanged across v7/v8/v9

Touches `test.yml` (exercised by this PR's own CI) and `create-release.yml`.

**Suggested merge timing: after tonight's release**, so the release pipeline isn't exercising two new action versions at once (setup-python v7 from #987 is already in tonight's cut).

🤖 Generated with [Claude Code](https://claude.com/claude-code)