### PR TITLE
chore(deps): range the robosystems-client dev pin and take 1.4.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,8 +117,11 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    # RoboSystems client for demo and testing
-    "robosystems-client==1.4.0",
+    # RoboSystems client for demo and testing. Ranged, not pinned: the demos
+    # are the dogfooding surface and should exercise the current client, and
+    # uv.lock is what makes a given checkout reproducible. <2 is the SDK's
+    # post-1.0 semver boundary.
+    "robosystems-client>=1.4.2,<2.0",
 
     # Testing framework
     "pytest>=9.0.0,<10.0",

--- a/uv.lock
+++ b/uv.lock
@@ -3699,7 +3699,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.34.2,<3.0" },
     { name = "retrying", specifier = ">=1.4.0,<2.0" },
     { name = "rich", marker = "extra == 'dev'", specifier = ">=15.0.0,<16.0" },
-    { name = "robosystems-client", marker = "extra == 'dev'", specifier = "==1.4.0" },
+    { name = "robosystems-client", marker = "extra == 'dev'", specifier = ">=1.4.2,<2.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0,<1.0" },
     { name = "sqlalchemy", specifier = ">=2.0.0,<3.0" },
     { name = "sse-starlette", specifier = ">=3.3.0,<4.0" },
@@ -3722,7 +3722,7 @@ lambda = [
 
 [[package]]
 name = "robosystems-client"
-version = "1.4.0"
+version = "1.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -3730,9 +3730,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/61/8f/f79cc4c529bfef5eb5cc834eda655dfe588a40f1ab763b34c3f7fe3244c1/robosystems_client-1.4.0.tar.gz", hash = "sha256:351aeff4da3502b052441942b578b16b3e7edb8715126478e28c46e31a879036", size = 512976, upload-time = "2026-08-07T07:05:44.296Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/0c/ae66af119bbdad2bcd12b31cbaf0df1187e841fb398c6d0056a4049bc43d/robosystems_client-1.4.2.tar.gz", hash = "sha256:92b2a7229080a00661faeab9f334b138541396baa91c26ff1200b5a687163a98", size = 512738, upload-time = "2026-08-07T21:54:34.521Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/f2/2df1009238a562ab694c6d50c24daf789cb5a6df9fd2eeec7b6c37bef937/robosystems_client-1.4.0-py3-none-any.whl", hash = "sha256:b8d717286518eb87f452df395d340262962a51496c0935041d9733eb81a203be", size = 1174000, upload-time = "2026-08-07T07:05:42.638Z" },
+    { url = "https://files.pythonhosted.org/packages/37/3f/340d93cad367637aa6ff5b54dd2fc7da0be9980b6fe54c11a0066e8bb9fc/robosystems_client-1.4.2-py3-none-any.whl", hash = "sha256:86826797654fc4779a8f4e1a90f0131afc86676bdc36c08b3987018f05dd91e4", size = 1173941, upload-time = "2026-08-07T21:54:32.567Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Replaces the exact `robosystems-client==1.4.0` dev pin with a range and takes `1.4.2`, published today with the description changes from #1081.

The exact pin wasn't buying reproducibility — `uv.lock` already does that, so a given checkout resolves to one exact version regardless of the range. What the `==` did buy was a manual `pyproject.toml` edit on every SDK publish, which is the friction this PR removes. From here, picking up a new client is `uv lock --upgrade-package robosystems-client` with no dependency edit.

`>=1.4.2,<2.0` matches the house style used by every other dependency in the file (`fastapi>=0.139.0,<1.0`, `lancedb>=0.34.0,<0.35`), and `<2` is the published SDK's post-1.0 semver boundary: additive changes ride minors, anything breaking costs a major after a deprecation cycle. The floor is `1.4.2` rather than `>=1` because the demos use recent endpoints and a permissive floor could resolve a client too old to run them.

Ranging it also keeps `examples/` — the dogfooding surface that validates the customer-facing path end to end — exercising the client customers actually install, rather than freezing on whatever was current when the pin was last touched.

## Changes

- `pyproject.toml`: `robosystems-client==1.4.0` → `robosystems-client>=1.4.2,<2.0`, with a comment recording why it's ranged.
- `uv.lock`: `robosystems-client` 1.4.0 → 1.4.2, scoped via `uv lock --upgrade-package` so nothing else in the lock moved.

## Breaking Changes

None. Dev-extras only — not a runtime dependency of the service.

## Testing

`basedpyright examples` — 0 errors, 0 warnings, 0 notes. That is the surface a client version change can affect: 25 files under `examples/` import `robosystems_client`, and nothing else in the repo depends on it. The release is description-only, so no generated type or signature changed. Full CI runs on this PR.
