### PR TITLE
fix(billing): make resource provisioning idempotent at the sink

### DIFF
--- a/robosystems/dagster/README.md
+++ b/robosystems/dagster/README.md
@@ -69,6 +69,7 @@ The instance-monitoring schedules are auto-enabled in staging and production onl
 | `materialize_graph_job` | `stale_graph_materialization_sensor` | Rebuild a graph marked stale |
 | `suspend_expired_graphs_job` | `expired_graph_subscription_sensor` | Move graphs with expired subscriptions to suspended |
 | `deprovision_suspended_graphs_job` | `suspended_graph_deprovisioning_sensor` | Deprovision after the retention window |
+| `reap_stalled_provisioning_job` | `stalled_provisioning_sensor` | Write off subscriptions stuck mid-provisioning so their infrastructure is reclaimed |
 | `invoice_subscription_renewal_job` | `invoice_subscription_renewal_sensor` | Rotate billing periods and generate invoices for invoice-billed subscriptions |
 | `send_email_job` | API | Email notifications |
 | `shared_master_wake_job`, `shared_master_sleep_job`, `shared_replicas_refresh_job`, `shared_repository_refresh_replicas_job` | Schedule / sensor / manual | Shared repository master lifecycle and replica refresh |
@@ -82,6 +83,7 @@ The instance-monitoring schedules are auto-enabled in staging and production onl
 | `stale_graph_materialization_sensor` | Graphs marked stale; batches writes within a window to avoid excessive rebuilds |
 | `expired_graph_subscription_sensor` | Graphs whose subscription lapsed |
 | `suspended_graph_deprovisioning_sensor` | Suspended graphs past their retention window |
+| `stalled_provisioning_sensor` | Subscriptions left in `provisioning` past the staleness window — the state no other sensor looks at |
 | `invoice_subscription_renewal_sensor` | Invoice-billed subscriptions whose period ended |
 | `graph_usage_monitor_sensor` | Storage usage against tier limits (email alerts at 80% and 100%) |
 | `worker_inflight_reaper_sensor` | Stale `worker:inflight:*` keys in Valkey DB 6 — runs in the always-on daemon, so no cold start |

