### PR TITLE
chore(deps): upgrade lancedb 0.30.2 → 0.34.0, retire the pylance hold

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "boto3>=1.42.0,<2.0",
     # OLAP Staging/Vector/Graph Databases
     "duckdb==1.4.4",
-    "lancedb>=0.30.0,<0.31",  # hold: 0.33 routes table.to_pandas() through pylance (beta-only); upgrade separately
+    "lancedb>=0.34.0,<0.35",  # 0.34 made pylance an optional extra (unused here); 0.30<->0.36 format compat verified 2026-08-01
     "ladybug==0.18.1",
     # OLTP Database (Postgres)
     "alembic>=1.18.5,<2.0",

--- a/robosystems/graph_api/core/lance/manager.py
+++ b/robosystems/graph_api/core/lance/manager.py
@@ -162,6 +162,7 @@ class LanceManager:
     """
     import duckdb
     import lancedb
+    from lancedb.index import IvfPq
 
     if duckdb_path is None:
       from robosystems.config.storage.shared import get_staging_duckdb_path
@@ -244,9 +245,12 @@ class LanceManager:
           f"48 sub-vectors)..."
         )
         table.create_index(
-          metric="cosine",
-          num_partitions=num_partitions,
-          num_sub_vectors=48,
+          "vector",
+          config=IvfPq(
+            distance_type="cosine",
+            num_partitions=num_partitions,
+            num_sub_vectors=48,
+          ),
         )
         logger.info("IVF-PQ index build complete")
       else:

--- a/robosystems/graph_api/core/lance/memory_store.py
+++ b/robosystems/graph_api/core/lance/memory_store.py
@@ -141,7 +141,8 @@ class LanceMemoryStore:
       table_dir.mkdir(parents=True, exist_ok=True)
 
     db = lancedb.connect(str(table_dir))
-    if self.MEMORY_TABLE not in db.table_names():
+    # list_tables() returns a ListTablesResponse; membership lives on .tables
+    if self.MEMORY_TABLE not in db.list_tables().tables:
       if not create:
         return db, None
       table = db.create_table(self.MEMORY_TABLE, schema=self._schema())

--- a/uv.lock
+++ b/uv.lock
@@ -1780,7 +1780,7 @@ wheels = [
 
 [[package]]
 name = "lancedb"
-version = "0.30.2"
+version = "0.34.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "deprecation" },
@@ -1792,12 +1792,10 @@ dependencies = [
     { name = "tqdm" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/87/67b23006663be175c396ae8f7c6ac98bfa4728de5b5583016b8b8c54eb14/lancedb-0.30.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:3dd8cb9e2e25efb32c088b24b3fbc57f3f24a636f4b8ad4b287b1eb52f6b5075", size = 41720461, upload-time = "2026-03-31T22:42:32.853Z" },
-    { url = "https://files.pythonhosted.org/packages/78/68/b3b5f638f8de91de75751414114690cae9c294dc79d9ab2602f4562ed9df/lancedb-0.30.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f083d50b257f645bd5c4b295d693648ffb37640ce1e9d72f55041b1382f0dbd6", size = 43626135, upload-time = "2026-03-31T22:50:28.577Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/d1/ea8b74a8b56dd4925cc9cb9cc23c7d9675708a7f6b33d22136dc7bb34dbc/lancedb-0.30.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3aef5538db9cd82af79c90831035b4d67e9aa182ef73095a1b919caddf9bb7a5", size = 46619289, upload-time = "2026-03-31T22:55:02.242Z" },
-    { url = "https://files.pythonhosted.org/packages/74/4b/5bfeacf948cfc3452b286a792dcbbfaf04649ef0820e1d3790d47bf5527e/lancedb-0.30.2-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:8b161cb1da04ae6ad45afe10093cfe4107821d93e7712b50200c435d6f4c8a20", size = 43641193, upload-time = "2026-03-31T22:51:13.63Z" },
-    { url = "https://files.pythonhosted.org/packages/28/4c/a51af0ce1d18fd86afa3e8538a81abf5523d24632abe7665ce6795b8009d/lancedb-0.30.2-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:7fabc0f57944fd79ddef62ed8cf4df770654b172b1ad1019a999304fed3169f3", size = 46665361, upload-time = "2026-03-31T22:54:20.282Z" },
-    { url = "https://files.pythonhosted.org/packages/88/d0/7e44e8143ac2dae8979ba882cc33d4af7b8da4741fb0361497e69b4a4379/lancedb-0.30.2-cp39-abi3-win_amd64.whl", hash = "sha256:531da53002c1c6fda829afccc8ced3056ef58eb036f09ddb2b94a06877ecc66c", size = 50940681, upload-time = "2026-03-31T23:25:52.35Z" },
+    { url = "https://files.pythonhosted.org/packages/df/f7/5262b9aa593f790757163c0165ab0da1dda054758901bea7e4f02c9cb633/lancedb-0.34.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:c462f2e6f933cad659fd0179394eaab578acbc9151fe2ef41bc29b36ecca5058", size = 52654213, upload-time = "2026-07-02T17:13:31.102Z" },
+    { url = "https://files.pythonhosted.org/packages/69/99/05ea0d32229ebea695193ff20c15d6ecae25785ad82a9d4723d98832a284/lancedb-0.34.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:48829e88e708947d0520454ab9e4f8efa35f3e3626469eadd3a6e061b89cb223", size = 55434501, upload-time = "2026-07-02T17:13:34.81Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/4e/4325c13d5afa93c466428a5a0f168ad4d96f5eb4a77bbe7c5100d39c9897/lancedb-0.34.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:05ba8a5b58e064edfbe5be71b1abf2e411b4eaf295d1a173dcb1a55c5bfb5285", size = 58659359, upload-time = "2026-07-02T17:13:38.424Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/5d/8ca165f1386caf6c4d1c515afd52f345b66432264eecfdfb7fd33eefd9af/lancedb-0.34.0-cp39-abi3-win_amd64.whl", hash = "sha256:51cbc11808f9e3332819b9367c975b3a888541447a8e7bea09c57c852a279153", size = 63530726, upload-time = "2026-07-02T17:13:41.612Z" },
 ]
 
 [[package]]
@@ -3665,7 +3663,7 @@ requires-dist = [
     { name = "icebug", specifier = ">=12.0,<13.0" },
     { name = "intuit-oauth", specifier = ">=1.2.0,<2.0" },
     { name = "ladybug", specifier = "==0.18.1" },
-    { name = "lancedb", specifier = ">=0.30.0,<0.31" },
+    { name = "lancedb", specifier = ">=0.34.0,<0.35" },
     { name = "lxml", specifier = ">=6.1.0,<7.0" },
     { name = "moto", extras = ["s3"], marker = "extra == 'dev'", specifier = ">=5.2.2,<6.0" },
     { name = "numpy", specifier = ">=2.4.0,<3.0" },


### PR DESCRIPTION
## Summary

Deliberate upgrade replacing closed dependabot #992, after an empirical compatibility evaluation.

**The hold is obsolete:** `# hold: 0.33 routes table.to_pandas() through pylance (beta-only)` — in 0.34 pylance became an **optional extra**; a clean install pulls no pylance and no prereleases, and `to_pandas()` works without it (we never call it anyway — our surface is connect/open_table/create_table/create_index/search/add/merge_insert/delete).

**Format compatibility verified empirically, both directions** (scratch venvs, production-fidelity schemas for both workloads — the memory store's 384-dim fixed-size-list schema and the manager's `AS vector` IVF-PQ build):

| Test | Result |
|---|---|
| 0.30-written data: CRUD + KNN from 0.34 and 0.36 | ✅ |
| IVF-PQ index built by 0.30: searched + rebuilt by 0.34 | ✅ |
| Rollback: 0.30 reads everything 0.34/0.36 wrote | ✅ |

No export/import, no data migration, version rollback cannot strand AI-memory data.

## Changes

- `pyproject.toml` — `lancedb>=0.34.0,<0.35` (0.34 is a month seasoned; 0.36.0 is brand-new and can arrive via dependabot next cycle), hold comment replaced with the resolution note
- `memory_store.py` — `table_names()` → `list_tables().tables` (deprecated in 0.34; note the new call returns a `ListTablesResponse`, so a bare membership test against it would silently fail — caught by probing before coding)
- `manager.py` — old `create_index(metric=…)` signature → unified `create_index("vector", config=IvfPq(…))` on the dormant IVF-PQ build path; exact call exercised against 0.34 directly

## Testing

- `just test graph_api/core/lance` — 44 passed against 0.34.0
- `just test graph_api/routers/databases/test_vector_search.py` — 19 passed
- `just test-code` clean

No urgency — can merge in the normal release cadence after tonight's release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)