### PR TITLE
fix(create-pr): stop requesting a review that now fires automatically

### DIFF
--- a/.claude/commands/create-pr.md
+++ b/.claude/commands/create-pr.md
@@ -76,15 +76,13 @@ gh pr create \
 
 Print the resulting PR URL.
 
-### 5. Request the Claude review — always
+### 5. The Claude review — automatic, do not request it
 
-Every pull request gets a `@claude` review. This is a change-management control, not a convenience: this is a single-maintainer repository where GitHub forbids self-approval, so an automated second reader on every change is the compensating control that stands in for independent human review. Skipping it on a given PR puts a hole in the control.
+Every pull request gets a `@claude` review. This is a change-management control, not a convenience: this is a single-maintainer repository where GitHub forbids self-approval, so an automated second reader on every change is the compensating control that stands in for independent human review.
 
-```bash
-gh pr comment <number> --body "@claude please review this PR"
-```
+**It fires on its own.** `.github/workflows/claude.yml` triggers on `pull_request` for `[opened, ready_for_review]`, so opening the PR is all it takes.
 
-Post it unconditionally, immediately after creating the PR. Do not ask first, and do not skip it for small or mechanical changes — a control that only runs on changes deemed interesting is not a control.
+**Do not post `@claude please review this PR`.** That was the old flow, and doing it now triggers a *second, independent* review on the `issue_comment` arm — two runs, two comments, twice the cost, for one PR. If a review is genuinely needed again (say after substantial new commits, since the workflow deliberately does not fire on `synchronize`), then post the comment — but as a considered re-review, never as routine.
 
 Two things this is **not**:
 
@@ -104,7 +102,7 @@ After creating the PR, report:
 1. The PR URL.
 2. A one-line summary of the title.
 3. Target ← source branches.
-4. Confirmation that the `@claude` review was requested — or, if it wasn't, why.
+4. That the automatic `@claude` review was triggered — or, if the PR edits `.github/workflows/claude.yml`, that it is expected not to run on this one (§5).
 
 ## Arguments
 


### PR DESCRIPTION
## Summary

`/create-pr` still posted `@claude please review this PR` after opening the PR. Now that `.github/workflows/claude.yml` triggers on `pull_request` `[opened, ready_for_review]`, that comment fires a **second, independent** run on the `issue_comment` arm — two reviews, two comments, twice the cost, for one pull request.

Self-inflicted: the review was made unconditional in the command before the workflow trigger existed. The trigger landed later and made the manual comment redundant rather than complementary.

## Changes

**`.claude/commands/create-pr.md`**
- §5 retitled "The Claude review — automatic, do not request it", and the `gh pr comment` step removed from the normal flow.
- Explains that opening the PR is sufficient, and that posting the comment anyway double-runs the reviewer.
- Keeps the manual comment documented as a **deliberate re-review** — the workflow intentionally does not fire on `synchronize`, so substantial new commits go unread unless someone asks.
- §Output: reports that the automatic review triggered, rather than that one was requested.

## Breaking Changes

None. Slash-command definition only.

## Testing

Not applicable — no code changed.

## Secondary purpose

This is the acceptance test for the permission fix in #1186. Two earlier attempts could not serve as one: the eleven rollout PRs and `robosystems-mcp-client#68` all edited `claude.yml`, which the action's anti-tampering guard blocks. This PR touches only the slash command, so the reviewer should run and — with `pull-requests: write` now on `main` — actually post.

If a `claude[bot]` comment appears here, the CC8.1 compensating control is demonstrated for the first time and the permission grant can be propagated to the remaining ten repositories.