### PR TITLE
chore(lambda): remove unused Runtime Interface Emulator from image

### DIFF
--- a/Dockerfile.lambda
+++ b/Dockerfile.lambda
@@ -15,6 +15,11 @@ FROM public.ecr.aws/lambda/python:3.13-arm64
 ARG CACHE_DATE
 RUN echo "os-refresh ${CACHE_DATE}" && dnf update -y --releasever=latest && dnf clean all && rm -rf /var/cache/dnf
 
+# Drop the Runtime Interface Emulator baked into the AWS base image. It only
+# serves local `docker run` emulation — deployed Lambda never executes it —
+# and its vendored Go modules surface in container vulnerability scans.
+RUN rm -f /usr/local/bin/aws-lambda-rie
+
 # Install uv for dependency export
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 


### PR DESCRIPTION
Removes `/usr/local/bin/aws-lambda-rie` from the Lambda container image. The Runtime Interface Emulator ships in the AWS base image for local `docker run` testing only — deployed Lambda never executes it — and its vendored Go modules show up in ECR container scanning. Deleting the binary removes the noise at zero functional cost.

If local Lambda emulation is ever needed, mount RIE at runtime instead of baking it into the production image.