### PR TITLE
fix(infra): security-stack ALB alarm deploy deadlock + bedrock rotation verification

### DIFF
--- a/.github/workflows/deploy-vpc.yml
+++ b/.github/workflows/deploy-vpc.yml
@@ -415,8 +415,39 @@ jobs:
             SECURITY_ENV="${{ inputs.environment }}"
           fi
 
+          # Resolve API ALB/TG dimensions live from ELB APIs for the ALB alarms.
+          # Deliberately not CFN exports: a cross-stack import deadlocks the
+          # pipeline (security failure skips deploy-api, which would publish
+          # the exports). Missing ALBs resolve to "" and the alarms are skipped.
+          resolve_alb_dims() {
+            local ALB_ARN TG_ARN
+            ALB_ARN=$(aws elbv2 describe-load-balancers --names "$1" \
+              --query 'LoadBalancers[0].LoadBalancerArn' --output text 2>/dev/null) || true
+            if [ -z "$ALB_ARN" ] || [ "$ALB_ARN" = "None" ]; then
+              echo ""
+              return 0
+            fi
+            TG_ARN=$(aws elbv2 describe-target-groups --load-balancer-arn "$ALB_ARN" \
+              --query 'TargetGroups[0].TargetGroupArn' --output text 2>/dev/null) || true
+            if [ -z "$TG_ARN" ] || [ "$TG_ARN" = "None" ]; then
+              echo ""
+              return 0
+            fi
+            # LoadBalancerFullName = ARN resource part minus "loadbalancer/";
+            # TargetGroupFullName = ARN resource part as-is
+            echo "$(echo "$ALB_ARN" | cut -d: -f6 | sed 's|^loadbalancer/||') $(echo "$TG_ARN" | cut -d: -f6)"
+          }
+
+          read -r ALB_PROD TG_PROD <<< "$(resolve_alb_dims robosystems-api-prod-alb)" || true
+          read -r ALB_STAGING TG_STAGING <<< "$(resolve_alb_dims robosystems-api-staging-alb)" || true
+          echo "API ALB dims: prod='${ALB_PROD:-}' staging='${ALB_STAGING:-}'"
+
           SECURITY_PARAMS="ParameterKey=Environment,ParameterValue=$SECURITY_ENV \
-                      ParameterKey=EnableConfig,ParameterValue=${{ inputs.security_config_enabled }}"
+                      ParameterKey=EnableConfig,ParameterValue=${{ inputs.security_config_enabled }} \
+                      ParameterKey=ApiAlbFullNameProd,ParameterValue=${ALB_PROD:-} \
+                      ParameterKey=ApiTgFullNameProd,ParameterValue=${TG_PROD:-} \
+                      ParameterKey=ApiAlbFullNameStaging,ParameterValue=${ALB_STAGING:-} \
+                      ParameterKey=ApiTgFullNameStaging,ParameterValue=${TG_STAGING:-}"
 
           echo "AWS Config recorder enabled: ${{ inputs.security_config_enabled }}"
 

