### PR TITLE
fix(oauth): hold authorization state in the shared store, not process memory

### DIFF
--- a/robosystems/operations/providers/oauth_handler.py
+++ b/robosystems/operations/providers/oauth_handler.py
@@ -7,6 +7,7 @@ handful of vendor-specific parameters; everything else is shared here.
 """
 
 import hashlib
+import json
 import secrets
 from datetime import UTC, datetime, timedelta
 from typing import Any, Protocol
@@ -17,6 +18,7 @@ from fastapi import HTTPException, status
 from sqlalchemy.orm import Session
 
 from ...config import env
+from ...config.valkey_registry import ValkeyDatabase, create_redis_client
 from ...logger import logger
 from ...models.core import ConnectionCredentials
 
@@ -55,29 +57,59 @@ class OAuthProviderProtocol(Protocol):
     return {}
 
 
+STATE_TTL_SECONDS = 600
+_STATE_KEY_PREFIX = "oauth:state:"
+
+
 class OAuthState:
   """Single-use, 10-minute CSRF state for an in-flight authorization.
 
-  Held in process memory, so a flow must complete on the worker that started
-  it and no state survives a restart. Both are acceptable because the window
-  is short and the user simply retries; nothing durable is lost.
+  Held in Valkey rather than process memory: the API runs multiple tasks
+  behind a load balancer with no session affinity, so the callback lands on
+  an arbitrary one. Per-process storage meant a flow only completed when the
+  callback happened to hit the task that started it — a coin flip at two
+  tasks, worse as the service scales out.
+
+  Expiry is the key's TTL, so abandoned flows evict themselves. Redemption
+  is a single ``GETDEL``, which makes single-use atomic *across* tasks; the
+  previous ``del`` on a local dict only held within one process.
+
+  This is defense in depth, not the only guard — the callback route is
+  authenticated and separately checks that the caller matches the user the
+  state was minted for.
   """
 
-  _states: dict[str, dict[str, Any]] = {}
+  @staticmethod
+  def _key(state: str) -> str:
+    return f"{_STATE_KEY_PREFIX}{hashlib.sha256(state.encode()).hexdigest()}"
 
   @classmethod
   def create(cls, connection_id: str, user_id: str, redirect_uri: str) -> str:
-    """Mint a state token and record what the callback should resume."""
-    state = secrets.token_urlsafe(32)
-    state_hash = hashlib.sha256(state.encode()).hexdigest()
+    """Mint a state token and record what the callback should resume.
 
