### PR TITLE
feat(mcp): add sync-connection tool over a shared connection-sync kernel

### DIFF
--- a/robosystems/middleware/mcp/tools/graph_tools.py
+++ b/robosystems/middleware/mcp/tools/graph_tools.py
@@ -9,10 +9,13 @@ Five tools that mirror a subset of the REST graph lifecycle surface at
 4. `materialize` — rebuild LadybugDB from OLTP (extensions) or staging
 5. `create-backup` — enqueue a full-dump backup (admin)
 
-Plus one platform-DB connection tool that shares the same hand-written
+Plus two platform-DB connection tools that share the same hand-written
 rationale (platform DB, graph-scoped auth, no extensions registrar):
 
 6. `set-write-policy` — opt a connection into / out of outbound write-back
+7. `sync-connection` — trigger a provider resync (the write half of the
+   sync-freshness pair; `get-fiscal-calendar` / `get-graph-sync-status`
+   are the read half)
 
 **Deliberately NOT exposed on MCP:**
 
@@ -36,7 +39,7 @@ not just the bare operation name.
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from typing import Any
 
 from robosystems.logger import logger
@@ -708,6 +711,159 @@ class GetGraphSyncStatusTool:
       }
     finally:
       close()
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# sync-connection
+# ══════════════════════════════════════════════════════════════════════════
+
+
+class SyncConnectionTool:
+  """Trigger a provider resync for this graph's connection.
+
+  The write half of the sync-freshness pair (`get-fiscal-calendar` /
+  `get-graph-sync-status` are the read half). Platform-DB, hand-written
+  for the same reason as `set-write-policy`: `Connection` lives in the
+  platform DB and the op is graph-scoped via the service rather than the
+  extensions registrar. Both this tool and the REST sync endpoint call
+  the same `dispatch_connection_sync` kernel — same lock, same dispatch.
+  """
+
+  def __init__(self, graph_client):
+    self.client = graph_client
+
+  def get_tool_definition(self) -> dict[str, Any]:
+    return {
+      "name": "sync-connection",
+      "description": (
+        "Pull fresh data from this graph's connected source system "
+        "(e.g. QuickBooks) into the ledger. Async — dispatches the "
+        "provider's sync pipeline and returns immediately.\n\n"
+        "**WHEN TO USE:**\n"
+        "- Before a period close when `get-fiscal-calendar` reports the "
+        "`sync_stale` blocker (source sync older than period end) — sync "
+        "first instead of passing `allow_stale_sync=true`\n"
+        "- When the user says the source system has new transactions\n"
+        "- After a code-level chart-of-accounts / mapping change that must "
+        "back-propagate: set `full_rebuild=true`\n\n"
+        "**PARAMETERS:**\n"
+        "- connection_id: Omit to auto-resolve the graph's single sync "
+        "connection; needed only when the graph has several (the error "
+        "lists them).\n"
+        "- provider: Optional auto-resolution filter (e.g. 'quickbooks').\n"
+        "- full_rebuild: EXPENSIVE — re-ingests the entire source history "
+        "and resets captured/classified state. Use only after a code-level "
+        "CoA/mapping change that must back-propagate; the default "
+        "incremental refresh is the common case.\n"
+        "- since_date: Bounded incremental window (YYYY-MM-DD); ignored "
+        "when full_rebuild=true.\n\n"
+        "**COMPLETION:** returns `task_id` once dispatched; the sync runs "
+        "in the background. Poll `get-fiscal-calendar` until "
+        "`last_sync_at` advances past the dispatch time (and any "
+        "`sync_stale` blocker clears) before proceeding with a close. A "
+        "`sync_in_progress` error means a sync is already running — wait "
+        "and poll rather than retrying."
+      ),
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "connection_id": {"type": "string"},
+          "provider": {"type": "string"},
+          "full_rebuild": {"type": "boolean", "default": False},
+          "since_date": {"type": "string", "format": "date"},
+        },
+        "additionalProperties": False,
+      },
+    }
+
+  async def execute(self, arguments: dict[str, Any]) -> dict[str, Any]:
+    from robosystems.operations.connection_service import (
+      AmbiguousSyncConnectionError,
+      ConnectionNotFoundError,
+      NoSyncConnectionError,
+      ProviderUnavailableError,
+      SyncInProgressError,
+      dispatch_connection_sync,
+      resolve_sync_connection,
+    )
+
+    user = _require_user(self.client)
+    if user is None:
+      return _user_missing_err()
+
+    graph_id = self.client.graph_id
+    repo_err = _block_shared_repo(graph_id)
+    if repo_err:
+      return repo_err
+
+    connection_id = arguments.get("connection_id") or None
+    provider = arguments.get("provider") or None
+    full_rebuild = bool(arguments.get("full_rebuild", False))
+    since_date = None
+    since_date_raw = arguments.get("since_date") or None
+    if since_date_raw:
+      try:
+        since_date = date.fromisoformat(since_date_raw)
+      except ValueError:
+        return {
+          "error": "invalid_arguments",
+          "message": f"since_date must be YYYY-MM-DD, got {since_date_raw!r}.",
+        }
+
+    try:
+      if connection_id is None:
+        connection = await resolve_sync_connection(
+          graph_id, str(user.id), provider=provider
+        )
+        connection_id = connection["connection_id"]
+      result = await dispatch_connection_sync(
+        graph_id=graph_id,
+        connection_id=connection_id,
+        user_id=str(user.id),
+        full_rebuild=full_rebuild,
+        since_date=since_date,
+        dispatch_timeout=120,
+      )
+    except NoSyncConnectionError as exc:
+      return {"error": "no_sync_connection", "message": str(exc)}
+    except AmbiguousSyncConnectionError as exc:
+      return {
+        "error": "ambiguous_sync_connection",
+        "message": str(exc),
+        "candidates": exc.candidates,
+      }
+    except ConnectionNotFoundError as exc:
+      return {"error": "connection_not_found", "message": str(exc)}
+    except SyncInProgressError as exc:
+      return {
+        "error": "sync_in_progress",
+        "message": str(exc),
+        "holder_id": exc.holder_id,
+        "ttl_remaining_seconds": exc.ttl_remaining,
+      }
+    except ProviderUnavailableError as exc:
+      return {"error": "provider_unavailable", "message": str(exc)}
+    except TimeoutError:
+      return {
+        "error": "dispatch_timeout",
+        "message": (
+          "Sync dispatch timed out; the job may not have started. "
+          "Check get-fiscal-calendar before retrying."
+        ),
+      }
+    except Exception as exc:
+      logger.error("sync-connection failed for %s: %s", graph_id, exc, exc_info=True)
+      return {"error": "command_failed", "message": str(exc)}
+
+    return {
+      "status": "accepted",
+      **result,
+      "message": (
+        "Sync dispatched. Poll get-fiscal-calendar until last_sync_at "
+        "advances past this dispatch (and any sync_stale blocker clears) "
+        "before closing."
+      ),
+    }
 
 
 # ══════════════════════════════════════════════════════════════════════════

