### PR TITLE
fix(postgres): scale the memory-low alarm threshold to the instance class

### DIFF
--- a/cloudformation/postgres.yaml
+++ b/cloudformation/postgres.yaml
@@ -195,6 +195,24 @@ Conditions:
   RDSProxyEnabledCondition: !Equals [!Ref EnableRDSProxy, "true"]
   PerformanceInsightsEnabledCondition: !Equals [!Ref EnablePerformanceInsights, "true"]
 
+Mappings:
+  # FreeableMemory alarm thresholds (~6% of instance RAM, in bytes). Postgres
+  # plus OS overhead legitimately consumes most of a small instance's memory,
+  # so a flat threshold pins the alarm on micro-class instances.
+  InstanceClassAlarmThresholds:
+    db.t4g.micro:
+      MemoryLowBytes: 67108864 # 64 MB of 1 GB
+    db.t4g.small:
+      MemoryLowBytes: 134217728 # 128 MB of 2 GB
+    db.t4g.medium:
+      MemoryLowBytes: 268435456 # 256 MB of 4 GB
+    db.r7g.large:
+      MemoryLowBytes: 1073741824 # 1 GB of 16 GB
+    db.r7g.xlarge:
+      MemoryLowBytes: 2147483648 # 2 GB of 32 GB
+    db.r7g.2xlarge:
+      MemoryLowBytes: 4294967296 # 4 GB of 64 GB
+
 Resources:
   # Common IAM policy for EC2 instances
   CommonEC2Policy:
@@ -717,7 +735,10 @@ Resources:
       Statistic: Minimum
       Period: 300
       EvaluationPeriods: 3
-      Threshold: 268435456
+      Threshold: !FindInMap
+        - InstanceClassAlarmThresholds
+        - !Ref DBInstanceClass
+        - MemoryLowBytes
       ComparisonOperator: LessThanThreshold
       TreatMissingData: breaching
       AlarmActions:


### PR DESCRIPTION
## Summary

The `robosystems-postgres-{env}-memory-low` CloudWatch alarm used a flat 256 MB `FreeableMemory` threshold for every environment. On a db.t4g.micro (1 GB RAM), Postgres plus OS overhead legitimately leaves ~120 MB freeable in steady state, so the staging alarm latched into ALARM and could never clear. This scales the threshold to the instance class instead.

## Changes

- **cloudformation/postgres.yaml**
  - Added an `InstanceClassAlarmThresholds` mappings block covering the `DBInstanceClass` AllowedValues list, setting the memory-low threshold at roughly 6% of instance RAM (64 MB for db.t4g.micro up to 4 GB for db.r7g.2xlarge).
  - `RDSFreeableMemoryLowAlarm` now resolves its `Threshold` via `!FindInMap` on `DBInstanceClass`. db.t4g.medium maps to the previous 256 MB, so the prod alarm's behavior is unchanged; the threshold also tracks any future instance resize automatically.

## Breaking Changes

None

## Testing

- `just cf-lint postgres` — clean.
- Verified against 7 days of CloudWatch data: staging (db.t4g.micro) freeable memory has a ~106 MB observed minimum, so the new 64 MB threshold clears the false alarm while still catching genuine pressure; prod (db.t4g.medium) sits at ~2.6 GB freeable and keeps its existing 256 MB threshold.
- Unit tests not run — no application code changed.
