### PR TITLE
fix(extensions): mark the graph stale on every write that materializes

### DIFF
--- a/.github/release-notes/v1.8.0.md
+++ b/.github/release-notes/v1.8.0.md
@@ -71,8 +71,46 @@ integrator will see them nowhere else:
   auto-select still runs the same scoring internally.
 - **`total_gb_hours` is retired** from usage responses. It was a storage-billing unit, and storage is
   included in the tier — there is no storage billing for it to denominate.
+- **The API-call fields are removed from the org usage summary** — `total_api_calls`,
+  `daily_avg_api_calls`, `projected_monthly_api_calls` and `api_calls_limit`, plus the `api_calls` key
+  in the per-graph breakdown and the daily trend. Nothing ever wrote the usage rows they were computed
+  from, so every one of them was arithmetically pinned to zero. No integration can depend on a
+  constant zero. API-usage metering is worth building; publishing zeros is not a substitute for it.
 - Reconciliation responses use `isReconcilingItem`; storage keeps its mechanical column names.
 - New: the report share controls, `update-graph-metadata`, and the graph-scope field on API keys.
+
+## Writes that never reached the graph
+
+The analytical graph is rebuilt from OLTP rows whenever a graph is marked stale, so an operation that
+writes rows without marking its graph leaves them invisible — the write succeeds, the API returns 200,
+and the graph answers as though the data were never there.
+
+**No RoboInvestor operation marked its graph at all.** A graph whose only activity was RoboInvestor
+never materialized: portfolios, securities, positions and their relationships stayed empty, and the
+cross-graph research path — a holding traversed to its issuer's reports — could not run. It went
+unnoticed because a graph that *also* keeps books gets marked by its accounting activity and
+materializes as a side effect, so the failure needed a portfolio-only graph to appear.
+
+Auditing the rest of the surface found the same defect in a form that hides better: five accounting
+operations — creating and updating agents, creating and deleting chart-of-accounts mappings, and
+linking an entity to a taxonomy — all write tables the graph reads, and none marked it. In practice a
+QuickBooks sync or a period close usually marks the graph soon afterward, which made delivery
+incidental rather than guaranteed. All are fixed, and a structural test now holds the whole surface:
+every operation either marks its graph or is listed as exempt with the table it writes and the reason
+the graph never reads it.
+
+Also fixed: a security's cross-graph attribution was read from its linked entity instead of the
+security's own column, so a security registered against an issuer it had not yet been linked to
+materialized with no attribution — exactly the pre-link state the cross-graph design depends on.
+
+## Corrected claims
+
+The extension catalog described RoboInvestor as offering trade execution, risk analysis, market data,
+dividends, benchmarks and performance monitoring. Dividends do not exist; the others are schema
+declarations with no implementation behind them. The description now covers what is built —
+private-market portfolio tracking, positions with cost basis, holdings by company, and a securities
+registry for ownership instruments with their terms — which is both accurate and a better description
+of the product than the version that named a public-equity feature set.
 
 ## Fixes
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # RoboSystems
 
