### PR TITLE
fix(backups): thread create_system_backup through the restore path

### DIFF
--- a/robosystems/graph_api/client/client.py
+++ b/robosystems/graph_api/client/client.py
@@ -1350,10 +1350,11 @@ class GraphClient(BaseGraphClient):
   ) -> dict[str, Any]:
     """Start a restore from an S3 backup; returns task_id and monitor_url.
 
-    ``force_overwrite`` is required to restore over an existing database.
-    ``create_system_backup``, ``encrypted`` and ``compressed`` are accepted
-    for wire compatibility but inert: no pre-restore snapshot is taken, and
-    the backup's own stored metadata governs decryption and decompression.
+    ``force_overwrite`` is required to restore over an existing database, and
+    ``create_system_backup`` snapshots that database to S3 first — a failed
+    snapshot aborts the restore. ``encrypted`` and ``compressed`` are accepted
+    for wire compatibility but inert: the backup's own stored metadata governs
+    decryption and decompression.
     """
     data = {
       "s3_bucket": s3_bucket,

--- a/robosystems/graph_api/routers/databases/restore.py
+++ b/robosystems/graph_api/routers/databases/restore.py
@@ -38,12 +38,17 @@ async def perform_restore(
   s3_bucket: str,
   s3_key: str,
   force_overwrite: bool,
+  create_system_backup: bool = True,
   connection_pool=None,
 ) -> None:
   """Run the restore in the background, updating task status for monitoring.
 
   ``connection_pool`` is the LadybugDB pool, needed to close open connections
   before the database files are replaced.
+
+  ``create_system_backup`` snapshots the existing database to S3 before it is
+  overwritten; a failed snapshot aborts the restore rather than leaving the
+  old data unrecoverable.
 
   Encryption and compression are read from the backup's own S3 metadata, so
   the caller does not describe them.
@@ -101,6 +106,7 @@ async def perform_restore(
       create_new_database=False,
       drop_existing=False,
       verify_after_restore=True,
+      create_system_backup=create_system_backup,
       progress_tracker=None,
     )
 
@@ -145,15 +151,16 @@ async def restore_database(
   This endpoint restores a complete LadybugDB database from S3:
   - Downloads the backup from S3
   - Decrypts and decompresses according to the backup's stored metadata
+  - Snapshots the existing database to S3 first, unless
+    ``create_system_backup`` is false; a failed snapshot aborts the restore
   - Replaces the existing database, which requires ``force_overwrite``
   - Runs asynchronously with progress tracking
 
   The restore operation runs as a background task and can be monitored
   using the returned task_id.
 
-  ``create_system_backup`` is accepted for wire compatibility but no
-  pre-restore snapshot is taken; ``encrypted`` and ``compressed`` are
-  likewise inert, since the backup's own metadata governs both.
+  ``encrypted`` and ``compressed`` are accepted for wire compatibility but
+  inert: the backup's own stored metadata governs both.
   """
   # Validate graph_id to prevent path injection
   graph_id = validate_database_name(graph_id)
@@ -192,6 +199,7 @@ async def restore_database(
     s3_bucket=s3_bucket,
     s3_key=s3_key,
     force_overwrite=force_overwrite,
+    create_system_backup=create_system_backup and database_exists,
     connection_pool=ladybug_service.db_manager.connection_pool,
   )
 
@@ -203,8 +211,7 @@ async def restore_database(
     message=f"Restore task started for database {graph_id}",
     database=graph_id,
     monitor_url=f"/tasks/{task_id}/monitor",
-    # No pre-restore snapshot is taken, so this cannot claim otherwise.
-    system_backup_created=False,
+    system_backup_created=create_system_backup and database_exists,
   )
 
 

--- a/robosystems/models/api/extensions/schedules.py
+++ b/robosystems/models/api/extensions/schedules.py
@@ -179,29 +179,6 @@ class PromoteObligationsResponse(BaseModel):
   )
 
 
