### PR TITLE
chore(dev): unblock Windows checkouts and WSL2 development

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,40 @@
+# Line-ending normalization.
+#
+# Git for Windows defaults to core.autocrlf=true, which rewrites text files to
+# CRLF on checkout. Several files in this repo are executed on Linux regardless
+# of the developer's platform — the container ENTRYPOINT (bin/entrypoint.sh),
+# the init scripts bind-mounted into postgres and localstack, and the git hooks
+# — and a stray \r breaks all of them ("bad interpreter", "$'\r': command not
+# found", "exec ...: no such file or directory"). Pin LF in the working tree so
+# a Windows checkout produces the same bytes as a macOS or Linux one.
+* text=auto eol=lf
+
+# Force LF on files that must not rely on text auto-detection.
+*.sh text eol=lf
+*.py text eol=lf
+*.yaml text eol=lf
+*.yml text eol=lf
+*.json text eol=lf
+*.jsonld text eol=lf
+*.sql text eol=lf
+*.ini text eol=lf
+*.toml text eol=lf
+*.mako text eol=lf
+justfile text eol=lf
+Dockerfile text eol=lf
+Dockerfile.* text eol=lf
+.env.example text eol=lf
+.env.local.example text eol=lf
+
+# Vendored third-party files — leave byte-identical to what upstream shipped.
+static/fonts/**/OFL.txt -text
+
+# Binary — never convert, never diff as text.
+*.png binary
+*.ico binary
+*.ttf binary
+*.gz binary
+*.zip binary
+*.parquet binary
+*.duckdb binary
+*.lbug binary

--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ just logs dagster-daemon      # View Dagster Daemon logs
 - `uv` for Python package and version management
 - `just` for project command runner
 
