### PR TITLE
feat(auth): scope identity provisioning and linking to the deployment enterprise org

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -135,11 +135,19 @@ INTUIT_REDIRECT_URI=http://localhost:3001/connections/qb-callback
 ## Connection to the customer IdP; enable via SSO_OIDC_ENABLED / SCIM_ENABLED
 ## in FEATURE FLAGS. Issuer is the org authorization server
 ## (e.g. https://<org>.okta.com, not /oauth2/default).
+## Env vars here are the LOCAL-DEV path; deployed environments carry this
+## whole block in the robosystems/{env} base secret (JWT_ISSUER precedent).
 # SSO_OIDC_ISSUER=
 # SSO_OIDC_CLIENT_ID=
 # SSO_OIDC_CLIENT_SECRET=
 # SSO_OIDC_PROVIDER_LABEL=SSO
 # SSO_DEFAULT_ROLE=member
+## Pin the deployment's single enterprise org (set AFTER the first
+## `scim bootstrap` mints it); scopes SCIM tokens, bootstrap, and OIDC linking.
+# ENTERPRISE_ORG_ID=
+## ID-token claim compared to the SCIM externalId at first-login linking.
+## Okta: sub (default). Entra: oid.
+# SSO_OIDC_BINDING_CLAIM=sub
 
 ## Cloudflare R2 (zero-egress downloads)
 # R2_ACCESS_KEY_ID=

--- a/robosystems/config/env.py
+++ b/robosystems/config/env.py
@@ -481,12 +481,16 @@ class EnvConfig:
     "SSO_OIDC_ENABLED",
     get_parameter_value("SSO_OIDC_ENABLED", "false").lower() == "true",
   )
-  SSO_OIDC_PROVIDER_LABEL = get_str_env("SSO_OIDC_PROVIDER_LABEL", "SSO")
-  # OIDC connection config (non-secret). The issuer is the IdP's org
-  # authorization server (e.g. https://<org>.okta.com — NOT /oauth2/default,
-  # which mints API access tokens rather than sign-in ID tokens).
-  SSO_OIDC_ISSUER = get_str_env("SSO_OIDC_ISSUER", "")
-  SSO_OIDC_CLIENT_ID = get_str_env("SSO_OIDC_CLIENT_ID", "")
+  # The SSO connection block lives in the base robosystems/{env} secret on
+  # deployed environments (JWT_ISSUER precedent — not secrets per se, but
+  # they ride with SSO_OIDC_CLIENT_SECRET so the whole connection is one
+  # operator surface). Env vars win everywhere, which is the local-dev path.
+  SSO_OIDC_PROVIDER_LABEL = get_secret_value("SSO_OIDC_PROVIDER_LABEL", "SSO")
+  # The issuer is the IdP's org authorization server (e.g.
+  # https://<org>.okta.com — NOT /oauth2/default, which mints API access
+  # tokens rather than sign-in ID tokens).
+  SSO_OIDC_ISSUER = get_secret_value("SSO_OIDC_ISSUER", "")
+  SSO_OIDC_CLIENT_ID = get_secret_value("SSO_OIDC_CLIENT_ID", "")
   # SCIM 2.0 provisioning surface (IdP pushes users into the enterprise org).
   # Gated independently of OIDC — a deployment may run one without the other.
   SCIM_ENABLED = get_bool_env(
@@ -494,7 +498,17 @@ class EnvConfig:
     get_parameter_value("SCIM_ENABLED", "false").lower() == "true",
   )
   # Org role SCIM-provisioned users join the enterprise org with.
