### PR TITLE
fix(auth): revoke cached grants together with the grant row

### DIFF
--- a/robosystems/middleware/auth/cache.py
+++ b/robosystems/middleware/auth/cache.py
@@ -856,6 +856,26 @@ class APIKeyCache:
       logger.error(f"Failed to invalidate JWT user data cache for {user_id}: {e}")
       return False
 
+  def _api_key_cache_keys(self, api_key_hash: str) -> list[str]:
+    """Every Redis key holding state for one API key: the validation entry,
+    its signature, and each cached per-graph access decision.
+
+    Revocation must drop all of them together. The per-graph entries are the
+    ones a partial sweep misses: ``validate_api_key_with_graph`` short-circuits
+    on a cached allow, so a surviving ``apikey_graph:`` entry keeps a revoked
+    key inside the graph until TTL even after the validation entry is gone.
+    """
+    api_key_cache_key = self._get_api_key_cache_key(api_key_hash)
+    signature_key = f"{self.CACHE_SIGNATURE_PREFIX}{api_key_hash}"
+
+    pattern = f"{self.GRAPH_CACHE_KEY_PREFIX}{api_key_hash}:*"
+    graph_keys = cast(list[str], self.redis.keys(pattern))
+
+    signature_pattern = f"{self.CACHE_SIGNATURE_PREFIX}graph_{api_key_hash}:*"
+    signature_keys = cast(list[str], self.redis.keys(signature_pattern))
+
+    return [api_key_cache_key, signature_key, *graph_keys, *signature_keys]
+
   def invalidate_api_key(self, api_key_hash: str) -> bool:
     """Drop every cached record for an API key: validation, signature, and
     per-graph access decisions. Returns True when the deletes took; False
@@ -863,16 +883,7 @@ class APIKeyCache:
     treat as incomplete.
     """
     try:
-      api_key_cache_key = self._get_api_key_cache_key(api_key_hash)
-      signature_key = f"{self.CACHE_SIGNATURE_PREFIX}{api_key_hash}"
-
-      pattern = f"{self.GRAPH_CACHE_KEY_PREFIX}{api_key_hash}:*"
-      graph_keys = cast(list[str], self.redis.keys(pattern))
-
-      signature_pattern = f"{self.CACHE_SIGNATURE_PREFIX}graph_{api_key_hash}:*"
-      signature_keys = cast(list[str], self.redis.keys(signature_pattern))
-
-      keys_to_delete = [api_key_cache_key, signature_key, *graph_keys, *signature_keys]
+      keys_to_delete = self._api_key_cache_keys(api_key_hash)
       if keys_to_delete:
         self.redis.delete(*keys_to_delete)
 
@@ -1021,11 +1032,12 @@ class APIKeyCache:
       logger.error(f"Failed to invalidate user graph access cache: {e}")
 
   def invalidate_user_data(self, user_id: str) -> None:
-    """Drop every cache entry embedding this user's profile.
+    """Drop every cache entry embedding this user's profile or grants.
 
     Covers the user-keyed JWT cache, any API key or JWT entry whose payload
