### PR TITLE
feat(events): expose payload_drift on the event block read surface

### DIFF
--- a/robosystems/graphql/resolvers/ledger.py
+++ b/robosystems/graphql/resolvers/ledger.py
@@ -306,6 +306,7 @@ class LedgerQuery:
     status: str | None = None,
     agent_id: str | None = None,
     source: str | None = None,
+    payload_drift: bool | None = None,
     limit: int | None = None,
     offset: int | None = None,
   ) -> list[EventBlock]:
@@ -314,7 +315,9 @@ class LedgerQuery:
     Drives the close-workspace inbox: defaulting to recent events first
     (``occurred_at DESC``) with filters for ``status`` (``captured`` for
     inbox queue, ``committed`` for the audit-trail view), ``source``
-    (``quickbooks`` / ``schedule`` / ``manual``), and ``event_type``.
+    (``quickbooks`` / ``schedule`` / ``manual``), ``event_type``, and
+    ``payload_drift`` (``true`` for the post-sync reconciliation
+    worklist — committed events whose upstream payload changed).
     """
     limit, offset = _resolve_pagination(limit, offset, default_limit=50)
     try:
@@ -326,6 +329,7 @@ class LedgerQuery:
           status=status,
           agent_id=agent_id,
           source=source,
+          payload_drift=payload_drift,
           limit=limit,
           offset=offset,
         )

--- a/robosystems/graphql/types/ledger.py
+++ b/robosystems/graphql/types/ledger.py
@@ -334,6 +334,7 @@ class EventBlock:
   currency: str
   description: str | None
   metadata: JSON
+  payload_drift: bool
   dimension_ids: list[str]
   agent_id: str | None
   resource_type: str | None
@@ -362,6 +363,7 @@ class EventBlock:
       currency=row.currency,
       description=row.description,
       metadata=row.metadata,
+      payload_drift=row.payload_drift,
       dimension_ids=list(row.dimension_ids),
       agent_id=row.agent_id,
       resource_type=row.resource_type,

--- a/robosystems/middleware/mcp/tools/event_block_tools.py
+++ b/robosystems/middleware/mcp/tools/event_block_tools.py
@@ -100,6 +100,10 @@ class ListEventBlocksTool:
 - To see a counterparty's event history (filter by agent_id)
 - To audit events from a specific source (quickbooks, plaid, etc.)
 - Close workflow: find unposted events (status=captured or committed)
+- Post-sync reconciliation: payload_drift=true lists committed events whose
+  upstream payload changed after posting — the local GL no longer mirrors
+  the source for these. The stashed incoming payload is in each event's
+  metadata.drift_payload (fetch via get-event-block or include_metadata=true)
 
 **PARAMETERS:**
 - event_type (optional): e.g., 'invoice_issued', 'contract_signed', 'bank_transaction'
@@ -107,11 +111,14 @@ class ListEventBlocksTool:
 - status (optional): 'captured' | 'classified' | 'committed' | 'pending' | 'fulfilled' | 'voided' | 'superseded'
 - agent_id (optional): Filter to a specific counterparty
 - source (optional): 'manual' | 'schedule' | 'system', a connected provider name, or a registered external source_name
+- payload_drift (optional): true → only drifted events (the reconciliation
+  worklist); false → only non-drifted; omit for all
 - limit (optional, default 50, max 1000)
 - offset (optional, default 0)
 - include_metadata (optional, default false): When false, returns a lean
   per-event summary (id, event_type, event_category, status, occurred_at,
-  source, agent_id, amount, currency, description, has_discharge_link).
+  source, agent_id, amount, currency, description, has_discharge_link,
+  payload_drift).
   When true, includes the full event_block metadata blob — `entries`,
   `qb_*` fields, connection_id, etc. — same shape as get-event-block.
   Default is summary-only because bulk metadata across hundreds of
@@ -132,6 +139,7 @@ class ListEventBlocksTool:
           "status": {"type": "string"},
           "agent_id": {"type": "string"},
           "source": {"type": "string"},
+          "payload_drift": {"type": "boolean"},
           "limit": {"type": "integer", "minimum": 1, "maximum": 1000, "default": 50},
           "offset": {"type": "integer", "minimum": 0, "default": 0},
           "include_metadata": {
@@ -171,6 +179,7 @@ class ListEventBlocksTool:
           status=arguments.get("status"),
           agent_id=arguments.get("agent_id"),
           source=arguments.get("source"),
+          payload_drift=arguments.get("payload_drift"),
           limit=limit,
           offset=offset,
         )
@@ -216,6 +225,7 @@ def _summarize_event_block(envelope) -> dict[str, Any]:
     "description": envelope.description,
     "has_discharge_link": envelope.discharges_event_id is not None,
     "has_obligation_link": envelope.obligated_by_event_id is not None,
+    "payload_drift": envelope.payload_drift,
   }
 
 

--- a/robosystems/models/api/event_block.py
+++ b/robosystems/models/api/event_block.py
@@ -357,6 +357,17 @@ class EventBlockEnvelope(BaseModel):
       "through a handler, otherwise whatever the adapter captured."
     ),
   )
+  payload_drift: bool = Field(
+    False,
+    description=(
+      "True when a source re-sync surfaced a changed upstream payload "
+      "for an event whose GL is already posted (committed/fulfilled "
+      "are immutable to sync). The live payload and GL are untouched; "
+      "the incoming payload is stashed in `metadata.drift_payload` "
+      "with `metadata.drift_detected_at`. Drifted events need operator "
+      "reconciliation — the local books no longer mirror the source."
+    ),
+  )
   dimension_ids: list[str] = Field(
     ...,
     description=(

--- a/robosystems/operations/extensions/loader.py
+++ b/robosystems/operations/extensions/loader.py
@@ -1493,7 +1493,16 @@ class OLTPLoader:
           # (bookkeeping field, not business payload) so the next
           # sync's gate comparison stays accurate. Without this update
           # the gate would re-fire indefinitely with the same comparison.
-          _drift_excluded = ("drift_payload", "drift_detected_at", "qb_sync_token")
+          # `connection_id` is excluded for the same reason: it names the
+          # connection that synced the row, not what happened upstream.
+          # A reconnect that mints a new connection id must not read as
+          # drift on every committed row in the window.
+          _drift_excluded = (
+            "drift_payload",
+            "drift_detected_at",
+            "qb_sync_token",
+            "connection_id",
+          )
           live_payload = {
             k: v for k, v in (evt.metadata_ or {}).items() if k not in _drift_excluded
           }
@@ -1519,6 +1528,14 @@ class OLTPLoader:
             qb_sync_token is not None and new_meta.get("qb_sync_token") != qb_sync_token
           ):
             new_meta["qb_sync_token"] = qb_sync_token
+            meta_changed = True
+          # Refresh `connection_id` the same way — write-back routing
+          # reads it off the event, so it must name the *live* connection
+          # after a reconnect, not the one that originally synced the row.
+          if (
+            connection_id is not None and new_meta.get("connection_id") != connection_id
+          ):
+            new_meta["connection_id"] = connection_id
             meta_changed = True
           if meta_changed:
             evt.metadata_ = new_meta

--- a/robosystems/operations/roboledger/reads/event_block.py
+++ b/robosystems/operations/roboledger/reads/event_block.py
@@ -49,6 +49,7 @@ def _to_envelope(event: Event, dimension_ids: list[str]) -> EventBlockEnvelope:
     currency=event.currency,
     description=event.description,
     metadata=dict(event.metadata_ or {}),
+    payload_drift=bool(event.payload_drift),
     dimension_ids=dimension_ids,
     agent_id=event.agent_id,
     resource_type=event.resource_type,
@@ -77,6 +78,7 @@ def list_event_blocks(
   status: str | None = None,
   agent_id: str | None = None,
   source: str | None = None,
+  payload_drift: bool | None = None,
   limit: int = 50,
   offset: int = 0,
 ) -> list[EventBlockEnvelope]:
@@ -91,6 +93,9 @@ def list_event_blocks(
     stmt = stmt.where(Event.agent_id == agent_id)
   if source is not None:
     stmt = stmt.where(Event.source == source)
+  if payload_drift is not None:
+    # payload_drift=True rides idx_events_payload_drift (partial index).
+    stmt = stmt.where(Event.payload_drift.is_(payload_drift))
 
   stmt = stmt.order_by(Event.occurred_at.desc()).limit(limit).offset(offset)
   events = session.execute(stmt).scalars().all()

--- a/tests/graphql/extensions/test_ledger.py
+++ b/tests/graphql/extensions/test_ledger.py
@@ -490,6 +490,35 @@ class TestEventBlockResolvers:
     assert kwargs["limit"] == 10
     assert kwargs["offset"] == 0
 
+  def test_event_blocks_payload_drift_filter_and_field(self) -> None:
+    drifted = self._event(id="evt_drift", status="committed")
+    drifted.payload_drift = True
+    with (
+      _patch_session(),
+      patch(
+        "robosystems.operations.roboledger.reads.event_block.list_event_blocks",
+        return_value=[drifted],
+      ) as list_mock,
+    ):
+      result = schema.execute_sync(
+        """
+        query {
+          eventBlocks(payloadDrift: true) {
+            id
+            payloadDrift
+          }
+        }
+        """,
+        context_value=_ctx(),
+      )
+
+    assert result.errors is None
+    assert result.data is not None
+    (block,) = result.data["eventBlocks"]
+    assert block["id"] == "evt_drift"
+    assert block["payloadDrift"] is True
+    assert list_mock.call_args.kwargs["payload_drift"] is True
+
   def test_event_block_raises_typed_error_when_schema_not_initialized(self) -> None:
     with (
       _patch_session(),

--- a/tests/middleware/mcp/tools/test_event_block_tools.py
+++ b/tests/middleware/mcp/tools/test_event_block_tools.py
@@ -1,0 +1,120 @@
+"""Unit tests for the Event Block MCP read tools.
+
+Mocks live at the operations-layer boundary (``ops_list_event_blocks``) —
+the tool is a thin shim, so we verify argument forwarding and response
+shaping only. The drift filter matters most: ``payload_drift=true`` is the
+post-sync reconciliation worklist, and both response modes must surface
+the flag.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from robosystems.middleware.mcp.tools.event_block_tools import ListEventBlocksTool
+from robosystems.models.api.event_block import EventBlockEnvelope
+
+MODULE = "robosystems.middleware.mcp.tools.event_block_tools"
+
+
+def _client() -> MagicMock:
+  client = MagicMock()
+  client.graph_id = "kg_test"
+  return client
+
+
+@contextmanager
+def _patched_session():
+  @contextmanager
+  def fake_session(_graph_id):
+    yield MagicMock()
+
+  with patch(f"{MODULE}.extensions_session", fake_session):
+    yield
+
+
+def _envelope(*, id: str = "evt_01", payload_drift: bool = False) -> EventBlockEnvelope:
+  return EventBlockEnvelope(
+    id=id,
+    event_type="journal_entry_recorded",
+    event_category="adjustment",
+    event_class="economic",
+    status="committed",
+    occurred_at=datetime(2026, 4, 15, 12, tzinfo=UTC),
+    effective_at=None,
+    source="quickbooks",
+    external_id="JournalEntry_42",
+    external_url=None,
+    amount=12345,
+    currency="USD",
+    description="Widget sale",
+    metadata={"drift_payload": {"amount": 99}} if payload_drift else {},
+    payload_drift=payload_drift,
+    dimension_ids=[],
+    agent_id=None,
+    resource_type=None,
+    resource_element_id=None,
+    replaced_by_event_id=None,
+    replaces_event_id=None,
+    obligated_by_event_id=None,
+    discharges_event_id=None,
+    created_at=datetime(2026, 4, 16, 9, tzinfo=UTC),
+    created_by="system",
+  )
+
+
+class TestListEventBlocksDriftFilter:
+  @pytest.mark.asyncio
+  async def test_payload_drift_arg_forwards_to_ops(self) -> None:
+    with (
+      _patched_session(),
+      patch(f"{MODULE}.ops_list_event_blocks", return_value=[]) as ops_mock,
+    ):
+      result = await ListEventBlocksTool(_client()).execute({"payload_drift": True})
+
+    assert result["event_count"] == 0
+    assert ops_mock.call_args.kwargs["payload_drift"] is True
+
+  @pytest.mark.asyncio
+  async def test_payload_drift_omitted_forwards_none(self) -> None:
+    with (
+      _patched_session(),
+      patch(f"{MODULE}.ops_list_event_blocks", return_value=[]) as ops_mock,
+    ):
+      await ListEventBlocksTool(_client()).execute({})
+
+    assert ops_mock.call_args.kwargs["payload_drift"] is None
+
+  @pytest.mark.asyncio
+  async def test_summary_mode_surfaces_drift_flag(self) -> None:
+    envelopes = [_envelope(id="evt_ok"), _envelope(id="evt_drift", payload_drift=True)]
+    with (
+      _patched_session(),
+      patch(f"{MODULE}.ops_list_event_blocks", return_value=envelopes),
+    ):
+      result = await ListEventBlocksTool(_client()).execute({})
+
+    assert result["mode"] == "summary"
+    by_id = {e["id"]: e for e in result["events"]}
+    assert by_id["evt_ok"]["payload_drift"] is False
+    assert by_id["evt_drift"]["payload_drift"] is True
+    # Summary mode stays lean — the stashed payload is metadata-only.
+    assert "drift_payload" not in by_id["evt_drift"]
+
+  @pytest.mark.asyncio
+  async def test_full_mode_carries_flag_and_stashed_payload(self) -> None:
+    envelopes = [_envelope(id="evt_drift", payload_drift=True)]
+    with (
+      _patched_session(),
+      patch(f"{MODULE}.ops_list_event_blocks", return_value=envelopes),
+    ):
+      result = await ListEventBlocksTool(_client()).execute({"include_metadata": True})
+
+    assert result["mode"] == "full"
+    (event,) = result["events"]
+    assert event["payload_drift"] is True
+    assert event["metadata"]["drift_payload"] == {"amount": 99}

