### PR TITLE
fix(usage): weight storage readings by time to get real GB-hours

### DIFF
--- a/robosystems/models/core/graph/graph_usage.py
+++ b/robosystems/models/core/graph/graph_usage.py
@@ -34,7 +34,7 @@ class UsageEventType(str, Enum):
   """Types of usage events we track."""
 
   # Storage events
-  STORAGE_SNAPSHOT = "storage_snapshot"  # Hourly storage measurements
+  STORAGE_SNAPSHOT = "storage_snapshot"  # Periodic storage measurements
   STORAGE_GROWTH = "storage_growth"  # Storage increase events
   STORAGE_CLEANUP = "storage_cleanup"  # Storage reduction events
 
@@ -57,6 +57,52 @@ class UsageEventType(str, Enum):
   SLOW_QUERY = "slow_query"  # Queries over threshold
   HIGH_MEMORY = "high_memory"  # Memory usage spikes
   ERROR_EVENT = "error_event"  # Error occurrences
+
+
+# A single reading stands in for the time since the one before it. Cap that
+# span so a sensor outage — or a graph deleted mid-month, whose last reading
+# would otherwise stretch to the period end — can't inflate the integral.
+# Deliberately generous relative to the snapshot cadence: this is a ceiling
+# on damage, not an encoding of the schedule.
+MAX_SNAPSHOT_WEIGHT_HOURS = 24.0
+
+
+def _integrate_gb_hours(
+  measurements: list[dict[str, Any]], period_start: datetime
+) -> tuple[float, float]:
+  """Integrate storage readings into GB-hours, returning (gb_hours, hours).
+
+  GB-hours is an integral over time, not a count of readings: each reading
+  is weighted by how long it stood. Summing the raw readings instead only
+  gives GB-hours when snapshots land exactly one hour apart, and the
+  usage-monitor sensor runs every six — which understated the figure ~6x.
+
+  Weighting off the timestamps rather than the sensor's nominal interval is
+  the point. The cadence has changed before and lives in a different module;
+  a consumer that hardcodes it is wrong the next time it moves, which is
+  precisely how this drifted.
+
+  Backward-looking on purpose: a reading is credited for the span *since*
+  the previous one, so the total never covers time nobody observed and a
+  graph stops accruing the moment snapshots stop.
+  """
+  gb_hours = 0.0
+  observed_hours = 0.0
+  previous_at = period_start
+
+  for measurement in measurements:
+    recorded_at = measurement["timestamp"]
+    if recorded_at.tzinfo is None:
+      recorded_at = recorded_at.replace(tzinfo=UTC)
+
+    span_hours = (recorded_at - previous_at).total_seconds() / 3600.0
+    span_hours = max(0.0, min(span_hours, MAX_SNAPSHOT_WEIGHT_HOURS))
+
+    gb_hours += (measurement["storage_gb"] or 0.0) * span_hours
+    observed_hours += span_hours
+    previous_at = recorded_at
+
+  return gb_hours, observed_hours
 
 
 class GraphUsage(Model):
@@ -390,15 +436,17 @@ class GraphUsage(Model):
       if record.storage_gb < graph_storage[record.graph_id]["min_storage_gb"]:
         graph_storage[record.graph_id]["min_storage_gb"] = record.storage_gb
 
+    period_start = datetime(year, month, 1, tzinfo=UTC)
+
     for graph_id, data in graph_storage.items():
       measurements = data["measurements"]
       data["measurement_count"] = len(measurements)
 
-      # Snapshots are hourly, so summing GB across measurements yields GB-hours.
-      data["total_gb_hours"] = sum(m["storage_gb"] for m in measurements)
+      gb_hours, observed_hours = _integrate_gb_hours(measurements, period_start)
+      data["total_gb_hours"] = gb_hours
 
-      if measurements:
-        data["avg_storage_gb"] = data["total_gb_hours"] / len(measurements)
+      if observed_hours > 0:
+        data["avg_storage_gb"] = gb_hours / observed_hours
 
       if data["min_storage_gb"] == float("inf"):
         data["min_storage_gb"] = 0.0

--- a/tests/models/core/graph/test_graph_usage.py
+++ b/tests/models/core/graph/test_graph_usage.py
@@ -279,8 +279,72 @@ class TestGraphUsage:
     assert graph_summary["measurement_count"] == 6  # 3 days * 2 hours
     assert graph_summary["max_storage_gb"] == 3.0
     assert graph_summary["min_storage_gb"] == 1.0
