### PR TITLE
Add minimal SCIM 2.0 provisioning for dedicated deployments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,10 +31,8 @@ LOG_LEVEL=INFO
 # PORT=8000
 
 ## Docker Image Configuration
-## - New users: Keep these to pull pre-built images (~10s download)
-## - Developers: Comment out to build locally from Dockerfile (~3 min build)
-## Images are cached after the first pull — run `just upgrade` to fetch newer ones
-## (works in both modes; a plain `just start` will keep running the cached image)
+## Keep these to pull pre-built images; comment out to build locally from the
+## Dockerfile. Images cache after first pull — `just upgrade` fetches newer ones.
 ROBOSYSTEMS_IMAGE=robofinsystems/robosystems:latest
 ROBOSYSTEMS_PULL_POLICY=if_not_present
 
@@ -133,6 +131,16 @@ INTUIT_REDIRECT_URI=http://localhost:3001/connections/qb-callback
 # TURNSTILE_SECRET_KEY=
 # TURNSTILE_SITE_KEY=
 
+## Enterprise SSO (OIDC + SCIM) — dedicated deployments only
+## Connection to the customer IdP; enable via SSO_OIDC_ENABLED / SCIM_ENABLED
+## in FEATURE FLAGS. Issuer is the org authorization server
+## (e.g. https://<org>.okta.com, not /oauth2/default).
+# SSO_OIDC_ISSUER=
+# SSO_OIDC_CLIENT_ID=
+# SSO_OIDC_CLIENT_SECRET=
+# SSO_OIDC_PROVIDER_LABEL=SSO
+# SSO_DEFAULT_ROLE=member
+
 ## Cloudflare R2 (zero-egress downloads)
 # R2_ACCESS_KEY_ID=
 # R2_SECRET_ACCESS_KEY=
@@ -151,10 +159,8 @@ R2_PUBLIC_URL=https://pub-d1753a082ea941e38d5a696fae8248f5.r2.dev
 ## In prod, IAM roles provide credentials via instance metadata
 AWS_REGION=us-east-1
 AWS_ENDPOINT_URL=http://localstack:4566
-# Browser-reachable endpoint for presigned-URL signing. Containers use the
-# docker DNS hostname above for internal S3 traffic, but presigned URLs are
-# consumed by the host browser which can't resolve "localstack". Unset in
-# staging/prod — real AWS endpoints are already browser-reachable.
+# Browser-reachable endpoint for presigned URLs (the host can't resolve the
+# "localstack" docker hostname). Dev only — unset in staging/prod.
 AWS_S3_PRESIGN_ENDPOINT_URL=http://localhost:4566
 AWS_ACCESS_KEY_ID=test
 AWS_SECRET_ACCESS_KEY=test
@@ -178,14 +184,11 @@ AWS_BEDROCK_SECRET_ACCESS_KEY=your-bedrock-secret-key
 ## Env var name: Same as below (e.g., USER_REGISTRATION_ENABLED)
 
 ## Extensions — RoboLedger & RoboInvestor product surfaces
-## Per-domain flags. EXTENSIONS_ENABLED is derived from these (no longer
-## a standalone env var). EXTENSIONS_GRAPHQL_ENABLED is a kill switch for
-## the GraphQL endpoint, kept as defense-in-depth.
+## EXTENSIONS_GRAPHQL_ENABLED is the GraphQL endpoint kill switch.
 # ROBOLEDGER_ENABLED=true
 # ROBOINVESTOR_ENABLED=true
 # EXTENSIONS_GRAPHQL_ENABLED=true
-# Period-close autopilot: when true the Dagster sensor drafts the closing entry
-# on the same tick a schedule matures. Default false (co-pilot); per-graph column overrides.
+# Period-close autopilot: sensor drafts the closing entry when a schedule matures
 # EXTENSIONS_PROMOTION_AUTO_DISPATCH=false
 
 ## Platform Operations
@@ -200,25 +203,12 @@ OTEL_ENABLED=false
 SECURITY_AUDIT_ENABLED=false
 # EMAIL_VERIFICATION_ENABLED=false
 # CAPTCHA_ENABLED=false
-## Auth posture surfaced by GET /v1/auth/providers
+## Auth posture (GET /v1/auth/providers). SSO/SCIM connection config is in SECRETS.
 # PASSWORD_AUTH_ENABLED=true
 # SSO_OIDC_ENABLED=false
-# SSO_OIDC_PROVIDER_LABEL=SSO
-## OIDC connection (required when SSO_OIDC_ENABLED=true). The issuer is the
-## IdP org authorization server (e.g. https://<org>.okta.com — NOT
-## /oauth2/default); the client secret comes from Secrets Manager in
-## prod/staging and from here in dev.
-# SSO_OIDC_ISSUER=
-# SSO_OIDC_CLIENT_ID=
-# SSO_OIDC_CLIENT_SECRET=
-# RATE_LIMIT_OIDC=120
-## SCIM 2.0 provisioning (IdP pushes users into the enterprise org)
 # SCIM_ENABLED=false
-# SSO_DEFAULT_ROLE=member
-# RATE_LIMIT_SCIM=120
 # PASSKEYS_ENABLED=false
-## Verification/reset/invitation email links target the login home (with
-## return_to context) instead of the originating app
+# Auth email links target the login home (with return_to) not the origin app
 # AUTH_EMAIL_LINKS_TO_LOGIN_HOME=false
 
 ## Organization
@@ -233,16 +223,12 @@ SECURITY_AUDIT_ENABLED=false
 # MCP_AUTO_LIMIT_ENABLED=true
 # MCP_WORKSPACE_ENABLED=true
 # MCP_GRAPHQL_ENABLED=true
-# Subgraph write/DDL MCP tools (write-graph-cypher, add-node-table,
-# add-relationship-table). Renamed from the former MCP_MEMORY_ENABLED.
+# Subgraph write/DDL MCP tools (write-graph-cypher, add-node-table, add-relationship-table)
 # MCP_SUBGRAPH_OPS_ENABLED=true
 # MCP_SEMANTIC_MEMORY_ENABLED=false
-# AI semantic memory (LanceDB) — master gate (REST + ops + recall + governance);
-# MCP_SEMANTIC_MEMORY_ENABLED is the additional MCP-tool sub-gate.
+# AI semantic memory (LanceDB) master gate; MCP_SEMANTIC_MEMORY_ENABLED is the MCP sub-gate
 # SEMANTIC_MEMORY_ENABLED=false
-# Tenant framework authoring (reporting_extension/custom_ontology taxonomy
-# blocks, create+update). Default: on in dev/test, OFF in prod/staging
-# (fail-closed; flip via SSM features/TAXONOMY_AUTHORING_ENABLED + restart).
+# Tenant framework authoring (taxonomy blocks). On in dev/test, off in prod/staging
 # TAXONOMY_AUTHORING_ENABLED=true
 
 ## Shared Repository Operations
@@ -254,11 +240,9 @@ SECURITY_AUDIT_ENABLED=false
 # CONNECTIONS_ENABLED=true
 # CONNECTION_QUICKBOOKS_ENABLED=true
 # CONNECTION_EXTERNAL_ENABLED=true
-# Off by default and in every deployed environment — the filing-driven entity
-# creation path predates the shared SEC repository. Set true to bring it back.
+# Filing-driven entity creation from SEC connections
 # CONNECTION_SEC_ENABLED=false
-# Route QB Reports API through Intuit's v2 service (ahead of their 2026-08-31
-# hard cutover). Set false to fall back to v1 at runtime. Retires after cutover.
+# Route QB Reports API through Intuit's v2 service (false = v1)
 # INTUIT_REPORTS_TESTING_MIGRATION=true
 
 ## Adapter Pipelines

--- a/.env.example
+++ b/.env.example
@@ -212,6 +212,10 @@ SECURITY_AUDIT_ENABLED=false
 # SSO_OIDC_CLIENT_ID=
 # SSO_OIDC_CLIENT_SECRET=
 # RATE_LIMIT_OIDC=120
+## SCIM 2.0 provisioning (IdP pushes users into the enterprise org)
+# SCIM_ENABLED=false
+# SSO_DEFAULT_ROLE=member
+# RATE_LIMIT_SCIM=120
 # PASSKEYS_ENABLED=false
 ## Verification/reset/invitation email links target the login home (with
 ## return_to context) instead of the originating app

