### PR TITLE
feat(graphs): restrict graph creation to org owners and admins

### DIFF
--- a/robosystems/models/api/orgs.py
+++ b/robosystems/models/api/orgs.py
@@ -146,16 +146,6 @@ class OrgLimitsResponse(BaseModel):
   current_usage: dict[str, Any]
   warnings: list[str]
   can_create_graph: bool
-  can_create_graph_reason: str | None = Field(
-    default=None,
-    description=(
-      "Why graph creation is unavailable to the caller, or null when it is "
-      "available. Distinguishes a quota that could be raised from a role "
-      "restriction the caller cannot resolve themselves, so clients can say "
-      "which applies instead of showing a dead control."
-    ),
-    examples=["Only organization owners and admins can create graphs"],
-  )
 
 
 class OrgUsageSummary(BaseModel):

--- a/robosystems/models/api/orgs.py
+++ b/robosystems/models/api/orgs.py
@@ -146,6 +146,16 @@ class OrgLimitsResponse(BaseModel):
   current_usage: dict[str, Any]
   warnings: list[str]
   can_create_graph: bool
+  can_create_graph_reason: str | None = Field(
+    default=None,
+    description=(
+      "Why graph creation is unavailable to the caller, or null when it is "
+      "available. Distinguishes a quota that could be raised from a role "
+      "restriction the caller cannot resolve themselves, so clients can say "
+      "which applies instead of showing a dead control."
+    ),
+    examples=["Only organization owners and admins can create graphs"],
+  )
 
 
 class OrgUsageSummary(BaseModel):

--- a/robosystems/models/core/org/org_user.py
+++ b/robosystems/models/core/org/org_user.py
@@ -137,3 +137,15 @@ class OrgUser(Model):
   def can_manage_billing(self) -> bool:
     """Check if user can manage billing settings."""
     return self.is_admin()
+
+  def can_create_graphs(self) -> bool:
+    """Check if user can create graphs for the org.
+
+    Creating a graph provisions infrastructure, consumes the org's
+    `max_graphs` quota and starts a recurring charge on the org's payment
+    method, so it is an org-level commitment rather than a personal one.
+    Named separately from `can_manage_billing` because the two can diverge:
+    this governs spending on the org's behalf, not administering the billing
+    account itself.
+    """
+    return self.is_admin()

--- a/robosystems/operations/graph/graph_creation_service.py
+++ b/robosystems/operations/graph/graph_creation_service.py
@@ -197,7 +197,16 @@ class GraphCreationService:
       if not user_orgs:
         raise ValueError("User has no organization")
 
-      org_id = user_orgs[0].org_id
+      membership = user_orgs[0]
+      org_id = membership.org_id
+
+      # Re-checked here as well as at the API boundary for the same reason the
+      # quota is: creation can be queued and retried, so the role is
+      # re-evaluated when the work actually runs rather than trusted from
+      # whenever it was requested.
+      if not membership.can_create_graphs():
+        raise ValueError("Only organization owners and admins can create graphs")
+
       org_limits = OrgLimits.get_or_create_for_org(org_id, db)
       can_create, reason = org_limits.can_create_graph(db)
       if not can_create:

--- a/robosystems/routers/graphs/main.py
+++ b/robosystems/routers/graphs/main.py
@@ -299,7 +299,25 @@ async def create_graph(
         message="User organization not found. Please contact support.",
       )
 
-    org_id = user_orgs[0].org_id
+    membership = user_orgs[0]
+    org_id = membership.org_id
+
+    # Creating a graph starts a recurring charge on the org's payment method
+    # and consumes org quota, so it is an owner/admin action. Members cannot
+    # add a payment method either (checkout is owner-only), so without this a
+    # member could commit the org's stored card without its billing
+    # administrators knowing until the invoice arrived.
+    if not membership.can_create_graphs():
+      _raise_http_exception(
+        status_code=status.HTTP_403_FORBIDDEN,
+        error_code="graph_creation_requires_admin",
+        message=(
+          "Only organization owners and admins can create graphs. "
+          "Ask an owner or admin to create one, or to grant you access to "
+          "an existing graph."
+        ),
+      )
+
     org_limits = OrgLimits.get_or_create_for_org(org_id, db)
 
     can_create, reason = org_limits.can_create_graph(db)

