### PR TITLE
feat(auth): harden auth posture gating and SCIM provisioning controls

### DIFF
--- a/main.py
+++ b/main.py
@@ -87,8 +87,16 @@ logger = get_logger("robosystems.api")
 
 # Path prefixes whose responses may contain per-user secrets (tokens,
 # API keys, billing details, org membership). These get `Cache-Control:
-# no-store` applied in the security-headers middleware.
-_SENSITIVE_PATH_PREFIXES = ("/v1/auth", "/v1/user", "/v1/billing", "/v1/orgs", "/scim")
+# no-store` applied in the security-headers middleware. `/admin` is here for
+# the SCIM bootstrap response, which carries a raw bearer token.
+_SENSITIVE_PATH_PREFIXES = (
+  "/v1/auth",
+  "/v1/user",
+  "/v1/billing",
+  "/v1/orgs",
+  "/scim",
+  "/admin",
+)
 
 
 def csp_variant_for_path(path: str) -> str:

--- a/robosystems/admin/commands/scim.py
+++ b/robosystems/admin/commands/scim.py
@@ -18,8 +18,14 @@ def scim():
   "--org-name", help="Create a new ENTERPRISE org with this name (omit --org-id)."
 )
 @click.option("--token-name", default="scim-provisioning", help="Label for the token.")
+@click.option(
+  "--expires-in-days",
+  default=365,
+  type=click.IntRange(1, 3650),
+  help="Token lifetime. Rotate with an overlapping second token before expiry.",
+)
 @click.pass_obj
-def bootstrap(client, org_id, org_name, token_name):
+def bootstrap(client, org_id, org_name, token_name, expires_in_days):
   """Create-or-reuse the enterprise org and mint a SCIM token.
 
   The raw token prints ONCE and is never recoverable — paste it into the
@@ -28,7 +34,7 @@ def bootstrap(client, org_id, org_name, token_name):
   if not org_id and not org_name:
     raise click.UsageError("Provide either --org-id or --org-name.")
 
-  data = {"token_name": token_name}
+  data = {"token_name": token_name, "expires_in_days": expires_in_days}
   if org_id:
     data["org_id"] = org_id
   if org_name:
@@ -39,6 +45,7 @@ def bootstrap(client, org_id, org_name, token_name):
   console.print()
   console.print(f"[bold]Org:[/bold] {result['org_name']} ({result['org_id']})")
   console.print(f"[bold]Token ID:[/bold] {result['scim_token_id']}")
+  console.print(f"[bold]Expires:[/bold] {result['expires_at']}")
   console.print()
   console.print("[bold yellow]SCIM bearer token (shown once):[/bold yellow]")
   console.print(f"[green]{result['token']}[/green]")

--- a/robosystems/admin/commands/users_orgs.py
+++ b/robosystems/admin/commands/users_orgs.py
@@ -180,6 +180,8 @@ def deactivate_user(client, identifier, yes):
 
   result = client._make_request("POST", f"/admin/v1/users/{user_id}/deactivate")
 
+  fully_applied = result.get("fully_applied", True)
+
   console.print(f"\n[green]Deactivated {result['email']}[/green]")
   console.print(f"  API keys revoked: {result['api_keys_revoked']}")
   if result.get("api_keys_failed"):
@@ -187,9 +189,19 @@ def deactivate_user(client, identifier, yes):
       f"[red]  {result['api_keys_failed']} API key(s) could NOT be revoked — "
       f"the account is only partially locked down. Re-run this command.[/red]"
     )
-  console.print("  All sessions invalidated.")
+  if fully_applied:
+    console.print("  All sessions invalidated.")
+  else:
+    console.print(
+      "[red]  Revocation side effects incompletely applied — a cached "
+      "session or key may keep authenticating until its TTL. Re-run this "
+      "command.[/red]"
+    )
   if not result["changed"]:
     console.print("[yellow]  (was already inactive — re-ran the revocation)[/yellow]")
+
+  if not fully_applied:
+    raise SystemExit(1)
 
 
 @users.command("activate")

--- a/robosystems/config/validation.py
+++ b/robosystems/config/validation.py
@@ -142,6 +142,7 @@ class EnvValidator:
     # first login attempt, which presents as a confusing auth error — fail at
     # boot instead. And a deployment with password auth off and no OIDC is one
     # nobody can log in to.
+    deployed = env_config.ENVIRONMENT not in ("dev", "local", "test")
     if getattr(env_config, "SSO_OIDC_ENABLED", False):
       for var_name in (
         "SSO_OIDC_ISSUER",
@@ -150,12 +151,38 @@ class EnvValidator:
       ):
         if not getattr(env_config, var_name, None):
           errors.append(f"{var_name}: Required when SSO_OIDC_ENABLED=true")
+      issuer = getattr(env_config, "SSO_OIDC_ISSUER", "") or ""
+      if issuer and deployed and not issuer.startswith("https://"):
+        errors.append(
+          "SSO_OIDC_ISSUER: Must be an https:// URL outside local development"
+        )
+      if "?" in issuer or "#" in issuer:
+        errors.append("SSO_OIDC_ISSUER: Must not contain a query or fragment")
     if not getattr(env_config, "PASSWORD_AUTH_ENABLED", True) and not getattr(
       env_config, "SSO_OIDC_ENABLED", False
     ):
       errors.append(
         "PASSWORD_AUTH_ENABLED=false requires SSO_OIDC_ENABLED=true — "
         "otherwise no one can log in to this deployment"
+      )
+    if getattr(env_config, "SCIM_ENABLED", False):
+      default_role = getattr(env_config, "SSO_DEFAULT_ROLE", "member")
+      if default_role not in ("member", "admin"):
+        errors.append(
+          "SSO_DEFAULT_ROLE: Must be 'member' or 'admin' — IdP-provisioned "
+          "users must not default to a privileged role"
+        )
+    if (
+      deployed
+      and (
+        getattr(env_config, "SSO_OIDC_ENABLED", False)
+        or getattr(env_config, "SCIM_ENABLED", False)
+      )
+      and not getattr(env_config, "RATE_LIMIT_ENABLED", False)
+    ):
+      errors.append(
+        "RATE_LIMIT_ENABLED: Required when SSO_OIDC_ENABLED or SCIM_ENABLED — "
+        "the OIDC/SCIM rate buckets are no-ops without it"
       )
 
     # Validate value ranges and formats

--- a/robosystems/middleware/auth/cache.py
+++ b/robosystems/middleware/auth/cache.py
@@ -856,9 +856,11 @@ class APIKeyCache:
       logger.error(f"Failed to invalidate JWT user data cache for {user_id}: {e}")
       return False
 
-  def invalidate_api_key(self, api_key_hash: str) -> None:
+  def invalidate_api_key(self, api_key_hash: str) -> bool:
     """Drop every cached record for an API key: validation, signature, and
-    per-graph access decisions.
+    per-graph access decisions. Returns True when the deletes took; False
+    means an entry may survive until TTL, which revocation callers must
+    treat as incomplete.
     """
     try:
       api_key_cache_key = self._get_api_key_cache_key(api_key_hash)
@@ -885,6 +887,7 @@ class APIKeyCache:
         },
         risk_level="medium",
       )
+      return True
 
     except Exception as e:
       logger.error(f"Failed to invalidate API key cache: {e}")
@@ -893,6 +896,7 @@ class APIKeyCache:
         details={"action": "cache_invalidation_failed", "error": str(e)},
         risk_level="medium",
       )
+      return False
 
   def cache_jwt_graph_access(
     self, user_id: str, graph_id: str, has_access: bool

--- a/robosystems/middleware/rate_limits/__init__.py
+++ b/robosystems/middleware/rate_limits/__init__.py
@@ -23,6 +23,7 @@ from .rate_limiting import (
   oidc_rate_limit_dependency,
   public_api_rate_limit_dependency,
   rate_limit_dependency,
+  scim_ip_rate_limit_dependency,
   scim_rate_limit_dependency,
   sensitive_auth_rate_limit_dependency,
   sse_connection_rate_limit_dependency,
@@ -76,6 +77,7 @@ __all__ = [
   "rate_limit_cache",
   # Main rate limiting
   "rate_limit_dependency",
+  "scim_ip_rate_limit_dependency",
   "scim_rate_limit_dependency",
   "sensitive_auth_rate_limit_dependency",
   "should_use_subscription_limits",

--- a/robosystems/middleware/rate_limits/rate_limiting.py
+++ b/robosystems/middleware/rate_limits/rate_limiting.py
@@ -298,12 +298,17 @@ def create_custom_rate_limit_dependency(
   window_seconds: int = 3600,
   limit_name: str = "custom",
   identifier_fn=None,
+  fail_closed: bool = False,
 ):
   """Create a custom rate limiting dependency with specific limits.
 
   ``identifier_fn`` overrides how the bucket key is derived from the request
   (default: ``get_user_identifier``). Return an ``apikey:``/``jwt:``-prefixed
   string to grant the full limit, anything else for the anonymous 1/10th.
+
+  ``fail_closed=True`` denies when the limiter backend is unavailable
+  instead of waving traffic through — for surfaces whose protection must not
+  silently disappear with Redis (the auth pattern).
   """
   resolve_identifier = identifier_fn or get_user_identifier
 
@@ -328,7 +333,9 @@ def create_custom_rate_limit_dependency(
 
     window = window_seconds
 
-    allowed, remaining = rate_limit_cache.check_rate_limit(cache_key, limit, window)
+    allowed, remaining = rate_limit_cache.check_rate_limit(
+      cache_key, limit, window, fail_closed=fail_closed
+    )
 
     if not allowed:
       current_time = getattr(request.state, "current_time", None) or int(time.time())
@@ -448,10 +455,14 @@ def _scim_rate_limit_identifier(request: Request) -> str:
 
 
 def scim_rate_limit_dependency(request: Request):
-  """Rate limiting for the SCIM provisioning surface (server-to-server)."""
+  """Rate limiting for the SCIM provisioning surface (server-to-server).
+
+  Fails closed: SCIM is an authentication surface, and its throttles must
+  not silently vanish with the limiter backend. The IdP retries a denial.
+  """
   limit = get_int_env("RATE_LIMIT_SCIM", "120")  # 120/minute per token
   return create_custom_rate_limit_dependency(
-    limit, 60, "scim", identifier_fn=_scim_rate_limit_identifier
+    limit, 60, "scim", identifier_fn=_scim_rate_limit_identifier, fail_closed=True
   )(request)
 
 
@@ -473,7 +484,7 @@ def scim_ip_rate_limit_dependency(request: Request):
   """
   limit = get_int_env("RATE_LIMIT_SCIM_IP", "300")  # 300/minute per IP
   return create_custom_rate_limit_dependency(
-    limit, 60, "scim_ip", identifier_fn=_scim_ip_identifier
+    limit, 60, "scim_ip", identifier_fn=_scim_ip_identifier, fail_closed=True
   )(request)
 
 

