### PR TITLE
chore(backups): make the download format self-describing

### DIFF
--- a/robosystems/config/storage/graph.py
+++ b/robosystems/config/storage/graph.py
@@ -483,6 +483,54 @@ def get_r2_download_key(graph_id: str, extension: str = ".lbug") -> str:
 
 
 # =============================================================================
+# Download Helpers
+# =============================================================================
+
+# Extensions a stored backup object can carry, ordered longest-first so a
+# compound extension wins over its own suffix (".lbug.zip" over ".zip").
+BACKUP_DOWNLOAD_EXTENSIONS = (
+  ".parquet.zip",
+  ".json.zip",
+  ".lbug.zst",
+  ".lbug.zip",
+  ".csv.zip",
+  ".lbug.gz",
+  ".duckdb",
+  ".tar.gz",
+  ".lbug",
+  ".zip",
+)
+
+
+def get_download_extension(s3_key: str, default: str = ".zip") -> str:
+  """Return the extension a stored backup should be served as.
+
+  The stored object key is the only reliable record of what a backup actually
+  contains, so the served filename is derived from it rather than assumed.
+  Keeping the compound extension makes the download self-describing — the
+  recipient sees both the payload and its compression without opening the file.
+
+  Args:
+      s3_key: Stored object key, from S3 or R2
+      default: Extension used when the key matches nothing known
+
+  Returns:
+      Extension string including the leading dot
+
+  Example:
+      >>> get_download_extension("graph-backups/databases/kg456/full/backup-20240115_123045.lbug.zip")
+      '.lbug.zip'
+      >>> get_download_extension("downloads/sec/sec.lbug.zst")
+      '.lbug.zst'
+  """
+  key = s3_key.lower()
+  for extension in BACKUP_DOWNLOAD_EXTENSIONS:
+    if key.endswith(extension):
+      return extension
+  return default
+
+
+# =============================================================================
 # URI Builders
 # =============================================================================
 

--- a/robosystems/graph_api/client/client.py
+++ b/robosystems/graph_api/client/client.py
@@ -1479,8 +1479,8 @@ class GraphClient(BaseGraphClient):
         backup_format: Backup format (only 'full_dump' supported)
         compression: Enable compression
         encryption: Enable encryption
-        backup_type: "standard", "replica", or "shared_repository"
-        s3_destination: Target S3 location (required for replica/shared_repository)
+        backup_type: "standard", "replica", "duckdb_staging", or "r2_download"
+        s3_destination: Target S3 location (required for all non-standard types)
         checkpoint: Run CHECKPOINT before backup
         vacuum: Run VACUUM to compact database before backup (DuckDB only)
 
@@ -1527,8 +1527,8 @@ class GraphClient(BaseGraphClient):
         compression: Enable compression
         encryption: Enable encryption
         timeout: Maximum time to wait for completion (seconds)
-        backup_type: "standard", "replica", or "shared_repository"
-        s3_destination: Target S3 location (required for replica/shared_repository)
+        backup_type: "standard", "replica", "duckdb_staging", or "r2_download"
+        s3_destination: Target S3 location (required for all non-standard types)
         checkpoint: Run CHECKPOINT before backup
         vacuum: Run VACUUM to compact database before backup (DuckDB only)
 

--- a/robosystems/graph_api/core/backup_service.py
+++ b/robosystems/graph_api/core/backup_service.py
@@ -6,17 +6,14 @@ uploading results to S3 via multipart upload with progress tracking.
 All heavy work (CHECKPOINT, compression, upload) happens on-instance,
 avoiding the need to transfer large databases over HTTP.
 
-Supports five backup types:
+Supports four backup types:
 - replica: Raw .lbug upload to S3 (downloaded by replica fleet at startup)
