### PR TITLE
Alarm delivery assurance + v1.8.0 release notes

### DIFF
--- a/.github/release-notes/v1.8.0.md
+++ b/.github/release-notes/v1.8.0.md
@@ -1,0 +1,101 @@
+v1.8.0 closes the 1.7 series. It is the release where the data-protection story became real —
+backups that run on a schedule, carry the right contents, and can be opened — and where two surfaces
+that had been advertised without being finished, subgraphs and cross-graph report sharing, were
+either completed or given the controls they needed.
+
+Covers everything since v1.7.0; the 1.7.x patches carried generated changelogs.
+
+## Cross-graph report sharing gets its controls
+
+Sharing copies a published report from one graph into another's books, across the organization
+boundary by design — a company distributing quarterly statements to investors who are, by
+definition, somewhere else. Authorization is capability-style: holding the recipient's graph id is
+sufficient, because the only way to hold one is that they handed it over.
+
+That model needed an exit, and now has one on both sides. A recipient can **block** a sender — with
+the option to purge what already arrived — and an admin of the receiving graph can **delete** a
+report shared in from elsewhere, which the ordinary owner rule could never permit, since the copy
+carries the sender's user id. A sender can **revoke** a delivered copy, wiring a `revoked_at` column
+that had been declared since the feature shipped and never used.
+
+Sharing also now marks the recipient's graph stale, so a shared report actually materializes rather
+than waiting for unrelated activity to trigger a rebuild.
+
+## Backups
+
+The largest arc in the series. Backups now run **nightly**, are bounded by a per-tier
+`max_backups_per_day` quota that is enforced rather than merely published, and are listed and
+downloadable by the customer who owns them — a backup you cannot see is not protection you can rely
+on.
+
+Two correctness fixes matter more than the scheduling. Payloads that were already compressed
+archives were being gzipped again, so a downloaded `.lbug.zip` could not be opened by anything
+trusting its name; reads now detect encoding by magic bytes rather than by a flag, so the existing
+mixed population stays readable. And `backup_type` was carrying two different questions — what a
+backup *is* and who started it — so a new `initiated_by` axis separates them, which is what lets
+quota exemption, listing visibility and labelling each do the right thing.
+
+Restore was hardened, retention enforcement fixed, and the listing now reports memory inclusion as a
+tri-state so a backup predating memory support reads as "makes no claim" rather than "had none."
+
+## Subgraphs as first-class citizens
+
+A subgraph inherited its parent's entire tool surface: 78 MCP tools, of which about 66 could not
+run — some failing loudly on an internal validator, and some failing *quietly by succeeding*,
+returning confident answers about relationships the subgraph does not have. The list is now cut to
+the 12 that apply, as an allowlist over the assembled set so a new tool is excluded by default
+rather than by someone remembering.
+
+`create-subgraph` also used to return an id that a URL-anchored connector could neither reach nor
+explain; it now returns a reachable connector URL and is explicit about credential reuse.
+
+## Authentication and access
+
+- **Graph-scoped API keys.** Keys can be minted for a single graph, honored for that graph and its
+  subgraphs and rejected elsewhere. This is what makes MCP connector clients work — they cannot send
+  custom headers, so a scoped key may be carried in the URL on the MCP transport route only.
+  Account-wide keys are rejected there.
+- Password changes now invalidate existing sessions.
+- OAuth state handling moved to a shared store.
+- Administrators can deactivate users.
+
+## API surface changes
+
+These ride the SDK's generated tier and are already reflected in the published clients, but a pinned
+integrator will see them nowhere else:
+
+- **`GET /subgraphs/quota` is removed** — folded into `GET /limits` as a `subgraphs` block with the
+  same `current_count` / `max_allowed` / `remaining` / `approaching_limit` shape the document meter
+  uses. Its `total_size_mb` / `max_size_mb` fields were never populated and are not carried over.
+- **`POST /operator/batch` and `POST /operator/recommend` are removed.** Neither had a consumer;
+  auto-select still runs the same scoring internally.
+- **`total_gb_hours` is retired** from usage responses. It was a storage-billing unit, and storage is
+  included in the tier — there is no storage billing for it to denominate.
+- Reconciliation responses use `isReconcilingItem`; storage keeps its mechanical column names.
+- New: the report share controls, `update-graph-metadata`, and the graph-scope field on API keys.
+
+## Fixes
+
+Forecast scenarios stopped walking past their stale tail and gained a scenario dimension; period
+comparatives resolve the prior calendar period correctly; the fact-provenance arms and rule-expression
+grammar were unified; adapter element qnames self-heal; provisioning gained idempotency and a correct
+failure disposition; repository credit reallocation, connection sync-result recording, and the
+Dagster worker host were all corrected. A dead pricing service and a shadowed storage metric were
+deleted rather than maintained.
+
+## Monitoring
+
+Three gaps in the alarm *delivery path* — the inbox was always monitored; what could not deliver was
+the signal. `AllocationFailures` was published under one dimension and alarmed on another, so it
+watched a stream nothing wrote to. Nothing alarmed on the application returning 5xx, only on errors
+the load balancer generates, which a healthy process returning 500s never produces. And nothing
+detected a dropped notification subscription, where nothing arriving is indistinguishable from
+nothing happening.
+
+## Deploying this release
+
+- **Migrations on both databases.** Platform: graph-backup initiator, API-key graph scope, connection
+  sync result. Extensions: fact dimensions, scenario-dimension backfill, and the share block list.
+- **CloudFormation stack updates**: `dagster`, `postgres`, `s3`, `worker`, and `security` — the last
+  carries the new API error and notification-delivery alarms, and reads a new
+  `API_TARGET_ERROR_THRESHOLD` repository variable.