--- a/robosystems/middleware/mcp/tools/instructions.py
+++ b/robosystems/middleware/mcp/tools/instructions.py
@@ -100,6 +100,11 @@ def build_instructions(
       else:
         orient += "."
       close_lines.append(orient)
+    if has("sync-connection"):
+      close_lines.append(
+        "- Stale source data (`sync_stale` blocker)? Pull fresh data with "
+        "`sync-connection`, then re-check `get-fiscal-calendar`."
+      )
     sections.append(_block(*close_lines))
 
   # Chart-of-accounts mapping.

--- a/robosystems/middleware/mcp/tools/manager.py
+++ b/robosystems/middleware/mcp/tools/manager.py
@@ -41,6 +41,7 @@ from .graph_tools import (
   MaterializeTool,
   SetWritePolicyTool,
   SwitchWorkspaceTool,
+  SyncConnectionTool,
 )
 from .graphql_tool import GraphqlQueryTool, GraphqlSchemaTool
 from .schema_tool import SchemaTool
@@ -239,6 +240,15 @@ class GraphMCPTools:
     self.set_write_policy_tool = None
     if not read_only and not self._is_shared_repository():
       self.set_write_policy_tool = SetWritePolicyTool(graph_client)
+
+    # Connection sync — the on-demand resync trigger (write half of the
+    # sync-freshness pair; get-fiscal-calendar / get-graph-sync-status are
+    # the read half). Same gate as set-write-policy: platform-DB,
+    # writable user graphs only — not roboledger-gated because the REST
+    # sync endpoint isn't either.
+    self.sync_connection_tool = None
+    if not read_only and not self._is_shared_repository():
+      self.sync_connection_tool = SyncConnectionTool(graph_client)
 
     # Layer 2: Period-workflow read tools (gated by roboledger extension
     # + ROBOLEDGER_ENABLED). Schedule-specific reads were retired in
@@ -814,6 +824,8 @@ class GraphMCPTools:
     tools.extend(self._get_workspace_tool_definitions())
     if self.set_write_policy_tool is not None:
       tools.append(self.set_write_policy_tool.get_tool_definition())
+    if self.sync_connection_tool is not None:
+      tools.append(self.sync_connection_tool.get_tool_definition())
     tools.extend(self._get_subgraph_write_tool_definitions())
     tools.extend(self._get_semantic_memory_tool_definitions())
     tools.extend(self._get_search_tool_definitions())
@@ -1012,6 +1024,15 @@ class GraphMCPTools:
             "shared-repository graph."
           )
         result = await self.set_write_policy_tool.execute(arguments)
+        return result if return_raw else json.dumps(result, indent=2)
+
+      elif name == "sync-connection":
+        if self.sync_connection_tool is None:
+          raise ValueError(
+            "sync-connection tool is not available on this read-only or "
+            "shared-repository graph."
+          )
+        result = await self.sync_connection_tool.execute(arguments)
         return result if return_raw else json.dumps(result, indent=2)
 
       elif name == "write-graph-cypher":

