### PR TITLE
Multi-user orgs phases 3+4: per-user repo subscriptions on org billing + guarded user deletion

### DIFF
--- a/migrations/platform/versions/7bedebbeefb6_add_subscriber_user_id_to_billing_.py
+++ b/migrations/platform/versions/7bedebbeefb6_add_subscriber_user_id_to_billing_.py
@@ -1,0 +1,87 @@
+"""add subscriber user_id to billing subscriptions
+
+Repository subscriptions are billed to the org but granted per user. The
+subscriber previously survived only in Stripe/checkout metadata, so webhook
+provisioning fell back to guessing the org owner. This adds the column and
+backfills it from the strongest evidence available for existing rows.
+
+Revision ID: 7bedebbeefb6
+Revises: ca0ce53039eb
+Create Date: 2026-08-02 23:16:53.203852
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "7bedebbeefb6"
+down_revision = "ca0ce53039eb"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+  op.add_column(
+    "billing_subscriptions", sa.Column("user_id", sa.String(), nullable=True)
+  )
+  op.create_index(
+    "idx_billing_sub_user", "billing_subscriptions", ["user_id"], unique=False
+  )
+  op.create_foreign_key(
+    "fk_billing_subscriptions_user_id",
+    "billing_subscriptions",
+    "users",
+    ["user_id"],
+    ["id"],
+  )
+
+  # 1. The checkout path already recorded the subscriber in metadata.
+  op.execute("""
+    UPDATE billing_subscriptions bs
+    SET user_id = bs.subscription_metadata->>'user_id'
+    WHERE bs.user_id IS NULL
+      AND bs.subscription_metadata->>'user_id' IS NOT NULL
+      AND EXISTS (
+        SELECT 1 FROM users u WHERE u.id = bs.subscription_metadata->>'user_id'
+      )
+  """)
+
+  # 2. Repository rows created through the direct path left no metadata, but
+  #    provisioning granted the subscriber a user_repository row. Use it only
+  #    when it identifies exactly one member of the paying org.
+  op.execute("""
+    UPDATE billing_subscriptions bs
+    SET user_id = sole.user_id
+    FROM (
+      SELECT ur.repository_name, ou.org_id, MIN(ur.user_id) AS user_id
+      FROM user_repository ur
+      JOIN org_users ou ON ou.user_id = ur.user_id
+      GROUP BY ur.repository_name, ou.org_id
+      HAVING COUNT(DISTINCT ur.user_id) = 1
+    ) sole
+    WHERE bs.user_id IS NULL
+      AND bs.resource_type = 'repository'
+      AND bs.resource_id = sole.repository_name
+      AND bs.org_id = sole.org_id
+  """)
+
+  # 3. Anything left over predates multi-user orgs, so the org owner is the
+  #    subscriber by construction.
+  op.execute("""
+    UPDATE billing_subscriptions bs
+    SET user_id = ou.user_id
+    FROM org_users ou
+    WHERE bs.user_id IS NULL
+      AND bs.resource_type = 'repository'
+      AND ou.org_id = bs.org_id
+      AND ou.role = 'OWNER'
+  """)
+
+
+def downgrade() -> None:
+  op.drop_constraint(
+    "fk_billing_subscriptions_user_id", "billing_subscriptions", type_="foreignkey"
+  )
+  op.drop_index("idx_billing_sub_user", table_name="billing_subscriptions")
+  op.drop_column("billing_subscriptions", "user_id")

--- a/robosystems/admin/commands/users_orgs.py
+++ b/robosystems/admin/commands/users_orgs.py
@@ -142,6 +142,73 @@ def user_activity(client, user_id):
       console.print(f"  {login['timestamp'][:19]} ({login['type']})")
 
 
+@users.command("delete")
+@click.argument("identifier")
+@click.option(
+  "--dry-run", is_flag=True, help="Show what deletion would do, without doing it"
+)
+@click.option("--yes", is_flag=True, help="Skip the confirmation prompt")
+@click.pass_obj
+def delete_user(client, identifier, dry_run, yes):
+  """Delete a user account by email or user ID, freeing the email address.
+
+  Refuses while the user's org still has live graphs, subscriptions in force,
+  or active repository access. Billing and audit history is retained.
+  """
+  user_id = identifier
+  if "@" in identifier:
+    matches = client._make_request(
+      "GET", "/admin/v1/users", params={"email": identifier, "limit": 10}
+    )
+    exact = [u for u in matches or [] if u["email"].lower() == identifier.lower()]
+    if not exact:
+      console.print(f"\n[red]No user found with email {identifier}[/red]")
+      raise SystemExit(1)
+    user_id = exact[0]["id"]
+
+  assessment = client._make_request(
+    "DELETE", f"/admin/v1/users/{user_id}", params={"dry_run": True}
+  )
+
+  console.print()
+  console.print(f"[bold]User:[/bold] {assessment['email']} ({assessment['user_id']})")
+
+  removals = assessment.get("removals") or {}
+  if any(removals.values()):
+    console.print("\n[bold]Will remove:[/bold]")
+    for name, count in removals.items():
+      if count:
+        console.print(f"  {name.replace('_', ' ')}: {count}")
+
+  if assessment.get("orgs_deleted"):
+    console.print(
+      f"\n[bold]Organizations deleted:[/bold] {', '.join(assessment['orgs_deleted'])}"
+    )
+  if assessment.get("orgs_retained"):
+    console.print(
+      f"[bold]Organizations retained:[/bold] {', '.join(assessment['orgs_retained'])}"
+    )
+
+  if assessment.get("blockers"):
+    console.print("\n[red]Cannot delete:[/red]")
+    for blocker in assessment["blockers"]:
+      console.print(f"  - {blocker['detail']}")
+    raise SystemExit(1)
+
+  if dry_run:
+    console.print("\n[yellow]Dry run — nothing was deleted.[/yellow]")
+    return
+
+  if not yes:
+    click.confirm(
+      f"\nPermanently delete {assessment['email']}?", abort=True, default=False
+    )
+
+  result = client._make_request("DELETE", f"/admin/v1/users/{user_id}")
+  console.print(f"\n[green]Deleted {result['email']}[/green]")
+  console.print("The email address is now available for registration or invitation.")
+
+
 @click.group()
 def orgs():
   """Manage organizations."""

--- a/robosystems/dagster/jobs/billing.py
+++ b/robosystems/dagster/jobs/billing.py
@@ -754,7 +754,10 @@ async def _trigger_resource_provisioning(
   resource_config = subscription.subscription_metadata.get("resource_config", {})
   resource_type = subscription.resource_type
 
-  user_id = subscription.subscription_metadata.get("user_id")
+  # The subscriber column is authoritative; metadata is the legacy copy for
+  # rows created before it existed. The org-owner fallback is last resort —
+  # with more than one member it can provision to the wrong person.
+  user_id = subscription.user_id or subscription.subscription_metadata.get("user_id")
   if not user_id:
     owner = (
       db_session.query(OrgUser)
@@ -771,6 +774,12 @@ async def _trigger_resource_provisioning(
       db_session.commit()
       return
     user_id = owner.user_id
+
+  # Persist whoever we resolved so cancellation and off-boarding can find the
+  # subscriber without re-deriving it from metadata or org roles.
+  if not subscription.user_id:
+    subscription.user_id = user_id
+    db_session.commit()
 
   context.log.info(f"Triggering provisioning for {resource_type}")
 

--- a/robosystems/models/api/admin/__init__.py
+++ b/robosystems/models/api/admin/__init__.py
@@ -34,6 +34,8 @@ from .subscription import (
 from .users import (
   UserActivityResponse,
   UserAPIKeyResponse,
+  UserDeletionBlockerResponse,
+  UserDeletionResponse,
   UserGraphAccessResponse,
   UserRepositoryAccessResponse,
   UserResponse,
@@ -69,6 +71,8 @@ __all__ = [
   "SubscriptionUpdateRequest",
   "UserAPIKeyResponse",
   "UserActivityResponse",
+  "UserDeletionBlockerResponse",
+  "UserDeletionResponse",
   "UserGraphAccessResponse",
   "UserRepositoryAccessResponse",
   "UserResponse",

--- a/robosystems/models/api/admin/users.py
+++ b/robosystems/models/api/admin/users.py
@@ -52,6 +52,26 @@ class UserAPIKeyResponse(BaseModel):
   expires_at: datetime | None
 
 
+class UserDeletionBlockerResponse(BaseModel):
+  """One reason a user account cannot be deleted."""
+
+  code: str
+  detail: str
+
+
+class UserDeletionResponse(BaseModel):
+  """Result of a user deletion, or of a dry run that only assessed it."""
+
+  user_id: str
+  email: str
+  deleted: bool
+  dry_run: bool
+  blockers: list[UserDeletionBlockerResponse]
+  removals: dict[str, int]
+  orgs_deleted: list[str]
+  orgs_retained: list[str]
+
+
 class UserActivityResponse(BaseModel):
   """Response with user's recent activity."""
 

--- a/robosystems/models/api/billing/subscription.py
+++ b/robosystems/models/api/billing/subscription.py
@@ -178,6 +178,13 @@ class GraphSubscriptionResponse(BaseModel):
   id: str = Field(..., description="Subscription ID")
   resource_type: str = Field(..., description="Resource type (graph or repository)")
   resource_id: str = Field(..., description="Resource identifier")
+  user_id: str | None = Field(
+    None,
+    description=(
+      "Organization member the subscription belongs to. Set for repository "
+      "subscriptions, which are billed to the org but granted per user."
+    ),
+  )
   plan_name: str = Field(..., description="Current plan name")
   plan_display_name: str = Field(
     ..., description="Human-readable plan name for UI display"
@@ -218,6 +225,13 @@ class UpgradeSubscriptionRequest(BaseModel):
   new_plan_name: str = Field(
     ..., description="New plan name to change to", examples=["advanced"]
   )
+  user_id: str | None = Field(
+    None,
+    description=(
+      "Organization member whose subscription to change. Defaults to the "
+      "caller; targeting another member requires org owner or admin."
+    ),
+  )
 
 
 class CancelSubscriptionRequest(BaseModel):
@@ -242,5 +256,12 @@ class CancelSubscriptionRequest(BaseModel):
     description=(
       "Required when immediate=True. Must equal the subscription's "
       "resource_id (e.g. graph_id) to confirm intent."
+    ),
+  )
+  user_id: str | None = Field(
+    None,
+    description=(
+      "Organization member whose subscription to cancel. Defaults to the "
+      "caller; canceling another member's requires org owner or admin."
     ),
   )

--- a/robosystems/models/core/billing/subscription.py
+++ b/robosystems/models/core/billing/subscription.py
@@ -69,6 +69,12 @@ class BillingSubscription(Base):
 
   org_id = Column(String, ForeignKey("orgs.id"), nullable=False)
 
