### PR TITLE
Ledger correctness batch: rollup filters, CoA update traits, materialization gates

### DIFF
--- a/robosystems/operations/extensions/materialize.py
+++ b/robosystems/operations/extensions/materialize.py
@@ -917,6 +917,21 @@ def _staging_sql(graph_id: str, entity_id: str, connstr: str) -> dict[str, str]:
   # have been generated yet — that's fine, they'll be populated on next
   # materialization after report creation.
 
+  # Scenario guard: fact sets stamped with a scenario_id are forecast
+  # months (NULL means actuals — see FactSet.scenario_id). The graph
+  # schema carries no scenario discriminator, so materializing them would
+  # blend plan into history for every graph reader (fact grids, Cypher,
+  # analytical views). Until an OLAP scenario leg exists, scenario facts
+  # and fact sets stay OLTP-only: every projection below that reads
+  # `facts` goes through this derived table, and every `fact_sets`
+  # projection filters `scenario_id IS NULL` directly.
+  actual_facts = (
+    f"(SELECT f.* FROM postgres_scan('{c}', '{s}', 'facts') f "
+    f"LEFT JOIN postgres_scan('{c}', '{s}', 'fact_sets') sfs "
+    f"ON sfs.id = f.fact_set_id "
+    f"WHERE sfs.scenario_id IS NULL)"
+  )
+
   tables["Taxonomy"] = f"""
     CREATE OR REPLACE TABLE Taxonomy AS
     SELECT
@@ -981,7 +996,7 @@ def _staging_sql(graph_id: str, entity_id: str, connstr: str) -> dict[str, str]:
         ELSE 'other'
       END                             AS duration_type,
       NULL::VARCHAR                   AS calendar_period_key
-    FROM postgres_scan('{c}', '{s}', 'facts')
+    FROM {actual_facts} f
   """
 
   # Units come from the facts actually present (numeric facts only — XBRL
@@ -996,7 +1011,7 @@ def _staging_sql(graph_id: str, entity_id: str, connstr: str) -> dict[str, str]:
       unit                            AS value,
       NULL::VARCHAR                   AS numerator_uri,
       NULL::VARCHAR                   AS denominator_uri
-    FROM postgres_scan('{c}', '{s}', 'facts')
+    FROM {actual_facts} f
     WHERE fact_type = 'Numeric'
     UNION
     SELECT
@@ -1022,7 +1037,7 @@ def _staging_sql(graph_id: str, entity_id: str, connstr: str) -> dict[str, str]:
       content_type                    AS content_type,
       false                           AS has_dimensions,
       0::BIGINT                       AS dimension_count
-    FROM postgres_scan('{c}', '{s}', 'facts')
+    FROM {actual_facts} f
   """
 
   tables["FactSet"] = f"""
@@ -1032,6 +1047,7 @@ def _staging_sql(graph_id: str, entity_id: str, connstr: str) -> dict[str, str]:
       COALESCE(factset_type, '')      AS factset_type,
       COALESCE(CAST(provenance AS VARCHAR), '')  AS provenance
     FROM postgres_scan('{c}', '{s}', 'fact_sets')
+    WHERE scenario_id IS NULL
   """
 
   # ── Base Ontology Relationships (Entity ↔ Taxonomy) ────────────────────
@@ -1112,6 +1128,7 @@ def _staging_sql(graph_id: str, entity_id: str, connstr: str) -> dict[str, str]:
     JOIN postgres_scan('{c}', '{s}', 'fact_sets') fs
       ON fs.id = f.fact_set_id
     WHERE fs.report_id IS NOT NULL
+      AND fs.scenario_id IS NULL
   """
 
   tables["FACT_HAS_ELEMENT"] = f"""
@@ -1119,7 +1136,7 @@ def _staging_sql(graph_id: str, entity_id: str, connstr: str) -> dict[str, str]:
     SELECT
       id                              AS src,
       element_id                      AS dst
-    FROM postgres_scan('{c}', '{s}', 'facts')
+    FROM {actual_facts} f
   """
 
   tables["FACT_HAS_PERIOD"] = f"""
@@ -1130,7 +1147,7 @@ def _staging_sql(graph_id: str, entity_id: str, connstr: str) -> dict[str, str]:
           || '_' || CAST(period_end AS VARCHAR)
           || '_' || period_type)
                                       AS dst
-    FROM postgres_scan('{c}', '{s}', 'facts')
+    FROM {actual_facts} f
   """
 
   # XBRL nonNumeric facts carry no unitRef — numeric facts only.