--- a/robosystems/middleware/mcp/tools/playbook_tools.py
+++ b/robosystems/middleware/mcp/tools/playbook_tools.py
@@ -31,6 +31,10 @@ _RECURRING_SEQUENCE: list[str] = [
   "get-fiscal-calendar — orient: read closed_through, close_target, "
   "closeable_now, blockers, catch_up_sequence. Confirm the period you intend "
   "to close is exactly closed_through + 1.",
+  "If blockers include sync_stale: run sync-connection (incremental, no "
+  "arguments needed — it auto-resolves the graph's sync connection), then "
+  "poll get-fiscal-calendar until last_sync_at advances and the blocker "
+  "clears. Prefer this over closing with allow_stale_sync=true.",
   "get-period-close-status (period_start/period_end as YYYY-MM-DD) — see "
   "which schedules are pending / drafted / posted and their amounts.",
   "promote-obligations (dispatch_handlers=true) — draft every matured "
@@ -47,7 +51,8 @@ _RECURRING_SEQUENCE: list[str] = [
   "close-period (period as YYYY-MM) — atomic: posts the drafts, runs the "
   "balance-sheet equation check, advances closed_through. Use "
   "allow_stale_sync=true only when the user has verified QB is complete "
-  "despite a stale sync.",
+  "despite a stale sync — normally run sync-connection instead (see the "
+  "sync_stale step above).",
 ]
 
 _INITIATE_SEQUENCE: list[str] = [
@@ -146,7 +151,8 @@ _KEY_RULES: list[str] = [
   "comprehensive_income) and 'metric' return HTTP 501 — statements are built "
   "via create-report.",
   "CLOSE BLOCKERS: sequence_violation (close in order), period_incomplete "
-  "(month not over yet), sync_stale (QuickBooks sync older than period end), "
+  "(month not over yet), sync_stale (QuickBooks sync older than period end "
+  "— run sync-connection and poll get-fiscal-calendar until it clears), "
   "calendar_not_initialized, and pending_obligations (matured "
   "schedule_entry_due events still 'pending' at/before the period — run "
   "promote-obligations to draft them, or, if they belong to a "

--- a/robosystems/operations/connection_service.py
+++ b/robosystems/operations/connection_service.py
@@ -3,8 +3,13 @@
 All connection metadata is stored in PostgreSQL (Connection model).
 Encrypted credentials are stored in ConnectionCredentials.
 No graph database operations — connections are platform metadata.
+
+Module-level functions at the bottom form the connection-sync dispatch
+kernel shared by the REST sync endpoint and the `sync-connection` MCP
+tool, so both surfaces validate, lock, and dispatch identically.
 """
 
+from datetime import date
 from typing import Any
 
 from sqlalchemy.orm import Session
@@ -577,3 +582,211 @@ class ConnectionService:
     finally:
       if session_created:
         session.close()
+
+
+class ConnectionSyncError(Exception):
+  """Base for connection-sync dispatch failures."""
+
+
+class ConnectionNotFoundError(ConnectionSyncError):
+  """Connection missing, outside the graph scope, or not owned by the caller."""
+
+
+class ProviderUnavailableError(ConnectionSyncError):
+  """The connection's provider is disabled or unknown."""
+
+
+class SyncInProgressError(ConnectionSyncError):
+  """A sync already holds the per-connection lock."""
+
+  def __init__(
+    self,
+    connection_id: str,
+    holder_id: str | None,
+    ttl_remaining: int | None,
+  ) -> None:
+    self.connection_id = connection_id
+    self.holder_id = holder_id
+    self.ttl_remaining = ttl_remaining
+    super().__init__(
+      f"Sync already in progress for connection {connection_id} "
+      f"(held by {holder_id}, expires in {ttl_remaining}s)"
+    )
+
+
+class NoSyncConnectionError(ConnectionSyncError):
+  """The graph has no syncable connection to resolve."""
+
+
+class AmbiguousSyncConnectionError(ConnectionSyncError):
+  """More than one syncable connection matched; the caller must pick one."""
+
+  def __init__(self, candidates: list[dict[str, Any]]) -> None:
+    self.candidates = candidates
+    listing = ", ".join(
+      f"{c.get('connection_id')} ({c.get('provider')})" for c in candidates
+    )
+    super().__init__(
+      f"Multiple sync connections found; specify connection_id: {listing}"
+    )
+
+
+async def resolve_sync_connection(
+  graph_id: str,
+  user_id: str,
+  provider: str | None = None,
+) -> dict[str, Any]:
+  """Resolve a graph's single syncable connection.
+
+  Considers only connections whose provider is registered (feature-flag
+  enabled). When several rows exist, currently-connected ones win — the
+  same preference `qb_sync_state` applies for the close gate. Refuses to
+  guess between multiple live candidates.
+
+  Raises:
+      NoSyncConnectionError: no syncable connection for the graph.
+      AmbiguousSyncConnectionError: more than one candidate; carries
+          `candidates` so callers can present the choice.
+  """
+  from robosystems.operations.providers.registry import provider_registry
+
+  connections = await ConnectionService.list_connections(
+    graph_id=graph_id, user_id=user_id, provider=provider
+  )
+  candidates = [
+    c for c in connections if provider_registry.is_enabled(c.get("provider", ""))
+  ]
+  connected = [c for c in candidates if c.get("status") == "connected"]
+  pool = connected or candidates
+  if not pool:
+    raise NoSyncConnectionError(
+      f"Graph {graph_id} has no syncable connection"
+      + (f" for provider '{provider}'" if provider else "")
+    )
+  if len(pool) > 1:
+    raise AmbiguousSyncConnectionError(
+      [
+        {
+          "connection_id": c.get("connection_id"),
+          "provider": c.get("provider"),
+          "status": c.get("status"),
+        }
+        for c in pool
+      ]
+    )
+  return pool[0]
+
+
+async def dispatch_connection_sync(
+  *,
+  graph_id: str,
+  connection_id: str,
+  user_id: str,
+  full_rebuild: bool = False,
+  since_date: date | None = None,
+  sync_options: dict[str, object] | None = None,
+  dispatch_timeout: float | None = None,
+) -> dict[str, Any]:
+  """Validate, lock, and dispatch a connection sync (async via Dagster).
+
+  The shared kernel behind `POST .../connections/{id}/sync` and the
+  `sync-connection` MCP tool: graph- and user-scoped connection lookup,
+  provider validation, the per-connection sync lock, and provider
+  dispatch. Completion is observed via `Connection.last_sync` (the load
+  asset updates it), surfaced through `get-fiscal-calendar` and the
+  connections read surface.
+
+  Raises:
+      ConnectionNotFoundError, ProviderUnavailableError,
+      SyncInProgressError. `TimeoutError` propagates when
+      `dispatch_timeout` elapses before the dispatch call returns.
+  """
+  import asyncio
+
+  from robosystems.config.valkey_registry import ValkeyDatabase, create_redis_client
+  from robosystems.middleware.auth.distributed_lock import DistributedLock
+  from robosystems.operations.providers.registry import provider_registry
+
+  connection = await ConnectionService.get_connection(
+    connection_id, user_id, graph_id=graph_id
+  )
+  if not connection:
+    raise ConnectionNotFoundError(f"Connection {connection_id} not found")
+
+  provider = connection["provider"].lower()
+  try:
+    provider_registry.get_provider(provider)
+  except ValueError as e:
+    raise ProviderUnavailableError(str(e)) from e
+
+  # Per-connection sync lock. Two concurrent qb_sync runs against the
+  # same connection_id race on the UPSERT path; the lock serializes
+  # them. 30-min TTL bounds a *stuck* job (Dagster crash mid-sync); the
+  # normal completion path releases the lock explicitly from `qb_load`
+  # via the `sync_lock_id` plumbed through `QBSyncConfig`. The 30-min
+  # number is a safety-net for failed syncs, not an "intentional
+  # cooldown."
+  #
+  # If the same operator mashes "Sync Now" or the OAuth callback races
+  # a scheduler, the second attempt surfaces the holder's lock_id.
+  sync_lock_id: str = ""
+  try:
+    redis_client = create_redis_client(ValkeyDatabase.LOCKS)
+    sync_lock = DistributedLock(
+      redis_client, f"qb_sync:{connection_id}", ttl_seconds=1800
+    )
+    lock_result = sync_lock.acquire(blocking=False)
+    if not lock_result.acquired:
+      raise SyncInProgressError(
+        connection_id, lock_result.holder_id, lock_result.ttl_remaining
+      )
+    # Capture the lock id so the Dagster job can release the lock on
+    # completion. `lock_result.lock_id` is the same value the holder
+    # stored under the lock key; `release_lock_by_id` does an atomic
+    # compare-and-delete against it.
+    sync_lock_id = lock_result.lock_id or ""
+  except SyncInProgressError:
+    raise
+  except Exception as e:
+    # Dashboards watch for `lock_skipped=true` to detect Valkey-
+    # degraded sync runs (we proceed unlocked rather than fail closed,
+    # so the silent race risk is real and worth surfacing).
+    logger.warning(
+      "Could not acquire sync lock for connection %s: %s; "
+      "proceeding without lock (concurrent-sync race still possible)",
+      connection_id,
+      e,
+      extra={
+        "connection_id": connection_id,
+        "lock_skipped": True,
+        "lock_skip_reason": type(e).__name__,
+      },
+    )
+
+  effective_options: dict[str, object] = dict(sync_options or {})
+  if full_rebuild:
+    effective_options["full_rebuild"] = True
+  if since_date is not None:
+    effective_options["since_date"] = since_date.isoformat()
+  # Lock release: pass the acquired lock_id through to QBSyncConfig
+  # so `qb_load` can release it on completion.
+  if sync_lock_id:
+    effective_options["sync_lock_id"] = sync_lock_id
+
+  task_id = await asyncio.wait_for(
+    provider_registry.sync_connection(
+      provider, connection, effective_options or None, graph_id
+    ),
+    timeout=dispatch_timeout,
+  )
+
+  logger.info(f"Sync initiated for connection {connection_id}: task_id={task_id}")
+
+  return {
+    "connection_id": connection_id,
+    "provider": provider,
+    "task_id": task_id,
+    "full_rebuild": bool(full_rebuild),
+    "since_date": since_date.isoformat() if since_date else None,
+    "last_sync_before_dispatch": connection.get("last_sync"),
+  }

--- a/robosystems/operations/providers/registry.py
+++ b/robosystems/operations/providers/registry.py
@@ -117,6 +117,10 @@ class ProviderRegistry:
       # Don't fail initialization if metrics fail
       logger.warning(f"Failed to record feature flag metrics: {e}")
 
+  def is_enabled(self, provider_type: str) -> bool:
+    """Whether a provider is registered (feature-flag enabled)."""
+    return provider_type.lower() in self._providers
+
   def get_provider(self, provider_type: str) -> dict[str, Any]:
     """Get provider configuration."""
     provider_lower = provider_type.lower()

--- a/robosystems/routers/graphs/connections/sync.py
+++ b/robosystems/routers/graphs/connections/sync.py
@@ -2,8 +2,6 @@
 Connection sync endpoint.
 """
 
-import asyncio
-
 from fastapi import APIRouter, Depends, Header, HTTPException, Path, status
 from sqlalchemy.orm import Session
 
@@ -30,11 +28,15 @@ from robosystems.models.api.common import (
 )
 from robosystems.models.api.graphs.connections import SyncConnectionRequest
 from robosystems.models.core import User
-from robosystems.operations.connection_service import ConnectionService
+from robosystems.operations.connection_service import (
+  ConnectionNotFoundError,
+  ProviderUnavailableError,
+  SyncInProgressError,
+  dispatch_connection_sync,
+)
 
 from .utils import (
   create_robustness_components,
-  provider_registry,
   record_operation_failure,
   record_operation_start,
   record_operation_success,
@@ -46,7 +48,7 @@ router = APIRouter()
 @router.post(
   "/{connection_id}/sync",
   summary="Sync Connection",
-  description="SEC: downloads latest EDGAR filings (5-10 min). QuickBooks: fetches transactions, balances, and chart of accounts. Returns an `OperationEnvelope` — monitor progress via SSE at `/v1/operations/{operation_id}/stream`. Supports `Idempotency-Key`.",
+  description="SEC: downloads latest EDGAR filings (5-10 min). QuickBooks: fetches transactions, balances, and chart of accounts. Async — returns an `OperationEnvelope` with the provider task id; completion is reflected in the connection's `last_sync` timestamp. Supports `Idempotency-Key`.",
   response_model=OperationEnvelope,
   status_code=status.HTTP_202_ACCEPTED,
   operation_id="syncConnection",
@@ -121,96 +123,34 @@ async def sync_connection(
       metadata={"connection_id": connection_id},
     )
 
-    # Get connection details
-    connection = await ConnectionService.get_connection(
-      connection_id, current_user.id, graph_id=graph_id
-    )
-
-    if not connection:
+    # Validate, lock, and dispatch via the shared kernel (also behind
+    # the `sync-connection` MCP tool); map domain exceptions to the
+    # HTTP contract this endpoint has always had.
+    try:
+      dispatch = await dispatch_connection_sync(
+        graph_id=graph_id,
+        connection_id=connection_id,
+        user_id=str(current_user.id),
+        full_rebuild=request.full_rebuild,
+        since_date=request.since_date,
+        sync_options=request.sync_options,
+        dispatch_timeout=operation_timeout,
+      )
+    except ConnectionNotFoundError:
       raise create_error_response(
         status_code=status.HTTP_404_NOT_FOUND,
         detail="Connection not found",
         code=ErrorCode.NOT_FOUND,
       )
-
-    provider = connection["provider"].lower()
-
-    # Validate provider is enabled before any sync operations
-    provider_registry.get_provider(provider)
-
-    # Per-connection sync lock. Two concurrent qb_sync runs
-    # against the same connection_id race on the UPSERT path; the
-    # lock serializes them. 30-min TTL bounds a *stuck* job (Dagster
-    # crash mid-sync); the normal completion path releases the lock
-    # explicitly from `qb_load` via the `sync_lock_id` plumbed through
-    # `QBSyncConfig`. The 30-min number is a safety-net for failed
-    # syncs, not an "intentional cooldown."
-    #
-    # If the same operator mashes "Sync Now" or the OAuth callback
-    # races a scheduler, the second attempt returns 409 with the
-    # holder's lock_id.
-    from robosystems.config.valkey_registry import ValkeyDatabase, create_redis_client
-    from robosystems.middleware.auth.distributed_lock import DistributedLock
-
-    sync_lock_id: str = ""
-    try:
-      redis_client = create_redis_client(ValkeyDatabase.LOCKS)
-      sync_lock = DistributedLock(
-        redis_client, f"qb_sync:{connection_id}", ttl_seconds=1800
-      )
-      lock_result = sync_lock.acquire(blocking=False)
-      if not lock_result.acquired:
-        raise create_error_response(
-          status_code=status.HTTP_409_CONFLICT,
-          detail=(
-            f"Sync already in progress for connection {connection_id} "
-            f"(held by {lock_result.holder_id}, "
-            f"expires in {lock_result.ttl_remaining}s)"
-          ),
-          code=ErrorCode.OPERATION_FAILED,
-        )
-      # Capture the lock id so the Dagster job can release the lock
-      # on completion. `lock_result.lock_id` is the same value the
-      # holder stored under the lock key; `release_lock_by_id` does
-      # an atomic compare-and-delete against it.
-      sync_lock_id = lock_result.lock_id or ""
-    except HTTPException:
-      raise
-    except Exception as e:
-      # Dashboards watch for `lock_skipped=true` to detect Valkey-
-      # degraded sync runs (we proceed unlocked rather than fail
-      # closed, so the silent race risk is real and worth surfacing).
-      logger.warning(
-        "Could not acquire sync lock for connection %s: %s; "
-        "proceeding without lock (concurrent-sync race still possible)",
-        connection_id,
-        e,
-        extra={
-          "connection_id": connection_id,
-          "lock_skipped": True,
-          "lock_skip_reason": type(e).__name__,
-        },
+    except SyncInProgressError as e:
+      raise create_error_response(
+        status_code=status.HTTP_409_CONFLICT,
+        detail=str(e),
+        code=ErrorCode.OPERATION_FAILED,
       )
 
-    effective_options: dict[str, object] = dict(request.sync_options or {})
-    if request.full_rebuild:
-      effective_options["full_rebuild"] = True
-    if request.since_date is not None:
-      effective_options["since_date"] = request.since_date.isoformat()
-    # Lock release: pass the acquired lock_id through to QBSyncConfig
-    # so `qb_load` can release it on completion.
-    if sync_lock_id:
-      effective_options["sync_lock_id"] = sync_lock_id
-
-    # Sync using provider registry with timeout coordination
-    task_id = await asyncio.wait_for(
-      provider_registry.sync_connection(
-        provider, connection, effective_options or None, graph_id
-      ),
-      timeout=operation_timeout,
-    )
-
-    logger.info(f"Sync initiated for connection {connection_id}: task_id={task_id}")
+    provider = dispatch["provider"]
+    task_id = dispatch["task_id"]
 
     # Record successful operation
     record_operation_success(
@@ -284,7 +224,7 @@ async def sync_connection(
       error_type="http_exception",
     )
     raise
-  except ValueError as e:
+  except (ProviderUnavailableError, ValueError) as e:
     # Handle disabled provider errors as client errors
     record_operation_failure(
       components=components,

--- a/tests/middleware/mcp/tools/test_graph_tools.py
+++ b/tests/middleware/mcp/tools/test_graph_tools.py
@@ -10,7 +10,7 @@ Covers the six tools in `middleware/mcp/tools/graph_tools.py`:
 6. `GetGraphSyncStatusTool`
 
 Plus the client-side sentinel `SwitchWorkspaceTool` and the platform-DB
-connection tool `SetWritePolicyTool`.
+connection tools `SetWritePolicyTool` and `SyncConnectionTool`.
 
 Shared-repo gate coverage (the primary defense-in-depth concern) lives
 in `tests/routers/graphs/test_ops_shared_repo_gates.py`. This file
@@ -34,6 +34,7 @@ from robosystems.middleware.mcp.tools.graph_tools import (
   MaterializeTool,
   SetWritePolicyTool,
   SwitchWorkspaceTool,
+  SyncConnectionTool,
 )
 
 MODULE = "robosystems.middleware.mcp.tools.graph_tools"
@@ -545,3 +546,129 @@ class TestSetWritePolicyExecute:
         {"connection_id": "conn_x", "write_policy": "native"}
       )
     assert result["error"] == "connection_not_found"
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# SyncConnectionTool
+# ══════════════════════════════════════════════════════════════════════════
+
+_DISPATCH_RESULT = {
+  "connection_id": "conn_1",
+  "provider": "quickbooks",
+  "task_id": "run_123",
+  "full_rebuild": False,
+  "since_date": None,
+  "last_sync_before_dispatch": "2026-07-31T00:00:00+00:00",
+}
+
+
+class TestSyncConnectionDefinition:
+  def test_definition_shape(self) -> None:
+    defn = SyncConnectionTool(_client()).get_tool_definition()
+    assert defn["name"] == "sync-connection"
+    props = defn["inputSchema"]["properties"]
+    assert set(props) == {"connection_id", "provider", "full_rebuild", "since_date"}
+    # No required params — connection auto-resolution is the default path.
+    assert "required" not in defn["inputSchema"]
+    assert props["full_rebuild"]["default"] is False
+
+
+class TestSyncConnectionExecute:
+  @pytest.mark.asyncio
+  async def test_missing_user(self) -> None:
+    client = _client()
+    client.user = None
+    result = await SyncConnectionTool(client).execute({})
+    assert result["error"] == "authentication_required"
+
+  @pytest.mark.asyncio
+  async def test_invalid_since_date(self) -> None:
+    result = await SyncConnectionTool(_client()).execute({"since_date": "07/01/2026"})
+    assert result["error"] == "invalid_arguments"
+
+  @pytest.mark.asyncio
+  async def test_auto_resolves_single_connection(self) -> None:
+    with (
+      patch(
+        f"{CONN_MODULE}.resolve_sync_connection",
+        new=AsyncMock(return_value={"connection_id": "conn_1"}),
+      ) as mock_resolve,
+      patch(
+        f"{CONN_MODULE}.dispatch_connection_sync",
+        new=AsyncMock(return_value=_DISPATCH_RESULT),
+      ) as mock_dispatch,
+    ):
+      result = await SyncConnectionTool(_client()).execute({})
+
+    assert result["status"] == "accepted"
+    assert result["task_id"] == "run_123"
+    assert mock_resolve.call_args.args[0] == GRAPH_ID
+    assert mock_dispatch.call_args.kwargs["connection_id"] == "conn_1"
+    assert mock_dispatch.call_args.kwargs["full_rebuild"] is False
+
+  @pytest.mark.asyncio
+  async def test_explicit_connection_id_skips_resolution(self) -> None:
+    with (
+      patch(
+        f"{CONN_MODULE}.resolve_sync_connection",
+        new=AsyncMock(),
+      ) as mock_resolve,
+      patch(
+        f"{CONN_MODULE}.dispatch_connection_sync",
+        new=AsyncMock(return_value=_DISPATCH_RESULT),
+      ) as mock_dispatch,
+    ):
+      result = await SyncConnectionTool(_client()).execute(
+        {"connection_id": "conn_9", "full_rebuild": True, "since_date": "2026-07-01"}
+      )
+
+    assert result["status"] == "accepted"
+    mock_resolve.assert_not_called()
+    kwargs = mock_dispatch.call_args.kwargs
+    assert kwargs["connection_id"] == "conn_9"
+    assert kwargs["full_rebuild"] is True
+    assert kwargs["since_date"].isoformat() == "2026-07-01"
+
+  @pytest.mark.asyncio
+  async def test_ambiguous_resolution_lists_candidates(self) -> None:
+    from robosystems.operations.connection_service import (
+      AmbiguousSyncConnectionError,
+    )
+
+    candidates = [
+      {"connection_id": "conn_1", "provider": "quickbooks", "status": "connected"},
+      {"connection_id": "conn_2", "provider": "sec", "status": "connected"},
+    ]
+    with patch(
+      f"{CONN_MODULE}.resolve_sync_connection",
+      new=AsyncMock(side_effect=AmbiguousSyncConnectionError(candidates)),
+    ):
+      result = await SyncConnectionTool(_client()).execute({})
+
+    assert result["error"] == "ambiguous_sync_connection"
+    assert result["candidates"] == candidates
+
+  @pytest.mark.asyncio
+  async def test_no_sync_connection(self) -> None:
+    from robosystems.operations.connection_service import NoSyncConnectionError
+
+    with patch(
+      f"{CONN_MODULE}.resolve_sync_connection",
+      new=AsyncMock(side_effect=NoSyncConnectionError("none")),
+    ):
+      result = await SyncConnectionTool(_client()).execute({})
+    assert result["error"] == "no_sync_connection"
+
+  @pytest.mark.asyncio
+  async def test_sync_in_progress_surfaces_holder(self) -> None:
+    from robosystems.operations.connection_service import SyncInProgressError
+
+    with patch(
+      f"{CONN_MODULE}.dispatch_connection_sync",
+      new=AsyncMock(side_effect=SyncInProgressError("conn_1", "holder_abc", 1200)),
+    ):
+      result = await SyncConnectionTool(_client()).execute({"connection_id": "conn_1"})
+
+    assert result["error"] == "sync_in_progress"
+    assert result["holder_id"] == "holder_abc"
+    assert result["ttl_remaining_seconds"] == 1200

--- a/tests/operations/test_connection_service.py
+++ b/tests/operations/test_connection_service.py
@@ -5,7 +5,7 @@ No graph database dependencies.
 """
 
 from datetime import UTC, datetime
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -1117,3 +1117,276 @@ class TestSetWritePolicy:
 
     assert result is not None
     mock_conn.set_write_policy.assert_called_once_with(mock_session, "qb_authoritative")
+
+
+# ---------------------------------------------------------------------------
+# Connection-sync dispatch kernel (resolve_sync_connection /
+# dispatch_connection_sync) — shared by the REST endpoint and the
+# `sync-connection` MCP tool.
+# ---------------------------------------------------------------------------
+
+REGISTRY_MODULE = "robosystems.operations.providers.registry"
+LOCK_MODULE = "robosystems.middleware.auth.distributed_lock"
+VALKEY_MODULE = "robosystems.config.valkey_registry"
+
+
+def _conn_dict(connection_id="conn_1", provider="quickbooks", status="connected"):
+  return {
+    "connection_id": connection_id,
+    "provider": provider,
+    "status": status,
+    "last_sync": "2026-07-31T00:00:00+00:00",
+    "metadata": {"realm_id": "123456"},
+  }
+
+
+class TestResolveSyncConnection:
+  @pytest.mark.asyncio
+  @pytest.mark.unit
+  async def test_no_connections_raises(self):
+    from robosystems.operations.connection_service import (
+      NoSyncConnectionError,
+      resolve_sync_connection,
+    )
+
+    with (
+      patch(
+        f"{MODULE}.ConnectionService.list_connections",
+        new=AsyncMock(return_value=[]),
+      ),
+      patch(f"{REGISTRY_MODULE}.provider_registry") as mock_registry,
+    ):
+      mock_registry.is_enabled.return_value = True
+      with pytest.raises(NoSyncConnectionError):
+        await resolve_sync_connection("kg_test", "usr_123")
+
+  @pytest.mark.asyncio
+  @pytest.mark.unit
+  async def test_single_connection_resolves(self):
+    from robosystems.operations.connection_service import resolve_sync_connection
+
+    with (
+      patch(
+        f"{MODULE}.ConnectionService.list_connections",
+        new=AsyncMock(return_value=[_conn_dict()]),
+      ),
+      patch(f"{REGISTRY_MODULE}.provider_registry") as mock_registry,
+    ):
+      mock_registry.is_enabled.return_value = True
+      result = await resolve_sync_connection("kg_test", "usr_123")
+
+    assert result["connection_id"] == "conn_1"
+
+  @pytest.mark.asyncio
+  @pytest.mark.unit
+  async def test_disabled_provider_filtered_out(self):
+    from robosystems.operations.connection_service import (
+      NoSyncConnectionError,
+      resolve_sync_connection,
+    )
+
+    with (
+      patch(
+        f"{MODULE}.ConnectionService.list_connections",
+        new=AsyncMock(return_value=[_conn_dict(provider="quickbooks")]),
+      ),
+      patch(f"{REGISTRY_MODULE}.provider_registry") as mock_registry,
+    ):
+      mock_registry.is_enabled.return_value = False
+      with pytest.raises(NoSyncConnectionError):
+        await resolve_sync_connection("kg_test", "usr_123")
+
+  @pytest.mark.asyncio
+  @pytest.mark.unit
+  async def test_prefers_connected_over_stale_rows(self):
+    from robosystems.operations.connection_service import resolve_sync_connection
+
+    rows = [
+      _conn_dict(connection_id="conn_old", status="error"),
+      _conn_dict(connection_id="conn_live", status="connected"),
+    ]
+    with (
+      patch(
+        f"{MODULE}.ConnectionService.list_connections",
+        new=AsyncMock(return_value=rows),
+      ),
+      patch(f"{REGISTRY_MODULE}.provider_registry") as mock_registry,
+    ):
+      mock_registry.is_enabled.return_value = True
+      result = await resolve_sync_connection("kg_test", "usr_123")
+
+    assert result["connection_id"] == "conn_live"
+
+  @pytest.mark.asyncio
+  @pytest.mark.unit
+  async def test_multiple_live_candidates_raise_ambiguous(self):
+    from robosystems.operations.connection_service import (
+      AmbiguousSyncConnectionError,
+      resolve_sync_connection,
+    )
+
+    rows = [
+      _conn_dict(connection_id="conn_1", provider="quickbooks"),
+      _conn_dict(connection_id="conn_2", provider="sec"),
+    ]
+    with (
+      patch(
+        f"{MODULE}.ConnectionService.list_connections",
+        new=AsyncMock(return_value=rows),
+      ),
+      patch(f"{REGISTRY_MODULE}.provider_registry") as mock_registry,
+    ):
+      mock_registry.is_enabled.return_value = True
+      with pytest.raises(AmbiguousSyncConnectionError) as exc:
+        await resolve_sync_connection("kg_test", "usr_123")
+
+    ids = [c["connection_id"] for c in exc.value.candidates]
+    assert ids == ["conn_1", "conn_2"]
+
+
+class TestDispatchConnectionSync:
+  def _lock_patches(self, acquired=True, holder_id=None, ttl_remaining=None):
+    lock_result = MagicMock()
+    lock_result.acquired = acquired
+    lock_result.holder_id = holder_id
+    lock_result.ttl_remaining = ttl_remaining
+    lock_result.lock_id = "lock_abc" if acquired else None
+    lock_instance = MagicMock()
+    lock_instance.acquire.return_value = lock_result
+    return (
+      patch(f"{LOCK_MODULE}.DistributedLock", MagicMock(return_value=lock_instance)),
+      patch(f"{VALKEY_MODULE}.create_redis_client", MagicMock()),
+    )
+
+  @pytest.mark.asyncio
+  @pytest.mark.unit
+  async def test_connection_not_found_raises(self):
+    from robosystems.operations.connection_service import (
+      ConnectionNotFoundError,
+      dispatch_connection_sync,
+    )
+
+    with patch(
+      f"{MODULE}.ConnectionService.get_connection",
+      new=AsyncMock(return_value=None),
+    ):
+      with pytest.raises(ConnectionNotFoundError):
+        await dispatch_connection_sync(
+          graph_id="kg_test", connection_id="conn_x", user_id="usr_123"
+        )
+
+  @pytest.mark.asyncio
+  @pytest.mark.unit
+  async def test_disabled_provider_raises_provider_unavailable(self):
+    from robosystems.operations.connection_service import (
+      ProviderUnavailableError,
+      dispatch_connection_sync,
+    )
+
+    with (
+      patch(
+        f"{MODULE}.ConnectionService.get_connection",
+        new=AsyncMock(return_value=_conn_dict()),
+      ),
+      patch(f"{REGISTRY_MODULE}.provider_registry") as mock_registry,
+    ):
+      mock_registry.get_provider.side_effect = ValueError("disabled")
+      with pytest.raises(ProviderUnavailableError):
+        await dispatch_connection_sync(
+          graph_id="kg_test", connection_id="conn_1", user_id="usr_123"
+        )
+
+  @pytest.mark.asyncio
+  @pytest.mark.unit
+  async def test_lock_contention_raises_sync_in_progress(self):
+    from robosystems.operations.connection_service import (
+      SyncInProgressError,
+      dispatch_connection_sync,
+    )
+
+    lock_patch, valkey_patch = self._lock_patches(
+      acquired=False, holder_id="holder_xyz", ttl_remaining=900
+    )
+    with (
+      patch(
+        f"{MODULE}.ConnectionService.get_connection",
+        new=AsyncMock(return_value=_conn_dict()),
+      ),
+      patch(f"{REGISTRY_MODULE}.provider_registry") as mock_registry,
+      lock_patch,
+      valkey_patch,
+    ):
+      mock_registry.get_provider.return_value = MagicMock()
+      with pytest.raises(SyncInProgressError) as exc:
+        await dispatch_connection_sync(
+          graph_id="kg_test", connection_id="conn_1", user_id="usr_123"
+        )
+
+    assert exc.value.holder_id == "holder_xyz"
+    assert exc.value.ttl_remaining == 900
+
+  @pytest.mark.asyncio
+  @pytest.mark.unit
+  async def test_happy_path_builds_options_and_returns_dispatch_info(self):
+    from datetime import date
+
+    from robosystems.operations.connection_service import dispatch_connection_sync
+
+    lock_patch, valkey_patch = self._lock_patches(acquired=True)
+    with (
+      patch(
+        f"{MODULE}.ConnectionService.get_connection",
+        new=AsyncMock(return_value=_conn_dict()),
+      ),
+      patch(f"{REGISTRY_MODULE}.provider_registry") as mock_registry,
+      lock_patch,
+      valkey_patch,
+    ):
+      mock_registry.get_provider.return_value = MagicMock()
+      mock_registry.sync_connection = AsyncMock(return_value="run_777")
+
+      result = await dispatch_connection_sync(
+        graph_id="kg_test",
+        connection_id="conn_1",
+        user_id="usr_123",
+        full_rebuild=True,
+        since_date=date(2026, 7, 1),
+        sync_options={"lookback_days": 90},
+      )
+
+    assert result["task_id"] == "run_777"
+    assert result["provider"] == "quickbooks"
+    assert result["last_sync_before_dispatch"] == "2026-07-31T00:00:00+00:00"
+
+    options = mock_registry.sync_connection.call_args.args[2]
+    assert options["full_rebuild"] is True
+    assert options["since_date"] == "2026-07-01"
+    assert options["sync_lock_id"] == "lock_abc"
+    assert options["lookback_days"] == 90
+
+  @pytest.mark.asyncio
+  @pytest.mark.unit
+  async def test_valkey_degraded_proceeds_without_lock(self):
+    from robosystems.operations.connection_service import dispatch_connection_sync
+
+    with (
+      patch(
+        f"{MODULE}.ConnectionService.get_connection",
+        new=AsyncMock(return_value=_conn_dict()),
+      ),
+      patch(f"{REGISTRY_MODULE}.provider_registry") as mock_registry,
+      patch(
+        f"{VALKEY_MODULE}.create_redis_client",
+        MagicMock(side_effect=RuntimeError("valkey down")),
+      ),
+    ):
+      mock_registry.get_provider.return_value = MagicMock()
+      mock_registry.sync_connection = AsyncMock(return_value="run_888")
+
+      result = await dispatch_connection_sync(
+        graph_id="kg_test", connection_id="conn_1", user_id="usr_123"
+      )
+
+    assert result["task_id"] == "run_888"
+    options = mock_registry.sync_connection.call_args.args[2]
+    assert options is None or "sync_lock_id" not in options

--- a/tests/routers/graphs/connections/test_sync.py
+++ b/tests/routers/graphs/connections/test_sync.py
@@ -14,6 +14,11 @@ from fastapi import HTTPException
 from robosystems.routers.graphs.connections.sync import sync_connection
 
 SYNC_MODULE = "robosystems.routers.graphs.connections.sync"
+# The validate → lock → dispatch orchestration lives in the shared kernel
+# (`dispatch_connection_sync`), so connection lookup and provider dispatch
+# are patched at their source modules, not on the router.
+KERNEL_MODULE = "robosystems.operations.connection_service"
+REGISTRY_MODULE = "robosystems.operations.providers.registry"
 
 GRAPH_ID = "kg01234567890abcdef"
 USER_ID = "usr_test123"
@@ -146,11 +151,11 @@ class TestSyncConnection:
       patch(f"{SYNC_MODULE}.record_operation_start"),
       patch(f"{SYNC_MODULE}.record_operation_success"),
       patch(
-        f"{SYNC_MODULE}.ConnectionService.get_connection",
+        f"{KERNEL_MODULE}.ConnectionService.get_connection",
         new_callable=AsyncMock,
         return_value=connection_dict,
       ),
-      patch(f"{SYNC_MODULE}.provider_registry") as mock_registry,
+      patch(f"{REGISTRY_MODULE}.provider_registry") as mock_registry,
     ):
       mock_registry.get_provider = MagicMock(return_value=MagicMock())
       mock_registry.sync_connection = AsyncMock(return_value="task_qb_001")
@@ -189,11 +194,11 @@ class TestSyncConnection:
       patch(f"{SYNC_MODULE}.record_operation_start"),
       patch(f"{SYNC_MODULE}.record_operation_success"),
       patch(
-        f"{SYNC_MODULE}.ConnectionService.get_connection",
+        f"{KERNEL_MODULE}.ConnectionService.get_connection",
         new_callable=AsyncMock,
         return_value=connection_dict,
       ),
-      patch(f"{SYNC_MODULE}.provider_registry") as mock_registry,
+      patch(f"{REGISTRY_MODULE}.provider_registry") as mock_registry,
     ):
       mock_registry.get_provider = MagicMock(return_value=MagicMock())
       mock_registry.sync_connection = AsyncMock(return_value="task_sec_001")
@@ -229,7 +234,7 @@ class TestSyncConnection:
       patch(f"{SYNC_MODULE}.record_operation_start"),
       patch(f"{SYNC_MODULE}.record_operation_failure"),
       patch(
-        f"{SYNC_MODULE}.ConnectionService.get_connection",
+        f"{KERNEL_MODULE}.ConnectionService.get_connection",
         new_callable=AsyncMock,
         return_value=None,
       ),
@@ -266,11 +271,11 @@ class TestSyncConnection:
       patch(f"{SYNC_MODULE}.record_operation_start"),
       patch(f"{SYNC_MODULE}.record_operation_failure"),
       patch(
-        f"{SYNC_MODULE}.ConnectionService.get_connection",
+        f"{KERNEL_MODULE}.ConnectionService.get_connection",
         new_callable=AsyncMock,
         return_value=connection_dict,
       ),
-      patch(f"{SYNC_MODULE}.provider_registry") as mock_registry,
+      patch(f"{REGISTRY_MODULE}.provider_registry") as mock_registry,
     ):
       mock_registry.get_provider = MagicMock(
         side_effect=ValueError("Provider is disabled")
@@ -308,14 +313,16 @@ class TestSyncConnection:
       patch(f"{SYNC_MODULE}.record_operation_start"),
       patch(f"{SYNC_MODULE}.record_operation_failure"),
       patch(
-        f"{SYNC_MODULE}.ConnectionService.get_connection",
+        f"{KERNEL_MODULE}.ConnectionService.get_connection",
         new_callable=AsyncMock,
         return_value=connection_dict,
       ),
-      patch(f"{SYNC_MODULE}.provider_registry") as mock_registry,
-      patch(f"{SYNC_MODULE}.asyncio.wait_for", side_effect=TimeoutError()),
+      patch(f"{REGISTRY_MODULE}.provider_registry") as mock_registry,
     ):
       mock_registry.get_provider = MagicMock(return_value=MagicMock())
