### PR TITLE
chore(billing): retention for graph_usage, stop promising SSE progress

### DIFF
--- a/robosystems/dagster/jobs/billing.py
+++ b/robosystems/dagster/jobs/billing.py
@@ -1175,12 +1175,43 @@ def allocate_user_repository_credits(
   }
 
 
+@op
+def cleanup_old_usage_records(
+  context: OpExecutionContext,
+  db: DatabaseResource,
+  cleanup_result: dict[str, Any],
+) -> dict[str, Any]:
+  """Apply the retention policy to ``graph_usage``.
+
+  ``graph_usage`` is the higher-volume table — a row per AI operation, plus one
+  per active graph per usage-sensor tick — and until now had no reaper at all,
+  while its lower-volume sibling ``graph_credit_transactions`` was pruned every
+  month. `GraphUsage.cleanup_old_records` was written for this and never wired.
+
+  Retention matches that sibling at twelve months, and the default
+  ``keep_monthly_summaries`` drops only the per-call rows: storage snapshots and
+  allocations survive so period rollups stay reproducible.
+  """
+  from robosystems.models.core.graph.graph_usage import GraphUsage
+
+  with db.get_session() as session:
+    result = GraphUsage.cleanup_old_records(session, older_than_days=365)
+
+  context.log.info(
+    f"Usage retention: deleted {result['deleted_records']} records, "
+    f"preserved {result['preserved_summaries']} summaries"
+  )
+
+  return {"usage_cleanup": result, "credit_cleanup": cleanup_result}
+
+
 @job(tags={"dagster/priority": "1", "dagster/max_retries": 3})
 def monthly_credit_allocation_job():
-  """Monthly credit allocation job."""
+  """Monthly credit allocation and retention job."""
   result = allocate_monthly_credits()
   repo_result = allocate_user_repository_credits(result)
-  cleanup_old_credit_transactions(repo_result)
+  cleanup_result = cleanup_old_credit_transactions(repo_result)
+  cleanup_old_usage_records(cleanup_result)
 
 
 @op

--- a/robosystems/models/api/billing/checkout.py
+++ b/robosystems/models/api/billing/checkout.py
@@ -51,6 +51,13 @@ class CheckoutStatusResponse(BaseModel):
     "For repositories, this is the repository slug (e.g., 'sec')",
   )
   operation_id: str | None = Field(
-    None, description="SSE operation ID for monitoring provisioning progress"
+    None,
+    description=(
+      "Always null. Webhook-driven provisioning passes no operation id "
+      "(`_trigger_resource_provisioning` calls `run_graph_provisioning` with "
+      "`operation_id=None`), so there is no SSE stream to follow — poll the "
+      "status endpoint instead. Retained rather than removed because it is on "
+      "a published response shape; wiring it is a feature, not a fix."
+    ),
   )
   error: str | None = Field(None, description="Error message if checkout failed")

--- a/robosystems/routers/billing/checkout.py
+++ b/robosystems/routers/billing/checkout.py
@@ -218,7 +218,12 @@ async def create_checkout_session(
   "/checkout/{session_id}/status",
   response_model=CheckoutStatusResponse,
   summary="Get Checkout Session Status",
-  description="Poll after returning from Stripe Checkout. Status progresses: pending_payment → provisioning → active. When active, resource_id is populated; for graphs, operation_id tracks SSE provisioning progress.",
+  description=(
+    "Poll after returning from Stripe Checkout. Status progresses: "
+    "pending_payment → provisioning → active. When active, resource_id is "
+    "populated. `operation_id` is always null for webhook-driven provisioning "
+    "and cannot be used to follow progress — poll this endpoint instead."
+  ),
   operation_id="getCheckoutStatus",
   responses={**RESOURCE_ERROR_RESPONSES},
 )

--- a/tests/dagster/test_billing_jobs.py
+++ b/tests/dagster/test_billing_jobs.py
@@ -53,7 +53,7 @@ class TestCreditAllocationLogic:
 
   @pytest.mark.unit
   def test_monthly_job_wires_exactly_the_allocation_ops(self):
-    """The monthly job is allocation + repo allocation + cleanup, and nothing else.
+    """The monthly job is allocation + repo allocation + both retention ops.
 
     Asserted as an exact set rather than a lower bound: the previous version
     (`"get_subscriptions_for_allocation" in op_names or len(op_names) >= 1`)
@@ -66,4 +66,45 @@ class TestCreditAllocationLogic:
       "allocate_monthly_credits",
       "allocate_user_repository_credits",
       "cleanup_old_credit_transactions",
+      "cleanup_old_usage_records",
     }