+  # The member the subscription belongs to. Billing is always the org's, but
+  # repository access and credits are per-user, so the subscriber has to be a
+  # column rather than a value recoverable only from provider metadata.
+  # Nullable because org-level rows (graphs) have no single subscriber.
+  user_id = Column(String, ForeignKey("users.id"), nullable=True)
+
   resource_type = Column(String, nullable=False)
   resource_id = Column(String, nullable=True)
 
@@ -108,6 +114,7 @@ class BillingSubscription(Base):
 
   __table_args__ = (
     Index("idx_billing_sub_org", "org_id"),
+    Index("idx_billing_sub_user", "user_id"),
     Index("idx_billing_sub_resource", "resource_type", "resource_id"),
     Index("idx_billing_sub_status", "status"),
     Index("idx_billing_sub_stripe", "stripe_subscription_id"),
@@ -129,12 +136,18 @@ class BillingSubscription(Base):
     session: Session,
     billing_interval: str = "monthly",
     stripe_subscription_id: str | None = None,
+    user_id: str | None = None,
   ) -> "BillingSubscription":
-    """Create a new subscription."""
+    """Create a new subscription.
+
+    Pass `user_id` for per-user resources (repository subscriptions) so access
+    and credits can be provisioned to the right member of the paying org.
+    """
     now = datetime.now(UTC)
 
     subscription = cls(
       org_id=org_id,
+      user_id=user_id,
       resource_type=resource_type,
       resource_id=resource_id,
       plan_name=plan_name,
@@ -210,21 +223,24 @@ class BillingSubscription(Base):
     session: Session,
     exclude_statuses: tuple[str, ...] = (),
   ) -> Optional["BillingSubscription"]:
-    """Get subscription for a specific resource and user (looks up user's org first)."""
-    from robosystems.models.core.org import OrgUser
+    """Get a specific user's subscription to a resource.
 
-    membership = session.query(OrgUser).filter(OrgUser.user_id == user_id).first()
-
-    if not membership:
-      return None
-
-    return cls.get_by_resource_and_org(
-      resource_type=resource_type,
-      resource_id=resource_id,
-      org_id=membership.org_id,
-      session=session,
-      exclude_statuses=exclude_statuses,
+    Keyed on the subscriber, not their org: repository access and credits are
+    granted per user, so one member's subscription must never resolve as
+    another member's. Ordering matches `get_by_resource_and_org` — the row
+    still in force wins, then recency.
+    """
+    query = session.query(cls).filter(
+      cls.resource_type == resource_type,
+      cls.resource_id == resource_id,
+      cls.user_id == user_id,
     )
+    if exclude_statuses:
+      query = query.filter(cls.status.notin_(exclude_statuses))
+    return query.order_by(
+      case((cls.status.in_(TERMINAL_SUBSCRIPTION_STATUSES), 1), else_=0),
+      cls.created_at.desc(),
+    ).first()
 
   @classmethod
   def get_active_subscriptions_for_org(
@@ -241,18 +257,22 @@ class BillingSubscription(Base):
     )
 
   @classmethod