+      # TimeoutError raised from the awaited dispatch propagates through
+      # asyncio.wait_for exactly like an elapsed dispatch_timeout.
+      mock_registry.sync_connection = AsyncMock(side_effect=TimeoutError())
 
       with pytest.raises(HTTPException) as exc_info:
         await sync_connection(
@@ -349,11 +356,11 @@ class TestSyncConnection:
       patch(f"{SYNC_MODULE}.record_operation_start"),
       patch(f"{SYNC_MODULE}.record_operation_failure"),
       patch(
-        f"{SYNC_MODULE}.ConnectionService.get_connection",
+        f"{KERNEL_MODULE}.ConnectionService.get_connection",
         new_callable=AsyncMock,
         return_value=connection_dict,
       ),
-      patch(f"{SYNC_MODULE}.provider_registry") as mock_registry,
+      patch(f"{REGISTRY_MODULE}.provider_registry") as mock_registry,
     ):
       mock_registry.get_provider = MagicMock(return_value=MagicMock())
       mock_registry.sync_connection = AsyncMock(
@@ -392,7 +399,7 @@ class TestSyncConnection:
       patch(f"{SYNC_MODULE}.record_operation_start"),
       patch(f"{SYNC_MODULE}.record_operation_failure"),
       patch(
-        f"{SYNC_MODULE}.ConnectionService.get_connection",
+        f"{KERNEL_MODULE}.ConnectionService.get_connection",
         new_callable=AsyncMock,
         side_effect=original_exc,
       ),
@@ -436,11 +443,11 @@ class TestSyncConnection:
       patch(f"{SYNC_MODULE}.record_operation_start"),
       patch(f"{SYNC_MODULE}.record_operation_success"),
       patch(
-        f"{SYNC_MODULE}.ConnectionService.get_connection",
+        f"{KERNEL_MODULE}.ConnectionService.get_connection",
         new_callable=AsyncMock,
         return_value=connection_dict,
       ),
-      patch(f"{SYNC_MODULE}.provider_registry") as mock_registry,
+      patch(f"{REGISTRY_MODULE}.provider_registry") as mock_registry,
     ):
       mock_registry.get_provider = MagicMock(return_value=MagicMock())
       sync_mock = AsyncMock(return_value="task_123")
