### PR TITLE
refactor(infra): deploy api.yaml from S3 and move its alarms back into it

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -273,6 +273,37 @@ jobs:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ inputs.aws_region }}
 
+      # api.yaml is deployed from S3 rather than inline. The inline --template-body
+      # ceiling is 51,200 bytes and api.yaml had grown to ~98% of it, which is what
+      # pushed the API's own alarms out into the security stack. From S3 the limit
+      # is 1 MB, so the template can hold the resources that belong to it.
+      #
+      # Keyed by commit SHA, not a fixed path: concurrent deploys cannot overwrite
+      # each other's object, re-running an old workflow run deploys that run's
+      # template rather than whatever is at HEAD, and the object is a durable
+      # record of what each build actually deployed. (Stack rollback is unaffected
+      # either way — CloudFormation rolls back to the template stored in the
+      # stack, not to this object.)
+      #
+      # Uploaded here rather than in package-scripts.sh because deploy-api does
+      # not depend on that job — only on deploy-s3, which is what creates the
+      # bucket.
+      - name: Upload API template to S3
+        id: upload-template
+        run: |
+          # arn:aws:s3:::robosystems-deployment-<env> -> robosystems-deployment-<env>
+          BUCKET_ARN="${{ inputs.deployment_bucket_arn }}"
+          BUCKET="${BUCKET_ARN##*:}"
+          if [ -z "$BUCKET" ]; then
+            echo "ERROR: could not derive a bucket name from deployment_bucket_arn='${BUCKET_ARN}'"
+            exit 1
+          fi
+          KEY="cloudformation/${{ github.sha }}/api.yaml"
+          aws s3 cp cloudformation/api.yaml "s3://${BUCKET}/${KEY}" \
+            --region "${{ inputs.aws_region }}"
+          echo "template_url=https://${BUCKET}.s3.${{ inputs.aws_region }}.amazonaws.com/${KEY}" >> $GITHUB_OUTPUT
+          echo "Template uploaded: s3://${BUCKET}/${KEY}"
+
       - name: Deploy API CloudFormation Stack
         id: deploy-stack
         run: |
@@ -351,6 +382,7 @@ jobs:
                 ParameterKey=PrometheusStackName,ParameterValue=\"${{ inputs.prometheus_stack_name }}\" \
                 ParameterKey=EmailFromAddress,ParameterValue=\"${{ inputs.aws_sns_alert_email }}\" \
                 ParameterKey=SNSAlertEmail,ParameterValue=\"${{ inputs.aws_sns_alert_email }}\" \
+                ParameterKey=ApiTargetErrorThreshold,ParameterValue=${{ vars.API_TARGET_ERROR_THRESHOLD || '5' }} \
                 ParameterKey=SharedProcessedBucketArn,ParameterValue=\"${{ inputs.shared_processed_bucket_arn }}\" \
                 ParameterKey=DeploymentBucketArn,ParameterValue=\"${{ inputs.deployment_bucket_arn }}\" \
                 ParameterKey=UserDataBucketArn,ParameterValue=\"${{ inputs.user_data_bucket_arn }}\" \
@@ -366,7 +398,7 @@ jobs:
             # Create new stack
             aws cloudformation $STACK_ACTION \
               --stack-name ${{ inputs.stack_name }} \
-              --template-body file://cloudformation/api.yaml \
+              --template-url ${{ steps.upload-template.outputs.template_url }} \
               --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM \
               --parameters $API_STACK_PARAMS \
               --tags \
