### PR TITLE
fix(sync): adapter elements carry XBRL-intrinsic metadata, healed on sync

### DIFF
--- a/robosystems/operations/extensions/loader.py
+++ b/robosystems/operations/extensions/loader.py
@@ -169,6 +169,100 @@ def _is_qb_contra_asset_sub_type(sub_type: str | None) -> bool:
   )
 
 
+# Contra-asset account-NAME markers — the fallback signal when the source
+# system's sub-type is uninformative. QuickBooks detail types are user-chosen:
+# an accumulated-amortization account created under a generic detail type
+# (e.g. "Other long-term assets") carries no contra sub-type at all, so the
+# sub-type rule alone silently misses it and the account lands as a plain
+# asset. An asset-classified account *named* for the accumulation convention
+# is a contra by accounting convention. Only consulted when the account_type
+# already classified the account as an asset, so equity Accumulated-* names
+# (AOCI) can never match.
+_CONTRA_ASSET_NAME_MARKERS: tuple[str, ...] = (
+  "accumulated depreciation",
+  "accumulated amortization",
+  "accumulated depletion",
+  "allowance for",
+)
+
+
+def _looks_like_contra_asset_name(name: str | None) -> bool:
+  if not name:
+    return False
+  lowered = name.lower()
+  return any(marker in lowered for marker in _CONTRA_ASSET_NAME_MARKERS)
+
+
+def _account_efs_identifier(meta: dict, name: str | None) -> str | None:
+  """Classify a source-system account into its FASB EFS trait identifier.
+
+  ``account_type`` drives the base classification; asset-typed accounts are
+  promoted to ``contraAsset`` on either signal — a known contra
+  ``account_sub_type``, or (fallback) a contra-convention account name.
+  Returns None when the account_type is missing or unknown; callers decide
+  whether that is a warning.
+  """
+  acct_type = meta.get("account_type")
+  if not acct_type:
+    return None
+  efs_identifier = _QB_ACCOUNT_TYPE_TO_TRAIT.get(acct_type)
+  if efs_identifier == "asset" and (
+    _is_qb_contra_asset_sub_type(meta.get("account_sub_type"))
+    or _looks_like_contra_asset_name(name)
+  ):
+    return "contraAsset"
+  return efs_identifier
+
+
+# qname prefix per adapter source. MUST stay in lockstep with the
+# materializer's Element projection (materialize.py ``tables["Element"]``),
+# which prefers the stored qname and falls back to this same
+# ``{prefix}:{code}`` derivation only for rows loaded before qnames were
+# written at sync time. The stored value is authoritative once healed.
+_ADAPTER_QNAME_PREFIXES: dict[str, str] = {
+  "quickbooks": "qb",
+  "xero": "xero",
+  "plaid": "plaid",
+}
+
+
+def _derive_adapter_qname(external_source: str | None, code: str | None) -> str | None:
+  """``qb:Intangible Assets:Accumulated Amortization``-style adapter qname.
+
+  Derived from the source system's fully-qualified account code, which the
+  source guarantees unique per book. Returns None for unknown sources or
+  blank codes — never guess an identity.
+  """
+  prefix = _ADAPTER_QNAME_PREFIXES.get(str(external_source or "").lower())
+  if not prefix or not code:
+    return None
+  return f"{prefix}:{code}"
+
+
+# Balance-sheet EFS classifications are stock concepts (point-in-time →
+# instant); everything else is a flow (duration). Mirrors
+# ``_INSTANT_CLASSIFICATIONS`` in operations/roboledger/commands/elements.py
+# — kept local so the sync path doesn't import the command layer.
+_INSTANT_EFS_IDENTIFIERS: frozenset[str] = frozenset(
+  {
+    "asset",
+    "contraAsset",
+    "liability",
+    "contraLiability",
+    "equity",
+    "contraEquity",
+    "temporaryEquity",
+  }
+)
+
+
+def _derive_element_period_type(efs_identifier: str | None) -> str:
+  """'instant' for stock classifications, 'duration' otherwise/unknown."""
+  if efs_identifier in _INSTANT_EFS_IDENTIFIERS:
+    return "instant"
+  return "duration"
+
+
 def _parse_metadata(raw) -> dict:
   """Parse metadata from dbt output — may be a dict, JSON string, or None."""
   if isinstance(raw, dict):
@@ -594,6 +688,58 @@ class OLTPLoader:
           ):
             existing_elements[str(el.external_id)] = el
 