-  def get_active_subscriptions_for_user(
-    cls, user_id: str, session: Session
+  def get_live_subscriptions_for_user(
+    cls, user_id: str, session: Session, resource_type: str | None = None
   ) -> list["BillingSubscription"]:
-    """Get all active subscriptions for a user (looks up user's org first)."""
-    from robosystems.models.core.org import OrgUser
+    """Get a user's own subscriptions that are still in force.
 
-    membership = session.query(OrgUser).filter(OrgUser.user_id == user_id).first()
-
-    if not membership:
-      return []
-
-    return cls.get_active_subscriptions_for_org(membership.org_id, session)
+    "In force" is everything outside the terminal statuses — a pending or
+    past-due row still bills and still has to be cleaned up when the member
+    is off-boarded or their account is deleted.
+    """
+    query = session.query(cls).filter(
+      cls.user_id == user_id,
+      cls.status.notin_(TERMINAL_SUBSCRIPTION_STATUSES),
+    )
+    if resource_type:
+      query = query.filter(cls.resource_type == resource_type)
+    return query.order_by(cls.created_at.asc()).all()
 
   @classmethod
   def get_by_provider_subscription_id(

--- a/robosystems/operations/README.md
+++ b/robosystems/operations/README.md
@@ -87,6 +87,10 @@ operations/
 │   ├── pricing_service.py               # Pricing calculations
 │   ├── metrics_service.py               # Analytics and performance metrics
 │   └── repository_subscription_service.py
+├── billing/                   # Subscription billing lifecycle (provider + billing row + access)
+│   └── repository_subscriptions.py      # Cancel one/all repo subs; shared by routers and off-boarding
+├── admin/                     # Support-plane actions with no self-serve surface
+│   └── user_deletion.py                 # Guarded account deletion (frees the email; retains audit history)
 ├── extensions/                # OLTP→OLAP materialization (materialize.py, loader.py, staleness.py)
 ├── library/                   # Taxonomy/framework library reads (shared + tenant)
 ├── search/                    # Document search (embeddings, markdown parsing, service)

--- a/robosystems/operations/admin/__init__.py
+++ b/robosystems/operations/admin/__init__.py
@@ -1,0 +1,19 @@
+"""Administrative operations — support-plane actions with no self-serve surface."""
+
+from .user_deletion import (
+  DeletionBlocker,
+  UserDeletionBlocked,
+  UserDeletionPlan,
+  UserNotFound,
+  execute_user_deletion,
+  plan_user_deletion,
+)
+
+__all__ = [
+  "DeletionBlocker",
+  "UserDeletionBlocked",
+  "UserDeletionPlan",
+  "UserNotFound",
+  "execute_user_deletion",
+  "plan_user_deletion",
+]

--- a/robosystems/operations/admin/user_deletion.py
+++ b/robosystems/operations/admin/user_deletion.py
@@ -1,0 +1,343 @@
+"""Administrative user deletion.
+
+Two support cases share one implementation: freeing an email that a self-registered
+account is squatting so the org can invite it, and honoring an account-deletion
+request (a standing SOC 2 obligation).
+
+Deletion is deliberately narrow. It refuses while the user's organization still
+holds anything of value — live graphs, subscriptions in force, repository access —
+so it can never be the path by which paid infrastructure or a billing relationship
+disappears. Financial and audit history outlives the account: billing rows are
+retained with the actor de-referenced rather than deleted, and an organization
+carrying any financial artifact is kept even once its last member is gone.
+"""
+
+from dataclasses import dataclass, field
+
+from sqlalchemy.orm import Session
+
+from robosystems.logger import get_logger
+from robosystems.models.core import (
+  BillingAuditLog,
+  BillingCustomer,
+  BillingInvoice,
+  BillingSubscription,
+  Connection,
+  Document,
+  Graph,
+  GraphBackup,
+  GraphCredits,
+  GraphStatus,
+  GraphUser,
+  Org,
+  OrgInvitation,
+  OrgLimits,
+  OrgRole,
+  OrgUser,
+  User,
+  UserAPIKey,
+  UserRepository,
+  UserRepositoryCredits,
+  UserToken,
+)
+from robosystems.models.core.billing.subscription import TERMINAL_SUBSCRIPTION_STATUSES
+from robosystems.models.core.user.user_repository import RepositoryAccessLevel
+from robosystems.models.core.user.user_repository_credits import (
+  UserRepositoryCreditTransaction,
+)
+
+logger = get_logger(__name__)
+
+LIVE_GRAPH_STATUSES = (GraphStatus.ACTIVE.value, GraphStatus.SUSPENDED.value)
+
+
+class UserNotFound(Exception):
+  """No user with the given identifier."""
+
+
+class UserDeletionBlocked(Exception):
+  """The user's account still holds resources that must be resolved first."""
+
+  def __init__(self, blockers: list["DeletionBlocker"]):
+    self.blockers = blockers
+    super().__init__("; ".join(b.detail for b in blockers))
+
+
+@dataclass(frozen=True)
+class DeletionBlocker:
+  """One reason the account cannot be deleted, with the resolution implied."""
+
+  code: str
+  detail: str
+
+
+@dataclass
+class UserDeletionPlan:
+  """What deletion would do — computed without writing anything."""
+
+  user_id: str
+  email: str
+  org_ids: list[str]
+  blockers: list[DeletionBlocker] = field(default_factory=list)
+  removals: dict[str, int] = field(default_factory=dict)
+  orgs_to_delete: list[str] = field(default_factory=list)
+  orgs_retained: list[str] = field(default_factory=list)
+
+  @property
+  def can_delete(self) -> bool:
+    return not self.blockers
+
+
+def _org_must_be_retained(org_id: str, session: Session) -> bool:
+  """Whether an org carries records that must outlive its last member.
+
+  Billing history is kept for compliance, and deprovisioned graphs stay as the
+  record of what once ran — so an org holding either is retained as an empty
+  shell rather than deleted. It is invisible to the product either way.
+  """
+  if session.query(BillingSubscription).filter_by(org_id=org_id).count():
+    return True
+  if session.query(BillingInvoice).filter_by(org_id=org_id).count():
+    return True
+  if session.query(BillingAuditLog).filter_by(org_id=org_id).count():
+    return True
+  return bool(session.query(Graph).filter_by(org_id=org_id).count())
+
+
+def plan_user_deletion(user_id: str, session: Session) -> UserDeletionPlan:
+  """Assess a deletion: what blocks it, and what it would remove.
+
+  Read-only — safe to call for a dry run and called again by the executor so
+  the guards are evaluated against the same state as the deletes.
+  """
+  user = User.get_by_id(user_id, session)
+  if not user:
+    raise UserNotFound(f"User {user_id} not found")
+
+  memberships = OrgUser.get_user_orgs(user_id, session)
+  org_ids = [m.org_id for m in memberships]
+
+  blockers: list[DeletionBlocker] = []
+  orgs_to_delete: list[str] = []
+  orgs_retained: list[str] = []
+
+  for membership in memberships:
+    other_members = (
+      session.query(OrgUser)
+      .filter(OrgUser.org_id == membership.org_id, OrgUser.user_id != user_id)
+      .count()
+    )
+    if membership.role == OrgRole.OWNER and other_members:
+      blockers.append(
+        DeletionBlocker(
+          code="org_has_other_members",
+          detail=(
+            f"User owns organization {membership.org_id}, which has "
+            f"{other_members} other member(s). Transfer ownership first."
+          ),
+        )
+      )
+    elif other_members == 0:
+      if _org_must_be_retained(membership.org_id, session):
+        orgs_retained.append(membership.org_id)
+      else:
+        orgs_to_delete.append(membership.org_id)
+    else:
+      orgs_retained.append(membership.org_id)
+
+  if org_ids:
+    live_graphs = (
+      session.query(Graph)
+      .filter(Graph.org_id.in_(org_ids), Graph.status.in_(LIVE_GRAPH_STATUSES))
+      .count()
+    )
+    if live_graphs:
+      blockers.append(
+        DeletionBlocker(
+          code="org_has_live_graphs",
+          detail=(
+            f"Organization still has {live_graphs} graph(s) that are not "
+            "deprovisioned. Delete them first."
+          ),
+        )
+      )
+
+    live_subscriptions = (
+      session.query(BillingSubscription)
+      .filter(
+        BillingSubscription.org_id.in_(org_ids),
+        BillingSubscription.status.notin_(TERMINAL_SUBSCRIPTION_STATUSES),
+      )
+      .count()
+    )
+    if live_subscriptions:
+      blockers.append(
+        DeletionBlocker(
+          code="org_has_active_subscriptions",
+          detail=(
+            f"Organization has {live_subscriptions} subscription(s) still in "
+            "force. Cancel them first."
+          ),
+        )
+      )
+
+  active_repos = (
+    session.query(UserRepository)
+    .filter(
+      UserRepository.user_id == user_id,
+      UserRepository.is_active,
+      UserRepository.access_level != RepositoryAccessLevel.NONE,
+    )
+    .count()
+  )
+  if active_repos:
+    blockers.append(
+      DeletionBlocker(
+        code="active_repository_access",
+        detail=(
+          f"User still has active access to {active_repos} shared "
+          "repository(ies). Cancel those subscriptions first."
+        ),
+      )
+    )
+
+  credit_pools = (
+    session.query(GraphCredits)
+    .filter(
+      (GraphCredits.user_id == user_id) | (GraphCredits.billing_admin_id == user_id)
+    )
+    .count()
+  )
+  if credit_pools:
+    blockers.append(
+      DeletionBlocker(
+        code="graph_credit_pools",
+        detail=(
+          f"User is still referenced by {credit_pools} graph credit pool(s). "
+          "Those graphs must finish deprovisioning first."
+        ),
+      )
+    )
+
+  removals = {
+    "api_keys": session.query(UserAPIKey).filter_by(user_id=user_id).count(),
+    "tokens": session.query(UserToken).filter_by(user_id=user_id).count(),
+    "graph_grants": session.query(GraphUser).filter_by(user_id=user_id).count(),
+    "connections": session.query(Connection).filter_by(user_id=user_id).count(),
+    "documents": session.query(Document).filter_by(user_id=user_id).count(),
+    "repository_grants": session.query(UserRepository)
+    .filter_by(user_id=user_id)
+    .count(),
+    "invitations_sent": session.query(OrgInvitation)
+    .filter_by(invited_by=user_id)
+    .count(),
+    "org_memberships": len(memberships),
+  }
+
+  return UserDeletionPlan(
+    user_id=user_id,
+    email=user.email,
+    org_ids=org_ids,
+    blockers=blockers,
+    removals=removals,
+    orgs_to_delete=orgs_to_delete,
+    orgs_retained=orgs_retained,
+  )
+
+
+def execute_user_deletion(
+  user_id: str, session: Session, actor: str = "admin"
+) -> UserDeletionPlan:
+  """Delete a user account and everything scoped to it.
+
+  Re-plans first and raises `UserDeletionBlocked` if anything still holds the
+  account, so a stale dry run can never authorize a deletion.
+  """
+  plan = plan_user_deletion(user_id, session)
+  if not plan.can_delete:
+    raise UserDeletionBlocked(plan.blockers)
+
+  user = User.get_by_id(user_id, session)
+  if not user:
+    raise UserNotFound(f"User {user_id} not found")
+
+  # Audit and billing history survive the account — the actor is de-referenced,
+  # never deleted, because retention is itself a compliance requirement.
+  session.query(BillingAuditLog).filter_by(actor_user_id=user_id).update(
+    {"actor_user_id": None}, synchronize_session=False
+  )
+  session.query(BillingSubscription).filter_by(user_id=user_id).update(
+    {"user_id": None}, synchronize_session=False
+  )
+  session.query(GraphBackup).filter_by(created_by_user_id=user_id).update(
+    {"created_by_user_id": None}, synchronize_session=False
+  )
+  session.query(UserRepository).filter_by(granted_by=user_id).update(
+    {"granted_by": None}, synchronize_session=False
+  )
+  session.query(OrgInvitation).filter_by(accepted_user_id=user_id).update(
+    {"accepted_user_id": None}, synchronize_session=False
+  )
+
+  # Repository access, deepest child first.
+  repo_ids = [
+    row.id for row in session.query(UserRepository.id).filter_by(user_id=user_id).all()
+  ]
+  if repo_ids:
+    pool_ids = [
+      row.id
+      for row in session.query(UserRepositoryCredits.id)
+      .filter(UserRepositoryCredits.user_repository_id.in_(repo_ids))
+      .all()
+    ]
+    if pool_ids:
+      session.query(UserRepositoryCreditTransaction).filter(
+        UserRepositoryCreditTransaction.credit_pool_id.in_(pool_ids)
+      ).delete(synchronize_session=False)
+      session.query(UserRepositoryCredits).filter(
+        UserRepositoryCredits.id.in_(pool_ids)
+      ).delete(synchronize_session=False)
+    session.query(UserRepository).filter(UserRepository.id.in_(repo_ids)).delete(
+      synchronize_session=False
+    )
+
+  session.query(OrgInvitation).filter_by(invited_by=user_id).delete(
+    synchronize_session=False
+  )
+  session.query(Document).filter_by(user_id=user_id).delete(synchronize_session=False)
+  session.query(Connection).filter_by(user_id=user_id).delete(synchronize_session=False)
+  session.query(GraphUser).filter_by(user_id=user_id).delete(synchronize_session=False)
+  session.query(UserAPIKey).filter_by(user_id=user_id).delete(synchronize_session=False)
+  session.query(UserToken).filter_by(user_id=user_id).delete(synchronize_session=False)
+  session.query(OrgUser).filter_by(user_id=user_id).delete(synchronize_session=False)
+
+  for org_id in plan.orgs_to_delete:
+    session.query(OrgInvitation).filter_by(org_id=org_id).delete(
+      synchronize_session=False
+    )
+    session.query(BillingCustomer).filter_by(org_id=org_id).delete(
+      synchronize_session=False
+    )
+    session.query(OrgLimits).filter_by(org_id=org_id).delete(synchronize_session=False)
+    session.query(Org).filter_by(id=org_id).delete(synchronize_session=False)
+
+  session.delete(user)
+
+  try:
+    session.commit()
+  except Exception:
+    session.rollback()
+    raise
+
+  logger.info(
+    f"Deleted user {user_id} ({plan.email}) by {actor}",
+    extra={
+      "user_id": user_id,
+      "actor": actor,
+      "orgs_deleted": plan.orgs_to_delete,
+      "orgs_retained": plan.orgs_retained,
+      "removals": plan.removals,
+    },
+  )
+
+  return plan

--- a/robosystems/operations/billing/__init__.py
+++ b/robosystems/operations/billing/__init__.py
@@ -1,0 +1,15 @@
+"""Billing operations — subscription lifecycle logic shared by routers and jobs."""
+
+from .repository_subscriptions import (
+  ProviderCancellationError,
+  RepositorySubscriptionError,
+  cancel_repository_subscription,
+  cancel_user_repository_subscriptions,
+)
+
+__all__ = [
+  "ProviderCancellationError",
+  "RepositorySubscriptionError",
+  "cancel_repository_subscription",
+  "cancel_user_repository_subscriptions",
+]

--- a/robosystems/operations/billing/repository_subscriptions.py
+++ b/robosystems/operations/billing/repository_subscriptions.py
@@ -1,0 +1,155 @@
+"""Repository subscription billing lifecycle.
+
+Shared repositories are billed to the organization but granted per user, so a
+cancellation has to reach three places: the payment provider, the billing row,
+and the member's access record. Routers and off-boarding both go through here
+so the three can never drift apart.
+
+Distinct from `operations/graph/repository_subscription_service.py`, which owns
+the access-grant layer alone (`UserRepository` rows and their credit pools) and
+knows nothing about the provider. This module is the outer lifecycle and calls
+into that layer; anything that stops billing belongs here.
+"""
+
+from sqlalchemy.orm import Session
+
+from robosystems.logger import get_logger
+from robosystems.models.core import UserRepository
+from robosystems.models.core.billing import BillingAuditLog, BillingSubscription
+from robosystems.models.core.billing.audit_log import BillingEventType
+
+logger = get_logger(__name__)
+
+
+class RepositorySubscriptionError(Exception):
+  """Base class for repository subscription operation failures."""
+
+
+class ProviderCancellationError(RepositorySubscriptionError):
+  """The payment provider could not cancel — nothing local was changed.
+
+  Both provider cancel methods treat an already-canceled or missing
+  subscription as success, so a failure here means the customer is still being
+  billed. Revoking access anyway would charge them for something they can no
+  longer use.
+  """
+
+
+def cancel_repository_subscription(
+  subscription: BillingSubscription,
+  session: Session,
+  actor_user_id: str,
+  immediate: bool = False,
+  reason: str = "user_request",
+) -> None:
+  """Cancel one repository subscription and revoke the matching access.
+
+  Provider first: a provider failure raises before anything local changes, so
+  the retry path stays open. `immediate=False` leaves access in place until the
+  period closes; `immediate=True` revokes it now.
+  """
+  from robosystems.operations.providers.payment_provider import get_payment_provider
+
+  repository_id = subscription.resource_id
+  subscriber_id = subscription.user_id
+
+  if subscription.stripe_subscription_id:
+    try:
+      provider = get_payment_provider("stripe")
+      if immediate:
+        provider.cancel_subscription(subscription.stripe_subscription_id)
+      else:
+        provider.cancel_subscription_at_period_end(subscription.stripe_subscription_id)
+    except Exception as e:
+      logger.error(
+        f"Failed to cancel Stripe subscription for {repository_id}: {e}",
+        extra={"subscription_id": subscription.id},
+        exc_info=True,
+      )
+      raise ProviderCancellationError(str(e)) from e
+
+  # A subscription that never reached an active period has no period end to
+  # cancel into — the only honest option is an immediate stop.
+  subscription.cancel(
+    session, immediate=immediate or subscription.current_period_end is None
+  )
+
+  if subscriber_id and repository_id:
+    user_repo = UserRepository.get_by_user_and_repository(
+      user_id=subscriber_id,
+      repository_name=repository_id,
+      session=session,
+    )
+    if user_repo:
+      if subscription.ends_at and not immediate:
+        user_repo.expires_at = subscription.ends_at
+        user_repo.next_billing_at = None
+        user_repo.updated_at = subscription.updated_at
+        session.commit()
+      else:
+        user_repo.revoke_access(session)
+
+  BillingAuditLog.log_event(
+    session=session,
+    event_type=BillingEventType.SUBSCRIPTION_CANCELED,
+    description=(
+      f"Repository subscription {subscription.id} canceled for {repository_id} "
+      f"({'immediate' if immediate else 'period_end'})"
+    ),
+    actor_type="user",
+    actor_user_id=actor_user_id,
+    org_id=subscription.org_id,
+    subscription_id=subscription.id,
+    event_data={
+      "immediate": immediate,
+      "reason": reason,
+      "resource_type": "repository",
+      "resource_id": repository_id,
+      "subscriber_user_id": subscriber_id,
+      "canceled_by_other": subscriber_id != actor_user_id,
+    },
+  )
+
+  logger.info(
+    f"Canceled repository subscription {subscription.id} for {repository_id}",
+    extra={
+      "subscription_id": subscription.id,
+      "subscriber_user_id": subscriber_id,
+      "actor_user_id": actor_user_id,
+      "immediate": immediate,
+      "reason": reason,
+    },
+  )
+
+
+def cancel_user_repository_subscriptions(
+  user_id: str,
+  session: Session,
+  actor_user_id: str,
+  reason: str = "org_offboarding",
+) -> list[str]:
+  """Cancel every repository subscription a user still holds, immediately.
+
+  Used when a member is removed from the org: the org paid for that access
+  because of the membership, so it ends with the membership rather than
+  running to the period end on someone else's card.
+
+  Raises ProviderCancellationError if the provider refuses — the caller must
+  abort rather than off-board a member the org keeps paying for.
+  """
+  subscriptions = BillingSubscription.get_live_subscriptions_for_user(
+    user_id, session, resource_type="repository"
+  )
+
+  canceled: list[str] = []
+  for subscription in subscriptions:
+    cancel_repository_subscription(
+      subscription,
+      session=session,
+      actor_user_id=actor_user_id,
+      immediate=True,
+      reason=reason,
+    )
+    canceled.append(subscription.id)
+
+  return canceled

--- a/robosystems/routers/admin/users.py
+++ b/robosystems/routers/admin/users.py
@@ -11,6 +11,8 @@ from ...middleware.auth.admin import require_admin
 from ...models.api.admin import (
   UserActivityResponse,
   UserAPIKeyResponse,
+  UserDeletionBlockerResponse,
+  UserDeletionResponse,
   UserGraphAccessResponse,
   UserRepositoryAccessResponse,
   UserResponse,
@@ -23,6 +25,12 @@ from ...models.core.graph.graph_credits import (
 from ...models.core.graph.graph_usage import GraphUsage, UsageEventType
 from ...models.core.user.user_api_key import UserAPIKey
 from ...models.core.user.user_repository import UserRepository
+from ...operations.admin import (
+  UserDeletionBlocked,
+  UserNotFound,
+  execute_user_deletion,
+  plan_user_deletion,
+)
 
 logger = get_logger(__name__)
 
@@ -354,6 +362,73 @@ async def get_user_activity(request: Request, user_id: str):
       repositories_accessed=repositories_accessed,
       credit_usage_month=credit_usage_month,
       storage_usage_gb=storage_usage,
+    )
+  finally:
+    session.close()
+
+
+@router.delete("/{user_id}", response_model=UserDeletionResponse)
+@require_admin(permissions=["users:write"])
+async def delete_user(
+  request: Request,
+  user_id: str,
+  dry_run: bool = Query(False, description="Assess the deletion without performing it"),
+):
+  """Delete a user account, freeing its email address.
+
+  Refuses while the user's organization still holds live graphs, subscriptions
+  in force, or active repository access — those must be resolved first. Billing
+  and audit history is retained with the actor de-referenced.
+  """
+  session = next(get_db_session())
+  try:
+    try:
+      plan = (
+        plan_user_deletion(user_id, session)
+        if dry_run
+        else execute_user_deletion(
+          user_id,
+          session,
+          actor=f"admin:{request.state.admin.get('name', 'unknown')}",
+        )
+      )
+    except UserNotFound:
+      raise HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND,
+        detail=f"User {user_id} not found",
+      )
+    except UserDeletionBlocked as blocked:
+      raise HTTPException(
+        status_code=status.HTTP_409_CONFLICT,
+        detail={
+          "message": "User cannot be deleted yet",
+          "blockers": [{"code": b.code, "detail": b.detail} for b in blocked.blockers],
+        },
+      )
+
+    deleted = not dry_run and plan.can_delete
+
+    logger.info(
+      f"Admin {'assessed' if dry_run else 'deleted'} user {user_id}",
+      extra={
+        "admin_key_id": request.state.admin_key_id,
+        "user_id": user_id,
+        "dry_run": dry_run,
+        "blockers": [b.code for b in plan.blockers],
+      },
+    )
+
+    return UserDeletionResponse(
+      user_id=plan.user_id,
+      email=plan.email,
+      deleted=deleted,
+      dry_run=dry_run,
+      blockers=[
+        UserDeletionBlockerResponse(code=b.code, detail=b.detail) for b in plan.blockers
+      ],
+      removals=plan.removals,
+      orgs_deleted=plan.orgs_to_delete,
+      orgs_retained=plan.orgs_retained,
     )
   finally:
     session.close()

--- a/robosystems/routers/billing/checkout.py
+++ b/robosystems/routers/billing/checkout.py
@@ -136,9 +136,12 @@ async def create_checkout_session(
       base_price_cents=base_price_cents,
       session=db,
       billing_interval="monthly",
+      user_id=current_user.id,
     )
 
-    # Store resource configuration and user_id in metadata
+    # Resource configuration for the post-payment provisioning step. The
+    # subscriber also stays in metadata for older webhook payloads; the
+    # user_id column is now the authoritative copy.
     subscription.subscription_metadata = {
       "resource_config": request.resource_config,
       "user_id": current_user.id,

--- a/robosystems/routers/billing/subscriptions.py
+++ b/robosystems/routers/billing/subscriptions.py
@@ -77,6 +77,7 @@ async def list_subscriptions(
           id=str(sub.id),
           resource_type=sub.resource_type,
           resource_id=sub.resource_id or "",
+          user_id=sub.user_id,
           plan_name=sub.plan_name,
           plan_display_name=_get_plan_display_name(
             sub.plan_name, sub.resource_type, sub.resource_id or ""
@@ -152,6 +153,7 @@ async def get_subscription(
       id=str(subscription.id),
       resource_type=subscription.resource_type,
       resource_id=subscription.resource_id or "",
+      user_id=subscription.user_id,
       plan_name=subscription.plan_name,
       plan_display_name=_get_plan_display_name(
         subscription.plan_name,
@@ -351,6 +353,7 @@ async def cancel_subscription(
       id=str(subscription.id),
       resource_type=subscription.resource_type,
       resource_id=subscription.resource_id or "",
+      user_id=subscription.user_id,
       plan_name=subscription.plan_name,
       plan_display_name=_get_plan_display_name(
         subscription.plan_name,

--- a/robosystems/routers/graphs/subscriptions.py
+++ b/robosystems/routers/graphs/subscriptions.py
@@ -47,6 +47,44 @@ def _get_plan_display_name(plan_name: str, resource_type: str, resource_id: str)
   return BillingConfig.get_plan_display_name(plan_name, resource_type, resource_id)
 
 
+def _resolve_subscription_target(
+  current_user: User,
+  target_user_id: str | None,
+  db: Session,
+) -> tuple[str, str]:
+  """Resolve whose subscription is being managed, and authorize it.
+
+  Members manage their own subscriptions; org owners and admins manage any
+  member's — the org is paying, so it can stop paying (decision 4). Returns
+  (target_user_id, org_id).
+  """
+  from ...models.core import OrgUser
+
+  user_orgs = OrgUser.get_user_orgs(current_user.id, db)
+  if not user_orgs:
+    raise HTTPException(
+      status_code=403, detail="You are not a member of any organization"
+    )
+  membership = user_orgs[0]
+
+  if not target_user_id or target_user_id == current_user.id:
+    return current_user.id, membership.org_id
+
+  if not membership.can_manage_billing():
+    raise HTTPException(
+      status_code=403,
+      detail="Only organization owners and admins can manage another member's subscription",
+    )
+
+  if not OrgUser.get_by_org_and_user(membership.org_id, target_user_id, db):
+    raise HTTPException(
+      status_code=404,
+      detail="User is not a member of this organization",
+    )
+
+  return target_user_id, membership.org_id
+
+
 def subscription_to_response(
   subscription: BillingSubscription,
   operation_id: str | None = None,
@@ -56,6 +94,7 @@ def subscription_to_response(
     id=subscription.id,
     resource_type=subscription.resource_type,
     resource_id=subscription.resource_id,
+    user_id=subscription.user_id,
     plan_name=subscription.plan_name,
     plan_display_name=_get_plan_display_name(
       subscription.plan_name, subscription.resource_type, subscription.resource_id
@@ -185,9 +224,11 @@ async def create_repository_subscription(
       )
 
     parent_repo_id = resolve_shared_repository_parent(graph_id)
-    # Only a subscription still in force conflicts. Canceled and failed rows
-    # are kept as history and must not block resubscribing — an unfiltered
-    # check here turned one declined card into a permanent 409.
+    # Only the caller's own subscription conflicts — repository access is
+    # per user, so a colleague's subscription is an upsell, not a duplicate.
+    # And only a subscription still in force conflicts: canceled and failed
+    # rows are kept as history, and an unfiltered check here turned one
+    # declined card into a permanent 409.
     existing = BillingSubscription.get_by_resource_and_user(
       resource_type="repository",
       resource_id=parent_repo_id,
@@ -245,6 +286,7 @@ async def create_repository_subscription(
       base_price_cents=plan_config["price_cents"],
       session=db,
       billing_interval="monthly",
+      user_id=current_user.id,
     )
 
     BillingAuditLog.log_event(
@@ -445,28 +487,18 @@ async def _change_repository_plan(
   current_user: User,
   db: Session,
 ) -> GraphSubscriptionResponse:
-  from ...models.core import OrgRole, OrgUser
-  from ...models.core.user.user_repository import UserRepository
   from ...operations.providers.payment_provider import get_payment_provider
 
-  # Verify user is an org owner
-  user_orgs = OrgUser.get_user_orgs(current_user.id, db)
-  if not user_orgs:
-    raise HTTPException(
-      status_code=403, detail="You are not a member of any organization"
-    )
-  if user_orgs[0].role != OrgRole.OWNER:
-    raise HTTPException(
-      status_code=403,
-      detail="Only organization owners can change subscription plans",
-    )
+  target_user_id, org_id = _resolve_subscription_target(
+    current_user, request.user_id, db
+  )
 
   # Find existing subscription (subscriptions are on the parent repo)
   parent_repo_id = resolve_shared_repository_parent(graph_id)
   subscription = BillingSubscription.get_by_resource_and_user(
     resource_type="repository",
     resource_id=parent_repo_id,
-    user_id=current_user.id,
+    user_id=target_user_id,
     session=db,
   )
   if not subscription:
@@ -505,13 +537,13 @@ async def _change_repository_plan(
   # subscription mutated with credits and rate limits untouched whenever the
   # record was missing — the partial write this order exists to prevent.
   user_repo = UserRepository.get_by_user_and_repository(
-    current_user.id, parent_repo_id, db
+    target_user_id, parent_repo_id, db
   )
   if not user_repo:
     logger.error(
-      f"No UserRepository record for user {current_user.id} on {parent_repo_id} "
+      f"No UserRepository record for user {target_user_id} on {parent_repo_id} "
       f"during plan change — no changes were made",
-      extra={"user_id": current_user.id, "repository_id": parent_repo_id},
+      extra={"user_id": target_user_id, "repository_id": parent_repo_id},
     )
     raise HTTPException(
       status_code=500,
@@ -564,7 +596,6 @@ async def _change_repository_plan(
   )
 
   # Audit log
-  org_id = user_orgs[0].org_id
   BillingAuditLog.log_event(
     session=db,
     event_type=(
@@ -581,6 +612,7 @@ async def _change_repository_plan(
     event_data={
       "resource_type": "repository",
       "resource_id": parent_repo_id,
+      "subscriber_user_id": target_user_id,
       "old_plan": old_plan,
       "new_plan": new_plan_tier,
       "old_price_cents": subscription.base_price_cents,
@@ -592,7 +624,8 @@ async def _change_repository_plan(
   logger.info(
     f"Changed repository {graph_id} plan: {old_plan} -> {new_plan_tier}",
     extra={
-      "user_id": current_user.id,
+      "user_id": target_user_id,
+      "actor_user_id": current_user.id,
       "repository_id": graph_id,
       "old_plan": old_plan,
       "new_plan": new_plan_tier,
@@ -610,9 +643,10 @@ async def _change_repository_plan(
     "Cancel a shared repository subscription. Two modes via the `immediate` "
     "flag: omit it (default `false`) to cancel at period end (access stays "
     "until the period closes); pass `true` with `confirm=<repo_id>` to stop "
-    "access right away. For user graphs, use "
+    "access right away. Members cancel their own subscription; org owners and "
+    "admins can cancel any member's by passing `user_id`. For user graphs, use "
     "`POST /v1/graphs/{graph_id}/operations/delete-graph` — this endpoint "
-    "rejects user graphs. Requires org owner role."
+    "rejects user graphs."
   ),
   operation_id="cancelRepositorySubscription",
   responses={**RESOURCE_ERROR_RESPONSES},
@@ -628,8 +662,12 @@ async def cancel_repository_subscription(
   db: Session = Depends(get_db_session),
   _rate_limit: None = Depends(subscription_aware_rate_limit_dependency),
 ) -> GraphSubscriptionResponse:
-  from ...models.core import OrgRole, OrgUser
-  from ...operations.providers.payment_provider import get_payment_provider
+  from ...operations.billing import (
+    ProviderCancellationError,
+  )
+  from ...operations.billing import (
+    cancel_repository_subscription as cancel_subscription_op,
+  )
 
   if not is_shared_repository(graph_id):
     raise HTTPException(
@@ -643,21 +681,12 @@ async def cancel_repository_subscription(
 
   parent_repo_id = resolve_shared_repository_parent(graph_id)
 
-  user_orgs = OrgUser.get_user_orgs(current_user.id, db)
-  if not user_orgs:
-    raise HTTPException(
-      status_code=403, detail="You are not a member of any organization"
-    )
-  if user_orgs[0].role != OrgRole.OWNER:
-    raise HTTPException(
-      status_code=403,
-      detail="Only organization owners can cancel subscriptions",
-    )
+  target_user_id, _org_id = _resolve_subscription_target(current_user, body.user_id, db)
 
   subscription = BillingSubscription.get_by_resource_and_user(
     resource_type="repository",
     resource_id=parent_repo_id,
-    user_id=current_user.id,
+    user_id=target_user_id,
     session=db,
   )
   if not subscription:
@@ -685,76 +714,26 @@ async def cancel_repository_subscription(
         ),
       )
 
-  # Stripe-side: full cancel for immediate, period-end otherwise. Both provider
-  # methods are idempotent (already-canceled/missing counts as success), so a
-  # raise here always means Stripe still has a live subscription that will
-  # keep billing — in which case the local cancel and access revocation must
-  # not proceed, or the customer pays for access they no longer have.
-  # Default cancel does NOT prorate or refund.
-  if subscription.stripe_subscription_id:
-    try:
-      provider = get_payment_provider("stripe")
-      if body.immediate:
-        provider.cancel_subscription(subscription.stripe_subscription_id)
-      else:
-        provider.cancel_subscription_at_period_end(subscription.stripe_subscription_id)
-    except Exception as e:
-      logger.error(
-        f"Failed to cancel Stripe subscription for {graph_id}: {e}",
-        extra={"subscription_id": subscription.id},
-        exc_info=True,
-      )
-      raise HTTPException(
-        status_code=502,
-        detail=(
-          "The payment provider could not cancel the subscription. "
-          "No changes were made — please try again."
-        ),
-      )
-
-  subscription.cancel(db, immediate=body.immediate)
-
-  user_repo = UserRepository.get_by_user_and_repository(
-    user_id=current_user.id,
-    repository_name=parent_repo_id,
-    session=db,
-  )
-  if user_repo:
-    if body.immediate:
-      user_repo.revoke_access(db)
-    else:
-      user_repo.expires_at = subscription.ends_at
-      user_repo.next_billing_at = None
-      user_repo.updated_at = subscription.updated_at
-      db.commit()
-
-  BillingAuditLog.log_event(
-    session=db,
-    event_type=BillingEventType.SUBSCRIPTION_CANCELED,
-    description=(
-      f"Repository subscription {subscription.id} canceled for {graph_id} "
-      f"({'immediate' if body.immediate else 'period_end'})"
-    ),
-    actor_type="user",
-    actor_user_id=current_user.id,
-    org_id=user_orgs[0].org_id,
-    subscription_id=subscription.id,
-    event_data={
-      "immediate": body.immediate,
-      "via": "graph_scoped.subscription_cancel",
-      "resource_type": "repository",
-      "resource_id": parent_repo_id,
-    },
-  )
-
-  logger.info(
-    f"Canceled repository subscription for {graph_id} (immediate={body.immediate})",
-    extra={
-      "user_id": current_user.id,
-      "repository_id": graph_id,
-      "subscription_id": subscription.id,
-      "immediate": body.immediate,
-    },
-  )
+  # Provider first, then local state and access — a provider failure means the
+  # customer is still being billed, so nothing local may change.
+  # Cancellation does NOT prorate or refund.
+  try:
+    cancel_subscription_op(
+      subscription,
+      session=db,
+      actor_user_id=current_user.id,
+      immediate=body.immediate,
+      reason="user_request"
+      if target_user_id == current_user.id
+      else "org_admin_request",
+    )
+  except ProviderCancellationError:
+    raise HTTPException(
+      status_code=502,
+      detail=(
+        "The payment provider could not cancel the subscription. "
+        "No changes were made — please try again."
+      ),
+    )
 
   return subscription_to_response(subscription)

--- a/robosystems/routers/orgs/members.py
+++ b/robosystems/routers/orgs/members.py
@@ -17,6 +17,10 @@ from ...models.api.orgs import (
   UpdateMemberRoleRequest,
 )
 from ...models.core import Graph, GraphUser, OrgRole, OrgUser, User
+from ...operations.billing import (
+  ProviderCancellationError,
+  cancel_user_repository_subscriptions,
+)
 
 logger = get_logger(__name__)
 
@@ -274,6 +278,30 @@ async def remove_member(
       raise HTTPException(
         status_code=status.HTTP_400_BAD_REQUEST,
         detail="Admins and owners cannot remove themselves",
+      )
+
+    # Cancel before removing: org membership is what justified the org-billed
+    # repository subscriptions, so they end with it. Provider first — if the
+    # payment provider refuses, the removal aborts rather than off-boarding a
+    # member the org keeps paying for.
+    try:
+      canceled = cancel_user_repository_subscriptions(
+        user_id=user_id,
+        session=db,
+        actor_user_id=current_user.id,
+      )
+    except ProviderCancellationError:
+      raise HTTPException(
+        status_code=status.HTTP_502_BAD_GATEWAY,
+        detail=(
+          "The payment provider could not cancel this member's repository "
+          "subscriptions. No changes were made — please try again."
+        ),
+      )
+    if canceled:
+      logger.info(
+        f"Canceled {len(canceled)} repository subscription(s) while removing "
+        f"user {user_id} from org {org_id}"
       )
 
     # Remove the member, revoking their access to org-owned graphs.

--- a/tests/dagster/test_billing_webhook_handlers.py
+++ b/tests/dagster/test_billing_webhook_handlers.py
@@ -1817,6 +1817,8 @@ class TestTriggerResourceProvisioning:
     sub.resource_type = "graph"
     sub.resource_id = "kg_01ABC123"
     sub.plan_name = "ladybug-standard"
+    # Legacy row: subscriber recorded only in metadata.
+    sub.user_id = None
     sub.subscription_metadata = {"user_id": "user_01ABC123", "resource_config": {}}
     return sub
 
@@ -1828,6 +1830,7 @@ class TestTriggerResourceProvisioning:
     sub.resource_type = "repository"
     sub.resource_id = None
     sub.plan_name = "starter"
+    sub.user_id = None
     sub.subscription_metadata = {
       "user_id": "user_01ABC123",
       "resource_config": {"repository_name": "sec"},
@@ -1890,6 +1893,30 @@ class TestTriggerResourceProvisioning:
       repository_name="sec",
     )
     mock_db_session.commit.assert_called()
+
+  async def test_subscriber_column_wins_over_metadata(
+    self, mock_db_session, mock_context, repository_subscription
+  ):
+    """With more than one member per org, guessing the subscriber provisions to
+    the wrong person — the column is authoritative."""
+    repository_subscription.user_id = "user_column"
+    repository_subscription.subscription_metadata["user_id"] = "user_stale_metadata"
+
+    with (
+      patch(PATCH_IAM_ORG_USER),
+      patch(PATCH_IAM_ORG_ROLE),
+      patch(PATCH_RUN_GRAPH, new_callable=AsyncMock),
+      patch(
+        PATCH_RUN_REPO, new_callable=AsyncMock, return_value={"repository_name": "sec"}
+      ) as mock_provision,
+    ):
+      from robosystems.dagster.jobs.billing import _trigger_resource_provisioning
+
+      await _trigger_resource_provisioning(
+        repository_subscription, mock_db_session, mock_context
+      )
+
+    assert mock_provision.await_args.kwargs["user_id"] == "user_column"
 
   async def test_falls_back_to_org_owner_when_no_user_id(
     self, mock_db_session, mock_context, graph_subscription

--- a/tests/models/core/billing/test_subscription.py
+++ b/tests/models/core/billing/test_subscription.py
@@ -826,3 +826,108 @@ class TestResubscribeLookups:
 
     assert found is not None
     assert found.id == latest.id
+
+
+class TestPerSubscriberLookups:
+  """Repository subscriptions are billed to the org but held per user.
+
+  These pin the fix for the multi-user case: one member's subscription must
+  never resolve as another member's, or member B is refused a subscription
+  (409) while getting neither access nor credits from member A's.
+  """
+
+  def _repo_sub(self, db_session, org_id, user_id, status: str | None = None):
+    sub = BillingSubscription.create_subscription(
+      org_id=org_id,
+      resource_type="repository",
+      resource_id="sec",
+      plan_name="starter",
+      base_price_cents=2900,
+      session=db_session,
+      user_id=user_id,
+    )
+    if status is not None:
+      sub.status = status
+      db_session.commit()
+    return sub
+
+  def _second_member(self, db_session, test_org):
+    from robosystems.models.core import OrgRole, OrgUser
+
+    unique_id = str(uuid.uuid4())[:8]
+    user = User(
+      id=f"test_user_{unique_id}",
+      email=f"second+{unique_id}@example.com",
+      name="Second Member",
+      password_hash="test_hash",
+    )
+    db_session.add(user)
+    db_session.flush()
+    OrgUser.create(
+      org_id=test_org.id, user_id=user.id, role=OrgRole.MEMBER, session=db_session
+    )
+    return user
+
+  def test_lookup_is_scoped_to_the_subscriber(
+    self, db_session: Session, test_user, test_org
+  ):
+    other = self._second_member(db_session, test_org)
+    mine = self._repo_sub(db_session, test_org.id, test_user.id)
+
+    found = BillingSubscription.get_by_resource_and_user(
+      resource_type="repository",
+      resource_id="sec",
+      user_id=test_user.id,
+      session=db_session,
+    )
+    assert found is not None
+    assert found.id == mine.id
+
+    assert (
+      BillingSubscription.get_by_resource_and_user(
+        resource_type="repository",
+        resource_id="sec",
+        user_id=other.id,
+        session=db_session,
+      )
+      is None
+    )
+
+  def test_colleagues_subscription_is_not_a_conflict(
+    self, db_session: Session, test_user, test_org
+  ):
+    """Member B subscribing after member A is the upsell, not a duplicate."""
+    from robosystems.models.core.billing.subscription import (
+      TERMINAL_SUBSCRIPTION_STATUSES,
+    )
+
+    other = self._second_member(db_session, test_org)
+    self._repo_sub(
+      db_session, test_org.id, test_user.id, status=SubscriptionStatus.ACTIVE.value
+    )
+
+    conflict = BillingSubscription.get_by_resource_and_user(
+      resource_type="repository",
+      resource_id="sec",
+      user_id=other.id,
+      session=db_session,
+      exclude_statuses=TERMINAL_SUBSCRIPTION_STATUSES,
+    )
+
+    assert conflict is None
+
+  def test_live_subscriptions_for_user_excludes_terminal_rows(
+    self, db_session: Session, test_user, test_org
+  ):
+    self._repo_sub(
+      db_session, test_org.id, test_user.id, status=SubscriptionStatus.CANCELED.value
+    )
+    live = self._repo_sub(
+      db_session, test_org.id, test_user.id, status=SubscriptionStatus.ACTIVE.value
+    )
+
+    found = BillingSubscription.get_live_subscriptions_for_user(
+      test_user.id, db_session, resource_type="repository"
+    )
+
+    assert [s.id for s in found] == [live.id]

--- a/tests/operations/admin/test_user_deletion.py
+++ b/tests/operations/admin/test_user_deletion.py
@@ -1,0 +1,210 @@
+"""Tests for administrative user deletion.
+
+The guards matter more than the deletes: this is the one path that removes an
+account, and it must refuse while the org still holds anything of value.
+"""
+
+from uuid import uuid4
+
+import pytest
+
+from robosystems.models.core import (
+  BillingAuditLog,
+  BillingSubscription,
+  Graph,
+  Org,
+  OrgRole,
+  OrgType,
+  OrgUser,
+  User,
+)
+from robosystems.models.core.billing.audit_log import BillingEventType
+from robosystems.models.core.user.user_repository import (
+  RepositoryAccessLevel,
+  RepositoryType,
+  UserRepository,
+)
+from robosystems.operations.admin import (
+  UserDeletionBlocked,
+  execute_user_deletion,
+  plan_user_deletion,
+)
+
+
+def _create_user(session, password_hash: str) -> User:
+  suffix = uuid4().hex[:8]
+  user = User(
+    email=f"deletable+{suffix}@example.com",
+    name="Deletable User",
+    password_hash=password_hash,
+  )
+  session.add(user)
+  session.commit()
+  session.refresh(user)
+  return user
+
+
+def _personal_org(session, user: User) -> Org:
+  org = Org.create(
+    name=f"Personal {uuid4().hex[:6]}",
+    org_type=OrgType.PERSONAL,
+    session=session,
+  )
+  OrgUser.create(org_id=org.id, user_id=user.id, role=OrgRole.OWNER, session=session)
+  return org
+
+
+def _ensure_sec_repository(session) -> None:
+  if Graph.get_by_id("sec", session) is None:
+    Graph.create(
+      graph_id="sec",
+      org_id=None,
+      graph_name="SEC",
+      graph_type="repository",
+      session=session,
+    )
+
+
+class TestDeletionGuards:
+  def test_live_graph_blocks_deletion(self, test_db, test_user):
+    user = _create_user(test_db, test_user.password_hash)
+    org = _personal_org(test_db, user)
+    Graph.create(
+      graph_id=f"kg{uuid4().hex[:16]}",
+      org_id=org.id,
+      graph_name="Live Graph",
+      graph_type="generic",
+      session=test_db,
+    )
+
+    plan = plan_user_deletion(user.id, test_db)
+
+    assert not plan.can_delete
+    assert [b.code for b in plan.blockers] == ["org_has_live_graphs"]
+    with pytest.raises(UserDeletionBlocked):
+      execute_user_deletion(user.id, test_db)
+
+  def test_subscription_in_force_blocks_deletion(self, test_db, test_user):
+    user = _create_user(test_db, test_user.password_hash)
+    org = _personal_org(test_db, user)
+    subscription = BillingSubscription.create_subscription(
+      org_id=org.id,
+      resource_type="repository",
+      resource_id="sec",
+      plan_name="sec-starter",
+      base_price_cents=4900,
+      session=test_db,
+      user_id=user.id,
+    )
+    subscription.activate(test_db)
+
+    plan = plan_user_deletion(user.id, test_db)
+
+    assert "org_has_active_subscriptions" in [b.code for b in plan.blockers]
+
+  def test_active_repository_access_blocks_deletion(self, test_db, test_user):
+    _ensure_sec_repository(test_db)
+    user = _create_user(test_db, test_user.password_hash)
+    _personal_org(test_db, user)
+    UserRepository.create_access(
+      user_id=user.id,
+      repository_type=RepositoryType.SEC,
+      repository_name="sec",
+      access_level=RepositoryAccessLevel.READ,
+      repository_plan="sec-starter",
+      session=test_db,
+    )
+
+    plan = plan_user_deletion(user.id, test_db)
+
+    assert "active_repository_access" in [b.code for b in plan.blockers]
+
+  def test_owner_of_shared_org_blocks_deletion(self, test_db, test_user):
+    owner = _create_user(test_db, test_user.password_hash)
+    org = _personal_org(test_db, owner)
+    colleague = _create_user(test_db, test_user.password_hash)
+    OrgUser.create(
+      org_id=org.id, user_id=colleague.id, role=OrgRole.MEMBER, session=test_db
+    )
+
+    plan = plan_user_deletion(owner.id, test_db)
+
+    assert "org_has_other_members" in [b.code for b in plan.blockers]
+
+
+class TestDeletionExecution:
+  def test_clean_account_is_deleted_and_email_freed(self, test_db, test_user):
+    user = _create_user(test_db, test_user.password_hash)
+    org_id = _personal_org(test_db, user).id
+    email = user.email
+
+    plan = execute_user_deletion(user.id, test_db, actor="admin:test")
+
+    assert plan.orgs_to_delete == [org_id]
+    assert User.get_by_email(email, test_db) is None
+    assert Org.get_by_id(org_id, test_db) is None
+
+  def test_invited_member_leaves_the_org_standing(self, test_db, test_user):
+    """Deleting a member of a shared org removes them, not the organization."""
+    owner = _create_user(test_db, test_user.password_hash)
+    org = _personal_org(test_db, owner)
+    member = _create_user(test_db, test_user.password_hash)
+    OrgUser.create(
+      org_id=org.id, user_id=member.id, role=OrgRole.MEMBER, session=test_db
+    )
+
+    plan = execute_user_deletion(member.id, test_db)
+
+    assert plan.orgs_retained == [org.id]
+    assert Org.get_by_id(org.id, test_db) is not None
+    assert OrgUser.get_by_org_and_user(org.id, member.id, test_db) is None
+    assert User.get_by_id(owner.id, test_db) is not None
+
+  def test_billing_audit_history_survives_the_account(self, test_db, test_user):
+    """Retention is a compliance requirement — the actor is de-referenced,
+    the record is not deleted."""
+    owner = _create_user(test_db, test_user.password_hash)
+    org = _personal_org(test_db, owner)
+    member = _create_user(test_db, test_user.password_hash)
+    OrgUser.create(
+      org_id=org.id, user_id=member.id, role=OrgRole.MEMBER, session=test_db
+    )
+    entry = BillingAuditLog.log_event(
+      session=test_db,
+      event_type=BillingEventType.SUBSCRIPTION_CANCELED,
+      org_id=org.id,
+      description="Canceled during off-boarding",
+      actor_type="user",
+      actor_user_id=member.id,
+    )
+    entry_id = entry.id
+
+    execute_user_deletion(member.id, test_db)
+
+    retained = test_db.query(BillingAuditLog).filter_by(id=entry_id).first()
+    assert retained is not None
+    assert retained.actor_user_id is None
+
+  def test_org_with_billing_history_is_retained(self, test_db, test_user):
+    """A canceled subscription is financial history — the org outlives its
+    last member so the record keeps its home."""
+    user = _create_user(test_db, test_user.password_hash)
+    org = _personal_org(test_db, user)
+    subscription = BillingSubscription.create_subscription(
+      org_id=org.id,
+      resource_type="repository",
+      resource_id="sec",
+      plan_name="sec-starter",
+      base_price_cents=4900,
+      session=test_db,
+      user_id=user.id,
+    )
+    subscription.status = "canceled"
+    test_db.commit()
+
+    plan = execute_user_deletion(user.id, test_db)
+
+    assert plan.orgs_retained == [org.id]
+    assert Org.get_by_id(org.id, test_db) is not None
+    test_db.refresh(subscription)
+    assert subscription.user_id is None

--- a/tests/operations/billing/test_repository_subscriptions.py
+++ b/tests/operations/billing/test_repository_subscriptions.py
@@ -1,0 +1,149 @@
+"""Tests for repository subscription cancellation.
+
+The invariant under test: the payment provider is the first thing to change and
+the gate on everything else. If it refuses, the customer is still being billed,
+so local state and access must be untouched.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from robosystems.models.core import BillingSubscription, Graph, OrgRole, OrgUser, User
+from robosystems.models.core.user.user_repository import (
+  RepositoryAccessLevel,
+  RepositoryType,
+  UserRepository,
+)
+from robosystems.operations.billing import (
+  ProviderCancellationError,
+  cancel_repository_subscription,
+  cancel_user_repository_subscriptions,
+)
+
+PROVIDER = "robosystems.operations.providers.payment_provider.get_payment_provider"
+
+
+@pytest.fixture
+def subscribed_member(test_db, test_user, test_org):
+  """An org member with an active, Stripe-linked repository subscription."""
+  from uuid import uuid4
+
+  if Graph.get_by_id("sec", test_db) is None:
+    Graph.create(
+      graph_id="sec",
+      org_id=None,
+      graph_name="SEC",
+      graph_type="repository",
+      session=test_db,
+    )
+
+  member = User(
+    email=f"subscriber+{uuid4().hex[:8]}@example.com",
+    name="Subscriber",
+    password_hash=test_user.password_hash,
+  )
+  test_db.add(member)
+  test_db.commit()
+  OrgUser.create(
+    org_id=test_org.id, user_id=member.id, role=OrgRole.MEMBER, session=test_db
+  )
+
+  subscription = BillingSubscription.create_subscription(
+    org_id=test_org.id,
+    resource_type="repository",
+    resource_id="sec",
+    plan_name="sec-starter",
+    base_price_cents=4900,
+    session=test_db,
+    user_id=member.id,
+  )
+  subscription.activate(test_db)
+  subscription.stripe_subscription_id = "sub_stripe_test"
+  test_db.commit()
+
+  access = UserRepository.create_access(
+    user_id=member.id,
+    repository_type=RepositoryType.SEC,
+    repository_name="sec",
+    access_level=RepositoryAccessLevel.READ,
+    repository_plan="sec-starter",
+    session=test_db,
+  )
+
+  return member, subscription, access
+
+
+class TestCancelRepositorySubscription:
+  def test_provider_failure_changes_nothing(self, test_db, subscribed_member):
+    member, subscription, access = subscribed_member
+    provider = MagicMock()
+    provider.cancel_subscription_at_period_end.side_effect = RuntimeError("stripe down")
+
+    with patch(PROVIDER, return_value=provider):
+      with pytest.raises(ProviderCancellationError):
+        cancel_repository_subscription(
+          subscription, session=test_db, actor_user_id=member.id
+        )
+
+    test_db.refresh(subscription)
+    test_db.refresh(access)
+    assert subscription.status == "active"
+    assert access.is_active is True
+
+  def test_period_end_cancel_keeps_access_until_the_period_closes(
+    self, test_db, subscribed_member
+  ):
+    member, subscription, access = subscribed_member
+
+    with patch(PROVIDER, return_value=MagicMock()):
+      cancel_repository_subscription(
+        subscription, session=test_db, actor_user_id=member.id
+      )
+
+    test_db.refresh(subscription)
+    test_db.refresh(access)
+    assert subscription.status == "canceled"
+    assert subscription.cancellation_type == "period_end"
+    assert access.is_active is True
+    # The access record is timezone-aware, the billing row is not.
+    assert access.expires_at.replace(tzinfo=None) == subscription.ends_at
+
+  def test_immediate_cancel_revokes_access(self, test_db, subscribed_member):
+    member, subscription, access = subscribed_member
+
+    with patch(PROVIDER, return_value=MagicMock()):
+      cancel_repository_subscription(
+        subscription, session=test_db, actor_user_id=member.id, immediate=True
+      )
+
+    test_db.refresh(subscription)
+    test_db.refresh(access)
+    assert subscription.cancellation_type == "immediate"
+    assert access.is_active is False
+
+
+class TestCancelAllForUser:
+  def test_offboarding_cancels_every_live_subscription(
+    self, test_db, subscribed_member, test_user
+  ):
+    member, subscription, access = subscribed_member
+
+    with patch(PROVIDER, return_value=MagicMock()):
+      canceled = cancel_user_repository_subscriptions(
+        member.id, session=test_db, actor_user_id=test_user.id
+      )
+
+    assert canceled == [subscription.id]
+    test_db.refresh(subscription)
+    test_db.refresh(access)
+    assert subscription.status == "canceled"
+    assert access.is_active is False
+
+  def test_no_subscriptions_is_a_no_op(self, test_db, test_user):
+    assert (
+      cancel_user_repository_subscriptions(
+        test_user.id, session=test_db, actor_user_id=test_user.id
+      )
+      == []
+    )

--- a/tests/routers/admin/test_users.py
+++ b/tests/routers/admin/test_users.py
@@ -1,0 +1,112 @@
+"""Tests for the admin users router — deletion surface."""
+
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from main import app
+from robosystems.models.core import Graph, Org, OrgType, OrgUser, User
+
+
+@pytest.fixture
+def mock_admin_auth(monkeypatch):
+  """Mock admin authentication to bypass AWS Secrets Manager."""
+
+  def mock_verify_admin_key(self, api_key):
+    return {
+      "key_id": "admin",
+      "name": "Test Admin",
+      "permissions": ["*"],
+      "created_by": "system",
+    }
+
+  monkeypatch.setattr(
+    "robosystems.middleware.auth.admin.AdminAuthMiddleware.verify_admin_key",
+    mock_verify_admin_key,
+  )
+  yield
+
+
+@pytest.fixture
+def client():
+  return TestClient(app)
+
+
+ADMIN_HEADERS = {"Authorization": "Bearer test-admin-key"}
+
+
+@pytest.fixture
+def deletable_user(db_session: Session):
+  """A user whose org holds nothing — the common support case."""
+  unique_id = str(uuid.uuid4())[:8]
+  user = User(
+    id=f"test_user_{unique_id}",
+    email=f"squatter+{unique_id}@example.com",
+    name="Squatter",
+    password_hash="test_hash",
+  )
+  db_session.add(user)
+  db_session.commit()
+
+  org = Org.create(
+    name=f"Personal {unique_id}", org_type=OrgType.PERSONAL, session=db_session
+  )
+  OrgUser.create(org_id=org.id, user_id=user.id, role="OWNER", session=db_session)
+  return user
+
+
+class TestDeleteUser:
+  def test_dry_run_reports_without_deleting(
+    self, client, db_session, deletable_user, mock_admin_auth
+  ):
+    response = client.delete(
+      f"/admin/v1/users/{deletable_user.id}?dry_run=true", headers=ADMIN_HEADERS
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["dry_run"] is True
+    assert data["deleted"] is False
+    assert data["blockers"] == []
+    assert User.get_by_id(deletable_user.id, db_session) is not None
+
+  def test_delete_frees_the_email(
+    self, client, db_session, deletable_user, mock_admin_auth
+  ):
+    email = deletable_user.email
+
+    response = client.delete(
+      f"/admin/v1/users/{deletable_user.id}", headers=ADMIN_HEADERS
+    )
+
+    assert response.status_code == 200
+    assert response.json()["deleted"] is True
+    assert User.get_by_email(email, db_session) is None
+
+  def test_live_graph_returns_conflict(
+    self, client, db_session, deletable_user, mock_admin_auth
+  ):
+    org_id = OrgUser.get_user_orgs(deletable_user.id, db_session)[0].org_id
+    Graph.create(
+      graph_id=f"kg{uuid.uuid4().hex[:16]}",
+      org_id=org_id,
+      graph_name="Live Graph",
+      graph_type="generic",
+      session=db_session,
+    )
+
+    response = client.delete(
+      f"/admin/v1/users/{deletable_user.id}", headers=ADMIN_HEADERS
+    )
+
+    assert response.status_code == 409
+    blockers = response.json()["detail"]["blockers"]
+    assert [b["code"] for b in blockers] == ["org_has_live_graphs"]
+    assert User.get_by_id(deletable_user.id, db_session) is not None
+
+  def test_unknown_user_returns_404(self, client, mock_admin_auth):
+    response = client.delete("/admin/v1/users/user_missing", headers=ADMIN_HEADERS)
+
+    assert response.status_code == 404

--- a/tests/routers/billing/test_subscriptions.py
+++ b/tests/routers/billing/test_subscriptions.py
@@ -63,6 +63,7 @@ class TestListSubscriptions:
     mock_sub1.id = "sub_1"
     mock_sub1.resource_type = "graph"
     mock_sub1.resource_id = "kg_123"
+    mock_sub1.user_id = None
     mock_sub1.plan_name = "standard"
     mock_sub1.billing_interval = "monthly"
     mock_sub1.status = "active"
@@ -78,6 +79,7 @@ class TestListSubscriptions:
     mock_sub2.id = "sub_2"
     mock_sub2.resource_type = "repository"
     mock_sub2.resource_id = "sec"
+    mock_sub2.user_id = "user_123"
     mock_sub2.plan_name = "starter"
     mock_sub2.billing_interval = "monthly"
     mock_sub2.status = "canceled"
@@ -166,6 +168,7 @@ class TestGetSubscription:
     mock_subscription.id = "sub_123"
     mock_subscription.resource_type = "graph"
     mock_subscription.resource_id = "kg_456"
+    mock_subscription.user_id = None
     mock_subscription.plan_name = "enterprise"
     mock_subscription.billing_interval = "monthly"
     mock_subscription.status = "active"
@@ -225,6 +228,7 @@ class TestGetSubscription:
     mock_subscription.id = "sub_123"
     mock_subscription.resource_type = "graph"
     mock_subscription.resource_id = None
+    mock_subscription.user_id = None
     mock_subscription.plan_name = "standard"
     mock_subscription.billing_interval = "monthly"
     mock_subscription.status = "pending_provisioning"
@@ -293,6 +297,7 @@ class TestCancelSubscription:
     sub.id = "sub_123"
     sub.resource_type = resource_type
     sub.resource_id = resource_id
+    sub.user_id = None
     sub.plan_name = "standard"
     sub.billing_interval = "monthly"
     sub.status = "active"

--- a/tests/routers/graphs/test_subscriptions_router.py
+++ b/tests/routers/graphs/test_subscriptions_router.py
@@ -80,6 +80,7 @@ class TestSubscriptionToResponse:
     subscription.id = "bsub_abc123"
     subscription.resource_type = "graph"
     subscription.resource_id = "kg1a2b3c"
+    subscription.user_id = None
     subscription.plan_name = "ladybug-standard"
     subscription.billing_interval = "monthly"
     subscription.status = "active"
@@ -120,6 +121,7 @@ class TestSubscriptionToResponse:
     subscription.id = "bsub_xyz789"
     subscription.resource_type = "repository"
     subscription.resource_id = "sec"
+    subscription.user_id = "user_123"
     subscription.plan_name = "sec-starter"
     subscription.billing_interval = "monthly"
     subscription.status = "provisioning"
@@ -140,6 +142,7 @@ class TestSubscriptionToResponse:
     assert response.id == "bsub_xyz789"
     assert response.resource_type == "repository"
     assert response.resource_id == "sec"
+    assert response.user_id == "user_123"
     assert response.current_period_start is None
     assert response.current_period_end is None
     assert response.started_at is None
@@ -156,6 +159,8 @@ class TestCancelRepositorySubscription:
     sub.id = "sub_123"
     sub.resource_type = "repository"
     sub.resource_id = "sec"
+    sub.org_id = "org_1"
+    sub.user_id = "user_123"
     sub.plan_name = "starter"
     sub.billing_interval = "monthly"
     sub.status = "active"
@@ -377,11 +382,58 @@ class TestCancelRepositorySubscription:
     assert exc.value.status_code == 404
 
   @pytest.mark.asyncio
-  async def test_rejects_non_owner(self, mock_user):
+  @patch(f"{MODULE}.BillingAuditLog")
+  @patch(f"{MODULE}.BillingSubscription.get_by_resource_and_user")
+  async def test_org_admin_can_cancel_another_members_subscription(
+    self, mock_get_sub, _mock_audit, mock_user
+  ):
+    """The org is paying, so an org admin can stop paying for any member."""
     from robosystems.models.core import OrgRole
 
     mock_org = Mock()
+    mock_org.org_id = "org_1"
     mock_org.role = OrgRole.ADMIN
+    mock_org.can_manage_billing = lambda: True
+
+    db = MagicMock()
+    sub = self._build_active_repo_subscription()
+    sub.user_id = "user_456"
+    mock_get_sub.return_value = sub
+
+    with (
+      patch(f"{MODULE}.is_shared_repository", return_value=True),
+      patch(f"{MODULE}.resolve_shared_repository_parent", return_value="sec"),
+      patch(
+        "robosystems.models.core.OrgUser.get_user_orgs",
+        return_value=[mock_org],
+      ),
+      patch(
+        "robosystems.models.core.OrgUser.get_by_org_and_user",
+        return_value=Mock(),
+      ),
+    ):
+      await cancel_repository_subscription(
+        graph_id="sec",
+        body=CancelSubscriptionRequest(user_id="user_456"),
+        current_user=mock_user,
+        db=db,
+        _rate_limit=None,
+      )
+
+    # The target member's subscription was the one looked up and canceled.
+    assert mock_get_sub.call_args.kwargs["user_id"] == "user_456"
+    sub.cancel.assert_called_once_with(db, immediate=False)
+
+  @pytest.mark.asyncio
+  async def test_plain_member_cannot_cancel_another_members_subscription(
+    self, mock_user
+  ):
+    from robosystems.models.core import OrgRole
+
+    mock_org = Mock()
+    mock_org.org_id = "org_1"
+    mock_org.role = OrgRole.MEMBER
+    mock_org.can_manage_billing = lambda: False
 
     with (
       patch(f"{MODULE}.is_shared_repository", return_value=True),
@@ -394,13 +446,14 @@ class TestCancelRepositorySubscription:
       with pytest.raises(HTTPException) as exc:
         await cancel_repository_subscription(
           graph_id="sec",
-          body=CancelSubscriptionRequest(),
+          body=CancelSubscriptionRequest(user_id="user_456"),
           current_user=mock_user,
           db=MagicMock(),
           _rate_limit=None,
         )
+
     assert exc.value.status_code == 403
-    assert "owner" in exc.value.detail.lower()
+    assert "owners and admins" in exc.value.detail.lower()
 
 
 class TestChangeRepositoryPlan:
@@ -411,6 +464,8 @@ class TestChangeRepositoryPlan:
     sub.id = "sub_123"
     sub.resource_type = "repository"
     sub.resource_id = "sec"
+    sub.org_id = "org_1"
+    sub.user_id = "user_123"
     sub.plan_name = "starter"
     sub.billing_interval = "monthly"
     sub.status = "active"
@@ -522,6 +577,8 @@ class TestCancelStripeFailureHandling:
     sub.id = "sub_123"
     sub.resource_type = "repository"
     sub.resource_id = "sec"
+    sub.org_id = "org_1"
+    sub.user_id = "user_123"
     sub.plan_name = "starter"
     sub.billing_interval = "monthly"
     sub.status = "active"
@@ -657,6 +714,8 @@ class TestChangePlanStripeFirst:
     sub.id = "sub_123"
     sub.resource_type = "repository"
     sub.resource_id = "sec"
+    sub.org_id = "org_1"
+    sub.user_id = "user_123"
     sub.plan_name = "starter"
     sub.status = "active"
     sub.base_price_cents = 2900

--- a/tests/routers/orgs/test_members.py
+++ b/tests/routers/orgs/test_members.py
@@ -357,3 +357,63 @@ class TestOrgMembersRouter:
       GraphUser.get_by_user_and_graph(member.id, outside_graph.graph_id, test_db)
       is not None
     )
+
+  async def test_remove_member_cancels_their_repository_subscriptions(
+    self, async_client, test_db, test_user
+  ):
+    """The org stops paying for a member's repository access when they leave."""
+    from robosystems.models.core import BillingSubscription, Graph
+    from robosystems.models.core.user.user_repository import (
+      RepositoryAccessLevel,
+      RepositoryType,
+      UserRepository,
+    )
+
+    if Graph.get_by_id("sec", test_db) is None:
+      Graph.create(
+        graph_id="sec",
+        org_id=None,
+        graph_name="SEC",
+        graph_type="repository",
+        session=test_db,
+      )
+
+    org = Org.create(
+      name=f"Billing Org {uuid4().hex[:6]}",
+      org_type=OrgType.TEAM,
+      session=test_db,
+    )
+    OrgUser.create(
+      org_id=org.id, user_id=test_user.id, role=OrgRole.OWNER, session=test_db
+    )
+    member = _create_user(test_db, test_user.password_hash)
+    OrgUser.create(
+      org_id=org.id, user_id=member.id, role=OrgRole.MEMBER, session=test_db
+    )
+
+    subscription = BillingSubscription.create_subscription(
+      org_id=org.id,
+      resource_type="repository",
+      resource_id="sec",
+      plan_name="sec-starter",
+      base_price_cents=4900,
+      session=test_db,
+      user_id=member.id,
+    )
+    subscription.activate(test_db)
+    access = UserRepository.create_access(
+      user_id=member.id,
+      repository_type=RepositoryType.SEC,
+      repository_name="sec",
+      access_level=RepositoryAccessLevel.READ,
+      repository_plan="sec-starter",
+      session=test_db,
+    )
+
+    response = await async_client.delete(f"/v1/orgs/{org.id}/members/{member.id}")
+
+    assert response.status_code == 204
+    test_db.refresh(subscription)
+    test_db.refresh(access)
+    assert subscription.status == "canceled"
+    assert access.is_active is False


### PR DESCRIPTION
Continues the multi-user orgs work merged in #1023 (phases 1, 1.5, 2). This is the repo-sales half plus the support/compliance escape hatch.

## Phase 3 — repository subscriptions on org billing

Shared repositories are billed to the organization but granted per user. The subscriber previously survived only in Stripe/checkout metadata, which produced two real defects the moment an org had a second member: member B got a 409 with neither access nor credits after member A subscribed (the conflict check was org-scoped while the grant is user-scoped), and webhook provisioning fell back to guessing the org owner.

- **`billing_subscriptions.user_id`** — nullable FK + index (migration `7bedebbeefb6`, round-tripped locally). Backfilled in three passes: checkout metadata, then the sole `user_repository` holder in the org, then the org owner for repository rows.
- **Per-subscriber lookups** — `get_by_resource_and_user` now keys on the subscriber instead of resolving through the org (what its name always claimed). The subscribe conflict check follows, so a colleague's subscription is the intended upsell rather than a duplicate. New `get_live_subscriptions_for_user`; the org-scoped `get_active_subscriptions_for_user` is deleted — it had zero callers, and a per-user-named org-scoped helper is exactly how the original defect happened.
- **Admin unsubscribe** — cancel and plan change take an optional target `user_id`. Members manage their own subscription; org owners and admins manage any member's, since the org is paying. `OrgUser.can_manage_billing()` finally has callers, and the OWNER-only rule that rejected admins is gone.
- **One cancellation path** — extracted to `operations/billing/repository_subscriptions.py`. Provider first, and a `ProviderCancellationError` means nothing local changed, so the retry path stays open and a customer is never charged for access they no longer have.
- **Off-boarding** — `remove_member` cancels the leaver's repository subscriptions *before* the membership row goes, and returns 502 if the provider refuses rather than off-boarding someone the org keeps paying for. This completes the phase 1.5 stub.
- Webhook provisioning reads the subscriber column first and persists whatever it resolved; `user_id` is exposed on subscription responses for the org billing UI.

## Phase 4 — guarded user deletion

Support needs to free an email that a self-registered account is squatting so an org can invite it; account deletion is also a standing SOC 2 obligation. Same operation.

- `DELETE /admin/v1/users/{id}` with `?dry_run`, behind `users:write`
- `just admin dev users delete <email|user_id> [--dry-run] [--yes]` — resolves email via the list endpoint and always assesses first, so blockers print before the confirmation
- **Guards**: live graphs, subscriptions in force, active repository access, graph credit pool references, or ownership of an org with other members
- **History outlives the account**: billing audit actors, subscription subscribers, and backup creators are de-referenced rather than deleted, and an org carrying billing history or deprovisioned graphs is retained as an empty shell instead of being removed

## Test plan

- `just test-all` — **11,860 passed**, 24 skipped; ruff, format, basedpyright and cf-lint clean
- New: per-subscriber lookup semantics, the colleague-is-not-a-conflict case, admin-cancels-another-member, provider-failure-changes-nothing, off-boarding cascade, deletion guards and retention, the admin endpoint
- Two existing tests pinned behavior this PR deliberately changes: `test_rejects_non_owner` (org admins were refused) and the webhook fixtures' metadata-only subscriber. Both updated, with the precedence now covered by a test.
- Migration round-tripped (`up` → `down` → `up`) against local Postgres
- Live check on the dev stack: the RoboLedger demo user is correctly refused with all three blockers; a throwaway registration deletes cleanly, the email re-registers, and no ownerless orgs are left behind

## Rollout

Migration `7bedebbeefb6` runs on both databases' usual path (platform only). The backfill is idempotent and touches only rows with a null subscriber. No feature flag: per-user conflict semantics and the widened cancel authority take effect on deploy, both of which are no-ops for today's single-member orgs. Org invitations remain inert behind `ORG_MEMBER_INVITATIONS_ENABLED`.

Remaining: phase 5 — SDK regeneration, `@robosystems/core` release, and the robosystems-app UI.