### PR TITLE
feat(forecast): scenario as a Fact dimension — carrier, emitters, backfill

### DIFF
--- a/migrations/extensions/versions/0026_fact_dimensions.py
+++ b/migrations/extensions/versions/0026_fact_dimensions.py
@@ -1,0 +1,66 @@
+"""add the fact_dimensions junction — Fact gains a dimension carrier
+
+Facts were the only ledger noun without a dimension link — transactions,
+entries, line_items, and events all carry junctions to the base
+``Dimension`` model. ``fact_dimensions`` completes the set so the report
+layer can mark a fact as belonging to an explicit member on an axis.
+Scenario is the first use: forecast facts gain a ``scenario`` Dimension,
+actuals stay unrowed (the XBRL default-member rule), so readers honoring
+the documented consolidated-totals contract exclude scenario facts by
+construction.
+
+Nothing writes this table yet — this is P0 of the scenario-dimension
+build; the forecast emitter and the backfill from
+``fact_sets.scenario_id`` land separately.
+
+FK semantics mirror the existing junctions: fact side CASCADE (a tag is
+meaningless without its fact), dimension side RESTRICT (dimensions are
+shared reference data; deleting one still in use is an explicit operator
+decision). New tenant schemas get the table via ``metadata.create_all``
+from the model; this migration covers public and existing tenants.
+
+Revision ID: 0026
+Revises: 0025
+Create Date: 2026-08-06
+
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+from migrations.extensions.helpers import TenantOps, for_each_tenant_schema
+
+# revision identifiers, used by Alembic.
+revision = "0026"
+down_revision = "0025"
+branch_labels = None
+depends_on = None
+
+
+def _create(conn, schema: str) -> None:
+  ops = TenantOps(conn, schema)
+  ops.create_table(
+    "fact_dimensions",
+    f"""
+    fact_id VARCHAR NOT NULL REFERENCES "{schema}".facts (id) ON DELETE CASCADE,
+    dimension_id VARCHAR NOT NULL REFERENCES "{schema}".dimensions (id) ON DELETE RESTRICT,
+    PRIMARY KEY (fact_id, dimension_id)
+    """,
+  )
+
+
+def _drop(conn, schema: str) -> None:
+  TenantOps(conn, schema).drop_table("fact_dimensions")
+
+
+def upgrade() -> None:
+  conn = op.get_bind()
+  _create(conn, "public")
+  for_each_tenant_schema(conn, _create)
+
+
+def downgrade() -> None:
+  conn = op.get_bind()
+  _drop(conn, "public")
+  for_each_tenant_schema(conn, _drop)

--- a/migrations/extensions/versions/0027_scenario_dimension_backfill.py
+++ b/migrations/extensions/versions/0027_scenario_dimension_backfill.py
@@ -1,0 +1,88 @@
+"""backfill scenario dimensions onto existing forecast facts
+
+Pure derivation, no value changes (scenario-dimension P1 backfill): every
+forecast fact already reaches its scenario by one join
+(``facts.fact_set_id → fact_sets.scenario_id``), so this materializes
+that relationship as Fact-level dimension rows:
+
+1. One ``scenario`` Dimension per distinct ``scenario_id``, named from
+   the owning forecast Structure. Deterministic ids (``dim_scn_`` +
+   md5 of the scenario id) make re-runs idempotent alongside the
+   ``(dimension_type, value)`` unique constraint.
+2. One ``fact_dimensions`` row per fact in a scenario-keyed FactSet.
+
+Actuals (``scenario_id IS NULL``) get no rows — the default-member rule.
+Reversible: the downgrade removes exactly the scenario-typed junction
+rows and dimensions this created.
+
+Revision ID: 0027
+Revises: 0026
+Create Date: 2026-08-06
+
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+from migrations.extensions.helpers import TenantOps, for_each_tenant_schema
+
+# revision identifiers, used by Alembic.
+revision = "0027"
+down_revision = "0026"
+branch_labels = None
+depends_on = None
+
+
+def _backfill(conn, schema: str) -> None:
+  ops = TenantOps(conn, schema)
+  ops.execute("""
+    INSERT INTO {s}.dimensions
+      (id, dimension_type, name, value, metadata, is_active, created_at, updated_at)
+    SELECT
+      'dim_scn_' || md5(sc.scenario_id),
+      'scenario',
+      COALESCE(st.name, sc.scenario_id),
+      sc.scenario_id,
+      '{}'::jsonb,
+      true,
+      now(),
+      now()
+    FROM (
+      SELECT DISTINCT scenario_id FROM {s}.fact_sets WHERE scenario_id IS NOT NULL
+    ) sc
+    LEFT JOIN {s}.structures st ON st.id = sc.scenario_id
+    ON CONFLICT (dimension_type, value) DO NOTHING
+  """)
+  ops.execute("""
+    INSERT INTO {s}.fact_dimensions (fact_id, dimension_id)
+    SELECT f.id, d.id
+    FROM {s}.facts f
+    JOIN {s}.fact_sets fs
+      ON fs.id = f.fact_set_id AND fs.scenario_id IS NOT NULL
+    JOIN {s}.dimensions d
+      ON d.dimension_type = 'scenario' AND d.value = fs.scenario_id
+    ON CONFLICT DO NOTHING
+  """)
+
+
+def _unwind(conn, schema: str) -> None:
+  ops = TenantOps(conn, schema)
+  ops.execute("""
+    DELETE FROM {s}.fact_dimensions fd
+    USING {s}.dimensions d
+    WHERE d.id = fd.dimension_id AND d.dimension_type = 'scenario'
+  """)
+  ops.execute("DELETE FROM {s}.dimensions WHERE dimension_type = 'scenario'")
+
+
+def upgrade() -> None:
+  conn = op.get_bind()
+  _backfill(conn, "public")
+  for_each_tenant_schema(conn, _backfill)
+
+
+def downgrade() -> None:
+  conn = op.get_bind()
+  _unwind(conn, "public")
+  for_each_tenant_schema(conn, _unwind)

