### PR TITLE
fix(billing): let provisioning failure disposition follow the claim protocol

### DIFF
--- a/robosystems/dagster/jobs/graph_lifecycle.py
+++ b/robosystems/dagster/jobs/graph_lifecycle.py
@@ -161,11 +161,8 @@ def reap_stalled_provisioning(
   unbilled forever. ``failed`` is also terminal, so the customer's route back
   — a fresh checkout — is already open.
   """
-  from datetime import UTC, datetime
-
   from robosystems.models.core.billing.subscription import BillingSubscription
 
-  now = datetime.now(UTC)
   reaped: list[str] = []
 
   with db.get_session() as session:
@@ -179,24 +176,22 @@ def reap_stalled_provisioning(
         context.log.warning(f"Subscription {subscription_id} not found, skipping")
         continue
 
-      # Re-check under this transaction: the sensor's read and this write are
-      # minutes apart, and a redelivery may have completed in between.
       if subscription.status != "provisioning":
         context.log.info(
           f"Subscription {subscription_id} is now {subscription.status}, skipping"
         )
         continue
 
-      subscription.status = "failed"
-      subscription.subscription_metadata = {
-        **(subscription.subscription_metadata or {}),
-        "error": "Provisioning stalled and was written off",
-        "failed_at": now.isoformat(),
-      }
-      if subscription.ends_at is None:
-        subscription.ends_at = now
-      session.commit()
-      subscription._invalidate_access_cache()
+      # The write-off re-checks staleness atomically at write time. Between
+      # the sensor's read and this run a redelivery may have re-claimed the
+      # row — status still "provisioning" but heartbeat fresh — and that run
+      # is live, not stalled.
+      if not subscription.write_off_stalled_provisioning(session):
+        context.log.info(
+          f"Subscription {subscription_id} completed or was re-claimed since "
+          "the sensor's read, skipping"
+        )
+        continue
 
       reaped.append(subscription_id)
       context.log.error(

--- a/robosystems/models/core/billing/subscription.py
+++ b/robosystems/models/core/billing/subscription.py
@@ -353,6 +353,11 @@ class BillingSubscription(Base):
     now = datetime.now(UTC)
     stale_cutoff = now - timedelta(minutes=stale_after_minutes)
 
+    # Pre-state for observability only — correctness comes from the UPDATE's
+    # predicate. If this still reads "provisioning" when the claim succeeds,
+    # the claim was taken from a stale holder rather than a first entry.
+    prior_status = self.status
+
     claimed = (
       session.query(BillingSubscription)
       .filter(
@@ -384,7 +389,16 @@ class BillingSubscription(Base):
     session.refresh(self)
 
     if claimed:
-      logger.info(f"Claimed subscription {self.id} for provisioning")
+      if prior_status == SubscriptionStatus.PROVISIONING.value:
+        logger.warning(
+          f"Re-claimed a stale provisioning attempt for subscription {self.id} — "
+          f"the prior run held the claim past {stale_after_minutes} minutes "
+          "without finishing. If this recurs, compare real provisioning "
+          "durations against STALE_PROVISIONING_MINUTES before trusting the "
+          "window."
+        )
+      else:
+        logger.info(f"Claimed subscription {self.id} for provisioning")
     else:
       logger.info(
         f"Provisioning claim refused for subscription {self.id} "
@@ -393,6 +407,70 @@ class BillingSubscription(Base):
       )
 
     return bool(claimed)
+
+  def write_off_stalled_provisioning(
+    self, session: Session, stale_after_minutes: int = STALE_PROVISIONING_MINUTES
+  ) -> bool:
+    """Terminally fail a provisioning attempt that is stale *right now*.
+
+    The claim's terminal counterpart, built with the same care: one
+    conditional UPDATE whose predicate re-checks staleness at write time.
+    The reaper's sensor read and this write are minutes apart, and in that
+    gap a provider redelivery may legitimately re-claim the row — which
+    leaves the status at ``provisioning`` but stamps a fresh heartbeat, so a
+    status check alone would write off a live run. Here a concurrent claim
+    either committed first (fresh heartbeat, no match) or blocks on the row
+    lock and then finds ``failed``, which it refuses.
+
+    ``ends_at`` starts the retention clock the lifecycle sensors measure —
+    terminal status plus that timestamp is what makes any infrastructure the
+    attempt created reclaimable on the ordinary schedule.
+
+    The metadata merge reads from ``self``, which is safe under the
+    predicate: any interleaved write stamps ``updated_at`` via ``onupdate``
+    and defeats the staleness check, so a row this method actually updates is
+    one nobody has touched since it was loaded.
+    """
+    now = datetime.now(UTC)
+    stale_cutoff = now - timedelta(minutes=stale_after_minutes)
+
+    wrote_off = (
+      session.query(BillingSubscription)
+      .filter(
+        BillingSubscription.id == self.id,
+        BillingSubscription.status == SubscriptionStatus.PROVISIONING.value,
+        BillingSubscription.updated_at < stale_cutoff,
+      )
+      .update(
+        {
+          BillingSubscription.status: SubscriptionStatus.FAILED.value,
+          BillingSubscription.subscription_metadata: {
+            **(self.subscription_metadata or {}),
+            "error": "Provisioning stalled and was written off",
+            "failed_at": now.isoformat(),
+          },
+          BillingSubscription.ends_at: self.ends_at or now,
+        },
+        synchronize_session=False,
+      )
+    )
+
+    session.commit()
+    session.refresh(self)
+
+    if wrote_off:
+      self._invalidate_access_cache()
+      logger.warning(
+        f"Wrote off stalled provisioning for subscription {self.id} "
+        f"(org={self.org_id}, resource_type={self.resource_type})"
+      )
+    else:
+      logger.info(
+        f"Stalled write-off refused for subscription {self.id} "
+        f"(status={self.status}) — completed or re-claimed since it was read"
+      )
+
+    return bool(wrote_off)
 
   def activate(self, session: Session) -> None:
     """Activate the subscription."""

--- a/robosystems/operations/graph/provisioning_service.py
+++ b/robosystems/operations/graph/provisioning_service.py
@@ -3,9 +3,13 @@
 Driven by Stripe billing webhooks or direct subscription creation, and called
 synchronously from the Dagster billing jobs and the subscription routers.
 
-Both entry points end the same way on failure: the subscription is marked
-failed and its Stripe subscription cancelled, so a customer is never left
-paying for a resource that was never created.
+Failure disposition belongs to the caller's protocol, not to these functions.
+The webhook path holds the provisioning claim, so a failed attempt stays
+claim-held and non-terminal — the provider's redelivery retries it once the
+staleness window passes, and the stalled-provisioning reaper is the one place
+a dead attempt is finally written off. The direct router path has no
+redelivery behind it, so it records the failure on the row itself and cancels
+the payment subscription. Writing a terminal status here would preempt both.
 """
 
 import time
@@ -25,8 +29,10 @@ async def run_graph_provisioning(
   """Create the graph, activate the subscription, and report to Dagster.
 
   ``operation_id`` streams progress over SSE; it is None on the
-  webhook-triggered path, which has no client listening. On failure the
-  subscription is marked failed and the error re-raised.
+  webhook-triggered path, which has no client listening. On failure the error
+  is re-raised and the row is left exactly as the caller staged it — the
+  webhook path still holds the provisioning claim, so the attempt stays
+  retryable by redelivery until the reaper writes it off.
   """
   from robosystems.database import get_db_session
   from robosystems.models.core.billing import (
@@ -211,7 +217,6 @@ async def run_graph_provisioning(
         error_details={"error_type": type(e).__name__},
       )
 
-    _mark_subscription_failed(subscription_id, str(e))
     raise
 
 
@@ -224,8 +229,10 @@ async def run_user_repository_provisioning(
   """Grant repository access, allocate credits, and activate the subscription.
 
   ``operation_id`` streams progress over SSE; it is None on the
-  webhook-triggered path. On failure the subscription is marked failed and the
-  error re-raised.
+  webhook-triggered path. On failure the error is re-raised and disposition is
+  the caller's: the webhook path keeps the claim held for redelivery, and the
+  subscription router marks the row failed and cancels the payment
+  subscription itself.
   """
   from robosystems.database import get_db_session
   from robosystems.models.core import RepositoryType
@@ -397,56 +404,4 @@ async def run_user_repository_provisioning(
         error_details={"error_type": type(e).__name__},
       )
 
-    _mark_subscription_failed(subscription_id, str(e))
     raise
-
-
-def _mark_subscription_failed(subscription_id: str, error: str) -> None:
-  """Mark a subscription as failed and cancel its Stripe subscription."""
-  from robosystems.database import get_db_session
-  from robosystems.models.core.billing import BillingSubscription
-
-  try:
-    db_gen = get_db_session()
-    db = next(db_gen)
-    try:
-      subscription = (
-        db.query(BillingSubscription)
-        .filter(BillingSubscription.id == subscription_id)
-        .first()
-      )
-      if subscription:
-        subscription.status = "failed"
-        if subscription.subscription_metadata:
-          metadata = dict(subscription.subscription_metadata)
-          metadata["error"] = error
-          subscription.subscription_metadata = metadata
-        else:
-          subscription.subscription_metadata = {"error": error}
-
-        if subscription.stripe_subscription_id:
-          try:
-            from robosystems.operations.providers.payment_provider import (
-              get_payment_provider,
-            )
-
-            provider = get_payment_provider("stripe")
-            provider.cancel_subscription(subscription.stripe_subscription_id)
-          except Exception as cancel_error:
-            logger.error(
-              f"Failed to cancel Stripe subscription "
-              f"{subscription.stripe_subscription_id}: {cancel_error}"
-            )
-
-        try:
-          db.commit()
-        except Exception as commit_error:
-          logger.error(f"Failed to commit subscription failure status: {commit_error}")
-          db.rollback()
-    finally:
-      try:
-        next(db_gen)
-      except StopIteration:
-        pass
-  except Exception as cleanup_error:
-    logger.error(f"Failed to mark subscription as failed: {cleanup_error}")

--- a/robosystems/routers/graphs/subscriptions.py
+++ b/robosystems/routers/graphs/subscriptions.py
@@ -1,5 +1,7 @@
 """Unified subscription management endpoints for graphs and repositories."""
 
+from datetime import UTC, datetime
+
 from fastapi import APIRouter, Body, Depends, HTTPException, Path, status
 from sqlalchemy.orm import Session
 
@@ -378,6 +380,10 @@ async def create_repository_subscription(
           exc_info=True,
         )
         subscription.status = SubscriptionStatus.FAILED.value
+        # Terminal rows carry ends_at — it is the retention timestamp the
+        # lifecycle machinery keys on, and a terminal row without it is
+        # invisible to that machinery.
+        subscription.ends_at = datetime.now(UTC)
         db.commit()
         raise HTTPException(
           status_code=402,
@@ -428,6 +434,7 @@ async def create_repository_subscription(
       failed_sub = db.query(BillingSubscription).filter_by(id=subscription_id).first()
       if failed_sub:
         failed_sub.status = SubscriptionStatus.FAILED.value
+        failed_sub.ends_at = datetime.now(UTC)
         # Cancel Stripe subscription so the customer isn't charged
         if failed_sub.stripe_subscription_id:
           try:

--- a/tests/dagster/test_graph_lifecycle.py
+++ b/tests/dagster/test_graph_lifecycle.py
@@ -194,21 +194,22 @@ class TestReapStalledProvisioning:
       ReapStalledProvisioningConfig(subscription_ids=subscription_ids),
     )
 
-  def test_marks_stalled_subscription_failed_and_starts_retention(self):
-    """`failed` + `ends_at` is what makes the lifecycle sensors act on it."""
+  def test_delegates_the_write_off_to_the_model(self):
+    """The op's job is wiring; the disposition lives on the model.
+
+    ``write_off_stalled_provisioning`` carries the staleness predicate and the
+    ``failed`` + ``ends_at`` write — its behavior is pinned against real
+    Postgres in ``tests/models/core/billing/test_provisioning_claim.py``.
+    """
     subscription = MagicMock()
     subscription.id = "bsub_stalled"
     subscription.status = "provisioning"
-    subscription.ends_at = None
-    subscription.subscription_metadata = {}
+    subscription.write_off_stalled_provisioning = MagicMock(return_value=True)
 
     result = self._run(subscription, ["bsub_stalled"])
 
     assert result["reaped_count"] == 1
-    assert subscription.status == "failed"
-    assert subscription.ends_at is not None
-    assert subscription.subscription_metadata["error"]
-    assert subscription.subscription_metadata["failed_at"]
+    subscription.write_off_stalled_provisioning.assert_called_once()
 
   def test_skips_a_subscription_that_completed_since_the_sensor_read(self):
     """The sensor's read and this write are minutes apart.
@@ -219,13 +220,25 @@ class TestReapStalledProvisioning:
     subscription = MagicMock()
     subscription.id = "bsub_recovered"
     subscription.status = "active"
-    subscription.ends_at = None
+    subscription.write_off_stalled_provisioning = MagicMock(return_value=True)
 
     result = self._run(subscription, ["bsub_recovered"])
 
     assert result["reaped_count"] == 0
-    assert subscription.status == "active"
-    assert subscription.ends_at is None
+    subscription.write_off_stalled_provisioning.assert_not_called()
+
+  def test_skips_a_subscription_reclaimed_since_the_sensor_read(self):
+    """Still `provisioning`, but the write-off refuses: a redelivery re-claimed
+    the row and stamped a fresh heartbeat, so the run is live, not stalled."""
+    subscription = MagicMock()
+    subscription.id = "bsub_reclaimed"
+    subscription.status = "provisioning"
+    subscription.write_off_stalled_provisioning = MagicMock(return_value=False)
+
+    result = self._run(subscription, ["bsub_reclaimed"])
+
+    assert result["reaped_count"] == 0
+    subscription.write_off_stalled_provisioning.assert_called_once()
 
   def test_missing_subscription_is_skipped(self):
     result = self._run(None, ["bsub_gone"])

--- a/tests/middleware/sse/test_direct_monitor.py
+++ b/tests/middleware/sse/test_direct_monitor.py
@@ -126,8 +126,13 @@ class TestRunGraphProvisioning:
             mock_manager.complete_operation.assert_not_called()
 
   @pytest.mark.asyncio
-  async def test_graph_provisioning_failure_marks_subscription_failed(self):
-    """Test that provisioning failure marks subscription as failed."""
+  async def test_graph_provisioning_failure_fails_the_sse_operation(self):
+    """A failed attempt fails the SSE operation and nothing more.
+
+    Disposition of the subscription row is the caller's, not this function's —
+    pinned against real Postgres in
+    ``tests/operations/graph/test_provisioning_failure_disposition.py``.
+    """
     with patch(
       "robosystems.operations.graph.provisioning_service.get_operation_manager"
     ) as mock_get_manager:
@@ -162,94 +167,6 @@ class TestRunGraphProvisioning:
             )
 
           mock_manager.fail_operation.assert_called_once()
-
-  @pytest.mark.asyncio
-  async def test_graph_provisioning_failure_cancels_stripe_subscription(self):
-    """Test that provisioning failure cancels the Stripe subscription."""
-    with patch(
-      "robosystems.operations.graph.provisioning_service.get_operation_manager"
-    ) as mock_get_manager:
-      mock_manager = AsyncMock()
-      mock_get_manager.return_value = mock_manager
-
-      with patch("robosystems.database.get_db_session") as mock_get_db:
-        mock_db = MagicMock()
-        mock_get_db.side_effect = [iter([mock_db]), iter([mock_db])]
-
-        mock_subscription = MagicMock()
-        mock_subscription.id = "sub123"
-        mock_subscription.status = "provisioning"
-        mock_subscription.subscription_metadata = {}
-        mock_subscription.stripe_subscription_id = "stripe_sub_abc"
-        mock_db.query.return_value.filter.return_value.first.return_value = (
-          mock_subscription
-        )
-
-        with patch(
-          "robosystems.operations.graph.graph_creation_service.GraphCreationService"
-        ) as mock_service_class:
-          mock_service = AsyncMock()
-          mock_service.create.side_effect = Exception("Provisioning failed")
-          mock_service_class.return_value = mock_service
-
-          with patch(
-            "robosystems.operations.providers.payment_provider.get_payment_provider"
-          ) as mock_get_provider:
-            mock_provider = MagicMock()
-            mock_get_provider.return_value = mock_provider
-
-            with pytest.raises(Exception, match="Provisioning failed"):
-              await run_graph_provisioning(
-                operation_id="op123",
-                subscription_id="sub123",
-                user_id="user456",
-                tier="ladybug-standard",
-              )
-
-            mock_provider.cancel_subscription.assert_called_once_with("stripe_sub_abc")
-            assert mock_subscription.status == "failed"
-
-  @pytest.mark.asyncio
-  async def test_graph_provisioning_failure_skips_cancel_without_stripe(self):
-    """Test that failure without Stripe subscription doesn't attempt cancel."""
-    with patch(
-      "robosystems.operations.graph.provisioning_service.get_operation_manager"
-    ) as mock_get_manager:
-      mock_manager = AsyncMock()
-      mock_get_manager.return_value = mock_manager
-
-      with patch("robosystems.database.get_db_session") as mock_get_db:
-        mock_db = MagicMock()
-        mock_get_db.side_effect = [iter([mock_db]), iter([mock_db])]
-
-        mock_subscription = MagicMock()
-        mock_subscription.id = "sub123"
-        mock_subscription.status = "provisioning"
-        mock_subscription.subscription_metadata = {}
-        mock_subscription.stripe_subscription_id = None
-        mock_db.query.return_value.filter.return_value.first.return_value = (
-          mock_subscription
-        )
-
-        with patch(
-          "robosystems.operations.graph.graph_creation_service.GraphCreationService"
-        ) as mock_service_class:
-          mock_service = AsyncMock()
-          mock_service.create.side_effect = Exception("Failed")
-          mock_service_class.return_value = mock_service
-
-          with patch(
-            "robosystems.operations.providers.payment_provider.get_payment_provider"
-          ) as mock_get_provider:
-            with pytest.raises(Exception, match="Failed"):
-              await run_graph_provisioning(
-                operation_id=None,
-                subscription_id="sub123",
-                user_id="user456",
-                tier="ladybug-standard",
-              )
-
-            mock_get_provider.assert_not_called()
 
 
 class TestRunUserRepositoryProvisioning:
@@ -354,64 +271,6 @@ class TestRunUserRepositoryProvisioning:
               user_id="user456",
               repository_name="invalid_repo",
             )
-
-  @pytest.mark.asyncio
-  async def test_repository_provisioning_failure_cancels_stripe_subscription(self):
-    """Test that repository provisioning failure cancels the Stripe subscription."""
-    with patch(
-      "robosystems.operations.graph.provisioning_service.get_operation_manager"
-    ) as mock_get_manager:
-      mock_manager = AsyncMock()
-      mock_get_manager.return_value = mock_manager
-
-      with patch("robosystems.database.get_db_session") as mock_get_db:
-        mock_db = MagicMock()
-        mock_get_db.side_effect = [iter([mock_db]), iter([mock_db])]
-
-        mock_subscription = MagicMock()
-        mock_subscription.id = "sub123"
-        mock_subscription.status = "provisioning"
-        mock_subscription.plan_name = "sec-starter"
-        mock_subscription.subscription_metadata = {}
-        mock_subscription.stripe_subscription_id = "stripe_sub_xyz"
-
-        mock_customer = MagicMock()
-        mock_customer.org_id = "org123"
-
-        mock_db.query.return_value.filter.return_value.first.return_value = (
-          mock_subscription
-        )
-
-        with patch(
-          "robosystems.models.core.billing.BillingCustomer"
-        ) as mock_billing_customer:
-          mock_billing_customer.get_by_user_id.return_value = mock_customer
-
-          with patch(
-            "robosystems.operations.graph.repository_subscription_service.RepositorySubscriptionService"
-          ) as mock_repo_service_class:
-            mock_repo_service = MagicMock()
-            mock_repo_service.grant_access.side_effect = Exception("Access denied")
-            mock_repo_service_class.return_value = mock_repo_service
-
-            with patch(
-              "robosystems.operations.providers.payment_provider.get_payment_provider"
-            ) as mock_get_provider:
-              mock_provider = MagicMock()
-              mock_get_provider.return_value = mock_provider
-
-              with pytest.raises(Exception, match="Access denied"):
-                await run_user_repository_provisioning(
-                  operation_id="op123",
-                  subscription_id="sub123",
-                  user_id="user456",
-                  repository_name="sec",
-                )
-
-              mock_provider.cancel_subscription.assert_called_once_with(
-                "stripe_sub_xyz"
-              )
-              assert mock_subscription.status == "failed"
 
 
 class TestDagsterMaterialization:

--- a/tests/models/core/billing/test_provisioning_claim.py
+++ b/tests/models/core/billing/test_provisioning_claim.py
@@ -1,13 +1,17 @@
-"""Tests for the provisioning claim — the idempotency gate at the sink.
+"""Tests for the provisioning claim and its terminal counterpart.
 
 Provisioning has more than one legitimate trigger, and a provider can also
 redeliver an event whose first attempt never finished. Both converge on
 ``claim_for_provisioning``, which has to hand the work to exactly one caller
 while still letting a genuinely dead attempt be retried.
+``write_off_stalled_provisioning`` is the other half of the same protocol:
+the one place a dead attempt is finally declared dead, guarded by the same
+staleness predicate so it can never write off a run that a redelivery has
+legitimately re-claimed in the meantime.
 
 These run against a real Postgres because the guarantee being tested is a
 database one: the predicate is re-evaluated after the winner's row lock
-clears, and no mock reproduces that. The concurrency case uses real threads on
+clears, and no mock reproduces that. The concurrency cases use real threads on
 independent connections for the same reason — asserting the mutex against a
 mocked session would only assert that the mock was called.
 """
@@ -59,6 +63,7 @@ def _make_subscription(
   status: str = SubscriptionStatus.PENDING_PAYMENT.value,
   resource_id: str | None = None,
   updated_at: datetime | None = None,
+  metadata: dict | None = None,
 ) -> BillingSubscription:
   subscription = BillingSubscription(
     org_id=org_id,
@@ -67,7 +72,7 @@ def _make_subscription(
     plan_name="ladybug-standard",
     base_price_cents=9900,
     status=status,
-    subscription_metadata={},
+    subscription_metadata=metadata or {},
   )
   session.add(subscription)
   session.commit()
@@ -285,3 +290,152 @@ class TestStaleReclaim:
 
     # Freshly stamped, so the next caller is refused.
     assert subscription.claim_for_provisioning(db_session) is False
+
+
+class TestWriteOffStalledProvisioning:
+  """The terminal half of the protocol: only a still-stale attempt dies.
+
+  The reaper's sensor read and its write are minutes apart. In that gap a
+  redelivery may legitimately re-claim the row — status still ``provisioning``
+  but heartbeat fresh — so a status check alone would write off a live run,
+  and the expired-graph sensor could then suspend the graph that run had just
+  created. The write-off's own predicate re-checks staleness at write time,
+  which is what these pin.
+  """
+
+  def test_stale_attempt_is_written_off(self, db_session: Session, test_org_id: str):
+    subscription = _make_subscription(
+      db_session,
+      test_org_id,
+      status=SubscriptionStatus.PROVISIONING.value,
+      updated_at=datetime.now(UTC) - timedelta(minutes=STALE_PROVISIONING_MINUTES + 5),
+    )
+
+    assert subscription.write_off_stalled_provisioning(db_session) is True
+    assert subscription.status == SubscriptionStatus.FAILED.value
+    assert subscription.ends_at is not None
+    assert subscription.subscription_metadata["error"]
+    assert subscription.subscription_metadata["failed_at"]
+
+  def test_fresh_attempt_is_left_alone(self, db_session: Session, test_org_id: str):
+    """An attempt inside the staleness window is a live run, not a stall."""
+    subscription = _make_subscription(
+      db_session,
+      test_org_id,
+      status=SubscriptionStatus.PROVISIONING.value,
+      updated_at=datetime.now(UTC) - timedelta(minutes=1),
+    )
+
+    assert subscription.write_off_stalled_provisioning(db_session) is False
+    assert subscription.status == SubscriptionStatus.PROVISIONING.value
+    assert subscription.ends_at is None
+
+  def test_reclaimed_attempt_is_not_written_off(
+    self, db_session: Session, test_org_id: str
+  ):
+    """The race the predicate exists for.
+
+    The sensor saw the row stale; before the reaper ran, a redelivery
+    re-claimed it. The claim stamped a fresh heartbeat, so the write-off must
+    find nothing — that run is live and about to build the resource.
+    """
+    subscription = _make_subscription(
+      db_session,
+      test_org_id,
+      status=SubscriptionStatus.PROVISIONING.value,
+      updated_at=datetime.now(UTC) - timedelta(minutes=STALE_PROVISIONING_MINUTES + 5),
+    )
+
+    assert subscription.claim_for_provisioning(db_session) is True
+
+    assert subscription.write_off_stalled_provisioning(db_session) is False
+    assert subscription.status == SubscriptionStatus.PROVISIONING.value
+
+  def test_written_off_row_is_not_claimable(
+    self, db_session: Session, test_org_id: str
+  ):
+    """Once written off, a late redelivery must not resurrect the attempt."""
+    subscription = _make_subscription(
+      db_session,
+      test_org_id,
+      status=SubscriptionStatus.PROVISIONING.value,
+      updated_at=datetime.now(UTC) - timedelta(minutes=STALE_PROVISIONING_MINUTES + 5),
+    )
+
+    assert subscription.write_off_stalled_provisioning(db_session) is True
+    assert subscription.claim_for_provisioning(db_session) is False
+    assert subscription.status == SubscriptionStatus.FAILED.value
+
+  def test_write_off_preserves_prior_metadata(
+    self, db_session: Session, test_org_id: str
+  ):
+    """The error a failed attempt recorded must survive the write-off."""
+    subscription = _make_subscription(
+      db_session,
+      test_org_id,
+      status=SubscriptionStatus.PROVISIONING.value,
+      updated_at=datetime.now(UTC) - timedelta(minutes=STALE_PROVISIONING_MINUTES + 5),
+      metadata={"last_provisioning_error": "no capacity"},
+    )
+
+    assert subscription.write_off_stalled_provisioning(db_session) is True
+    assert subscription.subscription_metadata["last_provisioning_error"] == (
+      "no capacity"
+    )
+    assert subscription.subscription_metadata["error"]
+
+  def test_concurrent_claim_and_write_off_resolve_to_one_winner(
+    self, db_session: Session, test_org_id: str
+  ):
+    """A stale row contested by a redelivery and the reaper goes to exactly one.
+
+    Both operations carry the same staleness predicate, so whichever commits
+    first flips the row out of the other's reach: a won claim stamps a fresh
+    heartbeat, a won write-off leaves ``failed``. Either order is correct;
+    both winning is the bug.
+    """
+    import threading
+
+    subscription = _make_subscription(
+      db_session,
+      test_org_id,
+      status=SubscriptionStatus.PROVISIONING.value,
+      updated_at=datetime.now(UTC) - timedelta(minutes=STALE_PROVISIONING_MINUTES + 5),
+    )
+    subscription_id = subscription.id
+
+    engine = db_session.get_bind()
+    SessionFactory = sessionmaker(bind=engine)
+
+    results: dict[str, bool] = {}
+    results_lock = threading.Lock()
+    start = threading.Barrier(2)
+
+    def run(name: str, method: str) -> None:
+      session = SessionFactory()
+      try:
+        row = (
+          session.query(BillingSubscription)
+          .filter(BillingSubscription.id == subscription_id)
+          .one()
+        )
+        start.wait(timeout=10)
+        won = getattr(row, method)(session)
+        with results_lock:
+          results[name] = won
+      finally:
+        session.close()
+
+    threads = [
+      threading.Thread(target=run, args=("claim", "claim_for_provisioning")),
+      threading.Thread(
+        target=run, args=("write_off", "write_off_stalled_provisioning")
+      ),
+    ]
+    for thread in threads:
+      thread.start()
+    for thread in threads:
+      thread.join(timeout=30)
+
+    assert len(results) == 2, "both threads must complete"
+    assert sum(results.values()) == 1, f"exactly one side must win, got {results}"

--- a/tests/operations/graph/test_provisioning_failure_disposition.py
+++ b/tests/operations/graph/test_provisioning_failure_disposition.py
@@ -1,0 +1,140 @@
+"""A provisioning failure must not decide the subscription's fate.
+
+Disposition after a failed attempt belongs to the caller's protocol: the
+webhook path holds the provisioning claim, so the row stays claim-held and
+non-terminal — retryable by the provider's redelivery once the staleness
+window passes, and written off only by the stalled-provisioning reaper. The
+subscription router, which has no redelivery behind it, records the failure
+itself.
+
+The regression these pin: the provisioning services used to mark the row
+``failed`` in their own exception handlers — a terminal status with no
+``ends_at``, which simultaneously discarded the redelivery retry (the claim
+refuses terminal rows) and left any infrastructure the attempt had created
+invisible to the lifecycle sensors (which filter on ``ends_at IS NOT NULL``).
+The webhook-handler tests never saw it because they mock these services;
+these tests run the real functions against a real Postgres.
+"""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy.orm import Session
+
+from robosystems.models.core import User
+from robosystems.models.core.billing import BillingSubscription, SubscriptionStatus
+from robosystems.operations.graph.provisioning_service import (
+  run_graph_provisioning,
+  run_user_repository_provisioning,
+)
+
+
+@pytest.fixture
+def provisioning_fixture(db_session: Session) -> tuple[str, str]:
+  """An org with an owner and a subscription mid-claim, as the webhook stages it.
+
+  Returns ``(subscription_id, user_id)``. Status is ``provisioning`` because
+  the claim — not the service — owns that transition; the service receives
+  the row already claimed.
+  """
+  from robosystems.models.core import Org, OrgRole, OrgType, OrgUser
+
+  unique_id = str(uuid.uuid4())[:8]
+
+  org = Org(
+    id=f"disp_org_{unique_id}",
+    name=f"Disposition Org {unique_id}",
+    org_type=OrgType.PERSONAL,
+  )
+  db_session.add(org)
+  db_session.flush()
+
+  user = User(
+    id=f"disp_user_{unique_id}",
+    email=f"disp+{unique_id}@example.com",
+    name="Disposition Test User",
+    password_hash="test_hash",
+  )
+  db_session.add(user)
+  db_session.flush()
+  db_session.add(OrgUser(org_id=org.id, user_id=user.id, role=OrgRole.OWNER))
+
+  subscription = BillingSubscription(
+    org_id=org.id,
+    resource_type="graph",
+    resource_id=None,
+    plan_name="ladybug-standard",
+    base_price_cents=9900,
+    status=SubscriptionStatus.PROVISIONING.value,
+    subscription_metadata={},
+  )
+  db_session.add(subscription)
+  db_session.commit()
+
+  return subscription.id, user.id
+
+
+def _reload(db_session: Session, subscription_id: str) -> BillingSubscription:
+  """Read the row's committed state, not this session's cached copy."""
+  db_session.expire_all()
+  return (
+    db_session.query(BillingSubscription)
+    .filter(BillingSubscription.id == subscription_id)
+    .one()
+  )
+
+
+async def test_failed_graph_provisioning_leaves_the_claim_held(
+  db_session: Session, provisioning_fixture: tuple[str, str]
+):
+  """The composed path, not a mock of it: creation fails, the row survives.
+
+  ``failed`` here would be terminal — the claim refuses terminal rows, so the
+  provider's redelivery would bounce off and the customer's payment would buy
+  nothing retryable.
+  """
+  subscription_id, user_id = provisioning_fixture
+
+  with patch(
+    "robosystems.operations.graph.graph_creation_service.GraphCreationService"
+  ) as mock_service_cls:
+    mock_service_cls.return_value = MagicMock(
+      create=AsyncMock(side_effect=RuntimeError("no capacity"))
+    )
+
+    with pytest.raises(RuntimeError, match="no capacity"):
+      await run_graph_provisioning(
+        operation_id=None,
+        subscription_id=subscription_id,
+        user_id=user_id,
+        tier="ladybug-standard",
+      )
+
+  row = _reload(db_session, subscription_id)
+  assert row.status == SubscriptionStatus.PROVISIONING.value
+  assert row.ends_at is None
+  assert row.resource_id is None
+
+
+async def test_failed_repository_provisioning_leaves_the_claim_held(
+  db_session: Session, provisioning_fixture: tuple[str, str]
+):
+  """Same property on the repository path, with no mocks at all.
+
+  The user has no billing customer, so the service raises on its own
+  validation — the earliest real failure the composed path produces.
+  """
+  subscription_id, user_id = provisioning_fixture
+
+  with pytest.raises(ValueError, match="Customer not found"):
+    await run_user_repository_provisioning(
+      operation_id=None,
+      subscription_id=subscription_id,
+      user_id=user_id,
+      repository_name="sec",
+    )
+
+  row = _reload(db_session, subscription_id)
+  assert row.status == SubscriptionStatus.PROVISIONING.value
+  assert row.ends_at is None


### PR DESCRIPTION
## Summary

Follow-up from the formal review of the four PRs merged since v1.7.5 (#1089–#1092). The provisioning failure path did not actually follow the disposition protocol #1090 introduced: the provisioning services still wrote a terminal status in their own exception handlers, and the stalled-provisioning write-off could race a legitimate re-claim. This PR makes the disposition protocol real end to end and adds the tests that would have caught the gap.

## Changes

**`robosystems/operations/graph/provisioning_service.py`**
- Removed the terminal-status write (and its Stripe cancellation) from both services' exception handlers, and deleted the now-dead helper. On the webhook path a failed attempt now genuinely stays claim-held — retryable by the provider's redelivery once the staleness window passes, written off only by the reaper. The subscription router path is unaffected: it has no redelivery behind it and already records the failure itself.
- Module and function docstrings now state the disposition split explicitly, since the old docstrings described the removed behavior.

**`robosystems/models/core/billing/subscription.py`**
- New `write_off_stalled_provisioning()` — the claim's terminal counterpart, built the same way: one conditional UPDATE whose predicate re-checks staleness at write time. The reaper's sensor read and its write are minutes apart; a redelivery that re-claims the row in that gap leaves the status unchanged but stamps a fresh heartbeat, so the previous status-only re-check would have written off a live run. Sets `ends_at`, merges the failure record into metadata, and invalidates the access cache.
- `claim_for_provisioning()` now logs a WARNING when it wins via the stale-reclaim branch — the observable signal that `STALE_PROVISIONING_MINUTES` and real provisioning durations are in conflict, which is the one number in this protocol that was picked rather than measured.

**`robosystems/dagster/jobs/graph_lifecycle.py`**
- `reap_stalled_provisioning` delegates the write to the model method and treats a refused write-off as "re-claimed since the sensor's read, skip". The op keeps only wiring: existence check, status pre-check for log quality, result accounting.

**`robosystems/routers/graphs/subscriptions.py`**
- Both `failed` writers now stamp `ends_at`. Terminal rows carry the retention timestamp the lifecycle machinery keys on; a terminal row without it is invisible to that machinery. The analogous writer in `subscription_service.py` is deliberately untouched — that flow attaches a subscription to a graph that may already exist and be in use, so stamping the retention clock there is a product decision about the direct-creation flow, not a bugfix.

## Breaking Changes

None. No API surface, no request/response shapes, no GraphQL schema — no SDK impact. No migration: existing columns and indexes only.

## Testing

- **`tests/operations/graph/test_provisioning_failure_disposition.py`** (new) — runs the real service functions against real Postgres and asserts a failed attempt leaves the row claim-held and non-terminal. The existing webhook-handler tests mock these services, which is exactly why the gap survived #1090's review; verified non-vacuous by restoring the previous service code, which fails the graph-path test.
- **`tests/models/core/billing/test_provisioning_claim.py`** — new `TestWriteOffStalledProvisioning` suite: stale attempt written off (with `ends_at` and metadata), fresh attempt refused, re-claimed attempt refused, written-off row not claimable, prior metadata preserved, and a threaded claim-vs-write-off race on independent connections asserting exactly one winner. Verified non-vacuous by removing the staleness predicate, which fails the fresh/re-claimed cases.
- **`tests/dagster/test_graph_lifecycle.py`** — reaper tests updated to the delegation shape, plus a new case for the refused write-off.
- `uv run pytest tests/models/core/billing/ tests/operations/graph/test_provisioning_failure_disposition.py tests/dagster/test_graph_lifecycle.py tests/dagster/test_billing_webhook_handlers.py` — 211 passed. `tests/routers/graphs/` — 745 passed, 5 skipped.
- `just test-code` — ruff, format, basedpyright, cf-lint all clean.
- Full `just test` not run in-session.
