### PR TITLE
feat(storage): daily reclaim of stranded build artifacts and orphan estates

### DIFF
--- a/robosystems/dagster/definitions.py
+++ b/robosystems/dagster/definitions.py
@@ -87,6 +87,10 @@ from robosystems.dagster.jobs.shared_repository import (
   shared_replicas_refresh_job,
   shared_repository_refresh_replicas_job,
 )
+from robosystems.dagster.jobs.storage_reclaim import (
+  daily_storage_reclaim_job,
+  daily_storage_reclaim_schedule,
+)
 from robosystems.dagster.resources import (
   DatabaseResource,
   GraphResource,
@@ -204,6 +208,7 @@ all_jobs = [
   invoice_subscription_renewal_job,
   # Platform: Infrastructure
   daily_backup_cleanup_job,
+  daily_storage_reclaim_job,
   hourly_auth_cleanup_job,
   weekly_health_check_job,
   instance_health_check_job,
@@ -245,6 +250,7 @@ all_schedules = [
   monthly_usage_report_schedule,
   # Platform: Infrastructure
   daily_backup_cleanup_schedule,
+  daily_storage_reclaim_schedule,
   hourly_auth_cleanup_schedule,
   weekly_health_check_schedule,
   instance_health_check_schedule,

--- a/robosystems/dagster/jobs/storage_reclaim.py
+++ b/robosystems/dagster/jobs/storage_reclaim.py
@@ -1,0 +1,133 @@
+"""Dagster storage reclaim job.
+
+Daily sweep deleting the instance storage the breakdown labels reclaimable:
+`transient` blue-green build artifacts stranded by crashed materializations,
+and `orphan` estates left behind by deleted subgraphs. The itemization made
+these visible on ``/usage``; this job is what actually collects them.
+
+Safety properties, in order of importance:
+
+- The Graph API holds the base's materialization lock across a `-wip`/`-prev`
+  delete, so an in-flight build cannot lose the copy it is writing into.
+- Orphan labelling requires a successful registry read; if the registry is
+  unreachable, items stay unlabelled and nothing is deleted (fail-safe).
+- Deleting a stranded WIP costs nothing: builds begin by deleting any
+  leftover WIP, so there are no resume semantics to preserve.
+- ``STORAGE_RECLAIM_ENABLED`` (SSM, read per run) is the runtime kill switch.
+"""
+
+import asyncio
+from datetime import UTC, datetime
+from typing import Any
+
+from dagster import (
+  DefaultScheduleStatus,
+  OpExecutionContext,
+  ScheduleDefinition,
+  job,
+  op,
+)
+
+from robosystems.config import env
+from robosystems.dagster.resources import DatabaseResource
+
+_RECLAIM_ENABLED_FLAG = "STORAGE_RECLAIM_ENABLED"
+
+# Schedule status: RUNNING in prod/staging, STOPPED in dev
+_SCHEDULE_STATUS = (
+  DefaultScheduleStatus.RUNNING
+  if env.ENVIRONMENT != "dev"
+  else DefaultScheduleStatus.STOPPED
+)
+
+
+@op
+def reclaim_instance_storage_sweep(
+  context: OpExecutionContext,
+  db: DatabaseResource,
+) -> dict[str, Any]:
+  """Reclaim transient/orphan storage across all active parent user graphs."""
+  from robosystems.config.parameter_store import get_parameter_value
+  from robosystems.models.core.graph import Graph
+  from robosystems.operations.graph.storage_reclaim import reclaim_instance_storage
+
+  # Read per run rather than at import, so flipping the flag takes effect on
+  # the next run instead of the next deploy.
+  if get_parameter_value(_RECLAIM_ENABLED_FLAG, "true").lower() != "true":
+    context.log.info(f"Storage reclaim disabled via {_RECLAIM_ENABLED_FLAG}")
+    return {"skipped": True, "reason": f"{_RECLAIM_ENABLED_FLAG} is false"}
+
+  graphs_swept = 0
+  error_count = 0
+  total_bytes_freed = 0
+  total_reclaimed = 0
+  total_skipped_items = 0
+
+  with db.get_session() as session:
+    # Same selection as the usage monitor: active parent user graphs with a
+    # tier. Subgraphs share their parent's instance, and the breakdown's
+    # `{id}_*` scan covers them from the parent id.
+    parent_graphs = (
+      session.query(Graph)
+      .filter(
+        Graph.is_repository.is_(False),
+        Graph.parent_graph_id.is_(None),
+        Graph.status == "active",
+        Graph.graph_tier.isnot(None),
+      )
+      .all()
+    )
+
+    context.log.info(
+      f"Sweeping {len(parent_graphs)} parent graphs for reclaimable storage"
+    )
+
+    for graph in parent_graphs:
+      graph_id = str(graph.graph_id)
+      try:
+        result = asyncio.run(reclaim_instance_storage(graph_id, session, dry_run=False))
+      except Exception as e:
+        context.log.warning(f"Reclaim sweep failed for {graph_id}: {e}")
+        error_count += 1
+        continue
+
+      graphs_swept += 1
+      reclaimed = result.get("reclaimed", [])
+      skipped = result.get("skipped", [])
+      total_reclaimed += len(reclaimed)
+      total_skipped_items += len(skipped)
+      total_bytes_freed += result.get("bytes_freed", 0)
+
+      if reclaimed or skipped:
+        context.log.info(
+          f"{graph_id}: reclaimed {len(reclaimed)} "
+          f"({result.get('bytes_freed', 0)} bytes), skipped {len(skipped)}"
+        )
+
+  context.log.info(
+    f"Storage reclaim sweep: {graphs_swept} graphs, "
+    f"{total_reclaimed} items reclaimed ({total_bytes_freed} bytes), "
+    f"{total_skipped_items} skipped, {error_count} errors"
+  )
+
+  return {
+    "graphs_swept": graphs_swept,
+    "items_reclaimed": total_reclaimed,
+    "bytes_freed": total_bytes_freed,
+    "items_skipped": total_skipped_items,
+    "error_count": error_count,
+    "timestamp": datetime.now(UTC).isoformat(),
+  }
+
+
+@job(tags={"dagster/priority": "1", "dagster/max_retries": 3})
+def daily_storage_reclaim_job():
+  """Daily reclaim of transient build artifacts and orphaned subgraph estates."""
+  reclaim_instance_storage_sweep()
+
+
+daily_storage_reclaim_schedule = ScheduleDefinition(
+  job=daily_storage_reclaim_job,
+  cron_schedule="30 5 * * *",  # 5:30 AM UTC daily, after backup cleanup
+  default_status=_SCHEDULE_STATUS,
+)

--- a/robosystems/graph_api/client/client.py
+++ b/robosystems/graph_api/client/client.py
@@ -776,7 +776,11 @@ class GraphClient(BaseGraphClient):
     return response.json()
 
   async def delete_database(
-    self, graph_id: str, preserve_duckdb: bool = False, staging_only: bool = False
+    self,
+    graph_id: str,
+    preserve_duckdb: bool = False,
+    staging_only: bool = False,
+    lock_token: str | None = None,
   ) -> dict[str, Any]:
     """Delete a database.
 
@@ -786,6 +790,11 @@ class GraphClient(BaseGraphClient):
             Useful when you want to rebuild LadybugDB from existing staging.
         staging_only: If True, delete only DuckDB staging, preserve LadybugDB graph.
             Useful for re-staging with different settings.
+        lock_token: Deleting a `-wip`/`-prev` name is guarded by the base's
+            materialization lock. A caller that already holds it (the
+            materialize flow cleaning up its own WIP) passes the token so the
+            endpoint doesn't re-acquire — without it, that delete would 409
+            against the caller's own lock.
 
     Note: preserve_duckdb and staging_only are mutually exclusive.
     """
@@ -794,7 +803,15 @@ class GraphClient(BaseGraphClient):
       params["preserve_duckdb"] = "true"
     if staging_only:
       params["staging_only"] = "true"
-    response = await self._request("DELETE", f"/databases/{graph_id}", params=params)
+    headers: dict[str, str] = {}
+    if lock_token:
+      headers["X-Materialization-Lock-Token"] = lock_token
+    response = await self._request(
+      "DELETE",
+      f"/databases/{graph_id}",
+      params=params,
+      headers=headers or None,
+    )
     return response.json()
 
   # =========================================================================

--- a/robosystems/graph_api/routers/databases/management.py
+++ b/robosystems/graph_api/routers/databases/management.py
@@ -5,7 +5,7 @@ This module provides endpoints for creating, listing, retrieving,
 and deleting LadybugDB graph databases.
 """
 
-from fastapi import APIRouter, Depends, HTTPException, Path, Query
+from fastapi import APIRouter, Depends, Header, HTTPException, Path, Query
 from fastapi import status as http_status
 
 from robosystems.graph_api.core.ladybug import get_ladybug_service
@@ -90,6 +90,12 @@ async def delete_database(
     False,
     description="If true, delete only DuckDB staging database, preserve LadybugDB graph",
   ),
+  x_materialization_lock_token: str | None = Header(
+    default=None,
+    description="Lock token from a materialization caller deleting its own "
+    "-wip/-prev artifact. If provided, the delete trusts the caller's lock "
+    "instead of acquiring one.",
+  ),
   ladybug_service=Depends(get_ladybug_service),
 ) -> dict:
   """
@@ -142,5 +148,51 @@ async def delete_database(
     # Add extra confirmation or restrictions for shared database deletion
     logger.warning(f"Attempting to delete shared database: {graph_id}")
 
-  ladybug_service.db_manager.delete_database(graph_id, preserve_duckdb=preserve_duckdb)
+  # A `-wip`/`-prev` name is a blue-green build artifact, and its base may be
+  # mid-materialization right now — deleting the WIP under an active build
+  # destroys the copy the build is writing into. Hold the base's
+  # materialization lock across the delete, same protocol as `swap_database`:
+  # acquiring (not just checking) closes the window where a build starts
+  # between the check and the unlink. The materialize flow deletes its own
+  # WIP (leftover cleanup, failure cleanup) while already holding this lock —
+  # it passes its token through so those deletes don't 409 against itself.
+  lock = None
+  if graph_id.endswith(("-wip", "-prev")) and not x_materialization_lock_token:
+    try:
+      from robosystems.config.valkey_registry import (
+        ValkeyDatabase,
+        create_async_redis_client,
+      )
+      from robosystems.graph_api.core.ladybug.materialization_lock import (
+        MaterializationLock,
+      )
+
+      redis_client = create_async_redis_client(ValkeyDatabase.LOCKS)
+      lock = MaterializationLock(redis_client, graph_id)
+      if not await lock.acquire(timeout_seconds=5):
+        raise HTTPException(
+          status_code=http_status.HTTP_409_CONFLICT,
+          detail=(
+            f"A materialization is in progress for {graph_id}'s base database; "
+            "the build artifact cannot be deleted while it may be written to."
+          ),
+        )
+    except HTTPException:
+      raise
+    except Exception as e:
+      # Degraded mode mirrors swap_database: an unreachable Valkey should not
+      # make artifacts undeletable forever. In that state materialize also
+      # runs unlocked, so both sides accept the same residual race — and the
+      # active database is never the target either way.
+      logger.warning(f"Could not acquire materialization lock for delete: {e}")
+      lock = None
+
+  try:
+    ladybug_service.db_manager.delete_database(
+      graph_id, preserve_duckdb=preserve_duckdb
+    )
+  finally:
+    if lock is not None and lock.acquired:
+      await lock.release()
+
   return {"status": "success", "message": f"Database {graph_id} deleted successfully"}

--- a/robosystems/middleware/graph/ingestion_limits.py
+++ b/robosystems/middleware/graph/ingestion_limits.py
@@ -195,7 +195,7 @@ class IngestionLimitChecker:
         "items": [],
       }
 
-    items = cls._label_orphans(db, graph_id, breakdown.get("items", []))
+    items = cls.label_orphans(db, graph_id, breakdown.get("items", []))
     total_bytes = breakdown.get("total_bytes", 0)
 
     # Roll the itemized view up per database for the summary shape, so a
@@ -274,7 +274,7 @@ class IngestionLimitChecker:
     }
 
   @classmethod
-  def _label_orphans(
+  def label_orphans(
     cls, db: Session, graph_id: str, items: list[dict[str, Any]]
   ) -> list[dict[str, Any]]:
     """Re-label items belonging to subgraphs the graph registry has no row for.

--- a/robosystems/models/api/graphs/limits.py
+++ b/robosystems/models/api/graphs/limits.py
@@ -123,8 +123,9 @@ class StorageItem(BaseModel):
     description=(
       "One of: graph, memory, subgraph, vectors, staging, transient "
       "(blue-green build artifact), orphan (a `{parent}_*` database, vector "
-      "index, or staging file with no row in the graph registry — reclaimable "
-      "leftover of a deleted subgraph)"
+      "index, or staging file with no row in the graph registry — leftover "
+      "of a deleted subgraph). Transient and orphan items are collected by "
+      "the platform's daily storage-reclaim job."
     ),
   )
   id: str = Field(..., description="Database or index identifier")

--- a/robosystems/operations/extensions/materialize.py
+++ b/robosystems/operations/extensions/materialize.py
@@ -1480,7 +1480,9 @@ class ExtensionsMaterializer:
       wip_exists = await client.database_exists(wip_id)
       if wip_exists:
         logger.info(f"Cleaning up leftover WIP database {wip_id}")
-        await client.delete_database(wip_id, preserve_duckdb=True)
+        await client.delete_database(
+          wip_id, preserve_duckdb=True, lock_token=lock.token if lock else None
+        )
 
       # Step 2: Create fresh WIP database with schema. Mark it is_subgraph so
       # its creation bypasses the per-node max_databases cap — on a dedicated
@@ -1520,7 +1522,9 @@ class ExtensionsMaterializer:
           f"({len(result.errors)} errors), abandoning WIP (active graph untouched)"
         )
         try:
-          await client.delete_database(wip_id, preserve_duckdb=True)
+          await client.delete_database(
+            wip_id, preserve_duckdb=True, lock_token=lock.token if lock else None
+          )
         except Exception as cleanup_err:
           logger.warning(f"Failed to clean up WIP {wip_id} after errors: {cleanup_err}")
 
@@ -1530,7 +1534,9 @@ class ExtensionsMaterializer:
       try:
         wip_exists = await client.database_exists(wip_id)
         if wip_exists:
-          await client.delete_database(wip_id, preserve_duckdb=True)
+          await client.delete_database(
+            wip_id, preserve_duckdb=True, lock_token=lock.token if lock else None
+          )
       except Exception as cleanup_err:
         logger.warning(
           f"Failed to clean up WIP {wip_id} after blue-green failure: {cleanup_err}"

--- a/robosystems/operations/graph/storage_reclaim.py
+++ b/robosystems/operations/graph/storage_reclaim.py
@@ -1,0 +1,125 @@
+"""Reclaim the disk the storage breakdown calls reclaimable.
+
+Two classes of leftover accumulate on an instance and nothing else collects
+them:
+
+- **Transient build artifacts** (`{base}-wip` / `{base}-prev`): a crashed
+  blue-green build strands its WIP copy, and only a later materialization of
+  the *same* database would clean it up (builds start by deleting any leftover
+  WIP — there are no resume semantics, so deleting one early costs nothing).
+  The Graph API refuses the delete while a build holds the base's
+  materialization lock, so an in-flight rebuild cannot lose its target.
+- **Orphan estates**: `{parent}_*` databases (plus their vector indexes and
+  staging files) whose registry row is gone — the remains of a deleted
+  subgraph. ``delete-subgraph`` cannot reach them because it resolves through
+  the registry, which is precisely what no longer knows they exist.
+
+Labelling reuses the same registry pass the storage breakdown uses
+(`IngestionLimitChecker._label_orphans`), so this deletes exactly what
+``/usage`` reports as `orphan`/`transient` — never anything the breakdown
+still attributes to a live database. A registry read failure leaves items
+unlabelled, so orphans are then *not* deleted: the sweep fails safe.
+
+Driven by the daily ``storage_reclaim`` Dagster job, not by any user-facing
+surface.
+
+Known limitation: an orphan whose ``.lbug`` file is already gone but whose
+vector index or staging file lingers is skipped (the Graph API's delete is
+anchored on the database file). Those fragments are rare and small; they are
+reported in ``skipped`` rather than silently ignored.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from robosystems.logger import logger
+
+__all__ = ["reclaim_instance_storage"]
+
+
+async def reclaim_instance_storage(
+  graph_id: str,
+  db: Session,
+  dry_run: bool = False,
+) -> dict[str, Any]:
+  """Delete reclaimable storage items on a parent graph's instance.
+
+  Returns ``{reclaimed, skipped, bytes_freed, ...}`` where ``reclaimed`` and
+  ``skipped`` carry one entry per database id (an estate's lbug/vectors/staging
+  bytes are folded together, mirroring how the breakdown attributes them).
+  """
+  from robosystems.graph_api.client.factory import get_graph_client
+  from robosystems.graph_api.core.storage_breakdown import (
+    TYPE_ORPHAN,
+    TYPE_TRANSIENT,
+  )
+  from robosystems.middleware.graph.ingestion_limits import IngestionLimitChecker
+
+  client = await get_graph_client(graph_id=graph_id, operation_type="write")
+  try:
+    breakdown = await client.get_storage_breakdown(graph_id)
+    items = IngestionLimitChecker._label_orphans(
+      db, graph_id, breakdown.get("items", [])
+    )
+
+    # One entry per database id: an orphan's lbug + vectors + staging items
+    # are a single estate and a single delete call.
+    targets: dict[str, dict[str, Any]] = {}
+    for item in items:
+      if item.get("type") not in (TYPE_TRANSIENT, TYPE_ORPHAN):
+        continue
+      item_id = item.get("id") or ""
+      entry = targets.setdefault(
+        item_id, {"id": item_id, "type": item.get("type"), "bytes": 0}
+      )
+      entry["bytes"] += item.get("bytes", 0)
+
+    plan = sorted(targets.values(), key=lambda e: str(e["id"]))
+
+    if dry_run:
+      return {
+        "graph_id": graph_id,
+        "dry_run": True,
+        "reclaimed": [],
+        "would_reclaim": plan,
+        "skipped": [],
+        "bytes_freed": 0,
+        "bytes_reclaimable": sum(e["bytes"] for e in plan),
+      }
+
+    reclaimed: list[dict[str, Any]] = []
+    skipped: list[dict[str, Any]] = []
+    for entry in plan:
+      target_id = str(entry["id"])
+      try:
+        # A transient artifact shares its base database's name — preserve the
+        # base's DuckDB staging and vector index (deleting only lbug + WAL).
+        # An orphan is a whole estate: take its staging and vectors with it.
+        await client.delete_database(
+          target_id, preserve_duckdb=entry["type"] == TYPE_TRANSIENT
+        )
+        reclaimed.append(entry)
+        logger.info(
+          f"Reclaimed {entry['type']} storage {target_id} "
+          f"({entry['bytes']} bytes) on {graph_id}'s instance"
+        )
+      except Exception as e:
+        # 409 = a materialization holds the base lock (transient artifacts
+        # only); 404 = no lbug file to anchor the delete (vectors/staging
+        # fragment). Both are per-item outcomes, not reasons to abort the
+        # rest of the sweep.
+        skipped.append({**entry, "reason": str(e)})
+        logger.warning(f"Could not reclaim {target_id} on {graph_id}: {e}")
+
+    return {
+      "graph_id": graph_id,
+      "dry_run": False,
+      "reclaimed": reclaimed,
+      "skipped": skipped,
+      "bytes_freed": sum(e["bytes"] for e in reclaimed),
+    }
+  finally:
+    await client.close()

--- a/robosystems/operations/graph/storage_reclaim.py
+++ b/robosystems/operations/graph/storage_reclaim.py
@@ -15,7 +15,7 @@ them:
   the registry, which is precisely what no longer knows they exist.
 
 Labelling reuses the same registry pass the storage breakdown uses
-(`IngestionLimitChecker._label_orphans`), so this deletes exactly what
+(`IngestionLimitChecker.label_orphans`), so this deletes exactly what
 ``/usage`` reports as `orphan`/`transient` — never anything the breakdown
 still attributes to a live database. A registry read failure leaves items
 unlabelled, so orphans are then *not* deleted: the sweep fails safe.
@@ -61,7 +61,7 @@ async def reclaim_instance_storage(
   client = await get_graph_client(graph_id=graph_id, operation_type="write")
   try:
     breakdown = await client.get_storage_breakdown(graph_id)
-    items = IngestionLimitChecker._label_orphans(
+    items = IngestionLimitChecker.label_orphans(
       db, graph_id, breakdown.get("items", [])
     )
 

--- a/tests/dagster/test_storage_reclaim_job.py
+++ b/tests/dagster/test_storage_reclaim_job.py
@@ -1,0 +1,52 @@
+"""Tests for the daily storage reclaim job."""
+
+import pytest
+from dagster import JobDefinition
+
+
+class TestStorageReclaimJobDefinition:
+  """Structure and registration of the storage reclaim job."""
+
+  @pytest.mark.unit
+  def test_job_has_one_op(self):
+    from robosystems.dagster.jobs.storage_reclaim import daily_storage_reclaim_job
+
+    assert isinstance(daily_storage_reclaim_job, JobDefinition)
+    op_names = {op_def.name for op_def in daily_storage_reclaim_job.all_node_defs}
+    assert op_names == {"reclaim_instance_storage_sweep"}
+
+  @pytest.mark.unit
+  def test_job_has_correct_tags(self):
+    from robosystems.dagster.jobs.storage_reclaim import daily_storage_reclaim_job
+
+    assert daily_storage_reclaim_job.tags.get("dagster/priority") == "1"
+    assert daily_storage_reclaim_job.tags.get("dagster/max_retries") == "3"
+
+  @pytest.mark.unit
+  def test_schedule_cron(self):
+    """Daily at 5:30 UTC — after backup cleanup, off business hours."""
+    from robosystems.dagster.jobs.storage_reclaim import (
+      daily_storage_reclaim_schedule,
+    )
+
+    assert daily_storage_reclaim_schedule.cron_schedule == "30 5 * * *"
+
+  @pytest.mark.unit
+  def test_schedule_targets_correct_job(self):
+    from robosystems.dagster.jobs.storage_reclaim import (
+      daily_storage_reclaim_job,
+      daily_storage_reclaim_schedule,
+    )
+
+    assert daily_storage_reclaim_schedule.job_name == daily_storage_reclaim_job.name
+
+  @pytest.mark.unit
+  def test_job_and_schedule_registered_in_definitions(self):
+    from robosystems.dagster.definitions import all_jobs, all_schedules
+    from robosystems.dagster.jobs.storage_reclaim import (
+      daily_storage_reclaim_job,
+      daily_storage_reclaim_schedule,
+    )
+
+    assert daily_storage_reclaim_job in all_jobs
+    assert daily_storage_reclaim_schedule in all_schedules

--- a/tests/graph_api/routers/databases/test_management.py
+++ b/tests/graph_api/routers/databases/test_management.py
@@ -369,3 +369,105 @@ class TestDatabaseManagementRouter:
     assert data["graph_id"] == "unhealthy_db"
     assert data["is_healthy"] is False
     assert data["size_bytes"] == 1024000000
+
+
+class TestTransientDeleteLockGuard:
+  """Deleting a `-wip`/`-prev` artifact must not race an in-flight build.
+
+  The route acquires the base's materialization lock (the same lock the
+  build holds for its whole run) before unlinking, and honours the
+  X-Materialization-Lock-Token passthrough so the materialize flow's own
+  cleanup deletes don't 409 against the lock it already holds.
+  """
+
+  @pytest.fixture
+  def client(self):
+    app = create_app()
+    from robosystems.graph_api.core.ladybug import get_ladybug_service
+
+    mock_service = MagicMock()
+    mock_service.read_only = False
+    mock_service.node_type = NodeType.WRITER
+    mock_service.db_manager.delete_database.return_value = None
+    app.dependency_overrides[get_ladybug_service] = lambda: mock_service
+    return TestClient(app)
+
+  def _service(self, client):
+    from robosystems.graph_api.core.ladybug import get_ladybug_service
+
+    return client.app.dependency_overrides[get_ladybug_service]()
+
+  @staticmethod
+  def _lock_mock(acquire_result: bool) -> MagicMock:
+    from unittest.mock import AsyncMock
+
+    lock_cls = MagicMock()
+    lock = lock_cls.return_value
+    lock.acquire = AsyncMock(return_value=acquire_result)
+    lock.release = AsyncMock()
+    lock.acquired = acquire_result
+    return lock_cls
+
+  def test_wip_delete_refused_while_build_holds_lock(self, client):
+    """A live build's WIP cannot be deleted out from under it."""
+    lock_cls = self._lock_mock(acquire_result=False)
+    with (
+      patch(
+        "robosystems.graph_api.core.ladybug.materialization_lock.MaterializationLock",
+        lock_cls,
+      ),
+      patch("robosystems.config.valkey_registry.create_async_redis_client"),
+    ):
+      response = client.delete("/databases/kg1a2b3c4d5-wip")
+
+    assert response.status_code == status.HTTP_409_CONFLICT
+    assert "materialization" in response.json()["detail"].lower()
+    self._service(client).db_manager.delete_database.assert_not_called()
+
+  def test_wip_delete_proceeds_when_no_build_running(self, client):
+    lock_cls = self._lock_mock(acquire_result=True)
+    with (
+      patch(
+        "robosystems.graph_api.core.ladybug.materialization_lock.MaterializationLock",
+        lock_cls,
+      ),
+      patch("robosystems.config.valkey_registry.create_async_redis_client"),
+    ):
+      response = client.delete("/databases/kg1a2b3c4d5-wip")
+
+    assert response.status_code == status.HTTP_200_OK
+    self._service(client).db_manager.delete_database.assert_called_once_with(
+      "kg1a2b3c4d5-wip", preserve_duckdb=False
+    )
+    lock_cls.return_value.release.assert_awaited_once()
+
+  def test_lock_token_passthrough_skips_acquisition(self, client):
+    """The materialize flow deletes its own WIP while holding the lock —
+    its token must let the delete through without a second acquire."""
+    lock_cls = self._lock_mock(acquire_result=False)
+    with (
+      patch(
+        "robosystems.graph_api.core.ladybug.materialization_lock.MaterializationLock",
+        lock_cls,
+      ),
+      patch("robosystems.config.valkey_registry.create_async_redis_client"),
+    ):
+      response = client.delete(
+        "/databases/kg1a2b3c4d5-wip",
+        headers={"X-Materialization-Lock-Token": "tok-123"},
+      )
+
+    assert response.status_code == status.HTTP_200_OK
+    lock_cls.assert_not_called()
+    self._service(client).db_manager.delete_database.assert_called_once()
+
+  def test_regular_delete_never_touches_the_lock(self, client):
+    lock_cls = self._lock_mock(acquire_result=False)
+    with patch(
+      "robosystems.graph_api.core.ladybug.materialization_lock.MaterializationLock",
+      lock_cls,
+    ):
+      response = client.delete("/databases/kg1a2b3c4d5")
+
+    assert response.status_code == status.HTTP_200_OK
+    lock_cls.assert_not_called()

--- a/tests/operations/graph/test_storage_reclaim.py
+++ b/tests/operations/graph/test_storage_reclaim.py
@@ -1,0 +1,139 @@
+"""Tests for the storage reclaim sweep (transient artifacts + orphan estates)."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from robosystems.operations.graph.storage_reclaim import reclaim_instance_storage
+
+GRAPH_ID = "kg_test"
+
+
+def _db_with_subgraphs(*graph_ids: str) -> MagicMock:
+  """A session whose registry reports these ids as live subgraphs."""
+  db = MagicMock()
+  db.query.return_value.filter.return_value.all.return_value = [
+    (graph_id,) for graph_id in graph_ids
+  ]
+  return db
+
+
+def _breakdown() -> dict:
+  return {
+    "graph_id": GRAPH_ID,
+    "total_bytes": 1200,
+    "items": [
+      {"type": "graph", "id": GRAPH_ID, "bytes": 100},
+      {"type": "memory", "id": f"{GRAPH_ID}_memory", "bytes": 10},
+      {"type": "vectors", "id": f"{GRAPH_ID}_memory", "bytes": 10},
+      {"type": "subgraph", "id": f"{GRAPH_ID}_dev", "bytes": 200},
+      {"type": "subgraph", "id": f"{GRAPH_ID}_gone", "bytes": 300},
+      {"type": "vectors", "id": f"{GRAPH_ID}_gone", "bytes": 40},
+      {"type": "staging", "id": f"{GRAPH_ID}_gone", "bytes": 50},
+      {"type": "transient", "id": f"{GRAPH_ID}-wip", "bytes": 490},
+    ],
+  }
+
+
+def _client(breakdown: dict | None = None) -> AsyncMock:
+  client = AsyncMock()
+  client.get_storage_breakdown.return_value = (
+    breakdown if breakdown is not None else _breakdown()
+  )
+  return client
+
+
+async def _run(client: AsyncMock, db: MagicMock, dry_run: bool = False) -> dict:
+  with patch(
+    "robosystems.graph_api.client.factory.get_graph_client",
+    new=AsyncMock(return_value=client),
+  ):
+    return await reclaim_instance_storage(GRAPH_ID, db, dry_run=dry_run)
+
+
+@pytest.mark.unit
+class TestReclaimTargeting:
+  @pytest.mark.asyncio
+  async def test_reclaims_transients_and_orphan_estates_only(self):
+    """Live databases are never targets; an orphan's estate is one delete."""
+    client = _client()
+    result = await _run(client, _db_with_subgraphs(f"{GRAPH_ID}_dev"))
+
+    deleted = {call.args[0] for call in client.delete_database.await_args_list}
+    assert deleted == {f"{GRAPH_ID}-wip", f"{GRAPH_ID}_gone"}
+
+    # Estate folded: lbug 300 + vectors 40 + staging 50 as one 390-byte entry.
+    by_id = {e["id"]: e for e in result["reclaimed"]}
+    assert by_id[f"{GRAPH_ID}_gone"]["bytes"] == 390
+    assert result["bytes_freed"] == 490 + 390
+    assert result["skipped"] == []
+
+  @pytest.mark.asyncio
+  async def test_transient_delete_preserves_the_bases_staging(self):
+    """A `-wip` shares its base's name in DuckDB/Lance terms — only the
+    lbug artifact goes; an orphan takes its whole estate with it."""
+    client = _client()
+    await _run(client, _db_with_subgraphs(f"{GRAPH_ID}_dev"))
+
+    kwargs_by_id = {
+      call.args[0]: call.kwargs for call in client.delete_database.await_args_list
+    }
+    assert kwargs_by_id[f"{GRAPH_ID}-wip"]["preserve_duckdb"] is True
+    assert kwargs_by_id[f"{GRAPH_ID}_gone"]["preserve_duckdb"] is False
+
+  @pytest.mark.asyncio
+  async def test_item_failure_skips_and_continues(self):
+    """A 409 (build in flight) or 404 is a per-item outcome, not an abort."""
+    client = _client()
+    client.delete_database.side_effect = [
+      RuntimeError("409: materialization in progress"),
+      {"status": "success"},
+    ]
+
+    result = await _run(client, _db_with_subgraphs(f"{GRAPH_ID}_dev"))
+
+    assert len(result["reclaimed"]) == 1
+    assert len(result["skipped"]) == 1
+    assert "409" in result["skipped"][0]["reason"]
+    assert result["bytes_freed"] == result["reclaimed"][0]["bytes"]
+
+  @pytest.mark.asyncio
+  async def test_registry_failure_never_deletes_orphans(self):
+    """No registry confirmation, no orphan deletion — the sweep fails safe.
+
+    Unlabelled `{parent}_*` items keep type `subgraph` and are not targets;
+    only the transient artifact (whose classification needs no registry) is
+    reclaimed.
+    """
+    db = MagicMock()
+    db.query.side_effect = RuntimeError("registry unavailable")
+    client = _client()
+
+    result = await _run(client, db)
+
+    deleted = {call.args[0] for call in client.delete_database.await_args_list}
+    assert deleted == {f"{GRAPH_ID}-wip"}
+    assert result["bytes_freed"] == 490
+
+  @pytest.mark.asyncio
+  async def test_dry_run_deletes_nothing(self):
+    client = _client()
+    result = await _run(client, _db_with_subgraphs(f"{GRAPH_ID}_dev"), dry_run=True)
+
+    client.delete_database.assert_not_awaited()
+    assert result["bytes_freed"] == 0
+    assert {e["id"] for e in result["would_reclaim"]} == {
+      f"{GRAPH_ID}-wip",
+      f"{GRAPH_ID}_gone",
+    }
+    assert result["bytes_reclaimable"] == 490 + 390
+
+  @pytest.mark.asyncio
+  async def test_client_closed_even_on_breakdown_failure(self):
+    client = _client()
+    client.get_storage_breakdown.side_effect = RuntimeError("instance unreachable")
+
+    with pytest.raises(RuntimeError):
+      await _run(client, _db_with_subgraphs())
+
+    client.close.assert_awaited_once()


### PR DESCRIPTION
## Summary

Adds the collection mechanism behind the storage labels #1079 introduced: a daily platform janitor that deletes `transient` blue-green build artifacts stranded by crashed materializations and `orphan` estates left behind by deleted subgraphs. The itemization made these visible on `/usage`; nothing until now could actually reclaim them (a stranded `-wip` waited for the next materialize of the same database, and an orphan is unreachable through `delete-subgraph` because the registry row it resolves through is exactly what's gone). Deliberately not a user-facing operation — no new API surface.

## Changes

**Graph API — lock-guarded artifact deletion (`graph_api/routers/databases/management.py`, `client/client.py`)**

- `DELETE /databases/{id}` now refuses a `-wip`/`-prev` name unless it can acquire the base's materialization lock — the same lock every blue-green build holds from before its first step to after its swap. In-flight build → 409; acquire-not-check closes the check-then-unlink race.
- The materialize flow deletes its own leftover WIP while already holding that lock (step 1 cleanup and both failure paths), so the endpoint honours the `X-Materialization-Lock-Token` passthrough — the same protocol `swap_database` already uses — and the three self-cleanup call sites in `operations/extensions/materialize.py` now pass their token. Without this, the guard would have 409'd every build's own cleanup. This is the subtlest part of the PR and worth a close look.
- Valkey-unreachable degrades open, mirroring the swap endpoint: in that state builds also run unlocked, so both sides accept the same residual, and the active database is never the delete's target either way.

**Reclaim sweep (`operations/graph/storage_reclaim.py`)**

- Reuses the registry pass the storage breakdown uses (`_label_orphans`), so it deletes exactly what `/usage` reports as `transient`/`orphan` — never anything attributed to a live database. A registry read failure leaves items unlabelled and orphans untouched: the sweep fails safe.
- An orphan's estate (database + vector index + staging file) folds into one delete; a transient delete passes `preserve_duckdb=True` so the base's staging and vectors are never collateral.
- Per-item failures (409 from the lock, 404 for a fragment with no `.lbug` anchor) are recorded as skipped and don't abort the sweep.

**Dagster job (`dagster/jobs/storage_reclaim.py`, `definitions.py`)**

- `daily_storage_reclaim_job` at 5:30 UTC (after backup cleanup), mirroring the `backup_cleanup` shape. Sweeps active parent user graphs; subgraphs ride the parent's `{id}_*` scan.
- `STORAGE_RECLAIM_ENABLED` SSM flag read per run is the runtime kill switch; schedule is STOPPED in dev.

**Known limitation** (documented in the module): an orphan whose `.lbug` is gone but whose vector index or staging file lingers is skipped — the Graph API delete anchors on the database file. Reported in `skipped`, not silently ignored.

## Breaking Changes

None. No API surface changes — the only OpenAPI delta is description text on `StorageItem` noting the daily reclaim job. No SDK action needed.

## Testing

`just test-all` run this session — full suite green (12,264 passed) plus dbt, ruff, format, basedpyright, cf-lint. New coverage: the 409-under-lock refusal, the lock-token passthrough (the build's own cleanup must not 409 against itself), lock release, non-transient deletes never touching the lock, orphan-vs-transient targeting with estate folding, `preserve_duckdb` per type, registry-failure fail-safe (orphans untouched), dry-run, per-item skip-and-continue, and the job/schedule registration.
