### PR TITLE
fix(billing): honour webhook retry semantics and the monthly refill calendar

### DIFF
--- a/robosystems/admin/commands/billing.py
+++ b/robosystems/admin/commands/billing.py
@@ -463,6 +463,33 @@ def add_bonus_credits(client, graph_id, amount, description):
   click.echo(f"   Description: {description}")
 
 
+@credits.command("reset")
+@click.argument("graph_id")
+@click.option("--reason", default=None, help="Reason recorded on the ledger rows")
+@click.confirmation_option(
+  prompt="Forfeit the remaining balance and refill to the monthly allocation?"
+)
+@click.pass_obj
+def reset_credit_pool(client, graph_id, reason):
+  """Reset a graph's credit pool to its monthly allocation.
+
+  The remaining balance is forfeited (recorded as an EXPIRATION ledger
+  row) and the pool refills to the monthly allocation. The scheduled
+  monthly reset still runs normally when the month turns.
+  """
+  data = {"reason": reason} if reason else {}
+
+  pool = client._make_request(
+    "POST", f"/admin/v1/credits/graphs/{graph_id}/reset", data=data
+  )
+
+  click.echo(f"✅ Reset credit pool for graph {graph_id}")
+  click.echo(f"   New balance: {pool['current_balance']:,.2f}")
+  click.echo(f"   Monthly allocation: {pool['monthly_allocation']:,.2f}")
+  if reason:
+    click.echo(f"   Reason: {reason}")
+
+
 @credits.command("analytics")
 @click.option("--tier", help="Filter by tier")
 @click.pass_obj

