### PR TITLE
fix(reports): compare a month against the prior calendar month

### DIFF
--- a/robosystems/operations/roboledger/reads/reports.py
+++ b/robosystems/operations/roboledger/reads/reports.py
@@ -915,10 +915,13 @@ def resolve_reporting_window(
 
 
 def build_current_and_prior_periods(start: date, end: date) -> list[FactPeriodSpec]:
-  """Return [current, prior] period specs of matching duration."""
-  duration = (end - start).days + 1
-  prior_end = start - timedelta(days=1)
-  prior_start = prior_end - timedelta(days=duration - 1)
+  """Return [current, prior] period specs.
+
+  Delegates to ``_compute_prior_period`` — which this module already
+  imported while also keeping a hand-copy of its body, so the two drifted
+  the moment one of them was fixed.
+  """
+  prior_start, prior_end = _compute_prior_period(start, end)
   return [
     FactPeriodSpec(start=start, end=end, label="Current"),
     FactPeriodSpec(start=prior_start, end=prior_end, label="Prior"),

--- a/robosystems/operations/roboledger/reports/fact_grid.py
+++ b/robosystems/operations/roboledger/reports/fact_grid.py
@@ -1873,12 +1873,57 @@ def _count_unmapped(
   return row.cnt if row else 0
 
 
+def _whole_month_span(period_start: date, period_end: date) -> int | None:
+  """Months spanned when the range is exactly N whole calendar months, else None."""
+  from robosystems.operations.roboledger.fiscal_calendar.periods import (
+    last_day_of_month,
+  )
+
+  if period_start.day != 1:
+    return None
+  if period_end.day != last_day_of_month(period_end.year, period_end.month):
+    return None
+  months = (
+    (period_end.year - period_start.year) * 12
+    + (period_end.month - period_start.month)
+    + 1
+  )
+  return months if months >= 1 else None
+
+
 def _compute_prior_period(period_start: date, period_end: date) -> tuple[date, date]:
-  """Compute the prior period of equal length ending the day before period_start."""
-  duration = (period_end - period_start).days + 1
+  """Compute the comparative prior period ending the day before period_start.
+
+  Calendar-aware, because subtracting a day count is not the same thing.
+  Months have different lengths, so equal-length arithmetic walks a monthly
+  period off its own boundaries: March 2026 (31 days) would compare against
+  2026-01-29 → 2026-02-28, and February against 2026-01-04 → 2026-01-31.
+  Neither matches any stored monthly FactSet, so the comparative column
+  queries a window nothing was ever stamped into — it returns empty or wrong
+  rather than failing.
+
+  When the range is exactly N whole calendar months, the prior period is the
+  N calendar months immediately before. Otherwise — an arbitrary range, where
+  "the previous one" has no calendar meaning — it falls back to equal length,
+  which is the only sensible reading and the original behaviour.
+  """
+  from robosystems.operations.roboledger.fiscal_calendar.periods import (
+    add_months,
+    parse_period,
+    period_name,
+  )
+
   prior_end = period_start - timedelta(days=1)
-  prior_start = prior_end - timedelta(days=duration - 1)
-  return prior_start, prior_end
+
+  months = _whole_month_span(period_start, period_end)
+  if months is not None:
+    prior_year, prior_month = parse_period(
+      add_months(period_name(period_start.year, period_start.month), -months)
+    )
+    return date(prior_year, prior_month, 1), prior_end
+
+  duration = (period_end - period_start).days + 1
+  return prior_end - timedelta(days=duration - 1), prior_end
 
 
 # Anonymous element id used when no rs-gaap RE fact is present in the

--- a/tests/operations/roboledger/reads/test_reports_extra.py
+++ b/tests/operations/roboledger/reads/test_reports_extra.py
@@ -109,6 +109,15 @@ class TestResolveReportingWindow:
 
 
 class TestBuildCurrentAndPriorPeriods:
+  """Whole-month ranges compare against whole calendar months.
+
+  Both assertions here previously pinned day-count arithmetic — April's
+  prior was 2026-03-02 ("30-day duration match") and Q1's was 2025-10-03
+  ("90-day duration"). Those are the defect written down: neither window
+  matches a stored monthly FactSet, so the comparative column queried a
+  range nothing was stamped into.
+  """
+
   @pytest.mark.unit
   def test_month_pair(self):
     periods = build_current_and_prior_periods(date(2026, 4, 1), date(2026, 4, 30))
@@ -117,17 +126,16 @@ class TestBuildCurrentAndPriorPeriods:
     assert periods[0].start == date(2026, 4, 1)
     assert periods[0].end == date(2026, 4, 30)
     assert periods[1].label == "Prior"
+    assert periods[1].start == date(2026, 3, 1)
     assert periods[1].end == date(2026, 3, 31)
-    assert periods[1].start == date(2026, 3, 2)  # 30-day duration match
 
   @pytest.mark.unit
   def test_quarter_pair(self):
     periods = build_current_and_prior_periods(date(2026, 1, 1), date(2026, 3, 31))
     assert periods[0].start == date(2026, 1, 1)
     assert periods[0].end == date(2026, 3, 31)
+    assert periods[1].start == date(2025, 10, 1)
     assert periods[1].end == date(2025, 12, 31)
-    # 90-day duration: prior_start = 2025-10-03
-    assert periods[1].start == date(2025, 10, 3)
 
 
 class TestGetLiveFinancialStatement:

--- a/tests/operations/roboledger/reports/test_fact_grid.py
+++ b/tests/operations/roboledger/reports/test_fact_grid.py
@@ -6,6 +6,8 @@ from datetime import date
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from robosystems.operations.roboledger.reports.fact_grid import (
   _EQUITY_FLOW_REDUCER_QNAMES,
   PeriodSpec,
@@ -55,22 +57,100 @@ class TestNaturalSign:
 
 
 class TestComputePriorPeriod:
-  def test_quarterly(self):
-    start, end = _compute_prior_period(date(2026, 1, 1), date(2026, 3, 31))
-    assert end == date(2025, 12, 31)
-    # Q1 = 90 days, so prior period is 90 days ending Dec 31
-    duration = (date(2026, 3, 31) - date(2026, 1, 1)).days + 1
-    assert (end - start).days + 1 == duration
+  """A whole-month range compares against whole calendar months.
 
-  def test_monthly(self):
-    start, end = _compute_prior_period(date(2026, 3, 1), date(2026, 3, 31))
-    assert end == date(2026, 2, 28)
-    assert start.month == 1 or start.month == 2  # 31-day month prior
+  These assertions used to be written against day-count arithmetic — the
+  quarterly case pinned "prior period is 90 days" and the monthly case
+  allowed `start.month == 1 or start.month == 2`, which is loose enough to
+  accept 2026-01-29. Both encoded the defect: months differ in length, so
+  subtracting a duration walks a monthly period off its own boundaries and
+  the comparative column queries a window no FactSet was ever stamped into.
+  """
+
+  @pytest.mark.parametrize(
+    ("label", "start", "end", "want_start", "want_end"),
+    [
+      (
+        "month",
+        date(2026, 3, 1),
+        date(2026, 3, 31),
+        date(2026, 2, 1),
+        date(2026, 2, 28),
+      ),
+      (
+        "short month",
+        date(2026, 2, 1),
+        date(2026, 2, 28),
+        date(2026, 1, 1),
+        date(2026, 1, 31),
+      ),
+      (
+        "year boundary",
+        date(2026, 1, 1),
+        date(2026, 1, 31),
+        date(2025, 12, 1),
+        date(2025, 12, 31),
+      ),
+      (
+        "quarter",
+        date(2026, 1, 1),
+        date(2026, 3, 31),
+        date(2025, 10, 1),
+        date(2025, 12, 31),
+      ),
+      (
+        "full year",
+        date(2026, 1, 1),
+        date(2026, 12, 31),
+        date(2025, 1, 1),
+        date(2025, 12, 31),
+      ),
+      (
+        "leap February",
+        date(2024, 3, 1),
+        date(2024, 3, 31),
+        date(2024, 2, 1),
+        date(2024, 2, 29),
+      ),
+    ],
+  )
+  def test_whole_month_ranges_step_back_by_calendar(
+    self, label, start, end, want_start, want_end
+  ):
+    assert _compute_prior_period(start, end) == (want_start, want_end)
+
+  def test_arbitrary_range_falls_back_to_equal_length(self):
+    """Only whole-month ranges get calendar treatment.
+
+    "The previous one" has no calendar meaning for an arbitrary window, so
+    equal length is the honest reading — and the original behaviour.
+    """
+    start, end = _compute_prior_period(date(2026, 3, 5), date(2026, 3, 20))
+
+    assert end == date(2026, 3, 4)
+    assert (end - start).days + 1 == 16  # same span as Mar 5-20
 
   def test_single_day(self):
     start, end = _compute_prior_period(date(2026, 6, 15), date(2026, 6, 15))
     assert start == date(2026, 6, 14)
     assert end == date(2026, 6, 14)
+
+  def test_both_call_sites_agree(self):
+    """The duplicate is gone; reads/reports.py delegates to this function.
+
+    That file imported this helper *and* kept a hand-copy of its body, so a
+    fix to one silently left the other behind. Pinning the agreement is what
+    stops the copy growing back.
+    """
+    from robosystems.operations.roboledger.reads.reports import (
+      build_current_and_prior_periods,
+    )
+
+    start, end = date(2026, 3, 1), date(2026, 3, 31)
+    specs = build_current_and_prior_periods(start, end)
+
+    assert (specs[1].start, specs[1].end) == _compute_prior_period(start, end)
+    assert (specs[1].start, specs[1].end) == (date(2026, 2, 1), date(2026, 2, 28))
 
 
 class TestBuildRows:


### PR DESCRIPTION
## What

`_compute_prior_period` subtracted a day count, so a monthly period walked off its own boundaries:

| Current period | Prior (before) | Prior (after) |
|---|---|---|
| March 2026 (31d) | **2026-01-29 → 2026-02-28** | 2026-02-01 → 2026-02-28 |
| February 2026 (28d) | **2026-01-04 → 2026-01-31** | 2026-01-01 → 2026-01-31 |
| Q1 2026 | **2025-10-03 → 2025-12-31** | 2025-10-01 → 2025-12-31 |

Neither of those windows matches a stored monthly FactSet, so every month-over-month comparative column queried a range nothing was ever stamped into. It returned empty or wrong rather than erroring — which is why it survived.

A range that is exactly N whole calendar months now steps back N calendar months. Anything else keeps equal-length arithmetic: *"the previous one"* has no calendar meaning for an arbitrary window, so equal length is the honest reading and the original behaviour is preserved there.

## Reuse over rolling a fourth

Month arithmetic composes `fiscal_calendar.periods` (`add_months`, `period_name`, `parse_period`, `last_day_of_month`). There were **already three** month helpers in the tree — adding a fourth is precisely how the first three happened. Verified no import cycle before wiring it (that module is pure stdlib).

## Also removes a duplicate

`reads/reports.py` imported `_compute_prior_period` **and** kept a hand-copy of its body inside `build_current_and_prior_periods`. Same file, both. So the two disagreed the moment either was touched — which is the mechanism behind this bug having two call paths in the first place. The copy is gone, the function delegates, and a test pins that the two call sites agree.

## Tests

**Three cases asserted the defect outright** and are corrected rather than kept:

- `# 30-day duration match` — April's prior pinned at 2026-03-02
- `# 90-day duration` — Q1's prior pinned at 2025-10-03
- `assert start.month == 1 or start.month == 2` — loose enough to accept 2026-01-29

Replaced with exact expectations across month, short month, year boundary, quarter, full year, and leap February (2024-02-29). Plus the equal-length fallback and the call-site agreement.

Full suite: **12,333 passed**, `just test-all` clean.