### PR TITLE
fix(security): classify CALL forms explicitly in the query analyzer

### DIFF
--- a/robosystems/security/cypher_analyzer.py
+++ b/robosystems/security/cypher_analyzer.py
@@ -82,6 +82,28 @@ class CypherSecurityAnalyzer:
     "show_connection",
   }
 
+  # Procedures permitted on a read-only path. This is an ALLOWLIST and the
+  # classifier fails closed: a `CALL` to anything not named here is treated
+  # as a write, because the engine's procedure surface includes index DDL
+  # and session-configuration verbs that the keyword patterns below cannot
+  # see (those keywords are matched on `\b` word boundaries, and `_` is a
+  # word character, so an underscore-joined procedure name never matches).
+  #
+  # Keep this list minimal. A legitimate read procedure that is missing
+  # shows up as a refused query — safe, visible, and a one-line fix. The
+  # inverse mistake is silent.
+  READ_ONLY_PROCEDURES = {
+    "show_tables",
+    "table_info",
+    "db_version",
+    "current_setting",
+    "show_connection",
+    "show_warnings",
+    "show_indexes",
+    "query_vector_index",
+    "query_fts_index",
+  }
+
   # Read-only keywords that should never trigger write detection
   READ_KEYWORDS = {
     "MATCH",
@@ -123,8 +145,14 @@ class CypherSecurityAnalyzer:
       r"\b(" + "|".join(self.ADMIN_KEYWORDS) + r")\b", re.IGNORECASE
     )
 
-    # Pattern to find CALL procedures
-    self.call_pattern = re.compile(r"\bCALL\s+(\w+)\s*\(", re.IGNORECASE)
+    # Pattern to find CALL procedures. Dots are allowed so namespaced
+    # procedure names resolve as one identifier rather than matching on
+    # their prefix alone.
+    self.call_pattern = re.compile(r"\bCALL\s+([\w.]+)\s*\(", re.IGNORECASE)
+
+    # `CALL <setting> = <value>` is the session-configuration form. It takes
+    # no parentheses, so the procedure pattern above never sees it.
+    self.call_assignment_pattern = re.compile(r"\bCALL\s+([\w.]+)\s*=", re.IGNORECASE)
 
     # Comments, string literals, and backtick identifiers are masked by the
     # single-pass scanner in `_clean_query` (not by regex) so an in-string
@@ -396,7 +424,45 @@ class CypherSecurityAnalyzer:
       if self._validate_keyword_context(query, keyword, start_pos):
         found_operations.add(keyword)
 
+    # `CALL` is a verb the keyword patterns above cannot classify, so it is
+    # scanned separately. Folding the result in here (rather than into a
+    # separate public predicate) is deliberate: `is_write_operation` and
+    # `analyze_query` are the two gates every surface actually calls, and
+    # both read from this set.
+    found_operations |= self._find_call_operations(query)
+
     return found_operations