--- a/robosystems/middleware/rate_limits/rate_limiting.py
+++ b/robosystems/middleware/rate_limits/rate_limiting.py
@@ -455,6 +455,28 @@ def scim_rate_limit_dependency(request: Request):
   )(request)
 
 
+def _scim_ip_identifier(request: Request) -> str:
+  # The `apikey:` prefix opts into the full limit (see
+  # create_custom_rate_limit_dependency); the key itself is purely IP-derived.
+  client_ip = request.client.host if request.client else "unknown"
+  return f"apikey:scim-ip:{client_ip}"
+
+
+def scim_ip_rate_limit_dependency(request: Request):
+  """Pre-authentication IP throttle in front of the SCIM surface.
+
+  The per-token bucket above keys off the *presented* bearer, so each newly
+  invented bogus bearer would otherwise mint a fresh full-size bucket; this
+  IP-keyed backstop caps that churn before authentication. Sized above
+  RATE_LIMIT_SCIM so a legitimate IdP burst exhausts its per-token budget
+  first, never this one.
+  """
+  limit = get_int_env("RATE_LIMIT_SCIM_IP", "300")  # 300/minute per IP
+  return create_custom_rate_limit_dependency(
+    limit, 60, "scim_ip", identifier_fn=_scim_ip_identifier
+  )(request)
+
+
 def general_api_rate_limit_dependency(request: Request):
   """General rate limiting for standard API endpoints."""
   limit = get_int_env("RATE_LIMIT_GENERAL_API", "200")  # 200/minute

--- a/robosystems/models/api/admin/scim.py
+++ b/robosystems/models/api/admin/scim.py
@@ -14,6 +14,12 @@ class ScimBootstrapRequest(BaseModel):
     description="Create a new ENTERPRISE org with this name (when org_id is omitted).",
   )
   token_name: str = Field(default="scim-provisioning")
+  expires_in_days: int = Field(
+    default=365,
+    ge=1,
+    le=3650,
+    description="Token lifetime. Every token expires; rotation is overlap-based.",
+  )
 
 
 class ScimBootstrapResponse(BaseModel):
@@ -22,6 +28,7 @@ class ScimBootstrapResponse(BaseModel):
   scim_token_id: str
   # The raw bearer token, shown exactly once — paste it into the IdP now.
   token: str
+  expires_at: str
 
 
 class ScimTokenRevokeResponse(BaseModel):

--- a/robosystems/models/api/admin/users.py
+++ b/robosystems/models/api/admin/users.py
@@ -91,6 +91,14 @@ class UserStatusResponse(BaseModel):
       "deactivation."
     ),
   )
+  fully_applied: bool = Field(
+    True,
+    description=(
+      "Whether every revocation side effect took, including session and "
+      "API-key cache invalidation. False means a cached credential may keep "
+      "authenticating until its TTL. Re-run the deactivation."
+    ),
+  )
 
 
 class UserActivityResponse(BaseModel):

--- a/robosystems/models/core/user/scim_token.py
+++ b/robosystems/models/core/user/scim_token.py
@@ -2,7 +2,7 @@
 
 import hashlib
 import secrets
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Optional
 
 import bcrypt
@@ -14,6 +14,11 @@ from robosystems.database import Model
 from robosystems.logger import logger
 from robosystems.security import SecurityAuditLogger, SecurityEventType
 from robosystems.utils.ulid import generate_prefixed_ulid
+
+# Every SCIM token expires; this is the lifetime minted when a caller does
+# not choose one. There is deliberately no non-expiring mint (RFC 7644
+# expects limited-lifetime bearers) — rotation is overlap-based.
+DEFAULT_TOKEN_LIFETIME_DAYS = 365
 
 
 class ScimToken(Model):
@@ -60,8 +65,12 @@ class ScimToken(Model):
     """Mint a SCIM token, returning ``(row, plaintext)``.
 
     The plaintext is shown once and never stored — only its bcrypt hash and
-    SHA-256 fingerprint persist.
+    SHA-256 fingerprint persist. ``expires_at=None`` gets the default
+    lifetime, not "never" — the expiry invariant is enforced here so no
+    caller can mint a non-expiring token.
     """
+    if expires_at is None:
+      expires_at = datetime.now(UTC) + timedelta(days=DEFAULT_TOKEN_LIFETIME_DAYS)
     plain_token = f"rfss{secrets.token_hex(32)}"
 
     token = cls(
@@ -117,11 +126,15 @@ class ScimToken(Model):
     if candidate is None or not candidate.is_active:
       return None
     expires = candidate.expires_at
-    if expires is not None:
-      if expires.tzinfo is None:
-        expires = expires.replace(tzinfo=UTC)
-      if expires < datetime.now(UTC):
-        return None
+    if expires is None:
+      # No non-expiring token is ever minted, so a NULL here is a row from
+      # before the invariant — refuse it rather than honoring it forever.
+      logger.warning(f"SCIM token {candidate.id} has no expiry; refusing. Rotate it.")
+      return None
+    if expires.tzinfo is None:
+      expires = expires.replace(tzinfo=UTC)
+    if expires < datetime.now(UTC):
+      return None
     if not cls._verify_token(plain_token, str(candidate.token_hash)):
       return None
     return candidate

--- a/robosystems/models/core/user/user.py
+++ b/robosystems/models/core/user/user.py
@@ -19,8 +19,9 @@ from robosystems.utils.ulid import generate_prefixed_ulid
 class DeactivationResult:
   """What a deactivation actually accomplished, not what it attempted.
 
-  The DB flag flip always commits (or the whole call raises); the two
-  side effects — auth-cache invalidation and API-key revocation — are
+  The DB flag flip always commits (or the whole call raises); the side
+  effects — auth-cache invalidation and API-key revocation, where each key
+  has its own DB flip *and* its own validation-cache entry — are
   best-effort, and a caller acting as an offboarding kill switch (SCIM)
   must know whether they took so it can fail loud and be retried.
   """
@@ -28,11 +29,19 @@ class DeactivationResult:
   # -1 when the key list could not even be loaded (count unknown).
   keys_found: int
   keys_revoked: int
+  # The user-level JWT/session caches.
   cache_invalidated: bool
+  # The per-key validation caches — a revoked key row with a surviving
+  # cache entry keeps authenticating until the entry's TTL.
+  key_caches_invalidated: bool
 
   @property
   def fully_applied(self) -> bool:
-    return self.cache_invalidated and self.keys_revoked == self.keys_found
+    return (
+      self.cache_invalidated
+      and self.key_caches_invalidated
+      and self.keys_revoked == self.keys_found
+    )
 
 
 class User(Model):
@@ -199,11 +208,12 @@ class User(Model):
       session.commit()
       session.refresh(self)
       cache_invalidated = self._invalidate_auth_cache()
-      keys_revoked, keys_found = self._revoke_api_keys(session)
+      keys_revoked, keys_found, key_caches_invalidated = self._revoke_api_keys(session)
       return DeactivationResult(
         keys_found=keys_found,
         keys_revoked=keys_revoked,
         cache_invalidated=cache_invalidated,
+        key_caches_invalidated=key_caches_invalidated,
       )
     except SQLAlchemyError:
       session.rollback()
@@ -233,39 +243,49 @@ class User(Model):
       session.rollback()
       raise
 
-  def _revoke_api_keys(self, session: Session) -> tuple[int, int]:
-    """Deactivate this user's active API keys and clear their caches.
+  def _revoke_api_keys(self, session: Session) -> tuple[int, int, bool]:
+    """Deactivate this user's API keys and clear their validation caches.
 
-    Returns ``(revoked, found)`` — the number that actually took alongside the
-    number attempted: revocation is best-effort per key, and an incident
-    response that reads "4 keys revoked" when one failed is worse than no
-    number at all. ``found`` is ``-1`` when the key list could not even be
-    loaded, which callers must read as incomplete.
+    Returns ``(revoked, found, caches_cleared)``: the number of active keys
+    that were actually revoked alongside the number found — revocation is
+    best-effort per key, and an incident response that reads "4 keys revoked"
+    when one failed is worse than no number at all — plus whether every key's
+    validation-cache entry was cleared. ``found`` is ``-1`` when the key list
+    could not even be loaded, which callers must read as incomplete.
 
-    Called on deactivate so programmatic access is revoked alongside JWT
-    invalidation. Each key's ``deactivate`` flips ``is_active`` and invalidates
-    that key's validation-cache entry. Failures are logged per-key but never
-    abort the user deactivation; the ``user.is_active`` guard in
-    ``validate_api_key`` is the authoritative backstop if a key is missed, and
-    re-running the deactivation retries whatever did not take.
+    Every key row is swept, not just the active ones: a key revoked on an
+    earlier pass whose cache invalidation failed keeps authenticating from
+    cache until TTL, and it no longer appears in the active list — so a retry
+    that only looked at active rows could never repair it. Failures are
+    logged per-key but never abort the user deactivation; the
+    ``user.is_active`` guard in ``validate_api_key`` is the authoritative
+    backstop if a key is missed, and re-running the deactivation retries
+    whatever did not take.
     """
     from .user_api_key import UserAPIKey
 
     try:
-      active_keys = UserAPIKey.get_active_by_user_id(str(self.id), session)
+      all_keys = UserAPIKey.get_by_user_id(str(self.id), session)
     except Exception as e:
       logger.error(f"Failed to load API keys for deactivated user {self.id}: {e}")
-      return 0, -1
+      return 0, -1, False
+
+    active_keys = [key for key in all_keys if key.is_active]
+    stale_keys = [key for key in all_keys if not key.is_active]
 
     revoked = 0
+    caches_cleared = True
     for key in active_keys:
       try:
-        key.deactivate(session)
+        caches_cleared = key.deactivate(session) and caches_cleared
         revoked += 1
       except Exception as e:
+        caches_cleared = False
         logger.error(
           f"Failed to revoke API key {key.id} for deactivated user {self.id}: {e}"
         )
+    for key in stale_keys:
+      caches_cleared = key.invalidate_cache() and caches_cleared
 
     if revoked != len(active_keys):
       logger.error(
@@ -274,8 +294,14 @@ class User(Model):
         f"table and are refused only by the user.is_active guard. Re-run the "
         f"deactivation."
       )
+    if not caches_cleared:
+      logger.error(
+        f"CRITICAL: validation-cache invalidation incomplete for user "
+        f"{self.id}'s API keys; a revoked key may keep authenticating from "
+        f"cache until TTL. Re-run the deactivation."
+      )
 
-    return revoked, len(active_keys)
+    return revoked, len(active_keys), caches_cleared
 
   def _invalidate_auth_cache(self) -> bool:
     """Invalidate auth caches derived from this user, True when it took.

--- a/robosystems/models/core/user/user.py
+++ b/robosystems/models/core/user/user.py
@@ -2,6 +2,7 @@
 
 import time
 from collections.abc import Sequence
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Optional
 
@@ -12,6 +13,26 @@ from sqlalchemy.orm import Session, relationship
 from robosystems.database import Model
 from robosystems.logger import logger
 from robosystems.utils.ulid import generate_prefixed_ulid
+
+
+@dataclass(frozen=True)
+class DeactivationResult:
+  """What a deactivation actually accomplished, not what it attempted.
+
+  The DB flag flip always commits (or the whole call raises); the two
+  side effects — auth-cache invalidation and API-key revocation — are
+  best-effort, and a caller acting as an offboarding kill switch (SCIM)
+  must know whether they took so it can fail loud and be retried.
+  """
+
+  # -1 when the key list could not even be loaded (count unknown).
+  keys_found: int
+  keys_revoked: int
+  cache_invalidated: bool
+
+  @property
+  def fully_applied(self) -> bool:
+    return self.cache_invalidated and self.keys_revoked == self.keys_found
 
 
 class User(Model):
@@ -153,8 +174,8 @@ class User(Model):
       session.rollback()
       raise
 
-  def deactivate(self, session: Session) -> int:
-    """Deactivate the user, returning how many API keys were revoked.
+  def deactivate(self, session: Session) -> DeactivationResult:
+    """Deactivate the user, reporting how completely the kill switch applied.
 
     Bumps ``session_version``, which invalidates every JWT issued for this
     user, and revokes all of the user's API keys. If the user is reactivated
@@ -166,6 +187,10 @@ class User(Model):
     API-key revocation is essential: keys don't carry ``session_version`` and
     ``UserAPIKey.get_by_key`` filters only on the key's own active flag, so
     without this a deactivated user would keep full programmatic access.
+
+    Idempotent and re-asserting: calling this on an already-inactive user
+    re-runs the cache invalidation and key sweep, which is exactly what a
+    retry after a partial failure needs.
     """
     self.is_active = False
     self.session_version = (self.session_version or 0) + 1
@@ -173,8 +198,13 @@ class User(Model):
     try:
       session.commit()
       session.refresh(self)
-      self._invalidate_auth_cache()
-      return self._revoke_api_keys(session)
+      cache_invalidated = self._invalidate_auth_cache()
+      keys_revoked, keys_found = self._revoke_api_keys(session)
+      return DeactivationResult(
+        keys_found=keys_found,
+        keys_revoked=keys_revoked,
+        cache_invalidated=cache_invalidated,
+      )
     except SQLAlchemyError:
       session.rollback()
       raise
@@ -203,13 +233,14 @@ class User(Model):
       session.rollback()
       raise
 
-  def _revoke_api_keys(self, session: Session) -> int:
+  def _revoke_api_keys(self, session: Session) -> tuple[int, int]:
     """Deactivate this user's active API keys and clear their caches.
 
-    Returns how many were actually revoked, which is what callers must report:
-    revocation is best-effort per key, so the number attempted is not the
-    number that took, and an incident response that reads "4 keys revoked"
-    when one failed is worse than no number at all.
+    Returns ``(revoked, found)`` — the number that actually took alongside the
+    number attempted: revocation is best-effort per key, and an incident
+    response that reads "4 keys revoked" when one failed is worse than no
+    number at all. ``found`` is ``-1`` when the key list could not even be
+    loaded, which callers must read as incomplete.
 
     Called on deactivate so programmatic access is revoked alongside JWT
     invalidation. Each key's ``deactivate`` flips ``is_active`` and invalidates
@@ -224,7 +255,7 @@ class User(Model):
       active_keys = UserAPIKey.get_active_by_user_id(str(self.id), session)
     except Exception as e:
       logger.error(f"Failed to load API keys for deactivated user {self.id}: {e}")
-      return 0
+      return 0, -1
 
     revoked = 0
     for key in active_keys:
@@ -244,10 +275,10 @@ class User(Model):
         f"deactivation."
       )
 
