### PR TITLE
fix(usage): record credit consumption in the usage ledger

### DIFF
--- a/robosystems/operations/graph/credit_service.py
+++ b/robosystems/operations/graph/credit_service.py
@@ -29,6 +29,7 @@ from ...models.core import (
   Graph,
   GraphCredits,
   GraphCreditTransaction,
+  GraphUsage,
   GraphUser,
 )
 from ...models.core.graph.graph_credits import CreditTransactionType
@@ -253,15 +254,19 @@ class CreditService:
       except Exception as e:
         logger.warning(f"Failed to update credit cache after consumption: {e}")
 
+      # Resolved once, outside the best-effort blocks below: both consume it,
+      # and computing it inside the first one left it unbound for the second
+      # whenever that block raised early.
+      graph_tier_val = (
+        credits.graph_tier.value
+        if hasattr(credits.graph_tier, "value")
+        else str(credits.graph_tier)
+      )
+
       # Record OTel credit consumption metric
       try:
         from ...middleware.otel.metrics import get_endpoint_metrics
 
-        graph_tier_val = (
-          credits.graph_tier.value
-          if hasattr(credits.graph_tier, "value")
-          else str(credits.graph_tier)
-        )
         get_endpoint_metrics().record_credit_consumption(
           operation_type=operation_type,
           credits_consumed=float(consumption_result["credits_consumed"]),
@@ -269,6 +274,38 @@ class CreditService:
         )
       except Exception:
         pass  # Metrics are best-effort, never break credit consumption
