### PR TITLE
fix(graph): normalize refresh skips and scope failure paging to the refresh document

### DIFF
--- a/.github/workflows/service-refresh.yml
+++ b/.github/workflows/service-refresh.yml
@@ -305,8 +305,11 @@ jobs:
             jq -r '.counts // {} | to_entries[] | "| \(.key) | \(.value) |"' /tmp/status.json
           } >> "$GITHUB_STEP_SUMMARY"
 
-          # `failed` already excludes the skip exit codes (3 = stale
-          # /etc/environment, 4 = script not installed yet). Those mean the
+          # `failed` already excludes the skips (script not installed yet, or
+          # stale /etc/environment). The refresh document normalizes those to
+          # exit 0 — a non-zero exit would consume the SSM MaxErrors budget and
+          # terminate the rest of the fleet's invocations — and the Lambda
+          # classifies them off the REFRESH_RESULT marker. A skip means the
           # instance has not cycled onto the new scripts and its container was
           # deliberately left alone — a transitional state that must not fail a
           # deploy, but must stay visible, which the summary above does.

--- a/bin/lambda/graph_container_refresh.py
+++ b/bin/lambda/graph_container_refresh.py
@@ -4,9 +4,10 @@ Refresh graph API containers across the fleet with one tag-targeted SSM command.
 The per-instance work — wait for in-flight destructive ops, pull, skip on an
 unchanged digest, swap, health-check, prune — lives on the instance in
 `/usr/local/bin/refresh-graph-container.sh`. This function is the *trigger and
-the aggregator, not the worker*: it dispatches one `AWS-RunShellScript` command
-at a tag expression and reports back. No instance enumeration, no per-instance
-job, no runner sleeping through a busy-wait.
+the aggregator, not the worker*: it dispatches the stack's own refresh document
+(graph-infra.yaml `GraphRefreshDocument`, which wraps that script) at a tag
+expression and reports back. No instance enumeration, no per-instance job, no
+runner sleeping through a busy-wait.
 
 Why that matters: `databases_per_instance: 1` on every tier means customer count
 is instance count, so the enumerate-into-a-matrix approach this replaces hit a
@@ -39,7 +40,15 @@ ssm = boto3.client("ssm")
 ENVIRONMENT = os.environ["ENVIRONMENT"]
 ALERT_TOPIC_ARN = os.environ.get("ALERT_TOPIC_ARN", "")
 
-REFRESH_SCRIPT = "/usr/local/bin/refresh-graph-container.sh"
+# The stack-owned SSM document that wraps refresh-graph-container.sh. Dispatching
+# our own document rather than AWS-RunShellScript is what lets the failure-paging
+# EventBridge rule filter on document-name (the only environment- or
+# purpose-specific field an SSM invocation event carries) and lets the role's
+# SendCommand grant collapse to exactly this behavior. The wrapper shell — the
+# presence guard and the skip-exit normalization — lives in the document, next to
+# the rule that depends on it. Required, like ENVIRONMENT: falling back to the
+# generic document would silently un-scope the paging rule.
+REFRESH_DOCUMENT = os.environ["REFRESH_DOCUMENT_NAME"]
 
 # Rate control defaults live here, not only in the caller, so a hand-rolled
 # invocation cannot accidentally hit the fleet at SSM's default concurrency of
@@ -50,9 +59,9 @@ REFRESH_SCRIPT = "/usr/local/bin/refresh-graph-container.sh"
 DEFAULT_MAX_CONCURRENCY = "10%"
 DEFAULT_MAX_ERRORS = "10%"
 
-# The busy-wait ceiling the instance script honors. executionTimeout must always
-# exceed it, and is set explicitly rather than left to AWS-RunShellScript's
-# 3600s default so that raising the wait cannot silently truncate the command.
+# The busy-wait ceiling the instance script honors. The document's
+# ExecutionTimeout parameter must always exceed it, and is passed explicitly on
+# every dispatch so that raising the wait cannot silently truncate the command.
 DEFAULT_MAX_WAIT_MINUTES = 30
 REFRESH_HEADROOM_SECONDS = 900
 
@@ -78,19 +87,22 @@ ALL_GROUPS = ["writer", "shared-replicas"]
 
 TERMINAL_STATUSES = {"Success", "Failed", "Cancelled", "TimedOut", "Cancelling"}
 
-# Exit codes that mean "this instance has not picked up the new deployment yet"
-# rather than "the refresh broke." SSM records any non-zero exit as `Failed`, so
-# without this classification a fleet that has not cycled onto the new scripts
-# fails the caller — which is the opposite of the intent, since the container was
-# deliberately left untouched.
+# REFRESH_RESULT markers that mean "this instance has not picked up the new
+# deployment yet" rather than "the refresh broke":
 #
