### PR TITLE
chore: dev tooling cleanup — playwright artifacts, mcp.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,6 +134,8 @@ dmypy.json
 .claude/scheduled_tasks.lock
 .claude/worktrees/
 CLAUDE.local.md
+# Playwright MCP session artifacts (snapshots, console logs)
+.playwright-mcp/
 
 .gemini/
 GEMINI.md

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -47,25 +47,6 @@
         "ROBOSYSTEMS_GRAPH_ID": "${input:robosystems-graph-id}"
       }
     },
-    "Context7": {
-      "command": "npx",
-      "args": ["-y", "@upstash/context7-mcp"]
-    },
-    "sequential-thinking": {
-      "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"]
-    },
-    "puppeteer": {
-      "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-puppeteer"]
-    },
-    "postgres": {
-      "command": "uvx",
-      "args": ["postgres-mcp", "--access-mode=unrestricted"],
-      "env": {
-        "DATABASE_URI": "postgresql://postgres:postgres@localhost:5432/robosystems"
-      }
-    },
     "aws-documentation": {
       "command": "uvx",
       "args": ["awslabs.aws-documentation-mcp-server@latest"],


### PR DESCRIPTION
Two local-dev-tooling chores:

- **Ignore `.playwright-mcp/`** — the Playwright MCP plugin writes page snapshots and console logs there during browser-driven test sessions (first used for the centralized-login E2E pass). Local-only artifacts.
- **Trim `.vscode/mcp.json` to project-relevant servers** — keeps the three robosystems servers (HTTP endpoint, published bridge, local bridge checkout) and aws-documentation (still maintained under awslabs). Removes Context7 (now consumed via Claude plugins), sequential-thinking and puppeteer (retired; playwright via plugin), and postgres — recommending an unrestricted DB connection by default wasn't right. `.vscode/extensions.json` is untouched: it covers editor extensions only, no MCP overlap.