### PR TITLE
fix(security): align tool surfaces and validators with declared scopes

### DIFF
--- a/robosystems/graph_api/core/ladybug/service.py
+++ b/robosystems/graph_api/core/ladybug/service.py
@@ -228,15 +228,27 @@ def validate_cypher_query(cypher: str) -> None:
   from robosystems.security.cypher_analyzer import (
     is_admin_operation,
     is_bulk_operation,
+    is_non_read_call,
     is_schema_ddl,
   )
 
-  if is_bulk_operation(cypher) or is_admin_operation(cypher) or is_schema_ddl(cypher):
+  # `is_non_read_call` covers the CALL family (procedure DDL, session
+  # configuration) that the three family predicates cannot see — this
+  # validator deliberately does not use `is_write_operation`, since writer
+  # instances execute ordinary graph writes through this path. Index
+  # creation runs on the dedicated manager paths, never through here.
+  if (
+    is_bulk_operation(cypher)
+    or is_admin_operation(cypher)
+    or is_schema_ddl(cypher)
+    or is_non_read_call(cypher)
+  ):
     raise HTTPException(
       status_code=status.HTTP_403_FORBIDDEN,
       detail=(
         "Query contains an engine-level operation (bulk load, attach/install, "
-        "or schema DDL) that is not permitted on the ad-hoc query endpoint."
+        "schema DDL, or a restricted CALL) that is not permitted on the "
+        "ad-hoc query endpoint."
       ),
     )
 

--- a/robosystems/operations/operators/adapters/api.py
+++ b/robosystems/operations/operators/adapters/api.py
@@ -74,7 +74,10 @@ async def run_operator_api(
   # difference between covering one execution path and covering all of them.
   enforce_operator_credits(operator, graph_id, str(user.id), db_session, mode)
 
-  tools = HttpToolAccess(graph_id)
+  # The tool surface must not exceed what the role gate above checked for:
+  # a read-only operator skips the write-role gate, so it must also get a
+  # read-only tool surface.
+  tools = HttpToolAccess(graph_id, read_only=operator.spec.read_only)
   ai_client = AIClient()
 
   if db_session is None:

--- a/robosystems/operations/operators/implementations/cypher.py
+++ b/robosystems/operations/operators/implementations/cypher.py
@@ -58,9 +58,13 @@ class CypherOperator(Operator):
       OperatorCapability.ENTITY_ANALYSIS,
       OperatorCapability.CUSTOM,
     ],
-    # Every tool this operator can reach is in READ_ONLY_TOOLS above, so a
-    # graph `viewer` may run it. Removing this flag (or adding a write tool
-    # to the allowlist without removing it) is what the adapters gate on.
+    # A graph `viewer` may run this operator because the flag is enforced in
+    # two places downstream: HttpToolAccess builds the tool surface with
+    # read_only=True (write tools are never wired), and run_tool_loop
+    # refuses tool names outside the advertised READ_ONLY_TOOLS set. The
+    # flag alone guarantees nothing — the adapters skip the write-role gate
+    # because of it, so those two enforcement points are what make that
+    # skip safe.
     read_only=True,
     version="2.0.0",
     requires_credits=True,

--- a/robosystems/operations/operators/tool_access.py
+++ b/robosystems/operations/operators/tool_access.py
@@ -20,10 +20,17 @@ class HttpToolAccess:
 
   Uses the full GraphMCPTools pipeline (HTTP → Graph API). Best for
   operators that execute Cypher queries or read graph schema.
