### PR TITLE
fix: close three retention, validation, and reporting gaps

### DIFF
--- a/robosystems/admin/commands/users_orgs.py
+++ b/robosystems/admin/commands/users_orgs.py
@@ -182,6 +182,11 @@ def deactivate_user(client, identifier, yes):
 
   console.print(f"\n[green]Deactivated {result['email']}[/green]")
   console.print(f"  API keys revoked: {result['api_keys_revoked']}")
+  if result.get("api_keys_failed"):
+    console.print(
+      f"[red]  {result['api_keys_failed']} API key(s) could NOT be revoked — "
+      f"the account is only partially locked down. Re-run this command.[/red]"
+    )
   console.print("  All sessions invalidated.")
   if not result["changed"]:
     console.print("[yellow]  (was already inactive — re-ran the revocation)[/yellow]")

--- a/robosystems/dagster/jobs/backup_cleanup.py
+++ b/robosystems/dagster/jobs/backup_cleanup.py
@@ -39,15 +39,26 @@ def cleanup_tracked_backups(
   db: DatabaseResource,
   s3: S3Resource,
 ) -> dict[str, Any]:
-  """Delete S3 objects and mark GraphBackup records as EXPIRED.
+  """Delete S3 objects, then mark the GraphBackup records EXPIRED.
 
   Covers both customer API backups and SEC pipeline backups,
   since both create GraphBackup records with expires_at.