-    names this user, and their JWT graph access. Call after a profile change
-    so no surface keeps serving the old record.
+    names this user (each API key's per-graph access decisions go with it),
+    and their JWT graph access. Call after a profile change or a grant
+    revocation so no surface keeps serving the old record.
     """
     try:
       invalidated_count = 0
@@ -1052,7 +1064,11 @@ class APIKeyCache:
               continue
             user_data = data.get("user_data", {})
             if user_data.get("id") == user_id:
-              self.redis.delete(key)
+              # Drop the key's per-graph access decisions along with the
+              # validation entry: a revoked grant is what brought us here,
+              # and a cached allow on that graph would outlive it.
+              api_key_hash = key[len(self.CACHE_KEY_PREFIX) :]
+              self.redis.delete(*self._api_key_cache_keys(api_key_hash))
               invalidated_count += 1
         except Exception as e:
           logger.error(f"Failed to check/invalidate API key cache {key}: {e}")

--- a/robosystems/models/core/user/user_repository.py
+++ b/robosystems/models/core/user/user_repository.py
@@ -260,6 +260,8 @@ class UserRepository(Model):
       session.rollback()
       raise
 
+    access.invalidate_access_cache()
+
     return access
 
   @classmethod
@@ -371,6 +373,31 @@ class UserRepository(Model):
     except SQLAlchemyError:
       session.rollback()
       raise
+
+    self.invalidate_access_cache()
+
+  def invalidate_access_cache(self) -> None:
+    """Drop the user's cached access decisions after this grant changes.
+
+    Both auth paths cache the allow/deny answer per graph for the TTL, so the
+    grant row is only authoritative once those entries are gone: a denial
+    recorded before the subscription existed would keep refusing a paying
+    subscriber, and an allow recorded before a revocation would keep admitting
+    a former one — the endpoint's ``immediate=true`` promise is only as good
+    as this call. Sweeps every entry the user owns rather than the one
+    repository, because a subgraph of the repository is cached under its own
+    id. Best-effort: the row has committed and the entries lapse on TTL.
+    """
+    try:
+      import importlib
+
+      cache_module = importlib.import_module("robosystems.middleware.auth.cache")
+      cache_module.api_key_cache.invalidate_user_data(str(self.user_id))
+    except Exception as e:
+      logger.warning(
+        f"Failed to invalidate access cache for user {self.user_id}, "
+        f"repository {self.repository_name}: {e}"
+      )
 
   def upgrade_tier(
     self,

--- a/robosystems/operations/admin/user_deletion.py
+++ b/robosystems/operations/admin/user_deletion.py
@@ -245,6 +245,43 @@ def plan_user_deletion(user_id: str, session: Session) -> UserDeletionPlan:
   )
 
 
+def _invalidate_auth_caches(user_id: str, api_key_fingerprints: list[str]) -> None:
+  """Evict everything that could still authenticate the deleted account.
+
+  A JWT is refused once its user row is gone, and an API key once its row is
+  gone — but only when the check reaches the database. Both paths are fronted
+  by a cache with a TTL of minutes, so without this sweep a deleted account
+  keeps authenticating from cache. Best-effort: a Redis failure is logged at
+  CRITICAL rather than raised, because the deletion has already committed and
+  the entries lapse on TTL.
+  """
+  import importlib
+
+  try:
+    cache_module = importlib.import_module("robosystems.middleware.auth.cache")
+    api_key_cache = cache_module.api_key_cache
+  except Exception as e:
+    logger.error(
+      f"CRITICAL: auth cache module unavailable after deleting user {user_id}; "
+      f"cached credentials survive until TTL: {e}"
+    )
+    return
+
+  cleared = True
+  for fingerprint in api_key_fingerprints:
+    cleared = bool(api_key_cache.invalidate_api_key(fingerprint)) and cleared
+  cleared = bool(api_key_cache.invalidate_jwt_user_data(user_id)) and cleared
+  cleared = bool(api_key_cache.invalidate_user_jwt_graph_access(user_id)) and cleared
+  # Catches any key entry the fingerprints could not address.
+  api_key_cache.invalidate_user_data(user_id)
+
+  if not cleared:
+    logger.error(
+      f"CRITICAL: auth cache invalidation incomplete after deleting user "
+      f"{user_id}; a cached credential may keep authenticating until TTL."
+    )
+
+
 def execute_user_deletion(
   user_id: str, session: Session, actor: str = "admin"
 ) -> UserDeletionPlan:
@@ -260,6 +297,19 @@ def execute_user_deletion(
   user = User.get_by_id(user_id, session)
   if not user:
     raise UserNotFound(f"User {user_id} not found")
+
+  # The bulk delete below bypasses UserAPIKey.delete(), which is where a key
+  # normally clears its own cache entry — and the fingerprint that addresses
+  # that entry dies with the row. Capture it now; the caches are purged after
+  # the commit so a request racing the deletion cannot re-populate them from
+  # a row that still exists.
+  api_key_fingerprints = [
+    row.key_fingerprint
+    for row in session.query(UserAPIKey.key_fingerprint)
+    .filter_by(user_id=user_id)
+    .all()
+    if row.key_fingerprint
+  ]
 
   # Audit and billing history survive the account — the actor is de-referenced,
   # never deleted, because retention is itself a compliance requirement.
@@ -328,6 +378,8 @@ def execute_user_deletion(
   except Exception:
     session.rollback()
     raise
+
+  _invalidate_auth_caches(user_id, api_key_fingerprints)
 
   logger.info(
     f"Deleted user {user_id} ({plan.email}) by {actor}",

--- a/robosystems/operations/billing/repository_subscriptions.py
+++ b/robosystems/operations/billing/repository_subscriptions.py
@@ -128,11 +128,19 @@ def cancel_user_repository_subscriptions(
   actor_user_id: str,
   reason: str = "org_offboarding",
 ) -> list[str]:
-  """Cancel every repository subscription a user still holds, immediately.
+  """Cancel every repository subscription a user still holds, immediately,
+  and revoke every repository grant they still hold — whether or not a live
+  subscription stands behind it.
 
   Used when a member is removed from the org: the org paid for that access
   because of the membership, so it ends with the membership rather than
   running to the period end on someone else's card.
+
+  The second sweep exists because a period-end cancellation moves the billing
+  row to a terminal status at once while deliberately leaving the grant alive
+  until ``expires_at``. Authorization reads the grant, not the billing row, so
+  a sweep keyed on live subscriptions alone would off-board the member and
+  leave them inside the repository until the period closed.
 
   Raises ProviderCancellationError if the provider refuses — the caller must
   abort rather than off-board a member the org keeps paying for.
@@ -151,5 +159,18 @@ def cancel_user_repository_subscriptions(
       reason=reason,
     )
     canceled.append(subscription.id)
+
+  for grant in UserRepository.get_user_repositories(user_id, session):
+    grant.revoke_access(session, reason=reason)
+    logger.info(
+      f"Revoked repository grant {grant.repository_name} for user {user_id} "
+      f"with no live subscription behind it",
+      extra={
+        "user_id": user_id,
+        "repository": grant.repository_name,
+        "actor_user_id": actor_user_id,
+        "reason": reason,
+      },
+    )
 
   return canceled

--- a/robosystems/operations/graph/repository_subscription_service.py
+++ b/robosystems/operations/graph/repository_subscription_service.py
@@ -52,31 +52,6 @@ def get_available_plans_for_repository(
   return list(manifest.plans.keys())
 
 
-def _invalidate_graph_access_cache(user_id: str, repository_name: str) -> None:
-  """Drop the cached API-key access decision for a repository.
-
-  ``validate_api_key_with_graph`` caches the allow/deny answer per API key and
-  graph, so a denial recorded before the subscription existed outlives the
-  grant for the whole TTL: the subscriber pays and is refused with a 403 until
-  it expires. The grant and revoke paths are the only moments the answer can
-  change, so both clear it here.
-
-  Best-effort by design — the cache repopulates from the database on the next
-  request, so a Redis failure costs a stale entry, not a broken grant, and must
-  not fail the provisioning that already committed.
-  """
-  try:
-    import importlib
-
-    cache_module = importlib.import_module("robosystems.middleware.auth.cache")
-    cache_module.api_key_cache.invalidate_user_graph_access(user_id, repository_name)
-  except Exception as e:
-    logger.warning(
-      f"Failed to invalidate graph access cache for user {user_id}, "
-      f"repository {repository_name}: {e}"
-    )
-
-
 class RepositorySubscriptionService:
   """Service for managing shared repository subscriptions and access."""
 
@@ -406,7 +381,7 @@ class RepositorySubscriptionService:
         existing.updated_at = datetime.now(UTC)
         self.session.commit()
         logger.info(f"Reactivated access for user {user_id}")
-        _invalidate_graph_access_cache(user_id, repository_type.value)
+        existing.invalidate_access_cache()
       return True
 
     if repository_plan is None:
@@ -444,8 +419,6 @@ class RepositorySubscriptionService:
       f"plan {repository_plan}"
     )
 
-    _invalidate_graph_access_cache(user_id, repository_type.value)
-
     return True
 
   def revoke_access(
@@ -473,7 +446,5 @@ class RepositorySubscriptionService:
     logger.info(
       f"Revoked access for user {user_id}, repository {repository_type.value}"
     )
-
-    _invalidate_graph_access_cache(user_id, repository_type.value)
 
     return True

--- a/tests/middleware/auth/test_cache_comprehensive.py
+++ b/tests/middleware/auth/test_cache_comprehensive.py
@@ -939,3 +939,43 @@ class TestInvalidateUserData:
     cache.invalidate_user_data(target)
 
     assert good in deleted, "a corrupt sibling entry aborted the sweep"
+
+  def test_purges_the_keys_per_graph_decisions_with_it(self, cache):
+    """A matched API-key entry takes its ``apikey_graph:`` decisions along.
+
+    ``validate_api_key_with_graph`` short-circuits on a cached allow, so a
+    surviving per-graph entry would keep a revoked key inside the graph for
+    the TTL after the validation entry was gone.
+    """
+    import fnmatch
+
+    target, other = "user_target", "user_other"
+    api_key = f"{cache.CACHE_KEY_PREFIX}hash_target"
+    api_key_other = f"{cache.CACHE_KEY_PREFIX}hash_other"
+    graph_target = f"{cache.GRAPH_CACHE_KEY_PREFIX}hash_target:kg1"
+    graph_target_2 = f"{cache.GRAPH_CACHE_KEY_PREFIX}hash_target:sec"
+    graph_other = f"{cache.GRAPH_CACHE_KEY_PREFIX}hash_other:kg1"
+
+    store = {
+      api_key: self._entry(cache, target),
+      api_key_other: self._entry(cache, other),
+      graph_target: '{"has_access": true}',
+      graph_target_2: '{"has_access": true}',
+      graph_other: '{"has_access": true}',
+    }
+
+    cache.redis.keys.side_effect = lambda pattern: [
+      k for k in store if fnmatch.fnmatchcase(k, pattern)
+    ]
+    cache.redis.get.side_effect = store.get
+
+    deleted: list[str] = []
+    cache.redis.delete.side_effect = lambda *keys: deleted.extend(keys)
+
+    cache.invalidate_user_data(target)
+
+    assert api_key in deleted
+    assert graph_target in deleted, "per-graph decision survived the sweep"
+    assert graph_target_2 in deleted, "per-graph decision survived the sweep"
+    assert api_key_other not in deleted
+    assert graph_other not in deleted

--- a/tests/operations/billing/test_repository_subscriptions.py
+++ b/tests/operations/billing/test_repository_subscriptions.py
@@ -140,6 +140,31 @@ class TestCancelAllForUser:
     assert subscription.status == "canceled"
     assert access.is_active is False
 
+  def test_offboarding_revokes_a_grant_left_by_a_period_end_cancel(
+    self, test_db, subscribed_member, test_user
+  ):
+    """A period-end cancel makes the billing row terminal at once but leaves
+    the grant alive to ``expires_at``. Off-boarding sweeps by live
+    subscription, so without a second pass the removed member kept access."""
+    member, subscription, access = subscribed_member
+
+    with patch(PROVIDER, return_value=MagicMock()):
+      cancel_repository_subscription(
+        subscription, session=test_db, actor_user_id=member.id
+      )
+    test_db.refresh(access)
+    assert access.is_active is True, "precondition"
+
+    with patch(PROVIDER, return_value=MagicMock()):
+      canceled = cancel_user_repository_subscriptions(
+        member.id, session=test_db, actor_user_id=test_user.id
+      )
+
+    assert canceled == [], "the billing row was already terminal"
+    test_db.refresh(access)
+    assert access.is_active is False
+    assert not UserRepository.user_has_access(member.id, "sec", test_db)
+
   def test_no_subscriptions_is_a_no_op(self, test_db, test_user):
     assert (
       cancel_user_repository_subscriptions(

--- a/tests/security/test_revocation_invariant.py
+++ b/tests/security/test_revocation_invariant.py
@@ -1,0 +1,390 @@
+"""The revocation invariant: after any revocation, nothing still authorizes.
+
+Every grant in the platform is fronted by an auth cache with a TTL of minutes,
+so a revocation is only real once both halves are gone — the grant row in the
+database and every cache entry that was derived from it. Three findings
+(spec: security/org-multi-user-hardening.md, the "revocation cluster") were
+each an instance of one half being withdrawn while the other kept authorizing.
+
+Each test below seeds the cache in the exact shape the production write paths
+produce, revokes through one of the platform's revocation surfaces, and then
+asserts the same thing: no grant row and no cache entry still authorizes the
+revoked user. The revocation surfaces are the ones the spec enumerates:
+
+- graph membership removal (router)
+- org membership removal, including the F15 grant a period-end cancel leaves
+  alive (router)
+- immediate repository-subscription cancellation (F8, operation)
+- administrative account deletion (F7, operation)
+"""
+
+from __future__ import annotations
+
+import fnmatch
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from robosystems.middleware.auth.cache import APIKeyCache
+from robosystems.models.core import (
+  BillingSubscription,
+  Graph,
+  GraphRole,
+  GraphUser,
+  Org,
+  OrgRole,
+  OrgType,
+  OrgUser,
+  User,
+  UserAPIKey,
+)
+from robosystems.models.core.user.user_repository import (
+  RepositoryAccessLevel,
+  RepositoryType,
+  UserRepository,
+)
+from robosystems.operations.admin import execute_user_deletion
+from robosystems.operations.billing import (
+  cancel_repository_subscription,
+  cancel_user_repository_subscriptions,
+)
+
+PROVIDER = "robosystems.operations.providers.payment_provider.get_payment_provider"
+
+pytestmark = pytest.mark.asyncio
+
+
+class FakeRedis:
+  """The subset of the Redis API the auth cache uses, over a dict."""
+
+  def __init__(self) -> None:
+    self.store: dict[str, str] = {}
+
+  def ping(self) -> bool:
+    return True
+
+  def keys(self, pattern: str) -> list[str]:
+    return [k for k in self.store if fnmatch.fnmatchcase(k, pattern)]
+
+  def get(self, key: str) -> str | None:
+    return self.store.get(key)
+
+  def setex(self, key: str, _ttl: int, value: str) -> None:
+    self.store[key] = value
+
+  def delete(self, *keys: str) -> int:
+    removed = 0
+    for key in keys:
+      if key in self.store:
+        del self.store[key]
+        removed += 1
+    return removed
+
+  def pipeline(self) -> FakePipeline:
+    return FakePipeline(self)
+
+
+class FakePipeline:
+  """Buffers commands and returns their results from ``execute``."""
+
+  def __init__(self, redis: FakeRedis) -> None:
+    self._redis = redis
+    self._results: list[object] = []
+
+  def get(self, key: str) -> None:
+    self._results.append(self._redis.get(key))
+
+  def setex(self, key: str, ttl: int, value: str) -> None:
+    self._results.append(self._redis.setex(key, ttl, value))
+
+  def execute(self) -> list[object]:
+    results, self._results = self._results, []
+    return results
+
+
+@pytest.fixture
+def cache():
+  """A real APIKeyCache over a fake Redis, installed everywhere the code
+  under test resolves the cache singleton — the operations and models go
+  through ``importlib`` to the module attribute, the routers bind it at
+  import time.
+  """
+  with patch("robosystems.middleware.auth.cache.redis.Redis"):
+    instance = APIKeyCache()
+  instance._redis = FakeRedis()
+  with (
+    patch("robosystems.middleware.auth.cache.api_key_cache", instance),
+    patch("robosystems.routers.graphs.members.api_key_cache", instance),
+    patch("robosystems.routers.orgs.members.api_key_cache", instance),
+  ):
+    yield instance
+
+
+def _create_user(session, password_hash: str) -> User:
+  user = User(
+    email=f"revoked+{uuid4().hex[:8]}@example.com",
+    name="Soon Revoked",
+    password_hash=password_hash,
+  )
+  session.add(user)
+  session.commit()
+  session.refresh(user)
+  return user
+
+
+def _ensure_sec(session) -> None:
+  if Graph.get_by_id("sec", session) is None:
+    Graph.create(
+      graph_id="sec",
+      org_id=None,
+      graph_name="SEC",
+      graph_type="repository",
+      session=session,
+    )
+
+
+def _seed_authorizing_entries(
+  cache: APIKeyCache, user: User, fingerprint: str, graph_ids: list[str]
+) -> None:
+  """Write every kind of entry that would let this user through, using the
+  production write paths so the shapes are exact."""
+  user_data = {
+    "id": user.id,
+    "email": user.email,
+    "name": user.name,
+    "is_active": True,
+    "session_version": 0,
+  }
+  cache.cache_api_key_validation(fingerprint, user_data, is_active=True)
+  cache.cache_jwt_user_data(user.id, user_data, session_version=0)
+  for graph_id in graph_ids:
+    cache.cache_graph_access(fingerprint, graph_id, has_access=True)
+    cache.cache_jwt_graph_access(user.id, graph_id, has_access=True)
+
+
+def _still_authorizing(cache: APIKeyCache, user: User, fingerprint: str) -> list[str]:
+  """Cache keys whose presence would still admit the user on some path."""
+  store = cache._redis.store  # type: ignore[union-attr]
+  return sorted(
+    key
+    for key in store
+    if key == f"{cache.CACHE_KEY_PREFIX}{fingerprint}"
+    or key.startswith(f"{cache.GRAPH_CACHE_KEY_PREFIX}{fingerprint}:")
+    or key == f"{cache.USER_DATA_PREFIX}{user.id}"
+    or key.startswith(f"{cache.JWT_GRAPH_CACHE_KEY_PREFIX}{user.id}:")
+  )
+
+
+class TestSeedIsRealistic:
+  """If the seed did not authorize, the invariant tests would pass vacuously."""
+
+  def test_seeded_entries_read_back_as_grants(self, cache, test_db, test_user):
+    user = _create_user(test_db, test_user.password_hash)
+    _seed_authorizing_entries(cache, user, "fp_seed", ["kg1", "sec"])
+
+    assert cache.get_cached_api_key_validation("fp_seed")["user_data"]["id"] == user.id
+    assert cache.get_cached_graph_access("fp_seed", "kg1") is True
+    assert cache.get_cached_jwt_graph_access(user.id, "sec") is True
+    assert cache.get_cached_jwt_user_data(user.id, 0)["user_data"]["id"] == user.id
+    assert len(_still_authorizing(cache, user, "fp_seed")) == 6
+
+
+class TestGraphMembershipRevocation:
+  async def test_removing_a_graph_member_leaves_nothing_authorizing(
+    self, cache, async_client, test_db, test_user
+  ):
+    org = Org.create(
+      name=f"Org {uuid4().hex[:6]}", org_type=OrgType.TEAM, session=test_db
+    )
+    OrgUser.create(
+      org_id=org.id, user_id=test_user.id, role=OrgRole.OWNER, session=test_db
+    )
+    graph = Graph.create(
+      graph_id=f"kg{uuid4().hex[:16]}",
+      org_id=org.id,
+      graph_name="Team Graph",
+      graph_type="generic",
+      session=test_db,
+    )
+    member = _create_user(test_db, test_user.password_hash)
+    OrgUser.create(
+      org_id=org.id, user_id=member.id, role=OrgRole.MEMBER, session=test_db
+    )
+    GraphUser.create(
+      user_id=member.id, graph_id=graph.graph_id, role=GraphRole.MEMBER, session=test_db
+    )
+    _seed_authorizing_entries(cache, member, "fp_graph", [graph.graph_id])
+
+    response = await async_client.delete(
+      f"/v1/graphs/{graph.graph_id}/members/{member.id}"
+    )
+
+    assert response.status_code == 204
+    assert not GraphUser.user_has_access(member.id, graph.graph_id, test_db)
+    assert _still_authorizing(cache, member, "fp_graph") == []
+
+
+class TestOrgMembershipRevocation:
+  async def test_removing_an_org_member_revokes_period_end_repository_grant(
+    self, cache, async_client, test_db, test_user
+  ):
+    """F15: a period-end cancel leaves the grant alive to ``expires_at`` while
+    the billing row is already terminal. Off-boarding must revoke it anyway —
+    the grant, not the billing row, is what authorization reads."""
+    _ensure_sec(test_db)
+    org = Org.create(
+      name=f"Org {uuid4().hex[:6]}", org_type=OrgType.TEAM, session=test_db
+    )
+    OrgUser.create(
+      org_id=org.id, user_id=test_user.id, role=OrgRole.OWNER, session=test_db
+    )
+    graph = Graph.create(
+      graph_id=f"kg{uuid4().hex[:16]}",
+      org_id=org.id,
+      graph_name="Team Graph",
+      graph_type="generic",
+      session=test_db,
+    )
+    member = _create_user(test_db, test_user.password_hash)
+    OrgUser.create(
+      org_id=org.id, user_id=member.id, role=OrgRole.MEMBER, session=test_db
+    )
+    GraphUser.create(
+      user_id=member.id, graph_id=graph.graph_id, role=GraphRole.MEMBER, session=test_db
+    )
+
+    subscription = BillingSubscription.create_subscription(
+      org_id=org.id,
+      resource_type="repository",
+      resource_id="sec",
+      plan_name="sec-starter",
+      base_price_cents=4900,
+      session=test_db,
+      user_id=member.id,
+    )
+    subscription.activate(test_db)
+    subscription.stripe_subscription_id = "sub_period_end"
+    test_db.commit()
+    grant = UserRepository.create_access(
+      user_id=member.id,
+      repository_type=RepositoryType.SEC,
+      repository_name="sec",
+      access_level=RepositoryAccessLevel.READ,
+      repository_plan="sec-starter",
+      session=test_db,
+    )
+    with patch(PROVIDER, return_value=MagicMock()):
+      cancel_repository_subscription(
+        subscription, session=test_db, actor_user_id=member.id
+      )
+    test_db.refresh(grant)
+    assert grant.is_active is True, "precondition: period-end cancel keeps the grant"
+    assert (
+      BillingSubscription.get_live_subscriptions_for_user(
+        member.id, test_db, resource_type="repository"
+      )
+      == []
+    ), "precondition: the billing row is already terminal"
+
+    _seed_authorizing_entries(cache, member, "fp_org", [graph.graph_id, "sec"])
+
+    with patch(PROVIDER, return_value=MagicMock()):
+      response = await async_client.delete(f"/v1/orgs/{org.id}/members/{member.id}")
+
+    assert response.status_code == 204
+    test_db.refresh(grant)
+    assert grant.is_active is False
+    assert not UserRepository.user_has_access(member.id, "sec", test_db)
+    assert not GraphUser.user_has_access(member.id, graph.graph_id, test_db)
+    assert _still_authorizing(cache, member, "fp_org") == []
+
+
+class TestRepositorySubscriptionRevocation:
+  def test_immediate_cancel_leaves_nothing_authorizing(
+    self, cache, test_db, test_user, test_org
+  ):
+    """F8: the endpoint promises ``immediate=true`` stops access immediately;
+    that is only true once the cached decisions go with the grant."""
+    _ensure_sec(test_db)
+    member = _create_user(test_db, test_user.password_hash)
+    OrgUser.create(
+      org_id=test_org.id, user_id=member.id, role=OrgRole.MEMBER, session=test_db
+    )
+    subscription = BillingSubscription.create_subscription(
+      org_id=test_org.id,
+      resource_type="repository",
+      resource_id="sec",
+      plan_name="sec-starter",
+      base_price_cents=4900,
+      session=test_db,
+      user_id=member.id,
+    )
+    subscription.activate(test_db)
+    grant = UserRepository.create_access(
+      user_id=member.id,
+      repository_type=RepositoryType.SEC,
+      repository_name="sec",
+      access_level=RepositoryAccessLevel.READ,
+      repository_plan="sec-starter",
+      session=test_db,
+    )
+    _seed_authorizing_entries(cache, member, "fp_repo", ["sec", "sec_historical"])
+
+    with patch(PROVIDER, return_value=MagicMock()):
+      cancel_repository_subscription(
+        subscription, session=test_db, actor_user_id=member.id, immediate=True
+      )
+
+    test_db.refresh(grant)
+    assert grant.is_active is False
+    assert _still_authorizing(cache, member, "fp_repo") == []
+
+  def test_offboarding_sweep_revokes_grants_without_live_subscriptions(
+    self, cache, test_db, test_user, test_org
+  ):
+    """F15 at the operation level: a grant with no billing row behind it at
+    all (a comped or legacy grant) is still revoked by the off-boarding sweep."""
+    _ensure_sec(test_db)
+    member = _create_user(test_db, test_user.password_hash)
+    grant = UserRepository.create_access(
+      user_id=member.id,
+      repository_type=RepositoryType.SEC,
+      repository_name="sec",
+      access_level=RepositoryAccessLevel.READ,
+      repository_plan="sec-starter",
+      session=test_db,
+    )
+    _seed_authorizing_entries(cache, member, "fp_comped", ["sec"])
+
+    canceled = cancel_user_repository_subscriptions(
+      member.id, session=test_db, actor_user_id=test_user.id
+    )
+
+    assert canceled == []
+    test_db.refresh(grant)
+    assert grant.is_active is False
+    assert _still_authorizing(cache, member, "fp_comped") == []
+
+
+class TestAccountDeletionRevocation:
+  def test_deleting_an_account_leaves_nothing_authenticating(
+    self, cache, test_db, test_user
+  ):
+    """F7: the bulk delete bypasses ``UserAPIKey.delete``, so without an
+    explicit sweep a deleted account keeps authenticating from cache."""
+    user = _create_user(test_db, test_user.password_hash)
+    org = Org.create(
+      name=f"Personal {uuid4().hex[:6]}", org_type=OrgType.PERSONAL, session=test_db
+    )
+    OrgUser.create(org_id=org.id, user_id=user.id, role=OrgRole.OWNER, session=test_db)
+    key_row, _plain = UserAPIKey.create(user_id=user.id, name="ci", session=test_db)
+    fingerprint = key_row.key_fingerprint
+    assert fingerprint
+    _seed_authorizing_entries(cache, user, fingerprint, ["kg1", "sec"])
+
+    execute_user_deletion(user.id, test_db)
+
+    assert User.get_by_id(user.id, test_db) is None
+    assert test_db.query(UserAPIKey).filter_by(user_id=user.id).count() == 0
+    assert _still_authorizing(cache, user, fingerprint) == []


### PR DESCRIPTION
## Summary

Hardens the revocation paths so a withdrawn grant stops authorizing at once: every surface that revokes access now clears the auth-cache entries derived from that grant in the same step, and the off-boarding sweep revokes every repository grant a member still holds. Detailed notes: `local/RoboSystems/specs/security/org-multi-user-hardening.md` (§1, the revocation cluster).

## Changes

- **`middleware/auth/cache.py`** — `invalidate_user_data` now drops each matched API key's per-graph access decisions along with its validation entry (shared helper `_api_key_cache_keys`, also used by `invalidate_api_key`).
- **`models/core/user/user_repository.py`** — `UserRepository.invalidate_access_cache()`, called after `create_access` and `revoke_access` commit; the model is the choke point for every caller. The operation-level helper in `repository_subscription_service.py` is removed in its favour.
- **`operations/billing/repository_subscriptions.py`** — `cancel_user_repository_subscriptions` also revokes any active repository grant with no live subscription behind it (a period-end cancel leaves the grant alive to `expires_at`).
- **`operations/admin/user_deletion.py`** — captures API-key fingerprints before the bulk delete and sweeps the account's API-key and JWT cache entries after commit; incomplete sweeps log at CRITICAL.
- **Tests** — new `tests/security/test_revocation_invariant.py`: seeds the cache in production shape (real `APIKeyCache` over a fake Redis) and asserts after graph-member removal, org-member removal, immediate repository cancel, the off-boarding sweep, and account deletion that no grant row and no cache entry still authorizes. All five revocation cases fail against `main`. Plus one regression test each in `test_cache_comprehensive.py` and `test_repository_subscriptions.py`.

## Breaking Changes

None. No API surface changes; nothing for the SDKs.

## Testing

- `just test-code` — clean (ruff, format, basedpyright).
- Full unit suite (`pytest -m "not slow and not integration"`) — 12,850 passed, 23 skipped.
- New invariant tests verified to fail with the source changes stashed (5 of 6; the sixth is the seed self-check).

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