+
+  ``read_only`` decides whether GraphMCPTools wires its write tools at all.
+  It must mirror the operator spec's ``read_only`` flag: the write-role gate
+  in the adapters is skipped for read-only operators, so a read-only
+  operator handed a write-capable tool surface would have an ungated write
+  path. Defaults to read-only so a caller has to opt in to writes.
   """
 
-  def __init__(self, graph_id: str) -> None:
+  def __init__(self, graph_id: str, read_only: bool = True) -> None:
     self._graph_id = graph_id
+    self._read_only = read_only
     self._client = None
     self._tools = None
 
@@ -41,10 +48,14 @@ class HttpToolAccess:
 
     self._client = await create_graph_mcp_client(graph_id=self._graph_id)
     schema_extensions = resolve_schema_extensions(self._graph_id)
-    self._tools = GraphMCPTools(self._client, schema_extensions=schema_extensions)
+    self._tools = GraphMCPTools(
+      self._client,
+      schema_extensions=schema_extensions,
+      read_only=self._read_only,
+    )
     logger.info(
       f"Initialized HTTP tool access for graph {self._graph_id} "
-      f"(extensions={schema_extensions})"
+      f"(extensions={schema_extensions}, read_only={self._read_only})"
     )
 
   async def call_tool(

--- a/robosystems/operations/operators/tool_loop.py
+++ b/robosystems/operations/operators/tool_loop.py
@@ -108,6 +108,10 @@ async def run_tool_loop(
     logger.warning(
       "run_tool_loop: none of %s available on graph %s", tool_names, ctx.graph_id
     )
+  # The dispatch below must enforce this set, not just advertise it: the
+  # model can emit any tool name, and call_tool dispatches whatever the
+  # underlying tool manager exposes.
+  advertised = {t["name"] for t in tools}
 
   messages: list[AIMessage] = _seed_history(ctx)
   messages.append(AIMessage(role="user", content=ctx.query))
@@ -157,6 +161,23 @@ async def run_tool_loop(
       tools_called.append(name)
 
       is_error = False
+      if name not in advertised:
+        logger.warning(
+          "run_tool_loop: model requested unadvertised tool %s on graph %s",
+          name,
+          ctx.graph_id,
+        )
+        tool_results.append(
+          {
+            "type": "tool_result",
+            "tool_use_id": tool_use_id,
+            "content": _serialize_tool_result(
+              {"error": f"Tool '{name}' is not available"}
+            ),
+            "is_error": True,
+          }
+        )
+        continue
       try:
         result = await ctx.tools.call_tool(name, args, return_raw=True)
         # Registrar/domain tools report failure as {"error": ...} instead of

--- a/robosystems/security/cypher_analyzer.py
+++ b/robosystems/security/cypher_analyzer.py
@@ -100,6 +100,7 @@ class CypherSecurityAnalyzer:
     "show_connection",
     "show_warnings",
     "show_indexes",
+    "show_functions",
     "query_vector_index",
     "query_fts_index",
   }
@@ -264,6 +265,28 @@ class CypherSecurityAnalyzer:
     except Exception as e:
       logger.warning(f"Admin operation analysis failed: {e}")
       # Default to true for safety with admin operations
+      return True
+
+  def is_non_read_call(self, query: str) -> bool:
+    """Check if a query contains CALL forms that are not read-only.
+
+    True for procedure invocations outside READ_ONLY_PROCEDURES and for
+    session-configuration assignments. Exists for validators that gate on
+    the operation *family* (bulk / admin / DDL) rather than on
+    `is_write_operation`, so they can still refuse the CALL surface without
+    refusing ordinary graph writes.
+
+    Args:
+        query: The Cypher query to check
+
+    Returns:
+        True if the query contains non-read CALL forms, False otherwise
+    """
+    try:
+      cleaned_query = self._clean_query(query)
+      return len(self._find_call_operations(cleaned_query)) > 0
+    except Exception as e:
+      logger.warning(f"CALL analysis failed, defaulting to non-read: {e}")
       return True
 
   def has_system_calls(self, query: str) -> bool:
@@ -734,6 +757,23 @@ def is_admin_operation(query: str) -> bool:
       True if the query contains admin operations, False otherwise
   """
   return cypher_analyzer.is_admin_operation(query)
