### PR TITLE
fix(billing): make repository credit reallocation symmetric

### DIFF
--- a/robosystems/models/core/user/user_repository_credits.py
+++ b/robosystems/models/core/user/user_repository_credits.py
@@ -301,8 +301,22 @@ class UserRepositoryCredits(Base):
   ) -> None:
     """Update the monthly allocation, as on a plan change.
 
-    With ``immediate_credit`` an upgrade tops the current balance up by the
-    difference right away, rather than waiting for the next allocation.
+    With ``immediate_credit`` the balance moves by the change in allocation
+    right away, rather than waiting for the next monthly allocation, so a
+    same-day plan change takes effect the day it is bought.
+
+    The adjustment is **symmetric**: a downgrade takes back what an upgrade
+    would have granted. Granting on the way up without deducting on the way
+    down does not merely under-charge — it compounds, because the next
+    upgrade's delta is computed against the new, lower allocation and grants
+    the difference a second time for the same net position.
+
+    Two properties bound it. The deduction never drives the balance below
+    zero, so a downgrade cannot manufacture an overage out of credits already
+    spent; and the operation is idempotent for a given target, since a repeat
+    call finds ``monthly_allocation`` already at ``new_allocation`` and
+    computes a zero delta. That makes a retried plan change a no-op without
+    needing a separate idempotency record.
     """
     old_allocation = self.monthly_allocation
     difference = new_allocation - old_allocation
@@ -332,6 +346,35 @@ class UserRepositoryCredits(Base):
         },
         session=session,
       )
+
+    elif immediate_credit and difference < 0:
+      # Clamped to what is actually there. A balance already drawn down (or
+      # negative from an overage) must not be pushed further down by a plan
+      # change — the user keeps what they have already used.
+      available = max(Decimal("0"), cast(Decimal, self.current_balance))
+      deduction = min(-difference, available)
+
+      if deduction > 0:
+        self.current_balance = cast(Decimal, self.current_balance) - deduction
+
+        UserRepositoryCreditTransaction.create_transaction(
+          credit_pool_id=cast(str, self.id),
+          transaction_type=UserRepositoryCreditTransactionType.BONUS,
+          amount=-deduction,
+          description="Tier downgrade credit adjustment",
+          metadata={
+            "old_allocation": str(old_allocation),
+            "new_allocation": str(new_allocation),
+            "uncollected": str(-difference - deduction),
+          },
+          session=session,
+        )
+      else:
+        logger.info(
+          f"Downgrade on user pool {self.id} deducted nothing: balance "
+          f"{self.current_balance} leaves no headroom against a "
+          f"{-difference} reduction"
+        )
 
     try:
       session.commit()

--- a/tests/models/core/user/test_user_repository_credits.py
+++ b/tests/models/core/user/test_user_repository_credits.py
@@ -442,6 +442,127 @@ class TestUserRepositoryCredits:
     assert credits.current_balance == Decimal("99999999.99")  # Capped at MAX_BALANCE
     mock_logger.warning.assert_called_once()
 
