### PR TITLE
chore(ci): review every org-authored PR automatically

### DIFF
--- a/.claude/commands/create-pr.md
+++ b/.claude/commands/create-pr.md
@@ -76,15 +76,22 @@ gh pr create \
 
 Print the resulting PR URL.
 
-### 5. Optional Claude review
+### 5. Request the Claude review — always
 
-Only if the user explicitly asks (e.g. passes `review` / `--review` in arguments), request a review:
+Every pull request gets a `@claude` review. This is a change-management control, not a convenience: this is a single-maintainer repository where GitHub forbids self-approval, so an automated second reader on every change is the compensating control that stands in for independent human review. Skipping it on a given PR puts a hole in the control.
 
 ```bash
 gh pr comment <number> --body "@claude please review this PR"
 ```
 
-Otherwise leave it off — the description is now accurate, and the user can run `/pr-review` locally (full context) or `@claude` manually when ready. Do not request review by default.
+Post it unconditionally, immediately after creating the PR. Do not ask first, and do not skip it for small or mechanical changes — a control that only runs on changes deemed interesting is not a control.
+
+Two things this is **not**:
+
+- **Not an approval.** The review posts as a comment from `claude[bot]`, not as an approving review, and it must stay that way. An unconditional bot approval on every PR is a rubber stamp, and it would be worse evidence than the documented exception it replaced. The reviewer's job is to find problems, not to sign off.
+- **Not a substitute for `/pr-review`.** That command runs locally with full session context and is the deeper pass. This is the standing automatic one.
+
+If the workflow does not fire (it is gated to `OWNER`/`MEMBER`/`COLLABORATOR` authors, so fork PRs are excluded by design), say so in the output rather than silently moving on.
 
 ## Output
 
@@ -93,14 +100,15 @@ After creating the PR, report:
 1. The PR URL.
 2. A one-line summary of the title.
 3. Target ← source branches.
-4. Whether a Claude review was requested.
+4. Confirmation that the `@claude` review was requested — or, if it wasn't, why.
 
 ## Arguments
 
 `$ARGUMENTS` may contain:
 
 - A target branch (default `main`).
-- `review` / `--review` to auto-request a `@claude` review.
 - Freeform guidance on what to emphasize in the description.
+
+`review` / `--review` is accepted and ignored — the review is now unconditional (§5).
 
 $ARGUMENTS

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,6 +1,8 @@
 name: Claude Code Review
 
 on:
+  pull_request:
+    types: [opened, ready_for_review]
   issue_comment:
     types: [created]
   pull_request_review_comment:
@@ -9,6 +11,12 @@ on:
     types: [opened, assigned]
   pull_request_review:
     types: [submitted]
+
+# One review per PR at a time. A rapid draft→ready→draft toggle would otherwise
+# stack runs and burn Claude usage on states nobody is waiting for.
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   check-runner-availability:
@@ -37,7 +45,20 @@ jobs:
     # only run when the triggering actor is a repo OWNER/MEMBER/COLLABORATOR, so a
     # drive-by comment/issue from an outside account cannot invoke Claude with
     # repo secrets in scope (this repo is public).
+    #
+    # The pull_request arm runs a review automatically on every PR opened by an
+    # org member — the compensating control for CC8.1, since a sole maintainer
+    # cannot approve their own PR (see the change management control evidence).
+    # It is gated twice against outside contributors draining Claude usage: the
+    # head-repo check rejects every fork PR outright, and author_association
+    # rejects CONTRIBUTOR/NONE. This is `pull_request`, never
+    # `pull_request_target`, so a fork PR carries no secrets even if it ran.
     if: |
+      (
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
+      ) ||
       (
         github.event_name == 'issue_comment' &&
         contains(github.event.comment.body, '@claude') &&
@@ -83,8 +104,15 @@ jobs:
           additional_permissions: |
             actions: read
 
-          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
-          # prompt: 'Update the pull request description to include a summary of changes.'
+          # On the automatic pull_request trigger there is no comment to act on,
+          # so supply the review brief. Left empty for comment-driven events so
+          # Claude follows the instructions in the comment that tagged it.
+          #
+          # Deliberately does NOT approve: org policy sets
+          # can_approve_pull_request_reviews=false, and an unconditional bot
+          # approval on every PR is a rubber stamp — worse audit evidence than
+          # the documented exception it would replace.
+          prompt: ${{ github.event_name == 'pull_request' && 'Review this pull request. This repository is public and is maintained by a single engineer who cannot approve their own PRs, so this review is the compensating change-management control — be substantive rather than cursory. Focus on correctness bugs, multi-tenancy (graph operations must stay scoped to graph_id), security of any auth or write path, and whether the PR description matches the diff. Post your findings as a comment. Do not approve the pull request.' || '' }}
 
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md


### PR DESCRIPTION
## Summary

Every pull request opened by an org member now gets an automatic Claude review. This is the compensating change-management control for SOC 2 CC8.1: a sole maintainer cannot approve their own pull request — GitHub forbids self-approval — so an automatic second reader stands in for independent review.

`/create-pr` previously requested the review only when asked. That is now unconditional, but the slash command alone was never sufficient as a control: it only covers PRs opened through it, and a control that runs when someone remembers to invoke it is not a control. The workflow trigger is the enforcement point.

## Changes

**`.github/workflows/claude.yml`**
- Added a `pull_request` trigger on `[opened, ready_for_review]`. Deliberately not `synchronize` — every push to an open PR would re-run the review.
- Added a `pull_request` arm to the job gate, guarded twice against outside contributors: `head.repo.full_name == github.repository` rejects fork PRs outright, and `author_association` restricts to `OWNER`/`MEMBER`/`COLLABORATOR`. Stays on `pull_request` rather than `pull_request_target`, so a fork PR carries no secrets regardless.
- Added a `concurrency` group keyed on the PR number with `cancel-in-progress`, so a draft/ready toggle cannot stack runs.
- Added a conditional `prompt` supplying the review brief on the automatic trigger, left empty for comment-driven events so Claude still follows the comment that tagged it. The brief instructs it to post findings as a comment and **not** to approve.

**`.claude/commands/create-pr.md`**
- §5 changed from opt-in to unconditional, framed as a control rather than a convenience, with explicit instruction not to skip it on small or mechanical changes.
- `review` / `--review` is now accepted and ignored.

## Breaking Changes

None.

## Testing

Workflow YAML validated by parsing with `yaml.safe_load` and asserting the trigger set, gate count, fork check, and concurrency block. Pre-commit hooks passed (`ruff check`, `ruff format --check`, `basedpyright`, `cf-lint-all`). The full test suite was not run — this change touches CI configuration and a slash-command definition only, no application code.

This PR is itself the first live exercise of the new trigger.

## Why not let it approve

Org policy already sets `can_approve_pull_request_reviews=false`. Beyond that, an unconditional bot approval on every PR is a rubber stamp — it would flip the Vanta `github-code-change-approved-or-justified` test green while producing worse audit evidence than the documented exception it replaced.
