### PR TITLE
fix(graphs): publish the file-size limit the write path enforces

### DIFF
--- a/.github/configs/graph.yml
+++ b/.github/configs/graph.yml
@@ -35,7 +35,6 @@ production:
 
       # Copy operation limits
       copy_operations:
-        max_file_size_gb: 1.0 # Maximum file size per copy operation
         timeout_seconds: 900 # 15 minute timeout for dedicated instance
         concurrent_operations: 1 # One copy operation at a time
         max_files_per_operation: 100 # Maximum files per batch copy
@@ -100,7 +99,6 @@ production:
 
       # Copy operation limits
       copy_operations:
-        max_file_size_gb: 5.0 # Larger files for larger workloads
         timeout_seconds: 1800 # 30 minute timeout for large operations
         concurrent_operations: 3 # Support concurrent operations for team
         max_files_per_operation: 1000 # Higher batch limits
@@ -165,7 +163,6 @@ production:
 
       # Copy operation limits
       copy_operations:
-        max_file_size_gb: 10.0 # Maximum file size for enterprise workloads
         timeout_seconds: 3600 # 1 hour timeout for massive operations
         concurrent_operations: 5 # Maximum concurrency for enterprise
         max_files_per_operation: 10000 # Very high batch limits
@@ -231,7 +228,6 @@ production:
 
       # Copy operation limits (for platform data loading)
       copy_operations:
-        max_file_size_gb: 10.0 # Large files for bulk data loading
         timeout_seconds: 3600 # 1 hour for massive SEC filings
         concurrent_operations: 3 # Moderate concurrency for platform operations
         max_files_per_operation: 10000 # High batch limits for quarterly filings
@@ -326,7 +322,6 @@ staging:
 
       # Copy operation limits
       copy_operations:
-        max_file_size_gb: 1.0
         timeout_seconds: 900
         concurrent_operations: 1
         max_files_per_operation: 100
@@ -378,7 +373,6 @@ staging:
       max_subgraphs: 10
 
       copy_operations:
-        max_file_size_gb: 5.0
         timeout_seconds: 1800
         concurrent_operations: 3
         max_files_per_operation: 1000
@@ -429,7 +423,6 @@ staging:
       max_subgraphs: 25
 
       copy_operations:
-        max_file_size_gb: 10.0
         timeout_seconds: 3600
         concurrent_operations: 5
         max_files_per_operation: 10000
@@ -480,7 +473,6 @@ staging:
       max_subgraphs: 10 # Platform-managed subgraphs only
 
       copy_operations:
-        max_file_size_gb: 10.0
         timeout_seconds: 3600
         concurrent_operations: 3
         max_files_per_operation: 10000
@@ -546,7 +538,6 @@ development:
       max_subgraphs: 3
 
       copy_operations:
-        max_file_size_gb: 1.0
         timeout_seconds: 900
         concurrent_operations: 1
         max_files_per_operation: 100

--- a/robosystems/config/graph_tier.py
+++ b/robosystems/config/graph_tier.py
@@ -15,6 +15,7 @@ from typing import Any
 import yaml
 
 from robosystems.config import env
+from robosystems.config.constants import MAX_FILE_SIZE_MB
 
 
 class GraphTier(str, Enum):
@@ -261,16 +262,29 @@ class GraphTierConfig:
   def get_copy_operation_limits(
     cls, tier: str, environment: str | None = None
   ) -> dict[str, Any]:
-    """Get copy operation limits for a tier."""
+    """Get copy operation limits for a tier.
+
+    ``max_file_size_gb`` is **derived from the enforced constant, not read from
+    graph.yml**, and is therefore the same for every tier. Upload size is not a
+    tier-scoped product limit: ``ingest_file_cmd`` reads the whole object into
+    memory to count rows, and it does that in the shared API container, so the
+    ceiling is bounded by that container rather than by the tenant's graph
+    instance. Publishing a per-tier figure here previously advertised up to
+    10 GB against a flat 100 MB rejection.
+
+    Raising this means making the row-count path stream; until then the
+    published number tracks the one the write path actually enforces.
+    """
     tier_config = cls.get_tier_config(tier, environment)
     default_limits = {
-      "max_file_size_gb": 1.0,
       "timeout_seconds": 300,
       "concurrent_operations": 1,
       "max_files_per_operation": 100,
       "daily_copy_operations": 10,
     }
