### PR TITLE
feat(telemetry): per-user query telemetry and alarms for shared repositories

### DIFF
--- a/cloudformation/graph-ladybug-replicas.yaml
+++ b/cloudformation/graph-ladybug-replicas.yaml
@@ -799,6 +799,73 @@ Resources:
         - !Ref ReplicaAlertTopic
       TreatMissingData: notBreaching
 
+  # Container-start marker from the replica entrypoint. Fires on every
+  # container start on an existing instance (unexpected — the serving process
+  # should start once per instance) and on fresh instance launches (expected
+  # during deploys and scale-out), so pages during an instance refresh are
+  # normal. The alarm exists for the unexpected case.
+  ReplicaContainerStartMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Sub /robosystems/${Environment}/graph-api
+      FilterPattern: '"Starting LadybugDB Shared Replica API"'
+      MetricTransformations:
+        - MetricName: ReplicaContainerStart
+          MetricNamespace: !Sub RoboSystems/SharedReplicas/${Environment}
+          MetricValue: "1"
+          Unit: Count
+
+  ReplicaContainerStartAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub robosystems-shared-replicas-${Environment}-container-start
+      AlarmDescription: Replica serving container started - expected only during deploys and scale-out
+      MetricName: ReplicaContainerStart
+      Namespace: !Sub RoboSystems/SharedReplicas/${Environment}
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 0
+      ComparisonOperator: GreaterThanThreshold
+      AlarmActions:
+        - !Ref ReplicaAlertTopic
+      TreatMissingData: notBreaching
+
+  # Application-published telemetry for the shared query surface (emitted by
+  # the API tier into RoboSystems/Security/{env}; alarmed here rather than in
+  # api.yaml because these guard the shared-replica surface).
+  QueryAbuseSignalAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub robosystems-shared-replicas-${Environment}-query-abuse-signal
+      AlarmDescription: Sustained adverse query outcomes on shared repositories
+      MetricName: QueryAbuseSignal
+      Namespace: !Sub RoboSystems/Security/${Environment}
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 20
+      ComparisonOperator: GreaterThanThreshold
+      AlarmActions:
+        - !Ref ReplicaAlertTopic
+      TreatMissingData: notBreaching
+
+  QueryEngineDisruptionAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub robosystems-shared-replicas-${Environment}-query-engine-disruption
+      AlarmDescription: Query outcome consistent with an engine connection loss on a shared repository
+      MetricName: QueryEngineDisruption
+      Namespace: !Sub RoboSystems/Security/${Environment}
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 0
+      ComparisonOperator: GreaterThanThreshold
+      AlarmActions:
+        - !Ref ReplicaAlertTopic
+      TreatMissingData: notBreaching
+
 Outputs:
   ALBDNSName:
     Description: DNS name of the shared replicas ALB

--- a/robosystems/middleware/auth/dependencies.py
+++ b/robosystems/middleware/auth/dependencies.py
@@ -168,6 +168,17 @@ def _get_user_for_verified_jwt(user_id: str, token_session_version: int) -> User
 API_KEY_HEADER = APIKeyHeader(name="X-API-Key", auto_error=False)
 
 
+def _stash_api_key_identity(request: Request, api_key: str) -> None:
+  """Record which API key authenticated this request on request.state.
+
+  The first 8 characters are the key's stored identification prefix
+  (``UserAPIKey.prefix``), so downstream telemetry can attribute activity
+  to a specific key without access to the raw header. JWT-authenticated
+  requests leave the attribute unset.
+  """
+  request.state.api_key_prefix = api_key[:8]
+
+
 def verify_jwt_claims(
   token: str, device_fingerprint: dict[str, Any] | None = None
 ) -> tuple[str, int] | None:
