### PR TITLE
fix(sec): nightly full-rebuild materialization + per-database run concurrency

### DIFF
--- a/dagster_home/dagster.yaml
+++ b/dagster_home/dagster.yaml
@@ -77,6 +77,12 @@ run_coordinator:
         limit: 1
         value:
           applyLimitPerUniqueValue: true
+      # Parity with dagster_prod.yaml: one materialization per target graph
+      # database (see the prod file for the full rationale).
+      - key: "materialize_db"
+        limit: 1
+        value:
+          applyLimitPerUniqueValue: true
 
 # Telemetry - disable for privacy
 telemetry:

--- a/dagster_home/dagster_prod.yaml
+++ b/dagster_home/dagster_prod.yaml
@@ -106,6 +106,19 @@ run_coordinator:
         limit: 1
         value:
           applyLimitPerUniqueValue: true
+      # One materialization per target graph database. sec_materialize carries
+      # materialize_db as a job-level tag, so sensor-fired and manually launched
+      # runs are both covered. Two materialize runs COPYing into the same
+      # LadybugDB database interleave writes, and rel tables have no primary
+      # key — duplicate edges land silently and would publish to replicas as
+      # corrupt data. The stage→materialize sensor's own STARTED/QUEUED guard is
+      # check-then-act and cannot close this race (observed 2026-08-13: a
+      # sensor backlog tick fired 17s behind a manual launch). Queuing the
+      # duplicate makes the worst case a redundant run, never corruption.
+      - key: "materialize_db"
+        limit: 1
+        value:
+          applyLimitPerUniqueValue: true
 
 # Telemetry - disable for privacy
 telemetry:

--- a/robosystems/adapters/sec/pipeline/jobs.py
+++ b/robosystems/adapters/sec/pipeline/jobs.py
@@ -173,6 +173,12 @@ sec_materialize_job = define_asset_job(
   tags={
     "pipeline": "sec",
     "phase": "materialize",
+    # One writer per target database: paired with the tag_concurrency_limits
+    # entry in dagster_home/dagster_prod.yaml, this queues a duplicate launch
+    # instead of letting it race. Job-level so sensor-fired AND manually
+    # launched runs both carry it. Concurrent COPYs into the same LadybugDB
+    # database silently duplicate rel-table edges (no primary key).
+    "materialize_db": "sec",
     # Light profile: HTTP orchestration to Graph API
     "ecs/cpu": "512",
     "ecs/memory": "2048",

--- a/robosystems/adapters/sec/pipeline/sensors.py
+++ b/robosystems/adapters/sec/pipeline/sensors.py
@@ -8,7 +8,7 @@ Nightly Pipeline (enable all for automated daily updates):
 - Phase 2+3 (Process+Stage): sec_incremental_pipeline_sensor chains
   download → process (batched loop) → stage (DuckDB INSERT)
 - Phase 4 (Materialize): sec_stage_to_materialize_sensor chains stage → materialize
-  (incremental Mon-Thu; full rebuild on the Friday ET run as a weekly reconciliation)
+  (full rebuild nightly; incremental mode is parked — see the sensor docstring)
 - Phase 5 (Publish+Refresh): sec_post_materialize_publish_sensor chains
   materialize → lbug S3 publish → duckdb S3 publish → replica refresh → master sleep
 - Phase 5c (Text Index): sec_post_stage_index_sensor chains
@@ -18,15 +18,12 @@ Backfill Processing (enable for bulk/manual processing):
 - sec_processing_sensor: Discovers pending SourceFiles, triggers batch processing per quarter
 
 Nightly flow: New data is added to existing DuckDB tables (INSERT with dedup),
-then only the new rows are COPYed into the existing LadybugDB graph (keyset
-anti-join). The Friday ET run instead does a full rebuild from DuckDB to
-reconcile drift. The whole chain wakes the master at the start and sleeps it
-after publish, so reconciliation reuses that lifecycle rather than a separate
-schedule.
+then the LadybugDB graph is fully rebuilt from DuckDB (the staging source of
+truth). The whole chain wakes the master at the start and sleeps it after
+publish.
 """
 
-from datetime import UTC, datetime, timedelta
-from zoneinfo import ZoneInfo
+from datetime import UTC, datetime
 
 from dagster import (
   DagsterRunStatus,
@@ -543,16 +540,18 @@ def sec_stage_to_materialize_sensor(context: RunStatusSensorContext):
   Part of the nightly pipeline chain:
     process → stage (DuckDB INSERT) → materialize → S3 publish
 
-  Mon-Thu nights materialize **incrementally** - only new rows are COPYed into
-  the existing graph (per-table keyset anti-join), no rebuild. The **Friday** ET
-  run does a **full rebuild** instead: a weekly reconciliation from the same
-  DuckDB staging (source of truth) that erases any incremental drift (partial
-  batch failures, un-refreshed mutable Entity attributes, hash-batch edge cases).
-  Reconciliation rides this same chain — wake → stage → materialize → publish →
-  sleep — rather than a separate schedule, so the master lifecycle and S3 publish
-  are reused for both modes. S3 publishes are handled by
+  Every night does a **full rebuild** from the same DuckDB staging (source of
+  truth): rebuild-from-scratch erases any drift (partial batch failures,
+  un-refreshed mutable Entity attributes), and its streaming COPY into an empty
+  database has a far smaller memory working set than incremental mode, whose
+  keyset-export + anti-join scales with the accumulated graph. Incremental
+  (per-table keyset anti-join, no rebuild) is parked as of 2026-08-13 — at
+  current corpus scale it exceeds the shared master's memory budget and
+  OOM-kills the Graph API mid-run — but remains available for manual runs via
+  SECMaterializeConfig. The chain — wake → stage → materialize → publish →
+  sleep — is unchanged. S3 publishes are handled by
   sec_post_materialize_publish_sensor (which keys off the mode:incremental tag,
-  set for both).
+  set on every nightly run).
   """
   if env.ENVIRONMENT == "dev":
     context.log.info("Skipping chain sensor in dev environment")
@@ -580,32 +579,13 @@ def sec_stage_to_materialize_sensor(context: RunStatusSensorContext):
     )
     return
 
-  # Friday ET run = weekly full-rebuild reconciliation; other nights incremental.
-  et_now = datetime.now(ZoneInfo("America/New_York"))
-  materialize_mode = "full" if et_now.weekday() == 4 else "incremental"
-  if materialize_mode == "full":
-    # Guard against a second full in the same window — e.g. a Thursday chain that
-    # spilled past ET midnight also reads as Friday. One full rebuild per week is
-    # enough; fall back to incremental if one already ran in the last 3 days.
-    try:
-      recent_full = context.instance.get_run_records(
-        filters=RunsFilter(
-          job_name="sec_materialize",
-          statuses=[DagsterRunStatus.SUCCESS],
-          tags={"materialize_mode": "full"},
-        ),
-        limit=1,
-        ascending=False,
-      )
-      if recent_full and (
-        datetime.now(UTC) - recent_full[0].create_timestamp < timedelta(days=3)
-      ):
-        materialize_mode = "incremental"
-        context.log.info("Full rebuild already ran this week — using incremental")
-    except Exception as guard_err:
-      context.log.warning(
-        f"Could not check recent full rebuilds ({guard_err}); proceeding with full"
-      )
+  # Full rebuild every night. Incremental mode is parked (2026-08-13): at
+  # current corpus scale its keyset-export + anti-join phase runs DuckDB and
+  # LadybugDB hot simultaneously and exceeds the shared master's memory budget,
+  # OOM-killing the Graph API mid-run. The machinery remains available for
+  # manual runs via SECMaterializeConfig; revisit when nightly full-rebuild
+  # duration threatens the wake window.
+  materialize_mode = "full"
 
   context.log.info(
     f"DuckDB staging completed (run_id={dagster_run.run_id}), "
@@ -628,7 +608,7 @@ def sec_stage_to_materialize_sensor(context: RunStatusSensorContext):
       "pipeline": "sec",
       "phase": "materialize",
       # mode:incremental marks the chain lineage (the publish + sleep sensors key
-      # off it) for BOTH incremental and Friday full-rebuild runs.
+      # off it) for every nightly run regardless of materialize_mode.
       "mode": "incremental",
       "materialize_mode": materialize_mode,
     },

--- a/tests/adapters/sec/pipeline/test_init.py
+++ b/tests/adapters/sec/pipeline/test_init.py
@@ -63,8 +63,8 @@ class TestGetDagsterComponents:
   def test_expected_number_of_schedules(self):
     """Test that the expected number of schedules are registered."""
     components = get_dagster_components()
-    # Only the incremental download schedule — the weekly full-rebuild
-    # reconciliation rides the nightly chain (Friday full), not a separate schedule.
+    # Only the incremental download schedule — the nightly full rebuild rides
+    # the sensor chain (stage → materialize), not a separate schedule.
     assert len(components["schedules"]) == 1
 
   def test_asset_names_include_core_pipeline(self):

--- a/tests/adapters/sec/pipeline/test_sensors.py
+++ b/tests/adapters/sec/pipeline/test_sensors.py
@@ -410,6 +410,15 @@ class TestSecStageToMaterializeSensor:
     assert isinstance(result[0], RunRequest)
     assert result[0].tags["mode"] == "incremental"
     assert result[0].tags["phase"] == "materialize"
+    # Incremental materialize_mode is parked — every nightly run is a full
+    # rebuild (see sec_stage_to_materialize_sensor docstring).
+    assert result[0].tags["materialize_mode"] == "full"
+    assert (
+      result[0].run_config["ops"]["sec_graph_materialized"]["config"][
+        "materialize_mode"
+      ]
+      == "full"
+    )
 
   @patch("robosystems.adapters.sec.pipeline.sensors.env")
   def test_skips_when_materialize_already_running(self, mock_env):


### PR DESCRIPTION
## Summary

Switches the nightly SEC materialization to a full rebuild every night and parks incremental mode: at current corpus scale, incremental's keyset-export + anti-join phase runs DuckDB and LadybugDB hot simultaneously and exceeds the shared master's memory budget, failing the last two nightly runs (2026-08-12 and 2026-08-13) with identical signatures. A full rebuild streams COPY into an empty database with a far smaller working set and is unaffected. Also adds a run-level concurrency limit so two materializations can never write the same graph database concurrently.

## Changes

**`robosystems/adapters/sec/pipeline/sensors.py`**
- `sec_stage_to_materialize_sensor` now always requests `materialize_mode: "full"`; the weekday-based mode selection and the 3-day "recent full" guard are removed (the guard existed only to prevent a double full in one weekly window — with full running nightly it would have downgraded every night after the first success back to the failing incremental mode).
- Module and sensor docstrings updated to document the parked status and the un-park trigger (nightly full-rebuild duration threatening the wake window). The incremental machinery is deliberately **not** removed — it stays reachable for manual runs via `SECMaterializeConfig` and remains covered by the real-engine parity test.

**`robosystems/adapters/sec/pipeline/jobs.py`**
- `sec_materialize_job` gains a job-level `materialize_db: sec` tag, so sensor-fired and manually launched runs both carry it.

**`dagster_home/dagster_prod.yaml`, `dagster_home/dagster.yaml`**
- New `tag_concurrency_limits` entry on `materialize_db` (limit 1 per unique value): one in-flight materialization per target graph database. The sensor's existing STARTED/QUEUED guard is check-then-act and lost this race in practice (a sensor backlog tick fired 17 s behind a manual launch); concurrent COPYs into the same LadybugDB database would silently duplicate rel-table edges since rel tables have no primary key. With the limit, a duplicate launch queues — worst case a redundant run, never interleaved writes. Follows the existing `quarter` limit pattern in the same file.

**Tests**
- `test_sensors.py`: the stage→materialize RunRequest test now asserts `materialize_mode == "full"` in both tags and run config.
- `test_init.py`: comment updated for the retired Friday cadence.

## Breaking Changes

None. No API surface changes; SDK tiers untouched (Dagster orchestration + instance config only).

## Testing

- `just test adapters/sec/pipeline` — 186 passed, 9 skipped
- `just test dagster` — 231 passed
- `just test-code` — ruff, format, basedpyright, cf-lint all green
