### PR TITLE
fix(backup): enforce tier retention on the paths that skipped it

### DIFF
--- a/robosystems/dagster/jobs/backup_cleanup.py
+++ b/robosystems/dagster/jobs/backup_cleanup.py
@@ -155,11 +155,123 @@ def cleanup_instance_backups(
   }
 
 
+@op
+def cleanup_orphaned_backups(
+  context: OpExecutionContext,
+  db: DatabaseResource,
+  s3: S3Resource,
+) -> dict[str, Any]:
+  """Delete application backup objects that no ``GraphBackup`` row references.
+
+  ``cleanup_tracked_backups`` can only act on rows, so an object whose record
+  was never written — or was removed — is invisible to it, and survives until
+  the 90-day S3 lifecycle rule regardless of the graph's tier. A standard-tier
+  orphan therefore outlives its 7-day retention by more than twelve weeks.
+  Observed in prod: a 2026-06-06 object under ``kg19dcbe757481af06fc9b`` with
+  no row at all.
+
+  Retention comes from the owning graph's tier, parsed out of the key, so an
+  orphan expires on the same clock its tracked siblings would have. Unknown or
+  unparseable graphs fall back to the 90-day maximum rather than deleting
+  early — this op removes data, so every ambiguity resolves toward keeping it.
+  """
+  from robosystems.config.graph_tier import GraphTierConfig
+  from robosystems.config.storage.graph import get_backup_prefix
+  from robosystems.models.core import Graph, GraphBackup
+
+  prefix = get_backup_prefix()
+  now = datetime.now(UTC)
+
+  deleted_count = 0
+  skipped_tracked = 0
+  objects_to_delete: list[dict[str, str]] = []
+
+  try:
+    with db.get_session() as session:
+      # Every key any row still points at, whatever its status. An EXPIRED row
+      # whose S3 delete failed is already the lifecycle rule's problem, and
+      # deleting it here would race op 1.
+      tracked_keys: set[str] = {
+        key
+        for (key,) in session.query(GraphBackup.s3_key).filter(
+          GraphBackup.s3_key.isnot(None)
+        )
+      }
+      tracked_keys |= {
+        key
+        for (key,) in session.query(GraphBackup.s3_metadata_key).filter(
+          GraphBackup.s3_metadata_key.isnot(None)
+        )
+      }
+
+      retention_by_graph: dict[str, int] = {}
+
+      def _retention_days(graph_id: str) -> int:
+        """Tier retention for a graph, defaulting to the 90-day maximum."""
+        if graph_id not in retention_by_graph:
+          graph = Graph.get_by_id(graph_id, session)
+          tier = str(graph.graph_tier) if graph and graph.graph_tier else None
+          retention_by_graph[graph_id] = (
+            GraphTierConfig.get_backup_limits(tier).get(
+              "backup_retention_days", MAX_RETENTION_DAYS
+            )
+            if tier
+            else MAX_RETENTION_DAYS
+          )
+        return retention_by_graph[graph_id]
+
+      paginator = s3.client.get_paginator("list_objects_v2")
+      for page in paginator.paginate(Bucket=s3.bucket, Prefix=prefix):
+        for obj in page.get("Contents", []):
+          key = obj["Key"]
+
+          if key in tracked_keys:
+            skipped_tracked += 1
+            continue
+
+          # graph-backups/databases/{graph_id}/{backup_type}/backup-{ts}{ext}
+          parts = key[len(prefix) :].split("/")
+          if len(parts) < 2 or not parts[0]:
+            context.log.warning(f"Unparseable backup key, leaving in place: {key}")
+            continue
+
+          cutoff = now - timedelta(days=_retention_days(parts[0]))
+          if obj["LastModified"].replace(tzinfo=UTC) >= cutoff:
+            continue
+
+          objects_to_delete.append({"Key": key})
+          if len(objects_to_delete) >= 1000:
+            s3.client.delete_objects(
+              Bucket=s3.bucket, Delete={"Objects": objects_to_delete}
+            )
+            deleted_count += len(objects_to_delete)
+            objects_to_delete = []
+
+    if objects_to_delete:
+      s3.client.delete_objects(Bucket=s3.bucket, Delete={"Objects": objects_to_delete})
+      deleted_count += len(objects_to_delete)
+
+  except Exception as e:
+    context.log.error(f"Failed to clean up orphaned backups: {e}")
+
+  context.log.info(
+    f"Orphaned backup cleanup: {deleted_count} deleted, {skipped_tracked} tracked"
+  )
+
+  return {
+    "deleted_count": deleted_count,
+    "skipped_tracked": skipped_tracked,
+    "prefix": prefix,
+    "timestamp": now.isoformat(),
+  }
+
+
 @job(tags={"dagster/priority": "1", "dagster/max_retries": 3})
 def daily_backup_cleanup_job():
   """Daily cleanup of expired backups across all storage layers."""
   cleanup_tracked_backups()
   cleanup_instance_backups()