@@ -214,6 +225,8 @@ async def get_optional_user(
   # Fall back to API key authentication
   if api_key:
     user = validate_api_key(api_key)
+    if user:
+      _stash_api_key_identity(request, api_key)
     return user
 
   return None
@@ -280,6 +293,7 @@ async def get_current_user(
   if api_key:
     user = validate_api_key(api_key)
     if user:
+      _stash_api_key_identity(request, api_key)
       SecurityAuditLogger.log_auth_success(
         user_id=str(user.id),
         ip_address=client_ip,
@@ -420,6 +434,7 @@ async def get_current_user_with_graph(
   if api_key:
     user = validate_api_key_with_graph(api_key, graph_id)
     if user:
+      _stash_api_key_identity(request, api_key)
       SecurityAuditLogger.log_auth_success(
         user_id=str(user.id),
         ip_address=client_ip,
@@ -629,6 +644,7 @@ async def get_current_user_sse(
   if api_key:
     user = validate_api_key(api_key)
     if user:
+      _stash_api_key_identity(request, api_key)
       SecurityAuditLogger.log_auth_success(
         user_id=str(user.id),
         ip_address=client_ip,

--- a/robosystems/middleware/graph/query_telemetry.py
+++ b/robosystems/middleware/graph/query_telemetry.py
@@ -1,0 +1,237 @@
+"""Shared-repository query telemetry.
+
+Detection layer for the shared query surface: classifies bad query/tool
+outcomes (timeouts, capacity rejections, rate limits, policy denials, engine
+disruptions) and records them through the security audit log, which publishes
+the CloudWatch metrics the detective-control alarms watch. Also emits
+structured per-query cost lines (start/end pairs) so operators can rank users
+by total execution time and reconstruct in-flight work around an incident.
+
+Scope: shared repositories ONLY. User graphs run on dedicated instances, so
+per-query telemetry of this kind never applies to them; every entry point
+gates on the shared-repository check and no-ops elsewhere.
+
+All functions are best-effort — they must never raise into the request path.
+"""
+
+import json
+import uuid
+from typing import Any
+
+from fastapi import Request
+
+from robosystems.logger import logger
+
+# Outcome classes recorded per HTTP status. Statuses not listed are not
+# telemetry-relevant on this surface (404s, billing 402s, generic 5xxs).
+_SIGNAL_FOR_STATUS: dict[int, str] = {
+  400: "statement_rejected",
+  403: "access_denied",
+  408: "timeout",
+  429: "rate_limited",
+  503: "capacity_rejected",
+}
+
+# Exception shapes that indicate the engine connection was lost mid-query
+# (backend restart) rather than a normal error response. Matched by type name
+# so no HTTP-client library needs importing here.
+_DISRUPTION_TYPE_NAMES = frozenset(
+  {
+    "ConnectError",
+    "ConnectionError",
+    "ConnectionResetError",
+    "ConnectionAbortedError",
+    "ReadError",
+    "RemoteProtocolError",
+    "ServerDisconnectedError",
+    "ClientConnectorError",
+    "ClientOSError",
+    "IncompleteReadError",
+  }
+)
+_DISRUPTION_MESSAGE_MARKERS = (
+  "connection reset",
+  "connection refused",
+  "connection closed",
+  "connection aborted",
+  "server disconnected",
+  "peer closed connection",
+)
+
+# The client-visible envelope produced when an MCP event stream ends without
+# any terminal event — see routers/graphs/mcp/streaming.py.
+_AGGREGATION_FALLBACK_ERROR = "Unable to aggregate results"
+
+# Greppable prefix for the per-query cost lines (CloudWatch Logs Insights:
+# parse @message 'SHARED_QUERY_COST: *' as payload).
+_COST_LINE_PREFIX = "SHARED_QUERY_COST"
+
+
+def _is_shared(graph_id: str) -> bool:
+  from robosystems.middleware.graph.utils import MultiTenantUtils
+
+  return MultiTenantUtils.is_shared_repository_or_subgraph(graph_id)
+
+
+def api_key_prefix_from_request(request: Request | None) -> str | None:
+  """Return the identification prefix of the API key that authenticated
+  this request, if one did (set by the auth dependencies)."""
+  if request is None:
+    return None
+  return getattr(request.state, "api_key_prefix", None)
+
+
+def signal_for_status(status_code: int | None) -> str | None:
+  if status_code is None:
+    return None
+  return _SIGNAL_FOR_STATUS.get(status_code)
+
+
+def is_engine_disruption(error: BaseException) -> bool:
+  """True when an exception looks like the engine connection dropped
+  mid-query rather than a normal error response."""
+  if type(error).__name__ in _DISRUPTION_TYPE_NAMES:
+    return True
+  message = str(error).lower()
+  return any(marker in message for marker in _DISRUPTION_MESSAGE_MARKERS)
+
+
+def is_disrupted_aggregation(result: Any) -> bool:
+  """True when an aggregated MCP stream ended without any terminal event —
+  the client-visible shape of an engine connection lost mid-stream."""
+  return (
+    isinstance(result, dict)
+    and result.get("success") is False
+    and result.get("error") == _AGGREGATION_FALLBACK_ERROR
+  )
+
+
+def record_shared_query_outcome(
+  graph_id: str,
+  user_id: Any,
+  *,
+  signal: str | None = None,
+  status_code: int | None = None,
+  error: BaseException | None = None,
+  api_key_prefix: str | None = None,
+  endpoint: str | None = None,
+  source: str = "query",
+  tool_name: str | None = None,
+  disruption: bool = False,
+) -> None:
+  """Record one bad query outcome on a shared repository (no-op elsewhere).
+
+  Classification precedence: an explicit ``signal`` wins; otherwise
+  ``status_code`` maps through the outcome table; otherwise ``error`` is
+  checked for the engine-disruption shape. Unclassifiable outcomes are
+  silently dropped — this records signals, not every failure.
+  """
+  try:
+    if not _is_shared(graph_id):
+      return
+    if signal is None:
+      signal = signal_for_status(status_code)
+    if signal is None and error is not None and is_engine_disruption(error):
+      signal = "engine_disruption"
+      disruption = True
+    if signal is None:
+      return
+
+    metadata: dict[str, Any] = {"source": source}
+    if status_code is not None:
+      metadata["status_code"] = status_code
+    if tool_name:
+      metadata["tool_name"] = tool_name
+
+    from robosystems.security.audit_logger import SecurityAuditLogger
+
+    SecurityAuditLogger.log_query_abuse_signal(
+      user_id=str(user_id) if user_id else None,
+      graph_id=graph_id,
+      signal=signal,
+      api_key_prefix=api_key_prefix,
+      endpoint=endpoint,
+      metadata=metadata,
+      disruption=disruption,
+    )
+  except Exception as e:
+    logger.debug(f"Failed to record shared query outcome: {e}")
+
+
+def log_shared_query_start(
+  graph_id: str,
+  user_id: Any,
+  *,
+  api_key_prefix: str | None = None,
+  source: str = "query",
+  tool_name: str | None = None,
+  query_length: int | None = None,
+  strategy: str | None = None,
+) -> str | None:
+  """Emit the start half of a per-query cost line pair on a shared repository.
+
+  Returns an execution id to pass to ``log_shared_query_end`` so the pair can
+  be joined in log queries; returns None (and emits nothing) off the shared
+  surface.
+  """
+  try:
+    if not _is_shared(graph_id):
+      return None
+    exec_id = uuid.uuid4().hex[:12]
+    _emit_cost_line(
+      {
+        "phase": "start",
+        "exec_id": exec_id,
+        "graph_id": graph_id,
+        "user_id": str(user_id) if user_id else None,
+        "api_key_prefix": api_key_prefix,
+        "source": source,
+        "tool_name": tool_name,
+        "query_length": query_length,
+        "strategy": strategy,
+      }
+    )
+    return exec_id
+  except Exception as e:
+    logger.debug(f"Failed to log shared query start: {e}")
+    return None
+
+
+def log_shared_query_end(
+  exec_id: str | None,
+  graph_id: str,
+  user_id: Any,
+  *,
+  outcome: str,
+  duration_ms: float | None = None,
+  row_count: int | None = None,
+  api_key_prefix: str | None = None,
+  source: str = "query",
+  tool_name: str | None = None,
+) -> None:
+  """Emit the end half of a cost line pair. Safe to call with a None exec_id
+  (emits nothing — the start half was off-surface or failed)."""
+  try:
+    if exec_id is None or not _is_shared(graph_id):
+      return
+    _emit_cost_line(
+      {
+        "phase": "end",
+        "exec_id": exec_id,
+        "graph_id": graph_id,
+        "user_id": str(user_id) if user_id else None,
+        "api_key_prefix": api_key_prefix,
+        "source": source,
+        "tool_name": tool_name,
+        "outcome": outcome,
+        "duration_ms": round(duration_ms, 1) if duration_ms is not None else None,
+        "row_count": row_count,
+      }
+    )
+  except Exception as e:
+    logger.debug(f"Failed to log shared query end: {e}")
+
+
+def _emit_cost_line(payload: dict[str, Any]) -> None:
+  compact = {k: v for k, v in payload.items() if v is not None}
+  logger.info(f"{_COST_LINE_PREFIX}: {json.dumps(compact, default=str)}")

--- a/robosystems/routers/graphs/mcp/execute.py
+++ b/robosystems/routers/graphs/mcp/execute.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import sys
 from datetime import UTC, datetime
 from typing import Any
 
@@ -25,6 +26,13 @@ from robosystems.logger import api_logger, logger
 from robosystems.middleware.auth.dependencies import get_current_user_with_graph
 from robosystems.middleware.graph import get_graph_repository
 from robosystems.middleware.graph.query_queue import get_query_queue
+from robosystems.middleware.graph.query_telemetry import (
+  api_key_prefix_from_request,
+  is_disrupted_aggregation,
+  log_shared_query_end,
+  log_shared_query_start,
+  record_shared_query_outcome,
+)
 from robosystems.middleware.graph.statement_kernel import (
   StatementEngine,
   statement_kernel,
@@ -513,6 +521,10 @@ async def call_mcp_tool(
   # Import config
   from robosystems.config import env
 
+  # Shared-repository telemetry context (no-ops on user graphs)
+  key_prefix = api_key_prefix_from_request(full_request)
+  exec_id: str | None = None
+
   # Initialize monitoring and logging
   # (Operation logging is handled by circuit breaker)
 
@@ -625,6 +637,17 @@ async def call_mcp_tool(
       elif format == "json":
         strategy = MCPExecutionStrategy.JSON_COMPLETE
 
+    query_arg = tool_call.arguments.get("query") if tool_call.arguments else None
+    exec_id = log_shared_query_start(
+      graph_id,
+      current_user.id,
+      api_key_prefix=key_prefix,
+      source="mcp_rest",
+      tool_name=tool_call.name,
+      query_length=len(query_arg) if isinstance(query_arg, str) else None,
+      strategy=strategy.value,
+    )
+
     # Log execution attempt (debug level for production to reduce verbosity)
     if env.ENVIRONMENT in ["staging", "prod"]:
       logger.debug(
@@ -684,6 +707,17 @@ async def call_mcp_tool(
 
           # Aggregate and return as JSON
           aggregated = aggregate_streamed_results(events)
+          if is_disrupted_aggregation(aggregated):
+            record_shared_query_outcome(
+              graph_id,
+              current_user.id,
+              signal="stream_disrupted",
+              disruption=True,
+              api_key_prefix=key_prefix,
+              endpoint="/v1/graphs/{graph_id}/mcp/call-tool",
+              source="mcp_rest",
+              tool_name=tool_call.name,
+            )
           return MCPToolResult(result=aggregated)
         else:
           # For other clients, return NDJSON stream
@@ -838,6 +872,23 @@ async def call_mcp_tool(
 
       # Record success metrics
       execution_time = (datetime.now(UTC) - start_time).total_seconds() * 1000
+
+      if sys.exc_info()[0] is not None:
+        cost_outcome = "error"
+      elif is_streaming:
+        cost_outcome = "dispatched_stream"
+      else:
+        cost_outcome = "completed"
+      log_shared_query_end(
+        exec_id,
+        graph_id,
+        current_user.id,
+        outcome=cost_outcome,
+        duration_ms=execution_time,
+        api_key_prefix=key_prefix,
+        source="mcp_rest",
+        tool_name=tool_call.name,
+      )
       record_operation_metric(
         operation_type=OperationType.TOOL_EXECUTION,
         status=OperationStatus.SUCCESS,
@@ -855,9 +906,18 @@ async def call_mcp_tool(
       # Record success in circuit breaker
       circuit_breaker.record_success(graph_id, tool_call.name)
 
-  except HTTPException:
+  except HTTPException as exc:
     # Record failure metrics
     execution_time = (datetime.now(UTC) - start_time).total_seconds() * 1000
+    record_shared_query_outcome(
+      graph_id,
+      current_user.id,
+      status_code=exc.status_code,
+      api_key_prefix=key_prefix,
+      endpoint="/v1/graphs/{graph_id}/mcp/call-tool",
+      source="mcp_rest",
+      tool_name=tool_call.name,
+    )
     record_operation_metric(
       operation_type=OperationType.TOOL_EXECUTION,
       status=OperationStatus.FAILURE,
@@ -874,6 +934,15 @@ async def call_mcp_tool(
   except Exception as e:
     # Record failure
     circuit_breaker.record_failure(graph_id, tool_call.name)
+    record_shared_query_outcome(
+      graph_id,
+      current_user.id,
+      error=e,
+      api_key_prefix=key_prefix,
+      endpoint="/v1/graphs/{graph_id}/mcp/call-tool",
+      source="mcp_rest",
+      tool_name=tool_call.name,
+    )
 
     logger.error(
       f"MCP tool execution failed: {e}",

--- a/robosystems/routers/graphs/mcp/execute.py
+++ b/robosystems/routers/graphs/mcp/execute.py
@@ -524,6 +524,10 @@ async def call_mcp_tool(
   # Shared-repository telemetry context (no-ops on user graphs)
   key_prefix = api_key_prefix_from_request(full_request)
   exec_id: str | None = None
+  # Branches whose true outcome differs from the strategy-based inference in
+  # the finally block set this explicitly (server-side aggregation completes
+  # inline; queue submission only hands off).
+  cost_outcome: str | None = None
 
   # Initialize monitoring and logging
   # (Operation logging is handled by circuit breaker)
@@ -707,7 +711,9 @@ async def call_mcp_tool(
 
           # Aggregate and return as JSON
           aggregated = aggregate_streamed_results(events)
+          cost_outcome = "completed"
           if is_disrupted_aggregation(aggregated):
+            cost_outcome = "stream_disrupted"
             record_shared_query_outcome(
               graph_id,
               current_user.id,
@@ -804,10 +810,12 @@ async def call_mcp_tool(
                 await asyncio.sleep(1)
 
             await handler.close()
+            cost_outcome = "queued"
             return EventSourceResponse(monitor_queue())
           else:
             # Return queue info for polling
             await handler.close()
+            cost_outcome = "queued"
             return JSONResponse(
               status_code=http_status.HTTP_202_ACCEPTED,
               content={
@@ -874,16 +882,18 @@ async def call_mcp_tool(
       execution_time = (datetime.now(UTC) - start_time).total_seconds() * 1000
 
       if sys.exc_info()[0] is not None:
-        cost_outcome = "error"
+        resolved_outcome = "error"
+      elif cost_outcome is not None:
+        resolved_outcome = cost_outcome
       elif is_streaming:
-        cost_outcome = "dispatched_stream"
+        resolved_outcome = "dispatched_stream"
       else:
-        cost_outcome = "completed"
+        resolved_outcome = "completed"
       log_shared_query_end(
         exec_id,
         graph_id,
         current_user.id,
-        outcome=cost_outcome,
+        outcome=resolved_outcome,
         duration_ms=execution_time,
         api_key_prefix=key_prefix,
         source="mcp_rest",

--- a/robosystems/routers/graphs/mcp/remote.py
+++ b/robosystems/routers/graphs/mcp/remote.py
@@ -28,6 +28,7 @@ Transport rules:
 import asyncio
 import json
 import re
+import time
 from importlib.metadata import version as pkg_version
 from typing import Any
 
@@ -40,6 +41,13 @@ from sse_starlette.sse import EventSourceResponse
 from robosystems.logger import api_logger, logger
 from robosystems.middleware.auth.dependencies import get_current_user_with_graph
 from robosystems.middleware.graph import get_graph_repository
+from robosystems.middleware.graph.query_telemetry import (
+  api_key_prefix_from_request,
+  is_disrupted_aggregation,
+  log_shared_query_end,
+  log_shared_query_start,
+  record_shared_query_outcome,
+)
 from robosystems.middleware.graph.types import GRAPH_OR_SUBGRAPH_ID_PATTERN
 from robosystems.middleware.otel.metrics import endpoint_metrics_decorator
 from robosystems.middleware.rate_limits import (
@@ -359,6 +367,9 @@ async def _stream_tool_call(
   timeout: int,
   msg_id: Any,
   progress_token: Any,
+  user_id: str | None = None,
+  api_key_prefix: str | None = None,
+  exec_id: str | None = None,
 ):
   """Drive one tools/call as the SSE body of the POST response.
 
@@ -372,6 +383,10 @@ async def _stream_tool_call(
   events: list[dict[str, Any]] = []
   last_progress = 0.0
   payload: dict[str, Any]
+  started = time.monotonic()
+  # Default covers the generator being closed at a yield (client disconnect
+  # cancels in-flight work); every settled path overwrites it.
+  outcome = "client_disconnected"
   try:
     try:
       async with asyncio.timeout(timeout):
@@ -388,9 +403,32 @@ async def _stream_tool_call(
             yield {"data": json.dumps(notification)}
 
       result = aggregate_streamed_results(events)
+      outcome = "completed"
+      if is_disrupted_aggregation(result):
+        outcome = "stream_disrupted"
+        record_shared_query_outcome(
+          graph_id,
+          user_id,
+          signal="stream_disrupted",
+          disruption=True,
+          api_key_prefix=api_key_prefix,
+          endpoint="/v1/graphs/{graph_id}/mcp",
+          source="mcp_remote",
+          tool_name=tool_call.name,
+        )
       payload = {"jsonrpc": "2.0", "id": msg_id, "result": _to_tool_result(result)}
       circuit_breaker.record_success(graph_id, tool_call.name)
     except TimeoutError:
+      outcome = "timeout"
+      record_shared_query_outcome(
+        graph_id,
+        user_id,
+        signal="timeout",
+        api_key_prefix=api_key_prefix,
+        endpoint="/v1/graphs/{graph_id}/mcp",
+        source="mcp_remote",
+        tool_name=tool_call.name,
+      )
       payload = {
         "jsonrpc": "2.0",
         "id": msg_id,
@@ -405,7 +443,17 @@ async def _stream_tool_call(
         },
       }
     except Exception as e:
+      outcome = "error"
       circuit_breaker.record_failure(graph_id, tool_call.name)
+      record_shared_query_outcome(
+        graph_id,
+        user_id,
+        error=e,
+        api_key_prefix=api_key_prefix,
+        endpoint="/v1/graphs/{graph_id}/mcp",
+        source="mcp_remote",
+        tool_name=tool_call.name,
+      )
       logger.error(
         f"Remote MCP streamed tool execution failed: {e}",
         extra={"graph_id": graph_id, "tool_name": tool_call.name},
@@ -420,6 +468,16 @@ async def _stream_tool_call(
       }
     yield {"data": json.dumps(payload)}
   finally:
+    log_shared_query_end(
+      exec_id,
+      graph_id,
+      user_id,
+      outcome=outcome,
+      duration_ms=(time.monotonic() - started) * 1000,
+      api_key_prefix=api_key_prefix,
+      source="mcp_remote",
+      tool_name=tool_call.name,
+    )
     if not handler._closed:
       await handler.close()
 
@@ -430,6 +488,8 @@ async def _stream_queued_call(
   current_user: User,
   msg_id: Any,
   progress_token: Any,
+  api_key_prefix: str | None = None,
+  exec_id: str | None = None,
 ):
   """Bridge a queued cypher execution onto the SSE response.
 
@@ -450,6 +510,8 @@ async def _stream_queued_call(
   queue_id: str | None = None
   query_settled = False  # reached completed/failed/cancelled in the queue
   last_progress = 0.0
+  started = time.monotonic()
+  outcome = "client_disconnected"
   try:
     try:
       queue_id = await queue_manager.submit_query(
@@ -496,6 +558,7 @@ async def _stream_queued_call(
 
           if state == "completed":
             query_settled = True
+            outcome = "completed"
             result = await queue_manager.get_query_result(queue_id)
             payload = {
               "jsonrpc": "2.0",
@@ -506,19 +569,41 @@ async def _stream_queued_call(
             break
           if state in ("failed", "cancelled"):
             query_settled = True
+            outcome = f"queue_{state}"
             error = status.get("error") or f"Query {state}"
+            if state == "failed":
+              record_shared_query_outcome(
+                graph_id,
+                current_user.id,
+                signal="queue_failed",
+                api_key_prefix=api_key_prefix,
+                endpoint="/v1/graphs/{graph_id}/mcp",
+                source="mcp_remote",
+                tool_name=tool_call.name,
+              )
             payload = _tool_error_payload(msg_id, str(error))
             break
 
           await asyncio.sleep(_QUEUE_POLL_SECONDS)
     except TimeoutError:
+      outcome = "bridge_timeout"
       payload = _tool_error_payload(
         msg_id,
         f"Error: queued query did not complete within "
         f"{_QUEUE_BRIDGE_TIMEOUT_SECONDS} seconds",
       )
     except Exception as e:
+      outcome = "error"
       circuit_breaker.record_failure(graph_id, tool_call.name)
+      record_shared_query_outcome(
+        graph_id,
+        current_user.id,
+        error=e,
+        api_key_prefix=api_key_prefix,
+        endpoint="/v1/graphs/{graph_id}/mcp",
+        source="mcp_remote",
+        tool_name=tool_call.name,
+      )
       logger.error(
         f"Remote MCP queued execution failed: {e}",
         extra={"graph_id": graph_id, "tool_name": tool_call.name},
@@ -527,6 +612,16 @@ async def _stream_queued_call(
 
     yield {"data": json.dumps(payload)}
   finally:
+    log_shared_query_end(
+      exec_id,
+      graph_id,
+      current_user.id,
+      outcome=outcome,
+      duration_ms=(time.monotonic() - started) * 1000,
+      api_key_prefix=api_key_prefix,
+      source="mcp_remote",
+      tool_name=tool_call.name,
+    )
     # Reached without a settled queue state on disconnect (generator closed
     # at a yield), bridge timeout, or submit/monitor failure: stop the queued
     # work so abandoned queries don't burn queue capacity.
@@ -556,11 +651,24 @@ async def _handle_tools_call(
     )
 
   tool_call = MCPToolCall(name=name, arguments=arguments)
+  key_prefix = api_key_prefix_from_request(request)
 
   try:
     circuit_breaker.check_circuit(graph_id, name)
     access_type = await authorize_mcp_tool_call(graph_id, tool_call, current_user)
   except HTTPException as e:
+    # Tool failures leave this transport as HTTP 200 + isError per the MCP
+    # contract, so outcomes must be recorded here at classification time —
+    # status-code-level telemetry is blind to this surface.
+    record_shared_query_outcome(
+      graph_id,
+      current_user.id,
+      status_code=e.status_code,
+      api_key_prefix=key_prefix,
+      endpoint="/v1/graphs/{graph_id}/mcp",
+      source="mcp_remote",
+      tool_name=name,
+    )
     detail = e.detail if isinstance(e.detail, str) else json.dumps(e.detail)
     return _tool_error_result(msg_id, detail)
 
@@ -605,6 +713,17 @@ async def _handle_tools_call(
   )
   timeout = MCPStrategySelector.get_timeout_for_strategy(strategy)
 
+  query_arg = arguments.get("query")
+  exec_id = log_shared_query_start(
+    graph_id,
+    current_user.id,
+    api_key_prefix=key_prefix,
+    source="mcp_remote",
+    tool_name=name,
+    query_length=len(query_arg) if isinstance(query_arg, str) else None,
+    strategy=strategy.value,
+  )
+
   meta = params.get("_meta")
   progress_token = meta.get("progressToken") if isinstance(meta, dict) else None
   accept_header = request.headers.get("accept", "")
@@ -624,7 +743,15 @@ async def _handle_tools_call(
     strategy in _QUEUE_STRATEGIES and name in _CYPHER_READ_TOOLS and client_accepts_sse
   ):
     return EventSourceResponse(
-      _stream_queued_call(graph_id, tool_call, current_user, msg_id, progress_token),
+      _stream_queued_call(
+        graph_id,
+        tool_call,
+        current_user,
+        msg_id,
+        progress_token,
+        api_key_prefix=key_prefix,
+        exec_id=exec_id,
+      ),
       ping=_SSE_PING_SECONDS,
     )
 
@@ -637,18 +764,66 @@ async def _handle_tools_call(
   if strategy in _SSE_STRATEGIES and client_accepts_sse:
     return EventSourceResponse(
       _stream_tool_call(
-        handler, graph_id, tool_call, strategy, timeout, msg_id, progress_token
+        handler,
+        graph_id,
+        tool_call,
+        strategy,
+        timeout,
+        msg_id,
+        progress_token,
+        user_id=str(current_user.id),
+        api_key_prefix=key_prefix,
+        exec_id=exec_id,
       ),
       ping=_SSE_PING_SECONDS,
     )
 
+  direct_started = time.monotonic()
   try:
     result = await execute_tool_to_json(handler, graph_id, tool_call, strategy, timeout)
   except HTTPException as e:
+    record_shared_query_outcome(
+      graph_id,
+      current_user.id,
+      status_code=e.status_code,
+      api_key_prefix=key_prefix,
+      endpoint="/v1/graphs/{graph_id}/mcp",
+      source="mcp_remote",
+      tool_name=name,
+    )
+    log_shared_query_end(
+      exec_id,
+      graph_id,
+      current_user.id,
+      outcome=f"http_{e.status_code}",
+      duration_ms=(time.monotonic() - direct_started) * 1000,
+      api_key_prefix=key_prefix,
+      source="mcp_remote",
+      tool_name=name,
+    )
     detail = e.detail if isinstance(e.detail, str) else json.dumps(e.detail)
     return _tool_error_result(msg_id, detail)
   except Exception as e:
     circuit_breaker.record_failure(graph_id, name)
+    record_shared_query_outcome(
+      graph_id,
+      current_user.id,
+      error=e,
+      api_key_prefix=key_prefix,
+      endpoint="/v1/graphs/{graph_id}/mcp",
+      source="mcp_remote",
+      tool_name=name,
+    )
+    log_shared_query_end(
+      exec_id,
+      graph_id,
+      current_user.id,
+      outcome="error",
+      duration_ms=(time.monotonic() - direct_started) * 1000,
+      api_key_prefix=key_prefix,
+      source="mcp_remote",
+      tool_name=name,
+    )
     logger.error(
       f"Remote MCP tool execution failed: {e}",
       extra={"graph_id": graph_id, "user_id": str(current_user.id), "tool_name": name},
@@ -659,6 +834,29 @@ async def _handle_tools_call(
       await handler.close()
 
   circuit_breaker.record_success(graph_id, name)
+  outcome = "completed"
+  if is_disrupted_aggregation(result):
+    outcome = "stream_disrupted"
+    record_shared_query_outcome(
+      graph_id,
+      current_user.id,
+      signal="stream_disrupted",
+      disruption=True,
+      api_key_prefix=key_prefix,
+      endpoint="/v1/graphs/{graph_id}/mcp",
+      source="mcp_remote",
+      tool_name=name,
+    )
+  log_shared_query_end(
+    exec_id,
+    graph_id,
+    current_user.id,
+    outcome=outcome,
+    duration_ms=(time.monotonic() - direct_started) * 1000,
+    api_key_prefix=key_prefix,
+    source="mcp_remote",
+    tool_name=name,
+  )
   return _rpc_result(msg_id, _to_tool_result(result))
 
 

--- a/robosystems/routers/graphs/query/execute.py
+++ b/robosystems/routers/graphs/query/execute.py
@@ -735,6 +735,15 @@ async def execute_cypher_query(
   except ValueError as e:
     # Handle credit-related errors (no credit pool found)
     if "No credit pool found" in str(e):
+      log_shared_query_end(
+        exec_id,
+        graph_id,
+        current_user.id,
+        outcome="http_402",
+        duration_ms=(datetime.now(UTC) - start_time).total_seconds() * 1000,
+        api_key_prefix=key_prefix,
+        source="query_cypher",
+      )
       raise HTTPException(
         status_code=http_status.HTTP_402_PAYMENT_REQUIRED,
         detail="No credit pool found for this graph. Please check your subscription.",
@@ -745,6 +754,15 @@ async def execute_cypher_query(
       status_code=http_status.HTTP_400_BAD_REQUEST,
       api_key_prefix=key_prefix,
       endpoint="/v1/graphs/{graph_id}/query/cypher",
+      source="query_cypher",
+    )
+    log_shared_query_end(
+      exec_id,
+      graph_id,
+      current_user.id,
+      outcome="http_400",
+      duration_ms=(datetime.now(UTC) - start_time).total_seconds() * 1000,
+      api_key_prefix=key_prefix,
       source="query_cypher",
     )
     # Re-raise other ValueErrors — 400s are client errors, keep specific message

--- a/robosystems/routers/graphs/query/execute.py
+++ b/robosystems/routers/graphs/query/execute.py
@@ -24,6 +24,12 @@ from robosystems.logger import api_logger, log_metric, logger
 from robosystems.middleware.auth.dependencies import get_current_user_with_graph
 from robosystems.middleware.graph import get_universal_repository
 from robosystems.middleware.graph.query_queue import get_query_queue
+from robosystems.middleware.graph.query_telemetry import (
+  api_key_prefix_from_request,
+  log_shared_query_end,
+  log_shared_query_start,
+  record_shared_query_outcome,
+)
 from robosystems.middleware.graph.statement_kernel import (
   StatementEngine,
   statement_kernel,
@@ -140,6 +146,11 @@ async def execute_cypher_query(
 
   # Initialize client_info for exception handling
   client_info = {"is_interactive": False}
+
+  # Shared-repository telemetry context (no-ops on user graphs)
+  is_shared = MultiTenantUtils.is_shared_repository_or_subgraph(graph_id)
+  key_prefix = api_key_prefix_from_request(full_request)
+  exec_id: str | None = None
 
   try:
     # Authorize the statement — write policy, engine validation, role gate.
@@ -280,6 +291,15 @@ async def execute_cypher_query(
       },
     )
 
+    exec_id = log_shared_query_start(
+      graph_id,
+      current_user.id,
+      api_key_prefix=key_prefix,
+      source="query_cypher",
+      query_length=len(request.query),
+      strategy=strategy.value,
+    )
+
     # Execute based on strategy
     if strategy == ExecutionStrategy.SSE_QUEUE_STREAM:
       # Queue with SSE then stream results
@@ -291,6 +311,14 @@ async def execute_cypher_query(
       )
 
       # Stream with unified monitoring support
+      log_shared_query_end(
+        exec_id,
+        graph_id,
+        current_user.id,
+        outcome="dispatched_stream",
+        api_key_prefix=key_prefix,
+        source="query_cypher",
+      )
       return await stream_sse_with_queue(
         request=request,
         graph_id=graph_id,
@@ -303,6 +331,14 @@ async def execute_cypher_query(
 
     elif strategy == ExecutionStrategy.SSE_STREAMING:
       # Direct SSE streaming
+      log_shared_query_end(
+        exec_id,
+        graph_id,
+        current_user.id,
+        outcome="dispatched_stream",
+        api_key_prefix=key_prefix,
+        source="query_cypher",
+      )
       return await stream_sse_response(
         repository=repository,
         request=request,
@@ -315,6 +351,14 @@ async def execute_cypher_query(
 
     elif strategy == ExecutionStrategy.NDJSON_STREAMING:
       # NDJSON streaming
+      log_shared_query_end(
+        exec_id,
+        graph_id,
+        current_user.id,
+        outcome="dispatched_stream",
+        api_key_prefix=key_prefix,
+        source="query_cypher",
+      )
       return await stream_ndjson_response(
         repository=repository,
         request=request,
@@ -349,6 +393,17 @@ async def execute_cypher_query(
 
         # Extract columns
         columns = list(result[0].keys()) if result else []
+
+        log_shared_query_end(
+          exec_id,
+          graph_id,
+          current_user.id,
+          outcome="completed",
+          duration_ms=execution_time,
+          row_count=len(result),
+          api_key_prefix=key_prefix,
+          source="query_cypher",
+        )
 
         # Check if result is too large for testing tools
         if (
@@ -467,11 +522,27 @@ async def execute_cypher_query(
         # (ALB + ASG) — queuing just delays the inevitable, so return a
         # timeout error. User graphs benefit from the queue since they have
         # limited connections (max 3) and no read replicas.
-        is_shared = MultiTenantUtils.is_shared_repository_or_subgraph(graph_id)
-
         if client_info["is_interactive"] or is_shared:
           elapsed = (datetime.now(UTC) - start_time).total_seconds()
 
+          record_shared_query_outcome(
+            graph_id,
+            current_user.id,
+            signal="timeout",
+            status_code=http_status.HTTP_408_REQUEST_TIMEOUT,
+            api_key_prefix=key_prefix,
+            endpoint="/v1/graphs/{graph_id}/query/cypher",
+            source="query_cypher",
+          )
+          log_shared_query_end(
+            exec_id,
+            graph_id,
+            current_user.id,
+            outcome="timeout",
+            duration_ms=elapsed * 1000,
+            api_key_prefix=key_prefix,
+            source="query_cypher",
+          )
           return JSONResponse(
             status_code=http_status.HTTP_408_REQUEST_TIMEOUT,
             content={
@@ -649,6 +720,14 @@ async def execute_cypher_query(
       "monitor": f"/v1/operations/{sse_response['operation_id']}/stream",  # Unified monitoring only
     }
 
+    log_shared_query_end(
+      exec_id,
+      graph_id,
+      current_user.id,
+      outcome="queued",
+      api_key_prefix=key_prefix,
+      source="query_cypher",
+    )
     return JSONResponse(
       status_code=http_status.HTTP_202_ACCEPTED, content=response_content
     )
@@ -660,6 +739,14 @@ async def execute_cypher_query(
         status_code=http_status.HTTP_402_PAYMENT_REQUIRED,
         detail="No credit pool found for this graph. Please check your subscription.",
       )
+    record_shared_query_outcome(
+      graph_id,
+      current_user.id,
+      status_code=http_status.HTTP_400_BAD_REQUEST,
+      api_key_prefix=key_prefix,
+      endpoint="/v1/graphs/{graph_id}/query/cypher",
+      source="query_cypher",
+    )
     # Re-raise other ValueErrors — 400s are client errors, keep specific message
     raise HTTPException(
       status_code=http_status.HTTP_400_BAD_REQUEST,
@@ -669,10 +756,44 @@ async def execute_cypher_query(
   except HTTPException as exc:
     if exc.status_code >= 500:
       circuit_breaker.record_failure(graph_id, "cypher_query")
+    record_shared_query_outcome(
+      graph_id,
+      current_user.id,
+      status_code=exc.status_code,
+      api_key_prefix=key_prefix,
+      endpoint="/v1/graphs/{graph_id}/query/cypher",
+      source="query_cypher",
+    )
+    log_shared_query_end(
+      exec_id,
+      graph_id,
+      current_user.id,
+      outcome=f"http_{exc.status_code}",
+      duration_ms=(datetime.now(UTC) - start_time).total_seconds() * 1000,
+      api_key_prefix=key_prefix,
+      source="query_cypher",
+    )
     raise
 
   except Exception as e:
     circuit_breaker.record_failure(graph_id, "cypher_query", error=e)
+    record_shared_query_outcome(
+      graph_id,
+      current_user.id,
+      error=e,
+      api_key_prefix=key_prefix,
+      endpoint="/v1/graphs/{graph_id}/query/cypher",
+      source="query_cypher",
+    )
+    log_shared_query_end(
+      exec_id,
+      graph_id,
+      current_user.id,
+      outcome="error",
+      duration_ms=(datetime.now(UTC) - start_time).total_seconds() * 1000,
+      api_key_prefix=key_prefix,
+      source="query_cypher",
+    )
 
     # Record business event for unexpected errors
     metrics_instance = get_endpoint_metrics()

--- a/robosystems/routers/graphs/query/sql.py
+++ b/robosystems/routers/graphs/query/sql.py
@@ -8,13 +8,17 @@ tables). Authorization runs through the shared StatementKernel.
 
 from datetime import UTC, datetime
 
-from fastapi import APIRouter, Body, Depends, HTTPException, Path, status
+from fastapi import APIRouter, Body, Depends, HTTPException, Path, Request, status
 from sqlalchemy.orm import Session
 
 from robosystems.database import get_db_session
 from robosystems.logger import api_logger, logger
 from robosystems.middleware.auth.dependencies import get_current_user_with_graph
 from robosystems.middleware.graph import get_universal_repository
+from robosystems.middleware.graph.query_telemetry import (
+  api_key_prefix_from_request,
+  record_shared_query_outcome,
+)
 from robosystems.middleware.graph.statement_kernel import (
   StatementEngine,
   statement_kernel,
@@ -53,6 +57,7 @@ circuit_breaker = CircuitBreakerManager()
   "/v1/graphs/{graph_id}/query/sql", business_event_type="table_query_executed"
 )
 async def execute_sql(
+  full_request: Request,
   graph_id: str = Path(
     ...,
     description="Graph database identifier",
@@ -70,13 +75,24 @@ async def execute_sql(
 
   # Authorize the statement — SQL is read-only and blocked on shared repos.
   # Shared, transport-independent path (also used by /query/cypher, MCP).
-  statement_kernel.authorize(
-    engine=StatementEngine.SQL,
-    graph_id=graph_id,
-    statement=request.sql,
-    user=current_user,
-    session=db,
-  )
+  try:
+    statement_kernel.authorize(
+      engine=StatementEngine.SQL,
+      graph_id=graph_id,
+      statement=request.sql,
+      user=current_user,
+      session=db,
+    )
+  except HTTPException as exc:
+    record_shared_query_outcome(
+      graph_id,
+      current_user.id,
+      status_code=exc.status_code,
+      api_key_prefix=api_key_prefix_from_request(full_request),
+      endpoint="/v1/graphs/{graph_id}/query/sql",
+      source="query_sql",
+    )
+    raise
 
   try:
     # Verify graph access

--- a/robosystems/security/audit_logger.py
+++ b/robosystems/security/audit_logger.py
@@ -51,13 +51,17 @@ class SecurityEventType(Enum):
   SUBGRAPH_DELETED = "subgraph_deleted"
   # Graph lifecycle events
   GRAPH_DELETED = "graph_deleted"
+  # Shared-repository query telemetry
+  QUERY_ABUSE_SIGNAL = "query_abuse_signal"
+  QUERY_ENGINE_DISRUPTION = "query_engine_disruption"
 
 
 # CloudWatch metrics: the compliance/alerting-relevant subset of security
 # events is published to RoboSystems/Security/{env} so the detective-control
-# alarms in cloudformation/api.yaml can actually fire. Operational events
-# (email_sent, auth_success, operation_timeout, …) are deliberately excluded
-# to keep the metric stream low-volume and the alarms meaningful.
+# alarms (cloudformation/api.yaml, graph-ladybug-replicas.yaml) can actually
+# fire. Operational events (email_sent, auth_success, operation_timeout, …)
+# are deliberately excluded to keep the metric stream low-volume and the
+# alarms meaningful.
 _METRIC_FOR_EVENT: dict[SecurityEventType, str] = {
   SecurityEventType.AUTH_FAILURE: "AuthFailure",
   SecurityEventType.AUTH_TOKEN_EXPIRED: "AuthFailure",
@@ -68,6 +72,8 @@ _METRIC_FOR_EVENT: dict[SecurityEventType, str] = {
   SecurityEventType.INJECTION_ATTEMPT: "InjectionAttempt",
   SecurityEventType.PATH_TRAVERSAL_ATTEMPT: "InjectionAttempt",
   SecurityEventType.PRIVILEGE_ESCALATION_ATTEMPT: "PrivilegeEscalationAttempt",
+  SecurityEventType.QUERY_ABUSE_SIGNAL: "QueryAbuseSignal",
+  SecurityEventType.QUERY_ENGINE_DISRUPTION: "QueryEngineDisruption",
 }
 
 # Emitted in addition to AuthFailure when the failure is on the admin surface,
@@ -393,6 +399,39 @@ class SecurityAuditLogger:
       endpoint=endpoint,
       details=details,
       risk_level="medium" if amount < 1000 else "high",
+    )
+
+  @staticmethod
+  def log_query_abuse_signal(
+    user_id: str | None,
+    graph_id: str,
+    signal: str,
+    api_key_prefix: str | None = None,
+    endpoint: str | None = None,
+    metadata: dict[str, Any] | None = None,
+    disruption: bool = False,
+  ):
+    """Log a shared-repository query outcome that counts toward abuse detection.
+
+    ``signal`` names the outcome class (e.g. ``timeout``, ``admission_reject``,
+    ``rate_limited``, ``analyzer_reject``, ``write_denied``). Set ``disruption``
+    for engine-connection-loss outcomes, which publish their own metric so they
+    can alarm at a lower threshold than routine pressure signals.
+    """
+    details: dict[str, Any] = {"graph_id": graph_id, "signal": signal}
+    if api_key_prefix:
+      details["api_key_prefix"] = api_key_prefix
+    if metadata:
+      details.update(metadata)
+
+    SecurityAuditLogger.log_security_event(
+      event_type=SecurityEventType.QUERY_ENGINE_DISRUPTION
+      if disruption
+      else SecurityEventType.QUERY_ABUSE_SIGNAL,
+      user_id=user_id,
+      endpoint=endpoint,
+      details=details,
+      risk_level="critical" if disruption else "medium",
     )
 
   @staticmethod

--- a/static/description.md
+++ b/static/description.md
@@ -29,7 +29,7 @@ The core platform surface for querying and managing graphs. Reads are REST `GET`
 
 - **Subgraphs**: List subgraphs, quota, and storage information
 - **Backups**: List backups, download URLs, and storage statistics
-- **Analytics**: Usage and content analytics
+- **Usage**: Graph content metrics and consumption usage (storage, credits)
 
 **Lifecycle commands** (`/operations/{op_name}`):
 
@@ -40,11 +40,14 @@ The core platform surface for querying and managing graphs. Reads are REST `GET`
 - **change-tier**: Change graph infrastructure tier with Stripe billing integration
 - **materialize**: Ingest DuckDB-staged tables or OLTP data into the graph (direct or Dagster-orchestrated)
 
-### Documents & Search
+### Documents, Search & Memory
 
-- **Documents**: Upload, list, retrieve, update, and delete documents attached to a graph
+Reads are REST `GET`s; content writes share the same `/operations/{op_name}` envelope as lifecycle commands.
+
+- **Documents**: List and retrieve documents attached to a graph; write via `index-document` / `delete-document`
 - **Search**: Full-text and semantic (BM25 + KNN) search across graph documents via OpenSearch, with section-level retrieval
-- **Files**: Manage uploaded files — create upload, list, inspect, update status, and delete
+- **Files**: Stage uploaded files — `create-file-upload`, `ingest-file`, and `delete-file` commands with list and inspect reads
+- **Memory**: Per-graph semantic memory for AI agents — ranked `recall` plus list/get reads, with `remember` / `forget` / `update-memory` commands
 
 ### MCP & AI Operators
 
@@ -53,6 +56,7 @@ The core platform surface for querying and managing graphs. Reads are REST `GET`
 
 ### Data Synchronization
 
+- **Connections**: Provider connections with OAuth flows, sync triggers, and status
 - **SEC Filings**: Process XBRL documents and build filing knowledge graphs
 - **QuickBooks**: Sync transactions, accounts, and financial reports
 
@@ -68,8 +72,8 @@ Domain extensions (RoboLedger, RoboInvestor) bring their own schema and OLTP tab
 
 [RoboLedger](https://roboledger.ai) is an accounting and financial reporting extension — a ledger-grade system of record that AI and analysts can both query and operate, broadly implementing the [Seattle Method](http://xbrlsite.com/seattlemethod/). Three block molecules are the authoring substrate:
 
-- **Information Blocks** — reportable content (schedules, statements, metrics) bundled with period-versioned fact sets, typed mechanics, and rules; `evaluate-rules` runs arithmetic checks over materialized facts
-- **Event Blocks** — REA event capture: record what happened via an action-verb vocabulary, and a handler registry derives debits/credits across the three-level ledger (Transaction → Entry → LineItem)
+- **Information Blocks** — reportable content (schedules, statements, metrics) bundled with period-versioned fact sets, typed mechanics, and rules; `evaluate-rules` runs arithmetic checks over materialized facts, and `assert-metrics` writes asserted metric series
+- **Event Blocks** — REA event capture: record what happened via an action-verb vocabulary, and a handler registry derives debits/credits across the three-level ledger (Transaction → Entry → LineItem); external systems post events through registered event sources
 - **Taxonomy Blocks** — accounting frameworks as data: Elements, Associations (presentation / calculation / mapping), Structures, and structural rules in one write; Ships with `rs-gaap` (~2,000 curated US-GAAP concepts) as the initial base taxonomy
 
 Built on the blocks:
@@ -78,6 +82,7 @@ Built on the blocks:
 - **Close lifecycle** — fiscal calendar (`closed_through` / `close_target`) with period close/reopen gated on the balance equation and QuickBooks sync-staleness
 - **Mapping** — CoA→GAAP associations plus AI-assisted bulk mapping via the **MappingOperator** (auto-approve / review / skip)
 - **Reporting** — multi-period statements through a Reporting Style, with a draft → under_review → filed → archived lifecycle and publish lists
+- **Forecasting** — operating-plan scenarios projected through the same statement structures: rule-driven forecasts, per-line growth trajectories, and manual line assertions, with forecast periods returned alongside actuals on statement reads
 - **Analytical views** — `live-financial-statement` from the OLTP ledger; `build-fact-grid` and `financial-statement-analysis` over the materialized XBRL graph hypercube
 - **Serialization** — reports to **JSON-LD** (SHACL-validatable) and **XBRL 2.1** (Arelle-validated)
 - **Pipelines** — QuickBooks ELT via dbt/Dagster with a configurable `write_policy`
@@ -96,7 +101,7 @@ Built on the blocks:
 - **User Management**: Manage user account settings and profile
 - **Subscriptions**: Shared repository subscription access & AI credits
 - **Limits**: Rate limiting and usage tracking for shared repositories
-- **Organizations**: Team collaboration and permission management
+- **Organizations**: Multi-user orgs — invitations, member roles, org-billed subscriptions, and per-graph membership
 
 ## MCP Client
 

--- a/static/graph-api-description.md
+++ b/static/graph-api-description.md
@@ -7,7 +7,8 @@ High-performance REST API for LadybugDB graph database operations. Provides mult
 - **Data Ingestion**: DuckDB staging from S3 Parquet, PostgreSQL (postgres_scanner), and queries
 - **Backup & Restore**: On-demand full database backups with optional encryption and compression
 - **Health & Monitoring**: Real-time health checks, metrics, and task tracking
-- **Vector Search**: LanceDB-powered semantic search across graph data
+- **Vector Search**: LadybugDB-native HNSW indexes built at materialization and searched in Cypher (`QUERY_VECTOR_INDEX`)
+- **Semantic Memory**: Per-graph LanceDB memory store backing the platform AI-memory surface (writer/master only)
 
 ## API Operations
 
@@ -17,6 +18,7 @@ High-performance REST API for LadybugDB graph database operations. Provides mult
 - Get database metadata (size, health status, node/relationship counts)
 - List all accessible databases
 - Health checks and status monitoring
+- LadybugDB engine version migrations
 
 ### Query Execution
 
@@ -29,6 +31,7 @@ High-performance REST API for LadybugDB graph database operations. Provides mult
 
 - **DuckDB Staging**: Validate and transform data before graph import
 - **Materialization**: Stage DuckDB tables into LadybugDB graph
+- **Blue-Green Swap**: Materialize a WIP database beside the active one, then promote it atomically (one-way)
 - **Batch Processing**: Chunked operations for large datasets
 - **Schema Validation**: Ensure data conforms to graph schema
 

--- a/tests/middleware/auth/test_dependencies.py
+++ b/tests/middleware/auth/test_dependencies.py
@@ -1325,3 +1325,56 @@ class TestRequireGraphWriteRole:
     ):
       # member/admin -> no raise
       require_graph_write_role("user_1", "kg0123456789abcdef")
+
+
+class TestApiKeyIdentityStash:
+  """API-key auth records the key's identification prefix on request.state."""
+
+  @pytest.mark.asyncio
+  @patch("robosystems.middleware.auth.dependencies.validate_api_key")
+  async def test_get_optional_user_stashes_prefix(self, mock_validate_api_key):
+    api_key = "rfs" + "a" * 64
+    mock_request = Mock()
+    mock_request.headers = {}
+    mock_validate_api_key.return_value = Mock(spec=User)
+
+    result = await get_optional_user(request=mock_request, api_key=api_key)
+
+    assert result is not None
+    assert mock_request.state.api_key_prefix == api_key[:8]
+
+  @pytest.mark.asyncio
+  @patch("robosystems.middleware.auth.dependencies.validate_api_key")
+  async def test_invalid_key_stashes_nothing(self, mock_validate_api_key):
+    api_key = "rfs" + "b" * 64
+    mock_request = Mock()
+    mock_request.headers = {}
+
+    class _State:
+      pass
+
+    mock_request.state = _State()
+    mock_validate_api_key.return_value = None
+
+    result = await get_optional_user(request=mock_request, api_key=api_key)
+
+    assert result is None
+    assert not hasattr(mock_request.state, "api_key_prefix")
+
+  @pytest.mark.asyncio
+  @patch("robosystems.middleware.auth.dependencies.SecurityAuditLogger")
+  @patch("robosystems.middleware.auth.dependencies.validate_api_key")
+  async def test_get_current_user_stashes_prefix(self, mock_validate_api_key, _audit):
+    api_key = "rfs" + "c" * 64
+    mock_request = Mock()
+    mock_request.headers = {}
+    mock_request.client.host = "203.0.113.9"
+    mock_request.url.path = "/v1/graphs/sec/query/cypher"
+    mock_user = Mock(spec=User)
+    mock_user.id = "user_1"
+    mock_validate_api_key.return_value = mock_user
+
+    result = await get_current_user(request=mock_request, api_key=api_key)
+
+    assert result == mock_user
+    assert mock_request.state.api_key_prefix == api_key[:8]

--- a/tests/middleware/graph/test_query_telemetry.py
+++ b/tests/middleware/graph/test_query_telemetry.py
@@ -1,0 +1,196 @@
+"""Tests for shared-repository query telemetry.
+
+Covers outcome classification (status map, engine-disruption shapes, the
+aggregation-fallback envelope), the shared-repository scope gate (user graphs
+must never emit), and the start/end cost-line pairing.
+"""
+
+import json
+from unittest.mock import Mock, patch
+
+from robosystems.middleware.graph.query_telemetry import (
+  api_key_prefix_from_request,
+  is_disrupted_aggregation,
+  is_engine_disruption,
+  log_shared_query_end,
+  log_shared_query_start,
+  record_shared_query_outcome,
+  signal_for_status,
+)
+
+_SHARED_CHECK = (
+  "robosystems.middleware.graph.utils.MultiTenantUtils.is_shared_repository_or_subgraph"
+)
+_AUDIT = "robosystems.security.audit_logger.SecurityAuditLogger.log_query_abuse_signal"
+_TELEMETRY_LOGGER = "robosystems.middleware.graph.query_telemetry.logger"
+
+
+class TestClassification:
+  def test_status_map_covers_signal_statuses(self):
+    assert signal_for_status(400) == "statement_rejected"
+    assert signal_for_status(403) == "access_denied"
+    assert signal_for_status(408) == "timeout"
+    assert signal_for_status(429) == "rate_limited"
+    assert signal_for_status(503) == "capacity_rejected"
+
+  def test_status_map_drops_non_signal_statuses(self):
+    assert signal_for_status(402) is None
+    assert signal_for_status(404) is None
+    assert signal_for_status(500) is None
+    assert signal_for_status(None) is None
+
+  def test_engine_disruption_by_exception_type(self):
+    assert is_engine_disruption(ConnectionResetError("boom"))
+    assert is_engine_disruption(ConnectionError("boom"))
+
+  def test_engine_disruption_by_message(self):
+    assert is_engine_disruption(RuntimeError("peer closed connection unexpectedly"))
+    assert is_engine_disruption(Exception("Server disconnected without response"))
+
+  def test_ordinary_errors_are_not_disruptions(self):
+    assert not is_engine_disruption(ValueError("bad query syntax"))
+    assert not is_engine_disruption(TimeoutError())
+
+  def test_disrupted_aggregation_matches_fallback_envelope(self):
+    assert is_disrupted_aggregation(
+      {"success": False, "error": "Unable to aggregate results", "tool": "x"}
+    )
+
+  def test_disrupted_aggregation_ignores_other_shapes(self):
+    assert not is_disrupted_aggregation({"success": True, "result": {}})
+    assert not is_disrupted_aggregation({"success": False, "error": "Query failed"})
+    assert not is_disrupted_aggregation(None)
+    assert not is_disrupted_aggregation("Unable to aggregate results")
+
+
+class TestRecordSharedQueryOutcome:
+  @patch(_AUDIT)
+  @patch(_SHARED_CHECK, return_value=False)
+  def test_user_graph_never_records(self, mock_shared, mock_audit):
+    record_shared_query_outcome("kg123abc", "user_1", status_code=408)
+    mock_audit.assert_not_called()
+
+  @patch(_AUDIT)
+  @patch(_SHARED_CHECK, return_value=True)
+  def test_status_code_classifies(self, mock_shared, mock_audit):
+    record_shared_query_outcome(
+      "sec",
+      "user_1",
+      status_code=429,
+      api_key_prefix="rfs12345",
+      endpoint="/v1/graphs/{graph_id}/query/cypher",
+      source="query_cypher",
+    )
+    mock_audit.assert_called_once()
+    kwargs = mock_audit.call_args.kwargs
+    assert kwargs["signal"] == "rate_limited"
+    assert kwargs["user_id"] == "user_1"
+    assert kwargs["api_key_prefix"] == "rfs12345"
+    assert kwargs["disruption"] is False
+    assert kwargs["metadata"]["source"] == "query_cypher"
+    assert kwargs["metadata"]["status_code"] == 429
+
+  @patch(_AUDIT)
+  @patch(_SHARED_CHECK, return_value=True)
+  def test_explicit_signal_wins(self, mock_shared, mock_audit):
+    record_shared_query_outcome(
+      "sec", "user_1", signal="stream_disrupted", disruption=True, tool_name="rgc"
+    )
+    kwargs = mock_audit.call_args.kwargs
+    assert kwargs["signal"] == "stream_disrupted"
+    assert kwargs["disruption"] is True
+    assert kwargs["metadata"]["tool_name"] == "rgc"
+
+  @patch(_AUDIT)
+  @patch(_SHARED_CHECK, return_value=True)
+  def test_disruption_error_classifies_and_flags(self, mock_shared, mock_audit):
+    record_shared_query_outcome("sec", "user_1", error=ConnectionResetError("gone"))
+    kwargs = mock_audit.call_args.kwargs
+    assert kwargs["signal"] == "engine_disruption"
+    assert kwargs["disruption"] is True
+
+  @patch(_AUDIT)
+  @patch(_SHARED_CHECK, return_value=True)
+  def test_unclassifiable_outcome_is_dropped(self, mock_shared, mock_audit):
+    record_shared_query_outcome("sec", "user_1", status_code=500)
+    record_shared_query_outcome("sec", "user_1", error=ValueError("syntax"))
+    record_shared_query_outcome("sec", "user_1")
+    mock_audit.assert_not_called()
+
+  @patch(_AUDIT, side_effect=RuntimeError("audit down"))
+  @patch(_SHARED_CHECK, return_value=True)
+  def test_recording_failure_never_raises(self, mock_shared, mock_audit):
+    record_shared_query_outcome("sec", "user_1", status_code=408)
+
+
+class TestCostLines:
+  @patch(_TELEMETRY_LOGGER)
+  @patch(_SHARED_CHECK, return_value=True)
+  def test_start_end_pair_share_exec_id(self, mock_shared, mock_logger):
+    exec_id = log_shared_query_start(
+      "sec",
+      "user_1",
+      api_key_prefix="rfs12345",
+      source="query_cypher",
+      query_length=42,
+      strategy="json_complete",
+    )
+    assert exec_id is not None
+
+    log_shared_query_end(
+      exec_id,
+      "sec",
+      "user_1",
+      outcome="completed",
+      duration_ms=123.5,
+      row_count=7,
+      api_key_prefix="rfs12345",
+      source="query_cypher",
+    )
+
+    assert mock_logger.info.call_count == 2
+    start_msg = mock_logger.info.call_args_list[0].args[0]
+    end_msg = mock_logger.info.call_args_list[1].args[0]
+    assert start_msg.startswith("SHARED_QUERY_COST: ")
+    start = json.loads(start_msg.split("SHARED_QUERY_COST: ", 1)[1])
+    end = json.loads(end_msg.split("SHARED_QUERY_COST: ", 1)[1])
+    assert start["phase"] == "start"
+    assert end["phase"] == "end"
+    assert start["exec_id"] == end["exec_id"] == exec_id
+    assert start["user_id"] == end["user_id"] == "user_1"
+    assert start["query_length"] == 42
+    assert end["outcome"] == "completed"
+    assert end["duration_ms"] == 123.5
+    assert end["row_count"] == 7
+
+  @patch(_TELEMETRY_LOGGER)
+  @patch(_SHARED_CHECK, return_value=False)
+  def test_user_graph_emits_nothing(self, mock_shared, mock_logger):
+    exec_id = log_shared_query_start("kg123abc", "user_1")
+    assert exec_id is None
+    log_shared_query_end(exec_id, "kg123abc", "user_1", outcome="completed")
+    mock_logger.info.assert_not_called()
+
+  @patch(_TELEMETRY_LOGGER)
+  @patch(_SHARED_CHECK, return_value=True)
+  def test_end_with_none_exec_id_is_noop(self, mock_shared, mock_logger):
+    log_shared_query_end(None, "sec", "user_1", outcome="completed")
+    mock_logger.info.assert_not_called()
+
+
+class TestApiKeyPrefixFromRequest:
+  def test_reads_state_attribute(self):
+    request = Mock()
+    request.state.api_key_prefix = "rfs12345"
+    assert api_key_prefix_from_request(request) == "rfs12345"
+
+  def test_missing_attribute_returns_none(self):
+    class _State:
+      pass
+
+    request = Mock()
+    request.state = _State()
+    assert api_key_prefix_from_request(request) is None
+
+  def test_none_request_returns_none(self):
+    assert api_key_prefix_from_request(None) is None

--- a/tests/routers/graphs/query/test_sql.py
+++ b/tests/routers/graphs/query/test_sql.py
@@ -42,6 +42,7 @@ async def test_execute_sql_success():
     ),
   ):
     resp = await sql_module.execute_sql(
+      full_request=MagicMock(),
       graph_id="kg1234567890abcdef",
       request=req,
       current_user=_user(),
@@ -61,6 +62,7 @@ async def test_execute_sql_shared_repo_blocked():
   ):
     with pytest.raises(HTTPException) as e:
       await sql_module.execute_sql(
+        full_request=MagicMock(),
         graph_id="sec",
         request=req,
         current_user=_user(),

--- a/tests/security/test_audit_metrics.py
+++ b/tests/security/test_audit_metrics.py
@@ -265,3 +265,63 @@ class TestAdminAuthFailurePath:
       await mw(request)
 
     mock_log.assert_not_called()
+
+
+class TestQueryAbuseSignalMetrics:
+  """The shared-query telemetry events publish their own alarm metrics."""
+
+  @patch("robosystems.security.audit_logger._publish_security_metrics")
+  def test_query_abuse_signal_emits_metric(self, mock_publish):
+    SecurityAuditLogger.log_security_event(
+      event_type=SecurityEventType.QUERY_ABUSE_SIGNAL,
+    )
+    mock_publish.assert_called_once_with(["QueryAbuseSignal"])
+
+  @patch("robosystems.security.audit_logger._publish_security_metrics")
+  def test_query_engine_disruption_emits_metric(self, mock_publish):
+    SecurityAuditLogger.log_security_event(
+      event_type=SecurityEventType.QUERY_ENGINE_DISRUPTION,
+    )
+    mock_publish.assert_called_once_with(["QueryEngineDisruption"])
+
+  @patch("robosystems.security.audit_logger._publish_security_metrics")
+  def test_log_query_abuse_signal_routes_by_disruption_flag(self, mock_publish):
+    SecurityAuditLogger.log_query_abuse_signal(
+      user_id="user_1",
+      graph_id="sec",
+      signal="timeout",
+      api_key_prefix="rfs12345",
+    )
+    mock_publish.assert_called_once_with(["QueryAbuseSignal"])
+    mock_publish.reset_mock()
+
+    SecurityAuditLogger.log_query_abuse_signal(
+      user_id="user_1",
+      graph_id="sec",
+      signal="stream_disrupted",
+      disruption=True,
+    )
+    mock_publish.assert_called_once_with(["QueryEngineDisruption"])
+
+  @patch("robosystems.security.audit_logger._publish_security_metrics")
+  def test_log_query_abuse_signal_detail_payload(self, mock_publish):
+    with patch(
+      "robosystems.security.audit_logger.SecurityAuditLogger.log_security_event"
+    ) as mock_event:
+      SecurityAuditLogger.log_query_abuse_signal(
+        user_id="user_1",
+        graph_id="sec",
+        signal="rate_limited",
+        api_key_prefix="rfs12345",
+        endpoint="/v1/graphs/{graph_id}/query/cypher",
+        metadata={"status_code": 429, "source": "query_cypher"},
+      )
+    kwargs = mock_event.call_args.kwargs
+    assert kwargs["event_type"] == SecurityEventType.QUERY_ABUSE_SIGNAL
+    assert kwargs["user_id"] == "user_1"
+    assert kwargs["risk_level"] == "medium"
+    details = kwargs["details"]
+    assert details["graph_id"] == "sec"
+    assert details["signal"] == "rate_limited"
+    assert details["api_key_prefix"] == "rfs12345"
+    assert details["status_code"] == 429


### PR DESCRIPTION
## Summary

Adds a detection layer for the shared-repository query surface: classified query and tool outcomes are recorded through the security audit log with per-user and per-API-key attribution, every shared-repo query emits structured start/end cost lines, and the shared-replica stack gains CloudWatch alarms (including a container-start metric filter). Scope is deliberately shared repositories only — user graphs run on dedicated instances and are excluded by design at every entry point.

## Changes

**Telemetry kernel**
- `middleware/graph/query_telemetry.py` (new): outcome classification (status-code map, engine-connection-loss shapes, stream-aggregation fallback envelope), `SHARED_QUERY_COST` start/end line pairs joined by an execution id, and a shared-repository gate on every function. All best-effort — telemetry never raises into the request path.

**Attribution**
- `middleware/auth/dependencies.py`: API-key auth success now stashes the key's stored identification prefix on `request.state.api_key_prefix` (mirrors the existing admin-surface pattern), so telemetry carries both `user_id` and key identity. JWT requests leave it unset.

**Event vocabulary + metrics**
- `security/audit_logger.py`: two new `SecurityEventType`s (`QUERY_ABUSE_SIGNAL`, `QUERY_ENGINE_DISRUPTION`) mapped to CloudWatch metrics in the existing `RoboSystems/Security/{env}` namespace, plus a `log_query_abuse_signal` helper. Disruption outcomes publish their own metric so they can alarm at a lower threshold.

**Query router**
- `routers/graphs/query/execute.py`: outcome recording at the `HTTPException` chokepoint and the directly-returned timeout response, engine-disruption detection in the generic error handler, and cost lines on all terminal paths (streaming dispatch and queue handoff are labeled as such).
- `routers/graphs/query/sql.py`: records statement-kernel rejections; handler gains a `Request` parameter for key attribution.

**MCP surfaces** (both route around the query router, so they get their own hooks — recorded at outcome classification, since the remote transport wraps tool failures as HTTP 200 + `isError`)
- `routers/graphs/mcp/execute.py`: recording at the REST endpoint's exception chokepoints (covers the shared `authorize_mcp_tool_call` gauntlet and tool timeouts), aggregation-envelope check on the stream-aggregated path, cost lines with a `dispatched_stream`/`completed`/`error` outcome from the execution `finally`.
- `routers/graphs/mcp/remote.py`: the SSE tool-call and queue-bridge generators record timeouts, failures, and disrupted aggregations with full duration coverage; generator closure from a client disconnect is labeled `client_disconnected`. The direct JSON path records at its exception handlers and checks the aggregated result.

**Infrastructure**
- `cloudformation/graph-ladybug-replicas.yaml`: metric filter on the replica container-start log marker plus three alarms (`container-start`, `query-abuse-signal`, `query-engine-disruption`) wired to the existing replicas SNS topic. Homed here rather than `api.yaml` (which sits at the CloudFormation inline-template size ceiling). Thresholds are initial values, expected to be tuned once real traffic data exists.

**Docs**
- `static/description.md`, `static/graph-api-description.md`: regenerated API surface descriptions (drift from the recently merged MCP transport work).

## Testing

- Full gate `just test-all` run this session: **12,111 passed, 24 skipped**, ruff + format + basedpyright clean, cf-lint 71/71 PASS.
- New coverage: `tests/middleware/graph/test_query_telemetry.py` (classification, scope gate, cost-line pairing), `tests/security/test_audit_metrics.py` (new event→metric mappings), `tests/middleware/auth/test_dependencies.py` (key-prefix stash on success, nothing on failure).
- Existing query/MCP router suites (150 tests) pass unchanged apart from `test_sql.py` gaining the new handler parameter.

## Notes

- Detection only — no new enforcement or limiting anywhere in this PR.
- Alarms take effect on the next shared-replicas stack deploy; the emit side rides the API deploy. Both should land in the same release as the remote MCP transport.
- Known Phase-0 residual: query-router SSE/NDJSON streaming cost lines stop at dispatch; the MCP aggregation paths have full end-line coverage.
