### PR TITLE
fix(billing): one definition of a graph's credit balance

### DIFF
--- a/robosystems/models/core/graph/graph_credits.py
+++ b/robosystems/models/core/graph/graph_credits.py
@@ -309,7 +309,18 @@ class GraphCredits(Base):
       }
 
   def allocate_monthly_credits(self, session: Session) -> bool:
-    """Allocate monthly credits if due."""
+    """Allocate monthly credits if due. Credits do not roll over.
+
+    The balance is *replaced* by the monthly allocation rather than added to
+    it. Adding was the outlier: the public offering page states "Credits do not
+    roll over between billing periods" (`routers/offering.py`),
+    `UserRepositoryCredits.allocate_monthly_credits` resets and documents
+    itself as "no rollover, same as user graphs", and `GraphCredits` carries no
+    `rollover_credits` column while `UserRepositoryCredits` does. Accumulating
+    here also made `current_balance` drift permanently away from the
+    `monthly_allocation - consumed_this_month` figure the read paths reported,
+    so the same pool answered differently depending on which one you asked.
+    """
     now = datetime.now(UTC)
 
     # Check if allocation is due (monthly)
@@ -318,17 +329,7 @@ class GraphCredits(Base):
       if days_since_last < 30:  # Not due yet
         return False
 
-    # Add monthly allocation with overflow protection
-    MAX_BALANCE = Decimal("99999999.99")  # Max value for Numeric(10,2) field
-    new_balance = self.current_balance + self.monthly_allocation
-    if new_balance > MAX_BALANCE:
-      logger.warning(
-        f"Credit balance overflow prevented for graph {self.graph_id}. "
-        f"Would have been {new_balance}, capped at {MAX_BALANCE}"
-      )
-      new_balance = MAX_BALANCE
-
-    self.current_balance = new_balance
+    self.current_balance = self.monthly_allocation
     self.last_allocation_date = now
     self.updated_at = now
 
@@ -381,13 +382,15 @@ class GraphCredits(Base):
       else Decimal("0")
     )
 
-    # Calculate the actual current balance based on allocation minus consumption
-    actual_current_balance = self.monthly_allocation - consumed_this_month
-
+    # `current_balance` is the column the atomic consume path decrements and
+    # gates on, so it is the only balance a caller can actually spend. This
+    # previously recomputed `monthly_allocation - consumed_this_month` and
+    # returned it under the same name, which disagreed with the real column
+    # for any graph whose allocation had ever rolled over.
     return {
       "graph_id": self.graph_id,
       "graph_tier": self.graph_tier,  # This now uses the property that gets it from graph
-      "current_balance": safe_float(actual_current_balance),
+      "current_balance": safe_float(self.current_balance),
       "monthly_allocation": safe_float(self.monthly_allocation),
       "consumed_this_month": safe_float(consumed_this_month),
       "transaction_count": transactions.transaction_count if transactions else 0,

--- a/robosystems/operations/graph/credit_service.py
+++ b/robosystems/operations/graph/credit_service.py
@@ -573,9 +573,13 @@ class CreditService:
         "error": "No credit pool found for graph",
       }
 
-    # Calculate actual remaining balance (allocation - consumed)
-    consumed_this_month = self._get_consumed_this_month(parent_graph_id)
-    actual_balance = float(credits.monthly_allocation) - float(consumed_this_month)
+    # `current_balance` is the column `consume_credits_atomic` decrements and
+    # gates its UPDATE on, so it is the only balance that determines whether a
+    # spend will actually succeed. This used to derive
+    # `monthly_allocation - consumed_this_month` instead and cache it under the
+    # same key the consume path writes — two different definitions of "balance"
+    # sharing one key, so a caller got whichever had written last.
+    actual_balance = float(credits.current_balance)
 
     has_sufficient = Decimal(str(actual_balance)) >= required_credits
 

--- a/tests/models/core/graph/test_graph_credits.py
+++ b/tests/models/core/graph/test_graph_credits.py
@@ -3,7 +3,6 @@
 import json
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
-from unittest.mock import patch
 
 import pytest
 
@@ -261,7 +260,12 @@ class TestGraphCredits:
     # Should allocate since more than 30 days have passed
     result = credits.allocate_monthly_credits(self.session)
     assert result is True
-    assert credits.current_balance == Decimal("1500")
+    # Credits do not roll over — the unspent 500 is not carried forward. This
+    # asserted 1500 (a top-up) while the offering page tells customers
+    # "Credits do not roll over between billing periods" and
+    # `UserRepositoryCredits` resets, documenting itself as "no rollover, same
+    # as user graphs". Graph credits were the only ones that accumulated.
+    assert credits.current_balance == Decimal("1000")
     assert credits.last_allocation_date > last_month
 
     # Check allocation transaction was created
