### PR TITLE
fix(billing): resolve webhook subscriptions exactly, or not at all

### DIFF
--- a/robosystems/dagster/jobs/billing.py
+++ b/robosystems/dagster/jobs/billing.py
@@ -161,14 +161,58 @@ def _extract_stripe_subscription_id(data: dict) -> str | None:
   return None
 
 
-def _resolve_subscription(event_data: dict, db_session: Any, context: Any) -> Any:
+def _extract_local_subscription_id(data: dict) -> str | None:
+  """Our own `BillingSubscription.id` from the Stripe payload's metadata.
+
+  The create paths write `subscription_id` into the Stripe subscription's
+  metadata, and Stripe copies that onto derived objects such as invoices. It
+  identifies one exact row, so it is a far better disambiguator than the
+  customer id — which now maps to an org holding many concurrent
+  subscriptions.
+  """
+  candidates = [data.get("metadata")]
+  if parent := data.get("parent"):
+    if isinstance(parent, dict) and (details := parent.get("subscription_details")):
+      if isinstance(details, dict):
+        candidates.append(details.get("metadata"))
+
+  for metadata in candidates:
+    if isinstance(metadata, dict):
+      local_id = metadata.get("subscription_id")
+      if isinstance(local_id, str) and local_id:
+        return local_id
+  return None
+
+
+def _resolve_subscription(
+  event_data: dict,
+  db_session: Any,
+  context: Any,
+  *,
+  allow_customer_fallback: bool = True,
+) -> Any:
   """Resolve the BillingSubscription for any Stripe event.
 
-  Tries subscription ID first (multiple payload locations), then falls
-  back to customer ID. This is the single entry point for subscription
-  lookup — all handlers should use this instead of rolling their own.
+  Tries the Stripe subscription id first (several payload locations), then our
+  own id from the payload metadata, then — only when the caller permits it and
+  the answer is unambiguous — the billing customer.
 
-  Raises SubscriptionNotFoundError if the subscription cannot be found.
+  `allow_customer_fallback=False` is required for handlers that mutate or
+  cancel what they resolve. A `customer.subscription.*` payload IS the
+  subscription, so `_extract_stripe_subscription_id` always finds an id in it;
+  failing to match that id locally means the subscription genuinely is not in
+  our database, and picking a different one from the same org would apply the
+  event to the wrong resource. Raising instead lets Stripe retry.
+
+  The customer fallback exists for invoice events, where `invoice.created` can
+  legitimately arrive before `checkout.session.completed` has written the local
+  row. It is kept for those, but only when the org has exactly one candidate:
+  `BillingCustomer.org_id` is the primary key, so one Stripe customer maps to
+  an org that may hold one subscription per graph plus one per member per
+  repository. "Most recently created active subscription" stopped being a
+  reasonable guess the moment an org could have more than one member.
+
+  Raises SubscriptionNotFoundError if the subscription cannot be resolved.
   """
   from robosystems.models.core.billing import BillingCustomer, BillingSubscription
 
@@ -187,21 +231,23 @@ def _resolve_subscription(event_data: dict, db_session: Any, context: Any) -> An
     if subscription:
       return subscription
 
+  # --- Try by our own subscription ID, carried in the Stripe metadata ---
+  local_sub_id = _extract_local_subscription_id(event_data)
+  if local_sub_id:
+    subscription = (
+      db_session.query(BillingSubscription)
+      .filter(BillingSubscription.id == local_sub_id)
+      .first()
+    )
+    if subscription:
+      return subscription
+
   # --- Fallback: customer ID → org → subscription ---
-  # Prefer active/provisioning over canceled to avoid matching a stale
-  # subscription when the org has re-subscribed.
   customer_id = event_data.get("customer")
-  if customer_id:
+  if customer_id and allow_customer_fallback:
     customer = BillingCustomer.get_by_stripe_customer_id(customer_id, db_session)
     if customer:
-      from sqlalchemy import case
-
-      status_priority = case(
-        {"active": 0, "provisioning": 1, "pending_payment": 2, "canceled": 3},
-        value=BillingSubscription.status,
-        else_=4,
-      )
-      subscription = (
+      candidates = (
         db_session.query(BillingSubscription)
         .filter(
           BillingSubscription.org_id == customer.org_id,
@@ -209,18 +255,29 @@ def _resolve_subscription(event_data: dict, db_session: Any, context: Any) -> An
             ["pending_payment", "provisioning", "active", "canceled"]
           ),
         )
-        .order_by(status_priority, BillingSubscription.created_at.desc())
-        .first()
+        .limit(2)
+        .all()
       )
