### PR TITLE
Let invited users register while registration is closed

### DIFF
--- a/robosystems/routers/auth/register.py
+++ b/robosystems/routers/auth/register.py
@@ -63,28 +63,45 @@ async def register(
   session: Session = Depends(get_async_db_session),
   rate_limit: None = Depends(auth_rate_limit_dependency),
 ) -> AuthResponse:
-  # Check if registration is enabled
+  # Check if registration is enabled.
+  #
+  # An invitation is itself the authorization to register, so closing
+  # registration stops *unsolicited* signups without also blocking the people
+  # an org admin deliberately invited. That composition — closed registration
+  # plus invitations — is invite-only mode.
+  #
+  # The token is resolved here rather than trusted as a mere presence check:
+  # otherwise any string would buy an attacker passage to the checks below,
+  # including the duplicate-email probe that closed registration is meant to
+  # deny. It is validated again in full (email match, expiry) further down.
   if not env.USER_REGISTRATION_ENABLED:
-    # Get client details for security logging
-    client_ip = fastapi_request.client.host if fastapi_request.client else None
-    user_agent = fastapi_request.headers.get("user-agent")
-
-    SecurityAuditLogger.log_security_event(
-      event_type=SecurityEventType.AUTHORIZATION_DENIED,
-      ip_address=client_ip,
-      user_agent=user_agent,
-      endpoint="/v1/auth/register",
-      details={
-        "reason": "registration_disabled",
-        "attempted_email": request.email,
-      },
-      risk_level="low",
+    has_valid_invitation = (
+      request.invite_token is not None
+      and OrgInvitation.get_valid_by_token(request.invite_token, session) is not None
     )
 
-    raise HTTPException(
-      status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-      detail="Registration is temporarily disabled. Please check back later or contact support for early access.",
-    )
+    if not has_valid_invitation:
+      # Get client details for security logging
+      client_ip = fastapi_request.client.host if fastapi_request.client else None
+      user_agent = fastapi_request.headers.get("user-agent")
+
+      SecurityAuditLogger.log_security_event(
+        event_type=SecurityEventType.AUTHORIZATION_DENIED,
+        ip_address=client_ip,
+        user_agent=user_agent,
+        endpoint="/v1/auth/register",
+        details={
+          "reason": "registration_disabled",
+          "attempted_email": request.email,
+          "invitation_presented": request.invite_token is not None,
+        },
+        risk_level="low",
+      )
+
+      raise HTTPException(
+        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        detail="Registration is temporarily disabled. Please check back later or contact support for early access.",
+      )
 
   # Validate and sanitize input
   if not validate_email(request.email):

--- a/tests/routers/auth/test_auth.py
+++ b/tests/routers/auth/test_auth.py
@@ -621,3 +621,81 @@ class TestInvitedRegistration:
 
     assert response.status_code == 400
     assert "invalid or has expired" in response.json()["detail"]
+
+  @patch.object(
+    __import__("robosystems.config", fromlist=["env"]).env,
+    "USER_REGISTRATION_ENABLED",
+    False,
+  )
+  @patch.dict(os.environ, {"ENVIRONMENT": "dev"})
+  def test_invited_user_can_register_while_registration_is_closed(
+    self, client: TestClient, test_db, test_user
+  ):
+    """Invite-only mode: closing registration stops unsolicited signups, not
+    the people an admin deliberately invited."""
+    from robosystems.models.core import OrgUser
+
+    org, _invitation, raw_token = self._make_invitation(
+      test_db, test_user, "closedreg@example.com"
+    )
+
+    response = client.post(
+      "/v1/auth/register",
+      json={
+        "name": "Invited User",
+        "email": "closedreg@example.com",
+        "password": "S3cur3P@ssw0rd!2024",
+        "invite_token": raw_token,
+      },
+    )
+
+    assert response.status_code == 201
+    new_user = User.get_by_email("closedreg@example.com", test_db)
+    assert new_user is not None
+    assert OrgUser.get_user_orgs(new_user.id, test_db)[0].org_id == org.id
+
+  @patch.object(
+    __import__("robosystems.config", fromlist=["env"]).env,
+    "USER_REGISTRATION_ENABLED",
+    False,
+  )
+  @patch.dict(os.environ, {"ENVIRONMENT": "dev"})
+  def test_uninvited_registration_still_blocked_when_closed(
+    self, client: TestClient, test_db
+  ):
+    response = client.post(
+      "/v1/auth/register",
+      json={
+        "name": "Walk In",
+        "email": "walkin@example.com",
+        "password": "S3cur3P@ssw0rd!2024",
+      },
+    )
+
+    assert response.status_code == 503
+    assert User.get_by_email("walkin@example.com", test_db) is None
+
+  @patch.object(
+    __import__("robosystems.config", fromlist=["env"]).env,
+    "USER_REGISTRATION_ENABLED",
+    False,
+  )
+  @patch.dict(os.environ, {"ENVIRONMENT": "dev"})
+  def test_bogus_token_does_not_open_closed_registration(
+    self, client: TestClient, test_db
+  ):
+    """A made-up token must not buy passage past the gate — otherwise any
+    string would reach the checks below, including the duplicate-email probe
+    that closed registration exists to deny."""
+    response = client.post(
+      "/v1/auth/register",
+      json={
+        "name": "Probe",
+        "email": "probe@example.com",
+        "password": "S3cur3P@ssw0rd!2024",
+        "invite_token": "not-a-real-token",
+      },
+    )
+
+    assert response.status_code == 503
+    assert User.get_by_email("probe@example.com", test_db) is None


### PR DESCRIPTION
Found while turning invitations on in staging, which has `USER_REGISTRATION_ENABLED=false`: invitations could be *sent* but never *accepted*. The gate returned 503 before the invite token was ever examined, so the whole invite loop dead-ended at the last step.

## The change

An invitation is itself the authorization to register. Closing registration should stop unsolicited signups without blocking the people an org admin deliberately invited — so `register.py` now admits a registration that presents a valid invitation, and blocks everything else exactly as before.

That composition — `USER_REGISTRATION_ENABLED=false` + `ORG_MEMBER_INVITATIONS_ENABLED=true` — is **invite-only mode**, which is a chunk of what `specs/parking lot/controlled-registration.md` was written to provide, reached without any of its new flags.

## Why the gate resolves the token instead of checking for one

A presence check would let any string past the gate and into the checks below — including the duplicate-email probe that closed registration exists to deny. So the gate resolves the token against `org_invitations` and admits only a token that actually exists and is live. It's re-validated in full further down (email match, expiry, status), so a valid-but-wrong-email token still fails there as it did before.

The extra lookup sits behind the existing auth rate limiter, so it isn't a new unauthenticated probing surface.

## Test plan

`just test-all` — **11,863 passed**, 24 skipped; ruff, format, basedpyright, cf-lint clean.

Three new tests pin the behavior:
- invited user registers successfully while registration is closed, and lands in the inviting org
- an uninvited registration is still 503'd, and creates no user
- a made-up token does not open the gate — still 503, still no user

## Rollout

No migration, no flag of its own. Prod has `USER_REGISTRATION_ENABLED=true`, so nothing changes there until registration is deliberately closed. Staging is the environment this unblocks.