### PR TITLE
fix(auth): retire revoked API keys from the listing and the sweep

### DIFF
--- a/robosystems/dagster/jobs/infrastructure.py
+++ b/robosystems/dagster/jobs/infrastructure.py
@@ -50,11 +50,11 @@ REVOKED_KEY_RETENTION_DAYS = 30
 def cleanup_stale_api_keys(context: OpExecutionContext, db: DatabaseResource) -> dict:
   """Delete API keys that are past their expiry or long revoked.
 
-  Each key's cached validation entry is cleared before its row is dropped:
-  the cache is keyed on the row's fingerprint, so once the row is gone a
-  surviving entry can never be targeted and would keep the key authenticating
-  until its TTL with nothing left to revoke. A key whose cache clear fails is
-  left in place for the next run rather than deleted blind.
+  A key that lapsed by date is cleared from the validation cache before its
+  row is dropped: the cache is keyed on the row's fingerprint, so once the
+  row is gone a surviving entry can never be targeted and would keep the key
+  authenticating until its TTL with nothing left to revoke. A key whose cache
+  clear fails is left in place for the next run rather than deleted blind.
   """
   with db.get_session() as session:
     now = datetime.now(UTC)
@@ -81,7 +81,12 @@ def cleanup_stale_api_keys(context: OpExecutionContext, db: DatabaseResource) ->
     deferred_count = 0
 
     for key in stale_keys:
-      if not key.invalidate_cache():
+      # A key revoked long ago has no cache entry left to strand: the
+      # validation cache lives for minutes against a retention window of
+      # days, and clearing it costs two keyspace scans against the shared
+      # cache — not worth spending where it cannot pay. Only a key still
+      # active at the point it lapsed by date can hold a live entry.
+      if key.is_active and not key.invalidate_cache():
         deferred_count += 1
         continue
       session.delete(key)

