### PR TITLE
fix(graphs): resolve graph-scoped reads on the graph role, not org membership

### DIFF
--- a/migrations/platform/versions/a40f29cc6fe7_drop_subgraph_scoped_graph_user_rows.py
+++ b/migrations/platform/versions/a40f29cc6fe7_drop_subgraph_scoped_graph_user_rows.py
@@ -1,0 +1,35 @@
+"""drop subgraph scoped graph_user rows
+
+Revision ID: a40f29cc6fe7
+Revises: 7fd78cf16c54
+Create Date: 2026-08-15 21:43:34.702797
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a40f29cc6fe7"
+down_revision = "7fd78cf16c54"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+  # Data-only backfill; autogenerate has nothing to detect.
+  #
+  # Subgraph creation used to write a GraphUser row on the subgraph id for the
+  # creator. Authorization never read it (GraphUser.get_effective_role resolves
+  # a subgraph to its parent grant), and member removal never deleted it, so it
+  # outlived the parent grant. Creation no longer writes it and the graph list
+  # derives subgraphs from the parent grant, leaving these rows with no reader.
+  op.execute(
+    "DELETE FROM graph_users "
+    "WHERE graph_id IN (SELECT graph_id FROM graphs WHERE is_subgraph IS TRUE)"
+  )
+
+
+def downgrade() -> None:
+  # The rows carried no information the parent grant does not; nothing to
+  # restore.
+  pass

--- a/robosystems/operations/graph/subgraph_service.py
+++ b/robosystems/operations/graph/subgraph_service.py
@@ -263,7 +263,10 @@ class SubgraphService:
     fork_options: dict[str, Any] | None = None,
     platform_managed: bool = False,
   ) -> dict[str, Any]:
-    """Create a subgraph end to end: database, schema, metadata, and access.
+    """Create a subgraph end to end: database, schema, and metadata.
+
+    Access needs no row of its own — a subgraph is reachable by whoever holds
+    a grant on the parent, at the parent's role.
 
     ``subgraph_type`` selects the schema: "knowledge" installs the knowledge
     extension without the base schema, "empty" installs nothing at all, and
@@ -276,7 +279,6 @@ class SubgraphService:
     """
     from ...database import get_db_session
     from ...models.core.graph import Graph
-    from ...models.core.graph.graph_user import GraphUser
 
     subgraph_id = construct_subgraph_id(parent_graph.graph_id, name)
 
@@ -352,20 +354,18 @@ class SubgraphService:
       )
       db.add(subgraph)
 
-      graph_user = GraphUser(
-        user_id=user.id,
-        graph_id=subgraph_id,
-        role="admin",
-        created_at=now,
-        updated_at=now,
-      )
-      db.add(graph_user)
+      # No GraphUser row for the subgraph: access to a subgraph is the
+      # parent's grant (GraphUser.get_effective_role resolves subgraphs to
+      # the parent), so a subgraph-scoped row would never be read for
+      # authorization and would outlive the parent grant when a member is
+      # removed.
 
       db.commit()
       db.refresh(subgraph)
 
       logger.info(
-        f"Created subgraph {subgraph_id} (index {next_index}) for parent {parent_graph.graph_id}"
+        f"Created subgraph {subgraph_id} (index {next_index}) for parent "
+        f"{parent_graph.graph_id} by user {user.id}"
       )
 
       fork_status = None