--- a/tests/operations/event_block/test_commands_update.py
+++ b/tests/operations/event_block/test_commands_update.py
@@ -35,6 +35,7 @@ def _event(event_id: str, status: str = "classified") -> SimpleNamespace:
     currency="USD",
     description=None,
     metadata_={},
+    payload_drift=False,
     agent_id=None,
     resource_type=None,
     resource_element_id=None,

--- a/tests/operations/extensions/test_loader_resync.py
+++ b/tests/operations/extensions/test_loader_resync.py
@@ -460,6 +460,54 @@ class TestSyncTokenCapture:
     # Live payload untouched — a committed event's payload is immutable.
     assert "drift_payload" not in committed.metadata_
 
+  def test_connection_id_change_alone_does_not_flag_drift(self):
+    """A re-sync under a different connection id (reconnect minted a new
+    one) must not flag drift on committed events — `connection_id` names
+    the connection that synced the row, not upstream state. The stored
+    value must refresh to the live connection, because write-back routing
+    reads it off the event."""
+    from robosystems.operations.extensions.loader import OLTPLoader
+
+    committed = MagicMock()
+    committed.external_id = "JE_500"
+    committed.status = "committed"
+    committed.id = "evt_committed"
+    committed.payload_drift = False
+
+    capture_session = MagicMock()
+    capture_session.query.return_value.filter.return_value.all.return_value = []
+    OLTPLoader()._capture_transactions_as_events(
+      capture_session,
+      self._dbt_data_with_sync_token(None),
+      source="quickbooks",
+      connection_id="conn_old",
+      created_by="user_1",
+      now=datetime.now(UTC),
+    )
+    initial_event = capture_session.add_all.call_args_list[0][0][0][0]
+    committed.metadata_ = {
+      k: v for k, v in initial_event.metadata_.items() if not k.startswith("dispatch_")
+    }
+    assert committed.metadata_["connection_id"] == "conn_old"
+
+    # Re-sync the identical payload under a new connection id.
+    drift_session = MagicMock()
+    drift_session.query.return_value.filter.return_value.all.return_value = [committed]
+    result = OLTPLoader()._capture_transactions_as_events(
+      drift_session,
+      self._dbt_data_with_sync_token(None),
+      source="quickbooks",
+      connection_id="conn_new",
+      created_by="user_1",
+      now=datetime.now(UTC),
+    )
+
+    assert result.drift_detected == 0
+    assert committed.payload_drift is False
+    assert "drift_payload" not in committed.metadata_
+    # Routing bookkeeping refreshed to the live connection.
+    assert committed.metadata_["connection_id"] == "conn_new"
+
 
 class TestSyncTokenGate:
   """SyncToken freshness gate on the UPSERT path.

--- a/tests/operations/roboledger/reads/test_event_block.py
+++ b/tests/operations/roboledger/reads/test_event_block.py
@@ -1,0 +1,78 @@
+"""Tests for event block read operations.
+
+Focus is the ``payload_drift`` surface added for post-sync reconciliation:
+the envelope must carry the flag off the ORM row, and ``list_event_blocks``
+must compose (or omit) the drift predicate so the reconciliation worklist
+is enumerable.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+
+from robosystems.models.extensions.roboledger.event import Event
+from robosystems.operations.roboledger.reads.event_block import (
+  _to_envelope,
+  list_event_blocks,
+)
+
+
+def _event(*, payload_drift: bool | None = None) -> Event:
+  return Event(
+    id="evt_01",
+    event_type="journal_entry_recorded",
+    event_category="adjustment",
+    event_class="economic",
+    status="committed",
+    occurred_at=datetime(2026, 4, 15, 12, tzinfo=UTC),
+    source="quickbooks",
+    external_id="JournalEntry_42",
+    amount=12345,
+    currency="USD",
+    metadata_={"qb_txn_type": "JournalEntry"},
+    payload_drift=payload_drift,
+    created_at=datetime(2026, 4, 16, 9, tzinfo=UTC),
+    created_by="system",
+  )
+
+
+def _captured_list_stmt(session: MagicMock) -> str:
+  (stmt,) = session.execute.call_args.args
+  return str(stmt)
+
+
+class TestEnvelopeCarriesDrift:
+  def test_drifted_row_maps_true(self) -> None:
+    envelope = _to_envelope(_event(payload_drift=True), [])
+    assert envelope.payload_drift is True
+
+  def test_unset_column_maps_false(self) -> None:
+    # A row constructed without the flag (Python-side default is None
+    # until flush) must read as not-drifted, never None.
+    envelope = _to_envelope(_event(), [])
+    assert envelope.payload_drift is False
+
+
+class TestListDriftFilter:
+  def _session(self) -> MagicMock:
+    session = MagicMock()
+    session.execute.return_value.scalars.return_value.all.return_value = []
+    return session
+
+  def test_true_filter_composes_drift_predicate(self) -> None:
+    session = self._session()
+    list_event_blocks(session, payload_drift=True)
+    assert "payload_drift IS true" in _captured_list_stmt(session)
+
+  def test_false_filter_composes_drift_predicate(self) -> None:
+    session = self._session()
+    list_event_blocks(session, payload_drift=False)
+    assert "payload_drift IS false" in _captured_list_stmt(session)
+
+  def test_omitted_filter_leaves_drift_out(self) -> None:
+    session = self._session()
+    list_event_blocks(session)
+    # The column always appears in the SELECT list; only the predicate
+    # must be absent.
+    assert "payload_drift IS" not in _captured_list_stmt(session)