+
+  Order matters, and it used to be the other way around. Marking the row
+  first drops it out of ``get_expired_backups`` forever, and the orphan sweep
+  skips every key a row still references — so a single transient S3 error
+  meant nothing ever retried the delete and the object rode the 90-day
+  lifecycle rule regardless of the graph's tier. A standard-tier backup
+  outlived its 7-day retention by twelve weeks on one failed API call.
+
+  Leaving the row un-expired is the retry: tomorrow's run picks it up again.
+  Deleting an absent key is a success in S3, so a row whose object is already
+  gone still settles on the next pass.
   """
   from robosystems.models.core import GraphBackup
 
   expired_count = 0
-  error_count = 0
+  deferred_count = 0
 
   with db.get_session() as session:
     expired_backups = GraphBackup.get_expired_backups(session)
@@ -55,41 +66,29 @@ def cleanup_tracked_backups(
 
     for backup in expired_backups:
       try:
-        # Mark record as expired FIRST — if S3 deletion fails afterward,
-        # the record is already expired and the S3 lifecycle rule (90 days)
-        # will clean up the orphaned object as a safety net.
-        backup.expire_backup(session)
+        s3.client.delete_object(Bucket=backup.s3_bucket, Key=backup.s3_key)
 
-        # Delete S3 backup object
-        try:
-          s3.client.delete_object(Bucket=backup.s3_bucket, Key=backup.s3_key)
-        except Exception as e:
-          context.log.warning(f"Failed to delete S3 object {backup.s3_key}: {e}")
-
-        # Delete S3 metadata object if present
         if backup.s3_metadata_key:
-          try:
-            s3.client.delete_object(Bucket=backup.s3_bucket, Key=backup.s3_metadata_key)
-          except Exception as e:
-            context.log.warning(
-              f"Failed to delete metadata {backup.s3_metadata_key}: {e}"
-            )
+          s3.client.delete_object(Bucket=backup.s3_bucket, Key=backup.s3_metadata_key)
 
+        backup.expire_backup(session)
         expired_count += 1
 
       except Exception as e:
-        context.log.error(
-          f"Failed to clean up backup {backup.id} for graph {backup.graph_id}: {e}"
+        # Deliberately left un-expired so the next daily run retries it.
+        context.log.warning(
+          f"Deferred cleanup of backup {backup.id} for graph {backup.graph_id} "
+          f"to the next run: {e}"
         )
-        error_count += 1
+        deferred_count += 1
 
   context.log.info(
-    f"Tracked backup cleanup: {expired_count} expired, {error_count} errors"
+    f"Tracked backup cleanup: {expired_count} expired, {deferred_count} deferred"
   )
 
   return {
     "expired_count": expired_count,
-    "error_count": error_count,
+    "deferred_count": deferred_count,
     "timestamp": datetime.now(UTC).isoformat(),
   }
 
@@ -188,9 +187,11 @@ def cleanup_orphaned_backups(
 
   try:
     with db.get_session() as session:
-      # Every key any row still points at, whatever its status. An EXPIRED row
-      # whose S3 delete failed is already the lifecycle rule's problem, and
-      # deleting it here would race op 1.
+      # Every key any row still points at, whatever its status — deleting one
+      # here would race op 1. Op 1 no longer strands anything behind this
+      # guard: a row is marked EXPIRED only once its objects are actually
+      # gone, so a failed delete stays visible to tomorrow's tracked sweep
+      # instead of becoming the lifecycle rule's problem.
       tracked_keys: set[str] = {
         key
         for (key,) in session.query(GraphBackup.s3_key).filter(

--- a/robosystems/models/api/admin/users.py
+++ b/robosystems/models/api/admin/users.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class UserResponse(BaseModel):
@@ -79,7 +79,18 @@ class UserStatusResponse(BaseModel):
   email: str
   is_active: bool
   changed: bool
-  api_keys_revoked: int
+  api_keys_revoked: int = Field(
+    ..., description="API keys actually revoked, not the number attempted."
+  )
+  api_keys_failed: int = Field(
+    0,
+    description=(
+      "API keys that could not be revoked. Non-zero means the account is only "
+      "partially locked down — the surviving keys are refused by the "
+      "user.is_active guard, but the rows are still live. Re-run the "
+      "deactivation."
+    ),
+  )
 
 
 class UserActivityResponse(BaseModel):

--- a/robosystems/models/core/user/user.py
+++ b/robosystems/models/core/user/user.py
@@ -125,8 +125,8 @@ class User(Model):
       session.rollback()
       raise
 
-  def deactivate(self, session: Session) -> None:
-    """Deactivate the user.
+  def deactivate(self, session: Session) -> int:
+    """Deactivate the user, returning how many API keys were revoked.
 
     Bumps ``session_version``, which invalidates every JWT issued for this
     user, and revokes all of the user's API keys. If the user is reactivated
@@ -146,7 +146,7 @@ class User(Model):
       session.commit()
       session.refresh(self)
       self._invalidate_auth_cache()
-      self._revoke_api_keys(session)
+      return self._revoke_api_keys(session)
     except SQLAlchemyError:
       session.rollback()
       raise
@@ -175,14 +175,20 @@ class User(Model):
       session.rollback()
       raise
 
-  def _revoke_api_keys(self, session: Session) -> None:
-    """Deactivate all of this user's active API keys and clear their caches.
+  def _revoke_api_keys(self, session: Session) -> int:
+    """Deactivate this user's active API keys and clear their caches.
+
+    Returns how many were actually revoked, which is what callers must report:
+    revocation is best-effort per key, so the number attempted is not the
+    number that took, and an incident response that reads "4 keys revoked"
+    when one failed is worse than no number at all.
 
     Called on deactivate so programmatic access is revoked alongside JWT
     invalidation. Each key's ``deactivate`` flips ``is_active`` and invalidates
     that key's validation-cache entry. Failures are logged per-key but never
-    abort the user deactivation (best-effort); the ``user.is_active`` guard in
-    ``validate_api_key`` is the authoritative backstop if a key is missed.
+    abort the user deactivation; the ``user.is_active`` guard in
+    ``validate_api_key`` is the authoritative backstop if a key is missed, and
+    re-running the deactivation retries whatever did not take.
     """
     from .user_api_key import UserAPIKey
 
@@ -190,15 +196,27 @@ class User(Model):
       active_keys = UserAPIKey.get_active_by_user_id(str(self.id), session)
     except Exception as e:
       logger.error(f"Failed to load API keys for deactivated user {self.id}: {e}")
-      return
+      return 0
 
+    revoked = 0
     for key in active_keys:
       try:
         key.deactivate(session)
+        revoked += 1
       except Exception as e:
         logger.error(
           f"Failed to revoke API key {key.id} for deactivated user {self.id}: {e}"
         )
