### PR TITLE
refactor(billing): point app URLs at their real destinations

### DIFF
--- a/robosystems/config/shared_repositories.py
+++ b/robosystems/config/shared_repositories.py
@@ -300,7 +300,7 @@ def get_all_repository_pricing() -> dict:
     "plans": plans,
     "repositories": repositories,
     "billing_model": "No credit consumption for queries, rate-limited by subscription tier",
-    "upgrade_url": f"{env.ROBOSYSTEMS_URL}/billing",
+    "upgrade_url": f"{env.ROBOSYSTEMS_URL}/repositories/browse",
   }
 
 

--- a/robosystems/middleware/rate_limits/repository_rate_limits.py
+++ b/robosystems/middleware/rate_limits/repository_rate_limits.py
@@ -135,7 +135,7 @@ class DualLayerRateLimiter:
         "allowed": False,
         "reason": "no_access",
         "message": f"Access to {graph_id} repository requires a paid subscription",
-        "upgrade_url": f"{env.ROBOSYSTEMS_URL}/billing",
+        "upgrade_url": f"{env.ROBOSYSTEMS_URL}/repositories/browse",
       }
 
     repo_check = await self._check_repository_limit(

--- a/robosystems/operations/providers/payment_provider.py
+++ b/robosystems/operations/providers/payment_provider.py
@@ -206,7 +206,7 @@ class StripePaymentProvider(PaymentProvider):
       mode="subscription",
       line_items=[{"price": price_id, "quantity": 1}],
       success_url=f"{env.ROBOSYSTEMS_URL}/checkout/{{CHECKOUT_SESSION_ID}}",
-      cancel_url=f"{env.ROBOSYSTEMS_URL}/billing",
+      cancel_url=f"{env.ROBOSYSTEMS_URL}/organization?tab=billing",
       metadata=metadata,
       payment_method_types=["card"],
       billing_address_collection="auto",

--- a/robosystems/routers/billing/customer.py
+++ b/robosystems/routers/billing/customer.py
@@ -137,7 +137,9 @@ async def create_portal_session(
         f"Created Stripe customer for org {org_id} during portal session",
         extra={"org_id": org_id, "user_id": current_user.id},
       )
-    return_url = f"{env.ROBOSYSTEMS_URL}/billing"
+    # Billing lives on the org page's Billing tab; /billing still redirects here
+    # for older sessions, but returning directly avoids a redirect hop.
+    return_url = f"{env.ROBOSYSTEMS_URL}/organization?tab=billing"
     portal_url = provider.create_portal_session(customer.stripe_customer_id, return_url)
 
     logger.info(

--- a/robosystems/routers/graphs/mcp/execute.py
+++ b/robosystems/routers/graphs/mcp/execute.py
@@ -417,7 +417,7 @@ async def call_mcp_tool(
       if not repo_access:
         raise HTTPException(
           status_code=http_status.HTTP_403_FORBIDDEN,
-          detail=f"Access to {graph_id.upper()} repository requires a subscription. Visit {env.ROBOSYSTEMS_URL}/billing",
+          detail=f"Access to {graph_id.upper()} repository requires a subscription. Visit {env.ROBOSYSTEMS_URL}/repositories/browse",
         )
 
       # Get Redis client for rate limiting with proper ElastiCache support
@@ -443,7 +443,7 @@ async def call_mcp_tool(
           if reason == "no_access":
             raise HTTPException(
               status_code=http_status.HTTP_403_FORBIDDEN,
-              detail=f"{message}. Subscribe at {env.ROBOSYSTEMS_URL}/billing",
+              detail=f"{message}. Subscribe at {env.ROBOSYSTEMS_URL}/repositories/browse",
             )
           elif reason == "endpoint_not_allowed":
             raise HTTPException(
@@ -455,7 +455,7 @@ async def call_mcp_tool(
             raise HTTPException(
               status_code=http_status.HTTP_429_TOO_MANY_REQUESTS,
               detail=f"{message}. Limit: {detail.get('limit', 0)} per {detail.get('window', 'period')}. "
-              f"Upgrade for higher limits at {env.ROBOSYSTEMS_URL}/billing",
+              f"Upgrade for higher limits at {env.ROBOSYSTEMS_URL}/repositories/browse",
               headers={
                 "Retry-After": str(detail.get("retry_after", 60)),
                 "X-RateLimit-Repository": graph_id,

--- a/robosystems/routers/graphs/query/execute.py
+++ b/robosystems/routers/graphs/query/execute.py
@@ -741,7 +741,7 @@ async def _check_shared_repository_limits(
     raise HTTPException(
       status_code=http_status.HTTP_403_FORBIDDEN,
       detail=f"You don't have access to the '{graph_id}' repository. "
-      f"Subscribe at {env.ROBOSYSTEMS_URL}/billing",
+      f"Subscribe at {env.ROBOSYSTEMS_URL}/repositories/browse",
     )
 
   # Rate limiting is optional - skip if disabled (dev environments)
@@ -780,7 +780,7 @@ async def _check_shared_repository_limits(
       if reason == "no_access":
         raise HTTPException(
           status_code=http_status.HTTP_403_FORBIDDEN,
-          detail=f"{message}. Subscribe at {env.ROBOSYSTEMS_URL}/billing",
+          detail=f"{message}. Subscribe at {env.ROBOSYSTEMS_URL}/repositories/browse",
         )
       elif reason == "endpoint_not_allowed":
         raise HTTPException(status_code=http_status.HTTP_403_FORBIDDEN, detail=message)
@@ -789,7 +789,7 @@ async def _check_shared_repository_limits(
         raise HTTPException(
           status_code=http_status.HTTP_429_TOO_MANY_REQUESTS,
           detail=f"{message}. Limit: {detail.get('limit', 0)} per {detail.get('window', 'period')}. "
-          f"Upgrade for higher limits at {env.ROBOSYSTEMS_URL}/billing",
+          f"Upgrade for higher limits at {env.ROBOSYSTEMS_URL}/repositories/browse",
         )
       else:
         raise HTTPException(

--- a/robosystems/routers/graphs/search.py
+++ b/robosystems/routers/graphs/search.py
@@ -78,7 +78,7 @@ async def _check_search_rate_limit(
     raise HTTPException(
       status_code=http_status.HTTP_403_FORBIDDEN,
       detail=f"Access to {graph_id.upper()} repository requires a subscription. "
-      f"Visit {env.ROBOSYSTEMS_URL}/billing",
+      f"Visit {env.ROBOSYSTEMS_URL}/repositories/browse",
     )
 
   redis_client = create_async_redis_client(ValkeyDatabase.RATE_LIMITS)

--- a/tests/operations/providers/test_payment_provider.py
+++ b/tests/operations/providers/test_payment_provider.py
@@ -139,7 +139,9 @@ class TestStripeCheckoutSessions:
 
     call_args = stripe_provider.stripe.checkout.Session.create.call_args
     assert "robosystems.example.com/checkout" in call_args[1]["success_url"]
-    assert "robosystems.example.com/billing" in call_args[1]["cancel_url"]
+    assert (
+      "robosystems.example.com/organization?tab=billing" in call_args[1]["cancel_url"]
+    )
 
   def test_checkout_session_mode_is_subscription(self, stripe_provider):
     """Test that checkout mode is set to subscription."""


### PR DESCRIPTION
## Summary

The app moved billing onto the organization page and repointed `/billing` at `/organization?tab=billing`. Every URL this repo hands to a user or to Stripe pointed at `/billing`, so each now goes where the action actually happens.

No Stripe dashboard configuration changes are needed — both Stripe URLs are passed per-session from this code. There is no `billing_portal.Configuration` object in the codebase, so no stored `default_return_url` exists (and a per-session `return_url` would override one anyway). Webhooks point at the API, not the frontend, and are untouched.

## Changes

**Stripe session URLs → `/organization?tab=billing`**

- `routers/billing/customer.py` — portal `return_url`
- `operations/providers/payment_provider.py` — checkout `cancel_url`

**Repository upsell and rate-limit messages → `/repositories/browse`**

- `routers/graphs/query/execute.py` (3), `routers/graphs/mcp/execute.py` (3), `routers/graphs/search.py` (1)
- `middleware/rate_limits/repository_rate_limits.py`, `config/shared_repositories.py` — the repository `upgrade_url` values

These nine are all repository-scoped — "Access to X **repository** requires a subscription", "Subscribe at", the repository `upgrade_url` fields. `/repositories/browse` is where a repository plan is actually bought or changed, and is already where the app's own "Change Plan" button for a repository subscription routes. It also matters that these messages reach members, who cannot see the org billing tabs at all — sending them to `/organization?tab=billing` would have been a regression.

**Test**

- `tests/operations/providers/test_payment_provider.py` — the `cancel_url` assertion now expects the new destination.

## Testing

- `uv run pytest tests/operations/providers/test_payment_provider.py` — 32 pass.
- `uv run pytest tests/routers/billing/ tests/middleware/rate_limits/` — 230 pass.
- `just format` and `just lint` — clean.

## Notes

Pairs with RoboFinSystems/robosystems-app#275. The app keeps `/billing` as a redirect, so nothing breaks in the window before this deploys, and older links — including any already-issued Stripe sessions — keep working afterwards.
