### PR TITLE
fix(backup): allow restore on subgraphs of an entity graph

### DIFF
--- a/robosystems/models/api/graphs/backups.py
+++ b/robosystems/models/api/graphs/backups.py
@@ -99,7 +99,9 @@ class BackupListResponse(BaseModel):
       "Whether backups on this graph can be restored. False for entity graphs, "
       "which are materialized from the extensions database (use the materialize "
       "operation instead), and for shared repositories, which are "
-      "platform-managed and download-only."
+      "platform-managed and download-only. True for subgraphs of an entity "
+      "graph: only the parent is materialized, so a subgraph has no other "
+      "recovery path."
     ),
   )
   download_quota: DownloadQuota | None = Field(

--- a/robosystems/routers/graphs/backups/utils.py
+++ b/robosystems/routers/graphs/backups/utils.py
@@ -45,6 +45,12 @@ def restore_unsupported_reason(graph_id: str, db: Session) -> tuple[int, str] | 
   are a projection of the extensions OLTP database, so overwriting one with a
   snapshot desynchronizes it from its source of truth.
 
+  Subgraphs are the exception to the entity rule, and they inherit
+  ``graph_type`` from their parent. Only the parent is materialized —
+  ``materialize`` refuses subgraphs outright — so a subgraph is a separate
+  database written directly via Cypher with no upstream to rebuild from.
+  Refusing restore there would leave it with no recovery path at all.
+
   Fails closed on an unresolvable graph: a restore is destructive, so an
   unknown graph type is a refusal rather than a default-allow.
   """
@@ -66,7 +72,12 @@ def restore_unsupported_reason(graph_id: str, db: Session) -> tuple[int, str] | 
       "confirmed. Restore is refused rather than attempted.",
     )
 
-  if graph_record.graph_type == "entity":
+  # Subgraphs inherit graph_type from the parent, so an entity subgraph reads
+  # as "entity" here — but it is not materialized from anything. `materialize`
+  # blocks subgraphs (`_block_subgraph`), so refusing restore too would leave a
+  # subgraph with no recovery path while pointing at an operation that would
+  # also refuse it.
+  if graph_record.graph_type == "entity" and not graph_record.is_subgraph:
     return (
       status.HTTP_400_BAD_REQUEST,
       "Cannot restore backups for entity graphs. The graph is automatically "

--- a/robosystems/routers/graphs/operations.py
+++ b/robosystems/routers/graphs/operations.py
@@ -697,7 +697,7 @@ async def create_backup_op(
   status_code=status.HTTP_202_ACCEPTED,
   operation_id="restoreBackup",
   summary="Restore Backup",
-  description="Not allowed on entity graphs (use `materialize` instead) or shared repositories. Destructive: the existing database is snapshotted, then overwritten. Monitor progress via SSE at `/v1/operations/{operation_id}/stream`.",
+  description="Not allowed on entity graphs (use `materialize` instead) or shared repositories. Entity *subgraphs* are restorable — they are written directly and have no materialization path. Destructive: the existing database is snapshotted, then overwritten. Monitor progress via SSE at `/v1/operations/{operation_id}/stream`.",
   tags=[_OP_TAG],
   dependencies=[_RATE_LIMIT],
   responses={**OPERATION_ERROR_RESPONSES},

--- a/tests/routers/graphs/test_restore_backup_op.py
+++ b/tests/routers/graphs/test_restore_backup_op.py
@@ -54,9 +54,10 @@ def _user(user_id: str = "usr_test") -> MagicMock:
   return u
 
 
-def _graph(graph_type: str = "generic") -> MagicMock:
+def _graph(graph_type: str = "generic", is_subgraph: bool = False) -> MagicMock:
   g = MagicMock()
   g.graph_type = graph_type
+  g.is_subgraph = is_subgraph
   return g
 
 
@@ -105,6 +106,52 @@ class TestRestoreGraphTypeGates:
     assert exc.value.status_code == 400
     assert "entity graphs" in exc.value.detail
     assert "materialize" in exc.value.detail
+
+  @pytest.mark.asyncio
+  @patch("robosystems.models.core.Graph.get_by_id")
+  async def test_allows_entity_subgraph(self, mock_get_graph: MagicMock) -> None:
+    """A subgraph inherits `entity` from its parent but is not materialized
+    from anything — `materialize` refuses subgraphs, so refusing restore too
+    would leave it with no recovery path at all."""
+    mock_get_graph.return_value = _graph("entity", is_subgraph=True)
+
+    with patch("robosystems.models.core.GraphBackup.get_by_id") as mock_backup:
+      mock_backup.return_value = _backup()
+      with patch(
+        "robosystems.worker.client.enqueue_task",
+        new=AsyncMock(return_value={"operation_id": "op_sub"}),
+      ):
+        envelope = await _call()
+
+    assert envelope.operation_id == "op_sub"
+
+  @pytest.mark.asyncio
+  @patch("robosystems.models.core.Graph.get_by_id")
+  async def test_still_rejects_parent_entity_graph(
+    self, mock_get_graph: MagicMock
+  ) -> None:
+    """The parent itself stays refused — it *is* materialized from extensions."""
+    mock_get_graph.return_value = _graph("entity", is_subgraph=False)
+
+    with pytest.raises(HTTPException) as exc:
+      await _call()
+    assert exc.value.status_code == 400
+    assert "entity graphs" in exc.value.detail
+
+  @pytest.mark.asyncio
+  @pytest.mark.parametrize("graph_id", ["sec", "sec_historical"])
+  @patch("robosystems.models.core.Graph.get_by_id")
+  async def test_shared_repo_subgraph_still_rejected(
+    self, mock_get_graph: MagicMock, graph_id: str
+  ) -> None:
+    """Shared repositories are refused on ownership, before graph type is even
+    consulted — the subgraph carve-out must not reach them."""
+    mock_get_graph.return_value = _graph("repository", is_subgraph=True)
+
+    with pytest.raises(HTTPException) as exc:
+      await _call(graph_id=graph_id)
+    assert exc.value.status_code == 403
+    assert "shared repository" in exc.value.detail
 
   @pytest.mark.asyncio
   @patch("robosystems.models.core.Graph.get_by_id")


### PR DESCRIPTION
Subgraphs inherit `graph_type` from their parent (`subgraph_service.py:336`), so a subgraph of an entity graph reads as `entity` and was refused by the restore guard — with a message telling the caller to use `materialize` instead.

`materialize` calls `_block_subgraph` and refuses subgraphs outright. So the advice could not be followed, and **a subgraph of an entity graph had no recovery path at all.**

## Why the entity refusal doesn't extend to subgraphs

An entity graph is refused because it is a projection of the extensions OLTP database — restoring a snapshot over it desynchronizes it from its source of truth, and `materialize` is the correct rebuild path.

Only the *parent* is materialized. A subgraph is a separate LadybugDB database, written directly via Cypher, with no upstream to rebuild from. That makes it the class that needs restore most, not least — the same no-upstream category that carries the real recovery risk on this surface.

Concretely: `kg19ed34f81c37ba3f31fa_entities` holds a hand-authored corporate-structure layer (`Principal`, `RelatedParty`, and their ownership edges) that exists nowhere else. Before this change, losing it was unrecoverable through any supported operation.

## Behaviour

| Target | Before | After |
|---|---|---|
| Subgraph of an entity graph | refused (400) | **allowed** |
| Parent entity graph | refused (400) | refused (400) — unchanged, it *is* materialized |
| Shared repository, incl. subgraphs | refused (403) | refused (403) — unchanged |
| Generic / private repository | allowed | allowed |

The shared-repository check runs before graph type is consulted, so the carve-out cannot reach `sec` or `sec_historical`. `restore_supported` on the backup list response follows automatically, since it calls the same helper — no frontend change needed.

## Tests

Three added, and the entity-subgraph case verified to fail with the source change reverted:

- an entity subgraph is allowed through to the job enqueue
- the parent entity graph is still refused
- shared-repo subgraphs are still refused, on ownership rather than type

`just test-all` — 12,327 passed, 23 skipped; ruff, format, basedpyright, cf-lint clean.