### PR TITLE
Subgraphs as first-class MCP citizens: tool cut, reachable address, honest size

### DIFF
--- a/robosystems/adapters/sec/manifest.py
+++ b/robosystems/adapters/sec/manifest.py
@@ -43,7 +43,7 @@ SEC_MANIFEST = SharedRepositoryManifest(
     "\n"
     "NOTES\n"
     "- Deeper historical filings live in the `sec_historical` subgraph — switch "
-    "to it with `switch-workspace` when you need older periods.\n"
+    "to it with `resolve-subgraph` when you need older periods.\n"
     "- This is shared public data: period close, chart-of-accounts mapping, and "
     "all write operations are unavailable here."
   ),

--- a/robosystems/middleware/mcp/README.md
+++ b/robosystems/middleware/mcp/README.md
@@ -12,7 +12,7 @@ The MCP middleware:
 - Handles query validation and complexity management
 - Integrates with the Graph API for backend communication
 - Supports both shared repositories (SEC) and user graphs
-- Enables workspace management for isolated development environments
+- Enables subgraph navigation for isolated development environments
 - Provides data operation tools for staging, querying, and graph materialization
 
 **Operations kernel integration.** MCP tools are a **transport layer**, not a domain. Tools that touch extension OLTP data (period close, fiscal calendar, CoA→GAAP mapping, information blocks, events) delegate directly to the same `operations/roboledger/{reads,commands}/*` functions that the GraphQL resolvers and the named command operation routers call. An information block created via the `create-information-block` MCP tool goes through the exact same operations function as one created via `POST /extensions/roboledger/{g}/operations/create-information-block`. This is the single-source-of-truth contract that makes agent-driven workflows byte-identical to UI-driven workflows. Never add business logic to an MCP tool file — wire it into `operations/` and have the tool delegate.
@@ -60,14 +60,14 @@ mcp/
     ├── playbook_tools.py           # get-close-playbook (close-workflow guidance)
     ├── graph_tools.py              # create-subgraph, delete-subgraph, list-subgraphs,
     │                               # materialize, get-graph-sync-status, create-backup,
-    │                               # set-write-policy, switch-workspace (client-side)
+    │                               # set-write-policy, resolve-subgraph
     │
     │ # Layer 3: Document search + management (SEMANTIC_SEARCH_ENABLED)
     ├── search_tools.py      # search-documents, get-document-section
     ├── document_tools.py    # create-document, update-document, get-document, list-documents
     │
     │ # Layer 4: Infrastructure (feature-flag gated)
-    │ # (switch-workspace lives in graph_tools.py; it is a client-side tool)
+    │ # (resolve-subgraph lives in graph_tools.py; answered by the remote transport)
     └── subgraph_write_tools.py  # write-graph-cypher, add-node-table, add-relationship-table (MCP_SUBGRAPH_OPS_ENABLED)
 ```
 
@@ -205,18 +205,24 @@ Gated by `SEMANTIC_SEARCH_ENABLED`. Document management tools additionally skip 
 
 ### Layer 4: Infrastructure (feature-flag gated)
 
-**Workspaces:**
+**Subgraph navigation:**
 
-Only `switch-workspace` is registered. It is a **client-side** tool
-(defined in `graph_tools.py`): the MCP client intercepts it to retarget
-the active graph context before sending; there is no server handler.
-There are no `list-workspaces` / `create-workspace` / `delete-workspace`
-tools — create a subgraph with `create-subgraph` and then point
-`switch-workspace` (or the `graph_id`) at it.
+`resolve-subgraph` maps a subgraph in this graph's family to the MCP
+endpoint that serves it. It does **not** switch: a connector is anchored to
+one graph by its URL, so the remote transport answers with an address and
+the caller adds that endpoint as its own connector, reusing the same API
+key. Create with `create-subgraph` (which returns the URL directly), then
+`list-subgraphs` to enumerate and `resolve-subgraph` to address.
+
+It was called `switch-workspace`. The name promised a switch it never
+performed on the remote transport, and "workspace" framed a subgraph as a
+context you inhabit rather than the lightweight artifact it is. The old
+name is still dispatched, unadvertised, so existing prompts and older
+bridge versions keep working.
 
 | Tool | Description | Read-only OK |
 |------|-------------|--------------|
-| `switch-workspace` | Switch active workspace context (client-side) | Yes |
+| `resolve-subgraph` | Resolve a subgraph to its MCP endpoint | Yes |
 
 **Subgraph writes** (`MCP_SUBGRAPH_OPS_ENABLED`, writable subgraphs only):
 
@@ -237,7 +243,7 @@ tools — create a subgraph with `create-subgraph` and then point
 | Manifest `has_semantic_enrichment=True` | `resolve-element` |
 | `FACT_GRID_ENABLED=true` | `build-fact-grid` |
 | `SEMANTIC_SEARCH_ENABLED=true` | Layer 3 (search + document management) |
-| `MCP_WORKSPACE_ENABLED=true` | Graph-lifecycle tools (`create-subgraph`, `delete-subgraph`, `create-backup`, `switch-workspace`) |
+| `MCP_WORKSPACE_ENABLED=true` | Graph-lifecycle tools (`create-subgraph`, `delete-subgraph`, `create-backup`, `resolve-subgraph`) |
 | `MCP_SUBGRAPH_OPS_ENABLED=true` | Layer 4 subgraph write/DDL tools |
 
 A tool that would otherwise be unavailable due to any of these gates returns a structured error via `_tool_unavailable_reason` instead of silently no-oping — clients always see a typed reason when a tool isn't mounted in a given context.
@@ -388,7 +394,7 @@ ROBOLEDGER_ENABLED=true                # Enables all Layer 2b roboledger OLTP to
 ROBOINVESTOR_ENABLED=false             # Parallel flag for future roboinvestor OLTP MCP tools (no such tools exist today)
 FACT_GRID_ENABLED=false                # Gates build-fact-grid tool
 SEMANTIC_SEARCH_ENABLED=false          # Gates search-documents, get-document-section, and Layer 3 document management tools
-MCP_WORKSPACE_ENABLED=false            # Gates Layer 4 workspace tools
+MCP_WORKSPACE_ENABLED=false            # Gates Layer 4 subgraph navigation + lifecycle tools
 MCP_SUBGRAPH_OPS_ENABLED=false         # Gates Layer 4 subgraph write/DDL tools (write-cypher, add-node/rel-table)
 ```
 

--- a/robosystems/middleware/mcp/tools/__init__.py
+++ b/robosystems/middleware/mcp/tools/__init__.py
@@ -16,7 +16,7 @@ from .graph_tools import (
   GetGraphSyncStatusTool,
   ListSubgraphsTool,
   MaterializeTool,
-  SwitchWorkspaceTool,
+  ResolveSubgraphTool,
 )
 from .graphql_tool import GraphqlQueryTool, GraphqlSchemaTool
 from .manager import GraphMCPTools
@@ -45,7 +45,7 @@ __all__ = [
   "ListSubgraphsTool",
   "MaterializeTool",
   "ResolveElementTool",
+  "ResolveSubgraphTool",
   "SchemaTool",
-  "SwitchWorkspaceTool",
   "WriteCypherTool",
 ]

