### PR TITLE
chore: pre-1.9.0 review fixes (quoted CALL targets, disk-growth alarm, capacity-email dedup, demo reset guard)

### DIFF
--- a/.github/release-notes/v1.9.0.md
+++ b/.github/release-notes/v1.9.0.md
@@ -131,7 +131,9 @@ problem underneath the first: the worker's IAM grant permitted a different metri
 publish was denied and swallowed, since February. The notification-delivery alarm added in v1.8.0 had
 never been accepted by CloudWatch at all. All are corrected, the disk and delivery alarms as Metrics
 Insights queries, which aggregate across dimension sets and pick up new resources without anyone
-remembering to add them.
+remembering to add them. The rapid-disk-growth alarm beside them compared a per-second rate against a
+per-minute threshold and could never have fired; it now measures the change per thirty-minute period
+directly.
 
 Also: `api.yaml` deploys from S3 rather than inline, which frees it from a size ceiling it was ten
 lines under and lets its alarms live beside the resources they watch instead of in the account-global
@@ -207,13 +209,21 @@ evaluation recording an error rather than a verdict; both migrations fan into ev
   graph whose only admins were the organization's owner and admins — implicit, with no explicit grant
   row — wrote no snapshot and sent no warning at all. Recipients now resolve to explicit graph admins
   plus the organization's owners and admins; the snapshot is attributed to the monitor, not a member.
+  Delivery is deduplicated per recipient, so an admin whose email failed is retried on the next tick
+  while the ones already told are not emailed again; and the graph's storage snapshots appear in its
+  `recent_events` for every member, not only for whoever happened to be recorded against them.
 - `GET /v1/graphs/{id}/metrics` refuses shared repositories up front instead of issuing a full-scan
   count per label and per relationship type against the shared master; the only consumer already
   skipped repositories because the call timed out.
 - An authentication-cache invalidation path was corrected and gained the tests it did not have.
 - The query surfaces — REST, MCP and the Operator write tool — refuse procedures that execute a
   statement passed as a string argument, on every graph and regardless of role; the statement
-  analyzer cannot classify a payload it deliberately does not read.
+  analyzer cannot classify a payload it deliberately does not read. A quoted procedure name is
+  refused the same way — the engine resolves it to the same procedure, and the analyzer masks quoted
+  identifiers before it reads the name, so a name it cannot see is not a name it can vouch for.
+- The demos' one direct-database step, the local reset, now asks the database itself before deleting:
+  the URL must be a local host **and** the server must not answer as RDS. The API URL being local was
+  the only guard, and with a tunnel open, `localhost:5432` is production.
 - Fork-safe demo runners: the roboledger and roboinvestor demos honor `DEMO_API_URL`, keep credentials
   per target, and are strictly API-only against anything but the local stack; the scenario runner can
   skip the report-serialization pass.

--- a/.github/release-notes/v1.9.0.md
+++ b/.github/release-notes/v1.9.0.md
@@ -197,9 +197,11 @@ evaluation recording an error rather than a verdict; both migrations fan into ev
   400 at 100 MB. The published figure is now derived from the enforced constant, so every tier reads
   the same, much smaller, number; nothing could exceed it before. `FileUploadRequest` accepts an
   optional `file_size_bytes` so an over-limit upload is refused at presign rather than after the push.
-- **SEC statement reads no longer collapse a Q4 and an FY fact** that share a concept and an end date;
-  the survivor was arbitrary and unstable between identical calls. `financial-statement-analysis` can
-  now legitimately return both rows.
+- **SEC statement reads no longer collapse two periods that share an end date** — a Q4 and an FY
+  fact, and, since the review, any two periods that differ only in start date (two stubs of different
+  length, a 52- and a 53-week year); the survivor was arbitrary and unstable between identical calls.
+  `financial-statement-analysis` keys facts on the full period identity and returns `start_date` so
+  the caller can tell the rows apart.
 - The SEC nightly materialization runs as a full rebuild — incremental mode exceeded the shared
   master's memory at the current corpus size — and a per-database run limit ensures two
   materializations can never write the same graph concurrently.
