### PR TITLE
chore(ci): make release deployments dispatch-only, drop reusable-workflow fallback

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -155,36 +155,19 @@ jobs:
       branch_ref: ${{ needs.create-branch.outputs.branch_name }}
     secrets: inherit
 
-  # Check if ACTIONS_TOKEN is available for dispatch-based deployments
-  # Dispatch gives independent workflow runs for better monitoring
-  # Reusable workflows are fallback when PAT not available
-  check-deploy-method:
-    needs: create-tag
-    runs-on: ubuntu-latest
-    outputs:
-      use_dispatch: ${{ steps.check.outputs.use_dispatch }}
-    steps:
-      - name: Check for ACTIONS_TOKEN
-        id: check
-        run: |
-          if [ "${{ secrets.ACTIONS_TOKEN != '' }}" = "true" ]; then
-            echo "use_dispatch=true" >> $GITHUB_OUTPUT
-            echo "✅ ACTIONS_TOKEN available - will dispatch independent workflow runs"
-          else
-            echo "use_dispatch=false" >> $GITHUB_OUTPUT
-            echo "ℹ️ ACTIONS_TOKEN not set - using reusable workflows (bundled in this run)"
-          fi
-
   # ============================================================================
-  # DISPATCH-BASED DEPLOYMENTS (when ACTIONS_TOKEN is available)
-  # Each deployment runs as an independent workflow for better monitoring
+  # DEPLOYMENTS
+  # Each deployment is dispatched as an independent workflow run for better
+  # monitoring. workflow_dispatch is exempt from GitHub's "GITHUB_TOKEN events
+  # don't trigger workflows" rule, so this works with the default token too;
+  # ACTIONS_TOKEN is preferred when available.
   # ============================================================================
 
-  deploy-staging-dispatch:
-    needs: [create-branch, create-tag, check-deploy-method]
-    if: |
-      needs.check-deploy-method.outputs.use_dispatch == 'true' &&
-      (inputs.deploy_target == 'staging' || inputs.deploy_target == 'all')
+  deploy-staging:
+    needs: [create-tag]
+    if: inputs.deploy_target == 'staging' || inputs.deploy_target == 'all'
+    permissions:
+      actions: write
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -193,7 +176,7 @@ jobs:
       - name: Dispatch staging deployment
         id: dispatch
         env:
-          GH_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
+          GH_TOKEN: ${{ secrets.ACTIONS_TOKEN || github.token }}
         run: |
           echo "🚀 Dispatching staging deployment from tag ${{ needs.create-tag.outputs.tag_name }}"
 
@@ -205,10 +188,12 @@ jobs:
           # Wait briefly for the run to be created
           sleep 5
 
-          # Get the run ID of the triggered workflow
+          # Get the run ID of the triggered workflow (dispatched at the tag,
+          # so filtering by the tag ref avoids grabbing an unrelated run)
           RUN_ID=$(gh run list \
             --repo ${{ github.repository }} \
             --workflow=staging.yml \
+            --branch ${{ needs.create-tag.outputs.tag_name }} \
             --limit 1 \
             --json databaseId \
             --jq '.[0].databaseId')
@@ -216,13 +201,15 @@ jobs:
           echo "run_id=$RUN_ID" >> $GITHUB_OUTPUT
           echo "✅ Staging deployment dispatched: https://github.com/${{ github.repository }}/actions/runs/$RUN_ID"
 
-  deploy-prod-dispatch:
-    needs: [create-branch, create-tag, check-deploy-method, deploy-staging-dispatch]
+  deploy-prod:
+    needs: [create-tag, deploy-staging]
     if: |
-      always() &&
-      needs.check-deploy-method.outputs.use_dispatch == 'true' &&
+      !cancelled() &&
+      needs.create-tag.result == 'success' &&
       (inputs.deploy_target == 'prod' || inputs.deploy_target == 'all') &&
-      (needs.deploy-staging-dispatch.result == 'success' || needs.deploy-staging-dispatch.result == 'skipped')
+      (needs.deploy-staging.result == 'success' || needs.deploy-staging.result == 'skipped')
+    permissions:
+      actions: write
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -238,7 +225,7 @@ jobs:
       - name: Dispatch prod deployment
         id: dispatch
         env:
-          GH_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
+          GH_TOKEN: ${{ secrets.ACTIONS_TOKEN || github.token }}
         run: |
           echo "🚀 Dispatching prod deployment from tag ${{ needs.create-tag.outputs.tag_name }}"
 
@@ -250,10 +237,12 @@ jobs:
           # Wait briefly for the run to be created
           sleep 5
 
-          # Get the run ID of the triggered workflow
+          # Get the run ID of the triggered workflow (dispatched at the tag,
+          # so filtering by the tag ref avoids grabbing an unrelated run)
           RUN_ID=$(gh run list \
             --repo ${{ github.repository }} \
             --workflow=prod.yml \
+            --branch ${{ needs.create-tag.outputs.tag_name }} \
             --limit 1 \
             --json databaseId \
             --jq '.[0].databaseId')
@@ -261,59 +250,16 @@ jobs:
           echo "run_id=$RUN_ID" >> $GITHUB_OUTPUT
           echo "✅ Prod deployment dispatched: https://github.com/${{ github.repository }}/actions/runs/$RUN_ID"
 
