### PR TITLE
fix(graph-infra): page when the container-refresh dispatcher itself fails

### DIFF
--- a/.github/workflows/service-refresh.yml
+++ b/.github/workflows/service-refresh.yml
@@ -242,8 +242,11 @@ jobs:
             echo "::error::Failed to invoke ${FUNCTION}"; exit 1; }
 
           cat /tmp/start.json | jq .
+          # A propagated exception has no statusCode at all — its message is in
+          # errorMessage (the Lambda raises operational failures so the stack's
+          # errors alarm pages on them; see graph_container_refresh.handler).
           if [ "$(jq -r '.statusCode' /tmp/start.json)" != "200" ]; then
-            echo "::error::Refresh dispatch failed: $(jq -r '.error // "unknown"' /tmp/start.json)"
+            echo "::error::Refresh dispatch failed: $(jq -r '.error // .errorMessage // "unknown"' /tmp/start.json)"
             exit 1
           fi
 
@@ -265,12 +268,15 @@ jobs:
             if aws lambda invoke --function-name "$FUNCTION" \
                  --cli-binary-format raw-in-base64-out \
                  --payload "$(jq -n --argjson ids "$IDS" '{action:"status", command_ids:$ids}')" \
-                 --region "$REGION" /tmp/status.json >/dev/null; then
+                 --region "$REGION" /tmp/status.json >/dev/null \
+               && [ "$(jq -r '.statusCode // empty' /tmp/status.json)" = "200" ]; then
               POLL_ERRORS=0
             else
               # A transient failure is fine to ride out, but a poller that can
-              # never reach the Lambda must not look like "still in progress"
-              # until the deadline — the fleet may be mid-rollout and unwatched.
+              # never reach the Lambda — or only ever gets a function-error
+              # payload back (no statusCode) — must not look like "still in
+              # progress" until the deadline; the fleet may be mid-rollout and
+              # unwatched.
               POLL_ERRORS=$((POLL_ERRORS + 1))
               echo "::warning::status poll failed (${POLL_ERRORS} consecutive)"
               if [ "$POLL_ERRORS" -ge 5 ]; then

--- a/bin/lambda/graph_container_refresh.py
+++ b/bin/lambda/graph_container_refresh.py
@@ -38,7 +38,6 @@ logger.setLevel(logging.INFO)
 ssm = boto3.client("ssm")
 
 ENVIRONMENT = os.environ["ENVIRONMENT"]
-ALERT_TOPIC_ARN = os.environ.get("ALERT_TOPIC_ARN", "")
 
 # The stack-owned SSM document that wraps refresh-graph-container.sh. Dispatching
 # our own document rather than AWS-RunShellScript is what lets the failure-paging
@@ -302,19 +301,21 @@ def _response_code(invocation: dict[str, Any]) -> str:
 
 
 def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
-  """Dispatch on `event["action"]`."""
-  action = event.get("action")
+  """Dispatch on `event["action"]`.
 
-  try:
-    if action == "start":
-      return start(event)
-    elif action == "status":
-      return status(event)
-    else:
-      return {"statusCode": 400, "error": f"Unknown action: {action}"}
-  except Exception as e:
-    logger.error(f"Error in {action}: {e!s}", exc_info=True)
-    return {"statusCode": 500, "error": str(e)}
+  Caller mistakes (unknown action, missing command_ids) return 400-shaped
+  payloads. Operational failures propagate: an unhandled exception is what
+  increments the AWS/Lambda Errors metric, which the stack's
+  GraphContainerRefreshErrorsAlarm pages on. Swallowing them into a 500-shaped
+  payload left that alarm blind — a failed dispatch surfaced only as a red job
+  in a workflow someone had to be watching.
+  """
+  action = event.get("action")
+  if action == "start":
+    return start(event)
+  if action == "status":
+    return status(event)
+  return {"statusCode": 400, "error": f"Unknown action: {action}"}
 
 
 def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:

--- a/cloudformation/graph-infra.yaml
+++ b/cloudformation/graph-infra.yaml
@@ -961,7 +961,6 @@ Resources:
       Environment:
         Variables:
           ENVIRONMENT: !Ref Environment
-          ALERT_TOPIC_ARN: !Ref InfraAlertTopic
           REFRESH_DOCUMENT_NAME: !Ref GraphRefreshDocument
       Code:
         ImageUri: !Ref LambdaImageUri
@@ -1070,6 +1069,33 @@ Resources:
               "Graph container refresh <state> on instance <instance> (SSM command <command>)
               in ${Environment}. The container was left as-is; check the command output for
               REFRESH_RESULT and the instance's docker state."
