### PR TITLE
chore: pre-1.9.0 punch-list — membership audit events, opaque-call refusal

### DIFF
--- a/.github/release-notes/v1.9.0.md
+++ b/.github/release-notes/v1.9.0.md
@@ -42,6 +42,12 @@ disabled, every password-credential endpoint refuses, invitations included. Veri
 invitation emails can target a designated login home with return context, which is what let
 interactive sign-in consolidate onto one app during this series.
 
+**Membership changes are audited.** Adding a member, changing their role, or removing them — on an
+organization or on a graph — is a privileged access change, and each of the six mutation sites now
+writes a structured security-audit event carrying the actor, the target, the scope and the prior and
+new role, alongside the SCIM lifecycle events. Refusals were already recorded; the grants were not.
+Evidence, not alerts: no metric, no alarm.
+
 ## Passkeys
 
 The complete WebAuthn backend, behind `PASSKEYS_ENABLED`. After password verification an enrolled user
@@ -175,6 +181,9 @@ evaluation recording an error rather than a verdict; both migrations fan into ev
   materializations can never write the same graph concurrently.
 - The SEC connector's instructions no longer direct users to a historical subgraph with no serving path.
 - An authentication-cache invalidation path was corrected and gained the tests it did not have.
+- The query surfaces — REST, MCP and the Operator write tool — refuse procedures that execute a
+  statement passed as a string argument, on every graph and regardless of role; the statement
+  analyzer cannot classify a payload it deliberately does not read.
 - Fork-safe demo runners: the roboledger and roboinvestor demos honor `DEMO_API_URL`, keep credentials
   per target, and are strictly API-only against anything but the local stack; the scenario runner can
   skip the report-serialization pass.

