### PR TITLE
chore(infra): HTTPS-only S3 bucket policies + RDS pgaudit

### DIFF
--- a/cloudformation/audit.yaml
+++ b/cloudformation/audit.yaml
@@ -78,6 +78,24 @@ Resources:
         - Key: CreatedBy
           Value: CloudFormation
 
+  AuditBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref AuditBucket
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          # Deny all non-HTTPS requests
+          - Effect: Deny
+            Principal: "*"
+            Action: "s3:*"
+            Resource:
+              - !Sub ${AuditBucket.Arn}/*
+              - !GetAtt AuditBucket.Arn
+            Condition:
+              Bool:
+                "aws:SecureTransport": "false"
+
   # Error/diagnostics stream for the Firehose delivery (short retention).
   FirehoseLogGroup:
     Type: AWS::Logs::LogGroup

--- a/cloudformation/cloudtrail.yaml
+++ b/cloudformation/cloudtrail.yaml
@@ -98,6 +98,9 @@ Resources:
             ExpirationInDays: !Ref LogRetentionDays
       VersioningConfiguration:
         Status: Enabled
+      # Object Lock (governance mode) is enabled on the existing bucket via the
+      # S3 API, not here: CloudFormation's ObjectLockEnabled property requires
+      # bucket replacement, which a retained, name-pinned bucket cannot do.
       Tags:
         - Key: Name
           Value: !Sub "${ServiceTag}-cloudtrail-${Environment}"
@@ -133,6 +136,16 @@ Resources:
             Condition:
               StringEquals:
                 "s3:x-amz-acl": bucket-owner-full-control
+          - Sid: DenyInsecureTransport
+            Effect: Deny
+            Principal: "*"
+            Action: "s3:*"
+            Resource:
+              - !Sub "${CloudTrailBucket.Arn}/*"
+              - !GetAtt CloudTrailBucket.Arn
+            Condition:
+              Bool:
+                "aws:SecureTransport": "false"
 
   # CloudTrail - Minimalistic configuration
   CloudTrail:

--- a/cloudformation/postgres.yaml
+++ b/cloudformation/postgres.yaml
@@ -443,6 +443,11 @@ Resources:
       Family: postgres16
       Parameters:
         rds.force_ssl: "1"
+        # pgaudit session auditing (DDL + role/privilege changes). The library
+        # list keeps RDS's default pg_stat_statements. shared_preload_libraries
+        # is static: it sits in pending-reboot until the instance is rebooted.
+        shared_preload_libraries: "pg_stat_statements,pgaudit"
+        pgaudit.log: "ddl,role"
       Tags:
         - Key: Name
           Value: !Sub ${DBInstanceName}-${Environment}-paramgroup

--- a/cloudformation/s3.yaml
+++ b/cloudformation/s3.yaml
@@ -95,6 +95,24 @@ Resources:
         - Key: CreatedBy
           Value: CloudFormation
 
+  S3BucketSharedRawPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref S3BucketSharedRaw
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          # Deny all non-HTTPS requests
+          - Effect: Deny
+            Principal: "*"
+            Action: "s3:*"
+            Resource:
+              - !Sub ${S3BucketSharedRaw.Arn}/*
+              - !GetAtt S3BucketSharedRaw.Arn
+            Condition:
+              Bool:
+                "aws:SecureTransport": "false"
+
   # Shared Processed Data Bucket (parquet files for graph ingestion)
   S3BucketSharedProcessed:
     Type: AWS::S3::Bucket
@@ -136,6 +154,24 @@ Resources:
           Value: SharedProcessedData
         - Key: CreatedBy
           Value: CloudFormation
+
+  S3BucketSharedProcessedPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref S3BucketSharedProcessed
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          # Deny all non-HTTPS requests
+          - Effect: Deny
+            Principal: "*"
+            Action: "s3:*"
+            Resource:
+              - !Sub ${S3BucketSharedProcessed.Arn}/*
+              - !GetAtt S3BucketSharedProcessed.Arn
+            Condition:
+              Bool:
+                "aws:SecureTransport": "false"
 
   # User Data Bucket (user uploads, staging tables, exports)
   S3BucketUserData:
@@ -219,6 +255,24 @@ Resources:
           Value: UserData
         - Key: CreatedBy
           Value: CloudFormation
+
+  S3BucketUserDataPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref S3BucketUserData
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          # Deny all non-HTTPS requests
+          - Effect: Deny
+            Principal: "*"
+            Action: "s3:*"
+            Resource:
+              - !Sub ${S3BucketUserData.Arn}/*
+              - !GetAtt S3BucketUserData.Arn
+            Condition:
+              Bool:
+                "aws:SecureTransport": "false"
 
   # Public Data Repository Bucket (for all publicly accessible data including SEC textblocks)
   S3BucketPublicData:
@@ -461,6 +515,24 @@ Resources:
         - Key: CreatedBy
           Value: CloudFormation
 
+  S3BucketDeploymentNewPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref S3BucketDeploymentNew
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          # Deny all non-HTTPS requests
+          - Effect: Deny
+            Principal: "*"
+            Action: "s3:*"
+            Resource:
+              - !Sub ${S3BucketDeploymentNew.Arn}/*
+              - !GetAtt S3BucketDeploymentNew.Arn
+            Condition:
+              Bool:
+                "aws:SecureTransport": "false"
+
   # Logs Bucket (Dagster compute logs from ECS runs)
   S3BucketLogs:
     Type: AWS::S3::Bucket
@@ -507,6 +579,24 @@ Resources:
           Value: Logs
         - Key: CreatedBy
           Value: CloudFormation
+
+  S3BucketLogsPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref S3BucketLogs
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          # Deny all non-HTTPS requests
+          - Effect: Deny
+            Principal: "*"
+            Action: "s3:*"
+            Resource:
+              - !Sub ${S3BucketLogs.Arn}/*
+              - !GetAtt S3BucketLogs.Arn
+            Condition:
+              Bool:
+                "aws:SecureTransport": "false"
 
   # IAM Managed Policy for Graph Writers (read shared data, write sync buckets)
   GraphWriterS3Policy:

--- a/cloudformation/vpc.yaml
+++ b/cloudformation/vpc.yaml
@@ -822,6 +822,16 @@ Resources:
             Condition:
               StringEquals:
                 "aws:SourceAccount": !Ref AWS::AccountId
+          - Sid: DenyInsecureTransport
+            Effect: Deny
+            Principal: "*"
+            Action: "s3:*"
+            Resource:
+              - !Sub "${VPCFlowLogsBucket.Arn}/*"
+              - !GetAtt VPCFlowLogsBucket.Arn
+            Condition:
+              Bool:
+                "aws:SecureTransport": "false"
 
   # VPC Flow Log
   VPCFlowLog:


### PR DESCRIPTION
## Summary

- Add `aws:SecureTransport` deny statements to all S3 bucket policies that lacked them (shared-raw, shared-processed, user, deployment, logs, audit, cloudtrail, vpc-flow-logs — prod and staging pairs where applicable), matching the pattern already in place on the public-data bucket
- Enable `pgaudit` session auditing (`ddl,role`) in the RDS PostgreSQL parameter group, preserving the default `pg_stat_statements` preload

## Deploy notes

- Stacks to update after merge: `s3`, `audit`, `cloudtrail`, `vpc`, `postgres` (both environments)
- `shared_preload_libraries` is a static parameter: it sits in pending-reboot until each RDS instance is rebooted (staging first, prod in a quiet window)
- CloudTrail bucket Object Lock is enabled via the S3 API out-of-band — CloudFormation's `ObjectLockEnabled` requires bucket replacement, which a retained, name-pinned bucket cannot do (see template comment)

## Testing

- `just cf-lint` clean on all five templates

🤖 Generated with [Claude Code](https://claude.com/claude-code)