+  def _make_pool(self, *, balance: str, allocation: str) -> UserRepositoryCredits:
+    credits = UserRepositoryCredits(
+      user_repository_id=self.repo_access.id,
+      current_balance=Decimal(balance),
+      monthly_allocation=Decimal(allocation),
+    )
+    self.session.add(credits)
+    self.session.commit()
+    return credits
+
+  def _transaction_sum(self, credits: UserRepositoryCredits) -> Decimal:
+    rows = (
+      self.session.query(UserRepositoryCreditTransaction)
+      .filter_by(credit_pool_id=credits.id)
+      .all()
+    )
+    return sum((row.amount for row in rows), Decimal("0"))
+
+  def test_downgrade_deducts_the_allocation_difference(self):
+    """A downgrade takes back what the mirror upgrade would have granted."""
+    credits = self._make_pool(balance="2000", allocation="2000")
+
+    credits.update_monthly_allocation(
+      new_allocation=Decimal("1000"), session=self.session, immediate_credit=True
+    )
+
+    assert credits.monthly_allocation == Decimal("1000")
+    assert credits.current_balance == Decimal("1000")
+    assert self._transaction_sum(credits) == Decimal("-1000")
+
+  def test_cycling_plans_does_not_accumulate_credits(self):
+    """The property the whole fix exists for.
+
+    Granting on the way up without deducting on the way down compounds: each
+    upgrade's delta is computed against the lowered allocation, so the same
+    net position can be bought over and over. Both the balance and the
+    transaction ledger must come back to the single-upgrade value no matter
+    how many times the cycle runs.
+    """
+    credits = self._make_pool(balance="1000", allocation="1000")
+
+    for _ in range(3):
+      credits.update_monthly_allocation(
+        new_allocation=Decimal("5000"), session=self.session, immediate_credit=True
+      )
+      credits.update_monthly_allocation(
+        new_allocation=Decimal("1000"), session=self.session, immediate_credit=True
+      )
+
+    # One last upgrade, so the end state is the same net change as a single
+    # 1000 -> 5000 move.
+    credits.update_monthly_allocation(
+      new_allocation=Decimal("5000"), session=self.session, immediate_credit=True
+    )
+
+    assert credits.monthly_allocation == Decimal("5000")
+    assert credits.current_balance == Decimal("5000")
+    assert self._transaction_sum(credits) == Decimal("4000")
+
+  def test_downgrade_cannot_drive_the_balance_negative(self):
+    """Credits already spent are not clawed back into an overage."""
+    credits = self._make_pool(balance="200", allocation="5000")
+
+    credits.update_monthly_allocation(
+      new_allocation=Decimal("1000"), session=self.session, immediate_credit=True
+    )
+
+    assert credits.current_balance == Decimal("0")
+    assert self._transaction_sum(credits) == Decimal("-200")
+
+    transaction = (
+      self.session.query(UserRepositoryCreditTransaction)
+      .filter_by(credit_pool_id=credits.id)
+      .one()
+    )
+    uncollected = json.loads(transaction.transaction_metadata)["uncollected"]
+    assert Decimal(uncollected) == Decimal("3800")
+
+  def test_downgrade_on_an_empty_pool_writes_no_transaction(self):
+    credits = self._make_pool(balance="0", allocation="5000")
+
+    credits.update_monthly_allocation(
+      new_allocation=Decimal("1000"), session=self.session, immediate_credit=True
+    )
+
+    assert credits.current_balance == Decimal("0")
+    assert (
+      self.session.query(UserRepositoryCreditTransaction)
+      .filter_by(credit_pool_id=credits.id)
+      .count()
+      == 0
+    )
+
+  def test_downgrade_without_immediate_credit_leaves_the_balance_alone(self):
+    """The opt-out has to be symmetric too, or it becomes a free downgrade."""
+    credits = self._make_pool(balance="2000", allocation="2000")
+
+    credits.update_monthly_allocation(
+      new_allocation=Decimal("1000"), session=self.session, immediate_credit=False
+    )
+
+    assert credits.monthly_allocation == Decimal("1000")
+    assert credits.current_balance == Decimal("2000")
+    assert self._transaction_sum(credits) == Decimal("0")
+
+  def test_repeating_the_same_change_is_a_no_op(self):
+    """A retried plan change must not adjust twice.
+
+    Idempotency falls out of the delta being computed against the stored
+    allocation rather than being tracked separately.
+    """
+    credits = self._make_pool(balance="1000", allocation="1000")
+
+    for _ in range(3):
+      credits.update_monthly_allocation(
+        new_allocation=Decimal("3000"), session=self.session, immediate_credit=True
+      )
+
+    assert credits.current_balance == Decimal("3000")
+    assert self._transaction_sum(credits) == Decimal("2000")
+
   def test_get_summary(self):
     """Test getting credit summary."""
     now = datetime.now(UTC)


### PR DESCRIPTION
## Summary

Corrects repository credit reallocation on a plan change so the balance adjustment is symmetric. The design record is in the private vault at `specs/commerce/paid-path-hardening.md` (item 3), where the policy choice among three candidates is now recorded so it is not re-litigated.

## Changes

**`robosystems/models/core/user/user_repository_credits.py`** — `update_monthly_allocation`:

- A decrease in `monthly_allocation` now moves `current_balance` by the same difference, mirroring the existing increase branch. Previously only the positive direction had a branch, so the balance and the allocation could drift apart without bound — each subsequent increase computed its delta against the lowered allocation.
- The deduction is clamped to the credits actually present (`max(0, balance)`), so a plan change can never push a balance that has already been drawn down — or is already negative from an overage — further down. Credits already used stay used.
- Any shortfall between the intended and the collected deduction is recorded as `uncollected` on the transaction rather than being silently dropped, so the ledger explains itself.
- The `immediate_credit=False` opt-out is symmetric: it now skips the deduction as well as the grant. Skipping only one direction would have made it a free downgrade.
- Docstring records the two bounding properties and why no separate idempotency record is needed: the delta is computed against the stored allocation, so a repeated call to the same target finds a zero difference and does nothing.

The transaction keeps the existing `BONUS` type with a negative amount rather than introducing a new type. `amount` is already documented on the column as signed, and the three call sites that aggregate credit history filter on `CONSUMPTION` — reusing that type for a plan adjustment would have corrupted consumption analytics.

## Breaking Changes

None. No API surface, no request/response shapes, no GraphQL schema — no SDK impact. No migration: `transaction_type` is a plain `String` column and no new value was added.

## Testing

- **`tests/models/core/user/test_user_repository_credits.py`** — six new tests: the plain downgrade deduction, the full up-down cycle, the negative-balance clamp with its `uncollected` record, the empty-pool no-op, the symmetric opt-out, and repeat-application idempotency. Each asserts both the balance and the transaction sum, so a fix that moved the balance without a matching ledger entry would fail.
- Verified non-vacuous: restoring the previous implementation makes the cycle test fail with **17,000 credits accumulated where the single net upgrade is worth 5,000**, and the plain downgrade test fail outright.
- `uv run pytest tests/models/core/user/ tests/security/test_credit_race_conditions.py tests/operations/graph` — 813 passed.
- `just test-code` — ruff, format, basedpyright, cf-lint all clean.
- Full `just test` not run in-session.
