### PR TITLE
fix(orgs): close out an account when its last membership goes

### DIFF
--- a/robosystems/models/api/admin/users.py
+++ b/robosystems/models/api/admin/users.py
@@ -13,7 +13,18 @@ class UserResponse(BaseModel):
   email: str
   name: str | None
   email_verified: bool
-  org_id: str
+  is_active: bool = Field(
+    default=True,
+    description=(
+      "Whether the account can authenticate. Removal from a last organization "
+      "deactivates the account, so an inactive user with no org is the shape "
+      "support sees when asked to free an email."
+    ),
+  )
+  org_id: str = Field(
+    default="",
+    description="Empty when the user belongs to no organization.",
+  )
   org_role: str
   created_at: datetime
   updated_at: datetime

--- a/robosystems/routers/admin/users.py
+++ b/robosystems/routers/admin/users.py
@@ -51,7 +51,12 @@ async def list_users(
   """List all users with optional filters."""
   session = next(get_db_session())
   try:
-    query = session.query(User).join(OrgUser, User.id == OrgUser.user_id)
+    # Outer join: a user with no org membership is exactly who support needs
+    # to find here — removal from a last org deactivates the account and
+    # leaves the email squatted, and freeing it means resolving this email to
+    # an id. An inner join hid precisely that population (the row builder
+    # below already handles a missing membership).
+    query = session.query(User).outerjoin(OrgUser, User.id == OrgUser.user_id)
 
     if email:
       query = query.filter(User.email.ilike(f"%{email}%"))
@@ -72,6 +77,7 @@ async def list_users(
           email=user.email,
           name=user.name,
           email_verified=user.email_verified,
+          is_active=user.is_active,
           org_id=org_user.org_id if org_user else "",
           org_role=org_user.role if org_user else "MEMBER",
           created_at=user.created_at,
@@ -126,6 +132,7 @@ async def get_user(request: Request, user_id: str):
       email=user.email,
       name=user.name,
       email_verified=user.email_verified,
+      is_active=user.is_active,
       org_id=org_user.org_id if org_user else "",
       org_role=org_user.role if org_user else "MEMBER",
       created_at=user.created_at,

--- a/robosystems/routers/graphs/main.py
+++ b/robosystems/routers/graphs/main.py
@@ -368,10 +368,17 @@ async def create_graph(
     # Check org's graph limits
     user_orgs = OrgUser.get_user_orgs(current_user.id, db)
     if not user_orgs:
+      # Reachable, not exceptional: removal from a last org leaves an account
+      # with no membership, and every other org-resolving surface answers 403
+      # here. A 500 would file an ordinary authorization outcome as a server
+      # fault and count against the API's error rate.
       _raise_http_exception(
-        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        status_code=status.HTTP_403_FORBIDDEN,
         error_code="org_not_found",
-        message="User organization not found. Please contact support.",
+        message=(
+          "You are not a member of any organization, so there is nothing to "
+          "bill a new graph to. Please contact support."
+        ),
       )
 
     membership = user_orgs[0]

--- a/robosystems/routers/orgs/members.py
+++ b/robosystems/routers/orgs/members.py
@@ -320,11 +320,16 @@ async def remove_member(
       row.graph_id
       for row in db.query(Graph.graph_id).filter(Graph.org_id == org_id).all()
     ]
+    graph_grants_revoked = 0
     if org_graph_ids:
-      db.query(GraphUser).filter(
-        GraphUser.user_id == user_id,
-        GraphUser.graph_id.in_(org_graph_ids),
-      ).delete(synchronize_session=False)
+      graph_grants_revoked = (
+        db.query(GraphUser)
+        .filter(
+          GraphUser.user_id == user_id,
+          GraphUser.graph_id.in_(org_graph_ids),
+        )
+        .delete(synchronize_session=False)
+      )
 
     removed_role = target_membership.role
     db.delete(target_membership)
@@ -332,6 +337,25 @@ async def remove_member(
 
     api_key_cache.invalidate_user_jwt_graph_access(user_id)
     api_key_cache.invalidate_user_data(user_id)
+
+    # A user belongs to exactly one org, so removing their last membership
+    # leaves an account that can authenticate but reach nothing: every
+    # org-scoped surface resolves the caller's first membership and there is
+    # no way to create or join an org from the outside. Deactivating makes
+    # that state honest — the kill switch also bumps `session_version` and
+    # revokes API keys, so no credential outlives the membership that
+    # justified it. Reversible by an admin (`activate`) if the removal was a
+    # mistake; freeing the email for a fresh signup is still a deletion.
+    deactivated_user = False
+    if not OrgUser.get_user_orgs(user_id, db):
+      removed_user = User.get_by_id(user_id, db)
+      if removed_user is not None and removed_user.is_active:
+        removed_user.deactivate(db)
+        deactivated_user = True
+        logger.info(
+          f"Deactivated user {user_id}: removal from org {org_id} left them "
+          f"with no organization"
+        )
 
     SecurityAuditLogger.log_security_event(
       event_type=SecurityEventType.ORG_MEMBER_REMOVED,
@@ -342,8 +366,9 @@ async def remove_member(
         "target_user_id": user_id,
         "previous_role": removed_role.value,
         "self_removal": user_id == current_user.id,
-        "org_graph_grants_revoked": len(org_graph_ids),
+        "org_graph_grants_revoked": graph_grants_revoked,
         "repository_subscriptions_canceled": len(canceled),
+        "user_deactivated": deactivated_user,
       },
       risk_level="low",
     )

--- a/robosystems/routers/orgs/members.py
+++ b/robosystems/routers/orgs/members.py
@@ -346,16 +346,33 @@ async def remove_member(
     # revokes API keys, so no credential outlives the membership that
     # justified it. Reversible by an admin (`activate`) if the removal was a
     # mistake; freeing the email for a fresh signup is still a deletion.
+    #
+    # Best-effort by construction: the removal is already committed above, so
+    # a failure here must not fail the request. Letting it raise would report
+    # a completed removal as a 500 (the rollback is a no-op on an already
+    # committed transaction), send the caller to retry into a 404, and skip
+    # the audit record below — leaving a privileged access change with no
+    # evidence, which is the gap this surface just closed. Log loudly instead:
+    # the account is live when it should not be, which is the state this
+    # branch exists to prevent, and it is repaired by `users deactivate`.
     deactivated_user = False
     if not OrgUser.get_user_orgs(user_id, db):
       removed_user = User.get_by_id(user_id, db)
       if removed_user is not None and removed_user.is_active:
-        removed_user.deactivate(db)
-        deactivated_user = True
-        logger.info(
-          f"Deactivated user {user_id}: removal from org {org_id} left them "
-          f"with no organization"
-        )
+        try:
+          removed_user.deactivate(db)
+          deactivated_user = True
+          logger.info(
+            f"Deactivated user {user_id}: removal from org {org_id} left them "
+            f"with no organization"
+          )
+        except Exception as exc:
+          logger.critical(
+            f"Removed user {user_id} from org {org_id} but could not deactivate "
+            f"the account, which now has no organization and is still active: "
+            f"{exc!s}. Repair with: admin users deactivate {user_id}",
+            exc_info=True,
+          )
 
     SecurityAuditLogger.log_security_event(
       event_type=SecurityEventType.ORG_MEMBER_REMOVED,

--- a/tests/routers/admin/test_users.py
+++ b/tests/routers/admin/test_users.py
@@ -110,3 +110,69 @@ class TestDeleteUser:
     response = client.delete("/admin/v1/users/user_missing", headers=ADMIN_HEADERS)
 
     assert response.status_code == 404
+
+
+@pytest.fixture
+def orgless_user(db_session: Session):
+  """The state removal now leaves behind: deactivated, no org, email still
+  taken. This is exactly who support is asked to find."""
+  unique_id = str(uuid.uuid4())[:8]
+  user = User(
+    id=f"test_user_{unique_id}",
+    email=f"orgless+{unique_id}@example.com",
+    name="Orgless",
+    password_hash="test_hash",
+    is_active=False,
+  )
+  db_session.add(user)
+  db_session.commit()
+  return user
+
+
+class TestListingFindsOrglessUsers:
+  """Freeing a squatted email starts by resolving it to a user id. An inner
+  join on membership hid the one population that ever needs freeing."""
+
+  def test_listing_includes_a_user_with_no_org(
+    self, client, mock_admin_auth, orgless_user
+  ):
+    response = client.get(
+      "/admin/v1/users",
+      params={"email": orgless_user.email},
+      headers=ADMIN_HEADERS,
+    )
+
+    assert response.status_code == 200
+    emails = [u["email"] for u in response.json()]
+    assert orgless_user.email in emails
+
+  def test_orgless_row_reports_empty_org_and_inactive_status(
+    self, client, mock_admin_auth, orgless_user
+  ):
+    response = client.get(
+      "/admin/v1/users",
+      params={"email": orgless_user.email},
+      headers=ADMIN_HEADERS,
+    )
+
+    assert response.status_code == 200
+    row = next(u for u in response.json() if u["email"] == orgless_user.email)
+    assert row["org_id"] == ""
+    assert row["is_active"] is False
+
+  def test_a_user_with_an_org_is_still_listed_once(
+    self, client, mock_admin_auth, deletable_user
+  ):
+    """The outer join must not duplicate rows for users who do have a
+    membership."""
+    response = client.get(
+      "/admin/v1/users",
+      params={"email": deletable_user.email},
+      headers=ADMIN_HEADERS,
+    )
+
+    assert response.status_code == 200
+    rows = [u for u in response.json() if u["email"] == deletable_user.email]
+    assert len(rows) == 1
+    assert rows[0]["org_id"] != ""
+    assert rows[0]["is_active"] is True

--- a/tests/routers/graphs/test_graph.py
+++ b/tests/routers/graphs/test_graph.py
@@ -258,10 +258,12 @@ class TestGraphCreationEndpoint:
 
               assert response.status_code == 202
 
-  async def test_create_graph_user_limits_not_found(
+  async def test_create_graph_refuses_a_user_with_no_organization(
     self, async_client: AsyncClient, sample_graph_request
   ):
-    """Test graph creation when user has no organization."""
+    """A caller with no org is refused, not errored. Removal from a last org
+    leaves exactly this state, so it is an ordinary authorization outcome —
+    a 500 would file it as a server fault and count against the error rate."""
     with patch("robosystems.database.get_db_session") as mock_get_db:
       with patch("robosystems.models.core.OrgUser.get_user_orgs") as mock_get_user_orgs:
         mock_db = Mock()
@@ -275,10 +277,10 @@ class TestGraphCreationEndpoint:
           json=sample_graph_request.model_dump(),
         )
 
-        assert response.status_code == 500
+        assert response.status_code == 403
         data = response.json()
         assert data["detail"]["error"]["code"] == "org_not_found"
-        assert "User organization not found" in data["detail"]["error"]["message"]
+        assert "not a member of any organization" in data["detail"]["error"]["message"]
 
   async def test_create_graph_limit_reached(
     self, async_client: AsyncClient, sample_graph_request

--- a/tests/routers/orgs/test_members.py
+++ b/tests/routers/orgs/test_members.py
@@ -651,3 +651,28 @@ class TestRemovalFromLastOrgDeactivates:
     assert response.status_code == 204
     details = audit.log_security_event.call_args.kwargs["details"]
     assert details["org_graph_grants_revoked"] == 1
+
+  async def test_a_failed_deactivation_still_completes_and_records_the_removal(
+    self, async_client, test_db, test_user
+  ):
+    """The removal commits before deactivation, so a failure there must not
+    fail the request: raising would report a completed removal as a 500, send
+    a retry into a 404, and skip the audit record for a privileged access
+    change that really happened."""
+    from sqlalchemy.exc import SQLAlchemyError
+
+    org, member = self._org_with_owner_and_member(test_db, test_user)
+
+    with (
+      patch(
+        "robosystems.models.core.User.deactivate",
+        side_effect=SQLAlchemyError("commit failed"),
+      ),
+      patch("robosystems.routers.orgs.members.SecurityAuditLogger") as audit,
+    ):
+      response = await async_client.delete(f"/v1/orgs/{org.id}/members/{member.id}")
+
+    assert response.status_code == 204
+    assert OrgUser.get_by_org_and_user(org.id, member.id, test_db) is None
+    details = audit.log_security_event.call_args.kwargs["details"]
+    assert details["user_deactivated"] is False

--- a/tests/routers/orgs/test_members.py
+++ b/tests/routers/orgs/test_members.py
@@ -533,3 +533,121 @@ class TestOrgMembershipAuditEvents:
     assert response.status_code == 502
     audit.log_security_event.assert_not_called()
     assert OrgUser.get_by_org_and_user(org.id, member.id, test_db) is not None
+
+
+class TestRemovalFromLastOrgDeactivates:
+  """A user belongs to exactly one org, so losing their last membership
+  leaves an account that authenticates but reaches nothing. Removal
+  deactivates it rather than leaving that state live."""
+
+  def _org_with_owner_and_member(self, test_db, test_user):
+    org = Org.create(
+      name=f"Offboard Org {uuid4().hex[:6]}",
+      org_type=OrgType.TEAM,
+      session=test_db,
+    )
+    OrgUser.create(
+      org_id=org.id, user_id=test_user.id, role=OrgRole.OWNER, session=test_db
+    )
+    member = _create_user(test_db, test_user.password_hash)
+    OrgUser.create(
+      org_id=org.id, user_id=member.id, role=OrgRole.MEMBER, session=test_db
+    )
+    return org, member
+
+  async def test_last_membership_removal_deactivates_the_account(
+    self, async_client, test_db, test_user
+  ):
+    org, member = self._org_with_owner_and_member(test_db, test_user)
+    assert member.is_active is True
+
+    response = await async_client.delete(f"/v1/orgs/{org.id}/members/{member.id}")
+
+    assert response.status_code == 204
+    test_db.refresh(member)
+    assert member.is_active is False
+
+  async def test_deactivation_is_recorded_on_the_removal_event(
+    self, async_client, test_db, test_user
+  ):
+    org, member = self._org_with_owner_and_member(test_db, test_user)
+
+    with patch("robosystems.routers.orgs.members.SecurityAuditLogger") as audit:
+      response = await async_client.delete(f"/v1/orgs/{org.id}/members/{member.id}")
+
+    assert response.status_code == 204
+    details = audit.log_security_event.call_args.kwargs["details"]
+    assert details["user_deactivated"] is True
+
+  async def test_a_remaining_membership_leaves_the_account_active(
+    self, async_client, test_db, test_user
+  ):
+    """The trigger is *no org left*, not *an org was left*. A user who still
+    holds another membership keeps their account."""
+    org, member = self._org_with_owner_and_member(test_db, test_user)
+    second_org = Org.create(
+      name=f"Second Org {uuid4().hex[:6]}",
+      org_type=OrgType.TEAM,
+      session=test_db,
+    )
+    OrgUser.create(
+      org_id=second_org.id, user_id=member.id, role=OrgRole.MEMBER, session=test_db
+    )
+
+    response = await async_client.delete(f"/v1/orgs/{org.id}/members/{member.id}")
+
+    assert response.status_code == 204
+    test_db.refresh(member)
+    assert member.is_active is True
+
+  async def test_deactivation_revokes_the_removed_member_api_keys(
+    self, async_client, test_db, test_user
+  ):
+    """The point of routing through ``User.deactivate`` rather than setting
+    the flag: API keys carry no session version, so they must be revoked
+    explicitly or the removed member keeps programmatic access."""
+    from robosystems.models.core import UserAPIKey
+
+    org, member = self._org_with_owner_and_member(test_db, test_user)
+    _key, _plain = UserAPIKey.create(
+      user_id=member.id, name="offboarding probe", session=test_db
+    )
+    assert UserAPIKey.get_active_by_user_id(member.id, test_db)
+
+    response = await async_client.delete(f"/v1/orgs/{org.id}/members/{member.id}")
+
+    assert response.status_code == 204
+    assert UserAPIKey.get_active_by_user_id(member.id, test_db) == []
+
+  async def test_grant_count_reports_rows_deleted_not_graphs_swept(
+    self, async_client, test_db, test_user
+  ):
+    """The audited count is evidence: it must be the grants actually revoked,
+    not the org's graph count."""
+    from robosystems.models.core import Graph, GraphUser
+
+    org, member = self._org_with_owner_and_member(test_db, test_user)
+    granted = Graph.create(
+      graph_id=f"graph_{uuid4().hex[:8]}",
+      org_id=org.id,
+      graph_name="Granted",
+      graph_type="generic",
+      session=test_db,
+    )
+    Graph.create(
+      graph_id=f"graph_{uuid4().hex[:8]}",
+      org_id=org.id,
+      graph_name="Not Granted",
+      graph_type="generic",
+      session=test_db,
+    )
+    GraphUser.create(
+      user_id=member.id, graph_id=granted.graph_id, role="member", session=test_db
+    )
+
+    with patch("robosystems.routers.orgs.members.SecurityAuditLogger") as audit:
+      response = await async_client.delete(f"/v1/orgs/{org.id}/members/{member.id}")
+
+    assert response.status_code == 204
+    details = audit.log_security_event.call_args.kwargs["details"]
+    assert details["org_graph_grants_revoked"] == 1


### PR DESCRIPTION
## Summary

A user belongs to exactly one organization, so removing their last membership left an account in a state nothing handled: able to authenticate, unable to reach anything, and with no way to create or join an organization from the outside. This makes that outcome explicit — the account is closed out on removal — and fixes the two things that made the state hard to act on.

Found while running the org multi-user acceptance walk against production; details in `specs/security/org-multi-user-hardening.md` (F16).

## Changes

**`routers/orgs/members.py`** — when a removal leaves the member with no organization, the account is routed through the existing deactivation switch (which also bumps the session version and revokes API keys, so no credential outlives the membership that justified it). Reversible by an admin; freeing the address for a fresh signup remains a deletion. The removal record gains the outcome, and now reports the grants actually revoked rather than the organization's graph count.

**`routers/admin/users.py`, `models/api/admin/users.py`** — the user listing inner-joined membership, so an account belonging to no organization could not appear in it. That is exactly the population support is asked to act on, and the row builder already handled a missing membership; only the join disagreed. Now an outer join, and the response carries the account's active flag so a live account is distinguishable from a closed one.

**`routers/graphs/main.py`** — graph creation raised 500 for a caller with no organization, where every other organization-resolving surface answers 403. It is a reachable state, not a fault, and the 500 counted against the error rate the alarms watch. Now 403 with the same code.

## Breaking Changes

None. The admin user listing gains a field and returns rows it previously omitted; no field changed shape or meaning. `POST /v1/graphs` returns 403 instead of 500 for a caller with no organization — the error code is unchanged, and no client branches on it.

SDK: additive on the generated tier (`is_active` on the admin user response). Nothing in the stable tier is touched, so this rides a client minor at the next regen.

## Testing

- `just test` — full unit suite, **12938 passed, 38 skipped**.
- `just test-code` — ruff, format, basedpyright, cf-lint all clean.
- Nine new tests. The five covering deactivation and the three covering the listing were each confirmed to **fail against this branch's parent** before the fix, so they test the behavior rather than restating it.
- One pre-existing failure (`admin/test_orgs.py::test_list_orgs_includes_max_graphs`) appears only in partial-suite runs and reproduces identically on pristine `main`; it passes alone and in full-suite order.