+        # Adapter elements carry a derived qname (``{prefix}:{code}``) so
+        # they are addressable everywhere library elements are — envelope
+        # patches, the update validator's projection, and the OLAP graph
+        # (which now prefers this stored value over its own synthesis).
+        # Derived from the book-unique account code; healed on every sync
+        # (NULL from pre-qname loader versions, or a source-side rename
+        # moving the code).
+        desired_qnames: dict[str, str] = {}
+        for row in rows:
+          derived = _derive_adapter_qname(
+            str(row.get("external_source") or source), str(row["code"])
+          )
+          if derived:
+            desired_qnames[str(row["external_id"])] = derived
+
+        # qname uniqueness is schema-wide while the derivation is only
+        # book-unique — a second connection (or a native element) may
+        # already own the string. Fail loud and leave identity unset
+        # rather than stealing it or crashing the sync.
+        qname_owner_by_qname: dict[str, Element] = {}
+        if desired_qnames:
+          for el in (
+            session.query(Element)
+            .filter(Element.qname.in_(set(desired_qnames.values())))
+            .all()
+          ):
+            qname_owner_by_qname[str(el.qname)] = el
+
+        def _resolve_element_qname(ext_id: str) -> str | None:
+          desired = desired_qnames.get(ext_id)
+          if desired is None:
+            return None
+          owner = qname_owner_by_qname.get(desired)
+          if owner is None or (
+            str(owner.external_source or "") == source
+            and str(owner.connection_id or "") == str(connection_id)
+            and str(owner.external_id or "") == ext_id
+          ):
+            return desired
+          logger.warning(
+            "Element qname collision: %r is already owned by element %s "
+            "(source=%s connection=%s) — leaving qname unset for %s "
+            "account %s; resolve the collision, then re-sync to heal",
+            desired,
+            owner.id,
+            owner.external_source,
+            owner.connection_id,
+            source,
+            ext_id,
+          )
+          return None
+
         new_element_objects: list[Element] = []
         updated_count = 0
         for row in rows:
@@ -604,6 +750,10 @@ class OLTPLoader:
             if ext_parent and str(ext_parent) not in ("", "None", "nan")
             else None
           )
+
+          meta = _parse_metadata(row.get("metadata"))
+          efs_identifier = _account_efs_identifier(meta, str(row["name"]))
+          resolved_qname = _resolve_element_qname(ext_id)
 
           if ext_id in existing_elements:
             # UPDATE in place — preserve elem_* ULID.
@@ -617,7 +767,18 @@ class OLTPLoader:
             el.currency = str(row.get("currency", "USD"))
             el.is_active = bool(row.get("is_active", True))
             el.is_placeholder = bool(row.get("is_placeholder", False))
-            el.metadata_ = _parse_metadata(row.get("metadata"))
+            el.metadata_ = meta
+            # Heal XBRL-intrinsic metadata rows loaded before the loader
+            # wrote it (or drifted since): qname follows the source code;
+            # period_type follows the account's stock/flow classification.
+            if resolved_qname is not None and el.qname != resolved_qname:
+              el.qname = resolved_qname
+            if efs_identifier is not None:
+              desired_period_type = _derive_element_period_type(efs_identifier)
+              if el.period_type != desired_period_type:
+                el.period_type = desired_period_type
+            if el.item_type is None:
+              el.item_type = "monetary"
             el.updated_at = now
             element_lookup[ext_id] = el.id
             if parent_external:
@@ -635,6 +796,7 @@ class OLTPLoader:
                 code=str(row["code"]),
                 name=str(row["name"]),
                 description=str(row["description"]) if row.get("description") else None,
+                qname=resolved_qname,
                 balance_type=str(row["balance_type"]),
                 parent_id=None,  # resolved in second pass
                 depth=int(row.get("depth", 0)),
@@ -643,14 +805,15 @@ class OLTPLoader:
                 is_active=bool(row.get("is_active", True)),
                 is_placeholder=bool(row.get("is_placeholder", False)),
                 source=source,
-                period_type="duration",
+                period_type=_derive_element_period_type(efs_identifier),
                 element_type="concept",
                 is_abstract=False,
                 is_monetary=True,
+                item_type="monetary",
                 external_id=ext_id,
                 external_source=str(row["external_source"]),
                 connection_id=connection_id,
-                metadata_=_parse_metadata(row.get("metadata")),
+                metadata_=meta,
                 version=1,
                 created_at=now,
                 updated_at=now,
@@ -832,9 +995,14 @@ class OLTPLoader:
     liquidity instead of inferring it from the account name. Returns the
     number of rows actually inserted (EFS + liquidity).
 
-    Idempotent: skips elements that already carry an EFS trait (could
-    happen if a downstream classifier ran first), and uses an INSERT
-    with ON CONFLICT DO NOTHING to handle re-syncs cleanly.
+    Idempotent, and self-healing for adapter-written rows: an element
+    whose stored EFS trait no longer matches what this pass derives
+    (e.g. a contra-asset loaded before contra-promotion existed, stuck
+    on plain ``asset``) has its adapter-written rows replaced. Rows with
+    any other provenance (``source`` not equal to this adapter — the
+    envelope/manual path leaves source NULL) are deliberate overrides
+    and are never touched. Inserts use ON CONFLICT DO NOTHING to handle
+    re-syncs cleanly.
 
     Currently only QuickBooks is wired. Xero / NetSuite layer in by
     adding their classification dict + a source check. The cross-source
