### PR TITLE
docs(mcp): restore the Claude connector path via generated connector URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ RoboSystems provides comprehensive client libraries for building applications:
 
 ### MCP (Model Context Protocol)
 
-Every graph is an MCP server, and the graph's URL is the preferred way to connect — Claude Code, Cursor, or any MCP client that supports HTTP transports, no install required. The URL picks the graph (`sec` for the public SEC repository, your graph id for your own); your API key goes in the `X-API-Key` header.
+Every graph is an MCP server, and the graph's URL is the preferred way to connect — Claude, Claude Code, Cursor, or any MCP client that supports HTTP transports, no install required. The URL picks the graph (`sec` for the public SEC repository, your graph id for your own); your API key goes in the `X-API-Key` header, or rides inside a generated connector URL for clients that cannot send headers.
 
 **Claude Code** — one command:
 
@@ -259,9 +259,9 @@ claude mcp add --transport http robosystems-sec \
 }
 ```
 
-**Claude (claude.ai / Desktop)** — custom connectors currently authenticate with OAuth only (no API-key header support), so they can't connect yet. Use Claude Code or Cursor; on Claude Desktop the [stdio bridge](https://github.com/RoboFinSystems/robosystems-mcp-client) works today.
+**Claude (claude.ai / Desktop)** — generate a connector URL from your Connect page in the app and paste it into Settings → Connectors → Add custom connector. The URL carries its own graph-scoped API key (Claude's connectors can't send custom headers), valid only for that graph and revocable anytime from Settings → API Keys.
 
-- **Documentation**: [Wiki guide](https://github.com/RoboFinSystems/robosystems/wiki/AI-Operators-and-MCP) | legacy [stdio bridge](https://github.com/RoboFinSystems/robosystems-mcp-client) for clients without HTTP transport support
+- **Documentation**: [Wiki guide](https://github.com/RoboFinSystems/robosystems/wiki/AI-Operators-and-MCP) | [stdio bridge](https://github.com/RoboFinSystems/robosystems-mcp-client) (proxy mode) for clients without HTTP transport support
 
 ### TypeScript/JavaScript Client
 

--- a/static/description.md
+++ b/static/description.md
@@ -105,7 +105,7 @@ Built on the blocks:
 
 ## Connect via MCP
 
-Every graph is an MCP server, and the graph's URL is the preferred way to connect — Claude Code, Cursor, or any MCP client that supports HTTP transports, no install required. The URL picks the graph (`sec` for the public SEC repository, your graph id for your own); your API key goes in the `X-API-Key` header:
+Every graph is an MCP server, and the graph's URL is the preferred way to connect — Claude, Claude Code, Cursor, or any MCP client that supports HTTP transports, no install required. The URL picks the graph (`sec` for the public SEC repository, your graph id for your own); your API key goes in the `X-API-Key` header:
 
 ```
 https://api.robosystems.ai/v1/graphs/{graph_id}/mcp
@@ -119,7 +119,7 @@ claude mcp add --transport http robosystems-sec \
   --header "X-API-Key: <your key>"
 ```
 
-Clients without HTTP transport support — including Claude Desktop, whose custom connectors are OAuth-only today and cannot send an API-key header — can use the legacy [stdio bridge](https://www.npmjs.com/package/@robosystems/mcp).
+For claude.ai and Claude Desktop — whose custom connectors cannot send an API-key header — generate a connector URL from the Connect page in the app: the URL carries its own graph-scoped, revocable API key, so it pastes straight into Settings → Connectors → Add custom connector. Clients without HTTP transport support can use the [stdio bridge](https://www.npmjs.com/package/@robosystems/mcp) in proxy mode.
 
 ## Clients
 


### PR DESCRIPTION
## Summary

Reverses the 2026-08-05 Claude demotion now that graph-scoped connector URLs are live (v1.7.1): claude.ai / Claude Desktop custom connectors connect by pasting a connector URL generated from the app's Connect page — the URL carries its own graph-scoped, revocable API key, so no header is needed. README and the Swagger description get the Claude block back; the stdio bridge references now say proxy mode.

**Hold merge until the v1.7.1 prod deploy + connector end-to-end verification pass.**