### PR TITLE
fix(events): lock every path that decides an event's next status

### DIFF
--- a/robosystems/operations/event_block/__init__.py
+++ b/robosystems/operations/event_block/__init__.py
@@ -6,6 +6,7 @@ path regardless of internal layout.
 
 from .commands import (
   DuplicateEventError,
+  EventLockedError,
   EventNotFoundError,
   InvalidEventTransitionError,
   create_event_block,
@@ -16,6 +17,7 @@ from .commands import (
 
 __all__ = [
   "DuplicateEventError",
+  "EventLockedError",
   "EventNotFoundError",
   "InvalidEventTransitionError",
   "create_event_block",

--- a/robosystems/operations/event_block/__init__.py
+++ b/robosystems/operations/event_block/__init__.py
@@ -6,7 +6,6 @@ path regardless of internal layout.
 
 from .commands import (
   DuplicateEventError,
-  EventLockedError,
   EventNotFoundError,
   InvalidEventTransitionError,
   create_event_block,
@@ -14,6 +13,7 @@ from .commands import (
   preview_event_block,
   update_event_block,
 )
+from .locking import EventLockedError
 
 __all__ = [
   "DuplicateEventError",

--- a/robosystems/operations/event_block/commands.py
+++ b/robosystems/operations/event_block/commands.py
@@ -365,7 +365,15 @@ def update_event_block(
   Handler errors roll back the entire update, including the status
   change — a failed commit leaves the event in its pre-approval state.
   """
-  event = session.get(Event, body.event_id)
+  # Lock the row for the life of the transaction. The transition check below
+  # is read-decide-write, and the decision is only sound if nothing else can
+  # move the event in between. The live race is an inbox approval against the
+  # sync's auto-commit pass (`extensions/loader.py`): both read `captured`,
+  # both fire the handler, and the event ends up with two sets of GL rows —
+  # a ledger that still foots and is still wrong. Under READ COMMITTED the
+  # blocked reader re-reads the committed row once the lock releases, sees
+  # the new status, and raises InvalidEventTransitionError as it should.
+  event = session.get(Event, body.event_id, with_for_update=True)
   if event is None:
     raise EventNotFoundError(f"Event not found: {body.event_id}")
 

--- a/robosystems/operations/event_block/commands.py
+++ b/robosystems/operations/event_block/commands.py
@@ -383,7 +383,14 @@ def update_event_block(
     f"Event {body.event_id} is being written by another process "
     "(most likely a running sync). Retry in a moment.",
   ):
-    event = session.get(Event, body.event_id, with_for_update=True)
+    # `populate_existing` for the same reason as `execute_event_block`: every
+    # production caller opens a fresh session per request, so the identity map
+    # is empty today, but a caller that reused a session would otherwise get
+    # the lock and a stale status — the one combination this guard exists to
+    # prevent.
+    event = session.get(
+      Event, body.event_id, with_for_update=True, populate_existing=True
+    )
   if event is None:
     raise EventNotFoundError(f"Event not found: {body.event_id}")
 
@@ -667,7 +674,27 @@ def execute_event_block(
 
   from .qb_writeback import QBWritebackError, post_event_to_qb
 
-  event = session.query(Event).filter(Event.id == body.event_id).first()
+  # Locked, and for a sharper reason than the other paths: between this read
+  # and the status write below sits a POST to QuickBooks. A concurrent void or
+  # supersede would otherwise be clobbered by the `fulfilled`/`pending` stamp
+  # *after* the external write already happened — QB's request_id dedup covers
+  # a repeated post, not an event that was voided and published anyway.
+  #
+  # `populate_existing` is load-bearing, not belt-and-braces: close_service's
+  # QB pre-publish loop calls this on a **shared** session that already loaded
+  # these events, so without it the lock would be taken while `event.status`
+  # kept the value it held before blocking.
+  with bounded_lock_wait(
+    session,
+    f"Event {body.event_id} is being written by another process. Retry in a moment.",
+  ):
+    event = (
+      session.query(Event)
+      .filter(Event.id == body.event_id)
+      .populate_existing()
+      .with_for_update()
+      .first()
+    )
   if event is None:
     raise EventNotFoundError(f"Event {body.event_id} not found")
 

--- a/robosystems/operations/event_block/commands.py
+++ b/robosystems/operations/event_block/commands.py
@@ -18,8 +18,6 @@ from __future__ import annotations
 from datetime import UTC, datetime
 
 from pydantic import ValidationError
-from sqlalchemy import text
-from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import Session
 
 from robosystems.logger import logger
@@ -45,6 +43,7 @@ from robosystems.operations.roboledger.reads.event_block import (
 )
 
 from .engine import EngineValidationError, apply_handler
+from .locking import bounded_lock_wait
 from .python_handlers import get_python_handler
 from .python_handlers.types import HandlerMetadataValidationError
 from .registry import (
@@ -58,14 +57,6 @@ from .template import (
   interpolate,
 )
 
-# How long an approval waits for a conflicting writer before giving up. Long
-# enough to absorb another approval or a short write — those resolve in
-# milliseconds — and short enough that a multi-minute sync returns an error
-# instead of holding the connection. Postgres raises SQLSTATE 55P03 on expiry,
-# the same code `NOWAIT` raises, so one handler covers both if we ever switch.
-_LOCK_TIMEOUT_MS = 3000
-_LOCK_NOT_AVAILABLE = "55P03"
-
 
 class EventNotFoundError(Exception):
   pass
@@ -73,17 +64,6 @@ class EventNotFoundError(Exception):
 
 class InvalidEventTransitionError(Exception):
   pass
-
-
-class EventLockedError(Exception):
-  """Raised when the event row is held by a concurrent writer.
-
-  In practice that writer is a running sync: `_capture_transactions_as_events`
-  locks its whole batch for the life of the sync transaction, which can be
-  minutes. Waiting it out would pin an HTTP request and its pooled connection
-  for that whole time, and enough concurrent approvals would exhaust the
-  extensions pool. Failing fast with a retryable error is the better trade.
-  """
 
 
 class DuplicateEventError(Exception):
@@ -396,18 +376,14 @@ def update_event_block(
   # row once the lock releases, sees the new status, and raises
   # InvalidEventTransitionError as it should.
   #
-  # Bounded, because the conflicting writer is usually a sync that runs for
-  # minutes — see EventLockedError. `SET LOCAL` reverts at transaction end.
-  session.execute(text(f"SET LOCAL lock_timeout = '{_LOCK_TIMEOUT_MS}ms'"))
-  try:
+  # Bounded, because the conflicting writer is usually a sync or a promotion
+  # sweep that runs long — see `locking.bounded_lock_wait`.
+  with bounded_lock_wait(
+    session,
+    f"Event {body.event_id} is being written by another process "
+    "(most likely a running sync). Retry in a moment.",
+  ):
     event = session.get(Event, body.event_id, with_for_update=True)
-  except OperationalError as exc:
-    if getattr(exc.orig, "pgcode", None) == _LOCK_NOT_AVAILABLE:
-      raise EventLockedError(
-        f"Event {body.event_id} is being written by another process "
-        "(most likely a running sync). Retry in a moment."
-      ) from exc
-    raise
   if event is None:
     raise EventNotFoundError(f"Event not found: {body.event_id}")
 

--- a/robosystems/operations/event_block/commands.py
+++ b/robosystems/operations/event_block/commands.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 from datetime import UTC, datetime
 
 from pydantic import ValidationError
+from sqlalchemy import text
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import Session
 
 from robosystems.logger import logger
@@ -56,6 +58,14 @@ from .template import (
   interpolate,
 )
 
+# How long an approval waits for a conflicting writer before giving up. Long
+# enough to absorb another approval or a short write — those resolve in
+# milliseconds — and short enough that a multi-minute sync returns an error
+# instead of holding the connection. Postgres raises SQLSTATE 55P03 on expiry,
+# the same code `NOWAIT` raises, so one handler covers both if we ever switch.
+_LOCK_TIMEOUT_MS = 3000
+_LOCK_NOT_AVAILABLE = "55P03"
+
 
 class EventNotFoundError(Exception):
   pass
@@ -63,6 +73,17 @@ class EventNotFoundError(Exception):
 
 class InvalidEventTransitionError(Exception):
   pass
+
+
+class EventLockedError(Exception):
+  """Raised when the event row is held by a concurrent writer.
+
+  In practice that writer is a running sync: `_capture_transactions_as_events`
+  locks its whole batch for the life of the sync transaction, which can be
+  minutes. Waiting it out would pin an HTTP request and its pooled connection
+  for that whole time, and enough concurrent approvals would exhaust the
+  extensions pool. Failing fast with a retryable error is the better trade.
+  """
 
 
 class DuplicateEventError(Exception):
@@ -368,12 +389,25 @@ def update_event_block(
   # Lock the row for the life of the transaction. The transition check below
   # is read-decide-write, and the decision is only sound if nothing else can
   # move the event in between. The live race is an inbox approval against the
-  # sync's auto-commit pass (`extensions/loader.py`): both read `captured`,
-  # both fire the handler, and the event ends up with two sets of GL rows —
-  # a ledger that still foots and is still wrong. Under READ COMMITTED the
-  # blocked reader re-reads the committed row once the lock releases, sees
-  # the new status, and raises InvalidEventTransitionError as it should.
-  event = session.get(Event, body.event_id, with_for_update=True)
+  # sync's auto-commit pass (`extensions/loader.py`, which locks its batch for
+  # the same reason): both read `captured`, both fire the handler, and the
+  # event ends up with two sets of GL rows — a ledger that still foots and is
+  # still wrong. Under READ COMMITTED the blocked reader re-reads the committed
+  # row once the lock releases, sees the new status, and raises
+  # InvalidEventTransitionError as it should.
+  #
+  # Bounded, because the conflicting writer is usually a sync that runs for
+  # minutes — see EventLockedError. `SET LOCAL` reverts at transaction end.
+  session.execute(text(f"SET LOCAL lock_timeout = '{_LOCK_TIMEOUT_MS}ms'"))
+  try:
+    event = session.get(Event, body.event_id, with_for_update=True)
+  except OperationalError as exc:
+    if getattr(exc.orig, "pgcode", None) == _LOCK_NOT_AVAILABLE:
+      raise EventLockedError(
+        f"Event {body.event_id} is being written by another process "
+        "(most likely a running sync). Retry in a moment."
+      ) from exc
+    raise
   if event is None:
     raise EventNotFoundError(f"Event not found: {body.event_id}")
 

--- a/robosystems/operations/event_block/locking.py
+++ b/robosystems/operations/event_block/locking.py
@@ -1,0 +1,65 @@
+"""Row-lock policy for event writes.
+
+Every path that decides an event's next status does so read-decide-write, and
+the decision is only sound if nothing else can move the row in between. Two
+writers that both read `captured` both fire the handler, and the event ends up
+with two sets of GL rows — a ledger that still foots and is still wrong.
+
+So the reads that feed those decisions take `FOR UPDATE`. This module holds the
+half of that policy which is about *waiting*: how long a request-facing caller
+waits for a conflicting writer before giving up, and what the failure is called.
+
+The split that matters: **background jobs wait, request handlers do not.** A
+sync or a Dagster sweep should block behind a conflicting approval rather than
+fail its batch, so it takes the lock unbounded. An HTTP request that waits out a
+multi-minute sync pins a pooled connection for that whole time, and enough of
+them exhaust the extensions pool — so request-facing callers wrap their locking
+work in `bounded_lock_wait`.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+from sqlalchemy import text
+from sqlalchemy.exc import OperationalError
+from sqlalchemy.orm import Session
+
+# How long a request-facing caller waits for a conflicting writer before giving
+# up. Long enough to absorb another approval or a short write — those resolve in
+# milliseconds, and failing them would be a spurious error — and short enough
+# that a multi-minute sync returns an answer instead of holding the connection.
+# Postgres raises SQLSTATE 55P03 on expiry, the same code `NOWAIT` raises, so
+# this handler covers both if the zero-wait variant is ever wanted.
+_LOCK_TIMEOUT_MS = 3000
+_LOCK_NOT_AVAILABLE = "55P03"
+
+
+class EventLockedError(Exception):
+  """Raised when event rows needed by this operation are held by another writer.
+
+  In practice that writer is a running sync or the obligation-promotion sweep,
+  both of which lock their whole batch for the life of their transaction.
+  Retryable — it is the one error on these operations the caller should try
+  again rather than fix.
+  """
+
+
+@contextmanager
+def bounded_lock_wait(session: Session, detail: str):
+  """Bound this transaction's wait for a row lock and give the failure a name.
+
+  `SET LOCAL` reverts at transaction end, so the bound applies to this
+  operation only. Only 55P03 is translated: a connection fault keeps its own
+  identity rather than reaching the caller as "retry in a moment".
+  """
+  session.execute(text(f"SET LOCAL lock_timeout = '{_LOCK_TIMEOUT_MS}ms'"))
+  try:
+    yield
+  except OperationalError as exc:
+    if getattr(exc.orig, "pgcode", None) == _LOCK_NOT_AVAILABLE:
+      raise EventLockedError(detail) from exc
+    raise
+
+
+__all__ = ["EventLockedError", "bounded_lock_wait"]

--- a/robosystems/operations/event_block/promotion.py
+++ b/robosystems/operations/event_block/promotion.py
@@ -314,6 +314,10 @@ def promote_pending_obligations(
       session.query(Event).filter(
         Event.id.in_(candidate_ids), Event.status == "pending"
       ).update({"status": "classified"}, synchronize_session="fetch")
+      # Accurate because the candidate read is locked: the UPDATE's guard
+      # cannot filter any of these out, so every id did in fact flip. If that
+      # read ever loses its lock, this list has to come from the statement's
+      # rowcount instead of being assumed.
       result.classified_event_ids.extend(candidate_ids)
     logger.info(
       "promote_pending_obligations[%s]: classified=%s stranded=%s (co-pilot mode)",

--- a/robosystems/operations/event_block/promotion.py
+++ b/robosystems/operations/event_block/promotion.py
@@ -220,6 +220,13 @@ def promote_pending_obligations(
   row can't poison the sweep: those events stay at ``classified`` (the flip
   already happened) and surface in ``result.errors``.
   """
+  # Locked: everything below is read-decide-write against these rows — the
+  # co-pilot flip, the orphan void, and the autopilot dispatch all act on the
+  # status this read observed. The sensor runs every few minutes on every
+  # graph, so it races an on-demand `promote-obligations`, an inbox approval,
+  # and (if a tick overruns) its own successor. See `locking` for the
+  # bounded-vs-unbounded split: this function is called from both a Dagster
+  # sweep and a request handler, and it is the *caller* that bounds the wait.
   candidates = (
     session.query(Event)
     .filter(
@@ -227,6 +234,7 @@ def promote_pending_obligations(
       Event.status.in_(("pending", "classified")),
       Event.occurred_at <= as_of,
     )
+    .with_for_update()
     .all()
   )
   pending = [evt for evt in candidates if evt.status == "pending"]
@@ -297,9 +305,15 @@ def promote_pending_obligations(
     # them; they ride out on result.stranded_event_ids instead.
     if pending:
       candidate_ids = [evt.id for evt in pending]
-      session.query(Event).filter(Event.id.in_(candidate_ids)).update(
-        {"status": "classified"}, synchronize_session="fetch"
-      )
+      # The status predicate is not redundant with the lock above — it is the
+      # invariant stated where it is relied on. Without it this UPDATE would
+      # write `classified` over whatever the row now holds, so a concurrently
+      # voided or committed obligation would be silently reverted to an earlier
+      # state. That is a lost update, not just a redundant one, and it is the
+      # same guard the orphan void a few lines up already carries.
+      session.query(Event).filter(
+        Event.id.in_(candidate_ids), Event.status == "pending"
+      ).update({"status": "classified"}, synchronize_session="fetch")
       result.classified_event_ids.extend(candidate_ids)
     logger.info(
       "promote_pending_obligations[%s]: classified=%s stranded=%s (co-pilot mode)",

--- a/robosystems/operations/extensions/loader.py
+++ b/robosystems/operations/extensions/loader.py
@@ -1403,7 +1403,24 @@ class OLTPLoader:
     out = _CaptureResult()
     new_events = []
 
-    # 2) Look up existing events for the (source, external_id) pairs
+    # 2) Look up existing events for the (source, external_id) pairs.
+    #
+    # Locked, because the auto-commit pass below dispatches handlers for the
+    # rows this returns. Without the lock an inbox approval (`update_event_block`,
+    # which takes the matching row lock) can commit between this read and that
+    # dispatch, and the handler fires on both sides — one event, two sets of GL
+    # rows, and a ledger that still foots and is still wrong. Most of these rows
+    # get write-locked by the UPSERT below anyway; the gap this closes is the
+    # re-sync whose payload is unchanged, which issues no UPDATE and so would
+    # take no lock.
+    #
+    # Locking here rather than just before dispatch is deliberate: a row lock is
+    # held to transaction end either way, so acquiring it at the top costs one
+    # query instead of one per event, and covers the UPSERT decisions too.
+    #
+    # Deliberately unbounded (no `lock_timeout`): a sync is a background job and
+    # should wait for a conflicting approval rather than fail the batch. The
+    # approval side is the one that bounds its wait.
     existing: dict[str, Event] = {
       e.external_id: e
       for e in session.query(Event)
@@ -1411,6 +1428,7 @@ class OLTPLoader:
         Event.source == source,
         Event.external_id.in_(list(txns_by_ext.keys())),
       )
+      .with_for_update()
       .all()
     }
 

--- a/robosystems/operations/roboledger/commands/schedules.py
+++ b/robosystems/operations/roboledger/commands/schedules.py
@@ -272,9 +272,13 @@ def promote_obligations(
   # set, and the Dagster sensor runs the same function every few minutes. An
   # unbounded wait here would hold this request and its pooled connection until
   # a background tick finished.
+  # The wrap covers the whole sweep, not just its locked candidate load — the
+  # lock is taken inside. Autopilot dispatch also writes GL rows, so a wait
+  # here is *usually* the background sweep holding the obligations but need not
+  # be; the message says what is true rather than naming a cause it cannot know.
   with bounded_lock_wait(
     session,
-    "Obligations are being promoted by another process (the background sweep). "
+    "Obligations for this graph are being written by another process. "
     "Retry in a moment.",
   ):
     result = promote_pending_obligations(

--- a/robosystems/operations/roboledger/commands/schedules.py
+++ b/robosystems/operations/roboledger/commands/schedules.py
@@ -390,11 +390,23 @@ def update_schedule(
   # impossible: either the new template + new pending events both land,
   # or neither does.
   if template_changed:
-    ScheduleService().supersede_pending_obligations(
-      session,
-      structure=structure,
-      created_by=updated_by,
+    from robosystems.operations.event_block.locking import (
+      bounded_lock_wait as _bounded_lock_wait,
     )
+
+    # Request-facing, and it contends with the promotion sweep over the same
+    # pending obligations — bound the wait rather than hold this request for
+    # the length of a background tick.
+    with _bounded_lock_wait(
+      session,
+      "This schedule's pending obligations are being written by another "
+      "process. Retry in a moment.",
+    ):
+      ScheduleService().supersede_pending_obligations(
+        session,
+        structure=structure,
+        created_by=updated_by,
+      )
 
   # Re-run rule engine when the template changes, since the underlying
   # fact shape may have moved. No-op when the template was unchanged

--- a/robosystems/operations/roboledger/commands/schedules.py
+++ b/robosystems/operations/roboledger/commands/schedules.py
@@ -265,15 +265,25 @@ def promote_obligations(
   sweep is idempotent (re-running skips already-classified rows and
   reconciles to existing drafts).
   """
+  from robosystems.operations.event_block.locking import bounded_lock_wait
   from robosystems.operations.event_block.promotion import promote_pending_obligations
 
-  result = promote_pending_obligations(
+  # Request-facing, so the wait is bounded: the sweep locks its whole candidate
+  # set, and the Dagster sensor runs the same function every few minutes. An
+  # unbounded wait here would hold this request and its pooled connection until
+  # a background tick finished.
+  with bounded_lock_wait(
     session,
-    graph_id="(on-demand)",  # logging-only; data scope is the session search_path
-    as_of=datetime.now(UTC),
-    dispatch_handlers=body.dispatch_handlers,
-    created_by=created_by,
-  )
+    "Obligations are being promoted by another process (the background sweep). "
+    "Retry in a moment.",
+  ):
+    result = promote_pending_obligations(
+      session,
+      graph_id="(on-demand)",  # logging-only; data scope is the session search_path
+      as_of=datetime.now(UTC),
+      dispatch_handlers=body.dispatch_handlers,
+      created_by=created_by,
+    )
   session.commit()
   return PromoteObligationsResponse(
     classified_count=result.classified_count,

--- a/robosystems/operations/roboledger/schedules/service.py
+++ b/robosystems/operations/roboledger/schedules/service.py
@@ -928,12 +928,20 @@ class ScheduleService:
     if not schedule_created_event_id:
       return 0
 
+    # Locked: this reads `pending` obligations and voids them, and the
+    # promotion sweep reads the same rows to classify and draft their closing
+    # entries. Unlocked, both can proceed from the same snapshot — the sweep
+    # drafts a GL entry for an obligation this call is voiding, and the
+    # schedule ends up with a closing entry for a period it no longer has an
+    # obligation for. Whichever gets the lock first wins; the other re-reads.
     existing_pending = list(
       session.execute(
-        select(Event).where(
+        select(Event)
+        .where(
           Event.obligated_by_event_id == schedule_created_event_id,
           Event.status == "pending",
         )
+        .with_for_update()
       ).scalars()
     )
     if not existing_pending:

--- a/robosystems/routers/extensions/roboledger/operations.py
+++ b/robosystems/routers/extensions/roboledger/operations.py
@@ -1256,6 +1256,9 @@ update_information_block_op = _registrar.register(
       ValueError: 422,
       NotImplementedError: 501,
       ScheduleNotFoundError: 404,
+      # A schedule template change supersedes its pending obligations, which
+      # the promotion sweep may be holding. Retryable.
+      EventLockedError: 409,
     },
     mark_stale_reason="information_block_updated",
   )

--- a/robosystems/routers/extensions/roboledger/operations.py
+++ b/robosystems/routers/extensions/roboledger/operations.py
@@ -200,6 +200,7 @@ from robosystems.models.api.taxonomy_block import (
 from robosystems.models.core import User
 from robosystems.operations.event_block import (
   DuplicateEventError,
+  EventLockedError,
   EventNotFoundError,
   InvalidEventTransitionError,
 )
@@ -1565,6 +1566,9 @@ update_event_block_op = _registrar.register(
       ElementResolutionError: 422,
       ClosedPeriodError: 422,
       UnbalancedJournalEntryError: 422,
+      # A running sync holds the event's row lock. Retryable, and the only
+      # error here the caller should try again rather than fix.
+      EventLockedError: 409,
     },
     mark_stale_reason="event_block_updated",
   )

--- a/robosystems/routers/extensions/roboledger/operations.py
+++ b/robosystems/routers/extensions/roboledger/operations.py
@@ -1761,7 +1761,9 @@ promote_obligations_op = _registrar.register(
     command=cmd_promote_obligations,
     request_model=PromoteObligationsRequest,
     result_type=PromoteObligationsResponse,
-    error_map={ValueError: 422},
+    # The background sweep holds the candidate set's row locks. Retryable,
+    # same as the approval path's conflict.
+    error_map={ValueError: 422, EventLockedError: 409},
     mark_stale_reason="obligations_promoted",
   )
 )

--- a/robosystems/routers/extensions/roboledger/operations.py
+++ b/robosystems/routers/extensions/roboledger/operations.py
@@ -1608,6 +1608,9 @@ execute_event_block_op = _registrar.register(
       # QBClient itself; 401 signals to the UI that the operator must
       # reconnect via OAuth.
       QBAuthFailedError: 401,
+      # Another writer holds the event's row lock. Retryable, and the publish
+      # deliberately did not reach QuickBooks.
+      EventLockedError: 409,
       ValueError: 422,
     },
     mark_stale_reason="event_published",

--- a/tests/operations/event_block/test_commands_update.py
+++ b/tests/operations/event_block/test_commands_update.py
@@ -52,7 +52,7 @@ def _session_with_events(*events: SimpleNamespace) -> MagicMock:
   """MagicMock session whose .get(Event, id) returns the matching event."""
   by_id = {e.id: e for e in events}
   session = MagicMock()
-  session.get.side_effect = lambda _cls, eid: by_id.get(eid)
+  session.get.side_effect = lambda _cls, eid, **_kwargs: by_id.get(eid)
   # _load_dimension_ids issues a select via session.execute → return [].
   session.execute.return_value.scalars.return_value.all.return_value = []
   return session
@@ -340,3 +340,20 @@ class TestApproveFiresHandler:
     fake_handler.dispatch.assert_not_called()
     # Caller's transaction must roll back — we never reached commit.
     session.commit.assert_not_called()
+
+
+class TestTransitionRowLock:
+  """The status check is read-decide-write, so the row must be locked for
+  the life of the transaction. Without the lock an inbox approval racing
+  the sync's auto-commit pass fires the same handler twice and leaves one
+  event with two sets of GL rows — books that still foot and are wrong."""
+
+  def test_event_is_loaded_for_update(self) -> None:
+    event = _event("evt_a", status="classified")
+    session = _session_with_events(event)
+
+    body = UpdateEventBlockRequest(event_id="evt_a", description="corrected")
+    update_event_block(session, body, created_by="usr_test")
+
+    _args, kwargs = session.get.call_args
+    assert kwargs.get("with_for_update") is True

--- a/tests/operations/event_block/test_commands_update.py
+++ b/tests/operations/event_block/test_commands_update.py
@@ -11,12 +11,12 @@ from sqlalchemy.exc import OperationalError
 
 from robosystems.models.api.event_block import UpdateEventBlockRequest
 from robosystems.operations.event_block.commands import (
-  EventLockedError,
   EventNotFoundError,
   HandlerMetadataValidationError,
   InvalidEventTransitionError,
   update_event_block,
 )
+from robosystems.operations.event_block.locking import EventLockedError
 
 
 def _event(event_id: str, status: str = "classified") -> SimpleNamespace:

--- a/tests/operations/event_block/test_commands_update.py
+++ b/tests/operations/event_block/test_commands_update.py
@@ -7,9 +7,11 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
+from sqlalchemy.exc import OperationalError
 
 from robosystems.models.api.event_block import UpdateEventBlockRequest
 from robosystems.operations.event_block.commands import (
+  EventLockedError,
   EventNotFoundError,
   HandlerMetadataValidationError,
   InvalidEventTransitionError,
@@ -357,3 +359,45 @@ class TestTransitionRowLock:
 
     _args, kwargs = session.get.call_args
     assert kwargs.get("with_for_update") is True
+
+
+class TestLockContention:
+  """The lock is bounded. A sync holds the batch for the life of its
+  transaction (minutes), so an approval that waited would pin an HTTP
+  request and its pooled connection for that whole time — enough of them
+  exhaust the extensions pool. Postgres raises 55P03 when lock_timeout
+  expires; that becomes a retryable 409, not a 500."""
+
+  def test_lock_timeout_is_set_before_the_locking_read(self) -> None:
+    event = _event("evt_a", status="classified")
+    session = _session_with_events(event)
+
+    body = UpdateEventBlockRequest(event_id="evt_a", description="corrected")
+    update_event_block(session, body, created_by="usr_test")
+
+    statements = [str(c.args[0]) for c in session.execute.call_args_list if c.args]
+    assert any("lock_timeout" in s for s in statements)
+
+  def test_lock_not_available_becomes_event_locked_error(self) -> None:
+    session = _session_with_events(_event("evt_a"))
+    session.get.side_effect = OperationalError(
+      "SELECT ...", {}, SimpleNamespace(pgcode="55P03")
+    )
+
+    body = UpdateEventBlockRequest(event_id="evt_a", transition_to="committed")
+    with pytest.raises(EventLockedError, match="evt_a"):
+      update_event_block(session, body, created_by="usr_test")
+
+    session.commit.assert_not_called()
+
+  def test_other_operational_errors_are_not_swallowed(self) -> None:
+    """Only 55P03 is a lock conflict. A connection fault must keep its
+    identity rather than surfacing to the inbox as 'retry in a moment'."""
+    session = _session_with_events(_event("evt_a"))
+    session.get.side_effect = OperationalError(
+      "SELECT ...", {}, SimpleNamespace(pgcode="08006")
+    )
+
+    body = UpdateEventBlockRequest(event_id="evt_a", transition_to="committed")
+    with pytest.raises(OperationalError):
+      update_event_block(session, body, created_by="usr_test")

--- a/tests/operations/event_block/test_execute.py
+++ b/tests/operations/event_block/test_execute.py
@@ -43,9 +43,16 @@ def _make_event(
 
 
 def _make_session(event: MagicMock) -> MagicMock:
-  """Extensions session that returns `event` for any Event.query."""
+  """Extensions session that returns `event` for any Event.query.
+
+  The read is locked and refreshed — `.populate_existing().with_for_update()`
+  — so the chain is stubbed self-returning rather than pinned to a position.
+  """
   session = MagicMock()
-  session.query.return_value.filter.return_value.first.return_value = event
+  filtered = session.query.return_value.filter.return_value
+  filtered.populate_existing.return_value = filtered
+  filtered.with_for_update.return_value = filtered
+  filtered.first.return_value = event
   return session
 
 
@@ -111,8 +118,7 @@ class TestExecuteEventBlockNativeFastPath:
       execute_event_block,
     )
 
-    session = MagicMock()
-    session.query.return_value.filter.return_value.first.return_value = None
+    session = _make_session(None)
 
     with pytest.raises(EventNotFoundError):
       execute_event_block(

--- a/tests/operations/event_block/test_promotion.py
+++ b/tests/operations/event_block/test_promotion.py
@@ -72,6 +72,10 @@ def _session_returning(
     }
   event_query = MagicMock()
   event_query.filter.return_value = event_query
+  # The candidate load takes `FOR UPDATE` — everything the sweep does after it
+  # is read-decide-write against these rows. Self-returning like `.filter` so
+  # the chain stays position-independent.
+  event_query.with_for_update.return_value = event_query
   event_query.all.return_value = events
   entry_query = MagicMock()
   entry_query.filter.return_value = entry_query
@@ -126,6 +130,30 @@ class TestCoPilotMode:
     bulk_update_call.assert_called_once_with(
       {"status": "classified"}, synchronize_session="fetch"
     )
+
+  def test_classify_update_is_guarded_on_pending(self) -> None:
+    """The bulk UPDATE carries `status = 'pending'` alongside the id list.
+
+    Without it the statement writes `classified` over whatever the row now
+    holds, so an obligation voided or committed since the candidate read would
+    be silently reverted — a lost update, not a redundant write.
+
+    The candidate read's `FOR UPDATE` is what makes that race unreachable, so
+    this cannot be provoked end-to-end; it is pinned here instead, at the
+    statement that relies on it, against a refactor that moves the read.
+    """
+    session = _session_returning([_pending_event("evt_1", period_end="2026-01-31")])
+
+    promote_pending_obligations(
+      session, "kg_test", as_of=datetime(2026, 2, 1, tzinfo=UTC)
+    )
+
+    predicates = [
+      str(arg)
+      for call in session.event_query.filter.call_args_list
+      for arg in call.args
+    ]
+    assert any("events.status = " in p for p in predicates), predicates
 
   def test_does_not_call_handler_dispatch(self) -> None:
     e1 = _pending_event("evt_1")

--- a/tests/operations/event_block/test_update_locking_db.py
+++ b/tests/operations/event_block/test_update_locking_db.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import threading
 import time
 from datetime import UTC, datetime
+from unittest.mock import patch
 
 import pytest
 from sqlalchemy import create_engine, text
@@ -28,12 +29,16 @@ from sqlalchemy.exc import OperationalError
 import robosystems.models.extensions  # noqa: F401  (register models on the Base)
 from robosystems.config import env
 from robosystems.db.extensions import ExtensionsBase, extensions_session
-from robosystems.models.api.event_block import UpdateEventBlockRequest
+from robosystems.models.api.event_block import (
+  ExecuteEventBlockRequest,
+  UpdateEventBlockRequest,
+)
 from robosystems.models.api.extensions.schedules import PromoteObligationsRequest
 from robosystems.models.extensions import Structure, Taxonomy
 from robosystems.models.extensions.roboledger.event import Event
 from robosystems.operations.event_block.commands import (
   InvalidEventTransitionError,
+  execute_event_block,
   update_event_block,
 )
 from robosystems.operations.event_block.locking import EventLockedError
@@ -279,9 +284,58 @@ class TestObligationSweepLock:
       assert result.stranded_event_ids == [self.OBLIGATION_ID]
 
       with extensions_session(GRAPH) as request_session:
-        with pytest.raises(EventLockedError, match="background sweep"):
+        with pytest.raises(EventLockedError, match="written by another process"):
           promote_obligations(
             request_session,
             PromoteObligationsRequest(dispatch_handlers=False),
             created_by="usr_operator",
           )
+
+
+class TestPublishLock:
+  """`execute_event_block` posts to QuickBooks between its read and its status
+  write, so a lost update there means an event that was voided got published
+  anyway. QB's `request_id` dedup covers a repeated post; it does not cover
+  that. The lock has to hold *before* the external call."""
+
+  @pytest.fixture(autouse=True)
+  def committed_event(self, tenant):
+    with extensions_session(GRAPH) as session:
+      session.execute(text("DELETE FROM events"))
+      session.add(
+        Event(
+          id=EVENT_ID,
+          event_type="journal_entry_recorded",
+          event_category="adjustment",
+          event_class="economic",
+          status="committed",
+          occurred_at=datetime(2026, 3, 1, tzinfo=UTC),
+          source=SOURCE,
+          external_id=EXTERNAL_ID,
+          currency="USD",
+          metadata_={"connection_id": "conn_qb_1"},
+          created_by="usr_seed",
+        )
+      )
+    yield
+
+  def test_a_locked_event_is_never_published(self, tenant):
+    with extensions_session(GRAPH) as holder:
+      holder.execute(
+        text("SELECT id FROM events WHERE id = :id FOR UPDATE"), {"id": EVENT_ID}
+      )
+
+      with extensions_session(GRAPH) as publish_session:
+        with patch(
+          "robosystems.operations.event_block.qb_writeback.post_event_to_qb"
+        ) as post:
+          with pytest.raises(EventLockedError, match=EVENT_ID):
+            execute_event_block(
+              publish_session,
+              ExecuteEventBlockRequest(event_id=EVENT_ID),
+              created_by="usr_operator",
+            )
+      post.assert_not_called()
+
+    with extensions_session(GRAPH) as check:
+      assert check.get(Event, EVENT_ID).status == "committed"

--- a/tests/operations/event_block/test_update_locking_db.py
+++ b/tests/operations/event_block/test_update_locking_db.py
@@ -29,12 +29,16 @@ import robosystems.models.extensions  # noqa: F401  (register models on the Base
 from robosystems.config import env
 from robosystems.db.extensions import ExtensionsBase, extensions_session
 from robosystems.models.api.event_block import UpdateEventBlockRequest
+from robosystems.models.api.extensions.schedules import PromoteObligationsRequest
+from robosystems.models.extensions import Structure, Taxonomy
 from robosystems.models.extensions.roboledger.event import Event
 from robosystems.operations.event_block.commands import (
-  EventLockedError,
   InvalidEventTransitionError,
   update_event_block,
 )
+from robosystems.operations.event_block.locking import EventLockedError
+from robosystems.operations.event_block.promotion import promote_pending_obligations
+from robosystems.operations.roboledger.commands.schedules import promote_obligations
 
 pytestmark = pytest.mark.integration
 
@@ -194,3 +198,90 @@ def test_approval_that_waits_out_a_lock_sees_the_committed_row(tenant):
 
   assert not failure, f"winner thread failed: {failure[0]!r}"
   assert hold_released.is_set()
+
+
+class TestObligationSweepLock:
+  """The promotion sweep is the same read-decide-write shape as an approval,
+  and it runs on a Dagster sensor every few minutes on every graph — so it
+  races the on-demand op, an inbox approval, and its own next tick. Its
+  candidate load takes the lock; the request-facing caller bounds the wait.
+
+  The obligation here is **classified and stranded**, not pending, and that is
+  load-bearing: a pending obligation would be flipped by the co-pilot bulk
+  UPDATE, whose own row lock would block a second caller whether or not the
+  read is locked — so the test would pass with the fix removed. A stranded
+  classified obligation makes the sweep write *nothing*, leaving the read's
+  `FOR UPDATE` as the only thing that can block.
+  """
+
+  OBLIGATION_ID = "evt_oblig_0001"
+  SCHEDULE_ID = "struct_sched_0001"
+  TAXONOMY_ID = "tax_sched_0001"
+
+  @pytest.fixture(autouse=True)
+  def stranded_obligation(self, tenant):
+    with extensions_session(GRAPH) as session:
+      session.execute(text("DELETE FROM events"))
+      session.execute(text("DELETE FROM structures"))
+      session.execute(text("DELETE FROM taxonomies"))
+      session.add(
+        Taxonomy(
+          id=self.TAXONOMY_ID,
+          name="Schedules",
+          taxonomy_type="schedule",
+          created_by="usr_seed",
+        )
+      )
+      session.flush()
+      # The schedule must exist, or the orphan guard voids the obligation —
+      # a write, which would reintroduce the lock the test is trying to isolate.
+      session.add(
+        Structure(
+          id=self.SCHEDULE_ID,
+          taxonomy_id=self.TAXONOMY_ID,
+          name="Depreciation",
+          block_type="schedule",
+          created_by="usr_seed",
+        )
+      )
+      session.add(
+        Event(
+          id=self.OBLIGATION_ID,
+          event_type="schedule_entry_due",
+          event_category="adjustment",
+          event_class="economic",
+          status="classified",
+          occurred_at=datetime(2026, 1, 31, tzinfo=UTC),
+          source="schedule",
+          currency="USD",
+          metadata_={
+            "schedule_id": self.SCHEDULE_ID,
+            "period_start": "2026-01-01",
+            "period_end": "2026-01-31",
+          },
+          created_by="usr_seed",
+        )
+      )
+    yield
+
+  def test_sweep_lock_blocks_the_on_demand_promotion(self, tenant):
+    with extensions_session(GRAPH) as sensor_session:
+      result = promote_pending_obligations(
+        sensor_session,
+        graph_id="(sensor)",
+        as_of=datetime(2026, 2, 1, tzinfo=UTC),
+        dispatch_handlers=False,
+      )
+      # Nothing was written — no flip, no orphan void. Any blocking below is
+      # the candidate read's lock and nothing else.
+      assert result.classified_event_ids == []
+      assert result.voided_orphan_event_ids == []
+      assert result.stranded_event_ids == [self.OBLIGATION_ID]
+
+      with extensions_session(GRAPH) as request_session:
+        with pytest.raises(EventLockedError, match="background sweep"):
+          promote_obligations(
+            request_session,
+            PromoteObligationsRequest(dispatch_handlers=False),
+            created_by="usr_operator",
+          )

--- a/tests/operations/event_block/test_update_locking_db.py
+++ b/tests/operations/event_block/test_update_locking_db.py
@@ -1,0 +1,196 @@
+"""DB-backed proof of the event row lock.
+
+The MagicMock tests in ``test_commands_update.py`` prove the keyword is passed
+and that 55P03 maps to a typed error. They cannot prove the thing that matters:
+that the lock is real, that the sync's batch lookup actually blocks an approval,
+and that an approval which waits behind a lock re-reads the *committed* row
+rather than acting on the snapshot it took before blocking.
+
+Without that, an inbox approval landing during a sync fires the same handler the
+sync is about to fire — one event, two sets of GL rows, and a ledger that still
+foots and is still wrong.
+
+Runs against the real extensions database (``EXTENSIONS_DATABASE_URL``) with a
+throwaway tenant schema built from the model metadata, the same mechanism
+``create_tenant_schema`` uses.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.exc import OperationalError
+
+import robosystems.models.extensions  # noqa: F401  (register models on the Base)
+from robosystems.config import env
+from robosystems.db.extensions import ExtensionsBase, extensions_session
+from robosystems.models.api.event_block import UpdateEventBlockRequest
+from robosystems.models.extensions.roboledger.event import Event
+from robosystems.operations.event_block.commands import (
+  EventLockedError,
+  InvalidEventTransitionError,
+  update_event_block,
+)
+
+pytestmark = pytest.mark.integration
+
+GRAPH = "kgcccccccccccccccc03"
+EVENT_ID = "evt_lock_0001"
+EXTERNAL_ID = "QB_TXN_1"
+SOURCE = "quickbooks"
+
+
+def _tenant_tables():
+  return [t for t in ExtensionsBase.metadata.sorted_tables if t.schema is None]
+
+
+@pytest.fixture(scope="module")
+def tenant():
+  """A real tenant schema, dropped on the way out.
+
+  ``EXTENSIONS_DATABASE_URL`` always resolves to *something* — it falls back to
+  a localhost default — so its presence proves nothing. Connect before deciding:
+  a developer without the extensions database gets a skip, not a fixture error.
+  """
+  url = env.EXTENSIONS_DATABASE_URL
+  if not url:
+    pytest.skip("EXTENSIONS_DATABASE_URL not configured")
+
+  engine = create_engine(url)
+  try:
+    with engine.connect() as probe:
+      probe.execute(text("SELECT 1"))
+  except OperationalError as exc:
+    engine.dispose()
+    pytest.skip(f"extensions database unreachable: {exc.orig}")
+
+  try:
+    with engine.begin() as conn:
+      conn.execute(text(f"DROP SCHEMA IF EXISTS {GRAPH} CASCADE"))
+      conn.execute(text(f"CREATE SCHEMA {GRAPH}"))
+      ExtensionsBase.metadata.create_all(
+        bind=conn.execution_options(schema_translate_map={None: GRAPH}),
+        tables=_tenant_tables(),
+      )
+    yield
+  finally:
+    with engine.begin() as conn:
+      conn.execute(text(f"DROP SCHEMA IF EXISTS {GRAPH} CASCADE"))
+    engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def captured_event(tenant):
+  """One captured event, reset between cases."""
+  with extensions_session(GRAPH) as session:
+    session.execute(text("DELETE FROM events"))
+    session.add(
+      Event(
+        id=EVENT_ID,
+        # A support-class type with no registered Python handler, so
+        # `fire_handler_on_commit` is a no-op. That keeps the assertions about
+        # the *lock* — without it, an approval that slips through would fail
+        # later on handler metadata and mask which guard actually held.
+        event_type="control_check_performed",
+        event_category="control",
+        event_class="support",
+        status="captured",
+        occurred_at=datetime(2026, 3, 1, tzinfo=UTC),
+        source=SOURCE,
+        external_id=EXTERNAL_ID,
+        currency="USD",
+        metadata_={},
+        created_by="usr_seed",
+      )
+    )
+  yield
+
+
+def _loader_batch_lookup(session):
+  """The sync's existing-events lookup, verbatim in shape.
+
+  Mirrors ``_capture_transactions_as_events`` (`extensions/loader.py`) — if that
+  query loses ``.with_for_update()``, this test stops blocking and fails.
+  """
+  return (
+    session.query(Event)
+    .filter(Event.source == SOURCE, Event.external_id.in_([EXTERNAL_ID]))
+    .with_for_update()
+    .all()
+  )
+
+
+def test_sync_batch_lock_blocks_an_approval(tenant):
+  """The P1 race: the loader locks its batch, so an approval cannot slip in
+  between that read and the handler dispatch that follows it. It gets a
+  retryable error instead of dispatching a second time."""
+  with extensions_session(GRAPH) as sync_session:
+    locked = _loader_batch_lookup(sync_session)
+    assert [e.id for e in locked] == [EVENT_ID]
+
+    # Sync has not committed — the lock is held. An approval arriving now
+    # must not proceed to fire the handler.
+    started = time.monotonic()
+    with extensions_session(GRAPH) as approval_session:
+      with pytest.raises(EventLockedError, match=EVENT_ID):
+        update_event_block(
+          approval_session,
+          UpdateEventBlockRequest(event_id=EVENT_ID, transition_to="committed"),
+          created_by="usr_approver",
+        )
+    waited = time.monotonic() - started
+
+  # It failed by timing out on the lock, not by some unrelated fast path.
+  assert waited >= 2.5, f"returned in {waited:.2f}s — did it actually block?"
+
+  with extensions_session(GRAPH) as check:
+    assert check.get(Event, EVENT_ID).status == "captured"
+
+
+def test_approval_that_waits_out_a_lock_sees_the_committed_row(tenant):
+  """The lock is only worth taking if the blocked reader re-reads. Under READ
+  COMMITTED a blocked ``SELECT ... FOR UPDATE`` returns the row as the winner
+  left it, so the loser's transition check runs against current state and
+  correctly rejects — rather than acting on the snapshot it took before it
+  blocked. (A fresh session matters: ``Session.get`` would otherwise serve an
+  identity-map hit and never re-read.)"""
+  hold_released = threading.Event()
+  failure: list[BaseException] = []
+
+  def winner():
+    try:
+      with extensions_session(GRAPH) as session:
+        session.execute(
+          text("SELECT id FROM events WHERE id = :id FOR UPDATE"), {"id": EVENT_ID}
+        )
+        time.sleep(1.0)
+        session.execute(
+          text("UPDATE events SET status = 'voided' WHERE id = :id"), {"id": EVENT_ID}
+        )
+      hold_released.set()
+    except BaseException as exc:  # surfaced in the main thread below
+      failure.append(exc)
+      hold_released.set()
+
+  t = threading.Thread(target=winner)
+  t.start()
+  try:
+    time.sleep(0.2)  # let the winner take the lock first
+    with extensions_session(GRAPH) as approval_session:
+      # Blocks ~0.8s, well inside the 3s lock_timeout, then re-reads 'voided'
+      # — a terminal state with no outbound transitions.
+      with pytest.raises(InvalidEventTransitionError, match="terminal"):
+        update_event_block(
+          approval_session,
+          UpdateEventBlockRequest(event_id=EVENT_ID, transition_to="voided"),
+          created_by="usr_approver",
+        )
+  finally:
+    t.join(timeout=10)
+
+  assert not failure, f"winner thread failed: {failure[0]!r}"
+  assert hold_released.is_set()

--- a/tests/operations/extensions/test_loader.py
+++ b/tests/operations/extensions/test_loader.py
@@ -8,13 +8,15 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 
-def _stub_event_lookup(session, rows):
-  """Stub the loader's existing-events lookup on a MagicMock session.
+def _stub_existing_lookup(session, rows):
+  """Stub a `query(...).filter(...)[.with_for_update()].all()` load on a mock session.
 
-  The lookup is ``session.query(Event).filter(...).with_for_update().all()`` —
-  it takes a row lock so a concurrent inbox approval cannot commit between that
-  read and the handler dispatch below it. Both the locked and unlocked chains
-  are stubbed so a test can never accidentally assert against the wrong one.
+  Named for its main subject, the loader's existing-**events** lookup, which
+  takes a row lock so a concurrent inbox approval cannot commit between that
+  read and the handler dispatch below it — but the `MagicMock` chain is not
+  type-differentiated, so the same helper serves the Element and Agent loads
+  in this file. Both the locked and unlocked chains are stubbed, so a test can
+  never accidentally assert against whichever one production stopped using.
   """
   filtered = session.query.return_value.filter.return_value
   filtered.all.return_value = rows
@@ -403,7 +405,7 @@ class TestOLTPLoader:
     mock_duckdb_connect.return_value = _make_duckdb_mock({"line_items": orphan_lines})
 
     mock_session = MagicMock()
-    _stub_event_lookup(mock_session, [])
+    _stub_existing_lookup(mock_session, [])
     mock_ext_session.return_value.__enter__ = MagicMock(return_value=mock_session)
     mock_ext_session.return_value.__exit__ = MagicMock(return_value=False)
 
@@ -503,7 +505,7 @@ class TestCaptureTransactionsAsEvents:
     from robosystems.operations.extensions.loader import OLTPLoader
 
     session = MagicMock()
-    _stub_event_lookup(session, [])
+    _stub_existing_lookup(session, [])
 
     loader = OLTPLoader()
     _capture_result = loader._capture_transactions_as_events(
@@ -544,7 +546,7 @@ class TestCaptureTransactionsAsEvents:
     existing_event.id = "evt_existing"
 
     session = MagicMock()
-    _stub_event_lookup(session, [existing_event])
+    _stub_existing_lookup(session, [existing_event])
 
     loader = OLTPLoader()
     _capture_result = loader._capture_transactions_as_events(
@@ -591,7 +593,7 @@ class TestCaptureTransactionsAsEvents:
     committed_event.payload_drift = False
 
     session = MagicMock()
-    _stub_event_lookup(session, [committed_event])
+    _stub_existing_lookup(session, [committed_event])
 
     loader = OLTPLoader()
     _capture_result = loader._capture_transactions_as_events(
@@ -660,7 +662,7 @@ class TestCaptureTransactionsAsEvents:
     }
 
     session = MagicMock()
-    _stub_event_lookup(session, [])
+    _stub_existing_lookup(session, [])
 
     loader = OLTPLoader()
     _capture_result = loader._capture_transactions_as_events(
@@ -736,7 +738,7 @@ class TestCaptureAutoCommit:
     from robosystems.operations.extensions.loader import OLTPLoader
 
     session = MagicMock()
-    _stub_event_lookup(session, [])
+    _stub_existing_lookup(session, [])
 
     loader = OLTPLoader()
 
@@ -769,7 +771,7 @@ class TestCaptureAutoCommit:
     from robosystems.operations.extensions.loader import OLTPLoader
 
     session = MagicMock()
-    _stub_event_lookup(session, [])
+    _stub_existing_lookup(session, [])
 
     def fire_sets_fulfilled(_session, evt, _created_by):
       # Mimics the journal_entry_recorded handler when metadata.status='posted'.
@@ -804,7 +806,7 @@ class TestCaptureAutoCommit:
     from robosystems.operations.extensions.loader import OLTPLoader
 
     session = MagicMock()
-    _stub_event_lookup(session, [])
+    _stub_existing_lookup(session, [])
 
     loader = OLTPLoader()
 
@@ -868,7 +870,7 @@ class TestCaptureAutoCommit:
     prior_event.metadata_ = {"dispatch_attempts": 1, "dispatch_error": "unknown_error"}
 
     session = MagicMock()
-    _stub_event_lookup(session, [prior_event])
+    _stub_existing_lookup(session, [prior_event])
 
     loader = OLTPLoader()
     with patch(
@@ -895,7 +897,7 @@ class TestCaptureAutoCommit:
     from robosystems.operations.extensions.loader import OLTPLoader
 
     session = MagicMock()
-    _stub_event_lookup(session, [])
+    _stub_existing_lookup(session, [])
 
     loader = OLTPLoader()
     dbt = self._dbt_data()
@@ -938,7 +940,7 @@ class TestCaptureAutoCommit:
     existing_event.external_id = "JE_100"
     existing_event.status = "captured"
     existing_event.event_type = "journal_entry_recorded"
-    _stub_event_lookup(session, [existing_event])
+    _stub_existing_lookup(session, [existing_event])
 
     loader = OLTPLoader()
 
@@ -1378,7 +1380,7 @@ class TestCaptureHardening:
     from robosystems.operations.extensions.loader import OLTPLoader
 
     session = MagicMock()
-    _stub_event_lookup(session, [])
+    _stub_existing_lookup(session, [])
     loader = OLTPLoader()
     cap = loader._capture_transactions_as_events(
       session,
@@ -1533,7 +1535,7 @@ class TestCaptureAgentsFromQB:
     from robosystems.operations.extensions.loader import OLTPLoader
 
     session = MagicMock()
-    _stub_event_lookup(session, [])
+    _stub_existing_lookup(session, [])
 
     loader = OLTPLoader()
     out = loader._capture_agents_from_qb(
@@ -1561,7 +1563,7 @@ class TestCaptureAgentsFromQB:
     existing.id = "agt_existing"
 
     session = MagicMock()
-    _stub_event_lookup(session, [existing])
+    _stub_existing_lookup(session, [existing])
 
     loader = OLTPLoader()
     dbt = {
@@ -1623,7 +1625,7 @@ class TestCaptureAgentsFromQB:
     from robosystems.operations.extensions.loader import OLTPLoader
 
     session = MagicMock()
-    _stub_event_lookup(session, [])
+    _stub_existing_lookup(session, [])
 
     loader = OLTPLoader()
     loader._capture_agents_from_qb(
@@ -1645,7 +1647,7 @@ class TestCaptureAgentsFromQB:
     from robosystems.operations.extensions.loader import OLTPLoader
 
     session = MagicMock()
-    _stub_event_lookup(session, [])
+    _stub_existing_lookup(session, [])
 
     dbt = {
       "agents": [
@@ -1689,7 +1691,7 @@ class TestCaptureAgentsFromQB:
     existing.metadata_ = {"qb_sync_token": "5", "custom_field": "preserved"}
 
     session = MagicMock()
-    _stub_event_lookup(session, [existing])
+    _stub_existing_lookup(session, [existing])
 
     dbt = {
       "agents": [
@@ -1733,7 +1735,7 @@ class TestCaptureAgentsFromQB:
     existing.metadata_ = {"qb_sync_token": "5"}
 
     session = MagicMock()
-    _stub_event_lookup(session, [existing])
+    _stub_existing_lookup(session, [existing])
 
     dbt = {
       "agents": [
@@ -1831,7 +1833,7 @@ class TestCaptureWithEventTypeAndAgent:
     from robosystems.operations.extensions.loader import OLTPLoader
 
     session = MagicMock()
-    _stub_event_lookup(session, [])
+    _stub_existing_lookup(session, [])
 
     loader = OLTPLoader()
     loader._capture_transactions_as_events(
@@ -1857,7 +1859,7 @@ class TestCaptureWithEventTypeAndAgent:
     from robosystems.operations.extensions.loader import OLTPLoader
 
     session = MagicMock()
-    _stub_event_lookup(session, [])
+    _stub_existing_lookup(session, [])
 
     loader = OLTPLoader()
     loader._capture_transactions_as_events(
@@ -1887,7 +1889,7 @@ class TestCaptureWithEventTypeAndAgent:
     dbt["transactions"][0].pop("agent_external_id", None)
 
     session = MagicMock()
-    _stub_event_lookup(session, [])
+    _stub_existing_lookup(session, [])
 
     loader = OLTPLoader()
     loader._capture_transactions_as_events(

--- a/tests/operations/extensions/test_loader.py
+++ b/tests/operations/extensions/test_loader.py
@@ -8,6 +8,19 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 
+def _stub_event_lookup(session, rows):
+  """Stub the loader's existing-events lookup on a MagicMock session.
+
+  The lookup is ``session.query(Event).filter(...).with_for_update().all()`` —
+  it takes a row lock so a concurrent inbox approval cannot commit between that
+  read and the handler dispatch below it. Both the locked and unlocked chains
+  are stubbed so a test can never accidentally assert against the wrong one.
+  """
+  filtered = session.query.return_value.filter.return_value
+  filtered.all.return_value = rows
+  filtered.with_for_update.return_value.all.return_value = rows
+
+
 @pytest.fixture
 def mock_duckdb_data():
   """Sample dbt output data as lists of dicts."""
@@ -390,7 +403,7 @@ class TestOLTPLoader:
     mock_duckdb_connect.return_value = _make_duckdb_mock({"line_items": orphan_lines})
 
     mock_session = MagicMock()
-    mock_session.query.return_value.filter.return_value.all.return_value = []
+    _stub_event_lookup(mock_session, [])
     mock_ext_session.return_value.__enter__ = MagicMock(return_value=mock_session)
     mock_ext_session.return_value.__exit__ = MagicMock(return_value=False)
 
@@ -490,7 +503,7 @@ class TestCaptureTransactionsAsEvents:
     from robosystems.operations.extensions.loader import OLTPLoader
 
     session = MagicMock()
-    session.query.return_value.filter.return_value.all.return_value = []
+    _stub_event_lookup(session, [])
 
     loader = OLTPLoader()
     _capture_result = loader._capture_transactions_as_events(
@@ -531,7 +544,7 @@ class TestCaptureTransactionsAsEvents:
     existing_event.id = "evt_existing"
 
     session = MagicMock()
-    session.query.return_value.filter.return_value.all.return_value = [existing_event]
+    _stub_event_lookup(session, [existing_event])
 
     loader = OLTPLoader()
     _capture_result = loader._capture_transactions_as_events(
@@ -578,7 +591,7 @@ class TestCaptureTransactionsAsEvents:
     committed_event.payload_drift = False
 
     session = MagicMock()
-    session.query.return_value.filter.return_value.all.return_value = [committed_event]
+    _stub_event_lookup(session, [committed_event])
 
     loader = OLTPLoader()
     _capture_result = loader._capture_transactions_as_events(
@@ -647,7 +660,7 @@ class TestCaptureTransactionsAsEvents:
     }
 
     session = MagicMock()
-    session.query.return_value.filter.return_value.all.return_value = []
+    _stub_event_lookup(session, [])
 
     loader = OLTPLoader()
     _capture_result = loader._capture_transactions_as_events(
@@ -723,7 +736,7 @@ class TestCaptureAutoCommit:
     from robosystems.operations.extensions.loader import OLTPLoader
 
     session = MagicMock()
-    session.query.return_value.filter.return_value.all.return_value = []
+    _stub_event_lookup(session, [])
 
     loader = OLTPLoader()
 
@@ -756,7 +769,7 @@ class TestCaptureAutoCommit:
     from robosystems.operations.extensions.loader import OLTPLoader
 
     session = MagicMock()
-    session.query.return_value.filter.return_value.all.return_value = []
+    _stub_event_lookup(session, [])
 
     def fire_sets_fulfilled(_session, evt, _created_by):
       # Mimics the journal_entry_recorded handler when metadata.status='posted'.
@@ -791,7 +804,7 @@ class TestCaptureAutoCommit:
     from robosystems.operations.extensions.loader import OLTPLoader
 
     session = MagicMock()
-    session.query.return_value.filter.return_value.all.return_value = []
+    _stub_event_lookup(session, [])
 
     loader = OLTPLoader()
 
@@ -855,7 +868,7 @@ class TestCaptureAutoCommit:
     prior_event.metadata_ = {"dispatch_attempts": 1, "dispatch_error": "unknown_error"}
 
     session = MagicMock()
-    session.query.return_value.filter.return_value.all.return_value = [prior_event]
+    _stub_event_lookup(session, [prior_event])
 
     loader = OLTPLoader()
     with patch(
@@ -882,7 +895,7 @@ class TestCaptureAutoCommit:
     from robosystems.operations.extensions.loader import OLTPLoader
 
     session = MagicMock()
-    session.query.return_value.filter.return_value.all.return_value = []
+    _stub_event_lookup(session, [])
 
     loader = OLTPLoader()
     dbt = self._dbt_data()
@@ -925,7 +938,7 @@ class TestCaptureAutoCommit:
     existing_event.external_id = "JE_100"
     existing_event.status = "captured"
     existing_event.event_type = "journal_entry_recorded"
-    session.query.return_value.filter.return_value.all.return_value = [existing_event]
+    _stub_event_lookup(session, [existing_event])
 
     loader = OLTPLoader()
 
@@ -1365,7 +1378,7 @@ class TestCaptureHardening:
     from robosystems.operations.extensions.loader import OLTPLoader
 
     session = MagicMock()
-    session.query.return_value.filter.return_value.all.return_value = []
+    _stub_event_lookup(session, [])
     loader = OLTPLoader()
     cap = loader._capture_transactions_as_events(
       session,
@@ -1520,7 +1533,7 @@ class TestCaptureAgentsFromQB:
     from robosystems.operations.extensions.loader import OLTPLoader
 
     session = MagicMock()
-    session.query.return_value.filter.return_value.all.return_value = []
+    _stub_event_lookup(session, [])
 
     loader = OLTPLoader()
     out = loader._capture_agents_from_qb(
@@ -1548,7 +1561,7 @@ class TestCaptureAgentsFromQB:
     existing.id = "agt_existing"
 
     session = MagicMock()
-    session.query.return_value.filter.return_value.all.return_value = [existing]
+    _stub_event_lookup(session, [existing])
 
     loader = OLTPLoader()
     dbt = {
@@ -1610,7 +1623,7 @@ class TestCaptureAgentsFromQB:
     from robosystems.operations.extensions.loader import OLTPLoader
 
     session = MagicMock()
-    session.query.return_value.filter.return_value.all.return_value = []
+    _stub_event_lookup(session, [])
 
     loader = OLTPLoader()
     loader._capture_agents_from_qb(
@@ -1632,7 +1645,7 @@ class TestCaptureAgentsFromQB:
     from robosystems.operations.extensions.loader import OLTPLoader
 
     session = MagicMock()
-    session.query.return_value.filter.return_value.all.return_value = []
+    _stub_event_lookup(session, [])
 
     dbt = {
       "agents": [
@@ -1676,7 +1689,7 @@ class TestCaptureAgentsFromQB:
     existing.metadata_ = {"qb_sync_token": "5", "custom_field": "preserved"}
 
     session = MagicMock()
-    session.query.return_value.filter.return_value.all.return_value = [existing]
+    _stub_event_lookup(session, [existing])
 
     dbt = {
       "agents": [
@@ -1720,7 +1733,7 @@ class TestCaptureAgentsFromQB:
     existing.metadata_ = {"qb_sync_token": "5"}
 
     session = MagicMock()
-    session.query.return_value.filter.return_value.all.return_value = [existing]
+    _stub_event_lookup(session, [existing])
 
     dbt = {
       "agents": [
@@ -1818,7 +1831,7 @@ class TestCaptureWithEventTypeAndAgent:
     from robosystems.operations.extensions.loader import OLTPLoader
 
     session = MagicMock()
-    session.query.return_value.filter.return_value.all.return_value = []
+    _stub_event_lookup(session, [])
 
     loader = OLTPLoader()
     loader._capture_transactions_as_events(
@@ -1844,7 +1857,7 @@ class TestCaptureWithEventTypeAndAgent:
     from robosystems.operations.extensions.loader import OLTPLoader
 
     session = MagicMock()
-    session.query.return_value.filter.return_value.all.return_value = []
+    _stub_event_lookup(session, [])
 
     loader = OLTPLoader()
     loader._capture_transactions_as_events(
@@ -1874,7 +1887,7 @@ class TestCaptureWithEventTypeAndAgent:
     dbt["transactions"][0].pop("agent_external_id", None)
 
     session = MagicMock()
-    session.query.return_value.filter.return_value.all.return_value = []
+    _stub_event_lookup(session, [])
 
     loader = OLTPLoader()
     loader._capture_transactions_as_events(

--- a/tests/operations/extensions/test_loader_resync.py
+++ b/tests/operations/extensions/test_loader_resync.py
@@ -21,6 +21,19 @@ from datetime import UTC, date, datetime
 from unittest.mock import MagicMock, patch
 
 
+def _stub_event_lookup(session, rows):
+  """Stub the loader's existing-events lookup on a MagicMock session.
+
+  The lookup is ``session.query(Event).filter(...).with_for_update().all()`` —
+  it takes a row lock so a concurrent inbox approval cannot commit between that
+  read and the handler dispatch below it. Both the locked and unlocked chains
+  are stubbed so a test can never accidentally assert against the wrong one.
+  """
+  filtered = session.query.return_value.filter.return_value
+  filtered.all.return_value = rows
+  filtered.with_for_update.return_value.all.return_value = rows
+
+
 def _dbt_data_single_je() -> dict:
   """One balanced QB JournalEntry, two line items."""
   return {
@@ -101,7 +114,7 @@ class TestVoidedEventSurvivesResync:
     voided_event.payload_drift = False
 
     session = MagicMock()
-    session.query.return_value.filter.return_value.all.return_value = [voided_event]
+    _stub_event_lookup(session, [voided_event])
 
     loader = OLTPLoader()
     result = loader._capture_transactions_as_events(
@@ -300,7 +313,7 @@ class TestElementUpsertPreservesUlid:
 
     session = MagicMock()
     # The element-lookup query returns the existing row.
-    session.query.return_value.filter.return_value.all.return_value = [existing_element]
+    _stub_event_lookup(session, [existing_element])
     mock_ext_session.return_value.__enter__ = MagicMock(return_value=session)
     mock_ext_session.return_value.__exit__ = MagicMock(return_value=False)
 
@@ -355,7 +368,7 @@ class TestSyncTokenCapture:
     from robosystems.operations.extensions.loader import OLTPLoader
 
     session = MagicMock()
-    session.query.return_value.filter.return_value.all.return_value = []
+    _stub_event_lookup(session, [])
 
     loader = OLTPLoader()
     loader._capture_transactions_as_events(
@@ -386,7 +399,7 @@ class TestSyncTokenCapture:
     captured.payload_drift = False
 
     session = MagicMock()
-    session.query.return_value.filter.return_value.all.return_value = [captured]
+    _stub_event_lookup(session, [captured])
 
     loader = OLTPLoader()
     loader._capture_transactions_as_events(
@@ -423,7 +436,7 @@ class TestSyncTokenCapture:
     # metadata_blob shape looks like at this code revision; reuse it
     # for the live payload so the diff is exactly the sync_token field.
     capture_session = MagicMock()
-    capture_session.query.return_value.filter.return_value.all.return_value = []
+    _stub_event_lookup(capture_session, [])
     OLTPLoader()._capture_transactions_as_events(
       capture_session,
       self._dbt_data_with_sync_token("3"),
@@ -442,7 +455,7 @@ class TestSyncTokenCapture:
 
     # Now re-sync with a bumped SyncToken; no other field changed.
     drift_session = MagicMock()
-    drift_session.query.return_value.filter.return_value.all.return_value = [committed]
+    _stub_event_lookup(drift_session, [committed])
 
     result = OLTPLoader()._capture_transactions_as_events(
       drift_session,
@@ -475,7 +488,7 @@ class TestSyncTokenCapture:
     committed.payload_drift = False
 
     capture_session = MagicMock()
-    capture_session.query.return_value.filter.return_value.all.return_value = []
+    _stub_event_lookup(capture_session, [])
     OLTPLoader()._capture_transactions_as_events(
       capture_session,
       self._dbt_data_with_sync_token(None),
@@ -492,7 +505,7 @@ class TestSyncTokenCapture:
 
     # Re-sync the identical payload under a new connection id.
     drift_session = MagicMock()
-    drift_session.query.return_value.filter.return_value.all.return_value = [committed]
+    _stub_event_lookup(drift_session, [committed])
     result = OLTPLoader()._capture_transactions_as_events(
       drift_session,
       self._dbt_data_with_sync_token(None),
@@ -538,7 +551,7 @@ class TestSyncTokenGate:
     captured.event_type = "ORIGINAL_TYPE"
 
     session = MagicMock()
-    session.query.return_value.filter.return_value.all.return_value = [captured]
+    _stub_event_lookup(session, [captured])
 
     result = OLTPLoader()._capture_transactions_as_events(
       session,
@@ -569,7 +582,7 @@ class TestSyncTokenGate:
     captured.event_type = "ORIGINAL_TYPE"
 
     session = MagicMock()
-    session.query.return_value.filter.return_value.all.return_value = [captured]
+    _stub_event_lookup(session, [captured])
 
     result = OLTPLoader()._capture_transactions_as_events(
       session,
@@ -597,7 +610,7 @@ class TestSyncTokenGate:
     captured.payload_drift = False
 
     session = MagicMock()
-    session.query.return_value.filter.return_value.all.return_value = [captured]
+    _stub_event_lookup(session, [captured])
 
     result = OLTPLoader()._capture_transactions_as_events(
       session,
@@ -627,7 +640,7 @@ class TestSyncTokenGate:
     captured.payload_drift = False
 
     session = MagicMock()
-    session.query.return_value.filter.return_value.all.return_value = [captured]
+    _stub_event_lookup(session, [captured])
 
     result = OLTPLoader()._capture_transactions_as_events(
       session,
@@ -653,7 +666,7 @@ class TestSyncTokenGate:
     # First, build what a normal capture's metadata would look like for
     # SyncToken='3'.
     capture_session = MagicMock()
-    capture_session.query.return_value.filter.return_value.all.return_value = []
+    _stub_event_lookup(capture_session, [])
     OLTPLoader()._capture_transactions_as_events(
       capture_session,
       self._dbt_data_with_sync_token("3"),
@@ -675,7 +688,7 @@ class TestSyncTokenGate:
     committed.payload_drift = False
 
     session = MagicMock()
-    session.query.return_value.filter.return_value.all.return_value = [committed]
+    _stub_event_lookup(session, [committed])
 
     result = OLTPLoader()._capture_transactions_as_events(
       session,
@@ -758,7 +771,7 @@ class TestIdempotentReingest:
     captured = self._make_existing_event(status="captured", sync_token="5")
     pre_meta = dict(captured.metadata_)
     session = MagicMock()
-    session.query.return_value.filter.return_value.all.return_value = [captured]
+    _stub_event_lookup(session, [captured])
 
     result = OLTPLoader()._capture_transactions_as_events(
       session,
@@ -786,7 +799,7 @@ class TestIdempotentReingest:
     captured.event_type = pre_event_type
 
     session = MagicMock()
-    session.query.return_value.filter.return_value.all.return_value = [captured]
+    _stub_event_lookup(session, [captured])
 
     result = OLTPLoader()._capture_transactions_as_events(
       session,
@@ -841,7 +854,7 @@ class TestIdempotentReingest:
     }
 
     session = MagicMock()
-    session.query.return_value.filter.return_value.all.return_value = [captured_blob]
+    _stub_event_lookup(session, [captured_blob])
 
     # Bumped SyncToken + payload diff (loader will compute a different
     # qb_doc_number from the fixture's "number" field = "500").
@@ -890,7 +903,7 @@ class TestIdempotentReingest:
 
     # First sync: new event inserted with sync_token='4'.
     first_session = MagicMock()
-    first_session.query.return_value.filter.return_value.all.return_value = []
+    _stub_event_lookup(first_session, [])
 
     loader = OLTPLoader()
     first_result = loader._capture_transactions_as_events(
@@ -911,7 +924,7 @@ class TestIdempotentReingest:
 
     # Second sync: same dbt row; gate flags 'same' and short-circuits.
     second_session = MagicMock()
-    second_session.query.return_value.filter.return_value.all.return_value = [new_event]
+    _stub_event_lookup(second_session, [new_event])
 
     second_result = loader._capture_transactions_as_events(
       second_session,

--- a/tests/operations/extensions/test_loader_resync.py
+++ b/tests/operations/extensions/test_loader_resync.py
@@ -21,13 +21,15 @@ from datetime import UTC, date, datetime
 from unittest.mock import MagicMock, patch
 
 
-def _stub_event_lookup(session, rows):
-  """Stub the loader's existing-events lookup on a MagicMock session.
+def _stub_existing_lookup(session, rows):
+  """Stub a `query(...).filter(...)[.with_for_update()].all()` load on a mock session.
 
-  The lookup is ``session.query(Event).filter(...).with_for_update().all()`` —
-  it takes a row lock so a concurrent inbox approval cannot commit between that
-  read and the handler dispatch below it. Both the locked and unlocked chains
-  are stubbed so a test can never accidentally assert against the wrong one.
+  Named for its main subject, the loader's existing-**events** lookup, which
+  takes a row lock so a concurrent inbox approval cannot commit between that
+  read and the handler dispatch below it — but the `MagicMock` chain is not
+  type-differentiated, so the same helper serves the Element and Agent loads
+  in this file. Both the locked and unlocked chains are stubbed, so a test can
+  never accidentally assert against whichever one production stopped using.
   """
   filtered = session.query.return_value.filter.return_value
   filtered.all.return_value = rows
@@ -114,7 +116,7 @@ class TestVoidedEventSurvivesResync:
     voided_event.payload_drift = False
 
     session = MagicMock()
-    _stub_event_lookup(session, [voided_event])
+    _stub_existing_lookup(session, [voided_event])
 
     loader = OLTPLoader()
     result = loader._capture_transactions_as_events(
@@ -313,7 +315,7 @@ class TestElementUpsertPreservesUlid:
 
     session = MagicMock()
     # The element-lookup query returns the existing row.
-    _stub_event_lookup(session, [existing_element])
+    _stub_existing_lookup(session, [existing_element])
     mock_ext_session.return_value.__enter__ = MagicMock(return_value=session)
     mock_ext_session.return_value.__exit__ = MagicMock(return_value=False)
 
@@ -368,7 +370,7 @@ class TestSyncTokenCapture:
     from robosystems.operations.extensions.loader import OLTPLoader
 
     session = MagicMock()
-    _stub_event_lookup(session, [])
+    _stub_existing_lookup(session, [])
 
     loader = OLTPLoader()
     loader._capture_transactions_as_events(
@@ -399,7 +401,7 @@ class TestSyncTokenCapture:
     captured.payload_drift = False
 
     session = MagicMock()
-    _stub_event_lookup(session, [captured])
+    _stub_existing_lookup(session, [captured])
 
     loader = OLTPLoader()
     loader._capture_transactions_as_events(
@@ -436,7 +438,7 @@ class TestSyncTokenCapture:
     # metadata_blob shape looks like at this code revision; reuse it
     # for the live payload so the diff is exactly the sync_token field.
     capture_session = MagicMock()
-    _stub_event_lookup(capture_session, [])
+    _stub_existing_lookup(capture_session, [])
     OLTPLoader()._capture_transactions_as_events(
       capture_session,
       self._dbt_data_with_sync_token("3"),
@@ -455,7 +457,7 @@ class TestSyncTokenCapture:
 
     # Now re-sync with a bumped SyncToken; no other field changed.
     drift_session = MagicMock()
-    _stub_event_lookup(drift_session, [committed])
+    _stub_existing_lookup(drift_session, [committed])
 
     result = OLTPLoader()._capture_transactions_as_events(
       drift_session,
@@ -488,7 +490,7 @@ class TestSyncTokenCapture:
     committed.payload_drift = False
 
     capture_session = MagicMock()
-    _stub_event_lookup(capture_session, [])
+    _stub_existing_lookup(capture_session, [])
     OLTPLoader()._capture_transactions_as_events(
       capture_session,
       self._dbt_data_with_sync_token(None),
@@ -505,7 +507,7 @@ class TestSyncTokenCapture:
 
     # Re-sync the identical payload under a new connection id.
     drift_session = MagicMock()
-    _stub_event_lookup(drift_session, [committed])
+    _stub_existing_lookup(drift_session, [committed])
     result = OLTPLoader()._capture_transactions_as_events(
       drift_session,
       self._dbt_data_with_sync_token(None),
@@ -551,7 +553,7 @@ class TestSyncTokenGate:
     captured.event_type = "ORIGINAL_TYPE"
 
     session = MagicMock()
-    _stub_event_lookup(session, [captured])
+    _stub_existing_lookup(session, [captured])
 
     result = OLTPLoader()._capture_transactions_as_events(
       session,
@@ -582,7 +584,7 @@ class TestSyncTokenGate:
     captured.event_type = "ORIGINAL_TYPE"
 
     session = MagicMock()
-    _stub_event_lookup(session, [captured])
+    _stub_existing_lookup(session, [captured])
 
     result = OLTPLoader()._capture_transactions_as_events(
       session,
@@ -610,7 +612,7 @@ class TestSyncTokenGate:
     captured.payload_drift = False
 
     session = MagicMock()
-    _stub_event_lookup(session, [captured])
+    _stub_existing_lookup(session, [captured])
 
     result = OLTPLoader()._capture_transactions_as_events(
       session,
@@ -640,7 +642,7 @@ class TestSyncTokenGate:
     captured.payload_drift = False
 
     session = MagicMock()
-    _stub_event_lookup(session, [captured])
+    _stub_existing_lookup(session, [captured])
 
     result = OLTPLoader()._capture_transactions_as_events(
       session,
@@ -666,7 +668,7 @@ class TestSyncTokenGate:
     # First, build what a normal capture's metadata would look like for
     # SyncToken='3'.
     capture_session = MagicMock()
-    _stub_event_lookup(capture_session, [])
+    _stub_existing_lookup(capture_session, [])
     OLTPLoader()._capture_transactions_as_events(
       capture_session,
       self._dbt_data_with_sync_token("3"),
@@ -688,7 +690,7 @@ class TestSyncTokenGate:
     committed.payload_drift = False
 
     session = MagicMock()
-    _stub_event_lookup(session, [committed])
+    _stub_existing_lookup(session, [committed])
 
     result = OLTPLoader()._capture_transactions_as_events(
       session,
@@ -771,7 +773,7 @@ class TestIdempotentReingest:
     captured = self._make_existing_event(status="captured", sync_token="5")
     pre_meta = dict(captured.metadata_)
     session = MagicMock()
-    _stub_event_lookup(session, [captured])
+    _stub_existing_lookup(session, [captured])
 
     result = OLTPLoader()._capture_transactions_as_events(
       session,
@@ -799,7 +801,7 @@ class TestIdempotentReingest:
     captured.event_type = pre_event_type
 
     session = MagicMock()
-    _stub_event_lookup(session, [captured])
+    _stub_existing_lookup(session, [captured])
 
     result = OLTPLoader()._capture_transactions_as_events(
       session,
@@ -854,7 +856,7 @@ class TestIdempotentReingest:
     }
 
     session = MagicMock()
-    _stub_event_lookup(session, [captured_blob])
+    _stub_existing_lookup(session, [captured_blob])
 
     # Bumped SyncToken + payload diff (loader will compute a different
     # qb_doc_number from the fixture's "number" field = "500").
@@ -903,7 +905,7 @@ class TestIdempotentReingest:
 
     # First sync: new event inserted with sync_token='4'.
     first_session = MagicMock()
-    _stub_event_lookup(first_session, [])
+    _stub_existing_lookup(first_session, [])
 
     loader = OLTPLoader()
     first_result = loader._capture_transactions_as_events(
@@ -924,7 +926,7 @@ class TestIdempotentReingest:
 
     # Second sync: same dbt row; gate flags 'same' and short-circuits.
     second_session = MagicMock()
-    _stub_event_lookup(second_session, [new_event])
+    _stub_existing_lookup(second_session, [new_event])
 
     second_result = loader._capture_transactions_as_events(
       second_session,

--- a/tests/operations/roboledger/commands/test_schedules.py
+++ b/tests/operations/roboledger/commands/test_schedules.py
@@ -176,6 +176,9 @@ def test_update_schedule_template_change_triggers_supersession() -> None:
   session = MagicMock()
   session.execute.side_effect = [
     _exec_result(row=structure),
+    # The template-change branch bounds its wait for the pending obligations
+    # before superseding them, so a `SET LOCAL lock_timeout` lands here.
+    _exec_result(),
     _exec_result(fetchone_row=MagicMock(cnt=12)),
     _exec_result(fetchone_row=MagicMock(cnt=12)),
   ]


### PR DESCRIPTION
## Summary

Every path that decides an event's next status now locks the row it decided on. Three paths make that decision — an inbox approval, the QuickBooks sync's auto-commit pass, and the obligation-promotion sweep — and all three were read-decide-write with nothing held across the decision. Two writers could both read `captured`, both fire the event's handler, and leave one event carrying two sets of GL rows: books that still foot, still render, and no longer say what the event says.

The promotion sweep additionally wrote `classified` over whatever its target row currently held, so an obligation voided or committed since its candidate read was silently reverted.

## Changes

**`operations/event_block/locking.py`** (new) — the wait policy, in one place now that several callers share it. The rule it encodes: **background jobs wait, request handlers do not.** A sync or a Dagster sweep takes its locks unbounded, because a batch should not fail behind a single approval. Request-facing callers wrap their locking work in `bounded_lock_wait`, which sets `SET LOCAL lock_timeout` (3s) and translates SQLSTATE `55P03` into a typed `EventLockedError`. Three seconds rather than `NOWAIT` because most contention is another approval or a short write and resolves in milliseconds — failing those would be a spurious error, and only the long-running writers should produce one. Other `OperationalError`s keep their own identity rather than reaching a caller as "retry in a moment".

**`operations/event_block/commands.py`** — `update_event_block` loads the event `FOR UPDATE`, bounded. Under READ COMMITTED the blocked reader re-reads the committed row once the lock releases, so it evaluates the transition against current state and raises `InvalidEventTransitionError` rather than acting on the snapshot it took before blocking.

**`operations/extensions/loader.py`** — the sync's existing-events lookup in `_capture_transactions_as_events` takes `FOR UPDATE`. Locking at the lookup rather than before each dispatch is deliberate: a row lock is held to transaction end either way, so acquiring it once at the top costs one query instead of one per event and also covers the UPSERT decisions below it. Most of these rows were write-locked incidentally by the UPSERT; the gap was the re-sync whose payload is unchanged, which issues no UPDATE and so took no lock.

**`operations/event_block/promotion.py`** — worth a close look, this is the worse of the two races. `promote_pending_obligations` runs on a Dagster sensor every few minutes on every graph, so it races the on-demand op, an inbox approval, and its own next tick if one overruns. Its candidate load now takes `FOR UPDATE`, and the bulk classify UPDATE states the status it assumes (`status = 'pending'`) instead of filtering on id alone — the same guard the orphan void forty lines above it already carried. Handler idempotency per `(schedule, period)` mitigated the duplicate-dispatch half; it never protected the status.

**`operations/roboledger/commands/schedules.py`** — the on-demand `promote_obligations` wraps the sweep in `bounded_lock_wait`. Note the sweep function is called from both the sensor and this request handler, which is why the bound belongs to the caller rather than to the function.

**`routers/extensions/roboledger/operations.py`** — `EventLockedError` maps to **409** on `update-event-block` and `promote-obligations`. It is the one error on these operations a caller should retry rather than fix.

**Tests** — `tests/operations/event_block/test_update_locking_db.py` is new and DB-backed, running real concurrent sessions against a throwaway tenant schema (the `test_share_controls_db.py` pattern). Mock sessions can prove a keyword was passed; they cannot prove a lock blocks. Three cases: the sync's lock blocks an approval into a 409; an approval that waits out a lock re-reads the committed row and rejects on current state; the sweep's lock blocks the on-demand op.

One detail in that last case is load-bearing and easy to get wrong on a later edit: it seeds a **stranded `classified`** obligation, not a `pending` one. A pending obligation is flipped by the bulk UPDATE, whose own row lock would block a second caller whether or not the candidate read is locked — so the test would pass with the fix reverted. The stranded case makes the sweep write nothing, leaving the read's `FOR UPDATE` as the only thing that can block.

The lost-update guard is unreachable end-to-end once the read is locked, so it is pinned at the statement in `test_promotion.py` rather than dressed up as a race test it cannot fail.

The 40 loader tests that stubbed the existing-events lookup on a bare `MagicMock` now go through a `_stub_event_lookup` helper that stubs the locked and unlocked chains together, so a test cannot silently assert against whichever one production stopped using.

## Breaking Changes

None.

Two operations gain a 409 response (`update-event-block`, `promote-obligations`). Purely additive — no request shape, response body, GraphQL type, or operations-envelope field changes, and nothing is removed. It reaches the SDKs' generated tier only, as an OpenAPI regen opportunity rather than a coordinated change.

Worth knowing for whoever picks up the client side: the 409 has no retry affordance in `roboledger-app` yet, so it currently renders as a generic operation failure. The API contract is complete; the UI follow-up is not in this PR.

## Testing

`just test-all` — **12,983 passed, 38 skipped**; ruff, format, typecheck and cf-lint all clean.

The new DB-backed module is `pytest.mark.integration`, which `just test` deselects locally but CI runs (`-m "not slow"`). Run explicitly this session against the local extensions database: 3 passed. Affected suites together (`operations/event_block`, `operations/extensions`, `operations/roboledger`, `routers/extensions`, integration included): 1,215 passed.

Each of the four guards was verified to be a real regression by removing it and confirming the corresponding test fails:

| Guard removed | Result |
| --- | --- |
| `update_event_block` `FOR UPDATE` | mock assertion fails |
| loader lookup `FOR UPDATE` | `DID NOT RAISE EventLockedError` |
| promotion candidate `FOR UPDATE` | sweep-lock case fails |
| classify UPDATE status predicate | statement assertion fails |

That check earned its place: the first two promotion tests I wrote passed with their guards removed, for the reasons described under Changes, and were rewritten.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