+
+    if revoked != len(active_keys):
+      logger.error(
+        f"CRITICAL: revoked {revoked} of {len(active_keys)} API keys for "
+        f"deactivated user {self.id}; the remainder are still live in the key "
+        f"table and are refused only by the user.is_active guard. Re-run the "
+        f"deactivation."
+      )
+
+    return revoked
 
   def _invalidate_auth_cache(self) -> None:
     """Invalidate auth caches derived from this user.

--- a/robosystems/operations/admin/user_status.py
+++ b/robosystems/operations/admin/user_status.py
@@ -29,6 +29,7 @@ class UserStatusChange:
   is_active: bool
   changed: bool
   api_keys_revoked: int
+  api_keys_failed: int = 0
 
 
 def set_user_active(
@@ -48,6 +49,11 @@ def set_user_active(
 
   Reactivation does **not** restore revoked keys: `UserAPIKey.deactivate` flips
   each key's own flag, and nothing flips it back. The user must issue new ones.
+
+  ``api_keys_revoked`` counts keys that were actually revoked, and
+  ``api_keys_failed`` the ones that were not. It used to report the number
+  found before the attempt, so a partial revocation — the case an operator
+  most needs to see, mid-incident — was indistinguishable from a clean one.
   """
   user = User.get_by_id(user_id, session)
   if not user:
@@ -56,12 +62,14 @@ def set_user_active(
   was_active = bool(user.is_active)
 
   if active:
+    found = 0
     revoked = 0
     user.activate(session)
   else:
-    # Count before the call: afterwards there are none left to count.
-    revoked = len(UserAPIKey.get_active_by_user_id(str(user.id), session))
-    user.deactivate(session)
+    found = len(UserAPIKey.get_active_by_user_id(str(user.id), session))
+    revoked = user.deactivate(session)
+
+  failed = found - revoked
 
   logger.info(
     f"User {user_id} {'activated' if active else 'deactivated'}",
@@ -70,6 +78,7 @@ def set_user_active(
       "actor": actor,
       "was_active": was_active,
       "api_keys_revoked": revoked,
+      "api_keys_failed": failed,
     },
   )
 
@@ -79,4 +88,5 @@ def set_user_active(
     is_active=active,
     changed=was_active != active,
     api_keys_revoked=revoked,
+    api_keys_failed=failed,
   )

--- a/robosystems/operations/information_block/rules/expressions.py
+++ b/robosystems/operations/information_block/rules/expressions.py
@@ -168,12 +168,52 @@ def _normalize_equality(expr: str) -> str:
   return re.sub(r"(?<![=<>!])=(?!=)", "==", expr)
 
 
+_VARIABLE_REF_RE = re.compile(r"\$([A-Za-z_]\w*)")
+
+
+def _bind_variables(expr: str, variable_names: list[str]) -> str:
+  """Rewrite each ``$Name`` to ``_var_Name``, rejecting any unknown name.
+
+  Tokenized rather than substring-replaced. Replacing ``$`` + each known name
+  in turn let an unknown name through whenever a known one was a prefix of it:
+  with ``Revenue`` bound, ``$RevenueNet`` became ``_var_RevenueNet``, no ``$``
+  survived to trip the unbound check, and the rule saved cleanly — then raised
+  ``unbound name`` on every evaluation for the rest of its life. That is the
+  authoring-vs-evaluation split this module exists to close.
+
+  A trailing ``$`` or one followed by a non-identifier character matches no
+  token and is caught by the leftover check.
+  """
+  known = set(variable_names)
+  unknown: list[str] = []
+
+  def _sub(match: re.Match[str]) -> str:
+    name = match.group(1)
+    if name not in known:
+      unknown.append(name)
+      return match.group(0)
+    return f"_var_{name}"
+
+  bound = _VARIABLE_REF_RE.sub(_sub, expr)
+
+  if unknown:
+    raise InvalidRuleExpression(
+      f"unbound $Variable(s) in expression: {expr!r}: "
+      f"{', '.join(sorted(set(unknown)))}. Known variables: {variable_names}"
+    )
+  if "$" in bound:
+    raise InvalidRuleExpression(
+      f"unbound $Variable in expression: {expr!r}. Known variables: {variable_names}"
+    )
+  return bound
+
+
 def parse_arithmetic_expression(
   expr: str, variable_names: list[str]
 ) -> ParsedExpression:
   """Parse a rule expression string into a validated AST.
 
-  1. Replaces ``$Name`` with ``_var_Name``.
+  1. Replaces each ``$Name`` token with ``_var_Name``, rejecting unknown names.
   2. Normalizes bare ``=`` to ``==`` (XBRL-style equality).
   3. Parses with ``ast.parse(mode='eval')``.
   4. Walks the tree and rejects any node outside the allowed whitelist.
@@ -189,13 +229,7 @@ def parse_arithmetic_expression(
   Raises :class:`InvalidRuleExpression` for unbound variables, syntax
   errors, or disallowed constructs.
   """
-  preprocessed = expr
-  for name in variable_names:
-    preprocessed = preprocessed.replace(f"${name}", f"_var_{name}")
-  if "$" in preprocessed:
-    raise InvalidRuleExpression(
-      f"unbound $Variable in expression: {expr!r}. Known variables: {variable_names}"
-    )
+  preprocessed = _bind_variables(expr, variable_names)
   preprocessed = _normalize_equality(preprocessed)
   try:
     tree = ast.parse(preprocessed, mode="eval")

--- a/robosystems/routers/admin/users.py
+++ b/robosystems/routers/admin/users.py
@@ -394,6 +394,7 @@ async def _set_active(
         "user_id": user_id,
         "changed": change.changed,
         "api_keys_revoked": change.api_keys_revoked,
+        "api_keys_failed": change.api_keys_failed,
       },
     )
 