--- a/robosystems/middleware/graph/statement_kernel.py
+++ b/robosystems/middleware/graph/statement_kernel.py
@@ -23,6 +23,7 @@ from starlette import status as http_status
 from robosystems.middleware.graph.utils import MultiTenantUtils, parse_subgraph_id
 from robosystems.models.core import User
 from robosystems.security.cypher_analyzer import (
+  has_opaque_statement_call,
   is_admin_operation,
   is_bulk_operation,
   is_schema_ddl,
@@ -78,6 +79,22 @@ class StatementKernel:
   def _authorize_cypher(
     self, graph_id: str, statement: str, user: User, session: Session
   ) -> StatementAuthorization:
+    # Refuse procedures that execute a string payload (CALL GQL('...')) before
+    # any classification or role check. The analyzer masks string literals so
+    # it cannot see what the payload would do, and a subgraph member holds
+    # write access legitimately — so this is not a write-policy question, it
+    # is a "the gauntlet cannot run on this shape" question, on every graph.
+    if has_opaque_statement_call(statement):
+      logger.warning(
+        f"User {user.id} attempted an opaque statement call on {graph_id}: {statement[:100]}"
+      )
+      raise HTTPException(
+        status_code=http_status.HTTP_403_FORBIDDEN,
+        detail="Procedures that execute a statement passed as a string "
+        "(e.g. CALL GQL(...)) are not allowed through the query endpoints. "
+        "Submit the statement directly so it can be authorized.",
+      )
+
     # Analyze query
     is_write = is_write_operation(statement)
     access_type = "write" if is_write else "read"

--- a/robosystems/middleware/mcp/tools/subgraph_write_tools.py
+++ b/robosystems/middleware/mcp/tools/subgraph_write_tools.py
@@ -73,11 +73,21 @@ def _validate_write_query(query: str) -> str | None:
   guard — which also protects the Operator path — can't diverge from the kernel.
   """
   from robosystems.security.cypher_analyzer import (
+    has_opaque_statement_call,
     is_admin_operation,
     is_bulk_operation,
     is_schema_ddl,
     is_write_operation,
   )
+
+  # A procedure that executes a string payload (CALL GQL('...')) classifies
+  # as a write, so it would pass the write requirement below — and the family
+  # gates cannot see inside the string. Refuse the shape, as the kernel does.
+  if has_opaque_statement_call(query):
+    return (
+      "Blocked operation detected. Procedures that execute a statement passed "
+      "as a string (e.g. CALL GQL) are not allowed; submit the statement directly."
+    )
 
   # Block DDL / bulk / admin — the same dangerous categories the kernel and the
   # read tool reject (DROP/ALTER/TABLE/INDEX, LOAD CSV/COPY, CALL DB./APOC.).

--- a/robosystems/routers/auth/register.py
+++ b/robosystems/routers/auth/register.py
@@ -362,13 +362,25 @@ async def register(
     logger.info(f"Email automatically verified for development user: {sanitized_email}")
 
   if invitation is not None:
-    logger.info(
-      f"User {sanitized_email} joined org {org.id} via invitation {invitation.id}",
-      extra={
-        "user_id": user.id,
+    # The org-side "member added" record for the invited-registration path.
+    # The joiner is the actor (they accepted); the inviter is carried so the
+    # grant chain is reconstructible from this one line.
+    SecurityAuditLogger.log_security_event(
+      event_type=SecurityEventType.ORG_MEMBER_ADDED,
+      user_id=user.id,
+      ip_address=client_ip,
+      user_agent=user_agent,
+      endpoint="/v1/auth/register",
+      details={
+        "action": "org_member_added",
         "org_id": org.id,
-        "org_role": invitation.role.value,
+        "target_user_id": user.id,
+        "new_role": invitation.role.value,
+        "via": "invitation",
+        "invitation_id": invitation.id,
+        "invited_by": invitation.invited_by,
       },
+      risk_level="low",
     )
   else:
     logger.info(

--- a/robosystems/routers/graphs/members.py
+++ b/robosystems/routers/graphs/members.py
@@ -23,11 +23,16 @@ from robosystems.models.api.graphs.members import (
   UpdateGraphMemberRoleRequest,
 )
 from robosystems.models.core import Graph, GraphRole, GraphUser, OrgRole, OrgUser, User
-from robosystems.security import SecurityAuditLogger
+from robosystems.security import SecurityAuditLogger, SecurityEventType
 
 logger = get_logger(__name__)
 
 router = APIRouter(prefix="/members", tags=["Graph Members"])
+
+
+def _role_value(role: str | GraphRole) -> str:
+  """``GraphUser.role`` is a plain string column; normalize for audit details."""
+  return role.value if isinstance(role, GraphRole) else str(role)
 
 
 def _load_managed_graph(graph_id: str, db: Session) -> Graph:
@@ -173,8 +178,17 @@ async def add_graph_member(
   )
   _invalidate_target_caches(target.id)
 
-  logger.info(
-    f"User {current_user.id} granted {target.id} role {request.role.value} on graph {graph_id}"
+  SecurityAuditLogger.log_security_event(
+    event_type=SecurityEventType.GRAPH_MEMBER_ADDED,
+    user_id=current_user.id,
+    details={
+      "action": "graph_member_added",
+      "graph_id": graph_id,
+      "org_id": graph.org_id,
+      "target_user_id": target.id,
+      "new_role": request.role.value,
+    },
+    risk_level="low",
   )
   return _explicit_member_response(row, target)
 
@@ -210,11 +224,21 @@ async def update_graph_member_role(
       ),
     )
 
+  previous_role = row.role
   row.update_role(request.role, db)
   _invalidate_target_caches(user_id)
 
-  logger.info(
-    f"User {current_user.id} set {user_id} role to {request.role.value} on graph {graph_id}"
+  SecurityAuditLogger.log_security_event(
+    event_type=SecurityEventType.GRAPH_MEMBER_ROLE_CHANGED,
+    user_id=current_user.id,
+    details={
+      "action": "graph_member_role_changed",
+      "graph_id": graph_id,
+      "target_user_id": user_id,
+      "previous_role": _role_value(previous_role),
+      "new_role": request.role.value,
+    },
+    risk_level="low",
   )
   return _explicit_member_response(row, row.user)
 
@@ -246,7 +270,18 @@ async def remove_graph_member(
       detail="User has no explicit grant on this graph",
     )
 
+  removed_role = row.role
   row.delete(db)
   _invalidate_target_caches(user_id)
 
-  logger.info(f"User {current_user.id} revoked {user_id} access to graph {graph_id}")
+  SecurityAuditLogger.log_security_event(
+    event_type=SecurityEventType.GRAPH_MEMBER_REMOVED,
+    user_id=current_user.id,
+    details={
+      "action": "graph_member_removed",
+      "graph_id": graph_id,
+      "target_user_id": user_id,
+      "previous_role": _role_value(removed_role),
+    },
+    risk_level="low",
+  )

--- a/robosystems/routers/orgs/members.py
+++ b/robosystems/routers/orgs/members.py
@@ -21,6 +21,7 @@ from ...operations.billing import (
   ProviderCancellationError,
   cancel_user_repository_subscriptions,
 )
+from ...security import SecurityAuditLogger, SecurityEventType
 
 logger = get_logger(__name__)
 
@@ -165,6 +166,7 @@ async def update_member_role(
         )
 
     # Update the role
+    previous_role = target_membership.role
     target_membership.role = request.role
     db.commit()
     db.refresh(target_membership)
@@ -176,8 +178,17 @@ async def update_member_role(
 
     target_user = target_membership.user
 
-    logger.info(
-      f"User {current_user.id} updated role for user {user_id} in org {org_id} to {request.role}"
+    SecurityAuditLogger.log_security_event(
+      event_type=SecurityEventType.ORG_MEMBER_ROLE_CHANGED,
+      user_id=current_user.id,
+      details={
+        "action": "org_member_role_changed",
+        "org_id": org_id,
+        "target_user_id": user_id,
+        "previous_role": previous_role.value,
+        "new_role": request.role.value,
+      },
+      risk_level="low",
     )
 
     return OrgMemberResponse(
@@ -315,13 +326,27 @@ async def remove_member(
         GraphUser.graph_id.in_(org_graph_ids),
       ).delete(synchronize_session=False)
 
+    removed_role = target_membership.role
     db.delete(target_membership)
     db.commit()
 
     api_key_cache.invalidate_user_jwt_graph_access(user_id)
     api_key_cache.invalidate_user_data(user_id)
 
-    logger.info(f"User {user_id} removed from org {org_id} by user {current_user.id}")
+    SecurityAuditLogger.log_security_event(
+      event_type=SecurityEventType.ORG_MEMBER_REMOVED,
+      user_id=current_user.id,
+      details={
+        "action": "org_member_removed",
+        "org_id": org_id,
+        "target_user_id": user_id,
+        "previous_role": removed_role.value,
+        "self_removal": user_id == current_user.id,
+        "org_graph_grants_revoked": len(org_graph_ids),
+        "repository_subscriptions_canceled": len(canceled),
+      },
+      risk_level="low",
+    )
 
   except HTTPException:
     raise

--- a/robosystems/security/audit_logger.py
+++ b/robosystems/security/audit_logger.py
@@ -55,6 +55,18 @@ class SecurityEventType(Enum):
   SCIM_USER_DEACTIVATED = "scim_user_deactivated"
   SCIM_USER_REACTIVATED = "scim_user_reactivated"
   SCIM_AUTH_FAILURE = "scim_auth_failure"
+  # Membership lifecycle — privileged access changes made through our own
+  # API (SOC 2 CC6.x: access granted, modified and removed through an
+  # authorized process, with a record). Evidence, not alerts: no metric,
+  # like the SCIM lifecycle events. ``user_id`` on the event is the actor;
+  # ``details`` carries the target, the scope (org_id / graph_id) and the
+  # prior and new role.
+  ORG_MEMBER_ADDED = "org_member_added"
+  ORG_MEMBER_ROLE_CHANGED = "org_member_role_changed"
+  ORG_MEMBER_REMOVED = "org_member_removed"
+  GRAPH_MEMBER_ADDED = "graph_member_added"
+  GRAPH_MEMBER_ROLE_CHANGED = "graph_member_role_changed"
+  GRAPH_MEMBER_REMOVED = "graph_member_removed"
   # Passkey MFA lifecycle (operational; only MFA_FAILED alarms — a spike is
   # the second-factor brute-force / phishing-relay signal)
   PASSKEY_ENROLLED = "passkey_enrolled"

--- a/robosystems/security/cypher_analyzer.py
+++ b/robosystems/security/cypher_analyzer.py
@@ -106,6 +106,19 @@ class CypherSecurityAnalyzer:
     "query_fts_index",
   }
 
+  # Procedures that execute a *statement supplied as a string argument*.
+  # Static analysis classifies the CALL, never the payload: `_clean_query`
+  # masks string literals precisely so keyword detection sees code and not
+  # data, which means every family gate (bulk / admin / DDL) is blind to
+  # what such a procedure will run. The write gate already fails closed on
+  # any CALL outside READ_ONLY_PROCEDURES, but a caller who legitimately
+  # holds write access (a subgraph member) passes that gate — so these are
+  # refused outright on every surface, regardless of role. Names are
+  # matched case-insensitively against the CALL target.
+  OPAQUE_STATEMENT_PROCEDURES = {
+    "gql",
+  }
+
   # Read-only keywords that should never trigger write detection
   READ_KEYWORDS = {
     "MATCH",
@@ -257,6 +270,21 @@ class CypherSecurityAnalyzer:
       logger.warning(f"System call analysis failed: {e}")
       # Default to false for system calls
       return False
+
+  def has_opaque_statement_call(self, query: str) -> bool:
+    """Check whether a query calls a procedure in OPAQUE_STATEMENT_PROCEDURES.
+
+    Fails closed: if analysis raises, the query is treated as containing one.
+    """
+    try:
+      cleaned_query = self._clean_query(query)
+      for match in self.call_pattern.finditer(cleaned_query):
+        if match.group(1).lower() in self.OPAQUE_STATEMENT_PROCEDURES:
+          return True
+      return False
+    except Exception as e:
+      logger.warning(f"Opaque-statement call analysis failed: {e}")
+      return True
 
   def _validate_query_security(self, query: str) -> None:
     """
@@ -628,6 +656,18 @@ def is_non_read_call(query: str) -> bool:
 def has_system_calls(query: str) -> bool:
   """Determine whether a Cypher query calls a system procedure."""
   return cypher_analyzer.has_system_calls(query)
+
+
+def has_opaque_statement_call(query: str) -> bool:
+  """
+  Determine whether a Cypher query calls a procedure that executes a
+  statement supplied as a string (e.g. ``CALL GQL('...')``).
+
+  Such calls defeat static authorization by construction — the payload is a
+  string literal the analyzer deliberately does not read — so callers refuse
+  them outright rather than classifying them.
+  """
+  return cypher_analyzer.has_opaque_statement_call(query)
 
 
 def is_schema_ddl(query: str) -> bool:

--- a/tests/middleware/graph/test_statement_kernel.py
+++ b/tests/middleware/graph/test_statement_kernel.py
@@ -1,6 +1,6 @@
 """Unit tests for StatementKernel — the extracted statement authorization gauntlet.
 
-The four cypher-analyzer predicates are patched per-test so each policy tier is
+The five cypher-analyzer predicates are patched per-test so each policy tier is
 isolated deterministically (the analyzers have their own coverage). Topology
 helpers (subgraph detection, shared-repo, role) are patched to place the graph.
 """
@@ -32,6 +32,7 @@ def _topology(
   is_bulk=False,
   is_admin=False,
   is_ddl=False,
+  is_opaque_call=False,
   is_subgraph=False,
   is_shared=False,
   has_write_access=True,
@@ -42,6 +43,7 @@ def _topology(
     patch(f"{MOD}.is_bulk_operation", return_value=is_bulk),
     patch(f"{MOD}.is_admin_operation", return_value=is_admin),
     patch(f"{MOD}.is_schema_ddl", return_value=is_ddl),
+    patch(f"{MOD}.has_opaque_statement_call", return_value=is_opaque_call),
     patch(f"{MOD}.parse_subgraph_id", return_value=(object() if is_subgraph else None)),
     patch(
       f"{MOD}.MultiTenantUtils.is_shared_repository_or_subgraph",
@@ -128,6 +130,32 @@ def test_schema_ddl_blocked():
       _authorize("kg1234567890abcdef", "DROP TABLE foo")
   assert e.value.status_code == 403
   assert "Schema DDL" in e.value.detail
+
+
+def test_opaque_statement_call_blocked_on_subgraph_for_writer():
+  """The case no other gate catches: a subgraph member with write access,
+  where the write gate would allow the CALL and the family gates cannot see
+  the payload. The deny must fire before any of them."""
+  with _topology(
+    is_write=True, is_subgraph=True, has_write_access=True, is_opaque_call=True
+  ):
+    with pytest.raises(HTTPException) as e:
+      _authorize(
+        "kg1234567890abcdef_dev",
+        "CALL GQL('CREATE NODE TABLE Evil(id INT64, PRIMARY KEY(id))')",
+      )
+  assert e.value.status_code == 403
+  assert "CALL GQL" in e.value.detail
+
+
+def test_opaque_statement_call_blocked_on_main_graph_read():
+  """Refused with the specific message even when the analyzer would have
+  called it a read, so the caller learns the actual rule."""
+  with _topology(is_write=False, is_opaque_call=True):
+    with pytest.raises(HTTPException) as e:
+      _authorize("kg1234567890abcdef", "CALL GQL('MATCH (n) RETURN n')")
+  assert e.value.status_code == 403
+  assert "passed as a string" in e.value.detail
 
 
 def _authorize_sql(graph_id, statement="SELECT 1"):

--- a/tests/middleware/mcp/test_subgraph_write_tools.py
+++ b/tests/middleware/mcp/test_subgraph_write_tools.py
@@ -127,6 +127,18 @@ class TestValidateWriteQuery:
     assert "Blocked" in result
 
   @pytest.mark.unit
+  def test_opaque_statement_call_blocked(self):
+    """CALL GQL('...') classifies as a write, so it would satisfy the
+    write requirement — and the DDL/bulk/admin gates cannot see inside the
+    string. The tool refuses the shape itself rather than relying on the
+    engine-side validator."""
+    result = _validate_write_query(
+      "CALL GQL('CREATE NODE TABLE Evil(id INT64, PRIMARY KEY(id))')"
+    )
+    assert result is not None
+    assert "CALL GQL" in result
+
+  @pytest.mark.unit
   def test_load_csv_blocked(self):
     result = _validate_write_query("LOAD CSV FROM 'file.csv' AS row CREATE (n:Foo)")
     assert result is not None

--- a/tests/routers/auth/test_auth.py
+++ b/tests/routers/auth/test_auth.py
@@ -552,6 +552,54 @@ class TestInvitedRegistration:
     True,
   )
   @patch.dict(os.environ, {"ENVIRONMENT": "dev"})
+  def test_register_with_invitation_audits_the_org_join(
+    self, client: TestClient, test_db, test_user
+  ):
+    """The invited join is the org-side "member added" — a privileged access
+    change that must leave a structured record carrying the inviter."""
+    from robosystems.models.core import OrgRole
+    from robosystems.security import SecurityEventType
+
+    org, invitation, raw_token = self._make_invitation(
+      test_db, test_user, "audited-invitee@example.com", role=OrgRole.MEMBER
+    )
+
+    with patch("robosystems.routers.auth.register.SecurityAuditLogger") as audit:
+      response = client.post(
+        "/v1/auth/register",
+        json={
+          "name": "Audited Invitee",
+          "email": "audited-invitee@example.com",
+          "password": "S3cur3P@ssw0rd!2024",
+          "invite_token": raw_token,
+        },
+      )
+
+    assert response.status_code == 201
+    joined = [
+      c.kwargs
+      for c in audit.log_security_event.call_args_list
+      if c.kwargs["event_type"] is SecurityEventType.ORG_MEMBER_ADDED
+    ]
+    assert len(joined) == 1
+    new_user = User.get_by_email("audited-invitee@example.com", test_db)
+    assert joined[0]["user_id"] == new_user.id
+    assert joined[0]["details"] == {
+      "action": "org_member_added",
+      "org_id": org.id,
+      "target_user_id": new_user.id,
+      "new_role": "member",
+      "via": "invitation",
+      "invitation_id": invitation.id,
+      "invited_by": test_user.id,
+    }
+
+  @patch.object(
+    __import__("robosystems.config", fromlist=["env"]).env,
+    "USER_REGISTRATION_ENABLED",
+    True,
+  )
+  @patch.dict(os.environ, {"ENVIRONMENT": "dev"})
   def test_register_with_invitation_email_mismatch(
     self, client: TestClient, test_db, test_user
   ):

--- a/tests/routers/graphs/test_members.py
+++ b/tests/routers/graphs/test_members.py
@@ -8,6 +8,7 @@ parent-graph-only rule.
 
 from __future__ import annotations
 
+from unittest.mock import patch
 from uuid import uuid4
 
 import pytest
@@ -22,6 +23,7 @@ from robosystems.models.core import (
   OrgUser,
   User,
 )
+from robosystems.security import SecurityEventType
 
 pytestmark = pytest.mark.asyncio
 
@@ -293,3 +295,92 @@ class TestRemoveGraphMember:
     )
 
     assert response.status_code == 404
+
+
+class TestGraphMembershipAuditEvents:
+  """Grant, role change and revoke on a graph are privileged access changes
+  and each must leave a structured security-audit record (SOC 2 CC6.x). This
+  router previously audited only refusals."""
+
+  def _org_graph_with_teammate(self, test_db, test_user, grant: GraphRole | None):
+    org, graph = _setup_org_graph(test_db, test_user.id)
+    teammate = _create_user(test_db, test_user.password_hash)
+    OrgUser.create(
+      org_id=org.id, user_id=teammate.id, role=OrgRole.MEMBER, session=test_db
+    )
+    if grant is not None:
+      GraphUser.create(
+        user_id=teammate.id, graph_id=graph.graph_id, role=grant, session=test_db
+      )
+    return org, graph, teammate
+
+  async def test_grant_is_audited(self, async_client, test_db, test_user):
+    org, graph, teammate = self._org_graph_with_teammate(test_db, test_user, None)
+
+    with patch("robosystems.routers.graphs.members.SecurityAuditLogger") as audit:
+      response = await async_client.post(
+        f"/v1/graphs/{graph.graph_id}/members",
+        json={"user_id": teammate.id, "role": "viewer"},
+      )
+
+    assert response.status_code == 201
+    kwargs = audit.log_security_event.call_args.kwargs
+    assert kwargs["event_type"] is SecurityEventType.GRAPH_MEMBER_ADDED
+    assert kwargs["user_id"] == test_user.id
+    assert kwargs["details"] == {
+      "action": "graph_member_added",
+      "graph_id": graph.graph_id,
+      "org_id": org.id,
+      "target_user_id": teammate.id,
+      "new_role": "viewer",
+    }
+
+  async def test_role_change_is_audited(self, async_client, test_db, test_user):
+    _, graph, teammate = self._org_graph_with_teammate(
+      test_db, test_user, GraphRole.VIEWER
+    )
+
+    with patch("robosystems.routers.graphs.members.SecurityAuditLogger") as audit:
+      response = await async_client.put(
+        f"/v1/graphs/{graph.graph_id}/members/{teammate.id}",
+        json={"role": "member"},
+      )
+
+    assert response.status_code == 200
+    kwargs = audit.log_security_event.call_args.kwargs
+    assert kwargs["event_type"] is SecurityEventType.GRAPH_MEMBER_ROLE_CHANGED
+    assert kwargs["details"]["previous_role"] == "viewer"
+    assert kwargs["details"]["new_role"] == "member"
+    assert kwargs["details"]["target_user_id"] == teammate.id
+
+  async def test_revoke_is_audited(self, async_client, test_db, test_user):
+    _, graph, teammate = self._org_graph_with_teammate(
+      test_db, test_user, GraphRole.MEMBER
+    )
+
+    with patch("robosystems.routers.graphs.members.SecurityAuditLogger") as audit:
+      response = await async_client.delete(
+        f"/v1/graphs/{graph.graph_id}/members/{teammate.id}"
+      )
+
+    assert response.status_code == 204
+    kwargs = audit.log_security_event.call_args.kwargs
+    assert kwargs["event_type"] is SecurityEventType.GRAPH_MEMBER_REMOVED
+    assert kwargs["details"]["previous_role"] == "member"
+    assert kwargs["details"]["graph_id"] == graph.graph_id
+
+  async def test_conflicting_grant_leaves_no_record(
+    self, async_client, test_db, test_user
+  ):
+    _, graph, teammate = self._org_graph_with_teammate(
+      test_db, test_user, GraphRole.VIEWER
+    )
+
+    with patch("robosystems.routers.graphs.members.SecurityAuditLogger") as audit:
+      response = await async_client.post(
+        f"/v1/graphs/{graph.graph_id}/members",
+        json={"user_id": teammate.id, "role": "viewer"},
+      )
+
+    assert response.status_code == 409
+    audit.log_security_event.assert_not_called()

--- a/tests/routers/orgs/test_members.py
+++ b/tests/routers/orgs/test_members.py
@@ -7,11 +7,13 @@ and removal flows to protect billing-linked org resources.
 
 from __future__ import annotations
 
+from unittest.mock import patch
 from uuid import uuid4
 
 import pytest
 
 from robosystems.models.core import Org, OrgRole, OrgType, OrgUser, User
+from robosystems.security import SecurityEventType
 
 pytestmark = pytest.mark.asyncio
 
@@ -417,3 +419,117 @@ class TestOrgMembersRouter:
     test_db.refresh(access)
     assert subscription.status == "canceled"
     assert access.is_active is False
+
+
+class TestOrgMembershipAuditEvents:
+  """Every membership change made through the API is a privileged access
+  change and must leave a structured security-audit record (SOC 2 CC6.x) —
+  actor, target, scope, prior and new role. Refusals were already audited;
+  these cover the grants."""
+
+  def _org_with_owner_and_member(self, test_db, test_user):
+    org = Org.create(
+      name=f"Audit Org {uuid4().hex[:6]}",
+      org_type=OrgType.TEAM,
+      session=test_db,
+    )
+    OrgUser.create(
+      org_id=org.id, user_id=test_user.id, role=OrgRole.OWNER, session=test_db
+    )
+    member = _create_user(test_db, test_user.password_hash)
+    OrgUser.create(
+      org_id=org.id, user_id=member.id, role=OrgRole.MEMBER, session=test_db
+    )
+    return org, member
+
+  async def test_role_change_is_audited(self, async_client, test_db, test_user):
+    org, member = self._org_with_owner_and_member(test_db, test_user)
+
+    with patch("robosystems.routers.orgs.members.SecurityAuditLogger") as audit:
+      response = await async_client.put(
+        f"/v1/orgs/{org.id}/members/{member.id}",
+        json={"role": OrgRole.ADMIN.value},
+      )
+
+    assert response.status_code == 200
+    kwargs = audit.log_security_event.call_args.kwargs
+    assert kwargs["event_type"] is SecurityEventType.ORG_MEMBER_ROLE_CHANGED
+    assert kwargs["user_id"] == test_user.id
+    assert kwargs["details"] == {
+      "action": "org_member_role_changed",
+      "org_id": org.id,
+      "target_user_id": member.id,
+      "previous_role": "member",
+      "new_role": "admin",
+    }
+
+  async def test_removal_is_audited(self, async_client, test_db, test_user):
+    org, member = self._org_with_owner_and_member(test_db, test_user)
+
+    with patch("robosystems.routers.orgs.members.SecurityAuditLogger") as audit:
+      response = await async_client.delete(f"/v1/orgs/{org.id}/members/{member.id}")
+
+    assert response.status_code == 204
+    kwargs = audit.log_security_event.call_args.kwargs
+    assert kwargs["event_type"] is SecurityEventType.ORG_MEMBER_REMOVED
+    assert kwargs["user_id"] == test_user.id
+    details = kwargs["details"]
+    assert details["org_id"] == org.id
+    assert details["target_user_id"] == member.id
+    assert details["previous_role"] == "member"
+    assert details["self_removal"] is False
+    assert details["repository_subscriptions_canceled"] == 0
+
+  async def test_refused_change_leaves_no_grant_record(
+    self, async_client, test_db, test_user
+  ):
+    """A refusal is not a membership change: the denied path emits nothing
+    from these sites (the authorization-denied record, where one exists, is a
+    different event)."""
+    org, member = self._org_with_owner_and_member(test_db, test_user)
+    outsider = _create_user(test_db, test_user.password_hash)
+    OrgUser.create(
+      org_id=org.id, user_id=outsider.id, role=OrgRole.MEMBER, session=test_db
+    )
+    # A plain member may not change roles.
+    from main import app
+    from robosystems.middleware.auth.dependencies import get_current_user
+
+    previous = app.dependency_overrides.get(get_current_user)
+    app.dependency_overrides[get_current_user] = lambda: outsider
+    try:
+      with patch("robosystems.routers.orgs.members.SecurityAuditLogger") as audit:
+        response = await async_client.put(
+          f"/v1/orgs/{org.id}/members/{member.id}",
+          json={"role": OrgRole.ADMIN.value},
+        )
+    finally:
+      if previous is not None:
+        app.dependency_overrides[get_current_user] = previous
+      else:
+        app.dependency_overrides.pop(get_current_user, None)
+
+    assert response.status_code == 403
+    audit.log_security_event.assert_not_called()
+
+  async def test_provider_refusal_aborts_before_any_record(
+    self, async_client, test_db, test_user
+  ):
+    """Removal cancels repository subscriptions first; if the provider refuses,
+    nothing was removed and nothing may be recorded as removed."""
+    from robosystems.operations.billing import ProviderCancellationError
+
+    org, member = self._org_with_owner_and_member(test_db, test_user)
+
+    with (
+      patch(
+        "robosystems.routers.orgs.members.cancel_user_repository_subscriptions",
+        side_effect=ProviderCancellationError("stripe said no"),
+      ),
+      patch("robosystems.routers.orgs.members.SecurityAuditLogger") as audit,
+    ):
+      response = await async_client.delete(f"/v1/orgs/{org.id}/members/{member.id}")
+
+    assert response.status_code == 502
+    audit.log_security_event.assert_not_called()
+    assert OrgUser.get_by_org_and_user(org.id, member.id, test_db) is not None

--- a/tests/security/test_cypher_analyzer.py
+++ b/tests/security/test_cypher_analyzer.py
@@ -276,6 +276,65 @@ class TestIsNonReadCall:
     assert is_non_read_call("MATCH (n) RETURN n") is False
 
 
+class TestHasOpaqueStatementCall:
+  """`has_opaque_statement_call` names the procedures whose payload is a
+  statement in a string. The analyzer masks string literals by design, so
+  the family gates cannot see what such a call would run — the predicate
+  exists so the kernel can refuse the shape outright, on every graph and
+  regardless of role."""
+
+  @pytest.mark.parametrize(
+    "query",
+    [
+      "CALL GQL('MATCH (n) RETURN n')",
+      "CALL gql('INSERT (:X {id: 1})')",
+      "call Gql('CREATE NODE TABLE Evil(id INT64, PRIMARY KEY(id))') RETURN *",
+      "MATCH (n) RETURN n; CALL GQL('COPY Evil FROM \"/etc/passwd\"')",
+    ],
+  )
+  def test_opaque_calls_are_flagged(self, analyzer, query):
+    assert analyzer.has_opaque_statement_call(query) is True
+
+  @pytest.mark.parametrize(
+    "query",
+    [
+      "MATCH (n) RETURN n",
+      "CALL show_tables() RETURN *",
+      "CALL CREATE_VECTOR_INDEX('Fact','x','embedding')",
+      "MATCH (n:Fact) WHERE n.name = 'CALL GQL(x)' RETURN n",
+      "MATCH (n:Fact) WHERE n.name = 'gql' RETURN n",
+      "MATCH (n:Gql) RETURN n",
+    ],
+  )
+  def test_other_forms_are_not_flagged(self, analyzer, query):
+    """Ordinary reads/writes, allowlisted and non-allowlisted CALLs, and the
+    procedure name appearing only as data or as a label are all clean —
+    the predicate is about the CALL target, nothing else."""
+    assert analyzer.has_opaque_statement_call(query) is False
+
+  def test_family_gates_are_blind_to_the_payload(self, analyzer):
+    """The reason the predicate exists: DDL, bulk and admin verbs inside the
+    string are invisible to every family gate, and the write gate alone does
+    not stop a caller who legitimately holds write access."""
+    payloads = [
+      "CALL GQL('CREATE NODE TABLE Evil(id INT64, PRIMARY KEY(id))')",
+      "CALL GQL('COPY Evil FROM \"/etc/passwd\"')",
+      "CALL GQL('INSTALL httpfs')",
+      "CALL GQL('ATTACH \"s3://x\" AS y')",
+    ]
+    for q in payloads:
+      assert analyzer.is_schema_ddl(q) is False
+      assert analyzer.is_bulk_operation(q) is False
+      assert analyzer.is_admin_operation(q) is False
+      assert analyzer.has_opaque_statement_call(q) is True
+
+  def test_module_level_wrapper(self):
+    from robosystems.security.cypher_analyzer import has_opaque_statement_call
+
+    assert has_opaque_statement_call("CALL GQL('MATCH (n) RETURN n')") is True
+    assert has_opaque_statement_call("MATCH (n) RETURN n") is False
+
+
 class TestQuerySecurityValidation:
   """Tests for query security validation."""
 


### PR DESCRIPTION
## Summary

Two punch-list items landing ahead of the v1.9.0 tag, plus their release-notes lines (the curated notes replace the generated changelog, so both are written in).

- **Membership changes are audited (SOC 2 CC6.x).** Adding, re-roling and removing a member — on an organization or on a graph — now emits a structured `SECURITY_AUDIT` event alongside the SCIM lifecycle events: actor, target, scope, prior and new role. Six sites: org role-change and removal, the invited-join branch of registration, and the three graph-member endpoints. Evidence, not alerts — no metric, no alarm. New `SecurityEventType` members: `ORG_MEMBER_{ADDED,ROLE_CHANGED,REMOVED}`, `GRAPH_MEMBER_{ADDED,ROLE_CHANGED,REMOVED}`.
- **Query surfaces refuse procedures that execute a string payload.** A small class in the analyzer (`OPAQUE_STATEMENT_PROCEDURES`, `has_opaque_statement_call`), refused first in `StatementKernel` and in the MCP write tool, on every graph regardless of role. Detail in the vault: `specs/data-plane/gql-query-endpoint.md` §4.

## Tests

- 8 new router tests for the audit events (org role change / removal / provider-refusal-emits-nothing / non-admin refusal; graph grant / role change / revoke / conflict; invited registration carries `invited_by`).
- Analyzer + kernel + write-tool tests for the refusal, including the case the family gates cannot see.
- Full unit suite: 12,873 passed.

## Notes

- `.github/release-notes/v1.9.0.md` updated in this PR.
- No API surface change; the new event types are internal.