### PR TITLE
Backfill minor release-note archives

### DIFF
--- a/.github/release-notes/README.md
+++ b/.github/release-notes/README.md
@@ -25,9 +25,11 @@ up by a later release.
 
 ## Archived notes
 
-`v1.4.0.md` and `v1.5.0.md` predate this mechanism. They are the release bodies
-as published on GitHub, copied here verbatim so the writing lives in the repo
-rather than only in GitHub's database. They keep their original headings and
-trailing links, so treat them as records rather than as templates for the
-format above. Neither can affect a release — their tags already exist, so the
-workflow short-circuits before reading them.
+Every minor release from `v1.0.0` through `v1.6.0` predates this mechanism.
+Their files are the release bodies as published on GitHub, copied here verbatim
+so the writing lives in the repo rather than only in GitHub's database
+(`v1.4.0`/`v1.5.0` were archived first; the rest were backfilled 2026-08-04).
+They keep their original headings and trailing links, so treat them as records
+rather than as templates for the format above. None of them can affect a
+release — their tags already exist, so the workflow short-circuits before
+reading them.

--- a/.github/release-notes/v1.0.0.md
+++ b/.github/release-notes/v1.0.0.md
@@ -1,0 +1,56 @@
+# RoboSystems Service v1.0.0
+
+## Initial Open Source Release
+
+This is the inaugural open source release of robosystems, providing a complete infrastructure automation and deployment platform.
+
+### 🚀 Key Features
+
+- **Complete Infrastructure as Code**: Comprehensive Terraform configurations for AWS infrastructure deployment
+- **CI/CD Pipeline**: Full GitHub Actions workflow automation for building, testing, and deployment
+- **Multi-Service Architecture**: Support for API, databases (PostgreSQL, Kuzu), caching (Valkey), and monitoring (Prometheus, Grafana)
+- **Container Orchestration**: Docker-based deployments with ECS and Auto Scaling Group management
+- **Worker System**: Distributed task processing with beat scheduling and monitoring capabilities
+- **Development Tools**: Pre-configured development environment with Docker support and editor configurations
+
+### 🏗️ Infrastructure Components
+
+- **Networking**: VPC setup with bastion host access
+- **Storage**: S3 bucket management and Kuzu graph database volumes
+- **Monitoring**: Integrated Prometheus metrics collection and Grafana dashboards
+- **Security**: IAM role management and secure database access patterns
+- **Scalability**: Auto-scaling groups for dynamic resource management
+
+### 🔧 Developer Experience
+
+- Comprehensive GitHub issue templates and contribution guidelines
+- Automated PR testing and deployment workflows
+- Branch protection rules for different workflow stages
+- Self-hosted GitHub Actions runner maintenance automation
+- Environment configuration templates and Docker development setup
+
+### 📋 Technical Notes
+
+- **Total codebase**: 243,000+ lines across 686 files
+- **Deployment targets**: Production and staging environment support
+- **Database migrations**: Automated migration runner workflows
+- **Container refresh**: Automated container and ASG refresh capabilities
+
+---
+
+## 📊 Release Statistics
+
+- **Commits:** 2
+- **Files Changed:** 686
+- **Lines Added:** 243175
+- **Lines Deleted:** 24
+- **Previous Release:** initial
+
+## 🔗 Links
+
+- **Full Changelog:** [initial...v1.0.0](https://github.com/RoboFinSystems/robosystems/compare/initial...v1.0.0)
+- **All Releases:** [View all releases](https://github.com/RoboFinSystems/robosystems/releases)
+
+---
+🤖 Generated with [Claude Code](https://claude.ai/code)
+

--- a/.github/release-notes/v1.1.0.md
+++ b/.github/release-notes/v1.1.0.md
@@ -1,0 +1,61 @@
+# RoboSystems Service v1.1.0
+
+## Release Summary
+
+Version 1.1.0 introduces a major infrastructure overhaul with enhanced Graph API capabilities, improved authentication systems, and comprehensive database management improvements across 441 files and 146 commits.
+
+## ✨ Key Features & Improvements
+
+• **Enhanced Graph API**: Refactored configuration, improved schema validation, and added production-readiness features
+• **Advanced Authentication**: Implemented graph-scoped authentication with improved user context handling
+• **Database Management**: Enhanced DuckDB session management and Kuzu database rebuild processes
+• **Infrastructure Modernization**: Complete worker infrastructure overhaul with updated deployment workflows
+• **Demo & Documentation**: Added comprehensive demo scripts for SEC repository and accounting workflows
+• **File Management**: New ingestion endpoints with improved status handling and error messaging
+
+## ⚠️ Breaking Changes
+
+• **Infrastructure Renaming**: Kuzu-related workflows and components renamed to Graph API equivalents
+• **Authentication Dependencies**: Refactored to use new user context handling system
+• **Deployment Workflows**: Updated permissions and CloudFormation policies may require infrastructure updates
+• **Configuration Changes**: Graph API configuration structure has been modified
+
+## 🔧 Technical Improvements
+
+• **Neo4j Integration**: Added staging mount configuration and CloudWatch log group setup
+• **Distributed Systems**: Added distributed lock TTL configuration for improved reliability  
+• **Database Extensions**: Included Kuzu extensions for DuckDB and HTTPFS support (v0.11.3)
+• **Lambda Functions**: Enhanced monitoring and rotation capabilities for graph instances
+• **Type Safety**: Improved type annotations and error handling throughout graph services
+
+## 🐛 Bug Fixes
+
+• Fixed DuckDB ingestion issues with improved session management
+• Enhanced query parameterization in GraphClient and DuckDBTableManager
+• Resolved credential management issues in demo scripts
+
+## 📋 Infrastructure Changes
+
+• Removed obsolete worker monitoring components
+• Updated CloudFormation log group references and policies
+• Enhanced VSCode workspace configuration and development tools
+• Improved Docker configuration and build processes
+
+---
+
+## 📊 Release Statistics
+
+- **Commits:** 146
+- **Files Changed:** 441
+- **Lines Added:** 36282
+- **Lines Deleted:** 16174
+- **Previous Release:** v1.0.1
+
+## 🔗 Links
+
+- **Full Changelog:** [v1.0.1...v1.1.0](https://github.com/RoboFinSystems/robosystems/compare/v1.0.1...v1.1.0)
+- **All Releases:** [View all releases](https://github.com/RoboFinSystems/robosystems/releases)
+
+---
+🤖 Generated with [Claude Code](https://claude.ai/code)
+

--- a/.github/release-notes/v1.2.0.md
+++ b/.github/release-notes/v1.2.0.md
@@ -1,0 +1,51 @@
+# RoboSystems Service v1.2.0
+
+## Release Summary
+This release introduces a major database migration from Kuzu to Ladybug for graph operations, along with enhanced graph endpoints and improved test coverage across billing and graph functionalities.
+
+## 🚀 New Features & Improvements
+- Enhanced user and subgraph models with new attributes for better data representation
+- Improved database size retrieval capabilities for graph operations
+- Added comprehensive test coverage for billing and graph operations
+- Streamlined graph-api-neo4j service configuration
+
+## ⚠️ Breaking Changes
+- **Database Migration**: Complete replacement of Kuzu graph database with Ladybug
+  - All Kuzu extensions and binaries have been removed
+  - Workflow files have been renamed and reconfigured for Ladybug deployment
+  - Existing graph data may require migration - see migration documentation
+
+## 🔧 Technical Changes
+- **Infrastructure Updates**:
+  - Refactored GitHub Actions workflows for graph deployment (`deploy-kuzu-writers.yml` → `deploy-graph-ladybug.yml`)
+  - Updated deployment configurations across staging and production environments
+  - Modified Docker configurations and Lambda functions for new graph infrastructure
+- **Dependencies**: Updated Python dependencies to support enhanced graph functionality
+- **Configuration**: Comprehensive updates to environment variables, stack configurations, and deployment scripts
+
+## 📚 Documentation & Developer Experience
+- Updated contributing guidelines and security documentation
+- Enhanced README with latest setup instructions
+- Improved development tooling and VS Code task configurations
+
+**Pull Requests**: #82, #83, #84, #85  
+**Changed Files**: 403 files modified with 11,836 lines added and 6,692 lines removed
+
+---
+
+## 📊 Release Statistics
+
+- **Commits:** 11
+- **Files Changed:** 403
+- **Lines Added:** 11836
+- **Lines Deleted:** 6692
+- **Previous Release:** v1.1.14
+
+## 🔗 Links
+
+- **Full Changelog:** [v1.1.14...v1.2.0](https://github.com/RoboFinSystems/robosystems/compare/v1.1.14...v1.2.0)
+- **All Releases:** [View all releases](https://github.com/RoboFinSystems/robosystems/releases)
+
+---
+🤖 Generated with [Claude Code](https://claude.ai/code)
+

--- a/.github/release-notes/v1.3.0.md
+++ b/.github/release-notes/v1.3.0.md
@@ -1,0 +1,56 @@
+# RoboSystems Service v1.3.0
+
+## Release Summary
+
+Version 1.3.0 represents a major infrastructure overhaul focused on migrating from worker-based architecture to Dagster orchestration with ECS Fargate, along with enhanced SEC pipeline processing capabilities.
+
+## 🚀 Key Features & Improvements
+
+- **New Dagster Integration**: Complete migration to Dagster for workflow orchestration with ECS Fargate deployment
+- **Enhanced SEC Pipeline**: Improved parallel processing capabilities with better error handling and UUID management
+- **Lambda Container Support**: Added container image support for Lambda functions with updated deployment workflows
+- **Infrastructure Modernization**: Streamlined GitHub Actions workflows and removed legacy worker configurations
+
+## ⚠️ Breaking Changes
+
+- **Worker Architecture Removed**: Legacy worker infrastructure and GitHub Actions runner configurations have been completely removed
+- **PostgreSQL Stack Refactoring**: PostgreSQL stack names and configurations have been restructured
+- **Workflow Changes**: Multiple GitHub Actions workflows have been consolidated or removed
+
+## 🔧 Notable Technical Changes
+
+- **Database Migrations**: Added new Alembic migration to rename `celery_task_id` to `operation_id` reflecting the shift away from Celery
+- **Container Images**: New `Dockerfile.lambda` for Lambda containerization
+- **Timeout Adjustments**: Increased deployment timeouts for PostgreSQL (15→25 min) and ElastiCache (15→25 min) to accommodate AWS service creation times
+- **Configuration Updates**: Major overhaul of deployment configurations and stack management
+
+## 🐛 Bug Fixes
+
+- Resolved Dagster deployment issues with improved ECS RunLauncher configuration
+- Fixed Lambda image tagging for proper CloudFormation detection
+- Enhanced error logging for better security and debugging clarity
+- Updated psycopg2-binary version compatibility
+
+## 🛡️ Security Improvements
+
+- Enhanced error logging to improve security posture while maintaining debugging capabilities
+- Removed sensitive configuration exposure in legacy worker systems
+
+---
+
+## 📊 Release Statistics
+
+- **Commits:** 47
+- **Files Changed:** 825
+- **Lines Added:** 26718
+- **Lines Deleted:** 49801
+- **Previous Release:** v1.2.5
+
+## 🔗 Links
+
+- **Full Changelog:** [v1.2.5...v1.3.0](https://github.com/RoboFinSystems/robosystems/compare/v1.2.5...v1.3.0)
+- **All Releases:** [View all releases](https://github.com/RoboFinSystems/robosystems/releases)
+
+---
+🤖 Generated with [Claude Code](https://claude.ai/code)
+

--- a/.github/release-notes/v1.6.0.md
+++ b/.github/release-notes/v1.6.0.md
@@ -1,0 +1,56 @@
+# RoboSystems Service v1.6.0
+
+A significant release centered on the **LadybugDB 0.18 upgrade**, overhauling the graph database pipeline to use Apache Arrow for data transfer, introducing a dedicated semantic memory surface, and improving SEC filing ingestion reliability.
+
+## Key Features & Improvements
+
+- **LadybugDB 0.18 upgrade** — Bumped to LadybugDB 0.18.1 with package rename (`real-ladybug` → `ladybug`), encompassing broad changes across the graph API engine, manager, pool, and service layers
+- **Arrow-based data pipeline** — Replaced the DuckDB `ATTACH`-based materialization with a streaming DuckDB → Arrow → LadybugDB pipeline, eliminating intermediate files and enabling zero-copy handoff at the DuckDB→Arrow step
+- **Semantic memory surface** — Added a new dedicated semantic memory router and `memory_store` module backed by LanceDB, cleanly separating vector-index concerns from the core graph API
+- **New `empty` subgraph type** — Introduced an `empty` subgraph type for graphs; retired the legacy `memory` alias and notional `versioned` type
+- **SEC multi-document iXBRL support** — Inline XBRL filings that span multiple documents are now correctly loaded as a document set
+
+## ⚠️ Breaking Changes
+
+- **`memory` subgraph alias removed** — The `memory` subgraph type alias has been retired. Update any graph definitions using `memory` to the appropriate replacement (`empty` or the explicit LanceDB semantic memory surface).
+- **LadybugDB package rename** — The dependency has moved from `real-ladybug` to `ladybug`. Environments pinning the old package name will need updating.
+- **`reporting_style` column migrated** — `graphs.reporting_style_id` has been dropped and moved to the entity-level via a new extensions migration (`0020_entity_reporting_style`). Downstream consumers reading this column from the `graphs` table must update.
+
+## Bug Fixes
+
+- **SEC ingestion** — Processing now correctly fails when a filing yields zero facts instead of silently continuing
+- **Migration export bucket** — Migration exports now upload to the correct `USER_DATA_BUCKET`; the system-backup bucket is properly passed through from the migration worker to the writer
+- **Migration service discovery** — The migration job now correctly reaches `graph_api` by container hostname in dev environments
+- **Migration imports** — Fixed the migration writer to correctly discover and import `LadybugAllocationManager`
+- **Parquet export paths** — Request data is no longer leaked into parquet export file paths
+
+## Infrastructure & Security
+
+- **CI hardening** — Restored `id-token: write` on the Claude review workflow; hardened the `claude.yml` author gate and removed unused permissions
+- **Database cascades** — Added `ON DELETE CASCADE` to the documents foreign key relationship via Alembic migration
+- **Deployment workflows** — Updates across `prod.yml`, `staging.yml`, `create-release.yml`, and `tag-release.yml` for improved reliability
+
+## Notable Technical Changes
+
+- Extensive documentation updates clarifying the Arrow handoff architecture and de-conflating vector-index vs. LanceDB memory concepts
+- DuckDB pool and manager refactored to align with the new Arrow-first data flow
+- 206 files changed across 96 commits (~9,200 lines added, ~4,400 removed)
+
+---
+
+## 📊 Release Statistics
+
+- **Commits:** 96
+- **Files Changed:** 206
+- **Lines Added:** 9247
+- **Lines Deleted:** 4355
+- **Previous Release:** v1.5.17
+
+## 🔗 Links
+
+- **Full Changelog:** [v1.5.17...v1.6.0](https://github.com/RoboFinSystems/robosystems/compare/v1.5.17...v1.6.0)
+- **All Releases:** [View all releases](https://github.com/RoboFinSystems/robosystems/releases)
+
+---
+🤖 Generated with [Claude Code](https://claude.ai/code)
+


### PR DESCRIPTION
Completes the `.github/release-notes/` archive started with v1.4.0/v1.5.0: the published GitHub release bodies for **v1.0.0, v1.1.0, v1.2.0, v1.3.0, and v1.6.0** are copied in verbatim, per the convention documented in the directory README — original headings and trailing links kept, records not templates. Every minor from the 1.0.0 graduation onward now lives in the repo rather than only in GitHub's database.

None of these can affect a release: their tags already exist, so `tag-release.yml` short-circuits before the curated-notes check. The README's archived-notes section is updated to describe the full set.

## Test plan

Docs-only. Verified each fetched body is the complete published release (no CRLF artifacts, correct headings), and that all seven minors v1.0.0–v1.6.0 are now present in the directory.