### PR TITLE
chore(cloudformation): user-bucket versioning + FIPS TLS listener policy

### DIFF
--- a/cloudformation/api.yaml
+++ b/cloudformation/api.yaml
@@ -1019,9 +1019,9 @@ Resources:
       LoadBalancerArn: !Ref ApiALB
       Port: 443
       Protocol: HTTPS
-      # Modern TLS only (TLS 1.2 + 1.3). Without an explicit SslPolicy the ALB
-      # default (ELBSecurityPolicy-2016-08) still negotiates TLS 1.0/1.1.
-      SslPolicy: ELBSecurityPolicy-TLS13-1-2-2021-06
+      # FIPS-validated ciphers, TLS 1.2+ only. Without an explicit SslPolicy
+      # the ALB default (ELBSecurityPolicy-2016-08) negotiates TLS 1.0/1.1.
+      SslPolicy: ELBSecurityPolicy-TLS13-1-2-FIPS-2023-04
       Certificates:
         - CertificateArn: !Ref ApiCertificate
 

--- a/cloudformation/s3.yaml
+++ b/cloudformation/s3.yaml
@@ -196,6 +196,12 @@ Resources:
           - BucketKeyEnabled: false
             ServerSideEncryptionByDefault:
               SSEAlgorithm: AES256
+      # Versioning protects user data against accidental delete/overwrite.
+      # With versioning on, the expiration rules below produce delete markers
+      # rather than removing data — the ExpireNoncurrentVersions rule is what
+      # actually reclaims space, so keep them paired.
+      VersioningConfiguration:
+        Status: Enabled
       LifecycleConfiguration:
         Rules:
           # User staging data expires after 7 days
@@ -244,6 +250,23 @@ Resources:
             Transitions:
               - TransitionInDays: 30
                 StorageClass: STANDARD_IA
+          # Noncurrent versions are 30-day recovery copies, not an archive;
+          # also purge orphaned delete markers left by the expiration rules.
+          - Id: ExpireNoncurrentVersions
+            Status: Enabled
+            NoncurrentVersionExpiration:
+              NoncurrentDays: 30
+            ExpiredObjectDeleteMarker: true
+          # Shared-repository files are platform-derived (rebuilt from source
+          # data), not user data — versioning is bucket-wide so they can't be
+          # excluded, but reclaim their overwritten copies the next day rather
+          # than holding 30-day recovery versions of large database files.
+          # (S3 applies the earliest-deletion rule where prefixes overlap.)
+          - Id: ExpireSharedRepoNoncurrentVersions
+            Status: Enabled
+            Prefix: shared-repositories/
+            NoncurrentVersionExpiration:
+              NoncurrentDays: 1
       Tags:
         - Key: Name
           Value: !Sub ${AWS::StackName}-${Environment}-user-bucket


### PR DESCRIPTION
## Summary

- Enable S3 versioning on the user data bucket, paired with lifecycle cleanup so the existing prefix expiration rules keep reclaiming space:
  - 30-day noncurrent-version expiry + expired delete-marker purge (bucket-wide)
  - 1-day noncurrent expiry for `shared-repositories/` — platform-derived artifacts rebuilt from source; no recovery-copy value, and these are the large rewrite-heavy objects
- Switch the API ALB HTTPS listener to `ELBSecurityPolicy-TLS13-1-2-FIPS-2023-04` — same TLS 1.2+ floor, FIPS-validated ciphers, no client-compat change for API traffic

Both changes are additive/in-place: versioning enablement does not touch existing objects, and the listener policy swap is applied in-place by CloudFormation.

`cf-lint` clean on both templates; api.yaml at 50,398 bytes (ceiling 51,200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)