### PR TITLE
feat(graphs): add update-graph-metadata operation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,7 @@ exposes only ledger fields (no `INVESTOR_NOT_INITIALIZED` runtime errors).
 | Restore backup | `POST /v1/graphs/{g}/operations/restore-backup` |
 |  Change tier | `POST /v1/graphs/{g}/operations/change-tier` |
 | Materialize | `POST /v1/graphs/{g}/operations/materialize` |
+| Update metadata | `POST /v1/graphs/{g}/operations/update-graph-metadata` |
 
 All graph operation responses are `OperationEnvelope` and support `Idempotency-Key`. Reads (list subgraphs, list backups, health, etc.) remain REST GETs at their existing paths.
 

--- a/robosystems/models/api/graphs/operations.py
+++ b/robosystems/models/api/graphs/operations.py
@@ -2,7 +2,7 @@
 
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class DeleteSubgraphOp(BaseModel):
@@ -49,6 +49,103 @@ class ChangeTierOp(BaseModel):
   new_tier: Literal["ladybug-standard", "ladybug-large", "ladybug-xlarge"] = Field(
     ...,
     description="Target infrastructure tier",
+  )
+
+
+class UpdateGraphMetadataOp(BaseModel):
+  """Body for the update-graph-metadata operation.
+
+  Partial update — only supplied (non-null) fields change, so a caller
+  editing just the display name need not resend the description and tags.
+  Because ``None`` means "leave alone", clearing a field uses its empty
+  value instead: pass ``""`` to clear the description and ``[]`` to clear
+  the tags. ``graph_name`` cannot be cleared; it is the graph's label
+  everywhere it is listed.
+
+  This is the platform-level label for the graph, independent of the
+  entity name shown on financial statements — change that through
+  ``POST /extensions/roboledger/{graph_id}/operations/update-entity``.
+  """
+
+  model_config = ConfigDict(
+    json_schema_extra={
+      "examples": [
+        {"graph_name": "Acme Consulting LLC"},
+        {
+          "graph_name": "Acme Consulting LLC",
+          "description": "Primary operating entity, consolidated monthly",
+          "tags": ["consulting", "production"],
+        },
+        {"description": "", "tags": []},
+      ]
+    }
+  )
+
+  graph_name: str | None = Field(
+    default=None,
+    min_length=1,
+    max_length=255,
+    description="New display name. Omit to leave unchanged; cannot be cleared.",
+  )
+  description: str | None = Field(
+    default=None,
+    max_length=1000,
+    description="New description. Omit to leave unchanged; pass '' to clear.",
+  )
+  tags: list[str] | None = Field(
+    default=None,
+    max_length=20,
+    description=(
+      "Replaces the full tag list (not a merge). Omit to leave unchanged; "
+      "pass [] to clear. Tags are trimmed, de-duplicated, and capped at 50 "
+      "characters each."
+    ),
+  )
+
+  @field_validator("graph_name")
+  @classmethod
+  def _strip_name(cls, value: str | None) -> str | None:
+    if value is None:
+      return None
+    stripped = value.strip()
+    if not stripped:
+      raise ValueError("graph_name cannot be blank")
+    return stripped
+
+  @field_validator("tags")
+  @classmethod
+  def _normalize_tags(cls, value: list[str] | None) -> list[str] | None:
+    if value is None:
+      return None
+    normalized: list[str] = []
+    for tag in value:
+      cleaned = tag.strip()
+      if not cleaned:
+        continue
+      if len(cleaned) > 50:
+        raise ValueError(f"Tag exceeds 50 characters: {cleaned[:50]}...")
+      if cleaned not in normalized:
+        normalized.append(cleaned)
+    return normalized
+
+
+class GraphMetadataResult(BaseModel):
+  """Result payload for the update-graph-metadata operation."""
+
+  graph_id: str = Field(description="Graph the metadata belongs to")
+  graph_name: str = Field(description="Display name after the update")
+  description: str = Field(
+    default="", description="Description after the update ('' when unset)"
+  )
+  tags: list[str] = Field(
+    default_factory=list, description="Tags after the update (empty when unset)"
+  )
+  updated_fields: list[str] = Field(
+    default_factory=list,
+    description=(
+      "Fields this call actually changed. Empty when the submitted values "
+      "already matched what was stored."
+    ),
   )
 
 

--- a/robosystems/models/api/user.py
+++ b/robosystems/models/api/user.py
@@ -86,6 +86,16 @@ class GraphInfo(BaseModel):
     description="Display name for the graph",
     examples=["Acme Consulting LLC", "SEC EDGAR Filings"],
   )
+  description: str = Field(
+    default="",
+    description="Free-form description ('' when unset)",
+    examples=["", "Primary operating entity, consolidated monthly"],
+  )
+  tags: list[str] = Field(
+    default_factory=list,
+    description="Organizational tags for the graph",
+    examples=[[], ["consulting", "production"]],
+  )
   role: str = Field(
     ..., description="User's role/access level", examples=["admin", "member", "read"]
   )
