### PR TITLE
fix(billing): finalize checkout provisioning in a fresh session

### DIFF
--- a/robosystems/dagster/jobs/billing.py
+++ b/robosystems/dagster/jobs/billing.py
@@ -92,12 +92,18 @@ async def _handle_checkout_completed(
 
     if stripe_subscription_id:
       subscription.stripe_subscription_id = stripe_subscription_id
-      # Preserve checkout session ID in metadata before overwriting
-      # Must create a new dict — SQLAlchemy won't detect in-place JSONB mutation
-      if subscription.provider_subscription_id:
+      # Preserve the ORIGINAL checkout session id (from the event) before we
+      # overwrite provider_subscription_id with the Stripe subscription id.
+      # Must create a new dict — SQLAlchemy won't detect in-place JSONB mutation.
+      # Read it from session_id, NOT provider_subscription_id: on a webhook
+      # redelivery that column is already the Stripe sub id, so storing it would
+      # clobber the real cs_… id and break the checkout-status lookup. Guard on
+      # absence so a redelivery stays idempotent.
+      existing_metadata = subscription.subscription_metadata or {}
+      if "checkout_session_id" not in existing_metadata:
         subscription.subscription_metadata = {
-          **(subscription.subscription_metadata or {}),
-          "checkout_session_id": subscription.provider_subscription_id,
+          **existing_metadata,
+          "checkout_session_id": session_id,
         }
       subscription.provider_subscription_id = stripe_subscription_id
 

--- a/robosystems/operations/graph/provisioning_service.py
+++ b/robosystems/operations/graph/provisioning_service.py
@@ -20,6 +20,89 @@ from robosystems.logger import logger
 from robosystems.middleware.sse.operation_manager import get_operation_manager
 
 
+def _finalize_graph_provisioning(
+  subscription_id: str, graph_id: str, user_id: str
+) -> None:
+  """Link the graph to the subscription and activate it, in a fresh session.
+
+  Split out of run_graph_provisioning because the long async graph build
+  detaches any subscription instance / session opened before it: the link commit
+  then persists nothing and activate()'s session.refresh() raises "Instance is
+  not persistent within this Session", stranding the subscription at
+  'provisioning' while the graph is live and paid. Runs synchronously with no
+  awaits so the re-fetched instance stays persistent through both commits.
+  """
+  from robosystems.config.billing import BillingConfig
+  from robosystems.database import get_db_session
+  from robosystems.models.core.billing import (
+    BillingAuditLog,
+    BillingCustomer,
+    BillingEventType,
+    BillingSubscription,
+  )
+  from robosystems.operations.graph.subscription_service import (
+    generate_subscription_invoice,
+  )
+
+  db_gen = get_db_session()
+  db = next(db_gen)
+  try:
+    subscription = (
+      db.query(BillingSubscription)
+      .filter(BillingSubscription.id == subscription_id)
+      .first()
+    )
+    if not subscription:
+      raise ValueError(
+        f"Subscription {subscription_id} not found during provisioning completion"
+      )
+
+    # Link the graph before anything else can fail. The lifecycle sensors join
+    # subscriptions to graphs on resource_id, so a graph created here and
+    # orphaned by a later failure would otherwise be unreachable by the
+    # machinery whose whole job is reclaiming it — running, unbilled, and
+    # invisible. Committing the link also makes the claim's terminal condition
+    # true, so no redelivery can create a second graph.
+    subscription.resource_id = graph_id
+    db.commit()
+
+    subscription.activate(db)
+
+    BillingAuditLog.log_event(
+      session=db,
+      event_type=BillingEventType.SUBSCRIPTION_ACTIVATED,
+      org_id=subscription.org_id,
+      subscription_id=subscription.id,
+      description=f"Activated subscription for graph {graph_id}",
+      actor_type="system",
+      event_data={
+        "current_period_start": subscription.current_period_start.isoformat(),
+        "current_period_end": subscription.current_period_end.isoformat(),
+        "provisioning_method": "checkout",
+      },
+    )
+
+    if not subscription.stripe_subscription_id:
+      customer = BillingCustomer.get_by_user_id(user_id, db)
+      if customer and customer.invoice_billing_enabled:
+        plan_config = BillingConfig.get_subscription_plan(subscription.plan_name)
+        tier_label = (
+          plan_config["display_name"] if plan_config else subscription.plan_name
+        )
+        generate_subscription_invoice(
+          subscription=subscription,
+          customer=customer,
+          description=f"Graph subscription - {tier_label}",
+          session=db,
+        )
+        logger.info(f"Generated invoice for subscription {subscription_id}")
+  finally:
+    try:
+      next(db_gen)
+    except StopIteration:
+      pass
+
+
 async def run_graph_provisioning(
   operation_id: str | None,
   subscription_id: str,
@@ -35,18 +118,10 @@ async def run_graph_provisioning(
   retryable by redelivery until the reaper writes it off.
   """
   from robosystems.database import get_db_session
-  from robosystems.models.core.billing import (
-    BillingAuditLog,
-    BillingCustomer,
-    BillingEventType,
-    BillingSubscription,
-  )
+  from robosystems.models.core.billing import BillingSubscription
   from robosystems.operations.graph.graph_creation_service import (
     GraphCreationConfig,
     GraphCreationService,
-  )
-  from robosystems.operations.graph.subscription_service import (
-    generate_subscription_invoice,
   )
 
   manager = get_operation_manager()
@@ -120,50 +195,17 @@ async def run_graph_provisioning(
       graph_id = creation_result.graph_id
       logger.info(f"Created graph {graph_id} for subscription {subscription_id}")
 
-      # Link the graph before anything else can fail. The lifecycle sensors
-      # join subscriptions to graphs on resource_id, so a graph created here
-      # and orphaned by a later failure would otherwise be unreachable by the
-      # machinery whose whole job is reclaiming it — running, unbilled, and
-      # invisible. Committing the link also makes the claim's terminal
-      # condition true, so no redelivery can create a second graph.
-      subscription.resource_id = graph_id
-      db.commit()
-
       if operation_id:
         await manager.emit_progress(operation_id, "Activating subscription...", 70)
 
-      subscription.activate(db)
-
-      BillingAuditLog.log_event(
-        session=db,
-        event_type=BillingEventType.SUBSCRIPTION_ACTIVATED,
-        org_id=subscription.org_id,
-        subscription_id=subscription.id,
-        description=f"Activated subscription for graph {graph_id}",
-        actor_type="system",
-        event_data={
-          "current_period_start": subscription.current_period_start.isoformat(),
-          "current_period_end": subscription.current_period_end.isoformat(),
-          "provisioning_method": "checkout",
-        },
-      )
-
-      if not subscription.stripe_subscription_id:
-        customer = BillingCustomer.get_by_user_id(user_id, db)
-        if customer and customer.invoice_billing_enabled:
-          from robosystems.config.billing import BillingConfig
-
-          plan_config = BillingConfig.get_subscription_plan(subscription.plan_name)
-          tier_label = (
-            plan_config["display_name"] if plan_config else subscription.plan_name
-          )
-          generate_subscription_invoice(
-            subscription=subscription,
-            customer=customer,
-            description=f"Graph subscription - {tier_label}",
-            session=db,
-          )
-          logger.info(f"Generated invoice for subscription {subscription_id}")
+      # Complete in a fresh session. The long async graph build above can
+      # invalidate the session opened before it and detach `subscription`, so
+      # the link commit persists nothing and activate()'s session.refresh()
+      # raises "Instance is not persistent within this Session" — which stranded
+      # the subscription at 'provisioning' with resource_id unset even though the
+      # graph was live and paid. Re-fetch and run the completion writes with no
+      # awaits interleaved so the instance stays persistent through both commits.
+      _finalize_graph_provisioning(subscription_id, graph_id, user_id)
 
       duration_ms = (time.time() - start_time) * 1000
 

--- a/tests/dagster/test_billing_webhook_handlers.py
+++ b/tests/dagster/test_billing_webhook_handlers.py
@@ -297,6 +297,43 @@ class TestHandleCheckoutCompleted:
       "cs_session_abc"
     )
 
+  async def test_redelivery_keeps_original_checkout_session_id(
+    self, mock_db_session, mock_context, mock_subscription, mock_customer
+  ):
+    """A webhook redelivery must not clobber the preserved checkout session id.
+
+    State as left by the first delivery: metadata already carries the real cs_
+    id and provider_subscription_id has been rewritten to the Stripe sub id. The
+    pre-fix code re-preserved ``provider_subscription_id`` (now sub_…),
+    overwriting the good value — so the checkout-status lookup (which keys on the
+    cs_ id) 404s forever. The value must survive a redelivery unchanged.
+    """
+    mock_subscription.subscription_metadata = {"checkout_session_id": "cs_session_abc"}
+    mock_subscription.provider_subscription_id = "sub_stripe_first"
+    session_data = make_checkout_session(
+      session_id="cs_session_abc",
+      subscription_id="sub_stripe_first",
+    )
+
+    with (
+      patch(PATCH_BILLING_SUB) as MockSub,
+      patch(PATCH_BILLING_CUST),
+      patch(PATCH_TRIGGER, new_callable=AsyncMock),
+    ):
+      MockSub.get_by_provider_subscription_id.return_value = mock_subscription
+      mock_db_session.query.return_value.filter.return_value.first.return_value = (
+        mock_customer
+      )
+
+      from robosystems.dagster.jobs.billing import _handle_checkout_completed
+
+      await _handle_checkout_completed(session_data, mock_db_session, mock_context)
+
+    assert (
+      mock_subscription.subscription_metadata.get("checkout_session_id")
+      == "cs_session_abc"
+    )
+
   async def test_subscription_lookup_falls_back_to_metadata(
     self, mock_db_session, mock_context, mock_subscription, mock_customer
   ):

--- a/tests/middleware/sse/test_direct_monitor.py
+++ b/tests/middleware/sse/test_direct_monitor.py
@@ -39,7 +39,7 @@ class TestRunGraphProvisioning:
 
       with patch("robosystems.database.get_db_session") as mock_get_db:
         mock_db = MagicMock()
-        mock_get_db.return_value = iter([mock_db])
+        mock_get_db.side_effect = lambda: iter([mock_db])
 
         mock_subscription = MagicMock()
         mock_subscription.id = "sub123"
@@ -93,7 +93,7 @@ class TestRunGraphProvisioning:
 
       with patch("robosystems.database.get_db_session") as mock_get_db:
         mock_db = MagicMock()
-        mock_get_db.return_value = iter([mock_db])
+        mock_get_db.side_effect = lambda: iter([mock_db])
 
         mock_subscription = MagicMock()
         mock_subscription.id = "sub123"
@@ -141,7 +141,7 @@ class TestRunGraphProvisioning:
 
       with patch("robosystems.database.get_db_session") as mock_get_db:
         mock_db = MagicMock()
-        mock_get_db.return_value = iter([mock_db])
+        mock_get_db.side_effect = lambda: iter([mock_db])
 
         mock_subscription = MagicMock()
         mock_subscription.id = "sub123"
@@ -183,7 +183,7 @@ class TestRunUserRepositoryProvisioning:
 
       with patch("robosystems.database.get_db_session") as mock_get_db:
         mock_db = MagicMock()
-        mock_get_db.return_value = iter([mock_db])
+        mock_get_db.side_effect = lambda: iter([mock_db])
 
         mock_subscription = MagicMock()
         mock_subscription.id = "sub123"
@@ -245,7 +245,7 @@ class TestRunUserRepositoryProvisioning:
 
       with patch("robosystems.database.get_db_session") as mock_get_db:
         mock_db = MagicMock()
-        mock_get_db.return_value = iter([mock_db])
+        mock_get_db.side_effect = lambda: iter([mock_db])
 
         mock_subscription = MagicMock()
         mock_subscription.id = "sub123"

--- a/tests/operations/graph/test_provisioning_failure_disposition.py
+++ b/tests/operations/graph/test_provisioning_failure_disposition.py
@@ -117,6 +117,105 @@ async def test_failed_graph_provisioning_leaves_the_claim_held(
   assert row.resource_id is None
 
 
+async def test_successful_graph_provisioning_activates_and_links(
+  db_session: Session, provisioning_fixture: tuple[str, str]
+):
+  """The success path the failure tests never covered: creation succeeds, so the
+  subscription must end ACTIVE with resource_id linked to the new graph."""
+  subscription_id, user_id = provisioning_fixture
+  graph_id = "kg" + uuid.uuid4().hex[:20]
+
+  with (
+    patch(
+      "robosystems.operations.graph.graph_creation_service.GraphCreationService"
+    ) as mock_service_cls,
+    patch(
+      "robosystems.operations.graph.provisioning_service.report_asset_materialization",
+      new=AsyncMock(),
+    ),
+  ):
+    mock_service_cls.return_value = MagicMock(
+      create=AsyncMock(return_value=MagicMock(graph_id=graph_id))
+    )
+    result = await run_graph_provisioning(
+      operation_id=None,
+      subscription_id=subscription_id,
+      user_id=user_id,
+      tier="ladybug-standard",
+    )
+
+  assert result["graph_id"] == graph_id
+  row = _reload(db_session, subscription_id)
+  assert row.status == SubscriptionStatus.ACTIVE.value
+  assert row.resource_id == graph_id
+
+
+async def test_graph_provisioning_activates_despite_session_detach(
+  db_session: Session, provisioning_fixture: tuple[str, str]
+):
+  """The prod failure, reproduced deterministically.
+
+  The long async graph build invalidated the session that loaded the
+  subscription, detaching the instance; the completion then ran on that detached
+  instance and activate()'s ``session.refresh()`` raised "not persistent within
+  this Session", stranding the row at 'provisioning' with resource_id unset even
+  though the graph was live and paid. Here we detach the outer session mid-build
+  (``expunge_all``) as the deterministic stand-in for that invalidation. The
+  completion must still link the graph and activate the subscription — pre-fix
+  this raised; the fix re-fetches into a fresh session.
+  """
+  subscription_id, user_id = provisioning_fixture
+  graph_id = "kg" + uuid.uuid4().hex[:20]
+
+  from robosystems.database import get_db_session as _real_get_db_session
+
+  created_sessions: list[Session] = []
+
+  def _recording_get_db_session():
+    gen = _real_get_db_session()
+    session = next(gen)
+    created_sessions.append(session)
+    try:
+      yield session
+    finally:
+      try:
+        next(gen)
+      except StopIteration:
+        pass
+
+  async def _succeed_and_detach(_config):
+    # The first session opened is the one run_graph_provisioning loaded the
+    # subscription into; expunging it detaches the instance, reproducing the
+    # connection invalidation the long real build caused in prod.
+    created_sessions[0].expunge_all()
+    return MagicMock(graph_id=graph_id)
+
+  with (
+    patch("robosystems.database.get_db_session", _recording_get_db_session),
+    patch(
+      "robosystems.operations.graph.graph_creation_service.GraphCreationService"
+    ) as mock_service_cls,
+    patch(
+      "robosystems.operations.graph.provisioning_service.report_asset_materialization",
+      new=AsyncMock(),
+    ),
+  ):
+    mock_service_cls.return_value = MagicMock(
+      create=AsyncMock(side_effect=_succeed_and_detach)
+    )
+    result = await run_graph_provisioning(
+      operation_id=None,
+      subscription_id=subscription_id,
+      user_id=user_id,
+      tier="ladybug-standard",
+    )
+
+  assert result["graph_id"] == graph_id
+  row = _reload(db_session, subscription_id)
+  assert row.status == SubscriptionStatus.ACTIVE.value
+  assert row.resource_id == graph_id
+
+
 async def test_failed_repository_provisioning_leaves_the_claim_held(
   db_session: Session, provisioning_fixture: tuple[str, str]
 ):


### PR DESCRIPTION
## Summary

A cold checkout signup could complete payment and provision the graph, yet leave the subscription stranded at `provisioning` (never activated, `resource_id` unset). This fixes the provisioning-completion path so the subscription reliably links to its graph and activates, and fixes a related bug that broke the checkout-status page after payment. Found end-to-end while walking the paid signup path against production.

## Changes

**`operations/graph/provisioning_service.py` — finalize in a fresh session (the main fix)**

- The long async graph build (`await GraphCreationService.create(...)`) invalidated the sync session that had loaded the subscription, detaching the instance. The subsequent link commit then persisted nothing and `activate()`'s `session.refresh()` raised `"Instance is not persistent within this Session"` — so the subscription stuck at `provisioning` with `resource_id` unset even though the graph was live and the payment collected.
- Extracted the completion into `_finalize_graph_provisioning`, which re-fetches the subscription in a **fresh** session and runs the link + activate + audit + invoice writes synchronously, with **no awaits interleaved**, so the instance stays persistent through both commits. The "link the graph before anything else can fail" two-commit ordering is preserved.

**`dagster/jobs/billing.py` — don't clobber the preserved checkout session id**

- `_handle_checkout_completed` stored `checkout_session_id` from `subscription.provider_subscription_id`, but a webhook redelivery finds that column already rewritten to the Stripe subscription id — overwriting the real `cs_…` id that the checkout-status route keys on, so the provisioning page polled `…/checkout/{session}/status` and got a permanent 404.
- Now stores the id from the event (`session_id`) and only when absent, so a redelivery is idempotent.

**Tests**

- `test_provisioning_failure_disposition.py`: a success-path test (asserts `active` + `resource_id` linked) and a deterministic reproduction that detaches the outer session mid-build — it fails on the pre-fix code with the exact production error and passes on the fix.
- `test_billing_webhook_handlers.py`: a redelivery test asserting the preserved `checkout_session_id` is not clobbered.
- `test_direct_monitor.py`: updated the `get_db_session` mock to a per-call factory, since the completion now opens a second session.

## Breaking Changes

None. No public API shape changes; no client SDK impact. The completion behavior is unchanged on the happy path — it simply now survives the session invalidation that stranded it.

## Testing

- `just test` (full unit suite): **12,841 passed, 38 skipped, 0 failed**.
- `just test-code` (ruff + format + basedpyright + cf-lint): all clean.
- The detachment regression was confirmed to **fail on the pre-fix code** (same `InvalidRequestError`) and pass on the fix.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
