### PR TITLE
Link the Vanta Trust Center from README and SECURITY.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,7 @@ pip install robosystems-client
 
 - **[SECURITY.md](/SECURITY.md)** - Security control catalog with implementation references
 - **[Compliance](https://github.com/RoboFinSystems/robosystems/wiki/Security-and-Compliance)** - Compliance stacks, toggles, and SOC 2 posture
+- **[Trust Center](https://app.vanta.com/robosystems.ai/trust/lzitnsl1mo27b6zahy0ksy)** - Live compliance posture and audit artifacts
 
 ## API Reference
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,6 +2,8 @@
 
 Security controls implemented at the infrastructure, application, and data levels.
 
+Live compliance posture and audit artifacts are published in the [RoboSystems Trust Center](https://app.vanta.com/robosystems.ai/trust/lzitnsl1mo27b6zahy0ksy).
+
 ## Authentication and Access Control
 
 ### JWT Authentication
@@ -389,6 +391,7 @@ Production environment enforces at startup:
 
 - Security Team: security@robosystems.ai
 - Administrative Team: admin@robosystems.ai
+- Trust Center: https://app.vanta.com/robosystems.ai/trust/lzitnsl1mo27b6zahy0ksy
 
 ### Automated Response
 


### PR DESCRIPTION
## Summary

We now have a Vanta-hosted Trust Center (https://app.vanta.com/robosystems.ai/trust/lzitnsl1mo27b6zahy0ksy). This links it from the two public security surfaces in this repo:

- `SECURITY.md` — intro line plus the Incident Response contact list
- `README.md` — Security & Compliance documentation section

Companion changes: the shared footer gains a Trust Center entry (robosystems-core #16), and the in-flight security.txt PRs reference it as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)