-    return revoked
+    return revoked, len(active_keys)
 
-  def _invalidate_auth_cache(self) -> None:
-    """Invalidate auth caches derived from this user.
+  def _invalidate_auth_cache(self) -> bool:
+    """Invalidate auth caches derived from this user, True when it took.
 
     Always DELETE rather than rewrite: the cached entry's session_version
     is what gates the cache hit, so an old entry left in place defeats the
@@ -271,7 +302,7 @@ class User(Model):
       api_key_cache = cache_module.api_key_cache
     except Exception as e:
       logger.error(f"Auth cache module unavailable for user {self.id}: {e}")
-      return
+      return False
 
     user_id = str(self.id)
 
@@ -290,10 +321,10 @@ class User(Model):
     # One retry with a short backoff handles transient Redis blips
     # (connection reset, single-node failover) without going to extremes.
     if _try_invalidate():
-      return
+      return True
     time.sleep(0.05)
     if _try_invalidate():
-      return
+      return True
 
     # Both attempts failed. Log loudly — this is the fail-open window.
     # Surface as an error so it's monitorable; downstream alerting should
@@ -302,3 +333,4 @@ class User(Model):
       f"CRITICAL: auth cache invalidation failed twice for user {user_id}; "
       f"prior session may remain valid for up to JWT/cache TTL"
     )
+    return False

--- a/robosystems/models/core/user/user_api_key.py
+++ b/robosystems/models/core/user/user_api_key.py
@@ -33,7 +33,7 @@ class UserAPIKey(Model):
   # Nullable: a row whose key has never been validated may not have one yet
   # (it is backfilled on validation, the only place plaintext is available).
   # A key revoked while this is NULL cannot be cache-invalidated by
-  # fingerprint — ``_invalidate_cache`` warns and the entry lapses on TTL.
+  # fingerprint — ``invalidate_cache`` warns and the entry lapses on TTL.
   key_fingerprint = Column(String(64), nullable=True, unique=True, index=True)
   prefix = Column(
     String, nullable=False, index=True
@@ -252,8 +252,14 @@ class UserAPIKey(Model):
         session.rollback()
         raise
 
-  def deactivate(self, session: Session) -> None:
-    """Deactivate the API key and invalidate cache."""
+  def deactivate(self, session: Session) -> bool:
+    """Deactivate the API key, returning whether its cache entry was cleared.
+
+    The DB flip either commits or this raises; the cache invalidation is
+    best-effort, and a caller acting as a kill switch must know whether it
+    took — a cached validation entry keeps the key usable until its TTL even
+    though the row is inactive.
+    """
     self.is_active = False
     self.updated_at = datetime.now(UTC)
     try:
@@ -263,7 +269,7 @@ class UserAPIKey(Model):
       session.rollback()
       raise
 
-    self._invalidate_cache()
+    return self.invalidate_cache()
 
   def activate(self, session: Session) -> None:
     """Activate the API key and invalidate cache."""
@@ -276,12 +282,12 @@ class UserAPIKey(Model):
       session.rollback()
       raise
 
-    self._invalidate_cache()
+    self.invalidate_cache()
 
   def delete(self, session: Session) -> None:
     """Delete the API key, clearing its cache entry first — the row's
     fingerprint is needed to find it."""
-    self._invalidate_cache()
+    self.invalidate_cache()
 
     session.delete(self)
     try:
@@ -295,12 +301,12 @@ class UserAPIKey(Model):
     """Deterministic SHA-256 fingerprint of a plaintext API key.
 
     Used as the cache key in `validate_api_key`. Stored on the row so
-    `_invalidate_cache` can clear the same entry without needing the plaintext.
+    `invalidate_cache` can clear the same entry without needing the plaintext.
 
     NOT credential storage: the API key itself is stored as bcrypt in
     ``key_hash`` (see ``_hash_api_key`` below). This SHA-256 is solely a
     deterministic lookup fingerprint so the cache key derived from the
-    plaintext (``sha256(plain_key)``) matches what ``_invalidate_cache``
+    plaintext (``sha256(plain_key)``) matches what ``invalidate_cache``
     reads off the row. A KDF would be the wrong tool: those exist to make
     low-entropy human secrets expensive to guess, and an API key is
     generated at full entropy.
@@ -327,12 +333,14 @@ class UserAPIKey(Model):
       logger.error(f"API key verification failed: {e}")
       return False
 
-  def _invalidate_cache(self) -> None:
-    """Drop this key's cached validation result.
+  def invalidate_cache(self) -> bool:
+    """Drop this key's cached validation result, True when it took.
 
     Keyed on ``key_fingerprint``, matching what ``validate_api_key`` caches
-    under. A row with a NULL fingerprint (never validated) cannot be targeted;
-    its cache entry, if any, lapses on TTL.
+    under. A row with a NULL fingerprint (never validated) cannot be targeted
+    but also has no addressable entry to leave stale — reported as success.
+    A False return means an entry may survive until its TTL, so callers
+    enforcing revocation must treat it as incomplete and retry.
     """
     try:
       # Imported lazily to avoid a circular dependency on the auth middleware.
@@ -347,9 +355,9 @@ class UserAPIKey(Model):
           f"API key {self.id} has no key_fingerprint; cache cannot be "
           f"invalidated until the key is validated once after deploy."
         )
