### PR TITLE
fix(query): read the queued operation id off the response dict

### DIFF
--- a/robosystems/routers/graphs/mcp/execute.py
+++ b/robosystems/routers/graphs/mcp/execute.py
@@ -769,6 +769,8 @@ async def call_mcp_tool(
             graph_id=graph_id,
           )
 
+          operation_id = sse_response["operation_id"]
+
           if strategy == MCPExecutionStrategy.QUEUE_WITH_MONITORING:
 
             async def monitor_queue():
@@ -797,8 +799,8 @@ async def call_mcp_tool(
               status_code=http_status.HTTP_202_ACCEPTED,
               content={
                 "queued": True,
-                "operation_id": sse_response.operation_id,  # Unified SSE operation ID
-                "monitor_url": f"/v1/operations/{sse_response.operation_id}/stream",  # Unified monitoring only
+                "operation_id": operation_id,
+                "monitor_url": sse_response["_links"]["stream"],
                 "message": "Tool execution queued. Monitor via SSE endpoint.",
               },
             )

--- a/robosystems/routers/graphs/query/execute.py
+++ b/robosystems/routers/graphs/query/execute.py
@@ -331,7 +331,7 @@ async def execute_cypher_query(
         current_user=current_user,
         priority=_get_user_priority(current_user),
         chunk_size=chunk_size,
-        operation_id=sse_response.operation_id,  # Pass operation_id for unified events
+        operation_id=sse_response["operation_id"],
       )
 
     elif strategy == ExecutionStrategy.SSE_STREAMING:

--- a/tests/routers/graphs/mcp/test_mcp_execute.py
+++ b/tests/routers/graphs/mcp/test_mcp_execute.py
@@ -310,6 +310,79 @@ class TestCallMcpToolValidation:
       assert exc_info.value.status_code == 403
       assert "not allowed" in exc_info.value.detail.lower()
 
