### PR TITLE
chore(ci): pin fork PRs to GitHub-hosted runners, document fork flow

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -87,14 +87,20 @@ Issues labeled `good first issue` or `help wanted` are good starting points.
 
 ## Branching
 
-Create branches with the project tooling, which branches from `origin/<base>` and sets the upstream correctly:
+**Contributing from a fork.** External contributors work from a fork and open a pull request against this repository. You do not need push access here, and we do not grant it — a fork gives you everything required to contribute, and your commits keep your authorship when they merge. Branch in your own fork:
+
+```bash
+git switch -c feature/add-user-auth
+```
+
+**With push access.** Maintainers create branches with the project tooling, which branches from `origin/<base>` and sets the upstream correctly:
 
 ```bash
 just create-feature feature add-user-auth main
 just create-feature bugfix fix-connection-timeout main
 ```
 
-The first argument is the branch type: `feature` (new capability), `bugfix` (fix to existing behavior), `hotfix` (urgent fix), `chore` (dependencies, config), or `refactor` (no functional change). All pull requests target `main`.
+Either way, the first path segment is the branch type: `feature` (new capability), `bugfix` (fix to existing behavior), `hotfix` (urgent fix), `chore` (dependencies, config), or `refactor` (no functional change). All pull requests target `main`.
 
 ## Coding Standards
 
@@ -170,7 +176,19 @@ git push origin your-branch-name
 gh pr create --base main --title "Your PR title" --body "Your PR description"
 ```
 
+From a fork, push the branch to your own remote first and target this repository as the base:
+
+```bash
+git push origin your-branch-name
+gh pr create --repo RoboFinSystems/robosystems --base main \
+  --title "Your PR title" --body "Your PR description"
+```
+
 From a Claude Code session, the `/create-pr` slash command does the same thing, writing the description from the work in the session and cross-checking each claim against `git diff <target>...<branch>`.
+
+### CI on fork pull requests
+
+A first-time contributor's workflow runs need maintainer approval before they start, so expect CI to sit idle until someone approves it. Fork pull requests always run on GitHub-hosted runners and receive no repository secrets, so any job that depends on credentials will not run for them.
 
 ### Requirements
 
@@ -178,7 +196,7 @@ From a Claude Code session, the `/create-pr` slash command does the same thing, 
 - Coverage does not regress meaningfully
 - Documentation is updated alongside behavior changes
 - One feature or fix per PR
-- At least one maintainer approval before merge
+- At least one maintainer approval before merge, and a maintainer performs the merge
 
 Address review feedback with new commits rather than force-pushing, so reviewers can follow what changed.
 

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -27,11 +27,17 @@ jobs:
           ref: ${{ github.ref }}
           token: ${{ github.token }}
 
+      # Pull requests from forks carry untrusted code, so they are pinned to
+      # ephemeral GitHub-hosted runners regardless of RUNNER_LABELS. Self-hosted
+      # runners persist between jobs; running a fork's code on one would let an
+      # external contributor reach the runner host and anything it can access.
+      # RUNNER_LABELS is a GitHub variable that can be flipped to self-hosted at
+      # any time, so the guard lives here rather than relying on its value.
       - name: Select runner
         id: select
         uses: ./.github/actions/select-runner
         with:
-          runner_labels: ${{ vars.RUNNER_LABELS || 'github-hosted' }}
+          runner_labels: ${{ github.event.pull_request.head.repo.fork && 'github-hosted' || vars.RUNNER_LABELS || 'github-hosted' }}
           runner_scope: ${{ vars.RUNNER_SCOPE || 'both' }}
           github_token: ${{ github.token }}
 


### PR DESCRIPTION
## Summary

Prepares the repository for external contributions arriving as fork pull requests, prompted by the first one (RFC RoboFinSystems/xbrlkit#60). Two things: fork PRs are pinned to GitHub-hosted runners in the workflow rather than inheriting whatever `RUNNER_LABELS` currently says, and `CONTRIBUTING.md` gains the fork path it was missing.

## Changes

**`.github/workflows/test-ci.yml`** — the `Select runner` step passed `vars.RUNNER_LABELS` straight through, so which runner a pull request landed on depended entirely on that variable's value at the time. `RUNNER_LABELS` is `github-hosted` today, but it is a GitHub variable that exists precisely so it can be switched to self-hosted, and self-hosted runners persist between jobs. Fork pull requests now resolve to `github-hosted` unconditionally via `github.event.pull_request.head.repo.fork`, so the property holds regardless of how the variable is later set. Same-repo pull requests and pushes to `main` are unaffected and still honour `RUNNER_LABELS`.

**`.github/CONTRIBUTING.md`** — the Branching section pointed every reader at `just create-feature`, which branches from `origin/<base>` and pushes to this repository. That only works with push access, which external contributors do not have and are not given. Documented alongside it:

- The fork branching path, and that a fork is sufficient to contribute — commits keep their authorship when merged.
- `gh pr create --repo ...` for opening a PR from a fork.
- A short note that first-time contributors' workflow runs wait on maintainer approval, and that fork PRs get no repository secrets — both are existing GitHub behaviour that is otherwise surprising when CI appears to hang.
- The merge requirement now records that a maintainer performs the merge, not only that one approves.

Reviewers may want to look closely at the runner expression, since the fallback chain has three terms and the `&&`/`||` idiom is easy to misread. It evaluates as: fork PR → `github-hosted`; otherwise → `RUNNER_LABELS`; otherwise → `github-hosted`. For pushes, `github.event.pull_request` is null, the property access yields null, and the expression falls through to the existing behaviour.

## Breaking Changes

None. No API surface, no schema, no SDK impact — the change is confined to CI configuration and contributor documentation.

## Testing

`just test-all` not run: the branch changes no Python and no CloudFormation, so the unit suite and `cf-lint` have nothing to exercise.

- Pre-commit gate ran on commit and passed clean — ruff check ("All checks passed!"), format (1693 files already formatted), basedpyright (0 errors, 0 warnings, 0 notes).
- `test-ci.yml` was parsed with PyYAML to confirm it is still valid YAML and that the `runner_labels` input carries the intended expression.
- The runner expression itself is verified by reading, not execution — it takes a real fork pull request to exercise the `fork == true` branch, and the next external contribution will be the first one to do that.