-        return
+        return True
 
-      api_key_cache.invalidate_api_key(fingerprint)
+      cleared = bool(api_key_cache.invalidate_api_key(fingerprint))
 
       SecurityAuditLogger.log_security_event(
         event_type=SecurityEventType.AUTHORIZATION_DENIED,
@@ -359,6 +367,8 @@ class UserAPIKey(Model):
         },
         risk_level="low",
       )
+      return cleared
 
     except Exception as e:
       logger.error(f"Failed to invalidate cache for user API key {self.id}: {e}")
+      return False

--- a/robosystems/operations/admin/scim_bootstrap.py
+++ b/robosystems/operations/admin/scim_bootstrap.py
@@ -13,8 +13,7 @@ from sqlalchemy.orm import Session
 
 from robosystems.logger import logger
 from robosystems.models.core import Org, OrgLimits, OrgType, ScimToken
-
-DEFAULT_TOKEN_LIFETIME_DAYS = 365
+from robosystems.models.core.user.scim_token import DEFAULT_TOKEN_LIFETIME_DAYS
 
 
 class ScimBootstrapError(Exception):

--- a/robosystems/operations/admin/scim_bootstrap.py
+++ b/robosystems/operations/admin/scim_bootstrap.py
@@ -7,11 +7,14 @@ run once per tenant from the admin CLI. The raw token is returned exactly once
 """
 
 from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
 
 from sqlalchemy.orm import Session
 
 from robosystems.logger import logger
 from robosystems.models.core import Org, OrgLimits, OrgType, ScimToken
+
+DEFAULT_TOKEN_LIFETIME_DAYS = 365
 
 
 class ScimBootstrapError(Exception):
@@ -29,6 +32,7 @@ class ScimBootstrapResult:
   scim_token_id: str
   # Shown once; only its hash is stored.
   raw_token: str
+  expires_at: datetime
 
 
 def bootstrap_scim(
@@ -37,11 +41,17 @@ def bootstrap_scim(
   org_name: str | None = None,
   org_id: str | None = None,
   token_name: str = "scim-provisioning",
+  expires_in_days: int = DEFAULT_TOKEN_LIFETIME_DAYS,
 ) -> ScimBootstrapResult:
   """Create-or-reuse the enterprise org and mint a SCIM token for it.
 
   Pass ``org_id`` to attach a token to an existing org, or ``org_name`` to
   create a fresh ``ENTERPRISE`` org (with default limits) first.