-RoboSystems is an open-source, AI-native financial intelligence platform for accounting, financial reporting, and investment management. It gives AI agents and analysts a ledger-grade system of record they can both query and operate — closing the books, producing reports, and analyzing portfolios across accounting, market, and SEC data. Powers [RoboLedger](https://roboledger.ai) and [RoboInvestor](https://roboinvestor.ai).
+RoboSystems is an open-source, AI-native financial intelligence platform for accounting, financial reporting, and investment management. It models your financial data as a **knowledge graph** — transactions, facts, reporting elements, and the calculation structures that relate them are all nodes and edges, with the semantics preserved rather than flattened into rows you query around. On top of that graph it gives AI agents and analysts a ledger-grade system of record they can both query and operate — closing the books, producing reports, and analyzing portfolios across accounting, market, and SEC data. Powers [RoboLedger](https://roboledger.ai) and [RoboInvestor](https://roboinvestor.ai).
+
+**Every tenant gets their own graph.** Not a row-level slice of a shared table — a dedicated graph database on its own instance, with a dedicated OLTP schema behind it. Your ontology, your taxonomies, and your calculation structures live in it as artifacts you can read, export, and take with you.
 
 Open source top to bottom — the accounting ontology, reporting taxonomies, and calculation structures are inspectable, portable artifacts you own, not configuration trapped in a vendor platform: [semantic sovereignty](https://robosystems.ai/blog/semantic-sovereignty) for your financial data.
 
@@ -171,7 +173,22 @@ See the **[Bootstrap Guide](https://github.com/RoboFinSystems/robosystems/wiki/B
 
 ## Architecture
 
-Built end-to-end on open-source engines — PostgreSQL, LadybugDB, DuckDB, LanceDB, OpenSearch, and Valkey — assembled into a transactional core with a materialized analytical graph and integrated vector search, with no proprietary database lock-in. The components:
+Built end-to-end on open-source engines — PostgreSQL, LadybugDB, DuckDB, LanceDB, OpenSearch, and Valkey — assembled into a transactional core with a materialized analytical graph and integrated vector search, with no proprietary database lock-in.
+
+### Multi-Tenancy & Isolation
+
+The tenancy model is one rule: **every isolation primitive keys on `graph_id` — never on an organization.** Session `search_path`, cache keys, idempotency keys, rate-limit buckets, and credit accounting all namespace on the graph, or on the user where the thing genuinely belongs to a person. No shared state is ever org-keyed. The consequence worth understanding is that two graphs inside the *same* organization are isolated by the identical mechanism that separates two unrelated customers, rather than by a weaker variant of it — there is no "internal" path that skips the boundary.
+
+- **A dedicated graph database per tenant.** Every tier allocates one LadybugDB database per instance (`databases_per_instance: 1`) — no shared writer, no query contention from a neighbor, and a blast radius of one tenant. Tiers differ by instance size, not by how many tenants share it.
+- **Schema-per-graph OLTP.** The extensions PostgreSQL database gives each graph its own schema, and `SET search_path` is re-stamped on entry to every request rather than assumed from a pooled connection. A CI structural test pins that contract so it can't quietly regress.
+- **Two databases, two migration histories.** Platform state (identity, orgs, billing, graph metadata) is a separate database from extensions OLTP, with independent Alembic histories. A migration to one never touches the other.
+- **The graph is a derived projection.** OLTP rows are the system of record; the analytical graph is rebuilt from them blue-green — built alongside the live graph and swapped only when the build is clean. Nothing in the graph is authoritative, which is what makes a rebuild routine instead of risky.
+- **Subgraphs** are isolated data environments within a tenant — separate databases sharing the parent's credits and permissions — used for AI memory, development, and team workspaces.
+- **Shared repositories** (SEC XBRL) are the one multi-reader surface: a separate read-only tier with its own replicas, queryable *alongside* your own graph, and never writable through it.
+
+Because tenancy is enforced at the graph rather than in application predicates, the same codebase serves managed SaaS, a single-tenant dedicated deployment, and a fully self-hosted install with no fork. Details: [Graphs & Multi-Tenancy](https://github.com/RoboFinSystems/robosystems/wiki/Graphs-and-Multi-Tenancy).
+
+### Components
 
 **Application Layer:**
 

--- a/robosystems/operations/extensions/materialize.py
+++ b/robosystems/operations/extensions/materialize.py
@@ -1243,7 +1243,15 @@ def _staging_sql(graph_id: str, entity_id: str, connstr: str) -> dict[str, str]:
       sec.is_active,
       NULL::VARCHAR                   AS ticker,
       NULL::VARCHAR                   AS figi,
-      e.metadata->>'source_graph_id'  AS source_graph_id
+      -- The security's own column first: it carries the investor's declared
+      -- cross-graph intent from the moment the security is created, whereas the
+      -- entity join only resolves once `_ensure_linked_entity` has run. Reading
+      -- the join alone materialized NULL for every security still awaiting its
+      -- handshake — exactly the pre-association state the design turns on.
+      COALESCE(
+        sec.source_graph_id,
+        e.metadata->>'source_graph_id'
+      )                               AS source_graph_id
     FROM postgres_scan('{c}', '{s}', 'securities') sec
     LEFT JOIN postgres_scan('{c}', '{s}', 'entities') e
       ON sec.entity_id = e.id

--- a/robosystems/routers/extensions/roboinvestor/operations.py
+++ b/robosystems/routers/extensions/roboinvestor/operations.py
@@ -159,6 +159,7 @@ create_portfolio_block_op = _registrar.register(
       SecurityNotFoundError: (404, lambda e: f"Security not found: {e}"),
       DuplicateActivePositionError: (409, str),
     },
+    mark_stale_reason="portfolio_block_created",
   )
 )
 
@@ -180,6 +181,7 @@ update_portfolio_block_op = _registrar.register(
       SecurityNotFoundError: (404, lambda e: f"Security not found: {e}"),
       DuplicateActivePositionError: (409, str),
     },
+    mark_stale_reason="portfolio_block_updated",
   )
 )
 
@@ -208,6 +210,7 @@ delete_portfolio_block_op = _registrar.register(
         ),
       ),
     },
