### PR TITLE
fix: purge documents on offboarding + apply org graph limit at checkout

### DIFF
--- a/robosystems/config/deprovisioning.py
+++ b/robosystems/config/deprovisioning.py
@@ -7,6 +7,11 @@ from dataclasses import dataclass, field
 class DeprovisioningConfig:
   """Configuration for graph deprovisioning behavior."""
 
+  # The suspend → auto-deprovision grace window. A canceled subscription
+  # suspends the graph; suspended_graph_deprovisioning_sensor
+  # (dagster/sensors/graph_lifecycle.py) only tears it down once
+  # ends_at < now - retention_days, unless the cancellation was IMMEDIATE.
+  # Load-bearing — not the backup hosting window (that is backup_hosting_days).
   retention_days: int = 7
   require_final_backup: bool = True
   backup_delay_hours: int = 24

--- a/robosystems/operations/graph/deprovision_service.py
+++ b/robosystems/operations/graph/deprovision_service.py
@@ -32,6 +32,8 @@ class DeprovisionResult:
   extensions_schema_dropped: bool = False
   registry_deallocated: bool = False
   records_cleaned: bool = False
+  documents_deleted: int = 0
+  search_purged: bool = False
   errors: list[str] = field(default_factory=list)
 
   @property
@@ -131,6 +133,9 @@ class GraphDeprovisionService:
     # --- 3b. Drop extensions OLTP schema (financial-data removal) ---
     self._drop_extensions_schema(graph_id, result)
 
+    # --- 3c. Purge documents from the shared search index ---
+    self._purge_search_index(graph_id, result)
+
     # --- 4. Deallocate DynamoDB registry ---
     await self._deallocate_registry(graph_id, result)
 
@@ -214,6 +219,7 @@ class GraphDeprovisionService:
 
       # Clean subgraph PG records (schemas, files) before marking deprovisioned
       self._clean_pg_records(subgraph.graph_id, session, result)
+      self._purge_search_index(subgraph.graph_id, result)
 
       # Mark subgraph as deprovisioned regardless of DB deletion outcome
       try:
@@ -260,6 +266,31 @@ class GraphDeprovisionService:
       result.errors.append(error_msg)
       logger.warning(error_msg, extra={"graph_id": graph_id})
 
+  def _purge_search_index(self, graph_id: str, result: DeprovisionResult) -> None:
+    """Purge the tenant's documents from the shared OpenSearch index.
+
+    The document index is shared across all tenants (an application-level
+    graph_id filter is the only boundary), so a departed tenant's content
+    persisting in it is real over-retention. Guarded on SEMANTIC_SEARCH_ENABLED
+    so a search-disabled deployment is a clean no-op, and best-effort so an
+    index failure records a warning without stranding the teardown.
+    """
+    from ...config import env
+
+    if not env.SEMANTIC_SEARCH_ENABLED:
+      return
+    try:
+      from ...operations.search.client import OpenSearchClient
+
+      client = OpenSearchClient(env.OPENSEARCH_URL, env.OPENSEARCH_INDEX)
+      client.delete_by_graph_id(graph_id)
+      result.search_purged = True
+      logger.info(f"Purged search index for graph {graph_id}")
+    except Exception as e:
+      error_msg = f"Search index purge failed: {e}"
+      result.errors.append(error_msg)
+      logger.warning(error_msg, extra={"graph_id": graph_id})
+
   async def _deallocate_registry(
     self, graph_id: str, result: DeprovisionResult
   ) -> None:
@@ -284,6 +315,7 @@ class GraphDeprovisionService:
     GraphBackup records are intentionally kept for post-deprovisioning hosting.
     """
     try:
+      from ...models.core.document import Document
       from ...models.core.graph.graph_credits import (
         GraphCredits,
         GraphCreditTransaction,
@@ -311,6 +343,16 @@ class GraphDeprovisionService:
       session.query(GraphFile).filter(GraphFile.graph_id == graph_id).delete(
         synchronize_session=False
       )
+
+      # documents.graph_id cascades on the graphs row, but step 7 is a soft
+      # delete so the cascade never fires — delete explicitly here. The shared
+      # OpenSearch content is purged separately in _purge_search_index.
+      documents_deleted = (
+        session.query(Document)
+        .filter(Document.graph_id == graph_id)
+        .delete(synchronize_session=False)
+      )
+      result.documents_deleted += documents_deleted
 
       session.flush()
       result.records_cleaned = True

--- a/robosystems/routers/billing/checkout.py
+++ b/robosystems/routers/billing/checkout.py
@@ -51,7 +51,7 @@ async def create_checkout_session(
     )
 
   try:
-    from ...models.core import OrgRole, OrgUser
+    from ...models.core import OrgLimits, OrgRole, OrgUser
 
     # Get user's org - they must be an OWNER
     user_orgs = OrgUser.get_user_orgs(current_user.id, db)
@@ -69,6 +69,17 @@ async def create_checkout_session(
         status_code=403,
         detail="Only organization owners can manage billing",
       )
+
+    # Gate a graph checkout on the org's graph limit before collecting payment.
+    # The graph-creation route enforces the same limit up front, but in the
+    # checkout lane provisioning happens post-payment via the webhook, so
+    # without this an org at its limit could pay and then be refused the graph
+    # it just bought. Refuse the sale here instead, matching the graph route.
+    if request.resource_type == "graph":
+      org_limits = OrgLimits.get_or_create_for_org(org_id, db)
+      can_create, reason = org_limits.can_create_graph(db)
+      if not can_create:
+        raise HTTPException(status_code=403, detail=reason)
 
     customer = BillingCustomer.get_or_create(org_id, db)
     logger.info(f"Using billing customer for org {org_id}")

--- a/tests/operations/graph/test_deprovision_search_purge.py
+++ b/tests/operations/graph/test_deprovision_search_purge.py
@@ -1,0 +1,56 @@
+# pyright: reportPrivateUsage=false
+"""Regression tests for the OpenSearch purge on graph deprovision.
+
+Locks in the fix that a deprovisioned tenant's documents are removed from the
+shared search index (an application-level graph_id filter is the only boundary),
+that a search-disabled deployment is a clean no-op, and that an index failure is
+best-effort — recorded, never blocking teardown.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from robosystems.operations.graph.deprovision_service import (
+  DeprovisionResult,
+  GraphDeprovisionService,
+)
+
+GID = "kg" + "0" * 16
+_CLIENT = "robosystems.operations.search.client.OpenSearchClient"
+_FLAG = "robosystems.config.env.EnvConfig.SEMANTIC_SEARCH_ENABLED"
+
+
+@pytest.mark.unit
+class TestDeprovisionSearchPurge:
+  def test_purge_deletes_and_records(self) -> None:
+    svc = GraphDeprovisionService("test")
+    result = DeprovisionResult(graph_id=GID, status="success")
+    with patch(_FLAG, True), patch(_CLIENT) as cls:
+      client = MagicMock()
+      cls.return_value = client
+      svc._purge_search_index(GID, result)
+    client.delete_by_graph_id.assert_called_once_with(GID)
+    assert result.search_purged is True
+    assert result.errors == []
+
+  def test_purge_skipped_when_search_disabled(self) -> None:
+    # No cluster call, no error, no partial-status downgrade.
+    svc = GraphDeprovisionService("test")
+    result = DeprovisionResult(graph_id=GID, status="success")
+    with patch(_FLAG, False), patch(_CLIENT) as cls:
+      svc._purge_search_index(GID, result)
+    cls.assert_not_called()
+    assert result.search_purged is False
+    assert result.errors == []
+
+  def test_purge_failure_is_best_effort(self) -> None:
+    svc = GraphDeprovisionService("test")
+    result = DeprovisionResult(graph_id=GID, status="success")
+    with patch(_FLAG, True), patch(_CLIENT) as cls:
+      client = MagicMock()
+      client.delete_by_graph_id.side_effect = RuntimeError("boom")
+      cls.return_value = client
+      svc._purge_search_index(GID, result)  # must not raise
+    assert result.search_purged is False
+    assert any("Search index purge failed" in e for e in result.errors)

--- a/tests/operations/graph/test_deprovision_service.py
+++ b/tests/operations/graph/test_deprovision_service.py
@@ -76,6 +76,14 @@ def _patch_infra():
   )
 
 
+@pytest.fixture(autouse=True)
+def _stub_search_purge():
+  """Deprovision runs a best-effort OpenSearch purge, and SEMANTIC_SEARCH_ENABLED
+  is true under test — stub the client so these tests never reach a real cluster."""
+  with patch("robosystems.operations.search.client.OpenSearchClient"):
+    yield
+
+
 class TestDeprovisionService:
   """Tests for GraphDeprovisionService.deprovision_graph."""
 
@@ -362,6 +370,7 @@ class TestDeprovisionService:
     self, service, db_session, test_graph, test_user
   ):
     """Verify PG records are cleaned up."""
+    from robosystems.models.core.document import Document
     from robosystems.models.core.graph.graph_credits import GraphCredits
     from robosystems.models.core.graph.graph_user import GraphUser
 
@@ -380,6 +389,14 @@ class TestDeprovisionService:
     )
     db_session.add(credits)
     db_session.commit()