+  cleanup_orphaned_backups()
 
 
 daily_backup_cleanup_schedule = ScheduleDefinition(

--- a/robosystems/middleware/mcp/tools/graph_tools.py
+++ b/robosystems/middleware/mcp/tools/graph_tools.py
@@ -584,7 +584,7 @@ class CreateBackupTool:
           "retention_days": {
             "type": "integer",
             "minimum": 1,
-            "maximum": 2555,
+            "maximum": 90,
             "default": 30,
           },
         },
@@ -622,13 +622,21 @@ class CreateBackupTool:
       if admin_err:
         return admin_err
 
-      # Cap retention to the tier max.
+      # Cap retention to the tier max. Unconditional, mirroring the REST
+      # route: a missing graph row or tier falls back to the smallest tier's
+      # cap rather than skipping the clamp. Skipping it would let an uncapped
+      # value reach `expires_at` while the 90-day S3 lifecycle rule still
+      # deletes the object, leaving a completed record pointing at nothing.
       graph_record = Graph.get_by_id(graph_id, session)
-      if graph_record and graph_record.graph_tier:
-        tier_max = GraphTierConfig.get_backup_limits(graph_record.graph_tier).get(
-          "backup_retention_days", 90
-        )
-        retention_days = min(retention_days, tier_max)
+      backup_tier = (
+        str(graph_record.graph_tier)
+        if graph_record and graph_record.graph_tier
+        else "ladybug-standard"
+      )
+      tier_max = GraphTierConfig.get_backup_limits(backup_tier).get(
+        "backup_retention_days", 7
+      )
+      retention_days = min(retention_days, tier_max)
 
       run_config = build_graph_job_config(
         "backup_graph_job",

--- a/tests/dagster/test_backup_cleanup_jobs.py
+++ b/tests/dagster/test_backup_cleanup_jobs.py
@@ -8,12 +8,12 @@ class TestBackupCleanupJobDefinition:
   """Tests for backup cleanup job structure and registration."""
 
   @pytest.mark.unit
-  def test_job_has_two_ops(self):
-    """Test that the job graph contains exactly 2 ops."""
+  def test_job_has_three_ops(self):
+    """Test that the job graph contains exactly 3 ops."""
     from robosystems.dagster.jobs.backup_cleanup import daily_backup_cleanup_job
 
     assert isinstance(daily_backup_cleanup_job, JobDefinition)
-    assert len(daily_backup_cleanup_job.all_node_defs) == 2
+    assert len(daily_backup_cleanup_job.all_node_defs) == 3
 
   @pytest.mark.unit
   def test_job_op_names(self):
@@ -24,6 +24,7 @@ class TestBackupCleanupJobDefinition:
     assert op_names == {
       "cleanup_tracked_backups",
       "cleanup_instance_backups",
+      "cleanup_orphaned_backups",
     }
 
   @pytest.mark.unit
@@ -68,3 +69,99 @@ class TestBackupCleanupJobDefinition:
 
     schedule_names = [s.name for s in all_schedules]
     assert "daily_backup_cleanup_job_schedule" in schedule_names
+
+
+class TestOrphanedBackupCleanup:
+  """The orphan sweep removes S3 objects, so its guards matter more than its
+  happy path: it must never touch a tracked key, and it must resolve every
+  ambiguity toward keeping data."""
+
+  @staticmethod
+  def _run(objects, tracked, tier="ladybug-standard", graph_exists=True):
+    from unittest.mock import MagicMock, patch
+
+    from dagster import build_op_context
+
+    from robosystems.dagster.jobs.backup_cleanup import cleanup_orphaned_backups
+
+    session = MagicMock()
+
+    def _query(col):
+      q = MagicMock()
+      q.filter.return_value = [(k,) for k in tracked]
+      return q
+
+    session.query.side_effect = _query
+    db = MagicMock()
+    db.get_session.return_value.__enter__ = lambda *_: session
+    db.get_session.return_value.__exit__ = lambda *_: False
+
+    s3 = MagicMock()
+    s3.bucket = "test-bucket"
+    s3.client.get_paginator.return_value.paginate.return_value = [{"Contents": objects}]
+
+    graph = MagicMock()
+    graph.graph_tier = tier
+
+    with patch(
+      "robosystems.models.core.Graph.get_by_id",
+      return_value=graph if graph_exists else None,
+    ):
+      result = cleanup_orphaned_backups(build_op_context(), db, s3)
+
+    deleted = [
+      o["Key"]
+      for call in s3.client.delete_objects.call_args_list
+      for o in call.kwargs["Delete"]["Objects"]
+    ]
+    return result, deleted
+
+  @staticmethod
+  def _obj(key, days_old):
+    from datetime import UTC, datetime, timedelta
+
+    return {
+      "Key": key,
+      "LastModified": datetime.now(UTC) - timedelta(days=days_old),
+    }
+
+  @pytest.mark.unit
+  def test_deletes_orphan_past_tier_retention(self):
+    """A standard-tier orphan expires at 7 days, not at the 90-day lifecycle."""
+    key = "graph-backups/databases/kg1/full/backup-20260101_000000.lbug.zip"
+    result, deleted = self._run([self._obj(key, 30)], tracked=set())
+
+    assert deleted == [key]
+    assert result["deleted_count"] == 1
+
+  @pytest.mark.unit
+  def test_keeps_orphan_inside_tier_retention(self):
+    key = "graph-backups/databases/kg1/full/backup-20260101_000000.lbug.zip"
+    result, deleted = self._run([self._obj(key, 3)], tracked=set())
+
+    assert deleted == []
+    assert result["deleted_count"] == 0
+
+  @pytest.mark.unit
+  def test_never_touches_a_tracked_key(self):
+    """Tracked objects belong to op 1 — deleting them here would race it."""
+    key = "graph-backups/databases/kg1/full/backup-20260101_000000.lbug.zip"
+    result, deleted = self._run([self._obj(key, 3650)], tracked={key})
+
+    assert deleted == []
+    assert result["skipped_tracked"] == 1
+
+  @pytest.mark.unit
+  def test_unknown_graph_falls_back_to_the_90_day_maximum(self):
+    """An unresolvable graph must not be treated as short-retention."""
+    key = "graph-backups/databases/ghost/full/backup-20260101_000000.lbug.zip"
+    _, kept = self._run([self._obj(key, 30)], tracked=set(), graph_exists=False)
+    assert kept == []
+
+    _, swept = self._run([self._obj(key, 120)], tracked=set(), graph_exists=False)
+    assert swept == [key]
+
+  @pytest.mark.unit
+  def test_unparseable_key_is_left_in_place(self):
+    _, deleted = self._run([self._obj("graph-backups/databases/", 3650)], tracked=set())
+    assert deleted == []


### PR DESCRIPTION
On-demand is the intended backup model, so tier retention is the whole of the contract. Two paths were not honouring it.

## 1. MCP `create-backup` could bypass the retention clamp

| | REST | MCP (before) |
| --- | --- | --- |
| Input ceiling | `le=90` | **2555 days** |
| Clamp | unconditional | `if graph_record and graph_record.graph_tier:` |
| Fallback when tier missing | `7` (smallest tier) | `90` (largest) |

A graph with no registry row or a null `graph_tier` skipped the clamp entirely, so the requested value went straight to `expires_at` — potentially years out. The daily sweep then never selects it, while the 90-day S3 lifecycle rule deletes the object anyway, leaving a `completed` record pointing at nothing.

The REST route already clamps unconditionally, and its comment describes this exact failure mode. MCP now mirrors it, ceiling included.

Narrow in practice — it needs a missing row or null tier, and the tool is admin-gated behind `MCP_WORKSPACE_ENABLED`. All current graphs have tiers set.

## 2. Orphaned backup objects outlived their tier retention

`cleanup_tracked_backups` iterates `GraphBackup` rows, so an object whose record was never written — or was later removed — is invisible to it. It then survives until the 90-day S3 lifecycle rule regardless of tier, meaning a standard-tier orphan outlives its 7-day retention by more than twelve weeks.

Not hypothetical: prod holds a 2026-06-06 object under `kg19dcbe757481af06fc9b` (generic, `ladybug-standard`) with no row at all.

`cleanup_orphaned_backups` closes it, taking retention from the owning graph's tier parsed out of the key, so an orphan expires on the same clock its tracked siblings would have.

**It deletes data, so every ambiguity resolves toward keeping it:**

- Keys referenced by any `GraphBackup` row are skipped whatever the row's status — an `EXPIRED` row whose S3 delete failed belongs to op 1, and touching it here would race that op
- An unresolvable or unparseable graph falls back to the 90-day maximum rather than being treated as short-retention
- Scoped to the `graph-backups/databases/` prefix, so instance backups, shared-repository backups and the R2 `downloads/` distribution artifact are untouched

## Tests

Five added for the sweep, covering the guards rather than just the happy path: deletes past tier retention, keeps inside it, never touches a tracked key, falls back to 90 days for an unknown graph, and leaves an unparseable key in place. Job-shape tests updated to three ops, and verified to fail with the source reverted.

`just test-all` — 12,338 passed, 23 skipped; ruff, format, basedpyright, cf-lint clean.

## Not included

`max_backups_per_day` is configured per tier and surfaced through `/limits` and `/offering`, but no code path enforces it. Left out of this PR as a separate call — see the note on the linked spec.