### PR TITLE
feat(admin): expose user deactivate/activate

### DIFF
--- a/robosystems/admin/commands/users_orgs.py
+++ b/robosystems/admin/commands/users_orgs.py
@@ -142,6 +142,70 @@ def user_activity(client, user_id):
       console.print(f"  {login['timestamp'][:19]} ({login['type']})")
 
 
+def _resolve_user_id(client, identifier):
+  """Accept an email or a user ID and return the user ID."""
+  if "@" not in identifier:
+    return identifier
+
+  matches = client._make_request(
+    "GET", "/admin/v1/users", params={"email": identifier, "limit": 10}
+  )
+  exact = [u for u in matches or [] if u["email"].lower() == identifier.lower()]
+  if not exact:
+    console.print(f"\n[red]No user found with email {identifier}[/red]")
+    raise SystemExit(1)
+  return exact[0]["id"]
+
+
+@users.command("deactivate")
+@click.argument("identifier")
+@click.option("--yes", is_flag=True, help="Skip the confirmation prompt")
+@click.pass_obj
+def deactivate_user(client, identifier, yes):
+  """Deactivate a user by email or ID, cutting off all access.
+
+  Invalidates every session and revokes every API key — the escalation above a
+  password change, which rotates the credential but leaves keys working so
+  routine rotation doesn't break integrations. Use this for a compromised or
+  suspended account. Reactivating does not restore the revoked keys.
+  """
+  user_id = _resolve_user_id(client, identifier)
+
+  if not yes:
+    click.confirm(
+      f"\nDeactivate {identifier}? This ends all sessions and revokes all API keys.",
+      abort=True,
+      default=False,
+    )
+
+  result = client._make_request("POST", f"/admin/v1/users/{user_id}/deactivate")
+
+  console.print(f"\n[green]Deactivated {result['email']}[/green]")
+  console.print(f"  API keys revoked: {result['api_keys_revoked']}")
+  console.print("  All sessions invalidated.")
+  if not result["changed"]:
+    console.print("[yellow]  (was already inactive — re-ran the revocation)[/yellow]")
+
+
+@users.command("activate")
+@click.argument("identifier")
+@click.pass_obj
+def activate_user(client, identifier):
+  """Reactivate a deactivated user by email or ID.
+
+  Restores sign-in only. Revoked API keys are not reinstated — the user must
+  issue new ones.
+  """
+  user_id = _resolve_user_id(client, identifier)
+  result = client._make_request("POST", f"/admin/v1/users/{user_id}/activate")
+
+  console.print(f"\n[green]Activated {result['email']}[/green]")
+  if result["changed"]:
+    console.print("  They can sign in again; API keys must be re-issued.")
+  else:
+    console.print("[yellow]  (was already active — nothing changed)[/yellow]")
+
+
 @users.command("delete")
 @click.argument("identifier")
 @click.option(
@@ -155,16 +219,7 @@ def delete_user(client, identifier, dry_run, yes):
   Refuses while the user's org still has live graphs, subscriptions in force,
   or active repository access. Billing and audit history is retained.
   """
-  user_id = identifier
-  if "@" in identifier:
-    matches = client._make_request(
-      "GET", "/admin/v1/users", params={"email": identifier, "limit": 10}
-    )
-    exact = [u for u in matches or [] if u["email"].lower() == identifier.lower()]
-    if not exact:
-      console.print(f"\n[red]No user found with email {identifier}[/red]")
-      raise SystemExit(1)
-    user_id = exact[0]["id"]
+  user_id = _resolve_user_id(client, identifier)
 
   assessment = client._make_request(
     "DELETE", f"/admin/v1/users/{user_id}", params={"dry_run": True}

--- a/robosystems/models/api/admin/__init__.py
+++ b/robosystems/models/api/admin/__init__.py
@@ -40,6 +40,7 @@ from .users import (
   UserGraphAccessResponse,
   UserRepositoryAccessResponse,
   UserResponse,
+  UserStatusResponse,
 )
 
 __all__ = [
@@ -78,4 +79,5 @@ __all__ = [
   "UserGraphAccessResponse",
   "UserRepositoryAccessResponse",
   "UserResponse",
+  "UserStatusResponse",
 ]

--- a/robosystems/models/api/admin/users.py
+++ b/robosystems/models/api/admin/users.py
@@ -72,6 +72,16 @@ class UserDeletionResponse(BaseModel):
   orgs_retained: list[str]
 
 
+class UserStatusResponse(BaseModel):
+  """Result of activating or deactivating a user."""
+
+  user_id: str
+  email: str
+  is_active: bool
+  changed: bool
+  api_keys_revoked: int
+
+
 class UserActivityResponse(BaseModel):
   """Response with user's recent activity."""
 

--- a/robosystems/operations/admin/__init__.py
+++ b/robosystems/operations/admin/__init__.py
@@ -8,12 +8,15 @@ from .user_deletion import (
   execute_user_deletion,
   plan_user_deletion,
 )
+from .user_status import UserStatusChange, set_user_active
 
 __all__ = [
   "DeletionBlocker",
   "UserDeletionBlocked",
   "UserDeletionPlan",
   "UserNotFound",
+  "UserStatusChange",
   "execute_user_deletion",
   "plan_user_deletion",
+  "set_user_active",
 ]

--- a/robosystems/operations/admin/user_status.py
+++ b/robosystems/operations/admin/user_status.py
@@ -1,0 +1,82 @@
+"""Activate or deactivate a user account.
+
+Deactivation is the support-plane response to a compromised or suspended
+account, and the only one short of deletion. It is deliberately heavier than a
+credential rotation: a password change invalidates sessions but leaves API keys
+alone, because rotation is routine and revoking keys on it would break
+integrations. Deactivation is the escalation — it invalidates sessions *and*
+revokes every key.
+"""
+
+from dataclasses import dataclass
+
+from sqlalchemy.orm import Session
+
+from ...logger import get_logger
+from ...models.core import User
+from ...models.core.user.user_api_key import UserAPIKey
+from .user_deletion import UserNotFound
+
+logger = get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class UserStatusChange:
+  """Outcome of an activate/deactivate, including what it revoked."""
+
+  user_id: str
+  email: str
+  is_active: bool
+  changed: bool
+  api_keys_revoked: int
+
+
+def set_user_active(
+  user_id: str,
+  active: bool,
+  session: Session,
+  *,
+  actor: str | None = None,
+) -> UserStatusChange:
+  """Set a user's active flag, revoking access when deactivating.
+
+  The underlying model call is always performed rather than skipped when the
+  user is already in the target state. Key revocation is best-effort per key, so
+  a re-run after a partial failure must be able to finish the job — a no-op
+  short-circuit would leave keys live on exactly the retry an operator reaches
+  for during an incident.
+
+  Reactivation does **not** restore revoked keys: `UserAPIKey.deactivate` flips
+  each key's own flag, and nothing flips it back. The user must issue new ones.
+  """
+  user = User.get_by_id(user_id, session)
+  if not user:
+    raise UserNotFound(user_id)
+
+  was_active = bool(user.is_active)
+
+  if active:
+    revoked = 0
+    user.activate(session)
+  else:
+    # Count before the call: afterwards there are none left to count.
+    revoked = len(UserAPIKey.get_active_by_user_id(str(user.id), session))
+    user.deactivate(session)
+
+  logger.info(
+    f"User {user_id} {'activated' if active else 'deactivated'}",
+    extra={
+      "user_id": user_id,
+      "actor": actor,
+      "was_active": was_active,
+      "api_keys_revoked": revoked,
+    },
+  )
+
+  return UserStatusChange(
+    user_id=str(user.id),
+    email=str(user.email),
+    is_active=active,
+    changed=was_active != active,
+    api_keys_revoked=revoked,
+  )

--- a/robosystems/routers/admin/users.py
+++ b/robosystems/routers/admin/users.py
@@ -16,6 +16,7 @@ from ...models.api.admin import (
   UserGraphAccessResponse,
   UserRepositoryAccessResponse,
   UserResponse,
+  UserStatusResponse,
 )
 from ...models.core import Graph, GraphUser, OrgUser, User
 from ...models.core.graph.graph_credits import (
@@ -30,6 +31,7 @@ from ...operations.admin import (
   UserNotFound,
   execute_user_deletion,
   plan_user_deletion,
+  set_user_active,
 )
 
 logger = get_logger(__name__)
@@ -365,6 +367,72 @@ async def get_user_activity(request: Request, user_id: str):
     )
   finally:
     session.close()
+
+
+async def _set_active(
+  request: Request, user_id: str, active: bool
+) -> UserStatusResponse:
+  session = next(get_db_session())
+  try:
+    try:
+      change = set_user_active(
+        user_id,
+        active,
+        session,
+        actor=f"admin:{request.state.admin.get('name', 'unknown')}",
+      )
+    except UserNotFound:
+      raise HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND,
+        detail=f"User {user_id} not found",
+      )
+
+    logger.info(
+      f"Admin {'activated' if active else 'deactivated'} user {user_id}",
+      extra={
+        "admin_key_id": request.state.admin_key_id,
+        "user_id": user_id,
+        "changed": change.changed,
+        "api_keys_revoked": change.api_keys_revoked,
+      },
+    )
+
+    return UserStatusResponse(
+      user_id=change.user_id,
+      email=change.email,
+      is_active=change.is_active,
+      changed=change.changed,
+      api_keys_revoked=change.api_keys_revoked,
+    )
+  finally:
+    session.close()
+
+
+@router.post("/{user_id}/deactivate", response_model=UserStatusResponse)
+@require_admin(permissions=["users:write"])
+async def deactivate_user(request: Request, user_id: str):
+  """Deactivate a user, cutting off both interactive and programmatic access.
+
+  Invalidates every session and revokes every API key. This is the escalation
+  above a password change — that rotates a credential and invalidates sessions,
+  but deliberately leaves keys alone so routine rotation doesn't break
+  integrations. Use this when an account is compromised or must be suspended.
+
+  Safe to re-run: key revocation is best-effort per key, so a repeat call
+  finishes anything a partial failure left behind.
+  """
+  return await _set_active(request, user_id, active=False)
+
+
+@router.post("/{user_id}/activate", response_model=UserStatusResponse)
+@require_admin(permissions=["users:write"])
+async def activate_user(request: Request, user_id: str):
+  """Reactivate a deactivated user.
+
+  Restores sign-in only. Revoked API keys are **not** reinstated — the user
+  must issue new ones.
+  """
+  return await _set_active(request, user_id, active=True)
 
 
 @router.delete("/{user_id}", response_model=UserDeletionResponse)