-#   3 — script present, /etc/environment predates the completeness contract
-#   4 — script not on the instance at all (installed at boot)
+#   skipped-no-script — the refresh script is not on the instance at all
+#                       (scripts install at boot; the instance predates them)
+#   skipped-stale-env — script present, but /etc/environment predates the
+#                       completeness contract (the script's exit 3)
 #
-# These are matched on the script's own explicit exit codes, never inferred from a
-# generic 127: a missing `docker` inside the script also exits 127, and that is a
-# real failure that must not be downgraded.
-SKIP_RESPONSE_CODES = {3: "skipped-stale-env", 4: "skipped-no-script"}
+# The document normalizes both to exit 0, because SSM counts every non-zero exit
+# toward MaxErrors: a skip that exits non-zero burns the error budget and
+# terminates the rest of the fleet's queued invocations, so a uniformly
+# not-yet-cycled fleet could never even report itself. The stdout marker is the
+# signal instead. Real failures keep their non-zero exits — MaxErrors still halts
+# a bad rollout. Markers are matched exactly, never inferred from an exit code: a
+# missing `docker` inside the script exits 127 and must stay a failure.
+SKIP_RESULTS = {"skipped-no-script", "skipped-stale-env"}
 
 
 def _targets_for(group: str, environment: str) -> list[dict[str, Any]]:
@@ -106,25 +118,25 @@ def _targets_for(group: str, environment: str) -> list[dict[str, Any]]:
   ]
 
 
-def _build_commands(
-  max_wait_minutes: int, force_ignore_busy: bool, force_restart: bool
-) -> list[str]:
-  """The two shell lines the fleet runs.
+def _build_parameters(
+  max_wait_minutes: int,
+  force_ignore_busy: bool,
+  force_restart: bool,
+  execution_timeout: int,
+) -> dict[str, list[str]]:
+  """The document parameters that vary per dispatch.
 
