### PR TITLE
fix(admin): tolerate pre-provisioning subscriptions in the admin list

### DIFF
--- a/robosystems/admin/commands/billing.py
+++ b/robosystems/admin/commands/billing.py
@@ -52,7 +52,7 @@ def list_subscriptions(client, status, email, resource_type, include_canceled, l
   for sub in subscriptions:
     table.add_row(
       sub["id"],
-      sub["resource_id"],
+      sub["resource_id"] or "—",
       sub.get("owner_email", "N/A"),
       sub["status"],
       sub["plan_name"],
@@ -79,7 +79,7 @@ def get_subscription(client, subscription_id):
   click.echo("=" * 60)
 
   click.echo(f"\nID: {sub['id']}")
-  click.echo(f"Resource: {sub['resource_type']} / {sub['resource_id']}")
+  click.echo(f"Resource: {sub['resource_type']} / {sub['resource_id'] or '—'}")
   click.echo(f"Org: {sub.get('org_name', 'N/A')} ({sub['org_id']})")
   click.echo(f"Owner: {sub.get('owner_name', 'N/A')} ({sub.get('owner_email', 'N/A')})")
   click.echo(f"Status: {sub['status']}")

--- a/robosystems/models/api/admin/subscription.py
+++ b/robosystems/models/api/admin/subscription.py
@@ -37,7 +37,7 @@ class SubscriptionResponse(BaseModel):
   has_payment_method: bool
   invoice_billing_enabled: bool
   resource_type: str
-  resource_id: str
+  resource_id: str | None
   plan_name: str
   billing_interval: str
   base_price_cents: int

--- a/robosystems/models/core/billing/subscription.py
+++ b/robosystems/models/core/billing/subscription.py
@@ -130,7 +130,7 @@ class BillingSubscription(Base):
     cls,
     org_id: str,
     resource_type: str,
-    resource_id: str,
+    resource_id: str | None,
     plan_name: str,
     base_price_cents: int,
     session: Session,
@@ -142,6 +142,8 @@ class BillingSubscription(Base):
 
     Pass `user_id` for per-user resources (repository subscriptions) so access
     and credits can be provisioned to the right member of the paying org.
+    `resource_id` may be None for pre-provisioning rows (checkout creates the
+    subscription first and binds the resource after payment).
     """
     now = datetime.now(UTC)
 

--- a/tests/routers/admin/test_subscription.py
+++ b/tests/routers/admin/test_subscription.py
@@ -147,6 +147,33 @@ class TestListSubscriptions:
     subscription_ids = [sub["id"] for sub in data]
     assert test_subscription.id in subscription_ids
 
+  def test_list_subscriptions_with_null_resource_id(
+    self, client, db_session, test_org, test_subscription, mock_admin_auth
+  ):
+    """A pre-provisioning row (resource_id=None, as checkout creates) must not
+    break the list endpoint."""
+    pending = BillingSubscription.create_subscription(
+      org_id=test_org.id,
+      resource_type="repository",
+      resource_id=None,
+      plan_name="starter",
+      base_price_cents=2900,
+      session=db_session,
+    )
+    pending.status = SubscriptionStatus.PENDING_PAYMENT.value
+    db_session.commit()
+
+    response = client.get(
+      "/admin/v1/subscriptions",
+      headers={"Authorization": "Bearer test-admin-key"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    by_id = {sub["id"]: sub for sub in data}
+    assert by_id[pending.id]["resource_id"] is None
+    assert by_id[test_subscription.id]["resource_id"] is not None
+
   def test_list_subscriptions_with_resource_type_filter(
     self, client, db_session, test_subscription, mock_admin_auth
   ):


### PR DESCRIPTION
## Summary

`GET /admin/v1/subscriptions` returned 500 whenever any subscription row had a NULL `resource_id`, which broke both `just admin stats` and `just admin subscriptions list` (both drive that endpoint). NULL is a legitimate state: `billing_subscriptions.resource_id` is nullable by design, and the checkout flow creates the subscription row *before* provisioning binds a resource (`routers/billing/checkout.py`), so pending-payment rows — or rows canceled before provisioning — carry NULL indefinitely. The admin response model declared the field required, so one such row failed Pydantic validation and poisoned the entire list response.

## Changes

- **`models/api/admin/subscription.py`** — `SubscriptionResponse.resource_id` is now `str | None`, matching the nullable column.
- **`admin/commands/billing.py`** — the CLI renders NULL `resource_id` as `—` in the subscriptions table (rich's `add_row` raises on `None`) and in the `get` detail view.
- **`models/core/billing/subscription.py`** — `create_subscription`'s `resource_id` type hint corrected to `str | None` (checkout already passes `None`); docstring notes the pre-provisioning case.
- **`tests/routers/admin/test_subscription.py`** — regression test: a `pending_payment` row with `resource_id=None` alongside a normal row must list cleanly with a 200.

## Testing

- `uv run pytest tests/routers/admin/test_subscription.py tests/admin/test_cli.py` — 110 passed, including the new regression test.
- `just test-code` (ruff + format + basedpyright + cf-lint) — all checks passed.
- Full `just test-all` not run this session.

## Notes

- Root cause confirmed from prod API logs: `1 validation error for SubscriptionResponse — resource_id: Input should be a valid string [input_value=None]`.
- The published SDKs do not wrap `/admin/v1/*`, so there is no client-contract impact.
