### PR TITLE
feat(graphs): subgraph write-surface gates + durable-bytes storage accounting

### DIFF
--- a/robosystems/graph_api/core/storage_breakdown.py
+++ b/robosystems/graph_api/core/storage_breakdown.py
@@ -26,6 +26,17 @@ TYPE_MEMORY = "memory"
 TYPE_SUBGRAPH = "subgraph"
 TYPE_VECTORS = "vectors"
 TYPE_STAGING = "staging"
+TYPE_TRANSIENT = "transient"
+
+# Applied by the platform API, not here: a `{parent}_*` database with no row in
+# the graph registry. This module is instance-local and cannot tell a live
+# subgraph from the remains of a deleted one, so it reports both as
+# TYPE_SUBGRAPH and the registry-aware layer re-labels what it knows is gone.
+TYPE_ORPHAN = "orphan"
+
+# Blue-green build artifacts (see `swap_database`). Real disk, but transient and
+# reclaimable, so they are reported apart from the databases they belong to.
+TRANSIENT_SUFFIXES = ("-wip", "-prev")
 
 
 def path_size_bytes(path: Path) -> int:
@@ -53,18 +64,40 @@ def path_size_bytes(path: Path) -> int:
   return total
 
 
+def _base_name(name: str) -> str:
+  """Strip a blue-green suffix, leaving the database the artifact belongs to."""
+  for suffix in TRANSIENT_SUFFIXES:
+    if name.endswith(suffix):
+      return name[: -len(suffix)]
+  return name
+
+
 def _owns(name: str, graph_id: str) -> bool:
   """Whether an on-disk name belongs to this graph.
 
   Exact match is the graph itself; the ``_`` boundary covers its memory
   database and subgraphs. Top-level ids are fixed-length ``kg`` + hex, so the
   prefix cannot collide with a different tenant's graph.
+
+  Matching on the base name is what brings the graph's *own* build artifacts
+  into scope. ``{graph_id}-wip`` uses a hyphen, so it failed both arms of this
+  test and went uncounted, while a subgraph's ``{graph_id}_{name}-wip`` passed
+  on the ``_`` prefix — the same artifact counted or not depending on which
+  database it was built for.
   """
-  return name == graph_id or name.startswith(f"{graph_id}_")
+  base = _base_name(name)
+  return base == graph_id or base.startswith(f"{graph_id}_")
 
 
 def _classify_lbug(stem: str, graph_id: str) -> str:
-  """Classify a `.lbug` database by its name."""
+  """Classify a `.lbug` database by its name.
+
+  Order matters: the transient check comes first because a subgraph's build
+  artifact matches the subgraph fallthrough below, and reporting it as a
+  subgraph is what made the storage breakdown disagree with the subgraph list.
+  """
+  if stem.endswith(TRANSIENT_SUFFIXES):
+    return TYPE_TRANSIENT
   if stem == graph_id:
     return TYPE_GRAPH
   if stem == f"{graph_id}_memory":
@@ -141,7 +174,7 @@ def compute_storage_breakdown(graph_id: str) -> dict[str, Any]:
 
   Returns:
       ``{graph_id, total_bytes, items: [{type, id, bytes}]}`` where ``type``
-      is one of graph, memory, subgraph, vectors, staging.
+      is one of graph, memory, subgraph, vectors, staging, transient.
 
   Raises:
       HTTPException: If ``graph_id`` fails name validation.

--- a/robosystems/middleware/graph/ingestion_limits.py
+++ b/robosystems/middleware/graph/ingestion_limits.py
@@ -187,6 +187,7 @@ class IngestionLimitChecker:
           "(Graph API unavailable). Retry shortly."
         ],
         "total_storage_gb": None,
+        "enforced_storage_gb": None,
         "limit_gb": limit_gb,
         "usage_percentage": None,
         "status": "unknown",
@@ -194,7 +195,7 @@ class IngestionLimitChecker:
         "items": [],
       }
 
-    items: list[dict[str, Any]] = breakdown.get("items", [])
+    items = cls._label_orphans(db, graph_id, breakdown.get("items", []))
     total_bytes = breakdown.get("total_bytes", 0)
 
     # Roll the itemized view up per database for the summary shape, so a
@@ -210,14 +211,37 @@ class IngestionLimitChecker:
       {
         "graph_id": gid,
         "is_parent": gid == graph_id,
-        "size_mb": round(size / (1024**2), 2),
+        # Same reason as total_storage_gb below: 2 decimals of MB bottoms out
+        # at ~10.24 KB, which is larger than a freshly created subgraph.
+        "size_mb": round(size / (1024**2), 6),
       }
       for gid, size in sorted(bytes_by_database.items())
     ]
 
-    total_storage_gb = round((total_bytes or 0) / (1024**3), 2)
+    # Not rounded to 2 decimals. A tenant's whole footprint is routinely tens
+    # of megabytes against a 20 GB cap, and 0.01 GB is a ~10.7 MB quantum —
+    # enough to erase the entire number and to disagree visibly with the
+    # itemized bytes below it. 9 decimals is byte-level.
+    total_storage_gb = round((total_bytes or 0) / (1024**3), 9)
+
+    # The cap is enforced on durable bytes only. A blue-green build briefly
+    # holds a `-wip` copy the size of the database it is rebuilding — counting
+    # it would fail a tenant near the cap in the middle of every materialize,
+    # and a `-wip` left by a crashed build would block the very operation
+    # (materialization) that rebuilds and reclaims it. Orphans stay counted:
+    # they are durable, and blocking on them surfaces registry drift instead
+    # of hiding it. `total_storage_gb` above stays the full real-disk figure —
+    # it is what metering records and what the itemized list sums to.
+    from robosystems.graph_api.core.storage_breakdown import TYPE_TRANSIENT
+
+    transient_bytes = sum(
+      item.get("bytes", 0) for item in items if item.get("type") == TYPE_TRANSIENT
+    )
+    enforced_storage_gb = round(
+      max((total_bytes or 0) - transient_bytes, 0) / (1024**3), 9
+    )
     usage_percentage = (
-      round((total_storage_gb / limit_gb) * 100, 1) if limit_gb > 0 else 0
+      round((enforced_storage_gb / limit_gb) * 100, 1) if limit_gb > 0 else 0
     )
 
     # Determine status
@@ -231,7 +255,7 @@ class IngestionLimitChecker:
     errors: list[str] = []
     if instance_status == "over_limit":
       errors.append(
-        f"Aggregate instance storage {total_storage_gb:.2f} GB exceeds "
+        f"Aggregate instance storage {enforced_storage_gb:.2f} GB exceeds "
         f"{tier} limit of {limit_gb:.0f} GB ({usage_percentage:.1f}%). "
         f"Upgrade tier or reduce data before materializing."
       )