--- a/robosystems/dagster/jobs/infrastructure.py
+++ b/robosystems/dagster/jobs/infrastructure.py
@@ -1,12 +1,12 @@
 """Dagster infrastructure jobs.
 
 These jobs handle system maintenance:
-- Auth cleanup (expired API keys, tokens)
+- Auth cleanup (expired and long-revoked API keys)
 - Health checks (credit allocation, graph credits)
 - Graph instance monitoring
 """
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from dagster import (
@@ -16,6 +16,7 @@ from dagster import (
   job,
   op,
 )
+from sqlalchemy import and_, or_
 
 from robosystems.config import env
 from robosystems.dagster.resources import DatabaseResource
@@ -38,31 +39,62 @@ INSTANCE_SCHEDULE_STATUS = (
 # Auth Cleanup Job
 # ============================================================================
 
+# Revoked keys are held briefly rather than dropped on revocation, so an
+# accidental revocation can still be traced and so the row outlives the
+# validation cache entry it must invalidate. Past that, the row is only
+# clutter — nothing can reactivate a key from the user-facing surface.
+REVOKED_KEY_RETENTION_DAYS = 30
+
 
 @op
-def cleanup_expired_api_keys(context: OpExecutionContext, db: DatabaseResource) -> dict:
-  """Clean up expired API keys from the database."""
+def cleanup_stale_api_keys(context: OpExecutionContext, db: DatabaseResource) -> dict:
+  """Delete API keys that are past their expiry or long revoked.
+
+  Each key's cached validation entry is cleared before its row is dropped:
+  the cache is keyed on the row's fingerprint, so once the row is gone a
+  surviving entry can never be targeted and would keep the key authenticating
+  until its TTL with nothing left to revoke. A key whose cache clear fails is
+  left in place for the next run rather than deleted blind.
+  """
   with db.get_session() as session:
     now = datetime.now(UTC)
+    revoked_cutoff = now - timedelta(days=REVOKED_KEY_RETENTION_DAYS)
 
-    expired_keys = (
+    stale_keys = (
       session.query(UserAPIKey)
       .filter(
-        UserAPIKey.expires_at.isnot(None),
-        UserAPIKey.expires_at < now,
+        or_(
+          and_(
+            UserAPIKey.expires_at.isnot(None),
+            UserAPIKey.expires_at < now,
+          ),
+          and_(
+            UserAPIKey.is_active.is_(False),
+            UserAPIKey.updated_at < revoked_cutoff,
+          ),
+        )
       )
       .all()
     )
 
-    deleted_count = len(expired_keys)
+    deleted_count = 0
+    deferred_count = 0
 
-    for key in expired_keys:
+    for key in stale_keys:
+      if not key.invalidate_cache():
+        deferred_count += 1
+        continue
       session.delete(key)
+      deleted_count += 1
 
-    context.log.info(f"Cleaned up {deleted_count} expired API keys")
+    context.log.info(
+      f"API key cleanup: {deleted_count} deleted, "
+      f"{deferred_count} deferred (cache entry still live)"
+    )
 
     return {
       "deleted_count": deleted_count,
+      "deferred_count": deferred_count,
       "timestamp": now.isoformat(),
     }
 
@@ -70,7 +102,7 @@ def cleanup_expired_api_keys(context: OpExecutionContext, db: DatabaseResource) 
 @job(tags={"dagster/priority": "1", "dagster/max_retries": 3})
 def hourly_auth_cleanup_job():
   """Hourly auth cleanup job."""
-  cleanup_expired_api_keys()
+  cleanup_stale_api_keys()
 
 
 # ============================================================================

--- a/robosystems/routers/user/api_keys.py
+++ b/robosystems/routers/user/api_keys.py
@@ -37,6 +37,7 @@ router = APIRouter(tags=["User"])
   "/user/api-keys",
   response_model=APIKeysResponse,
   summary="List API Keys",
+  description="Lists active keys only. Revoked keys are omitted — revocation is permanent, so a revoked key never returns to this list.",
   operation_id="listUserAPIKeys",
   responses={**AUTHENTICATED_ERROR_RESPONSES},
 )
@@ -51,18 +52,14 @@ async def list_api_keys(
   user_id = getattr(current_user, "id", None) if current_user else None
 
   try:
-    api_keys = UserAPIKey.get_by_user_id(current_user.id, db)
+    # Active only: a revoked key can never be reactivated from this surface,
+    # so listing it forever leaves the user's key list growing without bound
+    # and offers no action they can take on the row.
+    api_keys = UserAPIKey.get_active_by_user_id(current_user.id, db)
 
     api_key_infos = []
-    active_keys = 0
-    inactive_keys = 0
 
     for api_key in api_keys:
-      if api_key.is_active:
-        active_keys += 1
-      else:
-        inactive_keys += 1
-
       api_key_infos.append(
         APIKeyInfo(
           id=api_key.id,
@@ -86,9 +83,7 @@ async def list_api_keys(
       event_type="api_keys_listed",
       event_data={
         "user_id": user_id,
-        "total_keys": len(api_keys),
-        "active_keys": active_keys,
-        "inactive_keys": inactive_keys,
+        "active_keys": len(api_keys),
       },
       user_id=user_id,
     )

--- a/tests/dagster/test_infrastructure_jobs.py
+++ b/tests/dagster/test_infrastructure_jobs.py
@@ -117,8 +117,10 @@ class TestStaleApiKeyCleanup:
     until TTL.
     """
     stuck = MagicMock()
+    stuck.is_active = True
     stuck.invalidate_cache.return_value = False
     clean = MagicMock()
+    clean.is_active = True
     clean.invalidate_cache.return_value = True
 
     mock_session.query.return_value.filter.return_value.all.return_value = [
@@ -133,10 +135,27 @@ class TestStaleApiKeyCleanup:
     assert result["deferred_count"] == 1
 
   @pytest.mark.unit
+  def test_long_revoked_key_is_dropped_without_a_cache_scan(self, mock_session):
+    """Clearing the cache costs two keyspace scans and can find nothing this
+    long after revocation — the entry outlived its TTL weeks ago."""
+    revoked = MagicMock()
+    revoked.is_active = False
+
+    mock_session.query.return_value.filter.return_value.all.return_value = [revoked]
+
+    result = cleanup_stale_api_keys(build_op_context(), _db(mock_session))
+
+    revoked.invalidate_cache.assert_not_called()
+    mock_session.delete.assert_called_once_with(revoked)
+    assert result["deleted_count"] == 1
+    assert result["deferred_count"] == 0
+
+  @pytest.mark.unit
   def test_cache_is_cleared_before_the_row_is_dropped(self, mock_session):
     calls = []
 
     key = MagicMock()
+    key.is_active = True
     key.invalidate_cache.side_effect = lambda: calls.append("invalidate") or True
     mock_session.delete.side_effect = lambda _row: calls.append("delete")
     mock_session.query.return_value.filter.return_value.all.return_value = [key]

--- a/tests/dagster/test_infrastructure_jobs.py
+++ b/tests/dagster/test_infrastructure_jobs.py
@@ -3,14 +3,35 @@
 Tests auth cleanup, health check, and instance maintenance jobs.
 """
 
-from unittest.mock import patch
+from contextlib import contextmanager
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import MagicMock, patch
 
 import pytest
+from dagster import build_op_context
 
 from robosystems.dagster.jobs.infrastructure import (
+  REVOKED_KEY_RETENTION_DAYS,
+  cleanup_stale_api_keys,
   hourly_auth_cleanup_job,
   weekly_health_check_job,
 )
+from robosystems.models.core.user.user_api_key import UserAPIKey
+
+
+def _db(session: Any) -> MagicMock:
+  """Stand in for DatabaseResource, handing the op `session` and committing
+  on exit the way the real resource does."""
+
+  @contextmanager
+  def _session_cm():
+    yield session
+    session.commit()
+
+  db = MagicMock()
+  db.get_session = _session_cm
+  return db
 
 
 class TestJobGraphs:
@@ -33,6 +54,96 @@ class TestJobGraphs:
     assert job_def.name == "weekly_health_check_job"
     # Has multiple ops for different health checks
     assert len(job_def.all_node_defs) >= 2
+
+
+class TestStaleApiKeyCleanup:
+  """The sweep must take expired and long-revoked keys, and nothing else."""
+
+  @pytest.mark.unit
+  def test_sweeps_expired_and_long_revoked_keys_only(self, test_db, test_user):
+    now = datetime.now(UTC)
+
+    live, _ = UserAPIKey.create(user_id=test_user.id, name="live", session=test_db)
+    expired, _ = UserAPIKey.create(
+      user_id=test_user.id,
+      name="expired",
+      expires_at=now - timedelta(hours=1),
+      session=test_db,
+    )
+    revoked_recently, _ = UserAPIKey.create(
+      user_id=test_user.id, name="recent", session=test_db
+    )
+    revoked_long_ago, _ = UserAPIKey.create(
+      user_id=test_user.id, name="old", session=test_db
+    )
+
+    ids = {
+      name: str(key.id)
+      for name, key in {
+        "live": live,
+        "expired": expired,
+        "revoked_recently": revoked_recently,
+        "revoked_long_ago": revoked_long_ago,
+      }.items()
+    }
+
+    with patch.object(UserAPIKey, "invalidate_cache", return_value=True):
+      revoked_recently.deactivate(test_db)
+      revoked_long_ago.deactivate(test_db)
+
+      # deactivate() stamps updated_at, which is what dates the revocation.
+      revoked_long_ago.updated_at = now - timedelta(days=REVOKED_KEY_RETENTION_DAYS + 1)
+      test_db.commit()
+
+      result = cleanup_stale_api_keys(build_op_context(), _db(test_db))
+
+    surviving = {
+      str(row.id)
+      for row in test_db.query(UserAPIKey)
+      .filter(UserAPIKey.user_id == test_user.id)
+      .all()
+    }
+
+    assert surviving == {ids["live"], ids["revoked_recently"]}
+    assert result["deleted_count"] >= 2
+    assert result["deferred_count"] == 0
+
+  @pytest.mark.unit
+  def test_key_whose_cache_survives_is_deferred_not_deleted(self, mock_session):
+    """A row must outlive a failed cache clear — deleting it strands the entry.
+
+    The cache is keyed on the row's fingerprint, so once the row is gone the
+    surviving entry can never be targeted and the key keeps authenticating
+    until TTL.
+    """
+    stuck = MagicMock()
+    stuck.invalidate_cache.return_value = False
+    clean = MagicMock()
+    clean.invalidate_cache.return_value = True
+
+    mock_session.query.return_value.filter.return_value.all.return_value = [
+      stuck,
+      clean,
+    ]
+
+    result = cleanup_stale_api_keys(build_op_context(), _db(mock_session))
+
+    mock_session.delete.assert_called_once_with(clean)
+    assert result["deleted_count"] == 1
+    assert result["deferred_count"] == 1
+
+  @pytest.mark.unit
+  def test_cache_is_cleared_before_the_row_is_dropped(self, mock_session):
+    calls = []
+
+    key = MagicMock()
+    key.invalidate_cache.side_effect = lambda: calls.append("invalidate") or True
+    mock_session.delete.side_effect = lambda _row: calls.append("delete")
+    mock_session.query.return_value.filter.return_value.all.return_value = [key]
+
+    cleanup_stale_api_keys(build_op_context(), _db(mock_session))
+
+    assert calls == ["invalidate", "delete"]
 
 
 class TestJobExecution:

--- a/tests/routers/user/test_api_key_revocation.py
+++ b/tests/routers/user/test_api_key_revocation.py
@@ -48,3 +48,26 @@ class TestRevocationCompleteness:
     resp = client.delete(f"/v1/user/api-keys/{key_id}", headers=_auth(test_user))
     assert resp.status_code == 200
     assert _is_active(test_db, key_id) is False
+
+
+class TestRevokedKeysLeaveTheList:
+  """Revocation is permanent, so the listing drops the key rather than
+  carrying it forever as a row the user can take no action on."""
+
+  def test_list_returns_active_keys_only(self, client, test_user, test_db):
+    kept, _plain = UserAPIKey.create(user_id=test_user.id, name="kept", session=test_db)
+    doomed, _plain = UserAPIKey.create(
+      user_id=test_user.id, name="doomed", session=test_db
+    )
+    kept_id, doomed_id = str(kept.id), str(doomed.id)
+
+    resp = client.delete(f"/v1/user/api-keys/{doomed_id}", headers=_auth(test_user))
+    assert resp.status_code == 200
+
+    resp = client.get("/v1/user/api-keys", headers=_auth(test_user))
+    assert resp.status_code == 200
+    assert {key["id"] for key in resp.json()["api_keys"]} == {kept_id}
+
+    # The row itself stays put for the hourly sweep to retire on its own
+    # schedule — the listing hides it, revocation does not delete it.
+    assert _is_active(test_db, doomed_id) is False

--- a/tests/routers/user/test_user_profile.py
+++ b/tests/routers/user/test_user_profile.py
@@ -568,13 +568,13 @@ class TestUserAPIKeys:
     # Cleanup
     app.dependency_overrides = {}
 
-  @patch("robosystems.models.core.UserAPIKey.get_by_user_id")
+  @patch("robosystems.models.core.UserAPIKey.get_active_by_user_id")
   def test_list_api_keys_success(
-    self, mock_get_by_user_id, client_with_api_keys: TestClient
+    self, mock_get_active_by_user_id, client_with_api_keys: TestClient
   ):
     """Test successful API key listing."""
-    # Mock the database query to return the user's API keys
-    mock_get_by_user_id.return_value = client_with_api_keys.mock_user.api_keys
+    # The listing is active-only; revoked keys are excluded at the query.
+    mock_get_active_by_user_id.return_value = client_with_api_keys.mock_user.api_keys
 
     response = client_with_api_keys.get("/v1/user/api-keys")
 


### PR DESCRIPTION
## Summary

Revoked API keys had nowhere to go. Revocation is a soft flip (`is_active = False`), the listing endpoint returned every row a user had ever created, and the hourly cleanup job only deleted keys past an `expires_at` — a column that is optional at creation and therefore null for keys minted from the UI. The result is that rounds of key provisioning leave the settings screen dominated by dead keys, permanently, with no action available on any of those rows.

This makes the listing active-only and gives the hourly sweep a second criterion so the rows are actually retired.

## Changes

**`robosystems/routers/user/api_keys.py`**

- The listing now queries `get_active_by_user_id` instead of `get_by_user_id`. Revoked keys are excluded at the query, not in the response.
- The filter is applied in the handler only. `revoke_api_key` and `update_api_key` continue to resolve keys through the unfiltered lookup, deliberately: revoking an already-revoked key must find it and re-assert the cache invalidation, which is what the endpoint's 503-retry path relies on to converge.
- The `api_keys_listed` business event dropped its `total_keys` / `inactive_keys` split, which is now constant.

**`robosystems/dagster/jobs/infrastructure.py`**

- `cleanup_expired_api_keys` → `cleanup_stale_api_keys`, now also sweeping keys revoked more than `REVOKED_KEY_RETENTION_DAYS` (30) ago, dated off `updated_at`.
- A key that lapsed by date has its cached validation entry cleared before its row is dropped. Worth a close look: the cache is keyed on the row's fingerprint, so dropping the row first would leave an entry nothing can target. A key whose cache clear fails is counted as deferred and left for the next run rather than deleted blind — the same fail-loud contract the revoke endpoint uses.
- The revoked branch skips that clear. It runs two `KEYS` patterns against the shared cache, which Valkey serves single-threaded; against a five-minute validation TTL and a thirty-day retention window, it can only ever scan for an entry that lapsed weeks earlier. The cost was bounded while it ran once per interactive revocation and would have become a loop over every stale key.
- Return value gains `deferred_count`.

Note that filtering and sweeping are independent: the listing hides a revoked key immediately, and the row survives its retention window regardless.

## Breaking Changes

None. The response model and parameters of `listUserAPIKeys` are unchanged, so no client regeneration is required — the only OpenAPI movement is an added `description` string on the endpoint, which is documentation-only and touches neither tier of the SDK contract.

API consumers reading this endpoint should know the behavior change is real even though the shape is not: revoked keys no longer appear in the response.

## Testing

- `just test` — 12,925 passed, 38 skipped.
- `just test-code` — clean (ruff, format, basedpyright, cf-lint).
- Both new tests were verified to fail against the pre-change source: the sweep test with the revoked branch removed from the predicate, the listing test with the handler pointed back at the unfiltered lookup.
- The sweep's predicate is covered against a real database (which rows survive, which are taken); the deferral and the invalidate-before-delete ordering are covered with a mocked session.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
