### PR TITLE
fix: v1.8.0 release blockers — cross-graph share delivery, access-log redaction, download quota

### DIFF
--- a/.github/release-notes/v1.8.0.md
+++ b/.github/release-notes/v1.8.0.md
@@ -21,7 +21,17 @@ carries the sender's user id. A sender can **revoke** a delivered copy, wiring a
 that had been declared since the feature shipped and never used.
 
 Sharing also now marks the recipient's graph stale, so a shared report actually materializes rather
-than waiting for unrelated activity to trigger a rebuild.
+than waiting for unrelated activity to trigger a rebuild. Revoking and purging mark it too — the
+withdrawal has to reach the graph as surely as the delivery did.
+
+Two more things the cross-graph path needed before it could be trusted. A shared report now carries
+its **own taxonomy** across, not just the taxonomies its facts happen to cite: a report built on the
+sender's reporting extension whose facts are all standard concepts used to arrive referencing a
+taxonomy that existed only in the sender's schema, and the recipient's next rebuild would fail whole
+rather than lose one edge. And **revoking a report survives the recipient being deleted.** Withdrawal
+had to open the recipient's schema to remove the copy, so once that schema was gone the share could
+never be stamped revoked — and a report with an active share cannot be deleted, which left the sender
+permanently unable to either withdraw or delete a report whose only recipient no longer existed.
 
 ## Backups
 
@@ -101,6 +111,14 @@ incidental rather than guaranteed. All are fixed, and a structural test now hold
 every operation either marks its graph or is listed as exempt with the table it writes and the reason
 the graph never reads it.
 
+The first version of that test only saw the operations declared through the registrar — 26 of
+roboledger's 48 — which is how `update-entity` kept editing materialized company details without
+ever marking its graph, while a test named for the whole surface passed. The guard now enumerates
+the hand-written routes too, and each must say which of the three things it is: it marks in its own
+handler, it delegates to a command or tool that marks, or it is exempt with the table named. Two
+more gaps closed on the way in: `update-entity`, and the mapping tool the `auto-map-elements`
+operator writes through, which is hand-written and so never inherited the registrar's mark.
+
 Also fixed: a security's cross-graph attribution was read from its linked entity instead of the
 security's own column, so a security registered against an issuer it had not yet been linked to
 materialized with no attribution — exactly the pre-link state the cross-graph design depends on.
@@ -167,8 +185,11 @@ nothing happening.
 - **Migrations on both databases.** Platform: graph-backup initiator, API-key graph scope, connection
   sync result. Extensions: fact dimensions, scenario-dimension backfill, the share block list, and
   the linked-concept source that lets a shared report carry the sender's reporting extension.
-  **Apply the extensions migrations before the API rolls** — without the last one, a share carrying
-  extension concepts is rejected rather than delivered.
+  Both sets run automatically when the new Dagster daemon boots, which is concurrent with the API
+  rollout rather than ahead of it. Expect a short window where the new API is serving against the old
+  schema: a share carrying extension concepts is **rejected rather than delivered** until the daemon
+  comes up. It fails closed — the recipient gets a per-target error and the transaction rolls back —
+  so the window costs a retry, not data. Nothing else in the release depends on the new columns.
 - **CloudFormation stack updates**: `dagster`, `postgres`, `s3`, `worker`, and `security` — the last
   carries the new API error and notification-delivery alarms, and reads a new
   `API_TARGET_ERROR_THRESHOLD` repository variable.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # RoboSystems
 
