### PR TITLE
chore: pre-1.9.0 punch-list tranche 2 — capacity alerts, registry sweep, three alarms, checkout gate

### DIFF
--- a/.github/release-notes/v1.9.0.md
+++ b/.github/release-notes/v1.9.0.md
@@ -132,6 +132,17 @@ lines under and lets its alarms live beside the resources they watch instead of 
 security stack; the refresh dispatcher has an errors alarm; and RDS gains a connection-count alarm
 whose threshold follows the instance class.
 
+Three more places that detected a condition and told nobody now page. The shared master's serving
+container being killed and restarted under the nightly materialization — which happened twice in one
+week and was caught only by a red orchestration run — has its own alarm, tuned so the master's
+deliberate nightly wake is one start and does not page while a second start within twelve hours does.
+The daily graph-registry sweep no longer **deletes** a registry row whose instance is missing from the
+instance registry: that row is a live graph's routing, and the instance registry drifts on fleet
+cycling, so a slow volume re-attach was turning a transient drift into a permanent orphan. The sweep
+marks such rows, clears the mark when the instance returns, publishes the count, and an alarm watches
+it. And the reaper that writes off a subscription whose provisioning never finished — a customer who
+paid and has no resource — now pages on every occurrence instead of leaving one error line in a log.
+
 ## Billing: what production actually does
 
 Walking the paid signup path end to end on production found what reading it had not. A cold checkout
@@ -149,6 +160,17 @@ already was at creation. Dead overage-invoice scaffolding for a postpaid model t
 have was removed, three declared-but-never-written records now get written — including payment audit
 events, which are compliance evidence — and the higher-volume usage table gained the retention policy
 its sibling already had, landing before there was any data a mistake could destroy.
+
+Two more refuse-the-sale gates and one compensator proven. A graph checkout now checks writer capacity
+for the tier before the payment session, exactly as it already checked the organization's graph limit,
+and fails closed when capacity cannot be determined — provisioning runs after payment, so a sale that
+completes against a full fleet is money taken for a graph that cannot be delivered. The rollback for a
+paid tier upgrade, whose four tests had all patched it out, now executes for real in the
+reattachment-timeout case and every post-condition holds: the volume re-attached to the old instance,
+its registry tier reverted, the graph registry taken off `migrating`, and the subscription back at the
+old plan and price. And the provisioning-claim suite, which proved the mutex against real threads and
+a real database, now also pins the second half of the double-provisioning blast radius — one credit
+pool per graph, refused by the database itself if anything got past the claim.
 
 ## Taxonomy
 
@@ -174,6 +196,14 @@ evaluation recording an error rather than a verdict; both migrations fan into ev
   master's memory at the current corpus size — and a per-database run limit ensures two
   materializations can never write the same graph concurrently.
 - The SEC connector's instructions no longer direct users to a historical subgraph with no serving path.
+- **Capacity warnings reach every graph admin.** The storage-usage sensor picked one arbitrary
+  explicit graph admin for both the storage snapshot and the 80%/100% email, so an organization-owned
+  graph whose only admins were the organization's owner and admins — implicit, with no explicit grant
+  row — wrote no snapshot and sent no warning at all. Recipients now resolve to explicit graph admins
+  plus the organization's owners and admins; the snapshot is attributed to the monitor, not a member.
+- `GET /v1/graphs/{id}/metrics` refuses shared repositories up front instead of issuing a full-scan
+  count per label and per relationship type against the shared master; the only consumer already
+  skipped repositories because the call timed out.
 - An authentication-cache invalidation path was corrected and gained the tests it did not have.
 - Fork-safe demo runners: the roboledger and roboinvestor demos honor `DEMO_API_URL`, keep credentials
   per target, and are strictly API-only against anything but the local stack; the scenario runner can
@@ -196,6 +226,9 @@ in the published clients (1.10.1):
 - A published value changes: `max_file_size_gb` on `/limits` and `/tiers` is now the same figure on
   every tier. Any material quoting the old per-tier values is now wrong.
 - Response content, not shape: `financial-statement-analysis` may return two rows where it returned one.
+- Status change: `GET /v1/graphs/{id}/metrics` on a shared repository returns 400 (it previously
+  timed out or returned 404); `POST /v1/billing/checkout` for a graph tier with no free writer slot
+  returns 409 before any payment session is created.
 
 ## Deploying this release
 
@@ -206,7 +239,8 @@ in the published clients (1.10.1):
   in `public` and every tenant schema. Until 0031 has run, rollup verification records `error` on
   every evaluation; nothing else in the release depends on the new tables.
 - **CloudFormation stack updates**: `api` (now uploaded to the deployment bucket and deployed by URL),
-  `security`, `graph-infra`, `graph-volumes`, `graph-ladybug-replicas`, `postgres`, and `worker`. The
+  `security`, `graph-infra`, `graph-volumes`, `graph-ladybug-replicas`, `postgres`, `worker`, and
+  `dagster` (the stalled-provisioning write-off alarm). The
   API alarms move from `security` into `api` under the same names within a single run; deploying prod
   first keeps that gap to the minutes between the two jobs.
 - **The shared-replica root-volume alarm may read `ALARM` on first deploy** if the fleet is near the

--- a/cloudformation/dagster.yaml
+++ b/cloudformation/dagster.yaml
@@ -1069,6 +1069,38 @@ Resources:
         - !Ref DagsterAlertTopic
       TreatMissingData: notBreaching
 
+  # The stalled-provisioning reaper writes off a subscription whose
+  # provisioning never finished. That row is a customer who paid and has no
+  # working resource, and the reaper's log line was the only place it was
+  # ever recorded — this makes it a page.
+  StalledProvisioningWriteOffMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref DagsterLogGroup
+      FilterPattern: '"STALLED PROVISIONING WRITTEN OFF"'
+      MetricTransformations:
+        - MetricName: StalledProvisioningWriteOff
+          MetricNamespace: !Sub RoboSystems/Dagster/${Environment}
+          MetricValue: "1"
+          Unit: Count
+
+  StalledProvisioningWriteOffAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: HasAlertEmail
+    Properties:
+      AlarmName: !Sub robosystems-dagster-${Environment}-stalled-provisioning-write-off
+      AlarmDescription: A paid subscription was written off after provisioning stalled - the customer has no resource and needs an operator
+      MetricName: StalledProvisioningWriteOff
+      Namespace: !Sub RoboSystems/Dagster/${Environment}
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 0
+      ComparisonOperator: GreaterThanThreshold
+      AlarmActions:
+        - !Ref DagsterAlertTopic
+      TreatMissingData: notBreaching
+
 
 Outputs:
   ClusterName:

--- a/cloudformation/graph-infra.yaml
+++ b/cloudformation/graph-infra.yaml
@@ -528,6 +528,30 @@ Resources:
       AlarmActions:
         - !Ref InfraAlertTopic
 
+  # A graph-registry row pointing at an instance the instance registry no
+  # longer knows. Published (zero included) by the daily registry sweep, which
+  # marks such rows rather than deleting them; any non-zero value is a live
+  # graph whose routing is stale and needs reconciling from on-disk truth.
+  OrphanedGraphRegistrationsAlarm:
+    Type: AWS::CloudWatch::Alarm
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      AlarmName: !Sub robosystems-graph-${Environment}-orphaned-graph-registrations
+      AlarmDescription: A graph-registry row points at an instance absent from the instance registry (routing drift, marked by the daily sweep)
+      MetricName: OrphanedGraphRegistrations
+      Namespace: !Sub "RoboSystems/Graph/${Environment}"
+      Statistic: Maximum
+      Period: 86400
+      EvaluationPeriods: 1
+      Threshold: 0
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - !Ref InfraAlertTopic
+      OKActions:
+        - !Ref InfraAlertTopic
+
   # Registry table throttle alarms (tables are on-demand; throttles signal
   # burst beyond adaptive capacity or a hot key)
   InstanceRegistryReadThrottleAlarm:

