### PR TITLE
fix(backup): make restore fail closed

### DIFF
--- a/robosystems/dagster/jobs/graph.py
+++ b/robosystems/dagster/jobs/graph.py
@@ -348,7 +348,11 @@ def restore_backup(
     s3_key = backup_record.s3_key
     compression_enabled = backup_record.compression_enabled
 
-  # Create system backup before restore if requested
+  # Snapshot the current database before overwriting it. A failure here aborts:
+  # the restore is destructive and irreversible, `create_system_backup=False` is
+  # passed downstream on the strength of this snapshot existing, and continuing
+  # would leave the graph with no rollback at all. An operator who wants the
+  # restore anyway can re-run with create_system_backup=false and say so.
   if config.create_system_backup:
     context.log.info("Creating system backup before restore...")
     try:
@@ -368,7 +372,11 @@ def restore_backup(
       finally:
         loop.close()
     except Exception as e:
-      context.log.warning(f"Failed to create system backup: {e}")
+      raise Failure(
+        f"Safety backup failed for graph {config.graph_id}, so the restore was "
+        f"not attempted — it would have overwritten the database with no "
+        f"rollback: {e}"
+      ) from e
 
   context.log.info(f"Restoring from {s3_bucket}/{s3_key}")
 
@@ -395,14 +403,23 @@ def restore_backup(
   finally:
     loop.close()
 
-  verification_status = "not_verified"
+  # `restore_with_sse` reports failure by returning rather than raising, so an
+  # unchecked result reads as success and the op returns "completed" over a
+  # graph that was just overwritten by a restore that did not finish. The
+  # worker fails its task on a failed integrity check or post-restore
+  # verification, so this status is the authoritative outcome.
+  if restore_result.get("status") != "completed":
+    raise Failure(
+      f"Restore of graph {config.graph_id} from backup {config.backup_id} did "
+      f"not complete (status={restore_result.get('status')!r}): "
+      f"{restore_result.get('error') or 'no error reported'}"
+    )
+
+  # Verification is not optional in the worker — `verify_after_restore` only
+  # decides whether the caller is told about it.
+  verification_status = "verified" if config.verify_after_restore else "not_verified"
   if config.verify_after_restore:
-    if restore_result.get("status") == "completed":
-      verification_status = "verified"
-      context.log.info("Restore verification successful")
-    else:
-      verification_status = "failed"
-      context.log.warning(f"Restore status: {restore_result.get('status')}")
+    context.log.info("Restore verification successful")
 
   with db.get_session() as session:
     backup_record = GraphBackup.get_by_id(config.backup_id, session)

--- a/robosystems/graph_api/routers/databases/restore.py
+++ b/robosystems/graph_api/routers/databases/restore.py
@@ -50,6 +50,12 @@ async def perform_restore(
   overwritten; a failed snapshot aborts the restore rather than leaving the
   old data unrecoverable.
 
+  Nothing on disk is touched until the replacement payload has been downloaded
+  and its checksum verified. ``restore_backup`` does both before it reaches the
+  importer, and the importer takes the safety snapshot immediately before it
+  overwrites — so every abort short of the final copy leaves the existing
+  database exactly as it was.
+
   Encryption and compression are read from the backup's own S3 metadata, so
   the caller does not describe them.
   """
@@ -77,28 +83,20 @@ async def perform_restore(
       f"original_size: {backup_metadata.original_size}"
     )
 
-    # Deleting here rather than in the backup manager: only this process holds
-    # the LadybugDB connections that must close before the files go away.
+    # Only this process holds the LadybugDB connections, so they must close
+    # here — but closing is all that happens now. The files themselves are
+    # replaced by the importer, after the payload is verified and the safety
+    # snapshot is taken. Deleting them here instead used to defeat both: a
+    # failed download left the graph with nothing, and the importer's
+    # abort-on-failed-snapshot guard was dead code because it is conditioned on
+    # the database still existing.
     if connection_pool and force_overwrite:
-      import shutil
-      from pathlib import Path
-
-      from robosystems.middleware.graph.utils import MultiTenantUtils
-
-      logger.info(f"[Task {task_id}] Deleting existing database for {graph_id}")
-
       connection_pool.close_database_connections(graph_id)
-      logger.info(f"[Task {task_id}] Closed LadybugDB connections")
+      logger.info(f"[Task {task_id}] Closed LadybugDB connections for {graph_id}")
 
-      db_path = Path(MultiTenantUtils.get_database_path_for_graph(graph_id))
-      if db_path.exists():
-        if db_path.is_file():
-          db_path.unlink()
-        else:
-          shutil.rmtree(db_path)
-        logger.info(f"[Task {task_id}] Deleted existing database files at {db_path}")
-
-    # drop_existing=False: the force_overwrite branch above already removed it.
+    # drop_existing=False: the full-dump importer overwrites in place, and
+    # doing it there keeps the existing database intact until the replacement
+    # is on disk and checksum-verified.
     restore_job = RestoreJob(
       graph_id=graph_id,
       backup_metadata=backup_metadata,

--- a/robosystems/operations/graph/engine/backup_manager.py
+++ b/robosystems/operations/graph/engine/backup_manager.py
@@ -1100,6 +1100,12 @@ class BackupManager:
     ``create_system_backup`` is False, the existing database is snapshotted to
     S3 first and a snapshot failure aborts the restore — losing the old data
     with no rollback is worse than not restoring.
+
+    This is the only place the existing database is removed. Callers must not
+    clear it first: the snapshot above is conditioned on the target still
+    existing, so a caller that deletes ahead of us silently turns the safety
+    net off, and a download or checksum failure then has nothing to fall back
+    to. ``backup_data`` is already verified by the time it arrives here.
     """
     logger.info(f"Importing full dump to graph '{graph_id}'")
 
@@ -1194,11 +1200,26 @@ class BackupManager:
       with zipfile.ZipFile(zip_file, "r") as zf:
         zf.extractall(temp_path)
 
+      # The WAL goes before the database file, same as DatabaseManager.delete:
+      # left behind, LadybugDB replays the outgoing database's un-checkpointed
+      # writes on top of the restored one.
+      wal_path = Path(f"{target_path}.wal")
+      if wal_path.exists():
+        wal_path.unlink()
+        logger.info(f"Removed stale WAL before restoring graph '{graph_id}'")
+
+      # Clear the existing target whatever shape it has — a single .lbug file
+      # in current engine versions, a directory in older ones — since the
+      # incoming dump may not be the same shape.
+      if os.path.exists(target_path):
+        if os.path.isfile(target_path):
+          os.unlink(target_path)
+        else:
+          shutil.rmtree(target_path)
+
       if (temp_path / f"{graph_id}.lbug").exists():
         shutil.copy2(temp_path / f"{graph_id}.lbug", target_path)
       else:
-        if os.path.exists(target_path):
-          shutil.rmtree(target_path)
         shutil.copytree(temp_path / graph_id, target_path)
 
       if progress_tracker:

--- a/tests/dagster/test_graph_jobs.py
+++ b/tests/dagster/test_graph_jobs.py
@@ -6,6 +6,8 @@ wait-for-capacity graph creation replaced by worker task + sensor retry.
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from robosystems.dagster.jobs.graph import (
   _emit_completion_sync,
   _emit_failure_sync,
@@ -71,3 +73,101 @@ class TestSyncSSEHelpers:
 
       # Should not raise
       _emit_progress_sync("op123", "test", 50)
+
+
+class TestRestoreBackupOpFailsClosed:
+  """A restore overwrites a database irreversibly, so every failure on the
+  path must stop the job rather than return a "completed" envelope over it.
+
+  `restore_with_sse` reports failure by returning `{"status": "failed"}`, and
+  the safety snapshot is the only rollback the operation has.
+  """
+
+  @staticmethod
+  def _run(restore_status="completed", backup_raises=False, create_system_backup=True):
+    from dagster import build_op_context
+
+    from robosystems.dagster.jobs.graph import RestoreGraphConfig, restore_backup
+
+    backup_record = MagicMock()
+    backup_record.graph_id = "kg123"
+    backup_record.s3_bucket = "bucket"
+    backup_record.s3_key = "key"
+    backup_record.compression_enabled = True
+
+    session = MagicMock()
+    db = MagicMock()
+    db.get_session.return_value.__enter__ = lambda *_: session
+    db.get_session.return_value.__exit__ = lambda *_: False
+
+    client = MagicMock()
+
+    async def _restore(**_kwargs):
+      return {"status": restore_status, "error": "boom"}
+
+    async def _close():
+      return None
+
+    client.restore_with_sse = _restore
+    client.close = _close
+
+    async def _create_client(*_a, **_k):
+      return client
+
+    manager = MagicMock()
+
+    async def _create_backup(_job):
+      if backup_raises:
+        raise RuntimeError("s3 unavailable")
+      return MagicMock(s3_key="safety.zip")
+
+    manager.create_backup = _create_backup
+
+    with (
+      patch(
+        "robosystems.models.core.GraphBackup.get_by_id", return_value=backup_record
+      ),
+      patch(
+        "robosystems.graph_api.client.factory.GraphClientFactory.create_client",
+        _create_client,
+      ),
+      patch(
+        "robosystems.operations.graph.engine.backup_manager.create_backup_manager",
+        return_value=manager,
+      ),
+    ):
+      return restore_backup(
+        build_op_context(),
+        db,
+        MagicMock(),
+        RestoreGraphConfig(
+          graph_id="kg123",
+          backup_id="backup1",
+          create_system_backup=create_system_backup,
+        ),
+      )
+
+  @pytest.mark.unit
+  def test_completed_restore_returns_completed(self):
+    result = self._run()
+
+    assert result["status"] == "completed"
+    assert result["verification_status"] == "verified"
+
+  @pytest.mark.unit
+  def test_failed_restore_raises(self):
+    """The graph has already been overwritten by this point — reporting
+    success would hide that from the operator and from the SSE envelope."""
+    from dagster import Failure
+
+    with pytest.raises(Failure, match="did not complete"):
+      self._run(restore_status="failed")
+
+  @pytest.mark.unit
+  def test_safety_backup_failure_aborts_before_restore(self):
+    """`create_system_backup=False` is passed downstream on the strength of
+    this snapshot, so continuing without it leaves no rollback anywhere."""
+    from dagster import Failure
+
+    with pytest.raises(Failure, match="Safety backup failed"):
+      self._run(backup_raises=True)

--- a/tests/operations/graph/engine/test_backup_manager_extended.py
+++ b/tests/operations/graph/engine/test_backup_manager_extended.py
@@ -1659,3 +1659,91 @@ class TestCreateBackupManagerFactory:
       mgr = create_backup_manager()
 
       assert isinstance(mgr, BackupManager)
+
+
+# ===========================================================================
+# _import_full_dump — the only place the existing database is removed
+# ===========================================================================
+
+
+def _full_dump_zip(graph_id: str, payload: bytes) -> bytes:
+  """A full-dump archive of the single-file shape the engine writes today."""
+  buf = io.BytesIO()
+  with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+    zf.writestr(f"{graph_id}.lbug", payload)
+  return buf.getvalue()
+
+
+@pytest.mark.unit
+class TestImportFullDumpRemovesTarget:
+  """The importer owns removal of the outgoing database.
+
+  `perform_restore` used to clear the files before the payload was downloaded,
+  which lost the graph outright on a failed download and silently disabled the
+  snapshot guard below (it is conditioned on the target still existing).
+  """
+
+  @pytest.mark.asyncio
+  async def test_replaces_existing_file_and_deletes_stale_wal(self, manager, tmp_path):
+    target = tmp_path / "test_graph.lbug"
+    target.write_bytes(b"outgoing database")
+    wal = tmp_path / "test_graph.lbug.wal"
+    wal.write_bytes(b"un-checkpointed writes from the outgoing database")
+
+    with patch(
+      "robosystems.operations.graph.engine.backup_manager.MultiTenantUtils"
+    ) as mock_mt:
+      mock_mt.get_database_path_for_graph.return_value = str(target)
+
+      await manager._import_full_dump(
+        "test_graph",
+        _full_dump_zip("test_graph", b"restored database"),
+        create_system_backup=False,
+      )
+
+    assert target.read_bytes() == b"restored database"
+    # A surviving WAL is replayed against whatever now holds the same name.
+    assert not wal.exists()
+
+  @pytest.mark.asyncio
+  async def test_replaces_existing_directory_shape(self, manager, tmp_path):
+    """Older engine versions stored a database as a directory."""
+    target = tmp_path / "test_graph.lbug"
+    target.mkdir()
+    (target / "stale.bin").write_bytes(b"outgoing")
+
+    with patch(
+      "robosystems.operations.graph.engine.backup_manager.MultiTenantUtils"
+    ) as mock_mt:
+      mock_mt.get_database_path_for_graph.return_value = str(target)
+
+      await manager._import_full_dump(
+        "test_graph",
+        _full_dump_zip("test_graph", b"restored database"),
+        create_system_backup=False,
+      )
+
+    assert target.is_file()
+    assert target.read_bytes() == b"restored database"
+
+  @pytest.mark.asyncio
+  async def test_failed_snapshot_leaves_database_untouched(self, manager, tmp_path):
+    """The abort-on-failed-snapshot guard must fire before anything is removed."""
+    target = tmp_path / "test_graph.lbug"
+    target.write_bytes(b"outgoing database")
+
+    manager.s3_adapter.upload_backup = AsyncMock(return_value=None)
+
+    with patch(
+      "robosystems.operations.graph.engine.backup_manager.MultiTenantUtils"
+    ) as mock_mt:
+      mock_mt.get_database_path_for_graph.return_value = str(target)
+
+      with pytest.raises(RuntimeError, match="system backup"):
+        await manager._import_full_dump(
+          "test_graph",
+          _full_dump_zip("test_graph", b"restored database"),
+          create_system_backup=True,
+        )
+
+    assert target.read_bytes() == b"outgoing database"


### PR DESCRIPTION
## Summary

Restore had no fail-closed behavior on any of its failure paths. A restore that did not finish came back as a successful operation over a graph that had already been overwritten.

Restore is permitted on custom graphs and entity subgraphs. Subgraphs have no materialization path to rebuild from, so these are exactly the graphs with no other recovery route — which is what makes the reporting gap matter.

## Changes

- **Safety backup is now mandatory when requested.** A failure aborts instead of logging a warning and continuing. `create_system_backup=false` remains the explicit opt-out, and is what the job passes downstream on the strength of the snapshot existing.
- **A non-completed restore result raises.** The client reports failure by returning rather than raising, so the unchecked result read as success.
- **Removal moved to the importer.** The worker closes LadybugDB connections but no longer deletes files. The importer removes the existing database after the payload is downloaded and checksum-verified and after the safety snapshot is taken, so every abort short of the final copy leaves the database as it was. This also restores the importer's abort-on-failed-snapshot guard, which was dead code — it is conditioned on the target still existing, and the caller had already deleted it.
- **Stale WAL is cleared before the dump lands**, matching `DatabaseManager.delete`. Left behind, it is replayed against the restored database. Both on-disk shapes (single `.lbug` file, legacy directory) are handled.

## Testing

Six new tests, verified to fail against the pre-fix code:
- restore op returns completed / raises on failed status / aborts on safety-backup failure
- importer replaces either on-disk shape, deletes the stale WAL, and leaves the database untouched when the snapshot fails

`just test-code` clean; 201 restore/backup tests pass.

## Notes

Predates v1.7.6, but PR #1105 widened restore to entity subgraphs, which increased the blast radius.