@@ -379,7 +411,7 @@ jobs:
             # Update existing stack, handling "No updates" error
             UPDATE_OUTPUT=$(aws cloudformation $STACK_ACTION \
               --stack-name ${{ inputs.stack_name }} \
-              --template-body file://cloudformation/api.yaml \
+              --template-url ${{ steps.upload-template.outputs.template_url }} \
               --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM \
               --parameters $API_STACK_PARAMS \
               --tags \

--- a/.github/workflows/deploy-vpc.yml
+++ b/.github/workflows/deploy-vpc.yml
@@ -415,40 +415,11 @@ jobs:
             SECURITY_ENV="${{ inputs.environment }}"
           fi
 
-          # Resolve API ALB/TG dimensions live from ELB APIs for the ALB alarms.
-          # Deliberately not CFN exports: a cross-stack import deadlocks the
-          # pipeline (security failure skips deploy-api, which would publish
-          # the exports). Missing ALBs resolve to "" and the alarms are skipped.
-          resolve_alb_dims() {
-            local ALB_ARN TG_ARN
-            ALB_ARN=$(aws elbv2 describe-load-balancers --names "$1" \
-              --query 'LoadBalancers[0].LoadBalancerArn' --output text 2>/dev/null) || true
-            if [ -z "$ALB_ARN" ] || [ "$ALB_ARN" = "None" ]; then
-              echo ""
-              return 0
-            fi
-            TG_ARN=$(aws elbv2 describe-target-groups --load-balancer-arn "$ALB_ARN" \
-              --query 'TargetGroups[0].TargetGroupArn' --output text 2>/dev/null) || true
-            if [ -z "$TG_ARN" ] || [ "$TG_ARN" = "None" ]; then
-              echo ""
-              return 0
-            fi
-            # LoadBalancerFullName = ARN resource part minus "loadbalancer/";
-            # TargetGroupFullName = ARN resource part as-is
-            echo "$(echo "$ALB_ARN" | cut -d: -f6 | sed 's|^loadbalancer/||') $(echo "$TG_ARN" | cut -d: -f6)"
-          }
-
-          read -r ALB_PROD TG_PROD <<< "$(resolve_alb_dims robosystems-api-prod-alb)" || true
-          read -r ALB_STAGING TG_STAGING <<< "$(resolve_alb_dims robosystems-api-staging-alb)" || true
-          echo "API ALB dims: prod='${ALB_PROD:-}' staging='${ALB_STAGING:-}'"
-
+          # The API ALB alarms this job used to parameterize now live in api.yaml
+          # and reference the ALB and target group as CloudFormation resources,
+          # so there is nothing to resolve here any more.
           SECURITY_PARAMS="ParameterKey=Environment,ParameterValue=$SECURITY_ENV \
-                      ParameterKey=EnableConfig,ParameterValue=${{ inputs.security_config_enabled }} \
-                      ParameterKey=ApiAlbFullNameProd,ParameterValue=${ALB_PROD:-} \
-                      ParameterKey=ApiTgFullNameProd,ParameterValue=${TG_PROD:-} \
-                      ParameterKey=ApiAlbFullNameStaging,ParameterValue=${ALB_STAGING:-} \
-                      ParameterKey=ApiTgFullNameStaging,ParameterValue=${TG_STAGING:-} \
-                      ParameterKey=ApiTargetErrorThreshold,ParameterValue=${{ vars.API_TARGET_ERROR_THRESHOLD || '5' }}"
+                      ParameterKey=EnableConfig,ParameterValue=${{ inputs.security_config_enabled }}"
 
           echo "AWS Config recorder enabled: ${{ inputs.security_config_enabled }}"
 

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -246,7 +246,7 @@ jobs:
 
       - name: Package and upload scripts
         run: |
-          echo "📦 Packaging UserData scripts and CloudFormation templates..."
+          echo "📦 Packaging UserData scripts..."
           ./bin/tools/package-scripts.sh ${{ vars.ENVIRONMENT_PROD || 'prod' }}
           echo "✅ Scripts packaged and uploaded successfully"
 

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -263,7 +263,7 @@ jobs:
 
       - name: Package and upload scripts
         run: |
-          echo "📦 Packaging UserData scripts and CloudFormation templates..."
+          echo "📦 Packaging UserData scripts..."
           ./bin/tools/package-scripts.sh ${{ vars.ENVIRONMENT_STAGING || 'staging' }}
           echo "✅ Scripts packaged and uploaded successfully"
 

--- a/bin/tools/package-scripts.sh
+++ b/bin/tools/package-scripts.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 # Package and upload UserData scripts to S3 for deployment
 # Note: Lambda functions are now deployed via container images (see Dockerfile.lambda and build.yml)
-# Note: CloudFormation templates are deployed inline (all under 40KB limit)
+# Note: CloudFormation templates are not uploaded here. Most deploy inline via
+#       --template-body (51,200-byte limit). api.yaml exceeds that and is
+#       uploaded to this same bucket by the deploy-api job itself, keyed by
+#       commit SHA — deploy-api depends on deploy-s3 but not on this job.
 
 set -e
 

--- a/cloudformation/api.yaml
+++ b/cloudformation/api.yaml
@@ -143,6 +143,21 @@ Parameters:
     Type: String
     Default: ""
 
+  # Sustained 5xx from the application over a 5-minute window. Deliberately a
+  # parameter, not a literal: there is no traffic baseline to tune against yet,
+  # so this will move — and a threshold that needs a code change to adjust ends
+  # up never adjusted. Sourced from the API_TARGET_ERROR_THRESHOLD GitHub
+  # variable so it can be retuned without a PR.
+  #
+  # Comparison is GreaterThanThreshold, matching the sibling ALB alarms, so the
+  # alarm fires *above* this count — 5 means the sixth 5xx in five minutes. Worth
+  # knowing where the floor sits: at current traffic, five 5xx in five minutes is
+  # already a lot of broken. Lower it rather than reaching for the operator.
+  ApiTargetErrorThreshold:
+    Type: Number
+    Default: 5
+    MinValue: 0
+
   # Frontend URLs (for transactional email links, billing redirects, CORS)
   RoboSystemsAppUrl:
     Type: String
@@ -1207,6 +1222,121 @@ Resources:
       AlarmActions:
         !If [HasAlertEmail, [!Ref SecurityAlertTopic], !Ref "AWS::NoValue"]
 
+  # Authenticated counterpart of AuthFailureSpikeAlarm above: a valid credential
+  # accumulating 403s fast, i.e. cross-tenant probing with a leaked or
+  # over-curious key. Baseline is ~zero, so a modest threshold stays quiet in
+  # normal use.
+  AuthorizationDeniedAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub robosystems-${Environment}-api-authorization-denied-spike
+      AlarmDescription: Spike in authorization denials (possible cross-tenant probing with a valid credential)
+      MetricName: AuthorizationDenied
+      Namespace: !Sub "RoboSystems/Security/${Environment}"
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 20
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      AlarmActions:
+        !If [HasAlertEmail, [!Ref SecurityAlertTopic], !Ref "AWS::NoValue"]
+
+  # ── API ALB health alarms ──────────────────────────────────────────────────
+  # These read the ALB and target group as CloudFormation resources, so the
+  # dimensions are always correct and always present. They previously lived in
+  # security.yaml, where api.yaml's inline-template ceiling had forced them, and
+  # had to reach the ALB by name through a live ELB lookup in the deploy job —
+  # a path that could not tell "the ALB does not exist yet" from "the describe
+  # call failed", and silently deleted the alarms in both cases.
+  ApiAlbUnhealthyHostsAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub robosystems-${Environment}-api-alb-unhealthy-hosts
+      AlarmDescription: API ALB target reporting unhealthy
+      MetricName: UnHealthyHostCount
+      Namespace: AWS/ApplicationELB
+      Statistic: Maximum
+      Period: 60
+      EvaluationPeriods: 5
+      Threshold: 0
+      ComparisonOperator: GreaterThanThreshold
+      Dimensions:
+        - Name: LoadBalancer
+          Value: !GetAtt ApiALB.LoadBalancerFullName
+        - Name: TargetGroup
+          Value: !GetAtt ApiTargetGroup.TargetGroupFullName
+      TreatMissingData: notBreaching
+      AlarmActions:
+        !If [HasAlertEmail, [!Ref SecurityAlertTopic], !Ref "AWS::NoValue"]
+
+  ApiAlbHighLatencyAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub robosystems-${Environment}-api-alb-high-latency
+      AlarmDescription: API ALB target response time is high
+      MetricName: TargetResponseTime
+      Namespace: AWS/ApplicationELB
+      Statistic: Average
+      Period: 60
+      EvaluationPeriods: 5
+      Threshold: 2
+      ComparisonOperator: GreaterThanThreshold
+      Dimensions:
+        - Name: LoadBalancer
+          Value: !GetAtt ApiALB.LoadBalancerFullName
+      TreatMissingData: notBreaching
+      AlarmActions:
+        !If [HasAlertEmail, [!Ref SecurityAlertTopic], !Ref "AWS::NoValue"]
+
+  ApiAlb5xxAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub robosystems-${Environment}-api-alb-5xx-spike
+      AlarmDescription: Elevated 5xx responses from the API ALB
+      MetricName: HTTPCode_ELB_5XX_Count
+      Namespace: AWS/ApplicationELB
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 25
+      ComparisonOperator: GreaterThanThreshold
+      Dimensions:
+        - Name: LoadBalancer
+          Value: !GetAtt ApiALB.LoadBalancerFullName
+      TreatMissingData: notBreaching
+      AlarmActions:
+        !If [HasAlertEmail, [!Ref SecurityAlertTopic], !Ref "AWS::NoValue"]
+
+  # The 5xx alarm above watches HTTPCode_ELB_5XX_Count — errors the *load
+  # balancer* generates. A healthy process returning 500 on every business
+  # endpoint produces none of those: its targets stay healthy, the liveness
+  # probe keeps passing, and the outage is invisible end to end. Target_5XX is
+  # the application's own errors, and is the one an outage actually rides
+  # through.
+  ApiTarget5xxAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub robosystems-${Environment}-api-target-5xx
+      AlarmDescription: The API is returning 5xx responses to clients
+      MetricName: HTTPCode_Target_5XX_Count
+      Namespace: AWS/ApplicationELB
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: !Ref ApiTargetErrorThreshold
+      ComparisonOperator: GreaterThanThreshold
+      Dimensions:
+        - Name: LoadBalancer
+          Value: !GetAtt ApiALB.LoadBalancerFullName
+        - Name: TargetGroup
+          Value: !GetAtt ApiTargetGroup.TargetGroupFullName
+      # No traffic is the normal state at this scale, and no traffic cannot be
+      # an outage — a request has to reach the app for it to 5xx.
+      TreatMissingData: notBreaching
+      AlarmActions:
+        !If [HasAlertEmail, [!Ref SecurityAlertTopic], !Ref "AWS::NoValue"]
+
   # ===========================================
   # API Key Rotation Lambda
   # ===========================================
@@ -1335,6 +1465,30 @@ Resources:
       RotationRules:
         AutomaticallyAfterDays: 1000
       RotateImmediatelyOnUpdate: false
+
+  # Gated on HasLambdaImage alongside the function it watches. The previous copy
+  # in security.yaml was unconditional and named the function with a literal
+  # stack-name prefix, so on a deployment without a Lambda image it alarmed on a
+  # function that did not exist — no metrics, no data, permanently OK.
+  AdminKeyRotationErrorsAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: HasLambdaImage
+    Properties:
+      AlarmName: !Sub robosystems-${Environment}-admin-key-rotation-errors
+      AlarmDescription: Admin key rotation Lambda reported errors
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref ApiKeyRotationLambda
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 0
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      AlarmActions:
+        !If [HasAlertEmail, [!Ref SecurityAlertTopic], !Ref "AWS::NoValue"]
 
   # ========================================
   # SERVICE DISCOVERY (Internal DNS)

--- a/cloudformation/security.yaml
+++ b/cloudformation/security.yaml
@@ -38,38 +38,6 @@ Parameters:
     AllowedValues: ["true", "false"]
     Description: Enable Amazon GuardDuty threat detection
 
-  # API ALB alarm dimensions, resolved live from ELB APIs by the deploy job
-  # (never CFN imports: a cross-stack import would deadlock the pipeline —
-  # security failing skips deploy-api, which is what publishes the exports).
-  # Empty values skip the ALB alarms via conditions.
-  ApiAlbFullNameProd:
-    Type: String
-    Default: ""
-  ApiTgFullNameProd:
-    Type: String
-    Default: ""
-  ApiAlbFullNameStaging:
-    Type: String
-    Default: ""
-  ApiTgFullNameStaging:
-    Type: String
-    Default: ""
-
-  # Sustained 5xx from the application over a 5-minute window. Deliberately a
-  # parameter, not a literal: there is no traffic baseline to tune against yet,
-  # so this will move — and a threshold that needs a code change to adjust ends
-  # up never adjusted. Sourced from the API_TARGET_ERROR_THRESHOLD GitHub
-  # variable so it can be retuned without a PR.
-  #
-  # Comparison is GreaterThanThreshold, matching the sibling ALB alarms, so the
-  # alarm fires *above* this count — 5 means the sixth 5xx in five minutes. Worth
-  # knowing where the floor sits: at current traffic, five 5xx in five minutes is
-  # already a lot of broken. Lower it rather than reaching for the operator.
-  ApiTargetErrorThreshold:
-    Type: Number
-    Default: 5
-    MinValue: 0
-
   EnableSecurityHub:
     Type: String
     Default: "true"
@@ -127,12 +95,6 @@ Conditions:
     - !Equals [!Ref EnableCISStandard, "true"]
   AccessAnalyzerOn: !Equals [!Ref EnableAccessAnalyzer, "true"]
   ConfigOn: !Equals [!Ref EnableConfig, "true"]
-  HasApiAlbProd: !And
-    - !Not [!Equals [!Ref ApiAlbFullNameProd, ""]]
-    - !Not [!Equals [!Ref ApiTgFullNameProd, ""]]
-  HasApiAlbStaging: !And
-    - !Not [!Equals [!Ref ApiAlbFullNameStaging, ""]]
-    - !Not [!Equals [!Ref ApiTgFullNameStaging, ""]]
 
 Resources:
   # --- GuardDuty: continuous threat detection over CloudTrail/VPC/DNS telemetry.
@@ -337,10 +299,15 @@ Resources:
   # per-env security-alerts SNS topics (owned by api.yaml as
   # robosystems-<env>-security-alerts, email-subscribed). Account-global
   # signals (GuardDuty findings, root-credential use) notify the prod topic —
-  # ${Environment} normalizes to prod in the deploy job. The per-env
-  # AuthorizationDenied alarms also live here rather than beside their four
-  # siblings in api.yaml because that template sits at the 51,200-byte
-  # inline-template ceiling and cannot grow.
+  # ${Environment} normalizes to prod in the deploy job.
+  #
+  # What belongs in this stack is the account-global detective baseline only.
+  # Alarms on API-stack resources (ALB health, the security metric namespace,
+  # the rotation Lambda) used to live here because api.yaml had run out of
+  # inline-template room; api.yaml now deploys from S3, so they sit beside the
+  # resources they watch and reference them directly. Resist adding per-env
+  # application alarms back here — the size pressure that justified it is gone.
+  #
   # Precondition: the topic must already exist (api stack deployed with
   # SNSAlertEmail set), or the topic-policy attachment fails this stack.
   SecurityAlertsTopicPolicy:
@@ -539,224 +506,6 @@ Resources:
               from <sourceIP> at <eventTime>. If this was not a deliberate
               deploy or teardown, investigate immediately."
 
-  # Authenticated counterpart of api.yaml's AuthFailureSpikeAlarm: a valid
-  # credential accumulating 403s fast, i.e. cross-tenant probing with a leaked
-  # or over-curious key. Baseline is ~zero, so a modest threshold stays quiet
-  # in normal use. One alarm per environment (see section comment for why they
-  # are here).
-  AuthorizationDeniedAlarmProd:
-    Type: AWS::CloudWatch::Alarm
-    Properties:
-      AlarmName: robosystems-prod-api-authorization-denied-spike
-      AlarmDescription: Spike in authorization denials (possible cross-tenant probing with a valid credential)
-      MetricName: AuthorizationDenied
-      Namespace: RoboSystems/Security/prod
-      Statistic: Sum
-      Period: 300
-      EvaluationPeriods: 1
-      Threshold: 20
-      ComparisonOperator: GreaterThanThreshold
-      TreatMissingData: notBreaching
-      AlarmActions:
-        - !Sub arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:robosystems-prod-security-alerts
-
-  AuthorizationDeniedAlarmStaging:
-    Type: AWS::CloudWatch::Alarm
-    Properties:
-      AlarmName: robosystems-staging-api-authorization-denied-spike
-      AlarmDescription: Spike in authorization denials (possible cross-tenant probing with a valid credential)
-      MetricName: AuthorizationDenied
-      Namespace: RoboSystems/Security/staging
-      Statistic: Sum
-      Period: 300
-      EvaluationPeriods: 1
-      Threshold: 20
-      ComparisonOperator: GreaterThanThreshold
-      TreatMissingData: notBreaching
-      AlarmActions:
-        - !Sub arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:robosystems-staging-security-alerts
-
-  # ── API ALB + operational Lambda alarms ────────────────────────────────────
-  # Placed here (not api.yaml) because api.yaml sits at the 51,200-byte inline
-  # ceiling. ALB dimensions come from exports the API stacks publish, so BOTH
-  # API stacks must be deployed (creating the exports) before the first
-  # security-stack update that includes these alarms.
-  ApiAlbUnhealthyHostsAlarmProd:
-    Type: AWS::CloudWatch::Alarm
-    Condition: HasApiAlbProd
-    Properties:
-      AlarmName: robosystems-prod-api-alb-unhealthy-hosts
-      AlarmDescription: API ALB target reporting unhealthy
-      MetricName: UnHealthyHostCount
-      Namespace: AWS/ApplicationELB
-      Statistic: Maximum
-      Period: 60
-      EvaluationPeriods: 5
-      Threshold: 0
-      ComparisonOperator: GreaterThanThreshold
-      Dimensions:
-        - Name: LoadBalancer
-          Value: !Ref ApiAlbFullNameProd
-        - Name: TargetGroup
-          Value: !Ref ApiTgFullNameProd
-      TreatMissingData: notBreaching
-      AlarmActions:
-        - !Sub arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:robosystems-prod-security-alerts
-
-  ApiAlbHighLatencyAlarmProd:
-    Type: AWS::CloudWatch::Alarm
-    Condition: HasApiAlbProd
-    Properties:
-      AlarmName: robosystems-prod-api-alb-high-latency
-      AlarmDescription: API ALB target response time is high
-      MetricName: TargetResponseTime
-      Namespace: AWS/ApplicationELB
-      Statistic: Average
-      Period: 60
-      EvaluationPeriods: 5
-      Threshold: 2
-      ComparisonOperator: GreaterThanThreshold
-      Dimensions:
-        - Name: LoadBalancer
-          Value: !Ref ApiAlbFullNameProd
-      TreatMissingData: notBreaching
-      AlarmActions:
-        - !Sub arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:robosystems-prod-security-alerts
-
-  ApiAlb5xxAlarmProd:
-    Type: AWS::CloudWatch::Alarm
-    Condition: HasApiAlbProd
-    Properties:
-      AlarmName: robosystems-prod-api-alb-5xx-spike
-      AlarmDescription: Elevated 5xx responses from the API ALB
-      MetricName: HTTPCode_ELB_5XX_Count
-      Namespace: AWS/ApplicationELB
-      Statistic: Sum
-      Period: 300
-      EvaluationPeriods: 1
-      Threshold: 25
-      ComparisonOperator: GreaterThanThreshold
-      Dimensions:
-        - Name: LoadBalancer
-          Value: !Ref ApiAlbFullNameProd
-      TreatMissingData: notBreaching
-      AlarmActions:
-        - !Sub arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:robosystems-prod-security-alerts
-
-  # The 5xx alarm above watches HTTPCode_ELB_5XX_Count — errors the *load
-  # balancer* generates. A healthy process returning 500 on every business
-  # endpoint produces none of those: its targets stay healthy, the liveness
-  # probe keeps passing, and the outage is invisible end to end. Target_5XX is
-  # the application's own errors, and is the one an outage actually rides
-  # through.
-  ApiTarget5xxAlarmProd:
-    Type: AWS::CloudWatch::Alarm
-    Condition: HasApiAlbProd
-    Properties:
-      AlarmName: robosystems-prod-api-target-5xx
-      AlarmDescription: The API is returning 5xx responses to clients
-      MetricName: HTTPCode_Target_5XX_Count
-      Namespace: AWS/ApplicationELB
-      Statistic: Sum
-      Period: 300
-      EvaluationPeriods: 1
-      Threshold: !Ref ApiTargetErrorThreshold
-      ComparisonOperator: GreaterThanThreshold
-      Dimensions:
-        - Name: LoadBalancer
-          Value: !Ref ApiAlbFullNameProd
-        - Name: TargetGroup
-          Value: !Ref ApiTgFullNameProd
-      # No traffic is the normal state at this scale, and no traffic cannot be
-      # an outage — a request has to reach the app for it to 5xx.
-      TreatMissingData: notBreaching
-      AlarmActions:
-        - !Sub arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:robosystems-prod-security-alerts
-
-  ApiAlbUnhealthyHostsAlarmStaging:
-    Type: AWS::CloudWatch::Alarm
-    Condition: HasApiAlbStaging
-    Properties:
-      AlarmName: robosystems-staging-api-alb-unhealthy-hosts
-      AlarmDescription: API ALB target reporting unhealthy
-      MetricName: UnHealthyHostCount
-      Namespace: AWS/ApplicationELB
-      Statistic: Maximum
-      Period: 60
-      EvaluationPeriods: 5
-      Threshold: 0
-      ComparisonOperator: GreaterThanThreshold
-      Dimensions:
-        - Name: LoadBalancer
-          Value: !Ref ApiAlbFullNameStaging
-        - Name: TargetGroup
-          Value: !Ref ApiTgFullNameStaging
-      TreatMissingData: notBreaching
-      AlarmActions:
-        - !Sub arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:robosystems-staging-security-alerts
-
-  ApiAlbHighLatencyAlarmStaging:
-    Type: AWS::CloudWatch::Alarm
-    Condition: HasApiAlbStaging
-    Properties:
-      AlarmName: robosystems-staging-api-alb-high-latency
-      AlarmDescription: API ALB target response time is high
-      MetricName: TargetResponseTime
-      Namespace: AWS/ApplicationELB
-      Statistic: Average
-      Period: 60
-      EvaluationPeriods: 5
-      Threshold: 2
-      ComparisonOperator: GreaterThanThreshold
-      Dimensions:
-        - Name: LoadBalancer
-          Value: !Ref ApiAlbFullNameStaging
-      TreatMissingData: notBreaching
-      AlarmActions:
-        - !Sub arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:robosystems-staging-security-alerts
-
-  ApiAlb5xxAlarmStaging:
-    Type: AWS::CloudWatch::Alarm
-    Condition: HasApiAlbStaging
-    Properties:
-      AlarmName: robosystems-staging-api-alb-5xx-spike
-      AlarmDescription: Elevated 5xx responses from the API ALB
-      MetricName: HTTPCode_ELB_5XX_Count
-      Namespace: AWS/ApplicationELB
-      Statistic: Sum
-      Period: 300
-      EvaluationPeriods: 1
-      Threshold: 25
-      ComparisonOperator: GreaterThanThreshold
-      Dimensions:
-        - Name: LoadBalancer
-          Value: !Ref ApiAlbFullNameStaging
-      TreatMissingData: notBreaching
-      AlarmActions:
-        - !Sub arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:robosystems-staging-security-alerts
-
-  ApiTarget5xxAlarmStaging:
-    Type: AWS::CloudWatch::Alarm
-    Condition: HasApiAlbStaging
-    Properties:
-      AlarmName: robosystems-staging-api-target-5xx
-      AlarmDescription: The API is returning 5xx responses to clients
-      MetricName: HTTPCode_Target_5XX_Count
-      Namespace: AWS/ApplicationELB
-      Statistic: Sum
-      Period: 300
-      EvaluationPeriods: 1
-      Threshold: !Ref ApiTargetErrorThreshold
-      ComparisonOperator: GreaterThanThreshold
-      Dimensions:
-        - Name: LoadBalancer
-          Value: !Ref ApiAlbFullNameStaging
-        - Name: TargetGroup
-          Value: !Ref ApiTgFullNameStaging
-      TreatMissingData: notBreaching
-      AlarmActions:
-        - !Sub arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:robosystems-staging-security-alerts
-
   # Delivery assurance for the alert channel itself: every alarm in this account
   # reaches a human through SNS email.
   #
@@ -816,46 +565,6 @@ Resources:
             'Sum', 300))
       AlarmActions:
         - !Sub arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:robosystems-prod-security-alerts
