### PR TITLE
fix(views): key fact-grid dedup on the full period signature

### DIFF
--- a/robosystems/models/api/views/view_response.py
+++ b/robosystems/models/api/views/view_response.py
@@ -6,7 +6,24 @@ from robosystems.models.api.views.fact_grid import Dimension
 class FactRecord(BaseModel):
   element_id: str = Field(..., description="Element qname (e.g., 'us-gaap:Assets')")
   element_name: str | None = Field(None, description="Element local name")
+  period_start: str | None = Field(
+    None,
+    description=(
+      "Period start date (YYYY-MM-DD); null for instant facts. A duration "
+      "fact is identified by (start, end) — two facts for the same element "
+      "can share an end date and differ only here (e.g. a quarterly and a "
+      "year-to-date figure from the same 10-Q)."
+    ),
+  )
   period_end: str | None = Field(None, description="Period end date (YYYY-MM-DD)")
+  duration_type: str | None = Field(
+    None,
+    description=(
+      "Period duration classification (e.g. 'quarterly', 'nine_months', "
+      "'annual'); null for instant facts. Use with period_start to tell "
+      "overlapping windows apart."
+    ),
+  )
   value: float | None = Field(None, description="Numeric fact value")
   unit: str | None = Field(None, description="Unit of measure (e.g., 'USD')")
   entity_ticker: str | None = Field(

--- a/robosystems/operations/roboledger/views/fact_query.py
+++ b/robosystems/operations/roboledger/views/fact_query.py
@@ -122,19 +122,27 @@ def _build_entity_match(
 
 
 def _deduplicate_fact_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
-  """Dedup by ``(element, period, entity)`` keeping the first occurrence,
+  """Dedup on the full period signature, keeping the first occurrence,
   then sort by ``period_end`` DESC.
 
   DISTINCT + ORDER BY returns empty results in LadybugDB, so the query
-  omits both and we handle dedup + sort here. Entity is always part of the
-  key — without it two filers reporting the same element for the same
-  period collapse into one row.
+  omits both and we handle dedup + sort here.
+
+  The key is ``(element, period_start, period_end, entity)``. Both ends of
+  the period are load-bearing: an XBRL duration fact is identified by
+  *(start, end)*, not by end alone, so a 10-Q reports the same element for
+  the 3-month AND the 9-month window ending on the same day. Keying on
+  ``period_end`` alone collapsed those into one arbitrary row — the caller
+  asked for a quarter and silently got year-to-date. Entity is in the key
+  for the same reason: without it two filers reporting the same element for
+  the same period collapse into one row.
   """
   seen: set[tuple] = set()
   deduped: list[dict[str, Any]] = []
   for row in rows:
     key = (
       row.get("element_id", ""),
+      row.get("period_start", ""),
       row.get("period_end", ""),
       row.get("entity_ticker") or row.get("entity_name", ""),
     )
@@ -243,11 +251,18 @@ async def query_fact_grid(
   # us-gaap:Assets fact count is identical with and without the traversal,
   # and materialize.py builds the edge for native and shared facts alike),
   # so the join drops nothing and the caller can always tell filers apart.
+  #
+  # period_start and duration_type are projected because an XBRL duration
+  # fact is identified by (start, end): without start_date the dedup key
+  # cannot distinguish a quarterly fact from the year-to-date fact sharing
+  # its end_date, and the caller has no way to tell which one it received.
   return_clause = (
     "\n      RETURN\n"
     "        el.qname as element_id,\n"
     "        el.name as element_name,\n"
+    "        p.start_date as period_start,\n"
     "        p.end_date as period_end,\n"
+    "        p.duration_type as duration_type,\n"
     "        f.numeric_value as value,\n"
     "        u.value as unit,\n"
     "        ent.ticker as entity_ticker,\n"

--- a/tests/operations/roboledger/views/test_fact_query.py
+++ b/tests/operations/roboledger/views/test_fact_query.py
@@ -383,6 +383,20 @@ class TestQueryFactGrid:
     query = mock_repository.execute_query.call_args[0][0]
     assert "LIMIT" not in query.upper()
 
+  @pytest.mark.asyncio
+  @pytest.mark.unit
+  async def test_projects_the_full_period_signature(self, mock_repository):
+    """The dedup key needs both ends of the period, so the query must
+    project them. Without period_start the caller cannot distinguish a
+    quarterly fact from the YTD fact sharing its end_date — and neither
+    can the dedup."""
+    with patch(PATCH_REPO, return_value=mock_repository):
+      await query_fact_grid(MOCK_GRAPH_ID, elements=["us-gaap:Assets"])
+    query = mock_repository.execute_query.call_args[0][0]
+    assert "p.start_date as period_start" in query
+    assert "p.end_date as period_end" in query
+    assert "p.duration_type as duration_type" in query
+
 
 class TestDeduplicateFactRows:
   @pytest.mark.unit
@@ -414,6 +428,80 @@ class TestDeduplicateFactRows:
     ]
     deduped = _deduplicate_fact_rows(rows)
     assert len(deduped) == 2
+
+  @pytest.mark.unit
+  def test_overlapping_durations_sharing_an_end_date_are_not_collapsed(self):
+    """A 10-Q reports the same element for both the quarterly and the
+    year-to-date window ending on the same day. Keying on period_end alone
+    dropped one of them and returned the other with no way to tell which —
+    reproduced live on SEC: NVDA us-gaap:Revenues for 2024-10-27 returned
+    the nine-month 91,166,000,000 while the quarterly 35,082,000,000 was
+    silently discarded.
+    """
+    rows = [
+      {
+        "element_id": "us-gaap:Revenues",
+        "period_start": "2024-01-29",
+        "period_end": "2024-10-27",
+        "duration_type": "nine_months",
+        "entity_ticker": "NVDA",
+        "value": 91_166_000_000,
+      },
+      {
+        "element_id": "us-gaap:Revenues",
+        "period_start": "2024-07-29",
+        "period_end": "2024-10-27",
+        "duration_type": "quarterly",
+        "entity_ticker": "NVDA",
+        "value": 35_082_000_000,
+      },
+    ]
+    deduped = _deduplicate_fact_rows(rows)
+    assert len(deduped) == 2
+    assert {r["duration_type"] for r in deduped} == {"nine_months", "quarterly"}
+
+  @pytest.mark.unit
+  def test_true_duplicates_still_collapse(self):
+    """Identical period signature — the dedup this function exists for."""
+    rows = [
+      {
+        "element_id": "us-gaap:Revenues",
+        "period_start": "2024-07-29",
+        "period_end": "2024-10-27",
+        "duration_type": "quarterly",
+        "entity_ticker": "NVDA",
+        "value": 35_082_000_000,
+      },
+      {
+        "element_id": "us-gaap:Revenues",
+        "period_start": "2024-07-29",
+        "period_end": "2024-10-27",
+        "duration_type": "quarterly",
+        "entity_ticker": "NVDA",
+        "value": 35_082_000_000,
+      },
+    ]
+    assert len(_deduplicate_fact_rows(rows)) == 1
+
+  @pytest.mark.unit
+  def test_instants_without_a_start_date_still_collapse(self):
+    """Instant facts carry no start_date; the missing key element must not
+    turn two reads of the same instant into two rows."""
+    rows = [
+      {
+        "element_id": "us-gaap:Assets",
+        "period_end": "2024-10-27",
+        "entity_ticker": "NVDA",
+        "value": 1,
+      },
+      {
+        "element_id": "us-gaap:Assets",
+        "period_end": "2024-10-27",
+        "entity_ticker": "NVDA",
+        "value": 1,
+      },
+    ]
+    assert len(_deduplicate_fact_rows(rows)) == 1
 
   @pytest.mark.unit
   def test_sorted_desc_by_period_end(self):


### PR DESCRIPTION
## Problem

An XBRL duration fact is identified by `(start_date, end_date)`, but `_deduplicate_fact_rows` keyed on `end_date` alone. A 10-Q reports the same element for both the quarterly and the year-to-date window ending on the same day, so one was dropped and the other returned with no way to tell which — `truncated` stayed `false` and no warning was emitted.

Verified against the SEC repo: NVDA `us-gaap:Revenues` for `period_end` 2024-10-27 carries a `nine_months` fact of 91,166,000,000 and a `quarterly` fact of 35,082,000,000. `build-fact-grid` returned the nine-month figure to a caller asking for that quarter.

## Change

- Project `p.start_date` and `p.duration_type` in the Cypher RETURN.
- Add `period_start` and `duration_type` to `FactRecord`.
- Include `period_start` in the dedup key.

Instant facts carry no `start_date`, so that key element is simply absent for them and they still collapse.

This restores the contract `ViewResponse` already documents — that each fact is returned as its own record so the consumer can arrange cells on the full aspect signature.

## Tests

Four added: the NVDA regression, true-duplicates-still-collapse, instants-still-collapse, and one pinning the projection so a future edit to the RETURN clause cannot silently re-break the dedup. 93 pass across the views, extensions-router and MCP-tool suites.

Also verified live that `p.start_date` / `p.duration_type` project correctly against the prod SEC graph before relying on them.

Background: `local/RoboSystems/specs/v16-landing-review.md` (H3).