### PR TITLE
fix(monitoring): give the SNS delivery alarm an explicit period

### DIFF
--- a/cloudformation/security.yaml
+++ b/cloudformation/security.yaml
@@ -805,6 +805,12 @@ Resources:
         - Id: failed
           Label: NumberOfNotificationsFailed across all topics
           ReturnData: true
+          # Period is schema-optional but the service rejects the alarm without
+          # it here: an alarm normally inherits its period from a MetricStat,
+          # and a SEARCH-only expression has none to inherit from. Omitting it
+          # fails the stack with "Period must not be null". Keep it equal to the
+          # SEARCH period below.
+          Period: 300
           Expression: >-
             SUM(SEARCH('{AWS/SNS,TopicName} MetricName="NumberOfNotificationsFailed"',
             'Sum', 300))


### PR DESCRIPTION
## Summary

The v1.8.0 staging deploy failed at `deploy-vpc / security`: the SNS delivery-failure alarm added in `1c0a2b47` was rejected by CloudWatch on its first deploy, rolling back the security stack and stopping the run before anything downstream deployed. This gives the alarm the explicit `Period` the service requires, so the stack can apply.

## Changes

- **`cloudformation/security.yaml`** — set `Period: 300` on the `SnsDeliveryFailureAlarm` metric query, matching the period already used inside its `SEARCH` call.

An alarm normally inherits its period from the `MetricStat` it watches. This one watches a `SEARCH` expression and nothing else, so there is no `MetricStat` to inherit from and the field is never populated, producing:

```
SnsDeliveryFailureAlarm  CREATE_FAILED
Period must not be null (Service: CloudWatch, Status Code: 400)
```

`MetricDataQuery.Period` is marked optional in the CloudFormation schema and `cfn-lint` passes either way, so nothing catches this ahead of the deploy — hence the inline comment recording why it is not optional here.

Worth noting for reviewers:

- The two `ApiTarget5xxAlarmProd` / `ApiTarget5xxAlarmStaging` entries that also show `CREATE_FAILED` in that run are collateral — `Resource creation cancelled` from the rollback, not defects. Their ALB/target-group dimensions resolve live from the ELB API in `deploy-vpc.yml` and both resolved non-empty, so they create on retry.
- The expression alarms in `cloudformation/graph-volumes.yaml` are unaffected: each pairs its expression with a `MetricStat` carrying `Period: 300`, so they have a period to inherit. That difference is what made the omission look safe.
- `RoboSystemsSecurity` is left in `UPDATE_ROLLBACK_COMPLETE`, which is retriable directly — no `continue-update-rollback` needed.
- The same account-global security stack is deployed by the production pipeline (`prod.yml`), so this blocked that leg too.
- This alarm has still never existed in the account. Its own comment block notes it cannot report its own brokenness and that a staging exercise is the only validation it will get — that exercise is outstanding until this deploys.

## Breaking Changes

None. CloudFormation template only — no API surface, GraphQL schema, or operations envelope changes, and no client SDK impact.

## Testing

`just cf-lint security` — passes. Pre-commit hooks ran clean (ruff, format).

`just test-all` not run: the change is a single CloudFormation property and touches no Python. Real verification is the deploy itself, which is the step that rejected it.