-      if subscription:
+      # Exactly one candidate or none — never a guess between several. An
+      # invoice misattributed here is permanent, because invoices dedupe on
+      # `stripe_invoice_id` and no later event revisits the association.
+      if len(candidates) == 1:
         context.log.info(
-          f"Resolved subscription {subscription.id} via customer {customer_id}"
+          f"Resolved subscription {candidates[0].id} via customer {customer_id} "
+          f"(sole candidate for org {customer.org_id})"
         )
-        return subscription
+        return candidates[0]
+      if len(candidates) > 1:
+        context.log.warning(
+          f"Refusing to resolve via customer {customer_id}: org "
+          f"{customer.org_id} has multiple candidate subscriptions and the "
+          f"event carries no subscription id to disambiguate them"
+        )
 
   raise SubscriptionNotFoundError(
     f"Subscription not found (stripe_sub={stripe_sub_id}, "
-    f"customer={event_data.get('customer')})"
+    f"local_sub={local_sub_id}, customer={event_data.get('customer')}, "
+    f"customer_fallback={'allowed' if allow_customer_fallback else 'disallowed'})"
   )
 
 
@@ -559,7 +616,13 @@ async def _handle_subscription_updated(
   status = subscription_data.get("status")
   cancel_at_period_end = subscription_data.get("cancel_at_period_end", False)
 
-  subscription = _resolve_subscription(subscription_data, db_session, context)
+  # No customer fallback: this handler mutates and can cancel what it
+  # resolves, and a customer.subscription.* payload always carries its own
+  # id — so a miss means we do not have this subscription, not that we
+  # should pick another one from the same org. Raising lets Stripe retry.
+  subscription = _resolve_subscription(
+    subscription_data, db_session, context, allow_customer_fallback=False
+  )
 
   # Sync billing period dates from Stripe
   # Newer Stripe API versions moved these from the subscription root
@@ -680,7 +743,13 @@ async def _handle_subscription_deleted(
   """
   from datetime import UTC, datetime
 
-  subscription = _resolve_subscription(subscription_data, db_session, context)
+  # No customer fallback: this handler mutates and can cancel what it
+  # resolves, and a customer.subscription.* payload always carries its own
+  # id — so a miss means we do not have this subscription, not that we
+  # should pick another one from the same org. Raising lets Stripe retry.
+  subscription = _resolve_subscription(
+    subscription_data, db_session, context, allow_customer_fallback=False
+  )
 
   if subscription.status == "canceled":
     # Already canceled (via portal updated handler or UI cancel button).

--- a/tests/dagster/test_stripe_webhook_payloads.py
+++ b/tests/dagster/test_stripe_webhook_payloads.py
@@ -397,6 +397,8 @@ class TestResolveSubscription:
     mock_query = MagicMock()
     mock_query.filter.return_value = mock_query
     mock_query.order_by.return_value = mock_query
+    mock_query.limit.return_value = mock_query
+    mock_query.all.return_value = [mock_sub]
     mock_query.first.return_value = mock_sub
     db.query.return_value = mock_query
 
@@ -426,6 +428,8 @@ class TestResolveSubscription:
     mock_query = MagicMock()
     mock_query.filter.return_value = mock_query
     mock_query.order_by.return_value = mock_query
+    mock_query.limit.return_value = mock_query
+    mock_query.all.return_value = [mock_sub]
     mock_query.first.return_value = mock_sub
     db.query.return_value = mock_query
 
@@ -469,6 +473,8 @@ class TestResolveSubscription:
     mock_query = MagicMock()
     mock_query.filter.return_value = mock_query
     mock_query.order_by.return_value = mock_query
+    mock_query.limit.return_value = mock_query
+    mock_query.all.return_value = []
     mock_query.first.return_value = None
     db.query.return_value = mock_query
 
@@ -491,4 +497,161 @@ class TestResolveSubscription:
     assert result == mock_sub
     MockSub.get_by_provider_subscription_id.assert_called_with(
       "sub_1T98GkReD8VoQizP4kyPVtC1", db
+    )
+
+
+class TestCustomerFallbackIsBounded:
+  """The customer fallback must never guess between several subscriptions.
+
+  `BillingCustomer.org_id` is the primary key, so one Stripe customer maps to
+  an org that may now hold one subscription per graph plus one per member per
+  repository. Picking "most recent active" was reasonable when an org had one
+  member and one subscription; with multi-user orgs it silently applies an
+  event to the wrong resource.
+  """
+
+  def _customer(self, org_id="org_test"):
+    customer = MagicMock()
+    customer.org_id = org_id
+    return customer
+
+  def _subscription(self, sub_id):
+    sub = MagicMock()
+    sub.id = sub_id
+    sub.org_id = "org_test"
+    return sub
+
+  def _db_returning(self, rows):
+    db = MagicMock()
+    query = MagicMock()
+    query.filter.return_value = query
+    query.order_by.return_value = query
+    query.limit.return_value = query
+    query.all.return_value = rows
+    query.first.return_value = rows[0] if rows else None
+    db.query.return_value = query
+    return db
+
+  @patch("robosystems.models.core.billing.BillingCustomer")
+  @patch("robosystems.models.core.billing.BillingSubscription")
+  def test_sole_candidate_still_resolves(self, MockSub, MockCustomer):
+    """The race the fallback exists for: invoice.created can arrive before
+    checkout.session.completed has written the local row."""
+    sub = self._subscription("bsub_only")
+    MockSub.get_by_provider_subscription_id.return_value = None
+    MockSub.get_by_stripe_subscription_id.return_value = None
+    MockCustomer.get_by_stripe_customer_id.return_value = self._customer()
+
+    result = _resolve_subscription(
+      RENEWAL_INVOICE_CREATED, self._db_returning([sub]), MagicMock()
+    )
+
+    assert result is sub
+
+  @patch("robosystems.models.core.billing.BillingCustomer")
+  @patch("robosystems.models.core.billing.BillingSubscription")
+  def test_multiple_candidates_refuse_rather_than_guess(self, MockSub, MockCustomer):
+    """The scenario a second org member creates: the org already has an active
+    subscription when a new one's first invoice arrives. Attributing it to the
+    existing subscription would be permanent, because invoices dedupe on
+    `stripe_invoice_id` and nothing revisits the association."""
+    MockSub.get_by_provider_subscription_id.return_value = None
+    MockSub.get_by_stripe_subscription_id.return_value = None
+    MockCustomer.get_by_stripe_customer_id.return_value = self._customer()
+
+    db = self._db_returning(
+      [self._subscription("bsub_graph"), self._subscription("bsub_repo_member2")]
+    )
+
+    with pytest.raises(SubscriptionNotFoundError):
+      _resolve_subscription(RENEWAL_INVOICE_CREATED, db, MagicMock())
+
+  @patch("robosystems.models.core.billing.BillingCustomer")
+  @patch("robosystems.models.core.billing.BillingSubscription")
+  def test_destructive_handlers_refuse_the_fallback_entirely(
+    self, MockSub, MockCustomer
+  ):
+    """A customer.subscription.* payload always carries its own id, so a local
+    miss means we do not have it — not that another of the org's subscriptions
+    should be cancelled in its place."""
+    MockSub.get_by_provider_subscription_id.return_value = None
+    MockSub.get_by_stripe_subscription_id.return_value = None
+    MockCustomer.get_by_stripe_customer_id.return_value = self._customer()
+
+    db = self._db_returning([self._subscription("bsub_someone_elses")])
+
+    with pytest.raises(SubscriptionNotFoundError):
+      _resolve_subscription(
+        RENEWAL_SUBSCRIPTION_UPDATED,
+        db,
+        MagicMock(),
+        allow_customer_fallback=False,
+      )
+
+    # Never consulted — the refusal is structural, not a query that came back
+    # empty, so it holds no matter what the org happens to contain.
+    MockCustomer.get_by_stripe_customer_id.assert_not_called()
+
+  @patch("robosystems.models.core.billing.BillingCustomer")
+  @patch("robosystems.models.core.billing.BillingSubscription")
+  def test_our_own_id_in_metadata_resolves_without_the_fallback(
+    self, MockSub, MockCustomer
+  ):
+    """The create paths write `subscription_id` into the Stripe metadata, and
+    Stripe copies it onto derived objects — it identifies one exact row."""
+    sub = self._subscription("bsub_01KK9WP4KDFMFR7G579ABNME6N")
+    MockSub.get_by_provider_subscription_id.return_value = None
+    MockSub.get_by_stripe_subscription_id.return_value = None
+
+    db = self._db_returning([sub])
+
+    result = _resolve_subscription(
+      NEW_SUB_CHECKOUT_COMPLETED, db, MagicMock(), allow_customer_fallback=False
+    )
+
+    assert result is sub
+    MockCustomer.get_by_stripe_customer_id.assert_not_called()
+
+
+class TestDestructiveHandlersOptOutOfTheFallback:
+  """The handlers that mutate what they resolve must pass
+  `allow_customer_fallback=False`.
+
+  Asserted on the handlers rather than on the resolver: a test that calls
+  `_resolve_subscription(..., allow_customer_fallback=False)` directly proves
+  the parameter works, but would still pass if a handler stopped supplying it.
+  That is the difference between testing the control and testing that the
+  control is wired up.
+  """
+
+  @pytest.mark.asyncio
+  @pytest.mark.parametrize(
+    "handler_name,payload",
+    [
+      ("_handle_subscription_updated", RENEWAL_SUBSCRIPTION_UPDATED),
+      ("_handle_subscription_deleted", RENEWAL_SUBSCRIPTION_UPDATED),
+    ],
+  )
+  async def test_handler_disallows_customer_fallback(self, handler_name, payload):
+    from robosystems.dagster.jobs import billing
+
+    handler = getattr(billing, handler_name)
+    resolved = MagicMock()
+    resolved.status = "active"
+    resolved.resource_type = "graph"
+
+    with patch.object(
+      billing, "_resolve_subscription", return_value=resolved
+    ) as resolver:
+      try:
+        await handler(payload, MagicMock(), MagicMock())
+      except Exception:
+        # Downstream behaviour is covered elsewhere; this asserts only how the
+        # resolver was invoked, which happens before anything else can fail.
+        pass
+
+    assert resolver.call_count == 1
+    assert resolver.call_args.kwargs.get("allow_customer_fallback") is False, (
+      f"{handler_name} can cancel what it resolves, so it must not fall back "
+      f"to picking another of the org's subscriptions"
     )


### PR DESCRIPTION
## Summary

When a Stripe event's subscription id did not match locally, the resolver fell back to the billing customer, mapped that to an org, and returned the org's most recent active subscription. Two handlers then **mutate and can cancel** whatever comes back.

That fallback was reasonable when an org held one subscription. It no longer is: `BillingCustomer.org_id` is the primary key, so one Stripe customer maps to an org that may hold one subscription per graph **plus one per member per repository**. "Most recent active" became a guess the moment orgs could have a second member.

## Three changes

**Handlers that mutate what they resolve no longer accept the fallback.** A `customer.subscription.*` payload *is* the subscription — `_extract_stripe_subscription_id` returns its own `id` field — so the id is always present. Failing to match it locally means we don't have that subscription, not that another of the org's should stand in. Raising lets Stripe retry, which the webhook router already handles.

**The resolver now tries our own subscription id from the Stripe metadata** before considering the customer. The create paths write `subscription_id` into the metadata and Stripe copies it onto derived objects, so it identifies one exact row. This is a better disambiguator than the customer id and costs nothing.

**Where the fallback remains** — invoice events, where `invoice.created` can legitimately precede `checkout.session.completed`, as the code at `subscriptions.py:331-333` documents — it resolves only when the org has **exactly one** candidate, and logs rather than guesses otherwise. A misattributed invoice is permanent: invoices dedupe on `stripe_invoice_id` and nothing revisits the association.

## Test approach

The existing suite here uses **real payloads copied from production `billing_audit_logs`**, so the change is exercised against actual Stripe traffic shapes rather than invented ones. Three of those tests needed their mocked query chain updated (`.order_by().first()` → `.limit(2).all()`), since detecting ambiguity requires fetching more than one row.

New tests cover the sole-candidate race, the multi-candidate refusal, and metadata resolution.

The wiring test is the one that matters: it asserts **on the handlers** that they pass `allow_customer_fallback=False`, not just that the resolver honours the parameter. My first version tested only the resolver — it would have kept passing if a handler stopped supplying the flag. Verified by restoring the old behaviour: three tests fail, the ambiguity guard and both handler wirings.

## Verification

`just test-all` — 11,916 passed, 24 skipped, ruff + format + basedpyright clean.

Detail in `local/RoboSystems/specs/multi-user-org-hardening.md` (F6).