--- a/cloudformation/graph-ladybug-replicas.yaml
+++ b/cloudformation/graph-ladybug-replicas.yaml
@@ -841,6 +841,42 @@ Resources:
           MetricValue: "1"
           Unit: Count
 
+  # The shared MASTER's start marker, from the same entrypoint into the same
+  # log group. Unlike a replica, the master is scaled 0->1 on purpose every
+  # night (shared_master_wake), so one start per day is expected and cannot
+  # page. What must page is a SECOND start while it is up — the container was
+  # killed and restarted under the nightly materialization (the 2026-08-12/13
+  # OOM kills, which nothing detected until a red Dagster run). A 12-hour
+  # sliding window never holds two nightly wakes but covers the master's whole
+  # waking life, so Sum > 1 is exactly "restarted while working". Homed here
+  # with the other shared-repository serving alarms.
+  SharedMasterContainerStartMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Sub /robosystems/${Environment}/graph-api
+      FilterPattern: '"Starting LadybugDB Shared Master API"'
+      MetricTransformations:
+        - MetricName: SharedMasterContainerStart
+          MetricNamespace: !Sub RoboSystems/SharedReplicas/${Environment}
+          MetricValue: "1"
+          Unit: Count
+
+  SharedMasterContainerRestartAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub robosystems-shared-replicas-${Environment}-master-container-restart
+      AlarmDescription: Shared master serving container started more than once within 12 hours - it was killed and restarted while up (the nightly wake alone is one start and does not page)
+      MetricName: SharedMasterContainerStart
+      Namespace: !Sub RoboSystems/SharedReplicas/${Environment}
+      Statistic: Sum
+      Period: 43200
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanThreshold
+      AlarmActions:
+        - !Ref ReplicaAlertTopic
+      TreatMissingData: notBreaching
+
   # Replicas hold the database on the ROOT volume: it is a launch-template device
   # with DeleteOnTermination and no autoscaling, and it is not in the volume
   # registry — so the graph-volumes expansion ladder cannot help here and this

--- a/robosystems/config/env.py
+++ b/robosystems/config/env.py
@@ -675,9 +675,10 @@ class EnvConfig:
   # --- Connection Providers ---
   # CONNECTIONS_ENABLED controls whether the /connections router is included.
   # Code defaults to TRUE — the fully-featured platform exposes connection