--- a/tests/operations/admin/test_user_status.py
+++ b/tests/operations/admin/test_user_status.py
@@ -1,0 +1,109 @@
+"""Tests for administrative activate/deactivate.
+
+Deactivation is the escalation above a credential rotation: a password change
+invalidates sessions but leaves API keys working, so this is the only path that
+cuts off programmatic access short of deleting the account. What matters here is
+that it revokes *both* halves, and that re-running it finishes a partial job.
+"""
+
+from uuid import uuid4
+
+import pytest
+
+from robosystems.models.core import User
+from robosystems.models.core.user.user_api_key import UserAPIKey
+from robosystems.operations.admin import UserNotFound, set_user_active
+
+
+def _create_user(session, password_hash: str) -> User:
+  suffix = uuid4().hex[:8]
+  user = User(
+    email=f"suspendable+{suffix}@example.com",
+    name="Suspendable User",
+    password_hash=password_hash,
+  )
+  session.add(user)
+  session.commit()
+  session.refresh(user)
+  return user
+
+
+class TestDeactivate:
+  def test_revokes_sessions_and_keys(self, test_db, test_user):
+    user = _create_user(test_db, test_user.password_hash)
+    UserAPIKey.create(user_id=user.id, name="key one", session=test_db)
+    UserAPIKey.create(user_id=user.id, name="key two", session=test_db)
+    before = user.session_version or 0
+
+    change = set_user_active(user.id, False, test_db)
+
+    assert change.is_active is False
+    assert change.changed is True
+    assert change.api_keys_revoked == 2
+
+    test_db.refresh(user)
+    assert user.is_active is False
+    # Both halves of access are cut: JWTs die via the version bump, keys via
+    # their own flag. Neither alone is sufficient.
+    assert (user.session_version or 0) > before
+    assert UserAPIKey.get_active_by_user_id(str(user.id), test_db) == []
+
+  def test_rerun_finishes_a_partial_revocation(self, test_db, test_user):
+    """A retry during an incident must not short-circuit on the is_active flag.
+
+    Key revocation is best-effort per key, so a key can survive a failed first
+    pass. If the second call no-opped because the user was already inactive,
+    that key would stay live — the exact opposite of what the operator wants.
+    """
+    user = _create_user(test_db, test_user.password_hash)
+    set_user_active(user.id, False, test_db)
+
+    # Simulate a key that outlived the first pass.
+    UserAPIKey.create(user_id=user.id, name="straggler", session=test_db)
+    assert len(UserAPIKey.get_active_by_user_id(str(user.id), test_db)) == 1
+
+    change = set_user_active(user.id, False, test_db)
+
+    assert change.changed is False  # flag was already off...
+    assert change.api_keys_revoked == 1  # ...but the straggler was still killed
+    assert UserAPIKey.get_active_by_user_id(str(user.id), test_db) == []
+
+  def test_reports_zero_keys_when_there_are_none(self, test_db, test_user):
+    user = _create_user(test_db, test_user.password_hash)
+
+    change = set_user_active(user.id, False, test_db)
+
+    assert change.api_keys_revoked == 0
+    assert change.changed is True
+
+
+class TestActivate:
+  def test_restores_sign_in_but_not_keys(self, test_db, test_user):
+    user = _create_user(test_db, test_user.password_hash)
+    UserAPIKey.create(user_id=user.id, name="doomed", session=test_db)
+    set_user_active(user.id, False, test_db)
+
+    change = set_user_active(user.id, True, test_db)
+
+    assert change.is_active is True
+    assert change.changed is True
+    assert change.api_keys_revoked == 0
+
+    test_db.refresh(user)
+    assert user.is_active is True
+    # Reactivation deliberately does not resurrect revoked keys.
+    assert UserAPIKey.get_active_by_user_id(str(user.id), test_db) == []
+
+  def test_activating_an_active_user_reports_no_change(self, test_db, test_user):
+    user = _create_user(test_db, test_user.password_hash)
+
+    change = set_user_active(user.id, True, test_db)
+
+    assert change.is_active is True
+    assert change.changed is False
+
+
+class TestMissingUser:
+  def test_unknown_user_raises(self, test_db):
+    with pytest.raises(UserNotFound):
+      set_user_active(f"user_{uuid4().hex}", False, test_db)


