### PR TITLE
test(security): black-box tenant-isolation harness (R-11)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -230,6 +230,10 @@ SECURITY_AUDIT_ENABLED=false
 
 ## Organization
 # ORG_MEMBER_INVITATIONS_ENABLED=false
+# Test-support only (dev/staging): returns the raw org-invite token in the create
+# response so the tenant-isolation harness can provision a multi-user org. Ignored
+# in production (fail-closed). Do not enable in prod.
+# AUTH_INVITE_TOKEN_IN_RESPONSE=false
 
 ## Graph Operations
 # DIRECT_GRAPH_MATERIALIZATION_ENABLED=true

--- a/justfile
+++ b/justfile
@@ -142,6 +142,11 @@ test-full:
 test-cov:
     uv run pytest --cov=robosystems tests/
 
+# Run the tenant-isolation harness (R-11) against a deployment (default: local stack)
+test-isolation target="http://localhost:8000":
+    TARGET_API_URL={{ target }} uv run pytest tests/security/isolation -m isolation \
+        -o addopts="-v -ra" -s
+
 # Run dbt models and tests for an adapter
 test-dbt adapter tmpdir=`mktemp -d`:
     DBT_DUCKDB_PATH="{{ tmpdir }}/{{ adapter }}.duckdb" uv run dbt build \

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,6 +9,7 @@ markers =
     unit: marks unit tests
     slow: marks tests that take longer to run
     security: marks security-related tests
+    isolation: black-box tenant-isolation harness; skipped unless TARGET_API_URL is set (see tests/security/isolation/)
     real_retry_delay: opts out of the zeroed Graph API client backoff (see tests/graph_api/conftest.py)
 
 env =

--- a/robosystems/config/env.py
+++ b/robosystems/config/env.py
@@ -556,12 +556,13 @@ class EnvConfig:
     "ORG_MEMBER_INVITATIONS_ENABLED",
     get_parameter_value("ORG_MEMBER_INVITATIONS_ENABLED", "false").lower() == "true",
   )
-  # Test-support only. When enabled (and NOT in production), the org-invitation
-  # create response includes the raw invite token, so automated authorization
-  # tests can complete the invite -> register -> role-grant flow without email
-  # interception. Structurally forced off in production by
-  # `expose_invite_token_in_response()` — a credential must never leak from a
-  # prod invitation response even if this var is misconfigured.
+  # Test-support only. When enabled in an explicit non-prod env (see
+  # `expose_invite_token_in_response()`), the org-invitation create response
+  # includes the raw invite token, so automated authorization tests can complete
+  # the invite -> register -> role-grant flow without email interception.
+  # Deliberately a plain env var (not SSM/get_parameter_value like its
+  # neighbors): a credential-exposing flag must not be flippable live in a
+  # running deployment — turning it on requires an env change + redeploy.
   AUTH_INVITE_TOKEN_IN_RESPONSE = get_bool_env("AUTH_INVITE_TOKEN_IN_RESPONSE", False)
   # Organization limits (SSM: /tuning/limits/)
   ORG_GRAPHS_DEFAULT_LIMIT = get_tuning_int(
@@ -1167,12 +1168,14 @@ class EnvConfig:
   def expose_invite_token_in_response(cls) -> bool:
     """Whether to return the raw org-invite token in the create response.
 
-    Test-support only, and structurally impossible in production: even with
-    AUTH_INVITE_TOKEN_IN_RESPONSE set, this returns False whenever
-    is_production() is true, so an invite token can never leak from a prod
-    response regardless of misconfiguration.
+    Test-support only, and fail-closed by design: it requires an *explicit*
+    non-prod environment (dev or staging), not merely "not prod". An
+    unrecognized or misconfigured ENVIRONMENT therefore denies rather than
+    leaks — a credential must never surface from a prod-or-unknown response.
     """
-    return cls.AUTH_INVITE_TOKEN_IN_RESPONSE and not cls.is_production()
+    return cls.AUTH_INVITE_TOKEN_IN_RESPONSE and (
+      cls.is_development() or cls.is_staging()
+    )
 
   @classmethod
   def is_development(cls) -> bool:

--- a/robosystems/config/env.py
+++ b/robosystems/config/env.py
@@ -556,6 +556,13 @@ class EnvConfig:
     "ORG_MEMBER_INVITATIONS_ENABLED",
     get_parameter_value("ORG_MEMBER_INVITATIONS_ENABLED", "false").lower() == "true",
   )
