### PR TITLE
chore(infra): CloudWatch alarm coverage across ALB, RDS, DynamoDB, Lambda, bastion

### DIFF
--- a/cloudformation/api.yaml
+++ b/cloudformation/api.yaml
@@ -1435,3 +1435,14 @@ Outputs:
     Value: !GetAtt ApiNamespace.Arn
     Export:
       Name: !Sub ${AWS::StackName}-ServiceDiscoveryNamespaceArn
+
+  # ALB dimensions for alarms defined in security.yaml (at inline-size ceiling here)
+  ApiLoadBalancerFullName:
+    Value: !GetAtt ApiALB.LoadBalancerFullName
+    Export:
+      Name: !Sub ${AWS::StackName}-LoadBalancerFullName
+
+  ApiTargetGroupFullName:
+    Value: !GetAtt ApiTargetGroup.TargetGroupFullName
+    Export:
+      Name: !Sub ${AWS::StackName}-TargetGroupFullName

--- a/cloudformation/bastion.yaml
+++ b/cloudformation/bastion.yaml
@@ -354,6 +354,29 @@ Resources:
         Timeout: PT10M
         Count: 1
 
+  # CPU alarm: only evaluates while the bastion runs (it auto-stops after
+  # init), so missing data stays OK rather than alarming on a stopped host
+  BastionCpuHighAlarm:
+    Type: AWS::CloudWatch::Alarm
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      AlarmName: !Sub robosystems-bastion-${Environment}-cpu-high
+      AlarmDescription: Bastion host CPU is unexpectedly high
+      MetricName: CPUUtilization
+      Namespace: AWS/EC2
+      Dimensions:
+        - Name: InstanceId
+          Value: !Ref BastionHostEC2Instance
+      Statistic: Average
+      Period: 300
+      EvaluationPeriods: 3
+      Threshold: 90
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - !Sub arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:robosystems-${Environment}-security-alerts
+
 Outputs:
   BastionHostId:
     Description: Instance ID of the bastion host (use with SSM)

--- a/cloudformation/graph-infra.yaml
+++ b/cloudformation/graph-infra.yaml
@@ -524,6 +524,169 @@ Resources:
       AlarmActions:
         - !Ref InfraAlertTopic
 
+  # Registry table throttle alarms (tables are on-demand; throttles signal
+  # burst beyond adaptive capacity or a hot key)
+  InstanceRegistryReadThrottleAlarm:
+    Type: AWS::CloudWatch::Alarm
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      AlarmName: !Sub robosystems-graph-${Environment}-instance-registry-read-throttle
+      MetricName: ReadThrottleEvents
+      Namespace: AWS/DynamoDB
+      Dimensions:
+        - Name: TableName
+          Value: !Ref InstanceRegistry
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 0
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - !Ref InfraAlertTopic
+
+  InstanceRegistryWriteThrottleAlarm:
+    Type: AWS::CloudWatch::Alarm
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      AlarmName: !Sub robosystems-graph-${Environment}-instance-registry-write-throttle
+      MetricName: WriteThrottleEvents
+      Namespace: AWS/DynamoDB
+      Dimensions:
+        - Name: TableName
+          Value: !Ref InstanceRegistry
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 0
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - !Ref InfraAlertTopic
+
+  GraphRegistryReadThrottleAlarm:
+    Type: AWS::CloudWatch::Alarm
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      AlarmName: !Sub robosystems-graph-${Environment}-graph-registry-read-throttle
+      MetricName: ReadThrottleEvents
+      Namespace: AWS/DynamoDB
+      Dimensions:
+        - Name: TableName
+          Value: !Ref GraphRegistry
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 0
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - !Ref InfraAlertTopic
+
+  GraphRegistryWriteThrottleAlarm:
+    Type: AWS::CloudWatch::Alarm
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      AlarmName: !Sub robosystems-graph-${Environment}-graph-registry-write-throttle
+      MetricName: WriteThrottleEvents
+      Namespace: AWS/DynamoDB
+      Dimensions:
+        - Name: TableName
+          Value: !Ref GraphRegistry
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 0
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - !Ref InfraAlertTopic
+
+  VolumeRegistryReadThrottleAlarm:
+    Type: AWS::CloudWatch::Alarm
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      AlarmName: !Sub robosystems-graph-${Environment}-volume-registry-read-throttle
+      MetricName: ReadThrottleEvents
+      Namespace: AWS/DynamoDB
+      Dimensions:
+        - Name: TableName
+          Value: !Ref VolumeRegistry
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 0
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - !Ref InfraAlertTopic
+
+  VolumeRegistryWriteThrottleAlarm:
+    Type: AWS::CloudWatch::Alarm
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      AlarmName: !Sub robosystems-graph-${Environment}-volume-registry-write-throttle
+      MetricName: WriteThrottleEvents
+      Namespace: AWS/DynamoDB
+      Dimensions:
+        - Name: TableName
+          Value: !Ref VolumeRegistry
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 0
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - !Ref InfraAlertTopic
+
+  # Error alarms for this stack's Lambdas (key generation + secret rotation)
+  ApiKeyGeneratorErrorsAlarm:
+    Type: AWS::CloudWatch::Alarm
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      AlarmName: !Sub ${AWS::StackName}-api-key-generator-errors
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Dimensions:
+        - Name: FunctionName
+          Value: !Sub "${AWS::StackName}-api-key-generator"
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 0
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - !Ref InfraAlertTopic
+
+  ApiSecretRotationErrorsAlarm:
+    Type: AWS::CloudWatch::Alarm
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      AlarmName: !Sub ${AWS::StackName}-api-secret-rotation-errors
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Dimensions:
+        - Name: FunctionName
+          Value: !Sub "${AWS::StackName}-api-secret-rotation"
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 0
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - !Ref InfraAlertTopic
+
   # ===== CloudWatch Log Groups =====
   # Unified log group for all Graph API instances
   # Log streams are partitioned by: {cluster_tier}/{instance_id}/{node_type}

