### PR TITLE
fix(backup): close the five findings from the v1.7.8..main review

### DIFF
--- a/cloudformation/dagster.yaml
+++ b/cloudformation/dagster.yaml
@@ -11,6 +11,11 @@ Parameters:
     Description: Environment name (prod or staging)
     ConstraintDescription: Must be prod or staging
 
+  SNSAlertEmail:
+    Type: String
+    Default: ""
+    Description: Email for Dagster alerts (e.g. backup coverage gaps); empty disables alarm notifications
+
   # Infrastructure & Networking
   VpcId:
     Type: AWS::EC2::VPC::Id
@@ -225,6 +230,7 @@ Parameters:
     Default: "https://roboinvestor.ai"
 
 Conditions:
+  HasAlertEmail: !Not [!Equals [!Ref SNSAlertEmail, ""]]
   HasBastionAccess: !Not [!Equals [!Ref BastionSecurityGroupId, ""]]
   HasApiAccess: !Not [!Equals [!Ref ApiSecurityGroupId, ""]]
   HasOpenSearch: !Not [!Equals [!Ref OpenSearchEndpoint, ""]]
@@ -1012,6 +1018,57 @@ Resources:
           Value: !Ref ComponentTag
         - Key: CreatedBy
           Value: CloudFormation
+
+
+  # ========================================
+  # BACKUP COVERAGE ALERTING
+  # ========================================
+  # The nightly backup schedule can stop without failing: a daemon problem, a
+  # disabled schedule, or an exception before any RunRequest is returned all
+  # produce NO run at all, and an absent run is exactly what a run list cannot
+  # surface. `assert_backup_coverage` answers the outcome question instead —
+  # does every graph that should have a backup have one — and logs CRITICAL on
+  # a gap. This turns that log into a notification; without it the check
+  # detects the condition and tells nobody.
+
+  DagsterAlertTopic:
+    Type: AWS::SNS::Topic
+    Condition: HasAlertEmail
+    Properties:
+      TopicName: !Sub robosystems-dagster-${Environment}-alerts
+      DisplayName: !Sub RoboSystems Dagster ${Environment} Alerts
+      Subscription:
+        - Endpoint: !Ref SNSAlertEmail
+          Protocol: email
+
+  BackupCoverageGapMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref DagsterLogGroup
+      FilterPattern: '"BACKUP COVERAGE GAP"'
+      MetricTransformations:
+        - MetricName: BackupCoverageGap
+          MetricNamespace: !Sub RoboSystems/Dagster/${Environment}
+          MetricValue: "1"
+          Unit: Count
+
+  BackupCoverageGapAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: HasAlertEmail
+    Properties:
+      AlarmName: !Sub robosystems-dagster-${Environment}-backup-coverage-gap
+      AlarmDescription: A graph that should have a nightly backup has none in the last two cycles
+      MetricName: BackupCoverageGap
+      Namespace: !Sub RoboSystems/Dagster/${Environment}
+      Statistic: Sum
+      Period: 86400
+      EvaluationPeriods: 1
+      Threshold: 0
+      ComparisonOperator: GreaterThanThreshold
+      AlarmActions:
+        - !Ref DagsterAlertTopic
+      TreatMissingData: notBreaching
+
 
 Outputs:
   ClusterName:

--- a/migrations/platform/versions/2eae4a0ad7ef_add_initiated_by_to_graph_backups.py
+++ b/migrations/platform/versions/2eae4a0ad7ef_add_initiated_by_to_graph_backups.py
@@ -14,6 +14,17 @@ Existing ``backup_type = 'system'`` rows are pre-restore snapshots and
 migration-export artifacts. They are re-encoded as a full backup with a system
 initiator, which is what they always were.
 
+Also drops ``encrypted_size_bytes``. Application-layer encryption was retired
+before it ever ran, and both writers always passed the compressed size into
+this column, so it has never held anything but a duplicate of
+``compressed_size_bytes``. That makes the drop reversible: the downgrade
+repopulates it from its twin and loses nothing.
+
+Note the contrast with ``encryption_enabled``, which stays. That column records
+which backups were once *marked* encrypted — real information, and worth
+keeping given the SOC 2 angle. This one records a number that was always
+identical to another column.
+
 """
 
 import sqlalchemy as sa
@@ -50,8 +61,20 @@ def upgrade() -> None:
     """
   )
 
+  op.drop_column("graph_backups", "encrypted_size_bytes")
+
 
 def downgrade() -> None:
+  # Restored from its twin rather than defaulted: the column was always a copy
+  # of compressed_size_bytes, so this reproduces every historical value exactly.
+  op.add_column(
+    "graph_backups",
+    sa.Column(
+      "encrypted_size_bytes", sa.BigInteger(), nullable=False, server_default="0"
+    ),
+  )
+  op.execute("UPDATE graph_backups SET encrypted_size_bytes = compressed_size_bytes")
+
   # Fold system-initiated rows back into the old shared encoding. Scheduled
   # backups have no pre-split representation, so they come back as plain user
   # backups — the distinction is genuinely absent from the old schema rather

--- a/robosystems/config/storage/graph.py
+++ b/robosystems/config/storage/graph.py
@@ -183,6 +183,22 @@ def get_backup_metadata_key(graph_id: str, timestamp: datetime) -> str:
   return f"{config.prefix}metadata/{graph_id}/backup-{timestamp_str}.json"
 
 
+def get_backup_metadata_prefix(graph_id: str | None = None) -> str:
+  """Build S3 prefix for listing backup metadata sidecars.
+
+  Example:
+      >>> get_backup_metadata_prefix("kg456")
+      'graph-backups/metadata/kg456/'
+  """
+  config = GRAPH_STORAGE[GraphStorageType.BACKUPS]
+  prefix = f"{config.prefix}metadata/"
+
+  if graph_id:
+    prefix += f"{graph_id}/"
+
+  return prefix
+
+
 def get_backup_prefix(
   graph_id: str | None = None, backup_type: str | None = None
 ) -> str:

--- a/robosystems/dagster/assets/shared_repositories/publish.py
+++ b/robosystems/dagster/assets/shared_repositories/publish.py
@@ -383,7 +383,6 @@ def _upsert_r2_backup_record(
       existing.completed_at = now
       existing.original_size_bytes = original_size
       existing.compressed_size_bytes = compressed_size
-      existing.encrypted_size_bytes = compressed_size
       existing.s3_bucket = bucket
       existing.s3_key = key
       existing.backup_metadata = {
@@ -408,7 +407,6 @@ def _upsert_r2_backup_record(
         session=session,
         original_size=original_size,
         compressed_size=compressed_size,
-        encrypted_size=compressed_size,
         checksum="",
         metadata={
           "storage": "r2",

--- a/robosystems/dagster/jobs/backup_cleanup.py
+++ b/robosystems/dagster/jobs/backup_cleanup.py
@@ -115,10 +115,14 @@ def cleanup_orphaned_backups(
   early — this op removes data, so every ambiguity resolves toward keeping it.
   """
   from robosystems.config.graph_tier import GraphTierConfig
-  from robosystems.config.storage.graph import get_backup_prefix
+  from robosystems.config.storage.graph import (
+    get_backup_metadata_prefix,
+    get_backup_prefix,
+  )
   from robosystems.models.core import Graph, GraphBackup
 
-  prefix = get_backup_prefix()
+  payload_prefix = get_backup_prefix()
+  metadata_prefix = get_backup_metadata_prefix()
   now = datetime.now(UTC)
 
   deleted_count = 0
@@ -162,31 +166,40 @@ def cleanup_orphaned_backups(
         return retention_by_graph[graph_id]
 
       paginator = s3.client.get_paginator("list_objects_v2")
-      for page in paginator.paginate(Bucket=s3.bucket, Prefix=prefix):
-        for obj in page.get("Contents", []):
-          key = obj["Key"]
+      # Both halves of a backup, not just the payload. The metadata sidecar
+      # lives under a sibling prefix and was reachable only through the tracked
+      # sweep, whose delete is guarded on the row knowing the key — which
+      # nothing set until now. Untracked sidecars therefore outlived tier
+      # retention entirely and rode the 90-day bucket lifecycle, including for
+      # 7-day tiers. Both prefixes key on {graph_id} as their first segment, so
+      # the same parse and the same retention clock apply to each.
+      for prefix in (payload_prefix, metadata_prefix):
+        for page in paginator.paginate(Bucket=s3.bucket, Prefix=prefix):
+          for obj in page.get("Contents", []):
+            key = obj["Key"]
 
-          if key in tracked_keys:
-            skipped_tracked += 1
-            continue
+            if key in tracked_keys:
+              skipped_tracked += 1
+              continue
 
-          # graph-backups/databases/{graph_id}/{backup_type}/backup-{ts}{ext}
-          parts = key[len(prefix) :].split("/")
-          if len(parts) < 2 or not parts[0]:
-            context.log.warning(f"Unparseable backup key, leaving in place: {key}")
-            continue
+            # graph-backups/databases/{graph_id}/{backup_type}/backup-{ts}{ext}
+            # graph-backups/metadata/{graph_id}/backup-{ts}.json
+            parts = key[len(prefix) :].split("/")
+            if len(parts) < 2 or not parts[0]:
+              context.log.warning(f"Unparseable backup key, leaving in place: {key}")
+              continue
 
-          cutoff = now - timedelta(days=_retention_days(parts[0]))
-          if obj["LastModified"].replace(tzinfo=UTC) >= cutoff:
-            continue
+            cutoff = now - timedelta(days=_retention_days(parts[0]))
+            if obj["LastModified"].replace(tzinfo=UTC) >= cutoff:
+              continue
 
-          objects_to_delete.append({"Key": key})
-          if len(objects_to_delete) >= 1000:
-            s3.client.delete_objects(
-              Bucket=s3.bucket, Delete={"Objects": objects_to_delete}
-            )
-            deleted_count += len(objects_to_delete)
-            objects_to_delete = []
+            objects_to_delete.append({"Key": key})
+            if len(objects_to_delete) >= 1000:
+              s3.client.delete_objects(
+                Bucket=s3.bucket, Delete={"Objects": objects_to_delete}
+              )
+              deleted_count += len(objects_to_delete)
+              objects_to_delete = []
 
     if objects_to_delete:
       s3.client.delete_objects(Bucket=s3.bucket, Delete={"Objects": objects_to_delete})
@@ -202,7 +215,7 @@ def cleanup_orphaned_backups(
   return {
     "deleted_count": deleted_count,
     "skipped_tracked": skipped_tracked,
-    "prefix": prefix,
+    "prefixes": [payload_prefix, metadata_prefix],
     "timestamp": now.isoformat(),
   }
 

--- a/robosystems/dagster/jobs/graph.py
+++ b/robosystems/dagster/jobs/graph.py
@@ -118,6 +118,10 @@ class BackupGraphConfig(Config):
   retention_days: int = 30
   compression: bool = True
   initiated_by: str = "user"
+  # Set when the caller already reserved a row against the daily quota. The
+  # job adopts it rather than inserting a second one — see the reservation
+  # comment in the create-backup route.
+  backup_id: str | None = None
 
 
 class RestoreGraphConfig(Config):
@@ -209,18 +213,35 @@ def create_backup(
   with db.get_session() as session:
     s3_adapter = S3BackupAdapter(enable_compression=config.compression)
 
-    backup_record = GraphBackup.create(
-      graph_id=config.graph_id,
-      database_name=database_name,
-      backup_type=config.backup_type,
-      initiated_by=config.initiated_by,
-      s3_bucket=s3_adapter.bucket_name,
-      s3_key=s3_key,
-      session=session,
-      created_by_user_id=config.user_id,
-      compression_enabled=config.compression,
-      expires_at=datetime.now(UTC) + timedelta(days=config.retention_days),
+    # Adopt the caller's reservation when there is one. Quota is counted from
+    # these rows, so a caller that checked the count and then let the job
+    # insert would leave a window where concurrent requests all pass the same
+    # check. Callers that don't enforce quota — the nightly schedule — insert
+    # here as before.
+    backup_record = (
+      GraphBackup.get_by_id(config.backup_id, session) if config.backup_id else None
     )
+
+    if backup_record is None:
+      backup_record = GraphBackup.create(
+        graph_id=config.graph_id,
+        database_name=database_name,
+        backup_type=config.backup_type,
+        initiated_by=config.initiated_by,
+        s3_bucket=s3_adapter.bucket_name,
+        s3_key=s3_key,
+        session=session,
+        created_by_user_id=config.user_id,
+        compression_enabled=config.compression,
+        expires_at=datetime.now(UTC) + timedelta(days=config.retention_days),
+      )
+    else:
+      backup_record.database_name = database_name
+      backup_record.s3_bucket = s3_adapter.bucket_name
+      backup_record.s3_key = s3_key
+      backup_record.expires_at = datetime.now(UTC) + timedelta(
+        days=config.retention_days
+      )
 
     backup_record.start_backup(session)
     backup_id = str(backup_record.id)
@@ -247,6 +268,10 @@ def create_backup(
     backup_record = GraphBackup.get_by_id(backup_id, session)
     if backup_record:
       backup_record.s3_key = backup_info.s3_key
+      # Without this the retention sweep skips the sidecar entirely — its
+      # delete is guarded on the row knowing the key — so metadata objects
+      # outlived tier retention and rode the 90-day bucket lifecycle instead.
+      backup_record.s3_metadata_key = backup_info.s3_metadata_key
       backup_record.complete_backup(
         session=session,
         original_size=backup_info.original_size,

--- a/robosystems/dagster/jobs/graph.py
+++ b/robosystems/dagster/jobs/graph.py
@@ -276,7 +276,6 @@ def create_backup(
         session=session,
         original_size=backup_info.original_size,
         compressed_size=backup_info.compressed_size,
-        encrypted_size=backup_info.compressed_size,
         checksum=backup_info.checksum,
         node_count=backup_info.node_count,
         relationship_count=backup_info.relationship_count,

--- a/robosystems/middleware/mcp/tools/graph_tools.py
+++ b/robosystems/middleware/mcp/tools/graph_tools.py
@@ -644,20 +644,32 @@ class CreateBackupTool:
       # above mirrors it: this path enqueues the same job, so a check that
       # lives on only one of them is not a limit. A negative value means
       # unlimited; an unresolvable tier gets the smallest allowance.
-      max_per_day = backup_limits.get("max_backups_per_day", 2)
-      if max_per_day is not None and max_per_day >= 0:
-        from robosystems.models.core import GraphBackup
+      # Reserve the slot the same way the REST route does. Counting rows and
+      # letting the async job insert one leaves a window where concurrent
+      # requests all pass the same check, and a limit enforced on one of two
+      # entry points is not a limit.
+      from fastapi import HTTPException
 
-        taken_today = GraphBackup.count_user_initiated_today(graph_id, session)
-        if taken_today >= max_per_day:
-          return {
-            "error": "daily_backup_limit_reached",
-            "message": (
-              f"Daily backup limit reached for this graph "
-              f"({taken_today}/{max_per_day} on the {backup_tier} tier). "
-              f"Scheduled backups do not count against this limit."
-            ),
-          }
+      from robosystems.routers.graphs.operations import (
+        _release_backup_slot,
+        _reserve_backup_slot,
+      )
+
+      max_per_day = backup_limits.get("max_backups_per_day", 2)
+      try:
+        reservation_id = _reserve_backup_slot(
+          graph_id=graph_id,
+          user_id=str(user.id),
+          max_per_day=max_per_day,
+          backup_tier=backup_tier,
+          retention_days=retention_days,
+          db=session,
+        )
+      except HTTPException as limit_error:
+        return {
+          "error": "daily_backup_limit_reached",
+          "message": limit_error.detail,
+        }
 
       run_config = build_graph_job_config(
         "backup_graph_job",
@@ -668,13 +680,18 @@ class CreateBackupTool:
         retention_days=retention_days,
         compression=True,
         initiated_by="user",
+        backup_id=reservation_id,
       )
-      response = await enqueue_task(
-        task_type="dagster_job_monitor",
-        graph_id=graph_id,
-        user_id=str(user.id),
-        params={"job_name": "backup_graph_job", "run_config": run_config},
-      )
+      try:
+        response = await enqueue_task(
+          task_type="dagster_job_monitor",
+          graph_id=graph_id,
+          user_id=str(user.id),
+          params={"job_name": "backup_graph_job", "run_config": run_config},
+        )
+      except Exception:
+        _release_backup_slot(reservation_id, session)
+        raise
       operation_id = response["operation_id"]
       return {
         "status": "accepted",

--- a/robosystems/models/core/graph/graph_backup.py
+++ b/robosystems/models/core/graph/graph_backup.py
@@ -106,7 +106,6 @@ class GraphBackup(Model):
   # Size and compression metrics
   original_size_bytes = Column(BigInteger, nullable=False, default=0)
   compressed_size_bytes = Column(BigInteger, nullable=False, default=0)
-  encrypted_size_bytes = Column(BigInteger, nullable=False, default=0)
   compression_ratio = Column(Float, nullable=False, default=0.0)
 
   # Database statistics at backup time
@@ -387,7 +386,6 @@ class GraphBackup(Model):
     session: Session,
     original_size: int,
     compressed_size: int,
-    encrypted_size: int,
     checksum: str,
     node_count: int = 0,
     relationship_count: int = 0,
@@ -399,7 +397,6 @@ class GraphBackup(Model):
     self.completed_at = datetime.now(UTC)
     self.original_size_bytes = original_size
     self.compressed_size_bytes = compressed_size
-    self.encrypted_size_bytes = encrypted_size
     self.compression_ratio = (
       (original_size - compressed_size) / original_size if original_size > 0 else 0
     )
@@ -465,7 +462,6 @@ class GraphBackup(Model):
       "s3_metadata_key": self.s3_metadata_key,
       "original_size_bytes": self.original_size_bytes,
       "compressed_size_bytes": self.compressed_size_bytes,
-      "encrypted_size_bytes": self.encrypted_size_bytes,
       "compression_ratio": self.compression_ratio,
       "node_count": self.node_count,
       "relationship_count": self.relationship_count,
@@ -512,7 +508,7 @@ class GraphBackup(Model):
 
   @property
   def storage_efficiency(self) -> float:
-    """Calculate storage efficiency (stored size over original size)."""
+    """Stored size over original size."""
     if self.original_size_bytes == 0 or self.original_size_bytes is None:
       return 0.0
-    return self.encrypted_size_bytes / self.original_size_bytes
+    return self.compressed_size_bytes / self.original_size_bytes

--- a/robosystems/operations/aws/s3.py
+++ b/robosystems/operations/aws/s3.py
@@ -442,6 +442,10 @@ class BackupMetadata:
   database_version: str | None = None
   backup_format: str = "cypher"
   s3_key: str | None = None
+  # Key of the sidecar JSON written alongside the payload. Carried so the
+  # caller can record it: retention deletes the sidecar only when the row knows
+  # where it is, and nothing used to tell the row.
+  s3_metadata_key: str | None = None
   # Whether the archive carries the graph's semantic memory store: "included",
   # "absent", or None for a backup taken before memory was captured at all.
   # None is a third state, not a synonym for "absent" — see the manifest
@@ -834,6 +838,7 @@ class S3BackupAdapter:
         or metadata.get("lbug_version"),
         backup_format="full_dump",
         s3_key=backup_path,
+        s3_metadata_key=metadata_path,
         memory=metadata.get("memory"),
         payload_delta=metadata.get("payload_delta"),
       )

--- a/robosystems/operations/graph/engine/backup_manager.py
+++ b/robosystems/operations/graph/engine/backup_manager.py
@@ -38,6 +38,75 @@ class BackupPayloadMismatch(RuntimeError):
   """The archive's contents disagree with the database it claims to back up."""
 
 
+# Name of the manifest inside a full-dump archive, mirroring the producer in
+# ``graph_api/routers/databases/restore.py``.
+BACKUP_MANIFEST_NAME = "backup-manifest.json"
+
+
+def _restore_memory_store(graph_id: str, extracted: Path) -> str:
+  """Apply the archive's memory claim to the graph's live memory store.
+
+  The manifest is a **tri-state**, and the third state is carried by the
+  manifest's *absence*:
+
+  - ``included`` — the archive holds a memory store; replace the live one.
+  - ``absent``   — a memory-aware backup of a graph that had none. **Leave the
+    live store alone.** Memory has no upstream, so the asymmetry favours
+    keeping data over matching the snapshot exactly; the same fail-closed
+    instinct that made restore abort on a failed safety backup.
+  - *no manifest* — the archive predates memory capture and makes **no claim
+    either way**. Also leave the live store alone: deleting data on the
+    strength of a format gap is the worst available reading.
+
+  Only ``included`` writes. Returns what happened, for the operation log —
+  a restore that silently did nothing to memory is exactly what this contract
+  exists to prevent.
+  """
+  from robosystems.utils.path_validation import get_lance_index_path
+
+  manifest_path = extracted / BACKUP_MANIFEST_NAME
+  if not manifest_path.exists():
+    logger.info(
+      f"Backup for '{graph_id}' carries no manifest; leaving existing memory "
+      f"store untouched (archive makes no claim)"
+    )
+    return "unchanged (no claim)"
+
+  try:
+    manifest = json.loads(manifest_path.read_text())
+  except Exception as e:
+    logger.warning(f"Unreadable backup manifest for '{graph_id}': {e}")
+    return "unchanged (unreadable manifest)"
+
+  claim = manifest.get("memory")
+  if claim != "included":
+    logger.info(
+      f"Backup for '{graph_id}' records memory as '{claim}'; leaving existing "
+      f"memory store untouched"
+    )
+    return f"unchanged ({claim})"
+
+  source = extracted / "memory"
+  if not source.is_dir():
+    # The manifest says included but the payload has no memory directory.
+    # Refuse rather than guess: replacing with nothing would delete a store the
+    # archive claims to contain, and skipping silently would leave a restore
+    # reporting success over a claim it did not honour.
+    raise BackupPayloadMismatch(
+      f"Backup for '{graph_id}' records memory as included but the archive "
+      f"contains no memory directory."
+    )
+
+  destination = get_lance_index_path(graph_id)
+  if destination.exists():
+    shutil.rmtree(destination)
+  destination.parent.mkdir(parents=True, exist_ok=True)
+  shutil.copytree(source, destination)
+
+  logger.info(f"Restored semantic memory store for graph '{graph_id}'")
+  return "replaced"
+
+
 def _reconcile_payload_against_stats(
   graph_id: str,
   stats: dict[str, Any],
@@ -489,9 +558,23 @@ class BackupManager:
 
       backup_duration = asyncio.get_event_loop().time() - start_time
 
+      # The record describes the ARCHIVE, not the live database, whenever the
+      # archive was measured. This matters because reconciliation deliberately
+      # tolerates drift: a backup taken while writes land records live=100 over
+      # an archive holding 98, and `_verify_restore` compares a restored
+      # database against these numbers. Recording the live count would make
+      # every drifted backup fail verification *after* overwriting the target.
+      # The live counts are not lost — they ride in `payload_delta` below.
+      measured_nodes = (payload or {}).get("node_count")
+      measured_rels = (payload or {}).get("relationship_count")
+
       metadata = {
-        "node_count": stats["node_count"],
-        "relationship_count": stats["relationship_count"],
+        "node_count": (
+          measured_nodes if measured_nodes is not None else stats["node_count"]
+        ),
+        "relationship_count": (
+          measured_rels if measured_rels is not None else stats["relationship_count"]
+        ),
         "backup_duration_seconds": backup_duration,
         "backup_format": backup_job.backup_format.value,
         "database_engine": "graph",
@@ -1366,8 +1449,12 @@ class BackupManager:
       else:
         shutil.copytree(temp_path / graph_id, target_path)
 
+      memory_outcome = _restore_memory_store(graph_id, temp_path)
+
       if progress_tracker:
-        progress_tracker.update_import_progress(message="Restored full database dump")
+        progress_tracker.update_import_progress(
+          message=f"Restored full database dump (memory: {memory_outcome})"
+        )
 
   async def _ensure_database_exists(self, graph_id: str) -> None:
     """Touch the database so the repository creates it if absent.

--- a/robosystems/routers/graphs/operations.py
+++ b/robosystems/routers/graphs/operations.py
@@ -547,6 +547,77 @@ async def delete_graph_op(
   return await _dispatch(ctx, _runner, cache)
 
 
+def _reserve_backup_slot(
+  *,
+  graph_id: str,
+  user_id: str,
+  max_per_day: int | None,
+  backup_tier: str,
+  retention_days: int,
+  db: Session,
+) -> str:
+  """Take a slot against the graph's daily backup quota, returning its row id.
+
+  Counting rows and then letting the async job insert one leaves a window where
+  concurrent requests all observe the same count and all pass. The row is
+  therefore inserted here, and the job adopts it.
+
+  The count and the insert are serialized per graph by locking the graph row
+  first. That is enough because the quota is per-graph: two requests for the
+  same graph queue behind each other, and unrelated graphs never wait on one
+  another. Placeholder storage fields are overwritten by the job once it knows
+  the real key.
+
+  Raises 429 when the tier's allowance is spent. A negative limit means
+  unlimited, and an unresolvable tier already fell back to the smallest
+  allowance upstream.
+  """
+  from datetime import UTC, datetime, timedelta
+
+  from sqlalchemy import select
+
+  from robosystems.models.core import BackupInitiator, Graph, GraphBackup
+
+  if max_per_day is not None and max_per_day >= 0:
+    db.execute(select(Graph).where(Graph.graph_id == graph_id).with_for_update())
+
+    taken_today = GraphBackup.count_user_initiated_today(graph_id, db)
+    if taken_today >= max_per_day:
+      raise HTTPException(
+        status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+        detail=(
+          f"Daily backup limit reached for this graph "
+          f"({taken_today}/{max_per_day} on the {backup_tier} tier). "
+          f"Scheduled backups do not count against this limit."
+        ),
+      )
+
+  reservation = GraphBackup.create(
+    graph_id=graph_id,
+    database_name=graph_id,
+    backup_type="full",
+    initiated_by=BackupInitiator.USER.value,
+    s3_bucket="",
+    s3_key="",
+    session=db,
+    created_by_user_id=user_id,
+    expires_at=datetime.now(UTC) + timedelta(days=retention_days),
+  )
+  return str(reservation.id)
+
+
+def _release_backup_slot(backup_id: str, db: Session) -> None:
+  """Fail a reservation whose job never got enqueued, freeing the slot."""
+  from robosystems.models.core import GraphBackup
+
+  try:
+    reservation = GraphBackup.get_by_id(backup_id, db)
+    if reservation is not None:
+      reservation.fail_backup(db, "Backup job could not be enqueued")
+  except Exception as e:
+    logger.error(f"Could not release backup reservation {backup_id}: {e}")
+
+
 # ═══════════════════════════════════════════════════════════════════════════
 # create-backup
 # ═══════════════════════════════════════════════════════════════════════════
@@ -634,19 +705,14 @@ async def create_backup_op(
   # unresolvable tier gets the smallest allowance rather than an exemption.
   # A negative limit means unlimited (the xlarge tier).
   max_per_day = backup_limits.get("max_backups_per_day", 2)
-  if max_per_day is not None and max_per_day >= 0:
-    from robosystems.models.core import GraphBackup as _GraphBackup
-
-    taken_today = _GraphBackup.count_user_initiated_today(graph_id, db)
-    if taken_today >= max_per_day:
-      raise HTTPException(
-        status_code=status.HTTP_429_TOO_MANY_REQUESTS,
-        detail=(
-          f"Daily backup limit reached for this graph "
-          f"({taken_today}/{max_per_day} on the {backup_tier} tier). "
-          f"Scheduled backups do not count against this limit."
-        ),
-      )
+  reservation_id = _reserve_backup_slot(
+    graph_id=graph_id,
+    user_id=user_id,
+    max_per_day=max_per_day,
+    backup_tier=backup_tier,
+    retention_days=effective_retention_days,
+    db=db,
+  )
 
   run_config = build_graph_job_config(
     "backup_graph_job",
@@ -657,14 +723,21 @@ async def create_backup_op(
     retention_days=effective_retention_days,
     compression=True,
     initiated_by="user",
+    backup_id=reservation_id,
   )
 
-  response = await enqueue_task(
-    task_type="dagster_job_monitor",
-    graph_id=graph_id,
-    user_id=user_id,
-    params={"job_name": "backup_graph_job", "run_config": run_config},
-  )
+  try:
+    response = await enqueue_task(
+      task_type="dagster_job_monitor",
+      graph_id=graph_id,
+      user_id=user_id,
+      params={"job_name": "backup_graph_job", "run_config": run_config},
+    )
+  except Exception:
+    # Release the slot rather than leaving a PENDING row holding quota for a
+    # job that will never run. FAILED rows are excluded from the count.
+    _release_backup_slot(reservation_id, db)
+    raise
   operation_id = response["operation_id"]
 
   envelope = wrap_pending(

--- a/tests/dagster/test_backup_cleanup_jobs.py
+++ b/tests/dagster/test_backup_cleanup_jobs.py
@@ -77,7 +77,7 @@ class TestOrphanedBackupCleanup:
   ambiguity toward keeping data."""
 
   @staticmethod
-  def _run(objects, tracked, tier="ladybug-standard", graph_exists=True):
+  def _run(objects, tracked, tier="ladybug-standard", graph_exists=True, metadata=None):
     from unittest.mock import MagicMock, patch
 
     from dagster import build_op_context
@@ -98,7 +98,16 @@ class TestOrphanedBackupCleanup:
 
     s3 = MagicMock()
     s3.bucket = "test-bucket"
-    s3.client.get_paginator.return_value.paginate.return_value = [{"Contents": objects}]
+
+    # The sweep walks two disjoint prefixes — payloads and metadata sidecars —
+    # so the paginator has to answer per-prefix. A single canned return value
+    # would hand the same objects to both passes and double-count them.
+    def _paginate(Bucket, Prefix):
+      if Prefix.endswith("/metadata/"):
+        return [{"Contents": metadata or []}]
+      return [{"Contents": objects}]
+
+    s3.client.get_paginator.return_value.paginate.side_effect = _paginate
 
     graph = MagicMock()
     graph.graph_tier = tier
@@ -379,3 +388,48 @@ class TestBackupCoverageAssertion:
     assert result["checked"] == 0
     assert result["uncovered"] == []
     assert "error" in result
+
+
+class TestMetadataSidecarCleanup:
+  """Sidecars have to expire on the same clock as the payloads they describe.
+
+  `cleanup_tracked_backups` deletes a sidecar only when the row knows its key,
+  and nothing populated `s3_metadata_key` until now — so untracked sidecars
+  were reachable by neither sweep and rode the 90-day bucket lifecycle even for
+  a 7-day tier.
+  """
+
+  @pytest.mark.unit
+  def test_sweeps_orphaned_sidecars_on_tier_retention(self):
+    payload = "graph-backups/databases/kg1/full/backup-20260101_000000.lbug.zip"
+    sidecar = "graph-backups/metadata/kg1/backup-20260101_000000.json"
+
+    _, deleted = TestOrphanedBackupCleanup._run(
+      [TestOrphanedBackupCleanup._obj(payload, 30)],
+      tracked=set(),
+      metadata=[TestOrphanedBackupCleanup._obj(sidecar, 30)],
+    )
+
+    assert sorted(deleted) == sorted([payload, sidecar])
+
+  @pytest.mark.unit
+  def test_keeps_a_sidecar_inside_tier_retention(self):
+    sidecar = "graph-backups/metadata/kg1/backup-20260101_000000.json"
+
+    _, deleted = TestOrphanedBackupCleanup._run(
+      [], tracked=set(), metadata=[TestOrphanedBackupCleanup._obj(sidecar, 3)]
+    )
+
+    assert deleted == []
+
+  @pytest.mark.unit
+  def test_never_touches_a_tracked_sidecar(self):
+    """Once the row records the key, the sidecar belongs to the tracked sweep."""
+    sidecar = "graph-backups/metadata/kg1/backup-20260101_000000.json"
+
+    result, deleted = TestOrphanedBackupCleanup._run(
+      [], tracked={sidecar}, metadata=[TestOrphanedBackupCleanup._obj(sidecar, 3650)]
+    )
+
+    assert deleted == []
+    assert result["skipped_tracked"] == 1

--- a/tests/models/core/graph/test_graph_backup.py
+++ b/tests/models/core/graph/test_graph_backup.py
@@ -98,7 +98,6 @@ class TestGraphBackupModel:
       s3_metadata_key="backups/2024/01/backup.meta.json",
       original_size_bytes=1000000,
       compressed_size_bytes=250000,
-      encrypted_size_bytes=260000,
       compression_ratio=0.75,
       node_count=5000,
       relationship_count=10000,
@@ -122,7 +121,6 @@ class TestGraphBackupModel:
     assert backup.s3_metadata_key == "backups/2024/01/backup.meta.json"
     assert backup.original_size_bytes == 1000000
     assert backup.compressed_size_bytes == 250000
-    assert backup.encrypted_size_bytes == 260000
     assert backup.compression_ratio == 0.75
     assert backup.node_count == 5000
     assert backup.relationship_count == 10000
@@ -244,7 +242,6 @@ class TestGraphBackupModel:
         session=db_session,
         original_size=1000000,
         compressed_size=250000,
-        encrypted_size=260000,
         checksum=f"checksum_{i}",
       )
       # Manually adjust completed_at for testing
@@ -406,7 +403,6 @@ class TestGraphBackupModel:
         session=db_session,
         original_size=1000000 * (i + 1),
         compressed_size=250000 * (i + 1),
-        encrypted_size=260000 * (i + 1),
         checksum=f"checksum_{i}",
       )
 
@@ -489,7 +485,6 @@ class TestGraphBackupModel:
       session=db_session,
       original_size=5000000,
       compressed_size=1000000,
-      encrypted_size=1050000,
       checksum="sha256_test_checksum",
       node_count=10000,
       relationship_count=25000,
@@ -501,7 +496,6 @@ class TestGraphBackupModel:
     assert backup.completed_at is not None
     assert backup.original_size_bytes == 5000000
     assert backup.compressed_size_bytes == 1000000
-    assert backup.encrypted_size_bytes == 1050000
     assert backup.compression_ratio == 0.8  # (5M - 1M) / 5M
     assert backup.checksum == "sha256_test_checksum"
     assert backup.node_count == 10000
@@ -627,7 +621,6 @@ class TestGraphBackupModel:
       session=db_session,
       original_size=1000000,
       compressed_size=250000,
-      encrypted_size=260000,
       checksum="b" * 64,
     )
 
@@ -714,7 +707,7 @@ class TestGraphBackupModel:
 
     # With sizes
     backup.original_size_bytes = 1000000
-    backup.encrypted_size_bytes = 300000
+    backup.compressed_size_bytes = 300000
     assert backup.storage_efficiency == 0.3  # 300K / 1M
 
     # Zero original size
@@ -739,7 +732,6 @@ class TestGraphBackupModel:
       session=mock_session,
       original_size=1000000,
       compressed_size=300000,
-      encrypted_size=310000,
       checksum="test",
     )
     assert backup.compression_ratio == 0.7  # (1M - 300K) / 1M
@@ -757,7 +749,6 @@ class TestGraphBackupModel:
       session=mock_session,
       original_size=0,
       compressed_size=0,
-      encrypted_size=0,
       checksum="test",
     )
     assert backup2.compression_ratio == 0.0

--- a/tests/operations/graph/engine/test_backup_manager_extended.py
+++ b/tests/operations/graph/engine/test_backup_manager_extended.py
@@ -1875,3 +1875,197 @@ class TestReconcilePayloadAgainstStats:
       )
       is None
     )