--- a/robosystems/routers/orgs/usage.py
+++ b/robosystems/routers/orgs/usage.py
@@ -71,12 +71,24 @@ async def get_org_limits(
     if current_graphs >= limits.max_graphs * 0.9:
       warnings.append(f"Approaching graph limit ({current_graphs}/{limits.max_graphs})")
 
+    # Two independent reasons creation can be unavailable, and clients need to
+    # tell them apart: a quota is raisable, a role restriction is not — the
+    # member has to ask someone else. Resolving both here keeps the rule in one
+    # place instead of having every client re-derive it from the caller's role.
+    if not membership.can_create_graphs():
+      can_create_graph = False
+      can_create_graph_reason = "Only organization owners and admins can create graphs"
+    else:
+      can_create_graph, quota_reason = limits.can_create_graph(db)
+      can_create_graph_reason = None if can_create_graph else quota_reason
+
     return OrgLimitsResponse(
       org_id=org_id,
       max_graphs=limits.max_graphs,
       current_usage=usage,
       warnings=warnings,
-      can_create_graph=limits.can_create_graph(db)[0],
+      can_create_graph=can_create_graph,
+      can_create_graph_reason=can_create_graph_reason,
     )
 
   except HTTPException:

--- a/robosystems/routers/orgs/usage.py
+++ b/robosystems/routers/orgs/usage.py
@@ -71,16 +71,10 @@ async def get_org_limits(
     if current_graphs >= limits.max_graphs * 0.9:
       warnings.append(f"Approaching graph limit ({current_graphs}/{limits.max_graphs})")
 
-    # Two independent reasons creation can be unavailable, and clients need to
-    # tell them apart: a quota is raisable, a role restriction is not — the
-    # member has to ask someone else. Resolving both here keeps the rule in one
-    # place instead of having every client re-derive it from the caller's role.
-    if not membership.can_create_graphs():
-      can_create_graph = False
-      can_create_graph_reason = "Only organization owners and admins can create graphs"
-    else:
-      can_create_graph, quota_reason = limits.can_create_graph(db)
-      can_create_graph_reason = None if can_create_graph else quota_reason
+    # Role as well as quota: reporting True to a member who would be refused at
+    # the create endpoint would make this flag a lie, and clients act on it —
+    # the graph-creation page gates its whole wizard behind it.
+    can_create_graph = membership.can_create_graphs() and limits.can_create_graph(db)[0]
 
     return OrgLimitsResponse(
       org_id=org_id,
@@ -88,7 +82,6 @@ async def get_org_limits(
       current_usage=usage,
       warnings=warnings,
       can_create_graph=can_create_graph,
-      can_create_graph_reason=can_create_graph_reason,
     )
 
   except HTTPException:

--- a/tests/routers/graphs/test_graph.py
+++ b/tests/routers/graphs/test_graph.py
@@ -991,3 +991,60 @@ class TestGraphCapacityEndpoint:
       # Others succeed
       assert status_map["ladybug-large"]["status"] == "ready"
       assert status_map["ladybug-xlarge"]["status"] == "ready"
+
+
+class TestGraphCreationRequiresAdmin:
+  """Creating a graph starts a recurring charge on the org's payment method
+  and consumes org quota, so it is an owner/admin action.
+
+  Members cannot add a payment method either — checkout is owner-only — so
+  without this gate a member could commit the org's stored card without its
+  billing administrators knowing until the invoice arrived.
+  """
+
+  @pytest.fixture
+  def graph_request(self):
+    return CreateGraphRequest(
+      metadata=GraphMetadata(
+        graph_name="Members Cannot Create",
+        description="Role gate coverage",
+        schema_extensions=["roboledger"],
+      ),
+      instance_tier="ladybug-standard",
+      custom_schema=None,
+      initial_entity=InitialEntityData(name="Test Corp", uri="https://testcorp.com"),
+      tags=["test"],
+    )
+
+  async def test_plain_member_is_refused(
+    self, async_client: AsyncClient, graph_request
+  ):
+    """A member gets 403 before quota is even consulted."""
+    with (
+      patch("robosystems.database.get_db_session") as mock_get_db,
+      patch("robosystems.models.core.OrgUser.get_user_orgs") as mock_get_user_orgs,
+    ):
+      mock_limits = Mock(spec=OrgLimits)
+      # Quota is wide open; the refusal must come from the role check alone.
+      mock_limits.can_create_graph.return_value = (True, "Can create graph")
+
+      with patch.object(OrgLimits, "get_or_create_for_org", return_value=mock_limits):
+        mock_get_db.return_value = iter([Mock()])
+
+        mock_org_user = Mock()
+        mock_org_user.org_id = "test-org-123"
+        mock_org_user.can_create_graphs.return_value = False
+        mock_get_user_orgs.return_value = [mock_org_user]
+
+        response = await async_client.post(
+          "/v1/graphs",
+          json=graph_request.model_dump(),
+        )
+
+        assert response.status_code == 403
+        error = response.json()["detail"]["error"]
+        assert error["code"] == "graph_creation_requires_admin"
+        # The message has to point somewhere actionable: unlike a quota, the
+        # member cannot resolve this themselves.
+        assert "owners and admins" in error["message"]
+        mock_limits.can_create_graph.assert_not_called()

--- a/tests/routers/orgs/test_usage.py
+++ b/tests/routers/orgs/test_usage.py
@@ -310,12 +310,14 @@ class TestOrgUsageEndpoints:
 
 
 class TestGraphCreationAllowance:
-  """`can_create_graph` answers two different questions, and clients need to
-  tell them apart: a quota can be raised, a role restriction cannot — the
-  member has to ask someone else. Only the reason distinguishes them.
+  """`can_create_graph` must account for role as well as quota.
+
+  Clients gate real UI on this flag — the graph-creation page hides its whole
+  wizard behind it — so reporting True to a member the create endpoint would
+  refuse sends them into a flow that 403s at the end.
   """
 
-  async def test_member_is_refused_with_a_role_reason(
+  async def test_member_is_refused_even_with_quota_available(
     self, async_client, test_db, test_user
   ):
     """A plain member cannot create graphs regardless of remaining quota."""
@@ -340,12 +342,9 @@ class TestGraphCreationAllowance:
     # Quota is wide open — the refusal is purely about role.
     assert payload["current_usage"]["graphs"]["current"] == 0
     assert payload["can_create_graph"] is False
-    assert "owners and admins" in payload["can_create_graph_reason"]
 
-  async def test_admin_with_quota_is_allowed_and_has_no_reason(
-    self, async_client, test_db, test_user
-  ):
-    """An admin under quota gets a clean allowance with no explanation."""
+  async def test_admin_with_quota_is_allowed(self, async_client, test_db, test_user):
+    """An admin under quota is allowed."""
     org = Org.create(
       name=f"Admin Allowed Org {uuid4().hex[:6]}",
       org_type=OrgType.TEAM,
@@ -363,13 +362,11 @@ class TestGraphCreationAllowance:
     assert response.status_code == 200
     payload = response.json()
     assert payload["can_create_graph"] is True
-    assert payload["can_create_graph_reason"] is None
 
-  async def test_admin_at_quota_is_refused_with_a_quota_reason(
+  async def test_admin_at_quota_is_still_refused(
     self, async_client, test_db, test_user
   ):
-    """An admin at the cap is refused for a reason they *can* act on, which is
-    why it must read differently from the role refusal."""
+    """Role passing does not bypass the quota check."""
     org = Org.create(
       name=f"Admin Capped Org {uuid4().hex[:6]}",
       org_type=OrgType.TEAM,
@@ -388,6 +385,3 @@ class TestGraphCreationAllowance:
     assert response.status_code == 200
     payload = response.json()
     assert payload["can_create_graph"] is False
-    reason = payload["can_create_graph_reason"]
-    assert "limit" in reason.lower()
-    assert "owners and admins" not in reason

--- a/tests/routers/orgs/test_usage.py
+++ b/tests/routers/orgs/test_usage.py
@@ -307,3 +307,87 @@ class TestOrgUsageEndpoints:
     assert body["period_days"] == 45
     assert len(body["daily_trend"]) == 30
     assert all(entry["credits_used"] == 0 for entry in body["daily_trend"])
+
+
+class TestGraphCreationAllowance:
+  """`can_create_graph` answers two different questions, and clients need to
+  tell them apart: a quota can be raised, a role restriction cannot — the
+  member has to ask someone else. Only the reason distinguishes them.
+  """
+
+  async def test_member_is_refused_with_a_role_reason(
+    self, async_client, test_db, test_user
+  ):
+    """A plain member cannot create graphs regardless of remaining quota."""
+    owner = _create_user(test_db, password_hash=test_user.password_hash)
+    org = Org.create(
+      name=f"Role Gate Org {uuid4().hex[:6]}",
+      org_type=OrgType.TEAM,
+      session=test_db,
+    )
+    OrgUser.create(org_id=org.id, user_id=owner.id, role=OrgRole.OWNER, session=test_db)
+    OrgUser.create(
+      org_id=org.id, user_id=test_user.id, role=OrgRole.MEMBER, session=test_db
+    )
+    limits = OrgLimits.create_default_limits(org_id=org.id, session=test_db)
+    limits.max_graphs = 10
+    test_db.commit()
+
+    response = await async_client.get(f"/v1/orgs/{org.id}/limits")
+
+    assert response.status_code == 200
+    payload = response.json()
+    # Quota is wide open — the refusal is purely about role.
+    assert payload["current_usage"]["graphs"]["current"] == 0
+    assert payload["can_create_graph"] is False
+    assert "owners and admins" in payload["can_create_graph_reason"]
+
+  async def test_admin_with_quota_is_allowed_and_has_no_reason(
+    self, async_client, test_db, test_user
+  ):
+    """An admin under quota gets a clean allowance with no explanation."""
+    org = Org.create(
+      name=f"Admin Allowed Org {uuid4().hex[:6]}",
+      org_type=OrgType.TEAM,
+      session=test_db,
+    )
+    OrgUser.create(
+      org_id=org.id, user_id=test_user.id, role=OrgRole.ADMIN, session=test_db
+    )
+    limits = OrgLimits.create_default_limits(org_id=org.id, session=test_db)
+    limits.max_graphs = 10
+    test_db.commit()
+
+    response = await async_client.get(f"/v1/orgs/{org.id}/limits")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["can_create_graph"] is True
+    assert payload["can_create_graph_reason"] is None
+
+  async def test_admin_at_quota_is_refused_with_a_quota_reason(
+    self, async_client, test_db, test_user
+  ):
+    """An admin at the cap is refused for a reason they *can* act on, which is
+    why it must read differently from the role refusal."""
+    org = Org.create(
+      name=f"Admin Capped Org {uuid4().hex[:6]}",
+      org_type=OrgType.TEAM,
+      session=test_db,
+    )
+    OrgUser.create(
+      org_id=org.id, user_id=test_user.id, role=OrgRole.OWNER, session=test_db
+    )
+    _create_graph(test_db, org.id, "Only")
+    limits = OrgLimits.create_default_limits(org_id=org.id, session=test_db)
+    limits.max_graphs = 1
+    test_db.commit()
+
+    response = await async_client.get(f"/v1/orgs/{org.id}/limits")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["can_create_graph"] is False
+    reason = payload["can_create_graph_reason"]
+    assert "limit" in reason.lower()
+    assert "owners and admins" not in reason


### PR DESCRIPTION
Creating a graph provisions infrastructure, consumes the org's `max_graphs` quota, and starts a recurring charge on the org's payment method — an org-level commitment that any member could make.

Members cannot add a payment method (checkout is already owner-only), so the effect was that a member could commit the org's *stored* card without its billing administrators knowing until the invoice arrived. `checkout.py` already states the rule — "Only organization owners can manage billing" — the create paths just didn't honor it.

## Changes

- **`OrgUser.can_create_graphs()`** — named separately from `can_manage_billing` because the two can diverge: spending on the org's behalf versus administering the billing account itself.
- **Enforced at the create endpoint**, before quota is consulted, with a distinct `graph_creation_requires_admin` code.
- **Enforced again in `GraphCreationService`**, for the same reason the quota is re-checked there: creation can be queued and retried, so the role is evaluated when the work runs rather than trusted from when it was requested.
- **`getOrgLimits` accounts for role in `can_create_graph`.** Returning `true` to a member the create endpoint would refuse makes the flag a lie, and clients gate real UI on it — the graph-creation page hides its entire wizard behind it.

## Compatibility

No response-shape change. Existing clients reading `can_create_graph` get correct behavior as soon as this deploys, which is what makes the app's existing `/graphs/new` guard start catching members.

Every existing graph-creation test passes unchanged — the happy path is untouched.

## Tests

Four new: a member is refused while quota is wide open, an admin under quota is allowed, an admin at the cap is still refused, and the create endpoint refuses a member before consulting quota at all.

Full suite: 11,878 passed.

## Note

An earlier revision added a `can_create_graph_reason` string, on the argument that clients must distinguish a raisable quota from a role restriction. No client ended up using it — the app reads role from org context, since `/home` has no other reason to fetch limits — so it was removed rather than merged unconsumed. It is additive and nullable if a consumer appears.