### PR TITLE
chore: drop the non-functional lgtm suppression markers

### DIFF
--- a/robosystems/models/core/user/user_api_key.py
+++ b/robosystems/models/core/user/user_api_key.py
@@ -301,12 +301,11 @@ class UserAPIKey(Model):
     ``key_hash`` (see ``_hash_api_key`` below). This SHA-256 is solely a
     deterministic lookup fingerprint so the cache key derived from the
     plaintext (``sha256(plain_key)``) matches what ``_invalidate_cache``
-    reads off the row. CodeQL's "weak hash on sensitive data" rule is a
-    false positive here — silenced via lgtm[py/weak-sensitive-data-hashing].
+    reads off the row. A KDF would be the wrong tool: those exist to make
+    low-entropy human secrets expensive to guess, and an API key is
+    generated at full entropy.
     """
-    return hashlib.sha256(  # lgtm[py/weak-sensitive-data-hashing]
-      plain_key.encode("utf-8")
-    ).hexdigest()
+    return hashlib.sha256(plain_key.encode("utf-8")).hexdigest()
 
   @staticmethod
   def _hash_api_key(plain_key: str) -> str:

--- a/robosystems/operations/providers/oauth_handler.py
+++ b/robosystems/operations/providers/oauth_handler.py
@@ -84,20 +84,11 @@ class OAuthState:
     """Storage key for a state token: a SHA-256 of the token, never the token.
 
     Hashing at rest means a read of the store can't replay an in-flight
-    flow. It is *not* credential storage, so the password-hashing rules
-    don't apply: the input is a 256-bit ``secrets.token_urlsafe`` value,
-    not a human-chosen secret. A KDF exists to make low-entropy guesses
-    expensive; against full entropy it buys nothing and costs latency on
-    every callback. Same construction and same reasoning as
-    ``UserApiKey._fingerprint_api_key``.
-
-    CodeQL's ``py/weak-sensitive-data-hashing`` fires here (the taint
-    source is ``secrets.token_urlsafe``) and is dismissed as a false
-    positive in code scanning — as it already was against this same call
-    at its previous line number. The marker below is for readers; the
-    dismissal is what actually silences it.
+    flow. A KDF would be the wrong tool here for the same reason as in
+    ``UserApiKey._fingerprint_api_key``: the input is a 256-bit
+    ``secrets.token_urlsafe`` value, not a human-chosen secret.
     """
-    return f"{_STATE_KEY_PREFIX}{hashlib.sha256(state.encode()).hexdigest()}"  # lgtm[py/weak-sensitive-data-hashing]
+    return f"{_STATE_KEY_PREFIX}{hashlib.sha256(state.encode()).hexdigest()}"
 
   @classmethod
   def create(cls, connection_id: str, user_id: str, redirect_uri: str) -> str:


### PR DESCRIPTION
## What

The `# lgtm[py/weak-sensitive-data-hashing]` markers suppress nothing. They were an LGTM.com feature and have done nothing since that service retired — CodeQL code scanning ignores them. The alerts they appear to handle are silenced by **dismissal in code scanning**, which is how all nine instances of this rule have actually been resolved.

That made the comment worse than absent. `user_api_key.py` stated the alert was *"silenced via lgtm[py/weak-sensitive-data-hashing]"*, which reads as the code handling it and sends a reader looking for a mechanism that isn't there. Found while resolving the same alert on #1094.

## What's kept

The surrounding prose, trimmed to the part that earns its place: why a KDF is the wrong tool for a full-entropy token, and — in `user_api_key.py` — the distinction from the bcrypt `key_hash` sitting right below it. Both are design rationale a reader genuinely needs.

Dropped the narration of what CodeQL does about it. That couples source to a scanner's heuristics, it belongs on the dismissal (where it now is), and it's exactly the sort of comment that goes stale without anyone noticing.

## What's deliberately not here

I initially added explanatory comments to the four other sites that carry dismissed alerts with no in-code rationale (`auth/utils.py` ×2, `rate_limits/rate_limiting.py` ×2) and backed them out. `cache_key = sha256(api_key)` explains itself; annotating self-evident lines with scanner trivia is the noise this repo's comment standard exists to prevent.

Net **−18 / +8** across two files, no new comments anywhere.

## Worth knowing

Dismissals are **location-bound** — the #1094 alert had already been dismissed against that same call and re-raised only because the line moved. So this rule will keep resurfacing on unrelated refactors. If it becomes a recurring tax, the durable fix is a repo-level `.github/codeql/codeql-config.yml` query filter, which is a deliberate decision rather than a reaction to the next moved line.

`just test-code` clean; 414 tests pass across `models/core/user`, `operations/providers`, `middleware/auth`.