@@ -403,6 +404,7 @@ async def _set_active(
       is_active=change.is_active,
       changed=change.changed,
       api_keys_revoked=change.api_keys_revoked,
+      api_keys_failed=change.api_keys_failed,
     )
   finally:
     session.close()

--- a/tests/dagster/test_backup_cleanup_jobs.py
+++ b/tests/dagster/test_backup_cleanup_jobs.py
@@ -165,3 +165,96 @@ class TestOrphanedBackupCleanup:
   def test_unparseable_key_is_left_in_place(self):
     _, deleted = self._run([self._obj("graph-backups/databases/", 3650)], tracked=set())
     assert deleted == []
+
+
+class TestTrackedBackupCleanupRetries:
+  """A failed S3 delete must stay retryable.
+
+  Marking the row EXPIRED first dropped it out of `get_expired_backups`
+  forever, and the orphan sweep skips every key a row still references — so
+  one transient S3 error meant nothing retried the delete and the object rode
+  the 90-day lifecycle rule regardless of tier. A standard-tier backup
+  outlived its 7-day retention by twelve weeks on a single failed API call.
+  """
+
+  @staticmethod
+  def _run(delete_fails=False, metadata_key="meta/key"):
+    from unittest.mock import MagicMock, patch
+
+    from dagster import build_op_context
+
+    from robosystems.dagster.jobs.backup_cleanup import cleanup_tracked_backups
+
+    backup = MagicMock()
+    backup.id = "bk_1"
+    backup.graph_id = "kg123"
+    backup.s3_bucket = "bucket"
+    backup.s3_key = "graph-backups/databases/kg123/full/backup-1.zip"
+    backup.s3_metadata_key = metadata_key
+
+    session = MagicMock()
+    db = MagicMock()
+    db.get_session.return_value.__enter__ = lambda *_: session
+    db.get_session.return_value.__exit__ = lambda *_: False
+
+    s3 = MagicMock()
+    if delete_fails:
+      s3.client.delete_object.side_effect = Exception("throttled")
+
+    with patch(
+      "robosystems.models.core.GraphBackup.get_expired_backups",
+      return_value=[backup],
+    ):
+      result = cleanup_tracked_backups(build_op_context(), db, s3)
+
+    return result, backup
+
+  @pytest.mark.unit
+  def test_expires_row_only_after_objects_are_gone(self):
+    result, backup = self._run()
+
+    assert result["expired_count"] == 1
+    assert result["deferred_count"] == 0
+    backup.expire_backup.assert_called_once()
+
+  @pytest.mark.unit
+  def test_failed_delete_leaves_row_unexpired_for_the_next_run(self):
+    result, backup = self._run(delete_fails=True)
+
+    assert result["expired_count"] == 0
+    assert result["deferred_count"] == 1
+    # Still un-EXPIRED, so tomorrow's get_expired_backups picks it up again.
+    backup.expire_backup.assert_not_called()
+
+  @pytest.mark.unit
+  def test_metadata_delete_failure_also_defers(self):
+    """Both objects have to go before the row is settled."""
+    from unittest.mock import MagicMock, patch
+
+    from dagster import build_op_context
+
+    from robosystems.dagster.jobs.backup_cleanup import cleanup_tracked_backups
+
+    backup = MagicMock()
+    backup.id = "bk_1"
+    backup.graph_id = "kg123"
+    backup.s3_bucket = "bucket"
+    backup.s3_key = "key"
+    backup.s3_metadata_key = "meta"
+
+    session = MagicMock()
+    db = MagicMock()
+    db.get_session.return_value.__enter__ = lambda *_: session
+    db.get_session.return_value.__exit__ = lambda *_: False
+
+    s3 = MagicMock()
+    s3.client.delete_object.side_effect = [None, Exception("throttled")]
+
+    with patch(
+      "robosystems.models.core.GraphBackup.get_expired_backups",
+      return_value=[backup],
+    ):
+      result = cleanup_tracked_backups(build_op_context(), db, s3)
+
+    assert result["deferred_count"] == 1
+    backup.expire_backup.assert_not_called()