@@ -491,11 +498,11 @@ class TestSyncConnection:
       patch(f"{SYNC_MODULE}.record_operation_start"),
       patch(f"{SYNC_MODULE}.record_operation_success"),
       patch(
-        f"{SYNC_MODULE}.ConnectionService.get_connection",
+        f"{KERNEL_MODULE}.ConnectionService.get_connection",
         new_callable=AsyncMock,
         return_value=connection_dict,
       ),
-      patch(f"{SYNC_MODULE}.provider_registry") as mock_registry,
+      patch(f"{REGISTRY_MODULE}.provider_registry") as mock_registry,
     ):
       mock_registry.get_provider = MagicMock(return_value=MagicMock())
       sync_mock = AsyncMock(return_value="task_456")
@@ -543,11 +550,11 @@ class TestSyncConnection:
       patch(f"{SYNC_MODULE}.record_operation_start"),
       patch(f"{SYNC_MODULE}.record_operation_success"),
       patch(
-        f"{SYNC_MODULE}.ConnectionService.get_connection",
+        f"{KERNEL_MODULE}.ConnectionService.get_connection",
         new_callable=AsyncMock,
         return_value=connection_dict,
       ),
-      patch(f"{SYNC_MODULE}.provider_registry") as mock_registry,
+      patch(f"{REGISTRY_MODULE}.provider_registry") as mock_registry,
     ):
       mock_registry.get_provider = MagicMock(return_value=MagicMock())
       mock_registry.sync_connection = AsyncMock(return_value="task_001")