@@ -241,12 +265,81 @@ class IngestionLimitChecker:
       "retryable": False,
       "errors": errors,
       "total_storage_gb": total_storage_gb,
+      "enforced_storage_gb": enforced_storage_gb,
       "limit_gb": limit_gb,
       "usage_percentage": usage_percentage,
       "status": instance_status,
       "databases": databases,
       "items": items,
     }
+
+  @classmethod
+  def _label_orphans(
+    cls, db: Session, graph_id: str, items: list[dict[str, Any]]
+  ) -> list[dict[str, Any]]:
+    """Re-label items belonging to subgraphs the graph registry has no row for.
+
+    ``compute_storage_breakdown`` runs on the instance and classifies every
+    ``{parent}_*`` database as a subgraph, because from there a live subgraph
+    and the remains of a deleted one look identical. Only here, with a session
+    in hand, can the two be told apart.
+
+    That mattered beyond tidiness: ``/usage`` sums these items by type while
+    the subgraphs page sums by registered id, so leftovers inflated one number
+    and not the other, and the same graph reported two different subgraph
+    footprints. The pass covers a deleted subgraph's whole estate — its
+    database, its vector index, and any staging file it accumulated before
+    staging was closed to subgraphs — not just the ``.lbug`` file. Bytes are
+    untouched — this is a labelling pass, and orphans still occupy disk and
+    still count against the cap.
+    """
+    from robosystems.graph_api.core.storage_breakdown import (
+      TYPE_ORPHAN,
+      TYPE_STAGING,
+      TYPE_SUBGRAPH,
+      TYPE_VECTORS,
+    )
+
+    subgraph_shaped_types = (TYPE_SUBGRAPH, TYPE_VECTORS, TYPE_STAGING)
+
+    def _subgraph_estate(item: dict[str, Any]) -> bool:
+      """Whether this item's id names a subgraph (live or deleted).
+
+      The ``_memory`` exclusion matters for the vectors arm: the memory
+      database's index is ``{parent}_memory``, which is subgraph-shaped but
+      never registered, and must not read as an orphan.
+      """
+      item_id = item.get("id") or ""
+      return (
+        item.get("type") in subgraph_shaped_types
+        and item_id.startswith(f"{graph_id}_")
+        and item_id != f"{graph_id}_memory"
+      )
+
+    if not any(_subgraph_estate(item) for item in items):
+      return items
+
+    try:
+      from robosystems.models.core import Graph
+
+      registered = {
+        str(row[0])
+        for row in db.query(Graph.graph_id)
+        .filter(Graph.parent_graph_id == graph_id, Graph.deleted_at.is_(None))
+        .all()
+      }
+    except Exception as e:
+      # A labelling refinement is not worth failing a storage check over —
+      # the cap reads bytes, which this pass does not touch.
+      logger.debug(f"Could not resolve registered subgraphs for {graph_id}: {e}")
+      return items
+
+    return [
+      {**item, "type": TYPE_ORPHAN}
+      if _subgraph_estate(item) and item.get("id") not in registered
+      else item
+      for item in items
+    ]
 
   @classmethod
   def _get_pending_row_counts(cls, db: Session, graph_id: str) -> dict[str, int]:

--- a/robosystems/middleware/mcp/tools/manager.py
+++ b/robosystems/middleware/mcp/tools/manager.py
@@ -270,6 +270,7 @@ class GraphMCPTools:
       self._has_extension("roboledger")
       and env.ROBOLEDGER_ENABLED
       and not self._is_shared_repository()
+      and not self._is_subgraph()
       and not read_only
     ):
       self.get_graph_sync_status_tool = GetGraphSyncStatusTool(graph_client)
@@ -286,9 +287,11 @@ class GraphMCPTools:
     # sync-freshness pair; get-fiscal-calendar / get-graph-sync-status are
     # the read half). Same gate as set-write-policy: platform-DB,
     # writable user graphs only — not roboledger-gated because the REST
-    # sync endpoint isn't either.
+    # sync endpoint isn't either. Withheld from subgraphs alongside its
+    # read half above: connections are registered to the parent, and a sync
+    # feeds the staging pipeline the subgraph doesn't have.
     self.sync_connection_tool = None
-    if not read_only and not self._is_shared_repository():
+    if not read_only and not self._is_shared_repository() and not self._is_subgraph():
       self.sync_connection_tool = SyncConnectionTool(graph_client)
 
     # Layer 2: Period-workflow read tools (gated by roboledger extension
@@ -469,8 +472,13 @@ class GraphMCPTools:
 
       self.semantic_recall_tool = SemanticRecallTool(graph_client)
       if not read_only:
-        self.semantic_remember_tool = SemanticRememberTool(graph_client)
-        self.semantic_update_memory_tool = SemanticUpdateMemoryTool(graph_client)
+        # A subgraph gets no memory store of its own, so the two tools that
+        # would create one are withheld. Forget stays — see the note on the
+        # REST `forget` op: anything stored before the gate must still be
+        # removable.
+        if not self._is_subgraph():
+          self.semantic_remember_tool = SemanticRememberTool(graph_client)
+          self.semantic_update_memory_tool = SemanticUpdateMemoryTool(graph_client)
         self.semantic_forget_tool = SemanticForgetTool(graph_client)
 
     # Layer 3: Document management tools (user graphs only, not shared repos)
@@ -586,6 +594,23 @@ class GraphMCPTools:
       )
 
       return is_shared_repository_or_subgraph(self.client.graph_id)
+    except Exception:
+      return False
+
+  def _is_subgraph(self) -> bool:
+    """Whether this connector is pointed at a subgraph.
+
+    Subgraphs are the direct-write surface (write-cypher, schema extension),
+    which is mutually exclusive with the staging pipeline: materialization
+    swaps a rebuilt database over the active one and would discard those
+    writes. They also get no semantic memory. MCP dispatch bypasses FastAPI
+    DI, so the REST gate in `routers/graphs/operations` has to be mirrored
+    here or the connector is a way around it.
+    """
+    try:
+      from robosystems.middleware.graph.utils import is_subgraph
+
+      return is_subgraph(self.client.graph_id)
     except Exception:
       return False
 

--- a/robosystems/models/api/graphs/limits.py
+++ b/robosystems/models/api/graphs/limits.py
@@ -120,7 +120,12 @@ class StorageItem(BaseModel):
 
   type: str = Field(
     ...,
-    description="One of: graph, memory, subgraph, vectors, staging",
+    description=(
+      "One of: graph, memory, subgraph, vectors, staging, transient "
+      "(blue-green build artifact), orphan (a `{parent}_*` database, vector "
+      "index, or staging file with no row in the graph registry — reclaimable "
+      "leftover of a deleted subgraph)"
+    ),
   )
   id: str = Field(..., description="Database or index identifier")
   bytes: int = Field(..., description="Size in bytes")