--- a/tests/operations/admin/test_user_status.py
+++ b/tests/operations/admin/test_user_status.py
@@ -107,3 +107,54 @@ class TestMissingUser:
   def test_unknown_user_raises(self, test_db):
     with pytest.raises(UserNotFound):
       set_user_active(f"user_{uuid4().hex}", False, test_db)
+
+
+class TestRevocationCountIsWhatActuallyHappened:
+  """The reported number must be revocations, not attempts.
+
+  It used to be counted before the attempt, so a partial revocation — the case
+  an operator most needs to see, mid-incident — was indistinguishable from a
+  clean one. "3 keys revoked" while one is still live is worse than no number.
+  """
+
+  def test_partial_revocation_is_reported(self, test_db, test_user, monkeypatch):
+    user = _create_user(test_db, test_user.password_hash)
+    UserAPIKey.create(user_id=user.id, name="key one", session=test_db)
+    UserAPIKey.create(user_id=user.id, name="key two", session=test_db)
+    UserAPIKey.create(user_id=user.id, name="key three", session=test_db)
+
+    original = UserAPIKey.deactivate
+    calls = {"n": 0}
+
+    def _flaky(self, session):
+      calls["n"] += 1
+      if calls["n"] == 2:
+        raise RuntimeError("redis down")
+      return original(self, session)
+
+    monkeypatch.setattr(UserAPIKey, "deactivate", _flaky)
+
+    change = set_user_active(user.id, False, test_db)
+
+    assert change.api_keys_revoked == 2
+    assert change.api_keys_failed == 1
+    # And the survivor is genuinely still live in the key table, which is what
+    # the count is warning about.
+    assert len(UserAPIKey.get_active_by_user_id(str(user.id), test_db)) == 1
+
+  def test_clean_revocation_reports_no_failures(self, test_db, test_user):
+    user = _create_user(test_db, test_user.password_hash)
+    UserAPIKey.create(user_id=user.id, name="key one", session=test_db)
+
+    change = set_user_active(user.id, False, test_db)
+
+    assert change.api_keys_revoked == 1
+    assert change.api_keys_failed == 0
+
+  def test_activate_reports_zero(self, test_db, test_user):
+    user = _create_user(test_db, test_user.password_hash)
+
+    change = set_user_active(user.id, True, test_db)
+
+    assert change.api_keys_revoked == 0
+    assert change.api_keys_failed == 0

--- a/tests/operations/information_block/rules/test_expressions.py
+++ b/tests/operations/information_block/rules/test_expressions.py
@@ -382,3 +382,51 @@ class TestDesugarPriors:
       assert synth == {}
       with pytest.raises(InvalidRuleExpression, match="disallowed"):
         parse_arithmetic_expression(expr, ["X", "Y"])
