### PR TITLE
fix(forecast): anchor the walk on the seam, and keep forecasts out of the books

### DIFF
--- a/robosystems/middleware/mcp/tools/playbook_tools.py
+++ b/robosystems/middleware/mcp/tools/playbook_tools.py
@@ -85,10 +85,13 @@ _RECURRING_SEQUENCE: list[str] = [
   "the new closed_through. Nothing needs re-basing — the walk re-anchors on "
   "the newest closed month by itself and reports the move in its "
   "diagnostics, so the scenario's levers stay as authored. Read "
-  "anchor_period on the response to confirm it advanced; a scenario the "
-  "close has overtaken entirely fails loudly and needs its horizon "
-  "extended. Scenarios deliberately built on a counterfactual base carry "
-  "base_anchor='fixed' and stay put.",
+  "anchor_period on the response to confirm it advanced. A scenario whose "
+  "horizon the close has passed entirely computes no months and says so in "
+  "its diagnostics — its stale months are cleared and its levers kept, so "
+  "extending horizon_months and re-running is all it needs. Scenarios "
+  "deliberately built on a counterfactual base carry base_anchor='fixed' "
+  "and stay put. Note the anchor only ever advances onto a month the close "
+  "stamped: a report published for an open month does not move it.",
 ]
 
 _INITIATE_SEQUENCE: list[str] = [

--- a/robosystems/middleware/mcp/tools/playbook_tools.py
+++ b/robosystems/middleware/mcp/tools/playbook_tools.py
@@ -82,10 +82,13 @@ _RECURRING_SEQUENCE: list[str] = [
   "reads (statements, fact grids) against the newly closed month.",
   "If the tenant runs forecast scenarios: re-run compute-forecast for each "
   "forecast block after the close so the actuals/forecast seam advances to "
-  "the new closed_through. A scenario whose base_period lags closed_through "
-  "re-bases at the seam — keep scenario bases at the current closed_through "
-  "(advance or rebuild them after each close, per the tenant's "
-  "procedures doc).",
+  "the new closed_through. Nothing needs re-basing — the walk re-anchors on "
+  "the newest closed month by itself and reports the move in its "
+  "diagnostics, so the scenario's levers stay as authored. Read "
+  "anchor_period on the response to confirm it advanced; a scenario the "
+  "close has overtaken entirely fails loudly and needs its horizon "
+  "extended. Scenarios deliberately built on a counterfactual base carry "
+  "base_anchor='fixed' and stay put.",
 ]
 
 _INITIATE_SEQUENCE: list[str] = [

--- a/robosystems/models/api/extensions/forecasts.py
+++ b/robosystems/models/api/extensions/forecasts.py
@@ -244,7 +244,21 @@ class CreateForecastRequest(BaseModel):
       "Seed month (``YYYY-MM``) the walk projects forward from. "
       "Defaults to the fiscal calendar's closed-through period, else "
       "the newest actual report month. Resolved and stored at create "
-      "time."
+      "time, and it never moves afterwards — every lever is keyed to a "
+      "month inside ``base_period + 1 … + horizon_months``, so moving it "
+      "would mean restating all of them. ``base_anchor`` decides whether "
+      "the walk still *seeds* here once months close under it."
+    ),
+  )
+  base_anchor: Literal["seam", "fixed"] = Field(
+    "seam",
+    description=(
+      "Where the walk takes its opening balances as periods close. "
+      "``seam`` (default) re-anchors on the newest closed month inside "
+      "the horizon, so the scenario survives a close untouched and its "
+      "first forward month rolls off real balances. ``fixed`` pins the "
+      "walk to ``base_period`` — the deliberate counterfactual, whose "
+      "balances are meant to diverge from actuals."
     ),
   )
   levers: list[LeverAssertionRequest] = Field(
@@ -295,6 +309,14 @@ class UpdateForecastRequest(BaseModel):
   scenario_kind: Literal["budget", "forecast", "projection"] | None = None
   horizon_months: int | None = Field(None, ge=1, le=36)
   base_period: str | None = Field(None, pattern=_PERIOD_PATTERN)
+  base_anchor: Literal["seam", "fixed"] | None = Field(
+    None,
+    description=(
+      "Switch the walk between seam-anchored (default) and pinned to "
+      "``base_period``. Changes nothing about the authored window, so "
+      "unlike ``base_period`` it needs no levers re-supplied."
+    ),
+  )
   levers: list[LeverAssertionRequest] | None = Field(
     None,
     min_length=1,

--- a/robosystems/models/api/information_block.py
+++ b/robosystems/models/api/information_block.py
@@ -710,10 +710,25 @@ class ForecastMechanics(BaseModel):
   base_period: str = Field(
     ...,
     description=(
-      "Seed month (``YYYY-MM``) the walk projects forward from — "
+      "Origin month (``YYYY-MM``) of the authored horizon window — "
       "resolved at create time (request → fiscal calendar "
       "closed-through → newest actual report month) and stored so "
-      "recompute is deterministic."
+      "recompute is deterministic. Every lever, line assertion and "
+      "growth rate is keyed to a month in ``base_period + 1 … "
+      "base_period + horizon_months``, so this never moves on its own; "
+      "``base_anchor`` decides whether the *walk* still seeds here."
+    ),
+  )
+  base_anchor: Literal["seam", "fixed"] = Field(
+    "seam",
+    description=(
+      "Where the walk takes its opening balances. ``seam`` (default) "
+      "re-anchors on the newest closed month at or after "
+      "``base_period``, so a scenario survives a period close without "
+      "being rebuilt and its first forward month rolls off real "
+      "balances. ``fixed`` pins the walk to ``base_period`` — the "
+      "deliberate counterfactual (“if we had restarted in July”), "
+      "whose balances diverge from actuals on purpose."
     ),
   )
   levers: list[LeverAssertionLite] = Field(
@@ -2085,7 +2100,24 @@ class ComputeForecastResponse(BaseModel):
     ),
   )
   entity_id: str
-  base_period: str = Field(..., description="Seed month the walk projected from.")
+  base_period: str = Field(
+    ...,
+    description=(
+      "Origin month of the block's authored horizon window — where its "
+      "levers are keyed from. Equal to ``anchor_period`` unless the walk "
+      "re-anchored at the seam."
+    ),
+  )
+  anchor_period: str = Field(
+    ...,
+    description=(
+      "Month the walk actually seeded its opening balances from. With "
+      "``base_anchor='seam'`` this advances to the newest closed month "
+      "as periods close, so the first forward month rolls off real "
+      "balances instead of a stale base; with ``'fixed'`` it always "
+      "equals ``base_period``."
+    ),
+  )
   months: int = Field(..., description="Forward months requested.")
   months_computed: list[ForecastMonthLite] = Field(default_factory=list)
   halted_at: str | None = Field(

--- a/robosystems/operations/extensions/materialize.py
+++ b/robosystems/operations/extensions/materialize.py
@@ -1022,19 +1022,32 @@ def _staging_sql(graph_id: str, entity_id: str, connstr: str) -> dict[str, str]:
   tables["Fact"] = f"""
     CREATE OR REPLACE TABLE Fact AS
     SELECT
-      id                              AS identifier,
+      f.id                            AS identifier,
       NULL::VARCHAR                   AS uri,
-      COALESCE(string_value, CAST(value AS VARCHAR)) AS value,
-      value                           AS numeric_value,
-      fact_type                       AS fact_type,
-      CASE WHEN fact_type = 'Numeric'
-           THEN COALESCE(decimals, '-2')
-           ELSE decimals END          AS decimals,
-      value_type                      AS value_type,
-      content_type                    AS content_type,
-      false                           AS has_dimensions,
-      0::BIGINT                       AS dimension_count
+      COALESCE(f.string_value, CAST(f.value AS VARCHAR)) AS value,
+      f.value                         AS numeric_value,
+      f.fact_type                     AS fact_type,
+      CASE WHEN f.fact_type = 'Numeric'
+           THEN COALESCE(f.decimals, '-2')
+           ELSE f.decimals END        AS decimals,
+      f.value_type                    AS value_type,
+      f.content_type                  AS content_type,
+      -- Derived, not hardcoded. It read `false` / `0` for every fact while
+      -- four graph read paths filter consolidated totals on exactly this
+      -- column, so the contract they rely on was being satisfied by the
+      -- scenario exclusion upstream rather than by the flag itself. Nothing
+      -- is dimensioned in OLTP today except scenario facts, which the
+      -- exclusion drops — so this changes no output. It changes what
+      -- happens when something dimensioned does reach the graph: the
+      -- filters start working instead of silently passing everything.
+      COALESCE(fd.n, 0) > 0           AS has_dimensions,
+      COALESCE(fd.n, 0)::BIGINT       AS dimension_count
     FROM {actual_facts} f
+    LEFT JOIN (
+      SELECT fact_id, COUNT(*) AS n
+      FROM postgres_scan('{c}', '{s}', 'fact_dimensions')
+      GROUP BY fact_id
+    ) fd ON fd.fact_id = f.id
   """
 
   tables["FactSet"] = f"""

--- a/robosystems/operations/information_block/forecast.py
+++ b/robosystems/operations/information_block/forecast.py
@@ -595,6 +595,7 @@ def create(
     scenario_kind=payload.scenario_kind,
     horizon_months=payload.horizon_months,
     base_period=base_period,
+    base_anchor=payload.base_anchor,
     levers=levers,
     line_assertions=line_assertions,
     line_growth=line_growth,
@@ -640,7 +641,8 @@ def update(
 ) -> str:
   """Update a forecast block in place.
 
-  Mutable: name, scenario_kind, horizon_months, base_period, levers.
+  Mutable: name, scenario_kind, horizon_months, base_period, base_anchor,
+  levers.
   Changing ``horizon_months`` or ``base_period`` requires re-supplying
   ``levers`` — the persisted expansion can't be re-derived (the
   uniform-vs-override distinction is gone), so re-expansion needs the
@@ -701,6 +703,7 @@ def update(
     scenario_kind=scenario_kind,
     horizon_months=horizon_months,
     base_period=base_period,
+    base_anchor=payload.base_anchor or current.base_anchor,
     levers=levers,
     line_assertions=line_assertions,
     line_growth=line_growth,

--- a/robosystems/operations/information_block/forecast_compute.py
+++ b/robosystems/operations/information_block/forecast_compute.py
@@ -141,6 +141,8 @@ def _actual_set_at(
   entity_id: str,
   period_start: date,
   period_end: date,
+  *,
+  canonical_only: bool = False,
 ) -> FactSet | None:
   """The newest actual report set for a structure at exactly one month.
 
@@ -153,34 +155,49 @@ def _actual_set_at(
   publication snapshots, same contract as the envelope loaders: a Report
   published later for the base month must not seed the forecast off a
   frozen snapshot that may have been regenerated with a different style.
+
+  ``canonical_only`` drops the publication fallback entirely, which is a
+  different question from "which set is better": **the existence of a
+  canonical set is what makes a month closed.** ``create_report`` consults
+  no fiscal calendar — it takes whatever window the caller passes — so a
+  report generated for an open or future month leaves a perfectly valid
+  publication snapshot behind it. And reopening retracts only canonical
+  sets (`statement_sets._canonical_set_ids_in_window`), deliberately
+  leaving snapshots in place. Preferring canonical is right when seeding
+  from a month already known to be closed; it is not enough when the
+  question *is* whether the month is closed.
   """
+  stmt = select(FactSet).where(
+    FactSet.structure_id == structure_id,
+    FactSet.factset_type == "report",
+    FactSet.scenario_id.is_(None),
+    FactSet.entity_id == entity_id,
+    FactSet.period_end == period_end,
+    FactSet.period_start >= period_start,
+  )
+  if canonical_only:
+    stmt = stmt.where(FactSet.report_id.is_(None))
   return session.execute(
-    select(FactSet)
-    .where(
-      FactSet.structure_id == structure_id,
-      FactSet.factset_type == "report",
-      FactSet.scenario_id.is_(None),
-      FactSet.entity_id == entity_id,
-      FactSet.period_end == period_end,
-      FactSet.period_start >= period_start,
-    )
-    .order_by(
+    stmt.order_by(
       FactSet.report_id.isnot(None).asc(),
       FactSet.created_at.desc(),
-    )
-    .limit(1)
+    ).limit(1)
   ).scalar_one_or_none()
 
 
 def _newest_actual_month(
   session: Session, structure_id: str, entity_id: str
 ) -> str | None:
-  """Newest month carrying any actual report set for a structure.
+  """Newest month carrying a canonical (close-stamped) set for a structure.
 
   An upper bound for the anchor scan, kept separate from
   :func:`_actual_set_at` because it deliberately does *not* apply that
   function's monthly-window guard — it may well land on the annual
   comparative set. Bounding is all it is for.
+
+  Canonical-only for the same reason the scan is: a publication snapshot
+  can exist for a month that is open or has been reopened, so it says
+  nothing about where the books are closed through.
   """
   newest = session.execute(
     select(FactSet.period_end)
@@ -188,6 +205,7 @@ def _newest_actual_month(
       FactSet.structure_id == structure_id,
       FactSet.factset_type == "report",
       FactSet.scenario_id.is_(None),
+      FactSet.report_id.is_(None),
       FactSet.entity_id == entity_id,
     )
     .order_by(FactSet.period_end.desc())
@@ -218,10 +236,22 @@ def _resolve_anchor_period(
 
   So the anchor advances with the close. Candidates are the months
   strictly after ``base_period`` and inside the authored horizon, newest
-  first; the first one carrying a **monthly** actual income statement (and
-  balance sheet, when the graph has one) wins. Scanning back from the
+  first; the first one carrying a **monthly, canonical** income statement
+  (and balance sheet, when the graph has one) wins. Scanning back from the
   horizon end rather than forward from the base means a gap in the middle
   of the closed history can't strand the anchor behind it.
+
+  **Canonical is the whole point of the predicate, not a preference.** The
+  anchor is a claim that the books are closed through a month, and it has
+  teeth: the walk seeds its opening balances there and
+  :func:`_invalidate_superseded_head` deletes every scenario month at or
+  before it. A publication snapshot proves nothing about closure —
+  ``create_report`` never consults the fiscal calendar, so one can exist
+  for an open or even future month, and reopening a month retracts only
+  the canonical set and deliberately leaves the snapshot. Anchoring on a
+  snapshot would seed the walk from an incomplete month and discard real
+  forecast months to do it. Close-stamping is the only thing that means
+  closed, and it tracks reopen for free.
 
   One query establishes where that scan can start, because otherwise its
   cheapest case is also its most expensive one: a scenario whose base is
@@ -247,12 +277,26 @@ def _resolve_anchor_period(
       continue
     month_start, month_end = period_date_range(month)
     if (
-      _actual_set_at(session, is_structure_id, entity_id, month_start, month_end)
+      _actual_set_at(
+        session,
+        is_structure_id,
+        entity_id,
+        month_start,
+        month_end,
+        canonical_only=True,
+      )
       is None
     ):
       continue
     if bs_structure_id is not None and (
-      _actual_set_at(session, bs_structure_id, entity_id, month_start, month_end)
+      _actual_set_at(
+        session,
+        bs_structure_id,
+        entity_id,
+        month_start,
+        month_end,
+        canonical_only=True,
+      )
       is None
     ):
       # An income statement without the matching balance sheet cannot seed
@@ -589,10 +633,54 @@ def cmd_compute_forecast(
     months.append(month)
 
   if not months:
-    raise ValueError(
+    # Fully overtaken: the close has passed the end of the authored window,
+    # so every month this scenario ever computed is now a closed month.
+    #
+    # This used to raise, which read as the loud answer and was the quiet
+    # one. The exception rolls the session back, so the superseded months
+    # survived it — the precise stale state `_invalidate_superseded_head`
+    # exists to remove, left behind by the one case where *all* of them
+    # qualify. A partially-overtaken scenario cleaned up after itself while
+    # a fully-overtaken one did not, which is the limit case behaving
+    # opposite to the trend.
+    #
+    # So it cleans up and returns instead, with no computed months and a
+    # diagnostic that leads with the condition. Only DERIVED months go; the
+    # authored lever set is excluded from the sweep exactly as it is
+    # everywhere else, so the scenario keeps its identity and can be
+    # forecast again the moment its horizon is extended.
+    cleared = _invalidate_superseded_head(
+      session,
+      scenario_id=scenario_id,
+      entity_id=entity_id,
+      through_period_end=base_end,
+    )
+    diagnostics.append(
       f"Forecast {scenario_id!r} has no forward months left: its horizon "
       f"ends {window_end} and the books are closed through {anchor_period}. "
-      "Extend horizon_months, or re-create the scenario on a later base."
+      f"Nothing was computed. "
+      + (
+        f"Its {cleared} previously computed fact set(s) were all months "
+        "that have since closed, and have been cleared. "
+        if cleared
+        else ""
+      )
+      + "Extend horizon_months to forecast from the current close, or "
+      "re-create the scenario on a later base. The authored levers are "
+      "untouched."
+    )
+    session.flush()
+    return ComputeForecastResponse(
+      structure_id=structure.id,
+      scenario_id=scenario_id,
+      entity_id=entity_id,
+      base_period=mechanics.base_period,
+      anchor_period=anchor_period,
+      months=months_n,
+      months_computed=[],
+      halted_at=None,
+      skipped=skipped,
+      diagnostics=diagnostics,
     )
 
   if anchor_period != mechanics.base_period:

--- a/robosystems/operations/information_block/forecast_compute.py
+++ b/robosystems/operations/information_block/forecast_compute.py
@@ -2,8 +2,17 @@
 
 :mod:`.forecast` holds the authored surface (scenario identity, lever
 assertions, line assertions, growth rates); this module derives everything
-downstream, one forward month at a time from the block's ``base_period``.
-Per month, in order:
+downstream, one forward month at a time from the walk's **anchor**.
+
+The anchor is not the block's ``base_period``. ``base_period`` is the origin
+of the authored window — every lever is keyed to a month inside it, so moving
+it means restating all of them, which is why advancing a scenario's base by
+hand meant deleting and rebuilding it. The anchor is derived instead: with
+``base_anchor='seam'`` (the default) it advances to the newest closed month
+inside the horizon, so a scenario survives a period close untouched and its
+first forward month opens on real balances rather than on a base several
+closes old. ``base_anchor='fixed'`` pins the walk to ``base_period`` for the
+deliberate counterfactual. Per month, in order:
 
 1. **Carry-forward** — every income-statement leaf that carried a fact in the
    base month's actual report and isn't rule-driven repeats its prior value.
@@ -113,6 +122,7 @@ if TYPE_CHECKING:
   from datetime import date
 
   from sqlalchemy.orm import Session
+  from sqlalchemy.sql.elements import ColumnElement
 
 
 @dataclass
@@ -160,6 +170,55 @@ def _actual_set_at(
     )
     .limit(1)
   ).scalar_one_or_none()
+
+
+def _resolve_anchor_period(
+  session: Session,
+  *,
+  base_period: str,
+  horizon_months: int,
+  is_structure_id: str,
+  bs_structure_id: str | None,
+  entity_id: str,
+) -> str:
+  """The newest month inside the horizon that can seed the walk.
+
+  A scenario is authored against a base month and then the books move on.
+  Left pinned to that base, the walk keeps opening every recompute from
+  balances that are now many closes old: the forward months carry a
+  balance sheet that never saw what actually happened, so the plan grid
+  shows a cash line stepping from the last actual straight into a figure
+  the scenario's own cash-flow statement cannot explain. The transition
+  isn't wrong arithmetic — the walk foots to the penny against its own
+  base — it is anchored to a month nobody is looking at any more.
+
+  So the anchor advances with the close. Candidates are the months
+  strictly after ``base_period`` and inside the authored horizon, newest
+  first; the first one carrying a **monthly** actual income statement (and
+  balance sheet, when the graph has one) wins. Scanning back from the
+  horizon end rather than forward from the base means a gap in the middle
+  of the closed history can't strand the anchor behind it.
+
+  Returns ``base_period`` when nothing later qualifies — a scenario whose
+  base is still the seam, which is every scenario at creation time.
+  """
+  for offset in range(horizon_months, 0, -1):
+    month = add_months(base_period, offset)
+    month_start, month_end = period_date_range(month)
+    if (
+      _actual_set_at(session, is_structure_id, entity_id, month_start, month_end)
+      is None
+    ):
+      continue
+    if bs_structure_id is not None and (
+      _actual_set_at(session, bs_structure_id, entity_id, month_start, month_end)
+      is None
+    ):
+      # An income statement without the matching balance sheet cannot seed
+      # the roll; keep walking back rather than anchoring half-blind.
+      continue
+    return month
+  return base_period
 
 
 def _local_calc_arcs(
@@ -267,14 +326,41 @@ def cmd_compute_forecast(
     )
   bs_structure_id = newest_actual_structure_id(session, "balance_sheet")
 
-  base_start, base_end = period_date_range(mechanics.base_period)
+  # The authored window never moves — every lever is keyed to a month in
+  # `base_period + 1 … base_period + horizon`, so advancing the base would
+  # force the author to restate all of them (which is exactly why advancing
+  # it by hand meant deleting and rebuilding the scenario). The *anchor*
+  # moves instead: it is derived, it needs nothing restated, and it is what
+  # the opening balances come from.
+  anchor_period = mechanics.base_period
+  if mechanics.base_anchor == "seam":
+    # Whether the anchor must also carry a balance sheet is decided by what
+    # the BASE month carries, not by whether the graph has a balance-sheet
+    # structure at all. A scenario that rolls a balance sheet must not
+    # re-anchor onto a month that would silently drop the roll; one that
+    # never had a base balance sheet was already running IS-only and
+    # shouldn't be held back by a requirement it never met.
+    base_window = period_date_range(mechanics.base_period)
+    rolls_balance_sheet = bs_structure_id is not None and (
+      _actual_set_at(session, bs_structure_id, entity_id, *base_window) is not None
+    )
+    anchor_period = _resolve_anchor_period(
+      session,
+      base_period=mechanics.base_period,
+      horizon_months=mechanics.horizon_months,
+      is_structure_id=is_structure_id,
+      bs_structure_id=bs_structure_id if rolls_balance_sheet else None,
+      entity_id=entity_id,
+    )
+
+  base_start, base_end = period_date_range(anchor_period)
   base_is_set = _actual_set_at(
     session, is_structure_id, entity_id, base_start, base_end
   )
   if base_is_set is None:
     raise ValueError(
       f"No actual income statement at the base period "
-      f"{mechanics.base_period} (a monthly set whose window starts "
+      f"{anchor_period} (a monthly set whose window starts "
       f"{base_start} and ends {base_end}). Close the months through the "
       "base period (closing stamps each month's statement sets), or set "
       "base_period to a month that has one."
@@ -343,7 +429,7 @@ def cmd_compute_forecast(
         SkippedForecastLite(
           rule_id=rule.id,
           element_qname=None,
-          period=mechanics.base_period,
+          period=anchor_period,
           reason="rule has no resolvable target element",
         )
       )
@@ -446,10 +532,42 @@ def cmd_compute_forecast(
         break
   cf_structure_id = newest_actual_structure_id(session, "cash_flow_statement")
 
-  ctx: ArticulationContext | None = None
   diagnostics: list[str] = []
+
+  # The months to walk. The authored window's END is fixed — a scenario
+  # doesn't silently grow a longer horizon because months closed under it —
+  # so a re-anchored walk computes fewer months, not later ones. The months
+  # between the base and the anchor are actuals now; the moving seam already
+  # preferred actuals over them on every read.
+  window_end = add_months(mechanics.base_period, mechanics.horizon_months)
+  months = []
+  for offset in range(1, months_n + 1):
+    month = add_months(anchor_period, offset)
+    if month > window_end:
+      break
+    months.append(month)
+
+  if not months:
+    raise ValueError(
+      f"Forecast {scenario_id!r} has no forward months left: its horizon "
+      f"ends {window_end} and the books are closed through {anchor_period}. "
+      "Extend horizon_months, or re-create the scenario on a later base."
+    )
+
+  if anchor_period != mechanics.base_period:
+    diagnostics.append(
+      f"Walk re-anchored from base {mechanics.base_period} to {anchor_period}, "
+      f"the newest closed month inside the horizon: opening balances come "
+      f"from that month's actuals, so the first forward month rolls off real "
+      f"figures. {len(months)} of the horizon's {mechanics.horizon_months} "
+      f"months remain forward-looking (the rest have closed). Levers keep "
+      f"their authored months — nothing needs restating. Set "
+      f"base_anchor='fixed' to pin the walk to the base instead."
+    )
+
+  ctx: ArticulationContext | None = None
   if bs_structure_id is not None and base_bs_set is not None:
-    horizon_end = period_date_range(add_months(mechanics.base_period, months_n))[1]
+    horizon_end = period_date_range(months[-1])[1]
     ctx = load_articulation_context(
       session,
       bs_structure_id=bs_structure_id,
@@ -497,13 +615,12 @@ def cmd_compute_forecast(
   months_computed: list[ForecastMonthLite] = []
   halted_at: str | None = None
   unverified_months: list[str] = []
-  months = [add_months(mechanics.base_period, i) for i in range(1, months_n + 1)]
   active_instant_ids = {
     ar.target.id for ar in ordered_active if ar.target.period_type == "instant"
   }
   prior_bs = dict(bs_prior)
   prev_period_end = base_end
-  prev_month = mechanics.base_period
+  prev_month = anchor_period
 
   for month_index, month in enumerate(months, start=1):
     month_start, month_end = period_date_range(month)
@@ -767,9 +884,12 @@ def cmd_compute_forecast(
     resolved = resolve_calc_dag(current, set(current), calculations, calc_order)
 
     # (d) Upsert the month's scenario sets.
+    # `base_period` on the provenance is the month this walk actually
+    # seeded from and `month_index` counts forward from it — both describe
+    # the run, not the authoring, so a re-anchored run stamps the anchor.
     provenance = ForecastProvenance(
       scenario_structure_id=scenario_id,
-      base_period=mechanics.base_period,
+      base_period=anchor_period,
       month_index=month_index,
       drivers=active_driver_qnames,
     )
@@ -1009,12 +1129,32 @@ def cmd_compute_forecast(
         f"left over from a longer previous run."
       )
 
+    # And the other end of the window: months a previous run computed that
+    # the anchor has since moved past. They are closed months now, so every
+    # read prefers the actuals over them — which is exactly why they would
+    # sit there indefinitely, invisible on the plan grid and still present
+    # to anything reading the scenario directly.
+    if anchor_period != mechanics.base_period:
+      superseded = _invalidate_superseded_head(
+        session,
+        scenario_id=scenario_id,
+        entity_id=entity_id,
+        through_period_end=base_end,
+      )
+      if superseded:
+        diagnostics.append(
+          f"Dropped {superseded} scenario fact set(s) at or before "
+          f"{anchor_period}, computed by an earlier run for months that "
+          f"have since closed."
+        )
+
   session.flush()
   return ComputeForecastResponse(
     structure_id=structure.id,
     scenario_id=scenario_id,
     entity_id=entity_id,
     base_period=mechanics.base_period,
+    anchor_period=anchor_period,
     months=months_n,
     months_computed=months_computed,
     halted_at=halted_at,
@@ -1254,12 +1394,67 @@ def _invalidate_stale_tail(
   ``VerificationResult.fact_set_id`` carries no FK, so those rows go
   explicitly — the same sweep ``delete_scenario`` does.
   """
+  return _sweep_scenario_sets(
+    session,
+    scenario_id=scenario_id,
+    entity_id=entity_id,
+    period_bound=FactSet.period_end > through_period_end,
+  )
+
+
+def _invalidate_superseded_head(
+  session: Session,
+  *,
+  scenario_id: str,
+  entity_id: str,
+  through_period_end: date,
+) -> int:
+  """Delete scenario sets at or before the month the walk re-anchored to.
+
+  The head counterpart of :func:`_invalidate_stale_tail`, and it exists for
+  the same reason. When the anchor advances past months a previous run
+  computed, those months are now closed: actuals exist for them, and every
+  read prefers actuals at an overlap, so they are invisible on the plan
+  grid. Invisible is not gone. They are scenario facts describing months
+  the scenario no longer forecasts, chained off an anchor the walk has
+  abandoned, and they still carry their own passing verification results —
+  the same "reads as current" failure the tail sweep was written for, at
+  the other end of the window. Anything reading the scenario directly
+  (a graph query, a fact grid) sees them as forecast.
+
+  Same lever-set exclusion, and for the same reason: the authored lever
+  FactSet carries this ``scenario_id`` with a period envelope spanning the
+  full horizon, so its ``period_end`` sits past the anchor and is safe here
+  — but only by accident of the envelope, and a sweep that relied on that
+  would break the first time the envelope shape changed.
+  """
+  return _sweep_scenario_sets(
+    session,
+    scenario_id=scenario_id,
+    entity_id=entity_id,
+    period_bound=FactSet.period_end <= through_period_end,
+  )
+
+
+def _sweep_scenario_sets(
+  session: Session,
+  *,
+  scenario_id: str,
+  entity_id: str,
+  period_bound: ColumnElement[bool],
+) -> int:
+  """Delete the scenario's computed sets matching ``period_bound``.
+
+  One implementation for both sweeps so the lever-set exclusion — the
+  sharp edge of making the scenario id the forecast Structure's own id —
+  is written once and cannot drift between them.
+  """
   stale = (
     session.execute(
       select(FactSet).where(
         FactSet.scenario_id == scenario_id,
         FactSet.entity_id == entity_id,
-        FactSet.period_end > through_period_end,
+        period_bound,
         not_(
           and_(
             FactSet.structure_id == scenario_id,

--- a/robosystems/operations/information_block/forecast_compute.py
+++ b/robosystems/operations/information_block/forecast_compute.py
@@ -172,6 +172,30 @@ def _actual_set_at(
   ).scalar_one_or_none()
 
 
+def _newest_actual_month(
+  session: Session, structure_id: str, entity_id: str
+) -> str | None:
+  """Newest month carrying any actual report set for a structure.
+
+  An upper bound for the anchor scan, kept separate from
+  :func:`_actual_set_at` because it deliberately does *not* apply that
+  function's monthly-window guard — it may well land on the annual
+  comparative set. Bounding is all it is for.
+  """
+  newest = session.execute(
+    select(FactSet.period_end)
+    .where(
+      FactSet.structure_id == structure_id,
+      FactSet.factset_type == "report",
+      FactSet.scenario_id.is_(None),
+      FactSet.entity_id == entity_id,
+    )
+    .order_by(FactSet.period_end.desc())
+    .limit(1)
+  ).scalar()
+  return None if newest is None else period_from_date(newest)
+
+
 def _resolve_anchor_period(
   session: Session,
   *,
@@ -199,11 +223,28 @@ def _resolve_anchor_period(
   horizon end rather than forward from the base means a gap in the middle
   of the closed history can't strand the anchor behind it.
 
-  Returns ``base_period`` when nothing later qualifies — a scenario whose
-  base is still the seam, which is every scenario at creation time.
+  One query establishes where that scan can start, because otherwise its
+  cheapest case is also its most expensive one: a scenario whose base is
+  still the seam — every scenario at creation, and most of them most of
+  the time — finds nothing, and finding nothing means having walked the
+  entire horizon to prove it. The newest actual ``period_end`` on the
+  income-statement structure bounds any month that could qualify. It is a
+  bound, not an answer: the newest set may be the ANNUAL comparative one,
+  whose ``period_end`` coincides with a monthly one at the fiscal year
+  end and which :func:`_actual_set_at` deliberately refuses. Too high is
+  harmless (the scan walks down); too low would skip a valid anchor, and
+  it cannot be, since every monthly set is included in the maximum.
+
+  Returns ``base_period`` when nothing later qualifies.
   """
+  newest_actual_month = _newest_actual_month(session, is_structure_id, entity_id)
+  if newest_actual_month is None:
+    return base_period
+
   for offset in range(horizon_months, 0, -1):
     month = add_months(base_period, offset)
+    if month > newest_actual_month:
+      continue
     month_start, month_end = period_date_range(month)
     if (
       _actual_set_at(session, is_structure_id, entity_id, month_start, month_end)

--- a/robosystems/operations/information_block/rules/engine.py
+++ b/robosystems/operations/information_block/rules/engine.py
@@ -61,6 +61,28 @@ from robosystems.operations.information_block.rules.expressions import (
 )
 
 
+def _actual_set_ids(structure_id: str):
+  """The structure's FactSets that are actuals — the undimensioned scenario.
+
+  Every unpinned fact read in this module goes through here. Scoping by
+  ``structure_id`` alone reads as "this statement" and means "this
+  statement, in every scenario": scenario month sets are deliberately
+  stamped with the *statement* structure's id, because that is how a
+  scenario column renders through the same structure as its actuals.
+
+  The consequence is worse than a widened scope, because the unpinned
+  binder takes the newest fact per element. The newest fact on a graph
+  carrying a forecast is a month that has not happened, so a check of the
+  books would answer about the plan — and write the verdict onto the
+  books. Invisible until a graph has its first forecast, which is why it
+  survived the engine's whole life.
+  """
+  return select(FactSet.id).where(
+    FactSet.structure_id == structure_id,
+    FactSet.scenario_id.is_(None),
+  )
+
+
 def _bind_variables(
   session: Session,
   rule: Rule,
@@ -114,7 +136,10 @@ def _bind_variables(
     if fact_set_id is not None:
       stmt = base_stmt.where(Fact.fact_set_id == fact_set_id)
     else:
-      stmt = base_stmt.where(Fact.structure_id == structure_id)
+      stmt = base_stmt.where(
+        Fact.structure_id == structure_id,
+        Fact.fact_set_id.in_(_actual_set_ids(structure_id)),
+      )
     bindings[name] = session.execute(stmt).scalar()
 
   return bindings
@@ -155,12 +180,19 @@ def _bind_sum_variables(
     # failures. Schedule facts aren't replicated into GL line items,
     # so summing historical periods here doesn't double-count
     # anything that landed in opening balances.
+    # Scenario months are excluded for the same reason as every other
+    # unpinned read here (see `_actual_set_ids`). A schedule structure
+    # carries no scenario sets today, so this is inert — and it is the
+    # third unpinned read in this module, which is exactly how many
+    # places the invariant has to hold in for it to be one.
     row = session.execute(
       text(
-        "SELECT ROUND(SUM(value)::numeric, 2) AS total "
-        "FROM facts "
-        "WHERE element_id = :eid AND structure_id = :sid "
-        "AND period_type = 'duration' AND fact_type = 'Numeric'"
+        "SELECT ROUND(SUM(f.value)::numeric, 2) AS total "
+        "FROM facts f "
+        "JOIN fact_sets fs ON fs.id = f.fact_set_id "
+        "WHERE f.element_id = :eid AND f.structure_id = :sid "
+        "AND f.period_type = 'duration' AND f.fact_type = 'Numeric' "
+        "AND fs.scenario_id IS NULL"
       ),
       {"eid": element_id, "sid": structure_id},
     ).fetchone()
@@ -209,8 +241,18 @@ def _load_period_balances(
   if fact_set_id is not None:
     stmt = stmt.where(Fact.fact_set_id == fact_set_id)
   else:
-    # No FactSet exists for this structure (never reported) — no balances.
-    stmt = stmt.where(Fact.structure_id == structure_id)
+    # No ACTUAL FactSet exists for this structure (never reported) — no
+    # balances. The comment here used to say exactly that while the code
+    # scoped by `structure_id`, which is not the same thing the moment a
+    # scenario exists: the walk stamps its balance-sheet sets on the
+    # statement structure even when no actual balance sheet does (the
+    # degraded, rule-driven branch), so "never reported" and "carries only
+    # forecast months" are the same state to this query. Summing those
+    # would foot the plan and stamp the verdict on the books.
+    stmt = stmt.where(
+      Fact.structure_id == structure_id,
+      Fact.fact_set_id.in_(_actual_set_ids(structure_id)),
+    )
   if period_end is not None:
     stmt = stmt.where(Fact.period_end <= period_end)
   if period_start is not None:

--- a/tests/operations/extensions/test_materialize.py
+++ b/tests/operations/extensions/test_materialize.py
@@ -132,7 +132,9 @@ class TestNonnumericFactStaging:
 
   def test_fact_value_coalesces_string_value(self):
     sql = _staging_sql(GRAPH_ID, ENTITY_ID, CONNSTR)["Fact"]
-    assert "COALESCE(string_value, CAST(value AS VARCHAR))" in sql
+    # Columns are `f.`-qualified since the projection became a join (the
+    # dimension count), so match on the shape rather than the prefix.
+    assert "COALESCE(f.string_value, CAST(f.value AS VARCHAR))" in sql
 
   def test_fact_type_and_value_type_pass_through(self):
     sql = _staging_sql(GRAPH_ID, ENTITY_ID, CONNSTR)["Fact"]
@@ -147,8 +149,8 @@ class TestNonnumericFactStaging:
     sql = _staging_sql(GRAPH_ID, ENTITY_ID, CONNSTR)["Fact"]
     # Legacy '-2' preserved for numeric rows with unspecified decimals;
     # Nonnumeric rows pass NULL through (no @decimals in XBRL).
-    assert "CASE WHEN fact_type = 'Numeric'" in sql
-    assert "COALESCE(decimals, '-2')" in sql
+    assert "CASE WHEN f.fact_type = 'Numeric'" in sql
+    assert "COALESCE(f.decimals, '-2')" in sql
 
   def test_unit_table_derives_from_fact_units(self):
     sql = _staging_sql(GRAPH_ID, ENTITY_ID, CONNSTR)["Unit"]
@@ -803,6 +805,26 @@ class TestScenarioExclusion:
     assert sql.count("fs.scenario_id IS NULL") == 2, (
       "FACT_HAS_ENTITY has two UNION branches; both must filter scenarios"
     )
+
+  def test_has_dimensions_is_derived_not_hardcoded(self):
+    """The flag four graph read paths filter consolidated totals on.
+
+    It read `false` / `0` for every fact, so the "consolidated totals only"
+    contract was being upheld by the scenario exclusion upstream rather
+    than by the flag itself — a filter that passes everything the moment
+    anything dimensioned reaches the graph. Nothing dimensioned does today
+    (only scenario facts carry a junction row, and those are excluded), so
+    deriving it changes no output; it changes what happens when that stops
+    being true.
+    """
+    sql = _staging_sql(GRAPH_ID, ENTITY_ID, CONNSTR)["Fact"]
+    assert "false                           AS has_dimensions" not in sql
+    assert "0::BIGINT                       AS dimension_count" not in sql
+    assert "fact_dimensions" in sql, (
+      "has_dimensions must come from the junction, not a literal"
+    )
+    assert "COALESCE(fd.n, 0) > 0" in sql
+    assert "COALESCE(fd.n, 0)::BIGINT" in sql
 
   def test_no_unguarded_facts_scan_anywhere(self):
     """Completeness sweep: any projection reading facts or fact_sets must

--- a/tests/operations/information_block/rules/test_scenario_leakage.py
+++ b/tests/operations/information_block/rules/test_scenario_leakage.py
@@ -1,0 +1,315 @@
+"""Scenario facts must not reach a rule evaluation of the actual books.
+
+The default-member rule says actuals are the undimensioned scenario and a
+forecast carries an explicit member, so any reader honoring the contract
+excludes forecasts by construction. On the graph that contract is
+``has_dimensions = false``; in OLTP it is ``fact_sets.scenario_id IS NULL``.
+
+The rule engine reads OLTP, and it has two unpinned paths — ``evaluate-rules``
+called with nothing but a ``structure_id`` is a supported request, and the
+period close evaluates its statement structures without pinning a FactSet.
+Both used to scope by ``structure_id`` alone, and scenario month sets carry
+the *statement* structure's id: the whole point of the design is that a
+scenario column renders through the same structure as its actuals. So the
+scope that reads as "this statement" is really "this statement, in every
+scenario, including months that have not happened".
+
+These tests exist because that is invisible on a graph with no forecasts,
+which is every graph the engine was written against.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import date
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+import robosystems.models.extensions  # noqa: F401  (register models)
+from robosystems.db.extensions import ExtensionsBase
+
+pytestmark = pytest.mark.unit
+
+ACTUAL_START = date(2026, 6, 1)
+ACTUAL_END = date(2026, 6, 30)
+FORECAST_START = date(2026, 9, 1)
+FORECAST_END = date(2026, 9, 30)
+
+
+@pytest.fixture()
+def ext_session():
+  """Extensions schema in the test Postgres DB, one throwaway schema per test."""
+  database_url = os.environ.get("TEST_DATABASE_URL")
+  if not database_url:
+    pytest.skip("TEST_DATABASE_URL not configured")
+
+  schema = f"ext_leak_{uuid.uuid4().hex[:12]}"
+  engine = create_engine(database_url)
+  with engine.begin() as conn:
+    conn.execute(text(f'CREATE SCHEMA "{schema}"'))
+
+  session = sessionmaker(bind=engine)()
+  session.execute(text(f'SET search_path TO "{schema}"'))
+  ExtensionsBase.metadata.create_all(bind=session.connection())
+  session.commit()
+  session.execute(text(f'SET search_path TO "{schema}"'))
+
+  try:
+    yield session
+  finally:
+    session.rollback()
+    session.close()
+    with engine.begin() as conn:
+      conn.execute(text(f'DROP SCHEMA "{schema}" CASCADE'))
+    engine.dispose()
+
+
+class _Books:
+  """A balance sheet structure, its elements, and whatever sets a test adds."""
+
+  def __init__(self, session) -> None:
+    from robosystems.models.extensions import Element, Structure, Taxonomy
+
+    self.session = session
+    taxonomy = Taxonomy(name="rs-gaap", taxonomy_type="reporting_extension")
+    session.add(taxonomy)
+    session.flush()
+    self.taxonomy_id = taxonomy.id
+
+    self.structure = Structure(
+      name="Balance Sheet", block_type="balance_sheet", taxonomy_id=taxonomy.id
+    )
+    self.scenario = Structure(
+      name="Plan", block_type="forecast", taxonomy_id=taxonomy.id
+    )
+    session.add_all([self.structure, self.scenario])
+    session.flush()
+
+    def _el(qname: str, balance_type: str):
+      element = Element(
+        name=qname.split(":")[-1],
+        qname=qname,
+        balance_type=balance_type,
+        period_type="instant",
+        taxonomy_id=taxonomy.id,
+      )
+      session.add(element)
+      return element
+
+    self.assets = _el("rs-gaap:Assets", "debit")
+    self.cash = _el("rs-gaap:CashAndCashEquivalentsAtCarryingValue", "debit")
+    self.ppe = _el("rs-gaap:PropertyPlantAndEquipmentNet", "debit")
+    self.liabilities = _el("rs-gaap:Liabilities", "credit")
+    self.equity = _el("rs-gaap:StockholdersEquity", "credit")
+    session.flush()
+
+  def add_calc_arcs(self) -> None:
+    from robosystems.models.extensions import Association
+
+    for order, child in enumerate((self.cash, self.ppe)):
+      self.session.add(
+        Association(
+          structure_id=self.structure.id,
+          from_element_id=self.assets.id,
+          to_element_id=child.id,
+          association_type="calculation",
+          order_value=float(order),
+          weight=1.0,
+        )
+      )
+    self.session.flush()
+
+  def add_rule(self, pattern: str, expression: str, variables: list[tuple[str, str]]):
+    from robosystems.models.extensions import Rule
+
+    rule = Rule(
+      taxonomy_id=self.taxonomy_id,
+      rule_category="FundamentalAccountingConceptRelation",
+      rule_pattern=pattern,
+      rule_expression=expression,
+      target_kind="structure",
+      target_structure_id=self.structure.id,
+      rule_variables=[
+        {"variable_name": name, "variable_qname": qname} for name, qname in variables
+      ],
+    )
+    self.session.add(rule)
+    self.session.flush()
+    return rule
+
+  def add_set(self, *, scenario: bool, period, values: dict) -> str:
+    from robosystems.models.extensions.roboledger import Fact, FactSet
+
+    period_start, period_end = period
+    fact_set = FactSet(
+      structure_id=self.structure.id,
+      period_start=period_start,
+      period_end=period_end,
+      factset_type="report",
+      entity_id="ent_1",
+      scenario_id=self.scenario.id if scenario else None,
+    )
+    fact_set.provenance = (
+      {
+        "origin": "forecast",
+        "scenario_structure_id": self.scenario.id,
+        "base_period": "2026-06",
+        "month_index": 3,
+        "drivers": [],
+      }
+      if scenario
+      else {"origin": "pivot", "mapping_id": "m", "period": "2026-06"}
+    )
+    self.session.add(fact_set)
+    self.session.flush()
+
+    for element, value in values.items():
+      self.session.add(
+        Fact(
+          element_id=element.id,
+          value=value,
+          fact_type="Numeric",
+          period_start=period_start,
+          period_end=period_end,
+          period_type="instant",
+          entity_id="ent_1",
+          structure_id=self.structure.id,
+          fact_set_id=fact_set.id,
+        )
+      )
+    self.session.flush()
+    return fact_set.id
+
+
+def _evaluate(session, structure_id: str):
+  from robosystems.operations.information_block.rules.engine import (
+    evaluate_rules_for_structure,
+  )
+
+  # Exactly the `evaluate-rules` shape: a structure, nothing else. The
+  # request model documents all three narrowing arguments as optional.
+  return evaluate_rules_for_structure(session, structure_id, global_calculations={})
+
+
+class TestUnpinnedBindingIgnoresScenarios:
+  """An unpinned check binds the newest fact per element — and the newest
+  fact on a graph with a forecast is a month that has not happened yet."""
+
+  def test_the_equation_is_checked_against_actuals(self, ext_session) -> None:
+    books = _Books(ext_session)
+    books.add_rule(
+      "EqualTo",
+      "$Assets = ($Liabilities + $Equity)",
+      [
+        ("Assets", books.assets.qname),
+        ("Liabilities", books.liabilities.qname),
+        ("Equity", books.equity.qname),
+      ],
+    )
+    # Actuals balance.
+    books.add_set(
+      scenario=False,
+      period=(ACTUAL_START, ACTUAL_END),
+      values={books.assets: 100.0, books.liabilities: 40.0, books.equity: 60.0},
+    )
+    # A forecast three months out that does not — the scenario is allowed
+    # to be mid-edit, unverified, or plain wrong; it is not the books.
+    books.add_set(
+      scenario=True,
+      period=(FORECAST_START, FORECAST_END),
+      values={books.assets: 999.0, books.liabilities: 1.0, books.equity: 1.0},
+    )
+
+    results = _evaluate(ext_session, books.structure.id)
+
+    assert [r.status for r in results] == ["pass"], (
+      "the actual books balance; a forecast month bound in their place is "
+      f"what makes this fail — {[(r.status, r.message) for r in results]}"
+    )
+
+  def test_a_graph_without_forecasts_is_unaffected(self, ext_session) -> None:
+    """The control: the filter must not change the answer on actuals alone."""
+    books = _Books(ext_session)
+    books.add_rule(
+      "EqualTo",
+      "$Assets = ($Liabilities + $Equity)",
+      [
+        ("Assets", books.assets.qname),
+        ("Liabilities", books.liabilities.qname),
+        ("Equity", books.equity.qname),
+      ],
+    )
+    books.add_set(
+      scenario=False,
+      period=(ACTUAL_START, ACTUAL_END),
+      values={books.assets: 100.0, books.liabilities: 40.0, books.equity: 55.0},
+    )
+
+    results = _evaluate(ext_session, books.structure.id)
+
+    assert [r.status for r in results] == ["fail"]
+
+
+class TestUnpinnedRollupIgnoresScenarios:
+  """The rollup path pins to the newest ACTUAL FactSet — unless there isn't
+  one, and then it used to fall back to summing everything on the structure.
+
+  Reachable: the walk emits balance-sheet sets on the statement structure
+  even when no actual balance sheet exists (the degraded, rule-driven
+  working-capital branch), so a structure can carry scenario sets and no
+  actual set at all.
+  """
+
+  def test_no_actual_set_means_nothing_to_foot(self, ext_session) -> None:
+    books = _Books(ext_session)
+    books.add_calc_arcs()
+    books.add_rule(
+      "RollUp",
+      "$Assets = ($Cash + $PPE)",
+      [
+        ("Assets", books.assets.qname),
+        ("Cash", books.cash.qname),
+        ("PPE", books.ppe.qname),
+      ],
+    )
+    # Only a scenario set exists, and it does not foot.
+    books.add_set(
+      scenario=True,
+      period=(FORECAST_START, FORECAST_END),
+      values={books.assets: 999.0, books.cash: 1.0, books.ppe: 1.0},
+    )
+
+    results = _evaluate(ext_session, books.structure.id)
+
+    assert [r.status for r in results] == ["skipped"], (
+      "with no actual FactSet there is nothing to check; reporting a "
+      "verdict here reports one about a forecast, and stamps it on the "
+      f"actual books — {[(r.status, r.message) for r in results]}"
+    )
+
+  def test_an_actual_set_still_foots(self, ext_session) -> None:
+    """The control: the actual rollup still evaluates, and still fails when
+    it should."""
+    books = _Books(ext_session)
+    books.add_calc_arcs()
+    books.add_rule(
+      "RollUp",
+      "$Assets = ($Cash + $PPE)",
+      [
+        ("Assets", books.assets.qname),
+        ("Cash", books.cash.qname),
+        ("PPE", books.ppe.qname),
+      ],
+    )
+    books.add_set(
+      scenario=False,
+      period=(ACTUAL_START, ACTUAL_END),
+      values={books.assets: 200.0, books.cash: 100.0, books.ppe: 50.0},
+    )
+
+    results = _evaluate(ext_session, books.structure.id)
+
+    assert [r.status for r in results] == ["fail"]

--- a/tests/operations/information_block/test_forecast_base_binding.py
+++ b/tests/operations/information_block/test_forecast_base_binding.py
@@ -157,3 +157,127 @@ class TestActualSetAt:
 
     assert found is not None
     assert found.id == newer.id
+
+
+class TestCanonicalOnly:
+  """`canonical_only` asks a different question from "which set is better".
+
+  The publication fallback is right when seeding from a month already known
+  to be closed — a report published later must not beat the close stamp,
+  but it will do in a pinch. It is wrong when the question *is* whether the
+  month is closed, which is what the forecast walk's moving anchor asks.
+  `create_report` consults no fiscal calendar, so a report generated for an
+  open or future month leaves a perfectly valid publication snapshot; and
+  reopening a month retracts only the canonical set
+  (`statement_sets._canonical_set_ids_in_window`), deliberately leaving the
+  snapshot behind. Close-stamping is the only thing that means closed.
+
+  These run against a real schema because the callers stub `_actual_set_at`
+  out entirely — a harness that implements the distinction itself proves
+  the call sites pass the flag, not that the flag does anything.
+  """
+
+  def test_a_publication_snapshot_alone_is_not_canonical(
+    self, ext_session, statement_structure
+  ):
+    _add_set(
+      ext_session, statement_structure.id, report_id="rep_1", created_offset_minutes=0
+    )
+    ext_session.commit()
+
+    assert (
+      _actual_set_at(
+        ext_session,
+        statement_structure.id,
+        "ent_1",
+        PERIOD_START,
+        PERIOD_END,
+        canonical_only=True,
+      )
+      is None
+    )
+
+  def test_the_publication_fallback_survives_by_default(
+    self, ext_session, statement_structure
+  ):
+    """The control — the same row, and the default read still finds it.
+
+    Seeding the walk from an explicitly authored base month keeps working
+    on a tenant whose base carries only a published report.
+    """
+    published = _add_set(
+      ext_session, statement_structure.id, report_id="rep_1", created_offset_minutes=0
+    )
+    ext_session.commit()
+
+    found = _actual_set_at(
+      ext_session, statement_structure.id, "ent_1", PERIOD_START, PERIOD_END
+    )
+
+    assert found is not None
+    assert found.id == published.id
+
+  def test_a_canonical_set_is_found(self, ext_session, statement_structure):
+    canonical = _add_set(
+      ext_session, statement_structure.id, report_id=None, created_offset_minutes=0
+    )
+    _add_set(
+      ext_session, statement_structure.id, report_id="rep_1", created_offset_minutes=60
+    )
+    ext_session.commit()
+
+    found = _actual_set_at(
+      ext_session,
+      statement_structure.id,
+      "ent_1",
+      PERIOD_START,
+      PERIOD_END,
+      canonical_only=True,
+    )
+
+    assert found is not None
+    assert found.id == canonical.id
+
+
+class TestNewestActualMonthIsCanonical:
+  """The anchor scan's upper bound answers the same question, so it takes
+  the same filter — otherwise a report published for a future month sets a
+  bound past the seam and the scan starts by probing months nobody closed.
+  """
+
+  def test_a_publication_only_month_does_not_raise_the_bound(
+    self, ext_session, statement_structure
+  ):
+    from robosystems.operations.information_block.forecast_compute import (
+      _newest_actual_month,
+    )
+
+    _add_set(
+      ext_session, statement_structure.id, report_id=None, created_offset_minutes=0
+    )
+    # A report generated for a month three ahead of the close.
+    later = _add_set(
+      ext_session,
+      statement_structure.id,
+      report_id="rep_future",
+      created_offset_minutes=60,
+    )
+    later.period_start = date(2026, 9, 1)
+    later.period_end = date(2026, 9, 30)
+    ext_session.commit()
+
+    assert (
+      _newest_actual_month(ext_session, statement_structure.id, "ent_1") == "2026-06"
+    )
+
+  def test_no_canonical_sets_at_all_is_none(self, ext_session, statement_structure):
+    from robosystems.operations.information_block.forecast_compute import (
+      _newest_actual_month,
+    )
+
+    _add_set(
+      ext_session, statement_structure.id, report_id="rep_1", created_offset_minutes=0
+    )
+    ext_session.commit()
+
+    assert _newest_actual_month(ext_session, statement_structure.id, "ent_1") is None

--- a/tests/operations/information_block/test_forecast_compute.py
+++ b/tests/operations/information_block/test_forecast_compute.py
@@ -292,6 +292,8 @@ def _run(
   base_is_facts: list[Any] | None = None,
   schedule_projection: ScheduleProjection | None = None,
   verify: Any = None,
+  closed_months: set[str] | None = None,
+  bs_closed_months: set[str] | None = None,
 ):
   """``verify`` controls ``_verify_month_sets``.
 
@@ -299,7 +301,16 @@ def _run(
   rules ran. Pass a callable to vary the result per month, which is what
   makes the stop-the-walk behaviour testable at all; the fixed stub is
   precisely why it never was.
+
+  ``closed_months`` names the months carrying actual statement sets —
+  ``{"2026-06"}`` (the base alone) by default, which is where the books
+  stood when each of these scenarios was authored. Widen it to move the
+  seam and watch the walk re-anchor. ``bs_closed_months`` narrows the
+  balance-sheet half independently, for the month that closed its income
+  statement but not its balance sheet.
   """
+  closed = closed_months if closed_months is not None else {"2026-06"}
+  bs_closed = bs_closed_months if bs_closed_months is not None else closed
   structure = _structure(mechanics)
   recorder = _Recorder()
 
@@ -315,10 +326,26 @@ def _run(
     "fs_lever": authored_facts,
   }
 
-  def _base_set(session: Any, sid: str, *a: Any, **k: Any) -> Any:
+  def _base_set(
+    session: Any,
+    sid: str,
+    entity_id: Any = None,
+    period_start: Any = None,
+    period_end: Any = None,
+  ) -> Any:
+    # Which months are closed has to be modelled rather than assumed now
+    # that the walk asks, in order to resolve its anchor. A stub answering
+    # "yes" for every month would report the whole horizon as closed.
+    month = (
+      None if period_end is None else f"{period_end.year:04d}-{period_end.month:02d}"
+    )
     if sid == "struct_is":
+      if month is not None and month not in closed:
+        return None
       return SimpleNamespace(id="fs_base_is")
     if sid == "struct_bs" and schedule_projection is not None:
+      if month is not None and month not in bs_closed:
+        return None
       # A BS base set exists so the walk builds an articulation context
       # (patched below to the bare schedule-only shape).
       return SimpleNamespace(id="fs_base_bs")
@@ -1270,6 +1297,213 @@ class TestStaleTailInvalidation:
       mock_inv.call_args.kwargs["through_period_end"]
       == response.months_computed[-1].period_end
     )
+
+
+def _seam_mechanics(horizon: int = 6, anchor: str = "seam") -> dict:
+  m = _mechanics(
+    _levers_for(horizon),
+    horizon=horizon,
+  )
+  m["base_anchor"] = anchor
+  return m
+
+
+def _levers_for(horizon: int) -> list[LeverAssertionLite]:
+  months = [
+    f"2026-{6 + i:02d}" if 6 + i <= 12 else f"2027-{6 + i - 12:02d}"
+    for i in range(1, horizon + 1)
+  ]
+  return [
+    _lever("rs-driver:RevenueGrowthRate", "el_growth", 0.03, months),
+    _lever("rs-driver:CostOfRevenueRate", "el_rate", 0.62, months),
+  ]
+
+
+SEAM_RULES = [GROWTH_RULE, COGS_RULE]
+
+
+class TestSeamAnchoredRoll:
+  """The walk re-anchors on the newest closed month, and the base holds still.
+
+  Before this, `base_period` did two jobs at once: it was the origin of the
+  authored lever window AND the month the walk took its opening balances
+  from. Advancing it to keep the balances current meant restating every
+  lever onto a shifted month window, which the update path rejects without
+  a full re-supply — so in practice a close meant deleting the scenario and
+  rebuilding it, and the close playbook carried a step saying exactly that.
+  Left un-advanced, the forward months opened on balances several closes
+  old, and the plan grid showed a cash line stepping from the last actual
+  into a figure the scenario's own cash-flow statement could not explain.
+
+  Splitting the two jobs fixes both ends: the authored window stays where it
+  was written, and the anchor moves on its own.
+  """
+
+  def test_reanchors_to_the_newest_closed_month(self) -> None:
+    response, rec = _run(
+      _seam_mechanics(horizon=6),
+      SEAM_RULES,
+      _levers_for(6),
+      months=6,
+      closed_months={"2026-06", "2026-07", "2026-08"},
+    )
+
+    assert response.anchor_period == "2026-08"
+    assert response.base_period == "2026-06"
+    # The closed months are not re-forecast; the walk starts after them.
+    assert [m.period for m in response.months_computed] == [
+      "2026-09",
+      "2026-10",
+      "2026-11",
+      "2026-12",
+    ]
+    assert rec.month("struct_is", date(2026, 7, 31)) is None
+
+  def test_the_horizon_end_holds_still(self) -> None:
+    """A re-anchored walk computes FEWER months, never later ones.
+
+    Otherwise a scenario quietly grows a longer horizon every time a month
+    closes under it, projecting into months its author never asserted a
+    lever for.
+    """
+    response, _ = _run(
+      _seam_mechanics(horizon=6),
+      SEAM_RULES,
+      _levers_for(6),
+      months=6,
+      closed_months={"2026-06", "2026-07", "2026-08"},
+    )
+
+    assert response.months_computed[-1].period == "2026-12"
+    assert len(response.months_computed) == 4
+
+  def test_levers_keep_their_authored_months(self) -> None:
+    """The point of the whole change: nothing has to be restated.
+
+    The levers were written against `base_period + 1 … + horizon`. The walk
+    now starts in the middle of that window and must still bind them —
+    which is what makes a scenario survive a close without being rebuilt.
+    """
+    response, rec = _run(
+      _seam_mechanics(horizon=6),
+      SEAM_RULES,
+      _levers_for(6),
+      months=6,
+      closed_months={"2026-06", "2026-07", "2026-08"},
+    )
+
+    assert response.skipped == []
+    # 3% growth off the anchor month's actual revenue of 100.
+    assert rec.value("struct_is", date(2026, 9, 30), "el_rev") == pytest.approx(103.0)
+    assert rec.value("struct_is", date(2026, 10, 31), "el_rev") == pytest.approx(106.09)
+
+  def test_fixed_anchor_pins_the_walk_to_the_base(self) -> None:
+    """The counterfactual stays available, and stays deliberate.
+
+    "If we had restarted consulting last July" is a real question; its
+    balances are supposed to diverge from actuals. It just has to be asked
+    on purpose rather than fallen into by a scenario nobody re-based.
+    """
+    response, _ = _run(
+      _seam_mechanics(horizon=6, anchor="fixed"),
+      SEAM_RULES,
+      _levers_for(6),
+      months=6,
+      closed_months={"2026-06", "2026-07", "2026-08"},
+    )
+
+    assert response.anchor_period == "2026-06"
+    assert [m.period for m in response.months_computed][:2] == ["2026-07", "2026-08"]
+    assert len(response.months_computed) == 6
+
+  def test_an_unclosed_horizon_is_unchanged(self) -> None:
+    """The overwhelmingly common case: base is still the seam."""
+    response, _ = _run(
+      _seam_mechanics(horizon=3),
+      SEAM_RULES,
+      _levers_for(3),
+      months=3,
+    )
+
+    assert response.anchor_period == "2026-06"
+    assert [m.period for m in response.months_computed] == ALL_MONTHS
+    assert not any("re-anchored" in d for d in response.diagnostics)
+
+  def test_reanchoring_is_explained(self) -> None:
+    response, _ = _run(
+      _seam_mechanics(horizon=6),
+      SEAM_RULES,
+      _levers_for(6),
+      months=6,
+      closed_months={"2026-06", "2026-07", "2026-08"},
+    )
+
+    explanation = " ".join(response.diagnostics)
+    assert "re-anchored" in explanation
+    assert "2026-06" in explanation and "2026-08" in explanation
+    # Shorter-than-requested without a halt is a new shape; it has to say so
+    # rather than leave the caller to spot a length mismatch.
+    assert response.halted_at is None
+    assert len(response.months_computed) < response.months
+
+  def test_a_fully_overtaken_scenario_says_so(self) -> None:
+    """An expired scenario is an author-actionable condition, not a no-op.
+
+    Returning "0 months computed" with a green response would read as
+    success to every caller.
+    """
+    with pytest.raises(ValueError, match="no forward months left"):
+      _run(
+        _seam_mechanics(horizon=3),
+        SEAM_RULES,
+        _levers_for(3),
+        months=3,
+        closed_months={"2026-06", "2026-07", "2026-08", "2026-09"},
+      )
+
+  def test_a_month_without_a_balance_sheet_cannot_anchor(self) -> None:
+    """Anchoring half-blind would silently drop the balance-sheet roll."""
+    response, _ = _run(
+      _seam_mechanics(horizon=6),
+      SEAM_RULES,
+      _levers_for(6),
+      months=6,
+      closed_months={"2026-06", "2026-07", "2026-08"},
+      bs_closed_months={"2026-06", "2026-07"},
+      schedule_projection=ScheduleProjection(),
+    )
+
+    assert response.anchor_period == "2026-07"
+
+  def test_superseded_head_is_swept(self) -> None:
+    """Months an earlier run computed that have since closed must go.
+
+    Every read prefers actuals at an overlap, so they are invisible on the
+    plan grid — which is precisely why they would sit there indefinitely,
+    still visible to anything reading the scenario directly, still carrying
+    their own passing verification results.
+    """
+    with (
+      patch.object(fc, "_invalidate_superseded_head", return_value=2) as head,
+      patch.object(fc, "_invalidate_stale_tail", return_value=0),
+    ):
+      response, _ = _run(
+        _seam_mechanics(horizon=6),
+        SEAM_RULES,
+        _levers_for(6),
+        months=6,
+        closed_months={"2026-06", "2026-07", "2026-08"},
+      )
+
+    assert head.call_args.kwargs["scenario_id"] == "struct_budget"
+    assert head.call_args.kwargs["through_period_end"] == date(2026, 8, 31)
+    assert any("at or before 2026-08" in d for d in response.diagnostics)
+
+  def test_nothing_is_swept_when_the_anchor_did_not_move(self) -> None:
+    with patch.object(fc, "_invalidate_superseded_head") as head:
+      _run(_seam_mechanics(horizon=3), SEAM_RULES, _levers_for(3), months=3)
+
+    head.assert_not_called()
 
 
 # ── The real verifier ─────────────────────────────────────────────────────

--- a/tests/operations/information_block/test_forecast_compute.py
+++ b/tests/operations/information_block/test_forecast_compute.py
@@ -1270,3 +1270,311 @@ class TestStaleTailInvalidation:
       mock_inv.call_args.kwargs["through_period_end"]
       == response.months_computed[-1].period_end
     )
+
+
+# ── The real verifier ─────────────────────────────────────────────────────
+#
+# Everything above stubs `_verify_month_sets`. That makes the walk's
+# *response* to a verdict testable, which is what `TestStopTheWalk` proves.
+# It cannot prove the harder half: that the real verifier reaches the right
+# verdict on a wrong forecast. The classes below run the real one against a
+# real schema, because every one of the five correctness defects in this arm
+# was found by hand and none by CI — and the reason is structural. The BS
+# roll closes on a balancing cash plug, so `A = L + E` holds *by
+# construction* no matter how wrong the walk is; the accounting equation is
+# exactly the assertion that cannot fail. A month has to be balanced and
+# wrong for the suite to mean anything.
+
+
+@pytest.fixture()
+def ext_session():
+  """Extensions schema in the test Postgres DB, one throwaway schema per test."""
+  import os
+  import uuid
+
+  from sqlalchemy import create_engine, text
+  from sqlalchemy.orm import sessionmaker
+
+  import robosystems.models.extensions  # noqa: F401  (register models)
+  from robosystems.db.extensions import ExtensionsBase
+
+  database_url = os.environ.get("TEST_DATABASE_URL")
+  if not database_url:
+    pytest.skip("TEST_DATABASE_URL not configured")
+
+  schema = f"ext_fcverify_{uuid.uuid4().hex[:12]}"
+  engine = create_engine(database_url)
+  with engine.begin() as conn:
+    conn.execute(text(f'CREATE SCHEMA "{schema}"'))
+
+  session = sessionmaker(bind=engine)()
+  session.execute(text(f'SET search_path TO "{schema}"'))
+  ExtensionsBase.metadata.create_all(bind=session.connection())
+  session.commit()
+  session.execute(text(f'SET search_path TO "{schema}"'))
+
+  try:
+    yield session
+  finally:
+    session.rollback()
+    session.close()
+    with engine.begin() as conn:
+      conn.execute(text(f'DROP SCHEMA "{schema}" CASCADE'))
+    engine.dispose()
+
+
+VERIFY_START = date(2026, 7, 1)
+VERIFY_END = date(2026, 7, 31)
+
+
+def _seed_scenario_month(
+  session,
+  *,
+  assets: float,
+  cash: float,
+  ppe: float,
+  liabilities: float,
+  equity: float,
+) -> tuple[str, str]:
+  """One scenario balance-sheet month, with the corpus that gates actuals.
+
+  Two rules, both structure-scoped, both drawn from the shapes the real
+  corpus carries:
+
+  * ``EqualTo`` — the accounting equation. The BS roll's cash plug makes
+    this hold whatever else is wrong, which is why it is the control, not
+    the check.
+  * ``RollUp`` — the subtotal foots its calculation children. This is
+    articulation: it is what a PP&E line drifting away from its own
+    depreciation actually breaks.
+
+  Returns ``(structure_id, fact_set_id)``.
+  """
+  from robosystems.models.extensions import (
+    Association,
+    Element,
+    Rule,
+    Structure,
+    Taxonomy,
+  )
+  from robosystems.models.extensions.roboledger import Fact, FactSet
+
+  taxonomy = Taxonomy(name="rs-gaap", taxonomy_type="reporting_extension")
+  session.add(taxonomy)
+  session.flush()
+
+  structure = Structure(
+    name="Balance Sheet", block_type="balance_sheet", taxonomy_id=taxonomy.id
+  )
+  scenario = Structure(name="Plan", block_type="forecast", taxonomy_id=taxonomy.id)
+  session.add_all([structure, scenario])
+  session.flush()
+
+  def _el(qname: str, balance_type: str) -> Element:
+    element = Element(
+      name=qname.split(":")[-1],
+      qname=qname,
+      balance_type=balance_type,
+      period_type="instant",
+      taxonomy_id=taxonomy.id,
+    )
+    session.add(element)
+    return element
+
+  el_assets = _el("rs-gaap:Assets", "debit")
+  el_cash = _el("rs-gaap:CashAndCashEquivalentsAtCarryingValue", "debit")
+  el_ppe = _el("rs-gaap:PropertyPlantAndEquipmentNet", "debit")
+  el_liabilities = _el("rs-gaap:Liabilities", "credit")
+  el_equity = _el("rs-gaap:StockholdersEquity", "credit")
+  session.flush()
+
+  # Assets = Cash + PP&E, as calculation arcs. The RollUp evaluator derives
+  # its children from these live arcs rather than the rule's frozen list.
+  for order, child in enumerate((el_cash, el_ppe)):
+    session.add(
+      Association(
+        structure_id=structure.id,
+        from_element_id=el_assets.id,
+        to_element_id=child.id,
+        association_type="calculation",
+        order_value=float(order),
+        weight=1.0,
+      )
+    )
+
+  session.add(
+    Rule(
+      taxonomy_id=taxonomy.id,
+      rule_category="FundamentalAccountingConceptRelation",
+      rule_pattern="EqualTo",
+      rule_expression="$Assets = ($Liabilities + $Equity)",
+      target_kind="structure",
+      target_structure_id=structure.id,
+      rule_variables=[
+        {"variable_name": "Assets", "variable_qname": el_assets.qname},
+        {"variable_name": "Liabilities", "variable_qname": el_liabilities.qname},
+        {"variable_name": "Equity", "variable_qname": el_equity.qname},
+      ],
+    )
+  )
+  session.add(
+    Rule(
+      taxonomy_id=taxonomy.id,
+      rule_category="FundamentalAccountingConceptRelation",
+      rule_pattern="RollUp",
+      rule_expression="$Assets = ($Cash + $PPE)",
+      target_kind="structure",
+      target_structure_id=structure.id,
+      rule_variables=[
+        {"variable_name": "Assets", "variable_qname": el_assets.qname},
+        {"variable_name": "Cash", "variable_qname": el_cash.qname},
+        {"variable_name": "PPE", "variable_qname": el_ppe.qname},
+      ],
+    )
+  )
+
+  fact_set = FactSet(
+    structure_id=structure.id,
+    period_start=VERIFY_START,
+    period_end=VERIFY_END,
+    factset_type="report",
+    entity_id="ent_1",
+    scenario_id=scenario.id,
+  )
+  fact_set.provenance = {
+    "origin": "forecast",
+    "scenario_structure_id": scenario.id,
+    "base_period": "2026-06",
+    "month_index": 1,
+    "drivers": [],
+  }
+  session.add(fact_set)
+  session.flush()
+
+  for element, value in (
+    (el_assets, assets),
+    (el_cash, cash),
+    (el_ppe, ppe),
+    (el_liabilities, liabilities),
+    (el_equity, equity),
+  ):
+    session.add(
+      Fact(
+        element_id=element.id,
+        value=value,
+        fact_type="Numeric",
+        period_start=VERIFY_START,
+        period_end=VERIFY_END,
+        period_type="instant",
+        entity_id="ent_1",
+        structure_id=structure.id,
+        fact_set_id=fact_set.id,
+      )
+    )
+  session.flush()
+  return structure.id, fact_set.id
+
+
+def _verify(session, structure_id: str, fact_set_id: str):
+  return fc._verify_month_sets(
+    session,
+    sets=((structure_id, fact_set_id),),
+    period_end=VERIFY_END,
+    created_by="usr_test",
+    global_calculations={},
+  )
+
+
+class TestTheRealVerifier:
+  """`_verify_month_sets` itself, unstubbed, over a month that is wrong.
+
+  The month is deliberately *balanced*: Assets 200 = Liabilities 80 +
+  Equity 120, so the accounting equation passes. Its subtotal does not
+  foot — Cash 100 + PP&E 50 is 150, not 200 — so articulation is broken.
+  This is the shape of the PP&E defect that held `A = L + E` throughout
+  and shipped anyway.
+  """
+
+  def test_a_balanced_but_unarticulated_month_fails(self, ext_session) -> None:
+    structure_id, fact_set_id = _seed_scenario_month(
+      ext_session, assets=200.0, cash=100.0, ppe=50.0, liabilities=80.0, equity=120.0
+    )
+
+    passed, failures = _verify(ext_session, structure_id, fact_set_id)
+
+    assert passed is False, (
+      "the real verifier returned a pass (or an absence) for a month whose "
+      "subtotal is off by 50.00"
+    )
+    assert failures
+    assert any("rollup" in f.lower() for f in failures), failures
+
+  def test_the_accounting_equation_is_what_passes(self, ext_session) -> None:
+    """The control: the failing month is failing for the right reason.
+
+    Without this, a verifier that failed everything — a broken binder, a
+    corpus that never loads — would satisfy the test above and prove
+    nothing. The equation must pass on the same facts that fail the rollup.
+    """
+    from robosystems.models.extensions import VerificationResult
+
+    structure_id, fact_set_id = _seed_scenario_month(
+      ext_session, assets=200.0, cash=100.0, ppe=50.0, liabilities=80.0, equity=120.0
+    )
+    _verify(ext_session, structure_id, fact_set_id)
+
+    from sqlalchemy import select
+
+    from robosystems.models.extensions import Rule
+
+    status_by_pattern = {
+      pattern: status
+      for status, pattern in ext_session.execute(
+        select(VerificationResult.status, Rule.rule_pattern).join(
+          Rule, Rule.id == VerificationResult.rule_id
+        )
+      ).all()
+    }
+
+    assert status_by_pattern["EqualTo"] == "pass"
+    assert status_by_pattern["RollUp"] == "fail"
+
+  def test_a_correct_month_passes(self, ext_session) -> None:
+    """And the verifier is not simply always-False on this corpus."""
+    structure_id, fact_set_id = _seed_scenario_month(
+      ext_session, assets=150.0, cash=100.0, ppe=50.0, liabilities=60.0, equity=90.0
+    )
+
+    passed, failures = _verify(ext_session, structure_id, fact_set_id)
+
+    assert passed is True, failures
+    assert failures == []
+
+  def test_the_walk_halts_on_the_real_verdict(self, ext_session) -> None:
+    """The two halves, joined: real verdict in, explained halt out.
+
+    `TestStopTheWalk` feeds the walk a hand-written verdict; this feeds it
+    the one the real verifier produced, and checks the real failure message
+    survives all the way into the caller's diagnostics.
+    """
+    structure_id, fact_set_id = _seed_scenario_month(
+      ext_session, assets=200.0, cash=100.0, ppe=50.0, liabilities=80.0, equity=120.0
+    )
+    verdict = _verify(ext_session, structure_id, fact_set_id)
+    assert verdict[0] is False
+
+    response, _ = _run(
+      _mechanics(FULL_LEVERS, horizon=6),
+      FULL_RULES,
+      FULL_LEVERS,
+      months=6,
+      verify=lambda *a, **k: verdict,
+    )
+
+    assert response.halted_at == "2026-07"
+    assert len(response.months_computed) == 1
+    assert response.months_computed[0].verification_passed is False
+    assert any("halted at 2026-07" in d for d in response.diagnostics)
+    assert any("rollup" in d.lower() for d in response.diagnostics), (
+      "the real verifier's reason has to reach the caller, not just the verdict"
+    )

--- a/tests/operations/information_block/test_forecast_compute.py
+++ b/tests/operations/information_block/test_forecast_compute.py
@@ -294,6 +294,7 @@ def _run(
   verify: Any = None,
   closed_months: set[str] | None = None,
   bs_closed_months: set[str] | None = None,
+  published_months: set[str] | None = None,
 ):
   """``verify`` controls ``_verify_month_sets``.
 
@@ -302,15 +303,20 @@ def _run(
   makes the stop-the-walk behaviour testable at all; the fixed stub is
   precisely why it never was.
 
-  ``closed_months`` names the months carrying actual statement sets —
-  ``{"2026-06"}`` (the base alone) by default, which is where the books
-  stood when each of these scenarios was authored. Widen it to move the
-  seam and watch the walk re-anchor. ``bs_closed_months`` narrows the
-  balance-sheet half independently, for the month that closed its income
-  statement but not its balance sheet.
+  ``closed_months`` names the months carrying **canonical** (close-stamped)
+  statement sets — ``{"2026-06"}`` (the base alone) by default, which is
+  where the books stood when each of these scenarios was authored. Widen it
+  to move the seam and watch the walk re-anchor. ``bs_closed_months``
+  narrows the balance-sheet half independently, for the month that closed
+  its income statement but not its balance sheet.
+
+  ``published_months`` names months carrying only a **publication
+  snapshot** — a report was generated for them, but they are open, or were
+  reopened. They are visible to a non-canonical read and must never anchor.
   """
   closed = closed_months if closed_months is not None else {"2026-06"}
   bs_closed = bs_closed_months if bs_closed_months is not None else closed
+  published = published_months or set()
   structure = _structure(mechanics)
   recorder = _Recorder()
 
@@ -332,19 +338,27 @@ def _run(
     entity_id: Any = None,
     period_start: Any = None,
     period_end: Any = None,
+    *,
+    canonical_only: bool = False,
   ) -> Any:
     # Which months are closed has to be modelled rather than assumed now
     # that the walk asks, in order to resolve its anchor. A stub answering
     # "yes" for every month would report the whole horizon as closed.
+    #
+    # And closed is not the same question as "a set exists": a publication
+    # snapshot can sit on an open or reopened month, so `canonical_only`
+    # has to be honoured here or the tests can't tell the two apart.
     month = (
       None if period_end is None else f"{period_end.year:04d}-{period_end.month:02d}"
     )
+    visible = closed if canonical_only else closed | published
+    bs_visible = bs_closed if canonical_only else bs_closed | published
     if sid == "struct_is":
-      if month is not None and month not in closed:
+      if month is not None and month not in visible:
         return None
       return SimpleNamespace(id="fs_base_is")
     if sid == "struct_bs" and schedule_projection is not None:
-      if month is not None and month not in bs_closed:
+      if month is not None and month not in bs_visible:
         return None
       # A BS base set exists so the walk builds an articulation context
       # (patched below to the bare schedule-only shape).
@@ -357,7 +371,7 @@ def _run(
     # The anchor scan's upper bound. Reads from the same `closed_months`
     # model as `_actual_set_at` so the two can't disagree about where the
     # books stand — a bound below the seam would skip a valid anchor.
-    patch.object(fc, "_newest_actual_month", return_value=max(closed)),
+    patch.object(fc, "_newest_actual_month", return_value=max(closed)),  # canonical
     patch.object(
       fc,
       "load_articulation_context",
@@ -1451,19 +1465,111 @@ class TestSeamAnchoredRoll:
     assert len(response.months_computed) < response.months
 
   def test_a_fully_overtaken_scenario_says_so(self) -> None:
-    """An expired scenario is an author-actionable condition, not a no-op.
+    """An expired scenario is an author-actionable condition, not a no-op."""
+    response, _ = _run(
+      _seam_mechanics(horizon=3),
+      SEAM_RULES,
+      _levers_for(3),
+      months=3,
+      closed_months={"2026-06", "2026-07", "2026-08", "2026-09"},
+    )
 
-    Returning "0 months computed" with a green response would read as
-    success to every caller.
+    assert response.months_computed == []
+    assert response.halted_at is None
+    assert any("no forward months left" in d for d in response.diagnostics)
+    assert any("horizon_months" in d for d in response.diagnostics), (
+      "the diagnostic has to name the way out, not just the condition"
+    )
+
+  def test_a_fully_overtaken_scenario_still_cleans_up(self) -> None:
+    """The limit case must not behave opposite to the trend.
+
+    This used to raise, which read as the loud answer and was the quiet
+    one: the exception rolled the session back, so every superseded month
+    survived it — and a fully-overtaken scenario is precisely the case
+    where *all* of them qualify for the sweep. A partially-overtaken
+    scenario cleaned up after itself while a fully-overtaken one did not.
     """
-    with pytest.raises(ValueError, match="no forward months left"):
-      _run(
+    with patch.object(fc, "_invalidate_superseded_head", return_value=3) as head:
+      response, _ = _run(
         _seam_mechanics(horizon=3),
         SEAM_RULES,
         _levers_for(3),
         months=3,
         closed_months={"2026-06", "2026-07", "2026-08", "2026-09"},
       )
+
+    head.assert_called_once()
+    assert head.call_args.kwargs["scenario_id"] == "struct_budget"
+    assert head.call_args.kwargs["through_period_end"] == date(2026, 9, 30)
+    assert any("have been cleared" in d for d in response.diagnostics)
+
+  def test_a_publication_snapshot_is_not_a_closed_month(self) -> None:
+    """An anchor is a claim that the books are closed through a month.
+
+    `create_report` consults no fiscal calendar, so a report generated for
+    an open — or future — month leaves a valid publication snapshot behind
+    it. Anchoring there would seed the walk from an incomplete month and
+    delete real forecast months to do it.
+    """
+    response, _ = _run(
+      _seam_mechanics(horizon=6),
+      SEAM_RULES,
+      _levers_for(6),
+      months=6,
+      closed_months={"2026-06"},
+      published_months={"2026-07", "2026-08"},
+    )
+
+    assert response.anchor_period == "2026-06"
+    assert next(m.period for m in response.months_computed) == "2026-07"
+
+  def test_the_scan_below_the_bound_still_demands_canonical(self) -> None:
+    """The bound is canonical, so it usually hides a non-canonical scan —
+    the first month probed is the bound itself, which is closed by
+    definition. It stops hiding it the moment the scan walks DOWN: the
+    newest closed month can carry an income statement without a balance
+    sheet, and the month below it can be one that was reopened. Then the
+    scan is the only thing standing between the walk and a month nobody
+    closed.
+    """
+    response, _ = _run(
+      _seam_mechanics(horizon=6),
+      SEAM_RULES,
+      _levers_for(6),
+      months=6,
+      # 2026-08 closed its income statement but not its balance sheet, so
+      # the scan can't anchor there and keeps walking back.
+      closed_months={"2026-06", "2026-08"},
+      bs_closed_months={"2026-06"},
+      # 2026-07 was reopened: canonical retracted, snapshot left behind.
+      published_months={"2026-07"},
+      schedule_projection=ScheduleProjection(),
+    )
+
+    assert response.anchor_period == "2026-06", (
+      "the scan walked past the bound into a reopened month and treated "
+      "its leftover publication snapshot as a close"
+    )
+
+  def test_a_reopened_month_stops_anchoring(self) -> None:
+    """Reopening retracts the canonical set and leaves the snapshot.
+
+    So the same publication row that never proved closure in the first
+    place is exactly what is left behind when a month stops being closed.
+    """
+    response, _ = _run(
+      _seam_mechanics(horizon=6),
+      SEAM_RULES,
+      _levers_for(6),
+      months=6,
+      # 2026-08 was closed and has been reopened: canonical gone, snapshot
+      # left. 2026-07 is still genuinely closed.
+      closed_months={"2026-06", "2026-07"},
+      published_months={"2026-08"},
+    )
+
+    assert response.anchor_period == "2026-07"
 
   def test_a_month_without_a_balance_sheet_cannot_anchor(self) -> None:
     """Anchoring half-blind would silently drop the balance-sheet roll."""
@@ -1525,7 +1631,7 @@ class TestAnchorScanBound:
   def _resolve(newest: str | None, closed: set[str], horizon: int = 12):
     probed: list[str] = []
 
-    def _at(session, sid, entity_id, period_start, period_end):
+    def _at(session, sid, entity_id, period_start, period_end, *, canonical_only=False):
       month = f"{period_end.year:04d}-{period_end.month:02d}"
       probed.append(month)
       return SimpleNamespace(id="fs") if month in closed else None

--- a/tests/operations/information_block/test_forecast_compute.py
+++ b/tests/operations/information_block/test_forecast_compute.py
@@ -354,6 +354,10 @@ def _run(
   with (
     patch.object(fc, "newest_actual_structure_id", side_effect=_structures),
     patch.object(fc, "_actual_set_at", side_effect=_base_set),
+    # The anchor scan's upper bound. Reads from the same `closed_months`
+    # model as `_actual_set_at` so the two can't disagree about where the
+    # books stand — a bound below the seam would skip a valid anchor.
+    patch.object(fc, "_newest_actual_month", return_value=max(closed)),
     patch.object(
       fc,
       "load_articulation_context",
@@ -1504,6 +1508,115 @@ class TestSeamAnchoredRoll:
       _run(_seam_mechanics(horizon=3), SEAM_RULES, _levers_for(3), months=3)
 
     head.assert_not_called()
+
+
+class TestAnchorScanBound:
+  """The anchor scan asks one question before it starts walking.
+
+  Its cheapest case was also its most expensive: a scenario whose base is
+  still the seam — every scenario at creation, and most of them most of
+  the time — finds nothing, and finding nothing meant having probed every
+  month of the horizon to prove it. One query for the newest actual month
+  bounds that. The bound is only ever an upper bound, so the risk worth
+  testing is a bound that comes back too LOW and skips a valid anchor.
+  """
+
+  @staticmethod
+  def _resolve(newest: str | None, closed: set[str], horizon: int = 12):
+    probed: list[str] = []
+
+    def _at(session, sid, entity_id, period_start, period_end):
+      month = f"{period_end.year:04d}-{period_end.month:02d}"
+      probed.append(month)
+      return SimpleNamespace(id="fs") if month in closed else None
+
+    with (
+      patch.object(fc, "_newest_actual_month", return_value=newest),
+      patch.object(fc, "_actual_set_at", side_effect=_at),
+    ):
+      anchor = fc._resolve_anchor_period(
+        MagicMock(),
+        base_period="2026-06",
+        horizon_months=horizon,
+        is_structure_id="struct_is",
+        bs_structure_id=None,
+        entity_id="ent_1",
+      )
+    return anchor, probed
+
+  def test_an_unmoved_seam_probes_nothing(self) -> None:
+    """The common case: the books are still at the base."""
+    anchor, probed = self._resolve("2026-06", {"2026-06"})
+
+    assert anchor == "2026-06"
+    assert probed == [], (
+      "walking a 12-month horizon to conclude nothing has closed is the "
+      f"case this bound exists to remove; probed {probed}"
+    )
+
+  def test_the_scan_starts_at_the_bound(self) -> None:
+    anchor, probed = self._resolve("2026-08", {"2026-06", "2026-07", "2026-08"})
+
+    assert anchor == "2026-08"
+    assert probed == ["2026-08"]
+
+  def test_a_bound_past_the_horizon_still_stops_at_the_horizon(self) -> None:
+    """The annual comparative set can push the bound past the window."""
+    anchor, probed = self._resolve("2027-12", {"2026-06", "2026-07"}, horizon=3)
+
+    assert anchor == "2026-07"
+    assert probed == ["2026-09", "2026-08", "2026-07"]
+
+  def test_a_gap_below_the_bound_is_walked_through(self) -> None:
+    """The bound narrows the scan; it does not replace it.
+
+    A month can carry the newest actuals while an intervening one has no
+    monthly set — scanning down from the bound is what keeps a gap from
+    stranding the anchor.
+    """
+    anchor, probed = self._resolve("2026-09", {"2026-06", "2026-07"})
+
+    assert anchor == "2026-07"
+    assert probed == ["2026-09", "2026-08", "2026-07"]
+
+  def test_no_actuals_at_all_is_the_base(self) -> None:
+    anchor, probed = self._resolve(None, set())
+
+    assert anchor == "2026-06"
+    assert probed == []
+
+
+class TestNewestActualMonth:
+  """The bound query itself — deliberately without the monthly-window guard."""
+
+  def test_returns_the_month_of_the_newest_actual_set(self) -> None:
+    session = MagicMock()
+    session.execute.return_value.scalar.return_value = date(2026, 12, 31)
+
+    assert fc._newest_actual_month(session, "struct_is", "ent_1") == "2026-12"
+
+  def test_no_actual_sets_is_none(self) -> None:
+    session = MagicMock()
+    session.execute.return_value.scalar.return_value = None
+
+    assert fc._newest_actual_month(session, "struct_is", "ent_1") is None
+
+  def test_it_excludes_scenario_sets(self) -> None:
+    """Or the bound would sit at the end of the forecast horizon, which is
+    every month the scan is supposed to rule out."""
+    session = MagicMock()
+    session.execute.return_value.scalar.return_value = date(2026, 6, 30)
+
+    fc._newest_actual_month(session, "struct_is", "ent_1")
+
+    predicate = " ".join(
+      str(
+        session.execute.call_args.args[0].whereclause.compile(
+          compile_kwargs={"literal_binds": True}
+        )
+      ).split()
+    )
+    assert "scenario_id IS NULL" in predicate, predicate
 
 
 # ── The real verifier ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes items 2 and 3 of the forecast-hardening spec and runs item 1's reader-conformance audit. A scenario now survives a period close without being rebuilt, the verification gate is tested against a forecast that is wrong rather than only against a stubbed verdict, and the audit that was scoped as a precondition for projecting scenario facts into the graph turned up two live OLTP defects instead.

Item 1's projection flip is deliberately **not** taken here. It buys a capability nothing currently asks for, and the exclusion means the graph is limited rather than wrong; the audit was kept because it stands alone.

## Changes

**Seam-anchored balance-sheet roll** (`operations/information_block/forecast_compute.py`, `forecast.py`, `models/api/information_block.py`, `models/api/extensions/forecasts.py`)

`base_period` was doing two jobs: origin of the authored lever window, and the month the walk seeded its opening balances from. Advancing it to keep balances current forced a restatement of every lever onto a shifted window, which `update` rejects without a full re-supply — so keeping a scenario current across a close meant deleting and rebuilding it. Left un-advanced, the forward months opened on balances several closes old.

- `base_anchor: "seam" | "fixed"` on `ForecastMechanics` (default `seam`), threaded through create and update. Switching it restates nothing, unlike `base_period`.
- `_resolve_anchor_period` scans back from the horizon end for the newest month carrying **close-stamped** income-statement **and** balance-sheet sets. Whether the balance sheet is required is decided by what the *base* month carries, so a scenario that rolls one can't re-anchor onto a month that would silently drop the roll. Canonical-only matters: `create_report` consults no fiscal calendar, so a publication snapshot can sit on an open or reopened month and proves nothing about closure.
- The walk computes `anchor+1 … base+horizon`. **The window's end never moves** — a re-anchored walk computes fewer months, never later ones, or a scenario silently grows a horizon its author never asserted levers for. A scenario the close has fully overtaken computes no months, clears its now-closed stale months, and says so in its diagnostics (this raised in the first push — see the review follow-up below).
- `anchor_period` on the response and in each month's `ForecastProvenance`; a re-anchor is announced in `diagnostics` rather than applied quietly (months_computed shorter than months without a halt is a new shape).
- `_invalidate_superseded_head` sweeps months an earlier run computed that have since closed — invisible on the plan grid because actuals win at overlaps, still visible to anything reading the scenario directly. It shares one implementation with the tail sweep (`_sweep_scenario_sets`) so the lever-set exclusion is written once.
- The base-advance step is removed from the close playbook (`middleware/mcp/tools/playbook_tools.py`).

**A test that binds `verification_passed` to a forecast that is wrong** (`tests/operations/information_block/test_forecast_compute.py`)

`TestStopTheWalk` proves the walk's *response* to a verdict by injecting one; nothing proved the real verifier reaches the right verdict. `TestTheRealVerifier` runs the real `_verify_month_sets` — and through it the real rule engine — against a real extensions schema, over a month that is balanced and wrong: `Assets 200 = Liabilities 80 + Equity 120` passes the accounting equation while `Cash 100 + PP&E 50` fails the rollup. That shape is the point; the BS roll closes on a balancing cash plug, so `A = L + E` holds by construction however wrong the walk is.

The `_run` harness now models which months are closed (`closed_months` / `bs_closed_months`) — a stub answering "yes" for every month would report the whole horizon as already closed.

**Rule-engine scenario leakage** (`operations/information_block/rules/engine.py`) — worth close review

Scenario month sets carry the *statement* structure's id, by design: a scenario column renders through the same structure as its actuals. The engine has two unpinned entry points — `evaluate-rules` called with only a `structure_id` (all three narrowing arguments are documented optional) and the period close, which evaluates its statement structures without pinning a FactSet — and both scoped by `structure_id` alone.

- `_bind_variables` takes the newest fact per element when unpinned. On a graph carrying a forecast the newest fact is a month that has not happened, so a check of the books answered about the plan and wrote the verdict onto the books.
- `_load_period_balances` pins to the newest *actual* FactSet but fell back to `structure_id` scope when there wasn't one. Reachable: the walk stamps balance-sheet sets on the statement structure even where no actual balance sheet exists (the degraded, rule-driven branch), so "never reported" and "carries only forecast months" were the same state to that query. The comment there already said "no balances"; the code did something else.
- Both now scope through one shared `_actual_set_ids`. `_bind_sum_variables` gets the same filter — inert today (schedule structures carry no scenario sets) and the third place the invariant has to hold to be one.

**`has_dimensions` was a literal** (`operations/extensions/materialize.py`)

`Fact.has_dimensions` and `dimension_count` were hardcoded `false` / `0` while four graph read paths filter consolidated totals on exactly that column — so the documented contract was being upheld by the scenario exclusion upstream, not by the flag. Anything dimensioned reaching the graph would have passed straight through every one of those filters. Now derived from the `fact_dimensions` junction. Provably inert today: only scenario facts carry a junction row, and those are excluded.

**Review follow-ups** (commits `94719978`, `13cc580e`, `003fbddd`) — see the PR comments for detail: the anchor scan is bounded by one query instead of walking the whole horizon; anchor candidates must be close-stamped rather than merely present; the overtaken path sweeps and returns instead of raising (the exception rolled the sweep back); and the close playbook's account of all this was corrected, since it ships to MCP clients in the same image as the tools it describes.

## Breaking Changes

None.

Additive only on the client SDK surface — `anchor_period` on `ComputeForecastResponse`, `base_anchor` on `ForecastMechanics` / `CreateForecastRequest` / `UpdateForecastRequest`. Generated tier, so it rides a client minor; nothing in the stable tier or the integration template's emit path is touched. An SDK regen opportunity, not a coordination point.

Behaviour note for existing forecast blocks: `base_anchor` defaults to `seam`, so blocks authored before it existed re-anchor as periods close. Checked against the live Harbinger graph — all three scenarios carry `base_period: 2026-06` against `closed_through: 2026-06`, i.e. already seam-anchored, so the default is a no-op there today. Scenarios deliberately built on a counterfactual base want `base_anchor: "fixed"`, which needs no levers re-supplied.

## Testing

- `just test-code` — clean (ruff check, format, basedpyright: 0 errors, cfn-lint, actionlint).
- Full unit suite via `uv run pytest -m "not slow"` — **12,958 passed, 38 skipped**. (Note for anyone reproducing: sourcing `.env.local` sets `ENTERPRISE_ORG_ID`, which CI does not, and that alone fails 36 unrelated SCIM/OIDC tests. Run with only `TEST_DATABASE_URL` set.)
- Both new engine tests were confirmed to **fail before** the fix and pass after; each ships with a control that would catch a filter which simply drops everything.
- The seam-anchoring tests were mutation-checked: with re-anchoring disabled, 7 of the 10 fail and the 3 that pass are exactly the ones asserting unchanged behaviour. The real-verifier tests were mutation-checked twice — forcing the rollup evaluator to pass breaks the main assertion, and a binder that never binds breaks the control.
- The materializer change was verified by **executing the generated staging SQL against real DuckDB + Postgres**, not by reading it: the scenario fact stays excluded, and a deliberately dimensioned actual fact projects as `(true, 1)` where it previously read `(false, 0)`.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.