-  The first is a presence guard with its own exit code so that "this instance
-  has not picked up the script yet" is reported as itself. It must NOT be
-  inferred from bash's 127 — a missing `docker` inside the script exits 127 too,
-  and that is a real failure that must not be downgraded to a benign skip.
+  The wrapper shell itself — the presence guard and the skip-exit
+  normalization — lives in the document (graph-infra.yaml), not here: the
+  document is the reviewable, IAM-scoped statement of what this function can
+  make an instance do, and the paging rule filters on its name.
   """
-  env_prefix = (
-    f"MAX_WAIT_MINUTES={max_wait_minutes} "
-    f"FORCE_IGNORE_BUSY={'true' if force_ignore_busy else 'false'} "
-    f"FORCE_RESTART={'true' if force_restart else 'false'}"
-  )
-  return [
-    f"[ -x {REFRESH_SCRIPT} ] || {{ echo REFRESH_RESULT=skipped-no-script; exit 4; }}",
-    f"{env_prefix} {REFRESH_SCRIPT}",
-  ]
+  return {
+    "MaxWaitMinutes": [str(max_wait_minutes)],
+    "ForceIgnoreBusy": ["true" if force_ignore_busy else "false"],
+    "ForceRestart": ["true" if force_restart else "false"],
+    "ExecutionTimeout": [str(execution_timeout)],
+  }
 
 
 def start(event: dict[str, Any]) -> dict[str, Any]:
@@ -143,20 +155,19 @@ def start(event: dict[str, Any]) -> dict[str, Any]:
 
   groups = ALL_GROUPS if node_type == "all" else [node_type]
   execution_timeout = max_wait_minutes * 60 + REFRESH_HEADROOM_SECONDS
-  commands = _build_commands(max_wait_minutes, force_ignore_busy, force_restart)
+  parameters = _build_parameters(
+    max_wait_minutes, force_ignore_busy, force_restart, execution_timeout
+  )
 
   dispatched: list[dict[str, Any]] = []
   for group in groups:
     targets = _targets_for(group, environment)
     try:
       response = ssm.send_command(
-        DocumentName="AWS-RunShellScript",
+        DocumentName=REFRESH_DOCUMENT,
         Targets=targets,
         Comment=f"graph container refresh ({environment}/{group})"[:100],
-        Parameters={
-          "commands": commands,
-          "executionTimeout": [str(execution_timeout)],
-        },
+        Parameters=parameters,
         MaxConcurrency=max_concurrency,
         MaxErrors=max_errors,
         TimeoutSeconds=3600,
@@ -225,24 +236,28 @@ def status(event: dict[str, Any]) -> dict[str, Any]:
         counts[inv_status] = counts.get(inv_status, 0) + 1
         overall[inv_status] = overall.get(inv_status, 0) + 1
 
-        response_code = inv.get("ResponseCode")
-        skip_reason = SKIP_RESPONSE_CODES.get(response_code) if response_code else None
-
-        outcome = _refresh_result(inv) or skip_reason
+        outcome = _refresh_result(inv)
         if outcome:
           results[outcome] = results.get(outcome, 0) + 1
 
+        if outcome in SKIP_RESULTS:
+          # Deliberately not a failure, whatever the invocation status says:
+          # the container was left running its current image on purpose. Under
+          # the current document skips arrive as Success (their exits are
+          # normalized to 0); a Failed invocation carrying a skip marker is a
+          # hand-run of the raw script, and gets the same grace.
+          skipped += 1
+          continue
+
         if inv_status in {"Failed", "TimedOut"}:
-          if skip_reason:
-            # Deliberately not a failure: the container was left running its
-            # current image on purpose.
-            skipped += 1
-            continue
           failures.append(
             {
               "instance_id": inv.get("InstanceId", "unknown"),
               "status": inv_status,
-              "response_code": str(response_code if response_code is not None else ""),
+              # Distinguishes "ran and failed" from "Terminated before running"
+              # — the latter means MaxErrors tripped elsewhere in the fleet.
+              "status_details": inv.get("StatusDetails", ""),
+              "response_code": _response_code(inv),
             }
           )
 
@@ -273,6 +288,17 @@ def _refresh_result(invocation: dict[str, Any]) -> str | None:
       if line.startswith("REFRESH_RESULT="):
         return line.split("=", 1)[1]
   return None
+
+
+def _response_code(invocation: dict[str, Any]) -> str:
+  """The shell exit code, from where SSM actually reports it: on the plugin,
+  never on the invocation itself. -1 means the plugin never ran (the invocation
+  was terminated first) and is reported as empty, like a missing plugin."""
+  for plugin in invocation.get("CommandPlugins", []):
+    code = plugin.get("ResponseCode")
+    if code is not None and code != -1:
+      return str(code)
+  return ""
 
 
 def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:

--- a/bin/userdata/common/refresh-graph-container.sh
+++ b/bin/userdata/common/refresh-graph-container.sh
@@ -27,7 +27,11 @@
 # Exits 0 when the container was refreshed OR was already current, non-zero on
 # failure. The non-zero exit is load-bearing: SSM records it as `Failed`, which is
 # what lets a fleet-wide --max-errors budget halt a bad rollout instead of
-# marching a broken image across every customer's database.
+# marching a broken image across every customer's database. The one exception is
+# exit 3 (below), a benign skip: the fleet-refresh document (graph-infra.yaml
+# GraphRefreshDocument) normalizes it to 0 so a skip cannot consume that same
+# error budget — from SSM's side, only real failures look like failures. Hand
+# runs of this script still see the raw 3.
 
 set -o pipefail
 
@@ -45,10 +49,11 @@ STALE_WINDOW_SECONDS=21600
 REQUIRED_ENV_SCHEMA=2
 
 # Distinct exit code for "this instance predates the environment contract." The
-# caller maps it to a loud skip rather than a failure: the instance has not
-# cycled since the contract landed, which is a transitional state to be waited
-# out or backfilled, not a broken refresh. Any other non-zero exit is a real
-# failure and must stay one.
+# fleet document maps it to exit 0, and the aggregator classifies the skip off
+# the REFRESH_RESULT marker printed alongside it: the instance has not cycled
+# since the contract landed, which is a transitional state to be waited out or
+# backfilled, not a broken refresh. Any other non-zero exit is a real failure
+# and must stay one.
 EXIT_STALE_ENV=3
 
 log() { echo "[refresh] $*"; }

--- a/cloudformation/graph-infra.yaml
+++ b/cloudformation/graph-infra.yaml
@@ -849,6 +849,85 @@ Resources:
   # platform gets a refresh path that is not GitHub Actions — an ops CLI command,
   # a post-image-push hook, or an Operator tool — with the rate-control defaults
   # applied in one place rather than at each caller.
+
+  # The refresh dispatches this stack-owned document rather than the generic
+  # AWS-RunShellScript, for three reasons that are one fact — the document name
+  # is the only environment- or purpose-specific field an SSM invocation event
+  # carries:
+  #   1. The failure rule below filters on it. Matching bare Failed/TimedOut
+  #      invocation events made every failed SSM command in the account page
+  #      BOTH environments' topics, each stamping its own environment name into
+  #      the message.
+  #   2. The Lambda role's SendCommand collapses to this one document: the role
+  #      can trigger a refresh on this environment's fleet, not run arbitrary
+  #      shell on it.
+  #   3. A hand-run refresh gets the same wrapper semantics instead of
+  #      re-typing them.
+  #
+  # Skip normalization: "script not installed" and the script's own exit 3
+  # ("/etc/environment predates the completeness contract") exit 0 here, with
+  # the REFRESH_RESULT stdout marker as the signal the Lambda classifies on.
+  # SSM counts every non-zero exit toward MaxErrors, so a skip that exits
+  # non-zero burns the error budget and terminates the rest of the fleet's
+  # queued invocations — a uniformly not-yet-cycled fleet could never even
+  # report itself. Real failures keep their non-zero exits, so MaxErrors still
+  # halts a bad rollout and the rule below still pages.
+  GraphRefreshDocument:
+    Type: AWS::SSM::Document
+    Properties:
+      Name: !Sub "${AWS::StackName}-graph-refresh"
+      DocumentType: Command
+      UpdateMethod: NewVersion
+      TargetType: /AWS::EC2::Instance
+      Content:
+        schemaVersion: "2.2"
+        description: >-
+          Refresh the graph API container on this instance to the current image.
+          Instances that have not yet cycled onto the refresh script (or whose
+          /etc/environment predates the completeness contract) exit 0 with a
+          REFRESH_RESULT=skipped-* marker rather than consuming the MaxErrors
+          budget.
+        parameters:
+          MaxWaitMinutes:
+            type: String
+            description: Minutes to wait for in-flight destructive operations
+            default: "30"
+            allowedPattern: "^[0-9]{1,4}$"
+          ForceIgnoreBusy:
+            type: String
+            description: Bypass the busy-counter wait (emergency escape hatch)
+            default: "false"
+            allowedValues: ["true", "false"]
+          ForceRestart:
+            type: String
+            description: Restart even when the image digest is unchanged
+            default: "false"
+            allowedValues: ["true", "false"]
+          ExecutionTimeout:
+            type: String
+            description: Per-instance execution timeout in seconds
+            default: "2700"
+            allowedPattern: "^[0-9]{1,6}$"
+        mainSteps:
+          - action: aws:runShellScript
+            name: refreshGraphContainer
+            inputs:
+              timeoutSeconds: "{{ ExecutionTimeout }}"
+              runCommand:
+                - '[ -x /usr/local/bin/refresh-graph-container.sh ] || { echo REFRESH_RESULT=skipped-no-script; exit 0; }'
+                - 'MAX_WAIT_MINUTES={{ MaxWaitMinutes }} FORCE_IGNORE_BUSY={{ ForceIgnoreBusy }} FORCE_RESTART={{ ForceRestart }} /usr/local/bin/refresh-graph-container.sh; rc=$?; [ "$rc" -eq 3 ] && exit 0; exit $rc'
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-graph-refresh"
+        - Key: Environment
+          Value: !Ref Environment
+        - Key: Service
+          Value: !Ref ServiceTag
+        - Key: Component
+          Value: !Ref ComponentTag
+        - Key: CreatedBy
+          Value: CloudFormation
+
   GraphContainerRefreshFunction:
     Type: AWS::Lambda::Function
     DeletionPolicy: Delete
@@ -869,6 +948,7 @@ Resources:
         Variables:
           ENVIRONMENT: !Ref Environment
           ALERT_TOPIC_ARN: !Ref InfraAlertTopic
+          REFRESH_DOCUMENT_NAME: !Ref GraphRefreshDocument
       Code:
         ImageUri: !Ref LambdaImageUri
       ImageConfig:
@@ -905,12 +985,13 @@ Resources:
           PolicyDocument:
             Version: "2012-10-17"
             Statement:
-              # SendCommand is scoped to the document AND to instances carrying
-              # this environment's Service tag, so this role cannot be used to
-              # run shell on arbitrary instances in the account.
+              # SendCommand is scoped to the stack's own refresh document AND to
+              # instances carrying this environment's Service tag: the role can
+              # trigger a refresh on this environment's fleet, not run arbitrary
+              # shell on it.
               - Effect: Allow
                 Action: ssm:SendCommand
-                Resource: !Sub "arn:${AWS::Partition}:ssm:${AWS::Region}::document/AWS-RunShellScript"
+                Resource: !Sub "arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:document/${GraphRefreshDocument}"
               - Effect: Allow
                 Action: ssm:SendCommand
                 Resource: !Sub "arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:instance/*"
@@ -939,6 +1020,13 @@ Resources:
   # Failure notification is push, not poll. Previously a failed refresh surfaced
   # only as a red job in a workflow someone had to be watching; nothing paged.
   # This fires regardless of whether anyone is looking at the run.
+  #
+  # Filtered to this stack's own document — the only environment- or
+  # purpose-specific field an SSM invocation event carries. Unfiltered, this
+  # pattern matched every failed SSM command in the account, so one prod
+  # failure paged BOTH environments' topics with each stamping its own
+  # environment name into the message, and unrelated commands (secrets
+  # rotation, maintenance sweeps) paged as "graph container refresh".
   GraphRefreshFailureRule:
     Type: AWS::Events::Rule
     Properties:
@@ -951,6 +1039,8 @@ Resources:
         detail-type:
           - EC2 Command Invocation Status-change Notification
         detail:
+          document-name:
+            - !Ref GraphRefreshDocument
           status:
             - Failed
             - TimedOut

--- a/tests/infrastructure/test_userdata_refresh.py
+++ b/tests/infrastructure/test_userdata_refresh.py
@@ -22,11 +22,12 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = REPO_ROOT / "bin" / "userdata" / "common" / "refresh-graph-container.sh"
 LAMBDA = REPO_ROOT / "bin" / "lambda" / "graph_container_refresh.py"
+TEMPLATE = REPO_ROOT / "cloudformation" / "graph-infra.yaml"
 
-# Exit codes the script uses to mean "this instance has not picked up the new
-# deployment yet." The refresh Lambda classifies these as skips rather than
-# failures, so they are a contract between two files — see
-# TestExitCodeContract at the bottom.
+# The exit code the script uses to mean "this instance has not picked up the new
+# deployment yet." The fleet-refresh document normalizes it to 0 and the Lambda
+# classifies the skip off the REFRESH_RESULT marker, so the skip semantics are a
+# contract across three files — see TestSkipContract at the bottom.
 EXIT_STALE_ENV = 3
 
 REQUIRED_ENV = {
@@ -352,33 +353,44 @@ class TestImageTag:
     assert not any(pull.endswith(":prod") for pull in result.pulls)
 
 
-class TestExitCodeContract:
-  """The skip exit codes are a contract between the script and its aggregator.
+class TestSkipContract:
+  """The skip semantics are a contract across three files.
 
-  SSM records any non-zero exit as `Failed`, so something has to know that 3 and
-  4 mean "this instance has not cycled onto the new scripts yet, and its
-  container was deliberately left alone." If the script's codes drift from the
-  aggregator's classification, an un-cycled fleet goes from a warning back to a
-  failed deploy — the exact regression this pairing exists to prevent, and one
-  nothing else would catch. The aggregator moved from the composite action to the
-  Lambda when the per-instance matrix was retired; the contract did not change.
+  The script exits 3 for a stale /etc/environment, printing a REFRESH_RESULT
+  marker alongside. The fleet-refresh SSM document (graph-infra.yaml) guards for
+  a missing script and normalizes both skip shapes to exit 0 — SSM counts every
+  non-zero exit toward MaxErrors, so a skip that exits non-zero burns the error
+  budget and terminates the rest of the fleet's invocations. The Lambda then
+  classifies skips off the markers, never off an exit code. If any leg drifts, an
+  un-cycled fleet goes from a warning back to a failed deploy (or back to
+  cascade-terminating itself) — regressions nothing else would catch, and the
+  second of which shipped in the document's first fleet-wide prod run.
   """
 