+Developed and tested on macOS and Linux. On Windows, use WSL2 with the repo cloned inside the Linux filesystem — see the **[Windows Setup (WSL2) Guide](https://github.com/RoboFinSystems/robosystems/wiki/Windows-Setup-with-WSL2)**.
+
 #### Deployment Requirements
 
 - Fork this repo
@@ -278,7 +280,7 @@ pip install robosystems-client
 
 **Getting Started & Platform:**
 
-- [Home / Overview](https://github.com/RoboFinSystems/robosystems/wiki) · [Quick Start](https://github.com/RoboFinSystems/robosystems/wiki/Quick-Start) · [Core Concepts](https://github.com/RoboFinSystems/robosystems/wiki/Core-Concepts) · [Architecture Overview](https://github.com/RoboFinSystems/robosystems/wiki/Architecture-Overview) · [Bootstrap Guide](https://github.com/RoboFinSystems/robosystems/wiki/Bootstrap-Guide) · [Security & Compliance](https://github.com/RoboFinSystems/robosystems/wiki/Security-and-Compliance)
+- [Home / Overview](https://github.com/RoboFinSystems/robosystems/wiki) · [Quick Start](https://github.com/RoboFinSystems/robosystems/wiki/Quick-Start) · [Core Concepts](https://github.com/RoboFinSystems/robosystems/wiki/Core-Concepts) · [Architecture Overview](https://github.com/RoboFinSystems/robosystems/wiki/Architecture-Overview) · [Bootstrap Guide](https://github.com/RoboFinSystems/robosystems/wiki/Bootstrap-Guide) · [Windows Setup (WSL2)](https://github.com/RoboFinSystems/robosystems/wiki/Windows-Setup-with-WSL2) · [Security & Compliance](https://github.com/RoboFinSystems/robosystems/wiki/Security-and-Compliance)
 
 **Operations Layer:**
 

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -191,7 +191,7 @@ case $DOCKER_PROFILE in
     exec uv run uvicorn main:app \
       --host 0.0.0.0 \
       --port 8000 \
-      --loop uvloop \
+      --loop auto \
       --http httptools \
       --access-log \
       --proxy-headers \

--- a/justfile
+++ b/justfile
@@ -94,7 +94,6 @@ install-hooks:
 # Create virtual environment (assumes uv is installed)
 venv:
     uv venv
-    source .venv/bin/activate
     @just install
 
 # Install dependencies from lock file

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,10 @@ dependencies = [
     "sse-starlette>=3.3.0,<4.0",
     "strawberry-graphql[fastapi]>=0.314.0,<1.0",
     "uvicorn>=0.48.0,<1.0",
-    "uvloop>=0.21.0,<1.0",
+    # uvloop ships no Windows wheels and its sdist refuses to build there, so an
+    # unconditional dependency makes `uv sync` fail outright on Windows hosts.
+    # Mirrors the marker uvicorn[standard] already carries for its own uvloop dep.
+    "uvloop>=0.21.0,<1.0; sys_platform != 'win32'",
     # Cloud Service (AWS)
     "boto3>=1.42.0,<2.0",
     # OLAP Staging/Vector/Graph Databases

--- a/robosystems/graph_api/main.py
+++ b/robosystems/graph_api/main.py
@@ -146,7 +146,9 @@ def main():
     workers=args.workers,
     log_level=args.log_level,
     access_log=True,
-    loop="uvloop",
+    # "auto" resolves to uvloop wherever it is installed (every container) and
+    # degrades to asyncio where it is not; "uvloop" imports it unconditionally.
+    loop="auto",
     http="httptools",
   )
 

--- a/tests/graph_api/test_main.py
+++ b/tests/graph_api/test_main.py
@@ -66,7 +66,7 @@ class TestMain:
         workers=1,
         log_level="info",
         access_log=True,
-        loop="uvloop",
+        loop="auto",
         http="httptools",
       )
 

--- a/uv.lock
+++ b/uv.lock
@@ -3608,7 +3608,7 @@ dependencies = [
     { name = "stripe" },
     { name = "uuid6" },
     { name = "uvicorn" },
-    { name = "uvloop" },
+    { name = "uvloop", marker = "sys_platform != 'win32'" },
 ]
 
 [package.optional-dependencies]
@@ -3706,7 +3706,7 @@ requires-dist = [
     { name = "stripe", specifier = ">=11.1.0,<12.0" },
     { name = "uuid6", specifier = ">=2025.0.0" },
     { name = "uvicorn", specifier = ">=0.48.0,<1.0" },
-    { name = "uvloop", specifier = ">=0.21.0,<1.0" },
+    { name = "uvloop", marker = "sys_platform != 'win32'", specifier = ">=0.21.0,<1.0" },
 ]
 provides-extras = ["dev"]
 


### PR DESCRIPTION
Local development is macOS/Linux-centric in ways that break a Windows checkout before the stack ever starts. This fixes the three that are cheap and platform-neutral, and documents WSL2 as the supported Windows path.

## Changes

**`.gitattributes` (new) — pin LF line endings.** Git for Windows defaults to `core.autocrlf=true`, which rewrites text files to CRLF on checkout. Several files here execute on Linux regardless of the developer's platform — `bin/entrypoint.sh` (the image `ENTRYPOINT`), the init scripts bind-mounted into postgres and localstack, and the git hooks — and a stray `\r` breaks all of them.

Verified via `git ls-files --eol` that the only tracked files currently carrying CRLF are two vendored font licenses; those are excluded with an explicit `-text` rule, so adding this produces zero working-tree churn (`ruff format` reports 1651 files unchanged).

**`uvloop` gets a `sys_platform != 'win32'` marker.** uvloop publishes no Windows wheels (49 files on 0.22.1, all macOS/manylinux/musllinux) and its sdist refuses to build there, so an unconditional dependency made `uv sync` fail outright on Windows — taking every `uv run` recipe with it (`test`, `lint`, `typecheck`, `migrate-*`, all the demos). This mirrors the marker `uvicorn[standard]` already carries for its own uvloop dep. Relock diff is 2 lines, no version churn.

**uvicorn event loop selected as `auto`, not `uvloop`.** Two call sites: `bin/entrypoint.sh:194` and `robosystems/graph_api/main.py:149`. `loop="uvloop"` is an unconditional `import uvloop`; `loop="auto"` try/excepts and falls back to asyncio. Verified identical resolution where uvloop is installed:

```
auto    -> uvloop.Loop
uvloop  -> uvloop.Loop
```

Every container runs on exactly the same event loop as before.

**Drive-by:** removed a no-op `source .venv/bin/activate` from the `venv` recipe — each `just` recipe line runs in its own shell, so the activation never outlived it.

## Docs

New wiki page **Windows Setup (WSL2)** covering `wsl --install`, `.wslconfig` memory allocation, Docker Desktop WSL integration, and a hard "clone into `~/`, never `/mnt/c`" section explaining the concrete consequences (postgres `initdb` cannot chmod the data-directory bind mount; LadybugDB/DuckDB file locking is unreliable across the boundary). Closes with an honest account of native Windows as untested, tabling the four remaining issues. Linked from the sidebar, Quick Start prerequisites, and the README.

## Testing

- `just test` — 11,887 passed, 24 skipped
- `just test-code` — ruff, format, basedpyright (0 errors), cfn-lint all clean
- One test asserted `loop="uvloop"` directly (`tests/graph_api/test_main.py:69`); updated

## Scope

This makes Windows *less broken*, not supported — WSL2 remains the answer, and it costs nothing extra to maintain since it is the Linux path we already test. Native Windows still has known issues (arelle bundle symlinks in Docker build mode, postgres on NTFS paths, `just test-dbt` temp paths, WinNAT port exclusions), documented rather than fixed.