### PR TITLE
fix(graph): delete published report artifacts at teardown

### DIFF
--- a/robosystems/operations/graph/deprovision_service.py
+++ b/robosystems/operations/graph/deprovision_service.py
@@ -36,6 +36,7 @@ class DeprovisionResult:
   documents_deleted: int = 0
   connections_deleted: int = 0
   search_purged: bool = False
+  report_bundles_deleted: int = 0
   errors: list[str] = field(default_factory=list)
 
   @property
@@ -138,6 +139,9 @@ class GraphDeprovisionService:
     # --- 3c. Purge documents from the shared search index ---
     self._purge_search_index(graph_id, result)
 
+    # --- 3d. Purge published report artifacts from object storage ---
+    self._purge_report_bundles(graph_id, result)
+
     # --- 4. Deallocate DynamoDB registry ---
     await self._deallocate_registry(graph_id, result)
 
@@ -165,6 +169,7 @@ class GraphDeprovisionService:
         "documents_deleted": result.documents_deleted,
         "connections_deleted": result.connections_deleted,
         "search_purged": result.search_purged,
+        "report_bundles_deleted": result.report_bundles_deleted,
         "errors": result.errors,
       },
     )
@@ -390,6 +395,63 @@ class GraphDeprovisionService:
       logger.info(f"Purged search index for graph {graph_id}")
     except Exception as e:
       error_msg = f"Search index purge failed: {e}"
+      result.errors.append(error_msg)
+      logger.warning(error_msg, extra={"graph_id": graph_id})
+
+  def _purge_report_bundles(self, graph_id: str, result: DeprovisionResult) -> None:
+    """Delete the tenant's published report artifacts from object storage.
+
+    Report bundles are the serialized publications of a customer's reports —
+    financial statements in JSON-LD and XBRL — and they were the last customer
+    data store teardown never reached. Their prefix deliberately carries no
+    lifecycle rule: a clock there would destroy the artifact of a live report
+    whose row still exists, which is why `delete_report_artifacts` deletes them
+    on withdrawal instead. Absence of a clock was correct; absence of a teardown
+    delete was not, and it left a departed tenant's statements in the bucket
+    indefinitely.
+
+    Deletes the whole `report-bundles/{graph_id}/` prefix, so every report,
+    generation and flavor goes together. The final backup lives under a
+    different prefix and is untouched.
+
+    Best-effort like its siblings — a storage failure records a warning rather
+    than stranding the capacity release — but an object that fails to delete is
+    recorded as an error, because incomplete disposal is the one outcome this
+    step exists to prevent.
+    """
+    try:
+      from ...config import env
+      from ...config.storage.graph import get_report_bundle_prefix
+      from ..aws.s3 import S3Client
+
+      bucket = env.USER_DATA_BUCKET
+      prefix = get_report_bundle_prefix(graph_id)
+      s3 = S3Client()
+
+      deleted = 0
+      failed = 0
+      for key in s3.list_objects(bucket, prefix=prefix):
+        if s3.delete_object(bucket, key):
+          deleted += 1
+        else:
+          failed += 1
+          logger.warning(
+            f"Failed to delete report artifact s3://{bucket}/{key}",
+            extra={"graph_id": graph_id},
+          )
+
+      result.report_bundles_deleted = deleted
+      if failed:
+        result.errors.append(
+          f"Report bundle purge incomplete: {failed} object(s) not deleted"
+        )
+      elif deleted:
+        logger.info(
+          f"Purged {deleted} report artifact(s) for graph {graph_id}",
+          extra={"graph_id": graph_id},
+        )
+    except Exception as e:
+      error_msg = f"Report bundle purge failed: {e}"
       result.errors.append(error_msg)
       logger.warning(error_msg, extra={"graph_id": graph_id})
 

--- a/tests/operations/graph/test_deprovision_service.py
+++ b/tests/operations/graph/test_deprovision_service.py
@@ -109,6 +109,19 @@ def _stub_search_purge():
     yield
 
 
