### PR TITLE
Fold subgraph URLs into list-subgraphs; delete two navigation tools; prune Claude settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -91,29 +91,7 @@
       "WebFetch(domain:docs.dagster.io)",
       "WebFetch(domain:pypi.org)",
       "WebFetch(domain:astral.sh)",
-      "WebFetch(domain:aws.amazon.com)",
-      "WebFetch(domain:deepwiki.com)",
-      "WebFetch(domain:instances.vantage.sh)",
-      "Skill(staged-review)",
-      "mcp__aws-documentation__search_documentation",
-      "mcp__aws-documentation__read_documentation",
-      "mcp__aws-documentation__read_sections",
-      "mcp__aws-documentation__recommend",
-      "mcp__Context7__resolve-library-id",
-      "mcp__Context7__get-library-docs",
-      "mcp__Context7__query-docs",
-      "mcp__sequential-thinking__sequentialthinking",
-      "mcp__robosystems__get-graph-info",
-      "mcp__robosystems__get-graph-schema",
-      "mcp__robosystems__get-example-queries",
-      "mcp__robosystems__read-graph-cypher",
-      "mcp__robosystems__build-fact-grid",
-      "mcp__robosystems__resolve-element",
-      "mcp__robosystems__financial-statement-analysis",
-      "mcp__robosystems__live-financial-statement",
-      "mcp__robosystems__list-workspaces",
-      "mcp__robosystems__switch-workspace",
-      "Bash(just create-release:*)"
+      "WebFetch(domain:aws.amazon.com)"
     ],
     "ask": [
       "Bash(git branch --list:*)",
@@ -134,8 +112,7 @@
       "Bash(aws autoscaling update-auto-scaling-group:*)",
       "Bash(aws s3 cp:*)",
       "Bash(aws s3 mv:*)",
-      "Bash(aws s3 sync:*)",
-      "Bash(just create-release:*)"
+      "Bash(aws s3 sync:*)"
     ],
     "deny": [
       "Bash(just admin * migrations:*)",

--- a/robosystems/adapters/sec/manifest.py
+++ b/robosystems/adapters/sec/manifest.py
@@ -43,7 +43,7 @@ SEC_MANIFEST = SharedRepositoryManifest(
     "\n"
     "NOTES\n"
     "- Deeper historical filings live in the `sec_historical` subgraph — switch "
-    "to it with `resolve-subgraph` when you need older periods.\n"
+    "to its connector URL (see `list-subgraphs`) for older periods.\n"
     "- This is shared public data: period close, chart-of-accounts mapping, and "
     "all write operations are unavailable here."
   ),

--- a/robosystems/middleware/mcp/README.md
+++ b/robosystems/middleware/mcp/README.md
@@ -60,14 +60,13 @@ mcp/
     ├── playbook_tools.py           # get-close-playbook (close-workflow guidance)
     ├── graph_tools.py              # create-subgraph, delete-subgraph, list-subgraphs,
     │                               # materialize, get-graph-sync-status, create-backup,
-    │                               # set-write-policy, resolve-subgraph
+    │                               # set-write-policy, list-subgraphs
     │
     │ # Layer 3: Document search + management (SEMANTIC_SEARCH_ENABLED)
     ├── search_tools.py      # search-documents, get-document-section
     ├── document_tools.py    # create-document, update-document, get-document, list-documents
     │
     │ # Layer 4: Infrastructure (feature-flag gated)
-    │ # (resolve-subgraph lives in graph_tools.py; answered by the remote transport)
     └── subgraph_write_tools.py  # write-graph-cypher, add-node-table, add-relationship-table (MCP_SUBGRAPH_OPS_ENABLED)
 ```
 
@@ -207,22 +206,28 @@ Gated by `SEMANTIC_SEARCH_ENABLED`. Document management tools additionally skip 
 
 **Subgraph navigation:**
 
-`resolve-subgraph` maps a subgraph in this graph's family to the MCP
-endpoint that serves it. It does **not** switch: a connector is anchored to
-one graph by its URL, so the remote transport answers with an address and
-the caller adds that endpoint as its own connector, reusing the same API
-key. Create with `create-subgraph` (which returns the URL directly), then
-`list-subgraphs` to enumerate and `resolve-subgraph` to address.
+`list-subgraphs` is the whole navigation surface. Each row carries the
+graph's `connector_url`, so enumerating and addressing are one call.
+`create-subgraph` returns the same URL directly, which covers the other
+path — you never have to construct one.
 
-It was called `switch-workspace`. The name promised a switch it never
-performed on the remote transport, and "workspace" framed a subgraph as a
-context you inhabit rather than the lightweight artifact it is. The old
-name is still dispatched, unadvertised, so existing prompts and older
-bridge versions keep working.
+There is no tool that changes the active graph, because there is nothing to
+change: a connector is anchored to one graph by its URL. Reaching a
+subgraph means adding its endpoint as its own connector. A key scoped to a
+parent covers that parent's subgraphs, so a parent connector reuses its own
+key; going the other way (subgraph → parent or sibling) it does not, and a
+key for the target comes from the app's MCP page.
+
+Two earlier tools tried to fill this gap and neither earned its place.
+`switch-workspace` named a switch the transport never performed.
+`resolve-subgraph` renamed that honestly but still only formatted a URL out
+of an id `list-subgraphs` already returned — a tool whose output was a
+format string over another tool's output. Both are gone; the URL moved to
+where callers were already looking.
 
 | Tool | Description | Read-only OK |
 |------|-------------|--------------|
-| `resolve-subgraph` | Resolve a subgraph to its MCP endpoint | Yes |
+| `list-subgraphs` | Enumerate this family's graphs, each with its `connector_url` | Yes |
 
 **Subgraph writes** (`MCP_SUBGRAPH_OPS_ENABLED`, writable subgraphs only):
 
@@ -243,7 +248,7 @@ bridge versions keep working.
 | Manifest `has_semantic_enrichment=True` | `resolve-element` |
 | `FACT_GRID_ENABLED=true` | `build-fact-grid` |
 | `SEMANTIC_SEARCH_ENABLED=true` | Layer 3 (search + document management) |
-| `MCP_WORKSPACE_ENABLED=true` | Graph-lifecycle tools (`create-subgraph`, `delete-subgraph`, `create-backup`, `resolve-subgraph`) |
+| `MCP_WORKSPACE_ENABLED=true` | Graph-lifecycle tools (`create-subgraph`, `delete-subgraph`, `create-backup`, `list-subgraphs`) |
 | `MCP_SUBGRAPH_OPS_ENABLED=true` | Layer 4 subgraph write/DDL tools |
 
 A tool that would otherwise be unavailable due to any of these gates returns a structured error via `_tool_unavailable_reason` instead of silently no-oping — clients always see a typed reason when a tool isn't mounted in a given context.

--- a/robosystems/middleware/mcp/tools/__init__.py
+++ b/robosystems/middleware/mcp/tools/__init__.py
@@ -16,7 +16,6 @@ from .graph_tools import (
   GetGraphSyncStatusTool,
   ListSubgraphsTool,
   MaterializeTool,
-  ResolveSubgraphTool,
 )
 from .graphql_tool import GraphqlQueryTool, GraphqlSchemaTool
 from .manager import GraphMCPTools
@@ -45,7 +44,6 @@ __all__ = [
   "ListSubgraphsTool",
   "MaterializeTool",
   "ResolveElementTool",
-  "ResolveSubgraphTool",
   "SchemaTool",
   "WriteCypherTool",
 ]

--- a/robosystems/middleware/mcp/tools/graph_tools.py
+++ b/robosystems/middleware/mcp/tools/graph_tools.py
@@ -392,10 +392,19 @@ class ListSubgraphsTool:
     return {
       "name": "list-subgraphs",
       "description": (
-        "List every subgraph (workspace) under this parent graph, plus the "
-        "parent itself as the `primary` entry. Use the returned "
-        "`subgraph_id` with `resolve-subgraph` or as the `graph_id` in "
-        "future tool calls."
+        "List every subgraph under this parent graph, plus the parent itself "
+        "as the `primary` entry. Each row carries `connector_url` — the MCP "
+        "endpoint that serves that graph.\n\n"
+        "A subgraph is a separate endpoint, not a mode of this one: this "
+        "connector is anchored to its own graph by URL and cannot be "
+        "retargeted. To work in a subgraph, add its `connector_url` as its "
+        "own MCP connector.\n\n"
+        "**Credential:** a key scoped to a parent graph also covers that "
+        "parent's subgraphs, so a connector on the parent can reuse its own "
+        "key on any subgraph listed here. Going the other way — from a "
+        "subgraph to its parent or a sibling — a subgraph-scoped key does "
+        "not reach, and a key for the target is generated from the app's MCP "
+        "page (/connect)."
       ),
       "inputSchema": {
         "type": "object",
@@ -405,9 +414,14 @@ class ListSubgraphsTool:
     }
 
   async def execute(self, arguments: dict[str, Any]) -> dict[str, Any]:
+    from robosystems.config import env
     from robosystems.models.core.graph import Graph
 
     parent_id = self.client.graph_id
+
+    def connector_url(gid: str) -> str:
+      return f"{env.ROBOSYSTEMS_API_URL}/v1/graphs/{gid}/mcp"
+
     session, close = _open_platform_session()
     try:
       subgraphs = (
@@ -426,6 +440,7 @@ class ListSubgraphsTool:
           "description": parent.graph_name if parent else "Primary graph",
           "type": "primary",
           "parent_graph_id": None,
+          "connector_url": connector_url(parent_id),
         }
       )
       for sg in subgraphs:
@@ -437,6 +452,7 @@ class ListSubgraphsTool:
             "type": "subgraph",
             "parent_graph_id": parent_id,
             "created_at": sg.created_at.isoformat() if sg.created_at else None,
+            "connector_url": connector_url(sg.graph_id),
           }
         )
 
@@ -912,70 +928,6 @@ class SyncConnectionTool:
         "Sync dispatched. Poll get-fiscal-calendar until last_sync_at "
         "advances past this dispatch (and any sync_stale blocker clears) "
         "before closing."
-      ),
-    }
-
-
-# ══════════════════════════════════════════════════════════════════════════
-# resolve-subgraph
-# ══════════════════════════════════════════════════════════════════════════
-
-
-class ResolveSubgraphTool:
-  """Resolve a subgraph in this graph's family to its MCP endpoint.
-
-  Named for what it does. It was `switch-workspace`, which promised a switch
-  it has never performed on the remote transport: a connector is anchored to
-  one graph by its URL, so the remote handler answers with an address rather
-  than changing anything (see `_remote_resolve_subgraph`).
-
-  The "workspace" framing went with it. A subgraph is a lightweight artifact
-  — closer to a document or a memory than to a context you inhabit — and
-  calling it a workspace invited exactly the session-switching model the URL
-  anchor rules out.
-
-  The old name is gone rather than aliased. A tool list is re-fetched on
-  every connect, so a caller discovers the new name immediately, and an
-  unknown-tool error is louder than a silent alias — the permission files
-  that still allowed a `list-workspaces` tool the server never had are the
-  argument against keeping dead names around.
-  """
-
-  def __init__(self, graph_client):
-    self.client = graph_client
-
-  def get_tool_definition(self) -> dict[str, Any]:
-    return {
-      "name": "resolve-subgraph",
-      "description": (
-        "Resolve a subgraph in this graph's family to the MCP endpoint that "
-        "serves it, so you can reach it. This connector is anchored to one "
-        "graph by its URL and does not change graphs — the subgraph is a "
-        "separate endpoint you add as its own connector, reusing this "
-        "connector's API key. Pair with `list-subgraphs` to see what exists."
-      ),
-      "inputSchema": {
-        "type": "object",
-        "properties": {
-          "subgraph": {
-            "type": "string",
-            "description": (
-              "Subgraph id (e.g. `kg123_dev`), its short name (`dev`), or "
-              "`primary` for the parent graph."
-            ),
-          },
-        },
-        "required": ["subgraph"],
-        "additionalProperties": False,
-      },
-    }
-
-  async def execute(self, arguments: dict[str, Any]) -> dict[str, Any]:
-    return {
-      "error": "remote_transport_only",
-      "message": (
-        "resolve-subgraph is answered by the remote MCP transport, which "
-        "knows this connector's URL. Call it over the graph's /mcp endpoint."
       ),
     }
 

--- a/robosystems/middleware/mcp/tools/graph_tools.py
+++ b/robosystems/middleware/mcp/tools/graph_tools.py
@@ -917,7 +917,7 @@ class SyncConnectionTool:
 
 
 # ══════════════════════════════════════════════════════════════════════════
-# resolve-subgraph (was switch-workspace)
+# resolve-subgraph
 # ══════════════════════════════════════════════════════════════════════════
 
 
@@ -934,8 +934,11 @@ class ResolveSubgraphTool:
   calling it a workspace invited exactly the session-switching model the URL
   anchor rules out.
 
-  The retired wire name `switch-workspace` stays accepted at dispatch (never
-  advertised) so saved prompts and older bridges keep working.
+  The old name is gone rather than aliased. A tool list is re-fetched on
+  every connect, so a caller discovers the new name immediately, and an
+  unknown-tool error is louder than a silent alias — the permission files
+  that still allowed a `list-workspaces` tool the server never had are the
+  argument against keeping dead names around.
   """
 
   def __init__(self, graph_client):

--- a/robosystems/middleware/mcp/tools/instructions.py
+++ b/robosystems/middleware/mcp/tools/instructions.py
@@ -2,7 +2,7 @@
 Per-graph MCP instructions generator.
 
 Produces the routing guidance handed to MCP clients via the server's
-`instructions` handshake field (and the `resolve-subgraph` tool result). The
+`instructions` handshake field. The
 string is always in the connected agent's context, so it stays short and points
 at the live tool *families* rather than restating each tool's schema — the
 discovery layer that tells an agent which tool to reach for, given an intent.

--- a/robosystems/middleware/mcp/tools/manager.py
+++ b/robosystems/middleware/mcp/tools/manager.py
@@ -99,7 +99,6 @@ SUBGRAPH_TOOL_PROFILE = frozenset(
     # Navigation back out
     "list-subgraphs",
     "resolve-subgraph",
-    "switch-workspace",  # retired alias, still dispatched
   }
 )
 
@@ -1091,10 +1090,8 @@ class GraphMCPTools:
         result = await self.list_subgraphs_tool.execute(arguments)
         return result if return_raw else json.dumps(result, indent=2)
 
-      # `switch-workspace` is the retired name, still dispatched so saved
-      # prompts and older bridge versions keep working after the rename.
-      elif name in ("resolve-subgraph", "switch-workspace"):
-        # Client-side sentinel — the MCP client should intercept locally.
+      elif name == "resolve-subgraph":
+        # Answered by the remote transport, which knows the connector URL.
         if self.resolve_subgraph_tool is None:
           raise ValueError(
             "resolve-subgraph tool is not available. "

--- a/robosystems/middleware/mcp/tools/manager.py
+++ b/robosystems/middleware/mcp/tools/manager.py
@@ -39,7 +39,6 @@ from .graph_tools import (
   GetGraphSyncStatusTool,
   ListSubgraphsTool,
   MaterializeTool,
-  ResolveSubgraphTool,
   SetWritePolicyTool,
   SyncConnectionTool,
 )
@@ -98,7 +97,6 @@ SUBGRAPH_TOOL_PROFILE = frozenset(
     "update-memory",
     # Navigation back out
     "list-subgraphs",
-    "resolve-subgraph",
   }
 )
 
@@ -226,8 +224,8 @@ class GraphMCPTools:
 
     # Layer 3: Graph lifecycle tools — subgraph navigation + lifecycle ops
     # mirroring a subset of the REST `/v1/graphs/{g}/operations/*` surface.
-    # Writes are gated by `read_only`; `resolve-subgraph` only resolves an
-    # address, so it stays available whenever the navigation flag is set.
+    # Writes are gated by `read_only`; `list-subgraphs` is a pure read, so it
+    # stays available whenever the navigation flag is set.
     #
     # Deliberately **not exposed on MCP** — both still live on REST for
     # humans:
@@ -238,12 +236,10 @@ class GraphMCPTools:
     self.create_subgraph_tool = None
     self.delete_subgraph_tool = None
     self.list_subgraphs_tool = None
-    self.resolve_subgraph_tool = None
     self.create_backup_tool = None
     if env.MCP_WORKSPACE_ENABLED:
       # Navigation tools (list / switch) — always available.
       self.list_subgraphs_tool = ListSubgraphsTool(graph_client)
-      self.resolve_subgraph_tool = ResolveSubgraphTool(graph_client)
       # Write tools — blocked on shared-repo or read-only graphs.
       if not read_only:
         self.create_subgraph_tool = CreateSubgraphTool(graph_client)
@@ -657,8 +653,6 @@ class GraphMCPTools:
         are included.
     """
     tools = []
-    if self.resolve_subgraph_tool is not None:
-      tools.append(self.resolve_subgraph_tool.get_tool_definition())
     if self.list_subgraphs_tool is not None:
       tools.append(self.list_subgraphs_tool.get_tool_definition())
     if self.create_subgraph_tool is not None:
@@ -1088,16 +1082,6 @@ class GraphMCPTools:
             "Set MCP_WORKSPACE_ENABLED=true to enable this feature."
           )
         result = await self.list_subgraphs_tool.execute(arguments)
-        return result if return_raw else json.dumps(result, indent=2)
-
-      elif name == "resolve-subgraph":
-        # Answered by the remote transport, which knows the connector URL.
-        if self.resolve_subgraph_tool is None:
-          raise ValueError(
-            "resolve-subgraph tool is not available. "
-            "Set MCP_WORKSPACE_ENABLED=true to enable this feature."
-          )
-        result = await self.resolve_subgraph_tool.execute(arguments)
         return result if return_raw else json.dumps(result, indent=2)
 
       elif name == "create-backup":

--- a/robosystems/middleware/mcp/tools/subgraph_write_tools.py
+++ b/robosystems/middleware/mcp/tools/subgraph_write_tools.py
@@ -52,7 +52,7 @@ def _validate_subgraph_context(graph_id: str) -> dict[str, Any] | None:
       "message": "This tool only works on subgraphs, not the parent graph. "
       "Use create-subgraph to create a subgraph first, "
       "then connect to that subgraph's own MCP endpoint "
-      "(resolve-subgraph returns its URL).",
+      "(list-subgraphs returns each connector_url).",
     }
 
   # Shared repository subgraphs are always read-only

--- a/robosystems/routers/graphs/mcp/execute.py
+++ b/robosystems/routers/graphs/mcp/execute.py
@@ -105,7 +105,6 @@ READ_ONLY_MCP_TOOLS: frozenset[str] = frozenset(
     "get-example-queries",
     "query-graphql",
     "list-subgraphs",
-    "resolve-subgraph",
     # Financial analysis / reporting reads
     "financial-statement-analysis",
     "live-financial-statement",

--- a/robosystems/routers/graphs/mcp/execute.py
+++ b/robosystems/routers/graphs/mcp/execute.py
@@ -106,7 +106,6 @@ READ_ONLY_MCP_TOOLS: frozenset[str] = frozenset(
     "query-graphql",
     "list-subgraphs",
     "resolve-subgraph",
-    "switch-workspace",  # retired alias of resolve-subgraph
     # Financial analysis / reporting reads
     "financial-statement-analysis",
     "live-financial-statement",

--- a/robosystems/routers/graphs/mcp/remote.py
+++ b/robosystems/routers/graphs/mcp/remote.py
@@ -225,7 +225,7 @@ async def _validate_read_access(graph_id: str, current_user: User) -> None:
     sess.close()
 
 
-# On the npx bridge the retired `switch-workspace` mutated client process
+# The npx bridge's own client-side workspace tool mutates client process
 # state. A remote connector has no client process and is URL-anchored to one
 # graph, so the remote surface answers with an address instead — which is why
 # the tool is now named for resolving rather than switching.
@@ -257,8 +257,7 @@ def _remote_resolve_subgraph(graph_id: str, arguments: dict[str, Any]) -> str:
   """
   from robosystems.config import env
 
-  # `workspace_id` is the retired parameter name, still accepted.
-  target = str(arguments.get("subgraph") or arguments.get("workspace_id") or "").strip()
+  target = str(arguments.get("subgraph") or "").strip()
   parent = graph_id.split("_")[0]
   if not target:
     return "Error: subgraph is required (an id, a short name, or 'primary')."
@@ -380,7 +379,7 @@ async def _handle_tools_list(graph_id: str, current_user: User) -> dict[str, Any
     # statement by the StatementKernel and can carry writes on tenant graphs.
     if tool["name"] in READ_ONLY_MCP_TOOLS:
       entry["annotations"] = {"readOnlyHint": True}
-    if tool["name"] in ("resolve-subgraph", "switch-workspace"):
+    if tool["name"] == "resolve-subgraph":
       entry["description"] = _REMOTE_RESOLVE_SUBGRAPH_DESCRIPTION
     mcp_tools.append(entry)
 
@@ -828,9 +827,8 @@ async def _handle_tools_call(
   # resolve-subgraph never reaches the tool layer on this transport: the
   # connector is URL-anchored (a subgraph is another connector URL), so the
   # answer is the target's URL. Runs after the gauntlet — access to THIS
-  # graph is still required to resolve its family's URLs. The retired name
-  # stays accepted so older prompts and bridges keep working.
-  if name in ("resolve-subgraph", "switch-workspace"):
+  # graph is still required to resolve its family's URLs.
+  if name == "resolve-subgraph":
     return _rpc_result(
       msg_id,
       _to_tool_result(

--- a/robosystems/routers/graphs/mcp/remote.py
+++ b/robosystems/routers/graphs/mcp/remote.py
@@ -27,7 +27,6 @@ Transport rules:
 
 import asyncio
 import json
-import re
 import time
 from importlib.metadata import version as pkg_version
 from typing import Any
@@ -225,96 +224,6 @@ async def _validate_read_access(graph_id: str, current_user: User) -> None:
     sess.close()
 
 
-# The npx bridge's own client-side workspace tool mutates client process
-# state. A remote connector has no client process and is URL-anchored to one
-# graph, so the remote surface answers with an address instead — which is why
-# the tool is now named for resolving rather than switching.
-_REMOTE_RESOLVE_SUBGRAPH_DESCRIPTION = (
-  "Resolve a subgraph in this graph's family (or `primary` for the parent) to "
-  "the MCP endpoint that serves it. This connector is anchored to one graph by "
-  "its URL and does not change graphs — the subgraph is a separate endpoint "
-  "you add as its own connector. Within a parent's own subgraphs, this "
-  "connector's API key already covers the target, so reuse it."
-)
-
-
-def _remote_resolve_subgraph(graph_id: str, arguments: dict[str, Any]) -> str:
-  """Answer resolve-subgraph with the target's connector URL (text result).
-
-  Targets are constrained to this connector's graph family — the parent or
-  one of its subgraphs. The URL alone carries no credential, so the caller
-  still has to supply one; what changes is whether they must *mint* one.
-
-  Scope runs one way. ``validate_api_key_with_graph`` honours a scoped key
-  for "its own graph and its subgraphs", so descending — a connector on the
-  parent, targeting one of its subgraphs — the key already in this
-  connector's URL is **guaranteed** to cover the target. Ascending or
-  sideways (subgraph → parent, subgraph → sibling) it is not: a
-  subgraph-scoped key reaches neither. An unscoped user key covers both
-  directions, but we can't tell which kind is in play from here, so the
-  message promises reuse only where it is certain and stays honest about
-  "may already work" everywhere else.
-  """
-  from robosystems.config import env
-
-  target = str(arguments.get("subgraph") or "").strip()
-  parent = graph_id.split("_")[0]
-  if not target:
-    return "Error: subgraph is required (an id, a short name, or 'primary')."
-
-  if target == "primary":
-    target_id = parent
-  elif "_" in target:
-    target_id = target
-  else:
-    target_id = f"{parent}_{target}"
-
-  if not re.fullmatch(GRAPH_OR_SUBGRAPH_ID_PATTERN, target_id):
-    return f"Error: '{target}' is not a valid subgraph id or name."
-
-  if target_id != parent and not target_id.startswith(f"{parent}_"):
-    return (
-      f"Error: '{target}' is outside this connector's graph family "
-      f"('{parent}' and its subgraphs). A different graph needs its own "
-      "connector, set up from that graph's MCP page."
-    )
-
-  connector_url = f"{env.ROBOSYSTEMS_API_URL}/v1/graphs/{target_id}/mcp"
-
-  # Descending within the family is the common case and the certain one.
-  descending = graph_id == parent and target_id != parent
-  credential_step = (
-    (
-      "Reuse the API key this connector already uses — a key scoped to "
-      f"'{graph_id}' covers its subgraphs, so it works on the new URL "
-      "unchanged. No new credential is needed."
-    )
-    if descending
-    else (
-      "Supply a credential the target accepts. A key scoped to a subgraph "
-      "does not reach its parent or siblings, so the current one may not "
-      f"carry over; if it doesn't, generate one from the app's MCP page "
-      f"(/connect) with '{target_id}' selected."
-    )
-  )
-
-  return json.dumps(
-    {
-      "switched": False,
-      "reason": "url_anchored_connector",
-      "target_graph_id": target_id,
-      "connector_url": connector_url,
-      "credential_reuse": "guaranteed" if descending else "depends_on_key_scope",
-      "message": (
-        f"This connector is anchored to graph '{graph_id}' by its URL and "
-        f"does not change graphs. Add an MCP connector for "
-        f"{connector_url}. {credential_step}"
-      ),
-    },
-    indent=2,
-  )
-
-
 async def _handle_initialize(
   graph_id: str, current_user: User, params: dict[str, Any]
 ) -> dict[str, Any]:
@@ -379,8 +288,6 @@ async def _handle_tools_list(graph_id: str, current_user: User) -> dict[str, Any
     # statement by the StatementKernel and can carry writes on tenant graphs.
     if tool["name"] in READ_ONLY_MCP_TOOLS:
       entry["annotations"] = {"readOnlyHint": True}
-    if tool["name"] == "resolve-subgraph":
-      entry["description"] = _REMOTE_RESOLVE_SUBGRAPH_DESCRIPTION
     mcp_tools.append(entry)
 
   return {"tools": mcp_tools}
@@ -823,18 +730,6 @@ async def _handle_tools_call(
       "access_type": access_type,
     },
   )
-
-  # resolve-subgraph never reaches the tool layer on this transport: the
-  # connector is URL-anchored (a subgraph is another connector URL), so the
-  # answer is the target's URL. Runs after the gauntlet — access to THIS
-  # graph is still required to resolve its family's URLs.
-  if name == "resolve-subgraph":
-    return _rpc_result(
-      msg_id,
-      _to_tool_result(
-        {"type": "text", "text": _remote_resolve_subgraph(graph_id, arguments)}
-      ),
-    )
 
   from robosystems.middleware.graph.query_queue import get_query_queue
 

--- a/tests/middleware/mcp/test_subgraph_tool_profile.py
+++ b/tests/middleware/mcp/test_subgraph_tool_profile.py
@@ -79,17 +79,18 @@ class TestSubgraphToolProfile:
       f"profile names matching no real tool: {sorted(unmatched)}"
     )
 
-  def test_the_retired_name_is_gone(self, all_flags_on):
-    """`switch-workspace` must not resurface — not advertised, not dispatched.
+  def test_the_retired_navigation_tools_are_gone(self, all_flags_on):
+    """Neither `switch-workspace` nor `resolve-subgraph` may resurface.
 
-    It was renamed rather than aliased. A tool list is re-fetched on every
-    connect, so callers pick up `resolve-subgraph` immediately, and an
-    unknown-tool error beats a dead name that outlives everyone's memory of
-    what it did.
+    The first advertised a switch the URL-anchored transport never performed;
+    the second only formatted a URL from an id `list-subgraphs` already
+    returns. `list-subgraphs` now carries `connector_url` per row, which is
+    the whole job in the place you were already looking.
     """
     names = {t["name"] for t in _tools_for(PARENT).get_tool_definitions_as_dict()}
-    assert "resolve-subgraph" in names
+    assert "list-subgraphs" in names
     assert "switch-workspace" not in names
+    assert "resolve-subgraph" not in names
 
   def test_the_surface_that_makes_a_subgraph_useful_survives(self, all_flags_on):
     names = {t["name"] for t in _tools_for(SUBGRAPH).get_tool_definitions_as_dict()}

--- a/tests/middleware/mcp/test_subgraph_tool_profile.py
+++ b/tests/middleware/mcp/test_subgraph_tool_profile.py
@@ -69,25 +69,27 @@ class TestSubgraphToolProfile:
     """Every profile name must be a real tool, or the allowlist silently lies.
 
     A misspelled entry withholds a tool it was meant to keep, and nothing
-    fails — the filter just quietly drops it. Two entries are deliberately
-    absent from the advertised list and must stay allowed anyway:
-
-    - `get-graph-info` registers outside this manager.
-    - `switch-workspace` is the retired name of `resolve-subgraph`, still
-      dispatched so older prompts and bridges keep working; it is never
-      advertised, so it can't appear here.
+    fails — the filter just quietly drops it. `get-graph-info` is the one
+    deliberate exception: it registers outside this manager and is listed
+    only so the call_tool guard admits it.
     """
     real = {t["name"] for t in _tools_for(PARENT).get_tool_definitions_as_dict()}
     unmatched = SUBGRAPH_TOOL_PROFILE - real
-    assert unmatched == {"get-graph-info", "switch-workspace"}, (
+    assert unmatched == {"get-graph-info"}, (
       f"profile names matching no real tool: {sorted(unmatched)}"
     )
 
-  def test_the_retired_name_still_dispatches(self, all_flags_on):
-    """The rename must not strand callers holding the old tool name."""
+  def test_the_retired_name_is_gone(self, all_flags_on):
+    """`switch-workspace` must not resurface — not advertised, not dispatched.
+
+    It was renamed rather than aliased. A tool list is re-fetched on every
+    connect, so callers pick up `resolve-subgraph` immediately, and an
+    unknown-tool error beats a dead name that outlives everyone's memory of
+    what it did.
+    """
     names = {t["name"] for t in _tools_for(PARENT).get_tool_definitions_as_dict()}
     assert "resolve-subgraph" in names
-    assert "switch-workspace" not in names, "the retired name must not be advertised"
+    assert "switch-workspace" not in names
 
   def test_the_surface_that_makes_a_subgraph_useful_survives(self, all_flags_on):
     names = {t["name"] for t in _tools_for(SUBGRAPH).get_tool_definitions_as_dict()}

--- a/tests/middleware/mcp/test_tools.py
+++ b/tests/middleware/mcp/test_tools.py
@@ -1,7 +1,7 @@
 """Tests for standalone MCP tools (BuildFactGridTool).
 
 Graph lifecycle tools (`create-subgraph`, `delete-subgraph`,
-`list-subgraphs`, `resolve-subgraph`, `create-backup`, `restore-backup`,
+`list-subgraphs`, `create-backup`, `restore-backup`,
 `materialize`, `get-graph-sync-status`) have dedicated coverage in
 `tests/middleware/mcp/tools/test_graph_tools.py`.
 

--- a/tests/middleware/mcp/tools/test_graph_tools.py
+++ b/tests/middleware/mcp/tools/test_graph_tools.py
@@ -9,7 +9,7 @@ Covers the six tools in `middleware/mcp/tools/graph_tools.py`:
 5. `CreateBackupTool`
 6. `GetGraphSyncStatusTool`
 
-Plus the client-side sentinel `ResolveSubgraphTool` and the platform-DB
+Plus the platform-DB
 connection tools `SetWritePolicyTool` and `SyncConnectionTool`.
 
 Shared-repo gate coverage (the primary defense-in-depth concern) lives
@@ -32,7 +32,6 @@ from robosystems.middleware.mcp.tools.graph_tools import (
   GetGraphSyncStatusTool,
   ListSubgraphsTool,
   MaterializeTool,
-  ResolveSubgraphTool,
   SetWritePolicyTool,
   SyncConnectionTool,
 )
@@ -497,24 +496,6 @@ class TestGetGraphSyncStatusExecute:
 # ══════════════════════════════════════════════════════════════════════════
 # ResolveSubgraphTool (client-side sentinel)
 # ══════════════════════════════════════════════════════════════════════════
-
-
-class TestResolveSubgraph:
-  def test_definition(self) -> None:
-    defn = ResolveSubgraphTool(_client()).get_tool_definition()
-    assert defn["name"] == "resolve-subgraph"
-    assert "subgraph" in defn["inputSchema"]["required"]
-
-  @pytest.mark.asyncio
-  async def test_base_execute_defers_to_the_remote_transport(self) -> None:
-    """Only the remote transport can answer this — it knows the connector URL.
-
-    The base class returns an explicit error rather than a wrong answer, so a
-    caller reaching it through some other path is told where the real
-    implementation lives instead of getting silence.
-    """
-    result = await ResolveSubgraphTool(_client()).execute({"subgraph": "primary"})
-    assert result["error"] == "remote_transport_only"
 
 
 # ══════════════════════════════════════════════════════════════════════════

--- a/tests/middleware/mcp/tools/test_manager_helpers.py
+++ b/tests/middleware/mcp/tools/test_manager_helpers.py
@@ -223,11 +223,6 @@ class TestCallToolErrors:
     assert "not available" in result or "Error" in result
 
   @pytest.mark.asyncio
-  async def test_disabled_resolve_subgraph_raises(self, tools):
-    result = await tools.call_tool("resolve-subgraph", {})
-    assert "not available" in result or "Error" in result
-
-  @pytest.mark.asyncio
   async def test_disabled_add_node_table_raises(self, tools):
     result = await tools.call_tool("add-node-table", {})
     assert "not available" in result or "Error" in result

--- a/tests/routers/graphs/mcp/test_mcp_remote.py
+++ b/tests/routers/graphs/mcp/test_mcp_remote.py
@@ -15,7 +15,6 @@ from robosystems.routers.graphs.mcp.remote import (
   METHOD_NOT_FOUND,
   PARSE_ERROR,
   _event_to_progress,
-  _remote_resolve_subgraph,
   _to_tool_result,
   _tool_error_payload,
   _tool_failure,
@@ -104,46 +103,41 @@ class TestEventToProgress:
 KG = "kg19fb490f76871d22e835"
 
 
-class TestRemoteResolveSubgraph:
-  def test_named_subgraph_builds_id_and_url(self):
-    text = _remote_resolve_subgraph(KG, {"subgraph": "dev"})
-    payload = json.loads(text)
-    assert payload["switched"] is False
-    assert payload["target_graph_id"] == f"{KG}_dev"
-    assert payload["connector_url"].endswith(f"/v1/graphs/{KG}_dev/mcp")
+class TestSubgraphAddressing:
+  """A subgraph is reached by its own connector URL, and only via listing.
 
-  def test_full_subgraph_id_passes_through(self):
-    payload = json.loads(_remote_resolve_subgraph(KG, {"subgraph": f"{KG}_dev"}))
-    assert payload["target_graph_id"] == f"{KG}_dev"
+  Two tools used to stand between a caller and that URL. `switch-workspace`
+  named a switch the URL-anchored transport never performed;
+  `resolve-subgraph` renamed it honestly but still only formatted a URL out
+  of an id `list-subgraphs` already returned. Both are gone — the URL now
+  rides on each `list-subgraphs` row.
 
-  def test_primary_resolves_parent_from_subgraph(self):
-    payload = json.loads(_remote_resolve_subgraph(f"{KG}_dev", {"subgraph": "primary"}))
-    assert payload["target_graph_id"] == KG
+  The deletion also removed an input surface. `resolve-subgraph` took a
+  free-form target and therefore needed its own validation: reject path
+  traversal, reject ids outside this connector's graph family. Those tests
+  lived here. `list-subgraphs` accepts no arguments at all and enumerates
+  from `parent_graph_id`, so a caller cannot aim it anywhere — the class of
+  bug is designed out rather than guarded against.
+  """
 
-  def test_shared_repo_subgraph_resolves(self):
-    payload = json.loads(_remote_resolve_subgraph("sec", {"subgraph": "historical"}))
-    assert payload["target_graph_id"] == "sec_historical"
+  def test_no_navigation_tool_survives_on_the_transport(self):
+    from robosystems.routers.graphs.mcp import remote
 
-  def test_missing_workspace_id_is_error_text(self):
-    assert _remote_resolve_subgraph(KG, {}).startswith("Error:")
+    for gone in ("_remote_resolve_subgraph", "_remote_switch_workspace"):
+      assert not hasattr(remote, gone), f"{gone} should have been removed"
 
-  def test_invalid_characters_rejected(self):
-    text = _remote_resolve_subgraph(KG, {"subgraph": "../etc/passwd"})
-    assert text.startswith("Error:")
+  def test_list_subgraphs_takes_no_input(self):
+    from unittest.mock import MagicMock
 
-  def test_foreign_graph_family_rejected(self):
-    # A full id outside this connector's family must not resolve to a URL.
-    other = "kg29fb490f76871d22e835_dev"
-    text = _remote_resolve_subgraph(KG, {"subgraph": other})
-    assert text.startswith("Error:")
-    assert "family" in text
+    from robosystems.middleware.mcp.tools.graph_tools import ListSubgraphsTool
 
-  def test_message_never_claims_current_key_transfers(self):
-    # A URL-token connector's credential may not cover the target; the
-    # guidance must point at minting one, not claim the same key works.
-    payload = json.loads(_remote_resolve_subgraph(KG, {"subgraph": "dev"}))
-    assert "same API key" not in payload["message"]
-    assert "credential" in payload["message"]
+    client = MagicMock()
+    client.graph_id = KG
+    schema = ListSubgraphsTool(client).get_tool_definition()["inputSchema"]
+
+    # No properties means no target to validate, and nothing to traverse.
+    assert schema["properties"] == {}
+    assert schema["additionalProperties"] is False
 
 
 @pytest.mark.asyncio
@@ -238,8 +232,8 @@ def _make_handler(tools=None, instructions="per-graph guidance"):
         "inputSchema": {"type": "object", "properties": {}},
       },
       {
-        "name": "resolve-subgraph",
-        "description": "client-side text",
+        "name": "read-graph-cypher",
+        "description": "cypher",
         "inputSchema": {"type": "object", "properties": {}},
       },
     ]
@@ -292,7 +286,7 @@ class TestInitialize:
 
 @pytest.mark.asyncio
 class TestToolsList:
-  async def test_shape_annotations_and_description_rewrite(self):
+  async def test_shape_and_readonly_annotations(self):
     handler = _make_handler()
     with (
       patch.object(remote, "_validate_read_access", AsyncMock()),
@@ -304,9 +298,9 @@ class TestToolsList:
 
     tools = {tool["name"]: tool for tool in body["result"]["tools"]}
     assert tools["get-graph-schema"]["annotations"] == {"readOnlyHint": True}
-    # The npx "client-side tool" text must never reach a remote client.
-    assert "client-side" not in tools["resolve-subgraph"]["description"]
-    assert "connector" in tools["resolve-subgraph"]["description"].lower()
+    # Cypher reads stay unhinted — the StatementKernel classifies them per
+    # statement, and they can carry writes on a tenant graph.
+    assert "annotations" not in tools["read-graph-cypher"]
 
 
 @pytest.mark.asyncio
@@ -342,25 +336,40 @@ class TestToolsCall:
     assert body["result"]["isError"] is True
     assert "need a sub" in body["result"]["content"][0]["text"]
 
-  async def test_resolve_subgraph_intercepted_after_gauntlet(self):
+  async def test_subgraph_urls_still_require_access_to_this_graph(self):
+    """Learning a family's connector URLs is gated by the same gauntlet.
+
+    `resolve-subgraph` used to be answered by a special case *after*
+    `authorize_mcp_tool_call`, precisely so resolving an address could not
+    bypass access control. That special case is gone; `list-subgraphs` now
+    carries the URLs and takes the ordinary tool path, so the guarantee has
+    to hold there instead.
+    """
+    handler = _make_handler()
     authorize = AsyncMock(return_value="read")
     with (
       patch.object(remote, "circuit_breaker", Mock()),
       patch.object(remote, "authorize_mcp_tool_call", authorize),
+      patch.object(remote, "get_graph_repository", AsyncMock(return_value=Mock())),
+      patch.object(remote, "MCPHandler", Mock(return_value=handler)),
+      patch.object(
+        remote,
+        "execute_tool_to_json",
+        AsyncMock(return_value={"type": "text", "text": "{}"}),
+      ),
     ):
       request = _make_request(
         {
           "jsonrpc": "2.0",
           "id": 1,
           "method": "tools/call",
-          "params": {"name": "resolve-subgraph", "arguments": {"subgraph": "dev"}},
+          "params": {"name": "list-subgraphs", "arguments": {}},
         }
       )
       body = _body(await dispatch_jsonrpc(request, KG, _make_user()))
 
     authorize.assert_awaited_once()
-    payload = json.loads(body["result"]["content"][0]["text"])
-    assert payload["target_graph_id"] == f"{KG}_dev"
+    assert "result" in body
 
   async def test_success_maps_result_to_content(self):
     handler = _make_handler()

--- a/tests/routers/graphs/test_ops_shared_repo_gates.py
+++ b/tests/routers/graphs/test_ops_shared_repo_gates.py
@@ -149,24 +149,12 @@ class TestSyncConnectionMCPSharedRepoGate:
 
 
 class TestSharedRepoNavigationStillAllowed:
-  """SEC users should still be able to switch between `sec` and
-  `sec_historical`. `resolve-subgraph` only resolves an address, but
-  verify the server-side dispatch doesn't reject it on shared repos."""
+  """A SEC user must still be able to get from `sec` to `sec_historical`.
 
-  def test_resolve_subgraph_tool_registered_on_shared_repo(self) -> None:
-    from robosystems.middleware.mcp.tools.graph_tools import ResolveSubgraphTool
-
-    client = MagicMock()
-    client.graph_id = "sec"
-    client.user = _user()
-
-    tool = ResolveSubgraphTool(client)
-    defn = tool.get_tool_definition()
-
-    # The tool advertises itself normally — the MCP client intercepts
-    # before calling execute. The definition must still be emitted.
-    assert defn["name"] == "resolve-subgraph"
-    assert "subgraph" in defn["inputSchema"]["properties"]
+  The write gates above deny a lot on shared repos; navigation is not one of
+  them. `list-subgraphs` is now the whole navigation surface — it carries
+  each graph's `connector_url` — so if it were gated here, the deeper
+  historical filings would be unreachable rather than merely read-only."""
 
   def test_list_subgraphs_tool_defined_on_shared_repo(self) -> None:
     from robosystems.middleware.mcp.tools.graph_tools import ListSubgraphsTool
@@ -175,6 +163,8 @@ class TestSharedRepoNavigationStillAllowed:
     client.graph_id = "sec"
     client.user = _user()
 
-    tool = ListSubgraphsTool(client)
-    defn = tool.get_tool_definition()
+    defn = ListSubgraphsTool(client).get_tool_definition()
     assert defn["name"] == "list-subgraphs"
+    # The address is the point: naming a subgraph without saying where it
+    # lives would leave the caller exactly where the old tool pair did.
+    assert "connector_url" in defn["description"]


### PR DESCRIPTION
Follow-up to #1076. Three things, and the last one subsumes the first.

## 1. `switch-workspace` → `resolve-subgraph`, no alias

#1076 shipped the rename with the old wire name still dispatched. Removed. MCP tools aren't in either SDK (verified: zero references), tool lists re-fetch on connect, and the npx bridge supplies its own workspace tools in legacy mode. Nothing depended on it.

## 2. …then `resolve-subgraph` deleted too

Asked what it actually did, the honest answer was: not much. Its output was a format string — `{API_URL}/v1/graphs/{id}/mcp` — over an id `list-subgraphs` already returned. And `list-subgraphs`' own description told you to go call it. Two tools for one lookup, neither of them the place you were already looking.

**`list-subgraphs` now carries `connector_url` on every row** (including the `primary` row for the parent) and states the credential rule in its description. `create-subgraph` already returned the URL directly. Both paths to a subgraph are covered; the dedicated tool isn't needed.

Subgraph profile: **13 → 12 tools**. And the model lands where it belongs — a subgraph is a lightweight artifact you list and address, not a context you travel to. You don't *resolve* a file.

**This deletes an input surface rather than guarding one.** `resolve-subgraph` took a free-form target, so it needed its own validation — reject path traversal, reject ids outside this connector's family — with tests for both. `list-subgraphs` takes **no arguments** and enumerates from `parent_graph_id`. A caller cannot aim it anywhere. That class of bug is designed out, not defended against.

One invariant needed re-homing: resolving an address was answered by a special case placed deliberately *after* `authorize_mcp_tool_call`, so learning a family's URLs couldn't bypass access control. That special case is gone; `list-subgraphs` takes the ordinary tool path and runs the same gauntlet. Now asserted there.

The rename in (1) was still worth doing — the old name advertised a verb it never performed — but it treated the symptom.

## 3. Committed Claude settings pruned

`.claude/settings.json` is world-readable; this repo is public.

**18 `mcp__*` entries removed.** They name one contributor's connector setup — `robosystems`, `Context7`, `aws-documentation`, `sequential-thinking`. Nobody else has servers by those names, so they're inert for others while reading as project config. `settings.local.json` (git-ignored) already held 35 such entries and now holds these.

Same config-vs-state line the repo already applies to `.claude/commands/`: what's true for everyone is committed; one person's environment isn't.

**`deepwiki.com` and `instances.vantage.sh` removed** from WebFetch — third-party research sites. What remains is official docs for actual dependencies.

**Two dead/contradictory entries**, both found while in here:

- `Skill(staged-review)` — no such skill exists anywhere.
- `Bash(just create-release:*)` was in **allow *and* ask *and* deny**. Deny wins, so the others were inert, but a self-contradicting rule is one nobody can reason about. Releases stay user-only.

The settings file is also what argued for (1) and (2): it still allowed `mcp__robosystems__list-workspaces`, **a tool the server has never exposed**. A bridge-era name that drifted into an allowlist and outlived everyone's memory of it. That is what a permanent alias becomes.

## Verification

2,552 tests pass across `tests/middleware`, `tests/routers/graphs`, `tests/adapters/sec`. Ruff, format, and basedpyright clean. `settings.json` re-validated as JSON.

Output verified end-to-end:

```json
{
  "subgraph_id": "kg19…_entities",
  "name": "entities",
  "type": "subgraph",
  "connector_url": "https://api.robosystems.ai/v1/graphs/kg19…_entities/mcp"
}
```

Sibling cleanups: `robosystems-mcp-client` README in RoboFinSystems/robosystems-mcp-client#65; `robosystems-content-machine` committed locally, awaiting your push.