+
+
+def is_non_read_call(query: str) -> bool:
+  """
+  Determine if a Cypher query contains CALL forms that are not read-only.
+
+  Procedure invocations outside the read-only allowlist and session
+  configuration assignments both count. For validators gating on operation
+  family rather than write-ness.
+
+  Args:
+      query: The Cypher query to analyze
+
+  Returns:
+      True if the query contains non-read CALL forms, False otherwise
+  """
+  return cypher_analyzer.is_non_read_call(query)
 
 
 def has_system_calls(query: str) -> bool:

--- a/tests/graph_api/core/ladybug/test_service.py
+++ b/tests/graph_api/core/ladybug/test_service.py
@@ -246,6 +246,36 @@ class TestValidateCypherQueryEngineVerbs:
       validate_cypher_query("MATCH (n) WHERE n.note = '//' COPY t FROM '/x'")
     assert exc_info.value.status_code == 403
 
+  @pytest.mark.parametrize(
+    "call_form",
+    [
+      "CALL CREATE_VECTOR_INDEX('Fact','x','embedding')",
+      "CALL DROP_VECTOR_INDEX('Fact','x')",
+      "CALL some_future_procedure()",
+      "CALL spill_to_disk=false",
+    ],
+  )
+  def test_non_read_call_forms_raise_403(self, call_form):
+    """The CALL family (procedure DDL, session configuration) is invisible
+    to the bulk/admin/DDL predicates, so it is refused via the analyzer's
+    dedicated CALL classification. Index creation runs on the dedicated
+    manager paths, which never pass through this validator."""
+    with pytest.raises(HTTPException) as exc_info:
+      validate_cypher_query(call_form)
+    assert exc_info.value.status_code == 403
+
+  @pytest.mark.parametrize(
+    "read_call",
+    [
+      "CALL SHOW_TABLES() RETURN *",
+      "CALL show_functions() RETURN *",
+      "CALL table_info('Fact') RETURN *",
+    ],
+  )
+  def test_allowlisted_read_calls_pass(self, read_call):
+    """Schema introspection procedures stay available on the ad-hoc endpoint."""
+    validate_cypher_query(read_call)  # Should not raise
+
 
 # ---------------------------------------------------------------------------
 # _raise_database_not_found

--- a/tests/operations/operators/test_tool_loop.py
+++ b/tests/operations/operators/test_tool_loop.py
@@ -247,3 +247,42 @@ async def test_hits_iteration_cap_then_forces_a_final_answer():
     and "step limit" in b.get("text", "")
     for b in last_user.content
   )
+
+
+async def test_unadvertised_tool_is_refused_without_dispatch():
+  """The advertised set is enforced at dispatch, not just at advertisement.
+
+  get_tool_schemas filters what the model is SHOWN, but the model can emit
+  any name it likes — and call_tool dispatches whatever the underlying
+  manager exposes, including write tools when the surface was built
+  write-capable. A name outside the advertised set must be refused before
+  call_tool, not after.
+  """
+  ai = MagicMock()
+  ai.create_message = AsyncMock(
+    side_effect=[
+      _tool_use("t1", "delete-journal-entry", entry_id="je_1"),
+      _final("That tool isn't available."),
+    ]
+  )
+  tools = _tools_mock(call_results=[])
+  ctx = _ctx(ai, tools)
+
+  result = await run_tool_loop(
+    ctx,
+    system="sys",
+    tool_names=["read-graph-cypher"],
+    max_iterations=5,
+    max_tokens=1000,
+  )
+
+  tools.call_tool.assert_not_awaited()
+  assert result.text == "That tool isn't available."
+
+  # The refusal is fed back to the model as an is_error tool_result so the
+  # transcript stays valid and the model can continue.
+  second_turn_messages = ai.create_message.call_args_list[1].kwargs["messages"]
+  blocks = _tool_result_blocks(second_turn_messages)
+  assert len(blocks) == 1
+  assert blocks[0]["is_error"] is True
+  assert "not available" in blocks[0]["content"]

