### PR TITLE
chore(examples): let a showcase episode load into a deployed environment

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -87,6 +87,33 @@ uv run python -m examples.coffee_roaster_demo.data
 uv run python -m examples.saas_startup_demo.data
 ```
 
+#### Loading an episode into a deployed environment
+
+Because every step but the reset is an ordinary API call, an episode can load
+into a deployed environment as easily as the local stack — which is how these
+two become demo tenants a prospect can be shown, rather than something that
+only exists on a laptop. Point `DEMO_API_URL` at the API and pass the graph id
+of an already-provisioned graph:
+
+```bash
+DEMO_API_URL=https://api.robosystems.ai just demo-coffee-roaster kg…
+```
+
+Three things differ off-local, all deliberate:
+
+- **Credentials and the demo-slot map** go to `.local/config.<host>.json`
+  instead of `.local/config.json`. The slot map is keyed on the scenario slug
+  and the runner reuses a graph on a hit, so a shared file would make a later
+  local run silently operate on the remote graph.
+- **The reset is skipped.** It issues raw `DELETE`s against whatever
+  `EXTENSIONS_DATABASE_URL` names, which an SSM tunnel can make look local, so
+  it is never run against a remote target. Give the episode a freshly
+  provisioned graph — re-running it over one that already holds demo data will
+  duplicate the data rather than replace it.
+- **The graph must already exist.** Provision it the way a customer would
+  (checkout, or `POST /v1/graphs` with a payment method on file) and pass its
+  id; the runner will not create one on a deployed environment.
+
 ### SEC — public company financial data
 
 `examples/sec_demo/` · [walkthrough](sec_demo/README.md)

--- a/examples/_scenario/runner.py
+++ b/examples/_scenario/runner.py
@@ -18,17 +18,26 @@ from outside the system" the way a real customer's integration would. The ONLY
 exception is ``reset.py``, which uses direct DB access for demo cleanup between
 runs — that path is intentionally NOT a product operation.
 
-Requires: Docker stack running (just start)
+That rule is what lets an episode load into a deployed environment as well as
+the local stack: set ``DEMO_API_URL`` and the whole run is ordinary API traffic
+against an account that already holds a provisioned graph. Credentials and the
+demo-slot map are kept in a per-target file so a remote run cannot capture the
+local slots, and the reset is skipped entirely off-local (see ``reset_demo``).
+
+Requires: the local Docker stack (just start), or ``DEMO_API_URL`` pointing at
+a deployed API.
 """
 
 from __future__ import annotations
 
 import json
+import os
 import sys
 import time
 from collections import Counter
 from datetime import date, timedelta
 from pathlib import Path
+from urllib.parse import urlparse
 
 from .drivers import Scenario
 
@@ -37,8 +46,35 @@ from .drivers import Scenario
 # ---------------------------------------------------------------------------
 
 SOURCE = "native"
-CREDENTIALS_FILE = Path(".local/config.json")
-BASE_URL = "http://localhost:8000"
+
+# The API the demo loads into. Defaults to the local stack; set DEMO_API_URL to
+# aim an episode at a deployed environment (for demo tenants a prospect will
+# actually be shown). Everything the runner does is a public API call, so the
+# only thing that changes with the target is the base URL — except the reset,
+# which is not a product operation. See ``reset_demo``.
+BASE_URL = os.environ.get("DEMO_API_URL", "http://localhost:8000").rstrip("/")
+
+_LOCAL_HOSTS = frozenset({"localhost", "127.0.0.1", "0.0.0.0", "host.docker.internal"})
+
+
+def _is_local_target() -> bool:
+  return (urlparse(BASE_URL).hostname or "") in _LOCAL_HOSTS
+
+
+def _credentials_file() -> Path:
+  """Credentials + demo-slot map, kept separate per target.
+
+  The slot map is keyed on ``scenario.slug`` and ``create_demo_graph`` returns
+  early on a hit, so sharing one file across targets would make a later local
+  run silently reuse a remote graph id — and point the reset at it.
+  """
+  if _is_local_target():
+    return Path(".local/config.json")
+  host = (urlparse(BASE_URL).hostname or "remote").replace(".", "-")
+  return Path(f".local/config.{host}.json")
+
+
+CREDENTIALS_FILE = _credentials_file()
 
 
 # ---------------------------------------------------------------------------
@@ -49,7 +85,12 @@ BASE_URL = "http://localhost:8000"
 def _client_config() -> dict[str, str]:
   """Build the standard SDK client config from saved credentials."""
   if not CREDENTIALS_FILE.exists():
-    print("  ERROR: No credentials file. Run `just demo-user` first.")
+    if _is_local_target():
+      print("  ERROR: No credentials file. Run `just demo-user` first.")
+    else:
+      print(f"  ERROR: No credentials for {BASE_URL}.")
+      print(f"  Write the account's API key to {CREDENTIALS_FILE} as")
+      print('  {"api_key": "..."} — demo-user only registers against local.')
     sys.exit(1)
   creds = json.loads(CREDENTIALS_FILE.read_text())
   return {"base_url": BASE_URL, "token": creds.get("api_key", "")}
@@ -94,7 +135,20 @@ def create_demo_graph(scenario: Scenario, entity_type: str) -> str:
   ``entity_type`` sets the entity's legal form on the create request, which
   the backend uses to prefill the graph's Reporting Style (partnership →
   PART, llc → LLC, else corporate).
+
+  Local targets only. Registering a user and creating a graph on a deployed
+  environment are billed, gated product actions with their own flows — a demo
+  runner reaching for them would either fail confusingly or quietly commit an
+  org's payment method. Provision the graph the way a customer does, then pass
+  its id.
   """
+  if not _is_local_target():
+    print(f"\n  ERROR: {BASE_URL} is not a local target, so this runner will")
+    print("  not register a user or create a graph. Provision the graph the")
+    print("  way a customer would (checkout, or POST /v1/graphs with a payment")
+    print("  method on file) and pass its id as the last argument.")
+    sys.exit(1)
+
   project_root = Path(__file__).resolve().parents[2]
   if str(project_root) not in sys.path:
     sys.path.insert(0, str(project_root))
@@ -224,7 +278,20 @@ def reset_demo(graph_id: str) -> None:
   This is the ONLY direct-DB operation in the demo. Everything else
   goes through the HTTP API. Drops the tenant schema and re-provisions
   it with the shared taxonomy seed data.
+
+  **Local targets only.** It issues raw DELETEs against whatever database
+  ``EXTENSIONS_DATABASE_URL`` currently points at, which is not necessarily
+  the same system as ``DEMO_API_URL`` — an SSM tunnel makes a remote database
+  look local. Rather than try to prove those two agree, the reset is simply
+  not run against a remote target: a graph provisioned there is empty anyway,
+  so there is nothing to reset on the intended path.
   """
+  if not _is_local_target():
+    print(f"  SKIPPED — reset is local-only, and the target is {BASE_URL}")
+    print("  Expecting a freshly provisioned graph; re-running this episode")
+    print("  against a graph that already holds demo data will duplicate it.")
+    return
+
   from .reset import reset_demo_state
 
   reset_demo_state(graph_id)


### PR DESCRIPTION
## Summary

Lets a showcase episode (Driftline Coffee, Cadence Labs) load into a deployed environment instead of only the local stack, so the two synthetic companies can exist as demo tenants rather than as fixtures that only run on a laptop. `DEMO_API_URL` selects the target.

The runner's transport rule already made this nearly free — every step but the reset goes through the public HTTP API — so the change is a base-URL indirection plus the three guards that the difference between targets actually requires.

## Changes

**`examples/_scenario/runner.py`**
- `BASE_URL` reads `DEMO_API_URL`, defaulting to `http://localhost:8000`. Added `_is_local_target()` and `_credentials_file()`.
- **Per-target credentials file.** Off local, credentials and the demo-slot map go to `.local/config.<host>.json`. The slot map is keyed on `scenario.slug` and `create_demo_graph` returns early on a hit, so a shared file would make a later local run silently operate on the remote graph — including pointing the reset at it.
- **`reset_demo` skips off local**, with a notice that a re-run over an existing remote graph duplicates rather than replaces. It issues raw `DELETE`s against whatever `EXTENSIONS_DATABASE_URL` names, and an SSM tunnel makes a remote database look local, so rather than trying to prove that agrees with `DEMO_API_URL` it simply does not run there. A graph provisioned remotely is empty anyway.
- **`create_demo_graph` refuses off local.** Registering a user and creating a graph are billed, gated product actions with their own flows; a demo runner reaching for them would either fail confusingly against controlled registration and the payment-method check, or quietly commit an org's payment method. The error names what to do instead.
- `_client_config`'s missing-credentials error is target-aware — `just demo-user` only registers against local, so pointing at that on a remote target would send someone in a circle.

**`examples/README.md`** — a subsection documenting the flow and stating all three differences explicitly, since each one is a place where the obvious assumption is wrong.

## Breaking Changes

None. With `DEMO_API_URL` unset every path behaves exactly as before, including the credentials file location.

## Testing

- `just demo-coffee-roaster --dry-run` — unchanged (27 accounts, 389 transactions, all entries balance).
- With `DEMO_API_URL=https://api.robosystems.ai`, the runner refuses graph creation with the intended message rather than attempting registration.
- Target resolution checked directly for both cases: local → `.local/config.json`, remote → `.local/config.api-robosystems-ai.json`, with trailing-slash normalization.
- `just test-code` — ruff, format, basedpyright, cf-lint all clean.
- Full `just test` not run in-session. No production code paths are touched by this PR.