--- a/main.py
+++ b/main.py
@@ -67,6 +67,9 @@ from robosystems.routers.admin import (
   orgs_router as admin_orgs_router,
 )
 from robosystems.routers.admin import (
+  scim_router as admin_scim_router,
+)
+from robosystems.routers.admin import (
   subscription_router as admin_subscription_router,
 )
 from robosystems.routers.admin import (
@@ -85,7 +88,7 @@ logger = get_logger("robosystems.api")
 # Path prefixes whose responses may contain per-user secrets (tokens,
 # API keys, billing details, org membership). These get `Cache-Control:
 # no-store` applied in the security-headers middleware.
-_SENSITIVE_PATH_PREFIXES = ("/v1/auth", "/v1/user", "/v1/billing", "/v1/orgs")
+_SENSITIVE_PATH_PREFIXES = ("/v1/auth", "/v1/user", "/v1/billing", "/v1/orgs", "/scim")
 
 
 def csp_variant_for_path(path: str) -> str:
@@ -472,6 +475,12 @@ def create_app() -> FastAPI:
   app.include_router(operations_router_v1)
   app.include_router(billing_router_v1)
 
+  # SCIM 2.0 provisioning — flag-gated (the managed platform never mounts it).
+  if env.SCIM_ENABLED:
+    from robosystems.routers.scim import router as scim_router
+
+    app.include_router(scim_router)
+
   # Extensions GraphQL endpoint (Strawberry). Graph-scoped at
   # /extensions/{graph_id}/graphql — see robosystems/graphql/README.md.
   if env.EXTENSIONS_GRAPHQL_ENABLED and (
@@ -556,6 +565,7 @@ def create_app() -> FastAPI:
   app.include_router(admin_graphs_router, include_in_schema=False)
   app.include_router(admin_users_router, include_in_schema=False)
   app.include_router(admin_orgs_router, include_in_schema=False)
+  app.include_router(admin_scim_router, include_in_schema=False)
 
   def custom_openapi():
     """Generate the OpenAPI schema, then layer on this API's own conventions.

--- a/pytest.ini
+++ b/pytest.ini
@@ -28,6 +28,7 @@ env =
     INTUIT_CLIENT_SECRET=test-intuit-secret
     INTUIT_ENVIRONMENT=sandbox
     INTUIT_REDIRECT_URI=http://localhost:8000/auth/callback
+    SCIM_ENABLED=true
     JWT_SECRET_KEY=test-jwt-secret-key-12345678901234567890abcdef
     CONNECTION_CREDENTIALS_KEY=test-connection-credentials-key-12345678901234567890abcdef
     GRAPH_API_URL=http://localhost:8001

--- a/robosystems/admin/cli.py
+++ b/robosystems/admin/cli.py
@@ -38,6 +38,7 @@ from ..logger import get_logger
 from .commands.billing import credits, invoices, subscriptions
 from .commands.graphs import graphs
 from .commands.ops import cache, instances, migrations
+from .commands.scim import scim
 from .commands.search import search
 from .commands.users_orgs import orgs, users
 from .commands.worker import worker
@@ -347,6 +348,7 @@ cli.add_command(orgs)
 cli.add_command(migrations)
 cli.add_command(cache)
 cli.add_command(instances)
+cli.add_command(scim)
 cli.add_command(search)
 cli.add_command(worker)
 

--- a/robosystems/admin/commands/scim.py
+++ b/robosystems/admin/commands/scim.py
@@ -1,0 +1,58 @@
+"""SCIM provisioning administration commands (thin HTTP wrappers)."""
+
+import click
+from rich.console import Console
+
+console = Console()
+
+
+@click.group()
+def scim():
+  """Manage SCIM provisioning for dedicated tenants."""
+  pass
+
+
+@scim.command("bootstrap")
+@click.option("--org-id", help="Attach the token to this existing org.")
+@click.option(
+  "--org-name", help="Create a new ENTERPRISE org with this name (omit --org-id)."
+)
+@click.option("--token-name", default="scim-provisioning", help="Label for the token.")
+@click.pass_obj
+def bootstrap(client, org_id, org_name, token_name):
+  """Create-or-reuse the enterprise org and mint a SCIM token.
+
+  The raw token prints ONCE and is never recoverable — paste it into the
+  customer's IdP now.
+  """
+  if not org_id and not org_name:
+    raise click.UsageError("Provide either --org-id or --org-name.")
+
+  data = {"token_name": token_name}
+  if org_id:
+    data["org_id"] = org_id
+  if org_name:
+    data["org_name"] = org_name
+
+  result = client._make_request("POST", "/admin/v1/scim/bootstrap", data=data)
+
+  console.print()
+  console.print(f"[bold]Org:[/bold] {result['org_name']} ({result['org_id']})")
+  console.print(f"[bold]Token ID:[/bold] {result['scim_token_id']}")
+  console.print()
+  console.print("[bold yellow]SCIM bearer token (shown once):[/bold yellow]")
+  console.print(f"[green]{result['token']}[/green]")
+  console.print()
+  console.print("[dim]Paste this into the IdP's SCIM connector now.[/dim]")
+
+
+@scim.command("revoke-token")
+@click.argument("token_id")
+@click.pass_obj
+def revoke_token(client, token_id):
+  """Revoke a SCIM token by id."""
+  result = client._make_request("POST", f"/admin/v1/scim/tokens/{token_id}/revoke")
+  if result.get("revoked"):
+    console.print(f"[green]Revoked SCIM token {token_id}.[/green]")
+  else:
+    console.print(f"[yellow]SCIM token {token_id} was not revoked.[/yellow]")

--- a/robosystems/config/env.py
+++ b/robosystems/config/env.py
@@ -487,6 +487,14 @@ class EnvConfig:
   # which mints API access tokens rather than sign-in ID tokens).
   SSO_OIDC_ISSUER = get_str_env("SSO_OIDC_ISSUER", "")
   SSO_OIDC_CLIENT_ID = get_str_env("SSO_OIDC_CLIENT_ID", "")
+  # SCIM 2.0 provisioning surface (IdP pushes users into the enterprise org).
+  # Gated independently of OIDC — a deployment may run one without the other.
+  SCIM_ENABLED = get_bool_env(
+    "SCIM_ENABLED",
+    get_parameter_value("SCIM_ENABLED", "false").lower() == "true",
+  )
+  # Org role SCIM-provisioned users join the enterprise org with.
+  SSO_DEFAULT_ROLE = get_str_env("SSO_DEFAULT_ROLE", "member")
   PASSKEYS_ENABLED = get_bool_env(
     "PASSKEYS_ENABLED",
     get_parameter_value("PASSKEYS_ENABLED", "false").lower() == "true",

--- a/robosystems/middleware/auth/scim.py
+++ b/robosystems/middleware/auth/scim.py
@@ -1,0 +1,76 @@
+"""SCIM bearer-token authentication.
+
+The SCIM surface has its own credential (``scim_tokens``, per-org) and its own
+auth path. A SCIM token is accepted **only** here; user JWTs and API keys are
+never accepted at ``/scim/v2``, and a SCIM token is never accepted by the
+normal auth dependencies. Failures answer with the SCIM error envelope, not
+FastAPI's ``{"detail": ...}``.
+"""
+
+from fastapi import Depends, HTTPException, Request, status
+from sqlalchemy.orm import Session
+
+from ...db.platform import get_db_session
+from ...logger import get_logger
+from ...models.api.scim import ERROR_SCHEMA
+from ...models.core import ScimToken
+from ...security.audit_logger import SecurityAuditLogger, SecurityEventType
+
+logger = get_logger(__name__)
+
+
+def _scim_unauthorized() -> HTTPException:
+  # SCIM error envelope, not the default detail shape.
+  return HTTPException(
+    status_code=status.HTTP_401_UNAUTHORIZED,
+    detail={
+      "schemas": [ERROR_SCHEMA],
+      "detail": "Invalid or missing SCIM bearer token",
+      "status": "401",
+    },
+    headers={"WWW-Authenticate": "Bearer"},
+  )
+
+
+def require_scim_org(
+  request: Request,
+  session: Session = Depends(get_db_session),
+) -> str:
+  """Authenticate a SCIM request and return the token's org scope.
+
+  Resolves the presented bearer to an active, unexpired ``scim_tokens`` row,
+  stamps its ``last_used_at``, and publishes the org on
+  ``request.state.scim_org_id``. Never distinguishes unknown / revoked /
+  expired in the response.
+  """
+  auth_header = request.headers.get("Authorization", "")
+  client_ip = request.client.host if request.client else None
+
+  if not auth_header.startswith("Bearer "):
+    SecurityAuditLogger.log_security_event(
+      event_type=SecurityEventType.SCIM_AUTH_FAILURE,
+      ip_address=client_ip,
+      user_agent=request.headers.get("User-Agent"),
+      endpoint=str(request.url.path),
+      details={"failure_reason": "missing_bearer"},
+      risk_level="high",
+    )
+    raise _scim_unauthorized()
+
+  token = ScimToken.validate_token(auth_header[7:], session)
+  if token is None:
+    SecurityAuditLogger.log_security_event(
+      event_type=SecurityEventType.SCIM_AUTH_FAILURE,
+      ip_address=client_ip,
+      user_agent=request.headers.get("User-Agent"),
+      endpoint=str(request.url.path),
+      details={"failure_reason": "invalid_token"},
+      risk_level="high",
+    )
+    raise _scim_unauthorized()
+
+  token.update_last_used(session)
+  org_id = str(token.org_id)
+  request.state.scim_org_id = org_id
+  request.state.scim_token_id = str(token.id)
+  return org_id

--- a/robosystems/middleware/rate_limits/__init__.py
+++ b/robosystems/middleware/rate_limits/__init__.py
@@ -23,6 +23,7 @@ from .rate_limiting import (
   oidc_rate_limit_dependency,
   public_api_rate_limit_dependency,
   rate_limit_dependency,
+  scim_rate_limit_dependency,
   sensitive_auth_rate_limit_dependency,
   sse_connection_rate_limit_dependency,
   sso_rate_limit_dependency,
@@ -75,6 +76,7 @@ __all__ = [
   "rate_limit_cache",
   # Main rate limiting
   "rate_limit_dependency",
+  "scim_rate_limit_dependency",
   "sensitive_auth_rate_limit_dependency",
   "should_use_subscription_limits",
   "sse_connection_rate_limit_dependency",

--- a/robosystems/middleware/rate_limits/rate_limiting.py
+++ b/robosystems/middleware/rate_limits/rate_limiting.py
@@ -419,6 +419,12 @@ def oidc_rate_limit_dependency(request: Request):
   return create_custom_rate_limit_dependency(limit, 60, "oidc")(request)
 
 
+def scim_rate_limit_dependency(request: Request):
+  """Rate limiting for the SCIM provisioning surface (server-to-server)."""
+  limit = get_int_env("RATE_LIMIT_SCIM", "120")  # 120/minute
+  return create_custom_rate_limit_dependency(limit, 60, "scim")(request)
+
+
 def general_api_rate_limit_dependency(request: Request):
   """General rate limiting for standard API endpoints."""
   limit = get_int_env("RATE_LIMIT_GENERAL_API", "200")  # 200/minute

--- a/robosystems/middleware/rate_limits/rate_limiting.py
+++ b/robosystems/middleware/rate_limits/rate_limiting.py
@@ -294,12 +294,21 @@ def get_user_from_request(request: Request) -> str | None:
 
 # Custom rate limiting dependencies for different endpoint categories
 def create_custom_rate_limit_dependency(
-  limit_per_hour: int, window_seconds: int = 3600, limit_name: str = "custom"
+  limit_per_hour: int,
+  window_seconds: int = 3600,
+  limit_name: str = "custom",
+  identifier_fn=None,
 ):
-  """Create a custom rate limiting dependency with specific limits."""
+  """Create a custom rate limiting dependency with specific limits.
+
+  ``identifier_fn`` overrides how the bucket key is derived from the request
+  (default: ``get_user_identifier``). Return an ``apikey:``/``jwt:``-prefixed
+  string to grant the full limit, anything else for the anonymous 1/10th.
+  """
+  resolve_identifier = identifier_fn or get_user_identifier
 
   def dependency(request: Request):
-    identifier = get_user_identifier(request)
+    identifier = resolve_identifier(request)
 
     # Include limit_name in the cache key to isolate each rate limit category
     # This prevents high-limit endpoints from polluting low-limit endpoint counters
@@ -419,10 +428,31 @@ def oidc_rate_limit_dependency(request: Request):
   return create_custom_rate_limit_dependency(limit, 60, "oidc")(request)
 
 
+def _scim_rate_limit_identifier(request: Request) -> str:
+  """Key the SCIM bucket off the bearer token, not the caller IP.
+
+  The SCIM token is an opaque ``rfss...`` string that ``get_user_identifier``
+  cannot reparse, so without this it would fall to the anonymous IP path —
+  throttling a legitimate IdP full-sync to a tenth of the budget and making
+  every tenant behind one egress IP share a bucket. The token *hash* is the
+  key; the raw token never lands in a cache key.
+  """
+  auth_header = request.headers.get("Authorization", "")
+  if auth_header.startswith("Bearer "):
+    import hashlib
+
+    token_hash = hashlib.sha256(auth_header[7:].encode()).hexdigest()
+    return f"apikey:scim:{token_hash}"
+  # No bearer → anonymous; the request 401s at require_scim_org anyway.
+  return get_user_identifier(request)
+
+
 def scim_rate_limit_dependency(request: Request):
   """Rate limiting for the SCIM provisioning surface (server-to-server)."""
-  limit = get_int_env("RATE_LIMIT_SCIM", "120")  # 120/minute
-  return create_custom_rate_limit_dependency(limit, 60, "scim")(request)
+  limit = get_int_env("RATE_LIMIT_SCIM", "120")  # 120/minute per token
+  return create_custom_rate_limit_dependency(
+    limit, 60, "scim", identifier_fn=_scim_rate_limit_identifier
+  )(request)
 
 
 def general_api_rate_limit_dependency(request: Request):

--- a/robosystems/models/api/admin/__init__.py
+++ b/robosystems/models/api/admin/__init__.py
@@ -27,6 +27,11 @@ from .graphs import (
 )
 from .invoice import InvoiceLineItemResponse, InvoiceResponse
 from .orgs import OrgGraphInfo, OrgResponse, OrgUpdateRequest, OrgUserInfo
+from .scim import (
+  ScimBootstrapRequest,
+  ScimBootstrapResponse,
+  ScimTokenRevokeResponse,
+)
 from .subscription import (
   SubscriptionCreateRequest,
   SubscriptionResponse,
@@ -69,6 +74,9 @@ __all__ = [
   "OrgUserInfo",
   "RepositoryCreditPoolResponse",
   "ResetCreditPoolRequest",
+  "ScimBootstrapRequest",
+  "ScimBootstrapResponse",
+  "ScimTokenRevokeResponse",
   "SubscriptionCreateRequest",
   "SubscriptionResponse",
   "SubscriptionUpdateRequest",

--- a/robosystems/models/api/admin/scim.py
+++ b/robosystems/models/api/admin/scim.py
@@ -1,0 +1,29 @@
+"""SCIM administration API models (admin surface, not the SCIM wire format)."""
+
+from pydantic import BaseModel, Field
+
+
+class ScimBootstrapRequest(BaseModel):
+  """Create-or-reuse the enterprise org and mint a SCIM token for it."""
+
+  org_id: str | None = Field(
+    default=None, description="Attach the token to this existing org."
+  )
+  org_name: str | None = Field(
+    default=None,
+    description="Create a new ENTERPRISE org with this name (when org_id is omitted).",
+  )
+  token_name: str = Field(default="scim-provisioning")
+
+
+class ScimBootstrapResponse(BaseModel):
+  org_id: str
+  org_name: str
+  scim_token_id: str
+  # The raw bearer token, shown exactly once — paste it into the IdP now.
+  token: str
+
+
+class ScimTokenRevokeResponse(BaseModel):
+  scim_token_id: str
+  revoked: bool

--- a/robosystems/models/api/scim.py
+++ b/robosystems/models/api/scim.py
@@ -1,0 +1,104 @@
+"""SCIM 2.0 request/response envelopes (RFC 7643 / 7644).
+
+Minimal Users-only surface: enough for Okta's Create/Read/Update/Deactivate
+and its filtered dedupe. Field names follow the SCIM schema verbatim (camelCase
+via aliases) so the wire format is spec-compliant regardless of our internal
+snake_case.
+"""
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+USER_SCHEMA = "urn:ietf:params:scim:schemas:core:2.0:User"
+LIST_RESPONSE_SCHEMA = "urn:ietf:params:scim:api:messages:2.0:ListResponse"
+ERROR_SCHEMA = "urn:ietf:params:scim:api:messages:2.0:Error"
+PATCH_OP_SCHEMA = "urn:ietf:params:scim:api:messages:2.0:PatchOp"
+
+
+class ScimName(BaseModel):
+  model_config = ConfigDict(populate_by_name=True, extra="ignore")
+
+  formatted: str | None = None
+  given_name: str | None = Field(default=None, alias="givenName")
+  family_name: str | None = Field(default=None, alias="familyName")
+
+
+class ScimEmail(BaseModel):
+  model_config = ConfigDict(populate_by_name=True, extra="ignore")
+
+  value: str
+  primary: bool = True
+  type: str | None = "work"
+
+
+class ScimMeta(BaseModel):
+  model_config = ConfigDict(populate_by_name=True)
+
+  resource_type: str = Field(default="User", alias="resourceType")
+  location: str | None = None
+  created: str | None = None
+  last_modified: str | None = Field(default=None, alias="lastModified")
+
+
+class ScimUserResource(BaseModel):
+  """A SCIM User resource as returned to the IdP."""
+
+  model_config = ConfigDict(populate_by_name=True)
+
+  schemas: list[str] = Field(default_factory=lambda: [USER_SCHEMA])
+  id: str
+  external_id: str | None = Field(default=None, alias="externalId")
+  user_name: str = Field(alias="userName")
+  name: ScimName | None = None
+  emails: list[ScimEmail] = Field(default_factory=list)
+  active: bool = True
+  meta: ScimMeta | None = None
+
+
+class ScimUserCreateRequest(BaseModel):
+  """Inbound POST/PUT body. Liberal in what it accepts (extra ignored)."""
+
+  model_config = ConfigDict(populate_by_name=True, extra="ignore")
+
+  schemas: list[str] | None = None
+  user_name: str = Field(alias="userName")
+  external_id: str | None = Field(default=None, alias="externalId")
+  name: ScimName | None = None
+  emails: list[ScimEmail] = Field(default_factory=list)
+  active: bool = True
+  # displayName / other core attrs are accepted-and-ignored via extra="ignore".
+
+
+class ScimListResponse(BaseModel):
+  model_config = ConfigDict(populate_by_name=True)
+
+  schemas: list[str] = Field(default_factory=lambda: [LIST_RESPONSE_SCHEMA])
+  total_results: int = Field(alias="totalResults")
+  start_index: int = Field(default=1, alias="startIndex")
+  items_per_page: int = Field(alias="itemsPerPage")
+  resources: list[ScimUserResource] = Field(default_factory=list, alias="Resources")
+
+
+class ScimPatchOperation(BaseModel):
+  model_config = ConfigDict(populate_by_name=True, extra="ignore")
+
+  op: str
+  path: str | None = None
+  value: Any = None
+
+
+class ScimPatchRequest(BaseModel):
+  model_config = ConfigDict(populate_by_name=True, extra="ignore")
+
+  schemas: list[str] | None = None
+  operations: list[ScimPatchOperation] = Field(alias="Operations")
+
+
+class ScimError(BaseModel):
+  model_config = ConfigDict(populate_by_name=True)
+
+  schemas: list[str] = Field(default_factory=lambda: [ERROR_SCHEMA])
+  detail: str
+  status: str
+  scim_type: str | None = Field(default=None, alias="scimType")

--- a/robosystems/operations/admin/__init__.py
+++ b/robosystems/operations/admin/__init__.py
@@ -1,5 +1,11 @@
 """Administrative operations — support-plane actions with no self-serve surface."""
 
+from .scim_bootstrap import (
+  OrgNotFoundError,
+  ScimBootstrapResult,
+  bootstrap_scim,
+  revoke_scim_token,
+)
 from .user_deletion import (
   DeletionBlocker,
   UserDeletionBlocked,
@@ -12,11 +18,15 @@ from .user_status import UserStatusChange, set_user_active
 
 __all__ = [
   "DeletionBlocker",
+  "OrgNotFoundError",
+  "ScimBootstrapResult",
   "UserDeletionBlocked",
   "UserDeletionPlan",
   "UserNotFound",
   "UserStatusChange",
+  "bootstrap_scim",
   "execute_user_deletion",
   "plan_user_deletion",
+  "revoke_scim_token",
   "set_user_active",
 ]

--- a/robosystems/operations/admin/scim_bootstrap.py
+++ b/robosystems/operations/admin/scim_bootstrap.py
@@ -1,0 +1,78 @@
+"""Bootstrap a dedicated tenant's SCIM provisioning.
+
+Stands up the one ``ENTERPRISE`` org SCIM users land in, and mints the bearer
+token the customer's IdP presents. A step in the dedicated-tenant lifecycle,
+run once per tenant from the admin CLI. The raw token is returned exactly once
+— it is never recoverable after this call.
+"""
+
+from dataclasses import dataclass
+
+from sqlalchemy.orm import Session
+
+from robosystems.logger import logger
+from robosystems.models.core import Org, OrgLimits, OrgType, ScimToken
+
+
+class ScimBootstrapError(Exception):
+  """Base class for bootstrap failures."""
+
+
+class OrgNotFoundError(ScimBootstrapError):
+  """A supplied org id does not resolve."""
+
+
+@dataclass(frozen=True)
+class ScimBootstrapResult:
+  org_id: str
+  org_name: str
+  scim_token_id: str
+  # Shown once; only its hash is stored.
+  raw_token: str
+
+
+def bootstrap_scim(
+  session: Session,
+  *,
+  org_name: str | None = None,
+  org_id: str | None = None,
+  token_name: str = "scim-provisioning",
+) -> ScimBootstrapResult:
+  """Create-or-reuse the enterprise org and mint a SCIM token for it.
+
+  Pass ``org_id`` to attach a token to an existing org, or ``org_name`` to
+  create a fresh ``ENTERPRISE`` org (with default limits) first.
+  """
+  if org_id is not None:
+    org = Org.get_by_id(org_id, session)
+    if org is None:
+      raise OrgNotFoundError(f"Org {org_id} not found")
+  else:
+    org = Org.create(
+      name=org_name or "Enterprise",
+      org_type=OrgType.ENTERPRISE,
+      session=session,
+    )
+    OrgLimits.create_default_limits(org.id, session)
+
+  token, raw_token = ScimToken.create(org.id, token_name, session)
+
+  logger.info(
+    f"Bootstrapped SCIM for org {org.id}",
+    extra={"org_id": org.id, "scim_token_id": token.id, "token_name": token_name},
+  )
+  return ScimBootstrapResult(
+    org_id=str(org.id),
+    org_name=str(org.name),
+    scim_token_id=str(token.id),
+    raw_token=raw_token,
+  )
+
+
+def revoke_scim_token(session: Session, token_id: str) -> bool:
+  """Revoke a SCIM token by id. Returns False if it does not exist."""
+  token = ScimToken.get_by_id(token_id, session)
+  if token is None:
+    return False
+  token.revoke(session)
+  return True

--- a/robosystems/routers/admin/__init__.py
+++ b/robosystems/routers/admin/__init__.py
@@ -5,6 +5,7 @@ from .credits import router as credits_router
 from .graphs import router as graphs_router
 from .invoice import router as invoice_router
 from .orgs import router as orgs_router
+from .scim import router as scim_router
 from .subscription import router as subscription_router
 from .users import router as users_router
 from .webhooks import router as webhooks_router
@@ -15,6 +16,7 @@ __all__ = [
   "graphs_router",
   "invoice_router",
   "orgs_router",
+  "scim_router",
   "subscription_router",
   "users_router",
   "webhooks_router",

--- a/robosystems/routers/admin/scim.py
+++ b/robosystems/routers/admin/scim.py
@@ -1,0 +1,81 @@
+"""Admin API for SCIM provisioning bootstrap (support-plane, ALB-isolated)."""
+
+from fastapi import APIRouter, HTTPException, Request, status
+
+from ...db.platform import get_db_session
+from ...logger import get_logger
+from ...middleware.auth.admin import require_admin
+from ...models.api.admin import (
+  ScimBootstrapRequest,
+  ScimBootstrapResponse,
+  ScimTokenRevokeResponse,
+)
+from ...operations.admin import (
+  OrgNotFoundError,
+  bootstrap_scim,
+  revoke_scim_token,
+)
+
+logger = get_logger(__name__)
+
+router = APIRouter(prefix="/admin/v1/scim", tags=["admin-scim"])
+
+
+@router.post("/bootstrap", response_model=ScimBootstrapResponse)
+@require_admin(permissions=["orgs:write"])
+async def scim_bootstrap(
+  request: Request, data: ScimBootstrapRequest
+) -> ScimBootstrapResponse:
+  """Create-or-reuse the enterprise org and mint a SCIM token.
+
+  The raw token is returned once and never recoverable — paste it into the
+  customer's IdP immediately.
+  """
+  session = next(get_db_session())
+  try:
+    try:
+      result = bootstrap_scim(
+        session,
+        org_name=data.org_name,
+        org_id=data.org_id,
+        token_name=data.token_name,
+      )
+    except OrgNotFoundError as exc:
+      raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
+
+    logger.info(
+      "Admin bootstrapped SCIM",
+      extra={
+        "admin_key_id": request.state.admin_key_id,
+        "org_id": result.org_id,
+        "scim_token_id": result.scim_token_id,
+      },
+    )
+    return ScimBootstrapResponse(
+      org_id=result.org_id,
+      org_name=result.org_name,
+      scim_token_id=result.scim_token_id,
+      token=result.raw_token,
+    )
+  finally:
+    session.close()
+
+
+@router.post("/tokens/{token_id}/revoke", response_model=ScimTokenRevokeResponse)
+@require_admin(permissions=["orgs:write"])
+async def scim_revoke_token(request: Request, token_id: str) -> ScimTokenRevokeResponse:
+  """Revoke a SCIM token, immediately refusing further provisioning with it."""
+  session = next(get_db_session())
+  try:
+    revoked = revoke_scim_token(session, token_id)
+    if not revoked:
+      raise HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND, detail=f"SCIM token {token_id} not found"
+      )
+    logger.info(
+      "Admin revoked SCIM token",
+      extra={"admin_key_id": request.state.admin_key_id, "scim_token_id": token_id},
+    )
+    return ScimTokenRevokeResponse(scim_token_id=token_id, revoked=True)
+  finally:
+    session.close()

--- a/robosystems/routers/scim/__init__.py
+++ b/robosystems/routers/scim/__init__.py
@@ -1,0 +1,24 @@
+"""SCIM 2.0 provisioning surface, mounted at /scim/v2.
+
+Every endpoint sits behind the per-org SCIM bearer dependency (which also
+publishes ``request.state.scim_org_id``) and the SCIM rate bucket, so both the
+conformance probes and the Users CRUD are authenticated uniformly. A user JWT
+or API key is never accepted here.
+"""
+
+from fastapi import APIRouter, Depends
+
+from ...middleware.auth.scim import require_scim_org
+from ...middleware.rate_limits import scim_rate_limit_dependency
+from .config import router as config_router
+from .users import router as users_router
+
+router = APIRouter(
+  prefix="/scim/v2",
+  tags=["SCIM"],
+  dependencies=[Depends(scim_rate_limit_dependency), Depends(require_scim_org)],
+)
+router.include_router(config_router)
+router.include_router(users_router)
+
+__all__ = ["router"]

--- a/robosystems/routers/scim/config.py
+++ b/robosystems/routers/scim/config.py
@@ -1,0 +1,106 @@
+"""SCIM service-discovery endpoints (RFC 7643 §5-8).
+
+Okta/Entra probe these before provisioning to learn what the server supports.
+Static JSON — the values describe the minimal Users-only surface this build
+implements (no Groups, PATCH supported, one filter).
+"""
+
+from fastapi import APIRouter
+
+from ...config import env
+from ...models.api.scim import USER_SCHEMA
+
+router = APIRouter()
+
+
+def _base_url() -> str:
+  return f"{env.ROBOSYSTEMS_API_URL}/scim/v2"
+
+
+@router.get("/ServiceProviderConfig", include_in_schema=False)
+async def service_provider_config() -> dict:
+  return {
+    "schemas": ["urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig"],
+    "documentationUri": "https://docs.robosystems.ai/scim",
+    "patch": {"supported": True},
+    "bulk": {"supported": False, "maxOperations": 0, "maxPayloadSize": 0},
+    "filter": {"supported": True, "maxResults": 200},
+    "changePassword": {"supported": False},
+    "sort": {"supported": False},
+    "etag": {"supported": False},
+    "authenticationSchemes": [
+      {
+        "type": "oauthbearertoken",
+        "name": "OAuth Bearer Token",
+        "description": "Authentication via a per-org SCIM bearer token.",
+        "primary": True,
+      }
+    ],
+    "meta": {
+      "location": f"{_base_url()}/ServiceProviderConfig",
+      "resourceType": "ServiceProviderConfig",
+    },
+  }
+
+
+@router.get("/ResourceTypes", include_in_schema=False)
+async def resource_types() -> dict:
+  user_type = {
+    "schemas": ["urn:ietf:params:scim:schemas:core:2.0:ResourceType"],
+    "id": "User",
+    "name": "User",
+    "endpoint": "/Users",
+    "description": "User Account",
+    "schema": USER_SCHEMA,
+    "meta": {
+      "location": f"{_base_url()}/ResourceTypes/User",
+      "resourceType": "ResourceType",
+    },
+  }
+  return {
+    "schemas": ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
+    "totalResults": 1,
+    "startIndex": 1,
+    "itemsPerPage": 1,
+    "Resources": [user_type],
+  }
+
+
+@router.get("/Schemas", include_in_schema=False)
+async def schemas() -> dict:
+  user_schema = {
+    "id": USER_SCHEMA,
+    "name": "User",
+    "description": "User Account",
+    "attributes": [
+      {
+        "name": "userName",
+        "type": "string",
+        "multiValued": False,
+        "required": True,
+        "caseExact": False,
+        "mutability": "readWrite",
+        "returned": "default",
+        "uniqueness": "server",
+      },
+      {
+        "name": "active",
+        "type": "boolean",
+        "multiValued": False,
+        "required": False,
+        "mutability": "readWrite",
+        "returned": "default",
+      },
+    ],
+    "meta": {
+      "resourceType": "Schema",
+      "location": f"{_base_url()}/Schemas/{USER_SCHEMA}",
+    },
+  }
+  return {
+    "schemas": ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
+    "totalResults": 1,
+    "startIndex": 1,
+    "itemsPerPage": 1,
+    "Resources": [user_schema],
+  }

--- a/robosystems/routers/scim/users.py
+++ b/robosystems/routers/scim/users.py
@@ -1,0 +1,318 @@
+"""SCIM 2.0 Users endpoints, scoped to the bearer token's org.
+
+Create/Read/Update/Deactivate plus the one filter Okta sends before creating
+(``userName eq``), which is the brownfield dedupe path. Everything delegates
+to ``operations/user_provisioning`` for create and to ``User.deactivate`` /
+``User.activate`` for the active toggle — the latter is the offboarding
+kill-switch (session_version bump + API-key revocation) auditors buy.
+"""
+
+import re
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Query, Request, status
+from sqlalchemy.orm import Session
+
+from ...config import env
+from ...db.platform import get_db_session
+from ...logger import get_logger
+from ...models.api.scim import (
+  ERROR_SCHEMA,
+  ScimEmail,
+  ScimListResponse,
+  ScimMeta,
+  ScimName,
+  ScimPatchRequest,
+  ScimUserCreateRequest,
+  ScimUserResource,
+)
+from ...models.core import Org, OrgRole, OrgUser, User
+from ...operations.user_provisioning import (
+  EmailAlreadyRegisteredError,
+  provision_user,
+)
+from ...security.audit_logger import SecurityAuditLogger, SecurityEventType
+
+logger = get_logger(__name__)
+
+router = APIRouter()
+
+# `userName eq "value"` — the only filter Okta/Entra send. Anything else is
+# unsupported (an empty ListResponse, never a 500).
+_USERNAME_EQ = re.compile(r'^\s*userName\s+eq\s+"(?P<value>[^"]*)"\s*$', re.IGNORECASE)
+
+
+def _scim_error(
+  status_code: int, detail: str, scim_type: str | None = None
+) -> HTTPException:
+  body: dict[str, Any] = {
+    "schemas": [ERROR_SCHEMA],
+    "detail": detail,
+    "status": str(status_code),
+  }
+  if scim_type:
+    body["scimType"] = scim_type
+  return HTTPException(status_code=status_code, detail=body)
+
+
+def _default_role() -> OrgRole:
+  try:
+    return OrgRole(env.SSO_DEFAULT_ROLE)
+  except ValueError:
+    return OrgRole.MEMBER
+
+
+def _to_resource(user: User) -> ScimUserResource:
+  location = f"{env.ROBOSYSTEMS_API_URL}/scim/v2/Users/{user.id}"
+  created = user.created_at.isoformat() if user.created_at else None
+  modified = user.updated_at.isoformat() if user.updated_at else None
+  return ScimUserResource(
+    id=str(user.id),
+    external_id=user.external_id,
+    user_name=user.email,
+    name=ScimName(formatted=user.name),
+    emails=[ScimEmail(value=user.email, primary=True)],
+    active=bool(user.is_active),
+    meta=ScimMeta(location=location, created=created, last_modified=modified),
+  )
+
+
+def _org_user_or_404(org_id: str, user_id: str, session: Session) -> User:
+  """Resolve a user that belongs to the token's org, else 404.
+
+  Membership is the scope boundary: a token for org A must never read or
+  mutate a user in org B, and must not leak that user's existence — so a
+  cross-org id is indistinguishable from an unknown one.
+  """
+  membership = OrgUser.get_by_org_and_user(org_id, user_id, session)
+  if membership is None:
+    raise _scim_error(status.HTTP_404_NOT_FOUND, "User not found")
+  user = User.get_by_id(user_id, session)
+  if user is None:
+    raise _scim_error(status.HTTP_404_NOT_FOUND, "User not found")
+  return user
+
+
+def _coerce_active(patch: ScimPatchRequest) -> bool | None:
+  """Extract the desired ``active`` state from a PATCH, tolerating Entra.
+
+  Okta is RFC-compliant; Entra (without the compat flag) sends capitalized
+  ``op`` and ``active`` as the string ``"False"``. Accept both shapes for the
+  one operation that must never silently fail — deactivation.
+  """
+  for operation in patch.operations:
+    op = (operation.op or "").lower()
+    if op not in ("replace", "add"):
+      continue
+    path = (operation.path or "").lower()
+    raw: Any = None
+    if path == "active":
+      raw = operation.value
+    elif operation.path is None and isinstance(operation.value, dict):
+      for key, val in operation.value.items():
+        if key.lower() == "active":
+          raw = val
+          break
+    if raw is None:
+      continue
+    if isinstance(raw, bool):
+      return raw
+    if isinstance(raw, str):
+      lowered = raw.strip().lower()
+      if lowered in ("true", "false"):
+        return lowered == "true"
+  return None
+
+
+def _set_active(user: User, active: bool, org_id: str, session: Session) -> None:
+  if bool(user.is_active) == active:
+    return
+  if active:
+    user.activate(session)
+    event = SecurityEventType.SCIM_USER_REACTIVATED
+  else:
+    user.deactivate(session)  # session_version bump + API-key revocation
+    event = SecurityEventType.SCIM_USER_DEACTIVATED
+  SecurityAuditLogger.log_security_event(
+    event_type=event,
+    user_id=str(user.id),
+    details={"action": event.value, "org_id": org_id, "external_id": user.external_id},
+    risk_level="medium",
+  )
+
+
+@router.get("/Users", include_in_schema=False)
+async def list_users(
+  request: Request,
+  filter: str | None = Query(default=None),
+  startIndex: int = Query(default=1, ge=1),
+  count: int = Query(default=100, ge=0, le=200),
+) -> ScimListResponse:
+  org_id = request.state.scim_org_id
+  session = next(get_db_session())
+  try:
+    base = (
+      session.query(User)
+      .join(OrgUser, User.id == OrgUser.user_id)
+      .filter(OrgUser.org_id == org_id)
+    )
+
+    if filter:
+      match = _USERNAME_EQ.match(filter)
+      if not match:
+        # Unsupported filter → empty result, never an error.
+        return ScimListResponse(
+          total_results=0, start_index=startIndex, items_per_page=0
+        )
+      base = base.filter(User.email == match.group("value").lower())
+
+    total = base.count()
+    rows = base.order_by(User.created_at).offset(startIndex - 1).limit(count).all()
+    resources = [_to_resource(u) for u in rows]
+    return ScimListResponse(
+      total_results=total,
+      start_index=startIndex,
+      items_per_page=len(resources),
+      resources=resources,
+    )
+  finally:
+    session.close()
+
+
+@router.post("/Users", status_code=status.HTTP_201_CREATED, include_in_schema=False)
+async def create_user(
+  request: Request, body: ScimUserCreateRequest
+) -> ScimUserResource:
+  org_id = request.state.scim_org_id
+  session = next(get_db_session())
+  try:
+    org = Org.get_by_id(org_id, session)
+    if org is None:
+      raise _scim_error(status.HTTP_404_NOT_FOUND, "Provisioning org not found")
+
+    email = body.user_name.strip().lower()
+    display_name = (
+      (body.name.formatted if body.name else None)
+      or " ".join(
+        p
+        for p in [
+          body.name.given_name if body.name else None,
+          body.name.family_name if body.name else None,
+        ]
+        if p
+      )
+      or email
+    )
+
+    try:
+      provisioned = provision_user(
+        session,
+        email=email,
+        name=display_name,
+        password_hash=None,
+        email_verified=True,  # the IdP asserted the mailbox
+        target_org=org,
+        target_org_role=_default_role(),
+        external_id=body.external_id,
+      )
+    except EmailAlreadyRegisteredError:
+      raise _scim_error(
+        status.HTTP_409_CONFLICT,
+        "A user with this userName already exists",
+        scim_type="uniqueness",
+      )
+
+    user = provisioned.user
+    if not body.active:
+      user.deactivate(session)
+
+    SecurityAuditLogger.log_security_event(
+      event_type=SecurityEventType.SCIM_USER_PROVISIONED,
+      user_id=str(user.id),
+      details={
+        "action": "scim_user_provisioned",
+        "org_id": org_id,
+        "external_id": user.external_id,
+      },
+      risk_level="low",
+    )
+    return _to_resource(user)
+  finally:
+    session.close()
+
+
+@router.get("/Users/{user_id}", include_in_schema=False)
+async def get_user(request: Request, user_id: str) -> ScimUserResource:
+  session = next(get_db_session())
+  try:
+    user = _org_user_or_404(request.state.scim_org_id, user_id, session)
+    return _to_resource(user)
+  finally:
+    session.close()
+
+
+@router.put("/Users/{user_id}", include_in_schema=False)
+async def replace_user(
+  request: Request, user_id: str, body: ScimUserCreateRequest
+) -> ScimUserResource:
+  org_id = request.state.scim_org_id
+  session = next(get_db_session())
+  try:
+    user = _org_user_or_404(org_id, user_id, session)
+
+    new_name = None
+    if body.name:
+      new_name = body.name.formatted or " ".join(
+        p for p in [body.name.given_name, body.name.family_name] if p
+      )
+    if new_name and new_name != user.name:
+      user.update(session, name=new_name)
+
+    _set_active(user, bool(body.active), org_id, session)
+
+    SecurityAuditLogger.log_security_event(
+      event_type=SecurityEventType.SCIM_USER_UPDATED,
+      user_id=str(user.id),
+      details={"action": "scim_user_updated", "org_id": org_id},
+      risk_level="low",
+    )
+    session.refresh(user)
+    return _to_resource(user)
+  finally:
+    session.close()
+
+
+@router.patch("/Users/{user_id}", include_in_schema=False)
+async def patch_user(
+  request: Request, user_id: str, body: ScimPatchRequest
+) -> ScimUserResource:
+  org_id = request.state.scim_org_id
+  session = next(get_db_session())
+  try:
+    user = _org_user_or_404(org_id, user_id, session)
+
+    desired_active = _coerce_active(body)
+    if desired_active is not None:
+      _set_active(user, desired_active, org_id, session)
+
+    session.refresh(user)
+    return _to_resource(user)
+  finally:
+    session.close()
+
+
+@router.delete(
+  "/Users/{user_id}", status_code=status.HTTP_204_NO_CONTENT, include_in_schema=False
+)
+async def delete_user(request: Request, user_id: str) -> None:
+  """SCIM DELETE maps to deactivate, idempotently — never destructive.
+
+  Hard deletion stays the admin-CLI operation with its blocker planner.
+  """
+  org_id = request.state.scim_org_id
+  session = next(get_db_session())
+  try:
+    user = _org_user_or_404(org_id, user_id, session)
+    _set_active(user, False, org_id, session)
+  finally:
+    session.close()

--- a/robosystems/security/audit_logger.py
+++ b/robosystems/security/audit_logger.py
@@ -49,6 +49,12 @@ class SecurityEventType(Enum):
   # OIDC login refused after the IdP authenticated (unprovisioned or
   # deactivated user) — alarm-worthy, unlike ordinary auth noise
   OIDC_LOGIN_DENIED = "oidc_login_denied"
+  # SCIM provisioning lifecycle (operational; only the auth failure alarms)
+  SCIM_USER_PROVISIONED = "scim_user_provisioned"
+  SCIM_USER_UPDATED = "scim_user_updated"
+  SCIM_USER_DEACTIVATED = "scim_user_deactivated"
+  SCIM_USER_REACTIVATED = "scim_user_reactivated"
+  SCIM_AUTH_FAILURE = "scim_auth_failure"
   # Subgraph events
   SUBGRAPH_CREATED = "subgraph_created"
   SUBGRAPH_DELETED = "subgraph_deleted"
@@ -73,6 +79,7 @@ _METRIC_FOR_EVENT: dict[SecurityEventType, str] = {
   SecurityEventType.API_KEY_EXPIRED: "AuthFailure",
   SecurityEventType.AUTHORIZATION_DENIED: "AuthorizationDenied",
   SecurityEventType.OIDC_LOGIN_DENIED: "AuthorizationDenied",
+  SecurityEventType.SCIM_AUTH_FAILURE: "AuthFailure",
   SecurityEventType.INJECTION_ATTEMPT: "InjectionAttempt",
   SecurityEventType.PATH_TRAVERSAL_ATTEMPT: "InjectionAttempt",
   SecurityEventType.PRIVILEGE_ESCALATION_ATTEMPT: "PrivilegeEscalationAttempt",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -145,6 +145,14 @@ def client(test_db):
   app.dependency_overrides[graph_scoped_rate_limit_dependency] = lambda: None
   app.dependency_overrides[sse_connection_rate_limit_dependency] = lambda: None
 
+  from robosystems.middleware.rate_limits import (
+    oidc_rate_limit_dependency,
+    scim_rate_limit_dependency,
+  )
+
+  app.dependency_overrides[oidc_rate_limit_dependency] = lambda: None
+  app.dependency_overrides[scim_rate_limit_dependency] = lambda: None
+
   # Override the get_db_session dependency to use test database
   from robosystems.database import get_async_db_session, get_db_session
 

--- a/tests/middleware/rate_limits/test_rate_limiting.py
+++ b/tests/middleware/rate_limits/test_rate_limiting.py
@@ -360,6 +360,53 @@ class TestBillingRateLimitDependency:
 
 
 @pytest.mark.unit
+class TestScimRateLimitDependency:
+  """The SCIM bucket must key off the bearer token, not the caller IP.
+
+  Regression: the opaque SCIM token isn't recognized by get_user_identifier,
+  so without token-keying it fell to the anonymous IP path (1/10th the limit)
+  and every tenant behind one egress IP shared a bucket.
+  """
+
+  @patch(f"{MODULE}.rate_limit_cache")
+  @patch(f"{MODULE}.get_int_env", return_value=120)
+  def test_bearer_gets_full_limit_not_anonymous_tenth(self, mock_env, mock_cache):
+    from robosystems.middleware.rate_limits.rate_limiting import (
+      scim_rate_limit_dependency,
+    )
+
+    mock_cache.check_rate_limit.return_value = (True, 119)
+    request = _make_request(
+      headers={"Authorization": "Bearer rfssdeadbeef"}, host="10.0.0.9"
+    )
+    scim_rate_limit_dependency(request)
+
+    call_args = mock_cache.check_rate_limit.call_args
+    # Full 120, not the anonymous 12.
+    assert call_args[0][1] == 120
+    # Keyed off the token hash, not the IP.
+    assert call_args[0][0].startswith("apikey:scim:")
+
+  @patch(f"{MODULE}.rate_limit_cache")
+  @patch(f"{MODULE}.get_int_env", return_value=120)
+  def test_two_tokens_same_ip_get_separate_buckets(self, mock_env, mock_cache):
+    from robosystems.middleware.rate_limits.rate_limiting import (
+      scim_rate_limit_dependency,
+    )
+
+    mock_cache.check_rate_limit.return_value = (True, 119)
+    keys = []
+    for token in ("rfssaaa", "rfssbbb"):
+      request = _make_request(
+        headers={"Authorization": f"Bearer {token}"}, host="10.0.0.9"
+      )
+      scim_rate_limit_dependency(request)
+      keys.append(mock_cache.check_rate_limit.call_args[0][0])
+
+    assert keys[0] != keys[1]
+
+
+@pytest.mark.unit
 class TestNamedRateLimitDependencies:
   """Tests for named rate limit dependency functions."""
 

--- a/tests/operations/admin/test_scim_bootstrap.py
+++ b/tests/operations/admin/test_scim_bootstrap.py
@@ -1,0 +1,61 @@
+"""Tests for SCIM provisioning bootstrap."""
+
+import pytest
+
+from robosystems.models.core import Org, OrgLimits, OrgType, ScimToken
+from robosystems.operations.admin import (
+  OrgNotFoundError,
+  bootstrap_scim,
+  revoke_scim_token,
+)
+
+
+class TestBootstrapScim:
+  def test_creates_enterprise_org_with_limits_and_token(self, test_db):
+    result = bootstrap_scim(test_db, org_name="Acme Accounting")
+
+    org = Org.get_by_id(result.org_id, test_db)
+    assert org is not None
+    assert org.org_type == OrgType.ENTERPRISE
+    assert org.name == "Acme Accounting"
+    assert OrgLimits.get_by_org_id(org.id, test_db) is not None
+
+    # The raw token validates against the stored hash; only its hash persists.
+    token = ScimToken.validate_token(result.raw_token, test_db)
+    assert token is not None
+    assert token.id == result.scim_token_id
+    assert token.org_id == org.id
+
+  def test_reuses_existing_org(self, test_db):
+    org = Org.create(name="Existing", org_type=OrgType.ENTERPRISE, session=test_db)
+
+    result = bootstrap_scim(test_db, org_id=org.id, token_name="second-token")
+
+    assert result.org_id == org.id
+    # No duplicate org created.
+    assert len([o for o in Org.get_all(test_db) if o.name == "Existing"]) == 1
+    assert ScimToken.validate_token(result.raw_token, test_db) is not None
+
+  def test_unknown_org_raises(self, test_db):
+    with pytest.raises(OrgNotFoundError):
+      bootstrap_scim(test_db, org_id="org_does_not_exist")
+
+  def test_two_tokens_can_coexist_for_rotation(self, test_db):
+    first = bootstrap_scim(test_db, org_name="Rotation Co")
+    second = bootstrap_scim(test_db, org_id=first.org_id, token_name="rotated")
+
+    # Both live during the swap.
+    assert ScimToken.validate_token(first.raw_token, test_db) is not None
+    assert ScimToken.validate_token(second.raw_token, test_db) is not None
+
+
+class TestRevokeScimToken:
+  def test_revoke_makes_token_invalid(self, test_db):
+    result = bootstrap_scim(test_db, org_name="Revoke Co")
+    assert ScimToken.validate_token(result.raw_token, test_db) is not None
+
+    assert revoke_scim_token(test_db, result.scim_token_id) is True
+    assert ScimToken.validate_token(result.raw_token, test_db) is None
+
+  def test_revoke_unknown_returns_false(self, test_db):
+    assert revoke_scim_token(test_db, "scim_nope") is False

--- a/tests/routers/scim/test_scim_users.py
+++ b/tests/routers/scim/test_scim_users.py
@@ -1,0 +1,246 @@
+"""End-to-end tests for the SCIM /scim/v2 surface.
+
+Uses the real mounted router (SCIM_ENABLED=true in pytest.ini) through the
+shared TestClient, so these exercise the bearer dependency, org-scoping,
+envelope shapes, and the deactivate kill-switch together. A ScimToken is
+minted in the test DB and presented as the bearer.
+"""
+
+import uuid
+
+import pytest
+
+from robosystems.models.core import (
+  Org,
+  OrgRole,
+  OrgType,
+  OrgUser,
+  ScimToken,
+  User,
+)
+
+
+@pytest.fixture
+def enterprise_org(test_db):
+  org = Org.create(
+    name=f"Enterprise {uuid.uuid4().hex[:6]}",
+    org_type=OrgType.ENTERPRISE,
+    session=test_db,
+  )
+  return org
+
+
+@pytest.fixture
+def scim_auth(test_db, enterprise_org):
+  _token, raw = ScimToken.create(enterprise_org.id, "test-scim", test_db)
+  return {"Authorization": f"Bearer {raw}"}
+
+
+def _make_member(test_db, org, *, email=None, external_id="okta-ext", active=True):
+  user = User.create(
+    email=email or f"member+{uuid.uuid4().hex[:8]}@customer.example",
+    name="Member",
+    password_hash=None,
+    session=test_db,
+    external_id=external_id,
+  )
+  OrgUser.create(org.id, user.id, OrgRole.MEMBER, test_db)
+  if not active:
+    user.deactivate(test_db)
+  return user
+
+
+class TestScimAuth:
+  def test_no_token_is_401_scim_envelope(self, client):
+    resp = client.get("/scim/v2/Users")
+    assert resp.status_code == 401
+    body = resp.json()["detail"]
+    assert "urn:ietf:params:scim:api:messages:2.0:Error" in body["schemas"]
+
+  def test_bogus_token_is_401(self, client):
+    resp = client.get(
+      "/scim/v2/Users", headers={"Authorization": "Bearer rfssdeadbeef"}
+    )
+    assert resp.status_code == 401
+
+  def test_user_jwt_is_not_accepted_at_scim(self, client, test_user):
+    # A normal auth token must never authenticate against the SCIM surface.
+    from robosystems.middleware.auth.jwt import create_jwt_token
+
+    jwt = create_jwt_token(test_user.id)
+    resp = client.get("/scim/v2/Users", headers={"Authorization": f"Bearer {jwt}"})
+    assert resp.status_code == 401
+
+
+class TestConformance:
+  def test_service_provider_config(self, client, scim_auth):
+    resp = client.get("/scim/v2/ServiceProviderConfig", headers=scim_auth)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["patch"]["supported"] is True
+    assert body["filter"]["supported"] is True
+    assert body["changePassword"]["supported"] is False
+
+  def test_resource_types_and_schemas(self, client, scim_auth):
+    assert client.get("/scim/v2/ResourceTypes", headers=scim_auth).status_code == 200
+    assert client.get("/scim/v2/Schemas", headers=scim_auth).status_code == 200
+
+
+class TestUsersCrud:
+  def test_create_user_provisions_passwordless_into_org(
+    self, client, scim_auth, enterprise_org, test_db
+  ):
+    email = f"new+{uuid.uuid4().hex[:8]}@customer.example"
+    resp = client.post(
+      "/scim/v2/Users",
+      headers=scim_auth,
+      json={
+        "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+        "userName": email,
+        "externalId": "okta-99",
+        "name": {"givenName": "New", "familyName": "Hire"},
+        "active": True,
+      },
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["userName"] == email
+    assert body["externalId"] == "okta-99"
+    assert body["active"] is True
+    assert body["id"]
+
+    user = User.get_by_email(email, test_db)
+    assert user is not None
+    assert user.password_hash is None
+    assert user.email_verified is True
+    assert OrgUser.get_by_org_and_user(enterprise_org.id, user.id, test_db) is not None
+
+  def test_duplicate_email_is_409_uniqueness(
+    self, client, scim_auth, test_db, enterprise_org
+  ):
+    existing = _make_member(test_db, enterprise_org)
+    resp = client.post(
+      "/scim/v2/Users",
+      headers=scim_auth,
+      json={"userName": existing.email, "externalId": "dup"},
+    )
+    assert resp.status_code == 409
+    assert resp.json()["detail"]["scimType"] == "uniqueness"
+
+  def test_filter_by_username_finds_member(
+    self, client, scim_auth, test_db, enterprise_org
+  ):
+    member = _make_member(test_db, enterprise_org)
+    resp = client.get(
+      "/scim/v2/Users",
+      params={"filter": f'userName eq "{member.email}"'},
+      headers=scim_auth,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["totalResults"] == 1
+    assert body["Resources"][0]["userName"] == member.email
+
+  def test_unsupported_filter_is_empty_not_error(self, client, scim_auth):
+    resp = client.get(
+      "/scim/v2/Users",
+      params={"filter": 'emails.value co "example.com"'},
+      headers=scim_auth,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["totalResults"] == 0
+
+  def test_get_user_by_id(self, client, scim_auth, test_db, enterprise_org):
+    member = _make_member(test_db, enterprise_org)
+    resp = client.get(f"/scim/v2/Users/{member.id}", headers=scim_auth)
+    assert resp.status_code == 200
+    assert resp.json()["id"] == member.id
+
+
+class TestOrgScoping:
+  def test_cannot_read_user_in_another_org(self, client, scim_auth, test_db):
+    """A token for org A must not resolve a user in org B — 404, no leak."""
+    other_org = Org.create(name="Other", org_type=OrgType.ENTERPRISE, session=test_db)
+    foreign = _make_member(test_db, other_org)
+
+    resp = client.get(f"/scim/v2/Users/{foreign.id}", headers=scim_auth)
+    assert resp.status_code == 404
+
+  def test_list_only_returns_own_org_members(
+    self, client, scim_auth, test_db, enterprise_org
+  ):
+    mine = _make_member(test_db, enterprise_org)
+    other_org = Org.create(name="Other2", org_type=OrgType.ENTERPRISE, session=test_db)
+    _make_member(test_db, other_org)
+
+    resp = client.get("/scim/v2/Users", headers=scim_auth)
+    ids = {r["id"] for r in resp.json()["Resources"]}
+    assert mine.id in ids
+    assert len(ids) == 1
+
+
+class TestDeactivation:
+  def test_patch_active_false_kills_sessions_and_keys(
+    self, client, scim_auth, test_db, enterprise_org
+  ):
+    from robosystems.models.core.user.user_api_key import UserAPIKey
+
+    member = _make_member(test_db, enterprise_org)
+    UserAPIKey.create(user_id=member.id, name="k", session=test_db)
+    before = member.session_version or 0
+
+    resp = client.patch(
+      f"/scim/v2/Users/{member.id}",
+      headers=scim_auth,
+      json={
+        "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+        "Operations": [{"op": "replace", "path": "active", "value": False}],
+      },
+    )
+    assert resp.status_code == 200
+    assert resp.json()["active"] is False
+
+    test_db.refresh(member)
+    assert member.is_active is False
+    assert (member.session_version or 0) > before
+    assert UserAPIKey.get_active_by_user_id(str(member.id), test_db) == []
+
+  def test_patch_active_tolerates_entra_string_false(
+    self, client, scim_auth, test_db, enterprise_org
+  ):
+    """Entra (without the compat flag) sends capitalized op and "False" —
+    the most important operation must still deactivate."""
+    member = _make_member(test_db, enterprise_org)
+    resp = client.patch(
+      f"/scim/v2/Users/{member.id}",
+      headers=scim_auth,
+      json={"Operations": [{"op": "Replace", "path": "active", "value": "False"}]},
+    )
+    assert resp.status_code == 200
+    test_db.refresh(member)
+    assert member.is_active is False
+
+  def test_delete_deactivates_idempotently(
+    self, client, scim_auth, test_db, enterprise_org
+  ):
+    member = _make_member(test_db, enterprise_org)
+    assert (
+      client.delete(f"/scim/v2/Users/{member.id}", headers=scim_auth).status_code == 204
+    )
+    test_db.refresh(member)
+    assert member.is_active is False
+    # Idempotent replay.
+    assert (
+      client.delete(f"/scim/v2/Users/{member.id}", headers=scim_auth).status_code == 204
+    )
+
+  def test_patch_reactivate(self, client, scim_auth, test_db, enterprise_org):
+    member = _make_member(test_db, enterprise_org, active=False)
+    resp = client.patch(
+      f"/scim/v2/Users/{member.id}",
+      headers=scim_auth,
+      json={"Operations": [{"op": "replace", "path": "active", "value": True}]},
+    )
+    assert resp.status_code == 200
+    test_db.refresh(member)
+    assert member.is_active is True


### PR DESCRIPTION
## Summary

Tier 2 of the enterprise SSO arc: a flag-gated SCIM 2.0 surface for IdP-driven user provisioning on isolated tenant deployments. Behind `SCIM_ENABLED` (default false); the managed platform never mounts it. Completes the arc atop #1148 (provisioning kernel + `scim_tokens`) and #1149 (OIDC login).

## Changes

- **`middleware/auth/scim.py`**: per-org bearer dependency against `scim_tokens` (sha256-fingerprint lookup → active/expiry → bcrypt verify). A user JWT or API key is never accepted here; a SCIM token is never accepted by the normal auth deps. Publishes `request.state.scim_org_id`; failures answer with the SCIM error envelope.
- **`routers/scim/`** (`/scim/v2`): conformance discovery endpoints; Users `POST/GET/PUT/PATCH/DELETE` + the `userName eq` filter Okta sends before creating. Create delegates to the provisioning kernel (passwordless, IdP-asserted email, into the token's org at `SSO_DEFAULT_ROLE`); the active toggle delegates to the existing deactivate kill-switch (session invalidation + API-key revocation), tolerating both RFC and Entra PATCH shapes; DELETE maps to an idempotent deactivate, never destructive.
- **Bootstrap**: `operations/admin/scim_bootstrap.py` + admin endpoint + CLI (`scim bootstrap` / `scim revoke-token`) create the enterprise org and mint its token once.
- **Wiring**: `SCIM_ENABLED` + `SSO_DEFAULT_ROLE` config, SCIM rate bucket, SCIM audit events, `/scim` added to the no-store sensitive prefixes.

## Tenant isolation

Every endpoint is confined to the token's org: `{id}` operations gate on `OrgUser.get_by_org_and_user`, list joins+filters on the org, and a cross-org id is a 404 (no existence leak). No IDOR.

## Tests

- `tests/routers/scim/`: bearer auth (no token / bogus token / user-JWT-rejected), conformance, Users CRUD, the filter, org-scoping (cross-org read + list both blocked), and the deactivate path proving `session_version` bump + API-key revocation — including the Entra `"False"`-string PATCH shape.
- `tests/operations/admin/test_scim_bootstrap.py`: org+token mint, reuse, rotation coexistence, revoke.
- Full `just test-all` green.

## Security

Ran `/security-review`: no blocking findings. Two authorization observations (global-vs-org-scoped `active`; 409 uniqueness as a platform-wide email oracle) are benign in the single-tenant model SCIM ships in and require schema changes to address — recorded as design follow-ups, out of scope for minimal tier 2.

Not SDK surface (`include_in_schema=False`) — no client churn.