+
+  Every token expires — there is deliberately no "never" option (RFC 7644
+  expects limited-lifetime bearers). Rotation is overlap-based: mint the
+  replacement, swap it into the IdP, then revoke the old token; two live
+  tokens are legal during the swap.
   """
   if org_id is not None:
     org = Org.get_by_id(org_id, session)
@@ -55,7 +65,10 @@ def bootstrap_scim(
     )
     OrgLimits.create_default_limits(org.id, session)
 
-  token, raw_token = ScimToken.create(org.id, token_name, session)
+  expires_at = datetime.now(UTC) + timedelta(days=expires_in_days)
+  token, raw_token = ScimToken.create(
+    org.id, token_name, session, expires_at=expires_at
+  )
 
   logger.info(
     f"Bootstrapped SCIM for org {org.id}",
@@ -66,6 +79,7 @@ def bootstrap_scim(
     org_name=str(org.name),
     scim_token_id=str(token.id),
     raw_token=raw_token,
+    expires_at=expires_at,
   )
 
 

--- a/robosystems/operations/admin/user_status.py
+++ b/robosystems/operations/admin/user_status.py
@@ -29,6 +29,9 @@ class UserStatusChange:
   changed: bool
   api_keys_revoked: int
   api_keys_failed: int = 0
+  # False when any revocation side effect did not take — a session/key cache
+  # entry may keep authenticating until its TTL. Re-run the deactivation.
+  fully_applied: bool = True
 
 
 def set_user_active(
@@ -63,11 +66,13 @@ def set_user_active(
   if active:
     found = 0
     revoked = 0
+    fully_applied = True
     user.activate(session)
   else:
     result = user.deactivate(session)
     found = result.keys_found
     revoked = result.keys_revoked
+    fully_applied = result.fully_applied
 
   # found == -1 means the key list could not be loaded at all; report one
   # failure rather than a negative count so the operator still sees red.
@@ -81,6 +86,7 @@ def set_user_active(
       "was_active": was_active,
       "api_keys_revoked": revoked,
       "api_keys_failed": failed,
+      "fully_applied": fully_applied,
     },
   )
 
@@ -91,4 +97,5 @@ def set_user_active(
     changed=was_active != active,
     api_keys_revoked=revoked,
     api_keys_failed=failed,
+    fully_applied=fully_applied,
   )

--- a/robosystems/operations/admin/user_status.py
+++ b/robosystems/operations/admin/user_status.py
@@ -14,7 +14,6 @@ from sqlalchemy.orm import Session
 
 from ...logger import get_logger
 from ...models.core import User
-from ...models.core.user.user_api_key import UserAPIKey
 from .user_deletion import UserNotFound
 
 logger = get_logger(__name__)
@@ -66,10 +65,13 @@ def set_user_active(
     revoked = 0
     user.activate(session)
   else:
-    found = len(UserAPIKey.get_active_by_user_id(str(user.id), session))
-    revoked = user.deactivate(session)
+    result = user.deactivate(session)
+    found = result.keys_found
+    revoked = result.keys_revoked
 
-  failed = found - revoked
+  # found == -1 means the key list could not be loaded at all; report one
+  # failure rather than a negative count so the operator still sees red.
+  failed = (found - revoked) if found >= 0 else 1
 
   logger.info(
     f"User {user_id} {'activated' if active else 'deactivated'}",

--- a/robosystems/routers/admin/scim.py
+++ b/robosystems/routers/admin/scim.py
@@ -39,6 +39,7 @@ async def scim_bootstrap(
         org_name=data.org_name,
         org_id=data.org_id,
         token_name=data.token_name,
+        expires_in_days=data.expires_in_days,
       )
     except OrgNotFoundError as exc:
       raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
@@ -56,6 +57,7 @@ async def scim_bootstrap(
       org_name=result.org_name,
       scim_token_id=result.scim_token_id,
       token=result.raw_token,
+      expires_at=result.expires_at.isoformat(),
     )
   finally:
     session.close()

--- a/robosystems/routers/admin/users.py
+++ b/robosystems/routers/admin/users.py
@@ -395,6 +395,7 @@ async def _set_active(
         "changed": change.changed,
         "api_keys_revoked": change.api_keys_revoked,
         "api_keys_failed": change.api_keys_failed,
+        "fully_applied": change.fully_applied,
       },
     )
 
@@ -405,6 +406,7 @@ async def _set_active(
       changed=change.changed,
       api_keys_revoked=change.api_keys_revoked,
       api_keys_failed=change.api_keys_failed,
+      fully_applied=change.fully_applied,
     )
   finally:
     session.close()

--- a/robosystems/routers/auth/login.py
+++ b/robosystems/routers/auth/login.py
@@ -24,7 +24,7 @@ from ...security import SecurityAuditLogger, SecurityEventType
 from ...security.auth_protection import AdvancedAuthProtection
 from ...security.device_fingerprinting import extract_device_fingerprint
 from ...security.input_validation import sanitize_string, validate_email
-from .utils import verify_password
+from .utils import require_password_auth, verify_password
 
 # Create router for login endpoint
 router = APIRouter()
@@ -48,6 +48,7 @@ async def login(
   fastapi_request: Request,
   session: Session = Depends(get_async_db_session),
   rate_limit: None = Depends(auth_rate_limit_dependency),
+  _password_auth: None = Depends(require_password_auth),
 ) -> AuthResponse:
   # Validate and sanitize input
   if not validate_email(request.email):

--- a/robosystems/routers/auth/password_reset.py
+++ b/robosystems/routers/auth/password_reset.py
@@ -40,7 +40,7 @@ from ...security.input_validation import (
   validate_email,
 )
 from ...security.password import PasswordSecurity
-from .utils import detect_app_source, hash_password
+from .utils import detect_app_source, hash_password, require_password_auth
 
 # Create router for password reset endpoints
 router = APIRouter()
@@ -59,6 +59,7 @@ async def forgot_password(
   background_tasks: BackgroundTasks,
   session: Session = Depends(get_async_db_session),
   _rate_limit: None = Depends(auth_rate_limit_dependency),
+  _password_auth: None = Depends(require_password_auth),
 ) -> dict:
   # Validate and sanitize email
   if not validate_email(request.email):
@@ -157,6 +158,7 @@ async def forgot_password(
 async def validate_reset_token(
   token: str = Query(..., description="Password reset token"),
   session: Session = Depends(get_async_db_session),
+  _password_auth: None = Depends(require_password_auth),
 ) -> ResetPasswordValidateResponse:
   # Validate token without consuming it
   user_id = UserToken.validate_token(
@@ -200,6 +202,7 @@ async def reset_password(
   request: ResetPasswordRequest,
   fastapi_request: Request,
   session: Session = Depends(get_async_db_session),
+  _password_auth: None = Depends(require_password_auth),
 ) -> AuthResponse:
   # Verify token and get user
   user_id = UserToken.verify_token(

--- a/robosystems/routers/auth/register.py
+++ b/robosystems/routers/auth/register.py
@@ -38,7 +38,7 @@ from ...security.input_validation import (
   validate_email,
 )
 from ...security.password import PasswordSecurity
-from .utils import detect_app_source, hash_password
+from .utils import detect_app_source, hash_password, require_password_auth
 
 # Create router for register endpoint
 router = APIRouter()
@@ -65,8 +65,13 @@ async def register(
   background_tasks: BackgroundTasks,
   session: Session = Depends(get_async_db_session),
   rate_limit: None = Depends(auth_rate_limit_dependency),
+  _password_auth: None = Depends(require_password_auth),
 ) -> AuthResponse:
   # Check if registration is enabled.
+  #
+  # Note the guard above outranks invitations: with password auth disabled,
+  # an invitation must not become a side door to a password account — invited
+  # staff arrive via the IdP instead.
   #
   # An invitation is itself the authorization to register, so closing
   # registration stops *unsolicited* signups without also blocking the people

--- a/robosystems/routers/auth/utils.py
+++ b/robosystems/routers/auth/utils.py
@@ -47,6 +47,22 @@ class Config:
     }
 
 
+def require_password_auth() -> None:
+  """Dependency guard for every password-credential endpoint.
+
+  ``PASSWORD_AUTH_ENABLED=false`` (SSO-primary deployments) must disable the
+  whole credential surface — login, registration, reset, change — not just
+  its advertisement in ``/auth/providers``. A login that the UI hides but the
+  API still accepts is posture drift, not a posture: it would let a password
+  bypass the IdP's MFA and conditional-access policies.
+  """
+  if not env.PASSWORD_AUTH_ENABLED:
+    raise HTTPException(
+      status_code=status.HTTP_403_FORBIDDEN,
+      detail="Password authentication is disabled on this deployment",
+    )
+
+
 # Redis clients are now imported from middleware.auth.jwt
 
 

--- a/robosystems/routers/scim/__init__.py
+++ b/robosystems/routers/scim/__init__.py
@@ -9,14 +9,24 @@ or API key is never accepted here.
 from fastapi import APIRouter, Depends
 
 from ...middleware.auth.scim import require_scim_org
-from ...middleware.rate_limits import scim_rate_limit_dependency
+from ...middleware.rate_limits import (
+  scim_ip_rate_limit_dependency,
+  scim_rate_limit_dependency,
+)
 from .config import router as config_router
 from .users import router as users_router
 
+# Two rate buckets ahead of authentication: the IP bucket caps callers who
+# invent a new bearer per request (each presented bearer keys its own token
+# bucket), then the per-token bucket meters legitimate IdP traffic.
 router = APIRouter(
   prefix="/scim/v2",
   tags=["SCIM"],
-  dependencies=[Depends(scim_rate_limit_dependency), Depends(require_scim_org)],
+  dependencies=[
+    Depends(scim_ip_rate_limit_dependency),
+    Depends(scim_rate_limit_dependency),
+    Depends(require_scim_org),
+  ],
 )
 router.include_router(config_router)
 router.include_router(users_router)

--- a/robosystems/routers/scim/users.py
+++ b/robosystems/routers/scim/users.py
@@ -315,8 +315,16 @@ async def patch_user(
     user = _org_user_or_404(org_id, user_id, session)
 
     desired_active = _coerce_active(body)
-    if desired_active is not None:
-      _set_active(user, desired_active, org_id, session)
+    if desired_active is None:
+      # Nothing recognized means nothing applied — say so. A 200 here would
+      # tell the IdP an update (possibly a deactivation in a shape we don't
+      # parse) succeeded when the account is unchanged.
+      raise _scim_error(
+        status.HTTP_400_BAD_REQUEST,
+        "PATCH contained no supported operation (only 'active' is supported)",
+        scim_type="invalidValue",
+      )
+    _set_active(user, desired_active, org_id, session)
 
     session.refresh(user)
     return _to_resource(user)

--- a/robosystems/routers/scim/users.py
+++ b/robosystems/routers/scim/users.py
@@ -56,10 +56,13 @@ def _scim_error(
 
 
 def _default_role() -> OrgRole:
+  # Boot validation rejects anything outside member/admin; this is the
+  # runtime belt so a bypassed check can never mint owners.
   try:
-    return OrgRole(env.SSO_DEFAULT_ROLE)
+    role = OrgRole(env.SSO_DEFAULT_ROLE)
   except ValueError:
     return OrgRole.MEMBER
+  return role if role in (OrgRole.MEMBER, OrgRole.ADMIN) else OrgRole.MEMBER
 
 
 def _to_resource(user: User) -> ScimUserResource:
@@ -124,21 +127,41 @@ def _coerce_active(patch: ScimPatchRequest) -> bool | None:
   return None
 
 
-def _set_active(user: User, active: bool, org_id: str, session: Session) -> None:
-  if bool(user.is_active) == active:
-    return
-  if active:
-    user.activate(session)
-    event = SecurityEventType.SCIM_USER_REACTIVATED
-  else:
-    user.deactivate(session)  # session_version bump + API-key revocation
-    event = SecurityEventType.SCIM_USER_DEACTIVATED
+def _audit_active_change(user: User, org_id: str, event: SecurityEventType) -> None:
   SecurityAuditLogger.log_security_event(
     event_type=event,
     user_id=str(user.id),
     details={"action": event.value, "org_id": org_id, "external_id": user.external_id},
     risk_level="medium",
   )
+
+
+def _set_active(user: User, active: bool, org_id: str, session: Session) -> None:
+  transition = bool(user.is_active) != active
+
+  if active:
+    if not transition:
+      return
+    user.activate(session)
+    _audit_active_change(user, org_id, SecurityEventType.SCIM_USER_REACTIVATED)
+    return
+
+  # Deactivation runs even when the DB flag is already false: the flag flip
+  # is only part of the kill switch — an IdP retry after a 503 below is
+  # retrying the session-cache invalidation and API-key revocation, not the
+  # column write, so a short-circuit here would make the retry a no-op.
+  result = user.deactivate(session)
+  if transition:
+    _audit_active_change(user, org_id, SecurityEventType.SCIM_USER_DEACTIVATED)
+  if not result.fully_applied:
+    # The account is inactive in the DB, but revocation side effects did not
+    # all take. Fail the request so the IdP retries — deactivate is
+    # idempotent and re-asserts them — instead of reporting an offboarding
+    # complete that isn't.
+    raise _scim_error(
+      status.HTTP_503_SERVICE_UNAVAILABLE,
+      "Deactivation incompletely applied; retry",
+    )
 
 
 @router.get("/Users", include_in_schema=False)

--- a/robosystems/routers/user/api_keys.py
+++ b/robosystems/routers/user/api_keys.py
@@ -356,7 +356,16 @@ async def revoke_api_key(
 
     was_already_inactive = not api_key.is_active
 
-    api_key.deactivate(db)
+    if not api_key.deactivate(db):
+      # The key row is revoked, but its cached validation entry could not be
+      # cleared — until it is, the key may keep authenticating from cache.
+      # Fail the request so the caller retries: deactivate re-asserts the
+      # invalidation on an already-inactive key, so the retry converges.
+      raise create_error_response(
+        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        detail="API key revocation incompletely applied; retry",
+        code=ErrorCode.EXTERNAL_SERVICE_ERROR,
+      )
 
     metrics_instance = get_endpoint_metrics()
     metrics_instance.record_business_event(

--- a/robosystems/routers/user/password.py
+++ b/robosystems/routers/user/password.py
@@ -21,6 +21,7 @@ from ...models.api.common import (
 from ...models.api.user import UpdatePasswordRequest
 from ...models.core import User
 from ...security.password import PasswordSecurity
+from ..auth.utils import require_password_auth
 
 router = APIRouter(tags=["User"])
 
@@ -41,6 +42,7 @@ async def update_user_password(
   current_user: User = Depends(get_current_user),
   db: Session = Depends(get_db_session),
   _rate_limit: None = Depends(user_management_rate_limit_dependency),
+  _password_auth: None = Depends(require_password_auth),
 ):
   user_id = getattr(current_user, "id", None) if current_user else None
 

--- a/tests/config/test_validation.py
+++ b/tests/config/test_validation.py
@@ -148,6 +148,109 @@ class TestEnvValidator:
     with pytest.raises(ConfigValidationError):
       EnvValidator.validate_required_vars(env_config)
 
+  # The ConfigValidationError message is deliberately generic (details go to
+  # logs), so each rejection test below is paired with a passing twin that
+  # differs only in the value under test — that's what pins causality.
+
+  def _prod_oidc_config(self, issuer: str) -> MockEnvConfig:
+    env_config = MockEnvConfig()
+    env_config.ENVIRONMENT = "prod"
+    env_config.GRAPH_API_URL = None  # prod rejects an explicit URL
+    env_config.SSO_OIDC_ENABLED = True
+    env_config.SSO_OIDC_ISSUER = issuer
+    env_config.SSO_OIDC_CLIENT_ID = "client-id"
+    env_config.SSO_OIDC_CLIENT_SECRET = "client-secret"
+    return env_config
+
+  def test_oidc_deployed_requires_https_issuer(self):
+    """Outside local development the issuer must be https."""
+    env_config = self._prod_oidc_config("http://org.okta.example")
+
+    with patch("os.getenv", return_value=None):
+      with pytest.raises(ConfigValidationError):
+        EnvValidator.validate_required_vars(env_config)
+
+  def test_oidc_deployed_https_issuer_passes(self):
+    env_config = self._prod_oidc_config("https://org.okta.example")
+
+    with (
+      patch("os.getenv", return_value=None),
+      patch("robosystems.config.validation.logger"),
+    ):
+      EnvValidator.validate_required_vars(env_config)
+
+  def test_oidc_dev_allows_http_issuer(self):
+    env_config = MockEnvConfig()  # ENVIRONMENT=dev
+    env_config.SSO_OIDC_ENABLED = True
+    env_config.SSO_OIDC_ISSUER = "http://localhost:9999"
+    env_config.SSO_OIDC_CLIENT_ID = "client-id"
+    env_config.SSO_OIDC_CLIENT_SECRET = "client-secret"
+
+    with patch("robosystems.config.validation.logger"):
+      EnvValidator.validate_required_vars(env_config)
+
+  def test_oidc_issuer_with_query_rejected_everywhere(self):
+    # Passing twin: test_oidc_enabled_with_full_connection_passes (clean
+    # issuer, same dev environment).
+    env_config = MockEnvConfig()
+    env_config.SSO_OIDC_ENABLED = True
+    env_config.SSO_OIDC_ISSUER = "https://org.okta.example?next=x"
+    env_config.SSO_OIDC_CLIENT_ID = "client-id"
+    env_config.SSO_OIDC_CLIENT_SECRET = "client-secret"
+
+    with pytest.raises(ConfigValidationError):
+      EnvValidator.validate_required_vars(env_config)
+
+  def test_scim_default_role_owner_rejected(self):
+    """IdP-provisioned users must never default to a privileged role."""
+    env_config = MockEnvConfig()
+    env_config.SCIM_ENABLED = True
+    env_config.SSO_DEFAULT_ROLE = "owner"
+
+    with pytest.raises(ConfigValidationError):
+      EnvValidator.validate_required_vars(env_config)
+
+  def test_scim_default_role_admin_allowed(self):
+    env_config = MockEnvConfig()
+    env_config.SCIM_ENABLED = True
+    env_config.SSO_DEFAULT_ROLE = "admin"
+
+    with patch("robosystems.config.validation.logger"):
+      EnvValidator.validate_required_vars(env_config)
+
+  def test_scim_deployed_requires_rate_limiting(self):
+    """The OIDC/SCIM buckets are no-ops with rate limiting globally off."""
+    env_config = MockEnvConfig()
+    env_config.ENVIRONMENT = "prod"
+    env_config.GRAPH_API_URL = None
+    env_config.SCIM_ENABLED = True
+    env_config.RATE_LIMIT_ENABLED = False
+
+    with patch("os.getenv", return_value=None):
+      with pytest.raises(ConfigValidationError):
+        EnvValidator.validate_required_vars(env_config)
+
+  def test_scim_deployed_with_rate_limiting_passes(self):
+    env_config = MockEnvConfig()
+    env_config.ENVIRONMENT = "prod"
+    env_config.GRAPH_API_URL = None
+    env_config.SCIM_ENABLED = True
+    env_config.RATE_LIMIT_ENABLED = True
+
+    with (
+      patch("os.getenv", return_value=None),
+      patch("robosystems.config.validation.logger"),
+    ):
+      EnvValidator.validate_required_vars(env_config)
+
+  def test_dev_scim_without_rate_limiting_ok(self):
+    env_config = MockEnvConfig()  # ENVIRONMENT=dev
+    env_config.SCIM_ENABLED = True
+    env_config.RATE_LIMIT_ENABLED = False
+
+    with patch("robosystems.config.validation.logger"):
+      EnvValidator.validate_required_vars(env_config)
+
   def test_validate_required_vars_prod_no_s3_credentials_ok(self):
     """Test validation passes when S3 credentials are missing in production (uses IAM roles)."""
     env_config = MockEnvConfig()

--- a/tests/middleware/rate_limits/test_rate_limit_isolation.py
+++ b/tests/middleware/rate_limits/test_rate_limit_isolation.py
@@ -70,7 +70,7 @@ class TestRateLimitIsolation:
     # Mock the rate limit cache to track calls
     check_calls = []
 
-    def mock_check_rate_limit(identifier, limit, window):
+    def mock_check_rate_limit(identifier, limit, window, fail_closed=False):
       check_calls.append((identifier, limit, window))
       # Always allow for this test
       return (True, limit - 1)
@@ -124,7 +124,7 @@ class TestRateLimitIsolation:
     # Track cache calls
     check_calls = []
 
-    def mock_check_rate_limit(identifier, limit, window):
+    def mock_check_rate_limit(identifier, limit, window, fail_closed=False):
       check_calls.append((identifier, limit, window))
       return (True, limit - 1)
 
@@ -169,7 +169,7 @@ class TestRateLimitIsolation:
     # Track rate limit states per key
     rate_limit_states = {}
 
-    def mock_check_rate_limit(identifier, limit, window):
+    def mock_check_rate_limit(identifier, limit, window, fail_closed=False):
       if identifier not in rate_limit_states:
         rate_limit_states[identifier] = {"count": 0, "limit": limit}
 
@@ -233,7 +233,7 @@ class TestRateLimitIsolation:
 
     check_calls = []
 
-    def mock_check_rate_limit(identifier, limit, window):
+    def mock_check_rate_limit(identifier, limit, window, fail_closed=False):
       check_calls.append((identifier, limit, window))
       return (True, limit - 1)
 
@@ -302,7 +302,7 @@ class TestRateLimitIsolation:
     # Track rate limit states per key
     rate_limit_states = {}
 
-    def mock_check_rate_limit(identifier, limit, window):
+    def mock_check_rate_limit(identifier, limit, window, fail_closed=False):
       if identifier not in rate_limit_states:
         rate_limit_states[identifier] = {"count": 0, "limit": limit}
 

--- a/tests/middleware/rate_limits/test_rate_limiting.py
+++ b/tests/middleware/rate_limits/test_rate_limiting.py
@@ -600,3 +600,44 @@ class TestPublishedPrincipalIdentity:
     limit, window = get_rate_limit_config(identifier)
     anon_limit, _ = get_rate_limit_config("ip:10.0.0.9")
     assert limit > anon_limit
+
+
+class TestScimIpRateLimitDependency:
+  """Pre-auth IP backstop: rotating bogus bearers must share one IP bucket.
+
+  The per-token SCIM bucket keys off the presented bearer, so each invented
+  bearer would otherwise mint a fresh full-size bucket; this bucket caps that
+  churn per source IP before authentication.
+  """
+
+  @patch(f"{MODULE}.rate_limit_cache")
+  @patch(f"{MODULE}.get_int_env", return_value=300)
+  def test_rotating_bearers_share_the_ip_bucket(self, mock_env, mock_cache):
+    from robosystems.middleware.rate_limits.rate_limiting import (
+      scim_ip_rate_limit_dependency,
+    )
+
+    mock_cache.check_rate_limit.return_value = (True, 299)
+    keys = []
+    for token in ("rfssaaa", "rfssbbb", "rfssccc"):
+      request = _make_request(
+        headers={"Authorization": f"Bearer {token}"}, host="10.0.0.9"
+      )
+      scim_ip_rate_limit_dependency(request)
+      keys.append(mock_cache.check_rate_limit.call_args[0][0])
+
+    assert len(set(keys)) == 1
+    assert keys[0].startswith("apikey:scim-ip:10.0.0.9")
+
+  @patch(f"{MODULE}.rate_limit_cache")
+  @patch(f"{MODULE}.get_int_env", return_value=300)
+  def test_ip_bucket_gets_the_full_limit(self, mock_env, mock_cache):
+    from robosystems.middleware.rate_limits.rate_limiting import (
+      scim_ip_rate_limit_dependency,
+    )
+
+    mock_cache.check_rate_limit.return_value = (True, 299)
+    request = _make_request(headers={}, host="10.0.0.9")
+    scim_ip_rate_limit_dependency(request)
+    # Full 300, not the anonymous 30 — the bucket is deliberately IP-keyed.
+    assert mock_cache.check_rate_limit.call_args[0][1] == 300

--- a/tests/middleware/rate_limits/test_rate_limiting.py
+++ b/tests/middleware/rate_limits/test_rate_limiting.py
@@ -641,3 +641,26 @@ class TestScimIpRateLimitDependency:
     scim_ip_rate_limit_dependency(request)
     # Full 300, not the anonymous 30 — the bucket is deliberately IP-keyed.
     assert mock_cache.check_rate_limit.call_args[0][1] == 300
+
+
+class TestScimBucketsFailClosed:
+  """A limiter-backend outage must not silently disable SCIM's throttles."""
+
+  @patch(f"{MODULE}.rate_limit_cache")
+  @patch(f"{MODULE}.get_int_env", return_value=120)
+  def test_both_scim_buckets_pass_fail_closed(self, mock_env, mock_cache):
+    from robosystems.middleware.rate_limits.rate_limiting import (
+      scim_ip_rate_limit_dependency,
+      scim_rate_limit_dependency,
+    )
+
+    mock_cache.check_rate_limit.return_value = (True, 1)
+    request = _make_request(
+      headers={"Authorization": "Bearer rfssaaa"}, host="10.0.0.9"
+    )
+
+    scim_rate_limit_dependency(request)
+    assert mock_cache.check_rate_limit.call_args.kwargs["fail_closed"] is True
+
+    scim_ip_rate_limit_dependency(request)
+    assert mock_cache.check_rate_limit.call_args.kwargs["fail_closed"] is True

