### PR TITLE
chore(docs): promote the remote MCP endpoint as the preferred connection method

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ RoboSystems provides comprehensive client libraries for building applications:
 
 ### MCP (Model Context Protocol)
 
-Every graph is an MCP server. Connect Claude, Claude Code, Cursor, or any MCP client to the graph's URL — no install required. The URL picks the graph (`sec` for the public SEC repository, your graph id for your own); your API key goes in the `X-API-Key` header.
+Every graph is an MCP server, and the graph's URL is the preferred way to connect — Claude, Claude Code, Cursor, or any MCP client, no install required. The URL picks the graph (`sec` for the public SEC repository, your graph id for your own); your API key goes in the `X-API-Key` header.
 
 **Claude (claude.ai / Desktop)** — Settings → Connectors → Add custom connector:
 
@@ -266,7 +266,7 @@ claude mcp add --transport http robosystems-sec \
 }
 ```
 
-- **Documentation**: [Wiki guide](https://github.com/RoboFinSystems/robosystems/wiki/AI-Operators-and-MCP) | [stdio bridge](https://github.com/RoboFinSystems/robosystems-mcp-client) for clients without HTTP transport support
+- **Documentation**: [Wiki guide](https://github.com/RoboFinSystems/robosystems/wiki/AI-Operators-and-MCP) | legacy [stdio bridge](https://github.com/RoboFinSystems/robosystems-mcp-client) for clients without HTTP transport support
 
 ### TypeScript/JavaScript Client
 

--- a/static/description.md
+++ b/static/description.md
@@ -105,7 +105,7 @@ Built on the blocks:
 
 ## Connect via MCP
 
-Every graph is an MCP server — connect Claude, Claude Code, Cursor, or any MCP client directly, no install required. The URL picks the graph (`sec` for the public SEC repository, your graph id for your own); your API key goes in the `X-API-Key` header:
+Every graph is an MCP server, and the graph's URL is the preferred way to connect — Claude, Claude Code, Cursor, or any MCP client, no install required. The URL picks the graph (`sec` for the public SEC repository, your graph id for your own); your API key goes in the `X-API-Key` header:
 
 ```
 https://api.robosystems.ai/v1/graphs/{graph_id}/mcp
@@ -119,7 +119,7 @@ claude mcp add --transport http robosystems-sec \
   --header "X-API-Key: <your key>"
 ```
 
-Clients without HTTP transport support can use the [stdio bridge](https://www.npmjs.com/package/@robosystems/mcp).
+Clients without HTTP transport support can use the legacy [stdio bridge](https://www.npmjs.com/package/@robosystems/mcp).
 
 ## Clients
 


### PR DESCRIPTION
## Summary

With the remote MCP transport live in production (v1.7.0, verified 2026-08-05), the docs now present the graph URL as the preferred connection method and mark the stdio bridge as legacy.

## Changes

- **README**: the MCP section lead now states the graph's URL is the preferred way to connect; the stdio bridge link is marked legacy
- **static/description.md** (Swagger landing): same lead upgrade and legacy marker

## Breaking Changes

None

## Testing

Docs-only change; pre-commit format/lint checks passed.
