### PR TITLE
feat(examples): RoboInvestor end-to-end demo, and the three defects it found

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -2,8 +2,9 @@
 
 Runnable demos that load real and synthetic data into RoboSystems and query it
 back. Each one is a working reference for a different slice of the platform:
-double-entry accounting on a graph, SEC XBRL filings, a custom domain schema,
-and cross-taxonomy financial reporting.
+double-entry accounting on a graph, a venture portfolio with a cross-graph
+report share, SEC XBRL filings, a custom domain schema, and cross-taxonomy
+financial reporting.
 
 ## Prerequisites
 
@@ -24,6 +25,7 @@ just demo
 
 # Or pick one
 just demo-roboledger
+just demo-roboinvestor
 just demo-custom-graph
 just demo-sec --ticker NVDA --year 2025
 ```
@@ -113,6 +115,41 @@ Three things differ off-local, all deliberate:
 - **The graph must already exist.** Provision it the way a customer would
   (checkout, or `POST /v1/graphs` with a payment method on file) and pass its
   id; the runner will not create one on a deployed environment.
+
+### RoboInvestor — a venture portfolio, and a report that crosses graphs
+
+`examples/roboinvestor_demo/` · [walkthrough](roboinvestor_demo/README.md)
+
+The investment side, and the only demo that spans two tenants. Meridian
+Ventures Fund I holds five private instruments — a Series A preferred, a
+bridge warrant, a post-money SAFE, LLC units, and a seed position that
+gets disposed mid-run. Two of them are issued by Cadence Labs, which keeps
+its books on this platform, so the fund declares the relationship with
+`source_graph_id` before any link exists.
+
+Cadence then shares its filed annual report into the fund's graph. That
+share creates a linked entity, resolves both pre-associated securities,
+and makes one query possible:
+
+```
+Portfolio → Position → Security → Entity → Report → Fact
+```
+
+A private holding joined to its issuer's reported financials — the thing
+a single-tenant product cannot offer.
+
+```bash
+just demo-roboinvestor                  # provisions both graphs, runs everything
+just demo-roboinvestor --skip-share     # portfolio surface only, no handshake
+just demo-roboinvestor --revoke         # also withdraw the share at the end
+just demo-roboinvestor --dry-run        # preview the portfolio, write nothing
+```
+
+The issuer is the `saas_startup` scenario, provisioned inline on the first
+run and reused afterwards. The run ends with a hard validation pass and
+exits non-zero if any invariant fails — including that every RoboInvestor
+write marked its graph stale, which is the check that materialization
+depends on.
 
 ### SEC — public company financial data
 

--- a/examples/_scenario/reset.py
+++ b/examples/_scenario/reset.py
@@ -66,6 +66,10 @@ def reset_demo_state(graph_id: str) -> None:
     session.execute(text("DELETE FROM event_dimensions"))
     session.execute(text("DELETE FROM events"))
     session.execute(text("DELETE FROM agents"))
+    # fact_dimensions.dimension_id is ON DELETE RESTRICT, and facts are not
+    # wiped until further down — so the dimensions delete below fails on any
+    # graph whose forecast ran (scenario facts carry a `scenario` Dimension).
+    session.execute(text("DELETE FROM fact_dimensions"))
     session.execute(text("DELETE FROM dimensions"))
 
     # 4. Tenant-origin associations. The library's immutability triggers

--- a/examples/_scenario/runner.py
+++ b/examples/_scenario/runner.py
@@ -670,12 +670,12 @@ def create_mappings(
   offset = 0
   while True:
     page = client.list_elements(graph_id, source="rs-gaap", limit=1000, offset=offset)
-    items = (page or {}).get("elements", [])
+    items = page.elements if page else []
     if not items:
       break
     for e in items:
-      if e.get("qname"):
-        rs_gaap_by_qname[e["qname"]] = e["id"]
+      if e.qname:
+        rs_gaap_by_qname[e.qname] = e.id
     if len(items) < 1000:
       break
     offset += 1000
@@ -731,7 +731,7 @@ def create_disclosure_notes(
 
   taxonomies = client.list_taxonomies(graph_id, taxonomy_type="reporting_standard")
   rs_gaap = next(
-    (t for t in taxonomies if (t.get("standard") or "").startswith("rs-gaap")), None
+    (t for t in taxonomies if (t.standard or "").startswith("rs-gaap")), None
   )
   if rs_gaap is None:
     print("  ERROR: rs-gaap reporting standard not found in graph")
@@ -955,7 +955,7 @@ def create_text_block_notes(
 
   taxonomies = client.list_taxonomies(graph_id, taxonomy_type="reporting_standard")
   rs_gaap = next(
-    (t for t in taxonomies if (t.get("standard") or "").startswith("rs-gaap")), None
+    (t for t in taxonomies if (t.standard or "").startswith("rs-gaap")), None
   )
   if rs_gaap is None:
     print("  ERROR: rs-gaap reporting standard not found in graph")
@@ -1058,28 +1058,26 @@ def verify_disclosure_notes(graph_id: str) -> None:
     print("  WARNING: no disclosure notes rendered")
     return
   for block in blocks:
-    # parse_information_blocks snake_cases every key.
-    name = block.get("name") or block.get("display_name") or block.get("id")
-    facts = block.get("facts") or []
-    summary = block.get("verification_summary") or {}
-    rendering = (block.get("view") or {}).get("rendering") or {}
-    rows = rendering.get("rows") or []
+    name = block.name or block.display_name or block.id
+    facts = block.facts or []
+    summary = block.verification_summary
+    rendering = block.view.rendering if block.view else None
+    rows = (rendering.rows if rendering else None) or []
     print(f"  {name}: {len(facts)} facts, {len(rows)} rendered rows")
     for row in rows:
-      text_value = row.get("text_value")
-      if text_value:
+      if row.text_value:
         # Text-block row — show the narrative head, not a numeric column.
-        head = " ".join(str(text_value).split())[:100]
-        print(f"      {row.get('element_name')}: “{head}…”")
+        head = " ".join(str(row.text_value).split())[:100]
+        print(f"      {row.element_name}: “{head}…”")
         continue
-      values = row.get("values") or []
+      values = row.values or []
       latest = values[-1] if values else None
-      marker = "Σ" if row.get("is_subtotal") else " "
+      marker = "Σ" if row.is_subtotal else " "
       # Report fact values are natural-signed dollars (not cents).
       amount = f"${latest:,.2f}" if isinstance(latest, (int, float)) else "—"
-      print(f"    {marker} {row.get('element_name')}: {amount}")
-    passed = summary.get("passed", 0)
-    total = summary.get("total", 0)
+      print(f"    {marker} {row.element_name}: {amount}")
+    passed = summary.passed if summary else 0
+    total = summary.total if summary else 0
     if total:
       print(f"    Verification: {passed}/{total} rules passed")
 
@@ -1163,11 +1161,9 @@ def verify_metrics(
     return
   # Pick the library-seeded catalog by name — tenant-authored metric
   # blocks (create_custom_metrics) share the block_type.
-  block = next(
-    (b for b in blocks if b.get("name") == "Key Financial Metrics"), blocks[0]
-  )
-  structure_id = block.get("id")
-  print(f"  Metric block: {block.get('name')} ({structure_id})")
+  block = next((b for b in blocks if b.name == "Key Financial Metrics"), blocks[0])
+  structure_id = block.id
+  print(f"  Metric block: {block.name} ({structure_id})")
 
   windows = _metric_period_windows(scenario, period_windows)
   if not windows:
@@ -1195,20 +1191,20 @@ def verify_metrics(
   # Re-read the block — the standing sets are now the rendered series.
   blocks = client.list_information_blocks(graph_id, block_type="metric")
   block = next(
-    (b for b in blocks if b.get("name") == "Key Financial Metrics"),
+    (b for b in blocks if b.name == "Key Financial Metrics"),
     blocks[0] if blocks else None,
   )
-  rendering = ((block.get("view") or {}).get("rendering") or {}) if block else {}
-  periods = rendering.get("periods") or []
-  rows = rendering.get("rows") or []
+  rendering = block.view.rendering if block and block.view else None
+  periods = (rendering.periods if rendering else None) or []
+  rows = (rendering.rows if rendering else None) or []
   print(f"  Time series: {len(periods)} period(s), {len(rows)} metric row(s)")
   current_ratio = next(
-    (r for r in rows if r.get("element_qname") == "rs-metric:CurrentRatio"), None
+    (r for r in rows if r.element_qname == "rs-metric:CurrentRatio"), None
   )
   if current_ratio is None:
     print("  WARNING: Current Ratio row missing from the rendering")
     return
-  values = current_ratio.get("values") or []
+  values = current_ratio.values or []
   print(f"    Current Ratio series: {values}")
   numeric = [v for v in values if isinstance(v, (int, float))]
   if len(periods) >= len(windows) and len(numeric) >= len(windows):
@@ -1244,7 +1240,7 @@ def create_custom_metrics(graph_id: str, catalogs: list[dict]) -> list[dict]:
 
   taxonomies = client.list_taxonomies(graph_id, taxonomy_type="reporting_standard")
   rs_gaap = next(
-    (t for t in taxonomies if (t.get("standard") or "").startswith("rs-gaap")), None
+    (t for t in taxonomies if (t.standard or "").startswith("rs-gaap")), None
   )
   if rs_gaap is None:
     print("  ERROR: rs-gaap reporting standard not found in graph")
@@ -1339,7 +1335,7 @@ def create_custom_metrics(graph_id: str, catalogs: list[dict]) -> list[dict]:
       continue
 
     structures = client.list_structures(graph_id, block_type="metric")
-    structure = next((s for s in structures if s.get("name") == struct_name), None)
+    structure = next((s for s in structures if s.name == struct_name), None)
     if structure is None:
       print(f"  ERROR: metric structure {struct_name!r} not found after create")
       continue
@@ -1436,9 +1432,9 @@ def _statement_block_id(graph_id: str, block_type: str) -> str | None:
   client = _get_ledger_client()
   blocks = client.list_information_blocks(graph_id, block_type=block_type)
   for block in blocks:
-    if block.get("facts"):
-      return block.get("id")
-  return blocks[0].get("id") if blocks else None
+    if block.facts:
+      return block.id
+  return blocks[0].id if blocks else None
 
 
 def run_forecast_scenario(
@@ -1635,12 +1631,12 @@ def run_forecast_scenario(
   client = _get_ledger_client()
   blocks = client.list_information_blocks(graph_id, block_type="metric")
   metric_block = next(
-    (b for b in blocks if b.get("name") == "Key Financial Metrics"),
+    (b for b in blocks if b.name == "Key Financial Metrics"),
     blocks[0] if blocks else None,
   )
   if metric_block is None:
     return scenario_id
-  metric_id = metric_block.get("id")
+  metric_id = metric_block.id
   actual_rendering = _graphql_rendering(graph_id, metric_id, headers)
   actual_periods = len(actual_rendering.get("periods") or [])
 
@@ -2151,24 +2147,18 @@ def generate_annual_report(
   # Pull the package to confirm it rehydrates
   package = client.get_report_package(graph_id, report_id)
   if package:
-    items = package.get("items", []) or []
+    items = package.items or []
     # `block_type` lives nested at item.block.block_type on the
     # rehydrated InformationBlockEnvelope, not on the item itself.
-    block_names = [
-      (i.get("block") or {}).get("name")
-      or (i.get("block") or {}).get("block_type")
-      or "?"
-      for i in items
-    ]
+    block_names = [i.block.name or i.block.block_type or "?" for i in items]
     print(f"  Package:      {len(items)} block(s) — {', '.join(block_names)}")
 
     # Fact provenance — every FactSet records how its facts were
     # constructed (the auditability spine). Surfaced via the SDK on
-    # block.fact_set.provenance; report blocks pivot from the posted ledger.
+    # block.fact_set.provenance; report blocks pivot from the posted
+    # ledger. `provenance` is a JSON scalar, so it stays a dict.
     origins = [
-      (((i.get("block") or {}).get("fact_set") or {}).get("provenance") or {}).get(
-        "origin"
-      )
+      ((i.block.fact_set.provenance or {}).get("origin") if i.block.fact_set else None)
       for i in items
     ]
     if origins and all(origins):

--- a/examples/roboinvestor_demo/README.md
+++ b/examples/roboinvestor_demo/README.md
@@ -1,0 +1,125 @@
+# RoboInvestor Demo — Meridian Ventures Fund I
+
+The first demo that exercises the RoboInvestor surface, and the first that
+crosses a graph boundary.
+
+```bash
+just start                  # local stack
+just demo-user              # credentials → .local/config.json
+just demo-roboinvestor      # provisions both graphs and runs everything
+```
+
+The run ends with a validation pass and exits non-zero if any invariant
+fails, so it works as a pre-release gate as well as a walkthrough.
+
+## What it builds
+
+Two tenants, because the interesting part needs two:
+
+| Graph | Who | Extensions | Role |
+| --- | --- | --- | --- |
+| Issuer | Cadence Labs, Inc. | `roboledger` | A seed-funded B2B SaaS company that keeps its books here and files an annual report |
+| Investor | Meridian Ventures Fund I, LP | `roboinvestor`, `roboledger` | An early-stage venture fund holding five private instruments |
+
+The issuer is the existing `saas_startup` showcase scenario, provisioned
+inline on the first run and reused afterwards. Both graphs belong to the
+same user and org — the boundary being crossed is the **graph** boundary,
+which is where report-sharing authorization actually lives.
+
+The fund holds private-company ownership, not listed tickers: a Series A
+preferred, a bridge warrant, a post-money SAFE, LLC units, and a seed
+position that gets disposed mid-run. Two of them — the Cadence
+instruments — name an issuer that is also a tenant here.
+
+## The arc
+
+**1 · Pre-association.** The Cadence securities are registered with
+`source_graph_id` and no `entity_id`. That is declared intent before any
+link exists, and it is a first-class state: `holdings` reports the issuer
+as unlinked rather than erroring.
+
+**2 · The Portfolio Block is the write surface.** `create-portfolio-block`
+validates the portfolio and its positions whole and writes them in one
+transaction. `update-portfolio-block` then applies `add` / `update` /
+`dispose` deltas in a single atomic call — two new positions, a 409A
+re-mark, and an exit. Positions are never mutated as standalone atoms.
+Deleting a portfolio that still holds active positions is refused with a
+409 unless `confirm_active_positions` is set.
+
+**3 · Every write marks its graph stale.** Read back through the graph
+health endpoint before any materialization. Materialization is
+sensor-driven on that flag alone; RoboInvestor shipped with zero of its
+six operations setting it, which kept the entire domain out of LadybugDB.
+The check asserts both that the graph is stale *and* that the reason came
+from a RoboInvestor operation — a graph that also keeps books would
+otherwise be marked by its ledger writes and mask the defect.
+
+**4 · The handshake.** Cadence creates a publish list, adds the fund's
+graph, and shares its filed report. Each share is an independent copy: the
+report row, a cross-graph fact set, and every fact land in the fund's own
+schema. The share also creates a linked `Entity` for Cadence in the fund's
+graph and resolves **every** security that pre-associated to it — both
+instruments, from one share.
+
+**5 · The traversal.** After materialization, one Cypher query walks the
+whole chain:
+
+```
+Portfolio → Position → Security → Entity → Report → Fact
+```
+
+A private holding joined to its issuer's reported financials, in one
+query. Because SEC filings are a shared repository on the same platform, a
+private position and public-company facts sit in the same query surface —
+which is the thing that has no equivalent outside this platform.
+
+**6 · Revocation** (`--revoke`, opt-in). The sender withdraws the copy.
+The report leaves the fund's schema; the linked entity and the securities
+pointing at it stay. A declared holding is a relationship, not an artifact
+of one filing.
+
+## Flags
+
+```bash
+just demo-roboinvestor                  # everything
+just demo-roboinvestor <graph_id>       # reuse a specific investor graph
+just demo-roboinvestor --issuer <id>    # use a specific issuer graph
+just demo-roboinvestor --reload-issuer  # rebuild the issuer's ledger first
+just demo-roboinvestor --skip-share     # portfolio surface only, no handshake
+just demo-roboinvestor --revoke         # also withdraw the share at the end
+just demo-roboinvestor --dry-run        # preview the portfolio, write nothing
+```
+
+Offline preview of the portfolio arc, no platform needed:
+
+```bash
+uv run python -m examples.roboinvestor_demo.data
+```
+
+## Why the investor graph carries `roboledger`
+
+`add-publish-list-members` rejects any target graph whose
+`schema_extensions` doesn't list `roboledger`. A fund keeps no books, so
+that predicate really wants to be "target can receive reports" — until it
+is, a graph that only wants to *receive* reporting has to declare the
+ledger extension it will never write to. The demo provisions both rather
+than working around it, so the constraint stays visible.
+
+## Re-runs
+
+`_reset.py` wipes the fund's portfolios, securities, positions, anything
+the handshake delivered, and the issuer's publish lists — the only
+direct-DB step in the demo, and deliberately not a product operation.
+Everything else goes through the HTTP API via the SDK facades, the same
+surface the frontends and MCP tools use.
+
+Graph ids are cached in `.local/config.json` under the `roboinvestor_demo`
+and `saas_startup` slots, so re-runs reuse both graphs.
+
+## Related
+
+- `ref/roboinvestor.md` — the domain model, the maturity ground truth, and
+  the invariants this demo asserts
+- `ref/extensions.md` — the platform contract: tenancy, the operation
+  envelope, the staleness rule, and the cross-graph seam
+- [`examples/saas_startup_demo/`](../saas_startup_demo/) — the issuer

--- a/examples/roboinvestor_demo/_reset.py
+++ b/examples/roboinvestor_demo/_reset.py
@@ -65,6 +65,16 @@ def reset_investor_state(graph_id: str) -> None:
     )
     session.execute(text("DELETE FROM reports WHERE source_graph_id IS NOT NULL"))
 
+    # The concepts the share carried in. These have to go for the re-run to
+    # exercise the copy at all — left in place, `_ensure_shared_elements`
+    # finds them present and returns, and the run silently stops testing
+    # the path it exists to test. Elements before taxonomies (FK), and both
+    # only after the facts citing them are gone (above).
+    session.execute(text("DELETE FROM elements WHERE source = 'linked'"))
+    session.execute(
+      text("DELETE FROM taxonomies WHERE metadata->>'source_graph_id' IS NOT NULL")
+    )
+
     # Linked entities are the handshake's other product. Deleting them is
     # safe only because the securities that pointed at them are already
     # gone (above). The parent entity has source != 'linked' and stays.

--- a/examples/roboinvestor_demo/_reset.py
+++ b/examples/roboinvestor_demo/_reset.py
@@ -1,0 +1,96 @@
+"""Demo-only reset logic for roboinvestor_demo.
+
+Not a production operation, and the only place in this demo that touches
+PostgreSQL directly instead of going through the HTTP API. Wiping a tenant
+back to a clean slate is a demo convenience, not something a customer
+should be able to do, so it deliberately has no API surface.
+
+The reset spans **two** tenant schemas, because the demo's subject spans
+two graphs:
+
+- the investor's schema, where portfolios / securities / positions live
+  along with anything the handshake delivered (the shared report copy, its
+  facts, and the linked ``Entity``);
+- the issuer's schema, where the publish list and the outbound share record
+  live.
+
+Real withdrawals never take this path — a sender revokes with
+``revoke-report-share``, which deletes the recipient's copy and stamps the
+share record. The demo exercises that operation too; this module exists
+only so a re-run starts from a known-empty state rather than accumulating
+duplicate portfolios.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import text
+
+
+def reset_investor_state(graph_id: str) -> None:
+  """Wipe the investor graph's demo state, preserving the fund entity.
+
+  Removes, in FK order: positions, portfolios, securities, every report
+  that arrived from another graph (with its fact sets and facts), and the
+  linked entities the handshake created. The graph's own parent entity and
+  its library-seeded taxonomy survive, so the graph never needs
+  re-provisioning between runs.
+  """
+  from robosystems.db.extensions import extensions_session
+
+  with extensions_session(graph_id) as session:
+    # Positions FK both portfolios and securities, so they go first.
+    session.execute(text("DELETE FROM positions"))
+    session.execute(text("DELETE FROM portfolios"))
+    session.execute(text("DELETE FROM securities"))
+
+    # Shared-in reports and their facts. `source_graph_id IS NOT NULL` is
+    # exactly the set that arrived from elsewhere — a report the investor
+    # authored has a null source graph. Facts hang off fact_sets, which
+    # hang off the report.
+    session.execute(
+      text("""
+        DELETE FROM facts WHERE fact_set_id IN (
+          SELECT fs.id FROM fact_sets fs
+          JOIN reports r ON r.id = fs.report_id
+          WHERE r.source_graph_id IS NOT NULL
+        )
+      """)
+    )
+    session.execute(
+      text("""
+        DELETE FROM fact_sets WHERE report_id IN (
+          SELECT id FROM reports WHERE source_graph_id IS NOT NULL
+        )
+      """)
+    )
+    session.execute(text("DELETE FROM reports WHERE source_graph_id IS NOT NULL"))
+
+    # Linked entities are the handshake's other product. Deleting them is
+    # safe only because the securities that pointed at them are already
+    # gone (above). The parent entity has source != 'linked' and stays.
+    session.execute(text("DELETE FROM entities WHERE source = 'linked'"))
+
+    # A blocked sender would make the share fail with a per-target error
+    # rather than a hard failure, which reads as a mysterious demo bug. A
+    # previous run's block-source-graph experiment must not leak forward.
+    session.execute(text("DELETE FROM blocked_source_graphs"))
+
+    session.flush()
+
+
+def reset_issuer_share_state(graph_id: str) -> None:
+  """Drop the issuer graph's publish lists and outbound share records.
+
+  Scoped to the sender's own bookkeeping — the recipient's copy is removed
+  by :func:`reset_investor_state`. Deleting every list rather than only
+  the demo's is deliberate: the scenario demos that build this graph never
+  create publish lists, so anything here came from a prior run of *this*
+  demo.
+  """
+  from robosystems.db.extensions import extensions_session
+
+  with extensions_session(graph_id) as session:
+    session.execute(text("DELETE FROM report_shares"))
+    session.execute(text("DELETE FROM publish_list_members"))
+    session.execute(text("DELETE FROM publish_lists"))
+    session.flush()

--- a/examples/roboinvestor_demo/data.py
+++ b/examples/roboinvestor_demo/data.py
@@ -1,0 +1,305 @@
+"""Meridian Ventures Fund I — the synthetic venture portfolio.
+
+The fund is an early-stage venture investor, which is the positioning
+RoboInvestor actually models: ``Security`` is *ownership in a private
+company* — preferred stock, SAFEs, LLC units, warrants — not a brokerage
+position in a listed ticker. Every holding here is a private instrument
+with terms, and none of them has a market price.
+
+One holding is different in kind, and it is the whole point of the demo:
+**Cadence Labs is another tenant on this platform.** The fund declares
+that relationship with ``source_graph_id`` before any link exists (a
+*pre-association*), and the link resolves when Cadence shares a published
+report into the fund's graph. The other three holdings stay unlinked
+forever, which is the ordinary case and the control group.
+
+Dates are relative to today so the demo stays evergreen. Money is integer
+cents everywhere, matching the storage contract.
+
+Run ``uv run python -m examples.roboinvestor_demo.data`` for an offline
+preview of the portfolio without the platform running.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date, timedelta
+
+FUND_NAME = "Meridian Ventures Fund I, LP"
+FUND_URI = "https://meridianventures.example.com"
+FUND_TICKER = "MVF1"
+PORTFOLIO_NAME = "Fund I — Core Positions"
+PORTFOLIO_STRATEGY = "early_stage_venture"
+
+
+def _today() -> date:
+  return date.today()
+
+
+def _months_ago(months: int) -> date:
+  """Approximate month arithmetic — good enough for synthetic dates."""
+  d = _today() - timedelta(days=months * 30)
+  return d
+
+
+@dataclass(frozen=True)
+class SecuritySpec:
+  """One private instrument the fund owns.
+
+  ``links_to_issuer`` marks the holding whose issuer keeps its books on
+  this platform. That security is created with ``source_graph_id`` set to
+  the issuer's graph and no ``entity_id`` — the pre-association state the
+  handshake resolves.
+  """
+
+  key: str
+  name: str
+  security_type: str
+  security_subtype: str | None = None
+  terms: dict = field(default_factory=dict)
+  authorized_shares: int | None = None
+  outstanding_shares: int | None = None
+  links_to_issuer: bool = False
+
+
+@dataclass(frozen=True)
+class PositionSpec:
+  """One lot held in the portfolio, in the fund's base currency."""
+
+  security_key: str
+  quantity: float
+  quantity_type: str
+  cost_basis: int
+  acquisition_months_ago: int
+  current_value: int | None = None
+  valuation_source: str | None = None
+  notes: str | None = None
+
+
+# ── Securities ────────────────────────────────────────────────────────────
+#
+# Two of these carry `links_to_issuer=True` and both name the same issuer
+# graph. That is deliberate: `_ensure_linked_entity` updates *every*
+# security matching the source graph in one statement, so a single share
+# must resolve both. One security would not have proven that.
+
+SECURITIES: list[SecuritySpec] = [
+  SecuritySpec(
+    key="cadence_series_a",
+    name="Cadence Labs, Inc. — Series A Preferred",
+    security_type="preferred_stock",
+    security_subtype="series_a",
+    terms={
+      "liquidation_preference": "1x_non_participating",
+      "price_per_share_cents": 312,
+      "pre_money_valuation_cents": 18_000_000_00,
+      "board_seats": 1,
+      "pro_rata_rights": True,
+    },
+    authorized_shares=4_000_000,
+    outstanding_shares=3_205_128,
+    links_to_issuer=True,
+  ),
+  SecuritySpec(
+    key="cadence_warrant",
+    name="Cadence Labs, Inc. — Bridge Warrant",
+    security_type="warrant",
+    security_subtype="bridge_2026",
+    terms={
+      "strike_price_cents": 1,
+      "shares_underlying": 120_000,
+      "expiration_years": 10,
+      "coverage_pct": 15,
+    },
+    links_to_issuer=True,
+  ),
+  SecuritySpec(
+    key="halyard_safe",
+    name="Halyard Robotics, Inc. — SAFE (post-money)",
+    security_type="safe",
+    security_subtype="post_money_cap_no_discount",
+    terms={
+      "principal_cents": 750_000_00,
+      "valuation_cap_cents": 12_000_000_00,
+      "discount_pct": 0,
+      "mfn": True,
+    },
+  ),
+  SecuritySpec(
+    key="thornbury_units",
+    name="Thornbury Materials LLC — Class A Units",
+    security_type="llc_unit",
+    security_subtype="class_a",
+    terms={
+      "profit_share_pct": 8.5,
+      "tax_distributions": True,
+      "transfer_restriction": "right_of_first_refusal",
+    },
+    authorized_shares=2_000_000,
+    outstanding_shares=1_400_000,
+  ),
+  SecuritySpec(
+    key="aldergrove_seed",
+    name="Alder Grove Bio, Inc. — Series Seed Preferred",
+    security_type="preferred_stock",
+    security_subtype="series_seed",
+    terms={
+      "liquidation_preference": "1x_non_participating",
+      "price_per_share_cents": 89,
+      "pre_money_valuation_cents": 6_000_000_00,
+    },
+    authorized_shares=1_500_000,
+    outstanding_shares=1_123_595,
+  ),
+]
+
+
+# ── Initial positions (the create-portfolio-block envelope) ───────────────
+
+INITIAL_POSITIONS: list[PositionSpec] = [
+  PositionSpec(
+    security_key="cadence_series_a",
+    quantity=3_205_128,
+    quantity_type="shares",
+    cost_basis=10_000_000_00,
+    acquisition_months_ago=14,
+    current_value=14_500_000_00,
+    valuation_source="409a_valuation",
+    notes="Led the Series A; 1 board seat, pro-rata reserved for Series B.",
+  ),
+  PositionSpec(
+    security_key="halyard_safe",
+    quantity=750_000_00,
+    quantity_type="principal",
+    cost_basis=750_000_00,
+    acquisition_months_ago=9,
+    current_value=750_000_00,
+    valuation_source="cost",
+    notes="Post-money SAFE, converts at the next priced round.",
+  ),
+  PositionSpec(
+    security_key="aldergrove_seed",
+    quantity=1_123_595,
+    quantity_type="shares",
+    cost_basis=1_000_000_00,
+    acquisition_months_ago=22,
+    current_value=1_000_000_00,
+    valuation_source="cost",
+    notes="Seed position — company later acquired for stock.",
+  ),
+]
+
+
+# ── Deltas (the update-portfolio-block envelope) ──────────────────────────
+#
+# One of each kind, applied in a single atomic call:
+#   add     — the bridge warrant taken alongside the Series A, and a new
+#             LLC position from a later close
+#   update  — a fresh mark on the Cadence position (a 409A refresh)
+#   dispose — Alder Grove exits via acquisition
+
+ADDED_POSITIONS: list[PositionSpec] = [
+  PositionSpec(
+    security_key="cadence_warrant",
+    quantity=120_000,
+    quantity_type="shares",
+    cost_basis=0,
+    acquisition_months_ago=6,
+    current_value=54_000_00,
+    valuation_source="black_scholes_internal",
+    notes="Warrant coverage on the bridge note; nominal strike.",
+  ),
+  PositionSpec(
+    security_key="thornbury_units",
+    quantity=140_000,
+    quantity_type="units",
+    cost_basis=2_100_000_00,
+    acquisition_months_ago=4,
+    current_value=2_100_000_00,
+    valuation_source="cost",
+    notes="Growth-equity unit purchase; 8.5% profit share.",
+  ),
+]
+
+# The re-mark applied to the Cadence Series A position: a 409A refresh
+# after the company's annual report lands. Cents, like everything else.
+CADENCE_REMARK_VALUE = 17_800_000_00
+CADENCE_REMARK_SOURCE = "409a_valuation_refresh"
+
+DISPOSED_REASON = "Acquired by Northwind Therapeutics — stock-for-stock merger"
+
+
+def acquisition_date(spec: PositionSpec) -> date:
+  return _months_ago(spec.acquisition_months_ago)
+
+
+def inception_date() -> date:
+  return _months_ago(26)
+
+
+def valuation_date() -> date:
+  """The as-of date every mark in this demo shares."""
+  return _months_ago(1)
+
+
+def security_by_key(key: str) -> SecuritySpec:
+  for spec in SECURITIES:
+    if spec.key == key:
+      return spec
+  raise KeyError(f"Unknown security key: {key}")
+
+
+def issuer_linked_keys() -> list[str]:
+  """Keys of the securities that pre-associate to the issuer graph."""
+  return [s.key for s in SECURITIES if s.links_to_issuer]
+
+
+def _preview() -> None:
+  """Offline preview — the portfolio arc without the platform running."""
+  print(f"\n{FUND_NAME}")
+  print("=" * 68)
+  print(f"  Portfolio:  {PORTFOLIO_NAME}")
+  print(f"  Strategy:   {PORTFOLIO_STRATEGY}")
+  print(f"  Inception:  {inception_date()}")
+
+  print(f"\n  Securities ({len(SECURITIES)}):")
+  for spec in SECURITIES:
+    link = "  ← platform-native issuer" if spec.links_to_issuer else ""
+    subtype = f"/{spec.security_subtype}" if spec.security_subtype else ""
+    print(f"    {spec.name}")
+    print(f"      {spec.security_type}{subtype}{link}")
+
+  opening = sum(p.cost_basis for p in INITIAL_POSITIONS)
+  print(f"\n  Opening block ({len(INITIAL_POSITIONS)} positions):")
+  for pos in INITIAL_POSITIONS:
+    spec = security_by_key(pos.security_key)
+    print(
+      f"    {spec.name[:44]:<44} "
+      f"{pos.quantity:>12,.0f} {pos.quantity_type:<9} "
+      f"${pos.cost_basis / 100:>14,.2f}"
+    )
+  print(f"    {'':<44} {'':>12} {'cost basis':<9} ${opening / 100:>14,.2f}")
+
+  added = sum(p.cost_basis for p in ADDED_POSITIONS)
+  print(f"\n  Deltas (one atomic update-portfolio-block call):")
+  for pos in ADDED_POSITIONS:
+    spec = security_by_key(pos.security_key)
+    print(f"    add      {spec.name[:52]:<52} ${pos.cost_basis / 100:>14,.2f}")
+  print(
+    f"    update   {'Cadence Labs Series A — 409A refresh':<52} "
+    f"${CADENCE_REMARK_VALUE / 100:>14,.2f}"
+  )
+  print(f"    dispose  {'Alder Grove Bio Series Seed':<52} {DISPOSED_REASON}")
+
+  disposed = sum(
+    p.cost_basis for p in INITIAL_POSITIONS if p.security_key == "aldergrove_seed"
+  )
+  print(f"\n  Ending cost basis: ${(opening + added - disposed) / 100:,.2f}")
+  print(
+    f"  Active positions:  "
+    f"{len(INITIAL_POSITIONS) + len(ADDED_POSITIONS) - 1}\n"
+  )
+
+
+if __name__ == "__main__":
+  _preview()

--- a/examples/roboinvestor_demo/main.py
+++ b/examples/roboinvestor_demo/main.py
@@ -1,0 +1,956 @@
+#!/usr/bin/env python3
+"""Meridian Ventures Fund I — RoboInvestor end-to-end demo.
+
+The first demo that exercises the RoboInvestor surface, and the first that
+crosses a graph boundary. It builds a venture fund's private-markets
+portfolio, then has one of its portfolio companies publish a report *into*
+the fund's graph — which is the capability nothing else on the market has:
+
+    Portfolio → Position → Security → Entity → Report → Fact
+
+Getting to that traversal takes two tenants. The **issuer** is Cadence
+Labs, Inc., a seed-funded B2B SaaS company built by the existing showcase
+scenario (``examples/saas_startup_demo``) with a published, filed annual
+report. The **investor** is a fund graph provisioned here. Both belong to
+the same user and org in this run — the boundary being crossed is the
+*graph* boundary, which is where the report-sharing authorization actually
+lives.
+
+What each phase proves:
+
+1. **Pre-association.** Securities are registered naming the issuer's
+   graph before any link exists. ``entity_id`` stays null and ``holdings``
+   reports the issuer as unlinked — a first-class state, not an error.
+2. **The Portfolio Block is the write surface.** Portfolio and positions
+   validate whole and write atomically; the update applies add / update /
+   dispose deltas in one call; deleting a portfolio with active positions
+   is refused without an explicit confirmation.
+3. **Every write marks its graph stale.** Checked through the graph health
+   endpoint after the investor writes and before any materialization —
+   the regression guard for the defect that kept this entire domain out of
+   LadybugDB.
+4. **The handshake links.** The issuer shares its filed report to a publish
+   list containing the fund's graph. The share creates a linked ``Entity``
+   in the fund's graph and resolves *every* security that pre-associated
+   to the issuer.
+5. **The traversal executes.** After materialization, one Cypher query
+   walks from the fund's portfolio to the issuer's reported facts.
+6. **Revocation withdraws the copy** while leaving the linked entity — the
+   relationship survives one report being pulled.
+
+Every write goes through the HTTP API via the SDK facades, the same
+surface the frontends and MCP tools use. The one exception is ``_reset.py``,
+which uses direct DB access so re-runs start clean; that path is
+deliberately not a product operation.
+
+Prerequisites:
+    just start        # Docker stack (API, PostgreSQL, Valkey, LadybugDB)
+    just demo-user    # writes credentials to .local/config.json
+
+Usage:
+    just demo-roboinvestor                    # provision both graphs, run everything
+    just demo-roboinvestor <graph_id>         # reuse an existing investor graph
+    just demo-roboinvestor --issuer <id>      # use a specific issuer graph
+    just demo-roboinvestor --reload-issuer    # rebuild the issuer's ledger first
+    just demo-roboinvestor --skip-share       # portfolio surface only, no handshake
+    just demo-roboinvestor --dry-run          # preview the portfolio, write nothing
+
+The run ends with a hard validation pass; it exits non-zero if any
+invariant fails, so it doubles as a pre-release gate.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+from . import data as portfolio_data
+
+CREDENTIALS_FILE = Path(".local/config.json")
+BASE_URL = "http://localhost:8000"
+
+INVESTOR_SLOT = "roboinvestor_demo"
+ISSUER_SLOT = "saas_startup"
+
+PUBLISH_LIST_NAME = "Investor Reporting — Meridian"
+PUBLISH_LIST_DESCRIPTION = (
+  "Quarterly and annual reporting distributed to institutional investors."
+)
+
+
+# ---------------------------------------------------------------------------
+# Clients
+# ---------------------------------------------------------------------------
+
+
+def _client_config() -> dict[str, str]:
+  if not CREDENTIALS_FILE.exists():
+    print("  ERROR: No credentials file. Run `just demo-user` first.")
+    sys.exit(1)
+  creds = json.loads(CREDENTIALS_FILE.read_text())
+  return {"base_url": BASE_URL, "token": creds.get("api_key", "")}
+
+
+def _investor_client():
+  from robosystems_client.clients.investor_client import InvestorClient
+
+  return InvestorClient(_client_config())
+
+
+def _ledger_client():
+  from robosystems_client.clients.ledger_client import LedgerClient
+
+  return LedgerClient(_client_config())
+
+
+def _graph_client():
+  from robosystems_client.clients.graph_client import GraphClient
+
+  return GraphClient(_client_config())
+
+
+def _query_client():
+  from robosystems_client.clients.query_client import QueryClient
+
+  return QueryClient(_client_config())
+
+
+def _authenticated_client():
+  from robosystems_client.client import AuthenticatedClient
+
+  return AuthenticatedClient(
+    base_url=BASE_URL,
+    token=_client_config()["token"],
+    prefix="",
+    auth_header_name="X-API-Key",
+  )
+
+
+# ---------------------------------------------------------------------------
+# Step 1: the issuer graph — a company that keeps its books here
+# ---------------------------------------------------------------------------
+
+
+def ensure_issuer_graph(*, reload: bool, explicit: str | None) -> str:
+  """Return a RoboLedger graph holding a published, filed annual report.
+
+  Reuses the cached ``saas_startup`` graph when it already has one —
+  rebuilding a whole ledger to re-read one report would dominate the run.
+  Otherwise runs the showcase scenario inline, which provisions the graph
+  and files the report as its final step.
+  """
+  from examples._common.config import cached_graph_id, load_credentials
+
+  if explicit:
+    print(f"  Using issuer graph: {explicit}")
+    return explicit
+
+  cfg = load_credentials(CREDENTIALS_FILE) or {}
+  cached = cached_graph_id(cfg, ISSUER_SLOT)
+
+  if cached and not reload:
+    report_id = _published_report_id(cached)
+    if report_id:
+      print(f"  Reusing issuer graph: {cached}")
+      print(f"  Published report:     {report_id}")
+      return cached
+    print(f"  Issuer graph {cached} has no published report — rebuilding its ledger.")
+
+  print("\n  Building the issuer's ledger (Cadence Labs, Inc.)...")
+  print("  This is the full RoboLedger showcase scenario and takes a few minutes.")
+  print("  " + "-" * 66)
+
+  from examples.saas_startup_demo.main import main as run_saas_startup
+
+  # A bare argv creates or reuses the scenario's own graph slot; any
+  # positional arg would be read as a graph id to load into.
+  run_saas_startup(argv=["roboinvestor_demo"])
+
+  print("  " + "-" * 66)
+  cfg = load_credentials(CREDENTIALS_FILE) or {}
+  graph_id = cached_graph_id(cfg, ISSUER_SLOT)
+  if not graph_id:
+    print("  ERROR: the issuer scenario did not record a graph id.")
+    sys.exit(1)
+  return graph_id
+
+
+def _published_report_id(graph_id: str) -> str | None:
+  """The newest published report on a graph, or None."""
+  try:
+    reports = _ledger_client().list_reports(graph_id)
+  except Exception:
+    return None
+  published = [r for r in reports or [] if getattr(r, "generation_status", None) == "published"]
+  if not published:
+    return None
+  return published[-1].id
+
+
+# ---------------------------------------------------------------------------
+# Step 2: the investor graph
+# ---------------------------------------------------------------------------
+
+
+def create_investor_graph() -> str:
+  """Create (or reuse) the fund's graph.
+
+  Provisioned with **both** extensions. ``roboinvestor`` is the obvious
+  one; ``roboledger`` is required because ``add-publish-list-members``
+  rejects any target graph that doesn't declare it. An investor keeps no
+  books, so that predicate really wants to be "target can receive
+  reports" — until it is, a fund that wants to receive reporting has to
+  carry the ledger extension it will never write to.
+  """
+  project_root = Path(__file__).resolve().parents[2]
+  if str(project_root) not in sys.path:
+    sys.path.insert(0, str(project_root))
+
+  from examples._common.config import get_graph_id, now_timestamp, save_graph_id
+  from examples.credentials.utils import CredentialContext, ensure_user_credentials
+
+  context = CredentialContext(
+    base_url=BASE_URL,
+    credentials_path=CREDENTIALS_FILE,
+    force=False,
+    default_name_prefix="Meridian Demo",
+    default_email_prefix="roboinvestor_demo",
+    api_key_prefix="Meridian Demo Key",
+    display_title="Meridian Ventures Demo Setup",
+  )
+  credentials = ensure_user_credentials(context)
+  api_key = credentials["api_key"]
+
+  existing = get_graph_id(CREDENTIALS_FILE, INVESTOR_SLOT)
+  if existing:
+    print(f"  Reusing investor graph: {existing}")
+    return existing
+
+  from robosystems_client.api.graphs.create_graph import (
+    sync_detailed as api_create_graph,
+  )
+  from robosystems_client.api.operations.get_operation_status import (
+    sync_detailed as api_get_operation_status,
+  )
+  from robosystems_client.client import AuthenticatedClient
+  from robosystems_client.models import CreateGraphRequest, GraphMetadata
+
+  client = AuthenticatedClient(
+    base_url=BASE_URL, token=api_key, prefix="", auth_header_name="X-API-Key"
+  )
+
+  metadata = GraphMetadata(
+    graph_name=portfolio_data.FUND_NAME,
+    description="Early-stage venture fund — private-markets portfolio",
+    schema_extensions=["roboinvestor", "roboledger"],
+  )
+  request = CreateGraphRequest(
+    metadata=metadata,
+    initial_entity={
+      "name": portfolio_data.FUND_NAME,
+      "uri": portfolio_data.FUND_URI,
+      "entity_type": "partnership",
+      "ticker": portfolio_data.FUND_TICKER,
+    },
+    tags=["demo", "meridian", "roboinvestor", "venture"],
+  )
+  print(f"\n  Creating investor graph: {portfolio_data.FUND_NAME}")
+  response = api_create_graph(client=client, body=request)
+  if response.status_code >= 400:
+    body = response.content.decode() if response.content else "(no body)"
+    print(f"  Failed to create graph: HTTP {response.status_code}\n  {body}")
+    sys.exit(1)
+  if not response.parsed:
+    print(f"  Failed to create graph: empty response ({response.status_code})")
+    sys.exit(1)
+
+  parsed = response.parsed
+  graph_id = getattr(parsed, "graph_id", None)
+  operation_id = getattr(parsed, "operation_id", None)
+  if isinstance(parsed, dict):
+    graph_id = parsed.get("graph_id")
+    operation_id = parsed.get("operation_id")
+
+  if not graph_id and operation_id:
+    print(f"  Queued (operation: {operation_id}), waiting...")
+    for _ in range(30):
+      time.sleep(2)
+      status_resp = api_get_operation_status(operation_id=operation_id, client=client)
+      if not status_resp.parsed:
+        continue
+      status_data = status_resp.parsed
+      if isinstance(status_data, dict):
+        status = status_data.get("status")
+        result = status_data.get("result", {})
+      elif hasattr(status_data, "additional_properties"):
+        props = status_data.additional_properties
+        status = props.get("status")
+        result = props.get("result", {})
+      else:
+        status = getattr(status_data, "status", None)
+        result = getattr(status_data, "result", {})
+
+      if status == "completed":
+        graph_id = result.get("graph_id") if isinstance(result, dict) else None
+        break
+      if status == "failed":
+        error = result.get("error") if isinstance(result, dict) else "unknown"
+        print(f"  Graph creation failed: {error}")
+        sys.exit(1)
+
+  if not graph_id:
+    print("  Timed out waiting for graph creation")
+    sys.exit(1)
+
+  save_graph_id(CREDENTIALS_FILE, INVESTOR_SLOT, graph_id, now_timestamp())
+  print(f"  Graph created: {graph_id}")
+  return graph_id
+
+
+# ---------------------------------------------------------------------------
+# Step 3: securities (Master Data CRUD)
+# ---------------------------------------------------------------------------
+
+
+def register_securities(investor_graph: str, issuer_graph: str) -> dict[str, str]:
+  """Register every security, pre-associating the issuer's two instruments.
+
+  Securities are Master Data: positions reference them, and the portfolio
+  block never mints them. The two Cadence instruments are created with
+  ``source_graph_id`` and no ``entity_id`` — the investor declaring an
+  issuer relationship that doesn't exist yet.
+  """
+  client = _investor_client()
+  ids: dict[str, str] = {}
+
+  for spec in portfolio_data.SECURITIES:
+    body: dict[str, Any] = {
+      "name": spec.name,
+      "security_type": spec.security_type,
+      "terms": spec.terms,
+    }
+    if spec.security_subtype:
+      body["security_subtype"] = spec.security_subtype
+    if spec.authorized_shares is not None:
+      body["authorized_shares"] = spec.authorized_shares
+    if spec.outstanding_shares is not None:
+      body["outstanding_shares"] = spec.outstanding_shares
+    if spec.links_to_issuer:
+      body["source_graph_id"] = issuer_graph
+
+    result = client.create_security(investor_graph, body)
+    security_id = _field(result, "id")
+    ids[spec.key] = security_id
+
+    linked = "pre-associated" if spec.links_to_issuer else "unlinked"
+    print(f"    {spec.name[:52]:<52} {linked}")
+
+  return ids
+
+
+def show_pre_association(investor_graph: str, security_ids: dict[str, str]) -> None:
+  """Print the pre-association state — declared intent, no link yet."""
+  client = _investor_client()
+  for key in portfolio_data.issuer_linked_keys():
+    security = client.get_security(investor_graph, security_ids[key])
+    entity_id = _field(security, "entity_id", None)
+    source = _field(security, "source_graph_id", None)
+    print(f"    {_field(security, 'name')[:52]:<52}")
+    print(f"      source_graph_id: {source}")
+    print(f"      entity_id:       {entity_id or '(none — awaiting handshake)'}")
+
+
+# ---------------------------------------------------------------------------
+# Step 4: the Portfolio Block
+# ---------------------------------------------------------------------------
+
+
+def create_portfolio(
+  investor_graph: str, security_ids: dict[str, str], fund_entity_id: str | None
+) -> str:
+  """Create the portfolio and its opening positions in one atomic envelope."""
+  client = _investor_client()
+  valuation = portfolio_data.valuation_date()
+
+  portfolio: dict[str, Any] = {
+    "name": portfolio_data.PORTFOLIO_NAME,
+    "description": "Direct private-company positions held by Fund I.",
+    "strategy": portfolio_data.PORTFOLIO_STRATEGY,
+    "inception_date": portfolio_data.inception_date().isoformat(),
+    "base_currency": "USD",
+  }
+  if fund_entity_id:
+    portfolio["entity_id"] = fund_entity_id
+
+  positions = [
+    _position_body(spec, security_ids, valuation)
+    for spec in portfolio_data.INITIAL_POSITIONS
+  ]
+
+  block = client.create_portfolio_block(
+    investor_graph, {"portfolio": portfolio, "positions": positions}
+  )
+  portfolio_id = _field(block, "id")
+  _print_block(block)
+  return portfolio_id
+
+
+def apply_position_deltas(
+  investor_graph: str, portfolio_id: str, security_ids: dict[str, str]
+) -> None:
+  """Apply add / update / dispose deltas in a single atomic call."""
+  client = _investor_client()
+  valuation = portfolio_data.valuation_date()
+
+  block = client.get_portfolio_block(investor_graph, portfolio_id)
+  position_by_security = {
+    _field(_field(p, "security"), "id"): _field(p, "id")
+    for p in _field(block, "positions", []) or []
+  }
+
+  cadence_position = position_by_security.get(security_ids["cadence_series_a"])
+  aldergrove_position = position_by_security.get(security_ids["aldergrove_seed"])
+  if not cadence_position or not aldergrove_position:
+    print("  ERROR: opening positions missing — cannot apply deltas.")
+    sys.exit(1)
+
+  updates: dict[str, Any] = {
+    "positions": {
+      "add": [
+        _position_body(spec, security_ids, valuation)
+        for spec in portfolio_data.ADDED_POSITIONS
+      ],
+      "update": [
+        {
+          "id": cadence_position,
+          "current_value": portfolio_data.CADENCE_REMARK_VALUE,
+          "valuation_date": valuation.isoformat(),
+          "valuation_source": portfolio_data.CADENCE_REMARK_SOURCE,
+        }
+      ],
+      "dispose": [
+        {
+          "id": aldergrove_position,
+          "disposition_reason": portfolio_data.DISPOSED_REASON,
+        }
+      ],
+    }
+  }
+
+  print("    add:      2 positions (bridge warrant, LLC units)")
+  print(
+    f"    update:   Cadence Series A re-marked to "
+    f"${portfolio_data.CADENCE_REMARK_VALUE / 100:,.2f}"
+  )
+  print(f"    dispose:  Alder Grove Bio — {portfolio_data.DISPOSED_REASON}")
+
+  block = client.update_portfolio_block(investor_graph, portfolio_id, updates)
+  _print_block(block)
+
+
+def prove_cascade_guard(investor_graph: str, portfolio_id: str) -> bool:
+  """Deleting a portfolio holding active positions must be refused.
+
+  Returns True when the guard fired. The safety belt is the reason the
+  demo can hold a live portfolio through the rest of the run.
+  """
+  client = _investor_client()
+  try:
+    client.delete_portfolio_block(
+      investor_graph, portfolio_id, confirm_active_positions=False
+    )
+  except Exception as exc:
+    message = str(exc)
+    if "409" in message:
+      print("    Refused (409) — confirm_active_positions required. Guard holds.")
+      return True
+    print(f"    WARNING: refused, but not with a 409: {message[:160]}")
+    return False
+
+  print("    WARNING: the cascade delete SUCCEEDED without confirmation.")
+  return False
+
+
+def _position_body(
+  spec: portfolio_data.PositionSpec,
+  security_ids: dict[str, str],
+  valuation: date,
+) -> dict[str, Any]:
+  body: dict[str, Any] = {
+    "security_id": security_ids[spec.security_key],
+    "quantity": spec.quantity,
+    "quantity_type": spec.quantity_type,
+    "cost_basis": spec.cost_basis,
+    "currency": "USD",
+    "acquisition_date": portfolio_data.acquisition_date(spec).isoformat(),
+  }
+  if spec.current_value is not None:
+    body["current_value"] = spec.current_value
+    body["valuation_date"] = valuation.isoformat()
+    body["valuation_source"] = spec.valuation_source
+  if spec.notes:
+    body["notes"] = spec.notes
+  return body
+
+
+def _print_block(block: Any) -> None:
+  cost = _field(block, "total_cost_basis_dollars", 0.0) or 0.0
+  value = _field(block, "total_current_value_dollars", None)
+  active = _field(block, "active_position_count", 0)
+  owner = _field(block, "owner", None)
+  print(f"    Active positions: {active}")
+  print(f"    Cost basis:       ${cost:,.2f}")
+  print(f"    Current value:    {f'${value:,.2f}' if value is not None else '(unmarked)'}")
+  if owner:
+    print(f"    Owner:            {_field(owner, 'name')}")
+
+
+# ---------------------------------------------------------------------------
+# Step 5: staleness — the regression guard
+# ---------------------------------------------------------------------------
+
+
+def read_staleness(graph_id: str) -> tuple[bool, str | None]:
+  """Read the graph's staleness flag through the health endpoint.
+
+  Every extensions write is supposed to mark its graph stale; the
+  materialization sensor triggers on nothing else. RoboInvestor shipped
+  with zero of its six operations doing so, which kept portfolios,
+  securities and positions out of LadybugDB entirely. This is the check
+  that would have caught it.
+  """
+  from robosystems_client.api.graph_health.get_database_health import (
+    sync_detailed as api_health,
+  )
+
+  response = api_health(graph_id=graph_id, client=_authenticated_client())
+  if response.status_code >= 400 or not response.parsed:
+    print(f"    WARNING: health check returned HTTP {response.status_code}")
+    return (False, None)
+
+  parsed = response.parsed
+  payload = getattr(parsed, "additional_properties", None) or {}
+  if isinstance(parsed, dict):
+    payload = parsed
+
+  is_stale = _field(parsed, "is_stale", payload.get("is_stale"))
+  reason = _field(parsed, "stale_reason", payload.get("stale_reason"))
+  return (bool(is_stale), reason)
+
+
+# ---------------------------------------------------------------------------
+# Step 6: the cross-graph handshake
+# ---------------------------------------------------------------------------
+
+
+def share_report(issuer_graph: str, investor_graph: str, report_id: str) -> str | None:
+  """Publish the issuer's filed report into the fund's graph.
+
+  Creates a publish list on the issuer, adds the fund's graph as a member,
+  and shares. Each share is an independent copy: the report row, a
+  cross-graph fact set, and every fact are written into the recipient's
+  own schema. Returns the publish list id.
+  """
+  client = _ledger_client()
+
+  publish_list = client.create_publish_list(
+    issuer_graph, name=PUBLISH_LIST_NAME, description=PUBLISH_LIST_DESCRIPTION
+  )
+  list_id = _field(publish_list, "id")
+  print(f"    Publish list:  {list_id}")
+
+  client.add_publish_list_members(issuer_graph, list_id, [investor_graph])
+  print(f"    Member added:  {investor_graph}")
+
+  response = client.share_report(issuer_graph, report_id, list_id)
+  for item in _field(response, "results", []) or []:
+    status = _field(item, "status")
+    target = _field(item, "target_graph_id")
+    if status == "shared":
+      print(f"    Shared:        {target} ({_field(item, 'fact_count', 0)} facts)")
+    else:
+      print(f"    FAILED:        {target} — {_field(item, 'error', status)}")
+  return list_id
+
+
+def show_handshake_result(
+  investor_graph: str, issuer_graph: str, security_ids: dict[str, str]
+) -> None:
+  """Print what the share created on the investor's side."""
+  ledger = _ledger_client()
+  investor = _investor_client()
+
+  linked = [
+    e
+    for e in (ledger.list_entities(investor_graph, source="linked") or [])
+    if _field(e, "source") == "linked"
+  ]
+  for entity in linked:
+    print(f"    Linked entity:  {_field(entity, 'name')} ({_field(entity, 'id')})")
+
+  for key in portfolio_data.issuer_linked_keys():
+    security = investor.get_security(investor_graph, security_ids[key])
+    print(
+      f"    {_field(security, 'name')[:46]:<46} "
+      f"entity_id → {_field(security, 'entity_id', None) or '(still null)'}"
+    )
+
+  shared = [
+    r
+    for r in (ledger.list_reports(investor_graph) or [])
+    if _field(r, "source_graph_id", None) == issuer_graph
+  ]
+  for report in shared:
+    print(f"    Shared report:  {_field(report, 'name')} ({_field(report, 'id')})")
+
+
+# ---------------------------------------------------------------------------
+# Step 7: materialize + traverse
+# ---------------------------------------------------------------------------
+
+
+def materialize(graph_id: str) -> bool:
+  """Rebuild the graph from OLTP. Returns False on anything but a clean run.
+
+  A *partial* materialization is a failure, not a warning. Blue/green
+  abandons the whole WIP database when any table errors, so one bad table
+  leaves the previously-active graph untouched — on a first run that means
+  an empty graph, and every downstream read silently returns nothing. The
+  demo treats it as fatal so the cause is named where it happens.
+  """
+  from robosystems_client.clients.graph_client import MaterializationOptions
+
+  try:
+    result = _graph_client().materialize(
+      graph_id,
+      MaterializationOptions(
+        force=True, rebuild=True, on_progress=lambda msg: print(f"    {msg}")
+      ),
+    )
+  except Exception as exc:
+    print(f"    FAIL  materialization raised: {exc}")
+    return False
+
+  if not result.success:
+    print(f"    FAIL  materialization failed: {result.error or result.message}")
+    return False
+  if result.total_rows == 0:
+    print("    FAIL  materialization reported success but wrote 0 rows.")
+    print("          A partial run abandons the WIP graph — check the worker log:")
+    print("          just logs-grep worker 'Failed to materialize'")
+    return False
+
+  print(f"    Materialized {result.total_rows:,} rows")
+  return True
+
+
+TRAVERSAL_CYPHER = """
+MATCH (p:Portfolio)-[:PORTFOLIO_HAS_POSITION]->(pos:Position)
+      -[:POSITION_IN_SECURITY]->(s:Security)
+MATCH (issuer:Entity)-[:ENTITY_ISSUES_SECURITY]->(s)
+MATCH (issuer)-[:ENTITY_HAS_REPORT]->(r:Report)-[:REPORT_HAS_FACT]->(f:Fact)
+      -[:FACT_HAS_ELEMENT]->(e:Element)
+WHERE e.qname IN $qnames
+RETURN p.name AS portfolio,
+       s.name AS security,
+       issuer.name AS issuer,
+       r.name AS report,
+       e.qname AS concept,
+       f.numeric_value AS value
+ORDER BY security, concept
+"""
+
+TRAVERSAL_CONCEPTS = [
+  "rs-gaap:Revenues",
+  "rs-gaap:Assets",
+  "rs-gaap:NetIncomeLoss",
+  "rs-gaap:CashAndCashEquivalentsAtCarryingValue",
+]
+
+
+def run_traversal(investor_graph: str) -> list[dict[str, Any]]:
+  """The differentiated query: a private holding joined to its issuer's facts."""
+  try:
+    result = _query_client().query(
+      investor_graph, TRAVERSAL_CYPHER, {"qnames": TRAVERSAL_CONCEPTS}
+    )
+  except Exception as exc:
+    # An unmaterialized graph has no node tables at all, so this surfaces
+    # as a Cypher binder error rather than an empty result. Report and
+    # keep going — validation names the invariant that broke.
+    print(f"    FAIL  traversal query failed: {str(exc)[:200]}")
+    return []
+  rows = result.data or []
+  if not rows:
+    print("    (no rows — the traversal did not resolve)")
+    return []
+
+  for row in rows:
+    value = row.get("value")
+    rendered = f"${value:,.0f}" if isinstance(value, (int, float)) else "—"
+    print(
+      f"    {str(row.get('security'))[:38]:<38} "
+      f"{str(row.get('concept')):<48} {rendered:>18}"
+    )
+  return rows
+
+
+def show_graphql_reads(investor_graph: str, portfolio_id: str) -> None:
+  """Every RoboInvestor GraphQL read, against the finished graph."""
+  client = _investor_client()
+
+  portfolios = client.list_portfolios(investor_graph)
+  print(f"    portfolios:     {len(_field(portfolios, 'portfolios', []) or [])}")
+
+  securities = client.list_securities(investor_graph, is_active=True)
+  print(f"    securities:     {len(_field(securities, 'securities', []) or [])} active")
+
+  positions = client.list_positions(investor_graph, portfolio_id=portfolio_id)
+  print(f"    positions:      {len(_field(positions, 'positions', []) or [])}")
+
+  block = client.get_portfolio_block(investor_graph, portfolio_id)
+  print(f"    portfolioBlock: {_field(block, 'active_position_count', 0)} active")
+
+  holdings = client.get_holdings(investor_graph, portfolio_id)
+  for holding in _field(holdings, "holdings", []) or []:
+    name = _field(holding, "entity_name")
+    cost = _field(holding, "total_cost_basis_dollars", 0.0) or 0.0
+    count = len(_field(holding, "securities", []) or [])
+    source = _field(holding, "source_graph_id", None)
+    marker = "  (platform-native issuer)" if source else ""
+    print(f"    holdings:       {name[:34]:<34} {count} sec  ${cost:>14,.2f}{marker}")
+
+
+# ---------------------------------------------------------------------------
+# Step 8: revocation
+# ---------------------------------------------------------------------------
+
+
+def revoke_and_verify(issuer_graph: str, investor_graph: str, report_id: str) -> bool:
+  """Withdraw the shared copy and assert what survives it.
+
+  The recipient loses the report. They keep the linked ``Entity`` and the
+  securities pointing at it — an investor's declared holding is a
+  relationship, not an artifact of one filing, and breaking it over a
+  single withdrawal would be wrong.
+  """
+  ledger = _ledger_client()
+  try:
+    response = ledger.revoke_report_share(issuer_graph, report_id, investor_graph)
+  except Exception as exc:
+    print(f"    FAIL  revoke raised: {exc}")
+    return False
+
+  print(f"    Copy deleted:   {_field(response, 'copy_deleted', None)}")
+
+  remaining = [
+    r
+    for r in (ledger.list_reports(investor_graph) or [])
+    if _field(r, "source_graph_id", None) == issuer_graph
+  ]
+  linked = [
+    e
+    for e in (ledger.list_entities(investor_graph, source="linked") or [])
+    if _field(e, "source_graph_id", None) == issuer_graph
+  ]
+
+  ok = True
+  if remaining:
+    print(f"    FAIL  {len(remaining)} shared report(s) still in the fund's schema")
+    ok = False
+  else:
+    print("    PASS  shared report withdrawn from the fund's schema")
+
+  if linked:
+    print("    PASS  linked entity survives the withdrawal")
+  else:
+    print("    FAIL  linked entity was removed with the report")
+    ok = False
+  return ok
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+_MISSING = object()
+
+
+def _field(obj: Any, name: str, default: Any = _MISSING) -> Any:
+  """Read a field off an SDK model, a dict, or an attrs envelope result.
+
+  The SDK returns generated attrs classes in production and plain dicts
+  under some code paths; ``UNSET`` sentinels stand in for absent optional
+  fields. One accessor keeps the demo readable across all three.
+  """
+  if obj is None:
+    return None if default is _MISSING else default
+
+  if isinstance(obj, dict):
+    value = obj.get(name, _MISSING)
+  else:
+    value = getattr(obj, name, _MISSING)
+
+  if value is _MISSING or (
+    value is not None and "Unset" in type(value).__name__
+  ):
+    if default is _MISSING:
+      raise KeyError(f"{type(obj).__name__} has no field {name!r}")
+    return default
+  return value
+
+
+def _heading(step: str, title: str) -> None:
+  print(f"\n{step}  {title}")
+  print("  " + "-" * 68)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> None:
+  argv = sys.argv if argv is None else argv
+  dry_run = "--dry-run" in argv
+  reload_issuer = "--reload-issuer" in argv
+  skip_share = "--skip-share" in argv
+  revoke = "--revoke" in argv
+  issuer_override = _flag_value(argv, "--issuer")
+  positional = [a for a in argv[1:] if not a.startswith("--")]
+  # `--issuer <id>` consumes its own value; don't also read it as the
+  # investor graph id.
+  if issuer_override and issuer_override in positional:
+    positional.remove(issuer_override)
+
+  project_root = Path(__file__).resolve().parents[2]
+  if str(project_root) not in sys.path:
+    sys.path.insert(0, str(project_root))
+
+  print(f"\n{portfolio_data.FUND_NAME} — RoboInvestor End-to-End Demo")
+  print("=" * 70)
+
+  if dry_run:
+    portfolio_data._preview()
+    print("Dry run complete. No data written.")
+    return
+
+  _heading("[1/9]", "Issuer graph — a portfolio company that keeps its books here")
+  issuer_graph = ensure_issuer_graph(reload=reload_issuer, explicit=issuer_override)
+  report_id = _published_report_id(issuer_graph)
+  if not report_id and not skip_share:
+    print("  ERROR: the issuer graph has no published report to share.")
+    print("  Re-run with --reload-issuer to rebuild its ledger.")
+    sys.exit(1)
+
+  _heading("[2/9]", "Investor graph — the fund")
+  investor_graph = positional[0] if positional else create_investor_graph()
+
+  print("\n  Resetting prior demo state (the only direct-DB step)...")
+  from ._reset import reset_investor_state, reset_issuer_share_state
+
+  reset_investor_state(investor_graph)
+  reset_issuer_share_state(issuer_graph)
+  print("  Done")
+
+  fund_entity = _ledger_client().get_entity(investor_graph)
+  fund_entity_id = _field(fund_entity, "id", None) if fund_entity else None
+
+  _heading("[3/9]", "Securities — Master Data, with two pre-associations")
+  security_ids = register_securities(investor_graph, issuer_graph)
+
+  print("\n  Pre-association state (declared intent, no link yet):")
+  show_pre_association(investor_graph, security_ids)
+
+  _heading("[4/9]", "Portfolio Block — create (atomic envelope)")
+  portfolio_id = create_portfolio(investor_graph, security_ids, fund_entity_id)
+
+  _heading("[5/9]", "Portfolio Block — update (add / update / dispose, one call)")
+  apply_position_deltas(investor_graph, portfolio_id, security_ids)
+
+  print("\n  Cascade-delete guard:")
+  guard_held = prove_cascade_guard(investor_graph, portfolio_id)
+
+  _heading("[6/9]", "Staleness — every write marks its graph")
+  is_stale, stale_reason = read_staleness(investor_graph)
+  print(f"    is_stale:     {is_stale}")
+  print(f"    stale_reason: {stale_reason}")
+  if not is_stale:
+    print("    ^ REGRESSION: RoboInvestor writes are not marking the graph stale.")
+
+  shared = False
+  if skip_share:
+    _heading("[7/9]", "Report share — SKIPPED (--skip-share)")
+  else:
+    _heading("[7/9]", "Cross-graph handshake — the issuer publishes into the fund")
+    assert report_id is not None
+    share_report(issuer_graph, investor_graph, report_id)
+    print("\n  What the share created in the fund's graph:")
+    show_handshake_result(investor_graph, issuer_graph, security_ids)
+    shared = True
+
+  _heading("[8/9]", "Materialize + traverse")
+  print("  Materializing the fund's graph...")
+  materialized = materialize(investor_graph)
+
+  rows: list[dict[str, Any]] = []
+  if shared:
+    print("\n  Portfolio → Position → Security → Entity → Report → Fact")
+    rows = run_traversal(investor_graph)
+
+  print("\n  GraphQL reads:")
+  show_graphql_reads(investor_graph, portfolio_id)
+
+  _heading("[9/9]", "Validation")
+  from .validate import validate_run
+
+  ok = validate_run(
+    investor_graph=investor_graph,
+    issuer_graph=issuer_graph,
+    portfolio_id=portfolio_id,
+    security_ids=security_ids,
+    report_id=report_id,
+    shared=shared,
+    materialized=materialized,
+    guard_held=guard_held,
+    was_stale=is_stale,
+    stale_reason=stale_reason,
+    traversal_rows=rows,
+  )
+
+  # Revocation runs last, after the assertions, because it dismantles the
+  # state they check. The point it makes is what *doesn't* go away.
+  if shared and revoke:
+    _heading("[+]", "Revocation — the sender withdraws the copy")
+    assert report_id is not None
+    ok = revoke_and_verify(issuer_graph, investor_graph, report_id) and ok
+
+  print("\n" + "=" * 70)
+  print(f"  Investor graph: {investor_graph}")
+  print(f"  Issuer graph:   {issuer_graph}")
+  print(f"  Portfolio:      {portfolio_id}")
+  if shared and report_id:
+    print(f"  Shared report:  {report_id}")
+  print("=" * 70)
+
+  if not ok:
+    sys.exit(1)
+
+
+def _flag_value(argv: list[str], flag: str) -> str | None:
+  """Read ``--flag value`` or ``--flag=value`` out of argv."""
+  for i, arg in enumerate(argv):
+    if arg == flag and i + 1 < len(argv):
+      return argv[i + 1]
+    if arg.startswith(f"{flag}="):
+      return arg.split("=", 1)[1]
+  return None
+
+
+if __name__ == "__main__":
+  main()

--- a/examples/roboinvestor_demo/validate.py
+++ b/examples/roboinvestor_demo/validate.py
@@ -1,0 +1,359 @@
+"""Hard assertions over a finished RoboInvestor demo run.
+
+Everything here is checked through the product surface — GraphQL reads,
+the graph health endpoint, and Cypher against the materialized graph — so
+a failure means a customer would see it too.
+
+The invariants come from ``ref/roboinvestor.md`` §7 plus the platform
+staleness rule in ``ref/extensions.md`` §8. Two of them exist specifically
+because their absence went unnoticed for six months:
+
+- **Every operation marks its graph stale.** RoboInvestor shipped with
+  zero of six doing so. Nothing reached LadybugDB, and no test could see
+  it because no test and no demo ever created a pure-investor graph.
+- **The pre-association is a first-class state.** ``source_graph_id`` is
+  meaningful before ``entity_id`` exists, and anything reading issuer
+  attribution must prefer the security's own column — reading it off the
+  linked entity returns null for exactly the securities that declared
+  intent but have not yet been linked.
+
+``validate_run`` prints one line per check and returns False if any
+failed, so the caller can exit non-zero.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from . import data as portfolio_data
+
+# Stale reasons the six RoboInvestor operations emit. A stale graph
+# carrying some other domain's reason would mean the investor writes
+# still aren't marking — masked by a ledger write on a dual-schema graph,
+# which is exactly how the original defect stayed hidden.
+INVESTOR_STALE_REASONS = {
+  "portfolio_block_created",
+  "portfolio_block_updated",
+  "portfolio_block_deleted",
+  "security_created",
+  "security_updated",
+  "security_deleted",
+}
+
+EXPECTED_ACTIVE_POSITIONS = (
+  len(portfolio_data.INITIAL_POSITIONS) + len(portfolio_data.ADDED_POSITIONS) - 1
+)
+
+_DISPOSED_KEY = "aldergrove_seed"
+
+
+def _expected_cost_basis_cents() -> int:
+  opening = sum(p.cost_basis for p in portfolio_data.INITIAL_POSITIONS)
+  added = sum(p.cost_basis for p in portfolio_data.ADDED_POSITIONS)
+  disposed = sum(
+    p.cost_basis
+    for p in portfolio_data.INITIAL_POSITIONS
+    if p.security_key == _DISPOSED_KEY
+  )
+  return opening + added - disposed
+
+
+class Checks:
+  """Collects pass/fail results and prints them as it goes."""
+
+  def __init__(self) -> None:
+    self.failures: list[str] = []
+    self.passed = 0
+
+  def check(self, label: str, condition: bool, detail: str = "") -> bool:
+    if condition:
+      self.passed += 1
+      print(f"    PASS  {label}")
+    else:
+      self.failures.append(label)
+      suffix = f" — {detail}" if detail else ""
+      print(f"    FAIL  {label}{suffix}")
+    return condition
+
+  def equal(self, label: str, actual: Any, expected: Any) -> bool:
+    return self.check(label, actual == expected, f"expected {expected!r}, got {actual!r}")
+
+
+def _first_row(query: Any, graph_id: str, cypher: str, checks: Checks) -> dict[str, Any]:
+  """Run a Cypher check, turning a query failure into a recorded failure.
+
+  A gate that dies mid-run prints no summary, so an unrelated hiccup —
+  a memory-starved graph node, a restarting container — costs the whole
+  report. Returning an empty row makes each dependent check fail on its
+  own terms instead.
+  """
+  try:
+    result = query.query(graph_id, cypher)
+  except Exception as exc:
+    checks.check("graph query executed", False, str(exc)[:160])
+    return {}
+  return (result.data or [{}])[0]
+
+
+def validate_run(
+  *,
+  investor_graph: str,
+  issuer_graph: str,
+  portfolio_id: str,
+  security_ids: dict[str, str],
+  report_id: str | None,
+  shared: bool,
+  materialized: bool,
+  guard_held: bool,
+  was_stale: bool,
+  stale_reason: str | None,
+  traversal_rows: list[dict[str, Any]],
+) -> bool:
+  """Assert every invariant the run is supposed to establish."""
+  from .main import _field, _investor_client, _ledger_client, _query_client
+
+  checks = Checks()
+  investor = _investor_client()
+  ledger = _ledger_client()
+
+  # ── Securities (Master Data) ─────────────────────────────────────────
+  securities_page = investor.list_securities(investor_graph, is_active=True)
+  securities = _field(securities_page, "securities", []) or []
+  checks.equal(
+    "every security registered and active",
+    len(securities),
+    len(portfolio_data.SECURITIES),
+  )
+
+  issuer_keys = portfolio_data.issuer_linked_keys()
+  pre_associated = [
+    s for s in securities if _field(s, "source_graph_id", None) == issuer_graph
+  ]
+  checks.equal(
+    "securities pre-associated to the issuer graph",
+    len(pre_associated),
+    len(issuer_keys),
+  )
+
+  # ── Portfolio Block ──────────────────────────────────────────────────
+  block = investor.get_portfolio_block(investor_graph, portfolio_id)
+  checks.check("portfolio block reads back", block is not None)
+
+  if block is not None:
+    checks.equal(
+      "active position count after deltas",
+      _field(block, "active_position_count", 0),
+      EXPECTED_ACTIVE_POSITIONS,
+    )
+    expected_dollars = _expected_cost_basis_cents() / 100
+    checks.equal(
+      "total cost basis (dollars, from integer cents)",
+      round(_field(block, "total_cost_basis_dollars", 0.0) or 0.0, 2),
+      round(expected_dollars, 2),
+    )
+    checks.check(
+      "portfolio owner resolves to the fund entity",
+      _field(block, "owner", None) is not None,
+      "Portfolio.entity_id was accepted on write but did not surface",
+    )
+
+  # The disposed position must be gone from the active projection and
+  # must not have been hard-deleted — dispose is a soft state change.
+  active_positions = _field(
+    investor.list_positions(investor_graph, portfolio_id=portfolio_id, status="active"),
+    "positions",
+    [],
+  )
+  disposed_positions = _field(
+    investor.list_positions(
+      investor_graph, portfolio_id=portfolio_id, status="disposed"
+    ),
+    "positions",
+    [],
+  )
+  checks.equal(
+    "active positions (read projection)",
+    len(active_positions or []),
+    EXPECTED_ACTIVE_POSITIONS,
+  )
+  checks.equal("disposed position retained, not deleted", len(disposed_positions or []), 1)
+
+  # Money is integer cents in storage; dollars are a boundary concern.
+  cents_ok = all(
+    _field(p, "cost_basis", 0) == round((_field(p, "cost_basis_dollars", 0.0) or 0.0) * 100)
+    for p in (active_positions or [])
+  )
+  checks.check("cost basis cents ↔ dollars agree on every position", cents_ok)
+
+  # The re-mark applied through update-portfolio-block.
+  cadence_positions = [
+    p
+    for p in (active_positions or [])
+    if _field(p, "security_id", None) == security_ids["cadence_series_a"]
+  ]
+  if checks.check("re-marked position found", len(cadence_positions) == 1):
+    marked = cadence_positions[0]
+    checks.equal(
+      "409A re-mark applied (cents)",
+      _field(marked, "current_value", None),
+      portfolio_data.CADENCE_REMARK_VALUE,
+    )
+    checks.equal(
+      "valuation source recorded",
+      _field(marked, "valuation_source", None),
+      portfolio_data.CADENCE_REMARK_SOURCE,
+    )
+
+  checks.check(
+    "cascade-delete guard refuses active positions without confirmation",
+    guard_held,
+  )
+
+  # ── Staleness (the regression guard) ─────────────────────────────────
+  checks.check(
+    "investor writes marked the graph stale",
+    was_stale,
+    "materialization is sensor-driven on this flag alone",
+  )
+  checks.check(
+    "stale reason came from a RoboInvestor operation",
+    stale_reason in INVESTOR_STALE_REASONS,
+    f"got {stale_reason!r}; a ledger reason means the investor ops still aren't marking",
+  )
+
+  # ── The cross-graph handshake ────────────────────────────────────────
+  if shared:
+    linked = [
+      e
+      for e in (ledger.list_entities(investor_graph, source="linked") or [])
+      if _field(e, "source_graph_id", None) == issuer_graph
+    ]
+    linked_ok = checks.equal("linked entity created for the issuer", len(linked), 1)
+
+    if linked_ok:
+      linked_entity_id = _field(linked[0], "id")
+      resolved = [
+        s
+        for s in securities
+        if _field(s, "source_graph_id", None) == issuer_graph
+        and _field(s, "entity_id", None) == linked_entity_id
+      ]
+      checks.equal(
+        "every pre-associated security resolved to the linked entity",
+        len(resolved),
+        len(issuer_keys),
+      )
+
+    shared_reports = [
+      r
+      for r in (ledger.list_reports(investor_graph) or [])
+      if _field(r, "source_graph_id", None) == issuer_graph
+    ]
+    if checks.equal("shared report copied into the fund's schema", len(shared_reports), 1):
+      copy = shared_reports[0]
+      checks.equal(
+        "shared copy is published",
+        _field(copy, "generation_status", None),
+        "published",
+      )
+      checks.equal(
+        "shared copy back-references the source report",
+        _field(copy, "source_report_id", None),
+        report_id,
+      )
+
+    # Holdings roll up by issuer; the platform-native one must carry its
+    # source graph rather than the "unlinked" sentinel.
+    holdings = _field(
+      investor.get_holdings(investor_graph, portfolio_id), "holdings", []
+    )
+    issuer_holdings = [
+      h for h in (holdings or []) if _field(h, "source_graph_id", None) == issuer_graph
+    ]
+    if checks.equal("holdings roll up the issuer", len(issuer_holdings), 1):
+      checks.equal(
+        "both issuer securities roll into one holding",
+        len(_field(issuer_holdings[0], "securities", []) or []),
+        len(issuer_keys),
+      )
+
+  # ── Materialization + the traversal ──────────────────────────────────
+  # Everything below reads LadybugDB, so a failed materialization would
+  # turn one root cause into a dozen misleading failures. Report the root
+  # cause once and skip the derived checks.
+  if not checks.check(
+    "graph materialized cleanly",
+    materialized,
+    "blue/green abandons the whole WIP on any table error — the graph is unchanged",
+  ):
+    print("    SKIP  graph-shape and traversal checks (nothing was materialized)")
+  else:
+    query = _query_client()
+
+    row = _first_row(
+      query,
+      investor_graph,
+      """
+      MATCH (p:Portfolio) WITH count(p) AS portfolios
+      MATCH (s:Security)  WITH portfolios, count(s) AS securities
+      MATCH (pos:Position) RETURN portfolios, securities, count(pos) AS positions
+      """,
+      checks,
+    )
+    checks.equal("Portfolio nodes materialized", row.get("portfolios"), 1)
+    checks.equal(
+      "Security nodes materialized",
+      row.get("securities"),
+      len(portfolio_data.SECURITIES),
+    )
+    checks.equal(
+      "only active positions materialize",
+      row.get("positions"),
+      EXPECTED_ACTIVE_POSITIONS,
+    )
+
+    edge_row = _first_row(
+      query,
+      investor_graph,
+      """
+      MATCH (:Portfolio)-[r:PORTFOLIO_HAS_POSITION]->(:Position)
+      WITH count(r) AS has_position
+      MATCH (:Position)-[r2:POSITION_IN_SECURITY]->(:Security)
+      WITH has_position, count(r2) AS in_security
+      MATCH (:Entity)-[r3:ENTITY_HAS_PORTFOLIO]->(:Portfolio)
+      RETURN has_position, in_security, count(r3) AS owns_portfolio
+      """,
+      checks,
+    )
+    checks.equal(
+      "PORTFOLIO_HAS_POSITION edges",
+      edge_row.get("has_position"),
+      EXPECTED_ACTIVE_POSITIONS,
+    )
+    checks.equal(
+      "POSITION_IN_SECURITY edges", edge_row.get("in_security"), EXPECTED_ACTIVE_POSITIONS
+    )
+    checks.equal("ENTITY_HAS_PORTFOLIO edge", edge_row.get("owns_portfolio"), 1)
+
+  if shared and materialized:
+    checks.check(
+      "Portfolio → Position → Security → Entity → Report → Fact resolves",
+      len(traversal_rows) > 0,
+      "the differentiated capability did not execute",
+    )
+    issuers = {r.get("issuer") for r in traversal_rows}
+    checks.check(
+      "traversal attributes facts to the issuer",
+      len(issuers) == 1 and all(issuers),
+      f"issuers seen: {issuers}",
+    )
+
+  # ── Summary ──────────────────────────────────────────────────────────
+  total = checks.passed + len(checks.failures)
+  print(f"\n  {checks.passed}/{total} checks passed")
+  if checks.failures:
+    print("  Failed:")
+    for failure in checks.failures:
+      print(f"    - {failure}")
+    return False
+  return True

--- a/examples/roboledger_demo/_reset.py
+++ b/examples/roboledger_demo/_reset.py
@@ -69,6 +69,10 @@ def reset_demo_state(graph_id: str) -> None:
     session.execute(text("DELETE FROM event_dimensions"))
     session.execute(text("DELETE FROM events"))
     session.execute(text("DELETE FROM agents"))
+    # fact_dimensions.dimension_id is ON DELETE RESTRICT, and facts are not
+    # wiped until further down — so the dimensions delete below fails on any
+    # graph whose forecast ran (scenario facts carry a `scenario` Dimension).
+    session.execute(text("DELETE FROM fact_dimensions"))
     session.execute(text("DELETE FROM dimensions"))
 
     # 4. Tenant-origin associations. The library's immutability triggers

--- a/examples/roboledger_demo/main.py
+++ b/examples/roboledger_demo/main.py
@@ -668,12 +668,12 @@ def create_mappings(
   offset = 0
   while True:
     page = client.list_elements(graph_id, source="rs-gaap", limit=1000, offset=offset)
-    items = (page or {}).get("elements", [])
+    items = page.elements if page else []
     if not items:
       break
     for e in items:
-      if e.get("qname"):
-        rs_gaap_by_qname[e["qname"]] = e["id"]
+      if e.qname:
+        rs_gaap_by_qname[e.qname] = e.id
     if len(items) < 1000:
       break
     offset += 1000
@@ -1026,25 +1026,19 @@ def generate_fy2025_report(graph_id: str) -> str | None:
   # Pull the package to confirm it rehydrates
   package = client.get_report_package(graph_id, report_id)
   if package:
-    items = package.get("items", []) or []
+    items = package.items or []
     # `block_type` lives nested at item.block.block_type on the rehydrated
     # InformationBlockEnvelope; reading item.block_type directly finds nothing
     # and silently renders "?" for every item.
-    block_names = [
-      (i.get("block") or {}).get("name")
-      or (i.get("block") or {}).get("block_type")
-      or "?"
-      for i in items
-    ]
+    block_names = [i.block.name or i.block.block_type or "?" for i in items]
     print(f"  Package:      {len(items)} block(s) — {', '.join(block_names)}")
 
     # Fact provenance — every FactSet records how its facts were
     # constructed (the auditability spine). Surfaced via the SDK on
-    # block.fact_set.provenance; report blocks pivot from the posted ledger.
+    # block.fact_set.provenance; report blocks pivot from the posted
+    # ledger. `provenance` is a JSON scalar, so it stays a dict.
     origins = [
-      (((i.get("block") or {}).get("fact_set") or {}).get("provenance") or {}).get(
-        "origin"
-      )
+      ((i.block.fact_set.provenance or {}).get("origin") if i.block.fact_set else None)
       for i in items
     ]
     if origins and all(origins):

--- a/examples/saas_startup_demo/main.py
+++ b/examples/saas_startup_demo/main.py
@@ -74,9 +74,17 @@ FORECAST_LEVERS = {
 }
 
 
-def main() -> None:
+def main(argv: list[str] | None = None) -> None:
+  """Run the episode. ``argv`` defaults to ``sys.argv`` inside ``run_demo``.
+
+  It is a parameter so another demo can provision this company as a
+  dependency — ``examples/roboinvestor_demo`` needs a real issuer with a
+  filed report to share — without that demo's own flags leaking in as
+  scenario flags.
+  """
   run_demo(
     scenario=SCENARIO,
+    argv=argv,
     agents=AGENTS,
     mappings_for=mappings_for,
     documents=DOCUMENTS,

--- a/examples/seattle_method_demo/author_rollforwards.py
+++ b/examples/seattle_method_demo/author_rollforwards.py
@@ -106,12 +106,12 @@ def _build_known_mini_qname_set(client, graph_id: str) -> set[str]:
     page = client.list_elements(
       graph_id, taxonomy_id=taxonomy_id, limit=page_size, offset=offset
     )
-    items = (page or {}).get("elements", [])
+    items = page.elements if page else []
     if not items:
       break
     for e in items:
-      if e.get("qname"):
-        known.add(e["qname"])
+      if e.qname:
+        known.add(e.qname)
     if len(items) < page_size:
       break
     offset += page_size

--- a/examples/seattle_method_demo/ingest_transactions.py
+++ b/examples/seattle_method_demo/ingest_transactions.py
@@ -171,12 +171,12 @@ def _build_qname_to_element_id_map(client, graph_id: str) -> dict[str, str]:
     page = client.list_elements(
       graph_id, taxonomy_id=taxonomy_id, limit=page_size, offset=offset
     )
-    items = (page or {}).get("elements", [])
+    items = page.elements if page else []
     if not items:
       break
     for e in items:
-      if e.get("qname"):
-        out[e["qname"]] = e["id"]
+      if e.qname:
+        out[e.qname] = e.id
     if len(items) < page_size:
       break
     offset += page_size

--- a/examples/seattle_method_demo/seed_mappings.py
+++ b/examples/seattle_method_demo/seed_mappings.py
@@ -73,12 +73,12 @@ def _build_qname_lookup_by_taxonomy(
     page = client.list_elements(
       graph_id, taxonomy_id=taxonomy_id, limit=page_size, offset=offset
     )
-    items = (page or {}).get("elements", [])
+    items = page.elements if page else []
     if not items:
       break
     for e in items:
-      if e.get("qname"):
-        out[e["qname"]] = e["id"]
+      if e.qname:
+        out[e.qname] = e.id
     if len(items) < page_size:
       break
     offset += page_size
@@ -99,12 +99,12 @@ def _build_qname_lookup(
     page = client.list_elements(
       graph_id, source=source, limit=page_size, offset=offset
     )
-    items = (page or {}).get("elements", [])
+    items = page.elements if page else []
     if not items:
       break
     for e in items:
-      if e.get("qname"):
-        out[e["qname"]] = e["id"]
+      if e.qname:
+        out[e.qname] = e.id
     if len(items) < page_size:
       break
     offset += page_size
@@ -125,9 +125,9 @@ def _find_mapping_structure(client, graph_id: str) -> str:
     )
   # Prefer the mini mapping structure when the graph carries several.
   for s in structures:
-    if "mini" in (s.get("name") or "").lower():
-      return s["id"]
-  return structures[0]["id"]
+    if "mini" in (s.name or "").lower():
+      return s.id
+  return structures[0].id
 
 
 def seed_mappings(graph_id: str, dry_run: bool = False) -> tuple[int, list[str]]:

--- a/examples/seattle_method_world_online/author_rollforwards.py
+++ b/examples/seattle_method_world_online/author_rollforwards.py
@@ -90,12 +90,12 @@ def _build_known_mini_qname_set(client, graph_id: str) -> set[str]:
     page = client.list_elements(
       graph_id, taxonomy_id=taxonomy_id, limit=page_size, offset=offset
     )
-    items = (page or {}).get("elements", [])
+    items = page.elements if page else []
     if not items:
       break
     for e in items:
-      if e.get("qname"):
-        known.add(e["qname"])
+      if e.qname:
+        known.add(e.qname)
     if len(items) < page_size:
       break
     offset += page_size

--- a/examples/seattle_method_world_online/ingest_gl.py
+++ b/examples/seattle_method_world_online/ingest_gl.py
@@ -283,12 +283,12 @@ def _build_qname_to_element_id_map(client, graph_id: str) -> dict[str, str]:
     page = client.list_elements(
       graph_id, taxonomy_id=taxonomy_id, limit=page_size, offset=offset
     )
-    items = (page or {}).get("elements", [])
+    items = page.elements if page else []
     if not items:
       break
     for e in items:
-      if e.get("qname"):
-        out[e["qname"]] = e["id"]
+      if e.qname:
+        out[e.qname] = e.id
     if len(items) < page_size:
       break
     offset += page_size

--- a/justfile
+++ b/justfile
@@ -219,6 +219,10 @@ demo-coffee-roaster *args="":
 demo-saas-startup *args="":
     UV_ENV_FILE={{_local_env}} uv run python -m examples.saas_startup_demo.main {{args}}
 
+# Run RoboInvestor demo — Meridian Ventures Fund I, incl. the cross-graph report share (flags: --issuer <id>, --reload-issuer, --skip-share, --revoke, --dry-run, [graph_id])
+demo-roboinvestor *args="":
+    UV_ENV_FILE={{_local_env}} uv run python -m examples.roboinvestor_demo.main {{args}}
+
 # Run custom graph demo end-to-end (pass any flags: --new-user, --new-graph, --skip-queries)
 demo-custom-graph *args="":
     UV_ENV_FILE={{_local_env}} uv run python -m examples.custom_graph_demo.main {{args}}

--- a/migrations/extensions/versions/0029_linked_element_source.py
+++ b/migrations/extensions/versions/0029_linked_element_source.py
@@ -1,0 +1,79 @@
+"""admit 'linked' as an element source — concepts that arrive with a shared report
+
+A report shared from another graph carries facts, and those facts cite
+concepts. Library concepts resolve on both sides (``copy_library_into_tenant``
+gives every tenant the same deterministic UUID5 ids), but the sender's own
+reporting extension does not: those are ``elem_*`` ULIDs minted in the
+sender's schema alone. ``facts.element_id`` has no foreign key, so the
+share wrote them happily and the recipient's next materialization then
+failed on the whole database — LadybugDB rejects an edge with an unknown
+endpoint, and blue/green answers a partial run by abandoning the WIP.
+
+``_ensure_shared_elements`` now copies the sender's reporting-extension
+taxonomies alongside the report. Those copies need a source value that is
+**not** in ``COA_SOURCES``: the recipient must be able to read the sender's
+concepts without the sender's revenue accounts turning up in the
+recipient's own chart of accounts. ``'linked'`` mirrors
+``Entity.source='linked'``, which marks the entity the same share creates.
+
+No data changes — this only widens the closed list so the new writes are
+legal. The downgrade narrows it again and will fail if any linked concepts
+are already present, which is the honest outcome: those rows would
+otherwise violate the re-added constraint.
+
+Revision ID: 0029
+Revises: 0028
+Create Date: 2026-08-09
+
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+from migrations.extensions.helpers import TenantOps, for_each_tenant_schema
+
+# revision identifiers, used by Alembic.
+revision = "0029"
+down_revision = "0028"
+branch_labels = None
+depends_on = None
+
+# Byte-identical to 0024's _SOURCE_WIDENED plus 'linked'.
+_SOURCE_WIDENED = (
+  "source IN ("
+  "'fac', 'rs-gaap', 'us-gaap', 'ifrs', "
+  "'quickbooks', 'xero', 'plaid', 'native', 'import', 'system', "
+  "'disclosures', 'checklist', 'styles', 'cm', 'rs-metric', 'rs-driver', "
+  "'linked'"
+  ")"
+)
+_SOURCE_ORIGINAL = (
+  "source IN ("
+  "'fac', 'rs-gaap', 'us-gaap', 'ifrs', "
+  "'quickbooks', 'xero', 'plaid', 'native', 'import', 'system', "
+  "'disclosures', 'checklist', 'styles', 'cm', 'rs-metric', 'rs-driver'"
+  ")"
+)
+
+
+def _widen(conn, schema: str) -> None:
+  TenantOps(conn, schema).add_check("elements", "check_element_source", _SOURCE_WIDENED)
+
+
+def _narrow(conn, schema: str) -> None:
+  TenantOps(conn, schema).add_check(
+    "elements", "check_element_source", _SOURCE_ORIGINAL
+  )
+
+
+def upgrade() -> None:
+  conn = op.get_bind()
+  _widen(conn, "public")
+  for_each_tenant_schema(conn, _widen)
+
+
+def downgrade() -> None:
+  conn = op.get_bind()
+  _narrow(conn, "public")
+  for_each_tenant_schema(conn, _narrow)

--- a/robosystems/db/extensions.py
+++ b/robosystems/db/extensions.py
@@ -262,7 +262,10 @@ def _widen_library_checks(conn, schema: str) -> None:
     "'disclosures', 'checklist', 'styles', 'rs-metric', 'rs-driver', "
     # cm — Conceptual Model framework (cm:Debit/cm:Credit posting roles),
     # tenant-copied with the default pin.
-    "'cm'"
+    "'cm', "
+    # linked — concepts that arrived with a report shared from another
+    # graph (see Element.source). Not a CoA source.
+    "'linked'"
     ")"
   )
   widened_taxonomy_type = (

--- a/robosystems/models/extensions/element.py
+++ b/robosystems/models/extensions/element.py
@@ -109,7 +109,12 @@ class Element(ExtensionsBase):
       # 'rs-metric' — the metric catalog package (seeded at 0002 on fresh
       # databases, backfilled by 0022 on existing ones).
       # 'rs-driver' — the forecast lever catalog package (seeded at 0024).
-      "'cm', 'rs-metric', 'rs-driver')",
+      # 'linked' — a concept that arrived with a report shared from another
+      # graph. Deliberately NOT in COA_SOURCES: the sender's reporting
+      # extension has to exist here for their facts to mean anything, but
+      # their revenue accounts are not the recipient's chart of accounts.
+      # Mirrors Entity.source='linked' for the same reason.
+      "'cm', 'rs-metric', 'rs-driver', 'linked')",
       name="check_element_source",
     ),
   )

--- a/robosystems/operations/extensions/materialize.py
+++ b/robosystems/operations/extensions/materialize.py
@@ -1128,12 +1128,23 @@ def _staging_sql(graph_id: str, entity_id: str, connstr: str) -> dict[str, str]:
       AND fs.scenario_id IS NULL
   """
 
+  # Inner-joined to `elements` on purpose. `facts.element_id` has no
+  # foreign key, so an unresolvable concept reaches this point without
+  # complaint — and LadybugDB then rejects the edge, which blue/green
+  # scores as a partial run and answers by abandoning the entire WIP
+  # database. One dangling id would otherwise cost the graph everything,
+  # including rows with no relationship to whatever wrote the bad
+  # reference. Dropping the single edge is the proportionate response; the
+  # write paths are responsible for not creating the dangle in the first
+  # place (see `_ensure_shared_elements` for the cross-graph case).
   tables["FACT_HAS_ELEMENT"] = f"""
     CREATE OR REPLACE TABLE FACT_HAS_ELEMENT AS
     SELECT
-      id                              AS src,
-      element_id                      AS dst
+      f.id                            AS src,
+      f.element_id                    AS dst
     FROM {actual_facts} f
+    JOIN postgres_scan('{c}', '{s}', 'elements') e
+      ON e.id = f.element_id
   """
 
   tables["FACT_HAS_PERIOD"] = f"""

--- a/robosystems/operations/information_block/forecast_compute.py
+++ b/robosystems/operations/information_block/forecast_compute.py
@@ -44,7 +44,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from sqlalchemy import select
+from sqlalchemy import and_, not_, select
 
 from robosystems.models.api.fact_provenance import ForecastProvenance
 from robosystems.models.api.information_block import (
@@ -1238,8 +1238,17 @@ def _invalidate_stale_tail(
   of them was chained off a month that has since been replaced, so they
   describe a forecast that no longer exists while reading as current.
 
-  Safe to scope by ``scenario_id`` alone: it points at the owning forecast
-  block, and every set carrying it is produced here.
+  Scoping by ``scenario_id`` alone would be wrong, because not every set
+  carrying it is produced here: the **lever set** is authored by
+  ``_write_lever_fact_set`` at create time and carries the same
+  ``scenario_id``. Its envelope spans the full horizon, so any run asked
+  for fewer months than the horizon — the ``months=horizon-1`` probe, or
+  simply a shorter re-run — would sweep away the very assertions the next
+  ``compute-forecast`` reads, and the block would answer every later
+  request with "has no lever FactSet — the block is corrupt". It is
+  excluded by the pair that identifies it in ``_load_lever_fact_set``:
+  ``structure_id`` equal to the scenario, ``factset_type='custom'``.
+  Computed month sets point at statement structures instead.
 
   Facts cascade with their FactSet at the DB level;
   ``VerificationResult.fact_set_id`` carries no FK, so those rows go
@@ -1251,6 +1260,12 @@ def _invalidate_stale_tail(
         FactSet.scenario_id == scenario_id,
         FactSet.entity_id == entity_id,
         FactSet.period_end > through_period_end,
+        not_(
+          and_(
+            FactSet.structure_id == scenario_id,
+            FactSet.factset_type == "custom",
+          )
+        ),
       )
     )
     .scalars()

--- a/robosystems/operations/roboledger/commands/reports.py
+++ b/robosystems/operations/roboledger/commands/reports.py
@@ -1260,6 +1260,12 @@ def _ensure_shared_elements(
   sender's CoA would be a different (and wrong) situation, and is left for
   the materializer's own guard to absorb rather than dragging a foreign
   chart of accounts across the boundary.
+
+  **Fails closed.** A read failure against the source propagates, and
+  ``_share_to_target``'s handler turns it into a per-recipient error item
+  with the target transaction rolled back. Swallowing it would let the
+  fact-insert loop below write the exact dangling references this function
+  exists to prevent — the original defect, behind a rarer trigger.
   """
   if not element_ids:
     return
@@ -1317,68 +1323,70 @@ def _ensure_shared_elements(
     "is_active",
   )
 
-  try:
-    with extensions_session(source_graph_id) as source_session:
-      taxonomy_ids = [
-        row[0]
-        for row in source_session.execute(
-          text("""
-            SELECT DISTINCT e.taxonomy_id
-            FROM elements e
-            JOIN taxonomies t ON t.id = e.taxonomy_id
-            WHERE e.id = ANY(:ids)
-              AND t.taxonomy_type = 'reporting_extension'
-          """),
-          {"ids": list(missing)},
-        ).fetchall()
-      ]
-      if not taxonomy_ids:
-        logger.warning(
-          f"Shared facts from {source_graph_id} cite {len(missing)} concept(s) "
-          "outside any reporting extension; not copied."
-        )
-        return
+  with extensions_session(source_graph_id) as source_session:
+    taxonomy_ids = [
+      row[0]
+      for row in source_session.execute(
+        text("""
+          SELECT DISTINCT e.taxonomy_id
+          FROM elements e
+          JOIN taxonomies t ON t.id = e.taxonomy_id
+          WHERE e.id = ANY(:ids)
+            AND t.taxonomy_type = 'reporting_extension'
+        """),
+        {"ids": list(missing)},
+      ).fetchall()
+    ]
+    if not taxonomy_ids:
+      logger.warning(
+        f"Shared facts from {source_graph_id} cite {len(missing)} concept(s) "
+        "outside any reporting extension; not copied."
+      )
+      return
 
-      # Detached from the source session before it closes — these become new
-      # rows in a different schema, not attached instances.
-      taxonomies = [
-        ({f: getattr(t, f) for f in _TAX_FIELDS}, dict(t.metadata_ or {}))
-        for t in source_session.execute(
-          select(Taxonomy).where(Taxonomy.id.in_(taxonomy_ids))
-        )
-        .scalars()
-        .all()
-      ]
-      elements = [
-        {f: getattr(e, f) for f in _ELEM_FIELDS}
-        for e in source_session.execute(
-          select(Element)
-          .where(Element.taxonomy_id.in_(taxonomy_ids))
-          .order_by(Element.depth)
-        )
-        .scalars()
-        .all()
-      ]
-  except Exception:
-    logger.warning(
-      f"Could not read shared concepts from {source_graph_id}; the "
-      "recipient's materialization will skip the facts citing them."
-    )
-    return
+    # Detached from the source session before it closes — these become new
+    # rows in a different schema, not attached instances.
+    taxonomies = [
+      ({f: getattr(t, f) for f in _TAX_FIELDS}, dict(t.metadata_ or {}))
+      for t in source_session.execute(
+        select(Taxonomy).where(Taxonomy.id.in_(taxonomy_ids))
+      )
+      .scalars()
+      .all()
+    ]
+    elements = [
+      {f: getattr(e, f) for f in _ELEM_FIELDS}
+      for e in source_session.execute(
+        select(Element).where(Element.taxonomy_id.in_(taxonomy_ids))
+      )
+      .scalars()
+      .all()
+    ]
 
+  existing_taxonomies = {
+    row[0]
+    for row in target_session.execute(
+      text("SELECT id FROM taxonomies WHERE id = ANY(:ids)"),
+      {"ids": [f["id"] for f, _ in taxonomies]},
+    ).fetchall()
+  }
+
+  # Same two-pass shape as the elements below, and for the same reason:
+  # `parent_taxonomy_id` is a self-FK, so an extension whose parent is
+  # another extension in this batch would depend on insert order. It names a
+  # library taxonomy in every case seen so far — but "every case seen so far"
+  # is what the depth ordering relied on too.
+  tax_parents: dict[str, str] = {}
   for fields, metadata in taxonomies:
-    if target_session.get(Taxonomy, fields["id"]):
+    if fields["id"] in existing_taxonomies:
       continue
-    # `parent_taxonomy_id` on an extension names the standard it extends —
-    # a library taxonomy, present in every tenant. Null it rather than fail
-    # the share if the recipient somehow lacks it.
-    if fields["parent_taxonomy_id"] and not target_session.get(
-      Taxonomy, fields["parent_taxonomy_id"]
-    ):
-      fields["parent_taxonomy_id"] = None
+    parent_id = fields.pop("parent_taxonomy_id")
+    if parent_id:
+      tax_parents[fields["id"]] = parent_id
     target_session.add(
       Taxonomy(
         **fields,
+        parent_taxonomy_id=None,
         metadata_={**metadata, "source_graph_id": source_graph_id},
         is_shared=False,
         is_locked=True,
@@ -1387,15 +1395,103 @@ def _ensure_shared_elements(
     )
   target_session.flush()
 
-  # Depth-ordered so a child's self-referencing `parent_id` resolves to a
-  # row already inserted.
-  copied = 0
+  # Wire the parents that resolve; leave the rest null rather than fail the
+  # share over a taxonomy the recipient happens not to have.
+  if tax_parents:
+    resolvable_tax = {
+      row[0]
+      for row in target_session.execute(
+        text("SELECT id FROM taxonomies WHERE id = ANY(:ids)"),
+        {"ids": list(set(tax_parents.values()))},
+      ).fetchall()
+    }
+    for child_id, parent_id in tax_parents.items():
+      if parent_id in resolvable_tax:
+        target_session.execute(
+          text("UPDATE taxonomies SET parent_taxonomy_id = :pid WHERE id = :cid"),
+          {"pid": parent_id, "cid": child_id},
+        )
+    target_session.flush()
+
+  element_ids_in = [f["id"] for f in elements]
+  existing_elements = {
+    row[0]
+    for row in target_session.execute(
+      text("SELECT id FROM elements WHERE id = ANY(:ids)"),
+      {"ids": element_ids_in},
+    ).fetchall()
+  }
+  # `idx_elements_qname` is UNIQUE across the whole tenant, so a second
+  # sender using the same namespace prefix — `acme:` is nobody's reserved
+  # word — would otherwise fail the entire share on a collision neither
+  # party controls. Skip the colliding concept instead; its facts land
+  # without a concept edge, which the materializer's inner join already
+  # absorbs.
+  taken_qnames = {
+    row[0]
+    for row in target_session.execute(
+      text("SELECT qname FROM elements WHERE qname = ANY(:qnames) AND id != ALL(:ids)"),
+      {
+        "qnames": [f["qname"] for f in elements if f["qname"]],
+        "ids": element_ids_in,
+      },
+    ).fetchall()
+  }
+
+  # Two passes, because `parent_id` is a self-FK and **`depth` cannot order
+  # it**: the column defaults to 0 and nothing populates it, so every row in
+  # a tenant carries depth 0 and sorting by it is a no-op. An earlier version
+  # ordered by depth and passed its tests on whatever order the heap happened
+  # to return. Insert parentless, then wire parents that resolve — which also
+  # covers a parent living outside the copied taxonomies (the sender's CoA,
+  # say) without failing the share, matching how `parent_taxonomy_id` is
+  # handled above.
+  parents: dict[str, str] = {}
+  skipped_qname = 0
   for fields in elements:
-    if target_session.get(Element, fields["id"]):
+    if fields["id"] in existing_elements:
       continue
-    target_session.add(Element(**fields, source="linked", created_by=shared_by))
-    copied += 1
+    if fields["qname"] and fields["qname"] in taken_qnames:
+      logger.warning(
+        f"Concept {fields['qname']!r} from {source_graph_id} collides with an "
+        "existing qname in the recipient; skipped."
+      )
+      skipped_qname += 1
+      continue
+    parent_id = fields.pop("parent_id")
+    if parent_id:
+      parents[fields["id"]] = parent_id
+    target_session.add(
+      Element(**fields, parent_id=None, source="linked", created_by=shared_by)
+    )
   target_session.flush()
+
+  resolvable = {
+    row[0]
+    for row in target_session.execute(
+      text("SELECT id FROM elements WHERE id = ANY(:ids)"),
+      {"ids": list(set(parents.values()))},
+    ).fetchall()
+  }
+  for child_id, parent_id in parents.items():
+    if parent_id in resolvable:
+      target_session.execute(
+        text("UPDATE elements SET parent_id = :pid WHERE id = :cid"),
+        {"pid": parent_id, "cid": child_id},
+      )
+  target_session.flush()
+
+  copied = len(elements) - len(existing_elements) - skipped_qname
+  # Concepts cited by a fact but not carried by any copied extension — a
+  # mixed batch copies what it can and drops the rest, so name them rather
+  # than leaving the omission silent.
+  uncovered = missing - {f["id"] for f in elements}
+  if uncovered:
+    logger.warning(
+      f"{len(uncovered)} concept(s) cited by facts from {source_graph_id} "
+      f"belong to no reporting extension and were not copied: "
+      f"{sorted(uncovered)[:5]}"
+    )
 
   logger.info(
     f"Copied {copied} concept(s) in {len(taxonomies)} reporting extension(s) "

--- a/robosystems/operations/roboledger/commands/reports.py
+++ b/robosystems/operations/roboledger/commands/reports.py
@@ -1170,6 +1170,17 @@ def _share_to_target(
       )
       target_session.flush()
 
+      # The concepts have to land before the facts that cite them. A fact
+      # whose element_id resolves nowhere is not a partial delivery — it
+      # takes down the recipient's entire next materialization (see
+      # `_ensure_shared_elements`).
+      _ensure_shared_elements(
+        target_session,
+        source_graph_id,
+        {fd["element_id"] for fd in source_facts if fd.get("element_id")},
+        shared_by,
+      )
+
       for fact_data in source_facts:
         rf = Fact(
           element_id=fact_data["element_id"],
@@ -1209,6 +1220,187 @@ def _share_to_target(
       status="error",
       error="Failed to copy report data.",
     )
+
+
+def _ensure_shared_elements(
+  target_session: Session,
+  source_graph_id: str,
+  element_ids: set[str],
+  shared_by: str,
+) -> None:
+  """Copy the sender's own concepts into the recipient's schema.
+
+  A shared fact carries an ``element_id``, and that column has no foreign
+  key — so a fact citing a concept the recipient has never heard of is
+  written without complaint and only surfaces two steps later, in the
+  graph. **Library concepts are fine**: `copy_library_into_tenant` gives
+  every tenant the same deterministic UUID5 ids, so rs-gaap resolves
+  identically on both sides. The sender's *own* reporting extension does
+  not — those are ``elem_*`` ULIDs minted in the sender's schema alone,
+  and the recipient has no row for them.
+
+  The blast radius is why this is not a cosmetic gap. LadybugDB rejects an
+  edge whose endpoint has no primary key, blue/green treats any table
+  error as a partial run and abandons the whole WIP database, so **one**
+  unresolvable concept stops the recipient's entire graph from
+  materializing — their portfolios and positions included, none of which
+  had anything to do with the share. A disclosure note or a custom metric
+  is enough to trigger it, which makes it the ordinary case rather than an
+  edge one.
+
+  The unit copied is the *taxonomy*, not the individual element: elements
+  carry a self-referencing ``parent_id``, and the abstract head a note
+  hangs off is typically not itself cited by any fact. Copying element-wise
+  would violate that FK on the first note.
+
+  Copies are stamped ``source='linked'``, which is deliberately outside
+  ``COA_SOURCES``. The recipient needs the sender's concepts to read the
+  report; they must never appear in the recipient's own chart of accounts.
+  Only ``reporting_extension`` taxonomies travel — a fact citing the
+  sender's CoA would be a different (and wrong) situation, and is left for
+  the materializer's own guard to absorb rather than dragging a foreign
+  chart of accounts across the boundary.
+  """
+  if not element_ids:
+    return
+
+  from robosystems.db.extensions import extensions_session
+  from robosystems.models.extensions import Element, Taxonomy
+
+  present = {
+    row[0]
+    for row in target_session.execute(
+      text("SELECT id FROM elements WHERE id = ANY(:ids)"),
+      {"ids": list(element_ids)},
+    ).fetchall()
+  }
+  missing = element_ids - present
+  if not missing:
+    return
+
+  # Copied field-by-field rather than by raw INSERT: half of both tables is
+  # NOT NULL with a Python-side default and no database default, so a
+  # hand-written column list is wrong the day someone adds a column.
+  # Constructing the models lets those defaults apply.
+  _TAX_FIELDS = (
+    "id",
+    "name",
+    "description",
+    "taxonomy_type",
+    "version",
+    "standard",
+    "namespace_uri",
+    "parent_taxonomy_id",
+    "extension_type",
+    "effective_date",
+  )
+  _ELEM_FIELDS = (
+    "id",
+    "code",
+    "name",
+    "description",
+    "qname",
+    "namespace",
+    "uri",
+    "balance_type",
+    "period_type",
+    "substitution_group",
+    "is_abstract",
+    "is_monetary",
+    "element_type",
+    "item_type",
+    "taxonomy_id",
+    "parent_id",
+    "depth",
+    "path",
+    "currency",
+    "is_active",
+  )
+
+  try:
+    with extensions_session(source_graph_id) as source_session:
+      taxonomy_ids = [
+        row[0]
+        for row in source_session.execute(
+          text("""
+            SELECT DISTINCT e.taxonomy_id
+            FROM elements e
+            JOIN taxonomies t ON t.id = e.taxonomy_id
+            WHERE e.id = ANY(:ids)
+              AND t.taxonomy_type = 'reporting_extension'
+          """),
+          {"ids": list(missing)},
+        ).fetchall()
+      ]
+      if not taxonomy_ids:
+        logger.warning(
+          f"Shared facts from {source_graph_id} cite {len(missing)} concept(s) "
+          "outside any reporting extension; not copied."
+        )
+        return
+
+      # Detached from the source session before it closes — these become new
+      # rows in a different schema, not attached instances.
+      taxonomies = [
+        ({f: getattr(t, f) for f in _TAX_FIELDS}, dict(t.metadata_ or {}))
+        for t in source_session.execute(
+          select(Taxonomy).where(Taxonomy.id.in_(taxonomy_ids))
+        )
+        .scalars()
+        .all()
+      ]
+      elements = [
+        {f: getattr(e, f) for f in _ELEM_FIELDS}
+        for e in source_session.execute(
+          select(Element)
+          .where(Element.taxonomy_id.in_(taxonomy_ids))
+          .order_by(Element.depth)
+        )
+        .scalars()
+        .all()
+      ]
+  except Exception:
+    logger.warning(
+      f"Could not read shared concepts from {source_graph_id}; the "
+      "recipient's materialization will skip the facts citing them."
+    )
+    return
+
+  for fields, metadata in taxonomies:
+    if target_session.get(Taxonomy, fields["id"]):
+      continue
+    # `parent_taxonomy_id` on an extension names the standard it extends —
+    # a library taxonomy, present in every tenant. Null it rather than fail
+    # the share if the recipient somehow lacks it.
+    if fields["parent_taxonomy_id"] and not target_session.get(
+      Taxonomy, fields["parent_taxonomy_id"]
+    ):
+      fields["parent_taxonomy_id"] = None
+    target_session.add(
+      Taxonomy(
+        **fields,
+        metadata_={**metadata, "source_graph_id": source_graph_id},
+        is_shared=False,
+        is_locked=True,
+        created_by=shared_by,
+      )
+    )
+  target_session.flush()
+
+  # Depth-ordered so a child's self-referencing `parent_id` resolves to a
+  # row already inserted.
+  copied = 0
+  for fields in elements:
+    if target_session.get(Element, fields["id"]):
+      continue
+    target_session.add(Element(**fields, source="linked", created_by=shared_by))
+    copied += 1
+  target_session.flush()
+
+  logger.info(
+    f"Copied {copied} concept(s) in {len(taxonomies)} reporting extension(s) "
+    f"from {source_graph_id} alongside the shared report."
+  )
 
 
 def _ensure_linked_entity(

--- a/tests/operations/information_block/test_forecast_compute.py
+++ b/tests/operations/information_block/test_forecast_compute.py
@@ -1182,6 +1182,42 @@ class TestStaleTailInvalidation:
     assert vr[0] in deleted
     assert stale[0] in deleted and stale[1] in deleted
 
+  def test_the_lever_set_is_never_swept(self) -> None:
+    """The authored levers must survive a run shorter than the horizon.
+
+    The lever FactSet carries the same ``scenario_id`` as the computed
+    months but is authored at create time, and its envelope spans the full
+    horizon — so a ``months=horizon-1`` probe (or any shorter re-run) used
+    to delete the very assertions the next ``compute-forecast`` reads,
+    leaving the block answering "has no lever FactSet — the block is
+    corrupt" forever after.
+    """
+    from datetime import date
+
+    session = self._session_with([])
+    fc._invalidate_stale_tail(
+      session,
+      scenario_id="struct_budget",
+      entity_id="ent_1",
+      through_period_end=date(2026, 9, 30),
+    )
+
+    predicate = " ".join(
+      str(
+        session.execute.call_args_list[0]
+        .args[0]
+        .whereclause.compile(compile_kwargs={"literal_binds": True})
+      ).split()
+    )
+    # The lever set is identified in `_load_lever_fact_set` by structure_id
+    # == scenario and factset_type == 'custom'; the sweep has to negate that
+    # same pair, or it deletes it.
+    assert "NOT" in predicate, f"sweep has no exclusion at all: {predicate}"
+    assert "structure_id" in predicate and "'custom'" in predicate, (
+      "the sweep must exclude the authored lever set by the pair that "
+      f"identifies it; predicate was: {predicate}"
+    )
+
   def test_no_tail_is_a_no_op(self) -> None:
     from datetime import date
 


### PR DESCRIPTION
## Summary

Adds the first end-to-end demo for RoboInvestor, which is also the first that crosses a graph boundary — and fixes the three defects it found on the way. `ref/roboinvestor.md` §6 names the absence of exactly this demo as the reason a whole-domain staleness defect survived six months: nothing in the development loop ever produced a pure-investor graph, so nothing ever exercised the cross-graph seam.

The demo ends in 31 hard assertions and exits non-zero on any failure, so it doubles as a pre-release gate.

## Changes

### The demo — `examples/roboinvestor_demo/`

Meridian Ventures Fund I holds five private instruments (Series A preferred, a bridge warrant, a post-money SAFE, LLC units, and a seed position disposed mid-run). Two are issued by Cadence Labs, which keeps its books on this platform, so the fund pre-associates them by `source_graph_id` before any link exists. Cadence then shares its filed annual report into the fund's graph, which creates the linked entity, resolves both securities, and makes the traversal executable:

```
Portfolio → Position → Security → Entity → Report → Fact
```

- The issuer is the existing `saas_startup` scenario, provisioned inline on first run and reused after. `saas_startup_demo.main` now takes an `argv` so the caller's flags don't leak in as scenario flags.
- The investor graph is provisioned with `roboledger` as well as `roboinvestor`, because `add-publish-list-members` rejects any target that doesn't declare it. An investor keeps no books, so that predicate really wants to be "target can receive reports" — provisioned rather than worked around, so the constraint stays visible.
- Two assertions exist specifically because their absence went unnoticed: that every RoboInvestor write marks its graph stale, and that the stale *reason* came from a RoboInvestor operation rather than a ledger one that would mask it on a dual-schema graph.
- Everything goes through the HTTP API via the SDK facades. `_reset.py` is the sole direct-DB path and deliberately has no product surface.

### Cross-graph share: carry the sender's concepts — **please review closely**

A shared report copies facts, and every fact cites a concept. Library concepts resolve on both sides (`copy_library_into_tenant` gives every tenant the same deterministic UUID5 ids); the sender's own reporting extension does not — those are `elem_*` ULIDs minted in the sender's schema alone. `facts.element_id` carries no foreign key, so the share wrote them without complaint.

It surfaced two steps later, as everything: LadybugDB rejects an edge whose endpoint has no primary key, blue/green answers any table error by abandoning the whole WIP database, so one unresolvable concept stopped the recipient's entire graph from materializing — their own portfolios, securities and positions included. Reproduced with 6 of 85 shared facts; the recipient's graph came back `node_count: 0`. A disclosure note or a custom metric is enough to trigger it, which makes it the ordinary case.

- `_ensure_shared_elements` copies the sender's `reporting_extension` taxonomies alongside the report. **This widens what crosses the graph boundary on a share** — previously facts and the parent entity's metadata, now the concepts those facts cite. It stays inside an authorised share (the sender chose the recipient via a publish list) and is scoped to reporting extensions only; a fact citing the sender's chart of accounts is logged and skipped rather than dragging a foreign CoA across. Worth a second opinion on the boundary call.
- Copies are stamped `source='linked'`, deliberately outside `COA_SOURCES`, so the recipient can read the sender's concepts without the sender's revenue accounts appearing in the recipient's own chart of accounts. Mirrors `Entity.source='linked'`.
- The unit copied is the taxonomy, not the individual element: elements carry a self-referencing `parent_id`, and the abstract head a note hangs off is typically cited by no fact at all.
- `FACT_HAS_ELEMENT` now inner-joins `elements`, so any residual dangling reference drops one edge instead of a whole graph. The write paths own not creating the dangle; the materializer should not answer one bad id with total loss.

**Migration `0029` widens `check_element_source` to admit `'linked'` and must be applied before the code that writes it** — `just migrate-up extensions`.

### Forecast: the stale-tail sweep deleted its own levers

`_invalidate_stale_tail` scoped by `scenario_id` alone, on the stated assumption that "every set carrying it is produced here". The lever FactSet is authored by `_write_lever_fact_set` at create time, carries the same `scenario_id`, and spans the full horizon — so any run asked for fewer months than the horizon swept away the very assertions the next run reads, and the block answered every later `compute-forecast` with "has no lever FactSet — the block is corrupt", permanently. Now excluded by the same pair `_load_lever_fact_set` identifies it with. Regression test added.

### Demos: typed SDK reads, and a reset that predates `fact_dimensions`

- Eleven call sites still read 1.0-client GraphQL results as dicts (`list_elements`, `list_taxonomies`, `list_structures`, `list_information_blocks`, `get_report_package`). Each raises `AttributeError` on first contact, so every demo that maps a chart of accounts died at its mapping step: `demo-roboledger`, `demo-coffee-roaster`, `demo-saas-startup`, and both Seattle Method demos. An AST sweep over `examples/` is now clean.
- `fact_dimensions.dimension_id` is `ON DELETE RESTRICT` and both scenario resets drop `dimensions` before `facts`, so a re-run over any graph whose forecast had produced scenario facts died on the FK. Latent until now, because the forecast step was unreachable behind the item above.

## Breaking Changes

None. No GraphQL schema, operations envelope, or REST shape changed, so no client SDK regen is required by this PR.

One additive behaviour worth noting for consumers: elements can now carry `source='linked'`, so recipients of a shared report will see the sender's extension concepts in `list_elements`. `source` is an open string field and chart-of-accounts reads filter on `COA_SOURCES`, which excludes `'linked'` — so CoA, account rollups and fact-grid CoA resolution are unaffected.

## Testing

- `just test-all` — **12,408 passed, 23 skipped, 0 failed** (291s), plus ruff, format, basedpyright and cf-lint all clean.
- `just demo-roboinvestor` — **31/31 checks, exit 0**, against a local stack. The traversal returns Cadence Labs' reported facts against the fund's holdings.
- `just demo-roboinvestor --skip-share` — 22/22, isolating the portfolio surface from the handshake.
- `just demo-roboinvestor --reload-issuer` — full issuer ledger rebuild, confirming the forecast and reset fixes on the path that previously died.
- `just migrate-up extensions` — 0029 applied cleanly against the local extensions database.

Both failure modes were reproduced before fixing and confirmed gone after: the recipient graph at `node_count: 0`, and the 422 from a forecast whose lever set had been swept.