+
+
+# ===========================================================================
+# Memory store restore (the manifest tri-state, applied on the read side)
+# ===========================================================================
+
+
+@pytest.mark.unit
+class TestRestoreMemoryStore:
+  """The archive carries memory; the importer has to act on the claim.
+
+  Backing memory up without restoring it leaves a restore reporting success
+  while the one class of data with no upstream is silently untouched.
+  """
+
+  def _archive(self, tmp_path, claim, with_dir=True):
+    from robosystems.operations.graph.engine.backup_manager import (
+      BACKUP_MANIFEST_NAME,
+    )
+
+    extracted = tmp_path / "extracted"
+    extracted.mkdir()
+    if claim is not None:
+      (extracted / BACKUP_MANIFEST_NAME).write_text(json.dumps({"memory": claim}))
+    if with_dir:
+      mem = extracted / "memory" / "memory.lance"
+      mem.mkdir(parents=True)
+      (mem / "data.bin").write_bytes(b"restored-vectors")
+    return extracted
+
+  def _live(self, tmp_path, contents=b"existing-vectors"):
+    live = tmp_path / "lance" / "kg1"
+    (live / "memory").mkdir(parents=True)
+    (live / "memory" / "data.bin").write_bytes(contents)
+    return live
+
+  def test_included_replaces_the_live_store(self, tmp_path):
+    from robosystems.operations.graph.engine import backup_manager
+
+    extracted = self._archive(tmp_path, "included")
+    live = self._live(tmp_path)
+
+    with patch(
+      "robosystems.utils.path_validation.get_lance_index_path", return_value=live
+    ):
+      outcome = backup_manager._restore_memory_store("kg1", extracted)
+
+    assert outcome == "replaced"
+    assert (live / "memory.lance" / "data.bin").read_bytes() == b"restored-vectors"
+
+  def test_absent_leaves_the_live_store_alone(self, tmp_path):
+    """A graph that had no memory at backup time must not erase today's.
+
+    Memory has no upstream, so the asymmetry favours keeping data over
+    matching the snapshot exactly.
+    """
+    from robosystems.operations.graph.engine import backup_manager
+
+    extracted = self._archive(tmp_path, "absent", with_dir=False)
+    live = self._live(tmp_path)
+
+    with patch(
+      "robosystems.utils.path_validation.get_lance_index_path", return_value=live
+    ):
+      outcome = backup_manager._restore_memory_store("kg1", extracted)
+
+    assert outcome == "unchanged (absent)"
+    assert (live / "memory" / "data.bin").read_bytes() == b"existing-vectors"
+
+  def test_no_manifest_leaves_the_live_store_alone(self, tmp_path):
+    """A pre-memory archive makes no claim; deleting on that basis is worst."""
+    from robosystems.operations.graph.engine import backup_manager
+
+    extracted = self._archive(tmp_path, None, with_dir=False)
+    live = self._live(tmp_path)
+
+    with patch(
+      "robosystems.utils.path_validation.get_lance_index_path", return_value=live
+    ):
+      outcome = backup_manager._restore_memory_store("kg1", extracted)
+
+    assert outcome == "unchanged (no claim)"
+    assert (live / "memory" / "data.bin").read_bytes() == b"existing-vectors"
+
+  def test_included_but_missing_directory_raises(self, tmp_path):
+    """Honour the claim or fail; never report success over an unmet one."""
+    from robosystems.operations.graph.engine import backup_manager
+    from robosystems.operations.graph.engine.backup_manager import (
+      BackupPayloadMismatch,
+    )
+
+    extracted = self._archive(tmp_path, "included", with_dir=False)
+    live = self._live(tmp_path)
+
+    with (
+      patch(
+        "robosystems.utils.path_validation.get_lance_index_path", return_value=live
+      ),
+      pytest.raises(BackupPayloadMismatch, match="no memory directory"),
+    ):
+      backup_manager._restore_memory_store("kg1", extracted)
+
+
+@pytest.mark.unit
+class TestRecordDescribesTheArchive:
+  """The record's counts must describe the archive, not the live database.
+
+  Reconciliation deliberately tolerates drift, and `_verify_restore` compares a
+  restored database against these numbers — so recording the live count made
+  every drifted backup fail verification AFTER the target was overwritten.
+  """
+
+  @pytest.mark.asyncio
+  async def test_measured_payload_counts_win_over_live_counts(self, manager):
+    manager.s3_adapter.upload_backup = AsyncMock(
+      return_value=BackupMetadata(
+        graph_id="kg1",
+        backup_type="full",
+        timestamp=datetime.now(UTC),
+        original_size=1,
+        compressed_size=1,
+        checksum="abc",
+        compression_ratio=0.0,
+        node_count=98,
+        relationship_count=49,
+        backup_duration_seconds=0.1,
+      )
+    )
+
+    with (
+      patch.object(manager, "_get_database_stats", new_callable=AsyncMock) as stats,
+      patch.object(manager, "_export_database", new_callable=AsyncMock) as export,
+    ):
+      stats.return_value = {"node_count": 100, "relationship_count": 50}
+      export.return_value = (
+        b"dump",
+        ".lbug.zip",
+        {"node_count": 98, "relationship_count": 49, "memory": "absent"},
+      )
+
+      await manager.create_backup(
+        BackupJob(
+          graph_id="kg1",
+          backup_type=BackupType.FULL,
+          backup_format=BackupFormat.FULL_DUMP,
+        )
+      )
+
+    recorded = manager.s3_adapter.upload_backup.call_args.kwargs["metadata"]
+    assert recorded["node_count"] == 98
+    assert recorded["relationship_count"] == 49
+    # The live numbers survive as the drift record rather than being lost.
+    assert recorded["payload_delta"]["live_node_count"] == 100
+
+  @pytest.mark.asyncio
+  async def test_unmeasured_payload_falls_back_to_live_counts(self, manager):
+    """An older graph node sends no counts; the record still has to say something."""
+    manager.s3_adapter.upload_backup = AsyncMock(
+      return_value=BackupMetadata(
+        graph_id="kg1",
+        backup_type="full",
+        timestamp=datetime.now(UTC),
+        original_size=1,
+        compressed_size=1,
+        checksum="abc",
+        compression_ratio=0.0,
+        node_count=100,
+        relationship_count=50,
+        backup_duration_seconds=0.1,
+      )
+    )
+
+    with (
+      patch.object(manager, "_get_database_stats", new_callable=AsyncMock) as stats,
+      patch.object(manager, "_export_database", new_callable=AsyncMock) as export,
+    ):
+      stats.return_value = {"node_count": 100, "relationship_count": 50}
+      export.return_value = (
+        b"dump",
+        ".lbug.zip",
+        {"node_count": None, "relationship_count": None, "memory": None},
+      )
+
+      await manager.create_backup(
+        BackupJob(
+          graph_id="kg1",
+          backup_type=BackupType.FULL,
+          backup_format=BackupFormat.FULL_DUMP,
+        )
+      )
+
+    recorded = manager.s3_adapter.upload_backup.call_args.kwargs["metadata"]
+    assert recorded["node_count"] == 100
+    assert "payload_delta" not in recorded


