### PR TITLE
fix(extensions): stop a committed write coming back as a 500

### DIFF
--- a/robosystems/operations/information_block/forecast.py
+++ b/robosystems/operations/information_block/forecast.py
@@ -619,8 +619,9 @@ def create(
   session.flush()
 
   _write_lever_fact_set(session, structure, mechanics, entity_id, created_by)
+  structure_id = structure.id
   session.commit()
-  return structure.id
+  return structure_id
 
 
 def _load_forecast_or_404(session: Session, structure_id: str) -> Structure:
@@ -722,8 +723,9 @@ def update(
     )
 
   session.flush()
+  structure_id = structure.id
   session.commit()
-  return structure.id
+  return structure_id
 
 
 def delete(

--- a/robosystems/operations/information_block/rollforward.py
+++ b/robosystems/operations/information_block/rollforward.py
@@ -143,8 +143,14 @@ def create(
   )
   session.add(structure)
   session.flush()
+  # Read the id off the flush, before the commit expires the instance. A
+  # post-commit attribute access issues a refresh SELECT on a connection the
+  # commit already returned to the pool, whose search_path may have been reset
+  # to `public` — so the row resolves to the wrong schema and the write comes
+  # back as a 500 despite having committed.
+  structure_id = structure.id
   session.commit()
-  return structure.id
+  return structure_id
 
 
 def _load_rollforward_or_404(session: Session, structure_id: str) -> Structure:
@@ -207,8 +213,9 @@ def update(
   structure.artifact_mechanics = next_mechanics.model_dump(mode="json")
   structure.updated_by = updated_by
   session.flush()
+  structure_id = structure.id
   session.commit()
-  return structure.id
+  return structure_id
 
 
 def delete(

--- a/robosystems/operations/roboledger/commands/schedules.py
+++ b/robosystems/operations/roboledger/commands/schedules.py
@@ -224,13 +224,22 @@ def create_schedule(
     created_by=created_by,
   )
 
+  # Read every attribute the response needs before the commit expires the
+  # instance. A post-commit access issues a refresh SELECT on a connection the
+  # commit already returned to the pool, whose search_path may have been reset
+  # to `public` — so the row resolves to the wrong schema and a schedule that
+  # committed comes back to the caller as a 500.
+  metadata = structure.metadata_ or {}
+  structure_id = structure.id
+  structure_name = structure.name
+  structure_taxonomy_id = structure.taxonomy_id
+
   session.commit()
 
-  metadata = structure.metadata_ or {}
   return ScheduleCreatedResponse(
-    structure_id=structure.id,
-    name=structure.name,
-    taxonomy_id=structure.taxonomy_id,
+    structure_id=structure_id,
+    name=structure_name,
+    taxonomy_id=structure_taxonomy_id,
     total_periods=period_row.cnt if period_row else 0,
     total_facts=count_row.cnt if count_row else 0,
     rule_summary=_rule_summary(rule_results),
@@ -385,25 +394,32 @@ def update_schedule(
     )
     rule_summary = _rule_summary(rule_results)
 
+  # Captured before the commit expires the instance — these are not only the
+  # response's values, they are the parameter the recounts below bind, so a
+  # refresh that resolves to the wrong schema would break the counts too.
+  structure_id = structure.id
+  structure_name = structure.name
+  structure_taxonomy_id = structure.taxonomy_id
+
   session.commit()
 
   # Recount for response (same as create_schedule response shape)
   count_row = session.execute(
     text("SELECT COUNT(*) AS cnt FROM facts WHERE structure_id = :sid"),
-    {"sid": structure.id},
+    {"sid": structure_id},
   ).fetchone()
   period_row = session.execute(
     text(
       "SELECT COUNT(DISTINCT (period_start, period_end)) AS cnt "
       "FROM facts WHERE structure_id = :sid"
     ),
-    {"sid": structure.id},
+    {"sid": structure_id},
   ).fetchone()
 
   return ScheduleCreatedResponse(
-    structure_id=structure.id,
-    name=structure.name,
-    taxonomy_id=structure.taxonomy_id,
+    structure_id=structure_id,
+    name=structure_name,
+    taxonomy_id=structure_taxonomy_id,
     total_periods=period_row.cnt if period_row else 0,
     total_facts=count_row.cnt if count_row else 0,
     rule_summary=rule_summary,
@@ -748,13 +764,22 @@ def rebuild_schedule(
     created_by=created_by,
   )
 
+  # Read every attribute the response needs before the commit expires the
+  # instance. A post-commit access issues a refresh SELECT on a connection the
+  # commit already returned to the pool, whose search_path may have been reset
+  # to `public` — so the row resolves to the wrong schema and a schedule that
+  # committed comes back to the caller as a 500.
+  metadata = structure.metadata_ or {}
+  structure_id = structure.id
+  structure_name = structure.name
+  structure_taxonomy_id = structure.taxonomy_id
+
   session.commit()
 
-  metadata = structure.metadata_ or {}
   return ScheduleCreatedResponse(
-    structure_id=structure.id,
-    name=structure.name,
-    taxonomy_id=structure.taxonomy_id,
+    structure_id=structure_id,
+    name=structure_name,
+    taxonomy_id=structure_taxonomy_id,
     total_periods=period_row.cnt if period_row else 0,
     total_facts=count_row.cnt if count_row else 0,
     rule_summary=_rule_summary(rule_results),

--- a/tests/operations/information_block/test_no_post_commit_reads.py
+++ b/tests/operations/information_block/test_no_post_commit_reads.py
@@ -1,0 +1,150 @@
+"""Writes must not read their ORM instance back after committing it.
+
+`session.commit()` expires every instance in the session — the extensions
+`sessionmaker` does not set `expire_on_commit=False` — so an attribute access
+after the commit issues a refresh SELECT. The commit has already returned the
+connection to the pool, so that SELECT runs on whichever connection comes back
+out, and `extensions_session` resets `search_path` to `public` in its `finally`.
+A refresh that lands on a reset connection resolves `structures` to the public
+schema, finds no row, and raises `ObjectDeletedError`.
+
+The caller sees a 500 for a write that committed successfully — the same
+disease as reporting a committed event-block write as a 500, in a different
+path. It is intermittent by construction, because it depends on which pooled
+connection serves the refresh, which is why it survived until a 22,288-line
+demo run happened to hit it.
+
+The fix is to read what the response needs off the flush, before committing.
+This test guards the shape rather than the symptom: a timing-dependent bug
+cannot be reproduced reliably enough for an integration test to be the guard.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+# Modules whose writes build a response from an ORM instance.
+GUARDED = [
+  "robosystems/operations/information_block/rollforward.py",
+  "robosystems/operations/information_block/forecast.py",
+  "robosystems/operations/roboledger/commands/schedules.py",
+]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _is_session_commit(node: ast.stmt) -> bool:
+  return (
+    isinstance(node, ast.Expr)
+    and isinstance(node.value, ast.Call)
+    and isinstance(node.value.func, ast.Attribute)
+    and node.value.func.attr == "commit"
+    and isinstance(node.value.func.value, ast.Name)
+    and node.value.func.value.id == "session"
+  )
+
+
+def _orm_bound_names(func: ast.AST) -> set[str]:
+  """Locals bound to a session-tracked ORM instance.
+
+  Only these expire on commit. A `Row` from `session.execute(text(...))` and a
+  plain dict do not, so flagging every attribute read after a commit would bury
+  the real defect in false positives — `period_row.cnt` is safe and appears
+  right next to `structure.name`, which is not.
+  """
+  loaders = {"get", "first", "one", "one_or_none", "scalar_one", "scalar_one_or_none"}
+  names: set[str] = set()
+
+  for node in ast.walk(func):
+    if not isinstance(node, ast.Assign) or not node.targets:
+      continue
+    target = node.targets[0]
+    if not isinstance(target, ast.Name):
+      continue
+
+    value = node.value
+    # `Structure(...)` — a model constructor, by naming convention.
+    if (
+      isinstance(value, ast.Call)
+      and isinstance(value.func, ast.Name)
+      and value.func.id[:1].isupper()
+    ) or (
+      isinstance(value, ast.Call)
+      and isinstance(value.func, ast.Attribute)
+      and value.func.attr in loaders
+    ):
+      names.add(target.id)
+
+  return names
+
+
+def _orm_attribute_loads(node: ast.AST, orm_names: set[str]) -> list[str]:
+  """`x.y` reads in `node` where `x` is a session-tracked ORM instance."""
+  found = []
+  for child in ast.walk(node):
+    if not isinstance(child, ast.Attribute) or not isinstance(child.ctx, ast.Load):
+      continue
+    if not isinstance(child.value, ast.Name):
+      continue
+    if child.value.id not in orm_names or child.attr.startswith("__"):
+      continue
+    found.append(f"{child.value.id}.{child.attr}")
+  return found
+
+
+def _violations(path: Path) -> list[tuple[str, int, str]]:
+  """ORM attribute loads that appear after a `session.commit()` in the same block."""
+  tree = ast.parse(path.read_text())
+  out = []
+
+  for func in ast.walk(tree):
+    if not isinstance(func, ast.FunctionDef | ast.AsyncFunctionDef):
+      continue
+
+    orm_names = _orm_bound_names(func)
+    if not orm_names:
+      continue
+
+    for node in ast.walk(func):
+      for field in ("body", "orelse", "finalbody"):
+        block = getattr(node, field, None)
+        if not isinstance(block, list):
+          continue
+
+        committed = False
+        for stmt in block:
+          if _is_session_commit(stmt):
+            committed = True
+            continue
+          if not committed:
+            continue
+          for name in _orm_attribute_loads(stmt, orm_names):
+            out.append((str(path), getattr(stmt, "lineno", 0), name))
+
+  return out
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("relative_path", GUARDED)
+def test_no_orm_attribute_read_after_commit(relative_path: str) -> None:
+  path = REPO_ROOT / relative_path
+  assert path.exists(), f"guarded module moved: {relative_path}"
+
+  violations = _violations(path)
+
+  assert not violations, (
+    "ORM attribute read after session.commit() in "
+    + f"{relative_path}:\n"
+    + "\n".join(f"  line {line}: {name}" for _, line, name in violations)
+    + "\n\nThe commit expires the instance, so this issues a refresh SELECT on a "
+    "pooled connection whose search_path may be `public` — the row resolves to "
+    "the wrong schema and a committed write returns a 500. Read the value off "
+    "the flush, before the commit:\n"
+    "    session.flush()\n"
+    "    structure_id = structure.id\n"
+    "    session.commit()\n"
+    "    return structure_id"
+  )


### PR DESCRIPTION
`session.commit()` expires every instance — the extensions sessionmaker does not set `expire_on_commit=False` — so reading an attribute afterward issues a refresh `SELECT`. The commit has already returned the connection to the pool, so that `SELECT` runs on whichever connection comes back out, and `extensions_session` resets `search_path` to `public` in its `finally`. A refresh landing on a reset connection resolves `structures` to the public schema, finds nothing, and raises `ObjectDeletedError`.

The write has committed at that point. The caller gets a 500 for work that succeeded — the same disease as reporting a committed event-block write as a 500, in a different path.

It is intermittent by construction, since it depends on which pooled connection serves the refresh. It surfaced when a 22,288-line demo run happened to hit it building a rollforward block — **and the demo still reported success.**

## The seven reads

All now taken off the flush instead of after the commit.

| File | Function |
|---|---|
| `information_block/rollforward.py` | `create`, `update` |
| `information_block/forecast.py` | `create`, `update` |
| `roboledger/commands/schedules.py` | `create_schedule`, `rebuild_schedule`, and one more response build |

`rebuild_schedule` is the worst of them: the expired `structure.id` is the bound parameter for two recounts, not just a response field, so a refresh onto the wrong schema would have **miscounted** rather than merely failed. It is also the keystone MCP operation.

## The guard is structural, deliberately

A timing-dependent bug that needs a specific pooled connection cannot be reproduced reliably enough for an integration test to be the guard. The test parses each module and fails on an ORM attribute read appearing after a commit in the same block.

It resolves which locals are session-tracked first. A `Row` from `session.execute(text(...))` does not expire, and `period_row.cnt` sits on the line directly above `structure.name` — flagging every attribute read would have buried the real defect in false positives. Confirmed to fail against a reintroduced read.

**`rebuild_schedule` was found by the guard, not by the grep that preceded it** — the manual sweep found six sites and there were seven.

## Verified on a live stack

Rebuilt, re-ran `just demo-roboinvestor` (31/31), and confirmed zero `ObjectDeletedError` and zero unhandled exceptions across the run.