+
+    Document.create(
+      graph_id=test_graph.graph_id,
+      user_id=test_user.id,
+      title="A departed tenant's memo",
+      content="confidential",
+      session=db_session,
+    )
 
     with (
       patch(
@@ -416,6 +433,15 @@ class TestDeprovisionService:
         .count()
       )
       assert remaining_credits == 0
+
+      # The departed tenant's documents must not survive teardown.
+      remaining_documents = (
+        db_session.query(Document)
+        .filter(Document.graph_id == test_graph.graph_id)
+        .count()
+      )
+      assert remaining_documents == 0
+      assert result.documents_deleted >= 1
 
   @pytest.mark.asyncio
   async def test_deprovision_updates_subscription_metadata(

--- a/tests/routers/billing/test_checkout.py
+++ b/tests/routers/billing/test_checkout.py
@@ -39,6 +39,17 @@ class TestCreateCheckoutSession:
       resource_config={"tier": "standard"},
     )
 
+  @pytest.fixture(autouse=True)
+  def _allow_graph_limit(self):
+    """A graph checkout now gates on the org graph limit before payment. Default
+    to allow so the existing flow tests exercise the path below it; the refusal
+    case has its own test."""
+    with patch(
+      "robosystems.models.core.OrgLimits.get_or_create_for_org"
+    ) as mock_limits:
+      mock_limits.return_value.can_create_graph.return_value = (True, "")
+      yield mock_limits
+
   @pytest.mark.asyncio
   @patch("robosystems.models.core.OrgUser.get_user_orgs")
   @patch("robosystems.routers.billing.checkout.BillingCustomer.get_or_create")
@@ -367,6 +378,39 @@ class TestCreateCheckoutSession:
 
     assert result.checkout_url == "https://checkout.stripe.com/test"
     mock_get_plan.assert_called_once_with("sec", "starter")
+
+  @pytest.mark.asyncio
+  @patch("robosystems.models.core.OrgUser.get_user_orgs")
+  @patch("robosystems.routers.billing.checkout.BillingCustomer.get_or_create")
+  async def test_create_checkout_session_refuses_over_graph_limit(
+    self, mock_get_customer, mock_get_user_orgs, mock_user, mock_db, checkout_request
+  ):
+    """A graph checkout is refused before payment when the org is at its limit.
+
+    The refusal must land before any Stripe customer/session is created — the
+    whole point of §9.1 is not taking money for a graph we will then refuse.
+    """
+    from robosystems.models.core import OrgRole
+
+    mock_org_user = Mock()
+    mock_org_user.org_id = "org_123"
+    mock_org_user.role = OrgRole.OWNER
+    mock_get_user_orgs.return_value = [mock_org_user]
+
+    with patch(
+      "robosystems.models.core.OrgLimits.get_or_create_for_org"
+    ) as mock_limits:
+      mock_limits.return_value.can_create_graph.return_value = (
+        False,
+        "Graph limit reached (0 of 0 graphs used)",
+      )
+      with pytest.raises(HTTPException) as exc:
+        await create_checkout_session(checkout_request, mock_user, mock_db, None)
+
+    assert exc.value.status_code == 403
+    assert "limit" in exc.value.detail.lower()
+    # No payment plumbing should have run.
+    mock_get_customer.assert_not_called()
 
 
 class TestGetCheckoutStatus:


### PR DESCRIPTION
## Summary

Two pre-flight hardening fixes ahead of a cradle-to-grave tenant lifecycle drill. The first completes data deletion so an offboarded graph leaves no document residue behind; the second applies the organization graph limit at the point of sale, consistent with the graph-creation route.

## Changes

**Graph deprovision — complete document deletion** (`operations/graph/deprovision_service.py`, `config/deprovisioning.py`)

- `Document` rows are now deleted in `_clean_pg_records`. They previously survived teardown: `documents.graph_id` cascades on the `graphs` row, but that row is *soft*-deleted, so the cascade never fired.
- New best-effort `_purge_search_index` step removes the graph's content from the shared OpenSearch index, guarded on `SEMANTIC_SEARCH_ENABLED` so a search-disabled deployment is a clean no-op rather than a status downgrade.
- `DeprovisionResult` now reports `documents_deleted` and `search_purged`.
- Documented `retention_days` on `DeprovisioningConfig` to record that it is the suspend→deprovision sensor window (`dagster/sensors/graph_lifecycle.py`), distinct from the backup-hosting window — the two must not be conflated.

**Billing — harden the graph checkout precondition** (`routers/billing/checkout.py`)

- Apply the organization's graph limit at checkout, before creating the checkout session, so the same limit the graph-creation route enforces is checked at the point of sale. Reuses the existing `OrgLimits` helper so the two paths cannot disagree.
- Scoped to `resource_type == "graph"`; repository purchases are unaffected.

**Tests**

- `test_deprovision_search_purge.py` (new): the purge on the enabled / disabled / failure paths.
- `test_deprovision_service.py`: asserts `Document` rows are gone after teardown; a module-level stub keeps the purge off a real cluster.
- `test_checkout.py`: a refusal-before-payment test (asserts no Stripe customer is created), plus an allow-by-default patch so the existing flow tests exercise the path below the gate.

## Breaking Changes

None. No public API shape changes — the checkout refusal reuses the existing `403` response, and the new `DeprovisionResult` fields are additive and internal. No client SDK regen required.

## Testing

- `just test` (full unit suite): **12,838 passed, 38 skipped, 0 failed**.
- `just test-code` (ruff + format + basedpyright + cf-lint): all clean.
- Pre-commit hooks passed on both commits.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