--- a/robosystems/middleware/mcp/tools/graph_tools.py
+++ b/robosystems/middleware/mcp/tools/graph_tools.py
@@ -394,7 +394,7 @@ class ListSubgraphsTool:
       "description": (
         "List every subgraph (workspace) under this parent graph, plus the "
         "parent itself as the `primary` entry. Use the returned "
-        "`subgraph_id` with `switch-workspace` or as the `graph_id` in "
+        "`subgraph_id` with `resolve-subgraph` or as the `graph_id` in "
         "future tool calls."
       ),
       "inputSchema": {
@@ -917,16 +917,25 @@ class SyncConnectionTool:
 
 
 # ══════════════════════════════════════════════════════════════════════════
-# switch-workspace (kept name for backwards compat — client-side only)
+# resolve-subgraph (was switch-workspace)
 # ══════════════════════════════════════════════════════════════════════════
 
 
-class SwitchWorkspaceTool:
-  """Client-side workspace switcher.
+class ResolveSubgraphTool:
+  """Resolve a subgraph in this graph's family to its MCP endpoint.
 
-  The MCP client intercepts `switch-workspace` before sending; the
-  server-side execute is a no-op error. Kept as-is (name + behavior)
-  because the client already treats it as a sentinel.
+  Named for what it does. It was `switch-workspace`, which promised a switch
+  it has never performed on the remote transport: a connector is anchored to
+  one graph by its URL, so the remote handler answers with an address rather
+  than changing anything (see `_remote_resolve_subgraph`).
+
+  The "workspace" framing went with it. A subgraph is a lightweight artifact
+  — closer to a document or a memory than to a context you inhabit — and
+  calling it a workspace invited exactly the session-switching model the URL
+  anchor rules out.
+
+  The retired wire name `switch-workspace` stays accepted at dispatch (never
+  advertised) so saved prompts and older bridges keep working.
   """
 
   def __init__(self, graph_client):
@@ -934,35 +943,36 @@ class SwitchWorkspaceTool:
 
   def get_tool_definition(self) -> dict[str, Any]:
     return {
-      "name": "switch-workspace",
+      "name": "resolve-subgraph",
       "description": (
-        "Switch the active graph context to a different subgraph (or "
-        "`primary` to return to the parent). **Client-side tool** — the "
-        "MCP client should intercept this locally rather than calling the "
-        "server. Server-side invocation returns an error."
+        "Resolve a subgraph in this graph's family to the MCP endpoint that "
+        "serves it, so you can reach it. This connector is anchored to one "
+        "graph by its URL and does not change graphs — the subgraph is a "
+        "separate endpoint you add as its own connector, reusing this "
+        "connector's API key. Pair with `list-subgraphs` to see what exists."
       ),
       "inputSchema": {
         "type": "object",
         "properties": {
-          "workspace_id": {
+          "subgraph": {
             "type": "string",
             "description": (
-              "Target subgraph id (e.g. `kg123_dev`), or `primary` to "
-              "switch to the parent graph."
+              "Subgraph id (e.g. `kg123_dev`), its short name (`dev`), or "
+              "`primary` for the parent graph."
             ),
           },
         },
-        "required": ["workspace_id"],
+        "required": ["subgraph"],
         "additionalProperties": False,
       },
     }
 
   async def execute(self, arguments: dict[str, Any]) -> dict[str, Any]:
     return {
-      "error": "client_side_tool",
+      "error": "remote_transport_only",
       "message": (
-        "switch-workspace is a client-side tool. The MCP client should "
-        "intercept it locally rather than calling the server."
+        "resolve-subgraph is answered by the remote MCP transport, which "
+        "knows this connector's URL. Call it over the graph's /mcp endpoint."
       ),
     }
 

--- a/robosystems/middleware/mcp/tools/graph_tools.py
+++ b/robosystems/middleware/mcp/tools/graph_tools.py
@@ -137,8 +137,12 @@ class CreateSubgraphTool:
         "- name: Alphanumeric only, 1-20 chars (no hyphens or underscores)\n"
         "- fork_parent: Copy all parent data into the new subgraph\n"
         "- subgraph_type: `static` (default), `knowledge` (auto-includes the knowledge schema), or `empty` (bare database, no schema — define your own)\n\n"
-        "**RETURNS:** `subgraph_id` (format: `{parent_graph_id}_{name}`) — use it "
-        "as the `graph_id` in future tool calls to target the new subgraph."
+        "**RETURNS:** `subgraph_id` (format: `{parent_graph_id}_{name}`) and "
+        "`connector_url`. A subgraph is a separate MCP endpoint, not a mode of "
+        "this one: this connector is anchored to its own graph by URL and "
+        "cannot reach the new subgraph. To work in it, add an MCP connector "
+        "for `connector_url` — the API key this connector already uses covers "
+        "its own subgraphs, so reuse it as-is rather than generating a new one."
       ),
       "inputSchema": {
         "type": "object",
@@ -225,14 +229,30 @@ class CreateSubgraphTool:
         logger.error("create-subgraph failed for %s: %s", parent_graph_id, exc)
         return {"error": "create_failed", "message": str(exc)}
 
+      # An id with no way to reach it is the whole friction here: under the
+      # stdio bridge you created then switched in-session, but a remote
+      # connector is URL-anchored, so the caller needs the address and the
+      # (already-satisfied) credential answer handed to them, not inferred.
+      from robosystems.config import env
+
+      subgraph_id = result.get("graph_id")
       return {
-        "subgraph_id": result.get("graph_id"),
+        "subgraph_id": subgraph_id,
         "name": name,
         "parent_graph_id": parent_graph_id,
         "description": description,
         "forked_from_parent": fork_parent,
         "subgraph_type": subgraph_type,
         "operation_id": result.get("operation_id"),
+        "connector_url": f"{env.ROBOSYSTEMS_API_URL}/v1/graphs/{subgraph_id}/mcp",
+        "credential": (
+          "Reuse this connector's API key — a key scoped to "
+          f"'{parent_graph_id}' covers its subgraphs. No new key needed."
+        ),
+        "next_step": (
+          "Add an MCP connector for connector_url. This connector is anchored "
+          "to its own graph by URL and cannot switch to the new subgraph."
+        ),
       }
     finally:
       close()

--- a/robosystems/middleware/mcp/tools/instructions.py
+++ b/robosystems/middleware/mcp/tools/instructions.py
@@ -2,7 +2,7 @@
 Per-graph MCP instructions generator.
 
 Produces the routing guidance handed to MCP clients via the server's
-`instructions` handshake field (and the `switch-workspace` tool result). The
+`instructions` handshake field (and the `resolve-subgraph` tool result). The
 string is always in the connected agent's context, so it stays short and points
 at the live tool *families* rather than restating each tool's schema — the
 discovery layer that tells an agent which tool to reach for, given an intent.

--- a/robosystems/middleware/mcp/tools/manager.py
+++ b/robosystems/middleware/mcp/tools/manager.py
@@ -7,7 +7,7 @@ functionality for interacting with graph databases.
 Tool availability is schema-driven:
 - Core tools (cypher, schema) are always available
 - Extension tools (financial statements, etc.) require matching schema_extensions
-- Infrastructure tools (workspace, subgraph writes) are gated by feature flags
+- Infrastructure tools (subgraph navigation + writes) are gated by feature flags
 
 **Registrar-generated tools:** Extensions with an `OperationRegistrar`
 (roboledger, roboinvestor) contribute their `OperationSpec`s as
@@ -39,8 +39,8 @@ from .graph_tools import (
   GetGraphSyncStatusTool,
   ListSubgraphsTool,
   MaterializeTool,
+  ResolveSubgraphTool,
   SetWritePolicyTool,
-  SwitchWorkspaceTool,
   SyncConnectionTool,
 )
 from .graphql_tool import GraphqlQueryTool, GraphqlSchemaTool
@@ -98,7 +98,8 @@ SUBGRAPH_TOOL_PROFILE = frozenset(
     "update-memory",
     # Navigation back out
     "list-subgraphs",
-    "switch-workspace",
+    "resolve-subgraph",
+    "switch-workspace",  # retired alias, still dispatched
   }
 )
 
@@ -158,7 +159,7 @@ class GraphMCPTools:
   Tool availability is layered:
   - Layer 1 (Core): cypher, schema — always available
   - Layer 2 (Schema): financial tools — only when schema_extensions includes "roboledger"
-  - Layer 3 (Infrastructure): workspace, subgraph writes, data — gated by feature flags
+  - Layer 3 (Infrastructure): subgraph navigation + writes, data — gated by feature flags
   """
 
   def __init__(
@@ -226,9 +227,8 @@ class GraphMCPTools:
 
     # Layer 3: Graph lifecycle tools — subgraph navigation + lifecycle ops
     # mirroring a subset of the REST `/v1/graphs/{g}/operations/*` surface.
-    # Writes are gated by `read_only`; `switch-workspace` is a client-side
-    # sentinel so it stays always-available when the workspace feature
-    # flag is set.
+    # Writes are gated by `read_only`; `resolve-subgraph` only resolves an
+    # address, so it stays available whenever the navigation flag is set.
     #
     # Deliberately **not exposed on MCP** — both still live on REST for
     # humans:
@@ -239,12 +239,12 @@ class GraphMCPTools:
     self.create_subgraph_tool = None
     self.delete_subgraph_tool = None
     self.list_subgraphs_tool = None
-    self.switch_workspace_tool = None
+    self.resolve_subgraph_tool = None
     self.create_backup_tool = None
     if env.MCP_WORKSPACE_ENABLED:
       # Navigation tools (list / switch) — always available.
       self.list_subgraphs_tool = ListSubgraphsTool(graph_client)
-      self.switch_workspace_tool = SwitchWorkspaceTool(graph_client)
+      self.resolve_subgraph_tool = ResolveSubgraphTool(graph_client)
       # Write tools — blocked on shared-repo or read-only graphs.
       if not read_only:
         self.create_subgraph_tool = CreateSubgraphTool(graph_client)
@@ -648,7 +648,7 @@ class GraphMCPTools:
       self.resolve_element_tool.get_tool_definition(),
     ]
 
-  def _get_workspace_tool_definitions(self) -> list[dict[str, Any]]:
+  def _get_navigation_tool_definitions(self) -> list[dict[str, Any]]:
     """
     Get graph-lifecycle tool definitions (navigation + write ops).
 
@@ -658,8 +658,8 @@ class GraphMCPTools:
         are included.
     """
     tools = []
-    if self.switch_workspace_tool is not None:
-      tools.append(self.switch_workspace_tool.get_tool_definition())
+    if self.resolve_subgraph_tool is not None:
+      tools.append(self.resolve_subgraph_tool.get_tool_definition())
     if self.list_subgraphs_tool is not None:
       tools.append(self.list_subgraphs_tool.get_tool_definition())
     if self.create_subgraph_tool is not None:
@@ -885,7 +885,7 @@ class GraphMCPTools:
       tools.extend(self._get_event_block_tool_definitions())
 
     # Layer 3: Infrastructure tools (feature-flag gated)
-    tools.extend(self._get_workspace_tool_definitions())
+    tools.extend(self._get_navigation_tool_definitions())
     if self.set_write_policy_tool is not None:
       tools.append(self.set_write_policy_tool.get_tool_definition())
     if self.sync_connection_tool is not None:
@@ -1091,14 +1091,16 @@ class GraphMCPTools:
         result = await self.list_subgraphs_tool.execute(arguments)
         return result if return_raw else json.dumps(result, indent=2)
 
-      elif name == "switch-workspace":
+      # `switch-workspace` is the retired name, still dispatched so saved
+      # prompts and older bridge versions keep working after the rename.
+      elif name in ("resolve-subgraph", "switch-workspace"):
         # Client-side sentinel — the MCP client should intercept locally.
-        if self.switch_workspace_tool is None:
+        if self.resolve_subgraph_tool is None:
           raise ValueError(
-            "switch-workspace tool is not available. "
+            "resolve-subgraph tool is not available. "
             "Set MCP_WORKSPACE_ENABLED=true to enable this feature."
           )
-        result = await self.switch_workspace_tool.execute(arguments)
+        result = await self.resolve_subgraph_tool.execute(arguments)
         return result if return_raw else json.dumps(result, indent=2)
 
       elif name == "create-backup":

--- a/robosystems/middleware/mcp/tools/manager.py
+++ b/robosystems/middleware/mcp/tools/manager.py
@@ -57,6 +57,52 @@ if TYPE_CHECKING:
   from .registrar import _RegistrarMCPTool
 
 
+# The tool surface a tenant subgraph advertises.
+#
+# A subgraph is a modality container, not an extensions domain target: it has
+# no extensions OLTP schema (`extensions_session` validates `^kg[0-9a-f]{16,}$`,
+# which `{parent}_{name}` cannot match), no connections, and no OLTP→OLAP
+# materialization relationship. It inherits `schema_extensions` from its parent
+# (`subgraph_service` copies the column), so without this cut every roboledger
+# tool registers and roughly seventy percent of the advertised surface fails —
+# the OLTP ones with an internal schema-validator string, the platform ones by
+# confidently answering about a relationship that does not exist.
+#
+# The doctrine is not new: `graphql_tool` has rejected subgraphs on exactly
+# this reasoning since it shipped. This propagates that one-tool decision to
+# the tool-list layer.
+#
+# The short list is the product statement, not a consolation. A subgraph is a
+# live, writable graph database — schema plus Cypher — and it is the *only*
+# such surface, since `_validate_subgraph_context` blocks raw writes on the
+# parent. Naming that plainly is what makes it legible to an agent.
+SUBGRAPH_TOOL_PROFILE = frozenset(
+  {
+    # Schema DDL — the point of a subgraph
+    "add-node-table",
+    "add-relationship-table",
+    "get-graph-schema",
+    # Registered outside this manager (see routers/graphs/mcp), so it never
+    # appears in the list this filter trims. Listed anyway so the call_tool
+    # guard below treats it as allowed rather than refusing a tool that is
+    # perfectly meaningful on a subgraph.
+    "get-graph-info",
+    # Cypher, both directions
+    "read-graph-cypher",
+    "write-graph-cypher",
+    "get-example-queries",
+    # Per-graph semantic memory (LanceDB, genuinely per-graph)
+    "recall",
+    "remember",
+    "forget",
+    "update-memory",
+    # Navigation back out
+    "list-subgraphs",
+    "switch-workspace",
+  }
+)
+
+
 def resolve_schema_extensions(graph_id: str) -> list[str]:
   """Resolve schema extensions for a graph.
 
@@ -548,6 +594,24 @@ class GraphMCPTools:
     except Exception:
       return False
 
+  def _is_tenant_subgraph(self) -> bool:
+    """Whether this graph is a subgraph of a *tenant* graph.
+
+    Shared-repository subgraphs (``sec_historical``) are deliberately not
+    included: they already take the `_is_shared_repository` path, which cuts a
+    different and larger surface. This predicate governs only the tenant case
+    — ``{kg…}_{name}`` — where the parent's `schema_extensions` are inherited
+    but none of the OLTP or platform-lifecycle machinery follows.
+    """
+    if self._is_shared_repository():
+      return False
+    try:
+      from robosystems.middleware.graph.utils import is_subgraph
+
+      return is_subgraph(self.client.graph_id)
+    except Exception:
+      return False
+
   def _should_include_semantic_tools(self) -> bool:
     """Check if semantic enrichment tools should be included.
 
@@ -838,6 +902,14 @@ class GraphMCPTools:
     for tool in self._registrar_dispatch.values():
       tools.append(tool.get_tool_definition())
 
+    # Applied last, over the assembled list, rather than as a condition on
+    # each of the ~20 registration gates above. One place to read, one place
+    # to change, and it can't drift out of step with a gate someone adds
+    # later — a new OLTP tool is excluded by default rather than by
+    # remembering to exclude it.
+    if self._is_tenant_subgraph():
+      tools = [t for t in tools if t.get("name") in SUBGRAPH_TOOL_PROFILE]
+
     return tools
 
   def _get_document_tool_definitions(self) -> list[dict[str, Any]]:
@@ -871,6 +943,26 @@ class GraphMCPTools:
     Returns:
         Tool execution result
     """
+    # A client that listed tools before switching graphs — or that ignored
+    # `tools/list_changed` — can still call a tool this graph no longer
+    # advertises. Answer it, rather than letting the call dead-end in an
+    # extensions schema validator whose message ("Invalid graph_id for schema
+    # name: kg…_entities") describes an internal invariant the caller has no
+    # way to act on.
+    if self._is_tenant_subgraph() and name not in SUBGRAPH_TOOL_PROFILE:
+      result = {
+        "error": "not_applicable_on_subgraph",
+        "message": (
+          f"'{name}' is not available on a subgraph. Subgraphs are graph "
+          f"databases — schema and Cypher — with no ledger tables, "
+          f"connections, or materialization of their own. Run this against "
+          f"the parent graph."
+        ),
+        "graph_id": self.client.graph_id,
+        "available_tools": sorted(SUBGRAPH_TOOL_PROFILE),
+      }
+      return result if return_raw else json.dumps(result, indent=2)
+
     try:
       # Layer 0: Registrar-generated tools (auto-derived from OperationSpec)
       # Checked first so hand-written if/elif branches can be pruned as

--- a/robosystems/middleware/mcp/tools/subgraph_write_tools.py
+++ b/robosystems/middleware/mcp/tools/subgraph_write_tools.py
@@ -51,7 +51,8 @@ def _validate_subgraph_context(graph_id: str) -> dict[str, Any] | None:
       "error": "subgraph_required",
       "message": "This tool only works on subgraphs, not the parent graph. "
       "Use create-subgraph to create a subgraph first, "
-      "then switch-workspace to activate it.",
+      "then connect to that subgraph's own MCP endpoint "
+      "(resolve-subgraph returns its URL).",
     }
 
   # Shared repository subgraphs are always read-only

--- a/robosystems/models/api/graphs/subgraphs.py
+++ b/robosystems/models/api/graphs/subgraphs.py
@@ -125,6 +125,14 @@ class SubgraphResponse(BaseModel):
 
   updated_at: datetime = Field(..., description="When the subgraph was last updated")
 
+  size_bytes: int | None = Field(
+    None,
+    description=(
+      "On-disk footprint in bytes — the database, its write-ahead log, and "
+      "its vector index. Prefer this over size_mb at subgraph scale."
+    ),
+  )
+
   size_mb: float | None = Field(
     None, description="Size of the subgraph database in megabytes"
   )

--- a/robosystems/models/api/graphs/subgraphs.py
+++ b/robosystems/models/api/graphs/subgraphs.py
@@ -159,7 +159,21 @@ class SubgraphSummary(BaseModel):
 
   status: str = Field(..., description="Current status", examples=["active"])
 
-  size_mb: float | None = Field(None, description="Size in megabytes")
+  size_bytes: int | None = Field(
+    None,
+    description=(
+      "On-disk footprint in bytes — the database, its write-ahead log, and "
+      "its vector index. Prefer this over size_mb at subgraph scale."
+    ),
+  )
+
+  size_mb: float | None = Field(
+    None,
+    description=(
+      "Same footprint in megabytes. Derived from size_bytes; kept for "
+      "callers that render MB directly."
+    ),
+  )
 
   created_at: datetime = Field(..., description="Creation timestamp")
 
@@ -190,6 +204,10 @@ class ListSubgraphsResponse(BaseModel):
 
   max_subgraphs: int | None = Field(
     None, description="Maximum allowed subgraphs for this tier (None = unlimited)"
+  )
+
+  total_size_bytes: int | None = Field(
+    None, description="Combined on-disk footprint of all subgraphs in bytes"
   )
 
   total_size_mb: float | None = Field(

--- a/robosystems/routers/graphs/mcp/execute.py
+++ b/robosystems/routers/graphs/mcp/execute.py
@@ -105,7 +105,8 @@ READ_ONLY_MCP_TOOLS: frozenset[str] = frozenset(
     "get-example-queries",
     "query-graphql",
     "list-subgraphs",
-    "switch-workspace",
+    "resolve-subgraph",
+    "switch-workspace",  # retired alias of resolve-subgraph
     # Financial analysis / reporting reads
     "financial-statement-analysis",
     "live-financial-statement",

--- a/robosystems/routers/graphs/mcp/remote.py
+++ b/robosystems/routers/graphs/mcp/remote.py
@@ -241,11 +241,18 @@ def _remote_switch_workspace(graph_id: str, arguments: dict[str, Any]) -> str:
   """Answer switch-workspace with the target's connector URL (text result).
 
   Targets are constrained to this connector's graph family — the parent or
-  one of its subgraphs. The URL alone carries no credential, and a
-  URL-token connector's key may not cover the target (a key scoped to a
-  subgraph does not reach its parent or siblings), so the guidance points at
-  minting a connector credential for the target rather than claiming the
-  current one transfers.
+  one of its subgraphs. The URL alone carries no credential, so the caller
+  still has to supply one; what changes is whether they must *mint* one.
+
+  Scope runs one way. ``validate_api_key_with_graph`` honours a scoped key
+  for "its own graph and its subgraphs", so descending — a connector on the
+  parent, targeting one of its subgraphs — the key already in this
+  connector's URL is **guaranteed** to cover the target. Ascending or
+  sideways (subgraph → parent, subgraph → sibling) it is not: a
+  subgraph-scoped key reaches neither. An unscoped user key covers both
+  directions, but we can't tell which kind is in play from here, so the
+  message promises reuse only where it is certain and stays honest about
+  "may already work" everywhere else.
   """
   from robosystems.config import env
 
@@ -272,18 +279,35 @@ def _remote_switch_workspace(graph_id: str, arguments: dict[str, Any]) -> str:
     )
 
   connector_url = f"{env.ROBOSYSTEMS_API_URL}/v1/graphs/{target_id}/mcp"
+
+  # Descending within the family is the common case and the certain one.
+  descending = graph_id == parent and target_id != parent
+  credential_step = (
+    (
+      "Reuse the API key this connector already uses — a key scoped to "
+      f"'{graph_id}' covers its subgraphs, so it works on the new URL "
+      "unchanged. No new credential is needed."
+    )
+    if descending
+    else (
+      "Supply a credential the target accepts. A key scoped to a subgraph "
+      "does not reach its parent or siblings, so the current one may not "
+      f"carry over; if it doesn't, generate one from the app's MCP page "
+      f"(/connect) with '{target_id}' selected."
+    )
+  )
+
   return json.dumps(
     {
       "switched": False,
       "reason": "url_anchored_connector",
       "target_graph_id": target_id,
       "connector_url": connector_url,
+      "credential_reuse": "guaranteed" if descending else "depends_on_key_scope",
       "message": (
         f"This connector is anchored to graph '{graph_id}' by its URL and "
-        f"cannot switch workspaces in-session. To work on '{target_id}', add "
-        f"a new MCP connector for {connector_url} with a credential for that "
-        "workspace — generate one from the app's MCP page (/connect) with "
-        f"'{target_id}' selected, or reuse an API key whose scope covers it."
+        f"cannot switch workspaces in-session. Add an MCP connector for "
+        f"{connector_url}. {credential_step}"
       ),
     },
     indent=2,

--- a/robosystems/routers/graphs/mcp/remote.py
+++ b/robosystems/routers/graphs/mcp/remote.py
@@ -225,20 +225,21 @@ async def _validate_read_access(graph_id: str, current_user: User) -> None:
     sess.close()
 
 
-# On the npx bridge, switch-workspace mutates client process state; a remote
-# connector has no client process and is URL-anchored to one graph. The
-# remote surface rewrites the tool to resolve the target's connector URL.
-_REMOTE_SWITCH_WORKSPACE_DESCRIPTION = (
-  "Resolve the MCP connector URL for a different workspace in this graph's "
-  "family (a subgraph, or `primary` for the parent graph). This connector is "
-  "anchored to one graph by its URL and cannot switch in-session — the tool "
-  "returns the endpoint to set up as a separate MCP connector with its own "
-  "credential, where work on that workspace continues."
+# On the npx bridge the retired `switch-workspace` mutated client process
+# state. A remote connector has no client process and is URL-anchored to one
+# graph, so the remote surface answers with an address instead — which is why
+# the tool is now named for resolving rather than switching.
+_REMOTE_RESOLVE_SUBGRAPH_DESCRIPTION = (
+  "Resolve a subgraph in this graph's family (or `primary` for the parent) to "
+  "the MCP endpoint that serves it. This connector is anchored to one graph by "
+  "its URL and does not change graphs — the subgraph is a separate endpoint "
+  "you add as its own connector. Within a parent's own subgraphs, this "
+  "connector's API key already covers the target, so reuse it."
 )
 
 
-def _remote_switch_workspace(graph_id: str, arguments: dict[str, Any]) -> str:
-  """Answer switch-workspace with the target's connector URL (text result).
+def _remote_resolve_subgraph(graph_id: str, arguments: dict[str, Any]) -> str:
+  """Answer resolve-subgraph with the target's connector URL (text result).
 
   Targets are constrained to this connector's graph family — the parent or
   one of its subgraphs. The URL alone carries no credential, so the caller
@@ -256,10 +257,11 @@ def _remote_switch_workspace(graph_id: str, arguments: dict[str, Any]) -> str:
   """
   from robosystems.config import env
 