-    cls._states[state_hash] = {
+    Raises if the store is unreachable: a flow whose state was never
+    persisted can only fail later at the callback, so failing here keeps the
+    error next to its cause.
+    """
+    state = secrets.token_urlsafe(32)
+    now = datetime.now(UTC)
+    payload = {
       "connection_id": connection_id,
       "user_id": user_id,
       "redirect_uri": redirect_uri,
-      "created_at": datetime.now(UTC),
-      "expires_at": datetime.now(UTC) + timedelta(minutes=10),
+      "created_at": now.isoformat(),
+      "expires_at": (now + timedelta(seconds=STATE_TTL_SECONDS)).isoformat(),
     }
+
+    try:
+      client = create_redis_client(ValkeyDatabase.AUTH)
+      client.setex(cls._key(state), STATE_TTL_SECONDS, json.dumps(payload))
+    except Exception as exc:
+      logger.error(f"Failed to persist OAuth state: {exc}")
+      raise HTTPException(
+        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        detail="Unable to start the authorization flow. Please try again.",
+      ) from exc
 
     return state
 
@@ -85,31 +117,30 @@ class OAuthState:
   def validate(cls, state: str) -> dict[str, Any] | None:
     """Consume a state token, returning what it recorded, or None if invalid.
 
-    Consuming is the point: an expired or already-redeemed token is dropped so
-    the same authorization code can't be replayed.
+    Consuming is the point: an expired or already-redeemed token is gone, so
+    the same authorization code can't be replayed. Fails closed — an
+    unreachable or unparseable store reads as an invalid state rather than
+    waving the callback through.
     """
-    state_hash = hashlib.sha256(state.encode()).hexdigest()
-    state_data = cls._states.get(state_hash)
-
-    if not state_data:
+    try:
+      client = create_redis_client(ValkeyDatabase.AUTH)
+      raw = client.getdel(cls._key(state))
+    except Exception as exc:
+      logger.error(f"Failed to read OAuth state: {exc}")
       return None
 
-    if datetime.now(UTC) > state_data["expires_at"]:
-      del cls._states[state_hash]
+    if not raw:
       return None
 
-    del cls._states[state_hash]
-    return state_data
+    try:
+      payload = json.loads(raw)
+      payload["created_at"] = datetime.fromisoformat(payload["created_at"])
+      payload["expires_at"] = datetime.fromisoformat(payload["expires_at"])
+    except (ValueError, KeyError, TypeError) as exc:
+      logger.error(f"Discarding malformed OAuth state: {exc}")
+      return None
 
-  @classmethod
-  def cleanup_expired(cls):
-    """Drop states past their expiry (abandoned flows never call validate)."""
-    now = datetime.now(UTC)
-    expired_states = [
-      state_hash for state_hash, data in cls._states.items() if now > data["expires_at"]
-    ]
-    for state_hash in expired_states:
-      del cls._states[state_hash]
+    return payload
 
 
 class OAuthHandler:

--- a/robosystems/operations/providers/oauth_handler.py
+++ b/robosystems/operations/providers/oauth_handler.py
@@ -89,8 +89,13 @@ class OAuthState:
     not a human-chosen secret. A KDF exists to make low-entropy guesses
     expensive; against full entropy it buys nothing and costs latency on
     every callback. Same construction and same reasoning as
-    ``UserApiKey._fingerprint_api_key``, so CodeQL's "weak hash on
-    sensitive data" is a false positive here too.
+    ``UserApiKey._fingerprint_api_key``.
+
+    CodeQL's ``py/weak-sensitive-data-hashing`` fires here (the taint
+    source is ``secrets.token_urlsafe``) and is dismissed as a false
+    positive in code scanning — as it already was against this same call
+    at its previous line number. The marker below is for readers; the
+    dismissal is what actually silences it.
     """
     return f"{_STATE_KEY_PREFIX}{hashlib.sha256(state.encode()).hexdigest()}"  # lgtm[py/weak-sensitive-data-hashing]
 

--- a/robosystems/operations/providers/oauth_handler.py
+++ b/robosystems/operations/providers/oauth_handler.py
@@ -81,7 +81,18 @@ class OAuthState:
 
   @staticmethod
   def _key(state: str) -> str:
-    return f"{_STATE_KEY_PREFIX}{hashlib.sha256(state.encode()).hexdigest()}"
+    """Storage key for a state token: a SHA-256 of the token, never the token.
+
+    Hashing at rest means a read of the store can't replay an in-flight
+    flow. It is *not* credential storage, so the password-hashing rules
+    don't apply: the input is a 256-bit ``secrets.token_urlsafe`` value,
+    not a human-chosen secret. A KDF exists to make low-entropy guesses
+    expensive; against full entropy it buys nothing and costs latency on
+    every callback. Same construction and same reasoning as
+    ``UserApiKey._fingerprint_api_key``, so CodeQL's "weak hash on
+    sensitive data" is a false positive here too.
+    """
+    return f"{_STATE_KEY_PREFIX}{hashlib.sha256(state.encode()).hexdigest()}"  # lgtm[py/weak-sensitive-data-hashing]
 
   @classmethod
   def create(cls, connection_id: str, user_id: str, redirect_uri: str) -> str:

--- a/tests/operations/providers/test_oauth_handler.py
+++ b/tests/operations/providers/test_oauth_handler.py
@@ -8,6 +8,7 @@ import pytest
 from fastapi import HTTPException
 
 from robosystems.operations.providers.oauth_handler import (
+  STATE_TTL_SECONDS,
   OAuthHandler,
   OAuthState,
 )
@@ -52,12 +53,38 @@ class MockProvider:
     return {}
 
 
+class FakeValkey:
+  """Minimal Valkey stand-in with real TTL and GETDEL semantics.
+
+  A plain Mock would let the store's contract drift silently — single-use
+  redemption and expiry are the two properties under test, so they have to
+  actually happen here.
+  """
+
+  def __init__(self):
+    self.store: dict[str, tuple[str, float]] = {}
+    self.now = 1000.0
+
+  def setex(self, key: str, ttl_seconds: int, value: str) -> None:
+    self.store[key] = (value, self.now + ttl_seconds)
+
+  def getdel(self, key: str) -> str | None:
+    entry = self.store.pop(key, None)
+    if entry is None:
+      return None
+    value, expires_at = entry
+    return None if self.now >= expires_at else value
+
+  def advance(self, seconds: float) -> None:
+    self.now += seconds
+
+
 @pytest.fixture(autouse=True)
-def _clear_oauth_states():
-  """Clear OAuth state storage before each test."""
-  OAuthState._states.clear()
-  yield
-  OAuthState._states.clear()
+def fake_valkey():
+  """Back OAuthState with an in-test Valkey for the whole module."""
+  fake = FakeValkey()
+  with patch(f"{MODULE}.create_redis_client", return_value=fake):
+    yield fake
 
 
 @pytest.mark.unit
@@ -78,6 +105,35 @@ class TestOAuthState:
     assert data["user_id"] == "usr_1"
     assert data["redirect_uri"] == "https://example.com/callback"
 
+  def test_raw_state_is_not_the_storage_key(self, fake_valkey):
+    """The token is hashed at rest, so a store read can't replay a flow."""
+    state = OAuthState.create("conn_1", "usr_1", "https://example.com/callback")
+
+    assert state not in fake_valkey.store
+    assert len(fake_valkey.store) == 1
+
+  def test_state_survives_across_processes(self, fake_valkey):
+    """The whole point: a callback served by another task still validates.
+
+    Reloading the module gives a genuinely fresh class — the stand-in for a
+    second API task, which has none of the first one's in-process memory.
+    Only the shared store carries over. This is the assertion that fails
+    against a per-process dict, where the reloaded class starts empty and
+    every cross-task callback 400s.
+    """
+    import importlib
+
+    state = OAuthState.create("conn_1", "usr_1", "https://example.com/callback")
+
+    second_task = importlib.reload(
+      importlib.import_module("robosystems.operations.providers.oauth_handler")
+    )
+    with patch.object(second_task, "create_redis_client", return_value=fake_valkey):
+      data = second_task.OAuthState.validate(state)
+
+    assert data is not None
+    assert data["connection_id"] == "conn_1"
+
   def test_validate_one_time_use(self):
     state = OAuthState.create("conn_1", "usr_1", "https://example.com/callback")
 
@@ -92,41 +148,43 @@ class TestOAuthState:
 
     assert result is None
 
-  def test_validate_expired_state(self):
-    import hashlib
-
+  def test_validate_expired_state(self, fake_valkey):
     state = OAuthState.create("conn_1", "usr_1", "https://example.com/callback")
-    state_hash = hashlib.sha256(state.encode()).hexdigest()
 
-    # Manually expire the state
-    OAuthState._states[state_hash]["expires_at"] = datetime.now(UTC) - timedelta(
-      minutes=1
-    )
+    fake_valkey.advance(STATE_TTL_SECONDS + 1)
 
-    result = OAuthState.validate(state)
+    assert OAuthState.validate(state) is None
 
-    assert result is None
-    assert state_hash not in OAuthState._states
+  def test_abandoned_states_evict_on_ttl(self, fake_valkey):
+    """Abandoned flows expire on their own — the old dict grew forever."""
+    OAuthState.create("conn_1", "usr_1", "https://example.com/callback")
+    live = OAuthState.create("conn_2", "usr_2", "https://example.com/callback")
 
-  def test_cleanup_expired(self):
-    import hashlib
+    assert fake_valkey.store  # both persisted with a TTL...
+    for _, (_, expires_at) in fake_valkey.store.items():
+      assert expires_at == fake_valkey.now + STATE_TTL_SECONDS
 
-    # Create two states
-    state1 = OAuthState.create("conn_1", "usr_1", "https://example.com/callback")
-    state2 = OAuthState.create("conn_2", "usr_2", "https://example.com/callback")
-
-    hash1 = hashlib.sha256(state1.encode()).hexdigest()
-
-    # Expire only state1
-    OAuthState._states[hash1]["expires_at"] = datetime.now(UTC) - timedelta(minutes=1)
-
-    OAuthState.cleanup_expired()
-
-    assert hash1 not in OAuthState._states
-    # state2 should still be valid
-    data = OAuthState.validate(state2)
+    data = OAuthState.validate(live)
     assert data is not None
     assert data["connection_id"] == "conn_2"
+
+  def test_validate_fails_closed_when_store_unreachable(self):
+    """An outage must read as an invalid state, never as a pass."""
+    with patch(f"{MODULE}.create_redis_client", side_effect=RuntimeError("down")):
+      assert OAuthState.validate("any_state") is None
+
+  def test_validate_discards_malformed_payload(self, fake_valkey):
+    fake_valkey.store[OAuthState._key("s")] = ("not json", fake_valkey.now + 600)
+
+    assert OAuthState.validate("s") is None
+
+  def test_create_raises_when_store_unreachable(self):
+    """Fail at mint time, not silently three redirects later."""
+    with patch(f"{MODULE}.create_redis_client", side_effect=RuntimeError("down")):
+      with pytest.raises(HTTPException) as exc_info:
+        OAuthState.create("conn_1", "usr_1", "https://example.com/callback")
+
+    assert exc_info.value.status_code == 503
 
 
 @pytest.mark.unit
@@ -150,7 +208,7 @@ class TestOAuthHandlerAuthorizationUrl:
     assert isinstance(state, str)
 
   @patch(f"{MODULE}.env")
-  def test_rejects_redirect_uri_outside_allowlist(self, mock_env):
+  def test_rejects_redirect_uri_outside_allowlist(self, mock_env, fake_valkey):
     """A client-supplied redirect_uri outside the trusted origins is rejected
     (open-redirect / auth-code-theft guard)."""
     mock_env.get_main_cors_origins.return_value = ["https://roboledger.ai"]
@@ -163,7 +221,7 @@ class TestOAuthHandlerAuthorizationUrl:
 
     assert exc_info.value.status_code == 400
     # The flow never started — no state was persisted.
-    assert OAuthState._states == {}
+    assert fake_valkey.store == {}
 
   @patch(f"{MODULE}.env")
   def test_generates_url_with_default_redirect(self, mock_env):


### PR DESCRIPTION
## What

`OAuthState` kept in-flight authorization state in a class-level dict, so a flow only completed when the callback landed on the same API task that started it. Prod runs two tasks with no session affinity, which makes the QuickBooks connect flow a coin flip on first attempt — and the retry lands on an arbitrary task too, so retrying wasn't the reliable escape the docstring assumed.

State now lives in Valkey (`AUTH`) under a hashed key with a 10-minute TTL.

## Why it matters beyond the connect flow

- **Single-use is now atomic across tasks.** Redemption is one `GETDEL`; the previous `del` on a local dict only held within one process.
- **Abandoned flows evict themselves.** Expiry is the key's TTL. `cleanup_expired()` had no callers and the dict grew for the life of the process — removed rather than rewired.
- **Failure modes are explicit.** `create()` raises 503 if the store is unreachable, keeping the error next to its cause instead of surfacing three redirects later; `validate()` fails closed, matching the JWT revocation path.

## Not a security change

The callback route stays authenticated and still checks the caller against the user the state was minted for. The state token was — and remains — defense in depth rather than the only guard, and the old failure was closed (a miss 400s, with no fallback that waves the callback through). This is an availability and correctness fix.

## Tests

The store is backed by an in-test Valkey implementing real TTL and `GETDEL` semantics rather than a bare mock, because single-use and expiry are the two properties under test and a mock would let them drift.

The cross-task test reloads the module to get a genuinely fresh class — the stand-in for a second API task. Verified it fails against the per-process dict (which returns `None` on the second task), so it's testing the fix rather than restating it.

`tests/operations/providers/` + `tests/routers/graphs/connections/` — 230 passed. `just test-code` clean.