+
+
+class TestVariableBindingIsTokenized:
+  """An unknown `$Name` must be rejected at authoring time, always.
+
+  Binding was substring replacement over each known name in turn, so a known
+  name that was a *prefix* of an unknown one consumed the `$` and let the rest
+  through: with `Revenue` bound, `$RevenueNet` became `_var_RevenueNet`, no `$`
+  survived to trip the leftover check, and the rule saved clean — then raised
+  `unbound name` on every evaluation for the rest of its life. That authoring-
+  vs-evaluation split is exactly what this module exists to close.
+  """
+
+  def test_rejects_unknown_name_extending_a_known_one(self) -> None:
+    with pytest.raises(InvalidRuleExpression, match="RevenueNet"):
+      parse_arithmetic_expression("$RevenueNet = $Revenue * 2", ["Revenue"])
+
+  def test_rejects_unknown_name_extending_a_single_letter(self) -> None:
+    with pytest.raises(InvalidRuleExpression, match="Assets"):
+      parse_arithmetic_expression("$Assets = 1", ["A"])
+
+  def test_reports_every_unknown_name(self) -> None:
+    with pytest.raises(InvalidRuleExpression, match="Bar, Foo"):
+      parse_arithmetic_expression("$Foo = $Bar + $A", ["A"])
+
+  def test_known_name_that_is_a_prefix_of_another_still_binds(self) -> None:
+    """The legitimate case the old replacement got right only by accident."""
+    import ast
+
+    parsed = parse_arithmetic_expression("$Revenue = $Rev * 2", ["Rev", "Revenue"])
+    names = {n.id for n in ast.walk(parsed.tree) if isinstance(n, ast.Name)}
+
+    assert names == {"_var_Revenue", "_var_Rev"}
+
+  def test_synthesized_operands_still_bind(self) -> None:
+    """`avg()` and `[t-1]` desugar to `$__avg_X` / `$__prior_X` before parse."""
+    import ast
+
+    parsed = parse_arithmetic_expression(
+      "$__avg_X = $__prior_Y", ["__avg_X", "__prior_Y"]
+    )
+    names = {n.id for n in ast.walk(parsed.tree) if isinstance(n, ast.Name)}
+
+    assert names == {"_var___avg_X", "_var___prior_Y"}
+
+  def test_bare_dollar_is_still_rejected(self) -> None:
+    with pytest.raises(InvalidRuleExpression, match="unbound"):
+      parse_arithmetic_expression("$A = $", ["A"])


### PR DESCRIPTION
## Summary

Three independent low-risk fixes from the same review pass. Grouped because each is small and none touches the others.

### Backup retention bypassed by any transient S3 error

`cleanup_tracked_backups` marked a `GraphBackup` EXPIRED *before* deleting its S3 objects, and swallowed deletion failures. An EXPIRED row drops out of `get_expired_backups` permanently, and `cleanup_orphaned_backups` skips every key a row still references — so nothing ever retried the delete and the object rode the 90-day lifecycle rule regardless of the graph's tier. A standard-tier backup outlived its 7-day retention by twelve weeks on one failed API call.

The row is now marked EXPIRED only once its objects are actually gone. Leaving it un-expired *is* the retry: tomorrow's run picks it up. Deleting an absent key is a success in S3, so a row whose object is already gone still settles on the next pass. Return shape is now `expired_count` / `deferred_count` (`error_count` was unreachable once every failure became retryable).

### Variable-prefix loophole in rule expression validation

Binding was substring replacement over each known name in turn, so a known name that was a *prefix* of an unknown one consumed the `$` and let the rest through. With `Revenue` bound, `$RevenueNet = $Revenue * 2` became `_var_RevenueNet == _var_Revenue * 2`, no `$` survived to trip the leftover check, and the rule saved clean — then raised `unbound name` on every evaluation for the rest of its life.

Binding is now tokenized on `$Name`, with every name checked against the allowed set. This is the authoring-vs-evaluation split PR #1096 set out to close. No security impact — the AST whitelist was never involved.

### Deactivation reported attempts, not revocations

`api_keys_revoked` was counted *before* the attempt, and per-key revocation is best-effort, so a partial revocation was indistinguishable from a clean one — the case an operator most needs to see, mid-incident. `User.deactivate` now returns what actually took, `api_keys_failed` sits alongside it in the API response, a shortfall logs CRITICAL, and the admin CLI prints a red line telling the operator to re-run.

Note this is the reporting half only. The cache-TTL fail-open window on `validate_api_key` is a documented tradeoff with double-retry and CRITICAL logging already in place, and is not touched here.

## Testing

Twelve new tests across the three areas, each verified to fail against the pre-fix code. `just test-code` clean; full suite via CI.