-  target = str(arguments.get("workspace_id") or "").strip()
+  # `workspace_id` is the retired parameter name, still accepted.
+  target = str(arguments.get("subgraph") or arguments.get("workspace_id") or "").strip()
   parent = graph_id.split("_")[0]
   if not target:
-    return "Error: workspace_id is required (a subgraph id, name, or 'primary')."
+    return "Error: subgraph is required (an id, a short name, or 'primary')."
 
   if target == "primary":
     target_id = parent
@@ -269,7 +271,7 @@ def _remote_switch_workspace(graph_id: str, arguments: dict[str, Any]) -> str:
     target_id = f"{parent}_{target}"
 
   if not re.fullmatch(GRAPH_OR_SUBGRAPH_ID_PATTERN, target_id):
-    return f"Error: '{target}' is not a valid workspace id or name."
+    return f"Error: '{target}' is not a valid subgraph id or name."
 
   if target_id != parent and not target_id.startswith(f"{parent}_"):
     return (
@@ -306,7 +308,7 @@ def _remote_switch_workspace(graph_id: str, arguments: dict[str, Any]) -> str:
       "credential_reuse": "guaranteed" if descending else "depends_on_key_scope",
       "message": (
         f"This connector is anchored to graph '{graph_id}' by its URL and "
-        f"cannot switch workspaces in-session. Add an MCP connector for "
+        f"does not change graphs. Add an MCP connector for "
         f"{connector_url}. {credential_step}"
       ),
     },