--- a/robosystems/models/api/admin/__init__.py
+++ b/robosystems/models/api/admin/__init__.py
@@ -15,6 +15,7 @@ from .credits import (
   CreditHealthResponse,
   CreditPoolResponse,
   RepositoryCreditPoolResponse,
+  ResetCreditPoolRequest,
 )
 from .graphs import (
   GraphAnalyticsResponse,
@@ -66,6 +67,7 @@ __all__ = [
   "OrgUpdateRequest",
   "OrgUserInfo",
   "RepositoryCreditPoolResponse",
+  "ResetCreditPoolRequest",
   "SubscriptionCreateRequest",
   "SubscriptionResponse",
   "SubscriptionUpdateRequest",

--- a/robosystems/models/api/admin/credits.py
+++ b/robosystems/models/api/admin/credits.py
@@ -30,6 +30,14 @@ class BonusCreditsRequest(BaseModel):
   )
 
 
+class ResetCreditPoolRequest(BaseModel):
+  """Request to reset a graph credit pool to its monthly allocation."""
+
+  reason: str | None = Field(
+    default=None, description="Reason recorded on the ledger rows"
+  )
+
+
 class CreditAnalyticsResponse(BaseModel):
   """Response with system-wide credit analytics."""
 

--- a/robosystems/models/core/graph/graph_credits.py
+++ b/robosystems/models/core/graph/graph_credits.py
@@ -323,10 +323,13 @@ class GraphCredits(Base):
     """
     now = datetime.now(UTC)
 
-    # Check if allocation is due (monthly)
+    # One allocation per calendar month, matching both the monthly cron that
+    # drives bulk allocation and the transaction idempotency key below. A
+    # day-count gate here refuses the 1-Mar run for anything allocated on
+    # 1-Feb (28 days elapsed), silently skipping March fleet-wide.
     if self.last_allocation_date is not None:
-      days_since_last = (now - self.last_allocation_date).days
-      if days_since_last < 30:  # Not due yet
+      last = self.last_allocation_date
+      if (last.year, last.month) == (now.year, now.month):
         return False
 
     self.current_balance = self.monthly_allocation

--- a/robosystems/models/core/graph/graph_credits.py
+++ b/robosystems/models/core/graph/graph_credits.py
@@ -308,6 +308,37 @@ class GraphCredits(Base):
         "error": f"Credit consumption failed: {e!s}",
       }
 
+  def _expire_unspent(
+    self,
+    session: Session,
+    *,
+    description: str,
+    metadata: dict[str, Any],
+    idempotency_key: str | None,
+  ) -> Decimal:
+    """Record the forfeiture of the current balance before a reset.
+
+    A reset discards whatever is left in the pool; without this row the
+    ledger stops footing against the balance (`SUM(transactions)` drifts by
+    every discarded remainder, permanently). Returns the forfeited amount.
+    """
+    remainder = Decimal(str(self.current_balance or 0))
+    if remainder <= 0:
+      return Decimal("0")
+
+    GraphCreditTransaction.create_transaction(
+      graph_credits_id=self.id,
+      transaction_type=CreditTransactionType.EXPIRATION,
+      amount=-remainder,
+      description=description,
+      metadata=metadata,
+      session=session,
+      idempotency_key=idempotency_key,
+      graph_id=self.graph_id,
+      user_id=self.user_id,
+    )
+    return remainder
+
   def allocate_monthly_credits(self, session: Session) -> bool:
     """Allocate monthly credits if due. Credits do not roll over.
 
@@ -320,6 +351,10 @@ class GraphCredits(Base):
     here also made `current_balance` drift permanently away from the
     `monthly_allocation - consumed_this_month` figure the read paths reported,
     so the same pool answered differently depending on which one you asked.
+
+    The discarded remainder — unspent allocation and unspent bonus credits
+    alike — is recorded as an EXPIRATION transaction so the ledger keeps
+    footing against the balance through every reset.
     """
     now = datetime.now(UTC)
 
@@ -332,13 +367,21 @@ class GraphCredits(Base):
       if (last.year, last.month) == (now.year, now.month):
         return False
 
+    allocation_month = now.strftime("%Y-%m")
+
+    self._expire_unspent(
+      session,
+      description="Unspent credits forfeited at monthly reset (no rollover)",
+      metadata={
+        "allocation_month": allocation_month,
+        "expiration_type": "monthly_reset",
+      },
+      idempotency_key=f"monthly_expiration_{self.graph_id}_{allocation_month}",
+    )
+
     self.current_balance = self.monthly_allocation
     self.last_allocation_date = now
     self.updated_at = now
-
-    # Record transaction with idempotency based on month
-    allocation_month = now.strftime("%Y-%m")
-    idempotency_key = f"monthly_allocation_{self.graph_id}_{allocation_month}"
 
     GraphCreditTransaction.create_transaction(
       graph_credits_id=self.id,
@@ -350,12 +393,51 @@ class GraphCredits(Base):
         "allocation_type": "monthly",
       },
       session=session,
-      idempotency_key=idempotency_key,
+      idempotency_key=f"monthly_allocation_{self.graph_id}_{allocation_month}",
       graph_id=self.graph_id,
       user_id=self.user_id,
     )
 
     return True
+
+  def reset_pool(
+    self,
+    session: Session,
+    *,
+    initiated_by: str,
+    reason: str | None = None,
+  ) -> Decimal:
+    """Admin-initiated mid-month reset: forfeit the remainder, refill to the
+    monthly allocation, both recorded in the ledger.
+
+    Does not touch `last_allocation_date` — this is not a scheduled monthly
+    allocation, and the calendar-month refill gate must still fire normally
+    when the month turns. Returns the forfeited amount.
+    """
+    description = reason or "Credit pool reset by administrator"
+    forfeited = self._expire_unspent(
+      session,
+      description=description,
+      metadata={"expiration_type": "manual_reset", "initiated_by": initiated_by},
+      idempotency_key=None,
+    )
+
+    self.current_balance = self.monthly_allocation
+    self.updated_at = datetime.now(UTC)
+
+    GraphCreditTransaction.create_transaction(
+      graph_credits_id=self.id,
+      transaction_type=CreditTransactionType.ALLOCATION,
+      amount=self.monthly_allocation,
+      description=description,
+      metadata={"allocation_type": "manual_reset", "initiated_by": initiated_by},
+      session=session,
+      idempotency_key=None,
+      graph_id=self.graph_id,
+      user_id=self.user_id,
+    )
+
+    return forfeited
 
   def get_usage_summary(self, session: Session) -> dict[str, Any]:
     """Get usage summary for this graph."""

--- a/robosystems/operations/graph/credit_service.py
+++ b/robosystems/operations/graph/credit_service.py
@@ -503,6 +503,43 @@ class CreditService:
       "description": description,
     }
 
+  def reset_graph_pool(
+    self,
+    graph_id: str,
+    initiated_by: str,
+    reason: str | None = None,
+  ) -> dict[str, Any]:
+    """Reset a graph's pool to its monthly allocation, forfeiting the rest.
+
+    Both movements land in the ledger (EXPIRATION for the remainder, then a
+    manual ALLOCATION), and the scheduled monthly reset still fires normally
+    when the month turns — `last_allocation_date` is left alone.
+    """
+    parent_graph_id = self._get_parent_graph_id(graph_id)
+
+    credits = GraphCredits.get_by_graph_id(parent_graph_id, self.session)
+    if not credits:
+      return {"error": "No credit pool found for graph"}
+
+    forfeited = credits.reset_pool(
+      self.session, initiated_by=initiated_by, reason=reason
+    )
+
+    self.session.commit()
+
+    try:
+      from ...middleware.billing.cache import credit_cache
+
+      credit_cache.invalidate_graph_credit_balance(parent_graph_id)
+    except Exception as e:
+      logger.warning(f"Failed to invalidate credit cache after pool reset: {e}")
+
+    return {
+      "success": True,
+      "credits_forfeited": float(forfeited),
+      "new_balance": float(credits.current_balance),
+    }
+
   def get_credit_transactions(
     self,
     graph_id: str,

--- a/robosystems/operations/providers/payment_provider.py
+++ b/robosystems/operations/providers/payment_provider.py
@@ -208,6 +208,10 @@ class StripePaymentProvider(PaymentProvider):
       success_url=f"{env.ROBOSYSTEMS_URL}/checkout/{{CHECKOUT_SESSION_ID}}",
       cancel_url=f"{env.ROBOSYSTEMS_URL}/organization?tab=billing",
       metadata=metadata,
+      # Stripe does not copy session metadata onto the subscription it
+      # creates; stamp it there too so webhook resolution can match the
+      # subscription by our own identifiers.
+      subscription_data={"metadata": metadata},
       payment_method_types=["card"],
       billing_address_collection="auto",
       allow_promotion_codes=True,

--- a/robosystems/routers/admin/credits.py
+++ b/robosystems/routers/admin/credits.py
@@ -15,6 +15,7 @@ from ...models.api.admin import (
   CreditHealthResponse,
   CreditPoolResponse,
   RepositoryCreditPoolResponse,
+  ResetCreditPoolRequest,
 )
 from ...models.core import Graph, User
 from ...models.core.graph.graph_credits import (
@@ -186,6 +187,70 @@ async def add_bonus_credits_to_graph(
         "graph_id": graph_id,
         "amount": data.amount,
         "description": data.description,
+      },
+    )
+
+    return CreditPoolResponse(
+      graph_id=pool.graph_id,
+      user_id=pool.user_id,
+      graph_tier=pool.graph_tier,
+      current_balance=float(pool.current_balance),
+      monthly_allocation=float(pool.monthly_allocation),
+      credit_multiplier=1.0,
+      storage_limit_override_gb=float(pool.storage_override_gb)
+      if pool.storage_override_gb
+      else None,
+      created_at=pool.created_at,
+      updated_at=pool.updated_at,
+    )
+  finally:
+    session.close()
+
+
+@router.post("/graphs/{graph_id}/reset", response_model=CreditPoolResponse)
+@require_admin(permissions=["credits:write"])
+async def reset_graph_credit_pool(
+  request: Request, graph_id: str, data: ResetCreditPoolRequest | None = None
+):
+  """Reset a graph credit pool to its monthly allocation.
+
+  Forfeits the remaining balance (recorded as an EXPIRATION transaction)
+  and refills to the monthly allocation. The scheduled monthly reset still
+  fires normally when the month turns.
+  """
+  session = next(get_db_session())
+  try:
+    pool = GraphCredits.get_by_graph_id(graph_id, session)
+
+    if not pool:
+      raise HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND,
+        detail=f"Credit pool not found for graph {graph_id}",
+      )
+
+    credit_service = CreditService(session)
+    result = credit_service.reset_graph_pool(
+      graph_id=graph_id,
+      initiated_by=f"admin:{request.state.admin_key_id}",
+      reason=data.reason if data else None,
+    )
+
+    if "error" in result:
+      raise HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND,
+        detail=result["error"],
+      )
+
+    session.refresh(pool)
+
+    logger.info(
+      f"Admin reset credit pool for graph {graph_id} "
+      f"(forfeited {result['credits_forfeited']})",
+      extra={
+        "admin_key_id": request.state.admin_key_id,
+        "graph_id": graph_id,
+        "credits_forfeited": result["credits_forfeited"],
+        "new_balance": result["new_balance"],
       },
     )
 

--- a/robosystems/routers/admin/webhooks.py
+++ b/robosystems/routers/admin/webhooks.py
@@ -1,6 +1,6 @@
 """Admin webhook handlers for payment providers."""
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlalchemy.orm import Session
 
 from ...database import SessionFactory, get_db_session
@@ -32,8 +32,16 @@ async def _process_webhook_event(
 ) -> None:
   """Process a Stripe webhook event directly (no Dagster).
 
-  Creates its own database session since this runs as a background task
-  after the request session has been closed.
+  Runs inside the request so the HTTP status reflects the processing
+  outcome — Stripe only redelivers on a non-2xx response, so raising here
+  is what makes retry semantics real. Uses its own database session to keep
+  handler transaction boundaries independent of the request session.
+
+  Raises:
+      SubscriptionNotFoundError: the event references a subscription we have
+          no record of yet (e.g. invoice events racing checkout completion).
+          The event is left unmarked so the redelivery can succeed.
+      Exception: any handler failure; the event is left unmarked.
   """
   from robosystems.dagster.jobs.billing import (
     SubscriptionNotFoundError,
@@ -105,19 +113,20 @@ async def _process_webhook_event(
     )
 
   except SubscriptionNotFoundError as e:
-    # Subscription not found — do NOT mark as processed so Stripe retries.
-    # This handles timing issues where checkout.session.completed hasn't
-    # fired yet but invoice webhooks have already arrived.
+    # Not marked as processed; the raise turns into a non-2xx response so
+    # Stripe redelivers (covers invoice events racing checkout completion).
     logger.warning(
-      f"Webhook {event_type} deferred (will retry): {e}",
+      f"Webhook {event_type} deferred for Stripe redelivery: {e}",
       extra={"event_id": event_id, "event_type": event_type},
     )
+    raise
   except Exception as e:
     logger.error(
       f"Failed to process webhook {event_type}: {e}",
       exc_info=True,
       extra={"event_id": event_id, "event_type": event_type},
     )
+    raise
   finally:
     db.close()
 
@@ -144,16 +153,17 @@ This endpoint receives and processes webhook events from Stripe including:
 Stripe webhooks cannot provide admin API keys. Instead, security is enforced
 through Stripe's webhook signature verification (verify_webhook).
 
-**Processing**: Webhooks are processed directly as background tasks for low
-latency. Heavy operations (graph provisioning) are handled by the direct
-provisioning system which manages its own async execution.
+**Processing**: Webhooks are processed before the response is sent so the
+HTTP status reflects the outcome — Stripe redelivers on any non-2xx, which is
+the retry mechanism for events that arrive before their subscription exists.
+Heavy operations (graph provisioning) are handled by the direct provisioning
+system which manages its own async execution.
 
 Webhooks are verified using Stripe signature before processing.""",
   operation_id="handleStripeWebhook",
 )
 async def handle_stripe_webhook(
   request: Request,
-  background_tasks: BackgroundTasks,
   db: Session = Depends(get_db_session),
 ):
   """Handle Stripe webhook events."""
