### PR TITLE
fix(views): honour the requested fiscal year in statement analysis

### DIFF
--- a/robosystems/adapters/sec/mcp/__init__.py
+++ b/robosystems/adapters/sec/mcp/__init__.py
@@ -19,12 +19,14 @@ from .element_resolver import resolve_sec_element
 from .report_resolver import (
   ANNUAL_FORMS,
   QUARTERLY_FORMS,
+  SECReportResolutionError,
   resolve_sec_report,
 )
 
 __all__ = [
   "ANNUAL_FORMS",
   "QUARTERLY_FORMS",
+  "SECReportResolutionError",
   "resolve_sec_element",
   "resolve_sec_report",
 ]

--- a/robosystems/adapters/sec/mcp/report_resolver.py
+++ b/robosystems/adapters/sec/mcp/report_resolver.py
@@ -20,6 +20,15 @@ ANNUAL_FORMS: tuple[str, ...] = ("10-K", "20-F", "40-F")
 QUARTERLY_FORMS: tuple[str, ...] = ("10-K", "20-F", "40-F", "10-Q")
 
 
+class SECReportResolutionError(RuntimeError):
+  """Raised when the report lookup itself fails.
+
+  Distinct from a ``None`` return, which means the query ran and matched
+  nothing. Callers treat ``None`` as "no such filing" and may fall back to
+  a broader search; they must not do that when the lookup never completed.
+  """
+
+
 async def resolve_sec_report(
   graph_id: str,
   *,
@@ -68,9 +77,15 @@ async def resolve_sec_report(
     # shared master (DynamoDB discovery + retry) and times out the MCP tool.
     repository = await get_graph_repository(graph_id, operation_type="read")
     rows = await repository.execute_query(query, parameters)
-    if rows:
-      return rows[0]
   except Exception as e:
+    # Do NOT collapse an infrastructure failure into "no match". Callers
+    # fall back to an unscoped ticker sweep when this returns None, so
+    # swallowing here turned a transient graph timeout into a confident
+    # wrong answer — the caller's fiscal_year silently became "whatever is
+    # newest". A failed lookup must be distinguishable from an empty one.
     logger.warning(f"SEC report auto-resolve failed for {ticker}: {e}")
+    raise SECReportResolutionError(
+      f"Could not resolve an SEC filing for {ticker}: the report lookup failed."
+    ) from e
 
-  return None
+  return rows[0] if rows else None

--- a/robosystems/middleware/mcp/tools/financial_statement_tools.py
+++ b/robosystems/middleware/mcp/tools/financial_statement_tools.py
@@ -275,6 +275,18 @@ class FinancialStatementAnalysisTool(BaseTool):
       )
       report_id = resolved.get("identifier") if resolved else None
 
+      # Mirror of the REST view op: a requested fiscal_year that resolves
+      # to nothing must be an error, not a silent fall-through to the
+      # unscoped ticker sweep below (which orders by end_date DESC and
+      # would answer with the newest filing instead).
+      if fiscal_year is not None and not report_id:
+        return {
+          "error": (
+            f"No {period_type or 'annual'} filing found for {ticker} "
+            f"in fiscal year {fiscal_year}."
+          ),
+        }
+
     rows: list[dict] = []
     if report_id or ticker:
       rows = await query_financial_statement(

--- a/robosystems/routers/extensions/roboledger/views.py
+++ b/robosystems/routers/extensions/roboledger/views.py
@@ -263,6 +263,21 @@ async def financial_statement_analysis_op(
       )
       report_id = resolved.get("identifier") if resolved else None
 
+      # A requested fiscal_year that resolves to nothing is a 404, not a
+      # licence to answer with a different year. Without this the ticker
+      # path below sweeps the filer's entire history ordered by end_date
+      # DESC — fiscal_year is never passed down — so a request scoped to
+      # FY2005 came back with the newest filing and no indication that the
+      # scope had been dropped.
+      if body.fiscal_year is not None and not report_id:
+        raise HTTPException(
+          status_code=404,
+          detail=(
+            f"No {body.period_type or 'annual'} filing found for "
+            f"{body.ticker} in fiscal year {body.fiscal_year}."
+          ),
+        )
+
     rows: list[dict] = []
     if report_id or body.ticker:
       rows = await query_financial_statement(

--- a/tests/adapters/sec/mcp/test_report_resolver.py
+++ b/tests/adapters/sec/mcp/test_report_resolver.py
@@ -3,7 +3,9 @@
 Verifies:
 - form-code selection by period_type
 - fiscal_year filter threading
-- graceful None on query error or no match
+- None on no match, and a raised SECReportResolutionError on lookup failure
+  (the two must stay distinguishable — callers fall back to an unscoped
+  sweep on None, which is only safe when the query actually ran)
 """
 
 from __future__ import annotations
@@ -15,6 +17,7 @@ import pytest
 from robosystems.adapters.sec.mcp.report_resolver import (
   ANNUAL_FORMS,
   QUARTERLY_FORMS,
+  SECReportResolutionError,
   resolve_sec_report,
 )
 
@@ -122,11 +125,29 @@ class TestResolveSecReport:
 
   @pytest.mark.asyncio
   @pytest.mark.unit
-  async def test_repository_error_returns_none(self):
-    """Transient errors shouldn't bubble; caller gets None and handles it."""
+  async def test_repository_error_raises_not_returns_none(self):
+    """A failed lookup must be distinguishable from an empty one.
+
+    This previously returned None on any exception. Callers treat None as
+    "no such filing" and fall back to an unscoped ticker sweep, so a
+    transient graph error silently became a confident answer about the
+    wrong fiscal year. The swallow was the defect; the old test asserted it.
+    """
     with patch(
       "robosystems.adapters.sec.mcp.report_resolver.get_graph_repository",
       side_effect=RuntimeError("repo down"),
     ):
-      result = await resolve_sec_report(MOCK_GRAPH, ticker="NVDA")
-    assert result is None
+      with pytest.raises(SECReportResolutionError):
+        await resolve_sec_report(MOCK_GRAPH, ticker="NVDA")
+
+  @pytest.mark.asyncio
+  @pytest.mark.unit
+  async def test_query_error_also_raises(self, mock_repository):
+    """The failure can come from execute_query, not just repo acquisition."""
+    mock_repository.execute_query.side_effect = RuntimeError("query timeout")
+    with patch(
+      "robosystems.adapters.sec.mcp.report_resolver.get_graph_repository",
+      return_value=mock_repository,
+    ):
+      with pytest.raises(SECReportResolutionError):
+        await resolve_sec_report(MOCK_GRAPH, ticker="NVDA")

--- a/tests/middleware/mcp/tools/test_financial_statement_tools.py
+++ b/tests/middleware/mcp/tools/test_financial_statement_tools.py
@@ -140,6 +140,39 @@ class TestFinancialStatementAnalysisToolDefinition:
 @pytest.mark.asyncio
 class TestFinancialStatementAnalysisToolExecute:
   @pytest.mark.unit
+  async def test_unresolvable_fiscal_year_errors_instead_of_answering(self):
+    """Mirror of the REST view op's 404. An MCP caller asking for a fiscal
+    year with no filing must get an error, not the newest filing — the
+    unscoped ticker sweep never receives fiscal_year, so falling through
+    silently answers about a different year."""
+    tool = FinancialStatementAnalysisTool(_make_client("sec"))
+
+    with (
+      patch(f"{MODULE}.is_shared_repository_or_subgraph", return_value=True),
+      patch(
+        "robosystems.adapters.sec.mcp.resolve_sec_report",
+        new_callable=AsyncMock,
+        return_value=None,
+      ),
+      patch(
+        f"{MODULE}.query_financial_statement",
+        new_callable=AsyncMock,
+        return_value=[],
+      ) as mock_query,
+    ):
+      result = await tool.execute(
+        {
+          "statement_type": "income_statement",
+          "ticker": "NVDA",
+          "fiscal_year": 2005,
+        }
+      )
+
+    assert "error" in result
+    assert "2005" in result["error"]
+    mock_query.assert_not_called()
+
+  @pytest.mark.unit
   async def test_shared_repo_ticker_autoresolves(self):
     tool = FinancialStatementAnalysisTool(_make_client("sec"))
     resolved = {

--- a/tests/routers/extensions/roboledger/test_views.py
+++ b/tests/routers/extensions/roboledger/test_views.py
@@ -384,6 +384,83 @@ class TestFinancialStatementAnalysisOp:
   """Wire-shape contract for financial-statement-analysis."""
 
   @pytest.mark.unit
+  async def test_unresolvable_fiscal_year_404s_instead_of_answering(self):
+    """A requested fiscal_year that matches no filing must 404.
+
+    Previously the handler fell through to the ticker path, which sweeps
+    the filer's entire history ordered by end_date DESC and never receives
+    fiscal_year — so a FY2005 request came back with FY2026 numbers,
+    report_id null, no error and no warning. Verified live against the SEC
+    repo before the fix.
+    """
+    body = FinancialStatementAnalysisRequest(
+      statement_type="income_statement",
+      ticker="NVDA",
+      fiscal_year=2005,
+      period_type="annual",
+    )
+
+    with (
+      patch(f"{MODULE}.is_shared_repository_or_subgraph", return_value=True),
+      patch(
+        "robosystems.adapters.sec.mcp.resolve_sec_report",
+        new_callable=AsyncMock,
+        return_value=None,
+      ),
+      patch(
+        f"{MODULE}.query_financial_statement",
+        new_callable=AsyncMock,
+        return_value=[],
+      ) as mock_query,
+    ):
+      with pytest.raises(HTTPException) as exc:
+        await financial_statement_analysis_op(
+          body=body,
+          graph_id="sec",
+          user=_make_user(),
+          idempotency_key=None,
+          cache=_FakeCache(),
+        )
+
+    assert exc.value.status_code == 404
+    assert "2005" in str(exc.value.detail)
+    # The unscoped sweep must not run at all — that is the defect.
+    mock_query.assert_not_called()
+
+  @pytest.mark.unit
+  async def test_no_fiscal_year_still_autoresolves_latest(self):
+    """Without a fiscal_year there is no scope to violate: the documented
+    'auto-resolve the latest filing' behaviour is preserved."""
+    body = FinancialStatementAnalysisRequest(
+      statement_type="income_statement",
+      ticker="NVDA",
+    )
+
+    with (
+      patch(f"{MODULE}.is_shared_repository_or_subgraph", return_value=True),
+      patch(
+        "robosystems.adapters.sec.mcp.resolve_sec_report",
+        new_callable=AsyncMock,
+        return_value=None,
+      ),
+      patch(
+        f"{MODULE}.query_financial_statement",
+        new_callable=AsyncMock,
+        return_value=[],
+      ) as mock_query,
+    ):
+      envelope = await financial_statement_analysis_op(
+        body=body,
+        graph_id="sec",
+        user=_make_user(),
+        idempotency_key=None,
+        cache=_FakeCache(),
+      )
+
+    assert envelope.status == "completed"
+    mock_query.assert_called_once()
+
+  @pytest.mark.unit
   async def test_shared_repo_ticker_autoresolves_report(self):
     """On SEC, missing report_id triggers resolve_sec_report; facts flow through."""
     body = FinancialStatementAnalysisRequest(


### PR DESCRIPTION
## Problem

`resolve_sec_report` returned `None` both when no filing matched and from a bare `except` that swallowed any error. Both callers then fell through to the ticker path, which anchors on the Entity and sweeps the filer's whole history ordered by `end_date DESC` — `fiscal_year` is never passed down. A request scoped to one year was answered with the newest filing, with `report_id: null`, no error and no warning.

Verified against the SEC repo: `statement_type=income_statement, ticker=NVDA, fiscal_year=2005` returned FY2026 facts.

## Change

- `resolve_sec_report` raises `SECReportResolutionError` when the lookup fails, and returns `None` only when the query ran and matched nothing. A transient graph timeout is now a 5xx rather than a confident wrong answer.
- The REST view op and its MCP twin both refuse to fall through when a `fiscal_year` was requested and resolution found nothing — 404 and an error result respectively. Without a `fiscal_year` the documented auto-resolve-latest behaviour is unchanged.

Confirmed `report_id` takes precedence over `ticker` in `query_financial_statement`, so a successfully resolved report does scope the query — otherwise this fix would have been cosmetic.

## Tests

The resolver's error test asserted the swallow as intended behaviour (*"Transient errors shouldn't bubble; caller gets None and handles it"* — the caller does not). Replaced with two tests covering both failure origins, plus caller-level tests on both surfaces for the 404/error path and for the unscoped path staying intact.

2,625 tests pass across `adapters/sec`, `middleware/mcp`, `routers/extensions` and `operations/roboledger`.

Background: `local/RoboSystems/specs/v16-landing-review.md` (H4).