### PR TITLE
fix(worker): give the tier migration a timeout that covers its own waits

### DIFF
--- a/robosystems/worker/constants.py
+++ b/robosystems/worker/constants.py
@@ -5,7 +5,18 @@ Used by both the consumer loop and the Dagster reaper sensor.
 
 # Per-task-type timeouts in seconds. Keys must match the ``task_type`` the
 # enqueuer sends; an unrecognized key silently falls back to
-# ``DEFAULT_TASK_TIMEOUT``. The "operator" budget matches the operator's own
+# ``DEFAULT_TASK_TIMEOUT``, which is how a task whose own internal waits far
+# exceed two minutes can be killed mid-flight without anything saying so.
+#
+# This mapping must stay in exact correspondence with ``TASK_REGISTRY`` —
+# every registered task type has an entry here, and every entry here names a
+# registered task type. ``tests/worker/test_task_timeout_coverage.py`` asserts
+# both directions. The second direction is not pedantry: a task-type rename
+# leaves a dead key here *and* a registered task silently on the default, and
+# checking only for missing keys catches half of it. The "agent" -> "operator"
+# rename is the recorded precedent.
+#
+# The "operator" budget matches the operator's own
 # ``ExecutionProfile.max_time=600`` so the worker doesn't kill jobs the
 # operator thinks are still in budget — the MappingOperator makes one AI call
 # per CoA element during rs-gaap refinement, so a 100-element CoA at ~3-4s per
@@ -15,11 +26,14 @@ TASK_TIMEOUTS: dict[str, int] = {
   "extensions_materialize": 1800,  # 30 minutes
   "graph_creation": 60,  # 1 minute
   "subgraph_creation": 60,  # 1 minute
-  "repository_provisioning": 60,  # 1 minute
   "graph_materialization": 120,  # 2 minutes
   "dagster_job_monitor": 3600,  # 1 hour (backup/restore can be long)
-  "file_staging": 60,  # 1 minute
-  "document_indexing": 120,  # 2 minutes
+  # Drain (120s) + reattach (300s) are awaited before health verification even
+  # starts, so anything under 420s kills the migration around the volume
+  # detach — with the graph's volume unattached and its subscription left
+  # mid-flight. 900 covers those waits plus snapshot, ASG capacity, and
+  # verification, with headroom.
+  "graph_tier_upgrade": 900,  # 15 minutes
 }
 DEFAULT_TASK_TIMEOUT = 120  # 2 minutes
 

--- a/tests/worker/test_task_timeout_coverage.py
+++ b/tests/worker/test_task_timeout_coverage.py
@@ -1,0 +1,86 @@
+"""Structural coverage of TASK_TIMEOUTS against the worker task registry.
+
+A task type with no ``TASK_TIMEOUTS`` entry silently inherits
+``DEFAULT_TASK_TIMEOUT``. For a task whose own internal waits exceed that
+budget the worker kills it mid-flight, and nothing in the code, the logs, or
+the type checker says so — the only symptom is a task that always dies at the
+same elapsed time.
+
+These tests are the fix for that class of bug; the individual constants are
+the symptom. They deliberately assert *both* directions of the correspondence,
+because a task-type rename produces a dead key and a missing key at the same
+time, and checking only for missing keys catches half of it.
+"""
+
+import pytest
+
+from robosystems.worker.constants import DEFAULT_TASK_TIMEOUT, TASK_TIMEOUTS
+
+
+@pytest.fixture(scope="module")
+def registered_task_types() -> set[str]:
+  """Task types registered by importing the worker package.
+
+  Importing ``robosystems.worker`` runs the side-effect imports that trigger
+  every ``@register_task`` decorator, which is the same thing the worker
+  process does at startup.
+  """
+  import robosystems.worker  # noqa: F401  (imported for registration side effects)
+  from robosystems.worker.tasks import TASK_REGISTRY
+
+  return set(TASK_REGISTRY)
+
+
+@pytest.mark.unit
+def test_every_registered_task_has_an_explicit_timeout(
+  registered_task_types: set[str],
+) -> None:
+  missing = registered_task_types - set(TASK_TIMEOUTS)
+  assert not missing, (
+    f"Task types registered with no TASK_TIMEOUTS entry: {sorted(missing)}. "
+    f"They silently run on DEFAULT_TASK_TIMEOUT ({DEFAULT_TASK_TIMEOUT}s). Add an "
+    "entry in robosystems/worker/constants.py sized to the task's own internal "
+    "waits, not to how long it usually takes."
+  )
+
+
+@pytest.mark.unit
+def test_every_timeout_entry_names_a_registered_task(
+  registered_task_types: set[str],
+) -> None:
+  orphaned = set(TASK_TIMEOUTS) - registered_task_types
+  assert not orphaned, (
+    f"TASK_TIMEOUTS entries with no registered task type: {sorted(orphaned)}. "
+    "Either the task type was renamed (in which case a registered task is now "
+    "silently on the default — fix both sides) or the task is gone and the key "
+    "should be deleted. A task loaded behind a feature flag must be imported by "
+    "the registered_task_types fixture for this assertion to stay meaningful."
+  )
+
+
+@pytest.mark.unit
+def test_timeouts_are_positive_ints() -> None:
+  for task_type, timeout in TASK_TIMEOUTS.items():
+    assert isinstance(timeout, int), f"{task_type} timeout must be an int"
+    assert timeout > 0, f"{task_type} timeout must be positive"
+
+
+@pytest.mark.unit
+def test_tier_upgrade_budget_covers_its_internal_waits() -> None:
+  """The tier migration awaits drain + reattach before it verifies anything.
+
+  Pinned against the task's own constants so that raising either wait without
+  raising the worker budget fails here rather than in production, where the
+  symptom is a graph left with an unattached volume.
+  """
+  from robosystems.operations.graph.tasks.graph_tier_upgrade import (
+    DRAIN_TIMEOUT_SECONDS,
+    REATTACH_TIMEOUT_SECONDS,
+  )
+
+  internal_waits = DRAIN_TIMEOUT_SECONDS + REATTACH_TIMEOUT_SECONDS
+  assert TASK_TIMEOUTS["graph_tier_upgrade"] > internal_waits, (
+    f"graph_tier_upgrade budget ({TASK_TIMEOUTS['graph_tier_upgrade']}s) must exceed "
+    f"its own drain + reattach waits ({internal_waits}s) with headroom for the "
+    "snapshot, ASG capacity change, and health verification that follow them."
+  )


