### PR TITLE
docs(mcp): name the app surface consistently — the MCP page at /connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ claude mcp add --transport http robosystems-sec \
 }
 ```
 
-**Claude (claude.ai / Desktop)** — generate a connector URL from your Connect page in the app and paste it into Settings → Connectors → Add custom connector. The URL carries its own graph-scoped API key (Claude's connectors can't send custom headers), valid only for that graph and revocable anytime from Settings → API Keys.
+**Claude (claude.ai / Desktop)** — generate a connector URL from the **MCP page** in the app (`/connect`) and paste it into Settings → Connectors → Add custom connector. The URL carries its own graph-scoped API key (Claude's connectors can't send custom headers), valid only for that graph and revocable anytime from Settings → API Keys.
 
 - **Documentation**: [Wiki guide](https://github.com/RoboFinSystems/robosystems/wiki/AI-Operators-and-MCP) | [stdio bridge](https://github.com/RoboFinSystems/robosystems-mcp-client) (proxy mode) for clients without HTTP transport support
 

--- a/static/description.md
+++ b/static/description.md
@@ -119,7 +119,7 @@ claude mcp add --transport http robosystems-sec \
   --header "X-API-Key: <your key>"
 ```
 
-For claude.ai and Claude Desktop — whose custom connectors cannot send an API-key header — generate a connector URL from the Connect page in the app: the URL carries its own graph-scoped, revocable API key, so it pastes straight into Settings → Connectors → Add custom connector. Clients without HTTP transport support can use the [stdio bridge](https://www.npmjs.com/package/@robosystems/mcp) in proxy mode.
+For claude.ai and Claude Desktop — whose custom connectors cannot send an API-key header — generate a connector URL from the MCP page in the app (`/connect`): the URL carries its own graph-scoped, revocable API key, so it pastes straight into Settings → Connectors → Add custom connector. Clients without HTTP transport support can use the [stdio bridge](https://www.npmjs.com/package/@robosystems/mcp) in proxy mode.
 
 ## Clients
 


### PR DESCRIPTION
The in-app page was relabeled **MCP** (robosystems-app#285) to avoid the stem collision with roboledger's Connections; README and the Swagger description now call it "the MCP page in the app (`/connect`)" so the name readers see matches the nav item they'll look for.