### PR TITLE
Support curated release notes for milestone releases

### DIFF
--- a/.github/release-notes/README.md
+++ b/.github/release-notes/README.md
@@ -1,0 +1,33 @@
+# Curated release notes
+
+`tag-release.yml` generates the GitHub release body from a Claude-written
+changelog of the changes since the last tag. That framing suits routine
+releases but reads poorly for a milestone, where the story is what the version
+*is* rather than what changed since last Tuesday.
+
+To override it, commit the notes here as `v<version>.md` **before** dispatching
+`create-release.yml`. The file has to exist at the tagged ref, so it belongs in
+release prep alongside the version bump — not added afterwards. When the file is
+present the workflow uses it verbatim and skips the generated changelog, the
+release-statistics section, and the generated-with footer.
+
+No file, no change: the release falls back to the generated changelog. Skipping
+a release is a normal outcome, not a failure.
+
+## Writing a new one
+
+Write the body only. The workflow supplies the `# RoboSystems Service v<version>`
+heading and the links section, so don't repeat them here — start at the first
+line of prose.
+
+The filename is version-specific on purpose: a leftover file can never be picked
+up by a later release.
+
+## Archived notes
+
+`v1.4.0.md` and `v1.5.0.md` predate this mechanism. They are the release bodies
+as published on GitHub, copied here verbatim so the writing lives in the repo
+rather than only in GitHub's database. They keep their original headings and
+trailing links, so treat them as records rather than as templates for the
+format above. Neither can affect a release — their tags already exist, so the
+workflow short-circuits before reading them.

