### PR TITLE
fix(orgs): scope org usage and align graph counts

### DIFF
--- a/robosystems/routers/billing/subscriptions.py
+++ b/robosystems/routers/billing/subscriptions.py
@@ -149,14 +149,18 @@ async def get_subscription(
         detail="You are not a member of this organization",
       )
 
-    subscription = (
-      db.query(BillingSubscription)
-      .filter(
-        BillingSubscription.id == subscription_id,
-        BillingSubscription.org_id == org_id,
-      )
-      .first()
-    )
+    filters = [
+      BillingSubscription.id == subscription_id,
+      BillingSubscription.org_id == org_id,
+    ]
+
+    # Same narrowing the listing applies: a member sees their own subscriptions,
+    # billing managers see the org's. Without it, fetch-by-id remains a way
+    # around the filtered list for anyone holding an id.
+    if not membership.can_manage_billing():
+      filters.append(BillingSubscription.user_id == current_user.id)
+
+    subscription = db.query(BillingSubscription).filter(*filters).first()
 
     if not subscription:
       raise HTTPException(status_code=404, detail="Subscription not found")

--- a/robosystems/routers/orgs/main.py
+++ b/robosystems/routers/orgs/main.py
@@ -66,9 +66,13 @@ async def list_user_orgs(
     orgs = []
     for membership in org_memberships:
       org = membership.org
-      # Count members and graphs for each org
+      # Count members and graphs for each org. The graph count matches what the
+      # org detail view will actually list — counting every org graph here left
+      # a member reading "2 graphs" on the org card and then finding an empty
+      # list, since membership alone grants no graph access. Member count stays
+      # org-wide: the roster is visible to everyone in the org.
       member_count = len(OrgUser.get_org_users(org.id, db))
-      graph_count = db.query(Graph).filter(Graph.org_id == org.id).count()
+      graph_count = len(_visible_org_graphs(org.id, membership, current_user.id, db))
 
       orgs.append(
         OrgResponse(

--- a/robosystems/routers/orgs/usage.py
+++ b/robosystems/routers/orgs/usage.py
@@ -113,6 +113,17 @@ async def get_org_usage(
         detail="You are not a member of this organization",
       )
 
+    # This is an org-wide aggregate — per-graph names, credit balances and
+    # storage for every graph the org owns — so it is billing-shaped rather
+    # than caller-shaped, and gated like invoices. Narrowing it to the caller's
+    # graphs instead would make "organization usage" mean something different
+    # per reader; a plain member has no accessible view of an org-wide total.
+    if not membership.is_admin():
+      raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail="Only admins and owners can view organization usage",
+      )
+
     # Get all graphs for the org
     graphs = db.query(Graph).filter(Graph.org_id == org_id).all()
     graph_ids = [g.graph_id for g in graphs]
@@ -124,7 +135,7 @@ async def get_org_usage(
     # Aggregate credit usage across all graphs
     total_credits_used = Decimal(0)
     total_ai_operations = 0
-    total_storage_gb = Decimal(0)
+    total_storage_gb = 0.0
     total_api_calls = 0
 
     graph_usage_details = []
@@ -169,7 +180,12 @@ async def get_org_usage(
         .first()
       )
 
-      graph_storage = latest_storage.storage_gb if latest_storage else Decimal(0)
+      # GraphUsage.storage_gb is a Float column while the running total was a
+      # Decimal, so the first graph with a storage snapshot raised
+      # "unsupported operand type(s) for +=: 'decimal.Decimal' and 'float'"
+      # and 500'd the whole endpoint. Any org with real graph activity has
+      # snapshots, so this failed for exactly the orgs it mattered for.
+      graph_storage = float(latest_storage.storage_gb or 0) if latest_storage else 0.0
 
       graph_usage_details.append(
         {
@@ -177,7 +193,7 @@ async def get_org_usage(
           "graph_name": graph.graph_name,
           "credits_used": float(graph_credits_used),
           "ai_operations": graph_ai_ops,
-          "storage_gb": float(graph_storage),
+          "storage_gb": graph_storage,
           "api_calls": graph_api_calls,
           "credits_available": float(credits.current_balance) if credits else 0,
           "credits_allocated": float(credits.monthly_allocation) if credits else 0,

--- a/tests/routers/billing/test_subscriptions.py
+++ b/tests/routers/billing/test_subscriptions.py
@@ -744,3 +744,52 @@ class TestSubscriptionVisibilityByRole:
     filters = self._captured_filters(mock_db)
     assert len(filters) == 2, "billing managers must not be narrowed by subscriber"
     assert all("user_id" not in str(f) for f in filters)
+
+
+class TestSubscriptionFetchNarrowing:
+  """Fetch-by-id must apply the same narrowing as the listing, or it stays a
+  way around the filtered list for anyone holding an id."""
+
+  @pytest.fixture
+  def mock_user(self):
+    user = Mock(spec=User)
+    user.id = "user_123"
+    return user
+
+  def _membership(self, can_manage: bool):
+    membership = Mock()
+    membership.can_manage_billing.return_value = can_manage
+    return membership
+
+  @pytest.mark.asyncio
+  @patch("robosystems.models.core.OrgUser.get_by_org_and_user")
+  async def test_member_fetch_is_narrowed_to_their_own(
+    self, mock_get_org_user, mock_user
+  ):
+    mock_get_org_user.return_value = self._membership(can_manage=False)
+    mock_db = Mock()
+    mock_db.query.return_value.filter.return_value.first.return_value = None
+
+    with pytest.raises(HTTPException) as exc:
+      await get_subscription("org_123", "bsub_other", mock_user, mock_db, None)
+
+    assert exc.value.status_code == 404
+    filters = mock_db.query.return_value.filter.call_args[0]
+    assert len(filters) == 3
+    assert "user_id" in str(filters[-1])
+
+  @pytest.mark.asyncio
+  @patch("robosystems.models.core.OrgUser.get_by_org_and_user")
+  async def test_billing_manager_fetch_is_not_narrowed(
+    self, mock_get_org_user, mock_user
+  ):
+    mock_get_org_user.return_value = self._membership(can_manage=True)
+    mock_db = Mock()
+    mock_db.query.return_value.filter.return_value.first.return_value = None
+
+    with pytest.raises(HTTPException):
+      await get_subscription("org_123", "bsub_any", mock_user, mock_db, None)
+
+    filters = mock_db.query.return_value.filter.call_args[0]
+    assert len(filters) == 2
+    assert all("user_id" not in str(f) for f in filters)

--- a/tests/routers/orgs/test_usage.py
+++ b/tests/routers/orgs/test_usage.py
@@ -177,7 +177,10 @@ class TestOrgUsageEndpoints:
         graph_id=graph.graph_id,
         event_type=UsageEventType.STORAGE_SNAPSHOT.value,
         graph_tier=graph.graph_tier,
-        storage_gb=Decimal("7.5"),
+        # Float, matching the column type. Seeding a Decimal here was why the
+        # production crash stayed invisible: Decimal += Decimal aggregated
+        # fine, while real rows are floats and raised a TypeError.
+        storage_gb=7.5,
         recorded_at=now,
         billing_year=now.year,
         billing_month=now.month,
@@ -307,3 +310,96 @@ class TestOrgUsageEndpoints:
     assert body["period_days"] == 45
     assert len(body["daily_trend"]) == 30
     assert all(entry["credits_used"] == 0 for entry in body["daily_trend"])
+
+
+class TestOrgUsageVisibility:
+  """Org usage is an org-wide aggregate — per-graph names, credit balances and
+  storage for every graph the org owns — so it is gated like invoices rather
+  than narrowed per caller. A plain member has no accessible view of an
+  org-wide total.
+  """
+
+  async def test_member_cannot_read_org_usage(self, async_client, test_db, test_user):
+    owner = _create_user(test_db, password_hash=test_user.password_hash)
+    org = Org.create(
+      name=f"Usage Gate Org {uuid4().hex[:6]}",
+      org_type=OrgType.TEAM,
+      session=test_db,
+    )
+    OrgUser.create(org_id=org.id, user_id=owner.id, role=OrgRole.OWNER, session=test_db)
+    OrgUser.create(
+      org_id=org.id, user_id=test_user.id, role=OrgRole.MEMBER, session=test_db
+    )
+    _create_graph(test_db, org.id, "Not Yours")
+
+    response = await async_client.get(f"/v1/orgs/{org.id}/usage")
+
+    assert response.status_code == 403
+    assert "admins and owners" in response.json()["detail"]
+
+  async def test_admin_can_read_org_usage(self, async_client, test_db, test_user):
+    org = Org.create(
+      name=f"Usage Allowed Org {uuid4().hex[:6]}",
+      org_type=OrgType.TEAM,
+      session=test_db,
+    )
+    OrgUser.create(
+      org_id=org.id, user_id=test_user.id, role=OrgRole.ADMIN, session=test_db
+    )
+
+    response = await async_client.get(f"/v1/orgs/{org.id}/usage")
+
+    assert response.status_code == 200
+
+
+class TestOrgGraphCountConsistency:
+  """The count on the org card must match what the org detail view lists.
+
+  Counting every org graph left a member reading "2 graphs" and then finding
+  an empty list, since membership alone grants no graph access.
+  """
+
+  async def test_member_count_matches_visible_graphs(
+    self, async_client, test_db, test_user
+  ):
+    owner = _create_user(test_db, password_hash=test_user.password_hash)
+    org = Org.create(
+      name=f"Count Org {uuid4().hex[:6]}",
+      org_type=OrgType.TEAM,
+      session=test_db,
+    )
+    OrgUser.create(org_id=org.id, user_id=owner.id, role=OrgRole.OWNER, session=test_db)
+    OrgUser.create(
+      org_id=org.id, user_id=test_user.id, role=OrgRole.MEMBER, session=test_db
+    )
+    granted = _create_graph(test_db, org.id, "Granted")
+    _create_graph(test_db, org.id, "Hidden")
+    GraphUser.create(
+      user_id=test_user.id, graph_id=granted.graph_id, role="member", session=test_db
+    )
+
+    listing = await async_client.get("/v1/orgs")
+    detail = await async_client.get(f"/v1/orgs/{org.id}")
+
+    assert listing.status_code == 200
+    assert detail.status_code == 200
+    entry = next(o for o in listing.json()["orgs"] if o["id"] == org.id)
+    assert entry["graph_count"] == 1
+    assert len(detail.json()["graphs"]) == entry["graph_count"]
+
+  async def test_owner_count_covers_the_org(self, async_client, test_db, test_user):
+    org = Org.create(
+      name=f"Owner Count Org {uuid4().hex[:6]}",
+      org_type=OrgType.TEAM,
+      session=test_db,
+    )
+    OrgUser.create(
+      org_id=org.id, user_id=test_user.id, role=OrgRole.OWNER, session=test_db
+    )
+    _create_graph(test_db, org.id, "One")
+    _create_graph(test_db, org.id, "Two")
+
+    listing = await async_client.get("/v1/orgs")
+
+    entry = next(o for o in listing.json()["orgs"] if o["id"] == org.id)
+    assert entry["graph_count"] == 2


### PR DESCRIPTION
Completes the sweep of org-scoped reads that #1026 started. Same pattern each time: an org-scoped query standing in for a caller-scoped one, invisible while every org had a single member.

## Scope fixes

- **Org usage** required only membership while returning per-graph names, credit balances and storage for every graph the org owns. Now gated to admins and owners, like invoices — it is an org-wide aggregate, so narrowing it per caller would make the total mean something different per reader.
- **Subscription fetch-by-id** now applies the same narrowing as the listing, which otherwise stayed reachable for anyone holding an id.
- **The org card counted every org graph** while the detail view lists only reachable ones, so a member read "2 graphs" and then found an empty list. Member count stays org-wide — the roster is visible to everyone in the org.

## A live crash in the same endpoint

`GraphUsage.storage_gb` is a `Float` column while the running total was a `Decimal`, so the first graph with a storage snapshot raised:

```
unsupported operand type(s) for +=: 'decimal.Decimal' and 'float'
```

Every org with real graph activity has snapshots, so this 500'd for exactly the orgs it mattered for — owners included. It also **masked the scope gap above**, since the endpoint errored before returning anything; fixing the scope alone would have exposed the leak, and fixing the crash alone would have started serving it.

## Why the tests didn't catch it

The existing test seeded `storage_gb=Decimal("7.5")` — matching neither the column type nor production rows — so `Decimal += Decimal` aggregated cleanly and the suite stayed green. Corrected to a float; against the previous code it reproduces the exact `TypeError`.

## Tests

Six new: member refused / admin allowed on org usage, the org card count matching the detail listing for both a member and an owner, and fetch-by-id narrowing for a member versus a billing manager.

Full suite: 11,880 passed.

## Remaining sites reviewed, deliberately unchanged

`orgs/members.py:312` (off-boarding must revoke across every org graph), the nine `admin/*` sites (admin plane), and billing cancel / invoices / checkout (already owner or owner-admin gated).