### PR TITLE
fix(forecast): drop scenario months past the horizon a run actually reached

### DIFF
--- a/robosystems/operations/information_block/forecast_compute.py
+++ b/robosystems/operations/information_block/forecast_compute.py
@@ -992,6 +992,23 @@ def cmd_compute_forecast(
       f"A scenario whose structures carry no bound rules cannot be gated."
     )
 
+  # The scenario must hold exactly the months this run produced. Anything past
+  # the last one belongs to a longer previous run, and the month it chained
+  # from has just been rewritten underneath it — halting without this leaves
+  # the tail of the old forecast readable, and reading as verified.
+  if months_computed:
+    dropped = _invalidate_stale_tail(
+      session,
+      scenario_id=scenario_id,
+      entity_id=entity_id,
+      through_period_end=months_computed[-1].period_end,
+    )
+    if dropped:
+      diagnostics.append(
+        f"Dropped {dropped} scenario fact set(s) past {months_computed[-1].period}, "
+        f"left over from a longer previous run."
+      )
+
   session.flush()
   return ComputeForecastResponse(
     structure_id=structure.id,
@@ -1203,6 +1220,60 @@ def _verify_month_sets(
   if not any_results:
     return None, []
   return not failures, failures
+
+
+def _invalidate_stale_tail(
+  session: Session,
+  *,
+  scenario_id: str,
+  entity_id: str,
+  through_period_end: date,
+) -> int:
+  """Delete scenario sets beyond the last month this run produced.
+
+  The walk upserts month by month, so a run that halts at month 3 — or one
+  asked for a shorter horizon than the run before it — leaves the previous
+  run's months 4..N sitting in the scenario, fully queryable, each carrying
+  its own passing verification result. They do not merely go stale: every one
+  of them was chained off a month that has since been replaced, so they
+  describe a forecast that no longer exists while reading as current.
+
+  Safe to scope by ``scenario_id`` alone: it points at the owning forecast
+  block, and every set carrying it is produced here.
+
+  Facts cascade with their FactSet at the DB level;
+  ``VerificationResult.fact_set_id`` carries no FK, so those rows go
+  explicitly — the same sweep ``delete_scenario`` does.
+  """
+  stale = (
+    session.execute(
+      select(FactSet).where(
+        FactSet.scenario_id == scenario_id,
+        FactSet.entity_id == entity_id,
+        FactSet.period_end > through_period_end,
+      )
+    )
+    .scalars()
+    .all()
+  )
+  if not stale:
+    return 0
+
+  from robosystems.models.extensions import VerificationResult
+
+  set_ids = [fs.id for fs in stale]
+  for result in (
+    session.execute(
+      select(VerificationResult).where(VerificationResult.fact_set_id.in_(set_ids))
+    )
+    .scalars()
+    .all()
+  ):
+    session.delete(result)
+  for fact_set in stale:
+    session.delete(fact_set)
+  session.flush()
+  return len(set_ids)
 
 
 def _upsert_month_set(

--- a/tests/operations/information_block/test_forecast_compute.py
+++ b/tests/operations/information_block/test_forecast_compute.py
@@ -1130,3 +1130,107 @@ class TestStopTheWalk:
     assert len(response.months_computed) == 3
     assert all(m.verification_passed is None for m in response.months_computed)
     assert any("unverified, not verified" in d for d in response.diagnostics)
+
+
+class TestStaleTailInvalidation:
+  """A scenario must hold exactly the months the last run produced.
+
+  `_upsert_month_set` only touches months the walk reaches, so a run that
+  halts at month 3 — or one asked for a shorter horizon than the run before
+  it — used to leave the previous run's months 4..N in place. They stayed
+  fully queryable and carried their own passing verification results, while
+  the month they chained from had just been rewritten underneath them.
+  """
+
+  @staticmethod
+  def _session_with(stale_sets, verification_rows=()):
+    """A session whose first query returns fact sets, second verification rows."""
+    session = MagicMock()
+    results = [list(stale_sets), list(verification_rows)]
+    calls = []
+
+    def _execute(stmt):
+      calls.append(stmt)
+      out = MagicMock()
+      out.scalars.return_value.all.return_value = results.pop(0) if results else []
+      return out
+
+    session.execute.side_effect = _execute
+    return session
+
+  def test_drops_sets_past_the_last_computed_month(self) -> None:
+    from datetime import date
+
+    stale = [
+      SimpleNamespace(id="fs_oct"),
+      SimpleNamespace(id="fs_nov"),
+    ]
+    vr = [SimpleNamespace(id="vr_oct")]
+    session = self._session_with(stale, vr)
+
+    dropped = fc._invalidate_stale_tail(
+      session,
+      scenario_id="struct_budget",
+      entity_id="ent_1",
+      through_period_end=date(2026, 9, 30),
+    )
+
+    assert dropped == 2
+    deleted = [c.args[0] for c in session.delete.call_args_list]
+    # Verification rows carry no FK to fact_sets, so they must go explicitly
+    # or they orphan invisibly and keep reporting a pass.
+    assert vr[0] in deleted
+    assert stale[0] in deleted and stale[1] in deleted
+
+  def test_no_tail_is_a_no_op(self) -> None:
+    from datetime import date
+
+    session = self._session_with([])
+
+    assert (
+      fc._invalidate_stale_tail(
+        session,
+        scenario_id="struct_budget",
+        entity_id="ent_1",
+        through_period_end=date(2026, 9, 30),
+      )
+      == 0
+    )
+    session.delete.assert_not_called()
+
+  def test_halted_walk_invalidates_from_the_halt_month(self) -> None:
+    """The boundary is the last month actually produced, not the horizon."""
+    with patch.object(fc, "_invalidate_stale_tail", return_value=3) as mock_inv:
+      response, _ = _run(
+        _mechanics(FULL_LEVERS, horizon=6),
+        FULL_RULES,
+        FULL_LEVERS,
+        months=6,
+        verify=TestStopTheWalk._fail_on("2026-09"),
+      )
+
+    assert response.halted_at == "2026-09"
+    assert (
+      mock_inv.call_args.kwargs["through_period_end"]
+      == response.months_computed[-1].period_end
+    )
+    assert mock_inv.call_args.kwargs["scenario_id"] == "struct_budget"
+    assert any("past 2026-09" in d for d in response.diagnostics)
+
+  def test_shorter_horizon_invalidates_the_previous_tail(self) -> None:
+    """Not only halts: a 3-month rerun after a 12-month one has the same tail."""
+    with patch.object(fc, "_invalidate_stale_tail", return_value=9) as mock_inv:
+      response, _ = _run(
+        _mechanics(FULL_LEVERS, horizon=12),
+        FULL_RULES,
+        FULL_LEVERS,
+        months=3,
+        verify=lambda *a, **k: (True, []),
+      )
+
+    assert response.halted_at is None
+    assert len(response.months_computed) == 3
+    assert (
+      mock_inv.call_args.kwargs["through_period_end"]
+      == response.months_computed[-1].period_end
+    )


### PR DESCRIPTION
## Summary

PR #1109 stopped the forecast walk at a failed month. But the walk only upserts months it reaches, so halting leaves the previous run's tail behind.

A rerun that halts at month 3, after a run that produced 12, leaves months 4-12 in the scenario — fully queryable, each carrying its own passing `VerificationResult` — while the month they chained from has just been rewritten underneath them. They describe a forecast that no longer exists and read as current.

Not only halts: a 3-month recompute after a 12-month one leaves the same nine-month tail.

## Changes

- `_invalidate_stale_tail` removes scenario fact sets past the last month the run actually produced, called with `months_computed[-1].period_end` as the boundary.
- Scoping by `scenario_id` alone is safe — it points at the owning forecast block, and every set carrying it is produced by `compute_forecast`.
- Facts cascade with their FactSet (`facts.fact_set_id` is `ON DELETE CASCADE`). `verification_results.fact_set_id` carries no FK, so those rows go explicitly — the same sweep `delete_scenario` already does.
- What was dropped lands in `diagnostics` rather than being left for the caller to infer.

## Testing

Four new tests, verified to fail without the fix:
- drops sets past the boundary and sweeps their verification rows
- no-tail is a no-op
- a halted walk invalidates from the halt month, not the requested horizon
- a shorter rerun invalidates the previous run's tail

500 information_block tests pass; `just test-code` clean.

## Note

Existing scenarios already carrying a stale tail are not retroactively cleaned — the next `compute-forecast` on each block clears it.