--- a/cloudformation/graph-ladybug-replicas.yaml
+++ b/cloudformation/graph-ladybug-replicas.yaml
@@ -778,6 +778,27 @@ Resources:
         - !Ref ReplicaAlertTopic
       TreatMissingData: notBreaching
 
+  # 5xx spike alarm: distinguishes replica-side failures from the healthy-host
+  # and latency signals above
+  Replica5xxAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub robosystems-shared-replicas-${Environment}-5xx-spike
+      AlarmDescription: Alert on elevated 5xx responses from the replicas ALB
+      MetricName: HTTPCode_ELB_5XX_Count
+      Namespace: AWS/ApplicationELB
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 25
+      ComparisonOperator: GreaterThanThreshold
+      Dimensions:
+        - Name: LoadBalancer
+          Value: !GetAtt ReplicaALB.LoadBalancerFullName
+      AlarmActions:
+        - !Ref ReplicaAlertTopic
+      TreatMissingData: notBreaching
+
 Outputs:
   ALBDNSName:
     Description: DNS name of the shared replicas ALB

--- a/cloudformation/graph-volumes.yaml
+++ b/cloudformation/graph-volumes.yaml
@@ -499,6 +499,26 @@ Resources:
       AlarmActions:
         - !Ref VolumeAlertTopic
 
+  # Detachment Lambda Errors Alarm
+  VolumeDetachmentErrorsAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "robosystems-graph-volumes-${Environment}-detachment-errors"
+      AlarmDescription: Alert on volume detachment Lambda errors
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Dimensions:
+        - Name: FunctionName
+          Value: !Sub "${AWS::StackName}-volume-detachment"
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 0
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - !Ref VolumeAlertTopic
+
   # ========================================
   # LAMBDA LIVENESS ALARMS
   # ========================================

--- a/cloudformation/postgres.yaml
+++ b/cloudformation/postgres.yaml
@@ -680,6 +680,70 @@ Resources:
         - Key: CreatedBy
           Value: CloudFormation
 
