### PR TITLE
fix(graphs): make graph creation's rollback run on every failure path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,7 +121,7 @@ dev = [
     # are the dogfooding surface and should exercise the current client, and
     # uv.lock is what makes a given checkout reproducible. <2 is the SDK's
     # post-1.0 semver boundary.
-    "robosystems-client>=1.8.0,<2.0",
+    "robosystems-client>=1.8.1,<2.0",
 
     # Testing framework
     "pytest>=9.0.0,<10.0",

--- a/robosystems/operations/graph/graph_creation_service.py
+++ b/robosystems/operations/graph/graph_creation_service.py
@@ -7,6 +7,7 @@ OLTP provisioning plus the entity node — runs only when
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
@@ -21,6 +22,13 @@ from robosystems.middleware.graph.allocation_manager import (
 )
 
 logger = get_logger(__name__)
+
+# Budget for the rollback itself, not for the pipeline it rolls back. Sized
+# above the one Graph API call teardown makes (``delete_database``, which
+# carries the client's own 30s timeout and three retries with backoff — ~127s
+# worst case) plus the registry deallocation and PostgreSQL cleanup after it.
+# The worker's per-task budget must exceed the pipeline's waits *and* this.
+CLEANUP_TIMEOUT_SECONDS = 180
 
 
 # ---------------------------------------------------------------------------
@@ -166,9 +174,17 @@ class GraphCreationService:
       logger.info(f"Graph creation completed: {graph_id}")
       return result
 
-    except Exception as e:
+    except BaseException as e:
+      # BaseException, not Exception: the worker runs this handler under
+      # ``asyncio.wait_for``, and an expired budget delivers ``CancelledError``,
+      # which is a BaseException in 3.13. Catching only Exception let a timeout
+      # skip the rollback entirely and strand the allocation on a
+      # one-graph-per-instance writer.
       logger.error(f"Graph creation failed: {type(e).__name__}: {e}")
-      await self._cleanup(graph_id, location, graph_client)
+      await self._cleanup_within_budget(graph_id, location, graph_client)
+      # Re-raise the original, untranslated: ``wait_for`` turns a propagating
+      # CancelledError into TimeoutError, which is what the consumer's timeout
+      # branch records the operation from.
       raise
 
     finally:
@@ -513,26 +529,89 @@ class GraphCreationService:
     except Exception as e:
       logger.error(f"Failed to create credit pool for {graph_id}: {e}")
 
+  async def _cleanup_within_budget(
+    self,
+    graph_id: str,
+    location: DatabaseLocation | None,
+    graph_client=None,
+  ) -> None:
+    """Run the rollback under its own timeout.
+
+    The bound is what makes the cancellation path safe. ``asyncio.wait_for``
+    cancels the handler exactly once, so once that cancellation has been caught
+    an unbounded rollback is never interrupted again and holds the worker for
+    however long teardown takes. Overrunning the budget is logged and
+    abandoned — the caller is already failing, and delaying its failure further
+    helps nobody.
+    """
+    try:
+      await asyncio.wait_for(
+        self._cleanup(graph_id, location, graph_client),
+        timeout=CLEANUP_TIMEOUT_SECONDS,
+      )
+    except (TimeoutError, asyncio.CancelledError):
+      logger.error(
+        f"Rollback for {graph_id} did not finish within {CLEANUP_TIMEOUT_SECONDS}s; "
+        "resources may be left allocated"
+      )
+    except Exception as e:
+      logger.error(f"Rollback for {graph_id} failed: {e}", exc_info=True)
+
   async def _cleanup(
     self,
     graph_id: str,
     location: DatabaseLocation | None,
     graph_client=None,
   ) -> None:
-    """Deallocate database and close client on failure."""
-    try:
-      if location:
-        manager = LadybugAllocationManager(environment=env.ENVIRONMENT)
-        await manager.deallocate_database(graph_id)
-        logger.info(f"Deallocated {graph_id}")
-    except Exception as e:
-      logger.error(f"Cleanup deallocate failed for {graph_id}: {e}")
+    """Undo a partially built graph.
 
+    Which resources exist depends on how far the pipeline got, and the two
+    cases need different treatment. ``_persist_metadata`` **commits**, so a
+    failure after it leaves a `Graph` row, its `GraphUser` / `GraphSchema` /
+    staging rows, and possibly an extensions tenant schema — teardown for all
+    of that already exists in ``GraphDeprovisionService`` and is what runs.
+    A failure before it leaves only the allocation, which that service would
+    decline to touch (no row to find, so it returns ``not_found``), so the
+    allocation is released directly instead.
+
+    Best-effort throughout: a failure here must not replace the exception that
+    caused the rollback.
+    """
     try:
       if graph_client:
         await graph_client.close()
     except Exception as e:
       logger.error(f"Cleanup close failed for {graph_id}: {e}")
