### PR TITLE
chore(tests): drop the git-ignored vault reference from test_share_controls

### DIFF
--- a/tests/operations/roboledger/commands/test_share_controls.py
+++ b/tests/operations/roboledger/commands/test_share_controls.py
@@ -4,7 +4,7 @@ Sharing is authorized capability-style: whoever holds a graph's id can copy a
 published report into it. These are the tests for the three controls that make
 that model sound — the recipient can delete what landed and block the sender,
 and the sender can withdraw. See
-``local/RoboSystems/specs/extensions/cross-graph-share-controls.md``.
+``local/RoboSystems/archive/cross-graph-share-controls.md``.
 """
 
 from __future__ import annotations

--- a/tests/operations/roboledger/commands/test_share_controls.py
+++ b/tests/operations/roboledger/commands/test_share_controls.py
@@ -3,8 +3,7 @@
 Sharing is authorized capability-style: whoever holds a graph's id can copy a
 published report into it. These are the tests for the three controls that make
 that model sound — the recipient can delete what landed and block the sender,
-and the sender can withdraw. See
-``local/RoboSystems/archive/cross-graph-share-controls.md``.
+and the sender can withdraw.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

`tests/operations/roboledger/commands/test_share_controls.py` cited a design doc under `local/RoboSystems/`. This repo is **public** and `local/` is git-ignored, so that path resolves to nothing for anyone reading the tests from a clean checkout.

It was also stale: the spec had been archived when the recipient half shipped in #1118, so the path pointed at a file that no longer existed even for someone holding the vault.

Repathing it to `archive/` would have made it accurate without making it followable, so the reference is removed instead. The docstring already states the sharing model — capability-style, whoever holds a graph's id can copy a published report into it — and names the three controls the file tests, so the pointer carried nothing a reader couldn't get from the paragraph above it.

## The line

Vault references are fine where the reader has the vault: `.claude/commands/*` pair with `local/RoboSystems/runbooks/` by design, and that stays. Code and tests are read by people who don't have it — including external contributors — so the reasoning belongs inline.

This was the only such reference in the Python source; a sweep of `robosystems-app` and `roboinvestor-app` found none. `roboledger-app` had eight pointing at specs that never existed, cleaned separately in RoboFinSystems/roboledger-app#299.

## Verification

`just test-code` — ruff, format, basedpyright, cf-lint all clean.

Note: `just test` was not run. The change is a docstring, and the local Docker stack was down, so the DB-backed tests in this file could not execute. CI will run them.