### PR TITLE
fix(rules): validate rule expressions against the grammar that evaluates them

### DIFF
--- a/robosystems/operations/information_block/rules/expressions.py
+++ b/robosystems/operations/information_block/rules/expressions.py
@@ -134,6 +134,29 @@ def _validate(node: ast.AST) -> None:
       raise InvalidRuleExpression(f"disallowed AST node: {type(child).__name__}")
 
 
+def require_single_equality(
+  body: ast.expr, what: str = "equality pattern"
+) -> ast.Compare:
+  """Return ``body`` as a single ``LHS = RHS`` comparison, or raise.
+
+  The whitelist walker permits ``ast.Compare`` and ``ast.Eq`` without
+  bounding how many of each, so ``$A = $B = $C`` is structurally legal
+  while every consumer here requires exactly one operator. This was
+  open-coded in four places — parse, equality evaluation, derivation
+  evaluation, and LHS extraction — which is why the parser never grew the
+  check the other three all assumed. ``what`` keeps each caller's wording.
+  """
+  if (
+    not isinstance(body, ast.Compare)
+    or len(body.ops) != 1
+    or not isinstance(body.ops[0], ast.Eq)
+  ):
+    raise InvalidRuleExpression(
+      f"{what} expects a single LHS = RHS expression, got: {ast.dump(body)}"
+    )
+  return body
+
+
 def _normalize_equality(expr: str) -> str:
   """Replace bare ``=`` with ``==`` for Python's parser.
 
@@ -154,6 +177,14 @@ def parse_arithmetic_expression(
   2. Normalizes bare ``=`` to ``==`` (XBRL-style equality).
   3. Parses with ``ast.parse(mode='eval')``.
   4. Walks the tree and rejects any node outside the allowed whitelist.
+  5. Dry-runs the evaluator to reject anything it could not evaluate.
+
+  Step 5 is what keeps authoring and evaluation from describing different
+  grammars. The whitelist is structural — it exists to keep ``Call``,
+  ``Subscript`` and friends out — and is deliberately coarser than the
+  evaluator: it admits any ``ast.Constant`` and any number of ``Eq``
+  operators. Anything in that gap used to save cleanly and then raise on
+  every evaluation for the life of the rule.
 
   Raises :class:`InvalidRuleExpression` for unbound variables, syntax
   errors, or disallowed constructs.
@@ -171,17 +202,37 @@ def parse_arithmetic_expression(
   except SyntaxError as exc:
     raise InvalidRuleExpression(f"syntax error in expression {expr!r}: {exc}") from exc
   _validate(tree)
+  compare = require_single_equality(tree.body)
+  _eval_arith(compare.left, {}, shape_only=True)
+  _eval_arith(compare.comparators[0], {}, shape_only=True)
   return ParsedExpression(tree=tree, variable_names=variable_names)
 
 
-def _eval_arith(node: ast.expr, values: dict[str, float]) -> float:
-  """Recursively evaluate an arithmetic AST node to a float."""
+def _eval_arith(
+  node: ast.expr, values: dict[str, float], *, shape_only: bool = False
+) -> float:
+  """Recursively evaluate an arithmetic AST node to a float.
+
+  With ``shape_only``, variables resolve to a placeholder instead of a
+  bound value, so the walk checks only whether the tree is *evaluable*.
+  That is how :func:`parse_arithmetic_expression` validates at authoring
+  time — by running this function rather than by maintaining a second
+  description of the same grammar. The two used to be separate, and every
+  shape one accepted and the other rejected produced a rule that saved
+  cleanly and then raised on every evaluation, forever.
+  """
   if isinstance(node, ast.Constant):
-    if not isinstance(node.value, (int, float)):
+    # bool first: isinstance(True, int) is True in Python, so without this
+    # `$Assets = True` passes the numeric check and silently evaluates as 1.0.
+    if isinstance(node.value, bool) or not isinstance(node.value, (int, float)):
       raise InvalidRuleExpression(f"non-numeric constant: {node.value!r}")
     return float(node.value)
   if isinstance(node, ast.Name):
     key = node.id
+    if shape_only:
+      # Not 0.0 — that would trip the division guard below on a tree whose
+      # only fault is that we haven't bound values yet.
+      return 1.0
     if key not in values:
       raise InvalidRuleExpression(f"unbound name in expression: {key!r}")
     val = values[key]
@@ -189,10 +240,10 @@ def _eval_arith(node: ast.expr, values: dict[str, float]) -> float:
       raise InvalidRuleExpression(f"null value for variable {key!r}")
     return float(val)
   if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub):
-    return -_eval_arith(node.operand, values)
+    return -_eval_arith(node.operand, values, shape_only=shape_only)
   if isinstance(node, ast.BinOp):
-    lhs = _eval_arith(node.left, values)
-    rhs = _eval_arith(node.right, values)
+    lhs = _eval_arith(node.left, values, shape_only=shape_only)
+    rhs = _eval_arith(node.right, values, shape_only=shape_only)
     if isinstance(node.op, ast.Add):
       return lhs + rhs
     if isinstance(node.op, ast.Sub):
@@ -220,16 +271,7 @@ def evaluate_equality(
   The ``tolerance`` parameter defaults to :data:`EQUALITY_TOLERANCE`
   (``0.01``); callers can pass a rule-specific override.
   """
