### PR TITLE
chore(infra): pin OTel sidecar, codify registry PITR, drop unused ECR latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,9 @@ on:
       image_tag:
         description: "Image tag (git-sha based, use this for deployments)"
         value: ${{ jobs.docker.outputs.image_tag }}
+      image_ref:
+        description: "Digest-pinned reference (tag@sha256:...) — use for ECS task definitions"
+        value: ${{ jobs.docker.outputs.image_ref }}
       version_tag:
         description: "Version tag (v1.2.3) if release, empty otherwise (metadata only)"
         value: ${{ jobs.docker.outputs.version_tag }}
@@ -54,6 +57,7 @@ jobs:
     outputs:
       image: ${{ steps.resolve.outputs.image }}
       image_tag: ${{ steps.resolve.outputs.image_tag }}
+      image_ref: ${{ steps.digest.outputs.image_ref }}
       version_tag: ${{ steps.resolve.outputs.version_tag }}
       ecr_repository_url: ${{ steps.resolve.outputs.ecr_repository_url }}
       is_release: ${{ steps.resolve.outputs.is_release }}
@@ -232,21 +236,21 @@ jobs:
               --image-manifest "$MANIFEST" 2>/dev/null || echo "Tag ${VERSION_TAG} may already exist"
           fi
 
-          # Add latest tag for prod
-          if [[ "${{ inputs.environment }}" == "prod" ]]; then
-            aws ecr put-image \
-              --repository-name "$ECR_REPOSITORY" \
-              --image-tag "latest" \
-              --image-manifest "$MANIFEST" 2>/dev/null || echo "Tag latest may already exist"
-          fi
-
-      - name: Verify image exists
+      - name: Verify image and resolve digest
+        id: digest
         env:
           ECR_REPOSITORY: ${{ inputs.ecr_repository }}
           IMAGE_TAG: ${{ steps.resolve.outputs.image_tag }}
         run: |
-          aws ecr describe-images --repository-name "$ECR_REPOSITORY" --image-ids imageTag="$IMAGE_TAG" || exit 1
-          echo "✅ Image verified: ${IMAGE_TAG}"
+          # Digest-pinned reference (tag@sha256:...) for ECS task definitions,
+          # so deployed images are immutable content references.
+          DIGEST=$(aws ecr describe-images \
+            --repository-name "$ECR_REPOSITORY" \
+            --image-ids imageTag="$IMAGE_TAG" \
+            --query 'imageDetails[0].imageDigest' \
+            --output text) || exit 1
+          echo "image_ref=${IMAGE_TAG}@${DIGEST}" >> $GITHUB_OUTPUT
+          echo "✅ Image verified: ${IMAGE_TAG}@${DIGEST}"
 
   # Scan Docker image for vulnerabilities
   scan:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -173,11 +173,6 @@ jobs:
             TAGS="$TAGS -t ${ECR_URL}:${VERSION_TAG}"
           fi
 
-          # Add latest tag for prod environment
-          if [[ "${{ inputs.environment }}" == "prod" ]] && [[ "$IS_RELEASE" == "true" ]]; then
-            TAGS="$TAGS -t ${ECR_URL}:latest"
-          fi
-
           # Docker Hub tags - version pinned for releases
           if [[ "${{ inputs.publish_to_dockerhub }}" == "true" ]] && [[ "$IS_RELEASE" == "true" ]]; then
             echo "🚀 Publishing release to Docker Hub"

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -557,7 +557,7 @@ jobs:
       public_subnet_ids: ${{ needs.deploy-vpc.outputs.public_subnet_ids }}
       # Container & Application Configuration
       ecr_repository_url: ${{ needs.build.outputs.ecr_repository_url }}
-      ecr_image_tag: ${{ needs.build.outputs.image_tag }}
+      ecr_image_tag: ${{ needs.build.outputs.image_ref }}
       # ECS & Compute Configuration
       cpu: ${{ vars.API_CPU_PROD || '512' }}
       memory: ${{ vars.API_MEMORY_PROD || '1024' }}