--- a/tests/models/core/user/test_scim_token.py
+++ b/tests/models/core/user/test_scim_token.py
@@ -1,0 +1,61 @@
+"""ScimToken model invariants: every token expires, enforced in the model.
+
+The admin bootstrap layer bounds lifetimes too, but the invariant lives here
+so no direct caller can mint a non-expiring bearer, and a pre-invariant NULL
+row cannot keep authenticating forever.
+"""
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+from robosystems.models.core import Org, OrgType, ScimToken
+from robosystems.models.core.user.scim_token import DEFAULT_TOKEN_LIFETIME_DAYS
+
+
+def _org(test_db):
+  return Org.create(
+    name=f"Token Org {uuid.uuid4().hex[:6]}",
+    org_type=OrgType.ENTERPRISE,
+    session=test_db,
+  )
+
+
+class TestExpiryInvariant:
+  def test_create_without_expiry_gets_the_default_lifetime(self, test_db):
+    token, raw = ScimToken.create(_org(test_db).id, "default-lifetime", test_db)
+
+    assert token.expires_at is not None
+    expires = token.expires_at
+    if expires.tzinfo is None:
+      expires = expires.replace(tzinfo=UTC)
+    delta = expires - datetime.now(UTC)
+    assert (
+      timedelta(days=DEFAULT_TOKEN_LIFETIME_DAYS - 1)
+      < delta
+      <= timedelta(days=DEFAULT_TOKEN_LIFETIME_DAYS)
+    )
+    assert ScimToken.validate_token(raw, test_db) is not None
+
+  def test_explicit_expiry_is_honored(self, test_db):
+    expires_at = datetime.now(UTC) + timedelta(days=30)
+    token, _raw = ScimToken.create(
+      _org(test_db).id, "short", test_db, expires_at=expires_at
+    )
+    assert token.expires_at is not None
+
+  def test_null_expiry_row_is_refused(self, test_db):
+    """A row predating the invariant must not authenticate forever."""
+    token, raw = ScimToken.create(_org(test_db).id, "legacy", test_db)
+    token.expires_at = None
+    test_db.commit()
+
+    assert ScimToken.validate_token(raw, test_db) is None
+
+  def test_expired_token_is_refused(self, test_db):
+    _token, raw = ScimToken.create(
+      _org(test_db).id,
+      "expired",
+      test_db,
+      expires_at=datetime.now(UTC) - timedelta(minutes=1),
+    )
+    assert ScimToken.validate_token(raw, test_db) is None