-class ManualLineItemRequest(BaseModel):
-  element_id: str = Field(..., description="Element ID (chart of accounts)")
-  debit_amount: int = Field(0, ge=0, description="Debit in cents")
-  credit_amount: int = Field(0, ge=0, description="Credit in cents")
-  description: str | None = None
-
-
-class CreateManualClosingEntryRequest(BaseModel):
-  posting_date: date = Field(..., description="Posting date for the entry")
-  memo: str = Field(
-    ...,
-    min_length=1,
-    description="Memo describing the business event (e.g., 'Sale of computer to Vendor X on 3/15')",
-  )
-  line_items: list[ManualLineItemRequest] = Field(
-    ..., min_length=1, description="Line items; must balance (total DR = total CR)"
-  )
-  entry_type: EntryType = Field(
-    "closing",
-    description="Entry type: 'closing' (default), 'adjusting', 'standard', 'reversing'",
-  )
-
-
 # ── Responses ──────────────────────────────────────────────────────────────
 
 
@@ -237,40 +214,6 @@ class PeriodCloseStatusResponse(BaseModel):
   schedules: list[PeriodCloseItemResponse]
   total_draft: int
   total_posted: int
-
-
-class ClosingEntryResponse(BaseModel):
-  outcome: str = Field(
-    ...,
-    description=(
-      "What the idempotent call did: "
-      "'created' (new draft), 'unchanged' (existing draft still matches), "
-      "'regenerated' (stale draft replaced with fresh one), "
-      "'removed' (stale draft deleted; schedule no longer covers this period), "
-      "'skipped' (nothing to do — no draft and no in-scope fact)."
-    ),
-  )
-  entry_id: str | None = Field(
-    None, description="The draft entry ID. None for 'removed' and 'skipped' outcomes."
-  )
-  status: str | None = Field(
-    None, description="Entry status (always 'draft' when present)."
-  )
-  posting_date: date | None = None
-  memo: str | None = None
-  debit_element_id: str | None = None
-  credit_element_id: str | None = None
-  amount: float | None = Field(
-    None, description="Entry amount in dollars. None for 'removed' and 'skipped'."
-  )
-  reason: str | None = Field(
-    None,
-    description="Explanation for 'removed' and 'skipped' outcomes.",
-  )
-  reversal: ClosingEntryResponse | None = None
-
-
-ClosingEntryResponse.model_rebuild()
 
 
 class ScheduleCreatedResponse(BaseModel):

--- a/robosystems/operations/graph/engine/backup_manager.py
+++ b/robosystems/operations/graph/engine/backup_manager.py
@@ -95,6 +95,10 @@ class RestoreJob:
   create_new_database: bool = True
   drop_existing: bool = False
   verify_after_restore: bool = True
+  # Snapshot the existing database to S3 before overwriting it. Defaults on:
+  # a restore is destructive, and a failed snapshot aborts it rather than
+  # leaving the old data unrecoverable.
+  create_system_backup: bool = True
   progress_tracker: Any | None = None
 
   def __post_init__(self):
@@ -453,7 +457,11 @@ class BackupManager:
         await self._ensure_database_exists(graph_id)
 
       await self._import_backup_data(
-        graph_id, backup_data, restore_job.backup_format, restore_job.progress_tracker
+        graph_id,
+        backup_data,
+        restore_job.backup_format,
+        restore_job.progress_tracker,
+        restore_job.create_system_backup,
       )
 
       if restore_job.verify_after_restore:
@@ -946,8 +954,13 @@ class BackupManager:
     backup_data: bytes,
     backup_format: BackupFormat,
     progress_tracker=None,
+    create_system_backup: bool = True,
   ) -> None:
-    """Dispatch to the per-format importer."""
+    """Dispatch to the per-format importer.
+
+    ``create_system_backup`` only reaches the full-dump path — it is the only
+    importer that overwrites the database in place.
+    """
     if backup_format == BackupFormat.CSV:
       await self._import_from_csv(graph_id, backup_data, progress_tracker)
     elif backup_format == BackupFormat.JSON:
@@ -955,7 +968,9 @@ class BackupManager:
     elif backup_format == BackupFormat.PARQUET:
       await self._import_from_parquet(graph_id, backup_data, progress_tracker)
     elif backup_format == BackupFormat.FULL_DUMP:
-      await self._import_full_dump(graph_id, backup_data, progress_tracker)
+      await self._import_full_dump(
+        graph_id, backup_data, progress_tracker, create_system_backup
+      )
     else:
       raise ValueError(f"Unsupported backup format: {backup_format}")
 

--- a/robosystems/operations/roboledger/commands/schedules.py
+++ b/robosystems/operations/roboledger/commands/schedules.py
@@ -13,8 +13,6 @@ from sqlalchemy import or_, select, text
 from sqlalchemy.orm import Session
 
 from robosystems.models.api.extensions.schedules import (
-  ClosingEntryResponse,
-  CreateManualClosingEntryRequest,
   CreateScheduleRequest,
   DeleteScheduleRequest,
   PromoteObligationsRequest,
@@ -109,35 +107,6 @@ def reinstate_reopened_schedule_scopes(session: Session) -> int:
     {"closed_through": closed_through},
   )
   return result.rowcount or 0
-
-
-def _build_closing_entry_response(result) -> ClosingEntryResponse:
-  """Map a ScheduleService ClosingEntryResult to the wire response."""
-  reversal_resp = None
-  if result.reversal:
-    reversal_resp = ClosingEntryResponse(
-      outcome=result.reversal.outcome,
-      entry_id=result.reversal.entry_id,
-      status=result.reversal.status,
-      posting_date=result.reversal.posting_date,
-      memo=result.reversal.memo,
-      debit_element_id=result.reversal.debit_element_id,
-      credit_element_id=result.reversal.credit_element_id,
-      amount=result.reversal.amount,
-      reason=result.reversal.reason,
-    )
-  return ClosingEntryResponse(
-    outcome=result.outcome,
-    entry_id=result.entry_id,
-    status=result.status,
-    posting_date=result.posting_date,
-    memo=result.memo,
-    debit_element_id=result.debit_element_id,
-    credit_element_id=result.credit_element_id,
-    amount=result.amount,
-    reason=result.reason,
-    reversal=reversal_resp,
-  )
 
 
 def _validate_element_references(session: Session, body: CreateScheduleRequest) -> None:
@@ -306,38 +275,6 @@ def promote_obligations(
     stranded_event_ids=result.stranded_event_ids,
     errors=[{"event_id": eid, "error": msg} for eid, msg in result.errors],
   )
-
-
-def create_manual_closing_entry(
-  session: Session,
-  body: CreateManualClosingEntryRequest,
-  created_by: str,
-) -> ClosingEntryResponse:
-  """Create a manual (non-schedule) draft closing entry.
-
-  Used for one-off adjustments (asset disposals, impairments,
-  reclassifications). Total debits must equal total credits.
-  Raises `ValueError` for validation failures — caller maps to 422.
-  """
-  service = ScheduleService()
-  result = service.create_manual_closing_entry(
-    session,
-    posting_date=body.posting_date,
-    line_items=[
-      {
-        "element_id": li.element_id,
-        "debit_amount": li.debit_amount,
-        "credit_amount": li.credit_amount,
-        "description": li.description,
-      }
-      for li in body.line_items
-    ],
-    memo=body.memo,
-    created_by=created_by,
-    entry_type=body.entry_type,
-  )
-  session.commit()
-  return _build_closing_entry_response(result)
 
 
 # ─── Schedule update / delete ─────────────────────────────────────────────

--- a/tests/graph_api/routers/databases/test_backup_restore.py
+++ b/tests/graph_api/routers/databases/test_backup_restore.py
@@ -171,10 +171,7 @@ def test_restore_initiates_task_with_metadata(restore_client):
   assert payload["task_id"] == "task-456"
   assert payload["database"] == "graph1"
   assert payload["status"] == "initiated"
