### PR TITLE
Pin robosystems-client 1.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     # RoboSystems client for demo and testing
-    "robosystems-client==1.3.0",
+    "robosystems-client==1.4.0",
 
     # Testing framework
     "pytest>=9.0.0,<10.0",

--- a/uv.lock
+++ b/uv.lock
@@ -3699,7 +3699,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.34.2,<3.0" },
     { name = "retrying", specifier = ">=1.4.0,<2.0" },
     { name = "rich", marker = "extra == 'dev'", specifier = ">=15.0.0,<16.0" },
-    { name = "robosystems-client", marker = "extra == 'dev'", specifier = "==1.3.0" },
+    { name = "robosystems-client", marker = "extra == 'dev'", specifier = "==1.4.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0,<1.0" },
     { name = "sqlalchemy", specifier = ">=2.0.0,<3.0" },
     { name = "sse-starlette", specifier = ">=3.3.0,<4.0" },
@@ -3722,7 +3722,7 @@ lambda = [
 
 [[package]]
 name = "robosystems-client"
-version = "1.3.0"
+version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -3730,9 +3730,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ed/78/66169b66288a079b56ecb91e121300d5d55f8c033ae6d2db1bf193f4d42c/robosystems_client-1.3.0.tar.gz", hash = "sha256:59cea8f5ee3d93785bb55d3a28f8488a12f110306b45baa6069d3006d0a3ca20", size = 512255, upload-time = "2026-08-07T06:38:09.538Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/61/8f/f79cc4c529bfef5eb5cc834eda655dfe588a40f1ab763b34c3f7fe3244c1/robosystems_client-1.4.0.tar.gz", hash = "sha256:351aeff4da3502b052441942b578b16b3e7edb8715126478e28c46e31a879036", size = 512976, upload-time = "2026-08-07T07:05:44.296Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/fd/cadfaa640d098d11f111278b971008c07721b605503d3ea9b4234af7bf65/robosystems_client-1.3.0-py3-none-any.whl", hash = "sha256:5d10510da6724e221dfd122c5dc6b4a259439d85ac45e783241c7a2c32aeb391", size = 1173549, upload-time = "2026-08-07T06:38:08.004Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/f2/2df1009238a562ab694c6d50c24daf789cb5a6df9fd2eeec7b6c37bef937/robosystems_client-1.4.0-py3-none-any.whl", hash = "sha256:b8d717286518eb87f452df395d340262962a51496c0935041d9733eb81a203be", size = 1174000, upload-time = "2026-08-07T07:05:42.638Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Bumps the `examples/` dev pin from 1.3.0 to 1.4.0.

1.3.0 shipped `payload_drift` — the name #1072 retired — because SDK generation reads whatever the local stack is serving, and that stack was running a branch cut before #1072 merged. Restarting it faithfully rebuilt the pre-rename branch; merging upstream changed nothing about what the container served. 1.4.0 corrects it.

Verified on the installed package rather than assumed: `is_reconciling_item` present, `payload_drift` gone, and the fiscal-calendar model carries `stranded_obligation_count`. No example imports a removed symbol; no test imports the client at all.