@@ -1139,7 +1156,7 @@ def _staging_sql(graph_id: str, entity_id: str, connstr: str) -> dict[str, str]:
     SELECT
       id                              AS src,
       'unit_' || lower(unit)          AS dst
-    FROM postgres_scan('{c}', '{s}', 'facts')
+    FROM {actual_facts} f
     WHERE fact_type = 'Numeric'
   """
 
@@ -1155,6 +1172,7 @@ def _staging_sql(graph_id: str, entity_id: str, connstr: str) -> dict[str, str]:
     JOIN postgres_scan('{c}', '{s}', 'reports') rd
       ON fs.report_id = rd.id
     WHERE rd.source_graph_id IS NULL
+      AND fs.scenario_id IS NULL
     UNION ALL
     -- Shared facts: remap entity_id to the linked entity on this graph
     SELECT
@@ -1168,6 +1186,7 @@ def _staging_sql(graph_id: str, entity_id: str, connstr: str) -> dict[str, str]:
     JOIN postgres_scan('{c}', '{s}', 'entities') e
       ON e.metadata->>'source_graph_id' = rd.source_graph_id
     WHERE rd.source_graph_id IS NOT NULL
+      AND fs.scenario_id IS NULL
   """
 
   tables["STRUCTURE_HAS_FACT_SET"] = f"""
@@ -1177,6 +1196,7 @@ def _staging_sql(graph_id: str, entity_id: str, connstr: str) -> dict[str, str]:
       id                              AS dst
     FROM postgres_scan('{c}', '{s}', 'fact_sets')
     WHERE structure_id IS NOT NULL
+      AND scenario_id IS NULL
   """
 
   tables["REPORT_HAS_FACT_SET"] = f"""
@@ -1186,6 +1206,7 @@ def _staging_sql(graph_id: str, entity_id: str, connstr: str) -> dict[str, str]:
       id                              AS dst
     FROM postgres_scan('{c}', '{s}', 'fact_sets')
     WHERE report_id IS NOT NULL
+      AND scenario_id IS NULL
   """
 
   tables["FACT_SET_CONTAINS_FACT"] = f"""
@@ -1193,7 +1214,7 @@ def _staging_sql(graph_id: str, entity_id: str, connstr: str) -> dict[str, str]:
     SELECT
       fact_set_id                     AS src,
       id                              AS dst
-    FROM postgres_scan('{c}', '{s}', 'facts')
+    FROM {actual_facts} f
     WHERE fact_set_id IS NOT NULL
   """
 

--- a/robosystems/operations/graph/tasks/extensions_materialize.py
+++ b/robosystems/operations/graph/tasks/extensions_materialize.py
@@ -43,14 +43,21 @@ class ExtensionsMaterializeTask(BaseTask):
         rebuild=rebuild,
       )
 
-      if result.status == "error":
+      if result.status != "success":
+        # 'partial' matters as much as 'error' (same rule as the Dagster
+        # path): blue/green refused to swap the incomplete build, so the
+        # old graph generation is still active. Marking the graph fresh
+        # here would stop the staleness sensor from ever retrying while
+        # sync status reports 'fresh' — the stamp would lie about the
+        # refused swap.
         logger.error(
-          f"Extensions materialization failed for {self.graph_id}: {result.errors}"
+          f"Extensions materialization {result.status} for "
+          f"{self.graph_id}: {result.errors}"
         )
