### PR TITLE
fix: nine defects surfaced by an end-to-end demo suite run

### DIFF
--- a/bin/setup/README.md
+++ b/bin/setup/README.md
@@ -8,7 +8,7 @@ Scripts for bootstrapping and configuring RoboSystems deployments. These handle 
 | -------------------- | ------------------------------ | ------------------- | --------- |
 | `bootstrap.sh`       | Complete first-time setup      | AWS SSO, GitHub CLI | 5-10 min  |
 | `aws.sh`             | Secrets + SSM parameters       | AWS credentials     | 1-2 min   |
-| `gha.sh`             | Configure ~80 GitHub variables | GitHub CLI          | 2-3 min   |
+| `gha.sh`             | Configure GitHub variables     | GitHub CLI          | 2-3 min   |
 | `bedrock.sh`         | Local AI development setup     | AWS credentials     | 1 min     |
 | `localstack-init.sh` | Local AWS emulation            | Docker (automatic)  | N/A       |
 | `postgres-init.sh`   | PostgreSQL databases           | Docker (automatic)  | N/A       |
@@ -263,7 +263,7 @@ just setup-gha
 7. ECR repository name
 8. Optional: RoboLedger/RoboInvestor app URLs
 
-**Variables Set** (~80 total):
+**Variables Set** — run `just gha-list` for the live set.
 
 #### Core Configuration
 