--- a/robosystems/models/extensions/roboledger/dimension_junctions.py
+++ b/robosystems/models/extensions/roboledger/dimension_junctions.py
@@ -11,6 +11,9 @@ qualifiers:
 - Transaction: source system, provenance dimensions
 - Entry: fund, trust account, product channel dimensions
 - LineItem: department, class, location, project dimensions
+- Fact: report-layer aspects — scenario first (which world a number
+  belongs to); segment/geography/product members as the dimensional
+  spine grows
 """
 
 from sqlalchemy import Column, ForeignKey, String, Table
@@ -84,6 +87,28 @@ event_dimensions = Table(
     "event_id",
     String,
     ForeignKey("events.id", ondelete="CASCADE"),
+    primary_key=True,
+  ),
+  Column(
+    "dimension_id",
+    String,
+    ForeignKey("dimensions.id", ondelete="RESTRICT"),
+    primary_key=True,
+  ),
+)
+
+# Fact-level aspects. Actuals stay undimensioned (the default member, in
+# XBRL terms) — a row here marks a fact as belonging to an explicit member
+# on some axis. Scenario is the first: forecast facts carry a `scenario`
+# Dimension, so every reader honoring the documented consolidated-totals
+# contract (`has_dimensions = false`) excludes them by construction.
+fact_dimensions = Table(
+  "fact_dimensions",
+  ExtensionsBase.metadata,
+  Column(
+    "fact_id",
+    String,
+    ForeignKey("facts.id", ondelete="CASCADE"),
     primary_key=True,
   ),
   Column(

--- a/robosystems/operations/information_block/forecast.py
+++ b/robosystems/operations/information_block/forecast.py
@@ -49,7 +49,10 @@ from robosystems.models.api.information_block import (
   RenderingRowLite,
   ViewProjections,
 )
-from robosystems.models.extensions import Element, Structure
+from robosystems.models.extensions import Dimension, Element, Structure
+from robosystems.models.extensions.roboledger.dimension_junctions import (
+  fact_dimensions,
+)
 from robosystems.models.extensions.roboledger.fact import Fact
 from robosystems.models.extensions.roboledger.fact_set import FactSet
 from robosystems.operations.information_block.envelope import (
@@ -449,6 +452,33 @@ def _load_lever_fact_set(session: Session, structure_id: str) -> FactSet | None:
   ).scalar_one_or_none()
 
 
+def _ensure_scenario_dimension(session: Session, scenario_id: str, name: str) -> str:
+  """Get-or-create the ``scenario`` Dimension for a forecast Structure.
+
+  ``value`` is the structure id (stable across renames — the unique
+  constraint on ``(dimension_type, value)`` makes this idempotent);
+  ``name`` carries the display legibility. Shared by both scenario fact
+  producers: the lever-set writer here and ``_upsert_month_set`` in
+  :mod:`.forecast_compute`.
+  """
+  existing = session.execute(
+    select(Dimension.id).where(
+      Dimension.dimension_type == "scenario",
+      Dimension.value == scenario_id,
+    )
+  ).scalar_one_or_none()
+  if existing is not None:
+    return existing
+  dimension = Dimension(
+    dimension_type="scenario",
+    name=name,
+    value=scenario_id,
+  )
+  session.add(dimension)
+  session.flush()
+  return dimension.id
+
+
 def _write_lever_fact_set(
   session: Session,
   structure: Structure,
@@ -498,11 +528,13 @@ def _write_lever_fact_set(
     .all()
   }
 
+  new_facts: list[Fact] = []
+
   def _add_fact(element_id: str, month: str, value: float, period_type: str) -> None:
     element = elements_by_id.get(element_id)
     unit = _metric_unit(element) if element is not None else "pure"
     month_start, month_end = period_date_range(month)
-    session.add(
+    new_facts.append(
       Fact(
         id=generate_prefixed_ulid("fact"),
         element_id=element_id,
@@ -524,7 +556,19 @@ def _write_lever_fact_set(
   for assertion in mechanics.line_assertions:
     for month, value in sorted(assertion.values_by_period.items()):
       _add_fact(assertion.element_id, month, value, assertion.period_type)
+  session.add_all(new_facts)
   session.flush()
+  if new_facts:
+    scenario_dimension_id = _ensure_scenario_dimension(
+      session, structure.id, structure.name or structure.id
+    )
+    session.execute(
+      fact_dimensions.insert(),
+      [
+        {"fact_id": fact.id, "dimension_id": scenario_dimension_id}
+        for fact in new_facts
+      ],
+    )
   return fact_set
 
 

--- a/robosystems/operations/information_block/forecast_compute.py
+++ b/robosystems/operations/information_block/forecast_compute.py
@@ -61,10 +61,14 @@ from robosystems.models.extensions import (
   Rule,
   Structure,
 )
+from robosystems.models.extensions.roboledger.dimension_junctions import (
+  fact_dimensions,
+)
 from robosystems.models.extensions.roboledger.fact import Fact
 from robosystems.models.extensions.roboledger.fact_set import FactSet
 from robosystems.operations.information_block.forecast import (
   FORECAST_BLOCK_TYPE,
+  _ensure_scenario_dimension,
   _load_lever_fact_set,
 )
 from robosystems.operations.information_block.forecast_articulation import (
@@ -201,6 +205,9 @@ def cmd_compute_forecast(
       f"{body.structure_id!r} is {structure.block_type!r}"
     )
   scenario_id = structure.id
+  scenario_dimension_id = _ensure_scenario_dimension(
+    session, scenario_id, structure.name or scenario_id
+  )
   mechanics = ForecastMechanics.model_validate(structure.artifact_mechanics or {})
 
   months_n = body.months or mechanics.horizon_months
@@ -863,6 +870,7 @@ def cmd_compute_forecast(
       structure_id=is_structure_id,
       entity_id=entity_id,
       scenario_id=scenario_id,
+      scenario_dimension_id=scenario_dimension_id,
       period_start=month_start,
       period_end=month_end,
       provenance=provenance,
@@ -876,6 +884,7 @@ def cmd_compute_forecast(
         structure_id=bs_structure_id,
         entity_id=entity_id,
         scenario_id=scenario_id,
+        scenario_dimension_id=scenario_dimension_id,
         period_start=month_start,
         period_end=month_end,
         provenance=provenance,
@@ -889,6 +898,7 @@ def cmd_compute_forecast(
         structure_id=ctx.cf_structure_id,
         entity_id=entity_id,
         scenario_id=scenario_id,
+        scenario_dimension_id=scenario_dimension_id,
         period_start=month_start,
         period_end=month_end,
         provenance=provenance,
@@ -1162,6 +1172,7 @@ def _upsert_month_set(
   structure_id: str,
   entity_id: str,
   scenario_id: str,
+  scenario_dimension_id: str,
   period_start: date,
   period_end: date,
   provenance: ForecastProvenance,
@@ -1169,7 +1180,13 @@ def _upsert_month_set(
   facts: list[tuple[Element, float]],
 ) -> str | None:
   """Upsert one scenario standing set — the metrics full-replace pattern,