-    return tier_config.get("copy_operations", default_limits)
+    limits = dict(tier_config.get("copy_operations", default_limits))
+    limits["max_file_size_gb"] = MAX_FILE_SIZE_MB / 1024
+    return limits
 
   @classmethod
   def get_backup_limits(
@@ -474,7 +488,10 @@ class GraphTierConfig:
         "limits": {
           "monthly_credits": monthly_credits,
           "max_subgraphs": writer.get("max_subgraphs"),
-          "copy_operations": writer.get("copy_operations", {}),
+          # Through the accessor, not the raw block, so `max_file_size_gb` is
+          # the enforced figure here too — reading `writer` directly is how the
+          # two surfaces drifted apart in the first place.
+          "copy_operations": cls.get_copy_operation_limits(tier_name, environment),
           "backup": writer.get("backup_limits", {}),
           "graph_limits": writer.get("graph_limits", {}),
         },

--- a/robosystems/models/api/graphs/tables.py
+++ b/robosystems/models/api/graphs/tables.py
@@ -145,6 +145,17 @@ class FileUploadRequest(BaseModel):
     pattern=r"^[A-Za-z_][A-Za-z0-9_]*$",
     examples=["Entity", "Fact", "PERSON_WORKS_FOR_COMPANY"],
   )
+  file_size_bytes: int | None = Field(
+    default=None,
+    ge=0,
+    description=(
+      "Size of the file about to be uploaded, in bytes. Optional; when supplied, "
+      "an over-limit file is rejected here instead of after it has been pushed to "
+      "S3 and rejected by ingest-file. Advisory only — the authoritative check "
+      "measures the object after upload."
+    ),
+    examples=[1048576],
+  )
 
   class Config:
     extra = "forbid"

--- a/robosystems/operations/graph/commands/create_file_upload.py
+++ b/robosystems/operations/graph/commands/create_file_upload.py
@@ -14,7 +14,7 @@ from fastapi import HTTPException, status
 from sqlalchemy.orm import Session
 
 from robosystems.config import env
-from robosystems.config.constants import PRESIGNED_URL_EXPIRY_SECONDS
+from robosystems.config.constants import MAX_FILE_SIZE_MB, PRESIGNED_URL_EXPIRY_SECONDS
 from robosystems.config.shared_repositories import is_shared_repository_or_subgraph
 from robosystems.logger import api_logger, logger
 from robosystems.middleware.graph import get_universal_repository