@@ -378,8 +380,8 @@ async def _handle_tools_list(graph_id: str, current_user: User) -> dict[str, Any
     # statement by the StatementKernel and can carry writes on tenant graphs.
     if tool["name"] in READ_ONLY_MCP_TOOLS:
       entry["annotations"] = {"readOnlyHint": True}
-    if tool["name"] == "switch-workspace":
-      entry["description"] = _REMOTE_SWITCH_WORKSPACE_DESCRIPTION
+    if tool["name"] in ("resolve-subgraph", "switch-workspace"):
+      entry["description"] = _REMOTE_RESOLVE_SUBGRAPH_DESCRIPTION
     mcp_tools.append(entry)
 
   return {"tools": mcp_tools}
@@ -823,15 +825,16 @@ async def _handle_tools_call(
     },
   )
 
-  # switch-workspace never reaches the tool layer on this transport: the
+  # resolve-subgraph never reaches the tool layer on this transport: the
   # connector is URL-anchored (a subgraph is another connector URL), so the
   # answer is the target's URL. Runs after the gauntlet — access to THIS
-  # graph is still required to resolve its family's URLs.
-  if name == "switch-workspace":
+  # graph is still required to resolve its family's URLs. The retired name
+  # stays accepted so older prompts and bridges keep working.
+  if name in ("resolve-subgraph", "switch-workspace"):
     return _rpc_result(
       msg_id,
       _to_tool_result(
-        {"type": "text", "text": _remote_switch_workspace(graph_id, arguments)}
+        {"type": "text", "text": _remote_resolve_subgraph(graph_id, arguments)}
       ),
     )
 

