### PR TITLE
fix(storage): harden cap checks on ingestion and materialization paths

### DIFF
--- a/robosystems/middleware/graph/ingestion_limits.py
+++ b/robosystems/middleware/graph/ingestion_limits.py
@@ -89,8 +89,15 @@ class IngestionLimitChecker:
           f"Table '{tbl_name}' has {row_count:,} rows, exceeding max_single_table_rows limit ({max_single_table:,})"
         )
 
-    # Check aggregate instance storage cap (hard limit — product cap, blocks COGS overruns)
-    storage_check = await cls.check_instance_storage(db, graph_id, tier)
+    # Check aggregate instance storage cap (hard limit — product cap, blocks
+    # COGS overruns). Measured at instance scope: a subgraph shares its
+    # parent's box, so the denominator must be the whole instance — measuring
+    # the subgraph's own prefix excludes the parent and sibling databases.
+    # The row-count checks above stay scoped to the requested graph_id, whose
+    # own staging tables are what materialize.
+    storage_check = await cls.check_instance_storage(
+      db, cls._resolve_instance_scope(db, graph_id), tier
+    )
     if not storage_check["allowed"]:
       errors.extend(storage_check["errors"])
 
@@ -114,6 +121,22 @@ class IngestionLimitChecker:
       },
       "tier": tier,
     }