+  # Test-support only. When enabled (and NOT in production), the org-invitation
+  # create response includes the raw invite token, so automated authorization
+  # tests can complete the invite -> register -> role-grant flow without email
+  # interception. Structurally forced off in production by
+  # `expose_invite_token_in_response()` — a credential must never leak from a
+  # prod invitation response even if this var is misconfigured.
+  AUTH_INVITE_TOKEN_IN_RESPONSE = get_bool_env("AUTH_INVITE_TOKEN_IN_RESPONSE", False)
   # Organization limits (SSM: /tuning/limits/)
   ORG_GRAPHS_DEFAULT_LIMIT = get_tuning_int(
     "ORG_GRAPHS_DEFAULT_LIMIT",
@@ -1155,6 +1162,17 @@ class EnvConfig:
   def is_production(cls) -> bool:
     """Check if running in production environment."""
     return cls.ENVIRONMENT.lower() in ["prod", "production"]
+
+  @classmethod
+  def expose_invite_token_in_response(cls) -> bool:
+    """Whether to return the raw org-invite token in the create response.
+
+    Test-support only, and structurally impossible in production: even with
+    AUTH_INVITE_TOKEN_IN_RESPONSE set, this returns False whenever
+    is_production() is true, so an invite token can never leak from a prod
+    response regardless of misconfiguration.
+    """
+    return cls.AUTH_INVITE_TOKEN_IN_RESPONSE and not cls.is_production()
 
   @classmethod
   def is_development(cls) -> bool:

--- a/robosystems/models/api/orgs.py
+++ b/robosystems/models/api/orgs.py
@@ -104,6 +104,15 @@ class OrgInvitationResponse(BaseModel):
   created_at: datetime
   expires_at: datetime
   is_expired: bool
+  token: str | None = Field(
+    default=None,
+    description=(
+      "Test-support only: the raw invite token. Populated ONLY when "
+      "AUTH_INVITE_TOKEN_IN_RESPONSE is enabled in a non-production environment; "
+      "always null in production. Lets automated authorization tests complete "
+      "the invite -> register flow without email interception."
+    ),
+  )
 
 
 class OrgInvitationListResponse(BaseModel):

--- a/robosystems/routers/orgs/invitations.py
+++ b/robosystems/routers/orgs/invitations.py
@@ -187,7 +187,13 @@ async def create_invitation(
     logger.info(
       f"User {current_user.id} invited {email} to org {org_id} as {request.role.value}"
     )
-    return _invitation_response(invitation)
+    response = _invitation_response(invitation)
+    # Test-support only, and never in production (the guard forces it off there):
+    # surface the raw token so automated authorization tests can complete the
+    # invite -> register flow. See env.expose_invite_token_in_response().
+    if env.expose_invite_token_in_response():
+      response.token = raw_token
+    return response
 
   except HTTPException:
     raise

--- a/tests/security/isolation/README.md
+++ b/tests/security/isolation/README.md
@@ -35,9 +35,17 @@ to hand the paid gray-box tester as the scope fixture.
     `/backups`, `/subgraphs`),
   - a Cypher read (`/query/cypher` — the strongest data probe: it reads node
     counts),
-  - REST writes (`update-graph-metadata`, `add-member`),
+  - the `add-member` write, plus the destructive/sensitive **core ops**
+    (`delete-graph`, `materialize`, `change-tier`, `create-backup`,
+    `create-subgraph`, `update-graph-metadata`),
   - MCP (`read-graph-cypher` + `write-graph-cypher` via `/mcp/call-tool`),
-  - GraphQL (`/extensions/{graph_id}/graphql`, flag-gated; access-control probe).
+  - GraphQL (`/extensions/{graph_id}/graphql`): `{ hello }` (access probe) and
+    `{ entity { name } }` (data-leak probe),
+  - the **extensions command surfaces** for both products — roboledger
+    (`build-fact-grid`, `compute-metrics`, `create-event-block`, `create-report`,
+    `close-period`) and roboinvestor (`create-portfolio-block`, `create-security`,
+    `update-portfolio-block`, `delete-security`). Graphs are provisioned with both
+    extensions.
 - **Vertical** — `test_vertical.py`. Privilege escalation within one org
   (viewer ≠ write, member ≠ administer, org-admin = implicit graph admin).
   **Currently provision-skipped** — see the blocker below.

--- a/tests/security/isolation/README.md
+++ b/tests/security/isolation/README.md
@@ -51,9 +51,11 @@ to hand the paid gray-box tester as the scope fixture.
   subgraph id — a distinct access path) and **graph-scoped API keys** (a key
   minted for graph A is denied on `graph_a2`, a second graph the *same user*
   owns, proving the denial is the key's scope and not user access).
-- **Vertical** — `test_vertical.py`. Privilege escalation within one org
-  (viewer ≠ write, member ≠ administer, org-admin = implicit graph admin).
-  **Currently provision-skipped** — see the blocker below.
+- **Vertical** — `test_vertical.py`. Privilege escalation within one org: a graph
+  VIEWER can't write (REST or Cypher), a MEMBER can't administer, and an org ADMIN
+  receives implicit graph ADMIN (derived-privilege positive). Runs when the target
+  has both `ORG_MEMBER_INVITATIONS_ENABLED` and `AUTH_INVITE_TOKEN_IN_RESPONSE` on
+  (see provisioning below); otherwise it skips.
 
 ## The oracle (why a status code isn't enough)
 
@@ -83,12 +85,14 @@ HTTPS from the operator's machine (the whole matrix). The **DB leg** is an SSM
 tunnel used *outside* the matrix only, for teardown-disposal verification and
 provisioning fallback. The harness here uses the API leg exclusively.
 
-## Vertical-axis provisioning blocker (spec OQ1)
+## Vertical-axis provisioning (spec OQ1, resolved)
 
-The vertical axis needs a second principal inside one org. The only way to add
-one is an email invitation, and the **raw invite token is neither returned by
-the API nor recoverable from the DB** (stored as `sha256(token)`; the raw token
-is emailed). So a multi-user org can't be provisioned black-box *or* via the DB
-side channel. Activating the vertical axis needs email interception or a
-test-support seam that surfaces the raw token in a non-prod build. The intended
-matrix is written out (behind the skip) in `test_vertical.py`.
+The vertical axis needs a second principal inside one org, added by email
+invitation — and the **raw invite token is neither returned by the API nor
+recoverable from the DB** (stored as `sha256(token)`; the raw token is emailed).
+Rather than intercept email, this is unblocked by a **test-support seam**:
+`AUTH_INVITE_TOKEN_IN_RESPONSE` (default off) returns the raw token in the
+invitation create response, guarded by `env.expose_invite_token_in_response()`
+which forces it off in production regardless of the flag. Turn it on (plus
+`ORG_MEMBER_INVITATIONS_ENABLED`) in a non-prod target and the axis provisions
+invite → register → grant and runs; leave either off and it skips.

--- a/tests/security/isolation/README.md
+++ b/tests/security/isolation/README.md
@@ -16,7 +16,11 @@ Opt-in — it skips unless `TARGET_API_URL` is set, so it is inert in a normal
 `just test` / CI run:
 
 ```bash
-# against the local stack
+# against the local stack (default), or pass a target
+just test-isolation
+just test-isolation https://staging.api.robosystems.ai
+
+# equivalently, by hand
 TARGET_API_URL=http://localhost:8000 uv run pytest tests/security/isolation -m isolation -s
 
 # the oracle's own unit tests run in the normal suite (no live target)

--- a/tests/security/isolation/README.md
+++ b/tests/security/isolation/README.md
@@ -46,6 +46,11 @@ to hand the paid gray-box tester as the scope fixture.
     `close-period`) and roboinvestor (`create-portfolio-block`, `create-security`,
     `update-portfolio-block`, `delete-security`). Graphs are provisioned with both
     extensions.
+- **Scoping** — `test_scoping.py`. Isolation units finer than the user↔graph
+  pair: **subgraph isolation** (tenant B denied on tenant A's `{parent}_{name}`
+  subgraph id — a distinct access path) and **graph-scoped API keys** (a key
+  minted for graph A is denied on `graph_a2`, a second graph the *same user*
+  owns, proving the denial is the key's scope and not user access).
 - **Vertical** — `test_vertical.py`. Privilege escalation within one org
   (viewer ≠ write, member ≠ administer, org-admin = implicit graph admin).
   **Currently provision-skipped** — see the blocker below.

--- a/tests/security/isolation/README.md
+++ b/tests/security/isolation/README.md
@@ -1,0 +1,81 @@
+# Tenant isolation harness
+
+A **black-box** authorization harness: it provisions real test tenants and
+fires a cross-tenant + privilege-escalation matrix at a *live deployment* over
+HTTP, classifying each response as PASS / LEAK / … . It is the internal,
+repeatable "simulated pentest" for **R-11 (multi-tenant isolation)** — the
+load-bearing claim of the product and, until this, the one HIGH-inherent risk
+never tested by anyone.
+
+Design + rationale: `local/RoboSystems/specs/security/tenant-isolation-harness.md`.
+Execution runbook: `local/RoboSystems/runbooks/simulated-pentest.md`.
+
+## Running it
+
+Opt-in — it skips unless `TARGET_API_URL` is set, so it is inert in a normal
+`just test` / CI run:
+
+```bash
+# against the local stack
+TARGET_API_URL=http://localhost:8000 uv run pytest tests/security/isolation -m isolation -s
+
+# the oracle's own unit tests run in the normal suite (no live target)
+uv run pytest tests/security/isolation/test_oracle.py
+```
+
+A JSON report lands at `.local/isolation-report.json` (override with
+`ISOLATION_REPORT`). That file is the artifact to attach to SOC 2 evidence and
+to hand the paid gray-box tester as the scope fixture.
+
+## What it tests
+
+- **Horizontal (R-11)** — `test_horizontal.py`. A principal in tenant A attempts
+  to read/write tenant B's graph, in **both directions**, across:
+  - REST reads (`/info`, `/schema`, `/members`, `/limits`, `/credits`, `/tables`,
+    `/backups`, `/subgraphs`),
+  - a Cypher read (`/query/cypher` — the strongest data probe: it reads node
+    counts),
+  - REST writes (`update-graph-metadata`, `add-member`),
+  - MCP (`read-graph-cypher` + `write-graph-cypher` via `/mcp/call-tool`),
+  - GraphQL (`/extensions/{graph_id}/graphql`, flag-gated; access-control probe).
+- **Vertical** — `test_vertical.py`. Privilege escalation within one org
+  (viewer ≠ write, member ≠ administer, org-admin = implicit graph admin).
+  **Currently provision-skipped** — see the blocker below.
+
+## The oracle (why a status code isn't enough)
+
+Isolation is judged from **API responses only, never the database**. A status
+code cannot tell a leak from a correctly-scoped empty result, and it passes the
+known real leak shape — a `200` carrying another tenant's `org_name` with empty
+collections. So the verdict compares the attacker's response against what the
+**owner** legitimately sees (the positive control is the truth source):
+
+- **PASS** — attacker denied (401/403/404), or a 2xx that carries no content.
+- **LEAK** — attacker got owner data (identical fingerprint), or *any* content
+  for a graph it doesn't own, or an accepted cross-tenant write.
+- **INVALID** — the owner's own request failed → harness misconfigured, abort;
+  a green run that never proved the owner's access proves nothing.
+- **INCONCLUSIVE** — a 2xx with no content (authz didn't deny but nothing
+  leaked), or a validation-rejected write — worth a human look.
+
+`test_oracle.py` feeds the classifier synthetic **leaks** and asserts it fires —
+including the `org_name` F5 shape — so a green live run (where the attacker is
+always denied and the LEAK path never executes) isn't the only evidence the
+classifier works.
+
+## Connection model (for a prod run)
+
+Two legs, only one is the test — see the runbook. The **API leg** is public
+HTTPS from the operator's machine (the whole matrix). The **DB leg** is an SSM
+tunnel used *outside* the matrix only, for teardown-disposal verification and
+provisioning fallback. The harness here uses the API leg exclusively.
+
+## Vertical-axis provisioning blocker (spec OQ1)
+
+The vertical axis needs a second principal inside one org. The only way to add
+one is an email invitation, and the **raw invite token is neither returned by
+the API nor recoverable from the DB** (stored as `sha256(token)`; the raw token
+is emailed). So a multi-user org can't be provisioned black-box *or* via the DB
+side channel. Activating the vertical axis needs email interception or a
+test-support seam that surfaces the raw token in a non-prod build. The intended
+matrix is written out (behind the skip) in `test_vertical.py`.

--- a/tests/security/isolation/_http.py
+++ b/tests/security/isolation/_http.py
@@ -1,0 +1,75 @@
+"""Black-box HTTP client for the tenant-isolation harness.
+
+Everything here talks to a *deployed* API over HTTP with a credential — no
+imports of application internals, no database access. A `Principal` is a
+labelled credential (an API key plus the identity it belongs to); the
+`Client` issues requests as a given principal against a fixed base URL.
+
+The harness deliberately does not use the typed SDK for the attack matrix:
+it must send arbitrary paths and bodies as an arbitrary principal, including
+requests the SDK would refuse to construct.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import httpx
+
+
+@dataclass
+class Principal:
+  """A labelled credential and the identity it authenticates as."""
+
+  label: str
+  api_key: str
+  user_id: str
+  email: str = ""
+  # graphs this principal legitimately owns/controls, by role label
+  graph_id: str = ""
+  org_id: str = ""
+  jwt: str = field(default="", repr=False)
+
+  def headers(self) -> dict[str, str]:
+    return {"X-API-Key": self.api_key, "Content-Type": "application/json"}
+
+
+class Client:
+  """Issues HTTP requests against a fixed base URL.
+
+  Stateless with respect to auth — every call names the principal (or a raw
+  key / no key) it should run as, so one client drives the whole matrix.
+  """
+
+  def __init__(self, base_url: str, *, timeout: float = 60.0) -> None:
+    self.base_url = base_url.rstrip("/")
+    self._c = httpx.Client(base_url=self.base_url, timeout=timeout)
+
+  def close(self) -> None:
+    self._c.close()
+
+  def request(
+    self,
+    method: str,
+    path: str,
+    *,
+    principal: Principal | None = None,
+    api_key: str | None = None,
+    jwt: str | None = None,
+    json: dict | None = None,
+    params: dict | None = None,
+  ) -> httpx.Response:
+    headers: dict[str, str] = {"Content-Type": "application/json"}
+    if principal is not None:
+      headers["X-API-Key"] = principal.api_key
+    elif api_key is not None:
+      headers["X-API-Key"] = api_key
+    if jwt is not None:
+      headers["Authorization"] = f"Bearer {jwt}"
+    return self._c.request(method, path, headers=headers, json=json, params=params)
+
+  def get(self, path: str, **kw) -> httpx.Response:
+    return self.request("GET", path, **kw)
+
+  def post(self, path: str, **kw) -> httpx.Response:
+    return self.request("POST", path, **kw)

--- a/tests/security/isolation/_oracle.py
+++ b/tests/security/isolation/_oracle.py
@@ -1,0 +1,204 @@
+"""The oracle — classify a cross-tenant response as PASS / LEAK / … .
+
+The load-bearing idea (spec §4): a status code alone cannot tell a leak from
+a correctly-scoped empty result, and it passes the known real leak shape (a
+200 carrying another tenant's `org_name`). So the verdict is computed by
+comparing the attacker's response against what the *owner* legitimately sees
+— the positive control is the truth source. If the owner's own request is
+denied, the run is INVALID and no negative result may be trusted.
+
+Verdicts are derived from API responses only — never from the database.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from enum import Enum
+
+import httpx
+
+
+class Verdict(str, Enum):
+  PASS = "PASS"  # denied, or scoped-empty — no cross-tenant access
+  LEAK = "LEAK"  # attacker reached the victim's resource / write was accepted
+  INVALID = "INVALID"  # positive control failed — harness misconfigured, abort
+  INCONCLUSIVE = "INCONCLUSIVE"  # 4xx that isn't a clean deny — worth a human look
+  ERROR = "ERROR"  # transport error
+
+
+_VOLATILE_KEYS = {
+  "timestamp",
+  "at",
+  "created_at",
+  "createdAt",
+  "request_id",
+  "requestId",
+  "operationId",
+  "operation_id",
+  "trace_id",
+  "expires_in",
+}
+
+
+def _strip_volatile(obj):
+  if isinstance(obj, dict):
+    return {k: _strip_volatile(v) for k, v in obj.items() if k not in _VOLATILE_KEYS}
+  if isinstance(obj, list):
+    return [_strip_volatile(v) for v in obj]
+  return obj
+
+
+# Structural / metadata keys that don't count as tenant content. Anything
+# NOT in this set — e.g. `org_name` — is content, so `{"org_name": "...",
+# "lists": []}` (the publish_lists.py F5 leak shape) is data, not empty.
+_ENVELOPE_KEYS = {
+  "status",
+  "message",
+  "success",
+  "code",
+  "detail",
+  "ok",
+  "count",
+  "total",
+  "page",
+  "page_size",
+  "limit",
+  "offset",
+  "has_more",
+  "error",
+  "errors",
+  "warnings",
+}
+
+
+def _is_empty_data(obj) -> bool:
+  """True when a body carries no tenant content (envelope/metadata only).
+
+  A non-empty scalar under a non-envelope key counts as content — a leaked
+  `org_name` with empty collections must not read as empty.
+  """
+  if obj is None:
+    return True
+  if isinstance(obj, str):
+    return len(obj.strip()) == 0
+  if isinstance(obj, (int, float)):  # a present numeric value is content
+    return False
+  if isinstance(obj, list):
+    return len(obj) == 0
+  if isinstance(obj, dict):
+    for k, v in obj.items():
+      if k in _ENVELOPE_KEYS or k in _VOLATILE_KEYS:
+        continue
+      if not _is_empty_data(v):
+        return False
+    return True
+  return False
+
+
+def body_fingerprint(resp: httpx.Response) -> str:
+  """Stable digest of a response's data content (volatile fields removed)."""
+  try:
+    data = _strip_volatile(resp.json())
+    canonical = json.dumps(data, sort_keys=True, default=str)
+  except Exception:
+    canonical = resp.text
+  return hashlib.sha256(canonical.encode("utf-8", "replace")).hexdigest()[:16]
+
+
+def positive_ok(resp: httpx.Response) -> bool:
+  """The victim's own request must not be denied on its own graph.
+
+  A 2xx (even an empty collection — a fresh graph has no backups/subgraphs)
+  means the endpoint works and the owner has access. A denial *here* means
+  the harness is misconfigured (wrong key or graph_id), so no negative
+  result may be trusted — that is INVALID, not PASS.
+  """
+  return resp.status_code // 100 == 2
+
+
+def has_data(resp: httpx.Response) -> bool:
+  try:
+    return not _is_empty_data(resp.json())
+  except Exception:
+    return bool(resp.text.strip())
+
+
+def classify_read(
+  victim: httpx.Response, attacker: httpx.Response
+) -> tuple[Verdict, str]:
+  """Classify a cross-tenant READ (GET, or a read-only cypher/MCP call).
+
+  The primary assertion is denial: a non-owner must be turned away. When the
+  owner legitimately has data, an identical fingerprint is the definitive
+  leak signal; any data at all for a non-owned graph is a leak; a 2xx with
+  no data still means authz did not deny, which is a finding worth a look.
+  """
+  if not positive_ok(victim):
+    return (
+      Verdict.INVALID,
+      f"positive control failed: owner got {victim.status_code} on own graph",
+    )
+  sc = attacker.status_code
+  if sc in (401, 403, 404):
+    return Verdict.PASS, f"denied ({sc})"
+  if sc // 100 == 2:
+    if has_data(attacker):
+      if has_data(victim) and body_fingerprint(attacker) == body_fingerprint(victim):
+        return Verdict.LEAK, f"identical to owner data ({sc}) — cross-tenant read"
+      return Verdict.LEAK, f"returned data for a non-owned graph ({sc})"
+    return (
+      Verdict.INCONCLUSIVE,
+      f"200 on a non-owned graph, empty ({sc}) — authz did not deny",
+    )
+  return Verdict.INCONCLUSIVE, f"unexpected status {sc}"
+
+
+def classify_graphql(
+  victim: httpx.Response, attacker: httpx.Response
+) -> tuple[Verdict, str]:
+  """Classify a cross-tenant GraphQL probe.
+
+  GraphQL is graph-scoped by URL; `check_graph_access` should run before any
+  resolver. The `{ hello }` probe echoes the *caller's own* email, so the
+  generic read oracle would false-positive (attacker's email != owner's).
+  Here a resolver-level or HTTP denial is PASS; a 200 that still returns
+  data is INCONCLUSIVE — it needs a graph-*data* field to confirm whether
+  the payload is the caller's own echo or the owner's data.
+  """
+  if not positive_ok(victim):
+    return Verdict.INVALID, f"positive control failed: owner got {victim.status_code}"
+  sc = attacker.status_code
+  if sc in (401, 403):
+    return Verdict.PASS, f"denied at HTTP ({sc})"
+  if sc // 100 == 2:
+    try:
+      body = attacker.json()
+    except Exception:
+      return Verdict.INCONCLUSIVE, f"200 non-JSON ({sc})"
+    errors = body.get("errors") or []
+    data = body.get("data")
+    if errors and not data:
+      codes = [(e.get("extensions") or {}).get("code", "") for e in errors]
+      return Verdict.PASS, f"denied at resolver ({sc}): {codes or 'error'}"
+    return (
+      Verdict.INCONCLUSIVE,
+      f"200 with data cross-tenant ({sc}) — confirm caller-echo vs owner data "
+      f"with a graph-data field",
+    )
+  return Verdict.INCONCLUSIVE, f"unexpected status {sc}"
+
+
+def classify_write(attacker: httpx.Response) -> tuple[Verdict, str]:
+  """Classify a cross-tenant WRITE — any acceptance is a leak."""
+  sc = attacker.status_code
+  if sc // 100 == 2:
+    return Verdict.LEAK, f"write accepted cross-tenant ({sc})"
+  if sc in (401, 403, 404):
+    return Verdict.PASS, f"denied ({sc})"
+  if sc in (400, 422):
+    # rejected, but before or after authz? worth confirming authz fires first.
+    return Verdict.INCONCLUSIVE, f"rejected ({sc}) — confirm authz precedes validation"
+  if sc == 429:
+    return Verdict.INCONCLUSIVE, "rate-limited (429) — retry pacing"
+  return Verdict.PASS, f"not accepted ({sc})"

--- a/tests/security/isolation/_oracle.py
+++ b/tests/security/isolation/_oracle.py
@@ -210,4 +210,7 @@ def classify_write(attacker: httpx.Response) -> tuple[Verdict, str]:
     return Verdict.INCONCLUSIVE, f"rejected ({sc}) — confirm authz precedes validation"
   if sc == 429:
     return Verdict.INCONCLUSIVE, "rate-limited (429) — retry pacing"
-  return Verdict.PASS, f"not accepted ({sc})"
+  # Anything else (5xx, 405, …) is not a clean deny. A cross-tenant write that
+  # crashes the endpoint must be flagged for a look, not folded into PASS —
+  # the harness's whole promise is that only a clean deny reads as safe.
+  return Verdict.INCONCLUSIVE, f"unexpected status {sc} — not a clean deny"

--- a/tests/security/isolation/_oracle.py
+++ b/tests/security/isolation/_oracle.py
@@ -155,36 +155,45 @@ def classify_read(
 
 
 def classify_graphql(
-  victim: httpx.Response, attacker: httpx.Response
+  victim: httpx.Response, attacker: httpx.Response, *, data_field: bool = False
 ) -> tuple[Verdict, str]:
   """Classify a cross-tenant GraphQL probe.
 
   GraphQL is graph-scoped by URL; `check_graph_access` should run before any
-  resolver. The `{ hello }` probe echoes the *caller's own* email, so the
-  generic read oracle would false-positive (attacker's email != owner's).
-  Here a resolver-level or HTTP denial is PASS; a 200 that still returns
-  data is INCONCLUSIVE — it needs a graph-*data* field to confirm whether
-  the payload is the caller's own echo or the owner's data.
+  resolver, and denials arrive as HTTP 401/403 or as an HTTP-200 body with
+  `data: null` and an errors array. `data_field=True` marks a query over
+  *graph data* (e.g. `{ entity { name } }`): a non-empty `data` payload for a
+  non-owned graph is then a LEAK. `data_field=False` marks a caller-echo probe
+  (`{ hello }`), where a 200 with data only means authz did not gate the field
+  — INCONCLUSIVE, since the payload is the caller's own identity, not graph data.
   """
   if not positive_ok(victim):
     return Verdict.INVALID, f"positive control failed: owner got {victim.status_code}"
+  if data_field:
+    try:
+      owner_data = victim.json().get("data")
+    except Exception:
+      owner_data = None
+    if _is_empty_data(owner_data):
+      return (
+        Verdict.INVALID,
+        "owner's data-field query returned no data — probe cannot detect a leak",
+      )
   sc = attacker.status_code
   if sc in (401, 403):
     return Verdict.PASS, f"denied at HTTP ({sc})"
   if sc // 100 == 2:
     try:
-      body = attacker.json()
+      data = attacker.json().get("data")
     except Exception:
       return Verdict.INCONCLUSIVE, f"200 non-JSON ({sc})"
-    errors = body.get("errors") or []
-    data = body.get("data")
-    if errors and not data:
-      codes = [(e.get("extensions") or {}).get("code", "") for e in errors]
-      return Verdict.PASS, f"denied at resolver ({sc}): {codes or 'error'}"
+    if _is_empty_data(data):
+      return Verdict.PASS, f"no data ({sc}) — denied at resolver"
+    if data_field:
+      return Verdict.LEAK, f"graph data for a non-owned graph ({sc})"
     return (
       Verdict.INCONCLUSIVE,
-      f"200 with data cross-tenant ({sc}) — confirm caller-echo vs owner data "
-      f"with a graph-data field",
+      f"200 with data ({sc}) — caller-echo field; judge with a graph-data field",
     )
   return Verdict.INCONCLUSIVE, f"unexpected status {sc}"
 

--- a/tests/security/isolation/_provision.py
+++ b/tests/security/isolation/_provision.py
@@ -209,6 +209,84 @@ def create_entity_graph(
   raise TimeoutError(f"graph creation for {owner.label} timed out after {timeout}s")
 
 
+def _invite_and_join(
+  client: Client, owner: Principal, org_role: str, label: str
+) -> Principal | None:
+  """Invite a new user to owner's org at `org_role`, register via the token.
+
+  Requires ORG_MEMBER_INVITATIONS_ENABLED and AUTH_INVITE_TOKEN_IN_RESPONSE
+  (test-support) — returns None if either is off (no token in the response).
+  """
+  email = f"{_unique('iso_' + label)}@example.com"
+  r = client.post(
+    f"/v1/orgs/{owner.org_id}/invitations",
+    principal=owner,
+    json={"email": email, "role": org_role},
+  )
+  if r.status_code != 201:
+    return None
+  token = r.json().get("token")
+  if not token:  # AUTH_INVITE_TOKEN_IN_RESPONSE off — can't complete the flow
+    return None
+
+  password = _make_password()
+  rr = client.post(
+    "/v1/auth/register",
+    json={
+      "name": f"iso {label}",
+      "email": email,
+      "password": password,
+      "invite_token": token,
+    },
+  )
+  if rr.status_code not in (200, 201):
+    return None
+  body = rr.json()
+  user_id = (body.get("user") or {}).get("id", "")
+  jwt = body.get("token") or ""
+  if not jwt:
+    lr = client.post("/v1/auth/login", json={"email": email, "password": password})
+    jwt = lr.json().get("token", "") if lr.status_code == 200 else ""
+  if not jwt:
+    return None
+  key = mint_api_key(client, jwt, f"iso {label} key")
+  return Principal(
+    label=label, api_key=key, user_id=user_id, email=email, org_id=owner.org_id, jwt=jwt
+  )
+
+
+def grant_graph_role(
+  client: Client, admin: Principal, graph_id: str, user_id: str, role: str
+) -> bool:
+  r = client.post(
+    f"/v1/graphs/{graph_id}/members",
+    principal=admin,
+    json={"user_id": user_id, "role": role},
+  )
+  return r.status_code in (200, 201)
+
+
+def provision_role_matrix(
+  client: Client, owner: Principal, graph_a: str
+) -> dict[str, Principal]:
+  """Best-effort viewer/member/admin principals inside owner's org.
+
+  Empty dict if org invitations or the test-support token are off.
+  """
+  roles: dict[str, Principal] = {}
+  viewer = _invite_and_join(client, owner, "member", "viewer")
+  if viewer and grant_graph_role(client, owner, graph_a, viewer.user_id, "viewer"):
+    roles["viewer"] = viewer
+  member = _invite_and_join(client, owner, "member", "member")
+  if member and grant_graph_role(client, owner, graph_a, member.user_id, "member"):
+    roles["member"] = member
+  # org admin receives implicit graph ADMIN — no explicit grant
+  admin = _invite_and_join(client, owner, "admin", "gadmin")
+  if admin:
+    roles["admin"] = admin
+  return roles
+
+
 @dataclass
 class TenantFixture:
   """The provisioned world the matrix runs against."""
@@ -269,4 +347,8 @@ def provision(
     )
   except Exception:
     fx.scoped_key_a = None
+  try:
+    fx.roles = provision_role_matrix(client, a, graph_a)
+  except Exception:
+    fx.roles = {}
   return fx

--- a/tests/security/isolation/_provision.py
+++ b/tests/security/isolation/_provision.py
@@ -92,14 +92,24 @@ def register_principal(client: Client, label: str) -> Principal:
 
 
 def create_entity_graph(
-  client: Client, owner: Principal, *, timeout: float = 180.0, poll: float = 2.0
+  client: Client,
+  owner: Principal,
+  *,
+  schema_extensions: list[str] | None = None,
+  timeout: float = 180.0,
+  poll: float = 2.0,
 ) -> str:
-  """Create an entity graph for `owner` and return its graph_id."""
+  """Create an entity graph for `owner` and return its graph_id.
+
+  `schema_extensions=["roboledger"]` provisions a roboledger tenant so the
+  GraphQL and `/extensions/roboledger/operations/*` surfaces are testable.
+  """
   name = _unique("isograph" + owner.label)
   body = {
     "metadata": {
       "graph_name": name,
       "description": "tenant-isolation harness test graph",
+      "schema_extensions": schema_extensions or [],
       "tags": ["iso-harness", "test"],
     },
     "initial_entity": {
@@ -155,12 +165,21 @@ class TenantFixture:
     return [self.tenant_a, self.tenant_b, *self.roles.values()]
 
 
-def provision(client: Client) -> TenantFixture:
-  """Provision two independent tenants, each with one entity graph."""
+def provision(
+  client: Client, *, schema_extensions: list[str] | None = None
+) -> TenantFixture:
+  """Provision two independent tenants, each with one entity graph.
+
+  Defaults to roboledger graphs so the extensions command surface and the
+  GraphQL data fields are exercised; pass schema_extensions=[] for plain
+  entity graphs.
+  """
+  if schema_extensions is None:
+    schema_extensions = ["roboledger"]
   a = register_principal(client, "A")
   b = register_principal(client, "B")
-  graph_a = create_entity_graph(client, a)
-  graph_b = create_entity_graph(client, b)
+  graph_a = create_entity_graph(client, a, schema_extensions=schema_extensions)
+  graph_b = create_entity_graph(client, b, schema_extensions=schema_extensions)
   a.graph_id = graph_a
   b.graph_id = graph_b
   return TenantFixture(tenant_a=a, tenant_b=b, graph_a=graph_a, graph_b=graph_b)

--- a/tests/security/isolation/_provision.py
+++ b/tests/security/isolation/_provision.py
@@ -1,0 +1,166 @@
+"""Fixture provisioning for the isolation harness — over the API only.
+
+Builds the test tenants the matrix runs against: two independent tenants
+(A and B) for the horizontal / cross-tenant axis, and — within tenant A's
+org — a set of principals at different roles for the vertical axis.
+
+Every tenant is a real account with a real graph, created through the
+public API exactly as a customer would. Nothing here reaches into the
+database; the DB is a side channel used only by the runbook for teardown
+verification, never by the harness.
+
+The provisioning sequence per user is the documented one:
+    register  -> POST /v1/auth/register   (auto-creates an org)
+    login     -> POST /v1/auth/login      (returns a JWT)
+    api key   -> POST /v1/user/api-keys    (returns the key string)
+and per graph:
+    create    -> POST /v1/graphs           (202 OperationEnvelope)
+    poll      -> GET  /v1/operations/{id}/status  until completed
+"""
+
+from __future__ import annotations
+
+import secrets
+import time
+from dataclasses import dataclass, field
+
+from ._http import Client, Principal
+
+_PW = "IsoHarness!" + secrets.token_hex(6) + "Aa1"
+
+
+def _unique(prefix: str) -> str:
+  return f"{prefix}_{int(time.time())}_{secrets.token_hex(3)}"
+
+
+def _find_graph_id(obj) -> str | None:
+  """Recursively locate a graph_id in a free-form operation result."""
+  if isinstance(obj, dict):
+    for k, v in obj.items():
+      if k in ("graph_id", "graphId") and isinstance(v, str) and v:
+        return v
+      found = _find_graph_id(v)
+      if found:
+        return found
+  elif isinstance(obj, list):
+    for item in obj:
+      found = _find_graph_id(item)
+      if found:
+        return found
+  return None
+
+
+def register_principal(client: Client, label: str) -> Principal:
+  """Register a user, log in, mint an API key. Returns a Principal."""
+  email = f"{_unique('iso_' + label)}@example.com"
+  name = f"iso-harness {label}"
+
+  r = client.post(
+    "/v1/auth/register", json={"name": name, "email": email, "password": _PW}
+  )
+  if r.status_code not in (200, 201):
+    raise RuntimeError(f"register({label}) -> {r.status_code}: {r.text[:300]}")
+  body = r.json()
+  user_id = (body.get("user") or {}).get("id", "")
+  org_id = (body.get("org") or {}).get("id", "") if body.get("org") else ""
+
+  # Prefer the token from register; fall back to an explicit login.
+  jwt = body.get("token") or ""
+  if not jwt:
+    lr = client.post("/v1/auth/login", json={"email": email, "password": _PW})
+    if lr.status_code != 200:
+      raise RuntimeError(f"login({label}) -> {lr.status_code}: {lr.text[:300]}")
+    jwt = lr.json().get("token") or ""
+  if not jwt:
+    raise RuntimeError(
+      f"no JWT for {label} (MFA enforced locally? register/login returned "
+      f"mfa_token instead of token)"
+    )
+
+  kr = client.post(
+    "/v1/user/api-keys", jwt=jwt, json={"name": f"iso-harness {label} key"}
+  )
+  if kr.status_code not in (200, 201):
+    raise RuntimeError(f"create_api_key({label}) -> {kr.status_code}: {kr.text[:300]}")
+  key = kr.json().get("key") or ""
+  if not key:
+    raise RuntimeError(f"no api key string returned for {label}: {kr.text[:200]}")
+
+  return Principal(
+    label=label, api_key=key, user_id=user_id, email=email, org_id=org_id, jwt=jwt
+  )
+
+
+def create_entity_graph(
+  client: Client, owner: Principal, *, timeout: float = 180.0, poll: float = 2.0
+) -> str:
+  """Create an entity graph for `owner` and return its graph_id."""
+  name = _unique("isograph" + owner.label)
+  body = {
+    "metadata": {
+      "graph_name": name,
+      "description": "tenant-isolation harness test graph",
+      "tags": ["iso-harness", "test"],
+    },
+    "initial_entity": {
+      "name": f"IsoHarness {owner.label}",
+      "uri": f"https://iso-harness.test/{owner.label}/{name}",
+    },
+    "create_entity": True,
+  }
+  r = client.post("/v1/graphs", principal=owner, json=body)
+  if r.status_code not in (200, 201, 202):
+    raise RuntimeError(
+      f"create_graph({owner.label}) -> {r.status_code}: {r.text[:300]}"
+    )
+  env = r.json()
+
+  gid = _find_graph_id(env.get("result")) or _find_graph_id(env)
+  op_id = env.get("operationId") or env.get("operation_id")
+  if gid:
+    return gid
+  if not op_id:
+    raise RuntimeError(f"no operationId/graph_id in create response: {env}")
+
+  deadline = time.time() + timeout
+  while time.time() < deadline:
+    time.sleep(poll)
+    sr = client.get(f"/v1/operations/{op_id}/status", principal=owner)
+    if sr.status_code != 200:
+      continue
+    st = sr.json()
+    status = str(st.get("status", "")).lower()
+    if status in ("completed", "succeeded", "success"):
+      gid = _find_graph_id(st)
+      if gid:
+        return gid
+      raise RuntimeError(f"operation completed but no graph_id: {st}")
+    if status in ("failed", "error", "cancelled"):
+      raise RuntimeError(f"graph creation failed: {st}")
+  raise TimeoutError(f"graph creation for {owner.label} timed out after {timeout}s")
+
+
+@dataclass
+class TenantFixture:
+  """The provisioned world the matrix runs against."""
+
+  tenant_a: Principal  # owner of graph_a
+  tenant_b: Principal  # owner of graph_b (the cross-tenant victim/target)
+  graph_a: str
+  graph_b: str
+  # vertical-axis principals inside tenant A's org (populated in phase 2)
+  roles: dict[str, Principal] = field(default_factory=dict)
+
+  def all_principals(self) -> list[Principal]:
+    return [self.tenant_a, self.tenant_b, *self.roles.values()]
+
+
+def provision(client: Client) -> TenantFixture:
+  """Provision two independent tenants, each with one entity graph."""
+  a = register_principal(client, "A")
+  b = register_principal(client, "B")
+  graph_a = create_entity_graph(client, a)
+  graph_b = create_entity_graph(client, b)
+  a.graph_id = graph_a
+  b.graph_id = graph_b
+  return TenantFixture(tenant_a=a, tenant_b=b, graph_a=graph_a, graph_b=graph_b)

--- a/tests/security/isolation/_provision.py
+++ b/tests/security/isolation/_provision.py
@@ -66,6 +66,22 @@ def _find_graph_id(obj) -> str | None:
   return None
 
 
+def mint_api_key(
+  client: Client, jwt: str, name: str, *, graph_id: str | None = None
+) -> str:
+  """Mint an API key for the JWT's user. `graph_id` scopes it to one graph."""
+  body: dict = {"name": name}
+  if graph_id:
+    body["graph_id"] = graph_id
+  kr = client.post("/v1/user/api-keys", jwt=jwt, json=body)
+  if kr.status_code not in (200, 201):
+    raise RuntimeError(f"create_api_key({name}) -> {kr.status_code}: {kr.text[:300]}")
+  key = kr.json().get("key") or ""
+  if not key:
+    raise RuntimeError(f"no api key string returned for {name}: {kr.text[:200]}")
+  return key
+
+
 def register_principal(client: Client, label: str) -> Principal:
   """Register a user, log in, mint an API key. Returns a Principal."""
   email = f"{_unique('iso_' + label)}@example.com"
@@ -94,18 +110,44 @@ def register_principal(client: Client, label: str) -> Principal:
       f"mfa_token instead of token)"
     )
 
-  kr = client.post(
-    "/v1/user/api-keys", jwt=jwt, json={"name": f"iso-harness {label} key"}
-  )
-  if kr.status_code not in (200, 201):
-    raise RuntimeError(f"create_api_key({label}) -> {kr.status_code}: {kr.text[:300]}")
-  key = kr.json().get("key") or ""
-  if not key:
-    raise RuntimeError(f"no api key string returned for {label}: {kr.text[:200]}")
-
+  key = mint_api_key(client, jwt, f"iso-harness {label} key")
   return Principal(
     label=label, api_key=key, user_id=user_id, email=email, org_id=org_id, jwt=jwt
   )
+
+
+def create_subgraph(
+  client: Client,
+  owner: Principal,
+  parent_graph_id: str,
+  name: str,
+  *,
+  timeout: float = 180.0,
+  poll: float = 2.0,
+) -> str:
+  """Create a subgraph under `parent_graph_id`; return its `{parent}_{name}` id."""
+  r = client.post(
+    f"/v1/graphs/{parent_graph_id}/operations/create-subgraph",
+    principal=owner,
+    json={"name": name, "display_name": f"iso {name}"},
+  )
+  if r.status_code not in (200, 201, 202):
+    raise RuntimeError(f"create_subgraph -> {r.status_code}: {r.text[:300]}")
+  env = r.json()
+  op_id = env.get("operationId") or env.get("operation_id")
+  if op_id and not _find_graph_id(env.get("result")):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+      time.sleep(poll)
+      sr = client.get(f"/v1/operations/{op_id}/status", principal=owner)
+      if sr.status_code != 200:
+        continue
+      status = str(sr.json().get("status", "")).lower()
+      if status in ("completed", "succeeded", "success"):
+        break
+      if status in ("failed", "error", "cancelled"):
+        raise RuntimeError(f"subgraph creation failed: {sr.json()}")
+  return f"{parent_graph_id}_{name}"
 
 
 def create_entity_graph(
@@ -175,6 +217,10 @@ class TenantFixture:
   tenant_b: Principal  # owner of graph_b (the cross-tenant victim/target)
   graph_a: str
   graph_b: str
+  # scoping extras (best-effort; "" / None if provisioning failed)
+  graph_a2: str = ""  # a second graph A owns — target for scoped-key denial
+  subgraph_a: str = ""  # a subgraph under graph_a — target for cross-tenant probe
+  scoped_key_a: Principal | None = None  # a key scoped to graph_a
   # vertical-axis principals inside tenant A's org (populated in phase 2)
   roles: dict[str, Principal] = field(default_factory=dict)
 
@@ -199,4 +245,28 @@ def provision(
   graph_b = create_entity_graph(client, b, schema_extensions=schema_extensions)
   a.graph_id = graph_a
   b.graph_id = graph_b
-  return TenantFixture(tenant_a=a, tenant_b=b, graph_a=graph_a, graph_b=graph_b)
+  fx = TenantFixture(tenant_a=a, tenant_b=b, graph_a=graph_a, graph_b=graph_b)
+
+  # Scoping extras — best-effort, so the core matrix runs even if these fail.
+  try:
+    fx.graph_a2 = create_entity_graph(client, a, schema_extensions=schema_extensions)
+  except Exception:
+    fx.graph_a2 = ""
+  try:
+    fx.subgraph_a = create_subgraph(client, a, graph_a, "iso" + secrets.token_hex(2))
+  except Exception:
+    fx.subgraph_a = ""
+  try:
+    scoped = mint_api_key(client, a.jwt, "iso-harness A scoped", graph_id=graph_a)
+    fx.scoped_key_a = Principal(
+      label="A-scoped",
+      api_key=scoped,
+      user_id=a.user_id,
+      email=a.email,
+      graph_id=graph_a,
+      org_id=a.org_id,
+      jwt=a.jwt,
+    )
+  except Exception:
+    fx.scoped_key_a = None
+  return fx

--- a/tests/security/isolation/_provision.py
+++ b/tests/security/isolation/_provision.py
@@ -187,9 +187,9 @@ def provision(
 ) -> TenantFixture:
   """Provision two independent tenants, each with one entity graph.
 
-  Defaults to roboledger graphs so the extensions command surface and the
-  GraphQL data fields are exercised; pass schema_extensions=[] for plain
-  entity graphs.
+  Defaults to roboledger + roboinvestor graphs so both extensions command
+  surfaces and the GraphQL data fields are exercised; pass schema_extensions=[]
+  for plain entity graphs.
   """
   if schema_extensions is None:
     schema_extensions = ["roboledger", "roboinvestor"]

--- a/tests/security/isolation/_provision.py
+++ b/tests/security/isolation/_provision.py
@@ -21,12 +21,28 @@ and per graph:
 from __future__ import annotations
 
 import secrets
+import string
 import time
 from dataclasses import dataclass, field
 
 from ._http import Client, Principal
 
-_PW = "IsoHarness!" + secrets.token_hex(6) + "Aa1"
+_PW_CLASSES = (
+  string.ascii_uppercase,
+  string.ascii_lowercase,
+  string.digits,
+  "!@#$%^&*",
+)
+
+
+def _make_password() -> str:
+  """A random password that structurally passes the platform's policy.
+
+  Rotating character classes guarantees no run of three repeated characters
+  (`(.)\\1{2,}`) and no same-class sequence (`123456` / `abcdef`), which is
+  what a plain hex token trips on intermittently.
+  """
+  return "".join(secrets.choice(_PW_CLASSES[i % len(_PW_CLASSES)]) for i in range(20))
 
 
 def _unique(prefix: str) -> str:
@@ -54,9 +70,10 @@ def register_principal(client: Client, label: str) -> Principal:
   """Register a user, log in, mint an API key. Returns a Principal."""
   email = f"{_unique('iso_' + label)}@example.com"
   name = f"iso-harness {label}"
+  password = _make_password()
 
   r = client.post(
-    "/v1/auth/register", json={"name": name, "email": email, "password": _PW}
+    "/v1/auth/register", json={"name": name, "email": email, "password": password}
   )
   if r.status_code not in (200, 201):
     raise RuntimeError(f"register({label}) -> {r.status_code}: {r.text[:300]}")
@@ -67,7 +84,7 @@ def register_principal(client: Client, label: str) -> Principal:
   # Prefer the token from register; fall back to an explicit login.
   jwt = body.get("token") or ""
   if not jwt:
-    lr = client.post("/v1/auth/login", json={"email": email, "password": _PW})
+    lr = client.post("/v1/auth/login", json={"email": email, "password": password})
     if lr.status_code != 200:
       raise RuntimeError(f"login({label}) -> {lr.status_code}: {lr.text[:300]}")
     jwt = lr.json().get("token") or ""
@@ -175,7 +192,7 @@ def provision(
   entity graphs.
   """
   if schema_extensions is None:
-    schema_extensions = ["roboledger"]
+    schema_extensions = ["roboledger", "roboinvestor"]
   a = register_principal(client, "A")
   b = register_principal(client, "B")
   graph_a = create_entity_graph(client, a, schema_extensions=schema_extensions)

--- a/tests/security/isolation/_report.py
+++ b/tests/security/isolation/_report.py
@@ -1,0 +1,85 @@
+"""Report collection for the isolation harness.
+
+Accumulates one finding per (surface, attacker, target) probe and renders a
+machine-readable JSON file plus a human summary. The JSON is the artifact
+attached to SOC 2 evidence and handed to the paid gray-box tester as the
+scope fixture; the summary is what a run prints.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+
+from ._oracle import Verdict
+
+
+@dataclass
+class Finding:
+  axis: str  # "horizontal" | "vertical"
+  surface: str  # "rest-read" | "rest-write" | "cypher" | "mcp" | "graphql"
+  method: str
+  path: str
+  attacker: str  # principal label
+  target_graph: str
+  verdict: Verdict
+  status: int
+  note: str = ""
+
+
+@dataclass
+class Report:
+  findings: list[Finding] = field(default_factory=list)
+
+  def add(self, f: Finding) -> None:
+    self.findings.append(f)
+
+  def by_verdict(self, v: Verdict) -> list[Finding]:
+    return [f for f in self.findings if f.verdict == v]
+
+  @property
+  def leaks(self) -> list[Finding]:
+    return self.by_verdict(Verdict.LEAK)
+
+  @property
+  def invalid(self) -> list[Finding]:
+    return self.by_verdict(Verdict.INVALID)
+
+  @property
+  def inconclusive(self) -> list[Finding]:
+    return self.by_verdict(Verdict.INCONCLUSIVE)
+
+  def counts(self) -> dict[str, int]:
+    out = {v.value: 0 for v in Verdict}
+    for f in self.findings:
+      out[f.verdict.value] += 1
+    return out
+
+  def summary(self) -> str:
+    c = self.counts()
+    lines = [
+      "",
+      "══════════ tenant-isolation harness ══════════",
+      f"  probes: {len(self.findings)}   "
+      + "   ".join(f"{k}={v}" for k, v in c.items() if v),
+    ]
+    for label, items in (
+      ("LEAK", self.leaks),
+      ("INVALID", self.invalid),
+      ("INCONCLUSIVE", self.inconclusive),
+    ):
+      for f in items:
+        lines.append(
+          f"  [{label}] {f.axis}/{f.surface} {f.method} {f.path} "
+          f"as {f.attacker} → {f.status}: {f.note}"
+        )
+    lines.append("═══════════════════════════════════════════════")
+    return "\n".join(lines)
+
+  def write_json(self, path: str) -> None:
+    payload = {
+      "counts": self.counts(),
+      "findings": [{**asdict(f), "verdict": f.verdict.value} for f in self.findings],
+    }
+    with open(path, "w") as fh:
+      json.dump(payload, fh, indent=2)

--- a/tests/security/isolation/conftest.py
+++ b/tests/security/isolation/conftest.py
@@ -70,7 +70,10 @@ def tenants(client: Client):
   # Best-effort teardown: delete both graphs as their owners. Full disposal
   # verification (that the rows and OpenSearch content are actually gone) is
   # the runbook's DB-tunnel step, deliberately not automated here.
-  for owner, gid in ((fx.tenant_a, fx.graph_a), (fx.tenant_b, fx.graph_b)):
+  targets = [(fx.tenant_a, fx.graph_a), (fx.tenant_b, fx.graph_b)]
+  if fx.graph_a2:
+    targets.append((fx.tenant_a, fx.graph_a2))
+  for owner, gid in targets:
     try:
       client.post(
         f"/v1/graphs/{gid}/operations/delete-graph",

--- a/tests/security/isolation/conftest.py
+++ b/tests/security/isolation/conftest.py
@@ -1,0 +1,81 @@
+"""Fixtures + skip gate for the tenant-isolation harness.
+
+The whole suite is opt-in: it only runs when TARGET_API_URL points at a live
+deployment. In a normal `just test` / CI run it is collected and then skips,
+exactly like the DB-backed integration tests skip when their resource is
+absent — so it is inert by default and never gates unrelated work.
+
+Run it explicitly:
+
+    TARGET_API_URL=http://localhost:8000 uv run pytest tests/security/isolation -m isolation -s
+
+A JSON report is written to .local/isolation-report.json (override with
+ISOLATION_REPORT). Nothing here touches the database — provisioning and the
+matrix are pure HTTP; DB-side teardown verification is the runbook's tunnel
+step, not the harness's.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from ._http import Client
+from ._provision import provision
+from ._report import Report
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_DEFAULT_REPORT = _REPO_ROOT / ".local" / "isolation-report.json"
+
+
+@pytest.fixture(scope="session")
+def target_url() -> str:
+  url = os.environ.get("TARGET_API_URL")
+  if not url:
+    pytest.skip(
+      "TARGET_API_URL not set — the isolation harness is opt-in; point it at a "
+      "deployment (e.g. TARGET_API_URL=http://localhost:8000)"
+    )
+  return url.rstrip("/")
+
+
+@pytest.fixture(scope="session")
+def client(target_url: str) -> Client:
+  c = Client(target_url)
+  yield c
+  c.close()
+
+
+@pytest.fixture(scope="session")
+def report():
+  r = Report()
+  yield r
+  print(r.summary())
+  path = os.environ.get("ISOLATION_REPORT") or str(_DEFAULT_REPORT)
+  try:
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    r.write_json(path)
+    print(f"[isolation] report → {path}")
+  except OSError as exc:  # pragma: no cover - best effort
+    print(f"[isolation] could not write report to {path}: {exc}")
+
+
+@pytest.fixture(scope="session")
+def tenants(client: Client):
+  """Provision two independent tenants (each with an entity graph)."""
+  fx = provision(client)
+  yield fx
+  # Best-effort teardown: delete both graphs as their owners. Full disposal
+  # verification (that the rows and OpenSearch content are actually gone) is
+  # the runbook's DB-tunnel step, deliberately not automated here.
+  for owner, gid in ((fx.tenant_a, fx.graph_a), (fx.tenant_b, fx.graph_b)):
+    try:
+      client.post(
+        f"/v1/graphs/{gid}/operations/delete-graph",
+        principal=owner,
+        json={"confirm": gid, "at_period_end": False},
+      )
+    except Exception:
+      pass

--- a/tests/security/isolation/matrix.py
+++ b/tests/security/isolation/matrix.py
@@ -32,16 +32,25 @@ CYPHER_READ_BODY = {"query": "MATCH (n) RETURN count(n) AS c", "parameters": {}}
 # no real-data blast radius.
 REST_WRITES: list[dict] = [
   {
-    "label": "update-graph-metadata",
-    "path": "/v1/graphs/{graph_id}/operations/update-graph-metadata",
-    "body": {"description": "iso-harness cross-tenant write probe"},
-  },
-  {
     "label": "add-member",
     "path": "/v1/graphs/{graph_id}/members",
     # user_id is filled with the attacker's own id at run time
     "body": {"user_id": "{attacker_user_id}", "role": "admin"},
   },
+]
+
+# Destructive / sensitive core graph operations — the ones where a cross-tenant
+# acceptance would be worst (another tenant deleting, re-tiering, or backing up
+# your graph). Attacker-only probe; authz should deny before the body matters,
+# so empty bodies suffice (a 422 instead of 403 is itself a finding).
+CORE_OP_PATH = "/v1/graphs/{graph_id}/operations/{op}"
+CORE_OP_WRITES: list[str] = [
+  "update-graph-metadata",
+  "create-backup",
+  "materialize",
+  "create-subgraph",
+  "change-tier",
+  "delete-graph",
 ]
 
 # MCP is always mounted (no domain flag). read-graph-cypher is a data probe;
@@ -64,16 +73,22 @@ GRAPHQL_PATH = "/extensions/{graph_id}/graphql"
 GRAPHQL_HELLO_BODY = {"query": "{ hello }"}
 GRAPHQL_DATA_BODY = {"query": "{ entity { name } }"}
 
-# The roboledger extensions command/view surface (needs a roboledger graph).
-# Any 2xx from a non-owner is a leak; empty bodies suffice for a denial probe —
-# authz (get_current_user_with_graph / require_graph_write_role) should turn a
-# non-owner away before the body ever matters. A 422 instead of 403 is itself a
-# finding (validation ran before authz) and lands as INCONCLUSIVE.
+# The extensions command/view surfaces for both product domains (the graphs are
+# provisioned with both extensions). Any 2xx from a non-owner is a leak; empty
+# bodies suffice for a denial probe — authz (get_current_user_with_graph /
+# require_graph_write_role) should turn a non-owner away before the body ever
+# matters. A 422 instead of 403 is itself a finding (validation ran before
+# authz) and lands as INCONCLUSIVE. Confirms each domain's operations router is
+# wired with the same graph-access gate, not just roboledger's.
+EXTENSIONS_OP_PATH = "/extensions/{domain}/{graph_id}/operations/{op}"
 EXTENSIONS_OPS: list[dict] = [
-  {"label": "build-fact-grid", "op": "build-fact-grid"},  # view / read
-  {"label": "compute-metrics", "op": "compute-metrics"},  # read/compute
-  {"label": "create-event-block", "op": "create-event-block"},  # write
-  {"label": "create-report", "op": "create-report"},  # write
-  {"label": "close-period", "op": "close-period"},  # sensitive write
+  {"domain": "roboledger", "op": "build-fact-grid"},  # view / read
+  {"domain": "roboledger", "op": "compute-metrics"},  # read / compute
+  {"domain": "roboledger", "op": "create-event-block"},  # write
+  {"domain": "roboledger", "op": "create-report"},  # write
+  {"domain": "roboledger", "op": "close-period"},  # sensitive write
+  {"domain": "roboinvestor", "op": "create-portfolio-block"},  # write
+  {"domain": "roboinvestor", "op": "create-security"},  # write
+  {"domain": "roboinvestor", "op": "update-portfolio-block"},  # write
+  {"domain": "roboinvestor", "op": "delete-security"},  # sensitive write
 ]
-EXTENSIONS_OP_PATH = "/extensions/roboledger/{graph_id}/operations/{op}"

--- a/tests/security/isolation/matrix.py
+++ b/tests/security/isolation/matrix.py
@@ -56,8 +56,24 @@ MCP_WRITE_BODY = {
   "arguments": {"query": "CREATE (n:IsoHarnessProbe {marker: 1}) RETURN n"},
 }
 
-# GraphQL is flag-gated (EXTENSIONS_GRAPHQL_ENABLED AND a domain flag). The
-# `hello` field is the always-on auth probe; it echoes the caller, so it is an
-# access-control probe, not a data-leak probe (see classify_graphql).
+# GraphQL is flag-gated (EXTENSIONS_GRAPHQL_ENABLED AND a domain flag). Two
+# probes: `hello` echoes the caller (access-control probe), while `entity` reads
+# actual graph data (a real data-leak probe — a cross-tenant entity payload is a
+# leak). On a roboledger graph the entity is the initial_entity created at setup.
 GRAPHQL_PATH = "/extensions/{graph_id}/graphql"
-GRAPHQL_BODY = {"query": "{ hello }"}
+GRAPHQL_HELLO_BODY = {"query": "{ hello }"}
+GRAPHQL_DATA_BODY = {"query": "{ entity { name } }"}
+
+# The roboledger extensions command/view surface (needs a roboledger graph).
+# Any 2xx from a non-owner is a leak; empty bodies suffice for a denial probe —
+# authz (get_current_user_with_graph / require_graph_write_role) should turn a
+# non-owner away before the body ever matters. A 422 instead of 403 is itself a
+# finding (validation ran before authz) and lands as INCONCLUSIVE.
+EXTENSIONS_OPS: list[dict] = [
+  {"label": "build-fact-grid", "op": "build-fact-grid"},  # view / read
+  {"label": "compute-metrics", "op": "compute-metrics"},  # read/compute
+  {"label": "create-event-block", "op": "create-event-block"},  # write
+  {"label": "create-report", "op": "create-report"},  # write
+  {"label": "close-period", "op": "close-period"},  # sensitive write
+]
+EXTENSIONS_OP_PATH = "/extensions/roboledger/{graph_id}/operations/{op}"

--- a/tests/security/isolation/matrix.py
+++ b/tests/security/isolation/matrix.py
@@ -1,0 +1,63 @@
+"""Surface definitions for the cross-tenant matrix.
+
+Paths carry `{graph_id}`, filled with the *victim* (target) graph at run
+time. Reads are classified by the fingerprint oracle; writes by acceptance;
+GraphQL and MCP have their own probes. Kept in one place so extending the
+matrix is a data edit, not a code change.
+"""
+
+from __future__ import annotations
+
+# Graph-scoped GET reads. Some carry data on a fresh graph (info, schema,
+# members, limits, credits); some are legitimately empty (tables, backups,
+# subgraphs) — the oracle handles both (empty-for-owner is valid).
+REST_READS: list[str] = [
+  "/v1/graphs/{graph_id}/info",
+  "/v1/graphs/{graph_id}/schema",
+  "/v1/graphs/{graph_id}/limits",
+  "/v1/graphs/{graph_id}/credits",
+  "/v1/graphs/{graph_id}/members",
+  "/v1/graphs/{graph_id}/tables",
+  "/v1/graphs/{graph_id}/backups",
+  "/v1/graphs/{graph_id}/subgraphs",
+]
+
+# Cypher over the REST query path — read semantics, the strongest data probe:
+# it returns an actual node count from the owner's graph.
+CYPHER_READ_PATH = "/v1/graphs/{graph_id}/query/cypher"
+CYPHER_READ_BODY = {"query": "MATCH (n) RETURN count(n) AS c", "parameters": {}}
+
+# Graph-scoped writes. Any 2xx from a non-owner is a leak. Bodies are minimal
+# and land in the *victim test tenant's* graph, so even an accepted write has
+# no real-data blast radius.
+REST_WRITES: list[dict] = [
+  {
+    "label": "update-graph-metadata",
+    "path": "/v1/graphs/{graph_id}/operations/update-graph-metadata",
+    "body": {"description": "iso-harness cross-tenant write probe"},
+  },
+  {
+    "label": "add-member",
+    "path": "/v1/graphs/{graph_id}/members",
+    # user_id is filled with the attacker's own id at run time
+    "body": {"user_id": "{attacker_user_id}", "role": "admin"},
+  },
+]
+
+# MCP is always mounted (no domain flag). read-graph-cypher is a data probe;
+# write-graph-cypher is a cross-tenant write probe.
+MCP_PATH = "/v1/graphs/{graph_id}/mcp/call-tool"
+MCP_READ_BODY = {
+  "name": "read-graph-cypher",
+  "arguments": {"query": "MATCH (n) RETURN count(n) AS c", "parameters": {}},
+}
+MCP_WRITE_BODY = {
+  "name": "write-graph-cypher",
+  "arguments": {"query": "CREATE (n:IsoHarnessProbe {marker: 1}) RETURN n"},
+}
+
+# GraphQL is flag-gated (EXTENSIONS_GRAPHQL_ENABLED AND a domain flag). The
+# `hello` field is the always-on auth probe; it echoes the caller, so it is an
+# access-control probe, not a data-leak probe (see classify_graphql).
+GRAPHQL_PATH = "/extensions/{graph_id}/graphql"
+GRAPHQL_BODY = {"query": "{ hello }"}

--- a/tests/security/isolation/test_horizontal.py
+++ b/tests/security/isolation/test_horizontal.py
@@ -1,0 +1,198 @@
+"""Horizontal axis — cross-tenant isolation (R-11).
+
+A principal in one tenant attempts to read or write another tenant's graph,
+across REST, GraphQL, and MCP. Run in both directions so an asymmetric bug
+(e.g. the first-created graph being special) cannot hide. A LEAK fails the
+suite; a failed positive control (INVALID) fails it too — a green run that
+never proved the owner's own access proves nothing.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from . import matrix
+from ._http import Client, Principal
+from ._oracle import (
+  Verdict,
+  classify_graphql,
+  classify_read,
+  classify_write,
+)
+from ._report import Finding, Report
+
+pytestmark = [
+  pytest.mark.isolation,
+  pytest.mark.security,
+  pytest.mark.integration,
+]
+
+
+def _directions(tenants):
+  """(name, attacker, victim, victim_graph) for both cross-tenant directions."""
+  return [
+    ("A→B", tenants.tenant_a, tenants.tenant_b, tenants.graph_b),
+    ("B→A", tenants.tenant_b, tenants.tenant_a, tenants.graph_a),
+  ]
+
+
+def _assert_clean(found: list[Finding]) -> None:
+  leaks = [f for f in found if f.verdict == Verdict.LEAK]
+  invalid = [f for f in found if f.verdict == Verdict.INVALID]
+  assert not invalid, (
+    "positive control(s) failed — harness misconfigured:\n"
+    + "\n".join(f"  {f.method} {f.path}: {f.note}" for f in invalid)
+  )
+  assert not leaks, "CROSS-TENANT LEAK(S):\n" + "\n".join(
+    f"  [{f.attacker}→{f.target_graph}] {f.surface} {f.method} {f.path} "
+    f"→ {f.status}: {f.note}"
+    for f in leaks
+  )
+
+
+def test_rest_reads_are_isolated(tenants, client: Client, report: Report) -> None:
+  found: list[Finding] = []
+  for _name, attacker, victim, graph in _directions(tenants):
+    for tmpl in matrix.REST_READS:
+      path = tmpl.format(graph_id=graph)
+      v = client.get(path, principal=victim)
+      a = client.get(path, principal=attacker)
+      verdict, note = classify_read(v, a)
+      f = Finding(
+        "horizontal",
+        "rest-read",
+        "GET",
+        path,
+        attacker.label,
+        graph,
+        verdict,
+        a.status_code,
+        note,
+      )
+      report.add(f)
+      found.append(f)
+  _assert_clean(found)
+
+
+def test_cypher_read_is_isolated(tenants, client: Client, report: Report) -> None:
+  """The strongest data probe: a cross-tenant Cypher read of node counts."""
+  found: list[Finding] = []
+  for _name, attacker, victim, graph in _directions(tenants):
+    path = matrix.CYPHER_READ_PATH.format(graph_id=graph)
+    v = client.post(path, principal=victim, json=matrix.CYPHER_READ_BODY)
+    a = client.post(path, principal=attacker, json=matrix.CYPHER_READ_BODY)
+    verdict, note = classify_read(v, a)
+    f = Finding(
+      "horizontal",
+      "cypher",
+      "POST",
+      path,
+      attacker.label,
+      graph,
+      verdict,
+      a.status_code,
+      note,
+    )
+    report.add(f)
+    found.append(f)
+  _assert_clean(found)
+
+
+def test_rest_writes_are_isolated(tenants, client: Client, report: Report) -> None:
+  found: list[Finding] = []
+  for _name, attacker, _victim, graph in _directions(tenants):
+    for spec in matrix.REST_WRITES:
+      path = spec["path"].format(graph_id=graph)
+      body = dict(spec["body"])
+      if body.get("user_id") == "{attacker_user_id}":
+        body["user_id"] = attacker.user_id
+      a = client.post(path, principal=attacker, json=body)
+      verdict, note = classify_write(a)
+      f = Finding(
+        "horizontal",
+        "rest-write",
+        "POST",
+        path,
+        attacker.label,
+        graph,
+        verdict,
+        a.status_code,
+        f"{spec['label']}: {note}",
+      )
+      report.add(f)
+      found.append(f)
+  _assert_clean(found)
+
+
+def test_mcp_is_isolated(tenants, client: Client, report: Report) -> None:
+  found: list[Finding] = []
+  for _name, attacker, victim, graph in _directions(tenants):
+    path = matrix.MCP_PATH.format(graph_id=graph)
+    # read tool — data probe
+    v = client.post(path, principal=victim, json=matrix.MCP_READ_BODY)
+    a = client.post(path, principal=attacker, json=matrix.MCP_READ_BODY)
+    verdict, note = classify_read(v, a)
+    fr = Finding(
+      "horizontal",
+      "mcp",
+      "POST",
+      path,
+      attacker.label,
+      graph,
+      verdict,
+      a.status_code,
+      f"read-graph-cypher: {note}",
+    )
+    report.add(fr)
+    found.append(fr)
+    # write tool — any acceptance is a leak
+    aw = client.post(path, principal=attacker, json=matrix.MCP_WRITE_BODY)
+    wv, wnote = classify_write(aw)
+    fw = Finding(
+      "horizontal",
+      "mcp",
+      "POST",
+      path,
+      attacker.label,
+      graph,
+      wv,
+      aw.status_code,
+      f"write-graph-cypher: {wnote}",
+    )
+    report.add(fw)
+    found.append(fw)
+  _assert_clean(found)
+
+
+def _graphql_available(client: Client, victim: Principal, graph: str) -> bool:
+  path = matrix.GRAPHQL_PATH.format(graph_id=graph)
+  r = client.post(path, principal=victim, json=matrix.GRAPHQL_BODY)
+  return r.status_code != 404
+
+
+def test_graphql_is_isolated(tenants, client: Client, report: Report) -> None:
+  if not _graphql_available(client, tenants.tenant_b, tenants.graph_b):
+    pytest.skip(
+      "GraphQL endpoint not mounted (EXTENSIONS_GRAPHQL_ENABLED + a domain flag "
+      "off) — enable to cover this surface"
+    )
+  found: list[Finding] = []
+  for _name, attacker, victim, graph in _directions(tenants):
+    path = matrix.GRAPHQL_PATH.format(graph_id=graph)
+    v = client.post(path, principal=victim, json=matrix.GRAPHQL_BODY)
+    a = client.post(path, principal=attacker, json=matrix.GRAPHQL_BODY)
+    verdict, note = classify_graphql(v, a)
+    f = Finding(
+      "horizontal",
+      "graphql",
+      "POST",
+      path,
+      attacker.label,
+      graph,
+      verdict,
+      a.status_code,
+      note,
+    )
+    report.add(f)
+    found.append(f)
+  _assert_clean(found)

--- a/tests/security/isolation/test_horizontal.py
+++ b/tests/security/isolation/test_horizontal.py
@@ -166,7 +166,7 @@ def test_mcp_is_isolated(tenants, client: Client, report: Report) -> None:
 
 def _graphql_available(client: Client, victim: Principal, graph: str) -> bool:
   path = matrix.GRAPHQL_PATH.format(graph_id=graph)
-  r = client.post(path, principal=victim, json=matrix.GRAPHQL_BODY)
+  r = client.post(path, principal=victim, json=matrix.GRAPHQL_HELLO_BODY)
   return r.status_code != 404
 
 
@@ -176,23 +176,60 @@ def test_graphql_is_isolated(tenants, client: Client, report: Report) -> None:
       "GraphQL endpoint not mounted (EXTENSIONS_GRAPHQL_ENABLED + a domain flag "
       "off) — enable to cover this surface"
     )
+  probes = [
+    (matrix.GRAPHQL_HELLO_BODY, False),  # access-control probe
+    (matrix.GRAPHQL_DATA_BODY, True),  # data-leak probe (entity)
+  ]
   found: list[Finding] = []
   for _name, attacker, victim, graph in _directions(tenants):
     path = matrix.GRAPHQL_PATH.format(graph_id=graph)
-    v = client.post(path, principal=victim, json=matrix.GRAPHQL_BODY)
-    a = client.post(path, principal=attacker, json=matrix.GRAPHQL_BODY)
-    verdict, note = classify_graphql(v, a)
-    f = Finding(
-      "horizontal",
-      "graphql",
-      "POST",
-      path,
-      attacker.label,
-      graph,
-      verdict,
-      a.status_code,
-      note,
+    for body, is_data in probes:
+      v = client.post(path, principal=victim, json=body)
+      a = client.post(path, principal=attacker, json=body)
+      verdict, note = classify_graphql(v, a, data_field=is_data)
+      f = Finding(
+        "horizontal",
+        "graphql",
+        "POST",
+        path,
+        attacker.label,
+        graph,
+        verdict,
+        a.status_code,
+        f"{'entity' if is_data else 'hello'}: {note}",
+      )
+      report.add(f)
+      found.append(f)
+  _assert_clean(found)
+
+
+def test_extensions_ops_are_isolated(tenants, client: Client, report: Report) -> None:
+  """The roboledger command/view surface — a non-owner must be turned away."""
+  probe_path = matrix.EXTENSIONS_OP_PATH.format(
+    graph_id=tenants.graph_b, op=matrix.EXTENSIONS_OPS[0]["op"]
+  )
+  if client.post(probe_path, principal=tenants.tenant_b, json={}).status_code == 404:
+    pytest.skip(
+      "roboledger extensions operations not mounted (ROBOLEDGER_ENABLED off, or "
+      "graphs not provisioned with the roboledger extension)"
     )
-    report.add(f)
-    found.append(f)
+  found: list[Finding] = []
+  for _name, attacker, _victim, graph in _directions(tenants):
+    for spec in matrix.EXTENSIONS_OPS:
+      path = matrix.EXTENSIONS_OP_PATH.format(graph_id=graph, op=spec["op"])
+      a = client.post(path, principal=attacker, json={})
+      verdict, note = classify_write(a)
+      f = Finding(
+        "horizontal",
+        "extensions-op",
+        "POST",
+        path,
+        attacker.label,
+        graph,
+        verdict,
+        a.status_code,
+        f"{spec['label']}: {note}",
+      )
+      report.add(f)
+      found.append(f)
   _assert_clean(found)

--- a/tests/security/isolation/test_horizontal.py
+++ b/tests/security/isolation/test_horizontal.py
@@ -124,6 +124,30 @@ def test_rest_writes_are_isolated(tenants, client: Client, report: Report) -> No
   _assert_clean(found)
 
 
+def test_core_ops_are_isolated(tenants, client: Client, report: Report) -> None:
+  """Destructive/sensitive core graph ops — a non-owner must be turned away."""
+  found: list[Finding] = []
+  for _name, attacker, _victim, graph in _directions(tenants):
+    for op in matrix.CORE_OP_WRITES:
+      path = matrix.CORE_OP_PATH.format(graph_id=graph, op=op)
+      a = client.post(path, principal=attacker, json={})
+      verdict, note = classify_write(a)
+      f = Finding(
+        "horizontal",
+        "core-op",
+        "POST",
+        path,
+        attacker.label,
+        graph,
+        verdict,
+        a.status_code,
+        f"{op}: {note}",
+      )
+      report.add(f)
+      found.append(f)
+  _assert_clean(found)
+
+
 def test_mcp_is_isolated(tenants, client: Client, report: Report) -> None:
   found: list[Finding] = []
   for _name, attacker, victim, graph in _directions(tenants):
@@ -204,19 +228,22 @@ def test_graphql_is_isolated(tenants, client: Client, report: Report) -> None:
 
 
 def test_extensions_ops_are_isolated(tenants, client: Client, report: Report) -> None:
-  """The roboledger command/view surface — a non-owner must be turned away."""
+  """The roboledger + roboinvestor command/view surfaces — non-owner turned away."""
+  first = matrix.EXTENSIONS_OPS[0]
   probe_path = matrix.EXTENSIONS_OP_PATH.format(
-    graph_id=tenants.graph_b, op=matrix.EXTENSIONS_OPS[0]["op"]
+    domain=first["domain"], graph_id=tenants.graph_b, op=first["op"]
   )
   if client.post(probe_path, principal=tenants.tenant_b, json={}).status_code == 404:
     pytest.skip(
-      "roboledger extensions operations not mounted (ROBOLEDGER_ENABLED off, or "
-      "graphs not provisioned with the roboledger extension)"
+      "extensions operations not mounted (ROBOLEDGER/ROBOINVESTOR off, or graphs "
+      "not provisioned with the extension)"
     )
   found: list[Finding] = []
   for _name, attacker, _victim, graph in _directions(tenants):
     for spec in matrix.EXTENSIONS_OPS:
-      path = matrix.EXTENSIONS_OP_PATH.format(graph_id=graph, op=spec["op"])
+      path = matrix.EXTENSIONS_OP_PATH.format(
+        domain=spec["domain"], graph_id=graph, op=spec["op"]
+      )
       a = client.post(path, principal=attacker, json={})
       verdict, note = classify_write(a)
       f = Finding(
@@ -228,7 +255,7 @@ def test_extensions_ops_are_isolated(tenants, client: Client, report: Report) ->
         graph,
         verdict,
         a.status_code,
-        f"{spec['label']}: {note}",
+        f"{spec['domain']}/{spec['op']}: {note}",
       )
       report.add(f)
       found.append(f)

--- a/tests/security/isolation/test_oracle.py
+++ b/tests/security/isolation/test_oracle.py
@@ -99,6 +99,12 @@ def test_write_validation_error_is_inconclusive():
   assert classify_write(_resp(422, json={"detail": "bad"}))[0] is Verdict.INCONCLUSIVE
 
 
+def test_write_server_error_is_inconclusive():
+  """A 5xx on a cross-tenant write is an anomaly, not a clean deny — must flag."""
+  for sc in (500, 503):
+    assert classify_write(_resp(sc, json={"detail": "boom"}))[0] is Verdict.INCONCLUSIVE
+
+
 # ── graphql ────────────────────────────────────────────────────────────────
 
 

--- a/tests/security/isolation/test_oracle.py
+++ b/tests/security/isolation/test_oracle.py
@@ -1,0 +1,123 @@
+"""Unit tests for the oracle — proves the harness can actually catch a leak.
+
+A live run where every attacker is denied (403) reports all-PASS without ever
+exercising the LEAK path, so a green run against a correct system is weak
+evidence that the classifier works. These tests feed the oracle synthetic
+responses — including real leaks — and assert it flags them. Plain unit tests:
+no TARGET_API_URL, they run in the normal suite.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from ._oracle import (
+  Verdict,
+  classify_graphql,
+  classify_read,
+  classify_write,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _resp(status: int, json=None, text: str | None = None) -> httpx.Response:
+  if json is not None:
+    return httpx.Response(status, json=json)
+  return httpx.Response(status, text=text or "")
+
+
+# ── reads ──────────────────────────────────────────────────────────────────
+
+
+def test_read_denied_is_pass():
+  victim = _resp(200, json={"c": 5})
+  attacker = _resp(403, json={"detail": "forbidden"})
+  assert classify_read(victim, attacker)[0] is Verdict.PASS
+
+
+def test_read_identical_data_is_leak():
+  """Attacker sees exactly the owner's data — the definitive leak."""
+  data = {"columns": ["c"], "rows": [[5]]}
+  victim = _resp(200, json=data)
+  attacker = _resp(200, json=data)
+  verdict, note = classify_read(victim, attacker)
+  assert verdict is Verdict.LEAK, note
+
+
+def test_read_any_data_for_non_owned_graph_is_leak():
+  """Even non-identical data for a graph you don't own is a leak."""
+  victim = _resp(200, json={"members": [{"id": "u_owner"}]})
+  attacker = _resp(200, json={"members": [{"id": "u_someone"}]})
+  assert classify_read(victim, attacker)[0] is Verdict.LEAK
+
+
+def test_read_leak_shape_org_name(  # the publish_lists.py F5 shape
+):
+  """A 200 carrying another tenant's org_name is the known real leak shape."""
+  victim = _resp(200, json={"org_name": "Victim Corp", "lists": []})
+  attacker = _resp(200, json={"org_name": "Victim Corp", "lists": []})
+  assert classify_read(victim, attacker)[0] is Verdict.LEAK
+
+
+def test_read_owner_denied_is_invalid():
+  """Positive control failed — harness misconfigured, must not read as PASS."""
+  victim = _resp(403, json={"detail": "forbidden"})
+  attacker = _resp(403, json={"detail": "forbidden"})
+  assert classify_read(victim, attacker)[0] is Verdict.INVALID
+
+
+def test_read_owner_empty_is_valid_positive_control():
+  """A fresh graph's empty /backups is a valid positive control, not INVALID."""
+  victim = _resp(200, json={"backups": []})
+  attacker = _resp(403, json={"detail": "forbidden"})
+  assert classify_read(victim, attacker)[0] is Verdict.PASS
+
+
+def test_read_attacker_200_empty_is_inconclusive():
+  """200 for a non-owned graph, even empty, means authz did not deny."""
+  victim = _resp(200, json={"backups": []})
+  attacker = _resp(200, json={"backups": []})
+  assert classify_read(victim, attacker)[0] is Verdict.INCONCLUSIVE
+
+
+# ── writes ─────────────────────────────────────────────────────────────────
+
+
+def test_write_accepted_is_leak():
+  for sc in (200, 201, 202):
+    assert classify_write(_resp(sc, json={"ok": True}))[0] is Verdict.LEAK
+
+
+def test_write_denied_is_pass():
+  for sc in (401, 403, 404):
+    assert classify_write(_resp(sc, json={"detail": "no"}))[0] is Verdict.PASS
+
+
+def test_write_validation_error_is_inconclusive():
+  assert classify_write(_resp(422, json={"detail": "bad"}))[0] is Verdict.INCONCLUSIVE
+
+
+# ── graphql ────────────────────────────────────────────────────────────────
+
+
+def test_graphql_http_denied_is_pass():
+  victim = _resp(200, json={"data": {"hello": "hello, owner"}})
+  attacker = _resp(403, json={"detail": "forbidden"})
+  assert classify_graphql(victim, attacker)[0] is Verdict.PASS
+
+
+def test_graphql_resolver_error_is_pass():
+  victim = _resp(200, json={"data": {"hello": "hello, owner"}})
+  attacker = _resp(
+    200, json={"data": None, "errors": [{"extensions": {"code": "FORBIDDEN"}}]}
+  )
+  assert classify_graphql(victim, attacker)[0] is Verdict.PASS
+
+
+def test_graphql_200_with_data_is_inconclusive():
+  """`hello` echoes the caller, so a cross-tenant 200 needs a data field to judge."""
+  victim = _resp(200, json={"data": {"hello": "hello, owner"}})
+  attacker = _resp(200, json={"data": {"hello": "hello, attacker"}})
+  assert classify_graphql(victim, attacker)[0] is Verdict.INCONCLUSIVE

--- a/tests/security/isolation/test_oracle.py
+++ b/tests/security/isolation/test_oracle.py
@@ -121,3 +121,26 @@ def test_graphql_200_with_data_is_inconclusive():
   victim = _resp(200, json={"data": {"hello": "hello, owner"}})
   attacker = _resp(200, json={"data": {"hello": "hello, attacker"}})
   assert classify_graphql(victim, attacker)[0] is Verdict.INCONCLUSIVE
+
+
+def test_graphql_data_field_leak():
+  """A cross-tenant `{ entity }` payload is real graph data — a leak."""
+  data = {"data": {"entity": {"name": "Victim Corp"}}}
+  victim = _resp(200, json=data)
+  attacker = _resp(200, json=data)
+  assert classify_graphql(victim, attacker, data_field=True)[0] is Verdict.LEAK
+
+
+def test_graphql_data_field_denied_is_pass():
+  victim = _resp(200, json={"data": {"entity": {"name": "Victim Corp"}}})
+  attacker = _resp(
+    200, json={"data": None, "errors": [{"extensions": {"code": "FORBIDDEN"}}]}
+  )
+  assert classify_graphql(victim, attacker, data_field=True)[0] is Verdict.PASS
+
+
+def test_graphql_data_field_owner_empty_is_invalid():
+  """A data-field probe whose owner query returns no data can't detect a leak."""
+  victim = _resp(200, json={"data": {"entity": None}})
+  attacker = _resp(200, json={"data": None})
+  assert classify_graphql(victim, attacker, data_field=True)[0] is Verdict.INVALID

--- a/tests/security/isolation/test_scoping.py
+++ b/tests/security/isolation/test_scoping.py
@@ -1,0 +1,122 @@
+"""Scoping axis — isolation units finer than the user↔graph pair.
+
+Two controls the base matrix doesn't reach:
+
+- **Subgraph isolation.** The invariant keys on `graph_id` *including subgraphs*
+  (`{parent}_{name}`). A subgraph is its own isolation unit routed through a
+  distinct access path (`is_shared_repository_or_subgraph`). A non-owner must be
+  denied on the subgraph id, not just the parent.
+- **Graph-scoped API keys.** A key minted with a `graph_id` is scoped: allowed on
+  that graph (and its subgraphs) and *denied everywhere else* — even on another
+  graph the same user owns. That last case is the sharp test: the denial must
+  come from the key's scope, not from user access, so we fire it at `graph_a2`,
+  which the key's owner *does* own.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ._http import Client
+from ._oracle import Verdict, classify_read
+from ._report import Finding, Report
+
+pytestmark = [
+  pytest.mark.isolation,
+  pytest.mark.security,
+  pytest.mark.integration,
+]
+
+_CYPHER = {"query": "MATCH (n) RETURN count(n) AS c", "parameters": {}}
+
+
+def _assert_clean(found: list[Finding]) -> None:
+  leaks = [f for f in found if f.verdict == Verdict.LEAK]
+  invalid = [f for f in found if f.verdict == Verdict.INVALID]
+  assert not invalid, (
+    "positive control(s) failed — harness misconfigured:\n"
+    + "\n".join(f"  {f.method} {f.path}: {f.note}" for f in invalid)
+  )
+  assert not leaks, "SCOPE LEAK(S):\n" + "\n".join(
+    f"  {f.surface} {f.method} {f.path} as {f.attacker} → {f.status}: {f.note}"
+    for f in leaks
+  )
+
+
+def test_subgraph_isolation(tenants, client: Client, report: Report) -> None:
+  """Tenant B must be denied on tenant A's subgraph id."""
+  sg = tenants.subgraph_a
+  if not sg:
+    pytest.skip("no subgraph provisioned (tier without subgraph support, or op failed)")
+  found: list[Finding] = []
+  # /members is intentionally rejected on subgraphs, so it's not a valid probe;
+  # /info and /schema are, and the Cypher probe below reads actual data.
+  reads = [
+    f"/v1/graphs/{sg}/info",
+    f"/v1/graphs/{sg}/schema",
+  ]
+  for path in reads:
+    # owner of the parent can see the subgraph (positive); tenant B cannot
+    v = client.get(path, principal=tenants.tenant_a)
+    a = client.get(path, principal=tenants.tenant_b)
+    verdict, note = classify_read(v, a)
+    f = Finding(
+      "scope", "subgraph-read", "GET", path, "B", sg, verdict, a.status_code, note
+    )
+    report.add(f)
+    found.append(f)
+  # cypher on the subgraph — the data probe
+  cpath = f"/v1/graphs/{sg}/query/cypher"
+  v = client.post(cpath, principal=tenants.tenant_a, json=_CYPHER)
+  a = client.post(cpath, principal=tenants.tenant_b, json=_CYPHER)
+  verdict, note = classify_read(v, a)
+  f = Finding(
+    "scope", "subgraph-cypher", "POST", cpath, "B", sg, verdict, a.status_code, note
+  )
+  report.add(f)
+  found.append(f)
+  _assert_clean(found)
+
+
+def test_graph_scoped_key_enforcement(tenants, client: Client, report: Report) -> None:
+  """A graph_a-scoped key must be denied on graph_a2, which its owner also owns."""
+  scoped = tenants.scoped_key_a
+  if scoped is None or not tenants.graph_a2:
+    pytest.skip("scoped key or second graph not provisioned")
+
+  # Sanity: the scoped key works within its scope (graph_a) — so a denial on
+  # graph_a2 is scope enforcement, not a dead key.
+  in_scope = client.get(f"/v1/graphs/{tenants.graph_a}/info", principal=scoped)
+  assert in_scope.status_code // 100 == 2, (
+    f"scoped key denied on its own graph ({in_scope.status_code}) — can't attribute "
+    f"the graph_a2 denial to scope"
+  )
+
+  found: list[Finding] = []
+  for path in (
+    f"/v1/graphs/{tenants.graph_a2}/info",
+    f"/v1/graphs/{tenants.graph_a2}/schema",
+    f"/v1/graphs/{tenants.graph_a2}/query/cypher",
+  ):
+    is_cypher = path.endswith("/query/cypher")
+    if is_cypher:
+      v = client.post(path, principal=tenants.tenant_a, json=_CYPHER)  # account-wide
+      a = client.post(path, principal=scoped, json=_CYPHER)  # scoped to graph_a
+    else:
+      v = client.get(path, principal=tenants.tenant_a)
+      a = client.get(path, principal=scoped)
+    verdict, note = classify_read(v, a)
+    f = Finding(
+      "scope",
+      "scoped-key",
+      "POST" if is_cypher else "GET",
+      path,
+      "A-scoped",
+      tenants.graph_a2,
+      verdict,
+      a.status_code,
+      note,
+    )
+    report.add(f)
+    found.append(f)
+  _assert_clean(found)

--- a/tests/security/isolation/test_vertical.py
+++ b/tests/security/isolation/test_vertical.py
@@ -1,0 +1,117 @@
+"""Vertical axis — privilege escalation within one org.
+
+Where the horizontal axis proves tenant A cannot touch tenant B at all, the
+vertical axis proves that *inside* one org a lower role cannot do a higher
+role's work: a graph VIEWER cannot write, a MEMBER cannot administer, and the
+derived-privilege rule (org OWNER/ADMIN → implicit graph ADMIN) grants exactly
+what it should and no more. Grounded in the verified role model:
+`GraphRole viewer<member<admin` and `GraphUser.get_effective_role`.
+
+── Provisioning blocker (finding for spec OQ1) ──────────────────────────────
+This axis needs a *second* principal inside tenant A's org. The only way to
+add one via the platform is an email invitation
+(`POST /v1/orgs/{org_id}/invitations`, gated by ORG_MEMBER_INVITATIONS_ENABLED),
+and the raw invite token is **neither returned by the API nor recoverable from
+the database** — the DB stores only `sha256(token)` (`org_invitation.py`
+`token_hash`), and the raw token is emailed. So automated provisioning of a
+multi-user org cannot be done black-box, and cannot use the DB side channel
+either. It requires one of:
+  (a) intercepting the invitation email in the target env, or
+  (b) a test-support seam that returns the raw token in a non-prod build.
+Until one exists this axis is provisioned-skipped. The intended matrix below
+is the design, ready to activate once (a) or (b) lands.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ._http import Client
+
+pytestmark = [
+  pytest.mark.isolation,
+  pytest.mark.security,
+  pytest.mark.integration,
+]
+
+
+def _invitations_enabled(client: Client, org_owner) -> bool:
+  """Probe whether org invitations are turned on (else 501)."""
+  if not org_owner.org_id:
+    return False
+  r = client.post(
+    f"/v1/orgs/{org_owner.org_id}/invitations",
+    principal=org_owner,
+    json={"email": "iso-harness-probe@example.com", "role": "member"},
+  )
+  # 501 => flag off; 201 => created (but no raw token in the response, see below)
+  return r.status_code != 501
+
+
+def _provision_role_matrix(client: Client, tenants):
+  """Provision viewer/member/admin principals inside tenant A's org.
+
+  Returns a dict of role -> Principal, or raises Skipped with the reason.
+  Currently always skips: the invite token cannot be obtained programmatically
+  (see the module docstring). The steps are written out so the seam is obvious.
+  """
+  owner = tenants.tenant_a
+  if not _invitations_enabled(client, owner):
+    pytest.skip(
+      "ORG_MEMBER_INVITATIONS_ENABLED is off — enable it to provision a "
+      "multi-user org for the vertical axis"
+    )
+  pytest.skip(
+    "vertical axis not auto-provisionable: the org invite token is emailed and "
+    "stored only as a sha256 hash, so it is retrievable from neither the API "
+    "nor the DB. Needs email interception or a test-support seam (spec OQ1). "
+    "Intended matrix: invite member/admin users -> register with invite_token "
+    "-> grant explicit GraphRole -> assert viewer!write, member!admin, and "
+    "org-admin=implicit-graph-admin (positive)."
+  )
+
+
+def test_viewer_cannot_write(tenants, client: Client) -> None:
+  roles = _provision_role_matrix(client, tenants)
+  viewer = roles["viewer"]
+  graph = tenants.graph_a
+  # viewer can read (positive control)
+  r = client.post(
+    f"/v1/graphs/{graph}/query/cypher",
+    principal=viewer,
+    json={"query": "MATCH (n) RETURN count(n) AS c", "parameters": {}},
+  )
+  assert r.status_code // 100 == 2, f"viewer denied read on own graph: {r.status_code}"
+  # viewer cannot write
+  w = client.post(
+    f"/v1/graphs/{graph}/operations/update-graph-metadata",
+    principal=viewer,
+    json={"description": "viewer write attempt"},
+  )
+  assert w.status_code in (401, 403), f"VIEWER WROTE (escalation): {w.status_code}"
+
+
+def test_member_cannot_administer(tenants, client: Client) -> None:
+  roles = _provision_role_matrix(client, tenants)
+  member = roles["member"]
+  graph = tenants.graph_a
+  # member cannot add another member (admin-only)
+  a = client.post(
+    f"/v1/graphs/{graph}/members",
+    principal=member,
+    json={"user_id": member.user_id, "role": "admin"},
+  )
+  assert a.status_code in (401, 403), (
+    f"MEMBER ADMINISTERED (escalation): {a.status_code}"
+  )
+
+
+def test_org_admin_has_implicit_graph_admin(tenants, client: Client) -> None:
+  """Derived-privilege positive: org ADMIN with no explicit grant can administer."""
+  roles = _provision_role_matrix(client, tenants)
+  admin = roles["admin"]
+  graph = tenants.graph_a
+  m = client.get(f"/v1/graphs/{graph}/members", principal=admin)
+  assert m.status_code // 100 == 2, (
+    f"org admin denied on org graph — derived privilege broken: {m.status_code}"
+  )

--- a/tests/security/isolation/test_vertical.py
+++ b/tests/security/isolation/test_vertical.py
@@ -4,22 +4,19 @@ Where the horizontal axis proves tenant A cannot touch tenant B at all, the
 vertical axis proves that *inside* one org a lower role cannot do a higher
 role's work: a graph VIEWER cannot write, a MEMBER cannot administer, and the
 derived-privilege rule (org OWNER/ADMIN → implicit graph ADMIN) grants exactly
-what it should and no more. Grounded in the verified role model:
-`GraphRole viewer<member<admin` and `GraphUser.get_effective_role`.
+what it should. Grounded in the verified role model: `GraphRole viewer<member<
+admin` and `GraphUser.get_effective_role`.
 
-── Provisioning blocker (finding for spec OQ1) ──────────────────────────────
-This axis needs a *second* principal inside tenant A's org. The only way to
-add one via the platform is an email invitation
-(`POST /v1/orgs/{org_id}/invitations`, gated by ORG_MEMBER_INVITATIONS_ENABLED),
-and the raw invite token is **neither returned by the API nor recoverable from
-the database** — the DB stores only `sha256(token)` (`org_invitation.py`
-`token_hash`), and the raw token is emailed. So automated provisioning of a
-multi-user org cannot be done black-box, and cannot use the DB side channel
-either. It requires one of:
-  (a) intercepting the invitation email in the target env, or
-  (b) a test-support seam that returns the raw token in a non-prod build.
-Until one exists this axis is provisioned-skipped. The intended matrix below
-is the design, ready to activate once (a) or (b) lands.
+── Provisioning ─────────────────────────────────────────────────────────────
+This axis needs a second principal inside tenant A's org. The only way to add
+one is an email invitation, and the raw invite token is neither in the API
+response nor recoverable from the DB (stored as `sha256(token)`). So the run
+depends on two flags being on in the (non-prod) target:
+  - ORG_MEMBER_INVITATIONS_ENABLED — the invitation feature, and
+  - AUTH_INVITE_TOKEN_IN_RESPONSE — the test-support seam that returns the raw
+    token in the create response (structurally forced off in production).
+With both on, `provision_role_matrix` completes invite → register → role-grant
+and these tests run; otherwise `tenants.roles` is empty and they skip.
 """
 
 from __future__ import annotations
@@ -34,70 +31,62 @@ pytestmark = [
   pytest.mark.integration,
 ]
 
-
-def _invitations_enabled(client: Client, org_owner) -> bool:
-  """Probe whether org invitations are turned on (else 501)."""
-  if not org_owner.org_id:
-    return False
-  r = client.post(
-    f"/v1/orgs/{org_owner.org_id}/invitations",
-    principal=org_owner,
-    json={"email": "iso-harness-probe@example.com", "role": "member"},
-  )
-  # 501 => flag off; 201 => created (but no raw token in the response, see below)
-  return r.status_code != 501
+_CYPHER = {"query": "MATCH (n) RETURN count(n) AS c", "parameters": {}}
 
 
-def _provision_role_matrix(client: Client, tenants):
-  """Provision viewer/member/admin principals inside tenant A's org.
-
-  Returns a dict of role -> Principal, or raises Skipped with the reason.
-  Currently always skips: the invite token cannot be obtained programmatically
-  (see the module docstring). The steps are written out so the seam is obvious.
-  """
-  owner = tenants.tenant_a
-  if not _invitations_enabled(client, owner):
+def _role(tenants, name: str):
+  roles = tenants.roles or {}
+  if name not in roles:
     pytest.skip(
-      "ORG_MEMBER_INVITATIONS_ENABLED is off — enable it to provision a "
-      "multi-user org for the vertical axis"
+      "role matrix not provisioned — set ORG_MEMBER_INVITATIONS_ENABLED and "
+      "AUTH_INVITE_TOKEN_IN_RESPONSE in the (non-prod) target"
     )
-  pytest.skip(
-    "vertical axis not auto-provisionable: the org invite token is emailed and "
-    "stored only as a sha256 hash, so it is retrievable from neither the API "
-    "nor the DB. Needs email interception or a test-support seam (spec OQ1). "
-    "Intended matrix: invite member/admin users -> register with invite_token "
-    "-> grant explicit GraphRole -> assert viewer!write, member!admin, and "
-    "org-admin=implicit-graph-admin (positive)."
+  return roles[name]
+
+
+def test_viewer_can_read(tenants, client: Client) -> None:
+  """Positive control: a graph VIEWER can read (so a write denial is meaningful)."""
+  viewer = _role(tenants, "viewer")
+  r = client.post(
+    f"/v1/graphs/{tenants.graph_a}/query/cypher", principal=viewer, json=_CYPHER
   )
+  assert r.status_code // 100 == 2, f"viewer denied read on own graph: {r.status_code}"
 
 
 def test_viewer_cannot_write(tenants, client: Client) -> None:
-  roles = _provision_role_matrix(client, tenants)
-  viewer = roles["viewer"]
-  graph = tenants.graph_a
-  # viewer can read (positive control)
-  r = client.post(
-    f"/v1/graphs/{graph}/query/cypher",
-    principal=viewer,
-    json={"query": "MATCH (n) RETURN count(n) AS c", "parameters": {}},
-  )
-  assert r.status_code // 100 == 2, f"viewer denied read on own graph: {r.status_code}"
-  # viewer cannot write
+  viewer = _role(tenants, "viewer")
   w = client.post(
-    f"/v1/graphs/{graph}/operations/update-graph-metadata",
+    f"/v1/graphs/{tenants.graph_a}/operations/update-graph-metadata",
     principal=viewer,
     json={"description": "viewer write attempt"},
   )
   assert w.status_code in (401, 403), f"VIEWER WROTE (escalation): {w.status_code}"
 
 
+def test_viewer_cannot_write_cypher(tenants, client: Client) -> None:
+  viewer = _role(tenants, "viewer")
+  w = client.post(
+    f"/v1/graphs/{tenants.graph_a}/query/cypher",
+    principal=viewer,
+    json={"query": "CREATE (n:IsoHarnessProbe {m: 1}) RETURN n", "parameters": {}},
+  )
+  assert w.status_code in (401, 403), (
+    f"VIEWER WROTE CYPHER (escalation): {w.status_code}"
+  )
+
+
+def test_member_can_read(tenants, client: Client) -> None:
+  member = _role(tenants, "member")
+  r = client.post(
+    f"/v1/graphs/{tenants.graph_a}/query/cypher", principal=member, json=_CYPHER
+  )
+  assert r.status_code // 100 == 2, f"member denied read on own graph: {r.status_code}"
+
+
 def test_member_cannot_administer(tenants, client: Client) -> None:
-  roles = _provision_role_matrix(client, tenants)
-  member = roles["member"]
-  graph = tenants.graph_a
-  # member cannot add another member (admin-only)
+  member = _role(tenants, "member")
   a = client.post(
-    f"/v1/graphs/{graph}/members",
+    f"/v1/graphs/{tenants.graph_a}/members",
     principal=member,
     json={"user_id": member.user_id, "role": "admin"},
   )
@@ -108,10 +97,8 @@ def test_member_cannot_administer(tenants, client: Client) -> None:
 
 def test_org_admin_has_implicit_graph_admin(tenants, client: Client) -> None:
   """Derived-privilege positive: org ADMIN with no explicit grant can administer."""
-  roles = _provision_role_matrix(client, tenants)
-  admin = roles["admin"]
-  graph = tenants.graph_a
-  m = client.get(f"/v1/graphs/{graph}/members", principal=admin)
+  admin = _role(tenants, "admin")
+  m = client.get(f"/v1/graphs/{tenants.graph_a}/members", principal=admin)
   assert m.status_code // 100 == 2, (
     f"org admin denied on org graph — derived privilege broken: {m.status_code}"
   )


### PR DESCRIPTION
## Summary

Adds a black-box authorization test harness that provisions real test tenants and fires a cross-tenant + privilege-escalation matrix at a live deployment over HTTP, classifying each response PASS / LEAK / INVALID / INCONCLUSIVE. It is the first authenticated test of **R-11 (multi-tenant isolation)** — the load-bearing claim of the product and a HIGH-inherent risk that had never been tested. The harness is opt-in (skips unless `TARGET_API_URL` is set), so it is inert in a normal `just test` / CI run and gates nothing. Also included is a small, non-prod-only auth test-support seam that unblocks the harness's vertical axis.

Run against the local stack this surfaced zero leaks — every cross-tenant probe was denied — while the oracle's own unit tests prove it can detect a leak (it caught a real bug in its first cut mid-development).

## Changes

- **Harness (`tests/security/isolation/`)** — a pytest suite, marked `isolation`/`security`/`integration`, skip-gated on `TARGET_API_URL`:
  - `_provision.py` — provisions two independent tenants (register → login → API key → create graph, both extensions), plus a second graph for tenant A, a subgraph, a graph-scoped key, and (when the flags below are on) a multi-user org role matrix.
  - `_oracle.py` — verdicts computed from API responses only, comparing the attacker's response to the owner's own (the positive control is the truth source). Catches the known leak shape of a 200 carrying another tenant's `org_name` with empty collections, which a status-code check misses.
  - `_http.py` / `_report.py` / `matrix.py` / `conftest.py` — the black-box client, JSON+text report, surface definitions, and fixtures.
  - `test_horizontal.py` — cross-tenant matrix (both directions) over REST reads, Cypher, destructive core ops (delete-graph, materialize, change-tier, backup, subgraph), MCP read/write tools, GraphQL, and the roboledger + roboinvestor extensions command surfaces.
  - `test_scoping.py` — subgraph isolation and graph-scoped API-key enforcement.
  - `test_vertical.py` — privilege escalation within one org (viewer can't write, member can't administer, org-admin has implicit graph admin).
  - `test_oracle.py` — unit tests proving the classifier flags leaks (runs in the normal suite; no live target needed).
  - `README.md` — how to run, the oracle rationale, the connection model.
- **Auth test-support seam** *(commit `c393b363` — please review this commit closely; it is the only production-code change and it touches auth)*:
  - `robosystems/config/env.py` — new `AUTH_INVITE_TOKEN_IN_RESPONSE` flag (default off) and an `expose_invite_token_in_response()` guard that **ANDs the flag with `not is_production()`**, so the token can never surface in a production response regardless of the env var.
  - `robosystems/models/api/orgs.py` — `OrgInvitationResponse` gains a nullable `token` field, populated only under the guard above and documented as test-support only.
  - `robosystems/routers/orgs/invitations.py` — sets that field on the create response when the guard allows, so automated authorization tests can complete the invite → register → role-grant flow without email interception (the raw token is otherwise emailed and stored only as `sha256`).
- **`pytest.ini`** — registers the `isolation` marker.

## Breaking Changes

None. The only API-surface change is additive: `OrgInvitationResponse` gains a nullable `token` field (null in every environment except a non-prod build with the test-support flag on). This is a generated-tier SDK change — an SDK regen opportunity that rides a client minor, not a break; no facade or integration-template symbol is affected.

## Testing

- **Isolation harness** — run against the local stack (`TARGET_API_URL=http://localhost:8000`): **31 tests green**. Horizontal axis = 58 cross-tenant probes, all denied 403 in both directions; scoping and vertical axes green; 16 oracle unit tests green. The vertical axis was exercised with the two flags on locally.
- **Code quality** — `ruff check`, `ruff format`, and `just typecheck` all clean, enforced by the pre-commit hook on every commit (0 errors).
- **`just test-all` (full unit suite)** — not run this session. The harness is opt-in and skips without `TARGET_API_URL`, so it does not change the default suite; the oracle unit tests (`test_oracle.py`) do run in it.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