--- a/tests/operations/operators/test_write_role_gate.py
+++ b/tests/operations/operators/test_write_role_gate.py
@@ -166,3 +166,100 @@ class TestRegisteredOperatorDeclarations:
     assert MappingOperator.spec.read_only is False, (
       "MappingOperator persists mapping associations, so it must stay gated"
     )
+
+
+class TestToolSurfaceMatchesSpec:
+  """The tool surface handed to an operator must not exceed what the role
+  gate checked for. A read-only operator skips the write-role gate, so its
+  tool access must be built read-only — otherwise the flag that skips the
+  gate is also the flag that unlocks the write tools.
+  """
+
+  @pytest.mark.asyncio
+  async def test_api_adapter_builds_tool_access_from_the_spec(self) -> None:
+    from robosystems.operations.operators.adapters import api
+
+    user = MagicMock()
+    user.id = USER_ID
+
+    with (
+      patch.object(api, "enforce_operator_write_role"),
+      patch.object(api, "enforce_operator_credits"),
+      patch.object(api, "HttpToolAccess") as tool_access,
+      patch.object(api, "AIClient"),
+      patch.object(api, "TrackedAIClient"),
+    ):
+      tool_access.return_value = MagicMock(close=AsyncMock())
+      await api.run_operator_api(
+        operator=_operator(read_only=True),
+        graph_id=GRAPH_ID,
+        user=user,
+        query="anything",
+      )
+
+    tool_access.assert_called_once_with(GRAPH_ID, read_only=True)
+
+  @pytest.mark.asyncio
+  async def test_api_adapter_grants_writes_only_to_write_capable_specs(self) -> None:
+    from robosystems.operations.operators.adapters import api
+
+    user = MagicMock()
+    user.id = USER_ID
+
+    with (
+      patch.object(api, "enforce_operator_write_role"),
+      patch.object(api, "enforce_operator_credits"),
+      patch.object(api, "HttpToolAccess") as tool_access,
+      patch.object(api, "AIClient"),
+      patch.object(api, "TrackedAIClient"),
+    ):
+      tool_access.return_value = MagicMock(close=AsyncMock())
+      await api.run_operator_api(
+        operator=_operator(read_only=False),
+        graph_id=GRAPH_ID,
+        user=user,
+        query="anything",
+      )
+
+    tool_access.assert_called_once_with(GRAPH_ID, read_only=False)
+
+  @pytest.mark.asyncio
+  async def test_http_tool_access_wires_read_only_into_the_tool_manager(self) -> None:
+    from robosystems.operations.operators.tool_access import HttpToolAccess
+
+    with (
+      patch("robosystems.middleware.mcp.GraphMCPTools") as tools_cls,
+      patch(
+        "robosystems.middleware.mcp.create_graph_mcp_client",
+        new=AsyncMock(return_value=MagicMock()),
+      ),
+      patch(
+        "robosystems.middleware.mcp.tools.manager.resolve_schema_extensions",
+        return_value=[],
+      ),
+    ):
+      access = HttpToolAccess(GRAPH_ID, read_only=True)
+      await access.initialize()
+
+    assert tools_cls.call_args.kwargs["read_only"] is True
+
+  @pytest.mark.asyncio
+  async def test_http_tool_access_defaults_to_read_only(self) -> None:
+    """A caller that says nothing gets no write tools — the same fail-closed
+    default as OperatorSpec.read_only, in the opposite direction."""
+    from robosystems.operations.operators.tool_access import HttpToolAccess
+
+    with (
+      patch("robosystems.middleware.mcp.GraphMCPTools") as tools_cls,
+      patch(
+        "robosystems.middleware.mcp.create_graph_mcp_client",
+        new=AsyncMock(return_value=MagicMock()),
+      ),
+      patch(
+        "robosystems.middleware.mcp.tools.manager.resolve_schema_extensions",
+        return_value=[],
+      ),
+    ):
+      await HttpToolAccess(GRAPH_ID).initialize()
+
+    assert tools_cls.call_args.kwargs["read_only"] is True

