### PR TITLE
fix(forecast): halt the walk when a month fails verification

### DIFF
--- a/robosystems/models/api/information_block.py
+++ b/robosystems/models/api/information_block.py
@@ -2002,7 +2002,11 @@ class ForecastMonthLite(BaseModel):
     None,
     description=(
       "Whether every rule evaluated against the month's scenario sets "
-      "passed (None = no rules ran for the month)."
+      "passed. Three states, and the third is not the first: ``true`` = "
+      "rules ran and all passed; ``false`` = at least one failed or "
+      "errored, which halts the walk (see ``halted_at``); ``null`` = **no "
+      "rules ran**, so the month is unverified rather than verified. "
+      "Treat null as absence of evidence, never as a pass."
     ),
   )
   verification_failures: list[str] = Field(
@@ -2084,6 +2088,18 @@ class ComputeForecastResponse(BaseModel):
   base_period: str = Field(..., description="Seed month the walk projected from.")
   months: int = Field(..., description="Forward months requested.")
   months_computed: list[ForecastMonthLite] = Field(default_factory=list)
+  halted_at: str | None = Field(
+    None,
+    description=(
+      "Month (``YYYY-MM``) where the walk stopped because verification "
+      "failed, or null if it ran the full horizon. Each month's opening "
+      "balances are the previous month's closing balances, so computing "
+      "past a failure yields months derived from a known-wrong one rather "
+      "than merely unverified months. When set, ``months_computed`` ends "
+      "at this month and is shorter than ``months``; the failing month's "
+      "facts are kept so the failure can be inspected."
+    ),
+  )
   skipped: list[SkippedForecastLite] = Field(default_factory=list)
   diagnostics: list[str] = Field(
     default_factory=list,

--- a/robosystems/operations/information_block/forecast_compute.py
+++ b/robosystems/operations/information_block/forecast_compute.py
@@ -495,6 +495,8 @@ def cmd_compute_forecast(
 
   # ── The walk ──────────────────────────────────────────────────────────
   months_computed: list[ForecastMonthLite] = []
+  halted_at: str | None = None
+  unverified_months: list[str] = []
   months = [add_months(mechanics.base_period, i) for i in range(1, months_n + 1)]
   active_instant_ids = {
     ar.target.id for ar in ordered_active if ar.target.period_type == "instant"
@@ -934,6 +936,36 @@ def cmd_compute_forecast(
       )
     )
 
+    # (f.1) Stop the walk on a failed month.
+    #
+    # Step (e) below rolls this month's closing balances into the next
+    # month's opening context, so continuing past a failure does not
+    # produce N-1 unverified months — it produces N-1 months *derived from
+    # a known-wrong one*, each reporting its own verification status as
+    # though it stood alone. Truncating is the honest answer: the caller
+    # gets the months that verified plus the one that broke, and
+    # ``halted_at`` names where to look.
+    #
+    # The failed month's facts are deliberately kept. They are already
+    # written by the time verification runs, and they are what you need in
+    # order to see *why* it failed.
+    #
+    # `None` does not halt. It means no rules produced results — an
+    # absence, not a failure — and halting on it would break any graph
+    # whose scenario structures carry no bound rules. But it must not read
+    # as a pass either, so it is collected and surfaced once below.
+    if verification_passed is False:
+      halted_at = month
+      diagnostics.append(
+        f"Walk halted at {month}: verification failed, and every later "
+        f"month would be derived from it. "
+        f"{len(months_computed)} of {months_n} months computed. "
+        f"Failures: {'; '.join(verification_failures[:3]) or 'unreported'}"
+      )
+      break
+    if verification_passed is None:
+      unverified_months.append(month)
+
     # (e) Roll the window: next month's [t-1]/carry context is this
     # month's resolved IS values + the full balance sheet.
     prior_values.clear()
@@ -948,6 +980,18 @@ def cmd_compute_forecast(
     prev_period_end = month_end
     prev_month = month
 
+  # An unverified month is not a verified one. Reported once rather than
+  # per-month so a rule corpus that never binds reads as one loud fact
+  # instead of N quiet ones — the failure mode being that `None` has always
+  # been indistinguishable from a pass to every consumer.
+  if unverified_months:
+    diagnostics.append(
+      f"{len(unverified_months)} month(s) ran no verification rules and are "
+      f"unverified, not verified: {', '.join(unverified_months[:6])}"
+      f"{' …' if len(unverified_months) > 6 else ''}. "
+      f"A scenario whose structures carry no bound rules cannot be gated."
+    )
+
   session.flush()
   return ComputeForecastResponse(
     structure_id=structure.id,
@@ -956,6 +1000,7 @@ def cmd_compute_forecast(
     base_period=mechanics.base_period,
     months=months_n,
     months_computed=months_computed,
+    halted_at=halted_at,
     skipped=skipped,
     diagnostics=diagnostics,
   )

--- a/tests/operations/information_block/test_forecast_compute.py
+++ b/tests/operations/information_block/test_forecast_compute.py
@@ -291,7 +291,15 @@ def _run(
   calc_dag: dict | None = None,
   base_is_facts: list[Any] | None = None,
   schedule_projection: ScheduleProjection | None = None,
+  verify: Any = None,
 ):
+  """``verify`` controls ``_verify_month_sets``.
+
+  Default ``None`` keeps the historical stub — ``(None, [])``, i.e. no
+  rules ran. Pass a callable to vary the result per month, which is what
+  makes the stop-the-walk behaviour testable at all; the fixed stub is
+  precisely why it never was.
+  """
   structure = _structure(mechanics)
   recorder = _Recorder()
 
@@ -342,7 +350,11 @@ def _run(
       return_value=SimpleNamespace(id="fs_lever", entity_id="ent_1"),
     ),
     patch.object(fc, "_upsert_month_set", recorder),
-    patch.object(fc, "_verify_month_sets", return_value=(None, [])),
+    patch.object(
+      fc,
+      "_verify_month_sets",
+      **({"side_effect": verify} if callable(verify) else {"return_value": (None, [])}),
+    ),
   ):
     response = fc.cmd_compute_forecast(
       _session(structure),
@@ -1009,3 +1021,112 @@ class TestEnsureScenarioDimension:
     assert dimension.value == "struct_a"
     assert dimension.name == "Scenario A"
     session.flush.assert_called_once()
+
+
+class TestStopTheWalk:
+  """A failed month halts the walk instead of seeding the next one.
+
+  Each month's opening balances are the previous month's closing balances,
+  so computing past a verification failure does not produce N-1 *unverified*
+  months — it produces N-1 months derived from a known-wrong one, each
+  reporting its own status as though it stood alone.
+
+  This class exists because nothing could have caught that: the harness
+  pinned `_verify_month_sets` to `(None, [])`, so `verification_passed` was
+  never anything but None in any test, and `grep verification_passed tests/`
+  returned zero hits.
+  """
+
+  @staticmethod
+  def _fail_on(period: str):
+    """Verification that fails for exactly one month."""
+
+    def _verify(session, *, sets, period_end, created_by, global_calculations):
+      month = f"{period_end.year:04d}-{period_end.month:02d}"
+      if month == period:
+        return False, [f"A = L + E off by 1200.00 in {month}"]
+      return True, []
+
+    return _verify
+
+  def test_halts_at_the_failing_month(self) -> None:
+    response, _ = _run(
+      _mechanics(FULL_LEVERS, horizon=6),
+      FULL_RULES,
+      FULL_LEVERS,
+      months=6,
+      verify=self._fail_on("2026-09"),
+    )
+
+    assert response.halted_at == "2026-09"
+    # The failing month is computed and kept — it is the evidence.
+    assert [m.period for m in response.months_computed] == [
+      "2026-07",
+      "2026-08",
+      "2026-09",
+    ]
+    assert response.months_computed[-1].verification_passed is False
+    assert response.months_computed[-1].verification_failures
+
+  def test_months_after_the_failure_are_never_computed(self) -> None:
+    """The point of halting: no month is derived from a known-wrong one."""
+    response, rec = _run(
+      _mechanics(FULL_LEVERS, horizon=6),
+      FULL_RULES,
+      FULL_LEVERS,
+      months=6,
+      verify=self._fail_on("2026-08"),
+    )
+
+    computed = {m.period for m in response.months_computed}
+    assert computed.isdisjoint({"2026-09", "2026-10", "2026-11", "2026-12"})
+    assert len(response.months_computed) < response.months
+    # And nothing was written for them either.
+    written = {str(p) for p in getattr(rec, "periods", [])}
+    assert not (written & {"2026-10", "2026-11", "2026-12"})
+
+  def test_halt_is_explained_not_inferred(self) -> None:
+    """A caller must not have to spot a length mismatch to notice."""
+    response, _ = _run(
+      _mechanics(FULL_LEVERS, horizon=6),
+      FULL_RULES,
+      FULL_LEVERS,
+      months=6,
+      verify=self._fail_on("2026-08"),
+    )
+
+    assert any("halted at 2026-08" in d for d in response.diagnostics)
+    assert any("off by 1200.00" in d for d in response.diagnostics)
+
+  def test_all_passing_runs_the_full_horizon(self) -> None:
+    response, _ = _run(
+      _mechanics(FULL_LEVERS, horizon=6),
+      FULL_RULES,
+      FULL_LEVERS,
+      months=4,
+      verify=lambda *a, **k: (True, []),
+    )
+
+    assert response.halted_at is None
+    assert len(response.months_computed) == 4
+    assert all(m.verification_passed is True for m in response.months_computed)
+
+  def test_no_rules_does_not_halt_but_is_not_a_pass(self) -> None:
+    """`None` is absence of evidence, not evidence of correctness.
+
+    Halting on it would break any graph whose scenario structures carry no
+    bound rules. But it has always been indistinguishable from a pass to
+    every consumer, so it has to say so out loud.
+    """
+    response, _ = _run(
+      _mechanics(FULL_LEVERS),
+      FULL_RULES,
+      FULL_LEVERS,
+      months=3,
+      verify=lambda *a, **k: (None, []),
+    )
+
+    assert response.halted_at is None
+    assert len(response.months_computed) == 3
+    assert all(m.verification_passed is None for m in response.months_computed)
+    assert any("unverified, not verified" in d for d in response.diagnostics)


### PR DESCRIPTION
## The gate didn't exist

`ref/forecasting.md` §4 calls it *"the audit-grade claim no spreadsheet and no QuickBooks-adjacent FP&A tool makes: a scenario is a balanced, articulated model by construction, and one that doesn't verify doesn't publish."*

There was no mechanism behind it. `verification_passed` was computed at `forecast_compute.py:911` — **after** the month's fact sets were already written — attached to `ForecastMonthLite`, and **read by nothing that made a decision**. There is no publish step for a forecast, so there was nothing for it to gate.

## Ungated isn't the worst of it

The walk is sequential. `prior_values` and `prior_bs` roll a month's closing balances into the next month's opening context **regardless of outcome**:

```
month N fails  →  recorded as failed
               →  prior_values / prior_bs roll forward anyway
               →  month N+1 derives from the failed month
```

So a failure at month 3 of 24 didn't produce 21 *unverified* months. It produced 21 months **derived from a known-wrong one**, each reporting its own verification status as though it stood alone.

## What changed

**`False` halts.** The failing month's facts are kept — they're already written when verification runs, and they're what you need to see *why* it failed. `halted_at` names the month, `months_computed` ends there, and a diagnostic carries the failing rule messages so a caller doesn't infer the halt from a length mismatch.

**`None` does not halt.** It means no rules produced results — an absence, not a failure — and halting would break any graph whose scenario structures carry no bound rules. But every consumer had been treating `None` and `True` identically, so a rule corpus that silently stopped binding would have made the guarantee vacuous **with no signal at all**. The response now carries one summary diagnostic naming the unverified months (once, not per-month), and the field description says plainly that null is not a pass.

## Why nothing caught it

The harness pinned `_verify_month_sets` to `(None, [])`, so `verification_passed` was never anything but `None` in any test, and `grep -rn "verification_passed" tests/` returned **zero hits**.

The stub didn't hide a broken gate — it removed the only thing that would have shown there wasn't one. Both correctness bugs previously fixed on this path (PP&E net-book-value routing, the missing CF investing/financing sections) were found by reading code and reproducing by hand.

The harness now takes a `verify` parameter. `TestStopTheWalk` covers halt, no-halt-on-`None`, full horizon, and that the halt is *explained* rather than inferred. **Verified they fail when the halt is neutralized.**

## Behaviour change worth noting

A scenario with a mid-horizon failure will now truncate where it previously rendered fully. Live scenarios verify green, so no current impact expected — but it's a visible change if one starts failing.

877 passed across `information_block` + `models/api`; `just test-code` clean. Full suite not run.