-  # `perform_restore` takes no pre-restore snapshot, so the response must not
-  # claim one — even when the caller asks for it. The request flag is still
-  # recorded in task metadata below.
-  assert payload["system_backup_created"] is False
+  assert payload["system_backup_created"] is True
 
   client.task_manager.create_task.assert_awaited_once()
   _, kwargs = client.task_manager.create_task.await_args
@@ -186,6 +183,33 @@ def test_restore_initiates_task_with_metadata(restore_client):
   assert kwargs["metadata"]["force_overwrite"] is True
 
   client.task_manager.fail_task.assert_not_awaited()
+
+
+def test_restore_passes_system_backup_choice_to_background_task(restore_client):
+  """The caller's create_system_backup choice must reach `perform_restore`.
+
+  It rides RestoreJob into `_import_full_dump`, which is the only thing that
+  snapshots the database before overwriting it. Dropping the flag here would
+  silently force a snapshot the caller opted out of.
+  """
+  cluster = FakeClusterService(read_only=False, databases=["graph1"])
+  client = restore_client(cluster)
+
+  response = client.post(
+    "/databases/graph1/restore",
+    data={
+      "s3_bucket": "test-bucket",
+      "s3_key": "backups/graph1.zip",
+      "create_system_backup": "false",
+      "force_overwrite": "true",
+    },
+  )
+
+  assert response.status_code == 200
+  assert response.json()["system_backup_created"] is False
+
+  _, kwargs = client.perform_restore_mock.call_args
+  assert kwargs["create_system_backup"] is False
 
 
 @pytest.mark.asyncio

--- a/tests/operations/graph/engine/test_backup_manager_extended.py
+++ b/tests/operations/graph/engine/test_backup_manager_extended.py
@@ -674,9 +674,36 @@ class TestRestoreBackup:
       mock_val.assert_called_once_with(b"backup_bytes", metadata)
       mock_ensure.assert_called_once_with("test_graph")
       mock_import.assert_called_once_with(
-        "test_graph", b"backup_bytes", BackupFormat.FULL_DUMP, None
+        "test_graph", b"backup_bytes", BackupFormat.FULL_DUMP, None, True
       )
       mock_verify.assert_called_once_with("test_graph", metadata)
+
+  @pytest.mark.asyncio
+  async def test_restore_threads_system_backup_opt_out(self, manager, s3_adapter):
+    """`create_system_backup=False` must reach the importer.
+
+    Only `_import_full_dump` snapshots the database before overwriting it, so
+    a job that drops the flag here would force a snapshot the caller declined.
+    """
+    job, _ = self._make_restore_job(create_system_backup=False)
+
+    s3_adapter.download_backup_by_key = AsyncMock(return_value=b"backup_bytes")
+
+    with (
+      patch.object(
+        manager, "_validate_backup_integrity", new_callable=AsyncMock
+      ) as mock_val,
+      patch.object(manager, "_ensure_database_exists", new_callable=AsyncMock),
+      patch.object(
+        manager, "_import_backup_data", new_callable=AsyncMock
+      ) as mock_import,
+      patch.object(manager, "_verify_restore", new_callable=AsyncMock) as mock_verify,
+    ):
+      mock_val.return_value = True
+      mock_verify.return_value = True
+
+      assert await manager.restore_backup(job) is True
+      assert mock_import.call_args.args[4] is False
 
   @pytest.mark.asyncio
   async def test_restore_with_drop_existing(self, manager, s3_adapter):
@@ -1623,7 +1650,17 @@ class TestImportBackupData:
       await manager._import_backup_data(
         "g1", b"dump_data", BackupFormat.FULL_DUMP, None
       )
-      mock_imp.assert_called_once_with("g1", b"dump_data", None)
+      mock_imp.assert_called_once_with("g1", b"dump_data", None, True)
+
+  @pytest.mark.asyncio
+  async def test_full_dump_receives_system_backup_flag(self, manager):
+    """Full dump is the only importer that overwrites in place, so it is the
+    only one that takes the snapshot decision."""
+    with patch.object(manager, "_import_full_dump", new_callable=AsyncMock) as mock_imp:
+      await manager._import_backup_data(
+        "g1", b"dump_data", BackupFormat.FULL_DUMP, None, False
+      )
+      mock_imp.assert_called_once_with("g1", b"dump_data", None, False)
 
   @pytest.mark.asyncio
   async def test_raises_for_unsupported_format(self, manager):


