### PR TITLE
revert(ci): drop the automatic PR review trigger, keep the author gate

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,8 +1,6 @@
 name: Claude Code Review
 
 on:
-  pull_request:
-    types: [opened, ready_for_review]
   issue_comment:
     types: [created]
   pull_request_review_comment:
@@ -11,12 +9,6 @@ on:
     types: [opened, assigned]
   pull_request_review:
     types: [submitted]
-
-# One review per PR at a time. A rapid draft→ready→draft toggle would otherwise
-# stack runs and burn Claude usage on states nobody is waiting for.
-concurrency:
-  group: claude-review-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
-  cancel-in-progress: true
 
 jobs:
   check-runner-availability:
@@ -45,20 +37,7 @@ jobs:
     # only run when the triggering actor is a repo OWNER/MEMBER/COLLABORATOR, so a
     # drive-by comment/issue from an outside account cannot invoke Claude with
     # repo secrets in scope (this repo is public).
-    #
-    # The pull_request arm runs a review automatically on every PR opened by an
-    # org member — the compensating control for CC8.1, since a sole maintainer
-    # cannot approve their own PR (see the change management control evidence).
-    # It is gated twice against outside contributors draining Claude usage: the
-    # head-repo check rejects every fork PR outright, and author_association
-    # rejects CONTRIBUTOR/NONE. This is `pull_request`, never
-    # `pull_request_target`, so a fork PR carries no secrets even if it ran.
     if: |
-      (
-        github.event_name == 'pull_request' &&
-        github.event.pull_request.head.repo.full_name == github.repository &&
-        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
-      ) ||
       (
         github.event_name == 'issue_comment' &&
         contains(github.event.comment.body, '@claude') &&
@@ -82,15 +61,9 @@ jobs:
     runs-on: ${{ fromJSON(needs.check-runner-availability.outputs.runner_config) }}
     timeout-minutes: 15
     permissions:
-      # contents stays READ on purpose: the reviewer reads the diff and comments.
-      # It must not be able to push commits or open branches on a public repo.
       contents: read
-      # pull-requests + issues must be WRITE, not read: posting the review IS a
-      # write. With read the run completes green, burns tokens, and silently
-      # posts nothing (permission_denials_count > 0 in the execution result) —
-      # a control that looks healthy and produces no evidence.
-      pull-requests: write
-      issues: write
+      pull-requests: read
+      issues: read
       actions: read # Required for Claude to read CI results on PRs
       id-token: write # Required: claude-code-action mints a GitHub OIDC token to
         # authenticate to GitHub (setupGitHubToken → getOidcToken), independent of
@@ -110,15 +83,8 @@ jobs:
           additional_permissions: |
             actions: read
 
-          # On the automatic pull_request trigger there is no comment to act on,
-          # so supply the review brief. Left empty for comment-driven events so
-          # Claude follows the instructions in the comment that tagged it.
-          #
-          # Deliberately does NOT approve: org policy sets
-          # can_approve_pull_request_reviews=false, and an unconditional bot
-          # approval on every PR is a rubber stamp — worse audit evidence than
-          # the documented exception it would replace.
-          prompt: ${{ github.event_name == 'pull_request' && 'Review this pull request. This repository is public and is maintained by a single engineer who cannot approve their own PRs, so this review is the compensating change-management control — be substantive rather than cursory. Focus on correctness bugs, multi-tenancy (graph operations must stay scoped to graph_id), security of any auth or write path, and whether the PR description matches the diff. Post your findings as a comment. Do not approve the pull request.' || '' }}
+          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
+          # prompt: 'Update the pull request description to include a summary of changes.'
 
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md


### PR DESCRIPTION
## Summary

Reverts the automatic PR review trigger added earlier today. It fired on every pull request and **never once posted a review**, while each run concluded `success` and cost $0.20–$1.12.

The comment-triggered path was never broken. `/create-pr` posts `@claude please review this PR` on every PR it opens, and that path demonstrably works. A working control invoked by the command beats a broken one wired to an event.

## What went wrong

Three obstacles, hit in sequence:

1. **Anti-tampering guard** — `claude-code-action` refuses to run when the workflow file on a PR branch differs from the default branch, so the rollout PRs could not test themselves.
2. **Token permissions** — the job declared `pull-requests: read`; posting a comment is a write. Fixed, and it was not the cause.
3. **Tool permission denials** — with the trigger live and write granted, a run still posted nothing: `num_turns: 33`, `total_cost_usd: 1.12`, `permission_denials_count: 15`. These are Claude Code's own tool-permission layer rather than GitHub rejections, and the root cause is unresolved.

## Changes

**`.github/workflows/claude.yml`**
- Removed the `pull_request` trigger.
- Removed the `concurrency` group. It existed to de-duplicate draft/ready toggles on that trigger; on comment-driven runs it would *cancel a legitimate in-progress review*, so it is actively wrong without the trigger.
- Removed the automation `prompt`, restoring the commented-out original.
- Restored `pull-requests` / `issues` to `read` (robosystems only — the repo where they were bumped).

## Kept deliberately

**The `author_association` gate stays.** Several of these workflows had no gate at all and would run for any commenter on a public repository — a real hole that predates today's work and is unrelated to the trigger. All four comment arms remain restricted to `OWNER`/`MEMBER`/`COLLABORATOR`.

## Breaking Changes

None. CI configuration only.

## Testing

Each workflow parsed with `yaml.safe_load` and asserted on: no `pull_request` trigger, no `concurrency` block, no `pull_request` arm in the job gate, no automation prompt, permissions at `read`, and the four author gates intact.