@@ -219,15 +229,22 @@ async def handle_stripe_webhook(
       extra={"event_type": event_type, "event_id": event_id},
     )
 
-    # Process directly as a background task with its own DB session
-    background_tasks.add_task(
-      _process_webhook_event,
-      event_id=event_id,
-      event_type=event_type,
-      event_data=event_data,
-    )
+    from robosystems.dagster.jobs.billing import SubscriptionNotFoundError
 
-    return {"status": "success", "message": "Webhook accepted for processing"}
+    try:
+      await _process_webhook_event(
+        event_id=event_id,
+        event_type=event_type,
+        event_data=event_data,
+      )
+    except SubscriptionNotFoundError:
+      # Non-2xx so Stripe redelivers; the event was not marked as processed.
+      raise HTTPException(
+        status_code=409,
+        detail="Event references a subscription not yet recorded; retry",
+      )
+
+    return {"status": "success", "message": "Webhook processed"}
 
   except HTTPException:
     raise

--- a/tests/models/core/graph/test_graph_credits.py
+++ b/tests/models/core/graph/test_graph_credits.py
@@ -355,6 +355,122 @@ class TestGraphCredits:
     assert result is False
     assert credits.current_balance == Decimal("100")
 
+  def test_reset_forfeiture_keeps_the_ledger_footing(self):
+    """SUM(transactions) == current_balance through creation, consumption,
+    and the monthly reset. The discarded remainder gets an EXPIRATION row
+    instead of silently vanishing — without it every reset drifts the
+    ledger away from the balance permanently."""
+    from sqlalchemy import func
+
+    credits = GraphCredits.create_for_graph(
+      graph_id=self.graph.graph_id,
+      user_id=self.user.id,
+      billing_admin_id=self.billing_admin.id,
+      monthly_allocation=Decimal("1000"),
+      session=self.session,
+    )
+    consumption = credits.consume_credits_atomic(
+      amount=Decimal("300"),
+      operation_type="agent_call",
+      operation_description="AI call",
+      session=self.session,
+    )
+    assert consumption["success"] is True
+
+    credits.last_allocation_date = datetime.now(UTC) - timedelta(days=35)
+    self.session.commit()
+
+    assert credits.allocate_monthly_credits(self.session) is True
+    self.session.commit()
+
+    expiration = (
+      self.session.query(GraphCreditTransaction)
+      .filter_by(
+        graph_credits_id=credits.id,
+        transaction_type=CreditTransactionType.EXPIRATION.value,
+      )
+      .one()
+    )
+    assert expiration.amount == Decimal("-700")
+
+    ledger_total = (
+      self.session.query(func.sum(GraphCreditTransaction.amount))
+      .filter(GraphCreditTransaction.graph_credits_id == credits.id)
+      .scalar()
+    )
+    assert ledger_total == credits.current_balance == Decimal("1000")
+
+  def test_zero_remainder_reset_writes_no_expiration_row(self):
+    """A fully-spent pool has nothing to forfeit — no EXPIRATION noise."""
+    credits = GraphCredits(
+      graph_id=self.graph.graph_id,
+      user_id=self.user.id,
+      billing_admin_id=self.billing_admin.id,
+      current_balance=Decimal("0"),
+      monthly_allocation=Decimal("1000"),
+      last_allocation_date=datetime.now(UTC) - timedelta(days=35),
+    )
+    self.session.add(credits)
+    self.session.commit()
+
+    assert credits.allocate_monthly_credits(self.session) is True
+
+    expirations = (
+      self.session.query(GraphCreditTransaction)
+      .filter_by(
+        graph_credits_id=credits.id,
+        transaction_type=CreditTransactionType.EXPIRATION.value,
+      )
+      .count()
+    )
+    assert expirations == 0
+    assert credits.current_balance == Decimal("1000")
+
+  def test_manual_reset_forfeits_refills_and_leaves_the_monthly_gate_alone(self):
+    """An admin mid-month reset forfeits the remainder and refills, with
+    both movements in the ledger — and because it does not touch
+    last_allocation_date, the scheduled reset still fires when the month
+    turns."""
+    from unittest.mock import patch
+
+    june_first = datetime(2027, 6, 1, tzinfo=UTC)
+    credits = GraphCredits(
+      graph_id=self.graph.graph_id,
+      user_id=self.user.id,
+      billing_admin_id=self.billing_admin.id,
+      current_balance=Decimal("400"),
+      monthly_allocation=Decimal("1000"),
+      last_allocation_date=june_first,
+    )
+    self.session.add(credits)
+    self.session.commit()
+
+    forfeited = credits.reset_pool(self.session, initiated_by="admin:test")
+    self.session.commit()
+
+    assert forfeited == Decimal("400")
+    assert credits.current_balance == Decimal("1000")
+    assert credits.last_allocation_date == june_first
+
+    expiration = (
+      self.session.query(GraphCreditTransaction)
+      .filter_by(
+        graph_credits_id=credits.id,
+        transaction_type=CreditTransactionType.EXPIRATION.value,
+      )
+      .one()
+    )
+    assert expiration.amount == Decimal("-400")
+    assert expiration.transaction_metadata is not None
+
+    with patch(
+      "robosystems.models.core.graph.graph_credits.datetime", wraps=datetime
+    ) as mock_dt:
+      mock_dt.now.return_value = datetime(2027, 7, 1, tzinfo=UTC)
+      assert credits.allocate_monthly_credits(self.session) is True
+
+    assert credits.current_balance == Decimal("1000")
+
   def test_allocation_never_accumulates_past_the_monthly_amount(self):
     """A large prior balance is replaced, not added to.
 

--- a/tests/models/core/graph/test_graph_credits.py
+++ b/tests/models/core/graph/test_graph_credits.py
@@ -281,9 +281,9 @@ class TestGraphCredits:
     assert transaction.amount == Decimal("1000")
 
   def test_allocate_monthly_credits_not_due(self):
-    """Test monthly allocation when not due yet."""
+    """An allocation earlier in the same calendar month is not repeated."""
     now = datetime.now(UTC)
-    recent = now - timedelta(days=15)
+    start_of_month = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
 
     credits = GraphCredits(
       graph_id=self.graph.graph_id,
@@ -291,15 +291,69 @@ class TestGraphCredits:
       billing_admin_id=self.billing_admin.id,
       current_balance=Decimal("500"),
       monthly_allocation=Decimal("1000"),
-      last_allocation_date=recent,
+      last_allocation_date=start_of_month,
     )
     self.session.add(credits)
     self.session.commit()
 
-    # Should not allocate since less than 30 days
     result = credits.allocate_monthly_credits(self.session)
     assert result is False
     assert credits.current_balance == Decimal("500")
+
+  def test_march_allocation_after_february_first_is_not_skipped(self):
+    """February is 28 days, so a day-count gate refuses the 1-Mar run for a
+    1-Feb allocation and every graph on the fleet misses March. The gate is
+    calendar-month equality, matching the cron and the idempotency key."""
+    from unittest.mock import patch
+
+    credits = GraphCredits(
+      graph_id=self.graph.graph_id,
+      user_id=self.user.id,
+      billing_admin_id=self.billing_admin.id,
+      current_balance=Decimal("100"),
+      monthly_allocation=Decimal("1000"),
+      last_allocation_date=datetime(2027, 2, 1, tzinfo=UTC),
+    )
+    self.session.add(credits)
+    self.session.commit()
+
+    march_first = datetime(2027, 3, 1, tzinfo=UTC)
+    with patch(
+      "robosystems.models.core.graph.graph_credits.datetime", wraps=datetime
+    ) as mock_dt:
+      mock_dt.now.return_value = march_first
+      result = credits.allocate_monthly_credits(self.session)
+
+    assert result is True
+    assert credits.current_balance == Decimal("1000")
+    assert credits.last_allocation_date == march_first
+
+  def test_second_run_in_the_same_calendar_month_is_refused_even_after_30_days(self):
+    """1-Jan → 31-Jan is 30 elapsed days, which the old day-count gate let
+    through: the idempotency key suppressed the duplicate ledger row but the
+    reset still silently restored a month of consumed credits. Same-month is
+    refused outright now, so the balance never moves."""
+    from unittest.mock import patch
+
+    credits = GraphCredits(
+      graph_id=self.graph.graph_id,
+      user_id=self.user.id,
+      billing_admin_id=self.billing_admin.id,
+      current_balance=Decimal("100"),
+      monthly_allocation=Decimal("1000"),
+      last_allocation_date=datetime(2027, 1, 1, tzinfo=UTC),
+    )
+    self.session.add(credits)
+    self.session.commit()
+
+    with patch(
+      "robosystems.models.core.graph.graph_credits.datetime", wraps=datetime
+    ) as mock_dt:
+      mock_dt.now.return_value = datetime(2027, 1, 31, tzinfo=UTC)
+      result = credits.allocate_monthly_credits(self.session)
+
+    assert result is False
+    assert credits.current_balance == Decimal("100")
 
   def test_allocation_never_accumulates_past_the_monthly_amount(self):
     """A large prior balance is replaced, not added to.