--- a/.github/release-notes/v1.4.0.md
+++ b/.github/release-notes/v1.4.0.md
@@ -1,0 +1,101 @@
+# RoboSystems v1.4.0
+
+**The Platform Release** — 97 releases, 252 merged PRs, 879 commits, 8 weeks of relentless production hardening. v1.4.0 marks the completion of the core platform build and the transition to integration expansion.
+
+## What v1.3 Built
+
+v1.3.0 (Dec 23, 2025) shipped with Dagster replacing Celery and a functional but unproven SEC pipeline. Over 97 patch releases, the platform was battle-tested, hardened, and scaled into production readiness.
+
+### SEC Pipeline — Production Proven
+
+The SEC EDGAR pipeline went from "it works locally" to a production-grade system processing thousands of XBRL filings:
+
+- **EFTS-based discovery** with intelligent rate limiting and quarterly partitions
+- **Two-stage materialization**: DuckDB staging → LadybugDB (retry-safe, incremental)
+- **Batch consolidated processing** for efficient large filing sets
+- **20-F/40-F international filing support** (foreign filers)
+- **Hash-based batching** for deterministic materialization
+- **`sec_historical` subgraph** — 2009-2023 filing data alongside current `sec` database
+- **Self-contained adapter pattern** — client, processors, and pipeline all in one package (`adapters/sec/`)
+
+### Shared Replica Fleet — Three Architectures in Eight Weeks
+
+The read replica infrastructure evolved through three complete architectures to find the right model:
+
+| Model | Startup | Complexity | Result |
+|-------|---------|------------|--------|
+| EBS Snapshots | ~30 min | High (snapshot → template → refresh) | Too slow, too complex |
+| S3 ATTACH (httpfs) | ~20 min | High (~800 LOC S3-specific pool code) | Catalog namespace bugs |
+| **Local Download** | **~10 min** | **Low (standard file path)** | **Production model** |
+
+The final architecture downloads `.lbug` files from S3 to local NVMe on boot — same code path as user graphs, no special-casing.
+
+Auto-scaling with CPU + memory target tracking, configurable warmup periods, and ALB health gating round out the fleet.
+
+### MCP Tools — 15 Tools for AI Agents
+
+- **7 core tools**: Schema discovery, Cypher queries, fact exploration, example queries
+- **3 memory tools**: `write-graph-cypher`, `add-node-table`, `add-relationship-table` (with shared repo write protection)
+- **5 feature-gated tools**: Workspace CRUD, fact grid
+
+### Infrastructure Maturation
+
+- **GitHub OIDC** — zero AWS credentials in repositories
+- **SSM-only bastion** — no SSH keys, no public IPs
+- **SSM Parameter Store** for runtime feature flags and tuning (free tier, immediate effect)
+- **TuningConfig** — runtime-adjustable admission control, cache TTLs, load shedding
+- **EBS lifecycle management** via AWS DLM
+- **Graph deprovisioning** with admin endpoints and feature flags
+- **Backup expiration policies** (90-day) with daily cleanup jobs
+- **Neo4j backend removed** — LadybugDB is the only graph backend
+
+### Security Hardening
+
+- RDS encryption at rest
+- JWT revocation grace period
+- Admin API restricted to internal access
+- Shared repository write protection (subgraphs read-only)
+- `ACTIONS_TOKEN` elimination from cross-repo workflows
+
+### Billing & Subscriptions
+
+- Stripe webhook handlers for payment events
+- Invoice sync and capture improvements
+- Subscription cancellation on provisioning failure
+- Credit system wired end-to-end (AI operations only)
+
+### Deployment & CI/CD
+
+- Automated release flow with deployment summaries
+- API and Dagster deploys decoupled
+- Replica fleet deploys independently from writers
+- Registry scan limits to prevent CI timeouts
+- Fork-friendly bootstrap (`just bootstrap` → `just deploy prod`)
+
+## By the Numbers
+
+| Metric | Value |
+|--------|-------|
+| Releases | 97 (v1.3.0 → v1.3.96 → v1.4.0) |
+| Merged PRs | 252 (#100 → #362) |
+| Total Commits | 879 |
+| Files Changed | 563 |
+| Lines Added | 62,737 |
+| Lines Removed | 27,555 |
+| Net New Lines | +35,182 |
+| Duration | 53 days (Dec 23, 2025 → Feb 14, 2026) |
+
+## What's Next (v1.4.x)
+
+v1.4.0 closes the platform build. The system is stable, production-proven, and ready for integration expansion:
+
+- **QuickBooks Pipeline** (#118) — first dbt-based adapter, OAuth integration, real customer data
+- **Schema Management** (#351) — custom graph schema tooling
+- **LadybugDB Version Migration** (#350) — database upgrade pipeline
+- **SEC Launch** — marketing, content, early adopter onboarding
+
+The platform is built. Time to fill it with data.
+
+---
+
+**Full Changelog:** [v1.3.0...v1.4.0](https://github.com/RoboFinSystems/robosystems/compare/v1.3.0...v1.4.0)

--- a/.github/release-notes/v1.5.0.md
+++ b/.github/release-notes/v1.5.0.md
@@ -1,0 +1,41 @@
+# RoboSystems v1.5.0 — The Extensions Surface
+
+The 1.4 line built one thing end to end: the **extensions surface** — a transactional (OLTP) system-of-record that complements the existing columnar SEC graph (OLAP), so private-company data can be authored, validated, and materialized into the knowledge graph. v1.4.0 stood up the OLAP side; **v1.5.0 marks the extensions surface as a coherent multi-product platform.**
+
+This is a **minor** release: backward-compatible accretion. Throughout the 1.4 line the surface was developed behind feature flags and held off per-environment while it matured. **As of 1.5.0 it graduates to a first-class, default-on product surface** — the flags (`ROBOLEDGER_ENABLED`, `EXTENSIONS_GRAPHQL_ENABLED`, `CONNECTIONS_ENABLED`) now serve as per-deployment scoping and kill switches rather than a hide-incomplete-work gate. The 1.5 line is where this foundation gets patched and extended with new capabilities and an expanding product surface.
+
+## The four-part architecture
+
+1. **Typed GraphQL read surface** — `POST /extensions/{graph_id}/graphql` (Strawberry + GraphiQL in dev), graph-scoped at the URL, with complexity/depth guards and async context.
+2. **CQRS command + analytics surface** — `POST /extensions/{domain}/{graph_id}/operations/*` for command writes and analytical views (e.g. `build-fact-grid`), all returning the `OperationEnvelope` contract with `Idempotency-Key` support.
+3. **Molecules, not atoms** — the write surface is **Information Blocks**, **Taxonomy Blocks**, and **Event Blocks** (registry-driven, rule-evaluated envelopes) — no raw atom CRUD.
+4. **OLTP → OLAP materialization** — DuckDB `postgres_scanner` bridge into LadybugDB with blue/green rebuild and busy-counter safety.
+
+## Highlights
+
+**Information Block subsystem** — registry-driven operations with a rule-evaluation engine; statement, schedule, reconciliation, rollforward, policy, and metric block types; structural auto-rule emission; verification summaries.
+
+**Event-driven ledger (REA)** — event-driven transaction handling with canonical action verbs, AR/AP duality links, payment/discharge resolution, and the REA Agent (counterparty) model.
+
+**Taxonomy library** — the curated `rs-gaap` framework anchored to FAC; per-tenant library copy with sharp tenant curation (`tenant_copy`); calc/label/presentation/reporting-style packages; structural validators (structure, coverage, package integrity); library resync; immutability triggers.
+
+**Reporting & rendering** — compositional reporting styles with presets and a `change-reporting-style` operation; derived-and-persisted subtotal facts; indirect cash-flow derivation from first-class flow concepts; comprehensive-income structures; PP&E/depreciation synthesis; auto-derived retained earnings; trial balance.
+
+**Fiscal close & schedules** — fiscal-calendar service, period close with rule evaluation and a close gate over pending obligations, `promote-obligations`; authored schedules with event-driven obligations, a rollforward filter engine, and roll-forward opening-balance facts.
+
+**QuickBooks & connections** — QuickBooks sync (incremental + full-rebuild, distributed locking), per-connection write policy (`qb_authoritative` default), write-back with a close-draft outbox preview, Intuit token revocation on disconnect, and soft-delete connections that preserve tenant data for re-OAuth.
+
+**Serialization & XBRL** — publish-time JSON-LD report bundle on an XBRL-aligned RDF ontology, an XBRL 2.1 emitter, opt-in SHACL validation captured on the Report, and presigned bundle downloads.
+
+**Products** — **RoboLedger** (the AI controller layer over QuickBooks) is the launch-headline product. **RoboInvestor** ships alongside it and is enabled (portfolio/security/position blocks, cross-graph report sharing), providing the investor-analysis surface that interoperates with the ledger via report sharing.
+
+**Platform hardening** — fail-closed migration entrypoint; tenant DDL fan-out guard + `add_tenant_column` helper; SSM-tunable extensions connection pool; JWT session versioning; worker ECS scale-in protection; EBS pre-detach snapshots and Lambda liveness alarms.
+
+## Compatibility
+
+- **Minor / backward-compatible.** No contract breaks. The new `extensions` database has an independent migration history (`0001→0018`) on the shared RDS instance; the platform database is untouched.
+- **The extensions surface is enabled by default**, including both RoboLedger and RoboInvestor. Feature flags remain for per-deployment scoping and as kill switches.
+
+---
+
+**Span:** 1,611 commits · 358 PRs · 1,686 files · +584,735 / −60,457 · `v1.4.0…v1.5.0`

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -60,6 +60,25 @@ jobs:
             echo "Tag v${{ steps.get-version.outputs.version }} does not exist yet"
           fi
 
+      - name: Check for curated release notes
+        if: steps.check-tag.outputs.tag_exists == 'false'
+        id: curated-notes
+        env:
+          VERSION: ${{ steps.get-version.outputs.version }}
+        run: |
+          # Milestone releases ship hand-written notes committed at
+          # .github/release-notes/v<version>.md; when present they replace
+          # the generated delta changelog below.
+          NOTES_FILE=".github/release-notes/v${VERSION}.md"
+          if [ -f "$NOTES_FILE" ]; then
+            echo "found=true" >> $GITHUB_OUTPUT
+            echo "path=$NOTES_FILE" >> $GITHUB_OUTPUT
+            echo "📝 Curated release notes found: $NOTES_FILE"
+          else
+            echo "found=false" >> $GITHUB_OUTPUT
+            echo "No curated notes at $NOTES_FILE — generating changelog from changes since last tag"
+          fi
+
       - name: Analyze changes since last release
         if: steps.check-tag.outputs.tag_exists == 'false'
         id: analyze-changes
@@ -125,7 +144,7 @@ jobs:
           } >> $GITHUB_OUTPUT
 
       - name: Generate changelog with Claude
-        if: steps.check-tag.outputs.tag_exists == 'false'
+        if: steps.check-tag.outputs.tag_exists == 'false' && steps.curated-notes.outputs.found != 'true'
         id: generate-changelog
         # Untrusted inputs (commit messages, changed filenames) reach the shell
         # only through env vars, never ${{ }} interpolation. In the unquoted
@@ -181,7 +200,7 @@ jobs:
           echo "✅ Changelog prompt created"
 
       - name: Call Claude API for changelog
-        if: steps.check-tag.outputs.tag_exists == 'false'
+        if: steps.check-tag.outputs.tag_exists == 'false' && steps.curated-notes.outputs.found != 'true'
         id: claude-changelog
         run: |
           # Check if ANTHROPIC_API_KEY is available
@@ -254,6 +273,58 @@ jobs:
             echo "EOF"
           } >> $GITHUB_OUTPUT
 
+      - name: Compose release body
+        if: steps.check-tag.outputs.tag_exists == 'false'
+        # The changelog (Claude-generated or curated) is untrusted relative to
+        # the shell — emit it with printf/cat from env vars and files, never by
+        # splicing ${{ ... }} into the script.
+        env:
+          VERSION: ${{ steps.get-version.outputs.version }}
+          CURATED_FOUND: ${{ steps.curated-notes.outputs.found }}
+          CURATED_PATH: ${{ steps.curated-notes.outputs.path }}
+          CHANGELOG: ${{ steps.claude-changelog.outputs.changelog }}
+          LAST_TAG: ${{ steps.analyze-changes.outputs.last_tag }}
+          COMMITS_COUNT: ${{ steps.analyze-changes.outputs.commits_count }}
+          FILES_CHANGED: ${{ steps.analyze-changes.outputs.files_changed }}
+          ADDITIONS: ${{ steps.analyze-changes.outputs.additions }}
+          DELETIONS: ${{ steps.analyze-changes.outputs.deletions }}
+        run: |
+          if [ "$CURATED_FOUND" = "true" ]; then
+            cp "$CURATED_PATH" /tmp/release_changelog.md
+          else
+            printf '%s\n' "$CHANGELOG" > /tmp/release_changelog.md
+          fi
+
+          {
+            echo "# RoboSystems Service v${VERSION}"
+            echo ""
+            cat /tmp/release_changelog.md
+            echo ""
+            echo "---"
+            echo ""
+            if [ "$CURATED_FOUND" != "true" ]; then
+              echo "## 📊 Release Statistics"
+              echo ""
+              echo "- **Commits:** ${COMMITS_COUNT}"
+              echo "- **Files Changed:** ${FILES_CHANGED}"
+              echo "- **Lines Added:** ${ADDITIONS}"
+              echo "- **Lines Deleted:** ${DELETIONS}"
+              echo "- **Previous Release:** ${LAST_TAG}"
+              echo ""
+            fi
+            echo "## 🔗 Links"
+            echo ""
+            echo "- **Full Changelog:** [${LAST_TAG}...v${VERSION}](https://github.com/${{ github.repository }}/compare/${LAST_TAG}...v${VERSION})"
+            echo "- **All Releases:** [View all releases](https://github.com/${{ github.repository }}/releases)"
+            if [ "$CURATED_FOUND" != "true" ]; then
+              echo ""
+              echo "---"
+              echo "🤖 Generated with [Claude Code](https://claude.ai/code)"
+            fi
+          } > /tmp/release_body.md
+
+          echo "✅ Release body composed ($([ "$CURATED_FOUND" = "true" ] && echo "curated notes" || echo "generated changelog"))"
+
       - name: Create Release Tag
         if: steps.check-tag.outputs.tag_exists == 'false'
         run: |
@@ -268,28 +339,7 @@ jobs:
         with:
           tag_name: v${{ steps.get-version.outputs.version }}
           name: Release v${{ steps.get-version.outputs.version }}
-          body: |
-            # RoboSystems Service v${{ steps.get-version.outputs.version }}
-
-            ${{ steps.claude-changelog.outputs.changelog }}
-
-            ---
-
-            ## 📊 Release Statistics
-
-            - **Commits:** ${{ steps.analyze-changes.outputs.commits_count }}
-            - **Files Changed:** ${{ steps.analyze-changes.outputs.files_changed }}
-            - **Lines Added:** ${{ steps.analyze-changes.outputs.additions }}
-            - **Lines Deleted:** ${{ steps.analyze-changes.outputs.deletions }}
-            - **Previous Release:** ${{ steps.analyze-changes.outputs.last_tag }}
-
-            ## 🔗 Links
-
-            - **Full Changelog:** [${{ steps.analyze-changes.outputs.last_tag }}...v${{ steps.get-version.outputs.version }}](https://github.com/${{ github.repository }}/compare/${{ steps.analyze-changes.outputs.last_tag }}...v${{ steps.get-version.outputs.version }})
-            - **All Releases:** [View all releases](https://github.com/${{ github.repository }}/releases)
-
-            ---
-            🤖 Generated with [Claude Code](https://claude.ai/code)
+          body_path: /tmp/release_body.md
           draft: false
           prerelease: false
         env:
@@ -298,11 +348,9 @@ jobs:
 
       - name: Create release summary
         if: steps.check-tag.outputs.tag_exists == 'false'
-        # CHANGELOG is Claude-generated from the untrusted commit/file inputs, so
-        # route it through env — its markdown must not break out of the echo into
-        # the shell (same reason the prompt inputs use env above).
-        env:
-          CHANGELOG: ${{ steps.claude-changelog.outputs.changelog }}
+        # The changelog (Claude-generated or curated) is untrusted, so it is read
+        # from the file written by the compose step — its markdown must not break
+        # out into the shell (same reason the prompt inputs use env above).
         run: |
           VERSION="${{ steps.get-version.outputs.version }}"
 
@@ -317,8 +365,8 @@ jobs:
           echo "- **Lines Deleted:** ${{ steps.analyze-changes.outputs.deletions }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Previous Release:** ${{ steps.analyze-changes.outputs.last_tag }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### 🤖 Claude-Generated Changelog" >> $GITHUB_STEP_SUMMARY
-          echo "$CHANGELOG" >> $GITHUB_STEP_SUMMARY
+          echo "### 📝 Changelog" >> $GITHUB_STEP_SUMMARY
+          cat /tmp/release_changelog.md >> $GITHUB_STEP_SUMMARY
 
       - name: Set outputs
         id: set-outputs

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -51,13 +51,15 @@ jobs:
 
       - name: Check If Tag Exists
         id: check-tag
+        env:
+          VERSION: ${{ steps.get-version.outputs.version }}
         run: |
-          if [ $(git tag -l "v${{ steps.get-version.outputs.version }}") ]; then
+          if [ -n "$(git tag -l "v${VERSION}")" ]; then
             echo "tag_exists=true" >> $GITHUB_OUTPUT
-            echo "Tag v${{ steps.get-version.outputs.version }} already exists"
+            echo "Tag v${VERSION} already exists"
           else
             echo "tag_exists=false" >> $GITHUB_OUTPUT
-            echo "Tag v${{ steps.get-version.outputs.version }} does not exist yet"
+            echo "Tag v${VERSION} does not exist yet"
           fi
 
       - name: Check for curated release notes
@@ -82,11 +84,12 @@ jobs:
       - name: Analyze changes since last release
         if: steps.check-tag.outputs.tag_exists == 'false'
         id: analyze-changes
+        env:
+          VERSION: ${{ steps.get-version.outputs.version }}
         run: |
-          VERSION="${{ steps.get-version.outputs.version }}"
-
-          # Get the last release tag
-          LAST_TAG=$(git tag --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+          # Anchored at both ends so only strict vMAJOR.MINOR.PATCH tags are
+          # eligible; LAST_TAG is interpolated into git commands below.
+          LAST_TAG=$(git tag --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
 
           if [ -z "$LAST_TAG" ]; then
             echo "No previous release found, analyzing all commits"
@@ -202,9 +205,12 @@ jobs:
       - name: Call Claude API for changelog
         if: steps.check-tag.outputs.tag_exists == 'false' && steps.curated-notes.outputs.found != 'true'
         id: claude-changelog
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CLAUDE_MODEL: ${{ vars.CLAUDE_MODEL || 'claude-sonnet-4-6' }}
         run: |
           # Check if ANTHROPIC_API_KEY is available
-          if [ -z "${{ secrets.ANTHROPIC_API_KEY }}" ]; then
+          if [ -z "$ANTHROPIC_API_KEY" ]; then
             echo "::notice::ANTHROPIC_API_KEY not set - using basic changelog"
             CHANGELOG="## What's Changed"$'\n\n'
             CHANGELOG="${CHANGELOG}- ${{ steps.analyze-changes.outputs.commits_count }} commits with ${{ steps.analyze-changes.outputs.files_changed }} files changed"$'\n'
@@ -226,7 +232,7 @@ jobs:
 
           # Create a proper JSON payload using jq to handle escaping
           PAYLOAD=$(jq -n \
-            --arg model "${{ vars.CLAUDE_MODEL || 'claude-sonnet-4-6' }}" \
+            --arg model "$CLAUDE_MODEL" \
             --arg content "$PROMPT" \
             '{
               "model": $model,
@@ -239,11 +245,15 @@ jobs:
               ]
             }')
 
-          RESPONSE=$(curl -s --max-time 60 --retry 3 --retry-delay 10 -X POST "https://api.anthropic.com/v1/messages" \
-            -H "Content-Type: application/json" \
-            -H "x-api-key: ${{ secrets.ANTHROPIC_API_KEY }}" \
-            -H "anthropic-version: 2023-06-01" \
-            -d "$PAYLOAD")
+          # The API key is handed to curl through a config file on stdin rather
+          # than an -H flag. A "-H x-api-key: $VAR" form would not help: the
+          # shell expands the variable before exec, so the literal key would
+          # still sit in the curl process's argv for the life of the request.
+          RESPONSE=$(printf 'header = "x-api-key: %s"\n' "$ANTHROPIC_API_KEY" |
+            curl -s --config - --max-time 60 --retry 3 --retry-delay 10 -X POST "https://api.anthropic.com/v1/messages" \
+              -H "Content-Type: application/json" \
+              -H "anthropic-version: 2023-06-01" \
+              -d "$PAYLOAD")
 
           # Check for API errors
           if echo "$RESPONSE" | jq -e '.error' > /dev/null; then
@@ -327,11 +337,13 @@ jobs:
 
       - name: Create Release Tag
         if: steps.check-tag.outputs.tag_exists == 'false'
+        env:
+          VERSION: ${{ steps.get-version.outputs.version }}
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "v${{ steps.get-version.outputs.version }}" -m "Release v${{ steps.get-version.outputs.version }}"
-          git push origin "v${{ steps.get-version.outputs.version }}"
+          git tag -a "v${VERSION}" -m "Release v${VERSION}"
+          git push origin "v${VERSION}"
 
       - name: Create GitHub Release
         if: steps.check-tag.outputs.tag_exists == 'false'
@@ -351,9 +363,10 @@ jobs:
         # The changelog (Claude-generated or curated) is untrusted, so it is read
         # from the file written by the compose step — its markdown must not break
         # out into the shell (same reason the prompt inputs use env above).
+        env:
+          VERSION: ${{ steps.get-version.outputs.version }}
+          LAST_TAG: ${{ steps.analyze-changes.outputs.last_tag }}
         run: |
-          VERSION="${{ steps.get-version.outputs.version }}"
-
           echo "## 🚀 Release v$VERSION Created" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Release URL:** [v$VERSION](https://github.com/${{ github.repository }}/releases/tag/v$VERSION)" >> $GITHUB_STEP_SUMMARY
@@ -363,7 +376,7 @@ jobs:
           echo "- **Files Changed:** ${{ steps.analyze-changes.outputs.files_changed }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Lines Added:** ${{ steps.analyze-changes.outputs.additions }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Lines Deleted:** ${{ steps.analyze-changes.outputs.deletions }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Previous Release:** ${{ steps.analyze-changes.outputs.last_tag }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Previous Release:** ${LAST_TAG}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### 📝 Changelog" >> $GITHUB_STEP_SUMMARY
           cat /tmp/release_changelog.md >> $GITHUB_STEP_SUMMARY
@@ -371,8 +384,9 @@ jobs:
       - name: Set outputs
         id: set-outputs
         if: steps.check-tag.outputs.tag_exists == 'false'
+        env:
+          VERSION: ${{ steps.get-version.outputs.version }}
         run: |
-          VERSION="${{ steps.get-version.outputs.version }}"
           TAG_NAME="v$VERSION"
           RELEASE_URL="https://github.com/${{ github.repository }}/releases/tag/$TAG_NAME"
 

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -84,11 +84,10 @@ jobs:
       - name: Analyze changes since last release
         if: steps.check-tag.outputs.tag_exists == 'false'
         id: analyze-changes
-        env:
-          VERSION: ${{ steps.get-version.outputs.version }}
         run: |
-          # Anchored at both ends so only strict vMAJOR.MINOR.PATCH tags are
-          # eligible; LAST_TAG is interpolated into git commands below.
+          # Get the last release tag. The pattern is anchored at both ends so only
+          # a strict vMAJOR.MINOR.PATCH tag can be selected: LAST_TAG flows into
+          # later git commands and prompt text, so it must not carry trailing text.
           LAST_TAG=$(git tag --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
 
           if [ -z "$LAST_TAG" ]; then
@@ -245,12 +244,15 @@ jobs:
               ]
             }')
 
-          # The API key is handed to curl through a config file on stdin rather
-          # than an -H flag. A "-H x-api-key: $VAR" form would not help: the
-          # shell expands the variable before exec, so the literal key would
-          # still sit in the curl process's argv for the life of the request.
-          RESPONSE=$(printf 'header = "x-api-key: %s"\n' "$ANTHROPIC_API_KEY" |
-            curl -s --config - --max-time 60 --retry 3 --retry-delay 10 -X POST "https://api.anthropic.com/v1/messages" \
+            # The credential is fed to curl through a config file on stdin rather
+            # than an -H flag. Writing -H "x-api-key: $ANTHROPIC_API_KEY" would not
+            # help: the shell expands the variable before exec, so the literal key
+            # still lands in the curl process argv, which any other process on the
+            # runner can read. printf is a bash builtin, so it adds no process of
+            # its own, and curl parses the config at startup so --retry resends the
+            # header correctly.
+          RESPONSE=$(printf 'header = "x-api-key: %s"\n' "$ANTHROPIC_API_KEY" \
+            | curl -s --config - --max-time 60 --retry 3 --retry-delay 10 -X POST "https://api.anthropic.com/v1/messages" \
               -H "Content-Type: application/json" \
               -H "anthropic-version: 2023-06-01" \
               -d "$PAYLOAD")

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -476,6 +476,7 @@ Command groups: `subscriptions`, `invoices`, `credits`, `graphs`, `users`, `orgs
 - **GitHub-hosted runners** (default): Used for tests, builds, and deployments
 - **Self-hosted runners** (optional): Set `RUNNER_LABELS` repo variable to use self-hosted runners
 - **Deployments**: Manual workflow dispatch via `staging.yml` and `prod.yml`
+- **Release notes**: `tag-release.yml` auto-generates the changelog from changes since the last tag (via the Claude API). For milestone releases, commit curated notes to `.github/release-notes/v<version>.md` _before_ dispatching `create-release.yml` — when that file exists at the tagged ref it replaces the generated changelog (and the stats section is skipped)
 - **Infrastructure Config**: `.github/configs/graph.yml`
 
 ## AWS Infrastructure


### PR DESCRIPTION
## Summary

`tag-release.yml` normally builds the GitHub release body from a Claude-generated changelog of `git diff <last-tag>..HEAD`. That is the right default for routine patch releases, but it is the wrong artifact for a milestone release, where the notes want to be written by hand.

This adds an opt-in override: if `.github/release-notes/v<version>.md` exists at the tagged ref, its contents are used as the release body verbatim.

## Mechanism

1. New step `Check for curated release notes` (after `Check If Tag Exists`) probes for `.github/release-notes/v<version>.md` and sets `found` / `path` outputs.
2. `Generate changelog with Claude` and `Call Claude API for changelog` gain `&& steps.curated-notes.outputs.found != 'true'` — no Claude API call is made for a curated release.
3. New step `Compose release body` writes `/tmp/release_changelog.md` and `/tmp/release_body.md`. In curated mode it omits the "Release Statistics" block (delta stats are meaningless framing for milestone notes) and the "🤖 Generated with Claude Code" footer (the notes are not generated).
4. `Create GitHub Release` switches from an inline `body: |` block to `body_path:`, and `Create release summary` reads the composed changelog file instead of interpolating the changelog output.

The header, links section, and (in the default path) the statistics block and footer are reproduced line-for-line from the previous inline template, so **when no curated file exists the release body is byte-for-byte identical to today**. Verified by rendering both the old template and the new compose step against the same inputs and diffing.

Security discipline is preserved: the changelog — generated or curated — is untrusted relative to the shell, so it reaches the script only through env vars and files (`printf` / `cat`), never spliced in via `${{ ... }}`.

## Why the filename is version-specific

`v<version>.md` is keyed to the version read from `pyproject.toml`, so a leftover notes file can never leak into a later release: `v1.6.31` never picks up `v1.6.30.md`. Curating a release is an explicit, per-version act — commit the file before dispatching `create-release.yml`, and every other release keeps the generated changelog with no cleanup step required.

## Test plan

- [x] `yamllint` clean apart from the file's pre-existing line-length/comment-style warnings; YAML parses (12 steps).
- [x] Default path (no curated file): compose step output diffed byte-for-byte against the previous inline `body: |` template with representative inputs — identical, including the stats block and footer.
- [x] Curated path: stats block and footer omitted, curated markdown passes through verbatim, shell metacharacters in the changelog body stay literal.
- [ ] Confirmed end-to-end on the next release run (default path exercised by any routine release; curated path by the first milestone that ships a notes file).

No release-notes file is added here — mechanism only.

Aligns this repo with roboledger-app PR #280.

---

## Archived notes (second commit)

The `v1.4.0` and `v1.5.0` release bodies were written by hand and lived only in GitHub's release database — unversioned, and lost if a release is edited or the repo is mirrored elsewhere. They are copied into `.github/release-notes/` verbatim, along with a README covering how to author a new one.

Neither file can affect a release: both tags already exist, so `Check If Tag Exists` short-circuits the job before the curated-notes check runs. They are records, not templates — they keep the original heading and trailing links that the workflow would otherwise supply, which the README calls out.

The other 26 major/minor releases across the ecosystem still carry the generator footer, so they were left alone rather than enshrining machine-written delta summaries as the house style.


---

A third commit hardens input and credential handling in the same workflow; the release body and step summary are unchanged in both curated and generated modes.