--- a/robosystems/routers/graphs/backups/download.py
+++ b/robosystems/routers/graphs/backups/download.py
@@ -30,7 +30,7 @@ from robosystems.middleware.rate_limits import (
 from robosystems.models.api.graphs.backups import BackupDownloadUrlResponse
 from robosystems.models.core import Graph, User, UserRepository
 
-from .utils import get_backup_manager
+from .utils import get_backup_manager, verify_admin_access
 
 # Create router
 router = APIRouter()
@@ -53,7 +53,12 @@ router = APIRouter()
   status_code=status.HTTP_200_OK,
   responses={
     200: {"description": "Download URL generated successfully"},
-    403: {"description": "Access denied"},
+    403: {
+      "description": (
+        "Access denied — admin role on the graph, or an eligible repository "
+        "subscription, is required"
+      )
+    },
     404: {"description": "Backup not found"},
     500: {"description": "Failed to generate download URL"},
   },
@@ -81,6 +86,8 @@ async def get_backup_download_url(
   of compressed .lbug backup files without going through the API.
 
   Requirements:
+  - Admin role on the graph (dedicated graphs), or a repository subscription
+    whose plan includes downloads (shared repositories)
   - Backup must be in full_dump format (complete .lbug file)
   - File will be compressed
 
@@ -156,6 +163,13 @@ async def get_backup_download_url(
           },
         )
     else:
+      # A dedicated graph's backup is the whole database, unencrypted, behind
+      # a URL that lives up to a day. Creating and restoring one already
+      # require admin on the graph; taking one out does too. Shared
+      # repositories are gated by subscription plan above instead — there is
+      # no per-graph role there.
+      verify_admin_access(current_user, graph_id, session)
+
       # Dedicated graph: check tier-based download limits
       graph_record = Graph.get_by_id(graph_id, session)
       if not graph_record:

--- a/robosystems/routers/graphs/main.py
+++ b/robosystems/routers/graphs/main.py
@@ -144,8 +144,16 @@ async def get_graphs(
     member_graphs = 0
     repository_count = 0
 
+    listed_graph_ids: set[str] = set()
+
     # Add user graphs
     for user_graph in user_graphs:
+      # A subgraph carries no grant of its own — access is the parent's grant
+      # at the parent's role — so any row on a subgraph id predates that rule
+      # and is ignored; the subgraph is listed under its parent below.
+      if user_graph.graph.is_subgraph:
+        continue
+
       # Skip deprovisioned graphs
       graph_status = user_graph.graph.status or "active"
       if graph_status == "deprovisioned":
@@ -160,6 +168,7 @@ async def get_graphs(
       else:
         member_graphs += 1
 
+      listed_graph_ids.add(user_graph.graph_id)
       description, tags = _label_fields(user_graph.graph)
       graphs.append(
         GraphInfo(
@@ -173,16 +182,44 @@ async def get_graphs(
           isRepository=False,
           repositoryType=None,
           schemaExtensions=user_graph.graph.schema_extensions or [],
-          isSubgraph=user_graph.graph.is_subgraph or False,
-          parentGraphId=user_graph.graph.parent_graph_id,
+          isSubgraph=False,
+          parentGraphId=None,
           graphType=user_graph.graph.graph_type,
           status=graph_status,
         )
       )
 
+      for subgraph in Graph.get_subgraphs(user_graph.graph_id, session):
+        subgraph_status = subgraph.status or "active"
+        if subgraph_status == "deprovisioned":
+          continue
+        if user_graph.role == "admin":
+          admin_graphs += 1
+        else:
+          member_graphs += 1
+        listed_graph_ids.add(subgraph.graph_id)
+        description, tags = _label_fields(subgraph)
+        graphs.append(
+          GraphInfo(
+            graphId=subgraph.graph_id,
+            graphName=subgraph.graph_name,
+            description=description,
+            tags=tags,
+            role=user_graph.role,
+            isSelected=False,
+            createdAt=subgraph.created_at.isoformat(),
+            isRepository=False,
+            repositoryType=None,
+            schemaExtensions=subgraph.schema_extensions or [],
+            isSubgraph=True,
+            parentGraphId=subgraph.parent_graph_id,
+            graphType=subgraph.graph_type,
+            status=subgraph_status,
+          )
+        )
+
     # Add org-owned graphs the user holds implicitly as org owner/admin
     # (no explicit GraphUser row — access derives from the org role).
-    explicit_graph_ids = {ug.graph_id for ug in user_graphs}
     admin_org_ids = [
       ou.org_id
       for ou in OrgUser.get_user_orgs(current_user.id, session)
@@ -193,8 +230,8 @@ async def get_graphs(
         session.query(Graph)
         .filter(
           Graph.org_id.in_(admin_org_ids),
-          Graph.graph_id.notin_(explicit_graph_ids)
-          if explicit_graph_ids
+          Graph.graph_id.notin_(listed_graph_ids)
+          if listed_graph_ids
           else Graph.graph_id.isnot(None),
         )
         .all()

--- a/robosystems/routers/graphs/subscriptions.py
+++ b/robosystems/routers/graphs/subscriptions.py
@@ -141,7 +141,7 @@ async def get_subscription(
   _rate_limit: None = Depends(subscription_aware_rate_limit_dependency),
 ) -> GraphSubscriptionResponse:
   try:
-    from ...models.core import OrgUser
+    from ...models.core import GraphUser
 
     customer = BillingCustomer.get_by_user_id(current_user.id, db)
     if not customer:
@@ -164,17 +164,16 @@ async def get_subscription(
         resource_type="graph", resource_id=graph_id, session=db
       )
 
-      if subscription:
-        membership = OrgUser.get_by_org_and_user(
-          org_id=subscription.org_id,
-          user_id=current_user.id,
-          session=db,
+      # Org membership alone grants no graph access — a plain member needs an
+      # explicit grant, and owners/admins are implicit admins on every org
+      # graph. Resolve the graph role, the same rule the graph surface and
+      # the org graph listing apply, so a member cannot read the tier and
+      # billing period of a graph they cannot otherwise reach.
+      if subscription and not GraphUser.user_has_access(current_user.id, graph_id, db):
+        raise HTTPException(
+          status_code=403,
+          detail="You do not have access to this graph subscription",
         )
-        if not membership:
-          raise HTTPException(
-            status_code=403,
-            detail="You do not have access to this graph subscription",
-          )
 
     if not subscription:
       raise HTTPException(

--- a/robosystems/routers/orgs/main.py
+++ b/robosystems/routers/orgs/main.py
@@ -1,6 +1,7 @@
 """Organization management endpoints."""
 
 from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import or_
 from sqlalchemy.orm import Session
 
 from ...database import get_db_session
@@ -44,7 +45,11 @@ def _visible_org_graphs(
   if not granted:
     return []
 
-  return query.filter(Graph.graph_id.in_(granted)).all()
+  # A grant on a parent reaches its subgraphs (subgraphs carry no row of
+  # their own), so they are visible alongside it.
+  return query.filter(
+    or_(Graph.graph_id.in_(granted), Graph.parent_graph_id.in_(granted))
+  ).all()
 
 
 @router.get(

--- a/tests/routers/graphs/test_backup_download.py
+++ b/tests/routers/graphs/test_backup_download.py
@@ -376,10 +376,13 @@ class TestBackupDownloadEndpoint:
   )
   @patch("robosystems.routers.graphs.backups.download.Graph.get_by_id")
   @patch("robosystems.middleware.graph.utils.MultiTenantUtils.is_shared_repository")
-  @patch("robosystems.models.core.GraphUser.get_by_user_id")
+  @patch(
+    "robosystems.routers.graphs.backups.utils.GraphUser.user_has_admin_access",
+    return_value=True,
+  )
   def test_download_allowed_for_user_graph_under_limit(
     self,
-    mock_get_by_user_id,
+    mock_admin_access,
     mock_is_shared,
     mock_get_graph,
     mock_check_graph_limit,
@@ -398,11 +401,6 @@ class TestBackupDownloadEndpoint:
 
     try:
       mock_is_shared.return_value = False
-
-      mock_user_graph = MagicMock()
-      mock_user_graph.graph_id = "kg0123456789abcdef"
-      mock_user_graph.role = "admin"
-      mock_get_by_user_id.return_value = [mock_user_graph]
 
       # Graph has standard tier
       mock_graph_record = MagicMock()
@@ -442,10 +440,13 @@ class TestBackupDownloadEndpoint:
   )
   @patch("robosystems.routers.graphs.backups.download.Graph.get_by_id")
   @patch("robosystems.middleware.graph.utils.MultiTenantUtils.is_shared_repository")
-  @patch("robosystems.models.core.GraphUser.get_by_user_id")
+  @patch(
+    "robosystems.routers.graphs.backups.utils.GraphUser.user_has_admin_access",
+    return_value=True,
+  )
   def test_download_rate_limit_exceeded_for_user_graph(
     self,
-    mock_get_by_user_id,
+    mock_admin_access,
     mock_is_shared,
     mock_get_graph,
     mock_check_graph_limit,
@@ -463,11 +464,6 @@ class TestBackupDownloadEndpoint:
 
     try:
       mock_is_shared.return_value = False
-
-      mock_user_graph = MagicMock()
-      mock_user_graph.graph_id = "kg0123456789abcdef"
-      mock_user_graph.role = "admin"
-      mock_get_by_user_id.return_value = [mock_user_graph]
 
       # Graph has standard tier (2 downloads/month)
       mock_graph_record = MagicMock()
@@ -502,10 +498,13 @@ class TestBackupDownloadEndpoint:
   )
   @patch("robosystems.routers.graphs.backups.download.Graph.get_by_id")
   @patch("robosystems.middleware.graph.utils.MultiTenantUtils.is_shared_repository")
-  @patch("robosystems.models.core.GraphUser.get_by_user_id")
+  @patch(
+    "robosystems.routers.graphs.backups.utils.GraphUser.user_has_admin_access",
+    return_value=True,
+  )
   def test_download_allowed_for_xlarge_tier(
     self,
-    mock_get_by_user_id,
+    mock_admin_access,
     mock_is_shared,
     mock_get_graph,
     mock_check_graph_limit,
@@ -524,11 +523,6 @@ class TestBackupDownloadEndpoint:
 
     try:
       mock_is_shared.return_value = False
-
-      mock_user_graph = MagicMock()
-      mock_user_graph.graph_id = "kg0123456789abcdef"
-      mock_user_graph.role = "admin"
-      mock_get_by_user_id.return_value = [mock_user_graph]
 
       # Graph has xlarge tier (10 downloads/month)
       mock_graph_record = MagicMock()
@@ -566,10 +560,13 @@ class TestBackupDownloadEndpoint:
   )
   @patch("robosystems.routers.graphs.backups.download.Graph.get_by_id")
   @patch("robosystems.middleware.graph.utils.MultiTenantUtils.is_shared_repository")
-  @patch("robosystems.models.core.GraphUser.get_by_user_id")
+  @patch(
+    "robosystems.routers.graphs.backups.utils.GraphUser.user_has_admin_access",
+    return_value=True,
+  )
   def test_download_returns_404_when_backup_not_found(
     self,
-    mock_get_by_user_id,
+    mock_admin_access,
     mock_is_shared,
     mock_get_graph,
     mock_check_graph_limit,
@@ -587,11 +584,6 @@ class TestBackupDownloadEndpoint:
 
     try:
       mock_is_shared.return_value = False
-
-      mock_user_graph = MagicMock()
-      mock_user_graph.graph_id = "kg0123456789abcdef"
-      mock_user_graph.role = "admin"
-      mock_get_by_user_id.return_value = [mock_user_graph]
 
       # Graph with xlarge tier (10 downloads/month)
       mock_graph_record = MagicMock()

--- a/tests/routers/graphs/test_graph_read_authorization.py
+++ b/tests/routers/graphs/test_graph_read_authorization.py
@@ -1,0 +1,366 @@
+"""Reads that only separate at the second org member.
+
+With one member per org, org membership and graph access are the same set, so
+a read that authorizes on the former looks correct. The second member is the
+first user for whom they differ: a plain org member without a grant on a graph.
+Each test here puts that member at a graph-scoped read and asserts the graph
+role, not the org roster, decides — and that a subgraph's visibility follows
+the parent grant rather than a row of its own.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from robosystems.models.core import (
+  BillingSubscription,
+  Graph,
+  GraphRole,
+  GraphUser,
+  Org,
+  OrgRole,
+  OrgType,
+  OrgUser,
+  User,
+)
+from robosystems.models.core.billing import BillingCustomer
+
+pytestmark = pytest.mark.asyncio
+
+
+def _create_user(session, password_hash: str) -> User:
+  suffix = uuid4().hex[:8]
+  user = User(
+    email=f"second-member+{suffix}@example.com",
+    name=f"Second Member {suffix}",
+    password_hash=password_hash,
+  )
+  session.add(user)
+  session.commit()
+  session.refresh(user)
+  return user
+
+
+class _NoClose:
+  """The service closes the session it pulls from ``get_db_session``; the test
+  needs the fixture session to survive that."""
+
+  def __init__(self, session):
+    self._session = session
+
+  def __getattr__(self, name):
+    return getattr(self._session, name)
+
+  def close(self) -> None:
+    return None
+
+
+def _team_org_with_graph(session, owner_id: str) -> tuple[Org, Graph]:
+  org = Org.create(
+    name=f"Team {uuid4().hex[:6]}", org_type=OrgType.TEAM, session=session
+  )
+  OrgUser.create(org_id=org.id, user_id=owner_id, role=OrgRole.OWNER, session=session)
+  graph = Graph.create(
+    graph_id=f"kg{uuid4().hex[:16]}",
+    org_id=org.id,
+    graph_name="Team Graph",
+    graph_type="generic",
+    session=session,
+  )
+  return org, graph
+
+
+class TestGraphSubscriptionRead:
+  """``GET /v1/graphs/{graph_id}/subscriptions`` — the graph's tier and
+  billing period. Reads on graph access, not org membership."""
+
+  def _subscribed_graph_as_plain_member(self, test_db, test_user, test_org):
+    """A team org where ``test_user`` is a plain member, owning a graph with a
+    subscription; ``test_user`` holds no grant on the graph."""
+    owner = _create_user(test_db, test_user.password_hash)
+    org, graph = _team_org_with_graph(test_db, owner.id)
+    OrgUser.create(
+      org_id=org.id, user_id=test_user.id, role=OrgRole.MEMBER, session=test_db
+    )
+    # The endpoint resolves the caller's billing customer through their first
+    # org membership, whichever that is.
+    BillingCustomer.get_or_create(test_org.id, test_db)
+    BillingCustomer.get_or_create(org.id, test_db)
+    BillingSubscription.create_subscription(
+      org_id=org.id,
+      resource_type="graph",
+      resource_id=graph.graph_id,
+      plan_name="ladybug-standard",
+      base_price_cents=4900,
+      session=test_db,
+    )
+    return org, graph
+
+  async def test_org_member_without_grant_is_refused(
+    self, async_client, test_db, test_user, test_org
+  ):
+    _org, graph = self._subscribed_graph_as_plain_member(test_db, test_user, test_org)
+
+    response = await async_client.get(f"/v1/graphs/{graph.graph_id}/subscriptions")
+
+    assert response.status_code == 403
+
+  async def test_explicit_grant_admits(
+    self, async_client, test_db, test_user, test_org
+  ):
+    _org, graph = self._subscribed_graph_as_plain_member(test_db, test_user, test_org)
+    GraphUser.create(
+      user_id=test_user.id,
+      graph_id=graph.graph_id,
+      role=GraphRole.VIEWER,
+      session=test_db,
+    )
+
+    response = await async_client.get(f"/v1/graphs/{graph.graph_id}/subscriptions")
+
+    assert response.status_code == 200
+    assert response.json()["resource_id"] == graph.graph_id
+
+  async def test_org_admin_is_admitted_implicitly(
+    self, async_client, test_db, test_user, test_org
+  ):
+    org, graph = self._subscribed_graph_as_plain_member(test_db, test_user, test_org)
+    membership = OrgUser.get_by_org_and_user(org.id, test_user.id, test_db)
+    assert membership is not None
+    membership.role = OrgRole.ADMIN
+    test_db.commit()
+
+    response = await async_client.get(f"/v1/graphs/{graph.graph_id}/subscriptions")
+
+    assert response.status_code == 200
+
+
+class TestSubgraphAccessFollowsTheParentGrant:
+  """A subgraph has no ``GraphUser`` row of its own: creation writes none, the
+  graph list derives subgraphs from the parent grant, and removing a member
+  from the parent therefore leaves nothing behind on the subgraph."""
+
+  async def test_creation_writes_no_subgraph_grant_row(
+    self, test_db, test_user, test_org
+  ):
+    from robosystems.operations.graph.subgraph_service import SubgraphService
+
+    parent = Graph.create(
+      graph_id=f"kg{uuid4().hex[:16]}",
+      org_id=test_org.id,
+      graph_name="Parent",
+      graph_type="generic",
+      session=test_db,
+    )
+    GraphUser.create(
+      user_id=test_user.id,
+      graph_id=parent.graph_id,
+      role=GraphRole.ADMIN,
+      session=test_db,
+    )
+
+    service = SubgraphService()
+    with (
+      patch.object(
+        service,
+        "create_subgraph_database",
+        new=AsyncMock(return_value={"status": "created", "instance_id": "i-test"}),
+      ),
+      patch(
+        "robosystems.database.get_db_session",
+        return_value=iter([_NoClose(test_db)]),
+      ),
+    ):
+      result = await service.create_subgraph(
+        parent_graph=parent, user=test_user, name="dev", subgraph_type="empty"
+      )
+
+    subgraph_id = result["graph_id"]
+    assert Graph.get_by_id(subgraph_id, test_db) is not None
+    assert (
+      test_db.query(GraphUser).filter(GraphUser.graph_id == subgraph_id).count() == 0
+    )
+    # ...and the creator still reaches it, at the parent's role.
+    assert GraphUser.user_has_admin_access(test_user.id, subgraph_id, test_db)
+
+  async def test_graph_list_shows_subgraphs_of_every_granted_parent(
+    self, async_client, test_db, test_user
+  ):
+    """Not only the creator: any holder of a parent grant sees the subgraph in
+    the list, at the parent's role — the same answer authorization gives."""
+    owner = _create_user(test_db, test_user.password_hash)
+    org, parent = _team_org_with_graph(test_db, owner.id)
+    subgraph = Graph.create(
+      graph_id=f"{parent.graph_id}_dev",
+      org_id=org.id,
+      graph_name="dev",
+      graph_type="generic",
+      session=test_db,
+      parent_graph_id=parent.graph_id,
+      is_subgraph=True,
+      subgraph_name="dev",
+      subgraph_index=1,
+    )
+    OrgUser.create(
+      org_id=org.id, user_id=test_user.id, role=OrgRole.MEMBER, session=test_db
+    )
+    GraphUser.create(
+      user_id=test_user.id,
+      graph_id=parent.graph_id,
+      role=GraphRole.MEMBER,
+      session=test_db,
+    )
+
+    with patch("robosystems.routers.graphs.main.session", test_db):
+      response = await async_client.get("/v1/graphs")
+
+    assert response.status_code == 200
+    by_id = {g["graphId"]: g for g in response.json()["graphs"]}
+    assert by_id[parent.graph_id]["role"] == "member"
+    assert by_id[subgraph.graph_id]["isSubgraph"] is True
+    assert by_id[subgraph.graph_id]["parentGraphId"] == parent.graph_id
+    assert by_id[subgraph.graph_id]["role"] == "member"
+
+  async def test_graph_list_ignores_a_legacy_subgraph_row_without_duplicating(
+    self, async_client, test_db, test_user, test_org
+  ):
+    """A pre-existing row on the subgraph id (from before creation stopped
+    writing them) neither adds a second entry nor grants a different role."""
+    parent = Graph.create(
+      graph_id=f"kg{uuid4().hex[:16]}",
+      org_id=test_org.id,
+      graph_name="Parent",
+      graph_type="generic",
+      session=test_db,
+    )
+    subgraph = Graph.create(
+      graph_id=f"{parent.graph_id}_dev",
+      org_id=test_org.id,
+      graph_name="dev",
+      graph_type="generic",
+      session=test_db,
+      parent_graph_id=parent.graph_id,
+      is_subgraph=True,
+      subgraph_name="dev",
+      subgraph_index=1,
+    )
+    GraphUser.create(
+      user_id=test_user.id,
+      graph_id=parent.graph_id,
+      role=GraphRole.MEMBER,
+      session=test_db,
+    )
+    GraphUser.create(
+      user_id=test_user.id,
+      graph_id=subgraph.graph_id,
+      role=GraphRole.ADMIN,
+      session=test_db,
+    )
+
+    with patch("robosystems.routers.graphs.main.session", test_db):
+      response = await async_client.get("/v1/graphs")
+
+    assert response.status_code == 200
+    ids = [g["graphId"] for g in response.json()["graphs"]]
+    assert ids.count(subgraph.graph_id) == 1
+    entry = next(
+      g for g in response.json()["graphs"] if g["graphId"] == subgraph.graph_id
+    )
+    assert entry["role"] == "member"
+
+  async def test_org_graph_listing_shows_subgraphs_of_granted_parents(
+    self, async_client, test_db, test_user
+  ):
+    owner = _create_user(test_db, test_user.password_hash)
+    org, parent = _team_org_with_graph(test_db, owner.id)
+    Graph.create(
+      graph_id=f"{parent.graph_id}_dev",
+      org_id=org.id,
+      graph_name="dev",
+      graph_type="generic",
+      session=test_db,
+      parent_graph_id=parent.graph_id,
+      is_subgraph=True,
+      subgraph_name="dev",
+      subgraph_index=1,
+    )
+    hidden = Graph.create(
+      graph_id=f"kg{uuid4().hex[:16]}",
+      org_id=org.id,
+      graph_name="Not Granted",
+      graph_type="generic",
+      session=test_db,
+    )
+    OrgUser.create(
+      org_id=org.id, user_id=test_user.id, role=OrgRole.MEMBER, session=test_db
+    )
+    GraphUser.create(
+      user_id=test_user.id,
+      graph_id=parent.graph_id,
+      role=GraphRole.VIEWER,
+      session=test_db,
+    )
+
+    response = await async_client.get(f"/v1/orgs/{org.id}/graphs")
+
+    assert response.status_code == 200
+    ids = {g["graph_id"] for g in response.json()}
+    assert ids == {parent.graph_id, f"{parent.graph_id}_dev"}
+    assert hidden.graph_id not in ids
+
+
+class TestBackupDownloadRequiresAdmin:
+  """A dedicated graph's backup is the whole database; minting a download URL
+  for it is an admin action, like creating or restoring one."""
+
+  def _graph_with_grant(self, test_db, test_user, role: GraphRole) -> Graph:
+    owner = _create_user(test_db, test_user.password_hash)
+    org, graph = _team_org_with_graph(test_db, owner.id)
+    OrgUser.create(
+      org_id=org.id, user_id=test_user.id, role=OrgRole.MEMBER, session=test_db
+    )
+    GraphUser.create(
+      user_id=test_user.id, graph_id=graph.graph_id, role=role, session=test_db
+    )
+    return graph
+
+  async def test_viewer_cannot_mint_a_download_url(
+    self, async_client, test_db, test_user
+  ):
+    graph = self._graph_with_grant(test_db, test_user, GraphRole.VIEWER)
+
+    response = await async_client.get(
+      f"/v1/graphs/{graph.graph_id}/backups/bk_x/download"
+    )
+
+    assert response.status_code == 403
+    assert "Admin access required" in response.json()["detail"]
+
+  async def test_admin_passes_the_role_gate(self, async_client, test_db, test_user):
+    """The gate is the only thing under test: past it, the request reaches
+    the backup lookup, which is stubbed to report the backup missing."""
+    graph = self._graph_with_grant(test_db, test_user, GraphRole.ADMIN)
+    manager = MagicMock()
+    manager.get_backup_download_url = AsyncMock(return_value=None)
+
+    with (
+      patch(
+        "robosystems.routers.graphs.backups.download.get_backup_manager",
+        return_value=manager,
+      ),
+      patch(
+        "robosystems.routers.graphs.backups.download.DownloadRateLimiter"
+        ".check_graph_download_limit",
+        new=AsyncMock(return_value=(True, 1, datetime.now(UTC))),
+      ),
+    ):
+      response = await async_client.get(
+        f"/v1/graphs/{graph.graph_id}/backups/bk_x/download"
+      )
+
+    assert response.status_code == 404
+    manager.get_backup_download_url.assert_awaited_once()


### PR DESCRIPTION
## Summary

Three graph-scoped reads that only separate from org membership once an org has a second member: the graph subscription read now resolves the graph role, minting a backup download URL for a dedicated graph requires the admin role (matching create and restore), and subgraph access/visibility follows the parent grant rather than a row of its own. Companion to #1190; both are the current build in `local/RoboSystems/specs/security/org-multi-user-hardening.md`.

## Changes

- **`routers/graphs/subscriptions.py`** — `GET /v1/graphs/{graph_id}/subscriptions` authorizes via `GraphUser.user_has_access` (explicit grant, or implicit org owner/admin) instead of `OrgUser` membership.
- **`routers/graphs/backups/download.py`** — dedicated-graph downloads pass through `verify_admin_access` before the tier-limit check; shared repositories keep their subscription-plan gate. Docstring/OpenAPI text updated to state the requirement.
- **`operations/graph/subgraph_service.py`** — `create_subgraph` no longer writes a `GraphUser` row on the subgraph id. `get_effective_role` already resolves a subgraph to its parent grant, so the row was never read for authorization and outlived the parent grant when a member was removed.
- **`routers/graphs/main.py`** — `GET /v1/graphs` lists subgraphs under every parent the caller holds a grant on, at the parent's role, and ignores any legacy row on a subgraph id (no duplicates, no different role). Reviewers: this widens *listing* to what authorization already allows — previously only the subgraph's creator saw it in this list; the three frontends filter subgraphs out of this list and use `listSubgraphs` instead.
- **`routers/orgs/main.py`** — `_visible_org_graphs` includes subgraphs of granted parents (`or_(graph_id IN granted, parent_graph_id IN granted)`).
- **`migrations/platform/versions/a40f29cc6fe7_…`** — data-only backfill deleting `graph_users` rows on subgraph ids. Skeleton from `just migrate-create`, body written by hand (autogenerate has nothing to detect); downgrade is a no-op.
- **Tests** — new `tests/routers/graphs/test_graph_read_authorization.py` (9 tests; 6 fail against `main`). Four existing dedicated-graph tests in `test_backup_download.py` repointed from the removed `get_by_user_id` patch to `GraphUser.user_has_admin_access` so the real gate is executed.

## Breaking Changes

None. Response shapes are unchanged; `isSubgraph`/`parentGraphId` are existing fields. Nothing for the SDKs.

## Testing

- `just test-code` — clean.
- Full unit suite (`pytest -m "not slow and not integration"`) — 12,852 passed, 23 skipped.
- Migration applied locally (`just migrate-up` → `a40f29cc6fe7 (head)`).

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