+
+  # The EventBridge rule above pages when the refresh fails on an instance; this
+  # pages when the dispatcher itself dies — a timeout, an OOM, an image that no
+  # longer imports, or a raised dispatch error. The handler deliberately lets
+  # operational failures propagate (bin/lambda/graph_container_refresh.py) so
+  # they land on this metric instead of hiding inside a 500-shaped payload that
+  # only a watched workflow run would ever surface.
+  GraphContainerRefreshErrorsAlarm:
+    Type: AWS::CloudWatch::Alarm
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      AlarmName: !Sub ${AWS::StackName}-graph-container-refresh-errors
+      AlarmDescription: Graph container refresh Lambda failed — the dispatcher itself, not an instance-side refresh
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref GraphContainerRefreshFunction
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 0
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - !Ref InfraAlertTopic
 
   # A TopicPolicy replaces the topic's access policy wholesale, so the SNS
   # default same-account owner statement must be reproduced here — every

--- a/tests/lambda/test_graph_container_refresh.py
+++ b/tests/lambda/test_graph_container_refresh.py
@@ -22,6 +22,7 @@ field the real API only sets on the plugin.
 from unittest.mock import patch
 
 import pytest
+from botocore.exceptions import ClientError
 
 pytestmark = pytest.mark.unit
 
@@ -232,3 +233,26 @@ class TestHandler:
 
   def test_status_requires_a_command_id(self, gcr):
     assert gcr.handler({"action": "status"}, None)["statusCode"] == 400
+
+  def test_operational_failures_propagate(self, gcr):
+    """An unhandled exception is what increments the AWS/Lambda Errors metric
+    the stack's alarm pages on. Swallowed into a 500-shaped payload, a failed
+    dispatch was visible only as a red job in a workflow someone had to be
+    watching."""
+    with patch.object(gcr, "ssm") as ssm:
+      ssm.send_command.side_effect = RuntimeError("dispatch broke")
+      with pytest.raises(RuntimeError, match="dispatch broke"):
+        gcr.handler({"action": "start", "node_types": "writer"}, None)
+
+  def test_no_matching_instances_is_not_an_operational_failure(self, gcr):
+    """Staging routinely runs with no graph fleet at all; an empty tag match
+    must return cleanly, not page."""
+    with patch.object(gcr, "ssm") as ssm:
+      ssm.send_command.side_effect = ClientError(
+        {"Error": {"Code": "InvalidInstanceId"}}, "SendCommand"
+      )
+      result = gcr.handler({"action": "start", "node_types": "writer"}, None)
+    assert result["statusCode"] == 200
+    assert result["commands"] == [
+      {"node_type": "writer", "command_id": None, "matched": 0}
+    ]


### PR DESCRIPTION
## Summary

The fleet-refresh control plane pages when a refresh fails on an instance (EventBridge on the stack's SSM document), but nothing watched the dispatcher itself: the `graph-container-refresh` Lambda had no CloudWatch alarm on its `Errors` metric — the only two functions in the account without one, flagged by compliance monitoring — and its handler swallowed operational failures into a `statusCode: 500` payload the metric never sees, so a failed dispatch was visible only as a red job in a workflow someone had to be watching. This PR closes both halves: the alarm, and handler semantics that make the alarm meaningful.

## Changes

- **`cloudformation/graph-infra.yaml`** — add `GraphContainerRefreshErrorsAlarm` (`AWS/Lambda` `Errors` > 0 over 5 min → `InfraAlertTopic`), matching the stack's existing `api-key-generator` / `api-secret-rotation` alarms. Also drops the `ALERT_TOPIC_ARN` env var from the function: it was plumbed in but never read past module scope, and the role has no `sns:Publish` — dead wiring.
- **`bin/lambda/graph_container_refresh.py`** — the handler no longer catches all exceptions into a 500-shaped payload. Caller mistakes (unknown action, missing `command_ids`) keep their 400-shaped returns; operational failures (e.g. `SendCommand` errors other than the deliberate `InvalidInstanceId` empty-fleet skip) now propagate, which is what increments the `Errors` metric the new alarm pages on. Removed the unused `ALERT_TOPIC_ARN` constant.
- **`.github/workflows/service-refresh.yml`** — the status-poll loop now counts a function-error payload (no `statusCode`) toward the same consecutive-failure budget as an unreachable Lambda, instead of polling it to the deadline; the dispatch step surfaces `errorMessage` from a propagated exception.
- **`tests/lambda/test_graph_container_refresh.py`** — pins the new raise/return boundary from both sides: operational failures propagate; an empty tag match (staging routinely has no graph fleet) still returns cleanly and must not page.
- **Out-of-band (no diff):** retention on the two existing `/aws/lambda/*-graph-container-refresh` log groups set to 365 days, matching the stack's other Lambdas. Log groups are auto-created by Lambda, so they aren't template-managed.

The alarm takes effect in each environment on its next `graph-infra` deploy.

## Breaking Changes

None. No API surface, GraphQL schema, or SDK-visible shape changes. The Lambda's error contract changed only for its sole caller (`service-refresh.yml`, updated in the same PR).

## Testing

- `just test lambda` — 74 passed (includes the two new handler-boundary tests)
- `just test-code` — ruff, format, basedpyright, cf-lint all clean
- `just cf-lint graph-infra` — clean

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
