### PR TITLE
Fix timezone handling in the subscription grace-period check

### DIFF
--- a/robosystems/middleware/billing/enforcement.py
+++ b/robosystems/middleware/billing/enforcement.py
@@ -246,6 +246,10 @@ def require_graph_access(
   if subscription.status == "canceled":
     now = datetime.now(UTC)
     ends_at = subscription.ends_at
+    # The DateTime column is timezone-naive; comparing naive against aware
+    # raises TypeError. Normalize like OrgInvitation.is_expired does.
+    if ends_at is not None and ends_at.tzinfo is None:
+      ends_at = ends_at.replace(tzinfo=UTC)
 
     if ends_at and ends_at > now:
       # Grace period: reads OK, writes blocked

--- a/tests/middleware/billing/test_enforcement.py
+++ b/tests/middleware/billing/test_enforcement.py
@@ -5,14 +5,17 @@ These tests cover the billing enforcement functions for graph operations,
 including provisioning checks and subscription status validation.
 """
 
+from datetime import UTC, datetime, timedelta
 from unittest.mock import Mock, patch
 
 import pytest
+from fastapi import HTTPException
 
 from robosystems.config.graph_tier import GraphTier
 from robosystems.middleware.billing.enforcement import (
   check_can_provision_graph,
   check_graph_subscription_active,
+  require_graph_access,
 )
 from robosystems.models.core.billing import SubscriptionStatus
 
@@ -440,3 +443,109 @@ class TestEdgeCases:
 
       assert can_provision is True
       mock_logger.info.assert_called_once()
+
+
+class TestRequireGraphAccessGracePeriod:
+  """Canceled-subscription grace period in require_graph_access.
+
+  `BillingSubscription.ends_at` is a timezone-naive DateTime column while
+  the comparison side is `datetime.now(UTC)` — without tzinfo
+  normalization, every request to a graph in its cancellation grace
+  period raised TypeError (a 500) for the entire remaining paid period.
+  """
+
+  @pytest.fixture
+  def mock_session(self):
+    return Mock()
+
+  @pytest.fixture(autouse=True)
+  def clear_subscription_cache(self):
+    from robosystems.middleware.billing import enforcement
+
+    enforcement._subscription_cache.clear()
+    yield
+    enforcement._subscription_cache.clear()
+
+  def _active_graph(self):
+    graph = Mock()
+    graph.status = "active"
+    graph.is_repository = False
+    return graph
+
+  def _canceled_subscription(self, ends_at):
+    subscription = Mock()
+    subscription.status = "canceled"
+    subscription.ends_at = ends_at
+    return subscription
+
+  @patch("robosystems.middleware.billing.enforcement.env")
+  @patch("robosystems.middleware.billing.enforcement.BillingSubscription")
+  @patch("robosystems.middleware.billing.enforcement.Graph")
+  def test_naive_future_ends_at_allows_reads(
+    self, mock_graph_class, mock_subscription_class, mock_env, mock_session
+  ):
+    """A naive (column-typed) future ends_at must grant read access, not 500."""
+    mock_env.BILLING_ENABLED = True
+    mock_graph_class.get_by_id.return_value = self._active_graph()
+    mock_subscription_class.get_by_resource.return_value = self._canceled_subscription(
+      datetime.now(UTC).replace(tzinfo=None) + timedelta(days=10)
+    )
+
+    graph = require_graph_access("kg_gracetest1", mock_session)
+
+    assert graph is mock_graph_class.get_by_id.return_value
+
+  @patch("robosystems.middleware.billing.enforcement.env")
+  @patch("robosystems.middleware.billing.enforcement.BillingSubscription")
+  @patch("robosystems.middleware.billing.enforcement.Graph")
+  def test_naive_future_ends_at_blocks_writes(
+    self, mock_graph_class, mock_subscription_class, mock_env, mock_session
+  ):
+    """Grace period allows reads only — writes must 403, not 500."""
+    mock_env.BILLING_ENABLED = True
+    mock_graph_class.get_by_id.return_value = self._active_graph()
+    mock_subscription_class.get_by_resource.return_value = self._canceled_subscription(
+      datetime.now(UTC).replace(tzinfo=None) + timedelta(days=10)
+    )
+
+    with pytest.raises(HTTPException) as exc:
+      require_graph_access("kg_gracetest2", mock_session, require_write=True)
+
+    assert exc.value.status_code == 403
+    assert "canceled" in exc.value.detail.lower()
+
+  @patch("robosystems.middleware.billing.enforcement.env")
+  @patch("robosystems.middleware.billing.enforcement.BillingSubscription")
+  @patch("robosystems.middleware.billing.enforcement.Graph")
+  def test_naive_past_ends_at_denies_access(
+    self, mock_graph_class, mock_subscription_class, mock_env, mock_session
+  ):
+    """A naive past ends_at means the grace period is over: 403."""
+    mock_env.BILLING_ENABLED = True
+    mock_graph_class.get_by_id.return_value = self._active_graph()
+    mock_subscription_class.get_by_resource.return_value = self._canceled_subscription(
+      datetime.now(UTC).replace(tzinfo=None) - timedelta(days=1)
+    )
+
+    with pytest.raises(HTTPException) as exc:
+      require_graph_access("kg_gracetest3", mock_session)
+
+    assert exc.value.status_code == 403
+    assert "ended" in exc.value.detail.lower()
+
+  @patch("robosystems.middleware.billing.enforcement.env")
+  @patch("robosystems.middleware.billing.enforcement.BillingSubscription")
+  @patch("robosystems.middleware.billing.enforcement.Graph")
+  def test_aware_future_ends_at_still_works(
+    self, mock_graph_class, mock_subscription_class, mock_env, mock_session
+  ):
+    """Timezone-aware ends_at (future-proofing) passes through unchanged."""
+    mock_env.BILLING_ENABLED = True
+    mock_graph_class.get_by_id.return_value = self._active_graph()
+    mock_subscription_class.get_by_resource.return_value = self._canceled_subscription(
+      datetime.now(UTC) + timedelta(days=10)
+    )
+
+    graph = require_graph_access("kg_gracetest4", mock_session)
+
+    assert graph is mock_graph_class.get_by_id.return_value


### PR DESCRIPTION
## Summary

`require_graph_access` compares `BillingSubscription.ends_at` (a timezone-naive `DateTime` column) against `datetime.now(UTC)`. For a subscription canceled at period end, that comparison raises `TypeError` on every request to the graph for the remainder of the paid period — surfacing as a 500 where the documented behavior is "reads OK, writes blocked."

Normalizes `ends_at` to UTC before comparing, the same pattern `OrgInvitation.is_expired` already uses.

## Testing

- New `TestRequireGraphAccessGracePeriod`: naive future `ends_at` grants reads / 403s writes, naive past `ends_at` 403s, aware `ends_at` unchanged.
- Verified the new tests fail against the pre-fix code.

Ref: v16-landing-review H11 (vault).