--- a/tests/operations/graph/test_credit_service.py
+++ b/tests/operations/graph/test_credit_service.py
@@ -481,6 +481,58 @@ class TestCreditService:
     mock_session.commit.assert_called_once()
 
 
+class TestResetGraphPool:
+  """reset_graph_pool wires the model reset to commit + cache invalidation.
+
+  The ledger/balance mechanics are covered against a real database in
+  tests/models/core/graph/test_graph_credits.py; this pins the service
+  half the model test cannot see — the commit and the cache eviction.
+  """
+
+  def test_reset_delegates_commits_and_invalidates_cache(self):
+    session = MagicMock()
+    with patch("robosystems.middleware.billing.cache.credit_cache") as mock_cache:
+      service = CreditService(session)
+      credits = MagicMock()
+      credits.reset_pool.return_value = Decimal("400")
+      credits.current_balance = Decimal("1000")
+      with patch(
+        "robosystems.operations.graph.credit_service.GraphCredits"
+      ) as MockCredits:
+        MockCredits.get_by_graph_id.return_value = credits
+        result = service.reset_graph_pool(
+          "kg0123456789abcdef", initiated_by="admin:key", reason="mid-month refresh"
+        )
+
+    credits.reset_pool.assert_called_once_with(
+      session, initiated_by="admin:key", reason="mid-month refresh"
+    )
+    session.commit.assert_called_once()
+    mock_cache.invalidate_graph_credit_balance.assert_called_once_with(
+      "kg0123456789abcdef"
+    )
+    assert result == {
+      "success": True,
+      "credits_forfeited": 400.0,
+      "new_balance": 1000.0,
+    }
+
+  def test_missing_pool_returns_error(self):
+    session = MagicMock()
+    with patch("robosystems.middleware.billing.cache.credit_cache"):
+      service = CreditService(session)
+      with patch(
+        "robosystems.operations.graph.credit_service.GraphCredits"
+      ) as MockCredits:
+        MockCredits.get_by_graph_id.return_value = None
+        result = service.reset_graph_pool(
+          "kg0123456789abcdef", initiated_by="admin:key"
+        )
+
+    assert result == {"error": "No credit pool found for graph"}
+    session.commit.assert_not_called()
+
+
 class TestCreditCaching:
   """Test cases for credit caching functionality."""
 