### PR DESCRIPTION
## Summary

`graph_tier_upgrade` was registered as a worker task with no `TASK_TIMEOUTS` entry, so it ran on `DEFAULT_TASK_TIMEOUT` (120s) against 420s of its own internal waits (`DRAIN_TIMEOUT_SECONDS` 120 + `REATTACH_TIMEOUT_SECONDS` 300) before health verification even begins. The worker killed the migration around the volume-detach step, and the task's `_rollback` — a method on the task — died with it.

The constant is the symptom. The missing invariant is that `TASK_TIMEOUTS` and `TASK_REGISTRY` must stay in exact correspondence, which nothing asserted.

## Changes

- **`robosystems/worker/constants.py`**
  - Added `"graph_tier_upgrade": 900` — the drain + reattach waits plus headroom for the snapshot, ASG capacity change, and health verification that follow them.
  - Removed three entries that name no registered task type: `document_indexing`, `file_staging`, `repository_provisioning`. Nothing enqueues any of them (repository provisioning runs inline via `run_user_repository_provisioning`, not through the worker queue).
  - Expanded the module comment to state the correspondence invariant and point at the test.

- **`tests/worker/test_task_timeout_coverage.py`** (new) — the actual fix:
  - Every type in `TASK_REGISTRY` has a `TASK_TIMEOUTS` entry.
  - Every `TASK_TIMEOUTS` entry names a registered type. Both directions are asserted deliberately: a task-type rename produces a dead key *and* a silently defaulted task simultaneously, so checking only for missing keys catches half of it. The `agent` → `operator` rename is the recorded precedent for exactly that.
  - `graph_tier_upgrade`'s budget is pinned against the task's own `DRAIN_TIMEOUT_SECONDS + REATTACH_TIMEOUT_SECONDS`, so raising either wait without raising the worker budget fails in CI rather than in production.

Reviewers: the registry is populated by importing `robosystems.worker`, the same side-effect imports the worker process runs at startup. A future task loaded behind a feature flag needs importing in the `registered_task_types` fixture for the second assertion to stay meaningful — noted in the test.

## Breaking Changes

None. No API surface, no request/response shapes, no GraphQL schema — no SDK impact.

## Testing

- `uv run pytest tests/worker/` — 42 passed.
- Both new assertions verified to actually fail when the mapping is regressed (removed the new key → direction 1 fails; re-added an orphan key → direction 2 fails), rather than passing vacuously.
- `just test-code` — ruff, format, basedpyright, cf-lint all clean.
- Full `just test` not run in-session.
