### PR TITLE
docs: realign READMEs and instruction files with the code

### DIFF
--- a/.github/workflows/deploy-graph-replicas.yml
+++ b/.github/workflows/deploy-graph-replicas.yml
@@ -49,10 +49,9 @@ on:
         required: true
         type: string
       instance_type:
-        description: "EC2 instance type for replicas"
-        required: false
+        description: "EC2 instance type for replicas (authoritative source is .github/configs/graph.yml)"
+        required: true
         type: string
-        default: "r7g.medium"
 
       # Auto-scaling Configuration
       min_instances:

--- a/.github/workflows/deploy-graph.yml
+++ b/.github/workflows/deploy-graph.yml
@@ -429,8 +429,14 @@ jobs:
           echo "📊 Deployment Summary:"
           echo "  - $LBUG_COUNT Graph writers (LadybugDB)"
 
-          # Extract shared replica config from graph.yml
-          REPLICA_INSTANCE_TYPE=$(yq eval ".${ENV_KEY}.replicas[0].instance.type // \"m7g.large\"" .github/configs/graph.yml)
+          # Extract shared replica config from graph.yml. No fallback default:
+          # a silent guess here provisions the wrong hardware for the whole
+          # replica fleet, so a missing key must stop the deploy instead.
+          REPLICA_INSTANCE_TYPE=$(yq eval ".${ENV_KEY}.replicas[0].instance.type" .github/configs/graph.yml)
+          if [ -z "$REPLICA_INSTANCE_TYPE" ] || [ "$REPLICA_INSTANCE_TYPE" = "null" ]; then
+            echo "::error::No replica instance type configured at .${ENV_KEY}.replicas[0].instance.type in .github/configs/graph.yml"
+            exit 1
+          fi
           echo "replica_instance_type=${REPLICA_INSTANCE_TYPE}" >> $GITHUB_OUTPUT
 
           echo "  - Shared replica instance type: ${REPLICA_INSTANCE_TYPE}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -414,7 +414,9 @@ GET  /health                              # Health check
 ### LadybugDB Limitations
 
 - Sequential ingestion (one file at a time per database)
-- Connection pool size configurable (default 3, production config 10)
+- Connection pool is capped at 3 connections per database, everywhere. The per-tier
+  `connection_pool_size` in `.github/configs/graph.yml` and `LBUG_CONNECTION_POOL_SIZE` are surfaced
+  by `env.get_lbug_tier_config()` but read by nothing — tuning either is currently a no-op.
 - Single writer per database at a time
 
 ### Subgraphs

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ Because tenancy is enforced at the graph rather than in application predicates, 
 A curated knowledge graph of US public company financial data from SEC EDGAR XBRL filings. Runs on the shared LadybugDB tier, accessible via MCP tools, Cypher queries, and the AI Operator.
 
 - **Pipeline**: EDGAR → Download → Process (Parquet) → Stage (DuckDB) → Enrich (Icebug+fastembed) → Materialize (LadybugDB) → Index + Embed (OpenSearch)
-- **Graph**: 14 node types and 22 relationship types modeling the full XBRL reporting hierarchy
+- **Graph**: the base schema plus the `roboledger` extension — 20 node types and 41 relationship types modeling the full XBRL reporting hierarchy
 - **Search**: Hybrid BM25 + KNN vector search across XBRL text blocks, narrative sections, and iXBRL disclosures
 - **Enrichment**: Semantic element mapping, statement classification, and disclosure tagging — applying aspects of the Seattle Method to the shared repository's disclosures (the methodology RoboLedger implements more broadly)
 

--- a/bin/setup/README.md
+++ b/bin/setup/README.md
@@ -51,9 +51,9 @@ The complete bootstrap process for a fresh deployment:
 ├─────────────────────────────────────────────────────────────────────────────┤
 │  Deploys cloudformation/bootstrap-oidc.yaml:                                │
 │    - Creates IAM OIDC Provider for GitHub                                   │