-
-  # Admin-key-rotation Lambdas are defined in api.yaml (same ceiling constraint);
-  # function names are deterministic stack-name prefixes.
-  AdminKeyRotationErrorsAlarmProd:
-    Type: AWS::CloudWatch::Alarm
-    Properties:
-      AlarmName: robosystems-prod-admin-key-rotation-errors
-      AlarmDescription: Admin key rotation Lambda reported errors
-      MetricName: Errors
-      Namespace: AWS/Lambda
-      Dimensions:
-        - Name: FunctionName
-          Value: RoboSystemsAPIProd-admin-key-rotation
-      Statistic: Sum
-      Period: 300
-      EvaluationPeriods: 1
-      Threshold: 0
-      ComparisonOperator: GreaterThanThreshold
-      TreatMissingData: notBreaching
-      AlarmActions:
-        - !Sub arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:robosystems-prod-security-alerts
-
-  AdminKeyRotationErrorsAlarmStaging:
-    Type: AWS::CloudWatch::Alarm
-    Properties:
-      AlarmName: robosystems-staging-admin-key-rotation-errors
-      AlarmDescription: Admin key rotation Lambda reported errors
-      MetricName: Errors
-      Namespace: AWS/Lambda
-      Dimensions:
-        - Name: FunctionName
-          Value: RoboSystemsAPIStaging-admin-key-rotation
-      Statistic: Sum
-      Period: 300
-      EvaluationPeriods: 1
-      Threshold: 0
-      ComparisonOperator: GreaterThanThreshold
-      TreatMissingData: notBreaching
-      AlarmActions:
-        - !Sub arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:robosystems-staging-security-alerts
 
   # CUR pipeline Lambdas live in the AWS-provided RoboSystemsCUR stack (not in
   # this repo), so their generated names are literals here. They are stable

