### PR TITLE
fix(operators): check credits on every execution path, stop unbilled runs

### DIFF
--- a/robosystems/operations/operators/adapters/api.py
+++ b/robosystems/operations/operators/adapters/api.py
@@ -20,6 +20,7 @@ from robosystems.operations.operators.base import (
   enforce_operator_write_role,
 )
 from robosystems.operations.operators.credit_consumer import SessionCreditConsumer
+from robosystems.operations.operators.credit_preflight import enforce_operator_credits
 from robosystems.operations.operators.operator_context import OperatorContext
 from robosystems.operations.operators.progress import CallbackProgress
 from robosystems.operations.operators.tool_access import HttpToolAccess
@@ -67,13 +68,20 @@ async def run_operator_api(
   # be checked on this path.
   enforce_operator_write_role(operator, graph_id, str(user.id))
 
+  # Credits are consumed after each Bedrock call returns, so this pre-flight is
+  # what bounds spend. The SSE and background-queue strategies reach this
+  # function without an orchestrator, so checking here rather than there is the
+  # difference between covering one execution path and covering all of them.
+  enforce_operator_credits(operator, graph_id, str(user.id), db_session, mode)
+
   tools = HttpToolAccess(graph_id)
   ai_client = AIClient()
 
   if db_session is None:
-    logger.warning(
+    logger.error(
       f"Operator running WITHOUT credit tracking (no db_session): "
-      f"graph={graph_id} user={user.id} — Bedrock cost will not be attributed"
+      f"graph={graph_id} user={user.id} — Bedrock cost will not be attributed "
+      f"and the pre-flight balance check was skipped"
     )
   credit_consumer = SessionCreditConsumer(db_session) if db_session else None
 

--- a/robosystems/operations/operators/adapters/worker.py
+++ b/robosystems/operations/operators/adapters/worker.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from robosystems.db.platform import SessionFactory
 from robosystems.logger import logger
 from robosystems.operations.operators.ai_client import AIClient
 from robosystems.operations.operators.base import (
@@ -20,6 +21,7 @@ from robosystems.operations.operators.base import (
   enforce_operator_write_role,
 )
 from robosystems.operations.operators.credit_consumer import FactoryCreditConsumer
+from robosystems.operations.operators.credit_preflight import enforce_operator_credits
 from robosystems.operations.operators.operator_context import OperatorContext
 from robosystems.operations.operators.progress import OperationManagerProgress
 from robosystems.operations.operators.tool_access import DirectToolAccess
@@ -54,10 +56,23 @@ async def run_operator_worker(
   Returns:
       Result dict with operator output + credit summary.
   """
-  # Re-checked here rather than trusted from the enqueuing request: a task can
-  # sit in the queue, and the role that authorized it may have been revoked in
-  # between. Same reasoning as `GraphCreationService._validate_org`.
+  mode_str = params.get("mode", "standard")
+  try:
+    mode = OperatorMode(mode_str)
+  except ValueError:
+    mode = OperatorMode.STANDARD
+
+  # Both gates are re-checked here rather than trusted from the enqueuing
+  # request: a task can sit in the queue, and the role that authorized it may
+  # have been revoked — or the balance spent — in between. Same reasoning as
+  # `GraphCreationService._validate_org`.
   enforce_operator_write_role(operator, graph_id, user_id)
+
+  preflight_session = SessionFactory()
+  try:
+    enforce_operator_credits(operator, graph_id, user_id, preflight_session, mode)
+  finally:
+    preflight_session.close()
 
   tools = DirectToolAccess(graph_id)
   ai_client = AIClient()
@@ -69,12 +84,6 @@ async def run_operator_worker(
     user_id=user_id,
     credit_consumer=credit_consumer,
   )
-
-  mode_str = params.get("mode", "standard")
-  try:
-    mode = OperatorMode(mode_str)
-  except ValueError:
-    mode = OperatorMode.STANDARD
 
   ctx = OperatorContext(
     graph_id=graph_id,

--- a/robosystems/operations/operators/credit_consumer.py
+++ b/robosystems/operations/operators/credit_consumer.py
@@ -12,7 +12,15 @@ from __future__ import annotations
 
 from typing import Protocol, runtime_checkable
 
-from robosystems.logger import logger
+
+class CreditConsumptionError(Exception):
+  """Raised when credits for a completed AI call could not be recorded.
+
+  Distinguishes "billing failed" from "billed, and the cost rounded to zero" —
+  the implementations previously returned 0.0 for both, which made an unbounded
+  billing failure indistinguishable from a cheap call and impossible for the
+  caller to act on.
+  """
 
 
 @runtime_checkable
@@ -28,7 +36,11 @@ class CreditConsumer(Protocol):
     model: str,
     operation_description: str,
   ) -> float:
-    """Consume credits for an AI call. Returns credits consumed."""
+    """Consume credits for an AI call. Returns credits consumed.
+
+    Raises:
+        CreditConsumptionError: if the consumption could not be recorded.
+    """
 
 
 class SessionCreditConsumer:
@@ -65,8 +77,7 @@ class SessionCreditConsumer:
     if result.get("success"):
       return float(result.get("credits_consumed", 0))
 
-    logger.warning(f"Credit consumption failed: {result.get('error', 'Unknown')}")
-    return 0.0
+    raise CreditConsumptionError(str(result.get("error", "Unknown")))
 
 
 class FactoryCreditConsumer:
@@ -103,13 +114,11 @@ class FactoryCreditConsumer:
       if result.get("success"):
         return float(result.get("credits_consumed", 0))
 
-      logger.warning(
-        f"Credit consumption failed (worker): {result.get('error', 'Unknown')}"
-      )
-      return 0.0
+      raise CreditConsumptionError(str(result.get("error", "Unknown")))
+    except CreditConsumptionError:
+      raise
     except Exception as e:
-      logger.warning(f"Credit consumption failed (worker): {e}")
-      return 0.0
+      raise CreditConsumptionError(str(e)) from e
     finally:
       session.close()
 

--- a/robosystems/operations/operators/credit_preflight.py
+++ b/robosystems/operations/operators/credit_preflight.py
@@ -1,0 +1,158 @@
+"""Credit pre-flight for operator execution.
+
+Credits are consumed *after* a Bedrock call returns, so the pre-flight check is
+the only thing standing between an under-funded graph and real spend. It lives
+here rather than on the orchestrator because two of the three API execution
+strategies (SSE streaming and background queue) call the execution adapters
+directly and never construct an orchestrator — a check that lived only there
+covered one path in three.
+
+Fail-closed on purpose: an error resolving the balance denies the run. The
+normal "no credit pool" and "no shared-repository access" cases already return
+a well-formed negative answer from `CreditService.check_credit_balance`, so
+reaching the exception path means the balance genuinely could not be
+established, and the old fail-open behaviour turned that into free AI.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import TYPE_CHECKING, Any
+
+from robosystems.logger import logger
+
+if TYPE_CHECKING:
+  from robosystems.operations.operators.base import Operator, OperatorMode
+
+
+class InsufficientOperatorCreditsError(Exception):
+  """Raised before execution when a graph cannot fund an operator run.
+
+  Carries the numbers so callers can render them — the orchestrator turns this
+  back into a graceful `INSUFFICIENT_CREDITS` response for the sync path, while
+  the streaming and queued paths surface it as an error to the client.
+  """
+
+  def __init__(
+    self,
+    operator_name: str,
+    estimated_credits: float,
+    available_credits: float,
+    reason: str | None = None,
+  ) -> None:
+    self.operator_name = operator_name
+    self.estimated_credits = estimated_credits
+    self.available_credits = available_credits
+    self.reason = reason
+    super().__init__(
+      f"Insufficient credits for {operator_name}. "
+      f"Required: {estimated_credits:.0f}, Available: {available_credits:.0f}"
+      + (f" ({reason})" if reason else "")
+    )
+
+
+_MODE_ESTIMATES: dict[str, dict[str, int]] = {
+  "quick": {"input": 2000, "output": 500},
+  "standard": {"input": 5000, "output": 1500},
+  "extended": {"input": 15000, "output": 3000},
+  "streaming": {"input": 8000, "output": 2000},
+}
+
+
+def estimate_operator_tokens(operator: Operator, mode: OperatorMode) -> dict[str, int]:
+  """Rough per-run token estimate used only to size the pre-flight check."""
+  estimate = dict(_MODE_ESTIMATES.get(mode.value, {"input": 5000, "output": 1500}))
+
+  if "financial" in operator.spec.name.lower():
+    estimate["input"] = int(estimate["input"] * 1.5)
+    estimate["output"] = int(estimate["output"] * 1.5)
+
+  return estimate
+
+
+def estimate_operator_credits(operator: Operator, mode: OperatorMode) -> Decimal:
+  """Estimated credit cost of one operator run."""
+  from robosystems.config.billing.ai import AIBillingConfig
+
+  tokens = estimate_operator_tokens(operator, mode)
+  pricing = AIBillingConfig.TOKEN_PRICING.get(
+    "anthropic_claude_4_sonnet",
+    {"input": Decimal("3"), "output": Decimal("15")},
+  )
+
+  input_cost = (Decimal(tokens["input"]) / 1000) * pricing["input"]
+  output_cost = (Decimal(tokens["output"]) / 1000) * pricing["output"]
+  return input_cost + output_cost
+
+
+def check_operator_credits(
+  operator: Operator,
+  graph_id: str,
+  user_id: str,
+  session: Any,
+  mode: OperatorMode,
+) -> dict[str, Any]:
+  """Resolve whether `graph_id` can fund one run of `operator`.
+
+  Returns the `CreditService.check_credit_balance` result augmented with
+  `estimated_credits`. On an unexpected failure the result denies rather than
+  allows — see the module docstring.
+  """
+  from robosystems.operations.graph.credit_service import CreditService
+
+  estimated_cost = estimate_operator_credits(operator, mode)
+
+  try:
+    result = CreditService(session).check_credit_balance(
+      graph_id=graph_id,
+      required_credits=estimated_cost,
+      user_id=user_id,
+      operation_type="agent_call",
+    )
+  except Exception as e:
+    logger.error(
+      f"Credit pre-flight failed for graph={graph_id} operator={operator.spec.name}; "
+      f"denying the run: {e}",
+      exc_info=True,
+    )
+    return {
+      "has_sufficient_credits": False,
+      "available_credits": 0,
+      "estimated_credits": float(estimated_cost),
+      "error": f"Credit check failed: {e!s}",
+    }
+
+  result["estimated_credits"] = float(estimated_cost)
+  return result
+
+
+def enforce_operator_credits(
+  operator: Operator,
+  graph_id: str,
+  user_id: str,
+  session: Any,
+  mode: OperatorMode,
+) -> None:
+  """Deny an operator run the graph cannot fund.
+
+  No-ops for operators whose spec sets `requires_credits=False`, and when no
+  session is available to resolve a balance (tests and any context without the
+  platform DB) — the adapter logs that case separately, since it also means
+  consumption cannot be recorded.
+
+  Raises:
+      InsufficientOperatorCreditsError: if the graph cannot fund the run.
+  """
+  if not operator.spec.requires_credits or session is None:
+    return
+
+  result = check_operator_credits(operator, graph_id, user_id, session, mode)
+  if result.get("has_sufficient_credits"):
+    return
+
+  raise InsufficientOperatorCreditsError(
+    operator_name=operator.spec.name,
+    estimated_credits=float(result.get("estimated_credits", 0)),
+    available_credits=float(result.get("available_credits", 0)),
+    reason=result.get("error"),
+  )

--- a/robosystems/operations/operators/orchestrator.py
+++ b/robosystems/operations/operators/orchestrator.py
@@ -21,6 +21,9 @@ from robosystems.operations.operators.base import (
   OperatorResult,
   matches_graph_scope,
 )
+from robosystems.operations.operators.credit_preflight import (
+  InsufficientOperatorCreditsError,
+)
 from robosystems.operations.operators.operator_registry import (
   get_operator,
   list_operators,
@@ -461,26 +464,11 @@ class OperatorOrchestrator:
   ) -> OperatorResponse:
     """Execute an operator via the API adapter."""
     try:
-      # Credit pre-check
-      if operator.spec.requires_credits and self.db_session:
-        credit_check = await self._check_credits_for_operator(operator, mode)
-        if not credit_check["has_sufficient_credits"]:
-          return OperatorResponse(
-            content=f"Insufficient credits for {operator.spec.name}. "
-            f"Required: {credit_check['estimated_credits']:.0f}, "
-            f"Available: {credit_check['available_credits']:.0f}",
-            operator_name=operator.spec.name,
-            mode_used=mode,
-            error_details={
-              "code": "INSUFFICIENT_CREDITS",
-              "message": "Not enough credits to perform AI analysis",
-              "required_credits": credit_check["estimated_credits"],
-              "available_credits": credit_check["available_credits"],
-            },
-            execution_time=0.0,
-          )
-
-      # Execute via adapter with timeout
+      # The credit pre-flight lives in the adapter, not here: the SSE and
+      # background-queue strategies call the adapter directly and never build
+      # an orchestrator, so a check at this layer covered one path in three.
+      # This layer's job is only to render the refusal gracefully for the sync
+      # path, which returns a body rather than an error status.
       result = await asyncio.wait_for(
         run_operator_api(
           operator=operator,
@@ -509,6 +497,19 @@ class OperatorOrchestrator:
 
       return response
 
+    except InsufficientOperatorCreditsError as e:
+      return OperatorResponse(
+        content=str(e),
+        operator_name=operator.spec.name,
+        mode_used=mode,
+        error_details={
+          "code": "INSUFFICIENT_CREDITS",
+          "message": "Not enough credits to perform AI analysis",
+          "required_credits": e.estimated_credits,
+          "available_credits": e.available_credits,
+        },
+        execution_time=0.0,
+      )
     except TimeoutError:
       logger.error(f"Operator {operator.spec.name} timed out")
       return OperatorResponse(
@@ -663,63 +664,6 @@ class OperatorOrchestrator:
       "cache_misses": self._metrics.get("cache_misses", 0),
       "errors": self._metrics["errors"],
     }
-
-  async def _check_credits_for_operator(
-    self, operator: Operator, mode: OperatorMode
-  ) -> dict[str, Any]:
-    from decimal import Decimal
-
-    from robosystems.config.billing.ai import AIBillingConfig
-    from robosystems.operations.graph.credit_service import CreditService
-
-    try:
-      credit_service = CreditService(self.db_session)
-      estimated_tokens = self._estimate_token_usage(operator, mode)
-
-      pricing = AIBillingConfig.TOKEN_PRICING.get(
-        "anthropic_claude_4_sonnet",
-        {"input": Decimal("3"), "output": Decimal("15")},
-      )
-
-      input_cost = (Decimal(estimated_tokens["input"]) / 1000) * pricing["input"]
-      output_cost = (Decimal(estimated_tokens["output"]) / 1000) * pricing["output"]
-      estimated_cost = input_cost + output_cost
-
-      credit_check = credit_service.check_credit_balance(
-        graph_id=self.graph_id,
-        required_credits=estimated_cost,
-        user_id=str(self.user.id),
-        operation_type="agent_call",
-      )
-      credit_check["estimated_credits"] = float(estimated_cost)
-      credit_check["estimated_tokens"] = estimated_tokens
-      return credit_check
-
-    except Exception as e:
-      logger.warning(f"Credit check failed: {e!s}")
-      return {
-        "has_sufficient_credits": True,
-        "estimated_credits": 0,
-        "available_credits": 0,
-        "warning": f"Credit check failed: {e!s}",
-      }
-
-  def _estimate_token_usage(
-    self, operator: Operator, mode: OperatorMode
-  ) -> dict[str, int]:
-    mode_estimates = {
-      OperatorMode.QUICK: {"input": 2000, "output": 500},
-      OperatorMode.STANDARD: {"input": 5000, "output": 1500},
-      OperatorMode.EXTENDED: {"input": 15000, "output": 3000},
-      OperatorMode.STREAMING: {"input": 8000, "output": 2000},
-    }
-    estimate = mode_estimates.get(mode, {"input": 5000, "output": 1500})
-
-    if "financial" in operator.spec.name.lower():
-      estimate["input"] = int(estimate["input"] * 1.5)
-      estimate["output"] = int(estimate["output"] * 1.5)
-
-    return estimate
 
   def _get_cache_key(
     self, query: str, operator_type: str | None, mode: OperatorMode

--- a/robosystems/operations/operators/tracked_ai.py
+++ b/robosystems/operations/operators/tracked_ai.py
@@ -19,6 +19,19 @@ if TYPE_CHECKING:
   from robosystems.operations.operators.credit_consumer import CreditConsumer
 
 
+class UnbilledAICallError(Exception):
+  """Raised when a prior AI call in this run could not be billed.
+
+  Stops a tool-use loop from continuing to spend after billing has broken,
+  which is the difference between one unbilled call and an unbounded number.
+  """
+
+  def __init__(self, detail: str) -> None:
+    super().__init__(
+      f"Refusing further AI calls: a previous call could not be billed ({detail})"
+    )
+
+
 class TrackedAIClient:
   """AI client wrapper that automatically tracks tokens and consumes credits."""
 
@@ -38,6 +51,7 @@ class TrackedAIClient:
     self.total_tokens: dict[str, int] = {"input": 0, "output": 0}
     self.total_credits: float = 0.0
     self.call_count: int = 0
+    self._unbilled_call: str | None = None
 
   async def create_message(
     self,
@@ -67,6 +81,14 @@ class TrackedAIClient:
     Returns:
         AIResponse with content and token counts.
     """
+    # A tool-use loop can make dozens of calls. If one of them could not be
+    # billed, every later call in the same run would be unbilled too, so stop
+    # here rather than after the spend. The already-returned answer from the
+    # failed call is kept — Bedrock has been paid for it either way, and
+    # discarding it would waste the money without recovering it.
+    if self._unbilled_call is not None:
+      raise UnbilledAICallError(self._unbilled_call)
+
     response = await self._ai.create_message(
       messages=messages,
       system=system,
@@ -95,12 +117,23 @@ class TrackedAIClient:
         )
         self.total_credits += credits
       except Exception as e:
-        logger.warning(
-          f"Credit consumption failed for graph={self._graph_id} "
-          f"tokens=({response.input_tokens}/{response.output_tokens}): {e}"
-        )
+        self._mark_unbilled(response, str(e))
 
     return response
+
+  def _mark_unbilled(self, response: AIResponse, reason: str) -> None:
+    """Record that a completed AI call could not be billed.
+
+    Logged at ERROR because this is real unrecovered spend, not a degraded
+    read — the previous WARNING made an unbounded billing failure look like
+    routine noise.
+    """
+    detail = (
+      f"graph={self._graph_id} user={self._user_id} "
+      f"tokens=({response.input_tokens}/{response.output_tokens}): {reason}"
+    )
+    self._unbilled_call = detail
+    logger.error(f"AI call completed but could not be billed — {detail}")
 
   @property
   def credit_summary(self) -> dict[str, Any]:

--- a/tests/operations/operators/test_credit_preflight.py
+++ b/tests/operations/operators/test_credit_preflight.py
@@ -1,0 +1,310 @@
+"""Credits are checked before an operator runs, and billing failures stop it.
+
+Credits are consumed *after* each Bedrock call returns, so the pre-flight is the
+only thing bounding spend. It lives in the execution adapters because two of the
+three API strategies (SSE, background queue) call them directly and never build
+an orchestrator.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from robosystems.operations.operators.base import (
+  OperatorCapability,
+  OperatorMode,
+  OperatorResult,
+  OperatorSpec,
+)
+from robosystems.operations.operators.credit_preflight import (
+  InsufficientOperatorCreditsError,
+  check_operator_credits,
+  enforce_operator_credits,
+  estimate_operator_credits,
+)
+
+GRAPH_ID = "kg01234567890abcdef"
+USER_ID = "usr_test123"
+
+
+def _operator(*, requires_credits: bool = True, name: str = "Test Operator"):
+  operator = MagicMock()
+  operator.spec = OperatorSpec(
+    name=name,
+    description="test",
+    capabilities=[OperatorCapability.CUSTOM],
+    requires_credits=requires_credits,
+    read_only=True,
+  )
+  operator.run = AsyncMock(return_value=OperatorResult(content="ok"))
+  return operator
+
+
+def _credit_service(result: dict):
+  service = MagicMock()
+  service.check_credit_balance.return_value = result
+  return patch(
+    "robosystems.operations.graph.credit_service.CreditService",
+    return_value=service,
+  )
+
+
+class TestEnforceOperatorCredits:
+  def test_sufficient_balance_allows_the_run(self) -> None:
+    with _credit_service({"has_sufficient_credits": True, "available_credits": 500.0}):
+      enforce_operator_credits(
+        _operator(), GRAPH_ID, USER_ID, MagicMock(), OperatorMode.STANDARD
+      )
+
+  def test_insufficient_balance_raises_with_the_numbers(self) -> None:
+    with _credit_service({"has_sufficient_credits": False, "available_credits": 5.0}):
+      with pytest.raises(InsufficientOperatorCreditsError) as exc:
+        enforce_operator_credits(
+          _operator(), GRAPH_ID, USER_ID, MagicMock(), OperatorMode.STANDARD
+        )
+
+    assert exc.value.available_credits == 5.0
+    assert exc.value.estimated_credits > 0
+
+  def test_operator_not_requiring_credits_is_skipped(self) -> None:
+    with _credit_service({"has_sufficient_credits": False}) as service:
+      enforce_operator_credits(
+        _operator(requires_credits=False),
+        GRAPH_ID,
+        USER_ID,
+        MagicMock(),
+        OperatorMode.STANDARD,
+      )
+
+    service.assert_not_called()
+
+  def test_no_session_skips_rather_than_denying(self) -> None:
+    """Contexts without the platform DB (tests) must not be blocked; the
+    adapter logs that case separately because it also means consumption
+    cannot be recorded."""
+    enforce_operator_credits(
+      _operator(), GRAPH_ID, USER_ID, None, OperatorMode.STANDARD
+    )
+
+
+class TestPreflightFailsClosed:
+  def test_an_error_resolving_the_balance_denies_the_run(self) -> None:
+    """The normal 'no credit pool' and 'no shared-repo access' cases return a
+    well-formed negative answer, so reaching the exception path means the
+    balance genuinely could not be established — which used to mean free AI."""
+    with patch(
+      "robosystems.operations.graph.credit_service.CreditService",
+      side_effect=RuntimeError("database unreachable"),
+    ):
+      result = check_operator_credits(
+        _operator(), GRAPH_ID, USER_ID, MagicMock(), OperatorMode.STANDARD
+      )
+
+    assert result["has_sufficient_credits"] is False
+    assert "database unreachable" in result["error"]
+
+  def test_enforce_raises_when_the_check_errors(self) -> None:
+    with patch(
+      "robosystems.operations.graph.credit_service.CreditService",
+      side_effect=RuntimeError("boom"),
+    ):
+      with pytest.raises(InsufficientOperatorCreditsError):
+        enforce_operator_credits(
+          _operator(), GRAPH_ID, USER_ID, MagicMock(), OperatorMode.STANDARD
+        )
+
+
+class TestEstimation:
+  def test_extended_mode_costs_more_than_quick(self) -> None:
+    operator = _operator()
+    quick = estimate_operator_credits(operator, OperatorMode.QUICK)
+    extended = estimate_operator_credits(operator, OperatorMode.EXTENDED)
+    assert extended > quick > Decimal(0)
+
+  def test_financial_operators_are_estimated_higher(self) -> None:
+    plain = estimate_operator_credits(_operator(name="Plain"), OperatorMode.STANDARD)
+    financial = estimate_operator_credits(
+      _operator(name="Financial Operator"), OperatorMode.STANDARD
+    )
+    assert financial > plain
+
+
+class TestAdaptersRunThePreflight:
+  """Asserted through the adapters, and by proving tool access is never
+  constructed — the check has to happen before anything can spend."""
+
+  @pytest.mark.asyncio
+  async def test_api_adapter_denies_an_underfunded_graph(self) -> None:
+    from robosystems.operations.operators.adapters import api
+
+    user = MagicMock()
+    user.id = USER_ID
+
+    with (
+      patch.object(
+        api,
+        "enforce_operator_credits",
+        side_effect=InsufficientOperatorCreditsError("Test Operator", 10.0, 1.0),
+      ),
+      patch.object(api, "HttpToolAccess") as tool_access,
+      patch.object(api, "AIClient"),
+      patch.object(api, "TrackedAIClient"),
+    ):
+      with pytest.raises(InsufficientOperatorCreditsError):
+        await api.run_operator_api(
+          operator=_operator(), graph_id=GRAPH_ID, user=user, query="anything"
+        )
+
+    tool_access.assert_not_called()
+
+  @pytest.mark.asyncio
+  async def test_worker_adapter_denies_an_underfunded_graph(self) -> None:
+    from robosystems.operations.operators.adapters import worker
+
+    with (
+      patch.object(
+        worker,
+        "enforce_operator_credits",
+        side_effect=InsufficientOperatorCreditsError("Test Operator", 10.0, 1.0),
+      ),
+      patch.object(worker, "SessionFactory"),
+      patch.object(worker, "DirectToolAccess") as tool_access,
+      patch.object(worker, "AIClient"),
+      patch.object(worker, "TrackedAIClient"),
+      patch.object(worker, "FactoryCreditConsumer"),
+    ):
+      with pytest.raises(InsufficientOperatorCreditsError):
+        await worker.run_operator_worker(
+          operator=_operator(),
+          task_id="task_1",
+          graph_id=GRAPH_ID,
+          user_id=USER_ID,
+          params={},
+          manager=AsyncMock(),
+        )
+
+    tool_access.assert_not_called()
+
+
+class TestUnbilledCallsStopTheLoop:
+  """A tool-use loop can make dozens of calls. If one cannot be billed, every
+  later call in the same run would be unbilled too."""
+
+  @pytest.fixture
+  def ai_response(self):
+    response = MagicMock()
+    response.input_tokens = 100
+    response.output_tokens = 50
+    response.model = "claude-sonnet"
+    return response
+
+  def _tracked(self, consumer, ai_response):
+    from robosystems.operations.operators.tracked_ai import TrackedAIClient
+
+    ai = MagicMock()
+    ai.create_message = AsyncMock(return_value=ai_response)
+    return TrackedAIClient(
+      ai_client=ai, graph_id=GRAPH_ID, user_id=USER_ID, credit_consumer=consumer
+    ), ai
+
+  @pytest.mark.asyncio
+  async def test_zero_credits_is_not_treated_as_a_failure(self, ai_response) -> None:
+    """A call billed at zero is a cheap call, not a broken one — the consumers
+    signal failure by raising."""
+    consumer = MagicMock()
+    consumer.consume = AsyncMock(return_value=0.0)
+    tracked, ai = self._tracked(consumer, ai_response)
+
+    await tracked.create_message(messages=[])
+    await tracked.create_message(messages=[])
+
+    assert ai.create_message.await_count == 2
+    assert tracked.total_credits == 0.0
+
+  @pytest.mark.asyncio
+  async def test_first_unbilled_call_still_returns_its_answer(
+    self, ai_response
+  ) -> None:
+    """Bedrock has been paid for it either way; discarding the answer would
+    waste the money without recovering it."""
+    from robosystems.operations.operators.credit_consumer import (
+      CreditConsumptionError,
+    )
+
+    consumer = MagicMock()
+    consumer.consume = AsyncMock(side_effect=CreditConsumptionError("no pool"))
+    tracked, _ = self._tracked(consumer, ai_response)
+
+    assert await tracked.create_message(messages=[]) is ai_response
+
+  @pytest.mark.asyncio
+  async def test_the_next_call_is_refused(self, ai_response) -> None:
+    from robosystems.operations.operators.credit_consumer import (
+      CreditConsumptionError,
+    )
+    from robosystems.operations.operators.tracked_ai import UnbilledAICallError
+
+    consumer = MagicMock()
+    consumer.consume = AsyncMock(side_effect=CreditConsumptionError("no pool"))
+    tracked, ai = self._tracked(consumer, ai_response)
+
+    await tracked.create_message(messages=[])
+    with pytest.raises(UnbilledAICallError):
+      await tracked.create_message(messages=[])
+
+    # Refused before spending, not after.
+    assert ai.create_message.await_count == 1
+
+
+class TestConsumersSignalFailureByRaising:
+  @pytest.mark.asyncio
+  async def test_session_consumer_raises_on_failure(self) -> None:
+    from robosystems.operations.operators.credit_consumer import (
+      CreditConsumptionError,
+      SessionCreditConsumer,
+    )
+
+    service = MagicMock()
+    service.consume_ai_tokens.return_value = {"success": False, "error": "no pool"}
+
+    with patch(
+      "robosystems.operations.graph.credit_service.CreditService",
+      return_value=service,
+    ):
+      with pytest.raises(CreditConsumptionError, match="no pool"):
+        await SessionCreditConsumer(MagicMock()).consume(
+          graph_id=GRAPH_ID,
+          user_id=USER_ID,
+          input_tokens=100,
+          output_tokens=50,
+          model="claude-sonnet",
+          operation_description="test",
+        )
+
+  @pytest.mark.asyncio
+  async def test_session_consumer_returns_the_amount_on_success(self) -> None:
+    from robosystems.operations.operators.credit_consumer import SessionCreditConsumer
+
+    service = MagicMock()
+    service.consume_ai_tokens.return_value = {
+      "success": True,
+      "credits_consumed": 12.5,
+    }
+
+    with patch(
+      "robosystems.operations.graph.credit_service.CreditService",
+      return_value=service,
+    ):
+      credits = await SessionCreditConsumer(MagicMock()).consume(
+        graph_id=GRAPH_ID,
+        user_id=USER_ID,
+        input_tokens=100,
+        output_tokens=50,
+        model="claude-sonnet",
+        operation_description="test",
+      )
+
+    assert credits == 12.5

--- a/tests/operations/operators/test_orchestrator.py
+++ b/tests/operations/operators/test_orchestrator.py
@@ -401,27 +401,39 @@ class TestOperatorOrchestrator:
 
   @pytest.mark.asyncio
   async def test_credit_check_insufficient(self, mock_user):
+    """The orchestrator renders a refusal raised by the adapter.
+
+    The pre-flight itself moved into the execution adapters, because the SSE
+    and background-queue strategies bypass the orchestrator entirely. What
+    remains here is the sync path's graceful rendering — a body with an
+    INSUFFICIENT_CREDITS code rather than an error status. That the adapter
+    actually raises is asserted in
+    `tests/operations/operators/test_credit_preflight.py`.
+    """
+    from robosystems.operations.operators.credit_preflight import (
+      InsufficientOperatorCreditsError,
+    )
+
     mock_db = Mock()
     orchestrator = OperatorOrchestrator("test-graph", mock_user, mock_db)
 
     with patch(
-      "robosystems.operations.graph.credit_service.CreditService"
-    ) as mock_credit_service:
-      mock_instance = Mock()
-      mock_credit_service.return_value = mock_instance
-      mock_instance.check_credit_balance.return_value = {
-        "has_sufficient_credits": False,
-        "estimated_credits": 10.0,
-        "available_credits": 5.0,
-      }
-
+      "robosystems.operations.operators.orchestrator.run_operator_api",
+      side_effect=InsufficientOperatorCreditsError(
+        operator_name="financial",
+        estimated_credits=10.0,
+        available_credits=5.0,
+      ),
+    ):
       agent = FinancialOperator()
       response = await orchestrator._execute_operator(
         agent, "test query", OperatorMode.STANDARD, None, {}
       )
 
-      assert "Insufficient credits" in response.content
-      assert response.error_details["code"] == "INSUFFICIENT_CREDITS"
+    assert "Insufficient credits" in response.content
+    assert response.error_details["code"] == "INSUFFICIENT_CREDITS"
+    assert response.error_details["required_credits"] == 10.0
+    assert response.error_details["available_credits"] == 5.0
 
   @pytest.mark.asyncio
   async def test_credit_check_passes(self, mock_user):


### PR DESCRIPTION
> **Stacked on #1032** — targets `bugfix/operator-write-authz`, because both change the same two adapter functions. Merge #1032 first; this will retarget to `main` automatically.

## Summary

Credits are consumed *after* a Bedrock call returns, so the pre-flight check is what bounds spend. It lived on the orchestrator — but the SSE and background-queue strategies call the execution adapters directly and never build one, so it covered **one of three API paths**, and none of the worker path. This moves it into the two adapters, where every entry point passes.

Same placement argument as #1032, for the same reason: the adapters are the only common chokepoint.

## Three fail-open behaviours, all closed

**The pre-flight denied nothing when it errored.** It returned `has_sufficient_credits: True` on any exception. The ordinary "no credit pool" and "no shared-repository access" cases already return a well-formed *negative* answer from `check_credit_balance`, so reaching the exception path means the balance genuinely could not be established — which previously meant free AI.

**The consumers returned `0.0` for both "billing failed" and "billed, cost rounded to zero."** Those are indistinguishable to the caller, which is why the failure could not be acted on. They now raise `CreditConsumptionError`, so `0.0` means what it says. This surfaced as a false positive in my first attempt at the third fix — worth knowing the two are connected.

**A billing failure mid tool-use loop was logged at WARNING and the loop continued**, so one broken call meant every later call in the same run went unbilled too. `TrackedAIClient` now refuses the next call.

The answer from the failed call is still returned deliberately: Bedrock has been paid for it either way, and discarding it would waste the money without recovering it. The log moves to ERROR — this is unrecovered spend, not noise.

## Compatibility

The orchestrator still renders the refusal as an `INSUFFICIENT_CREDITS` body for the sync path, so that response shape is unchanged. Its now-duplicate pre-check and token estimator move into the new module.

## Test approach

Asserted through the adapters, with `tool_access.assert_not_called()` so the check has to happen before anything can spend. Verified by removing the pre-flight and confirming failure.

`test_orchestrator.py::test_credit_check_insufficient` was updated rather than deleted: it autouse-patches `run_operator_api`, which now contains the control, so it could no longer have caught a regression. It now asserts the orchestrator's rendering, and the adapter behaviour is asserted where it lives.

## Verification

`just test-all` — 11,907 passed, 24 skipped, ruff + format + basedpyright clean.

Detail in `local/RoboSystems/specs/multi-user-org-hardening.md` (F2).