--- a/tests/models/core/user/test_user_api_key.py
+++ b/tests/models/core/user/test_user_api_key.py
@@ -434,7 +434,7 @@ class TestUserAPIKeyModel:
     db_key = db_session.query(UserAPIKey).filter_by(id=api_key.id).first()
     assert db_key.last_used_at is None
 
-  @patch("robosystems.models.core.user.user_api_key.UserAPIKey._invalidate_cache")
+  @patch("robosystems.models.core.user.user_api_key.UserAPIKey.invalidate_cache")
   def test_deactivate_api_key(self, mock_invalidate, db_session):
     """Test deactivating an API key."""
     # Create a test user and API key
@@ -467,7 +467,7 @@ class TestUserAPIKeyModel:
     db_key = db_session.query(UserAPIKey).filter_by(id=api_key.id).first()
     assert db_key.is_active is False
 
-  @patch("robosystems.models.core.user.user_api_key.UserAPIKey._invalidate_cache")
+  @patch("robosystems.models.core.user.user_api_key.UserAPIKey.invalidate_cache")
   def test_activate_api_key(self, mock_invalidate, db_session):
     """Test activating an API key."""
     # Create a test user and API key
@@ -505,7 +505,7 @@ class TestUserAPIKeyModel:
     db_key = db_session.query(UserAPIKey).filter_by(id=api_key.id).first()
     assert db_key.is_active is True
 
-  @patch("robosystems.models.core.user.user_api_key.UserAPIKey._invalidate_cache")
+  @patch("robosystems.models.core.user.user_api_key.UserAPIKey.invalidate_cache")
   def test_delete_api_key(self, mock_invalidate, db_session):
     """Test deleting an API key."""
     # Create a test user and API key
@@ -535,7 +535,7 @@ class TestUserAPIKeyModel:
 
   @patch("importlib.import_module")
   @patch("robosystems.models.core.user.user_api_key.SecurityAuditLogger")
-  def test_invalidate_cache(self, mock_audit_logger, mock_import_module, db_session):
+  def testinvalidate_cache(self, mock_audit_logger, mock_import_module, db_session):
     """Test cache invalidation."""
     # Mock the cache module
     mock_cache_module = MagicMock()
@@ -553,7 +553,7 @@ class TestUserAPIKeyModel:
     )
 
     # Call invalidate cache
-    api_key._invalidate_cache()
+    api_key.invalidate_cache()
 
     # Verify cache invalidation was called with the fingerprint (matches the
     # cache key used by validate_api_key), not the bcrypt key_hash.
@@ -566,7 +566,7 @@ class TestUserAPIKeyModel:
 
   @patch("importlib.import_module")
   @patch("robosystems.models.core.user.user_api_key.logger")
-  def test_invalidate_cache_error(self, mock_logger, mock_import_module):
+  def testinvalidate_cache_error(self, mock_logger, mock_import_module):
     """Test cache invalidation error handling."""
     # Mock import failure
     mock_import_module.side_effect = ImportError("Module not found")
@@ -580,7 +580,7 @@ class TestUserAPIKeyModel:
     )
 
     # Call invalidate cache - should not raise
-    api_key._invalidate_cache()
+    api_key.invalidate_cache()
 
     # Verify error was logged
     mock_logger.error.assert_called_once()
@@ -650,8 +650,8 @@ class TestUserAPIKeyModel:
       prefix="rfs12345",
     )
 
-    # Mock _invalidate_cache to avoid import issues
-    with patch.object(api_key, "_invalidate_cache"):
+    # Mock invalidate_cache to avoid import issues
+    with patch.object(api_key, "invalidate_cache"):
       with pytest.raises(SQLAlchemyError):
         api_key.delete(mock_session)
 

--- a/tests/models/core/user/test_user_model.py
+++ b/tests/models/core/user/test_user_model.py
@@ -254,12 +254,26 @@ class TestUserModel:
 
     # Delete org-related tables before deleting users
     try:
-      from robosystems.models.core import Org, OrgInvitation, OrgLimits, OrgUser
+      from robosystems.models.core import (
+        Org,
+        OrgInvitation,
+        OrgLimits,
+        OrgUser,
+        ScimToken,
+      )
 
       db_session.query(OrgInvitation).delete()
       db_session.query(OrgUser).delete()
       db_session.query(OrgLimits).delete()
+      db_session.query(ScimToken).delete()
       db_session.query(Org).delete()
+    except ImportError:
+      pass
+
+    try:
+      from robosystems.models.core import UserIdentity
+
+      db_session.query(UserIdentity).delete()
     except ImportError:
       pass
 

--- a/tests/operations/admin/test_scim_bootstrap.py
+++ b/tests/operations/admin/test_scim_bootstrap.py
@@ -1,5 +1,7 @@
 """Tests for SCIM provisioning bootstrap."""
 
+from datetime import UTC, datetime, timedelta
+
 import pytest
 
 from robosystems.models.core import Org, OrgLimits, OrgType, ScimToken
@@ -47,6 +49,23 @@ class TestBootstrapScim:
     # Both live during the swap.
     assert ScimToken.validate_token(first.raw_token, test_db) is not None
     assert ScimToken.validate_token(second.raw_token, test_db) is not None
+
+  def test_token_expires_by_default(self, test_db):
+    """Every token expires — there is deliberately no non-expiring mint."""
+    result = bootstrap_scim(test_db, org_name="Expiry Co")
+
+    delta = result.expires_at - datetime.now(UTC)
+    assert timedelta(days=364) < delta <= timedelta(days=365)
+    # Still valid today, and the stored row carries the expiry.
+    token = ScimToken.validate_token(result.raw_token, test_db)
+    assert token is not None
+    assert token.expires_at is not None
+
+  def test_custom_expiry_honored(self, test_db):
+    result = bootstrap_scim(test_db, org_name="Short Co", expires_in_days=30)
+
+    delta = result.expires_at - datetime.now(UTC)
+    assert timedelta(days=29) < delta <= timedelta(days=30)
 
 
 class TestRevokeScimToken:

--- a/tests/operations/admin/test_user_status.py
+++ b/tests/operations/admin/test_user_status.py
@@ -158,3 +158,41 @@ class TestRevocationCountIsWhatActuallyHappened:
 
     assert change.api_keys_revoked == 0
     assert change.api_keys_failed == 0
+
+
+class TestFullyApplied:
+  """The response must say whether the kill switch fully took, not just
+  whether the key rows flipped — a surviving cache entry authenticates
+  until its TTL."""
+
+  def test_cache_failure_is_not_fully_applied(self, test_db, test_user, monkeypatch):
+    user = _create_user(test_db, test_user.password_hash)
+    monkeypatch.setattr(User, "_invalidate_auth_cache", lambda self: False)
+
+    change = set_user_active(user.id, False, test_db)
+
+    assert change.fully_applied is False
+    # The key side was clean; the session cache wasn't.
+    assert change.api_keys_failed == 0
+
+  def test_key_cache_failure_is_not_fully_applied(
+    self, test_db, test_user, monkeypatch
+  ):
+    user = _create_user(test_db, test_user.password_hash)
+    UserAPIKey.create(user_id=user.id, name="k", session=test_db)
+    monkeypatch.setattr(UserAPIKey, "invalidate_cache", lambda self: False)
+
+    change = set_user_active(user.id, False, test_db)
+
+    assert change.fully_applied is False
+    # The row itself revoked fine — only its cache entry survived.
+    assert change.api_keys_revoked == 1
+    assert change.api_keys_failed == 0
+
+  def test_clean_deactivation_is_fully_applied(self, test_db, test_user):
+    user = _create_user(test_db, test_user.password_hash)
+    UserAPIKey.create(user_id=user.id, name="k", session=test_db)
+
+    change = set_user_active(user.id, False, test_db)
+
+    assert change.fully_applied is True