### PR DESCRIPTION
All five verified against HEAD before fixing. Two were compositions introduced by the backup work itself; three were pre-existing and surfaced by it.

## P1 — Memory was archived but never restored

The importer extracted the whole archive and placed only the database, so a restore left the live memory store untouched — and could report success while the one class of data with **no upstream** went unrecovered.

The importer now applies the manifest contract that the producer already writes:

| Manifest | Action |
|---|---|
| `included` | replace the live store |
| `absent` | leave it alone — memory has no upstream, so the asymmetry favours keeping data |
| *no manifest* | leave it alone — a pre-memory archive makes no claim, and deleting on a format gap is the worst reading |
| `included` but no `memory/` in payload | **raise** |

That last row matters: honour the claim or fail, never report success over an unmet one.

## P1 — Accepted drift guaranteed a restore-verification failure

Reconciliation deliberately tolerates live-vs-archive count differences, but the record kept the **live** counts while `_verify_restore` compares a restored database against them. A backup taken during writes recorded 100 over an archive holding 98, and would fail verification *after* the target was already overwritten.

Two decisions composed badly: tolerant reconciliation, and a record describing the source rather than the artifact. **The record now describes the artifact it is a record of** — measured archive counts are what gets stored, with the live numbers riding in `payload_delta`. Verification becomes correct by construction rather than by a second comparison.