-  def test_lambda_classifies_the_scripts_stale_env_code_as_a_skip(self):
-    script = SCRIPT.read_text()
-    handler = LAMBDA.read_text()
-    assert f"EXIT_STALE_ENV={EXIT_STALE_ENV}" in script
-    assert f'{EXIT_STALE_ENV}: "skipped-stale-env"' in handler
-
-  def test_lambda_guards_for_a_missing_script(self):
+  def test_document_guards_for_a_missing_script_and_exits_zero(self):
     """Instances install common scripts at boot, so an un-cycled instance has no
-    script to run. That must be a distinct exit code rather than an inference
-    from bash's 127, which a missing `docker` would also produce.
+    script to run. The guard's marker must be a distinct signal rather than an
+    inference from bash's 127, which a missing `docker` would also produce —
+    and it must exit 0, or one un-cycled instance terminates the whole rollout.
     """
+    template = TEMPLATE.read_text()
+    assert "REFRESH_RESULT=skipped-no-script; exit 0" in template
+
+  def test_document_normalizes_the_scripts_stale_env_exit(self):
+    script = SCRIPT.read_text()
+    template = TEMPLATE.read_text()
+    assert f"EXIT_STALE_ENV={EXIT_STALE_ENV}" in script
+    assert f'[ "$rc" -eq {EXIT_STALE_ENV} ] && exit 0' in template
+
+  def test_lambda_classifies_skips_off_the_markers(self):
+    """The markers the script and document emit must be exactly the ones the
+    Lambda treats as skips."""
     handler = LAMBDA.read_text()
