### PR TITLE
fix(backup): checkpoint the database before creating a backup

### DIFF
--- a/robosystems/graph_api/routers/databases/restore.py
+++ b/robosystems/graph_api/routers/databases/restore.py
@@ -249,6 +249,31 @@ async def download_backup(
 
     from robosystems.middleware.graph.utils import MultiTenantUtils
 
+    # Fold the WAL into the main database file before copying it. LadybugDB
+    # holds recent writes in {graph_id}.lbug.wal until a checkpoint, and this
+    # path copies only the main file — so without this, a graph that has not
+    # been evicted since its last write backs up as of its last checkpoint,
+    # which for a young graph is an empty database. The default
+    # checkpoint_threshold is 512 MB, which a tenant graph never reaches.
+    #
+    # Mirrors OnInstanceBackupService._checkpoint, which the replica and
+    # duckdb_staging paths have always used. Safe to open here because the
+    # list_databases() membership check above already ran: LadybugDB creates a
+    # database when the path is absent, so checkpointing an unknown graph would
+    # mint an empty one and pass the existence guard below.
+    try:
+      with ladybug_service.db_manager.get_connection(graph_id, read_only=False) as conn:
+        conn.execute("CHECKPOINT")
+    except Exception as e:
+      # Fail the backup rather than fall through to a silently stale copy —
+      # a backup that reports success over incomplete data is worse than none.
+      logger.error(f"CHECKPOINT failed for {graph_id}, aborting backup: {e!s}")
+      raise HTTPException(
+        status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
+        detail="Could not checkpoint the database; backup aborted rather than "
+        "producing a possibly-stale copy.",
+      )
+
     db_path = MultiTenantUtils.get_database_path_for_graph(graph_id)
 
     if not os.path.exists(db_path):

--- a/tests/graph_api/routers/databases/test_backup_restore.py
+++ b/tests/graph_api/routers/databases/test_backup_restore.py
@@ -2,6 +2,7 @@
 
 import io
 import zipfile
+from contextlib import contextmanager
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -14,19 +15,38 @@ from robosystems.graph_api.routers.databases import backup as backup_module
 from robosystems.graph_api.routers.databases import restore as restore_module
 
 
+class FakeConnection:
+  def __init__(self, recorder, fail=False):
+    self._recorder = recorder
+    self._fail = fail
+
+  def execute(self, sql):
+    if self._fail:
+      raise RuntimeError("checkpoint boom")
+    self._recorder.append(sql)
+
+
 class FakeDBManager:
-  def __init__(self, databases):
+  def __init__(self, databases, checkpoint_fails=False):
     self._databases = databases
     self.connection_pool = None
+    self.executed: list[str] = []
+    self.opened_read_only: list[bool] = []
+    self._checkpoint_fails = checkpoint_fails
 
   def list_databases(self):
     return list(self._databases)
 
+  @contextmanager
+  def get_connection(self, graph_id, read_only=True):
+    self.opened_read_only.append(read_only)
+    yield FakeConnection(self.executed, fail=self._checkpoint_fails)
+
 
 class FakeClusterService:
-  def __init__(self, read_only=False, databases=None):
+  def __init__(self, read_only=False, databases=None, checkpoint_fails=False):
     self.read_only = read_only
-    self.db_manager = FakeDBManager(databases or [])
+    self.db_manager = FakeDBManager(databases or [], checkpoint_fails)
 
 
 @pytest.fixture
@@ -238,6 +258,53 @@ async def test_download_backup_returns_zip_for_file_db(monkeypatch, tmp_path):
     assert namelist == ["graph1.lbug"]
     extracted = zf.read("graph1.lbug")
     assert extracted == b"lbug-data"
+
+  # The WAL must be folded into the main file before it is copied — without
+  # this the backup captures the database as of its last pool eviction, which
+  # for a graph written to since then is stale and for a young one is empty.
+  assert cluster.db_manager.executed == ["CHECKPOINT"]
+  assert cluster.db_manager.opened_read_only == [False]
+
+
+@pytest.mark.asyncio
+async def test_download_backup_aborts_when_checkpoint_fails(monkeypatch, tmp_path):
+  """A failed checkpoint must fail the backup, not fall through to a stale copy.
+
+  Falling through is the whole defect class: a backup that reports success over
+  incomplete data is worse than one that never ran.
+  """
+  cluster = FakeClusterService(
+    read_only=False, databases=["graph1"], checkpoint_fails=True
+  )
+  db_file = tmp_path / "graph1.lbug"
+  db_file.write_bytes(b"lbug-data")
+
+  monkeypatch.setattr(
+    "robosystems.middleware.graph.utils.MultiTenantUtils.get_database_path_for_graph",
+    lambda graph_id: str(db_file),
+  )
+
+  with pytest.raises(HTTPException) as exc:
+    await restore_module.download_backup(graph_id="graph1", ladybug_service=cluster)
+
+  assert exc.value.status_code == 500
+  assert "checkpoint" in exc.value.detail.lower()
+
+
+@pytest.mark.asyncio
+async def test_download_backup_checkpoints_only_known_databases():
+  """The membership check must precede the checkpoint.
+
+  LadybugDB creates a database when the path is absent, so checkpointing an
+  unknown graph would mint an empty one and satisfy the existence guard.
+  """
+  cluster = FakeClusterService(read_only=False, databases=["graph1"])
+
+  with pytest.raises(HTTPException) as exc:
+    await restore_module.download_backup(graph_id="ghost", ladybug_service=cluster)
+
+  assert exc.value.status_code == 404
+  assert cluster.db_manager.executed == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
The `full_dump` backup producer copied the `.lbug` file directly and never ran `CHECKPOINT`.

LadybugDB holds recent writes in the `{graph_id}.lbug.wal` sidecar until a checkpoint folds them into the main file, and the default `checkpoint_threshold` is 512 MB — which a tenant-sized graph never reaches. So the main file only caught up when the database was evicted from the pool or the instance cycled, and copying it alone captured the database as of that point rather than as of the backup.

The `replica` and `duckdb_staging` paths in `OnInstanceBackupService` have always checkpointed first. Only `full_dump` — the restorable format, and the one behind the user-facing `create-backup` operation — skipped it.

## Behaviour

- `CHECKPOINT` runs before the copy, via the same pooled connection `OnInstanceBackupService._checkpoint` uses.
- **A checkpoint failure fails the backup.** Falling through would reproduce the exact silent staleness this fixes, and a backup that reports success over incomplete data is worse than one that never ran.
- The checkpoint runs **after** the existing `list_databases()` membership check. LadybugDB creates a database when the path is absent, so checkpointing an unknown graph would mint an empty one and then satisfy the existence guard below it.

## Tests

Three added, all verified to fail without the source change:

- the happy path asserts `CHECKPOINT` ran, on a writable connection, before the copy
- a failing checkpoint aborts with 500 rather than producing a copy
- an unknown graph 404s without opening a connection

`just test-all` — 12,323 passed, 23 skipped; ruff, format, basedpyright, cf-lint clean.

## Sequencing

Worth including in the same deploy as [#1102](https://github.com/RoboFinSystems/robosystems/pull/1102), which widens which backups are restorable.