+    mark_stale_reason="portfolio_block_deleted",
     requires_created_by=False,
   )
 )
@@ -229,6 +232,7 @@ create_security_op = _registrar.register(
     request_model=CreateSecurityRequest,
     result_type=SecurityResponse,
     error_map={EntityNotFoundError: (404, lambda _e: "Entity not found.")},
+    mark_stale_reason="security_created",
   )
 )
 
@@ -244,6 +248,7 @@ update_security_op = _registrar.register(
     request_model=UpdateSecurityOperation,
     result_type=SecurityResponse,
     error_map={SecurityMasterNotFoundError: (404, lambda _e: "Security not found.")},
+    mark_stale_reason="security_updated",
     requires_created_by=False,
   )
 )
@@ -260,6 +265,7 @@ delete_security_op = _registrar.register(
     request_model=DeleteSecurityOperation,
     result_type=DeleteResult,
     error_map={SecurityMasterNotFoundError: (404, lambda _e: "Security not found.")},
+    mark_stale_reason="security_deleted",
     requires_created_by=False,
   )
 )

--- a/robosystems/routers/extensions/roboledger/operations.py
+++ b/robosystems/routers/extensions/roboledger/operations.py
@@ -1012,6 +1012,7 @@ link_entity_taxonomy_op = _registrar.register(
       EntityNotFoundError: 404,
       TaxonomyMissingError: 404,
     },
+    mark_stale_reason="entity_taxonomy_linked",
     requires_created_by=False,
   )
 )
@@ -1045,6 +1046,7 @@ create_mapping_association_op = _registrar.register(
         lambda e: f"{e.side.capitalize()} element not found",  # type: ignore[attr-defined]
       ),
     },
+    mark_stale_reason="mapping_association_created",
   )
 )
 
@@ -1069,6 +1071,7 @@ delete_mapping_association_op = _registrar.register(
       AssociationNotFoundError: (404, lambda _e: "Association not found"),
       LibraryImmutableError: 403,
     },
+    mark_stale_reason="mapping_association_deleted",
   )
 )
 
@@ -1435,6 +1438,7 @@ create_agent_op = _registrar.register(
     request_model=CreateAgentRequest,
     result_type=LedgerAgentResponse,
     error_map={DuplicateExternalIdError: 409, ValueError: 422},
+    mark_stale_reason="agent_created",
   )
 )
 
@@ -1451,6 +1455,7 @@ update_agent_op = _registrar.register(
     request_model=UpdateAgentRequest,
     result_type=LedgerAgentResponse,
     error_map={AgentNotFoundError: 404, ValueError: 422},
+    mark_stale_reason="agent_updated",
   )
 )
 

--- a/robosystems/routers/graphs/main.py
+++ b/robosystems/routers/graphs/main.py
@@ -53,6 +53,23 @@ from robosystems.models.core import Graph, GraphUser, OrgLimits, OrgRole, OrgUse
 
 router = APIRouter(prefix="/v1/graphs", tags=["Graphs"])
 
