### PR TITLE
fix(auth): harden passkey enrollment and MFA token redemption

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -16,6 +16,7 @@ env =
     LOG_LEVEL=ERROR
     DATABASE_URL=postgresql://postgres:postgres@localhost:5432/robosystems_test
     TEST_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/robosystems_test
+    EXTENSIONS_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/extensions
     POSTGRES_PASSWORD=postgres
     AWS_ENDPOINT_URL=http://localhost:4566
     AWS_REGION=us-east-1

--- a/robosystems/middleware/auth/README.md
+++ b/robosystems/middleware/auth/README.md
@@ -170,8 +170,12 @@ enforcement without passkeys, or that runs OIDC/SCIM/passkeys with
 ### Passkey MFA (WebAuthn)
 
 `PASSKEYS_ENABLED` turns on the passkey surface: enrollment
-(`/v1/auth/passkeys/register/*`, from settings or the forced-enrollment
-lane), passwordless login (`/v1/auth/passkeys/login/*` — a user-verified
+(`/v1/auth/passkeys/register/*` — the settings lane takes a JWT session
+*plus* a fresh re-auth proof, password or `reauth`-ceremony assertion, and
+refuses API keys outright: a programmatic key must never mint an interactive
+credential that outlives its own revocation; the forced-enrollment lane's
+token is its own freshness proof), passwordless login
+(`/v1/auth/passkeys/login/*` — a user-verified
 discoverable credential is two factors in one gesture), the second-factor
 handshake (`/v1/auth/mfa/options` + `/verify`, driven by the short-lived
 purpose-scoped `mfa_token` that `/v1/auth/login` mints once a passkey
@@ -188,12 +192,14 @@ in `operations/passkeys.py`.
 
 All in `dependencies.py`. Every one of them accepts either credential type —
 JWT is tried first when an `Authorization: Bearer` header is present, otherwise
-the `X-API-Key` header is used.
+the `X-API-Key` header is used — except `get_optional_jwt_user`, which is
+deliberately JWT-only for surfaces that manage sign-in credentials themselves.
 
 | Dependency                                      | Returns | Notes                                                                   |
 | ----------------------------------------------- | ------- | ----------------------------------------------------------------------- |
 | `get_current_user`                              | `User`  | 401 if unauthenticated.                                                 |
 | `get_optional_user`                             | `User \| None` | Never raises for missing credentials.                             |
+| `get_optional_jwt_user`                         | `User \| None` | JWT sessions only — API keys read as anonymous. Passkey enrollment. |
 | `get_current_user_with_graph`                   | `User`  | Reads `graph_id` from the path and validates access.                    |
 | `get_current_user_with_graph_or_url_token`      | `User`  | As above, plus the `?token=` door. MCP only.                            |
 | `get_current_user_sse`                          | `User`  | As `get_current_user`, plus the `?token=` JWT door.                     |

--- a/robosystems/middleware/auth/dependencies.py
+++ b/robosystems/middleware/auth/dependencies.py
@@ -250,6 +250,25 @@ async def get_optional_user(
   return None
 
 
+async def get_optional_jwt_user(request: Request) -> User | None:
+  """Return the JWT-session user, or None — API keys are not accepted.
+
+  For surfaces that manage sign-in credentials themselves (passkey
+  enrollment): a programmatic key must never be able to mint an interactive
+  credential that outlives the key's own revocation.
+  """
+  authorization = request.headers.get("authorization")
+  if not authorization or not authorization.startswith("Bearer "):
+    return None
+
+  device_fingerprint = extract_device_fingerprint(request)
+  verify_result = verify_jwt_claims(authorization[7:], device_fingerprint)
+  if not verify_result:
+    return None
+  user_id, token_session_version = verify_result
+  return _get_user_for_verified_jwt(user_id, token_session_version)
+
+
 async def get_current_user(
   request: Request,
   api_key: str = Security(API_KEY_HEADER),

--- a/robosystems/models/api/passkeys.py
+++ b/robosystems/models/api/passkeys.py
@@ -13,13 +13,35 @@ from .auth import AuthResponse
 
 
 class PasskeyRegisterOptionsRequest(BaseModel):
-  """Begin enrollment. mfa_token is the forced-enrollment lane; omitted for
-  an authenticated settings-flow enrollment."""
+  """Begin enrollment.
+
+  Two disjoint lanes: ``mfa_token`` (forced enrollment — the token was minted
+  seconds after a password verify, so it is its own freshness proof) or an
+  authenticated settings-flow enrollment, which must carry a fresh re-auth
+  proof — ``password``, or a ``reauth``-ceremony ``assertion`` when adding a
+  passkey beside an existing one.
+  """
 
   mfa_token: str | None = Field(
     default=None,
     description="Enrollment token from a login that returned mfa_enrollment_required",
   )
+  password: str | None = Field(
+    default=None,
+    description="Current password — settings-lane re-authentication",
+  )
+  assertion: dict[str, Any] | None = Field(
+    default=None,
+    description="Fresh WebAuthn assertion from the re-auth ceremony (settings lane)",
+  )
+
+  @model_validator(mode="after")
+  def _lanes_are_disjoint(self) -> "PasskeyRegisterOptionsRequest":
+    if self.mfa_token and (self.password or self.assertion):
+      raise ValueError("mfa_token and a re-auth proof are mutually exclusive")
+    if bool(self.password) and bool(self.assertion):
+      raise ValueError("Provide at most one of password or assertion")
+    return self
 
 
 class PasskeyRegisterVerifyRequest(BaseModel):

--- a/robosystems/models/core/user/user_mfa_recovery_code.py
+++ b/robosystems/models/core/user/user_mfa_recovery_code.py
@@ -86,19 +86,23 @@ class UserMfaRecoveryCode(Model):
   def consume(
     cls, user_id: str, code: str, session: Session, auto_commit: bool = True
   ) -> bool:
-    """Mark a matching unused code as used. Returns False when none matches."""
-    row = (
+    """Mark a matching unused code as used. Returns False when none matches.
+
+    A single conditional UPDATE, not select-then-update: concurrent
+    redemptions of the same code race on the row's ``used_at IS NULL``
+    predicate, so exactly one wins.
+    """
+    updated = (
       session.query(cls)
       .filter(
         cls.user_id == user_id,
         cls.code_hash == _hash_code(code),
         cls.used_at.is_(None),
       )
-      .first()
+      .update({"used_at": datetime.now(UTC)}, synchronize_session=False)
     )
-    if row is None:
+    if not updated:
       return False
-    row.used_at = datetime.now(UTC)
     if auto_commit:
       try:
         session.commit()

--- a/robosystems/operations/oidc.py
+++ b/robosystems/operations/oidc.py
@@ -416,9 +416,11 @@ def resolve_oidc_user(
   account, and it accepted an empty-string ``external_id`` as provenance.
   A missing/empty ``binding_value`` never links.
 
-  When ``ENTERPRISE_ORG_ID`` pins the deployment's org, the fallback further
-  requires the matched user to be a member of that org — identities outside
-  the enterprise boundary never link, whatever their email or ``external_id``.
+  When ``ENTERPRISE_ORG_ID`` pins the deployment's org, membership is
+  required on *every* resolution, not only at link time: an identity linked
+  before the org was pinned, or a user since removed from the pinned org,
+  stops resolving. (The fallback additionally checks membership before
+  writing a link, so a refused resolution never leaves one behind.)
 
   The email-match fallback additionally refuses a claim whose ``email`` the
   IdP marked *unverified* (``email_verified: false``). It does not *require*
@@ -463,6 +465,11 @@ def resolve_oidc_user(
       session=session,
     )
     linked = True
+
+  if env.ENTERPRISE_ORG_ID and (
+    OrgUser.get_by_org_and_user(env.ENTERPRISE_ORG_ID, str(user.id), session) is None
+  ):
+    raise OIDCUserNotProvisionedError("No provisioned user for this identity")
 
   if not user.is_active:
     raise OIDCUserInactiveError("User is deactivated")

--- a/robosystems/routers/auth/mfa.py
+++ b/robosystems/routers/auth/mfa.py
@@ -53,47 +53,65 @@ from .utils import require_passkeys_enabled
 
 router = APIRouter()
 
-MFA_MAX_FAILURES = 5
+MFA_MAX_ATTEMPTS = 5
 
 _USED_KEY_PREFIX = "mfa:used:"
-_FAIL_KEY_PREFIX = "mfa:fail:"
+_ATTEMPTS_KEY_PREFIX = "mfa:attempts:"
 
 
 def _mfa_token_burned(jti: str) -> bool:
-  """Whether this token already minted a session or exhausted its retries.
+  """Whether this token already minted a session or exhausted its attempts.
 
-  Fails closed: an unreachable store reads as burned.
+  A cheap read-only pre-check; the authoritative gates are
+  ``_register_mfa_attempt`` (budget) and ``_claim_mfa_token`` (single use),
+  both of which are atomic. Fails closed: an unreachable store reads as
+  burned.
   """
   try:
     client = create_redis_client(ValkeyDatabase.AUTH)
     if client.get(f"{_USED_KEY_PREFIX}{jti}"):
       return True
-    failures = client.get(f"{_FAIL_KEY_PREFIX}{jti}")
-    return failures is not None and int(failures) >= MFA_MAX_FAILURES
+    attempts = client.get(f"{_ATTEMPTS_KEY_PREFIX}{jti}")
+    return attempts is not None and int(attempts) >= MFA_MAX_ATTEMPTS
   except Exception as exc:
     logger.error(f"Failed to read MFA token state: {exc}")
     return True
 
 
-def _mark_mfa_token_used(jti: str) -> None:
+def _claim_mfa_token(jti: str) -> bool:
+  """Atomically claim this token's one session mint (SET NX).
+
+  Called after factor verification and before the session is minted, so
+  concurrent redemptions of the same token race on the claim, not on the
+  mint. Fails closed: if the store cannot confirm the claim, no session.
+  """
   try:
     client = create_redis_client(ValkeyDatabase.AUTH)
-    client.setex(f"{_USED_KEY_PREFIX}{jti}", MFA_TOKEN_EXPIRY_SECONDS, "1")
+    return bool(
+      client.set(f"{_USED_KEY_PREFIX}{jti}", "1", nx=True, ex=MFA_TOKEN_EXPIRY_SECONDS)
+    )
   except Exception as exc:
-    # The token still dies at its 5-minute exp; losing single-use narrowing
-    # is logged, not fatal.
-    logger.error(f"Failed to mark MFA token used: {exc}")
+    logger.error(f"Failed to claim MFA token: {exc}")
+    return False
 
 
-def _record_mfa_failure(jti: str) -> None:
+def _register_mfa_attempt(jti: str) -> bool:
+  """Count a verification attempt up front; False once the budget is spent.
+
+  Increment-then-check, so concurrent requests cannot all observe a
+  below-budget counter. Fails closed: an unreachable store refuses the
+  attempt.
+  """
   try:
     client = create_redis_client(ValkeyDatabase.AUTH)
-    key = f"{_FAIL_KEY_PREFIX}{jti}"
+    key = f"{_ATTEMPTS_KEY_PREFIX}{jti}"
     count = client.incr(key)
     if count == 1:
       client.expire(key, MFA_TOKEN_EXPIRY_SECONDS)
+    return int(count) <= MFA_MAX_ATTEMPTS
   except Exception as exc:
-    logger.error(f"Failed to record MFA failure: {exc}")
+    logger.error(f"Failed to record MFA attempt: {exc}")
+    return False
 
 
 def _invalid_mfa_token() -> HTTPException:
@@ -162,13 +180,13 @@ def _apply_login_preamble(
 
 
 def _record_verify_failure(
-  jti: str,
   user: User,
   client_ip: str | None,
   user_agent: str | None,
   reason: str,
 ) -> None:
-  _record_mfa_failure(jti)
+  # The attempt itself was already counted at the top of the handler
+  # (increment-then-check); this records the IP/audit consequences.
   if client_ip:
     AdvancedAuthProtection.record_auth_attempt(
       ip_address=client_ip,
@@ -265,6 +283,8 @@ async def verify_mfa(
     fastapi_request, response, "/v1/auth/mfa/verify"
   )
   user, jti = _resolve_mfa_principal(request.mfa_token, "login", session)
+  if not _register_mfa_attempt(jti):
+    raise _invalid_mfa_token()
 
   if request.assertion is not None:
     auth_method = "password+passkey"
@@ -277,7 +297,7 @@ async def verify_mfa(
         expected_jti=jti,
       )
     except passkey_ops.PasskeyError as exc:
-      _record_verify_failure(jti, user, client_ip, user_agent, type(exc).__name__)
+      _record_verify_failure(user, client_ip, user_agent, type(exc).__name__)
       raise HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
         detail="MFA verification failed",
@@ -287,7 +307,7 @@ async def verify_mfa(
     try:
       passkey_ops.consume_recovery_code(session, user, request.recovery_code or "")
     except passkey_ops.RecoveryCodeInvalidError:
-      _record_verify_failure(jti, user, client_ip, user_agent, "recovery_code_invalid")
+      _record_verify_failure(user, client_ip, user_agent, "recovery_code_invalid")
       raise HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
         detail="MFA verification failed",
@@ -303,7 +323,10 @@ async def verify_mfa(
       risk_level="medium",
     )
 
-  _mark_mfa_token_used(jti)
+  if not _claim_mfa_token(jti):
+    # Someone else redeemed this token between our factor verification and
+    # now — one token, one session, whoever claims first.
+    raise _invalid_mfa_token()
   device_fingerprint = extract_device_fingerprint(fastapi_request)
   jwt_token = create_jwt_token(str(user.id), device_fingerprint, session=session)
 

--- a/robosystems/routers/auth/passkeys.py
+++ b/robosystems/routers/auth/passkeys.py
@@ -1,8 +1,10 @@
 """Passkey lifecycle and passwordless login endpoints.
 
-Enrollment accepts two principals: an authenticated session (the settings
-flow) or an ``enroll``-purpose MFA token (the forced-enrollment lane, where
-the login refused to mint a session until a passkey exists). Purpose scoping
+Enrollment accepts two principals: a JWT session plus a fresh re-auth proof
+(the settings flow — API keys are refused, and the session alone is not
+enough to mint a new sign-in credential), or an ``enroll``-purpose MFA token
+(the forced-enrollment lane, where the login refused to mint a session until
+a passkey exists — the token itself is the freshness proof). Purpose scoping
 keeps the lanes disjoint — an enroll token can never satisfy ``/mfa/verify``
 and a login token can never authorize enrollment.
 """
@@ -22,7 +24,7 @@ from sqlalchemy.orm import Session
 
 from ...database import get_async_db_session
 from ...logger import logger
-from ...middleware.auth.dependencies import get_current_user, get_optional_user
+from ...middleware.auth.dependencies import get_current_user, get_optional_jwt_user
 from ...middleware.auth.jwt import create_jwt_token
 from ...middleware.otel.metrics import endpoint_metrics_decorator, record_auth_metrics
 from ...middleware.rate_limits import (
@@ -54,7 +56,7 @@ from ...security.device_fingerprinting import extract_device_fingerprint
 from .mfa import (
   _apply_login_preamble,
   _authenticated_response,
-  _mark_mfa_token_used,
+  _claim_mfa_token,
   _resolve_mfa_principal,
 )
 from .utils import detect_app_source, require_passkeys_enabled
@@ -96,7 +98,11 @@ def _resolve_enrollment_principal(
   "/passkeys/register/options",
   response_model=CeremonyOptionsResponse,
   summary="Passkey Registration Options",
-  description="Begin a passkey enrollment ceremony.",
+  description=(
+    "Begin a passkey enrollment ceremony. The settings lane requires a fresh "
+    "re-auth proof (password or assertion); the forced lane presents its "
+    "enrollment token."
+  ),
   operation_id="getPasskeyRegistrationOptions",
   responses={
     **COMMON_ERROR_RESPONSES,
@@ -105,12 +111,34 @@ def _resolve_enrollment_principal(
 )
 async def get_registration_options(
   request: PasskeyRegisterOptionsRequest,
+  fastapi_request: Request,
   session: Session = Depends(get_async_db_session),
-  session_user: User | None = Depends(get_optional_user),
+  session_user: User | None = Depends(get_optional_jwt_user),
   rate_limit: None = Depends(mfa_rate_limit_dependency),
   _passkeys: None = Depends(require_passkeys_enabled),
 ) -> CeremonyOptionsResponse:
-  user, _jti = _resolve_enrollment_principal(session_user, request.mfa_token, session)
+  user, jti = _resolve_enrollment_principal(session_user, request.mfa_token, session)
+  if jti is None:
+    # Settings lane: a session alone must not mint a new sign-in credential —
+    # demand a fresh proof, exactly as passkey removal does. The forced lane
+    # needs none; its token was minted seconds after a password verify.
+    try:
+      passkey_ops.verify_reauth(
+        session, user, password=request.password, assertion=request.assertion
+      )
+    except passkey_ops.ReauthInvalidError:
+      client_ip = fastapi_request.client.host if fastapi_request.client else None
+      if client_ip:
+        AdvancedAuthProtection.record_auth_attempt(
+          ip_address=client_ip,
+          success=False,
+          email=str(user.email),
+          user_agent=fastapi_request.headers.get("user-agent"),
+        )
+      raise HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Re-authentication failed",
+      )
   options = passkey_ops.begin_registration(session, user)
   return CeremonyOptionsResponse(options=json.loads(options.options_json))
 
@@ -138,7 +166,7 @@ async def verify_registration(
   fastapi_request: Request,
   background_tasks: BackgroundTasks,
   session: Session = Depends(get_async_db_session),
-  session_user: User | None = Depends(get_optional_user),
+  session_user: User | None = Depends(get_optional_jwt_user),
   rate_limit: None = Depends(mfa_rate_limit_dependency),
   _passkeys: None = Depends(require_passkeys_enabled),
 ) -> PasskeyRegisterVerifyResponse:
@@ -194,7 +222,13 @@ async def verify_registration(
 
   auth: AuthResponse | None = None
   if jti is not None:
-    _mark_mfa_token_used(jti)
+    if not _claim_mfa_token(jti):
+      # The passkey enrolled, but this token's one session already minted —
+      # the user signs in again and is challenged with the new credential.
+      raise HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Invalid or expired MFA token",
+      )
     device_fingerprint = extract_device_fingerprint(fastapi_request)
     jwt_token = create_jwt_token(str(user.id), device_fingerprint, session=session)
     if client_ip:

--- a/tests/operations/test_oidc.py
+++ b/tests/operations/test_oidc.py
@@ -503,9 +503,10 @@ class TestResolveOidcUser:
     assert resolution.user.id == user.id
     assert resolution.linked is True
 
-  def test_org_boundary_ignores_established_identity(self, test_db):
-    """The boundary gates LINKING only: an already-linked identity resolves
-    regardless (SCIM deactivation is the offboarding control there)."""
+  def test_org_boundary_refuses_established_nonmember_identity(self, test_db):
+    """The boundary gates every resolution, not only linking: an identity
+    linked before the org was pinned — or whose user was since removed from
+    the pinned org — stops resolving, whatever SCIM thinks of ``is_active``."""
     org = Org.create(
       name="Pinned Enterprise 3", org_type=OrgType.ENTERPRISE, session=test_db
     )
@@ -519,8 +520,30 @@ class TestResolveOidcUser:
     )
 
     with patch.object(env, "ENTERPRISE_ORG_ID", str(org.id)):
+      with pytest.raises(OIDCUserNotProvisionedError):
+        resolve_oidc_user(
+          test_db, issuer=ISSUER, subject="okta|sub-ob3", email=user.email
+        )
+
+  def test_org_boundary_resolves_established_member_identity(self, test_db):
+    org = Org.create(
+      name="Pinned Enterprise 4", org_type=OrgType.ENTERPRISE, session=test_db
+    )
+    user = _create_user(test_db, external_id="okta|sub-ob4")
+    OrgUser.create(
+      org_id=str(org.id), user_id=str(user.id), role=OrgRole.MEMBER, session=test_db
+    )
+    UserIdentity.create(
+      user_id=str(user.id),
+      issuer=ISSUER,
+      subject="okta|sub-ob4",
+      email_at_link=user.email,
+      session=test_db,
+    )
+
+    with patch.object(env, "ENTERPRISE_ORG_ID", str(org.id)):
       resolution = resolve_oidc_user(
-        test_db, issuer=ISSUER, subject="okta|sub-ob3", email=user.email
+        test_db, issuer=ISSUER, subject="okta|sub-ob4", email=user.email
       )
     assert resolution.user.id == user.id
     assert resolution.linked is False

--- a/tests/routers/auth/test_login_mfa.py
+++ b/tests/routers/auth/test_login_mfa.py
@@ -56,6 +56,12 @@ class _FakeRedis:
   def expire(self, key, ttl):
     return True
 
+  def set(self, key, value, nx=False, ex=None):
+    if nx and key in self.store:
+      return None
+    self.store[key] = str(value)
+    return True
+
 
 @contextmanager
 def _fake_auth_valkey():
@@ -68,6 +74,50 @@ def _fake_auth_valkey():
     ),
   ):
     yield fake
+
+
+class TestAtomicTokenPrimitives:
+  """The two authoritative gates are atomic and fail closed.
+
+  Concurrent redemptions race on SET NX (one winner), and the attempt
+  budget increments before checking, so parallel requests cannot all
+  observe a below-budget counter.
+  """
+
+  def test_claim_is_single_winner(self):
+    from robosystems.routers.auth import mfa as mfa_router
+
+    with _fake_auth_valkey():
+      assert mfa_router._claim_mfa_token("jti-1") is True
+      assert mfa_router._claim_mfa_token("jti-1") is False
+
+  def test_claim_fails_closed_when_store_unreachable(self):
+    from robosystems.routers.auth import mfa as mfa_router
+
+    with patch(
+      "robosystems.routers.auth.mfa.create_redis_client",
+      side_effect=ConnectionError("down"),
+    ):
+      assert mfa_router._claim_mfa_token("jti-2") is False
+
+  def test_attempt_budget_counts_before_checking(self):
+    from robosystems.routers.auth import mfa as mfa_router
+
+    with _fake_auth_valkey():
+      results = [
+        mfa_router._register_mfa_attempt("jti-3")
+        for _ in range(mfa_router.MFA_MAX_ATTEMPTS + 2)
+      ]
+    assert results == [True] * mfa_router.MFA_MAX_ATTEMPTS + [False, False]
+
+  def test_attempt_fails_closed_when_store_unreachable(self):
+    from robosystems.routers.auth import mfa as mfa_router
+
+    with patch(
+      "robosystems.routers.auth.mfa.create_redis_client",
+      side_effect=ConnectionError("down"),
+    ):
+      assert mfa_router._register_mfa_attempt("jti-4") is False
 
 
 def _create_user(session, *, with_org_role=None):

--- a/tests/routers/auth/test_passkeys.py
+++ b/tests/routers/auth/test_passkeys.py
@@ -52,6 +52,12 @@ class _FakeRedis:
   def expire(self, key, ttl):
     return True
 
+  def set(self, key, value, nx=False, ex=None):
+    if nx and key in self.store:
+      return None
+    self.store[key] = str(value)
+    return True
+
 
 @contextmanager
 def _passkeys_on():
@@ -102,9 +108,11 @@ def _verified_registration(credential_id_b64: str):
 
 
 def _enroll_via_api(client, user, name="My Key"):
-  """Full settings-lane ceremony through the HTTP surface."""
+  """Full settings-lane ceremony through the HTTP surface (password re-auth)."""
   options_resp = client.post(
-    "/v1/auth/passkeys/register/options", json={}, headers=_bearer(user)
+    "/v1/auth/passkeys/register/options",
+    json={"password": PASSWORD},
+    headers=_bearer(user),
   )
   assert options_resp.status_code == 200
   options = options_resp.json()["options"]
@@ -143,14 +151,55 @@ class TestSettingsEnrollment:
 
   def test_anonymous_enrollment_refused(self, client, test_db):
     with _passkeys_on():
-      resp = client.post("/v1/auth/passkeys/register/options", json={})
+      resp = client.post(
+        "/v1/auth/passkeys/register/options", json={"password": PASSWORD}
+      )
+    assert resp.status_code == 401
+
+  def test_session_without_reauth_proof_refused(self, client, test_db):
+    """A live session alone must not begin enrollment — fresh proof required."""
+    user = _create_user(test_db)
+    with _passkeys_on():
+      resp = client.post(
+        "/v1/auth/passkeys/register/options", json={}, headers=_bearer(user)
+      )
+    assert resp.status_code == 401
+
+  def test_wrong_password_refused(self, client, test_db):
+    user = _create_user(test_db)
+    with _passkeys_on():
+      resp = client.post(
+        "/v1/auth/passkeys/register/options",
+        json={"password": "not-the-password"},
+        headers=_bearer(user),
+      )
+    assert resp.status_code == 401
+
+  def test_api_key_cannot_enroll(self, client, test_db):
+    """A programmatic key is not an enrollment principal, even knowing the
+    password — it must never mint an interactive credential that outlives
+    its own revocation."""
+    from robosystems.models.core import UserAPIKey
+
+    user = _create_user(test_db)
+    _row, plaintext = UserAPIKey.create(
+      user_id=str(user.id), name="leaked", session=test_db
+    )
+    with _passkeys_on():
+      resp = client.post(
+        "/v1/auth/passkeys/register/options",
+        json={"password": PASSWORD},
+        headers={"X-API-Key": plaintext},
+      )
     assert resp.status_code == 401
 
   def test_options_carry_rp_and_uv(self, client, test_db):
     user = _create_user(test_db)
     with _passkeys_on():
       resp = client.post(
-        "/v1/auth/passkeys/register/options", json={}, headers=_bearer(user)
+        "/v1/auth/passkeys/register/options",
+        json={"password": PASSWORD},
+        headers=_bearer(user),
       )
     options = resp.json()["options"]
     assert options["rp"]["id"] == "localhost"


### PR DESCRIPTION
## Summary

Post-merge hardening for the passkey MFA surface (#1160) and the SSO org boundary, from an internal security review. The whole surface is still dark behind `PASSKEYS_ENABLED` and has not shipped, so this lands before anything is enabled. Detailed dispositions: `specs/security/mfa-2fa.md` (vault).

## Changes

- **Passkey enrollment (`routers/auth/passkeys.py`, `middleware/auth/dependencies.py`, `models/api/passkeys.py`)** — the settings lane now authenticates with a JWT session only (new `get_optional_jwt_user` dependency; API keys read as anonymous on this surface) and requires a fresh re-auth proof — current password or a `reauth`-ceremony assertion — mirroring what passkey removal already required. The forced-enrollment lane is unchanged; its token is its own freshness proof.
- **OIDC resolution (`operations/oidc.py`)** — when `ENTERPRISE_ORG_ID` pins the deployment's org, membership is now required on every resolution, not only when a new identity link is created.
- **MFA token redemption (`routers/auth/mfa.py`, `models/core/user/user_mfa_recovery_code.py`)** — the single-use gate is an atomic SET NX claim taken before the session mints, the attempt budget increments before checking, recovery-code consumption is a single conditional UPDATE, and all three fail closed on store errors.
- **Tests** — atomic-primitive unit tests, enrollment principal/proof matrix (including the API-key and no-proof refusals), and the org-boundary tests now assert membership on both resolution paths.
- Ride-along: `pytest.ini` gains `EXTENSIONS_DATABASE_URL` in the test environment.

## Breaking Changes

None for the published SDKs. The new `password`/`assertion` fields on the enrollment options request are additive (generated tier — a client minor picks them up on the next regen). Behaviorally, settings-lane enrollment now demands a re-auth proof, so robosystems-app's PasskeysCard needs the matching prompt before `PASSKEYS_ENABLED` turns on anywhere — that frontend change is the follow-up, sequenced ahead of any flag flip.

## Testing

- `just test-all`: 11,285 passed (one unrelated, order-flaky materialization test errored in a second run; it passes 3/3 in isolation and the first full run was green).
- Full auth/OIDC/SCIM/passkey surface (577 tests) green; ruff, format, and basedpyright clean on all touched files.
- `/security-review` on the branch: no findings at threshold.
