### PR TITLE
fix(graph): exempt shared repositories from the orphan-registration sweep

### DIFF
--- a/robosystems/dagster/jobs/infrastructure.py
+++ b/robosystems/dagster/jobs/infrastructure.py
@@ -287,7 +287,9 @@ def cleanup_stale_registry_entries(context: OpExecutionContext) -> dict[str, Any
   Removes entries marked deleted more than 7 days ago. Entries whose
   instance_id is missing from the instance registry are marked and counted
   (``OrphanedGraphRegistrations``), never removed — the row is a live graph's
-  routing and the instance registry drifts on ASG cycling.
+  routing and the instance registry drifts on ASG cycling. Shared
+  repositories are exempt: they route via ALB, not via their registry row,
+  and their master is parked to zero between ingestion runs.
   """
   from robosystems.operations.graph.infrastructure import InstanceMonitor
 

--- a/robosystems/operations/graph/infrastructure.py
+++ b/robosystems/operations/graph/infrastructure.py
@@ -28,6 +28,7 @@ import boto3
 from botocore.exceptions import ClientError
 
 from robosystems.config import env
+from robosystems.config.shared_repositories import is_shared_repository_or_subgraph
 from robosystems.logger import logger
 
 if TYPE_CHECKING:
@@ -405,6 +406,11 @@ class InstanceMonitor:
     ``OrphanedGraphRegistrations`` so it can alarm, and the stamp is cleared
     when the instance reappears. Reconciling from on-disk truth is the
     follow-up, not this sweep.
+
+    Shared repositories are exempt from the orphan check — their rows are
+    bookkeeping, not routing, and their master is deliberately parked to zero
+    between ingestion runs. An exempt row that still carries a stamp from
+    before this rule is cleared on the next sweep.
     """
     logger.info("Starting graph registry cleanup")
 
@@ -466,7 +472,20 @@ class InstanceMonitor:
             result.errors += 1
           continue
 
-        instance_missing = bool(instance_id) and instance_id not in valid_instances
+        # A shared repository is exempt: its row is not a routing pointer.
+        # ``GraphClientFactory._create_shared_repository_client`` branches
+        # before any graph-registry lookup — reads go to the replica ALB,
+        # writes resolve the master from the *instance* registry by
+        # ``node_type=shared_master``. The shared master is also parked to
+        # zero between ingestion runs, so the instance its row names is
+        # legitimately absent most of the day; counting that as drift pages
+        # every night for a healthy fleet. Same predicate the router uses, so
+        # the two can never disagree about which graphs this applies to.
+        instance_missing = (
+          bool(instance_id)
+          and instance_id not in valid_instances
+          and not is_shared_repository_or_subgraph(graph_id)
+        )
         already_marked = item.get("instance_missing_since") is not None
 
         if instance_missing:
@@ -489,8 +508,8 @@ class InstanceMonitor:
               result.errors += 1
         elif already_marked:
           logger.info(
-            f"Graph {graph_id}: instance {instance_id} is back in the registry; "
-            "clearing the orphan marker"
+            f"Graph {graph_id} no longer counts as orphaned "
+            f"(instance {instance_id}); clearing the marker"
           )
           try:
             graph_table.update_item(

--- a/tests/operations/graph/test_infrastructure.py
+++ b/tests/operations/graph/test_infrastructure.py
@@ -470,6 +470,90 @@ class TestCleanupStaleGraphs:
     assert metric["MetricData"][0]["Value"] == 0
 
   @pytest.mark.unit
+  def test_shared_repository_with_parked_master_is_not_orphaned(self, monitor):
+    """A shared repo's row is bookkeeping, not routing, and its master is
+    parked to zero between ingestion runs — so a missing instance is the
+    normal resting state, not drift. Uses the real registry ids so the
+    exemption cannot drift from the predicate the router uses."""
+    graph_table = _make_dynamo_table(
+      items=[
+        {"graph_id": "sec", "status": "active", "instance_id": "i-parkedmaster0001"},
+        {
+          "graph_id": "sec_historical",
+          "status": "active",
+          "instance_id": "i-parkedmaster0001",
+        },
+      ]
+    )
+    instance_table = _make_dynamo_table(items=[])
+    monitor._dynamodb.Table.side_effect = lambda name: (
+      graph_table if name == "test-graph" else instance_table
+    )
+
+    result = monitor.cleanup_stale_graphs()
+
+    assert result.orphaned_count == 0
+    assert result.updated_count == 0
+    graph_table.update_item.assert_not_called()
+    graph_table.delete_item.assert_not_called()
+    metric = monitor._cloudwatch.put_metric_data.call_args.kwargs
+    assert metric["MetricData"][0]["Value"] == 0
+
+  @pytest.mark.unit
+  def test_shared_repository_marker_from_before_the_exemption_is_cleared(self, monitor):
+    """A row stamped by a sweep that predates the exemption self-heals rather
+    than carrying the stale marker forever."""
+    graph_table = _make_dynamo_table(
+      items=[
+        {
+          "graph_id": "sec",
+          "status": "active",
+          "instance_id": "i-parkedmaster0001",
+          "instance_missing_since": "2026-08-16T02:01:26+00:00",
+        },
+      ]
+    )
+    instance_table = _make_dynamo_table(items=[])
+    monitor._dynamodb.Table.side_effect = lambda name: (
+      graph_table if name == "test-graph" else instance_table
+    )
+
+    result = monitor.cleanup_stale_graphs()
+
+    assert result.orphaned_count == 0
+    assert result.updated_count == 1
+    update = graph_table.update_item.call_args.kwargs
+    assert update["Key"] == {"graph_id": "sec"}
+    assert update["UpdateExpression"] == "REMOVE instance_missing_since"
+
+  @pytest.mark.unit
+  def test_user_graph_is_still_orphaned_when_a_shared_repo_is_present(self, monitor):
+    """The exemption is scoped to shared repos — a user graph on the same
+    sweep is still marked and counted."""
+    graph_table = _make_dynamo_table(
+      items=[
+        {"graph_id": "sec", "status": "active", "instance_id": "i-parkedmaster0001"},
+        {
+          "graph_id": "kg_orphan",
+          "status": "active",
+          "instance_id": "i-doesnotexist00001",
+        },
+      ]
+    )
+    instance_table = _make_dynamo_table(items=[])
+    monitor._dynamodb.Table.side_effect = lambda name: (
+      graph_table if name == "test-graph" else instance_table
+    )
+
+    result = monitor.cleanup_stale_graphs()
+
+    assert result.orphaned_count == 1
+    update = graph_table.update_item.call_args.kwargs
+    assert update["Key"] == {"graph_id": "kg_orphan"}
+    metric = monitor._cloudwatch.put_metric_data.call_args.kwargs
+    assert metric["MetricData"][0]["Value"] == 1
+
+  @pytest.mark.unit
   def test_exception_sets_error_message(self, monitor):
     """Top-level exception is captured in error_message."""
     monitor._dynamodb.Table.side_effect = Exception("scan failed")


### PR DESCRIPTION
## Summary

`robosystems-graph-prod-orphaned-graph-registrations` went to ALARM on its first evaluation after deploy, for a healthy fleet. The shared master is parked to zero between SEC ingestion runs, so the instance named by the `sec` graph-registry row is absent from the instance registry most of the day — and the nightly sweep read that resting state as routing drift.

A shared repository's registry row is bookkeeping, not routing, so the stale `instance_id` is never dereferenced. This exempts those rows from the orphan check.

## Changes

**`operations/graph/infrastructure.py`**

- `cleanup_stale_graphs` no longer counts or stamps a row whose `graph_id` is a shared repository or a subgraph of one.
- The predicate is `is_shared_repository_or_subgraph` — the same one `GraphClientFactory._create_shared_repository_client` uses to take the ALB path — rather than the row's own `repository_type` field. **Worth a look:** this is the load-bearing choice. Reusing the router's predicate means the exemption and the routing decision cannot disagree about which graphs it covers, and it picks up subgraphs (`sec_historical`) without a second rule. The row field would have been self-contained but could drift from what the router actually does, and depends on the registering userdata having written it.
- The exemption is expressed as an extra conjunct on `instance_missing` rather than a `continue`, so an exempt row that still carries a marker falls through to the existing clear branch and self-heals on the next sweep. The live `sec` row carries one now; no manual registry write is needed to clean it up.
- That clear branch's log line said "instance … is back in the registry", which is not true for the exemption path. It now states the outcome without asserting a cause.

**`dagster/jobs/infrastructure.py`**

- Op docstring records the exemption alongside the existing mark-never-delete rule.

**`tests/operations/graph/test_infrastructure.py`**

- Three cases added. Two of them drive the real `sec` / `sec_historical` ids through the actual manifest registry rather than a patched predicate, so they fail if the registry ever stops recognising the deployed shared repo.
- The third asserts a user graph orphaned in the *same* sweep as an exempt row is still marked and counted — the exemption must not widen into a general suppression.

No CloudFormation change. The alarm's threshold and description are still correct; only what fed the metric was wrong. It clears on the first post-deploy sweep that publishes zero.

## Breaking Changes

None.

No SDK coordination needed. The change is confined to a scheduled Dagster sweep and its operation; no REST shape, GraphQL schema, operations envelope, or response model is touched, and the OpenAPI spec is unchanged.

## Testing

- `just test-code` — clean (ruff, format, basedpyright, cf-lint), re-run after the commit.
- `uv run pytest tests/operations/graph/ tests/dagster/` — 890 passed.
- Full `just test-all` not run in this session; the change is scoped to one operation and its Dagster op, both covered above.
- Verified against prod before writing the fix: the `sec` row points at `i-062f857aca359af01`, terminated at 13:30Z on 2026-08-15 when the shared-writer ASG went 1→0; ASG history shows the same wake/sleep cycle daily, with no wake window overlapping either sweep hour (weekly 02:00 UTC, daily 03:00 UTC). Every other registry row is clean and both shared replicas are InService.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
