### PR TITLE
Cross-graph share controls: recipient delete, block, and sender revoke

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -176,19 +176,22 @@ jobs:
         run: |
           uv lock --locked
 
-      - name: Create the extensions database
+      - name: Create and migrate the extensions database
         run: |
           # The platform DB (robosystems_test) comes from the service
           # container's POSTGRES_DB; the extensions DB is the second of the two
-          # databases this repo runs and has to be created by hand. DB-backed
-          # extensions tests provision their own tenant schemas from the model
-          # metadata, so an empty database is all they need — no migrations.
+          # databases this repo runs, and CI never made it — so every DB-backed
+          # extensions test skipped itself, silently, forever.
+          #
+          # Migrating is what makes them worth running: 0002 seeds the taxonomy
+          # library from the JSON-LD frameworks, which is exactly what the
+          # library-backed suites assert against. ~25s on a cold database.
           echo "🗄️  Creating the extensions database..."
           PGPASSWORD=postgres psql -h localhost -U postgres -d postgres \
             -c "CREATE DATABASE extensions" \
             || echo "extensions database already exists"
-          PGPASSWORD=postgres psql -h localhost -U postgres -d extensions \
-            -c "SELECT 1" > /dev/null
+          echo "🚀 Applying extensions migrations..."
+          uv run alembic -c migrations/extensions.ini upgrade head
           echo "✅ extensions database ready"
 
       - name: Configure Valkey authentication

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,9 @@ jobs:
       # Use fixed ports for robosystems
       DATABASE_URL: postgresql://postgres:postgres@localhost:5432/robosystems_test
       TEST_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/robosystems_test
+      # The second of the two databases — per-graph OLTP for the extensions.
+      # Created in its own step below; the service container only makes one.
+      EXTENSIONS_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/extensions
       POSTGRES_PASSWORD: postgres
       # Graph API Configuration
       GRAPH_API_URL: http://localhost:8001
@@ -172,6 +175,21 @@ jobs:
       - name: Validate lockfile
         run: |
           uv lock --locked
+
+      - name: Create the extensions database
+        run: |
+          # The platform DB (robosystems_test) comes from the service
+          # container's POSTGRES_DB; the extensions DB is the second of the two
+          # databases this repo runs and has to be created by hand. DB-backed
+          # extensions tests provision their own tenant schemas from the model
+          # metadata, so an empty database is all they need — no migrations.
+          echo "🗄️  Creating the extensions database..."
+          PGPASSWORD=postgres psql -h localhost -U postgres -d postgres \
+            -c "CREATE DATABASE extensions" \
+            || echo "extensions database already exists"
+          PGPASSWORD=postgres psql -h localhost -U postgres -d extensions \
+            -c "SELECT 1" > /dev/null
+          echo "✅ extensions database ready"
 
       - name: Configure Valkey authentication
         run: |

--- a/migrations/extensions/versions/0028_blocked_source_graphs.py
+++ b/migrations/extensions/versions/0028_blocked_source_graphs.py
@@ -1,0 +1,83 @@
+"""blocked_source_graphs — the recipient's deny list for cross-graph shares
+
+Cross-graph report sharing is capability-style: whoever holds a subscriber's
+``graph_id`` can copy a published report into that subscriber's tenant schema.
+The model only holds up if the recipient can refuse, and until now there was no
+way to. This table is that refusal — ``share-report`` consults it in the target
+schema before writing anything.
+
+It is a tenant table: the block is the recipient's own state about their own
+graph, needing no cross-tenant coordination, and it sits alongside
+``report_shares`` and ``publish_lists``. Fresh deployments get it from
+``create_tenant_schema``'s ``create_all`` over the model metadata; this
+migration is the backfill path for schemas that already exist.
+
+Revision ID: 0028
+Revises: 0027
+Create Date: 2026-08-09
+
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import Connection
+
+from migrations.extensions.helpers import TenantOps, for_each_tenant_schema
+
+# revision identifiers, used by Alembic.
+revision = "0028"
+down_revision = "0027"
+branch_labels = None
+depends_on = None
+
+_TABLE = "blocked_source_graphs"
+_INDEX = "idx_blocked_source_graphs_source"
+_UNIQUE = "uq_blocked_source_graphs_source"
+
+_TENANT_DDL = f"""
+  id TEXT PRIMARY KEY,
+  source_graph_id TEXT NOT NULL,
+  blocked_by TEXT NOT NULL,
+  blocked_at TIMESTAMP NOT NULL DEFAULT now(),
+  reason TEXT,
+  CONSTRAINT {_UNIQUE} UNIQUE (source_graph_id)
+"""
+
+
+def _create_in_tenant(conn: Connection, schema: str) -> None:
+  t = TenantOps(conn, schema)
+  t.create_table(_TABLE, _TENANT_DDL)
+  t.create_index(_INDEX, _TABLE, ["source_graph_id"])
+
+
+def _drop_in_tenant(conn: Connection, schema: str) -> None:
+  t = TenantOps(conn, schema)
+  t.drop_index(_INDEX)
+  t.drop_table(_TABLE)
+
+
+def upgrade() -> None:
+  op.create_table(
+    _TABLE,
+    sa.Column("id", sa.String(), nullable=False),
+    sa.Column("source_graph_id", sa.String(), nullable=False),
+    sa.Column("blocked_by", sa.String(), nullable=False),
+    sa.Column(
+      "blocked_at", sa.DateTime(), nullable=False, server_default=sa.text("now()")
+    ),
+    sa.Column("reason", sa.String(), nullable=True),
+    sa.PrimaryKeyConstraint("id"),
+    sa.UniqueConstraint("source_graph_id", name=_UNIQUE),
+  )
+  op.create_index(_INDEX, _TABLE, ["source_graph_id"], unique=False)
+
+  for_each_tenant_schema(op.get_bind(), _create_in_tenant)
+
+
+def downgrade() -> None:
+  for_each_tenant_schema(op.get_bind(), _drop_in_tenant)
+
+  op.drop_index(_INDEX, table_name=_TABLE)
+  op.drop_table(_TABLE)

--- a/robosystems/graphql/resolvers/ledger.py
+++ b/robosystems/graphql/resolvers/ledger.py
@@ -34,6 +34,7 @@ from robosystems.graphql.types.ledger import (
   AccountTree,
   AccountTreeNode,
   Agent,
+  BlockedSourceGraphList,
   ClosingBookStructures,
   Element,
   ElementList,
@@ -76,6 +77,9 @@ from robosystems.operations.roboledger.reads import (
 )
 from robosystems.operations.roboledger.reads import (
   ar_ap as reads_ar_ap,
+)
+from robosystems.operations.roboledger.reads import (
+  blocked_source_graphs as reads_blocked_source_graphs,
 )
 from robosystems.operations.roboledger.reads import (
   closing_book as reads_closing_book,
@@ -982,3 +986,27 @@ class LedgerQuery:
     if response is None:
       return None
     return PublishListDetail.from_pydantic(response)
+
+  # ── Blocked source graphs ───────────────────────────────────────────────
+
+  @strawberry.field
+  def blocked_source_graphs(
+    self,
+    info: Info[GraphQLContext, None],
+    limit: int | None = None,
+    offset: int | None = None,
+  ) -> BlockedSourceGraphList | None:
+    """Source graphs barred from sharing reports into this graph.
+
+    The read side of the recipient's exit from cross-graph sharing; manage the
+    list with the `block-source-graph` / `unblock-source-graph` operations.
+    """
+    limit, offset = _resolve_pagination(limit, offset, default_limit=100)
+    try:
+      with _open_session(info, "roboledger") as session:
+        response = reads_blocked_source_graphs.list_blocked_source_graphs(
+          session, limit=limit, offset=offset
+        )
+    except (ValueError, ProgrammingError):
+      _raise_ledger_not_initialized()
+    return BlockedSourceGraphList.from_pydantic(response)

--- a/robosystems/graphql/types/ledger.py
+++ b/robosystems/graphql/types/ledger.py
@@ -60,6 +60,12 @@ from robosystems.models.api.extensions.ar_ap import (
 from robosystems.models.api.extensions.ar_ap import (
   OpenBalanceByAgent as PydanticOpenBalanceByAgent,
 )
+from robosystems.models.api.extensions.blocked_source_graphs import (
+  BlockedSourceGraphListResponse as PydanticBlockedSourceGraphListResponse,
+)
+from robosystems.models.api.extensions.blocked_source_graphs import (
+  BlockedSourceGraphResponse as PydanticBlockedSourceGraphResponse,
+)
 from robosystems.models.api.extensions.closing_book import (
   ClosingBookCategory as PydanticClosingBookCategory,
 )
@@ -720,6 +726,19 @@ class PublishListDetail:
 @pydantic_type(model=PydanticPublishListListResponse, all_fields=True)
 class PublishListList:
   """Paginated list of publish lists."""
+
+
+# ── Blocked source graphs ─────────────────────────────────────────────────
+
+
+@pydantic_type(model=PydanticBlockedSourceGraphResponse, all_fields=True)
+class BlockedSourceGraph:
+  """A source graph barred from sharing reports into this graph."""
+
+
+@pydantic_type(model=PydanticBlockedSourceGraphListResponse, all_fields=True)
+class BlockedSourceGraphList:
+  """Paginated list of blocked source graphs."""
 
 
 # ── Mapped trial balance ──────────────────────────────────────────────────

--- a/robosystems/middleware/auth/dependencies.py
+++ b/robosystems/middleware/auth/dependencies.py
@@ -554,6 +554,29 @@ def require_graph_write_role(user_id: str, graph_id: str) -> None:
     session.close()
 
 
+def user_is_graph_admin(user_id: str, graph_id: str) -> bool:
+  """Whether the user holds the admin role on the graph.
+
+  A predicate, not a gate — unlike ``require_graph_write_role`` this returns a
+  bool rather than raising, because callers use it to *widen* an authorization
+  rule rather than to deny. The cross-graph share surface is the first such
+  caller: a report copied in from another graph carries the *sender's* user id
+  in ``created_by``, so the receiving graph's owner rule can never match, and a
+  graph admin is who gets to remove it.
+
+  Opens a short-lived platform session — ``GraphUser`` lives in the platform DB,
+  not the per-graph OLTP DB.
+  """
+  from robosystems.database import SessionFactory
+  from robosystems.models.core import GraphUser
+
+  session = SessionFactory()
+  try:
+    return GraphUser.user_has_admin_access(user_id, graph_id, session)
+  finally:
+    session.close()
+
+
 async def get_current_user_with_repository_access(
   request: Request,
   repository_id: str,

--- a/robosystems/models/api/extensions/blocked_source_graphs.py
+++ b/robosystems/models/api/extensions/blocked_source_graphs.py
@@ -1,0 +1,118 @@
+"""Blocked-source-graph request and response models.
+
+Cross-graph report sharing is authorized capability-style: a sender who holds
+your ``graph_id`` can copy a published report into your tenant schema. A block
+is the recipient's refusal — ``share-report`` consults the list before copying
+anything in, and a blocked sender receives an explicit per-target error rather
+than a silent drop.
+
+Blocking and purging are offered as one action because a recipient who blocks a
+sender almost always wants both: stop the next one, and remove the ones already
+landed.
+"""
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from robosystems.models.api.common import PaginationInfo
+
+# ── Requests ───────────────────────────────────────────────────────────────
+
+
+class BlockSourceGraphRequest(BaseModel):
+  """Block a source graph from sharing reports into this graph.
+
+  Blocking is idempotent: re-blocking an already-blocked source succeeds and
+  leaves the original ``blocked_at`` in place, so a retry can't be used to
+  rewrite the record.
+  """
+
+  source_graph_id: str = Field(
+    ...,
+    max_length=64,
+    description=(
+      "Graph ID to block. Read it off the `source_graph_id` provenance field "
+      "of a report that was shared to you."
+    ),
+  )
+  reason: str | None = Field(
+    None,
+    max_length=500,
+    description=("Free-form note for your own records. Never disclosed to the sender."),
+  )
+  purge: bool = Field(
+    False,
+    description=(
+      "Also delete every report already shared in from this source, with "
+      "their fact sets and facts. Reports you authored are never touched."
+    ),
+  )
+
+  model_config = ConfigDict(
+    json_schema_extra={
+      "examples": [
+        {"source_graph_id": "kg1a2b3c4d5e6f7a8b9c"},
+        {
+          "source_graph_id": "kg1a2b3c4d5e6f7a8b9c",
+          "reason": "No longer a shareholder.",
+          "purge": True,
+        },
+      ]
+    }
+  )
+
+
+class UnblockSourceGraphRequest(BaseModel):
+  """Remove a source graph from the block list, allowing shares again."""
+
+  source_graph_id: str = Field(..., max_length=64, description="Graph ID to unblock.")
+
+  model_config = ConfigDict(
+    json_schema_extra={"examples": [{"source_graph_id": "kg1a2b3c4d5e6f7a8b9c"}]}
+  )
+
+
+# ── Responses ──────────────────────────────────────────────────────────────
+
+
+class BlockedSourceGraphResponse(BaseModel):
+  """One blocked source graph."""
+
+  id: str = Field(..., description="Block row identifier (ULID).")
+  source_graph_id: str = Field(..., description="The blocked sender's graph ID.")
+  source_graph_name: str | None = Field(
+    None, description="Display name of the blocked graph (if known)."
+  )
+  blocked_by: str = Field(..., description="User ID that created the block.")
+  blocked_at: datetime = Field(..., description="When the block was created.")
+  reason: str | None = Field(None, description="Recipient's own note, if given.")
+
+
+class BlockSourceGraphResult(BaseModel):
+  """Outcome of a block, including anything the purge removed."""
+
+  block: BlockedSourceGraphResponse = Field(..., description="The block record.")
+  already_blocked: bool = Field(
+    False,
+    description=(
+      "True when the source was already blocked and this call was a no-op "
+      "apart from any purge."
+    ),
+  )
+  purged_report_count: int = Field(
+    0,
+    description=(
+      "Number of previously-shared reports deleted from this graph. Zero "
+      "unless `purge` was set."
+    ),
+  )
+
+
+class BlockedSourceGraphListResponse(BaseModel):
+  """Paginated list of blocked source graphs."""
+
+  blocked_source_graphs: list[BlockedSourceGraphResponse] = Field(
+    default_factory=list, description="Blocked source graphs."
+  )
+  pagination: PaginationInfo = Field(..., description="Pagination metadata.")

--- a/robosystems/models/api/extensions/reports.py
+++ b/robosystems/models/api/extensions/reports.py
@@ -198,6 +198,21 @@ class ShareReportRequest(BaseModel):
   )
 
 
+class RevokeReportShareRequest(BaseModel):
+  """Withdraw a report previously shared to one recipient graph.
+
+  The sender's half of the share controls: deletes the copy from that
+  recipient's tenant schema and stamps the share record ``revoked_at``. Scoped
+  to a single target — revoking a distribution to a whole publish list means
+  one call per member, so a withdrawal is always a deliberate act.
+  """
+
+  target_graph_id: str = Field(
+    ...,
+    description="Recipient graph whose copy should be withdrawn.",
+  )
+
+
 # ── Responses ────────────────────────────────────────────────────────────────
 
 
@@ -408,6 +423,22 @@ class ShareReportResponse(BaseModel):
     description=(
       "Per-recipient outcomes. Inspect to find partial failures — the "
       "share operation does not fail-fast across targets."
+    ),
+  )
+
+
+class RevokeReportShareResponse(BaseModel):
+  """Outcome of withdrawing a shared report from one recipient."""
+
+  report_id: str = Field(..., description="The report whose share was revoked.")
+  target_graph_id: str = Field(..., description="Recipient the copy was pulled from.")
+  revoked_at: datetime = Field(..., description="When the share was revoked.")
+  copy_deleted: bool = Field(
+    ...,
+    description=(
+      "True when a copy was found and deleted in the recipient's schema. "
+      "False when the recipient had already deleted it themselves — the "
+      "share is still marked revoked."
     ),
   )
 

--- a/robosystems/models/extensions/__init__.py
+++ b/robosystems/models/extensions/__init__.py
@@ -40,6 +40,7 @@ from .roboinvestor import (
 # RoboLedger extension (imports COA_SOURCES + ledger-specific models)
 from .roboledger import (
   COA_SOURCES,
+  BlockedSourceGraph,
   Entry,
   Fact,
   FactSet,
@@ -70,6 +71,7 @@ __all__ = [
   "Account",
   "Association",
   "AssociationClassification",
+  "BlockedSourceGraph",
   "Bridge",
   "Classification",
   "Dimension",

--- a/robosystems/models/extensions/roboledger/__init__.py
+++ b/robosystems/models/extensions/roboledger/__init__.py
@@ -24,6 +24,7 @@ from ..taxonomy import Taxonomy
 
 # RoboLedger-specific concepts
 from .agent import Agent
+from .blocked_source_graph import BlockedSourceGraph
 from .dimension_junctions import (
   entry_dimensions,
   event_dimensions,
@@ -52,6 +53,7 @@ __all__ = [
   "Account",
   "Agent",
   "Association",
+  "BlockedSourceGraph",
   "Dimension",
   "Element",
   "Entry",

--- a/robosystems/models/extensions/roboledger/blocked_source_graph.py
+++ b/robosystems/models/extensions/roboledger/blocked_source_graph.py
@@ -1,0 +1,42 @@
+"""BlockedSourceGraph model — the recipient's deny list for cross-graph shares.
+
+Cross-graph report sharing is capability-style: a company that holds a
+subscriber's ``graph_id`` can share published reports into that subscriber's
+tenant schema, and the handover of the id out-of-band is the handshake. That
+model is only sound if the recipient can refuse — a capability that cannot be
+declined is an obligation.
+
+A row here is the recipient saying "no more from this sender". ``share-report``
+consults it before copying anything in, and a blocked sender is told, rather
+than silently dropped: under the capability model the two parties already had a
+relationship, so a bounce is more honest than a shadow ban and stops the sender
+retrying forever.
+
+The table lives in the **recipient's** tenant schema, not the platform DB — it
+is the recipient's own state about their own graph and needs no cross-tenant
+coordination, mirroring how publish lists live in the sender's schema.
+"""
+
+from datetime import UTC, datetime
+
+from sqlalchemy import Column, DateTime, Index, String, UniqueConstraint
+
+from robosystems.db.extensions import ExtensionsBase
+from robosystems.utils.ulid import generate_prefixed_ulid
+
+
+class BlockedSourceGraph(ExtensionsBase):
+  __tablename__ = "blocked_source_graphs"
+  __table_args__ = (
+    UniqueConstraint("source_graph_id", name="uq_blocked_source_graphs_source"),
+    Index("idx_blocked_source_graphs_source", "source_graph_id"),
+  )
+
+  id = Column(String, primary_key=True, default=lambda: generate_prefixed_ulid("blk"))
+  source_graph_id = Column(String, nullable=False)
+  blocked_by = Column(String, nullable=False)  # user ID
+  blocked_at = Column(DateTime, nullable=False, default=lambda: datetime.now(UTC))
+  reason = Column(String, nullable=True)
+
+  def __repr__(self) -> str:
+    return f"<BlockedSourceGraph {self.source_graph_id}>"

--- a/robosystems/operations/roboledger/commands/blocked_source_graphs.py
+++ b/robosystems/operations/roboledger/commands/blocked_source_graphs.py
@@ -1,0 +1,130 @@
+"""Write operations for the cross-graph share block list.
+
+These commands run against the *recipient's* tenant schema — the graph doing the
+blocking. See ``models/extensions/roboledger/blocked_source_graph.py`` for why
+the deny list lives there rather than in the platform DB.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import select, text
+from sqlalchemy.orm import Session
+
+from robosystems.models.api.extensions.blocked_source_graphs import (
+  BlockedSourceGraphResponse,
+  BlockSourceGraphRequest,
+  BlockSourceGraphResult,
+  UnblockSourceGraphRequest,
+)
+from robosystems.models.extensions import BlockedSourceGraph, Report
+from robosystems.operations.roboledger.reads.blocked_source_graphs import (
+  _to_response,
+  enrich_blocks,
+)
+
+
+class SelfBlockError(Exception):
+  """Raised when a graph tries to block itself."""
+
+
+class SourceGraphNotBlockedError(LookupError):
+  """Raised when unblocking a source that isn't on the block list."""
+
+  def __init__(self, source_graph_id: str) -> None:
+    super().__init__(f"Graph '{source_graph_id}' is not blocked.")
+    self.source_graph_id = source_graph_id
+
+
+def block_source_graph(
+  session: Session, body: BlockSourceGraphRequest, created_by: str, *, graph_id: str
+) -> BlockSourceGraphResult:
+  """Block ``source_graph_id`` from sharing reports into this graph.
+
+  Idempotent: re-blocking an already-blocked source returns the existing record
+  with ``already_blocked=True`` and leaves ``blocked_at``/``blocked_by`` alone,
+  so a retry cannot rewrite who blocked whom and when.
+
+  With ``purge`` set, every report already shared in from that source is deleted
+  along with its fact sets and facts. Only shared copies are eligible — the
+  ``source_graph_id`` predicate cannot match a report this graph authored.
+
+  Raises `SelfBlockError` if the caller passes their own graph ID.
+  """
+  if body.source_graph_id == graph_id:
+    raise SelfBlockError("A graph cannot block itself.")
+
+  existing = session.execute(
+    select(BlockedSourceGraph).where(
+      BlockedSourceGraph.source_graph_id == body.source_graph_id
+    )
+  ).scalar_one_or_none()
+
+  already_blocked = existing is not None
+  if existing is None:
+    existing = BlockedSourceGraph(
+      source_graph_id=body.source_graph_id,
+      blocked_by=created_by,
+      reason=body.reason,
+    )
+    session.add(existing)
+    session.flush()
+
+  purged = 0
+  if body.purge:
+    purged = _purge_shared_reports(session, body.source_graph_id)
+
+  return BlockSourceGraphResult(
+    block=enrich_blocks([existing])[0],
+    already_blocked=already_blocked,
+    purged_report_count=purged,
+  )
+
+
+def unblock_source_graph(
+  session: Session, body: UnblockSourceGraphRequest
+) -> BlockedSourceGraphResponse:
+  """Lift a block, allowing that source to share in again.
+
+  Returns the removed record. Purged reports are not restored — unblocking
+  reopens the channel, it does not undo.
+
+  Raises `SourceGraphNotBlockedError` when the source was not blocked.
+  """
+  row = session.execute(
+    select(BlockedSourceGraph).where(
+      BlockedSourceGraph.source_graph_id == body.source_graph_id
+    )
+  ).scalar_one_or_none()
+  if row is None:
+    raise SourceGraphNotBlockedError(body.source_graph_id)
+
+  response = _to_response(row)
+  session.delete(row)
+  session.flush()
+  return response
+
+
+def _purge_shared_reports(session: Session, source_graph_id: str) -> int:
+  """Delete every report shared in from ``source_graph_id``. Returns the count.
+
+  Facts cascade from their parent fact_sets, so the fact_sets go first — the
+  same two-step ``delete_report`` uses.
+  """
+  report_ids = list(
+    session.execute(select(Report.id).where(Report.source_graph_id == source_graph_id))
+    .scalars()
+    .all()
+  )
+  if not report_ids:
+    return 0
+
+  session.execute(
+    text("DELETE FROM fact_sets WHERE report_id = ANY(:report_ids)"),
+    {"report_ids": report_ids},
+  )
+  session.execute(
+    text("DELETE FROM reports WHERE id = ANY(:report_ids)"),
+    {"report_ids": report_ids},
+  )
+  session.flush()
+  return len(report_ids)

