### PR TITLE
Commit QB publish markers at a durability boundary in close-period

### DIFF
--- a/robosystems/operations/roboledger/fiscal_calendar/close_service.py
+++ b/robosystems/operations/roboledger/fiscal_calendar/close_service.py
@@ -172,8 +172,12 @@ class PeriodCloseService:
      configured but the pivot fails. Runs after the draft→posted
      transition because the pivot reads posted entries only.
 
-  Callers commit the session. All failures raise domain exceptions that
-  the REST / MCP caller translates into its native error format.
+  Callers commit the session. One exception: the QB pre-publish step
+  (2b, before any close mutation) commits its own qb_external_id
+  markers — they record external writes that already happened and must
+  survive a failed close (see `_publish_drafts_to_qb`). All failures
+  raise domain exceptions that the REST / MCP caller translates into
+  its native error format.
 
   ``statement_stamper`` is injectable for tests; the default resolves
   :func:`stamp_canonical_statement_sets` lazily so this module stays
@@ -224,9 +228,11 @@ class PeriodCloseService:
     # 2b. Pre-publish step. For graphs with a QB connection in
     # `write_policy='qb_authoritative'` / `'hybrid'`, batch-publish every
     # in-period draft Entry whose triggering Event has
-    # `source IN ('schedule', 'manual')`. Atomic: any QB rejection
-    # raises `WritebackFailed` before the draft→posted transition
-    # below, rolling back the entire close.
+    # `source IN ('schedule', 'manual')`. Any QB rejection raises
+    # `WritebackFailed` before the draft→posted transition below, so the
+    # close itself never half-runs — but the step COMMITS the
+    # qb_external_id markers for entries that did reach QB (see its
+    # docstring), so a failed close never re-publishes them on retry.
     self._publish_drafts_to_qb(
       session, graph_id, period_start, period_end, actor_id=actor_id
     )
@@ -412,11 +418,20 @@ class PeriodCloseService:
     every in-period draft Entry whose triggering Event has
     ``source IN ('schedule', 'manual')`` to that QB connection.
 
-    Atomic: any per-event QB rejection collects into a list and raises
-    `WritebackFailed` BEFORE the close's draft→posted transition,
-    rolling back the entire close transaction. The operator fixes the
-    offending entries (mapping issue, balance error, period closed
-    in QB) and retries.
+    Any per-event QB rejection collects into a list and raises
+    `WritebackFailed` BEFORE the close's draft→posted transition, so no
+    close state mutates on failure. The operator fixes the offending
+    entries (mapping issue, balance error, period closed in QB) and
+    retries.
+
+    NOT atomic with the close, deliberately: each successful publish
+    stamps `Event.metadata['qb_external_id']` — the only dedupe marker —
+    and those markers are COMMITTED at the end of this step, before any
+    failure can roll them back. A QB JournalEntry is an external write
+    that already happened; losing its marker to a rollback would make
+    the retried close re-publish the same drafts as duplicates in the
+    customer's QuickBooks. Retries skip already-marked events via
+    `select_writeback_eligible_entries`.
 
     Skipped silently when:
     - No QB connection on the graph has qb_authoritative / hybrid policy
@@ -514,6 +529,17 @@ class PeriodCloseService:
             "qb_error": {"code": type(e).__name__, "message": str(e)},
           }
         )
+
+    # Durability boundary: the qb_external_id markers written by the loop
+    # record JournalEntries that now exist in QuickBooks, so they must
+    # survive whatever happens to the rest of the close. This is the
+    # close's first mutation point, and the tenant search_path is a plain
+    # (non-LOCAL) SET that survives commit. Without this commit, a later
+    # failure — the WritebackFailed below, a StatementStampError, a
+    # failed final commit — would roll the markers back while the QB
+    # writes stand, and the retried close would re-publish the same
+    # drafts into QuickBooks as duplicates.
+    session.commit()
 
     if failed_events:
       raise WritebackFailed(failed_events)

