### PR TITLE
fix(orgs): scope org billing and graph views to the caller

### DIFF
--- a/robosystems/models/api/billing/subscription.py
+++ b/robosystems/models/api/billing/subscription.py
@@ -217,6 +217,16 @@ class CreateRepositorySubscriptionRequest(BaseModel):
     description="Plan name for the repository subscription",
     examples=["sec-starter"],
   )
+  user_id: str | None = Field(
+    default=None,
+    description=(
+      "Subscribe this user instead of yourself. Org owners and admins only, "
+      "and the target must belong to the same organization. Omit to subscribe "
+      "yourself. Repository access is per-user while billing is org-level, so "
+      "the subscriber is what determines who gets access."
+    ),
+    examples=["user_01ABC123"],
+  )
 
 
 class UpgradeSubscriptionRequest(BaseModel):

--- a/robosystems/routers/billing/subscriptions.py
+++ b/robosystems/routers/billing/subscriptions.py
@@ -56,16 +56,28 @@ async def list_subscriptions(
         detail="You are not a member of this organization",
       )
 
+    filters = [
+      BillingSubscription.org_id == org_id,
+      # Exclude orphaned subscriptions that never completed provisioning
+      ~(
+        BillingSubscription.status.in_(["canceled", "failed"])
+        & BillingSubscription.resource_id.is_(None)
+      ),
+    ]
+
+    # Billing is org-scoped but repository access is per-user, so an org-wide
+    # list hands a plain member every other member's subscriptions. Owners and
+    # admins manage billing and need the whole org; everyone else sees only the
+    # rows attributed to them. `user_id` is set on repository subscriptions and
+    # NULL on graph subscriptions, which are org-level resources rather than
+    # per-person ones — so a plain member sees neither other people's seats nor
+    # the org's graph inventory.
+    if not membership.can_manage_billing():
+      filters.append(BillingSubscription.user_id == current_user.id)
+
     subscriptions = (
       db.query(BillingSubscription)
-      .filter(
-        BillingSubscription.org_id == org_id,
-        # Exclude orphaned subscriptions that never completed provisioning
-        ~(
-          BillingSubscription.status.in_(["canceled", "failed"])
-          & BillingSubscription.resource_id.is_(None)
-        ),
-      )
+      .filter(*filters)
       .order_by(BillingSubscription.created_at.desc())
       .all()
     )