### PR DESCRIPTION
## Summary

`User.deactivate()` and `User.activate()` have existed — documented and unit
tested — with **zero production callers**. The admin surface offered list, get,
graphs, activity, and delete, so the only response to a compromised account was
deleting it outright (a hard `session.delete` gated by blockers that can refuse)
or editing the database by hand. This wires the existing methods up.

The gap mattered more than its size suggests, because deactivation is what
revokes API keys. A password change invalidates sessions but deliberately leaves
keys working — rotation is routine, and revoking on it would break integrations
every time someone changes a password. Deactivation is the escalation that
revokes both, and it had no button.

## Changes

- **`operations/admin/user_status.py`** (new) — `set_user_active(user_id, active,
  session, *, actor)` returning a `UserStatusChange` (whether the flag moved, and
  how many keys were revoked). Raises the existing `UserNotFound`.
- **`routers/admin/users.py`** — `POST /admin/v1/users/{id}/deactivate` and
  `POST /admin/v1/users/{id}/activate`, both `users:write`, sharing one helper.
- **`admin/commands/users_orgs.py`** — `admin users deactivate|activate`,
  accepting an email or an ID. Deactivate confirms first and reports the key
  count. The email-or-ID resolution the delete command carried inline is now a
  shared `_resolve_user_id` rather than duplicated.