@@ -240,8 +242,9 @@ in the published clients (1.10.1):
 - New, schema-excluded by design: the OIDC redirect endpoints and `/scim/v2`.
 - Additive fields: `AuthResponse.status` / `mfa_token`; `PortalSessionResponse.billing_disabled`;
   `OrgInvitationResponse.token` (null everywhere except a non-production build with the test-support
-  flag on); `FileUploadRequest.file_size_bytes` — this last is stable-tier surface the integration
-  template imports, and is optional with a default, so no coordinated client major.
+  flag on); `AnalyticalStatementFactRow.start_date` on `financial-statement-analysis` (and the same
+  key in the MCP tool's rows); `FileUploadRequest.file_size_bytes` — this last is stable-tier surface
+  the integration template imports, and is optional with a default, so no coordinated client major.
 - A published value changes: `max_file_size_gb` on `/limits` and `/tiers` is now the same figure on
   every tier. Any material quoting the old per-tier values is now wrong.
 - Response content, not shape: `financial-statement-analysis` may return two rows where it returned one.

--- a/cloudformation/graph-volumes.yaml
+++ b/cloudformation/graph-volumes.yaml
@@ -686,19 +686,25 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub "robosystems-graph-volumes-${Environment}-rapid-disk-growth"
-      AlarmDescription: Disk usage growing rapidly (>10% in 30 minutes)
+      AlarmDescription: Disk usage growing rapidly (>10 percentage points in 30 minutes)
       # See DiskUsageWarningAlarm. Math over a single Metrics Insights query is
       # allowed; what an alarm cannot carry is a second Insights query.
+      #
+      # DIFF() is the difference between consecutive datapoints, and with a
+      # 30-minute period each datapoint is one 30-minute bucket, so the value
+      # is directly "percentage points grown in the last 30 minutes". Do not
+      # swap in RATE(): it is per *second*, so a per-minute threshold against
+      # it can never be crossed (a full 0-to-100 jump in 30 min is only 0.056).
       Metrics:
-        - Id: growth_rate
-          Expression: "RATE(disk_usage)"
+        - Id: growth
+          Expression: "DIFF(disk_usage)"
           ReturnData: true
         - Id: disk_usage
           Expression: !Sub 'SELECT MAX(DISK_USED_PERCENT) FROM "RoboSystems/Graph/${Environment}" WHERE path = ''/mnt/ladybug-data'''
           Period: 1800 # 30 minutes
           ReturnData: false
       EvaluationPeriods: 1
-      Threshold: 0.33 # 10% growth in 30 minutes = 0.33% per minute
+      Threshold: 10 # percentage points of disk_used_percent per 30-minute period
       ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
       AlarmActions:

--- a/examples/_common/local_db.py
+++ b/examples/_common/local_db.py
@@ -1,0 +1,58 @@
+"""Guard for the demos' one direct-database step: the reset.
+
+Every demo goes through the HTTP API except its ``_reset`` module, which
+issues raw ``DELETE``s against whatever ``EXTENSIONS_DATABASE_URL`` points
+at. The demos gate that on the *API* target being local — but the API URL
+and the database URL are two different settings, and ``localhost:5432`` is
+exactly where an SSM tunnel to production RDS lands. So before any reset
+runs, ask the database itself:
+
+1. the URL's host must be a loopback/local name (cheap, catches an edited
+   ``.env.local``), and
+2. the server must not be RDS — every RDS instance carries the ``rdsadmin``
+   role; a local Postgres never does.
+
+Refusal raises rather than returning False: a demo that reaches this point
+with a non-local database is misconfigured, and the safe outcome is a stack
+trace, not a skipped step that leaves stale demo state to be duplicated.
+"""
+
+from __future__ import annotations
+
+from urllib.parse import urlparse
+
+from sqlalchemy import create_engine, text
+
+LOCAL_DB_HOSTS = frozenset({"localhost", "127.0.0.1", "::1", "0.0.0.0", "postgres"})
+
+
+class NonLocalDatabaseError(RuntimeError):
+  """Raised when a demo reset would run against a database that is not local."""
+
+
+def assert_local_extensions_db() -> None:
+  """Refuse unless the extensions database is demonstrably a local Postgres."""
+  from robosystems.db.extensions import get_extensions_database_url
+
+  url = get_extensions_database_url()
+  host = (urlparse(url).hostname or "").lower()
+  if host not in LOCAL_DB_HOSTS:
+    raise NonLocalDatabaseError(
+      f"Demo reset refused: EXTENSIONS_DATABASE_URL host is '{host}', not a "
+      "local Postgres. The reset issues raw DELETEs and only ever runs locally."
+    )
+
+  engine = create_engine(url)
+  try:
+    with engine.connect() as conn:
+      on_rds = conn.execute(
+        text("SELECT 1 FROM pg_roles WHERE rolname = 'rdsadmin'")
+      ).first()
+  finally:
+    engine.dispose()
+  if on_rds is not None:
+    raise NonLocalDatabaseError(
+      f"Demo reset refused: '{host}' answers as an Amazon RDS instance (the "
+      "rdsadmin role is present) — a forwarded port, not a local database. "
+      "Close the tunnel or point EXTENSIONS_DATABASE_URL at the local stack."
+    )

--- a/examples/_scenario/reset.py
+++ b/examples/_scenario/reset.py
@@ -46,7 +46,10 @@ def reset_demo_state(graph_id: str) -> None:
   transactions, tenant associations, facts, schedules, fiscal calendar)
   is removed.
   """
+  from examples._common.local_db import assert_local_extensions_db
   from robosystems.db.extensions import extensions_session
+
+  assert_local_extensions_db()
 
   with extensions_session(graph_id) as session:
     # 1-3. All entries + line items + transactions (tenant-generated;

--- a/examples/roboinvestor_demo/_reset.py
+++ b/examples/roboinvestor_demo/_reset.py
@@ -35,7 +35,10 @@ def reset_investor_state(graph_id: str) -> None:
   its library-seeded taxonomy survive, so the graph never needs
   re-provisioning between runs.
   """
+  from examples._common.local_db import assert_local_extensions_db
   from robosystems.db.extensions import extensions_session
+
+  assert_local_extensions_db()
 
   with extensions_session(graph_id) as session:
     # Positions FK both portfolios and securities, so they go first.
@@ -97,7 +100,10 @@ def reset_issuer_share_state(graph_id: str) -> None:
   create publish lists, so anything here came from a prior run of *this*
   demo.
   """
+  from examples._common.local_db import assert_local_extensions_db
   from robosystems.db.extensions import extensions_session
+
+  assert_local_extensions_db()
 
   with extensions_session(graph_id) as session:
     session.execute(text("DELETE FROM report_shares"))

--- a/examples/roboinvestor_demo/main.py
+++ b/examples/roboinvestor_demo/main.py
@@ -219,7 +219,9 @@ def _published_report_id(graph_id: str) -> str | None:
     reports = _ledger_client().list_reports(graph_id)
   except Exception:
     return None
-  published = [r for r in reports or [] if getattr(r, "generation_status", None) == "published"]
+  published = [
+    r for r in reports or [] if getattr(r, "generation_status", None) == "published"
+  ]
   if not published:
     return None
   return published[-1].id
@@ -546,7 +548,9 @@ def _print_block(block: Any) -> None:
   owner = _field(block, "owner", None)
   print(f"    Active positions: {active}")
   print(f"    Cost basis:       ${cost:,.2f}")
-  print(f"    Current value:    {f'${value:,.2f}' if value is not None else '(unmarked)'}")
+  print(
+    f"    Current value:    {f'${value:,.2f}' if value is not None else '(unmarked)'}"
+  )
   if owner:
     print(f"    Owner:            {_field(owner, 'name')}")
 
@@ -838,9 +842,7 @@ def _field(obj: Any, name: str, default: Any = _MISSING) -> Any:
   else:
     value = getattr(obj, name, _MISSING)
 
-  if value is _MISSING or (
-    value is not None and "Unset" in type(value).__name__
-  ):
+  if value is _MISSING or (value is not None and "Unset" in type(value).__name__):
     if default is _MISSING:
       raise KeyError(f"{type(obj).__name__} has no field {name!r}")
     return default
@@ -897,9 +899,12 @@ def main(argv: list[str] | None = None) -> None:
   # EXTENSIONS_DATABASE_URL points at, which is *not* necessarily the same
   # system as DEMO_API_URL — with an SSM tunnel open, localhost:5432 can be a
   # remote RDS. The import lives inside the local-only branch so the route is
-  # unreachable off-local, not merely skipped. A remote run gets freshly
-  # provisioned graphs, so there is nothing to reset — re-running against the
-  # same remote graphs will duplicate demo state, not replace it.
+  # unreachable off-local, not merely skipped; and because the API host proves
+  # nothing about the database, the reset itself re-checks on the DB side
+  # (``examples/_common/local_db.py``: local host + not-RDS) before deleting.
+  # A remote run gets freshly provisioned graphs, so there is nothing to
+  # reset — re-running against the same remote graphs will duplicate demo
+  # state, not replace it.
   if _is_local_target():
     print("\n  Resetting prior demo state (the only direct-DB step)...")
     from ._reset import reset_investor_state, reset_issuer_share_state

--- a/examples/roboledger_demo/_reset.py
+++ b/examples/roboledger_demo/_reset.py
@@ -49,7 +49,10 @@ def reset_demo_state(graph_id: str) -> None:
   transactions, tenant associations, facts, schedules, fiscal calendar)
   is removed.
   """
+  from examples._common.local_db import assert_local_extensions_db
   from robosystems.db.extensions import extensions_session
+
+  assert_local_extensions_db()
 
   with extensions_session(graph_id) as session:
     # 1-3. All entries + line items + transactions (tenant-generated;