### PR DESCRIPTION
## Summary

The sync loader has recorded upstream payload drift on committed events since the UPSERT rework — the `payload_drift` column, the stashed `metadata.drift_payload`, and a partial index — but no read surface consumed any of it, so the post-sync reconciliation worklist was unenumerable. This PR surfaces the flag end to end on the event block read path, and fixes a false-drift source in the comparison itself, found while dress-rehearsing a resync against a copied tenant schema.

## Changes

- **`models/api/event_block.py`** — `EventBlockEnvelope` gains `payload_drift: bool` (default `False`) with a description documenting the semantics: committed/fulfilled events are immutable to re-sync; the incoming payload is stashed in `metadata.drift_payload`, and the flag marks the event as needing operator reconciliation.
- **`operations/roboledger/reads/event_block.py`** — `_to_envelope` maps the ORM column; `list_event_blocks` gains an optional `payload_drift` filter (`True` rides the existing `idx_events_payload_drift` partial index, which previously had no consumer).
- **`graphql/types/ledger.py` + `graphql/resolvers/ledger.py`** — the `EventBlock` type carries `payloadDrift` and the `eventBlocks` query accepts a `payloadDrift` filter argument.
- **`middleware/mcp/tools/event_block_tools.py`** — `list-event-blocks` accepts `payload_drift` and forwards it to the ops layer; the flag is included in both response modes (the lean summary projection and `include_metadata=true`), with tool docs pointing at `metadata.drift_payload` for the stashed payload.
- **`operations/extensions/loader.py`** — `connection_id` is excluded from the drift comparison and refreshed on the live event, exactly the treatment `qb_sync_token` already gets. It is loader bookkeeping stamped into the metadata blob, not upstream state — a re-sync under a newly minted connection id (e.g. after a reconnect) flagged drift on every committed row in the window, burying real drift under false flags. Verified against a copied production tenant schema: 201 flags pre-fix (190 artifact + 11 real), exactly 11 post-fix.
- **Tests** — new `tests/operations/roboledger/reads/test_event_block.py` (envelope mapping + filter predicate composition), new `tests/middleware/mcp/tools/test_event_block_tools.py` (argument forwarding + both response modes), a GraphQL filter/field test in `tests/graphql/extensions/test_ledger.py`, a `connection_id`-exclusion test in `tests/operations/extensions/test_loader_resync.py` mirroring the existing SyncToken-exclusion test, and one existing `SimpleNamespace` event fixture extended with the new attribute.

## Breaking Changes

None. Additive only — a new optional response field and a new optional filter argument on the GraphQL schema and MCP tool surface. SDK regen is an opportunity, not a requirement; the Python client's schema drift gate will pick up the new field/argument on its next `just refresh-schema` as an additive minor.

## Testing

- `just test` — full unit suite: 12,201 passed, 24 skipped (first commit); extensions loader suite re-run green after the second commit (129 passed).
- `just test-code` — ruff, format, basedpyright, cf-lint: all clean.
- End-to-end on a local stack: simulated upstream drift → resync → flag set, GL untouched, incoming payload stashed → `list-event-blocks payload_drift=true` (MCP) and `eventBlocks(payloadDrift: true)` (GraphQL) each return exactly the drifted event. Loader fix verified empirically against a copied production tenant schema (201 → 11 flags).