-- shared_repository: Compressed tar.gz to S3 (legacy, prefer r2_download)
 - duckdb_staging: Raw .duckdb upload to S3 (for local dev / analytics)
 - r2_download: zstd-compressed .lbug.zst upload to Cloudflare R2 (zero-egress subscriber downloads)
 - standard: ZIP + optional encrypt to S3 (existing user backup flow)
 """
 
-import hashlib
 import subprocess
-import tarfile
 import tempfile
 from datetime import UTC, datetime
 from pathlib import Path
@@ -70,9 +67,9 @@ class OnInstanceBackupService:
     Args:
         task_id: Background task ID for progress tracking
         graph_id: Database identifier
-        backup_type: "replica", "shared_repository", or "standard"
+        backup_type: "replica", "duckdb_staging", or "r2_download"
         s3_destination: Dict with "bucket" and "key"
-        compression: Enable compression (for shared_repository/standard)
+        compression: Enable compression (for r2_download/standard)
         encryption: Enable encryption (for standard only)
         checkpoint: Run CHECKPOINT before backup
 
@@ -147,10 +144,6 @@ class OnInstanceBackupService:
           task_id,
           db_size,
           s3_client=self._get_r2_client(),
-        )
-      elif backup_type == "shared_repository":
-        result = self._upload_shared_repository(
-          db_path, bucket, key, task_id, graph_id, db_size
         )
       else:
         raise ValueError(f"Unsupported on-instance backup type: {backup_type}")
@@ -330,7 +323,8 @@ class OnInstanceBackupService:
     if s3_client is None:
       s3_client = self._get_r2_client()
 
-    # Use EBS-backed temp dir (same pattern as _upload_shared_repository)
+    # Use EBS-backed temp dir, not /tmp (tmpfs/RAM-backed and too small for
+    # compressing multi-GB database files)
     ebs_temp_dir = Path(env.LBUG_DATABASE_PATH).parent / "backup-tmp"
     ebs_temp_dir.mkdir(parents=True, exist_ok=True)
     self._cleanup_stale_temp_dirs(ebs_temp_dir, max_age_hours=24)
@@ -409,95 +403,6 @@ class OnInstanceBackupService:
       "original_size_bytes": db_size,
       "compressed_size_bytes": uploaded_size,
       "compression_ratio": round(compression_ratio, 3),
-      "compress_time_seconds": round(compress_time, 1),
-      "uploaded_at": datetime.now(UTC).isoformat(),
-    }
-
-  def _upload_shared_repository(
-    self,
-    db_path: Path,
-    bucket: str,
-    key: str,
-    task_id: str,
-    graph_id: str,
-    db_size: int,
-  ) -> dict[str, Any]:
-    """Create tar.gz in temp dir and upload to S3 for subscriber downloads."""
-    logger.info(f"[Task {task_id}] Creating tar.gz backup for shared repository")
-
-    s3_client = self._get_s3_client()
-
-    # Use EBS-backed directory instead of /tmp (which is tmpfs/RAM-backed
-    # and too small for compressing multi-GB database files).
-    # LBUG_DATABASE_PATH is /app/data/lbug-dbs (inside container), mounted
-    # from the EBS volume. Parent (/app/data) has the full EBS capacity.
-    ebs_temp_dir = Path(env.LBUG_DATABASE_PATH).parent / "backup-tmp"
-    ebs_temp_dir.mkdir(parents=True, exist_ok=True)
-
-    # Clean up stale temp dirs from crashed backups (TemporaryDirectory
-    # auto-cleans on normal exit but not on process kill/OOM)
-    self._cleanup_stale_temp_dirs(ebs_temp_dir, max_age_hours=24)
-
-    with tempfile.TemporaryDirectory(dir=ebs_temp_dir) as temp_dir:
-      temp_path = Path(temp_dir)
-      backup_file = temp_path / f"{graph_id}.tar.gz"
-
-      # Stream compress the database
-      logger.info(f"[Task {task_id}] Compressing database...")
-      compress_start = datetime.now(UTC)
-      with tarfile.open(backup_file, "w:gz", compresslevel=6) as tar:
-        tar.add(db_path, arcname=db_path.name)
-      compress_time = (datetime.now(UTC) - compress_start).total_seconds()
-
-      compressed_size = backup_file.stat().st_size
-      compression_ratio = compressed_size / max(db_size, 1)
-
-      logger.info(
-        f"[Task {task_id}] Compression complete: "
-        f"{db_size / (1024**3):.2f}GB -> {compressed_size / (1024**3):.2f}GB "
-        f"({compression_ratio:.1%}) in {compress_time:.1f}s"
-      )
-
-      # Calculate checksum
-      sha256 = hashlib.sha256()
-      with open(backup_file, "rb") as f:
-        for chunk in iter(lambda: f.read(8192), b""):
-          sha256.update(chunk)
-      checksum = sha256.hexdigest()
-
-      # Upload compressed backup to S3
-      logger.info(f"[Task {task_id}] Uploading to s3://{bucket}/{key}")
-      transfer_config = TransferConfig(
-        multipart_chunksize=S3_MULTIPART_CHUNKSIZE,
-        multipart_threshold=S3_MULTIPART_THRESHOLD,
-        max_concurrency=S3_MAX_CONCURRENCY,
-      )
-
-      s3_client.upload_file(
-        str(backup_file),
-        bucket,
-        key,
-        Config=transfer_config,
-        ExtraArgs={
-          "Metadata": {
-            "backup_type": "shared_repository",
-            "checksum": checksum,
-            "created_at": datetime.now(UTC).isoformat(),
-            "original_size": str(db_size),
-          },
-          "StorageClass": "STANDARD",
-        },
-      )
-
-    return {
-      "status": "success",
-      "s3_uri": f"s3://{bucket}/{key}",
-      "s3_bucket": bucket,
-      "s3_key": key,
-      "original_size_bytes": db_size,
-      "compressed_size_bytes": compressed_size,
-      "compression_ratio": round(compression_ratio, 3),
-      "checksum": checksum,
       "compress_time_seconds": round(compress_time, 1),
       "uploaded_at": datetime.now(UTC).isoformat(),
     }

--- a/robosystems/graph_api/models/database.py
+++ b/robosystems/graph_api/models/database.py
@@ -79,12 +79,12 @@ class BackupRequest(BaseModel):
   )
   backup_type: str = Field(
     default="standard",
-    description="Backup type: 'standard' (ZIP to S3), 'replica' (raw .lbug to S3), 'shared_repository' (tar.gz to S3), 'duckdb_staging' (raw .duckdb to S3)",
-    pattern="^(standard|replica|shared_repository|duckdb_staging|r2_download)$",
+    description="Backup type: 'standard' (ZIP to S3), 'replica' (raw .lbug to S3), 'duckdb_staging' (raw .duckdb to S3), 'r2_download' (zstd .lbug.zst to R2)",
+    pattern="^(standard|replica|duckdb_staging|r2_download)$",
   )
   s3_destination: S3Destination | None = Field(
     default=None,
-    description="Target S3 location for on-instance upload (required for replica/shared_repository types)",
+    description="Target S3 location for on-instance upload (required for every non-standard type)",
   )
   checkpoint: bool = Field(
     default=True,

--- a/robosystems/graph_api/routers/databases/backup.py
+++ b/robosystems/graph_api/routers/databases/backup.py
@@ -7,8 +7,8 @@ LadybugDB databases.
 Supports four backup types:
 - standard: Existing BackupManager flow (ZIP, optional encrypt, S3 upload)
 - replica: Raw .lbug upload to S3 via OnInstanceBackupService (for replica fleet download)
-- shared_repository: Compressed tar.gz to S3 via OnInstanceBackupService
 - duckdb_staging: Raw .duckdb upload to S3 via OnInstanceBackupService
+- r2_download: zstd-compressed .lbug.zst to R2 via OnInstanceBackupService
 """
 
 from datetime import UTC, datetime
