### PR TITLE
chore(orgs): collapse the graph-limit default to a single runtime source

### DIFF
--- a/robosystems/models/core/org/org_limits.py
+++ b/robosystems/models/core/org/org_limits.py
@@ -8,7 +8,6 @@ from sqlalchemy import Column, DateTime, ForeignKey, Integer, String
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session, relationship
 
-from robosystems.config import env
 from robosystems.config.tuning import TuningConfig
 from robosystems.database import Model
 
@@ -27,7 +26,14 @@ class OrgLimits(Model):
   )
   org_id = Column(String, ForeignKey("orgs.id"), nullable=False, unique=True)
 
-  max_graphs = Column(Integer, nullable=False, default=env.ORG_GRAPHS_DEFAULT_LIMIT)
+  # Resolved per-insert, not at import: the same runtime source
+  # `create_default_limits` uses, so an insert that omits max_graphs cannot
+  # disagree with one that sets it explicitly.
+  max_graphs = Column(
+    Integer,
+    nullable=False,
+    default=lambda: TuningConfig.get_org_graphs_default_limit(),
+  )
 
   created_at = Column(DateTime, default=lambda: datetime.now(UTC), nullable=False)
   updated_at = Column(


### PR DESCRIPTION
## Summary

`OrgLimits.max_graphs` had two default sources that could disagree. Both now resolve through the same runtime accessor. No behavior change on any existing path.

## Changes

**`models/core/org/org_limits.py`**

The column default was resolved once at import (`env.ORG_GRAPHS_DEFAULT_LIMIT`); `create_default_limits` reads the tuning value at runtime. Every current insert goes through the latter — `user_provisioning` and `scim_bootstrap` both call it, and `get_or_create_for_org` covers anything that reaches provisioning without a row — so the two never diverged in practice.

They could, though. An insert path that omitted `max_graphs` would take the import-time value, which falls back to the code constant rather than the deployed setting whenever the import-time lookup comes up empty. That is one insert path away from being the authoritative source, and the divergence would be silent.

Making the column default a callable over `TuningConfig.get_org_graphs_default_limit()` collapses both to one source, so a future insert inherits the deployed value by construction rather than by convention. The now-unused `env` import drops out.

Tests construct `OrgLimits` with an explicit `max_graphs` throughout, so none exercise the default; `just test-code` and the org / provisioning / billing suites are green.