### PR TITLE
fix: four silent-failure defects — disk alarms, fact dedup, SEC manifest, cache invalidation

### DIFF
--- a/cloudformation/graph-ladybug-replicas.yaml
+++ b/cloudformation/graph-ladybug-replicas.yaml
@@ -841,6 +841,35 @@ Resources:
           MetricValue: "1"
           Unit: Count
 
+  # Replicas hold the database on the ROOT volume: it is a launch-template device
+  # with DeleteOnTermination and no autoscaling, and it is not in the volume
+  # registry — so the graph-volumes expansion ladder cannot help here and this
+  # alarm is deliberately notify-only. One threshold, not a ladder: the remedy is
+  # raising SHARED_REPLICAS_ROOT_VOLUME_SIZE_<ENV> and cycling the fleet, which is
+  # a deploy, so a warning tier would only page twice for the same action.
+  #
+  # Sizing matters because the download happens at boot: a replica s3 cp's the
+  # whole sec.lbug before it can serve, so once the file no longer fits, every
+  # instance that cycles fails to come up and the daily refresh cycles all of them.
+  # The failure is a cliff, not a slope. Metrics Insights for the same reason as
+  # graph-volumes.yaml — a MetricStat cannot match a partial dimension set.
+  ReplicaRootDiskUsageAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub robosystems-shared-replicas-${Environment}-root-disk-usage
+      AlarmDescription: Shared replica root volume exceeded 90% - the database no longer has room to grow and a cycling instance may fail to download it
+      Metrics:
+        - Id: worst_root_disk
+          Expression: !Sub 'SELECT MAX(DISK_USED_PERCENT) FROM "RoboSystems/Graph/${Environment}" WHERE path = ''/'''
+          Period: 300
+          ReturnData: true
+      EvaluationPeriods: 2 # 10 minutes sustained; the value is flat, so this only debounces gaps
+      Threshold: 90
+      ComparisonOperator: GreaterThanThreshold
+      AlarmActions:
+        - !Ref ReplicaAlertTopic
+      TreatMissingData: notBreaching
+
   ReplicaContainerStartAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:

--- a/cloudformation/graph-volumes.yaml
+++ b/cloudformation/graph-volumes.yaml
@@ -619,25 +619,25 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub "robosystems-graph-volumes-${Environment}-disk-usage-warning"
-      AlarmDescription: Disk usage exceeded 70% on any graph database instance (writers and shared master at /mnt/ladybug-data, shared replicas at /)
+      AlarmDescription: Disk usage exceeded 75% on any graph database data volume (/mnt/ladybug-data)
       # Metrics Insights, not a MetricStat with a partial dimension set. The CloudWatch
       # agent publishes DISK_USED_PERCENT with six dimensions (path, InstanceId,
       # AutoScalingGroupName, InstanceType, device, fstype); a MetricStat must match the
       # dimension set *exactly*, so the previous `Dimensions: [path=/mnt/ladybug-data]`
-      # matched nothing anywhere in the fleet and sat OK on "no datapoints received"
-      # for the life of the stack. An Insights query aggregates across dimension sets.
-      # No path filter: only / (replicas) and /mnt/ladybug-data (writers, shared master)
-      # publish this metric, and both are the volume holding the database. Metrics
-      # Insights rejects OR in WHERE, and an alarm allows only one Insights query, so
-      # filtering to both paths is not expressible — omitting the filter is the fix,
-      # not a shortcut. Verified live against prod before commit.
+      # matched nothing and sat OK on "no datapoints received" for the life of the
+      # stack. An Insights query aggregates across dimension sets while keeping the
+      # path filter, which is load-bearing: this ladder feeds VolumeMonitorFunction,
+      # and only attached data volumes are in the volume registry and expandable.
+      # Shared replicas keep the database on the root volume (DeleteOnTermination, no
+      # autoscaling) and are alarmed separately in graph-ladybug-replicas.yaml.
+      # Verified live against prod before commit.
       Metrics:
         - Id: worst_disk
