### PR TITLE
feat(limits): report document usage against the tier cap

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     # RoboSystems client for demo and testing
-    "robosystems-client==1.0.0",
+    "robosystems-client==1.1.0",
 
     # Testing framework
     "pytest>=9.0.0,<10.0",

--- a/robosystems/models/api/graphs/limits.py
+++ b/robosystems/models/api/graphs/limits.py
@@ -58,6 +58,21 @@ class CreditLimits(BaseModel):
   current_balance: int = Field(..., description="Current credit balance")
 
 
+class DocumentLimits(BaseModel):
+  """Knowledge-base document usage against the tier's cap."""
+
+  current_count: int = Field(
+    ..., description="Uploaded documents currently stored for this graph"
+  )
+  max_documents: int | None = Field(
+    None,
+    description="Maximum uploaded documents for this tier (null when uncapped)",
+  )
+  approaching_limit: bool = Field(
+    ..., description="Whether approaching document limit (>80%)"
+  )
+
+
 class ContentLimits(BaseModel):
   """Per-operation materialization limits."""
 
@@ -165,6 +180,11 @@ class GraphLimitsResponse(BaseModel):
             "monthly_ai_credits": 8000,
             "current_balance": 7500,
           },
+          "documents": {
+            "current_count": 12,
+            "max_documents": 100,
+            "approaching_limit": False,
+          },
           "content": {
             "max_rows_per_copy": 1000000,
             "max_single_table_rows": 2500000,
@@ -238,6 +258,9 @@ class GraphLimitsResponse(BaseModel):
   rate_limits: RateLimits = Field(..., description="API rate limits")
   credits: CreditLimits | None = Field(
     None, description="AI credit limits (if applicable)"
+  )
+  documents: DocumentLimits | None = Field(
+    None, description="Knowledge-base document usage and tier cap (user graphs only)"
   )
   content: ContentLimits | None = Field(
     None, description="Per-operation materialization limits (if applicable)"

--- a/robosystems/routers/graphs/limits.py
+++ b/robosystems/routers/graphs/limits.py
@@ -26,6 +26,7 @@ from robosystems.models.api.graphs.limits import (
   CopyOperationLimits,
   CreditLimits,
   DatabaseStorageEntry,
+  DocumentLimits,
   GraphLimitsResponse,
   InstanceUsage,
   QueryLimits,
@@ -65,7 +66,7 @@ async def _get_graph_client(graph_id: str) -> GraphClient:
   "/limits",
   response_model=GraphLimitsResponse,
   summary="Get Graph Operational Limits",
-  description="Limits vary by subscription tier (ladybug-standard, ladybug-large, ladybug-xlarge). Includes storage, query, backup, rate, credit, and instance usage limits.",
+  description="Limits vary by subscription tier (ladybug-standard, ladybug-large, ladybug-xlarge). Includes storage, query, backup, rate, credit, document, and instance usage limits.",
   operation_id="getGraphLimits",
   responses={**RESOURCE_ERROR_RESPONSES},
 )
@@ -224,6 +225,29 @@ async def get_graph_limits(
         # must be visible.
         logger.warning(f"Could not get credit limits for {graph_id}: {e}")
 
+    # Document usage against the tier cap. Mirrors upload enforcement
+    # (DocumentService._check_tier_limit): only uploaded documents count, and
+    # shared repositories have no documents surface at all.
+    document_limits = None
+    if not is_shared:
+      try:
+        from robosystems.config.billing.core import get_tier_max_documents
+        from robosystems.models.core import Document
+
+        max_documents = get_tier_max_documents(graph_tier)
+        document_count = Document.count_by_graph(
+          graph_id, session, source_type="uploaded_doc"
+        )
+        document_limits = DocumentLimits(
+          current_count=document_count,
+          max_documents=max_documents,
+          approaching_limit=(
+            max_documents is not None and document_count > max_documents * 0.8
+          ),
+        )
+      except Exception as e:
+        logger.warning(f"Could not get document limits for {graph_id}: {e}")
+
     # Get content limits and instance usage for non-shared graphs.
     # check_instance_storage is a single Graph API call covering the whole
     # instance — subgraphs live on the parent's box, so one breakdown itemizes
@@ -302,6 +326,7 @@ async def get_graph_limits(
       backups=BackupLimits(**backup_limits),
       rate_limits=RateLimits(**rate_limits),
       credits=CreditLimits(**credit_limits) if credit_limits else None,
+      documents=document_limits,
       content=content_limits,
       instance=instance_usage,
     )

--- a/tests/routers/graphs/test_graph_limits.py
+++ b/tests/routers/graphs/test_graph_limits.py
@@ -305,6 +305,46 @@ class TestGraphLimitsEndpoint:
       "current_balance": 31999,
     }
 
+  async def test_reports_document_usage_against_tier_cap(
+    self, async_client: AsyncClient, test_db, test_org, test_user
+  ):
+    """The meter must mirror upload enforcement: only uploaded documents
+    count toward the tier cap, not connection-synced ones."""
+    from robosystems.config.graph_tier import GraphTier
+    from robosystems.models.core import Document
+
+    graph = self._make_graph(test_db, test_org, test_user, GraphTier.LADYBUG_STANDARD)
+    for i in range(2):
+      Document.create(
+        graph_id=graph.graph_id,
+        user_id=test_user.id,
+        title=f"Uploaded {i}",
+        content="# doc",
+        session=test_db,
+      )
+    Document.create(
+      graph_id=graph.graph_id,
+      user_id=test_user.id,
+      title="Synced",
+      content="# synced",
+      session=test_db,
+      external_id="qb-123",
+      source_type="connection_sync",
+    )
+    self._use_test_db(test_db)
+
+    repo, client, storage = self._no_graph_api()
+    with repo, client, storage:
+      response = await async_client.get(f"/v1/graphs/{graph.graph_id}/limits")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["documents"] == {
+      "current_count": 2,
+      "max_documents": 100,
+      "approaching_limit": False,
+    }
+
   async def test_shared_repository_reports_the_enforced_fallback_tier(
     self, async_client: AsyncClient, test_db
   ):
@@ -343,6 +383,13 @@ class TestGraphLimitsEndpoint:
     assert data["graph_tier"] == "kuzu-standard"
     assert data["subscription_tier"] == "ladybug-standard"
     assert data["rate_limits"]["requests_per_minute"] == 60
+    # No billing plan for the legacy string: the count reports, the cap is
+    # open — matching enforcement, which only gates known tiers.
+    assert data["documents"] == {
+      "current_count": 0,
+      "max_documents": None,
+      "approaching_limit": False,
+    }
 
   async def test_shared_repository_subgraph_takes_the_shared_path(
     self, async_client: AsyncClient, test_db
@@ -363,5 +410,6 @@ class TestGraphLimitsEndpoint:
     assert data["subscription_tier"] == "ladybug-standard"
     assert data["rate_limits"]["requests_per_minute"] == 60
     assert data["credits"] is None
+    assert data["documents"] is None
     assert data["content"] is None
     assert data["instance"] is None

--- a/uv.lock
+++ b/uv.lock
@@ -3699,7 +3699,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.34.2,<3.0" },
     { name = "retrying", specifier = ">=1.4.0,<2.0" },
     { name = "rich", marker = "extra == 'dev'", specifier = ">=15.0.0,<16.0" },
-    { name = "robosystems-client", marker = "extra == 'dev'", specifier = "==1.0.0" },
+    { name = "robosystems-client", marker = "extra == 'dev'", specifier = "==1.1.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0,<1.0" },
     { name = "sqlalchemy", specifier = ">=2.0.0,<3.0" },
     { name = "sse-starlette", specifier = ">=3.3.0,<4.0" },
@@ -3722,7 +3722,7 @@ lambda = [
 
 [[package]]
 name = "robosystems-client"
-version = "1.0.0"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -3730,9 +3730,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2e/3b/17e90180f3877286a8479b0afbbd67ce6ef24123ec8a540bf65487a21648/robosystems_client-1.0.0.tar.gz", hash = "sha256:71b466b32e438aa06019f30ebd84e4b894290d2a76d899f3053728751295cfda", size = 511516, upload-time = "2026-08-05T01:40:09.249Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/c3/a576688dc1ca8134d185fbbf3b78c57412b009df58124acbe0cf44c97b63/robosystems_client-1.1.0.tar.gz", hash = "sha256:95ccb555a7135a73e3730cecaa091c28c859ac27015b1ee426d74c5446c3475a", size = 512015, upload-time = "2026-08-05T04:39:13.514Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/82/c5/894ff651dcd6bda9e777aee2ff7e7a47a1b8773070fce4da561fc5f881dc/robosystems_client-1.0.0-py3-none-any.whl", hash = "sha256:b46163b0444c9e9a540970778594fff588478b483e8ccb9106218c71094fdf23", size = 1179724, upload-time = "2026-08-05T01:40:07.434Z" },
+    { url = "https://files.pythonhosted.org/packages/64/74/a41b0b867a91257b25d67a6b7c2fc55e002ed758aba891b861404dc0a747/robosystems_client-1.1.0-py3-none-any.whl", hash = "sha256:228e4719b1da1359c0d9014fecbfc43d8efb4f9599080a766ef3249144a1021f", size = 1180984, upload-time = "2026-08-05T04:39:11.973Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds a `documents` section to `GET /v1/graphs/{graph_id}/limits` reporting the uploaded-document count against the tier's `max_documents` cap. Until now the cap existed only in server config and was visible to users solely in the limit-reached error message at upload time; the Usage page had nothing to render a documents meter from.

## Changes

- **`robosystems/models/api/graphs/limits.py`** — new `DocumentLimits` model (`current_count`, `max_documents`, `approaching_limit`), wired into `GraphLimitsResponse` as an optional `documents` field; OpenAPI example updated.
- **`robosystems/routers/graphs/limits.py`** — populates the section for user graphs, mirroring upload enforcement exactly: only `uploaded_doc` source documents count toward the cap, and shared repositories (which have no documents surface) report `null`. Tiers without a billing plan (legacy tier strings) report the count with an open cap. Failures degrade to `null` with a warning, matching the endpoint's other optional sections.
- **`tests/routers/graphs/test_graph_limits.py`** — new test pinning that connection-synced documents don't count toward the cap; assertions added for the shared-repository (`null`) and legacy-tier (open cap) paths.

## Testing

- `uv run pytest tests/routers/graphs/test_graph_limits.py` — 9 passed.
- `ruff check`, `ruff format --check`, `basedpyright` on the changed files — clean.
- Verified live against the local stack: `/v1/graphs/{id}/limits` on a `ladybug-standard` demo graph returns `{"current_count": 0, "max_documents": 100, "approaching_limit": false}`; OpenAPI spec carries the `DocumentLimits` schema.

## Notes / Follow-ups

- Additive schema change: rides as a minor on the TypeScript/Python clients (regen PRs to follow), then a `robosystems-app` Usage-page meter consuming it.