@@ -297,8 +301,16 @@ class TestGraphCredits:
     assert result is False
     assert credits.current_balance == Decimal("500")
 
-  def test_allocate_monthly_credits_overflow_protection(self):
-    """Test overflow protection during allocation."""
+  def test_allocation_never_accumulates_past_the_monthly_amount(self):
+    """A large prior balance is replaced, not added to.
+
+    Replaces the old overflow-protection test. That guard capped
+    `current_balance + monthly_allocation` at the `Numeric(10, 2)` ceiling —
+    a condition only reachable *because* allocation accumulated. With the
+    balance replaced, both values share one column type, so the sum can no
+    longer be formed and there is nothing to overflow. What matters now is
+    the invariant the guard was compensating for.
+    """
     credits = GraphCredits(
       graph_id=self.graph.graph_id,
       user_id=self.user.id,
@@ -310,12 +322,10 @@ class TestGraphCredits:
     self.session.add(credits)
     self.session.commit()
 
-    with patch("robosystems.models.core.graph.graph_credits.logger") as mock_logger:
-      result = credits.allocate_monthly_credits(self.session)
+    result = credits.allocate_monthly_credits(self.session)
 
     assert result is True
-    assert credits.current_balance == Decimal("99999999.99")  # Capped at MAX_BALANCE
-    mock_logger.warning.assert_called_once()
+    assert credits.current_balance == Decimal("2000000")
 
   def test_get_effective_storage_limit(self):
     """Test getting effective storage limit."""
@@ -624,3 +634,89 @@ class TestGraphCreditTransaction:
     assert transaction.operation_id is None
     assert transaction.user_id is None
     assert transaction.transaction_metadata is None
+
+
+class TestSingleBalanceDefinition:
+  """`current_balance` is the one definition of a graph's spendable credits.
+
+  Two definitions previously coexisted and were cached under the same key:
+  `consume_credits_atomic` decremented and gated on the `current_balance`
+  column, while the read paths recomputed
+  `monthly_allocation - consumed_this_month`. Because allocation *added* to the
+  balance, the two drifted apart permanently — so the same pool answered
+  differently depending on which one you asked, and a caller could be refused
+  at zero while the column it actually spends from held thousands.
+  """
+
+  @pytest.fixture(autouse=True)
+  def setup(self, db_session):
+    import uuid
+
+    self.session = db_session
+    unique_id = str(uuid.uuid4())[:8]
+
+    self.user = User(
+      email=f"balance_def_user_{unique_id}@example.com",
+      name="Test User",
+      password_hash="hashed_password",
+    )
+    self.session.add(self.user)
+    self.session.commit()
+
+    self.graph = Graph(
+      graph_id=f"test_balance_def_{unique_id}",
+      graph_name="Test Graph",
+      graph_type="entity",
+      graph_tier=GraphTier.LADYBUG_STANDARD.value,
+    )
+    self.session.add(self.graph)
+    self.session.commit()
+
+    self.credits = GraphCredits(
+      graph_id=self.graph.graph_id,
+      user_id=self.user.id,
+      billing_admin_id=self.user.id,
+      current_balance=Decimal("250"),
+      monthly_allocation=Decimal("1000"),
+    )
+    self.session.add(self.credits)
+    self.session.commit()
+
+  def test_usage_summary_reports_the_column_the_consume_path_gates_on(self):
+    """A balance that has diverged from `allocation - consumed` is reported
+    as-is; recomputing it here is what made the two disagree."""
+    summary = self.credits.get_usage_summary(self.session)
+
+    assert summary["current_balance"] == 250.0
+    assert summary["monthly_allocation"] == 1000.0
+
+  def test_allocation_makes_the_two_definitions_agree(self):
+    """After a reset with nothing consumed since, the real column and the
+    derived figure coincide — the property that stops them drifting again."""
+    self.credits.last_allocation_date = datetime.now(UTC) - timedelta(days=35)
+    self.session.commit()
+
+    assert self.credits.allocate_monthly_credits(self.session) is True
+
+    summary = self.credits.get_usage_summary(self.session)
+    derived = float(self.credits.monthly_allocation) - summary["consumed_this_month"]
+    assert summary["current_balance"] == derived == 1000.0
+
+  def test_consuming_moves_both_in_step(self):
+    """Consumption decrements the column and is reflected in the summary, so
+    the two stay equal through a normal spend."""
+    self.credits.current_balance = Decimal("1000")
+    self.credits.last_allocation_date = datetime.now(UTC)
+    self.session.commit()
+
+    self.credits.consume_credits_atomic(
+      amount=Decimal("300"),
+      operation_type="agent_call",
+      operation_description="AI call",
+      session=self.session,
+      user_id=self.user.id,
+    )
+
+    summary = self.credits.get_usage_summary(self.session)
+    assert summary["current_balance"] == 700.0
+    assert summary["consumed_this_month"] == 300.0

--- a/tests/operations/graph/test_subgraph_credit_sharing.py
+++ b/tests/operations/graph/test_subgraph_credit_sharing.py
@@ -184,14 +184,21 @@ class TestSubgraphCreditSharing:
     subgraph_id = f"{parent_graph.graph_id}_dev3"
 
     parent_credits.last_allocation_date = datetime(2024, 1, 1, tzinfo=UTC)
-    initial_balance = parent_credits.current_balance
+    # Spend some of the pool first, so a reset and a rollover would produce
+    # different numbers — otherwise this passes either way and asserts nothing.
+    parent_credits.current_balance = Decimal("2500")
     db_session.commit()
 
     result = credit_service.allocate_monthly_credits(graph_id=subgraph_id)
 
     assert result["success"] is True
     assert result["allocated_credits"] == 10000.0
-    assert result["new_balance"] == float(initial_balance + Decimal("10000"))
+    # Credits do not roll over: the balance is replaced, not topped up. The
+    # rollover this used to assert contradicted the offering page's "Credits do
+    # not roll over between billing periods" and drifted `current_balance`
+    # away from every read path that derived it from `monthly_allocation`.
+    assert result["new_balance"] == 10000.0
+    assert parent_credits.current_balance == Decimal("10000")
 
   def test_get_credit_transactions_with_subgraph_id(
     self,


### PR DESCRIPTION
## Summary

Two definitions of "balance" coexisted and were cached under the same key. `consume_credits_atomic` decrements and gates its UPDATE on the `current_balance` column; both read paths recomputed `monthly_allocation - consumed_this_month`. A caller got whichever wrote to the cache last.

They could not converge, because `allocate_monthly_credits` **added** the monthly amount while the derived figure **resets** each month — so the gap widened with every allocation. Visible effects: `/credits` and `/limits` returning different numbers for the same pool, and a heavy month refused at zero while the column it actually spends from held thousands.

## Why reset, not rollover

Graph credits were the only pool that accumulated. Four things already said otherwise:

- `routers/offering.py` tells customers **"Credits do not roll over between billing periods"**
- `UserRepositoryCredits.allocate_monthly_credits` resets, and documents itself as *"no rollover, same as user graphs"*
- `GraphCredits` has **no `rollover_credits` column**; `UserRepositoryCredits` does
- the derived formula the read paths used is itself reset semantics

So this is a defect, not a policy change — one line disagreed with the stated policy and with every other part of the system.

## Scope note

The review identified two divergent sites. There is a **third**: `GraphCredits.get_usage_summary` also recomputed the balance and returned it under the name `current_balance`, shadowing the real column. All three now report the column the consume path gates on.

The overflow guard is dropped along with the accumulation that required it — both values share one `Numeric(10, 2)` column, so the sum can no longer be formed. Its test is replaced by the invariant it was compensating for.

## Tests

Three existing tests asserted the rollover; they are updated rather than deleted, each carrying the reason. One was strengthened first — it set up a state where reset and rollover produce the same number, so it would have passed either way.

New `TestSingleBalanceDefinition` locks the invariant rather than the three call sites: a diverged balance is reported as-is, allocation makes the real and derived figures coincide, and a normal spend keeps them in step. Verified by restoring the old behaviour and confirming failure.

## ⚠️ Deploy consequence — needs a decision

For any graph that has already accumulated, `current_balance` is **higher** than the derived figure being shown today. On deploy those graphs will display a jump **up**, then drop to `monthly_allocation` at their next allocation.

A one-time reconciliation setting `current_balance = monthly_allocation - consumed_this_month` would make the transition seamless. Not included here — it is a data change to customer-visible balances and should be a deliberate call. Prod is small enough to size the impact with a single query first.

## Verification

`just test-all` — 11,913 passed, 24 skipped, ruff + format + basedpyright clean.

Detail in `local/RoboSystems/specs/multi-user-org-hardening.md` (F3).