--- a/tests/security/test_cypher_analyzer.py
+++ b/tests/security/test_cypher_analyzer.py
@@ -219,11 +219,61 @@ class TestCallClassification:
     would break the schema endpoints and the MCP client."""
     assert analyzer.is_write_operation(query) is False
 
+  def test_show_functions_is_a_read(self, analyzer):
+    """The MCP query validator's own remediation hint tells users to run
+    `CALL show_functions() RETURN *` in place of `SHOW FUNCTIONS` — the
+    sanctioned replacement must not be refused as a write."""
+    assert analyzer.is_write_operation("CALL show_functions() RETURN *") is False
+
   def test_configuration_inside_a_string_literal_is_not_a_write(self, analyzer):
     """String contents are masked before classification, so a literal that
     merely looks like a config verb must not trip the gate."""
     query = "MATCH (n:Fact) WHERE n.name = 'CALL timeout=0' RETURN n"
     assert analyzer.is_write_operation(query) is False
+
+
+class TestIsNonReadCall:
+  """`is_non_read_call` exposes the CALL classification to validators that
+  gate on operation *family* (bulk / admin / DDL) rather than on
+  `is_write_operation` — graph_api's ad-hoc query validator must allow
+  ordinary graph writes (writer instances execute them) while still
+  refusing the CALL surface."""
+
+  @pytest.mark.parametrize(
+    "query",
+    [
+      "CALL CREATE_VECTOR_INDEX('Fact','x','embedding')",
+      "CALL DROP_VECTOR_INDEX('Fact','x')",
+      "CALL some_future_procedure()",
+      "CALL spill_to_disk=false",
+      "MATCH (n) RETURN n; CALL timeout=0",
+    ],
+  )
+  def test_non_read_call_forms_are_flagged(self, analyzer, query):
+    assert analyzer.is_non_read_call(query) is True
+
+  @pytest.mark.parametrize(
+    "query",
+    [
+      "CALL SHOW_TABLES() RETURN *",
+      "CALL show_functions() RETURN *",
+      "CALL table_info('Fact') RETURN *",
+      "MATCH (n) RETURN n",
+      "CREATE (n:Foo {id: 1}) RETURN n",
+      "MATCH (n:Fact) WHERE n.name = 'CALL timeout=0' RETURN n",
+    ],
+  )
+  def test_reads_writes_and_allowlisted_calls_are_not_flagged(self, analyzer, query):
+    """Ordinary reads AND ordinary writes pass — the predicate is about the
+    CALL family only, so family-gating validators can compose it without
+    breaking writer instances."""
+    assert analyzer.is_non_read_call(query) is False
+
+  def test_module_level_wrapper(self):
+    from robosystems.security.cypher_analyzer import is_non_read_call
+
+    assert is_non_read_call("CALL CREATE_VECTOR_INDEX('a','b','c')") is True
+    assert is_non_read_call("MATCH (n) RETURN n") is False
 
 
 class TestQuerySecurityValidation:


### PR DESCRIPTION
## Summary

Hardening follow-ups from the second-review pass (detail: `local/RoboSystems/specs/_review-raw/second-review-raw.md`, findings R3-4 and R1's #1041 items — per disclosure policy the mechanics stay in the vault):

- Operator tool access is now constructed to match the operator spec's declared read scope, and the tool-use loop dispatches only tools it actually advertised to the model.
- The graph_api ad-hoc query validator now classifies the CALL statement family via the shared analyzer, consistent with the platform gate (#1041).
- `show_functions` joins the read-only procedure allowlist — the validator's own remediation hint recommends it, so it must be runnable.

## Testing

- New tests pin: tool access read-scope wiring (spec → tool manager, fail-closed default), unadvertised-tool refusal before dispatch, CALL-family rejection and read-CALL passage on the graph_api validator, and `show_functions` classification.
- Full operator + MCP middleware suites green (784), analyzer/service suites green (208), `just test-code` clean.