@@ -141,7 +146,13 @@ class InstanceUsage(BaseModel):
   )
   limit_gb: float = Field(..., description="Soft storage limit for this tier in GB")
   usage_percentage: float | None = Field(
-    None, description="Storage usage as percentage of limit (e.g. 105.2)"
+    None,
+    description=(
+      "Storage usage as percentage of limit (e.g. 105.2). Derived from the "
+      "enforced figure — durable bytes only, excluding `transient` build "
+      "artifacts — so it can read lower than total_storage_gb/limit_gb "
+      "while a blue-green rebuild is in flight."
+    ),
   )
   status: str = Field(
     ...,
@@ -154,8 +165,10 @@ class InstanceUsage(BaseModel):
   items: list[StorageItem] = Field(
     default_factory=list,
     description=(
-      "Itemized storage by type — graph, memory, subgraph, vectors, staging. "
-      "Sums to total_storage_gb."
+      "Itemized storage by type — graph, memory, subgraph, vectors, staging, "
+      "transient, orphan. Sums to total_storage_gb. Only `subgraph` items "
+      "correspond to live subgraphs, so this is the type to sum when "
+      "reconciling against the subgraph list."
     ),
   )
 

--- a/robosystems/operations/graph/commands/ingest_file.py
+++ b/robosystems/operations/graph/commands/ingest_file.py
@@ -103,7 +103,10 @@ async def ingest_file_cmd(
     )
 
   storage_limit_bytes = storage_check["limit_gb"] * 1024**3
-  current_storage_bytes = (storage_check["total_storage_gb"] or 0) * 1024**3
+  # Headroom is judged on the enforced figure, which excludes blue-green
+  # `-wip`/`-prev` build artifacts — same basis as the cap check itself, so an
+  # in-flight rebuild doesn't reject uploads the durable footprint can absorb.
+  current_storage_bytes = (storage_check["enforced_storage_gb"] or 0) * 1024**3
   if (
     not storage_check["allowed"]
     or current_storage_bytes + actual_file_size > storage_limit_bytes

--- a/robosystems/operations/graph/tier_validation.py
+++ b/robosystems/operations/graph/tier_validation.py
@@ -73,7 +73,9 @@ async def validate_storage_capacity(
   storage_info = await IngestionLimitChecker.check_instance_storage(
     db, graph_id, current_tier
   )
-  total_gb = storage_info.get("total_storage_gb")
+  # Judged on durable bytes: a blue-green `-wip`/`-prev` artifact is reclaimed
+  # by the next successful build and should not pin a graph to a larger tier.
+  total_gb = storage_info.get("enforced_storage_gb")
 
   # Fail closed: approving a downgrade without knowing the usage could land
   # a graph over its new, smaller cap the moment the change completes.

--- a/robosystems/routers/graphs/content_ops.py
+++ b/robosystems/routers/graphs/content_ops.py
@@ -58,6 +58,9 @@ from robosystems.routers.graphs.operations import (
   _AUDIT_EVENT,
   _GRAPH_OPS_PATH,
   _RATE_LIMIT,
+  _SUBGRAPH_NO_MEMORY,
+  _SUBGRAPH_NO_STAGING,
+  _block_subgraph,
   _ctx,
   _dispatch,
 )
@@ -169,6 +172,7 @@ async def remember_op(
 
   _require_memory_enabled()
   _block_shared_repo(graph_id)
+  _block_subgraph(graph_id, _SUBGRAPH_NO_MEMORY)
   _require_graph_write_access(graph_id, str(user.id))
 
   op_name = "remember"
@@ -231,6 +235,9 @@ async def forget_op(
 
   _require_memory_enabled()
   _block_shared_repo(graph_id)
+  # Deliberately not `_block_subgraph`: `remember` is closed, but anything a
+  # subgraph stored before that must still be removable without deleting the
+  # whole subgraph. Closing the way out as well as the way in strands data.
   _require_graph_write_access(graph_id, str(user.id))
 
   op_name = "forget"
@@ -291,6 +298,7 @@ async def update_memory_op(
 
   _require_memory_enabled()
   _block_shared_repo(graph_id)
+  _block_subgraph(graph_id, _SUBGRAPH_NO_MEMORY)
   _require_graph_write_access(graph_id, str(user.id))
 
   op_name = "update-memory"
@@ -512,6 +520,7 @@ async def create_file_upload_op(
   )
 
   _block_shared_repo(graph_id)
+  _block_subgraph(graph_id, _SUBGRAPH_NO_STAGING)
   _require_graph_write_access(graph_id, str(user.id))
 
   op_name = "create-file-upload"
@@ -568,6 +577,7 @@ async def ingest_file_op(
   from robosystems.operations.graph.commands.ingest_file import ingest_file_cmd
 
   _block_shared_repo(graph_id)
+  _block_subgraph(graph_id, _SUBGRAPH_NO_STAGING)
   _require_graph_write_access(graph_id, str(user.id))
 
   op_name = "ingest-file"
@@ -649,6 +659,8 @@ async def delete_file_op(
   from robosystems.operations.graph.commands.delete_file import delete_file_cmd
 
   _block_shared_repo(graph_id)
+  # Deliberately not `_block_subgraph`: uploads are closed, but files staged
+  # before that must stay removable. See the note on `forget`.
   _require_graph_write_access(graph_id, str(user.id))
 
   op_name = "delete-file"

--- a/robosystems/routers/graphs/limits.py
+++ b/robosystems/routers/graphs/limits.py
@@ -166,10 +166,28 @@ async def get_graph_limits(
 
         current_storage_gb = breakdown.get("total_bytes", 0) / (1024**3)
 
+        # The warning flag reads durable bytes only, matching cap enforcement:
+        # a blue-green `-wip` copy the size of the database would trip it on
+        # every rebuild of a graph past ~40% usage.
+        from robosystems.graph_api.core.storage_breakdown import TYPE_TRANSIENT
+
+        transient_bytes = sum(
+          item.get("bytes", 0)
+          for item in breakdown.get("items", [])
+          if item.get("type") == TYPE_TRANSIENT
+        )
+        durable_storage_gb = (breakdown.get("total_bytes", 0) - transient_bytes) / (
+          1024**3
+        )
+
         storage_limits = {
-          "current_usage_gb": round(current_storage_gb, 2),
+          # Byte-level precision, not 2 decimals. Rounding to 0.01 GB quantises
+          # this to ~10.7 MB, which for a graph in the tens of megabytes both
+          # destroys the figure and makes it contradict the itemized breakdown
+          # rendered directly beneath it.
+          "current_usage_gb": round(current_storage_gb, 9),
           "max_storage_gb": max_storage_gb,
-          "approaching_limit": current_storage_gb > (max_storage_gb * 0.8),
+          "approaching_limit": durable_storage_gb > (max_storage_gb * 0.8),
         }
       except Exception as e:
         logger.warning(f"Could not get storage info for {graph_id}: {e}")

--- a/robosystems/routers/graphs/operations.py
+++ b/robosystems/routers/graphs/operations.py
@@ -64,6 +64,44 @@ _RATE_LIMIT = Depends(subscription_aware_rate_limit_dependency)
 _GRAPH_OPS_PATH = "/v1/graphs/{graph_id}/operations"
 _AUDIT_EVENT = "graph.operation"
 
+# ── Surfaces refused on subgraphs ──────────────────────────────────────────
+#
+# A subgraph exists to be written to *directly*: raw Cypher and schema
+# extension, which the parent graph refuses outright (see
+# `middleware/mcp/tools/subgraph_write_tools` — "the main graph is read-only to
+# raw statements"). The staging pipeline is the parent's write path and works
+# the opposite way round: it rebuilds the database from DuckDB into a `-wip`
+# copy and file-renames it over the active one (`_materialize_blue_green`).
+# Point both at one database and the swap silently discards every direct write
+# made since staging began. They are not two ways to write — they are two
+# owners of the same file, and only one can win.
+_SUBGRAPH_NO_STAGING = (
+  "The file staging pipeline is not available on subgraphs. Staging rebuilds "
+  "the database and swaps it into place, which would discard the direct writes "
+  "a subgraph exists for. Upload to the parent graph, or write to the subgraph "
+  "directly through its own MCP connector."
+)
+
+# Semantic memory is per-database storage on the parent's instance. A subgraph
+# is meant to be cheap to create and throw away, and its memory would be a
+# second store to keep in step with the parent's for no gain.
+_SUBGRAPH_NO_MEMORY = (
+  "Semantic memory is not available on subgraphs. Store memories on the parent "
+  "graph, or keep the data in the subgraph itself as nodes."
+)
+
+
+def _block_subgraph(graph_id: str, detail: str) -> None:
+  """Refuse a surface that a subgraph must not have.
+
+  Distinct from `_block_shared_repo`, which is about ownership — this is about
+  two write models that cannot share one database.
+  """
+  from robosystems.middleware.graph.utils import is_subgraph
+
+  if is_subgraph(graph_id):
+    raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=detail)
+
 
 def _ctx(
   *,
@@ -886,6 +924,8 @@ async def materialize_op(
 
   op_name = "materialize"
   user_id = str(user.id)
+
+  _block_subgraph(graph_id, _SUBGRAPH_NO_STAGING)
 
   # `get_current_user_with_graph` proves graph membership only; a read-only
   # `viewer` would otherwise reach this write. Enforce member/admin, fail-closed.

--- a/tests/graph_api/core/test_storage_breakdown.py
+++ b/tests/graph_api/core/test_storage_breakdown.py
@@ -94,6 +94,49 @@ class TestComputeStorageBreakdown:
     assert items[f"{GRAPH_ID}_memory"] == "memory"
     assert items[f"{GRAPH_ID}_dev"] == "subgraph"
 
+  def test_classifies_blue_green_artifacts_as_transient(self, roots):
+    """A build artifact must not read as the subgraph it was built for.
+
+    `{parent}_{name}-wip` matches the subgraph prefix, so the classifier's
+    fallthrough labelled it `subgraph` — and `/usage`, which sums by type,
+    reported a footprint the subgraph list (which sums by registered id) could
+    never match.
+    """
+    _write(roots["lbug"] / f"{GRAPH_ID}.lbug", 10)
+    _write(roots["lbug"] / f"{GRAPH_ID}_dev.lbug", 20)
+    _write(roots["lbug"] / f"{GRAPH_ID}_dev-wip.lbug", 40)
+    _write(roots["lbug"] / f"{GRAPH_ID}-prev.lbug", 80)
+
+    items = {i["id"]: i["type"] for i in compute_storage_breakdown(GRAPH_ID)["items"]}
+
+    assert items[f"{GRAPH_ID}_dev"] == "subgraph"
+    assert items[f"{GRAPH_ID}_dev-wip"] == "transient"
+    assert items[f"{GRAPH_ID}-prev"] == "transient"
+
+  def test_subgraph_type_sums_to_live_subgraphs_only(self, roots):
+    """The `subgraph` bucket is what the subgraph list is reconciled against."""
+    _write(roots["lbug"] / f"{GRAPH_ID}_dev.lbug", 20)
+    _write(roots["lbug"] / f"{GRAPH_ID}_dev.lbug.wal", 5)
+    _write(roots["lbug"] / f"{GRAPH_ID}_dev-wip.lbug", 40)
+
+    items = compute_storage_breakdown(GRAPH_ID)["items"]
+    subgraph_bytes = sum(i["bytes"] for i in items if i["type"] == "subgraph")
+
+    assert subgraph_bytes == 25
+
+  def test_counts_the_parents_own_build_artifacts(self, roots):
+    """`{parent}-wip` is hyphenated, so it escaped the ownership test entirely.
+
+    A subgraph's artifact was counted and the parent's was not — the same
+    disk, visible or invisible depending on which database produced it.
+    """
+    _write(roots["lbug"] / f"{GRAPH_ID}.lbug", 100)
+    _write(roots["lbug"] / f"{GRAPH_ID}-wip.lbug", 700)
+
+    result = compute_storage_breakdown(GRAPH_ID)
+
+    assert result["total_bytes"] == 800
+
   def test_folds_wal_into_its_database(self, roots):
     """A WAL is the same logical object as its database to a quota reader."""
     _write(roots["lbug"] / f"{GRAPH_ID}.lbug", 100)

--- a/tests/middleware/graph/test_ingestion_limits.py
+++ b/tests/middleware/graph/test_ingestion_limits.py
@@ -7,6 +7,20 @@ import pytest
 from robosystems.middleware.graph.ingestion_limits import IngestionLimitChecker
 
 
+def _db_with_subgraphs(*graph_ids: str) -> MagicMock:
+  """A session whose registry reports these ids as live subgraphs.
+
+  Orphan labelling asks the registry which `{parent}_*` databases are real, so
+  a bare MagicMock (which iterates empty) would mark every subgraph item as an
+  orphan.
+  """
+  db = MagicMock()
+  db.query.return_value.filter.return_value.all.return_value = [
+    (graph_id,) for graph_id in graph_ids
+  ]
+  return db
+
+
 class TestCheckMaterializationLimits:
   """Test materialization limit checking (per-operation safety limits only)."""
 
@@ -443,7 +457,7 @@ class TestCheckInstanceStorage:
     already itemizes them — no per-subgraph call, and no dependence on the
     graph registry being in step with what is actually on disk.
     """
-    mock_db = MagicMock()
+    mock_db = _db_with_subgraphs("kg_test_dev")
 
     breakdown = {
       "graph_id": "kg_test",
@@ -528,6 +542,253 @@ class TestCheckInstanceStorage:
     assert len(result["databases"]) == 1
     assert result["databases"][0]["size_mb"] == 6 * 1024
     assert result["total_storage_gb"] == 6.0
+
+  @pytest.mark.asyncio
+  async def test_small_footprints_survive_rounding(self):
+    """A graph in the tens of megabytes must not report as a rounded zero.
+
+    2-decimal GB quantises to ~10.7 MB, so a real graph rendered as "0.05 GB"
+    and contradicted the itemized bytes it was supposed to summarise.
+    """
+    mock_db = MagicMock()
+    total = 56 * 1024**2  # 56 MB
+
+    with (
+      patch.object(
+        IngestionLimitChecker,
+        "_get_storage_breakdown",
+        new_callable=AsyncMock,
+        return_value={
+          "total_bytes": total,
+          "items": [{"type": "graph", "id": "kg_test", "bytes": total}],
+        },
+      ),
+      patch(
+        "robosystems.middleware.graph.ingestion_limits.GraphTierConfig.get_instance_storage_limit_gb",
+        return_value=20.0,
+      ),
+      patch(
+        "robosystems.middleware.graph.ingestion_limits.GraphTierConfig.get_graph_limits",
+        return_value={"warn_at_percentage": 80},
+      ),
+    ):
+      result = await IngestionLimitChecker.check_instance_storage(
+        db=mock_db,
+        graph_id="kg_test",
+        tier="ladybug-standard",
+      )
+
+    # Round-trips back to the byte count it was derived from.
+    assert round(result["total_storage_gb"] * 1024**3) == total
+    assert result["databases"][0]["size_mb"] == pytest.approx(56.0)
+
+
+class TestOrphanLabelling:
+  """`{parent}_*` databases with no registry row are not live subgraphs.
+
+  The Graph API cannot tell the difference — it sees disk, not the registry —
+  so it reports both as `subgraph`. Leaving it there made `/usage` (which sums
+  by type) and the subgraphs page (which sums by registered id) disagree about
+  the same graph's subgraph footprint.
+  """
+
+  @staticmethod
+  def _breakdown() -> dict:
+    return {
+      "graph_id": "kg_test",
+      "total_bytes": 3000,
+      "items": [
+        {"type": "graph", "id": "kg_test", "bytes": 1000},
+        {"type": "subgraph", "id": "kg_test_dev", "bytes": 1200},
+        {"type": "subgraph", "id": "kg_test_deleted", "bytes": 800},
+      ],
+    }
+
+  async def _run(self, db, breakdown: dict | None = None) -> dict:
+    with (
+      patch.object(
+        IngestionLimitChecker,
+        "_get_storage_breakdown",
+        new_callable=AsyncMock,
+        return_value=breakdown if breakdown is not None else self._breakdown(),
+      ),
+      patch(
+        "robosystems.middleware.graph.ingestion_limits.GraphTierConfig.get_instance_storage_limit_gb",
+        return_value=20.0,
+      ),
+      patch(
+        "robosystems.middleware.graph.ingestion_limits.GraphTierConfig.get_graph_limits",
+        return_value={"warn_at_percentage": 80},
+      ),
+    ):
+      return await IngestionLimitChecker.check_instance_storage(
+        db=db, graph_id="kg_test", tier="ladybug-standard"
+      )
+
+  @pytest.mark.asyncio
+  async def test_unregistered_subgraphs_become_orphans(self):
+    result = await self._run(_db_with_subgraphs("kg_test_dev"))
+    types = {i["id"]: i["type"] for i in result["items"]}
+
+    assert types["kg_test_dev"] == "subgraph"
+    assert types["kg_test_deleted"] == "orphan"
+
+  @pytest.mark.asyncio
+  async def test_subgraph_bytes_match_the_registered_set(self):
+    """The number `/usage` shows must be the one the subgraphs page sums."""
+    result = await self._run(_db_with_subgraphs("kg_test_dev"))
+    by_type: dict[str, int] = {}
+    for item in result["items"]:
+      by_type[item["type"]] = by_type.get(item["type"], 0) + item["bytes"]
+
+    assert by_type["subgraph"] == 1200
+    assert by_type["orphan"] == 800
+
+  @pytest.mark.asyncio
+  async def test_labelling_does_not_move_bytes(self):
+    """Orphans still occupy disk and still count against the cap."""
+    result = await self._run(_db_with_subgraphs())
+
+    assert sum(i["bytes"] for i in result["items"]) == 3000
+    assert round(result["total_storage_gb"] * 1024**3) == 3000
+
+  @pytest.mark.asyncio
+  async def test_registry_failure_leaves_labels_alone(self):
+    """A labelling refinement must not fail a storage check."""
+    db = MagicMock()
+    db.query.side_effect = RuntimeError("registry unavailable")
+
+    result = await self._run(db)
+
+    assert [i["type"] for i in result["items"]] == ["graph", "subgraph", "subgraph"]
+    assert result["allowed"] is True
+
+  @pytest.mark.asyncio
+  async def test_orphan_covers_the_whole_estate(self):
+    """A deleted subgraph's vector index and staging file are orphans too.
+
+    Everything with the subgraph's id is its estate — except the memory
+    database's index, whose `{parent}_memory` id is subgraph-shaped but never
+    registered, and must not read as an orphan.
+    """
+    breakdown = {
+      "graph_id": "kg_test",
+      "total_bytes": 700,
+      "items": [
+        {"type": "graph", "id": "kg_test", "bytes": 100},
+        {"type": "vectors", "id": "kg_test", "bytes": 100},
+        {"type": "vectors", "id": "kg_test_memory", "bytes": 100},
+        {"type": "subgraph", "id": "kg_test_deleted", "bytes": 100},
+        {"type": "vectors", "id": "kg_test_deleted", "bytes": 100},
+        {"type": "staging", "id": "kg_test_deleted", "bytes": 100},
+        {"type": "vectors", "id": "kg_test_dev", "bytes": 100},
+      ],
+    }
+
+    result = await self._run(_db_with_subgraphs("kg_test_dev"), breakdown)
+    types = [(i["type"], i["id"]) for i in result["items"]]
+
+    assert ("orphan", "kg_test_deleted") in types
+    assert types.count(("orphan", "kg_test_deleted")) == 3
+    assert ("vectors", "kg_test_memory") in types
+    assert ("vectors", "kg_test") in types
+    assert ("vectors", "kg_test_dev") in types
+
+
+class TestTransientEnforcementExclusion:
+  """The cap is enforced on durable bytes only.
+
+  A blue-green rebuild holds a `-wip` copy the size of the database, so
+  counting it would fail a tenant near the cap in the middle of every
+  materialize — and a leftover from a crashed build would block the very
+  operation that reclaims it. The full figure survives in `total_storage_gb`
+  (metering and the itemized list); only enforcement looks away.
+  """
+
+  @staticmethod
+  async def _run(breakdown: dict) -> dict:
+    with (
+      patch.object(
+        IngestionLimitChecker,
+        "_get_storage_breakdown",
+        new_callable=AsyncMock,
+        return_value=breakdown,
+      ),
+      patch(
+        "robosystems.middleware.graph.ingestion_limits.GraphTierConfig.get_instance_storage_limit_gb",
+        return_value=20.0,
+      ),
+      patch(
+        "robosystems.middleware.graph.ingestion_limits.GraphTierConfig.get_graph_limits",
+        return_value={"warn_at_percentage": 80},
+      ),
+    ):
+      return await IngestionLimitChecker.check_instance_storage(
+        db=_db_with_subgraphs(),
+        graph_id="kg_test",
+        tier="ladybug-standard",
+      )
+
+  @pytest.mark.asyncio
+  async def test_in_flight_rebuild_does_not_trip_the_cap(self):
+    """Durable 18 GB + an 18 GB wip copy must not read as 36/20 over-limit."""
+    gb = 1024**3
+    result = await self._run(
+      {
+        "graph_id": "kg_test",
+        "total_bytes": 36 * gb,
+        "items": [
+          {"type": "graph", "id": "kg_test", "bytes": 18 * gb},
+          {"type": "transient", "id": "kg_test-wip", "bytes": 18 * gb},
+        ],
+      }
+    )
+
+    assert result["allowed"] is True
+    assert result["errors"] == []
+    assert result["total_storage_gb"] == 36.0
+    assert result["enforced_storage_gb"] == 18.0
+    assert result["usage_percentage"] == 90.0
+    assert result["status"] == "approaching"
+
+  @pytest.mark.asyncio
+  async def test_orphans_stay_enforced(self):
+    """Orphans are durable: blocking on them surfaces registry drift."""
+    gb = 1024**3
+    result = await self._run(
+      {
+        "graph_id": "kg_test",
+        "total_bytes": 21 * gb,
+        "items": [
+          {"type": "graph", "id": "kg_test", "bytes": 18 * gb},
+          {"type": "subgraph", "id": "kg_test_gone", "bytes": 3 * gb},
+        ],
+      }
+    )
+
+    assert result["items"][1]["type"] == "orphan"
+    assert result["enforced_storage_gb"] == 21.0
+    assert result["allowed"] is False
+    assert result["status"] == "over_limit"
+
+  @pytest.mark.asyncio
+  async def test_genuinely_over_limit_still_blocks(self):
+    """The exclusion is surgical: durable bytes over the cap still refuse."""
+    gb = 1024**3
+    result = await self._run(
+      {
+        "graph_id": "kg_test",
+        "total_bytes": 23 * gb,
+        "items": [
+          {"type": "graph", "id": "kg_test", "bytes": 21 * gb},
+          {"type": "transient", "id": "kg_test-wip", "bytes": 2 * gb},
+        ],
+      }
+    )
+
+    assert result["allowed"] is False
+    assert result["enforced_storage_gb"] == 21.0
+    assert result["total_storage_gb"] == 23.0
 
 
 class TestUnmeasurableStorageFailsClosed:

--- a/tests/middleware/mcp/tools/test_manager_helpers.py
+++ b/tests/middleware/mcp/tools/test_manager_helpers.py
@@ -568,3 +568,62 @@ class TestTaxonomyToolRegistration:
       "create-mapping-association", {"mapping_id": "x"}
     )
     assert "Unknown tool" in registrar_result
+
+
+@pytest.mark.unit
+class TestSubgraphToolGating:
+  """A subgraph connector must not offer the pipeline or memory surfaces.
+
+  MCP dispatch bypasses FastAPI DI, so the REST gate in
+  `routers/graphs/operations` does not cover it — without this mirror the
+  connector handed out by `create-subgraph` is a way around it.
+  """
+
+  @staticmethod
+  def _tools(graph_id: str):
+    client = AsyncMock()
+    client.graph_id = graph_id
+    client.close = AsyncMock()
+    with (
+      patch.object(GraphMCPTools, "_should_include_semantic_tools", return_value=False),
+      patch("robosystems.middleware.mcp.tools.manager.env") as mock_env,
+    ):
+      mock_env.MCP_WORKSPACE_ENABLED = False
+      mock_env.MCP_SUBGRAPH_OPS_ENABLED = False
+      mock_env.FACT_GRID_ENABLED = False
+      mock_env.ROBOLEDGER_ENABLED = True
+      mock_env.EXTENSIONS_ENABLED = True
+      mock_env.SEMANTIC_SEARCH_ENABLED = False
+      mock_env.SEMANTIC_MEMORY_ENABLED = True
+      mock_env.MCP_SEMANTIC_MEMORY_ENABLED = True
+      return GraphMCPTools(client, schema_extensions=["roboledger"], read_only=False)
+
+  def test_materialize_withheld_from_subgraph(self):
+    assert self._tools("kg0123456789abcdef_dev").materialize_tool is None
+
+  def test_materialize_offered_on_parent(self):
+    assert self._tools("kg0123456789abcdef").materialize_tool is not None
+
+  def test_memory_writes_withheld_from_subgraph(self):
+    tools = self._tools("kg0123456789abcdef_dev")
+    assert tools.semantic_remember_tool is None
+    assert tools.semantic_update_memory_tool is None
+
+  def test_memory_cleanup_survives_on_subgraph(self):
+    """Forget stays reachable so anything already stored can be removed."""
+    tools = self._tools("kg0123456789abcdef_dev")
+    assert tools.semantic_forget_tool is not None
+    assert tools.semantic_recall_tool is not None
+
+  def test_memory_writes_offered_on_parent(self):
+    tools = self._tools("kg0123456789abcdef")
+    assert tools.semantic_remember_tool is not None
+    assert tools.semantic_update_memory_tool is not None
+
+  def test_sync_connection_withheld_from_subgraph(self):
+    """Connections belong to the parent, and a sync feeds the staging
+    pipeline the subgraph doesn't have — withheld with its read half."""
+    assert self._tools("kg0123456789abcdef_dev").sync_connection_tool is None
+
+  def test_sync_connection_offered_on_parent(self):
+    assert self._tools("kg0123456789abcdef").sync_connection_tool is not None

--- a/tests/operations/graph/commands/test_ingest_file_gate.py
+++ b/tests/operations/graph/commands/test_ingest_file_gate.py
@@ -23,12 +23,17 @@ def _storage_check(
   retryable: bool = False,
   total_storage_gb: float | None = 1.0,
   limit_gb: float = 20.0,
+  enforced_storage_gb: float | None = None,
 ) -> dict:
   return {
     "allowed": allowed,
     "retryable": retryable,
     "errors": [] if allowed else ["Instance storage exceeds limit"],
     "total_storage_gb": total_storage_gb,
+    # Enforced == total unless a test says otherwise (no transient artifacts).
+    "enforced_storage_gb": (
+      enforced_storage_gb if enforced_storage_gb is not None else total_storage_gb
+    ),
     "limit_gb": limit_gb,
     "usage_percentage": None,
     "status": "healthy" if allowed else "over_limit",
@@ -146,6 +151,30 @@ async def test_upload_without_headroom_blocks():
       await _run()
 
   assert exc.value.status_code == 413
+
+
+@pytest.mark.asyncio
+async def test_headroom_reads_enforced_not_total():
+  """An in-flight blue-green rebuild must not reject uploads.
+
+  Total includes the `-wip` copy and sits at the cap; the durable (enforced)
+  figure has room. Headroom is judged on the latter, same as the cap itself.
+  """
+  mock_graph = MagicMock()
+  mock_graph.parent_graph_id = None
+  mock_graph.graph_tier = "ladybug-standard"
+
+  files, s3, graph, storage = _gate_mocks(
+    50 * MB,
+    graph=mock_graph,
+    storage_check=_storage_check(
+      total_storage_gb=19.99, enforced_storage_gb=10.0, limit_gb=20.0
+    ),
+  )
+  with files, s3, graph, storage:
+    result = await _run()
+
+  assert result is not None
 
 
 @pytest.mark.asyncio

--- a/tests/operations/graph/test_tier_validation.py
+++ b/tests/operations/graph/test_tier_validation.py
@@ -87,7 +87,7 @@ class TestValidateStorageCapacity:
   async def test_passes_when_under_limit(self, mock_tier_config, mock_checker):
     mock_tier_config.get_instance_storage_limit_gb.side_effect = [20, 50]
     mock_checker.check_instance_storage = AsyncMock(
-      return_value={"total_storage_gb": 15}
+      return_value={"total_storage_gb": 15, "enforced_storage_gb": 15}
     )
     db = MagicMock()
 
@@ -102,7 +102,7 @@ class TestValidateStorageCapacity:
   async def test_fails_when_over_limit(self, mock_tier_config, mock_checker):
     mock_tier_config.get_instance_storage_limit_gb.side_effect = [20, 50]
     mock_checker.check_instance_storage = AsyncMock(
-      return_value={"total_storage_gb": 45}
+      return_value={"total_storage_gb": 45, "enforced_storage_gb": 45}
     )
     db = MagicMock()
 

--- a/tests/routers/graphs/test_content_ops.py
+++ b/tests/routers/graphs/test_content_ops.py
@@ -366,3 +366,133 @@ async def test_create_file_upload_op_enforces_write_role():
       )
   assert e.value.status_code == 403
   cmd.assert_not_awaited()
+
+
+# ── Subgraph gates ─────────────────────────────────────────────────────────
+#
+# A subgraph is the direct-write surface: raw Cypher and schema extension,
+# which the parent graph refuses. The staging pipeline is the parent's write
+# path and rebuilds the database into a `-wip` copy that it renames over the
+# active one — so pointing both at one database means the swap silently
+# discards every direct write made since staging. These assert the gate fires
+# before any command runs, on REST and on the MCP mirror.
+
+SUBGRAPH_ID = "kg19ed34f81c37ba3f31fa_entities"
+PARENT_ID = "kg19ed34f81c37ba3f31fa"
+
+
+async def test_ingest_file_blocked_on_subgraph():
+  cmd = AsyncMock()
+  with (
+    patch(f"{MODULE}._block_shared_repo"),
+    patch(f"{MODULE}._require_graph_write_access"),
+    patch(INGEST_CMD, new=cmd),
+  ):
+    with pytest.raises(HTTPException) as e:
+      await ingest_file_op(
+        IngestFileOp(file_id="gf_1"),
+        background_tasks=MagicMock(),
+        graph_id=SUBGRAPH_ID,
+        user=_user(),
+        idempotency_key=None,
+        cache=MagicMock(),
+        db=MagicMock(),
+      )
+  assert e.value.status_code == 403
+  assert "staging" in e.value.detail.lower()
+  cmd.assert_not_awaited()
+
+
+async def test_create_file_upload_blocked_on_subgraph():
+  cmd = AsyncMock()
+  body = FileUploadRequest(
+    file_name="x.parquet", table_name="t", content_type="application/x-parquet"
+  )
+  with (
+    patch(f"{MODULE}._block_shared_repo"),
+    patch(f"{MODULE}._require_graph_write_access"),
+    patch(CREATE_UPLOAD_CMD, new=cmd),
+  ):
+    with pytest.raises(HTTPException) as e:
+      await create_file_upload_op(
+        body,
+        graph_id=SUBGRAPH_ID,
+        user=_user(),
+        idempotency_key=None,
+        cache=MagicMock(),
+        db=MagicMock(),
+      )
+  assert e.value.status_code == 403
+  cmd.assert_not_awaited()
+
+
+async def test_update_memory_blocked_on_subgraph():
+  with (
+    patch(f"{MODULE}._require_memory_enabled"),
+    patch(f"{MODULE}._block_shared_repo"),
+    patch(f"{MODULE}._require_graph_write_access"),
+  ):
+    with pytest.raises(HTTPException) as e:
+      await update_memory_op(
+        UpdateMemoryOp(memory_id="mem_" + "0" * 32, text="hi"),
+        graph_id=SUBGRAPH_ID,
+        user=_user(),
+        idempotency_key=None,
+        cache=MagicMock(),
+      )
+  assert e.value.status_code == 403
+  assert "memory" in e.value.detail.lower()
+
+
+async def test_delete_file_still_allowed_on_subgraph():
+  """The way out stays open — closing it would strand data already staged."""
+  resp = DeleteFileResponse(
+    status="deleted",
+    file_id="gf_1",
+    file_name="x.parquet",
+    message="ok",
+    cascade_deleted=False,
+    tables_affected=[],
+    graph_marked_stale=False,
+  )
+  with (
+    patch(f"{MODULE}._block_shared_repo"),
+    patch(f"{MODULE}._require_graph_write_access"),
+    patch(DELETE_FILE_CMD, new=AsyncMock(return_value=resp)),
+  ):
+    env = await delete_file_op(
+      DeleteFileOp(file_id="gf_1", cascade=False),
+      graph_id=SUBGRAPH_ID,
+      user=_user(),
+      idempotency_key=None,
+      cache=MagicMock(),
+      db=MagicMock(),
+    )
+  assert env.status == "completed"
+
+
+async def test_parent_graph_is_unaffected():
+  """The gate keys on subgraph-ness, not on the id merely containing `_`."""
+  resp = FileUploadResponse(
+    upload_url="https://s3.example/presigned",
+    expires_in=3600,
+    file_id="gf_1",
+    s3_key="user-staging/u/kg/t/gf_1/x.parquet",
+  )
+  body = FileUploadRequest(
+    file_name="x.parquet", table_name="t", content_type="application/x-parquet"
+  )
+  with (
+    patch(f"{MODULE}._block_shared_repo"),
+    patch(f"{MODULE}._require_graph_write_access"),
+    patch(CREATE_UPLOAD_CMD, new=AsyncMock(return_value=resp)),
+  ):
+    env = await create_file_upload_op(
+      body,
+      graph_id=PARENT_ID,
+      user=_user(),
+      idempotency_key=None,
+      cache=MagicMock(),
+      db=MagicMock(),
+    )
+  assert env.status == "completed"

--- a/tests/routers/graphs/test_write_role_gates.py
+++ b/tests/routers/graphs/test_write_role_gates.py
@@ -85,3 +85,35 @@ class TestLifecycleWriteRoleGates:
         )
     assert exc.value.status_code == 403
     gate.assert_called_once_with("usr_1", "kg123")
+
+
+@pytest.mark.unit
+class TestMaterializeSubgraphGate:
+  """Materialization and direct writes cannot share a database.
+
+  Blue-green rebuilds from DuckDB into `{id}-wip` and renames it over the
+  active file, so every direct write made since staging began disappears at
+  the swap. A subgraph exists for those direct writes, so the pipeline is
+  refused there — before the write-role check, since it is a property of the
+  graph rather than of the caller.
+  """
+
+  def test_materialize_blocked_on_subgraph(self):
+    from robosystems.routers.graphs.operations import materialize_op
+
+    gate = MagicMock()
+    with patch(f"{OPS}.require_graph_write_role", gate):
+      with pytest.raises(HTTPException) as exc:
+        asyncio.run(
+          materialize_op(
+            body=MagicMock(),
+            graph_id="kg19ed34f81c37ba3f31fa_entities",
+            user=SimpleNamespace(id="usr_1"),
+            idempotency_key=None,
+            cache=MagicMock(),
+            db=MagicMock(),
+          )
+        )
+    assert exc.value.status_code == 403
+    assert "staging" in exc.value.detail.lower()
+    gate.assert_not_called()


### PR DESCRIPTION
## Summary

Makes the storage breakdown account for everything actually on disk — blue-green build artifacts and leftovers of deleted subgraphs get their own item types instead of masquerading as (or hiding from) the subgraph footprint — and enforces the storage cap on durable bytes only, so an in-flight rebuild can't block the very operation that reclaims it. Separately, closes the surfaces a subgraph must not have: the staging pipeline, materialization, and semantic-memory writes, on both REST and the MCP connector.

## Changes

**Storage accounting (`graph_api/core/storage_breakdown.py`, `middleware/graph/ingestion_limits.py`)**

- New `transient` item type for blue-green `-wip`/`-prev` artifacts. Previously a subgraph's build artifact was classified as a subgraph, while the parent's own `{id}-wip` (hyphenated) escaped the ownership test and went uncounted entirely.
- New `orphan` item type, applied by the platform layer: `{parent}_*` items with no live row in the graph registry. Covers a deleted subgraph's whole estate — database, vector index, and staging file — with the `{parent}_memory` index explicitly protected from mislabelling. This is what made `/usage` (sums by type) and the subgraphs page (sums by registered id) agree again.
- Cap enforcement moves to a new `enforced_storage_gb` figure that excludes `transient` bytes: a rebuild briefly holds a copy the size of the database, and a crashed build's leftover would otherwise block the materialize that rebuilds and reclaims it. Orphans stay counted — they're durable, and blocking on them surfaces registry drift instead of hiding it. `total_storage_gb` remains the full real-disk figure (metering truth; the itemized list sums to it).
- The ingest-file headroom check and tier-downgrade validation read the enforced figure; `/limits`' `approaching_limit` flag uses the same durable-bytes basis. Registry lookups ignore soft-deleted rows.
- Precision: `total_storage_gb` and `current_usage_gb` report at byte level instead of 2-decimal GB (a 0.01 GB quantum erased small tenants' footprints and contradicted the itemized bytes beneath them); `size_mb` likewise.

**Subgraph surface gating (`routers/graphs/operations.py`, `routers/graphs/content_ops.py`, `middleware/mcp/tools/manager.py`)**

- Subgraphs are the direct-write surface (raw Cypher, schema extension); the staging pipeline rebuilds the database and file-swaps it into place, discarding direct writes. The two write models can't share one database, so `materialize`, `create-file-upload`, and `ingest-file` now 403 on subgraphs.
- Semantic memory is parent-level: `remember` and `update-memory` are refused on subgraphs. The exits stay open deliberately — `forget` and `delete-file` still work so anything stored before the gate remains removable.
- The MCP connector mirrors the same gates (`materialize`, `get-graph-sync-status`, `remember`, `update-memory` withheld), since MCP dispatch bypasses FastAPI dependencies. `sync-connection` is withheld alongside its read half: connections belong to the parent, and a sync feeds the staging pipeline the subgraph doesn't have.

**Reviewer notes**

- The enforcement-basis change is the deliberate policy decision in this PR: transient bytes are visible (itemized, in totals) but not enforced. See the comment block in `check_instance_storage`.
- There is currently no reclaim path for a stale `-wip` left by a crashed build other than the next materialize; a GC follow-up may be worth filing.

## Breaking Changes

None. `StorageItem.type` is a plain string in the schema, so the new `transient`/`orphan` values are shape-compatible; `enforced_storage_gb` is internal and not exposed in the response models. Description-text updates can ride the next SDK regen — no coordinated release needed.

## Testing

Full gate run this session: `just test-all` — 12,249 passed, 0 failed (plus dbt, ruff, format, basedpyright, cf-lint all clean). New coverage includes: transient classification and the parent's own artifacts counting; orphan labelling across the estate (and the memory-index exclusion); enforcement excluding transient while keeping orphans and genuine overages blocking; registry-failure fail-open for labelling; REST and MCP subgraph gates firing before any command runs, with the parent unaffected.
