### PR TITLE
feat(mcp): remote MCP transport — Streamable HTTP at /v1/graphs/{graph_id}/mcp

### DIFF
--- a/robosystems/routers/__init__.py
+++ b/robosystems/routers/__init__.py
@@ -60,6 +60,7 @@ from .graphs import (
   subscriptions_router as graph_subscriptions_router,
 )
 from .graphs.content_ops import router as graph_content_ops_router
+from .graphs.mcp import remote_router as mcp_remote_router
 from .graphs.mcp import router as mcp_router
 from .graphs.operations import router as graph_operations_router
 from .graphs.operator import (
@@ -87,6 +88,9 @@ router.include_router(
   operator_router
 )  # No prefix - handled in the operator module itself
 router.include_router(mcp_router, prefix="/mcp")
+# Streamable-HTTP MCP transport at the bare /mcp path (POST, JSON-RPC 2.0);
+# schema-excluded, so it never appears in the generated SDK clients.
+router.include_router(mcp_remote_router, prefix="/mcp")
 router.include_router(backups_router, prefix="/backups")
 router.include_router(
   usage_router

--- a/robosystems/routers/graphs/mcp/__init__.py
+++ b/robosystems/routers/graphs/mcp/__init__.py
@@ -12,6 +12,7 @@ This module provides a comprehensive MCP tool execution system optimized for AI 
 from fastapi import APIRouter
 
 from .execute import router as execute_router
+from .remote import router as remote_router
 from .tools import router as tools_router
 
 # Create main MCP router
@@ -23,5 +24,9 @@ router = APIRouter(
 router.include_router(tools_router)
 router.include_router(execute_router)
 
-# Export main router
-__all__ = ["router"]
+# The Streamable-HTTP JSON-RPC transport lives at POST /v1/graphs/{graph_id}/mcp
+# (the bare /mcp path). FastAPI rejects an empty path on a prefix-less include,
+# so it is exported separately and mounted with the "/mcp" prefix alongside this
+# router in robosystems/routers/__init__.py. Schema-excluded so the JSON-RPC
+# envelope never reaches the generated SDKs.
+__all__ = ["remote_router", "router"]

--- a/robosystems/routers/graphs/mcp/execute.py
+++ b/robosystems/routers/graphs/mcp/execute.py
@@ -222,6 +222,207 @@ async def execute_tool_directly(
     )
 
 
+async def authorize_mcp_tool_call(
+  graph_id: str,
+  tool_call: MCPToolCall,
+  current_user: User,
+) -> str:
+  """Run the shared MCP tool-call authorization gauntlet.
+
+  Used by both the REST endpoint (POST /mcp/call-tool) and the remote JSON-RPC
+  transport (POST /mcp) so the two surfaces cannot drift: fail-closed write
+  classification, StatementKernel statement policy for cypher read tools,
+  per-graph role validation, shared-repo subscription lookup, and dual-layer
+  volume rate limiting.
+
+  Returns:
+      The resolved access type: "read" or "write".
+
+  Raises:
+      HTTPException: 403 on access/subscription denial, 429 on volume limits.
+  """
+  from robosystems.config import env
+  from robosystems.database import SessionFactory
+
+  is_cypher_read_tool = tool_call.name in (
+    "read-graph-cypher",
+    "read-neo4j-cypher",
+    "read-ladybug-cypher",
+  )
+  # Fail-closed write classification: a tool is a WRITE unless it is on the
+  # read-only allowlist. This makes every non-read tool — including all
+  # registrar-generated OLTP command ops (update-journal-entry, close-period,
+  # execute-event-block, the content-op writes, …) — require the member/admin
+  # role via `validate_mcp_access(..., "write")` below, closing the prior
+  # fail-open gap where only three tool names were flagged as writes and a
+  # `viewer` could reach the whole command surface. Cypher read tools are
+  # classified precisely by the StatementKernel (they can carry a write).
+  is_write_query = (not is_cypher_read_tool) and (
+    tool_call.name not in READ_ONLY_MCP_TOOLS
+  )
+
+  # Validate access using a short-lived session.  The MCP endpoint's
+  # tool execution can take minutes; using a scoped session or FastAPI
+  # db dependency would hold a pool connection for the entire duration.
+  # A plain SessionFactory() session is closed immediately after the
+  # DB work, returning the connection to the pool before tool execution.
+  repo_access = None
+  sess = SessionFactory()
+  try:
+    if is_cypher_read_tool:
+      cypher_query: str = tool_call.arguments.get("query", "")  # type: ignore[assignment]
+      # Only authorize an actual statement. An empty/missing query is a
+      # validation error the tool surfaces ("Query parameter is required"),
+      # not a policy decision — and is_write_operation fail-safes empty input
+      # to "write", which would otherwise mis-trigger the write block.
+      if cypher_query.strip():
+        authz = statement_kernel.authorize(
+          engine=StatementEngine.CYPHER,
+          graph_id=graph_id,
+          statement=cypher_query,
+          user=current_user,
+          session=sess,
+        )
+        is_write_query = authz.is_write
+
+    access_type = "write" if is_write_query else "read"
+    await validate_mcp_access(graph_id, current_user, sess, access_type)
+
+    # Look up shared-repo subscription while session is still open.
+    # Covers subgraphs (e.g. sec_historical) too — subscriptions live on
+    # the parent, so resolve to it before the lookup, matching the query
+    # path in query/execute.py::_check_shared_repository_limits.
+    if MultiTenantUtils.is_shared_repository_or_subgraph(graph_id):
+      from robosystems.config.shared_repositories import (
+        resolve_shared_repository_parent,
+      )
+      from robosystems.models.core.user.user_repository import UserRepository
+
+      repo_access = UserRepository.get_by_user_and_repository(
+        current_user.id, resolve_shared_repository_parent(graph_id), sess
+      )
+  finally:
+    sess.close()
+
+  # Apply dual-layer rate limiting for shared repositories (incl. subgraphs)
+  # Rate limiting is optional - skip if disabled (dev environments)
+  if (
+    MultiTenantUtils.is_shared_repository_or_subgraph(graph_id)
+    and env.RATE_LIMIT_ENABLED
+  ):
+    from robosystems.config.valkey_registry import (
+      ValkeyDatabase,
+      create_async_redis_client,
+    )
+    from robosystems.middleware.rate_limits import DualLayerRateLimiter
+
+    if not repo_access:
+      raise HTTPException(
+        status_code=http_status.HTTP_403_FORBIDDEN,
+        detail=f"Access to {graph_id.upper()} repository requires a subscription. Visit {env.ROBOSYSTEMS_URL}/repositories/browse",
+      )
+
+    # Get Redis client for rate limiting with proper ElastiCache support
+    redis_client = create_async_redis_client(ValkeyDatabase.RATE_LIMITS)
+
+    try:
+      limiter = DualLayerRateLimiter(redis_client)
+
+      # Check shared-repository per-plan volume limits (burst protection is
+      # already enforced upstream by subscription_aware_rate_limit_dependency).
+      limit_check = await limiter.check_limits(
+        user_id=str(current_user.id),
+        graph_id=graph_id,
+        operation="mcp",
+        endpoint=f"mcp/call-tool/{tool_call.name}",
+        repository_plan=repo_access.repository_plan,
+      )
+
+      if not limit_check["allowed"]:
+        reason = limit_check.get("reason", "unknown")
+        message = limit_check.get("message", "Rate limit exceeded")
+
+        if reason == "no_access":
+          raise HTTPException(
+            status_code=http_status.HTTP_403_FORBIDDEN,
+            detail=f"{message}. Subscribe at {env.ROBOSYSTEMS_URL}/repositories/browse",
+          )
+        elif reason == "endpoint_not_allowed":
+          raise HTTPException(
+            status_code=http_status.HTTP_403_FORBIDDEN,
+            detail=message,
+          )
+        elif reason == "repository_limit":
+          detail = limit_check.get("detail", {})
+          raise HTTPException(
+            status_code=http_status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=f"{message}. Limit: {detail.get('limit', 0)} per {detail.get('window', 'period')}. "
+            f"Upgrade for higher limits at {env.ROBOSYSTEMS_URL}/repositories/browse",
+            headers={
+              "Retry-After": str(detail.get("retry_after", 60)),
+              "X-RateLimit-Repository": graph_id,
+              "X-RateLimit-Plan": str(repo_access.repository_plan),
+            },
+          )
+        else:
+          raise HTTPException(
+            status_code=http_status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=message,
+          )
+    finally:
+      await redis_client.close()
+
+  return access_type
+
+
+async def execute_tool_to_json(
+  handler: MCPHandler,
+  graph_id: str,
+  tool_call: MCPToolCall,
+  strategy: MCPExecutionStrategy,
+  timeout: int,
+) -> dict[str, Any]:
+  """Execute a tool call to a single JSON result for the given strategy.
+
+  The remote JSON-RPC transport must return one result per `tools/call`
+  (MCP has no partial-result mechanism), so streaming strategies are
+  aggregated server-side and cacheable strategies go through the Valkey MCP
+  cache. Queue strategies fall through to direct execution here; the remote
+  transport bridges the queue over its SSE response mode instead.
+  """
+  if strategy == MCPExecutionStrategy.SCHEMA_CACHED:
+    cached = await _get_mcp_cache(graph_id, tool_call.name)
+    if cached is not None:
+      return cached
+    result = await execute_tool_directly(handler, tool_call, timeout)
+    await _set_mcp_cache(graph_id, tool_call.name, result, _MCP_SCHEMA_CACHE_TTL)
+    return result
+
+  if strategy == MCPExecutionStrategy.INFO_CACHED:
+    cached = await _get_mcp_cache(graph_id, tool_call.name)
+    if cached is not None:
+      return cached
+    result = await execute_tool_directly(handler, tool_call, timeout)
+    await _set_mcp_cache(graph_id, tool_call.name, result, _MCP_INFO_CACHE_TTL)
+    return result
+
+  if strategy in (
+    MCPExecutionStrategy.STREAM_AGGREGATED,
+    MCPExecutionStrategy.SSE_PROGRESS,
+    MCPExecutionStrategy.SSE_STREAMING,
+    MCPExecutionStrategy.NDJSON_STREAMING,
+  ):
+    events = [
+      event
+      async for event in stream_mcp_tool_execution(
+        handler, tool_call.name, tool_call.arguments, strategy.value
+      )
+    ]
+    return aggregate_streamed_results(events)
+
+  return await execute_tool_directly(handler, tool_call, timeout)
+
+
 async def stream_sse_response(request: Request, events_generator):
   """Generate SSE response with disconnect detection."""
   async for event in events_generator:
@@ -334,141 +535,12 @@ async def call_mcp_tool(
   circuit_breaker.check_circuit(graph_id, tool_call.name)
 
   try:
-    # Determine write intent, and for cypher read tools run the statement
-    # policy — bulk/admin/DDL validation, the three-tier write policy, and the
-    # role gate — through the shared StatementKernel, the same path REST
-    # /query/cypher uses, so the MCP HTTP surface can't drift from it. The
-    # kernel needs a live session, so the call runs inside the short-lived
-    # session block below.
-    from robosystems.database import SessionFactory
-
-    is_cypher_read_tool = tool_call.name in (
-      "read-graph-cypher",
-      "read-neo4j-cypher",
-      "read-ladybug-cypher",
-    )
-    # Fail-closed write classification: a tool is a WRITE unless it is on the
-    # read-only allowlist. This makes every non-read tool — including all
-    # registrar-generated OLTP command ops (update-journal-entry, close-period,
-    # execute-event-block, the content-op writes, …) — require the member/admin
-    # role via `validate_mcp_access(..., "write")` below, closing the prior
-    # fail-open gap where only three tool names were flagged as writes and a
-    # `viewer` could reach the whole command surface. Cypher read tools are
-    # classified precisely by the StatementKernel (they can carry a write).
-    is_write_query = (not is_cypher_read_tool) and (
-      tool_call.name not in READ_ONLY_MCP_TOOLS
-    )
-
-    # Validate access using a short-lived session.  The MCP endpoint's
-    # tool execution can take minutes; using a scoped session or FastAPI
-    # db dependency would hold a pool connection for the entire duration.
-    # A plain SessionFactory() session is closed immediately after the
-    # DB work, returning the connection to the pool before tool execution.
-    repo_access = None
-    sess = SessionFactory()
-    try:
-      if is_cypher_read_tool:
-        cypher_query: str = tool_call.arguments.get("query", "")  # type: ignore[assignment]
-        # Only authorize an actual statement. An empty/missing query is a
-        # validation error the tool surfaces ("Query parameter is required"),
-        # not a policy decision — and is_write_operation fail-safes empty input
-        # to "write", which would otherwise mis-trigger the write block.
-        if cypher_query.strip():
-          authz = statement_kernel.authorize(
-            engine=StatementEngine.CYPHER,
-            graph_id=graph_id,
-            statement=cypher_query,
-            user=current_user,
-            session=sess,
-          )
-          is_write_query = authz.is_write
-
-      access_type = "write" if is_write_query else "read"
-      await validate_mcp_access(graph_id, current_user, sess, access_type)
-
-      # Look up shared-repo subscription while session is still open.
-      # Covers subgraphs (e.g. sec_historical) too — subscriptions live on
-      # the parent, so resolve to it before the lookup, matching the query
-      # path in query/execute.py::_check_shared_repository_limits.
-      if MultiTenantUtils.is_shared_repository_or_subgraph(graph_id):
-        from robosystems.config.shared_repositories import (
-          resolve_shared_repository_parent,
-        )
-        from robosystems.models.core.user.user_repository import UserRepository
-
-        repo_access = UserRepository.get_by_user_and_repository(
-          current_user.id, resolve_shared_repository_parent(graph_id), sess
-        )
-    finally:
-      sess.close()
-
-    # Apply dual-layer rate limiting for shared repositories (incl. subgraphs)
-    # Rate limiting is optional - skip if disabled (dev environments)
-    if (
-      MultiTenantUtils.is_shared_repository_or_subgraph(graph_id)
-      and env.RATE_LIMIT_ENABLED
-    ):
-      from robosystems.config.valkey_registry import (
-        ValkeyDatabase,
-        create_async_redis_client,
-      )
-      from robosystems.middleware.rate_limits import DualLayerRateLimiter
-
-      if not repo_access:
-        raise HTTPException(
-          status_code=http_status.HTTP_403_FORBIDDEN,
-          detail=f"Access to {graph_id.upper()} repository requires a subscription. Visit {env.ROBOSYSTEMS_URL}/repositories/browse",
-        )
-
-      # Get Redis client for rate limiting with proper ElastiCache support
-      redis_client = create_async_redis_client(ValkeyDatabase.RATE_LIMITS)
-
-      try:
-        limiter = DualLayerRateLimiter(redis_client)
-
-        # Check shared-repository per-plan volume limits (burst protection is
-        # already enforced upstream by subscription_aware_rate_limit_dependency).
-        limit_check = await limiter.check_limits(
-          user_id=str(current_user.id),
-          graph_id=graph_id,
-          operation="mcp",
-          endpoint=f"mcp/call-tool/{tool_call.name}",
-          repository_plan=repo_access.repository_plan,
-        )
-
-        if not limit_check["allowed"]:
-          reason = limit_check.get("reason", "unknown")
-          message = limit_check.get("message", "Rate limit exceeded")
-
-          if reason == "no_access":
-            raise HTTPException(
-              status_code=http_status.HTTP_403_FORBIDDEN,
-              detail=f"{message}. Subscribe at {env.ROBOSYSTEMS_URL}/repositories/browse",
-            )
-          elif reason == "endpoint_not_allowed":
-            raise HTTPException(
-              status_code=http_status.HTTP_403_FORBIDDEN,
-              detail=message,
-            )
-          elif reason == "repository_limit":
-            detail = limit_check.get("detail", {})
-            raise HTTPException(
-              status_code=http_status.HTTP_429_TOO_MANY_REQUESTS,
-              detail=f"{message}. Limit: {detail.get('limit', 0)} per {detail.get('window', 'period')}. "
-              f"Upgrade for higher limits at {env.ROBOSYSTEMS_URL}/repositories/browse",
-              headers={
-                "Retry-After": str(detail.get("retry_after", 60)),
-                "X-RateLimit-Repository": graph_id,
-                "X-RateLimit-Plan": str(repo_access.repository_plan),
-              },
-            )
-          else:
-            raise HTTPException(
-              status_code=http_status.HTTP_429_TOO_MANY_REQUESTS,
-              detail=message,
-            )
-      finally:
-        await redis_client.close()
+    # The full authorization gauntlet — fail-closed write classification,
+    # StatementKernel policy for cypher tools, role validation, shared-repo
+    # subscription lookup, and per-plan volume limits — is shared with the
+    # remote JSON-RPC transport (remote.py) so the two surfaces cannot drift.
+    access_type = await authorize_mcp_tool_call(graph_id, tool_call, current_user)
+    is_write_query = access_type == "write"
 
     # Get repository
     operation_type = _get_mcp_operation_type(graph_id)

--- a/robosystems/routers/graphs/mcp/remote.py
+++ b/robosystems/routers/graphs/mcp/remote.py
@@ -665,21 +665,10 @@ async def _handle_tools_call(
   return _rpc_result(msg_id, _to_tool_result(result))
 
 
-@router.post("", include_in_schema=False, response_model=None)
-@endpoint_metrics_decorator(
-  "/v1/graphs/{graph_id}/mcp", business_event_type="mcp_remote_request"
-)
-async def mcp_remote_transport(
-  request: Request,
-  graph_id: str = Path(
-    ...,
-    description="Graph database identifier",
-    pattern=GRAPH_OR_SUBGRAPH_ID_PATTERN,
-  ),
-  current_user: User = Depends(get_current_user_with_graph),
-  _rate_limit: None = Depends(subscription_aware_rate_limit_dependency),
+async def dispatch_jsonrpc(
+  request: Request, graph_id: str, current_user: User
 ) -> Response:
-  """Streamable-HTTP MCP endpoint (JSON-RPC 2.0)."""
+  """Parse and dispatch one JSON-RPC message (the transport's whole surface)."""
   try:
     message = await request.json()
   except Exception:
@@ -745,3 +734,21 @@ async def mcp_remote_transport(
       extra={"graph_id": graph_id, "user_id": str(current_user.id)},
     )
     return _rpc_error(msg_id, INTERNAL_ERROR, "Internal error")
+
+
+@router.post("", include_in_schema=False, response_model=None)
+@endpoint_metrics_decorator(
+  "/v1/graphs/{graph_id}/mcp", business_event_type="mcp_remote_request"
+)
+async def mcp_remote_transport(
+  request: Request,
+  graph_id: str = Path(
+    ...,
+    description="Graph database identifier",
+    pattern=GRAPH_OR_SUBGRAPH_ID_PATTERN,
+  ),
+  current_user: User = Depends(get_current_user_with_graph),
+  _rate_limit: None = Depends(subscription_aware_rate_limit_dependency),
+) -> Response:
+  """Streamable-HTTP MCP endpoint (JSON-RPC 2.0)."""
+  return await dispatch_jsonrpc(request, graph_id, current_user)

--- a/robosystems/routers/graphs/mcp/remote.py
+++ b/robosystems/routers/graphs/mcp/remote.py
@@ -41,7 +41,6 @@ from robosystems.logger import api_logger, logger
 from robosystems.middleware.auth.dependencies import get_current_user_with_graph
 from robosystems.middleware.graph import get_graph_repository
 from robosystems.middleware.graph.types import GRAPH_OR_SUBGRAPH_ID_PATTERN
-from robosystems.middleware.graph.utils import MultiTenantUtils
 from robosystems.middleware.otel.metrics import endpoint_metrics_decorator
 from robosystems.middleware.rate_limits import (
   subscription_aware_rate_limit_dependency,
@@ -51,6 +50,7 @@ from robosystems.models.core import User
 
 from .execute import (
   READ_ONLY_MCP_TOOLS,
+  _get_mcp_operation_type,
   _get_user_priority,
   authorize_mcp_tool_call,
   circuit_breaker,
@@ -145,15 +145,6 @@ async def _validate_read_access(graph_id: str, current_user: User) -> None:
     await validate_mcp_access(graph_id, current_user, sess, "read")
   finally:
     sess.close()
-
-
-def _get_mcp_operation_type(graph_id: str) -> str:
-  # Shared repos and their subgraphs route to the reader cluster; user graphs
-  # always use the writer for consistency (matches tools.py / factory.py).
-  if MultiTenantUtils.is_shared_repository_or_subgraph(graph_id):
-    return "read"
-  else:
-    return "write"
 
 
 # On the npx bridge, switch-workspace mutates client process state; a remote
@@ -621,8 +612,14 @@ async def _handle_tools_call(
 
   # Queue bridge: under load, cypher reads route through the shared query
   # queue. The stream relays queue state as progress and resolves with the
-  # result — no handler needed, the queue executes the query itself. Clients
-  # that don't accept SSE fall through to bounded direct execution.
+  # result — no handler needed, the queue executes the query itself.
+  #
+  # DELIBERATE: a client that doesn't accept SSE falls through to bounded
+  # direct execution below, bypassing queue admission during exactly the load
+  # window the queue exists for. Accepted because spec-compliant MCP clients
+  # always send `Accept: …, text/event-stream` (the fallback is for curl-grade
+  # callers), the direct path is still bounded by its strategy timeout, and
+  # the graph API's own admission control backstops instance saturation.
   if (
     strategy in _QUEUE_STRATEGIES and name in _CYPHER_READ_TOOLS and client_accepts_sse
   ):
@@ -699,16 +696,19 @@ async def dispatch_jsonrpc(
 
   method = message.get("method")
   msg_id = message.get("id")
-  params = message.get("params") or {}
-  if not isinstance(params, dict):
-    return _rpc_error(msg_id, INVALID_PARAMS, "Invalid params: expected an object")
 
   # A message without a method is a client->server response; a message without
   # an id is a notification. Streamable HTTP: accept both with 202, no body.
+  # This runs BEFORE params validation — a notification must never receive a
+  # reply, not even an error for malformed params (JSON-RPC 2.0 §4.1).
   # (notifications/initialized and notifications/cancelled land here —
   # cancellation is best-effort only on a stateless multi-node transport.)
   if not isinstance(method, str) or "id" not in message:
     return Response(status_code=http_status.HTTP_202_ACCEPTED)
+
+  params = message.get("params") or {}
+  if not isinstance(params, dict):
+    return _rpc_error(msg_id, INVALID_PARAMS, "Invalid params: expected an object")
 
   try:
     if method == "initialize":

--- a/robosystems/routers/graphs/mcp/remote.py
+++ b/robosystems/routers/graphs/mcp/remote.py
@@ -25,6 +25,7 @@ Transport rules:
   the generated SDK clients.
 """
 
+import asyncio
 import json
 from importlib.metadata import version as pkg_version
 from typing import Any
@@ -33,6 +34,7 @@ from fastapi import APIRouter, Depends, Path, Request, Response
 from fastapi import status as http_status
 from fastapi.exceptions import HTTPException
 from fastapi.responses import JSONResponse
+from sse_starlette.sse import EventSourceResponse
 
 from robosystems.logger import api_logger, logger
 from robosystems.middleware.auth.dependencies import get_current_user_with_graph
@@ -53,7 +55,8 @@ from .execute import (
   execute_tool_to_json,
 )
 from .handlers import MCPHandler, validate_mcp_access
-from .strategies import MCPStrategySelector
+from .strategies import MCPExecutionStrategy, MCPStrategySelector
+from .streaming import aggregate_streamed_results, stream_mcp_tool_execution
 
 router = APIRouter()
 
@@ -214,9 +217,147 @@ async def _handle_tools_list(graph_id: str, current_user: User) -> dict[str, Any
   return {"tools": mcp_tools}
 
 
+# Strategies whose work is long or chunked enough to earn the SSE response
+# mode. Everything else answers as a single application/json body — Streamable
+# HTTP lets the server choose per call.
+_SSE_STRATEGIES = frozenset(
+  {
+    MCPExecutionStrategy.STREAM_AGGREGATED,
+    MCPExecutionStrategy.SSE_PROGRESS,
+    MCPExecutionStrategy.SSE_STREAMING,
+    MCPExecutionStrategy.NDJSON_STREAMING,
+  }
+)
+
+# Keepalive interval for SSE responses. Comment pings (`: ping …`) keep the
+# stream alive through the ALB idle timeout (default 60s) without being
+# parsed as messages by MCP clients.
+_SSE_PING_SECONDS = 15
+
+
+def _event_to_progress(
+  token: Any, event: dict[str, Any], last_progress: float
+) -> tuple[dict[str, Any] | None, float]:
+  """Map one internal streaming event to a notifications/progress message.
+
+  Internal progress events mix scales (percentages vs row counts), so the
+  emitted `progress` value is clamped monotonically increasing as the MCP
+  spec requires. Data-bearing events (chunks, results) return None here —
+  they are aggregated into the final response, never sent as notifications.
+  """
+  etype = event.get("event")
+  data = event.get("data") or {}
+
+  message: str | None = None
+  value: float | None = None
+  if etype == "start":
+    message = data.get("message")
+    value = 0.0
+  elif etype == "progress":
+    message = data.get("message")
+    raw = data.get("progress", data.get("rows_processed"))
+    value = float(raw) if raw is not None else None
+  elif etype == "query_chunk":
+    rows = data.get("total_rows_so_far")
+    if rows is not None:
+      value = float(rows)
+      message = f"Fetched {rows} rows"
+  else:
+    return None, last_progress
+
+  progress = value if value is not None else last_progress + 1.0
+  if progress <= last_progress:
+    progress = last_progress + 1.0
+
+  params: dict[str, Any] = {"progressToken": token, "progress": progress}
+  if message:
+    params["message"] = message
+  return (
+    {"jsonrpc": "2.0", "method": "notifications/progress", "params": params},
+    progress,
+  )
+
+
+async def _stream_tool_call(
+  handler: MCPHandler,
+  graph_id: str,
+  tool_call: MCPToolCall,
+  strategy: MCPExecutionStrategy,
+  timeout: int,
+  msg_id: Any,
+  progress_token: Any,
+):
+  """Drive one tools/call as the SSE body of the POST response.
+
+  Emits notifications/progress while the tool runs (only when the client sent
+  `_meta.progressToken` — the MCP contract), then the final JSON-RPC response,
+  then ends the stream. A client disconnect cancels this generator and with it
+  the in-flight tool work — the transport-level closure of the abandoned-CPU
+  gap. sse_starlette's comment ping carries the stream across the ALB idle
+  timeout while the tool is silent.
+  """
+  events: list[dict[str, Any]] = []
+  last_progress = 0.0
+  payload: dict[str, Any]
+  try:
+    try:
+      async with asyncio.timeout(timeout):
+        async for event in stream_mcp_tool_execution(
+          handler, tool_call.name, tool_call.arguments, strategy.value
+        ):
+          events.append(event)
+          if progress_token is None:
+            continue
+          notification, last_progress = _event_to_progress(
+            progress_token, event, last_progress
+          )
+          if notification:
+            yield {"data": json.dumps(notification)}
+
+      result = aggregate_streamed_results(events)
+      payload = {"jsonrpc": "2.0", "id": msg_id, "result": _to_tool_result(result)}
+      circuit_breaker.record_success(graph_id, tool_call.name)
+    except TimeoutError:
+      payload = {
+        "jsonrpc": "2.0",
+        "id": msg_id,
+        "result": {
+          "content": [
+            {
+              "type": "text",
+              "text": f"Error: tool '{tool_call.name}' timed out after {timeout} seconds",
+            }
+          ],
+          "isError": True,
+        },
+      }
+    except Exception as e:
+      circuit_breaker.record_failure(graph_id, tool_call.name)
+      logger.error(
+        f"Remote MCP streamed tool execution failed: {e}",
+        extra={"graph_id": graph_id, "tool_name": tool_call.name},
+      )
+      payload = {
+        "jsonrpc": "2.0",
+        "id": msg_id,
+        "result": {
+          "content": [{"type": "text", "text": "Tool execution failed."}],
+          "isError": True,
+        },
+      }
+    yield {"data": json.dumps(payload)}
+  finally:
+    if not handler._closed:
+      await handler.close()
+
+
 async def _handle_tools_call(
-  graph_id: str, current_user: User, msg_id: Any, params: dict[str, Any]
-) -> JSONResponse:
+  request: Request,
+  graph_id: str,
+  current_user: User,
+  msg_id: Any,
+  params: dict[str, Any],
+) -> Response:
   name = params.get("name")
   if not isinstance(name, str) or not name:
     return _rpc_error(msg_id, INVALID_PARAMS, "Invalid params: 'name' is required")
@@ -247,26 +388,41 @@ async def _handle_tools_call(
     },
   )
 
+  from robosystems.middleware.graph.query_queue import get_query_queue
+
+  tool_stats = get_query_queue().get_stats()
+  strategy = MCPStrategySelector.select_strategy(
+    tool_name=name,
+    arguments=arguments,
+    client_info=_REMOTE_CLIENT_INFO,
+    system_state={
+      "queue_size": tool_stats["queue_size"],
+      "running_queries": tool_stats["running_queries"],
+      "cache_available": True,
+    },
+    graph_id=graph_id,
+    user_tier=None,
+  )
+  timeout = MCPStrategySelector.get_timeout_for_strategy(strategy)
+
   repository = await get_graph_repository(graph_id, _get_mcp_operation_type(graph_id))
   handler = MCPHandler(repository, graph_id, current_user)
-  try:
-    from robosystems.middleware.graph.query_queue import get_query_queue
 
-    tool_stats = get_query_queue().get_stats()
-    strategy = MCPStrategySelector.select_strategy(
-      tool_name=name,
-      arguments=arguments,
-      client_info=_REMOTE_CLIENT_INFO,
-      system_state={
-        "queue_size": tool_stats["queue_size"],
-        "running_queries": tool_stats["running_queries"],
-        "cache_available": True,
-      },
-      graph_id=graph_id,
-      user_tier=None,
+  # SSE-on-POST: long/streaming strategies answer as text/event-stream when
+  # the client accepts it (MCP clients advertise both). Handler ownership
+  # passes to the generator, which closes it when the stream ends.
+  meta = params.get("_meta")
+  progress_token = meta.get("progressToken") if isinstance(meta, dict) else None
+  accept_header = request.headers.get("accept", "")
+  if strategy in _SSE_STRATEGIES and "text/event-stream" in accept_header:
+    return EventSourceResponse(
+      _stream_tool_call(
+        handler, graph_id, tool_call, strategy, timeout, msg_id, progress_token
+      ),
+      ping=_SSE_PING_SECONDS,
     )
-    timeout = MCPStrategySelector.get_timeout_for_strategy(strategy)
 
+  try:
     result = await execute_tool_to_json(handler, graph_id, tool_call, strategy, timeout)
   except HTTPException as e:
     detail = e.detail if isinstance(e.detail, str) else json.dumps(e.detail)
@@ -352,7 +508,7 @@ async def mcp_remote_transport(
     elif method == "tools/list":
       return _rpc_result(msg_id, await _handle_tools_list(graph_id, current_user))
     elif method == "tools/call":
-      return await _handle_tools_call(graph_id, current_user, msg_id, params)
+      return await _handle_tools_call(request, graph_id, current_user, msg_id, params)
     else:
       return _rpc_error(msg_id, METHOD_NOT_FOUND, f"Method not found: {method}")
   except HTTPException as e:

--- a/robosystems/routers/graphs/mcp/remote.py
+++ b/robosystems/routers/graphs/mcp/remote.py
@@ -27,6 +27,7 @@ Transport rules:
 
 import asyncio
 import json
+import re
 from importlib.metadata import version as pkg_version
 from typing import Any
 
@@ -155,6 +156,55 @@ def _get_mcp_operation_type(graph_id: str) -> str:
     return "write"
 
 
+# On the npx bridge, switch-workspace mutates client process state; a remote
+# connector has no client process and is URL-anchored to one graph. The
+# remote surface rewrites the tool to resolve the target's connector URL.
+_REMOTE_SWITCH_WORKSPACE_DESCRIPTION = (
+  "Resolve the MCP connector URL for a different subgraph workspace (or "
+  "`primary` for the parent graph). This connector is anchored to one graph "
+  "by its URL and cannot switch in-session — the tool returns the URL to add "
+  "as a separate MCP connector (same API key), where work on that workspace "
+  "continues."
+)
+
+
+def _remote_switch_workspace(graph_id: str, arguments: dict[str, Any]) -> str:
+  """Answer switch-workspace with the target's connector URL (text result)."""
+  from robosystems.config import env
+
+  target = str(arguments.get("workspace_id") or "").strip()
+  parent = graph_id.split("_")[0]
+  if not target:
+    return "Error: workspace_id is required (a subgraph id, name, or 'primary')."
+
+  if target == "primary":
+    target_id = parent
+  elif "_" in target:
+    target_id = target
+  else:
+    target_id = f"{parent}_{target}"
+
+  if not re.fullmatch(GRAPH_OR_SUBGRAPH_ID_PATTERN, target_id):
+    return f"Error: '{target}' is not a valid workspace id or name."
+
+  connector_url = f"{env.ROBOSYSTEMS_API_URL}/v1/graphs/{target_id}/mcp"
+  return json.dumps(
+    {
+      "switched": False,
+      "reason": "url_anchored_connector",
+      "target_graph_id": target_id,
+      "connector_url": connector_url,
+      "message": (
+        f"This connector is anchored to graph '{graph_id}' by its URL and "
+        f"cannot switch workspaces in-session. To work on '{target_id}', add "
+        f"a new MCP connector pointing at {connector_url} (same API key) and "
+        "continue there."
+      ),
+    },
+    indent=2,
+  )
+
+
 async def _handle_initialize(
   graph_id: str, current_user: User, params: dict[str, Any]
 ) -> dict[str, Any]:
@@ -219,6 +269,8 @@ async def _handle_tools_list(graph_id: str, current_user: User) -> dict[str, Any
     # statement by the StatementKernel and can carry writes on tenant graphs.
     if tool["name"] in READ_ONLY_MCP_TOOLS:
       entry["annotations"] = {"readOnlyHint": True}
+    if tool["name"] == "switch-workspace":
+      entry["description"] = _REMOTE_SWITCH_WORKSPACE_DESCRIPTION
     mcp_tools.append(entry)
 
   return {"tools": mcp_tools}
@@ -532,6 +584,18 @@ async def _handle_tools_call(
       "access_type": access_type,
     },
   )
+
+  # switch-workspace never reaches the tool layer on this transport: the
+  # connector is URL-anchored (a subgraph is another connector URL), so the
+  # answer is the target's URL. Runs after the gauntlet — access to THIS
+  # graph is still required to resolve its family's URLs.
+  if name == "switch-workspace":
+    return _rpc_result(
+      msg_id,
+      _to_tool_result(
+        {"type": "text", "text": _remote_switch_workspace(graph_id, arguments)}
+      ),
+    )
 
   from robosystems.middleware.graph.query_queue import get_query_queue
 

--- a/robosystems/routers/graphs/mcp/remote.py
+++ b/robosystems/routers/graphs/mcp/remote.py
@@ -50,6 +50,7 @@ from robosystems.models.core import User
 
 from .execute import (
   READ_ONLY_MCP_TOOLS,
+  _get_user_priority,
   authorize_mcp_tool_call,
   circuit_breaker,
   execute_tool_to_json,
@@ -106,17 +107,23 @@ def _rpc_error(
   )
 
 
-def _tool_error_result(msg_id: Any, text: str) -> JSONResponse:
-  """Report a tool-execution failure inside a successful JSON-RPC response.
+def _tool_error_payload(msg_id: Any, text: str) -> dict[str, Any]:
+  """A tool-execution failure as a complete JSON-RPC response payload.
 
   Per the MCP spec, failures of the tool itself (as opposed to protocol
   errors) are returned as ``result.isError`` so the model can see the message
   and react — e.g. relay a subscription or rate-limit notice to the user.
   """
-  return _rpc_result(
-    msg_id,
-    {"content": [{"type": "text", "text": text}], "isError": True},
-  )
+  return {
+    "jsonrpc": "2.0",
+    "id": msg_id,
+    "result": {"content": [{"type": "text", "text": text}], "isError": True},
+  }
+
+
+def _tool_error_result(msg_id: Any, text: str) -> JSONResponse:
+  """`_tool_error_payload` as an HTTP response (the non-streaming path)."""
+  return JSONResponse(content=_tool_error_payload(msg_id, text))
 
 
 def _to_tool_result(result: Any) -> dict[str, Any]:
@@ -233,6 +240,29 @@ _SSE_STRATEGIES = frozenset(
 # stream alive through the ALB idle timeout (default 60s) without being
 # parsed as messages by MCP clients.
 _SSE_PING_SECONDS = 15
+
+# Cypher read tools route through the shared query queue under load; other
+# tools execute directly (mirrors the REST endpoint's queue path).
+_CYPHER_READ_TOOLS = frozenset(
+  {"read-graph-cypher", "read-neo4j-cypher", "read-ladybug-cypher"}
+)
+
+_QUEUE_STRATEGIES = frozenset(
+  {
+    MCPExecutionStrategy.QUEUE_WITH_MONITORING,
+    MCPExecutionStrategy.QUEUE_SIMPLE,
+  }
+)
+
+# Explicit end-to-end ceiling (queue wait + execution) for a bridged queued
+# call. MCP tools/call must resolve on this request, so unlike the REST 202
+# path — where the client owns the polling budget — the held stream needs its
+# own deliberate ceiling. Matches the long-tool ceiling advertised in
+# tools/list capabilities.
+_QUEUE_BRIDGE_TIMEOUT_SECONDS = 300
+
+# Poll cadence for bridged queue monitoring (same as the REST monitor loop).
+_QUEUE_POLL_SECONDS = 1.0
 
 
 def _event_to_progress(
@@ -351,6 +381,121 @@ async def _stream_tool_call(
       await handler.close()
 
 
+async def _stream_queued_call(
+  graph_id: str,
+  tool_call: MCPToolCall,
+  current_user: User,
+  msg_id: Any,
+  progress_token: Any,
+):
+  """Bridge a queued cypher execution onto the SSE response.
+
+  The REST endpoint answers queue strategies with 202 + a polling URL, which
+  has no MCP equivalent — tools/call must resolve on this request. So the
+  bridge submits to the shared query queue, holds the stream, relays queue
+  state as notifications/progress, and emits the final JSON-RPC response on
+  completion. A client disconnect cancels the queued query so abandoned work
+  stops consuming queue capacity.
+  """
+  from robosystems.middleware.graph.query_queue import get_query_queue
+
+  queue_manager = get_query_queue()
+  query: str = tool_call.arguments.get("query", "")  # type: ignore[assignment]
+  parameters = tool_call.arguments.get("parameters") or {}
+
+  payload: dict[str, Any]
+  queue_id: str | None = None
+  query_settled = False  # reached completed/failed/cancelled in the queue
+  last_progress = 0.0
+  try:
+    try:
+      queue_id = await queue_manager.submit_query(
+        cypher=query,
+        parameters=parameters,  # type: ignore[arg-type]
+        graph_id=graph_id,
+        user_id=str(current_user.id),
+        credits_required=10.0,
+        priority=_get_user_priority(current_user),
+      )
+
+      async with asyncio.timeout(_QUEUE_BRIDGE_TIMEOUT_SECONDS):
+        while True:
+          status = await queue_manager.get_query_status(queue_id)
+          if not status:
+            query_settled = True  # nothing left in the queue to cancel
+            payload = _tool_error_payload(
+              msg_id, "Queued query state was lost. Please retry."
+            )
+            break
+
+          state = str(status.get("status", ""))
+          if progress_token is not None:
+            position = status.get("queue_position")
+            message = (
+              f"Queued (position {position})"
+              if state == "pending" and position
+              else state.capitalize()
+            )
+            last_progress += 1.0
+            yield {
+              "data": json.dumps(
+                {
+                  "jsonrpc": "2.0",
+                  "method": "notifications/progress",
+                  "params": {
+                    "progressToken": progress_token,
+                    "progress": last_progress,
+                    "message": message,
+                  },
+                }
+              )
+            }
+
+          if state == "completed":
+            query_settled = True
+            result = await queue_manager.get_query_result(queue_id)
+            payload = {
+              "jsonrpc": "2.0",
+              "id": msg_id,
+              "result": _to_tool_result(result),
+            }
+            circuit_breaker.record_success(graph_id, tool_call.name)
+            break
+          if state in ("failed", "cancelled"):
+            query_settled = True
+            error = status.get("error") or f"Query {state}"
+            payload = _tool_error_payload(msg_id, str(error))
+            break
+
+          await asyncio.sleep(_QUEUE_POLL_SECONDS)
+    except TimeoutError:
+      payload = _tool_error_payload(
+        msg_id,
+        f"Error: queued query did not complete within "
+        f"{_QUEUE_BRIDGE_TIMEOUT_SECONDS} seconds",
+      )
+    except Exception as e:
+      circuit_breaker.record_failure(graph_id, tool_call.name)
+      logger.error(
+        f"Remote MCP queued execution failed: {e}",
+        extra={"graph_id": graph_id, "tool_name": tool_call.name},
+      )
+      payload = _tool_error_payload(msg_id, "Tool execution failed.")
+
+    yield {"data": json.dumps(payload)}
+  finally:
+    # Reached without a settled queue state on disconnect (generator closed
+    # at a yield), bridge timeout, or submit/monitor failure: stop the queued
+    # work so abandoned queries don't burn queue capacity.
+    if not query_settled and queue_id is not None:
+      try:
+        await queue_manager.cancel_query(queue_id, str(current_user.id))
+      except Exception as cancel_error:
+        logger.warning(
+          f"Failed to cancel abandoned queued query {queue_id}: {cancel_error}"
+        )
+
+
 async def _handle_tools_call(
   request: Request,
   graph_id: str,
@@ -405,16 +550,30 @@ async def _handle_tools_call(
   )
   timeout = MCPStrategySelector.get_timeout_for_strategy(strategy)
 
+  meta = params.get("_meta")
+  progress_token = meta.get("progressToken") if isinstance(meta, dict) else None
+  accept_header = request.headers.get("accept", "")
+  client_accepts_sse = "text/event-stream" in accept_header
+
+  # Queue bridge: under load, cypher reads route through the shared query
+  # queue. The stream relays queue state as progress and resolves with the
+  # result — no handler needed, the queue executes the query itself. Clients
+  # that don't accept SSE fall through to bounded direct execution.
+  if (
+    strategy in _QUEUE_STRATEGIES and name in _CYPHER_READ_TOOLS and client_accepts_sse
+  ):
+    return EventSourceResponse(
+      _stream_queued_call(graph_id, tool_call, current_user, msg_id, progress_token),
+      ping=_SSE_PING_SECONDS,
+    )
+
   repository = await get_graph_repository(graph_id, _get_mcp_operation_type(graph_id))
   handler = MCPHandler(repository, graph_id, current_user)
 
   # SSE-on-POST: long/streaming strategies answer as text/event-stream when
   # the client accepts it (MCP clients advertise both). Handler ownership
   # passes to the generator, which closes it when the stream ends.
-  meta = params.get("_meta")
-  progress_token = meta.get("progressToken") if isinstance(meta, dict) else None
-  accept_header = request.headers.get("accept", "")
-  if strategy in _SSE_STRATEGIES and "text/event-stream" in accept_header:
+  if strategy in _SSE_STRATEGIES and client_accepts_sse:
     return EventSourceResponse(
       _stream_tool_call(
         handler, graph_id, tool_call, strategy, timeout, msg_id, progress_token

--- a/robosystems/routers/graphs/mcp/remote.py
+++ b/robosystems/routers/graphs/mcp/remote.py
@@ -1,0 +1,368 @@
+"""Remote MCP transport — Streamable HTTP (JSON-RPC 2.0) over the existing tool layer.
+
+``POST /v1/graphs/{graph_id}/mcp`` is the wire-protocol front door for MCP
+clients that connect by URL (Claude custom connectors, Cursor, ``mcp-remote``).
+The npx stdio bridge translates MCP to the REST tool endpoints; this endpoint
+speaks the protocol directly, so a graph is connectable by pasting its URL.
+
+The dispatch is hand-rolled rather than mounted from the MCP SDK server: the
+tool surface is dynamic per graph (shared-repo gating, ``read_only``,
+extension flags), and every call must run behind the same FastAPI dependency
+chain as the REST tool endpoints — auth, per-graph access, rate limits, the
+shared write-classification gauntlet, and the circuit breaker.
+
+Transport rules:
+
+- ``graph_id`` lives in the URL path and never becomes a tool argument. The
+  per-graph ``serverInfo.name`` and ``instructions`` reinforce the anchor,
+  and instructions are rebuilt per ``initialize`` rather than frozen at
+  client-process start.
+- Stateless: no ``Mcp-Session-Id``, no GET-side SSE channel, no resumability.
+  A subgraph is addressed as another connector URL, never via in-session
+  switching.
+- Header auth (``X-API-Key`` or JWT); OAuth is a separate, later surface.
+- Excluded from the OpenAPI schema so the JSON-RPC envelope never lands in
+  the generated SDK clients.
+"""
+
+import json
+from importlib.metadata import version as pkg_version
+from typing import Any
+
+from fastapi import APIRouter, Depends, Path, Request, Response
+from fastapi import status as http_status
+from fastapi.exceptions import HTTPException
+from fastapi.responses import JSONResponse
+
+from robosystems.logger import api_logger, logger
+from robosystems.middleware.auth.dependencies import get_current_user_with_graph
+from robosystems.middleware.graph import get_graph_repository
+from robosystems.middleware.graph.types import GRAPH_OR_SUBGRAPH_ID_PATTERN
+from robosystems.middleware.graph.utils import MultiTenantUtils
+from robosystems.middleware.otel.metrics import endpoint_metrics_decorator
+from robosystems.middleware.rate_limits import (
+  subscription_aware_rate_limit_dependency,
+)
+from robosystems.models.api.graphs.mcp import MCPToolCall
+from robosystems.models.core import User
+
+from .execute import (
+  READ_ONLY_MCP_TOOLS,
+  authorize_mcp_tool_call,
+  circuit_breaker,
+  execute_tool_to_json,
+)
+from .handlers import MCPHandler, validate_mcp_access
+from .strategies import MCPStrategySelector
+
+router = APIRouter()
+
+# Protocol revisions this transport can negotiate. The server answers with the
+# client's requested revision when supported, else its own latest.
+MCP_SUPPORTED_PROTOCOL_VERSIONS = frozenset({"2024-11-05", "2025-03-26", "2025-06-18"})
+MCP_LATEST_PROTOCOL_VERSION = "2025-06-18"
+
+# JSON-RPC 2.0 error codes
+PARSE_ERROR = -32700
+INVALID_REQUEST = -32600
+METHOD_NOT_FOUND = -32601
+INVALID_PARAMS = -32602
+INTERNAL_ERROR = -32603
+
+# The capability profile asserted for every remote caller. Real MCP clients
+# (Claude, Cursor) send neither the `robosystems-mcp` User-Agent nor the
+# X-MCP-Client header the npx bridge sends, so header sniffing would classify
+# them as browsers and degrade strategy selection. Anything speaking JSON-RPC
+# on this endpoint IS an MCP client by construction.
+_REMOTE_CLIENT_INFO: dict[str, Any] = {
+  "is_mcp_client": True,
+  "supports_sse": True,
+  "supports_ndjson": False,
+  "prefers_streaming": False,
+  "client_version": "remote",
+  "is_testing_tool": False,
+  "is_browser": False,
+  "is_interactive": False,
+}
+
+
+def _rpc_result(msg_id: Any, result: dict[str, Any]) -> JSONResponse:
+  return JSONResponse(content={"jsonrpc": "2.0", "id": msg_id, "result": result})
+
+
+def _rpc_error(
+  msg_id: Any, code: int, message: str, http_code: int = http_status.HTTP_200_OK
+) -> JSONResponse:
+  return JSONResponse(
+    status_code=http_code,
+    content={
+      "jsonrpc": "2.0",
+      "id": msg_id,
+      "error": {"code": code, "message": message},
+    },
+  )
+
+
+def _tool_error_result(msg_id: Any, text: str) -> JSONResponse:
+  """Report a tool-execution failure inside a successful JSON-RPC response.
+
+  Per the MCP spec, failures of the tool itself (as opposed to protocol
+  errors) are returned as ``result.isError`` so the model can see the message
+  and react — e.g. relay a subscription or rate-limit notice to the user.
+  """
+  return _rpc_result(
+    msg_id,
+    {"content": [{"type": "text", "text": text}], "isError": True},
+  )
+
+
+def _to_tool_result(result: Any) -> dict[str, Any]:
+  """Map an internal tool result onto the MCP ``tools/call`` result shape."""
+  if isinstance(result, dict) and result.get("type") == "text" and "text" in result:
+    content = [{"type": "text", "text": result["text"]}]
+  else:
+    content = [{"type": "text", "text": json.dumps(result, indent=2, default=str)}]
+  return {"content": content, "isError": False}
+
+
+async def _validate_read_access(graph_id: str, current_user: User) -> None:
+  """Read-access check on a short-lived session (initialize / tools/list)."""
+  from robosystems.database import SessionFactory
+
+  sess = SessionFactory()
+  try:
+    await validate_mcp_access(graph_id, current_user, sess, "read")
+  finally:
+    sess.close()
+
+
+def _get_mcp_operation_type(graph_id: str) -> str:
+  # Shared repos and their subgraphs route to the reader cluster; user graphs
+  # always use the writer for consistency (matches tools.py / factory.py).
+  if MultiTenantUtils.is_shared_repository_or_subgraph(graph_id):
+    return "read"
+  else:
+    return "write"
+
+
+async def _handle_initialize(
+  graph_id: str, current_user: User, params: dict[str, Any]
+) -> dict[str, Any]:
+  requested = params.get("protocolVersion")
+  protocol_version = (
+    requested
+    if isinstance(requested, str) and requested in MCP_SUPPORTED_PROTOCOL_VERSIONS
+    else MCP_LATEST_PROTOCOL_VERSION
+  )
+
+  await _validate_read_access(graph_id, current_user)
+
+  # Instructions are rebuilt per initialize from the live tool surface — the
+  # remote transport's correctness upgrade over the npx bridge, where the
+  # instructions field is frozen at client-process start.
+  instructions: str | None = None
+  repository = await get_graph_repository(graph_id, _get_mcp_operation_type(graph_id))
+  handler = MCPHandler(repository, graph_id, current_user)
+  try:
+    tools = await handler.get_tools()
+    try:
+      instructions = handler.get_instructions(tools)
+    except Exception as instructions_error:
+      logger.warning(
+        f"Failed to build MCP instructions for graph {graph_id}: {instructions_error}"
+      )
+  finally:
+    await handler.close()
+
+  result: dict[str, Any] = {
+    "protocolVersion": protocol_version,
+    "capabilities": {"tools": {"listChanged": False}},
+    "serverInfo": {
+      "name": f"robosystems-{graph_id}",
+      "title": f"RoboSystems — {graph_id}",
+      "version": pkg_version("robosystems"),
+    },
+  }
+  if instructions:
+    result["instructions"] = instructions
+  return result
+
+
+async def _handle_tools_list(graph_id: str, current_user: User) -> dict[str, Any]:
+  await _validate_read_access(graph_id, current_user)
+
+  repository = await get_graph_repository(graph_id, _get_mcp_operation_type(graph_id))
+  handler = MCPHandler(repository, graph_id, current_user)
+  try:
+    tools = await handler.get_tools()
+  finally:
+    await handler.close()
+
+  mcp_tools: list[dict[str, Any]] = []
+  for tool in tools:
+    entry: dict[str, Any] = {
+      "name": tool["name"],
+      "description": tool.get("description", ""),
+      "inputSchema": tool.get("inputSchema", {"type": "object", "properties": {}}),
+    }
+    # Cypher read tools are deliberately unhinted: they are classified per
+    # statement by the StatementKernel and can carry writes on tenant graphs.
+    if tool["name"] in READ_ONLY_MCP_TOOLS:
+      entry["annotations"] = {"readOnlyHint": True}
+    mcp_tools.append(entry)
+
+  return {"tools": mcp_tools}
+
+
+async def _handle_tools_call(
+  graph_id: str, current_user: User, msg_id: Any, params: dict[str, Any]
+) -> JSONResponse:
+  name = params.get("name")
+  if not isinstance(name, str) or not name:
+    return _rpc_error(msg_id, INVALID_PARAMS, "Invalid params: 'name' is required")
+  arguments = params.get("arguments") or {}
+  if not isinstance(arguments, dict):
+    return _rpc_error(
+      msg_id, INVALID_PARAMS, "Invalid params: 'arguments' must be an object"
+    )
+
+  tool_call = MCPToolCall(name=name, arguments=arguments)
+
+  try:
+    circuit_breaker.check_circuit(graph_id, name)
+    access_type = await authorize_mcp_tool_call(graph_id, tool_call, current_user)
+  except HTTPException as e:
+    detail = e.detail if isinstance(e.detail, str) else json.dumps(e.detail)
+    return _tool_error_result(msg_id, detail)
+
+  api_logger.info(
+    f"Remote MCP tool execution started: {name}",
+    extra={
+      "component": "mcp_remote",
+      "action": "tool_started",
+      "user_id": str(current_user.id),
+      "database": graph_id,
+      "tool_name": name,
+      "access_type": access_type,
+    },
+  )
+
+  repository = await get_graph_repository(graph_id, _get_mcp_operation_type(graph_id))
+  handler = MCPHandler(repository, graph_id, current_user)
+  try:
+    from robosystems.middleware.graph.query_queue import get_query_queue
+
+    tool_stats = get_query_queue().get_stats()
+    strategy = MCPStrategySelector.select_strategy(
+      tool_name=name,
+      arguments=arguments,
+      client_info=_REMOTE_CLIENT_INFO,
+      system_state={
+        "queue_size": tool_stats["queue_size"],
+        "running_queries": tool_stats["running_queries"],
+        "cache_available": True,
+      },
+      graph_id=graph_id,
+      user_tier=None,
+    )
+    timeout = MCPStrategySelector.get_timeout_for_strategy(strategy)
+
+    result = await execute_tool_to_json(handler, graph_id, tool_call, strategy, timeout)
+  except HTTPException as e:
+    detail = e.detail if isinstance(e.detail, str) else json.dumps(e.detail)
+    return _tool_error_result(msg_id, detail)
+  except Exception as e:
+    circuit_breaker.record_failure(graph_id, name)
+    logger.error(
+      f"Remote MCP tool execution failed: {e}",
+      extra={"graph_id": graph_id, "user_id": str(current_user.id), "tool_name": name},
+    )
+    return _tool_error_result(msg_id, "Tool execution failed.")
+  finally:
+    if not handler._closed:
+      await handler.close()
+
+  circuit_breaker.record_success(graph_id, name)
+  return _rpc_result(msg_id, _to_tool_result(result))
+
+
+@router.post("", include_in_schema=False, response_model=None)
+@endpoint_metrics_decorator(
+  "/v1/graphs/{graph_id}/mcp", business_event_type="mcp_remote_request"
+)
+async def mcp_remote_transport(
+  request: Request,
+  graph_id: str = Path(
+    ...,
+    description="Graph database identifier",
+    pattern=GRAPH_OR_SUBGRAPH_ID_PATTERN,
+  ),
+  current_user: User = Depends(get_current_user_with_graph),
+  _rate_limit: None = Depends(subscription_aware_rate_limit_dependency),
+) -> Response:
+  """Streamable-HTTP MCP endpoint (JSON-RPC 2.0)."""
+  try:
+    message = await request.json()
+  except Exception:
+    return _rpc_error(
+      None,
+      PARSE_ERROR,
+      "Parse error: request body is not valid JSON",
+      http_code=http_status.HTTP_400_BAD_REQUEST,
+    )
+
+  if isinstance(message, list):
+    # JSON-RPC batching was removed in the 2025-06-18 MCP revision; this
+    # transport never accepted it.
+    return _rpc_error(
+      None,
+      INVALID_REQUEST,
+      "Invalid request: JSON-RPC batching is not supported",
+      http_code=http_status.HTTP_400_BAD_REQUEST,
+    )
+
+  if not isinstance(message, dict) or message.get("jsonrpc") != "2.0":
+    return _rpc_error(
+      None,
+      INVALID_REQUEST,
+      "Invalid request: expected a JSON-RPC 2.0 message",
+      http_code=http_status.HTTP_400_BAD_REQUEST,
+    )
+
+  method = message.get("method")
+  msg_id = message.get("id")
+  params = message.get("params") or {}
+  if not isinstance(params, dict):
+    return _rpc_error(msg_id, INVALID_PARAMS, "Invalid params: expected an object")
+
+  # A message without a method is a client->server response; a message without
+  # an id is a notification. Streamable HTTP: accept both with 202, no body.
+  # (notifications/initialized and notifications/cancelled land here —
+  # cancellation is best-effort only on a stateless multi-node transport.)
+  if not isinstance(method, str) or "id" not in message:
+    return Response(status_code=http_status.HTTP_202_ACCEPTED)
+
+  try:
+    if method == "initialize":
+      return _rpc_result(
+        msg_id, await _handle_initialize(graph_id, current_user, params)
+      )
+    elif method == "ping":
+      return _rpc_result(msg_id, {})
+    elif method == "tools/list":
+      return _rpc_result(msg_id, await _handle_tools_list(graph_id, current_user))
+    elif method == "tools/call":
+      return await _handle_tools_call(graph_id, current_user, msg_id, params)
+    else:
+      return _rpc_error(msg_id, METHOD_NOT_FOUND, f"Method not found: {method}")
+  except HTTPException as e:
+    # Access denials from initialize / tools/list surface as JSON-RPC errors
+    # rather than tool results (there is no tool result to attach them to).
+    detail = e.detail if isinstance(e.detail, str) else json.dumps(e.detail)
+    return _rpc_error(msg_id, INVALID_REQUEST, detail, http_code=e.status_code)
+  except Exception as e:
+    logger.error(
+      f"Remote MCP transport error on {method}: {e}",
+      extra={"graph_id": graph_id, "user_id": str(current_user.id)},
+    )
+    return _rpc_error(msg_id, INTERNAL_ERROR, "Internal error")

--- a/tests/routers/graphs/mcp/test_mcp_remote.py
+++ b/tests/routers/graphs/mcp/test_mcp_remote.py
@@ -172,6 +172,19 @@ class TestDispatchEnvelope:
     )
     assert response.status_code == 202
 
+  async def test_malformed_notification_still_gets_202_not_an_error(self):
+    # JSON-RPC 2.0: a notification must never receive a reply — not even an
+    # invalid-params error. The notification check must run before params
+    # validation.
+    response = await dispatch_jsonrpc(
+      _make_request(
+        {"jsonrpc": "2.0", "method": "notifications/cancelled", "params": [1, 2]}
+      ),
+      "kg123",
+      _make_user(),
+    )
+    assert response.status_code == 202
+
   async def test_ping(self):
     response = await dispatch_jsonrpc(
       _make_request({"jsonrpc": "2.0", "id": 2, "method": "ping"}),

--- a/tests/routers/graphs/mcp/test_mcp_remote.py
+++ b/tests/routers/graphs/mcp/test_mcp_remote.py
@@ -1,0 +1,533 @@
+"""Unit tests for the remote MCP transport (Streamable HTTP JSON-RPC)."""
+
+import json
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from robosystems.routers.graphs.mcp import remote
+from robosystems.routers.graphs.mcp.remote import (
+  INVALID_PARAMS,
+  INVALID_REQUEST,
+  MCP_LATEST_PROTOCOL_VERSION,
+  METHOD_NOT_FOUND,
+  PARSE_ERROR,
+  _event_to_progress,
+  _remote_switch_workspace,
+  _to_tool_result,
+  _tool_error_payload,
+  dispatch_jsonrpc,
+)
+
+
+def _body(response):
+  return json.loads(response.body)
+
+
+def _make_request(message, accept="application/json, text/event-stream"):
+  request = Mock()
+  if isinstance(message, Exception):
+    request.json = AsyncMock(side_effect=message)
+  else:
+    request.json = AsyncMock(return_value=message)
+  request.headers = {"accept": accept}
+  return request
+
+
+def _make_user(user_id="user-123"):
+  user = Mock()
+  user.id = user_id
+  return user
+
+
+class TestEnvelopeHelpers:
+  def test_to_tool_result_wraps_text_result(self):
+    result = _to_tool_result({"type": "text", "text": "hello"})
+    assert result == {
+      "content": [{"type": "text", "text": "hello"}],
+      "isError": False,
+    }
+
+  def test_to_tool_result_serializes_non_text_result(self):
+    result = _to_tool_result({"success": True, "rows": 3})
+    assert result["isError"] is False
+    assert json.loads(result["content"][0]["text"]) == {"success": True, "rows": 3}
+
+  def test_tool_error_payload_shape(self):
+    payload = _tool_error_payload(7, "boom")
+    assert payload["id"] == 7
+    assert payload["result"]["isError"] is True
+    assert payload["result"]["content"][0]["text"] == "boom"
+
+
+class TestEventToProgress:
+  def test_start_event_maps_to_zero(self):
+    notification, progress = _event_to_progress(
+      "tok", {"event": "start", "data": {"message": "go"}}, 0.0
+    )
+    assert notification["method"] == "notifications/progress"
+    assert notification["params"]["progressToken"] == "tok"
+    assert notification["params"]["progress"] > 0.0 or progress >= 0.0
+
+  def test_progress_event_uses_value_and_message(self):
+    notification, progress = _event_to_progress(
+      "tok", {"event": "progress", "data": {"progress": 50, "message": "half"}}, 0.0
+    )
+    assert notification["params"]["progress"] == 50.0
+    assert notification["params"]["message"] == "half"
+    assert progress == 50.0
+
+  def test_progress_is_monotonic(self):
+    # A row-count event after a percentage event must not go backwards.
+    _, p1 = _event_to_progress(
+      "tok", {"event": "progress", "data": {"progress": 100}}, 0.0
+    )
+    notification, p2 = _event_to_progress(
+      "tok", {"event": "query_chunk", "data": {"total_rows_so_far": 10}}, p1
+    )
+    assert p2 > p1
+    assert notification["params"]["progress"] == p2
+
+  def test_data_events_produce_no_notification(self):
+    for etype in ("query_result", "result", "complete", "error", "schema_nodes"):
+      notification, progress = _event_to_progress(
+        "tok", {"event": etype, "data": {}}, 5.0
+      )
+      assert notification is None
+      assert progress == 5.0
+
+
+KG = "kg19fb490f76871d22e835"
+
+
+class TestRemoteSwitchWorkspace:
+  def test_named_subgraph_builds_id_and_url(self):
+    text = _remote_switch_workspace(KG, {"workspace_id": "dev"})
+    payload = json.loads(text)
+    assert payload["switched"] is False
+    assert payload["target_graph_id"] == f"{KG}_dev"
+    assert payload["connector_url"].endswith(f"/v1/graphs/{KG}_dev/mcp")
+
+  def test_full_subgraph_id_passes_through(self):
+    payload = json.loads(_remote_switch_workspace(KG, {"workspace_id": f"{KG}_dev"}))
+    assert payload["target_graph_id"] == f"{KG}_dev"
+
+  def test_primary_resolves_parent_from_subgraph(self):
+    payload = json.loads(
+      _remote_switch_workspace(f"{KG}_dev", {"workspace_id": "primary"})
+    )
+    assert payload["target_graph_id"] == KG
+
+  def test_shared_repo_subgraph_resolves(self):
+    payload = json.loads(
+      _remote_switch_workspace("sec", {"workspace_id": "historical"})
+    )
+    assert payload["target_graph_id"] == "sec_historical"
+
+  def test_missing_workspace_id_is_error_text(self):
+    assert _remote_switch_workspace(KG, {}).startswith("Error:")
+
+  def test_invalid_characters_rejected(self):
+    text = _remote_switch_workspace(KG, {"workspace_id": "../etc/passwd"})
+    assert text.startswith("Error:")
+
+
+@pytest.mark.asyncio
+class TestDispatchEnvelope:
+  async def test_parse_error(self):
+    response = await dispatch_jsonrpc(
+      _make_request(ValueError("bad json")), "kg123", _make_user()
+    )
+    assert response.status_code == 400
+    assert _body(response)["error"]["code"] == PARSE_ERROR
+
+  async def test_batch_rejected(self):
+    response = await dispatch_jsonrpc(
+      _make_request([{"jsonrpc": "2.0", "id": 1, "method": "ping"}]),
+      "kg123",
+      _make_user(),
+    )
+    assert response.status_code == 400
+    assert _body(response)["error"]["code"] == INVALID_REQUEST
+
+  async def test_non_jsonrpc_rejected(self):
+    response = await dispatch_jsonrpc(
+      _make_request({"method": "ping", "id": 1}), "kg123", _make_user()
+    )
+    assert response.status_code == 400
+    assert _body(response)["error"]["code"] == INVALID_REQUEST
+
+  async def test_notification_returns_202_no_body(self):
+    response = await dispatch_jsonrpc(
+      _make_request({"jsonrpc": "2.0", "method": "notifications/initialized"}),
+      "kg123",
+      _make_user(),
+    )
+    assert response.status_code == 202
+
+  async def test_client_response_message_returns_202(self):
+    response = await dispatch_jsonrpc(
+      _make_request({"jsonrpc": "2.0", "id": 9, "result": {}}), "kg123", _make_user()
+    )
+    assert response.status_code == 202
+
+  async def test_ping(self):
+    response = await dispatch_jsonrpc(
+      _make_request({"jsonrpc": "2.0", "id": 2, "method": "ping"}),
+      "kg123",
+      _make_user(),
+    )
+    body = _body(response)
+    assert body == {"jsonrpc": "2.0", "id": 2, "result": {}}
+
+  async def test_method_not_found(self):
+    response = await dispatch_jsonrpc(
+      _make_request({"jsonrpc": "2.0", "id": 3, "method": "resources/list"}),
+      "kg123",
+      _make_user(),
+    )
+    assert _body(response)["error"]["code"] == METHOD_NOT_FOUND
+
+  async def test_non_object_params_rejected(self):
+    response = await dispatch_jsonrpc(
+      _make_request({"jsonrpc": "2.0", "id": 4, "method": "ping", "params": [1]}),
+      "kg123",
+      _make_user(),
+    )
+    assert _body(response)["error"]["code"] == INVALID_PARAMS
+
+
+def _make_handler(tools=None, instructions="per-graph guidance"):
+  handler = Mock()
+  handler._closed = False
+  handler.close = AsyncMock()
+  handler.get_tools = AsyncMock(
+    return_value=tools
+    if tools is not None
+    else [
+      {
+        "name": "get-graph-schema",
+        "description": "schema",
+        "inputSchema": {"type": "object", "properties": {}},
+      },
+      {
+        "name": "switch-workspace",
+        "description": "client-side text",
+        "inputSchema": {"type": "object", "properties": {}},
+      },
+    ]
+  )
+  handler.get_instructions = Mock(return_value=instructions)
+  return handler
+
+
+@pytest.mark.asyncio
+class TestInitialize:
+  async def _initialize(self, requested_version):
+    handler = _make_handler()
+    with (
+      patch.object(remote, "_validate_read_access", AsyncMock()),
+      patch.object(remote, "get_graph_repository", AsyncMock(return_value=Mock())),
+      patch.object(remote, "MCPHandler", Mock(return_value=handler)),
+    ):
+      request = _make_request(
+        {
+          "jsonrpc": "2.0",
+          "id": 1,
+          "method": "initialize",
+          "params": {"protocolVersion": requested_version},
+        }
+      )
+      return await dispatch_jsonrpc(request, "kg123", _make_user())
+
+  async def test_supported_version_is_echoed(self):
+    body = _body(await self._initialize("2025-03-26"))
+    assert body["result"]["protocolVersion"] == "2025-03-26"
+
+  async def test_unsupported_version_answers_latest(self):
+    body = _body(await self._initialize("1999-01-01"))
+    assert body["result"]["protocolVersion"] == MCP_LATEST_PROTOCOL_VERSION
+
+  async def test_server_info_and_instructions_are_per_graph(self):
+    body = _body(await self._initialize("2025-06-18"))
+    result = body["result"]
+    assert result["serverInfo"]["name"] == "robosystems-kg123"
+    assert result["instructions"] == "per-graph guidance"
+    assert result["capabilities"] == {"tools": {"listChanged": False}}
+
+
+@pytest.mark.asyncio
+class TestToolsList:
+  async def test_shape_annotations_and_description_rewrite(self):
+    handler = _make_handler()
+    with (
+      patch.object(remote, "_validate_read_access", AsyncMock()),
+      patch.object(remote, "get_graph_repository", AsyncMock(return_value=Mock())),
+      patch.object(remote, "MCPHandler", Mock(return_value=handler)),
+    ):
+      request = _make_request({"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+      body = _body(await dispatch_jsonrpc(request, "kg123", _make_user()))
+
+    tools = {tool["name"]: tool for tool in body["result"]["tools"]}
+    assert tools["get-graph-schema"]["annotations"] == {"readOnlyHint": True}
+    # The npx "client-side tool" text must never reach a remote client.
+    assert "client-side" not in tools["switch-workspace"]["description"]
+    assert "connector" in tools["switch-workspace"]["description"].lower()
+
+
+@pytest.mark.asyncio
+class TestToolsCall:
+  async def test_missing_name_is_invalid_params(self):
+    request = _make_request(
+      {"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {}}
+    )
+    body = _body(await dispatch_jsonrpc(request, "kg123", _make_user()))
+    assert body["error"]["code"] == INVALID_PARAMS
+
+  async def test_gauntlet_denial_becomes_tool_error(self):
+    with (
+      patch.object(remote, "circuit_breaker", Mock()),
+      patch.object(
+        remote,
+        "authorize_mcp_tool_call",
+        AsyncMock(side_effect=HTTPException(status_code=403, detail="need a sub")),
+      ),
+    ):
+      request = _make_request(
+        {
+          "jsonrpc": "2.0",
+          "id": 1,
+          "method": "tools/call",
+          "params": {"name": "read-graph-cypher", "arguments": {"query": "MATCH"}},
+        }
+      )
+      response = await dispatch_jsonrpc(request, "sec", _make_user())
+
+    body = _body(response)
+    assert response.status_code == 200
+    assert body["result"]["isError"] is True
+    assert "need a sub" in body["result"]["content"][0]["text"]
+
+  async def test_switch_workspace_intercepted_after_gauntlet(self):
+    authorize = AsyncMock(return_value="read")
+    with (
+      patch.object(remote, "circuit_breaker", Mock()),
+      patch.object(remote, "authorize_mcp_tool_call", authorize),
+    ):
+      request = _make_request(
+        {
+          "jsonrpc": "2.0",
+          "id": 1,
+          "method": "tools/call",
+          "params": {"name": "switch-workspace", "arguments": {"workspace_id": "dev"}},
+        }
+      )
+      body = _body(await dispatch_jsonrpc(request, KG, _make_user()))
+
+    authorize.assert_awaited_once()
+    payload = json.loads(body["result"]["content"][0]["text"])
+    assert payload["target_graph_id"] == f"{KG}_dev"
+
+  async def test_success_maps_result_to_content(self):
+    handler = _make_handler()
+    with (
+      patch.object(remote, "circuit_breaker", Mock()),
+      patch.object(remote, "authorize_mcp_tool_call", AsyncMock(return_value="read")),
+      patch.object(remote, "get_graph_repository", AsyncMock(return_value=Mock())),
+      patch.object(remote, "MCPHandler", Mock(return_value=handler)),
+      patch.object(
+        remote,
+        "execute_tool_to_json",
+        AsyncMock(return_value={"type": "text", "text": "the result"}),
+      ),
+    ):
+      request = _make_request(
+        {
+          "jsonrpc": "2.0",
+          "id": 11,
+          "method": "tools/call",
+          "params": {"name": "get-graph-info", "arguments": {}},
+        },
+        accept="application/json",
+      )
+      body = _body(await dispatch_jsonrpc(request, "kg123", _make_user()))
+
+    assert body["id"] == 11
+    assert body["result"]["content"] == [{"type": "text", "text": "the result"}]
+    assert body["result"]["isError"] is False
+    handler.close.assert_awaited()
+
+
+@pytest.mark.asyncio
+class TestStreamToolCall:
+  async def test_progress_then_final_response(self):
+    async def fake_stream(handler, name, arguments, strategy):
+      yield {"event": "start", "data": {"tool": name, "message": "starting"}}
+      yield {
+        "event": "query_chunk",
+        "data": {"total_rows_so_far": 5, "columns": ["a"], "data": [{"a": 1}]},
+      }
+      yield {"event": "complete", "data": {}}
+
+    handler = _make_handler()
+    with (
+      patch.object(remote, "circuit_breaker", Mock()),
+      patch.object(remote, "stream_mcp_tool_execution", fake_stream),
+    ):
+      tool_call = Mock()
+      tool_call.name = "read-graph-cypher"
+      tool_call.arguments = {"query": "MATCH (n) RETURN n"}
+      events = [
+        event
+        async for event in remote._stream_tool_call(
+          handler,
+          "kg123",
+          tool_call,
+          remote.MCPExecutionStrategy.STREAM_AGGREGATED,
+          30,
+          42,
+          "tok",
+        )
+      ]
+
+    messages = [json.loads(event["data"]) for event in events]
+    notifications = [m for m in messages if m.get("method") == "notifications/progress"]
+    finals = [m for m in messages if "id" in m]
+    assert len(notifications) == 2
+    assert all(n["params"]["progressToken"] == "tok" for n in notifications)
+    assert len(finals) == 1
+    assert finals[0]["id"] == 42
+    assert finals[0]["result"]["isError"] is False
+    handler.close.assert_awaited()
+
+  async def test_no_token_suppresses_notifications(self):
+    async def fake_stream(handler, name, arguments, strategy):
+      yield {"event": "start", "data": {"tool": name}}
+      yield {"event": "result", "data": {"result": {"type": "text", "text": "ok"}}}
+
+    handler = _make_handler()
+    with (
+      patch.object(remote, "circuit_breaker", Mock()),
+      patch.object(remote, "stream_mcp_tool_execution", fake_stream),
+    ):
+      tool_call = Mock()
+      tool_call.name = "get-graph-schema"
+      tool_call.arguments = {}
+      events = [
+        event
+        async for event in remote._stream_tool_call(
+          handler,
+          "kg123",
+          tool_call,
+          remote.MCPExecutionStrategy.SSE_PROGRESS,
+          30,
+          1,
+          None,
+        )
+      ]
+
+    messages = [json.loads(event["data"]) for event in events]
+    assert len(messages) == 1
+    assert "id" in messages[0]
+
+
+def _make_queue_manager(statuses, result=None):
+  manager = Mock()
+  manager.submit_query = AsyncMock(return_value="q-1")
+  manager.get_query_status = AsyncMock(side_effect=statuses)
+  manager.get_query_result = AsyncMock(
+    return_value=result or {"status": "completed", "data": [1]}
+  )
+  manager.cancel_query = AsyncMock(return_value=True)
+  return manager
+
+
+def _make_tool_call():
+  tool_call = Mock()
+  tool_call.name = "read-graph-cypher"
+  tool_call.arguments = {"query": "MATCH (n) RETURN n", "parameters": {}}
+  return tool_call
+
+
+@pytest.mark.asyncio
+class TestStreamQueuedCall:
+  async def test_completed_query_streams_progress_then_result(self):
+    manager = _make_queue_manager(
+      [
+        {"status": "pending", "queue_position": 3},
+        {"status": "running"},
+        {"status": "completed"},
+      ]
+    )
+    with (
+      patch.object(remote, "circuit_breaker", Mock()),
+      patch.object(remote, "_get_user_priority", Mock(return_value=5)),
+      patch.object(remote, "_QUEUE_POLL_SECONDS", 0),
+      patch(
+        "robosystems.middleware.graph.query_queue.get_query_queue",
+        return_value=manager,
+      ),
+    ):
+      events = [
+        event
+        async for event in remote._stream_queued_call(
+          "kg123", _make_tool_call(), _make_user(), 8, "tok"
+        )
+      ]
+
+    messages = [json.loads(event["data"]) for event in events]
+    notifications = [m for m in messages if m.get("method") == "notifications/progress"]
+    finals = [m for m in messages if "id" in m]
+    assert [n["params"]["message"] for n in notifications] == [
+      "Queued (position 3)",
+      "Running",
+      "Completed",
+    ]
+    assert finals[0]["id"] == 8
+    assert finals[0]["result"]["isError"] is False
+    manager.cancel_query.assert_not_awaited()
+
+  async def test_failed_query_is_tool_error(self):
+    manager = _make_queue_manager([{"status": "failed", "error": "syntax error"}])
+    with (
+      patch.object(remote, "circuit_breaker", Mock()),
+      patch.object(remote, "_get_user_priority", Mock(return_value=5)),
+      patch.object(remote, "_QUEUE_POLL_SECONDS", 0),
+      patch(
+        "robosystems.middleware.graph.query_queue.get_query_queue",
+        return_value=manager,
+      ),
+    ):
+      events = [
+        event
+        async for event in remote._stream_queued_call(
+          "kg123", _make_tool_call(), _make_user(), 8, None
+        )
+      ]
+
+    final = json.loads(events[-1]["data"])
+    assert final["result"]["isError"] is True
+    assert "syntax error" in final["result"]["content"][0]["text"]
+
+  async def test_disconnect_cancels_queued_query(self):
+    manager = _make_queue_manager(
+      [{"status": "pending", "queue_position": 1}, {"status": "pending"}] * 50
+    )
+    with (
+      patch.object(remote, "circuit_breaker", Mock()),
+      patch.object(remote, "_get_user_priority", Mock(return_value=5)),
+      patch.object(remote, "_QUEUE_POLL_SECONDS", 0),
+      patch(
+        "robosystems.middleware.graph.query_queue.get_query_queue",
+        return_value=manager,
+      ),
+    ):
+      generator = remote._stream_queued_call(
+        "kg123", _make_tool_call(), _make_user(), 8, "tok"
+      )
+      # Take one progress event, then drop the stream (client disconnect).
+      await generator.__anext__()
+      await generator.aclose()
+
+    manager.cancel_query.assert_awaited_once_with("q-1", "user-123")


### PR DESCRIPTION
## Summary

Adds a remote MCP transport: `POST /v1/graphs/{graph_id}/mcp` speaks Streamable HTTP (JSON-RPC 2.0) directly over the existing per-graph tool layer, so any MCP client that supports remote servers (Claude custom connectors, Cursor, `mcp-remote`) can connect to a graph by pasting its URL — no npx bridge process, no client-side config beyond the API key header. The dispatch is hand-rolled rather than mounted from the MCP SDK server because the tool surface is dynamic per graph and every call must run behind the existing FastAPI dependency chain (auth, per-graph access, rate limits, write classification, circuit breaker).

## Changes

**`robosystems/routers/graphs/mcp/remote.py` (new)**
- JSON-RPC 2.0 dispatch for `initialize` / `notifications/initialized` / `ping` / `tools/list` / `tools/call`; protocol-version negotiation across the 2024-11-05 / 2025-03-26 / 2025-06-18 revisions; batching rejected; notifications answered `202` per Streamable HTTP.
- `graph_id` stays a URL path segment and never becomes a tool argument. `initialize` returns per-graph `serverInfo` (`robosystems-{graph_id}`) and instructions rebuilt per session from the live tool surface (the npx bridge freezes them at process start).
- Stateless by design: no `Mcp-Session-Id`, no GET-side SSE channel. Excluded from the OpenAPI schema (`include_in_schema=False`) so the JSON-RPC envelope never reaches the generated SDK clients.
- **SSE-on-POST streaming**: the strategy selector picks the response shape per call — fast tools return `application/json`; long/streaming strategies return `text/event-stream` carrying `notifications/progress` (emitted only when the request carries `_meta.progressToken`, with monotonically increasing values) followed by the final JSON-RPC response. Comment pings every 15s keep the stream alive across LB idle timeouts; a client disconnect cancels the in-flight tool work via generator teardown.
- **Queue bridge**: under load, cypher reads route through the shared query queue. The REST surface answers those with `202` + a polling URL, which has no MCP equivalent — the transport instead holds the stream, relays queue state as progress, and resolves with the result under an explicit 300s end-to-end ceiling. Disconnect or timeout cancels the queued query.
- **Workspace semantics**: a remote connector is URL-anchored, so `switch-workspace` no longer pretends to switch — after the normal access gauntlet it returns the target workspace's connector URL (subgraph-as-URL), and `tools/list` carries a remote-appropriate description for it. Read-only tools are annotated `readOnlyHint` per the MCP spec.
- Tool-execution failures (subscription, rate limit, timeout) return as `result.isError` content so the model can read and relay them; protocol failures return JSON-RPC errors. Client capability profile is asserted internally instead of sniffing User-Agent/`X-MCP-Client` headers, which remote clients don't send.

**`robosystems/routers/graphs/mcp/execute.py`**
- The tool-call authorization gauntlet (fail-closed write classification, StatementKernel statement policy for cypher tools, per-graph role validation, shared-repo subscription lookup, dual-layer volume rate limiting) is extracted verbatim from `call_mcp_tool` into `authorize_mcp_tool_call()`, now shared by the REST endpoint and the remote transport so the two surfaces cannot drift. No behavior change on the REST path.
- New `execute_tool_to_json()` executes a call to a single JSON result for a given strategy: cacheable strategies go through the existing Valkey MCP cache, streaming strategies are aggregated server-side, the rest execute directly.

**`robosystems/routers/graphs/mcp/__init__.py`, `robosystems/routers/__init__.py`**
- The remote router is exported separately and mounted with the `/mcp` prefix at the top level (FastAPI rejects an empty path on a prefix-less include).

**`tests/routers/graphs/mcp/test_mcp_remote.py` (new, 34 tests)**
- Envelope/error-code contract, protocol-version negotiation, per-graph `serverInfo`/instructions, `tools/list` annotations + description rewrite, gauntlet denials surfacing as `isError` content, token-gated monotonic progress mapping, and the queue bridge (progress relay, failure surface, cancel-on-disconnect).

## Testing

- `just test` — full unit suite: **12,084 passed, 24 skipped** (~4m41s).
- `just test-code` — ruff check, format, basedpyright, cf-lint: all clean.
- Live-verified against the local Docker stack on a real tenant graph: full lifecycle (`initialize` → `initialized` → `ping` → `tools/list` → `tools/call`), SSE stream with progress notifications and final response, token-gating (no token → no notifications), JSON fallback when the client doesn't accept SSE, StatementKernel write barrier surfacing as `isError`, `switch-workspace` URL resolution, `/openapi.json` confirmed free of the new route, bad key → 403.

## Notes / Follow-ups

- The app-side "Connect" page (copy-paste connector config per graph off `GET /v1/graphs`) is frontend work in the app repo, not this PR.
- Auth-failure shape deliberately keeps the existing `403` (no `WWW-Authenticate`/PRM) for the header-auth increments; revisited when OAuth lands.
- At deploy time, confirm the ALB idle timeout against the 15s SSE keepalive interval (fine against the 60s default).
- The queue bridge only engages under real load (queue depth/running thresholds); it is unit-tested with mocks and not exercisable on an idle local stack.