--- a/tests/routers/auth/test_password_auth_flag.py
+++ b/tests/routers/auth/test_password_auth_flag.py
@@ -1,0 +1,94 @@
+"""PASSWORD_AUTH_ENABLED must disable the whole password-credential surface.
+
+Regression suite for posture drift: the flag drives /auth/providers (what the
+UI renders) and these guards (what the API accepts) — if the two ever diverge,
+a hidden-but-functional password login would bypass the IdP's MFA and
+conditional-access policies on an SSO-primary deployment.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from robosystems.config import env
+
+# (method, path, request kwargs) for every password-credential endpoint.
+# Bodies are shape-valid so the guard is what answers, not model validation.
+PASSWORD_ENDPOINTS = [
+  (
+    "post",
+    "/v1/auth/login",
+    {"json": {"email": "someone@example.com", "password": "irrelevant-pw-1"}},
+  ),
+  (
+    "post",
+    "/v1/auth/register",
+    {
+      "json": {
+        "name": "Someone",
+        "email": "someone@example.com",
+        "password": "irrelevant-pw-1",
+      }
+    },
+  ),
+  (
+    "post",
+    "/v1/auth/password/forgot",
+    {"json": {"email": "someone@example.com"}},
+  ),
+  (
+    "get",
+    "/v1/auth/password/reset/validate",
+    {"params": {"token": "some-reset-token"}},
+  ),
+  (
+    "post",
+    "/v1/auth/password/reset",
+    {"json": {"token": "some-reset-token", "password": "irrelevant-pw-1"}},
+  ),
+]
+
+
+class TestPasswordAuthDisabled:
+  @pytest.mark.parametrize("method,path,kwargs", PASSWORD_ENDPOINTS)
+  def test_endpoint_refuses_when_disabled(self, client, method, path, kwargs):
+    with patch.object(env, "PASSWORD_AUTH_ENABLED", False):
+      resp = getattr(client, method)(path, **kwargs)
+    assert resp.status_code == 403
+    assert "disabled" in str(resp.json()["detail"]).lower()
+
+  def test_password_change_refuses_when_disabled(self, client, test_user):
+    from robosystems.middleware.auth.jwt import create_jwt_token
+
+    jwt = create_jwt_token(test_user.id)
+    with patch.object(env, "PASSWORD_AUTH_ENABLED", False):
+      resp = client.put(
+        "/v1/user/password",
+        headers={"Authorization": f"Bearer {jwt}"},
+        json={
+          "current_password": "irrelevant-pw-1",
+          "new_password": "irrelevant-pw-2",
+          "confirm_password": "irrelevant-pw-2",
+        },
+      )
+    assert resp.status_code == 403
+
+  def test_invitation_does_not_bypass_the_guard(self, client):
+    """An invite token must not become a side door to a password account."""
+    with patch.object(env, "PASSWORD_AUTH_ENABLED", False):
+      resp = client.post(
+        "/v1/auth/register",
+        json={
+          "name": "Invited",
+          "email": "invited@example.com",
+          "password": "irrelevant-pw-1",
+          "invite_token": "some-invite-token",
+        },
+      )
+    assert resp.status_code == 403
+
+
+class TestPasswordAuthDefaultOpen:
+  def test_forgot_password_open_by_default(self, client):
+    resp = client.post("/v1/auth/password/forgot", json={"email": "nobody@example.com"})
+    assert resp.status_code == 200

--- a/tests/routers/scim/test_scim_users.py
+++ b/tests/routers/scim/test_scim_users.py
@@ -246,6 +246,76 @@ class TestDeactivation:
     test_db.refresh(member)
     assert member.is_active is True
 
+  def test_stale_key_cache_fails_deactivation_and_retry_repairs(
+    self, client, scim_auth, test_db, enterprise_org
+  ):
+    """A revoked key whose validation-cache entry survived must fail the
+    deactivation (503), and the retry must sweep that key's cache even
+    though the key row is no longer active — a retry that only looked at
+    active rows would have nothing left to fix."""
+    from robosystems.models.core.user.user_api_key import UserAPIKey
+
+    member = _make_member(test_db, enterprise_org)
+    UserAPIKey.create(user_id=member.id, name="k", session=test_db)
+    deactivate_body = {
+      "Operations": [{"op": "replace", "path": "active", "value": False}]
+    }
+
+    with patch.object(UserAPIKey, "invalidate_cache", return_value=False):
+      resp = client.patch(
+        f"/scim/v2/Users/{member.id}", headers=scim_auth, json=deactivate_body
+      )
+    assert resp.status_code == 503
+
+    # The DB half applied: the key row is already revoked.
+    assert UserAPIKey.get_active_by_user_id(str(member.id), test_db) == []
+
+    with patch.object(
+      UserAPIKey, "invalidate_cache", return_value=True
+    ) as mock_invalidate:
+      resp = client.patch(
+        f"/scim/v2/Users/{member.id}", headers=scim_auth, json=deactivate_body
+      )
+    assert resp.status_code == 200
+    # The now-inactive key's cache entry was swept on the retry.
+    assert mock_invalidate.call_count == 1
+
+  def test_patch_with_no_supported_operation_is_400(
+    self, client, scim_auth, test_db, enterprise_org
+  ):
+    """A PATCH we applied nothing from must not report success — the shape
+    we failed to parse could have been a deactivation."""
+    member = _make_member(test_db, enterprise_org)
+    resp = client.patch(
+      f"/scim/v2/Users/{member.id}",
+      headers=scim_auth,
+      json={"Operations": [{"op": "replace", "path": "displayName", "value": "X"}]},
+    )
+    assert resp.status_code == 400
+    assert resp.json()["detail"]["scimType"] == "invalidValue"
+    test_db.refresh(member)
+    assert member.is_active is True
+
+  def test_patch_multi_op_with_active_still_applies(
+    self, client, scim_auth, test_db, enterprise_org
+  ):
+    """Unknown ops riding alongside active (the Entra multi-op shape) must
+    not block the one operation that matters."""
+    member = _make_member(test_db, enterprise_org)
+    resp = client.patch(
+      f"/scim/v2/Users/{member.id}",
+      headers=scim_auth,
+      json={
+        "Operations": [
+          {"op": "replace", "path": "displayName", "value": "X"},
+          {"op": "Replace", "path": "active", "value": "False"},
+        ]
+      },
+    )
+    assert resp.status_code == 200
+    test_db.refresh(member)
+    assert member.is_active is False
+
   def test_incomplete_deactivation_is_503_and_retryable(
     self, client, scim_auth, test_db, enterprise_org
   ):

--- a/tests/routers/scim/test_scim_users.py
+++ b/tests/routers/scim/test_scim_users.py
@@ -7,6 +7,7 @@ minted in the test DB and presented as the bearer.
 """
 
 import uuid
+from unittest.mock import patch
 
 import pytest
 
@@ -244,3 +245,36 @@ class TestDeactivation:
     assert resp.status_code == 200
     test_db.refresh(member)
     assert member.is_active is True
+
+  def test_incomplete_deactivation_is_503_and_retryable(
+    self, client, scim_auth, test_db, enterprise_org
+  ):
+    """The offboarding kill switch must fail loud, not report success.
+
+    When the revocation side effects don't all take (here: the auth-cache
+    invalidation), the IdP must see a retryable failure — and the retry must
+    re-run those side effects even though the DB flag already flipped.
+    """
+    member = _make_member(test_db, enterprise_org)
+    deactivate_body = {
+      "Operations": [{"op": "replace", "path": "active", "value": False}]
+    }
+
+    with patch.object(User, "_invalidate_auth_cache", return_value=False):
+      resp = client.patch(
+        f"/scim/v2/Users/{member.id}", headers=scim_auth, json=deactivate_body
+      )
+    assert resp.status_code == 503
+
+    # The DB half still applied — the account is inactive either way.
+    test_db.refresh(member)
+    assert member.is_active is False
+    version_after_failure = member.session_version or 0
+
+    # The IdP retry re-asserts the side effects and now reports success.
+    resp = client.patch(
+      f"/scim/v2/Users/{member.id}", headers=scim_auth, json=deactivate_body
+    )
+    assert resp.status_code == 200
+    test_db.refresh(member)
+    assert (member.session_version or 0) > version_after_failure

--- a/tests/routers/user/test_api_key_revocation.py
+++ b/tests/routers/user/test_api_key_revocation.py
@@ -1,0 +1,50 @@
+"""User-facing API-key revocation must fail loud when revocation is partial.
+
+Same contract as the SCIM deactivation path: the key row flips in the DB
+either way, but a surviving cached validation entry keeps the key usable
+until its TTL — so the endpoint must return a retryable failure rather than
+"revoked successfully", and the retry must converge (the lookup includes
+inactive keys, and deactivate re-asserts the cache invalidation).
+"""
+
+from unittest.mock import patch
+
+from robosystems.middleware.auth.jwt import create_jwt_token
+from robosystems.models.core.user.user_api_key import UserAPIKey
+
+
+def _auth(user):
+  return {"Authorization": f"Bearer {create_jwt_token(user.id)}"}
+
+
+def _is_active(session, key_id: str) -> bool:
+  # Re-query rather than refresh: the endpoint's error path closes the shared
+  # test session, detaching instances created before the request.
+  row = session.query(UserAPIKey).filter(UserAPIKey.id == key_id).one()
+  return bool(row.is_active)
+
+
+class TestRevocationCompleteness:
+  def test_stale_cache_is_503_and_retry_converges(self, client, test_user, test_db):
+    key, _plain = UserAPIKey.create(user_id=test_user.id, name="k", session=test_db)
+    key_id = str(key.id)
+
+    with patch.object(UserAPIKey, "invalidate_cache", return_value=False):
+      resp = client.delete(f"/v1/user/api-keys/{key_id}", headers=_auth(test_user))
+    assert resp.status_code == 503
+
+    # The DB half applied regardless.
+    assert _is_active(test_db, key_id) is False
+
+    # The retry finds the now-inactive key and re-asserts the invalidation.
+    resp = client.delete(f"/v1/user/api-keys/{key_id}", headers=_auth(test_user))
+    assert resp.status_code == 200
+    assert resp.json()["success"] is True
+
+  def test_clean_revocation_succeeds(self, client, test_user, test_db):
+    key, _plain = UserAPIKey.create(user_id=test_user.id, name="k2", session=test_db)
+    key_id = str(key.id)
+
+    resp = client.delete(f"/v1/user/api-keys/{key_id}", headers=_auth(test_user))
+    assert resp.status_code == 200
+    assert _is_active(test_db, key_id) is False


### PR DESCRIPTION
## Summary

Hardening pass over the enterprise SSO/SCIM surface (follow-up to #1148/#1149/#1150), from an external design review of the merged work:

- **Enforce the \`PASSWORD_AUTH_ENABLED\` posture at the endpoints.** The flag previously drove only the \`/auth/providers\` advertisement; now every password-credential endpoint (login, register, forgot/validate/reset, password change) refuses with 403 when it is disabled. Invitations do not bypass the guard. No behavior change for deployments with the flag at its default (true).
- **SCIM rate limiting: pre-auth IP bucket + boot checks.** An IP-keyed bucket now sits in front of the per-token bucket on \`/scim/v2\`; boot validation requires rate limiting to be enabled whenever the OIDC/SCIM surface is mounted outside local dev, requires an https issuer, and restricts \`SSO_DEFAULT_ROLE\` to member/admin.
- **SCIM provisioning tokens expire by default** (365d, configurable 1–3650 via admin API/CLI; rotation stays overlap-based). \`/admin\` responses now carry \`Cache-Control: no-store\`.
- **Deactivation reports completeness.** \`User.deactivate\` returns what actually took (keys revoked, cache invalidated); the SCIM active-toggle returns a retryable 503 when side effects don't fully apply and re-asserts them on the IdP's retry instead of short-circuiting.

## Testing

- Full suite green (\`just test-all\`: 12,656 passed + ruff/format/basedpyright clean)
- New coverage: posture-guard parametrized suite, IP-bucket keying, boot-validation pass/fail pairs, token-expiry defaults, incomplete-deactivation 503 + retry convergence
- Security review run on the branch: no findings