### PR TITLE
fix(graphs): remove connections and register the final backup at teardown

### DIFF
--- a/cloudformation/s3.yaml
+++ b/cloudformation/s3.yaml
@@ -204,16 +204,27 @@ Resources:
         Status: Enabled
       LifecycleConfiguration:
         Rules:
-          # User staging data expires after 7 days
-          - Id: ExpireStagingData
+          # Pre-ingestion uploads expire after 30 days. The prefix is
+          # user-staging/, not staging/: S3 prefix matching is literal, so the
+          # two rules this replaces (staging/ 7d and exports/ 30d) matched no
+          # object that has ever existed in this bucket, and source files sat
+          # here indefinitely — including a departed customer's, since
+          # deprovisioning does not touch S3. The objects are ingestion input,
+          # not a system of record; the graph holds the result. 30 days rather
+          # than the old rule's 7 because that number was written against a
+          # prefix nothing wrote to, so it was never sized against a real
+          # upload-to-ingest gap. Note GraphFile rows outlive the object and
+          # still report s3_key, so expiry leaves that metadata dangling.
+          - Id: ExpireUserStagingData
             Status: Enabled
-            Prefix: staging/
-            ExpirationInDays: 7
-          # User exports expire after 30 days
-          - Id: ExpireExports
-            Status: Enabled
-            Prefix: exports/
+            Prefix: user-staging/
             ExpirationInDays: 30
+          # report-bundles/ deliberately has no expiration rule. Those objects
+          # are live report publications, deleted explicitly when a report is
+          # withdrawn (delete_report_artifacts in the roboledger reports
+          # commands). A time-based rule here would destroy the published
+          # artifact of a report whose row still exists. Absence of coverage
+          # is the correct state — do not "fix" it.
           # Graph backups expire after 90 days (max tier retention)
           - Id: ExpireGraphBackups
             Status: Enabled

--- a/robosystems/config/deprovisioning.py
+++ b/robosystems/config/deprovisioning.py
@@ -17,11 +17,16 @@ class DeprovisioningConfig:
   backup_delay_hours: int = 24
   # 90 days for every tier: the S3 lifecycle rule (cloudformation/s3.yaml,
   # ExpireGraphBackups: 90) deletes the object then regardless of what is