+  # CloudWatch alarms for instance health (CPU, memory, disk queue)
+  RDSCpuHighAlarm:
+    Type: AWS::CloudWatch::Alarm
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      ActionsEnabled: true
+      AlarmName: !Sub robosystems-postgres-${Environment}-cpu-high
+      Namespace: AWS/RDS
+      MetricName: CPUUtilization
+      Dimensions:
+        - Value: !Sub ${DBInstanceName}-${Environment}
+          Name: DBInstanceIdentifier
+      Statistic: Average
+      Period: 300
+      EvaluationPeriods: 3
+      Threshold: 90
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - !Ref PostgresAlertTopic
+
+  RDSFreeableMemoryLowAlarm:
+    Type: AWS::CloudWatch::Alarm
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      ActionsEnabled: true
+      AlarmName: !Sub robosystems-postgres-${Environment}-memory-low
+      Namespace: AWS/RDS
+      MetricName: FreeableMemory
+      Dimensions:
+        - Value: !Sub ${DBInstanceName}-${Environment}
+          Name: DBInstanceIdentifier
+      Statistic: Minimum
+      Period: 300
+      EvaluationPeriods: 3
+      Threshold: 268435456
+      ComparisonOperator: LessThanThreshold
+      TreatMissingData: breaching
+      AlarmActions:
+        - !Ref PostgresAlertTopic
+
+  RDSDiskQueueHighAlarm:
+    Type: AWS::CloudWatch::Alarm
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      ActionsEnabled: true
+      AlarmName: !Sub robosystems-postgres-${Environment}-disk-queue-high
+      Namespace: AWS/RDS
+      MetricName: DiskQueueDepth
+      Dimensions:
+        - Value: !Sub ${DBInstanceName}-${Environment}
+          Name: DBInstanceIdentifier
+      Statistic: Average
+      Period: 300
+      EvaluationPeriods: 3
+      Threshold: 8
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - !Ref PostgresAlertTopic
+
   # CloudWatch alarm for low storage space
   RDSStorageLowAlarm:
     Type: AWS::CloudWatch::Alarm

--- a/cloudformation/security.yaml
+++ b/cloudformation/security.yaml
@@ -538,6 +538,210 @@ Resources:
       AlarmActions:
         - !Sub arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:robosystems-staging-security-alerts
 
+  # ── API ALB + operational Lambda alarms ────────────────────────────────────
+  # Placed here (not api.yaml) because api.yaml sits at the 51,200-byte inline
+  # ceiling. ALB dimensions come from exports the API stacks publish, so BOTH
+  # API stacks must be deployed (creating the exports) before the first
+  # security-stack update that includes these alarms.
+  ApiAlbUnhealthyHostsAlarmProd:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: robosystems-prod-api-alb-unhealthy-hosts
+      AlarmDescription: API ALB target reporting unhealthy
+      MetricName: UnHealthyHostCount
+      Namespace: AWS/ApplicationELB
+      Statistic: Maximum
+      Period: 60
+      EvaluationPeriods: 5
+      Threshold: 0
+      ComparisonOperator: GreaterThanThreshold
+      Dimensions:
+        - Name: LoadBalancer
+          Value: !ImportValue RoboSystemsAPIProd-LoadBalancerFullName
+        - Name: TargetGroup
+          Value: !ImportValue RoboSystemsAPIProd-TargetGroupFullName
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - !Sub arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:robosystems-prod-security-alerts
+
+  ApiAlbHighLatencyAlarmProd:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: robosystems-prod-api-alb-high-latency
+      AlarmDescription: API ALB target response time is high
+      MetricName: TargetResponseTime
+      Namespace: AWS/ApplicationELB
+      Statistic: Average
+      Period: 60
+      EvaluationPeriods: 5
+      Threshold: 2
+      ComparisonOperator: GreaterThanThreshold
+      Dimensions:
+        - Name: LoadBalancer
+          Value: !ImportValue RoboSystemsAPIProd-LoadBalancerFullName
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - !Sub arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:robosystems-prod-security-alerts
+
+  ApiAlb5xxAlarmProd:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: robosystems-prod-api-alb-5xx-spike
+      AlarmDescription: Elevated 5xx responses from the API ALB
+      MetricName: HTTPCode_ELB_5XX_Count
+      Namespace: AWS/ApplicationELB
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 25
+      ComparisonOperator: GreaterThanThreshold
+      Dimensions:
+        - Name: LoadBalancer
+          Value: !ImportValue RoboSystemsAPIProd-LoadBalancerFullName
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - !Sub arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:robosystems-prod-security-alerts
+
+  ApiAlbUnhealthyHostsAlarmStaging:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: robosystems-staging-api-alb-unhealthy-hosts
+      AlarmDescription: API ALB target reporting unhealthy
+      MetricName: UnHealthyHostCount
+      Namespace: AWS/ApplicationELB
+      Statistic: Maximum
+      Period: 60
+      EvaluationPeriods: 5
+      Threshold: 0
+      ComparisonOperator: GreaterThanThreshold
+      Dimensions:
+        - Name: LoadBalancer
+          Value: !ImportValue RoboSystemsAPIStaging-LoadBalancerFullName
+        - Name: TargetGroup
+          Value: !ImportValue RoboSystemsAPIStaging-TargetGroupFullName
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - !Sub arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:robosystems-staging-security-alerts
+
+  ApiAlbHighLatencyAlarmStaging:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: robosystems-staging-api-alb-high-latency
+      AlarmDescription: API ALB target response time is high
+      MetricName: TargetResponseTime
+      Namespace: AWS/ApplicationELB
+      Statistic: Average
+      Period: 60
+      EvaluationPeriods: 5
+      Threshold: 2
+      ComparisonOperator: GreaterThanThreshold
+      Dimensions:
+        - Name: LoadBalancer
+          Value: !ImportValue RoboSystemsAPIStaging-LoadBalancerFullName
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - !Sub arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:robosystems-staging-security-alerts
+
+  ApiAlb5xxAlarmStaging:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: robosystems-staging-api-alb-5xx-spike
+      AlarmDescription: Elevated 5xx responses from the API ALB
+      MetricName: HTTPCode_ELB_5XX_Count
+      Namespace: AWS/ApplicationELB
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 25
+      ComparisonOperator: GreaterThanThreshold
+      Dimensions:
+        - Name: LoadBalancer
+          Value: !ImportValue RoboSystemsAPIStaging-LoadBalancerFullName
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - !Sub arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:robosystems-staging-security-alerts
+
+  # Admin-key-rotation Lambdas are defined in api.yaml (same ceiling constraint);
+  # function names are deterministic stack-name prefixes.
+  AdminKeyRotationErrorsAlarmProd:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: robosystems-prod-admin-key-rotation-errors
+      AlarmDescription: Admin key rotation Lambda reported errors
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Dimensions:
+        - Name: FunctionName
+          Value: RoboSystemsAPIProd-admin-key-rotation
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 0
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - !Sub arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:robosystems-prod-security-alerts
+
+  AdminKeyRotationErrorsAlarmStaging:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: robosystems-staging-admin-key-rotation-errors
+      AlarmDescription: Admin key rotation Lambda reported errors
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Dimensions:
+        - Name: FunctionName
+          Value: RoboSystemsAPIStaging-admin-key-rotation
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 0
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - !Sub arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:robosystems-staging-security-alerts
+
+  # CUR pipeline Lambdas live in the AWS-provided RoboSystemsCUR stack (not in
+  # this repo), so their generated names are literals here. They are stable
+  # unless that stack is recreated — update these two values if it ever is.
+  CurInitializerErrorsAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: robosystems-cur-initializer-errors
+      AlarmDescription: CUR Athena initializer Lambda reported errors
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Dimensions:
+        - Name: FunctionName
+          Value: RoboSystemsCUR-AWSCURInitializer-dhIFEKWJGt2f
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 0
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - !Sub arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:robosystems-prod-security-alerts
+
+  CurNotificationErrorsAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: robosystems-cur-notification-errors
+      AlarmDescription: CUR S3 notification Lambda reported errors
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Dimensions:
+        - Name: FunctionName
+          Value: RoboSystemsCUR-AWSS3CURNotification-ZSi5BHYx7O2N
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 0
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - !Sub arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:robosystems-prod-security-alerts
+
 Outputs:
   GuardDutyDetectorId:
     Condition: GuardDutyOn