-RoboSystems is an open-source, AI-native financial intelligence platform for accounting, financial reporting, and investment management. It models your financial data as a **knowledge graph** — transactions, facts, reporting elements, and the calculation structures that relate them are all nodes and edges, with the semantics preserved rather than flattened into rows you query around. On top of that graph it gives AI agents and analysts a ledger-grade system of record they can both query and operate — closing the books, producing reports, and analyzing portfolios across accounting, market, and SEC data. Powers [RoboLedger](https://roboledger.ai) and [RoboInvestor](https://roboinvestor.ai).
+RoboSystems is an open-source, AI-native financial intelligence platform for accounting, financial reporting, and investment management. It models your financial data as a **knowledge graph** — transactions, facts, reporting elements, and the calculation structures that relate them are all nodes and edges, with the semantics preserved rather than flattened into rows you query around. On top of that graph it gives AI agents and analysts a ledger-grade system of record they can both query and operate — closing the books, producing reports, and analyzing portfolios across your own ledger, your holdings, and SEC public filings queryable alongside them. Powers [RoboLedger](https://roboledger.ai) and [RoboInvestor](https://roboinvestor.ai).
 
 **Every tenant gets their own graph.** Not a row-level slice of a shared table — a dedicated graph database on its own instance, with a dedicated OLTP schema behind it. Your ontology, your taxonomies, and your calculation structures live in it as artifacts you can read, export, and take with you.
-
-Open source top to bottom — the accounting ontology, reporting taxonomies, and calculation structures are inspectable, portable artifacts you own, not configuration trapped in a vendor platform: [semantic sovereignty](https://robosystems.ai/blog/semantic-sovereignty) for your financial data.
 
 ## Platform
 
@@ -174,6 +172,8 @@ See the **[Bootstrap Guide](https://github.com/RoboFinSystems/robosystems/wiki/B
 ## Architecture
 
 Built end-to-end on open-source engines — PostgreSQL, LadybugDB, DuckDB, LanceDB, OpenSearch, and Valkey — assembled into a transactional core with a materialized analytical graph and integrated vector search, with no proprietary database lock-in.
+
+That openness runs up the stack as well as down: the accounting ontology, reporting taxonomies, and calculation structures are inspectable, portable artifacts you own, not configuration trapped in a vendor platform — [semantic sovereignty](https://robosystems.ai/blog/semantic-sovereignty) for your financial data.
 
 ### Multi-Tenancy & Isolation
 

--- a/examples/_scenario/runner.py
+++ b/examples/_scenario/runner.py
@@ -850,9 +850,9 @@ def update_disclosure_notes(graph_id: str, notes: list[dict]) -> int:
     return 0
 
   taxonomies = client.list_taxonomies(graph_id, taxonomy_type="reporting_extension")
-  by_name = {t.get("name"): t for t in taxonomies}
+  by_name = {t.name: t for t in taxonomies}
   structures = client.list_structures(graph_id, block_type="regulatory_disclosure")
-  structure_by_name = {s.get("name"): s for s in structures}
+  structure_by_name = {s.name: s for s in structures}
 
   added = 0
   for note in updates:
@@ -904,14 +904,16 @@ def update_disclosure_notes(graph_id: str, notes: list[dict]) -> int:
     rollups = [
       r for r in (block.rules if block else []) if r.rule_pattern == "RollUp"
     ]
+    # `rule_variables` is typed `list[RuleVariableLite] | Unset`, and `Unset`
+    # defines neither `__iter__` nor `__len__` — iterating or measuring it
+    # raises TypeError rather than reading as empty. Its `__bool__` is False,
+    # so `or []` restores the guard the dict-era `.get(...) or []` provided.
+    rule_vars = [(r.rule_variables or []) for r in rollups]
     refreshed = any(
-      member["qname"]
-      in {v.get("variable_qname") for v in (r.get("rule_variables") or [])}
-      for r in rollups
+      member["qname"] in {v.variable_qname for v in variables}
+      for variables in rule_vars
     )
-    child_count = max(
-      (len(r.get("rule_variables") or []) - 1 for r in rollups), default=0
-    )
+    child_count = max((len(variables) - 1 for variables in rule_vars), default=0)
     if not refreshed:
       print(
         f"  ERROR: footing rule for {note['name']!r} was NOT refreshed "

--- a/examples/roboledger_demo/validate.py
+++ b/examples/roboledger_demo/validate.py
@@ -382,11 +382,11 @@ class _Validator:
     # orphan draft in the very period the demo then tells the user to close, so
     # it would post as a spurious extra closing entry. Clean it up here.
     try:
-      drafts = client.list_period_drafts(self.graph_id, close_target) or {}
+      drafts = client.list_period_drafts(self.graph_id, close_target)
       disposal_ids = [
-        d.get("entry_id")
-        for d in drafts.get("drafts", [])
-        if d.get("memo") == "Validation disposal" and d.get("entry_id")
+        d.entry_id
+        for d in (drafts.drafts if drafts else [])
+        if d.memo == "Validation disposal" and d.entry_id
       ]
       for eid in disposal_ids:
         client.delete_journal_entry(self.graph_id, eid)

--- a/examples/seattle_method_demo/load_taxonomy.py
+++ b/examples/seattle_method_demo/load_taxonomy.py
@@ -420,9 +420,9 @@ def upload_taxonomy(graph_id: str, elements: list[dict]) -> str:
 
   existing_taxonomies = client.list_taxonomies(graph_id) or []
   for tax in existing_taxonomies:
-    if (tax.get("name") or "").lower().startswith("seattle method"):
-      print(f"  Reusing existing mini CoA taxonomy: {tax.get('id')}")
-      return tax.get("id")
+    if (tax.name or "").lower().startswith("seattle method"):
+      print(f"  Reusing existing mini CoA taxonomy: {tax.id}")
+      return tax.id
 
   envelope = client.create_taxonomy_block(
     graph_id,

--- a/main.py
+++ b/main.py
@@ -28,6 +28,7 @@ from robosystems.middleware.database import DatabaseSessionMiddleware
 from robosystems.middleware.logging import (
   SecurityLoggingMiddleware,
   StructuredLoggingMiddleware,
+  install_uvicorn_log_redaction,
 )
 from robosystems.middleware.otel import setup_telemetry
 from robosystems.middleware.otel.metrics import (
@@ -161,6 +162,11 @@ async def lifespan(app: FastAPI):
 
 def create_app() -> FastAPI:
   """Build the configured FastAPI application."""
+  # Before anything can serve a request: Uvicorn's own access log writes the
+  # raw query string, which the application's redaction never reaches, and the
+  # MCP connector auth deliberately carries a graph-scoped key there.
+  install_uvicorn_log_redaction()
+
   # Load description from markdown file in static folder
   description_file = Path(__file__).parent / "static" / "description.md"
   api_description = (

--- a/robosystems/config/defaults.py
+++ b/robosystems/config/defaults.py
@@ -201,6 +201,12 @@ class SSEDefaults:
 
   MAX_CONNECTIONS_PER_USER = 5  # Max concurrent SSE connections per user
   QUEUE_SIZE = 100  # Event queue size per connection
+  # Seconds of event silence before the stream emits a keepalive. Must stay
+  # comfortably below the client read timeout (the Python SDK's SSE client
+  # defaults to 30s) — an operation that runs longer than this without
+  # emitting progress otherwise races the client's timeout and the client
+  # drops a job that is still running server-side.
+  KEEPALIVE_INTERVAL = 10
 
 
 class LimitsDefaults:

--- a/robosystems/db/extensions.py
+++ b/robosystems/db/extensions.py
@@ -430,6 +430,35 @@ def provision_tenant_schema(graph_id: str) -> None:
     conn.commit()
 
 
+def tenant_schema_exists(graph_id: str) -> bool:
+  """Whether ``graph_id`` still has a tenant schema in the extensions DB.
+
+  Cross-graph paths need this because ``extensions_session`` cannot tell
+  them: ``SET search_path`` to a schema that does not exist is legal in
+  PostgreSQL and only fails later, on the first query, as an ordinary
+  ``ProgrammingError`` indistinguishable from a genuine schema fault. Code
+  that must distinguish "the recipient was deprovisioned" from "something is
+  broken" has to ask up front — see ``_delete_shared_copy``.
+
+  Returns ``False`` when no extension domain is enabled or when ``graph_id``
+  is not a tenant-schema id (subgraphs share their parent's schema).
+  """
+  if not env.EXTENSIONS_ENABLED:
+    return False
+  if not _VALID_SCHEMA_PATTERN.match(graph_id):
+    return False
+
+  engine = _get_engine()
+  with engine.connect() as conn:
+    return (
+      conn.execute(
+        text("SELECT 1 FROM information_schema.schemata WHERE schema_name = :name"),
+        {"name": graph_id},
+      ).first()
+      is not None
+    )
+
+
 def drop_tenant_schema(graph_id: str) -> bool:
   """Drop a tenant's extensions OLTP schema and everything in it.
 

--- a/robosystems/middleware/logging.py
+++ b/robosystems/middleware/logging.py
@@ -4,6 +4,7 @@ This middleware captures all API requests and responses with structured
 logging that's optimized for CloudWatch searching and cost management.
 """
 
+import logging
 import time
 import uuid
 from collections.abc import Callable
@@ -56,6 +57,58 @@ def redact_sensitive_query_params(query_string: str) -> str:
   except Exception:
     # If parsing fails, return empty string to avoid exposing raw query
     return ""
+
+
+class UvicornAccessRedactionFilter(logging.Filter):
+  """Redact sensitive query parameters from Uvicorn's own access log.
+
+  Everything else in this module redacts *application* logging, which is not
+  the whole surface: the API runs with ``--access-log``, and Uvicorn writes
+  its own line straight from the ASGI scope —
+
+      '%s - "%s %s HTTP/%s" %d' % (client, method, path_with_query, ver, code)
+
+  — where ``path_with_query`` is the raw query string. Nothing in the app can
+  reach that record, so a secret in a URL lands in the access log intact no
+  matter how carefully the app logs.
+
+  That matters because the MCP connector auth deliberately accepts a
+  graph-scoped key as a ``token`` query parameter: claude.ai and Claude
+  Desktop custom connectors cannot send custom headers, so the URL is the only
+  place the credential can ride. Redacting it here keeps the access log — the
+  alternative was turning ``--access-log`` off and losing it.
+
+  Installed on the ``uvicorn.access`` logger by ``install_uvicorn_log_redaction``.
+  """
+
+  def filter(self, record: logging.LogRecord) -> bool:
+    args = record.args
+    # Uvicorn's access record: the third arg is the path (+ query string).
+    if isinstance(args, tuple) and len(args) >= 3 and isinstance(args[2], str):
+      path = args[2]
+      if "?" in path:
+        base, _, query = path.partition("?")
+        safe_query = redact_sensitive_query_params(query)
+        record.args = (
+          *args[:2],
+          f"{base}?{safe_query}" if safe_query else base,
+          *args[3:],
+        )
+    return True
+
+
+def install_uvicorn_log_redaction() -> None:
+  """Attach the access-log redaction filter, idempotently.
+
+  Called from application startup rather than the entrypoint so it holds for
+  every way the app is served — the container's `uvicorn` invocation, a local
+  `uv run uvicorn`, and the test client alike.
+  """
+  access_logger = logging.getLogger("uvicorn.access")
+  if not any(
+    isinstance(f, UvicornAccessRedactionFilter) for f in access_logger.filters
+  ):
+    access_logger.addFilter(UvicornAccessRedactionFilter())
 
 
 def get_safe_url_for_logging(request: Request) -> str:

--- a/robosystems/middleware/mcp/tools/taxonomy_tools.py
+++ b/robosystems/middleware/mcp/tools/taxonomy_tools.py
@@ -20,6 +20,7 @@ from robosystems.logger import logger
 from robosystems.models.api.extensions.taxonomies import (
   CreateMappingAssociationOperation,
 )
+from robosystems.operations.extensions.staleness import mark_graph_stale
 from robosystems.operations.roboledger.commands.taxonomies import (
   create_mapping_association,
 )
@@ -477,12 +478,18 @@ class CreateMappingAssociationTool:
       )
       with extensions_session(graph_id) as session:
         result = create_mapping_association(session, body, created_by="mapping-agent")
-        return {
-          "association_id": result.id,
-          "from_element_id": result.from_element_id,
-          "to_element_id": result.to_element_id,
-          "confidence": result.confidence,
-        }
+      # The registrar-published tools get this from `OperationSpec`; this one
+      # is hand-written and reaches the command directly, so it has to mark
+      # the graph itself. Associations are materialized, and `auto-map-elements`
+      # writes its whole mapping run through this tool — without the mark the
+      # operator's work never reaches LadybugDB.
+      mark_graph_stale(graph_id, "mapping_association_created")
+      return {
+        "association_id": result.id,
+        "from_element_id": result.from_element_id,
+        "to_element_id": result.to_element_id,
+        "confidence": result.confidence,
+      }
     except Exception as exc:
       logger.warning(f"create-mapping-association failed: {exc}")
       return {"error": str(exc)}

--- a/robosystems/middleware/sse/streaming.py
+++ b/robosystems/middleware/sse/streaming.py
@@ -15,6 +15,7 @@ from fastapi import HTTPException, Request
 from sse_starlette.sse import EventSourceResponse
 
 from robosystems.config import env
+from robosystems.config.defaults import SSEDefaults
 from robosystems.config.tuning import TuningConfig
 from robosystems.logger import logger
 from robosystems.middleware.sse.event_storage import (
@@ -350,7 +351,9 @@ async def create_sse_stream_starlette(
         break
 
       try:
-        event = await asyncio.wait_for(event_queue.get(), timeout=30.0)
+        event = await asyncio.wait_for(
+          event_queue.get(), timeout=SSEDefaults.KEEPALIVE_INTERVAL
+        )
 
         yield {
           "event": str(event.event_type),

--- a/robosystems/operations/aws/s3.py
+++ b/robosystems/operations/aws/s3.py
@@ -836,7 +836,11 @@ class S3BackupAdapter:
         backup_duration_seconds=metadata.get("backup_duration_seconds", 0.0),
         database_version=metadata.get("database_version")
         or metadata.get("lbug_version"),
-        backup_format="full_dump",
+        # The caller already puts the requested format in `metadata`; reading
+        # it here rather than hardcoding keeps the stored record honest the
+        # first time a format other than a full dump is offered. Latent today
+        # — the public create route accepts full dumps only.
+        backup_format=metadata.get("backup_format", "full_dump"),
         s3_key=backup_path,
         s3_metadata_key=metadata_path,
         memory=metadata.get("memory"),

--- a/robosystems/operations/extensions/materialize.py
+++ b/robosystems/operations/extensions/materialize.py
@@ -1107,13 +1107,22 @@ def _staging_sql(graph_id: str, entity_id: str, connstr: str) -> dict[str, str]:
       AND rd.source_graph_id IS NOT NULL
   """
 
+  # Inner-joined to `taxonomies` for the same reason as `FACT_HAS_ELEMENT`
+  # below: `reports.taxonomy_id` carries no foreign key, so a report whose
+  # taxonomy is absent from this schema — the cross-graph share case, where
+  # the sender's reporting extension may not have travelled — reaches here
+  # intact and costs the recipient their entire rebuild. Dropping the one
+  # edge is the proportionate response; `_ensure_shared_elements` is
+  # responsible for the taxonomy actually arriving.
   tables["REPORT_USES_TAXONOMY"] = f"""
     CREATE OR REPLACE TABLE REPORT_USES_TAXONOMY AS
     SELECT
-      id                              AS src,
-      taxonomy_id                     AS dst
-    FROM postgres_scan('{c}', '{s}', 'reports')
-    WHERE generation_status = 'published'
+      r.id                            AS src,
+      r.taxonomy_id                   AS dst
+    FROM postgres_scan('{c}', '{s}', 'reports') r
+    JOIN postgres_scan('{c}', '{s}', 'taxonomies') t
+      ON t.id = r.taxonomy_id
+    WHERE r.generation_status = 'published'
   """
 
   tables["REPORT_HAS_FACT"] = f"""

--- a/robosystems/operations/roboledger/commands/reports.py
+++ b/robosystems/operations/roboledger/commands/reports.py
@@ -1043,8 +1043,23 @@ def _delete_shared_copy(
   """Delete the copy of a shared report from the target tenant schema.
 
   Returns True when a copy was found and removed.
+
+  A recipient whose graph has been deprovisioned has no schema left, and is
+  treated as "the copy is already gone" rather than an error. Raising would
+  strand the share permanently: revocation stamps ``revoked_at`` only after
+  this returns, and ``delete_report`` refuses a report that still has an
+  active share row — so the sender could neither withdraw the report nor
+  delete it, over a recipient that no longer exists. Deleting the schema
+  deleted the copy; that is the outcome revocation was asking for.
   """
-  from robosystems.db.extensions import extensions_session
+  from robosystems.db.extensions import extensions_session, tenant_schema_exists
+
+  if not tenant_schema_exists(target_graph_id):
+    logger.info(
+      f"Recipient {target_graph_id} has no extensions schema; treating the "
+      f"shared copy of report {source_report_id} as already removed."
+    )
+    return False
 
   with extensions_session(target_graph_id) as target_session:
     deleted = _delete_copies_in_session(
@@ -1173,12 +1188,14 @@ def _share_to_target(
       # The concepts have to land before the facts that cite them. A fact
       # whose element_id resolves nowhere is not a partial delivery — it
       # takes down the recipient's entire next materialization (see
-      # `_ensure_shared_elements`).
+      # `_ensure_shared_elements`). The report's own taxonomy is passed
+      # separately because it can be missing when every fact resolves.
       _ensure_shared_elements(
         target_session,
         source_graph_id,
         {fd["element_id"] for fd in source_facts if fd.get("element_id")},
         shared_by,
+        report_taxonomy_id=report_snapshot["taxonomy_id"],
       )
 
       for fact_data in source_facts:
@@ -1227,6 +1244,7 @@ def _ensure_shared_elements(
   source_graph_id: str,
   element_ids: set[str],
   shared_by: str,
+  report_taxonomy_id: str | None = None,
 ) -> None:
   """Copy the sender's own concepts into the recipient's schema.
 
@@ -1253,6 +1271,15 @@ def _ensure_shared_elements(
   hangs off is typically not itself cited by any fact. Copying element-wise
   would violate that FK on the first note.
 
+  ``report_taxonomy_id`` is ensured **independently of the facts**, because
+  the two can go missing separately. A report built on a sender-specific
+  reporting extension whose facts all cite standard concepts leaves
+  ``element_ids`` fully resolvable and the taxonomy absent — and
+  ``reports.taxonomy_id`` has no foreign key either, so the copy is written
+  without complaint and ``REPORT_USES_TAXONOMY`` then points at nothing.
+  Keying the taxonomy copy off missing *elements* made delivery of the one
+  depend on the absence of the other.
+
   Copies are stamped ``source='linked'``, which is deliberately outside
   ``COA_SOURCES``. The recipient needs the sender's concepts to read the
   report; they must never appear in the recipient's own chart of accounts.
@@ -1267,21 +1294,29 @@ def _ensure_shared_elements(
   fact-insert loop below write the exact dangling references this function
   exists to prevent — the original defect, behind a rarer trigger.
   """
-  if not element_ids:
-    return
-
   from robosystems.db.extensions import extensions_session
   from robosystems.models.extensions import Element, Taxonomy
 
-  present = {
-    row[0]
-    for row in target_session.execute(
-      text("SELECT id FROM elements WHERE id = ANY(:ids)"),
-      {"ids": list(element_ids)},
-    ).fetchall()
-  }
-  missing = element_ids - present
-  if not missing:
+  missing: set[str] = set()
+  if element_ids:
+    present = {
+      row[0]
+      for row in target_session.execute(
+        text("SELECT id FROM elements WHERE id = ANY(:ids)"),
+        {"ids": list(element_ids)},
+      ).fetchall()
+    }
+    missing = element_ids - present
+
+  report_taxonomy_missing = (
+    bool(report_taxonomy_id)
+    and not target_session.execute(
+      text("SELECT 1 FROM taxonomies WHERE id = :tid"),
+      {"tid": report_taxonomy_id},
+    ).first()
+  )
+
+  if not missing and not report_taxonomy_missing:
     return
 
   # Copied field-by-field rather than by raw INSERT: half of both tables is
@@ -1324,40 +1359,66 @@ def _ensure_shared_elements(
   )
 
   with extensions_session(source_graph_id) as source_session:
-    taxonomy_ids = [
-      row[0]
-      for row in source_session.execute(
-        text("""
-          SELECT DISTINCT e.taxonomy_id
-          FROM elements e
-          JOIN taxonomies t ON t.id = e.taxonomy_id
-          WHERE e.id = ANY(:ids)
-            AND t.taxonomy_type = 'reporting_extension'
-        """),
-        {"ids": list(missing)},
-      ).fetchall()
-    ]
+    taxonomy_ids: set[str] = set()
+    if missing:
+      taxonomy_ids = {
+        row[0]
+        for row in source_session.execute(
+          text("""
+            SELECT DISTINCT e.taxonomy_id
+            FROM elements e
+            JOIN taxonomies t ON t.id = e.taxonomy_id
+            WHERE e.id = ANY(:ids)
+              AND t.taxonomy_type = 'reporting_extension'
+          """),
+          {"ids": list(missing)},
+        ).fetchall()
+      }
+      if not taxonomy_ids:
+        logger.warning(
+          f"Shared facts from {source_graph_id} cite {len(missing)} concept(s) "
+          "outside any reporting extension; not copied."
+        )
+
+    if report_taxonomy_missing:
+      # Same `reporting_extension` restriction the element path applies, for
+      # the same two reasons: a report built on a library framework resolves
+      # by deterministic id in every tenant and needs no copy, and a report
+      # somehow bound to the sender's chart of accounts must not drag that
+      # chart across the boundary. When neither holds, the edge is dropped by
+      # the materializer's own join rather than copied.
+      if source_session.execute(
+        text(
+          "SELECT 1 FROM taxonomies "
+          "WHERE id = :tid AND taxonomy_type = 'reporting_extension'"
+        ),
+        {"tid": report_taxonomy_id},
+      ).first():
+        taxonomy_ids.add(str(report_taxonomy_id))
+      else:
+        logger.warning(
+          f"Shared report from {source_graph_id} cites taxonomy "
+          f"{report_taxonomy_id!r}, which the recipient does not have and "
+          "which is not a reporting extension; not copied."
+        )
+
     if not taxonomy_ids:
-      logger.warning(
-        f"Shared facts from {source_graph_id} cite {len(missing)} concept(s) "
-        "outside any reporting extension; not copied."
-      )
       return
+
+    copy_ids = sorted(taxonomy_ids)
 
     # Detached from the source session before it closes — these become new
     # rows in a different schema, not attached instances.
     taxonomies = [
       ({f: getattr(t, f) for f in _TAX_FIELDS}, dict(t.metadata_ or {}))
-      for t in source_session.execute(
-        select(Taxonomy).where(Taxonomy.id.in_(taxonomy_ids))
-      )
+      for t in source_session.execute(select(Taxonomy).where(Taxonomy.id.in_(copy_ids)))
       .scalars()
       .all()
     ]
     elements = [
       {f: getattr(e, f) for f in _ELEM_FIELDS}
       for e in source_session.execute(
-        select(Element).where(Element.taxonomy_id.in_(taxonomy_ids))
+        select(Element).where(Element.taxonomy_id.in_(copy_ids))
       )
       .scalars()
       .all()

--- a/robosystems/routers/extensions/roboledger/operations.py
+++ b/robosystems/routers/extensions/roboledger/operations.py
@@ -54,6 +54,8 @@ that have no roboledger tenants.
 
 from __future__ import annotations
 
+from typing import Any
+
 from fastapi import APIRouter, Depends, Header, HTTPException, Path
 from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy.exc import ProgrammingError
@@ -496,6 +498,19 @@ async def _dispatch(
     raise HTTPException(status_code=409, detail=str(exc))
 
 
+def _result_payload(envelope: OperationEnvelope) -> dict[str, Any]:
+  """Return an `on_fresh_success` envelope's result as a plain dict.
+
+  `wrap_completed` runs every command result through
+  `model_dump(mode="json")`, so a hook that reaches for `envelope.result.foo`
+  reads absent rather than raising — the share, revoke, and purge hooks all
+  shipped that way and marked nothing stale. Going through this helper keeps
+  the normalization visible at each call site.
+  """
+  result = envelope.result
+  return result if isinstance(result, dict) else {}
+
+
 def _ledger_404() -> HTTPException:
   return HTTPException(
     status_code=404,
@@ -881,7 +896,15 @@ async def update_entity_op(
       )
     return result
 
-  return await _dispatch(ctx, _runner, cache)
+  # `name`, `legal_name`, `ticker`, `cik` and the rest of the updatable fields
+  # are columns of the materialized Entity node, so an edit that never marks
+  # the graph leaves LadybugDB answering with the old company details.
+  return await _dispatch(
+    ctx,
+    _runner,
+    cache,
+    on_fresh_success=lambda _env: mark_graph_stale(graph_id, "entity_updated"),
+  )
 
 
 change_reporting_style_op = _registrar.register(
@@ -2413,10 +2436,15 @@ async def share_report_op(
     # this, delivery depends on the recipient happening to have unrelated
     # ledger activity of their own. Mark each recipient that actually
     # received a copy. (`roboinvestor-maturity.md` D1, delivery half.)
-    result = getattr(envelope, "result", None)
-    for item in getattr(result, "results", []) or []:
-      if getattr(item, "status", None) == "shared":
-        mark_graph_stale(item.target_graph_id, "report_shared_in")
+    #
+    # Read as a dict, not attributes: `wrap_completed` normalizes the
+    # command's Pydantic result through `model_dump(mode="json")` before the
+    # hook ever sees it. Attribute access here is not a type error — it
+    # silently reads as absent, which is how this callback first shipped
+    # doing nothing at all.
+    for item in _result_payload(envelope).get("results") or []:
+      if item.get("status") == "shared":
+        mark_graph_stale(item["target_graph_id"], "report_shared_in")
 
   return await _dispatch(ctx, _runner, cache, on_fresh_success=_mark_recipients_stale)
 
@@ -2484,8 +2512,7 @@ async def revoke_report_share_op(
   def _mark_recipient_stale(envelope) -> None:
     # Same reasoning as the share path: the copy leaves the recipient's graph
     # only when their projection is rebuilt. Skip when nothing was deleted.
-    result = getattr(envelope, "result", None)
-    if getattr(result, "copy_deleted", False):
+    if _result_payload(envelope).get("copy_deleted"):
       mark_graph_stale(body.target_graph_id, "report_share_revoked")
 
   return await _dispatch(ctx, _runner, cache, on_fresh_success=_mark_recipient_stale)
@@ -2919,8 +2946,7 @@ async def block_source_graph_op(
     # Only a purge changes queryable content, and the OLAP projection is a
     # full rebuild from OLTP — a block on its own has nothing to re-project,
     # so it must not trigger one.
-    result = getattr(envelope, "result", None)
-    if getattr(result, "purged_report_count", 0):
+    if _result_payload(envelope).get("purged_report_count"):
       mark_graph_stale(graph_id, "shared_reports_purged")
 
   return await _dispatch(ctx, _runner, cache, on_fresh_success=_mark_stale_if_purged)

--- a/robosystems/routers/graphs/backups/download.py
+++ b/robosystems/routers/graphs/backups/download.py
@@ -101,6 +101,12 @@ async def get_backup_download_url(
     # Access validated by get_current_user_with_graph dependency
     is_shared = MultiTenantUtils.is_shared_repository_or_subgraph(graph_id)
     has_tier_limit = False
+    # The single id the monthly counter is keyed on. Both the check and the
+    # increment must use it: the shared path resolves a subgraph to its parent
+    # for the *check* (`sec_historical` → `sec`), so incrementing under the
+    # requested id instead left the checked counter permanently at zero and the
+    # quota unenforced for every subgraph download.
+    quota_resource_id = graph_id
 
     # Check download rate limits based on graph type
     if is_shared:
@@ -111,6 +117,7 @@ async def get_backup_download_url(
       )
 
       parent_repo_id = resolve_shared_repository_parent(graph_id)
+      quota_resource_id = parent_repo_id
       user_repo = UserRepository.get_by_user_and_repository(
         str(current_user.id), parent_repo_id, session
       )
@@ -204,7 +211,7 @@ async def get_backup_download_url(
     if is_shared or has_tier_limit:
       await DownloadRateLimiter.increment_download_count(
         user_id=str(current_user.id),
-        resource_id=graph_id,
+        resource_id=quota_resource_id,
       )
 
     # Record business event

--- a/tests/middleware/test_logging_redaction.py
+++ b/tests/middleware/test_logging_redaction.py
@@ -4,11 +4,16 @@ Test token redaction in logging middleware.
 This test ensures sensitive query parameters like tokens are never logged.
 """
 
+import io
+import logging
+
 from starlette.datastructures import URL
 
 from robosystems.middleware.logging import (
   SENSITIVE_QUERY_PARAMS,
+  UvicornAccessRedactionFilter,
   get_safe_url_for_logging,
+  install_uvicorn_log_redaction,
   redact_sensitive_query_params,
 )
 
@@ -121,3 +126,90 @@ class TestTokenRedaction:
     assert "from_sequence=10" in result
     assert "other=value" in result
     assert "jwt_here" not in result
+
+
+class TestUvicornAccessLogRedaction:
+  """Uvicorn's own access log, which application logging cannot reach.
+
+  The API runs with `--access-log`, and Uvicorn formats its line straight
+  from the ASGI scope — the raw query string included. Every other redaction
+  in this module operates on application logs, so a graph-scoped key riding
+  in an MCP connector URL reached the access log intact regardless.
+
+  These tests assert against the real `uvicorn.access` logger and the real
+  record shape Uvicorn emits, so a change to either is caught here rather
+  than in production logs.
+  """
+
+  @staticmethod
+  def _emit(path_with_query: str) -> str:
+    """Log one record exactly as Uvicorn does; return the formatted line."""
+    install_uvicorn_log_redaction()
+
+    logger = logging.getLogger("uvicorn.access")
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    logger.addHandler(handler)
+    previous_level, previous_propagate = logger.level, logger.propagate
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
+    try:
+      # Verbatim from uvicorn/protocols/http/httptools_impl.py.
+      logger.info(
+        '%s - "%s %s HTTP/%s" %d',
+        "10.0.0.1:54321",
+        "POST",
+        path_with_query,
+        "1.1",
+        200,
+      )
+    finally:
+      logger.removeHandler(handler)
+      logger.setLevel(previous_level)
+      logger.propagate = previous_propagate
+    return stream.getvalue()
+
+  def test_a_connector_token_never_reaches_the_access_log(self):
+    line = self._emit("/v1/graphs/kg1234567890abcdef/mcp?token=rfsc_supersecret_key")
+
+    assert "rfsc_supersecret_key" not in line
+    assert "token=REDACTED" in line
+    # The rest of the line has to survive, or the access log stops being useful.
+    assert "/v1/graphs/kg1234567890abcdef/mcp" in line
+    assert "POST" in line
+    assert "200" in line
+
+  def test_the_uvicorn_scope_helper_still_produces_what_we_redact(self):
+    """Guard the premise: if Uvicorn stops putting the query string in this
+    argument, the filter is aimed at nothing and these tests would pass
+    vacuously."""
+    from uvicorn.protocols.utils import get_path_with_query_string
+
+    raw = get_path_with_query_string(
+      {"path": "/v1/graphs/kg1234567890abcdef/mcp", "query_string": b"token=secret123"}
+    )
+    assert raw.endswith("?token=secret123")
+    assert "secret123" not in self._emit(raw)
+
+  def test_non_sensitive_query_params_are_left_alone(self):
+    line = self._emit("/v1/graphs/kg1234567890abcdef/backups?limit=50&offset=10")
+
+    assert "limit=50" in line
+    assert "offset=10" in line
+
+  def test_a_path_with_no_query_string_is_unchanged(self):
+    line = self._emit("/v1/status")
+
+    assert "/v1/status" in line
+    assert "?" not in line
+
+  def test_installing_twice_does_not_double_filter(self):
+    logger = logging.getLogger("uvicorn.access")
+    install_uvicorn_log_redaction()
+    install_uvicorn_log_redaction()
+
+    installed = [
+      f for f in logger.filters if isinstance(f, UvicornAccessRedactionFilter)
+    ]
+    assert len(installed) == 1

--- a/tests/operations/roboledger/commands/test_share_controls_db.py
+++ b/tests/operations/roboledger/commands/test_share_controls_db.py
@@ -28,7 +28,13 @@ from robosystems.models.api.extensions.blocked_source_graphs import (
   BlockSourceGraphRequest,
 )
 from robosystems.models.api.extensions.reports import RevokeReportShareRequest
-from robosystems.models.extensions import BlockedSourceGraph, Report, ReportShare
+from robosystems.models.extensions import (
+  BlockedSourceGraph,
+  Element,
+  Report,
+  ReportShare,
+  Taxonomy,
+)
 from robosystems.operations.roboledger.commands.blocked_source_graphs import (
   block_source_graph,
 )
@@ -153,6 +159,9 @@ def _clean_tenants(two_tenants):
       session.execute(text("DELETE FROM reports"))
       session.execute(text("DELETE FROM blocked_source_graphs"))
       session.execute(text("DELETE FROM report_shares"))
+      # Elements before taxonomies: `elements.taxonomy_id` is a real FK.
+      session.execute(text("DELETE FROM elements"))
+      session.execute(text("DELETE FROM taxonomies"))
   yield
 
 
@@ -488,3 +497,164 @@ def test_blocks_are_per_tenant_and_do_not_leak_across_schemas() -> None:
     ).scalar_one()
 
   assert count == 0
+
+
+# ── The report's own taxonomy ──────────────────────────────────────────────
+
+_EXT_TAXONOMY = "tax_acme_reporting_ext"
+
+
+def _seed_taxonomy(graph_id: str, taxonomy_id: str, taxonomy_type: str) -> None:
+  with extensions_session(graph_id) as session:
+    session.add(
+      Taxonomy(
+        id=taxonomy_id,
+        name="Acme Reporting Extension",
+        taxonomy_type=taxonomy_type,
+        created_by=_SENDER,
+      )
+    )
+
+
+def _seed_elements(graph_id: str, taxonomy_id: str) -> None:
+  """Give `graph_id` a row for every concept the shared facts cite."""
+  with extensions_session(graph_id) as session:
+    for fact in _SOURCE_FACTS:
+      session.add(
+        Element(
+          id=fact["element_id"],
+          name=fact["element_id"],
+          qname=f"{graph_id}:{fact['element_id']}",
+          taxonomy_id=taxonomy_id,
+          created_by=_SENDER,
+        )
+      )
+
+
+def _share_with_taxonomy(taxonomy_id: str) -> object:
+  snapshot = {**_REPORT_SNAPSHOT, "taxonomy_id": taxonomy_id}
+  with _patch_platform_graph_lookup():
+    return _share_to_target(
+      source_graph_id=SOURCE_GRAPH,
+      report_snapshot=snapshot,
+      source_facts=_SOURCE_FACTS,
+      target_graph_id=TARGET_GRAPH,
+      shared_by=_SENDER,
+    )
+
+
+def _taxonomy_ids(graph_id: str) -> set[str]:
+  with extensions_session(graph_id) as session:
+    return {
+      row[0] for row in session.execute(text("SELECT id FROM taxonomies")).fetchall()
+    }
+
+
+def test_the_report_taxonomy_travels_even_when_every_fact_resolves() -> None:
+  """The dangling-taxonomy case the element copy could not see.
+
+  A report can be built on the sender's own reporting extension while every
+  fact in it cites a standard concept the recipient already has. The element
+  copy then finds nothing missing and returns immediately — and the copied
+  report keeps a `taxonomy_id` naming a row that exists only in the sender's
+  schema. `reports.taxonomy_id` has no foreign key, so the OLTP insert
+  succeeds and the damage surfaces one step later, when
+  `REPORT_USES_TAXONOMY` points at nothing and takes the recipient's whole
+  rebuild down with it.
+  """
+  _seed_taxonomy(SOURCE_GRAPH, _EXT_TAXONOMY, "reporting_extension")
+  # Both sides already hold every concept the facts cite, so `missing` is
+  # empty — the precondition that used to short-circuit the taxonomy copy.
+  _seed_taxonomy(SOURCE_GRAPH, "tax_std_local", "reporting_standard")
+  _seed_taxonomy(TARGET_GRAPH, "tax_std_local", "reporting_standard")
+  _seed_elements(SOURCE_GRAPH, "tax_std_local")
+  _seed_elements(TARGET_GRAPH, "tax_std_local")
+
+  result = _share_with_taxonomy(_EXT_TAXONOMY)
+
+  assert result.status == "shared"
+  assert _EXT_TAXONOMY in _taxonomy_ids(TARGET_GRAPH), (
+    "the shared report's taxonomy did not travel; REPORT_USES_TAXONOMY would "
+    "dangle in the recipient's next materialization"
+  )
+
+  with extensions_session(TARGET_GRAPH) as session:
+    copied_taxonomy_id = session.execute(
+      text("SELECT taxonomy_id FROM reports WHERE source_graph_id = :src"),
+      {"src": SOURCE_GRAPH},
+    ).scalar_one()
+  assert copied_taxonomy_id == _EXT_TAXONOMY
+
+
+def test_a_library_report_taxonomy_is_not_copied() -> None:
+  """Only reporting extensions travel. A report on a shared framework
+  resolves by deterministic id in every tenant, and a taxonomy that is not a
+  reporting extension must never be dragged across the boundary — the
+  materializer's own join drops the edge instead."""
+  _seed_taxonomy(SOURCE_GRAPH, "tax_library_gaap", "reporting_standard")
+  _seed_elements(SOURCE_GRAPH, "tax_library_gaap")
+  _seed_taxonomy(TARGET_GRAPH, "tax_std_local", "reporting_standard")
+  _seed_elements(TARGET_GRAPH, "tax_std_local")
+
+  result = _share_with_taxonomy("tax_library_gaap")
+
+  assert result.status == "shared"
+  assert "tax_library_gaap" not in _taxonomy_ids(TARGET_GRAPH)
+
+
+# ── Revoking after the recipient is gone ───────────────────────────────────
+
+
+def test_revoke_survives_a_recipient_whose_schema_was_dropped() -> None:
+  """Deprovisioning the recipient must not strand the sender's report.
+
+  The recipient's schema is dropped on deprovision, and revocation has to
+  open it to delete the copy. When that raised, the share could never be
+  stamped revoked — and `delete_report` refuses a report that still has an
+  active share row, so the sender could neither withdraw the report nor
+  delete it, forever, over a graph that no longer exists.
+  """
+  gone_graph = "kgcccccccccccccccc03"  # never provisioned
+
+  with extensions_session(SOURCE_GRAPH) as session:
+    session.add(
+      Report(
+        id=_REPORT_SNAPSHOT["id"],
+        name=_REPORT_SNAPSHOT["name"],
+        taxonomy_id=_REPORT_SNAPSHOT["taxonomy_id"],
+        period_type="quarterly",
+        comparative=False,
+        generation_status="published",
+        filing_status="draft",
+        created_by=_SENDER,
+      )
+    )
+    session.add(
+      ReportShare(
+        id="share_gone_0001",
+        report_id=_REPORT_SNAPSHOT["id"],
+        target_graph_id=gone_graph,
+        shared_by=_SENDER,
+        fact_count=len(_SOURCE_FACTS),
+      )
+    )
+
+  response = revoke_report_share(
+    SOURCE_GRAPH,
+    _REPORT_SNAPSHOT["id"],
+    RevokeReportShareRequest(target_graph_id=gone_graph),
+    acting_user_id=_SENDER,
+  )
+
+  # Nothing was deleted — the schema took the copy with it.
+  assert response.copy_deleted is False
+
+  with extensions_session(SOURCE_GRAPH) as session:
+    revoked_at = session.execute(
+      text("SELECT revoked_at FROM report_shares WHERE id = 'share_gone_0001'")
+    ).scalar_one()
+  assert revoked_at is not None
+
+  # And with no active share left, the sender can delete their own report.
+  with extensions_session(SOURCE_GRAPH) as session:
+    assert delete_report(session, _REPORT_SNAPSHOT["id"], acting_user_id=_SENDER)

--- a/tests/routers/extensions/roboledger/test_operations.py
+++ b/tests/routers/extensions/roboledger/test_operations.py
@@ -10,12 +10,16 @@ envelope shape.
 from __future__ import annotations
 
 from datetime import UTC, date, datetime
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 from fastapi import HTTPException
 
 from robosystems.middleware.operations import OperationEnvelope
+from robosystems.models.api.extensions.blocked_source_graphs import (
+  BlockedSourceGraphResponse,
+  BlockSourceGraphResult,
+)
 from robosystems.models.api.extensions.entity import (
   LedgerEntityResponse,
   UpdateEntityRequest,
@@ -34,15 +38,24 @@ from robosystems.models.api.extensions.report_package import (
 from robosystems.models.api.extensions.reports import (
   CreateReportRequest,
   ReportResponse,
+  RevokeReportShareResponse,
+  ShareReportResponse,
+  ShareResultItem,
 )
 from robosystems.routers.extensions.roboledger.operations import (
   AutoMapElementsOperation,
+  BlockSourceGraphOperation,
   RegenerateReportOperation,
+  RevokeReportShareOperation,
+  ShareReportOperation,
   auto_map_elements_op,
+  block_source_graph_op,
   create_report_op,
   delete_journal_entry_op,
   file_report_op,
   regenerate_report_op,
+  revoke_report_share_op,
+  share_report_op,
   transition_filing_status_op,
   update_entity_op,
   update_event_block_op,
@@ -143,6 +156,9 @@ class TestUpdateEntityOp:
       patch(
         "robosystems.routers.extensions.roboledger.operations.extensions_session"
       ) as mock_session,
+      patch(
+        "robosystems.routers.extensions.roboledger.operations.mark_graph_stale"
+      ) as mark,
     ):
       mock_session.return_value.__enter__ = MagicMock(return_value=MagicMock())
       mock_session.return_value.__exit__ = MagicMock(return_value=False)
@@ -163,6 +179,40 @@ class TestUpdateEntityOp:
     assert envelope.result is not None
     assert envelope.result["id"] == "ent_kg01234567890abcdef"
     assert envelope.result["name"] == "Acme Corp"
+    # `name`, `legal_name`, `ticker`, `cik` … are all columns of the
+    # materialized Entity node, so the edit has to reach LadybugDB.
+    mark.assert_called_once_with(GRAPH_ID, "entity_updated")
+
+  @pytest.mark.asyncio
+  async def test_failed_update_does_not_mark_the_graph(self) -> None:
+    """The hook is `on_fresh_success` — a 404 must not schedule a rebuild."""
+    body = UpdateEntityRequest(name="New Name")
+
+    with (
+      patch(
+        "robosystems.routers.extensions.roboledger.operations.update_parent_entity",
+        return_value=None,
+      ),
+      patch(
+        "robosystems.routers.extensions.roboledger.operations.extensions_session"
+      ) as mock_session,
+      patch(
+        "robosystems.routers.extensions.roboledger.operations.mark_graph_stale"
+      ) as mark,
+    ):
+      mock_session.return_value.__enter__ = MagicMock(return_value=MagicMock())
+      mock_session.return_value.__exit__ = MagicMock(return_value=False)
+
+      with pytest.raises(HTTPException):
+        await update_entity_op(
+          body=body,
+          graph_id=GRAPH_ID,
+          user=_make_user(),
+          idempotency_key=None,
+          cache=_FakeCache(),
+        )
+
+    mark.assert_not_called()
 
   @pytest.mark.asyncio
   async def test_rejects_empty_update_with_400(self) -> None:
@@ -1287,3 +1337,209 @@ class TestHandWrittenWriteRoleGate:
 
     assert resolved is user
     gate.assert_called_once_with(str(user.id), GRAPH_ID)
+
+
+class TestCrossGraphStalenessCallbacks:
+  """The `on_fresh_success` hooks on share / revoke / block-with-purge.
+
+  These are driven through the real handler rather than by calling the hook
+  with a hand-made object, because the defect they regress lives *between*
+  the two: `wrap_completed` runs the command's Pydantic result through
+  `model_dump(mode="json")`, so the hook receives a dict. All three hooks
+  shipped reading it with `getattr`, which does not raise — it reports every
+  field absent, and each hook quietly marked nothing. A test that passed the
+  hook a Pydantic model would have passed against the broken code.
+
+  The demo cannot catch this either: it forces a rebuild after sharing.
+  """
+
+  @pytest.mark.asyncio
+  async def test_share_marks_every_recipient_that_received_a_copy(self) -> None:
+    body = ShareReportOperation(report_id="rpt_1", publish_list_id="pl_1")
+    result = ShareReportResponse(
+      report_id="rpt_1",
+      results=[
+        ShareResultItem(target_graph_id="kg0000000000000001", status="shared"),
+        ShareResultItem(
+          target_graph_id="kg0000000000000002",
+          status="error",
+          error="Recipient has blocked shares from this graph.",
+        ),
+        ShareResultItem(target_graph_id="kg0000000000000003", status="shared"),
+      ],
+    )
+
+    with (
+      patch(
+        "robosystems.routers.extensions.roboledger.operations.cmd_share_report",
+        return_value=result,
+      ),
+      patch(
+        "robosystems.routers.extensions.roboledger.operations.mark_graph_stale"
+      ) as mark,
+    ):
+      envelope = await share_report_op(
+        body=body,
+        graph_id=GRAPH_ID,
+        user=_make_user(),
+        idempotency_key=None,
+        cache=_FakeCache(),
+      )
+
+    assert envelope.status == "completed"
+    # The failed recipient is not marked: nothing landed in their schema.
+    assert mark.call_args_list == [
+      call("kg0000000000000001", "report_shared_in"),
+      call("kg0000000000000003", "report_shared_in"),
+    ]
+
+  @pytest.mark.asyncio
+  async def test_revoke_marks_the_recipient_when_a_copy_was_deleted(self) -> None:
+    body = RevokeReportShareOperation(
+      report_id="rpt_1", target_graph_id="kg0000000000000001"
+    )
+    result = RevokeReportShareResponse(
+      report_id="rpt_1",
+      target_graph_id="kg0000000000000001",
+      revoked_at=datetime(2026, 3, 1, tzinfo=UTC),
+      copy_deleted=True,
+    )
+
+    with (
+      patch(
+        "robosystems.routers.extensions.roboledger.operations.cmd_revoke_report_share",
+        return_value=result,
+      ),
+      patch(
+        "robosystems.routers.extensions.roboledger.operations.user_is_graph_admin",
+        return_value=True,
+      ),
+      patch(
+        "robosystems.routers.extensions.roboledger.operations.mark_graph_stale"
+      ) as mark,
+    ):
+      await revoke_report_share_op(
+        body=body,
+        graph_id=GRAPH_ID,
+        user=_make_user(),
+        idempotency_key=None,
+        cache=_FakeCache(),
+      )
+
+    mark.assert_called_once_with("kg0000000000000001", "report_share_revoked")
+
+  @pytest.mark.asyncio
+  async def test_revoke_does_not_mark_when_no_copy_was_found(self) -> None:
+    """A recipient who already deleted the copy has nothing to re-project."""
+    body = RevokeReportShareOperation(
+      report_id="rpt_1", target_graph_id="kg0000000000000001"
+    )
+    result = RevokeReportShareResponse(
+      report_id="rpt_1",
+      target_graph_id="kg0000000000000001",
+      revoked_at=datetime(2026, 3, 1, tzinfo=UTC),
+      copy_deleted=False,
+    )
+
+    with (
+      patch(
+        "robosystems.routers.extensions.roboledger.operations.cmd_revoke_report_share",
+        return_value=result,
+      ),
+      patch(
+        "robosystems.routers.extensions.roboledger.operations.user_is_graph_admin",
+        return_value=True,
+      ),
+      patch(
+        "robosystems.routers.extensions.roboledger.operations.mark_graph_stale"
+      ) as mark,
+    ):
+      await revoke_report_share_op(
+        body=body,
+        graph_id=GRAPH_ID,
+        user=_make_user(),
+        idempotency_key=None,
+        cache=_FakeCache(),
+      )
+
+    mark.assert_not_called()
+
+  @staticmethod
+  def _block_result(purged: int) -> BlockSourceGraphResult:
+    return BlockSourceGraphResult(
+      block=BlockedSourceGraphResponse(
+        id="blk_1",
+        source_graph_id="kg0000000000000009",
+        blocked_by="usr_test123",
+        blocked_at=datetime(2026, 3, 1, tzinfo=UTC),
+      ),
+      already_blocked=False,
+      purged_report_count=purged,
+    )
+
+  @pytest.mark.asyncio
+  async def test_block_marks_this_graph_when_the_purge_removed_reports(self) -> None:
+    body = BlockSourceGraphOperation(source_graph_id="kg0000000000000009", purge=True)
+
+    with (
+      patch(
+        "robosystems.routers.extensions.roboledger.operations.cmd_block_source_graph",
+        return_value=self._block_result(3),
+      ),
+      patch(
+        "robosystems.routers.extensions.roboledger.operations.user_is_graph_admin",
+        return_value=True,
+      ),
+      patch(
+        "robosystems.routers.extensions.roboledger.operations.extensions_session"
+      ) as mock_session,
+      patch(
+        "robosystems.routers.extensions.roboledger.operations.mark_graph_stale"
+      ) as mark,
+    ):
+      mock_session.return_value.__enter__ = MagicMock(return_value=MagicMock())
+      mock_session.return_value.__exit__ = MagicMock(return_value=False)
+
+      await block_source_graph_op(
+        body=body,
+        graph_id=GRAPH_ID,
+        user=_make_user(),
+        idempotency_key=None,
+        cache=_FakeCache(),
+      )
+
+    mark.assert_called_once_with(GRAPH_ID, "shared_reports_purged")
+
+  @pytest.mark.asyncio
+  async def test_block_without_a_purge_does_not_rebuild(self) -> None:
+    """A block on its own removes nothing, so it must not trigger a rebuild."""
+    body = BlockSourceGraphOperation(source_graph_id="kg0000000000000009")
+
+    with (
+      patch(
+        "robosystems.routers.extensions.roboledger.operations.cmd_block_source_graph",
+        return_value=self._block_result(0),
+      ),
+      patch(
+        "robosystems.routers.extensions.roboledger.operations.user_is_graph_admin",
+        return_value=True,
+      ),
+      patch(
+        "robosystems.routers.extensions.roboledger.operations.extensions_session"
+      ) as mock_session,
+      patch(
+        "robosystems.routers.extensions.roboledger.operations.mark_graph_stale"
+      ) as mark,
+    ):
+      mock_session.return_value.__enter__ = MagicMock(return_value=MagicMock())
+      mock_session.return_value.__exit__ = MagicMock(return_value=False)
+
+      await block_source_graph_op(
+        body=body,
+        graph_id=GRAPH_ID,
+        user=_make_user(),
+        idempotency_key=None,
+        cache=_FakeCache(),
+      )
+
+    mark.assert_not_called()

--- a/tests/routers/extensions/test_graph_staleness_coverage.py
+++ b/tests/routers/extensions/test_graph_staleness_coverage.py
@@ -18,9 +18,21 @@ happens to have unrelated activity.
 
 Asserted over the registrars' real specs rather than a fixed list, so an
 operation added later is covered on the day it is written.
+
+**And over the hand-written routes too.** Enumerating only `OperationSpec`s
+covers 26 of roboledger's 48 operations; the other 22 are hand-written
+`@router.post` handlers the registrar never sees, which is how `update-entity`
+kept writing materialized Entity columns without ever marking its graph while
+this file read as though it held the whole surface. Every hand-written route
+must be classified below — marking stale in its handler, marking stale in the
+command or tool it delegates to, or exempt with the reason — so a new one
+cannot land undeclared.
 """
 
 from __future__ import annotations
+
+import importlib
+import inspect
 
 import pytest
 
@@ -65,6 +77,103 @@ _EXEMPT: dict[str, str] = {
 
 _EXTENSIONS = ("roboledger", "roboinvestor")
 
+_OPERATION_ROUTERS = {
+  "roboledger": _roboledger_ops,
+  "roboinvestor": _roboinvestor_ops,
+}
+
+# ── Hand-written routes ────────────────────────────────────────────────────
+# Three ways a hand-written operation can be correct, and every one of them
+# has to be stated. `_EXEMPT` above covers registrar specs only.
+
+# The handler itself calls `mark_graph_stale` (directly or via the
+# `on_fresh_success` hook it passes to `_dispatch`).
+_STALE_IN_HANDLER = {
+  "bind-text-block",
+  "block-source-graph",
+  "create-report",
+  "delete-report",
+  "regenerate-report",
+  "revoke-report-share",
+  "share-report",
+  "update-entity",
+}
+
+# The handler delegates, and the mark lives in the callee. Recorded as a
+# dotted path so the assertion reads the callee's real source rather than
+# trusting the label — `close_period` marking its own graph is what lets
+# `backfill-plan-history` mark nothing of its own.
+_STALE_IN_CALLEE = {
+  "close-period": "robosystems.operations.roboledger.commands.fiscal_calendar.close_period",
+  "reopen-period": "robosystems.operations.roboledger.commands.fiscal_calendar.reopen_period",
+  # Backfill drives reopen/close per period; both mark.
+  "backfill-plan-history": "robosystems.operations.roboledger.commands.fiscal_calendar.close_period",
+  # Async: enqueues the mapping operator, whose writes all land through this
+  # direct MCP tool. The registrar-published tools inherit the mark from
+  # their `OperationSpec`; this one is hand-written and marks for itself.
+  "auto-map-elements": "robosystems.middleware.mcp.tools.taxonomy_tools.CreateMappingAssociationTool.execute",
+}
+
+# Same bar as `_EXEMPT`: name the table written and why the graph never
+# reads it. Verified against the `postgres_scan` sources in
+# `operations/extensions/materialize.py`.
+_HAND_WRITTEN_EXEMPT: dict[str, str] = {
+  "initialize": (
+    "Writes fiscal_calendars + fiscal_periods. Neither table is scanned by "
+    "materialize.py — the fiscal calendar has no graph node."
+  ),
+  "set-close-target": (
+    "Writes fiscal_calendars.close_target — a scheduling intent, not ledger "
+    "content, and the table is not scanned by materialize.py."
+  ),
+  "file-report": (
+    "Writes reports.filing_status. The Report SELECT does not carry that "
+    "column and filters on generation_status, so filing a report changes no "
+    "materialized value."
+  ),
+  "transition-filing-status": (
+    "Same column and same reasoning as file-report: filing_status is not materialized."
+  ),
+  "create-publish-list": "publish_lists is not scanned by materialize.py.",
+  "update-publish-list": "publish_lists is not scanned by materialize.py.",
+  "delete-publish-list": "publish_lists is not scanned by materialize.py.",
+  "add-publish-list-members": "publish_lists is not scanned by materialize.py.",
+  "remove-publish-list-member": "publish_lists is not scanned by materialize.py.",
+  "unblock-source-graph": (
+    "Writes blocked_source_graphs, which is not scanned by materialize.py. "
+    "Unlike block, it never purges — nothing leaves the graph, so there is "
+    "nothing to re-project."
+  ),
+}
+
+
+def _hand_written():
+  """Route name → (extension, endpoint) for every non-registrar operation."""
+  out = {}
+  for extension, module in _OPERATION_ROUTERS.items():
+    spec_names = {
+      spec.name for _reg, spec in OperationRegistrar.specs_for_extension(extension)
+    }
+    for route in module.router.routes:
+      name = getattr(route, "path", "").lstrip("/")
+      if name and name not in spec_names:
+        out[name] = (extension, route.endpoint)
+  return out
+
+
+def _resolve(dotted: str):
+  """Import a `module.attr` or `module.Class.method` path."""
+  parts = dotted.split(".")
+  for split in range(len(parts) - 1, 0, -1):
+    try:
+      obj = importlib.import_module(".".join(parts[:split]))
+    except ImportError:
+      continue
+    for attr in parts[split:]:
+      obj = getattr(obj, attr)
+    return obj
+  raise ImportError(f"Could not resolve {dotted}")
+
 
 def _specs():
   pairs = []
@@ -108,6 +217,55 @@ class TestGraphStalenessCoverage:
     assert not orphaned, (
       f"_EXEMPT names operations that are no longer registered: {orphaned}. "
       "Remove them, or correct the name if the operation was renamed."
+    )
+
+  def test_every_hand_written_route_is_classified(self) -> None:
+    """The gap this file used to have: a hand-written `@router.post` is
+    invisible to the spec enumeration above, so it could write materialized
+    tables and mark nothing while the suite stayed green."""
+    hand_written = _hand_written()
+    assert len(hand_written) >= 20, (
+      f"expected the hand-written operation surface, got {len(hand_written)} "
+      "— route wiring or a feature flag changed"
+    )
+    classified = _STALE_IN_HANDLER | set(_STALE_IN_CALLEE) | set(_HAND_WRITTEN_EXEMPT)
+    unclassified = sorted(set(hand_written) - classified)
+    assert not unclassified, (
+      f"Hand-written operations with no staleness decision on record: "
+      f"{unclassified}. Add each to _STALE_IN_HANDLER, _STALE_IN_CALLEE, or "
+      "_HAND_WRITTEN_EXEMPT with the table it writes and why."
+    )
+    stale_names = sorted(classified - set(hand_written))
+    assert not stale_names, (
+      f"These names are classified but no longer routed: {stale_names}. "
+      "Remove them, or correct the name if the operation was renamed."
+    )
+
+  def test_handlers_that_claim_to_mark_stale_actually_do(self) -> None:
+    """Reading the handler's source keeps the table above honest: deleting a
+    `mark_graph_stale` call fails here instead of silently downgrading the
+    operation to the exempt behavior."""
+    hand_written = _hand_written()
+    silent = sorted(
+      name
+      for name in _STALE_IN_HANDLER
+      if name in hand_written
+      and "mark_graph_stale" not in inspect.getsource(hand_written[name][1])
+    )
+    assert not silent, (
+      f"Handlers listed in _STALE_IN_HANDLER that no longer call "
+      f"mark_graph_stale: {silent}."
+    )
+
+  def test_callees_that_claim_to_mark_stale_actually_do(self) -> None:
+    """Same guard one level down, for handlers that delegate the mark."""
+    missing = sorted(
+      f"{name} -> {dotted}"
+      for name, dotted in _STALE_IN_CALLEE.items()
+      if "mark_graph_stale" not in inspect.getsource(_resolve(dotted))
+    )
+    assert not missing, (
+      f"Delegated staleness marks that are no longer in the callee: {missing}."
     )
 
   def test_exemptions_have_not_been_overtaken(self) -> None:

--- a/tests/routers/graphs/test_backup_download.py
+++ b/tests/routers/graphs/test_backup_download.py
@@ -619,3 +619,92 @@ class TestBackupDownloadEndpoint:
         del app.dependency_overrides[get_current_user_with_graph]
       if get_db_session in app.dependency_overrides:
         del app.dependency_overrides[get_db_session]
+
+  @patch("robosystems.routers.graphs.backups.download.get_backup_manager")
+  @patch(
+    "robosystems.routers.graphs.backups.download.DownloadRateLimiter.increment_download_count",
+    new_callable=AsyncMock,
+  )
+  @patch(
+    "robosystems.routers.graphs.backups.download.DownloadRateLimiter.check_download_limit",
+    new_callable=AsyncMock,
+  )
+  @patch(
+    "robosystems.routers.graphs.backups.download.DownloadRateLimiter.get_shared_repo_monthly_limit"
+  )
+  @patch(
+    "robosystems.routers.graphs.backups.download.UserRepository.get_by_user_and_repository"
+  )
+  @patch(
+    "robosystems.routers.graphs.backups.download.MultiTenantUtils.is_shared_repository_or_subgraph"
+  )
+  @patch("robosystems.models.core.GraphUser.get_by_user_id")
+  def test_subgraph_download_counts_against_the_parent_repository_quota(
+    self,
+    mock_get_by_user_id,
+    mock_is_shared,
+    mock_get_user_repo,
+    mock_get_monthly_limit,
+    mock_check_limit,
+    mock_increment,
+    mock_get_backup_manager,
+    client,
+    mock_auth_user,
+  ):
+    """The quota is checked on one key and incremented on another.
+
+    Shared-repository downloads resolve a subgraph to its parent for the
+    *check* (`sec_historical` → `sec`), because the subscription and its
+    monthly allowance belong to the parent. The increment used the requested
+    id instead, and the Redis key is built from whichever id it is given —
+    so the counter the check reads never moved and the monthly limit was
+    unenforced for every subgraph download. Both calls must name the same
+    resource.
+    """
+    from robosystems.database import get_db_session
+    from robosystems.middleware.auth.dependencies import get_current_user_with_graph
+
+    mock_session = MagicMock()
+    app.dependency_overrides[get_current_user_with_graph] = lambda: mock_auth_user
+    app.dependency_overrides[get_db_session] = lambda: mock_session
+
+    try:
+      mock_is_shared.return_value = True
+
+      mock_user_graph = MagicMock()
+      mock_user_graph.graph_id = "sec_historical"
+      mock_user_graph.role = "viewer"
+      mock_get_by_user_id.return_value = [mock_user_graph]
+
+      mock_user_repo = MagicMock()
+      mock_user_repo.repository_plan = "advanced"
+      mock_get_user_repo.return_value = mock_user_repo
+      mock_get_monthly_limit.return_value = 1
+
+      reset_time = datetime.now(UTC) + timedelta(hours=5)
+      mock_check_limit.return_value = (True, 4, reset_time)
+
+      mock_backup_mgr = MagicMock()
+      mock_backup_mgr.get_backup_download_url = AsyncMock(
+        return_value="https://s3.amazonaws.com/bucket/backup.lbug?signature=xyz"
+      )
+      mock_get_backup_manager.return_value = mock_backup_mgr
+
+      mock_auth_user.id = "test-user-123"
+
+      response = client.get("/v1/graphs/sec_historical/backups/backup123/download")
+
+      assert response.status_code == 200
+
+      # The check resolves to the parent...
+      assert mock_check_limit.call_args.kwargs["repository"] == "sec"
+      # ...so the increment has to move that same counter, not the subgraph's.
+      mock_increment.assert_called_once_with(
+        user_id="test-user-123",
+        resource_id="sec",
+      )
+    finally:
+      if get_current_user_with_graph in app.dependency_overrides:
+        del app.dependency_overrides[get_current_user_with_graph]
+      if get_db_session in app.dependency_overrides:
+        del app.dependency_overrides[get_db_session]


### PR DESCRIPTION
Two review passes over the pending v1.8.0 found eight defects. All are fixed here, each with a test verified to **fail against the original code** — not merely to pass now.

## Cross-graph sharing (the release's headline feature)

- **The staleness callbacks marked nothing.** Operation results are normalized to a dict before the `on_fresh_success` hook runs; share, revoke, and purge all read it with `getattr`, which reports every field absent rather than raising. The writes landed and the recipient's graph kept answering as though nothing arrived. The demo cannot catch this — it forces a rebuild after sharing.
- **A shared report could arrive without its taxonomy.** The taxonomy copy was keyed off missing fact elements, so a report on a sender-specific reporting extension whose facts are all standard concepts arrived referencing a taxonomy that exists only in the sender's schema. Fixed on the write path; `REPORT_USES_TAXONOMY` also inner-joins `taxonomies` so one bad id costs an edge rather than the recipient's whole rebuild.
- **Deleting a recipient stranded the sender's report permanently** — revocation could not stamp, and a report with an active share cannot be deleted.

## Staleness coverage

The structural guard enumerated `OperationSpec`s only: 26 of roboledger's 48 operations. Every hand-written route was invisible to a test named for the whole surface, which is how `update-entity` kept editing materialized Entity columns without marking its graph. The guard now classifies all 22 hand-written routes and reads their source, so a deleted `mark_graph_stale` fails here. It caught a third gap on its way in (`set-close-target`, verified exempt), plus the mapping tool `auto-map-elements` writes through.

## Other

- **Access logs**: server-level access logging is outside the application's redaction path. Filter added at app creation.
- **Download quota**: subgraph downloads checked the parent's counter and incremented the subgraph's, so the limit was unenforced. One resolved id for both.
- **`backup_format`** was recorded unconditionally, discarding the caller's value. Latent today.
- **SSE keepalive** now fires inside the client read timeout instead of racing it; demos converted to typed SDK reads, with one `Unset` guard restored that the conversion had dropped.

## Not changed

Deploy ordering. `deploy-api` and `deploy-dagster` run concurrently and migrations execute on daemon boot, so the API can briefly serve new code against the old schema. Reviewed and **deliberately kept** — running migrations ahead of deploy would mean running them locally, which is worse. Both migrations in this release fail closed (a share is rejected and rolled back), so the window costs a retry, not data. The release note claimed an ordering the pipeline does not enforce; it now describes the real sequence.

## Verification

- Full unit suite: **12,425 passed, 23 skipped, 0 failed**
- `just test-code`: ruff, format, and basedpyright all clean
- Each fix confirmed against the pre-fix code by reverting it and watching the new test fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)