### PR TITLE
fix(taxonomy): restore snake_case keys in rules.rule_variables

### DIFF
--- a/migrations/extensions/versions/0031_rule_variable_key_case.py
+++ b/migrations/extensions/versions/0031_rule_variable_key_case.py
@@ -1,0 +1,97 @@
+"""Restore snake_case keys in ``rules.rule_variables``.
+
+Migration 0030 rewrote ``rule_variables`` for every rule in the pinned
+packages and serialized each entry with the JSON-LD spelling
+(``variableName`` / ``variableQname``). That spelling is correct in the
+framework source — ``taxonomy/loader.py`` reads those RDF predicates and
+``arelle/context.py`` declares them — but it is the *wire* form. The
+column's contract is snake_case: ``rules/evaluators.py`` indexes
+``v["variable_name"]`` directly, so a camelCase row raises
+``KeyError('variable_name')`` and the evaluation records
+``status='error'`` instead of pass/fail.
+
+The effect was every ``RollUp`` rule in the rs-gaap-rollup-rules package —
+21 rows in ``public`` and 21 in each provisioned tenant — erroring on every
+evaluation. Rules of other patterns were untouched (the pinned packages
+carry no others), so the failure is bounded to the rollup surface rather
+than the engine.
+
+0030's guard compared the new value against the stored one, and camelCase
+differs from snake_case for *every* rule, so the update landed on all 21
+rather than only the six whose enumerations 0030 meant to correct. The
+values themselves are right — names, qnames and ordering all survived — so
+this migration is a pure key rename and preserves the #898 repair.
+
+Matched on the presence of the camelCase key rather than on
+``created_by``, so a row that acquired the bad shape by any route is
+repaired; the ``WHERE`` makes a second run a no-op.
+
+Revision ID: 0031
+Revises: 0030
+"""
+
+from __future__ import annotations
+
+from alembic import op
+from sqlalchemy import text
+
+from migrations.extensions.helpers import for_each_tenant_schema
+
+revision = "0031"
+down_revision = "0030"
+branch_labels = None
+depends_on = None
+
+# COALESCE so a row that is already snake_case (or was written by a mixed
+# path) keeps its value rather than being nulled out — the WHERE below
+# should exclude those, but the rewrite must not depend on it.
+_REKEY_SQL = """
+  UPDATE {schema}.rules
+     SET rule_variables = (
+       SELECT jsonb_agg(
+                jsonb_build_object(
+                  'variable_name',
+                  COALESCE(v ->> 'variableName', v ->> 'variable_name'),
+                  'variable_qname',
+                  COALESCE(v ->> 'variableQname', v ->> 'variable_qname')
+                )
+                ORDER BY ord
+              )
+         FROM jsonb_array_elements(rule_variables) WITH ORDINALITY AS t(v, ord)
+     )
+   WHERE rule_variables IS NOT NULL
+     AND jsonb_typeof(rule_variables) = 'array'
+     AND EXISTS (
+       SELECT 1
+         FROM jsonb_array_elements(rule_variables) AS e(v)
+        WHERE e.v ? 'variableName' OR e.v ? 'variableQname'
+     )
+"""
+
+
+def _rekey(conn, schema: str) -> None:
+  result = conn.execute(text(_REKEY_SQL.format(schema=f'"{schema}"')))
+  if result.rowcount:
+    print(f"  [rule_variables rekey -> {schema}] updated={result.rowcount}")
+
+
+def upgrade() -> None:
+  from robosystems.taxonomy.writer import SET_LIBRARY_RESYNC
+
+  conn = op.get_bind()
+
+  # The 0016 immutability triggers reject UPDATE on library-origin rows
+  # without the bypass GUC. SET LOCAL is transaction-scoped and covers the
+  # public fix and the whole tenant fan-out.
+  conn.execute(text(SET_LIBRARY_RESYNC))
+
+  _rekey(conn, "public")
+  for_each_tenant_schema(conn, _rekey)
+
+
+def downgrade() -> None:
+  """Intentionally a no-op.
+
+  Reinstating the camelCase keys would restore a state in which every
+  RollUp rule errors at evaluation. There is nothing to roll back to.
+  """

--- a/robosystems/operations/taxonomy_block/library_creator.py
+++ b/robosystems/operations/taxonomy_block/library_creator.py
@@ -30,6 +30,7 @@ rows alongside the old ones (duplicate concepts, dangling FKs).
 from __future__ import annotations
 
 import re