--- a/robosystems/routers/graphs/subscriptions.py
+++ b/robosystems/routers/graphs/subscriptions.py
@@ -194,7 +194,14 @@ async def get_subscription(
   response_model=GraphSubscriptionResponse,
   status_code=status.HTTP_201_CREATED,
   summary="Create Repository Subscription",
-  description="For shared repositories only (sec, industry, etc.). User graph subscriptions are created automatically during provisioning.",
+  description=(
+    "For shared repositories only (sec, industry, etc.). User graph "
+    "subscriptions are created automatically during provisioning. Subscribes "
+    "the caller by default; org owners and admins may subscribe another member "
+    "of their organization by passing `user_id`. Billing is charged to the "
+    "organization either way — repository access is per-user, so the "
+    "subscriber determines who receives access."
+  ),
   operation_id="createRepositorySubscription",
   responses={
     **RESOURCE_ERROR_RESPONSES,
@@ -223,8 +230,18 @@ async def create_repository_subscription(
         ),
       )
 
+    # Repository access is per-user while billing is org-level, so the
+    # subscriber — not the caller — is what determines who gets access. Owners
+    # and admins may subscribe another member of their org; everyone else
+    # resolves to themselves. Same rule (and same helper) as plan changes and
+    # cancellation, which have accepted a target user since Phase 3.
+    target_user_id, org_id = _resolve_subscription_target(
+      current_user, request.user_id, db
+    )
+    subscribing_for_other = target_user_id != current_user.id
+
     parent_repo_id = resolve_shared_repository_parent(graph_id)
-    # Only the caller's own subscription conflicts — repository access is
+    # Only the subscriber's own subscription conflicts — repository access is
     # per user, so a colleague's subscription is an upsell, not a duplicate.
     # And only a subscription still in force conflicts: canceled and failed
     # rows are kept as history, and an unfiltered check here turned one
@@ -232,7 +249,7 @@ async def create_repository_subscription(
     existing = BillingSubscription.get_by_resource_and_user(
       resource_type="repository",
       resource_id=parent_repo_id,
-      user_id=current_user.id,
+      user_id=target_user_id,
       session=db,
       exclude_statuses=TERMINAL_SUBSCRIPTION_STATUSES,
     )
@@ -240,7 +257,11 @@ async def create_repository_subscription(
     if existing:
       raise HTTPException(
         status_code=409,
-        detail=f"You already have an active subscription to the {graph_id} repository",
+        detail=(
+          f"That user already has an active subscription to the {graph_id} repository"
+          if subscribing_for_other
+          else f"You already have an active subscription to the {graph_id} repository"
+        ),
       )
 
     plan_config = BillingConfig.get_repository_plan(parent_repo_id, request.plan_name)
@@ -250,17 +271,8 @@ async def create_repository_subscription(
         detail=f"Invalid plan '{request.plan_name}' for repository '{graph_id}'",
       )
 
-    from ...models.core import OrgUser
-
-    user_orgs = OrgUser.get_user_orgs(current_user.id, db)
-    if not user_orgs:
-      raise HTTPException(
-        status_code=500,
-        detail="User organization not found. Please contact support.",
-      )
-
-    org_id = user_orgs[0].org_id
-
+    # org_id came from _resolve_subscription_target above, which already
+    # verified the caller's org membership and that any target user shares it.
     customer = BillingCustomer.get_or_create(org_id, db)
 
     can_provision, error_message = customer.can_provision_resources(
@@ -286,7 +298,7 @@ async def create_repository_subscription(
       base_price_cents=plan_config["price_cents"],
       session=db,
       billing_interval="monthly",
-      user_id=current_user.id,
+      user_id=target_user_id,
     )
 
     BillingAuditLog.log_event(
@@ -296,12 +308,16 @@ async def create_repository_subscription(
       subscription_id=subscription.id,
       description=f"Created {plan_name} subscription for {graph_id} repository",
       actor_type="user",
+      # The actor is who performed the action; the subscriber is who receives
+      # access. They differ when an owner or admin provisions for a member, and
+      # collapsing them would lose the record of who authorized the charge.
       actor_user_id=current_user.id,
       event_data={
         "resource_type": "repository",
         "resource_id": parent_repo_id,
         "plan_name": plan_name,
         "base_price_cents": plan_config["price_cents"],
+        "subscriber_user_id": target_user_id,
       },
     )
 
@@ -329,7 +345,7 @@ async def create_repository_subscription(
           price_id=stripe_price_id,
           metadata={
             "subscription_id": str(subscription.id),
-            "user_id": current_user.id,
+            "user_id": target_user_id,
             "resource_type": "repository",
             "resource_id": parent_repo_id,
           },
@@ -343,7 +359,8 @@ async def create_repository_subscription(
         logger.info(
           f"Created Stripe subscription for repository {graph_id}",
           extra={
-            "user_id": current_user.id,
+            "user_id": target_user_id,
+            "actor_user_id": current_user.id,
             "subscription_id": subscription.id,
             "stripe_subscription_id": stripe_subscription_id,
           },
@@ -353,7 +370,8 @@ async def create_repository_subscription(
         logger.error(
           f"Failed to create Stripe subscription for repository {graph_id}: {e}",
           extra={
-            "user_id": current_user.id,
+            "user_id": target_user_id,
+            "actor_user_id": current_user.id,
             "subscription_id": subscription.id,
             "plan_name": plan_name,
           },
@@ -366,9 +384,10 @@ async def create_repository_subscription(
           detail="Failed to create payment subscription. Please verify your payment method.",
         )
 
-    # Store IDs before commit detaches the objects
+    # Store IDs before commit detaches the objects. Provisioning grants the
+    # UserRepository row and credit pool, so it must key on the subscriber.
     subscription_id = subscription.id
-    user_id = current_user.id
+    user_id = target_user_id
 
     # Commit so run_user_repository_provisioning can see the subscription
     db.commit()

--- a/robosystems/routers/orgs/main.py
+++ b/robosystems/routers/orgs/main.py
@@ -14,11 +14,37 @@ from ...models.api.orgs import (
   OrgResponse,
   UpdateOrgRequest,
 )
-from ...models.core import Graph, OrgRole, OrgUser, User
+from ...models.core import Graph, GraphUser, OrgRole, OrgUser, User
 
 logger = get_logger(__name__)
 
 router = APIRouter(tags=["Org"])
+
+
+def _visible_org_graphs(
+  org_id: str, membership: OrgUser, user_id: str, db: Session
+) -> list[Graph]:
+  """Org graphs this user may see.
+
+  Org membership alone grants no graph access — a plain member needs an
+  explicit `GraphUser` grant — so listing every org graph to any member
+  discloses the names, tiers and IDs of graphs they cannot reach. Owners and
+  admins are implicit admins on every org-owned graph, so for them the visible
+  set is the whole org.
+
+  Mirrors the resolution `GraphUser.get_effective_role` performs per graph,
+  applied as a single query rather than per-row.
+  """
+  query = db.query(Graph).filter(Graph.org_id == org_id)
+
+  if membership.role in (OrgRole.OWNER, OrgRole.ADMIN):
+    return query.all()
+
+  granted = [gu.graph_id for gu in GraphUser.get_by_user_id(user_id, db)]
+  if not granted:
+    return []
+
+  return query.filter(Graph.graph_id.in_(granted)).all()
 
 
 @router.get(
@@ -115,7 +141,7 @@ async def get_org(
     limits = OrgLimits.get_by_org_id(org_id, db)
 
     # Get graphs
-    graphs = db.query(Graph).filter(Graph.org_id == org_id).all()
+    graphs = _visible_org_graphs(org_id, membership, current_user.id, db)
     graph_list = [
       {
         "graph_id": g.graph_id,
@@ -231,8 +257,8 @@ async def list_org_graphs(
         detail="You are not a member of this organization",
       )
 
-    # Get all graphs for the org
-    graphs = db.query(Graph).filter(Graph.org_id == org_id).all()
+    # Graphs this user may see — not every graph the org owns (see helper).
+    graphs = _visible_org_graphs(org_id, membership, current_user.id, db)
 
     result = []
     for graph in graphs:

--- a/tests/routers/billing/test_subscriptions.py
+++ b/tests/routers/billing/test_subscriptions.py
@@ -686,3 +686,61 @@ class TestCancelSubscription:
 
     assert exc.value.status_code == 403
     assert exc.value.detail == "Only organization owners can cancel subscriptions"
+
+
+class TestSubscriptionVisibilityByRole:
+  """Billing is org-scoped but repository access is per-user, so an org-wide
+  listing hands a plain member every colleague's subscription.
+
+  This was invisible while every org had one member: "all org subscriptions"
+  and "my subscriptions" were the same set.
+  """
+
+  @pytest.fixture
+  def mock_user(self):
+    user = Mock(spec=User)
+    user.id = "user_123"
+    return user
+
+  def _membership(self, can_manage: bool):
+    membership = Mock()
+    membership.can_manage_billing.return_value = can_manage
+    return membership
+
+  def _captured_filters(self, mock_db):
+    """The filter expressions handed to the subscription query."""
+    return mock_db.query.return_value.filter.call_args[0]
+
+  @pytest.mark.asyncio
+  @patch("robosystems.models.core.OrgUser.get_by_org_and_user")
+  async def test_member_listing_is_narrowed_to_their_own_rows(
+    self, mock_get_org_user, mock_user
+  ):
+    """A member who cannot manage billing gets an extra user_id predicate."""
+    mock_get_org_user.return_value = self._membership(can_manage=False)
+
+    mock_db = Mock()
+    mock_db.query.return_value.filter.return_value.order_by.return_value.all.return_value = []
+
+    await list_subscriptions("org_123", mock_user, mock_db, None)
+
+    filters = self._captured_filters(mock_db)
+    assert len(filters) == 3, "member listing must add the subscriber predicate"
+    assert "user_id" in str(filters[-1])
+
+  @pytest.mark.asyncio
+  @patch("robosystems.models.core.OrgUser.get_by_org_and_user")
+  async def test_billing_manager_listing_covers_the_whole_org(
+    self, mock_get_org_user, mock_user
+  ):
+    """Owners and admins manage billing, so they still see every row."""
+    mock_get_org_user.return_value = self._membership(can_manage=True)
+
+    mock_db = Mock()
+    mock_db.query.return_value.filter.return_value.order_by.return_value.all.return_value = []
+
+    await list_subscriptions("org_123", mock_user, mock_db, None)
+
+    filters = self._captured_filters(mock_db)
+    assert len(filters) == 2, "billing managers must not be narrowed by subscriber"
+    assert all("user_id" not in str(f) for f in filters)

--- a/tests/routers/graphs/test_subscriptions_router.py
+++ b/tests/routers/graphs/test_subscriptions_router.py
@@ -744,3 +744,102 @@ class TestChangePlanStripeFirst:
     assert exc.value.status_code == 502
     sub.update_plan.assert_not_called()
     user_repo.upgrade_tier.assert_not_called()
+
+
+class TestResolveSubscriptionTarget:
+  """Who may act on whose repository subscription.
+
+  Repository access is per-user while billing is org-level, so every
+  subscription endpoint needs to answer "which user is this for?" before doing
+  anything. This helper is that answer, and it now gates create as well as
+  plan-change and cancel.
+  """
+
+  def _user(self, user_id="user_self"):
+    user = Mock()
+    user.id = user_id
+    return user
+
+  def _membership(self, org_id="org_1", can_manage=False):
+    membership = Mock()
+    membership.org_id = org_id
+    membership.can_manage_billing.return_value = can_manage
+    return membership
+
+  @pytest.mark.unit
+  def test_no_target_resolves_to_caller(self):
+    """Omitting user_id means "me" — the default for self-service."""
+    from robosystems.routers.graphs.subscriptions import _resolve_subscription_target
+
+    db = Mock()
+    with patch("robosystems.models.core.OrgUser.get_user_orgs") as get_orgs:
+      get_orgs.return_value = [self._membership()]
+      target, org_id = _resolve_subscription_target(self._user(), None, db)
+
+    assert target == "user_self"
+    assert org_id == "org_1"
+
+  @pytest.mark.unit
+  def test_targeting_yourself_needs_no_billing_role(self):
+    """Passing your own id explicitly must not require owner/admin."""
+    from robosystems.routers.graphs.subscriptions import _resolve_subscription_target
+
+    db = Mock()
+    membership = self._membership(can_manage=False)
+    with patch("robosystems.models.core.OrgUser.get_user_orgs") as get_orgs:
+      get_orgs.return_value = [membership]
+      target, _ = _resolve_subscription_target(self._user(), "user_self", db)
+
+    assert target == "user_self"
+    membership.can_manage_billing.assert_not_called()
+
+  @pytest.mark.unit
+  def test_plain_member_cannot_target_another_user(self):
+    """A member may not subscribe, change, or cancel on someone else's behalf."""
+    from robosystems.routers.graphs.subscriptions import _resolve_subscription_target
+
+    db = Mock()
+    with patch("robosystems.models.core.OrgUser.get_user_orgs") as get_orgs:
+      get_orgs.return_value = [self._membership(can_manage=False)]
+      with pytest.raises(HTTPException) as exc:
+        _resolve_subscription_target(self._user(), "user_other", db)
+
+    assert exc.value.status_code == 403
+
+  @pytest.mark.unit
+  def test_billing_manager_may_target_a_fellow_member(self):
+    """Owners and admins act for members of their own org."""
+    from robosystems.routers.graphs.subscriptions import _resolve_subscription_target
+
+    db = Mock()
+    with (
+      patch("robosystems.models.core.OrgUser.get_user_orgs") as get_orgs,
+      patch("robosystems.models.core.OrgUser.get_by_org_and_user") as get_member,
+    ):
+      get_orgs.return_value = [self._membership(can_manage=True)]
+      get_member.return_value = Mock()
+      target, org_id = _resolve_subscription_target(self._user(), "user_other", db)
+
+    assert target == "user_other"
+    assert org_id == "org_1"
+
+  @pytest.mark.unit
+  def test_target_must_belong_to_the_same_org(self):
+    """Being an owner somewhere does not let you act on an outsider.
+
+    This is the cross-org guard: without it, any org owner could attach a
+    subscription to a user in a different organization.
+    """
+    from robosystems.routers.graphs.subscriptions import _resolve_subscription_target
+
+    db = Mock()
+    with (
+      patch("robosystems.models.core.OrgUser.get_user_orgs") as get_orgs,
+      patch("robosystems.models.core.OrgUser.get_by_org_and_user") as get_member,
+    ):
+      get_orgs.return_value = [self._membership(can_manage=True)]
+      get_member.return_value = None
+      with pytest.raises(HTTPException) as exc:
+        _resolve_subscription_target(self._user(), "user_outsider", db)
+
+    assert exc.value.status_code == 404

--- a/tests/routers/orgs/test_main.py
+++ b/tests/routers/orgs/test_main.py
@@ -14,6 +14,8 @@ import pytest
 
 from robosystems.models.core import (
   Graph,
+  GraphRole,
+  GraphUser,
   Org,
   OrgLimits,
   OrgRole,
@@ -268,3 +270,146 @@ class TestOrgRouter:
 
     assert response.status_code == 403
     assert response.json()["detail"] == "You are not a member of this organization"
+
+
+class TestOrgGraphVisibility:
+  """Org membership alone grants no graph access, so the org views must not
+  disclose graphs the caller cannot reach.
+
+  Every org had exactly one member (its owner) until multi-user orgs shipped,
+  which made "all org graphs" and "my graphs" the same set and hid this. The
+  second member is what separates them.
+  """
+
+  async def test_member_sees_only_granted_graphs(
+    self, async_client, test_db, test_user
+  ):
+    """A plain member sees graphs they hold a GraphUser row for — not the rest."""
+    owner = _create_member(test_db, test_user.password_hash)
+    org = Org.create(
+      name=f"Visibility Org {uuid4().hex[:6]}",
+      org_type=OrgType.TEAM,
+      session=test_db,
+    )
+    OrgUser.create(org_id=org.id, user_id=owner.id, role=OrgRole.OWNER, session=test_db)
+    OrgUser.create(
+      org_id=org.id, user_id=test_user.id, role=OrgRole.MEMBER, session=test_db
+    )
+
+    granted = Graph.create(
+      graph_id=f"graph_{uuid4().hex[:8]}",
+      org_id=org.id,
+      graph_name="Granted",
+      graph_type="generic",
+      session=test_db,
+    )
+    hidden = Graph.create(
+      graph_id=f"graph_{uuid4().hex[:8]}",
+      org_id=org.id,
+      graph_name="Hidden",
+      graph_type="generic",
+      session=test_db,
+    )
+    GraphUser.create(
+      user_id=test_user.id,
+      graph_id=granted.graph_id,
+      role=GraphRole.MEMBER,
+      session=test_db,
+    )
+
+    response = await async_client.get(f"/v1/orgs/{org.id}")
+
+    assert response.status_code == 200
+    visible = {g["graph_id"] for g in response.json()["graphs"]}
+    assert visible == {granted.graph_id}
+    assert hidden.graph_id not in visible
+
+  async def test_member_without_grants_sees_no_graphs(
+    self, async_client, test_db, test_user
+  ):
+    """An invited member who has not been granted anything sees an empty list."""
+    owner = _create_member(test_db, test_user.password_hash)
+    org = Org.create(
+      name=f"Ungranted Org {uuid4().hex[:6]}",
+      org_type=OrgType.TEAM,
+      session=test_db,
+    )
+    OrgUser.create(org_id=org.id, user_id=owner.id, role=OrgRole.OWNER, session=test_db)
+    OrgUser.create(
+      org_id=org.id, user_id=test_user.id, role=OrgRole.MEMBER, session=test_db
+    )
+    Graph.create(
+      graph_id=f"graph_{uuid4().hex[:8]}",
+      org_id=org.id,
+      graph_name="Owner Only",
+      graph_type="generic",
+      session=test_db,
+    )
+
+    response = await async_client.get(f"/v1/orgs/{org.id}")
+
+    assert response.status_code == 200
+    assert response.json()["graphs"] == []
+
+  async def test_owner_sees_every_org_graph_without_explicit_grants(
+    self, async_client, test_db, test_user
+  ):
+    """Owners are implicit graph admins, so they see the org's graphs with no
+    GraphUser rows of their own."""
+    org = Org.create(
+      name=f"Owner View Org {uuid4().hex[:6]}",
+      org_type=OrgType.TEAM,
+      session=test_db,
+    )
+    OrgUser.create(
+      org_id=org.id, user_id=test_user.id, role=OrgRole.OWNER, session=test_db
+    )
+    first = Graph.create(
+      graph_id=f"graph_{uuid4().hex[:8]}",
+      org_id=org.id,
+      graph_name="First",
+      graph_type="generic",
+      session=test_db,
+    )
+    second = Graph.create(
+      graph_id=f"graph_{uuid4().hex[:8]}",
+      org_id=org.id,
+      graph_name="Second",
+      graph_type="generic",
+      session=test_db,
+    )
+
+    response = await async_client.get(f"/v1/orgs/{org.id}")
+
+    assert response.status_code == 200
+    assert {g["graph_id"] for g in response.json()["graphs"]} == {
+      first.graph_id,
+      second.graph_id,
+    }
+
+  async def test_list_org_graphs_endpoint_applies_the_same_rule(
+    self, async_client, test_db, test_user
+  ):
+    """The dedicated graphs listing must not be a way around the detail view."""
+    owner = _create_member(test_db, test_user.password_hash)
+    org = Org.create(
+      name=f"Listing Org {uuid4().hex[:6]}",
+      org_type=OrgType.TEAM,
+      session=test_db,
+    )
+    OrgUser.create(org_id=org.id, user_id=owner.id, role=OrgRole.OWNER, session=test_db)
+    OrgUser.create(
+      org_id=org.id, user_id=test_user.id, role=OrgRole.MEMBER, session=test_db
+    )
+    Graph.create(
+      graph_id=f"graph_{uuid4().hex[:8]}",
+      org_id=org.id,
+      graph_name="Not Yours",
+      graph_type="generic",
+      session=test_db,
+    )
+
+    response = await async_client.get(f"/v1/orgs/{org.id}/graphs")
+
+    assert response.status_code == 200
+    assert response.json() == []


### PR DESCRIPTION
Org-scoped queries were standing in for user-scoped ones in three places. While every org had a single member the two sets were identical, so the divergence only shows up once an org has a second member.

## Changes

- **`list_subscriptions`** — returns only the caller's own rows unless they can manage billing. Owners and admins still see the whole org, so nothing changes for the people who manage it.
- **Org detail + org graph listing** — return the graphs the caller can actually reach, matching the resolution `get_effective_role` already performs per graph. Owners and admins are implicit graph admins, so their view is unchanged.
- **Repository subscription create** — accepts an optional `user_id`, letting an owner or admin subscribe a member. Routed through `_resolve_subscription_target`, the same helper plan changes and cancellation have used since per-user repository subscriptions landed. Omitting it subscribes the caller, so existing clients are unaffected. The audit actor stays the caller while the subscriber becomes the target — collapsing the two would lose who authorized the charge.

## Notes

`user_id` is populated on repository subscriptions and NULL on graph subscriptions, which are org-level rather than per-person — so the narrowed listing drops both other members' seats and the org's graph inventory.

No schema change, no new endpoints, no client-visible breakage.

## Tests

Four real-DB tests over the org views (member sees only granted graphs, member without grants sees none, owner sees all, and the dedicated listing applies the same rule), two over the subscription filter, and five over `_resolve_subscription_target` — which gated two endpoints already and had no coverage. The org tests were confirmed to fail against the previous behavior.

Full suite: 11,874 passed.