+
+    try:
+      from robosystems.db.platform import platform_session
+      from robosystems.models.core.graph import Graph
+
+      with platform_session() as db:
+        row = db.query(Graph).filter(Graph.graph_id == graph_id).first()
+
+        if row is not None:
+          from .deprovision_service import GraphDeprovisionService
+
+          service = GraphDeprovisionService(environment=env.ENVIRONMENT)
+          result = await service.deprovision_graph(
+            graph_id=graph_id,
+            session=db,
+            create_backup=False,
+            skip_backup_check=True,
+          )
+          logger.info(
+            f"Rolled back partially created graph {graph_id}: {result.status}",
+            extra={"graph_id": graph_id, "errors": result.errors},
+          )
+          return
+
+      if location:
+        manager = LadybugAllocationManager(environment=env.ENVIRONMENT)
+        await manager.deallocate_database(graph_id)
+        logger.info(f"Deallocated {graph_id}")
+    except Exception as e:
+      logger.error(f"Cleanup failed for {graph_id}: {e}", exc_info=True)
 
   # ---- Helpers -----------------------------------------------------------
 

--- a/robosystems/operations/graph/tasks/graph_creation.py
+++ b/robosystems/operations/graph/tasks/graph_creation.py
@@ -55,15 +55,14 @@ class GraphCreationTask(BaseTask):
         f"running full deprovision: {billing_error}"
       )
       try:
-        from robosystems.database import get_db_session
+        from robosystems.config import env
+        from robosystems.db.platform import platform_session
         from robosystems.operations.graph.deprovision_service import (
-          DeprovisionService,
+          GraphDeprovisionService,
         )
 
-        db_gen = get_db_session()
-        db = next(db_gen)
-        try:
-          deprovision = DeprovisionService()
+        with platform_session() as db:
+          deprovision = GraphDeprovisionService(environment=env.ENVIRONMENT)
           deprovision_result = await deprovision.deprovision_graph(
             graph_id=result.graph_id,
             session=db,
@@ -74,13 +73,14 @@ class GraphCreationTask(BaseTask):
             f"Deprovisioned graph {result.graph_id} after billing failure: "
             f"{deprovision_result.status}"
           )
-        finally:
-          try:
-            next(db_gen)
-          except StopIteration:
-            pass
       except Exception as cleanup_error:
-        logger.error(f"Failed to clean up graph {result.graph_id}: {cleanup_error}")
+        # Swallowed so it cannot replace the billing error the caller needs to
+        # see. What stops this path silently rotting again is the test that
+        # drives it, not this handler — it was an ImportError for four months.
+        logger.error(
+          f"Failed to clean up graph {result.graph_id}: {cleanup_error}",
+          exc_info=True,
+        )
       raise
 
     # Report to Dagster observable asset

--- a/robosystems/worker/constants.py
+++ b/robosystems/worker/constants.py
@@ -21,11 +21,24 @@ Used by both the consumer loop and the Dagster reaper sensor.
 # operator thinks are still in budget — the MappingOperator makes one AI call
 # per CoA element during rs-gaap refinement, so a 100-element CoA at ~3-4s per
 # call lands around 6-7 minutes.
