### PR TITLE
docs(create-pr): note that workflow-editing PRs get no Claude review

### DIFF
--- a/.claude/commands/create-pr.md
+++ b/.claude/commands/create-pr.md
@@ -93,6 +93,10 @@ Two things this is **not**:
 
 If the workflow does not fire (it is gated to `OWNER`/`MEMBER`/`COLLABORATOR` authors, so fork PRs are excluded by design), say so in the output rather than silently moving on.
 
+**One expected exception — a PR that edits `.github/workflows/claude.yml` will not be reviewed.** `claude-code-action` refuses to run whenever the workflow file on the PR branch differs from the version on the default branch. That is an anti-tampering guard: without it, a pull request could rewrite the reviewer to exfiltrate secrets. The run still completes green and posts nothing, logging `Workflow validation failed... your workflow will begin working once you merge your PR`.
+
+This is normal, not a fault. Do not report it as a broken review, and do not go hunting for a misconfiguration — check whether the PR touches `claude.yml` first. It also means a change to the review workflow itself can never be validated by its own PR; it has to be merged and then exercised by the next unrelated PR.
+
 ## Output
 
 After creating the PR, report:


### PR DESCRIPTION
## Summary

Documents a behaviour of `claude-code-action` that looks exactly like a broken review: it refuses to run whenever `.github/workflows/claude.yml` on the PR branch differs from the version on the default branch. The run completes **green** and posts **nothing**.

That is an anti-tampering guard, not a fault — without it a pull request could rewrite the reviewer to exfiltrate secrets.

## Changes

**`.claude/commands/create-pr.md`** — added a note to §5 covering the exception, why it exists, and its consequence: a change to the review workflow can never be validated by its own PR, only by the next unrelated one.

## Breaking Changes

None. Documentation only, inside a slash-command definition.

## Testing

Not applicable — no code changed.

## Why this was worth writing down

Hit twice in one day while rolling the automatic review across all eleven repositories: once on the eleven PRs that introduced it, and again on a follow-up PR that only edited a *comment* in the same file. Both times a green checkmark plus a missing review read as a misconfiguration. The log line is explicit if you go looking for it, but the failure is silent at the PR level.

This PR deliberately does not touch `claude.yml`, so it also serves as the acceptance test the previous two attempts could not be.