--- a/robosystems/operations/roboledger/commands/blocked_source_graphs.py
+++ b/robosystems/operations/roboledger/commands/blocked_source_graphs.py
@@ -27,6 +27,14 @@ class SelfBlockError(Exception):
   """Raised when a graph tries to block itself."""
 
 
+class AdminRoleRequiredError(Exception):
+  """Raised when a writer attempts an admin-only half of the block controls.
+
+  Stopping a sender is open to any writer; purging what already landed and
+  re-opening a closed channel are not. See `block_source_graph`.
+  """
+
+
 class SourceGraphNotBlockedError(LookupError):
   """Raised when unblocking a source that isn't on the block list."""
 
@@ -36,7 +44,12 @@ class SourceGraphNotBlockedError(LookupError):
 
 
 def block_source_graph(
-  session: Session, body: BlockSourceGraphRequest, created_by: str, *, graph_id: str
+  session: Session,
+  body: BlockSourceGraphRequest,
+  created_by: str,
+  *,
+  graph_id: str,
+  acting_user_is_graph_admin: bool = False,
 ) -> BlockSourceGraphResult:
   """Block ``source_graph_id`` from sharing reports into this graph.
 
@@ -48,10 +61,23 @@ def block_source_graph(
   along with its fact sets and facts. Only shared copies are eligible — the
   ``source_graph_id`` predicate cannot match a report this graph authored.
 
-  Raises `SelfBlockError` if the caller passes their own graph ID.
+  **Blocking is open to any writer; purging is not.** Stopping an unwanted
+  sender should be the easy half — a member who notices a bad share should not
+  have to find an admin to make it stop. Deleting what already landed is bulk
+  and irreversible, and deleting one shared report already requires an admin
+  (`delete_report`); letting a member remove all of them through this door
+  would make that gate decorative.
+
+  Raises `SelfBlockError` if the caller passes their own graph ID, or
+  `AdminRoleRequiredError` if a non-admin requests a purge.
   """
   if body.source_graph_id == graph_id:
     raise SelfBlockError("A graph cannot block itself.")