--- a/tests/operations/providers/test_payment_provider.py
+++ b/tests/operations/providers/test_payment_provider.py
@@ -125,6 +125,24 @@ class TestStripeCheckoutSessions:
     call_args = stripe_provider.stripe.checkout.Session.create.call_args
     assert call_args[1]["metadata"] == metadata
 
+  def test_checkout_session_stamps_metadata_on_the_subscription(self, stripe_provider):
+    """Stripe does not copy session metadata onto the subscription it
+    creates, and webhook resolution reads the subscription's metadata — so
+    the session must stamp it there explicitly via subscription_data."""
+    mock_session = Mock()
+    mock_session.id = "cs_test_789"
+    mock_session.url = "https://checkout.stripe.com/test"
+    stripe_provider.stripe.checkout.Session.create.return_value = mock_session
+
+    metadata = {
+      "user_id": "user_123",
+      "subscription_id": "sub_local_abc",
+    }
+    stripe_provider.create_checkout_session("cus_123", "price_456", metadata)
+
+    call_args = stripe_provider.stripe.checkout.Session.create.call_args
+    assert call_args[1]["subscription_data"] == {"metadata": metadata}
+
   @patch("robosystems.operations.providers.payment_provider.env")
   def test_checkout_session_urls_use_environment(self, mock_env, stripe_provider):
     """Test that success/cancel URLs use environment configuration."""

--- a/tests/routers/admin/test_credits.py
+++ b/tests/routers/admin/test_credits.py
@@ -416,6 +416,104 @@ class TestAddBonusCreditsToGraph:
 
 
 # ===========================================================================