@@ -139,6 +149,8 @@ class GraphInfo(BaseModel):
         {
           "graphId": "kg1a2b3c4d5",
           "graphName": "Acme Consulting LLC",
+          "description": "Primary operating entity, consolidated monthly",
+          "tags": ["consulting", "production"],
           "role": "admin",
           "isSelected": True,
           "createdAt": "2024-01-15T10:00:00Z",
@@ -153,6 +165,8 @@ class GraphInfo(BaseModel):
         {
           "graphId": "kg9z8y7x6w5_dev",
           "graphName": "TechCorp Enterprises - Dev",
+          "description": "",
+          "tags": ["sandbox"],
           "role": "member",
           "isSelected": False,
           "createdAt": "2024-02-20T14:30:00Z",
@@ -167,6 +181,8 @@ class GraphInfo(BaseModel):
         {
           "graphId": "sec",
           "graphName": "SEC EDGAR Filings",
+          "description": "",
+          "tags": [],
           "role": "read",
           "isSelected": False,
           "createdAt": "2024-01-01T00:00:00Z",

--- a/robosystems/models/core/graph/graph.py
+++ b/robosystems/models/core/graph/graph.py
@@ -220,6 +220,37 @@ class Graph(Model):
     return len(extensions) > 0
 
   @property
+  def description(self) -> str:
+    """Free-form description, or ``""`` when unset.
+
+    Stored inside the ``graph_metadata`` JSONB blob rather than in a column
+    of its own, so nothing at the database level constrains what a row can
+    hold. Type-check rather than trust: a malformed value reaching a
+    response model fails validation for the *whole* response, so a single
+    bad row would take out the entire graph list.
+    """
+    metadata = self.graph_metadata
+    if not isinstance(metadata, dict):
+      return ""
+    description = metadata.get("description")
+    return description if isinstance(description, str) else ""
+
+  @property
+  def tags(self) -> list[str]:
+    """Organizational tags, or ``[]`` when unset.
+
+    Same free-form JSONB caveat as ``description`` — non-string entries are
+    dropped rather than passed through to a response model.
+    """
+    metadata = self.graph_metadata
+    if not isinstance(metadata, dict):
+      return []
+    tags = metadata.get("tags")
+    if not isinstance(tags, list):
+      return []
+    return [tag for tag in tags if isinstance(tag, str)]
+
+  @property
   def database_name(self) -> str:
     """Database name on disk: ``{parent_graph_id}_{subgraph_name}`` for a
     subgraph, the graph ID itself otherwise."""

--- a/robosystems/operations/graph/commands/__init__.py
+++ b/robosystems/operations/graph/commands/__init__.py
@@ -7,6 +7,7 @@ OperationEnvelope via the shared dispatch infrastructure.
 """
 
 from robosystems.operations.graph.commands.materialize import materialize_cmd
+from robosystems.operations.graph.commands.metadata import update_graph_metadata_cmd
 from robosystems.operations.graph.commands.tier import change_graph_tier_cmd
 
-__all__ = ["change_graph_tier_cmd", "materialize_cmd"]
+__all__ = ["change_graph_tier_cmd", "materialize_cmd", "update_graph_metadata_cmd"]

--- a/robosystems/operations/graph/commands/metadata.py
+++ b/robosystems/operations/graph/commands/metadata.py
@@ -76,11 +76,13 @@ def update_graph_metadata_cmd(
     graph.graph_name = graph_name
     updated_fields.append("graph_name")
 
-  if description is not None and description != metadata.get("description", ""):
+  # Compare against the model's coerced view, not the raw blob: a malformed
+  # stored value should read as unset and be overwritten, not compared as-is.
+  if description is not None and description != graph.description:
     metadata["description"] = description
     updated_fields.append("description")
 
-  if tags is not None and tags != metadata.get("tags", []):
+  if tags is not None and tags != graph.tags:
     metadata["tags"] = tags
     updated_fields.append("tags")
 
@@ -100,7 +102,7 @@ def update_graph_metadata_cmd(
   return GraphMetadataResult(
     graph_id=str(graph.graph_id),
     graph_name=str(graph.graph_name),
-    description=metadata.get("description", ""),
-    tags=metadata.get("tags", []),
+    description=graph.description,
+    tags=graph.tags,
     updated_fields=updated_fields,
   )

--- a/robosystems/operations/graph/commands/metadata.py
+++ b/robosystems/operations/graph/commands/metadata.py
@@ -1,0 +1,106 @@
+"""Edit a graph's platform-level metadata — display name, description, tags.
+
+Backs the ``update-graph-metadata`` operation. Before this existed, every
+one of these fields was write-once at provisioning: ``graph_name`` was set
+by ``GraphCreationService`` and never touched again, and ``description`` /
+``tags`` were persisted into ``graph_metadata`` and read by nothing.
+
+Scope is deliberately the platform label only. The entity name that appears
+on financial statements lives in the extensions OLTP database and changes
+through ``update-entity``; the two are allowed to differ (an org may run
+"Acme — Prod" over an entity legally named "Acme Corporation, Inc.").
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from fastapi import HTTPException, status
+from sqlalchemy.orm import Session
+
+from robosystems.logger import logger
+from robosystems.models.api.graphs.operations import GraphMetadataResult
+from robosystems.models.core.graph import Graph
+
+__all__ = ["update_graph_metadata_cmd"]
+
+
+def update_graph_metadata_cmd(
+  graph_id: str,
+  *,
+  graph_name: str | None,
+  description: str | None,
+  tags: list[str] | None,
+  user_id: str,
+  db: Session,
+) -> GraphMetadataResult:
+  """Apply a partial metadata update to a graph and return the new state.
+
+  ``None`` means "leave unchanged" for each field; the caller is expected
+  to have rejected an all-``None`` update already. Requires admin on the
+  graph — this is graph configuration, not graph data, so the member role
+  that can write nodes is not sufficient.
+  """
+  from robosystems.config.shared_repositories import is_shared_repository_or_subgraph
+  from robosystems.models.core.graph.graph_user import GraphUser
+
+  # Shared repositories (SEC, etc.) are platform-managed and shown to every
+  # subscriber under the same name — one tenant must not be able to relabel
+  # them for everyone. Checked before the role lookup so the error names the
+  # real reason rather than "admin access required".
+  if is_shared_repository_or_subgraph(graph_id):
+    raise HTTPException(
+      status_code=status.HTTP_403_FORBIDDEN,
+      detail=f"Metadata on shared repository '{graph_id}' is platform-managed.",
+    )
+
+  graph = Graph.get_by_id(graph_id, db)
+  if graph is None:
+    raise HTTPException(
+      status_code=status.HTTP_404_NOT_FOUND,
+      detail=f"Graph {graph_id} not found",
+    )
+
+  # `user_has_admin_access` resolves a subgraph to its parent and honours the
+  # implicit admin an org OWNER/ADMIN holds over graphs their org pays for.
+  if not GraphUser.user_has_admin_access(user_id, graph_id, db):
+    raise HTTPException(
+      status_code=status.HTTP_403_FORBIDDEN,
+      detail=f"Admin access to graph {graph_id} is required to edit its metadata.",
+    )
+
+  metadata = {**graph.graph_metadata} if graph.graph_metadata else {}
+  updated_fields: list[str] = []
+
+  if graph_name is not None and graph_name != graph.graph_name:
+    graph.graph_name = graph_name
+    updated_fields.append("graph_name")
+
+  if description is not None and description != metadata.get("description", ""):
+    metadata["description"] = description
+    updated_fields.append("description")
+
+  if tags is not None and tags != metadata.get("tags", []):
+    metadata["tags"] = tags
+    updated_fields.append("tags")
+
+  if updated_fields:
+    # Reassign rather than mutate in place: SQLAlchemy does not track
+    # mutations inside a plain JSONB dict, so an in-place edit would be
+    # silently dropped at flush.
+    graph.graph_metadata = metadata
+    graph.updated_at = datetime.now(UTC)
+    db.commit()
+    db.refresh(graph)
+    logger.info(
+      f"Updated graph metadata for {graph_id}: "
+      f"fields={updated_fields} by user={user_id}"
+    )
+
+  return GraphMetadataResult(
+    graph_id=str(graph.graph_id),
+    graph_name=str(graph.graph_name),
+    description=metadata.get("description", ""),
+    tags=metadata.get("tags", []),
+    updated_fields=updated_fields,
+  )

--- a/robosystems/routers/graphs/main.py
+++ b/robosystems/routers/graphs/main.py
@@ -82,14 +82,15 @@ def _raise_http_exception(
 
 
 def _label_fields(graph: Graph | None) -> tuple[str, list[str]]:
-  """Read the ``(description, tags)`` pair out of ``graph_metadata``.
+  """Read the ``(description, tags)`` pair off a graph, tolerating ``None``.
 
-  Both live in the free-form JSONB blob rather than in columns of their own,
-  so tolerate absence and legacy rows that never had the keys written. Keeps
-  the three list branches below from repeating the same defaulting.
+  A repository row can be absent (``UserRepository.graph``), which the model
+  properties cannot express on their own. Coercion of the underlying JSONB
+  lives on the model so this and the update command agree on it.
   """
-  metadata = (graph.graph_metadata if graph else None) or {}
-  return metadata.get("description") or "", metadata.get("tags") or []
+  if graph is None:
+    return "", []
+  return graph.description, graph.tags
 
 
 @router.get(

--- a/robosystems/routers/graphs/main.py
+++ b/robosystems/routers/graphs/main.py
@@ -81,6 +81,17 @@ def _raise_http_exception(
   )
 
 
+def _label_fields(graph: Graph | None) -> tuple[str, list[str]]:
+  """Read the ``(description, tags)`` pair out of ``graph_metadata``.
+
+  Both live in the free-form JSONB blob rather than in columns of their own,
+  so tolerate absence and legacy rows that never had the keys written. Keeps
+  the three list branches below from repeating the same defaulting.
+  """
+  metadata = (graph.graph_metadata if graph else None) or {}
+  return metadata.get("description") or "", metadata.get("tags") or []
+
+
 @router.get(
   "",
   response_model=UserGraphsResponse,
@@ -131,10 +142,13 @@ async def get_graphs(
       else:
         member_graphs += 1
 
+      description, tags = _label_fields(user_graph.graph)
       graphs.append(
         GraphInfo(
           graphId=user_graph.graph_id,
           graphName=user_graph.graph.graph_name,
+          description=description,
+          tags=tags,
           role=user_graph.role,
           isSelected=user_graph.is_selected,
           createdAt=user_graph.created_at.isoformat(),
@@ -173,10 +187,13 @@ async def get_graphs(
           continue
 
         admin_graphs += 1
+        description, tags = _label_fields(graph)
         graphs.append(
           GraphInfo(
             graphId=graph.graph_id,
             graphName=graph.graph_name,
+            description=description,
+            tags=tags,
             role="admin",
             isSelected=False,
             createdAt=graph.created_at.isoformat(),
@@ -200,10 +217,13 @@ async def get_graphs(
         else user_repo.repository_name.upper()
       )
 
+      description, tags = _label_fields(user_repo.graph)
       graphs.append(
         GraphInfo(
           graphId=user_repo.repository_name,
           graphName=graph_name,
+          description=description,
+          tags=tags,
           role=user_repo.access_level.value,
           isSelected=False,
           createdAt=user_repo.created_at.isoformat(),

--- a/robosystems/routers/graphs/operations.py
+++ b/robosystems/routers/graphs/operations.py
@@ -49,8 +49,10 @@ from robosystems.models.api.graphs.operations import (
   ChangeTierOp,
   DeleteGraphOp,
   DeleteSubgraphOp,
+  GraphMetadataResult,
   MaterializeOp,
   RestoreBackupOp,
+  UpdateGraphMetadataOp,
 )
 from robosystems.models.api.graphs.subgraphs import CreateSubgraphRequest
 from robosystems.models.core import User
@@ -884,6 +886,68 @@ async def change_tier_op(
     event=_AUDIT_EVENT,
   )
   return envelope
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# update-graph-metadata
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@router.post(
+  "/update-graph-metadata",
+  response_model=OperationEnvelope[GraphMetadataResult],
+  operation_id="updateGraphMetadata",
+  summary="Update Graph Metadata",
+  description=(
+    "Edit the graph's platform-level label: display name, description, and "
+    'tags. Partial — only supplied (non-null) fields change; pass `""` to '
+    "clear the description and `[]` to clear the tags. Requires admin on the "
+    "graph. This is not the entity name that appears on financial statements "
+    "— change that through the roboledger `update-entity` operation."
+  ),
+  tags=[_OP_TAG],
+  dependencies=[_RATE_LIMIT],
+  responses={**OPERATION_ERROR_RESPONSES},
+)
+@endpoint_metrics_decorator(
+  f"{_GRAPH_OPS_PATH}/update-graph-metadata",
+  method="POST",
+  business_event_type="graph_update_metadata",
+)
+async def update_graph_metadata_op(
+  body: UpdateGraphMetadataOp,
+  graph_id: str = Path(..., pattern=GRAPH_OR_SUBGRAPH_ID_PATTERN),
+  user: User = Depends(get_current_user_with_graph),
+  idempotency_key: str | None = Header(None, alias="Idempotency-Key"),
+  cache: IdempotencyCache = Depends(get_idempotency_cache),
+  db: Session = Depends(get_async_db_session),
+) -> OperationEnvelope:
+  from robosystems.operations.graph.commands.metadata import update_graph_metadata_cmd
+
+  ctx = _ctx(
+    graph_id=graph_id,
+    user_id=str(user.id),
+    op="update-graph-metadata",
+    idempotency_key=idempotency_key,
+    body=body,
+  )
+
+  def _runner():
+    if body.graph_name is None and body.description is None and body.tags is None:
+      raise HTTPException(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        detail="No fields provided for update.",
+      )
+    return update_graph_metadata_cmd(
+      graph_id,
+      graph_name=body.graph_name,
+      description=body.description,
+      tags=body.tags,
+      user_id=str(user.id),
+      db=db,
+    )
+
+  return await _dispatch(ctx, _runner, cache)
 
 
 # ═══════════════════════════════════════════════════════════════════════════

--- a/static/description.md
+++ b/static/description.md
@@ -40,6 +40,7 @@ The core platform surface for querying and managing graphs. Reads are REST `GET`
 - **restore-backup**: Restore from backup (blocked for entity graphs — use `materialize` instead)
 - **change-tier**: Change graph infrastructure tier with Stripe billing integration
 - **materialize**: Ingest DuckDB-staged tables or OLTP data into the graph (direct or Dagster-orchestrated)
+- **update-graph-metadata**: Edit the graph's display name, description and tags (admin only; partial update)
 
 ### Documents, Search & Memory
 

--- a/tests/operations/graph/commands/test_metadata.py
+++ b/tests/operations/graph/commands/test_metadata.py
@@ -1,0 +1,219 @@
+"""Tests for update_graph_metadata_cmd.
+
+Runs against the real test database rather than mocks: the command edits a
+JSONB column, and the failure mode worth guarding (mutating the dict in
+place so SQLAlchemy never marks it dirty and the write silently vanishes)
+only reproduces against a real session.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+from robosystems.operations.graph.commands.metadata import update_graph_metadata_cmd
+
+
+def _update(graph_id, user_id, db, **fields):
+  """Call the command with every field defaulting to 'unchanged'."""
+  return update_graph_metadata_cmd(
+    graph_id,
+    graph_name=fields.get("graph_name"),
+    description=fields.get("description"),
+    tags=fields.get("tags"),
+    user_id=user_id,
+    db=db,
+  )
+
+
+class TestUpdateGraphMetadata:
+  def test_updates_all_three_fields(self, test_db, test_user, test_user_graph):
+    graph_id = test_user_graph.graph_id
+
+    result = _update(
+      graph_id,
+      test_user.id,
+      test_db,
+      graph_name="Renamed Graph",
+      description="Now with a description",
+      tags=["alpha", "beta"],
+    )
+
+    assert result.graph_name == "Renamed Graph"
+    assert result.description == "Now with a description"
+    assert result.tags == ["alpha", "beta"]
+    assert set(result.updated_fields) == {"graph_name", "description", "tags"}
+
+  def test_persists_across_sessions(self, test_db, test_user, test_user_graph):
+    """The JSONB write must survive a re-read, not just the in-memory object."""
+    from robosystems.models.core.graph import Graph
+
+    graph_id = test_user_graph.graph_id
+    _update(
+      graph_id,
+      test_user.id,
+      test_db,
+      graph_name="Persisted Name",
+      description="Persisted description",
+      tags=["persisted"],
+    )
+
+    test_db.expire_all()
+    reloaded = Graph.get_by_id(graph_id, test_db)
+    assert reloaded is not None
+    assert reloaded.graph_name == "Persisted Name"
+    assert reloaded.graph_metadata["description"] == "Persisted description"
+    assert reloaded.graph_metadata["tags"] == ["persisted"]
+
+  def test_partial_update_leaves_other_fields_alone(
+    self, test_db, test_user, test_user_graph
+  ):
+    graph_id = test_user_graph.graph_id
+    _update(
+      graph_id,
+      test_user.id,
+      test_db,
+      graph_name="Original",
+      description="Original description",
+      tags=["keep-me"],
+    )
+
+    result = _update(graph_id, test_user.id, test_db, graph_name="Only The Name")
+
+    assert result.graph_name == "Only The Name"
+    assert result.description == "Original description"
+    assert result.tags == ["keep-me"]
+    assert result.updated_fields == ["graph_name"]
+
+  def test_preserves_unrelated_metadata_keys(self, test_db, test_user, test_user_graph):
+    """`graph_metadata` also carries materialization state — don't clobber it."""
+    from robosystems.models.core.graph import Graph
+
+    graph_id = test_user_graph.graph_id
+    _update(graph_id, test_user.id, test_db, description="A description")
+
+    test_db.expire_all()
+    reloaded = Graph.get_by_id(graph_id, test_db)
+    assert reloaded is not None
+    # Written by the `sample_graph` fixture at creation.
+    assert reloaded.graph_metadata["purpose"] == "testing"
+    assert reloaded.graph_metadata["fixture"] is True
+
+  def test_empty_string_clears_description(self, test_db, test_user, test_user_graph):
+    graph_id = test_user_graph.graph_id
+    _update(graph_id, test_user.id, test_db, description="To be cleared")
+
+    result = _update(graph_id, test_user.id, test_db, description="")
+
+    assert result.description == ""
+    assert result.updated_fields == ["description"]
+
+  def test_empty_list_clears_tags(self, test_db, test_user, test_user_graph):
+    graph_id = test_user_graph.graph_id
+    _update(graph_id, test_user.id, test_db, tags=["doomed"])
+
+    result = _update(graph_id, test_user.id, test_db, tags=[])
+
+    assert result.tags == []
+    assert result.updated_fields == ["tags"]
+
+  def test_tags_replace_rather_than_merge(self, test_db, test_user, test_user_graph):
+    graph_id = test_user_graph.graph_id
+    _update(graph_id, test_user.id, test_db, tags=["old-one", "old-two"])
+
+    result = _update(graph_id, test_user.id, test_db, tags=["new-only"])
+
+    assert result.tags == ["new-only"]
+
+  def test_resubmitting_identical_values_is_a_noop(
+    self, test_db, test_user, test_user_graph
+  ):
+    graph_id = test_user_graph.graph_id
+    _update(
+      graph_id,
+      test_user.id,
+      test_db,
+      graph_name="Stable",
+      description="Stable description",
+      tags=["stable"],
+    )
+
+    result = _update(
+      graph_id,
+      test_user.id,
+      test_db,
+      graph_name="Stable",
+      description="Stable description",
+      tags=["stable"],
+    )
+
+    assert result.updated_fields == []
+    assert result.graph_name == "Stable"
+    assert result.description == "Stable description"
+    assert result.tags == ["stable"]
+
+  def test_reports_only_the_fields_that_changed(
+    self, test_db, test_user, test_user_graph
+  ):
+    graph_id = test_user_graph.graph_id
+    _update(graph_id, test_user.id, test_db, graph_name="Same", description="Different")
+
+    result = _update(
+      graph_id, test_user.id, test_db, graph_name="Same", description="Changed"
+    )
+
+    assert result.updated_fields == ["description"]
+
+
+class TestUpdateGraphMetadataGuards:
+  @pytest.mark.parametrize("graph_id", ["sec", "sec_historical"])
+  def test_rejects_shared_repository(self, test_db, test_user, graph_id: str):
+    with pytest.raises(HTTPException) as exc:
+      _update(graph_id, test_user.id, test_db, graph_name="Hijacked")
+
+    assert exc.value.status_code == 403
+    assert "platform-managed" in exc.value.detail
+
+  def test_unknown_graph_is_404(self, test_db, test_user):
+    with pytest.raises(HTTPException) as exc:
+      _update("kgdoesnotexist0000000", test_user.id, test_db, graph_name="Ghost")
+
+    assert exc.value.status_code == 404
+
+  def test_non_member_is_403(self, test_db, test_user_graph):
+    with pytest.raises(HTTPException) as exc:
+      _update(
+        test_user_graph.graph_id, "test-user-outsider", test_db, graph_name="Nope"
+      )
+
+    assert exc.value.status_code == 403
+    assert "Admin access" in exc.value.detail
+
+  def test_member_role_is_not_enough(self, test_db, test_user_graph):
+    """Editing graph configuration is admin-only; `member` can write data."""
+    import uuid
+
+    from robosystems.models.core import GraphUser, User
+
+    unique_id = str(uuid.uuid4())[:8]
+    member = User(
+      id=f"test-member-{unique_id}",
+      email=f"member+{unique_id}@example.com",
+      name="Member User",
+      password_hash="x",
+    )
+    test_db.add(member)
+    test_db.flush()
+    GraphUser.create(
+      user_id=member.id,
+      graph_id=test_user_graph.graph_id,
+      role="member",
+      is_selected=False,
+      session=test_db,
+    )
+
+    with pytest.raises(HTTPException) as exc:
+      _update(test_user_graph.graph_id, member.id, test_db, graph_name="Nope")
+
+    assert exc.value.status_code == 403
+    assert "Admin access" in exc.value.detail

--- a/tests/operations/graph/commands/test_metadata.py
+++ b/tests/operations/graph/commands/test_metadata.py
@@ -165,6 +165,81 @@ class TestUpdateGraphMetadata:
     assert result.updated_fields == ["description"]
 
 
+class TestMalformedStoredMetadata:
+  """`graph_metadata` is free-form JSONB — nothing stops a row holding a
+  non-string description or a tag list with junk in it. Those must read as
+  unset rather than reach a response model, where they would fail validation
+  for the whole response."""
+
+  def test_non_string_description_reads_as_empty(
+    self, test_db, test_user, test_user_graph
+  ):
+    from robosystems.models.core.graph import Graph
+
+    graph = Graph.get_by_id(test_user_graph.graph_id, test_db)
+    assert graph is not None
+    graph.graph_metadata = {**(graph.graph_metadata or {}), "description": 42}
+    test_db.commit()
+
+    result = _update(
+      test_user_graph.graph_id, test_user.id, test_db, graph_name="Renamed"
+    )
+
+    assert result.description == ""
+
+  def test_non_list_tags_read_as_empty(self, test_db, test_user, test_user_graph):
+    from robosystems.models.core.graph import Graph
+
+    graph = Graph.get_by_id(test_user_graph.graph_id, test_db)
+    assert graph is not None
+    graph.graph_metadata = {**(graph.graph_metadata or {}), "tags": "not-a-list"}
+    test_db.commit()
+
+    result = _update(
+      test_user_graph.graph_id, test_user.id, test_db, graph_name="Renamed"
+    )
+
+    assert result.tags == []
+
+  def test_non_string_tag_entries_are_dropped(
+    self, test_db, test_user, test_user_graph
+  ):
+    from robosystems.models.core.graph import Graph
+
+    graph = Graph.get_by_id(test_user_graph.graph_id, test_db)
+    assert graph is not None
+    graph.graph_metadata = {
+      **(graph.graph_metadata or {}),
+      "tags": ["keep", 7, None, "also-keep"],
+    }
+    test_db.commit()
+
+    result = _update(
+      test_user_graph.graph_id, test_user.id, test_db, graph_name="Renamed"
+    )
+
+    assert result.tags == ["keep", "also-keep"]
+
+  def test_malformed_value_is_overwritten_not_treated_as_equal(
+    self, test_db, test_user, test_user_graph
+  ):
+    """A malformed stored value reads as unset, so submitting a real one is a
+    change — not a no-op that leaves the junk in place."""
+    from robosystems.models.core.graph import Graph
+
+    graph = Graph.get_by_id(test_user_graph.graph_id, test_db)
+    assert graph is not None
+    graph.graph_metadata = {**(graph.graph_metadata or {}), "description": 42}
+    test_db.commit()
+
+    result = _update(
+      test_user_graph.graph_id, test_user.id, test_db, description="A real one"
+    )
+
+    assert result.updated_fields == ["description"]
+    assert result.description == "A real one"
+
+
 class TestUpdateGraphMetadataGuards:
   @pytest.mark.parametrize("graph_id", ["sec", "sec_historical"])
   def test_rejects_shared_repository(self, test_db, test_user, graph_id: str):

--- a/tests/routers/graphs/test_update_graph_metadata_op.py
+++ b/tests/routers/graphs/test_update_graph_metadata_op.py
@@ -1,0 +1,192 @@
+"""Tests for the update-graph-metadata operation handler and its body model.
+
+The command's own behaviour is covered in
+`tests/operations/graph/commands/test_metadata.py`; this file covers the
+request-model normalization and the router's envelope contract.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+from pydantic import ValidationError
+
+from robosystems.models.api.graphs.operations import (
+  GraphMetadataResult,
+  UpdateGraphMetadataOp,
+)
+from robosystems.routers.graphs.operations import update_graph_metadata_op
+
+_CMD = "robosystems.operations.graph.commands.metadata.update_graph_metadata_cmd"
+
+
+class _FakeCache:
+  """In-memory idempotency cache matching the real signature."""
+
+  def __init__(self) -> None:
+    self.store: dict = {}
+
+  async def get(
+    self, user_id, graph_id, operation_name, idempotency_key, body_fingerprint
+  ):
+    return self.store.get((user_id, graph_id, operation_name, idempotency_key))
+
+  async def put(
+    self,
+    user_id,
+    graph_id,
+    operation_name,
+    idempotency_key,
+    envelope,
+    body_fingerprint,
+    ttl_seconds=86400,
+  ):
+    self.store[(user_id, graph_id, operation_name, idempotency_key)] = envelope
+
+
+def _user() -> MagicMock:
+  u = MagicMock()
+  u.id = "usr_test"
+  return u
+
+
+def _result(**overrides) -> GraphMetadataResult:
+  defaults = {
+    "graph_id": "kg1a2b3c4d5",
+    "graph_name": "Renamed",
+    "description": "",
+    "tags": [],
+    "updated_fields": ["graph_name"],
+  }
+  return GraphMetadataResult(**{**defaults, **overrides})
+
+
+class TestUpdateGraphMetadataOpModel:
+  def test_all_fields_optional(self):
+    body = UpdateGraphMetadataOp()
+    assert body.graph_name is None
+    assert body.description is None
+    assert body.tags is None
+
+  def test_strips_surrounding_whitespace_from_name(self):
+    assert UpdateGraphMetadataOp(graph_name="  Acme  ").graph_name == "Acme"
+
+  def test_rejects_whitespace_only_name(self):
+    with pytest.raises(ValidationError):
+      UpdateGraphMetadataOp(graph_name="   ")
+
+  def test_rejects_empty_name(self):
+    with pytest.raises(ValidationError):
+      UpdateGraphMetadataOp(graph_name="")
+
+  def test_rejects_overlong_name(self):
+    with pytest.raises(ValidationError):
+      UpdateGraphMetadataOp(graph_name="x" * 256)
+
+  def test_rejects_overlong_description(self):
+    with pytest.raises(ValidationError):
+      UpdateGraphMetadataOp(description="x" * 1001)
+
+  def test_empty_description_is_allowed_as_a_clear(self):
+    assert UpdateGraphMetadataOp(description="").description == ""
+
+  def test_tags_are_trimmed_deduped_and_emptied_out(self):
+    body = UpdateGraphMetadataOp(tags=["  alpha ", "alpha", "", "   ", "beta"])
+    assert body.tags == ["alpha", "beta"]
+
+  def test_empty_tag_list_is_allowed_as_a_clear(self):
+    assert UpdateGraphMetadataOp(tags=[]).tags == []
+
+  def test_rejects_overlong_tag(self):
+    with pytest.raises(ValidationError):
+      UpdateGraphMetadataOp(tags=["x" * 51])
+
+  def test_rejects_too_many_tags(self):
+    with pytest.raises(ValidationError):
+      UpdateGraphMetadataOp(tags=[f"tag{i}" for i in range(21)])
+
+
+class TestUpdateGraphMetadataOpHandler:
+  @pytest.mark.asyncio
+  async def test_empty_body_is_400(self):
+    with pytest.raises(HTTPException) as exc:
+      await update_graph_metadata_op(
+        body=UpdateGraphMetadataOp(),
+        graph_id="kg1a2b3c4d5",
+        user=_user(),
+        idempotency_key=None,
+        cache=_FakeCache(),
+        db=MagicMock(),
+      )
+    assert exc.value.status_code == 400
+    assert "No fields provided" in exc.value.detail
+
+  @pytest.mark.asyncio
+  async def test_returns_completed_envelope_carrying_the_result(self):
+    """`wrap_completed` dumps the model, so `result` is a dict at this layer;
+    `response_model=OperationEnvelope[GraphMetadataResult]` types it on the
+    wire."""
+    with patch(_CMD, return_value=_result()) as cmd:
+      envelope = await update_graph_metadata_op(
+        body=UpdateGraphMetadataOp(graph_name="Renamed"),
+        graph_id="kg1a2b3c4d5",
+        user=_user(),
+        idempotency_key=None,
+        cache=_FakeCache(),
+        db=MagicMock(),
+      )
+
+    assert envelope.operation == "update-graph-metadata"
+    assert envelope.status == "completed"
+    assert envelope.created_by == "usr_test"
+    assert envelope.operation_id.startswith("op_")
+    assert envelope.result["graph_name"] == "Renamed"
+    assert envelope.result["updated_fields"] == ["graph_name"]
+    cmd.assert_called_once()
+
+  @pytest.mark.asyncio
+  async def test_forwards_only_supplied_fields_to_the_command(self):
+    with patch(_CMD, return_value=_result()) as cmd:
+      await update_graph_metadata_op(
+        body=UpdateGraphMetadataOp(description="just this"),
+        graph_id="kg1a2b3c4d5",
+        user=_user(),
+        idempotency_key=None,
+        cache=_FakeCache(),
+        db=MagicMock(),
+      )
+
+    kwargs = cmd.call_args.kwargs
+    assert kwargs["graph_name"] is None
+    assert kwargs["description"] == "just this"
+    assert kwargs["tags"] is None
+    assert kwargs["user_id"] == "usr_test"
+
+  @pytest.mark.asyncio
+  async def test_idempotency_key_replays_without_rerunning_the_command(self):
+    cache = _FakeCache()
+    body = UpdateGraphMetadataOp(graph_name="Renamed")
+
+    with patch(_CMD, return_value=_result()) as cmd:
+      first = await update_graph_metadata_op(
+        body=body,
+        graph_id="kg1a2b3c4d5",
+        user=_user(),
+        idempotency_key="key-123",
+        cache=cache,
+        db=MagicMock(),
+      )
+      second = await update_graph_metadata_op(
+        body=body,
+        graph_id="kg1a2b3c4d5",
+        user=_user(),
+        idempotency_key="key-123",
+        cache=cache,
+        db=MagicMock(),
+      )
+
+    assert cmd.call_count == 1
+    assert second.operation_id == first.operation_id
+    assert second.idempotent_replay is True

--- a/tests/routers/user/test_user_profile.py
+++ b/tests/routers/user/test_user_profile.py
@@ -274,6 +274,8 @@ class TestUserGraphs:
     # Create mock Graph objects for each UserGraph
     mock_graph1 = Mock()
     mock_graph1.graph_name = "Test Graph 1"
+    mock_graph1.description = "First test graph"
+    mock_graph1.tags = ["alpha"]
     mock_graph1.graph_tier = "ladybug-standard"
     mock_graph1.graph_type = "entity"
     mock_graph1.schema_extensions = []
@@ -283,6 +285,8 @@ class TestUserGraphs:
 
     mock_graph2 = Mock()
     mock_graph2.graph_name = "Test Graph 2"
+    mock_graph2.description = ""
+    mock_graph2.tags = []
     mock_graph2.graph_tier = "ladybug-standard"
     mock_graph2.graph_type = "entity"
     mock_graph2.schema_extensions = []
@@ -292,6 +296,8 @@ class TestUserGraphs:
 
     mock_graph3 = Mock()
     mock_graph3.graph_name = "Test Graph 3"
+    mock_graph3.description = ""
+    mock_graph3.tags = []
     mock_graph3.graph_tier = "ladybug-standard"
     mock_graph3.graph_type = "entity"
     mock_graph3.schema_extensions = []


### PR DESCRIPTION
## Summary

A graph's display name was write-once. `Graph.graph_name` was set by `GraphCreationService` at provisioning and there was no path to change it afterwards — no REST update, no operation, no admin route, no admin CLI command, and no mutator on the model.

`description` and `tags` were worse than immutable: `CreateGraphRequest.metadata` accepted them, `GraphCreationService` persisted them into the `graph_metadata` JSONB blob, and nothing ever read them back. The only consumers of that column read the materialization status keys. A customer could set a description at creation and it was unreachable forever.

This adds the missing write path and closes the read gap.

## Changes

- **New operation** `POST /v1/graphs/{graph_id}/operations/update-graph-metadata`, on the existing CQRS command surface alongside `change-tier` and `materialize`, so it inherits `OperationEnvelope`, `Idempotency-Key` and operation audit rather than reimplementing them. Typed as `OperationEnvelope[GraphMetadataResult]` so the shape reaches the SDKs.
- **`operations/graph/commands/metadata.py`** — the command. Worth a look: it reassigns `graph_metadata` rather than mutating the dict in place. SQLAlchemy does not track mutations inside a plain JSONB dict, so an in-place edit would be silently dropped at flush. There is a test pinning that specifically.
- **Partial-update semantics** match `update-entity`: `null` leaves a field alone, `""` clears the description, `[]` clears the tags. `graph_name` cannot be cleared — it is NOT NULL and is the label everywhere a graph is listed. The result reports `updated_fields` so a caller can distinguish a real change from a no-op resubmit.
- **Authorization** is admin on the graph, not the member write-role the data-write surfaces use — this is graph configuration, not graph content. `GraphUser.user_has_admin_access` resolves a subgraph to its parent and honours the implicit admin an org OWNER/ADMIN holds. Shared repositories are refused outright: their labels are shown to every subscriber, so one tenant must not be able to relabel them for everyone.
- **Read path** — `GraphInfo` now carries `description` and `tags`, populated in all three branches of the graph list (explicit grants, implicit org-owned, repositories). This is what makes the write observable at all.
- **Docs** — the operation is listed in the `CLAUDE.md` CQRS table and in `static/description.md`, which renders as the API description in Swagger. (Pre-existing and left alone: `delete-graph` is missing from both lists.)

## Breaking Changes

None. Purely additive to the public surface: one new operation, two new optional fields on `GraphInfo`. Both SDKs were regenerated and the emitted diffs verified additive — no removals, renames, or narrowed types — and shipped as the 1.5.0 minor under their post-1.0 contracts.

**Merge order:** both clients are already published at 1.5.0 with an `updateGraphMetadata` method pointing at this route, so this needs to merge and deploy ahead of them being usable. `RoboFinSystems/robosystems-app#293` consumes it and should not deploy until this is live in prod.

## Testing

`just test-code` clean (ruff check, ruff format, basedpyright 0 errors); pre-commit hooks green on both commits. Full `just test-all` deferred to CI.

29 new tests: 14 against the command using the real test database rather than mocks — the JSONB-tracking failure mode only reproduces against a real session — covering persistence across a re-read, partial updates, clearing, tag replacement, no-op resubmit, preservation of unrelated `graph_metadata` keys, and the 404 / shared-repo / non-member / member-role-insufficient guards. 15 against the request model and handler, covering name trimming, tag normalization, the empty-body 400, the envelope contract and idempotent replay.

Also exercised end-to-end against a local stack: empty body → 400; full update → 200 with tags normalized (`["  demo ", "demo", "sandbox"]` → `["demo", "sandbox"]`); partial update leaving siblings intact; identical resubmit returning `updated_fields: []`; an `Idempotency-Key` replaying the same `operationId` with `idempotentReplay: true`; blank name → 422; and the values reading back through `GET /v1/graphs`.