@@ -890,7 +1058,26 @@ class OLTPLoader:
       .all()
     )
 
+    # Existing EFS rows per element — loaded so a stale adapter-written
+    # classification can be HEALED, not just left alongside a new row.
+    # Joined on category rather than the adapter's identifier set so a
+    # manual override pointing at any EFS trait is still seen (and
+    # protected) here.
+    existing_efs_rows: dict[str, list[ElementTrait]] = {}
+    if elements:
+      for et, _t in (
+        session.query(ElementTrait, Trait)
+        .join(Trait, ElementTrait.trait_id == Trait.id)
+        .filter(
+          Trait.category == "elementsOfFinancialStatements",
+          ElementTrait.element_id.in_([e.id for e in elements]),
+        )
+        .all()
+      ):
+        existing_efs_rows.setdefault(str(et.element_id), []).append(et)
+
     rows: list[ElementTrait] = []
+    healed = 0
 
     def _trait_row(element_id: str, trait_id: str) -> ElementTrait:
       return ElementTrait(
@@ -909,7 +1096,12 @@ class OLTPLoader:
       acct_type = meta.get("account_type")
       if not acct_type:
         continue
-      efs_identifier = type_to_efs.get(acct_type)
+      # ``_account_efs_identifier`` carries the contra-asset promotion:
+      # asset-typed accounts flip to ``contraAsset`` on a known contra
+      # AccountSubType OR a contra-convention account name (the fallback
+      # for user-chosen generic detail types). The asset guard inside it
+      # keeps equity Accumulated-* names (AOCI) from ever matching.
+      efs_identifier = _account_efs_identifier(meta, str(elem.name))
       if efs_identifier is None:
         # Unknown source-system AccountType — log so unmapped types
         # surface in sync logs rather than silently producing
@@ -921,20 +1113,28 @@ class OLTPLoader:
           elem.id,
         )
         continue
-      # A contra-asset is asset-typed in QB but offsets the gross asset —
-      # override the account_type's plain ``asset`` trait with
-      # ``contraAsset`` so rollups subtract it and the schedule generator
-      # rolls it forward in the accumulate (not deplete) direction. Guard on
-      # the asset classification so a non-asset Accumulated-* sub-type (e.g.
-      # the equity AccumulatedOtherComprehensiveIncome) can never be
-      # mislabeled as a contra-asset.
-      if efs_identifier == "asset" and _is_qb_contra_asset_sub_type(
-        meta.get("account_sub_type")
-      ):
-        efs_identifier = "contraAsset"
       efs_trait_id = efs_id_by_identifier.get(efs_identifier)
       if efs_trait_id is not None:
-        rows.append(_trait_row(elem.id, efs_trait_id))
+        current_rows = existing_efs_rows.get(str(elem.id), [])
+        if not current_rows:
+          rows.append(_trait_row(elem.id, efs_trait_id))
+        elif all(str(r.trait_id) == str(efs_trait_id) for r in current_rows):
+          pass  # already classified correctly
+        elif all((r.source or "") == source for r in current_rows):
+          # Every existing EFS row was written by this adapter and no
+          # longer matches the derived classification — heal in place.
+          for stale_row in current_rows:
+            session.delete(stale_row)
+          rows.append(_trait_row(elem.id, efs_trait_id))
+          healed += 1
+        else:
+          logger.debug(
+            "Element %s EFS trait differs from %s derivation (%s) but "
+            "carries non-adapter provenance — leaving the override",
+            elem.id,
+            source,
+            efs_identifier,
+          )
 
       # Liquidity (current / noncurrent) — assets & liabilities only;
       # absent for equity / revenue / expense. Additive narrowing signal.
@@ -944,6 +1144,12 @@ class OLTPLoader:
         if liquidity_trait_id is not None:
           rows.append(_trait_row(elem.id, liquidity_trait_id))
 
+    if healed:
+      logger.info(
+        "Healed %d stale adapter-written EFS trait assignment(s) from %s",
+        healed,
+        source,
+      )
     if not rows:
       return 0
 

--- a/robosystems/operations/extensions/materialize.py
+++ b/robosystems/operations/extensions/materialize.py
@@ -431,9 +431,14 @@ def _staging_sql(graph_id: str, entity_id: str, connstr: str) -> dict[str, str]:
     SELECT
       e.id                            AS identifier,
       CASE
