### PR TITLE
fix(reports): make a shared report render for its recipient

### DIFF
--- a/.github/release-notes/v1.8.0.md
+++ b/.github/release-notes/v1.8.0.md
@@ -3,7 +3,8 @@ backups that run on a schedule, carry the right contents, and can be opened — 
 that had been advertised without being finished, subgraphs and cross-graph report sharing, were
 either completed or given the controls they needed. The last of those was then run end to end for
 the first time, which is how three defects in it — and around it — were found and fixed before a
-customer met them.
+customer met them. Looking at what the recipient of a shared report actually sees found a fourth,
+which the run could not: the data arrived correctly and rendered as an empty page.
 
 Covers everything since v1.7.0; the 1.7.x patches carried generated changelogs.
 
@@ -90,6 +91,8 @@ integrator will see them nowhere else:
   constant zero. API-usage metering is worth building; publishing zeros is not a substitute for it.
 - Reconciliation responses use `isReconcilingItem`; storage keeps its mechanical column names.
 - New: the report share controls, `update-graph-metadata`, and the graph-scope field on API keys.
+- New: blocking a sender with `purge` returns `purged_report_ids` alongside the count, so a caller
+  can see exactly which reports were removed rather than only how many.
 
 ## Writes that never reached the graph
 
@@ -152,6 +155,41 @@ a company that keeps its books on the platform, then has that company publish a 
 fund's graph, ending in the traversal the product exists for: a portfolio position, to the security,
 to the issuing company, to their filed report, to its facts. It closes with 31 assertions and exits
 non-zero, so it is a gate rather than a walkthrough.
+
+## What the recipient actually sees
+
+The run above proved the data arrived. Opening the recipient's report proved it could not be read: a
+report header, the provenance line naming the sender, and beneath it an empty page reading *no
+statements available* — while all eighty-five facts sat in the recipient's own schema.
+
+A report is a set of statements, and each fact belongs to one of them. The share had been collapsing
+that structure on the way across, on the reasoning that an identifier from the sender's books cannot
+mean anything in the recipient's. For a company's **own** custom disclosures that is exactly right.
+For the standard statements it is not: a balance sheet is seeded into every graph from the same
+taxonomy under the same identifier, so the sender's balance sheet already *is* the recipient's. Of
+the sixty-six structures in the sending company's books, fifty-five exist unchanged in the receiving
+one. Every read path resolves a fact through its statement, so discarding that association left the
+facts present and unreachable — delivered, materialized, and invisible.
+
+Statements now travel as themselves. Facts belonging to a disclosure genuinely local to the sender
+pool into a single set: delivered and queryable, but not yet renderable as a statement, which is a
+gap the format below is what closes.
+
+**A shared report now carries the sender's published document with it.** Alongside the rows, the
+share copies the sender's *holon* — the report as one self-contained file, its facts, its
+presentation and its calculation rules in a single document that renders outside the platform
+entirely, and that by construction contains no trace of the ledger behind it. The recipient reads the
+document the sender published rather than a reconstruction assembled from the copy, and it is never
+re-derived locally: if that document is gone, the answer is that it is gone, not a lookalike built
+from the recipient's own rows. The distinction is invisible at the point of use, which is precisely
+why it has to be decided in the code rather than left to chance.
+
+**Receiving a report is no longer conditional on keeping books.** Reading what a portfolio company
+sends required the recipient to have the accounting extension provisioned — so a fund had to stand up
+a ledger it would never post to, purely to read its own mail. Report reads and share delivery now
+accept an investment-management tenant as readily as an accounting one; authoring stays where it was.
+Withdrawal keeps pace: revoking a report, or blocking a sender and purging what they sent, now
+removes the stored document as well as the rows.
 
 ## Corrected claims
 

--- a/robosystems/graphql/resolvers/_common.py
+++ b/robosystems/graphql/resolvers/_common.py
@@ -87,6 +87,27 @@ def require_extension(info: Info[GraphQLContext, None], extension: str) -> None:
     )
 
 
+def require_any_extension(
+  info: Info[GraphQLContext, None], extensions: tuple[str, ...]
+) -> None:
+  """Like :func:`require_extension`, but any one of several will do.
+
+  For reads whose data can arrive on a graph that never provisioned the
+  extension that *owns* the table. A cross-graph report share writes ledger
+  rows into the recipient's schema, so an investor-only tenant legitimately
+  holds reports it can never author — gating those reads on `roboledger`
+  would hide data the platform delivered on purpose. The tenant schema always
+  has the tables (`provision_tenant_schema` creates all of them regardless of
+  the graph's extensions), so this is a policy gate, not a structural one.
+  """
+  provisioned = info.context["schema_extensions"]
+  if not any(extension in provisioned for extension in extensions):
+    raise strawberry.exceptions.StrawberryGraphQLError(
+      message=(f"none of {', '.join(extensions)} is provisioned for this graph"),
+      extensions={"code": "EXTENSION_NOT_PROVISIONED"},
+    )
+
+
 def open_extensions_session(info: Info[GraphQLContext, None], extension: str):
   """Shared auth, extension-gate, and extensions-session prelude.
 
@@ -99,6 +120,22 @@ def open_extensions_session(info: Info[GraphQLContext, None], extension: str):
   require_extension(info, extension)
   graph_id = require_graph_id(info)
   # Local import keeps this module importable without a running extensions DB.
+  from robosystems.db.extensions import extensions_session
+
+  return extensions_session(graph_id)
+
+
+def open_extensions_session_for_any(
+  info: Info[GraphQLContext, None], extensions: tuple[str, ...]
+):
+  """`open_extensions_session` for reads served to more than one domain.
+
+  See :func:`require_any_extension` — the received-report surface is the case
+  this exists for.
+  """
+  require_user(info)
+  require_any_extension(info, extensions)
+  graph_id = require_graph_id(info)
   from robosystems.db.extensions import extensions_session
 
   return extensions_session(graph_id)

--- a/robosystems/graphql/resolvers/ledger.py
+++ b/robosystems/graphql/resolvers/ledger.py
@@ -26,6 +26,9 @@ from robosystems.graphql.resolvers._common import (
   open_extensions_session as _open_session,
 )
 from robosystems.graphql.resolvers._common import (
+  open_extensions_session_for_any as _open_session_for_any,
+)
+from robosystems.graphql.resolvers._common import (
   resolve_pagination as _resolve_pagination,
 )
 from robosystems.graphql.types.ledger import (
@@ -126,6 +129,11 @@ from robosystems.operations.roboledger.schedules import ScheduleService
 # matches the router-level `_svc` pattern already in place.
 _fiscal_svc = FiscalCalendarService()
 _schedule_svc = ScheduleService()
+
+# Reports can arrive on a graph that never provisioned `roboledger` — a
+# cross-graph share writes them there — so the report *reads* accept either
+# extension. Everything else on this resolver stays `roboledger`-only.
+_REPORT_EXTENSIONS = ("roboledger", "roboinvestor")
 
 
 def _raise_ledger_not_initialized() -> NoReturn:
@@ -821,12 +829,19 @@ class LedgerQuery:
     return ClosingBookStructures.from_pydantic(response)
 
   # ── Reports ─────────────────────────────────────────────────────────────
+  #
+  # The report reads gate on `_REPORT_EXTENSIONS` rather than `roboledger`
+  # alone: a cross-graph share writes report rows into the recipient's schema,
+  # so an investor-only tenant holds reports it could never author. Gating
+  # these on `roboledger` would hide data the platform delivered on purpose,
+  # and force every recipient to provision a ledger they will never post to.
+  # The write paths below stay `roboledger`-only — receiving is not authoring.
 
   @strawberry.field
   def reports(self, info: Info[GraphQLContext, None]) -> ReportList | None:
     """List all report definitions for this graph."""
     try:
-      with _open_session(info, "roboledger") as session:
+      with _open_session_for_any(info, _REPORT_EXTENSIONS) as session:
         response = reads_reports.list_reports(session)
     except (ValueError, ProgrammingError):
       _raise_ledger_not_initialized()
@@ -840,7 +855,7 @@ class LedgerQuery:
   ) -> Report | None:
     """Single report definition with structures + entity name."""
     try:
-      with _open_session(info, "roboledger") as session:
+      with _open_session_for_any(info, _REPORT_EXTENSIONS) as session:
         response = reads_reports.get_report(session, report_id)
     except (ValueError, ProgrammingError):
       _raise_ledger_not_initialized()
@@ -860,7 +875,7 @@ class LedgerQuery:
     ``getStatement`` round-trip path.
     """
     try:
-      with _open_session(info, "roboledger") as session:
+      with _open_session_for_any(info, _REPORT_EXTENSIONS) as session:
         response = reads_reports.get_report_package(session, report_id)
     except (ValueError, ProgrammingError):
       _raise_ledger_not_initialized()
@@ -900,7 +915,7 @@ class LedgerQuery:
       )
     graph_id = require_graph_id(info)
     try:
-      with _open_session(info, "roboledger") as session:
+      with _open_session_for_any(info, _REPORT_EXTENSIONS) as session:
         response = reads_reports.get_report_download_url(
           session,
           graph_id,

--- a/robosystems/models/api/extensions/blocked_source_graphs.py
+++ b/robosystems/models/api/extensions/blocked_source_graphs.py
@@ -107,13 +107,15 @@ class BlockSourceGraphResult(BaseModel):
       "unless `purge` was set."
     ),
   )
+  # Also consumed server-side: the router's after-success hook uses these ids
+  # to delete each purged copy's stored publication once the row deletion has
+  # committed. That is an implementation detail and stays out of the
+  # description, which is published verbatim into both client SDKs.
   purged_report_ids: list[str] = Field(
     default_factory=list,
     description=(
       "Ids of the previously-shared reports deleted from this graph. Empty "
-      "unless `purge` was set. Reported so the caller can see exactly what "
-      "was removed, and so the purge can finish withdrawing each report's "
-      "stored publication once the deletion has committed."
+      "unless `purge` was set."
     ),
   )
 