-  compare = parsed.tree.body
-  if (
-    not isinstance(compare, ast.Compare)
-    or len(compare.ops) != 1
-    or not isinstance(compare.ops[0], ast.Eq)
-  ):
-    raise InvalidRuleExpression(
-      f"equality pattern expects a single LHS = RHS expression, got: "
-      f"{ast.dump(compare)}"
-    )
+  compare = require_single_equality(parsed.tree.body)
   mapped: dict[str, float] = {}
   for name in parsed.variable_names:
     if name not in values:
@@ -261,16 +303,7 @@ def lhs_variable_names(parsed: ParsedExpression) -> list[str]:
   (which must have a bound fact) from the RHS children (a missing child
   is treated as 0, matching the renderer's sum-of-present-children).
   """
-  body = parsed.tree.body
-  if (
-    not isinstance(body, ast.Compare)
-    or len(body.ops) != 1
-    or not isinstance(body.ops[0], ast.Eq)
-  ):
-    raise InvalidRuleExpression(
-      f"expected a single LHS = RHS expression, got: {ast.dump(body)}"
-    )
-  return variable_names_in(body.left)
+  return variable_names_in(require_single_equality(parsed.tree.body).left)
 
 
 def evaluate_arithmetic(parsed: ParsedExpression, values: dict[str, float]) -> float:
@@ -294,15 +327,7 @@ def evaluate_derivation(parsed: ParsedExpression, values: dict[str, float]) -> f
   :class:`InvalidRuleExpression` for a non-equality expression, a missing
   or null operand, or division by zero.
   """
-  compare = parsed.tree.body
-  if (
-    not isinstance(compare, ast.Compare)
-    or len(compare.ops) != 1
-    or not isinstance(compare.ops[0], ast.Eq)
-  ):
-    raise InvalidRuleExpression(
-      f"derivation expects a single LHS = RHS expression, got: {ast.dump(compare)}"
-    )
+  compare = require_single_equality(parsed.tree.body, "derivation")
   mapped = {f"_var_{name}": value for name, value in values.items()}
   return _eval_arith(compare.comparators[0], mapped)
 

--- a/tests/operations/information_block/rules/test_expressions.py
+++ b/tests/operations/information_block/rules/test_expressions.py
@@ -27,9 +27,31 @@ class TestLhsVariableNames:
     assert lhs_variable_names(parsed) == ["Assets"]
 
   def test_raises_when_not_an_equality(self) -> None:
-    parsed = parse_arithmetic_expression("$A + $B", ["A", "B"])
+    """A non-equality body is now refused at the gate, not here.
+
+    This used to parse and then raise on LHS extraction. The parser
+    enforces the same contract, so the tree can no longer be built —
+    which is the point of the change, not a gap in this test.
+    """
     with pytest.raises(InvalidRuleExpression):
-      lhs_variable_names(parsed)
+      parse_arithmetic_expression("$A + $B", ["A", "B"])
+
+  def test_require_single_equality_guards_a_handbuilt_tree(self) -> None:
+    """The function keeps its own guard for trees not built by the parser."""
+    import ast
+
+    from robosystems.operations.information_block.rules.expressions import (
+      ParsedExpression,
+      require_single_equality,
+    )
+
+    handbuilt = ParsedExpression(
+      tree=ast.parse("_var_A + _var_B", mode="eval"), variable_names=["A", "B"]
+    )
+    with pytest.raises(InvalidRuleExpression):
+      lhs_variable_names(handbuilt)
+    with pytest.raises(InvalidRuleExpression):
+      require_single_equality(handbuilt.tree.body)
 
 
 class TestParseArithmeticExpression:
@@ -66,10 +88,41 @@ class TestParseArithmeticExpression:
     with pytest.raises(InvalidRuleExpression, match="disallowed"):
       parse_arithmetic_expression("$A[0] = $B", ["A", "B"])
 
+  @pytest.mark.parametrize(
+    ("label", "expression", "names"),
+    [
+      ("string constant", '$Assets = "hello"', ["Assets"]),
+      ("none constant", "$Assets = None", ["Assets"]),
+      ("bool constant", "$Assets = True", ["Assets"]),
+      ("chained equality", "$Assets = $L = $E", ["Assets", "L", "E"]),
+    ],
+  )
+  def test_rejects_what_the_evaluator_cannot_evaluate(
+    self, label: str, expression: str, names: list[str]
+  ) -> None:
+    """Authoring must refuse anything evaluation would refuse.
+
+    Each of these passed the structural whitelist and then failed at
+    evaluation, so the rule saved cleanly and raised on every run for the
+    life of the rule. The bool case was worse: isinstance(True, int) is
+    True, so it evaluated silently as 1.0 rather than failing at all.
+    """
+    with pytest.raises(InvalidRuleExpression):
+      parse_arithmetic_expression(expression, names)
+
   def test_nested_arithmetic_parses(self) -> None:
     parsed = parse_arithmetic_expression(
       "$Total = ($A + $B + $C - $D)", ["Total", "A", "B", "C", "D"]
     )
+    assert parsed is not None
+
+  def test_shape_check_does_not_reject_a_valid_division(self) -> None:
+    """The dry-run binds a non-zero placeholder, or every ratio would 400.
+
+    Guards the obvious way to get the parse-time check wrong: binding 0.0
+    would trip the evaluator's division-by-zero guard on a sound rule.
+    """
+    parsed = parse_arithmetic_expression("$Ratio = $A / $B", ["Ratio", "A", "B"])
     assert parsed is not None
 
   def test_empty_variable_list_with_no_dollar_signs(self) -> None:
@@ -114,9 +167,22 @@ class TestEvaluateEquality:
     assert passed is True
 
   def test_raises_on_non_equality_expression(self) -> None:
-    parsed = parse_arithmetic_expression("$A + $B", ["A", "B"])
+    """Kept as the evaluator's own guard, on a tree the parser won't build.
+
+    The parser now rejects a non-equality body up front, so this can only
+    be reached by handing evaluate_equality a tree from somewhere else.
+    """
+    import ast
+
+    from robosystems.operations.information_block.rules.expressions import (
+      ParsedExpression,
+    )
+
+    handbuilt = ParsedExpression(
+      tree=ast.parse("_var_A + _var_B", mode="eval"), variable_names=["A", "B"]
+    )
     with pytest.raises(InvalidRuleExpression, match="equality pattern"):
-      evaluate_equality(parsed, {"A": 1.0, "B": 2.0})
+      evaluate_equality(handbuilt, {"A": 1.0, "B": 2.0})
 
   def test_unary_negation(self) -> None:
     parsed = parse_arithmetic_expression("$A = -$B", ["A", "B"])
@@ -210,9 +276,22 @@ class TestEvaluateDerivation:
       evaluate_derivation(parsed, {"A": 1.0})
 
   def test_non_equality_expression_raises(self) -> None:
-    parsed = parse_arithmetic_expression("$A + $B", ["A", "B"])
+    """The derivation guard survives the collapse, wording included.
+
+    Reachable only via a tree the parser didn't build, now that parsing
+    enforces the same contract.
+    """
+    import ast
+
+    from robosystems.operations.information_block.rules.expressions import (
+      ParsedExpression,
+    )
+
+    handbuilt = ParsedExpression(
+      tree=ast.parse("_var_A + _var_B", mode="eval"), variable_names=["A", "B"]
+    )
     with pytest.raises(InvalidRuleExpression, match="derivation expects"):
-      evaluate_derivation(parsed, {"A": 1.0, "B": 2.0})
+      evaluate_derivation(handbuilt, {"A": 1.0, "B": 2.0})
 
 
 class TestDesugarAggregates:


### PR DESCRIPTION
## What

Authoring and evaluation described the same grammar twice, and disagreed. The structural whitelist (`_ALLOWED_NODES`) exists to keep `Call`, `Subscript` and friends out, and is deliberately coarse — it admits any `ast.Constant` and any number of `Eq` operators. The evaluator is narrower. Everything in that gap saved cleanly and then raised on every evaluation for the life of the rule:

| Expression | Before |
|---|---|
| `$Assets = "hello"` | persisted, raised forever |
| `$Assets = None` | persisted, raised forever |
| `$Assets = $L = $E` | persisted, raised forever |
| `$Assets = True` | **persisted and evaluated as `1.0`, silently** |

The bool case wasn't previously recorded and is the worst of the four: `isinstance(True, int)` is `True` in Python, so it sailed through the numeric check and produced a *wrong answer* rather than an error.

## Approach

Restating the evaluator's rules inside the validator is the thing that drifted, so parsing now **dry-runs the evaluator itself**. `_eval_arith` gains a `shape_only` mode that binds a placeholder for variables, so authoring rejects exactly what evaluation would reject, by construction rather than by agreement.

The placeholder is `1.0` rather than `0.0` — binding zero would trip the evaluator's division-by-zero guard on a sound ratio rule. There's a test pinning that.

## Incidental find

The single-equality check was open-coded in **four** places: `evaluate_equality`, `evaluate_derivation`, `lhs_variable_names` — and absent from `parse_arithmetic_expression`, which is the bug. Three copies agreeing and one missing is how the gap survived. Collapsed into `require_single_equality`, with a parameter that preserves each caller's error wording.

## Compatibility

No caller is affected by the stricter parse. All seven call sites already invoked `lhs_variable_names` or `evaluate_equality` immediately afterward, both of which required an equality body — the contract was universal, just enforced three steps too late. `validators.py` (the authoring gate) now reports `unparseable_expression` where it previously let the rule save.

Three existing tests reached a downstream guard by building a non-equality tree *through the parser*; that route no longer exists, so they construct the tree directly and keep testing the guard they were written for.

## Tests

Full suite: **12,347 passed**, `just test-all` clean. Added a parametrized case per divergence, plus the division placeholder guard.