### PR TITLE
chore(infra): record the audit bucket's out-of-band Object Lock

### DIFF
--- a/cloudformation/audit.yaml
+++ b/cloudformation/audit.yaml
@@ -55,6 +55,15 @@ Resources:
         RestrictPublicBuckets: true
       VersioningConfiguration:
         Status: Enabled
+      # Object Lock (governance mode, 400 days) is enabled on the existing bucket
+      # via the S3 API, not here: CloudFormation's ObjectLockEnabled property
+      # requires bucket replacement, which a retained, name-pinned bucket cannot
+      # do. Adding it to this template fails the stack update rather than
+      # codifying the live state. Redeploys do not disturb it — CloudFormation
+      # only calls the sub-APIs for properties present in the template, so
+      # PutObjectLockConfiguration is never issued. Retention matches
+      # RetentionDays below and the treatment already applied to the CloudTrail
+      # bucket; it applies to objects written after it was set (2026-08-17).
       LifecycleConfiguration:
         Rules:
           - Id: AuditRetention


### PR DESCRIPTION
## Summary

Object Lock (governance mode, 400 days) was enabled on `robosystems-audit-prod-*` and `robosystems-audit-staging-*` via the S3 API on 2026-08-17. This adds the comment recording that, mirroring the note already carried at `cloudformation/cloudtrail.yaml:101-103`.

The application audit trail is what the System Description points at when it describes tamper-evident audit records, and it is the compensating control cited for absent segregation of duties. Until today the bucket had versioning only — the sole administrator could delete versions. The CloudTrail bucket already had Object Lock; the audit bucket did not.

## Why this is a comment and not a property

`ObjectLockEnabled` requires bucket replacement. `AuditBucket` is `DeletionPolicy: Retain`, `UpdateReplacePolicy: Retain`, with a pinned `BucketName`, so replacement is impossible — adding the property fails the stack update rather than codifying the live state. The comment exists so a later reader does not try.

It also records why redeploys are safe, which was the natural question: CloudFormation maps each managed bucket property to its own sub-API (`PutBucketLifecycleConfiguration`, `PutBucketVersioning`, and so on) and issues calls only for properties present in the template. With no `ObjectLockConfiguration` in the template, `PutObjectLockConfiguration` is never called and the out-of-band setting persists. Drift detection will report it; drift detection does not remediate.

That is demonstrated rather than assumed: the CloudTrail bucket's lock was applied around 2026-08-01 (commit `15927b04`), the `RoboSystemsCloudTrail` stack was updated 2026-08-02, and the bucket still reads `GOVERNANCE / 90` today.

## Applied configuration

```
aws s3api put-object-lock-configuration --bucket robosystems-audit-{prod,staging}-<account> \
  --object-lock-configuration '{"ObjectLockEnabled":"Enabled","Rule":{"DefaultRetention":{"Mode":"GOVERNANCE","Days":400}}}'
```

Verified afterward: both buckets return `Enabled / GOVERNANCE / 400`.

Retention matches the `RetentionDays` parameter and the bucket's existing lifecycle rule. Governance mode rather than compliance mode, matching the CloudTrail bucket — compliance mode is irreversible and cannot be relaxed even by the account root.

## Known limitation, stated deliberately

Default retention applies to objects written **after** it is set. The roughly 5,250 objects already in the prod bucket, dating from 2026-07-03, are not retroactively locked. This is why it was applied now rather than deferred; there is no mechanism to protect them short of rewriting them, which would falsify their timestamps.

## Testing

- `just cf-lint audit` — clean.
- No template properties changed, so no stack update is required for this to take effect; the configuration is already live.

## Deploy Notes

None. Comment-only change to the template. The bucket configuration is already applied and independent of deployment.