### PR TITLE
Correct the API description; default the SEC connection off

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -231,8 +231,11 @@ SECURITY_AUDIT_ENABLED=false
 
 ## Connection Providers
 # CONNECTIONS_ENABLED=true
-# CONNECTION_SEC_ENABLED=true
 # CONNECTION_QUICKBOOKS_ENABLED=true
+# CONNECTION_EXTERNAL_ENABLED=true
+# Off by default and in every deployed environment — the filing-driven entity
+# creation path predates the shared SEC repository. Set true to bring it back.
+# CONNECTION_SEC_ENABLED=false
 # Route QB Reports API through Intuit's v2 service (ahead of their 2026-08-31
 # hard cutover). Set false to fall back to v1 at runtime. Retires after cutover.
 # INTUIT_REPORTS_TESTING_MIGRATION=true

--- a/README.md
+++ b/README.md
@@ -40,9 +40,10 @@ Accounting and financial reporting extension — a ledger-grade system of record
 
 Built on the blocks:
 
-- **Close lifecycle** — fiscal calendar, close-target catch-up sequencing, and period close/reopen gated on the balance equation and [QuickBooks](https://quickbooks.intuit.com/partners/affiliates?cid=par_pim_4TcakSEFQs73) sync-staleness
+- **Close lifecycle** — fiscal calendar, close-target catch-up sequencing, and period close/reopen gated on the balance equation, [QuickBooks](https://quickbooks.intuit.com/partners/affiliates?cid=par_pim_4TcakSEFQs73) sync-staleness, and outstanding schedule obligations; every blocker names what is holding the close
 - **Mapping** — CoA→GAAP mapping associations plus AI-assisted bulk mapping via the **MappingOperator** (confidence-tiered: auto-approve / review / skip)
 - **Reporting** — multi-period reports rendered from shared facts through a Reporting Style; a report lifecycle (draft → under_review → filed → archived) with publish lists for distribution
+- **Forecasting** — operating-plan scenarios projected through the same statement structures: rule-driven forecasts, per-line growth trajectories, and manual line assertions, with forecast periods returned alongside actuals on statement reads
 - **Analytical operations** — `live-financial-statement` renders a statement straight from the OLTP ledger (no materialization required); `build-fact-grid` and `financial-statement-analysis` query the materialized XBRL hypercube in the graph
 - **Serialization** — reports serialize to web-native **JSON-LD** (stored, SHACL-validatable) and filing-grade **XBRL 2.1** (rebuilt on demand, Arelle-validated)
 - **Pipelines & data** — QuickBooks ELT via dbt/Dagster with a configurable `write_policy`, and SEC XBRL financial reporting

--- a/robosystems/config/env.py
+++ b/robosystems/config/env.py
@@ -657,9 +657,14 @@ class EnvConfig:
     get_parameter_value("CONNECTIONS_ENABLED", "true").lower() == "true",
   )
   # Individual provider flags (require CONNECTIONS_ENABLED=true)
+  # Defaults off: the SEC connection is a filing-driven entity-creation path
+  # that predates the shared SEC repository, and it is disabled in every
+  # deployed environment. Keeping the default on meant local dev registered a
+  # provider prod does not, and a fresh deployment would have shipped it live.
+  # The provider itself is intact — flip the flag to bring it back.
   CONNECTION_SEC_ENABLED = get_bool_env(
     "CONNECTION_SEC_ENABLED",
-    get_parameter_value("CONNECTION_SEC_ENABLED", "true").lower() == "true",
+    get_parameter_value("CONNECTION_SEC_ENABLED", "false").lower() == "true",
   )
   CONNECTION_QUICKBOOKS_ENABLED = get_bool_env(
     "CONNECTION_QUICKBOOKS_ENABLED",

--- a/static/description.md
+++ b/static/description.md
@@ -27,9 +27,10 @@ The core platform surface for querying and managing graphs. Reads are REST `GET`
 
 **Graph and infrastructure state:**
 
-- **Subgraphs**: List subgraphs, quota, and storage information
+- **Subgraphs**: List subgraphs with per-subgraph storage information
 - **Backups**: List backups, download URLs, and storage statistics (each backup reports its `download_extension` — `.lbug.zip` or zstd `.lbug.zst`)
 - **Usage**: Graph content metrics and consumption usage (storage, credits)
+- **Limits**: Tier limits and capacity in one read — storage, queries, rate limits, and the count-based caps on documents and subgraphs
 
 **Lifecycle commands** (`/operations/{op_name}`):
 
@@ -57,8 +58,8 @@ Reads are REST `GET`s; content writes share the same `/operations/{op_name}` env
 ### Data Synchronization
 
 - **Connections**: Provider connections with OAuth flows, sync triggers, and status
-- **SEC Filings**: Process XBRL documents and build filing knowledge graphs
-- **QuickBooks**: Sync transactions, accounts, and financial reports
+- **QuickBooks**: Sync transactions, accounts, and counterparties
+- **External sources**: Register a source namespace for integrations that run outside the platform and write through the public API — registration only, no credentials and no sync
 
 ### Extensions Surface
 


### PR DESCRIPTION
A description pass that turned up one config change worth making with it.

## Stale surface in the description

**Subgraphs no longer reports quota.** That data moved onto `GET /limits` when the dedicated `/subgraphs/quota` route came out (#1073), so the description was promising a field the endpoint had stopped returning.

**`/limits` was undocumented** despite now being the single read for tier capacity — storage, queries, rate limits, and the count-based caps on documents and subgraphs. It gets a line.

## The SEC connection: advertised, but dead where it counts

`CONNECTION_SEC_ENABLED` is `false` in **both prod and staging** SSM, and has been. Only the *code* default said `true` — so local dev registered a provider no deployed environment has, and a fresh deployment would have shipped it live.

The default now matches reality. **Nothing is deleted**: `sec_provider.py`, `SECConnectionConfig`, and `sec` in the `ProviderType` union all stay. That keeps this a flag flip rather than an API change — narrowing a published union would be breaking for TypeScript consumers and would cost a client major, for a provider nobody can currently reach. Flip the flag to revive the path.

Its bullet comes out of the description on the same principle that governs the tracked command files: public text should describe what's live, not a surface that isn't.

## The external provider is the opposite case

`CONNECTION_EXTERNAL_ENABLED` has no SSM override, so it runs on its `true` default — **live in prod, and documented nowhere.** It registers a source namespace for integrations that run outside the platform and write through the public API (registration only; no credentials, no sync), which is directly relevant to the custom-integration plane. Now documented, and added to `.env.example` alongside the others.

## README

Two gaps, both from features landing without the README following:

- **Forecasting was missing entirely** from RoboLedger's feature list — the operating-plan arc has shipped and been prod-validated, and `static/description.md` already described it.
- **The close-lifecycle line predated the obligation gates.** It listed the balance equation and sync-staleness; obligations now gate a close too, and every blocker names what is holding it.

## Verification

Flag defaults are read by `tests/config` and the disabled-provider path has its own coverage (`test_disabled_providers.py`), so the flip is exercised rather than assumed.

Full unit suite: 12,225 passed. Code quality clean.