### PR TITLE
fix(admin): invoice mark-paid sends query parameters

### DIFF
--- a/robosystems/admin/commands/billing.py
+++ b/robosystems/admin/commands/billing.py
@@ -355,8 +355,10 @@ def mark_invoice_paid(client, invoice_id, payment_method, payment_reference):
   if payment_reference:
     params["payment_reference"] = payment_reference
 
+  # The endpoint declares payment_method / payment_reference as query
+  # parameters, not a JSON body.
   invoice = client._make_request(
-    "PATCH", f"/admin/v1/invoices/{invoice_id}/mark-paid", data=params
+    "PATCH", f"/admin/v1/invoices/{invoice_id}/mark-paid", params=params
   )
 
   click.echo(f"✅ Marked invoice {invoice['invoice_number']} as paid")

--- a/robosystems/routers/admin/invoice.py
+++ b/robosystems/routers/admin/invoice.py
@@ -215,7 +215,7 @@ async def mark_invoice_paid(
     if not invoice:
       raise HTTPException(status_code=404, detail="Invoice not found")
 
-    if invoice.status == "PAID":
+    if str(invoice.status).lower() == "paid":
       raise HTTPException(status_code=400, detail="Invoice is already paid")
 
     invoice.mark_paid(

--- a/tests/admin/test_cli.py
+++ b/tests/admin/test_cli.py
@@ -459,10 +459,13 @@ class TestInvoicesCommands:
       ],
     )
     assert result.exit_code == 0
+    # The endpoint declares these as QUERY parameters; the previous version of
+    # this test asserted a JSON body, which is why the command never worked
+    # against a real API (422: query.payment_method field required).
     mock_make_request.assert_called_once_with(
       "PATCH",
       "/admin/v1/invoices/inv-1/mark-paid",
-      data={"payment_method": "bank_transfer", "payment_reference": "TXN-123"},
+      params={"payment_method": "bank_transfer", "payment_reference": "TXN-123"},
     )
     assert "Marked invoice INV-001 as paid" in result.output
 


### PR DESCRIPTION
## Summary

`just admin <env> invoices mark-paid` sent `payment_method` / `payment_reference` as a JSON body; the endpoint declares them as query parameters, so the command has never worked against a real API (`422 query.payment_method field required`). Sends them as query params now. The endpoint's already-paid guard compared against `"PAID"`; statuses are stored lowercase, so it could never fire — compares case-insensitively.

The CLI test asserted the body form (i.e. asserted the bug); updated to the endpoint's contract.

## Tests

- `tests/admin/test_cli.py::test_mark_paid` updated; `tests/routers/admin/test_invoice.py` unchanged and still valid.
- Not run locally in this session — a prod SSM tunnel held `localhost:5432` at the time; CI runs the suite.
- Verified live: four prod invoices marked paid through the fixed CLI.