-  SSO_DEFAULT_ROLE = get_str_env("SSO_DEFAULT_ROLE", "member")
+  SSO_DEFAULT_ROLE = get_secret_value("SSO_DEFAULT_ROLE", "member")
+  # Pins the single org this deployment's SCIM/OIDC surface operates against.
+  # Set after the first `scim bootstrap` mints the enterprise org (the id only
+  # exists then); once set, bearer tokens for other orgs are refused, bootstrap
+  # can only target this org, and OIDC first-login linking requires membership.
+  # Rides in the base secret with the SSO connection block.
+  ENTERPRISE_ORG_ID = get_secret_value("ENTERPRISE_ORG_ID", "")
+  # ID-token claim compared against the SCIM-provisioned external_id at
+  # first-login linking. Okta: externalId ≡ sub. Entra pairs SCIM externalId
+  # (objectId) with the `oid` claim, not `sub` — override there.
+  SSO_OIDC_BINDING_CLAIM = get_secret_value("SSO_OIDC_BINDING_CLAIM", "sub")
   PASSKEYS_ENABLED = get_bool_env(
     "PASSKEYS_ENABLED",
     get_parameter_value("PASSKEYS_ENABLED", "false").lower() == "true",

--- a/robosystems/config/secrets_manager.py
+++ b/robosystems/config/secrets_manager.py
@@ -10,6 +10,9 @@ Secrets are organized in AWS Secrets Manager with the following structure:
   Contains:
     Encryption keys: JWT_SECRET_KEY, CONNECTION_CREDENTIALS_KEY
     JWT/Auth: JWT_ISSUER, JWT_AUDIENCE
+    Enterprise SSO connection: SSO_OIDC_ISSUER, SSO_OIDC_CLIENT_ID,
+      SSO_OIDC_CLIENT_SECRET, SSO_OIDC_PROVIDER_LABEL, SSO_OIDC_BINDING_CLAIM,
+      SSO_DEFAULT_ROLE, ENTERPRISE_ORG_ID (dedicated deployments only)
     Service URLs: ROBOSYSTEMS_URL, ROBOLEDGER_URL, ROBOINVESTOR_URL
     Email: EMAIL_FROM_ADDRESS, EMAIL_FROM_NAME
     External services: INTUIT_*, SEC_GOV_USER_AGENT, OPENFIGI_API_KEY,
@@ -236,8 +239,17 @@ SECRET_MAPPINGS = {
   "AWS_S3_SECRET_ACCESS_KEY": (None, "AWS_S3_SECRET_ACCESS_KEY"),
   # --- Admin ---
   "ADMIN_API_KEY": ("admin", "ADMIN_API_KEY"),
-  # --- External Service API Keys ---
+  # --- Enterprise SSO connection (JWT_ISSUER precedent: the issuer/client
+  # id/org pin are not secrets per se, but they ride with the client secret
+  # so the whole IdP connection is one operator surface in the base secret) ---
   "SSO_OIDC_CLIENT_SECRET": (None, "SSO_OIDC_CLIENT_SECRET"),
+  "SSO_OIDC_ISSUER": (None, "SSO_OIDC_ISSUER"),
+  "SSO_OIDC_CLIENT_ID": (None, "SSO_OIDC_CLIENT_ID"),
+  "SSO_OIDC_PROVIDER_LABEL": (None, "SSO_OIDC_PROVIDER_LABEL"),
+  "SSO_OIDC_BINDING_CLAIM": (None, "SSO_OIDC_BINDING_CLAIM"),
+  "SSO_DEFAULT_ROLE": (None, "SSO_DEFAULT_ROLE"),
+  "ENTERPRISE_ORG_ID": (None, "ENTERPRISE_ORG_ID"),
+  # --- External Service API Keys ---
   "INTUIT_CLIENT_ID": (None, "INTUIT_CLIENT_ID"),
   "INTUIT_CLIENT_SECRET": (None, "INTUIT_CLIENT_SECRET"),
   "INTUIT_REDIRECT_URI": (None, "INTUIT_REDIRECT_URI"),

--- a/robosystems/config/validation.py
+++ b/robosystems/config/validation.py
@@ -172,6 +172,14 @@ class EnvValidator:
           "SSO_DEFAULT_ROLE: Must be 'member' or 'admin' — IdP-provisioned "
           "users must not default to a privileged role"
         )
+      # Warning, not error: the org id only exists after the first bootstrap
+      # run, so the enablement sequence is flags on → bootstrap → pin the id
+      # → restart. Unpinned, any org's bearer token is accepted.
+      if deployed and not getattr(env_config, "ENTERPRISE_ORG_ID", ""):
+        warnings.append(
+          "ENTERPRISE_ORG_ID: Unset while SCIM_ENABLED=true — SCIM/OIDC are "
+          "not scoped to a single org. Pin it after the first scim bootstrap."
+        )
     if (
       deployed
       and (

--- a/robosystems/middleware/auth/README.md
+++ b/robosystems/middleware/auth/README.md
@@ -275,17 +275,33 @@ RATE_LIMIT_ENABLED=true   # consumed by middleware/rate_limits/
 PASSWORD_AUTH_ENABLED=true    # false requires SSO_OIDC_ENABLED=true
 
 # Enterprise SSO (OIDC). Off by default; the managed platform never sets these.
+# The flags live in SSM Parameter Store (/features/); the whole connection
+# block below is read via get_secret_value — env vars locally, the
+# robosystems/{env} base secret when deployed (JWT_ISSUER precedent; nothing
+# SSO-related flows through CloudFormation).
 SSO_OIDC_ENABLED=false
 SSO_OIDC_ISSUER=            # IdP org authorization server, https:// when deployed;
                             # no query/fragment. For Okta this is https://<org>.okta.com,
                             # NOT /oauth2/default (that mints API tokens, not sign-in ID tokens)
 SSO_OIDC_CLIENT_ID=
-SSO_OIDC_CLIENT_SECRET=     # read via get_secret_value, not a plain env read
+SSO_OIDC_CLIENT_SECRET=
 SSO_OIDC_PROVIDER_LABEL=SSO # button label on the login home
 
 # SCIM 2.0 provisioning. Gated independently of OIDC.
 SCIM_ENABLED=false
 SSO_DEFAULT_ROLE=member     # validation rejects anything but member|admin
+
+# One-org boundary. Set AFTER the first `scim bootstrap` mints the enterprise
+# org (validation warns while unset + deployed). Once pinned: SCIM bearers for
+# other orgs 401, bootstrap only targets this org, and OIDC first-login
+# linking requires membership in it.
+ENTERPRISE_ORG_ID=
+
+# ID-token claim compared against the SCIM-stamped external_id at first-login
+# linking (equality required — presence is not provenance). Okta sends its
+# user id as both SCIM externalId and OIDC sub, so the default fits; Entra
+# pairs externalId (objectId) with `oid`.
+SSO_OIDC_BINDING_CLAIM=sub
 ```
 
 The OIDC redirect URI is derived, not configured:

--- a/robosystems/middleware/auth/scim.py
+++ b/robosystems/middleware/auth/scim.py
@@ -10,6 +10,7 @@ FastAPI's ``{"detail": ...}``.
 from fastapi import Depends, HTTPException, Request, status
 from sqlalchemy.orm import Session
 
+from ...config import env
 from ...db.platform import get_db_session
 from ...logger import get_logger
 from ...models.api.scim import ERROR_SCHEMA
@@ -69,8 +70,22 @@ def require_scim_org(
     )
     raise _scim_unauthorized()
 
-  token.update_last_used(session)
   org_id = str(token.org_id)
+  # One-org boundary: once the deployment pins its enterprise org, a valid
+  # token for any other org is refused with the same generic 401 as an
+  # invalid token (no reason leak).
+  if env.ENTERPRISE_ORG_ID and org_id != env.ENTERPRISE_ORG_ID:
+    SecurityAuditLogger.log_security_event(
+      event_type=SecurityEventType.SCIM_AUTH_FAILURE,
+      ip_address=client_ip,
+      user_agent=request.headers.get("User-Agent"),
+      endpoint=str(request.url.path),
+      details={"failure_reason": "org_boundary", "token_org_id": org_id},
+      risk_level="high",
+    )
+    raise _scim_unauthorized()
+
+  token.update_last_used(session)
   request.state.scim_org_id = org_id
   request.state.scim_token_id = str(token.id)
   return org_id

--- a/robosystems/operations/admin/__init__.py
+++ b/robosystems/operations/admin/__init__.py
@@ -1,6 +1,7 @@
 """Administrative operations — support-plane actions with no self-serve surface."""
 
 from .scim_bootstrap import (
+  OrgBoundaryError,
   OrgNotFoundError,
   ScimBootstrapResult,
   bootstrap_scim,
@@ -18,6 +19,7 @@ from .user_status import UserStatusChange, set_user_active
 
 __all__ = [
   "DeletionBlocker",
+  "OrgBoundaryError",
   "OrgNotFoundError",
   "ScimBootstrapResult",
   "UserDeletionBlocked",

--- a/robosystems/operations/admin/scim_bootstrap.py
+++ b/robosystems/operations/admin/scim_bootstrap.py
@@ -11,6 +11,7 @@ from datetime import UTC, datetime, timedelta
 
 from sqlalchemy.orm import Session
 
+from robosystems.config import env
 from robosystems.logger import logger
 from robosystems.models.core import Org, OrgLimits, OrgType, ScimToken
 from robosystems.models.core.user.scim_token import DEFAULT_TOKEN_LIFETIME_DAYS
@@ -22,6 +23,10 @@ class ScimBootstrapError(Exception):
 
 class OrgNotFoundError(ScimBootstrapError):
   """A supplied org id does not resolve."""
+
+
+class OrgBoundaryError(ScimBootstrapError):
+  """The deployment is pinned to one enterprise org and this isn't it."""
 
 
 @dataclass(frozen=True)
@@ -52,6 +57,15 @@ def bootstrap_scim(
   replacement, swap it into the IdP, then revoke the old token; two live
   tokens are legal during the swap.
   """
+  # Once the deployment pins its enterprise org, bootstrap can only mint
+  # tokens for that org — no new-org creation, no other-org targeting.
+  if env.ENTERPRISE_ORG_ID:
+    if org_id != env.ENTERPRISE_ORG_ID:
+      raise OrgBoundaryError(
+        f"This deployment is pinned to org {env.ENTERPRISE_ORG_ID}; "
+        "pass that org_id (org_name creation is disabled once pinned)"
+      )
+
   if org_id is not None:
     org = Org.get_by_id(org_id, session)
     if org is None:

--- a/robosystems/operations/oidc.py
+++ b/robosystems/operations/oidc.py
@@ -31,7 +31,7 @@ from sqlalchemy.orm import Session
 from robosystems.config import env
 from robosystems.config.valkey_registry import ValkeyDatabase, create_redis_client
 from robosystems.logger import logger
-from robosystems.models.core import User, UserIdentity
+from robosystems.models.core import OrgUser, User, UserIdentity
 
 
 class OIDCError(Exception):
@@ -401,16 +401,24 @@ def resolve_oidc_user(
   subject: str,
   email: str | None,
   email_verified: bool | None = None,
+  binding_value: str | None = None,
 ) -> OIDCResolution:
   """Resolve ``(issuer, sub)`` to a local user — link-only, never JIT.
 
   Primary lookup is the ``user_identities`` link. On a miss, exactly one
-  fallback: an active user whose email matches AND who carries a SCIM
-  ``external_id`` AND who has no identity for this issuer yet — then the
-  link is written and is the lookup forever after. The ``external_id``
-  predicate is load-bearing: without it, anyone controlling a matching
-  mailbox in the customer's IdP could bind onto a locally-created account
-  (an invited user, or later a client-portal guest).
+  fallback: an active user whose email matches AND whose SCIM ``external_id``
+  equals ``binding_value`` (the ID-token claim named by
+  ``SSO_OIDC_BINDING_CLAIM`` — ``sub`` by default; Okta sends the same user id
+  in both channels) AND who has no identity for this issuer yet — then the
+  link is written and is the lookup forever after. Equality, not mere
+  presence, is load-bearing twice over: presence alone let anyone controlling
+  a matching mailbox in the customer's IdP bind onto a locally-created
+  account, and it accepted an empty-string ``external_id`` as provenance.
+  A missing/empty ``binding_value`` never links.
+
+  When ``ENTERPRISE_ORG_ID`` pins the deployment's org, the fallback further
+  requires the matched user to be a member of that org — identities outside
+  the enterprise boundary never link, whatever their email or ``external_id``.
 
   The email-match fallback additionally refuses a claim whose ``email`` the
   IdP marked *unverified* (``email_verified: false``). It does not *require*
@@ -431,14 +439,21 @@ def resolve_oidc_user(
       raise OIDCUserNotProvisionedError("Identity link points at no user")
   else:
     user = User.get_by_email(email, session) if email else None
+    if user is None:
+      raise OIDCUserNotProvisionedError("No provisioned user for this identity")
     eligible = (
-      user is not None
-      and bool(user.is_active)
-      and user.external_id is not None
+      bool(user.is_active)
+      and bool(binding_value)
+      and user.external_id == binding_value
       and email_verified is not False
       and UserIdentity.get_by_user_and_issuer(str(user.id), issuer, session) is None
     )
-    if user is None or not eligible:
+    if eligible and env.ENTERPRISE_ORG_ID:
+      eligible = (
+        OrgUser.get_by_org_and_user(env.ENTERPRISE_ORG_ID, str(user.id), session)
+        is not None
+      )
+    if not eligible:
       raise OIDCUserNotProvisionedError("No provisioned user for this identity")
     identity = UserIdentity.create(
       user_id=str(user.id),

--- a/robosystems/routers/admin/scim.py
+++ b/robosystems/routers/admin/scim.py
@@ -11,6 +11,7 @@ from ...models.api.admin import (
   ScimTokenRevokeResponse,
 )
 from ...operations.admin import (
+  OrgBoundaryError,
   OrgNotFoundError,
   bootstrap_scim,
   revoke_scim_token,
@@ -43,6 +44,8 @@ async def scim_bootstrap(
       )
     except OrgNotFoundError as exc:
       raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
+    except OrgBoundaryError as exc:
+      raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
 
     logger.info(
       "Admin bootstrapped SCIM",

--- a/robosystems/routers/auth/oidc.py
+++ b/robosystems/routers/auth/oidc.py
@@ -221,6 +221,10 @@ async def oidc_callback(
     logger.error(f"OIDC callback dependency failure: {exc}")
     return _fail_redirect("oidc_failed")
 
+  # The claim compared against the SCIM-stamped external_id at first-login
+  # linking (default `sub`; Entra deployments configure `oid`). Absent claim
+  # → None → linking is refused rather than comparing against "None".
+  binding_raw = claims.get(env.SSO_OIDC_BINDING_CLAIM)
   try:
     resolution = resolve_oidc_user(
       session,
@@ -228,6 +232,7 @@ async def oidc_callback(
       subject=str(claims["sub"]),
       email=claims.get("email"),
       email_verified=claims.get("email_verified"),
+      binding_value=str(binding_raw) if binding_raw is not None else None,
     )
   except OIDCUserNotProvisionedError:
     return _denied("not_provisioned", "user_not_provisioned", "medium")

--- a/robosystems/routers/scim/users.py
+++ b/robosystems/routers/scim/users.py
@@ -213,6 +213,17 @@ async def create_user(
     if org is None:
       raise _scim_error(status.HTTP_404_NOT_FOUND, "Provisioning org not found")
 
+    # externalId is the OIDC link predicate — a user provisioned without it
+    # can never SSO in, silently. Okta always sends it (POC-verified);
+    # refusing here turns a misconfigured IdP mapping into a visible error.
+    external_id = (body.external_id or "").strip()
+    if not external_id:
+      raise _scim_error(
+        status.HTTP_400_BAD_REQUEST,
+        "externalId is required",
+        scim_type="invalidValue",
+      )
+
     email = body.user_name.strip().lower()
     display_name = (
       (body.name.formatted if body.name else None)
@@ -236,7 +247,7 @@ async def create_user(
         email_verified=True,  # the IdP asserted the mailbox
         target_org=org,
         target_org_role=_default_role(),
-        external_id=body.external_id,
+        external_id=external_id,
       )
     except EmailAlreadyRegisteredError:
       raise _scim_error(

--- a/tests/config/test_validation.py
+++ b/tests/config/test_validation.py
@@ -251,6 +251,40 @@ class TestEnvValidator:
     with patch("robosystems.config.validation.logger"):
       EnvValidator.validate_required_vars(env_config)
 
+  def test_scim_deployed_without_enterprise_org_id_warns(self):
+    """Unpinned deployment: a warning (never an error — the org id only
+    exists after the first bootstrap run, so boot must succeed unpinned)."""
+    env_config = MockEnvConfig()
+    env_config.ENVIRONMENT = "prod"
+    env_config.GRAPH_API_URL = None
+    env_config.SCIM_ENABLED = True
+    env_config.RATE_LIMIT_ENABLED = True
+    env_config.ENTERPRISE_ORG_ID = ""
+
+    with (
+      patch("os.getenv", return_value=None),
+      patch("robosystems.config.validation.logger") as mock_logger,
+    ):
+      EnvValidator.validate_required_vars(env_config)
+      warning_calls = [call[0][0] for call in mock_logger.warning.call_args_list]
+      assert any("ENTERPRISE_ORG_ID" in msg for msg in warning_calls)
+
+  def test_scim_deployed_with_enterprise_org_id_no_warning(self):
+    env_config = MockEnvConfig()
+    env_config.ENVIRONMENT = "prod"
+    env_config.GRAPH_API_URL = None
+    env_config.SCIM_ENABLED = True
+    env_config.RATE_LIMIT_ENABLED = True
+    env_config.ENTERPRISE_ORG_ID = "org_pinned123"
+
+    with (
+      patch("os.getenv", return_value=None),
+      patch("robosystems.config.validation.logger") as mock_logger,
+    ):
+      EnvValidator.validate_required_vars(env_config)
+      warning_calls = [call[0][0] for call in mock_logger.warning.call_args_list]
+      assert not any("ENTERPRISE_ORG_ID" in msg for msg in warning_calls)
+
   def test_validate_required_vars_prod_no_s3_credentials_ok(self):
     """Test validation passes when S3 credentials are missing in production (uses IAM roles)."""
     env_config = MockEnvConfig()

--- a/tests/operations/admin/test_scim_bootstrap.py
+++ b/tests/operations/admin/test_scim_bootstrap.py
@@ -1,11 +1,14 @@
 """Tests for SCIM provisioning bootstrap."""
 
 from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
 
 import pytest
 
+from robosystems.config import env
 from robosystems.models.core import Org, OrgLimits, OrgType, ScimToken
 from robosystems.operations.admin import (
+  OrgBoundaryError,
   OrgNotFoundError,
   bootstrap_scim,
   revoke_scim_token,
@@ -66,6 +69,35 @@ class TestBootstrapScim:
 
     delta = result.expires_at - datetime.now(UTC)
     assert timedelta(days=29) < delta <= timedelta(days=30)
+
+
+class TestOrgBoundaryPin:
+  """Once ENTERPRISE_ORG_ID pins the deployment, bootstrap can only mint
+  tokens for that org — no new-org creation, no other-org targeting."""
+
+  def test_pinned_refuses_org_name_creation(self, test_db):
+    org = Org.create(name="Pinned", org_type=OrgType.ENTERPRISE, session=test_db)
+
+    with patch.object(env, "ENTERPRISE_ORG_ID", str(org.id)):
+      with pytest.raises(OrgBoundaryError):
+        bootstrap_scim(test_db, org_name="Second Org")
+
+  def test_pinned_refuses_other_org_id(self, test_db):
+    org = Org.create(name="Pinned2", org_type=OrgType.ENTERPRISE, session=test_db)
+    other = Org.create(name="Other", org_type=OrgType.ENTERPRISE, session=test_db)
+
+    with patch.object(env, "ENTERPRISE_ORG_ID", str(org.id)):
+      with pytest.raises(OrgBoundaryError):
+        bootstrap_scim(test_db, org_id=other.id)
+
+  def test_pinned_allows_matching_org_id(self, test_db):
+    org = Org.create(name="Pinned3", org_type=OrgType.ENTERPRISE, session=test_db)
+
+    with patch.object(env, "ENTERPRISE_ORG_ID", str(org.id)):
+      result = bootstrap_scim(test_db, org_id=org.id, token_name="pinned-token")
+
+    assert result.org_id == org.id
+    assert ScimToken.validate_token(result.raw_token, test_db) is not None
 
 
 class TestRevokeScimToken:

--- a/tests/operations/test_oidc.py
+++ b/tests/operations/test_oidc.py
@@ -17,7 +17,8 @@ import pytest
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 
-from robosystems.models.core import User, UserIdentity
+from robosystems.config import env
+from robosystems.models.core import Org, OrgRole, OrgType, OrgUser, User, UserIdentity
 from robosystems.operations import oidc as oidc_ops
 from robosystems.operations.oidc import (
   OIDCConnection,
@@ -301,10 +302,16 @@ class TestResolveOidcUser:
     assert identity is not None and identity.last_login_at is not None
 
   def test_email_match_links_scim_provisioned_user(self, test_db):
-    user = _create_user(test_db, external_id="okta-ext-2")
+    # Okta shape: the IdP user id arrives as SCIM externalId and OIDC sub —
+    # the binding claim value must EQUAL the stored external_id to link.
+    user = _create_user(test_db, external_id="okta|sub-2")
 
     resolution = resolve_oidc_user(
-      test_db, issuer=ISSUER, subject="okta|sub-2", email=user.email.upper()
+      test_db,
+      issuer=ISSUER,
+      subject="okta|sub-2",
+      email=user.email.upper(),
+      binding_value="okta|sub-2",
     )
 
     assert resolution.user.id == user.id
@@ -319,12 +326,55 @@ class TestResolveOidcUser:
     user = _create_user(test_db, external_id=None, password_hash="some-hash")
 
     with pytest.raises(OIDCUserNotProvisionedError):
-      resolve_oidc_user(test_db, issuer=ISSUER, subject="okta|sub-3", email=user.email)
+      resolve_oidc_user(
+        test_db,
+        issuer=ISSUER,
+        subject="okta|sub-3",
+        email=user.email,
+        binding_value="okta|sub-3",
+      )
     assert UserIdentity.get_by_issuer_subject(ISSUER, "okta|sub-3", test_db) is None
+
+  def test_email_match_refused_on_binding_mismatch(self, test_db):
+    """external_id must EQUAL the binding claim — presence is not provenance.
+    A user provisioned under one IdP identity must not link from another."""
+    user = _create_user(test_db, external_id="okta|someone-else")
+
+    with pytest.raises(OIDCUserNotProvisionedError):
+      resolve_oidc_user(
+        test_db,
+        issuer=ISSUER,
+        subject="okta|sub-mm",
+        email=user.email,
+        binding_value="okta|sub-mm",
+      )
+    assert UserIdentity.get_by_issuer_subject(ISSUER, "okta|sub-mm", test_db) is None
+
+  def test_email_match_refused_without_binding_value(self, test_db):
+    """No binding claim value → never link, even for an otherwise-eligible
+    user (a misconfigured SSO_OIDC_BINDING_CLAIM fails closed)."""
+    user = _create_user(test_db, external_id="okta|sub-nb")
+
+    with pytest.raises(OIDCUserNotProvisionedError):
+      resolve_oidc_user(test_db, issuer=ISSUER, subject="okta|sub-nb", email=user.email)
+
+  def test_email_match_refused_empty_external_id(self, test_db):
+    """An empty-string external_id (an IdP sending externalId: "") is not
+    provenance and must not link — even against an empty binding value."""
+    user = _create_user(test_db, external_id="")
+
+    with pytest.raises(OIDCUserNotProvisionedError):
+      resolve_oidc_user(
+        test_db,
+        issuer=ISSUER,
+        subject="okta|sub-empty",
+        email=user.email,
+        binding_value="",
+      )
 
   def test_email_match_refused_when_email_verified_false(self, test_db):
     """An explicitly-unverified email must not link (OIDC Core §5.7)."""
-    user = _create_user(test_db, external_id="okta-ext-ev")
+    user = _create_user(test_db, external_id="okta|sub-ev")
 
     with pytest.raises(OIDCUserNotProvisionedError):
       resolve_oidc_user(
@@ -333,13 +383,14 @@ class TestResolveOidcUser:
         subject="okta|sub-ev",
         email=user.email,
         email_verified=False,
+        binding_value="okta|sub-ev",
       )
     assert UserIdentity.get_by_issuer_subject(ISSUER, "okta|sub-ev", test_db) is None
 
   def test_email_match_links_when_email_verified_absent(self, test_db):
     """Entra omits email_verified entirely — None must still be allowed to
     link (only an explicit False is refused)."""
-    user = _create_user(test_db, external_id="okta-ext-ev2")
+    user = _create_user(test_db, external_id="okta|sub-ev2")
 
     resolution = resolve_oidc_user(
       test_db,
@@ -347,6 +398,7 @@ class TestResolveOidcUser:
       subject="okta|sub-ev2",
       email=user.email,
       email_verified=None,
+      binding_value="okta|sub-ev2",
     )
     assert resolution.user.id == user.id
     assert resolution.linked is True
@@ -363,12 +415,26 @@ class TestResolveOidcUser:
 
   def test_second_subject_cannot_rebind_by_email(self, test_db):
     """One identity per issuer per user: once linked, a different subject
-    presenting the same email must not steal the account."""
-    user = _create_user(test_db, external_id="okta-ext-6")
-    resolve_oidc_user(test_db, issuer=ISSUER, subject="okta|sub-6a", email=user.email)
+    presenting the same email must not steal the account. The second call
+    passes a binding value equal to the stored external_id, so the refusal
+    below is pinned to the one-identity-per-issuer conjunct specifically."""
+    user = _create_user(test_db, external_id="okta|sub-6a")
+    resolve_oidc_user(
+      test_db,
+      issuer=ISSUER,
+      subject="okta|sub-6a",
+      email=user.email,
+      binding_value="okta|sub-6a",
+    )
 
     with pytest.raises(OIDCUserNotProvisionedError):
-      resolve_oidc_user(test_db, issuer=ISSUER, subject="okta|sub-6b", email=user.email)
+      resolve_oidc_user(
+        test_db,
+        issuer=ISSUER,
+        subject="okta|sub-6b",
+        email=user.email,
+        binding_value="okta|sub-6a",
+      )
 
   def test_deactivated_user_with_valid_identity_refused(self, test_db):
     """The Okta two-app assignment-drift case: SCIM deactivated the user but
@@ -387,10 +453,77 @@ class TestResolveOidcUser:
       resolve_oidc_user(test_db, issuer=ISSUER, subject="okta|sub-7", email=user.email)
 
   def test_deactivated_user_cannot_link_by_email(self, test_db):
-    user = _create_user(test_db, external_id="okta-ext-8", is_active=False)
+    user = _create_user(test_db, external_id="okta|sub-8", is_active=False)
 
     with pytest.raises(OIDCUserNotProvisionedError):
-      resolve_oidc_user(test_db, issuer=ISSUER, subject="okta|sub-8", email=user.email)
+      resolve_oidc_user(
+        test_db,
+        issuer=ISSUER,
+        subject="okta|sub-8",
+        email=user.email,
+        binding_value="okta|sub-8",
+      )
+
+  def test_org_boundary_refuses_nonmember_link(self, test_db):
+    """With ENTERPRISE_ORG_ID pinned, an eligible user outside the pinned org
+    must not link — the boundary scopes identities, not just tokens."""
+    org = Org.create(
+      name="Pinned Enterprise", org_type=OrgType.ENTERPRISE, session=test_db
+    )
+    user = _create_user(test_db, external_id="okta|sub-ob1")
+
+    with patch.object(env, "ENTERPRISE_ORG_ID", str(org.id)):
+      with pytest.raises(OIDCUserNotProvisionedError):
+        resolve_oidc_user(
+          test_db,
+          issuer=ISSUER,
+          subject="okta|sub-ob1",
+          email=user.email,
+          binding_value="okta|sub-ob1",
+        )
+    assert UserIdentity.get_by_issuer_subject(ISSUER, "okta|sub-ob1", test_db) is None
+
+  def test_org_boundary_links_member(self, test_db):
+    org = Org.create(
+      name="Pinned Enterprise 2", org_type=OrgType.ENTERPRISE, session=test_db
+    )
+    user = _create_user(test_db, external_id="okta|sub-ob2")
+    OrgUser.create(
+      org_id=str(org.id), user_id=str(user.id), role=OrgRole.MEMBER, session=test_db
+    )
+
+    with patch.object(env, "ENTERPRISE_ORG_ID", str(org.id)):
+      resolution = resolve_oidc_user(
+        test_db,
+        issuer=ISSUER,
+        subject="okta|sub-ob2",
+        email=user.email,
+        binding_value="okta|sub-ob2",
+      )
+    assert resolution.user.id == user.id
+    assert resolution.linked is True
+
+  def test_org_boundary_ignores_established_identity(self, test_db):
+    """The boundary gates LINKING only: an already-linked identity resolves
+    regardless (SCIM deactivation is the offboarding control there)."""
+    org = Org.create(
+      name="Pinned Enterprise 3", org_type=OrgType.ENTERPRISE, session=test_db
+    )
+    user = _create_user(test_db, external_id="okta|sub-ob3")
+    UserIdentity.create(
+      user_id=str(user.id),
+      issuer=ISSUER,
+      subject="okta|sub-ob3",
+      email_at_link=user.email,
+      session=test_db,
+    )
+
+    with patch.object(env, "ENTERPRISE_ORG_ID", str(org.id)):
+      resolution = resolve_oidc_user(
+        test_db, issuer=ISSUER, subject="okta|sub-ob3", email=user.email
+      )
+    assert resolution.user.id == user.id
+    assert resolution.linked is False
 
 
 class TestDiscoveryMetadata:

--- a/tests/routers/scim/test_scim_users.py
+++ b/tests/routers/scim/test_scim_users.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 
 import pytest
 
+from robosystems.config import env
 from robosystems.models.core import (
   Org,
   OrgRole,
@@ -116,6 +117,31 @@ class TestUsersCrud:
     assert user.email_verified is True
     assert OrgUser.get_by_org_and_user(enterprise_org.id, user.id, test_db) is not None
 
+  def test_create_without_external_id_is_400(self, client, scim_auth):
+    """externalId is the OIDC link predicate — provisioning without it makes
+    a silently never-linkable user, so the create must fail loud."""
+    resp = client.post(
+      "/scim/v2/Users",
+      headers=scim_auth,
+      json={"userName": f"noext+{uuid.uuid4().hex[:8]}@customer.example"},
+    )
+    assert resp.status_code == 400
+    body = resp.json()["detail"]
+    assert body["scimType"] == "invalidValue"
+    assert "externalId" in body["detail"]
+
+  def test_create_with_blank_external_id_is_400(self, client, scim_auth):
+    resp = client.post(
+      "/scim/v2/Users",
+      headers=scim_auth,
+      json={
+        "userName": f"blank+{uuid.uuid4().hex[:8]}@customer.example",
+        "externalId": "   ",
+      },
+    )
+    assert resp.status_code == 400
+    assert resp.json()["detail"]["scimType"] == "invalidValue"
+
   def test_duplicate_email_is_409_uniqueness(
     self, client, scim_auth, test_db, enterprise_org
   ):
@@ -178,6 +204,26 @@ class TestOrgScoping:
     ids = {r["id"] for r in resp.json()["Resources"]}
     assert mine.id in ids
     assert len(ids) == 1
+
+  def test_pinned_org_refuses_other_orgs_token(
+    self, client, scim_auth, test_db, enterprise_org
+  ):
+    """Once ENTERPRISE_ORG_ID pins the deployment, a valid token minted for
+    any other org gets the same generic 401 as an invalid token."""
+    other_org = Org.create(name="Stray", org_type=OrgType.ENTERPRISE, session=test_db)
+    _token, stray_raw = ScimToken.create(other_org.id, "stray-scim", test_db)
+
+    with patch.object(env, "ENTERPRISE_ORG_ID", str(enterprise_org.id)):
+      stray = client.get(
+        "/scim/v2/Users", headers={"Authorization": f"Bearer {stray_raw}"}
+      )
+      pinned = client.get("/scim/v2/Users", headers=scim_auth)
+
+    assert stray.status_code == 401
+    assert (
+      "urn:ietf:params:scim:api:messages:2.0:Error" in stray.json()["detail"]["schemas"]
+    )
+    assert pinned.status_code == 200
 
 
 class TestDeactivation:


### PR DESCRIPTION
## Summary

- Adds an `ENTERPRISE_ORG_ID` pin for dedicated deployments: SCIM bearer scoping, bootstrap targeting, and OIDC link-time org membership all honor it (boot warns while unpinned; enablement sequence is bootstrap → pin → restart)
- First-login identity linking now requires claim equality (`SSO_OIDC_BINDING_CLAIM`, default `sub`) against the SCIM-stamped `external_id`, rather than presence
- SCIM user creation requires a non-empty `externalId` (400 `invalidValue`)
- The SSO connection config block moves into the base deployment secret alongside its client secret (JWT_ISSUER precedent); env vars remain the local-dev path

No schema changes. Flags remain default-off; the managed platform does not mount this surface.

## Testing

- Full suite green (12,683 passed) + ruff/format/basedpyright clean
- New coverage: binding-predicate matrix (mismatch/empty/missing), org-pin refusals across bearer auth, bootstrap, and linking, externalId 400s, validation warning pair