+
+  @classmethod
+  def _resolve_instance_scope(cls, db: Session, graph_id: str) -> str:
+    """Map a graph id to the id owning its instance.
+
+    The storage breakdown's ``{id}_*`` prefix scan only covers the given id
+    and its children, so a subgraph id must be widened to its parent before
+    the instance cap is measured. Mirrors the resolution the ``/limits``
+    reporting path performs.
+    """
+    from robosystems.models.core import Graph
+
+    graph = Graph.get_by_id(graph_id, db)
+    if graph is not None and graph.parent_graph_id:
+      return str(graph.parent_graph_id)
+    return graph_id
 
   @classmethod
   async def check_instance_storage(

--- a/robosystems/operations/graph/commands/ingest_file.py
+++ b/robosystems/operations/graph/commands/ingest_file.py
@@ -21,7 +21,6 @@ from robosystems.config.constants import (
   MAX_FILE_SIZE_MB,
   SMALL_FILE_STAGING_THRESHOLD_MB,
 )
-from robosystems.config.graph_tier import GraphTierConfig
 from robosystems.logger import logger
 from robosystems.models.api.graphs.tables import FileUploadStatus
 from robosystems.models.core import Graph, GraphFile, GraphTable, User
@@ -74,22 +73,47 @@ async def ingest_file_cmd(
     )
 
   graph = Graph.get_by_id(graph_id, db)
-  if graph:
-    storage_limit_gb = GraphTierConfig.get_instance_storage_limit_gb(
-      str(graph.graph_tier)
+  if graph is None:
+    # A graph the registry cannot resolve is refused, not exempted — skipping
+    # the cap on a lookup miss is the fail-open shape this subsystem
+    # eliminated everywhere else.
+    raise HTTPException(
+      status_code=status.HTTP_404_NOT_FOUND,
+      detail=f"Graph {graph_id} not found",
     )
-    storage_limit_bytes = storage_limit_gb * 1024 * 1024 * 1024
 
-    all_tables = GraphTable.get_all_for_graph(graph_id, db)
-    current_storage_bytes = sum(t.total_size_bytes or 0 for t in all_tables)
+  # Gate against the measured instance footprint, not the logical staging
+  # sum: `GraphTable.total_size_bytes` counts only staging rows and is far
+  # smaller than the bytes on disk, so the old comparison could pass on an
+  # instance already at its cap. Instance scope for the same reason as
+  # materialization — a subgraph shares its parent's box.
+  from robosystems.middleware.graph.ingestion_limits import IngestionLimitChecker
 
-    if current_storage_bytes + actual_file_size > storage_limit_bytes:
-      raise HTTPException(
-        status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
-        detail=f"Storage limit exceeded. Current: {current_storage_bytes / (1024 * 1024 * 1024):.2f} GB, "
-        f"Limit: {storage_limit_gb} GB, "
-        f"Attempted upload: {actual_file_size / (1024 * 1024 * 1024):.2f} GB",
-      )
+  scope_graph_id = str(graph.parent_graph_id) if graph.parent_graph_id else graph_id
+  graph_tier = str(graph.graph_tier) or "ladybug-standard"
+  storage_check = await IngestionLimitChecker.check_instance_storage(
+    db, scope_graph_id, graph_tier
+  )
+
+  if storage_check.get("retryable"):
+    raise HTTPException(
+      status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+      detail="Storage usage could not be verified; retry shortly",
+      headers={"Retry-After": "30"},
+    )
+
+  storage_limit_bytes = storage_check["limit_gb"] * 1024**3
+  current_storage_bytes = (storage_check["total_storage_gb"] or 0) * 1024**3
+  if (
+    not storage_check["allowed"]
+    or current_storage_bytes + actual_file_size > storage_limit_bytes
+  ):
+    raise HTTPException(
+      status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+      detail=f"Storage limit exceeded. Current: {current_storage_bytes / (1024**3):.2f} GB, "
+      f"Limit: {storage_check['limit_gb']} GB, "
+      f"Attempted upload: {actual_file_size / (1024**3):.2f} GB",
+    )
 
   actual_row_count = None
   try:

--- a/tests/middleware/graph/test_ingestion_limits.py
+++ b/tests/middleware/graph/test_ingestion_limits.py
@@ -183,6 +183,102 @@ class TestCheckMaterializationLimits:
     assert "current_nodes" not in result["current_usage"]
     assert "current_relationships" not in result["current_usage"]
 
+  @pytest.mark.asyncio
+  async def test_subgraph_storage_check_measures_parent_scope(self):
+    """A subgraph id must widen to its parent for the storage check.
+
+    The breakdown's prefix scan for `kg123_dev` covers only `kg123_dev*`,
+    excluding the parent and sibling databases from the denominator — a
+    tenant at cap could keep promoting data via subgraphs. Row-count
+    checks stay on the subgraph's own staging.
+    """
+    mock_db = MagicMock()
+    mock_graph = MagicMock()
+    mock_graph.parent_graph_id = "kg123"
+
+    storage_ok = {
+      "allowed": True,
+      "retryable": False,
+      "errors": [],
+      "total_storage_gb": 1.0,
+      "limit_gb": 20.0,
+      "usage_percentage": 5.0,
+      "status": "healthy",
+      "databases": [],
+      "items": [],
+    }
+
+    with (
+      patch.object(
+        IngestionLimitChecker,
+        "_get_pending_row_counts",
+        return_value={"Entity": 1000},
+      ) as mock_rows,
+      patch(
+        "robosystems.models.core.Graph.get_by_id",
+        return_value=mock_graph,
+      ),
+      patch.object(
+        IngestionLimitChecker,
+        "check_instance_storage",
+        new_callable=AsyncMock,
+        return_value=storage_ok,
+      ) as mock_storage,
+    ):
+      result = await IngestionLimitChecker.check_materialization_limits(
+        db=mock_db,
+        graph_id="kg123_dev",
+        tier="ladybug-standard",
+      )
+
+    assert result["allowed"] is True
+    mock_storage.assert_awaited_once_with(mock_db, "kg123", "ladybug-standard")
+    mock_rows.assert_called_once_with(mock_db, "kg123_dev")
+
+  @pytest.mark.asyncio
+  async def test_parent_graph_storage_check_keeps_own_scope(self):
+    """A parent (or unregistered) graph id passes through unchanged."""
+    mock_db = MagicMock()
+    mock_graph = MagicMock()
+    mock_graph.parent_graph_id = None
+
+    storage_ok = {
+      "allowed": True,
+      "retryable": False,
+      "errors": [],
+      "total_storage_gb": 1.0,
+      "limit_gb": 20.0,
+      "usage_percentage": 5.0,
+      "status": "healthy",
+      "databases": [],
+      "items": [],
+    }
+
+    with (
+      patch.object(
+        IngestionLimitChecker,
+        "_get_pending_row_counts",
+        return_value={},
+      ),
+      patch(
+        "robosystems.models.core.Graph.get_by_id",
+        return_value=mock_graph,
+      ),
+      patch.object(
+        IngestionLimitChecker,
+        "check_instance_storage",
+        new_callable=AsyncMock,
+        return_value=storage_ok,
+      ) as mock_storage,
+    ):
+      await IngestionLimitChecker.check_materialization_limits(
+        db=mock_db,
+        graph_id="kg123",
+        tier="ladybug-standard",
+      )
+
+    mock_storage.assert_awaited_once_with(mock_db, "kg123", "ladybug-standard")
+
 
 class TestCheckInstanceStorage:
   """Test instance storage usage checking."""

--- a/tests/operations/graph/commands/test_ingest_file_gate.py
+++ b/tests/operations/graph/commands/test_ingest_file_gate.py
@@ -1,0 +1,168 @@
+"""Tests for the ingest-file storage gate.
+
+The gate must measure the instance's physical footprint (not the logical
+staging sum), refuse when the graph cannot be resolved, and surface an
+unmeasurable instance as retryable rather than allowed.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from robosystems.middleware.graph.ingestion_limits import IngestionLimitChecker
+from robosystems.operations.graph.commands.ingest_file import ingest_file_cmd
+
+GB = 1024**3
+MB = 1024**2
+
+
+def _storage_check(
+  *,
+  allowed: bool = True,
+  retryable: bool = False,
+  total_storage_gb: float | None = 1.0,
+  limit_gb: float = 20.0,
+) -> dict:
+  return {
+    "allowed": allowed,
+    "retryable": retryable,
+    "errors": [] if allowed else ["Instance storage exceeds limit"],
+    "total_storage_gb": total_storage_gb,
+    "limit_gb": limit_gb,
+    "usage_percentage": None,
+    "status": "healthy" if allowed else "over_limit",
+    "databases": [],
+    "items": [],
+  }
+
+
+def _gate_mocks(file_size_bytes: int, graph, storage_check: dict | None):
+  """Patch everything between the route and the storage gate."""
+  graph_file = MagicMock()
+  graph_file.graph_id = "kg123"
+  graph_file.s3_key = "uploads/kg123/file.csv"
+
+  s3 = MagicMock()
+  s3.s3_client.head_object.return_value = {"ContentLength": file_size_bytes}
+
+  return (
+    patch(
+      "robosystems.models.core.GraphFile.get_by_id",
+      return_value=graph_file,
+    ),
+    patch(
+      "robosystems.operations.graph.commands.ingest_file.S3Client",
+      return_value=s3,
+    ),
+    patch(
+      "robosystems.models.core.Graph.get_by_id",
+      return_value=graph,
+    ),
+    patch.object(
+      IngestionLimitChecker,
+      "check_instance_storage",
+      new_callable=AsyncMock,
+      return_value=storage_check,
+    ),
+  )
+
+
+async def _run() -> dict:
+  return await ingest_file_cmd(
+    graph_id="kg123",
+    file_id="file_1",
+    ingest_to_graph=False,
+    current_user=MagicMock(),
+    db=MagicMock(),
+    background_tasks=MagicMock(),
+  )
+
+
+@pytest.mark.asyncio
+async def test_unresolved_graph_refuses_instead_of_skipping():
+  """A Graph lookup miss must refuse, not silently bypass the cap."""
+  files, s3, graph, storage = _gate_mocks(10 * MB, graph=None, storage_check=None)
+  with files, s3, graph, storage as mock_storage:
+    with pytest.raises(HTTPException) as exc:
+      await _run()
+
+  assert exc.value.status_code == 404
+  mock_storage.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_unmeasurable_instance_is_retryable_not_allowed():
+  """Graph API unavailable -> 503 with Retry-After, never a pass."""
+  mock_graph = MagicMock()
+  mock_graph.parent_graph_id = None
+  mock_graph.graph_tier = "ladybug-standard"
+
+  files, s3, graph, storage = _gate_mocks(
+    10 * MB,
+    graph=mock_graph,
+    storage_check=_storage_check(allowed=False, retryable=True, total_storage_gb=None),
+  )
+  with files, s3, graph, storage:
+    with pytest.raises(HTTPException) as exc:
+      await _run()
+
+  assert exc.value.status_code == 503
+  assert exc.value.headers["Retry-After"] == "30"
+
+
+@pytest.mark.asyncio
+async def test_over_cap_instance_blocks_upload():
+  mock_graph = MagicMock()
+  mock_graph.parent_graph_id = None
+  mock_graph.graph_tier = "ladybug-standard"
+
+  files, s3, graph, storage = _gate_mocks(
+    10 * MB,
+    graph=mock_graph,
+    storage_check=_storage_check(allowed=False, total_storage_gb=21.0),
+  )
+  with files, s3, graph, storage:
+    with pytest.raises(HTTPException) as exc:
+      await _run()
+
+  assert exc.value.status_code == 413
+
+
+@pytest.mark.asyncio
+async def test_upload_without_headroom_blocks():
+  """Under cap now, but the incoming file would cross it."""
+  mock_graph = MagicMock()
+  mock_graph.parent_graph_id = None
+  mock_graph.graph_tier = "ladybug-standard"
+
+  files, s3, graph, storage = _gate_mocks(
+    50 * MB,
+    graph=mock_graph,
+    storage_check=_storage_check(total_storage_gb=19.99, limit_gb=20.0),
+  )
+  with files, s3, graph, storage:
+    with pytest.raises(HTTPException) as exc:
+      await _run()
+
+  assert exc.value.status_code == 413
+
+
+@pytest.mark.asyncio
+async def test_subgraph_upload_measures_parent_scope():
+  """A subgraph's upload counts against its parent's whole instance."""
+  mock_graph = MagicMock()
+  mock_graph.parent_graph_id = "kg_parent"
+  mock_graph.graph_tier = "ladybug-standard"
+
+  files, s3, graph, storage = _gate_mocks(
+    10 * MB,
+    graph=mock_graph,
+    storage_check=_storage_check(allowed=False, total_storage_gb=21.0),
+  )
+  with files, s3, graph, storage as mock_storage:
+    with pytest.raises(HTTPException) as exc:
+      await _run()
+
+  assert exc.value.status_code == 413
+  assert mock_storage.await_args.args[1] == "kg_parent"


### PR DESCRIPTION
## Summary

Hardens the storage-cap checks on the ingestion and materialization paths so both conform to the subsystem's established measure-or-refuse doctrine: measure the instance's actual footprint, and refuse rather than skip when it cannot be verified.

## Changes

- **`middleware/graph/ingestion_limits.py`** — materialization limit checks resolve the instance scope before measuring storage (matching the `/limits` reporting path); per-operation row checks keep their existing scope.
- **`operations/graph/commands/ingest_file.py`** — the upload gate now reads the same measured instance footprint the rest of the subsystem uses instead of a narrower logical sum, resolves scope the same way, returns a retryable 503 when usage cannot be verified, and refuses unresolved graphs.
- **Tests** — parent-scope resolution pinned in the ingestion-limits suite; a new gate suite covers the refuse/retryable/over-cap/headroom paths.

## Testing

- Full unit suite: 12,119 passed, 24 skipped.
- `ruff check`, `ruff format`, `basedpyright` — clean.

## Notes

- Internal design record: `archive/storage-enforcement-gaps.md` (private vault); live remainder tracked in `specs/commerce/graph-capacity.md`.