-  keyed by (structure, entity, factset_type, period_end, **scenario**)."""
+  keyed by (structure, entity, factset_type, period_end, **scenario**).
+
+  Every emitted fact is stamped with the scenario Dimension via
+  ``fact_dimensions`` — the explicit-member half of the default-member
+  rule (actuals carry no dimension rows and stay in consolidated
+  totals; scenario facts carry one and drop out for any reader
+  honoring the ``has_dimensions`` contract)."""
   if not facts:
     return None
   standing = session.execute(
@@ -1208,9 +1225,10 @@ def _upsert_month_set(
       session.delete(fact)
     standing.provenance = provenance.model_dump(mode="json")
 
+  new_facts: list[Fact] = []
   for element, value in facts:
     period_type = element.period_type or "duration"
-    session.add(
+    new_facts.append(
       Fact(
         id=generate_prefixed_ulid("fact"),
         element_id=element.id,
@@ -1225,7 +1243,12 @@ def _upsert_month_set(
         fact_set_id=standing.id,
       )
     )
+  session.add_all(new_facts)
   session.flush()
+  session.execute(
+    fact_dimensions.insert(),
+    [{"fact_id": fact.id, "dimension_id": scenario_dimension_id} for fact in new_facts],
+  )
   return standing.id
 
 

--- a/tests/operations/information_block/test_forecast_compute.py
+++ b/tests/operations/information_block/test_forecast_compute.py
@@ -250,6 +250,7 @@ def _session(structure: Any) -> MagicMock:
 def _structure(mechanics: dict) -> SimpleNamespace:
   return SimpleNamespace(
     id="struct_budget",
+    name="Budget Scenario",
     block_type="forecast",
     artifact_mechanics=mechanics,
   )
@@ -850,6 +851,7 @@ class TestUpsertMonthSet:
     session.execute.return_value.scalar_one_or_none.return_value = None
     added: list[Any] = []
     session.add.side_effect = added.append
+    session.add_all.side_effect = added.extend
 
     from robosystems.models.api.fact_provenance import ForecastProvenance
 
@@ -867,6 +869,7 @@ class TestUpsertMonthSet:
         structure_id="struct_is",
         entity_id="ent_1",
         scenario_id="struct_budget",
+        scenario_dimension_id="dim_scn_budget",
         period_start=date(2026, 7, 1),
         period_end=JUL,
         provenance=provenance,
@@ -898,7 +901,8 @@ class TestUpsertMonthSet:
     first.scalar_one_or_none.return_value = standing
     second = MagicMock()
     second.scalars.return_value.all.return_value = old_facts
-    session.execute.side_effect = [first, second]
+    # Third execute: the fact_dimensions junction insert.
+    session.execute.side_effect = [first, second, MagicMock()]
 
     from robosystems.models.api.fact_provenance import ForecastProvenance
 
@@ -913,6 +917,7 @@ class TestUpsertMonthSet:
       structure_id="struct_is",
       entity_id="ent_1",
       scenario_id="struct_budget",
+      scenario_dimension_id="dim_scn_budget",
       period_start=date(2026, 7, 1),
       period_end=JUL,
       provenance=provenance,
@@ -935,6 +940,7 @@ class TestUpsertMonthSet:
       structure_id="struct_bs",
       entity_id="ent_1",
       scenario_id="struct_budget",
+      scenario_dimension_id="dim_scn_budget",
       period_start=date(2026, 7, 1),
       period_end=JUL,
       provenance=ForecastProvenance(
@@ -947,3 +953,59 @@ class TestUpsertMonthSet:
     )
     assert result is None
     session.execute.assert_not_called()
+
+  def test_new_facts_are_stamped_with_the_scenario_dimension(self) -> None:
+    """Every emitted fact gets a fact_dimensions row pairing it with the
+    scenario Dimension — the explicit-member half of the default-member
+    rule. Actuals never pass through this path, so they stay unrowed."""
+    session = MagicMock()
+    session.execute.return_value.scalar_one_or_none.return_value = None
+
+    from robosystems.models.api.fact_provenance import ForecastProvenance
+
+    with patch.object(fc, "create_fact_set", return_value=SimpleNamespace(id="fs_new")):
+      fc._upsert_month_set(
+        session,
+        structure_id="struct_is",
+        entity_id="ent_1",
+        scenario_id="struct_budget",
+        scenario_dimension_id="dim_scn_budget",
+        period_start=date(2026, 7, 1),
+        period_end=JUL,
+        provenance=ForecastProvenance(
+          scenario_structure_id="struct_budget",
+          base_period="2026-06",
+          month_index=1,
+        ),
+        created_by="usr_test",
+        facts=[(EL_REV, 103.0), (EL_AR, 154.5)],
+      )
+
+    (new_facts,) = session.add_all.call_args.args
+    insert_call = session.execute.call_args
+    rows = insert_call.args[1]
+    assert {r["fact_id"] for r in rows} == {f.id for f in new_facts}
+    assert {r["dimension_id"] for r in rows} == {"dim_scn_budget"}
+
+
+class TestEnsureScenarioDimension:
+  def test_returns_existing_dimension_id(self) -> None:
+    session = MagicMock()
+    session.execute.return_value.scalar_one_or_none.return_value = "dim_existing"
+
+    assert fc._ensure_scenario_dimension(session, "struct_a", "Scenario A") == (
+      "dim_existing"
+    )
+    session.add.assert_not_called()
+
+  def test_creates_when_absent(self) -> None:
+    session = MagicMock()
+    session.execute.return_value.scalar_one_or_none.return_value = None
+
+    fc._ensure_scenario_dimension(session, "struct_a", "Scenario A")
+
+    (dimension,) = session.add.call_args.args
+    assert dimension.dimension_type == "scenario"
+    assert dimension.value == "struct_a"
+    assert dimension.name == "Scenario A"
+    session.flush.assert_called_once()

--- a/tests/operations/information_block/test_forecast_handlers.py
+++ b/tests/operations/information_block/test_forecast_handlers.py
@@ -548,7 +548,7 @@ class TestCreate:
 
 class TestWriteLeverFactSet:
   def test_self_referential_scenario_set_with_asserted_provenance(self) -> None:
-    structure = SimpleNamespace(id="struct_budget_01")
+    structure = SimpleNamespace(id="struct_budget_01", name="Budget 01")
     mechanics = ForecastMechanics(
       scenario_kind="budget",
       horizon_months=2,
@@ -566,6 +566,7 @@ class TestWriteLeverFactSet:
     session.execute.return_value.scalars.return_value.all.return_value = [GROWTH]
     added_facts: list[Any] = []
     session.add.side_effect = added_facts.append
+    session.add_all.side_effect = added_facts.extend
 
     with patch.object(
       forecast_handlers,
@@ -598,7 +599,7 @@ class TestWriteLeverFactSet:
     assert first.unit == "pure"  # percent → 'pure'
 
   def test_line_assertions_ride_the_same_set_with_typed_periods(self) -> None:
-    structure = SimpleNamespace(id="struct_budget_01")
+    structure = SimpleNamespace(id="struct_budget_01", name="Budget 01")
     mechanics = ForecastMechanics(
       scenario_kind="budget",
       horizon_months=2,
@@ -625,6 +626,7 @@ class TestWriteLeverFactSet:
     session.execute.return_value.scalars.return_value.all.return_value = [GROWTH, LOAN]
     added_facts: list[Any] = []
     session.add.side_effect = added_facts.append
+    session.add_all.side_effect = added_facts.extend
 
     with patch.object(
       forecast_handlers,


### PR DESCRIPTION
## Summary

Scenario is an aspect of a fact — which world a number belongs to, exactly as period answers "when" and entity answers "whose" — and is now modelled as one. Facts were the only ledger noun without a dimension link (transactions, entries, line items, and events all carry junctions to the base `Dimension` model); scenario identity lived only on the containing FactSet, an indirection the ontology work explicitly bans for every other aspect. This PR lands the OLTP half: the junction table, native stamping in both scenario fact producers, and a backfill. It ships entirely behind the materializer's existing scenario exclusion — the graph projection is deliberately untouched, so nothing reader-facing changes until the reader-conformance audit is done.

## Changes

- **`models/extensions/roboledger/dimension_junctions.py`** — `fact_dimensions` junction, mirroring the existing tables exactly: fact side CASCADE (a tag is meaningless without its fact), dimension side RESTRICT (dimensions are shared reference data).
- **`migrations/extensions/versions/0026_fact_dimensions.py`** — creates the table in `public` and every existing tenant schema via the `for_each_tenant_schema` pattern; new schemas get it from `metadata.create_all`. Hand-written: autogenerate produced destructive noise against schema-per-tenant tenancy (it wanted to drop live FKs and a partial index) and was discarded.
- **`migrations/extensions/versions/0027_scenario_dimension_backfill.py`** — pure derivation, no value changes: one `scenario` Dimension per distinct `fact_sets.scenario_id` (named from the owning forecast Structure; deterministic ids make re-runs idempotent alongside the `(dimension_type, value)` unique constraint), then one junction row per fact in a scenario-keyed set. Actuals get no rows — the XBRL default-member rule, anchored on `srt:StatementScenarioAxis` semantics. Reversible downgrade removes exactly what it created.
- **`operations/information_block/forecast.py` + `forecast_compute.py`** — both scenario fact producers stamp natively: the lever-set writer (`_write_lever_fact_set`) and the derived-month writer (`_upsert_month_set`) pair every emitted fact with the scenario Dimension via a shared `_ensure_scenario_dimension` (get-or-create; `value` = structure id, stable across renames; `name` = display legibility). The helper lives in `forecast.py` because `forecast_compute` already imports from it — the reverse would cycle. Reviewers should note the two-producer coverage: lever sets are also scenario-keyed, and stamping only the compute path would have left lever facts posing as undimensioned actuals once the projection eventually flips.
- **Tests** — junction-stamping and get-or-create tests in `test_forecast_compute.py`; existing fixtures extended (`SimpleNamespace` structures gain `name`, `add_all` routed into fact collectors).

## Breaking Changes

None. No public API surface changes — no GraphQL schema, operations envelope, or REST shape is touched. OLTP-only, additive, and the materializer's scenario exclusion keeps all of it out of the graph projection.

## Testing

- `just test` — full unit suite: 12,194 passed, 24 skipped.
- `just test-code` — ruff, format, basedpyright, cf-lint: all clean.
- Migrations applied locally against a multi-tenant extensions DB (public + two tenant schemas); the backfill verified against a local copy of production-shaped data — it landed exactly the row count the source join predicts, across all four scenarios, with legible dimension names.
- Live smoke test through the operations surface: forecast block created → lever facts stamped at create → block deleted → junction rows and facts cascaded, the Dimension row surviving as inert reference data (RESTRICT semantics, intended).