--- a/robosystems/models/api/extensions/blocked_source_graphs.py
+++ b/robosystems/models/api/extensions/blocked_source_graphs.py
@@ -107,6 +107,15 @@ class BlockSourceGraphResult(BaseModel):
       "unless `purge` was set."
     ),
   )
+  purged_report_ids: list[str] = Field(
+    default_factory=list,
+    description=(
+      "Ids of the previously-shared reports deleted from this graph. Empty "
+      "unless `purge` was set. Reported so the caller can see exactly what "
+      "was removed, and so the purge can finish withdrawing each report's "
+      "stored publication once the deletion has committed."
+    ),
+  )
 
 
 class BlockedSourceGraphListResponse(BaseModel):

--- a/robosystems/operations/roboledger/commands/blocked_source_graphs.py
+++ b/robosystems/operations/roboledger/commands/blocked_source_graphs.py
@@ -95,14 +95,15 @@ def block_source_graph(
     session.add(existing)
     session.flush()
 
-  purged = 0
+  purged_ids: list[str] = []
   if body.purge:
-    purged = _purge_shared_reports(session, body.source_graph_id)
+    purged_ids = _purge_shared_reports(session, body.source_graph_id)
 
   return BlockSourceGraphResult(
     block=enrich_blocks([existing])[0],
     already_blocked=already_blocked,
-    purged_report_count=purged,
+    purged_report_count=len(purged_ids),
+    purged_report_ids=purged_ids,
   )
 
 
@@ -145,11 +146,19 @@ def unblock_source_graph(
   return response
 
 
-def _purge_shared_reports(session: Session, source_graph_id: str) -> int:
-  """Delete every report shared in from ``source_graph_id``. Returns the count.
+def _purge_shared_reports(session: Session, source_graph_id: str) -> list[str]:
+  """Delete every report shared in from ``source_graph_id``. Returns their ids.
 
   Facts cascade from their parent fact_sets, so the fact_sets go first — the
   same two-step ``delete_report`` uses.
+
+  The ids are returned rather than the count because a purged copy's stored
+  publication has to go too — otherwise the sender's report survives the purge
+  in the recipient's bundle prefix. That deletion runs from the router's
+  after-success hook, not here: this function does not own the transaction, and
+  removing an artifact for a purge that then rolls back would destroy a live
+  report's publication. An orphan object after a crash is the recoverable
+  direction; a missing one is not.
   """
   report_ids = list(
     session.execute(select(Report.id).where(Report.source_graph_id == source_graph_id))
@@ -157,7 +166,7 @@ def _purge_shared_reports(session: Session, source_graph_id: str) -> int:
     .all()
   )
   if not report_ids:
-    return 0
+    return []
 
   session.execute(
     text("DELETE FROM fact_sets WHERE report_id = ANY(:report_ids)"),
@@ -168,4 +177,4 @@ def _purge_shared_reports(session: Session, source_graph_id: str) -> int:
     {"report_ids": report_ids},
   )
   session.flush()
-  return len(report_ids)
+  return report_ids

--- a/robosystems/operations/roboledger/commands/reports.py
+++ b/robosystems/operations/roboledger/commands/reports.py
@@ -16,6 +16,7 @@ from sqlalchemy.orm import Session
 from robosystems.config import env
 from robosystems.config.storage.graph import (
   get_report_bundle_key,
+  get_report_bundle_prefix,
   get_report_bundle_uri,
 )
 from robosystems.logger import logger
@@ -863,12 +864,6 @@ def share_report(
       "generation_count": int(report_def.generation_count or 0),
     }
 
-    # Read once, in the sender's session: the holon build needs the source
-    # rows, and every target gets the same bytes.
-    publication_artifacts = _load_publication_artifacts(
-      source_session, graph_id, report_def
-    )
-
     # The FactSets travel as themselves, not as one flat fact list. Every
     # read path on the recipient's side resolves a FactSet's Structure —
     # `get_report_package` joins it, `load_fact_set_by_id_for_structure`
@@ -899,6 +894,13 @@ def share_report(
       {"report_id": report_id},
     ).fetchall()
     source_facts = [row._asdict() for row in fact_rows]
+
+  # Read once, after the sender's session closes — S3 round-trips have no
+  # business holding a database connection open — and reused for every target,
+  # since each gets the same bytes.
+  publication_artifacts = _load_publication_artifacts(
+    graph_id, report_id, int(report_snapshot["generation_count"])
+  )
 
   for target_graph_id in target_graph_ids:
     result = _share_to_target(
@@ -1036,7 +1038,7 @@ def revoke_report_share(
 
 
 def _load_publication_artifacts(
-  session: Session, graph_id: str, report_def: Report
+  graph_id: str, report_id: str, generation_count: int
 ) -> dict[str, str]:
   """Read the sender's published artifacts so a share can carry them across.
 
@@ -1054,14 +1056,19 @@ def _load_publication_artifacts(
   of a share — it is what materializes into the recipient's graph and carries
   the cross-graph traversal — so an object-store fault degrades the
   recipient's renderers rather than failing the delivery outright.
+
+  Called after the sender's session closes, so none of this object-store I/O
+  holds a database connection open. The holon build below needs a session and
+  opens its own short-lived one, on the cold path only.
   """
+  from robosystems.db.extensions import extensions_session
+
   bucket = env.USER_DATA_BUCKET
-  generation_count = int(report_def.generation_count or 0)
   s3 = S3Client()
   artifacts: dict[str, str] = {}
 
   flat = s3.download_string(
-    bucket, get_report_bundle_key(graph_id, report_def.id, generation_count)
+    bucket, get_report_bundle_key(graph_id, report_id, generation_count)
   )
   if flat is not None:
     artifacts[".jsonld"] = flat
@@ -1069,33 +1076,34 @@ def _load_publication_artifacts(
     logger.warning(
       "Report %s has no readable JSON-LD bundle; the recipient's copy will "
       "carry no downloadable publication.",
-      report_def.id,
+      report_id,
     )
 
   # The holon is derived on demand, not stamped at publish, so a report nobody
   # has downloaded in that flavor yet has no object. Build it once here — the
   # key is immutable per generation, so this also warms the sender's cache.
   holon_key = get_report_bundle_key(
-    graph_id, report_def.id, generation_count, extension=".holon.jsonld"
+    graph_id, report_id, generation_count, extension=".holon.jsonld"
   )
   holon = s3.download_string(bucket, holon_key)
   if holon is None:
     try:
-      holon = serialize_to_holon_jsonld(
-        build_report_bundle(session, graph_id, report_def.id)
-      )
+      with extensions_session(graph_id) as build_session:
+        holon = serialize_to_holon_jsonld(
+          build_report_bundle(build_session, graph_id, report_id)
+        )
       s3.upload_string(
         content=holon,
         bucket=bucket,
         key=holon_key,
         content_type="application/ld+json",
-        metadata={"report-id": report_def.id, "graph-id": graph_id},
+        metadata={"report-id": report_id, "graph-id": graph_id},
       )
     except Exception:
       logger.exception(
         "Failed to materialize the holon for report %s; the recipient's copy "
         "will fall back to the package renderer.",
-        report_def.id,
+        report_id,
       )
       holon = None
   if holon is not None:
@@ -1148,15 +1156,46 @@ def _copy_publication_artifacts(
     )
 
 
+def delete_report_artifacts(graph_id: str, report_ids: list[str]) -> None:
+  """Remove the object-store artifacts of reports whose rows are gone.
+
+  Withdrawal has to reach object storage now that a shared copy carries
+  artifacts of its own. Before the holon travelled with the rows, a recipient's
+  copy had none — `bundle_url` was always NULL — so revoke and block-and-purge
+  were complete by construction. They no longer are, and an exit that leaves
+  the sender's published report sitting in the recipient's prefix is not the
+  exit either control advertises.
+
+  Deletes by prefix, so every generation and both flavors go together.
+
+  **Call this after the row deletion commits, never before.** Deleting an
+  artifact for a transaction that then rolls back destroys a live report's
+  publication; an artifact left behind by a crash is an orphan a later sweep
+  can take. The asymmetry decides the ordering.
+  """
+  if not report_ids:
+    return
+  bucket = env.USER_DATA_BUCKET
+  s3 = S3Client()
+  for report_id in report_ids:
+    prefix = get_report_bundle_prefix(graph_id, report_id)
+    for key in s3.list_objects(bucket, prefix=prefix):
+      if not s3.delete_object(bucket, key):
+        logger.warning(
+          "Failed to delete withdrawn report artifact s3://%s/%s.", bucket, key
+        )
+
+
 def _delete_copies_in_session(
   target_session: Session, source_graph_id: str, source_report_id: str
-) -> int:
+) -> list[str]:
   """Delete copies of one shared report from an open target session.
 
-  Returns how many were removed. Matches on the provenance pair, so it can
-  only ever reach a report that arrived from this sender — a report the target
-  authored has a null `source_graph_id` and cannot match. Does not commit; the
-  caller owns the transaction.
+  Returns the ids removed, so the caller can drop their object-store artifacts
+  once the transaction commits (see :func:`delete_report_artifacts`). Matches
+  on the provenance pair, so it can only ever reach a report that arrived from
+  this sender — a report the target authored has a null `source_graph_id` and
+  cannot match. Does not commit; the caller owns the transaction.
   """
   copy_ids = list(
     target_session.execute(
@@ -1169,7 +1208,7 @@ def _delete_copies_in_session(
     .all()
   )
   if not copy_ids:
-    return 0
+    return []
 
   # Facts cascade from their parent fact_sets, so the fact_sets go first.
   target_session.execute(
@@ -1180,7 +1219,7 @@ def _delete_copies_in_session(
     text("DELETE FROM reports WHERE id = ANY(:report_ids)"),
     {"report_ids": copy_ids},
   )
-  return len(copy_ids)
+  return copy_ids
 
 
 def _delete_shared_copy(
@@ -1212,7 +1251,9 @@ def _delete_shared_copy(
       target_session, source_graph_id, source_report_id
     )
     target_session.commit()
-    return deleted > 0
+
+  delete_report_artifacts(target_graph_id, deleted)
+  return bool(deleted)
 
 
 def _share_to_target(
@@ -1290,7 +1331,9 @@ def _share_to_target(
       # into their graph. The provenance pair can only ever match a copy from
       # this sender; a report the recipient authored has a null
       # `source_graph_id`.
-      _delete_copies_in_session(target_session, source_graph_id, report_snapshot["id"])
+      replaced_copy_ids = _delete_copies_in_session(
+        target_session, source_graph_id, report_snapshot["id"]
+      )
 
       shared_report = Report(
         name=report_snapshot["name"],
@@ -1400,13 +1443,14 @@ def _share_to_target(
           for fd in unresolved_facts
           if fd.get("period_end") is not None
         ]
-        # `period_end` is NOT NULL, so an all-instant remainder falls back to
-        # the report's own period end rather than failing the whole share.
+        # `facts.period_end` is NOT NULL on both sides, so `ends` is non-empty
+        # whenever `unresolved_facts` is — no fallback, which would only be
+        # able to supply the NULL that `fact_sets.period_end` rejects.
         catch_all_set = create_fact_set(
           target_session,
           structure_id=None,
           period_start=min(starts) if starts else None,
-          period_end=max(ends) if ends else report_snapshot.get("period_end"),
+          period_end=max(ends),
           factset_type="report",
           entity_id=unresolved_facts[0]["entity_id"],
           report_id=shared_report.id,
@@ -1456,11 +1500,16 @@ def _share_to_target(
 
       target_session.commit()
 
-      return ShareResultItem(
-        target_graph_id=target_graph_id,
-        status="shared",
-        fact_count=len(source_facts),
-      )
+    # After the commit, and only for the ids the replace actually removed — the
+    # new copy has a fresh report id, so its own artifacts are under a
+    # different prefix and cannot be caught by this.
+    delete_report_artifacts(target_graph_id, replaced_copy_ids)
+
+    return ShareResultItem(
+      target_graph_id=target_graph_id,
+      status="shared",
+      fact_count=len(source_facts),
+    )
 
   except Exception as e:
     # The detail stays in the log, not in the response: this exception was

--- a/robosystems/operations/roboledger/commands/reports.py
+++ b/robosystems/operations/roboledger/commands/reports.py
@@ -75,8 +75,14 @@ from robosystems.operations.serialization import (
   RdfFlavor,
   StatementBundle,
   build_report_bundle,
+  serialize_to_holon_jsonld,
   serialize_to_rdf,
 )
+
+# Extensions that give a graph a tenant schema, and so make it a legitimate
+# recipient of a shared report. Mirrors `_REPORT_EXTENSIONS` on the GraphQL
+# read side — the two ends of the same seam.
+_RECEIVING_EXTENSIONS = ("roboledger", "roboinvestor")
 
 
 class ReportNotFoundError(LookupError):
@@ -854,13 +860,38 @@ def share_report(
       "period_end": report_def.period_end,
       "comparative": report_def.comparative,
       "periods": report_def.periods,
+      "generation_count": int(report_def.generation_count or 0),
     }
+
+    # Read once, in the sender's session: the holon build needs the source
+    # rows, and every target gets the same bytes.
+    publication_artifacts = _load_publication_artifacts(
+      source_session, graph_id, report_def
+    )
+
+    # The FactSets travel as themselves, not as one flat fact list. Every
+    # read path on the recipient's side resolves a FactSet's Structure —
+    # `get_report_package` joins it, `load_fact_set_by_id_for_structure`
+    # pins on it — so a share that collapses N sets into one structure-less
+    # set delivers facts that nothing downstream can render.
+    fact_set_rows = source_session.execute(
+      text("""
+        SELECT fs.id, fs.structure_id, fs.factset_type, fs.period_start,
+               fs.period_end, fs.entity_id
+        FROM fact_sets fs
+        WHERE fs.report_id = :report_id
+        ORDER BY fs.created_at
+      """),
+      {"report_id": report_id},
+    ).fetchall()
+    source_fact_sets = [row._asdict() for row in fact_set_rows]
 
     fact_rows = source_session.execute(
       text("""
-        SELECT f.id, f.element_id, f.value, f.string_value, f.fact_type,
-               f.value_type, f.content_type, f.decimals, f.period_start,
-               f.period_end, f.period_type, f.unit, f.entity_id, f.created_at
+        SELECT f.id, f.fact_set_id, f.element_id, f.value, f.string_value,
+               f.fact_type, f.value_type, f.content_type, f.decimals,
+               f.period_start, f.period_end, f.period_type, f.unit,
+               f.entity_id, f.created_at
         FROM facts f
         JOIN fact_sets fs ON fs.id = f.fact_set_id
         WHERE fs.report_id = :report_id
@@ -873,7 +904,9 @@ def share_report(
     result = _share_to_target(
       source_graph_id=graph_id,
       report_snapshot=report_snapshot,
+      source_fact_sets=source_fact_sets,
       source_facts=source_facts,
+      publication_artifacts=publication_artifacts,
       target_graph_id=target_graph_id,
       shared_by=acting_user_id,
     )
@@ -1002,6 +1035,119 @@ def revoke_report_share(
   )
 
 
+def _load_publication_artifacts(
+  session: Session, graph_id: str, report_def: Report
+) -> dict[str, str]:
+  """Read the sender's published artifacts so a share can carry them across.
+
+  The **holon** — the report as ``#scene`` / ``#boundary`` / ``#projection``
+  named graphs — is the intended cross-tenant wire format: one self-contained
+  serialization that renders outside the system entirely, and whose partition
+  omits the ``#lineage`` graph by construction, so the books never cross with
+  the report. Carrying the sender's *object* rather than re-deriving one from
+  the recipient's copied rows is what makes the recipient's view the
+  publication the sender actually made, byte for byte, instead of a
+  reconstruction that can drift from it.
+
+  Returns the artifacts that resolved, keyed by file extension. A miss is
+  logged and omitted rather than raised: the row copy is the load-bearing half
+  of a share — it is what materializes into the recipient's graph and carries
+  the cross-graph traversal — so an object-store fault degrades the
+  recipient's renderers rather than failing the delivery outright.
+  """
+  bucket = env.USER_DATA_BUCKET
+  generation_count = int(report_def.generation_count or 0)
+  s3 = S3Client()
+  artifacts: dict[str, str] = {}
+
+  flat = s3.download_string(
+    bucket, get_report_bundle_key(graph_id, report_def.id, generation_count)
+  )
+  if flat is not None:
+    artifacts[".jsonld"] = flat
+  else:
+    logger.warning(
+      "Report %s has no readable JSON-LD bundle; the recipient's copy will "
+      "carry no downloadable publication.",
+      report_def.id,
+    )
+
+  # The holon is derived on demand, not stamped at publish, so a report nobody
+  # has downloaded in that flavor yet has no object. Build it once here — the
+  # key is immutable per generation, so this also warms the sender's cache.
+  holon_key = get_report_bundle_key(
+    graph_id, report_def.id, generation_count, extension=".holon.jsonld"
+  )
+  holon = s3.download_string(bucket, holon_key)
+  if holon is None:
+    try:
+      holon = serialize_to_holon_jsonld(
+        build_report_bundle(session, graph_id, report_def.id)
+      )
+      s3.upload_string(
+        content=holon,
+        bucket=bucket,
+        key=holon_key,
+        content_type="application/ld+json",
+        metadata={"report-id": report_def.id, "graph-id": graph_id},
+      )
+    except Exception:
+      logger.exception(
+        "Failed to materialize the holon for report %s; the recipient's copy "
+        "will fall back to the package renderer.",
+        report_def.id,
+      )
+      holon = None
+  if holon is not None:
+    artifacts[".holon.jsonld"] = holon
+
+  return artifacts
+
+
+def _copy_publication_artifacts(
+  artifacts: dict[str, str],
+  target_graph_id: str,
+  shared_report: Report,
+  generation_count: int,
+) -> None:
+  """Write the sender's artifacts under the recipient's own bundle keys.
+
+  Re-keying rather than sharing the sender's object is deliberate: the
+  recipient's copy is a distinct Report with its own id, and presigning is
+  scoped per graph. ``bundle_url`` has to land too — every download flavor is
+  gated on it (``get_report_bundle_download``), so without it the recipient's
+  Holon and download surfaces stay dark even with the objects in place.
+  """
+  if not artifacts:
+    return
+  bucket = env.USER_DATA_BUCKET
+  s3 = S3Client()
+  for extension, content in artifacts.items():
+    key = get_report_bundle_key(
+      target_graph_id, shared_report.id, generation_count, extension=extension
+    )
+    if not s3.upload_string(
+      content=content,
+      bucket=bucket,
+      key=key,
+      content_type="application/ld+json",
+      metadata={"report-id": shared_report.id, "graph-id": target_graph_id},
+    ):
+      logger.warning(
+        "Failed to copy %s artifact for shared report %s into %s.",
+        extension,
+        shared_report.id,
+        target_graph_id,
+      )
+      return
+
+  shared_report.generation_count = generation_count
+  if ".jsonld" in artifacts:
+    shared_report.bundle_url = get_report_bundle_uri(
+      bucket, target_graph_id, shared_report.id, generation_count
+    )
+
+
 def _delete_copies_in_session(
   target_session: Session, source_graph_id: str, source_report_id: str
 ) -> int:
@@ -1072,11 +1218,13 @@ def _delete_shared_copy(
 def _share_to_target(
   source_graph_id: str,
   report_snapshot: dict[str, Any],
+  source_fact_sets: list[dict[str, Any]],
   source_facts: list[dict[str, Any]],
   target_graph_id: str,
   shared_by: str,
+  publication_artifacts: dict[str, str] | None = None,
 ) -> ShareResultItem:
-  """Copy report definition + facts to a target graph's tenant schema."""
+  """Copy report definition + FactSets + facts to a target tenant schema."""
   from robosystems.db.extensions import extensions_session
   from robosystems.db.platform import SessionFactory
   from robosystems.models.core import Graph
@@ -1094,12 +1242,22 @@ def _share_to_target(
           error=f"Graph '{target_graph_id}' not found.",
         )
 
+      # Receiving is not authoring. `provision_tenant_schema` creates every
+      # tenant table regardless of the graph's extensions, so an investor-only
+      # tenant can hold a report perfectly well — and requiring `roboledger`
+      # of a recipient would mean a fund had to provision a ledger it will
+      # never post to just to read what its portfolio companies send it. The
+      # gate stays, narrowed to "has an extensions tenant at all", so a share
+      # still cannot land in a graph that never opted into the OLTP surface.
       extensions = target_graph.schema_extensions or []
-      if "roboledger" not in extensions:
+      if not any(ext in extensions for ext in _RECEIVING_EXTENSIONS):
         return ShareResultItem(
           target_graph_id=target_graph_id,
           status="error",
-          error="Target graph does not have 'roboledger' schema extension.",
+          error=(
+            "Target graph has no extensions schema — it must have one of: "
+            f"{', '.join(_RECEIVING_EXTENSIONS)}."
+          ),
         )
   except Exception as e:
     logger.error(f"Failed to validate target graph {target_graph_id}: {e}")
@@ -1153,37 +1311,110 @@ def _share_to_target(
       target_session.add(shared_report)
       target_session.flush()
 
-      # Cross-graph share: source-graph structure_id references rows in
-      # the source tenant schema and is meaningless in the target.
-      # Target Networks aren't populated per-structure on share; instead
-      # every shared fact is stamped against a single cross-graph FactSet
-      # that back-references the shared report, with a period envelope
-      # spanning all incoming facts.
-      starts = [
-        fd["period_start"] for fd in source_facts if fd.get("period_start") is not None
-      ]
-      ends = [
-        fd["period_end"] for fd in source_facts if fd.get("period_end") is not None
-      ]
+      # The holon crosses with the rows. Needs the flushed id, since the
+      # recipient's bundle keys are scoped by their own report id.
+      _copy_publication_artifacts(
+        publication_artifacts or {},
+        target_graph_id,
+        shared_report,
+        int(report_snapshot.get("generation_count") or 0),
+      )
+
+      # A Structure id crosses the graph boundary only if it resolves on the
+      # far side. Library-seeded structures do: `provision_tenant_schema`
+      # copies the canonical library into every tenant schema, and library
+      # ids are deterministic UUID5 over the taxonomy source — so the
+      # sender's "rs-gaap — Balance Sheet — Classified" *is* the recipient's,
+      # same id, same presentation arcs, no copying required. Tenant-local
+      # structures (`struct_*` ULIDs — a custom disclosure, a bespoke
+      # schedule) do not resolve, and their facts fall back to a single
+      # structure-less set below: delivered and queryable, but not
+      # renderable as a statement until the holon import half can recreate
+      # the structure itself in the recipient.
+      candidate_structure_ids = {
+        fs["structure_id"] for fs in source_fact_sets if fs.get("structure_id")
+      }
+      resolvable_structure_ids: set[str] = set()
+      if candidate_structure_ids:
+        resolvable_structure_ids = {
+          row[0]
+          for row in target_session.execute(
+            text("SELECT id FROM structures WHERE id = ANY(:ids)"),
+            {"ids": list(candidate_structure_ids)},
+          ).fetchall()
+        }
+
+      facts_by_source_set: dict[str, list[dict[str, Any]]] = {}
+      for fact_data in source_facts:
+        facts_by_source_set.setdefault(fact_data["fact_set_id"], []).append(fact_data)
+
       # The originating ledger is not present in the target graph, so the
       # shared facts collapse to `asserted` provenance referencing the
       # source graph/report rather than a re-derivable pivot.
-      shared_fact_set = create_fact_set(
-        target_session,
-        structure_id=None,
-        period_start=min(starts) if starts else None,
-        period_end=max(ends) if ends else None,
-        factset_type="report",
-        entity_id=source_facts[0]["entity_id"] if source_facts else "",
-        report_id=shared_report.id,
-        created_by=shared_by,
-        provenance=AssertedProvenance(
+      def _provenance(source_fact_set_id: str | None) -> AssertedProvenance:
+        basis = f"source_graph={source_graph_id} source_report={report_snapshot['id']}"
+        if source_fact_set_id is not None:
+          basis = f"{basis} source_fact_set={source_fact_set_id}"
+        return AssertedProvenance(
           source_system="cross_graph_share",
           asserted_by=shared_by,
-          basis_note=f"source_graph={source_graph_id} source_report={report_snapshot['id']}",
-        ),
-      )
-      target_session.flush()
+          basis_note=basis,
+        )
+
+      # One target FactSet per source FactSet whose Structure resolves; the
+      # remainder pool into one structure-less set so nothing is dropped.
+      target_set_for_source: dict[str, str] = {}
+      unresolved_facts: list[dict[str, Any]] = []
+      for source_set in source_fact_sets:
+        source_set_id = source_set["id"]
+        set_facts = facts_by_source_set.get(source_set_id, [])
+        if not set_facts:
+          continue
+        structure_id = source_set.get("structure_id")
+        if not structure_id or structure_id not in resolvable_structure_ids:
+          unresolved_facts.extend(set_facts)
+          continue
+        copied_set = create_fact_set(
+          target_session,
+          structure_id=structure_id,
+          period_start=source_set["period_start"],
+          period_end=source_set["period_end"],
+          factset_type=source_set["factset_type"],
+          entity_id=source_set["entity_id"],
+          report_id=shared_report.id,
+          created_by=shared_by,
+          provenance=_provenance(source_set_id),
+        )
+        target_session.flush()
+        target_set_for_source[source_set_id] = str(copied_set.id)
+
+      catch_all_set_id: str | None = None
+      if unresolved_facts:
+        starts = [
+          fd["period_start"]
+          for fd in unresolved_facts
+          if fd.get("period_start") is not None
+        ]
+        ends = [
+          fd["period_end"]
+          for fd in unresolved_facts
+          if fd.get("period_end") is not None
+        ]
+        # `period_end` is NOT NULL, so an all-instant remainder falls back to
+        # the report's own period end rather than failing the whole share.
+        catch_all_set = create_fact_set(
+          target_session,
+          structure_id=None,
+          period_start=min(starts) if starts else None,
+          period_end=max(ends) if ends else report_snapshot.get("period_end"),
+          factset_type="report",
+          entity_id=unresolved_facts[0]["entity_id"],
+          report_id=shared_report.id,
+          created_by=shared_by,
+          provenance=_provenance(None),
+        )
+        target_session.flush()
+        catch_all_set_id = str(catch_all_set.id)
 
       # The concepts have to land before the facts that cite them. A fact
       # whose element_id resolves nowhere is not a partial delivery — it
@@ -1199,6 +1430,11 @@ def _share_to_target(
       )
 
       for fact_data in source_facts:
+        target_set_id = target_set_for_source.get(
+          fact_data["fact_set_id"], catch_all_set_id
+        )
+        if target_set_id is None:
+          continue
         rf = Fact(
           element_id=fact_data["element_id"],
           value=fact_data["value"],
@@ -1212,7 +1448,7 @@ def _share_to_target(
           period_type=fact_data["period_type"],
           unit=fact_data["unit"],
           entity_id=fact_data["entity_id"],
-          fact_set_id=shared_fact_set.id,
+          fact_set_id=target_set_id,
         )
         target_session.add(rf)
 

--- a/robosystems/operations/roboledger/reads/reports.py
+++ b/robosystems/operations/roboledger/reads/reports.py
@@ -374,7 +374,7 @@ def get_report_download_url(
   # that legitimately has no flat bundle of its own: a cross-graph shared copy,
   # whose holon is the sender's published artifact copied in alongside the rows.
   if flavor == RdfFlavor.HOLON_JSONLD.value:
-    if str(report.generation_status) != "published":
+    if report.generation_status != "published":
       raise ReportBundleNotAvailableError(
         f"Report '{report_id}' is not published — publish or regenerate the "
         f"report to produce a holon."

--- a/robosystems/operations/roboledger/reads/reports.py
+++ b/robosystems/operations/roboledger/reads/reports.py
@@ -385,6 +385,7 @@ def get_report_download_url(
       report_id=report_id,
       generation_count=generation_count,
       expires_in=expires_in,
+      source_graph_id=report.source_graph_id,
     )
 
   if not report.bundle_url:
@@ -408,6 +409,7 @@ def get_report_download_url(
       flavor=XbrlFlavor(flavor),
       generation_count=generation_count,
       expires_in=expires_in,
+      source_graph_id=report.source_graph_id,
     )
   raise ValueError(
     f"Unsupported download format '{flavor}'. "
@@ -455,6 +457,33 @@ def _presign_stored_rdf_bundle(
   )
 
 
+def _refuse_local_rederivation(
+  report_id: str, source_graph_id: str | None, artifact: str
+) -> None:
+  """Stop a *received* report's artifact being re-derived from local rows.
+
+  The derived flavors are built on demand and cached, which is right for a
+  report this graph authored: the rows are the source of truth and the artifact
+  is a projection of them. It is wrong for a report that arrived from somewhere
+  else. There the artifact *is* the truth — the sender's published document,
+  copied in beside the rows — and the rows are a convenience projection of it,
+  carrying only what the share was able to bring across.
+
+  So a cache miss on a received report is a miss, not a build order. Rebuilding
+  would hand the recipient a document derived from their own copy while
+  presenting it as the sender's publication, and the difference is invisible at
+  the point of use. Better to say the artifact is gone.
+  """
+  if source_graph_id is None:
+    return
+  raise ReportBundleNotAvailableError(
+    f"Report '{report_id}' was shared from another graph and its {artifact} is "
+    f"no longer in storage. A received report is served as the sender's "
+    f"published artifact and is never re-derived locally; ask the sender to "
+    f"share it again."
+  )
+
+
 def _materialize_and_presign_xbrl(
   session: Session,
   graph_id: str,
@@ -462,6 +491,7 @@ def _materialize_and_presign_xbrl(
   flavor: XbrlFlavor,
   generation_count: int,
   expires_in: int,
+  source_graph_id: str | None = None,
 ) -> ReportBundleDownloadResponse:
   """Presign the XBRL zip, materializing + caching it on first download.
 
@@ -477,6 +507,7 @@ def _materialize_and_presign_xbrl(
   s3 = S3Client()
 
   if not s3.object_exists(bucket, key):
+    _refuse_local_rederivation(report_id, source_graph_id, "XBRL bundle")
     from robosystems.operations.serialization import (
       build_report_bundle,
       serialize_to_xbrl,
@@ -526,6 +557,7 @@ def _materialize_and_presign_holon(
   report_id: str,
   generation_count: int,
   expires_in: int,
+  source_graph_id: str | None = None,
 ) -> ReportBundleDownloadResponse:
   """Presign the dataset-form JSON-LD **holon**, materializing + caching it on
   first download.
@@ -545,6 +577,7 @@ def _materialize_and_presign_holon(
   s3 = S3Client()
 
   if not s3.object_exists(bucket, key):
+    _refuse_local_rederivation(report_id, source_graph_id, "holon")
     from robosystems.operations.serialization import (
       build_report_bundle,
       serialize_to_holon_jsonld,

--- a/robosystems/operations/roboledger/reads/reports.py
+++ b/robosystems/operations/roboledger/reads/reports.py
@@ -359,11 +359,6 @@ def get_report_download_url(
   report = session.get(Report, report_id)
   if report is None:
     return None
-  if not report.bundle_url:
-    raise ReportBundleNotAvailableError(
-      f"Report '{report_id}' has no published bundle — publish or "
-      f"regenerate the report to produce one."
-    )
   generation_count = int(report.generation_count or 0)
 
   # HOLON_JSONLD is a *derived* projection — materialized + cached on demand
@@ -371,13 +366,31 @@ def get_report_download_url(
   # in _RDF_FLAVOR_VALUES: this branch MUST stay above the _RDF_FLAVOR_VALUES
   # check below, which presigns the publish-stamped JSON-LD and rejects every
   # other RDF flavor as "reserved for future use".
+  #
+  # It also sits above the ``bundle_url`` gate below, and asks about
+  # publication directly instead. ``bundle_url`` names the *flat* JSON-LD
+  # object, which the holon path never reads — it serves its own cached object
+  # or rebuilds from rows. Gating on it made the holon unreachable for a report
+  # that legitimately has no flat bundle of its own: a cross-graph shared copy,
+  # whose holon is the sender's published artifact copied in alongside the rows.
   if flavor == RdfFlavor.HOLON_JSONLD.value:
+    if str(report.generation_status) != "published":
+      raise ReportBundleNotAvailableError(
+        f"Report '{report_id}' is not published — publish or regenerate the "
+        f"report to produce a holon."
+      )
     return _materialize_and_presign_holon(
       session=session,
       graph_id=graph_id,
       report_id=report_id,
       generation_count=generation_count,
       expires_in=expires_in,
+    )
+
+  if not report.bundle_url:
+    raise ReportBundleNotAvailableError(
+      f"Report '{report_id}' has no published bundle — publish or "
+      f"regenerate the report to produce one."
     )
   if flavor in _RDF_FLAVOR_VALUES:
     return _presign_stored_rdf_bundle(

--- a/robosystems/routers/extensions/roboledger/operations.py
+++ b/robosystems/routers/extensions/roboledger/operations.py
@@ -365,6 +365,7 @@ from robosystems.operations.roboledger.commands.reports import (
   ReportNotPublishedError,
   ReportShareNotFoundError,
   TaxonomyNotFoundError,
+  delete_report_artifacts,
 )
 from robosystems.operations.roboledger.commands.reports import (
   PublishListNotFoundError as ReportPublishListNotFoundError,
@@ -2954,14 +2955,22 @@ async def block_source_graph_op(
     except (ValueError, ProgrammingError):
       raise _ledger_404()
 
-  def _mark_stale_if_purged(envelope) -> None:
+  def _finish_purge(envelope) -> None:
     # Only a purge changes queryable content, and the OLAP projection is a
     # full rebuild from OLTP — a block on its own has nothing to re-project,
     # so it must not trigger one.
-    if _result_payload(envelope).get("purged_report_count"):
-      mark_graph_stale(graph_id, "shared_reports_purged")
+    payload = _result_payload(envelope)
+    if not payload.get("purged_report_count"):
+      return
+    mark_graph_stale(graph_id, "shared_reports_purged")
+    # The purge deleted rows; the senders' stored publications are still in
+    # this graph's bundle prefix until this runs. It belongs here rather than
+    # in the command because the rows must be committed first — deleting an
+    # artifact for a purge that rolled back would destroy a live report's
+    # publication, while an orphan object is recoverable.
+    delete_report_artifacts(graph_id, list(payload.get("purged_report_ids") or []))
 
-  return await _dispatch(ctx, _runner, cache, on_fresh_success=_mark_stale_if_purged)
+  return await _dispatch(ctx, _runner, cache, on_fresh_success=_finish_purge)
 
 
 # Hand-mounted rather than declared through `_registrar`, deliberately. Every

--- a/tests/operations/roboledger/commands/test_reports.py
+++ b/tests/operations/roboledger/commands/test_reports.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from robosystems.models.api.fact_provenance import AssertedProvenance
+from robosystems.models.extensions import Report as ReportModel
 from robosystems.operations.roboledger.commands.reports import (
   InvalidFilingTransitionError,
   NotAuthorizedError,
@@ -451,8 +452,21 @@ def test_share_to_target_stamps_asserted_provenance() -> None:
     fs.id = "fs_shared"
     return fs
 
+  # A source FactSet with no Structure exercises the catch-all copy — this
+  # test is about provenance stamping, not structure resolution.
+  source_fact_sets = [
+    {
+      "id": "fs_src_01",
+      "structure_id": None,
+      "factset_type": "report",
+      "period_start": date(2026, 1, 1),
+      "period_end": date(2026, 3, 31),
+      "entity_id": "ent_src",
+    }
+  ]
   source_facts = [
     {
+      "fact_set_id": "fs_src_01",
       "element_id": "e1",
       "value": 1.0,
       "string_value": None,
@@ -490,6 +504,7 @@ def test_share_to_target_stamps_asserted_provenance() -> None:
     result = _share_to_target(
       source_graph_id="kg_src",
       report_snapshot=report_snapshot,
+      source_fact_sets=source_fact_sets,
       source_facts=source_facts,
       target_graph_id="kg_tgt",
       shared_by="usr_share",
@@ -521,8 +536,19 @@ def test_share_to_target_carries_nonnumeric_columns() -> None:
   ext_cm = MagicMock()
   ext_cm.__enter__.return_value = target_session
 
+  source_fact_sets = [
+    {
+      "id": "fs_src_01",
+      "structure_id": None,
+      "factset_type": "report",
+      "period_start": date(2026, 1, 1),
+      "period_end": date(2026, 12, 31),
+      "entity_id": "ent_src",
+    }
+  ]
   source_facts = [
     {
+      "fact_set_id": "fs_src_01",
       "element_id": "e_policy",
       "value": None,
       "string_value": "# Inventory Policy\n\nFIFO, lower of cost or NRV.",
@@ -563,6 +589,7 @@ def test_share_to_target_carries_nonnumeric_columns() -> None:
     result = _share_to_target(
       source_graph_id="kg_src",
       report_snapshot=report_snapshot,
+      source_fact_sets=source_fact_sets,
       source_facts=source_facts,
       target_graph_id="kg_tgt",
       shared_by="usr_share",
@@ -579,6 +606,86 @@ def test_share_to_target_carries_nonnumeric_columns() -> None:
   assert copied[0].string_value.startswith("# Inventory Policy")
   assert copied[0].value is None
   assert copied[0].content_type == "text/markdown"
+
+
+def test_share_carries_the_senders_holon_into_the_recipients_prefix() -> None:
+  """The holon is the wire format: the recipient views the publication the
+  sender actually made, not one re-derived from the copied rows.
+
+  Both artifacts are re-keyed under the recipient's own graph + report id —
+  presigning is per-graph — and ``bundle_url`` is stamped, because every
+  download flavor is gated on it. Without the stamp the recipient's Holon tab
+  stays dark even with the object sitting in S3.
+  """
+  from robosystems.operations.roboledger.commands import reports as reports_mod
+
+  graph = MagicMock()
+  graph.schema_extensions = ["roboledger"]
+  platform_session = MagicMock()
+  platform_session.execute.return_value.scalar_one_or_none.return_value = graph
+  platform_cm = MagicMock()
+  platform_cm.__enter__.return_value = platform_session
+
+  target_session = MagicMock()
+  ext_cm = MagicMock()
+  ext_cm.__enter__.return_value = target_session
+
+  # `shared_report.id` is assigned by the DB on flush; stand it in so the
+  # recipient's bundle key is the one the assertions can name.
+  def _assign_id(obj):
+    if isinstance(obj, ReportModel):
+      obj.id = "rpt_copy"
+
+  target_session.add.side_effect = _assign_id
+
+  s3 = MagicMock()
+  s3.upload_string.return_value = True
+
+  with (
+    patch("robosystems.db.platform.SessionFactory", return_value=platform_cm),
+    patch("robosystems.db.extensions.extensions_session", return_value=ext_cm),
+    patch.object(reports_mod, "S3Client", return_value=s3),
+    patch.object(reports_mod, "_ensure_linked_entity"),
+    patch.object(reports_mod, "is_source_blocked", return_value=False),
+  ):
+    result = _share_to_target(
+      source_graph_id="kg_src",
+      report_snapshot={
+        "id": "rpt_src",
+        "name": "FY Report",
+        "taxonomy_id": "tax_1",
+        "period_type": "annual",
+        "comparative": False,
+        "generation_count": 3,
+      },
+      source_fact_sets=[],
+      source_facts=[],
+      publication_artifacts={
+        ".jsonld": '{"@context": "flat"}',
+        ".holon.jsonld": '{"@graph": "holon"}',
+      },
+      target_graph_id="kg_tgt",
+      shared_by="usr_share",
+    )
+
+  assert result.status == "shared"
+
+  written = {
+    call.kwargs["key"]: call.kwargs["content"]
+    for call in s3.upload_string.call_args_list
+  }
+  assert written == {
+    "report-bundles/kg_tgt/rpt_copy/g3.jsonld": '{"@context": "flat"}',
+    "report-bundles/kg_tgt/rpt_copy/g3.holon.jsonld": '{"@graph": "holon"}',
+  }
+
+  shared = next(
+    call.args[0]
+    for call in target_session.add.call_args_list
+    if isinstance(call.args[0], ReportModel)
+  )
+  assert shared.generation_count == 3
+  assert str(shared.bundle_url).endswith("report-bundles/kg_tgt/rpt_copy/g3.jsonld")
 
 
 # ── regenerate_report filing-status gate ──────────────────────────────────

--- a/tests/operations/roboledger/commands/test_share_controls.py
+++ b/tests/operations/roboledger/commands/test_share_controls.py
@@ -349,6 +349,7 @@ def test_share_to_a_blocking_recipient_returns_an_error_and_writes_nothing() -> 
     result = _share_to_target(
       source_graph_id=_SOURCE_GRAPH,
       report_snapshot={"id": "rpt_source", "name": "Q1", "taxonomy_id": "tax_01"},
+      source_fact_sets=[],
       source_facts=[],
       target_graph_id=_TARGET_GRAPH,
       shared_by="user_sender",
@@ -387,6 +388,7 @@ def test_share_to_an_unblocking_recipient_proceeds_to_the_copy() -> None:
         "comparative": False,
         "periods": None,
       },
+      source_fact_sets=[],
       source_facts=[],
       target_graph_id=_TARGET_GRAPH,
       shared_by="user_sender",

--- a/tests/operations/roboledger/commands/test_share_controls_db.py
+++ b/tests/operations/roboledger/commands/test_share_controls_db.py
@@ -48,6 +48,8 @@ from robosystems.operations.roboledger.commands.reports import (
 
 pytestmark = pytest.mark.integration
 
+_REPORTS_CMD = "robosystems.operations.roboledger.commands.reports"
+
 # Valid graph-id shapes (kg + 16+ lowercase hex) so `_sanitize_schema` accepts
 # them as schema names.
 SOURCE_GRAPH = "kgaaaaaaaaaaaaaaaa01"
@@ -465,6 +467,66 @@ def test_resharing_replaces_the_copy_rather_than_duplicating_it() -> None:
   assert rows[0].source_report_id == _REPORT_SNAPSHOT["id"]
   # The replaced copy took its fact sets and facts with it.
   assert _counts(TARGET_GRAPH) == (1, 1, len(_SOURCE_FACTS))
+
+
+def test_revoke_withdraws_the_stored_publication_too() -> None:
+  """Withdrawal has to reach object storage, not just the rows.
+
+  A shared copy now carries the sender's holon in the recipient's bundle
+  prefix. Deleting the rows and leaving that behind means the sender's
+  published report survives the revocation that was supposed to withdraw it —
+  the artifacts were invisible to this suite before they existed, so the
+  regression would have been silent.
+  """
+  _share()
+
+  with extensions_session(SOURCE_GRAPH) as session:
+    session.add(
+      Report(
+        id=_REPORT_SNAPSHOT["id"],
+        name=_REPORT_SNAPSHOT["name"],
+        taxonomy_id=_REPORT_SNAPSHOT["taxonomy_id"],
+        period_type="quarterly",
+        comparative=False,
+        generation_status="published",
+        filing_status="draft",
+        created_by=_SENDER,
+      )
+    )
+    session.add(
+      ReportShare(
+        id="share_0001",
+        report_id=_REPORT_SNAPSHOT["id"],
+        target_graph_id=TARGET_GRAPH,
+        shared_by=_SENDER,
+        fact_count=len(_SOURCE_FACTS),
+      )
+    )
+
+  copy_id = _copied_report_id()
+
+  with patch(f"{_REPORTS_CMD}.S3Client") as s3_cls:
+    s3 = s3_cls.return_value
+    s3.list_objects.return_value = [
+      f"report-bundles/{TARGET_GRAPH}/{copy_id}/g1.jsonld",
+      f"report-bundles/{TARGET_GRAPH}/{copy_id}/g1.holon.jsonld",
+    ]
+    s3.delete_object.return_value = True
+    revoke_report_share(
+      SOURCE_GRAPH,
+      _REPORT_SNAPSHOT["id"],
+      RevokeReportShareRequest(target_graph_id=TARGET_GRAPH),
+      acting_user_id=_SENDER,
+    )
+
+  # Scoped to the withdrawn copy's own prefix — never the whole graph's.
+  _, list_kwargs = s3.list_objects.call_args
+  assert list_kwargs["prefix"] == f"report-bundles/{TARGET_GRAPH}/{copy_id}/"
+  deleted = {call.args[1] for call in s3.delete_object.call_args_list}
+  assert deleted == {
+    f"report-bundles/{TARGET_GRAPH}/{copy_id}/g1.jsonld",
+    f"report-bundles/{TARGET_GRAPH}/{copy_id}/g1.holon.jsonld",
+  }
 
 
 def test_revoke_clears_every_active_share_row_for_the_recipient() -> None:

--- a/tests/operations/roboledger/commands/test_share_controls_db.py
+++ b/tests/operations/roboledger/commands/test_share_controls_db.py
@@ -33,6 +33,7 @@ from robosystems.models.extensions import (
   Element,
   Report,
   ReportShare,
+  Structure,
   Taxonomy,
 )
 from robosystems.operations.roboledger.commands.blocked_source_graphs import (
@@ -69,9 +70,37 @@ _REPORT_SNAPSHOT = {
   "periods": None,
 }
 
+# A library-seeded Structure id (deterministic UUID5, identical in every
+# tenant on the same taxonomy pin) and a tenant-local one (`struct_*` ULID,
+# meaningful only in the sender's schema). The share must carry the first
+# across and fall back for the second.
+_LIBRARY_STRUCTURE_ID = "b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d"
+_TENANT_LOCAL_STRUCTURE_ID = "struct_0000000000000000000001"
+_STRUCTURE_TAXONOMY = "tax_structures_local"
+
+_SOURCE_FACT_SETS = [
+  {
+    "id": "fs_source_0001",
+    "structure_id": _LIBRARY_STRUCTURE_ID,
+    "factset_type": "report",
+    "period_start": date(2026, 1, 1),
+    "period_end": date(2026, 3, 31),
+    "entity_id": _ENTITY_ID,
+  },
+  {
+    "id": "fs_source_0002",
+    "structure_id": _TENANT_LOCAL_STRUCTURE_ID,
+    "factset_type": "disclosure",
+    "period_start": None,
+    "period_end": date(2026, 3, 31),
+    "entity_id": _ENTITY_ID,
+  },
+]
+
 _SOURCE_FACTS = [
   {
     "id": "fact_0001",
+    "fact_set_id": "fs_source_0001",
     "element_id": "rs-gaap:Revenues",
     "value": 1000,
     "string_value": None,
@@ -88,6 +117,7 @@ _SOURCE_FACTS = [
   },
   {
     "id": "fact_0002",
+    "fact_set_id": "fs_source_0002",
     "element_id": "rs-gaap:Assets",
     "value": 5000,
     "string_value": None,
@@ -159,8 +189,10 @@ def _clean_tenants(two_tenants):
       session.execute(text("DELETE FROM reports"))
       session.execute(text("DELETE FROM blocked_source_graphs"))
       session.execute(text("DELETE FROM report_shares"))
-      # Elements before taxonomies: `elements.taxonomy_id` is a real FK.
+      # Elements and structures before taxonomies: both carry a real FK to
+      # `taxonomies.id`.
       session.execute(text("DELETE FROM elements"))
+      session.execute(text("DELETE FROM structures"))
       session.execute(text("DELETE FROM taxonomies"))
   yield
 
@@ -181,9 +213,30 @@ def _share() -> object:
     return _share_to_target(
       source_graph_id=SOURCE_GRAPH,
       report_snapshot=_REPORT_SNAPSHOT,
+      source_fact_sets=_SOURCE_FACT_SETS,
       source_facts=_SOURCE_FACTS,
       target_graph_id=TARGET_GRAPH,
       shared_by=_SENDER,
+    )
+
+
+def _seed_structure(graph_id: str, structure_id: str, block_type: str) -> None:
+  """Give `graph_id` one Structure row under an explicit id.
+
+  Stands in for the library copy: `provision_tenant_schema` seeds the
+  canonical library into every tenant schema, so in production both sides
+  already hold the same structure under the same deterministic id. These
+  throwaway schemas skip that copy, so the tests seed what they need.
+  """
+  with extensions_session(graph_id) as session:
+    session.add(
+      Structure(
+        id=structure_id,
+        name=f"Test {block_type}",
+        block_type=block_type,
+        taxonomy_id=_STRUCTURE_TAXONOMY,
+        created_by=_SENDER,
+      )
     )
 
 
@@ -205,6 +258,83 @@ def test_share_writes_into_the_target_schema_only() -> None:
 
   assert _counts(TARGET_GRAPH) == (1, 1, len(_SOURCE_FACTS))
   assert _counts(SOURCE_GRAPH) == (0, 0, 0)
+
+
+def _copied_report_id() -> str:
+  with extensions_session(TARGET_GRAPH) as session:
+    return session.execute(
+      text("SELECT id FROM reports WHERE source_graph_id = :src"),
+      {"src": SOURCE_GRAPH},
+    ).scalar_one()
+
+
+def _renderable_fact_sets(report_id: str) -> list[tuple[str, int]]:
+  """The recipient's read path, reduced to the join that decides visibility.
+
+  ``get_report_package`` inner-joins ``structures`` on ``fact_sets.structure_id``
+  and ``get_statement`` filters on ``structures.block_type`` — so a FactSet
+  with no resolvable Structure is invisible to every report read, however many
+  facts hang off it. This is that join.
+  """
+  with extensions_session(TARGET_GRAPH) as session:
+    return [
+      (row[0], row[1])
+      for row in session.execute(
+        text(
+          "SELECT fs.structure_id, count(f.id) "
+          "FROM fact_sets fs "
+          "JOIN structures s ON s.id = fs.structure_id "
+          "LEFT JOIN facts f ON f.fact_set_id = fs.id "
+          "WHERE fs.report_id = :report_id "
+          "GROUP BY fs.structure_id"
+        ),
+        {"report_id": report_id},
+      ).fetchall()
+    ]
+
+
+def test_a_library_structure_survives_the_graph_boundary() -> None:
+  """The regression that made a delivered report render as "No statements
+  available for this report yet."
+
+  Library structures are seeded into every tenant schema under deterministic
+  UUID5 ids, so the sender's balance sheet *is* the recipient's — same id, same
+  presentation arcs. A share that drops ``structure_id`` therefore throws away
+  a reference that was valid on the far side, and the facts land where no read
+  path can join them.
+  """
+  _seed_taxonomy(SOURCE_GRAPH, _STRUCTURE_TAXONOMY, "reporting_standard")
+  _seed_taxonomy(TARGET_GRAPH, _STRUCTURE_TAXONOMY, "reporting_standard")
+  _seed_structure(SOURCE_GRAPH, _LIBRARY_STRUCTURE_ID, "balance_sheet")
+  _seed_structure(TARGET_GRAPH, _LIBRARY_STRUCTURE_ID, "balance_sheet")
+
+  assert _share().status == "shared"
+
+  renderable = _renderable_fact_sets(_copied_report_id())
+  assert renderable == [(_LIBRARY_STRUCTURE_ID, 1)], (
+    "the shared report's balance sheet did not survive the copy; the "
+    "recipient's report viewer renders nothing"
+  )
+
+
+def test_a_tenant_local_structure_falls_back_without_dropping_facts() -> None:
+  """The other half: an id that is meaningful only in the sender's schema.
+
+  A custom disclosure carries a `struct_*` ULID the recipient has never seen.
+  Its facts still cross — they are queryable, and they materialize into the
+  recipient's graph — but they pool on a structure-less set rather than
+  pointing at a Structure that does not exist. Nothing is silently dropped,
+  which is the property the catch-all exists to hold.
+  """
+  _seed_taxonomy(SOURCE_GRAPH, _STRUCTURE_TAXONOMY, "reporting_standard")
+  _seed_structure(SOURCE_GRAPH, _TENANT_LOCAL_STRUCTURE_ID, "regulatory_disclosure")
+
+  assert _share().status == "shared"
+
+  # Neither structure resolves in the recipient, so both facts pool on one
+  # structure-less set — and every fact still arrives.
+  assert _renderable_fact_sets(_copied_report_id()) == []
+  assert _counts(TARGET_GRAPH) == (1, 1, len(_SOURCE_FACTS))
 
 
 def test_the_copy_carries_honest_provenance() -> None:
@@ -537,6 +667,7 @@ def _share_with_taxonomy(taxonomy_id: str) -> object:
     return _share_to_target(
       source_graph_id=SOURCE_GRAPH,
       report_snapshot=snapshot,
+      source_fact_sets=_SOURCE_FACT_SETS,
       source_facts=_SOURCE_FACTS,
       target_graph_id=TARGET_GRAPH,
       shared_by=_SENDER,

--- a/tests/operations/roboledger/reads/test_report_download.py
+++ b/tests/operations/roboledger/reads/test_report_download.py
@@ -27,12 +27,14 @@ def _report(
   *,
   generation_count: int = 3,
   generation_status: str = "published",
+  source_graph_id: str | None = None,
 ):
   """A minimal stand-in for a Report ORM row."""
   return SimpleNamespace(
     bundle_url=bundle_url,
     generation_count=generation_count,
     generation_status=generation_status,
+    source_graph_id=source_graph_id,
   )
 
 
@@ -84,6 +86,72 @@ class TestNotFoundAndNotAvailable:
     session = _session(_report(bundle_url=None, generation_status="draft"))
     with pytest.raises(ReportBundleNotAvailableError, match="not published"):
       get_report_download_url(session, "kg1", "rpt_1", flavor="holon-jsonld")
+
+
+class TestReceivedReportsAreNeverRederived:
+  """A report that arrived from another graph is served as the sender's
+  published artifact or not at all.
+
+  For an authored report the rows are the truth and the artifact is a
+  projection, so rebuilding a lost cache entry is free and correct. For a
+  received report the relationship inverts: the artifact is the sender's
+  document and the rows are what the share managed to bring across. Rebuilding
+  would present a locally-derived document as the sender's publication, and
+  nothing at the point of use would show the difference.
+  """
+
+  @pytest.mark.unit
+  @pytest.mark.parametrize(
+    ("flavor", "artifact"),
+    [("holon-jsonld", "holon"), ("xbrl-2.1", "XBRL bundle")],
+  )
+  def test_a_cache_miss_on_a_received_report_is_a_miss(self, flavor, artifact):
+    session = _session(_report(source_graph_id="kg_sender"))
+    with (
+      patch(f"{_REPORTS}.S3Client") as s3_cls,
+      patch("robosystems.operations.serialization.build_report_bundle") as build,
+    ):
+      s3_cls.return_value.object_exists.return_value = False
+      with pytest.raises(ReportBundleNotAvailableError, match=artifact):
+        get_report_download_url(session, "kg1", "rpt_1", flavor=flavor)
+
+    build.assert_not_called()
+
+  @pytest.mark.unit
+  @pytest.mark.parametrize("flavor", ["holon-jsonld", "xbrl-2.1"])
+  def test_a_cached_received_artifact_is_still_served(self, flavor):
+    """The refusal is about re-deriving, not about received reports — the
+    sender's own artifact serves normally."""
+    session = _session(_report(source_graph_id="kg_sender"))
+    with patch(f"{_REPORTS}.S3Client") as s3_cls:
+      s3 = s3_cls.return_value
+      s3.object_exists.return_value = True
+      s3.generate_presigned_url.return_value = "https://signed.example/artifact"
+      resp = get_report_download_url(session, "kg1", "rpt_1", flavor=flavor)
+
+    assert resp is not None
+    assert resp.download_url == "https://signed.example/artifact"
+
+  @pytest.mark.unit
+  def test_an_authored_report_still_rebuilds_on_a_miss(self):
+    """The negative control: the guard must not disable caching for the
+    reports this graph actually owns."""
+    session = _session(_report(source_graph_id=None))
+    with (
+      patch(f"{_REPORTS}.S3Client") as s3_cls,
+      patch("robosystems.operations.serialization.build_report_bundle") as build,
+      patch(
+        "robosystems.operations.serialization.serialize_to_holon_jsonld",
+        return_value="{}",
+      ),
+    ):
+      s3 = s3_cls.return_value
+      s3.object_exists.return_value = False
+      s3.upload_string.return_value = True
+      s3.generate_presigned_url.return_value = "https://signed.example/holon"
+      get_report_download_url(session, "kg1", "rpt_1", flavor="holon-jsonld")
+
+    build.assert_called_once()
 
 
 class TestJsonLd:

--- a/tests/operations/roboledger/reads/test_report_download.py
+++ b/tests/operations/roboledger/reads/test_report_download.py
@@ -26,9 +26,14 @@ def _report(
   bundle_url: str | None = "s3://bkt/report-bundles/kg1/rpt_1/g3.jsonld",
   *,
   generation_count: int = 3,
+  generation_status: str = "published",
 ):
   """A minimal stand-in for a Report ORM row."""
-  return SimpleNamespace(bundle_url=bundle_url, generation_count=generation_count)
+  return SimpleNamespace(
+    bundle_url=bundle_url,
+    generation_count=generation_count,
+    generation_status=generation_status,
+  )
 
 
 def _session(report) -> MagicMock:
@@ -54,6 +59,31 @@ class TestNotFoundAndNotAvailable:
     session = _session(_report())
     with pytest.raises(ValueError, match="Unsupported download format"):
       get_report_download_url(session, "kg1", "rpt_1", flavor="turtle")
+
+  @pytest.mark.unit
+  def test_a_published_report_serves_a_holon_without_a_flat_bundle(self):
+    """A cross-graph shared copy has no flat bundle of its own — the sender's
+    holon is copied in beside the rows. `bundle_url` names the flat object the
+    holon path never reads, so gating the holon on it would hide an artifact
+    that is present and valid."""
+    session = _session(_report(bundle_url=None))
+    with patch(f"{_REPORTS}.S3Client") as s3_cls:
+      s3 = s3_cls.return_value
+      s3.object_exists.return_value = True
+      s3.generate_presigned_url.return_value = "https://signed.example/holon"
+      resp = get_report_download_url(session, "kg1", "rpt_1", flavor="holon-jsonld")
+
+    assert resp is not None
+    assert resp.download_url == "https://signed.example/holon"
+    assert resp.format == "holon-jsonld"
+
+  @pytest.mark.unit
+  def test_an_unpublished_report_still_has_no_holon(self):
+    """The negative control: dropping the `bundle_url` gate must not turn the
+    holon into a draft-preview surface."""
+    session = _session(_report(bundle_url=None, generation_status="draft"))
+    with pytest.raises(ReportBundleNotAvailableError, match="not published"):
+      get_report_download_url(session, "kg1", "rpt_1", flavor="holon-jsonld")
 
 
 class TestJsonLd:

--- a/tests/routers/extensions/roboledger/test_operations.py
+++ b/tests/routers/extensions/roboledger/test_operations.py
@@ -1466,6 +1466,7 @@ class TestCrossGraphStalenessCallbacks:
 
   @staticmethod
   def _block_result(purged: int) -> BlockSourceGraphResult:
+    purged_ids = [f"rpt_purged_{n}" for n in range(purged)]
     return BlockSourceGraphResult(
       block=BlockedSourceGraphResponse(
         id="blk_1",
@@ -1475,6 +1476,7 @@ class TestCrossGraphStalenessCallbacks:
       ),
       already_blocked=False,
       purged_report_count=purged,
+      purged_report_ids=purged_ids,
     )
 
   @pytest.mark.asyncio
@@ -1509,6 +1511,45 @@ class TestCrossGraphStalenessCallbacks:
       )
 
     mark.assert_called_once_with(GRAPH_ID, "shared_reports_purged")
+
+  @pytest.mark.asyncio
+  async def test_purge_withdraws_the_stored_publications_after_the_rows(self) -> None:
+    """A purge that deletes rows and leaves the senders' holons in this
+    graph's bundle prefix has not withdrawn anything. The cleanup runs from
+    the after-success hook so it can only follow a committed deletion."""
+    body = BlockSourceGraphOperation(source_graph_id="kg0000000000000009", purge=True)
+
+    with (
+      patch(
+        "robosystems.routers.extensions.roboledger.operations.cmd_block_source_graph",
+        return_value=self._block_result(3),
+      ),
+      patch(
+        "robosystems.routers.extensions.roboledger.operations.user_is_graph_admin",
+        return_value=True,
+      ),
+      patch(
+        "robosystems.routers.extensions.roboledger.operations.extensions_session"
+      ) as mock_session,
+      patch("robosystems.routers.extensions.roboledger.operations.mark_graph_stale"),
+      patch(
+        "robosystems.routers.extensions.roboledger.operations.delete_report_artifacts"
+      ) as drop,
+    ):
+      mock_session.return_value.__enter__ = MagicMock(return_value=MagicMock())
+      mock_session.return_value.__exit__ = MagicMock(return_value=False)
+
+      await block_source_graph_op(
+        body=body,
+        graph_id=GRAPH_ID,
+        user=_make_user(),
+        idempotency_key=None,
+        cache=_FakeCache(),
+      )
+
+    drop.assert_called_once_with(
+      GRAPH_ID, ["rpt_purged_0", "rpt_purged_1", "rpt_purged_2"]
+    )
 
   @pytest.mark.asyncio
   async def test_block_without_a_purge_does_not_rebuild(self) -> None:


### PR DESCRIPTION
## Summary

A cross-graph report share delivered its facts and then hid them. The recipient saw a report header — correct name, period, "Shared report from …" provenance — over an empty **"No statements available for this report yet."** while their schema held all 85 facts. This fixes the delivery so a shared report renders for the tenant it was sent to, and carries the sender's **holon** across with it so the recipient views the publication the sender actually made.

## Changes

### The render defect — `operations/roboledger/commands/reports.py`

`_share_to_target` collapsed the sender's N FactSets into a single set with `structure_id=None`, on the stated premise that a source-graph structure id "is meaningless in the target". That premise is false for the structures a report's statements actually use: the taxonomy library is seeded into every tenant schema by `provision_tenant_schema` under deterministic UUID5 ids, so the sender's balance sheet *is* the recipient's — same id, same presentation arcs. (Measured on a live pair: 55 of the issuer's 66 structure ids exist verbatim in the recipient, including all four statement structures.)

Every report read then dropped those facts, because all three resolve a FactSet's Structure:
- `get_report_package` inner-joins `structures` on `fact_sets.structure_id`
- `get_statement` filters on `structures.block_type`
- `load_fact_set_by_id_for_structure` requires the pin to match

FactSets now travel as themselves — one target set per source set, carrying `structure_id` when the id resolves on the far side. Facts whose structure is tenant-local (a `struct_*` ULID, e.g. a custom disclosure) pool on a structure-less set: delivered, queryable, and materialized into the recipient's graph, but not renderable as a statement until a structure-aware import exists. Nothing is dropped.

`share_report` now selects the FactSet rows alongside the facts and passes both; `source_facts` carries `fact_set_id`.

### Holon delivery — same file, plus `reads/reports.py`

The share now copies the sender's holon (and flat JSON-LD) into the recipient's bundle prefix, re-keyed to the recipient's graph + report id, and stamps `bundle_url` / `generation_count`. The holon is the report as `#scene` / `#boundary` / `#projection` named graphs — self-contained, renderable outside the system, and omitting `#lineage` by construction, so the books never travel with the report. Copying the sender's *object* rather than re-deriving one from the recipient's copied rows makes the recipient's view byte-identical to what the sender published.

The copy is best-effort and logs on failure: the rows are the load-bearing half, since they are what materializes into the recipient's graph and carries the cross-graph traversal. An object-store fault degrades the renderers rather than failing the delivery.

**Reviewers may want to look closely at this one:** `get_report_download_url` no longer gates *every* flavor on `bundle_url`. That column names the flat JSON-LD object, which the holon path never reads — it serves its own cached object or rebuilds from rows. The holon branch now asks about publication status directly. Without this the copied holon was present in S3 and unreachable. A negative-control test covers the case the old gate was incidentally handling (an unpublished report must still have no holon).

### Receiving is not authoring — `graphql/resolvers/_common.py`, `resolvers/ledger.py`, `commands/reports.py`

`provision_tenant_schema` creates every tenant table and seeds the library regardless of a graph's `schema_extensions`, so an investor-only tenant can hold a report perfectly well. Two gates assumed otherwise:

- `_share_to_target` refused any target without `roboledger`. Narrowed to "has an extensions tenant at all" (`roboledger` **or** `roboinvestor`), so a share still cannot land in a graph that never opted into the OLTP surface.
- The GraphQL report **reads** (`reports`, `report`, `reportPackage`, `reportDownloadUrl`) gated on `roboledger`. They now accept either extension via a new `require_any_extension` / `open_extensions_session_for_any` pair. Every other field on the resolver — and every write path — stays `roboledger`-only.

The effect is that a fund does not have to provision a ledger it will never post to in order to read what its portfolio companies send it.

## Breaking Changes

None.

No GraphQL schema change — no fields, arguments, or types were added, removed, or retyped — so no client SDK regen is required, and nothing here touches the stable-tier facades or the integration template's emit path. Three behavior changes worth noting for release notes:

- Report reads and share targets now accept `roboinvestor`-provisioned graphs. This widens access to data already resident in the caller's own tenant schema; it grants no cross-tenant reach.
- `reportDownloadUrl(format: HOLON_JSONLD)` now succeeds for a published report with no flat bundle. The error code on failure is unchanged (`REPORT_BUNDLE_NOT_AVAILABLE`); its message differs for the holon flavor.
- The share-rejection message for an ineligible target graph changed. `ShareResultItem`'s shape is unchanged.

## Testing

- `just test-code` — passed (ruff, format, basedpyright, cf-lint).
- `uv run pytest tests/operations tests/graphql tests/routers` — **4663 passed, 5 skipped**.
- Post-merge with `main` (PR #1125): `tests/operations/roboledger tests/graphql` — **905 passed**.
- `just test-all` was started locally but not run to completion; CI is the gate for the full suite.

New coverage:
- `test_share_controls_db.py` — two DB-backed two-tenant cases: a library structure survives the boundary and lands renderable; a tenant-local structure falls back without dropping facts. Both were confirmed to fail against the previous behavior (not merely against the new signature — the old collapse was simulated to check the assertion actually bites).
- `test_reports.py` — the sender's artifacts are re-keyed under the recipient's prefix and `bundle_url` is stamped.
- `test_report_download.py` — a published report serves a holon without a flat bundle; an unpublished one still does not.

End-to-end against the live stack, via `just demo-roboinvestor` — **31/31 checks**, including `Portfolio → Position → Security → Entity → Report → Fact resolves`, confirming the LadybugDB traversal is intact. On the recipient's copy afterwards:

- `reportPackage` returns 4 items — Balance Sheet 30 facts, Income Statement 28, Cash Flow 14, Equity 5, in display order.
- Sender and recipient holon objects share ETag `177466cf…` — byte-identical.
- `reportDownloadUrl(HOLON_JSONLD)` resolves for the shared copy.