--- a/tests/operations/roboledger/fiscal_calendar/test_close_publish_durability.py
+++ b/tests/operations/roboledger/fiscal_calendar/test_close_publish_durability.py
@@ -1,0 +1,211 @@
+"""Close-period QB publish durability — real Postgres transactions.
+
+`_publish_drafts_to_qb` POSTs real JournalEntries to QuickBooks and
+stamps `Event.metadata['qb_external_id']` — the only dedupe marker —
+into the caller's open transaction. If a later failure rolled those
+markers back while the QB writes stand, the retried close would
+re-publish the same drafts as duplicates in the customer's QuickBooks.
+The step must commit the markers before any failure can lose them.
+
+These tests use a real Postgres session: the defect is commit/rollback
+ordering, which a MagicMock session structurally cannot observe.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import UTC, date, datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+import robosystems.models.extensions  # noqa: F401  (register models on ExtensionsBase)
+from robosystems.db.extensions import ExtensionsBase
+from robosystems.models.extensions.roboledger.entry import Entry
+from robosystems.models.extensions.roboledger.event import Event
+from robosystems.operations.roboledger.fiscal_calendar.close_service import (
+  PeriodCloseService,
+  WritebackFailed,
+)
+from robosystems.operations.roboledger.fiscal_calendar.qb_writeback import (
+  WritebackConnection,
+)
+
+pytestmark = pytest.mark.unit
+
+GRAPH_ID = "kg01234567890abcdef"
+JUNE_START = date(2026, 6, 1)
+JUNE_END = date(2026, 6, 30)
+
+
+@pytest.fixture()
+def ext_session():
+  """Extensions schema in the test Postgres DB, one throwaway schema per test."""
+  database_url = os.environ.get("TEST_DATABASE_URL")
+  if not database_url:
+    pytest.skip("TEST_DATABASE_URL not configured")
+
+  schema = f"ext_qbpub_{uuid.uuid4().hex[:12]}"
+  engine = create_engine(database_url)
+  with engine.begin() as conn:
+    conn.execute(text(f'CREATE SCHEMA "{schema}"'))
+
+  session = sessionmaker(bind=engine)()
+  session.execute(text(f'SET search_path TO "{schema}"'))
+  ExtensionsBase.metadata.create_all(bind=session.connection())
+  session.commit()
+  session.execute(text(f'SET search_path TO "{schema}"'))
+
+  try:
+    yield session
+  finally:
+    session.rollback()
+    session.close()
+    with engine.begin() as conn:
+      conn.execute(text(f'DROP SCHEMA "{schema}" CASCADE'))
+    engine.dispose()
+
+
+def _seed_draft(session, memo: str) -> tuple[Entry, Event]:
+  event = Event(
+    event_type="schedule_entry_due",
+    event_category="recognition",
+    occurred_at=datetime(2026, 6, 15, tzinfo=UTC),
+    source="manual",
+    created_by="usr_test",
+  )
+  session.add(event)
+  session.flush()
+  entry = Entry(
+    posting_date=date(2026, 6, 15),
+    status="draft",
+    memo=memo,
+    created_by="usr_test",
+    triggered_by_event_id=event.id,
+  )
+  session.add(entry)
+  session.flush()
+  return entry, event
+
+
+def _mark_published(session, event_id: str, qb_id: str) -> None:
+  """What execute_event_block does on success: stamp the dedupe marker."""
+  event = session.get(Event, event_id)
+  event.metadata_ = {**(event.metadata_ or {}), "qb_external_id": qb_id}
+  session.flush()
+
+
+def _writeback_connection():
+  return WritebackConnection(connection_id="conn_qb1", write_policy="qb_authoritative")
+
+
+def _platform_session_factory():
+  factory = MagicMock()
+  factory.return_value.__enter__ = MagicMock(return_value=MagicMock())
+  factory.return_value.__exit__ = MagicMock(return_value=False)
+  return factory
+
+
+def _publish(session, fake_execute):
+  """Run the pre-publish step with the QB boundary faked out."""
+  svc = PeriodCloseService()
+  with (
+    patch(
+      "robosystems.operations.roboledger.fiscal_calendar.qb_writeback.resolve_writeback_connection",
+      return_value=_writeback_connection(),
+    ),
+    patch("robosystems.database.SessionFactory", new=_platform_session_factory()),
+    patch(
+      "robosystems.operations.event_block.commands.execute_event_block",
+      side_effect=fake_execute,
+    ),
+  ):
+    svc._publish_drafts_to_qb(
+      session, GRAPH_ID, JUNE_START, JUNE_END, actor_id="usr_test"
+    )
+
+
+class TestPublishMarkerDurability:
+  def test_markers_survive_rollback_after_partial_failure(self, ext_session):
+    """Three publish, one rejected: the three markers must survive the
+    close rollback that WritebackFailed triggers."""
+    ok_entries = [_seed_draft(ext_session, f"dep {i}") for i in range(3)]
+    bad_entry, bad_event = _seed_draft(ext_session, "rejected one")
+    ext_session.commit()
+
+    def fake_execute(session, request, created_by):
+      if request.event_id == str(bad_event.id):
+        return SimpleNamespace(
+          status="pending",
+          qb_error={"code": "6000", "message": "period closed in QB"},
+        )
+      _mark_published(session, request.event_id, f"qb_{request.event_id[-6:]}")
+      return SimpleNamespace(status="fulfilled", qb_error=None)
+
+    with pytest.raises(WritebackFailed):
+      _publish(ext_session, fake_execute)
+
+    # The caller (extensions_session) rolls back on the domain exception.
+    ext_session.rollback()
+
+    for _entry, event in ok_entries:
+      persisted = ext_session.get(Event, event.id)
+      ext_session.refresh(persisted)
+      assert persisted.metadata_.get("qb_external_id"), (
+        "published marker was rolled back — retry would duplicate the QB entry"
+      )
+    ext_session.refresh(ext_session.get(Event, bad_event.id))
+    assert not ext_session.get(Event, bad_event.id).metadata_.get("qb_external_id")
+
+  def test_retry_skips_already_published_entries(self, ext_session):
+    """The retried close must publish ONLY the previously failed draft."""
+    for i in range(3):
+      _seed_draft(ext_session, f"dep {i}")
+    _bad_entry, bad_event = _seed_draft(ext_session, "rejected one")
+    ext_session.commit()
+
+    def first_attempt(session, request, created_by):
+      if request.event_id == str(bad_event.id):
+        return SimpleNamespace(status="pending", qb_error={"code": "6000"})
+      _mark_published(session, request.event_id, f"qb_{request.event_id[-6:]}")
+      return SimpleNamespace(status="fulfilled", qb_error=None)
+
+    with pytest.raises(WritebackFailed):
+      _publish(ext_session, first_attempt)
+    ext_session.rollback()
+
+    published_on_retry: list[str] = []
+
+    def second_attempt(session, request, created_by):
+      published_on_retry.append(request.event_id)
+      _mark_published(session, request.event_id, "qb_retry")
+      return SimpleNamespace(status="fulfilled", qb_error=None)
+
+    _publish(ext_session, second_attempt)
+
+    assert published_on_retry == [str(bad_event.id)], (
+      f"retry must re-publish only the failed draft, got {published_on_retry}"
+    )
+
+  def test_markers_survive_rollback_after_downstream_failure(self, ext_session):
+    """All publish fine, then a later close step fails (e.g. statement
+    stamping): the rollback must not take the markers with it."""
+    entry, event = _seed_draft(ext_session, "june depreciation")
+    ext_session.commit()
+
+    def fake_execute(session, request, created_by):
+      _mark_published(session, request.event_id, "qb_ok")
+      return SimpleNamespace(status="fulfilled", qb_error=None)
+
+    _publish(ext_session, fake_execute)
+
+    # Simulate StatementStampError later in the close: caller rolls back.
+    ext_session.rollback()
+
+    persisted = ext_session.get(Event, event.id)
+    ext_session.refresh(persisted)
+    assert persisted.metadata_.get("qb_external_id") == "qb_ok"


### PR DESCRIPTION
## Summary

Close-period's QB pre-publish step POSTs real JournalEntries to QuickBooks and stamps `Event.metadata['qb_external_id']` — the only dedupe marker — inside the caller's open transaction. Any later failure (a rejected draft in the same batch, a statement-stamp error, a failed final commit) rolled the markers back while the QB writes stood, so the retried close re-published the same drafts as duplicate entries in the customer's QuickBooks. Classic dual-write with no durable marker.

The publish step now commits the session at the end of the loop — before `WritebackFailed` and before any close mutation can fail. The markers record external writes that already happened, so they must survive whatever happens to the rest of the close; the close itself still never half-runs (the publish step precedes the draft→posted transition, and the tenant `search_path` is a plain `SET` that survives the commit). Docstrings that claimed full atomicity are corrected to describe the boundary.

## Testing

New real-Postgres tests (`test_close_publish_durability.py`) — the defect is commit/rollback ordering, which MagicMock sessions structurally cannot observe:
- 3-of-4 publish, one rejected → markers for the three survive the rollback; the rejected event stays unmarked.
- Retry after failure publishes only the previously failed draft.
- All publish fine, downstream close step fails → markers survive.

All three fail against the pre-fix code. Full `just test-all` green (12,016 passed).

Ref: v16-landing-review H2 (vault).