### PR TITLE
fix(scim): RFC 7644 error envelopes and PUT profile updates

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,6 +11,7 @@ from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from importlib.metadata import version as pkg_version
 from pathlib import Path
+from typing import Any
 
 from fastapi import FastAPI, Request, status
 from fastapi.exceptions import RequestValidationError
@@ -410,6 +411,19 @@ def create_app() -> FastAPI:
   # produce a string-detail response. Two shapes for one status code
   # break SDK response parsers (e.g., openapi-python-client). This handler
   # makes 422 consistently use the `ErrorResponse` shape.
+  def _scim_envelope(detail: Any, status_code: int) -> dict[str, Any]:
+    """RFC 7644 §3.12 error body. A dict that already carries ``schemas``
+    passes through verbatim; anything else is wrapped."""
+    from robosystems.models.api.scim import ERROR_SCHEMA
+
+    if isinstance(detail, dict) and detail.get("schemas"):
+      return detail
+    return {
+      "schemas": [ERROR_SCHEMA],
+      "detail": str(detail),
+      "status": str(status_code),
+    }
+
   @app.exception_handler(RequestValidationError)
   async def request_validation_handler(
     request: Request, exc: RequestValidationError
@@ -422,6 +436,12 @@ def create_app() -> FastAPI:
       msg = err.get("msg", "validation error")
       parts.append(f"{loc}: {msg}" if loc else msg)
     detail = "; ".join(parts) or "Request validation failed"
+    # SCIM clients parse only the RFC 7644 error envelope, and the RFC maps
+    # malformed requests to 400 invalidValue, not FastAPI's 422 shape.
+    if request.url.path.startswith("/scim/v2"):
+      body = _scim_envelope(detail, status.HTTP_400_BAD_REQUEST)
+      body["scimType"] = "invalidValue"
+      return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content=body)
     return JSONResponse(
       status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
       content={
@@ -435,12 +455,20 @@ def create_app() -> FastAPI:
   # `{"detail": <whatever-was-passed>}` shape and add `request_id` for
   # correlation. Detail may be a string (most common) or a dict (close-period
   # blockers, graph_limit, etc.); callers parse it as `response["detail"]`
-  # in both cases, so always wrap — never spread.
+  # in both cases, so always wrap — never spread. The one exception is the
+  # SCIM surface: IdPs parse the RFC 7644 envelope at the top level, so
+  # nesting it under "detail" makes every error unreadable to them.
   @app.exception_handler(StarletteHTTPException)
   async def http_exception_handler(
     request: Request, exc: StarletteHTTPException
   ) -> JSONResponse:
     request_id = getattr(request.state, "request_id", None)
+    if request.url.path.startswith("/scim/v2"):
+      return JSONResponse(
+        status_code=exc.status_code,
+        content=_scim_envelope(exc.detail, exc.status_code),
+        headers=getattr(exc, "headers", None),
+      )
     return JSONResponse(
       status_code=exc.status_code,
       content={"detail": exc.detail, "request_id": request_id},

--- a/robosystems/config/openapi_tags.py
+++ b/robosystems/config/openapi_tags.py
@@ -27,6 +27,10 @@ MAIN_API_TAGS = [
     "description": "🌳 Subgraphs - List and inspect subgraph databases",
   },
   {
+    "name": "Graph Members",
+    "description": "🧑‍🤝‍🧑 Graph members - Manage per-graph member access and roles",
+  },
+  {
     "name": "Backup",
     "description": "💾 Backup - List, download, and inspect graph backups",
   },

--- a/robosystems/routers/scim/users.py
+++ b/robosystems/routers/scim/users.py
@@ -11,6 +11,7 @@ import re
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, Query, Request, status
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from ...config import env
@@ -289,25 +290,65 @@ async def get_user(request: Request, user_id: str) -> ScimUserResource:
 async def replace_user(
   request: Request, user_id: str, body: ScimUserCreateRequest
 ) -> ScimUserResource:
+  """Replace the profile: name, userName/email, externalId, active.
+
+  An email change in the IdP must propagate here, or a user renamed before
+  their first OIDC sign-in can never link (the binding fallback matches on
+  email). Deliberately narrower than RFC 7644's replace-everything: an
+  attribute *absent* from the payload is left alone rather than cleared —
+  blanking ``external_id`` would erase the SCIM provenance the OIDC binding
+  fallback keys on.
+  """
   org_id = request.state.scim_org_id
   session = next(get_db_session())
   try:
     user = _org_user_or_404(org_id, user_id, session)
 
-    new_name = None
+    updates: dict[str, Any] = {}
+
     if body.name:
       new_name = body.name.formatted or " ".join(
         p for p in [body.name.given_name, body.name.family_name] if p
       )
-    if new_name and new_name != user.name:
-      user.update(session, name=new_name)
+      if new_name and new_name != user.name:
+        updates["name"] = new_name
+
+    new_email = (body.user_name or "").strip().lower()
+    if new_email and new_email != str(user.email).lower():
+      existing = User.get_by_email(new_email, session)
+      if existing is not None and str(existing.id) != str(user.id):
+        raise _scim_error(
+          status.HTTP_409_CONFLICT,
+          "userName is already in use",
+          scim_type="uniqueness",
+        )
+      updates["email"] = new_email
+
+    if body.external_id and body.external_id != user.external_id:
+      updates["external_id"] = body.external_id
+
+    if updates:
+      try:
+        user.update(session, **updates)
+      except IntegrityError:
+        # Pre-checked above; this is the concurrent-writer window.
+        session.rollback()
+        raise _scim_error(
+          status.HTTP_409_CONFLICT,
+          "userName is already in use",
+          scim_type="uniqueness",
+        )
 
     _set_active(user, bool(body.active), org_id, session)
 
     SecurityAuditLogger.log_security_event(
       event_type=SecurityEventType.SCIM_USER_UPDATED,
       user_id=str(user.id),
-      details={"action": "scim_user_updated", "org_id": org_id},
+      details={
+        "action": "scim_user_updated",
+        "org_id": org_id,
+        "fields": sorted(updates),
+      },
       risk_level="low",
     )
     session.refresh(user)

--- a/tests/routers/scim/test_scim_users.py
+++ b/tests/routers/scim/test_scim_users.py
@@ -56,7 +56,7 @@ class TestScimAuth:
   def test_no_token_is_401_scim_envelope(self, client):
     resp = client.get("/scim/v2/Users")
     assert resp.status_code == 401
-    body = resp.json()["detail"]
+    body = resp.json()
     assert "urn:ietf:params:scim:api:messages:2.0:Error" in body["schemas"]
 
   def test_bogus_token_is_401(self, client):
@@ -126,7 +126,7 @@ class TestUsersCrud:
       json={"userName": f"noext+{uuid.uuid4().hex[:8]}@customer.example"},
     )
     assert resp.status_code == 400
-    body = resp.json()["detail"]
+    body = resp.json()
     assert body["scimType"] == "invalidValue"
     assert "externalId" in body["detail"]
 
@@ -140,7 +140,7 @@ class TestUsersCrud:
       },
     )
     assert resp.status_code == 400
