### PR TITLE
fix(monitoring): express the SNS delivery alarm as a Metrics Insights query

### DIFF
--- a/cloudformation/security.yaml
+++ b/cloudformation/security.yaml
@@ -522,18 +522,29 @@ Resources:
   #
   # **This alarm cannot report its own brokenness.** SNS publishes
   # `NumberOfNotificationsFailed` only on failure — healthy is *no data*, which
-  # `notBreaching` renders as OK. A SEARCH expression that matches nothing (typo,
-  # rejected syntax, changed schema) produces the same no-data and the same OK.
-  # `notBreaching` is still the right setting — the alternative is an alarm that
-  # lives permanently in INSUFFICIENT_DATA — but it means the staging exercise is
-  # the *only* validation this alarm will ever get. **Re-run it whenever this
-  # expression changes.**
+  # `notBreaching` renders as OK. A query that matches nothing (typo, changed
+  # schema) produces the same no-data and the same OK. `notBreaching` is still
+  # the right setting — the alternative is an alarm that lives permanently in
+  # INSUFFICIENT_DATA — but it means a real deploy is the *only* validation this
+  # alarm will ever get. **Re-validate whenever this expression changes**, with
+  # `aws cloudwatch get-metric-data` on the expression before deploying it.
   #
-  # Aggregated across every topic with SEARCH rather than one alarm per topic:
-  # sixteen alert topics across ten stacks, and SEARCH also picks up topics added
-  # later without anyone remembering.
+  # Aggregated across every topic rather than one alarm per topic: sixteen alert
+  # topics across ten stacks, and the query also picks up topics added later
+  # without anyone remembering.
   #
-  # **One alarm, not one per environment.** SEARCH matches every topic in the
+  # **This is a Metrics Insights query, and it must not be rewritten as SEARCH.**
+  # `SUM(SEARCH(...))` is the obvious way to express this and it is rejected at
+  # deploy time — `PutMetricAlarm` answers "SEARCH is not supported on Metric
+  # Alarms". SEARCH works in dashboards and GetMetricData but never in an alarm.
+  # Metrics Insights is the supported route to the same fleet-wide aggregate, and
+  # it keeps the property this alarm exists for: the query picks up new topics on
+  # its own. No GROUP BY — that would make it a multi-time-series alarm, which
+  # additionally requires ORDER BY; a bare aggregate returns the single series an
+  # alarm wants. Period is required here, exactly as it was for the metric-math
+  # form: with no MetricStat there is nothing to inherit a period from.
+  #
+  # **One alarm, not one per environment.** The query matches every topic in the
   # account and region, so prod and staging copies would watch identical data and
   # both fire on the same failure. It routes to the prod alert topic because that
   # is the destination that gets read, not because it is prod-scoped.
@@ -554,15 +565,10 @@ Resources:
         - Id: failed
           Label: NumberOfNotificationsFailed across all topics
           ReturnData: true
-          # Period is schema-optional but the service rejects the alarm without
-          # it here: an alarm normally inherits its period from a MetricStat,
-          # and a SEARCH-only expression has none to inherit from. Omitting it
-          # fails the stack with "Period must not be null". Keep it equal to the
-          # SEARCH period below.
           Period: 300
           Expression: >-
-            SUM(SEARCH('{AWS/SNS,TopicName} MetricName="NumberOfNotificationsFailed"',
-            'Sum', 300))
+            SELECT SUM(NumberOfNotificationsFailed)
+            FROM SCHEMA("AWS/SNS", TopicName)
       AlarmActions:
         - !Sub arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:robosystems-prod-security-alerts
 


### PR DESCRIPTION
## Summary

The `Period` fix in #1129 was necessary but not sufficient — it cleared one rejection and exposed a second behind it, which failed the staging deploy again at `deploy-vpc / security`:

```
SnsDeliveryFailureAlarm  CREATE_FAILED
SEARCH is not supported on Metric Alarms (Status Code: 400)
```

`SEARCH` works in dashboards and `GetMetricData`, but `PutMetricAlarm` rejects it outright, so this alarm has never once been accepted by CloudWatch and no amount of refining the metric-math form would have got it there. This expresses it as a Metrics Insights query instead, which is the supported route to the same fleet-wide aggregate.

## Changes

**`cloudformation/security.yaml`** — `SnsDeliveryFailureAlarm` expression only:

```
SELECT SUM(NumberOfNotificationsFailed) FROM SCHEMA("AWS/SNS", TopicName)
```

- Keeps the property the alarm exists for: new SNS topics join the query without anyone remembering to add them. That is the documented reason Metrics Insights alarms exist — *"the alarm automatically adjusts as resources are added to or removed from your monitored group."*
- No `GROUP BY`. That would make it a multi-time-series alarm, which additionally requires `ORDER BY`; a bare aggregate returns the single time series an alarm wants.
- `Period: 300` stays, for the same reason it was added in #1129 — with no `MetricStat` there is nothing to inherit a period from.
- The comment now records that `SEARCH` is rejected here, so the obvious rewrite isn't attempted a third time, and points at `get-metric-data` as the pre-deploy check.

No other resource in the stack is touched.

## Breaking Changes

None. Single CloudFormation resource; no API, GraphQL or operations-envelope surface, and no client SDK impact.

## Testing

Neither of this alarm's two rejections is visible to `cfn-lint` or the test suite — only the service can reject them, which is why both previous attempts were found by a deploy. So it was validated against CloudWatch directly this time:

- Parsed the template, extracted the literal string the YAML renders, and ran **that exact string** through `aws cloudwatch get-metric-data` → `StatusCode: Complete`, no messages.
- Created a throwaway alarm with the same `Metrics` block via `put-metric-alarm` (no alarm actions) → **accepted**; `describe-alarms` showed the expression stored verbatim; deleted immediately and confirmed gone. This is the part `get-metric-data` cannot prove, and it is what was missing both previous times.
- `just cf-lint security` clean; `pytest tests/infrastructure/` 22 passed.

## Deploy notes

The failed update rolled back roughly 8 seconds in, during the create phase and before CloudFormation reached any deletes, so the twelve alarms being relocated by #1130 are all still present and **prod is not degraded**. `RoboSystemsSecurity` is back at `UPDATE_ROLLBACK_COMPLETE`, which is updatable — no `continue-update-rollback` or stack delete needed.

`deploy-api` never ran in either attempt, so the S3 `--template-url` path from #1130 and the alarm relocation are both still unexercised. The next staging run is their first real test as well as this one's.