--- a/bin/setup/aws.sh
+++ b/bin/setup/aws.sh
@@ -201,12 +201,21 @@ function create_ssm_feature_flags() {
         "DIRECT_GRAPH_MATERIALIZATION_ENABLED=true"
         "EMAIL_VERIFICATION_ENABLED=false"
         "FACT_GRID_ENABLED=false"
-        "EXTENSIONS_ENABLED=false"
+        # Extensions surfaces are gated per product domain. There is no
+        # settable EXTENSIONS_ENABLED: it is a *derived* property in
+        # config/env.py (ROBOLEDGER_ENABLED OR ROBOINVESTOR_ENABLED), so
+        # seeding that name — or the retired LEDGER_ENABLED / INVESTOR_ENABLED
+        # — produces a parameter nothing reads, and an operator who sets it to
+        # false gets no effect while extensions stay on. Seed the three names
+        # the code actually reads. Code defaults are true; these start false so
+        # a fresh environment opts in per domain.
+        "ROBOLEDGER_ENABLED=false"
+        "ROBOINVESTOR_ENABLED=false"
+        "EXTENSIONS_GRAPHQL_ENABLED=false"
         # Kill switch for graph_usage_monitor_sensor's 80%/100% storage emails.
         # Seeded at its code default purely so it is discoverable in
         # `just ssm-list <env> features` — a kill switch you cannot find is not one.
         "GRAPH_USAGE_ALERTS_ENABLED=true"
-        "LEDGER_ENABLED=false"
         "LOAD_SHEDDING_ENABLED=true"
         "MCP_AUTO_LIMIT_ENABLED=true"
         "MCP_SEMANTIC_MEMORY_ENABLED=false"

--- a/bin/setup/bootstrap.sh
+++ b/bin/setup/bootstrap.sh
@@ -878,7 +878,7 @@ setup_secrets_and_variables() {
     echo "  AWS Secrets Manager - Application secrets & feature flags"
     echo "                        (required for deployment, safe to re-run)"
     echo ""
-    echo "  GitHub Variables    - ~80 variables for custom domains, scaling,"
+    echo "  GitHub Variables    - ~185 variables for custom domains, scaling,"
     echo "                        instance sizes, etc. (optional, has defaults)"
     echo ""
 

--- a/bin/setup/gha.sh
+++ b/bin/setup/gha.sh
@@ -276,11 +276,15 @@ function setup_full_config() {
     fi
 
     # Dagster Webserver Configuration
+    # DESIRED_COUNT 0 leaves the UI off; bin/tools/tunnels.sh scales it to 1 on
+    # demand. Set to 1 to keep it always available.
     gh variable set DAGSTER_WEBSERVER_CPU_PROD --body "512"
     gh variable set DAGSTER_WEBSERVER_MEMORY_PROD --body "1024"
+    gh variable set DAGSTER_WEBSERVER_DESIRED_COUNT_PROD --body "1"
     if $setup_staging; then
         gh variable set DAGSTER_WEBSERVER_CPU_STAGING --body "512"
         gh variable set DAGSTER_WEBSERVER_MEMORY_STAGING --body "1024"
+        gh variable set DAGSTER_WEBSERVER_DESIRED_COUNT_STAGING --body "1"
     fi
 
     # Dagster Run Job Configuration (EcsRunLauncher - Fargate)
@@ -331,10 +335,14 @@ function setup_full_config() {
     fi
 
     # Database Configuration
+    # Performance Insights is on in prod only; 7 days is the free retention tier.
     gh variable set DATABASE_INSTANCE_SIZE_PROD --body "db.t4g.small"
     gh variable set DATABASE_ALLOCATED_STORAGE_PROD --body "20"
     gh variable set DATABASE_MAX_ALLOCATED_STORAGE_PROD --body "100"
     gh variable set DATABASE_MULTI_AZ_ENABLED_PROD --body "false"
+    gh variable set DATABASE_POSTGRES_VERSION_PROD --body "16"
+    gh variable set DATABASE_PI_ENABLED_PROD --body "true"
+    gh variable set DATABASE_PI_RETENTION_DAYS_PROD --body "7"
     # RDS Proxy (off by default - flip RDS_PROXY_ENABLED_PROD to "true" to turn on)
     gh variable set RDS_PROXY_ENABLED_PROD --body "false"
     gh variable set RDS_PROXY_MAX_CONNECTIONS_PERCENT_PROD --body "100"
@@ -344,6 +352,9 @@ function setup_full_config() {
         gh variable set DATABASE_ALLOCATED_STORAGE_STAGING --body "20"
         gh variable set DATABASE_MAX_ALLOCATED_STORAGE_STAGING --body "100"
         gh variable set DATABASE_MULTI_AZ_ENABLED_STAGING --body "false"
+        gh variable set DATABASE_POSTGRES_VERSION_STAGING --body "16"
+        gh variable set DATABASE_PI_ENABLED_STAGING --body "false"
+        gh variable set DATABASE_PI_RETENTION_DAYS_STAGING --body "7"
         gh variable set RDS_PROXY_ENABLED_STAGING --body "false"
         gh variable set RDS_PROXY_MAX_CONNECTIONS_PERCENT_STAGING --body "100"
         gh variable set RDS_PROXY_CONNECTION_BORROW_TIMEOUT_STAGING --body "120"
@@ -378,11 +389,13 @@ function setup_full_config() {
     # Valkey Configuration
     gh variable set VALKEY_NODE_TYPE_PROD --body "cache.t4g.micro"
     gh variable set VALKEY_NUM_NODES_PROD --body "1"
+    gh variable set VALKEY_VERSION_PROD --body "8.1"
     gh variable set VALKEY_ENCRYPTION_ENABLED_PROD --body "true"
     gh variable set VALKEY_SNAPSHOT_RETENTION_DAYS_PROD --body "7"
     if $setup_staging; then
         gh variable set VALKEY_NODE_TYPE_STAGING --body "cache.t4g.micro"
         gh variable set VALKEY_NUM_NODES_STAGING --body "1"
+        gh variable set VALKEY_VERSION_STAGING --body "8.1"
         gh variable set VALKEY_ENCRYPTION_ENABLED_STAGING --body "true"
         gh variable set VALKEY_SNAPSHOT_RETENTION_DAYS_STAGING --body "0"
     fi
@@ -490,6 +503,12 @@ function setup_full_config() {
     # Graph AMI: Auto-initialized by get-graph-ami action on first deploy
     # Stored in SSM: /robosystems/{env}/graph/ami-id
     # Updated via: graph-maintenance.yml workflow
+    # AUTO_UPDATE: monthly scheduled refresh of the AMI variable (staging 1st, prod 2nd)
+    # AUTO_DEPLOY: whether that scheduled run also triggers an ASG refresh
+    # Both are read without a fallback in graph-maintenance.yml, so an unset
+    # value reads as "not true" and the scheduled work stays off.
+    gh variable set GRAPH_AMI_AUTO_UPDATE --body "true"
+    gh variable set GRAPH_AMI_AUTO_DEPLOY --body "false"
 
     # Graph container refresh is now controlled via workflow_dispatch input
     # (graph_container_refresh parameter, defaults to true)
@@ -620,7 +639,7 @@ function main() {
     echo "Repository: $repo_info"
     echo ""
 
-    echo "This sets ~80 GitHub variables for full control over infrastructure."
+    echo "This sets the full GitHub variable set for control over infrastructure."
     echo "Note: Basic deployments work without this (workflows have sensible defaults)."
     echo ""
     read -p "Continue with full variable setup? (Y/n): " -n 1 -r

--- a/compose.yaml
+++ b/compose.yaml
@@ -70,7 +70,12 @@ services:
     deploy:
       resources:
         limits:
-          memory: 2g
+          # ladybug-standard budgets 1GB per parent database and admission
+          # control needs 1GB of headroom on top, but LBUG_DATABASES_PER_INSTANCE
+          # lets this one container hold every local graph — where prod gives
+          # each its own instance. 2g fit exactly one database and then rejected
+          # every query; 6g holds the handful the demos create concurrently.
+          memory: 6g
           cpus: "1.5"
         reservations:
           memory: 1g

--- a/examples/custom_graph_demo/memory_subgraph.py
+++ b/examples/custom_graph_demo/memory_subgraph.py
@@ -3,15 +3,23 @@
 Memory Subgraph Demo
 
 Creates a `knowledge` subgraph within an existing parent graph and exercises
-the two complementary memory modalities that share it:
+the two complementary memory modalities:
 
-  1. Structured knowledge graph — seeds Concept / Observation / Session nodes
-     via Cypher and traverses them with exact graph queries.
-  2. Semantic memory — stores free-text memories with `remember` and retrieves
-     them by meaning (local vector embeddings) with `recall` / `list-memories`.
+  1. Structured knowledge graph (on the subgraph) — seeds Concept /
+     Observation / Session nodes via Cypher and traverses them with exact
+     graph queries.
+  2. Semantic memory (on the parent graph) — stores free-text memories with
+     `remember` and retrieves them by meaning (local vector embeddings) with
+     `recall` / `list-memories`.
 
 Together these show the AI-memory read split: query (exact graph traversal)
-vs. search (ranked semantic recall), both scoped to the same subgraph.
+vs. search (ranked semantic recall).
+
+The two sit at different scopes on purpose. A subgraph exists to be cheap to
+create and throw away and is written to directly, so the API refuses semantic
+memory there (403) rather than maintain a second vector store in step with the
+parent's. Structured knowledge belongs in the subgraph; recall belongs on the
+parent.
 
 The `knowledge` schema extension provides the structured starter schema;
 semantic memory is backed by a per-graph vector store.
@@ -518,12 +526,20 @@ def _envelope_result(parsed) -> dict:
   return result if isinstance(result, dict) else {}
 
 
-def seed_semantic_memories(client: AuthenticatedClient, subgraph_id: str) -> None:
+def seed_semantic_memories(client: AuthenticatedClient, graph_id: str) -> int:
   """Store free-text memories via the `remember` content operation.
 
   Unlike the structured Concept/Observation graph above, these are embedded
   locally into a per-graph vector store and retrieved by meaning, not by
   exact key or traversal.
+
+  This runs against the **parent** graph, not the subgraph: semantic memory is
+  per-database storage on the parent's instance, and the API refuses it on a
+  subgraph with a 403 rather than keep a second store in step for no gain.
+  The two modalities therefore live at different scopes — structured knowledge
+  in the subgraph, semantic recall on the parent.
+
+  Returns the number of memories that failed to store.
   """
   print("\n" + "=" * 70)
   print("🧠 Semantic Memory — remember (vector store)")
@@ -552,6 +568,7 @@ def seed_semantic_memories(client: AuthenticatedClient, subgraph_id: str) -> Non
     },
   ]
 
+  failures = 0
   for mem in memories:
     body = RememberOp(
       text=mem["text"],
@@ -559,7 +576,7 @@ def seed_semantic_memories(client: AuthenticatedClient, subgraph_id: str) -> Non
       memory_type=mem["memory_type"],
       tags=mem["tags"],
     )
-    response = api_remember(graph_id=subgraph_id, client=client, body=body)
+    response = api_remember(graph_id=graph_id, client=client, body=body)
     if response.status_code in (200, 202):
       result = _envelope_result(response.parsed)
       mem_id = result.get("id", "?") if isinstance(result, dict) else "?"
@@ -568,10 +585,17 @@ def seed_semantic_memories(client: AuthenticatedClient, subgraph_id: str) -> Non
       print(f"   ❌ remember failed: {response.status_code}")
       if response.content:
         print(f"      {response.content.decode()[:200]}")
+      failures += 1
+  return failures
 
 
-def recall_semantic_memories(client: AuthenticatedClient, subgraph_id: str) -> None:
-  """Retrieve memories by meaning (`recall`) and enumerate them (`list-memories`)."""
+def recall_semantic_memories(client: AuthenticatedClient, graph_id: str) -> int:
+  """Retrieve memories by meaning (`recall`) and enumerate them (`list-memories`).
+
+  Runs against the parent graph — see ``seed_semantic_memories``. Returns the
+  number of recall queries that returned no hits or errored, so a silently
+  empty vector store fails the demo instead of printing "(no matches)".
+  """
   print("\n" + "=" * 70)
   print("🔎 Semantic Memory — recall (ranked by meaning)")
   print("=" * 70)
@@ -581,14 +605,16 @@ def recall_semantic_memories(client: AuthenticatedClient, subgraph_id: str) -> N
     "How does the user like to write queries?",
   ]
 
+  failures = 0
   for query in queries:
     print(f"\n   🔍 recall: {query!r}")
     body = MemoryRecallRequest(query=query, k=3)
-    response = api_recall_memory(graph_id=subgraph_id, client=client, body=body)
+    response = api_recall_memory(graph_id=graph_id, client=client, body=body)
     if response.status_code != 200:
       print(f"      ❌ recall failed: {response.status_code}")
       if response.content:
         print(f"      {response.content.decode()[:200]}")
+      failures += 1
       continue
 
     parsed = response.parsed
@@ -596,7 +622,8 @@ def recall_semantic_memories(client: AuthenticatedClient, subgraph_id: str) -> N
     if hits is None and isinstance(parsed, dict):
       hits = parsed.get("hits", [])
     if not hits:
-      print("      (no matches)")
+      print("      ❌ (no matches — the seeded memories should have ranked here)")
+      failures += 1
       continue
     for hit in hits:
       score = getattr(hit, "score", None)
@@ -607,12 +634,12 @@ def recall_semantic_memories(client: AuthenticatedClient, subgraph_id: str) -> N
       score_str = f"{score:.3f}" if isinstance(score, (int, float)) else "?"
       print(f"      [{score_str}] {str(snippet)[:80]}…")
 
-  # Governance view: enumerate every memory stored on the subgraph.
+  # Governance view: enumerate every memory stored on the parent graph.
   print("\n   📋 list-memories (governance enumeration)")
-  response = api_list_memories(graph_id=subgraph_id, client=client, limit=100)
+  response = api_list_memories(graph_id=graph_id, client=client, limit=100)
   if response.status_code != 200:
     print(f"      ⚠️  list-memories failed: {response.status_code}")
-    return
+    return failures + 1
   parsed = response.parsed
   total = getattr(parsed, "total", None)
   records = getattr(parsed, "memories", None)
@@ -627,6 +654,8 @@ def recall_semantic_memories(client: AuthenticatedClient, subgraph_id: str) -> N
       mem_type = rec.get("memory_type", "?")
       text = rec.get("text", "")
     print(f"      • [{mem_type}] {str(text)[:70]}…")
+
+  return failures
 
 
 def main():
@@ -678,19 +707,29 @@ def main():
   verify_memory_graph(client, subgraph_id)
 
   # --- Modality 2: semantic memory (ranked vector recall) ---
-  seed_semantic_memories(client, subgraph_id)
-  recall_semantic_memories(client, subgraph_id)
+  # Scoped to the parent graph: the API refuses semantic memory on subgraphs.
+  failures = seed_semantic_memories(client, graph_id)
+  failures += recall_semantic_memories(client, graph_id)
+
+  if failures:
+    print("\n" + "=" * 70)
+    print(
+      f"❌ Memory Subgraph Demo failed — {failures} semantic-memory step(s) failed."
+    )
+    print("=" * 70 + "\n")
+    sys.exit(1)
 
   print("\n" + "=" * 70)
   print("✅ Memory Subgraph Demo Complete!")
   print("=" * 70)
   print(f"\nParent Graph: {graph_id}")
   print(f"Knowledge Subgraph: {subgraph_id}")
-  print("\n💡 This subgraph now holds both memory modalities:")
+  print("\n💡 The two memory modalities live at different scopes:")
   print(
-    '   • Structured graph  → uv run query_graph.py --query "MATCH (c:Concept) RETURN c.name"'
+    "   • Structured graph (subgraph) → uv run query_graph.py "
+    '--query "MATCH (c:Concept) RETURN c.name"'
   )
-  print(f"   • Semantic recall   → POST /v1/graphs/{subgraph_id}/memory/recall")
+  print(f"   • Semantic recall (parent)    → POST /v1/graphs/{graph_id}/memory/recall")
   print("=" * 70 + "\n")
 
 

--- a/examples/custom_graph_demo/query_graph.py
+++ b/examples/custom_graph_demo/query_graph.py
@@ -37,7 +37,9 @@ if str(PROJECT_ROOT) not in sys.path:
 
 from examples._common.config import get_graph_id
 
-DEFAULT_CREDENTIALS_FILE = Path(__file__).resolve().parents[2] / ".local" / "config.json"
+DEFAULT_CREDENTIALS_FILE = (
+  Path(__file__).resolve().parents[2] / ".local" / "config.json"
+)
 DEMO_NAME = "custom_graph_demo"
 
 
@@ -140,8 +142,7 @@ LIMIT 40
 def load_credentials(credentials_path: Path) -> dict:
   if not credentials_path.exists():
     raise FileNotFoundError(
-      f"No credentials found at {credentials_path}. "
-      "Run setup_credentials.py first."
+      f"No credentials found at {credentials_path}. Run setup_credentials.py first."
     )
   with credentials_path.open() as fh:
     return json.load(fh)
@@ -171,38 +172,48 @@ def run_and_display(
   name: str,
   query: str,
   description: str | None = None,
-) -> None:
+) -> bool:
+  """Run one query and render it. Returns False if the query errored.
+
+  An empty result is not a failure — some presets legitimately match nothing
+  — but an exception is, and the caller needs to know so the run can exit
+  non-zero rather than reporting success over a wall of errors.
+  """
   print_info_section(name, subtitle=description)
 
   try:
     result = execute_query(client, graph_id, query)
     if not result["data"]:
       print_warning("No rows returned.")
-      return
+      return True
     print_table(
       result["data"],
       title=name,
       row_count_label=f"Rows returned (execution {result['execution_time_ms']:.1f} ms)",
     )
+    return True
   except Exception as exc:  # noqa: BLE001
     print_error(f"Query failed: {exc}")
+    return False
 
 
-def run_presets(
-  client: RoboSystemsClients, graph_id: str, presets: list[str]
-) -> None:
+def run_presets(client: RoboSystemsClients, graph_id: str, presets: list[str]) -> int:
+  """Run each preset, returning the number that failed."""
+  failures = 0
   for preset in presets:
     details = PRESET_QUERIES.get(preset)
     if not details:
       print_warning(f"Unknown preset: {preset}")
       continue
-    run_and_display(
+    if not run_and_display(
       client,
       graph_id,
       name=f"Preset: {preset}",
       query=details["query"],
       description=details.get("description"),
-    )
+    ):
+      failures += 1
+  return failures
 
 
 def interactive_mode(client: RoboSystemsClients, graph_id: str) -> None:
@@ -305,18 +316,22 @@ def main() -> None:
   client = build_client(api_key, args.base_url)
 
   if args.query:
-    run_and_display(client, graph_id, "Custom Query", args.query)
-    return
+    sys.exit(0 if run_and_display(client, graph_id, "Custom Query", args.query) else 1)
 
   if args.preset:
-    run_presets(client, graph_id, [args.preset])
-    return
+    _exit_on_failures(run_presets(client, graph_id, [args.preset]))
 
   if args.all:
-    run_presets(client, graph_id, list(PRESET_QUERIES))
-    return
+    _exit_on_failures(run_presets(client, graph_id, list(PRESET_QUERIES)))
 
   interactive_mode(client, graph_id)
+
+
+def _exit_on_failures(failures: int) -> None:
+  if failures:
+    print_error(f"{failures} query/queries failed.")
+    sys.exit(1)
+  sys.exit(0)
 
 
 if __name__ == "__main__":

--- a/examples/custom_graph_demo/upload_ingest.py
+++ b/examples/custom_graph_demo/upload_ingest.py
@@ -35,7 +35,9 @@ if str(PROJECT_ROOT) not in sys.path:
 from examples._common.config import get_graph_id
 
 DEMO_DIR = Path(__file__).parent
-DEFAULT_CREDENTIALS_FILE = Path(__file__).resolve().parents[2] / ".local" / "config.json"
+DEFAULT_CREDENTIALS_FILE = (
+  Path(__file__).resolve().parents[2] / ".local" / "config.json"
+)
 DATA_DIR = DEMO_DIR / "data"
 NODES_DIR = DATA_DIR / "nodes"
 RELATIONSHIPS_DIR = DATA_DIR / "relationships"
@@ -203,11 +205,18 @@ def materialize_graph_data(clients: RoboSystemsClients, graph_id: str) -> None:
     raise
 
 
-def run_post_ingest_checks(clients: RoboSystemsClients, graph_id: str) -> None:
-  """Run a small set of sanity-check queries after materialization."""
+def run_post_ingest_checks(clients: RoboSystemsClients, graph_id: str) -> int:
+  """Run a small set of sanity-check queries after materialization.
+
+  Returns the number of checks that failed, so the caller can fail the run.
+  A verification step that prints errors and still reports success is worse
+  than no verification at all — it makes a broken graph look loaded.
+  """
   print(f"\n{'=' * 70}")
   print("🔍 Verification queries")
   print("=" * 70)
+
+  failures = 0
 
   print("\n📊 Node counts")
   for label in EXPECTED_NODE_TABLES:
@@ -219,8 +228,12 @@ def run_post_ingest_checks(clients: RoboSystemsClients, graph_id: str) -> None:
         first_row = result.data[0]
         count = first_row.get("count") or next(iter(first_row.values()), 0)
       print(f"   • {{'label': '{label}', 'count': {count}}}")
+      if not count:
+        print(f"   ❌ Expected rows for label '{label}', got {count}")
+        failures += 1
     except Exception as exc:  # noqa: BLE001
       print(f"   ❌ Query failed for label '{label}': {exc}")
+      failures += 1
 
   print("\n📊 Relationship counts")
   for rel in EXPECTED_REL_TABLES:
@@ -232,8 +245,14 @@ def run_post_ingest_checks(clients: RoboSystemsClients, graph_id: str) -> None:
         first_row = result.data[0]
         count = first_row.get("count") or next(iter(first_row.values()), 0)
       print(f"   • {{'type': '{rel}', 'count': {count}}}")
+      if not count:
+        print(f"   ❌ Expected rows for relationship '{rel}', got {count}")
+        failures += 1
     except Exception as exc:  # noqa: BLE001
       print(f"   ❌ Query failed for relationship '{rel}': {exc}")
+      failures += 1
+
+  return failures
 
 
 def main() -> None:
@@ -298,17 +317,22 @@ def main() -> None:
 
   try:
     upload_tables(clients, graph_id, node_files, "Pass 1 - Node Tables")
-    upload_tables(
-      clients, graph_id, relationship_files, "Pass 2 - Relationship Tables"
-    )
+    upload_tables(clients, graph_id, relationship_files, "Pass 2 - Relationship Tables")
     # Wait for DuckDB staging to complete before materializing
     staging_ok = wait_for_staging(clients, graph_id, timeout_seconds=600)
     if not staging_ok:
       print("\n⚠️  Continuing with materialization despite staging issues...")
     materialize_graph_data(clients, graph_id)
-    run_post_ingest_checks(clients, graph_id)
+    check_failures = run_post_ingest_checks(clients, graph_id)
   except Exception:
     print("\n❌ Upload & ingest process failed.")
+    sys.exit(1)
+
+  if check_failures:
+    print(
+      f"\n❌ Upload & ingest complete but {check_failures} verification "
+      "check(s) failed — the graph is not queryable as loaded."
+    )
     sys.exit(1)
 
   print("\n✅ Upload & ingest complete!")

--- a/examples/seattle_method_demo/author_rollforwards.py
+++ b/examples/seattle_method_demo/author_rollforwards.py
@@ -79,8 +79,9 @@ def _find_mini_taxonomy_id(client, graph_id: str) -> str | None:
   """Find the mini CoA taxonomy_id on the graph by name."""
   taxonomies = client.list_taxonomies(graph_id) or []
   for tax in taxonomies:
-    if "mini" in (tax.get("name") or "").lower():
-      return tax.get("id")
+    # ariadne-generated GraphQL models: attribute access, not mapping `.get()`.
+    if "mini" in (tax.name or "").lower():
+      return tax.id
   return None
 
 

--- a/examples/seattle_method_demo/ingest_transactions.py
+++ b/examples/seattle_method_demo/ingest_transactions.py
@@ -339,6 +339,24 @@ def ingest(
   created = 0
   for je_id, rows in sorted(grouped.items()):
     payload = _build_event_payload(je_id, rows, qname_to_id, warnings)
+
+    # A JE whose every line is zero-amount carries no GL impact, and the API
+    # rejects it (a line item must have a non-zero debit or credit). JE-225 in
+    # the upstream data is one: a PPE write-off closing entry with Amount=0 on
+    # both lines. Recorded as a source data-quality note — the same category
+    # the reconciliation reports — rather than posted and failed, which is what
+    # previously produced a silent loss behind an exit code of 0.
+    if all(
+      not li["debit_amount"] and not li["credit_amount"]
+      for li in payload["metadata"]["line_items"]
+    ):
+      warnings.append(
+        f"{je_id}: every line is zero-amount in the source data — no GL "
+        f"impact, not posted"
+      )
+      print(f"  ⚠️  {je_id}: zero-amount entry in source data — skipped")
+      continue
+
     try:
       response = client.create_event_block(graph_id, payload)
       created += 1

--- a/examples/seattle_method_demo/ingest_transactions.py
+++ b/examples/seattle_method_demo/ingest_transactions.py
@@ -147,8 +147,9 @@ def _find_mini_taxonomy_id(client, graph_id: str) -> str | None:
   """Find the mini CoA taxonomy_id on the graph by name."""
   taxonomies = client.list_taxonomies(graph_id) or []
   for tax in taxonomies:
-    if "mini" in (tax.get("name") or "").lower():
-      return tax.get("id")
+    # ariadne-generated GraphQL models: attribute access, not mapping `.get()`.
+    if "mini" in (tax.name or "").lower():
+      return tax.id
   return None
 
 

--- a/examples/seattle_method_demo/ingest_transactions.py
+++ b/examples/seattle_method_demo/ingest_transactions.py
@@ -45,6 +45,7 @@ from __future__ import annotations
 import argparse
 import csv
 import json
+import sys
 from collections import defaultdict
 from datetime import date, datetime
 from pathlib import Path
@@ -297,10 +298,12 @@ def _pick_entry_type(description: str) -> str:
 
 def ingest(
   graph_id: str, csv_path: Path = CSV_PATH, dry_run: bool = False
-) -> tuple[int, list[str]]:
+) -> tuple[int, list[str], list[str]]:
   """Walk the CSV's JEs and post each one via create-event-block.
 
-  Returns ``(events_created, warnings)``.
+  Returns ``(events_created, warnings, failures)``. A warning is a data-shape
+  note raised while building a payload — the entry still posts. A failure means
+  the entry is missing from the ledger, so the two are counted apart.
   """
   if not csv_path.exists():
     raise SystemExit(f"Transactions CSV not found at {csv_path}")
@@ -309,6 +312,8 @@ def ingest(
   print(f"Found {len(grouped)} JournalEntry(ies) in {csv_path.name}")
 
   warnings: list[str] = []
+  failures: list[str] = []
+  skipped = 0
   if dry_run:
     # Stand-in element ids so the payload shape can be validated offline.
     fake_map = {
@@ -324,7 +329,7 @@ def ingest(
         f"category={payload['event_category']}, "
         f"type={payload['metadata']['type']}"
       )
-    return len(grouped), warnings
+    return len(grouped), warnings, failures
 
   client = _get_ledger_client()
   print("Resolving mini qnames to element_ids on the graph…")
@@ -339,10 +344,19 @@ def ingest(
       created += 1
       print(f"  ✓ {je_id} → event {response.id} status={response.status}")
     except Exception as exc:  # noqa: BLE001 — surface every failure for diagnosis
-      warnings.append(f"{je_id}: {exc}")
+      # 409 means this entry was already ingested on a previous run. The demo
+      # is documented as re-runnable against an existing graph, so a repeat is
+      # the expected path, not a lost write.
+      if "409" in str(exc):
+        skipped += 1
+        continue
+      failures.append(f"{je_id}: {exc}")
       print(f"  ✗ {je_id}: {exc}")
 
-  return created, warnings
+  if skipped:
+    print(f"  {skipped} entr(y/ies) already ingested — skipped")
+
+  return created, warnings, failures
 
 
 def main() -> None:
@@ -363,15 +377,22 @@ def main() -> None:
   )
   args = parser.parse_args()
 
-  created, warnings = ingest(args.graph_id, args.csv, dry_run=args.dry_run)
+  created, warnings, failures = ingest(args.graph_id, args.csv, dry_run=args.dry_run)
 
   if warnings:
-    print(f"\n{len(warnings)} JE(s) failed:")
+    print(f"\n{len(warnings)} warning(s):")
     for w in warnings:
       print(f"  ⚠️  {w}")
 
   action = "Would create" if args.dry_run else "Created"
   print(f"\n{action} {created} event(s).")
+
+  if failures:
+    print(f"\n❌ {len(failures)} JE(s) failed to post:")
+    for f in failures:
+      print(f"  ✗ {f}")
+    print("   The ledger is incomplete — these entries are missing.")
+    sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/examples/seattle_method_demo/main.py
+++ b/examples/seattle_method_demo/main.py
@@ -288,11 +288,23 @@ def step_ingest_transactions(graph_id: str, dry_run: bool = False) -> None:
   print("─" * 70)
   print(f"Step 5 — ingest 14 JEs → graph {graph_id}")
   print("─" * 70)
-  created, warnings = ingest_mod.ingest(graph_id, CSV_PATH, dry_run=dry_run)
+  created, warnings, failures = ingest_mod.ingest(graph_id, CSV_PATH, dry_run=dry_run)
   for w in warnings:
     print(f"  ⚠️  {w}")
   action = "Would create" if dry_run else "Created"
   print(f"  {action} {created} event(s)")
+
+  # Every downstream step reads these events, and this demo's whole claim is
+  # that it reconciles to Charlie's published figures to the cent. Reconciling
+  # a ledger that is missing entries would report a mismatch as a modelling
+  # difference when it is really a lost write.
+  if failures:
+    for f in failures:
+      print(f"  ✗ {f}")
+    raise SystemExit(
+      f"  Ingest incomplete — {len(failures)} of {len(failures) + created} "
+      "entr(y/ies) failed to post."
+    )
 
 
 def step_author_rollforwards(graph_id: str, dry_run: bool = False) -> None:

--- a/examples/seattle_method_demo/seed_mappings.py
+++ b/examples/seattle_method_demo/seed_mappings.py
@@ -168,6 +168,7 @@ def seed_mappings(graph_id: str, dry_run: bool = False) -> tuple[int, list[str]]
 
   warnings: list[str] = []
   created = 0
+  skipped = 0
   for mini_qname, rsgaap_qname in ALL_MAPPINGS:
     mini_id = mini_lookup.get(mini_qname)
     rsgaap_id = rsgaap_lookup.get(rsgaap_qname)
@@ -180,13 +181,24 @@ def seed_mappings(graph_id: str, dry_run: bool = False) -> tuple[int, list[str]]
     if dry_run:
       created += 1
       continue
-    client.create_mapping_association(
-      graph_id,
-      mapping_id=mapping_id,
-      from_element_id=mini_id,
-      to_element_id=rsgaap_id,
-    )
-    created += 1
+    try:
+      client.create_mapping_association(
+        graph_id,
+        mapping_id=mapping_id,
+        from_element_id=mini_id,
+        to_element_id=rsgaap_id,
+      )
+      created += 1
+    except Exception as exc:  # noqa: BLE001
+      # 409 means this pair is already mapped — the demo is documented as
+      # re-runnable against an existing graph (`--graph`, `--step`), so a
+      # repeat is the expected path, not an error. Anything else propagates.
+      if "409" not in str(exc):
+        raise
+      skipped += 1
+
+  if skipped:
+    print(f"  {skipped} mapping(s) already present — skipped")
 
   return created, warnings
 

--- a/examples/seattle_method_demo/seed_mappings.py
+++ b/examples/seattle_method_demo/seed_mappings.py
@@ -55,10 +55,15 @@ def _find_mini_taxonomy_id(client, graph_id: str) -> str | None:
   constraint admits a fixed enum with no 'mini' member — so element lookups
   scope by ``taxonomy_id``, resolved once here.
   """
+  # `list_taxonomies` comes from the ariadne-generated GraphQL client, whose
+  # models are Pydantic with attribute access and non-optional `id`/`name` —
+  # not the attrs/dict shape the OpenAPI client returns. Mapping-style `.get()`
+  # raises AttributeError here, which is what the sibling element lookup below
+  # already gets right.
   taxonomies = client.list_taxonomies(graph_id) or []
   for tax in taxonomies:
-    if "mini" in (tax.get("name") or "").lower():
-      return tax.get("id")
+    if "mini" in (tax.name or "").lower():
+      return tax.id
   return None
 
 

--- a/examples/seattle_method_world_online/author_rollforwards.py
+++ b/examples/seattle_method_world_online/author_rollforwards.py
@@ -73,8 +73,9 @@ def _get_ledger_client():
 def _find_mini_taxonomy_id(client, graph_id: str) -> str | None:
   taxonomies = client.list_taxonomies(graph_id) or []
   for tax in taxonomies:
-    if "mini" in (tax.get("name") or "").lower():
-      return tax.get("id")
+    # ariadne-generated GraphQL models: attribute access, not mapping `.get()`.
+    if "mini" in (tax.name or "").lower():
+      return tax.id
   return None
 
 

--- a/examples/seattle_method_world_online/ingest_gl.py
+++ b/examples/seattle_method_world_online/ingest_gl.py
@@ -266,8 +266,9 @@ def _build_event_payload(
 def _find_mini_taxonomy_id(client, graph_id: str) -> str | None:
   taxonomies = client.list_taxonomies(graph_id) or []
   for tax in taxonomies:
-    if "mini" in (tax.get("name") or "").lower():
-      return tax.get("id")
+    # ariadne-generated GraphQL models: attribute access, not mapping `.get()`.
+    if "mini" in (tax.name or "").lower():
+      return tax.id
   return None
 
 

--- a/examples/seattle_method_world_online/ingest_gl.py
+++ b/examples/seattle_method_world_online/ingest_gl.py
@@ -56,6 +56,7 @@ from __future__ import annotations
 import argparse
 import csv
 import json
+import sys
 import time
 from collections import OrderedDict
 from datetime import date, datetime
@@ -303,11 +304,18 @@ def ingest(
   dry_run: bool = False,
   limit: int | None = None,
   start: int = 0,
-) -> tuple[int, list[str]]:
+) -> tuple[int, list[str], list[str]]:
   """Walk the GL's journal ids and post each as one event.
 
-  Returns ``(events_created, warnings)``. ``limit`` caps how many entries are
-  posted, and ``start`` skips the first N so a partial run can be resumed.
+  Returns ``(events_created, warnings, failures)``. ``limit`` caps how many
+  entries are posted, and ``start`` skips the first N so a partial run can be
+  resumed.
+
+  Warnings and failures are deliberately separate. A warning is a data-shape
+  note raised while building a payload — the entry still posts. A failure is a
+  create-event-block call that errored, meaning that entry is *missing from the
+  ledger*. Counting the two together is how a lost entry hid behind a benign
+  note and still exited 0.
   """
   if not gl_path.exists():
     raise SystemExit(f"GeneralLedger.csv not found at {gl_path} — run the pull step.")
@@ -347,7 +355,7 @@ def ingest(
         f"category={payload['event_category']}, type={payload['metadata']['type']}"
       )
     print(f"  … (dry-run — showed {len(sample)} of {len(journal_ids)} entries)")
-    return len(journal_ids), warnings
+    return len(journal_ids), warnings, []
 
   client = _get_ledger_client()
   print("Resolving mini qnames to element_ids on the graph…")
@@ -362,6 +370,8 @@ def ingest(
     print(f"  ⚠️  {warnings[-1]}")
 
   created = 0
+  failures: list[str] = []
+  skipped = 0
   t0 = time.time()
   for idx, jid in enumerate(journal_ids, 1):
     payload = _build_event_payload(jid, grouped[jid], qname_to_id, coa_map, warnings)
@@ -370,17 +380,26 @@ def ingest(
       created += 1
       _ = response  # response.id is available but too noisy to print per entry
     except Exception as exc:
-      warnings.append(f"journalId {jid}: {exc}")
+      # 409 means this entry was already ingested on a previous run — the demo
+      # supports re-running against an existing graph, so that is not a loss.
+      if "409" in str(exc):
+        skipped += 1
+        continue
+      failures.append(f"journalId {jid}: {exc}")
       print(f"  ✗ journalId {jid}: {exc}")
 
     if idx % 250 == 0 or idx == len(journal_ids):
       rate = idx / max(time.time() - t0, 1e-6)
       print(
         f"  … {idx}/{len(journal_ids)} entries "
-        f"({created} ok, {len(warnings)} warning(s), {rate:.1f}/s)"
+        f"({created} ok, {skipped} already ingested, "
+        f"{len(failures)} failed, {len(warnings)} warning(s), {rate:.1f}/s)"
       )
 
-  return created, warnings
+  if skipped:
+    print(f"  {skipped} entr(y/ies) already ingested — skipped")
+
+  return created, warnings, failures
 
 
 def main() -> None:
@@ -407,7 +426,7 @@ def main() -> None:
   )
   args = parser.parse_args()
 
-  created, warnings = ingest(
+  created, warnings, failures = ingest(
     args.graph_id,
     args.gl,
     args.coa,
@@ -424,6 +443,17 @@ def main() -> None:
 
   action = "Would create" if args.dry_run else "Created"
   print(f"\n{action} {created} event(s).")
+
+  if failures:
+    shown = failures[:25]
+    print(
+      f"\n❌ {len(failures)} entr(y/ies) failed to post"
+      f"{' (first 25)' if len(failures) > 25 else ''}:"
+    )
+    for f in shown:
+      print(f"  ✗ {f}")
+    print("   The ledger is incomplete — these entries are missing.")
+    sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/examples/seattle_method_world_online/main.py
+++ b/examples/seattle_method_world_online/main.py
@@ -267,11 +267,28 @@ def step_ingest(graph_id: str, dry_run: bool = False, limit: int | None = None) 
   print("─" * 70)
   print(f"Step 5 — ingest World Online GL → graph {graph_id}")
   print("─" * 70)
-  created, warnings = ingest_mod.ingest(graph_id, dry_run=dry_run, limit=limit)
+  created, warnings, failures = ingest_mod.ingest(
+    graph_id, dry_run=dry_run, limit=limit
+  )
   if warnings:
     print(f"  {len(warnings)} warning(s) (see ingest output above)")
   action = "Would create" if dry_run else "Created"
   print(f"  {action} {created} event(s)")
+
+  # Stop the run rather than reconcile against a ledger with holes in it. Every
+  # downstream step — rollforwards, reconciliation, the four statements — reads
+  # these events, so continuing produces totals that look authoritative and are
+  # quietly short by whatever failed to post.
+  if failures:
+    print(f"\n  ❌ {len(failures)} entr(y/ies) failed to post:")
+    for f in failures[:25]:
+      print(f"    ✗ {f}")
+    if len(failures) > 25:
+      print(f"    … and {len(failures) - 25} more")
+    raise SystemExit(
+      "  Ingest incomplete — the ledger is missing entries, so the "
+      "reconciliation below would be meaningless."
+    )
 
 
 def step_author_rollforwards(graph_id: str, dry_run: bool = False) -> None:

--- a/examples/sec_demo/main.py
+++ b/examples/sec_demo/main.py
@@ -112,9 +112,7 @@ def update_credentials(data: dict):
     sys.exit(1)
 
 
-def create_sec_subscription(
-  api_key: str, base_url: str, plan_name: str = "starter"
-):
+def create_sec_subscription(api_key: str, base_url: str, plan_name: str = "starter"):
   """Create SEC repository subscription via API."""
   try:
     client = AuthenticatedClient(
@@ -278,12 +276,14 @@ def main():
       cwd=PROJECT_ROOT,
     )
     if result.returncode != 0:
-      print(f"\n⚠️  Example queries failed with exit code {result.returncode}")
-      print("   You can still query the SEC data manually using the commands above")
-    else:
-      print("\n" + "=" * 70)
-      print("✅ Example Queries Complete!")
-      print("=" * 70 + "\n")
+      print(f"\n❌ Example queries failed with exit code {result.returncode}")
+      print("   The data load succeeded — you can still query the SEC data")
+      print("   manually using the commands above — but the demo did not pass.")
+      sys.exit(result.returncode)
+
+    print("\n" + "=" * 70)
+    print("✅ Example Queries Complete!")
+    print("=" * 70 + "\n")
 
 
 if __name__ == "__main__":

--- a/examples/sec_demo/query_examples.py
+++ b/examples/sec_demo/query_examples.py
@@ -44,7 +44,9 @@ if str(PROJECT_ROOT) not in sys.path:
 
 from examples._common.config import get_graph_id
 
-DEFAULT_CREDENTIALS_FILE = Path(__file__).resolve().parents[2] / ".local" / "config.json"
+DEFAULT_CREDENTIALS_FILE = (
+  Path(__file__).resolve().parents[2] / ".local" / "config.json"
+)
 DEMO_NAME = "sec"
 
 
@@ -390,21 +392,29 @@ def run_and_display(
   name: str,
   query: str,
   description: str | None = None,
-) -> None:
+) -> bool:
+  """Run one query and render it. Returns False if the query errored.
+
+  An empty result is not a failure — a preset can legitimately match nothing
+  in a narrow load — but an exception is, and the caller needs it so the run
+  can exit non-zero instead of reporting success over a wall of errors.
+  """
   print_info_section(name, subtitle=description)
 
   try:
     result = execute_query(client, graph_id, query)
     if not result["data"]:
       print_warning("No rows returned.")
-      return
+      return True
     print_table(
       result["data"],
       title=name,
       row_count_label=f"Rows returned (execution {result['execution_time_ms']:.1f} ms)",
     )
+    return True
   except Exception as exc:
     print_error(f"Query failed: {exc}")
+    return False
 
 
 def execute_search(
@@ -431,15 +441,19 @@ def execute_search(
   )
   hits = []
   for hit in getattr(response, "hits", []):
-    hits.append({
-      "score": f"{getattr(hit, 'score', 0):.3f}",
-      "entity": getattr(hit, "entity_ticker", "") or "",
-      "form": getattr(hit, "form_type", "") or "",
-      "section": getattr(hit, "section_label", "") or getattr(hit, "element_qname", "") or "",
-      "source": getattr(hit, "source_type", "") or "",
-      "filing_date": getattr(hit, "filing_date", "") or "",
-      "snippet": (getattr(hit, "snippet", "") or "")[:120],
-    })
+    hits.append(
+      {
+        "score": f"{getattr(hit, 'score', 0):.3f}",
+        "entity": getattr(hit, "entity_ticker", "") or "",
+        "form": getattr(hit, "form_type", "") or "",
+        "section": getattr(hit, "section_label", "")
+        or getattr(hit, "element_qname", "")
+        or "",
+        "source": getattr(hit, "source_type", "") or "",
+        "filing_date": getattr(hit, "filing_date", "") or "",
+        "snippet": (getattr(hit, "snippet", "") or "")[:120],
+      }
+    )
   return {
     "total": getattr(response, "total", 0),
     "hits": hits,
@@ -452,52 +466,57 @@ def run_search_and_display(
   name: str,
   params: dict,
   description: str | None = None,
-) -> None:
-  """Run a document search and display results."""
+) -> bool:
+  """Run a document search and display results. False if the search errored."""
   print_info_section(name, subtitle=description)
 
   try:
     result = execute_search(client, graph_id, **params)
     if not result["hits"]:
       print_warning("No search results.")
-      return
+      return True
     print_table(
       result["hits"],
       title=name,
       row_count_label=f"{result['total']} total matches",
     )
+    return True
   except Exception as exc:
     print_error(f"Search failed: {exc}")
+    return False
 
 
-def run_presets(
-  client: RoboSystemsClients, graph_id: str, presets: list[str]
-) -> None:
+def run_presets(client: RoboSystemsClients, graph_id: str, presets: list[str]) -> int:
+  """Run each preset, returning the number that failed."""
+  failures = 0
   for preset in presets:
     # Check graph query presets first, then search presets
     details = PRESET_QUERIES.get(preset)
     if details:
-      run_and_display(
+      if not run_and_display(
         client,
         graph_id,
         name=f"Preset: {preset}",
         query=details["query"],
         description=details.get("description"),
-      )
+      ):
+        failures += 1
       continue
 
     search_details = SEARCH_PRESETS.get(preset)
     if search_details:
-      run_search_and_display(
+      if not run_search_and_display(
         client,
         graph_id,
         name=f"Search: {preset}",
         params=search_details["params"],
         description=search_details.get("description"),
-      )
+      ):
+        failures += 1
       continue
 
     print_warning(f"Unknown preset: {preset}")
+  return failures
 
 
 def interactive_mode(client: RoboSystemsClients, graph_id: str) -> None:
@@ -644,7 +663,7 @@ def main() -> None:
   client = build_client(api_key, args.base_url)
 
   if args.search:
-    run_search_and_display(
+    ok = run_search_and_display(
       client,
       graph_id,
       name="Search",
@@ -655,22 +674,27 @@ def main() -> None:
         "section": args.section,
       },
     )
-    return
+    sys.exit(0 if ok else 1)
 
   if args.query:
-    run_and_display(client, graph_id, "Custom Query", args.query)
-    return
+    sys.exit(0 if run_and_display(client, graph_id, "Custom Query", args.query) else 1)
 
   if args.preset:
-    run_presets(client, graph_id, [args.preset])
-    return
+    _exit_on_failures(run_presets(client, graph_id, [args.preset]))
 
   if args.all:
-    run_presets(client, graph_id, list(PRESET_QUERIES))
-    run_presets(client, graph_id, list(SEARCH_PRESETS))
-    return
+    failures = run_presets(client, graph_id, list(PRESET_QUERIES))
+    failures += run_presets(client, graph_id, list(SEARCH_PRESETS))
+    _exit_on_failures(failures)
 
   interactive_mode(client, graph_id)
+
+
+def _exit_on_failures(failures: int) -> None:
+  if failures:
+    print_error(f"{failures} query/queries failed.")
+    sys.exit(1)
+  sys.exit(0)
 
 
 if __name__ == "__main__":

--- a/robosystems/graph_api/client/client.py
+++ b/robosystems/graph_api/client/client.py
@@ -1545,7 +1545,7 @@ class GraphClient(BaseGraphClient):
     self,
     graph_id: str,
     sql: str,
-    parameters: list[Any] | None = None,
+    parameters: list[Any] | dict[str, Any] | None = None,
     timeout: float | None = None,
   ) -> dict[str, Any]:
     """Run a read-only SQL query against DuckDB staging.

--- a/robosystems/graph_api/models/tables.py
+++ b/robosystems/graph_api/models/tables.py
@@ -96,8 +96,15 @@ class TableQueryRequest(BaseModel):
 
   graph_id: str = Field(..., description="Graph database identifier")
   sql: str = Field(..., description="SQL query to execute")
-  parameters: list[Any] | None = Field(
-    default=None, description="Query parameters for safe value substitution"
+  parameters: list[Any] | dict[str, Any] | None = Field(
+    default=None,
+    description=(
+      "Query parameters for safe value substitution. A list binds positional "
+      "placeholders (`?`, `$1`); a dict binds named ones (`$name`). DuckDB "
+      "requires the dict form for named parameters — binding them from a list "
+      "fails with 'Values were not provided for the following prepared "
+      "statement parameters'."
+    ),
   )
 
   class Config:

--- a/robosystems/middleware/auth/dependencies.py
+++ b/robosystems/middleware/auth/dependencies.py
@@ -52,6 +52,13 @@ def _validate_cached_user_data(user_data: dict) -> bool:
   if name is not None and not isinstance(name, str):
     return False
 
+  # Entries written before a field joined the payload are stale, not merely
+  # incomplete: defaulting `email_verified` here would report False for a
+  # verified user, silently downgrading an authorization input. Rejecting sends
+  # the caller to the database, which re-caches the entry in full.
+  if "email_verified" not in user_data:
+    return False
+
   is_active = user_data.get("is_active")
   return not (is_active is not None and not isinstance(is_active, bool))
 
@@ -67,6 +74,7 @@ def _create_user_from_cache(user_data: dict) -> User | None:
       id=user_data.get("id"),
       email=user_data.get("email"),
       name=user_data.get("name"),
+      email_verified=bool(user_data["email_verified"]),
       is_active=user_data.get("is_active", True),
       session_version=user_data.get("session_version", 0),
     )
@@ -118,11 +126,17 @@ def _db_check_graph_access(user_id: str, graph_id: str) -> bool:
 
 
 def _serialize_user_for_jwt_cache(user: User) -> dict[str, Any]:
-  """Serialize the stable user fields needed by JWT auth dependencies."""
+  """Serialize the stable user fields needed by JWT auth dependencies.
+
+  Every field a consumer reads off the reconstructed `User` must be here — a
+  column omitted comes back as ``None`` rather than its declared default, since
+  column defaults apply on insert and a cache-built `User` is never flushed.
+  """
   return {
     "id": str(user.id),
     "email": user.email,
     "name": user.name,
+    "email_verified": bool(user.email_verified),
     "is_active": bool(user.is_active),
     "session_version": _safe_user_session_version(user),
   }

--- a/robosystems/middleware/auth/utils.py
+++ b/robosystems/middleware/auth/utils.py
@@ -35,6 +35,50 @@ def _key_scope_allows(key_graph_id: str | None, requested_graph_id: str) -> bool
   )
 
 
+def _serialize_user_for_api_key_cache(user: User, key_record: UserAPIKey) -> dict:
+  """Serialize the user fields the API-key cache-hit path rebuilds a `User` from.
+
+  Every field a consumer reads off the reconstructed `User` must be here. A
+  column omitted from this payload comes back as ``None`` rather than its
+  declared default, because SQLAlchemy applies column defaults on insert and a
+  cache-built `User` is never flushed — so a non-optional response field reading
+  it fails validation only on a warm cache. Keep this the single definition so
+  the next field added cannot be dropped from one call site out of four.
+  """
+  return {
+    "id": user.id,
+    "name": user.name,
+    "email": user.email,
+    "email_verified": bool(user.email_verified),
+    "is_active": user.is_active,
+    "key_graph_id": key_record.graph_id,
+  }
+
+
+def _cached_user_payload_is_complete(user_data: dict) -> bool:
+  """Whether a cached payload carries every field the rebuilt `User` needs.
+
+  Entries written before a field joined the payload are treated as stale so the
+  caller falls back to the database and re-caches. Defaulting the missing field
+  instead would be worse than the crash it replaces: `email_verified` would read
+  False for a verified user, silently downgrading an authorization input rather
+  than failing loudly. The fallback costs one DB read per stale entry, once.
+  """
+  return bool(user_data.get("id")) and "email_verified" in user_data
+
+
+def _hydrate_user_from_cache(user: User, user_data: dict) -> None:
+  """Populate a bare `User` from a complete cached payload.
+
+  Callers must gate on ``_cached_user_payload_is_complete`` first.
+  """
+  user.id = user_data["id"]
+  user.name = user_data.get("name")
+  user.email = user_data.get("email")
+  user.email_verified = bool(user_data["email_verified"])
+  user.is_active = user_data.get("is_active", True)
+
+
 def _safe_cache_call(func_name: str, *args, **kwargs):
   """Safely call cache functions, handling None cache gracefully."""
   if api_key_cache is None:
@@ -71,7 +115,7 @@ def validate_api_key(api_key: str, db_session: Session | None = None) -> User | 
       return None
 
     user_data = cached_data.get("user_data", {})
-    if user_data and user_data.get("id"):
+    if user_data and _cached_user_payload_is_complete(user_data):
       logger.debug(f"API key validation cache hit: {cache_key[:8]}...")
 
       # Graph-scoped keys are never valid without a graph context (least
@@ -83,10 +127,7 @@ def validate_api_key(api_key: str, db_session: Session | None = None) -> User | 
         return None
 
       user = User()
-      user.id = user_data["id"]
-      user.name = user_data.get("name")
-      user.email = user_data.get("email")
-      user.is_active = user_data.get("is_active", True)
+      _hydrate_user_from_cache(user, user_data)
 
       # Reject keys owned by a deactivated user, even when the key row and its
       # cache entry are still marked active. Deactivation invalidates the cache
@@ -130,13 +171,7 @@ def validate_api_key(api_key: str, db_session: Session | None = None) -> User | 
       return None
 
     try:
-      user_data = {
-        "id": user.id,
-        "name": user.name,
-        "email": user.email,
-        "is_active": user.is_active,
-        "key_graph_id": key_record.graph_id,
-      }
+      user_data = _serialize_user_for_api_key_cache(user, key_record)
       _safe_cache_call(
         "cache_api_key_validation", cache_key, user_data, is_active=key_record.is_active
       )
@@ -207,7 +242,7 @@ def validate_api_key_with_graph(
       return None
 
     user_data = cached_api_key.get("user_data", {})
-    if user_data and user_data.get("id"):
+    if user_data and _cached_user_payload_is_complete(user_data):
       logger.debug(
         f"API key + graph validation cache hit: {api_key_hash[:8]}... -> {graph_id}"
       )
@@ -227,10 +262,7 @@ def validate_api_key_with_graph(
         return None
 
       user = User()
-      user.id = user_data["id"]
-      user.name = user_data.get("name")
-      user.email = user_data.get("email")
-      user.is_active = user_data.get("is_active", True)
+      _hydrate_user_from_cache(user, user_data)
 
       # Reject keys owned by a deactivated user (see validate_api_key).
       if not user.is_active:
@@ -280,13 +312,7 @@ def validate_api_key_with_graph(
         f"API key rejected: scoped to another graph: {api_key_hash[:8]}... -> {graph_id}"
       )
       try:
-        user_data = {
-          "id": user.id,
-          "name": user.name,
-          "email": user.email,
-          "is_active": user.is_active,
-          "key_graph_id": key_record.graph_id,
-        }
+        user_data = _serialize_user_for_api_key_cache(user, key_record)
         _safe_cache_call(
           "cache_api_key_validation",
           api_key_hash,
@@ -325,13 +351,7 @@ def validate_api_key_with_graph(
     if not has_access:
       # Key is valid; only the graph decision is negative. Cache both.
       try:
-        user_data = {
-          "id": user.id,
-          "name": user.name,
-          "email": user.email,
-          "is_active": user.is_active,
-          "key_graph_id": key_record.graph_id,
-        }
+        user_data = _serialize_user_for_api_key_cache(user, key_record)
         _safe_cache_call(
           "cache_api_key_validation",
           api_key_hash,
@@ -346,13 +366,7 @@ def validate_api_key_with_graph(
     key_record.update_last_used(sess)
 
     try:
-      user_data = {
-        "id": user.id,
-        "name": user.name,
-        "email": user.email,
-        "is_active": user.is_active,
-        "key_graph_id": key_record.graph_id,
-      }
+      user_data = _serialize_user_for_api_key_cache(user, key_record)
       _safe_cache_call(
         "cache_api_key_validation",
         api_key_hash,

--- a/robosystems/models/api/extensions/reports.py
+++ b/robosystems/models/api/extensions/reports.py
@@ -537,7 +537,10 @@ class LiveFinancialStatementRequest(BaseModel):
   """Request for live-financial-statement (OLTP, entity graphs only)."""
 
   statement_type: str = Field(
-    ..., description="income_statement | balance_sheet | equity_statement"
+    ...,
+    description=(
+      "income_statement | balance_sheet | cash_flow_statement | equity_statement"
+    ),
   )
   period_start: date | None = Field(
     None, description="Explicit window start. Overrides period_type/fiscal_year."

--- a/robosystems/models/api/graphs/tables.py
+++ b/robosystems/models/api/graphs/tables.py
@@ -50,15 +50,22 @@ class SqlStatementRequest(BaseModel):
     examples=[
       "SELECT * FROM Entity WHERE entity_type = ? LIMIT ?",
       "SELECT COUNT(*) FROM Transaction WHERE amount > ? AND date >= ?",
+      "SELECT * FROM Entity WHERE industry = $industry LIMIT $limit",
       "SELECT * FROM Entity LIMIT 10",
     ],
   )
-  parameters: list[Any] | None = Field(
+  parameters: list[Any] | dict[str, Any] | None = Field(
     default=None,
-    description="Query parameters for safe value substitution. ALWAYS use parameters instead of string concatenation.",
+    description=(
+      "Query parameters for safe value substitution. ALWAYS use parameters "
+      "instead of string concatenation. Pass a list for positional "
+      "placeholders (`?` or `$1`) and an object for named ones "
+      "(`$param_name`) — the two forms cannot be mixed in one statement."
+    ),
     examples=[
       ["Company", 100],
       [1000, "2024-01-01"],
+      {"industry": "Technology", "limit": 10},
       None,
     ],
   )

--- a/robosystems/operations/event_block/__init__.py
+++ b/robosystems/operations/event_block/__init__.py
@@ -5,6 +5,7 @@ path regardless of internal layout.
 """
 
 from .commands import (
+  DuplicateEventError,
   EventNotFoundError,
   InvalidEventTransitionError,
   create_event_block,
@@ -14,6 +15,7 @@ from .commands import (
 )
 
 __all__ = [
+  "DuplicateEventError",
   "EventNotFoundError",
   "InvalidEventTransitionError",
   "create_event_block",

--- a/robosystems/operations/event_block/commands.py
+++ b/robosystems/operations/event_block/commands.py
@@ -65,6 +65,25 @@ class InvalidEventTransitionError(Exception):
   pass
 
 
+class DuplicateEventError(Exception):
+  """Raised when (source, external_id) already names an event on this graph.
+
+  `idx_events_source_external` is the deduplication key for external
+  integrations: it is what makes re-delivering the same upstream record safe.
+  Without this check the insert reached the database and the IntegrityError
+  escaped as an opaque 500, so a connector retrying a delivery — or a demo
+  re-run — could not tell "already ingested" from a real fault, which is the
+  one distinction the index exists to provide.
+  """
+
+  def __init__(self, source: str, external_id: str) -> None:
+    super().__init__(
+      f"Event already exists for source={source} external_id={external_id}"
+    )
+    self.source = source
+    self.external_id = external_id
+
+
 # Valid outbound transitions from each status.
 # Terminal states (fulfilled, voided, superseded) have empty sets — no further
 # transitions allowed. `superseded` is reachable from any non-terminal state
@@ -96,6 +115,23 @@ def _resolve_agent_type(session: Session, agent_id: str | None) -> str | None:
 # and external sources validate against the graph's registered Connections
 # instead: registering a connection is what opens a source name.
 _STATIC_EVENT_SOURCES = frozenset({"manual", "system", "schedule"})
+
+
+def _assert_not_duplicate(session: Session, body: CreateEventBlockRequest) -> None:
+  """Reject a re-post of an already-ingested (source, external_id) pair.
+
+  Mirrors the partial unique index, which only applies when external_id is
+  not null — events without one are not deduplicated and are skipped here too.
+  """
+  if not body.external_id:
+    return
+  existing = (
+    session.query(Event.id)
+    .filter(Event.source == body.source, Event.external_id == body.external_id)
+    .first()
+  )
+  if existing is not None:
+    raise DuplicateEventError(body.source, body.external_id)
 
 
 def _validate_event_source(source: str, graph_id: str) -> None:
@@ -195,6 +231,7 @@ def create_event_block(
   rolls back.
   """
   _validate_event_source(body.source, graph_id)
+  _assert_not_duplicate(session, body)
 
   if body.apply_handlers:
     # 1. Python registry wins over DSL registry

--- a/robosystems/operations/event_block/commands.py
+++ b/robosystems/operations/event_block/commands.py
@@ -257,8 +257,15 @@ def create_event_block(
       # Handler executes; errors roll back the whole unit of work.
       python_handler.dispatch(session, event, typed_metadata, created_by)
 
+      # Read the row into the envelope BEFORE committing. `commit()` expires
+      # every attribute on the instance, so a later `event.id` triggers a
+      # reload — and if that reload comes back empty the ORM raises
+      # ObjectDeletedError, which surfaces as a 500 for a write that already
+      # succeeded. That is the worst failure shape available: the caller is
+      # told the write failed, so a retry duplicates a committed event.
+      envelope = _to_envelope(event, body.dimension_ids)
       session.commit()
-      return _to_envelope(event, body.dimension_ids)
+      return envelope
 
     # 2. Fall through to the DSL registry
     agent_type = _resolve_agent_type(session, body.agent_id)
@@ -285,8 +292,10 @@ def create_event_block(
     # Fire handler — flushes Transaction + Entry + LineItems inside
     apply_handler(session, event, handler, created_by=created_by)
 
+    # Envelope before commit — see the python-handler path above.
+    envelope = _to_envelope(event, body.dimension_ids)
     session.commit()
-    return _to_envelope(event, body.dimension_ids)
+    return envelope
 
   # Capture-only path (apply_handlers=False)
   event = _build_event_row(body, created_by, status="captured")
@@ -299,8 +308,10 @@ def create_event_block(
       [{"event_id": event.id, "dimension_id": d} for d in body.dimension_ids],
     )
 
+  # Envelope before commit — see the python-handler path above.
+  envelope = _to_envelope(event, body.dimension_ids)
   session.commit()
-  return _to_envelope(event, body.dimension_ids)
+  return envelope
 
 
 def fire_handler_on_commit(
@@ -416,8 +427,11 @@ def update_event_block(
     # Errors propagate; the surrounding transaction rolls back.
     fire_handler_on_commit(session, event, created_by)
 
+  # Envelope before commit — see `create_event_block`. The dimension read has
+  # to happen here too: it reads `event.id`, which is expired by the commit.
+  envelope = _to_envelope(event, _load_dimension_ids(session, event.id))
   session.commit()
-  return _to_envelope(event, _load_dimension_ids(session, event.id))
+  return envelope
 
 
 def _python_preview_to_response(preview) -> PreviewEventBlockResponse:

--- a/robosystems/operations/graph/repository_subscription_service.py
+++ b/robosystems/operations/graph/repository_subscription_service.py
@@ -52,6 +52,31 @@ def get_available_plans_for_repository(
   return list(manifest.plans.keys())
 
 
+def _invalidate_graph_access_cache(user_id: str, repository_name: str) -> None:
+  """Drop the cached API-key access decision for a repository.
+
+  ``validate_api_key_with_graph`` caches the allow/deny answer per API key and
+  graph, so a denial recorded before the subscription existed outlives the
+  grant for the whole TTL: the subscriber pays and is refused with a 403 until
+  it expires. The grant and revoke paths are the only moments the answer can
+  change, so both clear it here.
+
+  Best-effort by design — the cache repopulates from the database on the next
+  request, so a Redis failure costs a stale entry, not a broken grant, and must
+  not fail the provisioning that already committed.
+  """
+  try:
+    import importlib
+
+    cache_module = importlib.import_module("robosystems.middleware.auth.cache")
+    cache_module.api_key_cache.invalidate_user_graph_access(user_id, repository_name)
+  except Exception as e:
+    logger.warning(
+      f"Failed to invalidate graph access cache for user {user_id}, "
+      f"repository {repository_name}: {e}"
+    )
+
+
 class RepositorySubscriptionService:
   """Service for managing shared repository subscriptions and access."""
 
@@ -381,6 +406,7 @@ class RepositorySubscriptionService:
         existing.updated_at = datetime.now(UTC)
         self.session.commit()
         logger.info(f"Reactivated access for user {user_id}")
+        _invalidate_graph_access_cache(user_id, repository_type.value)
       return True
 
     if repository_plan is None:
@@ -418,6 +444,8 @@ class RepositorySubscriptionService:
       f"plan {repository_plan}"
     )
 
+    _invalidate_graph_access_cache(user_id, repository_type.value)
+
     return True
 
   def revoke_access(
@@ -445,5 +473,7 @@ class RepositorySubscriptionService:
     logger.info(
       f"Revoked access for user {user_id}, repository {repository_type.value}"
     )
+
+    _invalidate_graph_access_cache(user_id, repository_type.value)
 
     return True

--- a/robosystems/operations/roboledger/commands/taxonomies.py
+++ b/robosystems/operations/roboledger/commands/taxonomies.py
@@ -55,6 +55,7 @@ __all__ = [
   "AssociationNotFoundError",
   "ElementNotFoundError",
   "LibraryImmutableError",
+  "MappingAssociationExistsError",
   "MappingStructureNotFoundError",
   "StructureNotFoundError",
   "TaxonomyNotFoundError",
@@ -111,6 +112,26 @@ class ElementNotFoundError(LookupError):
     super().__init__(f"{side} element not found: {element_id}")
     self.side = side  # "source" or "target"
     self.element_id = element_id
+
+
+class MappingAssociationExistsError(ValueError):
+  """Raised when the association already exists on the mapping structure.
+
+  `uq_association_structure_elements_type` makes the pair unique per structure
+  and type. Without this check the insert reached the database and surfaced the
+  IntegrityError as an opaque 500, which a caller cannot tell apart from a real
+  fault — so re-running a seeding script had no safe way to skip what it had
+  already created.
+  """
+
+  def __init__(self, mapping_id: str, from_element_id: str, to_element_id: str) -> None:
+    super().__init__(
+      f"Mapping association already exists on {mapping_id}: "
+      f"{from_element_id} → {to_element_id}"
+    )
+    self.mapping_id = mapping_id
+    self.from_element_id = from_element_id
+    self.to_element_id = to_element_id
 
 
 def _taxonomy_to_response(row: Taxonomy) -> TaxonomyResponse:
@@ -197,9 +218,9 @@ def create_mapping_association(
   """Add a mapping association (CoA element → reporting concept).
 
   Raises `MappingStructureNotFoundError` if the mapping structure is
-  missing, or `ElementNotFoundError` with `side="source"` / `"target"`
-  if either element is missing. The caller translates these to HTTP
-  status codes.
+  missing, `ElementNotFoundError` with `side="source"` / `"target"` if
+  either element is missing, or `MappingAssociationExistsError` if the pair
+  is already mapped. The caller translates these to HTTP status codes.
   """
   structure = session.execute(
     select(Structure).where(Structure.id == body.mapping_id)
@@ -226,6 +247,21 @@ def create_mapping_association(
   ).scalar_one_or_none()
   if to_elem is None:
     raise ElementNotFoundError("target", body.to_element_id)
+
+  # Pre-check the uniqueness the DB enforces, so a repeat gets a clean 409
+  # instead of an IntegrityError escaping as a 500.
+  existing = session.execute(
+    select(Association).where(
+      Association.structure_id == body.mapping_id,
+      Association.from_element_id == body.from_element_id,
+      Association.to_element_id == body.to_element_id,
+      Association.association_type == body.association_type,
+    )
+  ).scalar_one_or_none()
+  if existing is not None:
+    raise MappingAssociationExistsError(
+      body.mapping_id, body.from_element_id, body.to_element_id
+    )
 
   assoc = Association(
     id=generate_prefixed_ulid("assoc"),

--- a/robosystems/routers/extensions/roboledger/operations.py
+++ b/robosystems/routers/extensions/roboledger/operations.py
@@ -199,6 +199,7 @@ from robosystems.models.api.taxonomy_block import (
 )
 from robosystems.models.core import User
 from robosystems.operations.event_block import (
+  DuplicateEventError,
   EventNotFoundError,
   InvalidEventTransitionError,
 )
@@ -402,6 +403,7 @@ from robosystems.operations.roboledger.commands.taxonomies import (
   AssociationNotFoundError,
   ElementNotFoundError,
   EntityNotFoundError,
+  MappingAssociationExistsError,
   MappingStructureNotFoundError,
 )
 from robosystems.operations.roboledger.commands.taxonomies import (
@@ -1068,6 +1070,10 @@ create_mapping_association_op = _registrar.register(
         400,
         lambda e: f"{e.side.capitalize()} element not found",  # type: ignore[attr-defined]
       ),
+      MappingAssociationExistsError: (
+        409,
+        lambda _e: "Mapping association already exists",
+      ),
     },
     mark_stale_reason="mapping_association_created",
   )
@@ -1507,6 +1513,12 @@ create_event_block_op = _registrar.register(
     request_model=CreateEventBlockRequest,
     result_type=EventBlockEnvelope,
     error_map={
+      # Ahead of the broad `ValueError: 422` below so a repeat delivery is
+      # reported as a conflict rather than a validation failure.
+      DuplicateEventError: (
+        409,
+        lambda _e: "Event already ingested for this source and external_id",
+      ),
       HandlerNotFoundError: 404,
       HandlerAmbiguousError: 409,
       TemplateInterpolationError: 422,

--- a/robosystems/routers/graphs/operator/execute.py
+++ b/robosystems/routers/graphs/operator/execute.py
@@ -143,7 +143,16 @@ async def list_operators_endpoint(
   "/operator",
   response_model=OperatorResponse,
   summary="Auto-select Operator for Query",
-  description="Routes to the best operator for your query. Operators: `financial` (SEC, accounting), `research` (deep analysis), `rag` (knowledge base, free). Credit cost by mode: `quick` 5-10, `standard` 15-25, `extended` 30-75. Execution strategy (sync/SSE/async) auto-selected; override with `?mode=sync|async`.",
+  description=(
+    "Routes to the best operator for your query. Operators: `cypher` "
+    "(answers natural-language questions by querying the graph; supports "
+    "`quick`, `standard`, `extended`) and `mapping` (autonomous Chart of "
+    "Accounts → rs-gaap mapping; roboledger graphs only, `extended` only). "
+    "`GET /v1/graphs/{graph_id}/operator` lists what is registered. Credits "
+    "are consumed by actual token usage, not a fixed price per mode. "
+    "Execution strategy (sync/SSE/async) auto-selected; override with "
+    "`?mode=sync|async`."
+  ),
   operation_id="autoSelectOperator",
   responses={
     **RESOURCE_ERROR_RESPONSES,
@@ -304,7 +313,13 @@ async def get_operator_metadata(
   "/operator/{operator_type}",
   response_model=OperatorResponse,
   summary="Execute Specific Operator",
-  description="Available: `financial` (SEC filings, accounting), `research` (deep analysis), `rag` (retrieval, no credits). Execution strategy auto-selected; override with `?mode=sync|async`.",
+  description=(
+    "Available: `cypher` (natural-language questions answered by querying the "
+    "graph; RAG retrieval is one of its capabilities, not a separate operator) "
+    "and `mapping` (Chart of Accounts → rs-gaap mapping, roboledger graphs "
+    "only). `GET /v1/graphs/{graph_id}/operator` lists what is registered. "
+    "Execution strategy auto-selected; override with `?mode=sync|async`."
+  ),
   operation_id="executeSpecificOperator",
   responses={
     **RESOURCE_ERROR_RESPONSES,

--- a/robosystems/routers/graphs/query/execute.py
+++ b/robosystems/routers/graphs/query/execute.py
@@ -27,6 +27,7 @@ from sse_starlette.sse import EventSourceResponse
 
 from robosystems.config.graph_tier import GraphTier
 from robosystems.database import get_db_session
+from robosystems.graph_api.client.exceptions import GraphTransientError
 from robosystems.logger import api_logger, log_metric, logger
 from robosystems.middleware.auth.dependencies import get_current_user_with_graph
 from robosystems.middleware.graph import get_universal_repository
@@ -775,7 +776,14 @@ async def execute_cypher_query(
     )
 
   except HTTPException as exc:
-    if exc.status_code >= 500:
+    # 503 is deliberate backpressure (admission control, rebuilding, full
+    # queue), not a fault of the graph. Counting it as a breaker failure turns
+    # a resource ceiling into an outage: the rejections trip the breaker and
+    # every subsequent query fails even once the pressure clears.
+    if (
+      exc.status_code >= 500
+      and exc.status_code != http_status.HTTP_503_SERVICE_UNAVAILABLE
+    ):
       circuit_breaker.record_failure(graph_id, "cypher_query")
     record_shared_query_outcome(
       graph_id,
@@ -795,6 +803,48 @@ async def execute_cypher_query(
       source="query_cypher",
     )
     raise
+
+  except GraphTransientError as e:
+    # The Graph API rejected the request rather than failing it — admission
+    # control (memory/CPU/connection headroom), a 502/504, or its own client
+    # breaker already being open. Surface the reason as 503 + Retry-After so
+    # the caller can back off, and do not record a breaker failure: the graph
+    # is healthy, just at capacity.
+    retry_after = 30
+    logger.warning(f"Graph API unavailable for {graph_id}: {e}")
+    record_shared_query_outcome(
+      graph_id,
+      current_user.id,
+      status_code=http_status.HTTP_503_SERVICE_UNAVAILABLE,
+      api_key_prefix=key_prefix,
+      endpoint="/v1/graphs/{graph_id}/query/cypher",
+      source="query_cypher",
+    )
+    log_shared_query_end(
+      exec_id,
+      graph_id,
+      current_user.id,
+      outcome="http_503",
+      duration_ms=(datetime.now(UTC) - start_time).total_seconds() * 1000,
+      api_key_prefix=key_prefix,
+      source="query_cypher",
+    )
+    get_endpoint_metrics().record_business_event(
+      endpoint="/v1/graphs/{graph_id}/query",
+      method="POST",
+      event_type="query_admission_control_rejected",
+      event_data={
+        "graph_id": graph_id,
+        "query_length": len(request.query) if request else 0,
+        "error_message": str(e),
+      },
+      user_id=current_user.id if current_user else None,
+    )
+    raise HTTPException(
+      status_code=http_status.HTTP_503_SERVICE_UNAVAILABLE,
+      detail=str(e),
+      headers={"Retry-After": str(retry_after)},
+    )
 
   except Exception as e:
     circuit_breaker.record_failure(graph_id, "cypher_query", error=e)

--- a/tests/middleware/auth/test_dependencies.py
+++ b/tests/middleware/auth/test_dependencies.py
@@ -37,6 +37,7 @@ class TestCachedUserDataValidation:
       "id": 123,
       "email": "test@example.com",
       "name": "Test User",
+      "email_verified": True,
       "is_active": True,
     }
 
@@ -47,9 +48,26 @@ class TestCachedUserDataValidation:
     minimal_data = {
       "id": "user123",
       "email": "user@test.com",
+      "email_verified": False,
     }
 
     assert _validate_cached_user_data(minimal_data) is True
+
+  def test_validate_cached_user_data_missing_email_verified(self):
+    """A payload predating `email_verified` is stale, not merely incomplete.
+
+    Accepting it would rebuild a User whose `email_verified` is None — which
+    fails `UserResponse` validation as a 500 — or, if defaulted, would report
+    False for a verified user. Rejecting sends the caller to the database.
+    """
+    data = {
+      "id": "user123",
+      "email": "user@test.com",
+      "name": "Test User",
+      "is_active": True,
+    }
+
+    assert _validate_cached_user_data(data) is False
 
   def test_validate_cached_user_data_invalid_type(self):
     """Test validation fails with non-dict input."""
@@ -102,6 +120,7 @@ class TestCachedUserDataValidation:
       "id": 123,
       "email": "test@example.com",
       "name": "Test User",
+      "email_verified": True,
       "is_active": True,
     }
 
@@ -111,6 +130,7 @@ class TestCachedUserDataValidation:
     assert user.id == 123
     assert user.email == "test@example.com"
     assert user.name == "Test User"
+    assert user.email_verified is True
     assert user.is_active is True
 
   def test_create_user_from_cache_minimal_data(self):
@@ -118,6 +138,7 @@ class TestCachedUserDataValidation:
     user_data = {
       "id": "user456",
       "email": "minimal@example.com",
+      "email_verified": False,
     }
 
     user = _create_user_from_cache(user_data)
@@ -126,7 +147,27 @@ class TestCachedUserDataValidation:
     assert user.id == "user456"
     assert user.email == "minimal@example.com"
     assert user.name is None
+    assert user.email_verified is False
     assert user.is_active is True  # Default value
+
+  def test_create_user_from_cache_never_leaves_email_verified_none(self):
+    """`email_verified` must be a bool, never None, on the cache path.
+
+    `User.email_verified` is `nullable=False` with a column default, but column
+    defaults apply on insert and a cache-built User is never flushed — so an
+    omitted field arrives as None and only fails downstream, in `UserResponse`,
+    as a 500 on the warm-cache path alone. This pins the invariant at the source.
+    """
+    user_data = {
+      "id": "user789",
+      "email": "verified@example.com",
+      "email_verified": True,
+    }
+
+    user = _create_user_from_cache(user_data)
+
+    assert user is not None
+    assert isinstance(user.email_verified, bool)
 
   def test_create_user_from_cache_invalid_data(self):
     """Test creating user fails with invalid cached data."""
@@ -147,6 +188,7 @@ class TestCachedUserDataValidation:
       "id": 123,
       "email": "test@example.com",
       "name": "Test User",
+      "email_verified": True,
       "is_active": True,
     }
 
@@ -167,6 +209,7 @@ class TestCachedUserDataValidation:
     user_data = {
       "id": 123,
       "email": "test@example.com",
+      "email_verified": False,
     }
 
     with patch("robosystems.middleware.auth.dependencies.User") as mock_user_class:
@@ -320,6 +363,7 @@ class TestGetUserForVerifiedJWT:
         "id": "user_cache",
         "email": "cache@example.com",
         "name": "Cache User",
+        "email_verified": True,
         "is_active": True,
         "session_version": 5,
       }
@@ -782,7 +826,12 @@ class TestGetCurrentUserWithGraph:
     auth_token = "valid.jwt.token"
     user_id = "user123"
     cached_data = {
-      "user_data": {"id": user_id, "email": "test@example.com", "is_active": True}
+      "user_data": {
+        "id": user_id,
+        "email": "test@example.com",
+        "email_verified": True,
+        "is_active": True,
+      }
     }
 
     mock_verify_jwt.return_value = (user_id, 0)
@@ -1104,6 +1153,7 @@ class TestSecurityScenarios:
     xss_data = {
       "id": 123,
       "email": "test@example.com",
+      "email_verified": True,
       "name": "<script>alert('xss')</script>",
       "is_active": True,
     }
@@ -1121,6 +1171,7 @@ class TestSecurityScenarios:
     sql_injection_data = {
       "id": "1'; DROP TABLE users; --",
       "email": "test@example.com",
+      "email_verified": True,
       "is_active": True,
     }
 
@@ -1162,6 +1213,7 @@ class TestSecurityScenarios:
     large_data = {
       "id": 123,
       "email": "test@example.com",
+      "email_verified": True,
       "name": large_name,
       "is_active": True,
     }
@@ -1206,7 +1258,8 @@ class TestSecurityScenarios:
     ]
 
     for email, expected_valid in edge_case_emails:
-      data = {"id": 123, "email": email}
+      # email_verified present so the email rule is the only thing varying.
+      data = {"id": 123, "email": email, "email_verified": False}
       is_valid = _validate_cached_user_data(data)
       assert is_valid == expected_valid, f"Email '{email}' validation mismatch"
 

--- a/tests/middleware/auth/test_utils.py
+++ b/tests/middleware/auth/test_utils.py
@@ -31,6 +31,7 @@ class TestValidateAPIKey:
         "id": "user123",
         "name": "Test User",
         "email": "test@example.com",
+        "email_verified": True,
         "is_active": True,
       },
     }
@@ -118,6 +119,7 @@ class TestValidateAPIKey:
         "id": "user123",
         "name": "Test User",
         "email": "test@example.com",
+        "email_verified": True,
         "is_active": False,  # but the owning user is deactivated
       },
     }
@@ -439,6 +441,7 @@ class TestGraphScopedKeys:
         "id": "user123",
         "name": "Test User",
         "email": "test@example.com",
+        "email_verified": True,
         "is_active": True,
         "key_graph_id": "kg123",
       },
@@ -554,6 +557,7 @@ class TestGraphScopedKeys:
         "id": "user123",
         "name": "Test User",
         "email": "test@example.com",
+        "email_verified": True,
         "is_active": True,
         "key_graph_id": None,
       },
@@ -575,6 +579,7 @@ class TestGraphScopedKeys:
         "id": "user123",
         "name": "Test User",
         "email": "test@example.com",
+        "email_verified": True,
         "is_active": True,
         "key_graph_id": "kg123",
       },
@@ -600,6 +605,7 @@ class TestGraphScopedKeys:
         "id": "user123",
         "name": "Test User",
         "email": "test@example.com",
+        "email_verified": True,
         "is_active": True,
         "key_graph_id": "kg123",
       },

--- a/tests/operations/event_block/test_commands_envelope_ordering.py
+++ b/tests/operations/event_block/test_commands_envelope_ordering.py
@@ -1,0 +1,132 @@
+"""The response envelope must be built before the session is committed.
+
+`session.commit()` expires every attribute on the instances in the session, so
+reading `event.id` afterwards makes the ORM reload the row. When that reload
+comes back empty the ORM raises `ObjectDeletedError`, which reaches the client
+as a 500 for a write that already committed — the caller is told the write
+failed, so a retry duplicates a persisted event.
+
+These tests pin the ordering rather than the symptom: the reload only fails
+under conditions a unit test cannot reproduce (it depends on what the session's
+connection can still see post-commit), but the ordering that makes the reload
+possible at all is exactly what regressed, and it is directly observable.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+from robosystems.models.api.event_block import CreateEventBlockRequest
+from robosystems.operations.event_block.commands import create_event_block
+
+GRAPH_ID = "kg0123456789abcdef"
+
+
+def _patch_platform() -> tuple:
+  """Patch the platform lookups `_validate_event_source` reaches for."""
+  session_factory = MagicMock()
+  session_factory.return_value.__enter__ = MagicMock(return_value=MagicMock())
+  session_factory.return_value.__exit__ = MagicMock(return_value=False)
+  return (
+    patch("robosystems.database.SessionFactory", session_factory),
+    patch(
+      "robosystems.models.core.connection.connection.Connection.get_all_for_graph",
+      MagicMock(return_value=[]),
+    ),
+  )
+
+
+def _capture_only_body() -> CreateEventBlockRequest:
+  return CreateEventBlockRequest(
+    event_type="bank_transaction",
+    event_category="treasury",
+    source="manual",
+    occurred_at=datetime(2026, 7, 1, tzinfo=UTC),
+    metadata={},
+    apply_handlers=False,
+  )
+
+
+def _session_recording_order(events: list[str]) -> MagicMock:
+  """A session that records commit, and whose duplicate probe finds nothing."""
+  session = MagicMock()
+  session.query.return_value.filter.return_value.first.return_value = None
+  session.commit.side_effect = lambda: events.append("commit")
+
+  added: list = []
+  session.add.side_effect = lambda obj: added.append(obj)
+
+  def fake_flush():
+    for obj in added:
+      if getattr(obj, "id", None) is None:
+        obj.id = "evt_test"
+
+  session.flush.side_effect = fake_flush
+  return session
+
+
+def test_envelope_is_built_before_commit() -> None:
+  """`_to_envelope` must run while the instance's attributes are still loaded."""
+  order: list[str] = []
+  session = _session_recording_order(order)
+
+  real_to_envelope = None
+
+  def spy_to_envelope(event, dimension_ids):
+    order.append("to_envelope")
+    return real_to_envelope(event, dimension_ids)
+
+  import robosystems.operations.event_block.commands as commands_mod
+
+  real_to_envelope = commands_mod._to_envelope
+
+  factory_patch, lookup_patch = _patch_platform()
+  with (
+    factory_patch,
+    lookup_patch,
+    patch.object(commands_mod, "_to_envelope", spy_to_envelope),
+  ):
+    create_event_block(
+      session, _capture_only_body(), created_by="usr_test", graph_id=GRAPH_ID
+    )
+
+  assert order == ["to_envelope", "commit"], (
+    "envelope must be built before commit; building it after means a committed "
+    "write can be reported as a 500"
+  )
+
+
+def test_envelope_survives_post_commit_expiry() -> None:
+  """The envelope must be complete before commit expires the instance state.
+
+  Commit clears the instance dict, which is what SQLAlchemy's expiry does: the
+  values are gone and the next read has to hit the database. Building the
+  envelope first means the response never depends on that reload — which is the
+  reload that can fail and turn a committed write into a 500.
+
+  Expiry is applied per instance, never by patching the mapped class: mutating
+  `Event` would leak into every later test in the session.
+  """
+  session = MagicMock()
+  session.query.return_value.filter.return_value.first.return_value = None
+
+  added: list = []
+  session.add.side_effect = lambda obj: added.append(obj)
+
+  def fake_flush():
+    for obj in added:
+      if getattr(obj, "id", None) is None:
+        obj.id = "evt_test"
+
+  session.flush.side_effect = fake_flush
+  session.commit.side_effect = lambda: [obj.__dict__.clear() for obj in added]
+
+  factory_patch, lookup_patch = _patch_platform()
+  with factory_patch, lookup_patch:
+    envelope = create_event_block(
+      session, _capture_only_body(), created_by="usr_test", graph_id=GRAPH_ID
+    )
+
+  assert envelope.id == "evt_test"
+  assert envelope.source == "manual"

--- a/tests/operations/event_block/test_commands_source_validation.py
+++ b/tests/operations/event_block/test_commands_source_validation.py
@@ -129,6 +129,10 @@ class TestCreateEventBlockSourceGate:
     )
     added: list = []
     session.add.side_effect = lambda obj: added.append(obj)
+    # No prior event with this (source, external_id). A bare MagicMock would
+    # return a truthy row from the duplicate probe and trip the conflict guard,
+    # which this test is not about.
+    session.query.return_value.filter.return_value.first.return_value = None
 
     def fake_flush():
       for obj in added:


### PR DESCRIPTION
## Summary

A full local reset and an end-to-end run of every demo turned up nine defects. They share a shape: each is invisible on a cold, first-time run, so the test suite passed straight over all of them. Three only appear once a cache is warm or a container is loaded, four are documentation describing behaviour the code does not implement, and two are demos reporting success over failed steps — which is why the others survived earlier runs unnoticed.

All ten demos now pass end to end, and the two Seattle Method demos are genuinely re-runnable, which their docs have always claimed.

## Changes

**Warm-path defects (`robosystems/middleware/auth/`, `robosystems/routers/graphs/query/`, `robosystems/operations/graph/`)**

- **Repository access cached its own denial.** `validate_api_key_with_graph` caches the allow/deny answer per key and graph, and nothing invalidated it when access was *granted* — so a denial recorded before a user subscribed outlived the subscription for the cache TTL, and the subscriber was refused. `invalidate_user_graph_access` already existed for exactly this and had no callers anywhere; `grant_access` / `revoke_access` now call it.
- **`GET /v1/user` returned 500 on a warm cache.** `email_verified` was missing from all five cached-user payload builders and all three reconstructions. The column has `default=False`, but column defaults apply on insert and a cache-built `User` never flushes, so it stayed `None` and `UserResponse` rejected it. **Worth a close look:** defaulting the missing field would have been worse than the crash — it reports `False` for a verified user, silently downgrading an authorization input — so a payload lacking the field is treated as stale and falls back to the database, which re-caches it in full. Self-healing, no cache flush needed on deploy. The four duplicated payload dicts are now one serializer, since building them in four places is how the field went missing from all four.
- **Capacity rejection surfaced as 500 and tripped the circuit breaker.** The Graph API correctly returns 503 with a reason; the client maps that to `GraphTransientError`, which fell through to the generic handler. That turned a resource ceiling into a self-sustaining outage — the rejections opened the breaker and every later query failed even once pressure cleared. Now 503 + `Retry-After`, and 503 never counts as a breaker failure.

**Committed writes reported as failures (`robosystems/operations/event_block/`, `robosystems/operations/roboledger/commands/taxonomies.py`)**

- **`create_event_block` reported a committed write as a 500.** The envelope was built *after* `session.commit()`, which expires the instance, so reading `event.id` triggered a reload that could come back empty → `ObjectDeletedError` → 500 for a write already in the ledger. A client retrying a 5xx then duplicates it. All four sites now build the envelope while the instance is loaded, then commit.
- **Repeat writes returned an opaque 500 instead of 409.** `create-event-block` (`source`, `external_id`) and `create-mapping-association` (`uq_association_structure_elements_type`) let unique-constraint violations escape as unhandled `IntegrityError`. That defeats the point of `idx_events_source_external`, which exists so re-delivering an upstream record is safe — a connector could not tell "already ingested" from a server fault, and 5xx reads as *retry* to most HTTP stacks. Both now pre-check and raise a typed error → 409, ordered ahead of the broad `ValueError: 422` in their error maps.

**Served contract corrected (`robosystems/models/api/`, `robosystems/routers/graphs/operator/`, `bin/setup/`)**

- **SQL named parameters could not be supplied.** `SqlStatementRequest.sql` tells callers to use `$param_name`, but `parameters` was `list[Any] | None` — a list only binds positional placeholders, so the documented form always failed. DuckDB binds named parameters from a dict; `parameters` now accepts either. The Cypher path already took `dict[str, Any]`, so this also removes an inconsistency between the two query surfaces.
- **The operator endpoints advertised three operators that do not exist.** Both descriptions named `financial`, `research`, `rag` with a per-mode credit table. The registry ships `cypher` and `mapping`, and credits are charged on token usage, not a fixed price per mode. Rewritten against the live registry, now pointing at `GET /v1/graphs/{graph_id}/operator` rather than enumerating.
- `live-financial-statement` omitted `cash_flow_statement`, though `LIVE_STATEMENT_TYPES` and the MCP enum both accept it.
- **Bootstrap seeded two retired SSM flag names.** `EXTENSIONS_ENABLED` and `LEDGER_ENABLED` are read nowhere — the code reads `ROBOLEDGER_ENABLED`, `ROBOINVESTOR_ENABLED`, `EXTENSIONS_GRAPHQL_ENABLED`. `EXTENSIONS_ENABLED` is worse than dead: it is a derived property, so it can never be settable, and an operator setting it to `false` got no effect while extensions stayed on. A fresh fork got two inert parameters and none of the three live toggles.

**Demos reporting success over failure (`examples/`)**

- `custom-graph` exited 0 with all six count checks and all seven presets failed; `sec-demo` did the same across fifteen presets and the document search. Both now fail the run.
- The GL ingests appended API failures to the same `warnings` list as benign payload notes, so a lost write hid behind a note — World Online reported "3388 ok, 3 warnings" and exited 0 while one entry never posted. Failures are counted apart and abort before the reconciliation, since reconciling a ledger with holes reports a lost write as a modelling difference.
- **`JE-225` had never posted, on any run.** Both its source lines carry `Amount=0` and the API correctly rejects a line item with no non-zero debit or credit. It went unnoticed because a zero-amount entry contributes nothing, so the reconciliation still matched 18/18 — green because it wasn't looking. Now detected from the payload before posting and reported as a source data-quality note.
- `memory_subgraph` wrote semantic memories to the subgraph, which the API refuses by design (403). It printed four 403s, declared success, and pointed the reader at a recall endpoint that would never answer. Now runs against the parent graph, as the error message instructs.
- Five Seattle Method / World Online steps called `.get()` on ariadne-generated GraphQL models, which are Pydantic with attribute access. The first aborted the demo; the rest would have failed one step at a time.

**Local dev (`compose.yaml`)** — graph-api raised 2g → 6g. It runs `ladybug-standard`, whose config assumes a dedicated 4GB instance holding one database, while `LBUG_DATABASES_PER_INSTANCE` lets it hold every local graph. At 2g it fit exactly one database and then rejected every query — which is what exposed the 500-vs-503 mapping above.

## Breaking Changes

None.

Three changes are SDK-visible but additive, all in the **generated tier** — no facade, root export, or symbol on the integration template's emit path is touched, so this rides a client minor rather than a major:

- `SqlStatementRequest.parameters` widens `list[Any] | None` → `list[Any] | dict[str, Any] | None`. Purely additive; positional binding is unchanged and verified.
- `create-event-block` and `create-mapping-association` gain a `409` response. New status on an existing operation; no request or success-response shape changes.
- Description text corrected on the two operator endpoints and on `live-financial-statement`'s `statement_type`.

Worth an SDK regen to pick these up, but nothing here requires coordination.

## Testing

- `just test` — **12,430 passed, 23 skipped, 101 deselected** (final run, after all commits).
- `just test-code` — ruff, format, basedpyright, cf-lint all pass.
- **Demo suite, run end to end against a freshly reset local stack**: roboledger (42/42 checks, 10,379 rows, report filed, SHACL conforms + Arelle valid), custom-graph, sec (NVDA 2025 — 4 quarters loaded, all presets + document search), coffee-roaster (16,018 rows), saas-startup (16,542 rows), roboinvestor (31/31, including the cross-graph `Portfolio → Position → Security → Entity → Report → Fact` traversal), seattle-method (18/18 exact match, |Δ| = $0.00, balance sheet balances at $14,450.00), world-online (22/23 — the one mismatch is flagged upstream data quality — trial balance balances).
- **Re-run verified**, since idempotency is the documented contract: seattle-method and world-online both exit 0 on a second run against their existing graphs, skipping what already exists and reporting what they skipped.
- **Fixes verified by observed behaviour, not by reading the diff**: repository-access lockout reproduced as 403 → subscribe → 200; `email_verified` confirmed against the database row rather than trusting the response; duplicate event returns 409; named SQL binding confirmed to actually filter (`$ind` → `Aerospace` → `Aerospace Innovators 6`), not merely parse.
- The two new envelope-ordering tests were confirmed to **fail against the previous ordering** before being kept, so they detect the regression rather than merely passing.
