### PR TITLE
fix(billing): honor immediate cancels in the subscription-deleted webhook

### DIFF
--- a/robosystems/dagster/jobs/billing.py
+++ b/robosystems/dagster/jobs/billing.py
@@ -793,21 +793,32 @@ async def _handle_subscription_deleted(
   )
 
   if subscription.status == "canceled":
-    # Already canceled (via portal updated handler or UI cancel button).
-    # Preserve original canceled_at timestamp. Use Stripe's period end if
-    # the user paid for the current period, otherwise terminate now.
+    # Already canceled (via portal updated handler, UI cancel button, or the
+    # delete-graph op). Preserve the original canceled_at timestamp.
+    from robosystems.models.core.billing.subscription import CancellationType
+
     now = datetime.now(UTC)
-    # Period end may be at item level in newer Stripe API versions
-    period_end_ts = subscription_data.get("current_period_end")
-    if not period_end_ts:
-      items = subscription_data.get("items", {}).get("data", [])
-      if items:
-        period_end_ts = items[0].get("current_period_end")
-    if period_end_ts:
-      period_end = datetime.fromtimestamp(period_end_ts, tz=UTC)
-      subscription.ends_at = period_end if period_end > now else now
+    if subscription.cancellation_type == CancellationType.IMMEDIATE.value:
+      # The cancel was explicitly IMMEDIATE (delete-graph / immediate UI cancel),
+      # so the cancel path already set ends_at<=now on purpose. Do NOT push it out
+      # to the paid-through period end here — that would defeat the immediate
+      # teardown and strand the graph until period end, since the graph-lifecycle
+      # sensors gate suspension on ends_at < now. Keep ends_at no later than now.
+      if subscription.ends_at is None or subscription.ends_at > now:
+        subscription.ends_at = now
     else:
-      subscription.ends_at = now
+      # Period-end cancel: honor Stripe's period end (the user paid for the
+      # current period). Period end may be item-level in newer Stripe APIs.
+      period_end_ts = subscription_data.get("current_period_end")
+      if not period_end_ts:
+        items = subscription_data.get("items", {}).get("data", [])
+        if items:
+          period_end_ts = items[0].get("current_period_end")
+      if period_end_ts:
+        period_end = datetime.fromtimestamp(period_end_ts, tz=UTC)
+        subscription.ends_at = period_end if period_end > now else now
+      else:
+        subscription.ends_at = now
     subscription.updated_at = now
     db_session.commit()
     context.log.info(

--- a/robosystems/dagster/sensors/graph_lifecycle.py
+++ b/robosystems/dagster/sensors/graph_lifecycle.py
@@ -34,7 +34,7 @@ def expired_graph_subscription_sensor(context: SensorEvaluationContext):
   Query: BillingSubscription where:
   - resource_type = "graph"
   - status IN ("canceled", "failed")
-  - ends_at IS NOT NULL AND ends_at < now()
+  - ends_at IS NOT NULL AND (ends_at < now() OR cancellation_type = "immediate")
   - Linked graph status = "active" (not already suspended)
 
   ``failed`` belongs here alongside ``canceled`` for the same reason: both are
@@ -43,10 +43,13 @@ def expired_graph_subscription_sensor(context: SensorEvaluationContext):
   """
   from datetime import UTC, datetime
 
+  from sqlalchemy import or_
+
   from robosystems.database import session as db_session_factory
   from robosystems.models.core.billing.subscription import (
     TERMINAL_SUBSCRIPTION_STATUSES,
     BillingSubscription,
+    CancellationType,
   )
   from robosystems.models.core.graph import Graph, GraphStatus
 
@@ -54,7 +57,11 @@ def expired_graph_subscription_sensor(context: SensorEvaluationContext):
   try:
     now = datetime.now(UTC)
 
-    # Find expired subscriptions linked to active graphs
+    # Find expired subscriptions linked to active graphs. An IMMEDIATE cancel
+    # suspends regardless of ends_at: the user asked for teardown now, and this
+    # is defense-in-depth against ends_at being pushed into the future by a
+    # downstream event (e.g. the Stripe subscription.deleted handler). Mirrors
+    # the immediate-bypass the deprovision sensor already applies.
     expired_subs = (
       db.query(BillingSubscription)
       .join(Graph, BillingSubscription.resource_id == Graph.graph_id)
@@ -62,7 +69,10 @@ def expired_graph_subscription_sensor(context: SensorEvaluationContext):
         BillingSubscription.resource_type == "graph",
         BillingSubscription.status.in_(TERMINAL_SUBSCRIPTION_STATUSES),
         BillingSubscription.ends_at.isnot(None),
-        BillingSubscription.ends_at < now,
+        or_(
+          BillingSubscription.ends_at < now,
+          BillingSubscription.cancellation_type == CancellationType.IMMEDIATE.value,
+        ),
         Graph.status == GraphStatus.ACTIVE.value,
       )
       .all()

--- a/tests/dagster/test_billing_webhook_handlers.py
+++ b/tests/dagster/test_billing_webhook_handlers.py
@@ -1723,6 +1723,61 @@ class TestHandleSubscriptionDeleted:
     mock_db_session.commit.assert_called_once()
     mock_context.log.info.assert_called_once()
 
+  async def test_immediate_cancel_not_pushed_to_period_end(
+    self, mock_db_session, mock_context, mock_subscription
+  ):
+    """F7 regression: an IMMEDIATE cancel's ends_at must NOT be moved out to the
+    Stripe period end by the deleted-webhook. Otherwise the suspend sensor
+    (ends_at < now) never fires and the graph lingers until period end despite
+    the user asking for immediate teardown."""
+    from robosystems.models.core.billing.subscription import CancellationType
+
+    op_ends_at = datetime.now(UTC) - timedelta(seconds=5)  # set by the immediate cancel
+    future_period_end = int((datetime.now(UTC) + timedelta(days=30)).timestamp())
+    mock_subscription.status = "canceled"
+    mock_subscription.cancellation_type = CancellationType.IMMEDIATE.value
+    mock_subscription.ends_at = op_ends_at
+    mock_subscription.canceled_at = op_ends_at
+    sub_data = {"id": "sub_stripe_abc", "current_period_end": future_period_end}
+
+    with patch(PATCH_BILLING_SUB) as MockSub:
+      MockSub.get_by_provider_subscription_id.return_value = mock_subscription
+
+      from robosystems.dagster.jobs.billing import _handle_subscription_deleted
+
+      await _handle_subscription_deleted(sub_data, mock_db_session, mock_context)
+
+    # ends_at stays at (or before) now — never the future period end.
+    assert mock_subscription.ends_at == op_ends_at
+    assert mock_subscription.ends_at <= datetime.now(UTC)
+    mock_db_session.commit.assert_called_once()
+
+  async def test_period_end_cancel_still_adopts_stripe_period_end(
+    self, mock_db_session, mock_context, mock_subscription
+  ):
+    """Period-end cancels are unchanged: the deleted-webhook adopts Stripe's
+    current_period_end (the user paid through the current period)."""
+    from robosystems.models.core.billing.subscription import CancellationType
+
+    future_period_end = int((datetime.now(UTC) + timedelta(days=30)).timestamp())
+    mock_subscription.status = "canceled"
+    mock_subscription.cancellation_type = CancellationType.PERIOD_END.value
+    mock_subscription.ends_at = None
+    mock_subscription.canceled_at = datetime.now(UTC) - timedelta(seconds=5)
+    sub_data = {"id": "sub_stripe_abc", "current_period_end": future_period_end}
+
+    with patch(PATCH_BILLING_SUB) as MockSub:
+      MockSub.get_by_provider_subscription_id.return_value = mock_subscription
+
+      from robosystems.dagster.jobs.billing import _handle_subscription_deleted
+
+      await _handle_subscription_deleted(sub_data, mock_db_session, mock_context)
+
+    assert mock_subscription.ends_at == datetime.fromtimestamp(
+      future_period_end, tz=UTC
+    )
+    mock_db_session.commit.assert_called_once()
+
   async def test_unexpected_deletion_calls_immediate_cancel(
     self, mock_db_session, mock_context, mock_subscription
   ):

--- a/tests/dagster/test_graph_lifecycle.py
+++ b/tests/dagster/test_graph_lifecycle.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 from dagster import build_sensor_context
 
 from robosystems.dagster.sensors.graph_lifecycle import (
+  expired_graph_subscription_sensor,
   suspended_graph_deprovisioning_sensor,
 )
 
@@ -104,6 +105,79 @@ class TestSuspendedGraphDeprovisioningSensor:
       assert "ends_at" in compiled_clauses, (
         "Expected the deprovision query to still include the ends_at "
         "retention-window clause"
+      )
+
+
+class TestExpiredGraphSubscriptionSensor:
+  """Tests for the expired_graph_subscription_sensor (the suspend stage)."""
+
+  def test_finds_expired_subs_on_active_graphs(self):
+    """Yields one suspend run listing active graphs with terminal/expired subs."""
+    mock_sub = MagicMock()
+    mock_sub.resource_id = "kg_expired"
+
+    with patch("robosystems.database.session") as mock_db:
+      mock_session = MagicMock()
+      mock_db.return_value = mock_session
+      mock_session.query.return_value.join.return_value.filter.return_value.all.return_value = [
+        mock_sub
+      ]
+
+      context = build_sensor_context()
+      runs = list(expired_graph_subscription_sensor(context))
+
+      assert len(runs) == 1
+      config = runs[0].run_config["ops"]["suspend_expired_graphs"]["config"]
+      assert config["graph_ids"] == ["kg_expired"]
+
+  def test_skips_when_no_matches(self):
+    """Returns nothing when no subscriptions are expired."""
+    with patch("robosystems.database.session") as mock_db:
+      mock_session = MagicMock()
+      mock_db.return_value = mock_session
+      mock_session.query.return_value.join.return_value.filter.return_value.all.return_value = []
+
+      context = build_sensor_context()
+      runs = list(expired_graph_subscription_sensor(context))
+
+      assert len(runs) == 0
+
+  def test_session_cleanup(self):
+    """Database session is always cleaned up."""
+    with patch("robosystems.database.session") as mock_db:
+      mock_session = MagicMock()
+      mock_db.return_value = mock_session
+      mock_session.query.return_value.join.return_value.filter.return_value.all.return_value = []
+
+      context = build_sensor_context()
+      list(expired_graph_subscription_sensor(context))
+
+      mock_db.remove.assert_called_once()
+
+  def test_query_includes_immediate_cancellation_bypass(self):
+    """F7 defense-in-depth: the suspend query must OR
+    `cancellation_type == 'immediate'` against `ends_at < now`, so an immediate
+    cancel suspends even if a downstream event (e.g. the Stripe
+    subscription.deleted handler) pushed ends_at into the future. Mirrors the
+    deprovision sensor's immediate-bypass."""
+    with patch("robosystems.database.session") as mock_db:
+      mock_session = MagicMock()
+      mock_db.return_value = mock_session
+      mock_session.query.return_value.join.return_value.filter.return_value.all.return_value = []
+
+      context = build_sensor_context()
+      list(expired_graph_subscription_sensor(context))
+
+      filter_call = mock_session.query.return_value.join.return_value.filter
+      assert filter_call.called, "filter() was never invoked on the query"
+
+      compiled_clauses = " ".join(str(arg) for arg in filter_call.call_args.args)
+      assert "cancellation_type" in compiled_clauses, (
+        "Expected the suspend query to OR on cancellation_type (immediate "
+        f"bypass); got: {compiled_clauses}"
+      )
+      assert "ends_at" in compiled_clauses, (
+        "Expected the suspend query to still include the ends_at clause"
       )
 
 


### PR DESCRIPTION
## Problem

An immediate graph deletion — the `delete-graph` operation (or an immediate "delete now" cancel) — sets the subscription's `ends_at` to *now*, so the graph-lifecycle sensors (`expired_graph_subscription_sensor` → `suspended_graph_deprovisioning_sensor`) tear the graph down within ~10 minutes.

But the immediate cancel also cancels the Stripe subscription, which fires `customer.subscription.deleted`. That webhook's handler (`_handle_subscription_deleted`) then **overwrote `ends_at` with Stripe's `current_period_end`** whenever the customer had paid through the current period — it decided "canceled + paid ⇒ keep until period end" and **ignored `cancellation_type`**. So `ends_at` flipped from *now* to ~a month out.

Result: the suspend sensor gates on `ends_at < now`, so it **skipped the graph on every tick**, the graph never reached `suspended`, and it lingered until period end instead of deprovisioning. The customer-facing "delete now" silently did not complete — the graph kept running (and, absent a manual refund, kept billing).

Observed on a throwaway tenant: `delete-graph` returned the immediate envelope and logged `ends_at = now`; the webhook overwrote it to the period end ~0.4s later; the graph then sat `active` with the suspend sensor skipping every 5-minute tick.

## Fix

- **`_handle_subscription_deleted`** now branches on `cancellation_type`: an `IMMEDIATE` cancel keeps `ends_at <= now` (never pushed out); only a period-end cancel adopts Stripe's `current_period_end`.
- **Defense-in-depth**: `expired_graph_subscription_sensor` (the suspend stage) gains the same `cancellation_type == 'immediate'` bypass the deprovision sensor already has, so an immediate cancel suspends even if `ends_at` is somehow left in the future.

## Tests

- `test_immediate_cancel_not_pushed_to_period_end` — the immediate-cancel webhook keeps `ends_at` at now. **Fails on pre-fix code** with `ends_at = period end` (the exact production symptom).
- `test_period_end_cancel_still_adopts_stripe_period_end` — period-end cancels are unchanged.
- `test_query_includes_immediate_cancellation_bypass` — the suspend query ORs on `cancellation_type` (new `TestExpiredGraphSubscriptionSensor` class; the suspend sensor had no test coverage before).

Dagster billing + lifecycle suites green (101 tests); code-quality gate clean.