+@pytest.fixture(autouse=True)
+def stub_bundle_purge():
+  """Deprovision purges the graph's report artifacts from object storage — stub
+  the S3 client so these tests never reach a real bucket. Yields the class mock
+  so the tests that care about the purge can drive it."""
+  with patch("robosystems.operations.aws.s3.S3Client") as cls:
+    client = MagicMock()
+    client.list_objects.return_value = []
+    client.delete_object.return_value = True
+    cls.return_value = client
+    yield client
+
+
 class TestDeprovisionService:
   """Tests for GraphDeprovisionService.deprovision_graph."""
 
@@ -717,3 +730,99 @@ class TestDeprovisionService:
       db_session.refresh(test_graph)
       assert test_graph.deleted_at is not None
       assert isinstance(test_graph.deleted_at, datetime)
+
+
+class TestReportBundlePurge:
+  """Published report artifacts must not outlive the tenant.
+
+  Report bundles were the last customer data store teardown did not reach.
+  Their prefix carries no lifecycle rule by design — a clock there would destroy
+  a live report's publication — so teardown is the only thing that can remove
+  them, and these tests are what keep that true.
+  """
+
+  @pytest.mark.asyncio
+  async def test_bundles_are_deleted_under_the_graph_prefix(
+    self, service, db_session, test_graph, stub_bundle_purge
+  ):
+    """Every artifact under report-bundles/{graph_id}/ goes, and the count is
+    reported so the operator log states what actually happened."""
+    keys = [
+      f"report-bundles/{test_graph.graph_id}/rpt_a/g1.jsonld",
+      f"report-bundles/{test_graph.graph_id}/rpt_a/g1.holon.jsonld",
+      f"report-bundles/{test_graph.graph_id}/rpt_b/g2.zip",
+    ]
+    stub_bundle_purge.list_objects.return_value = keys
+
+    with (
+      patch(
+        "robosystems.graph_api.client.factory.get_graph_client",
+        new_callable=AsyncMock,
+      ),
+      patch("robosystems.middleware.graph.allocation_manager.LadybugAllocationManager"),
+    ):
+      result = await service.deprovision_graph(
+        test_graph.graph_id, db_session, create_backup=False
+      )
+
+    # Scoped to this graph's prefix — never the whole bucket.
+    _, kwargs = stub_bundle_purge.list_objects.call_args
+    assert kwargs["prefix"] == f"report-bundles/{test_graph.graph_id}/"
+
+    assert stub_bundle_purge.delete_object.call_count == 3
+    assert result.report_bundles_deleted == 3
+    assert not [e for e in result.errors if "Report bundle" in e]
+
+  @pytest.mark.asyncio
+  async def test_an_object_that_will_not_delete_is_recorded_as_an_error(
+    self, service, db_session, test_graph, stub_bundle_purge
+  ):
+    """Incomplete disposal is the one outcome this step exists to prevent, so a
+    surviving object degrades the teardown to `partial` rather than passing
+    quietly. This is deliberately stricter than the sibling purges."""
+    stub_bundle_purge.list_objects.return_value = [
+      f"report-bundles/{test_graph.graph_id}/rpt_a/g1.jsonld",
+      f"report-bundles/{test_graph.graph_id}/rpt_b/g1.jsonld",
+    ]
+    stub_bundle_purge.delete_object.side_effect = [True, False]
+
+    with (
+      patch(
+        "robosystems.graph_api.client.factory.get_graph_client",
+        new_callable=AsyncMock,
+      ),
+      patch("robosystems.middleware.graph.allocation_manager.LadybugAllocationManager"),
+    ):
+      result = await service.deprovision_graph(
+        test_graph.graph_id, db_session, create_backup=False
+      )
+
+    assert result.report_bundles_deleted == 1
+    assert any("Report bundle purge incomplete" in e for e in result.errors)
+    assert result.status == "partial"
+
+  @pytest.mark.asyncio
+  async def test_storage_failure_does_not_strand_the_teardown(
+    self, service, db_session, test_graph, stub_bundle_purge
+  ):
+    """Best-effort like its siblings: object storage being unreachable must not
+    hold the graph in a half-torn-down state or block the capacity release."""
+    stub_bundle_purge.list_objects.side_effect = RuntimeError("s3 unreachable")
+
+    with (
+      patch(
+        "robosystems.graph_api.client.factory.get_graph_client",
+        new_callable=AsyncMock,
+      ),
+      patch("robosystems.middleware.graph.allocation_manager.LadybugAllocationManager"),
+    ):
+      result = await service.deprovision_graph(
+        test_graph.graph_id, db_session, create_backup=False
+      )
+
+    assert any("Report bundle purge failed" in e for e in result.errors)
+
+    # The graph is still torn down and the row still soft-deleted.
+    db_session.refresh(test_graph)
+    assert test_graph.status == GraphStatus.DEPROVISIONED.value
+    assert test_graph.deleted_at is not None


