### PR TITLE
chore(cloudformation): add DynamoDB consumed-capacity alarms for registry tables

### DIFF
--- a/cloudformation/graph-infra.yaml
+++ b/cloudformation/graph-infra.yaml
@@ -650,6 +650,129 @@ Resources:
       AlarmActions:
         - !Ref InfraAlertTopic
 
+  # Registry table consumed-capacity alarms (on-demand billing, so these are
+  # anomaly ceilings: registry traffic is tiny and sustained consumption at
+  # this level means a runaway scan loop or abuse, not organic growth)
+  InstanceRegistryConsumedReadAlarm:
+    Type: AWS::CloudWatch::Alarm
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      AlarmName: !Sub robosystems-graph-${Environment}-instance-registry-read-consumed
+      MetricName: ConsumedReadCapacityUnits
+      Namespace: AWS/DynamoDB
+      Dimensions:
+        - Name: TableName
+          Value: !Ref InstanceRegistry
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 5000
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - !Ref InfraAlertTopic
+
+  InstanceRegistryConsumedWriteAlarm:
+    Type: AWS::CloudWatch::Alarm
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      AlarmName: !Sub robosystems-graph-${Environment}-instance-registry-write-consumed
+      MetricName: ConsumedWriteCapacityUnits
+      Namespace: AWS/DynamoDB
+      Dimensions:
+        - Name: TableName
+          Value: !Ref InstanceRegistry
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 5000
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - !Ref InfraAlertTopic
+
+  GraphRegistryConsumedReadAlarm:
+    Type: AWS::CloudWatch::Alarm
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      AlarmName: !Sub robosystems-graph-${Environment}-graph-registry-read-consumed
+      MetricName: ConsumedReadCapacityUnits
+      Namespace: AWS/DynamoDB
+      Dimensions:
+        - Name: TableName
+          Value: !Ref GraphRegistry
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 5000
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - !Ref InfraAlertTopic
+
+  GraphRegistryConsumedWriteAlarm:
+    Type: AWS::CloudWatch::Alarm
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      AlarmName: !Sub robosystems-graph-${Environment}-graph-registry-write-consumed
+      MetricName: ConsumedWriteCapacityUnits
+      Namespace: AWS/DynamoDB
+      Dimensions:
+        - Name: TableName
+          Value: !Ref GraphRegistry
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 5000
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - !Ref InfraAlertTopic
+
+  VolumeRegistryConsumedReadAlarm:
+    Type: AWS::CloudWatch::Alarm
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      AlarmName: !Sub robosystems-graph-${Environment}-volume-registry-read-consumed
+      MetricName: ConsumedReadCapacityUnits
+      Namespace: AWS/DynamoDB
+      Dimensions:
+        - Name: TableName
+          Value: !Ref VolumeRegistry
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 5000
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - !Ref InfraAlertTopic
+
+  VolumeRegistryConsumedWriteAlarm:
+    Type: AWS::CloudWatch::Alarm
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      AlarmName: !Sub robosystems-graph-${Environment}-volume-registry-write-consumed
+      MetricName: ConsumedWriteCapacityUnits
+      Namespace: AWS/DynamoDB
+      Dimensions:
+        - Name: TableName
+          Value: !Ref VolumeRegistry
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 5000
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - !Ref InfraAlertTopic
+
   # Error alarms for this stack's Lambdas (key generation + secret rotation)
   ApiKeyGeneratorErrorsAlarm:
     Type: AWS::CloudWatch::Alarm


### PR DESCRIPTION
## Summary

The three graph registry tables (instance, graph, volume) had throttle-event alarms only. This adds the complementary `ConsumedReadCapacityUnits` / `ConsumedWriteCapacityUnits` alarms per table — 6 new alarms per environment, wired to the existing InfraAlertTopic.

Tables are on-demand billing, so these are anomaly ceilings (Sum > 5000 units per 5 min ≈ 17 units/s sustained): registry traffic is tiny, and consumption at that level means a runaway scan loop or abuse, not organic growth. `TreatMissingData: notBreaching` since the tables are frequently idle.

`cf-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)