--- a/robosystems/dagster/definitions.py
+++ b/robosystems/dagster/definitions.py
@@ -52,6 +52,7 @@ from robosystems.dagster.jobs.graph import (
 )
 from robosystems.dagster.jobs.graph_lifecycle import (
   deprovision_suspended_graphs_job,
+  reap_stalled_provisioning_job,
   suspend_expired_graphs_job,
 )
 from robosystems.dagster.jobs.infrastructure import (
@@ -98,6 +99,7 @@ from robosystems.dagster.resources import (
 )
 from robosystems.dagster.sensors.graph_lifecycle import (
   expired_graph_subscription_sensor,
+  stalled_provisioning_sensor,
   suspended_graph_deprovisioning_sensor,
 )
 from robosystems.dagster.sensors.invoice_billing import (
@@ -225,6 +227,7 @@ all_jobs = [
   # Platform: Graph lifecycle
   suspend_expired_graphs_job,
   deprovision_suspended_graphs_job,
+  reap_stalled_provisioning_job,
   # Platform: Shared repository
   shared_master_wake_job,
   shared_master_sleep_job,
@@ -268,6 +271,7 @@ all_sensors = [
   # Platform: Graph lifecycle
   expired_graph_subscription_sensor,
   suspended_graph_deprovisioning_sensor,
+  stalled_provisioning_sensor,
   # Platform: Materialization (auto-rematerialize stale graphs)
   stale_graph_materialization_sensor,
   # Platform: Usage monitoring

--- a/robosystems/dagster/jobs/billing.py
+++ b/robosystems/dagster/jobs/billing.py
@@ -102,14 +102,17 @@ async def _handle_checkout_completed(
         }
       subscription.provider_subscription_id = stripe_subscription_id
 
-    subscription.status = "provisioning"
     subscription.provider_customer_id = customer_id
 
     db_session.commit()
 
     context.log.info(f"Payment collected for org {customer.org_id}")
 
-    # Trigger provisioning via sensor (set status to provisioning)
+    # Deliberately does NOT set "provisioning" here. The status transition is
+    # the provisioning claim, and it belongs to the sink so that every trigger
+    # contends for it on the same terms — setting it up front would hand this
+    # caller the claim before the sink could arbitrate, and would also stamp
+    # "provisioning" onto an already-active subscription.
     await _trigger_resource_provisioning(subscription, db_session, context)
 
   else:
@@ -809,6 +812,60 @@ async def _handle_setup_intent_succeeded(
     context.log.info(f"Customer {customer.org_id} already has payment method on file")
 
 
+def _merge_subscription_metadata(
+  subscription: Any, updates: dict, db_session: Any
+) -> None:
+  """Merge keys into ``subscription_metadata`` so SQLAlchemy sees the change.
+
+  The column is JSONB and mutating the dict in place is invisible to the unit
+  of work, so every write has to rebind the attribute to a new dict.
+  """
+  subscription.subscription_metadata = {
+    **(subscription.subscription_metadata or {}),
+    **updates,
+  }
+  db_session.commit()
+
+
+def _fail_subscription(subscription: Any, error: str, db_session: Any) -> None:
+  """Mark a subscription failed with a reason an operator can read.
+
+  ``failed`` is terminal, so this is only for conditions no retry can fix.
+  ``ends_at`` starts the retention clock the lifecycle sensors measure, which
+  is what lets any infrastructure the attempt created get reclaimed instead of
+  running unbilled forever.
+  """
+  now = datetime.now(UTC)
+  subscription.status = "failed"
+  subscription.subscription_metadata = {
+    **(subscription.subscription_metadata or {}),
+    "error": error,
+    "failed_at": now.isoformat(),
+  }
+  if subscription.ends_at is None:
+    subscription.ends_at = now
+  db_session.commit()
+
+
+def _record_provisioning_error(
+  subscription: Any, error: Exception, db_session: Any
+) -> None:
+  """Record why a provisioning attempt failed, leaving the row retryable.
+
+  Deliberately does not mark the subscription failed. The customer has paid,
+  the provider will redeliver, and the claim's staleness window will let that
+  redelivery through — writing a terminal status on the first failure would
+  throw away both. A row that never succeeds is written off by the stalled
+  provisioning reaper instead, which is the one place that decision is made.
+  """
+  subscription.subscription_metadata = {
+    **(subscription.subscription_metadata or {}),
+    "last_provisioning_error": str(error),
+    "last_provisioning_error_at": datetime.now(UTC).isoformat(),
+  }
+  db_session.commit()
+
+
 async def _trigger_resource_provisioning(
   subscription: Any, db_session: Any, context: OpExecutionContext
 ) -> None:
@@ -816,11 +873,24 @@ async def _trigger_resource_provisioning(
 
   Directly provisions the resource, eliminating sensor polling delay and
   ECS cold start.
+
+  More than one provider event legitimately reaches this function for the same
+  subscription, and provider redelivery can re-enter it with an event that was
+  never marked processed because the first attempt did not finish. Both are
+  arbitrated by ``claim_for_provisioning``, which is the single gate here — a
+  future third trigger inherits it for free.
   """
   from robosystems.models.core import OrgRole, OrgUser
 
   resource_config = subscription.subscription_metadata.get("resource_config", {})
   resource_type = subscription.resource_type
+
+  if not subscription.claim_for_provisioning(db_session):
+    context.log.info(
+      f"Skipping provisioning for subscription {subscription.id}: "
+      "claim held elsewhere or resource already provisioned"
+    )
+    return
 
   # The subscriber column is authoritative; the metadata copy covers rows
   # written before it existed. The org-owner fallback is last resort — with
@@ -837,9 +907,7 @@ async def _trigger_resource_provisioning(
     )
     if not owner:
       context.log.error(f"No owner found for org {subscription.org_id}")
-      subscription.status = "failed"
-      subscription.subscription_metadata["error"] = "No org owner found"
-      db_session.commit()
+      _fail_subscription(subscription, "No org owner found", db_session)
       return
     user_id = owner.user_id
 
@@ -857,11 +925,9 @@ async def _trigger_resource_provisioning(
   )
 
   if resource_type == "graph":
-    if not subscription.subscription_metadata:
-      subscription.subscription_metadata = {}
-    subscription.subscription_metadata.update(resource_config)
-    subscription.status = "provisioning"
-    db_session.commit()
+    # The claim already put the row in "provisioning"; only the config copy
+    # is left to persist.
+    _merge_subscription_metadata(subscription, resource_config, db_session)
 
     tier = subscription.plan_name
 
@@ -879,16 +945,15 @@ async def _trigger_resource_provisioning(
       )
     except Exception as e:
       context.log.error(f"Graph provisioning failed: {e}")
+      _record_provisioning_error(subscription, e, db_session)
       raise
 
   elif resource_type == "repository":
     repository_name = resource_config.get("repository_name")
 
-    if not subscription.subscription_metadata:
-      subscription.subscription_metadata = {}
-    subscription.subscription_metadata["repository_name"] = repository_name
-    subscription.status = "provisioning"
-    db_session.commit()
+    _merge_subscription_metadata(
+      subscription, {"repository_name": repository_name}, db_session
+    )
 
     context.log.info(
       f"Provisioning repository {repository_name} for subscription {subscription.id}"
@@ -906,15 +971,14 @@ async def _trigger_resource_provisioning(
       )
     except Exception as e:
       context.log.error(f"Repository provisioning failed: {e}")
+      _record_provisioning_error(subscription, e, db_session)
       raise
 
   else:
     context.log.error(f"Unknown resource type: {resource_type}")
-    subscription.status = "failed"
-    subscription.subscription_metadata["error"] = (
-      f"Unknown resource type: {resource_type}"
+    _fail_subscription(
+      subscription, f"Unknown resource type: {resource_type}", db_session
     )
-    db_session.commit()
 
 
 # ============================================================================

--- a/robosystems/dagster/jobs/graph_lifecycle.py
+++ b/robosystems/dagster/jobs/graph_lifecycle.py
@@ -128,3 +128,100 @@ def deprovision_suspended_graphs(
 def deprovision_suspended_graphs_job():
   """Deprovision graphs that have been suspended past retention period."""
   deprovision_suspended_graphs()
+
+
+# ============================================================================
+# Stalled provisioning
+# ============================================================================
+
+
+class ReapStalledProvisioningConfig(Config):
+  """Configuration for writing off stalled provisioning attempts."""
+
+  subscription_ids: list[str]
+
+
+@op
+def reap_stalled_provisioning(
+  context: OpExecutionContext,
+  db: DatabaseResource,
+  config: ReapStalledProvisioningConfig,
+) -> dict:
+  """Write off subscriptions stuck mid-provisioning.
+
+  A provisioning attempt that dies — a killed worker, an exception, a provider
+  event that was never redelivered — leaves the row in ``provisioning``, which
+  is not terminal and which neither lifecycle sensor looks at. Nothing else in
+  the system ever revisits that state, so this is the only place it ends.
+
+  Marking the row ``failed`` does two things: it makes the attempt visible to
+  ``admin subscriptions list``, and it puts the row in a state the lifecycle
+  sensors act on, so any graph the attempt managed to create is suspended and
+  then reclaimed on the ordinary retention schedule rather than running
+  unbilled forever. ``failed`` is also terminal, so the customer's route back
+  — a fresh checkout — is already open.
+  """
+  from datetime import UTC, datetime
+
+  from robosystems.models.core.billing.subscription import BillingSubscription
+
+  now = datetime.now(UTC)
+  reaped: list[str] = []
+
+  with db.get_session() as session:
+    for subscription_id in config.subscription_ids:
+      subscription = (
+        session.query(BillingSubscription)
+        .filter(BillingSubscription.id == subscription_id)
+        .first()
+      )
+      if not subscription:
+        context.log.warning(f"Subscription {subscription_id} not found, skipping")
+        continue
+
+      # Re-check under this transaction: the sensor's read and this write are
+      # minutes apart, and a redelivery may have completed in between.
+      if subscription.status != "provisioning":
+        context.log.info(
+          f"Subscription {subscription_id} is now {subscription.status}, skipping"
+        )
+        continue
+
+      subscription.status = "failed"
+      subscription.subscription_metadata = {
+        **(subscription.subscription_metadata or {}),
+        "error": "Provisioning stalled and was written off",
+        "failed_at": now.isoformat(),
+      }
+      if subscription.ends_at is None:
+        subscription.ends_at = now
+      session.commit()
+      subscription._invalidate_access_cache()
+
+      reaped.append(subscription_id)
+      context.log.error(
+        f"Wrote off stalled provisioning for subscription {subscription_id} "
+        f"(org={subscription.org_id}, resource_type={subscription.resource_type}, "
+        f"resource_id={subscription.resource_id}). The customer paid and has no "
+        "working resource — this needs an operator."
+      )
+
+  context.log.info(
+    f"Wrote off {len(reaped)}/{len(config.subscription_ids)} stalled subscriptions"
+  )
+
+  return {
+    "reaped_count": len(reaped),
+    "total_requested": len(config.subscription_ids),
+    "subscription_ids": reaped,
+  }
+
+
+@job(
+  tags={
+    "dagster/priority": "1",
+  }
+)
+def reap_stalled_provisioning_job():
+  """Write off subscriptions stuck mid-provisioning."""
+  reap_stalled_provisioning()

--- a/robosystems/dagster/sensors/graph_lifecycle.py
+++ b/robosystems/dagster/sensors/graph_lifecycle.py
@@ -14,6 +14,7 @@ from dagster import (
 
 from robosystems.dagster.jobs.graph_lifecycle import (
   deprovision_suspended_graphs_job,
+  reap_stalled_provisioning_job,
   suspend_expired_graphs_job,
 )
 from robosystems.logger import get_logger
@@ -32,14 +33,21 @@ def expired_graph_subscription_sensor(context: SensorEvaluationContext):
 
   Query: BillingSubscription where:
   - resource_type = "graph"
-  - status = "canceled"
+  - status IN ("canceled", "failed")
   - ends_at IS NOT NULL AND ends_at < now()
   - Linked graph status = "active" (not already suspended)
+
+  ``failed`` belongs here alongside ``canceled`` for the same reason: both are
+  terminal, so neither is a subscription still in force, and a graph left
+  running under one is infrastructure nobody is paying for.
   """
   from datetime import UTC, datetime
 
   from robosystems.database import session as db_session_factory
-  from robosystems.models.core.billing.subscription import BillingSubscription
+  from robosystems.models.core.billing.subscription import (
+    TERMINAL_SUBSCRIPTION_STATUSES,
+    BillingSubscription,
+  )
   from robosystems.models.core.graph import Graph, GraphStatus
 
   db = db_session_factory()
@@ -52,7 +60,7 @@ def expired_graph_subscription_sensor(context: SensorEvaluationContext):
       .join(Graph, BillingSubscription.resource_id == Graph.graph_id)
       .filter(
         BillingSubscription.resource_type == "graph",
-        BillingSubscription.status == "canceled",
+        BillingSubscription.status.in_(TERMINAL_SUBSCRIPTION_STATUSES),
         BillingSubscription.ends_at.isnot(None),
         BillingSubscription.ends_at < now,
         Graph.status == GraphStatus.ACTIVE.value,
@@ -96,6 +104,7 @@ def suspended_graph_deprovisioning_sensor(context: SensorEvaluationContext):
   Query: Graph where:
   - status = "suspended"
   - deleted_at IS NULL (not already deprovisioned)
+  - BillingSubscription.status IN ("canceled", "failed")
   - BillingSubscription.ends_at < (now - retention_days), OR
   - BillingSubscription.cancellation_type == "immediate" (retention bypassed
     when the user explicitly requested immediate teardown)
@@ -107,6 +116,7 @@ def suspended_graph_deprovisioning_sensor(context: SensorEvaluationContext):
   from robosystems.config.deprovisioning import get_deprovisioning_config
   from robosystems.database import session as db_session_factory
   from robosystems.models.core.billing.subscription import (
+    TERMINAL_SUBSCRIPTION_STATUSES,
     BillingSubscription,
     CancellationType,
   )
@@ -128,7 +138,7 @@ def suspended_graph_deprovisioning_sensor(context: SensorEvaluationContext):
       .join(Graph, BillingSubscription.resource_id == Graph.graph_id)
       .filter(
         BillingSubscription.resource_type == "graph",
-        BillingSubscription.status == "canceled",
+        BillingSubscription.status.in_(TERMINAL_SUBSCRIPTION_STATUSES),
         BillingSubscription.ends_at.isnot(None),
         or_(
           BillingSubscription.ends_at < cutoff,
@@ -156,6 +166,84 @@ def suspended_graph_deprovisioning_sensor(context: SensorEvaluationContext):
           "deprovision_suspended_graphs": {
             "config": {
               "graph_ids": graph_ids,
+            }
+          }
+        }
+      },
+    )
+  finally:
+    db_session_factory.remove()
+
+
+@sensor(
+  job=reap_stalled_provisioning_job,
+  minimum_interval_seconds=300,  # 5 minutes
+  default_status=DefaultSensorStatus.RUNNING,
+  description="Writes off subscriptions stuck mid-provisioning",
+)
+def stalled_provisioning_sensor(context: SensorEvaluationContext):
+  """Find subscriptions stuck in `provisioning` and hand them to the reaper.
+
+  Query: BillingSubscription where:
+  - status = "provisioning"
+  - updated_at < now() - STALE_PROVISIONING_MINUTES
+
+  ``provisioning`` is the state a paid subscription sits in while its resource
+  is being built. Nothing revisits it if the attempt dies, and because it is
+  neither active nor terminal it is invisible to both lifecycle sensors — so a
+  customer who paid can hold a subscription that no process will ever advance
+  or clean up. This sensor is the only thing that ends that state.
+
+  The window is the same constant the provisioning claim uses, so a row this
+  sensor considers dead is exactly a row a redelivery would have been allowed
+  to re-claim. The reaper re-checks status under its own transaction, which
+  covers the case where a retry succeeds between this read and that write.
+
+  Deliberately scoped to `provisioning` only. A stalled `upgrading` row is the
+  same shape of problem with no safe automatic disposition — the graph exists
+  and is serving reads, so writing the subscription off would tear down a
+  paying customer's graph, while forcing it back to active would claim a
+  migration succeeded when its volume may still be detached. That one wants an
+  operator, and the tier task's own timeout is what keeps it rare.
+  """
+  from datetime import UTC, datetime, timedelta
+
+  from robosystems.database import session as db_session_factory
+  from robosystems.models.core.billing.subscription import (
+    STALE_PROVISIONING_MINUTES,
+    BillingSubscription,
+  )
+
+  db = db_session_factory()
+  try:
+    now = datetime.now(UTC)
+    cutoff = now - timedelta(minutes=STALE_PROVISIONING_MINUTES)
+
+    stalled = (
+      db.query(BillingSubscription)
+      .filter(
+        BillingSubscription.status == "provisioning",
+        BillingSubscription.updated_at < cutoff,
+      )
+      .all()
+    )
+
+    if not stalled:
+      return
+
+    subscription_ids = [sub.id for sub in stalled]
+    context.log.warning(
+      f"Found {len(subscription_ids)} subscriptions stalled in provisioning "
+      f"for more than {STALE_PROVISIONING_MINUTES} minutes"
+    )
+
+    yield RunRequest(
+      run_key=f"reap-stalled-{now.strftime('%Y%m%d%H%M')}",
+      run_config={
+        "ops": {
+          "reap_stalled_provisioning": {
+            "config": {
+              "subscription_ids": subscription_ids,
             }
           }
         }

--- a/robosystems/models/core/billing/subscription.py
+++ b/robosystems/models/core/billing/subscription.py
@@ -38,6 +38,12 @@ TERMINAL_SUBSCRIPTION_STATUSES = (
   SubscriptionStatus.FAILED.value,
 )
 
+# How long a subscription may sit in ``provisioning`` before another trigger
+# may re-claim it, and before the reaper writes it off as stalled. Provisioning
+# is a seconds-to-minutes operation; anything still holding the claim past this
+# is not running any more, it just never said so.
+STALE_PROVISIONING_MINUTES = 30
+
 
 class BillingInterval(str, Enum):
   """Billing interval options."""
@@ -314,6 +320,79 @@ class BillingSubscription(Base):
         invalidate_subscription_cache(self.resource_id)
       except Exception as e:
         logger.warning(f"Cache invalidation failed for graph {self.resource_id}: {e}")
+
+  def claim_for_provisioning(
+    self, session: Session, stale_after_minutes: int = STALE_PROVISIONING_MINUTES
+  ) -> bool:
+    """Atomically claim this subscription for a provisioning run.
+
+    Returns True to exactly one caller. Provisioning has more than one
+    trigger — separate provider events, each legitimate on its own — so the
+    guard has to live at the sink rather than at each caller, or adding a
+    trigger later silently re-opens the hole.
+
+    The whole decision is one conditional UPDATE, which makes it a mutex
+    without an advisory lock or a new table:
+
+    * ``resource_id IS NULL`` is the terminal condition. Once a resource
+      exists the subscription is never re-provisioned, whatever its status
+      and however many callers arrive.
+    * ``pending``/``pending_payment`` is the ordinary first entry.
+    * A ``provisioning`` row is re-claimable only once it has gone stale,
+      which is what makes a genuinely dead attempt retryable (a killed
+      worker, a provider redelivery after a timeout) while two concurrent
+      callers still resolve to one winner: the loser re-evaluates the
+      predicate after the winner's row lock clears, sees a freshly stamped
+      row, and matches nothing.
+
+    ``updated_at`` is stamped by the claim itself, so it doubles as the
+    heartbeat the staleness window is measured against.
+    """
+    from sqlalchemy import and_, or_
+
+    now = datetime.now(UTC)
+    stale_cutoff = now - timedelta(minutes=stale_after_minutes)
+
+    claimed = (
+      session.query(BillingSubscription)
+      .filter(
+        BillingSubscription.id == self.id,
+        BillingSubscription.resource_id.is_(None),
+        or_(
+          BillingSubscription.status.in_(
+            (
+              SubscriptionStatus.PENDING.value,
+              SubscriptionStatus.PENDING_PAYMENT.value,
+            )
+          ),
+          and_(
+            BillingSubscription.status == SubscriptionStatus.PROVISIONING.value,
+            BillingSubscription.updated_at < stale_cutoff,
+          ),
+        ),
+      )
+      .update(
+        {
+          BillingSubscription.status: SubscriptionStatus.PROVISIONING.value,
+          BillingSubscription.updated_at: now,
+        },
+        synchronize_session=False,
+      )
+    )
+
+    session.commit()
+    session.refresh(self)
+
+    if claimed:
+      logger.info(f"Claimed subscription {self.id} for provisioning")
+    else:
+      logger.info(
+        f"Provisioning claim refused for subscription {self.id} "
+        f"(status={self.status}, resource_id={self.resource_id}) — "
+        "another trigger already holds it or the resource exists"
+      )
+
+    return bool(claimed)
 
   def activate(self, session: Session) -> None:
     """Activate the subscription."""

--- a/robosystems/operations/graph/provisioning_service.py
+++ b/robosystems/operations/graph/provisioning_service.py
@@ -114,10 +114,18 @@ async def run_graph_provisioning(
       graph_id = creation_result.graph_id
       logger.info(f"Created graph {graph_id} for subscription {subscription_id}")
 
+      # Link the graph before anything else can fail. The lifecycle sensors
+      # join subscriptions to graphs on resource_id, so a graph created here
+      # and orphaned by a later failure would otherwise be unreachable by the
+      # machinery whose whole job is reclaiming it — running, unbilled, and
+      # invisible. Committing the link also makes the claim's terminal
+      # condition true, so no redelivery can create a second graph.
+      subscription.resource_id = graph_id
+      db.commit()
+
       if operation_id:
         await manager.emit_progress(operation_id, "Activating subscription...", 70)
 
-      subscription.resource_id = graph_id
       subscription.activate(db)
 
       BillingAuditLog.log_event(

--- a/tests/dagster/test_billing_webhook_handlers.py
+++ b/tests/dagster/test_billing_webhook_handlers.py
@@ -207,7 +207,7 @@ class TestHandleCheckoutCompleted:
   async def test_happy_path_paid_checkout(
     self, mock_db_session, mock_context, mock_subscription, mock_customer
   ):
-    """Payment collected: updates customer, sets provisioning, triggers provisioning."""
+    """Payment collected: updates customer and hands off to the provisioning sink."""
     session_data = make_checkout_session(
       session_id="cs_session_abc",
       subscription_id="sub_stripe_new",
@@ -231,8 +231,12 @@ class TestHandleCheckoutCompleted:
     assert mock_customer.has_payment_method is True
     assert mock_subscription.stripe_subscription_id == "sub_stripe_new"
     assert mock_subscription.provider_subscription_id == "sub_stripe_new"
-    assert mock_subscription.status == "provisioning"
     assert mock_subscription.provider_customer_id == "cus_stripe_abc"
+    # The status transition belongs to the provisioning claim, not to this
+    # caller. Setting it here would hand this event the claim before the sink
+    # could arbitrate between it and invoice.payment_succeeded, and would also
+    # stamp "provisioning" onto an already-active subscription.
+    assert mock_subscription.status == "pending_payment"
     mock_db_session.commit.assert_called()
     mock_trigger.assert_awaited_once_with(
       mock_subscription, mock_db_session, mock_context
@@ -299,7 +303,7 @@ class TestHandleCheckoutCompleted:
     with (
       patch(PATCH_BILLING_SUB) as MockSub,
       patch(PATCH_BILLING_CUST),
-      patch(PATCH_TRIGGER, new_callable=AsyncMock),
+      patch(PATCH_TRIGGER, new_callable=AsyncMock) as mock_trigger,
     ):
       MockSub.get_by_provider_subscription_id.return_value = None
       # First call is metadata lookup (BillingSubscription.id == ...)
@@ -313,7 +317,12 @@ class TestHandleCheckoutCompleted:
 
       await _handle_checkout_completed(session_data, mock_db_session, mock_context)
 
-    assert mock_subscription.status == "provisioning"
+    # Reaching the provisioning hand-off is what proves the fallback resolved
+    # the subscription; the status itself is the claim's to set, not this
+    # handler's.
+    mock_trigger.assert_awaited_once_with(
+      mock_subscription, mock_db_session, mock_context
+    )
 
   async def test_subscription_not_found_logs_warning_and_returns(
     self, mock_db_session, mock_context
@@ -1806,6 +1815,29 @@ class TestHandleSetupIntentSucceeded:
 # ---------------------------------------------------------------------------
 
 
+def _granting_claim(sub):
+  """Make a mock subscription's provisioning claim behave like the real one.
+
+  The claim is the gate every trigger now passes through, so a mock that
+  returns a bare truthy MagicMock would let these tests pass while telling us
+  nothing about the status the provisioner actually sees. Granting the claim
+  here mirrors the real transition; ``_refusing_claim`` is its counterpart.
+  """
+
+  def claim(_session):
+    sub.status = "provisioning"
+    return True
+
+  sub.claim_for_provisioning = MagicMock(side_effect=claim)
+  return sub
+
+
+def _refusing_claim(sub):
+  """Model a claim held by another trigger, or a resource already built."""
+  sub.claim_for_provisioning = MagicMock(return_value=False)
+  return sub
+
+
 @pytest.mark.unit
 @pytest.mark.asyncio
 class TestTriggerResourceProvisioning:
@@ -1817,10 +1849,11 @@ class TestTriggerResourceProvisioning:
     sub.resource_type = "graph"
     sub.resource_id = "kg_01ABC123"
     sub.plan_name = "ladybug-standard"
+    sub.status = "pending_payment"
     # Legacy row: subscriber recorded only in metadata.
     sub.user_id = None
     sub.subscription_metadata = {"user_id": "user_01ABC123", "resource_config": {}}
-    return sub
+    return _granting_claim(sub)
 
   @pytest.fixture
   def repository_subscription(self):
@@ -1830,12 +1863,89 @@ class TestTriggerResourceProvisioning:
     sub.resource_type = "repository"
     sub.resource_id = None
     sub.plan_name = "starter"
+    sub.status = "pending_payment"
     sub.user_id = None
     sub.subscription_metadata = {
       "user_id": "user_01ABC123",
       "resource_config": {"repository_name": "sec"},
     }
-    return sub
+    return _granting_claim(sub)
+
+  async def test_refused_claim_skips_provisioning_entirely(
+    self, mock_db_session, mock_context, graph_subscription
+  ):
+    """The second trigger for one subscription must do nothing at all.
+
+    This is the whole point of the gate: two provider events reach this
+    function for the same payment, and only the one holding the claim may
+    provision. See ``tests/models/core/billing/test_provisioning_claim.py``
+    for the database-level proof that exactly one caller can hold it.
+    """
+    _refusing_claim(graph_subscription)
+
+    with (
+      patch(PATCH_IAM_ORG_USER),
+      patch(PATCH_IAM_ORG_ROLE),
+      patch(PATCH_RUN_GRAPH, new_callable=AsyncMock) as mock_run_graph,
+      patch(PATCH_RUN_REPO, new_callable=AsyncMock) as mock_run_repo,
+    ):
+      from robosystems.dagster.jobs.billing import _trigger_resource_provisioning
+
+      await _trigger_resource_provisioning(
+        graph_subscription, mock_db_session, mock_context
+      )
+
+    mock_run_graph.assert_not_awaited()
+    mock_run_repo.assert_not_awaited()
+
+  async def test_refused_claim_skips_repository_provisioning(
+    self, mock_db_session, mock_context, repository_subscription
+  ):
+    _refusing_claim(repository_subscription)
+
+    with (
+      patch(PATCH_IAM_ORG_USER),
+      patch(PATCH_IAM_ORG_ROLE),
+      patch(PATCH_RUN_GRAPH, new_callable=AsyncMock) as mock_run_graph,
+      patch(PATCH_RUN_REPO, new_callable=AsyncMock) as mock_run_repo,
+    ):
+      from robosystems.dagster.jobs.billing import _trigger_resource_provisioning
+
+      await _trigger_resource_provisioning(
+        repository_subscription, mock_db_session, mock_context
+      )
+
+    mock_run_graph.assert_not_awaited()
+    mock_run_repo.assert_not_awaited()
+
+  async def test_provisioning_failure_records_error_without_a_terminal_status(
+    self, mock_db_session, mock_context, graph_subscription
+  ):
+    """A failed attempt stays retryable and says why it failed.
+
+    Marking it failed here would discard both the provider's redelivery and
+    the claim's staleness window, stranding a customer who has paid. The
+    stalled-provisioning reaper is the one place that decision is made.
+    """
+    with (
+      patch(PATCH_IAM_ORG_USER),
+      patch(PATCH_IAM_ORG_ROLE),
+      patch(PATCH_RUN_GRAPH, side_effect=RuntimeError("no capacity")),
+      patch(PATCH_RUN_REPO, new_callable=AsyncMock),
+    ):
+      from robosystems.dagster.jobs.billing import _trigger_resource_provisioning
+
+      with pytest.raises(RuntimeError):
+        await _trigger_resource_provisioning(
+          graph_subscription, mock_db_session, mock_context
+        )
+
+    assert graph_subscription.status != "failed"
+    assert (
+      graph_subscription.subscription_metadata["last_provisioning_error"]
+      == "no capacity"
+    )
+    assert "last_provisioning_error_at" in graph_subscription.subscription_metadata
 
   async def test_graph_provisioning_happy_path(
     self, mock_db_session, mock_context, graph_subscription

--- a/tests/dagster/test_graph_lifecycle.py
+++ b/tests/dagster/test_graph_lifecycle.py
@@ -105,3 +105,130 @@ class TestSuspendedGraphDeprovisioningSensor:
         "Expected the deprovision query to still include the ends_at "
         "retention-window clause"
       )
+
+
+class TestStalledProvisioningSensor:
+  """Tests for the stalled_provisioning_sensor.
+
+  `provisioning` is the one subscription state nothing else revisits: it is
+  neither active nor terminal, so both lifecycle sensors skip it, and a
+  customer who paid can sit in it indefinitely. These pin that this sensor is
+  the thing that ends it.
+  """
+
+  def test_finds_stalled_subscriptions(self):
+    from robosystems.dagster.sensors.graph_lifecycle import (
+      stalled_provisioning_sensor,
+    )
+
+    mock_sub = MagicMock()
+    mock_sub.id = "bsub_stalled"
+
+    with patch("robosystems.database.session") as mock_db:
+      mock_session = MagicMock()
+      mock_db.return_value = mock_session
+      mock_session.query.return_value.filter.return_value.all.return_value = [mock_sub]
+
+      context = build_sensor_context()
+      runs = list(stalled_provisioning_sensor(context))
+
+      assert len(runs) == 1
+      config = runs[0].run_config["ops"]["reap_stalled_provisioning"]["config"]
+      assert config["subscription_ids"] == ["bsub_stalled"]
+
+  def test_skips_when_none_stalled(self):
+    from robosystems.dagster.sensors.graph_lifecycle import (
+      stalled_provisioning_sensor,
+    )
+
+    with patch("robosystems.database.session") as mock_db:
+      mock_session = MagicMock()
+      mock_db.return_value = mock_session
+      mock_session.query.return_value.filter.return_value.all.return_value = []
+
+      context = build_sensor_context()
+      assert list(stalled_provisioning_sensor(context)) == []
+
+  def test_session_cleanup(self):
+    from robosystems.dagster.sensors.graph_lifecycle import (
+      stalled_provisioning_sensor,
+    )
+
+    with patch("robosystems.database.session") as mock_db:
+      mock_session = MagicMock()
+      mock_db.return_value = mock_session
+      mock_session.query.return_value.filter.return_value.all.return_value = []
+
+      context = build_sensor_context()
+      list(stalled_provisioning_sensor(context))
+
+      mock_db.remove.assert_called_once()
+
+
+class TestReapStalledProvisioning:
+  """Tests for the reap_stalled_provisioning op."""
+
+  def _run(self, subscription, subscription_ids):
+    from contextlib import contextmanager
+
+    from dagster import build_op_context
+
+    from robosystems.dagster.jobs.graph_lifecycle import (
+      ReapStalledProvisioningConfig,
+      reap_stalled_provisioning,
+    )
+
+    session = MagicMock()
+    session.query.return_value.filter.return_value.first.return_value = subscription
+
+    @contextmanager
+    def get_session():
+      yield session
+
+    db = MagicMock()
+    db.get_session = get_session
+
+    return reap_stalled_provisioning(
+      build_op_context(),
+      db,
+      ReapStalledProvisioningConfig(subscription_ids=subscription_ids),
+    )
+
+  def test_marks_stalled_subscription_failed_and_starts_retention(self):
+    """`failed` + `ends_at` is what makes the lifecycle sensors act on it."""
+    subscription = MagicMock()
+    subscription.id = "bsub_stalled"
+    subscription.status = "provisioning"
+    subscription.ends_at = None
+    subscription.subscription_metadata = {}
+
+    result = self._run(subscription, ["bsub_stalled"])
+
+    assert result["reaped_count"] == 1
+    assert subscription.status == "failed"
+    assert subscription.ends_at is not None
+    assert subscription.subscription_metadata["error"]
+    assert subscription.subscription_metadata["failed_at"]
+
+  def test_skips_a_subscription_that_completed_since_the_sensor_read(self):
+    """The sensor's read and this write are minutes apart.
+
+    A redelivery can succeed in between, and writing the row off then would
+    tear down a graph that is working and paid for.
+    """
+    subscription = MagicMock()
+    subscription.id = "bsub_recovered"
+    subscription.status = "active"
+    subscription.ends_at = None
+
+    result = self._run(subscription, ["bsub_recovered"])
+
+    assert result["reaped_count"] == 0
+    assert subscription.status == "active"
+    assert subscription.ends_at is None
+
+  def test_missing_subscription_is_skipped(self):
+    result = self._run(None, ["bsub_gone"])
+
+    assert result["reaped_count"] == 0
+    assert result["total_requested"] == 1

--- a/tests/models/core/billing/test_provisioning_claim.py
+++ b/tests/models/core/billing/test_provisioning_claim.py
@@ -1,0 +1,287 @@
+"""Tests for the provisioning claim — the idempotency gate at the sink.
+
+Provisioning has more than one legitimate trigger, and a provider can also
+redeliver an event whose first attempt never finished. Both converge on
+``claim_for_provisioning``, which has to hand the work to exactly one caller
+while still letting a genuinely dead attempt be retried.
+
+These run against a real Postgres because the guarantee being tested is a
+database one: the predicate is re-evaluated after the winner's row lock
+clears, and no mock reproduces that. The concurrency case uses real threads on
+independent connections for the same reason — asserting the mutex against a
+mocked session would only assert that the mock was called.
+"""
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy.orm import Session, sessionmaker
+
+from robosystems.models.core import User
+from robosystems.models.core.billing import BillingSubscription, SubscriptionStatus
+from robosystems.models.core.billing.subscription import STALE_PROVISIONING_MINUTES
+
+
+@pytest.fixture
+def test_org_id(db_session: Session) -> str:
+  """Create an org with an owner, and return the org id."""
+  from robosystems.models.core import Org, OrgRole, OrgType, OrgUser
+
+  unique_id = str(uuid.uuid4())[:8]
+
+  org = Org(
+    id=f"claim_org_{unique_id}",
+    name=f"Claim Org {unique_id}",
+    org_type=OrgType.PERSONAL,
+  )
+  db_session.add(org)
+  db_session.flush()
+
+  user = User(
+    id=f"claim_user_{unique_id}",
+    email=f"claim+{unique_id}@example.com",
+    name="Claim Test User",
+    password_hash="test_hash",
+  )
+  db_session.add(user)
+  db_session.flush()
+
+  db_session.add(OrgUser(org_id=org.id, user_id=user.id, role=OrgRole.OWNER))
+  db_session.commit()
+  return org.id
+
+
+def _make_subscription(
+  session: Session,
+  org_id: str,
+  *,
+  status: str = SubscriptionStatus.PENDING_PAYMENT.value,
+  resource_id: str | None = None,
+  updated_at: datetime | None = None,
+) -> BillingSubscription:
+  subscription = BillingSubscription(
+    org_id=org_id,
+    resource_type="graph",
+    resource_id=resource_id,
+    plan_name="ladybug-standard",
+    base_price_cents=9900,
+    status=status,
+    subscription_metadata={},
+  )
+  session.add(subscription)
+  session.commit()
+
+  if updated_at is not None:
+    # onupdate would stamp "now" on an ORM write, so age the row in SQL.
+    session.query(BillingSubscription).filter(
+      BillingSubscription.id == subscription.id
+    ).update({BillingSubscription.updated_at: updated_at}, synchronize_session=False)
+    session.commit()
+    session.refresh(subscription)
+
+  return subscription
+
+
+class TestClaimAdmitsExactlyOneCaller:
+  """The core property: two triggers, one provisioning run."""
+
+  def test_second_sequential_caller_is_refused(
+    self, db_session: Session, test_org_id: str
+  ):
+    """The shape the two provider events actually take in production.
+
+    ``checkout.session.completed`` and ``invoice.payment_succeeded`` arrive
+    close together but usually not simultaneously; the second must find the
+    door shut even though the row it sees is in a status its own caller
+    considers provisionable.
+    """
+    subscription = _make_subscription(db_session, test_org_id)
+
+    assert subscription.claim_for_provisioning(db_session) is True
+    assert subscription.status == SubscriptionStatus.PROVISIONING.value
+
+    assert subscription.claim_for_provisioning(db_session) is False
+
+  def test_concurrent_callers_resolve_to_one_winner(
+    self, db_session: Session, test_org_id: str
+  ):
+    """Two threads on independent connections, one winner.
+
+    This is the case the per-event-id idempotency cannot cover, because the
+    two events are different events. Without the gate both callers pass the
+    status check and both provision.
+    """
+    import threading
+
+    subscription = _make_subscription(db_session, test_org_id)
+    subscription_id = subscription.id
+
+    engine = db_session.get_bind()
+    SessionFactory = sessionmaker(bind=engine)
+
+    results: list[bool] = []
+    results_lock = threading.Lock()
+    start = threading.Barrier(2)
+
+    def claim() -> None:
+      session = SessionFactory()
+      try:
+        row = (
+          session.query(BillingSubscription)
+          .filter(BillingSubscription.id == subscription_id)
+          .one()
+        )
+        start.wait(timeout=10)
+        won = row.claim_for_provisioning(session)
+        with results_lock:
+          results.append(won)
+      finally:
+        session.close()
+
+    threads = [threading.Thread(target=claim) for _ in range(2)]
+    for thread in threads:
+      thread.start()
+    for thread in threads:
+      thread.join(timeout=30)
+
+    assert len(results) == 2, "both threads must complete"
+    assert sum(results) == 1, f"exactly one claim must win, got {results}"
+
+  def test_many_concurrent_callers_still_resolve_to_one(
+    self, db_session: Session, test_org_id: str
+  ):
+    """The gate is at the sink, so adding callers must not widen the hole."""
+    import threading
+
+    subscription = _make_subscription(db_session, test_org_id)
+    subscription_id = subscription.id
+
+    engine = db_session.get_bind()
+    SessionFactory = sessionmaker(bind=engine)
+
+    caller_count = 6
+    results: list[bool] = []
+    results_lock = threading.Lock()
+    start = threading.Barrier(caller_count)
+
+    def claim() -> None:
+      session = SessionFactory()
+      try:
+        row = (
+          session.query(BillingSubscription)
+          .filter(BillingSubscription.id == subscription_id)
+          .one()
+        )
+        start.wait(timeout=10)
+        won = row.claim_for_provisioning(session)
+        with results_lock:
+          results.append(won)
+      finally:
+        session.close()
+
+    threads = [threading.Thread(target=claim) for _ in range(caller_count)]
+    for thread in threads:
+      thread.start()
+    for thread in threads:
+      thread.join(timeout=30)
+
+    assert len(results) == caller_count
+    assert sum(results) == 1, f"exactly one claim must win, got {results}"
+
+
+class TestTerminalCondition:
+  """Once the resource exists, nothing re-provisions."""
+
+  def test_claim_refused_when_resource_already_provisioned(
+    self, db_session: Session, test_org_id: str
+  ):
+    subscription = _make_subscription(
+      db_session,
+      test_org_id,
+      status=SubscriptionStatus.PENDING_PAYMENT.value,
+      resource_id="kg01234567890abcdef",
+    )
+
+    assert subscription.claim_for_provisioning(db_session) is False
+    assert subscription.status == SubscriptionStatus.PENDING_PAYMENT.value
+
+  def test_stale_provisioning_with_a_resource_is_still_refused(
+    self, db_session: Session, test_org_id: str
+  ):
+    """Staleness must not override the terminal condition.
+
+    A provisioning run that created the resource and then died is exactly the
+    row that is both stale and already provisioned. Re-claiming it would build
+    a second graph for one payment.
+    """
+    subscription = _make_subscription(
+      db_session,
+      test_org_id,
+      status=SubscriptionStatus.PROVISIONING.value,
+      resource_id="kg01234567890abcdef",
+      updated_at=datetime.now(UTC) - timedelta(hours=6),
+    )
+
+    assert subscription.claim_for_provisioning(db_session) is False
+
+  def test_active_subscription_is_refused(self, db_session: Session, test_org_id: str):
+    subscription = _make_subscription(
+      db_session,
+      test_org_id,
+      status=SubscriptionStatus.ACTIVE.value,
+      resource_id="kg01234567890abcdef",
+    )
+
+    assert subscription.claim_for_provisioning(db_session) is False
+    assert subscription.status == SubscriptionStatus.ACTIVE.value
+
+
+class TestStaleReclaim:
+  """A dead attempt has to be retryable, or a paid customer gets nothing."""
+
+  def test_stale_provisioning_row_can_be_reclaimed(
+    self, db_session: Session, test_org_id: str
+  ):
+    subscription = _make_subscription(
+      db_session,
+      test_org_id,
+      status=SubscriptionStatus.PROVISIONING.value,
+      updated_at=datetime.now(UTC) - timedelta(minutes=STALE_PROVISIONING_MINUTES + 5),
+    )
+
+    assert subscription.claim_for_provisioning(db_session) is True
+
+  def test_fresh_provisioning_row_is_not_reclaimed(
+    self, db_session: Session, test_org_id: str
+  ):
+    """An attempt still in flight must not be duplicated by a redelivery."""
+    subscription = _make_subscription(
+      db_session,
+      test_org_id,
+      status=SubscriptionStatus.PROVISIONING.value,
+      updated_at=datetime.now(UTC) - timedelta(minutes=1),
+    )
+
+    assert subscription.claim_for_provisioning(db_session) is False
+
+  def test_claim_stamps_updated_at_as_its_heartbeat(
+    self, db_session: Session, test_org_id: str
+  ):
+    """The staleness window is measured against the claim's own stamp."""
+    stale_at = datetime.now(UTC) - timedelta(hours=2)
+    subscription = _make_subscription(
+      db_session,
+      test_org_id,
+      status=SubscriptionStatus.PROVISIONING.value,
+      updated_at=stale_at,
+    )
+
+    assert subscription.claim_for_provisioning(db_session) is True
+
+    refreshed_at = subscription.updated_at
+    assert refreshed_at is not None
+    assert refreshed_at.replace(tzinfo=UTC) > stale_at
+
+    # Freshly stamped, so the next caller is refused.
+    assert subscription.claim_for_provisioning(db_session) is False


### PR DESCRIPTION
## Summary

Hardens subscription provisioning idempotency, and closes the lifecycle state that nothing owned. Both are dormant today because paid volume is near zero; both are silent and non-self-healing when they do fire, so they want fixing before volume rather than after.

Design record and the reasoning behind each decision are in the private vault at `specs/commerce/paid-path-hardening.md` (items 1 and 4).

## Changes

**Provisioning idempotency (`models/core/billing/subscription.py`, `dagster/jobs/billing.py`)**
- New `BillingSubscription.claim_for_provisioning()` — a single conditional `UPDATE` that acts as the gate. It folds in the terminal condition (a subscription whose resource already exists is never re-provisioned, whatever its status), the ordinary first entry, and a staleness window that keeps a genuinely dead attempt retryable without letting a live one be duplicated. `updated_at` is stamped by the claim and doubles as the heartbeat the window is measured against.
- The gate lives at the sink rather than at each caller, so a future third trigger inherits it. `_handle_checkout_completed` no longer sets the status itself — that transition *is* the claim.
- Failure path: records the error and leaves the row retryable, rather than writing a terminal status that would discard both the provider's redelivery and the staleness window.
- Fixed two in-place JSONB mutations on `subscription_metadata` that SQLAlchemy's unit of work never saw, so the error text a failed subscription carried was silently dropped. The file already documents this hazard elsewhere; these two sites predate it.

**Stalled provisioning (`dagster/jobs/graph_lifecycle.py`, `dagster/sensors/graph_lifecycle.py`, `dagster/definitions.py`)**
- `provisioning` is neither active nor terminal, so both lifecycle sensors filtered it out and nothing else revisited it. A subscription that entered it and stopped stayed there indefinitely, with any infrastructure the attempt created running unbilled and unreachable by the machinery meant to reclaim it.
- New `stalled_provisioning_sensor` + `reap_stalled_provisioning_job`: rows past the staleness window are marked `failed` with `ends_at` set, which both surfaces them in `admin subscriptions list` and puts them in a state the existing sensors act on, so reclamation happens on the ordinary retention schedule. The op re-checks status under its own transaction, since a retry can succeed between the sensor's read and the write.
- Deliberately scoped to `provisioning` only. A stalled `upgrading` row has no safe automatic disposition — writing it off would tear down a paying customer's graph, forcing it active would claim a migration succeeded when its volume may not be reattached. Rationale is in the sensor docstring; #1089 removes the mechanism that made it likely.

**Reclaim reachability**
- `dagster/sensors/graph_lifecycle.py`: both sensors now filter on `TERMINAL_SUBSCRIPTION_STATUSES` instead of `"canceled"` alone.
- `operations/graph/provisioning_service.py`: the graph is linked to its subscription immediately on creation rather than after activation. The sensors join subscriptions to graphs on `resource_id`, so a graph orphaned by a later failure was previously invisible to them regardless of status. Committing the link early also makes the claim's terminal condition true, so no redelivery can create a second graph.

## Breaking Changes

None. No API surface, no request/response shapes, no GraphQL schema — no SDK impact. No migration: `claim_for_provisioning` uses existing columns and `idx_billing_sub_status`.

## Testing

- **`tests/models/core/billing/test_provisioning_claim.py`** (new, 9 tests, real Postgres) — the concurrency guarantee is a database property, so it is tested with real threads on independent connections rather than mocks. Verified non-vacuous against two wrong implementations: a naive read-then-write fails, and so does a *correct predicate evaluated in Python* (`[True, True]` — two winners). Also covers the terminal condition, stale reclaim, fresh-attempt refusal, and the heartbeat stamp.
- **`tests/dagster/test_billing_webhook_handlers.py`** — added coverage that a refused claim skips provisioning entirely for both resource types, and that a failed attempt records its error without a terminal status. Two existing tests asserted the old behavior of the caller pre-setting `provisioning`; updated to assert the hand-off instead, which is what they were actually about.
- **`tests/dagster/test_graph_lifecycle.py`** — sensor wiring plus the reaper's disposition, including that it skips a subscription which completed between the sensor's read and the write.
- `uv run pytest tests/models/core/billing/ tests/dagster/ tests/middleware/sse/test_direct_monitor.py tests/routers/admin` — 448 passed.
- `just test-code` — ruff, format, basedpyright, cf-lint all clean.
- Full `just test` not run in-session.
