### PR TITLE
fix(operators): gate write-capable operators on the graph write role

### DIFF
--- a/robosystems/operations/operators/__init__.py
+++ b/robosystems/operations/operators/__init__.py
@@ -43,6 +43,7 @@ from robosystems.operations.operators.base import (
   OperatorResponse,
   OperatorResult,
   OperatorSpec,
+  enforce_operator_write_role,
   matches_graph_scope,
 )
 from robosystems.operations.operators.credit_consumer import (
@@ -117,6 +118,7 @@ __all__ = [
   "SessionCreditConsumer",
   "ToolAccess",
   "TrackedAIClient",
+  "enforce_operator_write_role",
   # Registry
   "get_operator",
   "get_operator_class",

--- a/robosystems/operations/operators/adapters/api.py
+++ b/robosystems/operations/operators/adapters/api.py
@@ -14,7 +14,11 @@ from typing import TYPE_CHECKING, Any
 
 from robosystems.logger import logger
 from robosystems.operations.operators.ai_client import AIClient
-from robosystems.operations.operators.base import OperatorMode, OperatorResult
+from robosystems.operations.operators.base import (
+  OperatorMode,
+  OperatorResult,
+  enforce_operator_write_role,
+)
 from robosystems.operations.operators.credit_consumer import SessionCreditConsumer
 from robosystems.operations.operators.operator_context import OperatorContext
 from robosystems.operations.operators.progress import CallbackProgress
@@ -58,6 +62,11 @@ async def run_operator_api(
   Returns:
       OperatorResult with domain content + runtime metadata attached.
   """
+  # Before any tool access is constructed: the tool layer carries no user
+  # identity, so this is the only point at which the caller's graph role can
+  # be checked on this path.
+  enforce_operator_write_role(operator, graph_id, str(user.id))
+
   tools = HttpToolAccess(graph_id)
   ai_client = AIClient()
 

--- a/robosystems/operations/operators/adapters/worker.py
+++ b/robosystems/operations/operators/adapters/worker.py
@@ -15,7 +15,10 @@ from typing import TYPE_CHECKING, Any
 
 from robosystems.logger import logger
 from robosystems.operations.operators.ai_client import AIClient
-from robosystems.operations.operators.base import OperatorMode
+from robosystems.operations.operators.base import (
+  OperatorMode,
+  enforce_operator_write_role,
+)
 from robosystems.operations.operators.credit_consumer import FactoryCreditConsumer
 from robosystems.operations.operators.operator_context import OperatorContext
 from robosystems.operations.operators.progress import OperationManagerProgress
@@ -51,6 +54,11 @@ async def run_operator_worker(
   Returns:
       Result dict with operator output + credit summary.
   """
+  # Re-checked here rather than trusted from the enqueuing request: a task can
+  # sit in the queue, and the role that authorized it may have been revoked in
+  # between. Same reasoning as `GraphCreationService._validate_org`.
+  enforce_operator_write_role(operator, graph_id, user_id)
+
   tools = DirectToolAccess(graph_id)
   ai_client = AIClient()
   credit_consumer = FactoryCreditConsumer()

--- a/robosystems/operations/operators/base.py
+++ b/robosystems/operations/operators/base.py
@@ -124,6 +124,15 @@ class OperatorSpec:
     default_factory=lambda: {"input": 150000, "output": 8000}
   )
   requires_credits: bool = True
+  read_only: bool = False
+  """Whether this operator only reads from the graph.
+
+  Fail-closed on purpose: the default is `False`, so an operator is treated as
+  write-capable — and gated on the graph write role — unless it declares
+  otherwise. An operator that gains a write tool later inherits the gate, and
+  one that forgets this flag is over-restricted rather than under-protected.
+  Set `True` only where the tool allowlist is provably read-only.
+  """
   execution_profile: dict[OperatorMode, ExecutionProfile] = field(
     default_factory=lambda: {
       OperatorMode.QUICK: ExecutionProfile(
@@ -511,3 +520,33 @@ class BaseOperator(ABC):
       f"name='{self.metadata.name}' "
       f"graph_id='{self.graph_id}'>"
     )
+
+
+def enforce_operator_write_role(
+  operator: Operator, graph_id: str, user_id: str
+) -> None:
+  """Gate a write-capable operator on the caller's graph write role.
+
+  Operators drive MCP tools through a tool-access layer that carries no user
+  identity, so the per-tool write classification the MCP router applies
+  (`validate_mcp_access(..., "write")`) never runs on this path. The role has
+  to be checked once, before the operator starts its tool-use loop.
+
+  Called from the execution adapters rather than the routers so that every
+  entry point inherits it — sync, SSE, queued background, and worker — since
+  two of those bypass the orchestrator and call the adapter directly.
+
+  No-ops for operators whose spec sets `read_only=True`; see
+  :attr:`OperatorSpec.read_only` for why the default is fail-closed.
+
+  Raises:
+      HTTPException: 403 if the user's role on the graph is read-only.
+  """
+  if operator.spec.read_only:
+    return
+
+  # Local import: this module is imported by the operator implementations, and
+  # the auth dependencies pull in the platform DB stack.
+  from robosystems.middleware.auth.dependencies import require_graph_write_role
+
+  require_graph_write_role(user_id, graph_id)

--- a/robosystems/operations/operators/implementations/cypher.py
+++ b/robosystems/operations/operators/implementations/cypher.py
@@ -58,6 +58,10 @@ class CypherOperator(Operator):
       OperatorCapability.ENTITY_ANALYSIS,
       OperatorCapability.CUSTOM,
     ],
+    # Every tool this operator can reach is in READ_ONLY_TOOLS above, so a
+    # graph `viewer` may run it. Removing this flag (or adding a write tool
+    # to the allowlist without removing it) is what the adapters gate on.
+    read_only=True,
     version="2.0.0",
     requires_credits=True,
     execution_profile={

--- a/tests/operations/operators/test_write_role_gate.py
+++ b/tests/operations/operators/test_write_role_gate.py
@@ -1,0 +1,168 @@
+"""The operator execution path gates write-capable operators on the graph role.
+
+Operators drive MCP tools through a tool-access layer that carries no user
+identity, so the per-tool write classification the MCP router applies never runs
+here. The gate lives in the two execution adapters rather than the routers,
+because the SSE and background-queue handlers call the adapters directly and
+bypass the orchestrator entirely — a router-level check would miss them.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from robosystems.operations.operators.base import (
+  OperatorCapability,
+  OperatorResult,
+  OperatorSpec,
+  enforce_operator_write_role,
+)
+
+GRAPH_ID = "kg01234567890abcdef"
+USER_ID = "usr_test123"
+
+
+def _operator(*, read_only: bool) -> MagicMock:
+  operator = MagicMock()
+  operator.spec = OperatorSpec(
+    name="Test Operator",
+    description="test",
+    capabilities=[OperatorCapability.CUSTOM],
+    read_only=read_only,
+  )
+  # Awaitable and harmless, so that removing the gate lets the adapter run to
+  # completion and the test fails with "DID NOT RAISE HTTPException" — the
+  # signal a reader can act on — rather than an incidental TypeError.
+  operator.run = AsyncMock(return_value=OperatorResult(content="ok"))
+  return operator
+
+
+class TestEnforceOperatorWriteRole:
+  def test_read_only_operator_skips_the_role_check(self) -> None:
+    with patch(
+      "robosystems.middleware.auth.dependencies.require_graph_write_role"
+    ) as gate:
+      enforce_operator_write_role(_operator(read_only=True), GRAPH_ID, USER_ID)
+
+    gate.assert_not_called()
+
+  def test_write_capable_operator_is_checked(self) -> None:
+    with patch(
+      "robosystems.middleware.auth.dependencies.require_graph_write_role"
+    ) as gate:
+      enforce_operator_write_role(_operator(read_only=False), GRAPH_ID, USER_ID)
+
+    gate.assert_called_once_with(USER_ID, GRAPH_ID)
+
+  def test_viewer_is_denied(self) -> None:
+    with patch(
+      "robosystems.middleware.auth.dependencies.require_graph_write_role",
+      side_effect=HTTPException(status_code=403, detail="read-only"),
+    ):
+      with pytest.raises(HTTPException) as exc:
+        enforce_operator_write_role(_operator(read_only=False), GRAPH_ID, USER_ID)
+
+    assert exc.value.status_code == 403
+
+  def test_spec_default_is_fail_closed(self) -> None:
+    """An operator that declares nothing is treated as write-capable."""
+    spec = OperatorSpec(
+      name="Undeclared",
+      description="test",
+      capabilities=[OperatorCapability.CUSTOM],
+    )
+    assert spec.read_only is False
+
+
+class TestAdaptersEnforceBeforeToolAccess:
+  """Both adapters check the role *before* constructing tool access.
+
+  Asserted through the adapter rather than by reading it, and by proving tool
+  access was never constructed — an ordering regression that left the gate in
+  place but moved it after initialization would still leak graph reads.
+  """
+
+  @pytest.mark.asyncio
+  async def test_api_adapter_denies_a_viewer(self) -> None:
+    from robosystems.operations.operators.adapters import api
+
+    user = MagicMock()
+    user.id = USER_ID
+
+    # AIClient is patched so that removing the gate fails this test with a
+    # clean "DID NOT RAISE HTTPException" rather than an unrelated credentials
+    # error from further down the adapter.
+    with (
+      patch.object(
+        api,
+        "enforce_operator_write_role",
+        side_effect=HTTPException(status_code=403, detail="read-only"),
+      ),
+      patch.object(api, "HttpToolAccess") as tool_access,
+      patch.object(api, "AIClient"),
+      patch.object(api, "TrackedAIClient"),
+    ):
+      with pytest.raises(HTTPException) as exc:
+        await api.run_operator_api(
+          operator=_operator(read_only=False),
+          graph_id=GRAPH_ID,
+          user=user,
+          query="anything",
+        )
+
+    assert exc.value.status_code == 403
+    tool_access.assert_not_called()
+
+  @pytest.mark.asyncio
+  async def test_worker_adapter_denies_a_viewer(self) -> None:
+    from robosystems.operations.operators.adapters import worker
+
+    with (
+      patch.object(
+        worker,
+        "enforce_operator_write_role",
+        side_effect=HTTPException(status_code=403, detail="read-only"),
+      ),
+      patch.object(worker, "DirectToolAccess") as tool_access,
+      patch.object(worker, "AIClient"),
+      patch.object(worker, "TrackedAIClient"),
+      patch.object(worker, "FactoryCreditConsumer"),
+    ):
+      with pytest.raises(HTTPException) as exc:
+        await worker.run_operator_worker(
+          operator=_operator(read_only=False),
+          task_id="task_1",
+          graph_id=GRAPH_ID,
+          user_id=USER_ID,
+          params={},
+          manager=AsyncMock(),
+        )
+
+    assert exc.value.status_code == 403
+    tool_access.assert_not_called()
+
+
+class TestRegisteredOperatorDeclarations:
+  """The read_only flag is a security decision, so each registered operator's
+  value is asserted explicitly — flipping one has to break a test that says why.
+  """
+
+  def test_cypher_operator_is_read_only(self) -> None:
+    from robosystems.operations.operators.implementations.cypher import CypherOperator
+
+    assert CypherOperator.spec.read_only is True, (
+      "CypherOperator is viewer-accessible because READ_ONLY_TOOLS contains no "
+      "write tool; adding one means this flag must go"
+    )
+
+  def test_mapping_operator_is_write_capable(self) -> None:
+    from robosystems.operations.operators.implementations.mapping.operator import (
+      MappingOperator,
+    )
+
+    assert MappingOperator.spec.read_only is False, (
+      "MappingOperator persists mapping associations, so it must stay gated"
+    )


### PR DESCRIPTION
## Summary

Operators reach MCP tools through a tool-access layer that carries no user identity, so the per-tool write classification the MCP router applies does not run on this path. Graph membership was the only thing proven before an operator started its tool-use loop.

Adds `OperatorSpec.read_only`, **defaulting to `False`** so an operator is treated as write-capable unless it declares otherwise. An operator that gains a write tool later inherits the gate, and one that omits the flag is over-restricted rather than under-protected. `CypherOperator` declares `read_only=True` — its allowlist contains no write tool, so it stays reader-accessible.

## Where the gate lives, and why

In the two execution adapters, not the routers or the orchestrator. The SSE and background-queue handlers call `run_operator_api` directly and bypass the orchestrator entirely, so a check at either of those layers would miss them. The adapters are the only point every entry path passes through — sync, SSE, queued background, and worker.

The worker adapter re-checks rather than trusting the enqueuing request: a queued task can outlive the role that authorized it. Same reasoning as `GraphCreationService._validate_org`.

## Test approach

Tests assert *through* the adapters rather than by reading them, and additionally assert that tool access was never constructed — so an ordering regression that keeps the gate but moves it after initialization still fails.

Verified by removing the gate from both adapters and confirming the tests fail; the mock operator is deliberately awaitable so that failure reads as "DID NOT RAISE HTTPException" rather than an incidental error from further down the adapter.

Each registered operator's `read_only` value is asserted explicitly, so changing one has to break a test that states the reason.

## Verification

`just test-all` — 11,895 passed, 24 skipped, ruff + format + basedpyright clean.

Detail in `local/RoboSystems/specs/multi-user-org-hardening.md` (§6.1).