### PR TITLE
docs: cover the end-to-end run and its migration in the v1.8.0 notes

### DIFF
--- a/.github/release-notes/v1.8.0.md
+++ b/.github/release-notes/v1.8.0.md
@@ -1,7 +1,9 @@
 v1.8.0 closes the 1.7 series. It is the release where the data-protection story became real —
 backups that run on a schedule, carry the right contents, and can be opened — and where two surfaces
 that had been advertised without being finished, subgraphs and cross-graph report sharing, were
-either completed or given the controls they needed.
+either completed or given the controls they needed. The last of those was then run end to end for
+the first time, which is how three defects in it — and around it — were found and fixed before a
+customer met them.
 
 Covers everything since v1.7.0; the 1.7.x patches carried generated changelogs.
 
@@ -103,6 +105,36 @@ Also fixed: a security's cross-graph attribution was read from its linked entity
 security's own column, so a security registered against an issuer it had not yet been linked to
 materialized with no attribution — exactly the pre-link state the cross-graph design depends on.
 
+## The cross-graph path, run end to end
+
+The controls above make the seam safe. Running it end to end is what showed it did not work.
+
+A shared report carries facts, and every fact names a concept. Concepts from the standard taxonomy
+resolve on both sides, because every graph seeds them with identical identifiers. A company's **own**
+extension concepts — the ones behind its disclosure notes and custom metrics — exist only in its own
+books, and those were being copied across as bare references to rows the recipient did not have.
+
+The consequence was wildly out of proportion to the cause. The analytical graph refuses a
+relationship whose endpoint is missing, and a rebuild that hits any error is abandoned whole — so a
+single unresolvable concept stopped the recipient's **entire** graph from rebuilding, including
+everything that had nothing to do with the share. One disclosure note in the sender's report was
+enough to do it. A share now carries the sender's reporting extensions with it, marked so the
+recipient can read them without them appearing in their own chart of accounts, and a rebuild that
+still meets an unknown concept now drops that one relationship instead of the graph.
+
+Two more surfaced in the same run. A forecast computed for fewer months than its horizon **deleted
+its own lever assertions**: the trim that clears months past the end of a run could not distinguish
+the authored levers from the computed results, because both carry the scenario's identifier, and the
+levers span the whole horizon. Any scenario computed short was left permanently uncomputable. And
+every demo that maps a chart of accounts had been broken since the SDK began returning typed read
+results — which is the reason none of the above had been seen.
+
+The run itself is new. `just demo-roboinvestor` builds a venture fund holding private instruments in
+a company that keeps its books on the platform, then has that company publish a report into the
+fund's graph, ending in the traversal the product exists for: a portfolio position, to the security,
+to the issuing company, to their filed report, to its facts. It closes with 31 assertions and exits
+non-zero, so it is a gate rather than a walkthrough.
+
 ## Corrected claims
 
 The extension catalog described RoboInvestor as offering trade execution, risk analysis, market data,
@@ -114,12 +146,12 @@ of the product than the version that named a public-equity feature set.
 
 ## Fixes
 
-Forecast scenarios stopped walking past their stale tail and gained a scenario dimension; period
-comparatives resolve the prior calendar period correctly; the fact-provenance arms and rule-expression
-grammar were unified; adapter element qnames self-heal; provisioning gained idempotency and a correct
-failure disposition; repository credit reallocation, connection sync-result recording, and the
-Dagster worker host were all corrected. A dead pricing service and a shadowed storage metric were
-deleted rather than maintained.
+Forecast scenarios gained a scenario dimension and stopped walking past their stale tail — the trim
+that does the stopping is the one corrected above. Period comparatives resolve the prior calendar
+period correctly; the fact-provenance arms and rule-expression grammar were unified; adapter element
+qnames self-heal; provisioning gained idempotency and a correct failure disposition; repository
+credit reallocation, connection sync-result recording, and the Dagster worker host were all
+corrected. A dead pricing service and a shadowed storage metric were deleted rather than maintained.
 
 ## Monitoring
 
@@ -133,7 +165,10 @@ nothing happening.
 ## Deploying this release
 
 - **Migrations on both databases.** Platform: graph-backup initiator, API-key graph scope, connection
-  sync result. Extensions: fact dimensions, scenario-dimension backfill, and the share block list.
+  sync result. Extensions: fact dimensions, scenario-dimension backfill, the share block list, and
+  the linked-concept source that lets a shared report carry the sender's reporting extension.
+  **Apply the extensions migrations before the API rolls** — without the last one, a share carrying
+  extension concepts is rejected rather than delivered.
 - **CloudFormation stack updates**: `dagster`, `postgres`, `s3`, `worker`, and `security` — the last
   carries the new API error and notification-delivery alarms, and reads a new
   `API_TARGET_ERROR_THRESHOLD` repository variable.


### PR DESCRIPTION
## Summary

Brings the curated v1.8.0 release notes up to date with #1122, which merged after they were last written. The curated file replaces the generated changelog at the tagged ref, so anything absent from it is not under-described — it is uncommunicated.

## Changes

### The deploy section was missing migration 0029

It enumerated the extensions migrations and stopped at the share block list (0028). `0029_linked_element_source` widens `check_element_source` to admit `'linked'`, and the share path writes that value — so on a deploy without it, every share carrying a sender's extension concepts is **rejected rather than delivered**. That is the feature this release leads with.

Added to the list, with the ordering stated explicitly rather than left to inference: apply the extensions migrations before the API rolls.

### A new section on the end-to-end run

Written from the customer's side — what broke and what it cost — with the demo as the thing that surfaced it rather than the subject:

- A shared report carried facts referencing the sender's own extension concepts, which exist only in the sender's books. One unresolvable concept stopped the recipient's **entire** graph from rebuilding, including data unrelated to the share; a single disclosure note was enough.
- A forecast computed for fewer months than its horizon deleted its own lever assertions, leaving the scenario permanently uncomputable.
- Every demo that maps a chart of accounts had been broken since the SDK began returning typed read results — which is why none of the above had been seen.

### The Fixes section contradicted itself

It credited forecast scenarios with no longer walking past their stale tail, without noting that the trim doing the stopping was itself the defect fixed in this release. Reconciled so the release does not advertise a feature and silently omit its correction.

The opening paragraph gained one clause so the summary reflects the arc.

## Breaking Changes

None. Documentation only — no code, schema, or API surface is touched.

## Testing

`just test-code` — ruff, format, basedpyright and cf-lint all clean. No test run is applicable to a documentation-only change; the code this describes was verified in #1122 (`just test-all`: 12,408 passed, and the demo at 31/31).

Line widths match the file's existing ~100-column convention.