@@ -638,7 +638,7 @@ jobs:
       subnet_ids: ${{ needs.deploy-vpc.outputs.private_subnet_ids }}
       # Container & Application Configuration
       ecr_repository_url: ${{ needs.build.outputs.ecr_repository_url }}
-      ecr_image_tag: ${{ needs.build.outputs.image_tag }}
+      ecr_image_tag: ${{ needs.build.outputs.image_ref }}
       # Fargate Configuration
       daemon_cpu: ${{ vars.DAGSTER_DAEMON_CPU_PROD || '1024' }}
       daemon_memory: ${{ vars.DAGSTER_DAEMON_MEMORY_PROD || '2048' }}

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -574,7 +574,7 @@ jobs:
       public_subnet_ids: ${{ needs.deploy-vpc.outputs.public_subnet_ids }}
       # Container & Application Configuration
       ecr_repository_url: ${{ needs.build.outputs.ecr_repository_url }}
-      ecr_image_tag: ${{ needs.build.outputs.image_tag }}
+      ecr_image_tag: ${{ needs.build.outputs.image_ref }}
       # ECS & Compute Configuration
       cpu: ${{ vars.API_CPU_STAGING || '512' }}
       memory: ${{ vars.API_MEMORY_STAGING || '1024' }}
@@ -655,7 +655,7 @@ jobs:
       subnet_ids: ${{ needs.deploy-vpc.outputs.private_subnet_ids }}
       # Container & Application Configuration
       ecr_repository_url: ${{ needs.build.outputs.ecr_repository_url }}
-      ecr_image_tag: ${{ needs.build.outputs.image_tag }}
+      ecr_image_tag: ${{ needs.build.outputs.image_ref }}
       # Fargate Configuration
       daemon_cpu: ${{ vars.DAGSTER_DAEMON_CPU_STAGING || '1024' }}
       daemon_memory: ${{ vars.DAGSTER_DAEMON_MEMORY_STAGING || '2048' }}

--- a/cloudformation/api.yaml
+++ b/cloudformation/api.yaml
@@ -763,7 +763,7 @@ Resources:
         - !If
           - HasObservabilityStack
           - Name: adot-collector
-            Image: public.ecr.aws/aws-observability/aws-otel-collector:latest
+            Image: public.ecr.aws/aws-observability/aws-otel-collector:v0.49.0
             Essential: true
             Environment:
               - Name: AWS_PROMETHEUS_ENDPOINT

--- a/cloudformation/graph-infra.yaml
+++ b/cloudformation/graph-infra.yaml
@@ -83,6 +83,8 @@ Resources:
               KeyType: RANGE
           Projection:
             ProjectionType: ALL
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
       Tags:
         - Key: Environment
           Value: !Ref Environment
@@ -124,6 +126,8 @@ Resources:
               KeyType: HASH
           Projection:
             ProjectionType: ALL
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
       Tags:
         - Key: Environment
           Value: !Ref Environment


### PR DESCRIPTION
## Summary

- Pin `aws-otel-collector` sidecar to `v0.49.0` (current `:latest` resolution — no runtime change)
- **Digest-pin ECS task-def images**: `build.yml` resolves the pushed image's digest (in the existing verify step) and outputs `image_ref` (`tag@sha256:...`); api + dagster deploy jobs pass it as `ECRImageTag`, so `!Sub ${ECRRepositoryUrl}:${ECRImageTag}` yields an immutable content reference
- Add `PointInTimeRecoverySpecification` to graph + instance registry tables in `graph-infra.yaml`, matching the volume registry; PITR was enabled live on 2026-08-01, this makes fresh/fork deploys inherit it
- Remove both ECR `:latest` pushes (buildx tag on release builds and `put-image` on the skip-build path) — nothing consumes them; Docker Hub `:latest` and the `:prod`/`:staging` env tags used by graph container refresh are unchanged

## Deploy notes

- First staging deploy after merge validates the digest-pinned flow end to end; prod follows
- `api`, `dagster`, and `graph-infra` stacks pick these up on the next deploy; no reboots or refreshes needed

## Testing

- `just cf-lint` clean on api + graph-infra; api.yaml at 50,393 bytes (ceiling 51,200)

🤖 Generated with [Claude Code](https://claude.com/claude-code)