@@ -140,6 +140,22 @@ async def create_file_upload_cmd(
       raise HTTPException(
         status_code=status.HTTP_400_BAD_REQUEST,
         detail="File name contains invalid characters",
+      )
+
+    # Fail before the upload rather than after it. `ingest-file` measures the
+    # real object and is the authoritative check; this only spares the caller a
+    # push to S3 that is already known to be rejected. Advisory by nature — a
+    # client can under-declare, which is why the post-upload check stays.
+    if (
+      request.file_size_bytes is not None
+      and request.file_size_bytes > MAX_FILE_SIZE_MB * 1024 * 1024
+    ):
+      raise HTTPException(
+        status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+        detail=(
+          f"File size {request.file_size_bytes / (1024 * 1024):.2f} MB exceeds "
+          f"maximum of {MAX_FILE_SIZE_MB} MB"
+        ),
       )
 
     logger.info(

--- a/tests/config/test_graph_tier_config.py
+++ b/tests/config/test_graph_tier_config.py
@@ -135,7 +135,13 @@ def test_accessors_return_configured_values(mock_graph_config):
   assert get_tier_api_rate_multiplier("ladybug-standard") == 1.0
 
   copy_limits = get_tier_copy_operation_limits("ladybug-standard")
-  assert copy_limits["max_file_size_gb"] == 3
+  # Same treatment as api_rate_multiplier above: no longer read from graph.yml.
+  # The published cap is derived from the constant the write path enforces, so
+  # the mocked YAML's `max_file_size_gb: 3` is ignored by design — that is what
+  # stops the published figure drifting from the enforced one again.
+  from robosystems.config.constants import MAX_FILE_SIZE_MB
+
+  assert copy_limits["max_file_size_gb"] == MAX_FILE_SIZE_MB / 1024
   assert copy_limits["timeout_seconds"] == 600
   assert copy_limits["daily_copy_operations"] == 20
 
@@ -156,7 +162,11 @@ def test_accessors_fall_back_to_defaults_when_missing(mock_graph_config):
   assert get_tier_api_rate_multiplier("ladybug-large") == 2.0  # derived, 2 vCPU
 
   default_copy = get_tier_copy_operation_limits("ladybug-large")
-  assert default_copy["max_file_size_gb"] == 1.0
+  # Derived rather than defaulted: a tier with no copy_operations block still
+  # publishes the enforced cap, not a placeholder that happens to differ.
+  from robosystems.config.constants import MAX_FILE_SIZE_MB
+
+  assert default_copy["max_file_size_gb"] == MAX_FILE_SIZE_MB / 1024
   assert default_copy["concurrent_operations"] == 1
 
   default_backup = get_tier_backup_limits("ladybug-large")
@@ -318,3 +328,51 @@ def test_backup_hosting_days_never_exceed_the_s3_lifecycle():
   for tier, days in config.backup_hosting_days.items():
     assert days <= 90, f"{tier} promises {days}-day backup hosting; S3 deletes at 90"
   assert config.get_backup_hosting_days("unknown-tier") <= 90
+
+
+def test_published_file_size_matches_the_enforced_constant():
+  """The published cap is derived, not a hand-kept copy of the enforced one.
+
+  `/v1/graphs/{g}/limits` and `/v1/graphs/tiers` previously served per-tier
+  figures from graph.yml (1/5/10 GB) while `ingest_file_cmd` rejected anything
+  over a flat `MAX_FILE_SIZE_MB` — a 100x overstatement on the largest tier.
+  The two cannot drift again because there is now one source.
+  """
+  from robosystems.config.constants import MAX_FILE_SIZE_MB
+
+  expected_gb = MAX_FILE_SIZE_MB / 1024
+  for tier in ("ladybug-standard", "ladybug-large", "ladybug-xlarge"):
+    limits = GraphTierConfig.get_copy_operation_limits(tier)
+    assert limits["max_file_size_gb"] == expected_gb, (
+      f"{tier} publishes {limits['max_file_size_gb']} GB but the write path "
+      f"enforces {MAX_FILE_SIZE_MB} MB"
+    )
+
+
+def test_file_size_is_not_tier_scoped():
+  """Upload size is bounded by the shared API container, not the tenant's box.
+
+  `ingest_file_cmd` reads the whole object into memory to count rows, and does
+  so in the API process — so a per-tier ceiling would describe a resource the
+  limit does not consume. Every tier must publish the same number.
+  """
+  published = {
+    GraphTierConfig.get_copy_operation_limits(tier)["max_file_size_gb"]
+    for tier in ("ladybug-standard", "ladybug-large", "ladybug-xlarge")
+  }
+  assert len(published) == 1
+
+
+def test_tiers_listing_reports_the_same_file_size_as_the_limits_endpoint():
+  """Both public surfaces resolve through the accessor.
+
+  `get_available_tiers` used to pass graph.yml's `copy_operations` block
+  through raw, so the two endpoints could disagree even after one was fixed.
+  """
+  from robosystems.config.constants import MAX_FILE_SIZE_MB
+
+  tiers = GraphTierConfig.get_available_tiers(include_disabled=True)
+  assert tiers, "expected at least one tier"
+  for tier in tiers:
+    copy_ops = tier["limits"]["copy_operations"]
+    assert copy_ops["max_file_size_gb"] == MAX_FILE_SIZE_MB / 1024

--- a/tests/operations/graph/commands/test_create_file_upload_size_gate.py
+++ b/tests/operations/graph/commands/test_create_file_upload_size_gate.py
@@ -1,0 +1,88 @@
+"""Tests for the presign-time file size gate.
+
+Rejecting an over-limit file at presign spares the caller a push to S3 that
+`ingest-file` is already certain to refuse. The check is advisory — the caller
+declares the size and could under-declare — so the post-upload measurement
+remains authoritative and is not replaced by this.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException, status
+
+from robosystems.config.constants import MAX_FILE_SIZE_MB
+from robosystems.models.api.graphs.tables import FileUploadRequest
+from robosystems.operations.graph.commands.create_file_upload import (
+  create_file_upload_cmd,
+)
+
+MB = 1024**2
+
+
+def _request(file_size_bytes: int | None) -> FileUploadRequest:
+  return FileUploadRequest(
+    file_name="data.csv",
+    content_type="text/csv",
+    table_name="Entity",
+    file_size_bytes=file_size_bytes,
+  )
+
+
+async def _run(file_size_bytes: int | None):
+  graph = MagicMock()
+  graph.graph_type = "generic"
+
+  with (
+    patch(
+      "robosystems.middleware.billing.enforcement.require_graph_access",
+      return_value=graph,
+    ),
+    patch(
+      "robosystems.operations.graph.commands.create_file_upload.get_universal_repository",
+    ) as repo,
+  ):
+    repo.return_value = MagicMock()
+    return await create_file_upload_cmd(
+      graph_id="kg123",
+      request=_request(file_size_bytes),
+      current_user=MagicMock(id="user123"),
+      db=MagicMock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_oversized_declared_file_is_refused_before_upload():
+  with pytest.raises(HTTPException) as exc:
+    await _run((MAX_FILE_SIZE_MB + 1) * MB)
+
+  assert exc.value.status_code == status.HTTP_413_REQUEST_ENTITY_TOO_LARGE
+  assert str(MAX_FILE_SIZE_MB) in str(exc.value.detail)
+
+
+async def _assert_size_gate_passed(file_size_bytes: int | None) -> None:
+  """Run the command and assert only that the size gate did not fire.
+
+  The presign path continues into S3 and response construction, which these
+  mocks do not satisfy; any failure past the gate is out of scope here.
+  """
+  try:
+    await _run(file_size_bytes)
+  except HTTPException as exc:
+    assert exc.status_code != status.HTTP_413_REQUEST_ENTITY_TOO_LARGE, (
+      f"size gate rejected {file_size_bytes} bytes but should not have"
+    )
+  except Exception:
+    pass
+
+
+@pytest.mark.asyncio
+async def test_declared_size_at_the_limit_is_allowed_through_the_gate():
+  """Exactly at the cap must pass — ingest-file compares with `>`, so this matches."""
+  await _assert_size_gate_passed(MAX_FILE_SIZE_MB * MB)
+
+
+@pytest.mark.asyncio
+async def test_omitted_size_skips_the_gate():
+  """The field is optional; existing clients that omit it are unaffected."""
+  await _assert_size_gate_passed(None)


### PR DESCRIPTION
## Summary

`GET /v1/graphs/{graph_id}/limits` and `GET /v1/graphs/tiers` advertised a per-tier `max_file_size_gb` of 1/5/10 GB read from `graph.yml`, while the write path rejected anything over a flat `MAX_FILE_SIZE_MB` (100 MB). An XLarge customer was told 10 GB and received a 400 at 100 MB. The published figure is now derived from the constant the write path enforces, so the two cannot drift apart again.

Raising the cap instead was considered and rejected on the evidence: `ingest_file_cmd` reads the whole object into memory to count rows, and does so in the API container, so the published caps were not merely unenforced but unachievable. Upload size is therefore not a tier-scoped limit — the memory consumed belongs to shared API infrastructure, not to the tenant's graph instance — and every tier now publishes the same number. Making the row-count path stream is what would let the cap rise; that is deliberately not in this PR.

## Changes

**`robosystems/config/graph_tier.py`**

- `get_copy_operation_limits` now sets `max_file_size_gb` from `MAX_FILE_SIZE_MB / 1024` and no longer reads it from `graph.yml`. Same treatment `api_rate_multiplier` already had, and for the same reason: a derived value cannot drift from what is enforced.
- `get_available_tiers` resolves `copy_operations` through that accessor instead of passing the raw `graph.yml` block through. **Worth a close look** — this raw passthrough is why the two public surfaces could disagree, so fixing only the `/limits` path would have left half the drift alive.

**`.github/configs/graph.yml`**

- Removed the nine now-dead `max_file_size_gb` entries across production, staging and shared writers, so nobody edits a value that no longer has an effect. The rest of each `copy_operations` block is untouched.

**`robosystems/models/api/graphs/tables.py` · `operations/graph/commands/create_file_upload.py`**

- `FileUploadRequest` gains an optional `file_size_bytes`. When supplied, an over-limit file is refused at presign with a 413 rather than after being pushed to S3 and rejected by `ingest-file`. It is advisory by nature — a caller can under-declare — so the post-upload measurement remains the authoritative check and is unchanged.

**Tests**

- Three new assertions in `tests/config/test_graph_tier_config.py`: published equals enforced, the value is not tier-scoped, and the `/tiers` listing agrees with `/limits`.
- New `tests/operations/graph/commands/test_create_file_upload_size_gate.py` covering over-limit rejection, exactly-at-limit acceptance (`ingest-file` compares with `>`, so the two must agree), and the omitted-field path that existing clients take.
- Two existing assertions in `test_graph_tier_config.py` were asserting the old behaviour — that `graph.yml`'s value wins — and now assert it is deliberately ignored.

## Breaking Changes

No schema or contract break. Two things reviewers should still see explicitly:

- **A published value changes.** `max_file_size_gb` goes from 1.0 / 5.0 / 10.0 per tier to `0.09765625` on every tier, on two public endpoints. No capability is lost — nothing could exceed 100 MB before this PR either — but the number customers read is now much smaller, and any published material quoting the old figures is now wrong.
- **`FileUploadRequest` is stable-tier surface.** `robosystems-integration-template/src/integration/emit/graph.py` imports it for the emit path. The added field is optional with a default, so `from_dict` on a payload lacking the key is unaffected and no coordinated client major is required. It is an additive change: an SDK regen opportunity, not a break.

## Testing

`just test-all` — green: **12,808 passed, 23 skipped, 101 deselected**, plus lint, format, typecheck and cf-lint all clean.

Also verified the resulting values directly: all three tiers report `max_file_size_gb = 0.09765625` (100 MB) from both `get_copy_operation_limits` and `get_available_tiers`.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
