### PR TITLE
chore: point trust center links at trust.robosystems.ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ pip install robosystems-client
 
 - **[SECURITY.md](/SECURITY.md)** - Security control catalog with implementation references
 - **[Compliance](https://github.com/RoboFinSystems/robosystems/wiki/Security-and-Compliance)** - Compliance stacks, toggles, and SOC 2 posture
-- **[Trust Center](https://app.vanta.com/robosystems.ai/trust/lzitnsl1mo27b6zahy0ksy)** - Live compliance posture and audit artifacts
+- **[Trust Center](https://trust.robosystems.ai)** - Live compliance posture and audit artifacts
 
 ## API Reference
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 Security controls implemented at the infrastructure, application, and data levels.
 
-Live compliance posture and audit artifacts are published in the [RoboSystems Trust Center](https://app.vanta.com/robosystems.ai/trust/lzitnsl1mo27b6zahy0ksy).
+Live compliance posture and audit artifacts are published in the [RoboSystems Trust Center](https://trust.robosystems.ai).
 
 ## Authentication and Access Control
 
@@ -391,7 +391,7 @@ Production environment enforces at startup:
 
 - Security Team: security@robosystems.ai
 - Administrative Team: admin@robosystems.ai
-- Trust Center: https://app.vanta.com/robosystems.ai/trust/lzitnsl1mo27b6zahy0ksy
+- Trust Center: https://trust.robosystems.ai
 
 ### Automated Response
 


### PR DESCRIPTION
The trust center now lives at the custom domain https://trust.robosystems.ai. Updates the SECURITY.md and README references from the vendor-hosted URL.