+
+  def _find_call_operations(self, query: str) -> set[str]:
+    """Find `CALL` forms that must not be treated as reads.
+
+    Two forms, neither reachable by the word-boundary keyword patterns:
+
+    - ``CALL <name>(...)`` — a procedure invocation. Fails closed: anything
+      outside ``READ_ONLY_PROCEDURES`` counts as a write, since the engine's
+      procedure surface includes index DDL whose names are underscore-joined
+      and therefore invisible to a ``\\b``-anchored keyword match.
+    - ``CALL <name> = <value>`` — session configuration. Always a write: it
+      mutates connection state that outlives the statement, and connections
+      are pooled and shared.
+
+    Args:
+        query: The cleaned query to analyze
+
+    Returns:
+        Set of normalized markers describing what was found
+    """
+    found: set[str] = set()
+
+    for match in self.call_assignment_pattern.finditer(query):
+      found.add(f"CALL_SET:{match.group(1).lower()}")
+
+    for match in self.call_pattern.finditer(query):
+      name = match.group(1).lower()
+      if name not in self.READ_ONLY_PROCEDURES:
+        found.add(f"CALL:{name}")
+
+    return found
 
   def _find_read_operations(self, query: str) -> set[str]:
     """

--- a/tests/security/test_cypher_analyzer.py
+++ b/tests/security/test_cypher_analyzer.py
@@ -162,6 +162,70 @@ class TestHasSystemCalls:
     assert has_system_calls("CALL show_tables() RETURN *")
 
 
+class TestCallClassification:
+  """`CALL` is classified explicitly, on an allowlist, failing closed.
+
+  The keyword patterns match on `\\b` word boundaries and `_` is a word
+  character, so an underscore-joined procedure name can never match them.
+  `CALL` itself appears in no keyword set. Both gaps meant the whole `CALL`
+  family classified as READ, on the surface that treats "not a write" as
+  "safe to run on a read replica".
+  """
+
+  @pytest.mark.parametrize(
+    "query",
+    [
+      "CALL CREATE_VECTOR_INDEX('Fact','x','embedding')",
+      "CALL DROP_VECTOR_INDEX('Fact','x')",
+      "CALL CREATE_FTS_INDEX('Fact','idx','text')",
+      "call create_vector_index(1)",
+      "CALL db.labels()",
+      "CALL some_future_procedure()",
+    ],
+  )
+  def test_unlisted_procedures_are_writes(self, analyzer, query):
+    """Fail closed: anything not on the read-only allowlist is a write,
+    including procedures that do not exist yet."""
+    assert analyzer.is_write_operation(query) is True
+
+  @pytest.mark.parametrize(
+    "query",
+    [
+      "CALL spill_to_disk=false",
+      "CALL timeout=0",
+      "CALL   TIMEOUT   =   0",
+    ],
+  )
+  def test_session_configuration_is_a_write(self, analyzer, query):
+    """`CALL <name> = <value>` mutates connection state that outlives the
+    statement, and connections are pooled and shared."""
+    assert analyzer.is_write_operation(query) is True
+
+  def test_trailing_configuration_after_a_read(self, analyzer):
+    """A read prefix must not launder a trailing configuration verb."""
+    assert analyzer.is_write_operation("MATCH (n) RETURN n; CALL timeout=0") is True
+
+  @pytest.mark.parametrize(
+    "query",
+    [
+      "CALL SHOW_TABLES() RETURN *",
+      "CALL TABLE_INFO('Fact') RETURN *",
+      "CALL db_version() RETURN *",
+      "CALL current_setting('threads') RETURN *",
+    ],
+  )
+  def test_allowlisted_read_procedures_stay_reads(self, analyzer, query):
+    """These are used by first-party schema introspection — regressing them
+    would break the schema endpoints and the MCP client."""
+    assert analyzer.is_write_operation(query) is False
+
+  def test_configuration_inside_a_string_literal_is_not_a_write(self, analyzer):
+    """String contents are masked before classification, so a literal that
+    merely looks like a config verb must not trip the gate."""
+    query = "MATCH (n:Fact) WHERE n.name = 'CALL timeout=0' RETURN n"
+    assert analyzer.is_write_operation(query) is False
+
+
 class TestQuerySecurityValidation:
   """Tests for query security validation."""
 


### PR DESCRIPTION
## Summary

Input-classification hardening on the query surface.

The analyzer's keyword patterns are anchored on word boundaries and the `CALL` verb appears in no keyword set, so `CALL` statements were left unclassified and fell through as reads.

## Change

- Adds an explicit read-only procedure allowlist; anything outside it classifies as a write, **failing closed** — including procedure names that do not exist yet.
- Session-configuration `CALL` forms are always writes, since they mutate connection state that outlives the statement.
- Both the platform gate and the `graph_api` validator route through the same `is_write_operation` entry point, so one change covers both surfaces.

First-party schema introspection (`SHOW_TABLES`, `TABLE_INFO`) stays on the read path and is pinned by tests. A legitimate read procedure missing from the allowlist surfaces as a refused query rather than a silent misclassification — the safe direction to be wrong in.

## Tests

Added coverage for the allowlist behaviour, the configuration form, a read-prefixed statement, string-literal false positives, and the first-party introspection calls. 82 pass in the analyzer suite; 2,385 across `security`, `middleware/mcp`, `routers/graphs/query` and `graph_api`.

## Deployment note

Please sequence this to prod **before or with** the marketplace push rather than after — it is on the surface that push directs traffic at.

Background and reachability analysis: `local/RoboSystems/specs/v16-landing-review.md` (H14). Detail stays in the private vault per the repo's disclosure policy.