-    assert resp.json()["detail"]["scimType"] == "invalidValue"
+    assert resp.json()["scimType"] == "invalidValue"
 
   def test_duplicate_email_is_409_uniqueness(
     self, client, scim_auth, test_db, enterprise_org
@@ -152,7 +152,7 @@ class TestUsersCrud:
       json={"userName": existing.email, "externalId": "dup"},
     )
     assert resp.status_code == 409
-    assert resp.json()["detail"]["scimType"] == "uniqueness"
+    assert resp.json()["scimType"] == "uniqueness"
 
   def test_filter_by_username_finds_member(
     self, client, scim_auth, test_db, enterprise_org
@@ -182,6 +182,93 @@ class TestUsersCrud:
     resp = client.get(f"/scim/v2/Users/{member.id}", headers=scim_auth)
     assert resp.status_code == 200
     assert resp.json()["id"] == member.id
+
+
+class TestReplaceUser:
+  def test_put_applies_username_email_change(
+    self, client, scim_auth, test_db, enterprise_org
+  ):
+    """An IdP-side email change must propagate, or a user renamed before
+    first OIDC sign-in can never link (the binding fallback matches email)."""
+    member = _make_member(test_db, enterprise_org)
+    new_email = f"renamed+{uuid.uuid4().hex[:8]}@customer.example"
+    resp = client.put(
+      f"/scim/v2/Users/{member.id}",
+      headers=scim_auth,
+      json={"userName": new_email, "externalId": member.external_id, "active": True},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["userName"] == new_email
+    test_db.refresh(member)
+    assert member.email == new_email
+
+  def test_put_email_conflict_is_409_uniqueness(
+    self, client, scim_auth, test_db, enterprise_org
+  ):
+    member = _make_member(test_db, enterprise_org)
+    other = _make_member(test_db, enterprise_org, external_id="okta-ext-2")
+    resp = client.put(
+      f"/scim/v2/Users/{member.id}",
+      headers=scim_auth,
+      json={"userName": other.email, "externalId": member.external_id, "active": True},
+    )
+    assert resp.status_code == 409
+    body = resp.json()
+    assert body["scimType"] == "uniqueness"
+    assert "urn:ietf:params:scim:api:messages:2.0:Error" in body["schemas"]
+    test_db.refresh(member)
+    assert member.email != other.email
+
+  def test_put_applies_external_id_change(
+    self, client, scim_auth, test_db, enterprise_org
+  ):
+    member = _make_member(test_db, enterprise_org)
+    resp = client.put(
+      f"/scim/v2/Users/{member.id}",
+      headers=scim_auth,
+      json={"userName": member.email, "externalId": "okta-rekeyed", "active": True},
+    )
+    assert resp.status_code == 200
+    test_db.refresh(member)
+    assert member.external_id == "okta-rekeyed"
+
+  def test_put_absent_external_id_is_not_cleared(
+    self, client, scim_auth, test_db, enterprise_org
+  ):
+    """Narrower than RFC replace-everything on purpose: blanking external_id
+    would erase the SCIM provenance the OIDC binding fallback keys on."""
+    member = _make_member(test_db, enterprise_org)
+    resp = client.put(
+      f"/scim/v2/Users/{member.id}",
+      headers=scim_auth,
+      json={"userName": member.email, "active": True},
+    )
+    assert resp.status_code == 200
+    test_db.refresh(member)
+    assert member.external_id == "okta-ext"
+
+
+class TestScimErrorEnvelopes:
+  def test_validation_error_is_scim_400_not_fastapi_422(self, client, scim_auth):
+    """A body pydantic rejects must come back as the RFC 7644 envelope —
+    IdPs do not parse FastAPI's 422 shape."""
+    resp = client.post(
+      "/scim/v2/Users", headers=scim_auth, json={"externalId": "no-username"}
+    )
+    assert resp.status_code == 400
+    body = resp.json()
+    assert "urn:ietf:params:scim:api:messages:2.0:Error" in body["schemas"]
+    assert body["scimType"] == "invalidValue"
+    assert body["status"] == "400"
+
+  def test_envelope_is_top_level_with_status_string(self, client):
+    resp = client.get("/scim/v2/Users")
+    assert resp.status_code == 401
+    body = resp.json()
+    assert "urn:ietf:params:scim:api:messages:2.0:Error" in body["schemas"]
+    assert body["status"] == "401"
+    assert "detail" in body
+    assert resp.headers.get("www-authenticate") == "Bearer"
 
 
 class TestOrgScoping:
@@ -220,9 +307,7 @@ class TestOrgScoping:
       pinned = client.get("/scim/v2/Users", headers=scim_auth)
 
     assert stray.status_code == 401
-    assert (
-      "urn:ietf:params:scim:api:messages:2.0:Error" in stray.json()["detail"]["schemas"]
-    )
+    assert "urn:ietf:params:scim:api:messages:2.0:Error" in stray.json()["schemas"]
     assert pinned.status_code == 200
 
 
@@ -338,7 +423,7 @@ class TestDeactivation:
       json={"Operations": [{"op": "replace", "path": "displayName", "value": "X"}]},
     )
     assert resp.status_code == 400
-    assert resp.json()["detail"]["scimType"] == "invalidValue"
+    assert resp.json()["scimType"] == "invalidValue"
     test_db.refresh(member)
     assert member.is_active is True
 


### PR DESCRIPTION
## Summary

Two SCIM 2.0 interoperability fixes from the same internal review that produced #1164, plus a small OpenAPI tag ride-along. IdPs parse the RFC 7644 error envelope at the top level of the response body; ours was nested inside the platform's `{"detail": ...}` wrapper. And `PUT /Users/{id}` silently ignored `userName`/email and `externalId` changes, so an IdP-side email change before a user's first OIDC sign-in left them permanently unable to link.

## Changes

- **`main.py`** — the global HTTPException and validation handlers now special-case `/scim/v2` paths: SCIM errors return the RFC 7644 envelope at the top level (a dict detail already carrying `schemas` passes through verbatim; anything else is wrapped), and body-validation failures return the RFC's `400` `invalidValue` instead of FastAPI's 422 shape.
- **`routers/scim/users.py`** — PUT now applies `userName`/email changes (pre-checked and constraint-backed `409` `uniqueness` on conflict) and `externalId` changes, alongside the existing name/active handling. Deliberately narrower than RFC replace-everything: attributes absent from the payload are left alone rather than cleared, because blanking `external_id` would erase the SCIM provenance the OIDC binding fallback keys on. The audit event now records which fields changed.
- **`config/openapi_tags.py`** — declare the `Graph Members` tag, which rendered undescribed and out of the curated order in Swagger. (Audited the whole registry both directions; this was the only gap — SCIM/admin tags are correctly undeclared because those routers are schema-excluded.)
- **Tests** — envelope assertions moved to the top-level shape (the old tests codified the nested bug), plus new coverage: PUT email change propagates, conflict is `409` `uniqueness`, `externalId` updates, absent `externalId` is not cleared, and validation errors on the SCIM surface come back as SCIM `400`s.

## Breaking Changes

None. The SCIM surface is excluded from the OpenAPI spec, so no SDK surface moves. The error-shape change only affects `/scim/v2` consumers (IdPs), for whom the previous shape was unreadable.

## Testing

- `just test-all`: full suite green (all checks passed).
- SCIM suite: 29 passed, including the six new tests; ruff, format, and basedpyright clean on touched files.