--- a/justfile
+++ b/justfile
@@ -170,9 +170,18 @@ typecheck module="":
     @uv run basedpyright {{ if module != "" { "robosystems/" + module } else { "" } }}
 
 # CloudFormation linting and validation
+# validate-template only accepts a template body up to 51,200 bytes. Templates
+# that deploy from S3 (api.yaml) are allowed to exceed that, so validate is
+# skipped for them rather than failing — cfn-lint above has no size limit and
+# does the static analysis that matters here.
 cf-lint template:
     @uv run cfn-lint -t cloudformation/{{template}}.yaml
-    @uv run aws cloudformation validate-template --template-body file://cloudformation/{{template}}.yaml > /dev/null
+    @size=$(wc -c < cloudformation/{{template}}.yaml | tr -d ' '); \
+    if [ "$size" -gt 51200 ]; then \
+      echo "{{template}}.yaml is $size bytes (over the 51,200-byte --template-body limit); deploys from S3, skipping validate-template"; \
+    else \
+      uv run aws cloudformation validate-template --template-body file://cloudformation/{{template}}.yaml > /dev/null; \
+    fi
 
 # Lint all CloudFormation templates
 cf-lint-all:

--- a/tests/infrastructure/test_cloudformation.py
+++ b/tests/infrastructure/test_cloudformation.py
@@ -3,20 +3,51 @@
 Catches issues like template size limits before deployment.
 """
 
+import re
 from pathlib import Path
 
 import pytest
 
-CFN_DIR = Path(__file__).resolve().parents[2] / "cloudformation"
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CFN_DIR = REPO_ROOT / "cloudformation"
+WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
 
-# AWS CloudFormation template body size limit (bytes)
+# AWS CloudFormation template size limits (bytes)
 # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-limits.html
+#
+# Two different ceilings apply depending on how a template reaches CloudFormation:
+# passed inline in the API request (--template-body), or fetched from S3
+# (--template-url). Which one a template gets is not a property of the template —
+# it is a property of how the deploy workflow invokes it, so that is what this
+# test reads rather than a hand-maintained list that would drift.
 CFN_TEMPLATE_BODY_LIMIT = 51_200
+CFN_TEMPLATE_S3_LIMIT = 1_048_576
+
+# --template-body file://cloudformation/<name>.yaml
+_INLINE_RE = re.compile(r"--template-body\s+file://cloudformation/([\w.-]+)\.yaml")
+# The S3 path cannot be read off the --template-url flag: the URL is a step
+# output built at deploy time, so the flag carries no template name. The upload
+# is the identifying signal — `aws s3 cp cloudformation/<name>.yaml` — and it
+# only counts as an S3 deploy if that same workflow also passes --template-url.
+_UPLOAD_RE = re.compile(r"s3\s+cp\s+cloudformation/([\w.-]+)\.yaml")
+_URL_FLAG = "--template-url"
+
+
+def _templates_by_deploy_mechanism() -> tuple[set[str], set[str]]:
+  """Return (inline, s3) template stems as the deploy workflows actually invoke them."""
+  inline: set[str] = set()
+  s3: set[str] = set()
+  for workflow in WORKFLOW_DIR.glob("*.yml"):
+    text = workflow.read_text()
+    inline.update(_INLINE_RE.findall(text))
+    if _URL_FLAG in text:
+      s3.update(_UPLOAD_RE.findall(text))
+  return inline, s3
 
 
 @pytest.mark.unit
 class TestCloudFormationTemplateSizes:
-  """Ensure all CloudFormation templates stay under the inline body size limit."""
+  """Ensure each CloudFormation template fits the limit its deploy path imposes."""
 
   @pytest.fixture
   def templates(self):
@@ -26,17 +57,51 @@ class TestCloudFormationTemplateSizes:
     """Sanity check that we found templates to validate."""
     assert len(templates) > 0, f"No .yaml templates found in {CFN_DIR}"
 
+  def test_deploy_mechanisms_are_discoverable(self):
+    """The regexes must actually match the workflows, or every check below passes vacuously."""
+    inline, s3 = _templates_by_deploy_mechanism()
+    assert inline, (
+      "No --template-body invocations found in .github/workflows. Either the "
+      "deploy workflows changed shape or the parsing here is stale — this test "
+      "cannot enforce anything until it can see how templates are deployed."
+    )
+    assert not (inline & s3), (
+      f"Templates deployed both inline and from S3: {sorted(inline & s3)}. One "
+      f"deploy path per template, or the applicable size limit is ambiguous."
+    )
+
   @pytest.mark.parametrize(
     "template",
     sorted(CFN_DIR.glob("*.yaml")),
     ids=lambda p: p.name,
   )
   def test_template_under_size_limit(self, template):
-    """Each template must be under the 51,200 byte inline body limit."""
+    """Each template must fit the limit for the mechanism its workflow uses.
+
+    Templates no workflow deploys (or that are deployed by hand) are held to the
+    inline limit — it is the stricter of the two, and reaching for S3 should be a
+    deliberate change to a deploy workflow rather than something a template
+    drifts into.
+    """
+    inline, s3 = _templates_by_deploy_mechanism()
+    stem = template.stem
+
+    if stem in s3:
+      limit, mechanism, remedy = (
+        CFN_TEMPLATE_S3_LIMIT,
+        "--template-url (S3)",
+        "Split the stack — this template is past what S3 accepts too.",
+      )
+    else:
+      limit, mechanism, remedy = (
+        CFN_TEMPLATE_BODY_LIMIT,
+        "--template-body (inline)",
+        "Trim verbose outputs, or upload it to S3 and switch its workflow to "
+        "--template-url (see the api.yaml upload step in deploy-api.yml).",
+      )
+
     size = template.stat().st_size
-    headroom = CFN_TEMPLATE_BODY_LIMIT - size
-    assert size <= CFN_TEMPLATE_BODY_LIMIT, (
-      f"{template.name} is {size:,} bytes, exceeding the "
-      f"{CFN_TEMPLATE_BODY_LIMIT:,} byte limit by {-headroom:,} bytes. "
-      f"Trim verbose outputs or switch to --template-url with S3."
+    assert size <= limit, (
+      f"{template.name} is {size:,} bytes, exceeding the {limit:,} byte "
+      f"{mechanism} limit by {size - limit:,} bytes. {remedy}"
     )


### PR DESCRIPTION
## Summary

`api.yaml` was at 50,398 of the 51,200-byte inline `--template-body` ceiling — 98%, roughly ten lines of headroom. That ceiling, not any design judgement, is why alarms on API resources were living in the account-global security stack. This uploads the template to S3 (1 MB limit) and moves those alarms back beside the resources they watch, where they can reference them directly instead of being handed their dimensions by the deploy job.

## Changes

**Deploy `api.yaml` from S3** — `.github/workflows/deploy-api.yml`

- New upload step puts `cloudformation/api.yaml` in the existing `robosystems-deployment-${env}` bucket at `cloudformation/<sha>/api.yaml`; both `create-stack` and `update-stack` switch to `--template-url`.
- SHA-keyed so concurrent deploys can't clobber each other's object and re-running an old workflow deploys that run's template. Stack rollback is unaffected either way — CloudFormation rolls back to the template stored in the stack, not to the object.
- Bucket name is derived from the existing `deployment_bucket_arn` input rather than reconstructed, so the namespaced variant in `s3.yaml` keeps working. Uploading here rather than in `package-scripts.sh` because `deploy-api` depends on `deploy-s3` (which creates the bucket) but not on that job.
- `waf.yaml` and `audit.yaml` in the same workflow stay inline, as does every other template.

**Move the alarms home** — `cloudformation/api.yaml`, `cloudformation/security.yaml`

- Twelve alarms return as six. They were prod/staging pairs in one shared stack; `api.yaml` is per-environment, so the duplication collapses and `HasApiAlbProd`/`HasApiAlbStaging` disappear.
- ALB alarms now read `!GetAtt ApiALB.LoadBalancerFullName` and `!GetAtt ApiTargetGroup.TargetGroupFullName`. Previously `deploy-vpc` looked the ALB up by name through the ELB API and passed dimensions as parameters — a path that could not distinguish "the ALB doesn't exist yet" from "the describe call failed" and resolved both to empty, flipping the conditions false and removing the alarms on an otherwise green deploy. `resolve_alb_dims`, five parameters and two conditions are deleted.
- `AdminKeyRotationErrorsAlarm` is now `Condition: HasLambdaImage` and `!Ref`s the function instead of naming it by literal stack prefix, so it no longer watches a function that doesn't exist on a deployment without a Lambda image.
- Alarm actions follow the `api.yaml` sibling pattern (`!If [HasAlertEmail, …]`) instead of a constructed ARN to a topic the template only assumed was present.
- `ApiTargetErrorThreshold` moves to `api.yaml`, still sourced from the `API_TARGET_ERROR_THRESHOLD` variable.
- `security.yaml` keeps only the account-global detective baseline and drops 36,166 → 24,973 bytes.

**Size test** — `tests/infrastructure/test_cloudformation.py`

Reworked rather than removed. It now derives which templates deploy inline and which deploy from S3 by reading the workflow files, then applies 51,200 or 1 MB accordingly. Deleting it would have given up the guard on the eighteen templates still deployed inline; a hand-maintained exempt list would have drifted. Templates no workflow deploys (`bootstrap-oidc.yaml`) are held to the stricter limit. Two extra assertions fail loudly if the parsing ever stops matching the workflows, so the suite can't start passing vacuously.

`just cf-lint` skips `validate-template` for oversized templates — that call carries the same 51,200 limit and was already failing on `api.yaml`. `cfn-lint` has no size limit and still runs.

**Comment corrections** — three had outlived their subject: `security.yaml` still described the ALB dimensions as CFN exports (removed in `17fcfa0e`), `package-scripts.sh` claimed all templates were under 40KB, and both pipelines echoed that it packages CloudFormation templates, which it has never done.

## Breaking Changes

None to any published surface — CloudFormation templates, deploy workflows, a justfile recipe and a test. No API, GraphQL, or operations-envelope changes, and no client SDK impact in either tier.

**Deploy sequencing does need a decision, though.** The security stack is account-global but held both environments' alarms. Whichever pipeline deploys first removes all twelve, and each environment's six are recreated only when *that* environment's API stack deploys. Staging-first leaves prod's ALB, authorization-denied and rotation alarms absent until prod deploys; prod-first shrinks prod's gap to the minutes between the security and api jobs within one run, since `deploy-vpc` completes before `deploy-api`. Alarm names are unchanged, so within a run the security stack releases each name before the api stack claims it.

## Testing

- `just cf-lint-all` — clean across all 20 templates.
- `uv run pytest tests/infrastructure/` — 22 passed. Confirmed the classification is real rather than vacuous: `api` is the only S3 template, 18 inline, `bootstrap-oidc` deployed by no workflow.
- `just test-code` — ruff, format, basedpyright, cf-lint all pass.
- All four edited workflows parse as YAML.
- Verified no dangling references to the removed parameters, conditions or alarm names, and that each moved alarm name now resolves to exactly one file.

Full `just test-all` unit suite not run — no Python application code changed. The deploy itself is the real verification for the S3 template path and the alarm handoff.