-    assert "-x {REFRESH_SCRIPT}" in handler or "-x /usr/local/bin" in handler
-    assert "exit 4" in handler
-    assert '4: "skipped-no-script"' in handler
+    script = SCRIPT.read_text()
+    template = TEMPLATE.read_text()
+    assert '"skipped-no-script", "skipped-stale-env"' in handler
+    assert "REFRESH_RESULT=skipped-stale-env" in script
+    assert "REFRESH_RESULT=skipped-no-script" in template
 
   def test_skips_are_excluded_from_the_failure_count(self):
     """`failed` is what the workflow fails on, so skips must not reach it."""

--- a/tests/lambda/conftest.py
+++ b/tests/lambda/conftest.py
@@ -39,6 +39,7 @@ def aws_env(monkeypatch):
     "INSTANCE_REGISTRY_TABLE", "robosystems-graph-test-instance-registry"
   )
   monkeypatch.setenv("ALERT_TOPIC_ARN", "arn:aws:sns:us-east-1:123456789012:test-topic")
+  monkeypatch.setenv("REFRESH_DOCUMENT_NAME", "robosystems-graph-test-graph-refresh")
   monkeypatch.setenv(
     "VOLUME_MANAGER_FUNCTION_ARN",
     "arn:aws:lambda:us-east-1:123456789012:function:test-volume-manager",

--- a/tests/lambda/test_graph_container_refresh.py
+++ b/tests/lambda/test_graph_container_refresh.py
@@ -7,11 +7,16 @@ list, so a wrong expression does not error — it matches nothing and reports
 success. SSM ANDs across target keys and ORs within one, which is why "all"
 cannot be a single command and is instead one per node-type group.
 
-**Skip classification.** SSM records any non-zero exit as `Failed`. Exit 3 and 4
-mean "this instance has not cycled onto the new scripts, and its container was
-deliberately left running" — a transitional state. If those leak into the failure
-count, an un-cycled fleet fails a deploy, which is the regression this
-classification exists to prevent.
+**Skip classification.** A skip — "this instance has not cycled onto the new
+scripts, and its container was deliberately left running" — is a transitional
+state that must not fail a deploy. The refresh document normalizes skip exits to
+0 (a non-zero exit consumes SSM's MaxErrors budget and terminates the rest of
+the fleet's invocations), and the Lambda classifies skips off the
+REFRESH_RESULT stdout marker, never off an exit code. If skips leak into the
+failure count, an un-cycled fleet fails a deploy, which is the regression this
+classification exists to prevent — and which shipped once, precisely because
+the original classification read `ResponseCode` at the invocation level, a
+field the real API only sets on the plugin.
 """
 
 from unittest.mock import patch
@@ -21,12 +26,28 @@ import pytest
 pytestmark = pytest.mark.unit
 
 
-def _invocation(status: str, response_code: int | None, output: str = ""):
-  inv = {"InstanceId": "i-abc", "Status": status}
+def _invocation(
+  status: str,
+  response_code: int | None = None,
+  output: str = "",
+  status_details: str = "",
+):
+  """Shape an invocation the way `list_command_invocations(Details=True)`
+  actually returns it: the exit code lives on the plugin, never on the
+  invocation. The first version of this fixture put ResponseCode at the
+  invocation level — a shape the real API never produces — which is exactly how
+  the classification bug these tests exist to catch survived them.
+  """
+  inv: dict = {"InstanceId": "i-abc", "Status": status}
+  if status_details:
+    inv["StatusDetails"] = status_details
+  plugin: dict = {}
   if response_code is not None:
-    inv["ResponseCode"] = response_code
+    plugin["ResponseCode"] = response_code
   if output:
-    inv["CommandPlugins"] = [{"Output": output}]
+    plugin["Output"] = output
+  if plugin:
+    inv["CommandPlugins"] = [plugin]
   return inv
 
 
@@ -55,24 +76,22 @@ class TestTargeting:
       gcr._targets_for("nonsense", "prod")
 
 
-class TestCommandConstruction:
-  def test_guard_precedes_the_refresh_and_owns_exit_4(self, gcr):
-    commands = gcr._build_commands(30, False, False)
-    assert len(commands) == 2
-    assert commands[0].startswith("[ -x /usr/local/bin/refresh-graph-container.sh ]")
-    assert "exit 4" in commands[0]
-    assert commands[1].endswith("/usr/local/bin/refresh-graph-container.sh")
+class TestParameterConstruction:
+  """The wrapper shell lives in the document (graph-infra.yaml); the Lambda only
+  supplies the per-dispatch values. tests/infrastructure covers the document's
+  side of that contract."""
 
-  def test_overrides_are_passed_as_env_prefixes(self, gcr):
-    commands = gcr._build_commands(45, True, True)
-    assert "MAX_WAIT_MINUTES=45" in commands[1]
-    assert "FORCE_IGNORE_BUSY=true" in commands[1]
-    assert "FORCE_RESTART=true" in commands[1]
+  def test_overrides_become_document_parameters(self, gcr):
+    params = gcr._build_parameters(45, True, True, 3600)
+    assert params["MaxWaitMinutes"] == ["45"]
+    assert params["ForceIgnoreBusy"] == ["true"]
+    assert params["ForceRestart"] == ["true"]
+    assert params["ExecutionTimeout"] == ["3600"]
 
   def test_force_flags_default_to_false(self, gcr):
-    commands = gcr._build_commands(30, False, False)
-    assert "FORCE_IGNORE_BUSY=false" in commands[1]
-    assert "FORCE_RESTART=false" in commands[1]
+    params = gcr._build_parameters(30, False, False, 2700)
+    assert params["ForceIgnoreBusy"] == ["false"]
+    assert params["ForceRestart"] == ["false"]
 
 
 class TestStart:
@@ -84,16 +103,27 @@ class TestStart:
     assert ssm.send_command.call_count == len(gcr.ALL_GROUPS)
     assert [c["node_type"] for c in result["commands"]] == gcr.ALL_GROUPS
 
+  def test_dispatches_the_stack_owned_document(self, gcr):
+    """Never AWS-RunShellScript: the failure-paging rule filters on the document
+    name, so the generic document would silently un-scope the page."""
+    with patch.object(gcr, "ssm") as ssm:
+      ssm.send_command.return_value = {"Command": {"CommandId": "cmd-1"}}
+      gcr.start({"node_types": "writer"})
+
+    kwargs = ssm.send_command.call_args.kwargs
+    assert kwargs["DocumentName"] == gcr.REFRESH_DOCUMENT
+    assert kwargs["DocumentName"] != "AWS-RunShellScript"
+
   def test_execution_timeout_exceeds_the_busy_wait(self, gcr):
-    """Left implicit, AWS-RunShellScript defaults to 3600s and a raised wait would
-    silently truncate the command mid-refresh."""
+    """Left implicit, a raised wait would silently truncate the command
+    mid-refresh."""
     with patch.object(gcr, "ssm") as ssm:
       ssm.send_command.return_value = {"Command": {"CommandId": "cmd-1"}}
       result = gcr.start({"node_types": "writer", "max_wait_minutes": 50})
 
     assert result["execution_timeout_seconds"] > 50 * 60
     params = ssm.send_command.call_args.kwargs["Parameters"]
-    assert params["executionTimeout"] == [str(result["execution_timeout_seconds"])]
+    assert params["ExecutionTimeout"] == [str(result["execution_timeout_seconds"])]
 
   def test_rate_control_defaults_are_applied_by_the_lambda(self, gcr):
     """Not just by the caller — otherwise a hand-rolled invocation hits the fleet
@@ -117,24 +147,50 @@ class TestStatusSkipClassification:
       ssm.get_paginator.return_value = _Paginator()
       return gcr.status({"command_id": "cmd-1"})
 
-  def test_stale_env_exit_is_a_skip_not_a_failure(self, gcr):
-    result = self._status(gcr, [_invocation("Failed", 3)])
-    assert result["failed"] == 0
-    assert result["skipped"] == 1
-    assert result["refresh_results"]["skipped-stale-env"] == 1
-
-  def test_missing_script_exit_is_a_skip_not_a_failure(self, gcr):
-    result = self._status(gcr, [_invocation("Failed", 4)])
+  def test_skips_arrive_as_success_and_classify_off_the_marker(self, gcr):
+    """The document normalizes skip exits to 0, so a skip is a Success
+    invocation whose only distinguishing feature is its stdout marker."""
+    result = self._status(
+      gcr, [_invocation("Success", 0, "REFRESH_RESULT=skipped-no-script")]
+    )
     assert result["failed"] == 0
     assert result["skipped"] == 1
     assert result["refresh_results"]["skipped-no-script"] == 1
 
+  def test_stale_env_marker_is_a_skip_not_a_failure(self, gcr):
+    result = self._status(
+      gcr, [_invocation("Success", 0, "REFRESH_RESULT=skipped-stale-env")]
+    )
+    assert result["failed"] == 0
+    assert result["skipped"] == 1
+    assert result["refresh_results"]["skipped-stale-env"] == 1
+
+  def test_a_hand_run_skip_with_a_raw_exit_code_gets_the_same_grace(self, gcr):
+    """Running refresh-graph-container.sh outside the document exits 3 with the
+    marker on stdout; the marker, not the exit code, is the signal."""
+    result = self._status(
+      gcr,
+      [_invocation("Failed", 3, "[refresh] ...\nREFRESH_RESULT=skipped-stale-env")],
+    )
+    assert result["failed"] == 0
+    assert result["skipped"] == 1
+
   def test_a_real_failure_still_counts(self, gcr):
     """127 from a missing binary inside the script is a genuine failure and must
-    not be downgraded just because it is also non-zero."""
+    not be downgraded just because a marker-less non-zero exit could look like
+    the old skip shape."""
     result = self._status(gcr, [_invocation("Failed", 127)])
     assert result["failed"] == 1
     assert result["skipped"] == 0
+    assert result["failures"][0]["response_code"] == "127"
+
+  def test_terminated_before_running_is_a_failure_with_no_exit_code(self, gcr):
+    """MaxErrors tripping elsewhere in the fleet terminates queued invocations;
+    SSM marks them Failed/Terminated with a plugin ResponseCode of -1."""
+    result = self._status(gcr, [_invocation("Failed", -1, status_details="Terminated")])
+    assert result["failed"] == 1
+    assert result["failures"][0]["response_code"] == ""
+    assert result["failures"][0]["status_details"] == "Terminated"
 
   def test_refresh_result_is_read_from_stdout(self, gcr):
     result = self._status(
@@ -149,7 +205,7 @@ class TestStatusSkipClassification:
       [
         _invocation("Success", 0, "REFRESH_RESULT=updated"),
         _invocation("Success", 0, "REFRESH_RESULT=no-op"),
-        _invocation("Failed", 4),
+        _invocation("Success", 0, "REFRESH_RESULT=skipped-no-script"),
         _invocation("Failed", 1),
       ],
     )


### PR DESCRIPTION
## Summary

The fleet-command graph refresh (#1141, 4b1e6390) hit prod for the first time in tonight's deploy and false-failed: all six writers predate the on-instance refresh script (launched 2026-08-02), which is the designed skip state — but the run went red, five of six writers never even reported, and both environments' infra-alert topics paged for the one prod event (the staging email claimed a staging failure that never happened).

Three defects, one per layer:

1. **Lambda misread the exit code.** `status()` read `ResponseCode` from the invocation, but SSM only sets it on `CommandPlugins[]` — so the skip mapping never fired and skips counted as failures. Classification now keys on the `REFRESH_RESULT` stdout marker; the plugin-level exit code is kept for failure detail only (including `status_details` to distinguish "ran and failed" from "Terminated before running").

2. **Skips burned the MaxErrors budget.** Skips exited 3/4, and SSM counts any non-zero exit toward `MaxErrors` — with 10% + serial concurrency, the first skip terminated the rest of the fleet's invocations. The wrapper now lives in a stack-owned `AWS::SSM::Document` that normalizes both skip shapes to exit 0, with the stdout marker as the signal. Real failures keep non-zero exits, so MaxErrors still halts a genuinely bad rollout.

3. **Paging was account-wide and env-blind.** The EventBridge rule matched every failed SSM invocation in the account; both env stacks' rules fired on any one event, each stamping its own `${Environment}` into the message. The rule now filters on `detail.document-name` — the only environment- or purpose-specific field the event carries. Side benefit: the Lambda role's `SendCommand` narrows from `AWS-RunShellScript` to the one refresh document.

The test fixture that let defect 1 through (it modeled `ResponseCode` at the invocation level — a shape the real API never returns) now mirrors the actual `list_command_invocations` response, and the script ↔ document ↔ Lambda skip contract is pinned across all three files in `tests/infrastructure/test_userdata_refresh.py`.

## Behavior after this lands

- A not-yet-cycled fleet reports `skipped-*` per instance, warns in the job summary, and the deploy stays green — no page.
- A real failure still fails the job, still halts the rollout via MaxErrors, and still pages — now exactly once, from the right environment.
- Unrelated SSM command failures (secrets rotation, maintenance sweeps) no longer page as "graph container refresh".

The writer fleet still needs an ASG cycle (`graph-asg-refresh.yml`) to pick up the refresh script; until then refreshes report as skips, which is the designed transitional state.

## Testing

- `tests/lambda/test_graph_container_refresh.py` — 21 tests incl. new marker-based classification, hand-run grace, terminated-invocation shape, document dispatch
- `tests/infrastructure/test_userdata_refresh.py` — script behavior suite + rewritten three-file skip contract
- `just cf-lint graph-infra` clean; full `just test-code` green
