### PR TITLE
fix(mcp): harden the remote transport

### DIFF
--- a/robosystems/middleware/auth/dependencies.py
+++ b/robosystems/middleware/auth/dependencies.py
@@ -168,15 +168,29 @@ def _get_user_for_verified_jwt(user_id: str, token_session_version: int) -> User
 API_KEY_HEADER = APIKeyHeader(name="X-API-Key", auto_error=False)
 
 
-def _stash_api_key_identity(request: Request, api_key: str) -> None:
+def _stash_api_key_identity(
+  request: Request,
+  api_key: str,
+  user: "User | None" = None,
+  auth_method: str = "api_key",
+) -> None:
   """Record which API key authenticated this request on request.state.
 
   The first 8 characters are the key's stored identification prefix
   (``UserAPIKey.prefix``), so downstream telemetry can attribute activity
   to a specific key without access to the raw header. JWT-authenticated
   requests leave the attribute unset.
+
+  When the resolved ``user`` is passed, the sanitized principal is also
+  published as ``request.state.auth_user_id`` / ``auth_method``, so
+  downstream consumers that cannot reparse the credential — the rate
+  limiter for URL-token connectors, and eventually opaque OAuth bearer
+  tokens — can identify the caller without re-validating anything.
   """
   request.state.api_key_prefix = api_key[:8]