+# TestResetGraphCreditPool
+# ===========================================================================
+
+
+class TestResetGraphCreditPool:
+  """Tests for POST /admin/v1/credits/graphs/{graph_id}/reset."""
+
+  @pytest.mark.unit
+  async def test_happy_path(self, mock_request, mock_session):
+    """Reset delegates to the service with the admin identity and reason."""
+    from robosystems.routers.admin.credits import reset_graph_credit_pool
+
+    pool = _make_graph_credit_pool(current_balance=Decimal("1000.0"))
+
+    reset_request = MagicMock()
+    reset_request.reason = "Customer goodwill mid-month refresh"
+
+    with (
+      patch(f"{MODULE}.get_db_session", return_value=iter([mock_session])),
+      patch(f"{MODULE}.GraphCredits") as MockGraphCredits,
+      patch(f"{MODULE}.CreditService") as MockCreditService,
+    ):
+      MockGraphCredits.get_by_graph_id.return_value = pool
+      mock_credit_svc = MagicMock()
+      mock_credit_svc.reset_graph_pool.return_value = {
+        "success": True,
+        "credits_forfeited": 400.0,
+        "new_balance": 1000.0,
+      }
+      MockCreditService.return_value = mock_credit_svc
+
+      result = await reset_graph_credit_pool(
+        request=mock_request,
+        graph_id="kg01234567890abcdef",
+        data=reset_request,
+      )
+
+    call_kwargs = mock_credit_svc.reset_graph_pool.call_args.kwargs
+    assert call_kwargs["graph_id"] == "kg01234567890abcdef"
+    assert call_kwargs["initiated_by"] == "admin:test_admin_key"
+    assert call_kwargs["reason"] == "Customer goodwill mid-month refresh"
+    assert result.graph_id == "kg01234567890abcdef"
+    mock_session.refresh.assert_called_once_with(pool)
+    mock_session.close.assert_called_once()
+
+  @pytest.mark.unit
+  async def test_not_found_raises_404(self, mock_request, mock_session):
+    """When pool does not exist, raise HTTPException 404."""
+    from fastapi import HTTPException
+
+    from robosystems.routers.admin.credits import reset_graph_credit_pool
+
+    with (
+      patch(f"{MODULE}.get_db_session", return_value=iter([mock_session])),
+      patch(f"{MODULE}.GraphCredits") as MockGraphCredits,
+    ):
+      MockGraphCredits.get_by_graph_id.return_value = None
+      with pytest.raises(HTTPException) as exc_info:
+        await reset_graph_credit_pool(
+          request=mock_request,
+          graph_id="kg_nonexistent",
+          data=None,
+        )
+
+    assert exc_info.value.status_code == 404
+    mock_session.close.assert_called_once()
+
+  @pytest.mark.unit
+  async def test_no_body_passes_null_reason(self, mock_request, mock_session):
+    """The body is optional; a bare POST resets with the default reason."""
+    from robosystems.routers.admin.credits import reset_graph_credit_pool
+
+    pool = _make_graph_credit_pool()
+
+    with (
+      patch(f"{MODULE}.get_db_session", return_value=iter([mock_session])),
+      patch(f"{MODULE}.GraphCredits") as MockGraphCredits,
+      patch(f"{MODULE}.CreditService") as MockCreditService,
+    ):
+      MockGraphCredits.get_by_graph_id.return_value = pool
+      mock_credit_svc = MagicMock()
+      mock_credit_svc.reset_graph_pool.return_value = {
+        "success": True,
+        "credits_forfeited": 0.0,
+        "new_balance": 1000.0,
+      }
+      MockCreditService.return_value = mock_credit_svc
+
+      await reset_graph_credit_pool(
+        request=mock_request,
+        graph_id="kg01234567890abcdef",
+        data=None,
+      )
+
+    assert mock_credit_svc.reset_graph_pool.call_args.kwargs["reason"] is None
+
+
+# ===========================================================================
 # TestListRepositoryCreditPools
 # ===========================================================================
 

--- a/tests/routers/admin/test_webhooks.py
+++ b/tests/routers/admin/test_webhooks.py
@@ -1,22 +1,25 @@
 """Comprehensive tests for Stripe webhook handlers.
 
-The webhook endpoint validates events and processes them directly via background tasks.
-Handler logic is tested in tests/dagster/jobs/test_billing.py.
+The webhook endpoint validates events and processes them before responding, so
+the HTTP status reflects the processing outcome — Stripe only redelivers on a
+non-2xx response. Handler logic is tested in tests/dagster/jobs/test_billing.py.
 """
 
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
 from main import app
+from robosystems.dagster.jobs.billing import SubscriptionNotFoundError
 
 
 class TestStripeWebhookEndpoint:
   """Tests for Stripe webhook endpoint.
 
-  The endpoint validates webhooks and processes them directly as background tasks.
+  The endpoint validates webhooks, processes them synchronously, and answers
+  with a status Stripe can act on (2xx = done, non-2xx = redeliver).
   """
 
   @pytest.fixture
@@ -30,6 +33,14 @@ class TestStripeWebhookEndpoint:
     with patch("robosystems.routers.admin.webhooks.get_db_session") as mock:
       session = Mock(spec=Session)
       mock.return_value.__next__ = Mock(return_value=session)
+      yield session
+
+  @pytest.fixture
+  def mock_processing_session(self):
+    """Mock the session `_process_webhook_event` opens for handler work."""
+    with patch("robosystems.routers.admin.webhooks.SessionFactory") as factory:
+      session = Mock(spec=Session)
+      factory.return_value = session
       yield session
 
   def test_webhook_missing_signature_header(self, client):