--- a/bin/setup/bedrock.sh
+++ b/bin/setup/bedrock.sh
@@ -365,9 +365,11 @@ rotate_access_key() {
     print_step "Verifying new key (IAM propagation can take ~10s)..."
     VERIFIED=false
     for _ in 1 2 3 4 5 6; do
-        if AWS_ACCESS_KEY_ID="$NEW_ACCESS_KEY_ID" \
+        # env -u, not VAR="": the AWS CLI treats an empty AWS_PROFILE as a
+        # real (empty-named) profile and errors instead of ignoring it
+        if env -u AWS_PROFILE -u AWS_SESSION_TOKEN \
+           AWS_ACCESS_KEY_ID="$NEW_ACCESS_KEY_ID" \
            AWS_SECRET_ACCESS_KEY="$NEW_SECRET_ACCESS_KEY" \
-           AWS_SESSION_TOKEN="" AWS_PROFILE="" \
            aws sts get-caller-identity --output text &>/dev/null; then
             VERIFIED=true
             break

--- a/cloudformation/api.yaml
+++ b/cloudformation/api.yaml
@@ -1435,14 +1435,3 @@ Outputs:
     Value: !GetAtt ApiNamespace.Arn
     Export:
       Name: !Sub ${AWS::StackName}-ServiceDiscoveryNamespaceArn
-
-  # ALB dimensions for alarms defined in security.yaml (at inline-size ceiling here)
-  ApiLoadBalancerFullName:
-    Value: !GetAtt ApiALB.LoadBalancerFullName
-    Export:
-      Name: !Sub ${AWS::StackName}-LoadBalancerFullName
-
-  ApiTargetGroupFullName:
-    Value: !GetAtt ApiTargetGroup.TargetGroupFullName
-    Export:
-      Name: !Sub ${AWS::StackName}-TargetGroupFullName

--- a/cloudformation/security.yaml
+++ b/cloudformation/security.yaml
@@ -38,6 +38,23 @@ Parameters:
     AllowedValues: ["true", "false"]
     Description: Enable Amazon GuardDuty threat detection
 
+  # API ALB alarm dimensions, resolved live from ELB APIs by the deploy job
+  # (never CFN imports: a cross-stack import would deadlock the pipeline —
+  # security failing skips deploy-api, which is what publishes the exports).
+  # Empty values skip the ALB alarms via conditions.
+  ApiAlbFullNameProd:
+    Type: String
+    Default: ""
+  ApiTgFullNameProd:
+    Type: String
+    Default: ""
+  ApiAlbFullNameStaging:
+    Type: String
+    Default: ""
+  ApiTgFullNameStaging:
+    Type: String
+    Default: ""
+
   EnableSecurityHub:
     Type: String
     Default: "true"
@@ -95,6 +112,12 @@ Conditions:
     - !Equals [!Ref EnableCISStandard, "true"]
   AccessAnalyzerOn: !Equals [!Ref EnableAccessAnalyzer, "true"]
   ConfigOn: !Equals [!Ref EnableConfig, "true"]
+  HasApiAlbProd: !And
+    - !Not [!Equals [!Ref ApiAlbFullNameProd, ""]]
+    - !Not [!Equals [!Ref ApiTgFullNameProd, ""]]
+  HasApiAlbStaging: !And
+    - !Not [!Equals [!Ref ApiAlbFullNameStaging, ""]]
+    - !Not [!Equals [!Ref ApiTgFullNameStaging, ""]]
 
 Resources:
   # --- GuardDuty: continuous threat detection over CloudTrail/VPC/DNS telemetry.
@@ -545,6 +568,7 @@ Resources:
   # security-stack update that includes these alarms.
   ApiAlbUnhealthyHostsAlarmProd:
     Type: AWS::CloudWatch::Alarm
+    Condition: HasApiAlbProd
     Properties:
       AlarmName: robosystems-prod-api-alb-unhealthy-hosts
       AlarmDescription: API ALB target reporting unhealthy
@@ -557,15 +581,16 @@ Resources:
       ComparisonOperator: GreaterThanThreshold
       Dimensions:
         - Name: LoadBalancer
-          Value: !ImportValue RoboSystemsAPIProd-LoadBalancerFullName
+          Value: !Ref ApiAlbFullNameProd
         - Name: TargetGroup
-          Value: !ImportValue RoboSystemsAPIProd-TargetGroupFullName
+          Value: !Ref ApiTgFullNameProd
       TreatMissingData: notBreaching
       AlarmActions:
         - !Sub arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:robosystems-prod-security-alerts
 
   ApiAlbHighLatencyAlarmProd:
     Type: AWS::CloudWatch::Alarm
+    Condition: HasApiAlbProd
     Properties:
       AlarmName: robosystems-prod-api-alb-high-latency
       AlarmDescription: API ALB target response time is high
@@ -578,13 +603,14 @@ Resources:
       ComparisonOperator: GreaterThanThreshold
       Dimensions:
         - Name: LoadBalancer
-          Value: !ImportValue RoboSystemsAPIProd-LoadBalancerFullName
+          Value: !Ref ApiAlbFullNameProd
       TreatMissingData: notBreaching
       AlarmActions:
         - !Sub arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:robosystems-prod-security-alerts
 
   ApiAlb5xxAlarmProd:
     Type: AWS::CloudWatch::Alarm
+    Condition: HasApiAlbProd
     Properties:
       AlarmName: robosystems-prod-api-alb-5xx-spike
       AlarmDescription: Elevated 5xx responses from the API ALB
@@ -597,13 +623,14 @@ Resources:
       ComparisonOperator: GreaterThanThreshold
       Dimensions:
         - Name: LoadBalancer
-          Value: !ImportValue RoboSystemsAPIProd-LoadBalancerFullName
+          Value: !Ref ApiAlbFullNameProd
       TreatMissingData: notBreaching
       AlarmActions:
         - !Sub arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:robosystems-prod-security-alerts
 
   ApiAlbUnhealthyHostsAlarmStaging:
     Type: AWS::CloudWatch::Alarm
+    Condition: HasApiAlbStaging
     Properties:
       AlarmName: robosystems-staging-api-alb-unhealthy-hosts
       AlarmDescription: API ALB target reporting unhealthy
@@ -616,15 +643,16 @@ Resources:
       ComparisonOperator: GreaterThanThreshold
       Dimensions:
         - Name: LoadBalancer
-          Value: !ImportValue RoboSystemsAPIStaging-LoadBalancerFullName
+          Value: !Ref ApiAlbFullNameStaging
         - Name: TargetGroup
-          Value: !ImportValue RoboSystemsAPIStaging-TargetGroupFullName
+          Value: !Ref ApiTgFullNameStaging
       TreatMissingData: notBreaching
       AlarmActions:
         - !Sub arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:robosystems-staging-security-alerts
 
   ApiAlbHighLatencyAlarmStaging:
     Type: AWS::CloudWatch::Alarm
+    Condition: HasApiAlbStaging
     Properties:
       AlarmName: robosystems-staging-api-alb-high-latency
       AlarmDescription: API ALB target response time is high
@@ -637,13 +665,14 @@ Resources:
       ComparisonOperator: GreaterThanThreshold
       Dimensions:
         - Name: LoadBalancer
-          Value: !ImportValue RoboSystemsAPIStaging-LoadBalancerFullName
+          Value: !Ref ApiAlbFullNameStaging
       TreatMissingData: notBreaching
       AlarmActions:
         - !Sub arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:robosystems-staging-security-alerts
 
   ApiAlb5xxAlarmStaging:
     Type: AWS::CloudWatch::Alarm
+    Condition: HasApiAlbStaging
     Properties:
       AlarmName: robosystems-staging-api-alb-5xx-spike
       AlarmDescription: Elevated 5xx responses from the API ALB
@@ -656,7 +685,7 @@ Resources:
       ComparisonOperator: GreaterThanThreshold
       Dimensions:
         - Name: LoadBalancer
-          Value: !ImportValue RoboSystemsAPIStaging-LoadBalancerFullName
+          Value: !Ref ApiAlbFullNameStaging
       TreatMissingData: notBreaching
       AlarmActions:
         - !Sub arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:robosystems-staging-security-alerts


### PR DESCRIPTION
## Summary

- **Deadlock fix**: the ALB alarms in security.yaml imported exports from the API stacks, but `deploy-api` runs downstream of `deploy-vpc/security` — a security failure skipped the job that publishes the exports, so no run could converge (observed on the v1.6.21 staging + prod runs). The alarms now take ALB/TG full names as parameters that the security job resolves live via `elbv2 describe-load-balancers`/`describe-target-groups`; conditions skip the alarms when an ALB doesn't exist. Since both ALBs already exist, alarms land on the first deploy with no ordering constraint.
- Remove the now-unused `LoadBalancerFullName`/`TargetGroupFullName` exports from api.yaml (never deployed — the runs that would have created them failed/were cancelled); api.yaml back to 50,393 bytes
- Fix `setup-bedrock rotate` verification: `AWS_PROFILE=""` is treated by the AWS CLI as a real empty-named profile (errors), so the STS check always failed; now unset via `env -u` (verified live — the rotated key works)

## Testing

- `just cf-lint` clean on security + api; `bash -n` clean
- Deploy converges in one run: security resolves live ALB dims → alarms created; deploy-api proceeds independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)