+  @pytest.mark.asyncio
+  async def test_queue_simple_returns_202_with_operation_id(self):
+    """The QUEUE_SIMPLE branch answers 202 with the queued operation's id.
+
+    Regression: this branch read ``sse_response.operation_id`` while
+    ``create_operation_response`` returns a plain ``dict``, so the caller got an
+    AttributeError-driven 500 *after* ``submit_query`` had already enqueued the
+    work. The strategy-selection test above proves we reach this branch; only
+    this one proves the branch answers.
+
+    Reached by a non-MCP, non-SSE client (plain SDK/curl) calling a cypher read
+    tool while the queue is deep — see ``_select_high_load_strategy``.
+    """
+    from robosystems.routers.graphs.mcp.execute import call_mcp_tool
+
+    mock_request = Mock()
+    mock_request.headers = {
+      "user-agent": "python-httpx/0.27",
+      "accept": "application/json",
+    }
+    user = _make_mock_user()
+    tool_call = _make_mock_tool_call(
+      "read-graph-cypher", {"query": "MATCH (n) RETURN n"}
+    )
+
+    queue = Mock()
+    # Over the high-load thresholds (queue_size > 10 or running_queries > 5).
+    queue.get_stats = Mock(return_value={"queue_size": 20, "running_queries": 10})
+    queue.submit_query = AsyncMock(return_value="queue-abc")
+
+    operation_response = {
+      "operation_id": "op-xyz",
+      "status": "pending",
+      "_links": {"stream": "/v1/operations/op-xyz/stream"},
+    }
+
+    with (
+      patch("robosystems.routers.graphs.mcp.execute.record_operation_metric"),
+      patch("robosystems.routers.graphs.mcp.execute.circuit_breaker"),
+      patch("robosystems.routers.graphs.mcp.execute.log_shared_query_start"),
+      patch("robosystems.routers.graphs.mcp.execute.record_shared_query_outcome"),
+      patch(
+        "robosystems.routers.graphs.mcp.execute.get_query_queue", return_value=queue
+      ),
+      patch(
+        "robosystems.routers.graphs.mcp.execute.get_graph_repository", new=AsyncMock()
+      ),
+      patch("robosystems.models.core.GraphUser.user_has_access", return_value=True),
+      patch("robosystems.routers.graphs.mcp.execute.MCPHandler") as handler_cls,
+      patch(
+        "robosystems.routers.graphs.mcp.execute.create_operation_response",
+        new=AsyncMock(return_value=operation_response),
+      ),
+    ):
+      handler_cls.return_value.close = AsyncMock()
+
+      response = await call_mcp_tool(
+        full_request=mock_request,
+        graph_id="kg01234567890abcdef",
+        tool_call=tool_call,
+        format=None,
+        test_mode=False,
+        current_user=user,
+        _rate_limit=None,
+      )
+
+    assert response.status_code == 202
+    body = json.loads(response.body)
+    assert body["queued"] is True
+    assert body["operation_id"] == "op-xyz"
+    assert body["monitor_url"] == "/v1/operations/op-xyz/stream"
+    queue.submit_query.assert_awaited_once()
+
   def test_non_cypher_tool_not_in_cypher_tool_list(self):
     """Test that non-cypher tools are not in the cypher validation tool list.
 


### PR DESCRIPTION
## Summary

Two queued-execution paths built their response from `sse_response.operation_id`, but `create_operation_response` returns a plain `dict`. The attribute access raised *after* the work had already been enqueued, so the caller got a 500 and lost the handle to a query that was still going to run. Both now read the id by key.

The second instance was found by temporarily enabling `reportAttributeAccessIssue` locally and sweeping for the same shape — it is a genuine live defect, not a cleanup.

## Changes

**`routers/graphs/mcp/execute.py`** — the `QUEUE_SIMPLE` branch of the REST call-tool endpoint. Reads `sse_response["operation_id"]`, and takes `monitor_url` from the response's own `_links["stream"]` rather than rebuilding the same path in an f-string, so the URL has a single source.

Scope worth noting for review: only this branch was affected. `QUEUE_WITH_MONITORING` never touches `sse_response`, and the remote MCP transport bridges queue strategies through a held stream, so connector traffic never reached this code. Reaching it needs a non-MCP, non-SSE client (plain SDK/curl) on a cypher read tool while the queue is deep — `queue_size > 10` or `running_queries > 5` — which is why it went unnoticed.

**`routers/graphs/query/execute.py`** — the `SSE_QUEUE_STREAM` branch passed `sse_response.operation_id` into `stream_sse_with_queue`. The same file already subscripts the same helper correctly a few hundred lines down (lines ~703-723), so this was an inconsistency within one module.

This one is the more reachable of the two: `needs_queue` triggers on `queue_size > 0` (`query/strategies.py:194`), so any SSE-capable client on `/v1/graphs/{graph_id}/query` hits it as soon as the queue is non-empty — no deep queue required.

**`tests/routers/graphs/mcp/test_mcp_execute.py`** — regression test driving the `QUEUE_SIMPLE` branch to its 202, asserting `operation_id`, `monitor_url`, and that the query was actually submitted.

The coverage gap is the interesting part for reviewers: the existing test asserted that the strategy selector *picks* `QUEUE_SIMPLE` and stopped there — proving we reach the broken branch without ever proving it answers. The new test was verified to fail against the pre-fix code (`'dict' object has no attribute 'operation_id'`, surfacing as a 500 through the generic handler), not merely to pass against the fix.

## Breaking Changes

None. Both endpoints previously 500'd on these paths, so there is no working behavior to preserve — the response shapes are unchanged and no SDK regen is needed.

## Testing

- `uv run pytest tests/routers/graphs/mcp/` — 165 passed
- `uv run pytest tests/routers/graphs/query/` — 16 passed
- `just test-code` (ruff + format + basedpyright + cf-lint) — all checks passed
- Regression test verified in both directions: fails without the fix, passes with it

Full `just test-all` not run this session; the two affected router modules and the code-quality gate were.

## Follow-up, not in this PR

`reportAttributeAccessIssue = "none"` in `pyproject.toml` is why neither defect was caught by the type gate. Enabling it repo-wide surfaces 497 findings, but ~232 are SQLAlchemy `Column[...]` assignment friction concentrated in `operations/` — `routers/` and `middleware/` together account for only 73. A scoped enable via pyright `executionEnvironments` over those two trees looks like the cheap version of this check; worth its own change.