+  if user is not None:
+    request.state.auth_user_id = str(user.id)
+    request.state.auth_method = auth_method
 
 
 def verify_jwt_claims(
@@ -226,7 +240,7 @@ async def get_optional_user(
   if api_key:
     user = validate_api_key(api_key)
     if user:
-      _stash_api_key_identity(request, api_key)
+      _stash_api_key_identity(request, api_key, user)
     return user
 
   return None
@@ -293,7 +307,7 @@ async def get_current_user(
   if api_key:
     user = validate_api_key(api_key)
     if user:
-      _stash_api_key_identity(request, api_key)
+      _stash_api_key_identity(request, api_key, user)
       SecurityAuditLogger.log_auth_success(
         user_id=str(user.id),
         ip_address=client_ip,
@@ -434,7 +448,7 @@ async def get_current_user_with_graph(
   if api_key:
     user = validate_api_key_with_graph(api_key, graph_id)
     if user:
-      _stash_api_key_identity(request, api_key)
+      _stash_api_key_identity(request, api_key, user)
       SecurityAuditLogger.log_auth_success(
         user_id=str(user.id),
         ip_address=client_ip,
@@ -514,7 +528,7 @@ async def get_current_user_with_graph_or_url_token(
 
   user = validate_api_key_with_graph(token, graph_id, require_scoped=True)
   if user:
-    _stash_api_key_identity(request, token)
+    _stash_api_key_identity(request, token, user, auth_method="api_key_url")
     SecurityAuditLogger.log_auth_success(
       user_id=str(user.id),
       ip_address=client_ip,
@@ -713,7 +727,7 @@ async def get_current_user_sse(
   if api_key:
     user = validate_api_key(api_key)
     if user:
-      _stash_api_key_identity(request, api_key)
+      _stash_api_key_identity(request, api_key, user)
       SecurityAuditLogger.log_auth_success(
         user_id=str(user.id),
         ip_address=client_ip,

--- a/robosystems/middleware/rate_limits/rate_limiting.py
+++ b/robosystems/middleware/rate_limits/rate_limiting.py
@@ -83,6 +83,14 @@ def get_user_identifier(request: Request) -> str:
     if user_id:
       return f"jwt:{user_id}"
 
+  # Principal published by the auth dependencies (request.state.auth_user_id).
+  # Covers credentials this function cannot reparse — the MCP connector's
+  # URL-carried key today, opaque OAuth bearer tokens later. Only set after
+  # successful validation, so it never grants identity to junk credentials.
+  auth_user_id = getattr(request.state, "auth_user_id", None)
+  if isinstance(auth_user_id, str) and auth_user_id:
+    return f"apikey:user:{auth_user_id}"
+
   # Fallback to IP address for unauthenticated requests
   client_ip = request.client.host if request.client else "unknown"
   return f"ip:{client_ip}"
@@ -282,6 +290,14 @@ def get_user_from_request(request: Request) -> str | None:
 
     api_key_hash = hashlib.sha256(api_key.encode()).hexdigest()
     return f"apikey_{api_key_hash}"
+
+  # Principal published by the auth dependencies for credentials that carry
+  # no reparseable header — the MCP connector's URL-carried key today, opaque
+  # OAuth bearer tokens later. Without this, connector traffic is bucketed as
+  # anonymous-by-IP, and every client behind one egress IP shares that budget.
+  auth_user_id = getattr(request.state, "auth_user_id", None)
+  if isinstance(auth_user_id, str) and auth_user_id:
+    return auth_user_id
 
   return None
 

--- a/robosystems/routers/graphs/mcp/execute.py
+++ b/robosystems/routers/graphs/mcp/execute.py
@@ -58,7 +58,7 @@ from robosystems.models.api.graphs.mcp import MCPToolCall, MCPToolResult
 from robosystems.models.core import User
 
 # Import MCP components
-from .handlers import MCPHandler, validate_mcp_access
+from .handlers import MCPHandler, is_tool_error_result, validate_mcp_access
 from .strategies import (
   MCPClientDetector,
   MCPExecutionStrategy,
@@ -403,7 +403,10 @@ async def execute_tool_to_json(
     if cached is not None:
       return cached
     result = await execute_tool_directly(handler, tool_call, timeout)
-    await _set_mcp_cache(graph_id, tool_call.name, result, _MCP_SCHEMA_CACHE_TTL)
+    # Never cache an execution failure — a transient backend error would be
+    # served as the schema for the full cache TTL.
+    if not is_tool_error_result(result):
+      await _set_mcp_cache(graph_id, tool_call.name, result, _MCP_SCHEMA_CACHE_TTL)
     return result
 
   if strategy == MCPExecutionStrategy.INFO_CACHED:
@@ -411,7 +414,8 @@ async def execute_tool_to_json(
     if cached is not None:
       return cached
     result = await execute_tool_directly(handler, tool_call, timeout)
-    await _set_mcp_cache(graph_id, tool_call.name, result, _MCP_INFO_CACHE_TTL)
+    if not is_tool_error_result(result):
+      await _set_mcp_cache(graph_id, tool_call.name, result, _MCP_INFO_CACHE_TTL)
     return result
 
   if strategy in (
@@ -848,7 +852,8 @@ async def call_mcp_tool(
           return MCPToolResult(result=cached)
         result = await execute_tool_directly(handler, tool_call, timeout)
         await handler.close()
-        await _set_mcp_cache(graph_id, tool_call.name, result, _MCP_SCHEMA_CACHE_TTL)
+        if not is_tool_error_result(result):
+          await _set_mcp_cache(graph_id, tool_call.name, result, _MCP_SCHEMA_CACHE_TTL)
         return MCPToolResult(result=result)
 
       elif strategy == MCPExecutionStrategy.INFO_CACHED:
@@ -858,7 +863,8 @@ async def call_mcp_tool(
           return MCPToolResult(result=cached)
         result = await execute_tool_directly(handler, tool_call, timeout)
         await handler.close()
-        await _set_mcp_cache(graph_id, tool_call.name, result, _MCP_INFO_CACHE_TTL)
+        if not is_tool_error_result(result):
+          await _set_mcp_cache(graph_id, tool_call.name, result, _MCP_INFO_CACHE_TTL)
         return MCPToolResult(result=result)
 
       else:

--- a/robosystems/routers/graphs/mcp/handlers.py
+++ b/robosystems/routers/graphs/mcp/handlers.py
@@ -35,6 +35,34 @@ MCP_AVAILABLE = False
 timeout_coordinator = TimeoutCoordinator()
 
 
+def tool_error_result(text: str, kind: str) -> dict[str, Any]:
+  """A tool-execution failure in the handler's text-result shape, marked so
+  transports can surface it as an MCP ``isError`` result and the circuit
+  breaker can count it — instead of both reading it as a success.
+
+  ``kind`` is one of:
+    - ``timeout``: the tool or backend query ran out of time (breaker-relevant)
+    - ``backend``: the graph API failed or an unexpected error occurred
+      (breaker-relevant)
+    - ``constraint``: the caller's query violated a policy/complexity limit —
+      a caller error, not a backend-health signal
+  """
+  return {"type": "text", "text": text, "is_error": True, "error_kind": kind}
+
+
+def is_tool_error_result(result: Any) -> bool:
+  """True when a handler result is a marked tool-execution failure."""
+  return isinstance(result, dict) and result.get("is_error") is True
+
+
+def tool_error_kind(result: Any) -> str | None:
+  """The failure kind of a marked tool-execution failure, else None."""
+  if not is_tool_error_result(result):
+    return None
+  kind = result.get("error_kind")
+  return kind if isinstance(kind, str) else "backend"
+
+
 async def validate_mcp_access(
   graph_id: str, current_user: Any, db: Session, operation_type: str = "read"
 ) -> None:
@@ -276,25 +304,30 @@ class MCPHandler:
       if name == "read-graph-cypher":
         error_msg += ". Consider simplifying your query or adding LIMIT clauses."
       logger.error(error_msg)
-      return {"type": "text", "text": f"Error: {error_msg}"}
+      return tool_error_result(f"Error: {error_msg}", "timeout")
 
-    except (GraphQueryTimeoutError, GraphQueryComplexityError) as e:
-      # Handle specific timeout/complexity errors with user-friendly messages
+    except GraphQueryTimeoutError as e:
+      logger.warning(f"Query timeout for {name}: {e}")
+      return tool_error_result(f"Query Error: {e!s}", "timeout")
+
+    except GraphQueryComplexityError as e:
+      # Caller's query exceeded policy limits — an error result, but not a
+      # backend-health signal.
       logger.warning(f"Query constraint violation for {name}: {e}")
-      return {"type": "text", "text": f"Query Error: {e!s}"}
+      return tool_error_result(f"Query Error: {e!s}", "constraint")
 
     except GraphAPIError as e:
       # Handle Graph API errors with their enhanced messages
       # These already include helpful context from the MCP adapter
       logger.error(f"Graph API error in tool '{name}': {e}")
-      return {"type": "text", "text": str(e)}
+      return tool_error_result(str(e), "backend")
 
     except Exception as e:
       logger.error(f"Tool call failed for {name} on {self.backend_type}: {e}")
-      return {
-        "type": "text",
-        "text": "Error: operation failed. Please try again or contact support.",
-      }
+      return tool_error_result(
+        "Error: operation failed. Please try again or contact support.",
+        "backend",
+      )
 
   async def execute_query_streaming(
     self, query: str, parameters: dict[str, Any] | None = None, chunk_size: int = 1000
@@ -388,10 +421,10 @@ class MCPHandler:
       return {"type": "text", "text": json.dumps(info, indent=2)}
     except Exception as e:
       logger.error(f"Error getting graph info: {e}")
-      return {
-        "type": "text",
-        "text": "Error getting graph info: service temporarily unavailable.",
-      }
+      return tool_error_result(
+        "Error getting graph info: service temporarily unavailable.",
+        "backend",
+      )
 
   async def close(self):
     """Close the MCP tools and database connections."""

--- a/robosystems/routers/graphs/mcp/remote.py
+++ b/robosystems/routers/graphs/mcp/remote.py
@@ -78,11 +78,14 @@ from .streaming import aggregate_streamed_results, stream_mcp_tool_execution
 router = APIRouter()
 
 # Protocol revisions this transport can negotiate. The server answers with the
-# client's requested revision when supported, else its own latest. Streamable
-# HTTP was introduced in 2025-03-26, so earlier revisions are not offered —
-# a 2024-11-05 client negotiates down (up) to a revision this transport
-# actually implements.
-MCP_SUPPORTED_PROTOCOL_VERSIONS = frozenset({"2025-03-26", "2025-06-18"})
+# client's requested revision when supported, else its own latest. Exactly the
+# revision this dispatch implements is offered — 2024-11-05 predates Streamable
+# HTTP, and 2025-03-26 permitted JSON-RPC batching, which this transport
+# unconditionally rejects, so advertising either would promise semantics the
+# wire doesn't honor. Clients on other revisions negotiate to 2025-06-18 at
+# initialize (Claude requests 2025-11-25 and accepts this fine); requests
+# carrying no MCP-Protocol-Version header are still served for compatibility.
+MCP_SUPPORTED_PROTOCOL_VERSIONS = frozenset({"2025-06-18"})
 MCP_LATEST_PROTOCOL_VERSION = "2025-06-18"
 
 # JSON-RPC 2.0 error codes
@@ -129,8 +132,12 @@ def _transport_gate(request: Request) -> None:
       detail="Origin not allowed",
     )
 
+  # Exact media-type essence match — a substring check would accept
+  # `text/plain; application/json` (still a browser simple request) and
+  # unrelated `+json` types.
   content_type = request.headers.get("content-type", "")
-  if "application/json" not in content_type.lower():
+  media_type = content_type.split(";", 1)[0].strip().casefold()
+  if media_type != "application/json":
     raise HTTPException(
       status_code=http_status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
       detail="Content-Type must be application/json",
@@ -517,6 +524,7 @@ async def _stream_tool_call(
         circuit_breaker.record_success(graph_id, tool_call.name)
     except TimeoutError:
       outcome = "timeout"
+      circuit_breaker.record_failure(graph_id, tool_call.name)
       record_shared_query_outcome(
         graph_id,
         user_id,
@@ -689,6 +697,11 @@ async def _stream_queued_call(
           await asyncio.sleep(_QUEUE_POLL_SECONDS)
     except TimeoutError:
       outcome = "bridge_timeout"
+      # Deliberate: the bridge ceiling exhausting counts against the breaker.
+      # Whether the 300s went to queue wait or execution, the backend didn't
+      # produce a result in time — and if the queue is saturated, opening the
+      # breaker sheds exactly the load the queue is drowning under.
+      circuit_breaker.record_failure(graph_id, tool_call.name)
       payload = _tool_error_payload(
         msg_id,
         f"Error: queued query did not complete within "

--- a/robosystems/routers/graphs/mcp/remote.py
+++ b/robosystems/routers/graphs/mcp/remote.py
@@ -66,15 +66,23 @@ from .execute import (
   circuit_breaker,
   execute_tool_to_json,
 )
-from .handlers import MCPHandler, validate_mcp_access
+from .handlers import (
+  MCPHandler,
+  is_tool_error_result,
+  tool_error_kind,
+  validate_mcp_access,
+)
 from .strategies import MCPExecutionStrategy, MCPStrategySelector
 from .streaming import aggregate_streamed_results, stream_mcp_tool_execution
 
 router = APIRouter()
 
 # Protocol revisions this transport can negotiate. The server answers with the
-# client's requested revision when supported, else its own latest.
-MCP_SUPPORTED_PROTOCOL_VERSIONS = frozenset({"2024-11-05", "2025-03-26", "2025-06-18"})
+# client's requested revision when supported, else its own latest. Streamable
+# HTTP was introduced in 2025-03-26, so earlier revisions are not offered —
+# a 2024-11-05 client negotiates down (up) to a revision this transport
+# actually implements.
+MCP_SUPPORTED_PROTOCOL_VERSIONS = frozenset({"2025-03-26", "2025-06-18"})
 MCP_LATEST_PROTOCOL_VERSION = "2025-06-18"
 
 # JSON-RPC 2.0 error codes
@@ -99,6 +107,34 @@ _REMOTE_CLIENT_INFO: dict[str, Any] = {
   "is_browser": False,
   "is_interactive": False,
 }
+
+
+def _transport_gate(request: Request) -> None:
+  """HTTP-level Streamable HTTP checks, run before auth and dispatch.
+
+  Origin: the MCP spec requires servers to validate Origin and answer 403 for
+  untrusted values. Server-to-server callers (Claude's backend, the npx
+  bridge) send no Origin header — absent is allowed; a browser context must
+  come from a first-party app origin.
+
+  Content-Type: JSON-RPC bodies must be ``application/json``, which also
+  keeps the endpoint out of the browser "simple request" delivery class.
+  """
+  from robosystems.config import env
+
+  origin = request.headers.get("origin")
+  if origin and origin not in env.get_main_cors_origins():
+    raise HTTPException(
+      status_code=http_status.HTTP_403_FORBIDDEN,
+      detail="Origin not allowed",
+    )
+
+  content_type = request.headers.get("content-type", "")
+  if "application/json" not in content_type.lower():
+    raise HTTPException(
+      status_code=http_status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+      detail="Content-Type must be application/json",
+    )
 
 
 def _rpc_result(msg_id: Any, result: dict[str, Any]) -> JSONResponse:
@@ -137,13 +173,38 @@ def _tool_error_result(msg_id: Any, text: str) -> JSONResponse:
   return JSONResponse(content=_tool_error_payload(msg_id, text))
 
 
+def _tool_failure(result: Any) -> tuple[bool, str | None]:
+  """Classify an internal tool result as (is_error, failure_kind).
+
+  Two failure encodings reach this transport: the handler's marked text
+  result (``is_error``/``error_kind``, see ``handlers.tool_error_result``)
+  and the streaming aggregator's failure shape (``success: False`` +
+  ``error`` — which also covers a stream that ended with no terminal event).
+  ``failure_kind`` is ``timeout``/``backend`` (breaker-relevant) or
+  ``constraint`` (caller error).
+  """
+  if is_tool_error_result(result):
+    return True, tool_error_kind(result)
+  if isinstance(result, dict) and result.get("success") is False and "error" in result:
+    kind = result.get("error_kind")
+    return True, kind if isinstance(kind, str) else "backend"
+  return False, None
+
+
 def _to_tool_result(result: Any) -> dict[str, Any]:
-  """Map an internal tool result onto the MCP ``tools/call`` result shape."""
+  """Map an internal tool result onto the MCP ``tools/call`` result shape.
+
+  Execution failures come back as ``isError: true`` so the model sees a
+  failed call rather than error prose masquerading as valid output.
+  """
+  is_error, _ = _tool_failure(result)
   if isinstance(result, dict) and result.get("type") == "text" and "text" in result:
     content = [{"type": "text", "text": result["text"]}]
+  elif is_error and isinstance(result, dict) and isinstance(result.get("error"), str):
+    content = [{"type": "text", "text": result["error"]}]
   else:
     content = [{"type": "text", "text": json.dumps(result, indent=2, default=str)}]
-  return {"content": content, "isError": False}
+  return {"content": content, "isError": is_error}
 
 
 async def _validate_read_access(graph_id: str, current_user: User) -> None:
@@ -161,16 +222,24 @@ async def _validate_read_access(graph_id: str, current_user: User) -> None:
 # connector has no client process and is URL-anchored to one graph. The
 # remote surface rewrites the tool to resolve the target's connector URL.
 _REMOTE_SWITCH_WORKSPACE_DESCRIPTION = (
-  "Resolve the MCP connector URL for a different subgraph workspace (or "
-  "`primary` for the parent graph). This connector is anchored to one graph "
-  "by its URL and cannot switch in-session — the tool returns the URL to add "
-  "as a separate MCP connector (same API key), where work on that workspace "
-  "continues."
+  "Resolve the MCP connector URL for a different workspace in this graph's "
+  "family (a subgraph, or `primary` for the parent graph). This connector is "
+  "anchored to one graph by its URL and cannot switch in-session — the tool "
+  "returns the endpoint to set up as a separate MCP connector with its own "
+  "credential, where work on that workspace continues."
 )
 
 
 def _remote_switch_workspace(graph_id: str, arguments: dict[str, Any]) -> str:
-  """Answer switch-workspace with the target's connector URL (text result)."""
+  """Answer switch-workspace with the target's connector URL (text result).
+
+  Targets are constrained to this connector's graph family — the parent or
+  one of its subgraphs. The URL alone carries no credential, and a
+  URL-token connector's key may not cover the target (a key scoped to a
+  subgraph does not reach its parent or siblings), so the guidance points at
+  minting a connector credential for the target rather than claiming the
+  current one transfers.
+  """
   from robosystems.config import env
 
   target = str(arguments.get("workspace_id") or "").strip()
@@ -188,6 +257,13 @@ def _remote_switch_workspace(graph_id: str, arguments: dict[str, Any]) -> str:
   if not re.fullmatch(GRAPH_OR_SUBGRAPH_ID_PATTERN, target_id):
     return f"Error: '{target}' is not a valid workspace id or name."
 
+  if target_id != parent and not target_id.startswith(f"{parent}_"):
+    return (
+      f"Error: '{target}' is outside this connector's graph family "
+      f"('{parent}' and its subgraphs). A different graph needs its own "
+      "connector, set up from that graph's MCP page."
+    )
+
   connector_url = f"{env.ROBOSYSTEMS_API_URL}/v1/graphs/{target_id}/mcp"
   return json.dumps(
     {
@@ -198,8 +274,9 @@ def _remote_switch_workspace(graph_id: str, arguments: dict[str, Any]) -> str:
       "message": (
         f"This connector is anchored to graph '{graph_id}' by its URL and "
         f"cannot switch workspaces in-session. To work on '{target_id}', add "
-        f"a new MCP connector pointing at {connector_url} (same API key) and "
-        "continue there."
+        f"a new MCP connector for {connector_url} with a credential for that "
+        "workspace — generate one from the app's MCP page (/connect) with "
+        f"'{target_id}' selected, or reuse an API key whose scope covers it."
       ),
     },
     indent=2,
@@ -405,7 +482,7 @@ async def _stream_tool_call(
             yield {"data": json.dumps(notification)}
 
       result = aggregate_streamed_results(events)
-      outcome = "completed"
+      failed, failure_kind = _tool_failure(result)
       if is_disrupted_aggregation(result):
         outcome = "stream_disrupted"
         record_shared_query_outcome(
@@ -418,8 +495,26 @@ async def _stream_tool_call(
           source="mcp_remote",
           tool_name=tool_call.name,
         )
+      elif failed and failure_kind == "timeout":
+        outcome = "timeout"
+        record_shared_query_outcome(
+          graph_id,
+          user_id,
+          signal="timeout",
+          api_key_prefix=api_key_prefix,
+          endpoint="/v1/graphs/{graph_id}/mcp",
+          source="mcp_remote",
+          tool_name=tool_call.name,
+        )
+      elif failed:
+        outcome = "tool_error"
+      else:
+        outcome = "completed"
       payload = {"jsonrpc": "2.0", "id": msg_id, "result": _to_tool_result(result)}
-      circuit_breaker.record_success(graph_id, tool_call.name)
+      if failed and failure_kind in ("timeout", "backend"):
+        circuit_breaker.record_failure(graph_id, tool_call.name)
+      else:
+        circuit_breaker.record_success(graph_id, tool_call.name)
     except TimeoutError:
       outcome = "timeout"
       record_shared_query_outcome(
@@ -560,20 +655,25 @@ async def _stream_queued_call(
 
           if state == "completed":
             query_settled = True
-            outcome = "completed"
             result = await queue_manager.get_query_result(queue_id)
+            failed, failure_kind = _tool_failure(result)
+            outcome = "tool_error" if failed else "completed"
             payload = {
               "jsonrpc": "2.0",
               "id": msg_id,
               "result": _to_tool_result(result),
             }
-            circuit_breaker.record_success(graph_id, tool_call.name)
+            if failed and failure_kind in ("timeout", "backend"):
+              circuit_breaker.record_failure(graph_id, tool_call.name)
+            else:
+              circuit_breaker.record_success(graph_id, tool_call.name)
             break
           if state in ("failed", "cancelled"):
             query_settled = True
             outcome = f"queue_{state}"
             error = status.get("error") or f"Query {state}"
             if state == "failed":
+              circuit_breaker.record_failure(graph_id, tool_call.name)
               record_shared_query_outcome(
                 graph_id,
                 current_user.id,
@@ -835,8 +935,14 @@ async def _handle_tools_call(
     if not handler._closed:
       await handler.close()
 
-  circuit_breaker.record_success(graph_id, name)
-  outcome = "completed"
+  failed, failure_kind = _tool_failure(result)
+  # Constraint failures mean the backend answered fine — they reset the
+  # breaker like a success; only timeout/backend failures count against it.
+  if failed and failure_kind in ("timeout", "backend"):
+    circuit_breaker.record_failure(graph_id, name)
+  else:
+    circuit_breaker.record_success(graph_id, name)
+
   if is_disrupted_aggregation(result):
     outcome = "stream_disrupted"
     record_shared_query_outcome(
@@ -849,6 +955,21 @@ async def _handle_tools_call(
       source="mcp_remote",
       tool_name=name,
     )
+  elif failed and failure_kind == "timeout":
+    outcome = "timeout"
+    record_shared_query_outcome(
+      graph_id,
+      current_user.id,
+      signal="timeout",
+      api_key_prefix=key_prefix,
+      endpoint="/v1/graphs/{graph_id}/mcp",
+      source="mcp_remote",
+      tool_name=name,
+    )
+  elif failed:
+    outcome = "tool_error"
+  else:
+    outcome = "completed"
   log_shared_query_end(
     exec_id,
     graph_id,
@@ -896,6 +1017,27 @@ async def dispatch_jsonrpc(
 
   method = message.get("method")
   msg_id = message.get("id")
+
+  # Post-negotiation requests must carry a supported MCP-Protocol-Version when
+  # they send the header at all (absent = pre-header clients, allowed for
+  # backwards compatibility). Unsupported values answer 400 per the spec.
+  # initialize is exempt — negotiation happens in its body.
+  version_header = request.headers.get("mcp-protocol-version")
+  if (
+    method != "initialize"
+    and version_header is not None
+    and version_header not in MCP_SUPPORTED_PROTOCOL_VERSIONS
+  ):
+    supported = ", ".join(sorted(MCP_SUPPORTED_PROTOCOL_VERSIONS))
+    if isinstance(method, str) and "id" in message:
+      return _rpc_error(
+        msg_id,
+        INVALID_REQUEST,
+        f"Unsupported MCP-Protocol-Version '{version_header}' (supported: {supported})",
+        http_code=http_status.HTTP_400_BAD_REQUEST,
+      )
+    # Notifications never receive JSON-RPC replies; reject at HTTP level only.
+    return Response(status_code=http_status.HTTP_400_BAD_REQUEST)
 
   # A message without a method is a client->server response; a message without
   # an id is a notification. Streamable HTTP: accept both with 202, no body.
@@ -947,6 +1089,7 @@ async def mcp_remote_transport(
     description="Graph database identifier",
     pattern=GRAPH_OR_SUBGRAPH_ID_PATTERN,
   ),
+  _transport: None = Depends(_transport_gate),
   current_user: User = Depends(get_current_user_with_graph_or_url_token),
   _rate_limit: None = Depends(subscription_aware_rate_limit_dependency),
 ) -> Response:

--- a/robosystems/routers/graphs/mcp/streaming.py
+++ b/robosystems/routers/graphs/mcp/streaming.py
@@ -156,6 +156,22 @@ async def stream_cypher_query(
     async for chunk in handler.execute_query_streaming(
       query, parameters, chunk_size=chunk_size
     ):
+      # A failed backend query arrives as an error chunk (see
+      # StreamingRepositoryWrapper): surface it as an error event, or the
+      # stream completes normally and aggregates to a successful empty result.
+      if isinstance(chunk, dict) and chunk.get("error"):
+        error_type = str(chunk.get("error_type", ""))
+        yield {
+          "event": "error",
+          "data": {
+            "tool": "read-graph-cypher",
+            "error": str(chunk["error"]),
+            "error_type": error_type,
+            "error_kind": "timeout" if "Timeout" in error_type else "backend",
+          },
+        }
+        return
+
       chunk_count += 1
       rows_in_chunk = len(chunk.get("data", []))
       total_rows += rows_in_chunk

--- a/robosystems/routers/graphs/mcp/streaming.py
+++ b/robosystems/routers/graphs/mcp/streaming.py
@@ -12,6 +12,8 @@ from typing import Any
 
 from robosystems.logger import logger
 
+from .handlers import is_tool_error_result, tool_error_kind
+
 
 async def stream_mcp_tool_execution(
   handler: Any,
@@ -76,6 +78,19 @@ async def stream_mcp_tool_execution(
 
       result = await handler.call_tool(tool_name, arguments)
 
+      # The handler encodes execution failures as marked text results; emit
+      # them as error events so aggregation yields a failure, not a success.
+      if is_tool_error_result(result):
+        yield {
+          "event": "error",
+          "data": {
+            "tool": tool_name,
+            "error": result.get("text", "Tool execution failed"),
+            "error_kind": tool_error_kind(result),
+          },
+        }
+        return
+
       yield {
         "event": "result",
         "data": {
@@ -102,6 +117,7 @@ async def stream_mcp_tool_execution(
         "tool": tool_name,
         "error": "Execution timeout",
         "message": f"Tool {tool_name} execution timed out",
+        "error_kind": "timeout",
       },
     }
   except Exception as e:
@@ -112,6 +128,7 @@ async def stream_mcp_tool_execution(
         "tool": tool_name,
         "error": str(e),
         "error_type": type(e).__name__,
+        "error_kind": "backend",
       },
     }
 
@@ -190,6 +207,17 @@ async def stream_cypher_query(
 
     result = await handler.call_tool("read-graph-cypher", arguments)
 
+    if is_tool_error_result(result):
+      yield {
+        "event": "error",
+        "data": {
+          "tool": "read-graph-cypher",
+          "error": result.get("text", "Query execution failed"),
+          "error_kind": tool_error_kind(result),
+        },
+      }
+      return
+
     # Parse result if it's in the expected format
     if isinstance(result, dict) and "text" in result:
       try:
@@ -240,6 +268,17 @@ async def stream_schema_retrieval(
 
   # Get full schema
   schema_result = await handler.call_tool(tool_name, arguments)
+
+  if is_tool_error_result(schema_result):
+    yield {
+      "event": "error",
+      "data": {
+        "tool": tool_name,
+        "error": schema_result.get("text", "Schema retrieval failed"),
+        "error_kind": tool_error_kind(schema_result),
+      },
+    }
+    return
 
   # Parse schema result
   if isinstance(schema_result, dict) and "text" in schema_result:
@@ -322,11 +361,18 @@ def aggregate_streamed_results(events: list[dict[str, Any]]) -> dict[str, Any]:
   # Check for errors
   for event in events:
     if event.get("event") == "error":
-      return {
+      failure: dict[str, Any] = {
         "success": False,
         "error": event["data"].get("error", "Unknown error"),
         "tool": tool_name,
       }
+      # Preserve the handler's failure classification so transports can
+      # separate breaker-relevant failures (timeout/backend) from caller
+      # errors (constraint).
+      kind = event["data"].get("error_kind")
+      if isinstance(kind, str):
+        failure["error_kind"] = kind
+      return failure
 
   # Aggregate based on event types
   if any(e.get("event") == "query_chunk" for e in events):

--- a/tests/middleware/auth/test_dependencies.py
+++ b/tests/middleware/auth/test_dependencies.py
@@ -1378,6 +1378,8 @@ class TestApiKeyIdentityStash:
 
     assert result == mock_user
     assert mock_request.state.api_key_prefix == api_key[:8]
+    assert mock_request.state.auth_user_id == "user_1"
+    assert mock_request.state.auth_method == "api_key"
 
 
 class TestGetCurrentUserWithGraphOrUrlToken:
@@ -1431,6 +1433,10 @@ class TestGetCurrentUserWithGraphOrUrlToken:
     assert result == mock_user
     mock_validate.assert_called_once_with(token, "kg123", require_scoped=True)
     assert request.state.api_key_prefix == token[:8]
+    # The sanitized principal must be published for consumers that cannot
+    # reparse the URL credential — the rate limiter reads these.
+    assert request.state.auth_user_id == "user123"
+    assert request.state.auth_method == "api_key_url"
 
   @pytest.mark.asyncio
   @patch("robosystems.middleware.auth.dependencies.validate_api_key_with_graph")

--- a/tests/middleware/rate_limits/test_rate_limiting.py
+++ b/tests/middleware/rate_limits/test_rate_limiting.py
@@ -504,3 +504,52 @@ class TestNamedRateLimitDependencies:
     mock_cache.check_rate_limit.return_value = (True, 9)
     request = _make_request(headers={"X-API-Key": "key"})
     jwt_refresh_rate_limit_dependency(request)
+
+
+@pytest.mark.unit
+class TestPublishedPrincipalIdentity:
+  """The auth layer publishes request.state.auth_user_id for credentials the
+  limiter cannot reparse (the MCP connector's URL token; opaque OAuth tokens
+  later). Without it those requests bucket as anonymous-by-IP, and every
+  client behind one egress IP shares a 5/min budget."""
+
+  class _State:
+    def __init__(self, auth_user_id=None):
+      if auth_user_id is not None:
+        self.auth_user_id = auth_user_id
+
+  def test_get_user_identifier_uses_published_principal(self):
+    request = _make_request()
+    request.state = self._State("user-42")
+    assert get_user_identifier(request) == "apikey:user:user-42"
+
+  def test_get_user_from_request_uses_published_principal(self):
+    request = _make_request()
+    request.state = self._State("user-42")
+    assert get_user_from_request(request) == "user-42"
+
+  def test_header_credentials_still_take_precedence(self):
+    request = _make_request(headers={"X-API-Key": "rfs" + "a" * 64})
+    request.state = self._State("user-42")
+    assert get_user_identifier(request).startswith("apikey:")
+    assert "user-42" not in get_user_identifier(request)
+
+  def test_absent_principal_falls_back_to_ip(self):
+    request = _make_request(host="10.0.0.9")
+    request.state = self._State()
+    assert get_user_identifier(request) == "ip:10.0.0.9"
+    assert get_user_from_request(request) is None
+
+  def test_non_string_principal_is_ignored(self):
+    request = _make_request(host="10.0.0.9")
+    request.state = self._State(auth_user_id=12345)
+    assert get_user_identifier(request) == "ip:10.0.0.9"
+    assert get_user_from_request(request) is None
+
+  def test_published_principal_gets_api_key_tier_limits(self):
+    request = _make_request()
+    request.state = self._State("user-42")
+    identifier = get_user_identifier(request)
+    limit, window = get_rate_limit_config(identifier)
+    anon_limit, _ = get_rate_limit_config("ip:10.0.0.9")
+    assert limit > anon_limit

--- a/tests/routers/graphs/mcp/test_mcp_handlers.py
+++ b/tests/routers/graphs/mcp/test_mcp_handlers.py
@@ -364,6 +364,9 @@ class TestMCPHandler:
 
           assert "Error" in result["text"]
           assert "timed out" in result["text"]
+          # Marked so transports return MCP isError instead of a success.
+          assert result["is_error"] is True
+          assert result["error_kind"] == "timeout"
 
           await handler.close()
 
@@ -390,6 +393,8 @@ class TestMCPHandler:
         result = await handler.call_tool("get-graph-info", {})
 
         assert "Error" in result["text"]
+        assert result["is_error"] is True
+        assert result["error_kind"] == "backend"
 
         await handler.close()
 

--- a/tests/routers/graphs/mcp/test_mcp_remote.py
+++ b/tests/routers/graphs/mcp/test_mcp_remote.py
@@ -272,8 +272,15 @@ class TestInitialize:
       return await dispatch_jsonrpc(request, "kg123", _make_user())
 
   async def test_supported_version_is_echoed(self):
+    body = _body(await self._initialize("2025-06-18"))
+    assert body["result"]["protocolVersion"] == "2025-06-18"
+
+  async def test_batching_revision_not_negotiable(self):
+    # The transport unconditionally rejects JSON-RPC batches, which 2025-03-26
+    # permitted — so that revision must not be offered. A client requesting it
+    # negotiates to the revision the wire actually implements.
     body = _body(await self._initialize("2025-03-26"))
-    assert body["result"]["protocolVersion"] == "2025-03-26"
+    assert body["result"]["protocolVersion"] == MCP_LATEST_PROTOCOL_VERSION
 
   async def test_unsupported_version_answers_latest(self):
     body = _body(await self._initialize("1999-01-01"))
@@ -461,6 +468,76 @@ class TestStreamToolCall:
     assert len(messages) == 1
     assert "id" in messages[0]
 
+  async def test_hard_timeout_is_error_and_breaker_failure(self):
+    import asyncio
+
+    async def hung_stream(handler, name, arguments, strategy):
+      yield {"event": "start", "data": {"tool": name}}
+      await asyncio.sleep(5)
+
+    handler = _make_handler()
+    breaker = Mock()
+    with (
+      patch.object(remote, "circuit_breaker", breaker),
+      patch.object(remote, "stream_mcp_tool_execution", hung_stream),
+    ):
+      tool_call = Mock()
+      tool_call.name = "read-graph-cypher"
+      tool_call.arguments = {"query": "MATCH (n) RETURN n"}
+      events = [
+        event
+        async for event in remote._stream_tool_call(
+          handler,
+          "kg123",
+          tool_call,
+          remote.MCPExecutionStrategy.STREAM_AGGREGATED,
+          0,  # timeout ceiling expires immediately
+          7,
+          None,
+        )
+      ]
+
+    final = json.loads(events[-1]["data"])
+    assert final["result"]["isError"] is True
+    breaker.record_failure.assert_called_once_with("kg123", "read-graph-cypher")
+    breaker.record_success.assert_not_called()
+
+  async def test_stream_error_event_is_error_and_breaker_failure(self):
+    async def failing_stream(handler, name, arguments, strategy):
+      yield {"event": "start", "data": {"tool": name}}
+      yield {
+        "event": "error",
+        "data": {"tool": name, "error": "backend down", "error_kind": "backend"},
+      }
+
+    handler = _make_handler()
+    breaker = Mock()
+    with (
+      patch.object(remote, "circuit_breaker", breaker),
+      patch.object(remote, "stream_mcp_tool_execution", failing_stream),
+    ):
+      tool_call = Mock()
+      tool_call.name = "read-graph-cypher"
+      tool_call.arguments = {"query": "MATCH (n) RETURN n"}
+      events = [
+        event
+        async for event in remote._stream_tool_call(
+          handler,
+          "kg123",
+          tool_call,
+          remote.MCPExecutionStrategy.STREAM_AGGREGATED,
+          30,
+          8,
+          None,
+        )
+      ]
+
+    final = json.loads(events[-1]["data"])
+    assert final["result"]["isError"] is True
+    assert "backend down" in final["result"]["content"][0]["text"]
+    breaker.record_failure.assert_called_once_with("kg123", "read-graph-cypher")
+    breaker.record_success.assert_not_called()
+
 
 def _make_queue_manager(statuses, result=None):
   manager = Mock()
@@ -630,6 +707,20 @@ class TestTransportGate:
 
   def test_json_with_charset_passes(self):
     _transport_gate(self._request({"content-type": "application/json; charset=utf-8"}))
+
+  def test_json_smuggled_in_parameters_is_415(self):
+    # A substring check would accept this — still a browser simple request.
+    with pytest.raises(HTTPException) as exc:
+      _transport_gate(self._request({"content-type": "text/plain; application/json"}))
+    assert exc.value.status_code == 415
+
+  def test_unrelated_json_suffix_type_is_415(self):
+    with pytest.raises(HTTPException) as exc:
+      _transport_gate(self._request({"content-type": "application/json-patch+json"}))
+    assert exc.value.status_code == 415
+
+  def test_media_type_match_is_case_insensitive(self):
+    _transport_gate(self._request({"content-type": "APPLICATION/JSON"}))
 
 
 @pytest.mark.asyncio

--- a/tests/routers/graphs/mcp/test_mcp_remote.py
+++ b/tests/routers/graphs/mcp/test_mcp_remote.py
@@ -7,6 +7,7 @@ import pytest
 from fastapi import HTTPException
 
 from robosystems.routers.graphs.mcp import remote
+from robosystems.routers.graphs.mcp.handlers import tool_error_result
 from robosystems.routers.graphs.mcp.remote import (
   INVALID_PARAMS,
   INVALID_REQUEST,
@@ -17,6 +18,8 @@ from robosystems.routers.graphs.mcp.remote import (
   _remote_switch_workspace,
   _to_tool_result,
   _tool_error_payload,
+  _tool_failure,
+  _transport_gate,
   dispatch_jsonrpc,
 )
 
@@ -25,13 +28,13 @@ def _body(response):
   return json.loads(response.body)
 
 
-def _make_request(message, accept="application/json, text/event-stream"):
+def _make_request(message, accept="application/json, text/event-stream", headers=None):
   request = Mock()
   if isinstance(message, Exception):
     request.json = AsyncMock(side_effect=message)
   else:
     request.json = AsyncMock(return_value=message)
-  request.headers = {"accept": accept}
+  request.headers = {"accept": accept, **(headers or {})}
   return request
 
 
@@ -131,6 +134,20 @@ class TestRemoteSwitchWorkspace:
   def test_invalid_characters_rejected(self):
     text = _remote_switch_workspace(KG, {"workspace_id": "../etc/passwd"})
     assert text.startswith("Error:")
+
+  def test_foreign_graph_family_rejected(self):
+    # A full id outside this connector's family must not resolve to a URL.
+    other = "kg29fb490f76871d22e835_dev"
+    text = _remote_switch_workspace(KG, {"workspace_id": other})
+    assert text.startswith("Error:")
+    assert "family" in text
+
+  def test_message_never_claims_current_key_transfers(self):
+    # A URL-token connector's credential may not cover the target; the
+    # guidance must point at minting one, not claim the same key works.
+    payload = json.loads(_remote_switch_workspace(KG, {"workspace_id": "dev"}))
+    assert "same API key" not in payload["message"]
+    assert "credential" in payload["message"]
 
 
 @pytest.mark.asyncio
@@ -544,3 +561,201 @@ class TestStreamQueuedCall:
       await generator.aclose()
 
     manager.cancel_query.assert_awaited_once_with("q-1", "user-123")
+
+
+class TestToolFailureClassification:
+  """Marked handler failures and aggregated stream failures map to isError."""
+
+  def test_marked_error_maps_to_is_error(self):
+    marked = tool_error_result("Error: it broke", "backend")
+    result = _to_tool_result(marked)
+    assert result["isError"] is True
+    assert result["content"] == [{"type": "text", "text": "Error: it broke"}]
+
+  def test_aggregated_failure_maps_to_is_error(self):
+    aggregated = {"success": False, "error": "boom", "tool": "read-graph-cypher"}
+    result = _to_tool_result(aggregated)
+    assert result["isError"] is True
+    assert result["content"] == [{"type": "text", "text": "boom"}]
+
+  def test_success_shapes_stay_not_error(self):
+    for value in (
+      {"type": "text", "text": "fine"},
+      {"success": True, "rows": 3},
+      ["plain", "list"],
+    ):
+      assert _to_tool_result(value)["isError"] is False
+
+  def test_tool_failure_kinds(self):
+    assert _tool_failure(tool_error_result("t", "timeout")) == (True, "timeout")
+    assert _tool_failure(tool_error_result("c", "constraint")) == (True, "constraint")
+    # Aggregated failures without a kind default to backend (covers the
+    # disrupted-stream shape).
+    assert _tool_failure({"success": False, "error": "x"}) == (True, "backend")
+    assert _tool_failure({"type": "text", "text": "ok"}) == (False, None)
+
+
+class TestTransportGate:
+  """Origin and Content-Type checks required by MCP Streamable HTTP."""
+
+  def _request(self, headers):
+    request = Mock()
+    request.headers = headers
+    return request
+
+  def test_absent_origin_with_json_passes(self):
+    _transport_gate(self._request({"content-type": "application/json"}))
+
+  def test_trusted_origin_passes(self):
+    from robosystems.config import env
+
+    origin = env.get_main_cors_origins()[0]
+    _transport_gate(
+      self._request({"origin": origin, "content-type": "application/json"})
+    )
+
+  def test_untrusted_origin_is_403(self):
+    with pytest.raises(HTTPException) as exc:
+      _transport_gate(
+        self._request(
+          {"origin": "https://evil.example", "content-type": "application/json"}
+        )
+      )
+    assert exc.value.status_code == 403
+
+  def test_non_json_content_type_is_415(self):
+    with pytest.raises(HTTPException) as exc:
+      _transport_gate(self._request({"content-type": "text/plain"}))
+    assert exc.value.status_code == 415
+
+  def test_json_with_charset_passes(self):
+    _transport_gate(self._request({"content-type": "application/json; charset=utf-8"}))
+
+
+@pytest.mark.asyncio
+class TestProtocolVersionHeader:
+  """Post-initialize requests carrying MCP-Protocol-Version must be validated."""
+
+  async def test_unsupported_version_header_is_400(self):
+    request = _make_request(
+      {"jsonrpc": "2.0", "id": 5, "method": "ping"},
+      headers={"mcp-protocol-version": "2024-11-05"},
+    )
+    response = await dispatch_jsonrpc(request, "kg123", _make_user())
+    assert response.status_code == 400
+    body = _body(response)
+    assert body["error"]["code"] == INVALID_REQUEST
+    assert "2024-11-05" in body["error"]["message"]
+
+  async def test_supported_version_header_passes(self):
+    request = _make_request(
+      {"jsonrpc": "2.0", "id": 5, "method": "ping"},
+      headers={"mcp-protocol-version": "2025-06-18"},
+    )
+    body = _body(await dispatch_jsonrpc(request, "kg123", _make_user()))
+    assert body["result"] == {}
+
+  async def test_absent_version_header_passes(self):
+    request = _make_request({"jsonrpc": "2.0", "id": 5, "method": "ping"})
+    body = _body(await dispatch_jsonrpc(request, "kg123", _make_user()))
+    assert body["result"] == {}
+
+  async def test_initialize_is_exempt_from_header_check(self):
+    handler = _make_handler()
+    with (
+      patch.object(remote, "_validate_read_access", AsyncMock()),
+      patch.object(remote, "get_graph_repository", AsyncMock(return_value=Mock())),
+      patch.object(remote, "MCPHandler", Mock(return_value=handler)),
+    ):
+      request = _make_request(
+        {
+          "jsonrpc": "2.0",
+          "id": 1,
+          "method": "initialize",
+          "params": {"protocolVersion": "2025-11-25"},
+        },
+        headers={"mcp-protocol-version": "2025-11-25"},
+      )
+      response = await dispatch_jsonrpc(request, "kg123", _make_user())
+    assert response.status_code == 200
+    # Unsupported requested revision negotiates down to the server's latest.
+    assert _body(response)["result"]["protocolVersion"] == MCP_LATEST_PROTOCOL_VERSION
+
+  async def test_notification_with_bad_header_is_400_without_body(self):
+    request = _make_request(
+      {"jsonrpc": "2.0", "method": "notifications/initialized"},
+      headers={"mcp-protocol-version": "bogus"},
+    )
+    response = await dispatch_jsonrpc(request, "kg123", _make_user())
+    assert response.status_code == 400
+    assert not response.body
+
+  async def test_pre_streamable_revision_is_not_negotiable(self):
+    assert "2024-11-05" not in remote.MCP_SUPPORTED_PROTOCOL_VERSIONS
+
+
+@pytest.mark.asyncio
+class TestToolFailureOutcomes:
+  """Execution failures reach the client as isError and the breaker as failures."""
+
+  async def _call(self, result, breaker):
+    handler = _make_handler()
+    with (
+      patch.object(remote, "circuit_breaker", breaker),
+      patch.object(remote, "authorize_mcp_tool_call", AsyncMock(return_value="read")),
+      patch.object(remote, "get_graph_repository", AsyncMock(return_value=Mock())),
+      patch.object(remote, "MCPHandler", Mock(return_value=handler)),
+      patch.object(remote, "execute_tool_to_json", AsyncMock(return_value=result)),
+    ):
+      request = _make_request(
+        {
+          "jsonrpc": "2.0",
+          "id": 21,
+          "method": "tools/call",
+          "params": {"name": "get-graph-info", "arguments": {}},
+        },
+        accept="application/json",
+      )
+      return _body(await dispatch_jsonrpc(request, "kg123", _make_user()))
+
+  async def test_swallowed_timeout_is_error_and_breaker_failure(self):
+    breaker = Mock()
+    body = await self._call(
+      tool_error_result("Error: tool 'get-graph-info' timed out", "timeout"), breaker
+    )
+    assert body["result"]["isError"] is True
+    breaker.record_failure.assert_called_once()
+    breaker.record_success.assert_not_called()
+
+  async def test_backend_error_is_error_and_breaker_failure(self):
+    breaker = Mock()
+    body = await self._call(
+      tool_error_result("Graph API unavailable", "backend"), breaker
+    )
+    assert body["result"]["isError"] is True
+    breaker.record_failure.assert_called_once()
+
+  async def test_constraint_error_is_error_but_not_breaker_failure(self):
+    breaker = Mock()
+    body = await self._call(
+      tool_error_result("Query Error: too complex", "constraint"), breaker
+    )
+    # The model sees a failed call; the breaker sees a healthy backend.
+    assert body["result"]["isError"] is True
+    breaker.record_failure.assert_not_called()
+    breaker.record_success.assert_called_once()
+
+  async def test_disrupted_aggregation_is_error_and_breaker_failure(self):
+    breaker = Mock()
+    body = await self._call(
+      {"success": False, "error": "Unable to aggregate results", "tool": "t"}, breaker
+    )
+    assert body["result"]["isError"] is True
+    breaker.record_failure.assert_called_once()
+
+  async def test_success_still_records_breaker_success(self):
+    breaker = Mock()
+    body = await self._call({"type": "text", "text": "fine"}, breaker)
+    assert body["result"]["isError"] is False
+    breaker.record_success.assert_called_once()
+    breaker.record_failure.assert_not_called()

--- a/tests/routers/graphs/mcp/test_mcp_streaming.py
+++ b/tests/routers/graphs/mcp/test_mcp_streaming.py
@@ -527,3 +527,84 @@ class TestMarkedErrorPropagation:
     assert result["success"] is False
     assert result["error"] == "boom"
     assert result["error_kind"] == "timeout"
+
+
+@pytest.mark.unit
+class TestStreamingErrorChunks:
+  """A failed backend query arrives as an error chunk from the streaming
+  wrapper — it must become an error event, never a successful empty result."""
+
+  def _handler_with_error_chunk(self, error_type):
+    async def failing_stream(query, parameters, chunk_size=1000):
+      yield {
+        "error": "connection lost",
+        "error_type": error_type,
+        "chunk_index": 0,
+        "is_last_chunk": True,
+        "row_count": 0,
+      }
+
+    handler = AsyncMock()
+    handler.execute_query_streaming = failing_stream
+    return handler
+
+  @pytest.mark.asyncio
+  async def test_error_chunk_yields_error_event_not_completion(self):
+    handler = self._handler_with_error_chunk("GraphAPIError")
+
+    events = await _collect_events(
+      stream_cypher_query(handler, {"query": "MATCH (n) RETURN n"}, 100)
+    )
+
+    event_types = [e["event"] for e in events]
+    assert "error" in event_types
+    assert "query_complete" not in event_types
+    assert "query_chunk" not in event_types
+    error_event = next(e for e in events if e["event"] == "error")
+    assert error_event["data"]["error"] == "connection lost"
+    assert error_event["data"]["error_kind"] == "backend"
+
+  @pytest.mark.asyncio
+  async def test_timeout_error_type_maps_to_timeout_kind(self):
+    handler = self._handler_with_error_chunk("GraphQueryTimeoutError")
+
+    events = await _collect_events(
+      stream_cypher_query(handler, {"query": "MATCH (n) RETURN n"}, 100)
+    )
+
+    error_event = next(e for e in events if e["event"] == "error")
+    assert error_event["data"]["error_kind"] == "timeout"
+
+  @pytest.mark.asyncio
+  async def test_error_chunk_aggregates_to_failure_end_to_end(self):
+    handler = self._handler_with_error_chunk("GraphAPIError")
+
+    events = await _collect_events(
+      stream_mcp_tool_execution(
+        handler, "read-graph-cypher", {"query": "MATCH (n) RETURN n"}, "sse_streaming"
+      )
+    )
+
+    result = aggregate_streamed_results(events)
+    assert result["success"] is False
+    assert result["error"] == "connection lost"
+    assert result["error_kind"] == "backend"
+
+  @pytest.mark.asyncio
+  async def test_rows_before_error_chunk_still_fail(self):
+    async def partial_then_error(query, parameters, chunk_size=1000):
+      yield {"chunk_index": 0, "data": [{"n": 1}], "columns": ["n"]}
+      yield {"error": "engine died mid-stream", "error_type": "GraphAPIError"}
+
+    handler = AsyncMock()
+    handler.execute_query_streaming = partial_then_error
+
+    events = await _collect_events(
+      stream_mcp_tool_execution(
+        handler, "read-graph-cypher", {"query": "MATCH (n) RETURN n"}, "sse_streaming"
+      )
+    )
+
+    result = aggregate_streamed_results(events)
+    assert result["success"] is False
+    assert result["error"] == "engine died mid-stream"

--- a/tests/routers/graphs/mcp/test_mcp_streaming.py
+++ b/tests/routers/graphs/mcp/test_mcp_streaming.py
@@ -440,3 +440,90 @@ class TestAggregateStreamedResults:
     result = aggregate_streamed_results(events)
 
     assert result["tool"] == "my-custom-tool"
+
+
+@pytest.mark.unit
+class TestMarkedErrorPropagation:
+  """Handler-marked execution failures must surface as error events, so the
+  aggregated result is a failure — never a success wrapping error prose."""
+
+  @pytest.mark.asyncio
+  async def test_generic_tool_marked_error_yields_error_event(self):
+    handler = AsyncMock()
+    handler.call_tool = AsyncMock(
+      return_value={
+        "type": "text",
+        "text": "Error: operation failed.",
+        "is_error": True,
+        "error_kind": "backend",
+      }
+    )
+
+    events = await _collect_events(
+      stream_mcp_tool_execution(handler, "get-graph-info", {}, "json_immediate")
+    )
+
+    event_types = [e["event"] for e in events]
+    assert "error" in event_types
+    assert "result" not in event_types
+    assert "complete" not in event_types
+    error_event = next(e for e in events if e["event"] == "error")
+    assert error_event["data"]["error_kind"] == "backend"
+
+  @pytest.mark.asyncio
+  async def test_cypher_fallback_marked_error_yields_error_event(self):
+    handler = AsyncMock()
+    handler.call_tool = AsyncMock(
+      return_value={
+        "type": "text",
+        "text": "Error: tool 'read-graph-cypher' timed out after 60 seconds",
+        "is_error": True,
+        "error_kind": "timeout",
+      }
+    )
+    del handler.execute_query_streaming
+
+    events = await _collect_events(
+      stream_mcp_tool_execution(
+        handler, "read-graph-cypher", {"query": "MATCH (n) RETURN n"}, "json_immediate"
+      )
+    )
+
+    event_types = [e["event"] for e in events]
+    assert "error" in event_types
+    assert "query_result" not in event_types
+
+  @pytest.mark.asyncio
+  async def test_schema_marked_error_yields_error_event(self):
+    handler = AsyncMock()
+    handler.call_tool = AsyncMock(
+      return_value={
+        "type": "text",
+        "text": "backend down",
+        "is_error": True,
+        "error_kind": "backend",
+      }
+    )
+
+    events = await _collect_events(
+      stream_mcp_tool_execution(handler, "get-graph-schema", {}, "json_complete")
+    )
+
+    event_types = [e["event"] for e in events]
+    assert "error" in event_types
+    assert "schema_nodes" not in event_types
+
+  def test_aggregation_preserves_error_kind(self):
+    events = [
+      {"event": "start", "data": {"tool": "get-graph-info"}},
+      {
+        "event": "error",
+        "data": {"tool": "get-graph-info", "error": "boom", "error_kind": "timeout"},
+      },
+    ]
+
+    result = aggregate_streamed_results(events)
+
+    assert result["success"] is False
+    assert result["error"] == "boom"
+    assert result["error_kind"] == "timeout"


### PR DESCRIPTION
## Summary

Hardening pass on the remote MCP transport and its supporting middleware, from an internal review of the connector work:

- **Rate limiting now recognizes the authenticated principal.** The auth dependencies publish a sanitized identity on `request.state`, and the rate limiter consumes it for credentials it cannot reparse from headers — connector clients now get their graph's proper tier bucketing instead of falling to the anonymous tier.
- **Tool execution failures propagate as MCP `isError` results** and count as circuit-breaker failures (timeouts and backend errors; caller-side query-constraint errors don't trip the breaker). Failure results are never cached.
- **Transport conformance:** Origin validation and `application/json` enforcement per MCP Streamable HTTP; the pre-Streamable `2024-11-05` revision removed from the negotiable set; post-initialize `MCP-Protocol-Version` headers validated (400 on unsupported values).
- **`switch-workspace`** targets are constrained to the connector's graph family, with clearer guidance on setting up a connector for the target workspace.

Companion change: robosystems-mcp-client#64 (bridge log hygiene).

## Testing

- Full suite: 12,181 passed, 24 skipped; ruff + format + basedpyright + cf-lint clean
- New regression coverage: rate-limit identity resolution, `isError`/breaker outcomes across direct, streamed, and queued paths, transport gate, protocol-version validation, switch-workspace family constraint