@@ -47,14 +47,11 @@ async def perform_backup(
   Perform the actual backup in the background.
   Updates task status for monitoring.
 
-  Routes to OnInstanceBackupService for replica/shared_repository/duckdb_staging types,
+  Routes to OnInstanceBackupService for replica/duckdb_staging/r2_download types,
   or to BackupManager for standard backups.
   """
   try:
-    if (
-      backup_type in ("replica", "shared_repository", "duckdb_staging", "r2_download")
-      and s3_destination
-    ):
+    if backup_type in ("replica", "duckdb_staging", "r2_download") and s3_destination:
       # On-instance backup: CHECKPOINT + direct S3 upload
       from robosystems.graph_api.core.backup_service import OnInstanceBackupService
 
@@ -138,10 +135,10 @@ async def create_backup(
   Backup types:
   - **standard**: Full dump ZIP, optionally encrypted, uploaded to S3
   - **replica**: Raw .lbug uploaded to S3 (downloaded by replica fleet at startup)
-  - **shared_repository**: Compressed tar.gz uploaded to S3 (for subscriber downloads)
   - **duckdb_staging**: Raw .duckdb uploaded to S3 (for local dev / analytics)
+  - **r2_download**: zstd-compressed .lbug.zst uploaded to R2 (subscriber downloads)
 
-  For replica/shared_repository/duckdb_staging types, s3_destination is required.
+  For replica/duckdb_staging/r2_download types, s3_destination is required.
   """
   if ladybug_service.read_only:
     raise HTTPException(
@@ -178,8 +175,7 @@ async def create_backup(
 
   # Validate s3_destination for non-standard backup types
   if (
-    request.backup_type
-    in ("replica", "shared_repository", "duckdb_staging", "r2_download")
+    request.backup_type in ("replica", "duckdb_staging", "r2_download")
     and not request.s3_destination
   ):
     raise HTTPException(

--- a/robosystems/models/api/graphs/backups.py
+++ b/robosystems/models/api/graphs/backups.py
@@ -65,6 +65,15 @@ class BackupResponse(BaseModel):
   encryption_enabled: bool
   compression_enabled: bool
   allow_export: bool
+  download_extension: str | None = Field(
+    None,
+    description=(
+      "Extension the download will carry, and therefore how to unpack it: "
+      "'.lbug.zip' is a ZIP holding the LadybugDB database file, '.lbug.zst' "
+      "is zstd-compressed (`zstd -d`). Null when the backup is encrypted and "
+      "so cannot be downloaded."
+    ),
+  )
   created_at: str
   completed_at: str | None
   expires_at: str | None

--- a/robosystems/models/api/graphs/backups.py
+++ b/robosystems/models/api/graphs/backups.py
@@ -138,21 +138,21 @@ class BackupDownloadUrlResponse(BaseModel):
     json_schema_extra={
       "examples": [
         {
-          "download_url": "https://s3.amazonaws.com/robosystems-backups/kg1a2b3c4d5/backup_20240115_100000.lbug.tar.gz?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=...",
+          "download_url": "https://s3.amazonaws.com/robosystems-user-prod/graph-backups/databases/kg1a2b3c4d5/full/backup-20240115_100000.lbug.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=...",
           "expires_in": 3600,
           "expires_at": 1705315200.0,
           "backup_id": "bk1a2b3c4d5",
           "graph_id": "kg1a2b3c4d5",
         },
         {
-          "download_url": "https://s3.amazonaws.com/robosystems-backups/kg9f8e7d6c5/backup_20240114_183000.lbug.tar.gz?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=...",
+          "download_url": "https://s3.amazonaws.com/robosystems-user-prod/graph-backups/databases/kg9f8e7d6c5/full/backup-20240114_183000.lbug.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=...",
           "expires_in": 86400,
           "expires_at": 1705401600.0,
           "backup_id": "bk9f8e7d6c5",
           "graph_id": "kg9f8e7d6c5",
         },
         {
-          "download_url": "https://s3.amazonaws.com/robosystems-backups/sec/backup_20240115_120000.lbug.tar.gz?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=...",
+          "download_url": "https://account.r2.cloudflarestorage.com/robosystems-downloads/downloads/sec/sec.lbug.zst?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=...",
           "expires_in": 300,
           "expires_at": 1705314900.0,
           "backup_id": "bksec123456",

--- a/robosystems/operations/graph/engine/backup_manager.py
+++ b/robosystems/operations/graph/engine/backup_manager.py
@@ -24,6 +24,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Any
 
+from robosystems.config.storage.graph import get_download_extension
 from robosystems.operations.aws.s3 import BackupMetadata, S3BackupAdapter
 
 from ....logger import logger
@@ -197,11 +198,10 @@ class BackupManager:
           and isinstance(backup.backup_metadata, dict)
           and backup.backup_metadata.get("storage") == "r2"
         )
-        if is_r2:
-          fmt = backup.backup_metadata.get("format", "raw")
-          extension = ".lbug.zst" if fmt == "zstd" else ".lbug"
-        else:
-          extension = ".zip"
+        # Derive the served extension from the stored key rather than the
+        # storage backend, so the filename describes what is inside it
+        # (".lbug.zip", not a bare ".zip" that hides the payload).
+        extension = get_download_extension(backup.s3_key)
         filename = f"{graph_id}_{timestamp_str}{extension}"
 
         # Choose S3 or R2 client based on backup storage type

--- a/robosystems/routers/graphs/backups/backup.py
+++ b/robosystems/routers/graphs/backups/backup.py
@@ -18,6 +18,7 @@ from fastapi import (
 )
 from sqlalchemy.orm import Session
 
+from robosystems.config.storage.graph import get_download_extension
 from robosystems.database import get_async_db_session
 from robosystems.logger import logger
 from robosystems.middleware.auth.dependencies import get_current_user_with_graph
@@ -143,6 +144,11 @@ async def list_backups(
           encryption_enabled=backup.encryption_enabled,
           compression_enabled=backup.compression_enabled,
           allow_export=not backup.encryption_enabled,  # Encrypted backups cannot be exported
+          download_extension=(
+            get_download_extension(backup.s3_key)
+            if backup.s3_key and not backup.encryption_enabled
+            else None
+          ),
           created_at=backup.created_at.isoformat()
           if backup.created_at
           else datetime.now(UTC).isoformat(),

--- a/robosystems/routers/graphs/backups/download.py
+++ b/robosystems/routers/graphs/backups/download.py
@@ -43,9 +43,10 @@ router = APIRouter()
   summary="Get temporary download URL for backup",
   description=(
     "Generate a temporary download URL for a backup (unencrypted backups only). "
-    "Backups of your own graphs download as a `.zip` containing the LadybugDB "
-    "database file `{graph_id}.lbug`; shared repository snapshots download as a "
-    "single zstd-compressed `.lbug.zst`. Decompress the latter with "
+    "The filename carries the extension listed as `download_extension` on the "
+    "backup: `.lbug.zip` is a ZIP holding the LadybugDB database file "
+    "`{graph_id}.lbug`; `.lbug.zst` (shared repository snapshots) is a single "
+    "zstd-compressed database file. Decompress the latter with "
     "`zstd -d <file>.lbug.zst` (install zstd first: `brew install zstd`, "
     "`apt-get install zstd`, or `dnf install zstd`) — no `--long` flag is needed."
   ),
@@ -85,8 +86,8 @@ async def get_backup_download_url(
   - File will be compressed
 
   Unpacking the download:
-  - `{graph_id}_{timestamp}.zip` (backups of a graph you own) — a standard ZIP
-    archive holding the LadybugDB database file `{graph_id}.lbug`; `unzip` it.
+  - `{graph_id}_{timestamp}.lbug.zip` (backups of a graph you own) — a standard
+    ZIP archive holding the LadybugDB database file `{graph_id}.lbug`; `unzip` it.
   - `{graph_id}_{timestamp}.lbug.zst` (shared repository snapshots) — a single
     zstd-compressed LadybugDB file. Install zstd (`brew install zstd` on macOS,
     `apt-get install zstd` on Debian/Ubuntu, `dnf install zstd` on

--- a/robosystems/routers/graphs/backups/download.py
+++ b/robosystems/routers/graphs/backups/download.py
@@ -41,7 +41,14 @@ router = APIRouter()
   response_model=BackupDownloadUrlResponse,
   operation_id="getBackupDownloadUrl",
   summary="Get temporary download URL for backup",
-  description="Generate a temporary download URL for a backup (unencrypted, compressed .lbug files only)",
+  description=(
+    "Generate a temporary download URL for a backup (unencrypted backups only). "
+    "Backups of your own graphs download as a `.zip` containing the LadybugDB "
+    "database file `{graph_id}.lbug`; shared repository snapshots download as a "
+    "single zstd-compressed `.lbug.zst`. Decompress the latter with "
+    "`zstd -d <file>.lbug.zst` (install zstd first: `brew install zstd`, "
+    "`apt-get install zstd`, or `dnf install zstd`) — no `--long` flag is needed."
+  ),
   status_code=status.HTTP_200_OK,
   responses={
     200: {"description": "Download URL generated successfully"},
@@ -76,6 +83,16 @@ async def get_backup_download_url(
   - Only unencrypted backups can be downloaded
   - Backup must be in full_dump format (complete .lbug file)
   - File will be compressed
+
+  Unpacking the download:
+  - `{graph_id}_{timestamp}.zip` (backups of a graph you own) — a standard ZIP
+    archive holding the LadybugDB database file `{graph_id}.lbug`; `unzip` it.
+  - `{graph_id}_{timestamp}.lbug.zst` (shared repository snapshots) — a single
+    zstd-compressed LadybugDB file. Install zstd (`brew install zstd` on macOS,
+    `apt-get install zstd` on Debian/Ubuntu, `dnf install zstd` on
+    Amazon Linux/Fedora), then run `zstd -d <file>.lbug.zst`. Compression uses a
+    128MB long window, so plain `zstd -d` suffices — no `--long` flag required.
+    Allow disk for roughly 2x the download size.
 
   Args:
     backup_id: Backup identifier

--- a/static/description.md
+++ b/static/description.md
@@ -28,7 +28,7 @@ The core platform surface for querying and managing graphs. Reads are REST `GET`
 **Graph and infrastructure state:**
 
 - **Subgraphs**: List subgraphs, quota, and storage information
-- **Backups**: List backups, download URLs, and storage statistics
+- **Backups**: List backups, download URLs, and storage statistics (downloads are `.zip` or zstd `.lbug.zst`)
 - **Usage**: Graph content metrics and consumption usage (storage, credits)
 
 **Lifecycle commands** (`/operations/{op_name}`):

--- a/static/description.md
+++ b/static/description.md
@@ -28,7 +28,7 @@ The core platform surface for querying and managing graphs. Reads are REST `GET`
 **Graph and infrastructure state:**
 
 - **Subgraphs**: List subgraphs, quota, and storage information
-- **Backups**: List backups, download URLs, and storage statistics (downloads are `.zip` or zstd `.lbug.zst`)
+- **Backups**: List backups, download URLs, and storage statistics (each backup reports its `download_extension` — `.lbug.zip` or zstd `.lbug.zst`)
 - **Usage**: Graph content metrics and consumption usage (storage, credits)
 
 **Lifecycle commands** (`/operations/{op_name}`):

--- a/tests/config/test_storage_graph.py
+++ b/tests/config/test_storage_graph.py
@@ -10,6 +10,7 @@ from robosystems.config.storage.graph import (
   get_backup_metadata_key,
   get_backup_prefix,
   get_backup_uri,
+  get_download_extension,
   get_instance_backup_key,
   get_instance_backup_prefix,
   get_instance_backup_uri,
@@ -157,6 +158,37 @@ class TestSharedRepoKeys:
   def test_get_shared_repo_backup_prefix_with_graph(self):
     result = get_shared_repo_backup_prefix("sec")
     assert result == "shared-repositories/backups/sec/"
+
+
+class TestDownloadExtension:
+  """Tests for deriving the served extension from a stored object key."""
+
+  def test_full_dump_zip(self):
+    key = "graph-backups/databases/kg1/full/backup-20240115_123045.lbug.zip"
+    assert get_download_extension(key) == ".lbug.zip"
+
+  def test_r2_zstd_snapshot(self):
+    assert get_download_extension("downloads/sec/sec.lbug.zst") == ".lbug.zst"
+
+  def test_raw_lbug(self):
+    assert get_download_extension("downloads/sec/sec.lbug") == ".lbug"
+
+  def test_compound_extension_wins_over_its_own_suffix(self):
+    """ ".lbug.zip" must not be truncated to ".zip" by an earlier match."""
+    for key, expected in (
+      ("a/b/backup.csv.zip", ".csv.zip"),
+      ("a/b/backup.json.zip", ".json.zip"),
+      ("a/b/backup.parquet.zip", ".parquet.zip"),
+      ("a/b/backup.lbug.gz", ".lbug.gz"),
+    ):
+      assert get_download_extension(key) == expected
+
+  def test_uppercase_key_matches(self):
+    assert get_download_extension("A/B/BACKUP.LBUG.ZST") == ".lbug.zst"
+
+  def test_unknown_key_falls_back_to_default(self):
+    assert get_download_extension("a/b/backup.bin") == ".zip"
+    assert get_download_extension("a/b/backup.bin", default=".lbug") == ".lbug"
 
 
 class TestURIBuilders:


### PR DESCRIPTION
## Summary

Backup downloads never said how to unpack them, and the served filename actively hid what was inside. Shared repository snapshots arrive zstd-compressed, and zstd ships with neither macOS nor most Linux distributions — so a subscriber who downloaded one had no documented way forward. This documents the unpacking step, makes the filename self-describing, exposes the format on the API so clients stop inferring it, and removes a dead third format that no documentation covered.

## Changes

**Self-describing download filename** (`operations/graph/engine/backup_manager.py`, `config/storage/graph.py`)

- The served extension was chosen from the *storage backend* — anything on S3 became a bare `.zip`, even though the stored key ends `.lbug.zip`. It is now derived from the stored key, which is the only reliable record of what a backup holds.
- New `get_download_extension()` lives with the other backup key builders in `config/storage/graph.py`. It also covers the formats the old branch flattened: `.csv.zip`, `.json.zip`, `.parquet.zip`, and the `.lbug.gz` that `get_backup_key()` defaults to.
- Worth a look: `BACKUP_DOWNLOAD_EXTENSIONS` is ordered longest-first so a compound extension wins over its own suffix (`.lbug.zip` must not match `.zip` first). `TestDownloadExtension` pins that invariant.

**`download_extension` on the backup list** (`models/api/graphs/backups.py`, `routers/graphs/backups/backup.py`)

- `BackupResponse` gains `download_extension`, so the app and SDKs can tell a user which unpack step applies instead of inferring it from `graph_id`. Null for encrypted backups, which cannot be downloaded at all.

**Removes the `shared_repository` backup type** (`graph_api/core/backup_service.py`, `graph_api/models/database.py`, `graph_api/routers/databases/backup.py`, `graph_api/client/client.py`)

- Nothing has invoked it since the publish pipeline moved to `r2_download`, but it remained an accepted value in the Graph API request-model pattern — a live path that would have produced a fourth download format (tar.gz) described nowhere.
- Drops `_upload_shared_repository` and its now-unused `tarfile`/`hashlib` imports (-105 lines), and corrects the type lists and docstrings that still advertised it.

**Documentation** (`routers/graphs/backups/download.py`, `static/description.md`)

- The download endpoint's description and docstring now name both file shapes, the zstd install per platform, and `zstd -d`. These flow into the OpenAPI spec, Swagger, and both generated SDKs.
- Notes that no `--long` flag is needed on the client side: compression uses a 128 MB window deliberately chosen so plain `zstd -d` works.
- The download-URL response examples advertised a `.lbug.tar.gz` extension the code has never produced; corrected to the real S3 and R2 keys.
- The matching wiki pages (`Graph-Operations`, `Shared-Repositories`) are updated separately — the wiki is its own repo.

## Breaking Changes

None to the public API surface.

`BackupResponse.download_extension` is additive and nullable, so it rides an SDK **minor**, not a major — worth a regen of both clients to surface it.

The removed `shared_repository` value narrows the `backup_type` pattern on the Graph API's internal `BackupRequest` model. That surface is service-internal (Graph API is not exposed to clients, and the value was already unreachable in practice — no caller in this repo passes it), so it carries no SDK impact.

## Testing

- `just test-code` — clean (ruff, format, basedpyright: 0 errors, 0 warnings).
- `uv run pytest tests/graph_api/ tests/operations/graph/engine/ tests/routers/graphs/` — 2328 passed, 6 skipped.
- Added `TestDownloadExtension` to `tests/config/test_storage_graph.py`: the compound-extension ordering invariant, case-insensitive keys, and the unknown-key fallback.
- Full `just test-all` not run; the suites above cover every module touched.