-    assert graph_summary["total_gb_hours"] == 12.0  # 1+1+2+2+3+3
-    assert graph_summary["avg_storage_gb"] == 2.0
+
+    # Snapshots are 12h apart and span 01-01 00:00 -> 01-03 12:00 (60h).
+    # Each reading is weighted by the span since the previous one, so the
+    # first (at the period start) carries no weight:
+    #   12h*1 + 12h*2 + 12h*2 + 12h*3 + 12h*3 = 132 GB-hours over 60h.
+    # This assertion previously read 12.0 ("1+1+2+2+3+3") — the raw sum of
+    # readings, which is only GB-hours if snapshots are exactly 1h apart.
+    assert graph_summary["total_gb_hours"] == 132.0
+    assert graph_summary["avg_storage_gb"] == pytest.approx(2.2)
+
+  def test_gb_hours_is_independent_of_snapshot_cadence(self):
+    """The same storage held for the same time bills the same either way.
+
+    This is the property the raw-sum version could not have: it scaled the
+    answer with how often the sensor happened to run. Two graphs hold 2 GB
+    across the same 24h window, sampled hourly vs every six hours.
+    """
+    for hour in range(0, 25):  # hourly
+      self.session.add(self._snapshot("graph_hourly", hour, 2.0))
+    for hour in range(0, 25, 6):  # every 6h
+      self.session.add(self._snapshot("graph_six_hourly", hour, 2.0))
+    self.session.commit()
+
+    hourly = GraphUsage.get_monthly_storage_summary(
+      graph_id="graph_hourly", year=2024, month=2, session=self.session
+    )["graph_hourly"]
+    six_hourly = GraphUsage.get_monthly_storage_summary(
+      graph_id="graph_six_hourly", year=2024, month=2, session=self.session
+    )["graph_six_hourly"]
+
+    assert hourly["total_gb_hours"] == pytest.approx(48.0)  # 2 GB * 24h
+    assert six_hourly["total_gb_hours"] == pytest.approx(48.0)
+    assert hourly["measurement_count"] != six_hourly["measurement_count"]
+
+  def test_gb_hours_caps_the_span_a_stale_reading_covers(self):
+    """A sensor outage must not let one reading bill for the whole gap."""
+    from robosystems.models.core.graph.graph_usage import MAX_SNAPSHOT_WEIGHT_HOURS
+
+    self.session.add(self._snapshot("graph_gap", 0, 1.0))
+    # Next reading lands 10 days later — the sensor was down in between.
+    self.session.add(self._snapshot("graph_gap", 0, 1.0, day=11))
+    self.session.commit()
+
+    summary = GraphUsage.get_monthly_storage_summary(
+      graph_id="graph_gap", year=2024, month=2, session=self.session
+    )["graph_gap"]
+
+    # Uncapped this would be 1 GB * 240h; the cap holds it to one span.
+    assert summary["total_gb_hours"] == pytest.approx(MAX_SNAPSHOT_WEIGHT_HOURS)
+
+  def _snapshot(self, graph_id: str, hour: int, storage_gb: float, day: int = 1):
+    """A storage snapshot in Feb 2024, `hour` hours after the period start."""
+    recorded_at = datetime(2024, 2, day, 0, 0, 0, tzinfo=UTC) + timedelta(hours=hour)
+    return GraphUsage(
+      user_id=self.test_user_id,
+      graph_id=graph_id,
+      event_type=UsageEventType.STORAGE_SNAPSHOT.value,
+      graph_tier="standard",
+      storage_bytes=int(storage_gb * 1024**3),
+      storage_gb=storage_gb,
+      billing_year=2024,
+      billing_month=2,
+      billing_day=recorded_at.day,
+      billing_hour=recorded_at.hour,
+      recorded_at=recorded_at,
+    )
 
   def test_get_monthly_storage_summary_no_data(self):
     """Test getting monthly storage summary with no data."""


### PR DESCRIPTION
## What

`get_monthly_storage_summary` summed raw storage readings and called the result GB-hours, on the strength of a comment asserting *"snapshots are hourly."* The usage-monitor sensor runs every **six** hours (`minimum_interval_seconds=21600`), so the figure rendered on `/usage` — and labelled "Total GB-hours for billing" — has been understating by roughly 6× since P3 started writing snapshot rows.

GB-hours is an integral, so it's now computed as one: each reading is weighted by the span since the previous reading, derived from the timestamps.

## Why derive the weight instead of multiplying by 6

Multiplying by the known cadence would fix today's number and re-arm the same trap. The cadence lives in a different module and has moved before; a consumer that hardcodes it is wrong the next time it moves — which is exactly how this drifted. Weighting off the data is correct at any cadence, including a mid-month change.

Two properties worth calling out:

- **Backward-looking.** A reading is credited for the span *since* the previous one, so the total never covers time nobody observed, and a graph stops accruing the moment snapshots stop.
- **Capped span** (`MAX_SNAPSHOT_WEIGHT_HOURS`). A sensor outage — or a graph deleted mid-month — can't let one stale reading bill for the whole gap. The cap is a ceiling on damage, not an encoding of the schedule.

`avg_storage_gb` becomes time-weighted for consistency. It was `total/count`, accidentally right only because `total` was a plain sum; with evenly spaced snapshots the two agree.

## Tests

The existing test asserted the defect directly — `total_gb_hours == 12.0`, commented `# 1+1+2+2+3+3`. Corrected rather than kept, with the arithmetic explained inline.

Added the test the old version could not have passed: the same storage held for the same duration integrates identically whether sampled hourly or six-hourly. Against the raw sum that's 50 vs 10, so it genuinely catches the regression. Also covered the outage cap.

`tests/models/core/`, `tests/routers/graphs/test_usage.py`, `tests/operations/graph/` — 1213 passed. `just test-code` clean.

## Deliberately not fixed here

`pricing_service._calculate_usage_metrics` carries the same raw-sum shape, but it reads `record.size_gb` and `record.query_count` and **neither column exists** on `GraphUsage` — it would `AttributeError` on the first real record, and `GraphPricingService` has no callers outside its own re-exports. Its tests pass only because they build `MagicMock` records with those attributes set by hand.

That's dead code with a fictional test rather than a live twin of this bug, so whether to delete it is a separate decision.