-          Expression: !Sub 'SELECT MAX(DISK_USED_PERCENT) FROM "RoboSystems/Graph/${Environment}"'
+          Expression: !Sub 'SELECT MAX(DISK_USED_PERCENT) FROM "RoboSystems/Graph/${Environment}" WHERE path = ''/mnt/ladybug-data'''
           Period: 300
           ReturnData: true
       EvaluationPeriods: 2 # 10 minutes of sustained high usage
-      Threshold: 70
+      Threshold: 75
       ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
 
@@ -646,11 +646,11 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub "robosystems-graph-volumes-${Environment}-disk-usage-critical"
-      AlarmDescription: CRITICAL - Disk usage exceeded 85% on any graph database instance (writers and shared master at /mnt/ladybug-data, shared replicas at /)
-      # See DiskUsageWarningAlarm for why this is a Metrics Insights query.
+      AlarmDescription: CRITICAL - Disk usage exceeded 85% on any graph database data volume (/mnt/ladybug-data)
+      # See DiskUsageWarningAlarm for why this is a path-filtered Metrics Insights query.
       Metrics:
         - Id: worst_disk
-          Expression: !Sub 'SELECT MAX(DISK_USED_PERCENT) FROM "RoboSystems/Graph/${Environment}"'
+          Expression: !Sub 'SELECT MAX(DISK_USED_PERCENT) FROM "RoboSystems/Graph/${Environment}" WHERE path = ''/mnt/ladybug-data'''
           Period: 300
           ReturnData: true
       EvaluationPeriods: 1 # Trigger immediately at critical level
@@ -666,15 +666,15 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub "robosystems-graph-volumes-${Environment}-disk-usage-emergency"
-      AlarmDescription: EMERGENCY - Disk usage exceeded 95% on any graph database instance (writers and shared master at /mnt/ladybug-data, shared replicas at /) - Database operations at risk!
-      # See DiskUsageWarningAlarm for why this is a Metrics Insights query.
+      AlarmDescription: EMERGENCY - Disk usage exceeded 90% on any graph database data volume (/mnt/ladybug-data) - Database operations at risk!
+      # See DiskUsageWarningAlarm for why this is a path-filtered Metrics Insights query.
       Metrics:
         - Id: worst_disk
-          Expression: !Sub 'SELECT MAX(DISK_USED_PERCENT) FROM "RoboSystems/Graph/${Environment}"'
+          Expression: !Sub 'SELECT MAX(DISK_USED_PERCENT) FROM "RoboSystems/Graph/${Environment}" WHERE path = ''/mnt/ladybug-data'''
           Period: 60
           ReturnData: true
       EvaluationPeriods: 1 # Trigger immediately
-      Threshold: 95
+      Threshold: 90
       ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
       AlarmActions:
@@ -687,16 +687,14 @@ Resources:
     Properties:
       AlarmName: !Sub "robosystems-graph-volumes-${Environment}-rapid-disk-growth"
       AlarmDescription: Disk usage growing rapidly (>10% in 30 minutes)
-      # See DiskUsageWarningAlarm. Math over a Metrics Insights query is allowed;
-      # what an alarm cannot have is more than one Insights query, which is why
-      # the two publishing paths are covered by omitting the filter rather than
-      # by a second query.
+      # See DiskUsageWarningAlarm. Math over a single Metrics Insights query is
+      # allowed; what an alarm cannot carry is a second Insights query.
       Metrics:
         - Id: growth_rate
           Expression: "RATE(disk_usage)"
           ReturnData: true
         - Id: disk_usage
-          Expression: !Sub 'SELECT MAX(DISK_USED_PERCENT) FROM "RoboSystems/Graph/${Environment}"'
+          Expression: !Sub 'SELECT MAX(DISK_USED_PERCENT) FROM "RoboSystems/Graph/${Environment}" WHERE path = ''/mnt/ladybug-data'''
           Period: 1800 # 30 minutes
           ReturnData: false
       EvaluationPeriods: 1

