### PR TITLE
chore(vscode): point the MCP config at the remote endpoint with prompted credentials

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,21 +1,50 @@
 {
-  "mcpServers": {
+  // Credentials never live in this file: ${input:...} values are prompted on
+  // first server start and stored in VS Code's encrypted secret storage.
+  "inputs": [
+    {
+      "type": "promptString",
+      "id": "robosystems-api-key",
+      "description": "RoboSystems API key (X-API-Key; .local/config.json after `just demo-user`)",
+      "password": true
+    },
+    {
+      "type": "promptString",
+      "id": "robosystems-graph-id",
+      "description": "Graph ID (e.g. kg1a2b3c4d5e)"
+    }
+  ],
+  "servers": {
+    // Preferred: VS Code speaks Streamable HTTP natively — point it straight
+    // at the remote MCP endpoint. The graph id lives in the URL path; the key
+    // rides in the X-API-Key header (account-wide or graph-scoped both work).
     "robosystems": {
+      "type": "http",
+      "url": "http://localhost:8000/v1/graphs/${input:robosystems-graph-id}/mcp",
+      "headers": {
+        "X-API-Key": "${input:robosystems-api-key}"
+      }
+    },
+    // Published stdio bridge (@robosystems/mcp >= 0.4.0 defaults to proxy
+    // mode, piping stdio to the same endpoint above). For clients without
+    // native HTTP transport, or to test the published package.
+    "robosystems-bridge": {
       "command": "npx",
       "args": ["-y", "@robosystems/mcp"],
       "env": {
         "ROBOSYSTEMS_API_URL": "http://localhost:8000",
-        "ROBOSYSTEMS_API_KEY": "rfs*",
-        "ROBOSYSTEMS_GRAPH_ID": "kg*"
+        "ROBOSYSTEMS_API_KEY": "${input:robosystems-api-key}",
+        "ROBOSYSTEMS_GRAPH_ID": "${input:robosystems-graph-id}"
       }
     },
-    "robosystems-local": {
+    // Local checkout of the bridge, for developing the bridge itself.
+    "robosystems-bridge-dev": {
       "command": "node",
       "args": ["../../robosystems-mcp-client/index.js"],
       "env": {
         "ROBOSYSTEMS_API_URL": "http://localhost:8000",
-        "ROBOSYSTEMS_API_KEY": "rfs*",
-        "ROBOSYSTEMS_GRAPH_ID": "kg*"
+        "ROBOSYSTEMS_API_KEY": "${input:robosystems-api-key}",
+        "ROBOSYSTEMS_GRAPH_ID": "${input:robosystems-graph-id}"
       }
     },
     "Context7": {


### PR DESCRIPTION
Rework `.vscode/mcp.json` around the new connection process:

- **`robosystems`** (preferred): native `"type": "http"` entry pointed at `/v1/graphs/{graph_id}/mcp` — VS Code speaks Streamable HTTP directly, key in the `X-API-Key` header.
- **`robosystems-bridge`**: the published `@robosystems/mcp` package, whose unchanged env vars now drive proxy mode by default (>= 0.4.0). For clients without native HTTP transport or to test the published package.
- **`robosystems-bridge-dev`**: local checkout of the bridge, for developing the bridge itself (was `robosystems-local`).
- Fixes the top-level key to `servers` — the schema VS Code actually reads (`mcpServers` is the Claude Desktop convention).

Credentials no longer live in the file: the API key and graph id are `${input:...}` prompts (key masked via `"password": true`) stored in VS Code's encrypted secret storage, so this tracked file never carries a real value and never needs editing to work. The other server entries (Context7, postgres, puppeteer, aws-documentation) are untouched.