### PR TITLE
Adopt robosystems-client 1.0.0 in examples

### DIFF
--- a/examples/_common/sdk.py
+++ b/examples/_common/sdk.py
@@ -50,5 +50,5 @@ def latest_report_id(client: LedgerClient, graph_id: str) -> str:
   reports = client.list_reports(graph_id) or []
   if not reports:
     raise SystemExit(f"No Report found for graph {graph_id}.")
-  reports.sort(key=lambda r: r.get("created_at") or "", reverse=True)
-  return str(reports[0]["id"])
+  reports.sort(key=lambda r: r.created_at or "", reverse=True)
+  return reports[0].id

--- a/examples/_scenario/runner.py
+++ b/examples/_scenario/runner.py
@@ -595,7 +595,7 @@ def create_mappings(
   if not structures:
     print("  ERROR: No mapping structure found")
     return 0
-  mapping_id = structures[0]["id"]
+  mapping_id = structures[0].id
 
   # Resolve rs-gaap qnames → element IDs via the library in the entity graph.
   # rs-gaap has ~2000 elements; list_elements caps at 1000 per page, so paginate.
@@ -671,7 +671,7 @@ def create_disclosure_notes(
     return 0, 0
 
   structures = client.list_structures(graph_id, block_type="coa_mapping")
-  mapping_id = structures[0]["id"] if structures else None
+  mapping_id = structures[0].id if structures else None
   if mapping_id is None:
     print("  ERROR: no coa_mapping structure — member multi-mapping skipped")
 
@@ -684,7 +684,7 @@ def create_disclosure_notes(
     payload = {
       "name": note.get("taxonomy_name", f"{struct_name} Extension"),
       "taxonomy_type": "reporting_extension",
-      "parent_taxonomy_id": rs_gaap["id"],
+      "parent_taxonomy_id": rs_gaap.id,
       "description": note.get("description"),
       "elements": [
         {
@@ -798,7 +798,7 @@ def update_disclosure_notes(graph_id: str, notes: list[dict]) -> int:
 
     order = float(len(note["members"]) + 1)
     payload = {
-      "taxonomy_id": taxonomy["id"],
+      "taxonomy_id": taxonomy.id,
       "elements_to_add": [
         {
           "qname": member["qname"],
@@ -833,9 +833,9 @@ def update_disclosure_notes(graph_id: str, notes: list[dict]) -> int:
       print(f"  ERROR: update-taxonomy-block failed: {e}")
       continue
 
-    block = client.get_information_block(graph_id, structure["id"]) or {}
+    block = client.get_information_block(graph_id, structure.id)
     rollups = [
-      r for r in (block.get("rules") or []) if r.get("rule_pattern") == "RollUp"
+      r for r in (block.rules if block else []) if r.rule_pattern == "RollUp"
     ]
     refreshed = any(
       member["qname"]
@@ -902,7 +902,7 @@ def create_text_block_notes(
     payload = {
       "name": note.get("taxonomy_name", f"{struct_name} Extension"),
       "taxonomy_type": "reporting_extension",
-      "parent_taxonomy_id": rs_gaap["id"],
+      "parent_taxonomy_id": rs_gaap.id,
       "description": note.get("description"),
       "elements": [
         {
@@ -1191,7 +1191,7 @@ def create_custom_metrics(graph_id: str, catalogs: list[dict]) -> list[dict]:
     payload = {
       "name": catalog.get("taxonomy_name", f"{struct_name} Extension"),
       "taxonomy_type": "reporting_extension",
-      "parent_taxonomy_id": rs_gaap["id"],
+      "parent_taxonomy_id": rs_gaap.id,
       "description": catalog.get("description"),
       "elements": [
         {
@@ -1276,7 +1276,7 @@ def create_custom_metrics(graph_id: str, catalogs: list[dict]) -> list[dict]:
     if structure is None:
       print(f"  ERROR: metric structure {struct_name!r} not found after create")
       continue
-    created.append({"structure_id": structure["id"], "name": struct_name})
+    created.append({"structure_id": structure.id, "name": struct_name})
     print(f"  {struct_name}: {len(metrics)} metric(s) authored")
 
   return created
@@ -1687,7 +1687,7 @@ def run_ai_mapping(graph_id: str) -> None:
   if not structures:
     print("  ERROR: No coa_mapping structure found — was the CoA taxonomy created?")
     return
-  mapping_id = structures[0]["id"]
+  mapping_id = structures[0].id
   print(f"  Mapping structure: {mapping_id}")
 
   try:
@@ -1835,15 +1835,15 @@ def create_schedules(
   # Find or create schedule taxonomy
   existing_taxonomies = client.list_taxonomies(graph_id, taxonomy_type="schedule")
   schedule_tax = next(
-    (t for t in existing_taxonomies if t["name"] == taxonomy_name), None
+    (t for t in existing_taxonomies if t.name == taxonomy_name), None
   )
   if schedule_tax:
-    taxonomy_id = schedule_tax["id"]
+    taxonomy_id = schedule_tax.id
     # Clean up prior-run schedules for idempotency
     existing_blocks = client.list_information_blocks(graph_id, block_type="schedule")
     for block in existing_blocks:
-      if block.get("taxonomy_name") == taxonomy_name:
-        client.delete_schedule(graph_id, block["id"])
+      if block.taxonomy_name == taxonomy_name:
+        client.delete_schedule(graph_id, block.id)
   else:
     result = client.create_taxonomy_block(
       graph_id,
@@ -2056,7 +2056,7 @@ def generate_annual_report(
   if not structures:
     print("  ERROR: No coa_mapping structure — was the CoA created?")
     return None
-  mapping_id = structures[0]["id"]
+  mapping_id = structures[0].id
 
   # Render against rs-gaap — the canonical reporting vocabulary. The
   # CoA was mapped CoA→rs-gaap above, and the Default Reporting Style's

--- a/examples/roboledger_demo/main.py
+++ b/examples/roboledger_demo/main.py
@@ -647,7 +647,7 @@ def create_mappings(
   if not structures:
     print("  ERROR: No mapping structure found")
     return 0
-  mapping_id = structures[0]["id"]
+  mapping_id = structures[0].id
 
   # Resolve rs-gaap qnames → element IDs via the library in the entity graph.
   # rs-gaap has ~2000 elements; list_elements caps at 1000 per page, so paginate.
@@ -714,7 +714,7 @@ def run_ai_mapping(graph_id: str) -> None:
   if not structures:
     print("  ERROR: No coa_mapping structure found — was the CoA taxonomy created?")
     return
-  mapping_id = structures[0]["id"]
+  mapping_id = structures[0].id
   print(f"  Mapping structure: {mapping_id}")
 
   try:
@@ -835,15 +835,15 @@ def create_schedules(graph_id: str, element_lookup: dict[str, str]) -> int:
   # Find or create schedule taxonomy
   existing_taxonomies = client.list_taxonomies(graph_id, taxonomy_type="schedule")
   cascade_tax = next(
-    (t for t in existing_taxonomies if t["name"] == "Cascade Schedules"), None
+    (t for t in existing_taxonomies if t.name == "Cascade Schedules"), None
   )
   if cascade_tax:
-    taxonomy_id = cascade_tax["id"]
+    taxonomy_id = cascade_tax.id
     # Clean up prior-run schedules for idempotency
     existing_blocks = client.list_information_blocks(graph_id, block_type="schedule")
     for block in existing_blocks:
-      if block.get("taxonomy_name") == "Cascade Schedules":
-        client.delete_schedule(graph_id, block["id"])
+      if block.taxonomy_name == "Cascade Schedules":
+        client.delete_schedule(graph_id, block.id)
   else:
     result = client.create_taxonomy_block(
       graph_id,
@@ -973,7 +973,7 @@ def generate_fy2025_report(graph_id: str) -> str | None:
   if not structures:
     print("  ERROR: No coa_mapping structure — was the CoA created?")
     return None
-  mapping_id = structures[0]["id"]
+  mapping_id = structures[0].id
 
   # Render against rs-gaap — the canonical reporting vocabulary. The
   # CoA was mapped CoA→rs-gaap above, and the Default Reporting Style's

--- a/examples/seattle_method_demo/reconcile.py
+++ b/examples/seattle_method_demo/reconcile.py
@@ -123,32 +123,36 @@ class ReconciliationLine:
 # ``IncomeLossFromContinuingOperationsBeforeTax`` is a subtotal but its
 # qname doesn't follow ``*Current/*Noncurrent`` patterns); explicit
 # listing is more honest than fragile regex.
-_COVERAGE_SUBTOTALS: frozenset[str] = frozenset({
-  "mini:CurrentAssets",
-  "mini:NoncurrentAssets",
-  "mini:CurrentLiabilities",
-  "mini:NoncurrentLiabilities",
-  "mini:Liabilities",
-  "mini:Equity",
-  "mini:GrossProfitLoss",
-  "mini:OperatingExpenses",
-  "mini:OperatingIncomeLoss",
-  "mini:IncomeLossFromContinuingOperationsBeforeTax",
-  "mini:NetCashFlowOperatingActivities",
-  "mini:NetCashFlowInvestingActivities",
-  "mini:NetCashFlowFinancingActivities",
-})
+_COVERAGE_SUBTOTALS: frozenset[str] = frozenset(
+  {
+    "mini:CurrentAssets",
+    "mini:NoncurrentAssets",
+    "mini:CurrentLiabilities",
+    "mini:NoncurrentLiabilities",
+    "mini:Liabilities",
+    "mini:Equity",
+    "mini:GrossProfitLoss",
+    "mini:OperatingExpenses",
+    "mini:OperatingIncomeLoss",
+    "mini:IncomeLossFromContinuingOperationsBeforeTax",
+    "mini:NetCashFlowOperatingActivities",
+    "mini:NetCashFlowInvestingActivities",
+    "mini:NetCashFlowFinancingActivities",
+  }
+)
 
-_COVERAGE_GRANULARITY: frozenset[str] = frozenset({
-  "mini:Cash",
-  "mini:Equipment",
-  "mini:AccumulatedDepreciation",
-  "mini:PropertyPlantAndEquipmentGross",
-  "mini:TradePayables",
-  "mini:RawMaterial",
-  "mini:OtherSecuredLoans",
-  "mini:MaturesInOneYear",
-})
+_COVERAGE_GRANULARITY: frozenset[str] = frozenset(
+  {
+    "mini:Cash",
+    "mini:Equipment",
+    "mini:AccumulatedDepreciation",
+    "mini:PropertyPlantAndEquipmentGross",
+    "mini:TradePayables",
+    "mini:RawMaterial",
+    "mini:OtherSecuredLoans",
+    "mini:MaturesInOneYear",
+  }
+)
 
 
 def _categorize_missing(concept: str) -> str:
@@ -310,28 +314,28 @@ def _load_concept_totals_via_graphql(
   rs-gaap and other taxonomies on the graph are filtered out
   client-side (the GraphQL query returns every CoA account).
 
-  The trialBalance response shape per row:
-  ``{account_id, account_code (=qname), account_name, trait,
-  account_type, total_debits, total_credits, net_balance}``.
-  Values come back as floats in dollars; we multiply by 100 for
-  internal cents-precision.
+  The trialBalance rows are typed (SDK 1.0): ``account_id``,
+  ``account_code`` (=qname), ``account_name``, ``trait``,
+  ``account_type``, ``total_debits``, ``total_credits``,
+  ``net_balance``. Values come back as floats in dollars; we
+  multiply by 100 for internal cents-precision.
   """
   data = client.get_trial_balance(
     graph_id,
     start_date=period_start.isoformat(),
     end_date=period_end.isoformat(),
   )
-  rows = (data or {}).get("rows", []) or []
+  rows = data.rows if data else []
 
   totals: list[ConceptTotal] = []
   for r in rows:
     # ``account_code`` carries the mini qname (set at load time —
     # see ``load_taxonomy.build_element_payloads``).
-    qname = r.get("account_code") or ""
+    qname = r.account_code
     if not qname.startswith("mini:"):
       continue
-    dollars_dr = float(r.get("total_debits") or 0)
-    dollars_cr = float(r.get("total_credits") or 0)
+    dollars_dr = r.total_debits
+    dollars_cr = r.total_credits
     # Filter on "had activity" not "non-zero net" — Charlie's
     # Receivables has $8K DR + $8K CR netting to $0, but it's
     # legitimate activity that the diff should compare.
@@ -342,13 +346,13 @@ def _load_concept_totals_via_graphql(
     # directly — they live on the Element row. Derive period_type
     # from trait (instant for asset/liability/equity, duration for
     # revenue/expense). For balance_type, infer from trait + sign.
-    trait = r.get("trait")
+    trait = r.trait
     period_type = _period_type_from_trait(trait)
     balance_type = _balance_type_from_trait(trait)
     totals.append(
       ConceptTotal(
         qname=qname,
-        label=r.get("account_name") or qname,
+        label=r.account_name or qname,
         balance_type=balance_type,
         period_type=period_type,
         trait=trait,
@@ -526,9 +530,7 @@ def _build_diff(
     # but they aren't meaningful for our current-period reconciliation.
     if f.value_cents == 0 and f.period_end.year < 2024:
       continue
-    expected_by_concept_kind.setdefault(
-      (f.concept, f.period_kind), f.value_cents
-    )
+    expected_by_concept_kind.setdefault((f.concept, f.period_kind), f.value_cents)
 
   diff_lines: list[ReconciliationLine] = []
   for c in ours:
@@ -541,9 +543,7 @@ def _build_diff(
     # grown). Ours are debit-positive (credit-balance concepts come
     # in negative). Sign-flip credit-balance concepts.
     our_signed = (
-      c.debit_positive_cents
-      if c.balance_type == "debit"
-      else -c.debit_positive_cents
+      c.debit_positive_cents if c.balance_type == "debit" else -c.debit_positive_cents
     )
     diff_lines.append(
       ReconciliationLine(
@@ -594,10 +594,9 @@ def _load_rollforward_ibs_via_graphql(
 
   Uses ``LedgerClient.list_information_blocks(block_type='rollforward')``
   — the same query the frontend / MCP / any external client would
-  hit. The envelope's ``artifact.mechanics`` field carries the
-  typed ``RollforwardMechanics`` JSON; we re-validate it through
-  Pydantic to recover the typed shape (the hand-written GraphQL
-  parser returns ``dict[str, Any]``).
+  hit. The typed row's ``artifact.mechanics`` field carries the
+  ``RollforwardMechanics`` JSON (an untyped GraphQL JSON scalar);
+  we re-validate it through Pydantic to recover the typed shape.
 
   Note: the IB envelope's ``facts`` field is empty here (see
   ``information_block/rollforward.py:build_envelope``); the filter
@@ -606,12 +605,11 @@ def _load_rollforward_ibs_via_graphql(
   blocks = client.list_information_blocks(graph_id, block_type="rollforward")
   out: list[tuple[str, RollforwardMechanics]] = []
   for block in blocks or []:
-    artifact = block.get("artifact") or {}
-    raw_mechanics = artifact.get("mechanics")
+    raw_mechanics = block.artifact.mechanics
     if not raw_mechanics:
       continue
     mechanics = RollforwardMechanics.model_validate(raw_mechanics)
-    out.append((block.get("id", ""), mechanics))
+    out.append((block.id, mechanics))
   return out
 
 
@@ -699,9 +697,7 @@ def _anchor_totals(concepts: list[ConceptTotal]) -> dict[str, int]:
   # count. Without explicit RE, the implicit addition closes the
   # accounting equation for a startup's first-period reconciliation
   # (no opening RE to inherit).
-  has_explicit_re = any(
-    "retainedearnings" in (c.qname or "").lower() for c in concepts
-  )
+  has_explicit_re = any("retainedearnings" in (c.qname or "").lower() for c in concepts)
   if not has_explicit_re:
     totals["Total Liabilities & Equity"] += totals["Net Income"]
 
@@ -814,17 +810,17 @@ def render_markdown(report: ReconciliationReport) -> str:
       out.append("| Concept | Period | Charlie's value |")
       out.append("|---|---|---:|")
       for f in sorted(items, key=lambda x: x.concept):
-        out.append(
-          f"| `{f.concept}` | {f.period_kind} | {_fmt_cents(f.value_cents)} |"
-        )
+        out.append(f"| `{f.concept}` | {f.period_kind} | {_fmt_cents(f.value_cents)} |")
       out.append("")
 
   # Anchor totals
   out.append("## Four Anchor Totals")
   out.append("")
-  out.append("These four lines must match Charlie's PoC for the test to "
-             "pass. All amounts are debit-positive cents internally; "
-             "presentation flips signs per accounting convention.")
+  out.append(
+    "These four lines must match Charlie's PoC for the test to "
+    "pass. All amounts are debit-positive cents internally; "
+    "presentation flips signs per accounting convention."
+  )
   out.append("")
   totals = _anchor_totals(report.concept_totals)
   out.append("| Anchor | Our value |")
@@ -836,11 +832,13 @@ def render_markdown(report: ReconciliationReport) -> str:
   # Concept-level period totals
   out.append("## Concept-Level Period Totals")
   out.append("")
-  out.append("Every mini concept with non-zero activity in the period. "
-             "``Δ debit-positive`` is the period flow (Σ DR − Σ CR). For "
-             "instant/asset concepts this equals the period-ending "
-             "balance (Charlie's data starts from zero). For duration "
-             "concepts this is the period income/expense.")
+  out.append(
+    "Every mini concept with non-zero activity in the period. "
+    "``Δ debit-positive`` is the period flow (Σ DR − Σ CR). For "
+    "instant/asset concepts this equals the period-ending "
+    "balance (Charlie's data starts from zero). For duration "
+    "concepts this is the period income/expense."
+  )
   out.append("")
   out.append("| QName | Label | Trait | Period | Δ debit-positive |")
   out.append("|---|---|---|---|---:|")
@@ -856,11 +854,13 @@ def render_markdown(report: ReconciliationReport) -> str:
   # Rollforward attribution detail
   out.append("## Rollforward Attribution")
   out.append("")
-  out.append("Each rollforward IB decomposes its BS source's period "
-             "delta across declared TDC filters. Where ``Σ filters == "
-             "Δ BS``, the rollforward is balanced (residual = 0). A "
-             "non-zero residual indicates either an unattributed flow "
-             "or a phantom TDC in the source data (logged at author time).")
+  out.append(
+    "Each rollforward IB decomposes its BS source's period "
+    "delta across declared TDC filters. Where ``Σ filters == "
+    "Δ BS``, the rollforward is balanced (residual = 0). A "
+    "non-zero residual indicates either an unattributed flow "
+    "or a phantom TDC in the source data (logged at author time)."
+  )
   out.append("")
   for rf in report.rollforward_results:
     out.append(f"### {rf.bs_label} ({rf.bs_qname})")
@@ -890,53 +890,67 @@ def render_markdown(report: ReconciliationReport) -> str:
   out.append("")
   out.append("**Their data quality** (source CSV inconsistencies):")
   out.append("")
-  out.append("- **JE-205** — Description \"Payment for contractor\" but "
-             "TDC on the AP line is `mini:PurchasesInventoryForSaleOnAccount`. "
-             "Contractor services aren't inventory; vocabulary misuse.")
-  out.append("- **JE-209** — TDC `mini:PaymentOfInterest` on the Cash "
-             "line is a typo for `mini:PaymentInterest` (the canonical "
-             "mini.xsd concept name). `ingest_transactions.py::"
-             "_KNOWN_TDC_ALIASES` normalizes it at ingest time so the "
-             "rollforward filter engine matches; logged as a warning "
-             "per JE so the substitution stays transparent. Note that "
-             "`mini:DecreaseFromPaymentOfInterest` (the AccruedExpenses-"
-             "side TDC) keeps the \"Of\" — Charlie's naming is "
-             "internally inconsistent.")
-  out.append("- **JE-226** — Income tax accrual ($400) but TDC is "
-             "`mini:InterestAccrued` instead of `IncomeTaxAccrued`. "
-             "Copy-paste-style bug from the JE-210 interest pattern.")
+  out.append(
+    '- **JE-205** — Description "Payment for contractor" but '
+    "TDC on the AP line is `mini:PurchasesInventoryForSaleOnAccount`. "
+    "Contractor services aren't inventory; vocabulary misuse."
+  )
+  out.append(
+    "- **JE-209** — TDC `mini:PaymentOfInterest` on the Cash "
+    "line is a typo for `mini:PaymentInterest` (the canonical "
+    "mini.xsd concept name). `ingest_transactions.py::"
+    "_KNOWN_TDC_ALIASES` normalizes it at ingest time so the "
+    "rollforward filter engine matches; logged as a warning "
+    "per JE so the substitution stays transparent. Note that "
+    "`mini:DecreaseFromPaymentOfInterest` (the AccruedExpenses-"
+    'side TDC) keeps the "Of" — Charlie\'s naming is '
+    "internally inconsistent."
+  )
+  out.append(
+    "- **JE-226** — Income tax accrual ($400) but TDC is "
+    "`mini:InterestAccrued` instead of `IncomeTaxAccrued`. "
+    "Copy-paste-style bug from the JE-210 interest pattern."
+  )
   out.append("")
   out.append("**Methodology gap** (architecturally aligned, semantically distinct):")
   out.append("")
-  out.append("- **JE-225** — \"Write off of PPE\" with `Amount = 0` on "
-             "both lines. Boundary test case. Our GL handler rejects "
-             "nil-amount entries (`must have non-zero D or C`); Charlie's "
-             "system likely creates `$0` facts. Reconciliation delta is "
-             "`$0` either way; the four anchor totals are unaffected.")
-  out.append("- **rs-gaap library subset** — Two flow concepts in "
-             "`mappings.py` don't exist in our currently-loaded rs-gaap "
-             "library: `rs-gaap:InterestPaidNet` (mapped through to the "
-             "closest available `rs-gaap:InterestExpense`) and "
-             "`rs-gaap:StockIssuedDuringPeriodValueNewIssues` (mapped "
-             "through to `rs-gaap:ProceedsFromIssuanceOfCommonStock`). "
-             "Approximation; future library expansion closes the gap.")
+  out.append(
+    '- **JE-225** — "Write off of PPE" with `Amount = 0` on '
+    "both lines. Boundary test case. Our GL handler rejects "
+    "nil-amount entries (`must have non-zero D or C`); Charlie's "
+    "system likely creates `$0` facts. Reconciliation delta is "
+    "`$0` either way; the four anchor totals are unaffected."
+  )
+  out.append(
+    "- **rs-gaap library subset** — Two flow concepts in "
+    "`mappings.py` don't exist in our currently-loaded rs-gaap "
+    "library: `rs-gaap:InterestPaidNet` (mapped through to the "
+    "closest available `rs-gaap:InterestExpense`) and "
+    "`rs-gaap:StockIssuedDuringPeriodValueNewIssues` (mapped "
+    "through to `rs-gaap:ProceedsFromIssuanceOfCommonStock`). "
+    "Approximation; future library expansion closes the gap."
+  )
   out.append("")
   out.append("**Our bug**: none identified.")
   out.append("")
-  out.append("**Matching**: see Anchor Totals table above + line-by-line "
-             "concept totals. Compare manually against Charlie's PoC "
-             "rendering at the expected-output URL — an automated HTML "
-             "diff is a possible future enhancement.")
+  out.append(
+    "**Matching**: see Anchor Totals table above + line-by-line "
+    "concept totals. Compare manually against Charlie's PoC "
+    "rendering at the expected-output URL — an automated HTML "
+    "diff is a possible future enhancement."
+  )
   out.append("")
 
   # Footer
   out.append("---")
   out.append("")
-  out.append("*Reconciliation produced by "
-             "`examples/seattle_method_demo/reconcile.py` against the "
-             "rollforward filter engine. See "
-             "`examples/seattle_method_demo/README.md` for the full "
-             "methodology and the architectural pattern this test validates.*")
+  out.append(
+    "*Reconciliation produced by "
+    "`examples/seattle_method_demo/reconcile.py` against the "
+    "rollforward filter engine. See "
+    "`examples/seattle_method_demo/README.md` for the full "
+    "methodology and the architectural pattern this test validates.*"
+  )
 
   return "\n".join(out) + "\n"
 
@@ -1015,7 +1029,9 @@ def main() -> None:
   concepts = _load_concept_totals_via_graphql(
     client, graph_id, args.period_start, args.period_end
   )
-  print(f"  Loaded {len(concepts)} concept(s) with period activity (via GraphQL trialBalance)")
+  print(
+    f"  Loaded {len(concepts)} concept(s) with period activity (via GraphQL trialBalance)"
+  )
   bs_label_by_qname = {c.qname: c.label for c in concepts}
 
   rollforwards = _load_rollforward_ibs_via_graphql(client, graph_id)

--- a/examples/seattle_method_world_online/trial_balance.py
+++ b/examples/seattle_method_world_online/trial_balance.py
@@ -87,25 +87,24 @@ def _fmt(v: float | None) -> str:
   return f"$({abs(v):,.2f})" if v < 0 else f"${v:,.2f}"
 
 
-def render(graph_id: str, rows: list[dict]) -> str:
+def render(graph_id: str, rows: list) -> str:
   # Keep only mini CoA accounts with activity (the graph also carries
   # the rs-gaap library; filter it out client-side, as reconcile does).
   mini_rows = [
     r
     for r in rows
-    if (r.get("account_code") or "").startswith("mini:")
-    and (float(r.get("total_debits") or 0) or float(r.get("total_credits") or 0))
+    if r.account_code.startswith("mini:") and (r.total_debits or r.total_credits)
   ]
   mini_rows.sort(
     key=lambda r: (
-      _TRAIT_ORDER.get(r.get("trait") or "", 99),
-      r.get("account_code") or "",
+      _TRAIT_ORDER.get(r.trait or "", 99),
+      r.account_code,
     )
   )
 
-  total_dr = sum(float(r.get("total_debits") or 0) for r in mini_rows)
-  total_cr = sum(float(r.get("total_credits") or 0) for r in mini_rows)
-  total_net = sum(float(r.get("net_balance") or 0) for r in mini_rows)
+  total_dr = sum(r.total_debits for r in mini_rows)
+  total_cr = sum(r.total_credits for r in mini_rows)
+  total_net = sum(r.net_balance for r in mini_rows)
   balances = abs(total_dr - total_cr) < 0.01
 
   lines = [
@@ -125,12 +124,12 @@ def render(graph_id: str, rows: list[dict]) -> str:
     "|---|---|---:|---:|---:|",
   ]
   for r in mini_rows:
-    name = r.get("account_name") or r.get("account_code")
+    name = r.account_name or r.account_code
     lines.append(
-      f"| {name} (`{r.get('account_code')}`) | {r.get('trait') or '—'} | "
-      f"{_fmt(float(r.get('total_debits') or 0))} | "
-      f"{_fmt(float(r.get('total_credits') or 0))} | "
-      f"{_fmt(float(r.get('net_balance') or 0))} |"
+      f"| {name} (`{r.account_code}`) | {r.trait or '—'} | "
+      f"{_fmt(r.total_debits)} | "
+      f"{_fmt(r.total_credits)} | "
+      f"{_fmt(r.net_balance)} |"
     )
   lines += [
     f"| **Total** | | **{_fmt(total_dr)}** | **{_fmt(total_cr)}** | "
@@ -163,7 +162,7 @@ def main() -> None:
   graph_id = _resolve_graph_id(args.graph_id)
   client = _get_ledger_client()
   data = client.get_trial_balance(graph_id, start_date=TB_START, end_date=TB_END)
-  rows = (data or {}).get("rows", []) or []
+  rows = data.rows if data else []
   if not rows:
     raise SystemExit(f"trialBalance returned no rows for graph {graph_id}.")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     # RoboSystems client for demo and testing
-    "robosystems-client==0.6.2",
+    "robosystems-client==1.0.0",
 
     # Testing framework
     "pytest>=9.0.0,<10.0",

--- a/uv.lock
+++ b/uv.lock
@@ -3699,7 +3699,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.34.2,<3.0" },
     { name = "retrying", specifier = ">=1.4.0,<2.0" },
     { name = "rich", marker = "extra == 'dev'", specifier = ">=15.0.0,<16.0" },
-    { name = "robosystems-client", marker = "extra == 'dev'", specifier = "==0.6.2" },
+    { name = "robosystems-client", marker = "extra == 'dev'", specifier = "==1.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0,<1.0" },
     { name = "sqlalchemy", specifier = ">=2.0.0,<3.0" },
     { name = "sse-starlette", specifier = ">=3.3.0,<4.0" },
@@ -3722,7 +3722,7 @@ lambda = [
 
 [[package]]
 name = "robosystems-client"
-version = "0.6.2"
+version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -3730,9 +3730,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8e/a8/e7189c12ea66269cfa1b7901310f8b75c2b62559ce0726eed0bd52d36730/robosystems_client-0.6.2.tar.gz", hash = "sha256:262d3139715043e46868d96901040b57e3a23da7ba83e69eaa0030d3da3caea7", size = 469785, upload-time = "2026-07-30T18:30:03.839Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/3b/17e90180f3877286a8479b0afbbd67ce6ef24123ec8a540bf65487a21648/robosystems_client-1.0.0.tar.gz", hash = "sha256:71b466b32e438aa06019f30ebd84e4b894290d2a76d899f3053728751295cfda", size = 511516, upload-time = "2026-08-05T01:40:09.249Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5a/91/2d26650de16f9b2f593a16840e9894fa9bf18611f083d79ca9ecbad299cb/robosystems_client-0.6.2-py3-none-any.whl", hash = "sha256:986fe03a5770e1328f63236fe674e0326722269b48ab948aaeb5f06299bffc9c", size = 1083177, upload-time = "2026-07-30T18:30:01.544Z" },
+    { url = "https://files.pythonhosted.org/packages/82/c5/894ff651dcd6bda9e777aee2ff7e7a47a1b8773070fce4da561fc5f881dc/robosystems_client-1.0.0-py3-none-any.whl", hash = "sha256:b46163b0444c9e9a540970778594fff588478b483e8ccb9106218c71094fdf23", size = 1179724, upload-time = "2026-08-05T01:40:07.434Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Moves the dev-extras pin to the graduated SDK (`robosystems-client==1.0.0`) and migrates every example that consumes GraphQL reads from dict access to the typed models: the two Seattle Method scripts (`reconcile.py`, `trial_balance.py`), plus `_common/sdk.py`, `_scenario/runner.py`, and `roboledger_demo/main.py` — the last three surfaced by basedpyright the moment the typed client landed in the venv, which is the 1.0 contract working as designed (backend tests import the client nowhere, so the pin only affects examples).

Also includes ruff-format normalization of `reconcile.py` (examples are ruff-excluded from the lint gate, so this is consistency-only noise in the diff).

## Test plan

`uv run basedpyright` — 0 errors (was 20 dict-subscript errors against the typed models). All five files byte-compile. The examples run against a live stack, so runtime verification happens on the next demo run; access-site changes are mechanical dict→attribute conversions preserving the old fallback semantics.