### PR TITLE
chore(deps): add pyarrow <25 ceiling as a deliberate hold

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ dependencies = [
     "icebug>=12.0,<13.0",
     "numpy>=2.4.0,<3.0",
     "pandas>=2.3.0,<3.0",
-    "pyarrow>=24.0.0",
+    "pyarrow>=24.0.0,<25",  # hold: 25 is a fresh major feeding the duckdb/ladybug arrow seams; bump deliberately, paired with icebug 13
     "rdflib>=7.0.0,<8.0",
     # External API Integrations
     "intuit-oauth>=1.2.0,<2.0",

--- a/uv.lock
+++ b/uv.lock
@@ -3679,7 +3679,7 @@ requires-dist = [
     { name = "pillow", specifier = ">=12.3.0" },
     { name = "psutil", specifier = ">=7.2.1,<8.0" },
     { name = "psycopg2-binary", specifier = ">=2.9.0,<3.0" },
-    { name = "pyarrow", specifier = ">=24.0.0" },
+    { name = "pyarrow", specifier = ">=24.0.0,<25" },
     { name = "pydantic", extras = ["email"], specifier = ">=2.13.4,<3.0" },
     { name = "pyjwt", specifier = ">=2.10.0,<3.0" },
     { name = "pyshacl", specifier = ">=0.26,<0.31" },


### PR DESCRIPTION
## Summary

Follow-up to closing #1007: icebug 13.0 requires pyarrow>=25, and because our `pyarrow>=24.0.0` pin had **no upper bound**, the three-week-old pyarrow 25.0.0 major would have ridden in silently as transitive cargo. pyarrow feeds the highest-blast-radius seams in the stack (DuckDB staging interop, the graph materialization arrow boundary, dbt-duckdb, lancedb), so majors there get taken deliberately per the dependency policy.

## Changes

- `pyproject.toml` — `pyarrow>=24.0.0,<25` with a `# hold:` comment naming the reason and the exit path (deliberate paired bump: icebug 13 + pyarrow 25 + staging materialization smoke, planned next cycle)
- `uv.lock` — constraint metadata only; resolution unchanged (stays 24.0.0)

## Testing

- `just test-code` clean; lock resolution verified unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)