## P1 — A coverage gap reached nobody

`assert_backup_coverage` logs CRITICAL, which is the right shape — it runs after the cleanup ops, and raising would make a coverage gap look like a retention malfunction. But nothing was listening, so the check detected the condition and told no one.

Adds a metric filter on the Dagster log group plus an alarm, following the replica stack's pattern. `SNSAlertEmail` defaults to empty and the topic and alarm are `Condition`-gated, so **the stack updates cleanly whether or not the deploy passes an address** — no workflow change required to land this safely. Pass the parameter when you want the subscription live.

## P2 — The daily quota could be bypassed while enqueueing

The route counted rows and then enqueued, while the row itself was inserted later inside the Dagster job — so concurrent requests all observed the same count and all passed.

The reservation is now taken in the route, with the count and insert **serialized per graph by locking the graph row**; the job adopts it via a new `backup_id` config field rather than inserting a second one. Locking the graph row is enough because the quota is per-graph, so unrelated graphs never wait on each other. A failed enqueue releases the slot rather than leaving a PENDING row holding quota forever. Applied to the MCP path too — a limit enforced on one of two entry points is not a limit.

Callers that don't enforce quota (the nightly schedule) still insert in the job, unchanged.

## P2 — Tier retention never reached the metadata sidecars

`s3_metadata_key` was read in two places and **written in none**, so the tracked sweep's delete was guarded on a value nothing set, and the orphan sweep scanned only the payload prefix. Sidecars outlived tier retention and rode the 90-day bucket lifecycle even for 7-day tiers.

The key is now recorded at completion, and the orphan sweep walks both prefixes on the same retention clock. Both key on `{graph_id}` as their first segment, so the same parse and the same tier lookup apply.

## Testing

`just test-all` — **12,371 passed**, 23 skipped; ruff, format, basedpyright and cf-lint clean.

New coverage: the memory tri-state on all four branches; measured-vs-live count recording in both directions; sidecar sweeping (deleted past retention, kept inside it, never touched when tracked). The orphan-sweep fixture is now prefix-aware — a single canned paginator response was handing the same objects to both passes and double-counting them.