### PR TITLE
fix(extensions): align write authorization across registration styles

### DIFF
--- a/robosystems/routers/extensions/roboledger/operations.py
+++ b/robosystems/routers/extensions/roboledger/operations.py
@@ -75,7 +75,10 @@ from sqlalchemy.orm import Session
 from robosystems.adapters.quickbooks.client.api import QBAuthFailedError
 from robosystems.database import get_db_session
 from robosystems.db.extensions import extensions_session
-from robosystems.middleware.auth.dependencies import get_current_user_with_graph
+from robosystems.middleware.auth.dependencies import (
+  get_current_user_with_graph,
+  require_graph_write_role,
+)
 from robosystems.middleware.extensions import (
   GraphExtensionContext,
   OperationRegistrar,
@@ -524,6 +527,26 @@ _registrar = OperationRegistrar(
 _require_roboledger = require_graph_extension("roboledger")
 
 
+def _require_roboledger_write(
+  graph_id: str = Path(..., pattern=GRAPH_OR_SUBGRAPH_ID_PATTERN),
+  user: User = Depends(get_current_user_with_graph),
+  _ext: GraphExtensionContext = Depends(_require_roboledger),
+) -> User:
+  """Membership + provisioning + write role for the hand-written ops below.
+
+  Every `@router.post` in this file is a command. `get_current_user_with_graph`
+  proves graph *membership* and `_require_roboledger` proves *provisioning* —
+  neither consults the graph role, so a read-only `viewer` cleared both. The
+  registrar applies `require_graph_write_role` to every op it mounts
+  (`middleware/extensions.py`); the ops that stayed hand-written for their
+  async dispatch, platform-DB or multi-stage error needs never picked it up.
+  This dependency is that same gate, so the two registration styles enforce
+  identically and a new hand-written op inherits it by using this dep.
+  """
+  require_graph_write_role(str(user.id), graph_id)
+  return user
+
+
 # ───────────────────────────────────────────────────────────────────────────
 # Operation request bodies — wrap path-specific IDs into the request body.
 # ───────────────────────────────────────────────────────────────────────────
@@ -737,8 +760,7 @@ class RemovePublishListMemberOperation(BaseModel):
 async def initialize_op(
   body: InitializeLedgerRequest,
   graph_id: str = Path(..., pattern=GRAPH_OR_SUBGRAPH_ID_PATTERN),
-  user: User = Depends(get_current_user_with_graph),
-  _ext: GraphExtensionContext = Depends(_require_roboledger),
+  user: User = Depends(_require_roboledger_write),
   idempotency_key: str | None = Header(None, alias="Idempotency-Key"),
   cache: IdempotencyCache = Depends(get_idempotency_cache),
   platform_db: Session = Depends(get_db_session),
@@ -797,8 +819,7 @@ async def initialize_op(
 async def update_entity_op(
   body: UpdateEntityRequest,
   graph_id: str = Path(..., pattern=GRAPH_OR_SUBGRAPH_ID_PATTERN),
-  user: User = Depends(get_current_user_with_graph),
-  _ext: GraphExtensionContext = Depends(_require_roboledger),
+  user: User = Depends(_require_roboledger_write),
   idempotency_key: str | None = Header(None, alias="Idempotency-Key"),
   cache: IdempotencyCache = Depends(get_idempotency_cache),
 ) -> OperationEnvelope:
@@ -1058,8 +1079,7 @@ class AutoMapElementsOperation(BaseModel):
 async def auto_map_elements_op(
   body: AutoMapElementsOperation,
   graph_id: str = Path(..., pattern=GRAPH_OR_SUBGRAPH_ID_PATTERN),
-  user: User = Depends(get_current_user_with_graph),
-  _ext: GraphExtensionContext = Depends(_require_roboledger),
+  user: User = Depends(_require_roboledger_write),
   idempotency_key: str | None = Header(None, alias="Idempotency-Key"),
   cache: IdempotencyCache = Depends(get_idempotency_cache),
 ) -> OperationEnvelope:
@@ -1319,8 +1339,7 @@ compute_forecast_op = _registrar.register(
 async def bind_text_block_op(
   body: BindTextBlockRequest,
   graph_id: str = Path(..., pattern=GRAPH_OR_SUBGRAPH_ID_PATTERN),
-  user: User = Depends(get_current_user_with_graph),
-  _ext: GraphExtensionContext = Depends(_require_roboledger),
+  user: User = Depends(_require_roboledger_write),
   idempotency_key: str | None = Header(None, alias="Idempotency-Key"),
   cache: IdempotencyCache = Depends(get_idempotency_cache),
   platform_db: Session = Depends(get_db_session),
@@ -1729,8 +1748,7 @@ rebuild_schedule_op = _registrar.register(
 async def set_close_target_op(
   body: SetCloseTargetOperation,
   graph_id: str = Path(..., pattern=GRAPH_OR_SUBGRAPH_ID_PATTERN),
-  user: User = Depends(get_current_user_with_graph),
-  _ext: GraphExtensionContext = Depends(_require_roboledger),
+  user: User = Depends(_require_roboledger_write),
   idempotency_key: str | None = Header(None, alias="Idempotency-Key"),
   cache: IdempotencyCache = Depends(get_idempotency_cache),
   platform_db: Session = Depends(get_db_session),
@@ -1808,8 +1826,7 @@ async def set_close_target_op(
 async def close_period_op(
   body: ClosePeriodOperation,
   graph_id: str = Path(..., pattern=GRAPH_OR_SUBGRAPH_ID_PATTERN),
-  user: User = Depends(get_current_user_with_graph),
-  _ext: GraphExtensionContext = Depends(_require_roboledger),
+  user: User = Depends(_require_roboledger_write),
   idempotency_key: str | None = Header(None, alias="Idempotency-Key"),
   cache: IdempotencyCache = Depends(get_idempotency_cache),
   platform_db: Session = Depends(get_db_session),
@@ -1947,8 +1964,7 @@ async def close_period_op(
 async def reopen_period_op(
   body: ReopenPeriodOperation,
   graph_id: str = Path(..., pattern=GRAPH_OR_SUBGRAPH_ID_PATTERN),
-  user: User = Depends(get_current_user_with_graph),
-  _ext: GraphExtensionContext = Depends(_require_roboledger),
+  user: User = Depends(_require_roboledger_write),
   idempotency_key: str | None = Header(None, alias="Idempotency-Key"),
   cache: IdempotencyCache = Depends(get_idempotency_cache),
   platform_db: Session = Depends(get_db_session),
@@ -2028,8 +2044,7 @@ async def reopen_period_op(
 async def backfill_plan_history_op(
   body: BackfillPlanHistoryOperation,
   graph_id: str = Path(..., pattern=GRAPH_OR_SUBGRAPH_ID_PATTERN),
-  user: User = Depends(get_current_user_with_graph),
-  _ext: GraphExtensionContext = Depends(_require_roboledger),
+  user: User = Depends(_require_roboledger_write),
   idempotency_key: str | None = Header(None, alias="Idempotency-Key"),
   cache: IdempotencyCache = Depends(get_idempotency_cache),
   platform_db: Session = Depends(get_db_session),
@@ -2092,8 +2107,7 @@ async def backfill_plan_history_op(
 async def create_report_op(
   body: CreateReportRequest,
   graph_id: str = Path(..., pattern=GRAPH_OR_SUBGRAPH_ID_PATTERN),
-  user: User = Depends(get_current_user_with_graph),
-  _ext: GraphExtensionContext = Depends(_require_roboledger),
+  user: User = Depends(_require_roboledger_write),
   idempotency_key: str | None = Header(None, alias="Idempotency-Key"),
   cache: IdempotencyCache = Depends(get_idempotency_cache),
 ) -> OperationEnvelope:
@@ -2158,8 +2172,7 @@ async def create_report_op(
 async def regenerate_report_op(
   body: RegenerateReportOperation,
   graph_id: str = Path(..., pattern=GRAPH_OR_SUBGRAPH_ID_PATTERN),
-  user: User = Depends(get_current_user_with_graph),
-  _ext: GraphExtensionContext = Depends(_require_roboledger),
+  user: User = Depends(_require_roboledger_write),
   idempotency_key: str | None = Header(None, alias="Idempotency-Key"),
   cache: IdempotencyCache = Depends(get_idempotency_cache),
 ) -> OperationEnvelope:
@@ -2224,8 +2237,7 @@ async def regenerate_report_op(
 async def delete_report_op(
   body: DeleteReportOperation,
   graph_id: str = Path(..., pattern=GRAPH_OR_SUBGRAPH_ID_PATTERN),
-  user: User = Depends(get_current_user_with_graph),
-  _ext: GraphExtensionContext = Depends(_require_roboledger),
+  user: User = Depends(_require_roboledger_write),
   idempotency_key: str | None = Header(None, alias="Idempotency-Key"),
   cache: IdempotencyCache = Depends(get_idempotency_cache),
 ) -> OperationEnvelope:
@@ -2284,8 +2296,7 @@ async def delete_report_op(
 async def share_report_op(
   body: ShareReportOperation,
   graph_id: str = Path(..., pattern=GRAPH_OR_SUBGRAPH_ID_PATTERN),
-  user: User = Depends(get_current_user_with_graph),
-  _ext: GraphExtensionContext = Depends(_require_roboledger),
+  user: User = Depends(_require_roboledger_write),
   idempotency_key: str | None = Header(None, alias="Idempotency-Key"),
   cache: IdempotencyCache = Depends(get_idempotency_cache),
 ) -> OperationEnvelope:
@@ -2345,8 +2356,7 @@ async def share_report_op(
 async def file_report_op(
   body: FileReportRequest,
   graph_id: str = Path(..., pattern=GRAPH_OR_SUBGRAPH_ID_PATTERN),
-  user: User = Depends(get_current_user_with_graph),
-  _ext: GraphExtensionContext = Depends(_require_roboledger),
+  user: User = Depends(_require_roboledger_write),
   idempotency_key: str | None = Header(None, alias="Idempotency-Key"),
   cache: IdempotencyCache = Depends(get_idempotency_cache),
 ) -> OperationEnvelope:
@@ -2397,8 +2407,7 @@ async def file_report_op(
 async def transition_filing_status_op(
   body: TransitionFilingStatusRequest,
   graph_id: str = Path(..., pattern=GRAPH_OR_SUBGRAPH_ID_PATTERN),
-  user: User = Depends(get_current_user_with_graph),
-  _ext: GraphExtensionContext = Depends(_require_roboledger),
+  user: User = Depends(_require_roboledger_write),
   idempotency_key: str | None = Header(None, alias="Idempotency-Key"),
   cache: IdempotencyCache = Depends(get_idempotency_cache),
 ) -> OperationEnvelope:
@@ -2455,8 +2464,7 @@ async def transition_filing_status_op(
 async def create_publish_list_op(
   body: CreatePublishListRequest,
   graph_id: str = Path(..., pattern=GRAPH_OR_SUBGRAPH_ID_PATTERN),
-  user: User = Depends(get_current_user_with_graph),
-  _ext: GraphExtensionContext = Depends(_require_roboledger),
+  user: User = Depends(_require_roboledger_write),
   idempotency_key: str | None = Header(None, alias="Idempotency-Key"),
   cache: IdempotencyCache = Depends(get_idempotency_cache),
 ) -> OperationEnvelope:
@@ -2499,8 +2507,7 @@ async def create_publish_list_op(
 async def update_publish_list_op(
   body: UpdatePublishListOperation,
   graph_id: str = Path(..., pattern=GRAPH_OR_SUBGRAPH_ID_PATTERN),
-  user: User = Depends(get_current_user_with_graph),
-  _ext: GraphExtensionContext = Depends(_require_roboledger),
+  user: User = Depends(_require_roboledger_write),
   idempotency_key: str | None = Header(None, alias="Idempotency-Key"),
   cache: IdempotencyCache = Depends(get_idempotency_cache),
 ) -> OperationEnvelope:
@@ -2553,8 +2560,7 @@ async def update_publish_list_op(
 async def delete_publish_list_op(
   body: DeletePublishListOperation,
   graph_id: str = Path(..., pattern=GRAPH_OR_SUBGRAPH_ID_PATTERN),
-  user: User = Depends(get_current_user_with_graph),
-  _ext: GraphExtensionContext = Depends(_require_roboledger),
+  user: User = Depends(_require_roboledger_write),
   idempotency_key: str | None = Header(None, alias="Idempotency-Key"),
   cache: IdempotencyCache = Depends(get_idempotency_cache),
 ) -> OperationEnvelope:
@@ -2604,8 +2610,7 @@ async def delete_publish_list_op(
 async def add_publish_list_members_op(
   body: AddPublishListMembersOperation,
   graph_id: str = Path(..., pattern=GRAPH_OR_SUBGRAPH_ID_PATTERN),
-  user: User = Depends(get_current_user_with_graph),
-  _ext: GraphExtensionContext = Depends(_require_roboledger),
+  user: User = Depends(_require_roboledger_write),
   idempotency_key: str | None = Header(None, alias="Idempotency-Key"),
   cache: IdempotencyCache = Depends(get_idempotency_cache),
 ) -> OperationEnvelope:
@@ -2664,8 +2669,7 @@ async def add_publish_list_members_op(
 async def remove_publish_list_member_op(
   body: RemovePublishListMemberOperation,
   graph_id: str = Path(..., pattern=GRAPH_OR_SUBGRAPH_ID_PATTERN),
-  user: User = Depends(get_current_user_with_graph),
-  _ext: GraphExtensionContext = Depends(_require_roboledger),
+  user: User = Depends(_require_roboledger_write),
   idempotency_key: str | None = Header(None, alias="Idempotency-Key"),
   cache: IdempotencyCache = Depends(get_idempotency_cache),
 ) -> OperationEnvelope:

--- a/tests/routers/extensions/roboledger/test_operations.py
+++ b/tests/routers/extensions/roboledger/test_operations.py
@@ -58,7 +58,13 @@ def _bypass_write_role():
   ``require_graph_write_role`` (unit-tested in
   ``tests/middleware/auth/test_dependencies.py``; the deny path is asserted in
   ``TestRegistrarWriteRoleGate`` below). These direct-call wiring tests use a
-  mock user with no DB-backed ``GraphUser`` row, so no-op the gate here."""
+  mock user with no DB-backed ``GraphUser`` row, so no-op the gate here.
+
+  Deliberately scoped to ``middleware.extensions`` only. The hand-written
+  handlers enforce through the ``_require_roboledger_write`` *dependency*,
+  which direct calls never resolve — broadening this patch to that module
+  would silently disarm ``TestHandWrittenWriteRoleGate`` below, which is the
+  same blind spot that let the gap ship in the first place."""
   with patch(
     "robosystems.middleware.extensions.require_graph_write_role", return_value=None
   ):
@@ -1202,3 +1208,82 @@ class TestRegistrarWriteRoleGate:
           cache=_FakeCache(),
         )
     assert exc.value.status_code == 403
+
+
+class TestHandWrittenWriteRoleGate:
+  """The hand-written `@router.post` ops enforce the same write role the
+  registrar does.
+
+  `TestRegistrarWriteRoleGate` above only ever exercised registrar-mounted
+  handlers, which enforce inside the handler body. The hand-written ops in
+  this module enforce through a *dependency*, so a direct call never resolves
+  it — which is precisely why no test in this file could catch the gap.
+  """
+
+  def test_every_hand_written_post_requires_the_write_dependency(self) -> None:
+    """Structural, not behavioral: asserts the invariant rather than one
+    instance, so a newly added hand-written op that forgets the gate fails
+    here instead of shipping."""
+    from robosystems.routers.extensions.roboledger.operations import (
+      _require_roboledger_write,
+      router,
+    )
+
+    def _dependency_calls(dependant) -> list:
+      calls = []
+      for dep in dependant.dependencies:
+        if dep.call is not None:
+          calls.append(dep.call)
+        calls.extend(_dependency_calls(dep))
+      return calls
+
+    ungated = []
+    for route in router.routes:
+      if "POST" not in getattr(route, "methods", set()):
+        continue
+      # Registrar-mounted handlers call `require_graph_write_role` in the
+      # handler body rather than via a dependency; they are covered by
+      # `TestRegistrarWriteRoleGate`.
+      if route.endpoint.__module__ == "robosystems.middleware.extensions":
+        continue
+      if _require_roboledger_write not in _dependency_calls(route.dependant):
+        ungated.append(route.path)
+
+    assert ungated == [], (
+      f"hand-written write ops missing the write-role gate: {ungated}"
+    )
+
+  def test_write_dependency_denies_a_viewer(self) -> None:
+    from robosystems.routers.extensions.roboledger.operations import (
+      _require_roboledger_write,
+    )
+
+    with patch(
+      "robosystems.routers.extensions.roboledger.operations.require_graph_write_role",
+      side_effect=HTTPException(
+        status_code=403, detail="Write access denied; your role is read-only."
+      ),
+    ):
+      with pytest.raises(HTTPException) as exc:
+        _require_roboledger_write(
+          graph_id=GRAPH_ID, user=_make_user(), _ext=MagicMock()
+        )
+
+    assert exc.value.status_code == 403
+
+  def test_write_dependency_returns_the_user_for_a_writer(self) -> None:
+    from robosystems.routers.extensions.roboledger.operations import (
+      _require_roboledger_write,
+    )
+
+    user = _make_user()
+    with patch(
+      "robosystems.routers.extensions.roboledger.operations.require_graph_write_role",
+      return_value=None,
+    ) as gate:
+      resolved = _require_roboledger_write(
+        graph_id=GRAPH_ID, user=user, _ext=MagicMock()
+      )
+
+    assert resolved is user
+    gate.assert_called_once_with(str(user.id), GRAPH_ID)


### PR DESCRIPTION
## Summary

The roboledger operation surface has two registration styles: declarative specs mounted by `OperationRegistrar`, and hand-written `@router.post` blocks for ops with async dispatch, platform-DB or multi-stage error needs. The registrar applies the shared write-role check before dispatch; the hand-written path did not, so the two styles enforced differently.

This adds a `_require_roboledger_write` dependency composing graph membership, extension provisioning and the write role, and uses it across the hand-written handlers. Both styles now enforce identically, and a new hand-written op inherits the gate by using the dependency.

Roboinvestor is unaffected (all registrar-mounted). `views.py`'s hand-written posts are reads and stay reader-accessible.

## Test approach

The keystone test is **structural rather than behavioral**: it walks the router's POST routes, skips registrar-mounted handlers, and asserts the dependency appears in each remaining route's resolved dependency tree. It asserts the invariant rather than one instance, so a future hand-written op that omits the gate fails in CI.

Verified by reverting one handler in isolation — the test failed and named that route. Two behavioral tests cover the dependency's allow and deny paths.

The existing autouse bypass fixture is deliberately left scoped to the registrar module. Broadening it to cover this path would disarm the new test, and these direct-call tests never resolve a `Depends` anyway — which is why this file's existing coverage could not have caught the difference.

## Verification

`just test-all` — 11,887 passed, 24 skipped, ruff + format + basedpyright clean.

Detail in `local/RoboSystems/specs/multi-user-org-hardening.md` (F1).