### PR TITLE
fix(graph-refresh): keep the REFRESH_RESULT marker inside SSM's output truncation window

### DIFF
--- a/cloudformation/graph-infra.yaml
+++ b/cloudformation/graph-infra.yaml
@@ -872,6 +872,14 @@ Resources:
   # queued invocations — a uniformly not-yet-cycled fleet could never even
   # report itself. Real failures keep their non-zero exits, so MaxErrors still
   # halts a bad rollout and the rule below still pages.
+  #
+  # Output forwarding: the script's output is captured to an on-instance log
+  # and only the REFRESH_RESULT line plus a bounded tail are echoed back. SSM
+  # truncates a plugin's inline Output after 2500 characters keeping the head,
+  # and the script prints its marker last — after docker-pull progress — so on
+  # a real image refresh the marker fell outside the window and the Lambda
+  # classified nothing (empty refresh_results on this document's first
+  # fleet-wide prod run). Marker first + 2000-byte tail fits by construction.
   GraphRefreshDocument:
     Type: AWS::SSM::Document
     Properties:
@@ -886,7 +894,9 @@ Resources:
           Instances that have not yet cycled onto the refresh script (or whose
           /etc/environment predates the completeness contract) exit 0 with a
           REFRESH_RESULT=skipped-* marker rather than consuming the MaxErrors
-          budget.
+          budget. Inline output carries the REFRESH_RESULT marker first, then a
+          bounded tail; full output is kept on the instance at
+          /var/log/graph-refresh-last.log.
         parameters:
           MaxWaitMinutes:
             type: String
@@ -915,7 +925,11 @@ Resources:
               timeoutSeconds: "{{ ExecutionTimeout }}"
               runCommand:
                 - '[ -x /usr/local/bin/refresh-graph-container.sh ] || { echo REFRESH_RESULT=skipped-no-script; exit 0; }'
-                - 'MAX_WAIT_MINUTES={{ MaxWaitMinutes }} FORCE_IGNORE_BUSY={{ ForceIgnoreBusy }} FORCE_RESTART={{ ForceRestart }} /usr/local/bin/refresh-graph-container.sh; rc=$?; [ "$rc" -eq 3 ] && exit 0; exit $rc'
+                - 'LOG=/var/log/graph-refresh-last.log'
+                - 'MAX_WAIT_MINUTES={{ MaxWaitMinutes }} FORCE_IGNORE_BUSY={{ ForceIgnoreBusy }} FORCE_RESTART={{ ForceRestart }} /usr/local/bin/refresh-graph-container.sh >"$LOG" 2>&1; rc=$?'
+                - 'grep "^REFRESH_RESULT=" "$LOG" || true'
+                - 'tail -c 2000 "$LOG"'
+                - '[ "$rc" -eq 3 ] && exit 0; exit $rc'
       Tags:
         - Key: Name
           Value: !Sub "${AWS::StackName}-graph-refresh"

--- a/tests/infrastructure/test_userdata_refresh.py
+++ b/tests/infrastructure/test_userdata_refresh.py
@@ -397,3 +397,37 @@ class TestSkipContract:
     handler = LAMBDA.read_text()
     assert '"failed": len(failures)' in handler
     assert '"skipped": skipped' in handler
+
+
+class TestMarkerVisibility:
+  """The REFRESH_RESULT marker must land inside SSM's truncation window.
+
+  ListCommandInvocations truncates each plugin's inline Output after 2500
+  characters, keeping the head. The script prints its marker last — after
+  docker-pull progress — so on a real image refresh the marker fell outside
+  the window and the Lambda classified nothing (empty refresh_results on the
+  document's first fleet-wide prod run; the skip and no-op paths survived only
+  because they exit before the pull). The document therefore captures the
+  script's output to an on-instance log and forwards the marker first,
+  followed by a bounded tail: marker + 2000-byte tail fits the 2500-character
+  window by construction.
+  """
+
+  def test_document_forwards_the_marker_before_the_log_tail(self):
+    template = TEMPLATE.read_text()
+    marker_at = template.find('grep "^REFRESH_RESULT=" "$LOG"')
+    tail_at = template.find('tail -c 2000 "$LOG"')
+    assert marker_at != -1, "document no longer forwards the marker line"
+    assert tail_at != -1, "document no longer forwards a bounded log tail"
+    assert marker_at < tail_at, "marker must precede the tail or truncation eats it"
+
+  def test_document_captures_the_scripts_output_to_the_log(self):
+    """Both streams: on failure the tail is the only inline diagnostic left."""
+    template = TEMPLATE.read_text()
+    assert '>"$LOG" 2>&1' in template
+
+  def test_skip_normalization_still_reads_the_captured_exit_code(self):
+    """The redirect moved the exit-code capture onto its own line; the exit-3
+    normalization must keep consuming that same $rc, not a fresh $?."""
+    template = TEMPLATE.read_text()
+    assert 'refresh-graph-container.sh >"$LOG" 2>&1; rc=$?' in template


### PR DESCRIPTION
## Problem

The first fleet-wide prod run of the #1145 refresh path (deploy run 31556246144) came back green — `Success: 6, failed: 0, skipped: 0` — but with an empty `refresh_results` map: the job summary could no longer say whether the fleet actually picked up the new image (`updated`) or silently didn't (`no-op`).

Root cause: SSM truncates a plugin's inline `Output` after 2500 characters, keeping the head. The refresh script emits `REFRESH_RESULT=` as its **last** line — after docker-pull progress — so on a real image refresh the marker falls outside the window and the Lambda's marker parse finds nothing. The skip and no-op paths were unaffected only because they exit before the pull; last night's rerun (`no-op: 6`) worked for exactly that reason.

## Fix

The SSM document (not the userdata script, so this ships via CloudFormation on a normal deploy — no fleet cycle needed) now captures the script's output to `/var/log/graph-refresh-last.log` on the instance and forwards inline only:

1. the `REFRESH_RESULT=` line (grepped from the log, first), then
2. a 2000-byte tail of the log — so marker + tail fit the 2500-char window by construction, and a failure still surfaces its final error output inline.

Full output stays on the instance for debugging. The exit-3 skip normalization is unchanged and keeps consuming the captured `$rc`.

## Tests

New `TestMarkerVisibility` class pins the contract: marker forwarded before the tail, both streams captured to the log, and the skip normalization reading the captured exit code. Existing `TestSkipContract` assertions all still hold. 49 passed; cfn-lint clean.

## Verification after deploy

The next deploy carrying a new graph image should show `updated: N` in the refresh-graph job summary instead of an empty table.