@@ -585,11 +592,11 @@ class TestSyncConnection:
       patch(f"{SYNC_MODULE}.record_operation_start"),
       patch(f"{SYNC_MODULE}.record_operation_failure") as mock_record_failure,
       patch(
-        f"{SYNC_MODULE}.ConnectionService.get_connection",
+        f"{KERNEL_MODULE}.ConnectionService.get_connection",
         new_callable=AsyncMock,
         return_value=connection_dict,
       ),
-      patch(f"{SYNC_MODULE}.provider_registry") as mock_registry,
+      patch(f"{REGISTRY_MODULE}.provider_registry") as mock_registry,
     ):
       mock_registry.get_provider = MagicMock(
         side_effect=ValueError("Provider disabled")
@@ -629,11 +636,11 @@ class TestSyncConnection:
       patch(f"{SYNC_MODULE}.record_operation_start"),
       patch(f"{SYNC_MODULE}.record_operation_success") as mock_record_success,
       patch(
-        f"{SYNC_MODULE}.ConnectionService.get_connection",
+        f"{KERNEL_MODULE}.ConnectionService.get_connection",
         new_callable=AsyncMock,
         return_value=connection_dict,
       ),
-      patch(f"{SYNC_MODULE}.provider_registry") as mock_registry,
+      patch(f"{REGISTRY_MODULE}.provider_registry") as mock_registry,
     ):
       mock_registry.get_provider = MagicMock(return_value=MagicMock())
       mock_registry.sync_connection = AsyncMock(return_value="task_success")
