### PR TITLE
chore(setup): add access key rotation to bedrock.sh

### DIFF
--- a/bin/setup/bedrock.sh
+++ b/bin/setup/bedrock.sh
@@ -7,7 +7,12 @@
 # Updates .env with the credentials.
 #
 # USAGE:
-#   just setup-bedrock
+#   just setup-bedrock            # initial setup (user, policy, key, .env)
+#   just setup-bedrock rotate     # rotate the access key and update .env
+#
+# ROTATION: creates a new key, updates .env, verifies the new key works,
+# then deactivates the old key. The deactivated key is deleted on the NEXT
+# rotation (two-key cycle), so there is always a working fallback.
 #
 # PREREQUISITES:
 #   - Bootstrap completed first (just bootstrap)
@@ -308,10 +313,99 @@ show_summary() {
 }
 
 # =============================================================================
+# KEY ROTATION
+# =============================================================================
+
+rotate_access_key() {
+    print_header "Bedrock Access Key Rotation"
+
+    check_prerequisites
+
+    # Inventory existing keys: "AccessKeyId Status" per line
+    KEY_ROWS=$(aws_cmd iam list-access-keys --user-name "$IAM_USER_NAME" \
+        --query 'AccessKeyMetadata[*].[AccessKeyId,Status]' --output text)
+
+    if [ -z "$KEY_ROWS" ]; then
+        print_error "No access keys exist for ${IAM_USER_NAME}"
+        print_info "Run 'just setup-bedrock' for initial setup"
+        exit 1
+    fi
+
+    KEY_COUNT=$(echo "$KEY_ROWS" | wc -l | tr -d ' ')
+
+    # IAM allows max 2 keys. If a previous rotation left an inactive key,
+    # delete it to make room; two active keys means state we didn't create.
+    if [ "$KEY_COUNT" -ge 2 ]; then
+        INACTIVE_KEY=$(echo "$KEY_ROWS" | awk '$2 == "Inactive" {print $1; exit}')
+        if [ -n "$INACTIVE_KEY" ]; then
+            print_step "Deleting inactive key from previous rotation: ${INACTIVE_KEY}"
+            aws_cmd iam delete-access-key --user-name "$IAM_USER_NAME" --access-key-id "$INACTIVE_KEY"
+            print_success "Deleted ${INACTIVE_KEY}"
+        else
+            print_error "Two ACTIVE keys exist — cannot rotate safely."
+            print_info "Determine which key is unused (aws iam get-access-key-last-used),"
+            print_info "delete it manually, then re-run: just setup-bedrock rotate"
+            exit 1
+        fi
+    fi
+
+    OLD_KEY_ID=$(aws_cmd iam list-access-keys --user-name "$IAM_USER_NAME" \
+        --query 'AccessKeyMetadata[?Status==`Active`].AccessKeyId | [0]' --output text)
+    print_info "Rotating out active key: ${OLD_KEY_ID}"
+
+    print_step "Creating replacement access key..."
+    KEY_OUTPUT=$(aws_cmd iam create-access-key --user-name "$IAM_USER_NAME" --output json)
+    NEW_ACCESS_KEY_ID=$(echo "$KEY_OUTPUT" | jq -r '.AccessKey.AccessKeyId')
+    NEW_SECRET_ACCESS_KEY=$(echo "$KEY_OUTPUT" | jq -r '.AccessKey.SecretAccessKey')
+    print_success "Created access key: ${NEW_ACCESS_KEY_ID}"
+
+    update_env_file
+
+    # New IAM keys are eventually consistent — verify before touching the old one
+    print_step "Verifying new key (IAM propagation can take ~10s)..."
+    VERIFIED=false
+    for _ in 1 2 3 4 5 6; do
+        if AWS_ACCESS_KEY_ID="$NEW_ACCESS_KEY_ID" \
+           AWS_SECRET_ACCESS_KEY="$NEW_SECRET_ACCESS_KEY" \
+           AWS_SESSION_TOKEN="" AWS_PROFILE="" \
+           aws sts get-caller-identity --output text &>/dev/null; then
+            VERIFIED=true
+            break
+        fi
+        sleep 5
+    done
+
+    if [ "$VERIFIED" != "true" ]; then
+        print_error "New key failed verification after 30s — old key left ACTIVE"
+        print_info "The .env now holds the new key; investigate before deactivating ${OLD_KEY_ID}"
+        exit 1
+    fi
+    print_success "New key verified"
+
+    print_step "Deactivating old key: ${OLD_KEY_ID}"
+    aws_cmd iam update-access-key --user-name "$IAM_USER_NAME" \
+        --access-key-id "$OLD_KEY_ID" --status Inactive
+    print_success "Old key deactivated (deleted automatically on next rotation)"
+
+    print_header "Rotation Complete"
+    echo -e "${CYAN}New Access Key:${NC} ${NEW_ACCESS_KEY_ID}"
+    echo -e "${CYAN}Old Key:${NC} ${OLD_KEY_ID} (Inactive)"
+    echo ""
+    echo "Restart Docker to pick up the new credentials:"
+    echo "   just restart"
+    echo ""
+}
+
+# =============================================================================
 # MAIN
 # =============================================================================
 
 main() {
+    if [[ "${1:-}" == "rotate" ]]; then
+        rotate_access_key
+        exit 0
+    fi
+
     print_header "Bedrock Local Development Setup"
 
     echo "This script creates an IAM user with Bedrock access for local Docker development."

--- a/justfile
+++ b/justfile
@@ -294,8 +294,9 @@ setup-gha:
     @bin/setup/gha.sh
 
 # Bedrock local development setup (creates IAM user, updates .env)
-setup-bedrock:
-    @bin/setup/bedrock.sh
+# Pass "rotate" to rotate the access key: just setup-bedrock rotate
+setup-bedrock *args:
+    @bin/setup/bedrock.sh {{ args }}
 
 # Apply the operational ECR image lifecycle policy (idempotent reconcile)
 # Single source of truth: bin/setup/ecr-lifecycle-policy.json (also applied by


### PR DESCRIPTION
## Summary

- `just setup-bedrock rotate` — rotates the RoboSystemsBedrockDev access key end to end: create replacement → update `.env` → verify via STS (propagation retries) → deactivate old key
- Two-key cycle: the deactivated key is deleted automatically on the next rotation, so there's always a working fallback; refuses to proceed if two active keys exist
- Keeps the IAM key-age compliance test satisfiable with one command going forward

## Testing

- `bash -n` clean; justfile parses; rotation path exercised against the live user next rotation

🤖 Generated with [Claude Code](https://claude.com/claude-code)