--- a/.github/workflows/deploy-vpc.yml
+++ b/.github/workflows/deploy-vpc.yml
@@ -447,7 +447,8 @@ jobs:
                       ParameterKey=ApiAlbFullNameProd,ParameterValue=${ALB_PROD:-} \
                       ParameterKey=ApiTgFullNameProd,ParameterValue=${TG_PROD:-} \
                       ParameterKey=ApiAlbFullNameStaging,ParameterValue=${ALB_STAGING:-} \
-                      ParameterKey=ApiTgFullNameStaging,ParameterValue=${TG_STAGING:-}"
+                      ParameterKey=ApiTgFullNameStaging,ParameterValue=${TG_STAGING:-} \
+                      ParameterKey=ApiTargetErrorThreshold,ParameterValue=${{ vars.API_TARGET_ERROR_THRESHOLD || '5' }}"
 
           echo "AWS Config recorder enabled: ${{ inputs.security_config_enabled }}"
 

--- a/bin/setup/gha.sh
+++ b/bin/setup/gha.sh
@@ -504,6 +504,14 @@ function setup_full_config() {
     # Notification Configuration
     gh variable set AWS_SNS_ALERT_EMAIL --body "$AWS_SNS_ALERT_EMAIL"
 
+    # Sustained application 5xx over 5 minutes before the API error alarm
+    # fires (security stack, both environments). Starts deliberately low —
+    # there is no traffic baseline to tune against, and a noisy alarm in a
+    # folder checked several times a day is recoverable where a missing one
+    # is not. Retune with `just gha-set API_TARGET_ERROR_THRESHOLD <n>` and
+    # redeploy the security stack; no code change needed.
+    gh variable set API_TARGET_ERROR_THRESHOLD --body "5"
+
     # Features Configuration
     gh variable set OBSERVABILITY_ENABLED_PROD --body "true"
     if $setup_staging; then

--- a/cloudformation/security.yaml
+++ b/cloudformation/security.yaml
@@ -60,6 +60,11 @@ Parameters:
   # so this will move — and a threshold that needs a code change to adjust ends
   # up never adjusted. Sourced from the API_TARGET_ERROR_THRESHOLD GitHub
   # variable so it can be retuned without a PR.
+  #
+  # Comparison is GreaterThanThreshold, matching the sibling ALB alarms, so the
+  # alarm fires *above* this count — 5 means the sixth 5xx in five minutes. Worth
+  # knowing where the floor sits: at current traffic, five 5xx in five minutes is
+  # already a lot of broken. Lower it rather than reaching for the operator.
   ApiTargetErrorThreshold:
     Type: Number
     Default: 5
@@ -752,25 +757,41 @@ Resources:
       AlarmActions:
         - !Sub arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:robosystems-staging-security-alerts
 
-  # Delivery assurance for the alert channel itself. Every alarm in this account
-  # reaches a human through SNS email, and AWS silently drops an unconfirmed
-  # email subscription after three days — after which nothing arrives, and
-  # nothing arriving is indistinguishable from nothing happening. This is the
-  # only control that tells those apart.
+  # Delivery assurance for the alert channel itself: every alarm in this account
+  # reaches a human through SNS email.
+  #
+  # **Be precise about what this catches, because the obvious reading is wrong.**
+  # It fires when SNS *attempts* a delivery and the attempt fails — the bounce
+  # window that precedes AWS disabling a confirmed subscriber. It does NOT
+  # detect a subscription sitting in `PendingConfirmation`, nor one AWS has
+  # already dropped: neither receives delivery attempts, so neither produces a
+  # failed-notification datapoint, and the alarm is silent straight through the
+  # scenario people assume it covers. **The check for that state is the
+  # subscription list itself** — `aws sns list-subscriptions-by-topic` for a
+  # `PendingConfirmation` ARN or a missing subscriber. See the periodic
+  # verification in `runbooks/incident-triage.md`.
+  #
+  # **This alarm cannot report its own brokenness.** SNS publishes
+  # `NumberOfNotificationsFailed` only on failure — healthy is *no data*, which
+  # `notBreaching` renders as OK. A SEARCH expression that matches nothing (typo,
+  # rejected syntax, changed schema) produces the same no-data and the same OK.
+  # `notBreaching` is still the right setting — the alternative is an alarm that
+  # lives permanently in INSUFFICIENT_DATA — but it means the staging exercise is
+  # the *only* validation this alarm will ever get. **Re-run it whenever this
+  # expression changes.**
   #
   # Aggregated across every topic with SEARCH rather than one alarm per topic:
-  # there are sixteen alert topics across ten stacks, and SEARCH also picks up
-  # topics added later without anyone remembering to add an alarm.
+  # sixteen alert topics across ten stacks, and SEARCH also picks up topics added
+  # later without anyone remembering.
   #
   # **One alarm, not one per environment.** SEARCH matches every topic in the
-  # account and region, so prod and staging copies would watch identical data
-  # and both fire on the same failure. It routes to the prod alert topic because
-  # that is the destination that gets read, not because it is prod-scoped.
+  # account and region, so prod and staging copies would watch identical data and
+  # both fire on the same failure. It routes to the prod alert topic because that
+  # is the destination that gets read, not because it is prod-scoped.
   #
-  # Yes, it is circular — a delivery-failure alarm delivered by the channel that
-  # is failing. Accepted deliberately: the realistic failure is *one*
-  # subscription being dropped, not SNS itself being down. A second channel is
-  # scope this does not need.
+  # Circular by design — a delivery-failure alarm delivered by the channel that
+  # is failing. Accepted: the realistic failure is one subscriber bouncing, not
+  # SNS itself being down.
   SnsDeliveryFailureAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:

--- a/cloudformation/security.yaml
+++ b/cloudformation/security.yaml
@@ -55,6 +55,16 @@ Parameters:
     Type: String
     Default: ""
 
+  # Sustained 5xx from the application over a 5-minute window. Deliberately a
+  # parameter, not a literal: there is no traffic baseline to tune against yet,
+  # so this will move — and a threshold that needs a code change to adjust ends
+  # up never adjusted. Sourced from the API_TARGET_ERROR_THRESHOLD GitHub
+  # variable so it can be retuned without a PR.
+  ApiTargetErrorThreshold:
+    Type: Number
+    Default: 5
+    MinValue: 0
+
   EnableSecurityHub:
     Type: String
     Default: "true"
@@ -628,6 +638,36 @@ Resources:
       AlarmActions:
         - !Sub arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:robosystems-prod-security-alerts
 
+  # The 5xx alarm above watches HTTPCode_ELB_5XX_Count — errors the *load
+  # balancer* generates. A healthy process returning 500 on every business
+  # endpoint produces none of those: its targets stay healthy, the liveness
+  # probe keeps passing, and the outage is invisible end to end. Target_5XX is
+  # the application's own errors, and is the one an outage actually rides
+  # through.
+  ApiTarget5xxAlarmProd:
+    Type: AWS::CloudWatch::Alarm
+    Condition: HasApiAlbProd
+    Properties:
+      AlarmName: robosystems-prod-api-target-5xx
+      AlarmDescription: The API is returning 5xx responses to clients
+      MetricName: HTTPCode_Target_5XX_Count
+      Namespace: AWS/ApplicationELB
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: !Ref ApiTargetErrorThreshold
+      ComparisonOperator: GreaterThanThreshold
+      Dimensions:
+        - Name: LoadBalancer
+          Value: !Ref ApiAlbFullNameProd
+        - Name: TargetGroup
+          Value: !Ref ApiTgFullNameProd
+      # No traffic is the normal state at this scale, and no traffic cannot be
+      # an outage — a request has to reach the app for it to 5xx.
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - !Sub arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:robosystems-prod-security-alerts
+
   ApiAlbUnhealthyHostsAlarmStaging:
     Type: AWS::CloudWatch::Alarm
     Condition: HasApiAlbStaging
@@ -689,6 +729,66 @@ Resources:
       TreatMissingData: notBreaching
       AlarmActions:
         - !Sub arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:robosystems-staging-security-alerts
+
+  ApiTarget5xxAlarmStaging:
+    Type: AWS::CloudWatch::Alarm
+    Condition: HasApiAlbStaging
+    Properties:
+      AlarmName: robosystems-staging-api-target-5xx
+      AlarmDescription: The API is returning 5xx responses to clients
+      MetricName: HTTPCode_Target_5XX_Count
+      Namespace: AWS/ApplicationELB
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: !Ref ApiTargetErrorThreshold
+      ComparisonOperator: GreaterThanThreshold
+      Dimensions:
+        - Name: LoadBalancer
+          Value: !Ref ApiAlbFullNameStaging
+        - Name: TargetGroup
+          Value: !Ref ApiTgFullNameStaging
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - !Sub arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:robosystems-staging-security-alerts
+
+  # Delivery assurance for the alert channel itself. Every alarm in this account
+  # reaches a human through SNS email, and AWS silently drops an unconfirmed
+  # email subscription after three days — after which nothing arrives, and
+  # nothing arriving is indistinguishable from nothing happening. This is the
+  # only control that tells those apart.
+  #
+  # Aggregated across every topic with SEARCH rather than one alarm per topic:
+  # there are sixteen alert topics across ten stacks, and SEARCH also picks up
+  # topics added later without anyone remembering to add an alarm.
+  #
+  # **One alarm, not one per environment.** SEARCH matches every topic in the
+  # account and region, so prod and staging copies would watch identical data
+  # and both fire on the same failure. It routes to the prod alert topic because
+  # that is the destination that gets read, not because it is prod-scoped.
+  #
+  # Yes, it is circular — a delivery-failure alarm delivered by the channel that
+  # is failing. Accepted deliberately: the realistic failure is *one*
+  # subscription being dropped, not SNS itself being down. A second channel is
+  # scope this does not need.
+  SnsDeliveryFailureAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: robosystems-sns-delivery-failures
+      AlarmDescription: An SNS topic failed to deliver a notification
+      ComparisonOperator: GreaterThanThreshold
+      EvaluationPeriods: 1
+      Threshold: 0
+      TreatMissingData: notBreaching
+      Metrics:
+        - Id: failed
+          Label: NumberOfNotificationsFailed across all topics
+          ReturnData: true
+          Expression: >-
+            SUM(SEARCH('{AWS/SNS,TopicName} MetricName="NumberOfNotificationsFailed"',
+            'Sum', 300))
+      AlarmActions:
+        - !Sub arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:robosystems-prod-security-alerts
 
   # Admin-key-rotation Lambdas are defined in api.yaml (same ceiling constraint);
   # function names are deterministic stack-name prefixes.

--- a/robosystems/middleware/graph/allocation_manager.py
+++ b/robosystems/middleware/graph/allocation_manager.py
@@ -1154,7 +1154,20 @@ class LadybugAllocationManager:
   async def _publish_failure_metric(
     self, failure_reason: str, entity_id: str, user_id: str | None = None
   ):
-    """Publish allocation failure metric to CloudWatch (only in prod/staging)."""
+    """Publish allocation failure metric to CloudWatch (only in prod/staging).
+
+    Emitted under **two** dimension sets, and the duplication is deliberate.
+    CloudWatch matches an alarm to a metric on the exact dimension set, so a
+    datum carrying only ``FailureReason`` is invisible to an alarm watching
+    ``Environment`` — which is what
+    ``graph-ladybug.yaml``'s ``AllocationFailureAlarm`` does. That alarm sat
+    ``OK`` for six months not because provisioning never failed but because
+    nothing had ever published to the stream it watches, and
+    ``TreatMissingData: notBreaching`` renders permanent silence as health.
+
+    Fixing the emitter rather than the alarm keeps ``FailureReason``, which is
+    the dimension worth having during triage, and needs no stack deploy.
+    """
     if self.environment in ["dev", "test"]:
       return
 
@@ -1168,7 +1181,15 @@ class LadybugAllocationManager:
           "Dimensions": [
             {"Name": "FailureReason", "Value": failure_reason},
           ],
-        }
+        },
+        {
+          "MetricName": "AllocationFailures",
+          "Value": 1,
+          "Unit": "Count",
+          "Dimensions": [
+            {"Name": "Environment", "Value": self.environment},
+          ],
+        },
       ]
       self.cloudwatch.put_metric_data(Namespace=namespace, MetricData=metric_data)
       logger.warning(

--- a/tests/middleware/graph/test_allocation_manager_extended.py
+++ b/tests/middleware/graph/test_allocation_manager_extended.py
@@ -734,11 +734,17 @@ class TestPublishMetrics:
     manager = _create_manager(environment="prod")
     await manager._publish_failure_metric("no_capacity", "entity1", "user1")
 
-    metric_data = manager.cloudwatch.put_metric_data.call_args.kwargs["MetricData"]
+    call = manager.cloudwatch.put_metric_data.call_args
+    metric_data = call.kwargs["MetricData"]
     dimension_sets = [
       {d["Name"]: d["Value"] for d in datum["Dimensions"]} for datum in metric_data
     ]
 
+    # An alarm matches on namespace *and* dimension set. Namespace arrives as a
+    # separate kwarg, so asserting only the dimensions would let a dropped
+    # `/{environment}` suffix re-break the alarm in the identical way with this
+    # test still green.
+    assert call.kwargs["Namespace"] == "RoboSystems/Graph/prod"
     assert {"FailureReason": "no_capacity"} in dimension_sets
     assert {"Environment": "prod"} in dimension_sets
     assert all(d["MetricName"] == "AllocationFailures" for d in metric_data)

--- a/tests/middleware/graph/test_allocation_manager_extended.py
+++ b/tests/middleware/graph/test_allocation_manager_extended.py
@@ -723,6 +723,28 @@ class TestPublishMetrics:
     manager.cloudwatch.put_metric_data.assert_called_once()
 
   @pytest.mark.asyncio
+  async def test_publish_failure_metric_emits_both_dimension_sets(self):
+    """The alarm matches on `Environment`; triage wants `FailureReason`.
+
+    CloudWatch matches an alarm to a metric on the exact dimension set, so
+    emitting only `FailureReason` leaves `AllocationFailureAlarm` watching a
+    stream nothing publishes to — it sat `OK` for six months on exactly that.
+    Asserting the call happened is what let it through; assert the payload.
+    """
+    manager = _create_manager(environment="prod")
+    await manager._publish_failure_metric("no_capacity", "entity1", "user1")
+
+    metric_data = manager.cloudwatch.put_metric_data.call_args.kwargs["MetricData"]
+    dimension_sets = [
+      {d["Name"]: d["Value"] for d in datum["Dimensions"]} for datum in metric_data
+    ]
+
+    assert {"FailureReason": "no_capacity"} in dimension_sets
+    assert {"Environment": "prod"} in dimension_sets
+    assert all(d["MetricName"] == "AllocationFailures" for d in metric_data)
+    assert all(d["Value"] == 1 for d in metric_data)
+
+  @pytest.mark.asyncio
   async def test_publish_allocation_metrics_handles_error(self):
     manager = _create_manager(environment="prod")
     manager.instance_table.scan.side_effect = _make_client_error()


### PR DESCRIPTION
Closes three gaps in the alarm **delivery path**, and adds the curated notes for v1.8.0.

The framing that survived the audit is worth stating first: **the alert inbox is monitored.** What was broken is whether a signal ever gets produced and arrives — and an empty folder looks exactly like a healthy platform. None of this is fixed by watching the inbox harder.

## The three fixes

**An alarm that could never fire.** `AllocationFailures` was published with a `FailureReason` dimension and alarmed on an `Environment` dimension. CloudWatch matches on the exact dimension set, so the alarm watched a stream nothing wrote to, and `TreatMissingData: notBreaching` rendered the permanent silence as health — `OK` since February. This is the alarm that would report a failed customer provisioning. The emitter now publishes both dimension sets; `FailureReason` stays because it is what triage wants. Fixing the emitter rather than the alarm means no stack deploy.

**Nothing alarmed on the application failing.** The existing 5xx alarm watches `HTTPCode_ELB_5XX_Count` — errors the *load balancer* generates. A healthy process returning 500 on every business endpoint produces none: its targets stay healthy, the liveness probe keeps passing, and the outage is invisible end to end. Adds `HTTPCode_Target_5XX_Count` alarms on the API target group in both environments.

**Nothing detected a dropped subscription.** AWS silently drops an unconfirmed SNS email subscription after three days, after which nothing arrives — and nothing arriving is indistinguishable from nothing happening. One account-wide alarm aggregates `NumberOfNotificationsFailed` across every topic via `SEARCH`, so topics added later are covered without anyone remembering.

## Two decisions worth reviewing

**The threshold is a variable, not a literal.** `API_TARGET_ERROR_THRESHOLD` (set to 5, seeded in `bin/setup/gha.sh`, `|| '5'` fallback in the workflow so an unset variable can't pass an empty string to a `Number` parameter). There is no traffic baseline to reason from, so this *will* move — and a threshold that needs a PR to change is one nobody changes.

**The alarms live in `security.yaml`, not `api.yaml`.** Forced, not stylistic: `api.yaml` is at 50,398 bytes against CloudFormation's 51,200-byte inline ceiling. `security.yaml` already owns both ALB alarms and already receives the target-group dimensions, so this is additive to an existing pattern with no new plumbing.

## Still outstanding

The **§7 adversarial proofs** are the real completion bar and are staging exercises, not blockers here — a green alarm is not evidence, only a transition is. §5.4's especially: a malformed `SEARCH` expression sits silently in `INSUFFICIENT_DATA`, which is this spec's own failure mode, so treat that alarm as unproven until exercised. Added to `incident-triage.md` as a periodic check.

Deliberately deferred: the deep-health endpoint (a bad dependency probe pulls healthy targets out of service — it wants its own change window) and the status-repo Issues toggle.

## Tests

The emitter test asserted only that `put_metric_data` was **called** — proving the call happened, never that the payload could match an alarm. That is exactly how this survived six months, reproduced in the test suite. It now asserts both dimension sets.

`just test-code` clean, 660 graph-middleware tests pass, `cfn-lint` + `validate-template` clean on `security.yaml`.

## Release notes

Also carries `.github/release-notes/v1.8.0.md`, covering the whole series since v1.7.0 (60 merges) — backups, subgraphs as first-class MCP citizens, graph-scoped API keys, the share controls, and the four API-surface removals a pinned integrator will see nowhere else. It must be on `main` **before** the `create-release` dispatch; the workflow reads it at the tagged ref.