+from collections.abc import Iterable
 
 from sqlalchemy import delete, exists, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
@@ -48,6 +49,7 @@ from robosystems.models.extensions import (
   Trait,
 )
 from robosystems.taxonomy.model import (
+  RuleVariableSpec,
   TaxonomyPackage,
   TraitAssignmentSpec,
 )
@@ -140,6 +142,34 @@ def _association_id(
 
 def _rule_id(standard: str, local_id: str) -> str:
   return generate_deterministic_uuid(f"{standard}:{local_id}", namespace="rule")
+
+
+# The stored key names for a rule's variable list. Snake_case is the storage
+# contract: operations/information_block/rules/evaluators.py indexes
+# ``v["variable_name"]`` directly, so any other spelling raises KeyError at
+# evaluation time rather than failing on write. The JSON-LD source spells the
+# same fields ``variableName`` / ``variableQname`` (see taxonomy/loader.py and
+# arelle/context.py) — that is the wire form and must not reach this column.
+RULE_VARIABLE_NAME_KEY = "variable_name"
+RULE_VARIABLE_QNAME_KEY = "variable_qname"
+
+
+def rule_variables_json(variables: Iterable[RuleVariableSpec]) -> list[dict[str, str]]:
+  """Serialize a rule's variables for the ``rules.rule_variables`` JSONB column.
+
+  Every writer — the library seeder and any migration that rewrites the
+  column — must go through here. Migration 0030 hand-rolled the dict with
+  the JSON-LD spelling and broke evaluation for all 21 seeded RollUp rules
+  across public and every tenant; 0031 repaired the data and this function
+  exists so the shape has one definition to drift from.
+  """
+  return [
+    {
+      RULE_VARIABLE_NAME_KEY: v.variable_name,
+      RULE_VARIABLE_QNAME_KEY: v.variable_qname,
+    }
+    for v in variables
+  ]
 
 
 def _default_role_uri(package: TaxonomyPackage) -> str:
@@ -793,10 +823,7 @@ def create_library_rules(
         counts["rules_skipped"] += 1
         continue
 
-    variables_json = [
-      {"variable_name": v.variable_name, "variable_qname": v.variable_qname}
-      for v in rule.rule_variables
-    ]
+    variables_json = rule_variables_json(rule.rule_variables)
 
     session.execute(
       pg_insert(Rule.__table__)

--- a/tests/taxonomy/test_rules_migration_shape.py
+++ b/tests/taxonomy/test_rules_migration_shape.py
@@ -196,6 +196,78 @@ class TestTenantPin:
     assert DEFAULT_TAXONOMY_PIN.get("rs-gaap-rules") == "v1"
 
 
+class TestRuleVariableKeyCase:
+  """``rules.rule_variables`` is stored snake_case; the JSON-LD source
+  spells the same fields camelCase.
+
+  Migration 0030 crossed the two and wrote the wire spelling into the
+  column, which every seeded ``RollUp`` rule in public and in both
+  provisioned tenants then failed to evaluate — ``evaluators.py`` indexes
+  ``v["variable_name"]`` with no fallback, so the rows raised
+  ``KeyError`` and recorded ``status='error'``. 0031 repaired the data.
+
+  These tests hold the two ends together: what the writer emits and what
+  the evaluator reads. A DB round-trip would catch it too, but this file's
+  contract is static checks, and the failure mode is a key name — which
+  is comparable without a database.
+  """
+
+  def test_serializer_emits_the_keys_the_evaluator_indexes(self) -> None:
+    """The real cross-check: every key ``evaluators.py`` pulls off a
+    rule-variable entry must be one the serializer writes."""
+    import re as _re
+
+    from robosystems.operations.taxonomy_block.library_creator import (
+      rule_variables_json,
+    )
+    from robosystems.taxonomy.model import RuleVariableSpec
+
+    evaluators_src = (
+      Path(__file__).resolve().parents[2]
+      / "robosystems"
+      / "operations"
+      / "information_block"
+      / "rules"
+      / "evaluators.py"
+    ).read_text()
+
+    indexed_keys = set(
+      _re.findall(r'\bv\[["\']([a-zA-Z_]+)["\']\]', evaluators_src)
+    ) | set(_re.findall(r'\bv\.get\(["\']([a-zA-Z_]+)["\']', evaluators_src))
+    assert indexed_keys, "found no rule-variable key access in evaluators.py"
+
+    emitted = set(
+      rule_variables_json(
+        [RuleVariableSpec(variable_name="Assets", variable_qname="rs-gaap:Assets")]
+      )[0]
+    )
+    missing = indexed_keys - emitted
+    assert not missing, (
+      f"evaluators.py reads {sorted(missing)} but the writer never emits it — "
+      "a rule serialized this way raises KeyError at evaluation time"
+    )
+
+  def test_wire_spelling_never_reaches_the_column(self) -> None:
+    """``variableName`` / ``variableQname`` belong to the JSON-LD source
+    (taxonomy/loader.py, arelle/context.py), not to the JSONB column."""
+    from robosystems.operations.taxonomy_block.library_creator import (
+      rule_variables_json,
+    )
+    from robosystems.taxonomy.model import RuleVariableSpec
+
+    emitted = rule_variables_json(
+      [RuleVariableSpec(variable_name="Assets", variable_qname="rs-gaap:Assets")]
+    )
+    assert emitted == [{"variable_name": "Assets", "variable_qname": "rs-gaap:Assets"}]
+
+  def test_repair_migration_targets_the_wire_spelling(self) -> None:
+    """0031 must key its ``WHERE`` on the camelCase spelling and write the
+    snake_case one — inverted, it would re-break every rule it touches."""
+    sql = (_MIGRATION_PATH.parent / "0031_rule_variable_key_case.py").read_text()
+    assert "'variable_name'," in sql and "'variable_qname'," in sql
+    assert "? 'variableName'" in sql
+
+
 class TestTenantWriterRuleCols:
   def test_rule_cols_include_polymorphic_target_fks(self) -> None:
     """The public→tenant INSERT...SELECT must name the polymorphic FK


### PR DESCRIPTION
## Summary

Migration `0030` reserialized `rule_variables` for every rule in its pinned packages using the JSON-LD spelling (`variableName` / `variableQname`). That spelling is correct in the framework source — `taxonomy/loader.py` reads those RDF predicates — but the JSONB column's contract is snake_case: `rules/evaluators.py` indexes `v["variable_name"]` directly, so a camelCase row raises `KeyError` and the evaluation records `status='error'` instead of pass/fail.

Every `RollUp` rule in `rs-gaap-rollup-rules` was affected: 21 rows in `public` and 21 in each provisioned tenant. Rules of other patterns were untouched — the pinned packages carry no others — so the breakage was bounded to the rollup surface, not the engine.

`0030`'s update guard compared the new value against the stored one, and camelCase differs from snake_case for *every* rule, so it landed on all 21 rather than only the six enumerations it meant to correct.

Values, names and ordering all survived, so `0031` is a pure key rename and preserves the #898 repair.

## Changes

- **`0031_rule_variable_key_case.py`** — rekeys `rule_variables` in `public` and every tenant schema under the library-resync GUC. Matched on the presence of the camelCase key rather than `created_by`, so a row that acquired the bad shape by any route is repaired and a second run is a no-op. `COALESCE` on both spellings so a mixed array can't be nulled out. Downgrade is a documented no-op — there is nothing to roll back to.
- **`library_creator.rule_variables_json()`** — the serialization now has one definition, and the seeder routes through it. `0030` hand-rolled the dict, which is how the spellings diverged.
- **`TestRuleVariableKeyCase`** — parses `evaluators.py` for the keys it indexes off a rule-variable entry and asserts the writer emits every one. Catches drift from either side, no DB round-trip needed.

## Verification

Local was deliberately re-broken to reproduce prod's exact shape (public 21 camel / 17 snake, tenant 21/17), then the migration was run through Alembic:

```
[rule_variables rekey -> public] updated=21
[rule_variables rekey -> kg19fee995fd3d86939bb8] updated=21
```

After: 0 camel / 38 snake in both schemas, 0 rules where the tenant copy differs from public, and variable values/order preserved. Re-running matched nothing (idempotent). A tenant schema was provisioned specifically to exercise the fan-out.

The new test was confirmed to fail with the bug reintroduced:

```
AssertionError: evaluators.py reads ['variable_name'] but the writer never emits it
```

`just test-all`: 12,466 passed, ruff + format + basedpyright + cf-lint clean.

## Deploy note

Both `public` and the two provisioned tenants in prod currently hold the broken shape, so rollup verification is recording `error` on every evaluation until this migration runs. `public` is the seed source for tenant provisioning, so any tenant created before it runs is born with the same defect.