@@ -669,11 +676,11 @@ class TestSyncConnection:
       patch(f"{SYNC_MODULE}.record_operation_start"),
       patch(f"{SYNC_MODULE}.record_operation_success"),
       patch(
-        f"{SYNC_MODULE}.ConnectionService.get_connection",
+        f"{KERNEL_MODULE}.ConnectionService.get_connection",
         new_callable=AsyncMock,
         return_value=connection_dict,
       ),
-      patch(f"{SYNC_MODULE}.provider_registry") as mock_registry,
+      patch(f"{REGISTRY_MODULE}.provider_registry") as mock_registry,
     ):
       mock_registry.get_provider = MagicMock(return_value=MagicMock())
       mock_registry.sync_connection = AsyncMock(return_value="task_quickbooks")
@@ -710,11 +717,11 @@ class TestSyncConnection:
       patch(f"{SYNC_MODULE}.record_operation_start"),
       patch(f"{SYNC_MODULE}.record_operation_success"),
       patch(
-        f"{SYNC_MODULE}.ConnectionService.get_connection",
+        f"{KERNEL_MODULE}.ConnectionService.get_connection",
         new_callable=AsyncMock,
         return_value=connection_dict,
       ),
-      patch(f"{SYNC_MODULE}.provider_registry") as mock_registry,
+      patch(f"{REGISTRY_MODULE}.provider_registry") as mock_registry,
     ):
       mock_registry.get_provider = MagicMock(return_value=MagicMock())
       mock_registry.sync_connection = AsyncMock(return_value="task_001")