@@ -58,12 +69,22 @@ class TestStripeWebhookEndpoint:
     assert response.status_code == 400
     assert "Invalid webhook signature" in response.json()["detail"]
 
+  @patch(
+    "robosystems.dagster.jobs.billing._handle_checkout_completed",
+    new_callable=AsyncMock,
+  )
   @patch("robosystems.routers.admin.webhooks.BillingAuditLog")
   @patch("robosystems.routers.admin.webhooks.get_payment_provider")
-  def test_webhook_accepted_for_processing(
-    self, mock_get_provider, mock_audit_log, client, mock_db_session
+  def test_webhook_processed_and_marked(
+    self,
+    mock_get_provider,
+    mock_audit_log,
+    mock_handler,
+    client,
+    mock_db_session,
+    mock_processing_session,
   ):
-    """Test that valid webhook events are accepted for direct processing."""
+    """A valid event is dispatched to its handler and marked processed."""
     mock_provider = Mock()
     mock_event = {
       "id": "evt_test123",
@@ -83,13 +104,17 @@ class TestStripeWebhookEndpoint:
     assert response.status_code == 200
     assert response.json() == {
       "status": "success",
-      "message": "Webhook accepted for processing",
+      "message": "Webhook processed",
     }
+    mock_handler.assert_awaited_once()
     # Verify idempotency check was called with correct event_id and source
     mock_audit_log.is_webhook_processed.assert_called_once()
     call_args = mock_audit_log.is_webhook_processed.call_args[0]
     assert call_args[0] == "evt_test123"
     assert call_args[1] == "stripe"
+    # Marked processed only after the handler succeeded
+    mock_audit_log.mark_webhook_processed.assert_called_once()
+    assert mock_audit_log.mark_webhook_processed.call_args[0][0] == "evt_test123"
 
   @patch("robosystems.routers.admin.webhooks.BillingAuditLog")
   @patch("robosystems.routers.admin.webhooks.get_payment_provider")
@@ -119,12 +144,22 @@ class TestStripeWebhookEndpoint:
       "message": "Event already processed",
     }
 
+  @patch(
+    "robosystems.dagster.jobs.billing._handle_payment_succeeded",
+    new_callable=AsyncMock,
+  )
   @patch("robosystems.routers.admin.webhooks.BillingAuditLog")
   @patch("robosystems.routers.admin.webhooks.get_payment_provider")
-  def test_webhook_payment_succeeded_accepted(
-    self, mock_get_provider, mock_audit_log, client, mock_db_session
+  def test_webhook_payment_succeeded_dispatched(
+    self,
+    mock_get_provider,
+    mock_audit_log,
+    mock_handler,
+    client,
+    mock_db_session,
+    mock_processing_session,
   ):
-    """Test that invoice.payment_succeeded events are accepted."""
+    """Test that invoice.payment_succeeded events reach their handler."""
     mock_provider = Mock()
     mock_event = {
       "id": "evt_test456",
@@ -142,14 +177,25 @@ class TestStripeWebhookEndpoint:
     )
 
     assert response.status_code == 200
-    assert "accepted" in response.json()["message"].lower()
+    mock_handler.assert_awaited_once()
+    mock_audit_log.mark_webhook_processed.assert_called_once()
 
+  @patch(
+    "robosystems.dagster.jobs.billing._handle_payment_failed",
+    new_callable=AsyncMock,
+  )
   @patch("robosystems.routers.admin.webhooks.BillingAuditLog")
   @patch("robosystems.routers.admin.webhooks.get_payment_provider")
-  def test_webhook_payment_failed_accepted(
-    self, mock_get_provider, mock_audit_log, client, mock_db_session
+  def test_webhook_payment_failed_dispatched(
+    self,
+    mock_get_provider,
+    mock_audit_log,
+    mock_handler,
+    client,
+    mock_db_session,
+    mock_processing_session,
   ):
-    """Test that invoice.payment_failed events are accepted."""
+    """Test that invoice.payment_failed events reach their handler."""
     mock_provider = Mock()
     mock_event = {
       "id": "evt_test789",
@@ -167,14 +213,24 @@ class TestStripeWebhookEndpoint:
     )
 
     assert response.status_code == 200
-    assert "accepted" in response.json()["message"].lower()
+    mock_handler.assert_awaited_once()
 
+  @patch(
+    "robosystems.dagster.jobs.billing._handle_subscription_updated",
+    new_callable=AsyncMock,
+  )
   @patch("robosystems.routers.admin.webhooks.BillingAuditLog")
   @patch("robosystems.routers.admin.webhooks.get_payment_provider")
-  def test_webhook_subscription_updated_accepted(
-    self, mock_get_provider, mock_audit_log, client, mock_db_session
+  def test_webhook_subscription_updated_dispatched(
+    self,
+    mock_get_provider,
+    mock_audit_log,
+    mock_handler,
+    client,
+    mock_db_session,
+    mock_processing_session,
   ):
-    """Test that customer.subscription.updated events are accepted."""
+    """Test that customer.subscription.updated events reach their handler."""
     mock_provider = Mock()
     mock_event = {
       "id": "evt_sub_update",
@@ -192,14 +248,24 @@ class TestStripeWebhookEndpoint:
     )
 
     assert response.status_code == 200
-    assert "accepted" in response.json()["message"].lower()
+    mock_handler.assert_awaited_once()
 
+  @patch(
+    "robosystems.dagster.jobs.billing._handle_subscription_deleted",
+    new_callable=AsyncMock,
+  )
   @patch("robosystems.routers.admin.webhooks.BillingAuditLog")
   @patch("robosystems.routers.admin.webhooks.get_payment_provider")
-  def test_webhook_subscription_deleted_accepted(
-    self, mock_get_provider, mock_audit_log, client, mock_db_session
+  def test_webhook_subscription_deleted_dispatched(
+    self,
+    mock_get_provider,
+    mock_audit_log,
+    mock_handler,
+    client,
+    mock_db_session,
+    mock_processing_session,
   ):
-    """Test that customer.subscription.deleted events are accepted."""
+    """Test that customer.subscription.deleted events reach their handler."""
     mock_provider = Mock()
     mock_event = {
       "id": "evt_sub_delete",
@@ -217,14 +283,19 @@ class TestStripeWebhookEndpoint:
     )
 
     assert response.status_code == 200
-    assert "accepted" in response.json()["message"].lower()
+    mock_handler.assert_awaited_once()
 
   @patch("robosystems.routers.admin.webhooks.BillingAuditLog")
   @patch("robosystems.routers.admin.webhooks.get_payment_provider")
   def test_webhook_unhandled_event_type_still_accepted(
-    self, mock_get_provider, mock_audit_log, client, mock_db_session
+    self,
+    mock_get_provider,
+    mock_audit_log,
+    client,
+    mock_db_session,
+    mock_processing_session,
   ):
-    """Test that unknown event types are still accepted (handler logs and marks processed)."""
+    """Unknown event types are acknowledged and marked so Stripe stops sending."""
     mock_provider = Mock()
     mock_event = {
       "id": "evt_unknown",
@@ -242,4 +313,78 @@ class TestStripeWebhookEndpoint:
     )
 
     assert response.status_code == 200
-    assert "accepted" in response.json()["message"].lower()
+    mock_audit_log.mark_webhook_processed.assert_called_once()
+
+  @patch(
+    "robosystems.dagster.jobs.billing._handle_payment_succeeded",
+    new_callable=AsyncMock,
+  )
+  @patch("robosystems.routers.admin.webhooks.BillingAuditLog")
+  @patch("robosystems.routers.admin.webhooks.get_payment_provider")
+  def test_unresolvable_subscription_returns_409_and_leaves_event_unmarked(
+    self,
+    mock_get_provider,
+    mock_audit_log,
+    mock_handler,
+    client,
+    mock_db_session,
+    mock_processing_session,
+  ):
+    """Stripe redelivers only on a non-2xx, so a subscription we cannot
+    resolve must surface as one — a 200 here means the event is dropped
+    forever, since there is no reconciliation job behind the webhook."""
+    mock_provider = Mock()
+    mock_event = {
+      "id": "evt_race",
+      "type": "invoice.payment_succeeded",
+      "data": {"object": {"id": "in_123", "subscription": "sub_unknown"}},
+    }
+    mock_provider.verify_webhook.return_value = mock_event
+    mock_get_provider.return_value = mock_provider
+    mock_audit_log.is_webhook_processed.return_value = False
+    mock_handler.side_effect = SubscriptionNotFoundError("sub_unknown not found")
+
+    response = client.post(
+      "/admin/v1/webhooks/stripe",
+      json=mock_event,
+      headers={"stripe-signature": "valid_signature"},
+    )
+
+    assert response.status_code == 409
+    mock_audit_log.mark_webhook_processed.assert_not_called()
+
+  @patch(
+    "robosystems.dagster.jobs.billing._handle_payment_succeeded",
+    new_callable=AsyncMock,
+  )
+  @patch("robosystems.routers.admin.webhooks.BillingAuditLog")
+  @patch("robosystems.routers.admin.webhooks.get_payment_provider")
+  def test_handler_failure_returns_500_and_leaves_event_unmarked(
+    self,
+    mock_get_provider,
+    mock_audit_log,
+    mock_handler,
+    client,
+    mock_db_session,
+    mock_processing_session,
+  ):
+    """A handler crash must not acknowledge the event; Stripe redelivers."""
+    mock_provider = Mock()
+    mock_event = {
+      "id": "evt_crash",
+      "type": "invoice.payment_succeeded",
+      "data": {"object": {"id": "in_123", "subscription": "sub_456"}},
+    }
+    mock_provider.verify_webhook.return_value = mock_event
+    mock_get_provider.return_value = mock_provider
+    mock_audit_log.is_webhook_processed.return_value = False
+    mock_handler.side_effect = RuntimeError("boom")
+
+    response = client.post(
+      "/admin/v1/webhooks/stripe",
+      json=mock_event,
+      headers={"stripe-signature": "valid_signature"},
+    )
+
+    assert response.status_code == 500
+    mock_audit_log.mark_webhook_processed.assert_not_called()


### PR DESCRIPTION
## Summary

Three billing correctness fixes from the second-review pass over the v1.6.27–v1.6.29 wave (detail: `local/RoboSystems/specs/_review-raw/second-review-raw.md`, findings R4-1, R4-5, R4-6):

- **Webhook processing now completes before the response is sent.** The handler previously acknowledged events with a 200 and processed them as background tasks, so an event referencing a subscription we could not resolve was acknowledged and never redelivered. Processing now runs inline: an unresolvable subscription returns 409, a handler failure returns 500, and Stripe's redelivery becomes the real retry mechanism the code always assumed it had.
- **Monthly credit allocation gates on calendar month, not a 30-day count.** February is 28 days, so a day-count gate refuses the 1-Mar run for anything allocated on 1-Feb and silently skips March fleet-wide. The gate now matches the allocation cron and the ledger idempotency key (one allocation per calendar month), which also closes the same-month re-run window.
- **Checkout metadata is stamped onto the created subscription** via `subscription_data` — Stripe does not copy session metadata to the subscription, so the exact-resolution branch added in #1037 never saw it on the checkout path.

## Testing

- `tests/routers/admin/test_webhooks.py` rewritten for the synchronous contract: dispatch per event type, 409/500 paths leave the event unmarked, idempotency short-circuit unchanged.
- New allocation tests pin the Feb→Mar boundary and the same-month refusal.
- New checkout test pins `subscription_data.metadata`.
- `just test-code` green; targeted suites 176 passed.