### PR TITLE
fix(operators): make MappingOperator reachable from the operator endpoint

### DIFF
--- a/robosystems/operations/operators/operator_context.py
+++ b/robosystems/operations/operators/operator_context.py
@@ -55,6 +55,18 @@ class ToolAccess(Protocol):
     `{"name", "description", "input_schema"}` ready to hand to the model.
     """
 
+  def get_tool_instance(self, tool_class: type) -> Any:
+    """Return an object exposing ``await .execute(arguments)`` for a tool.
+
+    For operators that drive tools imperatively rather than through the
+    model-driven loop (MappingOperator). Declared on the protocol because
+    both implementations provide it and an operator calling it must not
+    have to know which context it is running in — it was previously
+    implemented only on ``DirectToolAccess``, so every operator using it
+    raised ``AttributeError`` on the API path while working from the
+    worker.
+    """
+
 
 @dataclass
 class OperatorContext:

--- a/robosystems/operations/operators/tool_access.py
+++ b/robosystems/operations/operators/tool_access.py
@@ -15,6 +15,26 @@ from typing import Any
 from robosystems.logger import logger
 
 
+class _RemoteToolHandle:
+  """A tool-shaped object whose ``execute`` goes over the MCP HTTP surface.
+
+  Duck-types the one method imperative operators use, so the same operator
+  body runs against either access implementation.
+
+  ``return_raw=True`` is not incidental: ``GraphMCPTools.call_tool`` returns
+  a JSON *string* by default, while a direct tool returns its native dict.
+  Callers test results with ``"error" in result``, which silently degrades
+  to substring matching on a string — passing where it should fail.
+  """
+
+  def __init__(self, access: HttpToolAccess, tool_name: str) -> None:
+    self._access = access
+    self._tool_name = tool_name
+
+  async def execute(self, arguments: dict[str, Any]) -> Any:
+    return await self._access.call_tool(self._tool_name, arguments, return_raw=True)
+
+
 class HttpToolAccess:
   """MCP tool access via HTTP client.
 
@@ -68,6 +88,23 @@ class HttpToolAccess:
     if self._tools is None:
       await self.initialize()
     return await self._tools.call_tool(tool_name, arguments, return_raw=return_raw)
