### PR TITLE
fix(worker): allow the worker to publish graph metrics

### DIFF
--- a/cloudformation/worker.yaml
+++ b/cloudformation/worker.yaml
@@ -309,13 +309,30 @@ Resources:
                 Resource:
                   - !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/robosystems/${Environment}/worker:*"
               # CloudWatch Metrics
+              #
+              # Two namespaces, and the second one is load-bearing. Graph
+              # allocation runs in the worker, and its failure metric publishes
+              # to RoboSystems/Graph/${Environment} (allocation_manager.py's
+              # _publish_failure_metric) because that is the namespace the
+              # AllocationFailures alarms in graph-ladybug.yaml watch. With only
+              # the Worker namespace allowed, every publish returned AccessDenied
+              # into a logger.error and the alarms sat OK on "no datapoints
+              # received" -- in BOTH environments -- since February.
+              #
+              # Proven 2026-08-15 by inducing a real no_capacity failure in
+              # staging: the allocation failed in 17s, the metric never
+              # published, and the worker log carried the AccessDenied. The
+              # 2026-08-09 dimension fix was correct and could never have taken
+              # effect underneath this.
               - Effect: Allow
                 Action:
                   - cloudwatch:PutMetricData
                 Resource: "*"
                 Condition:
                   StringEquals:
-                    "cloudwatch:namespace": !Sub "RoboSystems/Worker/${Environment}"
+                    "cloudwatch:namespace":
+                      - !Sub "RoboSystems/Worker/${Environment}"
+                      - !Sub "RoboSystems/Graph/${Environment}"
               # OpenSearch (conditional)
               - !If
                 - HasOpenSearch


### PR DESCRIPTION
## Summary

Executing the detection arm of `disaster-recovery-testing` against staging found that `AllocationFailures` cannot publish in **either** environment, and has not been able to since it was created. The alarms were not merely quiet — the metric was blocked by IAM one layer below where anyone had looked.

## Changes

`cloudformation/worker.yaml` — the worker task role's `cloudwatch:PutMetricData` grant was conditioned on a single namespace:

```yaml
Condition:
  StringEquals:
    "cloudwatch:namespace": !Sub "RoboSystems/Worker/${Environment}"
```

Graph allocation runs in the worker, and its failure metric publishes to `RoboSystems/Graph/${Environment}` (`allocation_manager.py` `_publish_failure_metric`) because that is the namespace the `AllocationFailures` alarms in `graph-ladybug.yaml` watch. Every publish therefore returned `AccessDenied`, the emitter swallowed it into a `logger.error`, and both alarms sat `OK` on *"no datapoints were received"* since **2026-02-08**.

The condition now permits both namespaces.

## How it was found

The detection arm calls for inducing the condition rather than reasoning about it. The staging instance registry is empty, so the allocator fails fast *before writing anything* — a zero-mutation induction, no ASG change and no cleanup:

1. Baseline: both staging alarms `OK` since 2026-02-08; **zero** metric streams.
2. Induced a real graph creation. It failed in **17 seconds** with `No Ladybug Standard capacity currently available` — the `no_capacity` path at `allocation_manager.py:331`.
3. Five minutes later: still **zero** streams, alarm still `OK`.
4. The worker log carried the cause:

```
Failed to publish failure metric: AccessDenied ... assumed-role/robosystems-worker-task-role-staging
is not authorized to perform: cloudwatch:PutMetricData
```

Two consequences worth stating plainly:

- **The 2026-08-09 dimension fix was correct and could never have taken effect.** It made the emitter publish under both `FailureReason` and `Environment`; both were being denied. A fix landed on top of a blocker nobody had reached.
- **In prod this is the alarm that reports a paying customer's graph creation failing for lack of capacity** — the detection half of `paid-path-hardening`'s post-payment provisioning gap. That failure is currently both unhandled and unreported.

## Breaking Changes

None. IAM grant widened by one namespace; no API, schema, or SDK surface touched.

## Testing

- `just cf-lint worker` — clean.
- Rendered the template through a YAML parse to confirm the `Condition` emits a two-element list rather than a malformed scalar.
- Confirmed the current state the fix addresses: `RoboSystems/Graph/{prod,staging}` carry **0** `AllocationFailures` streams, and `RoboSystems/Worker/{prod,staging}` carry only `DLQDepth` and `QueueDepth` — exactly the metrics the old grant allowed.
- Not run: the end-to-end proof. It requires a worker stack deploy in each environment, after which the staging induction above should be repeated and the metric watched to publish and the alarm to transition. That re-run is what closes the `alarm-delivery-assurance` §7 row for `AllocationFailures`.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
