### PR TITLE
fix(ci): grant the review workflow write access to post its comment

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -82,9 +82,15 @@ jobs:
     runs-on: ${{ fromJSON(needs.check-runner-availability.outputs.runner_config) }}
     timeout-minutes: 15
     permissions:
+      # contents stays READ on purpose: the reviewer reads the diff and comments.
+      # It must not be able to push commits or open branches on a public repo.
       contents: read
-      pull-requests: read
-      issues: read
+      # pull-requests + issues must be WRITE, not read: posting the review IS a
+      # write. With read the run completes green, burns tokens, and silently
+      # posts nothing (permission_denials_count > 0 in the execution result) —
+      # a control that looks healthy and produces no evidence.
+      pull-requests: write
+      issues: write
       actions: read # Required for Claude to read CI results on PRs
       id-token: write # Required: claude-code-action mints a GitHub OIDC token to
         # authenticate to GitHub (setupGitHubToken → getOidcToken), independent of


### PR DESCRIPTION
## Summary

The automatic PR review merged earlier today ran, read the diff, spent tokens — and posted nothing. The job declared `pull-requests: read` and `issues: read`, but **posting a comment is a write**.

Evidence from run `31915540230` on #1185: `"is_error": false`, `"num_turns": 6`, `"total_cost_usd": 0.21`, and `"permission_denials_count": 3`. The run concluded `success`.

## Changes

**`.github/workflows/claude.yml`**
- `pull-requests: read` → `write`
- `issues: read` → `write` (PR comments post through the issues API)
- `contents` deliberately left at `read` — the reviewer reads the diff and comments; it must not be able to push commits or create branches on a public repository.
- Added comments recording why, so nobody "tidies" these back down to read.

## Breaking Changes

None.

## Testing

Workflow YAML validated by parsing and asserting the resulting permissions map. Verified against the action's configuration documentation, which states `pull-requests: write` is required to post comments.

**This PR cannot verify itself** — it edits `claude.yml`, and the action refuses to run when the workflow differs from the default branch. Confirming the fix requires merging this, then opening any unrelated PR and checking for a `claude[bot]` comment.

## Why this matters beyond CI hygiene

This is the compensating change-management control for SOC 2 CC8.1. In its current state it is exactly the failure mode it was built to replace: a green checkmark over an inert control, indistinguishable from a working one unless you read the execution result. The control cannot be claimed as operating until a review comment actually appears.

Scoped to this repository first rather than all eleven, so the fix is proven before the permission grant is propagated.