-  # providers. Prod and staging currently override to `false` via SSM during
-  # the staged rollout (flipped at the same time as the extensions). Individual
-  # provider flags below require CONNECTIONS_ENABLED=true to function.
+  # providers. Deployed environments may override it via SSM; the live value
+  # is whatever the parameter says (`just ssm-get <env> features/CONNECTIONS_ENABLED`),
+  # not this comment. Individual provider flags below require
+  # CONNECTIONS_ENABLED=true to function.
   CONNECTIONS_ENABLED = get_bool_env(
     "CONNECTIONS_ENABLED",
     get_parameter_value("CONNECTIONS_ENABLED", "true").lower() == "true",

--- a/robosystems/dagster/jobs/graph_lifecycle.py
+++ b/robosystems/dagster/jobs/graph_lifecycle.py
@@ -194,8 +194,11 @@ def reap_stalled_provisioning(
         continue
 
       reaped.append(subscription_id)
+      # The marker is what the CloudWatch metric filter matches
+      # (cloudformation/dagster.yaml, StalledProvisioningWriteOff): this is a
+      # paid customer with no resource, and detection here is the only page.
       context.log.error(
-        f"Wrote off stalled provisioning for subscription {subscription_id} "
+        f"STALLED PROVISIONING WRITTEN OFF: subscription {subscription_id} "
         f"(org={subscription.org_id}, resource_type={subscription.resource_type}, "
         f"resource_id={subscription.resource_id}). The customer paid and has no "
         "working resource — this needs an operator."

--- a/robosystems/dagster/jobs/infrastructure.py
+++ b/robosystems/dagster/jobs/infrastructure.py
@@ -282,22 +282,27 @@ def instance_metrics_collection_job():
 
 @op
 def cleanup_stale_registry_entries(context: OpExecutionContext) -> dict[str, Any]:
-  """Clean up stale entries from instance registry.
+  """Sweep the graph registry.
 
-  Removes:
-  - Entries marked as deleted older than 7 days
-  - Entries with missing instance_id references
+  Removes entries marked deleted more than 7 days ago. Entries whose
+  instance_id is missing from the instance registry are marked and counted
+  (``OrphanedGraphRegistrations``), never removed — the row is a live graph's
+  routing and the instance registry drifts on ASG cycling.
   """
   from robosystems.operations.graph.infrastructure import InstanceMonitor
 
   monitor = InstanceMonitor()
   result = monitor.cleanup_stale_graphs()
 
-  context.log.info(f"Instance registry cleanup: {result.removed_count} entries removed")
+  context.log.info(
+    f"Instance registry cleanup: {result.removed_count} entries removed, "
+    f"{result.orphaned_count} graphs pointing at missing instances"
+  )
 
   return {
     "timestamp": result.timestamp,
     "removed_count": result.removed_count,
+    "orphaned_count": result.orphaned_count,
     "errors": result.errors,
   }
 
@@ -382,8 +387,12 @@ def run_full_instance_maintenance(context: OpExecutionContext) -> dict[str, Any]
   instance_cleanup_result = monitor.cleanup_stale_graphs()
   results["instance_cleanup"] = {
     "removed_count": instance_cleanup_result.removed_count,
+    "orphaned_count": instance_cleanup_result.orphaned_count,
   }
-  context.log.info(f"Instance cleanup: {instance_cleanup_result.removed_count} removed")
+  context.log.info(
+    f"Instance cleanup: {instance_cleanup_result.removed_count} removed, "
+    f"{instance_cleanup_result.orphaned_count} orphaned"
+  )
 
   # Volume cleanup
   volume_cleanup_result = monitor.cleanup_stale_volumes()

--- a/robosystems/dagster/sensors/usage_monitor.py
+++ b/robosystems/dagster/sensors/usage_monitor.py
@@ -39,6 +39,49 @@ _SENSOR_STATUS = DefaultSensorStatus.RUNNING
 # Defaults on — an alerting sensor should fail toward telling you.
 _ALERTS_ENABLED_FLAG = "GRAPH_USAGE_ALERTS_ENABLED"
 
+# Storage is a property of the graph, not of whoever happened to be its first
+# explicit admin: snapshots are recorded under this principal so the row is
+# attributable to the measurement, not to a member who may later leave. Every
+# reader of STORAGE_SNAPSHOT rows keys by graph_id; ``GraphUsage.user_id`` has
+# no foreign key, so a non-user principal is safe.
+USAGE_MONITOR_PRINCIPAL = "system:usage-monitor"
+
+
+def _capacity_alert_recipients(db, graph) -> list:
+  """Everyone who administers the graph: explicit ``GraphUser`` admins plus
+  the owning org's owners and admins, who hold implicit graph admin with no
+  ``GraphUser`` row at all. Deduplicated; only active users with an email.
+
+  The previous ``.filter(role == "admin").first()`` picked one arbitrary
+  explicit admin, so an org-owned graph whose only admins were implicit got
+  no capacity email — exactly where multi-member orgs live.
+  """
+  from robosystems.models.core.graph.graph_user import GraphUser
+  from robosystems.models.core.org import OrgRole, OrgUser
+  from robosystems.models.core.user import User
+
+  user_ids: list[str] = [
+    row.user_id
+    for row in db.query(GraphUser.user_id)
+    .filter(GraphUser.graph_id == graph.graph_id, GraphUser.role == "admin")
+    .all()
+  ]
+  if graph.org_id:
+    user_ids.extend(
+      row.user_id
+      for row in db.query(OrgUser.user_id)
+      .filter(
+        OrgUser.org_id == graph.org_id,
+        OrgUser.role.in_([OrgRole.OWNER, OrgRole.ADMIN]),
+      )
+      .all()
+    )
+  if not user_ids:
+    return []
+  unique_ids = list(dict.fromkeys(user_ids))
+  users = db.query(User).filter(User.id.in_(unique_ids), User.is_active.is_(True)).all()
+  return [u for u in users if u.email]
+
 
 @sensor(
   minimum_interval_seconds=21600,  # 6 hours
@@ -68,8 +111,6 @@ def graph_usage_monitor_sensor(context: SensorEvaluationContext):
   from robosystems.database import session as db_session_factory
   from robosystems.middleware.graph.ingestion_limits import IngestionLimitChecker
   from robosystems.models.core.graph import Graph
-  from robosystems.models.core.graph.graph_user import GraphUser
-  from robosystems.models.core.user import User
 
   # Read per tick rather than at import, so flipping the flag takes effect on the
   # next evaluation instead of the next deploy.
@@ -115,26 +156,17 @@ def graph_usage_monitor_sensor(context: SensorEvaluationContext):
 
       instance_status = storage_check["status"]
 
-      # One admin lookup serves both the snapshot row and any alert below.
-      graph_user = (
-        db.query(GraphUser)
-        .filter(
-          GraphUser.graph_id == graph.graph_id,
-          GraphUser.role == "admin",
-        )
-        .first()
-      )
-
       # Persist the measurement as a STORAGE_SNAPSHOT row — this sensor is the
       # only writer, and the admin and org usage surfaces read those rows.
       # Recorded for every measured status, not just alert-worthy ones; skipped
-      # when the check returned "unknown" (nothing was measured).
-      if storage_check.get("total_storage_gb") is not None and graph_user:
+      # when the check returned "unknown" (nothing was measured). Attributed to
+      # the monitor itself, never to a member (see USAGE_MONITOR_PRINCIPAL).
+      if storage_check.get("total_storage_gb") is not None:
         try:
           from robosystems.models.core.graph.graph_usage import GraphUsage
 
           GraphUsage.record_storage_usage(
-            user_id=graph_user.user_id,
+            user_id=USAGE_MONITOR_PRINCIPAL,
             graph_id=graph.graph_id,
             graph_tier=graph_tier,
             storage_bytes=storage_check["total_storage_gb"] * (1024**3),
@@ -157,44 +189,51 @@ def graph_usage_monitor_sensor(context: SensorEvaluationContext):
         )
         continue
 
-      # Owner already looked up above for the snapshot row
-      if not graph_user:
-        continue
-
-      user = db.query(User).filter(User.id == graph_user.user_id).first()
-      if not user or not user.email:
-        continue
-
-      # Send capacity warning email
-      try:
-        from robosystems.operations.aws.ses import ses_service
-
-        sent = asyncio.run(
-          ses_service.send_capacity_warning_email(
-            user_email=user.email,
-            user_name=user.name or "there",
-            graph_id=graph.graph_id,
-            tier=graph_tier,
-            usage_percentage=storage_check["usage_percentage"],
-            used_gb=storage_check["total_storage_gb"],
-            limit_gb=storage_check["limit_gb"],
-            instance_status=instance_status,
-            databases=storage_check["databases"],
-          )
+      recipients = _capacity_alert_recipients(db, graph)
+      if not recipients:
+        context.log.warning(
+          f"No admin with an email for {graph.graph_id}; capacity alert not sent"
         )
+        continue
 
-        if sent:
-          # Set dedup key with TTL
-          redis_client.setex(dedup_key, _ALERT_DEDUP_TTL_SECONDS, "1")
-          alerts_sent += 1
-          context.log.info(
-            f"Sent {instance_status} alert for {graph.graph_id} to {user.email} "
-            f"({storage_check['usage_percentage']:.0f}%)"
+      # Send the capacity warning to every admin; the dedup key covers the
+      # graph+status, set once any delivery succeeded.
+      delivered = 0
+      for user in recipients:
+        try:
+          from robosystems.operations.aws.ses import ses_service
+
+          sent = asyncio.run(
+            ses_service.send_capacity_warning_email(
+              user_email=user.email,
+              user_name=user.name or "there",
+              graph_id=graph.graph_id,
+              tier=graph_tier,
+              usage_percentage=storage_check["usage_percentage"],
+              used_gb=storage_check["total_storage_gb"],
+              limit_gb=storage_check["limit_gb"],
+              instance_status=instance_status,
+              databases=storage_check["databases"],
+            )
           )
-        else:
-          context.log.warning(f"Failed to send capacity alert for {graph.graph_id}")
-      except Exception as e:
-        context.log.error(f"Error sending capacity alert for {graph.graph_id}: {e}")
+          if sent:
+            delivered += 1
+          else:
+            context.log.warning(
+              f"Failed to send capacity alert for {graph.graph_id} to {user.email}"
+            )
+        except Exception as e:
+          context.log.error(
+            f"Error sending capacity alert for {graph.graph_id} to {user.email}: {e}"
+          )
+
+      if delivered:
+        redis_client.setex(dedup_key, _ALERT_DEDUP_TTL_SECONDS, "1")
+        alerts_sent += 1
+        context.log.info(
+          f"Sent {instance_status} alert for {graph.graph_id} to {delivered} of "
+          f"{len(recipients)} admin(s) ({storage_check['usage_percentage']:.0f}%)"
+        )
 
     context.log.info(
       f"Usage monitor complete: checked {len(parent_graphs)} graphs, "

--- a/robosystems/operations/graph/infrastructure.py
+++ b/robosystems/operations/graph/infrastructure.py
@@ -77,6 +77,7 @@ class CleanupResult:
   timestamp: str
   removed_count: int = 0
   updated_count: int = 0
+  orphaned_count: int = 0
   errors: int = 0
   error_message: str | None = None
 
@@ -391,10 +392,19 @@ class InstanceMonitor:
       logger.warning(f"Failed to update volumes for instance {instance_id}: {e}")
 
   def cleanup_stale_graphs(self) -> CleanupResult:
-    """Drop graph-registry rows that are deleted or point nowhere.
+    """Drop long-deleted graph-registry rows; mark, never delete, orphaned ones.
 
-    Removes entries deleted more than ``STALE_GRAPH_DAYS`` ago, and any entry
-    whose ``instance_id`` is absent from the instance registry.
+    Removes entries deleted more than ``STALE_GRAPH_DAYS`` ago. An entry whose
+    ``instance_id`` is absent from the instance registry is **not** removed:
+    the row is a live graph's routing, and the instance registry drifts on
+    ASG cycling (a slow volume re-attach, a terminated writer awaiting
+    replacement). Deleting the row turned a transient drift into a permanent
+    orphan — user graphs have no boot-time re-registration and the repair
+    path can only ``UPDATE`` a row that still exists. Instead the row is
+    stamped ``instance_missing_since`` (once), the count is published as
+    ``OrphanedGraphRegistrations`` so it can alarm, and the stamp is cleared
+    when the instance reappears. Reconciling from on-disk truth is the
+    follow-up, not this sweep.
     """
     logger.info("Starting graph registry cleanup")
 
@@ -418,6 +428,8 @@ class InstanceMonitor:
         item["instance_id"] for item in instance_response.get("Items", [])
       }
 
+      now_iso = datetime.now(UTC).isoformat()
+
       for item in items:
         graph_id = item.get("graph_id")
         status = item.get("status")
@@ -436,12 +448,6 @@ class InstanceMonitor:
           except Exception:
             pass
 
-        if instance_id and instance_id not in valid_instances:
-          should_remove = True
-          logger.info(
-            f"Removing graph {graph_id}: instance {instance_id} doesn't exist"
-          )
-
         if should_remove:
           try:
             graph_table.delete_item(Key={"graph_id": graph_id})
@@ -449,9 +455,49 @@ class InstanceMonitor:
           except Exception as e:
             logger.error(f"Failed to remove graph {graph_id}: {e}")
             result.errors += 1
+          continue
+
+        instance_missing = bool(instance_id) and instance_id not in valid_instances
+        already_marked = item.get("instance_missing_since") is not None
+
+        if instance_missing:
+          result.orphaned_count += 1
+          if not already_marked:
+            logger.warning(
+              f"Graph {graph_id} points at instance {instance_id}, which is "
+              "absent from the instance registry; marking, not removing"
+            )
+            try:
+              graph_table.update_item(
+                Key={"graph_id": graph_id},
+                UpdateExpression="SET instance_missing_since = :ts",
+                ConditionExpression="attribute_not_exists(instance_missing_since)",
+                ExpressionAttributeValues={":ts": now_iso},
+              )
+              result.updated_count += 1
+            except Exception as e:
+              logger.error(f"Failed to mark graph {graph_id} as orphaned: {e}")
+              result.errors += 1
+        elif already_marked:
+          logger.info(
+            f"Graph {graph_id}: instance {instance_id} is back in the registry; "
+            "clearing the orphan marker"
+          )
+          try:
+            graph_table.update_item(
+              Key={"graph_id": graph_id},
+              UpdateExpression="REMOVE instance_missing_since",
+            )
+            result.updated_count += 1
+          except Exception as e:
+            logger.error(f"Failed to clear orphan marker on graph {graph_id}: {e}")
+            result.errors += 1
+
+      self._publish_orphaned_graph_metric(result.orphaned_count)
 
       logger.info(
-        f"Graph registry cleanup completed: {result.removed_count} entries removed"
+        f"Graph registry cleanup completed: {result.removed_count} entries removed, "
+        f"{result.orphaned_count} pointing at missing instances"
       )
 
     except Exception as e:
@@ -459,6 +505,26 @@ class InstanceMonitor:
       result.error_message = str(e)
 
     return result
+
+  def _publish_orphaned_graph_metric(self, count: int) -> None:
+    """Publish the orphaned-registration count so an alarm can watch it.
+
+    Published on every sweep, zero included, so the alarm sees a real
+    datapoint rather than reading OK on missing data.
+    """
+    try:
+      self.cloudwatch.put_metric_data(
+        Namespace=f"RoboSystems/Graph/{self.environment}",
+        MetricData=[
+          {
+            "MetricName": "OrphanedGraphRegistrations",
+            "Value": count,
+            "Unit": "Count",
+          }
+        ],
+      )
+    except Exception as e:
+      logger.warning(f"Could not publish OrphanedGraphRegistrations metric: {e}")
 
   def cleanup_stale_volumes(self) -> CleanupResult:
     """Correct or drop volume-registry rows that no longer reflect reality.

--- a/robosystems/routers/billing/checkout.py
+++ b/robosystems/routers/billing/checkout.py
@@ -20,6 +20,25 @@ from ...operations.providers.payment_provider import get_payment_provider
 
 logger = get_logger(__name__)
 
+
+async def _tier_capacity_status(plan_name: str) -> str:
+  """``ready`` when a writer for the tier has a free slot; otherwise
+  ``at_capacity``. ``scalable`` (no slot, ASG below max) counts as
+  ``at_capacity`` because nothing on the create path raises desired capacity.
+  Any failure to determine capacity reads as ``at_capacity``.
+  """
+  try:
+    from ...middleware.graph.allocation_manager import LadybugAllocationManager
+    from ...middleware.graph.types import GraphTier
+
+    manager = LadybugAllocationManager(environment=env.ENVIRONMENT)
+    status_value = await manager.check_tier_capacity(GraphTier(plan_name))
+  except Exception as e:
+    logger.warning(f"Could not determine capacity for tier {plan_name}: {e}")
+    return "at_capacity"
+  return "ready" if status_value == "ready" else "at_capacity"
+
+
 router = APIRouter(prefix="/billing", tags=["Billing"])
 
 
@@ -114,6 +133,22 @@ async def create_checkout_session(
         status_code=400,
         detail=f"Invalid plan '{request.plan_name}' for {request.resource_type}",
       )
+
+    # Gate a graph checkout on writer capacity for the tier — the same
+    # refuse-the-sale rule as the org graph limit above, one level down.
+    # Provisioning runs post-payment; if no writer has a free slot the sale
+    # must not complete. Fails closed: if capacity cannot be determined, the
+    # sale is refused rather than collected.
+    if request.resource_type == "graph":
+      capacity_status = await _tier_capacity_status(request.plan_name)
+      if capacity_status != "ready":
+        raise HTTPException(
+          status_code=409,
+          detail=(
+            f"No capacity is currently available for the '{request.plan_name}' "
+            "tier. Please contact support or try again later."
+          ),
+        )
 
     base_price_cents = plan_config.get(
       "base_price_cents", plan_config.get("price_cents", 0)

--- a/robosystems/routers/graphs/usage.py
+++ b/robosystems/routers/graphs/usage.py
@@ -19,6 +19,7 @@ from robosystems.database import get_db_session
 from robosystems.logger import logger
 from robosystems.middleware.auth.dependencies import get_current_user_with_graph
 from robosystems.middleware.graph.types import GRAPH_OR_SUBGRAPH_ID_PATTERN
+from robosystems.middleware.graph.utils import MultiTenantUtils
 from robosystems.middleware.otel.metrics import (
   endpoint_metrics_decorator,
   get_endpoint_metrics,
@@ -74,6 +75,22 @@ async def get_graph_metrics(
   db: Session = Depends(get_db_session),
   _rate_limit: None = Depends(subscription_aware_rate_limit_dependency),
 ) -> GraphMetricsResponse:
+  # Metrics are per-label/per-type COUNTs — a full scan each — issued against
+  # the graph's WRITE node. On a shared repository that is the shared master
+  # (asleep most of the day, and the corpus is hundreds of millions of rows),
+  # so the call either times out or lands a fleet of full scans on the node
+  # that materializes. Shared repositories are platform-managed; their size is
+  # published elsewhere. Refuse up front, before the circuit breaker records
+  # a failure against the graph.
+  if MultiTenantUtils.is_shared_repository_or_subgraph(graph_id.lower()):
+    raise HTTPException(
+      status_code=status.HTTP_400_BAD_REQUEST,
+      detail=(
+        f"Metrics are not available for shared repository '{graph_id}'. "
+        "Repository sizes are platform-managed and published with the repository."
+      ),
+    )
+
   circuit_breaker = CircuitBreakerManager()
   timeout_coordinator = TimeoutCoordinator()
   operation_logger = get_operation_logger()

--- a/tests/dagster/test_usage_monitor.py
+++ b/tests/dagster/test_usage_monitor.py
@@ -7,8 +7,12 @@ from dagster import build_sensor_context
 from robosystems.dagster.sensors.usage_monitor import (
   _ALERT_DEDUP_TTL_SECONDS,
   _ALERTS_ENABLED_FLAG,
+  USAGE_MONITOR_PRINCIPAL,
+  _capacity_alert_recipients,
   graph_usage_monitor_sensor,
 )
+
+RECIPIENTS = "robosystems.dagster.sensors.usage_monitor._capacity_alert_recipients"
 
 
 def _make_graph(graph_id="kg_test123", tier="ladybug-standard"):
@@ -105,17 +109,13 @@ class TestGraphUsageMonitorSensor:
     graph = _make_graph()
     mock_db.query.return_value.filter.return_value.all.return_value = [graph]
 
-    # Graph user and user lookups
-    mock_graph_user = MagicMock()
-    mock_graph_user.user_id = "user_123"
-    mock_graph_user.role = "admin"
-    mock_user = MagicMock()
-    mock_user.email = "user@example.com"
-    mock_user.name = "Test User"
-    mock_db.query.return_value.filter.return_value.first.side_effect = [
-      mock_graph_user,
-      mock_user,
-    ]
+    # Two admins resolve for the graph (one explicit, one implicit via org role)
+    admin_a = MagicMock()
+    admin_a.email = "a@example.com"
+    admin_a.name = "Admin A"
+    admin_b = MagicMock()
+    admin_b.email = "b@example.com"
+    admin_b.name = "Admin B"
 
     # Storage check returns approaching
     mock_check_storage.return_value = {
@@ -135,15 +135,64 @@ class TestGraphUsageMonitorSensor:
     mock_ses.send_capacity_warning_email = AsyncMock(return_value=True)
 
     context = build_sensor_context()
-    graph_usage_monitor_sensor(context)
+    with patch(RECIPIENTS, return_value=[admin_a, admin_b]):
+      graph_usage_monitor_sensor(context)
 
-    # Verify dedup key was set
+    # Every admin is emailed, and the dedup key is set once for the graph+status
+    sent_to = [
+      c.kwargs["user_email"]
+      for c in mock_ses.send_capacity_warning_email.call_args_list
+    ]
+    assert sent_to == ["a@example.com", "b@example.com"]
     mock_redis.setex.assert_called_once()
     dedup_call = mock_redis.setex.call_args
     assert dedup_call[0][0] == "usage_alert:kg_test123:approaching"
     assert dedup_call[0][1] == _ALERT_DEDUP_TTL_SECONDS
 
+    # The snapshot is attributed to the monitor, not to a member
+    added = [
+      a.args[0] for a in mock_db.add.call_args_list if hasattr(a.args[0], "user_id")
+    ]
+    assert added and all(r.user_id == USAGE_MONITOR_PRINCIPAL for r in added)
+
     mock_db.close.assert_called_once()
+
+  @patch("robosystems.operations.aws.ses.ses_service")
+  @patch("robosystems.config.valkey_registry.create_redis_client")
+  @patch(
+    "robosystems.middleware.graph.ingestion_limits.IngestionLimitChecker.check_instance_storage"
+  )
+  @patch("robosystems.database.session")
+  def test_no_recipient_records_snapshot_but_sends_nothing(
+    self,
+    mock_session_factory,
+    mock_check_storage,
+    mock_redis_factory,
+    mock_ses,
+  ):
+    """A graph with no reachable admin still gets its snapshot row (the usage
+    surfaces read it), but no email and no dedup key — the next tick retries."""
+    mock_db = MagicMock()
+    mock_session_factory.return_value = mock_db
+    mock_db.query.return_value.filter.return_value.all.return_value = [_make_graph()]
+    mock_check_storage.return_value = {
+      "total_storage_gb": 17.0,
+      "limit_gb": 20.0,
+      "usage_percentage": 85.0,
+      "status": "approaching",
+      "databases": [],
+    }
+    mock_redis = MagicMock()
+    mock_redis_factory.return_value = mock_redis
+    mock_redis.exists.return_value = False
+    mock_ses.send_capacity_warning_email = AsyncMock(return_value=True)
+
+    with patch(RECIPIENTS, return_value=[]):
+      graph_usage_monitor_sensor(build_sensor_context())
+
+    mock_ses.send_capacity_warning_email.assert_not_called()
+    mock_redis.setex.assert_not_called()
+    assert mock_db.add.called
 
   @patch("robosystems.config.valkey_registry.create_redis_client")
   @patch(
@@ -242,3 +291,98 @@ class TestGraphUsageMonitorSensor:
     graph_usage_monitor_sensor(context)
 
     mock_db.close.assert_called_once()
+
+
+class TestCapacityAlertRecipients:
+  """The recipient set is every graph admin — explicit rows AND the owning
+  org's owners/admins, who hold implicit graph admin with no GraphUser row.
+  The old lookup took one arbitrary explicit admin, so an org-owned graph with
+  only implicit admins got no email at all."""
+
+  @staticmethod
+  def _user(session, email, active=True):
+    from uuid import uuid4
+
+    from robosystems.models.core import User
+
+    u = User(email=email, name=email.split("@")[0], password_hash="x", is_active=active)
+    if not active:
+      u.id = f"user_inactive_{uuid4().hex[:6]}"
+    session.add(u)
+    session.commit()
+    session.refresh(u)
+    return u
+
+  def test_implicit_org_admins_are_recipients_without_a_graph_user_row(self, test_db):
+    from uuid import uuid4
+
+    from robosystems.models.core import (
+      Graph,
+      GraphRole,
+      GraphUser,
+      Org,
+      OrgRole,
+      OrgType,
+      OrgUser,
+    )
+
+    org = Org.create(name="Cap Org", org_type=OrgType.TEAM, session=test_db)
+    owner = self._user(test_db, f"owner+{uuid4().hex[:6]}@example.com")
+    org_admin = self._user(test_db, f"orgadmin+{uuid4().hex[:6]}@example.com")
+    member = self._user(test_db, f"member+{uuid4().hex[:6]}@example.com")
+    explicit = self._user(test_db, f"explicit+{uuid4().hex[:6]}@example.com")
+    viewer = self._user(test_db, f"viewer+{uuid4().hex[:6]}@example.com")
+    for u, r in (
+      (owner, OrgRole.OWNER),
+      (org_admin, OrgRole.ADMIN),
+      (member, OrgRole.MEMBER),
+      (explicit, OrgRole.MEMBER),
+      (viewer, OrgRole.MEMBER),
+    ):
+      OrgUser.create(org_id=org.id, user_id=u.id, role=r, session=test_db)
+    graph = Graph.create(
+      graph_id=f"kg{uuid4().hex[:16]}",
+      org_id=org.id,
+      graph_name="Cap Graph",
+      graph_type="generic",
+      session=test_db,
+    )
+    GraphUser.create(
+      user_id=explicit.id,
+      graph_id=graph.graph_id,
+      role=GraphRole.ADMIN,
+      session=test_db,
+    )
+    GraphUser.create(
+      user_id=viewer.id, graph_id=graph.graph_id, role=GraphRole.VIEWER, session=test_db
+    )
+    # The owner also holds an explicit admin row: must not be emailed twice
+    GraphUser.create(
+      user_id=owner.id, graph_id=graph.graph_id, role=GraphRole.ADMIN, session=test_db
+    )
+
+    recipients = _capacity_alert_recipients(test_db, graph)
+
+    emails = sorted(u.email for u in recipients)
+    assert emails == sorted([owner.email, org_admin.email, explicit.email])
+    assert len(recipients) == 3
+
+  def test_inactive_and_emailless_admins_are_skipped(self, test_db):
+    from uuid import uuid4
+
+    from robosystems.models.core import Graph, Org, OrgRole, OrgType, OrgUser
+
+    org = Org.create(name="Cap Org 2", org_type=OrgType.TEAM, session=test_db)
+    inactive = self._user(test_db, f"gone+{uuid4().hex[:6]}@example.com", active=False)
+    OrgUser.create(
+      org_id=org.id, user_id=inactive.id, role=OrgRole.OWNER, session=test_db
+    )
+    graph = Graph.create(
+      graph_id=f"kg{uuid4().hex[:16]}",
+      org_id=org.id,
+      graph_name="Cap Graph 2",
+      graph_type="generic",
+      session=test_db,
+    )
+
+    assert _capacity_alert_recipients(test_db, graph) == []

--- a/tests/dagster/test_usage_monitor.py
+++ b/tests/dagster/test_usage_monitor.py
@@ -301,13 +301,9 @@ class TestCapacityAlertRecipients:
 
   @staticmethod
   def _user(session, email, active=True):
-    from uuid import uuid4
-
     from robosystems.models.core import User
 
     u = User(email=email, name=email.split("@")[0], password_hash="x", is_active=active)
-    if not active:
-      u.id = f"user_inactive_{uuid4().hex[:6]}"
     session.add(u)
     session.commit()
     session.refresh(u)

--- a/tests/models/core/billing/test_provisioning_claim.py
+++ b/tests/models/core/billing/test_provisioning_claim.py
@@ -439,3 +439,105 @@ class TestWriteOffStalledProvisioning:
 
     assert len(results) == 2, "both threads must complete"
     assert sum(results.values()) == 1, f"exactly one side must win, got {results}"
+
+
+class TestOneCreditPoolPerGraph:
+  """The stated blast radius of a double provisioning was *two instances and
+  two credit pools*. The claim tests above prove the first half; this pins
+  the second: the pool is created downstream of the gate, and the database
+  itself refuses a second pool for the same graph even if a caller got past
+  it."""
+
+  def test_second_pool_for_the_same_graph_is_refused_by_the_database(
+    self, db_session: Session, test_org_id: str
+  ):
+    from decimal import Decimal
+
+    from sqlalchemy.exc import IntegrityError
+
+    from robosystems.models.core import Graph, OrgUser
+    from robosystems.models.core.graph.graph_credits import GraphCredits
+
+    owner_id = (
+      db_session.query(OrgUser.user_id).filter(OrgUser.org_id == test_org_id).scalar()
+    )
+    graph = Graph.create(
+      graph_id=f"kg{uuid.uuid4().hex[:16]}",
+      org_id=test_org_id,
+      graph_name="Claimed Graph",
+      graph_type="generic",
+      graph_tier="ladybug-standard",
+      session=db_session,
+    )
+
+    GraphCredits.create_for_graph(
+      graph_id=graph.graph_id,
+      user_id=owner_id,
+      billing_admin_id=owner_id,
+      monthly_allocation=Decimal("1000"),
+      session=db_session,
+    )
+    assert (
+      db_session.query(GraphCredits).filter_by(graph_id=graph.graph_id).count() == 1
+    )
+
+    with pytest.raises(IntegrityError):
+      GraphCredits.create_for_graph(
+        graph_id=graph.graph_id,
+        user_id=owner_id,
+        billing_admin_id=owner_id,
+        monthly_allocation=Decimal("1000"),
+        session=db_session,
+      )
+    db_session.rollback()
+
+    assert (
+      db_session.query(GraphCredits).filter_by(graph_id=graph.graph_id).count() == 1
+    )
+
+  def test_losing_claimant_provisions_nothing_so_no_second_pool_exists(
+    self, db_session: Session, test_org_id: str
+  ):
+    """End to end on the claim: the winner provisions a graph with a pool and
+    records the resource; the loser's claim is refused at the terminal
+    condition, so no second graph and no second pool can be created."""
+    from decimal import Decimal
+
+    from robosystems.models.core import Graph, OrgUser
+    from robosystems.models.core.graph.graph_credits import GraphCredits
+
+    owner_id = (
+      db_session.query(OrgUser.user_id).filter(OrgUser.org_id == test_org_id).scalar()
+    )
+    subscription = _make_subscription(db_session, test_org_id)
+
+    assert subscription.claim_for_provisioning(db_session) is True
+    graph = Graph.create(
+      graph_id=f"kg{uuid.uuid4().hex[:16]}",
+      org_id=test_org_id,
+      graph_name="Winner's Graph",
+      graph_type="generic",
+      graph_tier="ladybug-standard",
+      session=db_session,
+    )
+    GraphCredits.create_for_graph(
+      graph_id=graph.graph_id,
+      user_id=owner_id,
+      billing_admin_id=owner_id,
+      monthly_allocation=Decimal("1000"),
+      session=db_session,
+    )
+    subscription.resource_id = graph.graph_id
+    subscription.status = SubscriptionStatus.ACTIVE.value
+    db_session.commit()
+
+    # A redelivered event arrives after the winner finished
+    assert subscription.claim_for_provisioning(db_session) is False
+
+    pools = (
+      db_session.query(GraphCredits)
+      .join(Graph, Graph.graph_id == GraphCredits.graph_id)
+      .filter(Graph.org_id == test_org_id)
+      .count()
+    )
+    assert pools == 1

--- a/tests/operations/graph/tasks/test_graph_tier_upgrade.py
+++ b/tests/operations/graph/tasks/test_graph_tier_upgrade.py
@@ -335,7 +335,12 @@ class TestGraphTierUpgradeTask:
     assert rollback_kwargs["volume_detached"] is False
 
   async def test_rollback_on_reattachment_timeout(self, mock_dynamodb):
-    """Rollback is triggered when volume is not reattached in time."""
+    """The compensator actually runs on a reattachment timeout — this is the
+    one test in the file that executes ``_rollback`` rather than asserting a
+    mock of it was called. Post-conditions: the volume is re-attached to the
+    old instance, its registry tier reverted, the graph registry taken off
+    ``migrating``, and the subscription taken off ``upgrading`` at the old
+    plan and price."""
     graph_table, volume_table, instance_table = mock_dynamodb
     snapshot_response, detach_response = _make_lambda_responses()
 
@@ -352,8 +357,17 @@ class TestGraphTierUpgradeTask:
       "Item": {"volume_id": "vol-abc123", "status": "available"}
     }
 
+    attach_response = MagicMock()
+    attach_response_payload = MagicMock()
+    attach_response_payload.read.return_value = json.dumps({"statusCode": 200}).encode()
+    attach_response = {"Payload": attach_response_payload}
+
     mock_lambda = MagicMock()
-    mock_lambda.invoke.side_effect = [snapshot_response, detach_response]
+    mock_lambda.invoke.side_effect = [
+      snapshot_response,
+      detach_response,
+      attach_response,
+    ]
 
     mock_asg = MagicMock()
     mock_asg.describe_auto_scaling_groups.return_value = {
@@ -364,6 +378,19 @@ class TestGraphTierUpgradeTask:
 
     dynamodb_resource = MagicMock()
     dynamodb_resource.Table.side_effect = [graph_table, volume_table, instance_table]
+
+    # PostgreSQL side of the rollback: a subscription mid-upgrade, the graph
+    # row, and its credit pool.
+    subscription = MagicMock()
+    subscription.status = "upgrading"
+    subscription.stripe_subscription_id = None
+    graph_row = MagicMock()
+    graph_credits = MagicMock()
+    db = MagicMock()
+    db.query.return_value.filter_by.return_value.first.return_value = subscription
+
+    def _db_gen():
+      yield db
 
     task = _make_task()
 
@@ -379,7 +406,17 @@ class TestGraphTierUpgradeTask:
       patch(f"{TASK_MODULE}.REATTACH_TIMEOUT_SECONDS", 0),
       patch(f"{TASK_MODULE}.REATTACH_POLL_INTERVAL_SECONDS", 0),
       patch.object(task, "_drain_instance", new_callable=AsyncMock),
-      patch.object(task, "_rollback", new_callable=AsyncMock) as mock_rollback,
+      patch("robosystems.database.get_db_session", side_effect=_db_gen),
+      patch("robosystems.models.core.graph.Graph.get_by_id", return_value=graph_row),
+      patch(
+        "robosystems.models.core.graph.graph_credits.GraphCredits.get_by_graph_id",
+        return_value=graph_credits,
+      ),
+      patch(
+        "robosystems.config.billing.BillingConfig.get_subscription_plan",
+        return_value={"base_price_cents": 4900},
+      ),
+      patch("robosystems.config.billing.get_tier_credit_allocation", return_value=1000),
     ):
       mock_env.GRAPH_REGISTRY_TABLE = "test-graph-registry"
       mock_env.VOLUME_REGISTRY_TABLE = "test-volume-registry"
@@ -389,9 +426,32 @@ class TestGraphTierUpgradeTask:
       with pytest.raises(TimeoutError, match="not reattached"):
         await task.execute()
 
-    mock_rollback.assert_called_once()
-    rollback_kwargs = mock_rollback.call_args[1]
-    assert rollback_kwargs["volume_detached"] is True
+    # Volume re-attached to the OLD instance
+    attach_call = json.loads(mock_lambda.invoke.call_args_list[-1].kwargs["Payload"])
+    assert attach_call == {
+      "action": "attach_volume",
+      "volume_id": "vol-abc123",
+      "instance_id": "i-old123",
+    }
+    # Volume registry tier reverted
+    tier_reverts = [
+      c.kwargs
+      for c in volume_table.update_item.call_args_list
+      if c.kwargs.get("ExpressionAttributeValues", {}).get(":tier")
+      == "ladybug-standard"
+    ]
+    assert tier_reverts, "volume registry tier was not reverted"
+    # Graph registry back to active, migration markers removed
+    graph_revert = graph_table.update_item.call_args_list[-1].kwargs
+    assert graph_revert["ExpressionAttributeValues"][":status"] == "active"
+    assert "REMOVE migration_required" in graph_revert["UpdateExpression"]
+    # Subscription off `upgrading` at the old plan and price; graph + pool reverted
+    assert subscription.status == "active"
+    assert subscription.plan_name == "ladybug-standard"
+    assert subscription.base_price_cents == 4900
+    assert graph_row.graph_tier == "ladybug-standard"
+    assert graph_credits.monthly_allocation == 1000
+    db.commit.assert_called_once()
 
   async def test_graph_not_found_raises_error(self, mock_dynamodb):
     """Raises error when graph is not in DynamoDB registry."""

--- a/tests/operations/graph/test_infrastructure.py
+++ b/tests/operations/graph/test_infrastructure.py
@@ -348,8 +348,10 @@ class TestCleanupStaleGraphs:
     assert result.error_message is None
 
   @pytest.mark.unit
-  def test_removes_graph_with_invalid_instance_id(self, monitor):
-    """Graph referencing non-existent instance is removed."""
+  def test_marks_graph_with_missing_instance_instead_of_removing(self, monitor):
+    """A live graph whose instance is absent from the instance registry is
+    marked and counted, never deleted — the row is its routing, and the
+    instance registry drifts on ASG cycling."""
     graph_table = _make_dynamo_table(
       items=[
         {
@@ -359,7 +361,6 @@ class TestCleanupStaleGraphs:
         },
       ]
     )
-    # Instance table is empty -> instance_id is invalid
     instance_table = _make_dynamo_table(items=[])
 
     def table_router(name):
@@ -373,8 +374,68 @@ class TestCleanupStaleGraphs:
 
     result = monitor.cleanup_stale_graphs()
 
-    assert result.removed_count == 1
-    graph_table.delete_item.assert_called_once_with(Key={"graph_id": "kg_orphan"})
+    assert result.removed_count == 0
+    assert result.orphaned_count == 1
+    assert result.updated_count == 1
+    graph_table.delete_item.assert_not_called()
+    update = graph_table.update_item.call_args.kwargs
+    assert update["Key"] == {"graph_id": "kg_orphan"}
+    assert "SET instance_missing_since" in update["UpdateExpression"]
+    assert "attribute_not_exists" in update["ConditionExpression"]
+    metric = monitor._cloudwatch.put_metric_data.call_args.kwargs
+    assert metric["Namespace"] == "RoboSystems/Graph/test"
+    assert metric["MetricData"][0]["MetricName"] == "OrphanedGraphRegistrations"
+    assert metric["MetricData"][0]["Value"] == 1
+
+  @pytest.mark.unit
+  def test_already_marked_orphan_is_counted_not_restamped(self, monitor):
+    graph_table = _make_dynamo_table(
+      items=[
+        {
+          "graph_id": "kg_orphan",
+          "status": "active",
+          "instance_id": "i-doesnotexist00001",
+          "instance_missing_since": "2026-08-01T00:00:00+00:00",
+        },
+      ]
+    )
+    instance_table = _make_dynamo_table(items=[])
+    monitor._dynamodb.Table.side_effect = lambda name: (
+      graph_table if name == "test-graph" else instance_table
+    )
+
+    result = monitor.cleanup_stale_graphs()
+
+    assert result.orphaned_count == 1
+    assert result.updated_count == 0
+    graph_table.update_item.assert_not_called()
+    graph_table.delete_item.assert_not_called()
+
+  @pytest.mark.unit
+  def test_marker_is_cleared_when_instance_returns(self, monitor):
+    graph_table = _make_dynamo_table(
+      items=[
+        {
+          "graph_id": "kg_back",
+          "status": "active",
+          "instance_id": "i-1234567890abcdef0",
+          "instance_missing_since": "2026-08-01T00:00:00+00:00",
+        },
+      ]
+    )
+    instance_table = _make_dynamo_table(items=[{"instance_id": "i-1234567890abcdef0"}])
+    monitor._dynamodb.Table.side_effect = lambda name: (
+      graph_table if name == "test-graph" else instance_table
+    )
+
+    result = monitor.cleanup_stale_graphs()
+
+    assert result.orphaned_count == 0
+    assert result.updated_count == 1
+    update = graph_table.update_item.call_args.kwargs
+    assert update["UpdateExpression"] == "REMOVE instance_missing_since"
+    metric = monitor._cloudwatch.put_metric_data.call_args.kwargs
+    assert metric["MetricData"][0]["Value"] == 0
 
   @pytest.mark.unit
   def test_exception_sets_error_message(self, monitor):

--- a/tests/routers/billing/test_checkout.py
+++ b/tests/routers/billing/test_checkout.py
@@ -1,6 +1,6 @@
 """Tests for billing checkout endpoints."""
 
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from fastapi import HTTPException
@@ -49,6 +49,16 @@ class TestCreateCheckoutSession:
     ) as mock_limits:
       mock_limits.return_value.can_create_graph.return_value = (True, "")
       yield mock_limits
+
+  @pytest.fixture(autouse=True)
+  def _tier_has_capacity(self):
+    """A graph checkout also gates on writer capacity for the tier before
+    payment. Default to a free slot; the refusal case has its own test."""
+    with patch(
+      "robosystems.routers.billing.checkout._tier_capacity_status",
+      new=AsyncMock(return_value="ready"),
+    ) as mock_capacity:
+      yield mock_capacity
 
   @pytest.mark.asyncio
   @patch("robosystems.models.core.OrgUser.get_user_orgs")
@@ -411,6 +421,79 @@ class TestCreateCheckoutSession:
     assert "limit" in exc.value.detail.lower()
     # No payment plumbing should have run.
     mock_get_customer.assert_not_called()
+
+  @pytest.mark.asyncio
+  @patch("robosystems.models.core.OrgUser.get_user_orgs")
+  @patch("robosystems.routers.billing.checkout.BillingCustomer.get_or_create")
+  @patch("robosystems.routers.billing.checkout.BillingConfig.get_subscription_plan")
+  @patch("robosystems.routers.billing.checkout.BillingSubscription.create_subscription")
+  @patch("robosystems.routers.billing.checkout.get_payment_provider")
+  async def test_create_checkout_session_refuses_when_tier_has_no_capacity(
+    self,
+    mock_get_provider,
+    mock_create_sub,
+    mock_get_plan,
+    mock_get_customer,
+    mock_get_user_orgs,
+    mock_user,
+    mock_db,
+    checkout_request,
+  ):
+    """A graph checkout is refused before payment when no writer for the tier
+    has a free slot. Provisioning runs post-payment, so a sale that completes
+    against a full fleet is money taken for a graph that cannot be delivered.
+    The refusal lands before any Stripe session or subscription row exists."""
+    from robosystems.models.core import OrgRole
+
+    mock_org_user = Mock()
+    mock_org_user.org_id = "org_123"
+    mock_org_user.role = OrgRole.OWNER
+    mock_get_user_orgs.return_value = [mock_org_user]
+
+    mock_customer = Mock(spec=BillingCustomer)
+    mock_customer.invoice_billing_enabled = False
+    mock_customer.has_payment_method = False
+    mock_get_customer.return_value = mock_customer
+    mock_get_plan.return_value = {"base_price_cents": 2999}
+
+    with patch(
+      "robosystems.routers.billing.checkout._tier_capacity_status",
+      new=AsyncMock(return_value="at_capacity"),
+    ):
+      with pytest.raises(HTTPException) as exc:
+        await create_checkout_session(checkout_request, mock_user, mock_db, None)
+
+    assert exc.value.status_code == 409
+    assert "capacity" in exc.value.detail.lower()
+    mock_create_sub.assert_not_called()
+    mock_get_provider.assert_not_called()
+
+
+class TestTierCapacityStatus:
+  """The checkout gate's capacity probe fails closed and treats a scalable-but-
+  empty tier as at capacity, since nothing on the create path scales."""
+
+  @pytest.mark.asyncio
+  async def test_ready_only_when_a_slot_is_free(self):
+    from robosystems.routers.billing.checkout import _tier_capacity_status
+
+    with patch(
+      "robosystems.middleware.graph.allocation_manager.LadybugAllocationManager"
+    ) as manager_cls:
+      manager_cls.return_value.check_tier_capacity = AsyncMock(return_value="ready")
+      assert await _tier_capacity_status("ladybug-standard") == "ready"
+      manager_cls.return_value.check_tier_capacity = AsyncMock(return_value="scalable")
+      assert await _tier_capacity_status("ladybug-standard") == "at_capacity"
+
+  @pytest.mark.asyncio
+  async def test_probe_failure_reads_as_at_capacity(self):
+    from robosystems.routers.billing.checkout import _tier_capacity_status
+
+    with patch(
+      "robosystems.middleware.graph.allocation_manager.LadybugAllocationManager",
+      side_effect=RuntimeError("registry unreachable"),
+    ):
+      assert await _tier_capacity_status("ladybug-standard") == "at_capacity"
 
 
 class TestGetCheckoutStatus:

--- a/tests/routers/graphs/test_usage.py
+++ b/tests/routers/graphs/test_usage.py
@@ -175,6 +175,27 @@ class TestGetGraphMetrics:
     assert result.graph_id == "kg01234567890abcdef"
 
   @pytest.mark.asyncio
+  async def test_shared_repository_is_refused_before_any_scan(self):
+    """A shared repository's metrics would be a fleet of full-scan COUNTs on
+    the shared master; the endpoint refuses up front and never reaches the
+    metrics service or the circuit breaker."""
+    mock_service = AsyncMock()
+    mock_service.collect_metrics_for_graph_async = AsyncMock()
+
+    with patch("robosystems.routers.graphs.usage.graph_metrics_service", mock_service):
+      with pytest.raises(HTTPException) as exc_info:
+        await get_graph_metrics(
+          graph_id="sec",
+          current_user=_make_mock_user(),
+          db=Mock(),
+          _rate_limit=None,
+        )
+
+    assert exc_info.value.status_code == 400
+    assert "shared repository" in exc_info.value.detail
+    mock_service.collect_metrics_for_graph_async.assert_not_awaited()
+
+  @pytest.mark.asyncio
   async def test_returns_404_when_no_metrics(self):
     """Test 404 when metrics not available."""
     mock_service = AsyncMock()


### PR DESCRIPTION
## Summary

Second punch-list tranche ahead of the v1.9.0 tag; every item has its line in the curated notes.

- **Capacity warnings reach every graph admin.** The usage-monitor sensor picked one arbitrary explicit `GraphUser` admin for both the storage snapshot and the 80%/100% email, so an org-owned graph whose only admins were implicit (org owner/admins, no `GraphUser` row) got no snapshot and no warning. Recipients now resolve to explicit graph admins ∪ org owners/admins; the snapshot is attributed to the monitor (`system:usage-monitor`), not a member. Real-DB tests for the recipient set.
- **Registry sweep marks, never deletes, rows whose instance is missing.** Deleting the row orphaned a live graph's routing on transient instance-registry drift. Now `instance_missing_since` is stamped once (cleared when the instance returns), the count is published as `OrphanedGraphRegistrations`, and `graph-infra` gains an alarm on it. Long-deleted rows still drop.
- **Shared master restart alarm.** The container-start filter matched only the replica marker; the master's OOM kills this week paged nobody. New filter + alarm on `graph-ladybug-replicas`, `Sum > 1` over a 12 h sliding window so the deliberate nightly wake is one start and doesn't page.
- **Stalled-provisioning write-off pages.** The reaper's line now carries a marker; `dagster` gains a metric filter + alarm on any occurrence.
- **`GET /v1/graphs/{id}/metrics` refuses shared repositories up front** (400) instead of full-scan counts against the shared master; the dashboard already skipped repositories.
- **Graph checkout gates on writer capacity for the tier** before the payment session (409), same refuse-the-sale rule as the org graph-limit gate; fails closed.
- **Tests:** the tier-upgrade rollback executes for real in the reattachment-timeout case with post-conditions asserted (it had never run anywhere); the provisioning-claim suite pins one credit pool per graph.
- `env.py` comment no longer asserts a live SSM value.

## Tests

- Full unit suite: 12,860 passed.
- `cfn-lint` clean on `graph-infra`, `graph-ladybug-replicas`, `dagster`.

## Deploy notes

- Stack updates: `graph-infra`, `graph-ladybug-replicas`, `dagster` (new alarms/filters). Already listed in the v1.9.0 notes' deploy section.
- Two status changes are listed under "API surface changes" in the notes.