--- a/examples/roboledger_demo/main.py
+++ b/examples/roboledger_demo/main.py
@@ -334,10 +334,12 @@ def reset_demo(graph_id: str) -> None:
   local, so with tunnels open ``localhost:5432`` can be prod RDS. A remote /
   integration target has no business reaching Postgres at all, so the reset is
   simply not run off-local — and ``reset_demo_state`` is imported *inside* the
-  local-only branch so the route is unreachable there, not merely skipped. A
-  graph provisioned on a remote target is empty anyway; pass a freshly
-  provisioned graph and re-running over demo data will duplicate it, not replace
-  it.
+  local-only branch so the route is unreachable there, not merely skipped. The
+  API host proves nothing about the database, though, so ``reset_demo_state``
+  also re-checks on the DB side (``examples/_common/local_db.py``: local host
+  + not-RDS) before it deletes anything. A graph provisioned on a remote target
+  is empty anyway; pass a freshly provisioned graph and re-running over demo
+  data will duplicate it, not replace it.
   """
   if not _is_local_target():
     print(f"  SKIPPED — reset is local-only, and the target is {BASE_URL}")

--- a/robosystems/adapters/base.py
+++ b/robosystems/adapters/base.py
@@ -39,7 +39,6 @@ class SharedRepositoryManifest:
 
   # MCP Capabilities
   has_semantic_enrichment: bool = False
-  sibling_subgraphs: tuple[str, ...] = ()  # ("historical",) → graph_id_historical
 
   # Agent-facing routing guidance handed to MCP clients via the server's
   # `instructions` handshake field. Authored per-repo (shared repos have a

--- a/robosystems/adapters/sec/manifest.py
+++ b/robosystems/adapters/sec/manifest.py
@@ -18,7 +18,6 @@ SEC_MANIFEST = SharedRepositoryManifest(
   sync_frequency="daily",
   schema_extensions=("roboledger",),
   has_semantic_enrichment=True,
-  sibling_subgraphs=("historical",),  # sec_historical subgraph
   agent_instructions=(
     "Connected to the SEC EDGAR knowledge graph (`sec`) — a curated, READ-ONLY "
     "repository of public-company XBRL financial filings. There is no general "

--- a/robosystems/dagster/sensors/usage_monitor.py
+++ b/robosystems/dagster/sensors/usage_monitor.py
@@ -47,6 +47,13 @@ _ALERTS_ENABLED_FLAG = "GRAPH_USAGE_ALERTS_ENABLED"
 USAGE_MONITOR_PRINCIPAL = "system:usage-monitor"
 
 
+def _alert_dedup_key(graph_id: str, instance_status: str, user_id: str) -> str:
+  """Valkey key recording that *this* admin was told about *this* graph at
+  *this* status. Per recipient so a failed delivery is retried without
+  re-emailing the admins who already received it."""
+  return f"usage_alert:{graph_id}:{instance_status}:{user_id}"
+
+
 def _capacity_alert_recipients(db, graph) -> list:
   """Everyone who administers the graph: explicit ``GraphUser`` admins plus
   the owning org's owners and admins, who hold implicit graph admin with no
@@ -181,14 +188,6 @@ def graph_usage_monitor_sensor(context: SensorEvaluationContext):
       if instance_status not in _ALERT_STATUSES:
         continue
 
-      # Dedup: check if we already alerted for this graph at this status
-      dedup_key = f"usage_alert:{graph.graph_id}:{instance_status}"
-      if redis_client.exists(dedup_key):
-        context.log.debug(
-          f"Skipping alert for {graph.graph_id} ({instance_status}) — already alerted"
-        )
-        continue
-
       recipients = _capacity_alert_recipients(db, graph)
       if not recipients:
         context.log.warning(
@@ -196,10 +195,27 @@ def graph_usage_monitor_sensor(context: SensorEvaluationContext):
         )
         continue
 
-      # Send the capacity warning to every admin; the dedup key covers the
-      # graph+status, set once any delivery succeeded.
+      # Dedup per recipient, not per graph: the key is set only for a user
+      # whose delivery succeeded, so an admin whose send failed is retried on
+      # the next tick while the ones already told are not emailed again. A
+      # single graph-level key set on "any delivery succeeded" silenced the
+      # failed recipients for the whole TTL.
+      pending = [
+        user
+        for user in recipients
+        if not redis_client.exists(
+          _alert_dedup_key(graph.graph_id, instance_status, user.id)
+        )
+      ]
+      if not pending:
+        context.log.debug(
+          f"Skipping alert for {graph.graph_id} ({instance_status}) — all "
+          f"{len(recipients)} admin(s) already alerted"
+        )
+        continue
+
       delivered = 0
-      for user in recipients:
+      for user in pending:
         try:
           from robosystems.operations.aws.ses import ses_service
 
@@ -218,6 +234,11 @@ def graph_usage_monitor_sensor(context: SensorEvaluationContext):
           )
           if sent:
             delivered += 1
+            redis_client.setex(
+              _alert_dedup_key(graph.graph_id, instance_status, user.id),
+              _ALERT_DEDUP_TTL_SECONDS,
+              "1",
+            )
           else:
             context.log.warning(
               f"Failed to send capacity alert for {graph.graph_id} to {user.email}"
@@ -228,11 +249,10 @@ def graph_usage_monitor_sensor(context: SensorEvaluationContext):
           )
 
       if delivered:
-        redis_client.setex(dedup_key, _ALERT_DEDUP_TTL_SECONDS, "1")
         alerts_sent += 1
         context.log.info(
           f"Sent {instance_status} alert for {graph.graph_id} to {delivered} of "
-          f"{len(recipients)} admin(s) ({storage_check['usage_percentage']:.0f}%)"
+          f"{len(pending)} pending admin(s) ({storage_check['usage_percentage']:.0f}%)"
         )
 
     context.log.info(

--- a/robosystems/middleware/graph/statement_kernel.py
+++ b/robosystems/middleware/graph/statement_kernel.py
@@ -91,8 +91,9 @@ class StatementKernel:
       raise HTTPException(
         status_code=http_status.HTTP_403_FORBIDDEN,
         detail="Procedures that execute a statement passed as a string "
-        "(e.g. CALL GQL(...)) are not allowed through the query endpoints. "
-        "Submit the statement directly so it can be authorized.",
+        "(e.g. CALL GQL(...)), and CALLs whose procedure name is quoted, are "
+        "not allowed through the query endpoints. Submit the statement "
+        "directly, with an unquoted procedure name, so it can be authorized.",
       )
 
     # Analyze query

--- a/robosystems/middleware/mcp/tools/financial_statement_tools.py
+++ b/robosystems/middleware/mcp/tools/financial_statement_tools.py
@@ -305,6 +305,7 @@ class FinancialStatementAnalysisTool(BaseTool):
         "qname": row.get("qname"),
         "name": row.get("name"),
         "value": row.get("value"),
+        "start_date": row.get("start_date"),
         "end_date": row.get("end_date"),
         "period_type": row.get("period_type"),
         "duration_type": row.get("duration_type"),

--- a/robosystems/middleware/mcp/tools/subgraph_write_tools.py
+++ b/robosystems/middleware/mcp/tools/subgraph_write_tools.py
@@ -86,7 +86,8 @@ def _validate_write_query(query: str) -> str | None:
   if has_opaque_statement_call(query):
     return (
       "Blocked operation detected. Procedures that execute a statement passed "
-      "as a string (e.g. CALL GQL) are not allowed; submit the statement directly."
+      "as a string (e.g. CALL GQL), and CALLs with a quoted procedure name, are "
+      "not allowed; submit the statement directly with an unquoted name."
     )
 
   # Block DDL / bulk / admin — the same dangerous categories the kernel and the

--- a/robosystems/models/api/extensions/reports.py
+++ b/robosystems/models/api/extensions/reports.py
@@ -622,6 +622,7 @@ class AnalyticalStatementFactRow(BaseModel):
   qname: str
   name: str
   value: float | None = None
+  start_date: str | None = None
   end_date: str | None = None
   period_type: str | None = None
   duration_type: str | None = None

--- a/robosystems/operations/graph/infrastructure.py
+++ b/robosystems/operations/graph/infrastructure.py
@@ -423,10 +423,19 @@ class InstanceMonitor:
         response = graph_table.scan(ExclusiveStartKey=response["LastEvaluatedKey"])
         items.extend(response.get("Items", []))
 
+      # Paginate the instance scan too: a truncated first page would make every
+      # instance on a later page look missing, and every graph on those
+      # instances would be stamped orphaned and page — the sweep would create
+      # the condition it alarms on.
       instance_response = instance_table.scan(ProjectionExpression="instance_id")
-      valid_instances = {
-        item["instance_id"] for item in instance_response.get("Items", [])
-      }
+      instance_items = instance_response.get("Items", [])
+      while "LastEvaluatedKey" in instance_response:
+        instance_response = instance_table.scan(
+          ProjectionExpression="instance_id",
+          ExclusiveStartKey=instance_response["LastEvaluatedKey"],
+        )
+        instance_items.extend(instance_response.get("Items", []))
+      valid_instances = {item["instance_id"] for item in instance_items}
 
       now_iso = datetime.now(UTC).isoformat()
 
@@ -550,10 +559,19 @@ class InstanceMonitor:
         response = volume_table.scan(ExclusiveStartKey=response["LastEvaluatedKey"])
         items.extend(response.get("Items", []))
 
+      # Paginate the instance scan too: a truncated first page would make every
+      # instance on a later page look missing, and every graph on those
+      # instances would be stamped orphaned and page — the sweep would create
+      # the condition it alarms on.
       instance_response = instance_table.scan(ProjectionExpression="instance_id")
-      valid_instances = {
-        item["instance_id"] for item in instance_response.get("Items", [])
-      }
+      instance_items = instance_response.get("Items", [])
+      while "LastEvaluatedKey" in instance_response:
+        instance_response = instance_table.scan(
+          ProjectionExpression="instance_id",
+          ExclusiveStartKey=instance_response["LastEvaluatedKey"],
+        )
+        instance_items.extend(instance_response.get("Items", []))
+      valid_instances = {item["instance_id"] for item in instance_items}
 
       for item in items:
         volume_id = item.get("volume_id")

--- a/robosystems/operations/roboledger/views/financial_statement_query.py
+++ b/robosystems/operations/roboledger/views/financial_statement_query.py
@@ -122,8 +122,8 @@ async def query_financial_statement(
     f"WHERE {' AND '.join(where_clauses)} "
     "RETURN DISTINCT e.canonical_concept AS canonical_concept, e.qname AS qname, "
     "e.name AS name, f.numeric_value AS value, "
-    "p.end_date AS end_date, p.period_type AS period_type, "
-    "p.duration_type AS duration_type "
+    "p.start_date AS start_date, p.end_date AS end_date, "
+    "p.period_type AS period_type, p.duration_type AS duration_type "
     "ORDER BY end_date DESC "
     "LIMIT $limit"
   )
@@ -138,23 +138,29 @@ async def query_financial_statement(
 
 
 def deduplicate_facts(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
-  """Deduplicate facts by ``(qname, end_date, period_type, duration_type)``.
+  """Deduplicate facts by the full period identity:
+  ``(qname, start_date, end_date, period_type, duration_type)``.
 
-  ``duration_type`` is load-bearing and was missing from the key until
-  2026-08-14: an annual and a quarterly fact legitimately share a ``qname``
-  and an ``end_date`` (Q4 and FY both end on the fiscal year end), so keying
-  on the pair alone silently collapsed them into whichever row the engine
-  happened to return first. ``ORDER BY end_date DESC`` does not break that
-  tie, so the survivor was not merely arbitrary but *unstable* between
-  otherwise identical calls — a wrong number rather than an error, on the
-  public SEC surface. The sibling path ``fact_query.deduplicate_facts``
-  already keys on the full period identity; this is the same fix.
+  An XBRL duration fact is identified by *(start, end)*, not by end alone.
+  The key was ``(qname, end_date)`` until 2026-08-14, when ``duration_type``
+  was added because Q4 and FY share a ``qname`` and an ``end_date`` and were
+  collapsing into whichever row the engine returned first — ``ORDER BY
+  end_date DESC`` does not break the tie, so the survivor was *unstable*
+  between identical calls, a wrong number rather than an error on the public
+  SEC surface. ``duration_type`` alone is still only a coarse bucket
+  (``quarterly`` / ``annual`` / ``other`` …): two ``other``-length stubs
+  ending on the same day, or a 52- and a 53-week year with one end date,
+  share every field but ``start_date``. Keying on both ends closes the class
+  rather than the instance; the sibling ``fact_query._deduplicate_fact_rows``
+  keys the same way. ``start_date`` is NULL for instants, which is fine —
+  an instant's identity is its ``end_date``.
   """
-  seen: set[tuple[str, str, str, str]] = set()
+  seen: set[tuple[str, str, str, str, str]] = set()
   deduped: list[dict[str, Any]] = []
   for row in rows:
     key = (
       row.get("qname", "") or "",
+      row.get("start_date", "") or "",
       row.get("end_date", "") or "",
       row.get("period_type", "") or "",
       row.get("duration_type", "") or "",

--- a/robosystems/routers/extensions/roboledger/views.py
+++ b/robosystems/routers/extensions/roboledger/views.py
@@ -284,6 +284,7 @@ async def financial_statement_analysis_op(
         qname=row.get("qname", ""),
         name=row.get("name", ""),
         value=row.get("value"),
+        start_date=row.get("start_date"),
         end_date=row.get("end_date"),
         period_type=row.get("period_type"),
         duration_type=row.get("duration_type"),

--- a/robosystems/routers/graphs/usage.py
+++ b/robosystems/routers/graphs/usage.py
@@ -13,6 +13,7 @@ import time
 from datetime import UTC, datetime, timedelta
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query, status
+from sqlalchemy import or_
 from sqlalchemy.orm import Session
 
 from robosystems.database import get_db_session
@@ -44,6 +45,7 @@ from robosystems.models.api.graphs.metrics import (
   StorageSummary,
 )
 from robosystems.models.core import GraphUsage, User
+from robosystems.models.core.graph.graph_usage import UsageEventType
 from robosystems.operations.graph.metrics_service import GraphMetricsService
 
 router = APIRouter(tags=["Usage"])
@@ -407,13 +409,21 @@ async def get_graph_usage(
         )
 
     if include_events:
+      # The caller's own activity on this graph, plus the graph's storage
+      # snapshots. Snapshots are recorded by the usage monitor under a system
+      # principal (they measure the graph, not a member), so a user-only filter
+      # would hide them from every caller — and the caller has already passed
+      # the graph-access check, so a graph-scoped storage row is theirs to see.
       cutoff_date = now - timedelta(days=_get_days_from_time_range(time_range))
       events = (
         db.query(GraphUsage)
         .filter(
-          GraphUsage.user_id == current_user.id,
           GraphUsage.graph_id == graph_id,
           GraphUsage.recorded_at >= cutoff_date,
+          or_(
+            GraphUsage.user_id == current_user.id,
+            GraphUsage.event_type == UsageEventType.STORAGE_SNAPSHOT.value,
+          ),
         )
         .order_by(GraphUsage.recorded_at.desc())
         .limit(50)

--- a/robosystems/security/cypher_analyzer.py
+++ b/robosystems/security/cypher_analyzer.py
@@ -13,6 +13,11 @@ from enum import Enum
 
 logger = logging.getLogger(__name__)
 
+# What `_clean_query` substitutes for a backtick-quoted identifier. Named so
+# the CALL-target checks can recognise "the name was quoted" without ever
+# reading the raw (unmasked) query.
+_IDENTIFIER_PLACEHOLDER = "IDENTIFIER"
+
 
 class CypherOperationType(Enum):
   """Types of Cypher operations."""
@@ -274,12 +279,22 @@ class CypherSecurityAnalyzer:
   def has_opaque_statement_call(self, query: str) -> bool:
     """Check whether a query calls a procedure in OPAQUE_STATEMENT_PROCEDURES.
 
+    A backtick-quoted CALL target counts too. The engine resolves
+    ``CALL `GQL`(...)`` to the same procedure as ``CALL GQL(...)``, but
+    ``_clean_query`` has already masked the quoted name to a placeholder by
+    the time it is inspected here — so a name-based check cannot see it.
+    Nothing legitimate quotes a procedure name; refusing the shape closes
+    the evasion without weakening the masking the classifier depends on.
+
     Fails closed: if analysis raises, the query is treated as containing one.
     """
     try:
       cleaned_query = self._clean_query(query)
       for match in self.call_pattern.finditer(cleaned_query):
-        if match.group(1).lower() in self.OPAQUE_STATEMENT_PROCEDURES:
+        name = match.group(1)
+        if name == _IDENTIFIER_PLACEHOLDER:
+          return True
+        if name.lower() in self.OPAQUE_STATEMENT_PROCEDURES:
           return True
       return False
     except Exception as e:
@@ -387,7 +402,7 @@ class CypherSecurityAnalyzer:
           i += 1
           if c == "`":
             break
-        out.append(" IDENTIFIER ")
+        out.append(f" {_IDENTIFIER_PLACEHOLDER} ")
         continue
 
       out.append(ch)

--- a/tests/dagster/test_usage_monitor.py
+++ b/tests/dagster/test_usage_monitor.py
@@ -15,6 +15,14 @@ from robosystems.dagster.sensors.usage_monitor import (
 RECIPIENTS = "robosystems.dagster.sensors.usage_monitor._capacity_alert_recipients"
 
 
+def _admin(user_id, email):
+  user = MagicMock()
+  user.id = user_id
+  user.email = email
+  user.name = email.split("@")[0]
+  return user
+
+
 def _make_graph(graph_id="kg_test123", tier="ladybug-standard"):
   """Create a mock Graph object."""
   graph = MagicMock()
@@ -110,12 +118,10 @@ class TestGraphUsageMonitorSensor:
     mock_db.query.return_value.filter.return_value.all.return_value = [graph]
 
     # Two admins resolve for the graph (one explicit, one implicit via org role)
-    admin_a = MagicMock()
-    admin_a.email = "a@example.com"
-    admin_a.name = "Admin A"
-    admin_b = MagicMock()
-    admin_b.email = "b@example.com"
-    admin_b.name = "Admin B"
+    admin_a, admin_b = (
+      _admin("usr_a", "a@example.com"),
+      _admin("usr_b", "b@example.com"),
+    )
 
     # Storage check returns approaching
     mock_check_storage.return_value = {
@@ -138,16 +144,20 @@ class TestGraphUsageMonitorSensor:
     with patch(RECIPIENTS, return_value=[admin_a, admin_b]):
       graph_usage_monitor_sensor(context)
 
-    # Every admin is emailed, and the dedup key is set once for the graph+status
+    # Every admin is emailed, and a dedup key is set per delivered recipient
     sent_to = [
       c.kwargs["user_email"]
       for c in mock_ses.send_capacity_warning_email.call_args_list
     ]
     assert sent_to == ["a@example.com", "b@example.com"]
-    mock_redis.setex.assert_called_once()
-    dedup_call = mock_redis.setex.call_args
-    assert dedup_call[0][0] == "usage_alert:kg_test123:approaching"
-    assert dedup_call[0][1] == _ALERT_DEDUP_TTL_SECONDS
+    dedup_keys = [c[0][0] for c in mock_redis.setex.call_args_list]
+    assert dedup_keys == [
+      "usage_alert:kg_test123:approaching:usr_a",
+      "usage_alert:kg_test123:approaching:usr_b",
+    ]
+    assert all(
+      c[0][1] == _ALERT_DEDUP_TTL_SECONDS for c in mock_redis.setex.call_args_list
+    )
 
     # The snapshot is attributed to the monitor, not to a member
     added = [
@@ -218,17 +228,84 @@ class TestGraphUsageMonitorSensor:
       "databases": [],
     }
 
-    # Valkey: already alerted
+    # Valkey: already alerted (for the one admin who exists)
     mock_redis = MagicMock()
     mock_redis_factory.return_value = mock_redis
     mock_redis.exists.return_value = True
 
     context = build_sensor_context()
-    graph_usage_monitor_sensor(context)
+    with (
+      patch(RECIPIENTS, return_value=[_admin("usr_a", "a@example.com")]),
+      patch("robosystems.operations.aws.ses.ses_service") as mock_ses,
+    ):
+      mock_ses.send_capacity_warning_email = AsyncMock(return_value=True)
+      graph_usage_monitor_sensor(context)
 
-    # No email sent — dedup key exists
+    # No email sent — this admin's dedup key exists
+    mock_ses.send_capacity_warning_email.assert_not_called()
     mock_redis.setex.assert_not_called()
     mock_db.close.assert_called_once()
+
+  @patch("robosystems.operations.aws.ses.ses_service")
+  @patch("robosystems.config.valkey_registry.create_redis_client")
+  @patch(
+    "robosystems.middleware.graph.ingestion_limits.IngestionLimitChecker.check_instance_storage"
+  )
+  @patch("robosystems.database.session")
+  def test_partial_delivery_retries_only_the_failed_admin(
+    self,
+    mock_session_factory,
+    mock_check_storage,
+    mock_redis_factory,
+    mock_ses,
+  ):
+    """One admin's send fails: only the delivered admin gets a dedup key, so
+    the next tick skips them and retries the failed one — instead of a
+    single graph-level key silencing the failed admin for the whole TTL."""
+    mock_db = MagicMock()
+    mock_session_factory.return_value = mock_db
+    mock_db.query.return_value.filter.return_value.all.return_value = [_make_graph()]
+    mock_check_storage.return_value = {
+      "total_storage_gb": 17.0,
+      "limit_gb": 20.0,
+      "usage_percentage": 85.0,
+      "status": "approaching",
+      "databases": [],
+    }
+    admin_a, admin_b = (
+      _admin("usr_a", "a@example.com"),
+      _admin("usr_b", "b@example.com"),
+    )
+
+    # Tick 1: nobody alerted yet; delivery to B fails.
+    mock_redis = MagicMock()
+    mock_redis_factory.return_value = mock_redis
+    mock_redis.exists.return_value = False
+    mock_ses.send_capacity_warning_email = AsyncMock(side_effect=[True, False])
+
+    with patch(RECIPIENTS, return_value=[admin_a, admin_b]):
+      graph_usage_monitor_sensor(build_sensor_context())
+
+    assert [c[0][0] for c in mock_redis.setex.call_args_list] == [
+      "usage_alert:kg_test123:approaching:usr_a"
+    ]
+
+    # Tick 2: A's key exists, B's does not — only B is emailed.
+    mock_redis.reset_mock()
+    mock_redis.exists.side_effect = lambda key: key.endswith(":usr_a")
+    mock_ses.send_capacity_warning_email = AsyncMock(return_value=True)
+
+    with patch(RECIPIENTS, return_value=[admin_a, admin_b]):
+      graph_usage_monitor_sensor(build_sensor_context())
+
+    sent_to = [
+      c.kwargs["user_email"]
+      for c in mock_ses.send_capacity_warning_email.call_args_list
+    ]
+    assert sent_to == ["b@example.com"]
+    assert [c[0][0] for c in mock_redis.setex.call_args_list] == [
+      "usage_alert:kg_test123:approaching:usr_b"
+    ]
 
   @patch("robosystems.config.valkey_registry.create_redis_client")
   @patch(

--- a/tests/db/test_demo_reset_guard.py
+++ b/tests/db/test_demo_reset_guard.py
@@ -1,0 +1,76 @@
+"""The demos' direct-DB reset must prove the database is local before deleting.
+
+`examples/_common/local_db.assert_local_extensions_db` is the one guard in
+front of every demo `_reset` module. The API-URL check in the demos is not
+enough on its own: an SSM tunnel makes production RDS answer on
+`localhost:5432`, exactly where the local URL points.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from examples._common.local_db import (
+  NonLocalDatabaseError,
+  assert_local_extensions_db,
+)
+
+MOD = "examples._common.local_db"
+URL_ACCESSOR = "robosystems.db.extensions.get_extensions_database_url"
+
+
+def _engine_answering(rdsadmin_present: bool):
+  engine = MagicMock()
+  conn = engine.connect.return_value.__enter__.return_value
+  conn.execute.return_value.first.return_value = (1,) if rdsadmin_present else None
+  return engine
+
+
+@pytest.mark.unit
+def test_local_host_and_plain_postgres_passes():
+  engine = _engine_answering(rdsadmin_present=False)
+  with (
+    patch(
+      URL_ACCESSOR,
+      return_value="postgresql://postgres:postgres@localhost:5432/extensions",
+    ),
+    patch(f"{MOD}.create_engine", return_value=engine),
+  ):
+    assert_local_extensions_db()
+  engine.dispose.assert_called_once()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+  "url",
+  [
+    "postgresql://postgres:x@robosystems-prod.cluster-abc.us-east-1.rds.amazonaws.com:5432/extensions",
+    "postgresql://postgres:x@10.0.4.12:5432/extensions",
+    "postgresql://postgres:x@extensions.internal:5432/extensions",
+  ],
+)
+def test_non_local_host_is_refused_before_connecting(url):
+  with (
+    patch(URL_ACCESSOR, return_value=url),
+    patch(f"{MOD}.create_engine") as create_engine,
+  ):
+    with pytest.raises(NonLocalDatabaseError, match="not a local Postgres"):
+      assert_local_extensions_db()
+  create_engine.assert_not_called()
+
+
+@pytest.mark.unit
+def test_tunnelled_rds_on_localhost_is_refused():
+  """The scenario that motivates the guard: a local-looking URL whose other
+  end is RDS. The host check passes; the database itself gives it away."""
+  engine = _engine_answering(rdsadmin_present=True)
+  with (
+    patch(
+      URL_ACCESSOR,
+      return_value="postgresql://postgres:postgres@127.0.0.1:5432/extensions",
+    ),
+    patch(f"{MOD}.create_engine", return_value=engine),
+  ):
+    with pytest.raises(NonLocalDatabaseError, match="Amazon RDS"):
+      assert_local_extensions_db()
+  engine.dispose.assert_called_once()

--- a/tests/middleware/graph/test_statement_kernel.py
+++ b/tests/middleware/graph/test_statement_kernel.py
@@ -158,6 +158,39 @@ def test_opaque_statement_call_blocked_on_main_graph_read():
   assert "passed as a string" in e.value.detail
 
 
+def test_quoted_procedure_name_blocked_end_to_end_for_subgraph_writer():
+  """Unmocked analyzer: ``CALL `GQL`(...)`` must be refused for the one
+  caller every other gate lets through — a subgraph member with write
+  access. The engine resolves the quoted name to the same procedure, and
+  the analyzer masks it before any name check, so only a refuse-the-shape
+  rule closes this; the test pins that the kernel actually gets it."""
+  with (
+    patch(f"{MOD}.parse_subgraph_id", return_value=object()),
+    patch(
+      f"{MOD}.MultiTenantUtils.is_shared_repository_or_subgraph",
+      return_value=False,
+    ),
+    patch(
+      "robosystems.models.core.graph.graph_user.GraphUser.user_has_write_access",
+      return_value=True,
+    ),
+  ):
+    with pytest.raises(HTTPException) as e:
+      _authorize(
+        "kg1234567890abcdef_dev",
+        "CALL `GQL`('CREATE NODE TABLE Evil(id INT64, PRIMARY KEY(id))')",
+      )
+    # And the bare, unquoted form is refused the same way.
+    with pytest.raises(HTTPException) as e2:
+      _authorize(
+        "kg1234567890abcdef_dev",
+        "CALL GQL('CREATE NODE TABLE Evil(id INT64, PRIMARY KEY(id))')",
+      )
+  assert e.value.status_code == 403
+  assert "quoted" in e.value.detail
+  assert e2.value.status_code == 403
+
+
 def _authorize_sql(graph_id, statement="SELECT 1"):
   return statement_kernel.authorize(
     engine=StatementEngine.SQL,

--- a/tests/middleware/mcp/test_subgraph_write_tools.py
+++ b/tests/middleware/mcp/test_subgraph_write_tools.py
@@ -139,6 +139,17 @@ class TestValidateWriteQuery:
     assert "CALL GQL" in result
 
   @pytest.mark.unit
+  def test_quoted_procedure_name_blocked(self):
+    """A backtick-quoted CALL target resolves to the same procedure in the
+    engine but is masked before the analyzer reads the name — the tool
+    refuses the quoted shape rather than trusting a name it cannot see."""
+    result = _validate_write_query(
+      "CALL `GQL`('CREATE NODE TABLE Evil(id INT64, PRIMARY KEY(id))')"
+    )
+    assert result is not None
+    assert "quoted procedure name" in result
+
+  @pytest.mark.unit
   def test_load_csv_blocked(self):
     result = _validate_write_query("LOAD CSV FROM 'file.csv' AS row CREATE (n:Foo)")
     assert result is not None

--- a/tests/operations/graph/test_infrastructure.py
+++ b/tests/operations/graph/test_infrastructure.py
@@ -388,6 +388,38 @@ class TestCleanupStaleGraphs:
     assert metric["MetricData"][0]["Value"] == 1
 
   @pytest.mark.unit
+  def test_instance_registry_scan_is_paginated(self, monitor):
+    """An instance on the second page of the instance scan is still valid.
+    Without pagination every graph on a later-page instance would be stamped
+    orphaned and the sweep would raise the very alarm it feeds."""
+    graph_table = _make_dynamo_table(
+      items=[
+        {"graph_id": "kg_p2", "status": "active", "instance_id": "i-onpagetwo000001"},
+      ]
+    )
+    instance_table = MagicMock()
+    instance_table.scan.side_effect = [
+      {"Items": [{"instance_id": "i-onpageone000001"}], "LastEvaluatedKey": {"k": 1}},
+      {"Items": [{"instance_id": "i-onpagetwo000001"}]},
+    ]
+
+    def table_router(name):
+      if name == "test-graph":
+        return graph_table
+      if name == "test-instance":
+        return instance_table
+      return _make_dynamo_table()
+
+    monitor._dynamodb.Table.side_effect = table_router
+
+    result = monitor.cleanup_stale_graphs()
+
+    assert instance_table.scan.call_count == 2
+    assert instance_table.scan.call_args_list[1].kwargs["ExclusiveStartKey"] == {"k": 1}
+    assert result.orphaned_count == 0
+    graph_table.update_item.assert_not_called()
+
+  @pytest.mark.unit
   def test_already_marked_orphan_is_counted_not_restamped(self, monitor):
     graph_table = _make_dynamo_table(
       items=[

--- a/tests/operations/roboledger/views/test_financial_statement_query.py
+++ b/tests/operations/roboledger/views/test_financial_statement_query.py
@@ -3,7 +3,7 @@
 Verifies Cypher construction for:
 - report_id fast path vs ticker fallback path
 - period_type filters (annual/quarterly/instant + balance-sheet default)
-- dedup keeps first occurrence per (qname, end_date)
+- dedup keeps first occurrence per full period identity (qname, start, end, type, bucket)
 - input validation (at least one of report_id / ticker)
 """
 
@@ -110,6 +110,25 @@ class TestQueryFinancialStatement:
 
   @pytest.mark.asyncio
   @pytest.mark.unit
+  async def test_projects_the_full_period_identity(self, mock_repository):
+    """start_date must be projected or the dedup key cannot see it."""
+    with patch(
+      "robosystems.operations.roboledger.views.financial_statement_query.get_graph_repository",
+      return_value=mock_repository,
+    ):
+      await query_financial_statement(
+        MOCK_GRAPH, statement_type="income_statement", ticker="NVDA"
+      )
+    query, _ = mock_repository.execute_query.call_args[0]
+    for col in (
+      "p.start_date AS start_date",
+      "p.end_date AS end_date",
+      "p.duration_type AS duration_type",
+    ):
+      assert col in query
+
+  @pytest.mark.asyncio
+  @pytest.mark.unit
   async def test_annual_period_filter(self, mock_repository):
     with patch(
       "robosystems.operations.roboledger.views.financial_statement_query.get_graph_repository",
@@ -160,6 +179,95 @@ class TestDeduplicateFacts:
       if r["qname"] == "us-gaap:Assets" and r["end_date"] == "2025-12-31"
     )
     assert assets_2025["value"] == 100
+
+  @pytest.mark.unit
+  def test_q4_and_fy_sharing_an_end_date_both_survive(self):
+    """The 2026-08-14 case: same qname and end_date, different duration_type."""
+    rows = [
+      {
+        "qname": "us-gaap:Revenues",
+        "start_date": "2024-02-01",
+        "end_date": "2025-01-31",
+        "period_type": "duration",
+        "duration_type": "annual",
+        "value": 400,
+      },
+      {
+        "qname": "us-gaap:Revenues",
+        "start_date": "2024-11-01",
+        "end_date": "2025-01-31",
+        "period_type": "duration",
+        "duration_type": "quarterly",
+        "value": 100,
+      },
+    ]
+    assert [r["value"] for r in deduplicate_facts(rows)] == [400, 100]
+
+  @pytest.mark.unit
+  def test_distinct_periods_within_one_duration_bucket_both_survive(self):
+    """duration_type is a coarse bucket. Two periods that share qname,
+    end_date, period_type AND bucket but start on different days are still
+    two facts — a two-month and a five-month stub both classified ``other``,
+    or a 52- and a 53-week year with one fiscal year end. Only start_date
+    tells them apart, so it has to be in the key."""
+    rows = [
+      {
+        "qname": "us-gaap:Revenues",
+        "start_date": "2024-11-01",
+        "end_date": "2024-12-31",
+        "period_type": "duration",
+        "duration_type": "other",
+        "value": 20,
+      },
+      {
+        "qname": "us-gaap:Revenues",
+        "start_date": "2024-08-01",
+        "end_date": "2024-12-31",
+        "period_type": "duration",
+        "duration_type": "other",
+        "value": 50,
+      },
+      {
+        "qname": "us-gaap:Revenues",
+        "start_date": "2024-01-01",
+        "end_date": "2024-12-31",
+        "period_type": "duration",
+        "duration_type": "annual",
+        "value": 120,
+      },
+      {
+        "qname": "us-gaap:Revenues",
+        "start_date": "2023-12-31",
+        "end_date": "2024-12-31",
+        "period_type": "duration",
+        "duration_type": "annual",
+        "value": 121,
+      },
+    ]
+    assert [r["value"] for r in deduplicate_facts(rows)] == [20, 50, 120, 121]
+
+  @pytest.mark.unit
+  def test_same_period_from_two_filings_still_collapses(self):
+    """The dedup's actual job: one period reported twice keeps the first row."""
+    rows = [
+      {
+        "qname": "us-gaap:Assets",
+        "start_date": None,
+        "end_date": "2024-12-31",
+        "period_type": "instant",
+        "duration_type": None,
+        "value": 100,
+      },
+      {
+        "qname": "us-gaap:Assets",
+        "start_date": None,
+        "end_date": "2024-12-31",
+        "period_type": "instant",
+        "duration_type": None,
+        "value": 101,
+      },
+    ]
+    assert [r["value"] for r in deduplicate_facts(rows)] == [100]
 
   @pytest.mark.unit
   def test_empty_input(self):

--- a/tests/routers/graphs/test_usage.py
+++ b/tests/routers/graphs/test_usage.py
@@ -410,6 +410,44 @@ class TestGetGraphUsageAnalytics:
     assert result.recent_events == []
 
   @pytest.mark.asyncio
+  async def test_recent_events_include_graph_storage_snapshots(self):
+    """Storage snapshots are recorded under the usage monitor's system
+    principal, not a member — so the events query must admit them by event
+    type alongside the caller's own rows, or no user ever sees one."""
+    mock_db = Mock()
+    mock_query = Mock()
+    mock_query.filter.return_value = mock_query
+    mock_query.order_by.return_value = mock_query
+    mock_query.limit.return_value = mock_query
+    mock_query.all.return_value = []
+    mock_db.query.return_value = mock_query
+
+    cb_patch, tc_patch, ol_patch, rm_patch = _patch_robustness()
+
+    with cb_patch, tc_patch, ol_patch, rm_patch:
+      result = await get_graph_usage(
+        graph_id="kg01234567890abcdef",
+        time_range="30d",
+        include_storage=False,
+        include_credits=False,
+        include_performance=False,
+        include_events=True,
+        current_user=_make_mock_user(),
+        db=mock_db,
+        _rate_limit=None,
+      )
+
+    assert result.recent_events == []
+    clauses = [
+      str(c.compile(compile_kwargs={"literal_binds": True}))
+      for c in mock_query.filter.call_args[0]
+    ]
+    or_clauses = [c for c in clauses if " OR " in c]
+    assert len(or_clauses) == 1, clauses
+    assert "user_id" in or_clauses[0]
+    assert "storage_snapshot" in or_clauses[0]
+
+  @pytest.mark.asyncio
   async def test_timeout_returns_504(self):
     """Test timeout handling in usage analytics."""
     cb_patch, tc_patch, ol_patch, rm_patch = _patch_robustness()

--- a/tests/security/test_cypher_analyzer.py
+++ b/tests/security/test_cypher_analyzer.py
@@ -328,10 +328,40 @@ class TestHasOpaqueStatementCall:
       assert analyzer.is_admin_operation(q) is False
       assert analyzer.has_opaque_statement_call(q) is True
 
+  @pytest.mark.parametrize(
+    "query",
+    [
+      "CALL `GQL`('CREATE NODE TABLE Evil(id INT64, PRIMARY KEY(id))')",
+      "CALL `gql`('INSTALL httpfs')",
+      "call `Gql` ('COPY Evil FROM \"/etc/passwd\"') RETURN *",
+      # Any quoted target, not just the known opaque names: the analyzer
+      # cannot see through the mask, so it must not vouch for the name.
+      "CALL `show_tables`() RETURN *",
+      "MATCH (n) RETURN n; CALL `whatever`('x')",
+    ],
+  )
+  def test_quoted_call_targets_are_refused(self, analyzer, query):
+    """The engine resolves a backtick-quoted procedure name to the same
+    procedure as the bare name, but the classifier masks quoted identifiers
+    before it looks at the CALL target — so a name-based deny would be
+    evadable by quoting. Refuse the shape outright."""
+    assert analyzer.has_opaque_statement_call(query) is True
+
+  def test_quoted_identifiers_elsewhere_are_not_call_targets(self, analyzer):
+    """Quoting is only a problem *as the CALL target*. Backtick identifiers
+    in patterns, property access, and aliases stay ordinary."""
+    for q in [
+      "MATCH (n:`Fact`) RETURN n.`value` AS `v`",
+      "CALL show_tables() RETURN `name`",
+      "MATCH (`n`) WHERE `n`.x = 1 RETURN `n`",
+    ]:
+      assert analyzer.has_opaque_statement_call(q) is False
+
   def test_module_level_wrapper(self):
     from robosystems.security.cypher_analyzer import has_opaque_statement_call
 
     assert has_opaque_statement_call("CALL GQL('MATCH (n) RETURN n')") is True
+    assert has_opaque_statement_call("CALL `GQL`('MATCH (n) RETURN n')") is True
     assert has_opaque_statement_call("MATCH (n) RETURN n") is False
 
 


### PR DESCRIPTION
Five small fixes out of the post-sprint review of \`v1.8.8..main\`, each with tests, before the \`v1.9.0\` tag. Nothing here changes an API shape.

- **Query surfaces refuse a quoted procedure name** the same way they refuse opaque statement calls (analyzer masks quoted identifiers before name checks; a name it cannot see is not one it can vouch for). Regression tests through the analyzer, the kernel (unmocked), and the MCP write guard. The write gate was never bypassable this way — unknown CALLs already fail closed.
- **Rapid-disk-growth alarm can now fire**: \`RATE()\` is per second and was compared against a per-minute threshold, so it could never breach; now \`DIFF()\` per 30-minute period vs 10 points. \`cfn-lint\` + \`validate-template\` clean. (\`graph-volumes\` is already in the 1.9.0 deploy list.)
- **Capacity emails dedup per recipient**, set only on a successful send, so one delivered admin no longer silences the ones whose send failed for the whole TTL. Partial-delivery test added.
- **Storage snapshots visible in \`recent_events\`** for every member — they're recorded under the monitor's system principal, which the user-only filter hid.
- **Demo resets verify the database is local** (URL host + not-RDS via the \`rdsadmin\` role) before any raw DELETE — the API-URL check alone said nothing about the database, and with a tunnel open \`localhost:5432\` is production.

Release notes updated for all five. Not taken from the review: the checkout-gate reservation point (known — recorded in the commerce README as the open write-off decision) and two ruff notes that don't reproduce on the pinned toolchain.

**Second review pass (added):**
- `financial-statement-analysis` dedups on the full period identity — `start_date` projected, keyed, and surfaced (additive `AnalyticalStatementFactRow.start_date` + the MCP row); `duration_type` alone is a coarse bucket, so two periods differing only in start date still collapsed. Regression tests for the Q4/FY, same-bucket, and same-period-twice cases.
- Dropped the unread `sibling_subgraphs` manifest field (base + SEC).
- The registry sweep now paginates the instance-registry scan as it already did the graph scan, with a two-page test.