### PR TITLE
chore(infra): retain bastion SSM session logs for 365 days

### DIFF
--- a/cloudformation/bastion.yaml
+++ b/cloudformation/bastion.yaml
@@ -219,7 +219,9 @@ Resources:
     UpdateReplacePolicy: Retain
     Properties:
       LogGroupName: !Sub /robosystems/${Environment}/bastion-host
-      RetentionInDays: 30
+      # SSM session activity is security-relevant: retained 365 days, unlike
+      # the 14-90 day operational log groups (audit-tier retention policy).
+      RetentionInDays: 365
       Tags:
         - Key: Name
           Value: !Sub robosystems-bastion-logs-${Environment}


### PR DESCRIPTION
## Summary

- Raise bastion-host log group retention from 30 to 365 days in `bastion.yaml` — SSM session activity is security-relevant (audit-tier), unlike the 14-90 day operational log groups
- Live values already set via `put-retention-policy` on both environments; this aligns the template so the next bastion stack deploy converges rather than reverting

🤖 Generated with [Claude Code](https://claude.com/claude-code)