### PR TITLE
Document the tag-slice scope of generated minor release notes

### DIFF
--- a/.github/release-notes/README.md
+++ b/.github/release-notes/README.md
@@ -33,3 +33,12 @@ They keep their original headings and trailing links, so treat them as records
 rather than as templates for the format above. None of them can affect a
 release — their tags already exist, so the workflow short-circuits before
 reading them.
+
+Read the generated ones for what they are: the workflow diffs from the
+immediately preceding tag, so a generated minor body describes only the final
+slice that carried the bump (`v1.6.0` covers `v1.5.17...v1.6.0`), **not** the
+line it closes — the patch releases of the prior line are summarized in no
+minor's notes. Each file's trailing Full Changelog link states its true span.
+The hand-written `v1.4.0`/`v1.5.0` notes are genuine line retrospectives and
+don't share this limit. When a future minor deserves a line retrospective,
+write a curated file — that's the mechanism above.


### PR DESCRIPTION
Follow-up to #1050. The generated minor bodies in the archive are accurate about their tagged slice but misleading if read as line retrospectives: the workflow diffs from the immediately preceding tag, so `v1.6.0`'s notes cover `v1.5.17...v1.6.0` — the seventeen 1.5.x patches are summarized in no minor's notes. Only the hand-written `v1.4.0`/`v1.5.0` (and `v1.0.0`, which spans from `initial`) are true line summaries.

Rather than rewriting published records, this documents the caveat in the directory README: each file's trailing Full Changelog link states its true span, and a future minor that deserves a line retrospective should get a curated file — which is exactly what the mechanism is for.

## Test plan

Docs-only README change.