### PR DESCRIPTION
## Summary

24 new alarm resources, each placed in the stack that owns the resource it watches:

- **postgres.yaml**: RDS CPUUtilization (>90%), FreeableMemory (<256MB), DiskQueueDepth (>8) — alongside the existing FreeStorageSpace alarm, same topic
- **graph-infra.yaml**: read/write ThrottleEvents on all 3 registry tables + Errors on the api-key-generator and api-secret-rotation Lambdas
- **graph-volumes.yaml**: Errors on the volume-detachment Lambda (manager/monitor already covered)
- **graph-ladybug-replicas.yaml**: ALB 5xx spike (healthy-hosts + latency already covered)
- **bastion.yaml**: CPU high — evaluates only while the bastion runs (auto-stop design), notBreaching on missing data
- **security.yaml**: API ALB unhealthy-hosts/latency/5xx for both envs (via new `LoadBalancerFullName`/`TargetGroupFullName` exports from the API stacks), admin-key-rotation Lambda errors, and the two CUR-stack Lambdas (literal generated names — that stack is AWS-provided, not in this repo)

## Deploy notes

- **Ordering (one-time)**: deploy the `api` stacks (both envs) before the `security` stack — the security alarms import the new ALB exports
- api.yaml now at 50,768 bytes (ceiling 51,200 — 432 bytes headroom left)

## Testing

- `just cf-lint-all` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)