### PR TITLE
fix(graphs): DuckDB config fallback, parent-graph liveness gate, dead restore params

### DIFF
--- a/robosystems/config/env.py
+++ b/robosystems/config/env.py
@@ -812,6 +812,11 @@ class EnvConfig:
 
   # DuckDB Staging Configuration (for data ingestion/materialization)
   DUCKDB_STAGING_PATH = get_str_env("DUCKDB_STAGING_PATH", "./data/staging")
+  # Fallbacks for the staging connection's resource caps. The tier config in
+  # .github/configs/graph.yml wins when CLUSTER_TIER is set; these apply on
+  # hosts that carry no tier. Defaults match GraphTierConfig's own fallbacks.
+  DUCKDB_MEMORY_LIMIT = get_str_env("DUCKDB_MEMORY_LIMIT", "2GB")
+  DUCKDB_MAX_THREADS = get_int_env("DUCKDB_MAX_THREADS", 4)
 
   # Artifact Storage (precomputed Parquet files for enrichment refinement)
   ARTIFACT_PATH = get_str_env("ARTIFACT_PATH", "./data/artifacts")

--- a/robosystems/graph_api/client/client.py
+++ b/robosystems/graph_api/client/client.py
@@ -1350,9 +1350,10 @@ class GraphClient(BaseGraphClient):
   ) -> dict[str, Any]:
     """Start a restore from an S3 backup; returns task_id and monitor_url.
 
-    ``encrypted`` and ``compressed`` describe the stored artifact, not what to
-    do to it. ``force_overwrite`` is required to restore over an existing
-    database, and ``create_system_backup`` snapshots that database first.
+    ``force_overwrite`` is required to restore over an existing database.
+    ``create_system_backup``, ``encrypted`` and ``compressed`` are accepted
+    for wire compatibility but inert: no pre-restore snapshot is taken, and
+    the backup's own stored metadata governs decryption and decompression.
     """
     data = {
       "s3_bucket": s3_bucket,

--- a/robosystems/graph_api/routers/databases/restore.py
+++ b/robosystems/graph_api/routers/databases/restore.py
@@ -37,16 +37,16 @@ async def perform_restore(
   graph_id: str,
   s3_bucket: str,
   s3_key: str,
-  create_system_backup: bool,
   force_overwrite: bool,
-  encrypted: bool,
-  compressed: bool,
   connection_pool=None,
 ) -> None:
   """Run the restore in the background, updating task status for monitoring.
 
   ``connection_pool`` is the LadybugDB pool, needed to close open connections
   before the database files are replaced.
+
+  Encryption and compression are read from the backup's own S3 metadata, so
+  the caller does not describe them.
   """
   try:
     await restore_task_manager.update_task(
@@ -143,14 +143,17 @@ async def restore_database(
   Restore a database from S3 backup.
 
   This endpoint restores a complete LadybugDB database from S3:
-  - Downloads backup from S3
-  - Decrypts if encrypted
-  - Decompresses if compressed
-  - Creates a system backup of existing database before restore
+  - Downloads the backup from S3
+  - Decrypts and decompresses according to the backup's stored metadata
+  - Replaces the existing database, which requires ``force_overwrite``
   - Runs asynchronously with progress tracking
 
   The restore operation runs as a background task and can be monitored
   using the returned task_id.
+
+  ``create_system_backup`` is accepted for wire compatibility but no
+  pre-restore snapshot is taken; ``encrypted`` and ``compressed`` are
+  likewise inert, since the backup's own metadata governs both.
   """
   # Validate graph_id to prevent path injection
   graph_id = validate_database_name(graph_id)
@@ -188,10 +191,7 @@ async def restore_database(
     graph_id=graph_id,
     s3_bucket=s3_bucket,
     s3_key=s3_key,
-    create_system_backup=create_system_backup and database_exists,
     force_overwrite=force_overwrite,
-    encrypted=encrypted,
-    compressed=compressed,
     connection_pool=ladybug_service.db_manager.connection_pool,
   )
 
@@ -203,7 +203,8 @@ async def restore_database(
     message=f"Restore task started for database {graph_id}",
     database=graph_id,
     monitor_url=f"/tasks/{task_id}/monitor",
-    system_backup_created=create_system_backup and database_exists,
+    # No pre-restore snapshot is taken, so this cannot claim otherwise.
+    system_backup_created=False,
   )
 
 

--- a/robosystems/models/api/extensions/schedules.py
+++ b/robosystems/models/api/extensions/schedules.py
@@ -179,13 +179,6 @@ class PromoteObligationsResponse(BaseModel):
   )
 
 
-class CreateClosingEntryRequest(BaseModel):
-  posting_date: date = Field(..., description="Posting date for the entry")
-  period_start: date = Field(..., description="Period start")
-  period_end: date = Field(..., description="Period end")
-  memo: str | None = Field(None, description="Override memo")
-
-
 class ManualLineItemRequest(BaseModel):
   element_id: str = Field(..., description="Element ID (chart of accounts)")
   debit_amount: int = Field(0, ge=0, description="Debit in cents")
@@ -206,18 +199,6 @@ class CreateManualClosingEntryRequest(BaseModel):
   entry_type: EntryType = Field(
     "closing",
     description="Entry type: 'closing' (default), 'adjusting', 'standard', 'reversing'",
-  )
-
-
-class CreateClosingEntryOperation(CreateClosingEntryRequest):
-  """CQRS-shaped body for `POST /operations/create-closing-entry`.
-
-  `structure_id` moves into the body so REST + MCP share a single body
-  type via the registrar.
-  """
-
-  structure_id: str = Field(
-    ..., description="Schedule structure the closing entry is derived from."
   )
 
 

--- a/robosystems/operations/roboledger/commands/schedules.py
+++ b/robosystems/operations/roboledger/commands/schedules.py
@@ -14,7 +14,6 @@ from sqlalchemy.orm import Session
 
 from robosystems.models.api.extensions.schedules import (
   ClosingEntryResponse,
-  CreateClosingEntryOperation,
   CreateManualClosingEntryRequest,
   CreateScheduleRequest,
   DeleteScheduleRequest,
@@ -269,29 +268,6 @@ def create_schedule(
     schedule_created_event_id=metadata.get("schedule_created_event_id"),
     pending_event_count=metadata.get("pending_event_count", 0),
   )
-
-
-def create_closing_entry(
-  session: Session,
-  body: CreateClosingEntryOperation,
-  created_by: str,
-) -> ClosingEntryResponse:
-  """Create a draft closing entry from a schedule's facts for a period.
-
-  Raises `ValueError` for validation failures — caller maps to 422.
-  """
-  service = ScheduleService()
-  result = service.create_closing_entry(
-    session,
-    structure_id=body.structure_id,
-    posting_date=body.posting_date,
-    period_start=body.period_start,
-    period_end=body.period_end,
-    created_by=created_by,
-    memo=body.memo,
-  )
-  session.commit()
-  return _build_closing_entry_response(result)
 
 
 def promote_obligations(

--- a/robosystems/routers/graphs/subgraphs/utils.py
+++ b/robosystems/routers/graphs/subgraphs/utils.py
@@ -87,12 +87,20 @@ def verify_subgraph_tier_support(parent_graph: Graph):
 
 
 def verify_parent_graph_active(parent_graph: Graph):
-  """Placeholder for a parent-graph liveness check; currently a no-op.
+  """Verify the parent graph is active, raising 403 if it is not.
 
-  Callers must not rely on this for authorization — it performs no
-  validation and raises nothing.
+  A suspended parent has its access blocked while the infrastructure stays
+  in place, and a deprovisioned one has no infrastructure left to host a
+  subgraph — creating one under either would strand it.
   """
-  pass
+  if not parent_graph.is_active:
+    raise HTTPException(
+      status_code=status.HTTP_403_FORBIDDEN,
+      detail=(
+        f"Parent graph {parent_graph.graph_id} is {parent_graph.status}; "
+        "subgraph operations require an active parent graph."
+      ),
+    )
 
 
 def check_subgraph_quota(parent_graph: Graph, session: Session):

--- a/tests/graph_api/routers/databases/test_backup_restore.py
+++ b/tests/graph_api/routers/databases/test_backup_restore.py
@@ -171,7 +171,10 @@ def test_restore_initiates_task_with_metadata(restore_client):
   assert payload["task_id"] == "task-456"
   assert payload["database"] == "graph1"
   assert payload["status"] == "initiated"
-  assert payload["system_backup_created"] is True
+  # `perform_restore` takes no pre-restore snapshot, so the response must not
+  # claim one — even when the caller asks for it. The request flag is still
+  # recorded in task metadata below.
+  assert payload["system_backup_created"] is False
 
   client.task_manager.create_task.assert_awaited_once()
   _, kwargs = client.task_manager.create_task.await_args


### PR DESCRIPTION
## Summary

Four defects surfaced by the documentation scrub in #1081, where a docstring or comment turned out to describe behavior the code does not have. Each is fixed by making the code match the documented intent, or by making the documentation match reality where the intent was never built.

Follow-up to #1081, which is now merged; this branch sits directly on `main`.

## Changes

**`config/env.py` — restore the DuckDB staging fallback**

`graph_api/core/duckdb/pool.py` reads `env.DUCKDB_MEMORY_LIMIT` and `env.DUCKDB_MAX_THREADS`, neither of which existed on `EnvConfig`. That path is the documented fallback for a host with no `CLUSTER_TIER`, and it raised `AttributeError` instead — caught by `_configure_connection`'s broad `except`, which then skipped every remaining setting on the connection: thread count, memory limit, `preserve_insertion_order=false`, and the spill `temp_directory`. The last two exist specifically to keep large staging runs from exhausting memory and from spilling onto the root volume.

Both attributes added, defaulting to `"2GB"` and `4` to match `GraphTierConfig`'s own fallbacks. Tier config still wins when `CLUSTER_TIER` is set, so deployed instances are unaffected.

**`routers/graphs/subgraphs/utils.py` — make the parent-graph guard real**

`verify_parent_graph_active` was a bare `pass` with a docstring promising a 403. It is called before subgraph creation, so a suspended or deprovisioned parent could accept a new subgraph — one whose access is blocked, or whose infrastructure is gone. Implemented against the existing `Graph.is_active`.

**Behavior change:** subgraph creation against a non-active parent now returns 403 where it previously succeeded.

**`operations/roboledger/commands/schedules.py` — delete the orphaned closing-entry command**

`create_closing_entry` and its two request models had no importer anywhere: not registered as an `OperationSpec`, not exposed as an MCP tool, not called by any handler. Meanwhile the MCP tool text tells operators there is no such tool and that drafts come from `promote-obligations` / `create-event-block`. The live `ScheduleService.create_closing_entry` — used by the `schedule_entry_due` handler — is untouched; only the unreachable CQRS wrapper is gone.

**`graph_api/routers/databases/restore.py` — stop advertising a backup that never happens**

`perform_restore` accepted `create_system_backup`, `encrypted` and `compressed` and used none of them: encryption and compression come from the backup's own S3 metadata, and no pre-restore snapshot is taken anywhere. The endpoint nevertheless returned `system_backup_created: true` and documented "Creates a system backup of existing database before restore".

Dropped the three parameters from `perform_restore`, corrected the endpoint and client docstrings, and made `system_backup_created` return `false`. The `Form` fields and the client kwargs are retained for wire compatibility.

**Reviewer notes**

- One test had to change: `test_restore_initiates_task_with_metadata` asserted `system_backup_created is True`, pinning the false claim rather than any real behavior. The assertion now expects `false`; the metadata assertions that verify the request flag is still *recorded* are unchanged.
- `create_system_backup` remains accepted on the wire and in the SDK while doing nothing. This PR makes that honest rather than silently wrong, but the real choice is to implement the pre-restore snapshot or remove the parameter from the API and client. Worth its own issue.
- `create_manual_closing_entry` in the same commands module is a second orphan with the same profile as the one deleted here. It was left in place: removing it also strands `_build_closing_entry_response` and `ClosingEntryResponse`, making it a materially larger cleanup than this PR's scope.

## Breaking Changes

Two behavioral, both correcting documented-but-absent behavior:

- Subgraph creation against a suspended or deprovisioned parent now returns 403.
- `POST /databases/{graph_id}/restore` returns `system_backup_created: false`. No wire shape changed and no backup behavior changed — the field previously reported a snapshot that was never taken.

No request/response shape, field name, type, or requiredness changed, so no SDK regeneration is required.

## Testing

`just test-all` — **12,264 passed, 23 skipped, 0 failed**, plus dbt, ruff check, ruff format, basedpyright (0 errors/warnings/notes) and cf-lint all clean.
