### PR TITLE
chore: cite the data-plane ref section, not a line number

### DIFF
--- a/.github/actions/refresh-graph-asg/action.yml
+++ b/.github/actions/refresh-graph-asg/action.yml
@@ -117,7 +117,7 @@ runs:
         # decision an instance makes about itself.
         #
         # What they MUST share is the interpretation, because `instance_busy` is a
-        # coordination signal and not a guard (ref/data-plane.md §65): a negative
+        # coordination signal and not a guard (ref/data-plane.md §4): a negative
         # counter is idle, a counter with a stale heartbeat is a crashed writer,
         # and a missing registry row proceeds. Change a fail-open rule in one and
         # change it in the other, or the two drift — as the stale window already

--- a/bin/userdata/common/refresh-graph-container.sh
+++ b/bin/userdata/common/refresh-graph-container.sh
@@ -127,7 +127,7 @@ log "target image=${ECR_IMAGE}"
 #
 # This is a coordination signal, NOT a guard. `instance_busy`'s own module logs
 # write failures and never raises them, on the principle that a broken counter
-# must not block the actual work — see ref/data-plane.md §65. Every escape hatch
+# must not block the actual work — see ref/data-plane.md §4. Every escape hatch
 # below is therefore deliberate and must stay: a negative counter is idle, a
 # counter stuck with a stale heartbeat is a crashed writer, and a missing registry
 # row proceeds. Do not tighten these into a resource control.

--- a/tests/infrastructure/test_userdata_refresh.py
+++ b/tests/infrastructure/test_userdata_refresh.py
@@ -3,7 +3,7 @@
 That script decides whether to bounce a customer's graph container, so its
 fail-open branches, its refusal branches, and its no-op branch all need pinning
 down. `instance_busy` is a coordination signal rather than a guard
-(ref/data-plane.md §65), which means every one of the "proceed anyway" paths is
+(ref/data-plane.md §4), which means every one of the "proceed anyway" paths is
 deliberate — and a well-meaning future edit that tightens one into a real guard
 would look like a bug fix. These tests are what make that edit fail.
 
@@ -201,7 +201,7 @@ class TestEnvironmentContract:
 
 
 class TestBusyCounterFailsOpen:
-  """Every one of these paths is deliberate; see ref/data-plane.md §65.
+  """Every one of these paths is deliberate; see ref/data-plane.md §4.
 
   The counter reports, it does not decide. A broken or absent counter must never
   block a refresh, and tightening any of these into a real guard is the mistake


### PR DESCRIPTION
## Summary

Comment-only fix: three code comments and one test docstring cited the `instance_busy` fail-open doctrine as `ref/data-plane.md` **§65**, which is not a section. That doc numbers its sections and cites them as §2, §4, §5 — 65 was a *line* number that happens to fall inside section 4. Every one of those references pointed a reader at a section that doesn't exist.

Found while distilling `specs/data-plane/fleet-refresh-control-plane.md` into the ref doc after #1141 merged. The distillation added a §14, which would have shifted line 65 regardless.

## Changes

- `bin/userdata/common/refresh-graph-container.sh` — the `wait_until_idle` doctrine comment
- `.github/actions/refresh-graph-asg/action.yml` — the `STALE_WINDOW_SECONDS` cross-reference note
- `tests/infrastructure/test_userdata_refresh.py` — two references in the module docstring and the `TestBusyCounterFailsOpen` docstring

All four now read §4. No logic touched.

The reusable bit is *why* it happened rather than the fix: the citation came from the spec and was propagated across four files without being checked. An inherited reference is a claim like any other, and this one was wrong at the source.

## Breaking Changes

None. Comments and a docstring.

## Testing

- `uv run pytest tests/infrastructure/` — 51 passed
- `uv run actionlint -shellcheck=` — clean
- `bash -n` on the modified shell script — clean
- `just test-code` — clean (ran on commit via the pre-commit hook)