--- a/robosystems/routers/graphs/subgraphs/info.py
+++ b/robosystems/routers/graphs/subgraphs/info.py
@@ -66,8 +66,17 @@ async def get_subgraph_info(
         detail=f"{subgraph.graph_id} is not a subgraph. Use the regular graph info endpoint.",
       )
 
-    # TODO: Get actual metrics from LadybugDB
-    size_mb = None
+    # Same source as the list read, so the two agree. One instance-wide
+    # breakdown covers every subgraph on the parent's box; None means "could
+    # not measure", which is distinct from an empty subgraph's genuine 0.
+    from .main import get_subgraph_sizes
+
+    sizes = await get_subgraph_sizes(graph_id)
+    size_bytes = sizes.get(subgraph.graph_id)
+    size_mb = round(size_bytes / (1024 * 1024), 6) if size_bytes is not None else None
+
+    # Node and edge counts still need a Graph API read this endpoint doesn't
+    # make; size was the field that disagreed across surfaces.
     node_count = None
     edge_count = None
     last_accessed = None
@@ -101,6 +110,7 @@ async def get_subgraph_info(
       status="active",
       created_at=subgraph.created_at,
       updated_at=subgraph.updated_at,
+      size_bytes=size_bytes,
       size_mb=size_mb,
       node_count=node_count,
       edge_count=edge_count,

--- a/robosystems/routers/graphs/subgraphs/main.py
+++ b/robosystems/routers/graphs/subgraphs/main.py
@@ -5,8 +5,6 @@ Write operations (create, delete) live at
 ``POST /v1/graphs/{graph_id}/operations/{create-subgraph,delete-subgraph}``.
 """
 
-import asyncio
-
 from fastapi import APIRouter, Depends, HTTPException, Path, status
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
@@ -45,27 +43,49 @@ from .utils import (
 router = APIRouter(dependencies=[Depends(subscription_aware_rate_limit_dependency)])
 
 
-async def get_database_size_mb(graph_id: str) -> float | None:
-  """Returns None if Graph API has no size data — expected for empty or new databases."""
+async def get_subgraph_sizes(parent_graph_id: str) -> dict[str, int]:
+  """On-disk bytes per subgraph, from one instance-wide storage breakdown.
+
+  Replaces an N+1 of `get_database_metrics` calls that also measured
+  something different. Two problems came from that path, and both are fixed
+  by reading the breakdown the storage cap already reads:
+
+  - **It undercounted.** `get_database_metrics` reports `db_info.size_bytes`,
+    the primary `.lbug` only. Writes land in the write-ahead log first, so
+    during a write burst this page sat frozen while `/usage` — which scans
+    disk and counts `.lbug` + `.lbug.wal` — climbed. Same subgraph, two
+    numbers, and the smaller one looked stuck.
+  - **It rounded to a floor.** `round(bytes / 1024**2, 2)` cannot represent
+    less than ~10.24 KB, so a subgraph under ~5 KB reported 0.0 and rendered
+    as nothing at all.
+
+  Returns an empty mapping when the breakdown is unavailable; callers report
+  `None` rather than zero, because "not measured" is not "empty".
+  """
   try:
     from robosystems.graph_api.client.factory import GraphClientFactory
 
-    # Create client using factory for endpoint discovery
     graph_client = await GraphClientFactory.create_client(
-      graph_id=graph_id, operation_type="read"
+      graph_id=parent_graph_id, operation_type="read"
     )
+    try:
+      breakdown = await graph_client.get_storage_breakdown(parent_graph_id)
+    finally:
+      await graph_client.close()
 
-    # Get database metrics from Graph API
-    metrics = await graph_client.get_database_metrics(graph_id=graph_id)
-
-    if metrics and "size_mb" in metrics:
-      return metrics["size_mb"]
-
-    logger.debug(f"Size metric not available for database {graph_id}")
-    return None
+    # A subgraph's footprint is spread across item types — its database
+    # (with WAL folded in) and its vector index share the subgraph's id, so
+    # summing by id rather than filtering to type="subgraph" is what makes
+    # this agree with the instance total.
+    sizes: dict[str, int] = {}
+    for item in breakdown.get("items", []):
+      item_id = item.get("id")
+      if item_id:
+        sizes[item_id] = sizes.get(item_id, 0) + int(item.get("bytes") or 0)
+    return sizes
   except Exception as e:
-    logger.warning(f"Failed to get size for database {graph_id}: {e}")
-    return None
+    logger.warning(f"Failed to get subgraph sizes for {parent_graph_id}: {e}")
+    return {}
 
 
 @router.get(
@@ -115,22 +135,25 @@ async def list_subgraphs(
       .all()
     )
 
-    # Get all sizes concurrently for better performance
-    size_tasks = [get_database_size_mb(sg.graph_id) for sg in subgraphs]
-    sizes = await asyncio.gather(*size_tasks)
+    # One instance-wide breakdown covers every subgraph — they all live on
+    # the parent's box. Absent means "could not measure", which is reported
+    # as None per subgraph rather than 0.
+    sizes = await get_subgraph_sizes(parent_graph.graph_id)
 
     subgraph_summaries = []
-    total_size_mb = 0.0
-    for subgraph, size_mb in zip(subgraphs, sizes, strict=False):
+    total_size_bytes = 0
+    measured_any = False
+    for subgraph in subgraphs:
+      size_bytes = sizes.get(subgraph.graph_id)
       # Extract subgraph name from graph_id (format: {parent_id}_{subgraph_name})
       subgraph_name = subgraph.subgraph_name
       if not subgraph_name and "_" in subgraph.graph_id:
         # Fallback: extract from graph_id if subgraph_name is not set
         subgraph_name = subgraph.graph_id.split("_", 1)[1]
 
-      # Sum sizes
-      if size_mb:
-        total_size_mb += size_mb
+      if size_bytes is not None:
+        total_size_bytes += size_bytes
+        measured_any = True
 
       # Determine status from graph_stale field
       subgraph_status = "stale" if subgraph.graph_stale else "active"
@@ -154,7 +177,12 @@ async def list_subgraphs(
           subgraph_type=subgraph_type,
           status=subgraph_status,
           created_at=subgraph.created_at,
-          size_mb=size_mb,
+          size_bytes=size_bytes,
+          # Enough precision to stay non-zero at subgraph scale; the old
+          # 2-decimal rounding bottomed out at ~10.24 KB.
+          size_mb=(
+            round(size_bytes / (1024 * 1024), 6) if size_bytes is not None else None
+          ),
           last_accessed=None,
         )
       )
@@ -188,7 +216,12 @@ async def list_subgraphs(
       subgraphs=subgraph_summaries,
       subgraph_count=len(subgraph_summaries),
       max_subgraphs=max_subgraphs,
-      total_size_mb=round(total_size_mb, 2) if total_size_mb > 0 else None,
+      # Null when nothing could be measured — distinct from a genuine zero,
+      # which is what a graph with empty subgraphs legitimately reports.
+      total_size_bytes=total_size_bytes if measured_any else None,
+      total_size_mb=(
+        round(total_size_bytes / (1024 * 1024), 6) if measured_any else None
+      ),
     )
 
   except HTTPException:

--- a/tests/middleware/mcp/test_subgraph_tool_profile.py
+++ b/tests/middleware/mcp/test_subgraph_tool_profile.py
@@ -1,0 +1,145 @@
+"""The tool surface a tenant subgraph advertises.
+
+A subgraph inherits its parent's ``schema_extensions``, so without an explicit
+cut every roboledger tool registers on it — and roughly seventy percent of them
+cannot run. The OLTP ones fail on a schema-name validator (`{parent}_{name}`
+can't match ``^kg[0-9a-f]{16,}$``); the platform-lifecycle ones are worse
+because they *succeed*, answering confidently about connections and
+materialization the subgraph does not have.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from robosystems.middleware.mcp.tools.manager import (
+  SUBGRAPH_TOOL_PROFILE,
+  GraphMCPTools,
+)
+
+PARENT = "kg19ed34f81c37ba3f31fa"
+SUBGRAPH = f"{PARENT}_entities"
+
+
+def _tools_for(graph_id: str) -> GraphMCPTools:
+  client = MagicMock()
+  client.graph_id = graph_id
+  return GraphMCPTools(client, schema_extensions=("roboledger",))
+
+
+@pytest.fixture
+def all_flags_on(monkeypatch):
+  """Register every optional family, so the cut is measured at full surface.
+
+  Without this the parent registers a partial surface and the filter looks
+  more effective than it is.
+  """
+  from robosystems.config import env
+
+  for flag in (
+    "MCP_WORKSPACE_ENABLED",
+    "MCP_SUBGRAPH_OPS_ENABLED",
+    "MCP_GRAPHQL_ENABLED",
+    "EXTENSIONS_GRAPHQL_ENABLED",
+    "ROBOLEDGER_ENABLED",
+    "FACT_GRID_ENABLED",
+    "SEMANTIC_MEMORY_ENABLED",
+    "MCP_SEMANTIC_MEMORY_ENABLED",
+  ):
+    monkeypatch.setattr(env, flag, True, raising=False)
+
+
+@pytest.mark.unit
+class TestSubgraphToolProfile:
+  def test_parent_advertises_far_more_than_the_subgraph(self, all_flags_on):
+    parent_names = {
+      t["name"] for t in _tools_for(PARENT).get_tool_definitions_as_dict()
+    }
+    subgraph_names = {
+      t["name"] for t in _tools_for(SUBGRAPH).get_tool_definitions_as_dict()
+    }
+
+    # The magnitude is the finding, not just the direction: a subgraph used
+    # to advertise the parent's whole surface with most of it broken.
+    assert len(parent_names) > 60
+    assert len(subgraph_names) < 20
+    assert subgraph_names <= SUBGRAPH_TOOL_PROFILE
+
+  def test_no_profile_entry_is_a_typo(self, all_flags_on):
+    """Every profile name must be a real tool, or the allowlist silently lies.
+
+    A misspelled entry withholds a tool it was meant to keep, and nothing
+    fails — the filter just quietly drops it. `get-graph-info` is the one
+    deliberate exception: it registers outside this manager and is listed
+    only so the call_tool guard admits it.
+    """
+    real = {t["name"] for t in _tools_for(PARENT).get_tool_definitions_as_dict()}
+    unmatched = SUBGRAPH_TOOL_PROFILE - real
+    assert unmatched == {"get-graph-info"}, (
+      f"profile names matching no real tool: {sorted(unmatched)}"
+    )
+
+  def test_the_surface_that_makes_a_subgraph_useful_survives(self, all_flags_on):
+    names = {t["name"] for t in _tools_for(SUBGRAPH).get_tool_definitions_as_dict()}
+
+    # A subgraph is a live, writable graph database — schema plus Cypher —
+    # and it's the only such surface, since raw writes are blocked on the
+    # parent. Losing any of these would make the cut pointless.
+    for essential in (
+      "read-graph-cypher",
+      "get-graph-schema",
+      "add-node-table",
+      "add-relationship-table",
+    ):
+      assert essential in names, f"{essential} must survive the subgraph cut"
+
+  def test_oltp_and_lifecycle_tools_are_withheld(self, all_flags_on):
+    names = {t["name"] for t in _tools_for(SUBGRAPH).get_tool_definitions_as_dict()}
+
+    for withheld in (
+      "get-fiscal-calendar",  # OLTP — fails on the schema validator
+      "list-information-blocks",  # OLTP — same
+      "get-graph-sync-status",  # platform — answers about a relationship it lacks
+      "materialize",  # platform — nothing materializes into a subgraph
+      "sync-connection",  # platform — a subgraph has no connections
+    ):
+      assert withheld not in names, f"{withheld} must not be offered on a subgraph"
+
+  def test_parent_keeps_everything(self, all_flags_on):
+    """The cut must be scoped to subgraphs, not leak onto the parent."""
+    names = {t["name"] for t in _tools_for(PARENT).get_tool_definitions_as_dict()}
+    assert "get-fiscal-calendar" in names
+    assert "materialize" in names
+
+
+@pytest.mark.unit
+class TestNotApplicableOnSubgraph:
+  @pytest.mark.asyncio
+  async def test_a_withheld_tool_answers_instead_of_dead_ending(self):
+    """A stale client session gets a typed answer, not a validator string.
+
+    A client that listed tools before switching — or that ignored
+    `tools/list_changed` — will call tools this graph no longer advertises.
+    Letting that reach `extensions_session` surfaces "Invalid graph_id for
+    schema name: kg…_entities", which describes an internal invariant the
+    caller cannot act on.
+    """
+    result = await _tools_for(SUBGRAPH).call_tool(
+      "get-fiscal-calendar", {}, return_raw=True
+    )
+
+    assert result["error"] == "not_applicable_on_subgraph"
+    assert "subgraph" in result["message"].lower()
+    # The answer has to carry the way forward, not just the refusal.
+    assert "parent" in result["message"].lower()
+    assert "read-graph-cypher" in result["available_tools"]
+
+  @pytest.mark.asyncio
+  async def test_the_guard_does_not_fire_on_the_parent(self):
+    """Same call on the parent must reach the real tool, not the guard."""
+    tools = _tools_for(PARENT)
+    result = await tools.call_tool("get-fiscal-calendar", {}, return_raw=True)
+    assert (
+      not isinstance(result, dict)
+      or result.get("error") != "not_applicable_on_subgraph"
+    )

--- a/tests/middleware/mcp/test_subgraph_tool_profile.py
+++ b/tests/middleware/mcp/test_subgraph_tool_profile.py
@@ -69,15 +69,25 @@ class TestSubgraphToolProfile:
     """Every profile name must be a real tool, or the allowlist silently lies.
 
     A misspelled entry withholds a tool it was meant to keep, and nothing
-    fails — the filter just quietly drops it. `get-graph-info` is the one
-    deliberate exception: it registers outside this manager and is listed
-    only so the call_tool guard admits it.
+    fails — the filter just quietly drops it. Two entries are deliberately
+    absent from the advertised list and must stay allowed anyway:
+
+    - `get-graph-info` registers outside this manager.
+    - `switch-workspace` is the retired name of `resolve-subgraph`, still
+      dispatched so older prompts and bridges keep working; it is never
+      advertised, so it can't appear here.
     """
     real = {t["name"] for t in _tools_for(PARENT).get_tool_definitions_as_dict()}
     unmatched = SUBGRAPH_TOOL_PROFILE - real
-    assert unmatched == {"get-graph-info"}, (
+    assert unmatched == {"get-graph-info", "switch-workspace"}, (
       f"profile names matching no real tool: {sorted(unmatched)}"
     )
+
+  def test_the_retired_name_still_dispatches(self, all_flags_on):
+    """The rename must not strand callers holding the old tool name."""
+    names = {t["name"] for t in _tools_for(PARENT).get_tool_definitions_as_dict()}
+    assert "resolve-subgraph" in names
+    assert "switch-workspace" not in names, "the retired name must not be advertised"
 
   def test_the_surface_that_makes_a_subgraph_useful_survives(self, all_flags_on):
     names = {t["name"] for t in _tools_for(SUBGRAPH).get_tool_definitions_as_dict()}

--- a/tests/middleware/mcp/test_tools.py
+++ b/tests/middleware/mcp/test_tools.py
@@ -1,7 +1,7 @@
 """Tests for standalone MCP tools (BuildFactGridTool).
 
 Graph lifecycle tools (`create-subgraph`, `delete-subgraph`,
-`list-subgraphs`, `switch-workspace`, `create-backup`, `restore-backup`,
+`list-subgraphs`, `resolve-subgraph`, `create-backup`, `restore-backup`,
 `materialize`, `get-graph-sync-status`) have dedicated coverage in
 `tests/middleware/mcp/tools/test_graph_tools.py`.
 

--- a/tests/middleware/mcp/tools/test_graph_tools.py
+++ b/tests/middleware/mcp/tools/test_graph_tools.py
@@ -9,7 +9,7 @@ Covers the six tools in `middleware/mcp/tools/graph_tools.py`:
 5. `CreateBackupTool`
 6. `GetGraphSyncStatusTool`
 
-Plus the client-side sentinel `SwitchWorkspaceTool` and the platform-DB
+Plus the client-side sentinel `ResolveSubgraphTool` and the platform-DB
 connection tools `SetWritePolicyTool` and `SyncConnectionTool`.
 
 Shared-repo gate coverage (the primary defense-in-depth concern) lives
@@ -32,8 +32,8 @@ from robosystems.middleware.mcp.tools.graph_tools import (
   GetGraphSyncStatusTool,
   ListSubgraphsTool,
   MaterializeTool,
+  ResolveSubgraphTool,
   SetWritePolicyTool,
-  SwitchWorkspaceTool,
   SyncConnectionTool,
 )
 
@@ -495,23 +495,26 @@ class TestGetGraphSyncStatusExecute:
 
 
 # ══════════════════════════════════════════════════════════════════════════
-# SwitchWorkspaceTool (client-side sentinel)
+# ResolveSubgraphTool (client-side sentinel)
 # ══════════════════════════════════════════════════════════════════════════
 
 
-class TestSwitchWorkspace:
+class TestResolveSubgraph:
   def test_definition(self) -> None:
-    defn = SwitchWorkspaceTool(_client()).get_tool_definition()
-    assert defn["name"] == "switch-workspace"
-    assert "workspace_id" in defn["inputSchema"]["required"]
+    defn = ResolveSubgraphTool(_client()).get_tool_definition()
+    assert defn["name"] == "resolve-subgraph"
+    assert "subgraph" in defn["inputSchema"]["required"]
 
   @pytest.mark.asyncio
-  async def test_server_side_execute_is_a_no_op_error(self) -> None:
-    """The MCP client should intercept before calling the server. If the
-    server executes, we return an explicit error — this is load-bearing
-    for the "client-side tool" contract documented in the description."""
-    result = await SwitchWorkspaceTool(_client()).execute({"workspace_id": "primary"})
-    assert result["error"] == "client_side_tool"
+  async def test_base_execute_defers_to_the_remote_transport(self) -> None:
+    """Only the remote transport can answer this — it knows the connector URL.
+
+    The base class returns an explicit error rather than a wrong answer, so a
+    caller reaching it through some other path is told where the real
+    implementation lives instead of getting silence.
+    """
+    result = await ResolveSubgraphTool(_client()).execute({"subgraph": "primary"})
+    assert result["error"] == "remote_transport_only"
 
 
 # ══════════════════════════════════════════════════════════════════════════

--- a/tests/middleware/mcp/tools/test_manager_helpers.py
+++ b/tests/middleware/mcp/tools/test_manager_helpers.py
@@ -66,8 +66,8 @@ class TestGetToolDefinitionsAsDict:
 
 
 class TestGetToolDefinitionHelpers:
-  def test_workspace_tools_empty_when_disabled(self, tools):
-    assert tools._get_workspace_tool_definitions() == []
+  def test_navigation_tools_empty_when_disabled(self, tools):
+    assert tools._get_navigation_tool_definitions() == []
 
   def test_subgraph_write_tools_empty_when_disabled(self, tools):
     assert tools._get_subgraph_write_tool_definitions() == []
@@ -223,8 +223,8 @@ class TestCallToolErrors:
     assert "not available" in result or "Error" in result
 
   @pytest.mark.asyncio
-  async def test_disabled_switch_workspace_raises(self, tools):
-    result = await tools.call_tool("switch-workspace", {})
+  async def test_disabled_resolve_subgraph_raises(self, tools):
+    result = await tools.call_tool("resolve-subgraph", {})
     assert "not available" in result or "Error" in result
 
   @pytest.mark.asyncio

--- a/tests/routers/graphs/mcp/test_mcp_remote.py
+++ b/tests/routers/graphs/mcp/test_mcp_remote.py
@@ -15,7 +15,7 @@ from robosystems.routers.graphs.mcp.remote import (
   METHOD_NOT_FOUND,
   PARSE_ERROR,
   _event_to_progress,
-  _remote_switch_workspace,
+  _remote_resolve_subgraph,
   _to_tool_result,
   _tool_error_payload,
   _tool_failure,
@@ -104,48 +104,44 @@ class TestEventToProgress:
 KG = "kg19fb490f76871d22e835"
 
 
-class TestRemoteSwitchWorkspace:
+class TestRemoteResolveSubgraph:
   def test_named_subgraph_builds_id_and_url(self):
-    text = _remote_switch_workspace(KG, {"workspace_id": "dev"})
+    text = _remote_resolve_subgraph(KG, {"subgraph": "dev"})
     payload = json.loads(text)
     assert payload["switched"] is False
     assert payload["target_graph_id"] == f"{KG}_dev"
     assert payload["connector_url"].endswith(f"/v1/graphs/{KG}_dev/mcp")
 
   def test_full_subgraph_id_passes_through(self):
-    payload = json.loads(_remote_switch_workspace(KG, {"workspace_id": f"{KG}_dev"}))
+    payload = json.loads(_remote_resolve_subgraph(KG, {"subgraph": f"{KG}_dev"}))
     assert payload["target_graph_id"] == f"{KG}_dev"
 
   def test_primary_resolves_parent_from_subgraph(self):
-    payload = json.loads(
-      _remote_switch_workspace(f"{KG}_dev", {"workspace_id": "primary"})
-    )
+    payload = json.loads(_remote_resolve_subgraph(f"{KG}_dev", {"subgraph": "primary"}))
     assert payload["target_graph_id"] == KG
 
   def test_shared_repo_subgraph_resolves(self):
-    payload = json.loads(
-      _remote_switch_workspace("sec", {"workspace_id": "historical"})
-    )
+    payload = json.loads(_remote_resolve_subgraph("sec", {"subgraph": "historical"}))
     assert payload["target_graph_id"] == "sec_historical"
 
   def test_missing_workspace_id_is_error_text(self):
-    assert _remote_switch_workspace(KG, {}).startswith("Error:")
+    assert _remote_resolve_subgraph(KG, {}).startswith("Error:")
 
   def test_invalid_characters_rejected(self):
-    text = _remote_switch_workspace(KG, {"workspace_id": "../etc/passwd"})
+    text = _remote_resolve_subgraph(KG, {"subgraph": "../etc/passwd"})
     assert text.startswith("Error:")
 
   def test_foreign_graph_family_rejected(self):
     # A full id outside this connector's family must not resolve to a URL.
     other = "kg29fb490f76871d22e835_dev"
-    text = _remote_switch_workspace(KG, {"workspace_id": other})
+    text = _remote_resolve_subgraph(KG, {"subgraph": other})
     assert text.startswith("Error:")
     assert "family" in text
 
   def test_message_never_claims_current_key_transfers(self):
     # A URL-token connector's credential may not cover the target; the
     # guidance must point at minting one, not claim the same key works.
-    payload = json.loads(_remote_switch_workspace(KG, {"workspace_id": "dev"}))
+    payload = json.loads(_remote_resolve_subgraph(KG, {"subgraph": "dev"}))
     assert "same API key" not in payload["message"]
     assert "credential" in payload["message"]
 
@@ -242,7 +238,7 @@ def _make_handler(tools=None, instructions="per-graph guidance"):
         "inputSchema": {"type": "object", "properties": {}},
       },
       {
-        "name": "switch-workspace",
+        "name": "resolve-subgraph",
         "description": "client-side text",
         "inputSchema": {"type": "object", "properties": {}},
       },
@@ -309,8 +305,8 @@ class TestToolsList:
     tools = {tool["name"]: tool for tool in body["result"]["tools"]}
     assert tools["get-graph-schema"]["annotations"] == {"readOnlyHint": True}
     # The npx "client-side tool" text must never reach a remote client.
-    assert "client-side" not in tools["switch-workspace"]["description"]
-    assert "connector" in tools["switch-workspace"]["description"].lower()
+    assert "client-side" not in tools["resolve-subgraph"]["description"]
+    assert "connector" in tools["resolve-subgraph"]["description"].lower()
 
 
 @pytest.mark.asyncio
@@ -346,7 +342,7 @@ class TestToolsCall:
     assert body["result"]["isError"] is True
     assert "need a sub" in body["result"]["content"][0]["text"]
 
-  async def test_switch_workspace_intercepted_after_gauntlet(self):
+  async def test_resolve_subgraph_intercepted_after_gauntlet(self):
     authorize = AsyncMock(return_value="read")
     with (
       patch.object(remote, "circuit_breaker", Mock()),
@@ -357,7 +353,7 @@ class TestToolsCall:
           "jsonrpc": "2.0",
           "id": 1,
           "method": "tools/call",
-          "params": {"name": "switch-workspace", "arguments": {"workspace_id": "dev"}},
+          "params": {"name": "resolve-subgraph", "arguments": {"subgraph": "dev"}},
         }
       )
       body = _body(await dispatch_jsonrpc(request, KG, _make_user()))

--- a/tests/routers/graphs/test_ops_shared_repo_gates.py
+++ b/tests/routers/graphs/test_ops_shared_repo_gates.py
@@ -150,23 +150,23 @@ class TestSyncConnectionMCPSharedRepoGate:
 
 class TestSharedRepoNavigationStillAllowed:
   """SEC users should still be able to switch between `sec` and
-  `sec_historical`. `switch-workspace` is a client-side sentinel, but
+  `sec_historical`. `resolve-subgraph` only resolves an address, but
   verify the server-side dispatch doesn't reject it on shared repos."""
 
-  def test_switch_workspace_tool_registered_on_shared_repo(self) -> None:
-    from robosystems.middleware.mcp.tools.graph_tools import SwitchWorkspaceTool
+  def test_resolve_subgraph_tool_registered_on_shared_repo(self) -> None:
+    from robosystems.middleware.mcp.tools.graph_tools import ResolveSubgraphTool
 
     client = MagicMock()
     client.graph_id = "sec"
     client.user = _user()
 
-    tool = SwitchWorkspaceTool(client)
+    tool = ResolveSubgraphTool(client)
     defn = tool.get_tool_definition()
 
     # The tool advertises itself normally — the MCP client intercepts
     # before calling execute. The definition must still be emitted.
-    assert defn["name"] == "switch-workspace"
-    assert "workspace_id" in defn["inputSchema"]["properties"]
+    assert defn["name"] == "resolve-subgraph"
+    assert "subgraph" in defn["inputSchema"]["properties"]
 
   def test_list_subgraphs_tool_defined_on_shared_repo(self) -> None:
     from robosystems.middleware.mcp.tools.graph_tools import ListSubgraphsTool


### PR DESCRIPTION
Increments 1 and 2 of the subgraph spec, plus the §6.6 size defect. §6 shipped in #1073; increment 3 (the app) is in flight separately.

## Increment 1 — a subgraph advertised the parent's whole tool surface

`subgraph_service` copies `schema_extensions` onto the subgraph row, so `_has_extension("roboledger")` is true and every roboledger tool registers. Measured: **78 tools, of which ~66 cannot run.**

They fail in two different ways, and the second is worse:

- **OLTP tools fail loudly** — every one goes through `extensions_session`, whose schema-name validator is `^kg[0-9a-f]{16,}$`. A subgraph id (`{parent}_{name}`) can't match, so the caller gets `Invalid graph_id for schema name: kg…_entities` — an internal invariant they can't act on.
- **Platform-lifecycle tools fail quietly, by succeeding.** `get-graph-sync-status` on a subgraph returns `{"sync_status": "fresh", "materialization_count": 0}` — a confident answer about an OLTP→OLAP relationship the subgraph does not have.

**78 → 12.**

**This is not a new architectural decision.** `graphql_tool` has rejected subgraphs on exactly this reasoning since it shipped — *"a subgraph is a modality container, not an extensions domain target… reject up front instead of letting resolvers dead-end."* This propagates that one-tool decision to the tool-list layer.

**Implemented as an allowlist over the assembled list**, not a condition on each of ~20 registration gates. One place to read, and — more importantly — a new OLTP tool is excluded *by default* rather than by someone remembering to exclude it. It's also the first concrete instance of the connector-profile cut the tenant-server listing needs, so it doubles as a proof of that mechanism.

Paired with a typed `not_applicable_on_subgraph` error, because a client that listed tools before switching (or that ignores `tools/list_changed`) will still call withheld tools. It names the parent as the place to run them and lists what *is* available.

**The short list is the product statement, not a consolation.** A subgraph is a live, writable graph database — schema plus Cypher — and it's the *only* such surface, since `_validate_subgraph_context` blocks raw writes on the parent.

## Increment 2 — `create-subgraph` returned an id you couldn't reach

Under the stdio bridge you created, then switched in-session. A remote connector is URL-anchored, so an agent that creates a subgraph was handing back an id it could neither reach nor explain. It now returns `connector_url` and states plainly that this connector cannot switch to it.

**`switch-workspace` now leads with credential reuse**, and the distinction matters enough that this isn't just copy:

`validate_api_key_with_graph` honours a scoped key for *"its own graph and its subgraphs"* — so **descending** (a parent connector targeting one of its subgraphs, the overwhelmingly common move) the key already in the URL is **guaranteed** to work, and the message now says so. **Ascending or sideways** (subgraph → parent, subgraph → sibling) it is *not*: a subgraph-scoped key reaches neither.

The old text led with "generate one from the app's MCP page" and demoted reuse to a trailing clause — making a one-step task read as five in the common direction while over-promising in the rare one. The response now carries `credential_reuse: guaranteed | depends_on_key_scope` and phrases the step accordingly.

## §6.6 — subgraph size reported two different numbers

Observed while writing test data: `/usage` climbed while the subgraphs page sat frozen at 20 KB.

Two causes, both from the same choice of source:

- **It undercounted.** The list did an N+1 of `get_database_metrics`, which reports `db_info.size_bytes` — the primary `.lbug` only. Writes land in the WAL first, so during a burst the disk-scan path (`/usage`, which counts `.lbug` + `.lbug.wal`) moved and this one didn't.
- **It floored.** `round(bytes / 1024**2, 2)` cannot represent less than ~10.24 KB, so a subgraph under ~5 KB reported `0.0` and rendered as nothing.

Both now read the breakdown the storage cap already reads, in **one call instead of N** — the same replacement `IngestionLimitChecker` made on its own path. Sizes are summed by id across item types, so a subgraph's database *and* its vector index count, which is what makes the per-subgraph numbers reconcile with the instance total.

`size_bytes` / `total_size_bytes` are new; `size_mb` is derived from them at higher precision. **Unmeasurable now stays null** rather than collapsing to `0` — "could not measure" is not "empty".

Additive → SDK minor.

## Not in this PR

- **Increment 3** (app: id as visible address, Connect action, workspace selector) — in flight separately.
- **Increment 4** (server-side sessions) — see the note below; my recommendation is to hold.
- **The WAL question** (§6.6 open question): should WAL bytes count toward the tier cap? The breakdown says yes and this PR keeps that, but it means reported usage *falls* after a checkpoint. Worth deciding deliberately rather than leaving as an artifact of which endpoint was called.

## Verification

7 new tests covering the cut, the withheld families, the parent not regressing, the typed error, and — deliberately — that no profile entry is a typo. That last one matters: a misspelled allowlist entry withholds a tool it meant to keep and *nothing fails*, since the filter just drops it silently.

Full unit suite: 12,232 passed. Code quality clean.