- **`models/api/admin/users.py`** — `UserStatusResponse`.

**The one design decision worth a reviewer's attention:** the operation does
*not* short-circuit when the user is already in the target state. Key revocation
is best-effort per key (`_revoke_api_keys` logs and continues on failure), so a
key can survive a failed first pass. A no-op on the retry would leave it live on
exactly the call an operator reaches for during an incident, so the action always
runs and reports what it actually revoked. `changed` distinguishes "the flag
moved" from "the work ran."

Reactivation restores sign-in only — revoked keys are not reinstated, since
`UserAPIKey.deactivate` flips each key's own flag and nothing flips it back. The
endpoint docstring and the CLI output both say so.

## Breaking Changes

None. Two additive endpoints on the admin surface, which is ALB-denied and
reachable only via SSM tunnel, so it is not part of the client-SDK contract and
needs no regen.

## Testing

`just test-all` — green: **12,352 passed, 23 skipped**, plus ruff, format,
basedpyright (0 errors) and cf-lint. Exit code captured directly rather than
through a pipe.

New `tests/operations/admin/test_user_status.py` (6 cases against a real
database): deactivation revokes sessions *and* keys; a re-run finishes a partial
revocation; zero-key users report zero; reactivation restores sign-in but not
keys; activating an active user reports no change; unknown user raises.

The re-run case was verified to **fail** against a short-circuiting
implementation (the straggler key survives, `assert 0 == 1`) rather than assumed
to be meaningful. Both new routes and both CLI commands were confirmed
registered.

Not exercised against a live deployment.
