### PR TITLE
chore(docs): note claude.ai custom connectors are OAuth-only for now

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,14 +240,7 @@ RoboSystems provides comprehensive client libraries for building applications:
 
 ### MCP (Model Context Protocol)
 
-Every graph is an MCP server, and the graph's URL is the preferred way to connect — Claude, Claude Code, Cursor, or any MCP client, no install required. The URL picks the graph (`sec` for the public SEC repository, your graph id for your own); your API key goes in the `X-API-Key` header.
-
-**Claude (claude.ai / Desktop)** — Settings → Connectors → Add custom connector:
-
-```text
-URL:    https://api.robosystems.ai/v1/graphs/sec/mcp
-Header: X-API-Key: <your key>
-```
+Every graph is an MCP server, and the graph's URL is the preferred way to connect — Claude Code, Cursor, or any MCP client that supports HTTP transports, no install required. The URL picks the graph (`sec` for the public SEC repository, your graph id for your own); your API key goes in the `X-API-Key` header.
 
 **Claude Code** — one command:
 
@@ -265,6 +258,8 @@ claude mcp add --transport http robosystems-sec \
   "headers": { "X-API-Key": "<your key>" }
 }
 ```
+
+**Claude (claude.ai / Desktop)** — custom connectors currently authenticate with OAuth only (no API-key header support), so they can't connect yet. Use Claude Code or Cursor; on Claude Desktop the [stdio bridge](https://github.com/RoboFinSystems/robosystems-mcp-client) works today.
 
 - **Documentation**: [Wiki guide](https://github.com/RoboFinSystems/robosystems/wiki/AI-Operators-and-MCP) | legacy [stdio bridge](https://github.com/RoboFinSystems/robosystems-mcp-client) for clients without HTTP transport support
 

--- a/static/description.md
+++ b/static/description.md
@@ -105,7 +105,7 @@ Built on the blocks:
 
 ## Connect via MCP
 
-Every graph is an MCP server, and the graph's URL is the preferred way to connect — Claude, Claude Code, Cursor, or any MCP client, no install required. The URL picks the graph (`sec` for the public SEC repository, your graph id for your own); your API key goes in the `X-API-Key` header:
+Every graph is an MCP server, and the graph's URL is the preferred way to connect — Claude Code, Cursor, or any MCP client that supports HTTP transports, no install required. The URL picks the graph (`sec` for the public SEC repository, your graph id for your own); your API key goes in the `X-API-Key` header:
 
 ```
 https://api.robosystems.ai/v1/graphs/{graph_id}/mcp
@@ -119,7 +119,7 @@ claude mcp add --transport http robosystems-sec \
   --header "X-API-Key: <your key>"
 ```
 
-Clients without HTTP transport support can use the legacy [stdio bridge](https://www.npmjs.com/package/@robosystems/mcp).
+Clients without HTTP transport support — including Claude Desktop, whose custom connectors are OAuth-only today and cannot send an API-key header — can use the legacy [stdio bridge](https://www.npmjs.com/package/@robosystems/mcp).
 
 ## Clients
 


### PR DESCRIPTION
## Summary

Post-deploy verification found that claude.ai / Claude Desktop custom connectors currently authenticate with OAuth only — the Add custom connector dialog has no custom-header field, so they cannot send an `X-API-Key`. The docs now say so instead of implying the connector works.

## Changes

- **README**: the Claude connector block is replaced with a one-line note (OAuth-only for now; use Claude Code or Cursor; the stdio bridge covers Claude Desktop); Claude Code leads the section
- **static/description.md**: lead sentence lists HTTP-capable clients only; the bridge line notes the Claude Desktop situation

## Breaking Changes

None

## Testing

Docs-only change; pre-commit format/lint checks passed.