+  if body.purge and not acting_user_is_graph_admin:
+    raise AdminRoleRequiredError(
+      "Purging reports already shared in requires the graph admin role. "
+      "Block without `purge` to stop further shares."
+    )
 
   existing = session.execute(
     select(BlockedSourceGraph).where(
@@ -81,15 +107,30 @@ def block_source_graph(
 
 
 def unblock_source_graph(
-  session: Session, body: UnblockSourceGraphRequest
+  session: Session,
+  body: UnblockSourceGraphRequest,
+  *,
+  acting_user_is_graph_admin: bool = False,
 ) -> BlockedSourceGraphResponse:
   """Lift a block, allowing that source to share in again.
 
   Returns the removed record. Purged reports are not restored — unblocking
   reopens the channel, it does not undo.
 
-  Raises `SourceGraphNotBlockedError` when the source was not blocked.
+  **Admin only.** A block is a standing decision about who may write into this
+  graph, so reversing it is not something a member should be able to do over an
+  admin's head. This is also why the operation is hand-mounted in the router
+  rather than declared through the registrar: every registrar spec becomes an
+  MCP tool, and shared reports are readable by the recipient's AI operators —
+  an operator that could lift a block, over content a blocked sender supplied,
+  would hand the sender the undo button for their own exclusion.
+
+  Raises `SourceGraphNotBlockedError` when the source was not blocked, or
+  `AdminRoleRequiredError` when the caller is not a graph admin.
   """
+  if not acting_user_is_graph_admin:
+    raise AdminRoleRequiredError("Lifting a block requires the graph admin role.")
+
   row = session.execute(
     select(BlockedSourceGraph).where(
       BlockedSourceGraph.source_graph_id == body.source_graph_id

--- a/robosystems/operations/roboledger/commands/reports.py
+++ b/robosystems/operations/roboledger/commands/reports.py
@@ -23,6 +23,8 @@ from robosystems.models.api.extensions.reports import (
   CreateReportRequest,
   RegenerateReportRequest,
   ReportResponse,
+  RevokeReportShareRequest,
+  RevokeReportShareResponse,
   ShareReportRequest,
   ShareReportResponse,
   ShareResultItem,
@@ -39,6 +41,9 @@ from robosystems.models.extensions.structure import TEXT_BLOCK_CAPS
 from robosystems.operations.aws.s3 import S3Client
 from robosystems.operations.information_block.envelope import DISCLOSURE_BLOCK_TYPE
 from robosystems.operations.roboledger.fact_set import create_fact_set
+from robosystems.operations.roboledger.reads.blocked_source_graphs import (
+  is_source_blocked,
+)
 from robosystems.operations.roboledger.reads.reports import (
   build_periods,
   load_structures,
@@ -92,6 +97,10 @@ class PublishListEmptyError(Exception):
 
 class ReportNotPublishedError(Exception):
   """Raised when trying to share a report that isn't in 'published' state."""
+
+
+class ReportShareNotFoundError(LookupError):
+  """Raised when revoking a share that doesn't exist or is already revoked."""
 
 
 class TaxonomyNotFoundError(LookupError):
@@ -694,7 +703,13 @@ def transition_filing_status(
   return report_to_response(report_def, structures, entity_name)
 
 
-def delete_report(session: Session, report_id: str, acting_user_id: str) -> bool:
+def delete_report(
+  session: Session,
+  report_id: str,
+  acting_user_id: str,
+  *,
+  acting_user_is_graph_admin: bool = False,
+) -> bool:
   """Delete a report and its generated facts.
 
   Raises `NotAuthorizedError` if the caller doesn't own the report.
@@ -702,12 +717,23 @@ def delete_report(session: Session, report_id: str, acting_user_id: str) -> bool
   state (``filed`` or ``archived``) — the Report Block lifecycle treats
   filed/archived as immutable so the audit trail can't be erased.
   Returns True if a row was deleted, False if the report did not exist.
+
+  A report shared in from another graph (``source_graph_id`` set) is the one
+  exception to the owner rule: its ``created_by`` is the *sender's* user id, so
+  no one in the receiving graph could ever match it. An admin of the receiving
+  graph may delete such a copy — the recipient's exit from a share they did not
+  ask for. Native reports are unaffected; only their owner can delete them.
+
+  Deleting the copy deliberately leaves the sender's ``ReportShare`` row alone:
+  the sender's record that they sent it is theirs, not the recipient's to erase.
   """
   report_def = session.get(Report, report_id)
   if report_def is None:
     return False
   if report_def.created_by != acting_user_id:
-    raise NotAuthorizedError("Not authorized to delete this report.")
+    is_shared_copy = report_def.source_graph_id is not None
+    if not (is_shared_copy and acting_user_is_graph_admin):
+      raise NotAuthorizedError("Not authorized to delete this report.")
   if report_def.filing_status in {"filed", "archived"}:
     raise ReportNotFiledError(
       f"Report '{report_id}' is '{report_def.filing_status}' and cannot "
@@ -826,6 +852,119 @@ def share_report(
   return ShareReportResponse(report_id=report_id, results=results)
 
 
+def revoke_report_share(
+  graph_id: str,
+  report_id: str,
+  body: RevokeReportShareRequest,
+  acting_user_id: str,
+) -> RevokeReportShareResponse:
+  """Withdraw a shared report from one recipient graph.
+
+  The sender's half of the share controls. Takes `graph_id` rather than a
+  session for the same reason `share_report` does — it spans the source and
+  target tenant schemas.
+
+  Stamps `ReportShare.revoked_at` in the source and deletes the copied Report
+  (and its fact sets, whose facts cascade) from the target. A recipient who
+  already deleted the copy themselves is not an error: the share is still
+  marked revoked and `copy_deleted` comes back False.
+
+  The linked `Entity` in the target is deliberately left in place. An investor's
+  `Security` points at it, and the relationship survives one report being
+  pulled — deleting it would break the link over a single withdrawal.
+
+  Raises `ReportNotFoundError`, `NotAuthorizedError`, or
+  `ReportShareNotFoundError`.
+  """
+  from robosystems.db.extensions import extensions_session
+
+  now = datetime.now(UTC)
+
+  with extensions_session(graph_id) as source_session:
+    report_def = source_session.get(Report, report_id)
+    if report_def is None:
+      raise ReportNotFoundError(report_id)
+    if report_def.created_by != acting_user_id:
+      raise NotAuthorizedError("Not authorized to revoke shares of this report.")
+
+    share = source_session.execute(
+      select(ReportShare).where(
+        ReportShare.report_id == report_id,
+        ReportShare.target_graph_id == body.target_graph_id,
+        ReportShare.revoked_at.is_(None),
+      )
+    ).scalar_one_or_none()
+    if share is None:
+      raise ReportShareNotFoundError(
+        f"No active share of report '{report_id}' to '{body.target_graph_id}'."
+      )
+
+  copy_deleted = _delete_shared_copy(
+    source_graph_id=graph_id,
+    source_report_id=report_id,
+    target_graph_id=body.target_graph_id,
+  )
+
+  # Stamp only after the copy is gone. If the target write fails, the share
+  # stays un-revoked and the operation is safe to retry — the alternative
+  # leaves a record claiming the data was withdrawn while it is still there.
+  with extensions_session(graph_id) as source_session:
+    share = source_session.execute(
+      select(ReportShare).where(
+        ReportShare.report_id == report_id,
+        ReportShare.target_graph_id == body.target_graph_id,
+        ReportShare.revoked_at.is_(None),
+      )
+    ).scalar_one_or_none()
+    if share is not None:
+      share.revoked_at = now
+      source_session.commit()
+
+  return RevokeReportShareResponse(
+    report_id=report_id,
+    target_graph_id=body.target_graph_id,
+    revoked_at=now,
+    copy_deleted=copy_deleted,
+  )
+
+
+def _delete_shared_copy(
+  source_graph_id: str, source_report_id: str, target_graph_id: str
+) -> bool:
+  """Delete the copy of a shared report from the target tenant schema.
+
+  Returns True when a copy was found and removed. Matches on the provenance
+  pair, so it can only ever reach a report that arrived from this sender — a
+  report the target authored has a null `source_graph_id` and cannot match.
+  """
+  from robosystems.db.extensions import extensions_session
+
+  with extensions_session(target_graph_id) as target_session:
+    copy_ids = list(
+      target_session.execute(
+        select(Report.id).where(
+          Report.source_graph_id == source_graph_id,
+          Report.source_report_id == source_report_id,
+        )
+      )
+      .scalars()
+      .all()
+    )
+    if not copy_ids:
+      return False
+
+    target_session.execute(
+      text("DELETE FROM fact_sets WHERE report_id = ANY(:report_ids)"),
+      {"report_ids": copy_ids},
+    )
+    target_session.execute(
+      text("DELETE FROM reports WHERE id = ANY(:report_ids)"),
+      {"report_ids": copy_ids},
+    )
+    target_session.commit()
+    return True
+
+
 def _share_to_target(
   source_graph_id: str,
   report_snapshot: dict[str, Any],
@@ -869,6 +1008,19 @@ def _share_to_target(
   try:
     now = datetime.now(UTC)
     with extensions_session(target_graph_id) as target_session:
+      # The recipient's exit, checked before anything is written. Blocked
+      # senders are told rather than silently dropped: they already had a
+      # relationship with the recipient, so a bounce is more honest than a
+      # shadow ban and stops them retrying forever. (If the block table is
+      # somehow missing — code ahead of migration — this raises and the
+      # handler below turns it into an error item, so the share fails closed.)
+      if is_source_blocked(target_session, source_graph_id):
+        return ShareResultItem(
+          target_graph_id=target_graph_id,
+          status="error",
+          error="Recipient has blocked shares from this graph.",
+        )
+
       shared_report = Report(
         name=report_snapshot["name"],
         description=report_snapshot.get("description"),

--- a/robosystems/operations/roboledger/commands/reports.py
+++ b/robosystems/operations/roboledger/commands/reports.py
@@ -103,6 +103,20 @@ class ReportShareNotFoundError(LookupError):
   """Raised when revoking a share that doesn't exist or is already revoked."""
 
 
+class ReportHasActiveSharesError(Exception):
+  """Raised when deleting a report that is still shared to other graphs."""
+
+  def __init__(self, report_id: str, target_graph_ids: list[str]) -> None:
+    super().__init__(
+      f"Report '{report_id}' is still shared to {len(target_graph_ids)} "
+      f"graph(s). Revoke each share first — deleting the report here would "
+      f"strand the delivered copies in their schemas with no way to withdraw "
+      f"them."
+    )
+    self.report_id = report_id
+    self.target_graph_ids = target_graph_ids
+
+
 class TaxonomyNotFoundError(LookupError):
   """Raised when `create_report` references a missing taxonomy."""
 
@@ -726,6 +740,14 @@ def delete_report(
 
   Deleting the copy deliberately leaves the sender's ``ReportShare`` row alone:
   the sender's record that they sent it is theirs, not the recipient's to erase.
+
+  Raises `ReportHasActiveSharesError` if the report is still shared out to
+  other graphs. `revoke_report_share` needs this row to find and authorize the
+  withdrawal, so deleting first would strand every delivered copy in its
+  recipient's schema permanently — precisely when withdrawal matters most,
+  since a report deleted after distribution is usually one that was wrong.
+  Revoke each recipient first. Shared *copies* are unaffected: the recipient's
+  schema holds no share rows for a report they did not send.
   """
   report_def = session.get(Report, report_id)
   if report_def is None:
@@ -734,6 +756,18 @@ def delete_report(
     is_shared_copy = report_def.source_graph_id is not None
     if not (is_shared_copy and acting_user_is_graph_admin):
       raise NotAuthorizedError("Not authorized to delete this report.")
+  active_share_targets = list(
+    session.execute(
+      select(ReportShare.target_graph_id).where(
+        ReportShare.report_id == report_id,
+        ReportShare.revoked_at.is_(None),
+      )
+    )
+    .scalars()
+    .all()
+  )
+  if active_share_targets:
+    raise ReportHasActiveSharesError(report_id, active_share_targets)
   if report_def.filing_status in {"filed", "archived"}:
     raise ReportNotFiledError(
       f"Report '{report_id}' is '{report_def.filing_status}' and cannot "
@@ -794,6 +828,16 @@ def share_report(
     report_def = source_session.get(Report, report_id)
     if report_def is None:
       raise ReportNotFoundError(report_id)
+    # Strict ownership, deliberately — NOT the graph-admin widening that
+    # `delete_report` and `revoke_report_share` carry. Sharing is a publishing
+    # act, and this rule is load-bearing beyond authorization: because only an
+    # author can share, a report that arrived from elsewhere can never acquire
+    # outbound shares of its own. That is what lets `_purge_shared_reports` and
+    # the re-share replace in `_share_to_target` delete copies in raw SQL
+    # without tripping `ReportHasActiveSharesError` — they cannot orphan a share
+    # row, because a shared copy has none. Widen this to admins and both paths
+    # start stranding delivered copies in recipients' schemas with no way to
+    # withdraw them, which is precisely what that guard exists to prevent.
     if report_def.created_by != acting_user_id:
       raise NotAuthorizedError("Not authorized to share this report.")
     if report_def.generation_status != "published":
@@ -837,16 +881,40 @@ def share_report(
 
   successful = [r for r in results if r.status == "shared"]
   if successful:
+    now = datetime.now(UTC)
     with extensions_session(graph_id) as source_session:
       for result in successful:
-        source_session.add(
-          ReportShare(
-            report_id=report_id,
-            target_graph_id=result.target_graph_id,
-            shared_by=acting_user_id,
-            fact_count=result.fact_count,
+        # One active share row per (report, recipient). A re-share replaces
+        # the recipient's copy rather than adding a second, so the record of
+        # it must not fan out either — a second active row would describe a
+        # delivery that no longer exists, and revocation would have to guess
+        # which one it withdrew.
+        existing = (
+          source_session.execute(
+            select(ReportShare).where(
+              ReportShare.report_id == report_id,
+              ReportShare.target_graph_id == result.target_graph_id,
+              ReportShare.revoked_at.is_(None),
+            )
           )
+          .scalars()
+          .all()
         )
+        if existing:
+          for share in existing:
+            share.shared_by = acting_user_id
+            share.shared_at = now
+            share.fact_count = result.fact_count
+        else:
+          source_session.add(
+            ReportShare(
+              report_id=report_id,
+              target_graph_id=result.target_graph_id,
+              shared_by=acting_user_id,
+              shared_at=now,
+              fact_count=result.fact_count,
+            )
+          )
       source_session.commit()
 
   return ShareReportResponse(report_id=report_id, results=results)
@@ -857,6 +925,8 @@ def revoke_report_share(
   report_id: str,
   body: RevokeReportShareRequest,
   acting_user_id: str,
+  *,
+  acting_user_is_graph_admin: bool = False,
 ) -> RevokeReportShareResponse:
   """Withdraw a shared report from one recipient graph.
 
@@ -869,32 +939,40 @@ def revoke_report_share(
   already deleted the copy themselves is not an error: the share is still
   marked revoked and `copy_deleted` comes back False.
 
+  Revocation is *plural on both sides*: `_delete_shared_copy` removes every
+  copy carrying this provenance pair, so every active share row for the target
+  is stamped to match. Two shares of one report to one recipient are ordinary —
+  two overlapping publish lists, or a resend after a correction — and leaving
+  one row active would claim a delivery that no longer exists.
+
   The linked `Entity` in the target is deliberately left in place. An investor's
   `Security` points at it, and the relationship survives one report being
   pulled — deleting it would break the link over a single withdrawal.
+
+  Normally restricted to the report's author, who is also the only user who
+  could have shared it. A graph admin may also revoke, so an author's departure
+  does not strand delivered copies in recipients' schemas — the same reasoning
+  that widened `delete_report`.
 
   Raises `ReportNotFoundError`, `NotAuthorizedError`, or
   `ReportShareNotFoundError`.
   """
   from robosystems.db.extensions import extensions_session
 
-  now = datetime.now(UTC)
+  active_shares = (
+    ReportShare.report_id == report_id,
+    ReportShare.target_graph_id == body.target_graph_id,
+    ReportShare.revoked_at.is_(None),
+  )
 
   with extensions_session(graph_id) as source_session:
     report_def = source_session.get(Report, report_id)
     if report_def is None:
       raise ReportNotFoundError(report_id)
-    if report_def.created_by != acting_user_id:
+    if report_def.created_by != acting_user_id and not acting_user_is_graph_admin:
       raise NotAuthorizedError("Not authorized to revoke shares of this report.")
 
-    share = source_session.execute(
-      select(ReportShare).where(
-        ReportShare.report_id == report_id,
-        ReportShare.target_graph_id == body.target_graph_id,
-        ReportShare.revoked_at.is_(None),
-      )
-    ).scalar_one_or_none()
-    if share is None:
+    if not source_session.execute(select(ReportShare.id).where(*active_shares)).first():
       raise ReportShareNotFoundError(
         f"No active share of report '{report_id}' to '{body.target_graph_id}'."
       )
@@ -905,20 +983,16 @@ def revoke_report_share(
     target_graph_id=body.target_graph_id,
   )
 
-  # Stamp only after the copy is gone. If the target write fails, the share
-  # stays un-revoked and the operation is safe to retry — the alternative
+  # Stamp only after the copy is gone. If the target write fails, the shares
+  # stay un-revoked and the operation is safe to retry — the alternative
   # leaves a record claiming the data was withdrawn while it is still there.
+  now = datetime.now(UTC)
   with extensions_session(graph_id) as source_session:
-    share = source_session.execute(
-      select(ReportShare).where(
-        ReportShare.report_id == report_id,
-        ReportShare.target_graph_id == body.target_graph_id,
-        ReportShare.revoked_at.is_(None),
-      )
-    ).scalar_one_or_none()
-    if share is not None:
+    for share in (
+      source_session.execute(select(ReportShare).where(*active_shares)).scalars().all()
+    ):
       share.revoked_at = now
-      source_session.commit()
+    source_session.commit()
 
   return RevokeReportShareResponse(
     report_id=report_id,
@@ -928,41 +1002,56 @@ def revoke_report_share(
   )
 
 
+def _delete_copies_in_session(
+  target_session: Session, source_graph_id: str, source_report_id: str
+) -> int:
+  """Delete copies of one shared report from an open target session.
+
+  Returns how many were removed. Matches on the provenance pair, so it can
+  only ever reach a report that arrived from this sender — a report the target
+  authored has a null `source_graph_id` and cannot match. Does not commit; the
+  caller owns the transaction.
+  """
+  copy_ids = list(
+    target_session.execute(
+      select(Report.id).where(
+        Report.source_graph_id == source_graph_id,
+        Report.source_report_id == source_report_id,
+      )
+    )
+    .scalars()
+    .all()
+  )
+  if not copy_ids:
+    return 0
+
+  # Facts cascade from their parent fact_sets, so the fact_sets go first.
+  target_session.execute(
+    text("DELETE FROM fact_sets WHERE report_id = ANY(:report_ids)"),
+    {"report_ids": copy_ids},
+  )
+  target_session.execute(
+    text("DELETE FROM reports WHERE id = ANY(:report_ids)"),
+    {"report_ids": copy_ids},
+  )
+  return len(copy_ids)
+
+
 def _delete_shared_copy(
   source_graph_id: str, source_report_id: str, target_graph_id: str
 ) -> bool:
   """Delete the copy of a shared report from the target tenant schema.
 
-  Returns True when a copy was found and removed. Matches on the provenance
-  pair, so it can only ever reach a report that arrived from this sender — a
-  report the target authored has a null `source_graph_id` and cannot match.
+  Returns True when a copy was found and removed.
   """
   from robosystems.db.extensions import extensions_session
 
   with extensions_session(target_graph_id) as target_session:
-    copy_ids = list(
-      target_session.execute(
-        select(Report.id).where(
-          Report.source_graph_id == source_graph_id,
-          Report.source_report_id == source_report_id,
-        )
-      )
-      .scalars()
-      .all()
-    )
-    if not copy_ids:
-      return False
-
-    target_session.execute(
-      text("DELETE FROM fact_sets WHERE report_id = ANY(:report_ids)"),
-      {"report_ids": copy_ids},
-    )
-    target_session.execute(
-      text("DELETE FROM reports WHERE id = ANY(:report_ids)"),
-      {"report_ids": copy_ids},
+    deleted = _delete_copies_in_session(
+      target_session, source_graph_id, source_report_id
     )
     target_session.commit()
-    return True
+    return deleted > 0
 
 
 def _share_to_target(
@@ -1020,6 +1109,15 @@ def _share_to_target(
           status="error",
           error="Recipient has blocked shares from this graph.",
         )
+
+      # A re-share replaces rather than accumulates. Sharing one report to one
+      # recipient twice is ordinary — two overlapping publish lists, or a
+      # resend after a correction — and without this the recipient's books
+      # collect duplicate copies of the same statement, each materializing
+      # into their graph. The provenance pair can only ever match a copy from
+      # this sender; a report the recipient authored has a null
+      # `source_graph_id`.
+      _delete_copies_in_session(target_session, source_graph_id, report_snapshot["id"])
 
       shared_report = Report(
         name=report_snapshot["name"],
@@ -1101,11 +1199,15 @@ def _share_to_target(
       )
 
   except Exception as e:
+    # The detail stays in the log, not in the response: this exception was
+    # raised against the *recipient's* schema, and the sender is a different
+    # tenant. A raw driver message would tell them about the recipient's
+    # database — the same reason `enrich_blocks` resolves a name and not an org.
     logger.error(f"Failed to share report to {target_graph_id}: {e}")
     return ShareResultItem(
       target_graph_id=target_graph_id,
       status="error",
-      error=f"Failed to copy report data: {e!s}",
+      error="Failed to copy report data.",
     )
 
 

--- a/robosystems/operations/roboledger/reads/blocked_source_graphs.py
+++ b/robosystems/operations/roboledger/reads/blocked_source_graphs.py
@@ -1,0 +1,92 @@
+"""Read operations for the cross-graph share block list."""
+
+from __future__ import annotations
+
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from robosystems.models.api.common import create_pagination_info
+from robosystems.models.api.extensions.blocked_source_graphs import (
+  BlockedSourceGraphListResponse,
+  BlockedSourceGraphResponse,
+)
+from robosystems.models.extensions import BlockedSourceGraph
+
+
+def _to_response(
+  row: BlockedSourceGraph, graph_name: str | None = None
+) -> BlockedSourceGraphResponse:
+  return BlockedSourceGraphResponse(
+    id=row.id,
+    source_graph_id=row.source_graph_id,
+    source_graph_name=graph_name,
+    blocked_by=row.blocked_by,
+    blocked_at=row.blocked_at,
+    reason=row.reason,
+  )
+
+
+def enrich_blocks(
+  rows: list[BlockedSourceGraph],
+) -> list[BlockedSourceGraphResponse]:
+  """Attach graph display names from the platform DB.
+
+  Name only, deliberately — unlike publish-list members this does not resolve
+  the owning org. A block is a record the recipient keeps about a sender they
+  already know; there is no reason for it to widen what they can learn.
+  """
+  if not rows:
+    return []
+
+  from robosystems.db.platform import SessionFactory
+  from robosystems.models.core import Graph
+
+  graph_ids = {r.source_graph_id for r in rows}
+  names: dict[str, str | None] = {}
+  with SessionFactory() as platform_session:
+    for graph_id, graph_name in platform_session.execute(
+      select(Graph.graph_id, Graph.graph_name).where(Graph.graph_id.in_(graph_ids))
+    ).all():
+      names[graph_id] = graph_name
+
+  return [_to_response(r, graph_name=names.get(r.source_graph_id)) for r in rows]
+
+
+def list_blocked_source_graphs(
+  session: Session, *, limit: int = 100, offset: int = 0
+) -> BlockedSourceGraphListResponse:
+  """List every source graph blocked from sharing into this graph."""
+  total = (
+    session.execute(select(func.count()).select_from(BlockedSourceGraph)).scalar() or 0
+  )
+  rows = (
+    session.execute(
+      select(BlockedSourceGraph)
+      .order_by(BlockedSourceGraph.blocked_at.desc())
+      .offset(offset)
+      .limit(limit)
+    )
+    .scalars()
+    .all()
+  )
+
+  return BlockedSourceGraphListResponse(
+    blocked_source_graphs=enrich_blocks(list(rows)),
+    pagination=create_pagination_info(total, limit, offset),
+  )
+
+
+def is_source_blocked(session: Session, source_graph_id: str) -> bool:
+  """Whether this graph has blocked ``source_graph_id`` from sharing in.
+
+  The enforcement predicate — called from ``share_report``'s per-target copy
+  against the *target* tenant's session, before anything is written.
+  """
+  return (
+    session.execute(
+      select(BlockedSourceGraph.id).where(
+        BlockedSourceGraph.source_graph_id == source_graph_id
+      )
+    ).scalar_one_or_none()
+    is not None
+  )

--- a/robosystems/routers/extensions/roboledger/operations.py
+++ b/robosystems/routers/extensions/roboledger/operations.py
@@ -65,6 +65,7 @@ from robosystems.db.extensions import extensions_session
 from robosystems.middleware.auth.dependencies import (
   get_current_user_with_graph,
   require_graph_write_role,
+  user_is_graph_admin,
 )
 from robosystems.middleware.extensions import (
   GraphExtensionContext,
@@ -106,6 +107,12 @@ from robosystems.models.api.extensions.agent import (
   LedgerAgentResponse,
   UpdateAgentRequest,
 )
+from robosystems.models.api.extensions.blocked_source_graphs import (
+  BlockedSourceGraphResponse,
+  BlockSourceGraphRequest,
+  BlockSourceGraphResult,
+  UnblockSourceGraphRequest,
+)
 from robosystems.models.api.extensions.entity import (
   ChangeReportingStyleRequest,
   ChangeReportingStyleResponse,
@@ -144,6 +151,8 @@ from robosystems.models.api.extensions.reports import (
   CreateReportRequest,
   RegenerateReportRequest,
   ReportResponse,
+  RevokeReportShareRequest,
+  RevokeReportShareResponse,
   ShareReportRequest,
   ShareReportResponse,
 )
@@ -256,6 +265,16 @@ from robosystems.operations.roboledger.commands.agent import (
 from robosystems.operations.roboledger.commands.agent import (
   update_agent as cmd_update_agent,
 )
+from robosystems.operations.roboledger.commands.blocked_source_graphs import (
+  SelfBlockError,
+  SourceGraphNotBlockedError,
+)
+from robosystems.operations.roboledger.commands.blocked_source_graphs import (
+  block_source_graph as cmd_block_source_graph,
+)
+from robosystems.operations.roboledger.commands.blocked_source_graphs import (
+  unblock_source_graph as cmd_unblock_source_graph,
+)
 from robosystems.operations.roboledger.commands.entity import update_parent_entity
 from robosystems.operations.roboledger.commands.event_handler import (
   EventHandlerNotFoundError,
@@ -339,6 +358,7 @@ from robosystems.operations.roboledger.commands.reports import (
   ReportNotFiledError,
   ReportNotFoundError,
   ReportNotPublishedError,
+  ReportShareNotFoundError,
   TaxonomyNotFoundError,
 )
 from robosystems.operations.roboledger.commands.reports import (
@@ -355,6 +375,9 @@ from robosystems.operations.roboledger.commands.reports import (
 )
 from robosystems.operations.roboledger.commands.reports import (
   regenerate_report as cmd_regenerate_report,
+)
+from robosystems.operations.roboledger.commands.reports import (
+  revoke_report_share as cmd_revoke_report_share,
 )
 from robosystems.operations.roboledger.commands.reports import (
   share_report as cmd_share_report,
@@ -656,6 +679,23 @@ class ShareReportOperation(ShareReportRequest):
   )
 
 
+class RevokeReportShareOperation(RevokeReportShareRequest):
+  """Withdraw a shared Report from one recipient graph."""
+
+  report_id: str = Field(..., description="The Report whose share to withdraw.")
+
+  model_config = ConfigDict(
+    json_schema_extra={
+      "examples": [
+        {
+          "report_id": "rpt_01HVF8T0M2YTAY3BBNRH0V0",
+          "target_graph_id": "kg1a2b3c4d5e6f7a8b9c",
+        },
+      ]
+    },
+  )
+
+
 class UpdatePublishListOperation(UpdatePublishListRequest):
   """Update a publish list's metadata. Carries `list_id`."""
 
@@ -720,6 +760,14 @@ class RemovePublishListMemberOperation(BaseModel):
       ]
     },
   )
+
+
+class BlockSourceGraphOperation(BlockSourceGraphRequest):
+  """Bar a graph from sharing reports into this one."""
+
+
+class UnblockSourceGraphOperation(UnblockSourceGraphRequest):
+  """Lift a block on a source graph."""
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -2220,7 +2268,14 @@ async def regenerate_report_op(
   response_model=OperationEnvelope[DeleteResult],
   operation_id="deleteReport",
   summary="Delete Report",
-  description="Deletes the report definition and all generated facts.",
+  description=(
+    "Deletes the report definition and all generated facts. Normally "
+    "restricted to the report's creator. A report shared in from another "
+    "graph carries the sender's user id in `created_by`, so those may be "
+    "deleted by any admin of the receiving graph — the recipient's exit "
+    "from an unsolicited share. Deleting a shared copy does not affect the "
+    "sender's record that they sent it."
+  ),
   tags=[_OP_TAG],
   dependencies=[_RATE_LIMIT],
   responses={**OPERATION_ERROR_RESPONSES},
@@ -2249,7 +2304,12 @@ async def delete_report_op(
     try:
       with extensions_session(graph_id) as session:
         try:
-          deleted = cmd_delete_report(session, body.report_id, str(user.id))
+          deleted = cmd_delete_report(
+            session,
+            body.report_id,
+            str(user.id),
+            acting_user_is_graph_admin=user_is_graph_admin(str(user.id), graph_id),
+          )
         except NotAuthorizedError:
           raise HTTPException(
             status_code=403, detail="Not authorized to delete this report."
@@ -2264,7 +2324,15 @@ async def delete_report_op(
       )
     return DeleteResult(deleted=True)
 
-  return await _dispatch(ctx, _runner, cache)
+  # The OLAP projection is a full rebuild from OLTP, so a deleted report leaves
+  # the graph only once the graph is marked stale. Without this the recipient's
+  # delete is cosmetic — the report stays queryable by their AI operators.
+  return await _dispatch(
+    ctx,
+    _runner,
+    cache,
+    on_fresh_success=lambda _env: mark_graph_stale(graph_id, "report_deleted"),
+  )
 
 
 @router.post(
@@ -2278,7 +2346,9 @@ async def delete_report_op(
     "facts are cloned into the recipient's tenant schema with "
     "`source_graph_id` / `source_report_id` provenance fields populated. "
     "Per-target outcomes (success or error) surface in the response — "
-    "share does not fail-fast across targets."
+    "share does not fail-fast across targets. Recipients that have blocked "
+    "this graph come back as an error for that target; withdraw a delivered "
+    "copy with `revoke-report-share`."
   ),
   tags=[_OP_TAG],
   dependencies=[_RATE_LIMIT],
@@ -2328,7 +2398,84 @@ async def share_report_op(
     except (ValueError, ProgrammingError):
       raise _ledger_404()
 
-  return await _dispatch(ctx, _runner, cache)
+  def _mark_recipients_stale(envelope) -> None:
+    # A share writes rows into each recipient's OLTP schema, but their
+    # LadybugDB projection only picks the report up on a rebuild — so without
+    # this, delivery depends on the recipient happening to have unrelated
+    # ledger activity of their own. Mark each recipient that actually
+    # received a copy. (`roboinvestor-maturity.md` D1, delivery half.)
+    result = getattr(envelope, "result", None)
+    for item in getattr(result, "results", []) or []:
+      if getattr(item, "status", None) == "shared":
+        mark_graph_stale(item.target_graph_id, "report_shared_in")
+
+  return await _dispatch(ctx, _runner, cache, on_fresh_success=_mark_recipients_stale)
+
+
+@router.post(
+  "/revoke-report-share",
+  response_model=OperationEnvelope[RevokeReportShareResponse],
+  operation_id="revokeReportShare",
+  summary="Revoke Report Share",
+  description=(
+    "Withdraws a report previously shared to one recipient graph: deletes "
+    "the copy from that recipient's schema and stamps the share record "
+    "revoked. Scoped to a single recipient — withdrawing a distribution to a "
+    "whole publish list is one call per member. A recipient who already "
+    "deleted the copy is not an error; the share is still marked revoked and "
+    "`copy_deleted` returns false. The linked entity in the recipient's graph "
+    "is left in place, so an investor's declared holding survives."
+  ),
+  tags=[_OP_TAG],
+  dependencies=[_RATE_LIMIT],
+  responses={**OPERATION_ERROR_RESPONSES},
+)
+@endpoint_metrics_decorator(
+  "/extensions/roboledger/{graph_id}/operations/revoke-report-share",
+  method="POST",
+  business_event_type="ledger_revoke_report_share",
+)
+async def revoke_report_share_op(
+  body: RevokeReportShareOperation,
+  graph_id: str = Path(..., pattern=GRAPH_OR_SUBGRAPH_ID_PATTERN),
+  user: User = Depends(_require_roboledger_write),
+  idempotency_key: str | None = Header(None, alias="Idempotency-Key"),
+  cache: IdempotencyCache = Depends(get_idempotency_cache),
+) -> OperationEnvelope:
+  ctx = _ctx(
+    graph_id=graph_id,
+    user_id=str(user.id),
+    op="revoke-report-share",
+    idempotency_key=idempotency_key,
+    body=body,
+  )
+
+  def _runner():
+    try:
+      return cmd_revoke_report_share(
+        graph_id, body.report_id, body, acting_user_id=str(user.id)
+      )
+    except ReportNotFoundError:
+      raise HTTPException(
+        status_code=404, detail=f"Report '{body.report_id}' not found."
+      )
+    except ReportShareNotFoundError as e:
+      raise HTTPException(status_code=404, detail=str(e))
+    except NotAuthorizedError:
+      raise HTTPException(
+        status_code=403, detail="Not authorized to revoke shares of this report."
+      )
+    except (ValueError, ProgrammingError):
+      raise _ledger_404()
+
+  def _mark_recipient_stale(envelope) -> None:
+    # Same reasoning as the share path: the copy leaves the recipient's graph
+    # only when their projection is rebuilt. Skip when nothing was deleted.
+    result = getattr(envelope, "result", None)
+    if getattr(result, "copy_deleted", False):
+      mark_graph_stale(body.target_graph_id, "report_share_revoked")
+
+  return await _dispatch(ctx, _runner, cache, on_fresh_success=_mark_recipient_stale)
 
 
 @router.post(
@@ -2688,6 +2835,95 @@ async def remove_publish_list_member_op(
     return DeleteResult(deleted=True)
 
   return await _dispatch(ctx, _runner, cache)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Blocked source graphs — the recipient's exit from cross-graph sharing
+#
+# Sharing is authorized capability-style: whoever holds this graph's id can
+# copy a published report in. These two operations are how a recipient
+# declines. Read the current list via the `blockedSourceGraphs` GraphQL field.
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@router.post(
+  "/block-source-graph",
+  response_model=OperationEnvelope[BlockSourceGraphResult],
+  operation_id="blockSourceGraph",
+  summary="Block Source Graph",
+  description=(
+    "Bars a graph from sharing reports into this one. Subsequent "
+    "`share-report` calls naming this graph fail for this target with an "
+    "explicit error — blocked senders are told, not silently dropped. "
+    "Idempotent: re-blocking preserves the original `blocked_at`. Set "
+    "`purge` to also delete every report already shared in from that "
+    "source, along with its fact sets and facts; reports this graph "
+    "authored are never touched."
+  ),
+  tags=[_OP_TAG],
+  dependencies=[_RATE_LIMIT],
+  responses={**OPERATION_ERROR_RESPONSES},
+)
+@endpoint_metrics_decorator(
+  "/extensions/roboledger/{graph_id}/operations/block-source-graph",
+  method="POST",
+  business_event_type="ledger_block_source_graph",
+)
+async def block_source_graph_op(
+  body: BlockSourceGraphOperation,
+  graph_id: str = Path(..., pattern=GRAPH_OR_SUBGRAPH_ID_PATTERN),
+  user: User = Depends(_require_roboledger_write),
+  idempotency_key: str | None = Header(None, alias="Idempotency-Key"),
+  cache: IdempotencyCache = Depends(get_idempotency_cache),
+) -> OperationEnvelope:
+  ctx = _ctx(
+    graph_id=graph_id,
+    user_id=str(user.id),
+    op="block-source-graph",
+    idempotency_key=idempotency_key,
+    body=body,
+  )
+
+  def _runner():
+    try:
+      with extensions_session(graph_id) as session:
+        try:
+          return cmd_block_source_graph(
+            session, body, created_by=str(user.id), graph_id=graph_id
+          )
+        except SelfBlockError as e:
+          raise HTTPException(status_code=422, detail=str(e))
+    except (ValueError, ProgrammingError):
+      raise _ledger_404()
+
+  def _mark_stale_if_purged(envelope) -> None:
+    # Only a purge changes queryable content, and the OLAP projection is a
+    # full rebuild from OLTP — a block on its own has nothing to re-project,
+    # so it must not trigger one.
+    result = getattr(envelope, "result", None)
+    if getattr(result, "purged_report_count", 0):
+      mark_graph_stale(graph_id, "shared_reports_purged")
+
+  return await _dispatch(ctx, _runner, cache, on_fresh_success=_mark_stale_if_purged)
+
+
+unblock_source_graph_op = _registrar.register(
+  OperationSpec(
+    name="unblock-source-graph",
+    summary="Unblock Source Graph",
+    description=(
+      "Lifts a block, allowing that graph to share reports into this one "
+      "again. Reports removed by an earlier purge are not restored — "
+      "unblocking reopens the channel, it does not undo. Returns 404 when "
+      "the source was not blocked."
+    ),
+    command=cmd_unblock_source_graph,
+    request_model=UnblockSourceGraphOperation,
+    result_type=BlockedSourceGraphResponse,
+    error_map={SourceGraphNotBlockedError: 404},
+    requires_created_by=False,
+  )
+)
 
 
 # NOTE: `build-fact-grid` lives in the sibling `views.py` router.

--- a/robosystems/routers/extensions/roboledger/operations.py
+++ b/robosystems/routers/extensions/roboledger/operations.py
@@ -266,6 +266,7 @@ from robosystems.operations.roboledger.commands.agent import (
   update_agent as cmd_update_agent,
 )
 from robosystems.operations.roboledger.commands.blocked_source_graphs import (
+  AdminRoleRequiredError,
   SelfBlockError,
   SourceGraphNotBlockedError,
 )
@@ -355,6 +356,7 @@ from robosystems.operations.roboledger.commands.reports import (
   NoEntityError,
   NotAuthorizedError,
   PublishListEmptyError,
+  ReportHasActiveSharesError,
   ReportNotFiledError,
   ReportNotFoundError,
   ReportNotPublishedError,
@@ -2314,6 +2316,8 @@ async def delete_report_op(
           raise HTTPException(
             status_code=403, detail="Not authorized to delete this report."
           )
+        except ReportHasActiveSharesError as e:
+          raise HTTPException(status_code=409, detail=str(e))
         except ReportNotFiledError as e:
           raise HTTPException(status_code=422, detail=str(e))
     except (ValueError, ProgrammingError):
@@ -2453,7 +2457,11 @@ async def revoke_report_share_op(
   def _runner():
     try:
       return cmd_revoke_report_share(
-        graph_id, body.report_id, body, acting_user_id=str(user.id)
+        graph_id,
+        body.report_id,
+        body,
+        acting_user_id=str(user.id),
+        acting_user_is_graph_admin=user_is_graph_admin(str(user.id), graph_id),
       )
     except ReportNotFoundError:
       raise HTTPException(
@@ -2889,10 +2897,16 @@ async def block_source_graph_op(
       with extensions_session(graph_id) as session:
         try:
           return cmd_block_source_graph(
-            session, body, created_by=str(user.id), graph_id=graph_id
+            session,
+            body,
+            created_by=str(user.id),
+            graph_id=graph_id,
+            acting_user_is_graph_admin=user_is_graph_admin(str(user.id), graph_id),
           )
         except SelfBlockError as e:
           raise HTTPException(status_code=422, detail=str(e))
+        except AdminRoleRequiredError as e:
+          raise HTTPException(status_code=403, detail=str(e))
     except (ValueError, ProgrammingError):
       raise _ledger_404()
 
@@ -2907,23 +2921,68 @@ async def block_source_graph_op(
   return await _dispatch(ctx, _runner, cache, on_fresh_success=_mark_stale_if_purged)
 
 
-unblock_source_graph_op = _registrar.register(
-  OperationSpec(
-    name="unblock-source-graph",
-    summary="Unblock Source Graph",
-    description=(
-      "Lifts a block, allowing that graph to share reports into this one "
-      "again. Reports removed by an earlier purge are not restored — "
-      "unblocking reopens the channel, it does not undo. Returns 404 when "
-      "the source was not blocked."
-    ),
-    command=cmd_unblock_source_graph,
-    request_model=UnblockSourceGraphOperation,
-    result_type=BlockedSourceGraphResponse,
-    error_map={SourceGraphNotBlockedError: 404},
-    requires_created_by=False,
-  )
+# Hand-mounted rather than declared through `_registrar`, deliberately. Every
+# registrar spec is also published as an MCP tool
+# (`middleware/mcp/tools/registrar.py`), and shared reports land in the
+# recipient's schema where their own AI operators read them as ordinary data.
+# An operator that could lift a block — acting on text a blocked sender wrote —
+# would hand that sender the undo button for their own exclusion. `block` is
+# hand-written for the same reason; keeping both halves off the tool surface is
+# the point, not an accident of style.
+@router.post(
+  "/unblock-source-graph",
+  response_model=OperationEnvelope[BlockedSourceGraphResponse],
+  operation_id="unblockSourceGraph",
+  summary="Unblock Source Graph",
+  description=(
+    "Lifts a block, allowing that graph to share reports into this one "
+    "again. Reports removed by an earlier purge are not restored — "
+    "unblocking reopens the channel, it does not undo. Requires the graph "
+    "admin role: a block is a standing decision about who may write into "
+    "this graph, so a member cannot reverse it over an admin's head. "
+    "Returns 404 when the source was not blocked."
+  ),
+  tags=[_OP_TAG],
+  dependencies=[_RATE_LIMIT],
+  responses={**OPERATION_ERROR_RESPONSES},
 )
+@endpoint_metrics_decorator(
+  "/extensions/roboledger/{graph_id}/operations/unblock-source-graph",
+  method="POST",
+  business_event_type="ledger_unblock_source_graph",
+)
+async def unblock_source_graph_op(
+  body: UnblockSourceGraphOperation,
+  graph_id: str = Path(..., pattern=GRAPH_OR_SUBGRAPH_ID_PATTERN),
+  user: User = Depends(_require_roboledger_write),
+  idempotency_key: str | None = Header(None, alias="Idempotency-Key"),
+  cache: IdempotencyCache = Depends(get_idempotency_cache),
+) -> OperationEnvelope:
+  ctx = _ctx(
+    graph_id=graph_id,
+    user_id=str(user.id),
+    op="unblock-source-graph",
+    idempotency_key=idempotency_key,
+    body=body,
+  )
+
+  def _runner():
+    try:
+      with extensions_session(graph_id) as session:
+        try:
+          return cmd_unblock_source_graph(
+            session,
+            body,
+            acting_user_is_graph_admin=user_is_graph_admin(str(user.id), graph_id),
+          )
+        except AdminRoleRequiredError as e:
+          raise HTTPException(status_code=403, detail=str(e))
+        except SourceGraphNotBlockedError as e:
+          raise HTTPException(status_code=404, detail=str(e))
+    except (ValueError, ProgrammingError):
+      raise _ledger_404()
+
+  return await _dispatch(ctx, _runner, cache)
 
 
 # NOTE: `build-fact-grid` lives in the sibling `views.py` router.

--- a/tests/operations/roboledger/commands/test_reports.py
+++ b/tests/operations/roboledger/commands/test_reports.py
@@ -482,6 +482,10 @@ def test_share_to_target_stamps_asserted_provenance() -> None:
     patch("robosystems.db.extensions.extensions_session", return_value=ext_cm),
     patch.object(reports_mod, "create_fact_set", side_effect=_capture),
     patch.object(reports_mod, "_ensure_linked_entity"),
+    # The recipient's block list is consulted before the copy. This test is
+    # about provenance stamping, so put the target on the permissive side —
+    # a bare MagicMock session would otherwise read as "blocked".
+    patch.object(reports_mod, "is_source_blocked", return_value=False),
   ):
     result = _share_to_target(
       source_graph_id="kg_src",
@@ -553,6 +557,8 @@ def test_share_to_target_carries_nonnumeric_columns() -> None:
     patch("robosystems.db.extensions.extensions_session", return_value=ext_cm),
     patch.object(reports_mod, "create_fact_set", side_effect=_fs),
     patch.object(reports_mod, "_ensure_linked_entity"),
+    # See the note on the provenance test above — the block check runs first.
+    patch.object(reports_mod, "is_source_blocked", return_value=False),
   ):
     result = _share_to_target(
       source_graph_id="kg_src",

--- a/tests/operations/roboledger/commands/test_share_controls.py
+++ b/tests/operations/roboledger/commands/test_share_controls.py
@@ -21,6 +21,7 @@ from robosystems.models.api.extensions.blocked_source_graphs import (
 )
 from robosystems.models.api.extensions.reports import RevokeReportShareRequest
 from robosystems.operations.roboledger.commands.blocked_source_graphs import (
+  AdminRoleRequiredError,
   SelfBlockError,
   SourceGraphNotBlockedError,
   block_source_graph,
@@ -28,6 +29,7 @@ from robosystems.operations.roboledger.commands.blocked_source_graphs import (
 )
 from robosystems.operations.roboledger.commands.reports import (
   NotAuthorizedError,
+  ReportHasActiveSharesError,
   ReportNotFoundError,
   ReportShareNotFoundError,
   _share_to_target,
@@ -121,6 +123,24 @@ def test_graph_admin_cannot_delete_a_native_report_they_do_not_own() -> None:
     )
 
 
+def test_a_report_with_live_shares_cannot_be_deleted() -> None:
+  """Deleting the source first would strand every delivered copy: revoke reads
+  the report to authorize the withdrawal, so once it is gone the recipients'
+  copies can never be pulled. Revoke each recipient first."""
+  session = MagicMock()
+  session.get.return_value = _make_report(created_by="user_owner")
+  session.execute.return_value.scalars.return_value.all.return_value = [
+    _TARGET_GRAPH,
+    "kg3333333333333333",
+  ]
+
+  with pytest.raises(ReportHasActiveSharesError) as exc:
+    delete_report(session, "rpt_01", acting_user_id="user_owner")
+
+  assert exc.value.target_graph_ids == [_TARGET_GRAPH, "kg3333333333333333"]
+  session.delete.assert_not_called()
+
+
 # ─── G2: recipient block ────────────────────────────────────────────────────
 
 
@@ -202,10 +222,51 @@ def test_block_with_purge_reports_the_number_of_reports_removed() -> None:
   with patch(f"{_BLOCK_CMD}.enrich_blocks") as enrich:
     enrich.return_value = [_block_response()]
     result = block_source_graph(
-      session, body, created_by="user_recipient", graph_id=_TARGET_GRAPH
+      session,
+      body,
+      created_by="user_recipient",
+      graph_id=_TARGET_GRAPH,
+      acting_user_is_graph_admin=True,
     )
 
   assert result.purged_report_count == 2
+
+
+def test_a_writer_can_block_without_admin() -> None:
+  """Stopping a sender is the easy half — a member should not have to find an
+  admin to make an unwanted share stop."""
+  session = _block_session(existing=None)
+
+  with patch(f"{_BLOCK_CMD}.enrich_blocks") as enrich:
+    enrich.return_value = [_block_response()]
+    result = block_source_graph(
+      session,
+      BlockSourceGraphRequest(source_graph_id=_SOURCE_GRAPH),
+      created_by="user_member",
+      graph_id=_TARGET_GRAPH,
+      acting_user_is_graph_admin=False,
+    )
+
+  assert result.already_blocked is False
+
+
+def test_purge_requires_admin_and_writes_nothing_without_it() -> None:
+  """Deleting one shared report takes an admin; deleting all of them through
+  the block door must not be the cheaper path."""
+  session = MagicMock()
+  session.execute.return_value.scalar_one_or_none.return_value = None
+
+  with pytest.raises(AdminRoleRequiredError):
+    block_source_graph(
+      session,
+      BlockSourceGraphRequest(source_graph_id=_SOURCE_GRAPH, purge=True),
+      created_by="user_member",
+      graph_id=_TARGET_GRAPH,
+      acting_user_is_graph_admin=False,
+    )
+
+  session.add.assert_not_called()
+  session.execute.assert_not_called()
 
 
 def test_unblock_raises_when_the_source_was_not_blocked() -> None:
@@ -213,8 +274,24 @@ def test_unblock_raises_when_the_source_was_not_blocked() -> None:
 
   with pytest.raises(SourceGraphNotBlockedError):
     unblock_source_graph(
-      session, UnblockSourceGraphRequest(source_graph_id=_SOURCE_GRAPH)
+      session,
+      UnblockSourceGraphRequest(source_graph_id=_SOURCE_GRAPH),
+      acting_user_is_graph_admin=True,
     )
+
+
+def test_a_member_cannot_lift_an_admins_block() -> None:
+  """A block is a standing decision about who may write into this graph."""
+  session = _block_session(existing=MagicMock())
+
+  with pytest.raises(AdminRoleRequiredError):
+    unblock_source_graph(
+      session,
+      UnblockSourceGraphRequest(source_graph_id=_SOURCE_GRAPH),
+      acting_user_is_graph_admin=False,
+    )
+
+  session.delete.assert_not_called()
 
 
 def test_unblock_deletes_the_row() -> None:
@@ -227,7 +304,9 @@ def test_unblock_deletes_the_row() -> None:
   session = _block_session(existing=row)
 
   response = unblock_source_graph(
-    session, UnblockSourceGraphRequest(source_graph_id=_SOURCE_GRAPH)
+    session,
+    UnblockSourceGraphRequest(source_graph_id=_SOURCE_GRAPH),
+    acting_user_is_graph_admin=True,
   )
 
   session.delete.assert_called_once_with(row)
@@ -321,11 +400,18 @@ def test_share_to_an_unblocking_recipient_proceeds_to_the_copy() -> None:
 # ─── G3: sender revoke ──────────────────────────────────────────────────────
 
 
-def _revoke_sessions(*, report, share) -> MagicMock:
-  """extensions_session stand-in for the source graph."""
+def _revoke_sessions(*, report, shares: list | None = None) -> MagicMock:
+  """extensions_session stand-in for the source graph.
+
+  `revoke_report_share` probes for any active share with `.first()`, then
+  loads them all to stamp — plural on both, because a report can legitimately
+  have been shared to one recipient more than once.
+  """
+  shares = shares or []
   source_session = MagicMock()
   source_session.get.return_value = report
-  source_session.execute.return_value.scalar_one_or_none.return_value = share
+  source_session.execute.return_value.first.return_value = shares[0] if shares else None
+  source_session.execute.return_value.scalars.return_value.all.return_value = shares
 
   factory = MagicMock()
   factory.return_value.__enter__.return_value = source_session
@@ -333,7 +419,7 @@ def _revoke_sessions(*, report, share) -> MagicMock:
 
 
 def test_revoke_requires_the_report_to_exist() -> None:
-  factory, _ = _revoke_sessions(report=None, share=None)
+  factory, _ = _revoke_sessions(report=None)
 
   with patch("robosystems.db.extensions.extensions_session", factory):
     with pytest.raises(ReportNotFoundError):
@@ -346,9 +432,7 @@ def test_revoke_requires_the_report_to_exist() -> None:
 
 
 def test_only_the_reports_owner_may_revoke_its_shares() -> None:
-  factory, _ = _revoke_sessions(
-    report=_make_report(created_by="user_owner"), share=None
-  )
+  factory, _ = _revoke_sessions(report=_make_report(created_by="user_owner"))
 
   with patch("robosystems.db.extensions.extensions_session", factory):
     with pytest.raises(NotAuthorizedError):
@@ -361,9 +445,7 @@ def test_only_the_reports_owner_may_revoke_its_shares() -> None:
 
 
 def test_revoking_a_share_that_does_not_exist_raises() -> None:
-  factory, _ = _revoke_sessions(
-    report=_make_report(created_by="user_owner"), share=None
-  )
+  factory, _ = _revoke_sessions(report=_make_report(created_by="user_owner"))
 
   with patch("robosystems.db.extensions.extensions_session", factory):
     with pytest.raises(ReportShareNotFoundError):
@@ -379,7 +461,7 @@ def test_revoke_stamps_revoked_at_and_reports_the_copy_deleted() -> None:
   share = MagicMock()
   share.revoked_at = None
   factory, _ = _revoke_sessions(
-    report=_make_report(created_by="user_owner"), share=share
+    report=_make_report(created_by="user_owner"), shares=[share]
   )
 
   with (
@@ -404,13 +486,65 @@ def test_revoke_stamps_revoked_at_and_reports_the_copy_deleted() -> None:
   )
 
 
+def test_revoke_stamps_every_active_share_to_the_same_recipient() -> None:
+  """One report can legitimately reach one recipient more than once — two
+  overlapping publish lists, or a resend after a correction. `_delete_shared_copy`
+  removes every copy carrying the provenance pair, so every share row has to be
+  stamped to match; leaving one active would claim a delivery that is gone.
+  """
+  first, second = MagicMock(), MagicMock()
+  first.revoked_at = second.revoked_at = None
+  factory, _ = _revoke_sessions(
+    report=_make_report(created_by="user_owner"), shares=[first, second]
+  )
+
+  with (
+    patch("robosystems.db.extensions.extensions_session", factory),
+    patch(f"{_REPORTS_CMD}._delete_shared_copy", return_value=True),
+  ):
+    response = revoke_report_share(
+      _SOURCE_GRAPH,
+      "rpt_01",
+      RevokeReportShareRequest(target_graph_id=_TARGET_GRAPH),
+      acting_user_id="user_owner",
+    )
+
+  assert first.revoked_at is not None
+  assert second.revoked_at == first.revoked_at == response.revoked_at
+
+
+def test_a_graph_admin_may_revoke_a_departed_authors_shares() -> None:
+  """Without this an author's departure strands their delivered copies in
+  recipients' schemas with nobody able to withdraw them."""
+  share = MagicMock()
+  share.revoked_at = None
+  factory, _ = _revoke_sessions(
+    report=_make_report(created_by="user_departed"), shares=[share]
+  )
+
+  with (
+    patch("robosystems.db.extensions.extensions_session", factory),
+    patch(f"{_REPORTS_CMD}._delete_shared_copy", return_value=True),
+  ):
+    response = revoke_report_share(
+      _SOURCE_GRAPH,
+      "rpt_01",
+      RevokeReportShareRequest(target_graph_id=_TARGET_GRAPH),
+      acting_user_id="user_admin",
+      acting_user_is_graph_admin=True,
+    )
+
+  assert response.copy_deleted is True
+  assert share.revoked_at is not None
+
+
 def test_revoke_succeeds_when_the_recipient_already_deleted_the_copy() -> None:
   """Not an error: the recipient exercising their own exit first still leaves
   the sender's record honest."""
   share = MagicMock()
   share.revoked_at = None
   factory, _ = _revoke_sessions(
-    report=_make_report(created_by="user_owner"), share=share
+    report=_make_report(created_by="user_owner"), shares=[share]
   )
 
   with (

--- a/tests/operations/roboledger/commands/test_share_controls.py
+++ b/tests/operations/roboledger/commands/test_share_controls.py
@@ -1,0 +1,432 @@
+"""Tests for the cross-graph share controls — the recipient's and sender's exit.
+
+Sharing is authorized capability-style: whoever holds a graph's id can copy a
+published report into it. These are the tests for the three controls that make
+that model sound — the recipient can delete what landed and block the sender,
+and the sender can withdraw. See
+``local/RoboSystems/specs/extensions/cross-graph-share-controls.md``.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from robosystems.models.api.extensions.blocked_source_graphs import (
+  BlockedSourceGraphResponse,
+  BlockSourceGraphRequest,
+  UnblockSourceGraphRequest,
+)
+from robosystems.models.api.extensions.reports import RevokeReportShareRequest
+from robosystems.operations.roboledger.commands.blocked_source_graphs import (
+  SelfBlockError,
+  SourceGraphNotBlockedError,
+  block_source_graph,
+  unblock_source_graph,
+)
+from robosystems.operations.roboledger.commands.reports import (
+  NotAuthorizedError,
+  ReportNotFoundError,
+  ReportShareNotFoundError,
+  _share_to_target,
+  delete_report,
+  revoke_report_share,
+)
+
+_SOURCE_GRAPH = "kg1111111111111111"
+_TARGET_GRAPH = "kg2222222222222222"
+
+_COMMANDS = "robosystems.operations.roboledger.commands"
+_BLOCK_CMD = f"{_COMMANDS}.blocked_source_graphs"
+_REPORTS_CMD = f"{_COMMANDS}.reports"
+
+
+def _make_report(
+  *,
+  created_by: str = "user_sender",
+  source_graph_id: str | None = None,
+  filing_status: str = "draft",
+) -> MagicMock:
+  r = MagicMock()
+  r.id = "rpt_01"
+  r.created_by = created_by
+  r.source_graph_id = source_graph_id
+  r.source_report_id = "rpt_source" if source_graph_id else None
+  r.filing_status = filing_status
+  r.generation_status = "published"
+  return r
+
+
+# ─── G1: recipient delete ───────────────────────────────────────────────────
+#
+# The copied report carries the *sender's* user id in `created_by`, so the
+# plain owner rule can never match anyone in the receiving graph. A graph admin
+# there is who gets to remove it — and only for copies, never for native rows.
+
+
+def test_owner_can_delete_their_own_report() -> None:
+  session = MagicMock()
+  session.get.return_value = _make_report(created_by="user_owner")
+
+  assert delete_report(session, "rpt_01", acting_user_id="user_owner") is True
+
+
+def test_graph_admin_can_delete_a_shared_copy() -> None:
+  session = MagicMock()
+  session.get.return_value = _make_report(
+    created_by="user_sender", source_graph_id=_SOURCE_GRAPH
+  )
+
+  assert (
+    delete_report(
+      session,
+      "rpt_01",
+      acting_user_id="user_recipient_admin",
+      acting_user_is_graph_admin=True,
+    )
+    is True
+  )
+
+
+def test_non_admin_cannot_delete_a_shared_copy() -> None:
+  """Membership alone is not enough — removing inbound data is admin-only."""
+  session = MagicMock()
+  session.get.return_value = _make_report(
+    created_by="user_sender", source_graph_id=_SOURCE_GRAPH
+  )
+
+  with pytest.raises(NotAuthorizedError):
+    delete_report(
+      session,
+      "rpt_01",
+      acting_user_id="user_recipient_member",
+      acting_user_is_graph_admin=False,
+    )
+
+
+def test_graph_admin_cannot_delete_a_native_report_they_do_not_own() -> None:
+  """The widening is scoped to shared copies. Being an admin does not hand
+  someone the right to delete a colleague's own report."""
+  session = MagicMock()
+  session.get.return_value = _make_report(created_by="user_colleague")
+
+  with pytest.raises(NotAuthorizedError):
+    delete_report(
+      session,
+      "rpt_01",
+      acting_user_id="user_admin",
+      acting_user_is_graph_admin=True,
+    )
+
+
+# ─── G2: recipient block ────────────────────────────────────────────────────
+
+
+def _block_session(existing=None) -> MagicMock:
+  session = MagicMock()
+  session.execute.return_value.scalar_one_or_none.return_value = existing
+  return session
+
+
+def _block_response() -> BlockedSourceGraphResponse:
+  """A real response model — `enrich_blocks` is patched out in these tests, but
+  its return value feeds Pydantic validation, so a MagicMock won't do."""
+  return BlockedSourceGraphResponse(
+    id="blk_01",
+    source_graph_id=_SOURCE_GRAPH,
+    source_graph_name="Acme Inc",
+    blocked_by="user_recipient",
+    blocked_at=datetime(2026, 8, 9, tzinfo=UTC),
+    reason=None,
+  )
+
+
+def test_block_creates_a_row_and_reports_not_already_blocked() -> None:
+  session = _block_session(existing=None)
+  body = BlockSourceGraphRequest(source_graph_id=_SOURCE_GRAPH, reason="Exited.")
+
+  with patch(f"{_BLOCK_CMD}.enrich_blocks") as enrich:
+    enrich.return_value = [_block_response()]
+    result = block_source_graph(
+      session, body, created_by="user_recipient", graph_id=_TARGET_GRAPH
+    )
+
+  assert result.already_blocked is False
+  assert result.purged_report_count == 0
+  session.add.assert_called_once()
+
+
+def test_reblocking_is_idempotent_and_does_not_rewrite_the_record() -> None:
+  """A retry must not be usable to rewrite who blocked whom, and when."""
+  existing = MagicMock()
+  existing.blocked_by = "user_first"
+  existing.blocked_at = datetime(2026, 8, 1, tzinfo=UTC)
+  session = _block_session(existing=existing)
+
+  with patch(f"{_BLOCK_CMD}.enrich_blocks") as enrich:
+    enrich.return_value = [_block_response()]
+    result = block_source_graph(
+      session,
+      BlockSourceGraphRequest(source_graph_id=_SOURCE_GRAPH),
+      created_by="user_second",
+      graph_id=_TARGET_GRAPH,
+    )
+
+  assert result.already_blocked is True
+  session.add.assert_not_called()
+  assert existing.blocked_by == "user_first"
+  assert existing.blocked_at == datetime(2026, 8, 1, tzinfo=UTC)
+
+
+def test_a_graph_cannot_block_itself() -> None:
+  with pytest.raises(SelfBlockError):
+    block_source_graph(
+      MagicMock(),
+      BlockSourceGraphRequest(source_graph_id=_TARGET_GRAPH),
+      created_by="user_recipient",
+      graph_id=_TARGET_GRAPH,
+    )
+
+
+def test_block_with_purge_reports_the_number_of_reports_removed() -> None:
+  session = MagicMock()
+  session.execute.return_value.scalar_one_or_none.return_value = None
+  session.execute.return_value.scalars.return_value.all.return_value = [
+    "rpt_a",
+    "rpt_b",
+  ]
+  body = BlockSourceGraphRequest(source_graph_id=_SOURCE_GRAPH, purge=True)
+
+  with patch(f"{_BLOCK_CMD}.enrich_blocks") as enrich:
+    enrich.return_value = [_block_response()]
+    result = block_source_graph(
+      session, body, created_by="user_recipient", graph_id=_TARGET_GRAPH
+    )
+
+  assert result.purged_report_count == 2
+
+
+def test_unblock_raises_when_the_source_was_not_blocked() -> None:
+  session = _block_session(existing=None)
+
+  with pytest.raises(SourceGraphNotBlockedError):
+    unblock_source_graph(
+      session, UnblockSourceGraphRequest(source_graph_id=_SOURCE_GRAPH)
+    )
+
+
+def test_unblock_deletes_the_row() -> None:
+  row = MagicMock()
+  row.id = "blk_01"
+  row.source_graph_id = _SOURCE_GRAPH
+  row.blocked_by = "user_recipient"
+  row.blocked_at = datetime(2026, 8, 1, tzinfo=UTC)
+  row.reason = None
+  session = _block_session(existing=row)
+
+  response = unblock_source_graph(
+    session, UnblockSourceGraphRequest(source_graph_id=_SOURCE_GRAPH)
+  )
+
+  session.delete.assert_called_once_with(row)
+  assert response.source_graph_id == _SOURCE_GRAPH
+
+
+# ─── G2 enforcement: the block is honoured by the share path ────────────────
+
+
+def _target_graph_row() -> MagicMock:
+  graph = MagicMock()
+  graph.schema_extensions = ["roboledger"]
+  return graph
+
+
+def _patched_share(*, blocked: bool):
+  """Patch _share_to_target's two DB seams: the platform lookup and the
+  target tenant session."""
+  platform = MagicMock()
+  platform.__enter__.return_value.execute.return_value.scalar_one_or_none.return_value = _target_graph_row()
+
+  target_session = MagicMock()
+  extensions = MagicMock()
+  extensions.return_value.__enter__.return_value = target_session
+
+  return (
+    patch("robosystems.db.platform.SessionFactory", return_value=platform),
+    patch("robosystems.db.extensions.extensions_session", extensions),
+    patch(f"{_REPORTS_CMD}.is_source_blocked", return_value=blocked),
+    target_session,
+  )
+
+
+def test_share_to_a_blocking_recipient_returns_an_error_and_writes_nothing() -> None:
+  """Blocked senders are told, not silently dropped — under the capability
+  model the two already had a relationship, so a bounce beats a shadow ban."""
+  platform_p, ext_p, blocked_p, target_session = _patched_share(blocked=True)
+
+  with platform_p, ext_p, blocked_p:
+    result = _share_to_target(
+      source_graph_id=_SOURCE_GRAPH,
+      report_snapshot={"id": "rpt_source", "name": "Q1", "taxonomy_id": "tax_01"},
+      source_facts=[],
+      target_graph_id=_TARGET_GRAPH,
+      shared_by="user_sender",
+    )
+
+  assert result.status == "error"
+  assert "blocked" in (result.error or "").lower()
+  assert result.fact_count == 0
+  target_session.add.assert_not_called()
+  target_session.commit.assert_not_called()
+
+
+def test_share_to_an_unblocking_recipient_proceeds_to_the_copy() -> None:
+  """Negative control for the test above: with no block in place the same
+  fixture reaches the write, so the block assertion isn't passing vacuously."""
+  platform_p, ext_p, blocked_p, target_session = _patched_share(blocked=False)
+
+  with (
+    platform_p,
+    ext_p,
+    blocked_p,
+    patch(f"{_REPORTS_CMD}.create_fact_set"),
+    patch(f"{_REPORTS_CMD}._ensure_linked_entity"),
+  ):
+    result = _share_to_target(
+      source_graph_id=_SOURCE_GRAPH,
+      report_snapshot={
+        "id": "rpt_source",
+        "name": "Q1",
+        "description": None,
+        "taxonomy_id": "tax_01",
+        "mapping_id": None,
+        "period_type": "quarterly",
+        "period_start": date(2026, 1, 1),
+        "period_end": date(2026, 3, 31),
+        "comparative": False,
+        "periods": None,
+      },
+      source_facts=[],
+      target_graph_id=_TARGET_GRAPH,
+      shared_by="user_sender",
+    )
+
+  assert result.status == "shared"
+  target_session.add.assert_called()
+  target_session.commit.assert_called_once()
+
+
+# ─── G3: sender revoke ──────────────────────────────────────────────────────
+
+
+def _revoke_sessions(*, report, share) -> MagicMock:
+  """extensions_session stand-in for the source graph."""
+  source_session = MagicMock()
+  source_session.get.return_value = report
+  source_session.execute.return_value.scalar_one_or_none.return_value = share
+
+  factory = MagicMock()
+  factory.return_value.__enter__.return_value = source_session
+  return factory, source_session
+
+
+def test_revoke_requires_the_report_to_exist() -> None:
+  factory, _ = _revoke_sessions(report=None, share=None)
+
+  with patch("robosystems.db.extensions.extensions_session", factory):
+    with pytest.raises(ReportNotFoundError):
+      revoke_report_share(
+        _SOURCE_GRAPH,
+        "rpt_01",
+        RevokeReportShareRequest(target_graph_id=_TARGET_GRAPH),
+        acting_user_id="user_sender",
+      )
+
+
+def test_only_the_reports_owner_may_revoke_its_shares() -> None:
+  factory, _ = _revoke_sessions(
+    report=_make_report(created_by="user_owner"), share=None
+  )
+
+  with patch("robosystems.db.extensions.extensions_session", factory):
+    with pytest.raises(NotAuthorizedError):
+      revoke_report_share(
+        _SOURCE_GRAPH,
+        "rpt_01",
+        RevokeReportShareRequest(target_graph_id=_TARGET_GRAPH),
+        acting_user_id="user_someone_else",
+      )
+
+
+def test_revoking_a_share_that_does_not_exist_raises() -> None:
+  factory, _ = _revoke_sessions(
+    report=_make_report(created_by="user_owner"), share=None
+  )
+
+  with patch("robosystems.db.extensions.extensions_session", factory):
+    with pytest.raises(ReportShareNotFoundError):
+      revoke_report_share(
+        _SOURCE_GRAPH,
+        "rpt_01",
+        RevokeReportShareRequest(target_graph_id=_TARGET_GRAPH),
+        acting_user_id="user_owner",
+      )
+
+
+def test_revoke_stamps_revoked_at_and_reports_the_copy_deleted() -> None:
+  share = MagicMock()
+  share.revoked_at = None
+  factory, _ = _revoke_sessions(
+    report=_make_report(created_by="user_owner"), share=share
+  )
+
+  with (
+    patch("robosystems.db.extensions.extensions_session", factory),
+    patch(f"{_REPORTS_CMD}._delete_shared_copy", return_value=True) as delete_copy,
+  ):
+    response = revoke_report_share(
+      _SOURCE_GRAPH,
+      "rpt_01",
+      RevokeReportShareRequest(target_graph_id=_TARGET_GRAPH),
+      acting_user_id="user_owner",
+    )
+
+  assert response.copy_deleted is True
+  assert response.target_graph_id == _TARGET_GRAPH
+  assert isinstance(response.revoked_at, datetime)
+  assert share.revoked_at is not None
+  delete_copy.assert_called_once_with(
+    source_graph_id=_SOURCE_GRAPH,
+    source_report_id="rpt_01",
+    target_graph_id=_TARGET_GRAPH,
+  )
+
+
+def test_revoke_succeeds_when_the_recipient_already_deleted_the_copy() -> None:
+  """Not an error: the recipient exercising their own exit first still leaves
+  the sender's record honest."""
+  share = MagicMock()
+  share.revoked_at = None
+  factory, _ = _revoke_sessions(
+    report=_make_report(created_by="user_owner"), share=share
+  )
+
+  with (
+    patch("robosystems.db.extensions.extensions_session", factory),
+    patch(f"{_REPORTS_CMD}._delete_shared_copy", return_value=False),
+  ):
+    response = revoke_report_share(
+      _SOURCE_GRAPH,
+      "rpt_01",
+      RevokeReportShareRequest(target_graph_id=_TARGET_GRAPH),
+      acting_user_id="user_owner",
+    )
+
+  assert response.copy_deleted is False
+  assert share.revoked_at is not None
+
+
+# Silence an unused-import lint if `date` is dropped from a future edit.
+_ = date

--- a/tests/operations/roboledger/commands/test_share_controls_db.py
+++ b/tests/operations/roboledger/commands/test_share_controls_db.py
@@ -32,6 +32,7 @@ from robosystems.operations.roboledger.commands.blocked_source_graphs import (
   block_source_graph,
 )
 from robosystems.operations.roboledger.commands.reports import (
+  ReportHasActiveSharesError,
   _share_to_target,
   delete_report,
   revoke_report_share,
@@ -228,6 +229,7 @@ def test_block_and_purge_removes_what_already_landed() -> None:
       BlockSourceGraphRequest(source_graph_id=SOURCE_GRAPH, purge=True),
       created_by=_RECIPIENT_ADMIN,
       graph_id=TARGET_GRAPH,
+      acting_user_is_graph_admin=True,
     )
 
   assert result.purged_report_count == 1
@@ -281,6 +283,7 @@ def test_purge_never_touches_a_report_the_recipient_authored() -> None:
       BlockSourceGraphRequest(source_graph_id=SOURCE_GRAPH, purge=True),
       created_by=_RECIPIENT_ADMIN,
       graph_id=TARGET_GRAPH,
+      acting_user_is_graph_admin=True,
     )
 
   with extensions_session(TARGET_GRAPH) as session:
@@ -289,6 +292,121 @@ def test_purge_never_touches_a_report_the_recipient_authored() -> None:
   assert len(remaining) == 1
   assert remaining[0].name == "Recipient's own report"
   assert remaining[0].source_graph_id is None
+
+
+def test_resharing_replaces_the_copy_rather_than_duplicating_it() -> None:
+  """Sharing one report to one recipient twice is ordinary — two overlapping
+  publish lists, or a resend after a correction. The recipient must end up with
+  one copy of the statement, not two."""
+  _share()
+  _share()
+
+  with extensions_session(TARGET_GRAPH) as session:
+    rows = session.execute(
+      text("SELECT id, source_report_id FROM reports WHERE source_graph_id = :sgid"),
+      {"sgid": SOURCE_GRAPH},
+    ).all()
+
+  assert len(rows) == 1
+  assert rows[0].source_report_id == _REPORT_SNAPSHOT["id"]
+  # The replaced copy took its fact sets and facts with it.
+  assert _counts(TARGET_GRAPH) == (1, 1, len(_SOURCE_FACTS))
+
+
+def test_revoke_clears_every_active_share_row_for_the_recipient() -> None:
+  """`_delete_shared_copy` removes every copy carrying the provenance pair, so
+  revocation has to stamp every active share row to match. Two rows used to
+  raise `MultipleResultsFound` and surface as a 500."""
+  _share()
+
+  with extensions_session(SOURCE_GRAPH) as session:
+    session.add(
+      Report(
+        id=_REPORT_SNAPSHOT["id"],
+        name=_REPORT_SNAPSHOT["name"],
+        taxonomy_id=_REPORT_SNAPSHOT["taxonomy_id"],
+        period_type="quarterly",
+        comparative=False,
+        generation_status="published",
+        filing_status="draft",
+        created_by=_SENDER,
+      )
+    )
+    for n in (1, 2):
+      session.add(
+        ReportShare(
+          id=f"share_000{n}",
+          report_id=_REPORT_SNAPSHOT["id"],
+          target_graph_id=TARGET_GRAPH,
+          shared_by=_SENDER,
+          fact_count=len(_SOURCE_FACTS),
+        )
+      )
+
+  response = revoke_report_share(
+    SOURCE_GRAPH,
+    _REPORT_SNAPSHOT["id"],
+    RevokeReportShareRequest(target_graph_id=TARGET_GRAPH),
+    acting_user_id=_SENDER,
+  )
+
+  assert response.copy_deleted is True
+  assert _counts(TARGET_GRAPH) == (0, 0, 0)
+
+  with extensions_session(SOURCE_GRAPH) as session:
+    still_active = session.execute(
+      text("SELECT count(*) FROM report_shares WHERE revoked_at IS NULL")
+    ).scalar_one()
+
+  assert still_active == 0
+
+
+def test_a_report_with_live_shares_cannot_be_deleted_out_from_under_recipients() -> (
+  None
+):
+  """Deleting the source report first would make its delivered copies
+  unrevocable — `revoke_report_share` reads the report to authorize the
+  withdrawal, so the recipient would be stuck with it permanently."""
+  _share()
+
+  with extensions_session(SOURCE_GRAPH) as session:
+    session.add(
+      Report(
+        id=_REPORT_SNAPSHOT["id"],
+        name=_REPORT_SNAPSHOT["name"],
+        taxonomy_id=_REPORT_SNAPSHOT["taxonomy_id"],
+        period_type="quarterly",
+        comparative=False,
+        generation_status="published",
+        filing_status="draft",
+        created_by=_SENDER,
+      )
+    )
+    session.add(
+      ReportShare(
+        id="share_0001",
+        report_id=_REPORT_SNAPSHOT["id"],
+        target_graph_id=TARGET_GRAPH,
+        shared_by=_SENDER,
+        fact_count=len(_SOURCE_FACTS),
+      )
+    )
+
+  with extensions_session(SOURCE_GRAPH) as session:
+    with pytest.raises(ReportHasActiveSharesError):
+      delete_report(session, _REPORT_SNAPSHOT["id"], acting_user_id=_SENDER)
+
+  # Revoke first, and the same delete goes through.
+  revoke_report_share(
+    SOURCE_GRAPH,
+    _REPORT_SNAPSHOT["id"],
+    RevokeReportShareRequest(target_graph_id=TARGET_GRAPH),
+    acting_user_id=_SENDER,
+  )
+  with extensions_session(SOURCE_GRAPH) as session:
+    assert (
+      delete_report(session, _REPORT_SNAPSHOT["id"], acting_user_id=_SENDER) is True
+    )
 
 
 def test_sender_revoke_pulls_the_copy_and_stamps_the_share() -> None:

--- a/tests/operations/roboledger/commands/test_share_controls_db.py
+++ b/tests/operations/roboledger/commands/test_share_controls_db.py
@@ -1,0 +1,357 @@
+"""DB-backed two-tenant proof of the cross-graph share controls.
+
+The mock-based tests in ``test_share_controls.py`` prove the authorization
+rules. This module proves the thing mocks structurally cannot: that a share is
+genuinely a *cross-schema copy* — the rows land in the recipient's schema and
+nowhere else — and that the block and the recipient delete really keep them out
+and take them away.
+
+Runs against the real extensions database (``EXTENSIONS_DATABASE_URL``) with two
+throwaway tenant schemas created from the model metadata, the same mechanism
+``create_tenant_schema`` uses. The taxonomy-library copy is skipped: none of
+these paths read library content.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+from sqlalchemy import create_engine, text
+
+import robosystems.models.extensions  # noqa: F401  (register models on the Base)
+from robosystems.config import env
+from robosystems.db.extensions import ExtensionsBase, extensions_session
+from robosystems.models.api.extensions.blocked_source_graphs import (
+  BlockSourceGraphRequest,
+)
+from robosystems.models.api.extensions.reports import RevokeReportShareRequest
+from robosystems.models.extensions import BlockedSourceGraph, Report, ReportShare
+from robosystems.operations.roboledger.commands.blocked_source_graphs import (
+  block_source_graph,
+)
+from robosystems.operations.roboledger.commands.reports import (
+  _share_to_target,
+  delete_report,
+  revoke_report_share,
+)
+
+pytestmark = pytest.mark.integration
+
+# Valid graph-id shapes (kg + 16+ lowercase hex) so `_sanitize_schema` accepts
+# them as schema names.
+SOURCE_GRAPH = "kgaaaaaaaaaaaaaaaa01"
+TARGET_GRAPH = "kgbbbbbbbbbbbbbbbb02"
+
+_ENTITY_ID = "ent_test_0001"
+_SENDER = "user_sender"
+_RECIPIENT_ADMIN = "user_recipient_admin"
+
+_REPORT_SNAPSHOT = {
+  "id": "rpt_source_0001",
+  "name": "Q1 2026 Statements",
+  "description": "Quarterly distribution.",
+  "taxonomy_id": "tax_rsgaap_reporting",
+  "mapping_id": None,
+  "period_type": "quarterly",
+  "period_start": date(2026, 1, 1),
+  "period_end": date(2026, 3, 31),
+  "comparative": False,
+  "periods": None,
+}
+
+_SOURCE_FACTS = [
+  {
+    "id": "fact_0001",
+    "element_id": "rs-gaap:Revenues",
+    "value": 1000,
+    "string_value": None,
+    "fact_type": "Numeric",
+    "value_type": "inline",
+    "content_type": None,
+    "decimals": 0,
+    "period_start": date(2026, 1, 1),
+    "period_end": date(2026, 3, 31),
+    "period_type": "duration",
+    "unit": "USD",
+    "entity_id": _ENTITY_ID,
+    "created_at": datetime(2026, 4, 1, tzinfo=UTC),
+  },
+  {
+    "id": "fact_0002",
+    "element_id": "rs-gaap:Assets",
+    "value": 5000,
+    "string_value": None,
+    "fact_type": "Numeric",
+    "value_type": "inline",
+    "content_type": None,
+    "decimals": 0,
+    "period_start": None,
+    "period_end": date(2026, 3, 31),
+    "period_type": "instant",
+    "unit": "USD",
+    "entity_id": _ENTITY_ID,
+    "created_at": datetime(2026, 4, 1, tzinfo=UTC),
+  },
+]
+
+
+def _tenant_tables():
+  return [t for t in ExtensionsBase.metadata.sorted_tables if t.schema is None]
+
+
+@pytest.fixture(scope="module")
+def two_tenants():
+  """Two real tenant schemas, dropped on the way out."""
+  url = env.EXTENSIONS_DATABASE_URL
+  if not url:
+    pytest.skip("EXTENSIONS_DATABASE_URL not configured")
+
+  engine = create_engine(url)
+  tables = _tenant_tables()
+  try:
+    with engine.begin() as conn:
+      for schema in (SOURCE_GRAPH, TARGET_GRAPH):
+        conn.execute(text(f"DROP SCHEMA IF EXISTS {schema} CASCADE"))
+        conn.execute(text(f"CREATE SCHEMA {schema}"))
+        ExtensionsBase.metadata.create_all(
+          bind=conn.execution_options(schema_translate_map={None: schema}),
+          tables=tables,
+        )
+    yield
+  finally:
+    with engine.begin() as conn:
+      for schema in (SOURCE_GRAPH, TARGET_GRAPH):
+        conn.execute(text(f"DROP SCHEMA IF EXISTS {schema} CASCADE"))
+    engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _clean_tenants(two_tenants):
+  """Truncate the tables these tests touch between cases."""
+  for graph_id in (SOURCE_GRAPH, TARGET_GRAPH):
+    with extensions_session(graph_id) as session:
+      session.execute(text("DELETE FROM facts"))
+      session.execute(text("DELETE FROM fact_sets"))
+      session.execute(text("DELETE FROM reports"))
+      session.execute(text("DELETE FROM blocked_source_graphs"))
+      session.execute(text("DELETE FROM report_shares"))
+  yield
+
+
+def _patch_platform_graph_lookup():
+  """`_share_to_target` validates the target against the platform DB; these
+  graph ids exist only in the extensions database."""
+  target_graph = MagicMock()
+  target_graph.schema_extensions = ["roboledger"]
+
+  platform = MagicMock()
+  platform.__enter__.return_value.execute.return_value.scalar_one_or_none.return_value = target_graph
+  return patch("robosystems.db.platform.SessionFactory", return_value=platform)
+
+
+def _share() -> object:
+  with _patch_platform_graph_lookup():
+    return _share_to_target(
+      source_graph_id=SOURCE_GRAPH,
+      report_snapshot=_REPORT_SNAPSHOT,
+      source_facts=_SOURCE_FACTS,
+      target_graph_id=TARGET_GRAPH,
+      shared_by=_SENDER,
+    )
+
+
+def _counts(graph_id: str) -> tuple[int, int, int]:
+  with extensions_session(graph_id) as session:
+    reports = session.execute(text("SELECT count(*) FROM reports")).scalar_one()
+    fact_sets = session.execute(text("SELECT count(*) FROM fact_sets")).scalar_one()
+    facts = session.execute(text("SELECT count(*) FROM facts")).scalar_one()
+  return reports, fact_sets, facts
+
+
+def test_share_writes_into_the_target_schema_only() -> None:
+  """The isolation claim: a share is a copy into the recipient, and it leaves
+  the sender's schema untouched."""
+  result = _share()
+
+  assert result.status == "shared"
+  assert result.fact_count == len(_SOURCE_FACTS)
+
+  assert _counts(TARGET_GRAPH) == (1, 1, len(_SOURCE_FACTS))
+  assert _counts(SOURCE_GRAPH) == (0, 0, 0)
+
+
+def test_the_copy_carries_honest_provenance() -> None:
+  """The recipient's data is never silently commingled — the copy names where
+  it came from, and stamps its arrival."""
+  _share()
+
+  with extensions_session(TARGET_GRAPH) as session:
+    row = session.execute(
+      text(
+        "SELECT source_graph_id, source_report_id, shared_at, created_by FROM reports"
+      )
+    ).one()
+
+  assert row.source_graph_id == SOURCE_GRAPH
+  assert row.source_report_id == _REPORT_SNAPSHOT["id"]
+  assert row.shared_at is not None
+  # The copy is stamped with the *sender's* user id — which is exactly why the
+  # recipient's delete had to be widened beyond the owner rule.
+  assert row.created_by == _SENDER
+
+
+def test_a_block_keeps_the_copy_out() -> None:
+  with extensions_session(TARGET_GRAPH) as session:
+    block_source_graph(
+      session,
+      BlockSourceGraphRequest(source_graph_id=SOURCE_GRAPH),
+      created_by=_RECIPIENT_ADMIN,
+      graph_id=TARGET_GRAPH,
+    )
+
+  result = _share()
+
+  assert result.status == "error"
+  assert "blocked" in (result.error or "").lower()
+  assert _counts(TARGET_GRAPH) == (0, 0, 0)
+
+
+def test_block_and_purge_removes_what_already_landed() -> None:
+  _share()
+  assert _counts(TARGET_GRAPH)[0] == 1
+
+  with extensions_session(TARGET_GRAPH) as session:
+    result = block_source_graph(
+      session,
+      BlockSourceGraphRequest(source_graph_id=SOURCE_GRAPH, purge=True),
+      created_by=_RECIPIENT_ADMIN,
+      graph_id=TARGET_GRAPH,
+    )
+
+  assert result.purged_report_count == 1
+  assert _counts(TARGET_GRAPH) == (0, 0, 0)
+
+  with extensions_session(TARGET_GRAPH) as session:
+    blocked = session.execute(
+      text("SELECT source_graph_id FROM blocked_source_graphs")
+    ).scalar_one()
+  assert blocked == SOURCE_GRAPH
+
+
+def test_a_recipient_admin_can_delete_the_copy() -> None:
+  """G1 end to end: the report is owned by the sender's user id, and an admin
+  of the receiving graph removes it anyway."""
+  _share()
+
+  with extensions_session(TARGET_GRAPH) as session:
+    copy_id = session.execute(text("SELECT id FROM reports")).scalar_one()
+    deleted = delete_report(
+      session,
+      copy_id,
+      acting_user_id=_RECIPIENT_ADMIN,
+      acting_user_is_graph_admin=True,
+    )
+
+  assert deleted is True
+  assert _counts(TARGET_GRAPH) == (0, 0, 0)
+
+
+def test_purge_never_touches_a_report_the_recipient_authored() -> None:
+  """The purge predicate is `source_graph_id`, which a native report cannot
+  match — but prove it rather than assert it."""
+  _share()
+
+  with extensions_session(TARGET_GRAPH) as session:
+    session.add(
+      Report(
+        name="Recipient's own report",
+        taxonomy_id="tax_rsgaap_reporting",
+        period_type="quarterly",
+        comparative=False,
+        generation_status="published",
+        created_by=_RECIPIENT_ADMIN,
+      )
+    )
+
+  with extensions_session(TARGET_GRAPH) as session:
+    block_source_graph(
+      session,
+      BlockSourceGraphRequest(source_graph_id=SOURCE_GRAPH, purge=True),
+      created_by=_RECIPIENT_ADMIN,
+      graph_id=TARGET_GRAPH,
+    )
+
+  with extensions_session(TARGET_GRAPH) as session:
+    remaining = session.execute(text("SELECT name, source_graph_id FROM reports")).all()
+
+  assert len(remaining) == 1
+  assert remaining[0].name == "Recipient's own report"
+  assert remaining[0].source_graph_id is None
+
+
+def test_sender_revoke_pulls_the_copy_and_stamps_the_share() -> None:
+  """G3 end to end, through the real two-schema path."""
+  _share()
+
+  # The sender's own Report row + its ReportShare record — `share_report`
+  # writes these; this test drives `_share_to_target` directly, so stand them up.
+  with extensions_session(SOURCE_GRAPH) as session:
+    session.add(
+      Report(
+        id=_REPORT_SNAPSHOT["id"],
+        name=_REPORT_SNAPSHOT["name"],
+        taxonomy_id=_REPORT_SNAPSHOT["taxonomy_id"],
+        period_type="quarterly",
+        comparative=False,
+        generation_status="published",
+        filing_status="draft",
+        created_by=_SENDER,
+      )
+    )
+    session.add(
+      ReportShare(
+        id="share_0001",
+        report_id=_REPORT_SNAPSHOT["id"],
+        target_graph_id=TARGET_GRAPH,
+        shared_by=_SENDER,
+        fact_count=len(_SOURCE_FACTS),
+      )
+    )
+
+  response = revoke_report_share(
+    SOURCE_GRAPH,
+    _REPORT_SNAPSHOT["id"],
+    RevokeReportShareRequest(target_graph_id=TARGET_GRAPH),
+    acting_user_id=_SENDER,
+  )
+
+  assert response.copy_deleted is True
+  assert _counts(TARGET_GRAPH) == (0, 0, 0)
+
+  with extensions_session(SOURCE_GRAPH) as session:
+    revoked_at = session.execute(
+      text("SELECT revoked_at FROM report_shares WHERE id = 'share_0001'")
+    ).scalar_one()
+    # The sender keeps their own report; only the recipient's copy is pulled.
+    own_reports = session.execute(text("SELECT count(*) FROM reports")).scalar_one()
+
+  assert revoked_at is not None
+  assert own_reports == 1
+
+
+def test_blocks_are_per_tenant_and_do_not_leak_across_schemas() -> None:
+  """A block written in the target must be invisible in the source — the
+  schema-per-graph isolation the whole model rests on."""
+  with extensions_session(TARGET_GRAPH) as session:
+    session.add(
+      BlockedSourceGraph(source_graph_id=SOURCE_GRAPH, blocked_by=_RECIPIENT_ADMIN)
+    )
+
+  with extensions_session(SOURCE_GRAPH) as session:
+    count = session.execute(
+      text("SELECT count(*) FROM blocked_source_graphs")
+    ).scalar_one()
+
+  assert count == 0

--- a/tests/operations/roboledger/commands/test_share_controls_db.py
+++ b/tests/operations/roboledger/commands/test_share_controls_db.py
@@ -19,6 +19,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from sqlalchemy import create_engine, text
+from sqlalchemy.exc import OperationalError
 
 import robosystems.models.extensions  # noqa: F401  (register models on the Base)
 from robosystems.config import env
@@ -104,12 +105,26 @@ def _tenant_tables():
 
 @pytest.fixture(scope="module")
 def two_tenants():
-  """Two real tenant schemas, dropped on the way out."""
+  """Two real tenant schemas, dropped on the way out.
+
+  ``EXTENSIONS_DATABASE_URL`` always resolves to *something* — it falls back to
+  a localhost default — so its presence proves nothing. Connect before deciding:
+  a developer without the extensions database gets a skip, not a fixture error.
+  CI creates the database explicitly, so a skip there would be a regression and
+  is deliberately not something this fixture can hide.
+  """
   url = env.EXTENSIONS_DATABASE_URL
   if not url:
     pytest.skip("EXTENSIONS_DATABASE_URL not configured")
 
   engine = create_engine(url)
+  try:
+    with engine.connect() as probe:
+      probe.execute(text("SELECT 1"))
+  except OperationalError as exc:
+    engine.dispose()
+    pytest.skip(f"extensions database unreachable: {exc.orig}")
+
   tables = _tenant_tables()
   try:
     with engine.begin() as conn:


### PR DESCRIPTION
Adds the authorization controls that cross-graph report sharing was missing on both sides.

Report sharing copies a published report from one tenant's schema into another's, across the org boundary, authorized capability-style: possession of an unguessable `graph_id` is sufficient, because the only way to hold one is that the subscriber handed it over. That model is deliberate — an investor is not in the company's org, is not entitled to the ledger, and *is* entitled to quarterly reports — but it is only sound if the recipient can refuse.

## What's here

**Recipient delete.** A copy is written with the sender's user id in `created_by`, so the owner rule could never match anyone in the receiving graph. An admin of the receiving graph can now delete a report that arrived from elsewhere. Scoped to copies — a graph admin still can't delete a colleague's own report, and the filed/archived immutability rule is untouched.

**Recipient block.** A new per-tenant `blocked_source_graphs` table (migration `0028`, fanned out to every existing schema), consulted in the target's session before anything is written. Optionally purges reports already received from that source; reports the recipient authored are never eligible. Blocking is idempotent and preserves the original `blocked_at`. A blocked sender is told rather than silently dropped — they already had a relationship, so a bounce is more honest than a shadow ban and stops them retrying. The recipient's private note is never disclosed.

**Sender revoke.** `revoke-report-share` withdraws a delivered copy and stamps `ReportShare.revoked_at` — a column that had been declared since the feature shipped and never written or read. Scoped to one recipient, so withdrawal is always deliberate. A recipient who already deleted the copy is not an error. The linked entity is left in place so an investor's declared holding survives.

## Two gaps found while building

Neither was in the original design, and both made the difference between a control and a gesture:

1. **Nothing marked the graph stale on deletion.** Materialization is a full rebuild from OLTP, so a removed row leaves the recipient's graph only when the graph is marked stale — and `delete-report` did so nowhere. Delete, purge and revoke now each mark the right graph, conditionally where a no-op is possible.
2. **Sharing never marked the *target* stale either**, so delivery depended on the recipient happening to have unrelated ledger activity. One line in a handler already being edited, so it's folded in.

## Surface and compatibility

Three new operations and one new GraphQL field (`blockedSourceGraphs`); no removals, no changed shapes. Additive, so this is a client minor on both SDKs — branches are up in `robosystems-python-client` and `robosystems-typescript-client` and should merge after this deploys, not before.

## Tests

25 across the surface. 17 mock-based cover the authorization rules; 8 DB-backed run against two real tenant schemas and prove the copy lands in the recipient's schema and nowhere else, that a block keeps it out, that a purge spares native reports, and that blocks don't leak across schemas. Two pre-existing `_share_to_target` tests needed a patch for the new block check.

Full suite green: 12393 passed.