### PR TITLE
docs(models): correct the FactProvenance arm list in the FactSet description

### DIFF
--- a/robosystems/models/api/information_block.py
+++ b/robosystems/models/api/information_block.py
@@ -237,9 +237,10 @@ class FactSetLite(BaseModel):
     None,
     description=(
       "Typed ``FactProvenance`` descriptor (discriminated on ``origin``: "
-      "pivot | schedule | derived | asserted) recording how this FactSet's "
-      "facts were constructed. Surfaced as JSON, mirroring how mechanics "
-      "is exposed. Null when the FactSet carries no descriptor."
+      "pivot | schedule | derived | asserted | document | forecast | filed) "
+      "recording how this FactSet's facts were constructed. Surfaced as "
+      "JSON, mirroring how mechanics is exposed. Null when the FactSet "
+      "carries no descriptor."
     ),
   )
 


### PR DESCRIPTION
## Summary

The `provenance` field description on `FactSetLite` enumerated four `FactProvenance` union arms — `pivot | schedule | derived | asserted` — but the union in `models/api/fact_provenance.py` defines seven. `document`, `forecast`, and `filed` were added after the description was written and it was never updated alongside them.

This is a published string, not an internal comment: it reaches `/openapi.json`, the GraphQL schema snapshot both SDKs are generated from, and therefore the generated docstrings integrators read. The stale list is currently live in the installed client's `schema.graphql`, so anyone reading the field to decide which arms they need to handle sees three of the seven missing — including `filed`, the arm every SEC-sourced fact carries.

Corrected to the full list, in the union's declaration order.

## Changes

- `robosystems/models/api/information_block.py`: `FactSetLite.provenance` description now lists `pivot | schedule | derived | asserted | document | forecast | filed`. Wording and length otherwise unchanged.

Swept the repo for sibling enumerations of the same union. The three other places that spell out the arms in prose — `models/api/README.md`, `operations/information_block/README.md`, `graphql/README.md` — already list all seven correctly. This `Field` description was the only stale one.

## Breaking Changes

None. Description text only — no field added, removed, or renamed, no type change, no requiredness change. The published API surface is structurally identical, so this is additive documentation drift that can ride the next SDK regen rather than needing a coordinated release.

## Testing

`ruff check` + `ruff format --check` over `robosystems` clean; `basedpyright robosystems/models/api/information_block.py` — 0 errors, 0 warnings, 0 notes. No test asserts on this description (grepped `tests/`), and a string literal in a `Field` description has no runtime behavior to exercise, so the unit suite was left to CI.