+
+      # Usage-ledger row for the reporting surfaces. This is a different table
+      # from the credit ledger the atomic consume just wrote
+      # (`graph_credit_transactions`, authoritative for billing) — `graph_usage`
+      # is what `/orgs/{org_id}/usage` and the per-graph usage views read.
+      # `record_storage_usage` was the only recorder ever wired up, so
+      # `graph_usage` accumulated storage snapshots and nothing else: an org
+      # that had really run AI operations and spent credits still saw zero of
+      # both on its usage dashboard. Best-effort like the metric above — a
+      # reporting row must never fail a consumption that already committed.
+      try:
+        if user_id:
+          GraphUsage.record_credit_consumption(
+            user_id=user_id,
+            graph_id=graph_id,
+            graph_tier=graph_tier_val,
+            operation_type=operation_type,
+            credits_consumed=Decimal(str(consumption_result["credits_consumed"])),
+            base_credit_cost=Decimal(str(consumption_result["base_cost"])),
+            session=self.session,
+            cached_operation=cached,
+            metadata=metadata,
+          )
+        else:
+          # `GraphUsage.user_id` is NOT NULL and consumption is attributed per
+          # user, so an unattributed spend is dropped rather than forged.
+          logger.warning(
+            f"Credit consumption on {graph_id} has no user_id; "
+            f"usage row skipped (operation_type={operation_type})"
+          )
+      except Exception as e:
+        logger.warning(f"Failed to record credit usage for {graph_id}: {e}")
 
       return {
         "success": True,

--- a/robosystems/routers/orgs/usage.py
+++ b/robosystems/routers/orgs/usage.py
@@ -31,6 +31,22 @@ logger = get_logger(__name__)
 
 router = APIRouter(tags=["Org Usage"])
 
+# Event types that represent a caller-initiated API operation. Deliberately
+# excludes storage snapshots (written by a background sensor) and credit events
+# (reported separately as credits/AI operations).
+_API_EVENT_TYPES = frozenset(
+  {
+    UsageEventType.API_CALL.value,
+    UsageEventType.QUERY_EXECUTION.value,
+    UsageEventType.MCP_CALL.value,
+    UsageEventType.AGENT_CALL.value,
+    UsageEventType.IMPORT_OPERATION.value,
+    UsageEventType.BACKUP_OPERATION.value,
+    UsageEventType.SYNC_OPERATION.value,
+    UsageEventType.ANALYTICS_QUERY.value,
+  }
+)
+
 
 @router.get(
   "/orgs/{org_id}/limits",
@@ -172,7 +188,14 @@ async def get_org_usage(
         for r in usage_records
         if r.event_type == UsageEventType.CREDIT_CONSUMPTION.value
       )
-      graph_api_calls = len(usage_records)
+      # Count API-shaped events, not every row in the table. `graph_usage` also
+      # holds the 6-hourly storage snapshots the usage sensor writes and the
+      # credit-consumption rows counted just above, so `len(usage_records)`
+      # reported background bookkeeping as customer API traffic — an untouched
+      # graph still showed a steadily climbing "API calls" figure.
+      graph_api_calls = sum(
+        1 for r in usage_records if r.event_type in _API_EVENT_TYPES
+      )
 
       # Get latest storage snapshot
       latest_storage = (

--- a/tests/operations/graph/test_credit_service.py
+++ b/tests/operations/graph/test_credit_service.py
@@ -9,6 +9,7 @@ import pytest
 from robosystems.config.graph_tier import GraphTier
 from robosystems.models.core import (
   GraphCredits,
+  GraphUsage,
   User,
 )
 from robosystems.operations.graph.credit_service import (
@@ -613,3 +614,135 @@ class TestSharedRepositorySubgraphBilling:
       )
 
     assert mock_check.call_args.kwargs["repository_name"] == "sec"
+
+
+class TestCreditConsumptionWritesUsageLedger:
+  """Consuming credits records a `graph_usage` row, not just a credit ledger
+  transaction.
+
+  These are two different tables. `graph_credit_transactions` is authoritative
+  for billing and was always written; `graph_usage` is what the org and
+  per-graph usage dashboards read, and only `record_storage_usage` was ever
+  wired to it. In production that left `graph_usage` holding storage snapshots
+  and nothing else, so an org that had genuinely run AI operations and spent
+  credits saw zero of both on its usage view.
+  """
+
+  @pytest.fixture
+  def mock_session(self):
+    return MagicMock()
+
+  @pytest.fixture
+  def credit_service(self, mock_session):
+    with patch("robosystems.middleware.billing.cache.credit_cache"):
+      return CreditService(mock_session)
+
+  def _credits(self, result: dict):
+    credits = MagicMock()
+    credits.graph_tier = "ladybug-standard"
+    credits.consume_credits_atomic = Mock(return_value=result)
+    return credits
+
+  def _consume(self, credit_service, credits, **kwargs):
+    with (
+      patch("robosystems.middleware.billing.cache.credit_cache") as cache,
+      patch.object(GraphCredits, "get_by_graph_id", return_value=credits),
+      patch.object(GraphUsage, "record_credit_consumption") as record,
+    ):
+      # Real tuple, not a MagicMock: consume_credits unpacks this.
+      cache.get_cached_graph_credit_balance.return_value = (
+        Decimal("1000.0"),
+        "ladybug-standard",
+      )
+      result = credit_service.consume_credits(
+        graph_id="graph123",
+        operation_type="agent_call",
+        base_cost=Decimal("10.0"),
+        **kwargs,
+      )
+    return result, record
+
+  def test_successful_consumption_records_a_usage_row(self, credit_service):
+    credits = self._credits(
+      {
+        "success": True,
+        "credits_consumed": 10.0,
+        "new_balance": 990.0,
+        "transaction_id": "t-1",
+        "base_cost": 10.0,
+      }
+    )
+
+    result, record = self._consume(credit_service, credits, user_id="usr_abc")
+
+    assert result["success"] is True
+    record.assert_called_once()
+    kwargs = record.call_args.kwargs
+    assert kwargs["user_id"] == "usr_abc"
+    assert kwargs["graph_id"] == "graph123"
+    assert kwargs["operation_type"] == "agent_call"
+    assert kwargs["credits_consumed"] == Decimal("10.0")
+
+  def test_failed_consumption_records_nothing(self, credit_service):
+    credits = self._credits(
+      {"success": False, "error": "Insufficient credits", "available_credits": 1.0}
+    )
+
+    result, record = self._consume(credit_service, credits, user_id="usr_abc")
+
+    assert result["success"] is False
+    record.assert_not_called()
+
+  def test_unattributed_consumption_is_skipped_not_forged(self, credit_service):
+    """`GraphUsage.user_id` is NOT NULL and usage is attributed per user, so a
+    spend with no user is dropped rather than written against a placeholder."""
+    credits = self._credits(
+      {
+        "success": True,
+        "credits_consumed": 10.0,
+        "new_balance": 990.0,
+        "transaction_id": "t-1",
+        "base_cost": 10.0,
+      }
+    )
+
+    result, record = self._consume(credit_service, credits)
+
+    assert result["success"] is True
+    record.assert_not_called()
+
+  def test_a_failing_usage_write_never_breaks_consumption(self, credit_service):
+    """The credits are already committed by the time this runs — a reporting
+    row must not turn a successful spend into an error."""
+    credits = self._credits(
+      {
+        "success": True,
+        "credits_consumed": 10.0,
+        "new_balance": 990.0,
+        "transaction_id": "t-1",
+        "base_cost": 10.0,
+      }
+    )
+
+    with (
+      patch("robosystems.middleware.billing.cache.credit_cache") as cache,
+      patch.object(GraphCredits, "get_by_graph_id", return_value=credits),
+      patch.object(
+        GraphUsage,
+        "record_credit_consumption",
+        side_effect=RuntimeError("usage table unavailable"),
+      ),
+    ):
+      cache.get_cached_graph_credit_balance.return_value = (
+        Decimal("1000.0"),
+        "ladybug-standard",
+      )
+      result = credit_service.consume_credits(
+        graph_id="graph123",
+        operation_type="agent_call",
+        base_cost=Decimal("10.0"),
+        user_id="usr_abc",
+      )
+
+    assert result["success"] is True
+    assert result["credits_consumed"] == 10.0

--- a/tests/routers/orgs/test_usage.py
+++ b/tests/routers/orgs/test_usage.py
@@ -187,6 +187,19 @@ class TestOrgUsageEndpoints:
         billing_day=now.day,
         billing_hour=now.hour,
       ),
+      # A genuine caller-initiated call, so `total_api_calls` has something to
+      # count that is neither the credit event nor the background snapshot.
+      GraphUsage(
+        user_id=test_user.id,
+        graph_id=graph.graph_id,
+        event_type=UsageEventType.QUERY_EXECUTION.value,
+        graph_tier=graph.graph_tier,
+        recorded_at=now,
+        billing_year=now.year,
+        billing_month=now.month,
+        billing_day=now.day,
+        billing_hour=now.hour,
+      ),
     ]
     test_db.add_all(usage_records)
     test_db.flush()
@@ -210,7 +223,10 @@ class TestOrgUsageEndpoints:
     summary = body["summary"]
     assert summary["total_credits_used"] == pytest.approx(10.0)
     assert summary["total_ai_operations"] == 1
-    assert summary["total_api_calls"] == 2
+    # One query execution — not three. This counted every row in the table,
+    # so the background storage snapshot and the credit event were both
+    # reported to org admins as customer API traffic.
+    assert summary["total_api_calls"] == 1
     assert summary["total_storage_gb"] == pytest.approx(7.5, rel=1e-2)
 
     assert len(body["graph_details"]) == 1


### PR DESCRIPTION
## Summary

`graph_usage` feeds the org and per-graph usage dashboards, but only `record_storage_usage` was ever wired to it. `GraphUsage.record_credit_consumption` existed, was covered by tests, and had **no production caller** — the one call by that name in `credit_service` is the OTel *metrics* method, not the model write.

**Verified against production**, which is what turned this from a suspicion into a confirmed defect:

| table | contents |
|---|---|
| `graph_usage` | 66 rows, **all** `storage_snapshot` |
| `graph_credit_transactions` | 27 AI operations, 622.09 credits consumed |

So `/v1/orgs/{org_id}/usage` reported **0 credits and 0 AI operations** for graphs that had genuinely spent both — and its `api_calls` figure was `len(usage_records)`, i.e. the 6-hourly storage snapshots counted as customer traffic. An untouched graph showed a steadily climbing API-call count.

## Changes

Consumption now writes a usage row alongside the credit transaction. Two deliberate choices:

- **Best-effort**, like the adjacent OTel metric. The credits are already committed by the time this runs, so a reporting row must never turn a successful spend into an error.
- **An unattributed spend is skipped, not forged.** `GraphUsage.user_id` is NOT NULL and the point of the row is per-user attribution, so a consumption with no `user_id` logs and is dropped rather than written against a placeholder.

`api_calls` now counts caller-initiated event types only, excluding background snapshots and the credit events that are already reported separately as credits/AI operations.

## Incidental fix

`graph_tier_val` was computed inside the OTel `try` block, leaving it unbound for any later reader whenever that block raised early. Hoisted. Caught by basedpyright, not by review — worth noting given `reportAttributeAccessIssue`/`reportCallIssue` are disabled in `pyproject.toml`; `reportPossiblyUnbound` is what remained enabled and it earned its keep here.

## Tests

The existing `test_get_org_usage_aggregates_graph_metrics` asserted `total_api_calls == 2` against a fixture holding one credit event and one storage snapshot — encoding the bug. Its fixture now includes a real `QUERY_EXECUTION` row so the three categories are distinguishable, and asserts 1.

New `TestCreditConsumptionWritesUsageLedger` covers the wiring, the failure path writing nothing, the unattributed skip, and that a failing usage write leaves consumption successful.

Verified by reverting both halves — two tests fail, one per half.

## Verification

`just test-all` — 11,920 passed, 24 skipped, ruff + format + basedpyright clean.

Detail in `local/RoboSystems/specs/multi-user-org-hardening.md`.