### PR TITLE
fix(graphql): accept graph-scoped API keys on the extensions GraphQL endpoint

### DIFF
--- a/robosystems/graphql/context.py
+++ b/robosystems/graphql/context.py
@@ -45,6 +45,7 @@ from robosystems.middleware.auth.dependencies import (
   API_KEY_HEADER,
   get_current_user,
 )
+from robosystems.middleware.auth.utils import validate_api_key_with_graph
 from robosystems.middleware.extensions import load_graph_metadata
 from robosystems.middleware.graph.types import GRAPH_OR_SUBGRAPH_ID_PATTERN
 from robosystems.middleware.graph.utils.subgraph import is_subgraph
@@ -101,11 +102,26 @@ async def get_context(
   try:
     user = await get_current_user(request, api_key or "")
   except HTTPException:
-    if has_credentials:
-      # Bad/expired credentials → real transport-layer auth failure.
+    if not has_credentials:
+      # No credentials at all → anonymous fallthrough for introspection.
+      user = None
+    elif api_key and not request.headers.get("Authorization"):
+      # Pure API-key auth that the account-wide validator rejected. A
+      # graph-scoped key (the `rfsc…` kind the repository / MCP-connector flow
+      # mints) is refused by `get_current_user` by design — without a graph
+      # context it could otherwise reach account-level surfaces. But this
+      # endpoint's URL already scopes us to a single graph, so re-validate the
+      # key against that graph the same way the REST operations and MCP
+      # surfaces do. This is purely additive: account-wide keys never reach
+      # here (they pass `get_current_user`), and JWT/Bearer auth is guarded out
+      # by the Authorization-header check, so neither path changes.
+      user = validate_api_key_with_graph(api_key, graph_id, db)
+      if user is None:
+        # Genuinely invalid, or a key scoped to a different graph → real 401.
+        raise
+    else:
+      # Bad/expired Bearer token → real transport-layer auth failure.
       raise
-    # No credentials at all → anonymous fallthrough for introspection.
-    user = None
 
   # Subgraph guard: a subgraph is a modality container (scratch/knowledge),
   # not an extensions domain target — a `{parent}_{name}` graph_id has no

--- a/tests/graphql/extensions/test_context.py
+++ b/tests/graphql/extensions/test_context.py
@@ -82,13 +82,20 @@ class TestGetContextAuthContract:
     mock_meta.assert_not_called()
 
   async def test_invalid_api_key_re_raises_401(self):
-    """Case 2a: X-API-Key present but bad → real 401, NOT silent anonymous."""
+    """Case 2a: X-API-Key present but bad → real 401, NOT silent anonymous.
+
+    The account-wide validator rejects it, and the graph-scoped retry (for
+    graph-scoped keys) also comes back None, so the 401 stands.
+    """
     request = _make_request(headers={})
 
-    with patch(
-      f"{MODULE}.get_current_user",
-      new_callable=AsyncMock,
-      side_effect=HTTPException(status_code=401, detail="Invalid API key"),
+    with (
+      patch(
+        f"{MODULE}.get_current_user",
+        new_callable=AsyncMock,
+        side_effect=HTTPException(status_code=401, detail="Invalid API key"),
+      ),
+      patch(f"{MODULE}.validate_api_key_with_graph", return_value=None) as mock_scoped,
     ):
       with pytest.raises(HTTPException) as exc_info:
         await get_context(
@@ -99,6 +106,67 @@ class TestGetContextAuthContract:
         )
 
     assert exc_info.value.status_code == 401
+    # The graph-scoped retry is attempted for a pure API-key request, then fails.
+    mock_scoped.assert_called_once()
+
+  async def test_graph_scoped_key_accepted_via_graph_validation(self):
+    """Case 2a', the F6 fix: a graph-scoped (`rfsc…`) key is refused by the
+    account-wide validator (it has no graph context there) but is valid for
+    its OWN graph. This endpoint's URL scopes us to that graph, so the
+    graph-aware retry authenticates it — matching the REST-operations and MCP
+    surfaces, which already accept these keys."""
+    request = _make_request(headers={})
+    user = MagicMock()
+    user.id = "usr_owner"
+    db = MagicMock()
+
+    with (
+      patch(
+        f"{MODULE}.get_current_user",
+        new_callable=AsyncMock,
+        side_effect=HTTPException(status_code=401, detail="Invalid API key"),
+      ),
+      patch(f"{MODULE}.validate_api_key_with_graph", return_value=user) as mock_scoped,
+      patch(f"{MODULE}.check_graph_access") as mock_check,
+      patch(f"{MODULE}.load_graph_metadata", return_value=_entity_meta()),
+    ):
+      ctx = await get_context(
+        request=request,
+        api_key="rfsc_scoped_to_this_graph",
+        graph_id=GRAPH_ID,
+        db=db,
+      )
+
+    assert ctx["user"] is user
+    # Re-validated against THIS graph (the URL scope), reusing the request db.
+    mock_scoped.assert_called_once_with("rfsc_scoped_to_this_graph", GRAPH_ID, db)
+    # Graph access is still enforced on top of key validation.
+    mock_check.assert_called_once_with(user, GRAPH_ID)
+
+  async def test_bearer_failure_does_not_trigger_graph_scoped_retry(self):
+    """The graph-scoped retry is for pure API-key requests only. A failed
+    Bearer JWT must re-raise as-is and NEVER fall through to it, so JWT auth
+    (the frontends' path) is entirely unchanged."""
+    request = _make_request(headers={"Authorization": "Bearer expired.jwt"})
+
+    with (
+      patch(
+        f"{MODULE}.get_current_user",
+        new_callable=AsyncMock,
+        side_effect=HTTPException(status_code=401, detail="Token expired"),
+      ),
+      patch(f"{MODULE}.validate_api_key_with_graph") as mock_scoped,
+    ):
+      with pytest.raises(HTTPException) as exc_info:
+        await get_context(
+          request=request,
+          api_key=None,
+          graph_id=GRAPH_ID,
+          db=MagicMock(),
+        )
+
+    assert exc_info.value.status_code == 401
+    mock_scoped.assert_not_called()
 
   async def test_invalid_jwt_re_raises_401(self):
     """Case 2b: Authorization header present but bad → real 401."""


### PR DESCRIPTION
## Problem

The extensions GraphQL endpoint (`/extensions/{graph_id}/graphql`) authenticated API keys through the account-wide validator only, which by design rejects **graph-scoped** keys. As a result, a repository/connector key (the `rfsc…` kind minted by the repository "Generate API Key" and MCP-connector flows) received `401 Invalid API key` on GraphQL — even though the *same key* is accepted on that graph's REST operations and MCP surfaces.

The mismatch: those surfaces authenticate with `validate_api_key_with_graph(key, graph_id)`; the GraphQL context used generic `validate_api_key`, which refuses graph-scoped keys because it has no graph context. But this endpoint's URL *is* the graph scope.

Behavior was **fail-closed** (a scoped key got *less* access, never more), so this is a functionality/consistency bug, not a privilege issue — but it half-breaks the advertised repository-key flow for direct SDK GraphQL reads.

## Fix

`get_context` now falls back to `validate_api_key_with_graph(api_key, graph_id)` — the same graph-aware validator the operations and MCP surfaces use — when the account-wide path rejects a **pure API-key** request. Purely additive:

- Account-wide keys are unchanged (they still pass `get_current_user`; the fallback never runs for them).
- JWT/Bearer auth is unchanged (guarded out by the `Authorization`-header check).
- Graph access is still enforced afterward by `check_graph_access`.

Only new behavior: a graph-scoped key now authenticates on **its own** graph's GraphQL endpoint, and remains rejected on any other graph.

## Tests

Adds three cases to `tests/graphql/extensions/test_context.py`:
- a graph-scoped key authenticates on its own graph;
- an invalid key still returns 401 (the graph-aware retry also fails);
- a failed Bearer JWT never falls through to the API-key retry.

Auth + GraphQL + graph-access-control suites green (359 tests); code-quality gate clean.