--- a/cloudformation/graph-volumes.yaml
+++ b/cloudformation/graph-volumes.yaml
@@ -619,21 +619,23 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub "robosystems-graph-volumes-${Environment}-disk-usage-warning"
-      AlarmDescription: Disk usage exceeded 70% on any graph database instance at /mnt/ladybug-data
+      AlarmDescription: Disk usage exceeded 70% on any graph database instance (writers and shared master at /mnt/ladybug-data, shared replicas at /)
+      # Metrics Insights, not a MetricStat with a partial dimension set. The CloudWatch
+      # agent publishes DISK_USED_PERCENT with six dimensions (path, InstanceId,
+      # AutoScalingGroupName, InstanceType, device, fstype); a MetricStat must match the
+      # dimension set *exactly*, so the previous `Dimensions: [path=/mnt/ladybug-data]`
+      # matched nothing anywhere in the fleet and sat OK on "no datapoints received"
+      # for the life of the stack. An Insights query aggregates across dimension sets.
+      # No path filter: only / (replicas) and /mnt/ladybug-data (writers, shared master)
+      # publish this metric, and both are the volume holding the database. Metrics
+      # Insights rejects OR in WHERE, and an alarm allows only one Insights query, so
+      # filtering to both paths is not expressible — omitting the filter is the fix,
+      # not a shortcut. Verified live against prod before commit.
       Metrics:
-        - Id: m1
-          ReturnData: false
-          MetricStat:
-            Metric:
-              MetricName: DISK_USED_PERCENT
-              Namespace: !Sub "RoboSystems/Graph/${Environment}"
-              Dimensions:
-                - Name: path
-                  Value: /mnt/ladybug-data
-            Stat: Maximum
-            Period: 300
-        - Id: max_across_all
-          Expression: "MAX(METRICS())"
+        - Id: worst_disk
+          Expression: !Sub 'SELECT MAX(DISK_USED_PERCENT) FROM "RoboSystems/Graph/${Environment}"'
+          Period: 300
+          ReturnData: true
       EvaluationPeriods: 2 # 10 minutes of sustained high usage
       Threshold: 70
       ComparisonOperator: GreaterThanThreshold
@@ -644,21 +646,13 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub "robosystems-graph-volumes-${Environment}-disk-usage-critical"
-      AlarmDescription: CRITICAL - Disk usage exceeded 85% on any graph database instance at /mnt/ladybug-data
+      AlarmDescription: CRITICAL - Disk usage exceeded 85% on any graph database instance (writers and shared master at /mnt/ladybug-data, shared replicas at /)
+      # See DiskUsageWarningAlarm for why this is a Metrics Insights query.
       Metrics:
-        - Id: m1
-          ReturnData: false
-          MetricStat:
-            Metric:
-              MetricName: DISK_USED_PERCENT
-              Namespace: !Sub "RoboSystems/Graph/${Environment}"
-              Dimensions:
-                - Name: path
-                  Value: /mnt/ladybug-data
-            Stat: Maximum
-            Period: 300
-        - Id: max_across_all
-          Expression: "MAX(METRICS())"
+        - Id: worst_disk
+          Expression: !Sub 'SELECT MAX(DISK_USED_PERCENT) FROM "RoboSystems/Graph/${Environment}"'
+          Period: 300
+          ReturnData: true
       EvaluationPeriods: 1 # Trigger immediately at critical level
       Threshold: 85
       ComparisonOperator: GreaterThanThreshold
@@ -672,21 +666,13 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub "robosystems-graph-volumes-${Environment}-disk-usage-emergency"
-      AlarmDescription: EMERGENCY - Disk usage exceeded 95% on any graph database instance at /mnt/ladybug-data - Database operations at risk!
+      AlarmDescription: EMERGENCY - Disk usage exceeded 95% on any graph database instance (writers and shared master at /mnt/ladybug-data, shared replicas at /) - Database operations at risk!
+      # See DiskUsageWarningAlarm for why this is a Metrics Insights query.
       Metrics:
-        - Id: m1
-          ReturnData: false
-          MetricStat:
-            Metric:
-              MetricName: DISK_USED_PERCENT
-              Namespace: !Sub "RoboSystems/Graph/${Environment}"
-              Dimensions:
-                - Name: path
-                  Value: /mnt/ladybug-data
-            Stat: Maximum
-            Period: 60
-        - Id: max_across_all
-          Expression: "MAX(METRICS())"
+        - Id: worst_disk
+          Expression: !Sub 'SELECT MAX(DISK_USED_PERCENT) FROM "RoboSystems/Graph/${Environment}"'
+          Period: 60
+          ReturnData: true
       EvaluationPeriods: 1 # Trigger immediately
       Threshold: 95
       ComparisonOperator: GreaterThanThreshold
@@ -701,20 +687,18 @@ Resources:
     Properties:
       AlarmName: !Sub "robosystems-graph-volumes-${Environment}-rapid-disk-growth"
       AlarmDescription: Disk usage growing rapidly (>10% in 30 minutes)
+      # See DiskUsageWarningAlarm. Math over a Metrics Insights query is allowed;
+      # what an alarm cannot have is more than one Insights query, which is why
+      # the two publishing paths are covered by omitting the filter rather than
+      # by a second query.
       Metrics:
         - Id: growth_rate
           Expression: "RATE(disk_usage)"
+          ReturnData: true
         - Id: disk_usage
+          Expression: !Sub 'SELECT MAX(DISK_USED_PERCENT) FROM "RoboSystems/Graph/${Environment}"'
+          Period: 1800 # 30 minutes
           ReturnData: false
-          MetricStat:
-            Metric:
-              MetricName: DISK_USED_PERCENT
-              Namespace: !Sub "RoboSystems/Graph/${Environment}"
-              Dimensions:
-                - Name: path
-                  Value: /mnt/ladybug-data
-            Period: 1800 # 30 minutes
-            Stat: Average
       EvaluationPeriods: 1
       Threshold: 0.33 # 10% growth in 30 minutes = 0.33% per minute
       ComparisonOperator: GreaterThanThreshold

--- a/robosystems/adapters/sec/manifest.py
+++ b/robosystems/adapters/sec/manifest.py
@@ -42,8 +42,10 @@ SEC_MANIFEST = SharedRepositoryManifest(
     "`read-graph-cypher`.\n"
     "\n"
     "NOTES\n"
-    "- Deeper historical filings live in the `sec_historical` subgraph — switch "
-    "to its connector URL (see `list-subgraphs`) for older periods.\n"
+    # The `sec_historical` subgraph was advertised here until 2026-08-14 and is
+    # not served: the replica stack carries `sec` only, master reads are off,
+    # and the master is parked at desired 0, so every read for it fails. Do not
+    # restore this line until a read actually succeeds against that graph.
     "- This is shared public data: period close, chart-of-accounts mapping, and "
     "all write operations are unavailable here."
   ),

--- a/robosystems/middleware/auth/cache.py
+++ b/robosystems/middleware/auth/cache.py
@@ -1042,7 +1042,14 @@ class APIKeyCache:
         try:
           cached_data = cast(str | None, self.redis.get(key))
           if cached_data:
-            data = json.loads(cached_data)
+            # Entries are written through _encrypt_cache_data, so they are
+            # base64(fernet(json)) — a plain json.loads raised on every entry
+            # and the except below swallowed it, which meant no API-key entry
+            # was ever evicted. Decrypt through the same helper the read path
+            # uses; it returns the inner payload, so user_data is at the top.
+            data = self._decrypt_cache_data(cached_data)
+            if data is None:
+              continue
             user_data = data.get("user_data", {})
             if user_data.get("id") == user_id:
               self.redis.delete(key)
@@ -1057,7 +1064,11 @@ class APIKeyCache:
         try:
           cached_data = cast(str | None, self.redis.get(key))
           if cached_data:
-            data = json.loads(cached_data)
+            # Same defect as the API-key loop above: JWT entries are written
+            # encrypted too, so json.loads never succeeded here either.
+            data = self._decrypt_cache_data(cached_data)
+            if data is None:
+              continue
             user_data = data.get("user_data", {})
             if user_data.get("id") == user_id:
               self.redis.delete(key)

--- a/robosystems/operations/roboledger/views/financial_statement_query.py
+++ b/robosystems/operations/roboledger/views/financial_statement_query.py
@@ -138,16 +138,27 @@ async def query_financial_statement(
 
 
 def deduplicate_facts(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
-  """Deduplicate facts by ``(qname, end_date)``, keeping the first occurrence.
+  """Deduplicate facts by ``(qname, end_date, period_type, duration_type)``.
 
-  Results are ordered by ``end_date`` DESC at the query level, so the
-  first occurrence for each ``(qname, end_date)`` pair comes from the
-  most recent filing.
+  ``duration_type`` is load-bearing and was missing from the key until
+  2026-08-14: an annual and a quarterly fact legitimately share a ``qname``
+  and an ``end_date`` (Q4 and FY both end on the fiscal year end), so keying
+  on the pair alone silently collapsed them into whichever row the engine
+  happened to return first. ``ORDER BY end_date DESC`` does not break that
+  tie, so the survivor was not merely arbitrary but *unstable* between
+  otherwise identical calls — a wrong number rather than an error, on the
+  public SEC surface. The sibling path ``fact_query.deduplicate_facts``
+  already keys on the full period identity; this is the same fix.
   """
-  seen: set[tuple[str, str]] = set()
+  seen: set[tuple[str, str, str, str]] = set()
   deduped: list[dict[str, Any]] = []
   for row in rows:
-    key = (row.get("qname", "") or "", row.get("end_date", "") or "")
+    key = (
+      row.get("qname", "") or "",
+      row.get("end_date", "") or "",
+      row.get("period_type", "") or "",
+      row.get("duration_type", "") or "",
+    )
     if key not in seen:
       seen.add(key)
       deduped.append(row)

--- a/tests/middleware/auth/test_cache_comprehensive.py
+++ b/tests/middleware/auth/test_cache_comprehensive.py
@@ -853,3 +853,89 @@ class TestCachePerformance:
     encrypted_large = cache._encrypt_cache_data(large_data)
     decrypted_large = cache._decrypt_cache_data(encrypted_large)
     assert decrypted_large == large_data
+
+
+class TestInvalidateUserData:
+  """Regression cover for ``invalidate_user_data``.
+
+  This method had four production callers and no test. It read cache entries
+  with ``json.loads`` while the write path stores them via
+  ``_encrypt_cache_data`` (base64 of a Fernet token), so every iteration
+  raised and was swallowed by the surrounding ``except``: no API-key or JWT
+  entry was ever evicted on member removal, role change, or grant revoke.
+  Both tests below fail against that original code.
+  """
+
+  @pytest.fixture
+  def cache(self):
+    """APIKeyCache with a Mock injected at ``_redis``.
+
+    The ``redis`` attribute is a lazy property, so the mock goes on the
+    backing field rather than on the property itself.
+    """
+    with patch("robosystems.middleware.auth.cache.redis.Redis"):
+      cache = APIKeyCache()
+      cache._redis = Mock()
+      if not hasattr(cache, "_validation_failures"):
+        cache._validation_failures = 0
+      return cache
+
+  def _entry(self, cache, user_id):
+    """An entry in exactly the shape the write path produces."""
+    return cache._encrypt_cache_data(
+      {
+        "user_data": {"id": user_id, "email": f"{user_id}@example.com"},
+        "is_active": True,
+        "cached_at": datetime.now(UTC).isoformat(),
+        "cache_version": cache.CACHE_VERSION,
+      }
+    )
+
+  def test_invalidates_encrypted_api_key_and_jwt_entries(self, cache):
+    """Entries belonging to the user are deleted; others are left alone."""
+    target, other = "user_target", "user_other"
+    api_key = f"{cache.CACHE_KEY_PREFIX}hash_target"
+    api_key_other = f"{cache.CACHE_KEY_PREFIX}hash_other"
+    jwt_key = f"{cache.JWT_CACHE_KEY_PREFIX}jwt_target"
+
+    store = {
+      api_key: self._entry(cache, target),
+      api_key_other: self._entry(cache, other),
+      jwt_key: self._entry(cache, target),
+    }
+
+    cache.redis.keys.side_effect = lambda pattern: [
+      k for k in store if k.startswith(pattern.rstrip("*"))
+    ]
+    cache.redis.get.side_effect = store.get
+
+    deleted: list[str] = []
+    cache.redis.delete.side_effect = lambda *keys: deleted.extend(keys)
+
+    cache.invalidate_user_data(target)
+
+    # The two entries owned by the target user are evicted...
+    assert api_key in deleted, "encrypted API-key entry was not invalidated"
+    assert jwt_key in deleted, "encrypted JWT entry was not invalidated"
+    # ...and the unrelated user's entry survives.
+    assert api_key_other not in deleted
+
+  def test_undecryptable_entry_is_skipped_not_fatal(self, cache):
+    """A corrupt entry must not abort the sweep for the remaining keys."""
+    target = "user_target"
+    corrupt = f"{cache.CACHE_KEY_PREFIX}corrupt"
+    good = f"{cache.CACHE_KEY_PREFIX}good"
+
+    store = {corrupt: "not-a-fernet-token", good: self._entry(cache, target)}
+
+    cache.redis.keys.side_effect = lambda pattern: [
+      k for k in store if k.startswith(pattern.rstrip("*"))
+    ]
+    cache.redis.get.side_effect = store.get
+
+    deleted: list[str] = []
+    cache.redis.delete.side_effect = lambda *keys: deleted.extend(keys)
+
+    cache.invalidate_user_data(target)
+
+    assert good in deleted, "a corrupt sibling entry aborted the sweep"


### PR DESCRIPTION
## Summary

Four unrelated defects surfaced by a design-doc audit of the forward-work corpus. They share one shape: each is a mechanism that reads as working — a declared alarm, a dedup pass, a documented capability, an invalidation sweep — and does nothing. None of them fails loudly, so none had been noticed.

## Changes

### CloudWatch — the graph disk alarms watched nothing (`cloudformation/graph-volumes.yaml`, `graph-ladybug-replicas.yaml`)

All four `DISK_USED_PERCENT` alarms declared a `MetricStat` carrying a single `path` dimension. The CloudWatch agent publishes that metric with six (`path`, `InstanceId`, `AutoScalingGroupName`, `InstanceType`, `device`, `fstype`), and a `MetricStat` must match the dimension set **exactly** — so the alarms matched no metric stream anywhere in the graph fleet and sat `OK` on `"no datapoints were received"` for the life of the stack.

Each is now a Metrics Insights query, which aggregates across dimension sets while keeping the path filter. Two fleets, two treatments — this is the part to review:

**Data volumes (`/mnt/ladybug-data`) — writers and shared master.** Thresholds moved to **75 / 85 / 90**. The path filter is load-bearing: this ladder feeds `VolumeMonitorFunction`, which sweeps the volume registry and expands anything past `EXPANSION_THRESHOLD=0.8`, and only attached, registered data volumes are expandable. Live value is **1.09%**, so none of these fire.

**Root volumes (`/`) — shared replicas.** These hold the database on a launch-template device with `DeleteOnTermination`, no autoscaling, absent from the volume registry, so the expansion ladder cannot help them. They get **one notify-only alarm at 90%** in the replicas stack rather than a ladder: the remedy is raising `SHARED_REPLICAS_ROOT_VOLUME_SIZE_<ENV>` and cycling the fleet — one action, so one page.

⚠️ **The replica alarm will be `ALARM` on deploy.** Live value is **89.97%**. That is the intended signal, not a false positive, and it clears when the volume is resized. Sizing is a separate, deliberate decision and is not part of this PR.

Notes on the mechanics, for reviewers:

- Metrics Insights rejects `OR` in `WHERE` and an alarm permits only one Insights query, which is why the two paths are two alarms rather than one.
- Math over a single Insights query *is* permitted — that is what keeps `RATE()` working for `RapidDiskGrowthAlarm`.
- **Validated live against prod with `get-metric-data` before commit**, and the rendered YAML re-checked after quote-escaping. `cfn-lint` does not catch dimension mismatches, so it passes either way.

### SEC statement reads — fact dedup dropped the period type (`operations/roboledger/views/financial_statement_query.py`)

`deduplicate_facts` keyed on `(qname, end_date)` while projecting `duration_type` at the query level and never using it. An annual and a quarterly fact legitimately share a qname and an end date — Q4 and FY both land on the fiscal year end — so the pair collapsed them into whichever row came back first. `ORDER BY end_date DESC` does not break that tie, which made the survivor not merely arbitrary but **unstable between otherwise identical calls**.

Now keyed on `(qname, end_date, period_type, duration_type)`. The sibling path `fact_query.deduplicate_facts` already keyed on the full period identity; this brings the two into line.

**Behavioral note for reviewers:** this is a response-content change, not a schema change. `financial-statement-analysis` (REST view and MCP tool) can now legitimately return both a Q4 and an FY row where it previously returned one. Any consumer assuming one row per `(qname, end_date)` was relying on the defect.

### SEC manifest — an advertised subgraph with no serving path (`adapters/sec/manifest.py`)

`agent_instructions` ships to every connected MCP client and told users to switch to the `sec_historical` subgraph for older periods. That read cannot succeed: the replica stack serves `sec` only, shared-master reads are disabled, and the master runs at desired 0. Its snapshot is also weeks stale and it has no graph-registry row.

Removed rather than left as a documented dead end in front of new users. A comment records the condition for restoring it: a read against that graph actually succeeding.

### Auth cache — invalidation could not match its own entries (`middleware/auth/cache.py`)

`invalidate_user_data` parsed entries with `json.loads` while the write path stores them via `_encrypt_cache_data`, so the sweep could not match any entry and the surrounding `except` swallowed the result. Both the API-key and JWT loops were affected. They now route through `_decrypt_cache_data`, skipping entries that will not decrypt so a single bad entry cannot abort the sweep.

The method had four production callers and **no test**. Adds two regression tests, both confirmed to fail against the previous code.

Checked and deliberately unchanged: the two other `json.loads(cached_data)` sites (`get_cached_graph_access`, `get_cached_jwt_graph_access`) are correct — that cache family is written with plain `json.dumps` and is not encrypted.

## Breaking Changes

**None.** No REST shape, GraphQL schema, or operations-envelope change; the OpenAPI spec is unchanged, so no client regen is required and neither SDK tier is touched.

The statement-read dedup fix changes response *content* (see the behavioral note above) without changing response *shape*. Flagging it here for visibility rather than because it is a contract break — the previous behavior was non-deterministic and could not have been depended on safely.

## Testing

Run this session, all from a local environment:

- `just test` — **12,849 passed, 38 skipped, 0 failed** (5m14s)
- `just test-code` — clean (ruff, format, basedpyright, cf-lint: `0 errors, 0 warnings, 0 notes`)
- `just cf-lint graph-volumes` — clean
- Targeted: `tests/middleware/auth/` + `tests/operations/roboledger/views/` — 318 passed
- **Metrics Insights expressions validated live** against the prod `RoboSystems/Graph/prod` namespace with `cloudwatch get-metric-data` before commit, including the `RATE()` form. This is the check that matters here, because `cfn-lint` is blind to dimension mismatches.
- The two new auth-cache tests were **reverted against the original implementation and confirmed to fail**, then restored.

Not run: deployment of the CloudFormation change (`graph-volumes` deploys through its own workflow, not with the service release).

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.