-  # ============================================================================
-  # REUSABLE WORKFLOW DEPLOYMENTS (fallback when ACTIONS_TOKEN not available)
-  # Deployments run as part of this workflow - less visibility but no PAT needed
-  # ============================================================================
-
-  deploy-staging-reusable:
-    needs: [create-branch, create-tag, check-deploy-method]
-    if: |
-      needs.check-deploy-method.outputs.use_dispatch == 'false' &&
-      (inputs.deploy_target == 'staging' || inputs.deploy_target == 'all')
-    permissions:
-      contents: read
-      deployments: write
-      id-token: write
-      security-events: write
-    uses: ./.github/workflows/staging.yml
-    secrets: inherit
-
-  deploy-prod-reusable:
-    needs: [create-branch, create-tag, check-deploy-method, deploy-staging-reusable]
-    if: |
-      always() &&
-      needs.check-deploy-method.outputs.use_dispatch == 'false' &&
-      (inputs.deploy_target == 'prod' || inputs.deploy_target == 'all') &&
-      (needs.deploy-staging-reusable.result == 'success' || needs.deploy-staging-reusable.result == 'skipped')
-    permissions:
-      contents: read
-      deployments: write
-      id-token: write
-      security-events: write
-    uses: ./.github/workflows/prod.yml
-    secrets: inherit
-
   create-summary:
-    needs:
-      [
-        create-branch,
-        create-tag,
-        check-deploy-method,
-        deploy-staging-dispatch,
-        deploy-prod-dispatch,
-        deploy-staging-reusable,
-        deploy-prod-reusable,
-      ]
+    needs: [create-branch, create-tag, deploy-staging, deploy-prod]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
       - name: Create summary
         env:
-          USE_DISPATCH: ${{ needs.check-deploy-method.outputs.use_dispatch }}
-          STAGING_RUN_ID: ${{ needs.deploy-staging-dispatch.outputs.run_id }}
-          PROD_RUN_ID: ${{ needs.deploy-prod-dispatch.outputs.run_id }}
+          STAGING_RUN_ID: ${{ needs.deploy-staging.outputs.run_id }}
+          PROD_RUN_ID: ${{ needs.deploy-prod.outputs.run_id }}
         run: |
           echo "## Release Created" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -328,11 +274,11 @@ jobs:
           echo "**Release URL:** ${{ needs.create-tag.outputs.release_url }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
-          # Show deployment method and links
-          if [ "$USE_DISPATCH" = "true" ]; then
-            echo "### Deployments (Independent Workflows)" >> $GITHUB_STEP_SUMMARY
+          # Show deployment links
+          if [ "${{ inputs.deploy_target }}" != "none" ]; then
+            echo "### Deployments" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "Deployments are running as **separate workflow runs** for independent monitoring." >> $GITHUB_STEP_SUMMARY
+            echo "Deployments run as **separate workflow runs** for independent monitoring." >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
 
             if [ -n "$STAGING_RUN_ID" ]; then
@@ -343,12 +289,6 @@ jobs:
             fi
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "Monitor all deployments: \`gh run list --workflow=staging.yml\` / \`gh run list --workflow=prod.yml\`" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "### Deployments (Reusable Workflows)" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "Deployments are running as **part of this workflow** (ACTIONS_TOKEN not configured)." >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "To enable independent deployment tracking, set the \`ACTIONS_TOKEN\` secret." >> $GITHUB_STEP_SUMMARY
           fi
 
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -28,7 +28,6 @@ on:
         required: false
         type: boolean
         default: false
-  workflow_call: {} # Called from create-release.yml
 
 jobs:
   runner:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -28,7 +28,6 @@ on:
         required: false
         type: boolean
         default: false
-  workflow_call: {} # Called from create-release.yml
 
 jobs:
   # Guard: Verify staging environment is enabled


### PR DESCRIPTION
## Summary

Removes the dual deployment method from `create-release.yml`, making dispatch-based deployments the only path. The embedded reusable-workflow fallback existed for the case where `ACTIONS_TOKEN` isn't configured, but that configuration can't complete the workflow anyway (the version-bump push to protected `main` already requires the PAT), and the premise behind it is outdated: `workflow_dispatch` is exempt from GitHub's restriction on `GITHUB_TOKEN`-triggered events, so `gh workflow run` works with the default token given `actions: write`. Release runs no longer embed the full staging and prod pipelines.

## Changes

**`.github/workflows/create-release.yml`**

- Deleted the `check-deploy-method` job and both `deploy-staging-reusable` / `deploy-prod-reusable` jobs
- Renamed `deploy-staging-dispatch` / `deploy-prod-dispatch` to `deploy-staging` / `deploy-prod`; each now carries `permissions: actions: write` and falls back to `github.token` when `ACTIONS_TOKEN` is absent, so a fork without the PAT still deploys end-to-end via dispatch
- Tightened the `deploy-prod` condition to require `create-tag` success — previously the `always()` guard combined with "staging skipped counts as OK" made prod dispatch reachable after a failed tag job
- Fixed the dispatched run-id lookup to filter `gh run list` by the tag ref instead of taking the newest run of the workflow, which was racy under concurrent runs (summary links only)
- Simplified `create-summary`: single deployment section, no dual-method branching

**`.github/workflows/staging.yml` / `.github/workflows/prod.yml`**

- Dropped the `workflow_call: {}` triggers; `create-release.yml` was their only caller

## Breaking Changes

None. This is CI-only; no application code, API surface, or SDK-visible behavior changes. Operators of forks without `ACTIONS_TOKEN` keep a working release path (dispatch via the default token), provided their `main` isn't push-protected — which was already a requirement for the release workflow's version-bump step.

## Testing

- `actionlint` on all three workflows: no findings beyond pre-existing SC2086 shellcheck style notes that also fire on untouched jobs
- Verified no remaining references to the removed jobs or `workflow_call` anywhere in `.github/`
- Pre-commit hooks (lint/format) passed on commit
- `just test-all` not run — workflow-only change, no Python code touched