-│    - Creates IAM Role for GitHub Actions                                    │
-│    - Trusts: {GitHubOrg}/robosystems (main, release/*, v* tags)             │
-│    - Trusts: {GitHubOrg}/*-app repos (frontend apps)                        │
+│    - Backend role: trusts {GitHubOrg}/{backend repo} only                   │
+│    - Frontend role: trusts the three *-app repos + holon-viewer             │
+│    - Allowed refs (both roles): main, release/*, v* tags                    │
 └─────────────────────────────────────────────────────────────────────────────┘
                                     │
                                     ▼
@@ -72,16 +72,29 @@ The complete bootstrap process for a fresh deployment:
 │  STEP 5: CREATE ECR REPOSITORY                                              │
 ├─────────────────────────────────────────────────────────────────────────────┤
 │  Creates ECR repository:                                                    │
-│    - Repository name derived from GitHub repo (e.g., robosystems)           │
-│    - Image scanning on push                                                 │
-│    - Lifecycle policy: keep last 20 untagged images                         │
+│    - Repository name is always "robosystems" (fleet-uniform, even on        │
+│      a renamed fork — the deploy role's ECR scope assumes it)               │
+│    - Image scanning on push, AES256 encryption                              │
+│    - Prompts for a lifecycle policy: robust (default) / basic / skip        │
 └─────────────────────────────────────────────────────────────────────────────┘
                                     │
                                     ▼
 ┌─────────────────────────────────────────────────────────────────────────────┐
-│  STEP 6: CHECK GITHUB SECRETS                                               │
+│  STEP 6: SES EMAIL IDENTITY                                                 │
 ├─────────────────────────────────────────────────────────────────────────────┤
-│  Checks for optional secrets (not required with OIDC):                      │
+│  Verifies a sending domain for transactional email:                         │
+│    - Prompts for the email domain, stores it as AWS_SES_DOMAIN              │
+│    - Creates the SESv2 domain identity if missing                           │
+│    - Publishes DKIM CNAMEs to Route53 automatically when a hosted           │
+│      zone exists; otherwise prints them for manual DNS entry                │
+│    - Requests SES production access (out of the sandbox)                    │
+└─────────────────────────────────────────────────────────────────────────────┘
+                                    │
+                                    ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│  STEP 7: CHECK GITHUB SECRETS                                               │
+├─────────────────────────────────────────────────────────────────────────────┤
+│  Checks for optional secrets (repo and org level):                          │
 │    - ACTIONS_TOKEN (enables cross-workflow triggers)                        │
 │    - ANTHROPIC_API_KEY (enables AI-powered PR/release notes)                │
 │  Note: AWS credentials NOT needed with OIDC                                 │
@@ -89,7 +102,7 @@ The complete bootstrap process for a fresh deployment:
                                     │
                                     ▼
 ┌─────────────────────────────────────────────────────────────────────────────┐
-│  STEP 7: OPTIONAL CONFIGURATION (Interactive Prompts)                       │
+│  STEP 8: OPTIONAL CONFIGURATION (Interactive Prompts)                       │
 ├─────────────────────────────────────────────────────────────────────────────┤
 │  Prompt: "Setup AWS Secrets Manager?" (Y/n)                                 │
 │    └─► Runs aws.sh if yes (creates secrets + SSM parameters)                │
@@ -97,7 +110,7 @@ The complete bootstrap process for a fresh deployment:
 │  Prompt: "Setup GitHub Variables?" (y/N)                                    │
 │    └─► Runs gha.sh if yes                                                   │
 │                                                                             │
-│  Both prompt for environment choice:                                        │
+│  If either is selected, prompts for environment choice:                     │
 │    1) Production only (recommended)                                         │
 │    2) Production + Staging                                                  │
 └─────────────────────────────────────────────────────────────────────────────┘
@@ -138,21 +151,23 @@ just bootstrap my-fork-sso eu-west-1     # Custom profile and region
 
 **What It Creates**:
 
-| Resource             | Description                                                           |
-| -------------------- | --------------------------------------------------------------------- |
-| `.envrc`             | Local direnv config with AWS_PROFILE and AWS_REGION                   |
-| `~/.aws/config`      | SSO profile (if not exists)                                           |
-| CloudFormation Stack | `RoboSystemsGitHubOIDC`                                               |
-| ECR Repository       | `robosystems` (or repo name)                                          |
-| GitHub Variables     | `AWS_ROLE_ARN`, `AWS_ACCOUNT_ID`, `AWS_REGION`, `AWS_SNS_ALERT_EMAIL` |
-| Secrets Manager      | `robosystems/prod` (credentials)                                      |
-| SSM Parameters       | Feature flags + tuning parameters                                     |
+| Resource             | Description                                                                             |
+| -------------------- | --------------------------------------------------------------------------------------- |
+| `.envrc`             | Local direnv config with AWS_PROFILE and AWS_REGION                                     |
+| `~/.aws/config`      | SSO profile (if not exists)                                                             |
+| CloudFormation Stack | `RoboSystemsGitHubOIDC`                                                                 |
+| ECR Repository       | `robosystems` (fixed name, not derived from the repo)                                   |
+| SES Identity         | Domain identity + DKIM records for transactional email                                  |
+| GitHub Variables     | `AWS_ROLE_ARN`, `AWS_ACCOUNT_ID`, `AWS_REGION`, `AWS_SNS_ALERT_EMAIL`, `AWS_SES_DOMAIN` |
+| Secrets Manager      | `robosystems/prod` (credentials)                                                        |
+| SSM Parameters       | Feature flags + tuning parameters                                                       |
 
 **Environment Variables Used**:
 | Variable | Source | Description |
 |----------|--------|-------------|
 | `AWS_PROFILE` | Argument or env | SSO profile to use |
 | `AWS_REGION` | Argument or env | AWS region |
+| `ECR_LIFECYCLE_POLICY` | Env | Skips the lifecycle-policy prompt: `robust` (the bundled `ecr-lifecycle-policy.json`), `basic`, or `skip`/`none` |
 
 ---
 
@@ -181,22 +196,34 @@ just setup-aws
 | ---------- | ------------------------------- | ------------------------------ |
 | Secret     | `robosystems/prod`              | Production credentials         |
 | Secret     | `robosystems/staging`           | Staging credentials (optional) |
-| SSM Params | `/robosystems/{env}/features/*` | Feature flags (27 params)      |
-| SSM Params | `/robosystems/{env}/tuning/*`   | Tuning parameters (33 params)  |
+| SSM Params | `/robosystems/{env}/features/*` | Feature flags                  |
+| SSM Params | `/robosystems/{env}/tuning/*`   | Tuning parameters              |
 
-**Secrets Manager** (credentials only):
+The parameter sets live in the `params` arrays in `aws.sh` — read those for the
+current names and seeded values, or `just ssm-list {env} {features,tuning}` for
+what an environment actually has.
+
+**Secrets Manager** (credentials only — placeholders you fill in, except the two
+generated keys). `JWT_ISSUER` / `JWT_AUDIENCE` are only written in `internal`
+access mode:
 
 ```json
 {
-  "JWT_SECRET_KEY": "[generated]",
   "JWT_ISSUER": "localhost",
   "JWT_AUDIENCE": "localhost",
+  "JWT_SECRET_KEY": "[generated]",
   "CONNECTION_CREDENTIALS_KEY": "[generated]",
+  "TURNSTILE_SECRET_KEY": "...",
+  "TURNSTILE_SITE_KEY": "...",
   "INTUIT_CLIENT_ID": "...",
   "INTUIT_CLIENT_SECRET": "...",
-  "STRIPE_SECRET_KEY": "...",
+  "INTUIT_ENVIRONMENT": "production",
+  "INTUIT_REDIRECT_URI": "...",
   "SEC_GOV_USER_AGENT": "...",
-  "TURNSTILE_SECRET_KEY": "..."
+  "OPENFIGI_API_KEY": "...",
+  "STRIPE_SECRET_KEY": "...",
+  "STRIPE_PUBLISHABLE_KEY": "...",
+  "STRIPE_WEBHOOK_SECRET": "..."
 }
 ```
 
@@ -214,6 +241,9 @@ just setup-aws
   circuits/THRESHOLD, circuits/TIMEOUT, ...
   load_shedding/START_PRESSURE, load_shedding/STOP_PRESSURE, ...
   mcp/MAX_RESULT_ROWS, mcp/MAX_RESULT_SIZE_MB, ...
+  workers/MAX_WORKERS, timeouts/GRAPH_HTTP, timeouts/GRAPH_QUERY, ...
+  sse/MAX_CONNECTIONS_PER_USER, sse/QUEUE_SIZE, limits/ORG_GRAPHS_DEFAULT, ...
+  database/POOL_SIZE, database/MAX_OVERFLOW, ...
 ```
 
 **Managing SSM parameters**:
@@ -254,175 +284,67 @@ just setup-gha
 
 **Interactive Prompts**:
 
-1. Environment choice (Production only vs Production + Staging)
+1. Environment choice (Production only vs Production + Staging) — skipped when
+   bootstrap already passed `SETUP_STAGING`
 2. Root domain (optional - leave empty for VPC-only deployment)
 3. GitHub organization name
 4. Repository name
 5. AWS account ID
-6. Alert email (if not already set)
-7. ECR repository name
-8. Optional: RoboLedger/RoboInvestor app URLs
+6. AWS region (defaults to the region bootstrap exported, else `us-east-1`)
+7. Alert email (if not already set)
+8. ECR repository name
+9. Optional: RoboLedger/RoboInvestor app URLs — only offered when a root domain
+   was given
 
-**Variables Set** — run `just gha-list` for the live set.
+**Variables Set** — `gha.sh` is the authoritative list of names and seeded
+defaults; run `just gha-list` for what is live in this repo. The groups it
+configures, in script order:
 
-#### Core Configuration
+| Group                      | Covers                                                                                                                                 |
+| -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| Core & access              | `AWS_ECR_REPOSITORY`, `AWS_ACCOUNT_ID`, `AWS_REGION`, `ENVIRONMENT_*`, `API_ACCESS_MODE_*`                                             |
+| Domains & app URLs         | `API_DOMAIN_NAME_*`, `ROBOSYSTEMS_{API,APP}_URL_*`, `PUBLIC_DOMAIN_NAME_*`, optional `ROBOLEDGER_APP_URL_*` / `ROBOINVESTOR_APP_URL_*` |
+| API sizing & scaling       | `API_{MIN,MAX}_CAPACITY_*`, `API_CPU_*`, `API_MEMORY_*`, `API_{CPU,MEMORY}_TARGET_*`                                                   |
+| Dagster                    | daemon/webserver CPU + memory, `DAGSTER_WEBSERVER_DESIRED_COUNT_*`, `DAGSTER_MAX_CONCURRENT_RUNS_*`, `DAGSTER_CONTAINER_INSIGHTS_*`    |
+| Background worker          | `WORKER_*` (off by default)                                                                                                            |
+| Fargate capacity providers | `API_FARGATE_SPOT_WEIGHT_*`, `DAGSTER_{DAEMON,WEBSERVER}_FARGATE_SPOT_WEIGHT_*`, the matching `*_FARGATE_BASE_*`                       |
+| Database                   | `DATABASE_*` (instance size, storage, Multi-AZ, Postgres version, Performance Insights), `RDS_PROXY_*`                                 |
+| Valkey                     | `VALKEY_*` (node type, node count, version, encryption, snapshot retention)                                                            |
+| OpenSearch                 | `OPENSEARCH_*` (off by default)                                                                                                        |
+| LadybugDB writers          | `LBUG_{STANDARD,LARGE,XLARGE,SHARED}_*`                                                                                                |
+| Shared replicas            | `SHARED_REPLICAS_*`, `SHARED_REPOSITORIES_*`                                                                                           |
+| Graph AMI                  | `GRAPH_AMI_AUTO_UPDATE`, `GRAPH_AMI_AUTO_DEPLOY`                                                                                       |
+| Compliance & security      | `VPC_FLOW_LOGS_*`, `CLOUDTRAIL_*`, `SECURITY_ENABLED`, `SECURITY_CONFIG_ENABLED`, `AUDIT_*`, `SECRETS_ROTATION_ENABLED_*`              |
+| WAF                        | `WAF_*`                                                                                                                                |
+| Networking                 | `VPC_MAX_AVAILABILITY_ZONES`, `VPC_ENDPOINT_MODE`, `VPC_SECOND_OCTET`                                                                  |
+| Runners & alerting         | `RUNNER_LABELS`, `RUNNER_SCOPE`, `AWS_SNS_ALERT_EMAIL`, `API_TARGET_ERROR_THRESHOLD`                                                   |
+| Observability & publishing | `OBSERVABILITY_ENABLED_*`, `DOCKERHUB_PUBLISHING_ENABLED`                                                                              |
 
-| Variable              | Default       | Description                           |
-| --------------------- | ------------- | ------------------------------------- |
-| `AWS_ECR_REPOSITORY`  | `robosystems` | ECR repository name                   |
-| `AWS_ACCOUNT_ID`      | User input    | AWS account ID                        |
-| `AWS_REGION`          | `$AWS_REGION` | AWS region (falls back to `us-east-1`)|
-| `ENVIRONMENT_PROD`    | `prod`        | Production environment name           |
-| `ENVIRONMENT_STAGING` | `staging`     | Staging environment name (if enabled) |
+**Defaults worth knowing before the first deploy** (everything else is safe as
+shipped):
 
-#### Domain Configuration (optional - skip for VPC-only)
-
-| Variable                   | Example                      | Description              |
-| -------------------------- | ---------------------------- | ------------------------ |
-| `API_DOMAIN_NAME_ROOT`     | `robosystems.ai`             | Root domain              |
-| `API_DOMAIN_NAME_PROD`     | `api.robosystems.ai`         | Production API subdomain |
-| `API_DOMAIN_NAME_STAGING`  | `staging.api.robosystems.ai` | Staging API subdomain    |
-| `ROBOSYSTEMS_API_URL_PROD` | `https://api.robosystems.ai` | Production API URL       |
-| `ROBOSYSTEMS_APP_URL_PROD` | `https://robosystems.ai`     | Production app URL       |
-
-#### API Scaling & Sizing
-
-| Variable                    | Prod Default | Staging Default | Description                            |
-| --------------------------- | ------------ | --------------- | -------------------------------------- |
-| `API_MIN_CAPACITY_*`        | `1`          | `1`             | Min ECS tasks                          |
-| `API_MAX_CAPACITY_*`        | `10`         | `2`             | Max ECS tasks                          |
-| `API_CPU_*`                 | `512`        | `512`           | Fargate CPU units                      |
-| `API_MEMORY_*`              | `1024`       | `1024`          | Fargate memory (MB)                    |
-| `API_CPU_TARGET_*`          | `70`         | `70`            | CPU auto-scaling target                |
-| `API_MEMORY_TARGET_*`       | `80`         | `80`            | Memory auto-scaling target             |
-| `API_FARGATE_SPOT_WEIGHT_*` | `90`         | `90`            | Spot weight (OD derived as 100 - spot) |
-| `API_FARGATE_BASE_*`        | `0`          | `0`             | On-Demand base capacity                |
-
-#### Dagster Configuration
-
-| Variable                                  | Prod Default | Description                                      |
-| ----------------------------------------- | ------------ | ------------------------------------------------ |
-| `DAGSTER_DAEMON_CPU_*`                    | `1024`       | Daemon CPU units                                 |
-| `DAGSTER_DAEMON_MEMORY_*`                 | `2048`       | Daemon memory (MB)                               |
-| `DAGSTER_WEBSERVER_CPU_*`                 | `512`        | Webserver CPU units                              |
-| `DAGSTER_WEBSERVER_MEMORY_*`              | `1024`       | Webserver memory (MB)                            |
-| `DAGSTER_MAX_CONCURRENT_RUNS_*`           | `20`         | Max concurrent runs                              |
-| `DAGSTER_CONTAINER_INSIGHTS_*`            | `disabled`   | Container insights                               |
-| `DAGSTER_DAEMON_FARGATE_SPOT_WEIGHT_*`    | `80`         | Daemon Spot weight (OD derived as 100 - spot)    |
-| `DAGSTER_WEBSERVER_FARGATE_SPOT_WEIGHT_*` | `80`         | Webserver Spot weight (OD derived as 100 - spot) |
-| `DAGSTER_DAEMON_FARGATE_BASE_*`           | `0`          | Daemon On-Demand base                            |
-| `DAGSTER_WEBSERVER_FARGATE_BASE_*`        | `0`          | Webserver On-Demand base                         |
-
-#### Database Configuration
-
-| Variable                                | Prod Default   | Description                                  |
-| --------------------------------------- | -------------- | -------------------------------------------- |
-| `DATABASE_INSTANCE_SIZE_*`              | `db.t4g.small` | RDS instance type                            |
-| `DATABASE_ALLOCATED_STORAGE_*`          | `20`           | Initial storage (GB)                         |
-| `DATABASE_MAX_ALLOCATED_STORAGE_*`      | `100`          | Max storage (GB)                             |
-| `DATABASE_MULTI_AZ_ENABLED_*`           | `false`        | Multi-AZ deployment                          |
-| `DATABASE_POSTGRES_VERSION_*`           | `16.11`        | PostgreSQL version                           |
-| `RDS_PROXY_ENABLED_*`                   | `false`        | Enable RDS Proxy for connection pooling      |
-| `RDS_PROXY_MAX_CONNECTIONS_PERCENT_*`   | `100`          | Max % of DB max_connections proxy may use    |
-| `RDS_PROXY_CONNECTION_BORROW_TIMEOUT_*` | `120`          | Seconds client waits for a pooled connection |
-
-#### Valkey Configuration
-
-| Variable                           | Prod Default              | Description        |
-| ---------------------------------- | ------------------------- | ------------------ |
-| `VALKEY_NODE_TYPE_*`               | `cache.t4g.micro`         | Cache node type    |
-| `VALKEY_NUM_NODES_*`               | `1`                       | Number of nodes    |
-| `VALKEY_ENCRYPTION_ENABLED_*`      | `true`                    | Enable encryption  |
-| `VALKEY_SNAPSHOT_RETENTION_DAYS_*` | `7` (prod), `0` (staging) | Snapshot retention |
-| `VALKEY_VERSION_*`                 | `8.1`                     | Valkey version     |
-
-#### LadybugDB Writer Configuration
-
-| Variable                        | Prod Default | Description                              |
-| ------------------------------- | ------------ | ---------------------------------------- |
-| `LBUG_STANDARD_MIN_INSTANCES_*` | `1`          | Min standard instances (always deployed) |
-| `LBUG_STANDARD_MAX_INSTANCES_*` | `10`         | Max standard instances                   |
-| `LBUG_LARGE_ENABLED_*`          | `false`      | Enable large tier                        |
-| `LBUG_LARGE_MIN_INSTANCES_*`    | `0`          | Min large instances                      |
-| `LBUG_LARGE_MAX_INSTANCES_*`    | `20`         | Max large instances                      |
-| `LBUG_XLARGE_ENABLED_*`         | `false`      | Enable xlarge tier                       |
-| `LBUG_XLARGE_MIN_INSTANCES_*`   | `0`          | Min xlarge instances                     |
-| `LBUG_XLARGE_MAX_INSTANCES_*`   | `10`         | Max xlarge instances                     |
-| `LBUG_SHARED_ENABLED_*`         | `false`      | Enable shared tier                       |
-| `LBUG_SHARED_MIN_INSTANCES_*`   | `1`          | Min shared instances                     |
-| `LBUG_SHARED_MAX_INSTANCES_*`   | `1`          | Max shared instances                     |
-
-#### Shared Replicas Configuration
-
-| Variable                                         | Prod Default               | Description                    |
-| ------------------------------------------------ | -------------------------- | ------------------------------ |
-| `SHARED_REPLICAS_ENABLED_*`                      | `false`                    | Enable read-only replica fleet |
-| `SHARED_REPLICAS_MIN_INSTANCES_*`                | `1`                        | Min replica instances          |
-| `SHARED_REPLICAS_MAX_INSTANCES_*`                | `3`                        | Max replica instances          |
-| `SHARED_REPLICAS_DESIRED_CAPACITY_*`             | `1`                        | Initial desired capacity       |
-| `SHARED_REPLICAS_ROOT_VOLUME_SIZE_*`             | `150`                      | Root volume size (GB)          |
-| `SHARED_REPLICAS_CPU_TARGET_*`                   | `70`                       | CPU auto-scaling target        |
-| `SHARED_REPLICAS_MEMORY_TARGET_*`                | `80`                       | Memory auto-scaling target     |
-| `SHARED_REPLICAS_ENABLE_RESPONSE_TIME_SCALING_*` | `false`                    | Response time scaling          |
-| `SHARED_REPLICAS_RESPONSE_TIME_TARGET_*`         | `5`                        | Response time target (s)       |
-| `SHARED_REPLICAS_INSTANCE_WARMUP_*`              | `900`                      | Instance warmup (s)            |
-| `SHARED_REPLICAS_HEALTH_CHECK_GRACE_PERIOD_*`    | `900`                      | Health check grace (s)         |
-| `SHARED_REPOSITORIES_*`                          | `sec`                      | Repos to replicate             |
-| `SHARED_REPLICAS_SPOT_ENABLED_*`                 | `false`                    | Enable Spot instances          |
-| `SHARED_REPLICAS_SPOT_BASE_*`                    | `0`                        | On-Demand base capacity        |
-| `SHARED_REPLICAS_SPOT_WEIGHT_*`                  | `0`                        | Spot weight                    |
-| `SHARED_REPLICAS_SPOT_STRATEGY_*`                | `price-capacity-optimized` | Spot allocation strategy       |
-| `SHARED_REPLICAS_SPOT_REBALANCE_*`               | `true`                     | Enable Spot rebalancing        |
-
-#### Graph Settings
-
-| Variable         | Default       | Description                 |
-| ---------------- | ------------- | --------------------------- |
-| `GRAPH_AMI_ID_*` | Auto-detected | Amazon Linux 2023 ARM64 AMI |
-
-#### Compliance & Security
-
-| Variable                         | Default  | Description                                                                        |
-| -------------------------------- | -------- | ---------------------------------------------------------------------------------- |
-| `VPC_FLOW_LOGS_ENABLED`          | `false`  | Enable VPC flow logs                                                               |
-| `VPC_FLOW_LOGS_RETENTION_DAYS`   | `90`     | Flow log retention                                                                 |
-| `VPC_FLOW_LOGS_TRAFFIC_TYPE`     | `REJECT` | Traffic type to log                                                                |
-| `CLOUDTRAIL_ENABLED`             | `false`  | Enable CloudTrail                                                                  |
-| `CLOUDTRAIL_LOG_RETENTION_DAYS`  | `90`     | CloudTrail retention                                                               |
-| `CLOUDTRAIL_DATA_EVENTS_ENABLED` | `false`  | Log S3 data events                                                                 |
-| `SECRETS_ROTATION_ENABLED_*`     | `false`  | Monthly key rotation                                                               |
-| `AUDIT_ENABLED_*`                | `false`  | Retain audit logs to S3                                                            |
-| `AUDIT_RETENTION_DAYS`           | `400`    | Audit S3 retention (days)                                                          |
-| `SECURITY_ENABLED`               | `false`  | Enable the security baseline (GuardDuty, Security Hub, Access Analyzer, Inspector) |
-| `SECURITY_CONFIG_ENABLED`        | `false`  | Also enable the AWS Config recorder (cost scales with resource count)              |
-
-#### WAF Configuration
-
-| Variable                        | Default | Description               |
-| ------------------------------- | ------- | ------------------------- |
-| `WAF_ENABLED_*`                 | `false` | Enable WAF                |
-| `WAF_RATE_LIMIT_PER_IP`         | `3000`  | Requests per 5 min per IP |
-| `WAF_GEO_BLOCKING_ENABLED`      | `false` | Block non-US/CA traffic   |
-| `WAF_AWS_MANAGED_RULES_ENABLED` | `true`  | Use AWS managed rules     |
-
-#### Runner Configuration
-
-| Variable        | Default         | Description                    |
-| --------------- | --------------- | ------------------------------ |
-| `RUNNER_LABELS` | `github-hosted` | Runner labels (or self-hosted) |
-| `RUNNER_SCOPE`  | `both`          | Where to check for runners     |
-
-#### Other
-
-| Variable                       | Default    | Description                          |
-| ------------------------------ | ---------- | ------------------------------------ |
-| `AWS_SNS_ALERT_EMAIL`          | User input | CloudWatch alert email               |
-| `VPC_MAX_AVAILABILITY_ZONES`   | `2`        | Max AZs to use                       |
-| `VPC_ENDPOINT_MODE`            | `minimal`  | VPC endpoints (gateway/minimal/full) |
-| `VPC_SECOND_OCTET`             | `0`        | VPC CIDR second octet (for peering)  |
-| `OBSERVABILITY_ENABLED_*`      | `true`     | Enable observability                 |
-| `DOCKERHUB_PUBLISHING_ENABLED` | `false`    | Publish to Docker Hub                |
-| `PUBLIC_DOMAIN_NAME_*`         | (optional) | Public data domain                   |
+- **Fargate Spot is off in production.** `API_FARGATE_SPOT_WEIGHT_PROD` and both
+  Dagster spot weights seed to `0`; staging seeds them on (`90` for the API,
+  `80` for Dagster). The on-demand weight is not a variable — the deploy
+  workflow derives it as `100 - spot_weight`.
+- **Compliance and security stacks ship off** — VPC flow logs, CloudTrail, the
+  security baseline (GuardDuty, Security Hub, Access Analyzer, Inspector), the
+  AWS Config recorder, audit-log retention, secrets rotation, and WAF. The
+  baseline also needs the deploy-role grants from `bootstrap-oidc`, so re-run
+  bootstrap after enabling it.
+- **Only the standard LadybugDB writer tier deploys by default.** Large, xlarge,
+  shared, the shared-replica fleet, and OpenSearch are all opt-in. Shared-replica
+  Spot is off as well (`SHARED_REPLICAS_SPOT_ENABLED_*=false`, with
+  `SHARED_REPLICAS_OD_BASE_*` and `SHARED_REPLICAS_SPOT_WEIGHT_*` at `0`).
+- **`VPC_ENDPOINT_MODE=minimal`** — `gateway` is free (S3 + DynamoDB only),
+  `minimal` adds the ECR endpoints that keep deployment image pulls off the NAT
+  gateway, `full` costs roughly double `minimal`.
+- **`RUNNER_LABELS=github-hosted`** — set it to e.g. `self-hosted,Linux,X64` to
+  run workflows on your own runners; `RUNNER_SCOPE` (`repo` / `org` / `both`)
+  controls where the workflows look for them.
+- **Staging variables are only written when you pick "Production + Staging".**
+  Choosing production only also *deletes* `ENVIRONMENT_STAGING`, which is what
+  keeps staging deployments from firing accidentally.
 
 ---
 
@@ -546,23 +468,30 @@ Registers a local LadybugDB writer instance:
 
 **Databases Created**:
 
-| Database           | Purpose                                            |
-| ------------------ | -------------------------------------------------- |
-| `robosystems`      | Main application database (IAM, billing, metadata) |
-| `robosystems_test` | Test database for pytest                           |
-| `dagster`          | Dagster metadata database                          |
+| Database           | Purpose                                             |
+| ------------------ | --------------------------------------------------- |
+| `robosystems`      | Platform database (IAM, billing, graph metadata)    |
+| `robosystems_test` | Platform test database for pytest                   |
+| `dagster`          | Dagster metadata database                           |
+| `extensions`       | Extensions OLTP database (roboledger, roboinvestor) |
+| `extensions_test`  | Extensions test database for pytest                 |
+
+`robosystems` itself is created by the Postgres container from `POSTGRES_DB`;
+the script adds the other four. The platform and extensions databases have
+independent Alembic histories — see the migration commands in the root
+[CLAUDE.md](/CLAUDE.md).
 
 ---
 
 ## Environment Files
 
-Bootstrap creates/updates these files:
+| File         | Purpose                                          | Created by                 | Git Ignored |
+| ------------ | ------------------------------------------------ | -------------------------- | ----------- |
+| `.envrc`     | Direnv config (AWS_PROFILE, AWS_REGION)          | `bootstrap.sh`             | Yes         |
+| `.env`       | Docker Compose environment (container hostnames) | `just start` / `just init` | Yes         |
+| `.env.local` | Local development (localhost URLs)               | `just start` / `just init` | Yes         |
 
-| File         | Purpose                                          | Git Ignored |
-| ------------ | ------------------------------------------------ | ----------- |
-| `.envrc`     | Direnv config (AWS_PROFILE, AWS_REGION)          | No          |
-| `.env`       | Docker Compose environment (container hostnames) | Yes         |
-| `.env.local` | Local development (localhost URLs)               | Yes         |
+`bedrock.sh` writes the Bedrock development credentials into `.env`.
 
 ---
 

--- a/cloudformation/README.md
+++ b/cloudformation/README.md
@@ -2,39 +2,63 @@
 
 Infrastructure as Code for deploying RoboSystems to AWS. All templates are deployed via GitHub Actions workflows, except `bootstrap-oidc.yaml` which is deployed locally to enable CI/CD authentication.
 
+**This README describes what each template is for and how the stacks fit together. It deliberately does not restate parameter tables, defaults, or instance sizes.** Those live in each template's own `Parameters:` block, in `.github/configs/graph.yml` (graph tiers), and in the GitHub Actions variables the deploy workflows pass in (`just gha-list`). Template defaults are frequently *not* what an environment runs — sizing is overridden per environment by workflow inputs — so a restated default here is worse than no value at all.
+
 ## Quick Reference
 
-| Template | Purpose | Dependencies | Est. Monthly Cost |
-|----------|---------|--------------|-------------------|
-| `bootstrap-oidc.yaml` | GitHub OIDC for CI/CD | None | Free |
-| `vpc.yaml` | Network foundation | None | ~$35 (NAT Gateway) |
-| `postgres.yaml` | RDS PostgreSQL | VPC | ~$15 (db.t4g.micro) |
-| `valkey.yaml` | ElastiCache cache | VPC | ~$13 (cache.t4g.micro) |
-| `s3.yaml` | Object storage | None | Variable |
-| `api.yaml` | ECS API service | VPC, others | ~$20-50 (Fargate Spot) |
-| `dagster.yaml` | Workflow orchestration | VPC, others | ~$15-30 (Fargate) |
-| `worker.yaml` | Background task worker | VPC, Dagster | ~$10-20 (Fargate) |
-| `bastion.yaml` | Secure SSH access | VPC | Free (SSM only) |
-| `graph-infra.yaml` | Graph DB registries | None | ~$3 (DynamoDB) |
-| `graph-volumes.yaml` | EBS management | VPC, graph-infra | ~$1 (Lambda) |
-| `graph-ladybug.yaml` | LadybugDB writers | VPC, S3, Valkey, graph-infra | ~$50+ (EC2) |
-| `graph-ladybug-replicas.yaml` | LadybugDB readers | VPC, S3 | ~$30+ (EC2) |
-| `opensearch.yaml` | Document search | VPC | ~$30 (t3.medium.search) |
-| `prometheus.yaml` | Metrics collection | None | ~$0.03/metric-series |
-| `grafana.yaml` | Dashboards | None | ~$9/user/month |
-| `cloudtrail.yaml` | Audit logging | None | ~$2+ |
-| `waf.yaml` | Web firewall | API (for ALB ARN) | ~$6-7 |
+| Template | Purpose | Deployed by | Dependencies |
+|----------|---------|-------------|--------------|
+| `bootstrap-oidc.yaml` | GitHub OIDC for CI/CD | `just bootstrap` (local) | None |
+| `vpc.yaml` | Network foundation | `deploy-vpc.yml` | None |
+| `cloudtrail.yaml` | Audit logging | `deploy-vpc.yml` (`cloudtrail` job) | None |
+| `security.yaml` | Account-global detective controls | `deploy-vpc.yml` (`security` job) | None |
+| `s3.yaml` | Object storage | `deploy-s3.yml` | None |
+| `postgres.yaml` | RDS PostgreSQL | `deploy-postgres.yml` | VPC |
+| `valkey.yaml` | ElastiCache cache | `deploy-valkey.yml` | VPC |
+| `opensearch.yaml` | Document search | `deploy-opensearch.yml` | VPC, Bastion |
+| `bastion.yaml` | Secure SSM access | `deploy-bastion.yml` | VPC, S3, Valkey |
+| `graph-infra.yaml` | Graph DB registries | `deploy-graph-infra.yml` | None |
+| `graph-volumes.yaml` | EBS management | `deploy-graph-volumes.yml` | VPC, graph-infra |
+| `graph-ladybug.yaml` | LadybugDB writers | `deploy-graph.yml` → `deploy-graph-ladybug.yml` | VPC, S3, Valkey, Postgres, graph-volumes |
+| `graph-ladybug-replicas.yaml` | LadybugDB readers | `deploy-graph.yml` → `deploy-graph-replicas.yml` | VPC, S3, Valkey, Postgres, graph-ladybug (shared) |
+| `api.yaml` | ECS API service | `deploy-api.yml` | VPC, S3, Postgres, Valkey, Bastion |
+| `waf.yaml` | Web firewall | `deploy-api.yml` (`waf` job) | API (for ALB ARN) |
+| `audit.yaml` | Long-retention audit log forwarding | `deploy-api.yml` (`audit` job) | API (log group) |
+| `dagster.yaml` | Workflow orchestration | `deploy-dagster.yml` | VPC, S3, Postgres, Valkey |
+| `worker.yaml` | Background task worker | `deploy-dagster.yml` (same job) | Dagster (cluster + SG), Postgres, Valkey, S3 |
+| `prometheus.yaml` | Metrics collection | `deploy-prometheus.yml` | None |
+| `grafana.yaml` | Dashboards | `deploy-grafana.yml` | None |
+
+Five templates have no workflow of their own and ride a sibling's: `waf.yaml` and `audit.yaml` deploy from `deploy-api.yml`, `cloudtrail.yaml` and `security.yaml` from `deploy-vpc.yml`, and `worker.yaml` from `deploy-dagster.yml`.
+
+**Cost**: templates that can state a meaningful figure publish an `EstimatedMonthlyCost` output (`waf.yaml`, `audit.yaml`, `security.yaml`); everything else is dominated by instance sizing, which is set per environment by GitHub variables. Use `/cost-review` for actual spend rather than an estimate table here.
+
+### Feature-gated stacks
+
+Several stacks are off unless a GitHub variable turns them on:
+
+| Stack | Variable |
+|-------|----------|
+| `opensearch.yaml` | `OPENSEARCH_ENABLED_{PROD,STAGING}` |
+| `waf.yaml` | `WAF_ENABLED_{PROD,STAGING}` |
+| `audit.yaml` | `AUDIT_ENABLED_{PROD,STAGING}` |
+| `worker.yaml` | `WORKER_ENABLED_{PROD,STAGING}` |
+| `prometheus.yaml`, `grafana.yaml` | `OBSERVABILITY_ENABLED_{PROD,STAGING}` |
+| `cloudtrail.yaml` | `CLOUDTRAIL_ENABLED` (account-global, no env suffix) |
+| `security.yaml` | `SECURITY_ENABLED` (account-global, no env suffix) |
+
+`cloudtrail.yaml` and `security.yaml` create per-account singletons, so each is **one shared stack** (`RoboSystemsCloudTrail`, `RoboSystemsSecurity`) across both environments — never per-environment, or the second deploy collides. `vpc.yaml` and `grafana.yaml` are likewise shared.
 
 ## Deployment Order
 
-Templates have cross-stack dependencies that determine deployment order:
+`prod.yml` / `staging.yml` encode the real dependency graph as job `needs:`. The shape:
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────────┐
 │                           PHASE 1: BOOTSTRAP                                │
 ├─────────────────────────────────────────────────────────────────────────────┤
 │  bootstrap-oidc.yaml                                                        │
-│  └── Enables GitHub Actions → AWS authentication (deploy locally first)    │
+│  └── Enables GitHub Actions → AWS authentication (deploy locally first)     │
 └─────────────────────────────────────────────────────────────────────────────┘
                                       │
                                       ▼
@@ -42,114 +66,102 @@ Templates have cross-stack dependencies that determine deployment order:
 │                        PHASE 2: FOUNDATION                                  │
 ├─────────────────────────────────────────────────────────────────────────────┤
 │  vpc.yaml ◄───────── Core networking (VPC, subnets, NAT, IGW)               │
-│  s3.yaml  ◄───────── S3 buckets (deployment, shared-processed, user-data)  │
-│  graph-infra.yaml ◄─ DynamoDB registries (instance, graph, volume)         │
+│  ├── cloudtrail.yaml, security.yaml (same workflow, flag-gated)             │
+│  s3.yaml  ◄───────── Six buckets + CloudFront for public data               │
+│  └── package-scripts (uploads userdata/Lambda artifacts to the bucket)      │
+│  graph-infra.yaml ◄─ DynamoDB registries (instance, graph, volume)          │
 └─────────────────────────────────────────────────────────────────────────────┘
                                       │
                                       ▼
 ┌─────────────────────────────────────────────────────────────────────────────┐
 │                        PHASE 3: DATA LAYER                                  │
 ├─────────────────────────────────────────────────────────────────────────────┤
-│  postgres.yaml ◄──── RDS PostgreSQL (depends on VPC)                       │
-│  valkey.yaml ◄────── ElastiCache Valkey (depends on VPC)                   │
-│  graph-volumes.yaml ◄ EBS volume management Lambda (depends on VPC,        │
-│                       graph-infra)                                          │
-│  opensearch.yaml ◄─── OpenSearch managed domain for document search        │
-│                       (depends on VPC)                                      │
+│  postgres.yaml ◄──── RDS PostgreSQL (depends on VPC)                        │
+│  valkey.yaml ◄────── ElastiCache Valkey (depends on VPC)                    │
+│  bastion.yaml ◄───── SSM bastion host (depends on VPC, S3, Valkey)          │
+│  opensearch.yaml ◄── Managed OpenSearch domain (depends on VPC, Bastion)    │
+│  graph-volumes.yaml ◄ EBS lifecycle Lambdas (depends on VPC, graph-infra)   │
 └─────────────────────────────────────────────────────────────────────────────┘
                                       │
                                       ▼
 ┌─────────────────────────────────────────────────────────────────────────────┐
-│                      PHASE 4: APPLICATION SERVICES                          │
+│                      PHASE 4: GRAPH TIER                                    │
 ├─────────────────────────────────────────────────────────────────────────────┤
-│  api.yaml ◄─────────── ECS Fargate API (depends on VPC, uses SSM params)   │
-│  dagster.yaml ◄──────── Dagster orchestration (depends on VPC)             │
-│  worker.yaml ◄───────── Background task worker (depends on VPC, Dagster)   │
-│  bastion.yaml ◄──────── SSM bastion host (depends on VPC)                  │
-│  graph-ladybug.yaml ◄── LadybugDB writers (depends on VPC, S3, Valkey,     │
-│                         graph-infra, uses SSM params from graph-volumes)   │
+│  graph-ladybug.yaml ◄──────── One writer stack per enabled tier, fanned out │
+│                               by a matrix built from graph.yml              │
+│  graph-ladybug-replicas.yaml ◄ Read replica fleet with ALB (shared repos)   │
 └─────────────────────────────────────────────────────────────────────────────┘
                                       │
                                       ▼
 ┌─────────────────────────────────────────────────────────────────────────────┐
-│                      PHASE 5: SCALING & SECURITY                            │
+│                      PHASE 5: APPLICATION SERVICES                          │
 ├─────────────────────────────────────────────────────────────────────────────┤
-│  graph-ladybug-replicas.yaml ◄── Read replica fleet with ALB               │
-│  waf.yaml ◄───────────────────── WAF for ALB protection (needs API ALB)    │
+│  api.yaml ◄─────────── ECS Fargate API + ALB                                │
+│  ├── waf.yaml, audit.yaml (same workflow, flag-gated)                       │
+│  dagster.yaml ◄──────── Dagster daemon + webserver (Cloud Map, no ALB)      │
+│  └── worker.yaml (same job, flag-gated, reuses the Dagster cluster)         │
 └─────────────────────────────────────────────────────────────────────────────┘
                                       │
                                       ▼
 ┌─────────────────────────────────────────────────────────────────────────────┐
 │                      PHASE 6: OBSERVABILITY (Optional)                      │
 ├─────────────────────────────────────────────────────────────────────────────┤
-│  prometheus.yaml ◄─── Amazon Managed Prometheus (standalone)               │
-│  grafana.yaml ◄────── Amazon Managed Grafana (uses Prometheus, CloudWatch) │
-│  cloudtrail.yaml ◄─── Audit logging (standalone, creates own S3 bucket)    │
+│  prometheus.yaml ◄─── Amazon Managed Prometheus (standalone)                │
+│  grafana.yaml ◄────── Amazon Managed Grafana (uses Prometheus, CloudWatch)  │
 └─────────────────────────────────────────────────────────────────────────────┘
 ```
 
 ## Template Details
 
+Parameters are documented in each template — read the `Parameters:` block for names, types, defaults, and allowed values. What follows is the purpose, the resources worth knowing about, and the **export names** other stacks import.
+
 ### Bootstrap
 
 #### `bootstrap-oidc.yaml`
-**Purpose**: Enables passwordless GitHub Actions → AWS authentication using OIDC federation.
+**Purpose**: Enables passwordless GitHub Actions → AWS authentication using OIDC federation, for this repo and the three frontend app repos plus the holon viewer.
 
 **Deploy**: Locally with `just bootstrap` before any CI/CD workflows can run.
 
 **Key Resources**:
 - `AWS::IAM::OIDCProvider` - GitHub OIDC identity provider
-- `AWS::IAM::Role` - Assumable role for GitHub Actions
-
-**Parameters**:
-| Parameter | Default | Description |
-|-----------|---------|-------------|
-| `GitHubOrganization` | `RoboFinSystems` | GitHub org allowed to assume role |
-| `RepositoryFilter` | `*` | Which repos can assume the role |
+- `AWS::IAM::Role` - Deploy role for this repo, a separate frontend role, and an app super-admin role
 
 **Exports**:
-- `{StackName}-OidcRoleArn` - Role ARN for GitHub Actions to assume
+- `{StackName}-OIDCProviderArn`
+- `{StackName}-GitHubActionsRoleArn`, `-GitHubActionsRoleName`
+- `{StackName}-GitHubActionsFrontendRoleArn`, `-GitHubActionsFrontendRoleName`
+- `{StackName}-AppSuperAdminRoleArn`, `-AppSuperAdminRoleName`
 
 ---
 
 ### Core Infrastructure
 
 #### `vpc.yaml`
-**Purpose**: Foundation networking - VPC with public/private subnets across up to 5 AZs, NAT gateways, Internet gateway, and optional VPC endpoints.
+**Purpose**: Foundation networking - VPC with public/private subnets across up to 5 AZs, NAT gateway, Internet gateway, and optional VPC endpoints. Shared between prod and staging.
 
 **Key Resources**:
 - VPC with configurable CIDR `10.X.0.0/16` (where X = `VpcSecondOctet`)
-- Up to 5 Public subnets (`10.X.10.0/24` through `10.X.14.0/24`)
-- Up to 5 Private subnets (`10.X.1.0/24` through `10.X.5.0/24`)
+- Up to 5 public subnets (`10.X.10.0/24` through `10.X.14.0/24`)
+- Up to 5 private subnets (`10.X.1.0/24` through `10.X.5.0/24`)
 - NAT Gateway (single, shared across all AZs)
-- Internet Gateway
-- Route tables and security groups
-- VPC endpoints (configurable: S3, DynamoDB always free; ECR, Secrets Manager in minimal/full modes)
-- Optional VPC Flow Logs for SOC 2 compliance
+- Internet Gateway, route tables, security groups
+- VPC endpoints (`DeployVpcEndpoints`: `gateway` = free S3+DynamoDB, `minimal` ≈ $22/mo adding interface endpoints in 1 AZ, `full` ≈ $45/mo across 2 AZs)
+- Optional VPC Flow Logs to S3 for SOC 2 compliance
 
-**Parameters**:
-| Parameter | Default | Description |
-|-----------|---------|-------------|
-| `VpcSecondOctet` | `0` | Second octet for VPC CIDR (`10.X.0.0/16`). Change to avoid overlap with other VPCs for peering (0-255) |
-| `MaxAvailabilityZones` | `5` | Maximum AZs to use (2-6, uses fewer if region has limited AZs) |
-| `DeployVpcEndpoints` | `minimal` | VPC endpoint mode: `gateway` (free S3+DynamoDB), `minimal` (~$22/mo, +ECR in 1 AZ), `full` (~$45/mo, +ECR in 2 AZs) |
-| `EnableVPCFlowLogs` | `false` | Enable VPC Flow Logs for network traffic monitoring |
-| `FlowLogsRetentionDays` | `30` | Days to retain VPC Flow Logs (30 minimum for SOC 2) |
-| `FlowLogsTrafficType` | `REJECT` | Traffic type to capture: `ALL`, `ACCEPT`, or `REJECT` |
-
-**VPC Peering Note**: Forks can set `VpcSecondOctet` to a non-zero value (e.g., `2` for `10.2.0.0/16`) to enable VPC peering with another `10.0.0.0/16` VPC. This is configured via the `VPC_SECOND_OCTET` GitHub variable.
+**VPC Peering Note**: Forks can set `VpcSecondOctet` to a non-zero value (e.g. `2` for `10.2.0.0/16`) to enable VPC peering with another `10.0.0.0/16` VPC. Configured via the `VPC_SECOND_OCTET` GitHub variable.
 
 **Exports** (critical for other stacks):
 - `{StackName}-{Env}-VpcId` - VPC ID
 - `{StackName}-{Env}-VpcCidr` - VPC CIDR block (for peering/security groups)
 - `{StackName}-{Env}-PublicSubnetIds` - Comma-separated public subnet IDs
 - `{StackName}-{Env}-PrivateSubnetIds` - Comma-separated private subnet IDs
-- `{StackName}-{Env}-NatGatewayId` - NAT Gateway ID (first AZ)
+- `{StackName}-{Env}-NatGatewayIP` - NAT Gateway Elastic IP (first AZ)
+- `{StackName}-VPCFlowLogsEnabled`, `{StackName}-VPCFlowLogsBucket`
 
 ---
 
 #### `postgres.yaml`
-**Purpose**: RDS PostgreSQL database for IAM, billing, subscriptions, and metadata.
+**Purpose**: RDS PostgreSQL for IAM, billing, subscriptions, and metadata. Hosts both the `robosystems` platform database and the `extensions` OLTP database.
 
 **Dependencies**: VPC stack
 
@@ -157,22 +169,17 @@ Templates have cross-stack dependencies that determine deployment order:
 - `AWS::RDS::DBInstance` - PostgreSQL database
 - `AWS::RDS::DBSubnetGroup` - Multi-AZ subnet group
 - `AWS::EC2::SecurityGroup` - Database access security group
+- `AWS::SecretsManager::Secret` + rotation Lambda - master credential rotation
+- `AWS::RDS::DBProxy` - optional, behind `EnableRDSProxy`
+- CloudWatch alarms for CPU, memory, disk queue, free storage
 
-**Parameters**:
-| Parameter | Default | Description |
-|-----------|---------|-------------|
-| `Environment` | `prod` | Environment name |
-| `DBInstanceClass` | `db.t4g.micro` | RDS instance type |
-| `DBAllocatedStorage` | `20` | Initial storage in GB |
-| `DBMaxAllocatedStorage` | — | Max autoscale storage in GB |
-| `EnableMultiAZ` | `false` | Enable Multi-AZ |
-| `DBUsername` | `postgres` | Master username |
-| `VpcId` | Required | VPC ID |
-
-**Exports**:
-- `{StackName}-DatabaseEndpoint` - RDS endpoint
-- `{StackName}-DatabasePort` - RDS port (5432)
-- `{StackName}-DatabaseSecurityGroup` - Security group ID
+**Exports** (all carry an `{Env}` segment):
+- `{StackName}-{Env}-DatabaseEndpoint` / `-RDSEndpoint`
+- `{StackName}-{Env}-DatabasePort` / `-RDSPort`
+- `{StackName}-{Env}-RDSSecurityGroupId`
+- `{StackName}-{Env}-RDSPasswordSecretArn`, `-PostgresSecretArnPattern`
+- `{StackName}-{Env}-DatabaseProxyEndpoint`, `-DatabaseProxyArn`, `-RDSProxyEnabled`
+- plus engine/identifier/storage metadata exports
 
 ---
 
@@ -183,76 +190,55 @@ Templates have cross-stack dependencies that determine deployment order:
 
 **Key Resources**:
 - `AWS::ElastiCache::ReplicationGroup` - Valkey cluster (`Engine: valkey`)
-- `AWS::EC2::SecurityGroup` - Cache access security group
+- `AWS::EC2::SecurityGroup` - cluster SG plus a **client** SG that other stacks attach to
+- `AWS::SecretsManager::Secret` + rotation Lambda - AUTH token rotation
 
-**Parameters**:
-| Parameter | Default | Description |
-|-----------|---------|-------------|
-| `Environment` | `prod` | Environment name |
-| `NodeType` | `cache.t4g.micro` | ElastiCache node type |
-| `NumCacheNodes` | `1` | Number of cache nodes |
-| `ValkeyEngineVersion` | `8.1` | Valkey engine version |
-| `EnableEncryption` | `true` | Enable encryption in transit/at rest |
-| `VpcId` | Required | VPC ID |
-
-**Exports**:
-- `{StackName}-ValkeyEndpoint` - Valkey endpoint
-- `{StackName}-ValkeyPort` - Valkey port (6379)
-- `{StackName}-ValkeySecurityGroup` - Security group ID
+**Exports** (all carry an `{Env}` segment):
+- `{StackName}-{Env}-ValkeyEndpoint`, `-ValkeyPort`, `-ValkeyConfigEndpoint`
+- `{StackName}-{Env}-ValkeyUrl`, `-ValkeyUrlWithAuth`
+- `{StackName}-{Env}-ValkeyClientSecurityGroupId` - attach this to clients
+- `{StackName}-{Env}-ValkeyAuthSecretArn`, `-ValkeyAuthSecretName`
+- plus engine/encryption/replication-group metadata exports
 
 ---
 
 #### `opensearch.yaml`
 **Purpose**: Amazon OpenSearch Service managed domain for full-text document search (BM25) across SEC filing narratives, iXBRL disclosures, and text blocks.
 
-**Dependencies**: VPC stack
+**Dependencies**: VPC stack, Bastion (its security group is granted access for debugging)
 
 **Key Resources**:
-- `AWS::OpenSearchService::Domain` - Managed OpenSearch domain (single-node, single-AZ)
-- `AWS::EC2::SecurityGroup` - Domain access security group + client security group
-- `AWS::CloudWatch::Alarm` - Cluster red status and free storage alarms
-- `AWS::SNS::Topic` - Alert notifications
-- `AWS::Logs::LogGroup` - Application and slow query logs
+- `AWS::OpenSearchService::Domain` - managed domain (single-node/single-AZ by default; zone awareness and dedicated masters are parameterized)
+- `AWS::EC2::SecurityGroup` - domain SG + client SG
+- `AWS::CloudWatch::Alarm` - cluster red, low free storage, high JVM memory, writes blocked
+- `AWS::SNS::Topic` - alert notifications
+- `AWS::Logs::LogGroup` - application and slow query logs
 
-**Parameters**:
-| Parameter | Default | Description |
-|-----------|---------|-------------|
-| `Environment` | `prod` | Environment name |
-| `InstanceType` | `t3.medium.search` | OpenSearch instance type |
-| `EBSVolumeSize` | `100` | EBS volume size in GB |
-| `EngineVersion` | `OpenSearch_2.17` | OpenSearch engine version |
-| `VpcId` | Required | VPC ID |
-| `SubnetId` | Required | Private subnet ID (single-AZ) |
-| `SNSAlertEmail` | Required | Email for alert notifications |
+**Exports** (all carry an `{Env}` segment):
+- `{StackName}-{Env}-OpenSearchEndpoint`, `-OpenSearchDomainArn`, `-OpenSearchDomainName`
+- `{StackName}-{Env}-OpenSearchClientSecurityGroupId`
+- `{StackName}-{Env}-OpenSearchNotificationTopicArn`
 
-**Exports**:
-- `{StackName}-OpenSearchEndpoint` - Domain endpoint URL
-- `{StackName}-OpenSearchDomainArn` - Domain ARN
-
-**Feature-flag gated**: Deployed via `deploy-opensearch.yml` workflow, controlled by `OPENSEARCH_ENABLED_{ENV}` GitHub variable. Application access gated by `SEMANTIC_SEARCH_ENABLED` SSM parameter.
+**Feature-flag gated**: deployed via `deploy-opensearch.yml`, controlled by `OPENSEARCH_ENABLED_{ENV}`. Instance type, count, and version come from `OPENSEARCH_INSTANCE_TYPE_{ENV}` / `OPENSEARCH_INSTANCE_COUNT_{ENV}` / `OPENSEARCH_VERSION_{ENV}` — prod and staging deliberately differ. Application-side access is gated separately by the `SEMANTIC_SEARCH_ENABLED` SSM parameter read at runtime.
 
 ---
 
 #### `s3.yaml`
-**Purpose**: S3 buckets for deployment artifacts, processed data, and user data.
+**Purpose**: S3 buckets for deployment artifacts, raw and processed shared data, public data, user uploads, and compute logs.
 
 **Dependencies**: None (standalone)
 
-**Key Resources**:
-- `robosystems-{account}-deployment-{env}` - Deployment artifacts (userdata scripts, Lambda packages)
-- `robosystems-{account}-shared-processed-{env}` - SEC/shared data processing
-- `robosystems-{account}-user-{env}` - User-uploaded files
+**Key Resources** — six buckets, named `robosystems-{namespace}-{role}-{env}` where the workflow passes the AWS account ID as `Namespace` (falling back to `robosystems-{role}-{env}` when unset):
+- `…-deployment-{env}` - userdata scripts, Lambda packages, and the `api.yaml` template body
+- `…-shared-raw-{env}` - external source downloads (SEC, FRED, BLS)
+- `…-shared-processed-{env}` - parquet files for graph ingestion
+- `…-public-data-{env}` - publicly readable data, fronted by CloudFront
+- `…-user-{env}` - user uploads, staging tables, exports
+- `…-logs-{env}` - Dagster compute logs from ECS runs
 
-**Parameters**:
-| Parameter | Default | Description |
-|-----------|---------|-------------|
-| `Environment` | `prod` | Environment name |
-| `EnableVersioning` | `true` | Enable S3 versioning |
+All six are `DeletionPolicy: Retain`. The stack also creates the CloudFront distribution/OAC for public data and two managed IAM policies (graph-writer and shared-data-writer).
 
-**Exports**:
-- `{StackName}-DeploymentBucketName`, `-DeploymentBucketArn`
-- `{StackName}-SharedProcessedBucketName`, `-SharedProcessedBucketArn`
-- `{StackName}-UserDataBucketName`, `-UserDataBucketArn`
+**Exports** (all carry an `{Env}` segment): `-DeploymentBucketName`/`-Arn`, `-SharedRawBucketName`/`-Arn`, `-SharedProcessedBucketName`/`-Arn`, `-PublicDataBucketName`/`-Arn`, `-UserDataBucketName`/`-Arn`, `-LogsBucketName`/`-Arn`, plus `-PublicDataCDNURL`, `-CloudFrontDistributionId`, `-GraphWriterS3PolicyArn`, `-SharedDataWriterPolicyArn`.
 
 ---
 
@@ -261,113 +247,90 @@ Templates have cross-stack dependencies that determine deployment order:
 #### `api.yaml`
 **Purpose**: ECS Fargate API service with Application Load Balancer.
 
-**Dependencies**: VPC (required), Postgres/Valkey (via SSM parameters)
+**Dependencies**: VPC, S3, Postgres, Valkey, Bastion. Endpoints and security group IDs are passed in as stack parameters by `deploy-api.yml`, which reads them from the upstream stacks' outputs.
+
+**Deployed from S3**: at ~57 KB the template exceeds CloudFormation's 51,200-byte `--template-body` limit, so `deploy-api.yml` uploads it to the deployment bucket and deploys with `--template-url`.
 
 **Key Resources**:
-- `AWS::ECS::Cluster` - ECS cluster
-- `AWS::ECS::Service` - Fargate service
-- `AWS::ECS::TaskDefinition` - Container definitions
-- `AWS::ElasticLoadBalancingV2::LoadBalancer` - Application Load Balancer
-- `AWS::ElasticLoadBalancingV2::TargetGroup` - Target group
-- `AWS::Logs::LogGroup` - CloudWatch logs
+- `AWS::ECS::Cluster`, `AWS::ECS::Service`, `AWS::ECS::TaskDefinition`
+- `AWS::ElasticLoadBalancingV2::LoadBalancer` / `TargetGroup` / `Listener` / `ListenerRule`
+- `AWS::ServiceDiscovery::PrivateDnsNamespace` - `{env}.robosystems.local`
+- `AWS::SecretsManager::Secret` + rotation Lambda - admin API key
+- `AWS::Logs::LogGroup` and a set of security alarms (failed admin auth, auth-failure spike, injection attempt, privilege escalation, authorization-denied spike) plus ALB health/latency/5xx alarms
 
-**Parameters**:
-| Parameter | Default | Description |
-|-----------|---------|-------------|
-| `Environment` | `prod` | Environment name |
-| `ECRImageTag` | `latest` | Container image tag |
-| `MinCapacity` | `1` | Minimum tasks |
-| `MaxCapacity` | `10` | Maximum tasks |
-| `Cpu` | `512` | Task CPU units |
-| `Memory` | `1024` | Task memory (MB) |
-| `VpcId` | Required | VPC ID |
+**Access mode**: `ApiAccessMode` selects `public` (ALB with ACM certificate and Route53 record) or `internal` (private ALB reachable only through the SSM tunnel).
 
 **Exports**:
-- `{StackName}-ClusterArn` - ECS cluster ARN
-- `{StackName}-ServiceArn` - ECS service ARN
-- `{StackName}-AlbArn` - ALB ARN (used by WAF)
-- `{StackName}-AlbDnsName` - ALB DNS name
+- `{StackName}-ApiALBArn` - ALB ARN (consumed by `waf.yaml`)
+- `{StackName}-LoadBalancerDNS` - ALB DNS name
+- `{StackName}-ApiSecurityGroupId`
+- `{StackName}-AdminKeySecretArn`
+- `{StackName}-ServiceDiscoveryEndpoint`, `-ServiceDiscoveryNamespaceId`, `-ServiceDiscoveryNamespaceArn`
+- `{StackName}-{Env}-ECRRepositoryUsed`, `{StackName}-{Env}-CertificateArn`
 
 ---
 
 #### `dagster.yaml`
-**Purpose**: Dagster orchestration platform (webserver + daemon) on ECS Fargate.
+**Purpose**: Dagster orchestration platform (daemon + webserver) on ECS Fargate.
 
-**Dependencies**: VPC (required)
+**Dependencies**: VPC, S3, Postgres, Valkey
 
 **Key Resources**:
-- `AWS::ECS::Cluster` - Dagster ECS cluster
-- `AWS::ECS::Service` - Webserver and daemon services
-- `AWS::ECS::TaskDefinition` - Container definitions
-- `AWS::ElasticLoadBalancingV2::LoadBalancer` - Internal ALB
-- `AWS::Logs::LogGroup` - CloudWatch logs
+- `AWS::ECS::Cluster`, two `AWS::ECS::Service` (daemon, webserver), task definitions for both plus a run-job task definition that jobs override via `ecs/cpu`, `ecs/memory`, `ecs/ephemeral_storage` tags
+- `AWS::ServiceDiscovery::PrivateDnsNamespace` / `Service` - `dagster.{env}.robosystems.local`
+- `AWS::Logs::LogGroup`, SNS alert topic, backup-coverage-gap alarm
 
-**Parameters**:
-| Parameter | Default | Description |
-|-----------|---------|-------------|
-| `Environment` | `prod` | Environment name |
-| `WebserverCpu` | `256` | Webserver CPU units |
-| `WebserverMemory` | `512` | Webserver memory (MB) |
-| `DaemonCpu` | `512` | Daemon CPU units |
-| `DaemonMemory` | `1024` | Daemon memory (MB) |
+There is **no load balancer**: the webserver is reached over Cloud Map private DNS through the SSM tunnel (`just tunnel {env} dagster`). The webserver's desired count defaults to 0 — it is scaled up on demand.
 
 **Exports**:
-- `{StackName}-ClusterArn` - ECS cluster ARN
-- `{StackName}-WebserverServiceArn` - Webserver service ARN
-- `{StackName}-DaemonServiceArn` - Daemon service ARN
+- `{StackName}-ClusterName`, `-ClusterArn`
+- `{StackName}-SecurityGroupId` (output key `DagsterSecurityGroupId`)
+- `{StackName}-DaemonServiceArn`, `-WebserverServiceArn`
+- `{StackName}-RunJobTaskDefinition`
+- `{StackName}-InternalEndpoint`, `-DagsterUrl`
 
 ---
 
 #### `worker.yaml`
-**Purpose**: Background task worker service on ECS Fargate. Runs the queue consumer for asynchronous work, with optional queue-depth-based autoscaling.
+**Purpose**: Background task worker service on ECS Fargate. Runs the queue consumer for asynchronous work, with optional queue-depth-based autoscaling (`WorkerAutoscalingEnabled`).
 
-**Dependencies**: VPC, Dagster (reuses the Dagster ECS cluster and VPC-internal security group), PostgreSQL/Valkey (via SSM parameters)
+**Dependencies**: Dagster (reuses its ECS cluster and security group — both are read from the Dagster stack's outputs and passed in), Postgres, Valkey, S3
 
 **Key Resources**:
-- `AWS::ECS::Service` - Fargate worker service (on the Dagster cluster)
-- `AWS::ECS::TaskDefinition` - Worker container definition
-- `AWS::ApplicationAutoScaling::ScalableTarget` - Queue-depth autoscaling target
-- `AWS::Logs::LogGroup` - CloudWatch logs
+- `AWS::ECS::Service` - Fargate worker service on the Dagster cluster
+- `AWS::ECS::TaskDefinition` - worker container definition
+- Queue-depth-high / queue-depth-zero / DLQ-depth alarms and an SNS alert topic
+- `AWS::Logs::LogGroup`
 
-**Parameters**:
-| Parameter | Default | Description |
-|-----------|---------|-------------|
-| `Environment` | `prod` | Environment name |
-| `ImageTag` | `latest` | Container image tag |
-| `WorkerCpu` | `512` | Task CPU units |
-| `WorkerMemory` | `1024` | Task memory (MB) |
-| `WorkerDesiredCount` | `1` | Static desired count (when autoscaling disabled) |
-| `WorkerMinCount` | `1` | Minimum tasks (always-on baseline) |
-| `WorkerMaxCount` | `5` | Maximum tasks during burst |
+**Exports**:
+- `{StackName}-WorkerServiceArn`
+- `{StackName}-WorkerTaskDefinitionArn`
 
 ---
 
 #### `bastion.yaml`
-**Purpose**: EC2 bastion host for secure SSM-based access to private resources. No SSH keys or open ports required.
+**Purpose**: EC2 bastion host for secure SSM-based access to private resources. No SSH keys or open ports required — the security group has no ingress rules at all.
 
-**Dependencies**: VPC (required)
+**Dependencies**: VPC (public subnet), S3 (userdata script), Valkey (SG for tunnelling)
 
 **Key Resources**:
-- `AWS::EC2::Instance` - t4g.nano bastion instance
-- `AWS::IAM::Role` - SSM-enabled instance role
-- `AWS::IAM::InstanceProfile` - Instance profile
-
-**Parameters**:
-| Parameter | Default | Description |
-|-----------|---------|-------------|
-| `Environment` | `prod` | Environment name |
-| `InstanceType` | `t4g.nano` | EC2 instance type |
-| `VpcStackName` | Required | VPC stack name |
+- `AWS::EC2::Instance` - ARM64 Amazon Linux 2023 instance in a public subnet
+- `AWS::IAM::Role` / `InstanceProfile` - SSM-enabled, with read access to `/robosystems/*/features` and `/robosystems/*/tuning` SSM parameters for debugging
+- `AWS::Logs::LogGroup`, CPU-high alarm
 
 **Exports**:
-- `{StackName}-BastionInstanceId` - Instance ID for SSM session
+- `{StackName}-BastionHostId` - instance ID for SSM sessions
+- `{StackName}-BastionSecurityGroupId` - granted access by Postgres, Valkey, OpenSearch
 
 **Usage**:
 ```bash
-# Start SSM session
+# Preferred: the wrapper resolves the instance and ports for you
+# (services: postgres, valkey, dagster, api, api-internal, all)
+just tunnel prod postgres
+
+# Raw equivalents
 aws ssm start-session --target i-0123456789abcdef0
 
-# Port forward to RDS
 aws ssm start-session --target i-0123456789abcdef0 \
   --document-name AWS-StartPortForwardingSessionToRemoteHost \
   --parameters '{"host":["mydb.xxx.rds.amazonaws.com"],"portNumber":["5432"],"localPortNumber":["5432"]}'
@@ -377,133 +340,94 @@ aws ssm start-session --target i-0123456789abcdef0 \
 
 ### Graph Database Infrastructure
 
-The graph database system uses a modular architecture with separate templates for infrastructure, compute, and storage.
+The graph database system uses a modular architecture with separate templates for infrastructure, storage, writers, and readers.
 
 #### `graph-infra.yaml`
-**Purpose**: Core graph database infrastructure - DynamoDB registries for tracking instances, graphs, and volumes.
+**Purpose**: Core graph database infrastructure - DynamoDB registries for tracking instances, graphs, and volumes, plus the Graph API credential and the container-refresh control plane.
 
 **Dependencies**: None (standalone)
 
 **Key Resources**:
-- `AWS::DynamoDB::Table` - `robosystems-instance-registry-{env}` (tracks EC2 instances)
-- `AWS::DynamoDB::Table` - `robosystems-graph-registry-{env}` (tracks graph databases)
-- `AWS::DynamoDB::Table` - `robosystems-volume-registry-{env}` (tracks EBS volumes)
-- `AWS::SecretsManager::Secret` - Graph database authentication
-
-**Parameters**:
-| Parameter | Default | Description |
-|-----------|---------|-------------|
-| `Environment` | `prod` | Environment name |
-| `GraphSecretArn` | `` | Optional existing secret ARN |
-
-**Exports**:
-- `{StackName}-InstanceRegistryTableName`, `-InstanceRegistryTableArn`
-- `{StackName}-GraphRegistryTableName`, `-GraphRegistryTableArn`
-- `{StackName}-VolumeRegistryTableName`, `-VolumeRegistryTableArn`
-- `{StackName}-GraphSecretArn` - Authentication secret ARN
+- `AWS::DynamoDB::Table` × 3 - `robosystems-graph-{env}-instance-registry`, `-graph-registry`, `-volume-registry`
+- `AWS::SecretsManager::Secret` + `RotationSchedule` - Graph API authentication, rotated by Lambda
+- `AWS::SSM::Document` + `AWS::Lambda::Function` - fleet container refresh (`{StackName}-graph-container-refresh`)
+- `AWS::Logs::LogGroup` - unified `/robosystems/{env}/graph-api` log group
+- 15 CloudWatch alarms covering registry read/write throttles, consumed capacity, database capacity, and Lambda errors
 
 **DynamoDB Table Schemas**:
-| Table | Partition Key | Sort Key | Purpose |
-|-------|--------------|----------|---------|
-| instance-registry | `instance_id` | - | Track EC2 writer/reader instances |
-| graph-registry | `graph_id` | - | Track graph databases and their metadata |
-| volume-registry | `volume_id` | - | Track EBS volumes and attachments |
+| Table | Partition Key | GSIs | Purpose |
+|-------|--------------|------|---------|
+| instance-registry | `instance_id` | status/database_count, cluster_tier/status, backend_type/status | Track EC2 writer/reader instances |
+| graph-registry | `graph_id` | instance_id, entity_id | Track graph databases and their metadata |
+| volume-registry | `volume_id` | instance_id, database_id, tier | Track EBS volumes and attachments |
+
+**Exports**:
+- `{StackName}-InstanceRegistryTable`, `-InstanceRegistryTableArn`
+- `{StackName}-GraphRegistryTable`, `-GraphRegistryTableArn`
+- `{StackName}-VolumeRegistryTable`, `-VolumeRegistryTableArn`
+- `{StackName}-SecretArn` - Graph API authentication secret
+- `{StackName}-AlertTopicArn`, `-GraphContainerRefreshFunctionName`, `-unified-log-group`
 
 ---
 
 #### `graph-volumes.yaml`
-**Purpose**: Lambda-based EBS volume lifecycle management - creation, attachment, and cleanup.
+**Purpose**: Lambda-based EBS volume lifecycle management - creation, attachment, monitoring, detachment, and snapshot cleanup.
 
-**Dependencies**: VPC, graph-infra
+**Dependencies**: VPC, graph-infra (the volume registry table name is passed in as a parameter)
 
 **Key Resources**:
-- `AWS::Lambda::Function` - Volume management Lambda
-- `AWS::IAM::Role` - Lambda execution role with EC2/EBS permissions
-- `AWS::Lambda::Permission` - API Gateway integration
-- `AWS::SSM::Parameter` - Stores Lambda ARN for other stacks
+- `AWS::Lambda::Function` × 3 - volume manager, volume monitor, volume detachment
+- `AWS::Events::Rule` × 5 - scheduled monitoring, daily cleanup, instance termination, volume detachment, snapshot cleanup
+- `AWS::SNS::Topic` × 2 - alerts and detachment notifications
+- `AWS::IAM::Role` × 3, `AWS::EC2::SecurityGroup` × 2
+- 11 CloudWatch alarms including tiered disk-usage warning/critical/emergency, which invoke the monitor Lambda directly
 
-**Parameters**:
-| Parameter | Default | Description |
-|-----------|---------|-------------|
-| `Environment` | `prod` | Environment name |
-| `VpcStackName` | Required | VPC stack name |
-| `GraphInfraStackName` | Required | Graph infra stack name |
-| `VolumeType` | `gp3` | EBS volume type |
-| `VolumeSizeGB` | `100` | Default volume size |
-| `VolumeIops` | `3000` | IOPS for gp3 volumes |
-| `VolumeThroughput` | `125` | Throughput (MB/s) for gp3 |
-
-**SSM Parameters Created**:
-- `/robosystems/{env}/graph/volume-manager-lambda-arn` - Lambda ARN for invocation
+**Exports** (consumed by `graph-ladybug.yaml`, passed through by the deploy workflow):
+- `{StackName}-volume-manager-arn`
+- `{StackName}-detachment-topic`
+- `{StackName}-alert-topic`, `-volume-registry`, `-role-arn`
 
 ---
 
 #### `graph-ladybug.yaml`
-**Purpose**: LadybugDB writer instances - EC2 Auto Scaling Group with Launch Template.
+**Purpose**: LadybugDB writer instances - one EC2 Auto Scaling Group per tier, with a Launch Template. `deploy-graph.yml` builds a matrix from `.github/configs/graph.yml` and deploys one stack per enabled tier.
 
-**Dependencies**: VPC, S3, Valkey, graph-infra (reads SSM parameters from graph-volumes)
+**Dependencies**: VPC, S3, Valkey, Postgres, graph-volumes. `VolumeManagerFunctionArn` and `VolumeDetachmentTopicArn` are read from the graph-volumes stack outputs by the workflow and passed in as parameters.
 
 **Key Resources**:
-- `AWS::AutoScaling::AutoScalingGroup` - Writer instance ASG
-- `AWS::EC2::LaunchTemplate` - Instance configuration
-- `AWS::IAM::Role` - Instance role with S3/DynamoDB/EBS access
-- `AWS::CloudWatch::Alarm` - CPU and memory alarms
+- `AWS::AutoScaling::AutoScalingGroup` + `LifecycleHook` - writer ASG
+- `AWS::EC2::LaunchTemplate` - instance configuration
+- `AWS::IAM::Role` / `InstanceProfile` - S3/DynamoDB/EBS access
+- `AWS::CloudWatch::Alarm` × 3 - high CPU, high memory, allocation failures
+- `AWS::SNS::Topic` - per-tier alerts
 
-**Parameters**:
-| Parameter | Default | Description |
-|-----------|---------|-------------|
-| `Environment` | `prod` | Environment name |
-| `InstanceType` | Required (per-tier) | EC2 instance type (set per tier from `graph.yml`) |
-| `MinInstances` | `1` | Minimum instances |
-| `MaxInstances` | `10` | Maximum instances |
-| `DatabasesPerInstance` | `1` | Max databases per instance |
-| `VpcStackName` | Required | VPC stack name |
-| `S3StackName` | Required | S3 stack name |
-| `ValkeyStackName` | Required | Valkey stack name |
-| `GraphInfraStackName` | Required | Graph infra stack name |
+> `DesiredCapacity` is intentionally omitted from the ASG; it is managed by the application at runtime.
 
-> DesiredCapacity is intentionally omitted from the ASG; it is managed by the application at runtime.
-
-**Instance Tiers** (configured in `.github/configs/graph.yml`):
-| Tier | Instance Type | Memory | Use Case |
-|------|---------------|--------|----------|
-| ladybug-standard | m7g.large | 8 GB | Cost-efficient entry tier with subgraph support |
-| ladybug-large | r7g.large | 16 GB | Enhanced performance for growing teams |
-| ladybug-xlarge | r7g.xlarge | 32 GB | Maximum performance and scale |
+**Instance Tiers**: `WriterTier` selects the tier and `InstanceType` / `DatabasesPerInstance` are passed in from **`.github/configs/graph.yml`**, which is the authoritative source for instance type, RAM, vCPUs, subgraph limits, memory budgets, and per-tier copy/backup/graph limits — and which differs between prod and staging. Read its per-tier `instance:` block rather than relying on a table here. The tiers are `ladybug-standard`, `ladybug-large`, `ladybug-xlarge`, and `ladybug-shared` (platform-managed public repositories such as SEC — deployed by the same template with `SharedRepositories` set).
 
 **Exports**:
-- `{StackName}-AutoScalingGroupArn` - ASG ARN
-- `{StackName}-LaunchTemplateId` - Launch template ID
-- `{StackName}-InstanceSecurityGroup` - Security group ID
+- `{StackName}-asg-name` - Auto Scaling Group name
+- `{StackName}-sg-id` - writer security group ID
 
 ---
 
 #### `graph-ladybug-replicas.yaml`
-**Purpose**: Read-only LadybugDB replica fleet with Application Load Balancer for horizontal read scaling.
+**Purpose**: Read-only LadybugDB replica fleet with Application Load Balancer for horizontal read scaling of the shared repositories. Serves `SharedRepositories` only — the shared master keeps everything else.
 
-**Dependencies**: VPC, S3 (reads SSM parameters)
+**Dependencies**: VPC, S3, Valkey, Postgres, and the shared writer stack (`depends_on: ladybug-shared` in `graph.yml`)
 
 **Key Resources**:
-- `AWS::AutoScaling::AutoScalingGroup` - Reader instance ASG
-- `AWS::EC2::LaunchTemplate` - Replica configuration
-- `AWS::ElasticLoadBalancingV2::LoadBalancer` - Internal ALB
-- `AWS::ElasticLoadBalancingV2::TargetGroup` - Health-checked target group
-- `AWS::CloudWatch::Alarm` - Scaling and health alarms
+- `AWS::AutoScaling::AutoScalingGroup` + 3 `ScalingPolicy` (CPU, memory, optional response time)
+- `AWS::EC2::LaunchTemplate` - replica configuration, optional Spot via `SpotEnabled`
+- `AWS::ElasticLoadBalancingV2::LoadBalancer` / `TargetGroup` / `Listener` - internal ALB
+- `AWS::Logs::MetricFilter` + 7 alarms - insufficient/unhealthy hosts, high latency, 5xx spike, container start, query-abuse signal, query-engine disruption
 
-**Parameters**:
-| Parameter | Default | Description |
-|-----------|---------|-------------|
-| `Environment` | `prod` | Environment name |
-| `InstanceType` | `m7g.large` | EC2 instance type (smaller than writers) |
-| `MinInstances` | `2` | Minimum replicas (0 for cost-saving mode) |
-| `MaxInstances` | `10` | Maximum replicas |
-| `DesiredCapacity` | `2` | Desired replicas |
-| `VpcStackName` | Required | VPC stack name |
+Instance sizing and scaling for replicas come from `graph.yml`'s `shared-replicas` entry and the `SHARED_REPLICAS_*` GitHub variables; the replica memory block deliberately overrides the writer's settings because replica hardware differs.
 
 **Exports**:
-- `{StackName}-ReplicaAlbDnsName` - ALB DNS for read queries
-- `{StackName}-ReplicaAlbArn` - ALB ARN
-- `{StackName}-AutoScalingGroupArn` - Reader ASG ARN
+- `{StackName}-ALBDNSName`, `-ALBEndpoint` - read query entry point
+- `{StackName}-ASGName`, `-LaunchTemplateName`
+- `{StackName}-SecurityGroupId`, `-TargetGroupArn`
 
 ---
 
@@ -517,17 +441,11 @@ The graph database system uses a modular architecture with separate templates fo
 **Key Resources**:
 - `AWS::APS::Workspace` - Prometheus workspace
 
-**Parameters**:
-| Parameter | Default | Description |
-|-----------|---------|-------------|
-| `Environment` | `prod` | Environment name |
-| `ProjectName` | `robosystems` | Project name |
-
 **Exports**:
-- `{StackName}-PrometheusWorkspaceArn` - Workspace ARN
-- `{StackName}-PrometheusWorkspaceId` - Workspace ID
-- `{StackName}-PrometheusWorkspaceEndpoint` - Query endpoint
-- `{StackName}-PrometheusRemoteWriteEndpoint` - Remote write endpoint for ADOT
+- `{StackName}-PrometheusWorkspaceArn`, `-PrometheusWorkspaceId`
+- `{StackName}-PrometheusWorkspaceEndpoint` - query endpoint
+- `{StackName}-PrometheusRemoteWriteEndpoint` - remote write endpoint for ADOT
+- `{StackName}-PrometheusEnvironment`
 
 ---
 
@@ -538,12 +456,7 @@ The graph database system uses a modular architecture with separate templates fo
 
 **Key Resources**:
 - `AWS::Grafana::Workspace` - Grafana workspace (shared across environments)
-- `AWS::IAM::Role` - Service role with Prometheus, CloudWatch, Athena access
-
-**Parameters**:
-| Parameter | Default | Description |
-|-----------|---------|-------------|
-| `ProjectName` | `robosystems` | Project name |
+- `AWS::IAM::Role` - service role with Prometheus, CloudWatch, Athena access
 
 **Manual Setup Required**:
 1. Configure AWS SSO user for Grafana access
@@ -551,9 +464,9 @@ The graph database system uses a modular architecture with separate templates fo
 3. Configure data sources (Prometheus, CloudWatch)
 
 **Exports**:
-- `{StackName}-shared-GrafanaWorkspaceId` - Workspace ID
-- `{StackName}-shared-GrafanaWorkspaceEndpoint` - Grafana URL
-- `{StackName}-shared-GrafanaServiceRoleArn` - Service role ARN
+- `{StackName}-shared-GrafanaWorkspaceId`, `-shared-GrafanaWorkspaceEndpoint`
+- `{StackName}-shared-GrafanaServiceRoleArn`
+- `{StackName}-shared-ManualSetupRequired`, `-shared-DataSourceConfiguration`
 
 ---
 
@@ -562,103 +475,118 @@ The graph database system uses a modular architecture with separate templates fo
 #### `waf.yaml`
 **Purpose**: Web Application Firewall for ALB protection with rate limiting and attack prevention.
 
-**Dependencies**: API stack (needs ALB ARN to associate)
+**Dependencies**: API stack (needs `ApiAlbArn` to associate)
 
 **Key Resources**:
 - `AWS::WAFv2::WebACL` - Web ACL with rules
-- `AWS::WAFv2::IPSet` - Allowlisted IPs
+- `AWS::WAFv2::IPSet` - allowlisted IPs
 - `AWS::WAFv2::WebACLAssociation` - ALB association
-- `AWS::CloudWatch::Dashboard` - WAF metrics dashboard
-- `AWS::CloudWatch::Alarm` - High block rate alarm
+
+Those three are the whole stack — per-rule CloudWatch metrics are emitted by the Web ACL's `VisibilityConfig`, but the template creates no dashboard and no alarms.
 
 **WAF Rules** (in priority order):
-1. **AllowWhitelistedIPs** - Bypass all rules for trusted IPs
-2. **RateLimitPerIP** - Block IPs exceeding request limit (429 response)
+1. **AllowWhitelistedIPs** - bypass all rules for trusted IPs
+2. **RateLimitPerIP** - block IPs exceeding the request limit (429 response)
 3. **BlockCommonAttacks** - SQL injection, XSS detection (403 response)
-4. **SizeRestrictions** - Block oversized payloads (413 response)
-5. **GeoBlocking** - Optional: Block non-US/CA traffic (403 response)
-6. **AWSManagedRulesCommonRuleSet** - Optional: AWS managed rules
-
-**Parameters**:
-| Parameter | Default | Description |
-|-----------|---------|-------------|
-| `Environment` | `prod` | Environment name |
-| `ApiAlbArn` | `` | API ALB ARN to protect |
-| `RateLimitPerIP` | `3000` | Requests per 5 min per IP |
-| `EnableGeoBlocking` | `false` | Block non-US/CA traffic |
-| `EnableAwsManagedRules` | `true` | Use AWS managed rules |
-| `AllowedIPs` | `0.0.0.0/32` | IPs to allowlist |
+4. **SizeRestrictions** - block oversized payloads (413 response)
+5. **GeoBlocking** - optional: block non-US/CA traffic (403 response)
+6. **AWSManagedRulesCommonRuleSet** - optional: AWS managed rules
 
 **Exports**:
-- `{StackName}-WebACLId` - Web ACL ID
-- `{StackName}-WebACLArn` - Web ACL ARN
-- `{StackName}-AllowedIPSetArn` - IP allowlist ARN
+- `{StackName}-WebACLId`, `-WebACLArn`
+- `{StackName}-AllowedIPSetArn`
+
+---
+
+#### `audit.yaml`
+**Purpose**: Forwards only the compliance-relevant audit records out of the API log group (`/robosystems/{env}/api`) to a dedicated long-retention S3 bucket, so security evidence survives the short operational-log retention. Entirely log-side — no application code, nothing on the request path.
+
+**Dependencies**: API stack (subscribes to its log group)
+
+**Key Resources**:
+- `AWS::Logs::SubscriptionFilter` → `AWS::KinesisFirehose::DeliveryStream` → `AWS::S3::Bucket`
+- `AWS::IAM::Role` × 2 - Firehose delivery and subscription-filter roles
+- `AWS::Logs::LogGroup` / `LogStream` - Firehose error logging
+
+**Exports**:
+- `{StackName}-AuditBucket`
+- `{StackName}-AuditFirehoseArn`
+
+---
+
+#### `security.yaml`
+**Purpose**: Account- and region-global detective controls for SOC 2 (CC4/CC6/CC7). Every resource is a per-account singleton, so this is **one shared stack** (`RoboSystemsSecurity`), never per-environment.
+
+**Dependencies**: None
+
+**Key Resources**:
+- `AWS::GuardDuty::Detector` - threat detection
+- `AWS::SecurityHub::Hub` + `Standard` × 2 - FSBP always, CIS behind `EnableCISStandard`
+- `AWS::AccessAnalyzer::Analyzer` - external-access findings
+- `AWS::Config::ConfigurationRecorder` + `DeliveryChannel` + bucket - behind `EnableConfig`, recording frequency parameterized
+- `AWS::Events::Rule` × 4 - GuardDuty findings, root-account activity, Access Analyzer findings, detective-control tampering
+
+Each control has its own `Enable*` toggle so they can be turned on independently.
+
+**Exports**:
+- `{StackName}-GuardDutyDetectorId`
+- `{StackName}-ConfigBucket`
 
 ---
 
 #### `cloudtrail.yaml`
-**Purpose**: CloudTrail audit logging for SOC 2 compliance.
+**Purpose**: CloudTrail audit logging for SOC 2 compliance. Like `security.yaml`, an account-global singleton deployed as one shared stack (`RoboSystemsCloudTrail`).
 
 **Dependencies**: None (creates its own S3 bucket)
 
 **Key Resources**:
 - `AWS::S3::Bucket` - CloudTrail log bucket (with Intelligent-Tiering)
-- `AWS::CloudTrail::Trail` - Multi-region trail
-
-**Parameters**:
-| Parameter | Default | Description |
-|-----------|---------|-------------|
-| `Environment` | `prod` | Environment name |
-| `EnableCloudTrail` | `false` | Enable CloudTrail |
-| `LogRetentionDays` | `90` | Log retention period |
-| `DataEventsEnabled` | `false` | Log S3 data events (costly) |
-| `UserDataBucketArn` | `` | Optional: S3 bucket to monitor |
+- `AWS::CloudTrail::Trail` - multi-region trail; S3 data events are opt-in via `DataEventsEnabled` because they are costly
 
 **Exports**:
-- `{StackName}-CloudTrailArn` - Trail ARN
-- `{StackName}-CloudTrailBucket` - Log bucket name
-- `{StackName}-CloudTrailEnabled` - Whether enabled
+- `{StackName}-CloudTrailArn`
+- `{StackName}-CloudTrailBucket`
+- `{StackName}-CloudTrailEnabled`
 
 ---
 
 ## Cross-Stack References
 
-Templates communicate via CloudFormation exports and SSM Parameters:
+Templates share values two ways, and it is worth keeping them straight.
 
-### Export/Import Pattern
+### Export/Import (rare)
+Direct `Fn::ImportValue` between templates is used in exactly one place — `api.yaml` reaching into the Prometheus stack, whose name it takes as a parameter:
+
 ```yaml
-# Exporting stack (vpc.yaml)
+# prometheus.yaml exports
 Outputs:
-  VpcId:
-    Value: !Ref VPC
+  PrometheusWorkspaceArn:
+    Value: !GetAtt PrometheusWorkspace.Arn
     Export:
-      Name: !Sub "${AWS::StackName}-VpcId"
+      Name: !Sub "${AWS::StackName}-PrometheusWorkspaceArn"
 
-# Importing stack (postgres.yaml)
-Resources:
-  DBSubnetGroup:
-    Properties:
-      VpcSecurityGroups:
-        - Fn::ImportValue: !Sub "${VpcStackName}-VpcId"
+# api.yaml imports
+Resource: !ImportValue
+  Fn::Sub: "${PrometheusStackName}-PrometheusWorkspaceArn"
 ```
 
-### SSM Parameter Pattern
-Used for dynamic values that change (Lambda ARNs, instance IDs):
+Every other stack still publishes exports — they are the documented contract and are readable with `aws cloudformation list-exports` — but consumers reach them through the workflow rather than importing them, which is what keeps stacks independently deletable.
+
+### Workflow-mediated parameters (the dominant pattern here)
+Most cross-stack wiring is done by the **deploy workflow**, not by CloudFormation: the workflow reads an upstream stack's outputs with `describe-stacks` and passes them to the downstream stack as ordinary parameters. This is how `api.yaml` gets `DatabaseEndpoint` / `ValkeyUrl`, how `worker.yaml` gets the Dagster cluster ARN and security group, and how `graph-ladybug.yaml` gets `VolumeManagerFunctionArn` and `VolumeDetachmentTopicArn`:
+
 ```yaml
-# graph-volumes.yaml creates parameter
-Resources:
-  VolumeLambdaArnParameter:
-    Type: AWS::SSM::Parameter
-    Properties:
-      Name: !Sub "/robosystems/${Environment}/graph/volume-manager-lambda-arn"
-      Value: !GetAtt VolumeManagerLambda.Arn
-
-# graph-ladybug.yaml reads parameter
-Parameters:
-  VolumeLambdaArn:
-    Type: AWS::SSM::Parameter::Value<String>
-    Default: /robosystems/prod/graph/volume-manager-lambda-arn
+# deploy-dagster.yml
+CLUSTER_ARN=$(aws cloudformation describe-stacks \
+  --stack-name ${{ inputs.stack_name }} \
+  --query "Stacks[0].Outputs[?OutputKey=='ClusterArn'].OutputValue" \
+  --output text)
 ```
+
+Because this reads by **OutputKey**, not by export name, note that the two often differ — `dagster.yaml`'s `DagsterSecurityGroupId` output is exported as `{StackName}-SecurityGroupId`.
+
+### SSM Parameter Store
+No template creates or reads an SSM parameter. SSM Parameter Store is used **at runtime by the application**, not at deploy time by CloudFormation: feature flags and tuning values live at `/robosystems/{env}/{features,tuning}/{NAME}` and are read by the running services (see `just ssm-list`, `just ssm-get`). The templates' only involvement is granting IAM read access to those paths (`api.yaml`, `bastion.yaml`).
 
 ---
 
@@ -666,7 +594,7 @@ Parameters:
 
 ### Deploying via GitHub Actions
 
-Most templates are deployed automatically by GitHub Actions workflows:
+All 15 `deploy-*.yml` workflows are `workflow_call`-only — they cannot be dispatched directly. Deployment is driven through `prod.yml` / `staging.yml`, which are `workflow_dispatch` (and called by `create-release.yml`):
 
 ```bash
 # Deploy everything to production
@@ -675,9 +603,11 @@ just deploy prod
 # Deploy everything to staging
 just deploy staging
 
-# Deploy specific stack
-gh workflow run deploy-<stack>.yml -f environment=prod
+# Same thing, by hand
+gh workflow run prod.yml --ref <branch-or-tag>
 ```
+
+There is no per-stack entry point. To redeploy a single stack, run the environment workflow — jobs whose inputs are unchanged converge to no-ops — or, for a container-only refresh, use `service-refresh.yml` / `graph-asg-refresh.yml`.
 
 ### Local Validation
 
@@ -689,19 +619,21 @@ just cf-lint api
 just cf-lint-all
 ```
 
-`just cf-lint <name>` runs `cfn-lint` and `aws cloudformation validate-template` against `cloudformation/<name>.yaml`.
+`just cf-lint <name>` runs `cfn-lint` and then `aws cloudformation validate-template` against `cloudformation/<name>.yaml`. `validate-template` accepts a template body of at most 51,200 bytes, so for any template over that size the validate step is **skipped** with a notice rather than failing — currently that is `api.yaml`, which deploys from S3 via `--template-url` for the same reason. `cfn-lint` has no size limit and does the static analysis that matters.
 
 ### Viewing Stack Status
+
+Stack names are defined in `.github/configs/stacks.yml` (mirroring the workflows, which are the source of truth). They follow `RoboSystems{Component}{Variant}{Environment}`, with the shared stacks — `RoboSystemsVPC`, `RoboSystemsGrafana`, `RoboSystemsCloudTrail`, `RoboSystemsSecurity` — carrying no environment suffix.
 
 ```bash
 # List all stacks
 aws cloudformation list-stacks --stack-status-filter CREATE_COMPLETE UPDATE_COMPLETE
 
 # Describe a specific stack
-aws cloudformation describe-stacks --stack-name RoboSystemsApiProd
+aws cloudformation describe-stacks --stack-name RoboSystemsAPIProd
 
 # View stack events (useful for debugging)
-aws cloudformation describe-stack-events --stack-name RoboSystemsApiProd
+aws cloudformation describe-stack-events --stack-name RoboSystemsAPIProd
 
 # View stack exports
 aws cloudformation list-exports
@@ -713,10 +645,11 @@ Common issues:
 
 | Issue | Solution |
 |-------|----------|
-| Export not found | Ensure dependency stack is deployed first |
-| IAM permission denied | Check role has required permissions |
-| Resource limit exceeded | Request limit increase or delete unused resources |
-| Circular dependency | Use SSM parameters instead of direct exports |
+| Export not found | Ensure the dependency stack is deployed first, and check the export name with `aws cloudformation list-exports` — several carry an `{Env}` segment |
+| IAM permission denied | Check the OIDC deploy role has the required permissions (`bootstrap-oidc.yaml`) |
+| Resource limit exceeded | Request a limit increase or delete unused resources |
+| Circular dependency | Pass the value through the deploy workflow as a parameter instead of importing it |
+| `validate-template` size error | Expected for templates over 51,200 bytes; `just cf-lint` skips validate for those |
 
 ---
 
@@ -724,11 +657,11 @@ Common issues:
 
 When forking RoboSystems to a different AWS account:
 
-1. **Bootstrap First**: Deploy `bootstrap-oidc.yaml` with your GitHub organization
-2. **S3 Bucket Names**: Automatically namespaced with account ID to avoid collisions
-3. **OIDC Trust**: Update `GitHubOrganization` parameter in bootstrap
-4. **Secrets**: Create new secrets in Secrets Manager
-5. **Domain Names**: Optional - works without custom domains via SSM tunnel
+1. **Bootstrap First**: Deploy `bootstrap-oidc.yaml` with your GitHub organization (`GitHubOrg` parameter) via `just bootstrap`
+2. **S3 Bucket Names**: Namespaced by the `Namespace` parameter, which the workflows set to `AWS_ACCOUNT_ID`, so they stay globally unique
+3. **Configuration**: Run `just setup-gha` to populate the GitHub variables the deploy workflows read — the templates' own defaults are not the deployed sizing
+4. **Secrets**: Create new secrets in Secrets Manager (`just setup-aws`)
+5. **Domain Names**: Optional - works without custom domains via `ApiAccessMode=internal` and the SSM tunnel
 
 See the [Bootstrap Guide](https://github.com/RoboFinSystems/robosystems/wiki/Bootstrap-Guide) for complete fork deployment instructions.
 
@@ -739,4 +672,5 @@ See the [Bootstrap Guide](https://github.com/RoboFinSystems/robosystems/wiki/Boo
 - [Bootstrap Guide](https://github.com/RoboFinSystems/robosystems/wiki/Bootstrap-Guide) - Complete deployment walkthrough
 - [Architecture Overview](https://github.com/RoboFinSystems/robosystems/wiki/Architecture-Overview) - System architecture
 - [Setup Scripts](/bin/setup/README.md) - Bootstrap and configuration scripts
-- [Graph Config](/.github/configs/graph.yml) - Graph database tier configurations
+- [Graph Config](/.github/configs/graph.yml) - Graph database tier configurations (authoritative for instance sizing)
+- [Stack Names](/.github/configs/stacks.yml) - CloudFormation stack names per environment

--- a/examples/custom_graph_demo/README.md
+++ b/examples/custom_graph_demo/README.md
@@ -21,6 +21,9 @@ just demo-custom-graph
 # Force a fresh graph
 just demo-custom-graph --new-graph
 
+# Force a fresh user (implies --new-graph)
+just demo-custom-graph --new-user
+
 # Skip the verification queries at the end
 just demo-custom-graph --skip-queries
 ```
@@ -29,13 +32,17 @@ just demo-custom-graph --skip-queries
 
 When you run `just demo-custom-graph`, it automatically:
 
-1. **Sets up credentials** - Creates a user account and API key (or reuses existing)
-2. **Creates graph** - Initializes a new graph database with custom schema from `schema.json`
-3. **Generates data** - Creates 50 people, 10 companies, and 15 projects with relationships
-4. **Uploads & ingests** - Loads data into the graph via staging tables
-5. **Runs queries** - Executes example queries to demonstrate capabilities
+1. **Sets up credentials** (`setup_credentials.py`) - Creates a user account and API key (or reuses existing)
+2. **Creates graph** (`create_graph.py`) - Initializes a new graph database with custom schema from `schema.json`
+3. **Generates data** (`generate_data.py`) - Creates 60 people, 8 companies, and 6 projects with relationships
+4. **Uploads & ingests** (`upload_ingest.py`) - Uploads to S3, stages, validates, and materializes into the graph
+5. **Runs queries** (`query_graph.py`) - Executes all preset queries to demonstrate capabilities (skipped with `--skip-queries`)
+6. **Indexes documents** (`upload_documents.py`) - Uploads the markdown files in `documents/` to the graph's OpenSearch index and runs sample searches (skipped when `documents/` has no `.md` files)
+7. **Builds a memory subgraph** (`memory_subgraph.py`) - Creates a `knowledge` subgraph with structured memory (Concept / Observation / Session nodes) and exercises semantic memory (`remember` / `recall`) on the parent graph
 
 **Note**: The graph structure is defined in `schema.json` - you can customize this file to create your own graph schema!
+
+**Note**: Entity counts scale with `--count` (default 60 people). Companies and projects are derived from the person count, with floors of 4 and 6 respectively.
 
 ## Advanced Usage - Individual Steps
 
@@ -54,7 +61,7 @@ uv run setup_credentials.py --name "Your Name" --email your@email.com
 
 **Output**: User created, API key generated, credentials saved to `.local/config.json`
 
-### Step 2-5: Run All Remaining Steps
+### Step 2-7: Run All Remaining Steps
 
 ```bash
 # Run the main demo script
@@ -63,41 +70,59 @@ uv run main.py --new-graph
 
 # Or run each step individually
 uv run create_graph.py
-uv run generate_data.py
+uv run generate_data.py --regenerate
 uv run upload_ingest.py
 uv run query_graph.py --all
+uv run upload_documents.py
+uv run memory_subgraph.py
 ```
 
-**Output**: Graph created with custom data, example queries executed
+**Output**: Graph created with custom data, example queries executed, documents indexed, and a `knowledge` memory subgraph created
+
+**Note**: `main.py` always passes `--regenerate` to `generate_data.py` so the Parquet identifiers line up with the current graph — which is why data generation follows graph creation.
 
 ## Available Preset Queries
 
-### Summary
+Seven presets ship with `query_graph.py`. List them with `uv run query_graph.py --list`, run one with `--preset <name>`, or run them all with `--all`.
+
+| Preset | Description |
+| ------ | ----------- |
+| `summary` | Overview of node and relationship counts |
+| `people` | List all people with their roles and interests |
+| `companies` | Company overview with team sizes and sponsored projects |
+| `projects` | Active projects with sponsors and team members |
+| `teams` | Cross-company teams working on the same project |
+| `interests` | Top technical interests across the organization |
+| `graphviz` | Lightweight subgraph to visualize project connections |
+
+### summary
 
 High-level overview of node counts:
 
 ```cypher
 MATCH (n)
-WITH label(n) AS label, count(n) AS count
+WITH labels(n) AS label, count(n) AS count
 RETURN label, count
 ORDER BY count DESC
 ```
 
-### People
+### people
 
 View all people, their roles, and interests:
 
 ```cypher
 MATCH (p:Person)-[:PERSON_WORKS_FOR_COMPANY]->(c:Company)
 RETURN
-  p.name,
-  p.title,
-  c.name AS company,
-  p.interests
-ORDER BY p.name
+    p.identifier AS person_id,
+    p.name AS name,
+    p.title AS role,
+    c.name AS company,
+    p.interests AS interests
+ORDER BY name
+LIMIT 25
 ```
 
-### Company Overview
+### companies
 
 View all companies with team sizes and sponsored projects:
 
@@ -106,41 +131,31 @@ MATCH (c:Company)
 OPTIONAL MATCH (c)<-[:PERSON_WORKS_FOR_COMPANY]-(p:Person)
 OPTIONAL MATCH (c)-[:COMPANY_SPONSORS_PROJECT]->(proj:Project)
 RETURN
-  c.name,
-  c.industry,
-  c.location,
-  count(DISTINCT p) AS team_members,
-  count(DISTINCT proj) AS sponsored_projects
+    c.name AS company,
+    c.industry AS industry,
+    c.location AS location,
+    count(DISTINCT p) AS team_members,
+    count(DISTINCT proj) AS sponsored_projects
 ORDER BY team_members DESC
 ```
 
-### Employment Relationships
-
-See who works for which companies:
-
-```cypher
-MATCH (p:Person)-[:PERSON_WORKS_FOR_COMPANY]->(c:Company)
-RETURN p.name AS person, c.name AS company, c.industry
-ORDER BY c.name, p.name
-```
-
-### Project Teams
+### projects
 
 See which projects people are working on and who sponsors them:
 
 ```cypher
-MATCH (p:Person)-[:PERSON_WORKS_ON_PROJECT]->(proj:Project)
+MATCH (proj:Project)<-[:PERSON_WORKS_ON_PROJECT]-(p:Person)
 MATCH (proj)<-[:COMPANY_SPONSORS_PROJECT]-(c:Company)
 RETURN
-  proj.name AS project,
-  proj.status AS status,
-  proj.budget AS budget,
-  collect(DISTINCT p.name) AS team_members,
-  collect(DISTINCT c.name) AS sponsors
-ORDER BY proj.name
+    proj.name AS project,
+    proj.status AS status,
+    c.name AS sponsor,
+    proj.budget AS budget,
+    count(DISTINCT p) AS team_members
+ORDER BY project
 ```
 
-### Cross-Company Collaboration
+### teams
 
 Discover cross-company project collaborations:
 
@@ -149,13 +164,41 @@ MATCH (p1:Person)-[:PERSON_WORKS_FOR_COMPANY]->(c1:Company),
       (p2:Person)-[:PERSON_WORKS_FOR_COMPANY]->(c2:Company),
       (p1)-[:PERSON_WORKS_ON_PROJECT]->(proj:Project),
       (p2)-[:PERSON_WORKS_ON_PROJECT]->(proj)
-WHERE c1.identifier <> c2.identifier AND p1.identifier < p2.identifier
+WHERE p1.identifier < p2.identifier AND c1.identifier <> c2.identifier
 RETURN
-  proj.name AS project,
-  c1.name AS company_a,
-  c2.name AS company_b,
-  count(*) AS cross_company_pairs
-ORDER BY cross_company_pairs DESC
+    proj.name AS project,
+    c1.name AS company_a,
+    p1.name AS teammate_a,
+    c2.name AS company_b,
+    p2.name AS teammate_b
+ORDER BY proj.name, company_a, company_b
+LIMIT 50
+```
+
+### interests
+
+Top technical interests across the organization:
+
+```cypher
+MATCH (p:Person)
+RETURN p.interests AS interest_list, count(*) AS people
+ORDER BY people DESC, interest_list ASC
+LIMIT 20
+```
+
+### graphviz
+
+Lightweight subgraph for visualizing project connections:
+
+```cypher
+MATCH (p:Person)-[:PERSON_WORKS_ON_PROJECT]->(proj:Project)
+MATCH (p)-[:PERSON_WORKS_FOR_COMPANY]->(c:Company)
+RETURN
+    p.name AS person,
+    c.name AS company,
+    proj.name AS project
+ORDER BY proj.name, company
+LIMIT 40
 ```
 
 ## Technical Details
@@ -289,12 +332,13 @@ Enter interactive mode for ad-hoc queries:
 cd examples/custom_graph_demo
 uv run query_graph.py
 
-# Then type preset names or custom queries
-> presets
-> preset people
-> preset projects
-> MATCH (p:Person) RETURN count(p)
-> quit
+# Then type preset names or custom queries at the `cypher>` prompt
+cypher> help
+cypher> presets
+cypher> preset people
+cypher> preset projects
+cypher> MATCH (p:Person) RETURN count(p)
+cypher> quit
 ```
 
 ## Learn More
@@ -322,7 +366,7 @@ This demo shows patterns used in real RoboSystems integrations:
 **Solution:** Ensure RoboSystems is running:
 ```bash
 just start
-just logs robosystems-api  # Check API logs
+just logs api  # Check API logs
 ```
 
 **Problem:** "No credentials found"
@@ -350,7 +394,7 @@ just demo-custom-graph --new-graph
 - Credentials are saved in `.local/config.json` and reused across all demos
 - Generated data files are saved in `examples/custom_graph_demo/data/` for inspection
 - Use `just graph-query <graph_id> "<cypher>"` for ad-hoc queries
-- Check `just logs robosystems-api` if you encounter issues
+- Check `just logs api` if you encounter issues
 - Review `schema.json` to understand the complete graph structure before querying
 
 ## Success!
@@ -361,6 +405,8 @@ After running the demo, you have:
 2. Custom graph database with your schema
 3. Sample data demonstrating the graph structure
 4. Ready-to-use query examples
+5. The `documents/` markdown files indexed for document search
+6. A `knowledge` subgraph exercising structured and semantic memory
 
 Explore the data further with `just graph-query` or customize the schema for your own use case!
 

--- a/examples/seattle_method_demo/README.md
+++ b/examples/seattle_method_demo/README.md
@@ -24,21 +24,28 @@ is the primary external-facing artifact.
 # Make sure the stack is running
 just start
 
-# Run the demo end-to-end. Provisions a fresh test graph, pulls the
-# mini taxonomy, ingests the 14 JEs, authors rollforwards, runs the
-# mini reconciliation against Charlie's published facts, AND
-# materializes the 4-IB rs-gaap Report — two markdown artifacts land in
-# output/ at the end.
+# Run the demo end-to-end (nine steps). Provisions a fresh test graph,
+# pulls the mini taxonomy, ingests the 14 JEs, authors rollforwards, runs
+# the mini reconciliation against Charlie's published facts, materializes
+# the 4-IB rs-gaap Report, AND exports + validates the bundle artifacts —
+# eight artifacts land in output/ at the end.
 just demo-seattle-method
 
-# Or run a single step
+# Run against an existing graph, or validate without writing
+just demo-seattle-method --graph <graph_id>
+just demo-seattle-method --dry-run
+
+# Or run a single step. `pull` and `provision` stand alone; every other
+# step needs --graph <id> (provision prints one to carry forward).
 just demo-seattle-method --step pull
-just demo-seattle-method --step load
-just demo-seattle-method --step seed-mappings
-just demo-seattle-method --step ingest
-just demo-seattle-method --step author-rollforwards
-just demo-seattle-method --step reconcile        # mini reconciliation only
-just demo-seattle-method --step create-report    # rs-gaap 4-IB Report only
+just demo-seattle-method --step provision
+just demo-seattle-method --graph <id> --step load
+just demo-seattle-method --graph <id> --step seed-mappings
+just demo-seattle-method --graph <id> --step ingest
+just demo-seattle-method --graph <id> --step author-rollforwards
+just demo-seattle-method --graph <id> --step reconcile          # mini reconciliation only
+just demo-seattle-method --graph <id> --step create-report      # rs-gaap 4-IB Report only
+just demo-seattle-method --graph <id> --step download-bundles   # export + validate + DataBook
 
 # Reconcile + create-report can also be run via their dedicated recipes
 # (handy when iterating on the markdown rendering without re-provisioning):
@@ -50,16 +57,15 @@ just demo-seattle-method-create-report <graph_id>
 
 | Step                  | Artifact                                                                                                                                     |
 | --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| `pull`                | `local/taxonomies/mini/` — 30 XBRL artifacts curled from `xbrlsite.azurewebsites.net` AND `local/datasets/seattle_method/GeneralJournal.csv` from Charlie's `seattlemethod/prototypes` GitHub repo (both gitignored — re-fetched on demand) |
+| `pull`                | `local/taxonomies/mini/` — 67 XBRL artifacts curled from `xbrlsite.azurewebsites.net` (the two schemas plus every linkbase the entry point references) AND `local/datasets/seattle_method/GeneralJournal.csv` from Charlie's `seattlemethod/prototypes` GitHub repo (both gitignored — re-fetched on demand) |
 | `provision`           | A dedicated test graph (e.g. `kg_seattle_method_<timestamp>`) — isolated from real customer data                                             |
-| `load`                | 239 mini concepts as Elements + presentation/calculation/definition/formula linkbase arcs as Associations                                    |
-| `seed-mappings`       | ~36 mini→rs-gaap derivation Associations (BS/IS/CF/SE leaves touched by the 14-JE dataset)                                                   |
+| `load`                | 92 mini concepts as Elements + presentation/calculation/definition/formula linkbase arcs as Associations. `mini.xsd` declares 190 elements; only the 92 **monetary** ones become CoA leaves — hypercubes and abstract roll-ups are XBRL structural plumbing, not GL-postable accounts |
+| `seed-mappings`       | 38 mini→rs-gaap derivation Associations (15 BS/IS + 23 flow) covering the BS/IS/CF/SE leaves touched by the 14-JE dataset                    |
 | `ingest`              | 14 Events (one per JournalEntryID), 14 Entries, ~32 LineItems — each LineItem.metadata\_['transaction_description_code'] stamped from CSV    |
 | `author-rollforwards` | 8 rollforward IBs (one per BS leaf with activity) — Cash, Receivables, Inventories, PP&E, AP, Accrued, LTD, PaidInCapital                    |
 | `reconcile`           | `output/seattle-method-case-1.md` — mini-vocab line-by-line comparison vs. Charlie's PoC, classified per the reconciliation categories below |
 | `create-report`       | `output/seattle-method-case-1-four-statements.md` — rs-gaap 4-IB Report (BS / IS / CF / SE) materialized via create-report + reportPackage   |
-| `download-bundles`    | `output/seattle-method-case-1.jsonld` + `output/seattle-method-case-1.zip` — JSON-LD bundle + XBRL 2.1 report package, pulled via the SDK    |
-| `validate`            | Validates the downloaded artifacts **on the host, container-free**: `output/seattle-method-case-1-xbrl-validation.md` (Arelle vs XBRL 2.1 — structural parity) + `output/seattle-method-case-1-shacl-validation.md` (pyshacl vs `frameworks/ontology/v1/shapes.ttl` — semantic parity). Reads the on-disk `.jsonld`/`.zip` we just received — no API/DB. |
+| `download-bundles`    | The aligned artifact set, pulled via the SDK and validated **on the host, container-free** — download, validate and DataBook are one step. Writes `output/seattle-method-case-1.jsonld` (flat JSON-LD bundle), `.holon.jsonld` (native holon — the holon viewer's input), `.zip` (XBRL 2.1 report package), `-shacl-validation.md` (pyshacl vs `frameworks/ontology/v1/shapes.ttl` — semantic parity), `-xbrl-validation.md` (Arelle vs XBRL 2.1 — structural parity), and `.databook.md` (the DataBook, with both verdicts inlined). Validation reads the on-disk artifacts we just received — no API/DB. |
 
 Steps write to `output/` (gitignored — each run stamps fresh graph/report
 IDs, so committing it would churn). Committed reference copies live in
@@ -76,8 +82,15 @@ faithful to his upstream as it evolves.
 | Artifact | Upstream | Local destination (gitignored) |
 | --- | --- | --- |
 | `GeneralJournal.csv` (14 JEs) | [github.com/seattlemethod/prototypes/.../journal-entries-csv](https://github.com/seattlemethod/prototypes/blob/main/record-to-report/journal-entries-csv/GeneralJournal.csv) | `local/datasets/seattle_method/GeneralJournal.csv` |
-| `mini` base taxonomy + linkbases | [xbrlsite.azurewebsites.net/.../mini/base-taxonomy](https://xbrlsite.azurewebsites.net/2026/reporting-framework/mini/base-taxonomy/mini_ModelStructure.html) | `local/taxonomies/mini/` |
+| `mini` base taxonomy + linkbases (**2023** `reporting-scheme`) | [xbrlsite.azurewebsites.net/2023/reporting-scheme/mini/base-taxonomy](https://xbrlsite.azurewebsites.net/2023/reporting-scheme/mini/base-taxonomy/mini-entryPoint.xsd) — authoritative upstream is [github.com/seattlemethod/mini](https://github.com/seattlemethod/mini); we pull from xbrlsite because that is where the entry point's `linkbaseRef` hrefs resolve | `local/taxonomies/mini/` |
 | Record-to-Report `instance.xml` (reconciliation reference) | [xbrlsite.com/seattlemethod/platinum-testcases/record-to-report/report.zip](http://www.xbrlsite.com/seattlemethod/platinum-testcases/record-to-report/) | `local/datasets/seattle_method/report/instance.xml` |
+
+> **Not to be confused with the 2026 `MINI`.** This demo pulls the
+> **2023** `reporting-scheme` mini (`pull_mini.sh`). The sibling
+> [World Online demo](../seattle_method_world_online/) pulls the **2026**
+> `reporting-framework` MINI (`pull_mini_2026.sh`) for Charlie's
+> 22,288-line GL. Different framework versions, different demos — check
+> which script you are reading before copying a URL between them.
 
 `pull_mini.sh`, `pull_general_journal.sh`, and `pull_expected_report.sh`
 are idempotent (`step_pull` runs all three); re-runs overwrite the

--- a/examples/sec_demo/README.md
+++ b/examples/sec_demo/README.md
@@ -276,7 +276,7 @@ Common XBRL elements you'll encounter:
 **Solution:** Ensure RoboSystems is running:
 ```bash
 just start
-just logs robosystems-api  # Check API logs
+just logs api  # Check API logs
 ```
 
 **Problem:** "No credentials found"

--- a/frameworks/README.md
+++ b/frameworks/README.md
@@ -2,9 +2,11 @@
 
 This directory is the **authoritative source** for the JSON-LD taxonomy
 artifacts that every tenant graph copies into its per-tenant schema at
-provision time. Each child directory is a **framework** (fac, rs-gaap,
-…); the Python code that discovers, parses, writes, and pins this
-content lives at `robosystems/taxonomy/`.
+provision time. Each child directory carrying a top-level `v*.json`
+manifest is a **framework** (cm, fac, rs-gaap today) — the sibling
+`ontology/` holds the canonical RDF ontology + SHACL shapes and is
+deliberately _not_ a framework. The Python code that discovers, parses,
+writes, and pins this content lives at `robosystems/taxonomy/`.
 
 The directory name matches the DB tables it seeds: `frameworks`,
 `framework_packages`, `framework_bridges`.
@@ -15,7 +17,7 @@ A **framework** is a named, versioned, addressable bundle that pins
 specific `(package, version)` and `(bridge, version)` tuples and
 optionally `depends_on` other frameworks. The deliverable that says
 "`rs-gaap` v1 = these N packages + these M bridges + everything in
-`fac` v1, at these versions, in this load order."
+`fac` v1 and `cm` v1, at these versions, in this load order."
 
 A tenant graph pins a framework via:
 
@@ -39,7 +41,7 @@ shape:
 | **Upstream authority**            | Publishes a taxonomy nobody edits but everyone files against                         | FASB us-gaap, IASB IFRS, NAIC statutory, FFIEC call report, FERC Form 1, EIA-861, EPA TRI                  |
 | **`rs-` curation**                | Our authored, edited, render-target version of the upstream                          | `rs-gaap` (today); future `rs-ifrs`, `rs-call-report`, `rs-irs`, `rs-ferc`, `rs-statutory`, `rs-tri`       |
 | **Framework manifest**            | Pins packages + bridges + Styles into one composable deliverable                     | `rs-gaap/v1.json`                                                                                          |
-| **Reporting Styles**              | Vertical / filer-profile variants **within** a framework                             | Default, Small Private Company, Banking, Insurance, Mining (defined inside `rs-gaap-reporting-styles/v1/`) |
+| **Reporting Styles**              | Vertical / filer-profile variants **within** a framework                             | Default, Partnership, Limited Liability Company (defined inside `rs-gaap-reporting-styles/v1/`)            |
 | **Bridges**                       | Equivalences between namespaces (curation ↔ upstream for filing, or curation ↔ peer) | `fac-to-rs-gaap`, future `rs-gaap-to-us-gaap` (SEC export), `rs-gaap-to-ifrs`                              |
 | **Tenant CoA → curation mapping** | Per-graph: a customer's chart of accounts → rs-\* leaves                             | LINE_ITEM_RELATES_TO_ELEMENT + Associations (lives in the tenant schema, not here)                         |
 
@@ -53,14 +55,17 @@ without special-casing.
 |                 | Framework                                                                                                                     | Reporting Style                                                                  |
 | --------------- | ----------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
 | **What it is**  | A self-contained taxonomy stack with its own concept namespace, presentation, calc, and rules                                 | A vertical / filer-profile composition of named Disclosures _within_ a framework |
-| **Cardinality** | A few (one per regulatory regime: GAAP, IFRS, call report, tax, FERC, …)                                                      | Many per framework (Default, Small Private, Banking, Insurance, Mining, …)       |
+| **Cardinality** | A few (one per regulatory regime: GAAP, IFRS, call report, tax, FERC, …)                                                      | Many per framework (today in `rs-gaap`: Default, Partnership, LLC)               |
 | **Lives at**    | `{name}/{version}.json` (+ shared `packages/` and `bridges/` siblings)                                                        | Rows inside the `*-reporting-styles/v1/` package of a framework                  |
 | **Pinned by**   | Graph for availability (`Graph.taxonomy_pin` controls the tenant copy); Entity for adoption (`EntityTaxonomy` rows per basis) | Entity within a graph (`Entity.reporting_style_id`, extensions DB)               |
-| **Example**     | `rs-gaap@v1` for US GAAP filers                                                                                               | `Banking Style` for an entity in `rs-gaap@v1`                                    |
+| **Example**     | `rs-gaap@v1` for US GAAP filers                                                                                               | `Partnership Style` for an entity in `rs-gaap@v1`                                |
 
-A bank that files a 10-K and a call report is pinned to **two
-frameworks** (`rs-gaap` + `rs-call-report`) and within each one picks
-the **Reporting Style** for its filer profile (Banking Style in rs-gaap).
+A bank that files a 10-K and a call report would be pinned to **two
+frameworks** (`rs-gaap` + a future `rs-call-report`) and within each one
+pick the **Reporting Style** for its filer profile (a future Banking
+Style in rs-gaap). Vertical Styles are deferred; `rs-gaap@v1` ships the
+equity-form family only — Default (corporate), Partnership, and Limited
+Liability Company.
 
 ## Current layout
 
@@ -68,39 +73,67 @@ the **Reporting Style** for its filer profile (Banking Style in rs-gaap).
 frameworks/
 ├── README.md
 │
+├── cm/                         conceptual-model substrate (no depends_on, no bridges)
+│   ├── v1.json                 framework manifest
+│   └── packages/
+│       └── cm/v1/              cm:Debit + cm:Credit posting roles (2 concepts)
+│
 ├── fac/                        universal accounting substrate
 │   ├── v1.json                 framework manifest (flat; v2.json can sit alongside)
 │   └── packages/
-│       ├── fac-traits/v1/      universal trait vocabulary (24 axes; seeds `traits`)
+│       ├── README.md
+│       ├── fac-traits/v1/      universal trait vocabulary (26 axes / 100 members; seeds `traits`)
 │       ├── fac/v1/             FAC concepts (Assets, Liabilities, Equity, …)
 │       ├── fac-presentation/v1/
 │       └── fac-calculations/v1/
 │
-└── rs-gaap/                    US GAAP curation; depends_on fac@v1
-    ├── v1.json                 framework manifest
-    ├── packages/
-    │   ├── README.md
-    │   ├── rs-gaap/v1/                    curated us-gaap leaves
-    │   ├── rs-gaap-traits/v1/             per-element trait bindings (seeds `element_traits`)
-    │   ├── rs-gaap-hierarchy/v1/
-    │   ├── rs-gaap-presentation/v1/
-    │   ├── rs-gaap-calculations/v1/
-    │   ├── rs-gaap-type-subtype/v1/       general-special (type/subtype) arcs
-    │   ├── rs-gaap-references/v1/         ASC citation reference linkbase (attach-by-qname)
-    │   ├── rs-gaap-labels/v1/             supplementary + total-role label linkbase (attach-by-qname)
-    │   ├── rs-gaap-disclosures/v1/
-    │   ├── rs-gaap-disclosure-mechanics/v1/
-    │   ├── rs-gaap-reporting-checklist/v1/
-    │   ├── rs-gaap-reporting-styles/v1/   ★ vertical / filer-profile surface
-    │   ├── rs-gaap-rollup-rules/v1/       L2 rollup-shaped consistency rules
-    │   └── rs-gaap-rules/v1/              L1 cross-tree consistency rules (rs-gaap-targeted; moved from fac)
-    ├── bridges/
-    │   ├── README.md
-    │   ├── fac-to-rs-gaap/v1/
-    │   └── rs-gaap-disclosures-to-rs-gaap-textblocks/v1/
-    └── tenant-exclude/
-        └── v1.json                 per-tenant copy curation (policy, NOT a package)
+├── rs-gaap/                    US GAAP curation; depends_on fac@v1 + cm@v1
+│   ├── v1.json                 framework manifest
+│   ├── packages/
+│   │   ├── README.md
+│   │   ├── rs-gaap/v1/                    curated us-gaap leaves
+│   │   ├── rs-gaap-traits/v1/             per-element trait bindings (seeds `element_traits`)
+│   │   ├── rs-gaap-hierarchy/v1/
+│   │   ├── rs-gaap-presentation/v1/
+│   │   ├── rs-gaap-calculations/v1/
+│   │   ├── rs-gaap-type-subtype/v1/       general-special (type/subtype) arcs
+│   │   ├── rs-gaap-references/v1/         ASC citation reference linkbase (attach-by-qname)
+│   │   ├── rs-gaap-labels/v1/             supplementary + total-role label linkbase (attach-by-qname)
+│   │   ├── rs-gaap-disclosures/v1/
+│   │   ├── rs-gaap-disclosure-mechanics/v1/
+│   │   ├── rs-gaap-reporting-checklist/v1/
+│   │   ├── rs-gaap-reporting-styles/v1/   ★ vertical / filer-profile surface
+│   │   ├── rs-gaap-rollup-rules/v1/       L2 rollup-shaped consistency rules
+│   │   ├── rs-gaap-rules/v1/              L1 cross-tree consistency rules (rs-gaap-targeted; moved from fac)
+│   │   ├── rs-metric/v1/                  metric catalog + Derive rules (standing `metric` block)
+│   │   └── rs-driver/v1/                  forecast lever catalog + Derive rules (reference Structure)
+│   ├── bridges/
+│   │   ├── README.md
+│   │   ├── fac-to-rs-gaap/v1/
+│   │   └── rs-gaap-disclosures-to-rs-gaap-textblocks/v1/
+│   └── tenant-exclude/
+│       └── v1.json                 per-tenant copy curation (policy, NOT a package)
+│
+└── ontology/                   NOT a framework — the canonical RDF ontology
+    └── v1/                     context.jsonld · ontology.ttl · shapes.ttl
 ```
+
+### `cm/` — the conceptual-model substrate (a framework, not a reporting taxonomy)
+
+`cm@v1` is a minimal universal upper-vocabulary forked from Charlie
+Hoffman's Seattle Method [`universal`](https://github.com/seattlemethod/universal)
+conceptual model. v1 is intentionally tiny — two abstract concepts,
+`cm:Debit` and `cm:Credit`. A has-part arc from one of them to a
+Chart-of-Accounts element declares that element as the debit or credit
+leg of a Structure's posting template, which makes double-entry posting
+structure a first-class, queryable atom of an Information Block instead
+of opaque mechanics metadata. It is **not** a reporting taxonomy: it
+owns no presentation, calc, or rules, declares no `depends_on`, and
+ships no bridges (it still carries `framework_type: "reporting"` only
+because that is the sole type in use today). Tenants get it with the
+default pin because `rs-gaap` `depends_on` it. It expands additively
+(Thing, Event, Transaction, LineItem) when event serialization pulls
+those in.
 
 ### `tenant-exclude/` — per-tenant copy curation (a policy, not a package)
 
@@ -148,7 +181,10 @@ A framework manifest lives at `{name}/{version}.json`:
   "title": "RoboSystems rs-gaap Reporting Framework",
   "description": "...",
   "framework_type": "reporting",
-  "depends_on": [{ "framework": "fac", "version": "v1" }],
+  "depends_on": [
+    { "framework": "fac", "version": "v1" },
+    { "framework": "cm", "version": "v1" }
+  ],
   "packages": [
     {
       "standard": "rs-gaap",
@@ -171,7 +207,7 @@ A framework manifest lives at `{name}/{version}.json`:
     {
       "standard": "rs-gaap-reporting-styles",
       "version": "v1",
-      "ordinal": 9,
+      "ordinal": 11,
       "is_required": true
     }
   ],
@@ -195,9 +231,10 @@ Fields:
   reserved for future use.
 - **`depends_on[]`** — frameworks this one builds on. Resolved
   depth-first before this framework's own packages load. Cycles raise
-  `ValueError`. Today only `rs-gaap → fac`; future regulatory frameworks
-  like `rs-call-report` will depend on both `fac` and `rs-gaap` (since
-  call reports map from GAAP numbers with regulatory adjustments).
+  `ValueError`. Today only `rs-gaap → [fac, cm]`; future regulatory
+  frameworks like `rs-call-report` will depend on both `fac` and
+  `rs-gaap` (since call reports map from GAAP numbers with regulatory
+  adjustments).
 - **`packages[]`** — atomic units owned by this framework. Each entry is
   a `(standard, version, ordinal, is_required)` tuple.
   - `ordinal` orders the load: dependencies first, then this framework's
@@ -277,7 +314,7 @@ are intentionally different frameworks projecting from the same ledger.
 The same dynamic applies to call-report-to-GAAP, stat-to-GAAP,
 FERC-to-GAAP.
 
-Today the library ships two frameworks (fac + rs-gaap). The directory
+Today the library ships three frameworks (cm + fac + rs-gaap). The directory
 structure and `depends_on` machinery support adding peer frameworks
 without restructure. Multiple frameworks per graph is already
 mechanically possible at the copy layer — a legacy flat pin can list

--- a/frameworks/rs-gaap/packages/README.md
+++ b/frameworks/rs-gaap/packages/README.md
@@ -2,13 +2,17 @@
 
 This directory holds the **packages owned by the `rs-gaap@v1` framework** —
 the curated us-gaap leaves, the presentation/calc/disclosure machinery
-that lives on top of them, and the Reporting Styles surface for
-vertical/filer-profile flavoring.
+that lives on top of them, the Reporting Styles surface for
+vertical/filer-profile flavoring, and the metric / forecast-lever
+catalogs that derive from the same anchors.
 
 Packages owned by the upstream **`fac@v1`** framework (Charlie Hoffman's
 universal accounting-concept substrate) live next door at
-`../../../fac/packages/`. They are inherited via this framework's
-`depends_on: [{framework: fac, version: v1}]` and load first.
+`../../../fac/packages/`, and the **`cm@v1`** conceptual-model substrate
+(the `cm:Debit` / `cm:Credit` posting roles) at `../../../cm/packages/`.
+Both are inherited via this framework's
+`depends_on: [{framework: fac, version: v1}, {framework: cm, version: v1}]`
+and load first.
 
 Each package here is a versioned, self-contained JSON-LD unit;
 migration 0002 walks the framework manifest to load them in
@@ -65,8 +69,8 @@ Each package declares its provenance in its top-level JSON-LD metadata:
 packages/
 ├── rs-gaap/v1/                       forked  — RoboSystems canonical us-gaap (~2,000 leaves)
 ├── rs-gaap-traits/v1/                native  — per-element trait bindings for rs-gaap leaves;
-│                                              seeds `element_traits` junction (binds rs-gaap
-│                                              elements to fac-traits axes)
+│                                               seeds `element_traits` junction (binds rs-gaap
+│                                               elements to fac-traits axes)
 ├── rs-gaap-hierarchy/v1/             forked  — rs-gaap class hierarchy
 ├── rs-gaap-presentation/v1/          native  — rs-gaap presentation hierarchies
 ├── rs-gaap-calculations/v1/          native  — rs-gaap calc DAG (composes with fac-calculations)
@@ -76,11 +80,19 @@ packages/
 ├── rs-gaap-disclosures/v1/           native  — named Disclosures (~30)
 ├── rs-gaap-disclosure-mechanics/v1/  native  — DM rules per Disclosure
 ├── rs-gaap-reporting-checklist/v1/   native  — DR rules per report type
-└── rs-gaap-reporting-styles/v1/      native  — vertical / filer-profile composition surface
-                                                (Default, Small Private, Banking, Insurance, Mining, …)
+├── rs-gaap-reporting-styles/v1/      native  — vertical / filer-profile composition surface
+│                                               (v1 ships Default, Partnership, LLC)
+├── rs-gaap-rollup-rules/v1/          native  — L2 rollup-shaped consistency rules
+├── rs-gaap-rules/v1/                 native  — L1 cross-tree consistency rules (moved from fac)
+├── rs-metric/v1/                     native  — metric catalog: one concept + one Derive rule per
+│                                               metric, plus the standing Key Financial Metrics
+│                                               block (block_type `metric`) compute-metrics fills
+└── rs-driver/v1/                     native  — forecast lever catalog: one concept + one Derive
+                                                rule per lever, plus the Driver Catalog reference
+                                                Structure (block_type `custom`, never rendered)
 ```
 
-The trait vocabulary (`fac-traits/v1`, 99 traits across 26 categories)
+The trait vocabulary (`fac-traits/v1`, 100 traits across 26 categories)
 lives in the upstream `fac` framework and is inherited here via
 `depends_on`. `rs-gaap-traits/v1/` is the rs-gaap-specific binding —
 it declares which trait values apply to which rs-gaap leaves. Future
@@ -110,12 +122,29 @@ the hand-authored source (provenance in git history; the spent
 JSON-LD artifacts are now the source of truth, edit them directly. Both are `tenant_copy: true` —
 tenants get the citations and labels for the concepts they keep.
 
-**`rs-gaap-reporting-styles`** is THE vertical-flavor surface. New
-industries (Mining, Cooperative, B-Corp, etc.) are added
-here as new Reporting Style rows, **not** as new frameworks. The
-framework boundary is regulatory regime (GAAP, IFRS, call report,
+**`rs-gaap-reporting-styles`** is THE vertical-flavor surface. v1 ships
+the equity-form family only — `Default` (corporate), `Partnership`, and
+`LimitedLiabilityCompany`. New industries (Mining, Cooperative, B-Corp,
+etc.) land here as new Reporting Style rows, **not** as new frameworks.
+The framework boundary is regulatory regime (GAAP, IFRS, call report,
 statutory, tax); the Reporting Style boundary is filer profile
 within a regime.
+
+**`rs-metric`** and **`rs-driver`** are catalog packages owned by
+`rs-gaap@v1` but named without the `rs-gaap-` prefix, because each
+declares its own namespace (`…/rs-gaap/metrics/v1/`,
+`…/rs-gaap/drivers/v1/`) rather than adding to the rs-gaap concept
+namespace. Both follow the same shape: one qname-addressable concept per
+metric / lever, one `Derive`-pattern rule per concept, and a container
+node that is _both_ an abstract element and a Structure whose
+presentation arcs enumerate the catalog. They differ in direction: a
+metric's rule computes it from rs-gaap anchor facts
+(`$Metric = f(rs-gaap operands)`) and `compute-metrics` upserts the
+standing `metric` block; a driver's rule states the driven mechanics
+against rs-gaap anchors (`$Anchor = f(prior anchors, lever)`) while the
+lever _values_ are asserted per scenario as facts, and `compute-forecast`
+walks the cascade. The Driver Catalog Structure is `block_type: custom`
+— a reference catalog, never rendered.
 
 **SFAC 6** doesn't have its own package — its content (Assets,
 Liabilities, Equity, Revenues, Expenses, etc.) is encoded as the
@@ -130,10 +159,10 @@ inherit the same axes.
 
 A Reporting Style is a **selection vector** over per-statement
 presentation Structures, identified by a 4-segment code
-`{BS-layout}-{equity-form}-{IS-layout}-{CF-method}` (e.g.
-`BSC-CORP-IS01-CF1`). A preset composes one Network (presentation
-Structure) per statement type; switching a graph's Style re-renders its
-statements against the composed Networks.
+`{BS-layout}-{equity-form}-{IS-layout}-{CF-method}` (the seeded
+`Default` is `BSC-CORP-IS02-CF1`). A preset composes one Network
+(presentation Structure) per statement type; switching an entity's Style
+re-renders its statements against the composed Networks.
 
 Adding a preset is **pure package content** — no migration. On a fresh
 `reset-local`, migration `0008` re-reads this package's declarations and
@@ -156,10 +185,13 @@ composition.
      (`balance_sheet`, `income_statement`, `cash_flow_statement`,
      `equity_statement`). Each `networkRoleUri` is a presentation
      Structure's `roleUri`.
-     A Style with no `reportingStyleNetworks` (e.g. `Banking`) stays a
-     non-selectable placeholder.
-3. `just reset-local`, then `change-reporting-style` to the preset's
-   Structure id (`uuid5(roleUri, "structure")`) and re-render.
+     A Style whose composition is incomplete stays a non-selectable
+     placeholder — `change-reporting-style` rejects any target missing a
+     Network for one of those four statement types. All three seeded
+     Styles are complete today.
+3. `just reset-local`, then `change-reporting-style` (entity-scoped; it
+   flips `entities.reporting_style_id`) to the preset's Structure id
+   (`uuid5(roleUri, "structure")`) and re-render.
 
 ### The equity-form axis (worked example)
 
@@ -180,9 +212,14 @@ leaves`, which already sums `PartnersCapital`/`MembersEquity`), so the
 
 The `Partnership` / `LimitedLiabilityCompany` presets then compose those
 Networks (`BSC-PART-IS02-CF1`, `BSC-LLC-IS02-CF1`) with the shared
-`IS-multistep` + `CashFlow-indirect`. New graphs default to the matching
-Style from the entity's `entity_type` at creation (see
-`operations/graph/reporting_style_defaults.py`).
+`IS-multistep` + `CashFlow-indirect`. A new entity is defaulted to the
+matching Style from its `entity_type` at creation — partnership → PART,
+llc / limited_liability_company → LLC, everything else → the corporate
+Default (see `operations/graph/reporting_style_defaults.py`). The Style
+is pinned on the **entity**, not the graph: `entities.reporting_style_id`
+in the extensions DB (migration `0020`), so heterogeneous entities in one
+graph can each carry their own while resolving to the same canonical
+calc-DAG subtotals.
 
 **Known limit:** auto-derived Retained Earnings is corporate-specific —
 partnerships/LLCs roll undistributed earnings into the capital account, not

--- a/frameworks/rs-gaap/v1.json
+++ b/frameworks/rs-gaap/v1.json
@@ -2,7 +2,7 @@
   "framework": "rs-gaap",
   "version": "v1",
   "title": "RoboSystems rs-gaap Reporting Framework",
-  "description": "Sovereign rs-gaap leaf catalog (curated from FASB us-gaap) with named Disclosures, Disclosure Mechanics, presentation/rendering machinery, and Reporting Styles for vertical/filer-profile flavoring (Default, Small Private Company, Banking, Insurance, Mining, etc.). Depends on the fac framework for the universal accounting concept substrate and trait vocabulary; rs-gaap-traits/v1 binds those traits to rs-gaap elements (seeds the element_traits junction). The default framework pinned by every tenant graph filing under US GAAP.",
+  "description": "Sovereign rs-gaap leaf catalog (curated from FASB us-gaap) with named Disclosures, Disclosure Mechanics, presentation/rendering machinery, and Reporting Styles for legal-form flavoring (v1 ships Default, Partnership, and Limited Liability Company). Depends on the fac framework for the universal accounting concept substrate and trait vocabulary; rs-gaap-traits/v1 binds those traits to rs-gaap elements (seeds the element_traits junction). The default framework pinned by every tenant graph filing under US GAAP.",
   "framework_type": "reporting",
   "depends_on": [
     {"framework": "fac", "version": "v1"},

--- a/robosystems/adapters/sec/README.md
+++ b/robosystems/adapters/sec/README.md
@@ -38,10 +38,14 @@ throttled. Treat 5 req/s as the ceiling in practice, not the floor.
 |-------|---------|
 | `XBRLGraphProcessor` | One XBRL filing → parquet files |
 | `XBRLDuckDBGraphProcessor` | Unified staging + materialization |
-| `DuckDBStager` | Parquet → DuckDB |
-| `LadybugMaterializer` | DuckDB → LadybugDB |
-| `LadybugDirectCopier` | S3 → LadybugDB, bypassing DuckDB |
+| `DuckDBStager` | S3 Parquet → DuckDB (stage 1) |
+| `LadybugMaterializer` | DuckDB → LadybugDB (stage 2) |
 | `SECMetadataLoader` | Filer and report metadata, cached |
+
+The two ingestion stages are decoupled on purpose — a failed LadybugDB
+materialization must not discard hours of DuckDB staging work — and
+`XBRLDuckDBGraphProcessor` subclasses both for callers that run them together.
+There is no path from S3 straight into LadybugDB; staging is always in between.
 
 Supporting modules: `constants.py` (`SHARED_NODE_TABLES`, `QUARTER_END_DAYS`),
 `processing.py` (`process_single_filing_to_memory()`), `consolidation.py`
@@ -118,7 +122,7 @@ In production the `sec_knowledge_artifacts` asset downloads the staging DuckDB
 file from `s3://{user-bucket}/shared-repositories/databases/sec.duckdb`, builds
 the artifacts on the Fargate task, and uploads them to
 `s3://{SHARED_PROCESSED_BUCKET}/sec/artifacts/`. The DuckDB file itself is
-published by `sec_duckdb_s3_publish_job` after staging. Locally, artifacts live
+published by the `sec_duckdb_s3_publish` job after staging. Locally, artifacts live
 in `data/artifacts/`. `SemanticEnricher` checks local disk first and downloads
 from S3 when missing — a fresh environment with no artifacts still enriches, just
 without confidence refinement.

--- a/robosystems/admin/README.md
+++ b/robosystems/admin/README.md
@@ -1,6 +1,6 @@
 # Admin CLI
 
-Remote administration for the platform: subscriptions, invoices, credits, graphs, users, organizations, cache, instances, search indices, worker queues, and database migrations.
+Remote administration for the platform: subscriptions, invoices, credits, graphs, users, organizations, SCIM provisioning, cache, instances, search indices, worker queues, and database migrations.
 
 ## How it works
 
@@ -54,11 +54,11 @@ just admin dev stats
 ```bash
 just admin dev subscriptions list                          # List all
 just admin dev subscriptions list --status active
-just admin dev subscriptions list --tier ladybug-large
+just admin dev subscriptions list --resource-type graph
 just admin dev subscriptions list --email user@example.com
 just admin dev subscriptions list --include-canceled
 just admin dev subscriptions get SUBSCRIPTION_ID
-just admin dev subscriptions create USER_ID --resource-type graph --resource-id GRAPH_ID --plan-name ladybug-standard
+just admin dev subscriptions create --org-id ORG_ID --resource-id GRAPH_ID --plan-name ladybug-standard
 just admin dev subscriptions update SUBSCRIPTION_ID --status active --plan-name ladybug-large
 just admin dev subscriptions audit SUBSCRIPTION_ID
 just admin dev subscriptions audit SUBSCRIPTION_ID --event-type PAYMENT_FAILED
@@ -125,9 +125,13 @@ just admin dev users list --email example.com
 just admin dev users list --verified-only
 just admin dev users get USER_ID
 just admin dev users graphs USER_ID
-just admin dev users activity USER_ID --days 30
+just admin dev users activity USER_ID
+just admin dev users deactivate USER_OR_EMAIL
+just admin dev users activate USER_OR_EMAIL
 just admin dev users delete USER_OR_EMAIL --dry-run
 ```
+
+`users deactivate` is the support-plane response short of deletion; it takes a user ID or an email, as `activate` and `delete` do.
 
 `users delete` takes a user ID or an email. It frees the email address but retains billing and audit history, and refuses while the user's org still has live graphs, subscriptions in force, or active repository access.
 
@@ -142,6 +146,20 @@ just admin dev orgs update ORG_ID \
   --billing-contact-name "Accounts Payable" \
   --payment-terms "net_30" \
   --max-graphs 25
+```
+
+### scim
+
+SCIM provisioning for dedicated tenants. `bootstrap` creates-or-reuses the
+enterprise org and mints the bearer token the customer's IdP presents — the raw
+token prints once and is never recoverable, so paste it into the IdP connector
+immediately. Pass either `--org-id` (attach to an existing org) or `--org-name`
+(create a new `ENTERPRISE` org).
+
+```bash
+just admin prod scim bootstrap --org-name "Acme Inc"
+just admin prod scim bootstrap --org-id ORG_ID --token-name scim-provisioning --expires-in-days 365
+just admin prod scim revoke-token TOKEN_ID
 ```
 
 ### cache

--- a/robosystems/config/billing/core.py
+++ b/robosystems/config/billing/core.py
@@ -17,7 +17,15 @@ logger = logging.getLogger(__name__)
 
 # SINGLE SOURCE OF TRUTH: Subscription tier configuration
 # All tier-related settings are defined here in one place.
-# NOTE: Stripe prices are auto-created from this config on first checkout
+#
+# Editing a price here governs NEW checkouts only. Stripe prices are resolved
+# per checkout by matching the amount below against the plan product's active
+# prices, creating one if absent (PaymentProvider._get_or_create_graph_price).
+# Existing subscriptions stay attached to the immutable Stripe Price they were
+# created with, and stripe_price_id / base_price_cents are persisted per row on
+# billing_subscriptions — so a change here reprices nobody. Any price change
+# must ship a Stripe subscription-item swap plus a database backfill, or
+# existing subscribers keep paying the old amount indefinitely.
 #
 # Typical agent call (~5K input, ~1.5K output): ~38 credits
 #

--- a/robosystems/config/defaults.py
+++ b/robosystems/config/defaults.py
@@ -91,13 +91,20 @@ class AdmissionDefaults:
   These thresholds determine when to start rejecting new requests
   to protect system stability.
 
-  MEMORY_THRESHOLD is a percentage (0-100) used to *report* memory pressure.
-  It is deliberately not the gate for rejecting graph queries: a LadybugDB
-  buffer pool is a fixed pre-commitment that is supposed to fill, so percent
-  of total memory conflates that constant with the query working set that
-  actually predicts exhaustion. Rejection is gated on MIN_AVAILABLE_MB, an
+  These constants feed two different admission controllers, which use them
+  differently. Read the consumer before reasoning about either.
+
+  graph_api/core/admission_control.py (the LadybugDB query path) reports
+  MEMORY_THRESHOLD but deliberately does not reject on it: a LadybugDB buffer
+  pool is a fixed pre-commitment that is supposed to fill, so percent of total
+  memory conflates that constant with the query working set that actually
+  predicts exhaustion. There, rejection is gated on MIN_AVAILABLE_MB, an
   absolute headroom figure that does not move when the pool or the instance
   size changes.
+
+  middleware/graph/admission_control.py (the routing path) does the opposite:
+  it rejects on MEMORY_THRESHOLD as a straight percentage and never reads
+  MIN_AVAILABLE_MB.
   """
 
   MEMORY_THRESHOLD = 85.0  # Report memory pressure at 85% usage

--- a/robosystems/dagster/README.md
+++ b/robosystems/dagster/README.md
@@ -38,9 +38,13 @@ Run a job by hand:
 ```bash
 uv run dagster job execute -m robosystems.dagster -j monthly_credit_allocation_job
 
-uv run dagster job execute -m robosystems.dagster -j sec_download_job \
+uv run dagster job execute -m robosystems.dagster -j sec_download \
   -c '{"ops": {"sec_raw_filings": {"config": {"ticker": "NVDA", "year": 2025}}}}'
 ```
+
+Asset jobs are registered under a name that drops the `_job` suffix carried by
+their Python variable (`sec_download_job` → `sec_download`). `-j` takes the
+registered name — the tables below use it.
 
 ## Scheduled jobs
 
@@ -64,17 +68,19 @@ The instance-monitoring schedules are auto-enabled in staging and production onl
 
 | Job | Trigger | Purpose |
 | --- | ------- | ------- |
-| `backup_graph_job`, `restore_graph_job` | API | Back up / restore a graph via S3 |
+| `backup_graph_job` | API, `nightly_graph_backup_schedule` | Back up a graph to S3 — on demand, and nightly at 03:00 America/New_York (schedule runs in staging/prod, stopped in dev) |
+| `restore_graph_job` | API | Restore a graph from S3 |
 | `stage_file_job`, `materialize_file_job` | API | Stage an uploaded file, then materialize it |
-| `materialize_graph_job` | `stale_graph_materialization_sensor` | Rebuild a graph marked stale |
+| `materialize_graph_job` | API | Rebuild a graph from its staging tables |
 | `suspend_expired_graphs_job` | `expired_graph_subscription_sensor` | Move graphs with expired subscriptions to suspended |
 | `deprovision_suspended_graphs_job` | `suspended_graph_deprovisioning_sensor` | Deprovision after the retention window |
 | `reap_stalled_provisioning_job` | `stalled_provisioning_sensor` | Write off subscriptions stuck mid-provisioning so their infrastructure is reclaimed |
 | `invoice_subscription_renewal_job` | `invoice_subscription_renewal_sensor` | Rotate billing periods and generate invoices for invoice-billed subscriptions |
 | `send_email_job` | API | Email notifications |
-| `shared_master_wake_job`, `shared_master_sleep_job`, `shared_replicas_refresh_job`, `shared_repository_refresh_replicas_job` | Schedule / sensor / manual | Shared repository master lifecycle and replica refresh |
+| `shared_master_wake`, `shared_master_sleep`, `shared_replicas_refresh`, `shared_repository_refresh_replicas_job` | Schedule / sensor / manual | Shared repository master lifecycle and replica refresh |
 | `ladybug_migration_export_job`, `ladybug_migration_import_job`, `ladybug_migration_cleanup_job` | Manual | LadybugDB version migration: export pre-deploy, import post-deploy, delete rollback backups post-verify |
-| `extensions_materialize_job`, `extensions_promote_obligations_job` | Sensor (extensions builds only) | OLTP→OLAP materialization and period-boundary obligation promotion |
+| `extensions_materialize_job` | `stale_graph_materialization_sensor` | OLTP→OLAP materialization for a graph marked stale (extensions builds only) |
+| `extensions_promote_obligations_job` | `scheduled_obligation_promotion_sensor` | Period-boundary obligation promotion (extensions builds only) |
 
 ## Sensors
 

--- a/robosystems/graph_api/README.md
+++ b/robosystems/graph_api/README.md
@@ -148,14 +148,17 @@ optimized away.
   database file. Materializations additionally take a per-graph distributed lock
   so two of them can't interleave — see [`core/ladybug/`](core/ladybug/README.md).
 - **Sequential ingestion.** Files are materialized one at a time per database.
-- **Connection pool: 3 per database.** Both the LadybugDB and DuckDB pools are
-  initialized at 3 in `app.py`. Asking for a fourth does not queue — the pool
-  closes the oldest connection to make room. Concurrency comes from more
+- **Connection pool: 3 per database.** Hardcoded, not tier-resolved: the DuckDB
+  pool is initialized at 3 in `app.py`, and the LadybugDB pool takes the
+  `max_connections_per_db=3` default on `LadybugDatabaseManager`, which
+  `LadybugService` never overrides. Asking for a fourth does not queue — the
+  pool closes the oldest connection to make room. Concurrency comes from more
   instances, not a bigger pool.
 - **Admission control rejects before it crashes.** Requests are refused with 503
   when free memory drops below 1 GB (measured as the tighter of host-available
-  and cgroup headroom) or CPU exceeds 95%. A percentage-of-total memory gate
-  would misfire, because a buffer pool is *supposed* to fill.
+  and cgroup headroom) or CPU exceeds 90% — 80% for ingestion, which gets a
+  stricter limit. A percentage-of-total memory gate would misfire, because a
+  buffer pool is *supposed* to fill.
 - **No cross-database queries.** Each query is scoped to one database file.
 - **Memory is a fixed per-database budget** derived from the tier config, not a
   shared heap. Exceeding it is an OOM kill of the container, which is why
@@ -177,11 +180,15 @@ GRAPH_API_KEY=                        # cluster API key
 GRAPH_QUERY_TIMEOUT=30
 ```
 
-Memory, thread counts, chunk sizes, connection-pool size and subgraph caps are
-resolved per tier from [`.github/configs/graph.yml`](/.github/configs/graph.yml)
-using `CLUSTER_TIER`; the `LBUG_MAX_MEMORY_MB` / `LBUG_CHUNK_SIZE` /
-`LBUG_CONNECTION_POOL_SIZE` env vars are only the local-dev fallback when no
-tier block matches.
+Memory, thread counts, chunk sizes and subgraph caps are resolved per tier from
+[`.github/configs/graph.yml`](/.github/configs/graph.yml) using `CLUSTER_TIER`;
+the `LBUG_MAX_MEMORY_MB` / `LBUG_CHUNK_SIZE` env vars are only the local-dev
+fallback when no tier block matches.
+
+Connection-pool size is **not** among them. `graph.yml` carries a
+`connection_pool_size` per tier and `env.get_lbug_tier_config()` surfaces it
+(as does `LBUG_CONNECTION_POOL_SIZE`), but nothing reads either — both pools are
+capped at a hardcoded 3 per database (see Operational limits above).
 
 Client-side behavior (retries, circuit breaker, timeouts) is configured
 separately under the `GRAPH_CLIENT_` prefix — see [`client/`](client/README.md).

--- a/robosystems/middleware/auth/README.md
+++ b/robosystems/middleware/auth/README.md
@@ -2,9 +2,17 @@
 
 Authentication and per-graph authorization for the platform. This package
 exposes FastAPI **dependencies**, not ASGI middleware classes — you protect an
-endpoint by declaring the dependency in the route signature. It handles two
-credential types (JWT and API key), caches validation results in Valkey, and
-enforces graph access on every authenticated graph-scoped route.
+endpoint by declaring the dependency in the route signature. It handles three
+credential types (JWT, API key, and the SCIM bearer token), caches validation
+results in Valkey, and enforces graph access on every authenticated
+graph-scoped route.
+
+JWT and API key are the two general-purpose credentials and are
+interchangeable across the dependencies below. The SCIM token is not: it is
+accepted **only** at `/scim/v2` and nowhere else, and the general dependencies
+never accept it. Enterprise **OIDC login** is a different kind of thing again —
+a sign-in *method*, not a credential the API accepts; it terminates in an
+ordinary platform JWT.
 
 Rate limiting is a separate concern and lives in
 [`../rate_limits/`](../rate_limits/). This package's `__init__.py` re-exports
@@ -12,7 +20,7 @@ Rate limiting is a separate concern and lives in
 `subscription_aware_rate_limit_dependency` for convenience but implements
 neither.
 
-## The two credential surfaces
+## The credential surfaces
 
 **JWT (`Authorization: Bearer …`) is for frontends.** Short-lived HS256 access
 tokens, 30-minute expiry (`JWT_EXPIRY_HOURS = 0.5` in `config/constants.py` — a
@@ -38,6 +46,18 @@ concern:
 curl -H "X-API-Key: $(jq -r .api_key .local/config.json)" \
      http://localhost:8000/v1/graphs/$GRAPH_ID/...
 ```
+
+**SCIM bearer tokens (`Authorization: Bearer …` at `/scim/v2`) are for an
+IdP.** `scim.py:require_scim_org` is their entire auth path: it resolves the
+presented bearer to an active, unexpired `scim_tokens` row, stamps
+`last_used_at`, and returns the token's **org** — SCIM is org-scoped, not
+user-scoped, and publishes `request.state.scim_org_id` for the handlers.
+Storage mirrors `UserAPIKey` (bcrypt `token_hash`, indexed fingerprint, stored
+`prefix`), but the plaintext carries its own `rfss` prefix, so a SCIM token can
+never satisfy the `^rfsc?[0-9a-f]{64}$` API-key format and vice versa. Failures
+answer in the SCIM error envelope (`{"schemas": [...], "detail": ..., "status":
+"401"}`), not FastAPI's `{"detail": ...}`, and never distinguish unknown from
+revoked from expired.
 
 ### Key scoping
 
@@ -68,13 +88,81 @@ auth take precedence on both; the query parameter is consulted only when
 neither is present. Do not add a third door without matching this table, the
 redaction lists, and a scope story.
 
-### SSO
+### SSO — one word, two mechanisms
 
+**Cross-app handoff** is the original one and involves no IdP at all.
 `jwt.py:create_sso_token` mints a single-use handoff JWT with a 300-second TTL,
-carrying `{"sso": true}` and a `token_id` used to enforce single use. Reuse of
-a spent token is treated as a possible replay of a leaked credential and logged
-as such. Used for handoff between app.robosystems.ai, roboledger.ai, and
-roboinvestor.ai.
+carrying `{"sso": true}` and a `token_id` used to enforce single use. These
+tokens have no `jti`, cannot be revoked, and `verify_jwt_claims` refuses them as
+session bearers. Reuse of a spent token is treated as a possible replay of a
+leaked credential and logged as such. Used for handoff between
+app.robosystems.ai, roboledger.ai, and roboinvestor.ai.
+
+**Enterprise SSO (OIDC login)** is the newer one: a real IdP sign-in for
+dedicated deployments. The kernel is `operations/oidc.py`; the browser-facing
+endpoints are `routers/auth/oidc.py`, mounted **only** when
+`SSO_OIDC_ENABLED=true` (`routers/auth/__init__.py`) and both
+`include_in_schema=False`, because they speak in redirects rather than JSON —
+deliberately not SDK surface. The managed platform never mounts them.
+
+```
+GET /v1/auth/oidc/login     → 302 to the IdP (also the IdP-initiated login URI)
+GET /v1/auth/oidc/callback  → validates the ID token, resolves the user,
+                              302s to the login home's ?session_id= bridge
+```
+
+Things worth knowing before touching this path:
+
+- **The IdP authenticates; the platform mints.** The callback does not issue a
+  JWT. It writes an `sso_session:{id}` payload and hands the browser to the same
+  `sso-complete` consumption path the cross-app bridge uses — which is why the
+  two "SSO" concepts meet at exactly one point.
+- **Resolution is link-only — login never creates a user.**
+  `resolve_oidc_user` looks up the `user_identities` link on `(issuer, sub)`. On
+  a miss there is exactly one fallback: an active user whose email matches, who
+  carries a SCIM `external_id`, and who has no identity for this issuer yet. The
+  `external_id` predicate is load-bearing — without it anyone controlling a
+  matching mailbox in the customer's IdP could bind onto a locally-created
+  account. An explicit `email_verified: false` is refused (a missing claim is
+  tolerated; Entra omits it).
+- **`is_active` is re-checked even on a valid link**, because IdP assignment and
+  SCIM assignment drift apart (Okta runs them as two apps).
+- **Failures redirect, they do not return JSON** — `?reason=` on the login home,
+  with the real distinction in the audit log. A top-level browser navigation
+  that dead-ends on an error body is unrecoverable UX.
+- **CSRF/replay defenses**: PKCE, a nonce, GETDEL flow state (a replayed state
+  reads as invalid), a path-scoped `oidc_flow` browser-binding cookie compared
+  with `compare_digest`, and a third-party-initiated `iss` that is validated
+  against the configured issuer rather than followed.
+
+### SCIM provisioning
+
+`SCIM_ENABLED=true` mounts `routers/scim` at `/scim/v2` (`main.py`) — gated
+independently of OIDC, since a deployment may run either alone. The surface is
+Users CRUD (`GET`/`POST /Users`, `GET`/`PUT`/`PATCH`/`DELETE /Users/{id}`) plus
+the `ServiceProviderConfig` / `ResourceTypes` / `Schemas` conformance probes,
+all `include_in_schema=False`. Every route sits behind two rate buckets and then
+`require_scim_org`: an IP bucket first, because each presented bearer keys its
+own token bucket and a caller inventing a new bearer per request would otherwise
+never be metered, then the per-token bucket for legitimate IdP traffic.
+SCIM-provisioned users join the org with `SSO_DEFAULT_ROLE`.
+
+### Deployment posture
+
+`GET /v1/auth/providers` (`routers/auth/providers.py`) reports which methods a
+deployment offers — `password_auth`, `oidc` (with `provider_label`),
+`registration`, `passkeys` — so the login surface renders posture from runtime
+config instead of hardcoding it.
+
+Posture is enforced, not merely advertised: `require_password_auth` in
+`routers/auth/utils.py` guards *every* password-credential endpoint (login,
+registration, reset, change) with a 403 when `PASSWORD_AUTH_ENABLED=false`. A
+login the UI hides but the API still accepts would let a password bypass the
+IdP's MFA and conditional-access policies. `config/validation.py` refuses to
+boot a deployment that disables password auth without enabling OIDC, that
+enables OIDC without a complete connection, that sets a privileged
+`SSO_DEFAULT_ROLE`, or that runs OIDC/SCIM with `RATE_LIMIT_ENABLED=false` —
+the OIDC and SCIM rate buckets are no-ops without it.
 
 ## Dependencies
 
@@ -182,7 +270,27 @@ JWT_ISSUER=...
 JWT_AUDIENCE=...
 VALKEY_URL=redis://localhost:6379
 RATE_LIMIT_ENABLED=true   # consumed by middleware/rate_limits/
+
+# Auth posture — reported by GET /v1/auth/providers
+PASSWORD_AUTH_ENABLED=true    # false requires SSO_OIDC_ENABLED=true
+
+# Enterprise SSO (OIDC). Off by default; the managed platform never sets these.
+SSO_OIDC_ENABLED=false
+SSO_OIDC_ISSUER=            # IdP org authorization server, https:// when deployed;
+                            # no query/fragment. For Okta this is https://<org>.okta.com,
+                            # NOT /oauth2/default (that mints API tokens, not sign-in ID tokens)
+SSO_OIDC_CLIENT_ID=
+SSO_OIDC_CLIENT_SECRET=     # read via get_secret_value, not a plain env read
+SSO_OIDC_PROVIDER_LABEL=SSO # button label on the login home
+
+# SCIM 2.0 provisioning. Gated independently of OIDC.
+SCIM_ENABLED=false
+SSO_DEFAULT_ROLE=member     # validation rejects anything but member|admin
 ```
+
+The OIDC redirect URI is derived, not configured:
+`{ROBOSYSTEMS_API_URL}/v1/auth/oidc/callback`. Register that exact value with
+the IdP.
 
 Read these through `robosystems.config.env`, never `os.getenv()`.
 

--- a/robosystems/middleware/billing/README.md
+++ b/robosystems/middleware/billing/README.md
@@ -20,10 +20,13 @@ the codebase. If you are writing a new endpoint and reaching for credits, first
 check that it actually calls a model.
 
 **Storage is limit-enforced, not metered.** There is no storage-to-credits and
-no storage-to-USD path in the code. `CreditService.check_storage_limit()`
-reports usage against the graph's `storage_limit_gb` (with an optional admin
-override) and returns a status plus recommendations — it never computes a
-charge. Exceeding the limit gates the write path; it does not bill.
+no storage-to-USD path in the code. `GraphCredits.check_storage_limit()` — a
+method on the model in `models/core/graph/graph_credits.py`, not on
+`CreditService` — reports usage against the graph's `storage_limit_gb` (or
+`storage_override_gb` when an admin has set one) and returns usage, limit,
+percentage, and the `within_limit` / `approaching_limit` / `needs_warning`
+booleans. It never computes a charge. Exceeding the limit gates the write path;
+it does not bill.
 
 ## Credits
 
@@ -59,15 +62,22 @@ credit_service.consume_ai_tokens(
 ```
 
 Note the argument is `operation_description` — free text for the transaction
-record — not an `operation_type`. `model` takes the Bedrock inference-profile
-id and is mapped internally to the `TOKEN_PRICING` key. A model that has no
-pricing entry is a configuration error worth surfacing loudly, not defaulting
-silently.
+record — not an `operation_type`. `model` takes the Bedrock inference-profile id
+and is mapped through a hardcoded id → `TOKEN_PRICING`-key table inside
+`consume_ai_tokens`.
+
+**An unrecognised model does not fail — it bills at Sonnet rates.** The lookup
+defaults to `anthropic_claude_4_sonnet`, and if even that key were missing it
+falls back to a literal `3`/`15`, logging a warning either way. So adding a
+model without adding its mapping mis-bills quietly rather than erroring. When
+you introduce a new model, update the map in `consume_ai_tokens` and
+`TOKEN_PRICING` together.
 
 ## Enforcement
 
-`enforcement.py` holds the pre-flight gates. All three take a session and
-return a tuple rather than raising, so the caller controls the error shape.
+`enforcement.py` holds the pre-flight gates. All three take a session; the first
+two return a `(bool, error)` tuple rather than raising, so the caller controls
+the error shape. `require_graph_access` is the exception — it raises.
 
 `check_can_provision_graph(user_id, requested_tier, session) -> (bool, error)`
 resolves the user's organization and asks its `BillingCustomer` whether it may
@@ -113,12 +123,17 @@ from robosystems.middleware.billing import credit_cache
 credit_cache.cache_graph_credit_balance(
     graph_id="kg1a2b3c",
     balance=Decimal("50000"),
-    multiplier=Decimal("1.0"),
     graph_tier="standard",
 )
-balance = credit_cache.get_cached_graph_credit_balance("kg1a2b3c")
+cached = credit_cache.get_cached_graph_credit_balance("kg1a2b3c")
+if cached is not None:
+    balance, graph_tier = cached
 credit_cache.invalidate_graph_credit_balance("kg1a2b3c")
 ```
+
+`cache_graph_credit_balance` takes exactly `(graph_id, balance, graph_tier)` —
+there is no multiplier argument, and no multiplier is stored. The getter returns
+a `(Decimal, str)` tuple or `None` on a miss, not a bare balance.
 
 `update_cached_balance_after_consumption()` adjusts a cached balance in place
 and preserves the remaining TTL, so a consumption does not reset freshness.

--- a/robosystems/middleware/graph/README.md
+++ b/robosystems/middleware/graph/README.md
@@ -143,14 +143,36 @@ status = await queue.get_query_status(query_id)
 result = await queue.get_query_result(query_id)
 ```
 
-`admission_control.py` decides whether to accept at all. **Memory rejection is
-not gated on percent used.** `ADMISSION_MEMORY_THRESHOLD` (85%) only *reports*
-memory pressure; rejection uses `MIN_AVAILABLE_MB` (1 GB of absolute headroom).
-The reason is in `config/defaults.py`: a LadybugDB buffer pool is a fixed
+`admission_control.py` decides whether to accept at all. This one is
+**percent-gated on every axis**: `AdmissionController.check_admission()` issues
+`REJECT_MEMORY` as soon as `memory_percent` exceeds
+`ADMISSION_MEMORY_THRESHOLD` (85%) and `REJECT_CPU` above
+`ADMISSION_CPU_THRESHOLD` (90%). Queue capacity (80%) is softer — crossing
+`ADMISSION_QUEUE_THRESHOLD` starts *probabilistic* load shedding (50/70/90%
+rejection as the queue fills, scaled down for high-priority queries), not a hard
+reject, and a combined pressure score over 0.7 sheds on top of that.
+`LOAD_SHEDDING_ENABLED=false` short-circuits the whole gate to accept.
+
+**Two admission controllers exist and they do not behave alike — don't
+generalize from one to the other.**
+
+|                | `middleware/graph/admission_control.py` (this one) | `graph_api/core/admission_control.py` |
+| -------------- | ------------------------------------------------- | ------------------------------------- |
+| Guards | the query queue, in the API process | every Graph API request, on the engine host |
+| Memory gate | percent used > 85% → `REJECT_MEMORY` | absolute headroom < `MIN_AVAILABLE_MB` (1 GB); percent is *reported only* |
+| CPU | > 90%, uniform | > 90% as wired, tightened 10 points for ingestion (the class's own 95 default is overridden by `get_admission_controller`) |
+| Third axis | queue depth (probabilistic shedding) | per-database connection count |
+| Config | `ADMISSION_*` / `admission/` SSM | `LBUG_ADMISSION_*` / `lbug_admission/` SSM |
+
+The absolute-headroom design belongs to the *Graph API* controller and is
+argued in `config/defaults.py`: a LadybugDB buffer pool is a fixed
 pre-commitment that is *supposed* to fill, so percent-of-total conflates that
 constant with the query working set that actually predicts exhaustion, and an
-absolute figure does not move when the pool or the instance size changes. CPU
-(90%) and queue capacity (80%) are percentage-gated.
+absolute figure does not move when the pool or the instance size changes. That
+reasoning applies where the buffer pool lives; the queue gate here runs in the
+API process, which has no buffer pool, so percent-used is a fair proxy there.
+Both read `AdmissionDefaults.MEMORY_THRESHOLD = 85.0` — same number, opposite
+role.
 
 `execution_strategies.py` picks the execution path (direct query vs MCP,
 load-aware). `streaming_wrapper.py` adapts streaming results for Graph API
@@ -248,7 +270,7 @@ Read every one of these through `robosystems.config.env`, never `os.getenv()`.
 LBUG_DATABASE_PATH=./data/lbug-dbs      # database directory
 LBUG_ACCESS_PATTERN=api_auto            # api_auto | api_writer | direct_file
 LBUG_NODE_TYPE=writer
-LBUG_CONNECTION_POOL_SIZE=10
+LBUG_CONNECTION_POOL_SIZE=10            # inert — surfaced but read by nothing; pool is capped at 3
 LBUG_DATABASES_PER_INSTANCE=10
 GRAPH_API_URL=                          # resolved dynamically in prod
 ```

--- a/robosystems/middleware/mcp/README.md
+++ b/robosystems/middleware/mcp/README.md
@@ -132,20 +132,28 @@ delegates to `robosystems.operations.roboledger.{reads,commands}.*`.
 
 | Tool | Delegates to |
 |------|--------------|
-| `get-fiscal-calendar` | `reads/fiscal_calendar.get_fiscal_calendar` |
+| `get-fiscal-calendar` | `reads/fiscal_calendar.build_fiscal_calendar_response` |
 | `close-period` | `commands/fiscal_calendar.close_period` |
 | `reopen-period` | `commands/fiscal_calendar.reopen_period` |
-| `get-period-close-status` | `reads/fiscal_calendar.get_period_close_status` |
+| `backfill-plan-history` | `commands/fiscal_calendar.backfill_plan_history` |
+| `get-period-close-status` | `reads/schedules.get_period_close_status` |
 | `list-period-drafts` | `reads/period_drafts.list_period_drafts` |
 | `get-information-block` | `operations/information_block/reads.get_information_block` |
 | `list-information-blocks` | `operations/information_block/reads.list_information_blocks` |
 | `create-information-block` | `operations/information_block/commands.create_information_block` |
 | `update-information-block` | `operations/information_block/commands.update_information_block` |
 | `delete-information-block` | `operations/information_block/commands.delete_information_block` |
-| `get-unmapped-elements` | `reads/taxonomies.get_unmapped_elements` |
-| `suggest-mapping` | `commands/taxonomies.suggest_mapping` |
+| `list-mapping-structures` | `reads/taxonomies.list_mappings` |
+| `get-unmapped-elements` | `reads/taxonomies.list_unmapped_elements` |
+| `suggest-mapping` | `reads/taxonomies.suggest_mapping_candidates` |
 | `create-mapping-association` | `commands/taxonomies.create_mapping_association` |
-| `get-mapping-summary` | `reads/taxonomies.get_mapping_summary` |
+| `get-mapping-summary` | `reads/taxonomies.get_mapping_coverage` |
+
+Tool names and ops-function names are deliberately *not* kept in lockstep — the
+tool name is the agent-facing contract and the function name is the kernel's,
+so `suggest-mapping` is a read (`reads/`, not `commands/`) and
+`get-mapping-summary` reads coverage. Check the import block at the top of the
+tool module before assuming a name.
 
 Plus REA reads and event writes: `get-event-block` / `list-event-blocks` /
 `create-event-block`, `get-event-handler` / `list-event-handlers` (tenant
@@ -241,17 +249,24 @@ GRAPH_API_URL=http://localhost:8001   # auto-discovered in prod
 GRAPH_HTTP_TIMEOUT=60
 GRAPH_QUERY_TIMEOUT=30
 
+# Defaults as defined in config/env.py — most gates are on, not off
 ROBOLEDGER_ENABLED=true
-ROBOINVESTOR_ENABLED=false
+ROBOINVESTOR_ENABLED=true
 EXTENSIONS_GRAPHQL_ENABLED=true
 MCP_GRAPHQL_ENABLED=true
-FACT_GRID_ENABLED=false
-SEMANTIC_SEARCH_ENABLED=false
+FACT_GRID_ENABLED=true
+SEMANTIC_SEARCH_ENABLED=true
+MCP_WORKSPACE_ENABLED=true
+MCP_SUBGRAPH_OPS_ENABLED=true
+
+# The only two that default off — semantic memory is opt-in at both levels
 SEMANTIC_MEMORY_ENABLED=false
 MCP_SEMANTIC_MEMORY_ENABLED=false
-MCP_WORKSPACE_ENABLED=false
-MCP_SUBGRAPH_OPS_ENABLED=false
 ```
+
+Do not read a row in the gating summary as "off unless enabled": only the two
+semantic-memory flags default false. The rest are on, and a missing SSM
+parameter leaves them on — turning one off is an explicit act.
 
 The feature flags are SSM parameters, so they take effect at runtime without a
 redeploy:

--- a/robosystems/middleware/mcp/tools/taxonomy_tools.py
+++ b/robosystems/middleware/mcp/tools/taxonomy_tools.py
@@ -1,8 +1,12 @@
 """Taxonomy mapping read tools for CoA → GAAP mapping workflows.
 
-Four read-side tools; writes (`create-mapping-association`,
-`delete-mapping-association`, `create-associations`, etc.) are
-registrar-generated from the roboledger OperationSpec declarations.
+Four registered read-side tools, listed below. `ExpandToRsGaapCandidatesTool`
+is a fifth read class defined here but registered nowhere, so
+`expand-to-rs-gaap-candidates` is currently unreachable.
+
+Most writes (`delete-mapping-association`, `create-associations`, etc.) are
+registrar-generated from the roboledger OperationSpec declarations, but
+`CreateMappingAssociationTool` is hand-written in this module.
 
 1. list-mapping-structures: List `coa_mapping` structures with their OLTP ids
 2. get-unmapped-elements: List CoA elements not yet mapped to reporting taxonomy

--- a/robosystems/middleware/otel/README.md
+++ b/robosystems/middleware/otel/README.md
@@ -6,9 +6,9 @@ and query-queue metrics from application code. `setup.py` wires the OTel SDK to
 FastAPI; `metrics.py` holds every instrument the platform defines.
 
 In production the API task runs an ADOT collector sidecar that remote-writes to
-Amazon Managed Prometheus. **Only metrics are exported.** Traces are off by
-default in the application, and the deployed collector defines no traces
-pipeline, so nothing lands in X-Ray today.
+Amazon Managed Prometheus. **Only metrics are exported.** The application's OTLP
+span exporter is unreachable by configuration (see below), and the deployed
+collector defines no traces pipeline, so nothing lands in X-Ray today.
 
 ## Turning it on
 
@@ -19,11 +19,24 @@ logs and returns — no instruments, no exporters, no overhead.
 | Variable                      | Default                 | Effect                                                        |
 | ----------------------------- | ----------------------- | ------------------------------------------------------------- |
 | `OTEL_ENABLED`                | `false`                 | Master switch. Nothing is instrumented while false.            |
-| `OTEL_TRACES_ENABLED`         | `false`                 | Adds the OTLP span exporter. Metrics do not depend on this.    |
 | `OTEL_SERVICE_NAME`           | `robosystems`           | `service.name` resource attribute.                             |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | `http://localhost:4317` | Port `4317` is rewritten to `4318`; the exporters are HTTP.    |
 | `OTEL_RESOURCE_ATTRIBUTES`    | `""`                    | `key=value,key=value`; merged over the built-in attributes.    |
 | `OTEL_CONSOLE_EXPORT`         | `false`                 | Dev only — dumps spans to stdout.                              |
+
+**`OTEL_TRACES_ENABLED` is not a working variable.** `setup.py` reads it as
+`getattr(env, "OTEL_TRACES_ENABLED", False)`, but `config/env.py` never defines
+the attribute, so the lookup always falls through to `False` — setting the env
+var or the SSM parameter changes nothing. The OTLP *span* exporter is therefore
+unreachable in every environment. This is consistent with the deployment (the
+collector has no traces pipeline), but it means the flag is a stub, not a
+switch: wiring traces back on takes a code change in `config/env.py`, not
+configuration. Metrics never depended on it.
+
+A tracer provider and span processors are still installed whenever
+`OTEL_ENABLED` is true, so spans are produced and redacted — they just have
+nowhere to go, except in development, where `OTEL_CONSOLE_EXPORT=true` still
+attaches the console exporter.
 
 The service version is read from the installed `robosystems` package metadata,
 not from an env var. `service.instance.id` is set to the hostname (the container
@@ -52,9 +65,10 @@ shutdown_telemetry()   # at shutdown; flushes providers
 ```
 
 `setup_telemetry` instruments FastAPI (with `excluded_urls="status,health"`),
-`requests`, and `psycopg2`, then installs the metric views and — if traces are
-enabled — the span processors. Every step is wrapped in `try/except`: a missing
-or unreachable collector degrades to no telemetry rather than a failed boot.
+`requests`, and `psycopg2`, then installs the metric views and the span
+processors (the redaction processor always; an exporter only in the dev console
+case, per above). Every step is wrapped in `try/except`: a missing or
+unreachable collector degrades to no telemetry rather than a failed boot.
 
 ## Recording metrics
 
@@ -190,4 +204,5 @@ Metrics not appearing usually means one of: `OTEL_ENABLED` is false; the
 endpoint is still `localhost:4318` in a dev environment (exporters skipped); or
 the collector is unreachable and the failure was swallowed by the graceful
 degradation path — check the API logs for `Failed to configure OTLP` around
-startup. Traces missing is almost always `OTEL_TRACES_ENABLED` being false.
+startup. Traces missing is expected, not a misconfiguration: nothing can turn
+the OTLP span exporter on today (see "Turning it on").

--- a/robosystems/operations/README.md
+++ b/robosystems/operations/README.md
@@ -36,7 +36,7 @@ Every operation on the platform is one of four shapes, and the shape determines 
 | `graph/` | Platform graph lifecycle: creation, subscriptions, credits, pricing, tiers, subgraphs, deprovisioning, storage reclaim, backup/ingestion under `engine/`, worker tasks under `tasks/` |
 | `extensions/` | OLTP→OLAP materialization (`materialize.py`, `loader.py`, `staleness.py`) |
 | `billing/` | Subscription billing lifecycle shared by routers and off-boarding |
-| `admin/` | Support-plane actions with no self-serve surface (guarded account deletion) |
+| `admin/` | Support-plane actions with no self-serve surface: guarded account deletion, account activate/deactivate, SCIM tenant bootstrap |
 | `library/` | Taxonomy/framework library reads (shared and tenant) |
 | `search/` | Document search — client, embeddings, markdown parsing |
 | `memory/` | Per-graph semantic memory service |
@@ -44,6 +44,7 @@ Every operation on the platform is one of four shapes, and the shape determines 
 | `providers/` | External provider integrations and the provider registry |
 | `aws/` | S3 and SES helpers |
 | `connection_service.py`, `document_service.py` | Connection and document lifecycle |
+| `oidc.py` | OIDC login kernel: connection config, flow state, ID-token validation, link-only user resolution |
 | `user_provisioning.py` | Account-creation kernel shared by registration and IdP-driven (SCIM) provisioning |
 
 Cross-domain block envelopes sit at the top level; domain kernels hold reads, commands, and services; cross-cutting infrastructure is top level too.

--- a/robosystems/operations/README.md
+++ b/robosystems/operations/README.md
@@ -59,7 +59,7 @@ Cross-domain block envelopes sit at the top level; domain kernels hold reads, co
 
 ```python
 # reads/fiscal_calendar.py
-def get_fiscal_calendar(session: Session) -> FiscalCalendarResponse | None:
+def build_fiscal_calendar_response(session: Session, ...) -> FiscalCalendarResponse:
     ...  # query, return Pydantic model
 
 # commands/fiscal_calendar.py

--- a/robosystems/operations/graph/reporting_style_defaults.py
+++ b/robosystems/operations/graph/reporting_style_defaults.py
@@ -33,7 +33,7 @@ def default_style_for(entity_type: str | None) -> str:
 
 
 def resolve_reporting_style_id(entity_data: dict[str, Any] | None) -> str:
-  """Resolve the Reporting Style id to pin on a new graph.
+  """Resolve the Reporting Style id to pin on a new entity.
 
   Precedence: an explicit ``reporting_style_id`` on the create request wins;
   otherwise it's derived from the entity's ``entity_type``; otherwise the

--- a/robosystems/operations/graph/subgraph_service.py
+++ b/robosystems/operations/graph/subgraph_service.py
@@ -212,7 +212,7 @@ class SubgraphService:
         graph_id=database_name,
         schema_type="custom",  # Use custom to skip auto schema installation
         custom_schema_ddl=None,  # We'll install schema with extensions separately
-        is_subgraph=True,  # Bypass max_databases check for Enterprise/Premium
+        is_subgraph=True,  # Bypass max_databases check for Large/XLarge
       )
 
       # An empty subgraph (no base, no extensions) generates no DDL — skip the

--- a/robosystems/schemas/README.md
+++ b/robosystems/schemas/README.md
@@ -104,7 +104,6 @@ are different roles.
 
 Selected relationships:
 
-- `ENTITY_OWNS_ENTITY` — hierarchical ownership
 - `ELEMENT_HAS_LABEL`, `ELEMENT_HAS_REFERENCE`, `ELEMENT_HAS_TRAIT`
 - `ENTITY_HAS_TAXONOMY`, `TAXONOMY_EXTENDS_TAXONOMY`
 - `STRUCTURE_HAS_ASSOCIATION`, `ASSOCIATION_HAS_FROM_ELEMENT` / `_TO_ELEMENT`
@@ -115,6 +114,12 @@ Selected relationships:
 - `EVENT_OBLIGATED_BY_EVENT` — commitment to fulfillment
 - `EVENT_DISCHARGES_EVENT` — settlement / reciprocity
 - `EVENT_REPLACES_EVENT` — correction chain
+
+Parent–subsidiary ownership has **no edge**: nothing writes one on either path
+(SEC or OLTP materialization), so `base.py` deliberately defers
+`ENTITY_OWNS_ENTITY` until multi-entity consolidation ships. The designated
+source when it does is OLTP `entities.parent_entity_id`, mirrored today on the
+`Entity.parent_entity_id` property.
 
 `Agent` and `Event` are universal REA primitives; every planned RoboX extension
 needs them. `Event.event_action` carries the canonical action vocabulary

--- a/tests/README.md
+++ b/tests/README.md
@@ -264,7 +264,9 @@ mock_sessionmaker.return_value.return_value.__enter__.return_value = mock_sessio
 
 ## Continuous integration
 
-CI runs linting, formatting, type checking, and the test suite on every pull request and on pushes to `main` and `staging` — the same gate as `just test-all`. Run it locally before opening a pull request; the full suite takes several minutes.
+`test-ci.yml` runs the gate on every pull request and on pushes to `main`; the staging and production deploy workflows call the same reusable `test.yml` before deploying, but they are manual dispatches, not push triggers.
+
+The gate is close to `just test-all` but not identical. CI runs the test suite (`pytest -m "not slow"`), the dbt tests, `ruff check`, `basedpyright`, CloudFormation lint, workflow lint, and a Trivy dependency scan. It does **not** run a formatting step — `just test-all` calls `just format`, which rewrites files rather than checking them, so unformatted code passes CI and gets reformatted on your next local run. Run `just test-all` locally before opening a pull request; the full suite takes several minutes.
 
 ## Reference
 

--- a/tests/models/core/graph/test_graph_model.py
+++ b/tests/models/core/graph/test_graph_model.py
@@ -179,22 +179,22 @@ class TestGraphModel:
     assert standard_graph.can_have_subgraphs is True
 
     # Large tier can have subgraphs
-    enterprise_graph = Graph(
+    large_graph = Graph(
       graph_id="kg2",
-      graph_name="Enterprise",
+      graph_name="Large",
       graph_type="entity",
       graph_tier=GraphTier.LADYBUG_LARGE.value,
     )
-    assert enterprise_graph.can_have_subgraphs is True
+    assert large_graph.can_have_subgraphs is True
 
-    # Premium tier can have subgraphs
-    premium_graph = Graph(
+    # XLarge tier can have subgraphs
+    xlarge_graph = Graph(
       graph_id="kg3",
-      graph_name="Premium",
+      graph_name="XLarge",
       graph_type="entity",
       graph_tier=GraphTier.LADYBUG_XLARGE.value,
     )
-    assert premium_graph.can_have_subgraphs is True
+    assert xlarge_graph.can_have_subgraphs is True
 
   def test_has_specific_extension(self):
     """Test has_specific_extension method."""

--- a/tests/operations/graph/test_subgraph_service.py
+++ b/tests/operations/graph/test_subgraph_service.py
@@ -2,7 +2,7 @@
 Comprehensive tests for SubgraphService.
 
 Tests the critical subgraph service that manages subgraph operations for
-Enterprise and Premium tier graphs, including creation, deletion, and management.
+Large and XLarge tier graphs, including creation, deletion, and management.
 """
 
 from unittest.mock import AsyncMock, Mock, patch

--- a/tests/operations/graph/test_tier_command.py
+++ b/tests/operations/graph/test_tier_command.py
@@ -258,7 +258,7 @@ class TestChangeGraphTierCmd:
       mock_sub_cls.get_by_resource.return_value = subscription
       mock_billing_cfg.get_subscription_plan.return_value = {
         "name": "ladybug-large",
-        "base_price_cents": 29900,
+        "base_price_cents": 24900,
       }
       mock_gc_cls.get_by_graph_id.return_value = graph_credits
       mock_env.BILLING_ENABLED = True
@@ -300,7 +300,7 @@ class TestChangeGraphTierCmd:
       mock_sub_cls.get_by_resource.return_value = subscription
       mock_billing_cfg.get_subscription_plan.return_value = {
         "name": "ladybug-large",
-        "base_price_cents": 29900,
+        "base_price_cents": 24900,
       }
       mock_gc_cls.get_by_graph_id.return_value = graph_credits
       mock_env.BILLING_ENABLED = True
@@ -349,7 +349,7 @@ class TestChangeGraphTierCmd:
       mock_sub_cls.get_by_resource.return_value = subscription
       mock_billing_cfg.get_subscription_plan.return_value = {
         "name": "ladybug-large",
-        "base_price_cents": 29900,
+        "base_price_cents": 24900,
       }
       mock_gc_cls.get_by_graph_id.return_value = graph_credits
       mock_env.BILLING_ENABLED = True


### PR DESCRIPTION
## Summary

An audit checked all 45 tracked READMEs claim-by-claim against source. This PR corrects the seven badly stale ones plus the fourteen the audit named specific errors in — 21 doc files in all. It is **not** the complete set: the audit reported roughly twenty files carrying concrete errors and only enumerated a subset, so some minor drift remains unswept. Every finding was re-verified in source before editing, and four turned out to be wrong and were left alone.

- **`cloudformation/README.md`** was the worst by a wide margin (62 commits behind). Documents the two missing templates; replaces the tier table and every parameter table with pointers to their authoritative source rather than restating values that rot; deletes the "SSM Parameter Pattern" section, since no template creates or reads an SSM parameter (runtime Parameter Store use is now described where it actually happens); corrects the exports against source; and fixes the deploy instructions, since every stack is `workflow_call`-only and five piggyback on another stack's workflow. Net 743 → 677 lines while covering two more templates.
- **`bin/setup/README.md`** — `gha.sh` defaults (prod spot weights are 0, not 90/80), the undocumented SES identity bootstrap step, three `SHARED_REPLICAS_SPOT_*` variables that do not exist, and `postgres-init`'s `extensions` / `extensions_test` databases.
- **`frameworks/`** — the `cm` framework and the `rs-metric` / `rs-driver` packages were undocumented; four advertised reporting styles do not exist (v1 ships Default, Partnership, LLC); Style has been per-entity since extensions migration `0020`, not per-graph.
- **`middleware/`** — five wrong rows in the MCP delegation table, an admission-control section describing the *other* controller, `OTEL_TRACES_ENABLED` documented as a working variable when nothing reads it, and OIDC/SCIM absent from the auth README.
- **`admin`, `dagster`, `schemas`, `adapters/sec`, `graph_api`, `tests`, `operations`** — CLI examples that error as written, a sensor attributed to the wrong job, a class that exists nowhere in the repo, and a CI description that misstated the gate.
- **`config/defaults.py`** — its shared docstring described only one of its two admission-control consumers, which is the likely origin of the `middleware/graph` error above.
- **Tier vocabulary** — retire `Premium` / `Enterprise` for the canonical `Large` / `XLarge`, and refresh three stale price fixtures.

Separately, `fix(ci)` removes two instance-type fallbacks in the graph deploy workflows. Neither is reachable today — the sole caller always supplies the value and the config key resolves — but if either fired it would silently provision the wrong hardware for the whole replica fleet instead of stopping the deploy. The `yq` fallback is now an explicit guard, and the replicas input is required.

## Notes for the reviewer

- **`frameworks/rs-gaap/v1.json` is seed-forward only.** Its `description` is persisted (`Framework.description`), so the corrected text reaches newly seeded deployments only; already-seeded databases keep the old string until a reseed.
- **This fixes instances, not the mechanism.** Nothing here prevents recurrence — no domain owns published surfaces — so the next sizing or pricing change will reproduce this class of drift.
- Known follow-ups in `graph_api` connection-pool configuration, an unregistered MCP tool, and a credit-pricing fallback were found during the sweep and left as code changes for a separate PR. Details are recorded in the design vault rather than here.

## Testing

- `just test-all` green: **12,667 passed, 23 skipped**; ruff, format, basedpyright, cfn-lint and actionlint all clean.
- actionlint baseline unchanged at 28 pre-existing shellcheck infos, none of them at the edited lines, and clean in the `-shellcheck=` form CI actually runs.
- Workflow edits verified against the sole caller and against `yq` resolution for both environments before the fallbacks were removed.