--- a/tests/routers/graphs/test_ops_shared_repo_gates.py
+++ b/tests/routers/graphs/test_ops_shared_repo_gates.py
@@ -124,6 +124,27 @@ class TestDeleteSubgraphMCPSharedRepoGate:
     assert "sec" in result["message"]
 
 
+# ── MCP: SyncConnectionTool rejects shared repos ──────────────────────────
+
+
+class TestSyncConnectionMCPSharedRepoGate:
+  @pytest.mark.asyncio
+  @pytest.mark.parametrize("graph_id", ["sec", "sec_historical"])
+  async def test_rejects_shared_repo(self, graph_id: str) -> None:
+    """Shared repos sync via their own pipeline; a tenant agent must not
+    be able to trigger ingestion against them."""
+    from robosystems.middleware.mcp.tools.graph_tools import SyncConnectionTool
+
+    client = MagicMock()
+    client.graph_id = graph_id
+    client.user = _user()
+
+    result = await SyncConnectionTool(client).execute({})
+
+    assert result["error"] == "not_allowed_on_shared_repo"
+    assert graph_id in result["message"]
+
+
 # ── Navigation still allowed — positive invariants ────────────────────────
 
 


### PR DESCRIPTION
## Summary

Exposes the connection resync trigger on the MCP surface so an agent running the month-end close can clear a `sync_stale` blocker itself — sync, watch for `last_sync_at` to advance, then close — instead of dead-ending into "ask a human to press Sync Now." The REST sync endpoint and the new `sync-connection` MCP tool now call one shared kernel, so both surfaces validate, lock, and dispatch identically.

## Changes

### Operations kernel
- `operations/connection_service.py` — new `dispatch_connection_sync()` (graph- and user-scoped connection lookup → provider validation → per-connection distributed lock → provider dispatch) and `resolve_sync_connection()` (resolves a graph's single syncable connection; currently-connected rows win; refuses to guess between multiple live candidates). Typed domain exceptions: `ConnectionNotFoundError`, `ProviderUnavailableError`, `SyncInProgressError` (carries lock holder + TTL), `NoSyncConnectionError`, `AmbiguousSyncConnectionError` (carries the candidate list).
- `operations/providers/registry.py` — small `is_enabled()` helper so resolution can filter to feature-flag-enabled providers without the raising `get_provider()` path.

### REST endpoint (thin caller, contract unchanged)
- `routers/graphs/connections/sync.py` — the orchestration body moves into the kernel; the endpoint keeps its existing HTTP contract (404/409/403/504 mapping, lock-skip-on-degraded-Valkey semantics, idempotency, metric labels, `OperationEnvelope` response). Endpoint description updated to point completion at the connection's `last_sync` timestamp — the sync dispatch path never registered its `operation_id` with the SSE infrastructure, so the previous description promised a stream that carried no events.

### MCP tool
- `middleware/mcp/tools/graph_tools.py` — new `SyncConnectionTool`, registered beside `set-write-policy` (same gate: writable user graphs only, shared repos blocked). Omitting `connection_id` auto-resolves the graph's sync connection; ambiguity returns a typed error listing candidates. `full_rebuild` is documented as an expensive, deliberate opt-in; lock contention surfaces the holder + remaining TTL so an agent waits rather than retries. Completion contract: poll `get-fiscal-calendar` until `last_sync_at` advances.
- `middleware/mcp/tools/manager.py` — registration, listing, and dispatch wiring.
- `middleware/mcp/tools/playbook_tools.py` — the close playbook gains an explicit `sync_stale` step (run `sync-connection`, poll until the blocker clears) and steers away from `allow_stale_sync=true` as the default response.
- `middleware/mcp/tools/instructions.py` — orientation line pointing the `sync_stale` blocker at the tool.

### Tests
- `tests/operations/test_connection_service.py` — kernel coverage: resolution preference and ambiguity, disabled-provider filtering, lock contention, degraded-Valkey proceed-unlocked, sync-options plumbing including `sync_lock_id`.
- `tests/middleware/mcp/tools/test_graph_tools.py` — tool definition shape, auto-resolve vs explicit id, error mapping.
- `tests/routers/graphs/test_ops_shared_repo_gates.py` — `sync-connection` rejects shared repos (`sec`, `sec_historical`).
- `tests/routers/graphs/connections/test_sync.py` — patch targets updated to the kernel's new home; endpoint behavior assertions unchanged.

## Testing

- `just test` — full unit suite: **12,050 passed, 24 skipped**.
- `just test-code` — ruff, format, basedpyright, cf-lint: all clean.

## Notes / Follow-ups

- True SSE progress for connection syncs would mean routing dispatch through the worker's `dagster_job_monitor` rail (the create-backup pattern) — a provider-dispatch refactor across all three providers, deliberately out of scope here.
- End-to-end dogfood (driving a real incremental sync through the agent against the QuickBooks sandbox) is still pending; it needs the running local stack.