### PR DESCRIPTION
## Summary

Fixes a regression introduced in #1082 and completes the `create_system_backup` plumbing it was reaching for. Also removes a second orphaned closing-entry command found alongside the first.

`create_system_backup` is a real, caller-facing option — it snapshots the existing database to S3 before a restore overwrites it, and a failed snapshot aborts the restore rather than leaving the old data unrecoverable. The main API path (`POST /v1/graphs/{g}/operations/restore-backup`) has always honored it. The Graph API path silently did not: `RestoreJob` had no field for it, so `_import_backup_data` called `_import_full_dump` without the argument and got its `= True` default. A caller asking for `create_system_backup=false` still got a snapshot.

#1082 misread that as "the feature does not exist", dropped the parameter from `perform_restore`, and made the endpoint return `system_backup_created: false` — which was wrong in the opposite direction, since a snapshot is in fact taken. This PR threads the flag through instead.

## Changes

**`operations/graph/engine/backup_manager.py`**

- `RestoreJob` gains `create_system_backup: bool = True`.
- `restore_backup` passes it into `_import_backup_data`, which forwards it to `_import_full_dump` — the only importer that overwrites in place, and therefore the only one the decision applies to.

**`graph_api/routers/databases/restore.py`**

- `perform_restore` takes `create_system_backup` again and sets it on the `RestoreJob`.
- `system_backup_created` returns `create_system_backup and database_exists` — true when a snapshot is actually taken.
- Endpoint docstring describes the snapshot and its abort-on-failure semantics. `encrypted` / `compressed` remain documented as inert; the backup's own S3 metadata governs both.

**`graph_api/client/client.py`** — `restore_backup` docstring restored to describing the snapshot accurately.

**`operations/roboledger/commands/schedules.py` + `models/api/extensions/schedules.py`** — removes `create_manual_closing_entry`, the second orphaned CQRS command wrapper (sibling to the one deleted in #1082). It had no importer: not registered as an `OperationSpec`, not an MCP tool, not called by any handler. Its whole closure went with it — `CreateManualClosingEntryRequest`, `ManualLineItemRequest`, `ClosingEntryResponse`, `_build_closing_entry_response` — each of which existed only to serve it. `ScheduleService.create_manual_closing_entry`, which the `asset_disposed` handler calls to post a balanced disposal entry, is untouched.

**Reviewer notes**

- Three new tests pin the flag across each hop of the chain that was broken: endpoint → `perform_restore`, `RestoreJob` → `_import_backup_data`, and `_import_backup_data` → `_import_full_dump`. The original gap survived because no test followed the parameter past the first hop; each new test fails if its hop drops it.
- Two existing assertions were widened by one argument (`_import_backup_data` and `_import_full_dump` call signatures). They pin plumbing shape, not snapshot behavior, so the change is mechanical.
- #1082's assertion change to `test_restore_initiates_task_with_metadata` is reverted — the original `system_backup_created is True` was correct.
- The `commands.schedules` ↔ `information_block.schedule` circular import is pre-existing and unrelated; the module still imports fine through the normal app path.

## Breaking Changes

None on any wire shape. Two behavioral corrections, both restoring documented intent:

- `POST /databases/{graph_id}/restore` now honors `create_system_backup=false` instead of snapshotting regardless.
- `system_backup_created` reports whether a snapshot was taken, rather than the constant `false` that #1082 introduced.

No request/response field, type, or requiredness changed. The deleted models were never on a router, so `/openapi.json` and both published SDKs are unaffected — no regeneration required.

## Testing

`just test-all` — **12,267 passed, 23 skipped, 0 failed**, plus dbt, ruff check, ruff format, basedpyright (0 errors/warnings/notes) and cf-lint all clean.