+
+  def get_tool_instance(self, tool_class: type) -> Any:
+    """Return a call-by-name handle for a tool class.
+
+    Operators that drive tools imperatively hold a tool *object* and call
+    ``.execute(args)`` on it. On the direct path that object is the tool
+    itself; here it is a handle that routes back through
+    :meth:`call_tool`, so execution still goes through ``GraphMCPTools`` —
+    which is what applies the ``read_only`` gating and the registrar
+    dispatch. Instantiating the tool class and executing it in-process
+    would work and would bypass both, so the handle is the point.
+
+    The class is instantiated once here purely to read its declared name;
+    that instance is discarded and never executed.
+    """
+    tool_name = tool_class(self).get_tool_definition()["name"]
+    return _RemoteToolHandle(self, tool_name)
 
   async def get_tool_schemas(self, names: list[str]) -> list[dict[str, Any]]:
     """Return Anthropic-shaped tool definitions for the requested names.

--- a/tests/operations/operators/test_tool_access_parity.py
+++ b/tests/operations/operators/test_tool_access_parity.py
@@ -1,0 +1,124 @@
+"""Both ToolAccess implementations must satisfy the protocol identically.
+
+The bug this file exists for: `get_tool_instance` was implemented only on
+`DirectToolAccess` while `adapters/api.py` constructs `HttpToolAccess`, so
+every operator driving tools imperatively worked from the worker and raised
+`AttributeError` on the API path. Nothing tested the two against each other,
+so the divergence was invisible.
+"""
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from robosystems.operations.operators.operator_context import ToolAccess
+from robosystems.operations.operators.tool_access import (
+  DirectToolAccess,
+  HttpToolAccess,
+)
+
+MODULE = "robosystems.operations.operators.tool_access"
+
+
+class FakeTool:
+  """Stands in for an MCP tool class — same shape the real ones expose."""
+
+  def __init__(self, graph_client):
+    self.client = graph_client
+
+  def get_tool_definition(self) -> dict[str, Any]:
+    return {
+      "name": "get-unmapped-elements",
+      "description": "test tool",
+      "inputSchema": {"type": "object"},
+    }
+
+  async def execute(self, arguments: dict[str, Any]) -> Any:
+    return {"executed_in_process": True, "arguments": arguments}
+
+
+@pytest.mark.unit
+class TestToolAccessParity:
+  @pytest.mark.parametrize(
+    "access_factory",
+    [
+      pytest.param(lambda: DirectToolAccess("kg_test"), id="direct"),
+      pytest.param(lambda: HttpToolAccess("kg_test", read_only=False), id="http"),
+    ],
+  )
+  def test_both_implementations_satisfy_the_protocol(self, access_factory):
+    """The regression in one line: HttpToolAccess lacked get_tool_instance."""
+    access = access_factory()
+
+    assert isinstance(access, ToolAccess)
+    for method in ("call_tool", "get_tool_schemas", "get_tool_instance"):
+      assert hasattr(access, method), f"missing {method}"
+
+  @pytest.mark.asyncio
+  async def test_http_tool_handle_executes_over_the_mcp_surface(self):
+    """The handle must route through call_tool, not run the tool in-process.
+
+    In-process execution would work and would bypass both the read_only
+    gating and the registrar dispatch that GraphMCPTools applies, so this
+    asserts the indirection rather than merely asserting a result.
+    """
+    access = HttpToolAccess("kg_test", read_only=False)
+
+    with patch.object(
+      access, "call_tool", new=AsyncMock(return_value={"unmapped": []})
+    ) as mock_call:
+      handle = access.get_tool_instance(FakeTool)
+      result = await handle.execute({"mapping_id": "map_1"})
+
+    mock_call.assert_awaited_once_with(
+      "get-unmapped-elements", {"mapping_id": "map_1"}, return_raw=True
+    )
+    assert result == {"unmapped": []}
+    # Not the in-process path — FakeTool.execute was never reached.
+    assert "executed_in_process" not in result
+
+  @pytest.mark.asyncio
+  async def test_http_handle_returns_a_dict_not_a_json_string(self):
+    """`return_raw=True` is load-bearing, not stylistic.
+
+    GraphMCPTools.call_tool returns a JSON *string* by default. Callers
+    test outcomes with `"error" in result`; against a string that becomes
+    substring matching, which passes on any payload containing the word —
+    a wrong answer rather than a failure.
+    """
+    access = HttpToolAccess("kg_test", read_only=False)
+    fake_tools = AsyncMock()
+    fake_tools.call_tool = AsyncMock(return_value={"error": "boom"})
+    access._tools = fake_tools
+
+    handle = access.get_tool_instance(FakeTool)
+    result = await handle.execute({})
+
+    assert isinstance(result, dict)
+    assert "error" in result
+    assert fake_tools.call_tool.await_args.kwargs["return_raw"] is True
+
+  @pytest.mark.asyncio
+  async def test_direct_access_still_executes_in_process(self):
+    """The worker path is unchanged — this fix must not move it."""
+    access = DirectToolAccess("kg_test")
+
+    tool = access.get_tool_instance(FakeTool)
+    result = await tool.execute({"mapping_id": "map_1"})
+
+    assert result["executed_in_process"] is True
+
+  def test_direct_access_caches_instances_http_need_not(self):
+    """Documents the one intentional behavioural difference.
+
+    DirectToolAccess memoizes because the instance holds the tool; the HTTP
+    handle is a stateless name binding, so identity carries no meaning.
+    """
+    direct = DirectToolAccess("kg_test")
+    assert direct.get_tool_instance(FakeTool) is direct.get_tool_instance(FakeTool)
+
+    http = HttpToolAccess("kg_test", read_only=False)
+    a = http.get_tool_instance(FakeTool)
+    b = http.get_tool_instance(FakeTool)
+    assert a._tool_name == b._tool_name


### PR DESCRIPTION
## What

`MappingOperator._run_single_pass` calls `ctx.tools.get_tool_instance(...)`, which existed only on `DirectToolAccess`. `adapters/worker.py:64` builds that one; **`adapters/api.py:66` builds `HttpToolAccess`, which had no such method** — so the operator worked from the worker and raised `AttributeError` on every API path, which is the path the operator endpoint uses.

This is the intended shape: the operator is the bulk path (a new tenant with 100+ accounts, where it can crank through with full metadata available), while manual mapping — by hand or through MCP — stays the right tool for a handful of new accounts. Both need to work; only one did.

## The fix, and why not the other one

`HttpToolAccess` gains `get_tool_instance`, returning a name-bound handle whose `execute()` routes back through `call_tool`.

The tempting alternative — instantiate the tool class and execute it in-process — would also have worked and is wrong. `GraphMCPTools` is what applies the `read_only` gating and the **registrar dispatch**, and `create-mapping-association` is registrar-generated rather than present in the hand-written `if/elif` ladder. In-process execution would bypass both. The indirection is the point, not overhead. The class is instantiated once purely to read its declared name; that instance is discarded and never executed.

**`return_raw=True` is load-bearing, not stylistic.** `GraphMCPTools.call_tool` returns a JSON *string* by default while a direct tool returns its native dict, and callers test outcomes with `"error" in result`. Against a string that silently degrades to substring matching — passing on any payload containing the word. There's a test pinning it.

## Protocol

`get_tool_instance` is added to the `ToolAccess` protocol. It was already being used *as* a protocol method by an operator that cannot know which context it runs in; leaving it off the protocol is what let the two implementations drift apart with nothing to notice.

## Verified before building

`OperatorSpec.read_only` defaults to `False`, so `api.py` passes `read_only=False` and the manager wires the mapping tools — they're gated on `not read_only`. Had that defaulted the other way, this fix would have been necessary but not sufficient.

## Tests

Asserted the two implementations **against each other** rather than separately, since testing them separately is exactly what missed this. Confirmed they fail against the pre-fix class:

```
pre-fix hasattr(get_tool_instance): False
pre-fix isinstance(ToolAccess):     False
pre-fix raises: AttributeError: 'HttpToolAccess' object has no attribute 'get_tool_instance'
```

Full suite: **12,358 passed**, `just test-all` clean.