+
+  @pytest.mark.unit
+  def test_usage_retention_is_wired_and_matches_the_credit_ledger_window(self):
+    """`graph_usage` has a reaper, and it keeps the same window as its sibling.
+
+    The table is the higher-volume of the two and had no retention at all while
+    `graph_credit_transactions` was pruned monthly. Divergent windows would make
+    a period rollup reproducible from one table and not the other.
+    """
+    from contextlib import contextmanager
+    from unittest.mock import MagicMock, patch
+
+    from dagster import build_op_context
+
+    from robosystems.dagster.jobs.billing import cleanup_old_usage_records
+
+    session = MagicMock()
+
+    @contextmanager
+    def _session_cm():
+      yield session
+
+    db = MagicMock()
+    db.get_session = _session_cm
+
+    with patch(
+      "robosystems.models.core.graph.graph_usage.GraphUsage.cleanup_old_records",
+      return_value={
+        "deleted_records": 3,
+        "preserved_summaries": 7,
+        "total_processed": 10,
+      },
+    ) as reaper:
+      result = cleanup_old_usage_records(build_op_context(), db, {"prior": "value"})
+
+    reaper.assert_called_once()
+    assert reaper.call_args.kwargs["older_than_days"] == 365
+    assert result["usage_cleanup"]["deleted_records"] == 3
+    # The prior op's result is threaded through — it is the job's sequencing edge.
+    assert result["credit_cleanup"] == {"prior": "value"}


### PR DESCRIPTION
## Summary

Two remaining items from the billing-surface audit that were worth doing rather than deferring. Stacked on #1162 — merge that first.

Both are the same shape as the parent PR: machinery that was written and never connected, and a published description that promises something the code deliberately does not do.

## Changes

**`graph_usage` gets a retention policy — `dagster/jobs/billing.py`**

- New `cleanup_old_usage_records` op, wired at the tail of `monthly_credit_allocation_job`. It calls `GraphUsage.cleanup_old_records`, which was written for exactly this and had no callers.
- `graph_usage` is the higher-volume of the two usage tables — a row per AI operation, plus one per active graph per usage-sensor tick — and had no reaper at all, while the lower-volume `graph_credit_transactions` was pruned every month.
- Retention is 12 months, matching that sibling, so a period rollup is reproducible from both tables or neither. The default `keep_monthly_summaries` drops only the per-call rows; storage snapshots and allocations survive.
- **Timing is the point.** The fleet's oldest graph is roughly two months old, so this delete matches zero rows today. The policy lands before there is any data a mistake could destroy, which is the cheapest moment to introduce a `DELETE` into a monthly job.

**Stop promising SSE progress that was never wired — `models/api/billing/checkout.py`, `routers/billing/checkout.py`**

- `CheckoutStatusResponse.operation_id` described itself as an "SSE operation ID for monitoring provisioning progress", and the endpoint description told callers it tracks progress. Neither is true and neither ever was: `_trigger_resource_provisioning` calls `run_graph_provisioning` with `operation_id=None`, commented "No SSE tracking for webhook-triggered provisioning". The field is always null, and the two frontend branches gated on it never render.
- Both descriptions now say so and point callers at polling the status endpoint. The field is **retained**, not removed — it is on a published response shape, and wiring it properly is a feature with its own trigger, not a fix that belongs here.

## Breaking Changes

None. No schema change, no migration, no API shape change.

One behaviour change: `monthly_credit_allocation_job` gains a fourth op that issues a `DELETE` against `graph_usage` for rows older than 365 days. As noted above it matches nothing at current fleet age.

Two OpenAPI **description** strings change (`getCheckoutStatus` and the `operation_id` field). Descriptions flow into both generated SDKs on the next regen, but no field, type, or shape changes, so nothing is required of clients.

## Testing

`just test-all` — green: **12,797 passed, 23 skipped, 101 deselected**, plus lint, format, typecheck and cf-lint clean.

New test asserts the reaper is wired, that its window matches the credit-ledger one, and that the prior op's result is threaded through as the job's sequencing edge. The job's op-set assertion was updated to the new exact set.

## Deliberately not included

Collapsing the five duplicated `stripe_invoice_id` lookups onto the orphaned `BillingInvoice.get_by_stripe_invoice_id` was attempted and backed out. The refactor is correct, but 27 tests patch `BillingInvoice` wholesale and mock the lookup at the ORM-chain seam, so moving to the classmethod makes the mock return a truthy `MagicMock` instead of `None`. One test failed outright; the rest would have kept passing while exercising the opposite branch. Auditing all 27 is worth doing when the Stripe↔DB reconciliation job that actually benefits from a single seam is written — not as a drive-by refactor whose failure mode is silent.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
