### PR TITLE
fix(setup): stop gha.sh resetting AWS_REGION to us-east-1

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,11 @@ Dedicated frontend app: [`roboledger-app`](https://github.com/RoboFinSystems/rob
 
 ### [RoboInvestor](https://roboinvestor.ai)
 
-Portfolio management and investment tracking extension — tracks investor holdings and links them back to the companies behind them.
+Portfolio management and investment tracking extension — tracks holdings in private companies and links them back to the businesses that issued them.
 
 - **Portfolio Blocks** — the same molecule discipline as RoboLedger: a portfolio plus its positions and securities are validated and written as one envelope, with cost basis and current value held as integer cents and dollar totals computed at the boundary. Positions move through an active / disposed / archived lifecycle; reads expose `portfolios`, `positions`, `holdings` (rolled up by issuer), and the assembled `portfolioBlock`.
 - **Securities** — register and maintain ownership instruments (common stock, warrants, convertible notes, …) with an extensible `terms` blob for instrument-specific detail (strike price, liquidation preference, vesting)
-- **Cross-graph research** — a security links to its issuer through a mutual handshake: the investor records the issuer's `source_graph_id`, and the issuer shares a report that materializes its entity in the investor's graph. This joins private holdings to SEC public-company data in the shared repository — the differentiated capability — with authorization enforced at the report-sharing boundary, not the OLTP layer.
+- **Cross-graph research** — a security can point at the graph of the company that issued it, when that company also runs on the platform. The investor records the issuer's `source_graph_id` up front as a pre-association; when the issuer later shares a published report into the investor's graph, the issuer's entity is materialized there and any securities waiting on that `source_graph_id` link to it. A holding then traverses through to the issuer's own reported facts — `Portfolio → Position → Security → Entity → Report → Fact` — with authorization enforced at the report-sharing boundary, not the OLTP layer.
 
 Dedicated frontend app: [`roboinvestor-app`](https://github.com/RoboFinSystems/roboinvestor-app).
 

--- a/bin/setup/README.md
+++ b/bin/setup/README.md
@@ -271,7 +271,7 @@ just setup-gha
 | --------------------- | ------------- | ------------------------------------- |
 | `AWS_ECR_REPOSITORY`  | `robosystems` | ECR repository name                   |
 | `AWS_ACCOUNT_ID`      | User input    | AWS account ID                        |
-| `AWS_REGION`          | `us-east-1`   | AWS region                            |
+| `AWS_REGION`          | `$AWS_REGION` | AWS region (falls back to `us-east-1`)|
 | `ENVIRONMENT_PROD`    | `prod`        | Production environment name           |
 | `ENVIRONMENT_STAGING` | `staging`     | Staging environment name (if enabled) |
 

--- a/bin/setup/gha.sh
+++ b/bin/setup/gha.sh
@@ -173,6 +173,12 @@ function setup_full_config() {
     REPO_NAME=${REPO_NAME:-"robosystems"}
     read -p "Enter AWS Account ID: " AWS_ACCOUNT_ID
 
+    # Default to the region bootstrap.sh exported (or .envrc set), not a literal
+    # — otherwise a non-us-east-1 deployment silently loses its region here
+    AWS_REGION_DEFAULT="${AWS_REGION:-us-east-1}"
+    read -p "Enter AWS Region [${AWS_REGION_DEFAULT}]: " AWS_REGION_INPUT
+    AWS_REGION="${AWS_REGION_INPUT:-$AWS_REGION_DEFAULT}"
+
     # Check if alert email is already available (from bootstrap or GitHub)
     if [ -n "${ALERT_EMAIL:-}" ]; then
         # Passed from bootstrap.sh
@@ -199,7 +205,7 @@ function setup_full_config() {
 
     # AWS Configuration (typically org-level, set at repo level for forks)
     gh variable set AWS_ACCOUNT_ID --body "$AWS_ACCOUNT_ID"
-    gh variable set AWS_REGION --body "us-east-1"
+    gh variable set AWS_REGION --body "$AWS_REGION"
     gh variable set ENVIRONMENT_PROD --body "prod"
     if $setup_staging; then
         gh variable set ENVIRONMENT_STAGING --body "staging"


### PR DESCRIPTION
## Summary

`just bootstrap [profile] [region]` accepts a region and threads it everywhere — the generated `.envrc`, the AWS profile config, every `aws` call in the script, and the `AWS_REGION` GitHub variable that `prod.yml` / `staging.yml` read as `${{ vars.AWS_REGION || 'us-east-1' }}`.

`gha.sh` then overwrote that variable from a hardcoded literal:

```bash
gh variable set AWS_REGION --body "us-east-1"
```

Bootstrap offers to run `gha.sh` at the end (`bootstrap.sh:943`), *after* setting the variable correctly, so a fork bootstrapped outside us-east-1 lost its region on the way out — and every later `just setup-gha` reset it again. Nothing in the region path was broken except the last write.

## Changes

- **`bin/setup/gha.sh`** — default the region from the exported `AWS_REGION` (bootstrap sets it at `bootstrap.sh:53`; the generated `.envrc` sets it for standalone runs) and prompt for it like the account ID, ECR repo, and org name already are. Falls back to `us-east-1` when nothing is set, so the default path is unchanged.
- **`bin/setup/README.md`** — variable table no longer claims a fixed `us-east-1` default.

## Breaking Changes

None. No API surface, no SDK contract. The default-path behavior is identical; only a non-default region stops being discarded.

## Testing

`just test-code` via the pre-commit hook — ruff, format, basedpyright, cf-lint all clean (nothing Python or CFN changed).

`bash -n` clean. Verified the defaulting logic directly, since the surrounding script is interactive and hits AWS/`gh`:

| `AWS_REGION` in env | input | result |
| --- | --- | --- |
| unset | Enter | `us-east-1` |
| `eu-west-1` | Enter | `eu-west-1` |
| `eu-west-1` | `ap-south-1` | `ap-south-1` |

Companion PRs bring the three frontend app repos to parity — their `bootstrap.sh` was env-var-only and their `gha-setup.sh` prompt had the same literal default.