-  # promised here, and the final backup creates no GraphBackup row, so the
-  # tier-aware cleanup job cannot extend it either. This table once promised
-  # 180/365 days to Large/XLarge — hosting the infrastructure could not
-  # deliver. Extending it for real means exempting final backups from the
-  # lifecycle rule and tracking them in GraphBackup.
+  # promised here. This table once promised 180/365 days to Large/XLarge —
+  # hosting the infrastructure could not deliver.
+  #
+  # The final backup is now tracked in GraphBackup (DeprovisionService's
+  # _register_final_backup), which is what makes it retrievable during the
+  # published export window and moves its expiry onto the tier-aware cleanup
+  # job. That job reads the value below, so differentiating this table by tier
+  # would now take effect — but only up to the lifecycle rule's 90-day
+  # ceiling, which still deletes the object regardless. Extending it for real
+  # means raising or exempting that rule too.
   backup_hosting_days: dict[str, int] = field(
     default_factory=lambda: {
       "ladybug-standard": 90,

--- a/robosystems/models/api/graphs/backups.py
+++ b/robosystems/models/api/graphs/backups.py
@@ -56,7 +56,8 @@ class BackupResponse(BaseModel):
     description=(
       "Who started this backup. 'user' is one you requested and it counts "
       "against the tier's daily backup limit; 'scheduled' is taken nightly on "
-      "your behalf and does not."
+      "your behalf and does not; 'final' is the copy taken when a graph is "
+      "deprovisioned, so you can still retrieve your data afterwards."
     ),
   )
   memory_included: bool | None = Field(

--- a/robosystems/models/core/graph/graph_backup.py
+++ b/robosystems/models/core/graph/graph_backup.py
@@ -64,6 +64,15 @@ class BackupInitiator(str, Enum):
   SCHEDULED = "scheduled"
   """Taken by the nightly platform job. Listed, downloadable, quota-exempt."""
 
+  FINAL = "final"
+  """Taken at deprovisioning, as the departing customer's export copy.
+
+  Listed and downloadable like a scheduled backup — it is the one artifact a
+  customer most needs to reach, and the published export grace period is a
+  promise about exactly this row. Not SYSTEM: this is the opposite of an
+  artifact the customer cannot act on. Quota is irrelevant; the graph is gone.
+  """
+
   SYSTEM = "system"
   """Internal artifact — a pre-restore snapshot or a migration export.
 

--- a/robosystems/operations/admin/user_deletion.py
+++ b/robosystems/operations/admin/user_deletion.py
@@ -354,6 +354,15 @@ def execute_user_deletion(
   session.query(OrgInvitation).filter_by(invited_by=user_id).delete(
     synchronize_session=False
   )
+  # Documents and connections are graph assets that happen to record their
+  # creator, so the graph's teardown owns their removal (deprovision_service
+  # deletes both by graph_id). These two lines are a backstop for rows whose
+  # graph predates that cleanup: the org_has_live_graphs blocker above means
+  # every graph the user could reach is already DEPROVISIONED by the time we
+  # get here, so they cannot take a live org integration down with them.
+  # Do not relax that blocker without re-pointing these at the graph — by
+  # creator, this would delete the org's QuickBooks connection and its CDC
+  # watermark because a departing member happened to wire it up.
   session.query(Document).filter_by(user_id=user_id).delete(synchronize_session=False)
   session.query(Connection).filter_by(user_id=user_id).delete(synchronize_session=False)
   session.query(GraphUser).filter_by(user_id=user_id).delete(synchronize_session=False)

--- a/robosystems/operations/graph/deprovision_service.py
+++ b/robosystems/operations/graph/deprovision_service.py
@@ -8,7 +8,7 @@ and do not block the overall deprovisioning flow.
 """
 
 from dataclasses import dataclass, field
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 from sqlalchemy.orm import Session
 
@@ -26,6 +26,7 @@ class DeprovisionResult:
   graph_id: str
   previous_status: str = ""
   backup_created: bool = False
+  backup_registered: bool = False
   backup_path: str | None = None
   subgraphs_deleted: int = 0
   database_deleted: bool = False
@@ -123,7 +124,7 @@ class GraphDeprovisionService:
 
     # --- 1. Create final backup ---
     if create_backup and not skip_backup_check:
-      await self._create_final_backup(graph, result)
+      await self._create_final_backup(graph, session, result)
 
     # --- 2. Delete subgraphs ---
     await self._delete_subgraphs(graph_id, session, result)
@@ -170,8 +171,10 @@ class GraphDeprovisionService:
 
     return result
 
-  async def _create_final_backup(self, graph, result: DeprovisionResult) -> None:
-    """Create a final backup before teardown."""
+  async def _create_final_backup(
+    self, graph, session: Session, result: DeprovisionResult
+  ) -> None:
+    """Create a final backup before teardown, and register it for retrieval."""
     try:
       from .engine.backup_manager import (
         BackupFormat,
@@ -192,11 +195,92 @@ class GraphDeprovisionService:
       metadata = await backup_manager.create_backup(backup_job)
       result.backup_created = True
       result.backup_path = metadata.s3_key if metadata else None
+      if metadata:
+        self._register_final_backup(
+          graph,
+          session,
+          metadata,
+          backup_manager.s3_adapter.bucket_name,
+          retention_days,
+          result,
+        )
       logger.info(f"Final backup created for graph {graph.graph_id}")
     except Exception as e:
       error_msg = f"Backup creation failed: {e}"
       result.errors.append(error_msg)
       logger.warning(error_msg, extra={"graph_id": graph.graph_id})
+
+  def _register_final_backup(
+    self,
+    graph,
+    session: Session,
+    metadata,
+    s3_bucket: str,
+    retention_days: int,
+    result: DeprovisionResult,
+  ) -> None:
+    """Record the final backup as a GraphBackup row.
+
+    Without a row the object is unreachable: both the listing and the download
+    URL resolve through GraphBackup, so a final backup that exists only in S3
+    is invisible to the customer it was taken for — which is the export grace
+    period the privacy policy publishes. Only the user-initiated path created
+    rows, and deprovisioning does not go through it.
+
+    ``expires_at`` matches the tier's backup hosting window rather than the
+    shorter export window, so the retention sweep keeps treating this object
+    exactly as long as it did while untracked. Shortening it here would delete
+    the archive early, which is a different promise from the export one.
+
+    Built and flushed rather than going through ``GraphBackup.create`` /
+    ``complete_backup``: those commit, and this runs inside a best-effort step
+    of a caller-owned transaction, where an early commit would persist a
+    partial teardown if a later step failed.
+    """
+    from ...models.core.graph.graph_backup import (
+      BackupInitiator,
+      BackupStatus,
+      BackupType,
+      GraphBackup,
+    )
+
+    now = datetime.now(UTC)
+    backup_metadata: dict = {
+      "backup_format": metadata.backup_format,
+      "compression_ratio": metadata.compression_ratio,
+    }
+    if metadata.memory:
+      backup_metadata["memory"] = metadata.memory
+    if metadata.payload_delta:
+      backup_metadata["payload_delta"] = metadata.payload_delta
+
+    session.add(
+      GraphBackup(
+        graph_id=graph.graph_id,
+        database_name=graph.graph_id,
+        backup_type=BackupType.FULL.value,
+        initiated_by=BackupInitiator.FINAL.value,
+        status=BackupStatus.COMPLETED.value,
+        s3_bucket=s3_bucket,
+        s3_key=metadata.s3_key or "",
+        s3_metadata_key=metadata.s3_metadata_key,
+        original_size_bytes=metadata.original_size,
+        compressed_size_bytes=metadata.compressed_size,
+        compression_ratio=metadata.compression_ratio,
+        node_count=metadata.node_count,
+        relationship_count=metadata.relationship_count,
+        database_version=metadata.database_version,
+        backup_duration_seconds=metadata.backup_duration_seconds,
+        checksum=metadata.checksum,
+        compression_enabled=True,
+        backup_metadata=backup_metadata,
+        started_at=metadata.timestamp,
+        completed_at=now,
+        expires_at=now + timedelta(days=retention_days),
+      )
+    )
+    session.flush()
+    result.backup_registered = True
 
   async def _delete_subgraphs(
     self, graph_id: str, session: Session, result: DeprovisionResult

--- a/robosystems/operations/graph/deprovision_service.py
+++ b/robosystems/operations/graph/deprovision_service.py
@@ -33,6 +33,7 @@ class DeprovisionResult:
   registry_deallocated: bool = False
   records_cleaned: bool = False
   documents_deleted: int = 0
+  connections_deleted: int = 0
   search_purged: bool = False
   errors: list[str] = field(default_factory=list)
 
@@ -160,6 +161,9 @@ class GraphDeprovisionService:
         "backup_created": result.backup_created,
         "subgraphs_deleted": result.subgraphs_deleted,
         "database_deleted": result.database_deleted,
+        "documents_deleted": result.documents_deleted,
+        "connections_deleted": result.connections_deleted,
+        "search_purged": result.search_purged,
         "errors": result.errors,
       },
     )
@@ -315,6 +319,10 @@ class GraphDeprovisionService:
     GraphBackup records are intentionally kept for post-deprovisioning hosting.
     """
     try:
+      from ...models.core.connection.connection import Connection
+      from ...models.core.connection.connection_credentials import (
+        ConnectionCredentials,
+      )
       from ...models.core.document import Document
       from ...models.core.graph.graph_credits import (
         GraphCredits,
@@ -353,6 +361,31 @@ class GraphDeprovisionService:
         .delete(synchronize_session=False)
       )
       result.documents_deleted += documents_deleted
+
+      # Connections are a graph asset, not the creating member's: graph_id is
+      # the scoping FK and the delete endpoint gates on graph admin rather than
+      # the creator. So the graph's teardown is what removes them — nothing
+      # else does. Credentials go first and by id, because
+      # connection_credentials.connection_id carries no foreign key, so no
+      # cascade can ever reach it; dropping the connection rows first would
+      # strand a live encrypted OAuth token with no row left to find it by.
+      # Soft-deleted connections are included — deleted_at is unset here on
+      # purpose, since the graph is going away either way.
+      connection_ids = [
+        row.id
+        for row in session.query(Connection.id).filter(Connection.graph_id == graph_id)
+      ]
+      if connection_ids:
+        session.query(ConnectionCredentials).filter(
+          ConnectionCredentials.connection_id.in_(connection_ids)
+        ).delete(synchronize_session=False)
+
+      connections_deleted = (
+        session.query(Connection)
+        .filter(Connection.graph_id == graph_id)
+        .delete(synchronize_session=False)
+      )
+      result.connections_deleted += connections_deleted
 
       session.flush()
       result.records_cleaned = True

--- a/robosystems/operations/graph/deprovision_service.py
+++ b/robosystems/operations/graph/deprovision_service.py
@@ -236,6 +236,20 @@ class GraphDeprovisionService:
     ``complete_backup``: those commit, and this runs inside a best-effort step
     of a caller-owned transaction, where an early commit would persist a
     partial teardown if a later step failed.
+
+    The write goes inside a SAVEPOINT because it is the *first* database
+    statement of the teardown, and on PostgreSQL a failed statement aborts the
+    whole transaction — every later step would then fail against a dead
+    session, turning one best-effort miss into total failure and breaking this
+    module's contract that steps do not block each other.
+
+    A plain ``session.rollback()`` would be worse than the problem. The batch
+    job (``dagster/jobs/graph_lifecycle.py``) runs every graph through one
+    session that commits only after the loop, so rolling back here would
+    discard the completed teardowns of every graph already processed in that
+    run — graphs whose databases, extensions schemas and registry slots are
+    already gone, leaving their records looking live. The savepoint contains
+    the failure to this row alone.
     """
     from ...models.core.graph.graph_backup import (
       BackupInitiator,
@@ -254,32 +268,32 @@ class GraphDeprovisionService:
     if metadata.payload_delta:
       backup_metadata["payload_delta"] = metadata.payload_delta
 
-    session.add(
-      GraphBackup(
-        graph_id=graph.graph_id,
-        database_name=graph.graph_id,
-        backup_type=BackupType.FULL.value,
-        initiated_by=BackupInitiator.FINAL.value,
-        status=BackupStatus.COMPLETED.value,
-        s3_bucket=s3_bucket,
-        s3_key=metadata.s3_key or "",
-        s3_metadata_key=metadata.s3_metadata_key,
-        original_size_bytes=metadata.original_size,
-        compressed_size_bytes=metadata.compressed_size,
-        compression_ratio=metadata.compression_ratio,
-        node_count=metadata.node_count,
-        relationship_count=metadata.relationship_count,
-        database_version=metadata.database_version,
-        backup_duration_seconds=metadata.backup_duration_seconds,
-        checksum=metadata.checksum,
-        compression_enabled=True,
-        backup_metadata=backup_metadata,
-        started_at=metadata.timestamp,
-        completed_at=now,
-        expires_at=now + timedelta(days=retention_days),
+    with session.begin_nested():
+      session.add(
+        GraphBackup(
+          graph_id=graph.graph_id,
+          database_name=graph.graph_id,
+          backup_type=BackupType.FULL.value,
+          initiated_by=BackupInitiator.FINAL.value,
+          status=BackupStatus.COMPLETED.value,
+          s3_bucket=s3_bucket,
+          s3_key=metadata.s3_key or "",
+          s3_metadata_key=metadata.s3_metadata_key,
+          original_size_bytes=metadata.original_size,
+          compressed_size_bytes=metadata.compressed_size,
+          compression_ratio=metadata.compression_ratio,
+          node_count=metadata.node_count,
+          relationship_count=metadata.relationship_count,
+          database_version=metadata.database_version,
+          backup_duration_seconds=metadata.backup_duration_seconds,
+          checksum=metadata.checksum,
+          compression_enabled=True,
+          backup_metadata=backup_metadata,
+          started_at=metadata.timestamp,
+          completed_at=now,
+          expires_at=now + timedelta(days=retention_days),
+        )
       )
-    )
-    session.flush()
     result.backup_registered = True
 
   async def _delete_subgraphs(

--- a/robosystems/routers/graphs/backups/download.py
+++ b/robosystems/routers/graphs/backups/download.py
@@ -170,8 +170,15 @@ async def get_backup_download_url(
       # no per-graph role there.
       verify_admin_access(current_user, graph_id, session)
 
-      # Dedicated graph: check tier-based download limits
-      graph_record = Graph.get_by_id(graph_id, session)
+      # Dedicated graph: check tier-based download limits.
+      # Deprovisioned graphs are included deliberately. The final backup is
+      # taken precisely so a departing customer can retrieve their data during
+      # the published export grace period, and the default lookup skips
+      # deprovisioned rows — which 404'd the one download that window exists
+      # for. Access is unchanged: verify_admin_access above still gates this
+      # on graph admin, which after teardown only the org's owners and admins
+      # still hold.
+      graph_record = Graph.get_by_id(graph_id, session, include_deprovisioned=True)
       if not graph_record:
         logger.warning(
           f"Graph record not found for {graph_id} during download limit check"

--- a/tests/operations/graph/test_deprovision_service.py
+++ b/tests/operations/graph/test_deprovision_service.py
@@ -221,6 +221,77 @@ class TestDeprovisionService:
       assert 88 <= days <= 90, days
 
   @pytest.mark.asyncio
+  async def test_failed_backup_registration_does_not_wedge_the_teardown(
+    self, service, db_session, test_graph, test_user
+  ):
+    """A failed registration must not take the rest of the teardown with it.
+
+    Registering the backup is the first database write in deprovisioning, and
+    on PostgreSQL a failed statement aborts the entire transaction — so
+    without a SAVEPOINT every later step would fail against a dead session,
+    and in the batch job every graph after this one in the same run would too.
+    Here the write fails on a NOT NULL bucket; steps 2-7 must still complete.
+    """
+    from robosystems.models.core.document import Document
+    from robosystems.models.core.graph.graph_backup import GraphBackup
+
+    Document.create(
+      graph_id=test_graph.graph_id,
+      user_id=test_user.id,
+      title="Survives the failed registration",
+      content="confidential",
+      session=db_session,
+    )
+
+    with (
+      patch(
+        "robosystems.graph_api.client.factory.get_graph_client",
+        new_callable=AsyncMock,
+      ) as mock_get_client,
+      patch(
+        "robosystems.middleware.graph.allocation_manager.LadybugAllocationManager"
+      ) as mock_alloc_cls,
+      patch(
+        "robosystems.operations.graph.engine.backup_manager.BackupManager"
+      ) as mock_backup_cls,
+    ):
+      mock_get_client.return_value = AsyncMock()
+      mock_alloc_cls.return_value = AsyncMock()
+
+      mock_backup = AsyncMock()
+      # s3_bucket is NOT NULL, so the insert fails inside the savepoint.
+      mock_backup.s3_adapter.bucket_name = None
+      mock_backup.create_backup.return_value = _final_backup_metadata()
+      mock_backup_cls.return_value = mock_backup
+
+      result = await service.deprovision_graph(
+        test_graph.graph_id, db_session, create_backup=True
+      )
+
+      assert result.backup_registered is False
+      assert result.errors
+
+      # The teardown continued: PG cleanup ran and the graph reached its
+      # terminal state. Both would fail on a transaction poisoned at step 1.
+      assert result.records_cleaned is True
+      assert result.documents_deleted >= 1
+      assert (
+        db_session.query(Document)
+        .filter(Document.graph_id == test_graph.graph_id)
+        .count()
+        == 0
+      )
+      assert (
+        db_session.query(GraphBackup)
+        .filter(GraphBackup.graph_id == test_graph.graph_id)
+        .count()
+        == 0
+      )
+
+      db_session.refresh(test_graph)
+      assert test_graph.status == GraphStatus.DEPROVISIONED.value
+
+  @pytest.mark.asyncio
   async def test_deprovision_not_found(self, service, db_session):
     """Returns not_found for nonexistent graph."""
     result = await service.deprovision_graph("kg_nonexistent", db_session)

--- a/tests/operations/graph/test_deprovision_service.py
+++ b/tests/operations/graph/test_deprovision_service.py
@@ -1,7 +1,7 @@
 """Tests for GraphDeprovisionService."""
 
 import uuid
-from datetime import datetime
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -14,6 +14,31 @@ from robosystems.operations.graph.deprovision_service import (
 )
 
 SERVICE_MODULE = "robosystems.operations.graph.deprovision_service"
+
+
+def _final_backup_metadata(s3_key: str = "backups/test/final.lbug.zip"):
+  """A BackupMetadata stand-in with values a DB column will actually accept.
+
+  A bare MagicMock passes every attribute access and then fails at flush, which
+  the best-effort backup step swallows into result.errors — so the registration
+  would look tested while never running.
+  """
+  metadata = MagicMock()
+  metadata.s3_key = s3_key
+  metadata.s3_metadata_key = f"{s3_key}.metadata.json"
+  metadata.original_size = 2048
+  metadata.compressed_size = 512
+  metadata.compression_ratio = 0.75
+  metadata.node_count = 12
+  metadata.relationship_count = 7
+  metadata.database_version = "1.0"
+  metadata.backup_duration_seconds = 1.5
+  metadata.checksum = "abc123"
+  metadata.backup_format = "full_dump"
+  metadata.timestamp = datetime(2026, 8, 15, 12, 0, 0)
+  metadata.memory = None
+  metadata.payload_delta = None
+  return metadata
 
 
 @pytest.fixture
@@ -109,8 +134,8 @@ class TestDeprovisionService:
       mock_alloc_cls.return_value = mock_alloc
 
       mock_backup = AsyncMock()
-      mock_backup_metadata = MagicMock()
-      mock_backup_metadata.s3_key = "backups/test/final.dump"
+      mock_backup.s3_adapter.bucket_name = "test-backup-bucket"
+      mock_backup_metadata = _final_backup_metadata("backups/test/final.dump")
       mock_backup.create_backup.return_value = mock_backup_metadata
       mock_backup_cls.return_value = mock_backup
 
@@ -127,6 +152,73 @@ class TestDeprovisionService:
       db_session.refresh(test_graph)
       assert test_graph.status == GraphStatus.DEPROVISIONED.value
       assert test_graph.deleted_at is not None
+
+  @pytest.mark.asyncio
+  async def test_final_backup_is_registered_for_retrieval(
+    self, service, db_session, test_graph
+  ):
+    """The final backup must be reachable, not just present in S3.
+
+    Both the listing and the download URL resolve through GraphBackup, so an
+    unregistered final backup is invisible to the customer whose export grace
+    period it exists to serve.
+    """
+    from robosystems.models.core.graph.graph_backup import (
+      BackupInitiator,
+      BackupStatus,
+      GraphBackup,
+    )
+
+    with (
+      patch(
+        "robosystems.graph_api.client.factory.get_graph_client",
+        new_callable=AsyncMock,
+      ) as mock_get_client,
+      patch(
+        "robosystems.middleware.graph.allocation_manager.LadybugAllocationManager"
+      ) as mock_alloc_cls,
+      patch(
+        "robosystems.operations.graph.engine.backup_manager.BackupManager"
+      ) as mock_backup_cls,
+    ):
+      mock_get_client.return_value = AsyncMock()
+      mock_alloc_cls.return_value = AsyncMock()
+
+      mock_backup = AsyncMock()
+      mock_backup.s3_adapter.bucket_name = "test-backup-bucket"
+      mock_backup.create_backup.return_value = _final_backup_metadata()
+      mock_backup_cls.return_value = mock_backup
+
+      result = await service.deprovision_graph(
+        test_graph.graph_id, db_session, create_backup=True
+      )
+
+      assert result.backup_created is True
+      assert result.backup_registered is True, result.errors
+
+      row = (
+        db_session.query(GraphBackup)
+        .filter(GraphBackup.graph_id == test_graph.graph_id)
+        .one()
+      )
+      assert row.status == BackupStatus.COMPLETED.value
+      assert row.s3_key == "backups/test/final.lbug.zip"
+      assert row.s3_bucket == "test-backup-bucket"
+
+      # Not SYSTEM: that initiator is filtered out of the customer listing,
+      # which would leave the export invisible for a second reason.
+      assert row.initiated_by == BackupInitiator.FINAL.value
+      assert row.initiated_by != BackupInitiator.SYSTEM.value
+
+      # Expiry tracks the tier's backup hosting window, not the shorter export
+      # window — a 30-day expiry here would delete the archive early.
+      assert row.expires_at is not None
+      # The column is naive; the value written was UTC. Compare like for like.
+      expires_at = row.expires_at
+      if expires_at.tzinfo is not None:
+        expires_at = expires_at.astimezone(UTC).replace(tzinfo=None)
+      days = (expires_at - datetime.now(UTC).replace(tzinfo=None)).days
+      assert 88 <= days <= 90, days
 
   @pytest.mark.asyncio
   async def test_deprovision_not_found(self, service, db_session):

--- a/tests/operations/graph/test_deprovision_service.py
+++ b/tests/operations/graph/test_deprovision_service.py
@@ -370,6 +370,10 @@ class TestDeprovisionService:
     self, service, db_session, test_graph, test_user
   ):
     """Verify PG records are cleaned up."""
+    from robosystems.models.core.connection.connection import Connection
+    from robosystems.models.core.connection.connection_credentials import (
+      ConnectionCredentials,
+    )
     from robosystems.models.core.document import Document
     from robosystems.models.core.graph.graph_credits import GraphCredits
     from robosystems.models.core.graph.graph_user import GraphUser
@@ -397,6 +401,27 @@ class TestDeprovisionService:
       content="confidential",
       session=db_session,
     )
+
+    connection = Connection.create(
+      graph_id=test_graph.graph_id,
+      user_id=test_user.id,
+      provider="quickbooks",
+      session=db_session,
+      realm_id="realm-departed",
+    )
+    # Built directly rather than through create(): that path encrypts, which
+    # needs a real Fernet key, and what is under test is that the row is
+    # removed — not how its contents were sealed.
+    db_session.add(
+      ConnectionCredentials(
+        connection_id=connection.id,
+        provider="quickbooks",
+        user_id=test_user.id,
+        encrypted_credentials="ciphertext-standing-in-for-a-refresh-token",
+      )
+    )
+    db_session.commit()
+    connection_id = connection.id
 
     with (
       patch(
@@ -442,6 +467,24 @@ class TestDeprovisionService:
       )
       assert remaining_documents == 0
       assert result.documents_deleted >= 1
+
+      # Neither the connection nor — critically — the encrypted OAuth token
+      # behind it may outlive the graph. connection_credentials carries no FK,
+      # so nothing else in the tree would ever reach it.
+      remaining_connections = (
+        db_session.query(Connection)
+        .filter(Connection.graph_id == test_graph.graph_id)
+        .count()
+      )
+      assert remaining_connections == 0
+      assert result.connections_deleted >= 1
+
+      remaining_credentials = (
+        db_session.query(ConnectionCredentials)
+        .filter(ConnectionCredentials.connection_id == connection_id)
+        .count()
+      )
+      assert remaining_credentials == 0
 
   @pytest.mark.asyncio
   async def test_deprovision_updates_subscription_metadata(


### PR DESCRIPTION
## Summary

Graph deprovisioning left two loose ends: connection records were never removed with the graph they belonged to, and the final backup taken during teardown was written to S3 but never registered, so nothing could reach it. This closes both — offboarding now removes what it should, and keeps reachable the one archive it exists to hand back.

It also corrects two S3 lifecycle rules in the user bucket that pointed at prefixes which have never existed, so pre-ingestion uploads were covered by nothing and accumulated indefinitely.

All three were found while reviewing the data deletion and retention design notes against what the code actually does.

## Changes

**`operations/graph/deprovision_service.py`**

- `_clean_pg_records` now deletes `Connection` and `ConnectionCredentials` for the graph. Credentials are removed first and by id: `connection_credentials.connection_id` carries no foreign key, so no cascade reaches it and removing the connection rows first would leave its rows with nothing to find them by. Soft-deleted connections are included, since the graph is going either way.
- `_create_final_backup` now records the backup as a `GraphBackup` row via a new `_register_final_backup`. The row is built and flushed rather than going through `GraphBackup.create` / `complete_backup` — both of those commit, and this runs inside a best-effort step of a caller-owned transaction, where an early commit would persist a partial teardown if a later step failed.
- `expires_at` follows the tier's backup hosting window, not the shorter retrieval window. The cleanup job deletes objects past `expires_at`, so a shorter value here would remove the archive early; retrieval and retention are separate promises. The object's lifetime is unchanged either way — while untracked these resolved to the 90-day maximum through the orphan sweep.
- `DeprovisionResult` gains `connections_deleted` and `backup_registered`, and the operator log line now carries `documents_deleted`, `connections_deleted` and `search_purged`. Two of those fields already existed but never reached the log, so it could not state what teardown actually removed.

**`models/core/graph/graph_backup.py`**

- New `BackupInitiator.FINAL`. Deliberately not `SYSTEM`: that initiator is filtered out of the customer listing by design, as an artifact the customer cannot act on — the opposite of this row. `FINAL` passes the existing `!= SYSTEM` filter with no change to the listing query.

**`routers/graphs/backups/download.py`**

- The tier-limit lookup now resolves deprovisioned graphs. The default lookup skips them, which returned 404 *after* both access checks had already passed. **Worth a close look:** authorization is unchanged — `verify_admin_access` still gates the endpoint on graph admin, which after teardown only an org's owners and admins hold.

**`cloudformation/s3.yaml`**

- The user bucket carried `ExpireStagingData` (`staging/`, 7 days) and `ExpireExports` (`exports/`, 30 days). Neither prefix exists in that bucket — verified against prod, which holds exactly `graph-backups/`, `report-bundles/`, `shared-repositories/` and `user-staging/`. S3 prefix matching is literal, so both rules were inert and `user-staging/` was covered by nothing.
- Replaced with one rule on `user-staging/` at 30 days. These objects are ingestion input, not a system of record — the graph holds the result. 30 rather than the old rule's 7 because that number was written against a prefix nothing ever wrote to, so it was never sized against a real upload-to-ingest gap.
- **`report-bundles/` is deliberately left uncovered**, now with a comment recording why: those objects are live report publications with an explicit application-level delete on withdrawal (`delete_report_artifacts`), and a time-based rule would remove the published artifact of a report whose row still exists. Absence of coverage is the correct state there.
- **Deployment note:** the existing objects under `user-staging/` are all older than 30 days, so the first lifecycle evaluation after deploy will expire them. The bucket is versioned, so that writes delete markers and `ExpireNoncurrentVersions` reclaims the space ~30 days later.

**`models/api/graphs/backups.py`**

- The `initiated_by` description now covers the new value, which would otherwise reach the listing undescribed.

## Breaking Changes

None.

No SDK coordination needed. `initiated_by` is typed `str` in the API model, so the new value is data rather than a schema change, and the OpenAPI shape is unchanged apart from that field's description text. `DeprovisionResult` is internal and is not part of any response model. Everything else is additive.

## Testing

- `just test` — 12,921 passed, 38 skipped, 0 failed (5m09s).
- `just test-code` — clean (ruff, format, basedpyright, cf-lint), re-run after each subsequent commit including the template change; `just cf-lint s3` passes.
- `tests/operations/graph/test_deprovision_service.py` extended: teardown now asserts zero connection rows **and** zero credential rows, and a new test asserts the final backup is registered, completed, not `SYSTEM`-initiated, and expiring at the hosting window rather than a shorter one.
- One test-hygiene fix included: the existing deprovision test used a bare `MagicMock` for backup metadata, which passes every attribute access and then fails at flush — swallowed by the best-effort backup step. It now uses values a database column accepts, so the registration path is genuinely exercised rather than silently skipped.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
