### PR TITLE
refactor(auth): always target auth email links at the login home

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -226,8 +226,6 @@ SECURITY_AUDIT_ENABLED=false
 ## localhost (dev); set only to pin them explicitly
 # PASSKEY_RP_ID=
 # PASSKEY_ORIGIN=
-# Auth email links target the login home (with return_to) not the origin app
-# AUTH_EMAIL_LINKS_TO_LOGIN_HOME=false
 
 ## Organization
 # ORG_MEMBER_INVITATIONS_ENABLED=false

--- a/robosystems/config/env.py
+++ b/robosystems/config/env.py
@@ -551,12 +551,6 @@ class EnvConfig:
   # deployment's root domain); see get_passkey_rp_id/get_passkey_origin.
   PASSKEY_RP_ID = get_str_env("PASSKEY_RP_ID", "")
   PASSKEY_ORIGIN = get_str_env("PASSKEY_ORIGIN", "")
-  # When enabled, verification/reset/invitation email links target the login
-  # home instead of the originating app.
-  AUTH_EMAIL_LINKS_TO_LOGIN_HOME = get_bool_env(
-    "AUTH_EMAIL_LINKS_TO_LOGIN_HOME",
-    get_parameter_value("AUTH_EMAIL_LINKS_TO_LOGIN_HOME", "false").lower() == "true",
-  )
 
   # --- Organization ---
   ORG_MEMBER_INVITATIONS_ENABLED = get_bool_env(

--- a/robosystems/operations/aws/ses.py
+++ b/robosystems/operations/aws/ses.py
@@ -124,15 +124,18 @@ class SESEmailService:
   def _auth_link_parts(self, app: str) -> tuple[str, str]:
     """Base URL and return_to suffix for auth action links (verify/reset/invite).
 
-    When AUTH_EMAIL_LINKS_TO_LOGIN_HOME is on, auth links target the login
-    home and carry the originating app as return_to so the user is bridged
-    onward after the action. Email branding stays per-app either way.
+    Auth links always target the login home, carrying the originating app as
+    return_to so the user is bridged onward after the action. The product apps
+    render no interactive auth surface to land on — pointing an emailed link at
+    one only bounces the recipient to the login home anyway, a hop that can
+    strip the token. Email branding stays per-app.
+
+    A single-app deployment is its own login home, so this degrades to the
+    app's own URL with no suffix.
     """
-    if env.AUTH_EMAIL_LINKS_TO_LOGIN_HOME:
-      # The login home bridging back to itself is a no-op; skip the suffix.
-      suffix = "" if app == env.LOGIN_HOME_APP else f"&return_to={quote(app)}"
-      return self.login_home_url, suffix
-    return self.app_urls.get(app, self.app_urls[_DEFAULT_APP]), ""
+    # The login home bridging back to itself is a no-op; skip the suffix.
+    suffix = "" if app == env.LOGIN_HOME_APP else f"&return_to={quote(app)}"
+    return self.login_home_url, suffix
 
   def _get_email_template(
     self, email_type: str, template_data: dict[str, Any]

--- a/tests/operations/aws/test_ses.py
+++ b/tests/operations/aws/test_ses.py
@@ -413,7 +413,7 @@ class TestCapacityWarningEmail:
 
 
 class TestAuthLinkTargets:
-  """Auth action links honor AUTH_EMAIL_LINKS_TO_LOGIN_HOME."""
+  """Auth action links always target the login home."""
 
   def _html(self, mock_ses_client):
     return mock_ses_client.send_email.call_args.kwargs["Message"]["Body"]["Html"][
@@ -421,28 +421,10 @@ class TestAuthLinkTargets:
     ]
 
   @pytest.mark.asyncio
-  async def test_links_target_app_when_flag_off(self, ses_service, mock_ses_client):
-    mock_ses_client.send_email.return_value = {"MessageId": "msg-1"}
-
-    with patch.object(env, "AUTH_EMAIL_LINKS_TO_LOGIN_HOME", False):
-      await ses_service.send_verification_email(
-        user_email="test@example.com",
-        user_name="Test",
-        token="tok1",
-        app="roboledger",
-      )
-
-    html = self._html(mock_ses_client)
-    assert "https://roboledger.ai/auth/verify-email?token=tok1" in html
-    assert "return_to" not in html
-
-  @pytest.mark.asyncio
-  async def test_auth_links_target_login_home_when_flag_on(
-    self, ses_service, mock_ses_client
-  ):
+  async def test_auth_links_target_login_home(self, ses_service, mock_ses_client):
     mock_ses_client.send_email.return_value = {"MessageId": "msg-2"}
 
-    with patch.object(env, "AUTH_EMAIL_LINKS_TO_LOGIN_HOME", True):
+    with patch.object(env, "LOGIN_HOME_APP", "robosystems"):
       await ses_service.send_verification_email(
         user_email="test@example.com",
         user_name="Test",
@@ -481,15 +463,36 @@ class TestAuthLinkTargets:
       assert "return_to=roboledger" in html
 
   @pytest.mark.asyncio
-  async def test_welcome_link_unaffected_by_flag(self, ses_service, mock_ses_client):
-    mock_ses_client.send_email.return_value = {"MessageId": "msg-5"}
+  async def test_login_home_link_carries_no_return_to(
+    self, ses_service, mock_ses_client
+  ):
+    """A single-app deployment is its own login home — no bridge hop to add."""
+    mock_ses_client.send_email.return_value = {"MessageId": "msg-1"}
 
-    with patch.object(env, "AUTH_EMAIL_LINKS_TO_LOGIN_HOME", True):
-      await ses_service.send_welcome_email(
+    with patch.object(env, "LOGIN_HOME_APP", "robosystems"):
+      await ses_service.send_verification_email(
         user_email="test@example.com",
         user_name="Test",
-        app="roboledger",
+        token="tok1",
+        app="robosystems",
       )
+
+    html = self._html(mock_ses_client)
+    assert "https://robosystems.ai/auth/verify-email?token=tok1" in html
+    assert "return_to" not in html
+
+  @pytest.mark.asyncio
+  async def test_welcome_link_targets_the_originating_app(
+    self, ses_service, mock_ses_client
+  ):
+    """Welcome is not an auth action — it lands in the app the user signed up for."""
+    mock_ses_client.send_email.return_value = {"MessageId": "msg-5"}
+
+    await ses_service.send_welcome_email(
+      user_email="test@example.com",
+      user_name="Test",
+      app="roboledger",
+    )
 
     html = self._html(mock_ses_client)
     assert "https://roboledger.ai/home" in html


### PR DESCRIPTION
Retires `AUTH_EMAIL_LINKS_TO_LOGIN_HOME`, the rollout flag controlling whether verification / password-reset / org-invitation links point at the login home or at the originating product app.

## Why now

It has been `true` in prod since the centralized-login rollout, and its off-state is no longer coherent. The product apps render no interactive auth surface for an emailed link to land on — `roboledger.ai/login` and `/register` are pure redirectors, and RL#310 / RI#260 just removed the local-form fallback entirely. Pointing an emailed link at a product app now only bounces the recipient to the login home anyway, an extra hop that can strip the token.

This is the backend mirror of the frontend change that retired `NEXT_PUBLIC_CENTRALIZED_LOGIN`. Same underlying reason: interactive auth is centralized *by construction*, because the login home owns the WebAuthn Relying Party ID (`get_passkey_rp_id()` derives it from `ROBOSYSTEMS_URL`). A flag implying otherwise describes a configuration that cannot work.

## Behavior

Unchanged for every current deployment — prod already runs with the flag on.

A **single-app or self-hosted deployment** is its own login home, so `_auth_link_parts` degrades to that app's own URL with no `return_to` suffix. That path is now covered directly; previously only the flag-off branch exercised suffix-free links, so removing the flag would have dropped the coverage with it.

Welcome emails are untouched — not an auth action, still landing in the app the user signed up for. That's now asserted by name rather than as "unaffected by flag".

## Changes

- `config/env.py` — flag removed
- `operations/aws/ses.py` — `_auth_link_parts` unconditional
- `.env.example` — entry removed
- `tests/operations/aws/test_ses.py` — flag-off case reframed as the single-app case; `LOGIN_HOME_APP` pinned explicitly rather than leaning on the real module's default leaking through the fixture

## Tests

3,670 passed across `tests/operations` and `tests/routers/auth`; 513 in `tests/config`. Lint and format clean.