### PR TITLE
fix(billing): correct the billing-disabled deployment posture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -365,7 +365,7 @@ LBUG_DATABASE_PATH=/data/lbug-dbs
 
 # Feature Flags
 RATE_LIMIT_ENABLED=true
-BILLING_ENABLED=true
+BILLING_ENABLED=false      # code default; local dev and dedicated tenants run billing-off
 
 # Extensions — RoboLedger & RoboInvestor product surfaces
 ROBOLEDGER_ENABLED=true            # gates roboledger ops + GraphQL ledger fields

--- a/robosystems/dagster/jobs/billing.py
+++ b/robosystems/dagster/jobs/billing.py
@@ -1036,7 +1036,10 @@ def process_overage_invoices(
     for graph_info in graphs_with_negative_balance:
       try:
         overage_credits = abs(Decimal(str(graph_info["negative_balance"])))
-        usd_amount = float(overage_credits) * 0.005
+        # Billing-off deployments keep the overage *record* (credit quantity)
+        # but dollarize at $0 — the fee is settled off-platform via the MSA.
+        overage_rate = 0.005 if env.BILLING_ENABLED else 0.0
+        usd_amount = float(overage_credits) * overage_rate
 
         credits_record = GraphCredits.get_by_graph_id(graph_info["graph_id"], session)
 

--- a/robosystems/models/api/billing/customer.py
+++ b/robosystems/models/api/billing/customer.py
@@ -41,6 +41,11 @@ class BillingCustomer(BaseModel):
 class PortalSessionResponse(BaseModel):
   """Response for customer portal session creation."""
 
-  portal_url: str = Field(
-    ..., description="Stripe Customer Portal URL where user can manage payment methods"
+  portal_url: str | None = Field(
+    None,
+    description="Stripe Customer Portal URL where user can manage payment methods",
+  )
+  billing_disabled: bool = Field(
+    False,
+    description="True when billing is disabled on this deployment (no portal exists)",
   )

--- a/robosystems/operations/graph/subscription_service.py
+++ b/robosystems/operations/graph/subscription_service.py
@@ -47,7 +47,14 @@ def generate_subscription_invoice(
   Card customers settle it via the Stripe webhook; invoice-billing customers
   are tracked manually. Either way the invoice exists from the moment the
   subscription does.
+
+  Billing-off deployments (dedicated tenants — the fee flows through the
+  MSA, not platform billing) still generate the invoice as a usage record,
+  but at $0: the tier and period are the record; a plan-price amount would
+  assert a charge that doesn't exist on that vehicle.
   """
+  amount_cents = subscription.base_price_cents if BILLING_ENABLED else 0
+
   invoice = BillingInvoice.create_invoice(
     org_id=subscription.org_id,
     period_start=subscription.current_period_start,
@@ -61,7 +68,7 @@ def generate_subscription_invoice(
     resource_type=subscription.resource_type,
     resource_id=subscription.resource_id,
     description=description,
-    amount_cents=subscription.base_price_cents,
+    amount_cents=amount_cents,
     session=session,
   )
 
@@ -77,7 +84,7 @@ def generate_subscription_invoice(
     actor_type="system",
     event_data={
       "invoice_number": invoice.invoice_number,
-      "amount_cents": subscription.base_price_cents,
+      "amount_cents": amount_cents,
       "due_date": invoice.due_date.isoformat() if invoice.due_date else None,
       "payment_terms": customer.payment_terms,
       "resource_type": subscription.resource_type,
@@ -93,7 +100,7 @@ def generate_subscription_invoice(
       "invoice_number": invoice.invoice_number,
       "subscription_id": subscription.id,
       "org_id": subscription.org_id,
-      "amount_cents": subscription.base_price_cents,
+      "amount_cents": amount_cents,
       "due_date": invoice.due_date.isoformat() if invoice.due_date else None,
       "payment_terms": customer.payment_terms,
       "invoice_billing_enabled": customer.invoice_billing_enabled,

--- a/robosystems/routers/billing/customer.py
+++ b/robosystems/routers/billing/customer.py
@@ -107,8 +107,14 @@ async def create_portal_session(
   db: Session = Depends(get_db_session),
   _rate_limit: None = Depends(billing_rate_limit_dependency),
 ):
+  from ...config import env
+
+  # Same guard as checkout: with billing off there is no Stripe customer and
+  # no portal — calling the provider with empty keys would 500.
+  if not env.BILLING_ENABLED:
+    return PortalSessionResponse(portal_url=None, billing_disabled=True)
+
   try:
-    from ...config import env
     from ...models.core import OrgRole, OrgUser
 
     membership = OrgUser.get_by_org_and_user(org_id, current_user.id, db)

--- a/tests/dagster/test_billing_jobs.py
+++ b/tests/dagster/test_billing_jobs.py
@@ -60,3 +60,71 @@ class TestCreditAllocationLogic:
     # Verify job has expected ops
     op_names = [node.name for node in job_def.all_node_defs]
     assert "get_subscriptions_for_allocation" in op_names or len(op_names) >= 1
+
+
+class TestOverageDollarization:
+  """Overage invoices keep the credit quantity as the record everywhere,
+  but dollarize at $0 when billing is off (fee settled off-platform)."""
+
+  def _run_op(self, graphs):
+    from contextlib import contextmanager
+    from unittest.mock import Mock, patch
+
+    from dagster import build_op_context
+
+    from robosystems.dagster.jobs.billing import process_overage_invoices
+
+    session = Mock()
+
+    @contextmanager
+    def _session_cm():
+      yield session
+
+    db = Mock()
+    db.get_session = _session_cm
+
+    with patch(
+      "robosystems.dagster.jobs.billing.GraphCredits.get_by_graph_id",
+      return_value=None,
+    ):
+      return process_overage_invoices(build_op_context(), db, graphs)
+
+  @pytest.mark.unit
+  def test_overage_zero_dollars_when_billing_disabled(self):
+    from unittest.mock import patch
+
+    from robosystems.config import env
+
+    graphs = [
+      {
+        "graph_id": "kg_x",
+        "user_id": "u1",
+        "negative_balance": -2000,
+        "graph_tier": "ladybug-standard",
+      }
+    ]
+    with patch.object(env, "BILLING_ENABLED", False):
+      invoices = self._run_op(graphs)
+
+    assert len(invoices) == 1
+    assert invoices[0]["overage_credits"] == 2000.0
+    assert invoices[0]["amount_usd"] == 0.0
+
+  @pytest.mark.unit
+  def test_overage_real_dollars_when_billing_enabled(self):
+    from unittest.mock import patch
+
+    from robosystems.config import env
+
+    graphs = [
+      {
+        "graph_id": "kg_y",
+        "user_id": "u1",
+        "negative_balance": -2000,
+        "graph_tier": "ladybug-standard",
+      }
+    ]
+    with patch.object(env, "BILLING_ENABLED", True):
+      invoices = self._run_op(graphs)
+
+    assert invoices[0]["amount_usd"] == 10.0

--- a/tests/middleware/billing/test_enforcement.py
+++ b/tests/middleware/billing/test_enforcement.py
@@ -445,6 +445,63 @@ class TestEdgeCases:
       mock_logger.info.assert_called_once()
 
 
+class TestRequireGraphAccessBillingDisabled:
+  """require_graph_access with billing off — the dedicated-tenant posture.
+
+  Read and write access must both bypass the subscription machinery
+  entirely: no subscription row exists on those deployments, and the
+  lookup should never even run.
+  """
+
+  @pytest.fixture
+  def mock_session(self):
+    return Mock()
+
+  @pytest.fixture(autouse=True)
+  def clear_subscription_cache(self):
+    from robosystems.middleware.billing import enforcement
+
+    enforcement._subscription_cache.clear()
+    yield
+    enforcement._subscription_cache.clear()
+
+  def _active_graph(self):
+    graph = Mock()
+    graph.status = "active"
+    graph.is_repository = False
+    return graph
+
+  @patch("robosystems.middleware.billing.enforcement.env")
+  @patch("robosystems.middleware.billing.enforcement.BillingSubscription")
+  @patch("robosystems.middleware.billing.enforcement.Graph")
+  def test_read_access_without_subscription(
+    self, mock_graph_class, mock_subscription_class, mock_env, mock_session
+  ):
+    mock_env.BILLING_ENABLED = False
+    mock_graph_class.get_by_id.return_value = self._active_graph()
+    mock_subscription_class.get_by_resource.return_value = None
+
+    graph = require_graph_access("kg_billoff1", mock_session)
+
+    assert graph is mock_graph_class.get_by_id.return_value
+    mock_subscription_class.get_by_resource.assert_not_called()
+
+  @patch("robosystems.middleware.billing.enforcement.env")
+  @patch("robosystems.middleware.billing.enforcement.BillingSubscription")
+  @patch("robosystems.middleware.billing.enforcement.Graph")
+  def test_write_access_without_subscription(
+    self, mock_graph_class, mock_subscription_class, mock_env, mock_session
+  ):
+    mock_env.BILLING_ENABLED = False
+    mock_graph_class.get_by_id.return_value = self._active_graph()
+    mock_subscription_class.get_by_resource.return_value = None
+
+    graph = require_graph_access("kg_billoff2", mock_session, require_write=True)
+
+    assert graph is mock_graph_class.get_by_id.return_value
+    mock_subscription_class.get_by_resource.assert_not_called()
+
+
 class TestRequireGraphAccessGracePeriod:
   """Canceled-subscription grace period in require_graph_access.
 

--- a/tests/operations/test_subscription_flow.py
+++ b/tests/operations/test_subscription_flow.py
@@ -77,6 +77,72 @@ class TestSubscriptionCreation:
 
     assert sub1.id == sub2.id
 
+  def test_invoice_amount_zero_when_billing_disabled(
+    self, test_db, test_user, sample_graph, test_user_graph
+  ):
+    """Billing-off deployments keep the invoice as a usage record (tier +
+    period intact) but at $0 — the fee is settled off-platform."""
+    from robosystems.models.core.billing import BillingCustomer
+    from robosystems.operations.graph.subscription_service import (
+      generate_subscription_invoice,
+    )
+
+    service = GraphSubscriptionService(test_db)
+    with patch(
+      "robosystems.operations.graph.subscription_service.BILLING_ENABLED", False
+    ):
+      subscription = service.create_graph_subscription(
+        user_id=str(test_user.id),
+        graph_id=sample_graph.graph_id,
+        plan_name="ladybug-standard",
+      )
+      customer = BillingCustomer.get_or_create(subscription.org_id, test_db)
+      invoice = generate_subscription_invoice(
+        subscription=subscription,
+        customer=customer,
+        description="Graph Database Subscription - ladybug-standard",
+        session=test_db,
+      )
+
+    assert subscription.base_price_cents > 0
+    assert invoice.total_cents == 0
+    assert invoice.subtotal_cents == 0
+
+  def test_invoice_amount_real_when_billing_enabled(
+    self, test_db, test_user, sample_graph, test_user_graph
+  ):
+    """With billing on, the same invoice carries the plan price — managed
+    invoice-based billing depends on real amounts."""
+    from robosystems.models.core.billing import BillingCustomer
+    from robosystems.operations.graph.subscription_service import (
+      generate_subscription_invoice,
+    )
+
+    service = GraphSubscriptionService(test_db)
+    # Create the subscription with billing off (avoids the Stripe path)…
+    with patch(
+      "robosystems.operations.graph.subscription_service.BILLING_ENABLED", False
+    ):
+      subscription = service.create_graph_subscription(
+        user_id=str(test_user.id),
+        graph_id=sample_graph.graph_id,
+        plan_name="ladybug-standard",
+      )
+    customer = BillingCustomer.get_or_create(subscription.org_id, test_db)
+    # …then generate the invoice as a billing-on deployment would.
+    with patch(
+      "robosystems.operations.graph.subscription_service.BILLING_ENABLED", True
+    ):
+      invoice = generate_subscription_invoice(
+        subscription=subscription,
+        customer=customer,
+        description="Graph Database Subscription - ladybug-standard",
+        session=test_db,
+      )
+
+    assert invoice.total_cents == subscription.base_price_cents
+    assert invoice.total_cents > 0
+
 
 class TestSubscriptionEnforcement:
   """Test subscription enforcement cache."""

--- a/tests/routers/billing/test_customer.py
+++ b/tests/routers/billing/test_customer.py
@@ -235,3 +235,39 @@ class TestGetCustomer:
 
     assert result.payment_methods == []
     assert result.stripe_customer_id is None
+
+
+class TestCreatePortalSession:
+  """Portal sessions on a billing-off deployment.
+
+  With billing disabled there is no Stripe customer and no portal; the
+  endpoint previously called the provider with empty keys and 500'd.
+  """
+
+  @pytest.fixture
+  def mock_user(self):
+    user = Mock(spec=User)
+    user.id = "user_123"
+    user.email = "owner@example.com"
+    return user
+
+  @pytest.fixture
+  def mock_db(self):
+    return Mock()
+
+  @pytest.mark.asyncio
+  async def test_billing_disabled_returns_flag_without_stripe(self, mock_user, mock_db):
+    from robosystems.config import env
+    from robosystems.routers.billing.customer import create_portal_session
+
+    with (
+      patch.object(env, "BILLING_ENABLED", False),
+      patch(
+        "robosystems.routers.billing.customer.get_payment_provider"
+      ) as mock_provider,
+    ):
+      result = await create_portal_session("org_123", mock_user, mock_db, None)
+
+    assert result.billing_disabled is True
+    assert result.portal_url is None
+    mock_provider.assert_not_called()


### PR DESCRIPTION
## Summary

- `POST /v1/billing/portal` gains the same `BILLING_ENABLED` guard its checkout sibling already had — returns `billing_disabled: true` instead of 500ing against the payment provider with empty credentials (`PortalSessionResponse` extended additively)
- Subscription and overage invoices still generate on billing-off deployments — they're the usage record (tier, period, credit quantities intact) — but at **$0 amounts**: on those deployments the fee is settled off-platform, and real prices remain whenever billing is on (managed invoice-based billing unchanged)
- Adds the previously-missing `require_graph_access` coverage for the flag-off path (read + write both bypass the subscription lookup)
- CLAUDE.md env sample corrected (`BILLING_ENABLED=false` is the code default)

## Testing

- New tests: portal billing-off (no provider call), invoice $0-vs-real pair, overage dollarization pair, require_graph_access flag-off read/write
- Full suite green + ruff/format/basedpyright clean