+# Surfaced to prospects at graph-creation time, so these describe only what is
+# built. Both are read twice below — the schema-loading path and its fallback —
+# and single-sourcing them here is what keeps the two copies from diverging.
+_ROBOLEDGER_DESCRIPTION = (
+  "Complete accounting system with XBRL reporting and GL transactions. "
+  "Context-aware: SEC repositories get reporting-only tables, "
+  "entity graphs get full accounting capabilities."
+)
+
+_ROBOINVESTOR_DESCRIPTION = (
+  "Private-market portfolio tracking — positions with cost basis, holdings grouped "
+  "by company, and a securities registry covering preferred and common stock, LLC "
+  "units, LP interests, SAFEs, notes, warrants and options with their terms. Link a "
+  "holding to its issuer's graph and that company's reports publish straight into "
+  "yours, alongside public SEC filings."
+)
+
 
 def _create_error_response(
   error_code: str,
@@ -481,18 +498,10 @@ async def get_available_extensions(
             # which represents what entity graphs will get
             loader = get_contextual_schema_loader("application", "roboledger")
             # Override description with context-aware information
-            description = (
-              "Complete accounting system with XBRL reporting and GL transactions. "
-              "Context-aware: SEC repositories get reporting-only tables, "
-              "entity graphs get full accounting capabilities."
-            )
+            description = _ROBOLEDGER_DESCRIPTION
           elif ext_info["name"] == "roboinvestor":
             loader = get_schema_loader([ext_info["name"]])
-            description = (
-              "Investment portfolio management with securities tracking, trade execution, "
-              "and risk analysis. Includes market data, dividends, benchmarks, and "
-              "position-level performance monitoring."
-            )
+            description = _ROBOINVESTOR_DESCRIPTION
           else:
             loader = get_schema_loader([ext_info["name"]])
             description = ext_info["description"]  # Use original description
@@ -537,20 +546,12 @@ async def get_available_extensions(
       extensions=[
         AvailableExtension(
           name="roboledger",
-          description=(
-            "Complete accounting system with XBRL reporting and GL transactions. "
-            "Context-aware: SEC repositories get reporting-only tables, "
-            "entity graphs get full accounting capabilities."
-          ),
+          description=_ROBOLEDGER_DESCRIPTION,
           enabled=False,
         ),
         AvailableExtension(
           name="roboinvestor",
-          description=(
-            "Investment portfolio management with securities tracking, trade execution, "
-            "and risk analysis. Includes market data, dividends, benchmarks, and "
-            "position-level performance monitoring."
-          ),
+          description=_ROBOINVESTOR_DESCRIPTION,
           enabled=False,
         ),
       ],

--- a/tests/routers/extensions/test_graph_staleness_coverage.py
+++ b/tests/routers/extensions/test_graph_staleness_coverage.py
@@ -1,0 +1,124 @@
+"""Structural guard: every extensions write op that changes materialized
+content must mark its graph stale.
+
+The Dagster materialization sensor triggers purely on `Graph.graph_stale`, so
+an operation that writes OLTP rows without setting `mark_stale_reason` leaves
+those rows invisible to LadybugDB until something *else* marks the graph. The
+failure is silent in the worst way: the write succeeds, the API returns 200,
+and the graph simply answers as though the data were never there.
+
+RoboInvestor showed the defect in its pure form — zero of six operations
+declared the flag, so a graph whose only activity was RoboInvestor never
+materialized at all. RoboLedger showed the same class in a form that hides
+better: five operations wrote materialized tables without the flag, and got
+away with it because a QuickBooks sync or a period close usually marks the
+graph soon afterward. That makes delivery *incidental* rather than guaranteed,
+which is the same shape as a shared report that only lands if the recipient
+happens to have unrelated activity.
+
+Asserted over the registrars' real specs rather than a fixed list, so an
+operation added later is covered on the day it is written.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import robosystems.routers.extensions.roboinvestor.operations as _roboinvestor_ops
+import robosystems.routers.extensions.roboledger.operations as _roboledger_ops
+from robosystems.middleware.extensions import OperationRegistrar
+
+# Importing the two operations modules is what registers their specs on the
+# registrars; referenced here so neither import reads as unused and gets pruned.
+_SPEC_SOURCES = (_roboinvestor_ops.__name__, _roboledger_ops.__name__)
+
+# Operations that legitimately do not mark the graph stale, each with the
+# reason it is exempt. Every entry was verified against
+# `operations/extensions/materialize.py` — both the `TABLE_EXTENSIONS` map and
+# the per-table SELECT that would have to read the written rows.
+#
+# Adding a name here is a decision on the record, not a way to quiet the test:
+# state which table the operation writes and why the graph never reads it.
+_EXEMPT: dict[str, str] = {
+  "change-reporting-style": (
+    "Writes entities.reporting_style_id. The Entity SELECT does not carry that "
+    "column, so the Style changes render-time output rather than materialized "
+    "rows; statement Structures themselves are library-seeded and immutable."
+  ),
+  "evaluate-rules": (
+    "Writes verification_results, which has zero references in materialize.py "
+    "— there is no corresponding graph node."
+  ),
+  "create-event-handler": (
+    "Writes handler configuration; event_handlers has zero references in "
+    "materialize.py."
+  ),
+  "update-event-handler": (
+    "Writes handler configuration; event_handlers has zero references in "
+    "materialize.py."
+  ),
+  "preview-event-block": (
+    "Resolves handlers and returns the projected debits and credits. Writes "
+    "nothing at all."
+  ),
+}
+
+_EXTENSIONS = ("roboledger", "roboinvestor")
+
+
+def _specs():
+  pairs = []
+  for extension in _EXTENSIONS:
+    pairs.extend(
+      (extension, spec)
+      for _reg, spec in OperationRegistrar.specs_for_extension(extension)
+    )
+  return pairs
+
+
+@pytest.mark.unit
+class TestGraphStalenessCoverage:
+  def test_specs_are_registered(self) -> None:
+    """Guard the guard: if imports stop populating the registrars, every
+    assertion below passes vacuously."""
+    specs = _specs()
+    assert len(specs) >= 30, (
+      f"expected the full extensions operation surface, got {len(specs)} — "
+      f"import wiring or a feature flag changed (sources: {_SPEC_SOURCES})"
+    )
+
+  def test_every_write_op_marks_the_graph_stale(self) -> None:
+    missing = [
+      f"{extension}:{spec.name}"
+      for extension, spec in _specs()
+      if spec.mark_stale_reason is None and spec.name not in _EXEMPT
+    ]
+    assert not missing, (
+      "Operations that never mark the graph stale, so their writes never "
+      f"reach LadybugDB: {missing}. Either add mark_stale_reason, or add the "
+      "operation to _EXEMPT with the table it writes and why the graph "
+      "never reads it."
+    )
+
+  def test_exemptions_still_name_real_operations(self) -> None:
+    """A renamed or deleted operation must not leave a dead exemption behind:
+    a stale entry silently exempts nothing while reading as considered."""
+    registered = {spec.name for _extension, spec in _specs()}
+    orphaned = sorted(set(_EXEMPT) - registered)
+    assert not orphaned, (
+      f"_EXEMPT names operations that are no longer registered: {orphaned}. "
+      "Remove them, or correct the name if the operation was renamed."
+    )
+
+  def test_exemptions_have_not_been_overtaken(self) -> None:
+    """If an exempt operation later gains the flag, the exemption is wrong and
+    the reasoning recorded next to it is misleading."""
+    overtaken = sorted(
+      spec.name
+      for _extension, spec in _specs()
+      if spec.name in _EXEMPT and spec.mark_stale_reason is not None
+    )
+    assert not overtaken, (
+      f"These operations now declare mark_stale_reason: {overtaken}. Delete "
+      "their _EXEMPT entries — the recorded reason no longer holds."
+    )

--- a/tests/routers/graphs/test_graph.py
+++ b/tests/routers/graphs/test_graph.py
@@ -25,6 +25,8 @@ from robosystems.models.api.graphs.schema import (
 )
 from robosystems.models.core import OrgLimits
 from robosystems.routers.graphs.main import (
+  _ROBOINVESTOR_DESCRIPTION,
+  _ROBOLEDGER_DESCRIPTION,
   CreateGraphRequest,
   _create_error_response,
   _raise_http_exception,
@@ -462,15 +464,17 @@ class TestGetAvailableExtensions:
           assert "extensions" in data
           assert len(data["extensions"]) == 2  # Only available ones
 
-          # Check first extension
+          # Assert the curated descriptions verbatim, not keywords in them: the
+          # thing worth pinning is that each branch served its own copy rather
+          # than falling through to the module-docstring default. A substring
+          # match on prose breaks on any honest copy edit and proves less.
           ext1 = data["extensions"][0]
           assert ext1["name"] == "roboledger"
-          assert "accounting" in ext1["description"].lower()
+          assert ext1["description"] == _ROBOLEDGER_DESCRIPTION
 
-          # Check second extension
           ext2 = data["extensions"][1]
           assert ext2["name"] == "roboinvestor"
-          assert "investment" in ext2["description"].lower()
+          assert ext2["description"] == _ROBOINVESTOR_DESCRIPTION
 
   async def test_get_available_extensions_schema_manager_failure(
     self, async_client: AsyncClient


### PR DESCRIPTION
## Summary

Closes the RoboInvestor foundation gaps ahead of v1.8.0, and the audit turned the first one into a
platform-wide fix. The framing worth stating up front: **the analytical graph only rebuilds when a
graph is marked stale, so an operation that writes rows without marking its graph leaves them
invisible** — the write succeeds, the API returns 200, and the graph answers as though the data were
never there. That was true of every RoboInvestor operation and, less visibly, of five RoboLedger ones.

Also cuts a set of capability claims the extension catalog was making, and gives the README the two
things it never said: that this builds you a knowledge graph, and how the tenancy model works.

## Changes

**Writes that never reached the graph** (`routers/extensions/*/operations.py`)

- **RoboInvestor: 0 of 6 operations marked their graph stale**, against 16 in RoboLedger. A graph
  whose only activity was RoboInvestor never materialized — `Portfolio`, `Security`, `Position` and
  their four edge tables stayed empty, and the cross-graph path from a holding to its issuer's reports
  could not run. It hid because a dual-schema graph is marked by its QuickBooks sync or period close
  and materializes as a side effect, so the failure needs a portfolio-only graph to surface, and there
  is no RoboInvestor demo or DB-backed test that would produce one. All six now declare
  `mark_stale_reason`.
- **RoboLedger: five more, verified against the materialization SQL rather than inferred.**
  `create-agent` / `update-agent` (the `agents` table feeds the `Agent` node and `ENTITY_HAS_AGENT`),
  `create-mapping-association` / `delete-mapping-association` (`"mapping"` is in
  `_MATERIALIZED_ASSOCIATION_TYPES`), and `link-entity-taxonomy` (`entity_taxonomies` feeds
  `ENTITY_HAS_TAXONOMY`). A sync or a close usually marks the graph shortly after, which made delivery
  incidental rather than guaranteed — the same shape as a shared report that only lands if the
  recipient happens to have unrelated activity.
- **Five operations are correctly exempt, and are now recorded as such** rather than left as
  omissions. `change-reporting-style` writes `entities.reporting_style_id`, which the `Entity` SELECT
  does not carry, so a Style change alters render-time output and not materialized rows.
  `evaluate-rules` writes `verification_results` and the two event-handler ops write handler config;
  neither table appears anywhere in the materializer.

**`Security.source_graph_id` read from the wrong column** (`operations/extensions/materialize.py`)

Materialized from the linked entity's metadata rather than the security's own column, so a security
registered against an issuer it had not yet been linked to materialized with no attribution — exactly
the pre-link state the cross-graph design turns on. Now `COALESCE`s its own column first.

**A structural guard for the class** (`tests/routers/extensions/test_graph_staleness_coverage.py`)

Worth a close look, since it is the part that stops this recurring. It asserts over the registrars'
real specs rather than a fixed list, so an operation added later is covered the day it is written, and
it checks exemptions in **both** directions: an exemption naming an operation that no longer exists
fails, and so does one whose operation has since gained the flag. A dead exemption is worse than none,
because it reads as considered. All three failure directions were exercised by hand before commit.

**Extension catalog claims** (`routers/graphs/main.py`)

The available-extensions catalog — what a prospect reads when choosing schemas at graph creation —
advertised RoboInvestor as *"securities tracking, trade execution, and risk analysis. Includes market
data, dividends, benchmarks, and position-level performance monitoring."* Dividends exist nowhere in
the schema or models; trades, benchmarks and market data are graph node declarations with no OLTP
table, model or API; risk analysis and performance monitoring are not built. Four of the six are
listed as roadmap items in `roboinvestor-app`'s own README.

The replacement is drawn from what ships and from how the product is positioned in that app repo:
private-market portfolio tracking, positions with cost basis, holdings grouped by company, and a
securities registry for ownership instruments with their terms. That is also the sharper claim — the
old copy pointed at public-equity trading, which this is not, while `Security`'s own docstring
describes ownership in a private company. The false claims were making the product sound blander than
it is. Both descriptions were duplicated between the schema-loading path and its exception fallback
(four copies of two strings, which is how one stayed wrong); they are module constants now.

**README** (`README.md`)

Both prior "knowledge graph" mentions were about the SEC shared repository — someone else's public
dataset — while the customer's own graph was described as infrastructure the platform runs on. Both
app READMEs already lead with the framing this repo was missing. Multi-tenancy had the same problem in
a costlier place: the platform's most distinctive property, and what the delivery modes rest on,
appeared as the parenthetical "(schema-per-tenant)" twice plus a wiki link. Adds a **Multi-Tenancy &
Isolation** section built on the rule that governs the code — every isolation primitive keys on
`graph_id`, never on an organization.

Claims were verified rather than recalled: `databases_per_instance: 1` in all nine tier blocks of
`graph.yml`, and `tests/db/test_extensions_isolation.py` really is structural (runs the real
`extensions_session`, asserts the reset on return *and* on error).

**v1.8.0 release notes** (`.github/release-notes/v1.8.0.md`)

Two sections for the above, plus a removal the notes had missed: the API-call fields are gone from the
org usage summary, and that section exists precisely to name generated-tier removals a pinned
integrator sees nowhere else.

## Breaking Changes

**None.** No model, GraphQL, migration, or REST shape changes — `git diff` over `robosystems/models/`,
`robosystems/graphql/` and `migrations/` is empty. `mark_stale_reason` is server-side behavior and the
materializer SQL is internal.

No SDK coordination needed on either tier. The one externally visible difference is the *value* of
`AvailableExtension.description`, whose field and type are unchanged — a response-content correction,
not a contract change. The API-surface removals named in the release notes came from earlier PRs in
this series and are already reflected in the published 1.7.0 clients.

## Testing

`just test-all` was **not** run in full this session — deliberately, to let GHA run it. What was run
locally, all green:

- `just test-code` — clean (ruff + format + basedpyright + cf-lint), 0 errors / 0 warnings
- `just test routers/extensions` — 83 passed
- `just test operations/extensions` — 136 passed
- `just test routers/graphs` — 746 passed, 5 skipped
- `just test operations/roboinvestor` — 42 passed
- `just test operations/roboledger` — 804 passed
- `just test middleware` — 2131 passed, 93 deselected

The new guard was verified to actually fail, not just pass, in all three directions: removing a flag
names the offending operation; a bogus exemption on a flagged operation fails; an exemption naming a
nonexistent operation fails. The two touched tests in `test_graph.py` were changed from a substring
match on marketing prose to asserting the description constants verbatim, which checks the thing the
substring was standing in for (that each branch served its own copy rather than falling through to the
module-docstring default) without breaking on the next copy edit.
