### PR TITLE
fix(worker): point the worker at the real Dagster webserver address

### DIFF
--- a/cloudformation/worker.yaml
+++ b/cloudformation/worker.yaml
@@ -450,6 +450,14 @@ Resources:
               Value: "postgres"
             - Name: DAGSTER_POSTGRES_DB
               Value: dagster
+            # Address of the Dagster webserver's GraphQL API. Without these the
+            # worker falls back to env.py's compose default ("dagster-webserver"),
+            # which doesn't resolve in the VPC, and every job the worker submits
+            # (backup, restore, materialize) fails at DNS resolution.
+            - Name: DAGSTER_HOST
+              Value: !Sub webserver.dagster.${Environment}.robosystems.local
+            - Name: DAGSTER_PORT
+              Value: "3000"
           Secrets:
             - Name: POSTGRES_PASSWORD
               ValueFrom: !Sub "arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:robosystems/${Environment}/postgres:POSTGRES_PASSWORD::"


### PR DESCRIPTION
## Problem

`cloudformation/worker.yaml` never set `DAGSTER_HOST`, so the worker container fell back to the default in `robosystems/config/env.py:972`:

```python
DAGSTER_HOST = get_str_env("DAGSTER_HOST", "dagster-webserver")
```

That default is the local docker-compose service name. It doesn't resolve inside the VPC, so every Dagster job the worker submitted failed at DNS:

```
NameResolutionError: HTTPConnection(host='dagster-webserver', port=3000):
Failed to resolve 'dagster-webserver' ([Errno -2] Name or service not known)
```

`cloudformation/api.yaml` has carried the correct service-discovery address since Dagster was introduced. `git log -S DAGSTER_HOST -- cloudformation/worker.yaml` returns nothing — the worker never had it, so this path has never worked in ECS. It stayed invisible because the API returns `202 Accepted` as soon as the task is enqueued; the failure only surfaces downstream on the SSE stream.

The Dagster webserver itself is healthy and `webserver.dagster.prod.robosystems.local` resolves — only the address the worker dialed was wrong.

## Evidence

Two `dagster_job_monitor` tasks in the prod worker log over the last 14 days, zero successes — both failed with the same DNS error (`op_01KZAREXHPEA5FX8F…` on 2026-08-06, `op_01KZEMD4JDPQ1CVBWQMB0RGV9Q` on 2026-08-07).

## Blast radius

Every `enqueue_task(task_type="dagster_job_monitor")` caller:

- `routers/graphs/operations.py:609` — create-backup
- `routers/graphs/operations.py:744` — restore-backup
- `operations/graph/commands/materialize.py:218` — materialize
- `middleware/mcp/tools/graph_tools.py:648` — the MCP graph tools

Staging and prod worker task definitions are both missing the variable; the `!Sub` covers both.

## Fix

Adds `DAGSTER_HOST` / `DAGSTER_PORT` to the worker task definition, matching what `api.yaml` already does.

## Deploy notes

Task-definition parameter change, so CloudFormation cycles the worker tasks automatically — no ASG refresh needed. Backups will keep failing until the worker stack is deployed.

## Follow-up worth considering

A startup check in `config/validation.py` that rejects a compose-default hostname in a non-dev environment would turn this class of bug into a loud boot failure instead of a silent 100% failure rate nobody noticed. Not included here to keep the fix minimal.