### PR DESCRIPTION
## Summary

Deprovisioning removes the graph database, the extensions schema, documents, the search index, connections and connection credentials — and performs **no S3 deletion at all**. Published report bundles therefore outlive the tenant indefinitely.

This is not theoretical. Three of the five graph prefixes under `report-bundles/` in the production bucket belong to graphs the registry already lists as `deprovisioned`.

## Why the prefix has no lifecycle rule, and why that was still correct

`cloudformation/s3.yaml` deliberately leaves `report-bundles/` uncovered, and the comment there says not to "fix" it. That reasoning is sound: a time-based rule would delete the published artifact of a live report whose row still exists. Withdrawal is what removes them, via `delete_report_artifacts`.

What the earlier pass missed is that `delete_report_artifacts` has three callers and **none of them is teardown**. It checked that a delete path existed; it never asked whether deprovisioning could reach it. Uncovered was the right state for a clock, and the wrong state for teardown.

This is the fifth instance of the same defect class — after `Document` rows, the OpenSearch index, `Connection`, and `ConnectionCredentials`.

## Changes

`robosystems/operations/graph/deprovision_service.py`
- New `_purge_report_bundles` step, running as 3d immediately after the search-index purge — with the other data-store removals, before the registry deallocation releases capacity.
- Deletes the whole `report-bundles/{graph_id}/` prefix via the same `S3Client.list_objects` / `delete_object` pattern `delete_report_artifacts` uses, so every report, generation and flavor goes together. The final backup lives under `graph-backups/` and is untouched.
- `DeprovisionResult.report_bundles_deleted`, carried into the operator log line so the record states what was actually removed.

**One deliberate departure from its siblings.** The other best-effort steps record an error only when they raise. This one also records an error when an object *fails to delete*, degrading the teardown to `partial`. Incomplete disposal is precisely the outcome this step exists to prevent, so it should not pass quietly. A storage failure still never strands the teardown or blocks the capacity release.

## Why this matters beyond the code

Three approved, published documents describe this disposal, and until now each described a step that did not execute:

- Data Management Policy, Appendix B — `S3 - report bundles … deleted on withdrawal and at tenant decommissioning`
- Master Service Agreement §5 — deletion of Customer Data from active systems
- SOC 2 System Description §4 *Data* — teardown leaving "only the final backup and encrypted point-in-time database backups"

## Testing

- New `TestReportBundlePurge`, three cases: the prefix is scoped to the graph and every object under it is deleted with the count reported; an object that will not delete is recorded as an error and degrades status to `partial`; object storage being unreachable records a warning but still leaves the graph deprovisioned and soft-deleted.
- An autouse `stub_bundle_purge` fixture stubs `S3Client` for the whole module, matching the existing `_stub_search_purge` pattern — without it the new step would reach for a real bucket in every deprovision test.
- `uv run pytest tests/operations/graph` — 651 passed.
- `just test-code` — clean.

## Follow-up, not in this PR

The fix is forward-only. Objects belonging to graphs deprovisioned before it are not cleaned retroactively — nine objects across three prefixes today. Those are removed with a separate operator action against production.