-        await self.report_progress("Materialization failed.", percent=100)
+        await self.report_progress(f"Materialization {result.status}.", percent=100)
         return {
           "graph_id": self.graph_id,
-          "status": "error",
+          "status": result.status,
           "errors": result.errors,
           "duration_ms": result.duration_ms,
           "execution_time_ms": result.duration_ms,

--- a/robosystems/operations/roboledger/reads/account_rollups.py
+++ b/robosystems/operations/roboledger/reads/account_rollups.py
@@ -51,8 +51,8 @@ _ROLLUP_SQL = text("""
     source.id AS coa_element_id,
     source.name AS coa_name,
     source.code AS coa_code,
-    COALESCE(SUM(li.debit_amount), 0) AS total_debits,
-    COALESCE(SUM(li.credit_amount), 0) AS total_credits
+    COALESCE(bal.total_debits, 0) AS total_debits,
+    COALESCE(bal.total_credits, 0) AS total_credits
   FROM associations mapping
   JOIN elements source ON source.id = mapping.from_element_id
   JOIN elements target ON target.id = mapping.to_element_id
@@ -63,14 +63,25 @@ _ROLLUP_SQL = text("""
     WHERE et.is_primary = TRUE
       AND tr.category = 'elementsOfFinancialStatements'
   ) t ON t.element_id = target.id
-  LEFT JOIN line_items li ON li.element_id = source.id
-  LEFT JOIN entries e ON e.id = li.entry_id AND e.status = 'posted'
-    AND (e.posting_date >= :start_date OR :start_date IS NULL)
-    AND (e.posting_date <= :end_date OR :end_date IS NULL)
+  -- Balances pre-aggregated with the posted/date predicates inside the
+  -- derived table (mirroring trial_balance): predicates on a LEFT JOIN's
+  -- ON clause don't filter the outer rows, so line items from draft,
+  -- reversed, or out-of-window entries would still land in the sums.
+  -- The join stays LEFT so mapped accounts with no activity remain
+  -- visible with zero balances.
+  LEFT JOIN (
+    SELECT li.element_id,
+           SUM(li.debit_amount) AS total_debits,
+           SUM(li.credit_amount) AS total_credits
+    FROM line_items li
+    JOIN entries e ON e.id = li.entry_id
+    WHERE e.status = 'posted'
+      AND (e.posting_date >= :start_date OR :start_date IS NULL)
+      AND (e.posting_date <= :end_date OR :end_date IS NULL)
+    GROUP BY li.element_id
+  ) bal ON bal.element_id = source.id
   WHERE mapping.structure_id = :mapping_id
     AND mapping.association_type = 'mapping'
-  GROUP BY target.id, target.name, target.qname, t.identifier,
-           target.balance_type, source.id, source.name, source.code
   ORDER BY t.identifier, target.name, source.code
 """)
 

--- a/robosystems/operations/taxonomy_block/update_validator.py
+++ b/robosystems/operations/taxonomy_block/update_validator.py
@@ -26,9 +26,11 @@ from robosystems.models.api.taxonomy_block import (
 from robosystems.models.extensions import (
   Association,
   Element,
+  ElementTrait,
   Rule,
   Structure,
   Taxonomy,
+  Trait,
 )
 from robosystems.models.extensions.roboledger.fact import Fact
 from robosystems.models.extensions.roboledger.line_item import LineItem
@@ -73,6 +75,7 @@ def validate_update_envelope(
   structure_name_by_id = {s.id: s.name for s in current_structures}
   qname_by_element_id = {e.id: e.qname for e in current_elements}
   element_id_by_qname = {e.qname: e.id for e in current_elements if e.qname}
+  trait_by_element_id = _load_efs_traits(session, current_elements)
 
   _resolve_foreign_element_qnames(
     session, qname_by_element_id, current_elements, current_associations
@@ -100,7 +103,7 @@ def validate_update_envelope(
         TaxonomyBlockElementRequest(
           qname=qname,
           name=str(e.name),
-          trait=_element_classification_hint(e),
+          trait=trait_by_element_id.get(str(e.id)),
           balance_type=str(e.balance_type) if e.balance_type else None,
           period_type=str(e.period_type) if e.period_type else None,
           element_type=str(e.element_type) if e.element_type else "concept",
@@ -118,7 +121,7 @@ def validate_update_envelope(
         qname=qname,
         name=patch.name if patch.name is not None else str(e.name),
         trait=(
-          patch.trait if patch.trait is not None else _element_classification_hint(e)
+          patch.trait if patch.trait is not None else trait_by_element_id.get(str(e.id))
         ),
         balance_type=(
           patch.balance_type
@@ -272,16 +275,32 @@ def _resolve_foreign_element_qnames(
       qname_by_element_id[eid] = qname
 
 
-def _element_classification_hint(element: Element) -> str | None:
-  """Best-effort EFS trait for projection — None if not carried on the row.
+def _load_efs_traits(
+  session: Session, current_elements: list[Element]
+) -> dict[str, str]:
+  """Primary EFS trait identifier per element id, from the junction table.
 
-  The live DB row doesn't always carry a trait (it lives in the
-  element_traits junction), but for update validation we don't need to
-  re-check traits of rows that already validated at create time. Return
-  None so the CoA type-specific phase skips them (it only rejects *new*
-  rows with missing trait when the payload explicitly adds them).
+  The projection re-runs the create-time phases, and the CoA
+  type-specific phase rejects EVERY element with ``trait=None`` — not
+  just newly added ones — so existing rows must carry their live
+  classification into the virtual create request or any update on a
+  chart_of_accounts block fails validation wholesale.
   """
-  return None
+  if not current_elements:
+    return {}
+  element_ids = [e.id for e in current_elements]
+  return {
+    str(element_id): str(identifier)
+    for element_id, identifier in session.execute(
+      select(ElementTrait.element_id, Trait.identifier)
+      .join(Trait, Trait.id == ElementTrait.trait_id)
+      .where(
+        ElementTrait.element_id.in_(element_ids),
+        ElementTrait.is_primary.is_(True),
+        Trait.category == "elementsOfFinancialStatements",
+      )
+    ).all()
+  }
 
 
 def _validate_rules_to_remove(

--- a/tests/operations/extensions/test_materialize.py
+++ b/tests/operations/extensions/test_materialize.py
@@ -752,3 +752,64 @@ class TestPartialStatusAndSwapGate:
   async def test_error_build_does_not_swap(self):
     client = await self._run_blue_green("error")
     client.swap_database.assert_not_called()
+
+
+class TestScenarioExclusion:
+  """Forecast scenario fact sets must not reach the graph.
+
+  `FactSet.scenario_id` is the scenario axis — NULL means actuals, and
+  `forecast_compute` stamps every scenario month with a non-NULL
+  scenario_id. The graph schema carries no scenario discriminator, so a
+  materialized forecast would blend plan into history for every graph
+  reader (fact grids, Cypher, analytical views). Until an OLAP scenario
+  leg exists, every fact/fact_set projection must exclude scenario rows.
+  """
+
+  GUARDED_FACT_TABLES = [
+    "Fact",
+    "Period",
+    "Unit",
+    "FACT_HAS_ELEMENT",
+    "FACT_HAS_PERIOD",
+    "FACT_HAS_UNIT",
+    "FACT_SET_CONTAINS_FACT",
+  ]
+  FACT_SET_TABLES = ["FactSet", "STRUCTURE_HAS_FACT_SET", "REPORT_HAS_FACT_SET"]
+  JOINED_FACT_TABLES = ["REPORT_HAS_FACT", "FACT_HAS_ENTITY"]
+
+  def test_fact_projections_route_through_scenario_guard(self):
+    tables = _staging_sql(GRAPH_ID, ENTITY_ID, CONNSTR)
+    for name in self.GUARDED_FACT_TABLES:
+      assert "sfs.scenario_id IS NULL" in tables[name], (
+        f"{name} reads facts without the scenario guard"
+      )
+
+  def test_fact_set_projections_filter_scenario(self):
+    tables = _staging_sql(GRAPH_ID, ENTITY_ID, CONNSTR)
+    for name in self.FACT_SET_TABLES:
+      assert "scenario_id IS NULL" in tables[name], (
+        f"{name} projects fact_sets without filtering scenario rows"
+      )
+
+  def test_joined_fact_projections_filter_scenario(self):
+    tables = _staging_sql(GRAPH_ID, ENTITY_ID, CONNSTR)
+    for name in self.JOINED_FACT_TABLES:
+      assert "fs.scenario_id IS NULL" in tables[name], (
+        f"{name} joins fact_sets without filtering scenario rows"
+      )
+
+  def test_fact_has_entity_filters_both_union_branches(self):
+    sql = _staging_sql(GRAPH_ID, ENTITY_ID, CONNSTR)["FACT_HAS_ENTITY"]
+    assert sql.count("fs.scenario_id IS NULL") == 2, (
+      "FACT_HAS_ENTITY has two UNION branches; both must filter scenarios"
+    )
+
+  def test_no_unguarded_facts_scan_anywhere(self):
+    """Completeness sweep: any projection reading facts or fact_sets must
+    carry a scenario filter — catches future projections added without one."""
+    tables = _staging_sql(GRAPH_ID, ENTITY_ID, CONNSTR)
+    for name, sql in tables.items():
+      if "'facts'" in sql or "'fact_sets'" in sql:
+        assert "scenario_id IS NULL" in sql, (
+          f"{name} reads facts/fact_sets without a scenario filter"
+        )

--- a/tests/operations/graph/tasks/test_extensions_materialize.py
+++ b/tests/operations/graph/tasks/test_extensions_materialize.py
@@ -1,0 +1,127 @@
+"""Worker-path extensions materialization task.
+
+The blue/green gate refuses to swap a `partial` build, leaving the old
+graph generation active. The worker task (the path every manual API and
+MCP materialize takes) must treat that exactly like the Dagster path
+does — as a failure that leaves `graph_stale` set so the staleness
+sensor retries — rather than marking the graph fresh over a build that
+never swapped in.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from robosystems.operations.graph.tasks.extensions_materialize import (
+  ExtensionsMaterializeTask,
+)
+
+
+def _make_task() -> ExtensionsMaterializeTask:
+  manager = MagicMock()
+  manager.emit_progress = AsyncMock()
+  task = ExtensionsMaterializeTask(
+    task_id="op_test123",
+    graph_id="kg01234567890abcdef",
+    user_id="user_1",
+    params={"rebuild": True, "lock_key": None},
+    manager=manager,
+  )
+  return task
+
+
+def _result(status: str) -> SimpleNamespace:
+  return SimpleNamespace(
+    status=status,
+    errors=["FactSet: staging count mismatch"] if status != "success" else [],
+    duration_ms=42.0,
+    tables_staged=3,
+    tables_materialized=["Entity", "Element"],
+    total_rows=100,
+  )
+
+
+def _db_session_gen(db: MagicMock):
+  yield db
+
+
+class TestPartialBuildNotMarkedFresh:
+  @pytest.mark.asyncio
+  async def test_partial_short_circuits_before_mark_fresh(self):
+    """A partial build must not clear staleness — the swap was refused."""
+    task = _make_task()
+    db = MagicMock()
+
+    materializer = MagicMock()
+    materializer.materialize = AsyncMock(return_value=_result("partial"))
+
+    with (
+      patch(
+        "robosystems.operations.extensions.materialize.ExtensionsMaterializer",
+        return_value=materializer,
+      ),
+      patch(
+        "robosystems.database.get_db_session",
+        return_value=_db_session_gen(db),
+      ),
+    ):
+      result = await task.execute()
+
+    assert result["status"] == "partial"
+    assert result["errors"]
+    # The graph row must never be touched: no query, no mark_fresh.
+    db.query.assert_not_called()
+
+  @pytest.mark.asyncio
+  async def test_error_short_circuits_before_mark_fresh(self):
+    task = _make_task()
+    db = MagicMock()
+
+    materializer = MagicMock()
+    materializer.materialize = AsyncMock(return_value=_result("error"))
+
+    with (
+      patch(
+        "robosystems.operations.extensions.materialize.ExtensionsMaterializer",
+        return_value=materializer,
+      ),
+      patch(
+        "robosystems.database.get_db_session",
+        return_value=_db_session_gen(db),
+      ),
+    ):
+      result = await task.execute()
+
+    assert result["status"] == "error"
+    db.query.assert_not_called()
+
+  @pytest.mark.asyncio
+  async def test_success_marks_fresh(self):
+    """Guard against overcorrection: a clean build still clears staleness."""
+    task = _make_task()
+    db = MagicMock()
+    graph = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = graph
+
+    materializer = MagicMock()
+    materializer.materialize = AsyncMock(return_value=_result("success"))
+
+    with (
+      patch(
+        "robosystems.operations.extensions.materialize.ExtensionsMaterializer",
+        return_value=materializer,
+      ),
+      patch(
+        "robosystems.database.get_db_session",
+        return_value=_db_session_gen(db),
+      ),
+      patch(
+        "robosystems.dagster.reporting.report_asset_materialization",
+        new=AsyncMock(),
+      ),
+    ):
+      result = await task.execute()
+
+    assert result["status"] == "success"
+    graph.mark_fresh.assert_called_once_with(session=db)

--- a/tests/operations/roboledger/reads/test_account_rollups.py
+++ b/tests/operations/roboledger/reads/test_account_rollups.py
@@ -1,0 +1,195 @@
+"""Account rollups read — balance filtering against a real Postgres.
+
+The rollup SQL once carried its `status = 'posted'` and posting-date
+predicates on a `LEFT JOIN ... ON` clause, where they filter nothing:
+line items from draft or out-of-window entries still landed in the
+sums, so the lead schedule disagreed with the trial balance for the
+same mapping and window. These tests run the real SQL against a real
+Postgres schema — the defect class is invisible to MagicMock sessions.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import date
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+import robosystems.models.extensions  # noqa: F401  (register models on ExtensionsBase)
+from robosystems.db.extensions import ExtensionsBase
+from robosystems.models.extensions import Association, Element, Structure, Taxonomy
+from robosystems.models.extensions.roboledger.entry import Entry
+from robosystems.models.extensions.roboledger.line_item import LineItem
+from robosystems.operations.roboledger.reads.account_rollups import (
+  get_account_rollups,
+)
+
+pytestmark = pytest.mark.unit
+
+JUNE_START = date(2026, 6, 1)
+JUNE_END = date(2026, 6, 30)
+
+
+@pytest.fixture()
+def ext_session():
+  """Extensions schema in the test Postgres DB, one throwaway schema per test."""
+  database_url = os.environ.get("TEST_DATABASE_URL")
+  if not database_url:
+    pytest.skip("TEST_DATABASE_URL not configured")
+
+  schema = f"ext_rollup_{uuid.uuid4().hex[:12]}"
+  engine = create_engine(database_url)
+  with engine.begin() as conn:
+    conn.execute(text(f'CREATE SCHEMA "{schema}"'))
+
+  session = sessionmaker(bind=engine)()
+  session.execute(text(f'SET search_path TO "{schema}"'))
+  ExtensionsBase.metadata.create_all(bind=session.connection())
+  session.commit()
+  session.execute(text(f'SET search_path TO "{schema}"'))
+
+  try:
+    yield session
+  finally:
+    session.rollback()
+    session.close()
+    with engine.begin() as conn:
+      conn.execute(text(f'DROP SCHEMA "{schema}" CASCADE'))
+    engine.dispose()
+
+
+@pytest.fixture()
+def seeded_mapping(ext_session):
+  """A CoA mapping with posted, draft, and out-of-window activity.
+
+  - Sales (4000) -> Revenue: $8,500 posted June credit, $412,000 posted
+    May credit (out of window), $9,999 draft June credit.
+  - Equipment (1500) -> PP&E: mapped, zero activity.
+  """
+  taxonomy = Taxonomy(name="Mapping", taxonomy_type="mapping")
+  ext_session.add(taxonomy)
+  ext_session.flush()
+
+  mapping = Structure(
+    name="QB to rs-gaap", block_type="coa_mapping", taxonomy_id=taxonomy.id
+  )
+  ext_session.add(mapping)
+  ext_session.flush()
+
+  sales = Element(name="Sales", code="4000", balance_type="credit")
+  revenue = Element(name="Revenue", qname="rs-gaap:Revenue", balance_type="credit")
+  equipment = Element(name="Equipment", code="1500", balance_type="debit")
+  ppe = Element(name="PP&E", qname="rs-gaap:PPE", balance_type="debit")
+  ext_session.add_all([sales, revenue, equipment, ppe])
+  ext_session.flush()
+
+  ext_session.add_all(
+    [
+      Association(
+        structure_id=mapping.id,
+        from_element_id=sales.id,
+        to_element_id=revenue.id,
+        association_type="mapping",
+      ),
+      Association(
+        structure_id=mapping.id,
+        from_element_id=equipment.id,
+        to_element_id=ppe.id,
+        association_type="mapping",
+      ),
+    ]
+  )
+
+  def _entry_with_line(posting_date: date, status: str, credit_cents: int) -> None:
+    entry = Entry(
+      posting_date=posting_date,
+      status=status,
+      created_by="usr_test",
+    )
+    ext_session.add(entry)
+    ext_session.flush()
+    ext_session.add(
+      LineItem(
+        entry_id=entry.id,
+        element_id=sales.id,
+        debit_amount=0,
+        credit_amount=credit_cents,
+      )
+    )
+
+  _entry_with_line(date(2026, 6, 15), "posted", 850_000)  # $8,500 in window
+  _entry_with_line(date(2026, 5, 20), "posted", 41_200_000)  # $412,000 prior
+  _entry_with_line(date(2026, 6, 16), "draft", 999_900)  # $9,999 draft
+  ext_session.flush()
+
+  return mapping
+
+
+def _row_by_account(response, account_code: str):
+  for group in response.groups:
+    for row in group.accounts:
+      if row.account_code == account_code:
+        return row
+  return None
+
+
+class TestAccountRollupBalanceFiltering:
+  def test_window_excludes_drafts_and_prior_periods(self, ext_session, seeded_mapping):
+    """June window must report June's posted $8,500 — not $420,500 + drafts."""
+    response = get_account_rollups(
+      ext_session,
+      mapping_id=str(seeded_mapping.id),
+      start_date=JUNE_START,
+      end_date=JUNE_END,
+    )
+
+    sales = _row_by_account(response, "4000")
+    assert sales is not None
+    assert sales.total_credits == 8_500.0
+    assert sales.total_debits == 0.0
+    assert sales.net_balance == 8_500.0
+
+  def test_unwindowed_call_still_excludes_drafts(self, ext_session, seeded_mapping):
+    """No window: all posted activity sums, drafts still excluded."""
+    response = get_account_rollups(ext_session, mapping_id=str(seeded_mapping.id))
+
+    sales = _row_by_account(response, "4000")
+    assert sales is not None
+    assert sales.total_credits == 420_500.0
+
+  def test_zero_activity_account_stays_visible(self, ext_session, seeded_mapping):
+    """The lead schedule shows every mapped account, activity or not."""
+    response = get_account_rollups(
+      ext_session,
+      mapping_id=str(seeded_mapping.id),
+      start_date=JUNE_START,
+      end_date=JUNE_END,
+    )
+
+    equipment = _row_by_account(response, "1500")
+    assert equipment is not None
+    assert equipment.total_debits == 0.0
+    assert equipment.total_credits == 0.0
+    assert equipment.net_balance == 0.0
+
+  def test_agrees_with_trial_balance_shape(self, ext_session, seeded_mapping):
+    """Same predicate semantics as get_trial_balance for the same window."""
+    from robosystems.operations.roboledger.reads.trial_balance import (
+      get_trial_balance,
+    )
+
+    rollups = get_account_rollups(
+      ext_session,
+      mapping_id=str(seeded_mapping.id),
+      start_date=JUNE_START,
+      end_date=JUNE_END,
+    )
+    tb = get_trial_balance(ext_session, start_date=JUNE_START, end_date=JUNE_END)
+
+    sales_rollup = _row_by_account(rollups, "4000")
+    sales_tb = next(r for r in tb.rows if r.account_code == "4000")
+    assert sales_rollup.total_credits == sales_tb.total_credits
+    assert sales_rollup.total_debits == sales_tb.total_debits

--- a/tests/operations/taxonomy_block/test_update_validator_coa_traits.py
+++ b/tests/operations/taxonomy_block/test_update_validator_coa_traits.py
@@ -1,0 +1,140 @@
+"""Update-path projection must carry live EFS traits — real Postgres.
+
+The projection synthesizes a virtual create request from live rows and
+re-runs the create phases. The CoA type-specific phase rejects EVERY
+element with ``trait=None`` — so a projection that drops existing
+elements' classifications 422s every update on a chart_of_accounts
+block, however small the delta. Traits live in the element_traits
+junction, not on the Element row, so this needs a real session.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+import robosystems.models.extensions  # noqa: F401  (register models on ExtensionsBase)
+from robosystems.db.extensions import ExtensionsBase
+from robosystems.models.api.taxonomy_block import (
+  ElementUpdatePatch,
+  TaxonomyBlockElementRequest,
+  UpdateTaxonomyBlockRequest,
+)
+from robosystems.models.extensions import Element, ElementTrait, Taxonomy, Trait
+from robosystems.operations.taxonomy_block.update_validator import (
+  validate_update_envelope,
+)
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture()
+def ext_session():
+  """Extensions schema in the test Postgres DB, one throwaway schema per test."""
+  database_url = os.environ.get("TEST_DATABASE_URL")
+  if not database_url:
+    pytest.skip("TEST_DATABASE_URL not configured")
+
+  schema = f"ext_coaupd_{uuid.uuid4().hex[:12]}"
+  engine = create_engine(database_url)
+  with engine.begin() as conn:
+    conn.execute(text(f'CREATE SCHEMA "{schema}"'))
+
+  session = sessionmaker(bind=engine)()
+  session.execute(text(f'SET search_path TO "{schema}"'))
+  ExtensionsBase.metadata.create_all(bind=session.connection())
+  session.commit()
+  session.execute(text(f'SET search_path TO "{schema}"'))
+
+  try:
+    yield session
+  finally:
+    session.rollback()
+    session.close()
+    with engine.begin() as conn:
+      conn.execute(text(f'DROP SCHEMA "{schema}" CASCADE'))
+    engine.dispose()
+
+
+@pytest.fixture()
+def coa_taxonomy(ext_session):
+  """A minimal chart_of_accounts block whose traits live in the junction."""
+  taxonomy = Taxonomy(name="Tenant CoA", taxonomy_type="chart_of_accounts")
+  ext_session.add(taxonomy)
+  ext_session.flush()
+
+  cash = Element(
+    name="Cash",
+    qname="rl:Cash",
+    code="1000",
+    balance_type="debit",
+    period_type="instant",
+    taxonomy_id=taxonomy.id,
+  )
+  rent = Element(
+    name="Rent Expense",
+    qname="rl:RentExpense",
+    code="6000",
+    balance_type="debit",
+    period_type="duration",
+    taxonomy_id=taxonomy.id,
+  )
+  ext_session.add_all([cash, rent])
+  ext_session.flush()
+
+  asset_trait = Trait(category="elementsOfFinancialStatements", identifier="asset")
+  expense_trait = Trait(category="elementsOfFinancialStatements", identifier="expense")
+  ext_session.add_all([asset_trait, expense_trait])
+  ext_session.flush()
+
+  ext_session.add_all(
+    [
+      ElementTrait(element_id=cash.id, trait_id=asset_trait.id, is_primary=True),
+      ElementTrait(element_id=rent.id, trait_id=expense_trait.id, is_primary=True),
+    ]
+  )
+  ext_session.flush()
+
+  return taxonomy
+
+
+class TestCoaUpdateProjectionTraits:
+  def test_rename_produces_no_missing_classification(self, ext_session, coa_taxonomy):
+    """Renaming one account must not flag every element as unclassified."""
+    payload = UpdateTaxonomyBlockRequest(
+      taxonomy_id=str(coa_taxonomy.id),
+      elements_to_update=[
+        ElementUpdatePatch(qname="rl:Cash", name="Cash and Equivalents")
+      ],
+    )
+
+    issues = validate_update_envelope(ext_session, coa_taxonomy, payload)
+
+    missing = [i for i in issues if i.code == "coa_missing_classification"]
+    assert missing == [], (
+      f"existing elements' live traits must reach the projection; got {missing}"
+    )
+    assert issues == []
+
+  def test_new_element_without_trait_still_flagged(self, ext_session, coa_taxonomy):
+    """The check must keep rejecting genuinely new trait-less elements."""
+    payload = UpdateTaxonomyBlockRequest(
+      taxonomy_id=str(coa_taxonomy.id),
+      elements_to_add=[
+        TaxonomyBlockElementRequest(
+          qname="rl:MysteryAccount",
+          name="Mystery Account",
+          code="9999",
+        )
+      ],
+    )
+
+    issues = validate_update_envelope(ext_session, coa_taxonomy, payload)
+
+    flagged = [i for i in issues if i.code == "coa_missing_classification"]
+    assert len(flagged) == 1
+    assert flagged[0].context["element_qname"] == "rl:MysteryAccount"


### PR DESCRIPTION
## Summary

Four correctness fixes on the RoboLedger surface, from the v1.6 landing review's active tier (vault refs: H1, H6, H8, C1-interim).

**Account rollups filter binding** (`reads/account_rollups.py`): the posted-status and posting-date predicates sat on a `LEFT JOIN ... ON` clause, where they filter nothing — draft and out-of-window line items still landed in the sums, so the lead schedule disagreed with `mappedTrialBalance` for the same mapping and window. Balances now pre-aggregate in a derived table with the predicates inside (mirroring `trial_balance.py`), keeping zero-activity accounts visible.

**CoA update projection traits** (`taxonomy_block/update_validator.py`): the projection stubbed every existing element's trait to `None`, and the create-phase check rejects any `chart_of_accounts` element without one — so every `update-taxonomy-block` call on a CoA block 422'd regardless of the delta. The projection now carries each element's live EFS classification from the `element_traits` junction. New trait-less elements are still rejected.

**Partial materialization freshness** (`graph/tasks/extensions_materialize.py`): the worker path (manual API + MCP materialize) short-circuited only on `error`, so a `partial` build — where blue/green correctly refused the swap — still cleared `graph_stale` and reported success, stopping the staleness sensor from ever retrying. Now mirrors the Dagster path: any non-`success` status leaves staleness set.

**Forecast scenario exclusion** (`extensions/materialize.py`): fact sets stamped with a `scenario_id` (forecast months; NULL means actuals) materialized into the graph with no discriminator, blending plan into history for every graph reader. All fact/fact-set projections now exclude scenario rows; forecasts stay OLTP-only until an OLAP scenario leg exists.

## Testing

- New real-Postgres tests for the rollup SQL (draft/window exclusion, zero-activity visibility, trial-balance agreement) and the CoA update projection — this defect class is invisible to MagicMock sessions.
- Worker-task tests: `partial`/`error` never touch the graph row; `success` still marks fresh.
- Scenario-guard assertions on every fact/fact_set projection, plus a completeness sweep that trips if a future projection reads facts unguarded.
- All four fixes verified red-without/green-with. Scenario SQL additionally executed in real DuckDB against seeded actual+scenario rows: scenario rows excluded from all 12 projections, actuals and fact-set-less facts intact.
- `just test-all` green.