+#
+# The two creation budgets are derived from the Graph API calls they make, not
+# from how long a run usually takes. One call's worst case is the client's own
+# ``timeout`` across ``max_retries + 1`` attempts plus exponential backoff —
+# ~127s on ``GraphClientConfig`` defaults. Graph creation makes two such calls
+# (create_database, install_schema) before provisioning the extensions tenant
+# schema and copying the taxonomy library into it; subgraph creation makes
+# three, and its third is the fork, whose duration scales with the parent's
+# data. Both previously sat at 60s — below a *single* call's retry budget — so
+# a slow-but-succeeding run was killed mid-flight, and until the rollback was
+# fixed that killed run stranded its allocation.
+# ``tests/worker/test_task_timeout_coverage.py`` pins both against the client
+# config, so raising a retry budget without raising these fails there.
 TASK_TIMEOUTS: dict[str, int] = {
   "operator": 600,  # 10 minutes
   "extensions_materialize": 1800,  # 30 minutes
-  "graph_creation": 60,  # 1 minute
-  "subgraph_creation": 60,  # 1 minute
+  "graph_creation": 600,  # 10 minutes
+  "subgraph_creation": 900,  # 15 minutes (the fork copies parent data)
   "graph_materialization": 120,  # 2 minutes
   "dagster_job_monitor": 3600,  # 1 hour (backup/restore can be long)
   # Drain (120s) + reattach (300s) are awaited before health verification even

--- a/tests/operations/graph/tasks/test_graph_creation_task.py
+++ b/tests/operations/graph/tasks/test_graph_creation_task.py
@@ -1,0 +1,228 @@
+"""The compensating path for a graph that provisioned but could not be billed.
+
+`GraphCreationTask` provisions first and creates the billing subscription second,
+so a declined card arrives *after* an EC2 slot, a DynamoDB allocation, a
+LadybugDB database, a `Graph` row and a credit pool already exist. Undoing all
+of that is the only thing standing between a routine payment failure and a
+stranded instance the owner cannot delete.
+
+That path was dead for four months — it imported a class name that does not
+exist and the `ImportError` was swallowed by the same handler that logs cleanup
+failures. Nothing caught it because nothing referenced `GraphCreationTask` in
+the whole suite.
+
+These tests therefore drive the **real** `GraphDeprovisionService` against a
+real `Graph` row with only the infrastructure mocked, and assert the row's
+final state rather than that a mock was called. A mock named for the
+compensator would have passed happily against the broken import; the row would
+not.
+"""
+
+from __future__ import annotations
+
+import uuid
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from robosystems.config.graph_tier import GraphTier
+from robosystems.models.core import Graph, Org, OrgType, OrgUser, User
+from robosystems.models.core.graph import GraphStatus
+from robosystems.operations.graph.graph_creation_service import GraphCreationResult
+from robosystems.operations.graph.tasks.graph_creation import GraphCreationTask
+
+DEPROVISION_MODULE = "robosystems.operations.graph.deprovision_service"
+
+
+@pytest.fixture
+def test_user(db_session):
+  uid = str(uuid.uuid4())[:8]
+  user = User(
+    id=f"test_user_{uid}",
+    email=f"test+{uid}@example.com",
+    name="Test User",
+    password_hash="hash",
+  )
+  db_session.add(user)
+  db_session.commit()
+  db_session.refresh(user)
+  return user
+
+
+@pytest.fixture
+def test_org(db_session, test_user):
+  org = Org.create(name="Test Org", org_type=OrgType.PERSONAL, session=db_session)
+  OrgUser.create(org_id=org.id, user_id=test_user.id, role="OWNER", session=db_session)
+  return org
+
+
+@pytest.fixture
+def provisioned_graph(db_session, test_org):
+  """A graph in the state creation leaves it: fully provisioned, unbilled."""
+  uid = str(uuid.uuid4())[:8]
+  return Graph.create(
+    graph_id=f"kg_{uid}",
+    graph_name="Test Graph",
+    graph_type="entity",
+    org_id=test_org.id,
+    session=db_session,
+    graph_tier=GraphTier.LADYBUG_STANDARD,
+  )
+
+
+def _task(user_id: str) -> GraphCreationTask:
+  return GraphCreationTask(
+    task_id="op_test",
+    graph_id=None,
+    user_id=user_id,
+    params={"graph_name": "Test Graph", "tier": "ladybug-standard"},
+    manager=AsyncMock(),
+  )
+
+
+@contextmanager
+def _teardown_infra(db_session):
+  """Let the real deprovision service run against mocked infrastructure.
+
+  `platform_session` is redirected at the test session because the task opens
+  its own; everything below it is the genuine teardown, so the assertions are
+  about what teardown actually did.
+  """
+  with (
+    patch(
+      "robosystems.db.platform.platform_session",
+      lambda: _yield(db_session),
+    ),
+    patch(
+      "robosystems.graph_api.client.factory.get_graph_client",
+      new_callable=AsyncMock,
+    ),
+    patch(
+      "robosystems.middleware.graph.allocation_manager.LadybugAllocationManager"
+    ) as alloc_cls,
+    patch(f"{DEPROVISION_MODULE}.get_deprovisioning_config"),
+  ):
+    alloc_cls.return_value = AsyncMock()
+    yield
+
+
+@contextmanager
+def _yield(session):
+  yield session
+
+
+def _creation_result(graph_id: str) -> GraphCreationResult:
+  return GraphCreationResult(
+    graph_id=graph_id,
+    org_id="org_test",
+    instance_id="i-test",
+    private_ip="10.0.0.1",
+    graph_type="entity",
+    tier="ladybug-standard",
+    schema_type="extensions",
+    schema_extensions=[],
+  )
+
+
+@pytest.mark.asyncio
+async def test_billing_failure_tears_the_graph_down(
+  db_session, test_user, provisioned_graph
+):
+  """A declined card must leave no graph behind, and must still surface."""
+  task = _task(test_user.id)
+
+  with (
+    patch.object(
+      GraphCreationTask,
+      "_create_billing_subscription",
+      side_effect=RuntimeError("card declined"),
+    ),
+    patch(
+      "robosystems.operations.graph.graph_creation_service.GraphCreationService.create",
+      new_callable=AsyncMock,
+      return_value=_creation_result(provisioned_graph.graph_id),
+    ),
+    _teardown_infra(db_session),
+  ):
+    with pytest.raises(RuntimeError, match="card declined"):
+      await task.execute()
+
+  db_session.refresh(provisioned_graph)
+  assert provisioned_graph.status == GraphStatus.DEPROVISIONED.value
+  assert provisioned_graph.deleted_at is not None
+
+
+@pytest.mark.asyncio
+async def test_billing_error_survives_a_failing_teardown(
+  db_session, test_user, provisioned_graph
+):
+  """Cleanup failure must not replace the error the caller needs to see.
+
+  This is the behavior that hid the dead import: it is correct to swallow a
+  cleanup failure, which is exactly why the swallowing cannot be the only thing
+  standing behind this path.
+  """
+  task = _task(test_user.id)
+
+  with (
+    patch.object(
+      GraphCreationTask,
+      "_create_billing_subscription",
+      side_effect=RuntimeError("card declined"),
+    ),
+    patch(
+      "robosystems.operations.graph.graph_creation_service.GraphCreationService.create",
+      new_callable=AsyncMock,
+      return_value=_creation_result(provisioned_graph.graph_id),
+    ),
+    patch(
+      f"{DEPROVISION_MODULE}.GraphDeprovisionService",
+      side_effect=RuntimeError("teardown exploded"),
+    ),
+  ):
+    with pytest.raises(RuntimeError, match="card declined"):
+      await task.execute()
+
+
+@pytest.mark.asyncio
+async def test_compensator_is_constructed_with_an_environment(
+  db_session, test_user, provisioned_graph
+):
+  """Pins the constructor contract the dead import got wrong twice over.
+
+  `DeprovisionService` never existed, and `GraphDeprovisionService` takes a
+  required `environment` — so correcting the name alone would still have raised
+  `TypeError` into the same swallowing handler.
+  """
+  task = _task(test_user.id)
+
+  with (
+    patch.object(
+      GraphCreationTask,
+      "_create_billing_subscription",
+      side_effect=RuntimeError("card declined"),
+    ),
+    patch(
+      "robosystems.operations.graph.graph_creation_service.GraphCreationService.create",
+      new_callable=AsyncMock,
+      return_value=_creation_result(provisioned_graph.graph_id),
+    ),
+    patch(
+      "robosystems.db.platform.platform_session",
+      lambda: _yield(db_session),
+    ),
+    patch(f"{DEPROVISION_MODULE}.GraphDeprovisionService") as service_cls,
+  ):
+    service_cls.return_value = MagicMock(
+      deprovision_graph=AsyncMock(return_value=MagicMock(status="success"))
+    )
+
+    with pytest.raises(RuntimeError, match="card declined"):
+      await task.execute()
+
+  assert service_cls.call_args.kwargs["environment"]
+  call = service_cls.return_value.deprovision_graph.call_args.kwargs
+  assert call["graph_id"] == provisioned_graph.graph_id
+  assert call["create_backup"] is False
+  assert call["skip_backup_check"] is True

--- a/tests/operations/graph/test_graph_creation_cleanup.py
+++ b/tests/operations/graph/test_graph_creation_cleanup.py
@@ -1,0 +1,304 @@
+"""Rollback of a graph whose creation pipeline failed part-way through.
+
+Which resources exist when `create()` fails depends on where it failed, and the
+split is `_persist_metadata`, which **commits**. Before it, only the allocation
+exists. After it, so do a `Graph` row, its `GraphUser` / `GraphSchema` / staging
+rows, and possibly an extensions tenant schema — none of which the rollback used
+to touch, which is how a failed creation left a row its owner could not delete.
+
+The cancellation case is separate and worse: the worker runs the handler under
+`asyncio.wait_for`, and an expired budget raises `CancelledError` *inside* the
+pipeline. That is a `BaseException` in 3.13, so an `except Exception` rollback
+is skipped entirely and the allocation is stranded on a writer that holds one
+graph.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from contextlib import contextmanager
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from robosystems.config.graph_tier import GraphTier
+from robosystems.middleware.graph.allocation_manager import (
+  DatabaseLocation,
+  DatabaseStatus,
+)
+from robosystems.models.core import Graph, Org, OrgType, OrgUser, User
+from robosystems.models.core.graph import GraphStatus
+from robosystems.operations.graph.graph_creation_service import (
+  GraphCreationConfig,
+  GraphCreationService,
+)
+
+SERVICE_MODULE = "robosystems.operations.graph.graph_creation_service"
+DEPROVISION_MODULE = "robosystems.operations.graph.deprovision_service"
+
+
+@pytest.fixture
+def test_user(db_session):
+  uid = str(uuid.uuid4())[:8]
+  user = User(
+    id=f"test_user_{uid}",
+    email=f"test+{uid}@example.com",
+    name="Test User",
+    password_hash="hash",
+  )
+  db_session.add(user)
+  db_session.commit()
+  db_session.refresh(user)
+  return user
+
+
+@pytest.fixture
+def test_org(db_session, test_user):
+  org = Org.create(name="Test Org", org_type=OrgType.PERSONAL, session=db_session)
+  OrgUser.create(org_id=org.id, user_id=test_user.id, role="OWNER", session=db_session)
+  return org
+
+
+@pytest.fixture
+def persisted_graph(db_session, test_org):
+  """The row `_persist_metadata` commits before the later steps can fail."""
+  uid = str(uuid.uuid4())[:8]
+  return Graph.create(
+    graph_id=f"kg_{uid}",
+    graph_name="Test Graph",
+    graph_type="entity",
+    org_id=test_org.id,
+    session=db_session,
+    graph_tier=GraphTier.LADYBUG_STANDARD,
+  )
+
+
+@contextmanager
+def _yield(session):
+  yield session
+
+
+def _location() -> DatabaseLocation:
+  return DatabaseLocation(
+    graph_id="kg_test",
+    instance_id="i-test",
+    private_ip="10.0.0.1",
+    availability_zone="us-east-1a",
+    created_at=datetime(2026, 1, 1, tzinfo=UTC),
+    status=DatabaseStatus.ACTIVE,
+  )
+
+
+def _config() -> GraphCreationConfig:
+  return GraphCreationConfig(
+    user_id="u1",
+    tier="ladybug-standard",
+    graph_name="Test Graph",
+    graph_type="generic",
+  )
+
+
+@contextmanager
+def _teardown_infra(db_session):
+  """Real deprovision service, mocked infrastructure, test session."""
+  with (
+    patch("robosystems.db.platform.platform_session", lambda: _yield(db_session)),
+    patch(
+      "robosystems.graph_api.client.factory.get_graph_client", new_callable=AsyncMock
+    ),
+    patch(
+      "robosystems.middleware.graph.allocation_manager.LadybugAllocationManager"
+    ) as alloc_cls,
+    patch(f"{DEPROVISION_MODULE}.get_deprovisioning_config"),
+  ):
+    alloc_cls.return_value = AsyncMock()
+    yield
+
+
+class TestCleanupAfterPersist:
+  """A failure after `_persist_metadata` must not leave the row behind."""
+
+  @pytest.mark.asyncio
+  async def test_cleanup_deprovisions_a_persisted_row(
+    self, db_session, persisted_graph
+  ):
+    service = GraphCreationService()
+
+    with _teardown_infra(db_session):
+      await service._cleanup(persisted_graph.graph_id, _location(), None)
+
+    db_session.refresh(persisted_graph)
+    assert persisted_graph.status == GraphStatus.DEPROVISIONED.value
+    assert persisted_graph.deleted_at is not None
+
+  @pytest.mark.asyncio
+  async def test_cleanup_closes_the_client_before_teardown(
+    self, db_session, persisted_graph
+  ):
+    """Teardown opens its own client, so the pipeline's must be released first."""
+    service = GraphCreationService()
+    client = AsyncMock()
+
+    with _teardown_infra(db_session):
+      await service._cleanup(persisted_graph.graph_id, _location(), client)
+
+    client.close.assert_awaited_once()
+
+
+class TestCleanupBeforePersist:
+  """A failure before the row is committed still has an allocation to release."""
+
+  @pytest.mark.asyncio
+  async def test_cleanup_deallocates_when_no_row_exists(self, db_session):
+    service = GraphCreationService()
+
+    with (
+      patch("robosystems.db.platform.platform_session", lambda: _yield(db_session)),
+      patch(f"{SERVICE_MODULE}.LadybugAllocationManager") as alloc_cls,
+    ):
+      manager = AsyncMock()
+      alloc_cls.return_value = manager
+
+      await service._cleanup("kg_neverpersisted", _location(), None)
+
+    manager.deallocate_database.assert_awaited_once_with("kg_neverpersisted")
+
+  @pytest.mark.asyncio
+  async def test_no_row_and_no_allocation_is_not_an_error(self, db_session):
+    """`_validate_org` can fail before anything is allocated at all."""
+    service = GraphCreationService()
+
+    with (
+      patch("robosystems.db.platform.platform_session", lambda: _yield(db_session)),
+      patch(f"{SERVICE_MODULE}.LadybugAllocationManager") as alloc_cls,
+    ):
+      manager = AsyncMock()
+      alloc_cls.return_value = manager
+
+      await service._cleanup("kg_nothing", None, None)
+
+    manager.deallocate_database.assert_not_awaited()
+
+
+class TestCancellation:
+  """The worker's timeout arrives as a BaseException, not an Exception."""
+
+  @pytest.mark.asyncio
+  async def test_cancellation_runs_cleanup_and_propagates(self):
+    """The D2 regression: rollback must run, and the cancel must not be eaten.
+
+    Re-raising `CancelledError` unchanged is what lets `wait_for` convert it to
+    `TimeoutError`, which is what the consumer's timeout branch records the
+    failed operation from. Translating it here would silently reclassify every
+    timeout as a generic failure.
+    """
+    service = GraphCreationService()
+    cleanup = AsyncMock()
+
+    with (
+      patch.object(service, "_validate_org", return_value="org_test"),
+      patch.object(service, "_generate_graph_id", return_value="kg_cancelled"),
+      patch.object(
+        service, "_allocate", new_callable=AsyncMock, return_value=_location()
+      ),
+      patch.object(
+        service,
+        "_create_database",
+        new_callable=AsyncMock,
+        side_effect=asyncio.CancelledError(),
+      ),
+      patch.object(service, "_cleanup", cleanup),
+    ):
+      with pytest.raises(asyncio.CancelledError):
+        await service.create(_config())
+
+    cleanup.assert_awaited_once()
+
+  @pytest.mark.asyncio
+  async def test_ordinary_failure_still_runs_cleanup(self):
+    """Widening to BaseException must not lose the Exception case."""
+    service = GraphCreationService()
+    cleanup = AsyncMock()
+
+    with (
+      patch.object(service, "_validate_org", return_value="org_test"),
+      patch.object(service, "_generate_graph_id", return_value="kg_failed"),
+      patch.object(
+        service, "_allocate", new_callable=AsyncMock, return_value=_location()
+      ),
+      patch.object(
+        service,
+        "_create_database",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("graph api down"),
+      ),
+      patch.object(service, "_cleanup", cleanup),
+    ):
+      with pytest.raises(RuntimeError, match="graph api down"):
+        await service.create(_config())
+
+    cleanup.assert_awaited_once()
+
+  @pytest.mark.asyncio
+  async def test_rollback_is_bounded(self):
+    """An unbounded rollback would hold the worker for the whole teardown.
+
+    `wait_for` cancels the handler exactly once, so after that cancellation is
+    caught nothing interrupts the rollback a second time — the budget is the
+    only thing that ends it.
+    """
+    service = GraphCreationService()
+
+    async def _never_finishes(*_args, **_kwargs):
+      await asyncio.sleep(3600)
+
+    with (
+      patch.object(service, "_cleanup", _never_finishes),
+      patch(f"{SERVICE_MODULE}.CLEANUP_TIMEOUT_SECONDS", 0.01),
+    ):
+      # Returns rather than hanging or raising: the caller is already failing.
+      await service._cleanup_within_budget("kg_slow", _location(), None)
+
+  @pytest.mark.asyncio
+  async def test_rollback_failure_does_not_replace_the_original_error(self):
+    service = GraphCreationService()
+
+    with (
+      patch.object(service, "_validate_org", return_value="org_test"),
+      patch.object(service, "_generate_graph_id", return_value="kg_failed"),
+      patch.object(
+        service, "_allocate", new_callable=AsyncMock, return_value=_location()
+      ),
+      patch.object(
+        service,
+        "_create_database",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("graph api down"),
+      ),
+      patch.object(
+        service,
+        "_cleanup",
+        AsyncMock(side_effect=RuntimeError("rollback exploded")),
+      ),
+    ):
+      with pytest.raises(RuntimeError, match="graph api down"):
+        await service.create(_config())
+
+
+class TestCleanupIsBestEffort:
+  """A rollback that cannot reach its dependencies must not raise."""
+
+  @pytest.mark.asyncio
+  async def test_teardown_failure_is_swallowed(self, db_session, persisted_graph):
+    service = GraphCreationService()
+
+    with (
+      patch("robosystems.db.platform.platform_session", lambda: _yield(db_session)),
+      patch(
+        f"{DEPROVISION_MODULE}.GraphDeprovisionService",
+        MagicMock(side_effect=RuntimeError("teardown exploded")),
+      ),
+    ):
+      await service._cleanup(persisted_graph.graph_id, _location(), None)

--- a/tests/worker/test_task_timeout_coverage.py
+++ b/tests/worker/test_task_timeout_coverage.py
@@ -65,6 +65,78 @@ def test_timeouts_are_positive_ints() -> None:
     assert timeout > 0, f"{task_type} timeout must be positive"
 
 
+def _worst_case_graph_call_seconds() -> float:
+  """Worst-case wall clock for one Graph API call, from the client's own config.
+
+  Every attempt can burn the full request timeout, and ``_execute_with_retry``
+  makes ``max_retries + 1`` of them with exponential backoff between. Jitter
+  adds up to 10% per delay and is ignored here — it only makes the real number
+  larger, so a budget that clears this bound clears it with jitter too.
+  """
+  from robosystems.graph_api.client.config import GraphClientConfig
+
+  config = GraphClientConfig()
+  attempts = config.max_retries + 1
+  backoff = sum(
+    config.retry_delay * (config.retry_backoff**i) for i in range(attempts - 1)
+  )
+  return config.timeout * attempts + backoff
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+  ("task_type", "graph_api_calls"),
+  [
+    # create_database, install_schema
+    ("graph_creation", 2),
+    # create_database, install_schema, fork_from_parent
+    ("subgraph_creation", 3),
+  ],
+)
+def test_creation_budgets_cover_their_graph_api_calls(
+  task_type: str, graph_api_calls: int
+) -> None:
+  """A creation budget must exceed the retry budget of the calls it makes.
+
+  Both of these sat at 60s — less than one call's worst case — so a slow run
+  was killed mid-provision rather than allowed to finish. The failure mode is
+  invisible from the code: the only symptom is a task that always dies at the
+  same elapsed time, and (before the rollback was fixed) an allocation left
+  behind on a one-graph-per-instance writer.
+
+  The bound is deliberately the *floor*, not the budget: it ignores the
+  extensions tenant provisioning, the taxonomy copy, and the fork's own data
+  volume, all of which come on top.
+  """
+  floor = _worst_case_graph_call_seconds() * graph_api_calls
+  assert TASK_TIMEOUTS[task_type] > floor, (
+    f"{task_type} budget ({TASK_TIMEOUTS[task_type]}s) must exceed the worst-case "
+    f"retry budget of its {graph_api_calls} Graph API calls ({floor:.0f}s), which is "
+    "only the floor — the schema and data work it does on top is unbounded by this. "
+    "Raise the budget in robosystems/worker/constants.py, or lower the client's "
+    "timeout/max_retries in graph_api/client/config.py."
+  )
+
+
+@pytest.mark.unit
+def test_creation_budgets_leave_room_for_their_own_rollback() -> None:
+  """The rollback runs inside the same worker task, after the pipeline fails.
+
+  ``GraphCreationService`` catches the timeout's ``CancelledError`` and runs
+  teardown under ``CLEANUP_TIMEOUT_SECONDS``. Pinned so that shrinking the task
+  budget toward the rollback budget — which would leave a rollback with no room
+  to finish — fails here.
+  """
+  from robosystems.operations.graph.graph_creation_service import (
+    CLEANUP_TIMEOUT_SECONDS,
+  )
+
+  assert TASK_TIMEOUTS["graph_creation"] > CLEANUP_TIMEOUT_SECONDS, (
+    f"graph_creation budget ({TASK_TIMEOUTS['graph_creation']}s) must exceed the "
+    f"rollback budget ({CLEANUP_TIMEOUT_SECONDS}s) it triggers on failure."
+  )
+
+
 @pytest.mark.unit
 def test_tier_upgrade_budget_covers_its_internal_waits() -> None:
   """The tier migration awaits drain + reattach before it verifies anything.

--- a/uv.lock
+++ b/uv.lock
@@ -3699,7 +3699,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.34.2,<3.0" },
     { name = "retrying", specifier = ">=1.4.0,<2.0" },
     { name = "rich", marker = "extra == 'dev'", specifier = ">=15.0.0,<16.0" },
-    { name = "robosystems-client", marker = "extra == 'dev'", specifier = ">=1.8.0,<2.0" },
+    { name = "robosystems-client", marker = "extra == 'dev'", specifier = ">=1.8.1,<2.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0,<1.0" },
     { name = "sqlalchemy", specifier = ">=2.0.0,<3.0" },
     { name = "sse-starlette", specifier = ">=3.3.0,<4.0" },
@@ -3722,7 +3722,7 @@ lambda = [
 
 [[package]]
 name = "robosystems-client"
-version = "1.8.0"
+version = "1.8.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -3730,9 +3730,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6c/43/4554e408cefa3bfc801a748111026110dc5777d023d8e78ac8780038cee5/robosystems_client-1.8.0.tar.gz", hash = "sha256:a9bec3f2958410ad558383ff1c6e111e9d0bc86c0bdc8b425f0dcd278420bfb3", size = 521994, upload-time = "2026-08-09T21:52:00.477Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/d8/04ead718b75884bee558f6ac7d14b8e9f0b78abeb80eea23b51860aec35e/robosystems_client-1.8.1.tar.gz", hash = "sha256:39910cebb6ebfa397f37cf4beb4d58951a2381155d5c7a1a10edde53673981be", size = 522617, upload-time = "2026-08-10T06:08:35.401Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/b4/f6168e658dcf76ea3242c37441931d3925b74815315cd56a1489df419c00/robosystems_client-1.8.0-py3-none-any.whl", hash = "sha256:ec70b7ca9d91760a79289f1bfabf721f627d9aedc2bb93b757d098383e3cb5d0", size = 1200552, upload-time = "2026-08-09T21:51:58.661Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/38/723793fcc8ba2d5a5a2bb864e39af900fbaba7eb8b3a687b7f9413e4be2e/robosystems_client-1.8.1-py3-none-any.whl", hash = "sha256:7c002616964afc5192408edab24d63f1d095b4417244d50511534d4a2e1bfd38", size = 1201824, upload-time = "2026-08-10T06:08:33.748Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Graph creation allocates an instance slot, a routing entry, a database, a committed `Graph` row and a credit pool before it sets up billing. Undoing that on failure is one path, and it did not work under any failure mode. Three defects, all verified at HEAD.

Blast radius today is nil — four graph-tier subscriptions have ever been created and all four succeeded, so the compensator has never been invoked. Launch changes the arrival rate of the triggering event: a declined card is routine, not an incident.

## The compensator imported a class that does not exist

`DeprovisionService` was never defined. The module has `DeprovisionResult` and `GraphDeprovisionService`, and the latter takes a required `environment` — so correcting the name alone would still have raised into the same handler that swallows cleanup errors. Wrong since 2026-04-06, and invisible because nothing in the suite referenced `GraphCreationTask` at all.

## A worker timeout skipped the rollback entirely

The handler runs under `asyncio.wait_for`, whose expiry delivers `CancelledError` into the pipeline — a `BaseException` in 3.13, so `except Exception` never saw it and the allocation stayed active on a writer that holds one graph.

It now catches `BaseException`, runs the rollback under its own budget, and re-raises untranslated so `wait_for` still produces the `TimeoutError` the consumer records the operation from. The budget is what makes this safe: `wait_for` cancels once, so an unbounded rollback is never interrupted a second time.

## `_cleanup` released the allocation and nothing else

`_persist_metadata` commits, so a failure after it left a `Graph` row, its user/schema/staging rows and possibly an extensions tenant schema — a graph the owner cannot delete, since the delete path 404s without a subscription.

Rollback now delegates to `GraphDeprovisionService`, which already performs that teardown idempotently and in dependency order. A failure *before* the row is committed has only an allocation, and that case deallocates directly — the service would decline a graph it cannot find.

## Both creation budgets were below their own internal waits

60s, against a single Graph API call whose retry budget is ~127s (30s across four attempts with backoff). Graph creation makes two such calls before provisioning a tenant schema and copying the taxonomy library into it; subgraph creation makes three, and its third is the fork. A slow run was killed mid-provision.

Both are now derived from the calls they make, with the derivation pinned by a test against the client config rather than left in a comment. Crossing 120s turns on ECS scale-in protection for these tasks, which is correct for work that provisions infrastructure.

## Tests

Each defect is covered by a test confirmed to fail against the original code: the row stays `active` under the dead import and under the old `_cleanup`, and the cancellation case never awaits its cleanup. The task tests drive the real `GraphDeprovisionService` against a real row with only infrastructure mocked — a mock named for the compensator would have passed happily against the broken import.

Also carries the `robosystems-client` bump to 1.8.1 as a separate commit.

Ships before the v1.8.0 tag so the release's deploy is the one that fixes it.