-        WHEN e.external_source = 'quickbooks' THEN 'qb:' || e.code
-        WHEN e.external_source = 'xero' THEN 'xero:' || e.code
-        WHEN e.external_source = 'plaid' THEN 'plaid:' || e.code
+        -- Adapter elements: the loader now derives and stores the qname at
+        -- sync time (operations/extensions/loader.py); prefer the stored
+        -- value so OLTP stays the identity authority. The prefixed-code
+        -- fallback covers rows loaded before qnames were written — one
+        -- re-sync heals them and retires the fallback per tenant.
+        WHEN e.external_source = 'quickbooks' THEN COALESCE(e.qname, 'qb:' || e.code)
+        WHEN e.external_source = 'xero' THEN COALESCE(e.qname, 'xero:' || e.code)
+        WHEN e.external_source = 'plaid' THEN COALESCE(e.qname, 'plaid:' || e.code)
         -- Library/taxonomy concepts (rs-gaap, fac, us-gaap, cm, disclosures,
         -- styles, …) already carry a canonical namespaced qname; emit it
         -- verbatim. Re-prefixing would yield rl:rs-gaap:X, which no canonical

--- a/robosystems/operations/taxonomy_block/update_validator.py
+++ b/robosystems/operations/taxonomy_block/update_validator.py
@@ -77,6 +77,33 @@ def validate_update_envelope(
   element_id_by_qname = {e.qname: e.id for e in current_elements if e.qname}
   trait_by_element_id = _load_efs_traits(session, current_elements)
 
+  # Elements without a qname cannot be projected: patches key on qname, and
+  # an association endpoint reconstructing as None crashes the request
+  # models. Report them once, legibly, and exclude them (and their arcs)
+  # from the projection so the rest of the update still validates. Adapter
+  # elements get their qname written at connection sync — the heal is a
+  # re-sync, not a manual repair.
+  missing_qname_element_ids = {str(e.id) for e in current_elements if not e.qname}
+  if missing_qname_element_ids:
+    unnamed = [e for e in current_elements if not e.qname]
+    issues.append(
+      ValidationIssue(
+        phase="projection",
+        code="element_missing_qname",
+        message=(
+          f"{len(unnamed)} element(s) in this taxonomy have no qname and "
+          "cannot be addressed or projected for update validation. "
+          "Adapter-loaded elements receive their qname during connection "
+          "sync — re-run the sync to heal them, then retry this update."
+        ),
+        context={
+          "count": len(unnamed),
+          "element_ids": [str(e.id) for e in unnamed[:20]],
+          "element_names": [str(e.name) for e in unnamed[:20]],
+        },
+      )
+    )
+
   _resolve_foreign_element_qnames(
     session, qname_by_element_id, current_elements, current_associations
   )
@@ -94,6 +121,8 @@ def validate_update_envelope(
 
   virtual_elements: list[TaxonomyBlockElementRequest] = []
   for e in current_elements:
+    if str(e.id) in missing_qname_element_ids:
+      continue  # reported once via element_missing_qname above
     qname = str(e.qname) if e.qname else ""
     if qname in elements_to_remove_qnames:
       continue
@@ -177,8 +206,13 @@ def validate_update_envelope(
       continue
     if a.structure_id in structures_to_remove:
       continue
-    from_qname = qname_by_element_id.get(a.from_element_id, "")
-    to_qname = qname_by_element_id.get(a.to_element_id, "")
+    if (
+      str(a.from_element_id) in missing_qname_element_ids
+      or str(a.to_element_id) in missing_qname_element_ids
+    ):
+      continue  # endpoint reported via element_missing_qname above
+    from_qname = qname_by_element_id.get(a.from_element_id, "") or ""
+    to_qname = qname_by_element_id.get(a.to_element_id, "") or ""
     if from_qname in elements_to_remove_qnames:
       continue
     if to_qname in elements_to_remove_qnames:

--- a/tests/operations/extensions/test_loader.py
+++ b/tests/operations/extensions/test_loader.py
@@ -1054,12 +1054,16 @@ class TestApplySourceElementTraits:
 
     session = MagicMock()
 
-    def query_dispatcher(model):
+    def query_dispatcher(*models):
       result = MagicMock()
-      if model is Element:
+      if models == (Element,):
         result.filter.return_value.all.return_value = list(elements_by_id.values())
-      elif model is Trait:
+      elif models == (Trait,):
         result.filter.return_value.__iter__ = lambda self: iter(traits)
+      else:
+        # The (ElementTrait, Trait) join loading existing EFS rows for the
+        # heal pass — these tests model fresh elements with no prior rows.
+        result.join.return_value.filter.return_value.all.return_value = []
       return result
 
     session.query.side_effect = query_dispatcher

--- a/tests/operations/extensions/test_loader_element_metadata.py
+++ b/tests/operations/extensions/test_loader_element_metadata.py
@@ -1,0 +1,458 @@
+"""Adapter elements carry their XBRL-intrinsic metadata — real Postgres.
+
+The loader historically wrote adapter (QuickBooks) CoA elements with
+``qname=NULL``, ``period_type='duration'`` (hardcoded — wrong for every
+balance-sheet account), and ``item_type=NULL``. The OLAP materializer
+papered over the missing qname by synthesizing ``'qb:' || code`` at build
+time, so the graph looked healthy while OLTP — the identity-bearing
+store — had no identity: no adapter element was addressable through
+``update-taxonomy-block`` (patches key on qname), and the update
+validator's projection crashed reconstructing associations
+(``from_ref=None``).
+
+These tests pin the sync-heals-itself contract:
+
+- INSERT derives qname / period_type / item_type at load time.
+- Re-sync heals rows loaded before the loader wrote them (and after a
+  source-side account rename moves the code).
+- The trait pass heals a stale adapter-written EFS classification (the
+  pre-contra-promotion ``asset`` on an accumulated-amortization account)
+  while never touching a non-adapter (manual/envelope) trait row.
+- A schema-wide qname collision leaves identity unset and warns, rather
+  than stealing the string or crashing the sync.
+- The update validator reports NULL-qname elements as a legible issue
+  instead of a Pydantic crash.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+import robosystems.models.extensions  # noqa: F401  (register models on ExtensionsBase)
+from robosystems.db.extensions import ExtensionsBase
+from robosystems.models.extensions import Element, ElementTrait, Trait
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture()
+def ext_session():
+  """Extensions schema in the test Postgres DB, one throwaway schema per test."""
+  database_url = os.environ.get("TEST_DATABASE_URL")
+  if not database_url:
+    pytest.skip("TEST_DATABASE_URL not configured")
+
+  schema = f"ext_elmeta_{uuid.uuid4().hex[:12]}"
+  engine = create_engine(database_url)
+  with engine.begin() as conn:
+    conn.execute(text(f'CREATE SCHEMA "{schema}"'))
+
+  session = sessionmaker(bind=engine)()
+  session.execute(text(f'SET search_path TO "{schema}"'))
+  ExtensionsBase.metadata.create_all(bind=session.connection())
+  session.commit()
+  session.execute(text(f'SET search_path TO "{schema}"'))
+
+  try:
+    yield session
+  finally:
+    session.rollback()
+    session.close()
+    with engine.begin() as conn:
+      conn.execute(text(f'DROP SCHEMA "{schema}" CASCADE'))
+    engine.dispose()
+
+
+def _seed_traits(session) -> dict[str, Trait]:
+  """Seed the EFS + liquidity Trait rows the loader's trait pass resolves."""
+  traits: dict[str, Trait] = {}
+  for category, identifiers in (
+    (
+      "elementsOfFinancialStatements",
+      ["asset", "contraAsset", "liability", "equity", "revenue", "expense"],
+    ),
+    ("liquidity", ["current", "noncurrent"]),
+  ):
+    for identifier in identifiers:
+      t = Trait(category=category, identifier=identifier, name=identifier)
+      session.add(t)
+      traits[identifier] = t
+  session.flush()
+  return traits
+
+
+def _make_duckdb_mock(tables: dict[str, list[dict]]):
+  """DuckDB connection mock returning the given tables (mirrors test_loader)."""
+  mock_con = MagicMock()
+  table_names = list(tables.keys())
+
+  def execute_side_effect(query):
+    result = MagicMock()
+    if query == "SHOW TABLES":
+      result.fetchall.return_value = [(t,) for t in table_names]
+    else:
+      for t in table_names:
+        if f"SELECT * FROM {t}" in query:
+          rows = tables[t]
+          if rows:
+            columns = list(rows[0].keys())
+            result.description = [(c,) for c in columns]
+            result.fetchall.return_value = [tuple(r.values()) for r in rows]
+          else:
+            result.description = []
+            result.fetchall.return_value = []
+          break
+      else:
+        result.description = []
+        result.fetchall.return_value = []
+    return result
+
+  mock_con.execute.side_effect = execute_side_effect
+  return mock_con
+
+
+def _account(
+  ext_id: str,
+  code: str,
+  name: str,
+  balance_type: str,
+  account_type: str,
+  account_sub_type: str | None = None,
+) -> dict:
+  meta_parts = [f'"account_type": "{account_type}"']
+  if account_sub_type is not None:
+    meta_parts.append(f'"account_sub_type": "{account_sub_type}"')
+  return {
+    "external_id": ext_id,
+    "external_source": "quickbooks",
+    "code": code,
+    "name": name,
+    "description": None,
+    "balance_type": balance_type,
+    "external_parent_id": None,
+    "depth": 0,
+    "path": "",
+    "currency": "USD",
+    "is_active": True,
+    "is_placeholder": False,
+    "metadata": "{" + ", ".join(meta_parts) + "}",
+  }
+
+
+def _run_load(session, accounts: list[dict], connection_id: str = "conn_1"):
+  from robosystems.operations.extensions.loader import OLTPLoader
+
+  with (
+    patch("robosystems.db.extensions.provision_tenant_schema"),
+    patch("robosystems.db.extensions.extensions_session") as mock_ext_session,
+    patch("duckdb.connect") as mock_duckdb_connect,
+  ):
+    mock_duckdb_connect.return_value = _make_duckdb_mock({"elements": accounts})
+    mock_ext_session.return_value.__enter__ = MagicMock(return_value=session)
+    mock_ext_session.return_value.__exit__ = MagicMock(return_value=False)
+    return OLTPLoader().load(
+      graph_id="kg0123456789abcdef",
+      source="quickbooks",
+      connection_id=connection_id,
+      duckdb_path="/tmp/test.duckdb",
+      created_by="user_1",
+    )
+
+
+def _efs_identifiers(session, element_id: str) -> list[str]:
+  rows = (
+    session.query(Trait.identifier)
+    .join(ElementTrait, ElementTrait.trait_id == Trait.id)
+    .filter(
+      ElementTrait.element_id == element_id,
+      Trait.category == "elementsOfFinancialStatements",
+    )
+    .all()
+  )
+  return sorted(r[0] for r in rows)
+
+
+class TestInsertDerivesIntrinsicMetadata:
+  def test_qname_period_type_item_type_and_contra_trait(self, ext_session):
+    _seed_traits(ext_session)
+    ext_session.commit()
+
+    accounts = [
+      _account("1", "Truist Checking", "Truist Checking", "debit", "Bank"),
+      _account("2", "Consulting Services", "Consulting Services", "credit", "Income"),
+      # Contra via the known AccountSubType.
+      _account(
+        "3",
+        "Accumulated depreciation",
+        "Accumulated depreciation",
+        "debit",
+        "Fixed Asset",
+        account_sub_type="AccumulatedDepreciation",
+      ),
+      # Contra via the NAME fallback: user-chosen generic detail type
+      # carries no contra signal, so the sub-type rule alone misses it.
+      _account(
+        "4",
+        "Intangible Assets:Accumulated Amortization",
+        "Accumulated Amortization",
+        "debit",
+        "Other Asset",
+        account_sub_type="OtherLongTermAssets",
+      ),
+    ]
+    result = _run_load(ext_session, accounts)
+    assert result.elements == 4
+
+    by_ext = {
+      str(e.external_id): e
+      for e in ext_session.query(Element)
+      .filter(Element.external_source == "quickbooks")
+      .all()
+    }
+
+    bank = by_ext["1"]
+    assert bank.qname == "qb:Truist Checking"
+    assert bank.period_type == "instant"
+    assert bank.item_type == "monetary"
+    assert _efs_identifiers(ext_session, str(bank.id)) == ["asset"]
+
+    income = by_ext["2"]
+    assert income.qname == "qb:Consulting Services"
+    assert income.period_type == "duration"
+    assert _efs_identifiers(ext_session, str(income.id)) == ["revenue"]
+
+    accum_dep = by_ext["3"]
+    assert accum_dep.period_type == "instant"
+    assert _efs_identifiers(ext_session, str(accum_dep.id)) == ["contraAsset"]
+
+    accum_amort = by_ext["4"]
+    assert accum_amort.qname == "qb:Intangible Assets:Accumulated Amortization"
+    assert accum_amort.period_type == "instant"
+    assert _efs_identifiers(ext_session, str(accum_amort.id)) == ["contraAsset"]
+
+  def test_equity_accumulated_name_never_flips_to_contra(self, ext_session):
+    """AOCI-style equity names must not match the contra-name fallback."""
+    _seed_traits(ext_session)
+    ext_session.commit()
+
+    accounts = [
+      _account(
+        "10",
+        "Accumulated Adjustment",
+        "Accumulated Adjustment",
+        "credit",
+        "Equity",
+      ),
+    ]
+    _run_load(ext_session, accounts)
+    el = ext_session.query(Element).filter(Element.external_id == "10").one()
+    assert _efs_identifiers(ext_session, str(el.id)) == ["equity"]
+    assert el.period_type == "instant"
+
+
+class TestResyncHealsPreQnameRows:
+  def test_resync_heals_qname_period_type_and_stale_trait(self, ext_session):
+    """A row loaded by the pre-qname loader is healed in place on re-sync."""
+    traits = _seed_traits(ext_session)
+
+    # Pre-seed the element exactly as the old loader left it: NULL qname,
+    # hardcoded duration, no item_type, plain-asset EFS trait written by
+    # the adapter.
+    stale = Element(
+      code="Intangible Assets:Accumulated Amortization",
+      name="Accumulated Amortization",
+      balance_type="debit",
+      period_type="duration",
+      source="quickbooks",
+      external_id="155",
+      external_source="quickbooks",
+      connection_id="conn_1",
+      metadata_={"account_type": "Other Asset"},
+    )
+    ext_session.add(stale)
+    ext_session.flush()
+    ext_session.add(
+      ElementTrait(
+        element_id=stale.id,
+        trait_id=traits["asset"].id,
+        is_primary=True,
+        source="quickbooks",
+      )
+    )
+    ext_session.commit()
+    original_id = str(stale.id)
+
+    accounts = [
+      _account(
+        "155",
+        "Intangible Assets:Accumulated Amortization",
+        "Accumulated Amortization",
+        "debit",
+        "Other Asset",
+        account_sub_type="OtherLongTermAssets",
+      ),
+    ]
+    _run_load(ext_session, accounts)
+
+    healed = ext_session.query(Element).filter(Element.external_id == "155").one()
+    assert str(healed.id) == original_id  # ULID preserved (UPSERT, not re-mint)
+    assert healed.qname == "qb:Intangible Assets:Accumulated Amortization"
+    assert healed.period_type == "instant"
+    assert healed.item_type == "monetary"
+    # The stale adapter-written asset row is gone; contraAsset replaced it.
+    assert _efs_identifiers(ext_session, original_id) == ["contraAsset"]
+
+  def test_rename_moves_qname_with_the_code(self, ext_session):
+    _seed_traits(ext_session)
+    accounts = [_account("7", "Old Name", "Old Name", "debit", "Bank")]
+    _run_load(ext_session, accounts)
+    renamed = [_account("7", "New Name", "New Name", "debit", "Bank")]
+    _run_load(ext_session, renamed)
+
+    el = ext_session.query(Element).filter(Element.external_id == "7").one()
+    assert el.qname == "qb:New Name"
+
+  def test_manual_trait_override_is_preserved(self, ext_session):
+    """A non-adapter EFS row (source NULL = envelope/manual) is never healed."""
+    traits = _seed_traits(ext_session)
+    overridden = Element(
+      code="Accumulated depreciation",
+      name="Accumulated depreciation",
+      balance_type="debit",
+      period_type="instant",
+      source="quickbooks",
+      external_id="156",
+      external_source="quickbooks",
+      connection_id="conn_1",
+      metadata_={"account_type": "Fixed Asset"},
+    )
+    ext_session.add(overridden)
+    ext_session.flush()
+    # Manual override: deliberately classified plain asset, source NULL.
+    ext_session.add(
+      ElementTrait(
+        element_id=overridden.id,
+        trait_id=traits["asset"].id,
+        is_primary=True,
+      )
+    )
+    ext_session.commit()
+
+    accounts = [
+      _account(
+        "156",
+        "Accumulated depreciation",
+        "Accumulated depreciation",
+        "debit",
+        "Fixed Asset",
+        account_sub_type="AccumulatedDepreciation",
+      ),
+    ]
+    _run_load(ext_session, accounts)
+
+    assert _efs_identifiers(ext_session, str(overridden.id)) == ["asset"]
+
+
+class TestQnameCollision:
+  def test_collision_leaves_qname_unset(self, ext_session):
+    """A second connection with the same account code must not steal the qname."""
+    _seed_traits(ext_session)
+    owner = Element(
+      code="Cash",
+      name="Cash",
+      qname="qb:Cash",
+      balance_type="debit",
+      period_type="instant",
+      source="quickbooks",
+      external_id="1",
+      external_source="quickbooks",
+      connection_id="conn_other",
+      metadata_={"account_type": "Bank"},
+    )
+    ext_session.add(owner)
+    ext_session.commit()
+
+    accounts = [_account("1", "Cash", "Cash", "debit", "Bank")]
+    _run_load(ext_session, accounts, connection_id="conn_new")
+
+    newcomer = (
+      ext_session.query(Element)
+      .filter(Element.connection_id == "conn_new", Element.external_id == "1")
+      .one()
+    )
+    assert newcomer.qname is None
+    # The owner keeps its identity untouched.
+    ext_session.refresh(owner)
+    assert owner.qname == "qb:Cash"
+
+
+class TestUpdateValidatorMissingQname:
+  def test_null_qname_elements_reported_legibly(self, ext_session):
+    """NULL-qname elements yield a coded issue, not a Pydantic crash."""
+    from robosystems.models.api.taxonomy_block import UpdateTaxonomyBlockRequest
+    from robosystems.models.extensions import Association, Structure, Taxonomy
+    from robosystems.operations.taxonomy_block.update_validator import (
+      validate_update_envelope,
+    )
+
+    taxonomy = Taxonomy(
+      name="Quickbooks Chart of Accounts",
+      taxonomy_type="chart_of_accounts",
+    )
+    ext_session.add(taxonomy)
+    ext_session.flush()
+
+    named = Element(
+      code="Cash",
+      name="Cash",
+      qname="qb:Cash",
+      balance_type="debit",
+      period_type="instant",
+      source="quickbooks",
+      taxonomy_id=taxonomy.id,
+    )
+    unnamed = Element(
+      code="Accumulated Amortization",
+      name="Accumulated Amortization",
+      balance_type="debit",
+      period_type="duration",
+      source="quickbooks",
+      taxonomy_id=taxonomy.id,
+    )
+    ext_session.add_all([named, unnamed])
+    ext_session.flush()
+
+    structure = Structure(
+      name="Chart of Accounts",
+      block_type="chart_of_accounts",
+      taxonomy_id=taxonomy.id,
+    )
+    ext_session.add(structure)
+    ext_session.flush()
+    ext_session.add(
+      Association(
+        structure_id=structure.id,
+        from_element_id=unnamed.id,
+        to_element_id=named.id,
+        association_type="presentation",
+      )
+    )
+    ext_session.commit()
+
+    issues = validate_update_envelope(
+      ext_session,
+      taxonomy,
+      UpdateTaxonomyBlockRequest(taxonomy_id=str(taxonomy.id)),
+    )
+
+    codes = {i.code for i in issues}
+    assert "element_missing_qname" in codes
+    issue = next(i for i in issues if i.code == "element_missing_qname")
+    assert issue.context["count"] == 1
+    assert "Accumulated Amortization" in issue.context["element_names"]


### PR DESCRIPTION
## Summary

Adapter-loaded Chart of Accounts elements were created without their XBRL-intrinsic metadata: `qname` was never written (the OLAP materializer synthesized `'qb:' || code` at build time, so the graph looked healthy while OLTP — the identity-bearing store — had no identity), `period_type` was hardcoded `duration` (wrong for every balance-sheet account), and `item_type` was never set. Because `update-taxonomy-block` element patches key on qname, no adapter-loaded element has ever been addressable through the envelope, and the update validator crashed reconstructing associations from the NULLs — so the documented correction path for a misclassified account was unusable on every adapter tenant. This PR makes the connection sync derive that metadata at insert and heal it on every re-sync, so existing tenants converge with one sync and drift can't reaccumulate.

## Changes

- **`operations/extensions/loader.py`** — the element upsert now derives and heals the intrinsic set on both branches:
  - `qname` derived as `{prefix}:{code}` from the book-unique account code (`qb:` / `xero:` / `plaid:`), healed when NULL or when a source-side account rename moves the code. A schema-wide collision (a second connection or a native element already owning the string) leaves the qname unset with a warning instead of stealing it or failing the sync.
  - `period_type` derived from the account's EFS classification (stock → `instant`, flow → `duration`), healed on drift. Previously every adapter element landed as `duration`, including cash and equity accounts.
  - `item_type` stamped `monetary`.
  - The contra-asset promotion gains a **name-convention fallback** (accumulated depreciation/amortization/depletion, allowance-for) for accounts whose user-chosen QuickBooks detail type carries no contra signal — guarded on the asset classification so equity `Accumulated*` names (AOCI) can never match. Classification logic is consolidated into one helper (`_account_efs_identifier`) shared by the upsert and the trait pass.
  - The trait pass now **heals** a stale adapter-written EFS row (deletes and replaces it) instead of leaving it stuck on its load-time value, and never touches rows with any other provenance — manual/envelope trait writes carry `source NULL` and are preserved as deliberate overrides. Reviewers: this delete-and-replace is scoped to rows whose `source` equals the syncing adapter; that provenance check is the guard worth scrutinizing.
- **`operations/extensions/materialize.py`** — the Element projection prefers the stored qname (`COALESCE(e.qname, 'qb:' || e.code)` per adapter arm) so OLTP is the identity authority and OLAP follows it by construction; the synthesis survives only as a fallback for rows loaded before this change.
- **`operations/taxonomy_block/update_validator.py`** — NULL-qname elements are reported once as a coded `element_missing_qname` validation issue naming the elements (with the heal spelled out: re-run the connection sync), and are excluded from the projection along with their arcs, instead of crashing the request models with `from_ref=None`.
- **Tests** — new real-Postgres suite `tests/operations/extensions/test_loader_element_metadata.py` (7 tests) pinning: derive-at-insert (qname/period_type/item_type/contra via sub-type and via name fallback), the AOCI non-match, re-sync healing of a pre-change row (ULID preserved), rename-moves-qname, manual-override preservation, qname-collision behavior, and the validator's legible failure. The mock dispatcher in `test_loader.py` was extended for the trait pass's new existing-rows query.

## Breaking Changes

None. All changes are additive or corrective on the sync path; no REST shapes, GraphQL schema, or operations-envelope changes. Adapter element qnames become non-null in OLTP and authoritative for the graph projection — the projected values are identical to what the materializer already synthesized, so downstream consumers see no change.

## Testing

- `just test` — full unit suite: **12,274 passed, 23 skipped** (includes the 7 new real-Postgres tests).
- `just test-code` — ruff, format, basedpyright, cf-lint: **clean**.
